### PR TITLE
A small optimization for VirtualScheduler::Init 

### DIFF
--- a/tensorflow/core/grappler/costs/virtual_scheduler.cc
+++ b/tensorflow/core/grappler/costs/virtual_scheduler.cc
@@ -409,7 +409,7 @@ Status VirtualScheduler::Init(const GrapplerItem* item) {
   bool ill_formed = false;
   std::unordered_map<string, const NodeDef*> name_to_node;
   const std::vector<const NodeDef*> fetch_fanin_nodes =
-      ComputeTransitiveFanin(graph, fetch_nodes, name_to_node, &ill_formed);
+      ComputeTransitiveFanin(graph, fetch_nodes, &name_to_node, &ill_formed);
   if (ill_formed) {
     return errors::InvalidArgument(
         "Ill formed graph or invalid set of fetch nodes specified");

--- a/tensorflow/core/grappler/costs/virtual_scheduler.cc
+++ b/tensorflow/core/grappler/costs/virtual_scheduler.cc
@@ -407,23 +407,18 @@ Status VirtualScheduler::Init(const GrapplerItem* item) {
 
   // Get the nodes that would run to output fetch_nodes.
   bool ill_formed = false;
+  std::unordered_map<string, const NodeDef*> name_to_node;
   const std::vector<const NodeDef*> fetch_fanin_nodes =
-      ComputeTransitiveFanin(graph, fetch_nodes, &ill_formed);
+      ComputeTransitiveFanin(graph, fetch_nodes, name_to_node, &ill_formed);
   if (ill_formed) {
     return errors::InvalidArgument(
         "Ill formed graph or invalid set of fetch nodes specified");
   }
 
-  // TODO(dyoon): this is a bit inefficient as name_to_node is already built in
-  // ComputeTransitiveFanin().
   // Once ComputeTransitiveFanin is complete, only the nodes that can be reached
   // from the fetch nodes are scheduled. So the scheduled nodes should be
   // exactly the same as those executed for real. One possible discrepancy could
   // be the control flow nodes, where tf only executes one path.
-  std::unordered_map<string, const NodeDef*> name_to_node;
-  for (const auto& node : fetch_fanin_nodes) {
-    name_to_node[node->name()] = node;
-  }
 
   // Traverses the graph to record _Send nodes.
   // TODO(dyoon): Instead of identifying _Send node here manually, add _Send

--- a/tensorflow/core/grappler/grappler_item.cc
+++ b/tensorflow/core/grappler/grappler_item.cc
@@ -208,6 +208,5 @@ std::vector<const NodeDef*> ComputeTransitiveFanin(
   CHECK(!ill_formed);
   return result;
 }
-
 }  // end namespace grappler
 }  // end namespace tensorflow

--- a/tensorflow/core/grappler/grappler_item.cc
+++ b/tensorflow/core/grappler/grappler_item.cc
@@ -208,5 +208,13 @@ std::vector<const NodeDef*> ComputeTransitiveFanin(
   CHECK(!ill_formed);
   return result;
 }
+
+std::vector<const NodeDef*> ComputeTransitiveFanin(
+    const GraphDef& graph, const std::vector<string>& terminal_nodes, 
+    bool* ill_formed) {
+  std::unordered_map<string, const NodeDef*> name_to_fanin_node;
+  return ComputeTransitiveFanin(graph , terminal_nodes, &name_to_fanin_node, ill_formed);
+}
+
 }  // end namespace grappler
 }  // end namespace tensorflow

--- a/tensorflow/core/grappler/grappler_item.h
+++ b/tensorflow/core/grappler/grappler_item.h
@@ -148,9 +148,10 @@ std::vector<const NodeDef*> ComputeTransitiveFanin(
 // exist. Sets name_to_fanin_node for name to fanin nodes map.
 std::vector<const NodeDef*> ComputeTransitiveFanin(
     const GraphDef& graph, const std::vector<string>& terminal_nodes,
-    std::unordered_map<string, const NodeDef*>& name_to_fanin_node,
-    bool* ill_formed); 
- 
+    std::unordered_map<string, const NodeDef*>* name_to_fanin_node,
+    bool* ill_formed);
+
+
 }  // end namespace grappler
 }  // end namespace tensorflow
 

