### PR TITLE
Fix SqlDataset fails to raise StopIteration issue when combined with batch

### DIFF
--- a/tensorflow/core/kernels/data/experimental/sql_dataset_op.cc
+++ b/tensorflow/core/kernels/data/experimental/sql_dataset_op.cc
@@ -142,8 +142,13 @@ class SqlDatasetOp : public DatasetOpKernel {
         if (!query_connection_initialized_) {
           TF_RETURN_IF_ERROR(InitializeQueryConnection());
         }
-        next_calls_++;
-        return query_connection_->GetNext(ctx, out_tensors, end_of_sequence);
+	Status status = Status::OK();
+	if (!end_of_sequence_) {
+          next_calls_++;
+          status = query_connection_->GetNext(ctx, out_tensors, &end_of_sequence_);
+	}
+	*end_of_sequence = end_of_sequence_;
+	return status;
       }
 
      protected:
@@ -170,14 +175,15 @@ class SqlDatasetOp : public DatasetOpKernel {
               reader->ReadScalar(full_name("next_calls"), &next_calls_));
           int64 rem_next_calls = next_calls_;
           std::vector<Tensor> out_tensors;
-          bool end_of_sequence = false;
+          end_of_sequence_ = false;
           while (rem_next_calls--) {
             TF_RETURN_IF_ERROR(query_connection_->GetNext(ctx, &out_tensors,
-                                                          &end_of_sequence));
+                                                          &end_of_sequence_));
             out_tensors.clear();
           }
         } else {
           query_connection_initialized_ = false;
+          end_of_sequence_ = false;
         }
         return Status::OK();
       }
@@ -185,6 +191,7 @@ class SqlDatasetOp : public DatasetOpKernel {
      private:
       Status InitializeQueryConnection() EXCLUSIVE_LOCKS_REQUIRED(mu_) {
         query_connection_initialized_ = true;
+        end_of_sequence_ = false;
         query_connection_ =
             sql::DriverManager::CreateQueryConnection(dataset()->driver_name_);
         Status s = query_connection_->Open(dataset()->data_source_name_,
@@ -203,6 +210,7 @@ class SqlDatasetOp : public DatasetOpKernel {
       int64 next_calls_ GUARDED_BY(mu_) = 0;
       std::unique_ptr<sql::QueryConnection> query_connection_ GUARDED_BY(mu_);
       bool query_connection_initialized_ GUARDED_BY(mu_) = false;
+      bool end_of_sequence_ GUARDED_BY(mu_) = false;
     };
     const tstring driver_name_;
     const tstring data_source_name_;

--- a/tensorflow/python/data/experimental/kernel_tests/sql_dataset_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/sql_dataset_test.py
@@ -22,6 +22,7 @@ from tensorflow.python.data.experimental.kernel_tests import sql_dataset_test_ba
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors
 from tensorflow.python.framework import test_util
+from tensorflow.python.ops import array_ops
 from tensorflow.python.platform import test
 
 
@@ -467,6 +468,18 @@ class SqlDatasetTest(sql_dataset_test_base.SqlDatasetTestBase):
                         self.evaluate(get_next()))
     self.assertNotEqual((b"John", b"Adams", 9007199254740991.0),
                         self.evaluate(get_next()))
+    with self.assertRaises(errors.OutOfRangeError):
+      self.evaluate(get_next())
+
+  # Test that SqlDataset can stop correctly when combined with batch
+  def testReadResultSetWithBatchStop(self):
+    dataset = self._createSqlDataset(
+        query="SELECT * FROM data",
+        output_types=(dtypes.int32))
+    dataset = dataset.map(lambda x: array_ops.identity(x))
+    get_next = self.getNext(dataset.batch(2))
+    self.assertAllEqual(self.evaluate(get_next()), [0, 1])
+    self.assertAllEqual(self.evaluate(get_next()), [2])
     with self.assertRaises(errors.OutOfRangeError):
       self.evaluate(get_next())
 

--- a/tensorflow/python/data/experimental/kernel_tests/sql_dataset_test_base.py
+++ b/tensorflow/python/data/experimental/kernel_tests/sql_dataset_test_base.py
@@ -47,6 +47,7 @@ class SqlDatasetTestBase(test_base.DatasetTestBase):
     c.execute("DROP TABLE IF EXISTS students")
     c.execute("DROP TABLE IF EXISTS people")
     c.execute("DROP TABLE IF EXISTS townspeople")
+    c.execute("DROP TABLE IF EXISTS data")
     c.execute(
         "CREATE TABLE IF NOT EXISTS students (id INTEGER NOT NULL PRIMARY KEY, "
         "first_name VARCHAR(100), last_name VARCHAR(100), motto VARCHAR(100), "
@@ -86,5 +87,9 @@ class SqlDatasetTestBase(test_base.DatasetTestBase):
          ("John", "Adams", -19.95,
           1331241321342132321324589798264627463827647382647382643874.0,
           9007199254740992.0)])
+    c.execute("CREATE TABLE IF NOT EXISTS data (col1 INTEGER)")
+    c.executemany(
+        "INSERT INTO DATA VALUES (?)",
+        [(0,), (1,), (2,)])
     conn.commit()
     conn.close()


### PR DESCRIPTION
This fix fixes the issue raised in #33253 where SqlDataset fails to raise StopIteration when combined with batch(). The reason was that after all records have been consumed, the extra `next` in the kernel does not return empty record so the iteration will continue in the next round. This fix fixes the issue.

This fix fixes #33253.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>