### PR TITLE
Convert invalid names to strings to prevent formatting errors

### DIFF
--- a/tensorflow/lite/python/util.py
+++ b/tensorflow/lite/python/util.py
@@ -112,7 +112,7 @@ def get_tensors_from_tensor_names(graph, tensor_names):
   for name in tensor_names:
     tensor = tensor_name_to_tensor.get(name)
     if tensor is None:
-      invalid_tensors.append(name)
+      invalid_tensors.append(str(name))
     else:
       tensors.append(tensor)
 


### PR DESCRIPTION
In case user specify incorrect objection for TFLite converter, the code rasise ValueError. Unfortunately, during calculation of error message another error may appear due to invalid string formatting attempt. This PR prevents this situation by forcing string conversion for error messages.

Below is the example of such an error condition.

```
/usr/local/lib/python3.6/dist-packages/tensorflow/lite/python/util.py in get_tensors_from_tensor_names(graph, tensor_names)
      114   if invalid_tensors:
      115     raise ValueError("Invalid tensors '{}' were found.".format(
  --> 116         ",".join(invalid_tensors)))
      117   return tensors
      118

  TypeError: sequence item 0: expected str instance, Tensor found
  ```
