### PR TITLE
Fix typo in docstring

### DIFF
--- a/tensorflow/python/keras/engine/base_layer.py
+++ b/tensorflow/python/keras/engine/base_layer.py
@@ -1038,7 +1038,7 @@ class Layer(module.Module):
 
     This method can also be called directly on a Functional Model during
     construction. In this case, any loss Tensors passed to this Model must
-    be symbolic and be able to be traced back to the model's `Input`s. These
+    be symbolic and be able to be traced back to the model's `Inputs`. These
     losses become part of the model's topology and are tracked in `get_config`.
 
     Example:


### PR DESCRIPTION
`Input`s should be `Inputs` in the add_loss() docstring at tensorflow/python/keras/engine/base_layer.py