### PR TITLE
Fix the issue for importing googletest.h

### DIFF
--- a/tensorflow/lite/testing/kernel_test/input_generator.h
+++ b/tensorflow/lite/testing/kernel_test/input_generator.h
@@ -18,6 +18,10 @@ limitations under the License.
 #include <memory>
 #include <vector>
 
+#if defined(PLATFORM_GOOGLE) || defined(PLATFORM_GOOGLE_ANDROID)
+#include "testing/base/public/googletest.h"
+#endif
+
 #include "tensorflow/lite/c/c_api_internal.h"
 #include "tensorflow/lite/interpreter.h"
 #include "tensorflow/lite/model.h"
@@ -25,6 +29,23 @@ limitations under the License.
 
 namespace tflite {
 namespace testing {
+
+#if defined(PLATFORM_GOOGLE)
+string TmpDir() { return FLAGS_test_tmpdir; }
+#else
+string TmpDir() {
+  // 'bazel test' sets TEST_TMPDIR
+  const char* env = getenv("TEST_TMPDIR");
+  if (env && env[0] != '\0') {
+    return env;
+  }
+  env = getenv("TMPDIR");
+  if (env && env[0] != '\0') {
+    return env;
+  }
+  return "/tmp";
+}
+#endif
 
 // Generate random input, or read input from a file for kernel diff test.
 // Needs to load the tflite graph to get information like tensor shape and

--- a/tensorflow/lite/testing/kernel_test/input_generator_test.cc
+++ b/tensorflow/lite/testing/kernel_test/input_generator_test.cc
@@ -18,7 +18,6 @@ limitations under the License.
 #include <map>
 
 #include <gmock/gmock.h>
-#include "testing/base/public/googletest.h"
 #include <gtest/gtest.h>
 
 namespace tflite {
@@ -47,7 +46,7 @@ TEST(InputGeneratorTest, ReadWriteSimpleFile) {
   inputs.push_back(content);
   ASSERT_EQ(input_generator.GetInputs(), inputs);
 
-  auto output_filename = FLAGS_test_tmpdir + "/out.csv";
+  auto output_filename = TmpDir() + "/out.csv";
   ASSERT_EQ(input_generator.WriteInputsToFile(output_filename), kTfLiteOk);
 
   std::ifstream in(output_filename);

--- a/tensorflow/lite/testing/kernel_test/util_test.cc
+++ b/tensorflow/lite/testing/kernel_test/util_test.cc
@@ -18,7 +18,6 @@ limitations under the License.
 #include <memory>
 
 #include <gmock/gmock.h>
-#include "testing/base/public/googletest.h"
 #include <gtest/gtest.h>
 #include "tensorflow/lite/testing/tflite_driver.h"
 
@@ -32,7 +31,7 @@ TEST(UtilTest, SimpleE2ETest) {
   options.tflite_model = "tensorflow/lite/testdata/add.bin";
   options.read_input_from_file =
       "tensorflow/lite/testdata/test_input.csv";
-  options.dump_output_to_file = FLAGS_test_tmpdir + "/test_out.csv";
+  options.dump_output_to_file = TmpDir() + "/test_out.csv";
   options.kernel_type = "REFERENCE";
   std::unique_ptr<TestRunner> runner(new TfLiteDriver(
       TfLiteDriver::DelegateType::kNone, /*reference_kernel=*/true));


### PR DESCRIPTION
This PR removes `#include "testing/base/public/googletest.h"` in the `input_generator_test` and `util_test` so that these test can also run on the local environment. Otherwise, there will be an error below:

```
ERROR: /home/abc/tensorflow/tensorflow/lite/testing/kernel_test/BUILD:33:1: C++ compilation of rule '//tensorflow/lite/testing/kernel_test:util_test' failed (Exit 1)
tensorflow/lite/testing/kernel_test/util_test.cc:21:10: fatal error: testing/base/public/googletest.h: No such file or directory
 #include "testing/base/public/googletest.h"
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
Target //tensorflow/lite/testing/kernel_test:util_test failed to build
Use --verbose_failures to see the command lines of failed build steps.
``` 

Fixes #26671 