### PR TITLE
Expose tf.keras.CallbackList API

### DIFF
--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -185,6 +185,7 @@ def make_logs(model, logs, outputs, mode, prefix=''):
   return logs
 
 
+@keras_export('keras.callbacks.CallbackList')
 class CallbackList(object):
   """Container abstracting a list of callbacks.
 


### PR DESCRIPTION
Proposing this in reference to https://github.com/tensorflow/tensorflow/pull/23880#issuecomment-514821825. Will this change add "from tensorflow.python.keras.callbacks import CallbackList" to the machine-generated code in "tensorflow/_api/v1/keras/callbacks/init.py" upon building so that it can be imported as in the regular Keras? If not, please let me know what to do. Thanks!