### PR TITLE
Update protobuf.patch for Bazel's incompatible change bazelbuild/bazel#7362

### DIFF
--- a/third_party/protobuf/protobuf.patch
+++ b/third_party/protobuf/protobuf.patch
@@ -11,7 +11,15 @@ index 2fb26050..c2744d5b 100644
  
  ################################################################################
  # Protobuf Runtime Library
-@@ -218,7 +218,7 @@ cc_library(
+@@ -209,6 +209,7 @@ cc_library(
+     copts = COPTS,
+     includes = ["src/"],
+     linkopts = LINK_OPTS,
++    alwayslink = 1,
+     visibility = ["//visibility:public"],
+     deps = [":protobuf_lite"] + PROTOBUF_DEPS,
+ )
+@@ -219,7 +220,7 @@ cc_library(
  # TODO(keveman): Remove this target once the support gets added to Bazel.
  cc_library(
      name = "protobuf_headers",


### PR DESCRIPTION
This PR updates Tensorflow to change protobuf's cc_library //third_party/protobuf:protobuf to include `alwayslink = 1`. 

This is needed because tensorflow_framework.so currently defines the symbols provided by //third_party/protobuf:protobuf. Incompatible change bazelbuild/bazel#7362 is going to be flipped in Bazel 1.0. and is going to disable `--legacy_whole_archive` that was enabled by default and that caused every transitive cc_library linked into a transitive shared library to be linked in a whole-archive block. Putting `alwayslink = 1` recreates the behavior from before the flag flip.

The principled solution is to talk to the protobuf team and ask them to maintain a cc_library with alwayslink = 1 target that projects such as TF can depend on. This PR is a fast-fix for Bazel 1.0. And maybe we'll discover that those symbols shouldn't be defined by the protobuf_tensorflow.so at all and instead //third_party/protobuf:protobuf should be a dependency of executables using those symbols.