### PR TITLE
add rocm into build info flags

### DIFF
--- a/tensorflow/contrib/cmake/CMakeLists.txt
+++ b/tensorflow/contrib/cmake/CMakeLists.txt
@@ -555,7 +555,8 @@ if (tensorflow_ENABLE_GPU)
   # NOTE(mrry): Update these flags when the version of CUDA or cuDNN used
   # in the default build is upgraded.
   if(WIN32)
-    set(tensorflow_BUILD_INFO_FLAGS --build_config cuda --key_value
+    set(tensorflow_BUILD_INFO_FLAGS
+      --is_config_cuda True --is_config_rocm False --key_value
       msvcp_dll_name=msvcp140.dll
       cudart_dll_name=cudart64_${short_CUDA_VER}.dll
       cuda_version_number=${CUDA_VERSION}
@@ -563,7 +564,8 @@ if (tensorflow_ENABLE_GPU)
       cudnn_dll_name=cudnn64_${tensorflow_CUDNN_VERSION}.dll
       cudnn_version_number=${tensorflow_CUDNN_VERSION})
   else(WIN32)
-    set(tensorflow_BUILD_INFO_FLAGS --build_config cuda --key_value
+    set(tensorflow_BUILD_INFO_FLAGS
+      --is_config_cuda True --is_config_rocm False --key_value
       cuda_version_number=${CUDA_VERSION}
       cudnn_version_number=${tensorflow_CUDNN_VERSION})
   endif(WIN32)


### PR DESCRIPTION
This is a bug fix from JIZHI, the AI platform in Tencent.

@deven-amd
Below bug is caused by build_config_info changed from "--build_config cuda" to "--is_config_cuda True", but miss the file tensorflow/contrib/cmake/CMakeLists.txt
 
 
ERROR: /tensorflow-rep/tensorflow/python/BUILD:199:1: Executing genrule //tensorflow/python:py_build_info_gen failed (Exit 2): bash failed: error executing command 
  (cd /xxxxxxxxxx/execroot/org_tensorflow && \
  exec env - \
    LD_LIBRARY_PATH=/usr/local/cuda/extras/CUPTI/lib64/:/usr/local/cuda/lib64:/usr/local/nccl_2.4.7-1+cuda10.0_x86_64/lib:/usr/local/lib64 \
    PATH=/usr/local/cuda/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/ibutils/bin:/root/.ft:/root/bin:/root/.ft \
  /bin/bash -c 'source external/bazel_tools/tools/genrule/genrule-setup.sh; bazel-out/host/bin/tensorflow/tools/build_info/gen_build_info --raw_generate "bazel-out/host/bin/tensorflow/python/platform/build_info.py"  --is_config_cuda True --is_config_rocm False --key_value  cuda_version_number=${TF_CUDA_VERSION:-} cudnn_version_number=${TF_CUDNN_VERSION:-} ')
Execution platform: @bazel_tools//platforms:host_platform
usage: gen_build_info.py [-h] [--build_config BUILD_CONFIG]
                         [--raw_generate RAW_GENERATE]
                         [--key_value [KEY_VALUE [KEY_VALUE ...]]]
gen_build_info.py: error: unrecognized arguments: --is_config_cuda True --is_config_rocm False
Target //tensorflow/tools/pip_package:build_pip_package failed to build