### PR TITLE
[ROCm] Fix for the broken ROCm Nightly Community Supported Build

### DIFF
--- a/tensorflow/c/eager/c_api_experimental_test.cc
+++ b/tensorflow/c/eager/c_api_experimental_test.cc
@@ -82,9 +82,12 @@ void ExecuteWithProfiling(bool async) {
       {reinterpret_cast<const char*>(profiler_result->data),
        profiler_result->length}));
   string profile_proto_str = profile_proto.DebugString();
+#ifndef TENSORFLOW_USE_ROCM
+  // TODO(rocm): enable once GPU profiling is supported in ROCm mode
   if (!gpu_device_name.empty()) {
     EXPECT_TRUE(HasSubstr(profile_proto_str, "/device:GPU:0"));
   }
+#endif
   // "/host:CPU" is collected by TraceMe
   EXPECT_TRUE(HasSubstr(profile_proto_str, "/host:CPU"));
   EXPECT_TRUE(HasSubstr(profile_proto_str, "MatMul"));


### PR DESCRIPTION
The following commit causes the ` `//tensorflow/c/eager:c_api_experimental_test_gpu` test to fail leading to breakage in the ROCm Nightly Community Supported Build

https://github.com/tensorflow/tensorflow/commit/263200e6a10dce513baf938f47005f5b2ea2cf69

The diff at this line is the cause:
https://github.com/tensorflow/tensorflow/commit/263200e6a10dce513baf938f47005f5b2ea2cf69#diff-14a3327e71c141f7761cbfcf221cd4b9R331

The failure occurs (in the `ExecuteWithTracing` subtest) because the string "GPU:0" does not show up in the profiling result (even though the MatMul op is successfully placed on the GPU).

Though profiler is not enabled in ROCm mode, this test used to pass because the "label" associated with op-kernel execution event used to include the device name (which had "GPU:0" in it).

The change in the commit above drops the device name from the "label" and hence the test starts to fail.

Disabling the "GPU:0" check in ROCm mode for now. It should be re-enabled when profiling support is added in ROCm mode.

-----------------------------------------

@whchung @chsigg 