### PR TITLE
[r1.15 CherryPick]: Upgrading giflib to fix CVE-2019-15133

### DIFF
--- a/tensorflow/opensource_only.files
+++ b/tensorflow/opensource_only.files
@@ -65,6 +65,7 @@ tensorflow/third_party/fft2d/fft2d.h
 tensorflow/third_party/functools32.BUILD
 tensorflow/third_party/gast.BUILD
 tensorflow/third_party/gif.BUILD
+tensorflow/third_party/gif_fix_strtok_r.patch
 tensorflow/third_party/git/BUILD
 tensorflow/third_party/git/BUILD.tpl
 tensorflow/third_party/git/git_configure.bzl

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -287,12 +287,13 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
     tf_http_archive(
         name = "gif_archive",
         build_file = clean_dep("//third_party:gif.BUILD"),
-        sha256 = "34a7377ba834397db019e8eb122e551a49c98f49df75ec3fcc92b9a794a4f6d1",
-        strip_prefix = "giflib-5.1.4",
+        patch_file = clean_dep("//third_party:gif_fix_strtok_r.patch"),
+        sha256 = "31da5562f44c5f15d63340a09a4fd62b48c45620cd302f77a6d9acf0077879bd",
+        strip_prefix = "giflib-5.2.1",
         system_build_file = clean_dep("//third_party/systemlibs:gif.BUILD"),
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/ufpr.dl.sourceforge.net/project/giflib/giflib-5.1.4.tar.gz",
-            "http://pilotfiber.dl.sourceforge.net/project/giflib/giflib-5.1.4.tar.gz",
+            "https://storage.googleapis.com/mirror.tensorflow.org/pilotfiber.dl.sourceforge.net/project/giflib/giflib-5.2.1.tar.gz",
+            "http://pilotfiber.dl.sourceforge.net/project/giflib/giflib-5.2.1.tar.gz",
         ],
     )
 

--- a/third_party/gif.BUILD
+++ b/third_party/gif.BUILD
@@ -8,18 +8,18 @@ exports_files(["COPYING"])
 cc_library(
     name = "gif",
     srcs = [
-        "lib/dgif_lib.c",
-        "lib/egif_lib.c",
-        "lib/gif_err.c",
-        "lib/gif_font.c",
-        "lib/gif_hash.c",
-        "lib/gif_hash.h",
-        "lib/gif_lib_private.h",
-        "lib/gifalloc.c",
-        "lib/openbsd-reallocarray.c",
-        "lib/quantize.c",
+        "dgif_lib.c",
+        "egif_lib.c",
+        "gif_err.c",
+        "gif_font.c",
+        "gif_hash.c",
+        "gif_hash.h",
+        "gif_lib_private.h",
+        "gifalloc.c",
+        "openbsd-reallocarray.c",
+        "quantize.c",
     ],
-    hdrs = ["lib/gif_lib.h"],
+    hdrs = ["gif_lib.h"],
     defines = select({
         ":android": [
             "S_IREAD=S_IRUSR",
@@ -28,7 +28,7 @@ cc_library(
         ],
         "//conditions:default": [],
     }),
-    includes = ["lib/."],
+    includes = ["."],
     visibility = ["//visibility:public"],
     deps = select({
         ":windows": [":windows_polyfill"],

--- a/third_party/gif_fix_strtok_r.patch
+++ b/third_party/gif_fix_strtok_r.patch
@@ -1,0 +1,15 @@
+diff -r -u ./fixed_gif_font.c ./gif_font.c
+--- ./fixed_gif_font.c	2019-09-05 11:05:25.009598262 -0700
++++ ./gif_font.c	2019-09-05 10:52:45.308389085 -0700
+@@ -11,6 +11,11 @@
+
+ #include "gif_lib.h"
+
++// Windows doesn't have strtok_r.
++#if defined(WIN32) || defined(_WIN32) || defined(__WIN32) && !defined(__CYGWIN__)
++#define strtok_r strtok_s
++#endif
++
+ /*****************************************************************************
+  Ascii 8 by 8 regular font - only first 128 characters are supported.
+ *****************************************************************************/


### PR DESCRIPTION
Add a patch file to fix giflib's compilation issue on Windows (replace a call to strtok_r with strtok_s).
Based on PR: #32169.

**NVD**: 2019/08/17 - CVSS v2.0 Base Score: 4.3 - CVSS v3.0 Base Score: 6.5
In GIFLIB before 2019-02-16, a malformed GIF file triggers a divide-by-zero exception in the decoder function DGifSlurp in dgif_lib.c if the height field of the ImageSize data structure is equal to zero.

Source | Link | Type
---- | ---- | ----
MISC | bugs.chromium.org | Mailing List, Third Party Advisory
UBUNTU | usn.ubuntu.com | Third Party Advisory

PiperOrigin-RevId: 267533902