### PR TITLE
[lite/micro] Override operator delete in memory planner

### DIFF
--- a/tensorflow/lite/micro/memory_planner/greedy_memory_planner.h
+++ b/tensorflow/lite/micro/memory_planner/greedy_memory_planner.h
@@ -125,6 +125,8 @@ class GreedyMemoryPlanner : public MemoryPlanner {
 
   // Whether buffers have been added since the last plan was calculated.
   bool need_to_calculate_offsets_;
+
+  TF_LITE_REMOVE_VIRTUAL_DELETE
 };
 
 }  // namespace tflite

--- a/tensorflow/lite/micro/memory_planner/linear_memory_planner.h
+++ b/tensorflow/lite/micro/memory_planner/linear_memory_planner.h
@@ -40,6 +40,8 @@ class LinearMemoryPlanner : public MemoryPlanner {
   int buffer_offsets_[kMaxBufferCount];
   int current_buffer_count_;
   int next_free_offset_;
+
+  TF_LITE_REMOVE_VIRTUAL_DELETE
 };
 
 }  // namespace tflite


### PR DESCRIPTION
Fix #32416 .
Override operator delete.