### PR TITLE
[2.0.0-rc0 CherryPick]: Only add ModuleWrapper when lazy loading is requested or when using TF 1.x (to print deprecation warnings).

### DIFF
--- a/tensorflow/api_template.__init__.py
+++ b/tensorflow/api_template.__init__.py
@@ -125,25 +125,6 @@ if _running_from_pip_package():
     if _fi.file_exists(plugin_dir):
       _ll.load_library(plugin_dir)
 
-# These symbols appear because we import the python package which
-# in turn imports from tensorflow.core and tensorflow.python. They
-# must come from this module. So python adds these symbols for the
-# resolution to succeed.
-# pylint: disable=undefined-variable
-try:
-  del python
-except NameError:
-  pass
-try:
-  del core
-except NameError:
-  pass
-try:
-  del compiler
-except NameError:
-  pass
-# pylint: enable=undefined-variable
-
 # Add module aliases
 if hasattr(_current_module, 'keras'):
   losses = keras.losses

--- a/tensorflow/python/tools/api/generator/create_python_api.py
+++ b/tensorflow/python/tools/api/generator/create_python_api.py
@@ -243,22 +243,25 @@ __all__ = [_s for _s in dir() if not _s.startswith('_')]
 __all__.extend([_s for _s in _names_with_underscore])
 ''' % underscore_names_str
 
-    for dest_module, _ in self._module_imports.items():
-      deprecation = 'False'
-      has_lite = 'False'
-      if self._api_version == 1:  # Add 1.* deprecations.
-        if not dest_module.startswith(_COMPAT_MODULE_PREFIX):
-          deprecation = 'True'
-      # Workaround to make sure not load lite from lite/__init__.py
-      if (not dest_module and 'lite' in self._module_imports
-          and self._lazy_loading):
-        has_lite = 'True'
-      if self._lazy_loading:
-        public_apis_name = '_PUBLIC_APIS'
-      else:
-        public_apis_name = 'None'
-      footer_text_map[dest_module] = _DEPRECATION_FOOTER % (
-          dest_module, public_apis_name, deprecation, has_lite)
+    # Add module wrapper if we need to print deprecation messages
+    # or if we use lazy loading.
+    if self._api_version == 1 or self._lazy_loading:
+      for dest_module, _ in self._module_imports.items():
+        deprecation = 'False'
+        has_lite = 'False'
+        if self._api_version == 1:  # Add 1.* deprecations.
+          if not dest_module.startswith(_COMPAT_MODULE_PREFIX):
+            deprecation = 'True'
+        # Workaround to make sure not load lite from lite/__init__.py
+        if (not dest_module and 'lite' in self._module_imports
+            and self._lazy_loading):
+          has_lite = 'True'
+        if self._lazy_loading:
+          public_apis_name = '_PUBLIC_APIS'
+        else:
+          public_apis_name = 'None'
+        footer_text_map[dest_module] = _DEPRECATION_FOOTER % (
+            dest_module, public_apis_name, deprecation, has_lite)
 
     return module_text_map, footer_text_map
 

--- a/tensorflow/tools/api/tests/api_compatibility_test.py
+++ b/tensorflow/tools/api/tests/api_compatibility_test.py
@@ -314,7 +314,7 @@ class ApiCompatibilityTest(test.TestCase):
     visitor = python_object_to_proto_visitor.PythonObjectToProtoVisitor()
 
     public_api_visitor = public_api.PublicAPIVisitor(visitor)
-    public_api_visitor.private_map['tf'] = ['contrib']
+    public_api_visitor.private_map['tf'].append('contrib')
     if api_version == 2:
       public_api_visitor.private_map['tf'].append('enable_v2_behavior')
 

--- a/tensorflow/tools/common/public_api.py
+++ b/tensorflow/tools/common/public_api.py
@@ -40,6 +40,11 @@ class PublicAPIVisitor(object):
 
     # Modules/classes we want to suppress entirely.
     self._private_map = {
+        'tf': [
+            'compiler',
+            'core',
+            'python',
+        ],
         # Some implementations have this internal module that we shouldn't
         # expose.
         'tf.flags': ['cpp_flags'],

--- a/tensorflow/virtual_root_template_v2.__init__.py
+++ b/tensorflow/virtual_root_template_v2.__init__.py
@@ -97,4 +97,39 @@ for _m in _top_level_modules:
 # We still need all the names that are toplevel on tensorflow_core
 from tensorflow_core import *
 
+# These should not be visible in the main tf module.
+try:
+  del core
+except NameError:
+  pass
+
+try:
+  del python
+except NameError:
+  pass
+
+try:
+  del compiler
+except NameError:
+  pass
+
+try:
+  del tools
+except NameError:
+  pass
+
+try:
+  del examples
+except NameError:
+  pass
+
+# Manually patch keras and estimator so tf.keras and tf.estimator work
+keras = _sys.modules["tensorflow.keras"]
+if not _root_estimator: estimator = _sys.modules["tensorflow.estimator"]
+# Also import module aliases
+try:
+  from tensorflow_core import losses, metrics, initializers, optimizers
+except ImportError:
+  pass
+
 # LINT.ThenChange(//tensorflow/virtual_root_template_v1.__init__.py.oss)


### PR DESCRIPTION
That is, don't use TFModuleWrapper in r2.0 builds. We don't need to print deprecation warnings since deprecated 1.x symbols are already removed and we don't use lazy loading by default.