### PR TITLE
loading break due to undefined symbol about constexpr const char*

### DIFF
--- a/tensorflow/core/common_runtime/lower_functional_ops.cc
+++ b/tensorflow/core/common_runtime/lower_functional_ops.cc
@@ -25,6 +25,11 @@ limitations under the License.
 
 namespace tensorflow {
 
+/*static*/ constexpr const char* const
+  LowerFunctionalOpsPass::kLowerUsingSwitchMergeAttr;
+/*static*/ constexpr const char* const
+  LowerFunctionalOpsPass::kLowerAsMultiDeviceFunctionAttr;
+
 namespace {
 
 constexpr const char* const kLowerUsingSwitchMergeAttr =


### PR DESCRIPTION
- Problem
  * when build with ```bazel build --config opt -c dbg //tensorflow/tools/pip_package:build_pip_package```, there is a symbol not found error around ```kLowerUsingSwitchMergeAttr ``` when a python program loads the output dynamic linked libraries. 

- Root Cause
  * this is related to the new C++ standard about ```constexpr const char*``` as discussed [here](https://stackoverflow.com/questions/8016780/undefined-reference-to-static-constexpr-char), and my local C++ compiler does not support this yet

- Solution
  * add definitions in .cc file and the problem is gone

I don't know why the standard build options (without ```-c dbg```) do not break though ...
