### PR TITLE
Remove deprecate warning caused by usage of parallel_interleave in tf.data

### DIFF
--- a/tensorflow/python/data/experimental/ops/interleave_ops.py
+++ b/tensorflow/python/data/experimental/ops/interleave_ops.py
@@ -33,6 +33,21 @@ from tensorflow.python.util import deprecation
 from tensorflow.python.util.tf_export import tf_export
 
 
+
+def _parallel_interleave(map_func,
+                         cycle_length,
+                         block_length=1,
+                         sloppy=False,
+                         buffer_output_elements=None,
+                         prefetch_input_elements=None):
+  """An internal wrapper for deprecated parallel_interleave."""
+  def _apply_fn(dataset):
+    return readers.ParallelInterleaveDataset(
+        dataset, map_func, cycle_length, block_length, sloppy,
+        buffer_output_elements, prefetch_input_elements)
+
+  return _apply_fn
+
 @deprecation.deprecated(
     None,
     "Use `tf.data.Dataset.interleave(map_func, cycle_length, block_length, "
@@ -88,13 +103,9 @@ def parallel_interleave(map_func,
     A `Dataset` transformation function, which can be passed to
     `tf.data.Dataset.apply`.
   """
-  def _apply_fn(dataset):
-    return readers.ParallelInterleaveDataset(
-        dataset, map_func, cycle_length, block_length, sloppy,
-        buffer_output_elements, prefetch_input_elements)
-
-  return _apply_fn
-
+  return _parallel_interleave(
+      map_func, cycle_length, block_length, sloppy,
+      buffer_output_elements, prefetch_input_elements)
 
 class _DirectedInterleaveDataset(dataset_ops.DatasetV2):
   """A substitute for `Dataset.interleave()` on a fixed list of datasets."""

--- a/tensorflow/python/data/experimental/ops/readers.py
+++ b/tensorflow/python/data/experimental/ops/readers.py
@@ -535,7 +535,7 @@ def make_csv_dataset_v2(
   else:
     # Read files sequentially (if num_parallel_reads=1) or in parallel
     dataset = dataset.apply(
-        interleave_ops.parallel_interleave(
+        interleave_ops._parallel_interleave(
             filename_to_dataset, cycle_length=num_parallel_reads,
             sloppy=sloppy))
 
@@ -884,7 +884,7 @@ def make_batched_features_dataset_v2(file_pattern,
   else:
     # Read files sequentially (if reader_num_threads=1) or in parallel
     dataset = dataset.apply(
-        interleave_ops.parallel_interleave(
+        interleave_ops._parallel_interleave(
             lambda filename: reader(filename, *reader_args),
             cycle_length=reader_num_threads,
             sloppy=sloppy_ordering))


### PR DESCRIPTION
While playing with make_csv_dataset the following warning showed up:
```
WARNING:tensorflow:From /usr/local/lib/python2.7/dist-packages/tensorflow_core/python/data/experimental/ops/readers.py:521: parallel_interleave (from tensorflow.python.data.experimental.ops.interleave_ops) is deprecated and will be removed in a future version.
Instructions for updating:
Use `tf.data.Dataset.interleave(map_func, cycle_length, block_length, num_parallel_calls=tf.data.experimental.AUTOTUNE)` instead. If sloppy execution is desired, use `tf.data.Options.experimental_determinstic`.
```

This fix adds an wrapper of _parallel_interleave so that the deprecated warning could be removed.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>