### PR TITLE
[Intel Mkl] Upgrade curl to fix CVE-2019-5481 and CVE-2019-5482

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -502,12 +502,12 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
     tf_http_archive(
         name = "curl",
         build_file = clean_dep("//third_party:curl.BUILD"),
-        sha256 = "4376ac72b95572fb6c4fbffefb97c7ea0dd083e1974c0e44cd7e49396f454839",
-        strip_prefix = "curl-7.65.3",
+        sha256 = "d0393da38ac74ffac67313072d7fe75b1fa1010eb5987f63f349b024a36b7ffb",
+        strip_prefix = "curl-7.66.0",
         system_build_file = clean_dep("//third_party/systemlibs:curl.BUILD"),
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/curl.haxx.se/download/curl-7.65.3.tar.gz",
-            "https://curl.haxx.se/download/curl-7.65.3.tar.gz",
+            "https://storage.googleapis.com/mirror.tensorflow.org/curl.haxx.se/download/curl-7.66.0.tar.gz",
+            "https://curl.haxx.se/download/curl-7.66.0.tar.gz",
         ],
     )
 

--- a/third_party/curl.BUILD
+++ b/third_party/curl.BUILD
@@ -158,6 +158,7 @@ cc_library(
         "lib/pop3.h",
         "lib/progress.c",
         "lib/progress.h",
+        "lib/quic.h",
         "lib/rand.c",
         "lib/rand.h",
         "lib/rtsp.c",


### PR DESCRIPTION
# [CVE-2019-5482](https://nvd.nist.gov/vuln/detail/CVE-2019-5482)

*NVD:* 2019/09/16 - CVSS v2.0 Base Score: 7.5 - CVSS v3.0 Base Score: 0.0
Heap buffer overflow in the TFTP protocol handler in cURL 7.19.4 to 7.65.3.
## References to Advisories, Solutions, and Tools

Source | Link | Type
---- | ---- | ----
SUSE | [lists.opensuse.org](http://lists.opensuse.org/opensuse-security-announce/2019-09/msg00055.html) |  
FEDORA | [lists.fedoraproject.org](https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UA7KDM2WPM5CJDDGOEGFV6SSGD2J7RNT/) |  
SUSE | [lists.opensuse.org](http://lists.opensuse.org/opensuse-security-announce/2019-09/msg00048.html) |  
FEDORA | [lists.fedoraproject.org](https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/RGDVKSLY5JUNJRLYRUA6CXGQ2LM63XC3/) |  
CONFIRM | [curl.haxx.se](https://curl.haxx.se/docs/CVE-2019-5482.html) | Vendor Advisory

# CVE-2019-5481
*NVD:* 2019/09/16 - CVSS v2.0 Base Score: 7.5 - CVSS v3.0 Base Score: 0.0
Double-free vulnerability in the FTP-kerberos code in cURL 7.52.0 to 7.65.3.

## References to Advisories, Solutions, and Tools

Source | Link | Type
---- | ---- | ----
SUSE | [lists.opensuse.org](http://lists.opensuse.org/opensuse-security-announce/2019-09/msg00055.html) |  
FEDORA | [lists.fedoraproject.org](https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UA7KDM2WPM5CJDDGOEGFV6SSGD2J7RNT/) |  
SUSE | [lists.opensuse.org](http://lists.opensuse.org/opensuse-security-announce/2019-09/msg00048.html) |  
FEDORA | [lists.fedoraproject.org](https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/RGDVKSLY5JUNJRLYRUA6CXGQ2LM63XC3/) |  
CONFIRM | [curl.haxx.se](https://curl.haxx.se/docs/CVE-2019-5481.html) | Vendor Advisory

