### PR TITLE
[r2.0-CherryPick]:Implementing RFC#126: Allow Op names of the form RepoName>OpName

### DIFF
--- a/tensorflow/python/framework/python_op_gen_internal.cc
+++ b/tensorflow/python/framework/python_op_gen_internal.cc
@@ -472,6 +472,12 @@ void GenerateLowerCaseOpName(const string& str, string* result) {
   const int last_index = str.size() - 1;
   for (int i = 0; i <= last_index; ++i) {
     const char c = str[i];
+    // Convert namespace separators ('>' characters) to joiners
+    if (c == '>') {
+      result->push_back(joiner);
+      continue;
+    }
+
     // Emit a joiner only if a previous-lower-to-now-upper or a
     // now-upper-to-next-lower transition happens.
     if (isupper(c) && (i > 0)) {


### PR DESCRIPTION
This change maps '>' in the op names to underscores in the generated python op function names and export names.

Getting '.' in the names instead is theoretically doable but would add too much complexity to the whole codegen loop to be worthwhile.
(It would require analyzing the op names to group ops by their respective nested namespaces, code-gen'ing nested python classes that match the namespaces, then indenting the codegen'd python ops inside of the nested classes w/ the names set correctly).