### PR TITLE
Use arg 'axis' when calling 'tensorflow.python.ops.nn_impl.l2_normalize'

### DIFF
--- a/tensorflow/python/ops/clustering_ops.py
+++ b/tensorflow/python/ops/clustering_ops.py
@@ -216,11 +216,11 @@ class KMeans(object):
     output = []
     if not inputs_normalized:
       with ops.colocate_with(clusters, ignore_existing=True):
-        clusters = nn_impl.l2_normalize(clusters, dim=1)
+        clusters = nn_impl.l2_normalize(clusters, axis=1)
     for inp in inputs:
       with ops.colocate_with(inp, ignore_existing=True):
         if not inputs_normalized:
-          inp = nn_impl.l2_normalize(inp, dim=1)
+          inp = nn_impl.l2_normalize(inp, axis=1)
         output.append(1 - math_ops.matmul(inp, clusters, transpose_b=True))
     return output
 
@@ -251,7 +251,7 @@ class KMeans(object):
       # TODO(ands): Support COSINE distance in nearest_neighbors and remove
       # this.
       with ops.colocate_with(clusters, ignore_existing=True):
-        clusters = nn_impl.l2_normalize(clusters, dim=1)
+        clusters = nn_impl.l2_normalize(clusters, axis=1)
     for inp, score in zip(inputs, scores):
       with ops.colocate_with(inp, ignore_existing=True):
         (indices, distances) = gen_clustering_ops.nearest_neighbors(


### PR DESCRIPTION
See #31990 

-----

Use arg 'axis' when calling 'tensorflow.python.ops.nn_impl.l2_normalize' instead of the deprecated arg `dim`.

Whenever I use k-means, I get this warning:
```
W0826 17:01:44.808238 27644 deprecation.py:506] From C:\Users\rpherbig\AppData\Local\Programs\Python\Python37\lib\site-packages\tensorflow\contrib\factorization\python\ops\clustering_ops.py:740: calling l2_normalize (from tensorflow.python.ops.nn_impl) with dim is deprecated and will be removed in a future version.
Instructions for updating:
dim is deprecated, use axis instead
```

Due to the deprecation of the `dim` arg - see https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/ops/nn_impl.py#L592