### PR TITLE
[r2.0-CherryPick]:Update TRT6 headerfiles

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -776,7 +776,9 @@ class TRT_TensorOrWeights::SimpleITensor : public nvinfer1::ITensor {
 
   nvinfer1::TensorFormats getAllowedFormats() const override { return 1; }
 
-  bool isShape() const override { return false; }
+  bool isShapeTensor() const override { return false; }
+
+  bool isExecutionTensor() const override { return true; }
 #endif
 
  private:

--- a/third_party/tensorrt/tensorrt_configure.bzl
+++ b/third_party/tensorrt/tensorrt_configure.bzl
@@ -27,8 +27,8 @@ _TF_TENSORRT_HEADERS_V6 = [
     "NvUtils.h",
     "NvInferPlugin.h",
     "NvInferVersion.h",
-    "NvInferRTSafe.h",
-    "NvInferRTExt.h",
+    "NvInferRuntime.h",
+    "NvInferRuntimeCommon.h",
     "NvInferPluginUtils.h",
 ]
 


### PR DESCRIPTION
- This enables users to compile TF2.0 with TensorRT6.0.
- Without this PR, users would need to apply the patch before compiling TF2.0 with TensorRT6.0 which would not be a good experience.
- TensorRT6.0 comes with optimizations that accelerate 3D image segmentation among others.
- Google can still build and release TF2.0 with TensorRT5.1. So this PR doesn't affect that build/release process.

