### PR TITLE
[INTEL MKL]Fixing spurious omp thread spawning

### DIFF
--- a/tensorflow/compiler/xla/service/cpu/BUILD
+++ b/tensorflow/compiler/xla/service/cpu/BUILD
@@ -561,7 +561,7 @@ cc_library(
         "runtime_conv2d_mkl.cc",
     ],
     hdrs = ["runtime_conv2d_mkl.h"],
-    copts = runtime_copts(),
+    copts = runtime_copts() + tf_openmp_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":runtime_conv2d",

--- a/tensorflow/compiler/xla/service/cpu/BUILD
+++ b/tensorflow/compiler/xla/service/cpu/BUILD
@@ -6,7 +6,7 @@ load(
     "//third_party/mkl:build_defs.bzl",
     "mkl_deps",
 )
-load("//tensorflow:tensorflow.bzl", "tf_cc_binary", "tf_cc_test")
+load("//tensorflow:tensorflow.bzl", "tf_cc_binary", "tf_cc_test", "tf_openmp_copts")
 load(":build_defs.bzl", "runtime_copts")
 
 package(
@@ -621,7 +621,7 @@ cc_library(
     name = "runtime_matmul_mkl",
     srcs = ["runtime_matmul_mkl.cc"],
     hdrs = ["runtime_matmul_mkl.h"],
-    copts = runtime_copts(),
+    copts = runtime_copts() + tf_openmp_copts(),
     visibility = ["//visibility:public"],
     deps = [
         "//tensorflow/compiler/xla:executable_run_options",

--- a/tensorflow/compiler/xla/service/cpu/BUILD
+++ b/tensorflow/compiler/xla/service/cpu/BUILD
@@ -561,7 +561,7 @@ cc_library(
         "runtime_conv2d_mkl.cc",
     ],
     hdrs = ["runtime_conv2d_mkl.h"],
-    copts = runtime_copts() + tf_openmp_copts(),
+    copts = runtime_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":runtime_conv2d",

--- a/tensorflow/compiler/xla/service/cpu/BUILD
+++ b/tensorflow/compiler/xla/service/cpu/BUILD
@@ -561,7 +561,7 @@ cc_library(
         "runtime_conv2d_mkl.cc",
     ],
     hdrs = ["runtime_conv2d_mkl.h"],
-    copts = runtime_copts(),
+    copts = runtime_copts() + tf_openmp_copts(),
     visibility = ["//visibility:public"],
     deps = [
         ":runtime_conv2d",
@@ -621,7 +621,7 @@ cc_library(
     name = "runtime_matmul_mkl",
     srcs = ["runtime_matmul_mkl.cc"],
     hdrs = ["runtime_matmul_mkl.h"],
-    copts = runtime_copts() + tf_openmp_copts(),
+    copts = runtime_copts(),
     visibility = ["//visibility:public"],
     deps = [
         "//tensorflow/compiler/xla:executable_run_options",

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -73,6 +73,7 @@ load(
     "if_mobile",
     "if_not_windows",
     "if_windows",
+    "tf_openmp_copts",
     "tf_android_core_proto_headers",
     "tf_android_core_proto_sources",
     "tf_cc_test",
@@ -3240,7 +3241,7 @@ tf_cuda_library(
         "public/version.h",
     ],
     hdrs = CORE_CPU_LIB_HEADERS,
-    copts = tf_copts(),
+    copts = tf_copts() + tf_openmp_copts(),
     deps = [
         ":bfc_allocator",
         ":graph",

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -295,7 +295,6 @@ def tf_copts(
         if_mkl_v1_open_source_only(["-DENABLE_MKLDNN_V1"]) +
         if_enable_mkl(["-DENABLE_MKL"]) +
         if_ngraph(["-DINTEL_NGRAPH=1"]) +
-        if_mkl_lnx_x64(["-fopenmp"]) +
         if_android_arm(["-mfpu=neon"]) +
         if_linux_x86_64(["-msse3"]) +
         if_ios_x86_64(["-msse4.1"]) +
@@ -312,6 +311,8 @@ def tf_copts(
             "//conditions:default": ["-pthread"],
         })
     )
+def tf_openmp_copts():
+    return if_mkl_lnx_x64(["-fopenmp"])
 
 def tfe_xla_copts():
     return select({
@@ -1200,7 +1201,7 @@ def tf_cc_test_mkl(
         native.cc_test(
             name = src_to_test_name(src),
             srcs = if_mkl([src]) + tf_binary_additional_srcs(),
-            copts = tf_copts(allow_exceptions = True),
+            copts = tf_copts(allow_exceptions = True) + tf_openmp_copts(),
             linkopts = select({
                 clean_dep("//tensorflow:android"): [
                     "-pie",
@@ -1506,7 +1507,7 @@ def tf_mkl_kernel_library(
         hdrs = None,
         deps = None,
         alwayslink = 1,
-        copts = tf_copts(allow_exceptions = True)):
+        copts = tf_copts(allow_exceptions = True) + tf_openmp_copts()):
     """A rule to build MKL-based TensorFlow kernel libraries."""
 
     if not bool(srcs):

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -311,6 +311,7 @@ def tf_copts(
             "//conditions:default": ["-pthread"],
         })
     )
+
 def tf_openmp_copts():
     return if_mkl_lnx_x64(["-fopenmp"])
 


### PR DESCRIPTION
In some models that use eager/imperative code where we don’t rewrite a few operators to MKL, a lot (intra_op_threads*OMP_NUM_THREADS) of threads are spawned by Eigen matmul code. This is because -fopenmp flag is passed to Eigen as part of the build configuration. This PR fixes the configuration to not pass -fopenmp to Eigen under --config=mkl.