### PR TITLE
Pin tensorflow_estimator to 1.15.1

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -63,7 +63,7 @@ REQUIRED_PACKAGES = [
     'six >= 1.10.0',
     'protobuf >= 3.6.1',
     'tensorboard >= 1.15.0, < 1.16.0',
-    'tf-estimator-nightly >= 1.14.0.dev2019090401, < 1.14.0.dev2019090402',
+    'tensorflow-estimator == 1.15.1',
     'termcolor >= 1.1.0',
     'wrapt >= 1.11.1',
 ]


### PR DESCRIPTION
As this is the last TF release in 1.15 series and Estimator 1.15.1 is
the corresponding last Estimator release, we pin it using `==`.