### PR TITLE
Remove tf.enable_eager_execution() in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ $ python
 
 ```python
 >>> import tensorflow as tf
->>> tf.enable_eager_execution()
 >>> tf.add(1, 2).numpy()
 3
 >>> hello = tf.constant('Hello, TensorFlow!')


### PR DESCRIPTION
As TensorFlow moves to 2.0, eager execution is enabled by default
so there is no need to invoke `tf.enable_eager_execution()`
explicitly.

This PR removed tf.enable_eager_execution() from README.md

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>