### PR TITLE
Fix SIGABRT on `tf.image.encode_png` with empty tensor

### DIFF
--- a/tensorflow/core/kernels/encode_png_op.cc
+++ b/tensorflow/core/kernels/encode_png_op.cc
@@ -72,6 +72,10 @@ class EncodePngOp : public OpKernel {
                 errors::InvalidArgument(
                     "image must have 1, 2, 3, or 4 channels, got ", channels));
 
+    OP_REQUIRES(context, (image.NumElements() > 0),
+                errors::InvalidArgument(
+                    "image data should not be empty"));
+
     // Encode image to png string
     Tensor* output = nullptr;
     OP_REQUIRES_OK(context,

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -4071,6 +4071,14 @@ class PngTest(test_util.TensorFlowTestCase):
         self.assertEqual(image.get_shape().as_list(),
                          [None, None, channels or None])
 
+  def testEmptyTensor(self):
+    with self.cached_session(use_gpu=True) as sess:
+      image = array_ops.reshape(
+          constant_op.constant([], dtypes.uint8), [0, 0, 3])
+      with self.assertRaisesOpError(r"image data should not be empty"):
+        png = image_ops.encode_png(image)
+
+
 
 class GifTest(test_util.TensorFlowTestCase):
 


### PR DESCRIPTION
This fix address the issue raised in #31429 where SIGABRT was thrown on `tf.image.encode_png` with empty tensor.

Instead of thrown out SIGABRT, this fix adds the error checking so that InvalidArgument was returned gracefully.

This fix fixes #31429

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>