--- a/tensorflow/core/grappler/grappler_item.h
+++ b/tensorflow/core/grappler/grappler_item.h
@@ -143,6 +143,14 @@ std::vector<const NodeDef*> ComputeTransitiveFanin(
     const GraphDef& graph, const std::vector<string>& terminal_nodes,
     bool* ill_formed);
 
+// Return the transitive fanin of a set of terminal nodes. Sets 'ill_formed' to
+// true if one of the node is missing in the graph, or some node inputs don't
+// exist. Sets name_to_fanin_node for name to fanin nodes map.
+std::vector<const NodeDef*> ComputeTransitiveFanin(
+    const GraphDef& graph, const std::vector<string>& terminal_nodes,
+    std::unordered_map<string, const NodeDef*>& name_to_fanin_node,
+    bool* ill_formed); 
+ 
 }  // end namespace grappler
 }  // end namespace tensorflow
 

--- a/tensorflow/core/grappler/grappler_item.h
+++ b/tensorflow/core/grappler/grappler_item.h
@@ -151,7 +151,6 @@ std::vector<const NodeDef*> ComputeTransitiveFanin(
     std::unordered_map<string, const NodeDef*>* name_to_fanin_node,
     bool* ill_formed);
 
-
 }  // end namespace grappler
 }  // end namespace tensorflow
 

--- a/tensorflow/core/grappler/utils/transitive_fanin.cc
+++ b/tensorflow/core/grappler/utils/transitive_fanin.cc
@@ -26,6 +26,7 @@ namespace grappler {
 
 std::vector<const NodeDef*> ComputeTransitiveFanin(
     const GraphDef& graph, const std::vector<string>& terminal_nodes,
+    std::unordered_map<string, const NodeDef*>* name_to_fanin_node,
     bool* ill_formed) {
   *ill_formed = false;
   std::unordered_map<string, const NodeDef*> name_to_node;
@@ -60,6 +61,7 @@ std::vector<const NodeDef*> ComputeTransitiveFanin(
       continue;
     }
     result.push_back(node);
+    name_to_fanin_node->insert(std::pair<string, const NodeDef*>(node->name(), node));
     for (const string& input : node->input()) {
       const NodeDef* in = name_to_node[NodeName(input)];
       if (!in) {
@@ -88,8 +90,9 @@ Status SetTransitiveFaninGraph(const GraphDef& input_graph,
   // Determines transitive fanin nodes from terminal nodes and add them to the
   // output graph.
   bool ill_formed = false;
+  std::unordered_map<string, const NodeDef*> name_to_fanin_node;
   std::vector<const NodeDef*> keep =
-      ComputeTransitiveFanin(input_graph, terminal_nodes, &ill_formed);
+      ComputeTransitiveFanin(input_graph, terminal_nodes, &name_to_fanin_node, &ill_formed);
   if (ill_formed) {
     // Some graph edges are invalid, or some of the feeds/fetch don't exist:
     // let's be conservative and preserve the graph as is.

--- a/tensorflow/core/grappler/utils/transitive_fanin.h
+++ b/tensorflow/core/grappler/utils/transitive_fanin.h
@@ -29,6 +29,7 @@ namespace grappler {
 // transitive fanin.
 std::vector<const NodeDef*> ComputeTransitiveFanin(
     const GraphDef& graph, const std::vector<string>& terminal_nodes,
+    std::unordered_map<string, const NodeDef*>* name_to_fanin_node,
     bool* ill_formed);
 
 // Creates output_graph from input_graph using the transitive fanin from the


### PR DESCRIPTION
fix a TODO in virtual_scheduler.cc :
```
 // TODO(dyoon): this is a bit inefficient as name_to_node is already built in	
 // ComputeTransitiveFanin().
```

add a prototype for ComputeTransitiveFanin, get the name to fanin node map when constructing transitive fanin node , so we do not need to  build it again after this function call 