### PR TITLE
Track trackables in graph networks

### DIFF
--- a/tensorflow/python/feature_column/feature_column_v2.py
+++ b/tensorflow/python/feature_column/feature_column_v2.py
@@ -273,8 +273,8 @@ class _StateManagerImpl(StateManager):
     """
     self._trainable = trainable
     self._layer = layer
-    if self._layer is not None:
-      self._layer._maybe_create_attribute('_resources', [])  # pylint: disable=protected-access
+    if self._layer is not None and not hasattr(self._layer, '_resources'):
+      self._layer._resources = []  # pylint: disable=protected-access
     self._cols_to_vars_map = collections.defaultdict(lambda: {})
     # TODO(vbardiovsky): Make sure the resources are tracked by moving them to
     # the layer (inheriting from AutoTrackable), e.g.:

--- a/tensorflow/python/keras/engine/network_test.py
+++ b/tensorflow/python/keras/engine/network_test.py
@@ -35,6 +35,7 @@ from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import state_ops
 from tensorflow.python.platform import test
+from tensorflow.python.training.tracking.util import Checkpoint
 
 try:
   import yaml  # pylint:disable=g-import-not-at-top
@@ -1162,6 +1163,13 @@ class NetworkConstructionTest(keras_parameterized.TestCase):
     self.assertLen(net2.inputs, 2)
     self.assertEqual('a', net2.layers[0].name)
     self.assertEqual('b', net2.layers[1].name)
+
+  @keras_parameterized.run_with_all_model_types
+  def test_dependency_tracking(self):
+    model = testing_utils.get_small_mlp(1, 4, input_dim=3)
+    model.trackable = Checkpoint()
+    self.assertIn('trackable', model._unconditional_dependency_names)
+    self.assertEqual(model.trackable, model._lookup_dependency('trackable'))
 
 
 class DeferredModeTest(test.TestCase):

--- a/tensorflow/python/keras/engine/training.py
+++ b/tensorflow/python/keras/engine/training.py
@@ -1742,6 +1742,7 @@ class Model(network.Network):
       return self.callback_model
     return self
 
+  @trackable.no_automatic_dependency_tracking
   def _make_callback_model(self, grouped_model):
     first_replicated_model = self._distribution_strategy.unwrap(
         grouped_model)[0]


### PR DESCRIPTION
This change also removes automatic tracking of Keras-internal attributes. (resolving loading bug from #31893).

PiperOrigin-RevId: 266440936