### PR TITLE
Add CPU BatchNormalization for NCHW format

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -4379,6 +4379,7 @@ tf_kernel_library(
     deps = NN_DEPS + [
         ":fill_functor",
         ":redux_functor",
+        ":transpose_functor",
     ] + if_cuda([
         "//tensorflow/core:stream_executor",
     ]),

--- a/tensorflow/core/kernels/fused_batch_norm_op.cc
+++ b/tensorflow/core/kernels/fused_batch_norm_op.cc
@@ -267,12 +267,12 @@ struct FusedBatchNorm<CPUDevice, T, U> {
       const int64 in_rows = GetTensorDim(x_input, tensor_format, 'H');
       const int64 in_cols = GetTensorDim(x_input, tensor_format, 'W');
       const int64 in_depths = GetTensorDim(x_input, tensor_format, 'C');
-			OP_REQUIRES_OK(context, context->allocate_temp(
+      OP_REQUIRES_OK(context, context->allocate_temp(
                               DataTypeToEnum<T>::value,
                               ShapeFromFormat(FORMAT_NHWC, in_batch, in_rows,
                                               in_cols, in_depths),
                               &transformed_x));
-			OP_REQUIRES_OK(context, context->allocate_temp(
+      OP_REQUIRES_OK(context, context->allocate_temp(
                               DataTypeToEnum<T>::value,
                               ShapeFromFormat(FORMAT_NHWC, in_batch, in_rows,
                                               in_cols, in_depths),
@@ -355,11 +355,10 @@ struct FusedBatchNorm<CPUDevice, T, U> {
     // Explicitly checks the types of T and U and only casts x_shifted when
     // T != U. (Not doing so caused a 35-50% performance slowdown for
     // some compiler flags.)
-    CastIfNecessary<std::is_same<T, U>::value, decltype(y),
-                    decltype(x_shifted), T>::process(y, x_shifted,
-                                                     rest_by_depth, d);
+    CastIfNecessary<std::is_same<T, U>::value, decltype(y), decltype(x_shifted),
+                    T>::process(y, x_shifted, rest_by_depth, d);
 
-	  if (tensor_format == FORMAT_NCHW) {
+    if (tensor_format == FORMAT_NCHW) {
       // Perform NHWC to NCHW
       std::vector<int32> perm = {0, 3, 1, 2};
       ::tensorflow::DoTranspose(context->eigen_device<CPUDevice>(),
@@ -386,17 +385,17 @@ struct FusedBatchNormGrad<CPUDevice, T, U> {
       const int64 in_rows = GetTensorDim(x_input, tensor_format, 'H');
       const int64 in_cols = GetTensorDim(x_input, tensor_format, 'W');
       const int64 in_depths = GetTensorDim(x_input, tensor_format, 'C');
-			OP_REQUIRES_OK(context, context->allocate_temp(
+      OP_REQUIRES_OK(context, context->allocate_temp(
                               DataTypeToEnum<T>::value,
                               ShapeFromFormat(FORMAT_NHWC, in_batch, in_rows,
                                               in_cols, in_depths),
                               &transformed_y_backprop_input));
-			OP_REQUIRES_OK(context, context->allocate_temp(
+      OP_REQUIRES_OK(context, context->allocate_temp(
                               DataTypeToEnum<T>::value,
                               ShapeFromFormat(FORMAT_NHWC, in_batch, in_rows,
                                               in_cols, in_depths),
                               &transformed_x_input));
-			OP_REQUIRES_OK(context, context->allocate_temp(
+      OP_REQUIRES_OK(context, context->allocate_temp(
                               DataTypeToEnum<T>::value,
                               ShapeFromFormat(FORMAT_NHWC, in_batch, in_rows,
                                               in_cols, in_depths),

--- a/tensorflow/core/kernels/fused_batch_norm_op.cc
+++ b/tensorflow/core/kernels/fused_batch_norm_op.cc
@@ -34,6 +34,7 @@ limitations under the License.
 #include "tensorflow/core/kernels/fill_functor.h"
 #include "tensorflow/core/kernels/fused_batch_norm_op.h"
 #include "tensorflow/core/kernels/redux_functor.h"
+#include "tensorflow/core/kernels/transpose_functor.h"
 #include "tensorflow/core/util/env_var.h"
 #include "tensorflow/core/util/tensor_format.h"
 
@@ -251,9 +252,6 @@ struct FusedBatchNorm<CPUDevice, T, U> {
                   Tensor* saved_var_output, TensorFormat tensor_format,
                   ScratchAllocator* reserve_space_allocator,
                   ScratchAllocator* workspace_allocator, bool is_training) {
-    OP_REQUIRES(context, tensor_format == FORMAT_NHWC,
-                errors::Internal("The CPU implementation of FusedBatchNorm "
-                                 "only supports NHWC tensor format for now."));
     OP_REQUIRES(context, side_input.dim_size(0) == 0,
                 errors::Internal(
                     "The CPU implementation of FusedBatchNorm does not support "
@@ -262,13 +260,38 @@ struct FusedBatchNorm<CPUDevice, T, U> {
                 activation_mode == FusedBatchNormActivationMode::kIdentity,
                 errors::Internal("The CPU implementation of FusedBatchNorm "
                                  "does not support activations."));
-    typename TTypes<T, 4>::ConstTensor x(x_input.tensor<T, 4>());
+    Tensor transformed_x;
+    Tensor transformed_y;
+    if (tensor_format == FORMAT_NCHW) {
+      const int64 in_batch = GetTensorDim(x_input, tensor_format, 'N');
+      const int64 in_rows = GetTensorDim(x_input, tensor_format, 'H');
+      const int64 in_cols = GetTensorDim(x_input, tensor_format, 'W');
+      const int64 in_depths = GetTensorDim(x_input, tensor_format, 'C');
+			OP_REQUIRES_OK(context, context->allocate_temp(
+                              DataTypeToEnum<T>::value,
+                              ShapeFromFormat(FORMAT_NHWC, in_batch, in_rows,
+                                              in_cols, in_depths),
+                              &transformed_x));
+			OP_REQUIRES_OK(context, context->allocate_temp(
+                              DataTypeToEnum<T>::value,
+                              ShapeFromFormat(FORMAT_NHWC, in_batch, in_rows,
+                                              in_cols, in_depths),
+                              &transformed_y));
+      // Perform NCHW to NHWC
+      std::vector<int32> perm = {0, 2, 3, 1};
+      ::tensorflow::DoTranspose(context->eigen_device<CPUDevice>(), x_input,
+                                perm, &transformed_x);
+    } else {
+      transformed_x = x_input;
+      transformed_y = *y_output;
+    }
+    typename TTypes<T, 4>::Tensor x(transformed_x.tensor<T, 4>());
     typename TTypes<U>::ConstVec scale(scale_input.vec<U>());
     typename TTypes<U>::ConstVec offset(offset_input.vec<U>());
     typename TTypes<U>::ConstVec estimated_mean(estimated_mean_input.vec<U>());
     typename TTypes<U>::ConstVec estimated_variance(
         estimated_variance_input.vec<U>());
-    typename TTypes<T, 4>::Tensor y(y_output->tensor<T, 4>());
+    typename TTypes<T, 4>::Tensor y(transformed_y.tensor<T, 4>());
     typename TTypes<U>::Vec batch_mean(batch_mean_output->vec<U>());
     typename TTypes<U>::Vec batch_var(batch_var_output->vec<U>());
     typename TTypes<U>::Vec saved_mean(saved_mean_output->vec<U>());
@@ -332,8 +355,16 @@ struct FusedBatchNorm<CPUDevice, T, U> {
     // Explicitly checks the types of T and U and only casts x_shifted when
     // T != U. (Not doing so caused a 35-50% performance slowdown for
     // some compiler flags.)
-    CastIfNecessary<std::is_same<T, U>::value, decltype(y), decltype(x_shifted),
-                    T>::process(y, x_shifted, rest_by_depth, d);
+    CastIfNecessary<std::is_same<T, U>::value, decltype(y),
+                    decltype(x_shifted), T>::process(y, x_shifted,
+                                                     rest_by_depth, d);
+
+	  if (tensor_format == FORMAT_NCHW) {
+      // Perform NHWC to NCHW
+      std::vector<int32> perm = {0, 3, 1, 2};
+      ::tensorflow::DoTranspose(context->eigen_device<CPUDevice>(),
+                                transformed_y, perm, y_output);
+    }
   }
 };
 
@@ -347,16 +378,49 @@ struct FusedBatchNormGrad<CPUDevice, T, U> {
                   const Tensor* reserve_space,
                   ScratchAllocator* workspace_allocator,
                   TensorFormat tensor_format) {
-    OP_REQUIRES(context, tensor_format == FORMAT_NHWC,
-                errors::Internal("The CPU implementation of FusedBatchNormGrad "
-                                 "only supports NHWC tensor format for now."));
-    typename TTypes<T, 4>::ConstTensor y_backprop(
-        y_backprop_input.tensor<T, 4>());
-    typename TTypes<T, 4>::ConstTensor x(x_input.tensor<T, 4>());
+    Tensor transformed_y_backprop_input;
+    Tensor transformed_x_input;
+    Tensor transformed_x_backprop_output;
+    if (tensor_format == FORMAT_NCHW) {
+      const int64 in_batch = GetTensorDim(x_input, tensor_format, 'N');
+      const int64 in_rows = GetTensorDim(x_input, tensor_format, 'H');
+      const int64 in_cols = GetTensorDim(x_input, tensor_format, 'W');
+      const int64 in_depths = GetTensorDim(x_input, tensor_format, 'C');
+			OP_REQUIRES_OK(context, context->allocate_temp(
+                              DataTypeToEnum<T>::value,
+                              ShapeFromFormat(FORMAT_NHWC, in_batch, in_rows,
+                                              in_cols, in_depths),
+                              &transformed_y_backprop_input));
+			OP_REQUIRES_OK(context, context->allocate_temp(
+                              DataTypeToEnum<T>::value,
+                              ShapeFromFormat(FORMAT_NHWC, in_batch, in_rows,
+                                              in_cols, in_depths),
+                              &transformed_x_input));
+			OP_REQUIRES_OK(context, context->allocate_temp(
+                              DataTypeToEnum<T>::value,
+                              ShapeFromFormat(FORMAT_NHWC, in_batch, in_rows,
+                                              in_cols, in_depths),
+                              &transformed_x_backprop_output));
+      // Perform NCHW to NHWC
+      std::vector<int32> perm = {0, 2, 3, 1};
+      ::tensorflow::DoTranspose(context->eigen_device<CPUDevice>(),
+                                y_backprop_input, perm,
+                                &transformed_y_backprop_input);
+      ::tensorflow::DoTranspose(context->eigen_device<CPUDevice>(), x_input,
+                                perm, &transformed_x_input);
+    } else {
+      transformed_y_backprop_input = y_backprop_input;
+      transformed_x_input = x_input;
+      transformed_x_backprop_output = *x_backprop_output;
+    }
+    typename TTypes<T, 4>::Tensor y_backprop(
+        transformed_y_backprop_input.tensor<T, 4>());
+    typename TTypes<T, 4>::Tensor x(transformed_x_input.tensor<T, 4>());
     typename TTypes<U>::ConstVec scale(scale_input.vec<U>());
     typename TTypes<U>::ConstVec mean(mean_input.vec<U>());
     typename TTypes<U>::ConstVec variance(variance_input.vec<U>());
-    typename TTypes<T, 4>::Tensor x_backprop(x_backprop_output->tensor<T, 4>());
+    typename TTypes<T, 4>::Tensor x_backprop(
+        transformed_x_backprop_output.tensor<T, 4>());
     typename TTypes<U>::Vec offset_backprop(offset_backprop_output->vec<U>());
 
     // Note: the following formulas are used to compute the gradients for
@@ -407,7 +471,7 @@ struct FusedBatchNormGrad<CPUDevice, T, U> {
     Tensor scratch_rest_by_depth;
     if (std::is_same<T, U>::value) {
       OP_REQUIRES(context,
-                  scratch_rest_by_depth.CopyFrom(*x_backprop_output,
+                  scratch_rest_by_depth.CopyFrom(transformed_x_backprop_output,
                                                  {rest_size, depth}),
                   errors::Internal("Failed to copy a tensor"));
     } else {
@@ -440,7 +504,8 @@ struct FusedBatchNormGrad<CPUDevice, T, U> {
     // Compute 'offset_backprop_output':
     //   offset_backprop =
     //     y_backprop_rest_by_depth.sum(reduce_dims)
-    redux_sum_t(d, rest_by_depth, y_backprop_input, offset_backprop_output);
+    redux_sum_t(d, rest_by_depth, transformed_y_backprop_input,
+                offset_backprop_output);
     auto y_backprop_sum = offset_backprop;
 
     auto y_backprop_sum_one_by_depth = y_backprop_sum.reshape(one_by_depth);
@@ -466,6 +531,14 @@ struct FusedBatchNormGrad<CPUDevice, T, U> {
 
     x_backprop.reshape(rest_by_depth).device(d) =
         (coef1 * (y_backprop_centered - x_centered * coef2)).template cast<T>();
+
+    if (tensor_format == FORMAT_NCHW) {
+      // Perform NHWC to NCHW
+      std::vector<int32> perm = {0, 3, 1, 2};
+      ::tensorflow::DoTranspose(context->eigen_device<CPUDevice>(),
+                                transformed_x_backprop_output, perm,
+                                x_backprop_output);
+    }
   }
 };
 

--- a/tensorflow/python/ops/nn_fused_batchnorm_test.py
+++ b/tensorflow/python/ops/nn_fused_batchnorm_test.py
@@ -350,6 +350,8 @@ class BatchNormalizationTest(test.TestCase):
             x_shape, dtype, [1], np.float32, use_gpu=True, data_format='NCHW')
       self._test_inference(
           x_shape, dtype, [1], np.float32, use_gpu=False, data_format='NHWC')
+      self._test_inference(
+          x_shape, dtype, [1], np.float32, use_gpu=False, data_format='NCHW')
 
   def testInferenceShape2(self):
     x_shape = [1, 1, 6, 2]
@@ -377,6 +379,8 @@ class BatchNormalizationTest(test.TestCase):
             x_shape, dtype, [6], np.float32, use_gpu=True, data_format='NHWC')
       self._test_inference(
           x_shape, dtype, [6], np.float32, use_gpu=False, data_format='NHWC')
+      self._test_inference(
+          x_shape, dtype, [131], np.float32, use_gpu=False, data_format='NCHW')
 
   def testInferenceShape5(self):
     with compat.forward_compatibility_horizon(2019, 6, 7):
@@ -393,6 +397,9 @@ class BatchNormalizationTest(test.TestCase):
               x_shape, dtype, [6], np.float32, use_gpu=True, data_format='NHWC')
         self._test_inference(
             x_shape, dtype, [6], np.float32, use_gpu=False, data_format='NHWC')
+        self._test_inference(
+            x_shape, dtype, [131], np.float32, use_gpu=False,
+            data_format='NCHW')
 
   def testTrainingShape1(self):
     x_shape = [1, 1, 6, 1]
@@ -404,6 +411,8 @@ class BatchNormalizationTest(test.TestCase):
             x_shape, dtype, [1], np.float32, use_gpu=True, data_format='NCHW')
       self._test_training(
           x_shape, dtype, [1], np.float32, use_gpu=False, data_format='NHWC')
+      self._test_training(
+          x_shape, dtype, [1], np.float32, use_gpu=False, data_format='NCHW')
 
   def testTrainingShape2(self):
     x_shape = [1, 1, 6, 2]
@@ -431,6 +440,8 @@ class BatchNormalizationTest(test.TestCase):
             x_shape, dtype, [6], np.float32, use_gpu=True, data_format='NHWC')
       self._test_training(
           x_shape, dtype, [6], np.float32, use_gpu=False, data_format='NHWC')
+      self._test_training(
+          x_shape, dtype, [131], np.float32, use_gpu=False, data_format='NCHW')
 
   def testTrainingShape5(self):
     with compat.forward_compatibility_horizon(2019, 6, 7):
@@ -447,6 +458,9 @@ class BatchNormalizationTest(test.TestCase):
               x_shape, dtype, [6], np.float32, use_gpu=True, data_format='NHWC')
         self._test_training(
             x_shape, dtype, [6], np.float32, use_gpu=False, data_format='NHWC')
+        self._test_training(
+            x_shape, dtype, [131], np.float32, use_gpu=False,
+            data_format='NCHW')
 
   @test_util.run_deprecated_v1
   def testBatchNormGradShape1(self):
@@ -474,6 +488,13 @@ class BatchNormalizationTest(test.TestCase):
             np.float32,
             use_gpu=False,
             data_format='NHWC',
+            is_training=is_training)
+        self._test_gradient(
+            x_shape,
+            dtype, [1],
+            np.float32,
+            use_gpu=False,
+            data_format='NCHW',
             is_training=is_training)
 
   @test_util.run_deprecated_v1
@@ -538,6 +559,13 @@ class BatchNormalizationTest(test.TestCase):
             use_gpu=False,
             data_format='NHWC',
             is_training=is_training)
+        self._test_gradient(
+            x_shape,
+            dtype, [7],
+            np.float32,
+            use_gpu=False,
+            data_format='NCHW',
+            is_training=is_training)
 
   @test_util.run_deprecated_v1
   @test_util.disable_xla('This test never passed for XLA')
@@ -567,6 +595,13 @@ class BatchNormalizationTest(test.TestCase):
               np.float32,
               use_gpu=False,
               data_format='NHWC',
+              is_training=is_training)
+          self._test_gradient(
+              x_shape,
+              dtype, [7],
+              np.float32,
+              use_gpu=False,
+              data_format='NCHW',
               is_training=is_training)
 
   def _testBatchNormGradGrad(self, config):
@@ -599,6 +634,14 @@ class BatchNormalizationTest(test.TestCase):
           data_format='NHWC',
           is_training=is_training,
           err_tolerance=err_tolerance)
+      self._test_grad_grad(
+          shape,
+          dtype, [shape[1]],
+          np.float32,
+          use_gpu=False,
+          data_format='NCHW',
+          is_training=is_training,
+          err_tolerance=err_tolerance)
 
   @test_util.run_deprecated_v1
   def testBatchNormGradGradConfig1(self):
@@ -622,7 +665,7 @@ class BatchNormalizationTest(test.TestCase):
   def testBatchNormGradGradConfig3(self):
     config = {
         'shape': [2, 3, 4, 5],
-        'err_tolerance': 1e-2,
+        'err_tolerance': 2e-2,
         'dtype': np.float16,
     }
     self._testBatchNormGradGrad(config)

--- a/tensorflow/python/ops/nn_fused_batchnorm_test.py
+++ b/tensorflow/python/ops/nn_fused_batchnorm_test.py
@@ -378,9 +378,9 @@ class BatchNormalizationTest(test.TestCase):
         self._test_inference(
             x_shape, dtype, [6], np.float32, use_gpu=True, data_format='NHWC')
       self._test_inference(
-          x_shape, dtype, [6], np.float32, use_gpu=False, data_format='NHWC')
-      self._test_inference(
           x_shape, dtype, [131], np.float32, use_gpu=False, data_format='NCHW')
+      self._test_inference(
+          x_shape, dtype, [6], np.float32, use_gpu=False, data_format='NHWC')
 
   def testInferenceShape5(self):
     with compat.forward_compatibility_horizon(2019, 6, 7):
@@ -396,10 +396,10 @@ class BatchNormalizationTest(test.TestCase):
           self._test_inference(
               x_shape, dtype, [6], np.float32, use_gpu=True, data_format='NHWC')
         self._test_inference(
-            x_shape, dtype, [6], np.float32, use_gpu=False, data_format='NHWC')
-        self._test_inference(
             x_shape, dtype, [131], np.float32, use_gpu=False,
             data_format='NCHW')
+        self._test_inference(
+            x_shape, dtype, [6], np.float32, use_gpu=False, data_format='NHWC')
 
   def testTrainingShape1(self):
     x_shape = [1, 1, 6, 1]
@@ -425,10 +425,12 @@ class BatchNormalizationTest(test.TestCase):
 
   def testTrainingShape3(self):
     x_shape = [1, 2, 1, 6]
-    if test.is_gpu_available(cuda_only=True):
-      for dtype in [np.float16, np.float32]:
+    for dtype in [np.float16, np.float32]:
+      if test.is_gpu_available(cuda_only=True):
         self._test_training(
             x_shape, dtype, [2], np.float32, use_gpu=True, data_format='NCHW')
+      self._test_training(
+          x_shape, dtype, [2], np.float32, use_gpu=False, data_format='NCHW')
 
   def testTrainingShape4(self):
     x_shape = [27, 131, 127, 6]
@@ -439,9 +441,9 @@ class BatchNormalizationTest(test.TestCase):
         self._test_training(
             x_shape, dtype, [6], np.float32, use_gpu=True, data_format='NHWC')
       self._test_training(
-          x_shape, dtype, [6], np.float32, use_gpu=False, data_format='NHWC')
-      self._test_training(
           x_shape, dtype, [131], np.float32, use_gpu=False, data_format='NCHW')
+      self._test_training(
+          x_shape, dtype, [6], np.float32, use_gpu=False, data_format='NHWC')
 
   def testTrainingShape5(self):
     with compat.forward_compatibility_horizon(2019, 6, 7):
@@ -457,10 +459,10 @@ class BatchNormalizationTest(test.TestCase):
           self._test_training(
               x_shape, dtype, [6], np.float32, use_gpu=True, data_format='NHWC')
         self._test_training(
-            x_shape, dtype, [6], np.float32, use_gpu=False, data_format='NHWC')
-        self._test_training(
             x_shape, dtype, [131], np.float32, use_gpu=False,
             data_format='NCHW')
+        self._test_training(
+            x_shape, dtype, [6], np.float32, use_gpu=False, data_format='NHWC')
 
   @test_util.run_deprecated_v1
   def testBatchNormGradShape1(self):
@@ -522,8 +524,8 @@ class BatchNormalizationTest(test.TestCase):
   def testBatchNormGradShape3(self):
     for is_training in [True, False]:
       x_shape = [1, 2, 1, 6]
-      if test.is_gpu_available(cuda_only=True):
-        for dtype in [np.float16, np.float32]:
+      for dtype in [np.float16, np.float32]:
+        if test.is_gpu_available(cuda_only=True):
           self._test_gradient(
               x_shape,
               dtype, [2],
@@ -531,6 +533,13 @@ class BatchNormalizationTest(test.TestCase):
               use_gpu=True,
               data_format='NCHW',
               is_training=is_training)
+        self._test_gradient(
+            x_shape,
+            dtype, [2],
+            np.float32,
+            use_gpu=False,
+            data_format='NCHW',
+            is_training=is_training)
 
   @test_util.run_deprecated_v1
   def testBatchNormGradShape4(self):


### PR DESCRIPTION
Previously, CPU doesn't support NCHW. This makes other operations based on NCHW batch norm hard to use. For example, the layer norm can be transformed to use NCHW batch norm on GPU. However, since we don't have CPU NCHW batch norm, we have to either avoid using NCHW batch norm or add more parameters to control the execution path.

This PR enables NCHW batch norm on CPU.

fyi. @nluehr 