### PR TITLE
[tf.data] Increase default buffer size to 256 MB

### DIFF
--- a/tensorflow/python/data/ops/readers.py
+++ b/tensorflow/python/data/ops/readers.py
@@ -29,8 +29,7 @@ from tensorflow.python.ops import gen_experimental_dataset_ops as ged_ops
 from tensorflow.python.util.tf_export import tf_export
 
 
-# TODO(b/64974358): Increase default buffer size to 256 MB.
-_DEFAULT_READER_BUFFER_SIZE_BYTES = 256 * 1024  # 256 KB
+_DEFAULT_READER_BUFFER_SIZE_BYTES = 256 * 1024 * 1024  # 256 MB
 
 
 def _create_or_validate_filenames_dataset(filenames):

--- a/tensorflow/python/data/ops/readers.py
+++ b/tensorflow/python/data/ops/readers.py
@@ -29,7 +29,7 @@ from tensorflow.python.ops import gen_experimental_dataset_ops as ged_ops
 from tensorflow.python.util.tf_export import tf_export
 
 
-_DEFAULT_READER_BUFFER_SIZE_BYTES = 256 * 1024 * 1024  # 256 MB
+_DEFAULT_READER_BUFFER_SIZE_BYTES = 256 * 1024  # 256 KB
 
 
 def _create_or_validate_filenames_dataset(filenames):


### PR DESCRIPTION
A larger buffer size brings better throughput at the cost of buffer bloat.