### PR TITLE
[r2.0-CherryPick]: Autograph: Remove tf.autograph.experimental.set_loop_options doc

### DIFF
--- a/tensorflow/python/autograph/lang/directives.py
+++ b/tensorflow/python/autograph/lang/directives.py
@@ -26,6 +26,7 @@ from __future__ import division
 from __future__ import print_function
 
 from tensorflow.python.util.tf_export import tf_export
+from tensorflow.tools.docs.doc_controls import do_not_generate_docs
 
 UNSPECIFIED = object()
 
@@ -46,6 +47,8 @@ def set_element_type(entity, dtype, shape=UNSPECIFIED):
   del shape
 
 
+# TODO(b/140125096): Implement.
+@do_not_generate_docs
 @tf_export('autograph.experimental.set_loop_options')
 def set_loop_options(
     parallel_iterations=UNSPECIFIED,


### PR DESCRIPTION
It's not implemented yet.  Having a doc
https://www.tensorflow.org/versions/r2.0/api_docs/python/tf/autograph/experimental/set_loop_options
is confusing and misleading as it's not working. This PR removes the doc.

PiperOrigin-RevId: 269387821