### PR TITLE
[Intel MKL] Upgrading giflib to fix CVE-2019-15133

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -287,12 +287,12 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
     tf_http_archive(
         name = "gif_archive",
         build_file = clean_dep("//third_party:gif.BUILD"),
-        sha256 = "34a7377ba834397db019e8eb122e551a49c98f49df75ec3fcc92b9a794a4f6d1",
-        strip_prefix = "giflib-5.1.4",
+        sha256 = "31da5562f44c5f15d63340a09a4fd62b48c45620cd302f77a6d9acf0077879bd",
+        strip_prefix = "giflib-5.2.1",
         system_build_file = clean_dep("//third_party/systemlibs:gif.BUILD"),
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/ufpr.dl.sourceforge.net/project/giflib/giflib-5.1.4.tar.gz",
-            "http://pilotfiber.dl.sourceforge.net/project/giflib/giflib-5.1.4.tar.gz",
+            "https://storage.googleapis.com/mirror.tensorflow.org/ufpr.dl.sourceforge.net/project/giflib/giflib-5.2.1.tar.gz",
+            "http://pilotfiber.dl.sourceforge.net/project/giflib/giflib-5.2.1.tar.gz",
         ],
     )
 

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -291,7 +291,7 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
         strip_prefix = "giflib-5.2.1",
         system_build_file = clean_dep("//third_party/systemlibs:gif.BUILD"),
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/ufpr.dl.sourceforge.net/project/giflib/giflib-5.2.1.tar.gz",
+            "https://storage.googleapis.com/mirror.tensorflow.org/pilotfiber.dl.sourceforge.net/project/giflib/giflib-5.2.1.tar.gz",
             "http://pilotfiber.dl.sourceforge.net/project/giflib/giflib-5.2.1.tar.gz",
         ],
     )

--- a/third_party/gif.BUILD
+++ b/third_party/gif.BUILD
@@ -8,18 +8,18 @@ exports_files(["COPYING"])
 cc_library(
     name = "gif",
     srcs = [
-        "lib/dgif_lib.c",
-        "lib/egif_lib.c",
-        "lib/gif_err.c",
-        "lib/gif_font.c",
-        "lib/gif_hash.c",
-        "lib/gif_hash.h",
-        "lib/gif_lib_private.h",
-        "lib/gifalloc.c",
-        "lib/openbsd-reallocarray.c",
-        "lib/quantize.c",
+        "dgif_lib.c",
+        "egif_lib.c",
+        "gif_err.c",
+        "gif_font.c",
+        "gif_hash.c",
+        "gif_hash.h",
+        "gif_lib_private.h",
+        "gifalloc.c",
+        "openbsd-reallocarray.c",
+        "quantize.c",
     ],
-    hdrs = ["lib/gif_lib.h"],
+    hdrs = ["gif_lib.h"],
     defines = select({
         ":android": [
             "S_IREAD=S_IRUSR",
@@ -28,7 +28,7 @@ cc_library(
         ],
         "//conditions:default": [],
     }),
-    includes = ["lib/."],
+    includes = ["."],
     visibility = ["//visibility:public"],
     deps = select({
         ":windows": [":windows_polyfill"],


### PR DESCRIPTION
# [CVE-2019-15133](https://nvd.nist.gov/vuln/detail/CVE-2019-15133)

**NVD**: 2019/08/17 - CVSS v2.0 Base Score: 4.3 - CVSS v3.0 Base Score: 6.5
In GIFLIB before 2019-02-16, a malformed GIF file triggers a divide-by-zero exception in the decoder function DGifSlurp in dgif_lib.c if the height field of the ImageSize data structure is equal to zero.

## **References to Advisories, Solutions, and Tools**

Source | Link | Type
---- | ---- | ----
MISC | [bugs.chromium.org](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=13008) | Mailing List, Third Party Advisory
UBUNTU | [usn.ubuntu.com](https://usn.ubuntu.com/4107-1/) | Third Party Advisory

