### PR TITLE
[r2.0-rc1 CherryPick]: Several tf.keras mixed precision API changes

### DIFF
--- a/tensorflow/python/keras/engine/base_layer.py
+++ b/tensorflow/python/keras/engine/base_layer.py
@@ -2591,6 +2591,9 @@ class AddLoss(Layer):
   """
 
   def __init__(self, unconditional, **kwargs):
+    # Pass autocast=False, as there is no reason to cast loss to a different
+    # dtype.
+    kwargs['autocast'] = False
     super(AddLoss, self).__init__(**kwargs)
     self.unconditional = unconditional
 

--- a/tensorflow/python/keras/engine/network.py
+++ b/tensorflow/python/keras/engine/network.py
@@ -230,12 +230,10 @@ class Network(base_layer.Layer):
     else:
       self._graph = ops.get_default_graph()  # Used in symbolic mode only.
 
-    # Both graph and subclassed networks have a dtype policy. The policy is
-    # currently ignored for a graph network, as graph networks disable
-    # autocasting (making the policy's compute dtype meaningless) and graph
-    # networks have no variables (making the policy's variable_dtype
-    # meaningless). For subclassed networks, the dtype policy acts as it does
-    # for any ordinary layer.
+    # Both graph and subclassed networks have a dtype policy. For graph
+    # networks, the policy's compute and variable dtypes are ignored, but other
+    # fields, like the loss scale, are used by Models. For subclassed networks,
+    # the compute and variable dtypes are used as like any ordinary layer.
     self._set_dtype_policy(kwargs.get('dtype', None))
 
     # All layers in order of horizontal graph traversal.

--- a/tensorflow/python/keras/mixed_precision/experimental/keras_test.py
+++ b/tensorflow/python/keras/mixed_precision/experimental/keras_test.py
@@ -764,6 +764,17 @@ class KerasModelTest(keras_parameterized.TestCase):
                                    'optimizer" must be an instance of '):
         model.compile(optimizers.SGD(1.), 'mse')
 
+  @test_util.run_in_graph_and_eager_modes
+  @testing_utils.enable_v2_dtype_behavior
+  def test_functional_model_loss_dtype(self):
+    with policy.policy_scope('float16'):
+      x = layers.Input(shape=(1,))
+      y = AddLayer()(x)
+      model = models.Model(x, y)
+      model.add_loss(math_ops.cast(y, 'float32'))
+      # The loss should not be casted to the policy's dtype.
+      self.assertEqual(model.losses[0].dtype, 'float32')
+
   @parameterized.named_parameters(
       {
           'testcase_name': 'base',

--- a/tensorflow/python/keras/mixed_precision/experimental/policy.py
+++ b/tensorflow/python/keras/mixed_precision/experimental/policy.py
@@ -55,28 +55,21 @@ class Policy(object):
   computation dtype to avoid type errors.
 
   Policies also have a `tf.train.experimental.LossScale` instance, which is used
-  by Models to performance loss scaling. Layers which are not Models ignore
-  the loss scale.
+  by `tf.keras.Model`s to performance loss scaling. Loss scaling is only done by
+  Models in `Model.fit` and `Model.train_on_batch`. Layers which are not Models
+  ignore the loss scale.
 
   Policies are constructed by passing a string to the constructor, e.g.
   `tf.keras.mixed_precision.experimental.Policy('float32')`. The string
-  determines the compute and variable dtypes. Currently, it can be one of
-  in one of the following forms:
+  determines the compute and variable dtypes. It can be one of the following:
 
     * Any dtype name, such as 'float32' or 'float64'. Both the variable and
-      compute dtypes will be that dtype.
-    * '<dtype>_with_float32_vars', where <dtype> is any dtype. The compute dtype
-      will be <dtype>, while the variable dtype is float32. This can be used for
-      mixed precision, which uses float16 or bfloat16 for most computations, and
-      float32 for variables, but it is recommended to use the 'mixed_float16' or
-      'mixed_bfloat16' policies instead.
-    * 'mixed_float16' or 'mixed_bfloat16': Similar to
-      'float16_with_float32_vars' or 'bfloat16_with_float32_vars' respectively.
-      'mixed_float16' is identical to 'float16_with_float32_vars' except the
-      loss_scale is dynamic by default. 'mixed_bfloat16' is currently identical
-      to 'bfloat16_with_float32_vars'. More changes may be added to these mixed
-      policies in the future, to further differentiate them from
-      [b]float16_with_float32_vars.
+      compute dtypes will be that dtype. No loss scaling is done by default.
+    * 'mixed_float16' or 'mixed_bfloat16': The compute dtype is float16 or
+      bfloat16, while the variable dtype is float32. These policies are used for
+      mixed precision training. With 'mixed_float16', a dynamic loss scale is
+      used by default. 'mixed_bfloat16' does no loss scaling by default, as loss
+      scaling is unnecessary with bfloat16.
 
   ### How to use mixed precision in layers with Policies
 
@@ -118,6 +111,14 @@ class Policy(object):
   constructors in the `dtype` argument instead of policies, but only if the
   string is convertible to a dtype.
 
+  Note the 'mixed_float16' policy will apply loss scaling by default in
+  `Model.fit` and `Model.train_on_batch`. If neither method is used (e.g., a
+  custom training loop is used) and 'mixed_float16' is used, the loss scale must
+  be manually applied. See
+  `tf.keras.mixed_precision.experimental.LossScaleOptimizer` for details. For
+  'mixed_bfloat16', no loss scaling is done and loss scaling never needs to be
+  manually applied.
+
   ### The deprecated "infer" policy
 
   In addition to a dtype or "<dtype>_with_float32_vars", a policy can also be
@@ -129,13 +130,25 @@ class Policy(object):
   the dtype of the first input.
 
   Similarly to "infer", there is a deprecated "infer_with_float32_vars" policy
-  that infers the compute dtype, but not the variable dtype.
+  that infers the compute dtype, but not the variable dtype. Once a layer with
+  an "infer_with_float32_vars" policy is called for the first time, the layer's
+  policy will change to "<dtype>_with_float32_vars", where <dtype> is the dtype
+  of the first input. These policies force variables in float32.
+
+  Warning: Policies ending in "_with_float32_vars" will be removed in TensorFlow
+  2.1. Please use "mixed_float16" or "mixed_bfloat16" instead.
 
   In TensorFlow 1, only the "infer" and "infer_with_float32_vars" policies are
   available.
   """
   # TODO(reedwm): Replace link in above docstring with a version that is more
   # TensorFlow-specific, and that also mentions bfloat16.
