### PR TITLE
Add filter support for autograph with dataset

### DIFF
--- a/tensorflow/python/autograph/operators/py_builtins.py
+++ b/tensorflow/python/autograph/operators/py_builtins.py
@@ -383,7 +383,8 @@ def _tf_dataset_filter(function, iterable):
 def _py_filter(function, iterable):
   return filter(function, iterable)
 
-SUPPORTED_BUILTINS = (abs, float, int, len, print, range, enumerate, zip, map, filter)
+SUPPORTED_BUILTINS = (
+    abs, float, int, len, print, range, enumerate, zip, map, filter)
 
 if six.PY2:
   SUPPORTED_BUILTINS += (xrange,)

--- a/tensorflow/python/autograph/operators/py_builtins.py
+++ b/tensorflow/python/autograph/operators/py_builtins.py
@@ -370,7 +370,20 @@ def _py_map(fn, *iterables):
   return map(fn, *iterables)
 
 
-SUPPORTED_BUILTINS = (abs, float, int, len, print, range, enumerate, zip, map)
+def filter_(function, iterable):
+  if isinstance(iterable, dataset_ops.DatasetV2):
+    return _tf_dataset_filter(function, iterable)
+  return _py_filter(function, iterable)
+
+
+def _tf_dataset_filter(function, iterable):
+  return iterable.filter(function)
+
+
+def _py_filter(function, iterable):
+  return filter(function, iterable)
+
+SUPPORTED_BUILTINS = (abs, float, int, len, print, range, enumerate, zip, map, filter)
 
 if six.PY2:
   SUPPORTED_BUILTINS += (xrange,)
@@ -387,4 +400,5 @@ BUILTIN_FUINCTIONS_MAP = {
     'enumerate': enumerate_,
     'zip': zip_,
     'map': map_,
+    'filter': filter_,
 }

--- a/tensorflow/python/autograph/operators/py_builtins_test.py
+++ b/tensorflow/python/autograph/operators/py_builtins_test.py
@@ -279,6 +279,19 @@ class PyBuiltinsTest(test.TestCase):
     tc = TestSubclass()
     self.assertEqual(tc.test_method(), 21)
 
+  def test_filter(self):
+    self.assertListEqual(
+        list(py_builtins.filter_(lambda x: x == 'b', ['a', 'b', 'c'])), ['b'])
+    self.assertListEqual(
+        list(py_builtins.filter_(lambda x: x < 3, [3, 2, 1])), [2, 1])
+
+  def test_filter_dataset(self):
+    dataset = dataset_ops.DatasetV2.from_tensor_slices([3, 2, 1])
+    dataset = py_builtins.filter_(lambda x: x < 3, dataset)
+    iterator = dataset_ops.make_one_shot_iterator(dataset)
+    with self.cached_session() as sess:
+      self.assertAllEqual(self.evaluate(iterator.get_next()), 2)
+      self.assertAllEqual(self.evaluate(iterator.get_next()), 1)
 
 if __name__ == '__main__':
   test.main()


### PR DESCRIPTION
`filter` is one of the builtin functions in python, though it is not supported with dataset in autograph yet (as opposed to `enumerate/map`).

tf.data.Dataset already have filter support so adding it makes sense I think.

This PR adds the filter support for autograph with dataset.

This PR is related to #30802 (which adds `enumerate` support)

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>