### PR TITLE
[Intel MKL] Disable "Conv3D with stride > 1" cases.

### DIFF
--- a/tensorflow/python/kernel_tests/conv_ops_3d_test.py
+++ b/tensorflow/python/kernel_tests/conv_ops_3d_test.py
@@ -225,8 +225,9 @@ class Conv3DTest(test.TestCase):
 
   def testConv3D1x1x1Filter2x1x1Dilation(self):
     ctx = context.context()
-    is_eager = ctx is not None and ctx._thread_local_data.is_eager
-    if test.is_gpu_available(cuda_only=True) or test_util.IsMklEnabled() and is_eager is False:
+    is_eager = ctx is not None and ctx.executing_eagerly()
+    if test.is_gpu_available(cuda_only=True) or \
+      test_util.IsMklEnabled() and is_eager is False:
       self._VerifyDilatedConvValues(
           tensor_in_sizes=[1, 3, 6, 1, 1],
           filter_in_sizes=[1, 1, 1, 1, 1],
@@ -252,8 +253,9 @@ class Conv3DTest(test.TestCase):
 
   def testConv3D2x2x2Filter1x2x1Dilation(self):
     ctx = context.context()
-    is_eager = ctx is not None and ctx._thread_local_data.is_eager
-    if test.is_gpu_available(cuda_only=True) or test_util.IsMklEnabled() and is_eager is False:
+    is_eager = ctx is not None and ctx.executing_eagerly()
+    if test.is_gpu_available(cuda_only=True) or \
+      test_util.IsMklEnabled() and is_eager is False:
       self._VerifyDilatedConvValues(
           tensor_in_sizes=[1, 4, 6, 3, 1],
           filter_in_sizes=[2, 2, 2, 1, 1],

--- a/tensorflow/python/kernel_tests/conv_ops_3d_test.py
+++ b/tensorflow/python/kernel_tests/conv_ops_3d_test.py
@@ -32,6 +32,7 @@ from tensorflow.python.ops import nn_ops
 import tensorflow.python.ops.nn_grad  # pylint: disable=unused-import
 from tensorflow.python.platform import test
 from tensorflow.python.util.compat import collections_abc
+from tensorflow.python.eager import context
 
 
 def GetTestConfigs():
@@ -223,7 +224,9 @@ class Conv3DTest(test.TestCase):
         expected=expected_output)
 
   def testConv3D1x1x1Filter2x1x1Dilation(self):
-    if test.is_gpu_available(cuda_only=True) or test_util.IsMklEnabled():
+    ctx = context.context()
+    is_eager = ctx is not None and ctx._thread_local_data.is_eager
+    if test.is_gpu_available(cuda_only=True) or test_util.IsMklEnabled() and is_eager is False:
       self._VerifyDilatedConvValues(
           tensor_in_sizes=[1, 3, 6, 1, 1],
           filter_in_sizes=[1, 1, 1, 1, 1],
@@ -248,7 +251,9 @@ class Conv3DTest(test.TestCase):
         expected=expected_output)
 
   def testConv3D2x2x2Filter1x2x1Dilation(self):
-    if test.is_gpu_available(cuda_only=True) or test_util.IsMklEnabled():
+    ctx = context.context()
+    is_eager = ctx is not None and ctx._thread_local_data.is_eager
+    if test.is_gpu_available(cuda_only=True) or test_util.IsMklEnabled() and is_eager is False:
       self._VerifyDilatedConvValues(
           tensor_in_sizes=[1, 4, 6, 3, 1],
           filter_in_sizes=[2, 2, 2, 1, 1],

--- a/tensorflow/python/kernel_tests/conv_ops_3d_test.py
+++ b/tensorflow/python/kernel_tests/conv_ops_3d_test.py
@@ -227,7 +227,7 @@ class Conv3DTest(test.TestCase):
     ctx = context.context()
     is_eager = ctx is not None and ctx.executing_eagerly()
     if test.is_gpu_available(cuda_only=True) or \
-      test_util.IsMklEnabled() and is_eager is False:
+      (test_util.IsMklEnabled() and is_eager is False):
       self._VerifyDilatedConvValues(
           tensor_in_sizes=[1, 3, 6, 1, 1],
           filter_in_sizes=[1, 1, 1, 1, 1],

--- a/tensorflow/python/kernel_tests/conv_ops_3d_test.py
+++ b/tensorflow/python/kernel_tests/conv_ops_3d_test.py
@@ -255,7 +255,7 @@ class Conv3DTest(test.TestCase):
     ctx = context.context()
     is_eager = ctx is not None and ctx.executing_eagerly()
     if test.is_gpu_available(cuda_only=True) or \
-      test_util.IsMklEnabled() and is_eager is False:
+      (test_util.IsMklEnabled() and is_eager is False):
       self._VerifyDilatedConvValues(
           tensor_in_sizes=[1, 4, 6, 3, 1],
           filter_in_sizes=[2, 2, 2, 1, 1],


### PR DESCRIPTION
Currently "Conv3D" op with stride > 1 is not supported in eager mode, so we have to disable these test cases for now.