### PR TITLE
Simplify the signature of DatasetParams::GetInputs()

### DIFF
--- a/tensorflow/core/kernels/data/cache_dataset_ops_test.cc
+++ b/tensorflow/core/kernels/data/cache_dataset_ops_test.cc
@@ -36,15 +36,10 @@ class CacheDatasetParams : public DatasetParams {
         input_dataset_params.op_name(), input_dataset_params.iterator_prefix());
   }
 
-  Status GetInputs(const std::vector<Tensor*>& input_datasets,
-                   std::vector<std::unique_ptr<Tensor>>* created_tensors,
-                   gtl::InlinedVector<TensorValue, 4>* inputs) const override {
-    inputs->clear();
-    TF_RETURN_IF_ERROR(AddDatasetInputs(input_datasets, 1, inputs));
+  std::vector<Tensor> GetInputTensors() const override {
     Tensor filename_tensor =
         CreateTensor<tstring>(TensorShape({}), {filename_});
-    AddTensorInputs({filename_tensor}, created_tensors, inputs);
-    return Status::OK();
+    return {filename_tensor};
   }
 
   Status GetInputPlaceholder(

--- a/tensorflow/core/kernels/data/concatenate_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/concatenate_dataset_op_test.cc
@@ -40,13 +40,7 @@ class ConcatenateDatasetParams : public DatasetParams {
                                    input_dataset_params_0.iterator_prefix());
   }
 
-  Status GetInputs(const std::vector<Tensor*>& input_datasets,
-                   std::vector<std::unique_ptr<Tensor>>* created_tensors,
-                   gtl::InlinedVector<TensorValue, 4>* inputs) const override {
-    inputs->clear();
-    TF_RETURN_IF_ERROR(AddDatasetInputs(input_datasets, 2, inputs));
-    return Status::OK();
-  }
+  std::vector<Tensor> GetInputTensors() const override { return {}; }
 
   Status GetInputPlaceholder(
       std::vector<string>* input_placeholder) const override {

--- a/tensorflow/core/kernels/data/dataset_test_base.cc
+++ b/tensorflow/core/kernels/data/dataset_test_base.cc
@@ -770,8 +770,11 @@ Status DatasetOpsTestBaseV2::MakeDataset(
     created_tensors->push_back(std::move(t));
   }
   gtl::InlinedVector<TensorValue, 4> inputs;
-  TF_RETURN_IF_ERROR(
-      dataset_params.GetInputs(input_datasets, created_tensors, &inputs));
+  for (auto input_dataset : input_datasets) {
+    inputs.emplace_back(TensorValue(input_dataset));
+  }
+  AddTensorInputs(dataset_params.GetInputTensors(), created_tensors, &inputs);
+
   TF_RETURN_IF_ERROR(MakeDatasetOpKernel(dataset_params, dataset_kernel));
   TF_RETURN_IF_ERROR(CreateDatasetContext(dataset_kernel->get(), &inputs,
                                           dataset_ctx_params, dataset_ctx));
@@ -826,13 +829,14 @@ Status DatasetOpsTestBaseV2::MakeDatasetTensor(
 
   AttributeVector attributes;
   TF_RETURN_IF_ERROR(dataset_params.GetAttributes(&attributes));
-  gtl::InlinedVector<TensorValue, 4> inputs;
-  TF_RETURN_IF_ERROR(
-      dataset_params.GetInputs(input_datasets, created_tensors, &inputs));
-  std::vector<Tensor> input_tensors;
-  for (auto& tensor_value : inputs) {
-    input_tensors.emplace_back(*tensor_value.tensor);
+
+  std::vector<Tensor> dataset_inputs;
+  for (auto input_dataset : input_datasets) {
+    dataset_inputs.emplace_back(*input_dataset);
   }
+  auto input_tensors = dataset_params.GetInputTensors();
+  dataset_inputs.insert(dataset_inputs.end(), input_tensors.begin(),
+                        input_tensors.end());
 
   GraphConstructorOptions graph_opts;
   graph_opts.allow_internal_ops = true;
@@ -841,9 +845,20 @@ Status DatasetOpsTestBaseV2::MakeDatasetTensor(
   TF_RETURN_IF_ERROR(dataset_params.CreateFactory(&make_dataset_tensor_fdef));
   *dataset = std::make_unique<Tensor>();
   TF_RETURN_IF_ERROR(RunFunction(make_dataset_tensor_fdef, attributes,
-                                 input_tensors, graph_opts,
+                                 dataset_inputs, graph_opts,
                                  /*rets=*/{dataset->get()}));
   return Status::OK();
+}
+
+void DatasetOpsTestBaseV2::AddTensorInputs(
+    const std::vector<Tensor>& tensors,
+    std::vector<std::unique_ptr<Tensor>>* created_tensors,
+    gtl::InlinedVector<TensorValue, 4>* inputs) const {
+  for (auto& input : tensors) {
+    auto copy = absl::make_unique<Tensor>(input);
+    inputs->push_back(TensorValue(copy.get()));
+    created_tensors->push_back(std::move(copy));
+  }
 }
 
 DatasetParams::DatasetParams(DataTypeVector output_dtypes,
@@ -863,23 +878,21 @@ RangeDatasetParams::RangeDatasetParams(
     std::vector<PartialTensorShape> output_shapes, string node_name)
     : DatasetParams(std::move(output_dtypes), std::move(output_shapes),
                     std::move(node_name)),
-      start_(CreateTensor<int64>(TensorShape({}), {start})),
-      stop_(CreateTensor<int64>(TensorShape({}), {stop})),
-      step_(CreateTensor<int64>(TensorShape({}), {step})) {}
+      start_(start),
+      stop_(stop),
+      step_(step) {}
 
 RangeDatasetParams::RangeDatasetParams(int64 start, int64 stop, int64 step)
     : DatasetParams({DT_INT64}, {PartialTensorShape({})}, "range_dataset"),
-      start_(CreateTensor<int64>(TensorShape({}), {start})),
-      stop_(CreateTensor<int64>(TensorShape({}), {stop})),
-      step_(CreateTensor<int64>(TensorShape({}), {step})) {}
+      start_(start),
+      stop_(stop),
+      step_(step) {}
 
-Status RangeDatasetParams::GetInputs(
-    const std::vector<Tensor*>& input_datasets,
-    std::vector<std::unique_ptr<Tensor>>* created_tensors,
-    gtl::InlinedVector<TensorValue, 4>* inputs) const {
-  inputs->clear();
-  AddTensorInputs({start_, stop_, step_}, created_tensors, inputs);
-  return Status::OK();
+std::vector<Tensor> RangeDatasetParams::GetInputTensors() const {
+  Tensor start_tensor = CreateTensor<int64>(TensorShape({}), {start_});
+  Tensor stop_tensor = CreateTensor<int64>(TensorShape({}), {stop_});
+  Tensor step_tensor = CreateTensor<int64>(TensorShape({}), {step_});
+  return {start_tensor, stop_tensor, step_tensor};
 }
 
 Status RangeDatasetParams::GetInputPlaceholder(
@@ -904,14 +917,11 @@ string RangeDatasetParams::op_name() const {
   return RangeDatasetOp::kDatasetType;
 }
 
-Status BatchDatasetParams::GetInputs(
-    const std::vector<Tensor*>& input_datasets,
-    std::vector<std::unique_ptr<Tensor>>* created_tensors,
-    gtl::InlinedVector<TensorValue, 4>* inputs) const {
-  inputs->clear();
-  TF_RETURN_IF_ERROR(AddDatasetInputs(input_datasets, 1, inputs));
-  AddTensorInputs({batch_size_, drop_remainder_}, created_tensors, inputs);
-  return Status::OK();
+std::vector<Tensor> BatchDatasetParams::GetInputTensors() const {
+  Tensor batch_size = CreateTensor<int64>(TensorShape({}), {batch_size_});
+  Tensor drop_remainder =
+      CreateTensor<bool>(TensorShape({}), {drop_remainder_});
+  return {batch_size, drop_remainder};
 }
 
 Status BatchDatasetParams::GetInputPlaceholder(
@@ -940,14 +950,8 @@ string BatchDatasetParams::op_name() const {
 
 int BatchDatasetParams::op_version() const { return op_version_; }
 
-Status MapDatasetParams::GetInputs(
-    const std::vector<Tensor*>& input_datasets,
-    std::vector<std::unique_ptr<Tensor>>* created_tensors,
-    gtl::InlinedVector<TensorValue, 4>* inputs) const {
-  inputs->clear();
-  TF_RETURN_IF_ERROR(AddDatasetInputs(input_datasets, 1, inputs));
-  AddTensorInputs(other_arguments_, created_tensors, inputs);
-  return Status::OK();
+std::vector<Tensor> MapDatasetParams::GetInputTensors() const {
+  return other_arguments_;
 }
 
 Status MapDatasetParams::GetInputPlaceholder(
@@ -991,13 +995,8 @@ TensorSliceDatasetParams::TensorSliceDatasetParams(
                     TensorSliceShapes(components), std::move(node_name)),
       components_(std::move(components)) {}
 
-Status TensorSliceDatasetParams::GetInputs(
-    const std::vector<Tensor*>& input_datasets,
-    std::vector<std::unique_ptr<Tensor>>* created_tensors,
-    gtl::InlinedVector<TensorValue, 4>* inputs) const {
-  inputs->clear();
-  AddTensorInputs(components_, created_tensors, inputs);
-  return Status::OK();
+std::vector<Tensor> TensorSliceDatasetParams::GetInputTensors() const {
+  return components_;
 }
 
 Status TensorSliceDatasetParams::GetInputPlaceholder(
@@ -1048,14 +1047,8 @@ string TensorSliceDatasetParams::op_name() const {
   return TensorSliceDatasetOp::kDatasetType;
 }
 
-Status TakeDatasetParams::GetInputs(
-    const std::vector<Tensor*>& input_datasets,
-    std::vector<std::unique_ptr<Tensor>>* created_tensors,
-    gtl::InlinedVector<TensorValue, 4>* inputs) const {
-  inputs->clear();
-  TF_RETURN_IF_ERROR(AddDatasetInputs(input_datasets, 1, inputs));
-  AddTensorInputs({count_}, created_tensors, inputs);
-  return Status::OK();
+std::vector<Tensor> TakeDatasetParams::GetInputTensors() const {
+  return {CreateTensor<int64>(TensorShape({}), {count_})};
 }
 
 Status TakeDatasetParams::GetInputPlaceholder(

--- a/tensorflow/core/kernels/data/dataset_test_base.h
+++ b/tensorflow/core/kernels/data/dataset_test_base.h
@@ -789,12 +789,6 @@ class DatasetOpsTestBaseV2 : public DatasetOpsTestBase {
 
   Status CreateFactory(const DatasetParams& dataset_params,
                        FunctionDef* fdef) const;
-
-  // Copies the given tensors, storing them in the `inputs` vectors, and storing
-  // owned references to the copies in `created_tensors`.
-  void AddTensorInputs(const std::vector<Tensor>& tensors,
-                       std::vector<std::unique_ptr<Tensor>>* created_tensors,
-                       gtl::InlinedVector<TensorValue, 4>* inputs) const;
 };
 
 #define ITERATOR_GET_NEXT_TEST_P(dataset_op_test_class, dataset_params_class, \

--- a/tensorflow/core/kernels/data/dataset_test_base.h
+++ b/tensorflow/core/kernels/data/dataset_test_base.h
@@ -116,15 +116,8 @@ class DatasetParams {
 
   virtual ~DatasetParams() {}
 
-  // Returns the dataset input values as a TensorValue vector.
-  // Tensors created along the way are stored in `created_tensors`. These
-  // tensors must outlive the returned inputs. All dataset inputs must be passed
-  // in through `input_datasets`. `GetInputs` will not take ownership of the
-  // input datasets.
-  virtual Status GetInputs(
-      const std::vector<Tensor*>& input_datasets,
-      std::vector<std::unique_ptr<Tensor>>* created_tensors,
-      gtl::InlinedVector<TensorValue, 4>* inputs) const = 0;
+  // Returns the inputs (except the input datasets) as a tensor vector.
+  virtual std::vector<Tensor> GetInputTensors() const = 0;
 
   // Returns the dataset input names as a string vector.
   virtual Status GetInputPlaceholder(
@@ -169,37 +162,6 @@ class DatasetParams {
   virtual int op_version() const { return op_version_; }
 
  protected:
-  // Convenience methods for implementing `GetInputs` in subclasses.
-
-  // Verifies that input_datasets is the right size (specified by `num_inputs`),
-  // then adds the input datasets to the inputs vector. No copies or transfers
-  // of ownership occur; The caller is responsible for ensuring that the tensors
-  // in `input_datasets` outlive the tensor values placed in `inputs`.
-  Status AddDatasetInputs(const std::vector<Tensor*>& input_datasets,
-                          int num_inputs,
-                          gtl::InlinedVector<TensorValue, 4>* inputs) const {
-    if (input_datasets.size() != num_inputs) {
-      return errors::Internal("Expected ", num_inputs, " input datasets to ",
-                              op_name(), ", but got ", input_datasets.size());
-    }
-    for (auto dataset : input_datasets) {
-      inputs->push_back(TensorValue(dataset));
-    }
-    return Status::OK();
-  }
-
-  // Copies the given tensors, storing them in the `inputs` vectors, and storing
-  // owned references to the copies in `created_tensors`.
-  void AddTensorInputs(const std::vector<Tensor>& tensors,
-                       std::vector<std::unique_ptr<Tensor>>* created_tensors,
-                       gtl::InlinedVector<TensorValue, 4>* inputs) const {
-    for (auto& input : tensors) {
-      auto copy = absl::make_unique<Tensor>(input);
-      inputs->push_back(TensorValue(copy.get()));
-      created_tensors->push_back(std::move(copy));
-    }
-  }
-
   std::vector<std::shared_ptr<DatasetParams>> input_dataset_params_;
   DataTypeVector output_dtypes_;
   std::vector<PartialTensorShape> output_shapes_;
@@ -219,9 +181,7 @@ class RangeDatasetParams : public DatasetParams {
 
   RangeDatasetParams(int64 start, int64 stop, int64 step);
 
-  Status GetInputs(const std::vector<Tensor*>& input_datasets,
-                   std::vector<std::unique_ptr<Tensor>>* created_tensors,
-                   gtl::InlinedVector<TensorValue, 4>* inputs) const override;
+  std::vector<Tensor> GetInputTensors() const override;
 
   Status GetInputPlaceholder(
       std::vector<string>* input_placeholder) const override;
@@ -233,9 +193,9 @@ class RangeDatasetParams : public DatasetParams {
   string op_name() const override;
 
  private:
-  Tensor start_;
-  Tensor stop_;
-  Tensor step_;
+  int64 start_;
+  int64 stop_;
+  int64 step_;
 };
 
 // `BatchDatasetParams` is a common dataset parameter type that are used in
@@ -250,8 +210,8 @@ class BatchDatasetParams : public DatasetParams {
                      string node_name)
       : DatasetParams(std::move(output_dtypes), std::move(output_shapes),
                       std::move(node_name)),
-        batch_size_(CreateTensor<int64>(TensorShape({}), {batch_size})),
-        drop_remainder_(CreateTensor<bool>(TensorShape({}), {drop_remainder})),
+        batch_size_(batch_size),
+        drop_remainder_(drop_remainder),
         parallel_copy_(parallel_copy) {
     input_dataset_params_.push_back(std::make_unique<T>(input_dataset_params));
     op_version_ = 2;
@@ -259,9 +219,7 @@ class BatchDatasetParams : public DatasetParams {
         input_dataset_params.op_name(), input_dataset_params.iterator_prefix());
   }
 
-  Status GetInputs(const std::vector<Tensor*>& input_datasets,
-                   std::vector<std::unique_ptr<Tensor>>* created_tensors,
-                   gtl::InlinedVector<TensorValue, 4>* inputs) const override;
+  std::vector<Tensor> GetInputTensors() const override;
 
   Status GetInputPlaceholder(
       std::vector<string>* input_placeholder) const override;
@@ -275,8 +233,8 @@ class BatchDatasetParams : public DatasetParams {
   int op_version() const override;
 
  private:
-  Tensor batch_size_;
-  Tensor drop_remainder_;
+  int64 batch_size_;
+  bool drop_remainder_;
   bool parallel_copy_;
 };
 
@@ -305,9 +263,7 @@ class MapDatasetParams : public DatasetParams {
         input_dataset_params.op_name(), input_dataset_params.iterator_prefix());
   }
 
-  Status GetInputs(const std::vector<Tensor*>& input_datasets,
-                   std::vector<std::unique_ptr<Tensor>>* created_tensors,
-                   gtl::InlinedVector<TensorValue, 4>* inputs) const override;
+  std::vector<Tensor> GetInputTensors() const override;
 
   Status GetInputPlaceholder(
       std::vector<string>* input_placeholder) const override;
@@ -335,9 +291,7 @@ class TensorSliceDatasetParams : public DatasetParams {
  public:
   TensorSliceDatasetParams(std::vector<Tensor> components, string node_name);
 
-  Status GetInputs(const std::vector<Tensor*>& input_datasets,
-                   std::vector<std::unique_ptr<Tensor>>* created_tensors,
-                   gtl::InlinedVector<TensorValue, 4>* inputs) const override;
+  std::vector<Tensor> GetInputTensors() const override;
 
   Status GetInputPlaceholder(
       std::vector<string>* input_placeholder) const override;
@@ -373,15 +327,13 @@ class TakeDatasetParams : public DatasetParams {
                     string node_name)
       : DatasetParams(std::move(output_dtypes), std::move(output_shapes),
                       std::move(node_name)),
-        count_(CreateTensor<int64>(TensorShape({}), {count})) {
+        count_(count) {
     input_dataset_params_.push_back(absl::make_unique<T>(input_dataset_params));
     iterator_prefix_ = name_utils::IteratorPrefix(
         input_dataset_params.op_name(), input_dataset_params.iterator_prefix());
   }
 
-  Status GetInputs(const std::vector<Tensor*>& input_datasets,
-                   std::vector<std::unique_ptr<Tensor>>* created_tensors,
-                   gtl::InlinedVector<TensorValue, 4>* inputs) const override;
+  std::vector<Tensor> GetInputTensors() const override;
 
   Status GetInputPlaceholder(
       std::vector<string>* input_placeholder) const override;
@@ -393,7 +345,7 @@ class TakeDatasetParams : public DatasetParams {
   string op_name() const override;
 
  private:
-  Tensor count_;
+  int64 count_;
 };
 
 template <typename T>
@@ -837,6 +789,12 @@ class DatasetOpsTestBaseV2 : public DatasetOpsTestBase {
 
   Status CreateFactory(const DatasetParams& dataset_params,
                        FunctionDef* fdef) const;
+
+  // Copies the given tensors, storing them in the `inputs` vectors, and storing
+  // owned references to the copies in `created_tensors`.
+  void AddTensorInputs(const std::vector<Tensor>& tensors,
+                       std::vector<std::unique_ptr<Tensor>>* created_tensors,
+                       gtl::InlinedVector<TensorValue, 4>* inputs) const;
 };
 
 #define ITERATOR_GET_NEXT_TEST_P(dataset_op_test_class, dataset_params_class, \

--- a/tensorflow/core/kernels/data/experimental/assert_next_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/experimental/assert_next_dataset_op_test.cc
@@ -25,27 +25,22 @@ class AssertNextDatasetParams : public DatasetParams {
  public:
   template <typename T>
   AssertNextDatasetParams(T input_dataset_params,
-                          const std::vector<string>& transformations,
+                          const std::vector<tstring>& transformations,
                           DataTypeVector output_dtypes,
                           std::vector<PartialTensorShape> output_shapes,
                           string node_name)
       : DatasetParams(std::move(output_dtypes), std::move(output_shapes),
-                      std::move(node_name)) {
-    int num_transformations = transformations.size();
-    transformations_ = CreateTensor<tstring>(TensorShape({num_transformations}),
-                                             transformations);
+                      std::move(node_name)),
+        transformations_(transformations) {
     input_dataset_params_.push_back(absl::make_unique<T>(input_dataset_params));
     iterator_prefix_ = name_utils::IteratorPrefix(
         input_dataset_params.op_name(), input_dataset_params.iterator_prefix());
   }
 
-  Status GetInputs(const std::vector<Tensor*>& input_datasets,
-                   std::vector<std::unique_ptr<Tensor>>* created_tensors,
-                   gtl::InlinedVector<TensorValue, 4>* inputs) const override {
-    inputs->clear();
-    TF_RETURN_IF_ERROR(AddDatasetInputs(input_datasets, 1, inputs));
-    AddTensorInputs({transformations_}, created_tensors, inputs);
-    return Status::OK();
+  std::vector<Tensor> GetInputTensors() const override {
+    int num_transformations = transformations_.size();
+    return {CreateTensor<tstring>(TensorShape({num_transformations}),
+                                  transformations_)};
   }
 
   Status GetInputPlaceholder(
@@ -65,7 +60,7 @@ class AssertNextDatasetParams : public DatasetParams {
   string op_name() const override { return AssertNextDatasetOp::kDatasetType; }
 
  private:
-  Tensor transformations_;
+  std::vector<tstring> transformations_;
 };
 
 class AssertNextDatasetOpTest : public DatasetOpsTestBaseV2 {};

--- a/tensorflow/core/kernels/data/experimental/sampling_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/experimental/sampling_dataset_op_test.cc
@@ -31,20 +31,17 @@ class SamplingDatasetParams : public DatasetParams {
                         string node_name)
       : DatasetParams(std::move(output_dtypes), std::move(output_shapes),
                       std::move(node_name)),
-        rate_(CreateTensor<float>(TensorShape({}), {rate})) {
+        rate_(rate) {
     input_dataset_params_.push_back(absl::make_unique<T>(input_dataset_params));
     iterator_prefix_ = name_utils::IteratorPrefix(
         input_dataset_params.op_name(), input_dataset_params.iterator_prefix());
   }
 
-  Status GetInputs(const std::vector<Tensor*>& input_datasets,
-                   std::vector<std::unique_ptr<Tensor>>* created_tensors,
-                   gtl::InlinedVector<TensorValue, 4>* inputs) const override {
-    inputs->clear();
-    TF_RETURN_IF_ERROR(AddDatasetInputs(input_datasets, 1, inputs));
-    AddTensorInputs({rate_, seed_tensor_, seed2_tensor_}, created_tensors,
-                    inputs);
-    return Status::OK();
+  std::vector<Tensor> GetInputTensors() const override {
+    Tensor rate = CreateTensor<float>(TensorShape({}), {rate_});
+    Tensor seed_tensor = CreateTensor<int64>(TensorShape({}), {seed_tensor_});
+    Tensor seed2_tensor = CreateTensor<int64>(TensorShape({}), {seed2_tensor_});
+    return {rate, seed_tensor, seed2_tensor};
   }
 
   Status GetInputPlaceholder(
@@ -66,10 +63,10 @@ class SamplingDatasetParams : public DatasetParams {
 
  private:
   // Target sample rate, range (0,1], wrapped in a scalar Tensor
-  Tensor rate_;
+  float rate_;
   // Boxed versions of kRandomSeed and kRandomSeed2.
-  Tensor seed_tensor_ = CreateTensor<int64>(TensorShape({}), {kRandomSeed});
-  Tensor seed2_tensor_ = CreateTensor<int64>(TensorShape({}), {kRandomSeed2});
+  int64 seed_tensor_ = kRandomSeed;
+  int64 seed2_tensor_ = kRandomSeed2;
 };
 
 class SamplingDatasetOpTest : public DatasetOpsTestBaseV2 {};

--- a/tensorflow/core/kernels/data/tensor_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/tensor_dataset_op_test.cc
@@ -29,13 +29,7 @@ class TensorDatasetParams : public DatasetParams {
                       std::move(node_name)),
         components_(std::move(components)) {}
 
-  Status GetInputs(const std::vector<Tensor*>& input_datasets,
-                   std::vector<std::unique_ptr<Tensor>>* created_tensors,
-                   gtl::InlinedVector<TensorValue, 4>* inputs) const override {
-    inputs->clear();
-    AddTensorInputs(components_, created_tensors, inputs);
-    return Status::OK();
-  }
+  std::vector<Tensor> GetInputTensors() const override { return components_; }
 
   Status GetInputPlaceholder(
       std::vector<string>* input_placeholder) const override {


### PR DESCRIPTION
This PR simplies the signature of `DatasetParams::GetInputs(..)` by changing it to `GetInputTensors()`. 

Thanks for @aaudiber refactoring `dataset_test_base`(https://github.com/tensorflow/tensorflow/commit/ee8e382cfbb0ec568e1799a14e0628d1fc97ca23). This change comes from his suggestion: 

- `DatasetParams` is immutable and only returns the input parameters, so does not own any reference; 

- `DatasetTestBaseV2` 1) creates the input datasets based on the dataset parameters; 2) manages the lifecycle of the created datasets and input tensors.

Based on the above rules, `DatasetParams::GetInputs(...)` is changed to `GetInputTensors()` which only returns the input tensors except the input datasets. `DatasetTestBaseV2` will create the input datasets and store them internally.

cc:@jsimsa