### PR TITLE
fix for #32612 : load saved custom Loss class

### DIFF
--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -1176,14 +1176,14 @@ def deserialize(name, custom_objects=None):
 
 
 @keras_export('keras.losses.get')
-def get(identifier):
+def get(identifier, custom_objects=None):
   if identifier is None:
     return None
   if isinstance(identifier, six.string_types):
     identifier = str(identifier)
     return deserialize(identifier)
   if isinstance(identifier, dict):
-    return deserialize(identifier)
+    return deserialize(identifier, custom_objects)
   elif callable(identifier):
     return identifier
   else:

--- a/tensorflow/python/keras/saving/saving_utils.py
+++ b/tensorflow/python/keras/saving/saving_utils.py
@@ -224,7 +224,7 @@ def compile_args_from_training_config(training_config, custom_objects=None):
   # Recover loss functions and metrics.
   loss_config = training_config['loss']  # Deserialize loss class.
   if isinstance(loss_config, dict) and 'class_name' in loss_config:
-    loss_config = losses.get(loss_config)
+    loss_config = losses.get(loss_config, custom_objects)
   loss = nest.map_structure(
       lambda obj: custom_objects.get(obj, obj), loss_config)
   metrics = nest.map_structure(


### PR DESCRIPTION
Attempt to fix https://github.com/tensorflow/tensorflow/issues/32612

Here's an example with a custom Loss class, including config to ensure it's properly reloaded:
```python
class HuberLoss(keras.losses.Loss):
    def __init__(self, threshold=1.0, **kwargs):
        super().__init__(**kwargs)
        self.threshold = threshold
    
    @tf.function
    def call(self, y_true, y_pred):
        error = tf.abs(y_true - y_pred)
        is_small_error = error <= self.threshold
        squared_loss = tf.square(error) / 2
        linear_loss = error * self.threshold - 0.5 * self.threshold**2
        return tf.where(is_small_error, squared_loss, linear_loss)
    
    def get_config(self):
        cfg = super().get_config()
        cfg['threshold'] = self.threshold
        return cfg
```
The class can be used for a regression task this way:
```python
model = keras.Sequential([
  keras.layers.Dense(30, activation='relu', input_shape=X_train.shape[1:]),
  keras.layers.Dense(1)
])

model.compile(loss=HuberLoss(2.0), optimizer="sgd")
model.fit(X_train, y_train, epochs=1, validation_data=(X_valid, y_valid))

# save and reload
model.save('model_with_huber_loss_class.h5')
model = keras.models.load_model('model_with_huber_loss_class.h5', custom_objects={'HuberLoss': HuberLoss})

# continue training
model.fit(X_train, y_train, epochs=1, validation_data=(X_valid, y_valid))
```

The problem was that `saving_util.compile_args_from_training_config(training_config, custom_objects=None)` supports `custom_objects` but `custom_objects` was not propagated to `losses.get()`.
`losses.get()` later called `deserialize(identifier)` without specifying `custom_objects` while the `custom_objects` argument is supported by `deserialize()`: the default `None` was used and the custom class load failed.