### PR TITLE
Implement test for avg. pool into TFLu - Int8

### DIFF
--- a/tensorflow/lite/experimental/micro/kernels/pooling.cc
+++ b/tensorflow/lite/experimental/micro/kernels/pooling.cc
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 #include "tensorflow/lite/kernels/internal/reference/pooling.h"
+#include "tensorflow/lite/kernels/internal/reference/integer_ops/pooling.h"
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
@@ -94,6 +95,27 @@ void AverageEvalUint8(const TfLiteContext* context, const TfLiteNode* node,
       GetTensorShape(output), GetTensorData<uint8_t>(output));
 }
 
+void AverageEvalInt8(const TfLiteContext* context, const TfLiteNode* node,
+                     const TfLitePoolParams* params, const OpData* data,
+                     const TfLiteTensor* input, TfLiteTensor* output) {
+  int32_t activation_min, activation_max;
+  CalculateActivationRangeInt8(params->activation, output, &activation_min,
+                               &activation_max);
+
+  PoolParams op_params;
+  op_params.stride_height = params->stride_height;
+  op_params.stride_width = params->stride_width;
+  op_params.filter_height = params->filter_height;
+  op_params.filter_width = params->filter_width;
+  op_params.padding_values.height = data->padding.height;
+  op_params.padding_values.width = data->padding.width;
+  op_params.quantized_activation_min = activation_min;
+  op_params.quantized_activation_max = activation_max;
+  reference_integer_ops::AveragePool(
+      op_params, GetTensorShape(input), GetTensorData<int8_t>(input),
+      GetTensorShape(output), GetTensorData<int8_t>(output));
+}
+
 void MaxEvalFloat(TfLiteContext* context, TfLiteNode* node,
                   TfLitePoolParams* params, OpData* data,
                   const TfLiteTensor* input, TfLiteTensor* output) {
@@ -164,6 +186,9 @@ TfLiteStatus AverageEval(TfLiteContext* context, TfLiteNode* node) {
       break;
     case kTfLiteUInt8:
       AverageEvalUint8(context, node, params, &data, input, output);
+      break;
+    case kTfLiteInt8:
+      AverageEvalInt8(context, node, params, &data, input, output);
       break;
     default:
       context->ReportError(context, "Input type %s is not currently supported",

--- a/tensorflow/lite/experimental/micro/kernels/pooling_test.cc
+++ b/tensorflow/lite/experimental/micro/kernels/pooling_test.cc
@@ -165,6 +165,77 @@ void TestAveragePoolingUint8(
   }
 }
 
+void TestAveragePoolingInt8(
+    std::initializer_list<int> input_dims_data,
+    std::initializer_list<int8_t> input_data, const float input_min,
+    const float input_max, const int filter_height, const int filter_width,
+    const int stride_height, const int stride_width,
+    std::initializer_list<int8_t> expected_output_data,
+    std::initializer_list<int> output_dims_data, float output_min,
+    float output_max, TfLitePadding padding, TfLiteFusedActivation activation,
+    int8_t* output_data) {
+  TfLiteIntArray* input_dims = IntArrayFromInitializer(input_dims_data);
+  TfLiteIntArray* output_dims = IntArrayFromInitializer(output_dims_data);
+  const int output_dims_count = ElementCount(*output_dims);
+
+  constexpr int inputs_size = 1;
+  constexpr int outputs_size = 1;
+  constexpr int tensors_size = inputs_size + outputs_size;
+  TfLiteTensor tensors[tensors_size] = {
+      CreateQuantizedTensor(input_data, input_dims, "input_tensor", input_min,
+                            input_max),
+      CreateQuantizedTensor(output_data, output_dims, "output_tensor",
+                            output_min, output_max),
+  };
+
+  TfLiteContext context;
+  PopulateContext(tensors, tensors_size, &context);
+
+  ::tflite::ops::micro::AllOpsResolver resolver;
+  const TfLiteRegistration* registration =
+      resolver.FindOp(tflite::BuiltinOperator_AVERAGE_POOL_2D, 1);
+  TF_LITE_MICRO_EXPECT_NE(nullptr, registration);
+
+  TfLiteConvParams builtin_data = {padding,      stride_width,  stride_height,
+                                   filter_width, filter_height, activation};
+  const char* init_data = reinterpret_cast<const char*>(&builtin_data);
+  size_t init_data_size = 0;
+  void* user_data = nullptr;
+  if (registration->init) {
+    user_data = registration->init(&context, init_data, init_data_size);
+  }
+  int inputs_array_data[] = {1, 0};
+  TfLiteIntArray* inputs_array = IntArrayFromInts(inputs_array_data);
+  int outputs_array_data[] = {1, 1};
+  TfLiteIntArray* outputs_array = IntArrayFromInts(outputs_array_data);
+  int temporaries_array_data[] = {0};
+  TfLiteIntArray* temporaries_array = IntArrayFromInts(temporaries_array_data);
+
+  TfLiteNode node;
+  node.inputs = inputs_array;
+  node.outputs = outputs_array;
+  node.temporaries = temporaries_array;
+  node.user_data = user_data;
+  node.builtin_data = reinterpret_cast<void*>(&builtin_data);
+  node.custom_initial_data = nullptr;
+  node.custom_initial_data_size = 0;
+  node.delegate = nullptr;
+
+  if (registration->prepare) {
+    TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, registration->prepare(&context, &node));
+  }
+  TF_LITE_MICRO_EXPECT_NE(nullptr, registration->invoke);
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, registration->invoke(&context, &node));
+  if (registration->free) {
+    registration->free(&context, user_data);
+  }
+
+  for (int i = 0; i < output_dims_count; ++i) {
+    TF_LITE_MICRO_EXPECT_NEAR(expected_output_data.begin()[i], output_data[i],
+                              1e-5f);
+  }
+}
+
 void TestMaxPoolFloat(std::initializer_list<int> input_dims_data,
                       std::initializer_list<float> input_data, int filter_width,
                       int filter_height, int stride_width, int stride_height,
@@ -361,6 +432,183 @@ TF_LITE_MICRO_TEST(SimpleAveragePoolTestUint8) {
       {4, 1, 1, 2, 1},         // Output shape
       output_min, output_max,  // output quantization range
       kTfLitePaddingValid, kTfLiteActRelu, output_data);
+}
+
+TF_LITE_MICRO_TEST(SimpleAveragePoolTestInt8PaddingValidStride2ActNone) {
+  using tflite::testing::F2QS;
+
+  const float input_min = -15.9375;
+  const float input_max = 15.8130;
+  const float output_min = -15.9375;
+  const float output_max = 15.8130;
+  int8_t output_data[2];
+  tflite::testing::TestAveragePoolingInt8(
+      {4, 1, 2, 4, 1},  // Input shape
+      {
+          // Input values
+          F2QS(0., input_min, input_max),
+          F2QS(-6., input_min, input_max),
+          F2QS(2., input_min, input_max),
+          F2QS(4., input_min, input_max),
+          F2QS(3., input_min, input_max),
+          F2QS(2., input_min, input_max),
+          F2QS(-10., input_min, input_max),
+          F2QS(7., input_min, input_max)
+      },
+      input_min, input_max,  // input quantization range
+      2, 2,                  // filter height, filter width
+      2, 2,                  // stride height, stride width
+      {
+          // Output values
+          F2QS(-0.25, output_min, output_max),
+          F2QS(0.75, output_min, output_max)
+      },
+      {4, 1, 1, 2, 1},         // Output shape
+      output_min, output_max,  // output quantization range
+      kTfLitePaddingValid, kTfLiteActNone, output_data);
+}
+
+TF_LITE_MICRO_TEST(SimpleAveragePoolTestInt8PaddingValidStride1Stride2Relu) {
+  using tflite::testing::F2QS;
+
+  const float input_min = -15.9375;
+  const float input_max = 15.8130;
+  const float output_min = -15.9375;
+  const float output_max = 15.8130;
+  int8_t output_data[3];
+  tflite::testing::TestAveragePoolingInt8(
+      {4, 1, 2, 4, 1},  // Input shape
+      {
+          // Input values
+          F2QS(0., input_min, input_max),
+          F2QS(-6., input_min, input_max),
+          F2QS(2., input_min, input_max),
+          F2QS(4., input_min, input_max),
+          F2QS(3., input_min, input_max),
+          F2QS(2., input_min, input_max),
+          F2QS(-10., input_min, input_max),
+          F2QS(7., input_min, input_max)
+      },
+      input_min, input_max,  // input quantization range
+      2, 2,                  // filter height, filter width
+      2, 1,                  // stride height, stride width
+      {
+          // Output values
+          F2QS(0., output_min, output_max),
+          F2QS(0., output_min, output_max),
+          F2QS(0.75, output_min, output_max)
+      },
+      {4, 1, 1, 3, 1},         // Output shape
+      output_min, output_max,  // output quantization range
+      kTfLitePaddingValid, kTfLiteActRelu, output_data);
+}
+
+TF_LITE_MICRO_TEST(SimpleAveragePoolTestInt8PaddingValidStride2Stride1Relu1) {
+  using tflite::testing::F2QS;
+
+  const float input_min = -15.9375;
+  const float input_max = 15.8130;
+  const float output_min = -15.9375;
+  const float output_max = 15.8130;
+  int8_t output_data[2];
+  tflite::testing::TestAveragePoolingInt8(
+      {4, 1, 2, 4, 1},  // Input shape
+      {
+          // Input values
+          F2QS(0., input_min, input_max),
+          F2QS(-6., input_min, input_max),
+          F2QS(2., input_min, input_max),
+          F2QS(4., input_min, input_max),
+          F2QS(3., input_min, input_max),
+          F2QS(2., input_min, input_max),
+          F2QS(-10., input_min, input_max),
+          F2QS(7., input_min, input_max)
+      },
+      input_min, input_max,  // input quantization range
+      2, 2,                  // filter height, filter width
+      1, 2,                  // stride height, stride width
+      {
+          // Output values
+          F2QS(-0.25, output_min, output_max),
+          F2QS(0.75, output_min, output_max)
+      },
+      {4, 1, 1, 2, 1},         // Output shape
+      output_min, output_max,  // output quantization range
+      kTfLitePaddingValid, kTfLiteActRelu1, output_data);
+}
+
+TF_LITE_MICRO_TEST(SimpleAveragePoolTestInt8PaddingValidStride2Relu6) {
+  using tflite::testing::F2QS;
+
+  const float input_min = -15.9375;
+  const float input_max = 15.8130;
+  const float output_min = -15.9375;
+  const float output_max = 15.8130;
+  int8_t output_data[2];
+  tflite::testing::TestAveragePoolingInt8(
+      {4, 1, 2, 4, 1},  // Input shape
+      {
+          // Input values
+          F2QS(3., input_min, input_max),
+          F2QS(-6., input_min, input_max),
+          F2QS(8., input_min, input_max),
+          F2QS(4., input_min, input_max),
+          F2QS(3., input_min, input_max),
+          F2QS(2., input_min, input_max),
+          F2QS(10., input_min, input_max),
+          F2QS(7., input_min, input_max)
+      },
+      input_min, input_max,  // input quantization range
+      2, 2,                  // filter height, filter width
+      2, 2,                  // stride height, stride width
+      {
+          // Output values
+          F2QS(0.5, output_min, output_max),
+          F2QS(6., output_min, output_max)
+      },
+      {4, 1, 1, 2, 1},         // Output shape
+      output_min, output_max,  // output quantization range
+      kTfLitePaddingValid, kTfLiteActRelu6, output_data);
+}
+
+TF_LITE_MICRO_TEST(SimpleAveragePoolTestInt8PaddingSameStride1ActNone) {
+  using tflite::testing::F2QS;
+
+  const float input_min = -15.9375;
+  const float input_max = 15.8130;
+  const float output_min = -15.9375;
+  const float output_max = 15.8130;
+  int8_t output_data[8];
+  tflite::testing::TestAveragePoolingInt8(
+      {4, 1, 2, 4, 1},  // Input shape
+      {
+          // Input values
+          F2QS(3., input_min, input_max),
+          F2QS(-6., input_min, input_max),
+          F2QS(8., input_min, input_max),
+          F2QS(4., input_min, input_max),
+          F2QS(3., input_min, input_max),
+          F2QS(2., input_min, input_max),
+          F2QS(10., input_min, input_max),
+          F2QS(7., input_min, input_max)
+      },
+      input_min, input_max,  // input quantization range
+      2, 2,                  // filter height, filter width
+      1, 1,                  // stride height, stride width
+      {
+          // Output values
+          F2QS(0.5, output_min, output_max),
+          F2QS(3.5, output_min, output_max),
+          F2QS(7.25, output_min, output_max),
+          F2QS(5.5, output_min, output_max),
+          F2QS(2.5, output_min, output_max),
+          F2QS(6., output_min, output_max),
+          F2QS(8.5, output_min, output_max),
+          F2QS(7., output_min, output_max)
+      },
+      {4, 1, 2, 4, 1},         // Output shape
+      output_min, output_max,  // output quantization range
+      kTfLitePaddingValid, kTfLiteActNone, output_data);
 }
 
 TF_LITE_MICRO_TEST(SimpleMaxPoolTestFloat) {

--- a/tensorflow/lite/experimental/micro/tools/make/Makefile
+++ b/tensorflow/lite/experimental/micro/tools/make/Makefile
@@ -132,6 +132,7 @@ tensorflow/lite/kernels/internal/reference/process_broadcast_shapes.h \
 tensorflow/lite/kernels/internal/reference/round.h \
 tensorflow/lite/kernels/internal/reference/softmax.h \
 tensorflow/lite/kernels/internal/reference/strided_slice.h \
+tensorflow/lite/kernels/internal/reference/integer_ops/pooling.h \
 tensorflow/lite/kernels/internal/round.h \
 tensorflow/lite/kernels/internal/strided_slice_logic.h \
 tensorflow/lite/kernels/internal/tensor.h \


### PR DESCRIPTION
This patch adds tests in TFLu for average pooling Int8. Five more tests have been integrate into pooling_test.cc:

These tests will cover:

- Different fused activation (Relu, Relu1 and Relu6)
- Different output shapes
- Different strides
- Different paddings

The min and max value used for quantizing (-15.9375, 15.8130 respectively) have been chosen in order to have the dequantized output equal to the floating point one.

