### PR TITLE
Quantile Huber Loss to predict Specific Quantile Value

### DIFF
--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 import abc
 
 import six
+import numpy as np
 
 from tensorflow.python.distribute import distribution_strategy_context
 from tensorflow.python.framework import ops
@@ -744,6 +745,46 @@ class Huber(LossFunctionWrapper):
         huber_loss, name=name, reduction=reduction, delta=delta)
 
 
+class QuantileHuber(LossFunctionWrapper):
+  """Computes the Huber loss between `y_true` and `y_pred` considering quantiles.
+
+  Given `x = y_true - y_pred`:
+  ```
+  loss = q * |x| - 0.5 * d * q^2                if  x  <  -1*q*d
+  loss = (0.5 * x)/d                            if  x  >= -1*q*d & x<= (1-q)*d
+  loss = (1 - q) * |x| - 0.5 * d * (1 - q)^2    if  x  >  (1-q)*d
+  ```
+  where d is `delta` and q is `quantile`.  See: https://arxiv.org/pdf/1402.4624.pdf
+
+  Usage with the `compile` API:
+
+  ```python
+  model = tf.keras.Model(inputs, outputs)
+  model.compile('sgd', loss=tf.keras.losses.QuantileHuber())
+  ```
+
+  Args:
+    delta: A float, the point where the Huber loss function changes from a
+        quadratic to linear
+    quantile: A float, between 0 and 1. The loss function will try to update the
+        weights of model such that final result will be the quantile fraction of
+        the actual output.
+    reduction: (Optional) Type of reduction to apply to loss.
+    name: Optional name for the object.
+
+  Returns:
+    Tensor with one quantile scalar loss entry per sample.
+  """
+  def __init__(self,
+               delta=1.0,
+               quantile=0.5,
+               reduction=losses_utils.Reduction.SUM_OVER_BATCH_SIZE,
+               name='quantile_huber_loss'):
+      super(QuantileHuber, self).__init__(
+          quantile_huber_loss, name=name, reduction=reduction,
+          delta=delta, quantile=quantile)
+
+
 @keras_export('keras.metrics.mean_squared_error',
               'keras.metrics.mse',
               'keras.metrics.MSE',
@@ -888,6 +929,40 @@ def huber_loss(y_true, y_pred, delta=1.0):
           ops.convert_to_tensor(0.5, dtype=quadratic.dtype),
           math_ops.multiply(quadratic, quadratic)),
       math_ops.multiply(delta, linear))
+
+
+def quantile_huber_loss(y_true, y_pred, delta=1.0, quantile=0.5):
+  """Computes the Huber loss between `y_true` and `y_pred` considering quantiles.
+
+  Given `x = y_true - y_pred`:
+  ```
+  loss = q * |x| - 0.5 * d * q^2                if  x  <  -1*q*d
+  loss = (0.5 * x)/d                            if  x  >= -1*q*d & x<= (1-q)*d
+  loss = (1 - q) * |x| - 0.5 * d * (1 - q)^2    if  x  >  (1-q)*d
+  ```
+  where d is `delta` and q is `quantile`.  See: https://arxiv.org/pdf/1402.4624.pdf
+
+  Args:
+    delta: A float, the point where the Huber loss function changes from a
+        quadratic to linear
+    quantile: A float, between 0 and 1. The loss function will try to update the
+        weights of model such that final result will be the quantile fraction of
+        the actual output.
+    reduction: (Optional) Type of reduction to apply to loss.
+    name: Optional name for the object.
+
+  Returns:
+    Tensor with one quantile scalar loss entry per sample.
+  """
+  error = y_true - y_pred
+  big_op = (1.0 - quantile) * K.abs(error) - 0.5 * delta * (1.0 - quantile)**2
+  mid_op = (error * error) / (2 * delta)
+  small_op = quantile * K.abs(error) - 0.5 * delta * quantile**2
+  cond1 = K.less_equal(error, (1 - quantile) * delta)
+  result_cond1 = np.where(K.eval(cond1), K.eval(mid_op), K.eval(big_op))
+  cond2 = K.less(error, -1.0 * quantile * delta)
+  result_cond2 = np.where(K.eval(cond2), K.eval(small_op), result_cond1)
+  return K.variable(np.sum(result_cond2, axis=-1))
 
 
 @keras_export('keras.losses.logcosh')


### PR DESCRIPTION
We know that we have huber loss function added in keras tf-2 already which can perform both kind of behaviour MSE and MAE depending on the scale of data. In most of the prediction and analysis models, we often do not need just median or mean predicted value, but we also need the specific quantile value of prediction. This is the loss function I am adding which is derived from **huber_loss** here
[https://arxiv.org/pdf/1402.4624.pdf](https://arxiv.org/pdf/1402.4624.pdf). I name it **quantile_huber_loss** and the class which calls it is QuantileHuber. I have given great attention to the detail in implementing the function. function takes two extra arguements delta and quantile, where delta is common as the huber_loss and quantile is the float number between 0 and 1. Equation looks as below.
![qhuber_form](https://user-images.githubusercontent.com/20843596/64757745-9a0aa680-d550-11e9-8568-e90471e73f56.png)
