### PR TITLE
Eliminate no-op convert pair in algebraic simplifier

### DIFF
--- a/tensorflow/compiler/xla/service/algebraic_simplifier.cc
+++ b/tensorflow/compiler/xla/service/algebraic_simplifier.cc
@@ -176,25 +176,22 @@ bool IsConvertPairNoOp(const HloInstruction* convert) {
   const Shape& intermediate_shape = operand_convert->shape();
   const Shape& dest_shape = convert->shape();
 
-  const PrimitiveType& src_type =
-      src_shape.element_type();
-  const PrimitiveType& intermediate_type = intermediate_shape.element_type();
-  const PrimitiveType& dest_type = dest_shape.element_type();
+  const PrimitiveType src_type = src_shape.element_type();
+  const PrimitiveType intermediate_type = intermediate_shape.element_type();
+  const PrimitiveType dest_type = dest_shape.element_type();
 
   // src_type must be equal to dest_type.
   if (src_type != dest_type) {
     return false;
   }
 
-  // src_type must be a larger container than
-  // intermediate_type.
+  // src_type must be a larger container than intermediate_type.
   if (ShapeUtil::ByteSizeOfPrimitiveType(intermediate_type) <=
       ShapeUtil::ByteSizeOfPrimitiveType(src_type)) {
     return false;
   }
 
-  // Both src_type and intermediate_type must
-  // be either floating or integral.
+  // Both src_type and intermediate_type must be either floating or integral.
   bool is_conversion_floating =
       ShapeUtil::ElementIsFloating(src_shape) &&
       ShapeUtil::ElementIsFloating(intermediate_shape);
@@ -206,14 +203,14 @@ bool IsConvertPairNoOp(const HloInstruction* convert) {
     return false;
   }
 
-  // A conversion pair where src_type is signed and
-  // intermediate_type is unsigned cannot be optimized.
+  // A conversion pair where src_type is signed and intermediate_type is
+  // unsigned cannot be optimized.
   bool is_conversion_signed_to_unsigned =
       (ShapeUtil::ElementIsSigned(src_shape) &&
         !ShapeUtil::ElementIsSigned(intermediate_shape));
 
-  // If the conversion is integral, only signed to unsigned conversion is
-  // not allowed.
+  // If the conversion is integral, only signed to unsigned conversion is not
+  // allowed.
   if (is_conversion_integral && is_conversion_signed_to_unsigned) {
     return false;
   }

--- a/tensorflow/compiler/xla/service/algebraic_simplifier.cc
+++ b/tensorflow/compiler/xla/service/algebraic_simplifier.cc
@@ -203,18 +203,6 @@ bool IsConvertPairNoOp(const HloInstruction* convert) {
     return false;
   }
 
-  // A conversion pair where src_type is signed and intermediate_type is
-  // unsigned cannot be optimized.
-  bool is_conversion_signed_to_unsigned =
-      (ShapeUtil::ElementIsSigned(src_shape) &&
-        !ShapeUtil::ElementIsSigned(intermediate_shape));
-
-  // If the conversion is integral, only signed to unsigned conversion is not
-  // allowed.
-  if (is_conversion_integral && is_conversion_signed_to_unsigned) {
-    return false;
-  }
-
   return true;
 }
 

--- a/tensorflow/compiler/xla/service/algebraic_simplifier.cc
+++ b/tensorflow/compiler/xla/service/algebraic_simplifier.cc
@@ -199,11 +199,7 @@ bool IsConvertPairNoOp(const HloInstruction* convert) {
       ShapeUtil::ElementIsIntegral(src_shape) &&
       ShapeUtil::ElementIsIntegral(intermediate_shape);
 
-  if (!(is_conversion_floating || is_conversion_integral)) {
-    return false;
-  }
-
-  return true;
+  return is_conversion_floating || is_conversion_integral;
 }
 
 // AlgebraicSimplifierVisitor traverses the HLO computation and reduces certain

--- a/tensorflow/compiler/xla/service/algebraic_simplifier_test.cc
+++ b/tensorflow/compiler/xla/service/algebraic_simplifier_test.cc
@@ -1710,8 +1710,8 @@ TEST_F(AlgebraicSimplifierTest, ConvertBetweenSameType) {
   EXPECT_THAT(computation->root_instruction(), input);
 }
 
