### PR TITLE
[WIP] Enable more operators in Quantization-aware Training

### DIFF
--- a/tensorflow/contrib/quantize/python/quantize.py
+++ b/tensorflow/contrib/quantize/python/quantize.py
@@ -37,10 +37,10 @@ _ACTIVATION_TYPES = {'Relu', 'Relu6', 'Identity'}
 _RELU_TYPES = {'Relu', 'Relu6'}
 
 _QUANTIZATION_OP = {'FakeQuantWithMinMaxVars'}
-_VALID_SRC_OP = {'Add', 'AddV2', 'Mul'}
-_INTERMEDIATE_OP = {'Add', 'AddV2', 'Mul'}
+_VALID_SRC_OP = {'Add', 'AddV2', 'Mul', 'Sub', 'ConcatV2', 'Abs'}
+_INTERMEDIATE_OP = _VALID_SRC_OP
 _PASS_THROUGH_OP = {'Reshape', 'Identity', 'BatchToSpaceND', 'SpaceToBatchND',
-                    'MaxPool', 'Max'}
+                    'MaxPool', 'Max', 'Tile', 'Squeeze', 'ExpandDims'}
 _VALID_ACTIVATION_OP = {'Relu', 'Relu6'}
 
 


### PR DESCRIPTION
The first commit is moved to here from https://github.com/tensorflow/tensorflow/pull/31914 per @suharshs 's comments. The minor changes of the first commit serves as a initial, I'd like to have more discussions while this is in progress.