### PR TITLE
Fix issue with SparseCategoricalCrossentropy: 'list' object has no attribute 'op'

### DIFF
--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -974,6 +974,8 @@ def categorical_crossentropy(y_true,
 @keras_export('keras.metrics.sparse_categorical_crossentropy',
               'keras.losses.sparse_categorical_crossentropy')
 def sparse_categorical_crossentropy(y_true, y_pred, from_logits=False, axis=-1):
+  y_pred = ops.convert_to_tensor(y_pred)
+  y_true = math_ops.cast(y_true, y_pred.dtype)
   return K.sparse_categorical_crossentropy(
       y_true, y_pred, from_logits=from_logits, axis=axis)
 

--- a/tensorflow/python/keras/losses_test.py
+++ b/tensorflow/python/keras/losses_test.py
@@ -1003,6 +1003,14 @@ class SparseCategoricalCrossentropyTest(test.TestCase):
     loss = cce_obj(y_true, logits)
     self.assertAllClose((0.001822, 0.000459, 0.169846), self.evaluate(loss), 3)
 
+  def test_non_tensor(self):
+    # Test case for GitHub issue 33394.
+    cce_obj = keras.losses.SparseCategoricalCrossentropy()
+    y_true = [[0], [1], [2]]
+    y_pred = [[.9, .05, .05], [.5, .89, .6], [.05, .01, .94]]
+    loss = cce_obj(y_true, y_pred, sample_weight=2.3)
+    self.assertAlmostEqual(self.evaluate(loss), .7449, 3)
+
 
 @test_util.run_all_in_graph_and_eager_modes
 class HingeTest(test.TestCase):


### PR DESCRIPTION
This fix tries to address the issue raised in #33394 where usage of SparseCategoricalCrossentropy causes the issue:
```
AttributeError: 'list' object has no attribute 'op'
```
when values are passed directly (not calling ops.convert_to_tensor first).

This fix fixes the issue by performing the ops.convert_to_tensor
on y_true and y_pred, similiar to what are done in other losses.

This fix fixes #33394.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>