+
+  # If True, warn when a policy is created whose name ends in
+  # "_with_float32_vars". We always want to warn when a user creates such a
+  # policy, but when the TensorFlow creates a policy, it suppresses the warning
+  # by setting this to False when creating the policy.
+  _warn_about_float32_vars = True
 
   def __init__(self, name, loss_scale=USE_DEFAULT):
     """Constructs the policy.
@@ -148,21 +161,12 @@ class Policy(object):
       name: A string. Can be one of the following values:
         * Any dtype name, such as 'float32' or 'float64'. Both the variable and
           compute dtypes will be that dtype.
-        * '<dtype>_with_float32_vars', where <dtype> is any dtype. The compute
-          dtype will be <dtype>, while the variable dtype is float32. This can
-          be used for mixed precision, which uses float16 or bfloat16 for most
-          computations, and float32 for variables, but it is recommended to use
-          the 'mixed_float16' or 'mixed_bfloat16' policies instead.
-        * 'mixed_float16' or 'mixed_bfloat16': Similar to
-          'float16_with_float32_vars' or 'bfloat16_with_float32_vars'
-          respectively. 'mixed_float16' is identical to
-          'float16_with_float32_vars' except the loss_scale is dynamic by
-          default. 'mixed_bfloat16' is currently identical to
-          'bfloat16_with_float32_vars'. More changes may be added to these mixed
-          policies in the future, to further differentiate them from
-          [b]float16_with_float32_vars.
-        * 'infer' or 'infer_with_float32_vars' (deprecated): Infer the
-          computation dtype from the input dtype.
+        * 'mixed_float16' or 'mixed_bfloat16': The compute dtype is float16 or
+          bfloat16, while the variable dtype is float32. With 'mixed_float16',
+          a dynamic loss scale is used. These policies are used for mixed
+          precision training.
+        * 'infer' (deprecated): Infer the compute and variable dtype from the
+          input dtype.
       loss_scale: A `tf.train.experimental.LossScale`, or a value convertible to
         one such as "dynamic". Defaults to using no loss scaling unless `name`
         is "mixed_float16", in which case this defaults to "dynamic". Only
@@ -184,6 +188,18 @@ class Policy(object):
       name = 'float32'
     self._name = name
     self._compute_dtype, self._variable_dtype = self._parse_name(name)
+
+    if name.endswith('_with_float32_vars') and self._warn_about_float32_vars:
+      warning = ("WARNING: The '%s' policy is deprecated and will be removed "
+                 "in TensorFlow 2.1." % name)
+      if name == 'infer_with_float32_vars':
+        warning += (" Please use the 'mixed_float16' or 'mixed_bfloat16' "
+                    "policy instead.")
+      elif name == 'float16_with_float32_vars':
+        warning += " Please use the 'mixed_float16' policy instead."
+      elif name == 'bfloat16_with_float32_vars':
+        warning += " Please use the 'mixed_bfloat16' policy instead."
+      tf_logging.warn(warning)
 
     if loss_scale == USE_DEFAULT:
       loss_scale = 'dynamic' if name == 'mixed_float16' else None
@@ -221,10 +237,10 @@ class Policy(object):
       try:
         base_dtype = dtypes.as_dtype(base_name).name
       except TypeError:
-        error = ('Cannot convert value %s to a mixed precision Policy. '
-                 'Valid policies include include those in the form "<dtype>" '
-                 'and "<dtype>_with_float32_vars", where <dtype> is the name '
-                 'of a dtype.' % (name,))
+        error = ("Cannot convert value %s to a mixed precision Policy. "
+                 "Valid policies include include 'mixed_float16', "
+                 "'mixed_bfloat16', and the name of any dtype such as "
+                 "'float32'." % (name,))
         if float32_vars:
           error += (' The value %s ends with _with_float32_vars, but %s cannot '
                     'be converted to a DType' % (name, base_name))
@@ -337,7 +353,11 @@ def with_input_dtype(policy, dtype):
     # Policies without a compute dtype are either "infer" or
     # "infer_with_float32_vars", so the variable_dtype must be float32 here.
     assert policy.variable_dtype == 'float32'
-    return Policy(dtype + '_with_float32_vars')
+    try:
+      Policy._warn_about_float32_vars = False  # pylint: disable=protected-access
+      return Policy(dtype + '_with_float32_vars')
+    finally:
+      Policy._warn_about_float32_vars = True  # pylint: disable=protected-access
 
 
 # The current global policy in effect. If None, it means the current value of

--- a/tensorflow/python/keras/mixed_precision/experimental/policy.py
+++ b/tensorflow/python/keras/mixed_precision/experimental/policy.py
@@ -24,6 +24,7 @@ import six
 from tensorflow.python.framework import dtypes
 from tensorflow.python.keras import backend
 from tensorflow.python.keras.engine import base_layer_utils
+from tensorflow.python.platform import tf_logging
 from tensorflow.python.training.experimental import loss_scale as loss_scale_module
 from tensorflow.python.training.experimental import mixed_precision_global_state
 from tensorflow.python.util.tf_export import keras_export
@@ -65,28 +66,30 @@ class Policy(object):
     * Any dtype name, such as 'float32' or 'float64'. Both the variable and
       compute dtypes will be that dtype.
     * '<dtype>_with_float32_vars', where <dtype> is any dtype. The compute dtype
-      will be <dtype>, while the variable dtype is float32. This is intended for
-      the use of mixed precision, which uses float16 or bfloat16 for most
-      computations, and float32 for variables. This policy is only useful if
-      <dtype> is float16 or bfloat16, although <dtype> is allowed to be any
-      dtype. Note we will have a "mixed" policy in the future, which will make
-      it even easier to use mixed  precision by enabling other features, such as
-      using loss scaling by default.
+      will be <dtype>, while the variable dtype is float32. This can be used for
+      mixed precision, which uses float16 or bfloat16 for most computations, and
+      float32 for variables, but it is recommended to use the 'mixed_float16' or
+      'mixed_bfloat16' policies instead.
+    * 'mixed_float16' or 'mixed_bfloat16': Similar to
+      'float16_with_float32_vars' or 'bfloat16_with_float32_vars' respectively.
+      'mixed_float16' is identical to 'float16_with_float32_vars' except the
+      loss_scale is dynamic by default. 'mixed_bfloat16' is currently identical
+      to 'bfloat16_with_float32_vars'. More changes may be added to these mixed
+      policies in the future, to further differentiate them from
+      [b]float16_with_float32_vars.
 
   ### How to use mixed precision in layers with Policies
 
-  To use mixed precision in a model, the 'float16_with_float32_vars' policy can
+  To use mixed precision in a model, the 'mixed_float16' policy can
   be used. `tf.keras.mixed_precision.experimental.set_policy` can be used to set
-  the default policy for layers if no policy is passed to them. The loss scale
-  should be set to "dynamic" to perform loss scaling and dynamically determine
-  the optimal loss scale. For example:
+  the default policy for layers if no policy is passed to them. For example:
 
   ```python
-  tf.keras.mixed_precision.experimental.set_policy(
-      'float16_with_float32_vars', loss_scale='dynamic')
+  tf.keras.mixed_precision.experimental.set_policy('mixed_float16')
   model = tf.keras.models.Sequential(
       tf.keras.layers.Input((100,)),
-      # Dense layers use global policy of 'float16_with_float32_vars'
+      # Dense layers use global policy of 'mixed_float16', which does
+      # computations in float16 while keeping variables in float32.
       tf.keras.layers.Dense(10),
       tf.keras.layers.Dense(10),
       # Softmax should be done in float32 for numeric stability. We pass
@@ -100,8 +103,7 @@ class Policy(object):
   setting the global policy with `set_policy`:
 
   ```python
-  policy = tf.keras.mixed_precision.experimental.Policy(
-      'float16_with_float32_vars', loss_scale='dynamic')
+  policy = tf.keras.mixed_precision.experimental.Policy('mixed_float16')
   model = tf.keras.models.Sequential(
       tf.keras.layers.Input((100,)),
       tf.keras.layers.Dense(10, dtype=policy),
@@ -146,18 +148,24 @@ class Policy(object):
       name: A string. Can be one of the following values:
         * Any dtype name, such as 'float32' or 'float64'. Both the variable and
           compute dtypes will be that dtype.
-        * <dtype>_with_float32_vars, where <dtype> is any dtype. The compute
-          dtype will be <dtype>, while the variable dtype is float32. This is
-          intended for the use of mixed precision, which uses float16 or
-          bfloat16 for most computations, and float32 for variables. This policy
-          is only useful if <dtype> is float16 or bfloat16, although <dtype> is
-          allowed to be any dtype. Note we will have a "mixed" policy in the
-          future, which will make it even easier to use mixed  precision by
-          enabling other features such as loss scaling.
+        * '<dtype>_with_float32_vars', where <dtype> is any dtype. The compute
+          dtype will be <dtype>, while the variable dtype is float32. This can
+          be used for mixed precision, which uses float16 or bfloat16 for most
+          computations, and float32 for variables, but it is recommended to use
+          the 'mixed_float16' or 'mixed_bfloat16' policies instead.
+        * 'mixed_float16' or 'mixed_bfloat16': Similar to
+          'float16_with_float32_vars' or 'bfloat16_with_float32_vars'
+          respectively. 'mixed_float16' is identical to
+          'float16_with_float32_vars' except the loss_scale is dynamic by
+          default. 'mixed_bfloat16' is currently identical to
+          'bfloat16_with_float32_vars'. More changes may be added to these mixed
+          policies in the future, to further differentiate them from
+          [b]float16_with_float32_vars.
         * 'infer' or 'infer_with_float32_vars' (deprecated): Infer the
           computation dtype from the input dtype.
       loss_scale: A `tf.train.experimental.LossScale`, or a value convertible to
-        one such as "dynamic". Defaults to using no loss scaling. Only
+        one such as "dynamic". Defaults to using no loss scaling unless `name`
+        is "mixed_float16", in which case this defaults to "dynamic". Only
         `tf.keras.Model`s, not layers, use the loss scale, and it is only used
         during `Model.fit` or `Model.train_on_batch`.
 
@@ -178,8 +186,12 @@ class Policy(object):
     self._compute_dtype, self._variable_dtype = self._parse_name(name)
 
     if loss_scale == USE_DEFAULT:
-      loss_scale = None
-
+      loss_scale = 'dynamic' if name == 'mixed_float16' else None
+    if loss_scale and self._compute_dtype not in (None, 'float16'):
+      tf_logging.warn('Creating a Policy with a loss scale is only useful for '
+                      'float16 policies. You passed loss_scale=%r for policy '
+                      '%s. Consider not passing any loss_scale instead.' %
+                      (loss_scale, name))
     self._loss_scale = loss_scale_module.get(loss_scale)
 
   def _parse_name(self, name):
@@ -191,6 +203,11 @@ class Policy(object):
     Returns:
       The (compute_dtype, variable_dtype) pair.
     """
