### PR TITLE
Switch IteratorTest to use TF combinations

### DIFF
--- a/tensorflow/python/data/kernel_tests/iterator_test.py
+++ b/tensorflow/python/data/kernel_tests/iterator_test.py
@@ -32,6 +32,7 @@ from tensorflow.python.data.ops import iterator_ops
 from tensorflow.python.data.util import structure
 from tensorflow.python.eager import context
 from tensorflow.python.eager import def_function
+from tensorflow.python.framework import combinations
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors
@@ -55,7 +56,8 @@ from tensorflow.python.util import compat
 
 class IteratorTest(test_base.DatasetTestBase, parameterized.TestCase):
 
-  @test_util.deprecated_graph_mode_only
+  @combinations.generate(
+      combinations.combine(tf_api_version=[1, 2], mode=["graph"]))
   def testNoGradients(self):
     component = constant_op.constant([1.])
     side = constant_op.constant(0.)
@@ -66,7 +68,8 @@ class IteratorTest(test_base.DatasetTestBase, parameterized.TestCase):
     self.assertIsNone(gradients_impl.gradients(value, side)[0])
     self.assertIsNone(gradients_impl.gradients(value, [component, side])[0])
 
-  @test_util.deprecated_graph_mode_only
+  @combinations.generate(
+      combinations.combine(tf_api_version=[1, 2], mode=["graph"]))
   def testCapturingStateInOneShotRaisesException(self):
     var = variables.Variable(37.0, name="myvar")
     dataset = (
@@ -77,7 +80,8 @@ class IteratorTest(test_base.DatasetTestBase, parameterized.TestCase):
         "datasets that capture stateful objects.+myvar"):
       dataset_ops.make_one_shot_iterator(dataset)
 
