### PR TITLE
Increase the clarity of reshuffle_each_iteration documentation

### DIFF
--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -846,9 +846,9 @@ class DatasetV2(tracking_base.Trackable, composite_tensor.CompositeTensor):
       seed: (Optional.) A `tf.int64` scalar `tf.Tensor`, representing the random
         seed that will be used to create the distribution. See
         `tf.compat.v1.set_random_seed` for behavior.
-      reshuffle_each_iteration: (Optional.) A boolean, which if true indicates
-        that the dataset should be pseudorandomly reshuffled each time it is
-        iterated over. (Defaults to `True`.)
+      reshuffle_each_iteration: (Optional.) A boolean, which if true or null
+        indicates that the dataset should be pseudorandomly reshuffled each time
+        it is iterated over. (Defaults to `None`.)
 
     Returns:
       Dataset: A `Dataset`.
@@ -2922,9 +2922,9 @@ class ShuffleDataset(UnaryUnchangedStructureDataset):
       seed: (Optional.) A `tf.int64` scalar `tf.Tensor`, representing the random
         seed that will be used to create the distribution. See
         `tf.compat.v1.set_random_seed` for behavior.
-      reshuffle_each_iteration: (Optional.) A boolean, which if true indicates
-        that the dataset should be pseudorandomly reshuffled each time it is
-        iterated over. (Defaults to `True`.)
+      reshuffle_each_iteration: (Optional.) A boolean, which if true or null
+        indicates that the dataset should be pseudorandomly reshuffled each time
+        it is iterated over. (Defaults to `None`.)
 
     Returns:
       A `Dataset`.


### PR DESCRIPTION
When `reshuffle_each_iteration` is `None`, private instance variable `_reshuffle_each_iteration` gets set to `True`, which is I think what the original docstring is alluding to.

The original docstring says that the value defaults to `True` which is slightly confusing as the default is a `None`.  I've made changes to the docstrings to attempt to increase its clarity.