+    if name == 'mixed_float16':
+      return 'float16', 'float32'
+    elif name == 'mixed_bfloat16':
+      return 'bfloat16', 'float32'
+
     if name.endswith('_with_float32_vars'):
       base_name = name[:-len('_with_float32_vars')]
       float32_vars = True

--- a/tensorflow/python/keras/mixed_precision/experimental/policy_test.py
+++ b/tensorflow/python/keras/mixed_precision/experimental/policy_test.py
@@ -169,9 +169,47 @@ class PolicyTest(test.TestCase):
           'policies. You passed loss_scale=2.0 for policy float32. Consider '
           'not passing any loss_scale instead.')
 
-    for policy_name in 'float16', 'float16_with_float32_vars', 'mixed_float16':
+    for policy_name in 'float16', 'mixed_float16':
       with test.mock.patch.object(tf_logging, 'warn') as mock_warn:
         mp_policy.Policy(policy_name, loss_scale=2.)
+        mock_warn.assert_not_called()
+
+  @testing_utils.enable_v2_dtype_behavior
+  def test_float32_vars_warning(self):
+    with test.mock.patch.object(tf_logging, 'warn') as mock_warn:
+      mp_policy.Policy('infer_with_float32_vars')
+      self.assertEqual(
+          mock_warn.call_args[0][0],
+          "WARNING: The 'infer_with_float32_vars' policy is deprecated and "
+          "will be removed in TensorFlow 2.1. Please use the 'mixed_float16' "
+          "or 'mixed_bfloat16' policy instead.")
+
+    with test.mock.patch.object(tf_logging, 'warn') as mock_warn:
+      mp_policy.Policy('float16_with_float32_vars')
+      self.assertEqual(
+          mock_warn.call_args[0][0],
+          "WARNING: The 'float16_with_float32_vars' policy is deprecated and "
+          "will be removed in TensorFlow 2.1. Please use the 'mixed_float16' "
+          "policy instead.")
+
+    with test.mock.patch.object(tf_logging, 'warn') as mock_warn:
+      mp_policy.Policy('bfloat16_with_float32_vars')
+      self.assertEqual(
+          mock_warn.call_args[0][0],
+          "WARNING: The 'bfloat16_with_float32_vars' policy is deprecated and "
+          "will be removed in TensorFlow 2.1. Please use the 'mixed_bfloat16' "
+          "policy instead.")
+
+    with test.mock.patch.object(tf_logging, 'warn') as mock_warn:
+      mp_policy.Policy('float64_with_float32_vars')
+      self.assertEqual(
+          mock_warn.call_args[0][0],
+          "WARNING: The 'float64_with_float32_vars' policy is deprecated and "
+          "will be removed in TensorFlow 2.1.")
+
+    for policy_name in 'float16', 'float32', 'mixed_float16', 'mixed_bfloat16':
+      with test.mock.patch.object(tf_logging, 'warn') as mock_warn:
+        mp_policy.Policy(policy_name)
         mock_warn.assert_not_called()
 
   @testing_utils.enable_v2_dtype_behavior

