### PR TITLE
[XLA] [MLIR] Don't include CUDA when it isn't configured

### DIFF
--- a/tensorflow/compiler/xla/service/BUILD
+++ b/tensorflow/compiler/xla/service/BUILD
@@ -945,9 +945,10 @@ cc_library(
     deps = [
         ":service",
         "//tensorflow/compiler/xla/service/gpu:gpu_transfer_manager",
-        "//tensorflow/compiler/xla/service/mlir_gpu:mlir_compiler",
         "//tensorflow/core:stream_executor_no_cuda",
-    ],
+    ] + if_cuda_is_configured([
+        "//tensorflow/compiler/xla/service/mlir_gpu:mlir_compiler",
+    ]),
 )
 
 cc_library(


### PR DESCRIPTION
The git transaction f78a3d92b281e4904773c4a26e740d8995ed252e introduced a dependency on CUDA for all XLA backends.  Not everyone has CUDA compiled into their backend.

This change eliminates that dependency when CUDA is not configured.