### PR TITLE
Update the docstring of tf.strings.substr to cover negative len case

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_Substr.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_Substr.pbtxt
@@ -40,9 +40,7 @@ For each string in the input `Tensor`, creates a substring starting at index
 `pos` with a total length of `len`.
 
 If `len` defines a substring that would extend beyond the length of the input
-string, then as many characters as possible are used.
-
-A negative `len` indicates all characters until the end of the string.
+string, or if `len` is negative, then as many characters as possible are used.
 
 A negative `pos` indicates distance within the string backwards from the end.
 

--- a/tensorflow/core/api_def/base_api/api_def_Substr.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_Substr.pbtxt
@@ -42,6 +42,8 @@ For each string in the input `Tensor`, creates a substring starting at index
 If `len` defines a substring that would extend beyond the length of the input
 string, then as many characters as possible are used.
 
+A negative `len` indicates all characters until the end of the string.
+
 A negative `pos` indicates distance within the string backwards from the end.
 
 If `pos` specifies an index which is out of range for any of the input strings,


### PR DESCRIPTION
While using tf.strings.substr, initially I wasn't sure if negative `len` will be recognized.
The docstring does not mention this situation (normally it should, just like most of
the languages)

Verifired  that `tf.strings.substr` indeed recognizes negative `len` so believe it makes
sense to update the docstring to cover this scenario.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>