### PR TITLE
Enable direct dilated convolution via CUDNN

### DIFF
--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -22,8 +22,11 @@ import collections
 import numbers
 
 import numpy as np
+import uuid
 
 from tensorflow.python.eager import context
+from tensorflow.python.eager import function
+from tensorflow.python.framework import device
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors_impl
 from tensorflow.python.framework import graph_util
@@ -51,6 +54,11 @@ from tensorflow.python.util.deprecation import deprecated_args
 from tensorflow.python.util.deprecation import deprecated_argument_lookup
 
 from tensorflow.python.util.tf_export import tf_export
+
+_DEFUN_API_NAME_ATTRIBUTE = 'api_implements'
+_DEFUN_DEVICE_ATTRIBUTE = 'api_preferred_device'
+_CPU_DEVICE_NAME = 'CPU'
+_GPU_DEVICE_NAME = 'GPU'
 
 # Aliases for some automatically-generated names.
 local_response_normalization = gen_nn_ops.lrn
@@ -133,7 +141,7 @@ def _non_atrous_convolution(
     input_shape = input.get_shape()
     filter = ops.convert_to_tensor(filter, name="filter")  # pylint: disable=redefined-builtin
     filter_shape = filter.get_shape()
-    op = _NonAtrousConvolution(
+    op = _Convolution(
         input_shape,
         filter_shape=filter_shape,
         padding=padding,
@@ -143,8 +151,9 @@ def _non_atrous_convolution(
     return op(input, filter)
 
 
-class _NonAtrousConvolution(object):
-  """Helper class for _non_atrous_convolution.
+class _Convolution(object):
+  """Helper class for _non_atrous_convolution. It also support direct atrous
+  convolution via cuDNN if the dilations is given.
 
   Note that this class assumes that shapes of input and filter passed to
   __call__ are compatible with input_shape and filter_shape passed to the
@@ -157,6 +166,7 @@ class _NonAtrousConvolution(object):
     data_format: see _non_atrous_convolution.
     strides: see _non_atrous_convolution.
     name: see _non_atrous_convolution.
+    dilation_rate: see with_space_to_batch
   """
 
   def __init__(
@@ -166,7 +176,8 @@ class _NonAtrousConvolution(object):
       padding,
       data_format=None,
       strides=None,
-      name=None):
+      name=None,
+      dilation_rate=None):
     filter_shape = filter_shape.with_rank(input_shape.ndims)
     self.padding = padding
     self.name = name
@@ -182,6 +193,7 @@ class _NonAtrousConvolution(object):
     elif len(strides) != conv_dims:
       raise ValueError("len(strides)=%d, but should be %d" % (len(strides),
                                                               conv_dims))
+    self.dilations = dilation_rate
     if conv_dims == 1:
       # conv1d uses the 2-d data format names
       if data_format is None:
@@ -211,20 +223,25 @@ class _NonAtrousConvolution(object):
         raise ValueError("data_format must be \"NDHWC\" or \"NCDHW\". Have: %s"
                          % data_format)
       self.strides = strides
+      channel_index = 1 if data_format.startswith("NC") else 4
+      self.dilations = _get_sequence(dilation_rate, 3, channel_index,
+                                     "dilations")
       self.data_format = data_format
       self.conv_op = gen_nn_ops.conv3d
 
   # Note that we need this adapter since argument names for conv1d don't match
   # those for gen_nn_ops.conv2d and gen_nn_ops.conv3d.
   # pylint: disable=redefined-builtin
-  def _conv1d(self, input, filter, strides, padding, data_format, name):
+  def _conv1d(self, input, filter, strides, padding, data_format, name,
+              dilations):
     return conv1d(
         value=input,
         filters=filter,
         stride=strides,
         padding=padding,
         data_format=data_format,
-        name=name)
+        name=name,
+        dilations=dilations)
 
   # pylint: enable=redefined-builtin
 
@@ -235,7 +252,8 @@ class _NonAtrousConvolution(object):
         strides=self.strides,
         padding=self.padding,
         data_format=self.data_format,
-        name=self.name)
+        name=self.name,
+	dilations=self.dilations)
 
 
 @tf_export("nn.dilation2d", v1=[])
@@ -499,6 +517,9 @@ class _WithSpaceToBatch(object):
     filter_shape: see with_space_to_batch
     spatial_dims: see with_space_to_batch
     data_format: see with_space_to_batch
+    build_op_dilation: Function that maps (num_spatial_dims, paddings) ->
+      (function that maps (input, filter) -> output). It supports dilation rates
+      larger than 1.
   """
 
   def __init__(self,
@@ -508,7 +529,8 @@ class _WithSpaceToBatch(object):
                build_op,
                filter_shape=None,
                spatial_dims=None,
-               data_format=None):
+               data_format=None,
+               build_op_dilation=None):
     """Helper class for _with_space_to_batch."""
     dilation_rate = ops.convert_to_tensor(
         dilation_rate, dtypes.int32, name="dilation_rate")
@@ -588,6 +610,17 @@ class _WithSpaceToBatch(object):
     self.op = build_op(num_spatial_dims, "VALID")
     self.call = self._with_space_to_batch_call
 
+    # We check if the direct dilated convolution can be used. If yes, we will
+    # replace the self.op with build_op_dilation. We only support direct cuDNN
+    # dilated convolution for 1D and 2D conv.
+    can_use_fused = False if build_op_dilation is None else True
+    if input_shape.ndims is not None:
+      conv_dims = input_shape.ndims - 2
+      can_use_fused = can_use_fused and conv_dims <= 2
+    if can_use_fused:
+      self.op = build_op_dilation(num_spatial_dims, padding)
+      self.call = self._direct_call
+
   def _with_space_to_batch_call(self, inp, filter):  # pylint: disable=redefined-builtin
     """Call functionality for with_space_to_batch."""
     # Handle input whose shape is unknown during graph creation.
@@ -634,6 +667,26 @@ class _WithSpaceToBatch(object):
         result_converted.set_shape(output_shape)
 
     return result_converted
+
+  def _direct_call(self, inp, filter):  # pylint: disable=redefined-builtin
+    """Call functionality for directed dilated convolution."""
+    # We need to make sure the signatures of _direct_call same with
+    # _with_space_to_batch_call for the implementation selector. Therefore, we
+    # conduct a dummy call of required_space_to_batch_paddings to ensure the two
+    # input tensor input_shape and base_paddings are still there.
+    spatial_dims = self.spatial_dims
+    input_shape_tensor = array_ops.shape(inp)
+    input_spatial_shape = array_ops.stack(
+        [input_shape_tensor[i] for i in spatial_dims])
+    base_paddings = self.base_paddings
+    paddings, crops = array_ops.required_space_to_batch_paddings(
+        input_shape=input_spatial_shape,
+        base_paddings=base_paddings,
+        block_shape=self.dilation_rate)
+
+    result = self.op(inp, filter)
+
+    return result
 
   def __call__(self, inp, filter):  # pylint: disable=redefined-builtin
     return self.call(inp, filter)
@@ -1025,6 +1078,22 @@ def convolution_internal(
           data_format=data_format)
       return op(input, filters)
 
+def _get_context_device_type():
+  """Parse the current context and return the device type, eg CPU/GPU."""
+  current_device = context.context().device_name
+  if current_device is None:
+    return None
+  return device.DeviceSpec.from_string(current_device).device_type
+
+def _generate_defun_backend(unique_api_name, preferred_device, func):
+  function_attributes = {
+      _DEFUN_API_NAME_ATTRIBUTE: unique_api_name,
+      _DEFUN_DEVICE_ATTRIBUTE: preferred_device,
+  }
+  print("PPP register", func, "to", unique_api_name)
+  return function.defun_with_attributes(func=func,
+                                        attributes=function_attributes,
+                                        autograph=False)
 
 class Convolution(object):
   """Helper class for convolution.
@@ -1097,7 +1166,7 @@ class Convolution(object):
     self.padding = padding
     self.name = name
     self.dilation_rate = dilation_rate
-    self.conv_op = _WithSpaceToBatch(
+    self.conv_op_standard = _WithSpaceToBatch(
         input_shape,
         dilation_rate=dilation_rate,
         padding=padding,
@@ -1105,14 +1174,33 @@ class Convolution(object):
         filter_shape=filter_shape,
         spatial_dims=spatial_dims,
         data_format=data_format)
+    self.conv_op_cudnn = _WithSpaceToBatch(
+        input_shape,
+        dilation_rate=dilation_rate,
+        padding=padding,
+        build_op=self._build_op,
+        filter_shape=filter_shape,
+        spatial_dims=spatial_dims,
+        data_format=data_format,
+        build_op_dilation=self._build_op_dilation)
 
   def _build_op(self, _, padding):
-    return _NonAtrousConvolution(
+    return _Convolution(
         self.input_shape,
         filter_shape=self.filter_shape,
         padding=padding,
         data_format=self.data_format,
         strides=self.strides,
+        name=self.name)
+
+  def _build_op_dilation(self, _, padding):
+    return _Convolution(
+        self.input_shape,
+        filter_shape=self.filter_shape,
+        padding=padding,
+        data_format=self.data_format,
+        strides=self.strides,
+	dilation_rate=self.dilation_rate,
         name=self.name)
 
   def __call__(self, inp, filter):  # pylint: disable=redefined-builtin
@@ -1131,7 +1219,27 @@ class Convolution(object):
           name=self.name,
           call_from_convolution=False)
     else:
-      return self.conv_op(inp, filter)
+      params = {'inp': inp, 'filter': filter}
+      if context.executing_eagerly():
+        device_type = _get_context_device_type()
+        can_use_gpu = (
+            # Either user specified GPU or unspecified but GPU is available.
+            (device_type == _GPU_DEVICE_NAME
+             or (device_type is None and context.num_gpus() > 0)))
+        # Under eager context, check the device placement and prefer the
+        if can_use_gpu:
+          res = self.conv_op_cudnn(**params)
+        else:
+          res = self.conv_op_standard(**params)
+      else:
+        api_name = 'conv_' + str(uuid.uuid4())
+        conv_op_standard = _generate_defun_backend(
+            api_name, _CPU_DEVICE_NAME, self.conv_op_standard)
+        conv_op_cudnn = _generate_defun_backend(
+            api_name, _GPU_DEVICE_NAME, self.conv_op_cudnn)
+        res = conv_op_standard(**params)
+        function.register(conv_op_cudnn, **params)
+      return res
     # copybara:strip_end
     # copybara:insert return self.conv_op(inp, filter)
 


### PR DESCRIPTION
For the dilated convolution, TF will perform space-to-batch transforms and then call the non-atrous convolution kernels.

This PR removes the transforms and directly call the atrous convolution kernels from CUDNN. 

fyi. @nluehr 