### PR TITLE
[XLA:GPU][ROCm] Enabling amdgpu backend in XLA unit tests

### DIFF
--- a/tensorflow/compiler/xla/tests/build_defs.bzl
+++ b/tensorflow/compiler/xla/tests/build_defs.bzl
@@ -1,20 +1,22 @@
 """Build rules for XLA testing."""
 
 load("@local_config_cuda//cuda:build_defs.bzl", "cuda_is_configured")
+load("@local_config_rocm//rocm:build_defs.bzl", "rocm_is_configured")
 load("//tensorflow/compiler/xla/tests:plugin.bzl", "plugins")
 load("//tensorflow:tensorflow.bzl", "tf_cc_test")
 load(
     "//tensorflow/core/platform:default/build_config_root.bzl",
     "tf_cuda_tests_tags",
+    "tf_gpu_tests_tags",
 )
 
 all_backends = ["cpu", "gpu"] + plugins.keys()
 
 def filter_backends(backends):
-    """Removes "gpu" from a backend list if CUDA is not enabled.
+    """Removes "gpu" from a backend list if Cuda or Rocm is not enabled.
 
     This allows us to simply hardcode lists including "gpu" here and in the
-    BUILD file, without causing failures when CUDA isn't enabled.'
+    BUILD file, without causing failures when Cuda or Rocm isn't enabled.'
 
     Args:
       backends: A list of backends to filter.
@@ -23,6 +25,8 @@ def filter_backends(backends):
       The filtered list of backends.
     """
     if cuda_is_configured():
+        return backends
+    elif rocm_is_configured():
         return backends
     else:
         return [backend for backend in backends if backend != "gpu"]

--- a/tensorflow/compiler/xla/tests/build_defs.bzl
+++ b/tensorflow/compiler/xla/tests/build_defs.bzl
@@ -13,10 +13,10 @@ load(
 all_backends = ["cpu", "gpu"] + plugins.keys()
 
 def filter_backends(backends):
-    """Removes "gpu" from a backend list if Cuda or Rocm is not enabled.
+    """Removes "gpu" from a backend list if CUDA or ROCm is not enabled.
 
     This allows us to simply hardcode lists including "gpu" here and in the
-    BUILD file, without causing failures when Cuda or Rocm isn't enabled.'
+    BUILD file, without causing failures when CUDA or ROCm isn't enabled.'
 
     Args:
       backends: A list of backends to filter.
@@ -24,9 +24,7 @@ def filter_backends(backends):
     Returns:
       The filtered list of backends.
     """
-    if cuda_is_configured():
-        return backends
-    elif rocm_is_configured():
+    if cuda_is_configured() or rocm_is_configured():
         return backends
     else:
         return [backend for backend in backends if backend != "gpu"]


### PR DESCRIPTION
This PR enables amdgpu XLA backend for unit tests, in preparation for setting up ROCm XLA community support builds.