### PR TITLE
[XLA] Thunk to cudnn fp16 kernels for F16 batchnormalization and enable cudnn for batchnormalization by default

### DIFF
--- a/tensorflow/compiler/xla/debug_options_flags.cc
+++ b/tensorflow/compiler/xla/debug_options_flags.cc
@@ -42,9 +42,8 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_cpu_use_mkl_dnn(true);
 #endif  // INTEL_MKL
   opts.set_xla_gpu_max_kernel_unroll_factor(4);
-  // Set cudnn batchnorm off by default; it does not provide a performance win
-  // on average.
-  opts.set_xla_gpu_use_cudnn_batchnorm(false);
+  // Set cudnn batchnorm on by default.
+  opts.set_xla_gpu_use_cudnn_batchnorm(true);
 
   // Run all GPU work on one stream by default.  Using multiple streams
   // increases memory usage and we lack strong motivating benchmarks for tuning

--- a/tensorflow/compiler/xla/service/gpu/cudnn_batchnorm_rewriter.cc
+++ b/tensorflow/compiler/xla/service/gpu/cudnn_batchnorm_rewriter.cc
@@ -104,8 +104,8 @@ Status Visitor::HandleBatchNormInference(HloInstruction* batch_norm) {
   auto batchnorm_inference_result = HloInstruction::CreateCustomCall(
       batch_norm_shape, operands, kCudnnBatchNormForwardInferenceCallTarget);
   if (IsF32BatchNormWithFP16Inputs(batch_norm)) {
-    HloInstruction* libcall = computation_->AddInstruction(
-        std::move(batchnorm_inference_result /*custom_call*/));
+    HloInstruction* libcall =
+        computation_->AddInstruction(std::move(batchnorm_inference_result));
     Shape shape_f32 = ShapeUtil::ChangeElementType(libcall->shape(), F32);
     batchnorm_inference_result =
         HloInstruction::CreateConvert(shape_f32, libcall);

--- a/tensorflow/compiler/xla/service/gpu/cudnn_batchnorm_rewriter.cc
+++ b/tensorflow/compiler/xla/service/gpu/cudnn_batchnorm_rewriter.cc
@@ -45,12 +45,29 @@ class Visitor : public DfsHloVisitorWithDefault {
  private:
   bool changed_ = false;
   HloComputation* computation_;
+  std::function<HloInstruction*(HloInstruction*, PrimitiveType)> add_convert =
+      [this](HloInstruction* hlo, PrimitiveType elem_type) -> HloInstruction* {
+    Shape shape_ = ShapeUtil::ChangeElementType(hlo->shape(), elem_type);
+    return this->computation_->AddInstruction(
+        HloInstruction::CreateConvert(shape_, hlo));
+  };
 };
 
 // cudnn defines CUDNN_BN_MIN_EPSILON = 1e-5 as the minimum acceptable epsilon
 // for calls to its batchnorm ops.
 bool EpsilonInRange(HloInstruction* batch_norm) {
   return batch_norm->epsilon() >= 1e-5;
+}
+
+bool IsBatchNormFP16(HloInstruction* batch_norm) {
+  auto convert = batch_norm->operand(0);
+  if (convert->opcode() != HloOpcode::kConvert) {
+    return false;
+  }
+  if (convert->operand(0)->shape().element_type() != F16) {
+    return false;
+  }
+  return true;
 }
 
 Status Visitor::HandleBatchNormInference(HloInstruction* batch_norm) {
@@ -78,13 +95,34 @@ Status Visitor::HandleBatchNormInference(HloInstruction* batch_norm) {
 
   std::vector<HloInstruction*> operands(batch_norm->operands().begin(),
                                         batch_norm->operands().end());
+
+  bool is_convert_inserted = false;
+  if (IsBatchNormFP16(batch_norm)) {
+    operands[0] = add_convert(batch_norm->mutable_operand(0), F16);
+    is_convert_inserted = true;
+  }
   operands.push_back(epsilon);
   operands.push_back(feature_index);
 
-  std::unique_ptr<HloInstruction> libcall = HloInstruction::CreateCustomCall(
-      batch_norm->shape(), operands, kCudnnBatchNormForwardInferenceCallTarget);
-  TF_RETURN_IF_ERROR(
-      computation_->ReplaceWithNewInstruction(batch_norm, std::move(libcall)));
+  auto batch_norm_shape = ShapeUtil::MakeShape(
+      operands[0]->shape().element_type(), batch_norm->shape().dimensions());
+
+  auto create_custom_call = [&]() -> std::unique_ptr<HloInstruction> {
+    return HloInstruction::CreateCustomCall(
+        batch_norm_shape, operands, kCudnnBatchNormForwardInferenceCallTarget);
+  };
+  std::unique_ptr<HloInstruction> new_libcall;
+  if (is_convert_inserted) {
+    HloInstruction* libcall =
+        computation_->AddInstruction(create_custom_call());
+    Shape shape_f32 = ShapeUtil::ChangeElementType(libcall->shape(), F32);
+    new_libcall = HloInstruction::CreateConvert(shape_f32, libcall);
+  } else {
+    new_libcall = create_custom_call();
+  }
+
+  TF_RETURN_IF_ERROR(computation_->ReplaceWithNewInstruction(
+      batch_norm, std::move(new_libcall)));
   changed_ = true;
   return Status::OK();
 }
@@ -114,12 +152,28 @@ Status Visitor::HandleBatchNormTraining(HloInstruction* batch_norm) {
 
   std::vector<HloInstruction*> operands(batch_norm->operands().begin(),
                                         batch_norm->operands().end());
+
+  bool is_convert_inserted = false;
+  if (IsBatchNormFP16(batch_norm)) {
+    operands[0] = add_convert(batch_norm->mutable_operand(0), F16);
+    is_convert_inserted = true;
+  }
   operands.push_back(epsilon);
   operands.push_back(feature_index);
 
+  std::vector<Shape> batch_norm_tuple_shape;
+  batch_norm_tuple_shape.push_back(
+      ShapeUtil::MakeShape(operands[0]->shape().element_type(),
+                           batch_norm->shape().tuple_shapes(0).dimensions()));
+  for (int i = 1; i < batch_norm->shape().tuple_shapes_size(); i++) {
+    batch_norm_tuple_shape.push_back(batch_norm->shape().tuple_shapes(i));
+  }
+  const Shape& batch_norm_shape =
+      ShapeUtil::MakeTupleShape(batch_norm_tuple_shape);
+
   HloInstruction* libcall =
       computation_->AddInstruction(HloInstruction::CreateCustomCall(
-          batch_norm->shape(), operands,
+          batch_norm_shape, operands,
           kCudnnBatchNormForwardTrainingCallTarget));
 
   // The cudnn libcall returns a tuple
@@ -143,17 +197,33 @@ Status Visitor::HandleBatchNormTraining(HloInstruction* batch_norm) {
           computation_->AddInstruction(HloInstruction::CreateBroadcast(
               variance_plus_epsilon->shape(), epsilon, {}))));
 
-  // Repackage the results.
-  std::unique_ptr<HloInstruction> new_tuple = HloInstruction::CreateTuple({
+  HloInstruction* new_tuple =
+      computation_->AddInstruction(HloInstruction::CreateTuple({
+          computation_->AddInstruction(HloInstruction::CreateGetTupleElement(
+              libcall->shape().tuple_shapes(0), libcall, 0)),
+          computation_->AddInstruction(HloInstruction::CreateGetTupleElement(
+              libcall->shape().tuple_shapes(1), libcall, 1)),
+          variance,
+      }));
+
+  HloInstruction* new_gte =
       computation_->AddInstruction(HloInstruction::CreateGetTupleElement(
-          libcall->shape().tuple_shapes(0), libcall, 0)),
-      computation_->AddInstruction(HloInstruction::CreateGetTupleElement(
-          libcall->shape().tuple_shapes(1), libcall, 1)),
-      variance,
-  });
+          new_tuple->shape().tuple_shapes(0), new_tuple, 0));
+
+  if (is_convert_inserted) {
+    new_gte = add_convert(new_gte, F32);
+  }
+  // Repackage the results. Athough this tuple is redundant when convert is not
+  // inserted, TupleSimplifier eliminates the Tuple eventually
+  std::unique_ptr<HloInstruction> replacing_tuple = HloInstruction::CreateTuple(
+      {new_gte,
+       computation_->AddInstruction(HloInstruction::CreateGetTupleElement(
+           new_tuple->shape().tuple_shapes(1), new_tuple, 1)),
+       computation_->AddInstruction(HloInstruction::CreateGetTupleElement(
+           new_tuple->shape().tuple_shapes(1), new_tuple, 2))});
 
   TF_RETURN_IF_ERROR(computation_->ReplaceWithNewInstruction(
-      batch_norm, std::move(new_tuple)));
+      batch_norm, std::move(replacing_tuple)));
   changed_ = true;
   return Status::OK();
 }
