### PR TITLE
Resolve undeclared inclusion due to symlinks in nvcc path

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -840,6 +840,9 @@ def set_gcc_host_compiler_path(environ_cp):
       error_msg='Invalid gcc path. %s cannot be found.',
   )
 
+  # Resolve sym-links in paths to match Bazel
+  gcc_host_compiler_path = os.path.realpath(gcc_host_compiler_path)
+  
   write_action_env_to_bazelrc('GCC_HOST_COMPILER_PATH', gcc_host_compiler_path)
 
 


### PR DESCRIPTION
If there is a sym-link in the path that is used for the GCC compiler used by `nvcc` then Bazel resolves it while `configure.py` doesn't.  This results in issues with paths not matching, and errors about undeclared inclusions for header files in that GCC install.

This commit makes `configure.py` resolve any sym-links in the path so that it matches Bazel's behaviour.