### PR TITLE
Fix deprecated warning caused by shuffle_and_repeat when using make_csv_dataset

### DIFF
--- a/tensorflow/python/data/experimental/ops/interleave_ops.py
+++ b/tensorflow/python/data/experimental/ops/interleave_ops.py
@@ -33,23 +33,6 @@ from tensorflow.python.util import deprecation
 from tensorflow.python.util.tf_export import tf_export
 
 
-def _parallel_interleave(map_func,
-                         cycle_length,
-                         block_length=1,
-                         sloppy=False,
-                         buffer_output_elements=None,
-                         prefetch_input_elements=None):
-  """An internal wrapper for deprecated parallel_interleave."""
-
-  def _apply_fn(dataset):
-    return readers.ParallelInterleaveDataset(dataset, map_func, cycle_length,
-                                             block_length, sloppy,
-                                             buffer_output_elements,
-                                             prefetch_input_elements)
-
-  return _apply_fn
-
-
 @deprecation.deprecated(
     None,
     "Use `tf.data.Dataset.interleave(map_func, cycle_length, block_length, "
@@ -105,8 +88,12 @@ def parallel_interleave(map_func,
     A `Dataset` transformation function, which can be passed to
     `tf.data.Dataset.apply`.
   """
-  return _parallel_interleave(map_func, cycle_length, block_length, sloppy,
-                              buffer_output_elements, prefetch_input_elements)
+  def _apply_fn(dataset):
+    return readers.ParallelInterleaveDataset(
+        dataset, map_func, cycle_length, block_length, sloppy,
+        buffer_output_elements, prefetch_input_elements)
+
+  return _apply_fn
 
 
 class _DirectedInterleaveDataset(dataset_ops.DatasetV2):

--- a/tensorflow/python/data/experimental/ops/readers.py
+++ b/tensorflow/python/data/experimental/ops/readers.py
@@ -25,7 +25,6 @@ import gzip
 import numpy as np
 
 from tensorflow.python.data.experimental.ops import error_ops
-from tensorflow.python.data.experimental.ops import interleave_ops
 from tensorflow.python.data.experimental.ops import parsing_ops
 from tensorflow.python.data.experimental.ops import shuffle_ops
 from tensorflow.python.data.ops import dataset_ops

--- a/tensorflow/python/data/experimental/ops/readers.py
+++ b/tensorflow/python/data/experimental/ops/readers.py
@@ -208,11 +208,8 @@ def _maybe_shuffle_and_repeat(
     dataset, num_epochs, shuffle, shuffle_buffer_size, shuffle_seed):
   """Optionally shuffle and repeat dataset, as requested."""
   if num_epochs != 1 and shuffle:
-    # Use shuffle_and_repeat for perf
-    def _apply_fn(input_dataset):  # pylint: disable=missing-docstring
-      return shuffle_ops._ShuffleAndRepeatDataset(
-          input_dataset, shuffle_buffer_size, num_epochs, shuffle_seed)
-    return dataset.apply(_apply_fn)
+    return shuffle_ops._ShuffleAndRepeatDataset(
+        dataset, shuffle_buffer_size, num_epochs, shuffle_seed)
   elif shuffle:
     return dataset.shuffle(shuffle_buffer_size, shuffle_seed)
   elif num_epochs != 1:

--- a/tensorflow/python/data/experimental/ops/readers.py
+++ b/tensorflow/python/data/experimental/ops/readers.py
@@ -886,10 +886,10 @@ def make_batched_features_dataset_v2(file_pattern,
     # Read files sequentially (if reader_num_threads=1) or in parallel
     dataset = core_readers.ParallelInterleaveDataset(
         dataset,
-        filename_to_dataset,
-        cycle_length=num_parallel_reads,
+        lambda filename: reader(filename, *reader_args),
+        cycle_length=reader_num_threads,
         block_length=1,
-        sloppy=sloppy,
+        sloppy=sloppy_ordering,
         buffer_output_elements=None,
         prefetch_input_elements=None)
 

--- a/tensorflow/python/data/experimental/ops/readers.py
+++ b/tensorflow/python/data/experimental/ops/readers.py
@@ -209,9 +209,10 @@ def _maybe_shuffle_and_repeat(
   """Optionally shuffle and repeat dataset, as requested."""
   if num_epochs != 1 and shuffle:
     # Use shuffle_and_repeat for perf
-    return dataset.apply(
-        shuffle_ops.shuffle_and_repeat(shuffle_buffer_size, num_epochs,
-                                       shuffle_seed))
+    def _apply_fn(input_dataset):  # pylint: disable=missing-docstring
+      return shuffle_ops._ShuffleAndRepeatDataset(
+          input_dataset, shuffle_buffer_size, num_epochs, shuffle_seed)
+    return dataset.apply(_apply_fn)
   elif shuffle:
     return dataset.shuffle(shuffle_buffer_size, shuffle_seed)
   elif num_epochs != 1:


### PR DESCRIPTION
This fix fixes unnecessary deprecated warning caused by shuffle_and_repeat when using make_csv_dataset:
```
WARNING:tensorflow:From /usr/local/lib/python2.7/dist-packages/tensorflow_core/python/data/experimental/ops/readers.py:215: shuffle_and_repeat (from tensorflow.python.data.experimental.ops.shuffle_ops) is deprecated and will be removed in a future version.
Instructions for updating:
Use `tf.data.Dataset.shuffle(buffer_size, seed)` followed by `tf.data.Dataset.repeat(count)`. Static tf.data optimizations will take care of using the fused implementation.
```

Note the fix doesn't use shuffle().repeat() as was suggested in the warning message, instead this fix keeps the original implementation to avoid potential performance issues.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>