### PR TITLE
[ppc64le] Undo setting of OMP_NUM_THREADS

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1349,13 +1349,6 @@ def main():
   else:
     environ_cp['TF_CONFIGURE_IOS'] = '0'
 
-  # The numpy package on ppc64le uses OpenBLAS which has multi-threading
-  # issues that lead to incorrect answers.  Set OMP_NUM_THREADS=1 at
-  # runtime to allow the Tensorflow testcases which compare numpy
-  # results to Tensorflow results to succeed.
-  if is_ppc64le():
-    write_action_env_to_bazelrc('OMP_NUM_THREADS', 1)
-
   xla_enabled_by_default = is_linux() or is_macos()
   set_build_var(environ_cp, 'TF_ENABLE_XLA', 'XLA JIT', 'with_xla_support',
                 xla_enabled_by_default, 'xla')


### PR DESCRIPTION
This check was added because libopenblas on Power had threading
issues if OMP_NUM_THREADS was set higher than 1. This has been
fixed in all the latest versions of libopenblas and this check
is no longer needed.