### PR TITLE
To revert commit 7520b333d66a87574be8b910c284c61404e5ca03 (Update Eigen...) 

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -171,11 +171,11 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
         name = "eigen_archive",
         build_file = clean_dep("//third_party:eigen.BUILD"),
         patch_file = clean_dep("//third_party/eigen3:gpu_packet_math.patch"),
-        sha256 = "baa02bff5b966290d7d0cc9687edbc0bc465754e88637c6df61b243f4642302a",
-        strip_prefix = "eigen-eigen-7747e7809bd3",
+        sha256 = "7e7a57e33c59280a17a66e521396cd8b1a55d0676c9f807078522fda52114b5c",
+        strip_prefix = "eigen-eigen-8071cda5714d",
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/bitbucket.org/eigen/eigen/get/7747e7809bd3.tar.gz",
-            "https://bitbucket.org/eigen/eigen/get/7747e7809bd3.tar.gz",
+            "https://storage.googleapis.com/mirror.tensorflow.org/bitbucket.org/eigen/eigen/get/8071cda5714d.tar.gz",
+            "https://bitbucket.org/eigen/eigen/get/8071cda5714d.tar.gz",
         ],
     )
 


### PR DESCRIPTION
The commit 7520b333d66a87574be8b910c284c61404e5ca03 (Update Eigen to https://bitbucket.org/eigen/eigen/commits/7747e7809bd38fca...). breaks the build on Intel branch for architectures with AVX2. The errors shown is .

ERROR: /workspace/tensorflow/core/kernels/BUILD:3747:1: Couldn't build file tensorflow/core/kernels/_objs/cast_op/cast_op_impl_double.o: C++ compilation of rule '//tensorflow/core/kernels:cast_op' failed (Exit 1): gcc failed: error executing command
ERROR: /workspace/tensorflow/core/kernels/BUILD:3747:1: Couldn't build file tensorflow/core/kernels/_objs/cast_op/cast_op_impl_uint32.o: C++ compilation of rule 
ERROR: /....../tensorflow/core/kernels/BUILD:3747:1: C++ compilation of rule '//tensorflow/core/kernels:cast_op' failed (Exit 1)
     :

