### PR TITLE
Enable quantized Div for toco

### DIFF
--- a/tensorflow/lite/toco/graph_transformations/quantize.cc
+++ b/tensorflow/lite/toco/graph_transformations/quantize.cc
@@ -53,6 +53,7 @@ bool SupportsQuantization(Model* model, const Operator& op) {
       OperatorType::kConv,
       OperatorType::kDepthToSpace,
       OperatorType::kDepthwiseConv,
+      OperatorType::kDiv,
       OperatorType::kEqual,
       OperatorType::kExpandDims,
       OperatorType::kFullyConnected,


### PR DESCRIPTION
This addresses issue #32031 raised by @sunzhe09, "Unimplemented: this graph contains an operator of type Div for which the quantized form is not yet implemented". This was addressed in PR #26570 "Added quantized division for uint8" but quantize.cc was not modified to allow for TFLite conversion.