### PR TITLE
fixed __thread define usage for i386 build

### DIFF
--- a/tensorflow/contrib/makefile/Makefile
+++ b/tensorflow/contrib/makefile/Makefile
@@ -571,7 +571,7 @@ ifeq ($(TARGET),IOS)
 		-arch i386 \
 		-mno-sse \
 		-fembed-bitcode \
-		-D__thread=thread_local \
+		-D__thread= \
 		-DUSE_GEMM_FOR_CONV \
 		-Wno-c++11-narrowing \
 		-DTF_LEAN_BINARY \

--- a/tensorflow/core/util/work_sharder.cc
+++ b/tensorflow/core/util/work_sharder.cc
@@ -20,7 +20,7 @@ limitations under the License.
 
 namespace tensorflow {
 
-/* ABSL_CONST_INIT */ thread_local int per_thread_max_parallism = 1000000;
+/* ABSL_CONST_INIT */ __thread int per_thread_max_parallism = 1000000;
 
 void SetPerThreadMaxParallelism(int max_parallelism) {
   CHECK_LE(0, max_parallelism);


### PR DESCRIPTION
- make use of the `__thread` define specified in the makefile
- used inside `work_sharder.cc`