-  @test_util.deprecated_graph_mode_only
+  @combinations.generate(
+      combinations.combine(tf_api_version=[1, 2], mode=["graph"]))
   def testOneShotIterator(self):
     components = (np.arange(7),
                   np.array([[1, 2, 3]]) * np.arange(7)[:, np.newaxis],
@@ -103,7 +107,8 @@ class IteratorTest(test_base.DatasetTestBase, parameterized.TestCase):
       with self.assertRaises(errors.OutOfRangeError):
         sess.run(get_next)
 
-  @test_util.deprecated_graph_mode_only
+  @combinations.generate(
+      combinations.combine(tf_api_version=[1, 2], mode=["graph"]))
   def testOneShotIteratorCaptureByValue(self):
     components = (np.arange(7),
                   np.array([[1, 2, 3]]) * np.arange(7)[:, np.newaxis],
@@ -130,6 +135,7 @@ class IteratorTest(test_base.DatasetTestBase, parameterized.TestCase):
       with self.assertRaises(errors.OutOfRangeError):
         sess.run(get_next)
 
+  @combinations.generate(test_base.default_test_combinations())
   def testOneShotIteratorInsideContainer(self):
     components = (np.arange(7),
                   np.array([[1, 2, 3]]) * np.arange(7)[:, np.newaxis],
@@ -166,7 +172,8 @@ class IteratorTest(test_base.DatasetTestBase, parameterized.TestCase):
         with self.assertRaises(errors.OutOfRangeError):
           sess.run(get_next)
 
-  @test_util.deprecated_graph_mode_only
+  @combinations.generate(
+      combinations.combine(tf_api_version=[1, 2], mode=["graph"]))
   def testOneShotIteratorNonBlocking(self):
     dataset = dataset_ops.Dataset.from_tensors([1, 2, 3]).map(lambda x: x * x)
     iterator = dataset_ops.make_one_shot_iterator(dataset)
@@ -205,7 +212,8 @@ class IteratorTest(test_base.DatasetTestBase, parameterized.TestCase):
                        len([None for r in results if r is None]))
       self.assertAllEqual([[1, 4, 9]], [r for r in results if r is not None])
 
-  @test_util.deprecated_graph_mode_only
+  @combinations.generate(
+      combinations.combine(tf_api_version=[1, 2], mode=["graph"]))
   def testOneShotIteratorInitializerFails(self):
     # Define a dataset whose initialization will always fail.
     dataset = dataset_ops.Dataset.from_tensors(array_ops.gather([0], [4]))
@@ -235,7 +243,8 @@ class IteratorTest(test_base.DatasetTestBase, parameterized.TestCase):
       for t in threads:
         t.join()
 
-  @test_util.deprecated_graph_mode_only
+  @combinations.generate(
+      combinations.combine(tf_api_version=[1, 2], mode=["graph"]))
   def testSimpleSharedResource(self):
     components = (np.array(1, dtype=np.int64),
                   np.array([1, 2, 3], dtype=np.int64),
@@ -285,7 +294,8 @@ class IteratorTest(test_base.DatasetTestBase, parameterized.TestCase):
         with self.assertRaises(errors.OutOfRangeError):
           sess.run(get_next)
 
-  @test_util.deprecated_graph_mode_only
+  @combinations.generate(
+      combinations.combine(tf_api_version=[1, 2], mode=["graph"]))
   def testNotInitializedError(self):
     components = (np.array(1), np.array([1, 2, 3]), np.array(37.0))
     iterator = dataset_ops.make_initializable_iterator(
@@ -297,7 +307,8 @@ class IteratorTest(test_base.DatasetTestBase, parameterized.TestCase):
                                    "iterator has not been initialized"):
         sess.run(get_next)
 
-  @test_util.deprecated_graph_mode_only
+  @combinations.generate(
+      combinations.combine(tf_api_version=[1, 2], mode=["graph"]))
   def testReinitializableIterator(self):
     dataset_3 = dataset_ops.Dataset.from_tensors(
         constant_op.constant([1, 2, 3]))
@@ -342,7 +353,8 @@ class IteratorTest(test_base.DatasetTestBase, parameterized.TestCase):
       with self.assertRaises(errors.OutOfRangeError):
         sess.run(get_next)
 
-  @test_util.deprecated_graph_mode_only
+  @combinations.generate(
+      combinations.combine(tf_api_version=[1, 2], mode=["graph"]))
   def testReinitializableIteratorWithFunctions(self):
 
     def g():
@@ -369,6 +381,7 @@ class IteratorTest(test_base.DatasetTestBase, parameterized.TestCase):
       with self.assertRaises(errors.OutOfRangeError):
         sess.run(next_element)
 
+  @combinations.generate(test_base.default_test_combinations())
   def testReinitializableIteratorStaticErrors(self):
     # Non-matching structure for types and shapes.
     with self.assertRaises(TypeError):
@@ -402,7 +415,8 @@ class IteratorTest(test_base.DatasetTestBase, parameterized.TestCase):
               (constant_op.constant([1, 2, 3], dtype=dtypes.int64),
                constant_op.constant([4., 5., 6., 7.], dtype=dtypes.float64))))
 
-  @test_util.deprecated_graph_mode_only
+  @combinations.generate(
+      combinations.combine(tf_api_version=[1, 2], mode=["graph"]))
   def testIteratorStringHandle(self):
     dataset_3 = dataset_ops.Dataset.from_tensor_slices([1, 2, 3])
     dataset_4 = dataset_ops.Dataset.from_tensor_slices([10, 20, 30, 40])
@@ -460,7 +474,8 @@ class IteratorTest(test_base.DatasetTestBase, parameterized.TestCase):
         sess.run(
             next_element, feed_dict={handle_placeholder: iterator_4_handle})
 
-  @test_util.deprecated_graph_mode_only
+  @combinations.generate(
+      combinations.combine(tf_api_version=[1, 2], mode=["graph"]))
   def testIteratorStringHandleFuture(self):
     with forward_compat.forward_compatibility_horizon(2018, 8, 4):
       dataset_3 = dataset_ops.Dataset.from_tensor_slices([1, 2, 3])
@@ -526,7 +541,8 @@ class IteratorTest(test_base.DatasetTestBase, parameterized.TestCase):
           sess.run(
               next_element, feed_dict={handle_placeholder: iterator_4_handle})
 
-  @test_util.deprecated_graph_mode_only
+  @combinations.generate(
+      combinations.combine(tf_api_version=[1, 2], mode=["graph"]))
   def testIteratorStringHandleReuseTensorObject(self):
     dataset = dataset_ops.Dataset.from_tensor_slices([1, 2, 3])
     one_shot_iterator = dataset_ops.make_one_shot_iterator(dataset)
@@ -555,7 +571,8 @@ class IteratorTest(test_base.DatasetTestBase, parameterized.TestCase):
     self.assertEqual("foo_1", handle_with_same_name.op.name)
     self.assertIsNot(handle_with_name, handle_with_same_name)
 
-  @test_util.deprecated_graph_mode_only
+  @combinations.generate(
+      combinations.combine(tf_api_version=[1, 2], mode=["graph"]))
   def testIteratorStringHandleError(self):
     dataset_int_scalar = (
         dataset_ops.Dataset.from_tensor_slices([1, 2, 3]).repeat())
@@ -596,7 +613,8 @@ class IteratorTest(test_base.DatasetTestBase, parameterized.TestCase):
             feedable_int_vector.get_next(),
             feed_dict={handle_placeholder: handle_float_vector}))
 
