### PR TITLE
Fix tf.assert_equal issue when one tenor is empty and another is non-empty

### DIFF
--- a/tensorflow/python/kernel_tests/check_ops_test.py
+++ b/tensorflow/python/kernel_tests/check_ops_test.py
@@ -315,6 +315,17 @@ First 2 elements of y:
     else:
       self.assertEqual(check_op.type, "NoOp")
 
+  @test_util.run_in_graph_and_eager_modes
+  def test_raises_when_empty_and_non_equal_shapes(self):
+    value = constant_op.constant([1.0], name="value")
+    empty = constant_op.constant([], name="empty")
+    with self.assertRaisesRegexp(
+        (errors.InvalidArgumentError, ValueError),
+        (r"Condition x == y did not hold")):
+      with ops.control_dependencies([check_ops.assert_equal(value, empty)]):
+        out = array_ops.identity(value)
+      self.evaluate(out)
+
 
 class AssertNoneEqualTest(test.TestCase):
 

--- a/tensorflow/python/ops/check_ops.py
+++ b/tensorflow/python/ops/check_ops.py
@@ -485,8 +485,9 @@ def assert_negative(x, data=None, summarize=None, message=None, name=None):  # p
           'Condition x < 0 did not hold element-wise:',
           'x (%s) = ' % name, x]
     zero = ops.convert_to_tensor(0, dtype=x.dtype)
-    return _binary_assert('<', 'assert_less', math_ops.less, np.less, x, zero, data,
-                        summarize, message=None, name=None, allow_empty=True)
+    return _binary_assert('<', 'assert_less', math_ops.less, np.less,
+                          x, zero, data, summarize,
+                          message=None, name=None, allow_empty=True)
 
 
 @tf_export('debugging.assert_positive', v1=[])
@@ -537,8 +538,9 @@ def assert_positive(x, data=None, summarize=None, message=None, name=None):  # p
           message, 'Condition x > 0 did not hold element-wise:',
           'x (%s) = ' % name, x]
     zero = ops.convert_to_tensor(0, dtype=x.dtype)
-    return _binary_assert('<', 'assert_less', math_ops.less, np.less, zero, x, data,
-                        summarize, message=None, name=None, allow_empty=True)
+    return _binary_assert('<', 'assert_less', math_ops.less, np.less,
+                          zero, x, data, summarize,
+                          message=None, name=None, allow_empty=True)
 
 
 @tf_export('debugging.assert_non_negative', v1=[])
@@ -592,8 +594,10 @@ def assert_non_negative(x, data=None, summarize=None, message=None, name=None): 
           'Condition x >= 0 did not hold element-wise:',
           'x (%s) = ' % name, x]
     zero = ops.convert_to_tensor(0, dtype=x.dtype)
-    return _binary_assert('<=', 'assert_less_equal', math_ops.less_equal,
-                        np.less_equal, zero, x, data, summarize, message=None, name=None, allow_empty=True)
+    return _binary_assert('<=', 'assert_less_equal',
+                          math_ops.less_equal, np.less_equal,
+                          zero, x, data, summarize,
+                          message=None, name=None, allow_empty=True)
 
 
 @tf_export('debugging.assert_non_positive', v1=[])
@@ -647,8 +651,10 @@ def assert_non_positive(x, data=None, summarize=None, message=None, name=None): 
           'Condition x <= 0 did not hold element-wise:'
           'x (%s) = ' % name, x]
     zero = ops.convert_to_tensor(0, dtype=x.dtype)
-    return _binary_assert('<=', 'assert_less_equal', math_ops.less_equal,
-                          np.less_equal, x, zero, data, summarize, message=None, name=None, allow_empty=True)
+    return _binary_assert('<=', 'assert_less_equal',
+                          math_ops.less_equal, np.less_equal,
+                          x, zero, data, summarize,
+                          message=None, name=None, allow_empty=True)
 
 
 @tf_export('debugging.assert_equal', 'assert_equal', v1=[])

--- a/tensorflow/python/ops/check_ops.py
+++ b/tensorflow/python/ops/check_ops.py
@@ -485,7 +485,8 @@ def assert_negative(x, data=None, summarize=None, message=None, name=None):  # p
           'Condition x < 0 did not hold element-wise:',
           'x (%s) = ' % name, x]
     zero = ops.convert_to_tensor(0, dtype=x.dtype)
