### PR TITLE
[ROCm] fix CSB build

### DIFF
--- a/tensorflow/compiler/tf2xla/BUILD
+++ b/tensorflow/compiler/tf2xla/BUILD
@@ -5,6 +5,7 @@ load(
 )
 load("//tensorflow/compiler/xla:xla.bzl", "xla_proto_library", "xla_py_proto_library")
 load("//tensorflow:tensorflow.bzl", "tf_portable_proto_library")
+load("//tensorflow/stream_executor:build_defs.bzl", "if_cuda_or_rocm")
 
 package(
     default_visibility = [":internal"],
@@ -210,7 +211,7 @@ cc_library(
         "xla_op_registry.cc",
         "xla_resource.cc",
         "xla_cpu_backend.cc",
-    ] + if_cuda_is_configured([
+    ] + if_cuda_or_rocm([
         "xla_gpu_backend.cc",
     ]),
     hdrs = [

--- a/tensorflow/core/nccl/BUILD
+++ b/tensorflow/core/nccl/BUILD
@@ -52,6 +52,7 @@ tf_cuda_cc_test(
     srcs = ["nccl_manager_test.cc"],
     tags = tf_cuda_tests_tags() + [
         "no_cuda_on_cpu_tap",  # TODO(b/120284216): re-enable multi_gpu
+        "rocm_multi_gpu", # this test fails on ROCm unless 4 GPUs are used
     ],
     deps = [
         "//tensorflow/core:test",

--- a/tensorflow/core/nccl/BUILD
+++ b/tensorflow/core/nccl/BUILD
@@ -52,7 +52,7 @@ tf_cuda_cc_test(
     srcs = ["nccl_manager_test.cc"],
     tags = tf_cuda_tests_tags() + [
         "no_cuda_on_cpu_tap",  # TODO(b/120284216): re-enable multi_gpu
-        "rocm_multi_gpu", # this test fails on ROCm unless 4 GPUs are used
+        "rocm_multi_gpu",  # this test fails on ROCm unless 4 GPUs are used
     ],
     deps = [
         "//tensorflow/core:test",

--- a/tensorflow/python/keras/optimizer_v2/BUILD
+++ b/tensorflow/python/keras/optimizer_v2/BUILD
@@ -223,6 +223,7 @@ cuda_py_test(
     shard_count = 8,
     tags = [
         "no_windows",
+        "no_rocm",
     ],
     xla_enable_strict_auto_jit = True,
 )

--- a/tensorflow/python/keras/optimizer_v2/BUILD
+++ b/tensorflow/python/keras/optimizer_v2/BUILD
@@ -222,8 +222,8 @@ cuda_py_test(
     ],
     shard_count = 8,
     tags = [
-        "no_windows",
         "no_rocm",
+        "no_windows",
     ],
     xla_enable_strict_auto_jit = True,
 )

--- a/tensorflow/python/kernel_tests/linalg/linear_operator_circulant_test.py
+++ b/tensorflow/python/kernel_tests/linalg/linear_operator_circulant_test.py
@@ -357,6 +357,11 @@ class LinearOperatorCirculantTestNonHermitianSpectrum(
         self.evaluate(operator.assert_non_singular())
 
   def test_assert_non_singular_does_not_fail_for_non_singular_operator(self):
+
+    if test.is_built_with_rocm():
+      # ROCm does not yet support BLAS operations with complext types
+      self.skipTest("ROCm does not support BLAS operations for complex types")
+
     spectrum = math_ops.cast([-3j, 4 + 0j, 2j + 2], dtypes.complex64)
     operator = linalg.LinearOperatorCirculant(spectrum)
     with self.cached_session():
@@ -656,6 +661,11 @@ class LinearOperatorCirculant3DTest(test.TestCase):
       yield sess
 
   def test_real_spectrum_gives_self_adjoint_operator(self):
+
+    if test.is_built_with_rocm():
+      # ROCm does not yet support BLAS operations with complext types
+      self.skipTest("ROCm does not support BLAS operations for complex types")
+
     with self.cached_session():
       # This is a real and hermitian spectrum.
       spectrum = linear_operator_test_util.random_normal(
@@ -672,6 +682,11 @@ class LinearOperatorCirculant3DTest(test.TestCase):
       self.assertAllClose(matrix, matrix_h)
 
   def test_defining_operator_using_real_convolution_kernel(self):
+
+    if test.is_built_with_rocm():
+      # ROCm does not yet support BLAS operations with complext types
+      self.skipTest("ROCm does not support BLAS operations for complex types")
+
     with self.cached_session():
       convolution_kernel = linear_operator_test_util.random_normal(
           shape=(2, 2, 3, 5), dtype=dtypes.float32)
@@ -690,6 +705,11 @@ class LinearOperatorCirculant3DTest(test.TestCase):
       np.testing.assert_allclose(0, np.imag(matrix), atol=1e-5)
 
   def test_defining_spd_operator_by_taking_real_part(self):
+
+    if test.is_built_with_rocm():
+      # ROCm does not yet support BLAS operations with complext types
+      self.skipTest("ROCm does not support BLAS operations for complex types")
+
     with self.cached_session():  # Necessary for fft_kernel_label_map
       # S is real and positive.
       s = linear_operator_test_util.random_uniform(

--- a/tensorflow/tools/ci_build/linux/rocm/run_csb_tests.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_csb_tests.sh
@@ -35,10 +35,11 @@ export TF_GPU_COUNT=${N_GPUS}
 yes "" | $PYTHON_BIN_PATH configure.py
 
 # Run bazel test command. Double test timeouts to avoid flakes.
+# Run tests requiring more than one GPU separately.
 bazel test \
       --config=rocm \
       -k \
-      --test_tag_filters=gpu,-no_gpu,-no_rocm,-benchmark-test,-no_oss,-oss_serial, \
+      --test_tag_filters=gpu,-no_gpu,-no_rocm,-benchmark-test,-no_oss,-oss_serial,-rocm_multi_gpu, \
       --test_timeout 600,900,2400,7200 \
       --test_output=errors \
       --jobs=${N_JOBS} \
@@ -51,6 +52,20 @@ bazel test \
       -//tensorflow/contrib/... \
       -//tensorflow/lite/... \
       -//tensorflow/python/compiler/tensorrt/... \
-
-
+&& \
+bazel test \
+      --config=rocm \
+      -k \
+      --test_tag_filters=rocm_multi_gpu, \
+      --test_timeout 600,900,2400,7200 \
+      --test_output=errors \
+      --jobs=${N_JOBS} \
+      --local_test_jobs=1 \
+      --test_sharding_strategy=disabled \
+      -- \
+      //tensorflow/... \
+      -//tensorflow/compiler/... \
+      -//tensorflow/contrib/... \
+      -//tensorflow/lite/... \
+      -//tensorflow/python/compiler/tensorrt/... \
 

--- a/tensorflow/tools/ci_build/linux/rocm/run_csb_tests.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_csb_tests.sh
@@ -56,7 +56,7 @@ bazel test \
 bazel test \
       --config=rocm \
       -k \
-      --test_tag_filters=rocm_multi_gpu, \
+      --test_tag_filters=-no_rocm,rocm_multi_gpu, \
       --test_timeout 600,900,2400,7200 \
       --test_output=errors \
       --jobs=${N_JOBS} \


### PR DESCRIPTION
Co-authored with @deven-amd.  This PR fixes recent failures in the Linux AMD ROCm GPU Nightly CSB build.  This PR does not depend on https://github.com/tensorflow/tensorflow/pull/32296, however that PR is also required before CSB build is successful again.