### PR TITLE
Makefile to build TensorFlow Lite C library from source

### DIFF
--- a/tensorflow/lite/experimental/c/Makefile
+++ b/tensorflow/lite/experimental/c/Makefile
@@ -1,0 +1,37 @@
+SRCS =  c_api.cc c_api_experimental.cc
+OBJS = $(subst .cc,.o,$(subst .cxx,.o,$(subst .cpp,.o,$(SRCS))))
+TENSORFLOW_ROOT = $(shell go env GOPATH)/src/github.com/tensorflow/tensorflow
+CXXFLAGS = -DTF_COMPILE_LIBRARY -I$(TENSORFLOW_ROOT) -I$(TENSORFLOW_ROOT)/tensorflow/lite/tools/make/downloads/flatbuffers/include -fPIC
+TARGET = libtensorflowlite_c
+
+ifeq ($(OS),Windows_NT)
+	OS_ARCH = windows_x86_64
+	TARGET_SHARED := $(TARGET).dll
+else
+	TARGET_SHARED := $(TARGET).so
+	ifeq ($(shell uname -m),x86_64)
+		OS_ARCH = linux_x86_64
+	else
+	ifeq ($(shell uname -m),armv6l)
+		OS_ARCH = linux_armv6l
+	else
+		OS_ARCH = rpi_armv7l
+	endif
+	endif
+endif
+
+LDFLAGS += -L$(TENSORFLOW_ROOT)/tensorflow/lite/tools/make/gen/$(OS_ARCH)/lib
+LIBS = -ltensorflow-lite
+
+.SUFFIXES: .cpp .cxx .o
+
+all : $(TARGET_SHARED)
+
+$(TARGET_SHARED) : $(OBJS)
+		g++ -shared -o $@ $(OBJS) $(LDFLAGS) $(LIBS)
+.cxx.o :
+		g++ -std=c++14 -c $(CXXFLAGS) -I. $< -o $@
+.cpp.o :
+		g++ -std=c++14 -c $(CXXFLAGS) -I. $< -o $@
+clean :
+		rm -f *.o $(TARGET_SHARED)

--- a/tensorflow/lite/experimental/c/README.md
+++ b/tensorflow/lite/experimental/c/README.md
@@ -34,4 +34,4 @@ this will output the C shared library located at `<TENSORFLOW_DIRECTORY>/tensorf
 
 - [Rust tflite](https://crates.io/crates/tflite): Rust binding for TensorFlow Lite
 
-- [Tensorflow Lite for Alpine Linux](): Tiny `musl` build TensorFlow Lite for Alpine Linux.
+- [Tensorflow Lite for Alpine Linux](https://github.com/Jonarod/tensorflow_lite_alpine): Tiny `musl`-built TensorFlow Lite for Alpine Linux.

--- a/tensorflow/lite/experimental/c/README.md
+++ b/tensorflow/lite/experimental/c/README.md
@@ -1,0 +1,37 @@
+# Build TensorFlow Lite C library from source
+
+```bash
+cd <TENSORFLOW_DIRECTORY>/
+./tensorflow/tensorflow/lite/tools/make/download_dependencies.sh
+```
+
+then execute one of:
+```bash
+# for current platform
+$ ./tensorflow/tensorflow/lite/tools/make/build_lib.sh
+# OR, for Raspberry Pi
+$ ./tensorflow/tensorflow/lite/tools/make/build_rpi_lib.sh
+# OR, for ARM devices 
+$ ./tensorflow/tensorflow/lite/tools/make/build_aarch64_lib.sh
+# OR, for all iOS platforms
+$ ./tensorflow/tensorflow/lite/tools/make/build_ios_universal_lib.sh
+```
+
+this will produce a static lib located at `<TENSORFLOW_DIRECTORY>/tensorflow/tensorflow/lite/tools/make/gen/<PLATFORM>/lib/libtensorflow-lite.a`.
+
+From there, we can build the shared library:
+
+```bash
+cd <TENSORFLOW_DIRECTORY>/tensorflow/tensorflow/lite/experimental/c/
+make
+```
+this will output the C shared library located at `<TENSORFLOW_DIRECTORY>/tensorflow/lite/experimental/c/libtensorflowlite_c.so`
+
+
+# Unofficial related projects using this library
+
+- [Go-tflite](https://github.com/mattn/go-tflite): Go binding for TensorFlow Lite
+
+- [Rust tflite](https://crates.io/crates/tflite): Rust binding for TensorFlow Lite
+
+- [Tensorflow Lite for Alpine Linux](): Tiny `musl` build TensorFlow Lite for Alpine Linux.


### PR DESCRIPTION
After using `bazel` to build the library, I experienced performance hits compared to `make`.

Just to keep record and for someone to reproduce my original issue, I left the `bazel` build steps in my repo here: [https://github.com/Jonarod/tensorflow_lite_alpine/blob/master/builder/Dockerfile.bazel](https://github.com/Jonarod/tensorflow_lite_alpine/blob/master/builder/Dockerfile.bazel).

On the same repo, one can build `libtensorflowlite_c.so` using `make` (using [this Dockerfile](https://github.com/Jonarod/tensorflow_lite_alpine/blob/master/builder/Dockerfile)) and/or `bazel` (using [this Dockerfile](https://github.com/Jonarod/tensorflow_lite_alpine/blob/master/builder/Dockerfile.bazel)) then compare performance on inference. You should see the `make`-build performs better than the `bazel` one.