### PR TITLE
fixing documentation for tf.batch_to_space

### DIFF
--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -3318,13 +3318,16 @@ def batch_to_space_v2(input, block_shape, crops, name=None):  # pylint: disable=
       This operation is equivalent to the following steps:
       1. Reshape `input` to `reshaped` of shape: [block_shape[0], ...,
         block_shape[M-1], batch / prod(block_shape), input_shape[1], ...,
-        input_shape[N-1]]  2. Permute dimensions of `reshaped` to produce
+        input_shape[N-1]]  
+      2. Permute dimensions of `reshaped` to produce
         `permuted` of shape [batch / prod(block_shape),  input_shape[1],
         block_shape[0], ..., input_shape[M], block_shape[M-1],
-        input_shape[M+1], ..., input_shape[N-1]]  3. Reshape `permuted` to
+        input_shape[M+1], ..., input_shape[N-1]]  
+      3. Reshape `permuted` to
         produce `reshaped_permuted` of shape [batch / prod(block_shape),
         input_shape[1] * block_shape[0], ..., input_shape[M] * block_shape[M-1],
-        input_shape[M+1], ..., input_shape[N-1]]  4. Crop the start and end of
+        input_shape[M+1], ..., input_shape[N-1]]  
+      4. Crop the start and end of
         dimensions `[1, ..., M]` of `reshaped_permuted` according to `crops` to
         produce the
          output of shape: [batch / prod(block_shape),  input_shape[1] *


### PR DESCRIPTION
issue #33354

fixing documentation so it is easier to read on the website. 
each step is not separated correctly : https://www.tensorflow.org/api_docs/python/tf/batch_to_space