### PR TITLE
Fix android demo build

### DIFF
--- a/tensorflow/tools/ci_build/builds/android.sh
+++ b/tensorflow/tools/ci_build/builds/android.sh
@@ -39,7 +39,7 @@ TARGETS+=" //tensorflow/core/common_runtime/eager:execute"
 # in assets/ dir (see https://github.com/bazelbuild/bazel/issues/2334)
 # TODO(gunan): remove extra flags once sandboxing is enabled for all builds.
 bazel --bazelrc=/dev/null build \
-    --compilation_mode=opt --cxxopt=-std=c++14 --fat_apk_cpu=x86_64 \
+    --compilation_mode=opt --cxxopt=-std=c++1y --fat_apk_cpu=x86_64 \
     --spawn_strategy=sandboxed --genrule_strategy=sandboxed \
     --define=grpc_no_ares=true \
     ${TARGETS}


### PR DESCRIPTION
Seems like the gcc version is too old to support `-std=c++14` option