### PR TITLE
[r1.15-CherryPick]:Fix the license copy code after the latest changes in windows libtensorflow build scripts.

### DIFF
--- a/tensorflow/tools/ci_build/windows/libtensorflow_cpu.sh
+++ b/tensorflow/tools/ci_build/windows/libtensorflow_cpu.sh
@@ -36,7 +36,8 @@ run_configure_for_cpu_build
 # build_libtensorflow_tarball in ../builds/libtensorflow.sh
 # cannot be used on Windows since it relies on pkg_tar rules.
 # So we do something special here
-bazel --output_user_root=${TMPDIR} build -c opt --copt=/arch:AVX --announce_rc \
+bazel --output_user_root=${TMPDIR} build -c opt --copt=/arch:AVX --announce_rc --config=short_logs \
+  :LICENSE \
   tensorflow:tensorflow.dll \
   tensorflow:tensorflow_dll_import_lib \
   tensorflow/tools/lib_package:clicenses_generate \
@@ -51,7 +52,8 @@ mkdir -p ${DIR}
 cp bazel-bin/tensorflow/java/tensorflow_jni.dll ${DIR}/tensorflow_jni.dll
 zip -j ${DIR}/libtensorflow_jni-cpu-windows-$(uname -m).zip \
   ${DIR}/tensorflow_jni.dll \
-  bazel-genfiles/tensorflow/tools/lib_package/include/tensorflow/jni/LICENSE
+  bazel-genfiles/tensorflow/tools/lib_package/include/tensorflow/THIRD_PARTY_TF_JNI_LICENSES \
+  LICENSE
 rm -f ${DIR}/tensorflow_jni.dll
 
 # Zip up the .dll, LICENSE and include files for the C library.
@@ -67,7 +69,8 @@ cp tensorflow/c/c_api.h \
   tensorflow/c/tf_tensor.h \
   ${DIR}/include/tensorflow/c
 cp tensorflow/c/eager/c_api.h ${DIR}/include/tensorflow/c/eager
-cp bazel-genfiles/tensorflow/tools/lib_package/include/tensorflow/c/LICENSE ${DIR}/include/tensorflow/c
+cp LICENSE ${DIR}/LICENSE
+cp bazel-genfiles/tensorflow/tools/lib_package/THIRD_PARTY_TF_C_LICENSES ${DIR}/
 cd ${DIR}
 zip libtensorflow-cpu-windows-$(uname -m).zip \
   lib/tensorflow.dll \
@@ -78,5 +81,6 @@ zip libtensorflow-cpu-windows-$(uname -m).zip \
   include/tensorflow/c/tf_datatype.h \
   include/tensorflow/c/tf_status.h \
   include/tensorflow/c/tf_tensor.h \
-  include/tensorflow/c/LICENSE
-rm -rf lib include
+  LICENSE \
+  THIRD_PARTY_TF_C_LICENSES
+rm r-f lib include

--- a/tensorflow/tools/ci_build/windows/libtensorflow_gpu.sh
+++ b/tensorflow/tools/ci_build/windows/libtensorflow_gpu.sh
@@ -36,7 +36,8 @@ run_configure_for_gpu_build
 # build_libtensorflow_tarball in ../builds/libtensorflow.sh
 # cannot be used on Windows since it relies on pkg_tar rules.
 # So we do something special here
-bazel --output_user_root=${TMPDIR} build -c opt --copt=/arch:AVX --announce_rc \
+bazel --output_user_root=${TMPDIR} build -c opt --copt=/arch:AVX --announce_rc --config=short_logs \
+  :LICENSE \
   tensorflow:tensorflow.dll \
   tensorflow:tensorflow_dll_import_lib \
   tensorflow/tools/lib_package:clicenses_generate \
@@ -51,7 +52,8 @@ mkdir -p ${DIR}
 cp bazel-bin/tensorflow/java/tensorflow_jni.dll ${DIR}/tensorflow_jni.dll
 zip -j ${DIR}/libtensorflow_jni-gpu-windows-$(uname -m).zip \
   ${DIR}/tensorflow_jni.dll \
-  bazel-genfiles/tensorflow/tools/lib_package/include/tensorflow/jni/LICENSE
+  bazel-genfiles/tensorflow/tools/lib_package/include/tensorflow/THIRD_PARTY_TF_JNI_LICENSES \
+  LICENSE
 rm -f ${DIR}/tensorflow_jni.dll
 
 # Zip up the .dll, LICENSE and include files for the C library.
@@ -67,7 +69,8 @@ cp tensorflow/c/c_api.h \
   tensorflow/c/tf_tensor.h \
   ${DIR}/include/tensorflow/c
 cp tensorflow/c/eager/c_api.h ${DIR}/include/tensorflow/c/eager
-cp bazel-genfiles/tensorflow/tools/lib_package/include/tensorflow/c/LICENSE ${DIR}/include/tensorflow/c
+cp LICENSE ${DIR}/LICENSE
+cp bazel-genfiles/tensorflow/tools/lib_package/THIRD_PARTY_TF_C_LICENSES ${DIR}/
 cd ${DIR}
 zip libtensorflow-gpu-windows-$(uname -m).zip \
   lib/tensorflow.dll \
@@ -78,5 +81,6 @@ zip libtensorflow-gpu-windows-$(uname -m).zip \
   include/tensorflow/c/tf_datatype.h \
   include/tensorflow/c/tf_status.h \
   include/tensorflow/c/tf_tensor.h \
-  include/tensorflow/c/LICENSE
+  LICENSE \
+  THIRD_PARTY_TF_C_LICENSES
 rm -rf lib include


### PR DESCRIPTION
PiperOrigin-RevId: 272028365