### PR TITLE
Check types of name parameters

### DIFF
--- a/tensorflow/lite/python/util.py
+++ b/tensorflow/lite/python/util.py
@@ -110,6 +110,12 @@ def get_tensors_from_tensor_names(graph, tensor_names):
   tensors = []
   invalid_tensors = []
   for name in tensor_names:
+    if not isinstance(name, str):
+      raise ValueError("Invalid type for a tensor name in the provided graph. "
+                       "Expected type for a tensor name is 'str', instead got "
+                       "type '{}' for tensor name '{}'".format(
+                           type(name), name))
+
     tensor = tensor_name_to_tensor.get(name)
     if tensor is None:
       invalid_tensors.append(name)


### PR DESCRIPTION
In case user pass non-string as a tensor name, the code raises ValueError. One common mistake is to specify tensor object instad of its name. Unfortunately, in this case current implementation fails to produce an error message resulting in misleading errors like shown below. This PR introduce explicit type-checks of input parameters.

```
/usr/local/lib/python3.6/dist-packages/tensorflow/lite/python/util.py in get_tensors_from_tensor_names(graph, tensor_names)
      114   if invalid_tensors:
      115     raise ValueError("Invalid tensors '{}' were found.".format(
  --> 116         ",".join(invalid_tensors)))
      117   return tensors
      118

  TypeError: sequence item 0: expected str instance, Tensor found
```


