### PR TITLE
[xla] fix xla build on cuda devices without nccl

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -415,7 +415,7 @@ tf_cuda_library(
         "//tensorflow/core:stream_executor_no_cuda",
         "//tensorflow/stream_executor/cuda:cuda_activation",
         "//tensorflow/stream_executor/cuda:cuda_gpu_executor",
-    ] + if_cuda([
+    ] + if_nccl([
         "@local_config_nccl//:nccl",
     ]),
 )


### PR DESCRIPTION
Some cuda devices, such as Jetson devices, do not support NCCL.
Building `@local_config_nccl//:nccl` on such kind of devices
will cause problem.