### PR TITLE
Use correct casts to get right dimensions on s390x

### DIFF
--- a/tensorflow/core/framework/common_shape_fns.cc
+++ b/tensorflow/core/framework/common_shape_fns.cc
@@ -1571,9 +1571,9 @@ Status ConcatShapeHelper(InferenceContext* c, int start_value_index,
   // shape.
   int64 concat_dim;
   if (concat_dim_t->dtype() == DT_INT32) {
-	  concat_dim = static_cast<int64>(concat_dim_t->flat<int32>()(0));
+    concat_dim = static_cast<int64>(concat_dim_t->flat<int32>()(0));
   } else {
-	  concat_dim = concat_dim_t->flat<int64>()(0);
+    concat_dim = concat_dim_t->flat<int64>()(0);
   }
 
   // Minimum required number of dimensions.

--- a/tensorflow/core/framework/common_shape_fns.cc
+++ b/tensorflow/core/framework/common_shape_fns.cc
@@ -1569,7 +1569,12 @@ Status ConcatShapeHelper(InferenceContext* c, int start_value_index,
 
   // Merge all the non-concat dims, and sum the concat dim to make an output
   // shape.
-  const int32 concat_dim = concat_dim_t->scalar<int32>()();
+  int64 concat_dim;
+  if (concat_dim_t->dtype() == DT_INT32) {
+	  concat_dim = static_cast<int64>(concat_dim_t->flat<int32>()(0));
+  } else {
+	  concat_dim = concat_dim_t->flat<int64>()(0);
+  }
 
   // Minimum required number of dimensions.
   const int min_rank = concat_dim < 0 ? -concat_dim : concat_dim + 1;


### PR DESCRIPTION
The `testConcatAxisType` test in `concat_op_test` is failing on an assertion for s390x (Ref. Issue#[28114](https://github.com/tensorflow/tensorflow/issues/28114)):
```
Traceback (most recent call last):
  File "/root/.cache/bazel/_bazel_root/87c06bad5aec2f21ec96b7253de551e8/execroot/org_tensorflow/bazel-out/s390x-opt/bin/tensorflow/python/kernel_tests/concat_op_test.runfiles/org_tensorflow/tensorflow/python/kernel_tests/concat_op_test.py", line 621, in testConcatAxisType
    self.assertEqual([2, 6], c.get_shape().as_list())
AssertionError: Lists differ: [2, 6] != [4, 3]
```
It turned out that the cast operation was not correct for big-endian architecture and not able to draw right dimension value when the Axis is of int64 type. Updating the cast resolved the issue.