### PR TITLE
Handle the case where axis is a tuple.

### DIFF
--- a/tensorflow/python/keras/layers/normalization.py
+++ b/tensorflow/python/keras/layers/normalization.py
@@ -954,6 +954,8 @@ class LayerNormalization(Layer):
     # Convert axis to list and resolve negatives
     if isinstance(self.axis, int):
       self.axis = [self.axis]
+    elif isinstance(self.axis, tuple):
+      self.axis = list(self.axis)
     for idx, x in enumerate(self.axis):
       if x < 0:
         self.axis[idx] = ndims + x

--- a/tensorflow/python/keras/layers/normalization_test.py
+++ b/tensorflow/python/keras/layers/normalization_test.py
@@ -539,6 +539,10 @@ class LayerNormalizationTest(keras_parameterized.TestCase):
         kwargs={'scale': False,
                 'center': False},
         input_shape=(3, 3))
+    testing_utils.layer_test(
+        keras.layers.LayerNormalization,
+        kwargs={'axis': (-3, -2, -1)},
+        input_shape=(64, 64, 3))
 
   @tf_test_util.run_in_graph_and_eager_modes
   def test_layernorm_weights(self):

--- a/tensorflow/python/keras/layers/normalization_test.py
+++ b/tensorflow/python/keras/layers/normalization_test.py
@@ -542,7 +542,7 @@ class LayerNormalizationTest(keras_parameterized.TestCase):
     testing_utils.layer_test(
         keras.layers.LayerNormalization,
         kwargs={'axis': (-3, -2, -1)},
-        input_shape=(64, 64, 3))
+        input_shape=(2, 8, 8, 3))
 
   @tf_test_util.run_in_graph_and_eager_modes
   def test_layernorm_weights(self):


### PR DESCRIPTION
Previously the code only handled ints and lists as axis. Gave an error `TypeError: 'tuple' object does not support item assignment` when giving tuple as axis argument. See this issue https://github.com/tensorflow/tensorflow/issues/32311