### PR TITLE
Fix discrepancy between tf.io.gfile.mkdir and os.mkdir's created mode

### DIFF
--- a/tensorflow/core/platform/default/posix_file_system.cc
+++ b/tensorflow/core/platform/default/posix_file_system.cc
@@ -278,7 +278,8 @@ Status PosixFileSystem::CreateDir(const string& name) {
   if (translated.empty()) {
     return errors::AlreadyExists(name);
   }
-  if (mkdir(translated.c_str(), 0755) != 0) {
+  // Note: 0777 (511) matches python's default behavior
+  if (mkdir(translated.c_str(), 0777) != 0) {
     return IOError(name, errno);
   }
   return Status::OK();

--- a/tensorflow/python/lib/io/file_io_test.py
+++ b/tensorflow/python/lib/io/file_io_test.py
@@ -616,6 +616,20 @@ class FileIoTest(test.TestCase):
       info = np.load(f, allow_pickle=True)
     _ = [i for i in info.items()]
 
+  def testCreateDirMode(self):
+    os.umask(0000)
+
+    tf_dir = os.path.join(self._base_dir, "temp_dir_test1")
+    os_dir = os.path.join(self._base_dir, "temp_dir_test2")
+
+    file_io.create_dir_v2(tf_dir)
+    tf_mode = os.stat(tf_dir).st_mode
+
+    os.mkdir(os_dir)
+    os_mode = os.stat(os_dir).st_mode
+
+    self.assertEqual(tf_mode, os_mode)
+
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/lib/io/file_io_test.py
+++ b/tensorflow/python/lib/io/file_io_test.py
@@ -617,7 +617,7 @@ class FileIoTest(test.TestCase):
     _ = [i for i in info.items()]
 
   def testCreateDirMode(self):
-    os.umask(0000)
+    oldmask = os.umask(0000)
 
     tf_dir = os.path.join(self._base_dir, "temp_dir_test1")
     os_dir = os.path.join(self._base_dir, "temp_dir_test2")
@@ -627,6 +627,8 @@ class FileIoTest(test.TestCase):
 
     os.mkdir(os_dir)
     os_mode = os.stat(os_dir).st_mode
+
+    os.umask(oldmask)
 
     self.assertEqual(tf_mode, os_mode)
 


### PR DESCRIPTION
This fix tries to address the issue raised in #32963 where the modes of the directory created between tf.io.gfile.mkdir and os.mkdir are different (one is 0777 and another is 0755).

This fix fixes the issue.

This fix fixes #32963.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