-// Test that convert(convert(A, $TYPE1), $TYPE2) is simplified to A if
-// A is of $TYPE2 and convert(A, $TYP1) is an upcast.
+// Test that convert(convert(A, $TYPE1), $TYPE2) is simplified to A if A is of
+// $TYPE2 and convert(A, $TYP1) is an upcast.
 TEST_F(AlgebraicSimplifierTest, EliminateConvertPairUpCast) {
   auto m = CreateNewVerifiedModule();
   HloComputation::Builder builder(TestName());
@@ -1761,9 +1761,9 @@ TEST_F(AlgebraicSimplifierTest, DoNotEliminateConvertPairDownCast) {
               GmockMatch(m::Convert(m::Convert(m::Op().Is(input)))));
 }
 
-// Test that convert(convert(A, $TYPE1), $TYPE2) is simplified to A if
-// A is of $TYPE2 since convert(A, $TYP1) is an upcast and is a conversion from
-// unsigned to signed which is allowed.
+// Test that convert(convert(A, $TYPE1), $TYPE2) is simplified to A if A is of
+// $TYPE2 since convert(A, $TYP1) is an upcast and is a conversion from unsigned
+// to signed which is allowed.
 TEST_F(AlgebraicSimplifierTest, EliminateConvertPairUnsignedToSigned) {
   auto m = CreateNewVerifiedModule();
   HloComputation::Builder builder(TestName());

--- a/tensorflow/compiler/xla/service/algebraic_simplifier_test.cc
+++ b/tensorflow/compiler/xla/service/algebraic_simplifier_test.cc
@@ -1711,7 +1711,7 @@ TEST_F(AlgebraicSimplifierTest, ConvertBetweenSameType) {
 }
 
 // Test that convert(convert(A, $TYPE1), $TYPE2) is simplified to A if
-// A is of $TYPE2 and convert(A, $TYP1) is an upcast
+// A is of $TYPE2 and convert(A, $TYP1) is an upcast.
 TEST_F(AlgebraicSimplifierTest, EliminateConvertPairUpCast) {
   auto m = CreateNewVerifiedModule();
   HloComputation::Builder builder(TestName());
@@ -1737,7 +1737,7 @@ TEST_F(AlgebraicSimplifierTest, EliminateConvertPairUpCast) {
 }
 
 // Test that convert(convert(A, $TYPE1), $TYPE2) is NOT simplified to A even if
-// A is of $TYPE2 since convert(A, $TYP1) is a downcast
+// A is of $TYPE2 since convert(A, $TYP1) is a downcast.
 TEST_F(AlgebraicSimplifierTest, DoNotEliminateConvertPairDownCast) {
   auto m = CreateNewVerifiedModule();
   HloComputation::Builder builder(TestName());
@@ -1763,7 +1763,7 @@ TEST_F(AlgebraicSimplifierTest, DoNotEliminateConvertPairDownCast) {
 
 // Test that convert(convert(A, $TYPE1), $TYPE2) is simplified to A if
 // A is of $TYPE2 since convert(A, $TYP1) is an upcast and is a conversion from
-// unsigned to signed which is allowed
+// unsigned to signed which is allowed.
 TEST_F(AlgebraicSimplifierTest, EliminateConvertPairUnsignedToSigned) {
   auto m = CreateNewVerifiedModule();
   HloComputation::Builder builder(TestName());
@@ -1791,7 +1791,7 @@ TEST_F(AlgebraicSimplifierTest, EliminateConvertPairUnsignedToSigned) {
 // Test that Tuple(convert(A, $TYPE1) , floor(convert(convert(A, $TYPE1),
 // $TYPE2)), convert(convert(A, $TYPE1), $TYPE2)) is simplified to
 // Tuple(convert(A, $TYPE1) , floor(A), A) showing a case where the first
-// convert has a fan-out
+// convert has a fan-out.
 TEST_F(AlgebraicSimplifierTest, EliminateConvertPairMultiOut) {
   auto m = CreateNewVerifiedModule();
   HloComputation::Builder builder(TestName());

--- a/tensorflow/compiler/xla/service/algebraic_simplifier_test.cc
+++ b/tensorflow/compiler/xla/service/algebraic_simplifier_test.cc
@@ -1710,6 +1710,122 @@ TEST_F(AlgebraicSimplifierTest, ConvertBetweenSameType) {
   EXPECT_THAT(computation->root_instruction(), input);
 }
 
+// Test that convert(convert(A, $TYPE1), $TYPE2) is simplified to A if
+// A is of $TYPE2 and convert(A, $TYP1) is an upcast
+TEST_F(AlgebraicSimplifierTest, EliminateConvertPairUpCast) {
+  auto m = CreateNewVerifiedModule();
+  HloComputation::Builder builder(TestName());
+  HloInstruction* input =
+      builder.AddInstruction(HloInstruction::CreateParameter(
+          0, ShapeUtil::MakeShapeWithLayout(F16, {1, 14, 14, 64}, {3, 2, 1, 0}),
+          "param"));
+  HloInstruction* convert_1 =
+      builder.AddInstruction(HloInstruction::CreateConvert(
+          ShapeUtil::ChangeElementType(input->shape(), F32), input));
+  builder.AddInstruction(HloInstruction::CreateConvert(
+      ShapeUtil::ChangeElementType(convert_1->shape(), F16), convert_1));
+
+  auto computation = m->AddEntryComputation(builder.Build());
+
+  EXPECT_THAT(computation->root_instruction(),
+              GmockMatch(m::Convert(m::Convert(m::Op().Is(input)))));
+
+  AlgebraicSimplifier simplifier(default_options_);
+  ASSERT_TRUE(simplifier.Run(m.get()).ValueOrDie());
+
+  EXPECT_THAT(computation->root_instruction(), input);
+}
+
+// Test that convert(convert(A, $TYPE1), $TYPE2) is NOT simplified to A even if
+// A is of $TYPE2 since convert(A, $TYP1) is a downcast
+TEST_F(AlgebraicSimplifierTest, DoNotEliminateConvertPairDownCast) {
+  auto m = CreateNewVerifiedModule();
+  HloComputation::Builder builder(TestName());
+  HloInstruction* input =
+      builder.AddInstruction(HloInstruction::CreateParameter(
+          0, ShapeUtil::MakeShapeWithLayout(F32, {1, 14, 14, 64}, {3, 2, 1, 0}),
+          "param"));
+  HloInstruction* convert_1 =
+      builder.AddInstruction(HloInstruction::CreateConvert(
+          ShapeUtil::ChangeElementType(input->shape(), F16), input));
+  builder.AddInstruction(HloInstruction::CreateConvert(
+      ShapeUtil::ChangeElementType(convert_1->shape(), F32), convert_1));
+
+  auto computation = m->AddEntryComputation(builder.Build());
+
+  EXPECT_THAT(computation->root_instruction(),
+              GmockMatch(m::Convert(m::Convert(m::Op().Is(input)))));
+  AlgebraicSimplifier simplifier(default_options_);
+  ASSERT_FALSE(simplifier.Run(m.get()).ValueOrDie());
+  EXPECT_THAT(computation->root_instruction(),
+              GmockMatch(m::Convert(m::Convert(m::Op().Is(input)))));
+}
+
+// Test that convert(convert(A, $TYPE1), $TYPE2) is simplified to A if
+// A is of $TYPE2 since convert(A, $TYP1) is an upcast and is a conversion from
+// unsigned to signed which is allowed
+TEST_F(AlgebraicSimplifierTest, EliminateConvertPairUnsignedToSigned) {
+  auto m = CreateNewVerifiedModule();
+  HloComputation::Builder builder(TestName());
+  HloInstruction* input =
+      builder.AddInstruction(HloInstruction::CreateParameter(
+          0, ShapeUtil::MakeShapeWithLayout(U16, {1, 14, 14, 64}, {3, 2, 1, 0}),
+          "param"));
+  HloInstruction* convert_1 =
+      builder.AddInstruction(HloInstruction::CreateConvert(
+          ShapeUtil::ChangeElementType(input->shape(), S32), input));
+  builder.AddInstruction(HloInstruction::CreateConvert(
+      ShapeUtil::ChangeElementType(convert_1->shape(), U16), convert_1));
+
+  auto computation = m->AddEntryComputation(builder.Build());
+
+  EXPECT_THAT(computation->root_instruction(),
+              GmockMatch(m::Convert(m::Convert(m::Op().Is(input)))));
+
+  AlgebraicSimplifier simplifier(default_options_);
+  ASSERT_TRUE(simplifier.Run(m.get()).ValueOrDie());
+
+  EXPECT_THAT(computation->root_instruction(), input);
+}
+
+// Test that Tuple(convert(A, $TYPE1) , floor(convert(convert(A, $TYPE1),
+// $TYPE2)), convert(convert(A, $TYPE1), $TYPE2)) is simplified to
+// Tuple(convert(A, $TYPE1) , floor(A), A) showing a case where the first
+// convert has a fan-out
+TEST_F(AlgebraicSimplifierTest, EliminateConvertPairMultiOut) {
+  auto m = CreateNewVerifiedModule();
+  HloComputation::Builder builder(TestName());
+  HloInstruction* input =
+      builder.AddInstruction(HloInstruction::CreateParameter(
+          0, ShapeUtil::MakeShapeWithLayout(F16, {1, 14, 14, 64}, {3, 2, 1, 0}),
+          "param"));
+  HloInstruction* convert_1 =
+      builder.AddInstruction(HloInstruction::CreateConvert(
+          ShapeUtil::ChangeElementType(input->shape(), F32), input));
+  HloInstruction* convert_2 =
+      builder.AddInstruction(HloInstruction::CreateConvert(
+          ShapeUtil::ChangeElementType(convert_1->shape(), F16), convert_1));
+
+  HloInstruction* floor = builder.AddInstruction(HloInstruction::CreateUnary(
+      convert_2->shape(), HloOpcode::kFloor, convert_2));
+
+  // Collect all the reshapes into a tuple so they are not dead.
+  builder.AddInstruction(
+      HloInstruction::CreateTuple({convert_1, convert_2, floor}));
+
+  auto computation = m->AddEntryComputation(builder.Build());
+  EXPECT_THAT(computation->root_instruction(),
+              GmockMatch(m::Tuple(m::Op().Is(convert_1), m::Op().Is(convert_2),
+                                  m::Op().Is(floor))));
+
+  AlgebraicSimplifier simplifier(default_options_);
+  ASSERT_TRUE(simplifier.Run(m.get()).ValueOrDie());
+
+  EXPECT_THAT(computation->root_instruction(),
+              GmockMatch(m::Tuple(m::Op().Is(convert_1), m::Op().Is(input),
+                                  m::Floor(m::Op().Is(input)))));
+}
+
 // Test that copies are removed.
 TEST_F(AlgebraicSimplifierTest, RemoveCopy) {
   auto m = CreateNewVerifiedModule();


### PR DESCRIPTION
Few examples of cases that this optimization handles:

1. convert(convert(A, $TYPE1), $TYPE2) is simplified to A if A is of $TYPE2 and convert(A, $TYPE1) is an upcast
2. convert(convert(A, $TYPE1), $TYPE2) is NOT simplified to A even if A is of $TYPE2 since convert(A, $TYPE1) is a downcast
3. convert(convert(A, $TYPE1), $TYPE2) is simplified to A if A is of $TYPE2 and convert(A, $TYPE1) is an upcast and is a conversion from unsigned to signed which is allowed
4. convert(convert(A, $TYPE1), $TYPE2) is NOT simplified to A even if A is of $TYPE2 and convert(A, $TYPE1) is an upcast since convert(A, $TYPE1) is conversion from signed to unsigned which is NOT allowed
5. Tuple(convert(A, $TYPE1) , floor(convert(convert(A, $TYPE1), $TYPE2)), convert(convert(A, $TYPE1), $TYPE2)) is simplified to Tuple(convert(A, $TYPE1) , floor(A), A) showing a case where the first convert has a fan-out
6. Tuple(floor(convert(convert(A, $TYPE1),$TYPE2)), convert(convert(A, $TYPE1), $TYPE2)) is simplified to Tuple(floor(A), A) showing a case where the first convert ends up being removed by dead-code elimination
7. convert(convert(A, $TYPE1), $TYPE2) is NOT simplified to A even if A is of $TYPE2 and convert(A, $TYP1) is an upcast since convert(A, $TYP1) is conversion from integral to float(type change) which is NOT allowed

Added tests as well