### PR TITLE
Fixes compilation errors

### DIFF
--- a/tensorflow/lite/delegates/gpu/cl/selectors/convolution_selector.cc
+++ b/tensorflow/lite/delegates/gpu/cl/selectors/convolution_selector.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include "tensorflow/lite/delegates/gpu/cl/kernels/conv_buffer.h"
 #include "tensorflow/lite/delegates/gpu/cl/kernels/conv_buffer_1x1.h"
 #include "tensorflow/lite/delegates/gpu/cl/kernels/conv_constants.h"
+#include "tensorflow/lite/delegates/gpu/cl/kernels/conv_powervr.h"
 #include "tensorflow/lite/delegates/gpu/cl/kernels/conv_texture.h"
 #include "tensorflow/lite/delegates/gpu/cl/kernels/work_group_picking.h"
 #include "tensorflow/lite/delegates/gpu/cl/tensor_type.h"


### PR DESCRIPTION
```
g++ -std=c++14 -c -DTF_COMPILE_LIBRARY -DGL_GLEXT_PROTOTYPES -D__LITTLE_ENDIAN__ -DABSL_ATTRIBUTE_WEAK -DTFL_COMPILE_LIBRARY -I../../../.. -I../../tools/make/downloads/farmhash/src -I../../../../tensorflow/lite/tools/make/downloads/flatbuffers/include -I../../../../tensorflow/lite/tools/make/downloads/absl -I. cl/selectors/convolution_selector.cc -o cl/selectors/convolution_selector.o
cl/selectors/convolution_selector.cc: In function 'tflite::gpu::Status tflite::gpu::cl::{anonymous}::SelectConvolutionTextureArray(const tflite::gpu::Convolution2DAttributes&, const BHWC&, const tflite::gpu::cl::CreationContext&, const tflite::gpu::cl::OperationDef&, tflite::gpu::cl::ModelHints, std::unique_ptr<tflite::gpu::cl::GPUOperation>*)':
cl/selectors/convolution_selector.cc:39:5: error: 'IsConvPowerVRSupported' was not declared in this scope; did you mean 'IsConvBuffer1x1Supported'?
   39 |     IsConvPowerVRSupported(op_def, attr)) {
      |     ^~~~~~~~~~~~~~~~~~~~~~
      |     IsConvBuffer1x1Supported
cl/selectors/convolution_selector.cc:40:5: error: 'ConvPowerVR' was not declared in this scope
   40 |     ConvPowerVR conv;
      |     ^~~~~~~~~~~
In file included from ../../../../tensorflow/lite/delegates/gpu/cl/opencl_wrapper.h:22,
                 from ../../../../tensorflow/lite/delegates/gpu/cl/cl_device.h:22,
                 from ../../../../tensorflow/lite/delegates/gpu/cl/cl_context.h:19,
                 from ../../../../tensorflow/lite/delegates/gpu/cl/kernels/gpu_operation.h:23,
                 from ../../../../tensorflow/lite/delegates/gpu/cl/selectors/convolution_selector.h:21,
                 from cl/selectors/convolution_selector.cc:16:
cl/selectors/convolution_selector.cc:41:72: error: 'conv' was not declared in this scope; did you mean 'lconv'?
   41 |     RETURN_IF_ERROR(CreateConvPowerVR(creation_context, op_def, attr, &conv));
      |                                                                        ^~~~
../../../../tensorflow/lite/delegates/gpu/common/status.h:67:27: note: in definition of macro 'RETURN_IF_ERROR'
   67 |     const auto status2 = (status);     \
      |                           ^~~~~~
cl/selectors/convolution_selector.cc:41:21: error: 'CreateConvPowerVR' was not declared in this scope
   41 |     RETURN_IF_ERROR(CreateConvPowerVR(creation_context, op_def, attr, &conv));
      |                     ^~~~~~~~~~~~~~~~~
../../../../tensorflow/lite/delegates/gpu/common/status.h:67:27: note: in definition of macro 'RETURN_IF_ERROR'
   67 |     const auto status2 = (status);     \
      |                           ^~~~~~
cl/selectors/convolution_selector.cc:42:53: error: 'conv' was not declared in this scope; did you mean 'lconv'?
   42 |     *ptr = absl::make_unique<ConvPowerVR>(std::move(conv));
      |                                                     ^~~~
      |                                                     lconv
cl/selectors/convolution_selector.cc: In function 'tflite::gpu::Status tflite::gpu::cl::{anonymous}::SelectConvolutionTexture2D(const tflite::gpu::Convolution2DAttributes&, const tflite::gpu::cl::CreationContext&, const tflite::gpu::cl::OperationDef&, std::unique_ptr<tflite::gpu::cl::GPUOperation>*)':
cl/selectors/convolution_selector.cc:63:5: error: 'IsConvPowerVRSupported' was not declared in this scope; did you mean 'IsConvBuffer1x1Supported'?
   63 |     IsConvPowerVRSupported(op_def, attr)) {
      |     ^~~~~~~~~~~~~~~~~~~~~~
      |     IsConvBuffer1x1Supported
cl/selectors/convolution_selector.cc:64:5: error: 'ConvPowerVR' was not declared in this scope
   64 |     ConvPowerVR conv;
      |     ^~~~~~~~~~~
In file included from ../../../../tensorflow/lite/delegates/gpu/cl/opencl_wrapper.h:22,
                 from ../../../../tensorflow/lite/delegates/gpu/cl/cl_device.h:22,
                 from ../../../../tensorflow/lite/delegates/gpu/cl/cl_context.h:19,
                 from ../../../../tensorflow/lite/delegates/gpu/cl/kernels/gpu_operation.h:23,
                 from ../../../../tensorflow/lite/delegates/gpu/cl/selectors/convolution_selector.h:21,
                 from cl/selectors/convolution_selector.cc:16:
cl/selectors/convolution_selector.cc:65:72: error: 'conv' was not declared in this scope; did you mean 'lconv'?
   65 |     RETURN_IF_ERROR(CreateConvPowerVR(creation_context, op_def, attr, &conv));
      |                                                                        ^~~~
../../../../tensorflow/lite/delegates/gpu/common/status.h:67:27: note: in definition of macro 'RETURN_IF_ERROR'
   67 |     const auto status2 = (status);     \
      |                           ^~~~~~
cl/selectors/convolution_selector.cc:65:21: error: 'CreateConvPowerVR' was not declared in this scope
   65 |     RETURN_IF_ERROR(CreateConvPowerVR(creation_context, op_def, attr, &conv));
      |                     ^~~~~~~~~~~~~~~~~
../../../../tensorflow/lite/delegates/gpu/common/status.h:67:27: note: in definition of macro 'RETURN_IF_ERROR'
   67 |     const auto status2 = (status);     \
      |                           ^~~~~~
cl/selectors/convolution_selector.cc:66:53: error: 'conv' was not declared in this scope; did you mean 'lconv'?
   66 |     *ptr = absl::make_unique<ConvPowerVR>(std::move(conv));
      |                                                     ^~~~
      |                                                     lconv
cl/selectors/convolution_selector.cc: In function 'tflite::gpu::Status tflite::gpu::cl::{anonymous}::SelectConvolutionBuffer(const tflite::gpu::Convolution2DAttributes&, const tflite::gpu::cl::CreationContext&, const tflite::gpu::cl::OperationDef&, std::unique_ptr<tflite::gpu::cl::GPUOperation>*)':
cl/selectors/convolution_selector.cc:86:5: error: 'IsConvPowerVRSupported' was not declared in this scope; did you mean 'IsConvBuffer1x1Supported'?
   86 |     IsConvPowerVRSupported(op_def, attr)) {
      |     ^~~~~~~~~~~~~~~~~~~~~~
      |     IsConvBuffer1x1Supported
cl/selectors/convolution_selector.cc:87:5: error: 'ConvPowerVR' was not declared in this scope
   87 |     ConvPowerVR conv;
      |     ^~~~~~~~~~~
In file included from ../../../../tensorflow/lite/delegates/gpu/cl/opencl_wrapper.h:22,
                 from ../../../../tensorflow/lite/delegates/gpu/cl/cl_device.h:22,
                 from ../../../../tensorflow/lite/delegates/gpu/cl/cl_context.h:19,
                 from ../../../../tensorflow/lite/delegates/gpu/cl/kernels/gpu_operation.h:23,
                 from ../../../../tensorflow/lite/delegates/gpu/cl/selectors/convolution_selector.h:21,
                 from cl/selectors/convolution_selector.cc:16:
cl/selectors/convolution_selector.cc:88:72: error: 'conv' was not declared in this scope; did you mean 'lconv'?
   88 |     RETURN_IF_ERROR(CreateConvPowerVR(creation_context, op_def, attr, &conv));
      |                                                                        ^~~~
../../../../tensorflow/lite/delegates/gpu/common/status.h:67:27: note: in definition of macro 'RETURN_IF_ERROR'
   67 |     const auto status2 = (status);     \
      |                           ^~~~~~
cl/selectors/convolution_selector.cc:88:21: error: 'CreateConvPowerVR' was not declared in this scope
   88 |     RETURN_IF_ERROR(CreateConvPowerVR(creation_context, op_def, attr, &conv));
      |                     ^~~~~~~~~~~~~~~~~
../../../../tensorflow/lite/delegates/gpu/common/status.h:67:27: note: in definition of macro 'RETURN_IF_ERROR'
   67 |     const auto status2 = (status);     \
      |                           ^~~~~~
cl/selectors/convolution_selector.cc:89:53: error: 'conv' was not declared in this scope; did you mean 'lconv'?
   89 |     *ptr = absl::make_unique<ConvPowerVR>(std::move(conv));
      |                                                     ^~~~
      |                                                     lconv
make: *** [Makefile:234: cl/selectors/convolution_selector.o] Error 1
```