@@ -195,15 +265,57 @@ Status Visitor::HandleBatchNormGrad(HloInstruction* batch_norm) {
 
   std::vector<HloInstruction*> operands(batch_norm->operands().begin(),
                                         batch_norm->operands().end());
+  bool is_convert_inserted = false;
+  if (IsBatchNormFP16(batch_norm)) {
+    HloInstruction* operand_0_convert = batch_norm->mutable_operand(0);
+    operands[0] = add_convert(operand_0_convert, F16);
+    for (auto index = 1; index < operands.size(); index++) {
+      if ((batch_norm->operand(index)->opcode() == HloOpcode::kConvert) &&
+          (batch_norm->operand(index)->operand(0)->shape().element_type() ==
+           F16) &&
+          (ShapeUtil::Compatible(
+              operand_0_convert->shape(),
+              batch_norm->mutable_operand(index)->shape()))) {
+        operands[index] = add_convert(batch_norm->mutable_operand(index), F16);
+      }
+    }
+    is_convert_inserted = true;
+  }
   operands[3] = inverse_stddev;
   operands.push_back(epsilon);
   operands.push_back(feature_index);
 
-  std::unique_ptr<HloInstruction> libcall = HloInstruction::CreateCustomCall(
-      batch_norm->shape(), operands, kCudnnBatchNormBackwardCallTarget);
+  std::vector<Shape> batch_norm_tuple_shape;
+  batch_norm_tuple_shape.push_back(
+      ShapeUtil::MakeShape(operands[0]->shape().element_type(),
+                           batch_norm->shape().tuple_shapes(0).dimensions()));
+  for (int i = 1; i < batch_norm->shape().tuple_shapes_size(); i++) {
+    batch_norm_tuple_shape.push_back(batch_norm->shape().tuple_shapes(i));
+  }
+  const Shape& batch_norm_shape =
+      ShapeUtil::MakeTupleShape(batch_norm_tuple_shape);
+  HloInstruction* libcall =
+      computation_->AddInstruction(HloInstruction::CreateCustomCall(
+          batch_norm_shape, operands, kCudnnBatchNormBackwardCallTarget));
 
-  TF_RETURN_IF_ERROR(
-      computation_->ReplaceWithNewInstruction(batch_norm, std::move(libcall)));
+  HloInstruction* new_gte =
+      computation_->AddInstruction(HloInstruction::CreateGetTupleElement(
+          libcall->shape().tuple_shapes(0), libcall, 0));
+
+  if (is_convert_inserted) {
+    new_gte = add_convert(new_gte, F32);
+  }
+  // Repackage the results. Athough this tuple is redundant when convert is not
+  // inserted, TupleSimplifier eliminates the Tuple eventually
+  std::unique_ptr<HloInstruction> replacing_tuple = HloInstruction::CreateTuple(
+      {new_gte,
+       computation_->AddInstruction(HloInstruction::CreateGetTupleElement(
+           libcall->shape().tuple_shapes(1), libcall, 1)),
+       computation_->AddInstruction(HloInstruction::CreateGetTupleElement(
+           libcall->shape().tuple_shapes(1), libcall, 2))});
+
+  TF_RETURN_IF_ERROR(computation_->ReplaceWithNewInstruction(
+      batch_norm, std::move(replacing_tuple)));
   changed_ = true;
   return Status::OK();
 }

