### PR TITLE
[r1.15-CherryPick]:Cast `inputs` array to float64 in case of big endian architecture for normalization

### DIFF
--- a/tensorflow/contrib/layers/python/layers/normalization.py
+++ b/tensorflow/contrib/layers/python/layers/normalization.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import sys
 
 from tensorflow.contrib.framework.python.ops import add_arg_scope
 from tensorflow.contrib.framework.python.ops import variables
@@ -27,7 +28,7 @@ from tensorflow.python.ops import init_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import nn
 from tensorflow.python.ops import variable_scope
-
+from tensorflow.python.framework import dtypes
 
 __all__ = [
     'group_norm',
@@ -93,6 +94,12 @@ def instance_norm(inputs,
   inputs = ops.convert_to_tensor(inputs)
   inputs_shape = inputs.shape
   inputs_rank = inputs.shape.ndims
+  # For big endian, precision difference in last decimal values getting in
+  # float32 Vs float64 data type is causing normalization_test failure.
+  # The cast to float64 will calculate mean and variance correctly while
+  # normalization of `inputs` tensor.
+  if sys.byteorder == "big" and inputs.dtype.base_dtype == dtypes.float32:
+    inputs = math_ops.cast(inputs, dtypes.float64)
 
   if inputs_rank is None:
     raise ValueError('Inputs %s has undefined rank.' % inputs.name)


### PR DESCRIPTION
Hi @goldiegadde, @martinwicke,

Creating this cherry-pick with reference to https://github.com/tensorflow/tensorflow/pull/31188/. Thanks.