-  @test_util.deprecated_graph_mode_only
+  @combinations.generate(
+      combinations.combine(tf_api_version=[1, 2], mode=["graph"]))
   def testRemoteIteratorUsingRemoteCallOpDirectSession(self):
     worker_config = config_pb2.ConfigProto()
     worker_config.device_count["CPU"] = 3
@@ -654,7 +672,8 @@ class IteratorTest(test_base.DatasetTestBase, parameterized.TestCase):
                 target_placeholder: "/job:localhost/replica:0/task:0/cpu:1"
             })
 
-  @test_util.deprecated_graph_mode_only
+  @combinations.generate(
+      combinations.combine(tf_api_version=[1, 2], mode=["graph"]))
   def testRemoteIteratorUsingRemoteCallOpMultiWorkers(self):
     s1 = server_lib.Server.create_local_server()
     s2 = server_lib.Server.create_local_server()
@@ -708,7 +727,8 @@ class IteratorTest(test_base.DatasetTestBase, parameterized.TestCase):
       with self.assertRaises(errors.OutOfRangeError):
         sess.run(n)
 
-  @test_util.deprecated_graph_mode_only
+  @combinations.generate(
+      combinations.combine(tf_api_version=[1, 2], mode=["graph"]))
   def testRemoteIteratorUsingRemoteCallOpDirectSessionGPUCPU(self):
     if not test_util.is_gpu_available():
       self.skipTest("No GPU available")
@@ -765,7 +785,8 @@ class IteratorTest(test_base.DatasetTestBase, parameterized.TestCase):
                 target_placeholder: "/job:localhost/replica:0/task:0/cpu:0"
             })
 
-  @test_util.deprecated_graph_mode_only
+  @combinations.generate(
+      combinations.combine(tf_api_version=[1, 2], mode=["graph"]))
   def testRepeatedGetNextWarning(self):
     iterator = dataset_ops.make_one_shot_iterator(dataset_ops.Dataset.range(10))
     warnings.simplefilter("always")
@@ -778,34 +799,43 @@ class IteratorTest(test_base.DatasetTestBase, parameterized.TestCase):
           iterator_ops.GET_NEXT_CALL_WARNING_MESSAGE, str(warning.message))
 
   # pylint: disable=g-long-lambda