--- a/tensorflow/compiler/xla/service/gpu/cudnn_batchnorm_thunk.cc
+++ b/tensorflow/compiler/xla/service/gpu/cudnn_batchnorm_thunk.cc
@@ -31,7 +31,7 @@ namespace gpu {
 namespace dnn = se::dnn;
 
 namespace {
-void IsInputOutputDtypeValid(const HloInstruction* hlo) {
+void CheckInputOutputPrimitivetypeValid(const HloInstruction* hlo) {
   // Check Inputs.
   int64 num_operands = hlo->operand_count();
   PrimitiveType operand_dtype = hlo->operand(0)->shape().element_type();
@@ -136,7 +136,7 @@ CudnnBatchNormForwardInferenceThunk::CudnnBatchNormForwardInferenceThunk(
            kCudnnBatchNormForwardInferenceCallTarget);
   CHECK(
       LayoutUtil::LayoutsInShapesEqual(hlo->shape(), hlo->operand(0)->shape()));
-  IsInputOutputDtypeValid(hlo);
+  CheckInputOutputPrimitivetypeValid(hlo);
 }
 
 Status CudnnBatchNormForwardInferenceThunk::ExecuteOnStream(
@@ -245,7 +245,7 @@ CudnnBatchNormForwardTrainingThunk::CudnnBatchNormForwardTrainingThunk(
   CHECK_EQ(hlo->shape().tuple_shapes_size(), 3);
   CHECK(LayoutUtil::LayoutsInShapesEqual(hlo->shape().tuple_shapes(0),
                                          hlo->operand(0)->shape()));
-  IsInputOutputDtypeValid(hlo);
+  CheckInputOutputPrimitivetypeValid(hlo);
 }
 
 Status CudnnBatchNormForwardTrainingThunk::ExecuteOnStream(
@@ -374,7 +374,7 @@ CudnnBatchNormBackwardThunk::CudnnBatchNormBackwardThunk(
                                          hlo->operand(0)->shape()));
   CHECK(LayoutUtil::LayoutsInShapesEqual(hlo->shape().tuple_shapes(0),
                                          hlo->operand(4)->shape()));
-  IsInputOutputDtypeValid(hlo);
+  CheckInputOutputPrimitivetypeValid(hlo);
 }
 
 Status CudnnBatchNormBackwardThunk::ExecuteOnStream(

--- a/tensorflow/compiler/xla/service/hlo_verifier.cc
+++ b/tensorflow/compiler/xla/service/hlo_verifier.cc
@@ -927,6 +927,9 @@ Status CheckMixedPrecisionOperands(const HloInstruction* instruction) {
     case HloOpcode::kSort:
     case HloOpcode::kTuple:
     case HloOpcode::kWhile:
+    case HloOpcode::kBatchNormGrad:
+    case HloOpcode::kBatchNormInference:
+    case HloOpcode::kBatchNormTraining:
       break;
     default: {
       PrimitiveType fp_type = PRIMITIVE_TYPE_INVALID;


### PR DESCRIPTION
When using cuDNN for batchnormalization, xla currently thunks fp16 batchnorms to fp32 kernels by casting fp16 inputs and gradients to fp32 in the tf2xla bridge. This is non-optimal since cuDNN 7.6 has highly efficient `Half` kernels that can be leveraged. This PR modifies `cudnn_batchnorm_rewriter` and `cudnn_batchnorm_thunk` such that the converts introduced in the bridge get eliminated and the corresponding fp16 cudnn APIs get called. 
Note that instead of eliminating convert ops, I add converts which then get eliminated by `algebraic_simplifier`. [PR](https://github.com/tensorflow/tensorflow/pull/32435) adding capability to eliminate of convert pairs was merged earlier.

While investigating performance of mobilenet, it was found that enabling cuDNN for Batchnorm improves performance by around 10-12%. Running the numbers for a set of convolutional networks in addition to mobilenet with cuDNN turned on for Batchnorm, showed that enabling cuDNN, either improves performance or keeps it the same. This PR enables cudnn for batchnorm by default  based on the above-mentioned performance enhancements.