### PR TITLE
[XLA] Add DiagSlice HLO instruction

### DIFF
--- a/tensorflow/compiler/tf2xla/kernels/diag_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/diag_op.cc
@@ -115,7 +115,9 @@ REGISTER_XLA_OP(Name("Diag"), DiagOp);
 
 class DiagPartOp : public XlaOpKernel {
  public:
-  explicit DiagPartOp(OpKernelConstruction* ctx) : XlaOpKernel(ctx) {}
+  explicit DiagPartOp(OpKernelConstruction* ctx)
+      : XlaOpKernel(ctx),
+        is_gpu_(ctx->device_type().type_string() == DEVICE_GPU_XLA_JIT) {}
 
   void Compile(XlaOpKernelContext* ctx) override {
     const TensorShape input_shape = ctx->InputShape(0);
@@ -145,12 +147,17 @@ class DiagPartOp : public XlaOpKernel {
 
     xla::XlaOp input = ctx->Input(0);
 
+    xla::XlaOp reshape_input = xla::Reshape(input, {new_size, new_size});
     xla::XlaOp output = xla::Reshape(
-        xla::GetMatrixDiagonal(xla::Reshape(input, {new_size, new_size})),
+        is_gpu_ ? xla::GetMatrixDiagonalViaGather(reshape_input)
+                : xla::GetMatrixDiagonal(reshape_input),
         new_dims);
 
     ctx->SetOutput(0, output);
   }
+
+ private:
+  const bool is_gpu_;
 };
 
 REGISTER_XLA_OP(Name("DiagPart"), DiagPartOp);

--- a/tensorflow/compiler/tf2xla/kernels/matrix_diag_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/matrix_diag_ops.cc
@@ -267,7 +267,8 @@ REGISTER_XLA_OP(Name("MatrixDiagV2")
 class MatrixDiagPartOp : public XlaOpKernel {
  public:
   explicit MatrixDiagPartOp(OpKernelConstruction* context)
-      : XlaOpKernel(context) {}
+      : XlaOpKernel(context),
+        is_gpu_(context->device_type().type_string() == DEVICE_GPU_XLA_JIT) {}
 
   void Compile(XlaOpKernelContext* context) override {
     const TensorShape input_shape = context->InputShape(0);
@@ -315,13 +316,17 @@ class MatrixDiagPartOp : public XlaOpKernel {
     std::vector<xla::XlaOp> diag_list;
     xla::PaddingConfig padding_config;
     if (num_diags == 1) {
-      context->SetOutput(0, xla::GetMatrixDiagonal(input, upper_diag_index));
+      context->SetOutput(0,
+        is_gpu_ ? xla::GetMatrixDiagonalViaGather(input, upper_diag_index)
+                : xla::GetMatrixDiagonal(input, upper_diag_index));
       return;
     }
     padding_config = xla::MakeNoPaddingConfig(input_rank - 1);
     for (int diag_index = upper_diag_index; diag_index >= lower_diag_index;
          --diag_index) {
-      auto single_diag = xla::GetMatrixDiagonal(input, diag_index);
+      xla::XlaOp single_diag =
+          is_gpu_ ? xla::GetMatrixDiagonalViaGather(input, diag_index)
+                  : xla::GetMatrixDiagonal(input, diag_index);
       const int64 diag_length =
           (diag_index >= 0) ? (num_cols - diag_index) : (num_rows + diag_index);
       const int64 padding_length = max_diag_len - diag_length;
@@ -336,6 +341,9 @@ class MatrixDiagPartOp : public XlaOpKernel {
         xla::ConcatInDim(context->builder(), diag_list, input_rank - 2);
     context->SetOutput(0, xla::Reshape(concat, output_shape.dim_sizes()));
   }
+
+ private:
+  const bool is_gpu_;
 };
 
 REGISTER_XLA_OP(Name("MatrixDiagPart"), MatrixDiagPartOp);

--- a/tensorflow/compiler/xla/client/lib/matrix.cc
+++ b/tensorflow/compiler/xla/client/lib/matrix.cc
@@ -19,6 +19,9 @@ limitations under the License.
 #include <limits>
 #include <numeric>
 #include <vector>
+#include <string>
+#include <utility>
+#include <algorithm>
 
 #include "absl/algorithm/container.h"
 #include "absl/container/flat_hash_set.h"
@@ -99,6 +102,70 @@ XlaOp GetMatrixDiagonal(XlaOp x, int k) {
     }
     return SliceInMinorDims(result, {0},
                             {k > 0 ? std::min(m, n - k) : std::min(n, m + k)});
+  });
+}
+
+XlaOp GetMatrixDiagonalViaGather(XlaOp x, int k) {
+  XlaBuilder* builder = x.builder();
+  return builder->ReportErrorOrReturn([&]() -> StatusOr<XlaOp> {
+    TF_ASSIGN_OR_RETURN(Shape shape, builder->GetShape(x));
+    auto n_dims = static_cast<int32>(shape.rank());
+    TF_RET_CHECK(n_dims >= 2);
+    const int64 m = shape.dimensions(n_dims - 2);
+    const int64 n = shape.dimensions(n_dims - 1);
+
+    // The start_indices has a shape of {diag_len, 2}, and each pair of value in
+    // its dimension 1 represents the (row, col) of the diagonal. We set
+    // index_vector_dim to 1 and make start_index_map and collapsed_slice_dims
+    // contain the same two dimension indices. This makes sure that the (row,
+    // col) pairs in start_indices are propagated to the indices for the two
+    // collapsed dimensions in the operand indices through start_index_map.
+    const int64 num_index_dims = 2;
+    const int64 axis = n_dims - num_index_dims;
+
+    // Calculate the indices of diagonal part with offset k.
+    const int64 diag_len = std::max(std::min(m + std::min(k, 0),
+                                             n - std::max(k, 0)),
+                                    0LL);
+    XlaOp diag_base_indices = BroadcastInDim(
+        Iota(builder, S32, diag_len), { diag_len, num_index_dims }, { 0 });
+    XlaOp diag_offset = Broadcast(
+        ConstantR1<int>(builder, { std::max(-k, 0), std::max(k, 0) }),
+        { diag_len });
+    XlaOp start_indices = Add(diag_base_indices, diag_offset);
+
+    // Example of a 3D diag-part extracting diagonal part with offset=1 out of a
+    // tensor of shape [2,5,4].
+    //
+    //  operand = s32[2,5,4] parameter(0)
+    //  indices = s32[3,2] parameter(1)
+    //  gather = s32[2,3] gather(operand, indices),
+    //       offset_dims={0},
+    //       collapsed_slice_dims={1,2},
+    //       start_index_map={1,2},
+    //       index_vector_dim=1,
+    //       slice_sizes={2, 1, 1}
+
+    xla::GatherDimensionNumbers dim_numbers;
+    std::vector<int64> slice_sizes;
+    slice_sizes.reserve(n_dims);
+    for (int64 i = 0; i < n_dims; i++) {
+      int64 window_bound;
+      if (axis <= i) {
+        dim_numbers.add_collapsed_slice_dims(i);
+        dim_numbers.add_start_index_map(i);
+        window_bound = (shape.dimensions(i) != 0) ? 1 : 0;
+      } else {
+        dim_numbers.add_offset_dims(i);
+        window_bound = shape.dimensions(i);
+      }
+      slice_sizes.push_back(window_bound);
+    }
+
+    dim_numbers.set_index_vector_dim(1);
+
+    return Gather(x, start_indices, dim_numbers, slice_sizes,
+                  /*indices_are_sorted=*/true);
   });
 }
 

--- a/tensorflow/compiler/xla/client/lib/matrix.h
+++ b/tensorflow/compiler/xla/client/lib/matrix.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define TENSORFLOW_COMPILER_XLA_CLIENT_LIB_MATRIX_H_
 
 #include <array>
+#include <vector>
 
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
@@ -44,6 +45,7 @@ XlaOp GetDiagonalMask(XlaOp x, int diagonal = 0);
 //  If k < 0: then the output has shape [..., min(M + k, N)], containing the
 //            diagonal elements (i.e., with indices [..., i - k, i]).
 XlaOp GetMatrixDiagonal(XlaOp x, int k = 0);
+XlaOp GetMatrixDiagonalViaGather(XlaOp x, int k = 0);
 
 // Places diag along the kth diagonal of target.
 XlaOp SetMatrixDiagonal(XlaOp matrix, XlaOp diag, int k = 0);

--- a/tensorflow/compiler/xla/client/lib/matrix_test.cc
+++ b/tensorflow/compiler/xla/client/lib/matrix_test.cc
@@ -16,6 +16,9 @@ limitations under the License.
 #include "tensorflow/compiler/xla/client/lib/matrix.h"
 
 #include <limits>
+#include <string>
+#include <map>
+#include <vector>
 
 #include "absl/strings/string_view.h"
 #include "tensorflow/compiler/xla/client/lib/constants.h"
@@ -35,6 +38,8 @@ class MatrixTest : public ClientLibraryTestBase {
  protected:
   template <typename T>
   void TestMatrixDiagonal();
+  template <typename T>
+  void TestMatrixDiagonal4D();
   template <typename T>
   void TestSetMatrixDiagonal();
 
@@ -117,6 +122,43 @@ XLA_TEST_F(MatrixTest, GetMatrixDiagonal_S32) { TestMatrixDiagonal<int32>(); }
 XLA_TEST_F(MatrixTest, GetMatrixDiagonal_S64) { TestMatrixDiagonal<int64>(); }
 
 XLA_TEST_F(MatrixTest, GetMatrixDiagonal_F32) { TestMatrixDiagonal<float>(); }
+
+template <typename T>
+void MatrixTest::TestMatrixDiagonal4D() {
+  XlaBuilder builder("GetMatrixDiagonal");
+  Array4D<T> input(2, 2, 4, 3);
+  input.FillIota(0);
+  std::map<int, Array3D<T>> k_and_expected = {
+      {0, {{{0, 4, 8}, {12, 16, 20}}, {{24, 28, 32}, {36, 40, 44}}}},
+      {1, {{{1, 5}, {13, 17}}, {{25, 29}, {37, 41}}}},
+      {2, {{{2}, {14}}, {{26}, {38}}}},
+      {3, {{{}, {}}, {{}, {}}}},
+      {4, {{{}, {}}, {{}, {}}}},
+      {-1, {{{3, 7, 11}, {15, 19, 23}}, {{27, 31, 35}, {39, 43, 47}}}},
+      {-2, {{{6, 10}, {18, 22}}, {{30, 34}, {42, 46}}}},
+      {-3, {{{9}, {21}}, {{33}, {45}}}},
+      {-4, {{{}, {}}, {{}, {}}}},
+  };
+  for (const auto& kv : k_and_expected) {
+    XlaOp a;
+    auto a_data = CreateR4Parameter<T>(input, 0, "a", &builder, &a);
+    GetMatrixDiagonal(a, kv.first);
+
+    ComputeAndCompareR3<T>(&builder, kv.second, {a_data.get()});
+  }
+}
+
+XLA_TEST_F(MatrixTest, GetMatrixDiagonal4D_S32) {
+  TestMatrixDiagonal4D<int32>();
+}
+
+XLA_TEST_F(MatrixTest, GetMatrixDiagonal4D_S64) {
+  TestMatrixDiagonal4D<int64>();
+}
+
+XLA_TEST_F(MatrixTest, GetMatrixDiagonal4D_F32) {
+  TestMatrixDiagonal4D<float>();
+}
 
 Array3D<float> BatchedAValsFull() {
   return {{


### PR DESCRIPTION
This is a PR from JIZHI, the AI platform in Tencent.
@jlebar 
There is the purpose of the new HLO instruction:
Generate more efficient kernel for DiagPart and MatrixDiagPart. For example:
> %iota.3 = s32[1024,1024]{1,0} iota(), iota_dimension=0
 %iota.2 = s32[1024,1024]{1,0} iota(), iota_dimension=1
 %compare.0 = pred[1024,1024]{1,0} compare(s32[1024,1024]{1,0} %iota.3, s32[1024,1024]{1,0} %iota.2), direction=EQ
 %param_0.3 = f32[1024,1024]{1,0} parameter(0)
 %constant_0 = f32[] constant(0)
 %broadcast.0 = f32[1024,1024]{1,0} broadcast(f32[] %constant_0), dimensions={}
 %select.0 = f32[1024,1024]{1,0} select(pred[1024,1024]{1,0} %compare.0, f32[1024,1024]{1,0} 
 %param_0.3, f32[1024,1024]{1,0} %broadcast.0)
 ROOT %reduce.0 = f32[1024]{0} reduce(f32[1024,1024]{1,0} %select.0, f32[] %constant_0), dimensions={0}, to_apply=%add_F32.17

Here is the hlo code for tf.diag_part(X), where X is tensor with shape 1024x1024. the generated kernel's launch dimension is 1024x1024, and it has '_compare_' and '_select_' operation to get the right index to output. and the more expensive operation '_reduce_' to get the right value to output. The kernel is less efficient for diag-part op. Actually it just needs 1024 threads to get the right value from the diag part of the source matrix which just determined by offset.