### PR TITLE
[r1.15 CherryPick]: [INTEL-MKL] Use tf_opts when compiling MKL related eager files.

### DIFF
--- a/tensorflow/core/common_runtime/eager/BUILD
+++ b/tensorflow/core/common_runtime/eager/BUILD
@@ -1,6 +1,7 @@
 load(
     "//tensorflow:tensorflow.bzl",
     "tf_cc_test",
+    "tf_copts",
     "tf_cuda_library",
 )
 load(
@@ -276,6 +277,8 @@ cc_library(
 cc_library(
     name = "mkl_eager_op_rewrite",
     srcs = ["mkl_eager_op_rewrite.cc"],
+    copts = tf_copts(),
+    nocopts = "-fno-exceptions",
     deps = [
         ":eager_op_rewrite_registry",
         "//tensorflow/core:framework",


### PR DESCRIPTION
MKL ops was accidentally disabled in eager mode (my bad!). This PR re-enables MKL ops in eager mode. Context: https://github.com/tensorflow/tensorflow/pull/32317