### PR TITLE
MKL DNN: Fixing deprecation test for MKL DNN when OpenMP threads are set

### DIFF
--- a/tensorflow/tools/api/tests/deprecation_test.py
+++ b/tensorflow/tools/api/tests/deprecation_test.py
@@ -19,6 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
+import os
 import tensorflow as tf
 
 from tensorflow.python.platform import test
@@ -145,13 +146,31 @@ class DeprecationTest(test.TestCase):
   def testKerasDeprecation(self, mock_warning):
     self.assertEqual(0, mock_warning.call_count)
     tf.keras.backend.get_session()
-    self.assertEqual(1, mock_warning.call_count)
-    self.assertRegexpMatches(
-        mock_warning.call_args[0][-1],
-        "tf.compat.v1.keras.backend.get_session")
+    # if OpenMP is set in environment, then logging.warning
+    # is called two times. First for deprecation and 2nd for
+    # OMP related warning.
+    if os.environ.get('OMP_NUM_THREADS'):
+      self.assertEqual(2, mock_warning.call_count)
+      # First message on deprecation warning.
+      self.assertRegexpMatches(
+          mock_warning.call_args_list[0][0][-1],
+          "tf.compat.v1.keras.backend.get_session")
+      # Second message is not a deprecation warning.
+      self.assertRegexpMatches(
+          mock_warning.call_args_list[1][0][0],
+          "OMP_NUM_THREADS is no longer used by the default Keras config."
+          " To configure the number of threads, use tf.config.threading" 
+          " APIs")
+    else:
+      self.assertEqual(1, mock_warning.call_count)
+      self.assertRegexpMatches(
+          mock_warning.call_args[0][-1],
+          "tf.compat.v1.keras.backend.get_session")
     tf.keras.backend.get_session()
-    self.assertEqual(1, mock_warning.call_count)
-
+    if os.environ.get('OMP_NUM_THREADS'):
+      self.assertEqual(2, mock_warning.call_count)
+    else:
+      self.assertEqual(1, mock_warning.call_count)
   @test.mock.patch.object(logging, "warning", autospec=True)
   def testKerasEndpointDeprecation(self, mock_warning):
     self.assertEqual(0, mock_warning.call_count)


### PR DESCRIPTION
This unit test just tests if proper deprecation warning is raised using logging.warning call. Generally when tf.keral.backend.get_session() is called, one deprecation message is shown (to using the v2 version, that is, tf.compat.v1.keras.backend.get_session). But, if OMP_NUM_THREADS is set through environment, the tf.keras.backend.get_session() raises two separate logging.warning messages. These are: 1) usual deprecation warning as above, and 2) warning "how to set effectively set OMP_NUM_THREADS for Keras API. Thus, the warning call count becomes 2. The test is edited to incorporate this scenario when OMP_NUM_THREADS is set.