### PR TITLE
MKL DNN: Fix issues with hadoopFileSystem load error message

### DIFF
--- a/tensorflow/core/platform/hadoop/hadoop_file_system.cc
+++ b/tensorflow/core/platform/hadoop/hadoop_file_system.cc
@@ -128,9 +128,6 @@ class LibHDFS {
     // Try to load the library dynamically in case it has been installed
     // to a in non-standard location.
     status_ = TryLoadAndBind(kLibHdfsDso, &handle_);
-    if (!status_.ok()) {
-      LOG(ERROR) << "HadoopFileSystem load error: " << status_.error_message();
-    }
   }
 
   Status status_;


### PR DESCRIPTION
If Hadoop File system is not installed, still TF tries to load it. However, if cannot load it, then it emits error message. 
Here in this PR, the error message is removed, since the loading is tried speculatively and, thus, if fails to load, it should not emit any error message.