### PR TITLE
Update docstring for tf.linalg.matvec

### DIFF
--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -2733,7 +2733,7 @@ def matvec(a,
 
   # `a` * `b`
   # [ 58,  64]
-  c = tf.matvec(a, b)
+  c = tf.linalg.matvec(a, b)
 
 
   # 3-D tensor `a`
@@ -2753,7 +2753,7 @@ def matvec(a,
   # `a` * `b`
   # [[ 86, 212],
   #  [410, 563]]
-  c = tf.matvec(a, b)
+  c = tf.linalg.matvec(a, b)
   ```
 
   Args:


### PR DESCRIPTION
In tensorflow, `matvec` is exposed as `tf.linalg.matvec`
but in the docstring `tf.matvec` is used instead.

This fix fixes the docstring `tf.matvec` => `tf.linalg.matvec`

This fix fixes #31923.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>