-  @parameterized.named_parameters(
-      ("Tensor", lambda: constant_op.constant(37.0),
-       tensor_spec.TensorSpec([],
-                              dtypes.float32), ops.Tensor, dtypes.float32, []),
-      ("SparseTensor", lambda: sparse_tensor.SparseTensor(
-          indices=[[0]],
-          values=constant_op.constant([0], dtype=dtypes.int32),
-          dense_shape=[1]), sparse_tensor.SparseTensorSpec([1], dtypes.int32),
-       sparse_tensor.SparseTensor, dtypes.int32, [1]),
-      ("Nest", lambda: {
-          "a": constant_op.constant(37.0),
-          "b": (constant_op.constant(["Foo"]), constant_op.constant("Bar"))
-      }, {
-          "a":
-              tensor_spec.TensorSpec([], dtypes.float32),
-          "b": (tensor_spec.TensorSpec(
-              [1], dtypes.string), tensor_spec.TensorSpec([], dtypes.string))
-      }, {
-          "a": ops.Tensor,
-          "b": (ops.Tensor, ops.Tensor)
-      }, {
-          "a": dtypes.float32,
-          "b": (dtypes.string, dtypes.string)
-      }, {
-          "a": [],
-          "b": ([1], [])
-      }),
-  )
+  @combinations.generate(combinations.times(
+      test_base.default_test_combinations(),
+      combinations.combine(
+          tf_value_fn=lambda: constant_op.constant(37.0),
+          expected_element_structure=tensor_spec.TensorSpec([], dtypes.float32),
+          expected_output_classes=ops.Tensor,
+          expected_output_types=dtypes.float32, expected_output_shapes=[[]]) +
+      combinations.combine(
+          tf_value_fn=lambda: sparse_tensor.SparseTensor(
+              indices=[[0]], values=constant_op.constant(
+                  [0], dtype=dtypes.int32), dense_shape=[1]),
+          expected_element_structure=sparse_tensor.SparseTensorSpec(
+              [1], dtypes.int32),
+          expected_output_classes=sparse_tensor.SparseTensor,
+          expected_output_types=dtypes.int32, expected_output_shapes=[[1]]) +
+      combinations.combine(
+          tf_value_fn=lambda: {
+              "a": constant_op.constant(37.0),
+              "b": (constant_op.constant(["Foo"]), constant_op.constant("Bar"))
+          },
+          expected_element_structure={
+              "a": tensor_spec.TensorSpec([], dtypes.float32),
+              "b": (tensor_spec.TensorSpec([1], dtypes.string),
+                    tensor_spec.TensorSpec([], dtypes.string))
+          },
+          expected_output_classes={
+              "a": ops.Tensor,
+              "b": (ops.Tensor, ops.Tensor)
+          },
+          expected_output_types={
+              "a": dtypes.float32,
+              "b": (dtypes.string, dtypes.string)
+          },
+          expected_output_shapes={
+              "a": [],
+              "b": ([1], [])
+          })))
   def testIteratorStructure(self, tf_value_fn, expected_element_structure,
                             expected_output_classes, expected_output_types,
                             expected_output_shapes):
@@ -823,6 +853,7 @@ class IteratorTest(test_base.DatasetTestBase, parameterized.TestCase):
     self.assertEqual(expected_output_shapes,
                      dataset_ops.get_legacy_output_shapes(iterator))
 
+  @combinations.generate(test_base.default_test_combinations())
   def testIteratorGetNextName(self):
     with ops.Graph().as_default():
       iterator = dataset_ops.make_one_shot_iterator(
@@ -830,10 +861,9 @@ class IteratorTest(test_base.DatasetTestBase, parameterized.TestCase):
       next_element = iterator.get_next(name="overridden_name")
       self.assertEqual("overridden_name", next_element.op.name)
 
-  @parameterized.named_parameters(
-      ("Async", context.ASYNC),
-      ("Sync", context.SYNC),
-  )
+  @combinations.generate(combinations.combine(
+      tf_api_version=[1, 2], mode="eager",
+      execution_mode=[context.ASYNC, context.SYNC]))
   def testIteratorEagerIteration(self, execution_mode):
     with context.eager_mode(), context.execution_mode(execution_mode):
       val = 0
@@ -843,7 +873,8 @@ class IteratorTest(test_base.DatasetTestBase, parameterized.TestCase):
         self.assertEqual(val, foo.numpy())
         val += 1
 
-  @test_util.run_v2_only
+  @combinations.generate(
+      combinations.combine(tf_api_version=2, mode="eager"))
   def testIteratorV2Function(self):
 
     queue = data_flow_ops.FIFOQueue(10, dtypes.int64)
@@ -860,7 +891,8 @@ class IteratorTest(test_base.DatasetTestBase, parameterized.TestCase):
     for i in range(10):
       self.assertEqual(queue.dequeue().numpy(), i)
 
-  @test_util.run_v2_only
+  @combinations.generate(
+      combinations.combine(tf_api_version=2, mode="eager"))
   def testIteratorV2FunctionError(self):
     # In this test we verify that a function that raises an error ends up
     # properly deallocating the iterator resource.
@@ -890,7 +922,8 @@ class IteratorTest(test_base.DatasetTestBase, parameterized.TestCase):
 
     self.assertEqual(queue.size().numpy(), 2)
 
-  @test_util.run_v2_only
+  @combinations.generate(
+      combinations.combine(tf_api_version=2, mode="eager"))
   def testLimitedRetracing(self):
     trace_count = [0]
 


### PR DESCRIPTION
This PR switch `IteratorTest` to use TF combinations.