### PR TITLE
Fix few typos in the annotations and docs

### DIFF
--- a/tensorflow/core/common_runtime/function.h
+++ b/tensorflow/core/common_runtime/function.h
@@ -292,7 +292,7 @@ Status ValidateInlining(const Node* node, const FunctionBody* fbody,
 // explicitly specified devices inside fbody with the callee's device.
 //
 // Returns 'Status::OK()' if function was successfully inlined into the graph.
-// If function inlining is not possible returns a error with a reason, and
+// If function inlining is not possible returns an error with a reason, and
 // leaves the graph in unmodified state.
 Status InlineFunctionBody(const FunctionLibraryDefinition& flib_def, Graph* g,
                           Node* caller, const FunctionBody* fbody,

--- a/tensorflow/core/grappler/utils/frame.h
+++ b/tensorflow/core/grappler/utils/frame.h
@@ -28,7 +28,7 @@ namespace grappler {
 // any) the given node can be running in. It's constructed from an immutable
 // GraphView, and any modification of the underlying graph might invalidate it.
 //
-// All execution frames assigned an unique integer id, but they do not have any
+// All execution frames assigned a unique integer id, but they do not have any
 // meaning whatsoever, it's just a sequence number.
 //
 // See the paper "Dynamic Control Flow in Large-Scale Machine Learning" for

--- a/tensorflow/core/platform/cloud/curl_http_request.h
+++ b/tensorflow/core/platform/cloud/curl_http_request.h
@@ -224,7 +224,7 @@ class CurlHttpRequest : public HttpRequest {
   string uri_;
   RequestMethod method_ = RequestMethod::kGet;
 
-  // Limit the size of a http response that is copied into an error message.
+  // Limit the size of an http response that is copied into an error message.
   const size_t response_to_error_limit_ = 500;
 
   TF_DISALLOW_COPY_AND_ASSIGN(CurlHttpRequest);

--- a/tensorflow/lite/c/c_api_internal.h
+++ b/tensorflow/lite/c/c_api_internal.h
@@ -440,7 +440,7 @@ typedef struct TfLiteContext {
   // NOTE: ResizeTensor takes ownership of newSize.
   TfLiteStatus (*ResizeTensor)(struct TfLiteContext*, TfLiteTensor* tensor,
                                TfLiteIntArray* new_size);
-  // Request that a error be reported with format string msg.
+  // Request that an error be reported with format string msg.
   void (*ReportError)(struct TfLiteContext*, const char* msg, ...);
 
   // Add `tensors_to_add` tensors, preserving pre-existing Tensor entries.  If

--- a/tensorflow/lite/delegates/gpu/gl/compiler/compiled_node.cc
+++ b/tensorflow/lite/delegates/gpu/gl/compiler/compiled_node.cc
@@ -42,7 +42,7 @@ Status MergeCode(CompiledNodeAttributes* attr,
   RETURN_IF_ERROR(Rename(
       [&](absl::string_view name) -> std::string {
         std::string n(name.begin(), name.end());
-        // if a name is unique, then keep it as is. Otherwise append an unique
+        // if a name is unique, then keep it as is. Otherwise append a unique
         // index.
         if (known_names.find(n) == known_names.end()) {
           return n;

--- a/tensorflow/lite/experimental/c/c_api_types.h
+++ b/tensorflow/lite/experimental/c/c_api_types.h
@@ -440,7 +440,7 @@ typedef struct TfLiteContext {
   // NOTE: ResizeTensor takes ownership of newSize.
   TfLiteStatus (*ResizeTensor)(struct TfLiteContext*, TfLiteTensor* tensor,
                                TfLiteIntArray* new_size);
-  // Request that a error be reported with format string msg.
+  // Request that an error be reported with format string msg.
   void (*ReportError)(struct TfLiteContext*, const char* msg, ...);
 
   // Add `tensors_to_add` tensors, preserving pre-existing Tensor entries.  If

--- a/tensorflow/lite/java/demo/app/src/main/java/com/example/android/tflitecamerademo/Camera2BasicFragment.java
+++ b/tensorflow/lite/java/demo/app/src/main/java/com/example/android/tflitecamerademo/Camera2BasicFragment.java
@@ -811,7 +811,7 @@ public class Camera2BasicFragment extends Fragment
   private void classifyFrame() {
     if (classifier == null || getActivity() == null || cameraDevice == null) {
       // It's important to not call showToast every frame, or else the app will starve and
-      // hang. updateActiveModel() already puts a error message up with showToast.
+      // hang. updateActiveModel() already puts an error message up with showToast.
       // showToast("Uninitialized Classifier or invalid context.");
       return;
     }

--- a/third_party/gpus/crosstool/windows/msvc_wrapper_for_nvcc.py.tpl
+++ b/third_party/gpus/crosstool/windows/msvc_wrapper_for_nvcc.py.tpl
@@ -146,7 +146,7 @@ def InvokeNvcc(argv, log=False):
   nvccopts += m_options
   nvccopts += ['--compiler-options="' + " ".join(host_compiler_options) + '"']
   nvccopts += ['-x', 'cu'] + opt + includes + out + ['-c'] + src_files
-  # Specify an unique temp directory for nvcc to generate intermediate files,
+  # Specify a unique temp directory for nvcc to generate intermediate files,
   # then Bazel can ignore files under NVCC_TEMP_DIR during dependency check
   # http://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#options-for-guiding-compiler-driver
   # Different actions are sharing NVCC_TEMP_DIR, so we cannot remove it if the directory already exists.
@@ -154,7 +154,7 @@ def InvokeNvcc(argv, log=False):
     os.remove(NVCC_TEMP_DIR)
   if not os.path.exists(NVCC_TEMP_DIR):
     os.makedirs(NVCC_TEMP_DIR)
-  # Provide an unique dir for each compiling action to avoid conflicts.
+  # Provide a unique dir for each compiling action to avoid conflicts.
   tempdir = tempfile.mkdtemp(dir = NVCC_TEMP_DIR)
   nvccopts += ['--keep', '--keep-dir', tempdir]
   cmd = [NVCC_PATH] + nvccopts

--- a/third_party/hadoop/hdfs.h
+++ b/third_party/hadoop/hdfs.h
@@ -167,7 +167,7 @@ LIBHDFS_EXTERNAL
 void hdfsFileFreeReadStatistics(struct hdfsReadStatistics *stats);
 
 /**
- * hdfsConnectAsUser - Connect to a hdfs file system as a specific user
+ * hdfsConnectAsUser - Connect to an hdfs file system as a specific user
  * Connect to the hdfs.
  * @param nn   The NameNode.  See hdfsBuilderSetNameNode for details.
  * @param port The port on which the server is listening.
@@ -180,7 +180,7 @@ LIBHDFS_EXTERNAL
 hdfsFS hdfsConnectAsUser(const char *nn, tPort port, const char *user);
 
 /**
- * hdfsConnect - Connect to a hdfs file system.
+ * hdfsConnect - Connect to an hdfs file system.
  * Connect to the hdfs.
  * @param nn   The NameNode.  See hdfsBuilderSetNameNode for details.
  * @param port The port on which the server is listening.
@@ -377,7 +377,7 @@ LIBHDFS_EXTERNAL
 int hdfsDisconnect(hdfsFS fs);
 
 /**
- * hdfsOpenFile - Open a hdfs file in given mode.
+ * hdfsOpenFile - Open an hdfs file in given mode.
  * @param fs The configured filesystem handle.
  * @param path The full path to the file.
  * @param flags - an | of bits/fcntl.h file flags - supported flags are
@@ -397,7 +397,7 @@ hdfsFile hdfsOpenFile(hdfsFS fs, const char *path, int flags, int bufferSize,
                       short replication, tSize blocksize);
 
 /**
- * hdfsTruncateFile - Truncate a hdfs file to given length.
+ * hdfsTruncateFile - Truncate an hdfs file to given length.
  * @param fs The configured filesystem handle.
  * @param path The full path to the file.
  * @param newlength The size the file is to be truncated to


### PR DESCRIPTION
fix some typos:
'a error' change into 'an error'
'an unique' change into 'a unique'
'a http' change into 'an http'
'a hdfs' change into 'an hdfs'