--- a/tensorflow/python/training/experimental/loss_scale.py
+++ b/tensorflow/python/training/experimental/loss_scale.py
@@ -227,6 +227,9 @@ class FixedLossScale(LossScale):
     del grads
     return control_flow_ops.no_op(), True
 
+  def __repr__(self):
+    return 'FixedLossScale(%s)' % self._loss_scale_value
+
   def get_config(self):
     return {'loss_scale_value': self._loss_scale_value}
 
@@ -375,6 +378,17 @@ class DynamicLossScale(LossScale):
                                       update_if_not_finite_grads)
     should_apply_gradients = is_finite
     return update_op, should_apply_gradients
+
+  def __repr__(self):
+    if context.executing_eagerly():
+      return ('DynamicLossScale(current_loss_scale=%s, num_good_steps=%s, '
+              'initial_loss_scale=%s, increment_period=%s, multiplier=%s)' %
+              (self._current_loss_scale.numpy(), self._num_good_steps.numpy(),
+               self.initial_loss_scale, self.increment_period, self.multiplier))
+    else:
+      return ('DynamicLossScale(initial_loss_scale=%s, increment_period=%s, '
+              'multiplier=%s)' %
+              (self.initial_loss_scale, self.increment_period, self.multiplier))
 
   def get_config(self):
     return {

--- a/tensorflow/python/training/experimental/loss_scale_test.py
+++ b/tensorflow/python/training/experimental/loss_scale_test.py
@@ -92,6 +92,11 @@ class FixedLossScaleTest(test.TestCase):
     scalar = loss_scale_module.FixedLossScale(123)
     self.assertIsInstance(scalar(), ops.Tensor)
 
+  @test_util.run_in_graph_and_eager_modes
+  def test_repr(self):
+    loss_scale = loss_scale_module.FixedLossScale(123)
+    self.assertEqual(repr(loss_scale), 'FixedLossScale(123.0)')
+
 
 def _get_example_iter(inputs):
   dataset = dataset_ops.Dataset.from_tensor_slices(inputs)
@@ -301,6 +306,23 @@ class DynamicLossScaleTest(test.TestCase, parameterized.TestCase):
   def test_call_type(self):
     scalar = loss_scale_module.DynamicLossScale()
     self.assertIsInstance(scalar(), ops.Tensor)
+
+  @parameterized.named_parameters(*TESTCASES)
+  @test_util.run_in_graph_and_eager_modes
+  def test_repr(self, strategy_fn):
+    with strategy_fn().scope():
+      loss_scale = loss_scale_module.DynamicLossScale(
+          initial_loss_scale=1, increment_period=2, multiplier=3)
+      if context.executing_eagerly():
+        self.assertEqual(repr(loss_scale),
+                         'DynamicLossScale(current_loss_scale=1.0, '
+                         'num_good_steps=0, initial_loss_scale=1.0, '
+                         'increment_period=2, multiplier=3.0)')
+      else:
+        self.assertEqual(repr(loss_scale),
+                         'DynamicLossScale(initial_loss_scale=1.0, '
+                         'increment_period=2, multiplier=3.0)')
+
 
 if __name__ == '__main__':
   test.main()

--- a/tensorflow/tools/api/golden/v1/tensorflow.keras.mixed_precision.experimental.-policy.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.keras.mixed_precision.experimental.-policy.pbtxt
@@ -7,6 +7,10 @@ tf_class {
     mtype: "<type \'property\'>"
   }
   member {
+    name: "loss_scale"
+    mtype: "<type \'property\'>"
+  }
+  member {
     name: "name"
     mtype: "<type \'property\'>"
   }
@@ -20,6 +24,6 @@ tf_class {
   }
   member_method {
     name: "__init__"
-    argspec: "args=[\'self\', \'name\'], varargs=None, keywords=None, defaults=None"
+    argspec: "args=[\'self\', \'name\', \'loss_scale\'], varargs=None, keywords=None, defaults=[\'USE_DEFAULT\'], "
   }
 }

--- a/tensorflow/tools/api/golden/v2/tensorflow.keras.mixed_precision.experimental.-policy.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.keras.mixed_precision.experimental.-policy.pbtxt
@@ -7,6 +7,10 @@ tf_class {
     mtype: "<type \'property\'>"
   }
   member {
+    name: "loss_scale"
+    mtype: "<type \'property\'>"
+  }
+  member {
     name: "name"
     mtype: "<type \'property\'>"
   }
@@ -20,6 +24,6 @@ tf_class {
   }
   member_method {
     name: "__init__"
-    argspec: "args=[\'self\', \'name\'], varargs=None, keywords=None, defaults=None"
+    argspec: "args=[\'self\', \'name\', \'loss_scale\'], varargs=None, keywords=None, defaults=[\'USE_DEFAULT\'], "
   }
 }


### PR DESCRIPTION
This cherrypick deprecates a feature that will be removed in 2.0, and adds the replacement feature in 2.1. In particular, it deprecates the "infer_with_float32_vars" policy and adds the "mixed_[b]float16" policies.