### PR TITLE
Update tensorflow for upcoming incompatible change: https://github.com/bazelbuild/bazel/issues/7362

### DIFF
--- a/tensorflow/cc/saved_model/BUILD
+++ b/tensorflow/cc/saved_model/BUILD
@@ -92,6 +92,7 @@ cc_library(
     ]) + if_android([
         "//tensorflow/core:android_tensorflow_lib",
     ]),
+    alwayslink = 1,
 )
 
 cc_library(
@@ -105,6 +106,7 @@ cc_library(
         "//tensorflow/core:protos_all_cc",
         # mobile not supported yet
     ]),
+    alwayslink = 1,
 )
 
 cc_library(
@@ -123,6 +125,7 @@ cc_library(
         "//tensorflow/core/util/tensor_bundle:naming",
         # mobile not supported yet
     ]),
+    alwayslink = 1,
 )
 
 tf_cc_test(

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -780,6 +780,7 @@ cc_library(
         ":lib_proto_parsing",
         ":protos_all_cc",
     ],
+    alwayslink = 1,
 )
 
 # DEPRECATED: use platform:stringpiece instead.
@@ -2504,6 +2505,7 @@ cc_library(
                "@com_google_protobuf//:protobuf",
            ] + tf_protos_all_impl() + tf_protos_grappler_impl() +
            tf_additional_numa_deps(),
+    alwayslink = 1,
 )
 
 # File compiled with extra flags to get cpu-specific acceleration.

--- a/tensorflow/core/platform/default/build_config.bzl
+++ b/tensorflow/core/platform/default/build_config.bzl
@@ -346,7 +346,7 @@ def tf_proto_library_cc(
     if not srcs:
         # This is a collection of sub-libraries. Build header-only and impl
         # libraries containing all the sources.
-        proto_gen(y
+        proto_gen(
             name = cc_name + "_genproto",
             protoc = "@com_google_protobuf//:protoc",
             visibility = ["//visibility:public"],

--- a/tensorflow/core/platform/default/build_config.bzl
+++ b/tensorflow/core/platform/default/build_config.bzl
@@ -180,6 +180,7 @@ def cc_proto_library(
         # An empty cc_library to make rule dependency consistent.
         native.cc_library(
             name = name,
+            alwayslink = 1,
             **kargs
         )
         return
@@ -228,12 +229,14 @@ def cc_proto_library(
         hdrs = gen_hdrs,
         deps = cc_libs + deps,
         includes = includes,
+        alwayslink = 1,
         **kargs
     )
     native.cc_library(
         name = header_only_name,
         deps = ["@com_google_protobuf//:protobuf_headers"] + if_static([impl_name]),
         hdrs = gen_hdrs,
+        alwayslink = 1,
         **kargs
     )
 
@@ -343,7 +346,7 @@ def tf_proto_library_cc(
     if not srcs:
         # This is a collection of sub-libraries. Build header-only and impl
         # libraries containing all the sources.
-        proto_gen(
+        proto_gen(y
             name = cc_name + "_genproto",
             protoc = "@com_google_protobuf//:protoc",
             visibility = ["//visibility:public"],
@@ -354,10 +357,12 @@ def tf_proto_library_cc(
             deps = cc_deps + ["@com_google_protobuf//:protobuf_headers"] + if_static([name + "_cc_impl"]),
             testonly = testonly,
             visibility = visibility,
+            alwayslink = 1,
         )
         native.cc_library(
             name = cc_name + "_impl",
             deps = [s + "_impl" for s in cc_deps] + ["@com_google_protobuf//:cc_wkt_protos"],
+            alwayslink = 1,
         )
 
         return

--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -634,6 +634,7 @@ cc_library(
         "//tensorflow/core:op_gen_lib",
         "//tensorflow/core:protos_all_cc",
     ],
+    alwayslink = 1,
 )
 
 py_library(

--- a/third_party/systemlibs/protobuf.bzl
+++ b/third_party/systemlibs/protobuf.bzl
@@ -226,6 +226,7 @@ def cc_proto_library(
         # An empty cc_library to make rule dependency consistent.
         native.cc_library(
             name = name,
+            alwayslink = 1,
             **kargs
         )
         return
@@ -262,6 +263,7 @@ def cc_proto_library(
         hdrs = gen_hdrs,
         deps = cc_libs + deps,
         includes = includes,
+        alwayslink = 1,
         **kargs
     )
 


### PR DESCRIPTION
Update tensorflow for upcoming incompatible change: https://github.com/bazelbuild/bazel/issues/7362

This PR updates `cc_library`s to use `alwayslink=1` when needed. Currently, library archives and library object groups are wrapped in `--whole_archive`, `--no_whole_archive`, thus the whole library is always linked. This will change with Bazel 1.0, and libraries which export symbols must be tagged as `alwayslink=1`.