### PR TITLE
Improve API doc for ZipDataset

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_ZipDataset.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ZipDataset.pbtxt
@@ -1,5 +1,37 @@
 op {
   graph_op_name: "ZipDataset"
   visibility: HIDDEN
+  in_arg {
+    name: "input_datasets"
+    description: <<END
+List of `N` variant Tensors representing datasets to be zipped together.
+END
+  }
+  attr {
+    name: "output_types"
+  }
+  attr {
+    name: "output_shapes"
+  }
+  attr {
+    name: "N"
+    description: "The length of `input_datasets`"
+  }
   summary: "Creates a dataset that zips together `input_datasets`."
+  description: <<END
+The resulting dataset will produce a stream of elements, where elements `k`
+contains the concatenation of the `k`th elements from each of the input
+datasets.
+
+The stream will stop as soon as any one of the input datasets runs out 
+of elements, and noerror will be raised if the other datasets contain 
+additional data.
+
+`ZipDataset` invokes its input datasets serially, one record at a time.
+
+Most instances of this type of dataset come from the `zip()` method in
+`tf.data.DataSet`.  The `hoist_random_uniform`
+static optimization also creates instances of `ZipDataset` while rewriting
+stateful functions into stateless functions.
+END
 }

--- a/tensorflow/core/api_def/base_api/api_def_ZipDataset.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ZipDataset.pbtxt
@@ -19,19 +19,11 @@ END
   }
   summary: "Creates a dataset that zips together `input_datasets`."
   description: <<END
-The resulting dataset will produce a stream of elements, where elements `k`
-contains the concatenation of the `k`th elements from each of the input
-datasets.
+The resulting dataset will produce a stream of elements, whose elements are 
+created by zipping corresponding elements from each of the input datasets.
 
 The stream will stop as soon as any one of the input datasets runs out 
-of elements, and noerror will be raised if the other datasets contain 
+of elements, and no error will be raised if the other datasets contain 
 additional data.
-
-`ZipDataset` invokes its input datasets serially, one record at a time.
-
-Most instances of this type of dataset come from the `zip()` method in
-`tf.data.DataSet`.  The `hoist_random_uniform`
-static optimization also creates instances of `ZipDataset` while rewriting
-stateful functions into stateless functions.
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_ZipDataset.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ZipDataset.pbtxt
@@ -19,11 +19,10 @@ END
   }
   summary: "Creates a dataset that zips together `input_datasets`."
   description: <<END
-The resulting dataset will produce a stream of elements, whose elements are 
-created by zipping corresponding elements from each of the input datasets.
+The elements of the resulting dataset are created by zipping corresponding 
+elements from each of the input datasets.
 
-The stream will stop as soon as any one of the input datasets runs out 
-of elements, and no error will be raised if the other datasets contain 
-additional data.
+The size of the resulting dataset will match the size of the smallest input
+dataset, and no error will be raised if input datasets have different sizes.
 END
 }


### PR DESCRIPTION
This PR fills out the API documentation for the `ZipDataset` op. I extended the arguments lists to match the operator's definition, and I added a few paragraphs of description, including information about the different code paths by which a `ZipDataset` op might show up in a graph.