### PR TITLE
Nms stability

### DIFF
--- a/tensorflow/core/kernels/non_max_suppression_op.cc
+++ b/tensorflow/core/kernels/non_max_suppression_op.cc
@@ -24,7 +24,6 @@ limitations under the License.
 #include <queue>
 #include <vector>
 
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/bounds_check.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"
@@ -34,6 +33,7 @@ limitations under the License.
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/lib/gtl/stl_util.h"
 #include "tensorflow/core/platform/logging.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 namespace tensorflow {
 namespace {
@@ -174,7 +174,8 @@ void DoNonMaxSuppressionOp(OpKernelContext* context, const Tensor& scores,
   };
 
   auto cmp = [](const Candidate bs_i, const Candidate bs_j) {
-    return bs_i.score < bs_j.score;
+    return ((bs_i.score == bs_j.score) && (bs_i.box_index > bs_j.box_index)) ||
+           bs_i.score < bs_j.score;
   };
   std::priority_queue<Candidate, std::deque<Candidate>, decltype(cmp)>
       candidate_priority_queue(cmp);

--- a/tensorflow/core/kernels/non_max_suppression_op.cu.cc
+++ b/tensorflow/core/kernels/non_max_suppression_op.cu.cc
@@ -18,10 +18,6 @@ limitations under the License.
 #include <limits>
 
 #include "absl/strings/str_cat.h"
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
-#include "third_party/cub/device/device_radix_sort.cuh"
-#include "third_party/cub/device/device_segmented_radix_sort.cuh"
-#include "third_party/cub/device/device_select.cuh"
 #include "tensorflow/core/framework/numeric_types.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/tensor_types.h"
@@ -29,6 +25,10 @@ limitations under the License.
 #include "tensorflow/core/util/gpu_kernel_helper.h"
 #include "tensorflow/core/util/gpu_launch_config.h"
 #include "tensorflow/stream_executor/stream_executor.h"
+#include "third_party/cub/device/device_radix_sort.cuh"
+#include "third_party/cub/device/device_segmented_radix_sort.cuh"
+#include "third_party/cub/device/device_select.cuh"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 #define TF_RETURN_IF_CUDA_ERROR(result)                   \
   do {                                                    \
@@ -105,7 +105,7 @@ __device__ EIGEN_STRONG_INLINE bool OverThreshold(const Box* a, const Box* b,
   const float aa = intersection;
   const float bb = a_area + b_area - intersection;
   const float bt = bb * iou_threshold;
-  return aa > bt;
+  return aa >= bt;
 }
 
 template <bool flip_box>


### PR DESCRIPTION
Current CPU implementation has an unstable sort which can lead to significant difference the results. This PR adds ordering criteria for same scored boxes, stabilizing algorithm. Also GPU selection criteria has been changed from **greater** than to **greater or equal** to match CPU implementation.