### PR TITLE
Changes to support ci_build/install scripts with Ubuntu 18.04 docker …

### DIFF
--- a/tensorflow/tools/ci_build/install/install_deb_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_deb_packages.sh
@@ -43,7 +43,7 @@ apt-get install -y --no-install-recommends \
     autoconf \
     automake \
     build-essential \
-    clang-format-3.8 \
+    clang-format-3.9 \
     curl \
     ffmpeg \
     git \

--- a/tensorflow/tools/ci_build/install/install_deb_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_deb_packages.sh
@@ -43,7 +43,6 @@ apt-get install -y --no-install-recommends \
     autoconf \
     automake \
     build-essential \
-    clang-format-3.9 \
     curl \
     ffmpeg \
     git \

--- a/tensorflow/tools/ci_build/install/install_pip_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_pip_packages.sh
@@ -48,8 +48,8 @@ pip3 install virtualenv
 # Install six and future.
 pip2 install --upgrade six==1.12.0
 pip3 install --upgrade six==1.12.0
-pip2 install future>=0.17.1
-pip3 install future>=0.17.1
+pip2 install "future>=0.17.1"
+pip3 install "future>=0.17.1"
 
 # Install absl-py.
 pip2 install --upgrade absl-py

--- a/tensorflow/tools/ci_build/install/install_pip_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_pip_packages.sh
@@ -15,11 +15,20 @@
 # ==============================================================================
 
 set -e
+ubuntu_version=$(cat /etc/issue | grep -i ubuntu | awk '{print $2}' | \
+  awk -F'.' '{print $1}')
 
 # Get the latest version of pip so it recognize manylinux2010
-easy_install3 -U pip
-easy_install -U pip
-
+# easy_install is not available on ubuntu 18.04
+if [[ "$ubuntu_version" == "18" ]]; then
+  wget https://bootstrap.pypa.io/get-pip.py
+  python3 get-pip.py
+  python get-pip.py
+  rm -f get-pip.py
+else
+  easy_install3 -U pip
+  easy_install -U pip
+fi
 # Install pip packages from whl files to avoid the time-consuming process of
 # building from source.
 
@@ -91,6 +100,12 @@ pip2 install psutil
 pip3 install psutil
 pip2 install py-cpuinfo
 pip3 install py-cpuinfo
+
+# pylint==1.6.4 requires python-astroid (>= 1.4.5) requires lazy-object-proxy
+# Latest version of lazy-object-proxy (1.4.2) fails to install from source
+# when using setuptools 39.1.0
+pip2 install lazy-object-proxy==1.4.1
+pip3 install lazy-object-proxy==1.4.1
 
 # pylint tests require the following:
 pip2 install pylint==1.6.4

--- a/tensorflow/tools/ci_build/install/install_pip_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_pip_packages.sh
@@ -15,20 +15,13 @@
 # ==============================================================================
 
 set -e
-ubuntu_version=$(cat /etc/issue | grep -i ubuntu | awk '{print $2}' | \
-  awk -F'.' '{print $1}')
 
 # Get the latest version of pip so it recognize manylinux2010
-# easy_install is not available on ubuntu 18.04
-if [[ "$ubuntu_version" == "18" ]]; then
-  wget https://bootstrap.pypa.io/get-pip.py
-  python3 get-pip.py
-  python get-pip.py
-  rm -f get-pip.py
-else
-  easy_install3 -U pip
-  easy_install -U pip
-fi
+wget https://bootstrap.pypa.io/get-pip.py
+python3 get-pip.py
+python get-pip.py
+rm -f get-pip.py
+
 # Install pip packages from whl files to avoid the time-consuming process of
 # building from source.
 


### PR DESCRIPTION
…containers

Switched from clang-format-3.8 to clang-format-3.9, as it is available on
Ubuntu 18.04, in addition to being available on Ubuntu 14.04 and Ubuntu 16.04.

python-setuptools in Ubuntu 18.04 no longer includes easy_install. For Ubuntu
18.04 only, installing pip using the https://bootstrap.pypa.io/get-pip.py
python program. Ubuntu 16.04 and 14.04 behavior unchanged.

Force installing lazy-object-proxy version 1.4.1, because non x86_64 systems
that need to compile from source encounter an error with version 1.4.2:
`AttributeError: module 'setuptools.build_meta' has no attribute '__legacy__'`
This error is because we install setuptools with apt, and then replace
setuptools with a newer version using pip. This error is resolved in the latest
version of setuptools.