### PR TITLE
Support TensorRT 6

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -1566,8 +1566,11 @@ void Converter::MaybeApplyQuantizationRanges() {
 #endif
 
   if (use_calibration()) return;
+#if !IS_TRT_VERSION_GE(6, 0, 0, 0)
   // Attempt to find tensors that are missing ranges, and set the corresponding
   // layer's precision to FP16 to avoid Builder::buildCudaEngine() failing.
+  // This is only needed for TensorRT 5 and before because
+  // TensorRT6 falls to FP16 internally.
   // TensorRT doesn't need ranges for intermediate tensors when layers are fused
   // so find fused layers first.
   // Get all tensors from network and deduce fused ops.
@@ -1696,6 +1699,7 @@ void Converter::MaybeApplyQuantizationRanges() {
       }
     }
   }
+#endif
 }
 
 void Converter::PropagateQuantizationRanges() {

--- a/third_party/tensorrt/tensorrt_configure.bzl
+++ b/third_party/tensorrt/tensorrt_configure.bzl
@@ -26,8 +26,8 @@ _TF_TENSORRT_HEADERS_V6 = [
     "NvUtils.h",
     "NvInferPlugin.h",
     "NvInferVersion.h",
-    "NvInferRTSafe.h",
-    "NvInferRTExt.h",
+    "NvInferRuntime.h",
+    "NvInferRuntimeCommon.h",
     "NvInferPluginUtils.h",
 ]
 


### PR DESCRIPTION
- Update TRT6 headerfiles
- In TRT6, do not manually fall to fp16 in case of missing quant ranges
- Remove WAR of CombinedNMS converter that shrinks last output dim