### PR TITLE
Docs: fix example in SparseCategoricalCrossEntropy

### DIFF
--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -490,8 +490,8 @@ class SparseCategoricalCrossentropy(LossFunctionWrapper):
   cce = tf.keras.losses.SparseCategoricalCrossentropy()
   loss = cce(
     tf.convert_to_tensor([0, 1, 2]),
-    tf.convert_to_tensor([[.9, .05, .05], [.5, .89, .6], [.05, .01, .94]]))
-  print('Loss: ', loss.numpy())  # Loss: 0.3239
+    tf.convert_to_tensor([[.9, .05, .05], [.05, .89, .06], [.05, .01, .94]]))
+  print('Loss: ', loss.numpy())  # Loss: 0.0945
   ```
 
   Usage with the `compile` API:


### PR DESCRIPTION
Fixes the example in the docstring of `tf.keras.losses.SparseCategoricalCrossEntropy` to the one used in `tf.keras.losses.CategoricalCrossEntropy`.

Note that the current example is non-sensical as `[.5, .89, .6]` is not normalized (but `[.05, .89, .06]` is normalized, so it's probably just a typo).