### PR TITLE
Mark tf.keras.utils.multi_gpu_model as deprecated.

### DIFF
--- a/tensorflow/python/keras/utils/multi_gpu_utils.py
+++ b/tensorflow/python/keras/utils/multi_gpu_utils.py
@@ -21,6 +21,7 @@ from tensorflow.python.framework import ops
 from tensorflow.python.keras import backend as K
 from tensorflow.python.keras.engine.training import Model
 from tensorflow.python.ops import array_ops
+from tensorflow.python.util import deprecation
 from tensorflow.python.util.tf_export import keras_export
 
 
@@ -34,6 +35,8 @@ def _normalize_device_name(name):
 
 
 @keras_export('keras.utils.multi_gpu_model')
+@deprecation.deprecated(
+    '2020-04-01', 'Use `tf.distribute.MirroredStrategy` instead.')
 def multi_gpu_model(model, gpus, cpu_merge=True, cpu_relocation=False):
   """Replicates a model on different GPUs.
 


### PR DESCRIPTION
PiperOrigin-RevId: 271495434