### PR TITLE
Document ParallelInterleaveDatasetV2 op

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_ParallelInterleaveDatasetV2.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ParallelInterleaveDatasetV2.pbtxt
@@ -71,8 +71,10 @@ The `tf.data` Python API creates instances of this op from
 `Dataset.interleave()` when the `num_parallel_calls` parameter of that method
 is set to any value other than `None`.
 
-If the `experimental_deterministic` parameter of `tf.data.Options` is set to
-`True`, then the output of this op will be deterministic. Otherwise the output
-may be nondeterministic.
+By default, the output of this dataset will be deterministic, which may result
+in the dataset blocking if the next data item to be returned isn't available.
+In order to avoid head-of-line blocking, one can set the 
+`experimental_deterministic` parameter of `tf.data.Options` to `False`,
+which can improve performance at the expense of non-determinism.
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_ParallelInterleaveDatasetV2.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ParallelInterleaveDatasetV2.pbtxt
@@ -1,6 +1,47 @@
 op {
   graph_op_name: "ParallelInterleaveDatasetV2"
   visibility: HIDDEN
+  in_arg {
+    name: "input_dataset"
+    description: <<END
+Dataset that produces a stream of arguments for the function `f`.
+END
+  }
+  in_arg {
+    name: "other_arguments"
+    description: <<END
+Additional arguments to pass to `f` beyond those produced by `input_dataset`.
+Evaluated once when the dataset is instantiated.
+END
+  }
+  in_arg {
+    name: "cycle_length"
+    description: <<END
+Number of datasets (each created by applying `f` to the elements of
+`input_dataset`) among which the `ParallelInterleaveDatasetV2` will cycle in a
+round-robin fashion.
+END
+  }
+  in_arg {
+    name: "block_length"
+    description: <<END
+Number of elements at a time to produce from each interleaved invocation of a
+dataset returned by `f`.
+END
+  }
+  in_arg {
+    name: "num_parallel_calls"
+    description: <<END
+If this input is >=1, it bounds the number of datasets from which this instance
+of `ParallelInterleaveDatasetV2` will fetch simultaneously.
+The actual number of parallel calls will depend on the `cycle_length`
+parameter, the number of available CPUs, and the number of available datasets.
+
+If this input is set to -1 (i.e. the constant `tf.data.experimental.AUTOTUNE`
+in the Python API), then the dataset's kernel will choose an upper bound
+automatically.
+END
+  }
   attr {
     name: "f"
     description: <<END
@@ -9,5 +50,44 @@ A function mapping elements of `input_dataset`, concatenated with
 `output_types` and `output_shapes`.
 END
   }
+  attr {
+    name: "Targuments"
+    description: <<END
+Types of the elements of `other_arguments`.
+END
+  }
+  attr {
+    name: "output_types"
+  }
+  attr {
+    name: "output_shapes"
+  }
+  attr {
+    name: "sloppy"
+    description: <<END
+If `True`, return elements as they become available, even if that means returning
+these elements in a non-deterministic order. Sloppy operation may result in better
+performance in the presence of stragglers, but the dataset will still block if
+all of its open streams are blocked.
+If `False`, always return elements in a deterministic order.
+END
+  }
   summary: "Creates a dataset that applies `f` to the outputs of `input_dataset`."
+  description: <<END
+The resulting dataset is similar to the `InterleaveDataset`, except that the
+dataset will fetch records from the interleaved datasets in parallel.
+
+The `tf.data` Python API creates instances of this op from
+`Dataset.interleave()` when the `num_parallel_calls` parameter of that method
+is set to any value other than `None`.
+
+!! WARNING !! If the `sloppy` parameter is set to `True`, the operation of this
+dataset will not be deterministic!
+
+The `sloppy` parameter of this op always starts out set to `False` when the
+Python API creates instances of this op. If the `make_sloppy` static
+optimization pass runs, that optimization will set the `sloppy` parameter to
+`True`. Whether this optimization is performed is determined by the
+`experimental_deterministic` parameter of `tf.data.Options`.
+END
 }

--- a/tensorflow/core/api_def/base_api/api_def_ParallelInterleaveDatasetV2.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ParallelInterleaveDatasetV2.pbtxt
@@ -62,16 +62,6 @@ END
   attr {
     name: "output_shapes"
   }
-  attr {
-    name: "sloppy"
-    description: <<END
-If `True`, return elements as they become available, even if that means returning
-these elements in a non-deterministic order. Sloppy operation may result in better
-performance in the presence of stragglers, but the dataset will still block if
-all of its open streams are blocked.
-If `False`, always return elements in a deterministic order.
-END
-  }
   summary: "Creates a dataset that applies `f` to the outputs of `input_dataset`."
   description: <<END
 The resulting dataset is similar to the `InterleaveDataset`, except that the
@@ -81,13 +71,8 @@ The `tf.data` Python API creates instances of this op from
 `Dataset.interleave()` when the `num_parallel_calls` parameter of that method
 is set to any value other than `None`.
 
-!! WARNING !! If the `sloppy` parameter is set to `True`, the operation of this
-dataset will not be deterministic!
-
-The `sloppy` parameter of this op always starts out set to `False` when the
-Python API creates instances of this op. If the `make_sloppy` static
-optimization pass runs, that optimization will set the `sloppy` parameter to
-`True`. Whether this optimization is performed is determined by the
-`experimental_deterministic` parameter of `tf.data.Options`.
+If the `experimental_deterministic` parameter of `tf.data.Options` is set to
+`True`, then the output of this op will be deterministic. Otherwise the output
+may be nondeterministic.
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_ParallelInterleaveDatasetV2.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ParallelInterleaveDatasetV2.pbtxt
@@ -32,14 +32,9 @@ END
   in_arg {
     name: "num_parallel_calls"
     description: <<END
-If this input is >=1, it bounds the number of datasets from which this instance
-of `ParallelInterleaveDatasetV2` will fetch simultaneously.
-The actual number of parallel calls will depend on the `cycle_length`
-parameter, the number of available CPUs, and the number of available datasets.
-
-If this input is set to -1 (i.e. the constant `tf.data.experimental.AUTOTUNE`
-in the Python API), then the dataset's kernel will choose an upper bound
-automatically.
+Determines the number of threads that should be used for fetching data from
+input datasets in parallel. The Python API `tf.data.experimental.AUTOTUNE` 
+constant can be used to indicate that the level of parallelism should be autotuned.
 END
   }
   attr {


### PR DESCRIPTION
This PR adds documentation to the API spec for the `ParallelInterleaveDatasetV2` op in `tf.data`.

I documented all the inputs and attributes in the `REGISTER_OP()` call for the op. I documented how the `num_parallel_calls` attribute affects the degree of parallelism at runtime. I also documented how the Python API creates instances of this op and how the `sloppy` attribute is set in a graph rewrite durning static optimization.