### PR TITLE
Fix deprecation warning when calling boolean_mask

### DIFF
--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -1472,7 +1472,7 @@ def boolean_mask(tensor, mask, name="boolean_mask", axis=None):
 
   def _apply_mask_1d(reshaped_tensor, mask, axis=None):
     """Mask tensor along dimension 0 with a 1-D mask."""
-    indices = squeeze(where(mask), axis=[1])
+    indices = squeeze(where_v2(mask), axis=[1])
     return gather(reshaped_tensor, indices, axis=axis)
 
   with ops.name_scope(name, values=[tensor, mask]):


### PR DESCRIPTION
Running the examples from the [`tf.boolean_mask`](https://www.tensorflow.org/versions/r2.0/api_docs/python/tf/boolean_mask) documentation prints the following deprecation warning:

> W0828 15:35:30.538258 140631514593024 deprecation.py:323] From .../lib/python3.6/site-packages/tensorflow_core/python/ops/array_ops.py:1486: where (from tensorflow.python.ops.array_os) is deprecated and will be removed in a future version.
> Instructions for updating:
> Use tf.where in 2.0, which has the same broadcast rule as np.where

This PR fixes that.