### PR TITLE
sort NcclManager::Collective participants using device ID

### DIFF
--- a/tensorflow/core/nccl/nccl_manager.cc
+++ b/tensorflow/core/nccl/nccl_manager.cc
@@ -250,14 +250,14 @@ string NcclManager::GenerateCommunicatorKey() {
 
 Status NcclManager::GetCommunicator(NcclManager::Collective* collective,
                                     NcclManager::Communicator** communicator) {
-  // Sort by executor to make ordering of executors deterministic.
+  // Sort by device ID to make ordering of participants deterministic.
   std::sort(collective->participants.begin(), collective->participants.end(),
             [](const std::unique_ptr<Participant>& a,
                const std::unique_ptr<Participant>& b) {
-              if (a->executor == b->executor) {
-                return a->global_rank < b->global_rank;
+              if (a->gpu_device_id == b->gpu_device_id) {
+                return a->executor < b->executor;
               }
-              return a->executor < b->executor;
+              return a->gpu_device_id < b->gpu_device_id;
             });
 
   mutex_lock l(mu_);


### PR DESCRIPTION
Occasionally, the nccl_manager_test subtest `NcclManagerTest/0.BasicAllGather` would fail because the `NcclManagerTest/0.BasicSumReduction` would produce a device-to-rank ordering that might not be monotonically increasing.

```
hostname:25909:25993 [0] NCCL INFO Ring 00 :    0   1   2   3
hostname:25909:25994 [1] NCCL INFO Ring 00 : 1[2] -> 2[1] via direct shared memory
hostname:25909:25993 [0] NCCL INFO Ring 00 : 0[0] -> 1[2] via direct shared memory
hostname:25909:25996 [3] NCCL INFO Ring 00 : 3[3] -> 0[0] via direct shared memory
hostname:25909:25995 [2] NCCL INFO Ring 00 : 2[1] -> 3[3] via direct shared memory
```

This communicator would be reused by the `BasicAllGather` test.  However, the allgather reduction is expected to be ordered by rank; no other collective result depends on rank order.  Sorting the participants based on the device ID resolves the failed test.