### PR TITLE
Deprecate tf.test.is_gpu_available

### DIFF
--- a/tensorflow/python/framework/test_util.py
+++ b/tensorflow/python/framework/test_util.py
@@ -1382,6 +1382,8 @@ def run_cuda_only(func=None):
   return decorator
 
 
+@deprecation.deprecated(
+    None, "Use `tf.config.experimental.list_physical_devices('GPU')` instead.")
 @tf_export("test.is_gpu_available")
 def is_gpu_available(cuda_only=False, min_cuda_compute_capability=None):
   """Returns whether TensorFlow can access a GPU.


### PR DESCRIPTION
The tf.config.experimental.list_physical_devices API is preferable as
the current API results in an initialization of the runtime which may be
undesirable.

PiperOrigin-RevId: 270812165
(cherry picked from commit b8e6bc6a6980f79eae332ba9b01e722f571f2c05)