### PR TITLE
 Fix issue: reduce_max on empty int32 array

### DIFF
--- a/tensorflow/core/kernels/reduction_ops_common.h
+++ b/tensorflow/core/kernels/reduction_ops_common.h
@@ -150,6 +150,10 @@ class ReductionOp : public OpKernel {
     const Tensor& axes = ctx->input(1);
     VLOG(1) << "data shape: " << data.shape().DebugString();
     VLOG(1) << "axes      : " << axes.SummarizeValue(10);
+    // If the input is empty, should throw an error message
+    OP_REQUIRES(ctx, data.NumElements() != 0,
+                errors::InvalidArgument(
+                    "The input number of elements should larger than 0"));
 
     ReductionHelper helper;
     OP_REQUIRES_OK(ctx, helper.Simplify(data, axes, keep_dims_));


### PR DESCRIPTION
Fix the issue https://github.com/tensorflow/tensorflow/issues/31325
reduce_max on empty int32 array should throws an error message instead of  returns -2147483648