### PR TITLE
fix msvc 16.3.0 + cuda 10.1.243 build break

### DIFF
--- a/tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc
@@ -64,7 +64,7 @@ struct LeftUpdate<std::complex<T>, scatter_nd_op::UpdateOp::ADD> {
       std::complex<T>* out, const std::complex<T>& val) {
     T* ptr = reinterpret_cast<T*>(out);
     GpuAtomicAdd(ptr, val.real());
-    GpuAtomicAdd(ptr, val.imag());
+    GpuAtomicAdd(ptr + 1, val.imag());
   }
 };
 
@@ -73,8 +73,8 @@ struct LeftUpdate<std::complex<T>, scatter_nd_op::UpdateOp::SUB> {
   EIGEN_STRONG_INLINE EIGEN_DEVICE_FUNC void operator()(
       std::complex<T>* out, const std::complex<T>& val) {
     T* ptr = reinterpret_cast<T*>(out);
-    GpuAtomicAdd(ptr, -val.real());
-    GpuAtomicAdd(ptr, -val.imag());
+    GpuAtomicSub(ptr, val.real());
+    GpuAtomicSub(ptr + 1, val.imag());
   }
 };
 

--- a/tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc
@@ -72,7 +72,9 @@ template <typename T>
 struct LeftUpdate<std::complex<T>, scatter_nd_op::UpdateOp::SUB> {
   EIGEN_STRONG_INLINE EIGEN_DEVICE_FUNC void operator()(
       std::complex<T>* out, const std::complex<T>& val) {
-    LeftUpdate<std::complex<T>, scatter_nd_op::UpdateOp::ADD>()(out, -val);
+    T* ptr = reinterpret_cast<T*>(out);
+    GpuAtomicAdd(ptr, -val.real());
+    GpuAtomicAdd(ptr, -val.imag());
   }
 };
 


### PR DESCRIPTION
**System information**
- OS Platform and Distribution (e.g., Linux Ubuntu 16.04): Windows 10
- TensorFlow installed from (source or binary): source
- TensorFlow version: v2.0.0
- Python version: 3.7.3
- Bazel version (if compiling from source): 0.26.1
- GCC/Compiler version (if compiling from source): msvc 16.3.0
- CUDA/cuDNN version: 10.1.243 / 7.6.4.38
- GPU model and memory: NVIDIA GeForce RTX 2080 TI 11GB / driver 426.00

