### PR TITLE
[Intel MKL] Add FP32 fusion of MatMul and Relu.

### DIFF
--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -1461,7 +1461,7 @@ rinfo_.push_back({csinfo_.tanh_grad,
   }
 
   // Rewrite rule for _FusedMatMul.
-  // @return - true (no transpose attribute for input 1 and only has 1 post op);
+  // @return - true (no transpose attribute for input 1);
   //           false otherwise.
   static bool FusedMatMulRewrite(const Node* n) {
     bool trans_a;
@@ -1470,10 +1470,8 @@ rinfo_.push_back({csinfo_.tanh_grad,
     // Do not rewrite with transpose attribute because reorder has performance
     // impact.
     TF_CHECK_OK(GetNodeAttr(n->def(), "transpose_a", &trans_a));
-    // Do not rewrite with more than 1 post op because MKL-DNN doesn't support.
-    TF_CHECK_OK(GetNodeAttr(n->def(), "fused_ops", &fused_ops));
 
-    return (!trans_a) && (fused_ops.size() == 1);
+    return !trans_a;
   }
 
   // Check if we are performing pooling on depth or batch. If it is, then we

--- a/tensorflow/core/kernels/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl_conv_ops.cc
@@ -24,8 +24,8 @@ limitations under the License.
 #include <map>
 #include <vector>
 
-#include "mkldnn.hpp"
 #include "absl/strings/str_join.h"
+#include "mkldnn.hpp"
 #include "tensorflow/core/framework/bounds_check.h"
 #include "tensorflow/core/framework/numeric_op.h"
 #include "tensorflow/core/framework/op_kernel.h"
@@ -570,17 +570,15 @@ class MklConvOp : public OpKernel {
       OP_REQUIRES(context, dilations_.size() == 5,
                   errors::InvalidArgument("Dilation rates field must "
                                           "specify 5 dimensions"));
-      OP_REQUIRES(context,
-                  (GetTensorDim(dilations_, data_format_, 'N') == 1 &&
-                   GetTensorDim(dilations_, data_format_, 'C') == 1),
+      OP_REQUIRES(context, (GetTensorDim(dilations_, data_format_, 'N') == 1 &&
+                            GetTensorDim(dilations_, data_format_, 'C') == 1),
                   errors::InvalidArgument(
                       "Current implementation does not yet support "
                       "dilations rates in the batch and depth dimensions."));
       OP_REQUIRES(
-          context,
-          (GetTensorDim(dilations_, data_format_, '0') > 0 &&
-           GetTensorDim(dilations_, data_format_, '1') > 0 &&
-           GetTensorDim(dilations_, data_format_, '2') > 0),
+          context, (GetTensorDim(dilations_, data_format_, '0') > 0 &&
+                    GetTensorDim(dilations_, data_format_, '1') > 0 &&
+                    GetTensorDim(dilations_, data_format_, '2') > 0),
           errors::InvalidArgument("Dilated rates should be larger than 0."));
     }
   }
@@ -1351,6 +1349,7 @@ class MklFusedConvOp
     } else if (fused_ops == std::vector<string>{"Relu6"}) {
       this->set_fuse_activation(true, ALGORITHM::eltwise_bounded_relu, 6.0);
     } else if (fused_ops == std::vector<string>{"Elu"}) {
+      // TODO(intel-tf): wrong Alpha for Elu fusion, will fix it in future.
       this->set_fuse_activation(true, ALGORITHM::eltwise_elu);
     } else if (fused_ops == std::vector<string>{"BiasAdd", "Relu"}) {
       this->set_fuse_biasadd(true);
@@ -1366,6 +1365,7 @@ class MklFusedConvOp
                       "Fused Conv2D must have one extra argument: bias."));
     } else if (fused_ops == std::vector<string>{"BiasAdd", "Elu"}) {
       this->set_fuse_biasadd(true);
+      // TODO(intel-tf): wrong Alpha for Elu fusion, will fix it in future.
       this->set_fuse_activation(true, ALGORITHM::eltwise_elu);
       OP_REQUIRES(context, num_args == 1,
                   errors::InvalidArgument(
@@ -1396,6 +1396,7 @@ class MklFusedConvOp
     } else if (fused_ops == std::vector<string>{"BiasAdd", "Add", "Elu"}) {
       this->set_fuse_biasadd(true);
       this->set_fuse_add(true);
+      // TODO(intel-tf): wrong Alpha for Elu fusion, will fix it in future.
       this->set_fuse_activation(true, ALGORITHM::eltwise_elu);
       OP_REQUIRES(
           context, num_args == 2,

--- a/tensorflow/core/kernels/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl_conv_ops.cc
@@ -24,8 +24,8 @@ limitations under the License.
 #include <map>
 #include <vector>
 
-#include "mkldnn.hpp"
 #include "absl/strings/str_join.h"
+#include "mkldnn.hpp"
 #include "tensorflow/core/framework/bounds_check.h"
 #include "tensorflow/core/framework/numeric_op.h"
 #include "tensorflow/core/framework/op_kernel.h"
@@ -570,17 +570,15 @@ class MklConvOp : public OpKernel {
       OP_REQUIRES(context, dilations_.size() == 5,
                   errors::InvalidArgument("Dilation rates field must "
                                           "specify 5 dimensions"));
-      OP_REQUIRES(context,
-                  (GetTensorDim(dilations_, data_format_, 'N') == 1 &&
-                   GetTensorDim(dilations_, data_format_, 'C') == 1),
+      OP_REQUIRES(context, (GetTensorDim(dilations_, data_format_, 'N') == 1 &&
+                            GetTensorDim(dilations_, data_format_, 'C') == 1),
                   errors::InvalidArgument(
                       "Current implementation does not yet support "
                       "dilations rates in the batch and depth dimensions."));
       OP_REQUIRES(
-          context,
-          (GetTensorDim(dilations_, data_format_, '0') > 0 &&
-           GetTensorDim(dilations_, data_format_, '1') > 0 &&
-           GetTensorDim(dilations_, data_format_, '2') > 0),
+          context, (GetTensorDim(dilations_, data_format_, '0') > 0 &&
+                    GetTensorDim(dilations_, data_format_, '1') > 0 &&
+                    GetTensorDim(dilations_, data_format_, '2') > 0),
           errors::InvalidArgument("Dilated rates should be larger than 0."));
     }
   }
@@ -1351,7 +1349,7 @@ class MklFusedConvOp
     } else if (fused_ops == std::vector<string>{"Relu6"}) {
       this->set_fuse_activation(true, ALGORITHM::eltwise_bounded_relu, 6.0);
     } else if (fused_ops == std::vector<string>{"Elu"}) {
-      this->set_fuse_activation(true, ALGORITHM::eltwise_elu);
+      this->set_fuse_activation(true, ALGORITHM::eltwise_elu, 1.0);
     } else if (fused_ops == std::vector<string>{"BiasAdd", "Relu"}) {
       this->set_fuse_biasadd(true);
       this->set_fuse_activation(true, ALGORITHM::eltwise_relu);
@@ -1366,7 +1364,7 @@ class MklFusedConvOp
                       "Fused Conv2D must have one extra argument: bias."));
     } else if (fused_ops == std::vector<string>{"BiasAdd", "Elu"}) {
       this->set_fuse_biasadd(true);
-      this->set_fuse_activation(true, ALGORITHM::eltwise_elu);
+      this->set_fuse_activation(true, ALGORITHM::eltwise_elu, 1.0);
       OP_REQUIRES(context, num_args == 1,
                   errors::InvalidArgument(
                       "Fused Conv2D must have one extra argument: bias."));
@@ -1396,7 +1394,7 @@ class MklFusedConvOp
     } else if (fused_ops == std::vector<string>{"BiasAdd", "Add", "Elu"}) {
       this->set_fuse_biasadd(true);
       this->set_fuse_add(true);
-      this->set_fuse_activation(true, ALGORITHM::eltwise_elu);
+      this->set_fuse_activation(true, ALGORITHM::eltwise_elu, 1.0);
       OP_REQUIRES(
           context, num_args == 2,
           errors::InvalidArgument(

--- a/tensorflow/core/kernels/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl_conv_ops.cc
@@ -24,8 +24,8 @@ limitations under the License.
 #include <map>
 #include <vector>
 
-#include "absl/strings/str_join.h"
 #include "mkldnn.hpp"
+#include "absl/strings/str_join.h"
 #include "tensorflow/core/framework/bounds_check.h"
 #include "tensorflow/core/framework/numeric_op.h"
 #include "tensorflow/core/framework/op_kernel.h"
@@ -570,15 +570,17 @@ class MklConvOp : public OpKernel {
       OP_REQUIRES(context, dilations_.size() == 5,
                   errors::InvalidArgument("Dilation rates field must "
                                           "specify 5 dimensions"));
-      OP_REQUIRES(context, (GetTensorDim(dilations_, data_format_, 'N') == 1 &&
-                            GetTensorDim(dilations_, data_format_, 'C') == 1),
+      OP_REQUIRES(context,
+                  (GetTensorDim(dilations_, data_format_, 'N') == 1 &&
+                   GetTensorDim(dilations_, data_format_, 'C') == 1),
                   errors::InvalidArgument(
                       "Current implementation does not yet support "
                       "dilations rates in the batch and depth dimensions."));
       OP_REQUIRES(
-          context, (GetTensorDim(dilations_, data_format_, '0') > 0 &&
-                    GetTensorDim(dilations_, data_format_, '1') > 0 &&
-                    GetTensorDim(dilations_, data_format_, '2') > 0),
+          context,
+          (GetTensorDim(dilations_, data_format_, '0') > 0 &&
+           GetTensorDim(dilations_, data_format_, '1') > 0 &&
+           GetTensorDim(dilations_, data_format_, '2') > 0),
           errors::InvalidArgument("Dilated rates should be larger than 0."));
     }
   }
@@ -1349,7 +1351,7 @@ class MklFusedConvOp
     } else if (fused_ops == std::vector<string>{"Relu6"}) {
       this->set_fuse_activation(true, ALGORITHM::eltwise_bounded_relu, 6.0);
     } else if (fused_ops == std::vector<string>{"Elu"}) {
-      this->set_fuse_activation(true, ALGORITHM::eltwise_elu, 1.0);
+      this->set_fuse_activation(true, ALGORITHM::eltwise_elu);
     } else if (fused_ops == std::vector<string>{"BiasAdd", "Relu"}) {
       this->set_fuse_biasadd(true);
       this->set_fuse_activation(true, ALGORITHM::eltwise_relu);
@@ -1364,7 +1366,7 @@ class MklFusedConvOp
                       "Fused Conv2D must have one extra argument: bias."));
     } else if (fused_ops == std::vector<string>{"BiasAdd", "Elu"}) {
       this->set_fuse_biasadd(true);
-      this->set_fuse_activation(true, ALGORITHM::eltwise_elu, 1.0);
+      this->set_fuse_activation(true, ALGORITHM::eltwise_elu);
       OP_REQUIRES(context, num_args == 1,
                   errors::InvalidArgument(
                       "Fused Conv2D must have one extra argument: bias."));
@@ -1394,7 +1396,7 @@ class MklFusedConvOp
     } else if (fused_ops == std::vector<string>{"BiasAdd", "Add", "Elu"}) {
       this->set_fuse_biasadd(true);
       this->set_fuse_add(true);
-      this->set_fuse_activation(true, ALGORITHM::eltwise_elu, 1.0);
+      this->set_fuse_activation(true, ALGORITHM::eltwise_elu);
       OP_REQUIRES(
           context, num_args == 2,
           errors::InvalidArgument(

--- a/tensorflow/core/kernels/mkl_fused_ops_test.cc
+++ b/tensorflow/core/kernels/mkl_fused_ops_test.cc
@@ -242,6 +242,8 @@ class MklFusedConv2DOpTest : public OpsTestBase {
     if (std::find(fused_ops.begin(), fused_ops.end(), "Elu") !=
         fused_ops.end()) {
       last_op = "with_elu";
+      // TODO(intel-tf): correct typo "Relu" to "Elu" after fixing Conv and
+      // Elu fusion
       next_op = ops::Relu(root.WithOpName(last_op), next_op);
     }
 

--- a/tensorflow/core/kernels/mkl_fused_ops_test.cc
+++ b/tensorflow/core/kernels/mkl_fused_ops_test.cc
@@ -117,7 +117,7 @@ class CommonTestUtilities : public OpsTestBase {
 
     const int bias_size = filter_count;
     Tensor bias(dtype, {bias_size});
-    bias.flat<T>() = bias.flat<T>().setConstant(-1.0);
+    bias.flat<T>() = bias.flat<T>().setRandom();
 
     Tensor conv_2d;
     Tensor fused_conv_2d;
@@ -147,7 +147,7 @@ class CommonTestUtilities : public OpsTestBase {
 
     const int bias_size = filter_count;
     Tensor bias(dtype, {bias_size});
-    bias.flat<T>() = bias.flat<T>().setConstant(-1.0);
+    bias.flat<T>() = bias.flat<T>().setRandom();
 
     Tensor conv_2d;
     Tensor fused_conv_2d;
@@ -242,7 +242,7 @@ class MklFusedConv2DOpTest : public OpsTestBase {
     if (std::find(fused_ops.begin(), fused_ops.end(), "Elu") !=
         fused_ops.end()) {
       last_op = "with_elu";
-      next_op = ops::Elu(root.WithOpName(last_op), next_op);
+      next_op = ops::Relu(root.WithOpName(last_op), next_op);
     }
 
     CommonTestUtilities<T>::RunAndFetch(root, last_op, output);

--- a/tensorflow/core/kernels/mkl_fused_ops_test.cc
+++ b/tensorflow/core/kernels/mkl_fused_ops_test.cc
@@ -117,7 +117,7 @@ class CommonTestUtilities : public OpsTestBase {
 
     const int bias_size = filter_count;
     Tensor bias(dtype, {bias_size});
-    bias.flat<T>() = bias.flat<T>().setRandom();
+    bias.flat<T>() = bias.flat<T>().setConstant(-1.0);
 
     Tensor conv_2d;
     Tensor fused_conv_2d;
@@ -147,7 +147,7 @@ class CommonTestUtilities : public OpsTestBase {
 
     const int bias_size = filter_count;
     Tensor bias(dtype, {bias_size});
-    bias.flat<T>() = bias.flat<T>().setRandom();
+    bias.flat<T>() = bias.flat<T>().setConstant(-1.0);
 
     Tensor conv_2d;
     Tensor fused_conv_2d;
@@ -174,7 +174,7 @@ class CommonTestUtilities : public OpsTestBase {
     weight.flat<T>() = weight.flat<T>().setRandom();
 
     Tensor bias(dtype, {weight_count});
-    bias.flat<T>() = bias.flat<T>().setRandom();
+    bias.flat<T>() = bias.flat<T>().setConstant(-1.0);
 
     Tensor output;
     Tensor fused_output;
@@ -242,7 +242,7 @@ class MklFusedConv2DOpTest : public OpsTestBase {
     if (std::find(fused_ops.begin(), fused_ops.end(), "Elu") !=
         fused_ops.end()) {
       last_op = "with_elu";
-      next_op = ops::Relu(root.WithOpName(last_op), next_op);
+      next_op = ops::Elu(root.WithOpName(last_op), next_op);
     }
 
     CommonTestUtilities<T>::RunAndFetch(root, last_op, output);
@@ -653,7 +653,7 @@ class MklFusedMatMulOpTest : public OpsTestBase {
       if (std::find(fused_ops.begin(), fused_ops.end(), "Elu") !=
           fused_ops.end()) {
         last_op = "with_elu";
-        next_op = ops::Relu(root.WithOpName(last_op), next_op);
+        next_op = ops::Elu(root.WithOpName(last_op), next_op);
       }
 
       CommonTestUtilities<T>::RunAndFetch(root, last_op, output);

--- a/tensorflow/core/kernels/mkl_matmul_op_fused.cc
+++ b/tensorflow/core/kernels/mkl_matmul_op_fused.cc
@@ -32,15 +32,17 @@ class MklFusedMatMulOp : public MklDnnMatMulOpBase<T> {
  public:
   explicit MklFusedMatMulOp(OpKernelConstruction* ctx)
       : MklDnnMatMulOpBase<T>(ctx) {
-    std::vector<string> fused_ops;
-
-    OP_REQUIRES_OK(ctx, ctx->GetAttr("fused_ops", &fused_ops));
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("fused_ops", &fused_ops_));
     OP_REQUIRES_OK(ctx, ctx->GetAttr("transpose_a", &transpose_a_));
     OP_REQUIRES_OK(ctx, ctx->GetAttr("transpose_b", &transpose_b_));
 
-    OP_REQUIRES(ctx, fused_ops.size() == 1,
+    OP_REQUIRES(ctx, fused_ops_.size() <= 2,
                 errors::InvalidArgument(
-                    "MklFusedMatMul must have only one argument: bias."));
+                    "MklFusedMatMul must have 2 post-arguments at most."));
+    OP_REQUIRES(
+        ctx, fused_ops_[0] == "BiasAdd",
+        errors::InvalidArgument(
+            "The 1st post-argument of MklFusedMatMul must be BiasAdd."));
     OP_REQUIRES(
         ctx, transpose_a_ == false,
         errors::InvalidArgument("In[0] of MklMatMul can't be transposed."));
@@ -106,6 +108,9 @@ class MklFusedMatMulOp : public MklDnnMatMulOpBase<T> {
 
     MklDnnMatMulFwdParams matmul_params(src_dims, weight_dims, bias_dims,
                                         dst_dims, weight_format);
+
+    // Extend the basic parameters for data types and fusions.
+    ExtendMklDnnMatMulFwdParams(ctx, matmul_params);
     MklDnnMatMulFwdPrimitive<T, T, T, T, T>* matmul_prim =
         MklDnnMatMulFwdPrimitiveFactory<T, T, T, T, T>::Get(matmul_params, 0);
 
@@ -173,9 +178,29 @@ class MklFusedMatMulOp : public MklDnnMatMulOpBase<T> {
     }
   }
 
+  void ExtendMklDnnMatMulFwdParams(OpKernelContext* ctx,
+                                   MklDnnMatMulFwdParams& params) {
+    if (fused_ops_.size() == 2) {
+      string post_op = fused_ops_[1];
+
+      if (post_op == "Relu") {
+        params.post_op_params.push_back({"relu", {1.0, 0.0, 0.0}});
+      } else if (post_op == "Relu6") {
+        params.post_op_params.push_back({"relu6", {1.0, 6.0, 0.0}});
+      } else if (post_op == "Elu") {
+        params.post_op_params.push_back({"elu", {1.0, 0.0, 0.0}});
+      } else {
+        OP_REQUIRES_OK(
+            ctx, errors::InvalidArgument(
+                     "Unsupported post-argument in MklFusedMatMul: ", post_op));
+      }
+    }
+  }
+
  private:
   bool transpose_a_;
   bool transpose_b_;
+  std::vector<string> fused_ops_;
 };
 
 // Register mkl kernels for supported operations and types.

--- a/tensorflow/core/kernels/mkl_matmul_op_fused.cc
+++ b/tensorflow/core/kernels/mkl_matmul_op_fused.cc
@@ -84,11 +84,10 @@ class MklFusedMatMulOp : public MklDnnMatMulOpBase<T> {
     const int k = src_tf_shape.dim_size(dim_pair[0]);
     const int channel = weight_tf_shape.dim_size(1 - dim_pair[1]);
 
-    OP_REQUIRES(
-        ctx, k == weight_tf_shape.dim_size(dim_pair[1]),
-        errors::InvalidArgument(
-            "Matrix size-incompatible: In[0]: ", src_tf_shape.DebugString(),
-            ", In[1]: ", weight_tf_shape.DebugString()));
+    OP_REQUIRES(ctx, k == weight_tf_shape.dim_size(dim_pair[1]),
+                errors::InvalidArgument("Matrix size-incompatible: In[0]: ",
+                                        src_tf_shape.DebugString(), ", In[1]: ",
+                                        weight_tf_shape.DebugString()));
     OP_REQUIRES(ctx, bias_tensor.shape().dim_size(0) == channel,
                 errors::InvalidArgument(
                     "Must provide as many biases as the channel size: ",
@@ -170,9 +169,9 @@ class MklFusedMatMulOp : public MklDnnMatMulOpBase<T> {
 
       matmul_prim->Execute(src_data, weight_data, bias_data, dst_data);
     } catch (mkldnn::error& e) {
-      string error_msg = "Status: " + std::to_string(e.status) +
-                         ", message: " + string(e.message) + ", in file " +
-                         string(__FILE__) + ":" + std::to_string(__LINE__);
+      string error_msg = "Status: " + std::to_string(e.status) + ", message: " +
+                         string(e.message) + ", in file " + string(__FILE__) +
+                         ":" + std::to_string(__LINE__);
       OP_REQUIRES_OK(
           ctx, errors::Aborted("Operation received an exception:", error_msg));
     }
@@ -188,7 +187,7 @@ class MklFusedMatMulOp : public MklDnnMatMulOpBase<T> {
       } else if (post_op == "Relu6") {
         params.post_op_params.push_back({"relu6", {1.0, 6.0, 0.0}});
       } else if (post_op == "Elu") {
-        params.post_op_params.push_back({"elu", {1.0, 0.0, 0.0}});
+        params.post_op_params.push_back({"elu", {1.0, 1.0, 0.0}});
       } else {
         OP_REQUIRES_OK(
             ctx, errors::InvalidArgument(

--- a/tensorflow/core/kernels/mkl_matmul_ops_common.h
+++ b/tensorflow/core/kernels/mkl_matmul_ops_common.h
@@ -191,6 +191,20 @@ class MklDnnMatMulFwdPrimitive : public MklPrimitive {
           float op_beta = post_op_param.param[2];
           post_ops.append_eltwise(op_scale, mkldnn::eltwise_relu, op_alpha,
                                   op_beta);
+        } else if (post_op_param.name == "relu6") {
+          DCHECK_EQ(post_op_param.param.size(), 3);
+          float op_scale = post_op_param.param[0];
+          float op_alpha = post_op_param.param[1];
+          float op_beta = post_op_param.param[2];
+          post_ops.append_eltwise(op_scale, mkldnn::eltwise_bounded_relu,
+                                  op_alpha, op_beta);
+        } else if (post_op_param.name == "elu") {
+          DCHECK_EQ(post_op_param.param.size(), 3);
+          float op_scale = post_op_param.param[0];
+          float op_alpha = post_op_param.param[1];
+          float op_beta = post_op_param.param[2];
+          post_ops.append_eltwise(op_scale, mkldnn::eltwise_elu, op_alpha,
+                                  op_beta);
         } else if (post_op_param.name == "output_scale") {
           DCHECK_EQ(post_op_param.param.size(), 1);
           std::vector<float> scales;
@@ -198,6 +212,8 @@ class MklDnnMatMulFwdPrimitive : public MklPrimitive {
           post_ops_attr.set_output_scales(0, scales);
         } else {
           DCHECK((post_op_param.name == "relu") ||
+                 (post_op_param.name == "relu6") ||
+                 (post_op_param.name == "elu") ||
                  (post_op_param.name == "output_scale"));
         }
       }


### PR DESCRIPTION
This the 2nd part of Enable FP32 FusedMatMul(MatMul with BiasAdd) for MKL-DNN backend(https://github.com/tensorflow/tensorflow/pull/31782). It will fuse Relu/Relu6/Elu with FusedMatMul and rewrite it to MklFusedMatMul.


Modified:
- tensorflow/core/graph/mkl_layout_pass.cc
- tensorflow/core/kernels/mkl_fused_ops_test.cc
- tensorflow/core/kernels/mkl_matmul_op_fused.cc
- tensorflow/core/kernels/mkl_matmul_ops_common.h

Signed-off-by: Lu Teng teng.lu@intel.com