### PR TITLE
Add Pinball Loss

### DIFF
--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -1171,7 +1171,7 @@ class Pinball(LossFunctionWrapper):
   Usage:
 
   ```python
-  pinball_loss = tf.keras.losses.Pinball(tau=.1, axis=1)
+  pinball = tf.keras.losses.Pinball(tau=.1, axis=1)
   loss = pinball([0., 0., 1., 1.], [1., 1., 1., 0.])
 
   print('Loss: ', loss.numpy())  # Loss:

--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -1141,6 +1141,75 @@ class CosineSimilarity(LossFunctionWrapper):
         cosine_similarity, reduction=reduction, name=name, axis=axis)
 
 
+@keras_export([
+    'keras.losses.pinball',
+    'keras.metrics.pinball'
+])
+def pinball(y_true, y_pred, tau):
+  """Computes the pinball loss between `y_true` and `y_pred`.
+
+  Usage:
+
+  ```python
+  loss = pinball([0., 0., 1., 1.], [1., 1., 1., 0.], tau=.1)
+
+  print('Loss: ', loss.numpy())  # Loss:
+  ```
+
+  Args:
+    tau: a float between 0 and 1 the slope of the pinball loss. In the context of quantile regression,
+    the value of alpha determine the conditional quantile level.
+  """
+    delta_y = y_true - y_pred
+    return K.maximum(tau * delta_y, (tau - 1) * delta_y)
+
+
+@keras_export('keras.losses.Pinball')
+class Pinball(LossFunctionWrapper):
+  """Computes the pinball loss between `y_true` and `y_pred`.
+
+  Usage:
+
+  ```python
+  pinball_loss = tf.keras.losses.Pinball(tau=.1, axis=1)
+  loss = pinball([0., 0., 1., 1.], [1., 1., 1., 0.])
+
+  print('Loss: ', loss.numpy())  # Loss:
+  ```
+
+  Usage with the `compile` API:
+
+  ```python
+  model = tf.keras.Model(inputs, outputs)
+  model.compile('sgd', loss=tf.keras.losses.Pinball(axis=1))
+  ```
+
+  Args:
+    tau: a float between 0 and 1 the slope of the pinball loss. In the context of quantile regression,
+      the value of alpha determine the conditional quantile level.
+    axis: (Optional) Defaults to -1. The dimension along which the cosine
+      similarity is computed.
+    reduction: (Optional) Type of `tf.keras.losses.Reduction` to apply to loss.
+      Default value is `AUTO`. `AUTO` indicates that the reduction option will
+      be determined by the usage context. For almost all cases this defaults to
+      `SUM_OVER_BATCH_SIZE`.
+      When used with `tf.distribute.Strategy`, outside of built-in training
+      loops such as `tf.keras` `compile` and `fit`, using `AUTO` or
+      `SUM_OVER_BATCH_SIZE` will raise an error. Please see
+      https://www.tensorflow.org/alpha/tutorials/distribute/training_loops
+      for more details on this.
+    name: Optional name for the op.
+  """
+
+  def __init__(self,
+               tau=.5,
+               axis=-1,
+               reduction=losses_utils.ReductionV2.AUTO,
+               name='pinball_loss'):
+      super(Pinball, self).__init__(
+          pinball, tau=tau, reduction=reduction, name=name, axis=axis)
+
+
 # Aliases.
 
 bce = BCE = binary_crossentropy

--- a/tensorflow/python/keras/losses_test.py
+++ b/tensorflow/python/keras/losses_test.py
@@ -37,6 +37,7 @@ except ImportError:
   h5py = None
 
 ALL_LOSSES = [keras.losses.mean_squared_error,
+              keras.losses.pinball,
               keras.losses.mean_absolute_error,
               keras.losses.mean_absolute_percentage_error,
               keras.losses.mean_squared_logarithmic_error,
@@ -1619,6 +1620,136 @@ class HuberLossTest(test.TestCase):
     loss = h_obj(self.y_true, self.y_pred, sample_weight=sample_weight)
     actual_loss = sample_weight * np.sum(self.expected_losses) / self.batch_size
     self.assertAlmostEqual(self.evaluate(loss), actual_loss, 3)
+
+
+@test_util.run_all_in_graph_and_eager_modes
+class PinballTest(test.TestCase):
+
+  def test_config(self):
+    pin_obj = keras.losses.Pinball(
+        reduction=losses_utils.ReductionV2.SUM, name='pin_1')
+    self.assertEqual(pin_obj.name, 'pin_1')
+    self.assertEqual(pin_obj.reduction, losses_utils.ReductionV2.SUM)
+
+  def test_all_correct_unweighted(self):
+      pin_obj = keras.losses.Pinball()
+    y_true = constant_op.constant([4, 8, 12, 8, 1, 3], shape=(2, 3))
+    loss = pin_obj(y_true, y_true)
+    self.assertAlmostEqual(self.evaluate(loss), 0.0, 3)
+
+  def test_unweighted(self):
+    pin_obj = keras.losses.Pinball()
+    y_true = constant_op.constant([1, 9, 2, -5, -2, 6], shape=(2, 3))
+    y_pred = constant_op.constant([4, 8, 12, 8, 1, 3],
+                                  shape=(2, 3),
+                                  dtype=dtypes.float32)
+    loss = pin_obj(y_true, y_pred)
+    self.assertAlmostEqual(self.evaluate(loss), 2.75, 3)
+
+  def test_unweighted_quantile_0pc(self):
+    pin_obj = keras.losses.Pinball(alpha=0.)
+    y_true = constant_op.constant([1, 9, 2, -5, -2, 6], shape=(2, 3))
+    y_pred = constant_op.constant([4, 8, 12, 8, 1, 3],
+                                  shape=(2, 3),
+                                  dtype=dtypes.float32)
+    loss = pin_obj(y_true, y_pred)
+    self.assertAlmostEqual(self.evaluate(loss), 4.8333, 3)
+
+
+  def test_unweighted_quantile_10pc(self):
+    pin_obj = keras.losses.Pinball(alpha=.1)
+    y_true = constant_op.constant([1, 9, 2, -5, -2, 6], shape=(2, 3))
+    y_pred = constant_op.constant([4, 8, 12, 8, 1, 3],
+                                  shape=(2, 3),
+                                  dtype=dtypes.float32)
+    loss = pin_obj(y_true, y_pred)
+    self.assertAlmostEqual(self.evaluate(loss), 4.4166, 3)
+
+  def test_unweighted_quantile_90pc(self):
+    pin_obj = keras.losses.Pinball(alpha=.9)
+    y_true = constant_op.constant([1, 9, 2, -5, -2, 6], shape=(2, 3))
+    y_pred = constant_op.constant([4, 8, 12, 8, 1, 3],
+                                  shape=(2, 3),
+                                  dtype=dtypes.float32)
+    loss = pin_obj(y_true, y_pred)
+    self.assertAlmostEqual(self.evaluate(loss), 1.0833, 3)
+
+  def test_unweighted_quantile_100pc(self):
+    pin_obj = keras.losses.Pinball(alpha=1.)
+    y_true = constant_op.constant([1, 9, 2, -5, -2, 6], shape=(2, 3))
+    y_pred = constant_op.constant([4, 8, 12, 8, 1, 3],
+                                  shape=(2, 3),
+                                  dtype=dtypes.float32)
+    loss = pin_obj(y_true, y_pred)
+    self.assertAlmostEqual(self.evaluate(loss), 0.6666, 3)
+
+  def test_scalar_weighted(self):
+    pin_obj = keras.losses.Pinball()
+    y_true = constant_op.constant([1, 9, 2, -5, -2, 6], shape=(2, 3))
+    y_pred = constant_op.constant([4, 8, 12, 8, 1, 3],
+                                  shape=(2, 3),
+                                  dtype=dtypes.float32)
+    loss = pin_obj(y_true, y_pred, sample_weight=2.3)
+    self.assertAlmostEqual(self.evaluate(loss), 6.325, 3)
+
+  def test_sample_weighted(self):
+    pin_obj = keras.losses.Pinball()
+    y_true = constant_op.constant([1, 9, 2, -5, -2, 6], shape=(2, 3))
+    y_pred = constant_op.constant([4, 8, 12, 8, 1, 3],
+                                  shape=(2, 3),
+                                  dtype=dtypes.float32)
+    sample_weight = constant_op.constant([1.2, 3.4], shape=(2, 1))
+    loss = pin_obj(y_true, y_pred, sample_weight=sample_weight)
+    self.assertAlmostEqual(self.evaluate(loss), 40.7 / 6, 3)
+
+  def test_timestep_weighted(self):
+    pin_obj = keras.losses.Pinball()
+    y_true = constant_op.constant([1, 9, 2, -5, -2, 6], shape=(2, 3, 1))
+    y_pred = constant_op.constant([4, 8, 12, 8, 1, 3],
+                                  shape=(2, 3, 1),
+                                  dtype=dtypes.float32)
+    sample_weight = constant_op.constant([3, 6, 5, 0, 4, 2], shape=(2, 3))
+    loss = pin_obj(y_true, y_pred, sample_weight=sample_weight)
+    self.assertAlmostEqual(self.evaluate(loss), 41.5 / 6, 3)
+
+  def test_zero_weighted(self):
+    pin_obj = keras.losses.Pinball()
+    y_true = constant_op.constant([1, 9, 2, -5, -2, 6], shape=(2, 3))
+    y_pred = constant_op.constant([4, 8, 12, 8, 1, 3],
+                                  shape=(2, 3),
+                                  dtype=dtypes.float32)
+    loss = pin_obj(y_true, y_pred, sample_weight=0)
+    self.assertAlmostEqual(self.evaluate(loss), 0.0, 3)
+
+  def test_invalid_sample_weight(self):
+    pin_obj = keras.losses.Pinball()
+    y_true = constant_op.constant([1, 9, 2, -5, -2, 6], shape=(2, 3, 1))
+    y_pred = constant_op.constant([4, 8, 12, 8, 1, 3], shape=(2, 3, 1))
+    sample_weight = constant_op.constant([3, 6, 5, 0], shape=(2, 2))
+    with self.assertRaisesRegexp(ValueError,
+                                 'weights can not be broadcast to values'):
+      pin_obj(y_true, y_pred, sample_weight=sample_weight)
+
+  def test_no_reduction(self):
+    pin_obj = keras.losses.Pinball(
+        reduction=losses_utils.ReductionV2.NONE)
+    y_true = constant_op.constant([1, 9, 2, -5, -2, 6], shape=(2, 3))
+    y_pred = constant_op.constant([4, 8, 12, 8, 1, 3],
+                                  shape=(2, 3),
+                                  dtype=dtypes.float32)
+    loss = pin_obj(y_true, y_pred, sample_weight=2.3)
+    loss = self.evaluate(loss)
+    self.assertArrayNear(loss, [5.3666, 7.28333], 1e-3)
+
+  def test_sum_reduction(self):
+    pin_obj = keras.losses.Pinball(
+        reduction=losses_utils.ReductionV2.SUM)
+    y_true = constant_op.constant([1, 9, 2, -5, -2, 6], shape=(2, 3))
+    y_pred = constant_op.constant([4, 8, 12, 8, 1, 3],
+                                  shape=(2, 3),
+                                  dtype=dtypes.float32)
+    loss = pin_obj(y_true, y_pred, sample_weight=2.3)
+    self.assertAlmostEqual(self.evaluate(loss), 12.65, 3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Summary

The pinball loss is a very simple modification of the MAE and allows (conditional) quantile regression.

http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.470.9161&rep=rep1&type=pdf
https://towardsdatascience.com/deep-quantile-regression-c85481548b5a

This is rather simple to code, and would be of interest for a large community.

# Related Issues

# Related PR

   #32473

# PR Overview

    [ y] This PR requires new unit tests [y/n] (make sure tests are included)
    [ n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
    [ y] This PR is backwards compatible [y/n]
    [ n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
