### PR TITLE
Backport https://github.com/tensorflow/addons/pull/306 into master

### DIFF
--- a/tensorflow/contrib/seq2seq/python/kernel_tests/beam_search_decoder_test.py
+++ b/tensorflow/contrib/seq2seq/python/kernel_tests/beam_search_decoder_test.py
@@ -30,6 +30,7 @@ from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors
 from tensorflow.python.framework import ops
+from tensorflow.python.framework import tensor_shape
 from tensorflow.python.framework import test_util
 from tensorflow.python.keras import layers
 from tensorflow.python.layers import core as layers_core
@@ -221,22 +222,22 @@ class TestArrayShapeChecks(test.TestCase):
   def test_array_shape_static_checks(self):
     self.assertTrue(
         beam_search_decoder._check_static_batch_beam_maybe(
-            tf.TensorShape([None, None, None]), 3, 5))
+            tensor_shape.TensorShape([None, None, None]), 3, 5))
     self.assertTrue(
         beam_search_decoder._check_static_batch_beam_maybe(
-            tf.TensorShape([15, None, None]), 3, 5))
+            tensor_shape.TensorShape([15, None, None]), 3, 5))
     self.assertFalse(
         beam_search_decoder._check_static_batch_beam_maybe(
-            tf.TensorShape([16, None, None]), 3, 5))
+            tensor_shape.TensorShape([16, None, None]), 3, 5))
     self.assertTrue(
         beam_search_decoder._check_static_batch_beam_maybe(
-            tf.TensorShape([3, 5, None]), 3, 5))
+            tensor_shape.TensorShape([3, 5, None]), 3, 5))
     self.assertFalse(
         beam_search_decoder._check_static_batch_beam_maybe(
-            tf.TensorShape([3, 6, None]), 3, 5))
+            tensor_shape.TensorShape([3, 6, None]), 3, 5))
     self.assertFalse(
         beam_search_decoder._check_static_batch_beam_maybe(
-            tf.TensorShape([5, 3, None]), 3, 5))
+            tensor_shape.TensorShape([5, 3, None]), 3, 5))
 
 
 class TestEosMasking(test.TestCase):

--- a/tensorflow/contrib/seq2seq/python/kernel_tests/beam_search_decoder_test.py
+++ b/tensorflow/contrib/seq2seq/python/kernel_tests/beam_search_decoder_test.py
@@ -218,6 +218,27 @@ class TestArrayShapeChecks(test.TestCase):
         (8, 4), (None, None), 4, 5, is_valid=False)
 
 
+  def test_array_shape_static_checks(self):
+    self.assertTrue(
+        beam_search_decoder._check_static_batch_beam_maybe(
+            tf.TensorShape([None, None, None]), 3, 5))
+    self.assertTrue(
+        beam_search_decoder._check_static_batch_beam_maybe(
+            tf.TensorShape([15, None, None]), 3, 5))
+    self.assertFalse(
+        beam_search_decoder._check_static_batch_beam_maybe(
+            tf.TensorShape([16, None, None]), 3, 5))
+    self.assertTrue(
+        beam_search_decoder._check_static_batch_beam_maybe(
+            tf.TensorShape([3, 5, None]), 3, 5))
+    self.assertFalse(
+        beam_search_decoder._check_static_batch_beam_maybe(
+            tf.TensorShape([3, 6, None]), 3, 5))
+    self.assertFalse(
+        beam_search_decoder._check_static_batch_beam_maybe(
+            tf.TensorShape([5, 3, None]), 3, 5))
+
+
 class TestEosMasking(test.TestCase):
   """Tests EOS masking used in beam search."""
 


### PR DESCRIPTION
This is fixing the conditional in `tf.contrib.seq2seq.beam_search_decoder`'s `_check_static_batch_beam_maybe`, as reported in https://github.com/tensorflow/addons/issues/289 .