### PR TITLE
Fix some meaningless type qualifier warnings

### DIFF
--- a/tensorflow/core/kernels/cwise_ops.h
+++ b/tensorflow/core/kernels/cwise_ops.h
@@ -34,7 +34,7 @@ template <>
 struct scalar_arg_op<std::complex<float>> {
   EIGEN_EMPTY_STRUCT_CTOR(scalar_arg_op)
   typedef typename Eigen::NumTraits<std::complex<float>>::Real result_type;
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const float operator()(
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE float operator()(
       const std::complex<float>& a) const {
     return ::atan2f(a.imag(), a.real());
   }
@@ -44,7 +44,7 @@ template <>
 struct scalar_arg_op<std::complex<double>> {
   EIGEN_EMPTY_STRUCT_CTOR(scalar_arg_op)
   typedef typename Eigen::NumTraits<std::complex<double>>::Real result_type;
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const double operator()(
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE double operator()(
       const std::complex<double>& a) const {
     return ::atan2(a.imag(), a.real());
   }
@@ -55,7 +55,7 @@ struct scalar_arg_op<std::complex<double>> {
 template <typename T>
 struct scalar_asinh_op {
   EIGEN_EMPTY_STRUCT_CTOR(scalar_asinh_op)
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const T operator()(const T& a) const {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE T operator()(const T& a) const {
     return std::asinh(a);
   }
 };
@@ -67,7 +67,7 @@ struct functor_traits<scalar_asinh_op<T>> {
 template <typename T>
 struct scalar_acosh_op {
   EIGEN_EMPTY_STRUCT_CTOR(scalar_acosh_op)
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const T operator()(const T& a) const {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE T operator()(const T& a) const {
     return std::acosh(a);
   }
 };
@@ -79,7 +79,7 @@ struct functor_traits<scalar_acosh_op<T>> {
 template <typename T>
 struct scalar_atanh_op {
   EIGEN_EMPTY_STRUCT_CTOR(scalar_atanh_op)
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const T operator()(const T& a) const {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE T operator()(const T& a) const {
     return std::atanh(a);
   }
 };
@@ -127,8 +127,8 @@ struct safe_div_or_mod_op {
   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE safe_div_or_mod_op(bool* error)
       : error(error) {}
 
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const T operator()(const T& a,
-                                                           const T& b) const {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE T operator()(const T& a,
+                                                     const T& b) const {
     const T safe_b = tensorflow::internal::SubtleMustCopy(b);
     if (TF_PREDICT_TRUE(safe_b != 0)) {
       return DivOrMod()(a, safe_b);
@@ -150,8 +150,8 @@ struct functor_traits<safe_div_or_mod_op<T, DivOrMod>> {
 template <typename T, typename Binary>
 struct no_nan_op {
   EIGEN_EMPTY_STRUCT_CTOR(no_nan_op)
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const T operator()(const T& a,
-                                                           const T& b) const {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE T operator()(const T& a,
+                                                     const T& b) const {
     if (b != T(0)) {
       return Binary()(a, b);
     } else {
@@ -159,7 +159,7 @@ struct no_nan_op {
     }
   }
   template <typename Packet>
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Packet
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet
   packetOp(const Packet& a, const Packet& b) const {
     const Packet mask = pcmp_eq(b, pzero(b));
     const Packet quotient = Binary().packetOp(a, b);
@@ -376,13 +376,13 @@ struct less_equal : std::binary_function<T, T, bool> {
 // Functor that enables squared difference functor.
 template <typename Scalar>
 struct scalar_squared_difference_op {
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Scalar
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Scalar
   operator()(const Scalar& a, const Scalar& b) const {
     const Scalar v = scalar_difference_op<Scalar>()(a, b);
     return scalar_product_op<Scalar>()(v, scalar_conjugate_op<Scalar>()(v));
   }
   template <typename Packet>
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Packet
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet
   packetOp(const Packet& a, const Packet& b) const {
     const Packet v = scalar_difference_op<Scalar>().packetOp(a, b);
     return scalar_product_op<Scalar>().packetOp(
@@ -405,8 +405,8 @@ struct functor_traits<scalar_squared_difference_op<Scalar>> {
 // TODO(b/32239616): This kernel should be moved into Eigen and vectorized.
 template <typename T, typename Enable = void>
 struct google_floor_div {
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const T operator()(const T& x,
-                                                           const T& y) const {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE T operator()(const T& x,
+                                                     const T& y) const {
     if ((x < T(0)) != (y < T(0))) {
 // HIP does not have the device version of the abs routine defined
 // for all datatypes that T can resolve to
@@ -423,7 +423,7 @@ struct google_floor_div {
     }
   }
   template <typename Packet>
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Packet
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet
   packetOp(const Packet& x, const Packet& y) const {
     Packet zeros = pzero(x);
     Packet x_mask = pcmp_lt(x, zeros);
@@ -440,12 +440,12 @@ struct google_floor_div {
 template <typename T>
 struct google_floor_div<
     T, typename std::enable_if<std::is_unsigned<T>::value>::type> {
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const T operator()(const T& x,
-                                                           const T& y) const {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE T operator()(const T& x,
+                                                     const T& y) const {
     return x / y;
   }
   template <typename Packet>
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Packet
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet
   packetOp(const Packet& x, const Packet& y) const {
     return pdiv(x, y);
   }
@@ -467,12 +467,12 @@ struct functor_traits<google_floor_div<Scalar>> {
 
 template <typename T, typename Enable = void>
 struct google_floor_div_real {
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const T operator()(const T& x,
-                                                           const T& y) const {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE T operator()(const T& x,
+                                                     const T& y) const {
     return Eigen::numext::floor(x / y);
   }
   template <typename Packet>
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Packet
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet
   packetOp(const Packet& x, const Packet& y) const {
     return pfloor(pdiv(x, y));
   }
@@ -496,8 +496,8 @@ struct functor_traits<google_floor_div_real<Scalar>> {
 // TODO(rmlarsen): Add vectorized mod & fmod in Eigen and use it here.
 template <typename T>
 struct google_floor_fmod {
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const T operator()(const T& x,
-                                                           const T& y) const {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE T operator()(const T& x,
+                                                     const T& y) const {
     // EIGEN_STATIC_ASSERT(NUMERIC_TYPE_MUST_BE_REAL);
     T trunc_mod = scalar_fmod_op<T>()(x, y);
     return trunc_mod != T(0) && (y < T(0) != trunc_mod < T(0)) ? trunc_mod + y
@@ -517,8 +517,8 @@ struct functor_traits<google_floor_fmod<Scalar>> {
 // TODO(rmlarsen): Add vectorized mod & fmod in Eigen and use it here.
 template <typename T>
 struct google_floor_mod {
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const T operator()(const T& x,
-                                                           const T& y) const {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE T operator()(const T& x,
+                                                     const T& y) const {
     // EIGEN_STATIC_ASSERT(!NUMERIC_TYPE_MUST_BE_REAL);
     T trunc_mod = Eigen::internal::scalar_mod2_op<T>()(x, y);
     return trunc_mod != T(0) && (y < T(0) != trunc_mod < T(0)) ? trunc_mod + y
@@ -547,7 +547,7 @@ struct functor_traits<google_floor_mod<Scalar>> {
 
 template <typename Scalar, bool IsInteger = Eigen::NumTraits<Scalar>::IsInteger>
 struct scalar_round_op_google {
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Scalar
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Scalar
   operator()(const Scalar& x) const {
     EIGEN_STATIC_ASSERT((!NumTraits<Scalar>::IsComplex),
                         NUMERIC_TYPE_MUST_BE_REAL)
@@ -570,12 +570,12 @@ struct scalar_round_op_google {
 
 template <typename Scalar>
 struct scalar_round_op_google<Scalar, true> {
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Scalar
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Scalar
   operator()(const Scalar& x) const {
     return x;
   }
   template <typename Packet>
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Packet
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet
   packetOp(const Packet& x) const {
     return x;
   }
@@ -596,7 +596,7 @@ struct functor_traits<scalar_round_op_google<Scalar>> {
 
 template <typename Scalar, bool IsInteger = Eigen::NumTraits<Scalar>::IsInteger>
 struct scalar_round_up_op {
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Scalar
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Scalar
   operator()(const Scalar& x) const {
     EIGEN_STATIC_ASSERT((!NumTraits<Scalar>::IsComplex),
                         NUMERIC_TYPE_MUST_BE_REAL)
@@ -604,7 +604,7 @@ struct scalar_round_up_op {
   }
 
   template <typename Packet>
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Packet
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet
   packetOp(const Packet& x) const {
     return pfloor(padd(x, pset1<Packet>(0.5)));
   }
@@ -612,13 +612,13 @@ struct scalar_round_up_op {
 
 template <typename Scalar>
 struct scalar_round_up_op<Scalar, true> {
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Scalar
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Scalar
   operator()(const Scalar& x) const {
     return x;
   }
 
   template <typename Packet>
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Packet
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet
   packetOp(const Packet& x) const {
     return x;
   }
@@ -642,12 +642,12 @@ struct functor_traits<scalar_round_up_op<Scalar, IsInteger>> {
 template <typename Scalar>
 struct bitwise_xor_op {
   EIGEN_EMPTY_STRUCT_CTOR(bitwise_xor_op)
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Scalar
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Scalar
   operator()(const Scalar& x, const Scalar& y) const {
     return x ^ y;
   }
   template <typename Packet>
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Packet
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet
   packetOp(const Packet& a, const Packet& b) const {
     return Eigen::internal::pxor(a, b);
   }
@@ -661,7 +661,7 @@ struct functor_traits<bitwise_xor_op<Scalar>> {
 template <typename Scalar>
 struct xlogy_op {
   EIGEN_EMPTY_STRUCT_CTOR(xlogy_op)
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Scalar
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Scalar
   operator()(const Scalar& x, const Scalar& y) const {
     if (x == Scalar(0.)) {
       return Scalar(0.);
@@ -669,7 +669,7 @@ struct xlogy_op {
     return x * numext::log(y);
   }
   template <typename Packet>
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Packet
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet
   packetOp(const Packet& x, const Packet& y) const {
     Packet zeros = pzero(x);
     Packet mask = pcmp_eq(x, zeros);
@@ -696,7 +696,7 @@ struct functor_traits<xlogy_op<Scalar>> {
 template <typename Scalar>
 struct xdivy_op {
   EIGEN_EMPTY_STRUCT_CTOR(xdivy_op)
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Scalar
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Scalar
   operator()(const Scalar& x, const Scalar& y) const {
     if (x == Scalar(0.)) {
       return Scalar(0.);
@@ -704,7 +704,7 @@ struct xdivy_op {
     return x / y;
   }
   template <typename Packet>
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Packet
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet
   packetOp(const Packet& x, const Packet& y) const {
     Packet zeros = pzero(x);
     Packet mask = pcmp_eq(x, zeros);
@@ -736,7 +736,7 @@ struct scalar_erfinv_op {
     return y / static_cast<T>(numext::sqrt(2.));
   }
   template <typename Packet>
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Packet
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet
   packetOp(const Packet& x) const {
     Packet y = pndtri<Packet>(pmadd(pset1<Packet>(0.5), x, pset1<Packet>(0.5)));
     return pdiv(y, psqrt(pset1<Packet>(2.)));
@@ -940,7 +940,7 @@ struct logical_not : base<bool, Eigen::internal::scalar_boolean_not_op<bool>> {
 template <typename T>
 struct invert_op {
   EIGEN_EMPTY_STRUCT_CTOR(invert_op)
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const T operator()(const T& a) const {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE T operator()(const T& a) const {
     return ~a;
   }
 };
@@ -975,7 +975,7 @@ struct ceil : base<T, Eigen::internal::scalar_ceil_op<T>> {};
 template <typename Scalar>
 struct scalar_rint_op {
   EIGEN_EMPTY_STRUCT_CTOR(scalar_rint_op)
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Scalar
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Scalar
   operator()(const Scalar& a) const {
 #if defined(__CUDACC__) || defined(__HIPCC__)
     return ::rint(a);
@@ -1153,8 +1153,8 @@ struct logical_or : base<bool, Eigen::internal::scalar_boolean_or_op> {};
 template <typename T>
 struct bitwise_and_op {
   EIGEN_EMPTY_STRUCT_CTOR(bitwise_and_op)
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const T operator()(const T& x,
-                                                           const T& y) const {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE T operator()(const T& x,
+                                                     const T& y) const {
     return x & y;
   }
 };
@@ -1162,8 +1162,8 @@ struct bitwise_and_op {
 template <typename T>
 struct bitwise_or_op {
   EIGEN_EMPTY_STRUCT_CTOR(bitwise_or_op)
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const T operator()(const T& x,
-                                                           const T& y) const {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE T operator()(const T& x,
+                                                     const T& y) const {
     return x | y;
   }
 };
@@ -1180,8 +1180,8 @@ struct bitwise_xor : base<T, Eigen::internal::bitwise_xor_op<T>> {};
 template <typename T>
 struct left_shift_op {
   EIGEN_EMPTY_STRUCT_CTOR(left_shift_op)
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const T operator()(const T& x,
-                                                           const T& y) const {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE T operator()(const T& x,
+                                                     const T& y) const {
     // Avoids UB: don't shift by larger than the bitwidth of T, and
     // performs left shifts as unsigned shifts.
     T y_clamped = y;
@@ -1198,8 +1198,8 @@ struct left_shift_op {
 template <typename T>
 struct right_shift_op {
   EIGEN_EMPTY_STRUCT_CTOR(right_shift_op)
-  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const T operator()(const T& x,
-                                                           const T& y) const {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE T operator()(const T& x,
+                                                     const T& y) const {
     // Avoids UB: don't shift by larger than the bitwidth of T.
     T y_clamped = y;
     if (y_clamped < 0) {


### PR DESCRIPTION
According to GCC, `const` type qualifier on return type is meaningless.

This PR fixes some of these warnings.