### PR TITLE
[INTEL MKL] Fix to non-native gcc build.

### DIFF
--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -1584,6 +1584,7 @@ def _py_wrap_cc_impl(ctx):
     args += [src.path]
     outputs = [ctx.outputs.cc_out, ctx.outputs.py_out]
     ctx.actions.run(
+        use_default_shell_env = True,
         executable = ctx.executable._swig,
         arguments = args,
         inputs = inputs.to_list(),


### PR DESCRIPTION
This PR fixes following build error when building with non-native gcc version.
```ERROR: /ec/pdx/disks/aipg_lab_home_pool_01/mabuzain/code/private-tensorflow/tensorflow/compiler/tf2tensorrt/BUILD:506:1: SWIGing tensorflow/compiler/tf2tensorrt/utils/py_utils.i failed (Exit 1)
bazel-out/host/bin/external/swig/swig: /lib64/libstdc++.so.6: version `CXXABI_1.3.9' not found (required by bazel-out/host/bin/external/swig/swig)
Target //tensorflow/tools/pip_package:build_pip_package failed to build```