### PR TITLE
Fix grad check compatibility

### DIFF
--- a/tensorflow/python/keras/optimizers.py
+++ b/tensorflow/python/keras/optimizers.py
@@ -89,7 +89,7 @@ class Optimizer(object):
           function not implemented).
     """
     grads = K.gradients(loss, params)
-    if None in grads:
+    if any([g is None for g in grads]):
       raise ValueError('An operation has `None` for gradient. '
                        'Please make sure that all of your ops have a '
                        'gradient defined (i.e. are differentiable). '


### PR DESCRIPTION
Current code uses a conflicting check on `grads` during optimizer compilation - the fix addresses it. Below is a minimal reproducible example + full error trace. Full details at [SO question](https://stackoverflow.com/questions/58261348/valueerror-tried-to-convert-y-to-a-tensor-and-failed-error-none-values-not).

<hr>

**DOESN'T WORK**:

```python
from tensorflow.python.keras.layers import Input, Dense
from tensorflow.python.keras.models import Model
from tensorflow.python.keras.optimizers import Nadam
import numpy as np

ipt = Input(shape=(4,))
out = Dense(1, activation='sigmoid')(ipt)

model = Model(ipt, out)
model.compile(optimizer=Nadam(lr=1e-4), loss='binary_crossentropy')

X = np.random.randn(32,4)
Y = np.random.randint(0,2,(32,1))
model.train_on_batch(X,Y)
```

**WORKS**: remove `.python` from above's imports. 

<hr>

**Full error trace:**

```python
  File "<ipython-input-1-2db039c052cf>", line 20, in <module>
    model.train_on_batch(X,Y)
  File "D:\Anaconda\envs\tf2_env\lib\site-packages\tensorflow_core\python\keras\engine\training.py", line 1017, in train_on_batch
    self._make_train_function()
  File "D:\Anaconda\envs\tf2_env\lib\site-packages\tensorflow_core\python\keras\engine\training.py", line 2116, in _make_train_function
    params=self._collected_trainable_weights, loss=self.total_loss)
  File "D:\Anaconda\envs\tf2_env\lib\site-packages\tensorflow_core\python\keras\optimizers.py", line 653, in get_updates
    grads = self.get_gradients(loss, params)
  File "D:\Anaconda\envs\tf2_env\lib\site-packages\tensorflow_core\python\keras\optimizers.py", line 92, in get_gradients
    if None in grads:
  File "D:\Anaconda\envs\tf2_env\lib\site-packages\tensorflow_core\python\ops\math_ops.py", line 1336, in tensor_equals
    return gen_math_ops.equal(self, other)
  File "D:\Anaconda\envs\tf2_env\lib\site-packages\tensorflow_core\python\ops\gen_math_ops.py", line 3626, in equal
    name=name)
  File "D:\Anaconda\envs\tf2_env\lib\site-packages\tensorflow_core\python\framework\op_def_library.py", line 545, in _apply_op_helper
    (input_name, err))
 
ValueError: Tried to convert 'y' to a tensor and failed. Error: None values not supported.
```