### PR TITLE
Fix missing activation methods

### DIFF
--- a/tensorflow/lite/experimental/micro/kernels/activation_utils.h
+++ b/tensorflow/lite/experimental/micro/kernels/activation_utils.h
@@ -33,9 +33,18 @@ inline float ActivationValFloat(TfLiteFusedActivation act, float a) {
       return a;
     case kTfLiteActRelu:
       return a < 0.f ? 0.f : a;
+    case kTfLiteActRelu1:
+      return a < 0.f ? 0.f : ((a > 1.f) ? 1.f : a);
+    case kTfLiteActRelu6:
+      return a < 0.f ? 0.f : ((a > 6.f) ? 6.f : a);
+    case kTfLiteActTanh:
+      return (expf(a) - expf(-a)) / (expf(a) + expf(-a));
+    case kTfLiteActSignBit:
+      return signbit(a);
+    case kTfLiteActSigmoid:
+      return 1.f / (1.f + expf(-a));
     default:
-      // TODO(kreeger): Implement more activations.
-      exit(1);
+      return a;
   }
 }
 


### PR DESCRIPTION
My goal was mainly to get rid of exit(1) here which can't actually be in microcontroller firmware... yeah. Anyway, tried to go above and beyond and implemented all the rest of the activation methods defined by the enum. Just used a default that returns the input if a wrong method is passed in (shouldn't happen).