### PR TITLE
Add explicit TensorShape conversion to Keras Base Layer

### DIFF
--- a/tensorflow/python/keras/engine/base_layer.py
+++ b/tensorflow/python/keras/engine/base_layer.py
@@ -45,6 +45,7 @@ from tensorflow.python.framework import ops
 from tensorflow.python.framework import sparse_tensor
 from tensorflow.python.framework import tensor_spec
 from tensorflow.python.framework import tensor_util
+from tensorflow.python.framework.tensor_shape import TensorShape
 from tensorflow.python.keras import backend
 from tensorflow.python.keras import constraints
 from tensorflow.python.keras import initializers
@@ -672,7 +673,11 @@ class Layer(module.Module):
             'but saw signature signature entry: {}.'.format(s))
       return s.shape
     input_shape = nest.map_structure(check_type_return_shape, input_signature)
+    
     output_shape = self.compute_output_shape(input_shape)
+    if isinstance(output_shape, tuple):
+      output_shape = TensorShape(output_shape)
+    
     dtype = self._compute_dtype
     if dtype is None:
       input_dtypes = [s.dtype for s in nest.flatten(input_signature)]
@@ -2169,8 +2174,11 @@ class Layer(module.Module):
 
   def _symbolic_call(self, inputs):
     input_shapes = nest.map_structure(lambda x: x.shape, inputs)
-    output_shapes = self.compute_output_shape(input_shapes)
 
+    output_shapes = self.compute_output_shape(input_shapes)
+    if isinstance(output_shapes, tuple):
+      output_shapes = TensorShape(output_shapes)
+    
     def _make_placeholder_like(shape):
       ph = backend.placeholder(shape=shape, dtype=self.dtype)
       ph._keras_mask = None

--- a/tensorflow/python/keras/engine/base_layer.py
+++ b/tensorflow/python/keras/engine/base_layer.py
@@ -677,7 +677,9 @@ class Layer(module.Module):
     output_shape = self.compute_output_shape(input_shape)
     if isinstance(output_shape, tuple):
       output_shape = TensorShape(output_shape)
-    
+    elif isinstance(output_shape, list):
+      output_shape = list(map(lambda x: TensorShape(x) if isinstance(x, tuple) else x, output_shape))
+
     dtype = self._compute_dtype
     if dtype is None:
       input_dtypes = [s.dtype for s in nest.flatten(input_signature)]
@@ -2178,7 +2180,9 @@ class Layer(module.Module):
     output_shapes = self.compute_output_shape(input_shapes)
     if isinstance(output_shapes, tuple):
       output_shapes = TensorShape(output_shapes)
-    
+    elif isinstance(output_shapes, list):
+      output_shapes = list(map(lambda x: TensorShape(x) if isinstance(x, tuple) else x, output_shapes))
+      
     def _make_placeholder_like(shape):
       ph = backend.placeholder(shape=shape, dtype=self.dtype)
       ph._keras_mask = None

--- a/tensorflow/python/keras/engine/base_layer.py
+++ b/tensorflow/python/keras/engine/base_layer.py
@@ -2187,7 +2187,7 @@ class Layer(module.Module):
       The output shape with any tuples converted to TensorShapes 
     """
     def _convert_tuple_to_tensorshape(input_tuple):
-      return TensorShape(tuple(map(lambda x: x.aslist() if isinstance(x, TensorShape) else x, input_tuple)))
+      return TensorShape(tuple(map(lambda x: x.as_list() if isinstance(x, TensorShape) else x, input_tuple)))
 
     if isinstance(output_shape, tuple):
       output_shape = _convert_tuple_to_tensorshape(output_shape)


### PR DESCRIPTION
Fixes #32476

If you return a tuple in compute_output_shapes of a subclassed dynamic Keras Layer, it will be incorrectly interpreted (see #32476). In that case, map_structure will map to each item in the tuple individually, giving an incorrect output, as if each item in the tuple was intended to be a separate vector, which is incongruous to the [Keras docs](https://keras.io/layers/writing-your-own-keras-layers/). In this edge case, it will convert the tuple to a TensorShape directly.

This is my first PR for Tensorflow, so let me know if there's anything I should change.