### PR TITLE
Add gradient accumulation support for distribution strategy

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -5654,6 +5654,24 @@ cuda_py_test(
 )
 
 cuda_py_test(
+    name = "gradient_accumulation_test",
+    size = "small",
+    srcs = [
+        "training/gradient_accumulation_test.py",
+    ],
+    additional_deps = [
+        ":array_ops",
+        ":client_testlib",
+        ":constant_op",
+        ":platform",
+        ":training",
+        "//tensorflow/contrib/distribute/python:mirrored_strategy",
+        "//tensorflow/contrib/distribute/python:one_device_strategy",
+        "//tensorflow/python/estimator:estimator",
+    ],
+)
+
+cuda_py_test(
     name = "moving_averages_test",
     size = "small",
     srcs = [

--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -3090,7 +3090,12 @@ class Graph(object):
     Returns:
       A context object.
     """
-    return self._control_flow_context
+    if self._stack_state_is_thread_local:
+      if not hasattr(self._thread_local, "_control_flow_context"):
+        self._thread_local._control_flow_context = (self._control_flow_context)
+      return self._thread_local._control_flow_context
+    else:
+      return self._control_flow_context
 
   def _set_control_flow_context(self, ctx):
     """Sets the current control flow context.
@@ -3098,7 +3103,10 @@ class Graph(object):
     Args:
       ctx: a context object.
     """
-    self._control_flow_context = ctx
+    if self._stack_state_is_thread_local:
+      self._thread_local._control_flow_context = ctx
+    else:
+      self._control_flow_context = ctx
 
   def _copy_functions_to_graph_def(self, graph_def, starting_bytesize):
     """If this graph contains functions, copy them to `graph_def`."""

--- a/tensorflow/python/training/gradient_accumulation.py
+++ b/tensorflow/python/training/gradient_accumulation.py
@@ -1,0 +1,90 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Gradients accumulation for making use of bigger batch size on
+   limited memory GPUs.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import resource_variable_ops
+from tensorflow.python.ops import state_ops
+
+
+def grad_accumulation(grads_and_vars,
+                      iter_size=None,
+                      average=False):
+  """Construct subgraph for gradient accumulation.
+
+  The accumulated gradient is a neural network framework feature. It is a
+  workaround to enable big batches on limited memory GPUs. Instead of
+  back-propagating for every batch feed-forward, gradients across multiple
+  batches are accumulated. After multiple feed forwards, the accumulated
+  gradient is back-propagated through the network layer. This gives the
+  illusion of using big batches on limited memory GPUs.
+
+  Args:
+    grads_and_vars: List of (gradient, variable) pairs as returned by
+        compute_gradients().
+    iter_size: Number of local iteration before network weights are updated.
+    average: If True, compute the average over all.
+
+  Returns:
+    (accum_grad_ops, reset_grad_ops, accumulated_grads_and_vars)
+  """
+  accum_grads = []
+  accum_vars = []
+  accum_grad_ops = []
+  reset_grad_ops = []
+
+  for grad, var in grads_and_vars:
+    accum_vars.append(var)
+    with ops.device(var.device):
+      if grad is None:
+        accum_grads.append(None)
+        continue
+      assert isinstance(grad, (ops.Tensor, ops.IndexedSlices)),\
+          ("Gradient ", grad, " is neither a tensor nor IndexedSlices.")
+      accum_grad = resource_variable_ops.ResourceVariable(
+          lambda: array_ops.zeros(var.get_shape(), grad.dtype),
+          trainable=False,
+          collections=[ops.GraphKeys.LOCAL_VARIABLES],
+          name="grad_accumulator")
+      reset_grad_op = state_ops.assign(
+          accum_grad,
+          array_ops.zeros(var.get_shape(), grad.dtype),
+          name="reset_grad_accumulator")
+      if isinstance(grad, ops.Tensor):
+        accum_grad_op = accum_grad.assign_add(grad, name="grad_accumulation")
+      else:
+        accum_grad_op = state_ops.scatter_update(
+            accum_grad, grad.indices, grad.values, name="sparse_grad_accum")
+
+      accum_grads.append(accum_grad)
+      accum_grad_ops.append(accum_grad_op)
+      reset_grad_ops.append(reset_grad_op)
+  if average:
+    accum_grads_mean = [math_ops.multiply(v, 1.0 / iter_size)
+                        if v is not None else None
+                        for v in accum_grads]
+    accumulated_grads_and_vars = zip(accum_grads_mean, accum_vars)
+  else:
+    accumulated_grads_and_vars = zip(accum_grads, accum_vars)
+
+  return accum_grad_ops, reset_grad_ops, accumulated_grads_and_vars

--- a/tensorflow/python/training/gradient_accumulation_test.py
+++ b/tensorflow/python/training/gradient_accumulation_test.py
@@ -1,0 +1,137 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Functional test for GradientAccumulation."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.contrib.distribute.python import mirrored_strategy
+from tensorflow.contrib.distribute.python import one_device_strategy
+from tensorflow.python.data.ops import dataset_ops
+from tensorflow.python.estimator import estimator
+from tensorflow.python.estimator import model_fn as model_fn_lib
+from tensorflow.python.estimator import run_config
+from tensorflow.python.framework import constant_op
+from tensorflow.python.layers import layers
+from tensorflow.python.ops import array_ops
+from tensorflow.python.platform import test
+from tensorflow.python.training import gradient_descent
+from tensorflow.python.training import training_util
+
+class GradientAccumulationTest(test.TestCase):
+
+  def _build_model_fn_optimizer(self, iter_size=None):
+    """Simple model_fn with optimizer."""
+    optimizer = gradient_descent.GradientDescentOptimizer(0.2)
+
+    def model_fn(features, labels, mode):  # pylint: disable=unused-argument
+      """model_fn which uses a single unit Dense layer."""
+      layer = layers.Dense(1, use_bias=True)
+      logits = layer(features)
+
+      def loss_fn():
+        y = array_ops.reshape(logits, []) - constant_op.constant(1.)
+        return y * y
+
+      assert mode == model_fn_lib.ModeKeys.TRAIN
+
+      global_step = training_util.get_global_step()
+      train_op = optimizer.minimize(loss_fn(), global_step=global_step,
+          iter_size=iter_size)
+      return model_fn_lib.EstimatorSpec(mode, loss=loss_fn(), train_op=train_op)
+
+    return model_fn
+
+  def testMirroredStrategyWithGA(self):
+    distribution = mirrored_strategy.MirroredStrategy(["/device:GPU:0"])
+    config = run_config.RunConfig(train_distribute=distribution)
+
+    def train_input_fn():
+      features = dataset_ops.Dataset.from_tensors([[1.]]).repeat(10)
+      labels = dataset_ops.Dataset.from_tensors([1.]).repeat(10)
+      return dataset_ops.Dataset.zip((features, labels))
+
+    est = estimator.Estimator(
+        model_fn=self._build_model_fn_optimizer(iter_size=2), config=config)
+    est.train(input_fn=train_input_fn)
+
+    # Since there are 10 samples and 1 device and each global_step will
+    # consume iter_size=2 samples, so the final global_step until `input_fn`
+    # generates the `tf.errors.OutOfRange` error should be 10 / 2 = 5.
+    global_step = est.get_variable_value("global_step")
+    self.assertAllCloseAccordingToType(5, global_step)
+
+  def testOneDeviceStrategyWithGA(self):
+    distribution = one_device_strategy.OneDeviceStrategy(
+        device="/device:GPU:0")
+    config = run_config.RunConfig(train_distribute=distribution)
+
+    def train_input_fn():
+      features = dataset_ops.Dataset.from_tensors([[1.]]).repeat(10)
+      labels = dataset_ops.Dataset.from_tensors([1.]).repeat(10)
+      return dataset_ops.Dataset.zip((features, labels))
+
+    est = estimator.Estimator(
+        model_fn=self._build_model_fn_optimizer(iter_size=2), config=config)
+    est.train(input_fn=train_input_fn)
+
+    # Since there are 10 samples and 1 device and each global_step will
+    # consume iter_size=2 samples, so the final global_step until `input_fn`
+    # generates the `tf.errors.OutOfRange` error should be 10 / 2 = 5.
+    global_step = est.get_variable_value("global_step")
+    self.assertAllCloseAccordingToType(5, global_step)
+
+  def testMirroredStrategyWithGAMultiDevices(self):
+    distribution = mirrored_strategy.MirroredStrategy(
+        ["/device:GPU:0", "/device:GPU:1", "device:GPU:2"])
+    config = run_config.RunConfig(train_distribute=distribution)
+
+    def train_input_fn():
+      features = dataset_ops.Dataset.from_tensors([[1.]]).repeat(10)
+      labels = dataset_ops.Dataset.from_tensors([1.]).repeat(10)
+      return dataset_ops.Dataset.zip((features, labels))
+
+    est = estimator.Estimator(
+        model_fn=self._build_model_fn_optimizer(iter_size=2), config=config)
+    est.train(input_fn=train_input_fn)
+
+    # Since there are 10 samples and 3 device and each global_step will
+    # consume iter_size*num_gpus=6 samples, so the final global_step until
+    # `input_fn` generates the `tf.errors.OutOfRange` error should be
+    # 10 / 6 = 1. Note that in this case each device will remain some
+    # local accumulated grads which are not communicated with each other
+    # as the next apply_op has not been triggered before `input_fn` runs
+    # OutOfRange.
+    global_step = est.get_variable_value("global_step")
+    self.assertAllCloseAccordingToType(1, global_step)
+
+  def testMirroredStrategyWithGAWithIllegalIterSize(self):
+    distribution = mirrored_strategy.MirroredStrategy(
+        ["/device:GPU:0", "/device:GPU:1"])
+    config = run_config.RunConfig(train_distribute=distribution)
+
+    def train_input_fn():
+      features = dataset_ops.Dataset.from_tensors([[1.]]).repeat(10)
+      labels = dataset_ops.Dataset.from_tensors([1.]).repeat(10)
+      return dataset_ops.Dataset.zip((features, labels))
+
+    est = estimator.Estimator(
+        model_fn=self._build_model_fn_optimizer(iter_size=-3), config=config)
+    with self.assertRaises(ValueError):
+      est.train(input_fn=train_input_fn)
+
+if __name__ == "__main__":
+  test.main()


### PR DESCRIPTION
PR for issue #32176 .

There are still some issues to be fixed or further discussed:
(1）Gradient accumulation will break the default behavior of `basic_session_run_hooks`, e.g.:
```
I0917 17:51:10.444422 139809108260672 basic_session_run_hooks.py:262] loss = 0.435526, step = 0
I0917 17:51:10.495073 139809108260672 basic_session_run_hooks.py:692] global_step/sec: 19.6194
W0917 17:51:10.495340 139809108260672 basic_session_run_hooks.py:724] It seems that global step (tf.train.get_global_step) has not been increased. Current value (could be stable): 0 vs previous value: 0. You could increase the global step by passing tf.train.get_global_step() to Optimizer.apply_gradients or Optimizer.minimize.
I0917 17:51:10.495481 139809108260672 basic_session_run_hooks.py:260] loss = 0.435526, step = 0 (0.051 sec)
I0917 17:51:10.496573 139809108260672 basic_session_run_hooks.py:260] loss = 0.017421033, step = 1 (0.001 sec)
I0917 17:51:10.497781 139809108260672 basic_session_run_hooks.py:692] global_step/sec: 362.328
W0917 17:51:10.498049 139809108260672 basic_session_run_hooks.py:724] It seems that global step (tf.train.get_global_step) has not been increased. Current value (could be stable): 1 vs previous value: 1. You could increase the global step by passing tf.train.get_global_step() to Optimizer.apply_gradients or Optimizer.minimize.
I0917 17:51:10.498194 139809108260672 basic_session_run_hooks.py:260] loss = 0.017421033, step = 1 (0.002 sec)
I0917 17:51:10.499253 139809108260672 basic_session_run_hooks.py:260] loss = 0.00069683883, step = 2 (0.001 sec)
I0917 17:51:10.506485 139809108260672 basic_session_run_hooks.py:606] Saving checkpoints for 2 into /tmp/tmpYRa9ZY/model.ckpt.
```
`config.log_step_count_steps` should be scaled `iter_size` times larger.

(2) Currently gradients are *accumulated* locally, which implies that learning rate is adjusted `iter_size` times larger.

(3) This PR only support gradient accumulation for distribution strategy currently. Support for non-distribution case is natural as this GA realization is independent of optimizer and can be reused easily.

(4) GA add one new parameter `iter_size` to base class `Optimizer`, whether this will break some default behavior of some optimizer wrapper?

(5) Higher test coverage.