### PR TITLE
Update CONTRIBUTING.md to use in repo pylint style

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,18 +125,15 @@ Changes to TensorFlow Python code should conform to
 [Google Python Style Guide](https://github.com/google/styleguide/blob/gh-pages/pyguide.md)
 
 Use `pylint` to check your Python changes. To install `pylint` and
-retrieve TensorFlow's custom style definition:
+check a file with `pylint` against TensorFlow's custom style definition:
 
 ```bash
 pip install pylint
-wget -O /tmp/pylintrc https://raw.githubusercontent.com/tensorflow/tensorflow/master/tensorflow/tools/ci_build/pylintrc
+pylint --rcfile=tensorflow/tools/ci_build/pylintrc myfile.py
 ```
 
-To check a file with `pylint`:
-
-```bash
-pylint --rcfile=/tmp/pylintrc myfile.py
-```
+Note `pylint --rcfile=tensorflow/tools/ci_build/pylintrc` should run from the top level
+tensorflow directory.
 
 #### Coding style for other languages
 


### PR DESCRIPTION
In CONTRIBUTING.md, pylint style definition file was downloaded from
the web before used for style checking. However, as the
style definition file `tensorflow/tools/ci_build/pylintrc`
is really part of the repo, the download could be avoided with just
the following:
```
pylint --rcfile=tensorflow/tools/ci_build/pylintrc myfile.py
```

This PR updates CONTRIBUTING.md

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>