### PR TITLE
Remove unneeded Kineis dependency libraries

### DIFF
--- a/third_party/aws/BUILD.bazel
+++ b/third_party/aws/BUILD.bazel
@@ -52,8 +52,6 @@ cc_library(
         "aws-cpp-sdk-core/source/utils/xml/**/*.cpp",
         "aws-cpp-sdk-core/source/utils/crypto/*.cpp",
         "aws-cpp-sdk-core/source/utils/crypto/factory/**/*.cpp",
-        "aws-cpp-sdk-kinesis/include/**/*.h",
-        "aws-cpp-sdk-kinesis/source/**/*.cpp",
         "aws-cpp-sdk-s3/include/**/*.h",
         "aws-cpp-sdk-s3/source/**/*.cpp",
     ]),
@@ -90,7 +88,6 @@ cc_library(
     }),
     includes = [
         "aws-cpp-sdk-core/include/",
-        "aws-cpp-sdk-kinesis/include/",
         "aws-cpp-sdk-s3/include/",
     ],
     deps = [


### PR DESCRIPTION
In TensorFlow 1.x Kinesis used to be in tf.contrib. Now as
tf.contrib has been moved out it makes sense to remove Kinesis
form the dependency libraries in aws/BUILD, to reduce build time with C++ (slightly)
Note AWS itself is still very much needed as s3 is still supported

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>