### PR TITLE
Manylinux 2014 Dockerfiles for ppc64le

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.rbe.cuda10.0-cudnn7-ubuntu18.04-manylinux2014.ppc64le
+++ b/tensorflow/tools/ci_build/Dockerfile.rbe.cuda10.0-cudnn7-ubuntu18.04-manylinux2014.ppc64le
@@ -5,9 +5,9 @@
 # glibc (2.17) and system libstdc++ (4.8).
 #
 # To push a new version, run:
-# $ docker build -f Dockerfile.rbe.cuda10.0-cudnn7-ubuntu16.04-manylinux2014.ppc64le
-#  --tag "ibmcom/tensorflow-ppc64le/devel-cuda10.0-cudnn7-ubuntu16.04-manylinux2014" .
-# $ docker push ibmcom/tensorflow-ppc64le/devel-cuda10.0-cudnn7-ubuntu16.04-manylinux2014
+# $ docker build -f Dockerfile.rbe.cuda10.0-cudnn7-ubuntu18.04-manylinux2014.ppc64le
+#  --tag "ibmcom/tensorflow-ppc64le/devel-cuda10.0-cudnn7-ubuntu18.04-manylinux2014" .
+# $ docker push ibmcom/tensorflow-ppc64le/devel-cuda10.0-cudnn7-ubuntu18.04-manylinux2014
 
 FROM nvidia/cuda-ppc64le:10.0-cudnn7-devel-ubuntu18.04
 

