### PR TITLE
[r2.0-CherryPick]: Add missing 'continue' in code intended to skip creating TemporaryVar…

### DIFF
--- a/tensorflow/core/grappler/optimizers/memory_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/memory_optimizer.cc
@@ -609,6 +609,12 @@ bool SchedulingPass(Cluster* cluster, GrapplerItem* item) {
       VLOG(1) << "Shape not fully known for " << node->name();
       continue;
     }
+    DataType dtype = node->attr().at("T").type();
+    if (dtype != DT_HALF && dtype != DT_FLOAT && dtype != DT_DOUBLE &&
+        dtype != DT_INT64) {  // Only GPU-supported TemporaryVariable types.
+      VLOG(1) << "Unsupported dtype for " << node->name();
+      continue;
+    }
 
     // Compute a topological ordering for the node fanin.
     std::unordered_map<const NodeDef*, int> topo_order;


### PR DESCRIPTION
…iable nodes of invalid types on GPUs.

PiperOrigin-RevId: 267179945