### PR TITLE
Support the 3D convolution ops for auto_mixed_precision

### DIFF
--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision.cc
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision.cc
@@ -914,6 +914,22 @@ int GetCudaVersion(const Cluster& cluster) {
   return 0;
 }
 
+int GetCudnnVersion(const Cluster& cluster) {
+  auto devices = cluster.GetDevices();
+  for (const auto& device : devices) {
+    const DeviceProperties& device_properties = device.second;
+    if (device_properties.type() == "GPU") {
+      const auto& device_env = device_properties.environment();
+      auto it = device_env.find("cudnn");
+      if (it != device_env.end()) {
+        string cudnn_version_str = it->second;
+        return std::stoi(cudnn_version_str);
+      }
+    }
+  }
+  return 0;
+}
+
 class AutoMixedPrecisionImpl {
  public:
   AutoMixedPrecisionImpl(Cluster* cluster,
@@ -924,7 +940,8 @@ class AutoMixedPrecisionImpl {
         graph_(graph),
         id_(id),
         graph_view_(graph),
-        cuda_version_(GetCudaVersion(*cluster)) {}
+        cuda_version_(GetCudaVersion(*cluster)),
+        cudnn_version_(GetCudnnVersion(*cluster)) {}
 
   Status Optimize();
 
@@ -978,6 +995,7 @@ class AutoMixedPrecisionImpl {
   string id_;
   MutableGraphView graph_view_;
   int cuda_version_;
+  int cudnn_version_;
   NodeTypeAttrMap node_type_map_;
   GraphTypeTopologyView graph_type_view_;
   bool force_all_fp16_;
@@ -1032,7 +1050,8 @@ Status AutoMixedPrecisionImpl::PrintDebugLogs(bool preop, size_t timestamp) {
                          strings::StrCat("paintbuckets", suffix, ".txt"));
     f.open(fname.c_str(), std::fstream::out);
     f << "WhiteList:\n";
-    for (auto x : AutoMixedPrecisionLists::WhiteList(cuda_version_)) {
+    for (auto x : AutoMixedPrecisionLists::WhiteList(cuda_version_,
+                                                     cudnn_version_)) {
       f << x << "\n";
     }
     f << "\nBlackList:\n";
@@ -1177,7 +1196,8 @@ Status AutoMixedPrecisionImpl::Optimize() {
   optimization_level = absl::AsciiStrToUpper(optimization_level);
   force_all_fp16_ = optimization_level == "UNSAFE_FORCE_ALL";
 
-  fp16_whitelist_ = AutoMixedPrecisionLists::WhiteList(cuda_version_);
+  fp16_whitelist_ = AutoMixedPrecisionLists::WhiteList(cuda_version_,
+                                                       cudnn_version_);
   fp16_blacklist_ = AutoMixedPrecisionLists::BlackList();
   fp16_graylist_ = AutoMixedPrecisionLists::GrayList();
   fp16_clearlist_ = AutoMixedPrecisionLists::ClearList();

--- a/tensorflow/python/grappler/auto_mixed_precision_test.py
+++ b/tensorflow/python/grappler/auto_mixed_precision_test.py
@@ -19,6 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import os
+import unittest
 import numpy as np
 
 from tensorflow.core.framework import types_pb2

--- a/tensorflow/python/grappler/auto_mixed_precision_test.py
+++ b/tensorflow/python/grappler/auto_mixed_precision_test.py
@@ -71,6 +71,9 @@ def _conv2d(x, w):
   """Returns a 2d convolution layer with full stride."""
   return nn.conv2d(x, w, strides=[1, 1, 1, 1], padding='SAME')
 
+def _conv3d(x, w):
+  """Returns a 3d convolution layer with full stride."""
+  return nn.conv3d(x, w, strides=[1, 1, 1, 1, 1], padding='SAME')
 
 def _max_pool_2x2(x):
   """Downsamples a feature map by 2X."""
@@ -91,6 +94,19 @@ def _conv_bn(x):
   x = _conv2d(i, f)
   s = _weight([6])
   o = _weight([6])
+  y, _, _ = _fused_batchnorm(x, s, o)
+  y = array_ops.identity(y)
+  return y
+
+
+def _conv3d_bn(x):
+  """Conv3D followed by batchnorm."""
+  i = array_ops.reshape(x, [-1, 8, 8, 8, 1])
+  f = _weight([3, 3, 3, 1, 6])
+  x = _conv3d(i, f)
+  s = _weight([6])
+  o = _weight([6])
+  x = array_ops.reshape(x, [-1, 8, 8, 6])
   y, _, _ = _fused_batchnorm(x, s, o)
   y = array_ops.identity(y)
   return y
@@ -393,6 +409,55 @@ class AutoMixedPrecisionTest(test.TestCase):
                          3)  # Before Conv2D:0, Conv2D:1, Conv2D_1:1
         self.assertEqual(num_to_fp32, 1)  # After FusedBatchNormV3:0
         self.assertAllClose(output_val_ref, output_val, atol=1e-3, rtol=1e-3)
+
+  @test_util.run_deprecated_v1
+  @test_util.disable_xla('This test does not pass with XLA')
+  def test_conv3d_bn(self):
+    """Test graph with convolution followed by batch norm."""
+    with compat.forward_compatibility_horizon(2019, 6, 7):
+      if test.is_gpu_available(cuda_only=True):
+        random_seed.set_random_seed(0)
+        x = _input([2, 8, 8, 8, 1])
+        x = _conv3d_bn(x)
+        output = _conv3d_bn(x)
+
+        output_val_ref, output_val, cost_graph = self._run(output)
+        node_map = _build_node_map(cost_graph.node)
+        num_to_fp16, num_to_fp32 = _count_casts(cost_graph.node)
+
+        self._assert_output_fp16(node_map, 'Conv3D')
+        self._assert_output_fp16(node_map, 'FusedBatchNormV3')
+        self._assert_output_fp16(node_map, 'Conv3D_1')
+        self.assertEqual(num_to_fp16,
+                         3)  # Before Conv3D:0, Conv3D:1, Conv3D_1:1
+        self.assertEqual(num_to_fp32, 1)  # After FusedBatchNormV3:0
+        self.assertAllClose(output_val_ref, output_val, atol=1e-2, rtol=1e-2)
+
+  @test_util.run_deprecated_v1
+  @test_util.disable_xla('This test does not pass with XLA')
+  def test_conv3d(self):
+    """Test grad ops with convolution3d graph."""
+    if test.is_gpu_available(cuda_only=True):
+      random_seed.set_random_seed(0)
+      x = _input([2, 8, 8, 8, 1])
+      f = _weight([3, 3, 3, 1, 6])
+      y = _conv3d(x, f)
+      y = array_ops.identity(y)
+      optimizer = gradient_descent.GradientDescentOptimizer(
+          learning_rate=0.01)
+      g = optimizer.compute_gradients(y, [x, f])
+      output = (y, g)
+
+      output_val_ref, output_val, cost_graph = self._run(output)
+      node_map = _build_node_map(cost_graph.node)
+      self._assert_output_fp16(node_map, 'Conv3D')
+      self._assert_output_fp16(node_map,
+                               'gradients/Conv3D_grad/Conv3DBackpropInputV2')
+      self._assert_output_fp16(node_map,
+                               'gradients/Conv3D_grad/Conv3DBackpropFilterV2')
+
+      output_val_ref, output_val, cost_graph = self._run(output)
+      self.assertAllClose(output_val_ref, output_val, atol=1e-3, rtol=1e-3)
 
   @test_util.run_deprecated_v1
   @test_util.disable_xla('This test does not pass with XLA')

--- a/tensorflow/python/grappler/auto_mixed_precision_test.py
+++ b/tensorflow/python/grappler/auto_mixed_precision_test.py
@@ -410,29 +410,32 @@ class AutoMixedPrecisionTest(test.TestCase):
         self.assertEqual(num_to_fp32, 1)  # After FusedBatchNormV3:0
         self.assertAllClose(output_val_ref, output_val, atol=1e-3, rtol=1e-3)
 
+  # TODO: enable these tests when cuDNN is upgraded to >= 7.6.2. Same with the
+  # test_conv3d() below.
+  @unittest.skip("Test case should be skipped when cuDNN < 7.6.2")
   @test_util.run_deprecated_v1
   @test_util.disable_xla('This test does not pass with XLA')
   def test_conv3d_bn(self):
     """Test graph with convolution followed by batch norm."""
-    with compat.forward_compatibility_horizon(2019, 6, 7):
-      if test.is_gpu_available(cuda_only=True):
-        random_seed.set_random_seed(0)
-        x = _input([2, 8, 8, 8, 1])
-        x = _conv3d_bn(x)
-        output = _conv3d_bn(x)
+    if test.is_gpu_available(cuda_only=True):
+      random_seed.set_random_seed(0)
+      x = _input([2, 8, 8, 8, 1])
+      x = _conv3d_bn(x)
+      output = _conv3d_bn(x)
 
-        output_val_ref, output_val, cost_graph = self._run(output)
-        node_map = _build_node_map(cost_graph.node)
-        num_to_fp16, num_to_fp32 = _count_casts(cost_graph.node)
+      output_val_ref, output_val, cost_graph = self._run(output)
+      node_map = _build_node_map(cost_graph.node)
+      num_to_fp16, num_to_fp32 = _count_casts(cost_graph.node)
 
-        self._assert_output_fp16(node_map, 'Conv3D')
-        self._assert_output_fp16(node_map, 'FusedBatchNormV3')
-        self._assert_output_fp16(node_map, 'Conv3D_1')
-        self.assertEqual(num_to_fp16,
-                         3)  # Before Conv3D:0, Conv3D:1, Conv3D_1:1
-        self.assertEqual(num_to_fp32, 1)  # After FusedBatchNormV3:0
-        self.assertAllClose(output_val_ref, output_val, atol=1e-2, rtol=1e-2)
+      self._assert_output_fp16(node_map, 'Conv3D')
+      self._assert_output_fp16(node_map, 'FusedBatchNormV3')
+      self._assert_output_fp16(node_map, 'Conv3D_1')
+      self.assertEqual(num_to_fp16,
+                       3)  # Before Conv3D:0, Conv3D:1, Conv3D_1:1
+      self.assertEqual(num_to_fp32, 1)  # After FusedBatchNormV3:0
+      self.assertAllClose(output_val_ref, output_val, atol=1e-2, rtol=1e-2)
 
+  @unittest.skip("Test case should be skipped when cuDNN < 7.6.2")
   @test_util.run_deprecated_v1
   @test_util.disable_xla('This test does not pass with XLA')
   def test_conv3d(self):


### PR DESCRIPTION
Previous TF auto_mixed_precision doesn't support 3D convolutions.

Since the cuDNN enhanced the performance of 3D convolutions since v7.6.2 (https://docs.nvidia.com/deeplearning/sdk/cudnn-release-notes/rel_762.html#rel_762), this PR added the support and related tests.

fyi @nluehr @benbarsdell 