### PR TITLE
add INT8 quantization support for the OP RESIZE_NEAREST_NEIGHBOR

### DIFF
--- a/tensorflow/lite/tools/optimize/operator_property.cc
+++ b/tensorflow/lite/tools/optimize/operator_property.cc
@@ -270,6 +270,12 @@ OperatorProperty GetOperatorProperty(const BuiltinOperator& op) {
       property.restrict_same_input_output_scale = true;
       property.version = 2;
       break;
+    case BuiltinOperator_RESIZE_NEAREST_NEIGHBOR:
+      property.inputs = {{0, {}}};
+      property.outputs = {{0, {}}};
+      property.restrict_same_input_output_scale = true;
+      property.version = 2;
+      break;
     default:
       // No quantized implementation exists for this operation.
       property.quantizable = false;


### PR DESCRIPTION
This commit is to address the issue where UpSample2D was not supported during the tflite conversion with INT8 quantization. 

The bug was due to the missing `RESIZE_NEAREST_NEIGHBOR` property in `operator_property.cc`.

This addresses the issue https://github.com/tensorflow/tensorflow/issues/33438 .