### PR TITLE
Fix tf.image.*_jpeg_quality docs -- they only accept single image, docs say multiple

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1636,7 +1636,7 @@ def adjust_brightness(image, delta):
 
   Returns:
     A brightness-adjusted tensor of the same shape and type as `image`.
-  
+
   Usage Example:
     ```python
     import tensorflow as tf
@@ -1685,7 +1685,7 @@ def adjust_contrast(images, contrast_factor):
 
   Returns:
     The contrast-adjusted image or images.
-    
+
   Usage Example:
     ```python
     import tensorflow as tf
@@ -2003,7 +2003,7 @@ def random_jpeg_quality(image, min_jpeg_quality, max_jpeg_quality, seed=None):
   `max_jpeg_quality` must be in the interval `[0, 100]`.
 
   Args:
-    image: RGB image or images. Size of the last dimension must be 3.
+    image: 3D image. Size of the last dimension must be 1 or 3.
     min_jpeg_quality: Minimum jpeg encoding quality to use.
     max_jpeg_quality: Maximum jpeg encoding quality to use.
     seed: An operation-specific seed. It will be used in conjunction with the
@@ -2012,7 +2012,7 @@ def random_jpeg_quality(image, min_jpeg_quality, max_jpeg_quality, seed=None):
       interaction with the graph-level random seed.
 
   Returns:
-    Adjusted image(s), same shape and DType as `image`.
+    Adjusted image, same shape and DType as `image`.
 
   Raises:
     ValueError: if `min_jpeg_quality` or `max_jpeg_quality` is invalid.
@@ -2040,19 +2040,19 @@ def random_jpeg_quality(image, min_jpeg_quality, max_jpeg_quality, seed=None):
 def adjust_jpeg_quality(image, jpeg_quality, name=None):
   """Adjust jpeg encoding quality of an image.
 
-  This is a convenience method that converts images to uint8 representation,
-  encodes them to jpeg with `jpeg_quality`, decodes them, and then converts back
+  This is a convenience method that converts an image to uint8 representation,
+  encodes it to jpeg with `jpeg_quality`, decodes it, and then converts back
   to the original data type.
 
   `jpeg_quality` must be in the interval `[0, 100]`.
 
   Args:
-    image: image or images. Size of the last dimension must be None, 1 or 3.
+    image: 3D image. Size of the last dimension must be None, 1 or 3.
     jpeg_quality: Python int or Tensor of type int32. jpeg encoding quality.
     name: A name for this operation (optional).
 
   Returns:
-    Adjusted image(s), same shape and DType as `image`.
+    Adjusted image, same shape and DType as `image`.
 
   Usage Example:
     ```python
@@ -2136,14 +2136,14 @@ def adjust_saturation(image, saturation_factor, name=None):
 
   Returns:
     Adjusted image(s), same shape and DType as `image`.
-    
+
   Usage Example:
     ```python
     >> import tensorflow as tf
     >> x = tf.random.normal(shape=(256, 256, 3))
     >> tf.image.adjust_saturation(x, 0.5)
     ```
-    
+
   Raises:
     InvalidArgumentError: input must have 3 channels
   """
@@ -3469,15 +3469,15 @@ def image_gradients(image):
   Returns:
     Pair of tensors (dy, dx) holding the vertical and horizontal image
     gradients (1-step finite difference).
-    
+
   Usage Example:
     ```python
     BATCH_SIZE = 1
     IMAGE_HEIGHT = 5
     IMAGE_WIDTH = 5
     CHANNELS = 1
-    image = tf.reshape(tf.range(IMAGE_HEIGHT * IMAGE_WIDTH * CHANNELS, 
-      delta=1, dtype=tf.float32), 
+    image = tf.reshape(tf.range(IMAGE_HEIGHT * IMAGE_WIDTH * CHANNELS,
+      delta=1, dtype=tf.float32),
       shape=(BATCH_SIZE, IMAGE_HEIGHT, IMAGE_WIDTH, CHANNELS))
     dx, dy = tf.image.image_gradients(image)
     print(image[0, :,:,0])
@@ -3493,7 +3493,7 @@ def image_gradients(image):
       [5. 5. 5. 5. 5.]
       [5. 5. 5. 5. 5.]
       [5. 5. 5. 5. 5.]
-      [0. 0. 0. 0. 0.]], shape=(5, 5), dtype=float32)    
+      [0. 0. 0. 0. 0.]], shape=(5, 5), dtype=float32)
     print(dy[0, :,:,0])
     tf.Tensor(
       [[1. 1. 1. 1. 0.]
@@ -3502,7 +3502,7 @@ def image_gradients(image):
       [1. 1. 1. 1. 0.]
       [1. 1. 1. 1. 0.]], shape=(5, 5), dtype=float32)
     ```
