### PR TITLE
Use where_v2 to silence deprecation warning

### DIFF
--- a/tensorflow/python/data/util/random_seed.py
+++ b/tensorflow/python/data/util/random_seed.py
@@ -50,7 +50,7 @@ def get_seed(seed):
   else:
     with ops.name_scope("seed2") as scope:
       seed2 = ops.convert_to_tensor(seed2, dtype=dtypes.int64)
-      seed2 = array_ops.where(
+      seed2 = array_ops.where_v2(
           math_ops.logical_and(
               math_ops.equal(seed, 0), math_ops.equal(seed2, 0)),
           constant_op.constant(2**31 - 1, dtype=dtypes.int64),


### PR DESCRIPTION
Running this function currently prints the following deprecation warning:

> W0902 14:30:32.759225 140344378930944 deprecation.py:323] From /lib/python3.6/site-packages/tensorflow_core/python/data/util/random_seed.py:58: where (from tensorflow.python.ops.array_ops) is deprecated and will be removed in a future version.
Instructions for updating:
Use tf.where in 2.0, which has the same broadcast rule as np.where

This PR fixes that.