### PR TITLE
Using inexpensive opcodes to remove a list

### DIFF
--- a/tensorflow/python/ops/parallel_for/control_flow_ops_test.py
+++ b/tensorflow/python/ops/parallel_for/control_flow_ops_test.py
@@ -289,7 +289,7 @@ class BitwiseTest(PForTestCase):
         x1 = array_ops.gather(x, i)
         y1 = array_ops.gather(y, i)
         outputs = [op(x, y), op(x1, y), op(x, y1), op(x1, y1), op(x1, x1)]
-        output_dtypes *=0
+        output_dtypes *= 0
         output_dtypes.extend([t.dtype for t in outputs])
         return outputs
       # pylint: enable=cell-var-from-loop

--- a/tensorflow/python/ops/parallel_for/control_flow_ops_test.py
+++ b/tensorflow/python/ops/parallel_for/control_flow_ops_test.py
@@ -289,7 +289,7 @@ class BitwiseTest(PForTestCase):
         x1 = array_ops.gather(x, i)
         y1 = array_ops.gather(y, i)
         outputs = [op(x, y), op(x1, y), op(x, y1), op(x1, y1), op(x1, x1)]
-        del output_dtypes[:]
+        output_dtypes *=0
         output_dtypes.extend([t.dtype for t in outputs])
         return outputs
       # pylint: enable=cell-var-from-loop


### PR DESCRIPTION
Using fewer/inexpensive [opcodes](https://docs.python.org/3/library/dis.html) to remove a list; this is useful when a list is large. 