-    
+
   Raises:
     ValueError: If `image` is not a 4D tensor.
   """

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1636,7 +1636,7 @@ def adjust_brightness(image, delta):
 
   Returns:
     A brightness-adjusted tensor of the same shape and type as `image`.
-
+  
   Usage Example:
     ```python
     import tensorflow as tf
@@ -1685,7 +1685,7 @@ def adjust_contrast(images, contrast_factor):
 
   Returns:
     The contrast-adjusted image or images.
-
+    
   Usage Example:
     ```python
     import tensorflow as tf
@@ -2012,7 +2012,7 @@ def random_jpeg_quality(image, min_jpeg_quality, max_jpeg_quality, seed=None):
       interaction with the graph-level random seed.
 
   Returns:
-    Adjusted image, same shape and DType as `image`.
+    Adjusted image(s), same shape and DType as `image`.
 
   Raises:
     ValueError: if `min_jpeg_quality` or `max_jpeg_quality` is invalid.
@@ -2136,14 +2136,14 @@ def adjust_saturation(image, saturation_factor, name=None):
 
   Returns:
     Adjusted image(s), same shape and DType as `image`.
-
+    
   Usage Example:
     ```python
     >> import tensorflow as tf
     >> x = tf.random.normal(shape=(256, 256, 3))
     >> tf.image.adjust_saturation(x, 0.5)
     ```
-
+    
   Raises:
     InvalidArgumentError: input must have 3 channels
   """
@@ -3469,15 +3469,15 @@ def image_gradients(image):
   Returns:
     Pair of tensors (dy, dx) holding the vertical and horizontal image
     gradients (1-step finite difference).
-
+    
   Usage Example:
     ```python
     BATCH_SIZE = 1
     IMAGE_HEIGHT = 5
     IMAGE_WIDTH = 5
     CHANNELS = 1
-    image = tf.reshape(tf.range(IMAGE_HEIGHT * IMAGE_WIDTH * CHANNELS,
-      delta=1, dtype=tf.float32),
+    image = tf.reshape(tf.range(IMAGE_HEIGHT * IMAGE_WIDTH * CHANNELS, 
+      delta=1, dtype=tf.float32), 
       shape=(BATCH_SIZE, IMAGE_HEIGHT, IMAGE_WIDTH, CHANNELS))
     dx, dy = tf.image.image_gradients(image)
     print(image[0, :,:,0])
@@ -3493,7 +3493,7 @@ def image_gradients(image):
       [5. 5. 5. 5. 5.]
       [5. 5. 5. 5. 5.]
       [5. 5. 5. 5. 5.]
-      [0. 0. 0. 0. 0.]], shape=(5, 5), dtype=float32)
+      [0. 0. 0. 0. 0.]], shape=(5, 5), dtype=float32)    
     print(dy[0, :,:,0])
     tf.Tensor(
       [[1. 1. 1. 1. 0.]
@@ -3502,7 +3502,7 @@ def image_gradients(image):
       [1. 1. 1. 1. 0.]
       [1. 1. 1. 1. 0.]], shape=(5, 5), dtype=float32)
     ```
-
+    
   Raises:
     ValueError: If `image` is not a 4D tensor.
   """


### PR DESCRIPTION
* Update `tf.image.adjust_jpeg_quality` and `tf.image.random_jpeg_quality` docs to state that only one image (3D, not 4D) can be passed in.
* Update `tf.image.random_jpeg_quality` to clarify it can also accept a 1-channel input, instead of just 3-channel..

Python code showing the one-image restraints, and allowing of 1-channel input:

```python
>>> import tensorflow as tf
>>> tf.__version__
'2.0.0-rc2'
>>> import numpy as np
>>> tf.image.adjust_jpeg_quality(np.random.random((10, 100, 100, 3)), 75).numpy().shape
<extended traceback>
tensorflow.python.framework.errors_impl.InvalidArgumentError: image must be 3-dimensional[10,100,100,3] [Op:EncodeJpegVariableQuality]
>>> tf.image.random_jpeg_quality(np.random.random((10, 100, 100, 3)), 75, 95).numpy().shape
<extended traceback>
tensorflow.python.framework.errors_impl.InvalidArgumentError: image must be 3-dimensional[10,100,100,3] [Op:EncodeJpegVariableQuality]
>>> tf.image.random_jpeg_quality(np.random.random((100, 100, 1)), 75, 95).numpy().shape
(100, 100, 1)
```