### PR TITLE
[INTEL MKL]  Fixed missing copts in BUILD file.

### DIFF
--- a/tensorflow/core/common_runtime/eager/BUILD
+++ b/tensorflow/core/common_runtime/eager/BUILD
@@ -1,6 +1,7 @@
 load(
     "//tensorflow:tensorflow.bzl",
     "tf_cc_test",
+    "tf_copts",
     "tf_cuda_library",
 )
 load(
@@ -282,6 +283,8 @@ cc_library(
 cc_library(
     name = "mkl_eager_op_rewrite",
     srcs = ["mkl_eager_op_rewrite.cc"],
+    copts = tf_copts(),
+    nocopts = "-fno-exceptions",
     deps = [
         ":eager_op_rewrite_registry",
         "//tensorflow/core:framework",


### PR DESCRIPTION
The -DINTEL_MKL compiler option was not getting passed to mkl related eager files (removed in a prior commit.)  Added tf_copts  to the build, tf_copts includes -DINTEL_MKL.