### PR TITLE
Backport https://github.com/tensorflow/addons/pull/340 into master

### DIFF
--- a/tensorflow/contrib/seq2seq/python/kernel_tests/loss_test.py
+++ b/tensorflow/contrib/seq2seq/python/kernel_tests/loss_test.py
@@ -267,6 +267,18 @@ class LossTest(test.TestCase):
       compare_total = np.zeros((self.batch_size, self.sequence_length))
       self.assertAllClose(compare_total, res)
 
+  def testAmbiguousOrder(self):
+    with self.assertRaisesRegexp(ValueError, 'because of ambiguous order'):
+      with self.cached_session(use_gpu=True):
+        self.setup()
+        seq_loss = loss.SequenceLoss(
+            average_across_timesteps=False,
+            average_across_batch=True,
+            sum_over_timesteps=True,
+            sum_over_batch=False)
+        self.evaluate(
+            seq_loss(self.targets, self.logits, self.weights))
+
 
 if __name__ == '__main__':
   test.main()

--- a/tensorflow/contrib/seq2seq/python/ops/loss.py
+++ b/tensorflow/contrib/seq2seq/python/ops/loss.py
@@ -104,6 +104,12 @@ def sequence_loss(logits,
   if average_across_batch and sum_over_batch:
     raise ValueError("average_across_batch and sum_over_batch cannot be set "
                      "to True at same time.")
+  if average_across_batch and sum_over_timesteps:
+    raise ValueError("average_across_batch and sum_over_timesteps cannot be "
+                     "set to True at same time because of ambiguous order.")
+  if sum_over_batch and average_across_timesteps:
+    raise ValueError("sum_over_batch and average_across_timesteps cannot be "
+                     "set to True at same time because of ambiguous order.")
   with ops.name_scope(name, "sequence_loss", [logits, targets, weights]):
     num_classes = array_ops.shape(logits)[2]
     logits_flat = array_ops.reshape(logits, [-1, num_classes])


### PR DESCRIPTION
This is fixing the failure of the `tf.contrib.seq2seq.sequence_loss` to warn if incompatible modes are selected, as reported in https://github.com/tensorflow/addons/issues/329 .