### PR TITLE
[ROCm] Droppping "contrib" references from the ROCm CSB script

### DIFF
--- a/tensorflow/tools/ci_build/linux/rocm/run_csb_tests.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_csb_tests.sh
@@ -48,10 +48,8 @@ bazel test \
       -- \
       //tensorflow/... \
       -//tensorflow/compiler/... \
-      -//tensorflow/contrib/... \
       -//tensorflow/lite/... \
       -//tensorflow/python/compiler/tensorrt/... \
-# Run tests requiring more than one GPU separately.
 && bazel test \
       --config=rocm \
       -k \
@@ -64,7 +62,6 @@ bazel test \
       -- \
       //tensorflow/... \
       -//tensorflow/compiler/... \
-      -//tensorflow/contrib/... \
       -//tensorflow/lite/... \
       -//tensorflow/python/compiler/tensorrt/... \
 


### PR DESCRIPTION
The script used to do the ROCm Community Supported Build had references to the "tensorflow/contrib" directory. Now that the "contrib" dir is gone, the references to it are causing the CSB to error out, wven the build + all the tests are passing.

-------------------------

@whchung @chsigg 