**Any other info / logs**
```
tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: calling a __host__ function("std::operator -<float> ") from a __global__ function("tensorflow::ScatterNdOpKernel<    ::std::complex<float> , int, ( ::tensorflow::scatter_nd_op::UpdateOp)2, (int)1> ") is not allowed

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: identifier "std::operator -<float> " is undefined in device code

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: calling a __host__ function("std::operator -<float> ") from a __global__ function("tensorflow::ScatterNdOpKernel<    ::std::complex<float> , int, ( ::tensorflow::scatter_nd_op::UpdateOp)2, (int)2> ") is not allowed

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: identifier "std::operator -<float> " is undefined in device code

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: calling a __host__ function("std::operator -<float> ") from a __global__ function("tensorflow::ScatterNdOpKernel<    ::std::complex<float> , int, ( ::tensorflow::scatter_nd_op::UpdateOp)2, (int)3> ") is not allowed

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: identifier "std::operator -<float> " is undefined in device code

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: calling a __host__ function("std::operator -<float> ") from a __global__ function("tensorflow::ScatterNdOpKernel<    ::std::complex<float> , int, ( ::tensorflow::scatter_nd_op::UpdateOp)2, (int)4> ") is not allowed

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: identifier "std::operator -<float> " is undefined in device code

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: calling a __host__ function("std::operator -<float> ") from a __global__ function("tensorflow::ScatterNdOpKernel<    ::std::complex<float> , int, ( ::tensorflow::scatter_nd_op::UpdateOp)2, (int)5> ") is not allowed

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: identifier "std::operator -<float> " is undefined in device code

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: calling a __host__ function("std::operator -<float> ") from a __global__ function("tensorflow::ScatterNdOpKernel<    ::std::complex<float> , int, ( ::tensorflow::scatter_nd_op::UpdateOp)2, (int)6> ") is not allowed

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: identifier "std::operator -<float> " is undefined in device code

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: calling a __host__ function("std::operator -<float> ") from a __global__ function("tensorflow::ScatterNdOpKernel<    ::std::complex<float> , int, ( ::tensorflow::scatter_nd_op::UpdateOp)2, (int)7> ") is not allowed

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: identifier "std::operator -<float> " is undefined in device code

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: calling a __host__ function("std::operator -<float> ") from a __global__ function("tensorflow::ScatterNdOpKernel<    ::std::complex<float> , long long, ( ::tensorflow::scatter_nd_op::UpdateOp)2, (int)1> ") is not allowed

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: identifier "std::operator -<float> " is undefined in device code

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: calling a __host__ function("std::operator -<float> ") from a __global__ function("tensorflow::ScatterNdOpKernel<    ::std::complex<float> , long long, ( ::tensorflow::scatter_nd_op::UpdateOp)2, (int)2> ") is not allowed

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: identifier "std::operator -<float> " is undefined in device code

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: calling a __host__ function("std::operator -<float> ") from a __global__ function("tensorflow::ScatterNdOpKernel<    ::std::complex<float> , long long, ( ::tensorflow::scatter_nd_op::UpdateOp)2, (int)3> ") is not allowed

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: identifier "std::operator -<float> " is undefined in device code

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: calling a __host__ function("std::operator -<float> ") from a __global__ function("tensorflow::ScatterNdOpKernel<    ::std::complex<float> , long long, ( ::tensorflow::scatter_nd_op::UpdateOp)2, (int)4> ") is not allowed

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: identifier "std::operator -<float> " is undefined in device code

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: calling a __host__ function("std::operator -<float> ") from a __global__ function("tensorflow::ScatterNdOpKernel<    ::std::complex<float> , long long, ( ::tensorflow::scatter_nd_op::UpdateOp)2, (int)5> ") is not allowed

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: identifier "std::operator -<float> " is undefined in device code

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: calling a __host__ function("std::operator -<float> ") from a __global__ function("tensorflow::ScatterNdOpKernel<    ::std::complex<float> , long long, ( ::tensorflow::scatter_nd_op::UpdateOp)2, (int)6> ") is not allowed

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: identifier "std::operator -<float> " is undefined in device code

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: calling a __host__ function("std::operator -<float> ") from a __global__ function("tensorflow::ScatterNdOpKernel<    ::std::complex<float> , long long, ( ::tensorflow::scatter_nd_op::UpdateOp)2, (int)7> ") is not allowed

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: identifier "std::operator -<float> " is undefined in device code

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: calling a __host__ function("std::operator -<double> ") from a __global__ function("tensorflow::ScatterNdOpKernel<    ::std::complex<double> , int, ( ::tensorflow::scatter_nd_op::UpdateOp)2, (int)1> ") is not allowed

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: identifier "std::operator -<double> " is undefined in device code

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: calling a __host__ function("std::operator -<double> ") from a __global__ function("tensorflow::ScatterNdOpKernel<    ::std::complex<double> , int, ( ::tensorflow::scatter_nd_op::UpdateOp)2, (int)2> ") is not allowed

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: identifier "std::operator -<double> " is undefined in device code

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: calling a __host__ function("std::operator -<double> ") from a __global__ function("tensorflow::ScatterNdOpKernel<    ::std::complex<double> , int, ( ::tensorflow::scatter_nd_op::UpdateOp)2, (int)3> ") is not allowed

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: identifier "std::operator -<double> " is undefined in device code

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: calling a __host__ function("std::operator -<double> ") from a __global__ function("tensorflow::ScatterNdOpKernel<    ::std::complex<double> , int, ( ::tensorflow::scatter_nd_op::UpdateOp)2, (int)4> ") is not allowed

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: identifier "std::operator -<double> " is undefined in device code

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: calling a __host__ function("std::operator -<double> ") from a __global__ function("tensorflow::ScatterNdOpKernel<    ::std::complex<double> , int, ( ::tensorflow::scatter_nd_op::UpdateOp)2, (int)5> ") is not allowed

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: identifier "std::operator -<double> " is undefined in device code

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: calling a __host__ function("std::operator -<double> ") from a __global__ function("tensorflow::ScatterNdOpKernel<    ::std::complex<double> , int, ( ::tensorflow::scatter_nd_op::UpdateOp)2, (int)6> ") is not allowed

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: identifier "std::operator -<double> " is undefined in device code

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: calling a __host__ function("std::operator -<double> ") from a __global__ function("tensorflow::ScatterNdOpKernel<    ::std::complex<double> , int, ( ::tensorflow::scatter_nd_op::UpdateOp)2, (int)7> ") is not allowed

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: identifier "std::operator -<double> " is undefined in device code

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: calling a __host__ function("std::operator -<double> ") from a __global__ function("tensorflow::ScatterNdOpKernel<    ::std::complex<double> , long long, ( ::tensorflow::scatter_nd_op::UpdateOp)2, (int)1> ") is not allowed

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: identifier "std::operator -<double> " is undefined in device code

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: calling a __host__ function("std::operator -<double> ") from a __global__ function("tensorflow::ScatterNdOpKernel<    ::std::complex<double> , long long, ( ::tensorflow::scatter_nd_op::UpdateOp)2, (int)2> ") is not allowed

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: identifier "std::operator -<double> " is undefined in device code

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: calling a __host__ function("std::operator -<double> ") from a __global__ function("tensorflow::ScatterNdOpKernel<    ::std::complex<double> , long long, ( ::tensorflow::scatter_nd_op::UpdateOp)2, (int)3> ") is not allowed

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: identifier "std::operator -<double> " is undefined in device code

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: calling a __host__ function("std::operator -<double> ") from a __global__ function("tensorflow::ScatterNdOpKernel<    ::std::complex<double> , long long, ( ::tensorflow::scatter_nd_op::UpdateOp)2, (int)4> ") is not allowed

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: identifier "std::operator -<double> " is undefined in device code

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: calling a __host__ function("std::operator -<double> ") from a __global__ function("tensorflow::ScatterNdOpKernel<    ::std::complex<double> , long long, ( ::tensorflow::scatter_nd_op::UpdateOp)2, (int)5> ") is not allowed

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: identifier "std::operator -<double> " is undefined in device code

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: calling a __host__ function("std::operator -<double> ") from a __global__ function("tensorflow::ScatterNdOpKernel<    ::std::complex<double> , long long, ( ::tensorflow::scatter_nd_op::UpdateOp)2, (int)6> ") is not allowed

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: identifier "std::operator -<double> " is undefined in device code

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: calling a __host__ function("std::operator -<double> ") from a __global__ function("tensorflow::ScatterNdOpKernel<    ::std::complex<double> , long long, ( ::tensorflow::scatter_nd_op::UpdateOp)2, (int)7> ") is not allowed

tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc(102): error: identifier "std::operator -<double> " is undefined in device code

```