--- a/tensorflow/tools/ci_build/Dockerfile.rbe.cuda10.0-cudnn7-ubuntu18.04-manylinux2014.ppc64le
+++ b/tensorflow/tools/ci_build/Dockerfile.rbe.cuda10.0-cudnn7-ubuntu18.04-manylinux2014.ppc64le
@@ -1,0 +1,54 @@
+# Dockerfile to build a manylinux 2014 compliant compiler for ppc64le.
+# Based on Dockerfile.rbe.ubuntu16.04-manylinux2010
+#
+# Builds a devtoolset gcc/libstdc++ that targets manylinux 2014 compatible
+# glibc (2.17) and system libstdc++ (4.8).
+#
+# To push a new version, run:
+# $ docker build -f Dockerfile.rbe.cuda10.0-cudnn7-ubuntu16.04-manylinux2014.ppc64le
+#  --tag "ibmcom/tensorflow-ppc64le/devel-cuda10.0-cudnn7-ubuntu16.04-manylinux2014" .
+# $ docker push ibmcom/tensorflow-ppc64le/devel-cuda10.0-cudnn7-ubuntu16.04-manylinux2014
+
+FROM nvidia/cuda-ppc64le:10.0-cudnn7-devel-ubuntu18.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y \
+      bzip2 \
+      cpio \
+      file \
+      flex \
+      g++ \
+      make \
+      patch \
+      rpm2cpio \
+      unar \
+      wget \
+      tar \
+      xz-utils \
+      && \
+    rm -rf /var/lib/apt/lists/*
+
+ADD devtoolset/fixlinks.sh fixlinks.sh
+ADD devtoolset/build_devtoolset_ppc64le.sh build_devtoolset.sh
+ADD devtoolset/rpm-patch.sh rpm-patch.sh
+
+# Set up a sysroot for glibc 2.19 / libstdc++ 4.8 / devtoolset-7 in /dt7.
+RUN /build_devtoolset.sh devtoolset-7 /dt7
+# Set up a sysroot for glibc 2.19 / libstdc++ 4.8 / devtoolset-8 in /dt8.
+RUN /build_devtoolset.sh devtoolset-8 /dt8
+
+# Copy and run the install scripts.
+COPY install/*.sh /install/
+ARG DEBIAN_FRONTEND=noninteractive
+RUN /install/install_bootstrap_deb_packages.sh
+RUN /install/install_deb_packages.sh
+RUN /install/install_openblas_ppc64le.sh
+RUN /install/install_hdf5_ppc64le.sh
+#RUN /install/install_clang.sh #no apt repo for clang on ppc64le
+RUN /install/install_bazel_from_source.sh
+RUN /install/install_pip_packages.sh
+
+# TODO(klimek): Figure out a better way to get the right include paths
+# forwarded when we install new packages.
+RUN ln -s "/usr/include/powerpc64le-linux-gnu/python3.6m" "/dt7/usr/include/powerpc64le-linux-gnu/python3.6m"
+RUN ln -s "/usr/include/powerpc64le-linux-gnu/python3.6m" "/dt8/usr/include/powerpc64le-linux-gnu/python3.6m"

--- a/tensorflow/tools/ci_build/Dockerfile.rbe.ubuntu16.04-manylinux2014.ppc64le
+++ b/tensorflow/tools/ci_build/Dockerfile.rbe.ubuntu16.04-manylinux2014.ppc64le
@@ -1,0 +1,77 @@
+# Dockerfile to build a manylinux 2014 compliant compiler for ppc64le.
+# Based on Dockerfile.rbe.ubuntu16.04-manylinux2010
+#
+# Builds a devtoolset gcc/libstdc++ that targets manylinux 2014 compatible
+# glibc (2.17) and system libstdc++ (4.8).
+#
+# To push a new version, run:
+# $ docker build -f Dockerfile.rbe.ubuntu16.04-manylinux2014.ppc64le
+#  --tag "ibmcom/tensorflow-ppc64le/devel-ubuntu16.04-manylinux2014" .
+# $ docker push ibmcom/tensorflow-ppc64le/devel-ubuntu16.04-manylinux2014
+
+FROM ubuntu:16.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y \
+      bzip2 \
+      cpio \
+      file \
+      flex \
+      g++ \
+      make \
+      patch \
+      rpm2cpio \
+      unar \
+      wget \
+      tar \
+      xz-utils \
+      && \
+    rm -rf /var/lib/apt/lists/*
+
+ADD devtoolset/fixlinks.sh fixlinks.sh
+ADD devtoolset/build_devtoolset_ppc64le.sh build_devtoolset.sh
+ADD devtoolset/rpm-patch.sh rpm-patch.sh
+
+# Set up a sysroot for glibc 2.19 / libstdc++ 4.8 / devtoolset-7 in /dt7.
+RUN /build_devtoolset.sh devtoolset-7 /dt7
+# Set up a sysroot for glibc 2.19 / libstdc++ 4.8 / devtoolset-8 in /dt8.
+RUN /build_devtoolset.sh devtoolset-8 /dt8
+
+# Copy and run the install scripts.
+COPY install/*.sh /install/
+ARG DEBIAN_FRONTEND=noninteractive
+RUN /install/install_bootstrap_deb_packages.sh
+RUN /install/install_deb_packages.sh
+RUN /install/install_openblas_ppc64le.sh
+RUN /install/install_hdf5_ppc64le.sh
+#RUN /install/install_clang.sh #no apt repo for clang on ppc64le
+RUN /install/install_bazel_from_source.sh
+
+# Install golang.
+RUN /install/install_golang.sh
+env GOROOT=/usr/local/go
+env PATH=$GOROOT/bin:$PATH
+
+# Install python 3.6.
+# Replace easy_install3 (3.5) with easy_install-3.6 because in the next
+#   step that is used to install pip
+RUN wget https://www.python.org/ftp/python/3.6.8/Python-3.6.8.tar.xz && \
+    tar xvf Python-3.6.8.tar.xz && \
+    cd Python-3.6.8 && \
+    ./configure --enable-optimizations && \
+    make altinstall && \
+    cd .. && \
+    rm -rf Python-3.6.8 Python-3.6.8.tar.xz && \
+    update-alternatives --install /usr/local/bin/python3 python3 /usr/local/bin/python3.6 0 && \
+    rm -f /usr/bin/easy_install3 && \
+    update-alternatives --install /usr/bin/easy_install3 easy_install3 /usr/local/bin/easy_install-3.6 0
+
+RUN /install/install_pip_packages.sh
+
+# TODO(klimek): Figure out a better way to get the right include paths
+# forwarded when we install new packages.
+RUN ln -s "/usr/include/powerpc64le-linux-gnu/python2.7" "/dt7/usr/include/powerpc64le-linux-gnu/python2.7"
+RUN ln -s "/usr/include/powerpc64le-linux-gnu/python2.7" "/dt8/usr/include/powerpc64le-linux-gnu/python2.7"
+
+RUN ln -s "/usr/include/powerpc64le-linux-gnu/python3.6m" "/dt7/usr/include/powerpc64le-linux-gnu/python3.6m"
+RUN ln -s "/usr/include/powerpc64le-linux-gnu/python3.6m" "/dt8/usr/include/powerpc64le-linux-gnu/python3.6m"

--- a/tensorflow/tools/ci_build/devtoolset/build_devtoolset_ppc64le.sh
+++ b/tensorflow/tools/ci_build/devtoolset/build_devtoolset_ppc64le.sh
@@ -1,0 +1,138 @@
+#!/bin/bash -eu
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# Builds a devtoolset cross-compiler targeting manylinux 2014 (glibc 2.17 /
+# libstdc++ 4.8).
+# On ppc64le glibc is version 2.19, that is the earlier ubuntu version for ppc64le
+# Based on the script: build_devtoolset.sh 
+
+VERSION="$1"
+TARGET="$2"
+
+case "${VERSION}" in
+devtoolset-7)
+  LIBSTDCXX_VERSION="6.0.24"
+  ;;
+devtoolset-8)
+  LIBSTDCXX_VERSION="6.0.25"
+  ;;
+*)
+  echo "Usage: $0 {devtoolset-7|devtoolset-8} <target-directory>"
+  exit 1
+  ;;
+esac
+
+mkdir -p "${TARGET}"
+# Download binary glibc 2.19 release.
+wget "http://old-releases.ubuntu.com/ubuntu/pool/main/g/glibc/libc6_2.19-10ubuntu2.3_ppc64el.deb" && \
+    unar "libc6_2.19-10ubuntu2.3_ppc64el.deb" && \
+    tar -C "${TARGET}" -xvzf "libc6_2.19-10ubuntu2.3_ppc64el/data.tar.gz" && \
+    rm -rf "libc6_2.19-10ubuntu2.3_ppc64el.deb" "libc6_2.19-10ubuntu2.3_ppc64el"
+wget "http://old-releases.ubuntu.com/ubuntu/pool/main/g/glibc/libc6-dev_2.19-10ubuntu2.3_ppc64el.deb" && \
+    unar "libc6-dev_2.19-10ubuntu2.3_ppc64el.deb" && \
+    tar -C "${TARGET}" -xvf "libc6-dev_2.19-10ubuntu2.3_ppc64el/data.tar.xz" && \
+    rm -rf "libc6-dev_2.19-10ubuntu2.3_ppc64el.deb" "libc6-dev_2.19-10ubuntu2.3_ppc64el"
+
+# Put the current kernel headers from ubuntu in place.
+ln -s "/usr/include/linux" "${TARGET}/usr/include/linux"
+ln -s "/usr/include/asm-generic" "${TARGET}/usr/include/asm-generic"
+ln -s "/usr/include/powerpc64le-linux-gnu/asm" "${TARGET}/usr/include/asm"
+
+# Symlinks in the binary distribution are set up for installation in /usr, we
+# need to fix up all the links to stay within ${TARGET}.
+/fixlinks.sh "${TARGET}"
+
+# Patch to allow non-glibc 2.19 compatible builds to work.
+sed -i '54i#define TCP_USER_TIMEOUT 18' "${TARGET}/usr/include/netinet/tcp.h"
+
+# Download binary libstdc++ 4.8 release we are going to link against.
+# We only need the shared library, as we're going to develop against the
+# libstdc++ provided by devtoolset.
+wget "http://ports.ubuntu.com/ubuntu-ports/pool/main/g/gcc-4.8/libstdc++6_4.8.4-2ubuntu1~14.04.4_ppc64el.deb" && \
+    unar "libstdc++6_4.8.4-2ubuntu1~14.04.4_ppc64el.deb" && \
+    tar -C "${TARGET}" -xvf "libstdc++6_4.8.4-2ubuntu1~14.04.4_ppc64el/data.tar.xz" "./usr/lib/powerpc64le-linux-gnu/libstdc++.so.6.0.19" && \
+    rm -rf "libstdc++6_4.8.4-2ubuntu1~14.04.4_ppc64el.deb" "llibstdc++6_4.8.4-2ubuntu1~14.04.4_ppc64el"
+
+mkdir -p "${TARGET}-src"
+cd "${TARGET}-src"
+
+# Build a devtoolset cross-compiler based on our glibc 2.19 sysroot setup.
+
+case "${VERSION}" in
+devtoolset-7)
+  wget "http://vault.centos.org/centos/6/sclo/Source/rh/devtoolset-7/devtoolset-7-gcc-7.3.1-5.15.el6.src.rpm"
+  rpm2cpio "devtoolset-7-gcc-7.3.1-5.15.el6.src.rpm" |cpio -idmv
+  tar -xvjf "gcc-7.3.1-20180303.tar.bz2" --strip 1
+  ;;
+devtoolset-8)
+  wget "http://vault.centos.org/centos/6/sclo/Source/rh/devtoolset-8/devtoolset-8-gcc-8.2.1-3.el6.src.rpm"
+  rpm2cpio "devtoolset-8-gcc-8.2.1-3.el6.src.rpm" |cpio -idmv
+  tar -xvf "gcc-8.2.1-20180905.tar.xz" --strip 1
+  ;;
+esac
+
+# Apply the devtoolset patches to gcc.
+/rpm-patch.sh "gcc.spec"
+
+./contrib/download_prerequisites
+
+mkdir -p "${TARGET}-build"
+cd "${TARGET}-build"
+
+"${TARGET}-src/configure" \
+      --prefix="${TARGET}/usr" \
+      --with-sysroot="${TARGET}" \
+      --disable-bootstrap \
+      --disable-libmpx \
+      --disable-libsanitizer \
+      --disable-libunwind-exceptions \
+      --disable-libunwind-exceptions \
+      --disable-lto \
+      --disable-multilib \
+      --enable-__cxa_atexit \
+      --enable-gnu-indirect-function \
+      --enable-gnu-unique-object \
+      --enable-initfini-array \
+      --enable-languages="c,c++" \
+      --enable-linker-build-id \
+      --enable-plugin \
+      --enable-shared \
+      --enable-threads=posix \
+      --with-default-libstdcxx-abi="gcc4-compatible" \
+      --with-gcc-major-version-only \
+      --with-linker-hash-style="gnu" \
+      --with-tune="power8" \
+      && \
+    make -j 42 && \
+    make install
+
+# Create the devtoolset libstdc++ linkerscript that links dynamically against
+# the system libstdc++ 4.4 and provides all other symbols statically.
+# Run the command 'objdump -i' to find the correct OUTPUT_FORMAT for an architecture
+mv "${TARGET}/usr/lib64/libstdc++.so.${LIBSTDCXX_VERSION}" \
+   "${TARGET}/usr/lib64/libstdc++.so.${LIBSTDCXX_VERSION}.backup"
+echo -e "OUTPUT_FORMAT(elf64-powerpcle)\nINPUT ( libstdc++.so.6.0.19 -lstdc++_nonshared44 )" \
+   > "${TARGET}/usr/lib64/libstdc++.so.${LIBSTDCXX_VERSION}"
+cp "./powerpc64le-unknown-linux-gnu/libstdc++-v3/src/.libs/libstdc++_nonshared44.a" \
+   "${TARGET}/usr/lib64"
+
+# Link in architecture specific includes from the system; note that we cannot
+# link in the whole powerpc64le-linux-gnu folder, as otherwise we're overlaying
+# system gcc paths that we do not want to find.
+# TODO(klimek): Automate linking in all non-gcc / non-kernel include
+# directories.
+mkdir -p "${TARGET}/usr/include/powerpc64le-linux-gnu"
+ln -s "/usr/include/powerpc64le-linux-gnu/python3.5m" "${TARGET}/usr/include/powerpc64le-linux-gnu/python3.5m"

--- a/tensorflow/tools/ci_build/devtoolset/build_devtoolset_ppc64le.sh
+++ b/tensorflow/tools/ci_build/devtoolset/build_devtoolset_ppc64le.sh
@@ -64,7 +64,7 @@ sed -i '54i#define TCP_USER_TIMEOUT 18' "${TARGET}/usr/include/netinet/tcp.h"
 wget "http://ports.ubuntu.com/ubuntu-ports/pool/main/g/gcc-4.8/libstdc++6_4.8.4-2ubuntu1~14.04.4_ppc64el.deb" && \
     unar "libstdc++6_4.8.4-2ubuntu1~14.04.4_ppc64el.deb" && \
     tar -C "${TARGET}" -xvf "libstdc++6_4.8.4-2ubuntu1~14.04.4_ppc64el/data.tar.xz" "./usr/lib/powerpc64le-linux-gnu/libstdc++.so.6.0.19" && \
-    rm -rf "libstdc++6_4.8.4-2ubuntu1~14.04.4_ppc64el.deb" "llibstdc++6_4.8.4-2ubuntu1~14.04.4_ppc64el"
+    rm -rf "libstdc++6_4.8.4-2ubuntu1~14.04.4_ppc64el.deb" "libstdc++6_4.8.4-2ubuntu1~14.04.4_ppc64el"
 
 mkdir -p "${TARGET}-src"
 cd "${TARGET}-src"
@@ -136,3 +136,7 @@ cp "./powerpc64le-unknown-linux-gnu/libstdc++-v3/src/.libs/libstdc++_nonshared44
 # directories.
 mkdir -p "${TARGET}/usr/include/powerpc64le-linux-gnu"
 ln -s "/usr/include/powerpc64le-linux-gnu/python3.5m" "${TARGET}/usr/include/powerpc64le-linux-gnu/python3.5m"
+
+# Clean up
+rm -rf "${TARGET}-build"
+rm -rf "${TARGET}-src"

--- a/tensorflow/tools/ci_build/install/install_hdf5_ppc64le.sh
+++ b/tensorflow/tools/ci_build/install/install_hdf5_ppc64le.sh
@@ -19,12 +19,7 @@
 #It has to be compiled from source during the install
 apt-get update
 apt-get install -y libhdf5-dev
+apt-get clean
+rm -rf /var/lib/apt/lists/*
 
-#h5py is not expecting the shared libraries to have _serial in the name.
-ln -s /usr/lib/powerpc64le-linux-gnu/libhdf5_serial.so /usr/lib/powerpc64le-linux-gnu/libhdf5.so
-ln -s /usr/lib/powerpc64le-linux-gnu/libhdf5_serial_hl.so /usr/lib/powerpc64le-linux-gnu/libhdf5_hl.so
-
-#pip is not installed yet, so use easy_install
-#CPATH is the location of hdf5.h
-CPATH=/usr/include/hdf5/serial/ easy_install -U h5py
-CPATH=/usr/include/hdf5/serial/ easy_install3 -U h5py
+#h5py will then be installed from the install_pip_packages.sh script

--- a/tensorflow/tools/ci_build/install/install_openblas_ppc64le.sh
+++ b/tensorflow/tools/ci_build/install/install_openblas_ppc64le.sh
@@ -20,10 +20,10 @@ USE_OPENMP="USE_OPENMP=1"
 OPENBLAS_INSTALL_PATH="/usr"
 apt-get update
 apt-get install -y gfortran gfortran-5
+apt-get clean
+rm -rf /var/lib/apt/lists/*
 rm -rf ${OPENBLAS_SRC_PATH}
-git clone -b release-0.3.0 https://github.com/xianyi/OpenBLAS ${OPENBLAS_SRC_PATH}
+git clone -b v0.3.7 https://github.com/xianyi/OpenBLAS ${OPENBLAS_SRC_PATH}
 cd ${OPENBLAS_SRC_PATH}
-# Pick up fix for OpenBLAS issue 1571
-git cherry-pick -X theirs 961d25e9c7e4a1758adb1dbeaa15187de69dd052
 make TARGET=${POWER} ${USE_OPENMP} FC=gfortran
 make PREFIX=${OPENBLAS_INSTALL_PATH} install


### PR DESCRIPTION
Based on the work TensorFlow did to support manylinux 2010, these docker files
will be used to build docker images to build tensorflow for ppc64le that is
compliant with manylinux 2014.

ppc64le can never be manylinux 2010 compliant as little endian support for POWER
was not added until after 2010.

Docker files provided for CPU and GPU builds.

Cleaned up two ppc64le specific install scripts.