### PR TITLE
Fix _CumprodGrad for 0. inputs

### DIFF
--- a/tensorflow/python/ops/math_grad.py
+++ b/tensorflow/python/ops/math_grad.py
@@ -1831,11 +1831,10 @@ def _CumprodGrad(op, grad):
   exclusive = op.get_attr("exclusive")
   reverse = op.get_attr("reverse")
 
-  # TODO This fails when x contains 0 and should be fixed
   prod = math_ops.cumprod(x, axis, exclusive=exclusive, reverse=reverse)
   out = math_ops.cumsum(
       prod * grad, axis, exclusive=exclusive, reverse=not reverse)
-  return [out / x, None]
+  return [math_ops.div_no_nan(out, x), None]
 
 
 @ops.RegisterGradient("CumulativeLogsumexp")


### PR DESCRIPTION
The gradient of cumprod returned nan/inf, if it is given 0 inputs. A simple solution to this problem is to use math_ops.div_no_nan to compute the gradient instead of a normal div. This has the exact behaviour we need, it returns 0 for positions where x is 0, which is exactly the gradient at these positions anyways.