### PR TITLE
define _USE_MATH_DEFINES in hlo_evaluator.cc

### DIFF
--- a/tensorflow/compiler/xla/service/hlo_evaluator.h
+++ b/tensorflow/compiler/xla/service/hlo_evaluator.h
@@ -16,6 +16,8 @@ limitations under the License.
 #ifndef TENSORFLOW_COMPILER_XLA_SERVICE_HLO_EVALUATOR_H_
 #define TENSORFLOW_COMPILER_XLA_SERVICE_HLO_EVALUATOR_H_
 
+#define _USE_MATH_DEFINES
+
 #include <functional>
 #include <memory>
 


### PR DESCRIPTION
MSVC didn't define `M_PI` by default.

define `_USE_MATH_DEFINES` to use `M_PI`

https://docs.microsoft.com/en-us/cpp/c-runtime-library/math-constants

This PR fixed the `hlo_evaluator.cc` build break.