### PR TITLE
fix .so file name error on linux and macos

### DIFF
--- a/tensorflow/java/src/main/java/org/tensorflow/NativeLibrary.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/NativeLibrary.java
@@ -70,6 +70,12 @@ final class NativeLibrary {
     log("frameworkResourceName: " + frameworkResourceName);
     final InputStream frameworkResource =
         NativeLibrary.class.getClassLoader().getResourceAsStream(frameworkResourceName);
+    if ("libtensorflow_framework.so".equals(frameworkLibName)) {
+        frameworkLibName = "libtensorflow_framework.so.1";
+    }
+    if ("libtensorflow_framework.dylib".equals(frameworkLibName)) {
+        frameworkLibName = "libtensorflow_framework.1.dylib";
+    }
     // Do not complain if the framework resource wasn't found. This may just mean that we're
     // building with --config=monolithic (in which case it's not needed and not included).
     if (jniResource == null) {


### PR DESCRIPTION
run on linux error：
java.lang.UnsatisfiedLinkError: /tmp/tensorflow_native_libraries-1562914806051-0/libtensorflow_jni.so: libtensorflow_framework.so.1: cannot open shared object file: No such file or directory

run on macos error：
Exception in thread "main" java.lang.UnsatisfiedLinkError: /private/var/folders/0c/nz0823ps085b_1zcq6l8ry441kqw10/T/tensorflow_native_libraries-1562915587706-0/libtensorflow_jni.dylib: dlopen(/private/var/folders/0c/nz0823ps085b_1zcq6l8ry441kqw10/T/tensorflow_native_libraries-1562915587706-0/libtensorflow_jni.dylib, 1): Library not loaded: @rpath/libtensorflow_framework.1.dylib
  Referenced from: /private/var/folders/0c/nz0823ps085b_1zcq6l8ry441kqw10/T/tensorflow_native_libraries-1562915587706-0/libtensorflow_jni.dylib
  Reason: image not found