### PR TITLE
Use tf.nn.selu in keras.activations.selu

### DIFF
--- a/tensorflow/python/keras/activations.py
+++ b/tensorflow/python/keras/activations.py
@@ -153,9 +153,7 @@ def selu(x):
       [Self-Normalizing Neural Networks (Klambauer et al, 2017)]
       (https://arxiv.org/abs/1706.02515)
   """
-  alpha = 1.6732632423543772848170429916717
-  scale = 1.0507009873554804934193349852946
-  return scale * K.elu(x, alpha)
+  return nn.selu(x)
 
 
 @keras_export('keras.activations.softplus')


### PR DESCRIPTION
`tf.nn` has an [implementation of `selu`](https://github.com/tensorflow/tensorflow/blob/e1c98eeb8ff8a25d2ecdcf1961974d6c9c1e3df4/tensorflow/core/kernels/relu_op_functor.h#L160-L198) that does not rely on [`tf.where`](https://github.com/tensorflow/tensorflow/blob/cb2cdd81f6c2bf2ae22e7ff16d80d8fae0a8587e/tensorflow/python/keras/backend.py#L4397).

This simplifies the code and the new implementation is approximately 4 - 5 times faster on my laptop CPU:
```python
In [3]: x = tf.random.uniform((1024, 12, 12, 1024), -3., 3.)                                                                                                

In [4]: %timeit tf.nn.selu(x)                                                                                                                               
240 ms ± 8.76 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [5]: %timeit tf.keras.activations.selu(x)                                                                                                                
1.02 s ± 39.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```