### PR TITLE
slightly optimize tflite Concatenate operation

### DIFF
--- a/tensorflow/lite/kernels/internal/reference/reference_ops.h
+++ b/tensorflow/lite/kernels/internal/reference/reference_ops.h
@@ -1147,13 +1147,18 @@ inline void Concatenation(const ConcatenationParams& params,
     base_inner_size *= output_shape.Dims(i);
   }
 
+  std::vector<int> copy_sizes;
+  std::vector<Scalar*> input_ptrs;
+  for (int i = 0; i < inputs_count; ++i) {
+    copy_sizes.push_back(input_shapes[i]->Dims(axis) * base_inner_size);
+    input_ptrs.push_back(const_cast<Scalar*>(input_data[i]));
+  }
   Scalar* output_ptr = output_data;
   for (int k = 0; k < outer_size; k++) {
     for (int i = 0; i < inputs_count; ++i) {
-      const int copy_size = input_shapes[i]->Dims(axis) * base_inner_size;
-      memcpy(output_ptr, input_data[i] + k * copy_size,
-             copy_size * sizeof(Scalar));
-      output_ptr += copy_size;
+      memcpy(output_ptr, input_ptrs[i], copy_sizes[i] * sizeof(Scalar));
+      output_ptr += copy_sizes[i];
+      input_ptrs[i] += copy_sizes[i];
     }
   }
 }


### PR DESCRIPTION
Current implementation of tflite Concatenation calculates copy_size by accessing member varibales in innermost loop. It is redundant and causes performance loss.

This pull request reduces redundant member accesses, and get 20% performance gain.

The method I use for performance estimation is explained below.
This python script outputs example tflite model:
```
import tensorflow as tf
from tensorflow import keras
from tensorflow.keras import backend as K
from tensorflow.keras.layers import *
from tensorflow.keras.models import *

# construct model
a = Input(shape=(300, 300, 8))
b = Input(shape=(300, 300, 8))
y = Concatenate()([a, b])
model = Model(inputs=[a, b], outputs=[y])

# model path
keras_path = "model.h5"
tflite_path = "model.tflite"

# keras -> keras h5
keras.models.save_model(model, keras_path, include_optimizer=False)

# keras h5 -> tflite
converter = tf.lite.TFLiteConverter.from_keras_model_file(keras_path)
tflite_model = converter.convert()
open(tflite_path, "wb").write(tflite_model)
```

Here is output of benchmark_model with current implementation:

```
$./benchmark_model --graph=model.tflite --num_runs=10000
STARTING!
Min num runs: [10000]
Min runs duration (seconds): [1]
Max runs duration (seconds): [150]
Inter-run delay (seconds): [-1]
Num threads: [1]
Benchmark name: []
Output prefix: []
Min warmup runs: [1]
Min warmup runs duration (seconds): [0.5]
Graph: [model.tflite]
Input layers: []
Input shapes: []
Use gpu : [0]
Allow fp16 : [0]
Require full delegation : [0]
Enable op profiling: [0]
Max profiling buffer entries: [1024]
Loaded model model.tflite
resolved reporter
Initialized session in 0.145ms
Running benchmark for at least 1 iterations and at least 0.5 seconds but terminate if exceeding 150 seconds.
count=516 first=2018 curr=542 min=541 max=2018 avg=598.953 std=100

Running benchmark for at least 10000 iterations and at least 1 seconds but terminate if exceeding 150 seconds.
count=10000 first=608 curr=563 min=539 max=2371 avg=612.409 std=83

Average inference timings in us: Warmup: 598.953, Init: 145, no stats: 612.409
```

and with optimized implementation:
```
$./benchmark_model --graph=model.tflite --num_runs=10000
STARTING!
Min num runs: [10000]
Min runs duration (seconds): [1]
Max runs duration (seconds): [150]
Inter-run delay (seconds): [-1]
Num threads: [1]
Benchmark name: []
Output prefix: []
Min warmup runs: [1]
Min warmup runs duration (seconds): [0.5]
Graph: [model.tflite]
Input layers: []
Input shapes: []
Use gpu : [0]
Allow fp16 : [0]
Require full delegation : [0]
Enable op profiling: [0]
Max profiling buffer entries: [1024]
Loaded model model.tflite
resolved reporter
Initialized session in 0.143ms
Running benchmark for at least 1 iterations and at least 0.5 seconds but terminate if exceeding 150 seconds.
count=543 first=1852 curr=457 min=450 max=1852 avg=541.483 std=91

Running benchmark for at least 10000 iterations and at least 1 seconds but terminate if exceeding 150 seconds.
count=10000 first=462 curr=458 min=447 max=2558 avg=481.11 std=87

Average inference timings in us: Warmup: 541.483, Init: 143, no stats: 481.11
```
