### PR TITLE
Remove the "nomac" exclusion for FromTensorsTest

### DIFF
--- a/tensorflow/python/data/kernel_tests/BUILD
+++ b/tensorflow/python/data/kernel_tests/BUILD
@@ -241,9 +241,6 @@ tf_py_test(
         "//tensorflow/python/data/ops:dataset_ops",
         "//tensorflow/python/data/util:nest",
     ],
-    tags = [
-        "nomac",  # b/62040583
-    ],
 )
 
 tf_py_test(


### PR DESCRIPTION
`FromTensorsTest` could run on mac now, so this PR removes the `nomac` exclusion.