### PR TITLE
Clean up DatasetParams and refactor multiple DatasetOpTests

### DIFF
--- a/tensorflow/core/kernels/data/BUILD
+++ b/tensorflow/core/kernels/data/BUILD
@@ -27,6 +27,7 @@ cc_library(
     hdrs = ["dataset_test_base.h"],
     deps = [
         ":batch_dataset_op",
+        ":concatenate_dataset_op",
         ":dataset_utils",
         ":iterator_ops",
         ":map_dataset_op",
@@ -345,12 +346,10 @@ tf_cc_test(
     size = "small",
     srcs = ["padded_batch_dataset_op_test.cc"],
     deps = [
-        ":concatenate_dataset_op",
         ":dataset_test_base",
         ":dataset_utils",
         ":iterator_ops",
         ":padded_batch_dataset_op",
-        ":tensor_slice_dataset_op",
         "//tensorflow/core:core_cpu_internal",
         "//tensorflow/core:dataset_ops_op_lib",
         "//tensorflow/core:framework",

--- a/tensorflow/core/kernels/data/cache_dataset_ops_test.cc
+++ b/tensorflow/core/kernels/data/cache_dataset_ops_test.cc
@@ -32,8 +32,9 @@ class CacheDatasetParams : public DatasetParams {
                       std::move(node_name)),
         filename_(filename) {
     input_dataset_params_.push_back(absl::make_unique<T>(input_dataset_params));
-    iterator_prefix_ = name_utils::IteratorPrefix(
-        input_dataset_params.op_name(), input_dataset_params.iterator_prefix());
+    iterator_prefix_ =
+        name_utils::IteratorPrefix(input_dataset_params.dataset_type(),
+                                   input_dataset_params.iterator_prefix());
   }
 
   std::vector<Tensor> GetInputTensors() const override {
@@ -53,7 +54,7 @@ class CacheDatasetParams : public DatasetParams {
     return Status::OK();
   }
 
-  string op_name() const override { return CacheDatasetOp::kDatasetType; }
+  string dataset_type() const override { return CacheDatasetOp::kDatasetType; }
 
   string filename() const { return filename_; }
 

--- a/tensorflow/core/kernels/data/concatenate_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/concatenate_dataset_op_test.cc
@@ -36,7 +36,7 @@ class ConcatenateDatasetParams : public DatasetParams {
     input_dataset_params_.push_back(
         absl::make_unique<T>(input_dataset_params_1));
     iterator_prefix_ =
-        name_utils::IteratorPrefix(input_dataset_params_0.op_name(),
+        name_utils::IteratorPrefix(input_dataset_params_0.dataset_type(),
                                    input_dataset_params_0.iterator_prefix());
   }
 
@@ -55,7 +55,9 @@ class ConcatenateDatasetParams : public DatasetParams {
     return Status::OK();
   }
 
-  string op_name() const override { return ConcatenateDatasetOp::kDatasetType; }
+  string dataset_type() const override {
+    return ConcatenateDatasetOp::kDatasetType;
+  }
 };
 
 // Test case 1: same shape.

--- a/tensorflow/core/kernels/data/concatenate_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/concatenate_dataset_op_test.cc
@@ -22,44 +22,6 @@ namespace {
 
 constexpr char kNodeName[] = "concatenate_dataset";
 
-class ConcatenateDatasetParams : public DatasetParams {
- public:
-  template <typename T, typename P>
-  ConcatenateDatasetParams(T input_dataset_params_0, P input_dataset_params_1,
-                           DataTypeVector output_dtypes,
-                           std::vector<PartialTensorShape> output_shapes,
-                           string node_name)
-      : DatasetParams(std::move(output_dtypes), std::move(output_shapes),
-                      std::move(node_name)) {
-    input_dataset_params_.push_back(
-        absl::make_unique<T>(input_dataset_params_0));
-    input_dataset_params_.push_back(
-        absl::make_unique<T>(input_dataset_params_1));
-    iterator_prefix_ =
-        name_utils::IteratorPrefix(input_dataset_params_0.dataset_type(),
-                                   input_dataset_params_0.iterator_prefix());
-  }
-
-  std::vector<Tensor> GetInputTensors() const override { return {}; }
-
-  Status GetInputNames(std::vector<string>* input_names) const override {
-    input_names->reserve(2);
-    input_names->emplace_back(ConcatenateDatasetOp::kInputDataset);
-    input_names->emplace_back(ConcatenateDatasetOp::kAnotherDataset);
-    return Status::OK();
-  }
-
-  Status GetAttributes(AttributeVector* attr_vector) const override {
-    *attr_vector = {{ConcatenateDatasetOp::kOutputTypes, output_dtypes_},
-                    {ConcatenateDatasetOp::kOutputShapes, output_shapes_}};
-    return Status::OK();
-  }
-
-  string dataset_type() const override {
-    return ConcatenateDatasetOp::kDatasetType;
-  }
-};
-
 // Test case 1: same shape.
 ConcatenateDatasetParams SameShapeConcatenateDatasetParams() {
   auto tensor_slice_dataset_params_0 = TensorSliceDatasetParams(

--- a/tensorflow/core/kernels/data/dataset_test_base.cc
+++ b/tensorflow/core/kernels/data/dataset_test_base.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/versions.pb.h"
 #include "tensorflow/core/kernels/data/batch_dataset_op.h"
+#include "tensorflow/core/kernels/data/concatenate_dataset_op.h"
 #include "tensorflow/core/kernels/data/map_dataset_op.h"
 #include "tensorflow/core/kernels/data/range_dataset_op.h"
 #include "tensorflow/core/kernels/data/take_dataset_op.h"
@@ -1029,9 +1030,7 @@ std::vector<Tensor> TakeDatasetParams::GetInputTensors() const {
 
 Status TakeDatasetParams::GetInputNames(
     std::vector<string>* input_names) const {
-  input_names->reserve(input_dataset_params_.size() + 1);
-  input_names->emplace_back(TakeDatasetOp::kInputDataset);
-  input_names->emplace_back(TakeDatasetOp::kCount);
+  *input_names = {TakeDatasetOp::kInputDataset, TakeDatasetOp::kCount};
   return Status::OK();
 }
 
@@ -1043,6 +1042,28 @@ Status TakeDatasetParams::GetAttributes(AttributeVector* attr_vector) const {
 
 string TakeDatasetParams::dataset_type() const {
   return TakeDatasetOp::kDatasetType;
+}
+
+std::vector<Tensor> ConcatenateDatasetParams::GetInputTensors() const {
+  return {};
+}
+
+Status ConcatenateDatasetParams::GetInputNames(
+    std::vector<string>* input_names) const {
+  *input_names = {ConcatenateDatasetOp::kInputDataset,
+                  ConcatenateDatasetOp::kAnotherDataset};
+  return Status::OK();
+}
+
+Status ConcatenateDatasetParams::GetAttributes(
+    AttributeVector* attr_vector) const {
+  *attr_vector = {{ConcatenateDatasetOp::kOutputTypes, output_dtypes_},
+                  {ConcatenateDatasetOp::kOutputShapes, output_shapes_}};
+  return Status::OK();
+}
+
+string ConcatenateDatasetParams::dataset_type() const {
+  return ConcatenateDatasetOp::kDatasetType;
 }
 
 }  // namespace data

--- a/tensorflow/core/kernels/data/dataset_test_base.cc
+++ b/tensorflow/core/kernels/data/dataset_test_base.cc
@@ -813,10 +813,10 @@ Status DatasetOpsTestBaseV2::MakeDatasetOpKernel(
   TF_RETURN_IF_ERROR(dataset_params.GetInputNames(&input_names));
   AttributeVector attributes;
   TF_RETURN_IF_ERROR(dataset_params.GetAttributes(&attributes));
-  NodeDef node_def =
-      test::function::NDef(dataset_params.node_name(),
-                           name_utils::OpName(dataset_params.op_name(), params),
-                           input_names, attributes);
+  NodeDef node_def = test::function::NDef(
+      dataset_params.node_name(),
+      name_utils::OpName(dataset_params.dataset_type(), params), input_names,
+      attributes);
   TF_RETURN_IF_ERROR(CreateOpKernel(node_def, dataset_kernel));
   return Status::OK();
 }
@@ -909,12 +909,7 @@ Status RangeDatasetParams::GetAttributes(AttributeVector* attr_vector) const {
   return Status::OK();
 }
 
-Status RangeDatasetParams::CreateFactory(FunctionDef* fdef) const {
-  *fdef = test::function::MakeRangeDataset();
-  return Status::OK();
-}
-
-string RangeDatasetParams::op_name() const {
+string RangeDatasetParams::dataset_type() const {
   return RangeDatasetOp::kDatasetType;
 }
 
@@ -939,12 +934,7 @@ Status BatchDatasetParams::GetAttributes(AttributeVector* attr_vector) const {
   return Status::OK();
 }
 
-Status BatchDatasetParams::CreateFactory(FunctionDef* fdef) const {
-  *fdef = test::function::MakeBatchDataset();
-  return Status::OK();
-}
-
-string BatchDatasetParams::op_name() const {
+string BatchDatasetParams::dataset_type() const {
   return BatchDatasetOp::kDatasetType;
 }
 
@@ -972,15 +962,9 @@ Status MapDatasetParams::GetAttributes(AttributeVector* attr_vector) const {
   return Status::OK();
 }
 
-Status MapDatasetParams::CreateFactory(FunctionDef* fdef) const {
-  std::vector<string> input_names;
-  TF_RETURN_IF_ERROR(GetInputNames(&input_names));
-  bool has_other_args = input_names.size() > 1;
-  *fdef = test::function::MakeMapDataset(has_other_args);
-  return Status::OK();
+string MapDatasetParams::dataset_type() const {
+  return MapDatasetOp::kDatasetType;
 }
-
-string MapDatasetParams::op_name() const { return MapDatasetOp::kDatasetType; }
 
 std::vector<FunctionDef> MapDatasetParams::func_lib() const {
   return func_lib_;
@@ -1035,12 +1019,7 @@ std::vector<PartialTensorShape> TensorSliceDatasetParams::TensorSliceShapes(
   return shapes;
 }
 
-Status TensorSliceDatasetParams::CreateFactory(FunctionDef* fdef) const {
-  *fdef = test::function::MakeTensorSliceDataset();
-  return Status::OK();
-}
-
-string TensorSliceDatasetParams::op_name() const {
+string TensorSliceDatasetParams::dataset_type() const {
   return TensorSliceDatasetOp::kDatasetType;
 }
 
@@ -1062,12 +1041,7 @@ Status TakeDatasetParams::GetAttributes(AttributeVector* attr_vector) const {
   return Status::OK();
 }
 
-Status TakeDatasetParams::CreateFactory(FunctionDef* fdef) const {
-  *fdef = test::function::MakeTakeDataset();
-  return Status::OK();
-}
-
-string TakeDatasetParams::op_name() const {
+string TakeDatasetParams::dataset_type() const {
   return TakeDatasetOp::kDatasetType;
 }
 

--- a/tensorflow/core/kernels/data/dataset_test_base.h
+++ b/tensorflow/core/kernels/data/dataset_test_base.h
@@ -326,6 +326,35 @@ class TakeDatasetParams : public DatasetParams {
   int64 count_;
 };
 
+// `ConcatenateDatasetParams` is a common dataset parameter type that are used
+// in testing.
+class ConcatenateDatasetParams : public DatasetParams {
+ public:
+  template <typename T, typename P>
+  ConcatenateDatasetParams(T input_dataset_params_0, P input_dataset_params_1,
+                           DataTypeVector output_dtypes,
+                           std::vector<PartialTensorShape> output_shapes,
+                           string node_name)
+      : DatasetParams(std::move(output_dtypes), std::move(output_shapes),
+                      std::move(node_name)) {
+    input_dataset_params_.push_back(
+        absl::make_unique<T>(input_dataset_params_0));
+    input_dataset_params_.push_back(
+        absl::make_unique<T>(input_dataset_params_1));
+    iterator_prefix_ =
+        name_utils::IteratorPrefix(input_dataset_params_0.dataset_type(),
+                                   input_dataset_params_0.iterator_prefix());
+  }
+
+  std::vector<Tensor> GetInputTensors() const override;
+
+  Status GetInputNames(std::vector<string>* input_names) const override;
+
+  Status GetAttributes(AttributeVector* attr_vector) const override;
+
+  string dataset_type() const override;
+};
+
 template <typename T>
 struct GetNextTestCase {
   T dataset_params;

--- a/tensorflow/core/kernels/data/dataset_test_base.h
+++ b/tensorflow/core/kernels/data/dataset_test_base.h
@@ -146,17 +146,10 @@ class DatasetParams {
   // Returns the functions that will be used when running the dataset op.
   virtual std::vector<FunctionDef> func_lib() const { return {}; }
 
-  // Returns a function definition for the transformation performed by
-  // this type of dataset.
-  virtual Status CreateFactory(FunctionDef* fdef) const {
-    return errors::Unimplemented(
-        "CreateFactory is not implemented for params '", op_name(), "'");
-  }
-
-  // Returns the op name for the op represented by these parameters. This name
-  // needs to match the registered name of the dataset op (usually a constant
-  // called `kDatasetType`).
-  virtual string op_name() const = 0;
+  // Returns the dataset type for the op represented by these parameters. This
+  // type usually needs to match the constant called `kDatasetType` defined in
+  // the dataset kernel.
+  virtual string dataset_type() const = 0;
 
   virtual int op_version() const { return op_version_; }
 
@@ -186,9 +179,7 @@ class RangeDatasetParams : public DatasetParams {
 
   Status GetAttributes(AttributeVector* attr_vector) const override;
 
-  Status CreateFactory(FunctionDef* fdef) const override;
-
-  string op_name() const override;
+  string dataset_type() const override;
 
  private:
   int64 start_;
@@ -213,8 +204,9 @@ class BatchDatasetParams : public DatasetParams {
         parallel_copy_(parallel_copy) {
     input_dataset_params_.push_back(std::make_unique<T>(input_dataset_params));
     op_version_ = 2;
-    iterator_prefix_ = name_utils::IteratorPrefix(
-        input_dataset_params.op_name(), input_dataset_params.iterator_prefix());
+    iterator_prefix_ =
+        name_utils::IteratorPrefix(input_dataset_params.dataset_type(),
+                                   input_dataset_params.iterator_prefix());
   }
 
   std::vector<Tensor> GetInputTensors() const override;
@@ -223,9 +215,7 @@ class BatchDatasetParams : public DatasetParams {
 
   Status GetAttributes(AttributeVector* attr_vector) const override;
 
-  Status CreateFactory(FunctionDef* fdef) const override;
-
-  string op_name() const override;
+  string dataset_type() const override;
 
  private:
   int64 batch_size_;
@@ -254,8 +244,9 @@ class MapDatasetParams : public DatasetParams {
         use_inter_op_parallelism_(use_inter_op_parallelism),
         preserve_cardinality_(preserve_cardinality) {
     input_dataset_params_.push_back(absl::make_unique<T>(input_dataset_params));
-    iterator_prefix_ = name_utils::IteratorPrefix(
-        input_dataset_params.op_name(), input_dataset_params.iterator_prefix());
+    iterator_prefix_ =
+        name_utils::IteratorPrefix(input_dataset_params.dataset_type(),
+                                   input_dataset_params.iterator_prefix());
   }
 
   std::vector<Tensor> GetInputTensors() const override;
@@ -264,9 +255,7 @@ class MapDatasetParams : public DatasetParams {
 
   Status GetAttributes(AttributeVector* attr_vector) const override;
 
-  Status CreateFactory(FunctionDef* fdef) const override;
-
-  string op_name() const override;
+  string dataset_type() const override;
 
   std::vector<FunctionDef> func_lib() const override;
 
@@ -291,9 +280,7 @@ class TensorSliceDatasetParams : public DatasetParams {
 
   Status GetAttributes(AttributeVector* attr_vector) const override;
 
-  Status CreateFactory(FunctionDef* fdef) const override;
-
-  string op_name() const override;
+  string dataset_type() const override;
 
   int64 num_slices() const { return components_[0].dim_size(0); }
 
@@ -322,8 +309,9 @@ class TakeDatasetParams : public DatasetParams {
                       std::move(node_name)),
         count_(count) {
     input_dataset_params_.push_back(absl::make_unique<T>(input_dataset_params));
-    iterator_prefix_ = name_utils::IteratorPrefix(
-        input_dataset_params.op_name(), input_dataset_params.iterator_prefix());
+    iterator_prefix_ =
+        name_utils::IteratorPrefix(input_dataset_params.dataset_type(),
+                                   input_dataset_params.iterator_prefix());
   }
 
   std::vector<Tensor> GetInputTensors() const override;
@@ -332,9 +320,7 @@ class TakeDatasetParams : public DatasetParams {
 
   Status GetAttributes(AttributeVector* attr_vector) const override;
 
-  Status CreateFactory(FunctionDef* fdef) const override;
-
-  string op_name() const override;
+  string dataset_type() const override;
 
  private:
   int64 count_;
@@ -778,9 +764,6 @@ class DatasetOpsTestBaseV2 : public DatasetOpsTestBase {
       const DatasetParams& dataset_params,
       std::vector<std::unique_ptr<Tensor>>* created_tensors,
       std::unique_ptr<Tensor>* dataset);
-
-  Status CreateFactory(const DatasetParams& dataset_params,
-                       FunctionDef* fdef) const;
 };
 
 #define ITERATOR_GET_NEXT_TEST_P(dataset_op_test_class, dataset_params_class, \

--- a/tensorflow/core/kernels/data/experimental/assert_next_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/experimental/assert_next_dataset_op_test.cc
@@ -33,8 +33,9 @@ class AssertNextDatasetParams : public DatasetParams {
                       std::move(node_name)),
         transformations_(transformations) {
     input_dataset_params_.push_back(absl::make_unique<T>(input_dataset_params));
-    iterator_prefix_ = name_utils::IteratorPrefix(
-        input_dataset_params.op_name(), input_dataset_params.iterator_prefix());
+    iterator_prefix_ =
+        name_utils::IteratorPrefix(input_dataset_params.dataset_type(),
+                                   input_dataset_params.iterator_prefix());
   }
 
   std::vector<Tensor> GetInputTensors() const override {
@@ -56,7 +57,9 @@ class AssertNextDatasetParams : public DatasetParams {
     return Status::OK();
   }
 
-  string op_name() const override { return AssertNextDatasetOp::kDatasetType; }
+  string dataset_type() const override {
+    return AssertNextDatasetOp::kDatasetType;
+  }
 
  private:
   std::vector<tstring> transformations_;

--- a/tensorflow/core/kernels/data/experimental/map_and_batch_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/experimental/map_and_batch_dataset_op_test.cc
@@ -41,8 +41,9 @@ class MapAndBatchDatasetParams : public DatasetParams {
         type_arguments_(std::move(type_arguments)),
         preserve_cardinality_(preserve_cardinality) {
     input_dataset_params_.push_back(absl::make_unique<T>(input_dataset_params));
-    iterator_prefix_ = name_utils::IteratorPrefix(
-        input_dataset_params.op_name(), input_dataset_params.iterator_prefix());
+    iterator_prefix_ =
+        name_utils::IteratorPrefix(input_dataset_params.dataset_type(),
+                                   input_dataset_params.iterator_prefix());
   }
 
   std::vector<Tensor> GetInputTensors() const override {
@@ -81,7 +82,9 @@ class MapAndBatchDatasetParams : public DatasetParams {
 
   std::vector<FunctionDef> func_lib() const override { return func_lib_; }
 
-  string op_name() const override { return MapAndBatchDatasetOp::kDatasetType; }
+  string dataset_type() const override {
+    return MapAndBatchDatasetOp::kDatasetType;
+  }
 
  private:
   std::vector<Tensor> other_arguments_;

--- a/tensorflow/core/kernels/data/experimental/sampling_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/experimental/sampling_dataset_op_test.cc
@@ -33,8 +33,9 @@ class SamplingDatasetParams : public DatasetParams {
                       std::move(node_name)),
         rate_(rate) {
     input_dataset_params_.push_back(absl::make_unique<T>(input_dataset_params));
-    iterator_prefix_ = name_utils::IteratorPrefix(
-        input_dataset_params.op_name(), input_dataset_params.iterator_prefix());
+    iterator_prefix_ =
+        name_utils::IteratorPrefix(input_dataset_params.dataset_type(),
+                                   input_dataset_params.iterator_prefix());
   }
 
   std::vector<Tensor> GetInputTensors() const override {
@@ -57,7 +58,9 @@ class SamplingDatasetParams : public DatasetParams {
     return Status::OK();
   }
 
-  string op_name() const override { return SamplingDatasetOp::kDatasetType; }
+  string dataset_type() const override {
+    return SamplingDatasetOp::kDatasetType;
+  }
 
  private:
   // Target sample rate, range (0,1], wrapped in a scalar Tensor

--- a/tensorflow/core/kernels/data/filter_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/filter_dataset_op_test.cc
@@ -37,8 +37,9 @@ class FilterDatasetParams : public DatasetParams {
         func_lib_(std::move(func_lib)),
         type_arguments_(std::move(type_arguments)) {
     input_dataset_params_.push_back(absl::make_unique<T>(input_dataset_params));
-    iterator_prefix_ = name_utils::IteratorPrefix(
-        input_dataset_params.op_name(), input_dataset_params.iterator_prefix());
+    iterator_prefix_ =
+        name_utils::IteratorPrefix(input_dataset_params.dataset_type(),
+                                   input_dataset_params.iterator_prefix());
   }
 
   std::vector<Tensor> GetInputTensors() const override {
@@ -67,7 +68,7 @@ class FilterDatasetParams : public DatasetParams {
 
   std::vector<FunctionDef> func_lib() const override { return func_lib_; }
 
-  string op_name() const override { return FilterDatasetOp::kDatasetType; }
+  string dataset_type() const override { return FilterDatasetOp::kDatasetType; }
 
  private:
   std::vector<Tensor> other_arguments_;

--- a/tensorflow/core/kernels/data/filter_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/filter_dataset_op_test.cc
@@ -46,12 +46,13 @@ class FilterDatasetParams : public DatasetParams {
     return other_arguments_;
   }
 
-  Status GetInputNames(std::vector<string>* input_placeholder) const override {
-    input_placeholder->reserve(input_dataset_params_.size() +
-                               other_arguments_.size());
-    input_placeholder->emplace_back(FilterDatasetOp::kInputDataset);
+  Status GetInputNames(std::vector<string>* input_names) const override {
+    input_names->clear();
+    input_names->reserve(input_dataset_params_.size() +
+                         other_arguments_.size());
+    input_names->emplace_back(FilterDatasetOp::kInputDataset);
     for (int i = 0; i < other_arguments_.size(); ++i) {
-      input_placeholder->emplace_back(
+      input_names->emplace_back(
           absl::StrCat(FilterDatasetOp::kOtherArguments, "_", i));
     }
 

--- a/tensorflow/core/kernels/data/fixed_length_record_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/fixed_length_record_dataset_op_test.cc
@@ -49,13 +49,14 @@ class FixedLengthRecordDatasetParams : public DatasetParams {
         CreateTensor<tstring>(TensorShape({}), {ToString(compression_type_)})};
   }
 
-  Status GetInputNames(std::vector<string>* input_placeholder) const override {
-    *input_placeholder = {FixedLengthRecordDatasetOp::kFileNames,
-                          FixedLengthRecordDatasetOp::kHeaderBytes,
-                          FixedLengthRecordDatasetOp::kRecordBytes,
-                          FixedLengthRecordDatasetOp::kFooterBytes,
-                          FixedLengthRecordDatasetOp::kBufferSize,
-                          FixedLengthRecordDatasetOp::kCompressionType};
+  Status GetInputNames(std::vector<string>* input_names) const override {
+    input_names->clear();
+    *input_names = {FixedLengthRecordDatasetOp::kFileNames,
+                    FixedLengthRecordDatasetOp::kHeaderBytes,
+                    FixedLengthRecordDatasetOp::kRecordBytes,
+                    FixedLengthRecordDatasetOp::kFooterBytes,
+                    FixedLengthRecordDatasetOp::kBufferSize,
+                    FixedLengthRecordDatasetOp::kCompressionType};
     return Status::OK();
   }
 

--- a/tensorflow/core/kernels/data/fixed_length_record_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/fixed_length_record_dataset_op_test.cc
@@ -64,7 +64,7 @@ class FixedLengthRecordDatasetParams : public DatasetParams {
     return Status::OK();
   }
 
-  string op_name() const override {
+  string dataset_type() const override {
     return FixedLengthRecordDatasetOp::kDatasetType;
   }
 

--- a/tensorflow/core/kernels/data/flat_map_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/flat_map_dataset_op_test.cc
@@ -46,10 +46,10 @@ class FlatMapDatasetParams : public DatasetParams {
     return other_arguments_;
   }
 
-  Status GetInputNames(std::vector<string>* input_placeholder) const override {
-    input_placeholder->emplace_back(FlatMapDatasetOp::kInputDataset);
+  Status GetInputNames(std::vector<string>* input_names) const override {
+    input_names->emplace_back(FlatMapDatasetOp::kInputDataset);
     for (int i = 0; i < other_arguments_.size(); ++i) {
-      input_placeholder->emplace_back(
+      input_names->emplace_back(
           absl::StrCat(FlatMapDatasetOp::kOtherArguments, "_", i));
     }
     return Status::OK();

--- a/tensorflow/core/kernels/data/flat_map_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/flat_map_dataset_op_test.cc
@@ -37,8 +37,9 @@ class FlatMapDatasetParams : public DatasetParams {
         func_lib_(std::move(func_lib)),
         type_arguments_(std::move(type_arguments)) {
     input_dataset_params_.push_back(absl::make_unique<T>(input_dataset_params));
-    iterator_prefix_ = name_utils::IteratorPrefix(
-        input_dataset_params.op_name(), input_dataset_params.iterator_prefix());
+    iterator_prefix_ =
+        name_utils::IteratorPrefix(input_dataset_params.dataset_type(),
+                                   input_dataset_params.iterator_prefix());
   }
 
   std::vector<Tensor> GetInputTensors() const override {
@@ -62,7 +63,9 @@ class FlatMapDatasetParams : public DatasetParams {
     return Status::OK();
   }
 
-  string op_name() const override { return FlatMapDatasetOp::kDatasetType; }
+  string dataset_type() const override {
+    return FlatMapDatasetOp::kDatasetType;
+  }
 
   std::vector<FunctionDef> func_lib() const override { return func_lib_; }
 

--- a/tensorflow/core/kernels/data/interleave_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/interleave_dataset_op_test.cc
@@ -19,759 +19,506 @@ namespace {
 
 constexpr char kNodeName[] = "interleave_dataset";
 
-class InterleaveDatasetOpTest : public DatasetOpsTestBase {
- protected:
-  // Creates `TensorSliceDataset` variant tensor from the input vector of
-  // tensors.
-  Status CreateTensorSliceDatasetTensor(
-      std::vector<Tensor> *const tensor_vector, Tensor *dataset_tensor) {
-    DatasetBase *tensor_slice_dataset;
-    TF_RETURN_IF_ERROR(CreateTensorSliceDataset(
-        "tensor_slice_node", tensor_vector, &tensor_slice_dataset));
-    TF_RETURN_IF_ERROR(
-        StoreDatasetInVariantTensor(tensor_slice_dataset, dataset_tensor));
+class InterleaveDatasetParams : public DatasetParams {
+ public:
+  template <typename T>
+  InterleaveDatasetParams(T input_dataset_params,
+                          std::vector<Tensor> other_arguments,
+                          int64 cycle_length, int64 block_length,
+                          FunctionDefHelper::AttrValueWrapper func,
+                          std::vector<FunctionDef> func_lib,
+                          DataTypeVector type_arguments,
+                          DataTypeVector output_dtypes,
+                          std::vector<PartialTensorShape> output_shapes,
+                          string node_name)
+      : DatasetParams(std::move(output_dtypes), std::move(output_shapes),
+                      std::move(node_name)),
+        other_arguments_(std::move(other_arguments)),
+        cycle_length_(cycle_length),
+        block_length_(block_length),
+        func_(std::move(func)),
+        func_lib_(std::move(func_lib)),
+        type_arguments_(std::move(type_arguments)) {
+    input_dataset_params_.push_back(absl::make_unique<T>(input_dataset_params));
+    iterator_prefix_ =
+        name_utils::IteratorPrefix(input_dataset_params.dataset_type(),
+                                   input_dataset_params.iterator_prefix());
+  }
+
+  std::vector<Tensor> GetInputTensors() const override {
+    std::vector<Tensor> input_tensors = other_arguments_;
+    input_tensors.emplace_back(
+        CreateTensor<int64>(TensorShape({}), {cycle_length_}));
+    input_tensors.emplace_back(
+        CreateTensor<int64>(TensorShape({}), {block_length_}));
+    return input_tensors;
+  }
+
+  Status GetInputPlaceholder(
+      std::vector<string>* input_placeholder) const override {
+    input_placeholder->clear();
+    input_placeholder->reserve(input_dataset_params_.size() +
+                               other_arguments_.size() + 2);
+    input_placeholder->emplace_back(InterleaveDatasetOp::kInputDataset);
+    for (int i = 0; i < other_arguments_.size(); ++i) {
+      input_placeholder->emplace_back(
+          absl::StrCat(InterleaveDatasetOp::kOtherArguments, "_", i));
+    }
+    input_placeholder->emplace_back(InterleaveDatasetOp::kCycleLength);
+    input_placeholder->emplace_back(InterleaveDatasetOp::kBlockLength);
     return Status::OK();
   }
 
-  // Creates a new `InterleaveDataset` op kernel
-  Status CreateInterleaveDatasetKernel(
-      const FunctionDefHelper::AttrValueWrapper &func,
-      const DataTypeVector &output_types,
-      const std::vector<PartialTensorShape> &output_shapes,
-      std::unique_ptr<OpKernel> *op_kernel) {
-    NodeDef node_def = test::function::NDef(
-        kNodeName, name_utils::OpName(InterleaveDatasetOp::kDatasetType),
-        {InterleaveDatasetOp::kInputDataset, InterleaveDatasetOp::kCycleLength,
-         InterleaveDatasetOp::kBlockLength},
-        {{InterleaveDatasetOp::kFunc, func},
-         {InterleaveDatasetOp::kTarguments, {}},
-         {InterleaveDatasetOp::kOutputTypes, output_types},
-         {InterleaveDatasetOp::kOutputShapes, output_shapes}});
-    TF_RETURN_IF_ERROR(CreateOpKernel(node_def, op_kernel));
+  Status GetAttributes(AttributeVector* attr_vector) const override {
+    *attr_vector = {{InterleaveDatasetOp::kFunc, func_},
+                    {InterleaveDatasetOp::kTarguments, type_arguments_},
+                    {InterleaveDatasetOp::kOutputShapes, output_shapes_},
+                    {InterleaveDatasetOp::kOutputTypes, output_dtypes_}};
     return Status::OK();
   }
 
-  // Creates a new `InterleaveDataset` op kernel context.
-  Status CreateInterleaveDatasetContext(
-      OpKernel *const op_kernel,
-      gtl::InlinedVector<TensorValue, 4> *const inputs,
-      std::unique_ptr<OpKernelContext> *context) {
-    TF_RETURN_IF_ERROR(CheckOpKernelInput(*op_kernel, *inputs));
-    TF_RETURN_IF_ERROR(CreateOpKernelContext(op_kernel, inputs, context));
-    return Status::OK();
+  std::vector<FunctionDef> func_lib() const override { return func_lib_; }
+
+  string dataset_type() const override {
+    return InterleaveDatasetOp::kDatasetType;
   }
+
+ private:
+  std::vector<Tensor> other_arguments_;
+  int64 cycle_length_;
+  int64 block_length_;
+  FunctionDefHelper::AttrValueWrapper func_;
+  std::vector<FunctionDef> func_lib_;
+  DataTypeVector type_arguments_;
 };
 
-struct TestCase {
-  std::vector<Tensor> input_tensors;
-  FunctionDefHelper::AttrValueWrapper func;
-  std::vector<FunctionDef> func_lib;
-  Tensor cycle_length;
-  Tensor block_length;
-  std::vector<Tensor> expected_outputs;
-  DataTypeVector expected_output_dtypes;
-  std::vector<PartialTensorShape> expected_output_shapes;
-  int64 expected_cardinality;
-  std::vector<int> breakpoints;
-};
-
-template <typename T>
-std::vector<Tensor> ConvertToTensorVec(std::vector<T> values) {
-  std::vector<Tensor> tensors;
-  tensors.reserve(values.size());
-  for (auto &value : values) {
-    tensors.emplace_back(CreateTensor<T>(TensorShape({1}), {value}));
-  }
-  return tensors;
-}
+class InterleaveDatasetOpTest : public DatasetOpsTestBaseV2 {};
 
 FunctionDefHelper::AttrValueWrapper MakeTensorSliceDatasetFunc(
-    const DataTypeVector &output_types,
-    const std::vector<PartialTensorShape> &output_shapes) {
+    const DataTypeVector& output_types,
+    const std::vector<PartialTensorShape>& output_shapes) {
   return FunctionDefHelper::FunctionRef(
-      /*name*/ "MakeTensorSliceDataset",
-      /*attrs*/ {{"Toutput_types", output_types},
+      /*name=*/"MakeTensorSliceDataset",
+      /*attrs=*/{{"Toutput_types", output_types},
                  {"output_shapes", output_shapes}});
 }
 
 // test case 1: cycle_length = 1, block_length = 1.
-TestCase TestCase1() {
-  return {
-      /*input_tensors*/
+InterleaveDatasetParams InterleaveDatasetParams1() {
+  auto tensor_slice_dataset_params = TensorSliceDatasetParams(
+      /*components=*/
       {CreateTensor<int64>(TensorShape{3, 3, 1}, {0, 1, 2, 3, 4, 5, 6, 7, 8})},
-      /*func*/
+      /*node_name=*/"tensor_slice_dataset");
+  return InterleaveDatasetParams(
+      std::move(tensor_slice_dataset_params),
+      /*other_arguments=*/{},
+      /*cycle_length=*/1,
+      /*block_length=*/1,
+      /*func=*/
       MakeTensorSliceDatasetFunc(
           DataTypeVector({DT_INT64}),
           std::vector<PartialTensorShape>({PartialTensorShape({1})})),
-      /*func_lib*/ {test::function::MakeTensorSliceDataset()},
-      /*cycle_length*/
-      CreateTensor<int64>(TensorShape({}), {1}),
-      /*block_length*/
-      CreateTensor<int64>(TensorShape({}), {1}),
-      /*expected_outputs*/
-      ConvertToTensorVec<int64>({0, 1, 2, 3, 4, 5, 6, 7, 8}),
-      /*expected_output_dtypes*/ {DT_INT64},
-      /*expected_output_shapes*/ {PartialTensorShape({1})},
-      /*expected_cardinality*/ tensorflow::data::kUnknownCardinality,
-      /*breakpoints*/ {0, 4, 11}};
+      /*func_lib=*/{test::function::MakeTensorSliceDataset()},
+      /*type_arguments=*/{},
+      /*output_dtypes=*/{DT_INT64},
+      /*output_shapes=*/{PartialTensorShape({1})},
+      /*node_name=*/kNodeName);
 }
 
 // test case 2: cycle_length = 2, block_length = 1.
-TestCase TestCase2() {
-  return {
-      /*input_tensors*/
+InterleaveDatasetParams InterleaveDatasetParams2() {
+  auto tensor_slice_dataset_params = TensorSliceDatasetParams(
+      /*components=*/
       {CreateTensor<int64>(TensorShape{3, 3, 1}, {0, 1, 2, 3, 4, 5, 6, 7, 8})},
-      /*func*/
+      /*node_name=*/"tensor_slice_dataset");
+  return InterleaveDatasetParams(
+      std::move(tensor_slice_dataset_params),
+      /*other_arguments=*/{},
+      /*cycle_length=*/2,
+      /*block_length=*/1,
+      /*func=*/
       MakeTensorSliceDatasetFunc(
           DataTypeVector({DT_INT64}),
           std::vector<PartialTensorShape>({PartialTensorShape({1})})),
-      /*func_lib*/ {test::function::MakeTensorSliceDataset()},
-      /*cycle_length*/
-      CreateTensor<int64>(TensorShape({}), {2}),
-      /*block_length*/
-      CreateTensor<int64>(TensorShape({}), {1}),
-      /*expected_outputs*/
-      ConvertToTensorVec<int64>({0, 3, 1, 4, 2, 5, 6, 7, 8}),
-      /*expected_output_dtypes*/ {DT_INT64},
-      /*expected_output_shapes*/ {PartialTensorShape({1})},
-      /*expected_cardinality*/ tensorflow::data::kUnknownCardinality,
-      /*breakpoints*/ {0, 4, 11}};
+      /*func_lib=*/{test::function::MakeTensorSliceDataset()},
+      /*type_arguments=*/{},
+      /*output_dtypes=*/{DT_INT64},
+      /*output_shapes=*/{PartialTensorShape({1})},
+      /*node_name=*/kNodeName);
 }
 
 // test case 3: cycle_length = 3, block_length = 1.
-TestCase TestCase3() {
-  return {
-      /*input_tensors*/
+InterleaveDatasetParams InterleaveDatasetParams3() {
+  auto tensor_slice_dataset_params = TensorSliceDatasetParams(
+      /*components=*/
       {CreateTensor<int64>(TensorShape{3, 3, 1}, {0, 1, 2, 3, 4, 5, 6, 7, 8})},
-      /*func*/
+      /*node_name=*/"tensor_slice_dataset");
+  return InterleaveDatasetParams(
+      std::move(tensor_slice_dataset_params),
+      /*other_arguments=*/{},
+      /*cycle_length=*/3,
+      /*block_length=*/1,
+      /*func=*/
       MakeTensorSliceDatasetFunc(
           DataTypeVector({DT_INT64}),
           std::vector<PartialTensorShape>({PartialTensorShape({1})})),
-      /*func_lib*/ {test::function::MakeTensorSliceDataset()},
-      /*cycle_length*/
-      CreateTensor<int64>(TensorShape({}), {3}),
-      /*block_length*/
-      CreateTensor<int64>(TensorShape({}), {1}),
-      /*expected_outputs*/
-      ConvertToTensorVec<int64>({0, 3, 6, 1, 4, 7, 2, 5, 8}),
-      /*expected_output_dtypes*/ {DT_INT64},
-      /*expected_output_shapes*/ {PartialTensorShape({1})},
-      /*expected_cardinality*/ tensorflow::data::kUnknownCardinality,
-      /*breakpoints*/ {0, 4, 11}};
+      /*func_lib=*/{test::function::MakeTensorSliceDataset()},
+      /*type_arguments=*/{},
+      /*output_dtypes=*/{DT_INT64},
+      /*output_shapes=*/{PartialTensorShape({1})},
+      /*node_name=*/kNodeName);
 }
 
 // test case 4: cycle_length = 5, block_length = 1.
-TestCase TestCase4() {
-  return {
-      /*input_tensors*/
+InterleaveDatasetParams InterleaveDatasetParams4() {
+  auto tensor_slice_dataset_params = TensorSliceDatasetParams(
+      /*components=*/
       {CreateTensor<int64>(TensorShape{3, 3, 1}, {0, 1, 2, 3, 4, 5, 6, 7, 8})},
-      /*func*/
+      /*node_name=*/"tensor_slice_dataset");
+  return InterleaveDatasetParams(
+      std::move(tensor_slice_dataset_params),
+      /*other_arguments=*/{},
+      /*cycle_length=*/5,
+      /*block_length=*/1,
+      /*func=*/
       MakeTensorSliceDatasetFunc(
           DataTypeVector({DT_INT64}),
           std::vector<PartialTensorShape>({PartialTensorShape({1})})),
-      /*func_lib*/ {test::function::MakeTensorSliceDataset()},
-      /*cycle_length*/
-      CreateTensor<int64>(TensorShape({}), {3}),
-      /*block_length*/
-      CreateTensor<int64>(TensorShape({}), {1}),
-      /*expected_outputs*/
-      ConvertToTensorVec<int64>({0, 3, 6, 1, 4, 7, 2, 5, 8}),
-      /*expected_output_dtypes*/ {DT_INT64},
-      /*expected_output_shapes*/ {PartialTensorShape({1})},
-      /*expected_cardinality*/ tensorflow::data::kUnknownCardinality,
-      /*breakpoints*/ {0, 4, 11}};
+      /*func_lib=*/{test::function::MakeTensorSliceDataset()},
+      /*type_arguments=*/{},
+      /*output_dtypes=*/{DT_INT64},
+      /*output_shapes=*/{PartialTensorShape({1})},
+      /*node_name=*/kNodeName);
 }
 
 // test case 5: cycle_length = 2, block_length = 2.
-TestCase TestCase5() {
-  return {/*input_tensors*/
-          {CreateTensor<tstring>(TensorShape{3, 3, 1}, {"a", "b", "c", "d", "e",
-                                                        "f", "g", "h", "i"})},
-          /*func*/
-          MakeTensorSliceDatasetFunc(
-              DataTypeVector({DT_STRING}),
-              std::vector<PartialTensorShape>({PartialTensorShape({1})})),
-          /*func_lib*/ {test::function::MakeTensorSliceDataset()},
-          /*cycle_length*/
-          CreateTensor<int64>(TensorShape({}), {2}),
-          /*block_length*/
-          CreateTensor<int64>(TensorShape({}), {2}),
-          /*expected_outputs*/
-          ConvertToTensorVec<tstring>(
-              {"a", "b", "d", "e", "c", "f", "g", "h", "i"}),
-          /*expected_output_dtypes*/ {DT_STRING},
-          /*expected_output_shapes*/ {PartialTensorShape({1})},
-          /*expected_cardinality*/ tensorflow::data::kUnknownCardinality,
-          /*breakpoints*/ {0, 4, 11}};
+InterleaveDatasetParams InterleaveDatasetParams5() {
+  auto tensor_slice_dataset_params = TensorSliceDatasetParams(
+      /*components=*/
+      {CreateTensor<tstring>(TensorShape{3, 3, 1},
+                             {"a", "b", "c", "d", "e", "f", "g", "h", "i"})},
+      /*node_name=*/"tensor_slice_dataset");
+  return InterleaveDatasetParams(
+      std::move(tensor_slice_dataset_params),
+      /*other_arguments=*/{},
+      /*cycle_length=*/2,
+      /*block_length=*/2,
+      /*func=*/
+      MakeTensorSliceDatasetFunc(
+          DataTypeVector({DT_STRING}),
+          std::vector<PartialTensorShape>({PartialTensorShape({1})})),
+      /*func_lib=*/{test::function::MakeTensorSliceDataset()},
+      /*type_arguments=*/{},
+      /*output_dtypes=*/{DT_STRING},
+      /*output_shapes=*/{PartialTensorShape({1})},
+      /*node_name=*/kNodeName);
 }
 
 // test case 6: cycle_length = 2, block_length = 3.
-TestCase TestCase6() {
-  return {/*input_tensors*/
-          {CreateTensor<tstring>(TensorShape{3, 3, 1}, {"a", "b", "c", "d", "e",
-                                                        "f", "g", "h", "i"})},
-          /*func*/
-          MakeTensorSliceDatasetFunc(
-              DataTypeVector({DT_STRING}),
-              std::vector<PartialTensorShape>({PartialTensorShape({1})})),
-          /*func_lib*/ {test::function::MakeTensorSliceDataset()},
-          /*cycle_length*/
-          CreateTensor<int64>(TensorShape({}), {2}),
-          /*block_length*/
-          CreateTensor<int64>(TensorShape({}), {3}),
-          /*expected_outputs*/
-          ConvertToTensorVec<tstring>(
-              {"a", "b", "c", "d", "e", "f", "g", "h", "i"}),
-          /*expected_output_dtypes*/ {DT_STRING},
-          /*expected_output_shapes*/ {PartialTensorShape({1})},
-          /*expected_cardinality*/ tensorflow::data::kUnknownCardinality,
-          /*breakpoints*/ {0, 4, 11}};
+InterleaveDatasetParams InterleaveDatasetParams6() {
+  auto tensor_slice_dataset_params = TensorSliceDatasetParams(
+      /*components=*/
+      {CreateTensor<tstring>(TensorShape{3, 3, 1},
+                             {"a", "b", "c", "d", "e", "f", "g", "h", "i"})},
+      /*node_name=*/"tensor_slice_dataset");
+  return InterleaveDatasetParams(
+      std::move(tensor_slice_dataset_params),
+      /*other_arguments=*/{},
+      /*cycle_length=*/2,
+      /*block_length=*/3,
+      /*func=*/
+      MakeTensorSliceDatasetFunc(
+          DataTypeVector({DT_STRING}),
+          std::vector<PartialTensorShape>({PartialTensorShape({1})})),
+      /*func_lib=*/{test::function::MakeTensorSliceDataset()},
+      /*type_arguments=*/{},
+      /*output_dtypes=*/{DT_STRING},
+      /*output_shapes=*/{PartialTensorShape({1})},
+      /*node_name=*/kNodeName);
 }
 
 // test case 7: cycle_length = 2, block_length = 5.
-TestCase TestCase7() {
-  return {/*input_tensors*/
-          {CreateTensor<tstring>(TensorShape{3, 3, 1}, {"a", "b", "c", "d", "e",
-                                                        "f", "g", "h", "i"})},
-          /*func*/
-          MakeTensorSliceDatasetFunc(
-              DataTypeVector({DT_STRING}),
-              std::vector<PartialTensorShape>({PartialTensorShape({1})})),
-          /*func_lib*/ {test::function::MakeTensorSliceDataset()},
-          /*cycle_length*/
-          CreateTensor<int64>(TensorShape({}), {2}),
-          /*block_length*/
-          CreateTensor<int64>(TensorShape({}), {5}),
-          /*expected_outputs*/
-          ConvertToTensorVec<tstring>(
-              {"a", "b", "c", "d", "e", "f", "g", "h", "i"}),
-          /*expected_output_dtypes*/ {DT_STRING},
-          /*expected_output_shapes*/ {PartialTensorShape({1})},
-          /*expected_cardinality*/ tensorflow::data::kUnknownCardinality,
-          /*breakpoints*/ {0, 4, 11}};
+InterleaveDatasetParams InterleaveDatasetParams7() {
+  auto tensor_slice_dataset_params = TensorSliceDatasetParams(
+      /*components=*/
+      {CreateTensor<tstring>(TensorShape{3, 3, 1},
+                             {"a", "b", "c", "d", "e", "f", "g", "h", "i"})},
+      /*node_name=*/"tensor_slice_dataset");
+  return InterleaveDatasetParams(
+      std::move(tensor_slice_dataset_params),
+      /*other_arguments=*/{},
+      /*cycle_length=*/2,
+      /*block_length=*/5,
+      /*func=*/
+      MakeTensorSliceDatasetFunc(
+          DataTypeVector({DT_STRING}),
+          std::vector<PartialTensorShape>({PartialTensorShape({1})})),
+      /*func_lib=*/{test::function::MakeTensorSliceDataset()},
+      /*type_arguments=*/{},
+      /*output_dtypes=*/{DT_STRING},
+      /*output_shapes=*/{PartialTensorShape({1})},
+      /*node_name=*/kNodeName);
 }
 
 // test case 8: cycle_length = 0, block_length = 5.
-TestCase InvalidCycleLengthTestCase() {
-  return {
-      /*input_tensors*/
+InterleaveDatasetParams InterleaveDatasetParamsWithInvalidCycleLength() {
+  auto tensor_slice_dataset_params = TensorSliceDatasetParams(
+      /*components=*/
       {CreateTensor<int64>(TensorShape{3, 3, 1}, {0, 1, 2, 3, 4, 5, 6, 7, 8})},
-      /*func*/
+      /*node_name=*/"tensor_slice_dataset");
+  return InterleaveDatasetParams(
+      std::move(tensor_slice_dataset_params),
+      /*other_arguments=*/{},
+      /*cycle_length=*/0,
+      /*block_length=*/5,
+      /*func=*/
       MakeTensorSliceDatasetFunc(
           DataTypeVector({DT_INT64}),
           std::vector<PartialTensorShape>({PartialTensorShape({1})})),
-      /*func_lib*/ {test::function::MakeTensorSliceDataset()},
-      /*cycle_length*/
-      CreateTensor<int64>(TensorShape({}), {0}),
-      /*block_length*/
-      CreateTensor<int64>(TensorShape({}), {5}),
-      /*expected_outputs*/ ConvertToTensorVec<int64>({}),
-      /*expected_output_dtypes*/ {DT_INT64},
-      /*expected_output_shapes*/ {PartialTensorShape({1})},
-      /*expected_cardinality*/ tensorflow::data::kUnknownCardinality,
-      /*breakpoints*/ {}};
+      /*func_lib=*/{test::function::MakeTensorSliceDataset()},
+      /*type_arguments=*/{},
+      /*output_dtypes=*/{DT_INT64},
+      /*output_shapes=*/{PartialTensorShape({1})},
+      /*node_name=*/kNodeName);
 }
 
 // test case 9: cycle_length = 1, block_length = -1.
-TestCase InvalidBlockLengthTestCase() {
-  return {
-      /*input_tensors*/
+InterleaveDatasetParams InterleaveDatasetParamsWithInvalidBlockLength() {
+  auto tensor_slice_dataset_params = TensorSliceDatasetParams(
+      /*components=*/
       {CreateTensor<int64>(TensorShape{3, 3, 1}, {0, 1, 2, 3, 4, 5, 6, 7, 8})},
-      /*func*/
+      /*node_name=*/"tensor_slice_dataset");
+  return InterleaveDatasetParams(
+      std::move(tensor_slice_dataset_params),
+      /*other_arguments=*/{},
+      /*cycle_length=*/1,
+      /*block_length=*/-1,
+      /*func=*/
       MakeTensorSliceDatasetFunc(
           DataTypeVector({DT_INT64}),
           std::vector<PartialTensorShape>({PartialTensorShape({1})})),
-      /*func_lib*/ {test::function::MakeTensorSliceDataset()},
-      /*cycle_length*/ CreateTensor<int64>(TensorShape({}), {1}),
-      /*block_length*/ CreateTensor<int64>(TensorShape({}), {-1}),
-      /*expected_outputs*/ ConvertToTensorVec<int64>({}),
-      /*expected_output_dtypes*/ {DT_INT64},
-      /*expected_output_shapes*/ {PartialTensorShape({1})},
-      /*expected_cardinality*/ tensorflow::data::kUnknownCardinality,
-      /*breakpoints*/ {}};
+      /*func_lib=*/{test::function::MakeTensorSliceDataset()},
+      /*type_arguments=*/{},
+      /*output_dtypes=*/{DT_INT64},
+      /*output_shapes=*/{PartialTensorShape({1})},
+      /*node_name=*/kNodeName);
 }
 
-class ParameterizedInterleaveDatasetOpTest
-    : public InterleaveDatasetOpTest,
-      public ::testing::WithParamInterface<TestCase> {};
-
-TEST_P(ParameterizedInterleaveDatasetOpTest, GetNext) {
-  int thread_num = 2, cpu_num = 2;
-  const TestCase &test_case = GetParam();
-  TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime(test_case.func_lib, cpu_num));
-
-  std::unique_ptr<OpKernel> interleave_dataset_kernel;
-  TF_ASSERT_OK(CreateInterleaveDatasetKernel(
-      test_case.func, test_case.expected_output_dtypes,
-      test_case.expected_output_shapes, &interleave_dataset_kernel));
-
-  Tensor tensor_slice_dataset_tensor(DT_VARIANT, TensorShape({}));
-  std::vector<Tensor> inputs_for_tensor_slice_dataset = test_case.input_tensors;
-  TF_ASSERT_OK(CreateTensorSliceDatasetTensor(&inputs_for_tensor_slice_dataset,
-                                              &tensor_slice_dataset_tensor));
-  Tensor cycle_length = test_case.cycle_length;
-  Tensor block_length = test_case.block_length;
-  gtl::InlinedVector<TensorValue, 4> inputs(
-      {TensorValue(&tensor_slice_dataset_tensor), TensorValue(&cycle_length),
-       TensorValue(&block_length)});
-  std::unique_ptr<OpKernelContext> interleave_dataset_context;
-  TF_ASSERT_OK(CreateInterleaveDatasetContext(
-      interleave_dataset_kernel.get(), &inputs, &interleave_dataset_context));
-  DatasetBase *interleave_dataset;
-  TF_ASSERT_OK(CreateDataset(interleave_dataset_kernel.get(),
-                             interleave_dataset_context.get(),
-                             &interleave_dataset));
-  core::ScopedUnref scoped_unref(interleave_dataset);
-
-  std::unique_ptr<IteratorContext> iterator_ctx;
-  TF_ASSERT_OK(
-      CreateIteratorContext(interleave_dataset_context.get(), &iterator_ctx));
-  std::unique_ptr<IteratorBase> iterator;
-  TF_ASSERT_OK(interleave_dataset->MakeIterator(iterator_ctx.get(), "Iterator",
-                                                &iterator));
-  auto expected_outputs_it = test_case.expected_outputs.begin();
-  bool end_of_sequence = false;
-  std::vector<Tensor> out_tensors;
-  while (!end_of_sequence) {
-    TF_EXPECT_OK(
-        iterator->GetNext(iterator_ctx.get(), &out_tensors, &end_of_sequence));
-    if (!end_of_sequence) {
-      for (const auto &tensor : out_tensors) {
-        EXPECT_NE(expected_outputs_it, test_case.expected_outputs.end());
-        TF_EXPECT_OK(ExpectEqual(tensor, *expected_outputs_it));
-        expected_outputs_it++;
-      }
-    }
-  }
-  EXPECT_EQ(expected_outputs_it, test_case.expected_outputs.end());
+std::vector<GetNextTestCase<InterleaveDatasetParams>> GetNextTestCases() {
+  return {
+      {/*dataset_params=*/InterleaveDatasetParams1(),
+       /*expected_outputs=*/
+       CreateTensors<int64>(TensorShape({1}),
+                            {{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}})},
+      {/*dataset_params=*/InterleaveDatasetParams2(),
+       /*expected_outputs=*/CreateTensors<int64>(
+           TensorShape({1}), {{0}, {3}, {1}, {4}, {2}, {5}, {6}, {7}, {8}})},
+      {/*dataset_params=*/InterleaveDatasetParams3(),
+       /*expected_outputs=*/CreateTensors<int64>(
+           TensorShape({1}), {{0}, {3}, {6}, {1}, {4}, {7}, {2}, {5}, {8}})},
+      {/*dataset_params=*/InterleaveDatasetParams4(),
+       /*expected_outputs=*/CreateTensors<int64>(
+           TensorShape({1}), {{0}, {3}, {6}, {1}, {4}, {7}, {2}, {5}, {8}})},
+      {/*dataset_params=*/InterleaveDatasetParams5(),
+       /*expected_outputs=*/CreateTensors<tstring>(
+           TensorShape({1}),
+           {{"a"}, {"b"}, {"d"}, {"e"}, {"c"}, {"f"}, {"g"}, {"h"}, {"i"}})},
+      {/*dataset_params=*/InterleaveDatasetParams6(),
+       /*expected_outputs=*/CreateTensors<tstring>(
+           TensorShape({1}),
+           {{"a"}, {"b"}, {"c"}, {"d"}, {"e"}, {"f"}, {"g"}, {"h"}, {"i"}})},
+      {/*dataset_params=*/InterleaveDatasetParams7(),
+       /*expected_outputs=*/CreateTensors<tstring>(
+           TensorShape({1}),
+           {{"a"}, {"b"}, {"c"}, {"d"}, {"e"}, {"f"}, {"g"}, {"h"}, {"i"}})}};
 }
 
-TEST_F(InterleaveDatasetOpTest, InvalidCycleLength) {
-  int thread_num = 2, cpu_num = 2;
-  const TestCase &test_case = InvalidCycleLengthTestCase();
-  TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime(test_case.func_lib, cpu_num));
-
-  std::unique_ptr<OpKernel> interleave_dataset_kernel;
-  TF_ASSERT_OK(CreateInterleaveDatasetKernel(
-      test_case.func, test_case.expected_output_dtypes,
-      test_case.expected_output_shapes, &interleave_dataset_kernel));
-
-  Tensor tensor_slice_dataset_tensor(DT_VARIANT, TensorShape({}));
-  std::vector<Tensor> inputs_for_tensor_slice_dataset = test_case.input_tensors;
-  TF_ASSERT_OK(CreateTensorSliceDatasetTensor(&inputs_for_tensor_slice_dataset,
-                                              &tensor_slice_dataset_tensor));
-  Tensor cycle_length = test_case.cycle_length;
-  Tensor block_length = test_case.block_length;
-  gtl::InlinedVector<TensorValue, 4> inputs(
-      {TensorValue(&tensor_slice_dataset_tensor), TensorValue(&cycle_length),
-       TensorValue(&block_length)});
-  std::unique_ptr<OpKernelContext> interleave_dataset_context;
-  TF_ASSERT_OK(CreateInterleaveDatasetContext(
-      interleave_dataset_kernel.get(), &inputs, &interleave_dataset_context));
-  DatasetBase *interleave_dataset;
-  EXPECT_EQ(CreateDataset(interleave_dataset_kernel.get(),
-                          interleave_dataset_context.get(), &interleave_dataset)
-                .code(),
-            tensorflow::error::INVALID_ARGUMENT);
-}
-
-TEST_F(InterleaveDatasetOpTest, InvalidBlockLength) {
-  int thread_num = 2, cpu_num = 2;
-  const TestCase &test_case = InvalidBlockLengthTestCase();
-  TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime(test_case.func_lib, cpu_num));
-
-  std::unique_ptr<OpKernel> interleave_dataset_kernel;
-  TF_ASSERT_OK(CreateInterleaveDatasetKernel(
-      test_case.func, test_case.expected_output_dtypes,
-      test_case.expected_output_shapes, &interleave_dataset_kernel));
-
-  Tensor tensor_slice_dataset_tensor(DT_VARIANT, TensorShape({}));
-  std::vector<Tensor> inputs_for_tensor_slice_dataset = test_case.input_tensors;
-  TF_ASSERT_OK(CreateTensorSliceDatasetTensor(&inputs_for_tensor_slice_dataset,
-                                              &tensor_slice_dataset_tensor));
-  Tensor cycle_length = test_case.cycle_length;
-  Tensor block_length = test_case.block_length;
-  gtl::InlinedVector<TensorValue, 4> inputs(
-      {TensorValue(&tensor_slice_dataset_tensor), TensorValue(&cycle_length),
-       TensorValue(&block_length)});
-  std::unique_ptr<OpKernelContext> interleave_dataset_context;
-  TF_ASSERT_OK(CreateInterleaveDatasetContext(
-      interleave_dataset_kernel.get(), &inputs, &interleave_dataset_context));
-  DatasetBase *interleave_dataset;
-  EXPECT_EQ(CreateDataset(interleave_dataset_kernel.get(),
-                          interleave_dataset_context.get(), &interleave_dataset)
-                .code(),
-            tensorflow::error::INVALID_ARGUMENT);
-}
+ITERATOR_GET_NEXT_TEST_P(InterleaveDatasetOpTest, InterleaveDatasetParams,
+                         GetNextTestCases())
 
 TEST_F(InterleaveDatasetOpTest, DatasetNodeName) {
-  int thread_num = 2, cpu_num = 2;
-  const TestCase &test_case = TestCase1();
-  TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime(test_case.func_lib, cpu_num));
-
-  std::unique_ptr<OpKernel> interleave_dataset_kernel;
-  TF_ASSERT_OK(CreateInterleaveDatasetKernel(
-      test_case.func, test_case.expected_output_dtypes,
-      test_case.expected_output_shapes, &interleave_dataset_kernel));
-
-  Tensor tensor_slice_dataset_tensor(DT_VARIANT, TensorShape({}));
-  std::vector<Tensor> inputs_for_tensor_slice_dataset = test_case.input_tensors;
-  TF_ASSERT_OK(CreateTensorSliceDatasetTensor(&inputs_for_tensor_slice_dataset,
-                                              &tensor_slice_dataset_tensor));
-  Tensor cycle_length = test_case.cycle_length;
-  Tensor block_length = test_case.block_length;
-  gtl::InlinedVector<TensorValue, 4> inputs(
-      {TensorValue(&tensor_slice_dataset_tensor), TensorValue(&cycle_length),
-       TensorValue(&block_length)});
-  std::unique_ptr<OpKernelContext> interleave_dataset_context;
-  TF_ASSERT_OK(CreateInterleaveDatasetContext(
-      interleave_dataset_kernel.get(), &inputs, &interleave_dataset_context));
-  DatasetBase *interleave_dataset;
-  TF_ASSERT_OK(CreateDataset(interleave_dataset_kernel.get(),
-                             interleave_dataset_context.get(),
-                             &interleave_dataset));
-  core::ScopedUnref scoped_unref(interleave_dataset);
-
-  EXPECT_EQ(interleave_dataset->node_name(), kNodeName);
+  auto dataset_params = InterleaveDatasetParams1();
+  TF_ASSERT_OK(Initialize(dataset_params));
+  TF_ASSERT_OK(CheckDatasetNodeName(dataset_params.node_name()));
 }
 
 TEST_F(InterleaveDatasetOpTest, DatasetTypeString) {
-  int thread_num = 2, cpu_num = 2;
-  const TestCase &test_case = TestCase1();
-  TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime(test_case.func_lib, cpu_num));
-
-  std::unique_ptr<OpKernel> interleave_dataset_kernel;
-  TF_ASSERT_OK(CreateInterleaveDatasetKernel(
-      test_case.func, test_case.expected_output_dtypes,
-      test_case.expected_output_shapes, &interleave_dataset_kernel));
-
-  Tensor tensor_slice_dataset_tensor(DT_VARIANT, TensorShape({}));
-  std::vector<Tensor> inputs_for_tensor_slice_dataset = test_case.input_tensors;
-  TF_ASSERT_OK(CreateTensorSliceDatasetTensor(&inputs_for_tensor_slice_dataset,
-                                              &tensor_slice_dataset_tensor));
-  Tensor cycle_length = test_case.cycle_length;
-  Tensor block_length = test_case.block_length;
-  gtl::InlinedVector<TensorValue, 4> inputs(
-      {TensorValue(&tensor_slice_dataset_tensor), TensorValue(&cycle_length),
-       TensorValue(&block_length)});
-  std::unique_ptr<OpKernelContext> interleave_dataset_context;
-  TF_ASSERT_OK(CreateInterleaveDatasetContext(
-      interleave_dataset_kernel.get(), &inputs, &interleave_dataset_context));
-  DatasetBase *interleave_dataset;
-  TF_ASSERT_OK(CreateDataset(interleave_dataset_kernel.get(),
-                             interleave_dataset_context.get(),
-                             &interleave_dataset));
-  core::ScopedUnref scoped_unref(interleave_dataset);
-
-  EXPECT_EQ(interleave_dataset->type_string(),
-            name_utils::OpName(InterleaveDatasetOp::kDatasetType));
+  auto dataset_params = InterleaveDatasetParams1();
+  TF_ASSERT_OK(Initialize(dataset_params));
+  TF_ASSERT_OK(CheckDatasetTypeString(
+      name_utils::OpName(InterleaveDatasetOp::kDatasetType)));
 }
 
-TEST_P(ParameterizedInterleaveDatasetOpTest, DatasetOutputDtypes) {
-  int thread_num = 2, cpu_num = 2;
-  const TestCase &test_case = GetParam();
-  TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime(test_case.func_lib, cpu_num));
-
-  std::unique_ptr<OpKernel> interleave_dataset_kernel;
-  TF_ASSERT_OK(CreateInterleaveDatasetKernel(
-      test_case.func, test_case.expected_output_dtypes,
-      test_case.expected_output_shapes, &interleave_dataset_kernel));
-
-  Tensor tensor_slice_dataset_tensor(DT_VARIANT, TensorShape({}));
-  std::vector<Tensor> inputs_for_tensor_slice_dataset = test_case.input_tensors;
-  TF_ASSERT_OK(CreateTensorSliceDatasetTensor(&inputs_for_tensor_slice_dataset,
-                                              &tensor_slice_dataset_tensor));
-  Tensor cycle_length = test_case.cycle_length;
-  Tensor block_length = test_case.block_length;
-  gtl::InlinedVector<TensorValue, 4> inputs(
-      {TensorValue(&tensor_slice_dataset_tensor), TensorValue(&cycle_length),
-       TensorValue(&block_length)});
-  std::unique_ptr<OpKernelContext> interleave_dataset_context;
-  TF_ASSERT_OK(CreateInterleaveDatasetContext(
-      interleave_dataset_kernel.get(), &inputs, &interleave_dataset_context));
-  DatasetBase *interleave_dataset;
-  TF_ASSERT_OK(CreateDataset(interleave_dataset_kernel.get(),
-                             interleave_dataset_context.get(),
-                             &interleave_dataset));
-  core::ScopedUnref scoped_unref(interleave_dataset);
-
-  TF_EXPECT_OK(VerifyTypesMatch(interleave_dataset->output_dtypes(),
-                                test_case.expected_output_dtypes));
+std::vector<DatasetOutputDtypesTestCase<InterleaveDatasetParams>>
+DatasetOutputDtypesTestCases() {
+  return {{/*dataset_params=*/InterleaveDatasetParams1(),
+           /*expected_output_dtypes=*/{DT_INT64}},
+          {/*dataset_params=*/InterleaveDatasetParams2(),
+           /*expected_output_dtypes=*/{DT_INT64}},
+          {/*dataset_params=*/InterleaveDatasetParams3(),
+           /*expected_output_dtypes=*/{DT_INT64}},
+          {/*dataset_params=*/InterleaveDatasetParams4(),
+           /*expected_output_dtypes=*/{DT_INT64}},
+          {/*dataset_params=*/InterleaveDatasetParams5(),
+           /*expected_output_dtypes=*/{DT_STRING}},
+          {/*dataset_params=*/InterleaveDatasetParams6(),
+           /*expected_output_dtypes=*/{DT_STRING}},
+          {/*dataset_params=*/InterleaveDatasetParams7(),
+           /*expected_output_dtypes=*/{DT_STRING}}};
 }
 
-TEST_P(ParameterizedInterleaveDatasetOpTest, DatasetOutputShapes) {
-  int thread_num = 2, cpu_num = 2;
-  const TestCase &test_case = GetParam();
-  TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime(test_case.func_lib, cpu_num));
+DATASET_OUTPUT_DTYPES_TEST_P(InterleaveDatasetOpTest, InterleaveDatasetParams,
+                             DatasetOutputDtypesTestCases())
 
-  std::unique_ptr<OpKernel> interleave_dataset_kernel;
-  TF_ASSERT_OK(CreateInterleaveDatasetKernel(
-      test_case.func, test_case.expected_output_dtypes,
-      test_case.expected_output_shapes, &interleave_dataset_kernel));
-
-  Tensor tensor_slice_dataset_tensor(DT_VARIANT, TensorShape({}));
-  std::vector<Tensor> inputs_for_tensor_slice_dataset = test_case.input_tensors;
-  TF_ASSERT_OK(CreateTensorSliceDatasetTensor(&inputs_for_tensor_slice_dataset,
-                                              &tensor_slice_dataset_tensor));
-  Tensor cycle_length = test_case.cycle_length;
-  Tensor block_length = test_case.block_length;
-  gtl::InlinedVector<TensorValue, 4> inputs(
-      {TensorValue(&tensor_slice_dataset_tensor), TensorValue(&cycle_length),
-       TensorValue(&block_length)});
-  std::unique_ptr<OpKernelContext> interleave_dataset_context;
-  TF_ASSERT_OK(CreateInterleaveDatasetContext(
-      interleave_dataset_kernel.get(), &inputs, &interleave_dataset_context));
-  DatasetBase *interleave_dataset;
-  TF_ASSERT_OK(CreateDataset(interleave_dataset_kernel.get(),
-                             interleave_dataset_context.get(),
-                             &interleave_dataset));
-  core::ScopedUnref scoped_unref(interleave_dataset);
-
-  TF_EXPECT_OK(VerifyShapesCompatible(interleave_dataset->output_shapes(),
-                                      test_case.expected_output_shapes));
+std::vector<DatasetOutputShapesTestCase<InterleaveDatasetParams>>
+DatasetOutputShapesTestCases() {
+  return {{/*dataset_params=*/InterleaveDatasetParams1(),
+           /*expected_output_shapes=*/{PartialTensorShape({1})}},
+          {/*dataset_params=*/InterleaveDatasetParams2(),
+           /*expected_output_shapes=*/{PartialTensorShape({1})}},
+          {/*dataset_params=*/InterleaveDatasetParams3(),
+           /*expected_output_shapes=*/{PartialTensorShape({1})}},
+          {/*dataset_params=*/InterleaveDatasetParams4(),
+           /*expected_output_shapes=*/{PartialTensorShape({1})}},
+          {/*dataset_params=*/InterleaveDatasetParams5(),
+           /*expected_output_shapes=*/{PartialTensorShape({1})}},
+          {/*dataset_params=*/InterleaveDatasetParams6(),
+           /*expected_output_shapes=*/{PartialTensorShape({1})}},
+          {/*dataset_params=*/InterleaveDatasetParams7(),
+           /*expected_output_shapes=*/{PartialTensorShape({1})}}};
 }
 
-TEST_P(ParameterizedInterleaveDatasetOpTest, Cardinality) {
-  int thread_num = 2, cpu_num = 2;
-  const TestCase &test_case = GetParam();
-  TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime(test_case.func_lib, cpu_num));
+DATASET_OUTPUT_SHAPES_TEST_P(InterleaveDatasetOpTest, InterleaveDatasetParams,
+                             DatasetOutputShapesTestCases())
 
-  std::unique_ptr<OpKernel> interleave_dataset_kernel;
-  TF_ASSERT_OK(CreateInterleaveDatasetKernel(
-      test_case.func, test_case.expected_output_dtypes,
-      test_case.expected_output_shapes, &interleave_dataset_kernel));
-
-  Tensor tensor_slice_dataset_tensor(DT_VARIANT, TensorShape({}));
-  std::vector<Tensor> inputs_for_tensor_slice_dataset = test_case.input_tensors;
-  TF_ASSERT_OK(CreateTensorSliceDatasetTensor(&inputs_for_tensor_slice_dataset,
-                                              &tensor_slice_dataset_tensor));
-  Tensor cycle_length = test_case.cycle_length;
-  Tensor block_length = test_case.block_length;
-  gtl::InlinedVector<TensorValue, 4> inputs(
-      {TensorValue(&tensor_slice_dataset_tensor), TensorValue(&cycle_length),
-       TensorValue(&block_length)});
-  std::unique_ptr<OpKernelContext> interleave_dataset_context;
-  TF_ASSERT_OK(CreateInterleaveDatasetContext(
-      interleave_dataset_kernel.get(), &inputs, &interleave_dataset_context));
-  DatasetBase *interleave_dataset;
-  TF_ASSERT_OK(CreateDataset(interleave_dataset_kernel.get(),
-                             interleave_dataset_context.get(),
-                             &interleave_dataset));
-  core::ScopedUnref scoped_unref(interleave_dataset);
-
-  EXPECT_EQ(interleave_dataset->Cardinality(), test_case.expected_cardinality);
+std::vector<CardinalityTestCase<InterleaveDatasetParams>>
+CardinalityTestCases() {
+  return {{/*dataset_params=*/InterleaveDatasetParams1(),
+           /*expected_cardinality=*/kUnknownCardinality},
+          {/*dataset_params=*/InterleaveDatasetParams2(),
+           /*expected_cardinality=*/kUnknownCardinality},
+          {/*dataset_params=*/InterleaveDatasetParams3(),
+           /*expected_cardinality=*/kUnknownCardinality},
+          {/*dataset_params=*/InterleaveDatasetParams4(),
+           /*expected_cardinality=*/kUnknownCardinality},
+          {/*dataset_params=*/InterleaveDatasetParams5(),
+           /*expected_cardinality=*/kUnknownCardinality},
+          {/*dataset_params=*/InterleaveDatasetParams6(),
+           /*expected_cardinality=*/kUnknownCardinality},
+          {/*dataset_params=*/InterleaveDatasetParams7(),
+           /*expected_cardinality=*/kUnknownCardinality}};
 }
 
-TEST_P(ParameterizedInterleaveDatasetOpTest, IteratorOutputDtypes) {
-  int thread_num = 2, cpu_num = 2;
-  const TestCase &test_case = GetParam();
-  TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime(test_case.func_lib, cpu_num));
+DATASET_CARDINALITY_TEST_P(InterleaveDatasetOpTest, InterleaveDatasetParams,
+                           CardinalityTestCases())
 
-  std::unique_ptr<OpKernel> interleave_dataset_kernel;
-  TF_ASSERT_OK(CreateInterleaveDatasetKernel(
-      test_case.func, test_case.expected_output_dtypes,
-      test_case.expected_output_shapes, &interleave_dataset_kernel));
-
-  Tensor tensor_slice_dataset_tensor(DT_VARIANT, TensorShape({}));
-  std::vector<Tensor> inputs_for_tensor_slice_dataset = test_case.input_tensors;
-  TF_ASSERT_OK(CreateTensorSliceDatasetTensor(&inputs_for_tensor_slice_dataset,
-                                              &tensor_slice_dataset_tensor));
-  Tensor cycle_length = test_case.cycle_length;
-  Tensor block_length = test_case.block_length;
-  gtl::InlinedVector<TensorValue, 4> inputs(
-      {TensorValue(&tensor_slice_dataset_tensor), TensorValue(&cycle_length),
-       TensorValue(&block_length)});
-  std::unique_ptr<OpKernelContext> interleave_dataset_context;
-  TF_ASSERT_OK(CreateInterleaveDatasetContext(
-      interleave_dataset_kernel.get(), &inputs, &interleave_dataset_context));
-  DatasetBase *interleave_dataset;
-  TF_ASSERT_OK(CreateDataset(interleave_dataset_kernel.get(),
-                             interleave_dataset_context.get(),
-                             &interleave_dataset));
-  core::ScopedUnref scoped_unref(interleave_dataset);
-
-  std::unique_ptr<IteratorContext> iterator_ctx;
-  TF_ASSERT_OK(
-      CreateIteratorContext(interleave_dataset_context.get(), &iterator_ctx));
-  std::unique_ptr<IteratorBase> iterator;
-  TF_ASSERT_OK(interleave_dataset->MakeIterator(iterator_ctx.get(), "Iterator",
-                                                &iterator));
-
-  TF_EXPECT_OK(VerifyTypesMatch(iterator->output_dtypes(),
-                                test_case.expected_output_dtypes));
+std::vector<IteratorOutputDtypesTestCase<InterleaveDatasetParams>>
+IteratorOutputDtypesTestCases() {
+  return {{/*dataset_params=*/InterleaveDatasetParams1(),
+           /*expected_output_dtypes=*/{DT_INT64}},
+          {/*dataset_params=*/InterleaveDatasetParams2(),
+           /*expected_output_dtypes=*/{DT_INT64}},
+          {/*dataset_params=*/InterleaveDatasetParams3(),
+           /*expected_output_dtypes=*/{DT_INT64}},
+          {/*dataset_params=*/InterleaveDatasetParams4(),
+           /*expected_output_dtypes=*/{DT_INT64}},
+          {/*dataset_params=*/InterleaveDatasetParams5(),
+           /*expected_output_dtypes=*/{DT_STRING}},
+          {/*dataset_params=*/InterleaveDatasetParams6(),
+           /*expected_output_dtypes=*/{DT_STRING}},
+          {/*dataset_params=*/InterleaveDatasetParams7(),
+           /*expected_output_dtypes=*/{DT_STRING}}};
 }
 
-TEST_P(ParameterizedInterleaveDatasetOpTest, IteratorOutputShapes) {
-  int thread_num = 2, cpu_num = 2;
-  const TestCase &test_case = GetParam();
-  TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime(test_case.func_lib, cpu_num));
+ITERATOR_OUTPUT_DTYPES_TEST_P(InterleaveDatasetOpTest, InterleaveDatasetParams,
+                              IteratorOutputDtypesTestCases())
 
-  std::unique_ptr<OpKernel> interleave_dataset_kernel;
-  TF_ASSERT_OK(CreateInterleaveDatasetKernel(
-      test_case.func, test_case.expected_output_dtypes,
-      test_case.expected_output_shapes, &interleave_dataset_kernel));
-
-  Tensor tensor_slice_dataset_tensor(DT_VARIANT, TensorShape({}));
-  std::vector<Tensor> inputs_for_tensor_slice_dataset = test_case.input_tensors;
-  TF_ASSERT_OK(CreateTensorSliceDatasetTensor(&inputs_for_tensor_slice_dataset,
-                                              &tensor_slice_dataset_tensor));
-  Tensor cycle_length = test_case.cycle_length;
-  Tensor block_length = test_case.block_length;
-  gtl::InlinedVector<TensorValue, 4> inputs(
-      {TensorValue(&tensor_slice_dataset_tensor), TensorValue(&cycle_length),
-       TensorValue(&block_length)});
-  std::unique_ptr<OpKernelContext> interleave_dataset_context;
-  TF_ASSERT_OK(CreateInterleaveDatasetContext(
-      interleave_dataset_kernel.get(), &inputs, &interleave_dataset_context));
-  DatasetBase *interleave_dataset;
-  TF_ASSERT_OK(CreateDataset(interleave_dataset_kernel.get(),
-                             interleave_dataset_context.get(),
-                             &interleave_dataset));
-  core::ScopedUnref scoped_unref(interleave_dataset);
-
-  std::unique_ptr<IteratorContext> iterator_ctx;
-  TF_ASSERT_OK(
-      CreateIteratorContext(interleave_dataset_context.get(), &iterator_ctx));
-  std::unique_ptr<IteratorBase> iterator;
-  TF_ASSERT_OK(interleave_dataset->MakeIterator(iterator_ctx.get(), "Iterator",
-                                                &iterator));
-
-  TF_EXPECT_OK(VerifyShapesCompatible(iterator->output_shapes(),
-                                      test_case.expected_output_shapes));
+std::vector<IteratorOutputShapesTestCase<InterleaveDatasetParams>>
+IteratorOutputShapesTestCases() {
+  return {{/*dataset_params=*/InterleaveDatasetParams1(),
+           /*expected_output_shapes=*/{PartialTensorShape({1})}},
+          {/*dataset_params=*/InterleaveDatasetParams2(),
+           /*expected_output_shapes=*/{PartialTensorShape({1})}},
+          {/*dataset_params=*/InterleaveDatasetParams3(),
+           /*expected_output_shapes=*/{PartialTensorShape({1})}},
+          {/*dataset_params=*/InterleaveDatasetParams4(),
+           /*expected_output_shapes=*/{PartialTensorShape({1})}},
+          {/*dataset_params=*/InterleaveDatasetParams5(),
+           /*expected_output_shapes=*/{PartialTensorShape({1})}},
+          {/*dataset_params=*/InterleaveDatasetParams6(),
+           /*expected_output_shapes=*/{PartialTensorShape({1})}},
+          {/*dataset_params=*/InterleaveDatasetParams7(),
+           /*expected_output_shapes=*/{PartialTensorShape({1})}}};
 }
 
-TEST_F(InterleaveDatasetOpTest, IteratorOutputPrefix) {
-  int thread_num = 2, cpu_num = 2;
-  const TestCase &test_case = TestCase1();
-  TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime(test_case.func_lib, cpu_num));
+ITERATOR_OUTPUT_SHAPES_TEST_P(InterleaveDatasetOpTest, InterleaveDatasetParams,
+                              IteratorOutputShapesTestCases())
 
-  std::unique_ptr<OpKernel> interleave_dataset_kernel;
-  TF_ASSERT_OK(CreateInterleaveDatasetKernel(
-      test_case.func, test_case.expected_output_dtypes,
-      test_case.expected_output_shapes, &interleave_dataset_kernel));
-
-  Tensor tensor_slice_dataset_tensor(DT_VARIANT, TensorShape({}));
-  std::vector<Tensor> inputs_for_tensor_slice_dataset = test_case.input_tensors;
-  TF_ASSERT_OK(CreateTensorSliceDatasetTensor(&inputs_for_tensor_slice_dataset,
-                                              &tensor_slice_dataset_tensor));
-  Tensor cycle_length = test_case.cycle_length;
-  Tensor block_length = test_case.block_length;
-  gtl::InlinedVector<TensorValue, 4> inputs(
-      {TensorValue(&tensor_slice_dataset_tensor), TensorValue(&cycle_length),
-       TensorValue(&block_length)});
-  std::unique_ptr<OpKernelContext> interleave_dataset_context;
-  TF_ASSERT_OK(CreateInterleaveDatasetContext(
-      interleave_dataset_kernel.get(), &inputs, &interleave_dataset_context));
-  DatasetBase *interleave_dataset;
-  TF_ASSERT_OK(CreateDataset(interleave_dataset_kernel.get(),
-                             interleave_dataset_context.get(),
-                             &interleave_dataset));
-  core::ScopedUnref scoped_unref(interleave_dataset);
-
-  std::unique_ptr<IteratorContext> iterator_ctx;
-  TF_ASSERT_OK(
-      CreateIteratorContext(interleave_dataset_context.get(), &iterator_ctx));
-  std::unique_ptr<IteratorBase> iterator;
-  TF_ASSERT_OK(interleave_dataset->MakeIterator(iterator_ctx.get(), "Iterator",
-                                                &iterator));
-
-  EXPECT_EQ(iterator->prefix(),
-            name_utils::IteratorPrefix(InterleaveDatasetOp::kDatasetType,
-                                       "Iterator"));
+TEST_F(InterleaveDatasetOpTest, IteratorPrefix) {
+  auto dataset_params = InterleaveDatasetParams1();
+  TF_ASSERT_OK(Initialize(dataset_params));
+  TF_ASSERT_OK(CheckIteratorPrefix(name_utils::IteratorPrefix(
+      InterleaveDatasetOp::kDatasetType, dataset_params.iterator_prefix())));
 }
 
-TEST_P(ParameterizedInterleaveDatasetOpTest, Roundtrip) {
-  int thread_num = 2, cpu_num = 2;
-  const TestCase &test_case = GetParam();
-  TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime(test_case.func_lib, cpu_num));
-
-  std::unique_ptr<OpKernel> interleave_dataset_kernel;
-  TF_ASSERT_OK(CreateInterleaveDatasetKernel(
-      test_case.func, test_case.expected_output_dtypes,
-      test_case.expected_output_shapes, &interleave_dataset_kernel));
-
-  Tensor tensor_slice_dataset_tensor(DT_VARIANT, TensorShape({}));
-  std::vector<Tensor> inputs_for_tensor_slice_dataset = test_case.input_tensors;
-  TF_ASSERT_OK(CreateTensorSliceDatasetTensor(&inputs_for_tensor_slice_dataset,
-                                              &tensor_slice_dataset_tensor));
-  Tensor cycle_length = test_case.cycle_length;
-  Tensor block_length = test_case.block_length;
-  gtl::InlinedVector<TensorValue, 4> inputs(
-      {TensorValue(&tensor_slice_dataset_tensor), TensorValue(&cycle_length),
-       TensorValue(&block_length)});
-  std::unique_ptr<OpKernelContext> interleave_dataset_context;
-  TF_ASSERT_OK(CreateInterleaveDatasetContext(
-      interleave_dataset_kernel.get(), &inputs, &interleave_dataset_context));
-  DatasetBase *interleave_dataset;
-  TF_ASSERT_OK(CreateDataset(interleave_dataset_kernel.get(),
-                             interleave_dataset_context.get(),
-                             &interleave_dataset));
-  core::ScopedUnref scoped_unref(interleave_dataset);
-
-  std::unique_ptr<IteratorContext> iterator_ctx;
-  TF_ASSERT_OK(
-      CreateIteratorContext(interleave_dataset_context.get(), &iterator_ctx));
-  std::unique_ptr<IteratorBase> iterator;
-  TF_ASSERT_OK(interleave_dataset->MakeIterator(iterator_ctx.get(), "Iterator",
-                                                &iterator));
-
-  std::unique_ptr<SerializationContext> serialization_ctx;
-  TF_ASSERT_OK(CreateSerializationContext(&serialization_ctx));
-
-  bool end_of_sequence = false;
-  std::vector<Tensor> out_tensors;
-  int cur_iteration = 0;
-  auto expected_outputs_it = test_case.expected_outputs.begin();
-  const std::vector<int> &breakpoints = test_case.breakpoints;
-  for (int breakpoint : breakpoints) {
-    VariantTensorData data;
-    VariantTensorDataWriter writer(&data);
-    TF_EXPECT_OK(iterator->Save(serialization_ctx.get(), &writer));
-    TF_EXPECT_OK(writer.Flush());
-    VariantTensorDataReader reader(&data);
-    TF_EXPECT_OK(RestoreIterator(iterator_ctx.get(), &reader, "Iterator",
-                                 *interleave_dataset, &iterator));
-
-    while (cur_iteration <= breakpoint) {
-      TF_EXPECT_OK(iterator->GetNext(iterator_ctx.get(), &out_tensors,
-                                     &end_of_sequence));
-      if (!end_of_sequence) {
-        for (auto &tensor : out_tensors) {
-          EXPECT_NE(expected_outputs_it, test_case.expected_outputs.end());
-          TF_EXPECT_OK(ExpectEqual(tensor, *expected_outputs_it));
-          expected_outputs_it++;
-        }
-      }
-      cur_iteration++;
-    }
-
-    if (breakpoint >= test_case.expected_outputs.size()) {
-      EXPECT_TRUE(end_of_sequence);
-      EXPECT_EQ(expected_outputs_it, test_case.expected_outputs.end());
-    } else {
-      EXPECT_FALSE(end_of_sequence);
-    }
-  }
+std::vector<IteratorSaveAndRestoreTestCase<InterleaveDatasetParams>>
+IteratorSaveAndRestoreTestCases() {
+  return {
+      {/*dataset_params=*/InterleaveDatasetParams1(),
+       /*breakpoints=*/{0, 4, 11},
+       /*expected_outputs=*/
+       CreateTensors<int64>(TensorShape({1}),
+                            {{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}})},
+      {/*dataset_params=*/InterleaveDatasetParams2(),
+       /*breakpoints=*/{0, 4, 11},
+       /*expected_outputs=*/
+       CreateTensors<int64>(TensorShape({1}),
+                            {{0}, {3}, {1}, {4}, {2}, {5}, {6}, {7}, {8}})},
+      {/*dataset_params=*/InterleaveDatasetParams3(),
+       /*breakpoints=*/{0, 4, 11},
+       /*expected_outputs=*/
+       CreateTensors<int64>(TensorShape({1}),
+                            {{0}, {3}, {6}, {1}, {4}, {7}, {2}, {5}, {8}})},
+      {/*dataset_params=*/InterleaveDatasetParams4(),
+       /*breakpoints=*/{0, 4, 11},
+       /*expected_outputs=*/
+       CreateTensors<int64>(TensorShape({1}),
+                            {{0}, {3}, {6}, {1}, {4}, {7}, {2}, {5}, {8}})},
+      {/*dataset_params=*/InterleaveDatasetParams5(),
+       /*breakpoints=*/{0, 4, 11},
+       /*expected_outputs=*/
+       CreateTensors<tstring>(
+           TensorShape({1}),
+           {{"a"}, {"b"}, {"d"}, {"e"}, {"c"}, {"f"}, {"g"}, {"h"}, {"i"}})},
+      {/*dataset_params=*/InterleaveDatasetParams6(),
+       /*breakpoints=*/{0, 4, 11},
+       /*expected_outputs=*/
+       CreateTensors<tstring>(
+           TensorShape({1}),
+           {{"a"}, {"b"}, {"c"}, {"d"}, {"e"}, {"f"}, {"g"}, {"h"}, {"i"}})},
+      {/*dataset_params=*/InterleaveDatasetParams7(),
+       /*breakpoints=*/{0, 4, 11},
+       /*expected_outputs=*/
+       CreateTensors<tstring>(
+           TensorShape({1}),
+           {{"a"}, {"b"}, {"c"}, {"d"}, {"e"}, {"f"}, {"g"}, {"h"}, {"i"}})}};
 }
 
-INSTANTIATE_TEST_SUITE_P(InterleaveDatasetOpTest,
-                         ParameterizedInterleaveDatasetOpTest,
-                         ::testing::ValuesIn(std::vector<TestCase>(
-                             {TestCase1(), TestCase2(), TestCase3(),
-                              TestCase4(), TestCase5(), TestCase6(),
-                              TestCase7()})));
+ITERATOR_SAVE_AND_RESTORE_TEST_P(InterleaveDatasetOpTest,
+                                 InterleaveDatasetParams,
+                                 IteratorSaveAndRestoreTestCases())
+
+TEST_F(InterleaveDatasetOpTest, InvalidCycleLength) {
+  auto dataset_params = InterleaveDatasetParamsWithInvalidCycleLength();
+  EXPECT_EQ(Initialize(dataset_params).code(),
+            tensorflow::error::INVALID_ARGUMENT);
+}
+
+TEST_F(InterleaveDatasetOpTest, InvalidLength) {
+  auto dataset_params = InterleaveDatasetParamsWithInvalidBlockLength();
+  EXPECT_EQ(Initialize(dataset_params).code(),
+            tensorflow::error::INVALID_ARGUMENT);
+}
 
 }  // namespace
 }  // namespace data

--- a/tensorflow/core/kernels/data/interleave_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/interleave_dataset_op_test.cc
@@ -54,18 +54,17 @@ class InterleaveDatasetParams : public DatasetParams {
     return input_tensors;
   }
 
-  Status GetInputPlaceholder(
-      std::vector<string>* input_placeholder) const override {
-    input_placeholder->clear();
-    input_placeholder->reserve(input_dataset_params_.size() +
-                               other_arguments_.size() + 2);
-    input_placeholder->emplace_back(InterleaveDatasetOp::kInputDataset);
+  Status GetInputNames(std::vector<string>* input_names) const override {
+    input_names->clear();
+    input_names->reserve(input_dataset_params_.size() +
+                         other_arguments_.size() + 2);
+    input_names->emplace_back(InterleaveDatasetOp::kInputDataset);
     for (int i = 0; i < other_arguments_.size(); ++i) {
-      input_placeholder->emplace_back(
+      input_names->emplace_back(
           absl::StrCat(InterleaveDatasetOp::kOtherArguments, "_", i));
     }
-    input_placeholder->emplace_back(InterleaveDatasetOp::kCycleLength);
-    input_placeholder->emplace_back(InterleaveDatasetOp::kBlockLength);
+    input_names->emplace_back(InterleaveDatasetOp::kCycleLength);
+    input_names->emplace_back(InterleaveDatasetOp::kBlockLength);
     return Status::OK();
   }
 

--- a/tensorflow/core/kernels/data/map_defun_op_test.cc
+++ b/tensorflow/core/kernels/data/map_defun_op_test.cc
@@ -20,35 +20,86 @@ namespace {
 constexpr char kNodeName[] = "map_defun";
 constexpr char kOpName[] = "MapDefun";
 
-class MapDefunOpTest : public DatasetOpsTestBase {
- protected:
-  // Creates a new `MapDefun` op kernel
-  Status CreateMapDefunOpKernel(
-      const DataTypeVector& t_arguments, const DataTypeVector& t_captured,
-      const DataTypeVector& output_types,
-      const std::vector<PartialTensorShape>& output_shapes,
-      const FunctionDefHelper::AttrValueWrapper& func,
-      int max_intra_op_parallelism,
-      std::unique_ptr<OpKernel>* map_defun_kernel) {
-    std::vector<string> input_placeholders;
-    input_placeholders.reserve(t_arguments.size() + t_captured.size());
-    for (int i = 0; i < t_arguments.size(); ++i) {
-      input_placeholders.emplace_back(
+class MapDefunOpParams : public DatasetParams {
+ public:
+  MapDefunOpParams(std::vector<Tensor> arguments,
+                   std::vector<Tensor> captured_inputs,
+                   DataTypeVector type_arguments, DataTypeVector type_captured,
+                   DataTypeVector output_dtypes,
+                   std::vector<PartialTensorShape> output_shapes,
+                   FunctionDefHelper::AttrValueWrapper func,
+                   std::vector<FunctionDef> func_lib,
+                   int max_intra_op_parallelism, string node_name)
+      : DatasetParams(std::move(output_dtypes), std::move(output_shapes),
+                      std::move(node_name)),
+        arguments_(std::move(arguments)),
+        captured_inputs_(std::move(captured_inputs)),
+        type_arguments_(std::move(type_arguments)),
+        type_captured_(std::move(type_captured)),
+        func_(std::move(func)),
+        func_lib_(std::move(func_lib)),
+        max_intra_op_parallelism_(max_intra_op_parallelism) {}
+
+  std::vector<Tensor> GetInputTensors() const override {
+    std::vector<Tensor> input_tensors = arguments_;
+    input_tensors.insert(input_tensors.end(), captured_inputs_.begin(),
+                         captured_inputs_.end());
+    return input_tensors;
+  }
+
+  Status GetInputPlaceholder(
+      std::vector<string>* input_placeholder) const override {
+    input_placeholder->clear();
+
+    input_placeholder->reserve(arguments_.size() + captured_inputs_.size());
+    for (int i = 0; i < arguments_.size(); ++i) {
+      input_placeholder->emplace_back(
           strings::StrCat(MapDefunOp::kArguments, "_", i));
     }
-    for (int i = 0; i < t_captured.size(); ++i) {
-      input_placeholders.emplace_back(
+    for (int i = 0; i < captured_inputs_.size(); ++i) {
+      input_placeholder->emplace_back(
           strings::StrCat(MapDefunOp::kCapturedInputs, "_", i));
     }
+    return Status::OK();
+  }
 
-    NodeDef node_def = test::function::NDef(
-        kNodeName, kOpName, input_placeholders,
-        {{MapDefunOp::kTarguments, t_arguments},
-         {MapDefunOp::kTcaptured, t_captured},
-         {MapDefunOp::kOutputTypes, output_types},
-         {MapDefunOp::kOutputShapes, output_shapes},
-         {MapDefunOp::kFunc, func},
-         {MapDefunOp::kMaxIntraOpParallelism, max_intra_op_parallelism}});
+  Status GetAttributes(AttributeVector* attr_vector) const override {
+    *attr_vector = {
+        {MapDefunOp::kTarguments, type_arguments_},
+        {MapDefunOp::kTcaptured, type_captured_},
+        {MapDefunOp::kOutputShapes, output_shapes_},
+        {MapDefunOp::kOutputTypes, output_dtypes_},
+        {MapDefunOp::kFunc, func_},
+        {MapDefunOp::kMaxIntraOpParallelism, max_intra_op_parallelism_}};
+    return Status::OK();
+  }
+
+  std::vector<FunctionDef> func_lib() const override { return func_lib_; }
+
+  string dataset_type() const override { return "MapDef"; }
+
+ private:
+  std::vector<Tensor> arguments_;
+  std::vector<Tensor> captured_inputs_;
+  DataTypeVector type_arguments_;
+  DataTypeVector type_captured_;
+  FunctionDefHelper::AttrValueWrapper func_;
+  std::vector<FunctionDef> func_lib_;
+  int max_intra_op_parallelism_;
+};
+
+class MapDefunOpTest : public DatasetOpsTestBaseV2 {
+ protected:
+  // Creates a new `MapDefun` op kernel
+  Status CreateMapDefunOpKernel(const MapDefunOpParams& params,
+                                std::unique_ptr<OpKernel>* map_defun_kernel) {
+    std::vector<string> input_placeholders;
+    TF_RETURN_IF_ERROR(params.GetInputPlaceholder(&input_placeholders));
+    AttributeVector attributes;
+    TF_RETURN_IF_ERROR(params.GetAttributes(&attributes));
+
+    NodeDef node_def = test::function::NDef(kNodeName, kOpName,
+                                            input_placeholders, attributes);
     TF_RETURN_IF_ERROR(CreateOpKernel(node_def, map_defun_kernel));
     return Status::OK();
   }
@@ -64,121 +115,124 @@ class MapDefunOpTest : public DatasetOpsTestBase {
 };
 
 struct TestCase {
-  std::vector<Tensor> arguments;
-  std::vector<Tensor> captured_inputs;
-  DataTypeVector t_arguments;
-  DataTypeVector t_captured;
-  FunctionDefHelper::AttrValueWrapper func;
-  std::vector<FunctionDef> func_lib;
-  int max_intra_op_parallelism;
-  DataTypeVector output_dtypes;
-  std::vector<PartialTensorShape> output_shapes;
+  MapDefunOpParams map_defun_op_params;
   std::vector<Tensor> expected_outputs;
 };
 
 // Test case 1: one input for the map function with no captured inputs.
 TestCase TestCase1() {
-  return {
-      /*arguments*/ {
-          CreateTensor<int64>(TensorShape({3, 2}), {0, 1, 2, 3, 4, 5})},
-      /*captured_inputs*/ {},
-      /*t_arguments*/ {DT_INT64},
-      /*t_captured*/ {},
-      /*func*/ {FunctionDefHelper::FunctionRef("XTimesTwo", {{"T", DT_INT64}})},
-      /*func_lib*/ {test::function::XTimesTwo()},
-      /*max_intra_op_parallelism*/ 2,
-      /*output_dtypes*/ {DT_INT64},
-      /*output_shapes*/ {PartialTensorShape({2})},
-      /*expected_outputs*/
-      {CreateTensor<int64>(TensorShape({3, 2}), {0, 2, 4, 6, 8, 10})}};
+  return {/*map_defun_op_params=*/
+          MapDefunOpParams(
+              /*arguments=*/{CreateTensor<int64>(TensorShape({3, 2}),
+                                                 {0, 1, 2, 3, 4, 5})},
+              /*captured_inputs=*/{},
+              /*type_arguments=*/{DT_INT64},
+              /*type_captured=*/{},
+              /*output_dtypes=*/{DT_INT64},
+              /*output_shapes=*/{PartialTensorShape({2})},
+              /*func=*/
+              {FunctionDefHelper::FunctionRef("XTimesTwo", {{"T", DT_INT64}})},
+              /*func_lib=*/{test::function::XTimesTwo()},
+              /*max_intra_op_parallelism=*/2, /*node_name=*/kNodeName),
+          /*expected_outputs=*/
+          {CreateTensor<int64>(TensorShape({3, 2}), {0, 2, 4, 6, 8, 10})}};
 }
 
 // Test case 2: two inputs for the map function with no captured inputs.
 TestCase TestCase2() {
-  return {
-      /*arguments*/ {
-          CreateTensor<int64>(TensorShape({3, 2}), {0, 1, 2, 3, 4, 5}),
-          CreateTensor<int64>(TensorShape({3, 2}), {0, 10, 20, 30, 40, 50})},
-      /*captured_inputs*/ {},
-      /*t_arguments*/ {DT_INT64, DT_INT64},
-      /*t_captured*/ {},
-      /*func*/ {FunctionDefHelper::FunctionRef("XAddY", {{"T", DT_INT64}})},
-      /*func_lib*/ {test::function::XAddY()},
-      /*max_intra_op_parallelism*/ 2,
-      /*output_dtypes*/ {DT_INT64},
-      /*output_shapes*/ {PartialTensorShape({2})},
-      /*expected_outputs*/
-      {CreateTensor<int64>(TensorShape({3, 2}), {0, 11, 22, 33, 44, 55})}};
+  return {/*map_defun_op_params=*/
+          MapDefunOpParams(
+              /*arguments=*/{CreateTensor<int64>(TensorShape({3, 2}),
+                                                 {0, 1, 2, 3, 4, 5}),
+                             CreateTensor<int64>(TensorShape({3, 2}),
+                                                 {0, 10, 20, 30, 40, 50})},
+              /*captured_inputs=*/{},
+              /*type_arguments=*/{DT_INT64, DT_INT64},
+              /*type_captured=*/{},
+              /*output_dtypes=*/{DT_INT64},
+              /*output_shapes=*/{PartialTensorShape({2})},
+              /*func=*/
+              {FunctionDefHelper::FunctionRef("XAddY", {{"T", DT_INT64}})},
+              /*func_lib=*/{test::function::XAddY()},
+              /*max_intra_op_parallelism=*/2, /*node_name=*/kNodeName),
+          /*expected_outputs=*/
+          {CreateTensor<int64>(TensorShape({3, 2}), {0, 11, 22, 33, 44, 55})}};
 }
 
 // Test case 3: two inputs for the map function with one captured input.
 TestCase TestCase3() {
   return {
-      /*arguments*/ {
-          CreateTensor<int64>(TensorShape({3, 2}), {0, 1, 2, 3, 4, 5})},
-      /*captured_inputs*/
-      {CreateTensor<int64>(TensorShape({2}), {10, 100})},
-      /*t_arguments*/ {DT_INT64},
-      /*t_captured*/ {DT_INT64},
-      /*func*/ {FunctionDefHelper::FunctionRef("XAddY", {{"T", DT_INT64}})},
-      /*func_lib*/ {test::function::XAddY()},
-      /*max_intra_op_parallelism*/ 2,
-      /*output_dtypes*/ {DT_INT64},
-      /*output_shapes*/ {PartialTensorShape({2})},
-      /*expected_outputs*/
+      /*map_defun_op_params=*/
+      MapDefunOpParams(
+          /*arguments=*/{CreateTensor<int64>(TensorShape({3, 2}),
+                                             {0, 1, 2, 3, 4, 5})},
+          /*captured_inputs=*/
+          {CreateTensor<int64>(TensorShape({2}), {10, 100})},
+          /*type_arguments=*/{DT_INT64},
+          /*type_captured=*/{DT_INT64},
+          /*output_dtypes=*/{DT_INT64},
+          /*output_shapes=*/{PartialTensorShape({2})},
+          /*func=*/
+          {FunctionDefHelper::FunctionRef("XAddY", {{"T", DT_INT64}})},
+          /*func_lib=*/{test::function::XAddY()},
+          /*max_intra_op_parallelism=*/2, /*node_name=*/kNodeName),
+      /*expected_outputs=*/
       {CreateTensor<int64>(TensorShape({3, 2}), {10, 101, 12, 103, 14, 105})}};
 }
 
 TestCase InvalidOutputTypes() {
-  return {
-      /*arguments*/ {
-          CreateTensor<int64>(TensorShape({3, 2}), {0, 1, 2, 3, 4, 5})},
-      /*captured_inputs*/
-      {CreateTensor<int64>(TensorShape({2}), {10, 100})},
-      /*t_arguments*/ {DT_INT64},
-      /*t_captured*/ {DT_INT64},
-      /*func*/ {FunctionDefHelper::FunctionRef("XAddY", {{"T", DT_INT64}})},
-      /*func_lib*/ {test::function::XAddY()},
-      /*max_intra_op_parallelism*/ 2,
-      /*output_dtypes*/ {DT_FLOAT},
-      /*output_shapes*/ {PartialTensorShape({2})},
-      /*expected_outputs*/
-      {CreateTensor<int64>(TensorShape({3, 2}), {10, 101, 12, 103, 14, 105})}};
+  return {/*map_defun_op_params=*/
+          MapDefunOpParams(
+              /*arguments=*/{CreateTensor<int64>(TensorShape({3, 2}),
+                                                 {0, 1, 2, 3, 4, 5})},
+              /*captured_inputs=*/
+              {CreateTensor<int64>(TensorShape({2}), {10, 100})},
+              /*type_arguments=*/{DT_INT64},
+              /*type_captured=*/{DT_INT64},
+              /*output_dtypes=*/{DT_FLOAT},
+              /*output_shapes=*/{PartialTensorShape({2})},
+              /*func=*/
+              {FunctionDefHelper::FunctionRef("XAddY", {{"T", DT_INT64}})},
+              /*func_lib=*/{test::function::XAddY()},
+              /*max_intra_op_parallelism=*/2, /*node_name=*/kNodeName),
+          /*expected_outputs=*/{}};
 }
 
 TestCase InvalidOutputShapes() {
-  return {
-      /*arguments*/ {
-          CreateTensor<int64>(TensorShape({3, 2}), {0, 1, 2, 3, 4, 5})},
-      /*captured_inputs*/
-      {CreateTensor<int64>(TensorShape({2}), {10, 100})},
-      /*t_arguments*/ {DT_INT64},
-      /*t_captured*/ {DT_INT64},
-      /*func*/ {FunctionDefHelper::FunctionRef("XAddY", {{"T", DT_INT64}})},
-      /*func_lib*/ {test::function::XAddY()},
-      /*max_intra_op_parallelism*/ 2,
-      /*output_dtypes*/ {DT_INT64},
-      /*output_shapes*/ {PartialTensorShape({2, 2})},
-      /*expected_outputs*/
-      {CreateTensor<int64>(TensorShape({3, 2}), {10, 101, 12, 103, 14, 105})}};
+  return {/*map_defun_op_params=*/
+          MapDefunOpParams(
+              /*arguments=*/{CreateTensor<int64>(TensorShape({3, 2}),
+                                                 {0, 1, 2, 3, 4, 5})},
+              /*captured_inputs=*/
+              {CreateTensor<int64>(TensorShape({2}), {10, 100})},
+              /*type_arguments=*/{DT_INT64},
+              /*type_captured=*/{DT_INT64},
+              /*output_dtypes=*/{DT_INT64},
+              /*output_shapes=*/{PartialTensorShape({2, 2})},
+              /*func=*/
+              {FunctionDefHelper::FunctionRef("XAddY", {{"T", DT_INT64}})},
+              /*func_lib=*/{test::function::XAddY()},
+              /*max_intra_op_parallelism=*/2, /*node_name=*/kNodeName),
+          /*expected_outputs=*/{}};
 }
 
 TestCase InvalidInputs() {
-  return {
-      /*arguments*/ {
-          CreateTensor<int64>(TensorShape({3, 2}), {0, 1, 2, 3, 4, 5}),
-          CreateTensor<int64>(TensorShape({2, 2}), {0, 1, 2, 3})},
-      /*captured_inputs*/
-      {CreateTensor<int64>(TensorShape({2}), {10, 100})},
-      /*t_arguments*/ {DT_INT64, DT_INT64},
-      /*t_captured*/ {DT_INT64},
-      /*func*/ {FunctionDefHelper::FunctionRef("XAddY", {{"T", DT_INT64}})},
-      /*func_lib*/ {test::function::XAddY()},
-      /*max_intra_op_parallelism*/ 2,
-      /*output_dtypes*/ {DT_INT64},
-      /*output_shapes*/ {PartialTensorShape({2})},
-      /*expected_outputs*/
-      {CreateTensor<int64>(TensorShape({3, 2}), {10, 101, 12, 103, 14, 105})}};
+  return {/*map_defun_op_params=*/
+          MapDefunOpParams(
+              /*arguments=*/{CreateTensor<int64>(TensorShape({3, 2}),
+                                                 {0, 1, 2, 3, 4, 5}),
+                             CreateTensor<int64>(TensorShape({2, 2}),
+                                                 {0, 1, 2, 3})},
+              /*captured_inputs=*/{},
+              /*type_arguments=*/{DT_INT64, DT_INT64},
+              /*type_captured=*/{},
+              /*output_dtypes=*/{DT_INT64},
+              /*output_shapes=*/{PartialTensorShape({2})},
+              /*func=*/
+              {FunctionDefHelper::FunctionRef("XAddY", {{"T", DT_INT64}})},
+              /*func_lib=*/{test::function::XAddY()},
+              /*max_intra_op_parallelism=*/2, /*node_name=*/kNodeName),
+          /*expected_outputs=*/{}};
 }
 
 class ParameterizedMapDefunOpTest
@@ -186,26 +240,19 @@ class ParameterizedMapDefunOpTest
       public ::testing::WithParamInterface<TestCase> {};
 
 TEST_P(ParameterizedMapDefunOpTest, NormalTests) {
-  int thread_num = 2, cpu_num = 2;
   TestCase test_case = GetParam();
-  TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime(test_case.func_lib, cpu_num));
-
+  TF_ASSERT_OK(InitializeRuntime(test_case.map_defun_op_params));
+  auto input_tensors = test_case.map_defun_op_params.GetInputTensors();
+  gtl::InlinedVector<TensorValue, 4> input_values;
+  for (auto& input : input_tensors) {
+    input_values.push_back(TensorValue(&input));
+  }
   std::unique_ptr<OpKernel> map_defun_kernel;
-  TF_ASSERT_OK(CreateMapDefunOpKernel(
-      test_case.t_arguments, test_case.t_captured, test_case.output_dtypes,
-      test_case.output_shapes, test_case.func,
-      test_case.max_intra_op_parallelism, &map_defun_kernel));
-  gtl::InlinedVector<TensorValue, 4> inputs;
-  for (auto& arg : test_case.arguments) {
-    inputs.emplace_back(&arg);
-  }
-  for (auto& captured_input : test_case.captured_inputs) {
-    inputs.emplace_back(&captured_input);
-  }
+  TF_ASSERT_OK(
+      CreateMapDefunOpKernel(test_case.map_defun_op_params, &map_defun_kernel));
   std::unique_ptr<OpKernelContext> context;
   TF_ASSERT_OK(
-      CreateMapDefunContext(map_defun_kernel.get(), &inputs, &context));
+      CreateMapDefunContext(map_defun_kernel.get(), &input_values, &context));
   TF_ASSERT_OK(RunOpKernel(map_defun_kernel.get(), context.get()));
 
   EXPECT_EQ(context->num_outputs(), test_case.expected_outputs.size());
@@ -220,28 +267,21 @@ INSTANTIATE_TEST_SUITE_P(MapDefunOpTest, ParameterizedMapDefunOpTest,
                              {TestCase1(), TestCase2(), TestCase3()})));
 
 TEST_F(MapDefunOpTest, InvalidArguments) {
-  int thread_num = 2, cpu_num = 2;
-  TF_ASSERT_OK(InitThreadPool(thread_num));
   std::vector<TestCase> test_cases = {InvalidOutputTypes(),
                                       InvalidOutputShapes(), InvalidInputs()};
   for (auto& test_case : test_cases) {
-    TF_ASSERT_OK(InitFunctionLibraryRuntime(test_case.func_lib, cpu_num));
-
+    TF_ASSERT_OK(InitializeRuntime(test_case.map_defun_op_params));
+    auto input_tensors = test_case.map_defun_op_params.GetInputTensors();
+    gtl::InlinedVector<TensorValue, 4> input_values;
+    for (auto& input : input_tensors) {
+      input_values.push_back(TensorValue(&input));
+    }
     std::unique_ptr<OpKernel> map_defun_kernel;
-    TF_ASSERT_OK(CreateMapDefunOpKernel(
-        test_case.t_arguments, test_case.t_captured, test_case.output_dtypes,
-        test_case.output_shapes, test_case.func,
-        test_case.max_intra_op_parallelism, &map_defun_kernel));
-    gtl::InlinedVector<TensorValue, 4> inputs;
-    for (auto& arg : test_case.arguments) {
-      inputs.emplace_back(&arg);
-    }
-    for (auto& captured_input : test_case.captured_inputs) {
-      inputs.emplace_back(&captured_input);
-    }
+    TF_ASSERT_OK(CreateMapDefunOpKernel(test_case.map_defun_op_params,
+                                        &map_defun_kernel));
     std::unique_ptr<OpKernelContext> context;
     TF_ASSERT_OK(
-        CreateMapDefunContext(map_defun_kernel.get(), &inputs, &context));
+        CreateMapDefunContext(map_defun_kernel.get(), &input_values, &context));
     EXPECT_EQ(RunOpKernel(map_defun_kernel.get(), context.get()).code(),
               tensorflow::error::INVALID_ARGUMENT);
   }

--- a/tensorflow/core/kernels/data/map_defun_op_test.cc
+++ b/tensorflow/core/kernels/data/map_defun_op_test.cc
@@ -47,17 +47,16 @@ class MapDefunOpParams : public DatasetParams {
     return input_tensors;
   }
 
-  Status GetInputPlaceholder(
-      std::vector<string>* input_placeholder) const override {
-    input_placeholder->clear();
+  Status GetInputNames(std::vector<string>* input_names) const override {
+    input_names->clear();
 
-    input_placeholder->reserve(arguments_.size() + captured_inputs_.size());
+    input_names->reserve(arguments_.size() + captured_inputs_.size());
     for (int i = 0; i < arguments_.size(); ++i) {
-      input_placeholder->emplace_back(
+      input_names->emplace_back(
           strings::StrCat(MapDefunOp::kArguments, "_", i));
     }
     for (int i = 0; i < captured_inputs_.size(); ++i) {
-      input_placeholder->emplace_back(
+      input_names->emplace_back(
           strings::StrCat(MapDefunOp::kCapturedInputs, "_", i));
     }
     return Status::OK();
@@ -93,13 +92,13 @@ class MapDefunOpTest : public DatasetOpsTestBaseV2 {
   // Creates a new `MapDefun` op kernel
   Status CreateMapDefunOpKernel(const MapDefunOpParams& params,
                                 std::unique_ptr<OpKernel>* map_defun_kernel) {
-    std::vector<string> input_placeholders;
-    TF_RETURN_IF_ERROR(params.GetInputPlaceholder(&input_placeholders));
+    std::vector<string> input_namess;
+    TF_RETURN_IF_ERROR(params.GetInputNames(&input_namess));
     AttributeVector attributes;
     TF_RETURN_IF_ERROR(params.GetAttributes(&attributes));
 
-    NodeDef node_def = test::function::NDef(kNodeName, kOpName,
-                                            input_placeholders, attributes);
+    NodeDef node_def =
+        test::function::NDef(kNodeName, kOpName, input_namess, attributes);
     TF_RETURN_IF_ERROR(CreateOpKernel(node_def, map_defun_kernel));
     return Status::OK();
   }

--- a/tensorflow/core/kernels/data/optimize_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/optimize_dataset_op_test.cc
@@ -21,100 +21,74 @@ namespace {
 
 constexpr char kNodeName[] = "optimize_dataset";
 constexpr char kNoopElimination[] = "noop_elimination";
-constexpr char kIteratorPrefix[] = "Iterator";
 
-class OptimizeDatasetOpTest : public DatasetOpsTestBase {
- protected:
-  // Creates a new `OptimizeDataset` op kernel.
-  Status CreateOptimizeDatasetOpKernel(
-      const DataTypeVector& output_types,
-      const std::vector<PartialTensorShape>& output_shapes,
-      const std::vector<string>& optimization_configs,
-      std::unique_ptr<OpKernel>* optimize_dataset_op_kernel) {
-    NodeDef node_def = test::function::NDef(
-        kNodeName, name_utils::OpName(OptimizeDatasetOp::kDatasetType),
-        {OptimizeDatasetOp::kInputDataset, OptimizeDatasetOp::kOptimizations},
-        {{OptimizeDatasetOp::kOutputTypes, output_types},
-         {OptimizeDatasetOp::kOutputShapes, output_shapes},
-         {OptimizeDatasetOp::kOptimizationConfigs, optimization_configs}});
-    TF_RETURN_IF_ERROR(CreateOpKernel(node_def, optimize_dataset_op_kernel));
+class OptimizeDatasetParams : public DatasetParams {
+ public:
+  template <typename T>
+  OptimizeDatasetParams(T input_dataset_params, string optimizations,
+                        DataTypeVector output_dtypes,
+                        std::vector<PartialTensorShape> output_shapes,
+                        std::vector<tstring> optimization_configs,
+                        string node_name)
+      : DatasetParams(std::move(output_dtypes), std::move(output_shapes),
+                      std::move(node_name)),
+        optimizations_(std::move(optimizations)),
+        optimization_configs_(std::move(optimization_configs)) {
+    input_dataset_params_.push_back(absl::make_unique<T>(input_dataset_params));
+    iterator_prefix_ =
+        name_utils::IteratorPrefix(input_dataset_params.dataset_type(),
+                                   input_dataset_params.iterator_prefix());
+  }
+
+  std::vector<Tensor> GetInputTensors() const override {
+    return {CreateTensor<tstring>(TensorShape({1}), {optimizations_})};
+  }
+
+  Status GetInputPlaceholder(
+      std::vector<string>* input_placeholder) const override {
+    *input_placeholder = {OptimizeDatasetOp::kInputDataset,
+                          OptimizeDatasetOp::kOptimizations};
     return Status::OK();
   }
 
-  // Create a new `OptimizeDataset` op kernel context.
-  Status CreateOptimizeDatasetContext(
-      OpKernel* const op_kernel,
-      gtl::InlinedVector<TensorValue, 4>* const inputs,
-      std::unique_ptr<OpKernelContext>* context) {
-    TF_RETURN_IF_ERROR(CheckOpKernelInput(*op_kernel, *inputs));
-    TF_RETURN_IF_ERROR(CreateOpKernelContext(op_kernel, inputs, context));
+  Status GetAttributes(AttributeVector* attr_vector) const override {
+    *attr_vector = {
+        {OptimizeDatasetOp::kOutputShapes, output_shapes_},
+        {OptimizeDatasetOp::kOutputTypes, output_dtypes_},
+        {OptimizeDatasetOp::kOptimizationConfigs, optimization_configs_}};
     return Status::OK();
   }
+
+  string dataset_type() const override {
+    return OptimizeDatasetOp::kDatasetType;
+  }
+
+ private:
+  string optimizations_;
+  std::vector<tstring> optimization_configs_;
 };
 
+class OptimizeDatasetOpTest : public DatasetOpsTestBaseV2 {};
+
 TEST_F(OptimizeDatasetOpTest, NoopElimination) {
-  int thread_num = 2, cpu_num = 2;
-  TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
+  auto take_dataset_parmas =
+      TakeDatasetParams(RangeDatasetParams(-3, 3, 1),
+                        /*count=*/-3,
+                        /*output_dtypes=*/{DT_INT64},
+                        /*output_shapes=*/{PartialTensorShape({})},
+                        /*node_name=*/"take_dataset");
+  auto optimize_dataset_params =
+      OptimizeDatasetParams(std::move(take_dataset_parmas),
+                            /*optimizations=*/{kNoopElimination},
+                            /*output_dtypes=*/{DT_INT64},
+                            /*output_shapes=*/{PartialTensorShape({})},
+                            /*optimization_configs=*/{},
+                            /*node_name=*/kNodeName);
+  std::vector<Tensor> expected_outputs =
+      CreateTensors<int64>(TensorShape({}), {{-3}, {-2}, {-1}, {0}, {1}, {2}});
 
-  Tensor range_dataset_tensor;
-  DataTypeVector output_types = DataTypeVector({DT_INT64});
-  std::vector<PartialTensorShape> output_shapes =
-      std::vector<PartialTensorShape>{PartialTensorShape({})};
-  Tensor start = CreateTensor<int64>(TensorShape({}), {-3});
-  Tensor stop = CreateTensor<int64>(TensorShape({}), {3});
-  Tensor step = CreateTensor<int64>(TensorShape({}), {1});
-  TF_ASSERT_OK(MakeRangeDataset(start, stop, step, output_types, output_shapes,
-                                &range_dataset_tensor));
-
-  Tensor take_dataset_tensor;
-  int count = -3;
-  TF_ASSERT_OK(MakeTakeDataset(range_dataset_tensor, count, output_types,
-                               output_shapes, &take_dataset_tensor));
-
-  std::unique_ptr<OpKernel> optimize_dataset_kernel;
-  TF_ASSERT_OK(CreateOptimizeDatasetOpKernel(output_types, output_shapes,
-                                             /*optimization_configs*/ {},
-                                             &optimize_dataset_kernel));
-  Tensor optimizations =
-      CreateTensor<tstring>(TensorShape({1}), {kNoopElimination});
-  gtl::InlinedVector<TensorValue, 4> inputs(
-      {TensorValue(&take_dataset_tensor), TensorValue(&optimizations)});
-  std::unique_ptr<OpKernelContext> optimize_dataset_context;
-  TF_ASSERT_OK(CreateOptimizeDatasetContext(
-      optimize_dataset_kernel.get(), &inputs, &optimize_dataset_context));
-
-  DatasetBase* optimize_dataset;
-  TF_ASSERT_OK(CreateDataset(optimize_dataset_kernel.get(),
-                             optimize_dataset_context.get(),
-                             &optimize_dataset));
-  core::ScopedUnref scoped_unref(optimize_dataset);
-
-  std::unique_ptr<IteratorContext> iterator_context;
-  TF_ASSERT_OK(
-      CreateIteratorContext(optimize_dataset_context.get(), &iterator_context));
-  std::unique_ptr<IteratorBase> iterator;
-  TF_ASSERT_OK(optimize_dataset->MakeIterator(iterator_context.get(),
-                                              kIteratorPrefix, &iterator));
-
-  bool end_of_sequence = false;
-  std::vector<Tensor> out_tensors;
-  while (!end_of_sequence) {
-    std::vector<Tensor> next;
-    TF_EXPECT_OK(
-        iterator->GetNext(iterator_context.get(), &next, &end_of_sequence));
-    out_tensors.insert(out_tensors.end(), next.begin(), next.end());
-  }
-
-  std::vector<Tensor> expected_outputs = {
-      CreateTensor<int64>(TensorShape({}), {-3}),
-      CreateTensor<int64>(TensorShape({}), {-2}),
-      CreateTensor<int64>(TensorShape({}), {-1}),
-      CreateTensor<int64>(TensorShape({}), {0}),
-      CreateTensor<int64>(TensorShape({}), {1}),
-      CreateTensor<int64>(TensorShape({}), {2})};
-  TF_EXPECT_OK(ExpectEqual(out_tensors, expected_outputs,
-                           /*compare_order*/ true));
+  TF_ASSERT_OK(Initialize(optimize_dataset_params));
+  TF_EXPECT_OK(CheckIteratorGetNext(expected_outputs, /*compare_order=*/true));
 }
 
 }  // namespace

--- a/tensorflow/core/kernels/data/optimize_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/optimize_dataset_op_test.cc
@@ -44,10 +44,9 @@ class OptimizeDatasetParams : public DatasetParams {
     return {CreateTensor<tstring>(TensorShape({1}), {optimizations_})};
   }
 
-  Status GetInputPlaceholder(
-      std::vector<string>* input_placeholder) const override {
-    *input_placeholder = {OptimizeDatasetOp::kInputDataset,
-                          OptimizeDatasetOp::kOptimizations};
+  Status GetInputNames(std::vector<string>* input_names) const override {
+    *input_names = {OptimizeDatasetOp::kInputDataset,
+                    OptimizeDatasetOp::kOptimizations};
     return Status::OK();
   }
 

--- a/tensorflow/core/kernels/data/padded_batch_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/padded_batch_dataset_op_test.cc
@@ -11,7 +11,6 @@ limitations under the License.
 ==============================================================================*/
 #include "tensorflow/core/kernels/data/padded_batch_dataset_op.h"
 
-#include "tensorflow/core/kernels/data/concatenate_dataset_op.h"
 #include "tensorflow/core/kernels/data/dataset_test_base.h"
 
 namespace tensorflow {
@@ -21,1155 +20,736 @@ namespace {
 constexpr char kNodeName[] = "padded_batch_dataset";
 constexpr int kOpVersion = 2;
 
-class PaddedBatchDatasetOpTest : public DatasetOpsTestBase {
- protected:
-  // Creates `ConcatenateDataset` variant tensor from the input vector of
-  // tensor vectors.
-  Status CreateConcatenateDatasetTensor(
-      const std::vector<std::vector<Tensor>> &tensor_vectors,
-      const DataTypeVector &output_types,
-      const std::vector<PartialTensorShape> &output_shapes,
-      Tensor *concatenate_dataset_tensor) {
-    // Create two `TensorSliceDataset` tensors as the inputs for
-    // `ConcatenateDataset`.
-    std::vector<Tensor> tensor_slice_dataset_tensors;
-    for (int i = 0; i < tensor_vectors.size(); ++i) {
-      std::vector<Tensor> tensors = tensor_vectors[i];
-      DatasetBase *tensor_slice_dataset;
-      TF_RETURN_IF_ERROR(
-          CreateTensorSliceDataset(strings::StrCat("tensor_slice_node_", i),
-                                   &tensors, &tensor_slice_dataset));
-      Tensor dataset_tensor(DT_VARIANT, TensorShape({}));
-      TF_RETURN_IF_ERROR(
-          StoreDatasetInVariantTensor(tensor_slice_dataset, &dataset_tensor));
-      tensor_slice_dataset_tensors.emplace_back(std::move(dataset_tensor));
-    }
+class PaddedBatchDatasetOpTest : public DatasetOpsTestBaseV2 {};
 
-    // Create a `ConcatenateDataset` dataset.
-    std::unique_ptr<OpKernel> concatenate_dataset_op_kernel;
-    NodeDef concatenate_node_def = test::function::NDef(
-        "concatenate_dataset",
-        name_utils::OpName(ConcatenateDatasetOp::kDatasetType),
-        {ConcatenateDatasetOp::kInputDataset,
-         ConcatenateDatasetOp::kAnotherDataset},
-        {{ConcatenateDatasetOp::kOutputTypes, {output_types}},
-         {ConcatenateDatasetOp::kOutputShapes, {output_shapes}}});
-    TF_RETURN_IF_ERROR(
-        CreateOpKernel(concatenate_node_def, &concatenate_dataset_op_kernel));
-
-    gtl::InlinedVector<TensorValue, 4> concatenate_dataset_inputs;
-    for (auto &tensor : tensor_slice_dataset_tensors) {
-      concatenate_dataset_inputs.emplace_back(&tensor);
-    }
-
-    std::unique_ptr<OpKernelContext> concatenate_dataset_op_context;
-    TF_RETURN_IF_ERROR(CheckOpKernelInput(*concatenate_dataset_op_kernel,
-                                          concatenate_dataset_inputs));
-    TF_RETURN_IF_ERROR(CreateOpKernelContext(
-        concatenate_dataset_op_kernel.get(), &concatenate_dataset_inputs,
-        &concatenate_dataset_op_context));
-    DatasetBase *concatenate_dataset;
-    TF_RETURN_IF_ERROR(CreateDataset(concatenate_dataset_op_kernel.get(),
-                                     concatenate_dataset_op_context.get(),
-                                     &concatenate_dataset));
-
-    // Store the `ConcatenateDataset` dataset in a tensor.
-    TF_RETURN_IF_ERROR(StoreDatasetInVariantTensor(concatenate_dataset,
-                                                   concatenate_dataset_tensor));
-    return Status::OK();
+class PaddedBatchDatasetParams : public DatasetParams {
+ public:
+  template <typename T>
+  PaddedBatchDatasetParams(T input_dataset_params, int64 batch_size,
+                           std::vector<Tensor> padded_shapes,
+                           std::vector<Tensor> padded_values,
+                           bool drop_remainder, bool parallel_copy,
+                           DataTypeVector output_dtypes,
+                           std::vector<PartialTensorShape> output_shapes,
+                           int num_padded_shapes, string node_name)
+      : DatasetParams(std::move(output_dtypes), std::move(output_shapes),
+                      std::move(node_name)),
+        batch_size_(batch_size),
+        padded_shapes_(std::move(padded_shapes)),
+        padded_values_(std::move(padded_values)),
+        drop_remainder_(drop_remainder),
+        parallel_copy_(parallel_copy),
+        num_padded_shapes_(num_padded_shapes) {
+    input_dataset_params_.push_back(absl::make_unique<T>(input_dataset_params));
+    op_version_ = kOpVersion;
+    iterator_prefix_ =
+        name_utils::IteratorPrefix(input_dataset_params.dataset_type(),
+                                   input_dataset_params.iterator_prefix());
   }
 
-  // Creates a new `PaddedBatchDataset` op kernel
-  Status CreatePaddedBatchDatasetKernel(
-      bool parallel_copy, int n, const DataTypeVector &output_types,
-      const std::vector<PartialTensorShape> &output_shapes,
-      std::unique_ptr<OpKernel> *op_kernel) {
-    std::vector<string> inputs({PaddedBatchDatasetOp::kInputDataset,
-                                PaddedBatchDatasetOp::kBatchSize});
-    // Create the placeholder names for the input padded_shapes.
-    for (int i = 0; i < n; ++i) {
-      inputs.emplace_back(
+  std::vector<Tensor> GetInputTensors() const override {
+    std::vector<Tensor> input_tensors;
+    input_tensors.emplace_back(
+        CreateTensor<int64>(TensorShape({}), {batch_size_}));
+    for (auto& padded_shape : padded_shapes_) {
+      input_tensors.emplace_back(padded_shape);
+    }
+    for (auto& padded_value : padded_values_) {
+      input_tensors.emplace_back(padded_value);
+    }
+    input_tensors.emplace_back(
+        CreateTensor<bool>(TensorShape({}), {drop_remainder_}));
+    return input_tensors;
+  }
+
+  Status GetInputNames(std::vector<string>* input_names) const override {
+    *input_names = {PaddedBatchDatasetOp::kInputDataset,
+                    PaddedBatchDatasetOp::kBatchSize};
+    // Create the input names for the input padded_shapes.
+    for (int i = 0; i < num_padded_shapes_; ++i) {
+      input_names->emplace_back(
           strings::StrCat(PaddedBatchDatasetOp::kPaddedShapes, "_", i));
     }
-    // Create the placeholder names for the input padding_values.
-    for (int j = 0; j < output_types.size(); ++j) {
-      inputs.emplace_back(
+    // Create the input names for the input padding_values.
+    for (int j = 0; j < padded_values_.size(); ++j) {
+      input_names->emplace_back(
           strings::StrCat(PaddedBatchDatasetOp::kPaddingValues, "_", j));
     }
-    inputs.push_back(PaddedBatchDatasetOp::kDropRemainder);
-
-    name_utils::OpNameParams params;
-    params.op_version = kOpVersion;
-    NodeDef node_def = test::function::NDef(
-        kNodeName,
-        name_utils::OpName(PaddedBatchDatasetOp::kDatasetType, params), inputs,
-        {{PaddedBatchDatasetOp::kParallelCopy, parallel_copy},
-         {PaddedBatchDatasetOp::kToutputTypes, output_types},
-         {PaddedBatchDatasetOp::kOutputShapes, output_shapes},
-         {PaddedBatchDatasetOp::kNumPaddedShapes, n}});
-    TF_RETURN_IF_ERROR(CreateOpKernel(node_def, op_kernel));
+    input_names->push_back(PaddedBatchDatasetOp::kDropRemainder);
     return Status::OK();
   }
 
-  // Creates a new `PaddedBatchDataset` op kernel context.
-  Status CreatePaddedBatchDatasetContext(
-      OpKernel *const op_kernel,
-      gtl::InlinedVector<TensorValue, 4> *const inputs,
-      std::unique_ptr<OpKernelContext> *context) {
-    TF_RETURN_IF_ERROR(CheckOpKernelInput(*op_kernel, *inputs));
-    TF_RETURN_IF_ERROR(CreateOpKernelContext(op_kernel, inputs, context));
+  Status GetAttributes(AttributeVector* attr_vector) const override {
+    *attr_vector = {
+        {PaddedBatchDatasetOp::kParallelCopy, parallel_copy_},
+        {PaddedBatchDatasetOp::kToutputTypes, output_dtypes_},
+        {PaddedBatchDatasetOp::kOutputShapes, output_shapes_},
+        {PaddedBatchDatasetOp::kNumPaddedShapes, num_padded_shapes_}};
     return Status::OK();
   }
-};
 
-struct TestCase {
-  // Used for creating two `TensorSliceDataset` datasets, which will be the
-  // input datasets for `ConcatenateDataset`. Then the `ConcatenateDataset`
-  // dataset will be the input for `PaddedBatchDataset`.
-  std::vector<std::vector<Tensor>> input_tensors;
-  DataTypeVector concatenate_output_dtypes;
-  std::vector<PartialTensorShape> concatenate_output_shapes;
-  Tensor batch_size;
-  std::vector<Tensor> padded_shapes;
-  std::vector<Tensor> padding_values;
-  Tensor drop_remainder;
-  bool parallel_copy;
-  int64 n;
-  std::vector<Tensor> expected_outputs;
-  DataTypeVector expected_output_dtypes;
-  std::vector<PartialTensorShape> expected_output_shapes;
-  int64 expected_cardinality;
-  std::vector<int> breakpoints;
-};
-
-template <typename T>
-std::vector<Tensor> ConvertToTensorVec(std::vector<T> values) {
-  std::vector<Tensor> tensors;
-  tensors.reserve(values.size());
-  for (auto &value : values) {
-    tensors.emplace_back(CreateTensor<T>(TensorShape({1}), {value}));
+  string dataset_type() const override {
+    return PaddedBatchDatasetOp::kDatasetType;
   }
-  return tensors;
-}
+
+ private:
+  int64 batch_size_;
+  std::vector<Tensor> padded_shapes_;
+  std::vector<Tensor> padded_values_;
+  bool drop_remainder_;
+  bool parallel_copy_;
+  int num_padded_shapes_;
+};
 
 // Test case 1: input elements with same shapes.
-TestCase TestCase1() {
-  return {
-      /*input_tensors*/
-      {{CreateTensor<int64>(TensorShape{3, 2}, {0, 1, 2, 3, 4, 5})},
-       {CreateTensor<int64>(TensorShape{4, 2}, {6, 7, 8, 9, 10, 11, 12, 13})}},
-      /*concatenate_output_dtypes*/ {DT_INT64},
-      /*concatenate_output_shapes*/ {PartialTensorShape({2})},
-      /*batch_size*/
-      CreateTensor<int64>(TensorShape{}, {2}),
-      /*padded_shapes*/
-      {CreateTensor<int64>(TensorShape{1}, {3})},
-      /*padding_values*/
-      {CreateTensor<int64>(TensorShape{}, {1})},
-      /*drop_remainder*/
-      CreateTensor<bool>(TensorShape{}, {true}),
-      /*parallel_copy*/ true,
-      /*n*/ 1,
-      /*expected_outputs*/
-      {CreateTensor<int64>(TensorShape{2, 3}, {0, 1, 1, 2, 3, 1}),
-       CreateTensor<int64>(TensorShape{2, 3}, {4, 5, 1, 6, 7, 1}),
-       CreateTensor<int64>(TensorShape{2, 3}, {8, 9, 1, 10, 11, 1})},
-      /*expected_output_dtypes*/ {DT_INT64},
-      /*expected_output_shapes*/ {PartialTensorShape({2, 3})},
-      /*expected_cardinality*/ 3,
-      /*breakpoints*/ {0, 2, 5}};
+PaddedBatchDatasetParams PaddedBatchDatasetParams1() {
+  auto tensor_slice_dataset_params = TensorSliceDatasetParams(
+      /*components=*/{CreateTensor<int64>(
+          TensorShape{7, 2}, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13})},
+      /*node_name=*/"tensor_slice");
+  return PaddedBatchDatasetParams(
+      /*input_dataset_params=*/tensor_slice_dataset_params,
+      /*batch_size=*/2,
+      /*padded_shapes=*/{CreateTensor<int64>(TensorShape{1}, {3})},
+      /*padded_values=*/{CreateTensor<int64>(TensorShape{}, {1})},
+      /*drop_remainder=*/true,
+      /*parallel_copy=*/true,
+      /*output_dtypes=*/{DT_INT64},
+      /*output_shapes=*/{PartialTensorShape({2, 3})},
+      /*num_padded_shapes=*/1,
+      /*node_name=*/kNodeName);
 }
 
 // Test case 2: input elements with different shapes.
-TestCase TestCase2() {
-  return {/*input_tensors*/
-          {{CreateTensor<int64>(TensorShape{3, 2}, {0, 1, 2, 3, 4, 5})},
-           {CreateTensor<int64>(TensorShape{4, 1}, {6, 7, 8, 9})}},
-          /*concatenate_output_dtypes*/ {DT_INT64},
-          /*concatenate_output_shapes*/ {PartialTensorShape({-1})},
-          /*batch_size*/
-          CreateTensor<int64>(TensorShape{}, {2}),
-          /*padded_shapes*/
-          {CreateTensor<int64>(TensorShape{1}, {3})},
-          /*padding_values*/
-          {CreateTensor<int64>(TensorShape{}, {1})},
-          /*drop_remainder*/
-          CreateTensor<bool>(TensorShape{}, {true}),
-          /*parallel_copy*/ true,
-          /*n*/ 1,
-          /*expected_outputs*/
-          {CreateTensor<int64>(TensorShape{2, 3}, {0, 1, 1, 2, 3, 1}),
-           CreateTensor<int64>(TensorShape{2, 3}, {4, 5, 1, 6, 1, 1}),
-           CreateTensor<int64>(TensorShape{2, 3}, {7, 1, 1, 8, 1, 1})},
-          /*expected_output_dtypes*/ {DT_INT64},
-          /*expected_output_shapes*/ {PartialTensorShape({2, 3})},
-          /*expected_cardinality*/ 3,
-          /*breakpoints*/ {0, 2, 5}};
+PaddedBatchDatasetParams PaddedBatchDatasetParams2() {
+  auto tensor_slice_dataset_params_0 = TensorSliceDatasetParams(
+      /*components=*/CreateTensors<int64>(TensorShape{3, 2},
+                                          {{0, 1, 2, 3, 4, 5}}),
+      /*node_name=*/"tensor_slice_0");
+  auto tensor_slice_dataset_params_1 = TensorSliceDatasetParams(
+      /*components=*/CreateTensors<int64>(TensorShape{4, 1}, {{6, 7, 8, 9}}),
+      /*node_name=*/"tensor_slice_1");
+  auto concatenate_dataset_params =
+      ConcatenateDatasetParams(std::move(tensor_slice_dataset_params_0),
+                               std::move(tensor_slice_dataset_params_1),
+                               /*output_dtypes=*/{DT_INT64},
+                               /*output_shapes=*/{PartialTensorShape({-1})},
+                               /*node_name=*/"concatenate");
+  return PaddedBatchDatasetParams(
+      /*input_dataset_params=*/concatenate_dataset_params,
+      /*batch_size=*/2,
+      /*padded_shapes=*/{CreateTensor<int64>(TensorShape{1}, {3})},
+      /*padded_values=*/{CreateTensor<int64>(TensorShape{}, {1})},
+      /*drop_remainder=*/true,
+      /*parallel_copy=*/true,
+      /*output_dtypes=*/{DT_INT64},
+      /*output_shapes=*/{PartialTensorShape({2, 3})},
+      /*num_padded_shapes=*/1,
+      /*node_name=*/kNodeName);
 }
 
 // Test case 3: similar with the test case 2 but drop_remainder = false.
-TestCase TestCase3() {
-  return {/*input_tensors*/
-          {{CreateTensor<int64>(TensorShape{3, 2}, {0, 1, 2, 3, 4, 5})},
-           {CreateTensor<int64>(TensorShape{4, 1}, {6, 7, 8, 9})}},
-          /*concatenate_output_dtypes*/ {DT_INT64},
-          /*concatenate_output_shapes*/ {PartialTensorShape({-1})},
-          /*batch_size*/
-          CreateTensor<int64>(TensorShape{}, {2}),
-          /*padded_shapes*/
-          {CreateTensor<int64>(TensorShape{1}, {3})},
-          /*padding_values*/
-          {CreateTensor<int64>(TensorShape{}, {1})},
-          /*drop_remainder*/
-          CreateTensor<bool>(TensorShape{}, {false}),
-          /*parallel_copy*/ false,
-          /*n*/ 1,
-          /*expected_outputs*/
-          {CreateTensor<int64>(TensorShape{2, 3}, {0, 1, 1, 2, 3, 1}),
-           CreateTensor<int64>(TensorShape{2, 3}, {4, 5, 1, 6, 1, 1}),
-           CreateTensor<int64>(TensorShape{2, 3}, {7, 1, 1, 8, 1, 1}),
-           CreateTensor<int64>(TensorShape{1, 3}, {9, 1, 1})},
-          /*expected_output_dtypes*/ {DT_INT64},
-          /*expected_output_shapes*/ {PartialTensorShape({-1, 3})},
-          /*expected_cardinality*/ 4,
-          /*breakpoints*/ {0, 2, 5}};
+PaddedBatchDatasetParams PaddedBatchDatasetParams3() {
+  auto tensor_slice_dataset_params_0 = TensorSliceDatasetParams(
+      /*components=*/CreateTensors<int64>(TensorShape{3, 2},
+                                          {{0, 1, 2, 3, 4, 5}}),
+      /*node_name=*/"tensor_slice_0");
+  auto tensor_slice_dataset_params_1 = TensorSliceDatasetParams(
+      /*components=*/CreateTensors<int64>(TensorShape{4, 1}, {{6, 7, 8, 9}}),
+      /*node_name=*/"tensor_slice_1");
+  auto concatenate_dataset_params =
+      ConcatenateDatasetParams(std::move(tensor_slice_dataset_params_0),
+                               std::move(tensor_slice_dataset_params_1),
+                               /*output_dtypes=*/{DT_INT64},
+                               /*output_shapes=*/{PartialTensorShape({-1})},
+                               /*node_name=*/"concatenate");
+  return PaddedBatchDatasetParams(
+      /*input_dataset_params=*/concatenate_dataset_params,
+      /*batch_size=*/2,
+      /*padded_shapes=*/{CreateTensor<int64>(TensorShape{1}, {3})},
+      /*padded_values=*/{CreateTensor<int64>(TensorShape{}, {1})},
+      /*drop_remainder=*/false,
+      /*parallel_copy=*/true,
+      /*output_dtypes=*/{DT_INT64},
+      /*output_shapes=*/{PartialTensorShape({2, 3})},
+      /*num_padded_shapes=*/1,
+      /*node_name=*/kNodeName);
 }
 
 // Test case 4: similar with the test case 3 but the input elements can be
 // divided by the batch size evenly. As drop_remainder = false, the output
 // shape is still {-1, 3} instead of {2, 3}.
-TestCase TestCase4() {
-  return {/*input_tensors*/
-          {{CreateTensor<int64>(TensorShape{3, 2}, {0, 1, 2, 3, 4, 5})},
-           {CreateTensor<int64>(TensorShape{3, 1}, {6, 7, 8})}},
-          /*concatenate_output_dtypes*/ {DT_INT64},
-          /*concatenate_output_shapes*/ {PartialTensorShape({-1})},
-          /*batch_size*/
-          CreateTensor<int64>(TensorShape{}, {2}),
-          /*padded_shapes*/
-          {CreateTensor<int64>(TensorShape{1}, {3})},
-          /*padding_values*/
-          {CreateTensor<int64>(TensorShape{}, {1})},
-          /*drop_remainder*/
-          CreateTensor<bool>(TensorShape{}, {false}),
-          /*parallel_copy*/ false,
-          /*n*/ 1,
-          /*expected_outputs*/
-          {CreateTensor<int64>(TensorShape{2, 3}, {0, 1, 1, 2, 3, 1}),
-           CreateTensor<int64>(TensorShape{2, 3}, {4, 5, 1, 6, 1, 1}),
-           CreateTensor<int64>(TensorShape{2, 3}, {7, 1, 1, 8, 1, 1})},
-          /*expected_output_dtypes*/ {DT_INT64},
-          /*expected_output_shapes*/ {PartialTensorShape({-1, 3})},
-          /*expected_cardinality*/ 3,
-          /*breakpoints*/ {0, 2, 5}};
+PaddedBatchDatasetParams PaddedBatchDatasetParams4() {
+  auto tensor_slice_dataset_params_0 = TensorSliceDatasetParams(
+      /*components=*/CreateTensors<int64>(TensorShape{3, 2},
+                                          {{0, 1, 2, 3, 4, 5}}),
+      /*node_name=*/"tensor_slice_0");
+  auto tensor_slice_dataset_params_1 = TensorSliceDatasetParams(
+      /*components=*/CreateTensors<int64>(TensorShape{3, 1}, {{6, 7, 8}}),
+      /*node_name=*/"tensor_slice_1");
+  auto concatenate_dataset_params =
+      ConcatenateDatasetParams(std::move(tensor_slice_dataset_params_0),
+                               std::move(tensor_slice_dataset_params_1),
+                               /*output_dtypes=*/{DT_INT64},
+                               /*output_shapes=*/{PartialTensorShape({-1})},
+                               /*node_name=*/"concatenate");
+  return PaddedBatchDatasetParams(
+      /*input_dataset_params=*/concatenate_dataset_params,
+      /*batch_size=*/2,
+      /*padded_shapes=*/{CreateTensor<int64>(TensorShape{1}, {3})},
+      /*padded_values=*/{CreateTensor<int64>(TensorShape{}, {1})},
+      /*drop_remainder=*/false,
+      /*parallel_copy=*/true,
+      /*output_dtypes=*/{DT_INT64},
+      /*output_shapes=*/{PartialTensorShape({-1, 3})},
+      /*num_padded_shapes=*/1,
+      /*node_name=*/kNodeName);
 }
 
 // Test case 5: similar with the test case 3 but padded_shapes = {-1}.
-TestCase TestCase5() {
-  return {/*input_tensors*/
-          {{CreateTensor<int64>(TensorShape{3, 2}, {0, 1, 2, 3, 4, 5})},
-           {CreateTensor<int64>(TensorShape{4, 1}, {6, 7, 8, 9})}},
-          /*concatenate_output_dtypes*/ {DT_INT64},
-          /*concatenate_output_shapes*/ {PartialTensorShape({-1})},
-          /*batch_size*/
-          CreateTensor<int64>(TensorShape{}, {2}),
-          /*padded_shapes*/
-          {CreateTensor<int64>(TensorShape{1}, {-1})},
-          /*padding_values*/
-          {CreateTensor<int64>(TensorShape{}, {1})},
-          /*drop_remainder*/
-          CreateTensor<bool>(TensorShape{}, {false}),
-          /*parallel_copy*/ false,
-          /*n*/ 1,
-          /*expected_outputs*/
-          {CreateTensor<int64>(TensorShape{2, 2}, {0, 1, 2, 3}),
-           CreateTensor<int64>(TensorShape{2, 2}, {4, 5, 6, 1}),
-           CreateTensor<int64>(TensorShape{2, 1}, {7, 8}),
-           CreateTensor<int64>(TensorShape{1, 1}, {9})},
-          /*expected_output_dtypes*/ {DT_INT64},
-          /*expected_output_shapes*/ {PartialTensorShape({-1, -1})},
-          /*expected_cardinality*/ 4,
-          /*breakpoints*/ {0, 2, 5}};
+PaddedBatchDatasetParams PaddedBatchDatasetParams5() {
+  auto tensor_slice_dataset_params_0 = TensorSliceDatasetParams(
+      /*components=*/CreateTensors<int64>(TensorShape{3, 2},
+                                          {{0, 1, 2, 3, 4, 5}}),
+      /*node_name=*/"tensor_slice_0");
+  auto tensor_slice_dataset_params_1 = TensorSliceDatasetParams(
+      /*components=*/CreateTensors<int64>(TensorShape{4, 1}, {{6, 7, 8, 9}}),
+      /*node_name=*/"tensor_slice_1");
+  auto concatenate_dataset_params =
+      ConcatenateDatasetParams(std::move(tensor_slice_dataset_params_0),
+                               std::move(tensor_slice_dataset_params_1),
+                               /*output_dtypes=*/{DT_INT64},
+                               /*output_shapes=*/{PartialTensorShape({-1})},
+                               /*node_name=*/"concatenate");
+  return PaddedBatchDatasetParams(
+      /*input_dataset_params=*/concatenate_dataset_params,
+      /*batch_size=*/2,
+      /*padded_shapes=*/{CreateTensor<int64>(TensorShape{1}, {-1})},
+      /*padded_values=*/{CreateTensor<int64>(TensorShape{}, {1})},
+      /*drop_remainder=*/false,
+      /*parallel_copy=*/false,
+      /*output_dtypes=*/{DT_INT64},
+      /*output_shapes=*/{PartialTensorShape({-1, -1})},
+      /*num_padded_shapes=*/1,
+      /*node_name=*/kNodeName);
 }
 
 // Test case 6: similar with the test case 5 but parallel_copy = true.
-TestCase TestCase6() {
-  return {/*input_tensors*/
-          {{CreateTensor<int64>(TensorShape{3, 2}, {0, 1, 2, 3, 4, 5})},
-           {CreateTensor<int64>(TensorShape{4, 1}, {6, 7, 8, 9})}},
-          /*concatenate_output_dtypes*/ {DT_INT64},
-          /*concatenate_output_shapes*/ {PartialTensorShape({-1})},
-          /*batch_size*/
-          CreateTensor<int64>(TensorShape{}, {2}),
-          /*padded_shapes*/
-          {CreateTensor<int64>(TensorShape{1}, {-1})},
-          /*padding_values*/
-          {CreateTensor<int64>(TensorShape{}, {1})},
-          /*drop_remainder*/
-          CreateTensor<bool>(TensorShape{}, {false}),
-          /*parallel_copy*/ true,
-          /*n*/ 1,
-          /*expected_outputs*/
-          {CreateTensor<int64>(TensorShape{2, 2}, {0, 1, 2, 3}),
-           CreateTensor<int64>(TensorShape{2, 2}, {4, 5, 6, 1}),
-           CreateTensor<int64>(TensorShape{2, 1}, {7, 8}),
-           CreateTensor<int64>(TensorShape{1, 1}, {9})},
-          /*expected_output_dtypes*/ {DT_INT64},
-          /*expected_output_shapes*/ {PartialTensorShape({-1, -1})},
-          /*expected_cardinality*/ 4,
-          /*breakpoints*/ {0, 2, 5}};
+PaddedBatchDatasetParams PaddedBatchDatasetParams6() {
+  auto tensor_slice_dataset_params_0 = TensorSliceDatasetParams(
+      /*components=*/CreateTensors<int64>(TensorShape{3, 2},
+                                          {{0, 1, 2, 3, 4, 5}}),
+      /*node_name=*/"tensor_slice_0");
+  auto tensor_slice_dataset_params_1 = TensorSliceDatasetParams(
+      /*components=*/CreateTensors<int64>(TensorShape{4, 1}, {{6, 7, 8, 9}}),
+      /*node_name=*/"tensor_slice_1");
+  auto concatenate_dataset_params =
+      ConcatenateDatasetParams(std::move(tensor_slice_dataset_params_0),
+                               std::move(tensor_slice_dataset_params_1),
+                               /*output_dtypes=*/{DT_INT64},
+                               /*output_shapes=*/{PartialTensorShape({-1})},
+                               /*node_name=*/"concatenate");
+  return PaddedBatchDatasetParams(
+      /*input_dataset_params=*/concatenate_dataset_params,
+      /*batch_size=*/2,
+      /*padded_shapes=*/{CreateTensor<int64>(TensorShape{1}, {-1})},
+      /*padded_values=*/{CreateTensor<int64>(TensorShape{}, {1})},
+      /*drop_remainder=*/false,
+      /*parallel_copy=*/true,
+      /*output_dtypes=*/{DT_INT64},
+      /*output_shapes=*/{PartialTensorShape({-1, -1})},
+      /*num_padded_shapes=*/1,
+      /*node_name=*/kNodeName);
 }
 
 // Test case 7: empty input elements.
-TestCase TestCase7() {
-  return {/*input_tensors*/
-          {{CreateTensor<int64>(TensorShape{0}, {})},
-           {CreateTensor<int64>(TensorShape{0}, {})}},
-          /*concatenate_output_dtypes*/ {DT_INT64},
-          /*concatenate_output_shapes*/ {PartialTensorShape({-1})},
-          /*batch_size*/
-          CreateTensor<int64>(TensorShape{}, {2}),
-          /*padded_shapes*/
-          {CreateTensor<int64>(TensorShape{1}, {-1})},
-          /*padding_values*/
-          {CreateTensor<int64>(TensorShape{}, {1})},
-          /*drop_remainder*/
-          CreateTensor<bool>(TensorShape{}, {false}),
-          /*parallel_copy*/ true,
-          /*n*/ 1,
-          /*expected_outputs*/ {},
-          /*expected_output_dtypes*/ {DT_INT64},
-          /*expected_output_shapes*/ {PartialTensorShape({-1, -1})},
-          /*expected_cardinality*/ 0,
-          /*breakpoints*/ {0, 2, 5}};
+PaddedBatchDatasetParams PaddedBatchDatasetParams7() {
+  return PaddedBatchDatasetParams(
+      /*input_dataset_params=*/RangeDatasetParams(0, 0, 1),
+      /*batch_size=*/2,
+      /*padded_shapes=*/{CreateTensor<int64>(TensorShape{1}, {-1})},
+      /*padded_values=*/{CreateTensor<int64>(TensorShape{}, {1})},
+      /*drop_remainder=*/false,
+      /*parallel_copy=*/true,
+      /*output_dtypes=*/{DT_INT64},
+      /*output_shapes=*/{PartialTensorShape({-1, -1})},
+      /*num_padded_shapes=*/1,
+      /*node_name=*/kNodeName);
 }
 
-TestCase ShortPaddingTestCase() {
-  return {/*input_tensors*/
-          {{CreateTensor<int64>(TensorShape{3, 2}, {0, 1, 2, 3, 4, 5})},
-           {CreateTensor<int64>(TensorShape{3, 2}, {6, 7, 8, 9, 10, 11})}},
-          /*concatenate_output_dtypes*/ {DT_INT64},
-          /*concatenate_output_shapes*/ {PartialTensorShape({2})},
-          /*batch_size*/
-          CreateTensor<int64>(TensorShape{}, {2}),
-          /*padded_shapes*/
-          {CreateTensor<int64>(TensorShape{1}, {1})},
-          /*padding_values*/
-          {CreateTensor<int64>(TensorShape{}, {1})},
-          /*drop_remainder*/
-          CreateTensor<bool>(TensorShape{}, {false}),
-          /*parallel_copy*/ true,
-          /*n*/ 1,
-          /*expected_outputs*/ {},
-          /*expected_output_dtypes*/ {DT_INT64},
-          /*expected_output_shapes*/ {PartialTensorShape({-1, -1})},
-          /*expected_cardinality*/ 0,
-          /*breakpoints*/ {0, 2, 5}};
+// Test case 8: short padding shape.
+PaddedBatchDatasetParams PaddedBatchDatasetParamsWithShortPaddingShape() {
+  auto tensor_slice_dataset_params_0 = TensorSliceDatasetParams(
+      /*components=*/CreateTensors<int64>(TensorShape{3, 2},
+                                          {{0, 1, 2, 3, 4, 5}}),
+      /*node_name=*/"tensor_slice_0");
+  auto tensor_slice_dataset_params_1 = TensorSliceDatasetParams(
+      /*components=*/CreateTensors<int64>(TensorShape{3, 2},
+                                          {{6, 7, 8, 9, 10, 11}}),
+      /*node_name=*/"tensor_slice_1");
+  auto concatenate_dataset_params =
+      ConcatenateDatasetParams(std::move(tensor_slice_dataset_params_0),
+                               std::move(tensor_slice_dataset_params_1),
+                               /*output_dtypes=*/{DT_INT64},
+                               /*output_shapes=*/{PartialTensorShape({2})},
+                               /*node_name=*/"concatenate");
+  return PaddedBatchDatasetParams(
+      /*input_dataset_params=*/concatenate_dataset_params,
+      /*batch_size=*/2,
+      /*padded_shapes=*/{CreateTensor<int64>(TensorShape{1}, {1})},
+      /*padded_values=*/{CreateTensor<int64>(TensorShape{}, {1})},
+      /*drop_remainder=*/false,
+      /*parallel_copy=*/true,
+      /*output_dtypes=*/{DT_INT64},
+      /*output_shapes=*/{PartialTensorShape({-1, -1})},
+      /*num_padded_shapes=*/1,
+      /*node_name=*/kNodeName);
 }
 
-TestCase InvalidPaddingShapesTestCase() {
-  return {/*input_tensors*/
-          {{CreateTensor<int64>(TensorShape{3, 2}, {0, 1, 2, 3, 4, 5})},
-           {CreateTensor<int64>(TensorShape{3, 2}, {6, 7, 8, 9, 10, 11})}},
-          /*concatenate_output_dtypes*/ {DT_INT64},
-          /*concatenate_output_shapes*/ {PartialTensorShape({2})},
-          /*batch_size*/
-          CreateTensor<int64>(TensorShape{}, {2}),
-          /*padded_shapes*/
-          {CreateTensor<int64>(TensorShape{2}, {1, 2})},
-          /*padding_values*/
-          {CreateTensor<int64>(TensorShape{}, {1})},
-          /*drop_remainder*/
-          CreateTensor<bool>(TensorShape{}, {false}),
-          /*parallel_copy*/ true,
-          /*n*/ 1,
-          /*expected_outputs*/ {},
-          /*expected_output_dtypes*/ {DT_INT64},
-          /*expected_output_shapes*/ {PartialTensorShape({-1, -1})},
-          /*expected_cardinality*/ 0,
-          /*breakpoints*/ {0, 2, 5}};
+PaddedBatchDatasetParams PaddedBatchDatasetParamsWithInvalidPaddingShape() {
+  auto tensor_slice_dataset_params_0 = TensorSliceDatasetParams(
+      /*components=*/CreateTensors<int64>(TensorShape{3, 2},
+                                          {{0, 1, 2, 3, 4, 5}}),
+      /*node_name=*/"tensor_slice_0");
+  auto tensor_slice_dataset_params_1 = TensorSliceDatasetParams(
+      /*components=*/CreateTensors<int64>(TensorShape{3, 2},
+                                          {{6, 7, 8, 9, 10, 11}}),
+      /*node_name=*/"tensor_slice_1");
+  auto concatenate_dataset_params =
+      ConcatenateDatasetParams(std::move(tensor_slice_dataset_params_0),
+                               std::move(tensor_slice_dataset_params_1),
+                               /*output_dtypes=*/{DT_INT64},
+                               /*output_shapes=*/{PartialTensorShape({2})},
+                               /*node_name=*/"concatenate");
+  return PaddedBatchDatasetParams(
+      /*input_dataset_params=*/concatenate_dataset_params,
+      /*batch_size=*/2,
+      /*padded_shapes=*/{CreateTensor<int64>(TensorShape{2}, {1, 2})},
+      /*padded_values=*/{CreateTensor<int64>(TensorShape{}, {1})},
+      /*drop_remainder=*/false,
+      /*parallel_copy=*/true,
+      /*output_dtypes=*/{DT_INT64},
+      /*output_shapes=*/{PartialTensorShape({-1, -1})},
+      /*num_padded_shapes=*/1,
+      /*node_name=*/kNodeName);
 }
 
-TestCase InvalidBatchSizeTestCase() {
-  return {/*input_tensors*/
-          {{CreateTensor<int64>(TensorShape{3, 2}, {0, 1, 2, 3, 4, 5})},
-           {CreateTensor<int64>(TensorShape{3, 2}, {6, 7, 8, 9, 10, 11})}},
-          /*concatenate_output_dtypes*/ {DT_INT64},
-          /*concatenate_output_shapes*/ {PartialTensorShape({2})},
-          /*batch_size*/
-          CreateTensor<int64>(TensorShape{}, {-1}),
-          /*padded_shapes*/
-          {CreateTensor<int64>(TensorShape{1}, {3})},
-          /*padding_values*/
-          {CreateTensor<int64>(TensorShape{}, {1})},
-          /*drop_remainder*/
-          CreateTensor<bool>(TensorShape{}, {false}),
-          /*parallel_copy*/ true,
-          /*n*/ 1,
-          /*expected_outputs*/ {},
-          /*expected_output_dtypes*/ {DT_INT64},
-          /*expected_output_shapes*/ {PartialTensorShape({-1, -1})},
-          /*expected_cardinality*/ 0,
-          /*breakpoints*/ {0, 2, 5}};
+PaddedBatchDatasetParams PaddedBatchDatasetParamsWithInvalidBatchSize() {
+  auto tensor_slice_dataset_params_0 = TensorSliceDatasetParams(
+      /*components=*/CreateTensors<int64>(TensorShape{3, 2},
+                                          {{0, 1, 2, 3, 4, 5}}),
+      /*node_name=*/"tensor_slice_0");
+  auto tensor_slice_dataset_params_1 = TensorSliceDatasetParams(
+      /*components=*/CreateTensors<int64>(TensorShape{3, 2},
+                                          {{6, 7, 8, 9, 10, 11}}),
+      /*node_name=*/"tensor_slice_1");
+  auto concatenate_dataset_params =
+      ConcatenateDatasetParams(std::move(tensor_slice_dataset_params_0),
+                               std::move(tensor_slice_dataset_params_1),
+                               /*output_dtypes=*/{DT_INT64},
+                               /*output_shapes=*/{PartialTensorShape({2})},
+                               /*node_name=*/"concatenate");
+  return PaddedBatchDatasetParams(
+      /*input_dataset_params=*/concatenate_dataset_params,
+      /*batch_size=*/-1,
+      /*padded_shapes=*/{CreateTensor<int64>(TensorShape{1}, {3})},
+      /*padded_values=*/{CreateTensor<int64>(TensorShape{}, {1})},
+      /*drop_remainder=*/false,
+      /*parallel_copy=*/true,
+      /*output_dtypes=*/{DT_INT64},
+      /*output_shapes=*/{PartialTensorShape({-1, -1})},
+      /*num_padded_shapes=*/1,
+      /*node_name=*/kNodeName);
 }
 
-TestCase InvalidPaddedShapesSizeTestCase() {
-  return {/*input_tensors*/
-          {{CreateTensor<int64>(TensorShape{3, 2}, {0, 1, 2, 3, 4, 5})},
-           {CreateTensor<int64>(TensorShape{3, 2}, {6, 7, 8, 9, 10, 11})}},
-          /*concatenate_output_dtypes*/ {DT_INT64},
-          /*concatenate_output_shapes*/ {PartialTensorShape({2})},
-          /*batch_size*/
-          CreateTensor<int64>(TensorShape{}, {2}),
-          /*padded_shapes*/
-          {CreateTensor<int64>(TensorShape{1}, {3}),
-           CreateTensor<int64>(TensorShape{1}, {3})},
-          /*padding_values*/
-          {CreateTensor<int64>(TensorShape{}, {1})},
-          /*drop_remainder*/
-          CreateTensor<bool>(TensorShape{}, {false}),
-          /*parallel_copy*/ true,
-          /*n*/ 2,
-          /*expected_outputs*/ {},
-          /*expected_output_dtypes*/ {DT_INT64},
-          /*expected_output_shapes*/ {PartialTensorShape({-1, -1})},
-          /*expected_cardinality*/ 0,
-          /*breakpoints*/ {0, 2, 5}};
+PaddedBatchDatasetParams
+PaddedBatchDatasetParamsWithInvalidPaddingShapesSize() {
+  auto tensor_slice_dataset_params_0 = TensorSliceDatasetParams(
+      /*components=*/CreateTensors<int64>(TensorShape{3, 2},
+                                          {{0, 1, 2, 3, 4, 5}}),
+      /*node_name=*/"tensor_slice_0");
+  auto tensor_slice_dataset_params_1 = TensorSliceDatasetParams(
+      /*components=*/CreateTensors<int64>(TensorShape{3, 2},
+                                          {{6, 7, 8, 9, 10, 11}}),
+      /*node_name=*/"tensor_slice_1");
+  auto concatenate_dataset_params =
+      ConcatenateDatasetParams(std::move(tensor_slice_dataset_params_0),
+                               std::move(tensor_slice_dataset_params_1),
+                               /*output_dtypes=*/{DT_INT64},
+                               /*output_shapes=*/{PartialTensorShape({2})},
+                               /*node_name=*/"concatenate");
+  return PaddedBatchDatasetParams(
+      /*input_dataset_params=*/concatenate_dataset_params,
+      /*batch_size=*/2,
+      /*padded_shapes=*/
+      {CreateTensor<int64>(TensorShape{1}, {3}),
+       CreateTensor<int64>(TensorShape{1}, {3})},
+      /*padded_values=*/{CreateTensor<int64>(TensorShape{}, {1})},
+      /*drop_remainder=*/false,
+      /*parallel_copy=*/true,
+      /*output_dtypes=*/{DT_INT64},
+      /*output_shapes=*/{PartialTensorShape({-1, -1})},
+      /*num_padded_shapes=*/2,
+      /*node_name=*/kNodeName);
 }
 
-TestCase InvalidPaddedValuesSizeTestCase() {
-  return {/*input_tensors*/
-          {{CreateTensor<int64>(TensorShape{3, 2}, {0, 1, 2, 3, 4, 5})},
-           {CreateTensor<int64>(TensorShape{3, 2}, {6, 7, 8, 9, 10, 11})}},
-          /*concatenate_output_dtypes*/ {DT_INT64},
-          /*concatenate_output_shapes*/ {PartialTensorShape({2})},
-          /*batch_size*/
-          CreateTensor<int64>(TensorShape{}, {2}),
-          /*padded_shapes*/
-          {CreateTensor<int64>(TensorShape{1}, {3})},
-          /*padding_values*/
-          {CreateTensor<int64>(TensorShape{}, {1}),
-           CreateTensor<int64>(TensorShape{}, {1})},
-          /*drop_remainder*/
-          CreateTensor<bool>(TensorShape{}, {false}),
-          /*parallel_copy*/ true,
-          /*n*/ 1,
-          /*expected_outputs*/ {},
-          /*expected_output_dtypes*/ {DT_INT64, DT_INT64},
-          /*expected_output_shapes*/ {PartialTensorShape({-1, -1})},
-          /*expected_cardinality*/ 0,
-          /*breakpoints*/ {0, 2, 5}};
+PaddedBatchDatasetParams
+PaddedBatchDatasetParamsWithInvalidPaddingValuesSize() {
+  auto tensor_slice_dataset_params_0 = TensorSliceDatasetParams(
+      /*components=*/CreateTensors<int64>(TensorShape{3, 2},
+                                          {{0, 1, 2, 3, 4, 5}}),
+      /*node_name=*/"tensor_slice_0");
+  auto tensor_slice_dataset_params_1 = TensorSliceDatasetParams(
+      /*components=*/CreateTensors<int64>(TensorShape{3, 2},
+                                          {{6, 7, 8, 9, 10, 11}}),
+      /*node_name=*/"tensor_slice_1");
+  auto concatenate_dataset_params =
+      ConcatenateDatasetParams(std::move(tensor_slice_dataset_params_0),
+                               std::move(tensor_slice_dataset_params_1),
+                               /*output_dtypes=*/{DT_INT64},
+                               /*output_shapes=*/{PartialTensorShape({2})},
+                               /*node_name=*/"concatenate");
+  return PaddedBatchDatasetParams(
+      /*input_dataset_params=*/concatenate_dataset_params,
+      /*batch_size=*/2,
+      /*padded_shapes=*/
+      {CreateTensor<int64>(TensorShape{1}, {3})},
+      /*padded_values=*/
+      {CreateTensor<int64>(TensorShape{}, {1}),
+       CreateTensor<int64>(TensorShape{}, {1})},
+      /*drop_remainder=*/false,
+      /*parallel_copy=*/true,
+      /*output_dtypes=*/{DT_INT64},
+      /*output_shapes=*/{PartialTensorShape({-1, -1})},
+      /*num_padded_shapes=*/2,
+      /*node_name=*/kNodeName);
 }
 
-TestCase InvalidPaddedValuesDTypeTestCase() {
-  return {/*input_tensors*/
-          {{CreateTensor<int64>(TensorShape{3, 2}, {0, 1, 2, 3, 4, 5})},
-           {CreateTensor<int64>(TensorShape{3, 2}, {6, 7, 8, 9, 10, 11})}},
-          /*concatenate_output_dtypes*/ {DT_INT64},
-          /*concatenate_output_shapes*/ {PartialTensorShape({2})},
-          /*batch_size*/
-          CreateTensor<int64>(TensorShape{}, {2}),
-          /*padded_shapes*/
-          {CreateTensor<int64>(TensorShape{1}, {3})},
-          /*padding_values*/
-          {CreateTensor<tstring>(TensorShape{}, {"a"})},
-          /*drop_remainder*/
-          CreateTensor<bool>(TensorShape{}, {false}),
-          /*parallel_copy*/ true,
-          /*n*/ 1,
-          /*expected_outputs*/ {},
-          /*expected_output_dtypes*/ {DT_INT64},
-          /*expected_output_shapes*/ {PartialTensorShape({-1, -1})},
-          /*expected_cardinality*/ 0,
-          /*breakpoints*/ {0, 2, 5}};
+PaddedBatchDatasetParams
+PaddedBatchDatasetParamsWithInvalidPaddingValuesDType() {
+  auto tensor_slice_dataset_params_0 = TensorSliceDatasetParams(
+      /*components=*/CreateTensors<int64>(TensorShape{3, 2},
+                                          {{0, 1, 2, 3, 4, 5}}),
+      /*node_name=*/"tensor_slice_0");
+  auto tensor_slice_dataset_params_1 = TensorSliceDatasetParams(
+      /*components=*/CreateTensors<int64>(TensorShape{3, 2},
+                                          {{6, 7, 8, 9, 10, 11}}),
+      /*node_name=*/"tensor_slice_1");
+  auto concatenate_dataset_params =
+      ConcatenateDatasetParams(std::move(tensor_slice_dataset_params_0),
+                               std::move(tensor_slice_dataset_params_1),
+                               /*output_dtypes=*/{DT_INT64},
+                               /*output_shapes=*/{PartialTensorShape({2})},
+                               /*node_name=*/"concatenate");
+  return PaddedBatchDatasetParams(
+      /*input_dataset_params=*/concatenate_dataset_params,
+      /*batch_size=*/2,
+      /*padded_shapes=*/
+      {CreateTensor<int64>(TensorShape{1}, {3})},
+      /*padded_values=*/
+      {CreateTensor<tstring>(TensorShape{}, {"a"})},
+      /*drop_remainder=*/false,
+      /*parallel_copy=*/true,
+      /*output_dtypes=*/{DT_INT64},
+      /*output_shapes=*/{PartialTensorShape({-1, -1})},
+      /*num_padded_shapes=*/1,
+      /*node_name=*/kNodeName);
 }
 
-TestCase InvalidPaddedValuesShapeTestCase() {
-  return {/*input_tensors*/
-          {{CreateTensor<int64>(TensorShape{3, 2}, {0, 1, 2, 3, 4, 5})},
-           {CreateTensor<int64>(TensorShape{3, 2}, {6, 7, 8, 9, 10, 11})}},
-          /*concatenate_output_dtypes*/ {DT_INT64},
-          /*concatenate_output_shapes*/ {PartialTensorShape({2})},
-          /*batch_size*/
-          CreateTensor<int64>(TensorShape{}, {2}),
-          /*padded_shapes*/
-          {CreateTensor<int64>(TensorShape{1}, {3})},
-          /*padding_values*/
-          {CreateTensor<int64>(TensorShape{1}, {1})},
-          /*drop_remainder*/
-          CreateTensor<bool>(TensorShape{}, {false}),
-          /*parallel_copy*/ true,
-          /*n*/ 1,
-          /*expected_outputs*/ {},
-          /*expected_output_dtypes*/ {DT_INT64},
-          /*expected_output_shapes*/ {PartialTensorShape({-1, -1})},
-          /*expected_cardinality*/ 0,
-          /*breakpoints*/ {0, 2, 5}};
+PaddedBatchDatasetParams
+PaddedBatchDatasetParamsWithInvalidPaddingValuesShape() {
+  auto tensor_slice_dataset_params_0 = TensorSliceDatasetParams(
+      /*components=*/CreateTensors<int64>(TensorShape{3, 2},
+                                          {{0, 1, 2, 3, 4, 5}}),
+      /*node_name=*/"tensor_slice_0");
+  auto tensor_slice_dataset_params_1 = TensorSliceDatasetParams(
+      /*components=*/CreateTensors<int64>(TensorShape{3, 2},
+                                          {{6, 7, 8, 9, 10, 11}}),
+      /*node_name=*/"tensor_slice_1");
+  auto concatenate_dataset_params =
+      ConcatenateDatasetParams(std::move(tensor_slice_dataset_params_0),
+                               std::move(tensor_slice_dataset_params_1),
+                               /*output_dtypes=*/{DT_INT64},
+                               /*output_shapes=*/{PartialTensorShape({2})},
+                               /*node_name=*/"concatenate");
+  return PaddedBatchDatasetParams(
+      /*input_dataset_params=*/concatenate_dataset_params,
+      /*batch_size=*/2,
+      /*padded_shapes=*/
+      {CreateTensor<int64>(TensorShape{1}, {3})},
+      /*padded_values=*/
+      {CreateTensor<int64>(TensorShape{1}, {1})},
+      /*drop_remainder=*/false,
+      /*parallel_copy=*/true,
+      /*output_dtypes=*/{DT_INT64},
+      /*output_shapes=*/{PartialTensorShape({-1, -1})},
+      /*num_padded_shapes=*/1,
+      /*node_name=*/kNodeName);
 }
 
-class ParameterizedPaddedBatchDatasetOpTest
-    : public PaddedBatchDatasetOpTest,
-      public ::testing::WithParamInterface<TestCase> {};
-
-TEST_P(ParameterizedPaddedBatchDatasetOpTest, GetNext) {
-  int thread_num = 2, cpu_num = 2;
-  const TestCase &test_case = GetParam();
-  TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
-
-  std::unique_ptr<OpKernel> padded_batch_dataset_kernel;
-  TF_ASSERT_OK(CreatePaddedBatchDatasetKernel(
-      test_case.parallel_copy, test_case.n, test_case.expected_output_dtypes,
-      test_case.expected_output_shapes, &padded_batch_dataset_kernel));
-
-  Tensor concatenate_dataset_tensor(DT_VARIANT, TensorShape({}));
-  TF_ASSERT_OK(CreateConcatenateDatasetTensor(
-      test_case.input_tensors, test_case.concatenate_output_dtypes,
-      test_case.concatenate_output_shapes, &concatenate_dataset_tensor));
-  Tensor batch_size = test_case.batch_size;
-  std::vector<Tensor> padded_shapes = test_case.padded_shapes;
-  std::vector<Tensor> padding_values = test_case.padding_values;
-  Tensor drop_remainder = test_case.drop_remainder;
-  gtl::InlinedVector<TensorValue, 4> inputs(
-      {TensorValue(&concatenate_dataset_tensor), TensorValue(&batch_size)});
-  for (auto &padded_shape : padded_shapes) {
-    inputs.emplace_back(&padded_shape);
-  }
-  for (auto &padding_value : padding_values) {
-    inputs.emplace_back(&padding_value);
-  }
-  inputs.emplace_back(&drop_remainder);
-
-  std::unique_ptr<OpKernelContext> padded_batch_dataset_context;
-  TF_ASSERT_OK(
-      CreatePaddedBatchDatasetContext(padded_batch_dataset_kernel.get(),
-                                      &inputs, &padded_batch_dataset_context));
-  DatasetBase *padded_batch_dataset;
-  TF_ASSERT_OK(CreateDataset(padded_batch_dataset_kernel.get(),
-                             padded_batch_dataset_context.get(),
-                             &padded_batch_dataset));
-  core::ScopedUnref scoped_unref(padded_batch_dataset);
-
-  std::unique_ptr<IteratorContext> iterator_ctx;
-  TF_ASSERT_OK(
-      CreateIteratorContext(padded_batch_dataset_context.get(), &iterator_ctx));
-  std::unique_ptr<IteratorBase> iterator;
-  TF_ASSERT_OK(padded_batch_dataset->MakeIterator(iterator_ctx.get(),
-                                                  "Iterator", &iterator));
-  bool end_of_sequence = false;
-  std::vector<Tensor> out_tensors;
-  while (!end_of_sequence) {
-    std::vector<Tensor> next;
-    TF_EXPECT_OK(
-        iterator->GetNext(iterator_ctx.get(), &next, &end_of_sequence));
-    out_tensors.insert(out_tensors.end(), next.begin(), next.end());
-  }
-
-  TF_EXPECT_OK(ExpectEqual(out_tensors, test_case.expected_outputs,
-                           /*compare_order*/ true));
+std::vector<GetNextTestCase<PaddedBatchDatasetParams>> GetNextTestCases() {
+  return {{/*dataset_params=*/PaddedBatchDatasetParams1(),
+           /*expected_outputs=*/
+           CreateTensors<int64>(
+               TensorShape{2, 3},
+               {{0, 1, 1, 2, 3, 1}, {4, 5, 1, 6, 7, 1}, {8, 9, 1, 10, 11, 1}})},
+          {/*dataset_params=*/PaddedBatchDatasetParams2(),
+           /*expected_outputs=*/
+           CreateTensors<int64>(
+               TensorShape{2, 3},
+               {{0, 1, 1, 2, 3, 1}, {4, 5, 1, 6, 1, 1}, {7, 1, 1, 8, 1, 1}})},
+          {/*dataset_params=*/PaddedBatchDatasetParams3(),
+           /*expected_outputs=*/
+           {CreateTensor<int64>(TensorShape{2, 3}, {0, 1, 1, 2, 3, 1}),
+            CreateTensor<int64>(TensorShape{2, 3}, {4, 5, 1, 6, 1, 1}),
+            CreateTensor<int64>(TensorShape{2, 3}, {7, 1, 1, 8, 1, 1}),
+            CreateTensor<int64>(TensorShape{1, 3}, {9, 1, 1})}},
+          {/*dataset_params=*/PaddedBatchDatasetParams4(),
+           /*expected_outputs=*/
+           CreateTensors<int64>(
+               TensorShape{2, 3},
+               {{0, 1, 1, 2, 3, 1}, {4, 5, 1, 6, 1, 1}, {7, 1, 1, 8, 1, 1}})},
+          {/*dataset_params=*/PaddedBatchDatasetParams5(),
+           /*expected_outputs=*/
+           {CreateTensor<int64>(TensorShape{2, 2}, {0, 1, 2, 3}),
+            CreateTensor<int64>(TensorShape{2, 2}, {4, 5, 6, 1}),
+            CreateTensor<int64>(TensorShape{2, 1}, {7, 8}),
+            CreateTensor<int64>(TensorShape{1, 1}, {9})}},
+          {/*dataset_params=*/PaddedBatchDatasetParams6(),
+           /*expected_outputs=*/
+           {CreateTensor<int64>(TensorShape{2, 2}, {0, 1, 2, 3}),
+            CreateTensor<int64>(TensorShape{2, 2}, {4, 5, 6, 1}),
+            CreateTensor<int64>(TensorShape{2, 1}, {7, 8}),
+            CreateTensor<int64>(TensorShape{1, 1}, {9})}},
+          {/*dataset_params=*/PaddedBatchDatasetParams7(),
+           /*expected_outputs=*/{}}};
 }
+
+ITERATOR_GET_NEXT_TEST_P(PaddedBatchDatasetOpTest, PaddedBatchDatasetParams,
+                         GetNextTestCases())
 
 TEST_F(PaddedBatchDatasetOpTest, DatasetNodeName) {
-  int thread_num = 2, cpu_num = 2;
-  const TestCase &test_case = TestCase1();
-  TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
-
-  std::unique_ptr<OpKernel> padded_batch_dataset_kernel;
-  TF_ASSERT_OK(CreatePaddedBatchDatasetKernel(
-      test_case.parallel_copy, test_case.n, test_case.expected_output_dtypes,
-      test_case.expected_output_shapes, &padded_batch_dataset_kernel));
-
-  Tensor concatenate_dataset_tensor(DT_VARIANT, TensorShape({}));
-  TF_ASSERT_OK(CreateConcatenateDatasetTensor(
-      test_case.input_tensors, test_case.concatenate_output_dtypes,
-      test_case.concatenate_output_shapes, &concatenate_dataset_tensor));
-  Tensor batch_size = test_case.batch_size;
-  std::vector<Tensor> padded_shapes = test_case.padded_shapes;
-  std::vector<Tensor> padding_values = test_case.padding_values;
-  Tensor drop_remainder = test_case.drop_remainder;
-  gtl::InlinedVector<TensorValue, 4> inputs(
-      {TensorValue(&concatenate_dataset_tensor), TensorValue(&batch_size)});
-  for (auto &padded_shape : padded_shapes) {
-    inputs.emplace_back(&padded_shape);
-  }
-  for (auto &padding_value : padding_values) {
-    inputs.emplace_back(&padding_value);
-  }
-  inputs.emplace_back(&drop_remainder);
-
-  std::unique_ptr<OpKernelContext> padded_batch_dataset_context;
-  TF_ASSERT_OK(
-      CreatePaddedBatchDatasetContext(padded_batch_dataset_kernel.get(),
-                                      &inputs, &padded_batch_dataset_context));
-  DatasetBase *padded_batch_dataset;
-  TF_ASSERT_OK(CreateDataset(padded_batch_dataset_kernel.get(),
-                             padded_batch_dataset_context.get(),
-                             &padded_batch_dataset));
-  core::ScopedUnref scoped_unref(padded_batch_dataset);
-
-  EXPECT_EQ(padded_batch_dataset->node_name(), kNodeName);
+  auto dataset_params = PaddedBatchDatasetParams1();
+  TF_ASSERT_OK(Initialize(dataset_params));
+  TF_ASSERT_OK(CheckDatasetNodeName(dataset_params.node_name()));
 }
 
 TEST_F(PaddedBatchDatasetOpTest, DatasetTypeString) {
-  int thread_num = 2, cpu_num = 2;
-  const TestCase &test_case = TestCase1();
-  TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
-
-  std::unique_ptr<OpKernel> padded_batch_dataset_kernel;
-  TF_ASSERT_OK(CreatePaddedBatchDatasetKernel(
-      test_case.parallel_copy, test_case.n, test_case.expected_output_dtypes,
-      test_case.expected_output_shapes, &padded_batch_dataset_kernel));
-
-  Tensor concatenate_dataset_tensor(DT_VARIANT, TensorShape({}));
-  TF_ASSERT_OK(CreateConcatenateDatasetTensor(
-      test_case.input_tensors, test_case.concatenate_output_dtypes,
-      test_case.concatenate_output_shapes, &concatenate_dataset_tensor));
-  Tensor batch_size = test_case.batch_size;
-  std::vector<Tensor> padded_shapes = test_case.padded_shapes;
-  std::vector<Tensor> padding_values = test_case.padding_values;
-  Tensor drop_remainder = test_case.drop_remainder;
-  gtl::InlinedVector<TensorValue, 4> inputs(
-      {TensorValue(&concatenate_dataset_tensor), TensorValue(&batch_size)});
-  for (auto &padded_shape : padded_shapes) {
-    inputs.emplace_back(&padded_shape);
-  }
-  for (auto &padding_value : padding_values) {
-    inputs.emplace_back(&padding_value);
-  }
-  inputs.emplace_back(&drop_remainder);
-
-  std::unique_ptr<OpKernelContext> padded_batch_dataset_context;
-  TF_ASSERT_OK(
-      CreatePaddedBatchDatasetContext(padded_batch_dataset_kernel.get(),
-                                      &inputs, &padded_batch_dataset_context));
-  DatasetBase *padded_batch_dataset;
-  TF_ASSERT_OK(CreateDataset(padded_batch_dataset_kernel.get(),
-                             padded_batch_dataset_context.get(),
-                             &padded_batch_dataset));
-  core::ScopedUnref scoped_unref(padded_batch_dataset);
-
+  auto dataset_params = PaddedBatchDatasetParams1();
+  TF_ASSERT_OK(Initialize(dataset_params));
   name_utils::OpNameParams params;
-  params.op_version = kOpVersion;
-  EXPECT_EQ(padded_batch_dataset->type_string(),
-            name_utils::OpName(PaddedBatchDatasetOp::kDatasetType, params));
+  params.op_version = dataset_params.op_version();
+  TF_ASSERT_OK(CheckDatasetTypeString(
+      name_utils::OpName(PaddedBatchDatasetOp::kDatasetType, params)));
 }
 
-TEST_P(ParameterizedPaddedBatchDatasetOpTest, DatasetOutputDtypes) {
-  int thread_num = 2, cpu_num = 2;
-  const TestCase &test_case = GetParam();
-  TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
-
-  std::unique_ptr<OpKernel> padded_batch_dataset_kernel;
-  TF_ASSERT_OK(CreatePaddedBatchDatasetKernel(
-      test_case.parallel_copy, test_case.n, test_case.expected_output_dtypes,
-      test_case.expected_output_shapes, &padded_batch_dataset_kernel));
-
-  Tensor concatenate_dataset_tensor(DT_VARIANT, TensorShape({}));
-  TF_ASSERT_OK(CreateConcatenateDatasetTensor(
-      test_case.input_tensors, test_case.concatenate_output_dtypes,
-      test_case.concatenate_output_shapes, &concatenate_dataset_tensor));
-  Tensor batch_size = test_case.batch_size;
-  std::vector<Tensor> padded_shapes = test_case.padded_shapes;
-  std::vector<Tensor> padding_values = test_case.padding_values;
-  Tensor drop_remainder = test_case.drop_remainder;
-  gtl::InlinedVector<TensorValue, 4> inputs(
-      {TensorValue(&concatenate_dataset_tensor), TensorValue(&batch_size)});
-  for (auto &padded_shape : padded_shapes) {
-    inputs.emplace_back(&padded_shape);
-  }
-  for (auto &padding_value : padding_values) {
-    inputs.emplace_back(&padding_value);
-  }
-  inputs.emplace_back(&drop_remainder);
-
-  std::unique_ptr<OpKernelContext> padded_batch_dataset_context;
-  TF_ASSERT_OK(
-      CreatePaddedBatchDatasetContext(padded_batch_dataset_kernel.get(),
-                                      &inputs, &padded_batch_dataset_context));
-  DatasetBase *padded_batch_dataset;
-  TF_ASSERT_OK(CreateDataset(padded_batch_dataset_kernel.get(),
-                             padded_batch_dataset_context.get(),
-                             &padded_batch_dataset));
-  core::ScopedUnref scoped_unref(padded_batch_dataset);
-
-  TF_EXPECT_OK(VerifyTypesMatch(padded_batch_dataset->output_dtypes(),
-                                test_case.expected_output_dtypes));
+std::vector<DatasetOutputDtypesTestCase<PaddedBatchDatasetParams>>
+DatasetOutputDtypesTestCases() {
+  return {{/*dataset_params=*/PaddedBatchDatasetParams1(),
+           /*expected_output_dtypes=*/{DT_INT64}},
+          {/*dataset_params=*/PaddedBatchDatasetParams2(),
+           /*expected_output_dtypes=*/{DT_INT64}},
+          {/*dataset_params=*/PaddedBatchDatasetParams3(),
+           /*expected_output_dtypes=*/{DT_INT64}},
+          {/*dataset_params=*/PaddedBatchDatasetParams4(),
+           /*expected_output_dtypes=*/{DT_INT64}},
+          {/*dataset_params=*/PaddedBatchDatasetParams5(),
+           /*expected_output_dtypes=*/{DT_INT64}},
+          {/*dataset_params=*/PaddedBatchDatasetParams6(),
+           /*expected_output_dtypes=*/{DT_INT64}},
+          {/*dataset_params=*/PaddedBatchDatasetParams7(),
+           /*expected_output_dtypes=*/{DT_INT64}}};
 }
 
-TEST_P(ParameterizedPaddedBatchDatasetOpTest, DatasetOutputShapes) {
-  int thread_num = 2, cpu_num = 2;
-  const TestCase &test_case = GetParam();
-  TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
+DATASET_OUTPUT_DTYPES_TEST_P(PaddedBatchDatasetOpTest, PaddedBatchDatasetParams,
+                             DatasetOutputDtypesTestCases())
 
-  std::unique_ptr<OpKernel> padded_batch_dataset_kernel;
-  TF_ASSERT_OK(CreatePaddedBatchDatasetKernel(
-      test_case.parallel_copy, test_case.n, test_case.expected_output_dtypes,
-      test_case.expected_output_shapes, &padded_batch_dataset_kernel));
-
-  Tensor concatenate_dataset_tensor(DT_VARIANT, TensorShape({}));
-  TF_ASSERT_OK(CreateConcatenateDatasetTensor(
-      test_case.input_tensors, test_case.concatenate_output_dtypes,
-      test_case.concatenate_output_shapes, &concatenate_dataset_tensor));
-  Tensor batch_size = test_case.batch_size;
-  std::vector<Tensor> padded_shapes = test_case.padded_shapes;
-  std::vector<Tensor> padding_values = test_case.padding_values;
-  Tensor drop_remainder = test_case.drop_remainder;
-  gtl::InlinedVector<TensorValue, 4> inputs(
-      {TensorValue(&concatenate_dataset_tensor), TensorValue(&batch_size)});
-  for (auto &padded_shape : padded_shapes) {
-    inputs.emplace_back(&padded_shape);
-  }
-  for (auto &padding_value : padding_values) {
-    inputs.emplace_back(&padding_value);
-  }
-  inputs.emplace_back(&drop_remainder);
-
-  std::unique_ptr<OpKernelContext> padded_batch_dataset_context;
-  TF_ASSERT_OK(
-      CreatePaddedBatchDatasetContext(padded_batch_dataset_kernel.get(),
-                                      &inputs, &padded_batch_dataset_context));
-  DatasetBase *padded_batch_dataset;
-  TF_ASSERT_OK(CreateDataset(padded_batch_dataset_kernel.get(),
-                             padded_batch_dataset_context.get(),
-                             &padded_batch_dataset));
-  core::ScopedUnref scoped_unref(padded_batch_dataset);
-
-  TF_EXPECT_OK(VerifyShapesCompatible(padded_batch_dataset->output_shapes(),
-                                      test_case.expected_output_shapes));
+std::vector<DatasetOutputShapesTestCase<PaddedBatchDatasetParams>>
+DatasetOutputShapesTestCases() {
+  return {{/*dataset_params=*/PaddedBatchDatasetParams1(),
+           /*expected_output_shapes=*/{PartialTensorShape({2, 3})}},
+          {/*dataset_params=*/PaddedBatchDatasetParams2(),
+           /*expected_output_shapes=*/{PartialTensorShape({2, 3})}},
+          {/*dataset_params=*/PaddedBatchDatasetParams3(),
+           /*expected_output_shapes=*/{PartialTensorShape({-1, 3})}},
+          {/*dataset_params=*/PaddedBatchDatasetParams4(),
+           /*expected_output_shapes=*/{PartialTensorShape({-1, 3})}},
+          {/*dataset_params=*/PaddedBatchDatasetParams5(),
+           /*expected_output_shapes=*/{PartialTensorShape({-1, -1})}},
+          {/*dataset_params=*/PaddedBatchDatasetParams6(),
+           /*expected_output_shapes=*/{PartialTensorShape({-1, -1})}},
+          {/*dataset_params=*/PaddedBatchDatasetParams7(),
+           /*expected_output_shapes=*/{PartialTensorShape({-1, -1})}}};
 }
 
-TEST_P(ParameterizedPaddedBatchDatasetOpTest, Cardinality) {
-  int thread_num = 2, cpu_num = 2;
-  const TestCase &test_case = GetParam();
-  TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
+DATASET_OUTPUT_SHAPES_TEST_P(PaddedBatchDatasetOpTest, PaddedBatchDatasetParams,
+                             DatasetOutputShapesTestCases())
 
-  std::unique_ptr<OpKernel> padded_batch_dataset_kernel;
-  TF_ASSERT_OK(CreatePaddedBatchDatasetKernel(
-      test_case.parallel_copy, test_case.n, test_case.expected_output_dtypes,
-      test_case.expected_output_shapes, &padded_batch_dataset_kernel));
-
-  Tensor concatenate_dataset_tensor(DT_VARIANT, TensorShape({}));
-  TF_ASSERT_OK(CreateConcatenateDatasetTensor(
-      test_case.input_tensors, test_case.concatenate_output_dtypes,
-      test_case.concatenate_output_shapes, &concatenate_dataset_tensor));
-  Tensor batch_size = test_case.batch_size;
-  std::vector<Tensor> padded_shapes = test_case.padded_shapes;
-  std::vector<Tensor> padding_values = test_case.padding_values;
-  Tensor drop_remainder = test_case.drop_remainder;
-  gtl::InlinedVector<TensorValue, 4> inputs(
-      {TensorValue(&concatenate_dataset_tensor), TensorValue(&batch_size)});
-  for (auto &padded_shape : padded_shapes) {
-    inputs.emplace_back(&padded_shape);
-  }
-  for (auto &padding_value : padding_values) {
-    inputs.emplace_back(&padding_value);
-  }
-  inputs.emplace_back(&drop_remainder);
-
-  std::unique_ptr<OpKernelContext> padded_batch_dataset_context;
-  TF_ASSERT_OK(
-      CreatePaddedBatchDatasetContext(padded_batch_dataset_kernel.get(),
-                                      &inputs, &padded_batch_dataset_context));
-  DatasetBase *padded_batch_dataset;
-  TF_ASSERT_OK(CreateDataset(padded_batch_dataset_kernel.get(),
-                             padded_batch_dataset_context.get(),
-                             &padded_batch_dataset));
-  core::ScopedUnref scoped_unref(padded_batch_dataset);
-
-  EXPECT_EQ(padded_batch_dataset->Cardinality(),
-            test_case.expected_cardinality);
+std::vector<CardinalityTestCase<PaddedBatchDatasetParams>>
+CardinalityTestCases() {
+  return {{/*dataset_params=*/PaddedBatchDatasetParams1(),
+           /*expected_cardinality=*/3},
+          {/*dataset_params=*/PaddedBatchDatasetParams2(),
+           /*expected_cardinality=*/3},
+          {/*dataset_params=*/PaddedBatchDatasetParams3(),
+           /*expected_cardinality=*/4},
+          {/*dataset_params=*/PaddedBatchDatasetParams4(),
+           /*expected_cardinality=*/3},
+          {/*dataset_params=*/PaddedBatchDatasetParams5(),
+           /*expected_cardinality=*/4},
+          {/*dataset_params=*/PaddedBatchDatasetParams6(),
+           /*expected_cardinality=*/4},
+          {/*dataset_params=*/PaddedBatchDatasetParams7(),
+           /*expected_cardinality=*/0}};
 }
 
-TEST_P(ParameterizedPaddedBatchDatasetOpTest, IteratorOutputDtypes) {
-  int thread_num = 2, cpu_num = 2;
-  const TestCase &test_case = GetParam();
-  TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
+DATASET_CARDINALITY_TEST_P(PaddedBatchDatasetOpTest, PaddedBatchDatasetParams,
+                           CardinalityTestCases())
 
-  std::unique_ptr<OpKernel> padded_batch_dataset_kernel;
-  TF_ASSERT_OK(CreatePaddedBatchDatasetKernel(
-      test_case.parallel_copy, test_case.n, test_case.expected_output_dtypes,
-      test_case.expected_output_shapes, &padded_batch_dataset_kernel));
-
-  Tensor concatenate_dataset_tensor(DT_VARIANT, TensorShape({}));
-  TF_ASSERT_OK(CreateConcatenateDatasetTensor(
-      test_case.input_tensors, test_case.concatenate_output_dtypes,
-      test_case.concatenate_output_shapes, &concatenate_dataset_tensor));
-  Tensor batch_size = test_case.batch_size;
-  std::vector<Tensor> padded_shapes = test_case.padded_shapes;
-  std::vector<Tensor> padding_values = test_case.padding_values;
-  Tensor drop_remainder = test_case.drop_remainder;
-  gtl::InlinedVector<TensorValue, 4> inputs(
-      {TensorValue(&concatenate_dataset_tensor), TensorValue(&batch_size)});
-  for (auto &padded_shape : padded_shapes) {
-    inputs.emplace_back(&padded_shape);
-  }
-  for (auto &padding_value : padding_values) {
-    inputs.emplace_back(&padding_value);
-  }
-  inputs.emplace_back(&drop_remainder);
-
-  std::unique_ptr<OpKernelContext> padded_batch_dataset_context;
-  TF_ASSERT_OK(
-      CreatePaddedBatchDatasetContext(padded_batch_dataset_kernel.get(),
-                                      &inputs, &padded_batch_dataset_context));
-  DatasetBase *padded_batch_dataset;
-  TF_ASSERT_OK(CreateDataset(padded_batch_dataset_kernel.get(),
-                             padded_batch_dataset_context.get(),
-                             &padded_batch_dataset));
-  core::ScopedUnref scoped_unref(padded_batch_dataset);
-
-  std::unique_ptr<IteratorContext> iterator_ctx;
-  TF_ASSERT_OK(
-      CreateIteratorContext(padded_batch_dataset_context.get(), &iterator_ctx));
-  std::unique_ptr<IteratorBase> iterator;
-  TF_ASSERT_OK(padded_batch_dataset->MakeIterator(iterator_ctx.get(),
-                                                  "Iterator", &iterator));
-
-  TF_EXPECT_OK(VerifyTypesMatch(iterator->output_dtypes(),
-                                test_case.expected_output_dtypes));
+std::vector<IteratorOutputDtypesTestCase<PaddedBatchDatasetParams>>
+IteratorOutputDtypesTestCases() {
+  return {{/*dataset_params=*/PaddedBatchDatasetParams1(),
+           /*expected_output_dtypes=*/{DT_INT64}},
+          {/*dataset_params=*/PaddedBatchDatasetParams2(),
+           /*expected_output_dtypes=*/{DT_INT64}},
+          {/*dataset_params=*/PaddedBatchDatasetParams3(),
+           /*expected_output_dtypes=*/{DT_INT64}},
+          {/*dataset_params=*/PaddedBatchDatasetParams4(),
+           /*expected_output_dtypes=*/{DT_INT64}},
+          {/*dataset_params=*/PaddedBatchDatasetParams5(),
+           /*expected_output_dtypes=*/{DT_INT64}},
+          {/*dataset_params=*/PaddedBatchDatasetParams6(),
+           /*expected_output_dtypes=*/{DT_INT64}},
+          {/*dataset_params=*/PaddedBatchDatasetParams7(),
+           /*expected_output_dtypes=*/{DT_INT64}}};
 }
 
-TEST_P(ParameterizedPaddedBatchDatasetOpTest, IteratorOutputShapes) {
-  int thread_num = 2, cpu_num = 2;
-  const TestCase &test_case = GetParam();
-  TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
+ITERATOR_OUTPUT_DTYPES_TEST_P(PaddedBatchDatasetOpTest,
+                              PaddedBatchDatasetParams,
+                              IteratorOutputDtypesTestCases())
 
-  std::unique_ptr<OpKernel> padded_batch_dataset_kernel;
-  TF_ASSERT_OK(CreatePaddedBatchDatasetKernel(
-      test_case.parallel_copy, test_case.n, test_case.expected_output_dtypes,
-      test_case.expected_output_shapes, &padded_batch_dataset_kernel));
-
-  Tensor concatenate_dataset_tensor(DT_VARIANT, TensorShape({}));
-  TF_ASSERT_OK(CreateConcatenateDatasetTensor(
-      test_case.input_tensors, test_case.concatenate_output_dtypes,
-      test_case.concatenate_output_shapes, &concatenate_dataset_tensor));
-  Tensor batch_size = test_case.batch_size;
-  std::vector<Tensor> padded_shapes = test_case.padded_shapes;
-  std::vector<Tensor> padding_values = test_case.padding_values;
-  Tensor drop_remainder = test_case.drop_remainder;
-  gtl::InlinedVector<TensorValue, 4> inputs(
-      {TensorValue(&concatenate_dataset_tensor), TensorValue(&batch_size)});
-  for (auto &padded_shape : padded_shapes) {
-    inputs.emplace_back(&padded_shape);
-  }
-  for (auto &padding_value : padding_values) {
-    inputs.emplace_back(&padding_value);
-  }
-  inputs.emplace_back(&drop_remainder);
-
-  std::unique_ptr<OpKernelContext> padded_batch_dataset_context;
-  TF_ASSERT_OK(
-      CreatePaddedBatchDatasetContext(padded_batch_dataset_kernel.get(),
-                                      &inputs, &padded_batch_dataset_context));
-  DatasetBase *padded_batch_dataset;
-  TF_ASSERT_OK(CreateDataset(padded_batch_dataset_kernel.get(),
-                             padded_batch_dataset_context.get(),
-                             &padded_batch_dataset));
-  core::ScopedUnref scoped_unref(padded_batch_dataset);
-
-  std::unique_ptr<IteratorContext> iterator_ctx;
-  TF_ASSERT_OK(
-      CreateIteratorContext(padded_batch_dataset_context.get(), &iterator_ctx));
-  std::unique_ptr<IteratorBase> iterator;
-  TF_ASSERT_OK(padded_batch_dataset->MakeIterator(iterator_ctx.get(),
-                                                  "Iterator", &iterator));
-
-  TF_EXPECT_OK(VerifyShapesCompatible(iterator->output_shapes(),
-                                      test_case.expected_output_shapes));
+std::vector<IteratorOutputShapesTestCase<PaddedBatchDatasetParams>>
+IteratorOutputShapesTestCases() {
+  return {{/*dataset_params=*/PaddedBatchDatasetParams1(),
+           /*expected_output_shapes=*/{PartialTensorShape({2, 3})}},
+          {/*dataset_params=*/PaddedBatchDatasetParams2(),
+           /*expected_output_shapes=*/{PartialTensorShape({2, 3})}},
+          {/*dataset_params=*/PaddedBatchDatasetParams3(),
+           /*expected_output_shapes=*/{PartialTensorShape({-1, 3})}},
+          {/*dataset_params=*/PaddedBatchDatasetParams4(),
+           /*expected_output_shapes=*/{PartialTensorShape({-1, 3})}},
+          {/*dataset_params=*/PaddedBatchDatasetParams5(),
+           /*expected_output_shapes=*/{PartialTensorShape({-1, -1})}},
+          {/*dataset_params=*/PaddedBatchDatasetParams6(),
+           /*expected_output_shapes=*/{PartialTensorShape({-1, -1})}},
+          {/*dataset_params=*/PaddedBatchDatasetParams7(),
+           /*expected_output_shapes=*/{PartialTensorShape({-1, -1})}}};
 }
 
-TEST_F(PaddedBatchDatasetOpTest, IteratorOutputPrefix) {
-  int thread_num = 2, cpu_num = 2;
-  const TestCase &test_case = TestCase1();
-  TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
+ITERATOR_OUTPUT_SHAPES_TEST_P(PaddedBatchDatasetOpTest,
+                              PaddedBatchDatasetParams,
+                              IteratorOutputShapesTestCases())
 
-  std::unique_ptr<OpKernel> padded_batch_dataset_kernel;
-  TF_ASSERT_OK(CreatePaddedBatchDatasetKernel(
-      test_case.parallel_copy, test_case.n, test_case.expected_output_dtypes,
-      test_case.expected_output_shapes, &padded_batch_dataset_kernel));
-
-  Tensor concatenate_dataset_tensor(DT_VARIANT, TensorShape({}));
-  TF_ASSERT_OK(CreateConcatenateDatasetTensor(
-      test_case.input_tensors, test_case.concatenate_output_dtypes,
-      test_case.concatenate_output_shapes, &concatenate_dataset_tensor));
-  Tensor batch_size = test_case.batch_size;
-  std::vector<Tensor> padded_shapes = test_case.padded_shapes;
-  std::vector<Tensor> padding_values = test_case.padding_values;
-  Tensor drop_remainder = test_case.drop_remainder;
-  gtl::InlinedVector<TensorValue, 4> inputs(
-      {TensorValue(&concatenate_dataset_tensor), TensorValue(&batch_size)});
-  for (auto &padded_shape : padded_shapes) {
-    inputs.emplace_back(&padded_shape);
-  }
-  for (auto &padding_value : padding_values) {
-    inputs.emplace_back(&padding_value);
-  }
-  inputs.emplace_back(&drop_remainder);
-
-  std::unique_ptr<OpKernelContext> padded_batch_dataset_context;
-  TF_ASSERT_OK(
-      CreatePaddedBatchDatasetContext(padded_batch_dataset_kernel.get(),
-                                      &inputs, &padded_batch_dataset_context));
-  DatasetBase *padded_batch_dataset;
-  TF_ASSERT_OK(CreateDataset(padded_batch_dataset_kernel.get(),
-                             padded_batch_dataset_context.get(),
-                             &padded_batch_dataset));
-  core::ScopedUnref scoped_unref(padded_batch_dataset);
-
-  std::unique_ptr<IteratorContext> iterator_ctx;
-  TF_ASSERT_OK(
-      CreateIteratorContext(padded_batch_dataset_context.get(), &iterator_ctx));
-  std::unique_ptr<IteratorBase> iterator;
-  TF_ASSERT_OK(padded_batch_dataset->MakeIterator(iterator_ctx.get(),
-                                                  "Iterator", &iterator));
+TEST_F(PaddedBatchDatasetOpTest, IteratorPrefix) {
+  auto dataset_params = PaddedBatchDatasetParams1();
+  TF_ASSERT_OK(Initialize(dataset_params));
   name_utils::IteratorPrefixParams params;
-  params.op_version = kOpVersion;
-  EXPECT_EQ(iterator->prefix(),
-            name_utils::IteratorPrefix(PaddedBatchDatasetOp::kDatasetType,
-                                       "Iterator", params));
+  params.op_version = dataset_params.op_version();
+  TF_ASSERT_OK(CheckIteratorPrefix(
+      name_utils::IteratorPrefix(PaddedBatchDatasetOp::kDatasetType,
+                                 dataset_params.iterator_prefix(), params)));
 }
 
-TEST_P(ParameterizedPaddedBatchDatasetOpTest, Roundtrip) {
-  int thread_num = 2, cpu_num = 2;
-  const TestCase &test_case = GetParam();
-  TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
-
-  std::unique_ptr<OpKernel> padded_batch_dataset_kernel;
-  TF_ASSERT_OK(CreatePaddedBatchDatasetKernel(
-      test_case.parallel_copy, test_case.n, test_case.expected_output_dtypes,
-      test_case.expected_output_shapes, &padded_batch_dataset_kernel));
-
-  Tensor concatenate_dataset_tensor(DT_VARIANT, TensorShape({}));
-  TF_ASSERT_OK(CreateConcatenateDatasetTensor(
-      test_case.input_tensors, test_case.concatenate_output_dtypes,
-      test_case.concatenate_output_shapes, &concatenate_dataset_tensor));
-  Tensor batch_size = test_case.batch_size;
-  std::vector<Tensor> padded_shapes = test_case.padded_shapes;
-  std::vector<Tensor> padding_values = test_case.padding_values;
-  Tensor drop_remainder = test_case.drop_remainder;
-  gtl::InlinedVector<TensorValue, 4> inputs(
-      {TensorValue(&concatenate_dataset_tensor), TensorValue(&batch_size)});
-  for (auto &padded_shape : padded_shapes) {
-    inputs.emplace_back(&padded_shape);
-  }
-  for (auto &padding_value : padding_values) {
-    inputs.emplace_back(&padding_value);
-  }
-  inputs.emplace_back(&drop_remainder);
-
-  std::unique_ptr<OpKernelContext> padded_batch_dataset_context;
-  TF_ASSERT_OK(
-      CreatePaddedBatchDatasetContext(padded_batch_dataset_kernel.get(),
-                                      &inputs, &padded_batch_dataset_context));
-  DatasetBase *padded_batch_dataset;
-  TF_ASSERT_OK(CreateDataset(padded_batch_dataset_kernel.get(),
-                             padded_batch_dataset_context.get(),
-                             &padded_batch_dataset));
-  core::ScopedUnref scoped_unref(padded_batch_dataset);
-
-  std::unique_ptr<IteratorContext> iterator_ctx;
-  TF_ASSERT_OK(
-      CreateIteratorContext(padded_batch_dataset_context.get(), &iterator_ctx));
-  std::unique_ptr<IteratorBase> iterator;
-  TF_ASSERT_OK(padded_batch_dataset->MakeIterator(iterator_ctx.get(),
-                                                  "Iterator", &iterator));
-
-  std::unique_ptr<SerializationContext> serialization_ctx;
-  TF_ASSERT_OK(CreateSerializationContext(&serialization_ctx));
-
-  bool end_of_sequence = false;
-  std::vector<Tensor> out_tensors;
-  int cur_iteration = 0;
-  const std::vector<int> &breakpoints = test_case.breakpoints;
-  for (int breakpoint : breakpoints) {
-    VariantTensorData data;
-    VariantTensorDataWriter writer(&data);
-    TF_EXPECT_OK(iterator->Save(serialization_ctx.get(), &writer));
-    TF_EXPECT_OK(writer.Flush());
-    VariantTensorDataReader reader(&data);
-    TF_EXPECT_OK(RestoreIterator(iterator_ctx.get(), &reader, "Iterator",
-                                 *padded_batch_dataset, &iterator));
-
-    while (cur_iteration <= breakpoint) {
-      std::vector<Tensor> next;
-      TF_EXPECT_OK(
-          iterator->GetNext(iterator_ctx.get(), &next, &end_of_sequence));
-      out_tensors.insert(out_tensors.end(), next.begin(), next.end());
-      cur_iteration++;
-    }
-  }
-
-  TF_EXPECT_OK(ExpectEqual(out_tensors, test_case.expected_outputs,
-                           /*compare_order*/ true));
+std::vector<IteratorSaveAndRestoreTestCase<PaddedBatchDatasetParams>>
+IteratorSaveAndRestoreTestCases() {
+  return {{/*dataset_params=*/PaddedBatchDatasetParams1(),
+           /*breakpoints=*/{0, 2, 5},
+           /*expected_outputs=*/
+           CreateTensors<int64>(
+               TensorShape{2, 3},
+               {{0, 1, 1, 2, 3, 1}, {4, 5, 1, 6, 7, 1}, {8, 9, 1, 10, 11, 1}})},
+          {/*dataset_params=*/PaddedBatchDatasetParams2(),
+           /*breakpoints=*/{0, 2, 5},
+           /*expected_outputs=*/
+           CreateTensors<int64>(
+               TensorShape{2, 3},
+               {{0, 1, 1, 2, 3, 1}, {4, 5, 1, 6, 1, 1}, {7, 1, 1, 8, 1, 1}})},
+          {/*dataset_params=*/PaddedBatchDatasetParams3(),
+           /*breakpoints=*/{0, 2, 5},
+           /*expected_outputs=*/
+           {CreateTensor<int64>(TensorShape{2, 3}, {0, 1, 1, 2, 3, 1}),
+            CreateTensor<int64>(TensorShape{2, 3}, {4, 5, 1, 6, 1, 1}),
+            CreateTensor<int64>(TensorShape{2, 3}, {7, 1, 1, 8, 1, 1}),
+            CreateTensor<int64>(TensorShape{1, 3}, {9, 1, 1})}},
+          {/*dataset_params=*/PaddedBatchDatasetParams4(),
+           /*breakpoints=*/{0, 2, 5},
+           /*expected_outputs=*/
+           CreateTensors<int64>(
+               TensorShape{2, 3},
+               {{0, 1, 1, 2, 3, 1}, {4, 5, 1, 6, 1, 1}, {7, 1, 1, 8, 1, 1}})},
+          {/*dataset_params=*/PaddedBatchDatasetParams5(),
+           /*breakpoints=*/{0, 2, 5},
+           /*expected_outputs=*/
+           {CreateTensor<int64>(TensorShape{2, 2}, {0, 1, 2, 3}),
+            CreateTensor<int64>(TensorShape{2, 2}, {4, 5, 6, 1}),
+            CreateTensor<int64>(TensorShape{2, 1}, {7, 8}),
+            CreateTensor<int64>(TensorShape{1, 1}, {9})}},
+          {/*dataset_params=*/PaddedBatchDatasetParams6(),
+           /*breakpoints=*/{0, 2, 5},
+           /*expected_outputs=*/
+           {CreateTensor<int64>(TensorShape{2, 2}, {0, 1, 2, 3}),
+            CreateTensor<int64>(TensorShape{2, 2}, {4, 5, 6, 1}),
+            CreateTensor<int64>(TensorShape{2, 1}, {7, 8}),
+            CreateTensor<int64>(TensorShape{1, 1}, {9})}},
+          {/*dataset_params=*/PaddedBatchDatasetParams7(),
+           /*breakpoints=*/{0, 2, 5},
+           /*expected_outputs=*/{}}};
 }
 
-INSTANTIATE_TEST_SUITE_P(PaddedBatchDatasetOpTest,
-                         ParameterizedPaddedBatchDatasetOpTest,
-                         ::testing::ValuesIn(std::vector<TestCase>(
-                             {TestCase1(), TestCase2(), TestCase3(),
-                              TestCase4(), TestCase5(), TestCase6(),
-                              TestCase7()})));
+ITERATOR_SAVE_AND_RESTORE_TEST_P(PaddedBatchDatasetOpTest,
+                                 PaddedBatchDatasetParams,
+                                 IteratorSaveAndRestoreTestCases())
 
 TEST_F(PaddedBatchDatasetOpTest, ShortPadding) {
-  int thread_num = 2, cpu_num = 2;
-  TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
-
-  TestCase test_case = ShortPaddingTestCase();
-  std::unique_ptr<OpKernel> padded_batch_dataset_kernel;
-  TF_ASSERT_OK(CreatePaddedBatchDatasetKernel(
-      test_case.parallel_copy, test_case.n, test_case.expected_output_dtypes,
-      test_case.expected_output_shapes, &padded_batch_dataset_kernel));
-
-  Tensor concatenate_dataset_tensor(DT_VARIANT, TensorShape({}));
-  TF_ASSERT_OK(CreateConcatenateDatasetTensor(
-      test_case.input_tensors, test_case.concatenate_output_dtypes,
-      test_case.concatenate_output_shapes, &concatenate_dataset_tensor));
-  Tensor batch_size = test_case.batch_size;
-  std::vector<Tensor> padded_shapes = test_case.padded_shapes;
-  std::vector<Tensor> padding_values = test_case.padding_values;
-  Tensor drop_remainder = test_case.drop_remainder;
-  gtl::InlinedVector<TensorValue, 4> inputs(
-      {TensorValue(&concatenate_dataset_tensor), TensorValue(&batch_size)});
-  for (auto &padded_shape : padded_shapes) {
-    inputs.emplace_back(&padded_shape);
-  }
-  for (auto &padding_value : padding_values) {
-    inputs.emplace_back(&padding_value);
-  }
-  inputs.emplace_back(&drop_remainder);
-
-  std::unique_ptr<OpKernelContext> padded_batch_dataset_context;
-  TF_ASSERT_OK(
-      CreatePaddedBatchDatasetContext(padded_batch_dataset_kernel.get(),
-                                      &inputs, &padded_batch_dataset_context));
-  DatasetBase *padded_batch_dataset;
-  TF_ASSERT_OK(CreateDataset(padded_batch_dataset_kernel.get(),
-                             padded_batch_dataset_context.get(),
-                             &padded_batch_dataset));
-  core::ScopedUnref scoped_unref(padded_batch_dataset);
-
-  std::unique_ptr<IteratorContext> iterator_ctx;
-  TF_ASSERT_OK(
-      CreateIteratorContext(padded_batch_dataset_context.get(), &iterator_ctx));
-  std::unique_ptr<IteratorBase> iterator;
-  TF_ASSERT_OK(padded_batch_dataset->MakeIterator(iterator_ctx.get(),
-                                                  "Iterator", &iterator));
+  auto dataset_params = PaddedBatchDatasetParamsWithShortPaddingShape();
+  TF_ASSERT_OK(Initialize(dataset_params));
   bool end_of_sequence = false;
   std::vector<Tensor> out_tensors;
   EXPECT_EQ(
-      iterator->GetNext(iterator_ctx.get(), &out_tensors, &end_of_sequence)
+      iterator_->GetNext(iterator_ctx_.get(), &out_tensors, &end_of_sequence)
           .code(),
       tensorflow::error::DATA_LOSS);
 }
 
 TEST_F(PaddedBatchDatasetOpTest, InvalidPaddedShapes) {
-  int thread_num = 2, cpu_num = 2;
-  TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
-
-  TestCase test_case = InvalidPaddingShapesTestCase();
-  std::unique_ptr<OpKernel> padded_batch_dataset_kernel;
-  TF_ASSERT_OK(CreatePaddedBatchDatasetKernel(
-      test_case.parallel_copy, test_case.n, test_case.expected_output_dtypes,
-      test_case.expected_output_shapes, &padded_batch_dataset_kernel));
-
-  Tensor concatenate_dataset_tensor(DT_VARIANT, TensorShape({}));
-  TF_ASSERT_OK(CreateConcatenateDatasetTensor(
-      test_case.input_tensors, test_case.concatenate_output_dtypes,
-      test_case.concatenate_output_shapes, &concatenate_dataset_tensor));
-  Tensor batch_size = test_case.batch_size;
-  std::vector<Tensor> padded_shapes = test_case.padded_shapes;
-  std::vector<Tensor> padding_values = test_case.padding_values;
-  Tensor drop_remainder = test_case.drop_remainder;
-  gtl::InlinedVector<TensorValue, 4> inputs(
-      {TensorValue(&concatenate_dataset_tensor), TensorValue(&batch_size)});
-  for (auto &padded_shape : padded_shapes) {
-    inputs.emplace_back(&padded_shape);
-  }
-  for (auto &padding_value : padding_values) {
-    inputs.emplace_back(&padding_value);
-  }
-  inputs.emplace_back(&drop_remainder);
-
-  std::unique_ptr<OpKernelContext> padded_batch_dataset_context;
-  TF_ASSERT_OK(
-      CreatePaddedBatchDatasetContext(padded_batch_dataset_kernel.get(),
-                                      &inputs, &padded_batch_dataset_context));
-  DatasetBase *padded_batch_dataset;
-  TF_ASSERT_OK(CreateDataset(padded_batch_dataset_kernel.get(),
-                             padded_batch_dataset_context.get(),
-                             &padded_batch_dataset));
-  core::ScopedUnref scoped_unref(padded_batch_dataset);
-
-  std::unique_ptr<IteratorContext> iterator_ctx;
-  TF_ASSERT_OK(
-      CreateIteratorContext(padded_batch_dataset_context.get(), &iterator_ctx));
-  std::unique_ptr<IteratorBase> iterator;
-  TF_ASSERT_OK(padded_batch_dataset->MakeIterator(iterator_ctx.get(),
-                                                  "Iterator", &iterator));
+  auto dataset_params = PaddedBatchDatasetParamsWithInvalidPaddingShape();
+  TF_ASSERT_OK(Initialize(dataset_params));
   bool end_of_sequence = false;
   std::vector<Tensor> out_tensors;
   EXPECT_EQ(
-      iterator->GetNext(iterator_ctx.get(), &out_tensors, &end_of_sequence)
+      iterator_->GetNext(iterator_ctx_.get(), &out_tensors, &end_of_sequence)
           .code(),
       tensorflow::error::INVALID_ARGUMENT);
 }
 
-TEST_F(PaddedBatchDatasetOpTest, InvalidArguments) {
-  int thread_num = 2, cpu_num = 2;
-  TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
+class ParameterizedInvalidArgumentTest
+    : public PaddedBatchDatasetOpTest,
+      public ::testing::WithParamInterface<PaddedBatchDatasetParams> {};
 
-  std::vector<TestCase> test_cases = {
-      InvalidBatchSizeTestCase(), InvalidPaddedShapesSizeTestCase(),
-      InvalidPaddedValuesSizeTestCase(), InvalidPaddedValuesDTypeTestCase(),
-      InvalidPaddedValuesShapeTestCase()};
-  for (const TestCase &test_case : test_cases) {
-    std::unique_ptr<OpKernel> padded_batch_dataset_kernel;
-    TF_ASSERT_OK(CreatePaddedBatchDatasetKernel(
-        test_case.parallel_copy, test_case.n, test_case.expected_output_dtypes,
-        test_case.expected_output_shapes, &padded_batch_dataset_kernel));
-
-    Tensor concatenate_dataset_tensor(DT_VARIANT, TensorShape({}));
-    TF_ASSERT_OK(CreateConcatenateDatasetTensor(
-        test_case.input_tensors, test_case.concatenate_output_dtypes,
-        test_case.concatenate_output_shapes, &concatenate_dataset_tensor));
-    Tensor batch_size = test_case.batch_size;
-    std::vector<Tensor> padded_shapes = test_case.padded_shapes;
-    std::vector<Tensor> padding_values = test_case.padding_values;
-    Tensor drop_remainder = test_case.drop_remainder;
-    gtl::InlinedVector<TensorValue, 4> inputs(
-        {TensorValue(&concatenate_dataset_tensor), TensorValue(&batch_size)});
-    for (auto &padded_shape : padded_shapes) {
-      inputs.emplace_back(&padded_shape);
-    }
-    for (auto &padding_value : padding_values) {
-      inputs.emplace_back(&padding_value);
-    }
-    inputs.emplace_back(&drop_remainder);
-
-    std::unique_ptr<OpKernelContext> padded_batch_dataset_context;
-    TF_ASSERT_OK(CreatePaddedBatchDatasetContext(
-        padded_batch_dataset_kernel.get(), &inputs,
-        &padded_batch_dataset_context));
-    DatasetBase *padded_batch_dataset;
-    EXPECT_EQ(
-        CreateDataset(padded_batch_dataset_kernel.get(),
-                      padded_batch_dataset_context.get(), &padded_batch_dataset)
-            .code(),
-        tensorflow::error::INVALID_ARGUMENT);
-  }
+TEST_P(ParameterizedInvalidArgumentTest, InvalidPredicateFunc) {
+  auto dataset_params = GetParam();
+  EXPECT_EQ(Initialize(dataset_params).code(),
+            tensorflow::error::INVALID_ARGUMENT);
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    PaddedBatchDatasetOpTest, ParameterizedInvalidArgumentTest,
+    ::testing::ValuesIn(
+        {PaddedBatchDatasetParamsWithInvalidBatchSize(),
+         PaddedBatchDatasetParamsWithInvalidPaddingShapesSize(),
+         PaddedBatchDatasetParamsWithInvalidPaddingValuesSize(),
+         PaddedBatchDatasetParamsWithInvalidPaddingValuesDType(),
+         PaddedBatchDatasetParamsWithInvalidPaddingValuesShape()}));
 
 }  // namespace
 }  // namespace data

--- a/tensorflow/core/kernels/data/tensor_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/tensor_dataset_op_test.cc
@@ -46,7 +46,7 @@ class TensorDatasetParams : public DatasetParams {
     return Status::OK();
   }
 
-  string op_name() const override { return TensorDatasetOp::kDatasetType; }
+  string dataset_type() const override { return TensorDatasetOp::kDatasetType; }
 
  private:
   DataTypeVector TensorDtypes(const std::vector<Tensor>& input_components) {


### PR DESCRIPTION
This PR 
- cleans up `DatasetParams` a little bit 
  - `op_name()` -> `dataset_type()`; 
  - remove `CreateFactory()`
- refactors `InterleaveDatasetOpTest`, `MapDefunOpTest`, `OptimizeDatasetOpTest`, and `PaddedBatchDatasetOpTest`.