### PR TITLE
Add explicit TensorShape conversion to Keras Layer

### DIFF
--- a/tensorflow/python/keras/engine/base_layer.py
+++ b/tensorflow/python/keras/engine/base_layer.py
@@ -45,6 +45,7 @@ from tensorflow.python.framework import ops
 from tensorflow.python.framework import sparse_tensor
 from tensorflow.python.framework import tensor_spec
 from tensorflow.python.framework import tensor_util
+from tensorflow.python.framework.tensor_shape import TensorShape
 from tensorflow.python.keras import backend
 from tensorflow.python.keras import constraints
 from tensorflow.python.keras import initializers
@@ -672,7 +673,7 @@ class Layer(module.Module):
             'but saw signature signature entry: {}.'.format(s))
       return s.shape
     input_shape = nest.map_structure(check_type_return_shape, input_signature)
-    output_shape = self.compute_output_shape(input_shape)
+    output_shape = TensorShape(self.compute_output_shape(input_shape))
     dtype = self._compute_dtype
     if dtype is None:
       input_dtypes = [s.dtype for s in nest.flatten(input_signature)]
@@ -2169,7 +2170,7 @@ class Layer(module.Module):
 
   def _symbolic_call(self, inputs):
     input_shapes = nest.map_structure(lambda x: x.shape, inputs)
-    output_shapes = self.compute_output_shape(input_shapes)
+    output_shapes = TensorShape(self.compute_output_shape(input_shapes))
 
     def _make_placeholder_like(shape):
       ph = backend.placeholder(shape=shape, dtype=self.dtype)


### PR DESCRIPTION
Fixes #32476 

If you return a tuple in `compute_output_shapes` of a subclassed dynamic Keras Layer, it will be incorrectly interpreted (see #32476). The behavior doesn't occur when the output is, instead, a TensorShape. Since tf.TensorShape(tensor_shape) just returns tensor_shape, it is safe to add an explicit conversion to a TensorShape. This should address all potential return values of `compute_output_shapes` to make it inline with the Keras documentation (see: [Keras docs on custom layers](https://keras.io/layers/writing-your-own-keras-layers/)).

This is my first PR for Tensorflow, so let me know if there's anything I should change.