### PR TITLE
fix .so file name error on linux and macos

### DIFF
--- a/tensorflow/java/src/main/java/org/tensorflow/NativeLibrary.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/NativeLibrary.java
@@ -132,11 +132,6 @@ final class NativeLibrary {
   }
 
   private static String getVersionedLibraryName(String libFilename) {
-    // If the resource exists as an unversioned file, return that.
-    // if (resourceExists(libFilename)) {
-      // return libFilename;
-    // }
-
     final String versionName = getMajorVersionNumber();
 
     // If we're on darwin, the versioned libraries look like blah.1.dylib.

--- a/tensorflow/java/src/main/java/org/tensorflow/NativeLibrary.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/NativeLibrary.java
@@ -71,6 +71,12 @@ final class NativeLibrary {
     log("frameworkResourceName: " + frameworkResourceName);
     final InputStream frameworkResource =
         NativeLibrary.class.getClassLoader().getResourceAsStream(frameworkResourceName);
+	if ("libtensorflow_framework.so".equals(frameworkLibName)) {
+        frameworkLibName = "libtensorflow_framework.so.1";
+    }
+    if ("libtensorflow_framework.dylib".equals(frameworkLibName)) {
+        frameworkLibName = "libtensorflow_framework.1.dylib";
+    }
     // Do not complain if the framework resource wasn't found. This may just mean that we're
     // building with --config=monolithic (in which case it's not needed and not included).
     if (jniResource == null) {

--- a/tensorflow/java/src/main/java/org/tensorflow/NativeLibrary.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/NativeLibrary.java
@@ -71,7 +71,7 @@ final class NativeLibrary {
     log("frameworkResourceName: " + frameworkResourceName);
     final InputStream frameworkResource =
         NativeLibrary.class.getClassLoader().getResourceAsStream(frameworkResourceName);
-	if ("libtensorflow_framework.so".equals(frameworkLibName)) {
+    if ("libtensorflow_framework.so".equals(frameworkLibName)) {
         frameworkLibName = "libtensorflow_framework.so.1";
     }
     if ("libtensorflow_framework.dylib".equals(frameworkLibName)) {

--- a/tensorflow/java/src/main/java/org/tensorflow/NativeLibrary.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/NativeLibrary.java
@@ -71,12 +71,6 @@ final class NativeLibrary {
     log("frameworkResourceName: " + frameworkResourceName);
     final InputStream frameworkResource =
         NativeLibrary.class.getClassLoader().getResourceAsStream(frameworkResourceName);
-    if ("libtensorflow_framework.so".equals(frameworkLibName)) {
-        frameworkLibName = "libtensorflow_framework.so.1";
-    }
-    if ("libtensorflow_framework.dylib".equals(frameworkLibName)) {
-        frameworkLibName = "libtensorflow_framework.1.dylib";
-    }
     // Do not complain if the framework resource wasn't found. This may just mean that we're
     // building with --config=monolithic (in which case it's not needed and not included).
     if (jniResource == null) {
@@ -139,9 +133,9 @@ final class NativeLibrary {
 
   private static String getVersionedLibraryName(String libFilename) {
     // If the resource exists as an unversioned file, return that.
-    if (resourceExists(libFilename)) {
-      return libFilename;
-    }
+    // if (resourceExists(libFilename)) {
+      // return libFilename;
+    // }
 
     final String versionName = getMajorVersionNumber();
 
@@ -180,11 +174,13 @@ final class NativeLibrary {
    * determined.
    */
   private static String getMajorVersionNumber() {
+    // getImplementationVersion() retrun null. 
     String version = NativeLibrary.class.getPackage().getImplementationVersion();
     // expecting a string like 1.14.0, we want to get the first '1'.
     int dotIndex;
     if (version == null || (dotIndex = version.indexOf('.')) == -1) {
-      return null;
+      // we want to get the version 1.  
+      return "1";
     }
     String majorVersion = version.substring(0, dotIndex);
     try {


### PR DESCRIPTION
I have reported an error when using tensorflow1.14 on linux. The program prompts that libtensorflow_framework.so.1 cannot be found. It is found that only libtensorflow_framework.so is decompressed under /tmp, so I modified the NativeLibrary class and corrected the name when releasing the resource.

run on linux error：
java.lang.UnsatisfiedLinkError: /tmp/tensorflow_native_libraries-1562914806051-0/libtensorflow_jni.so: libtensorflow_framework.so.1: cannot open shared object file: No such file or directory

run on macos error：
Exception in thread "main" java.lang.UnsatisfiedLinkError: /private/var/folders/0c/nz0823ps085b_1zcq6l8ry441kqw10/T/tensorflow_native_libraries-1562915587706-0/libtensorflow_jni.dylib: dlopen(/private/var/folders/0c/nz0823ps085b_1zcq6l8ry441kqw10/T/tensorflow_native_libraries-1562915587706-0/libtensorflow_jni.dylib, 1): Library not loaded: @rpath/libtensorflow_framework.1.dylib
  Referenced from: /private/var/folders/0c/nz0823ps085b_1zcq6l8ry441kqw10/T/tensorflow_native_libraries-1562915587706-0/libtensorflow_jni.dylib
  Reason: image not found