### PR TITLE
Load saved custom Loss class

### DIFF
--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -1296,14 +1296,14 @@ def deserialize(name, custom_objects=None):
 
 
 @keras_export('keras.losses.get')
-def get(identifier):
+def get(identifier, custom_objects=None):
   if identifier is None:
     return None
   if isinstance(identifier, six.string_types):
     identifier = str(identifier)
     return deserialize(identifier)
   if isinstance(identifier, dict):
-    return deserialize(identifier)
+    return deserialize(identifier, custom_objects)
   elif callable(identifier):
     return identifier
   else:

--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -1303,7 +1303,7 @@ def get(identifier):
     identifier = str(identifier)
     return deserialize(identifier)
   if isinstance(identifier, dict):
-    return deserialize(identifier, custom_objects)
+    return deserialize(identifier)
   elif callable(identifier):
     return identifier
   else:

--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -1296,7 +1296,7 @@ def deserialize(name, custom_objects=None):
 
 
 @keras_export('keras.losses.get')
-def get(identifier, custom_objects=None):
+def get(identifier):
   if identifier is None:
     return None
   if isinstance(identifier, six.string_types):

--- a/tensorflow/python/keras/saving/saving_utils.py
+++ b/tensorflow/python/keras/saving/saving_utils.py
@@ -24,7 +24,6 @@ from tensorflow.python.eager import def_function
 from tensorflow.python.framework import tensor_spec
 from tensorflow.python.keras import backend as K
 from tensorflow.python.keras import losses
-from tensorflow.python.keras import metrics
 from tensorflow.python.keras import optimizers
 from tensorflow.python.keras.engine import base_layer_utils
 from tensorflow.python.keras.utils.io_utils import ask_to_proceed_with_overwrite

--- a/tensorflow/python/keras/saving/saving_utils.py
+++ b/tensorflow/python/keras/saving/saving_utils.py
@@ -241,6 +241,8 @@ def compile_args_from_training_config(training_config, custom_objects=None):
   metrics_config = training_config['metrics']
   if isinstance(metrics_config, dict) and 'class_name' in metrics_config:
     metrics_obj = metrics.deserialize(metrics_config, custom_objects)
+  elif isinstance(metrics_config, list):
+    metrics_obj = [ metrics.deserialize(obj, custom_objects) for obj in metrics_config ]
   else:
     metrics_obj = nest.map_structure(
       lambda obj: metrics.deserialize(obj, custom_objects),
@@ -249,6 +251,8 @@ def compile_args_from_training_config(training_config, custom_objects=None):
   weighted_metrics_config = training_config['weighted_metrics']
   if isinstance(weighted_metrics_config, dict) and 'class_name' in weighted_metrics_config:
     weighted_metrics = metrics.deserialize(weighted_metrics_config, custom_objects)
+  elif isinstance(weighted_metrics_config, list):
+    weighted_metrics = [ metrics.deserialize(obj, custom_objects) for obj in weighted_metrics_config ]
   else:
     weighted_metrics = nest.map_structure(
       lambda obj: metrics.deserialize(obj, custom_objects),

--- a/tensorflow/python/keras/saving/saving_utils.py
+++ b/tensorflow/python/keras/saving/saving_utils.py
@@ -254,7 +254,7 @@ def compile_args_from_training_config(training_config, custom_objects=None):
     loss = losses.deserialize(loss_config, custom_objects)
 
   # Recover metrics.
-  metrics_config = training_config['metrics']
+  metrics_config = training_config.get('metrics', None)
   if isinstance(metrics_config, dict):  # Metrics fed to compile as a dict.
     metrics = {
         k: convert_output_metrics(v, custom_objects)
@@ -268,7 +268,7 @@ def compile_args_from_training_config(training_config, custom_objects=None):
     metrics = None
 
   # Recover weighted metrics.
-  weighted_metrics_config = training_config['weighted_metrics']
+  weighted_metrics_config = training_config.get('weighted_metrics', None)
   if isinstance(weighted_metrics_config, dict):
     # Metrics fed to compile as a dict.
     weighted_metrics = {

--- a/tensorflow/python/keras/saving/saving_utils.py
+++ b/tensorflow/python/keras/saving/saving_utils.py
@@ -220,7 +220,7 @@ def should_overwrite(filepath, overwrite):
 
 
 def convert_output_metrics(metrics_config, custom_objects):
-  from google3.third_party.tensorflow.python.keras import metrics as metrics_module  # pylint:disable=g-import-not-at-top
+  from tensorflow.python.keras import metrics as metrics_module  # pylint:disable=g-import-not-at-top
   if isinstance(metrics_config, list):
     return [convert_output_metrics(mc, custom_objects) for mc in metrics_config]
   elif (isinstance(metrics_config, dict) or

--- a/tensorflow/python/keras/saving/saving_utils.py
+++ b/tensorflow/python/keras/saving/saving_utils.py
@@ -231,7 +231,7 @@ def compile_args_from_training_config(training_config, custom_objects=None):
   # Recover loss functions and metrics.
   loss_config = training_config['loss']  # Deserialize loss class.
   if isinstance(loss_config, dict) and 'class_name' in loss_config:
-    loss_config = losses.get(loss_config)
+    loss_config = losses.get(loss_config, custom_objects)
   loss = nest.map_structure(
       lambda obj: custom_objects.get(obj, obj), loss_config)
   metrics = nest.map_structure(


### PR DESCRIPTION
Attempt to fix https://github.com/tensorflow/tensorflow/issues/32612

Here's an example with a custom Loss class, including config to ensure it's properly reloaded:
```python
class HuberLoss(keras.losses.Loss):
    def __init__(self, threshold=1.0, **kwargs):
        super().__init__(**kwargs)
        self.threshold = threshold
    
    @tf.function
    def call(self, y_true, y_pred):
        error = tf.abs(y_true - y_pred)
        is_small_error = error <= self.threshold
        squared_loss = tf.square(error) / 2
        linear_loss = error * self.threshold - 0.5 * self.threshold**2
        return tf.where(is_small_error, squared_loss, linear_loss)
    
    def get_config(self):
        cfg = super().get_config()
        cfg['threshold'] = self.threshold
        return cfg
```
The class can be used for a regression task this way:
```python
model = keras.Sequential([
  keras.layers.Dense(30, activation='relu', input_shape=X_train.shape[1:]),
  keras.layers.Dense(1)
])

model.compile(loss=HuberLoss(2.0), optimizer="sgd")
model.fit(X_train, y_train, epochs=1, validation_data=(X_valid, y_valid))

# save and reload
model.save('model_with_huber_loss_class.h5')
model = keras.models.load_model('model_with_huber_loss_class.h5', custom_objects={'HuberLoss': HuberLoss})

# continue training
model.fit(X_train, y_train, epochs=1, validation_data=(X_valid, y_valid))
```

The problem was that `saving_util.compile_args_from_training_config(training_config, custom_objects=None)` supports `custom_objects` but `custom_objects` was not propagated to `losses.get()`.
`losses.get()` later called `deserialize(identifier)` without specifying `custom_objects` while the `custom_objects` argument is supported by `deserialize()`: the default `None` was used and the custom class load failed.
