### PR TITLE
TPU: Fix logging statement

### DIFF
--- a/tensorflow/python/tpu/tpu_strategy_util.py
+++ b/tensorflow/python/tpu/tpu_strategy_util.py
@@ -65,7 +65,7 @@ def initialize_tpu_system(cluster_resolver=None):
   if tpu_name in _INITIALIZED_TPU_SYSTEMS:
     logging.warning("TPU system %s has already been initialized. "
                     "Reinitializing the TPU can cause previously created "
-                    "variables on TPU to be lost.")
+                    "variables on TPU to be lost.", tpu_name)
 
   logging.info("Initializing the TPU system: %s", tpu_name)
 


### PR DESCRIPTION
Simple fix to include `tpu_name` in the logging statement, as the original author likely intended.

Current output looks like this:
```
WARNING:tensorflow:TPU system %s has already been initialized. Reinitializing the TPU can cause previously created variables on TPU to be lost.
```