-    return assert_less(x, zero, data=data, summarize=summarize)
+    return _binary_assert('<', 'assert_less', math_ops.less, np.less, x, zero, data,
+                        summarize, message=None, name=None, allow_empty=True)
 
 
 @tf_export('debugging.assert_positive', v1=[])
@@ -536,7 +537,8 @@ def assert_positive(x, data=None, summarize=None, message=None, name=None):  # p
           message, 'Condition x > 0 did not hold element-wise:',
           'x (%s) = ' % name, x]
     zero = ops.convert_to_tensor(0, dtype=x.dtype)
-    return assert_less(zero, x, data=data, summarize=summarize)
+    return _binary_assert('<', 'assert_less', math_ops.less, np.less, zero, x, data,
+                        summarize, message=None, name=None, allow_empty=True)
 
 
 @tf_export('debugging.assert_non_negative', v1=[])
@@ -590,7 +592,8 @@ def assert_non_negative(x, data=None, summarize=None, message=None, name=None): 
           'Condition x >= 0 did not hold element-wise:',
           'x (%s) = ' % name, x]
     zero = ops.convert_to_tensor(0, dtype=x.dtype)
-    return assert_less_equal(zero, x, data=data, summarize=summarize)
+    return _binary_assert('<=', 'assert_less_equal', math_ops.less_equal,
+                        np.less_equal, zero, x, data, summarize, message=None, name=None, allow_empty=True)
 
 
 @tf_export('debugging.assert_non_positive', v1=[])
@@ -644,7 +647,8 @@ def assert_non_positive(x, data=None, summarize=None, message=None, name=None): 
           'Condition x <= 0 did not hold element-wise:'
           'x (%s) = ' % name, x]
     zero = ops.convert_to_tensor(0, dtype=x.dtype)
-    return assert_less_equal(x, zero, data=data, summarize=summarize)
+    return _binary_assert('<=', 'assert_less_equal', math_ops.less_equal,
+                          np.less_equal, x, zero, data, summarize, message=None, name=None, allow_empty=True)
 
 
 @tf_export('debugging.assert_equal', 'assert_equal', v1=[])

--- a/tensorflow/python/ops/ragged/ragged_array_ops.py
+++ b/tensorflow/python/ops/ragged/ragged_array_ops.py
@@ -619,9 +619,8 @@ def stack_dynamic_partitions(data, partitions, num_partitions, name=None):
       permutation = sort_ops.argsort(partitions, stable=True)
       value_rowids = array_ops.gather(partitions, permutation)
       values = array_ops.gather(data, permutation)
-      check = check_ops.assert_less(
-          value_rowids[-1:],
-          num_partitions,
+      check = check_ops.assert_negative(
+          value_rowids[-1:] - num_partitions,
           message='partitions must be less than num_partitions')
       with ops.control_dependencies([check]):
         return ragged_tensor.RaggedTensor.from_value_rowids(

--- a/tensorflow/python/ops/ragged/ragged_tensor.py
+++ b/tensorflow/python/ops/ragged/ragged_tensor.py
@@ -398,7 +398,7 @@ class RaggedTensor(composite_tensor.CompositeTensor):
             check_ops.assert_equal(nvals1, nvals2, message=msg),
             check_ops.assert_non_negative(value_rowids[:1], message=msg),
             _assert_monotonic_increasing(value_rowids, message=msg),
-            check_ops.assert_less(value_rowids[-1:], nrows, message=msg),
+            check_ops.assert_negative(value_rowids[-1:] - nrows, message=msg),
         ]
         if not isinstance(values, RaggedTensor):
           checks.append(check_ops.assert_rank_at_least(values, 1))


### PR DESCRIPTION
This fix tries to address the issue raised in #32082 where tf.assert_equal([], [1.0]) doesn't raise error.
The reason was that in assert_equal `[1.0]` was broadcasted as `[]` and equal was in place in that situation.

This PR updates the _binary_asesert so that it will check if x, y are both empty or both non-empty. If one is empty and another is non-empty, then assertion throws exception. This change is to not impact other ops that depends on the broadcast behavior.

This fix fixes #32082.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>