### PR TITLE
Improve math_ops.py docs

### DIFF
--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -317,7 +317,23 @@ class DivideDelegateWithName(object):
 @tf_export("math.divide", "divide")
 @dispatch.add_dispatch_support
 def divide(x, y, name=None):
-  """Computes Python style division of `x` by `y`."""
+  """Computes Python style division of `x` by `y`.
+  
+  For example:
+  ```python
+  import tensorflow as tf
+  x = tf.constant([16, 12, 11])
+  y = tf.constant([4, 6, 2])
+  tf.divide(x,y)  # [4. , 2. , 5.5]
+  ```
+  Args:
+    x: A `Tensor`
+    y: A `Tensor`
+    name: A name for the operation (optional).
+
+  Returns:
+    A `Tensor` with same shape as input
+  """
 
   if name is not None:
     # Cannot use tensors operator overload, because it has no way to track

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -3290,21 +3290,36 @@ def cumsum(x, axis=0, exclusive=False, reverse=False, name=None):
   element of the input is identical to the first element of the output:
 
   ```python
-  tf.cumsum([a, b, c])  # [a, a + b, a + b + c]
+  # tf.cumsum([a, b, c])   # [a, a + b, a + b + c]
+  x = tf.constant([2, 4, 6, 8])
+  tf.cumsum(x)    # [ 2,  6, 12, 20]
+  
+  # using varying `axis` values
+  y = tf.constant([[2, 4, 6, 8], [1,3,5,7]])
+
+  tf.cumsum(y, axis=0)    # [[ 2,  4,  6,  8],
+                          #  [ 3,  7, 11, 15]]
+
+  tf.cumsum(y, axis=1)    # [[ 2,  6, 12, 20],
+                          #  [ 1,  4,  9, 16]]
   ```
 
   By setting the `exclusive` kwarg to `True`, an exclusive cumsum is performed
   instead:
 
   ```python
-  tf.cumsum([a, b, c], exclusive=True)  # [0, a, a + b]
+  # tf.cumsum([a, b, c], exclusive=True)  => [0, a, a + b]
+  x = tf.constant([2, 4, 6, 8])
+  tf.cumsum(x, exclusive=True)   # [ 0,  2,  6, 12]
   ```
 
   By setting the `reverse` kwarg to `True`, the cumsum is performed in the
   opposite direction:
 
   ```python
-  tf.cumsum([a, b, c], reverse=True)  # [a + b + c, b + c, c]
+  # tf.cumsum([a, b, c], reverse=True)  # [a + b + c, b + c, c]
+  x = tf.constant([2, 4, 6, 8])
+  tf.cumsum(x, reverse=True)    # [20, 18, 14,  8]
   ```
 
   This is more efficient than using separate `tf.reverse` ops.
@@ -3312,7 +3327,9 @@ def cumsum(x, axis=0, exclusive=False, reverse=False, name=None):
   The `reverse` and `exclusive` kwargs can also be combined:
 
   ```python
-  tf.cumsum([a, b, c], exclusive=True, reverse=True)  # [b + c, c, 0]
+  # tf.cumsum([a, b, c], exclusive=True, reverse=True)  # [b + c, c, 0]
+  x = tf.constant([2, 4, 6, 8])
+  tf.cumsum(x, exclusive=True, reverse=True)    # [18, 14,  8,  0]
   ```
 
   Args:

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -324,7 +324,7 @@ def divide(x, y, name=None):
   >>> x = tf.constant([16, 12, 11])
   >>> y = tf.constant([4, 6, 2])
   >>> tf.divide(x,y)
-  <tf.Tensor: id=..., shape=(3,), dtype=float64, 
+  <tf.Tensor: shape=(3,), dtype=float64, 
   numpy=array([4. , 2. , 5.5])>
   
   Args:
@@ -3310,18 +3310,18 @@ def cumsum(x, axis=0, exclusive=False, reverse=False, name=None):
   # tf.cumsum([a, b, c])   # [a, a + b, a + b + c]
   >>> x = tf.constant([2, 4, 6, 8])
   >>> tf.cumsum(x)
-  <tf.Tensor: id=..., shape=(4,), dtype=int32, numpy=array([ 2,  6, 12, 20], dtype=int32)>
+  <tf.Tensor: shape=(4,), dtype=int32, numpy=array([ 2,  6, 12, 20], dtype=int32)>
   
   # using varying `axis` values
   >>> y = tf.constant([[2, 4, 6, 8], [1,3,5,7]])
 
   >>> tf.cumsum(y, axis=0)
-  <tf.Tensor: id=..., shape=(2, 4), dtype=int32, numpy=
+  <tf.Tensor: shape=(2, 4), dtype=int32, numpy=
   array([[ 2,  4,  6,  8],
          [ 3,  7, 11, 15]], dtype=int32)>
 
   >>> tf.cumsum(y, axis=1)
-  <tf.Tensor: id=..., shape=(2, 4), dtype=int32, numpy=
+  <tf.Tensor: shape=(2, 4), dtype=int32, numpy=
   array([[ 2,  6, 12, 20],
          [ 1,  4,  9, 16]], dtype=int32)>
  
@@ -3331,7 +3331,7 @@ def cumsum(x, axis=0, exclusive=False, reverse=False, name=None):
   # tf.cumsum([a, b, c], exclusive=True)  => [0, a, a + b]
   >>> x = tf.constant([2, 4, 6, 8])
   >>> tf.cumsum(x, exclusive=True)
-  <tf.Tensor: id=..., shape=(4,), dtype=int32, numpy=array([ 0,  2,  6, 12], dtype=int32)>
+  <tf.Tensor: shape=(4,), dtype=int32, numpy=array([ 0,  2,  6, 12], dtype=int32)>
 
   By setting the `reverse` kwarg to `True`, the cumsum is performed in the
   opposite direction:
@@ -3339,7 +3339,7 @@ def cumsum(x, axis=0, exclusive=False, reverse=False, name=None):
   # tf.cumsum([a, b, c], reverse=True)  # [a + b + c, b + c, c]
   >>> x = tf.constant([2, 4, 6, 8])
   >>> tf.cumsum(x, reverse=True) 
-  <tf.Tensor: id=..., shape=(4,), dtype=int32, numpy=array([20, 18, 14,  8], dtype=int32)>
+  <tf.Tensor: shape=(4,), dtype=int32, numpy=array([20, 18, 14,  8], dtype=int32)>
 
   This is more efficient than using separate `tf.reverse` ops.
 
@@ -3348,7 +3348,7 @@ def cumsum(x, axis=0, exclusive=False, reverse=False, name=None):
   # tf.cumsum([a, b, c], exclusive=True, reverse=True)  # [b + c, c, 0]
   >>> x = tf.constant([2, 4, 6, 8])
   >>> tf.cumsum(x, exclusive=True, reverse=True)
-  <tf.Tensor: id=..., shape=(4,), dtype=int32, numpy=array([18, 14,  8,  0], dtype=int32)>
+  <tf.Tensor: shape=(4,), dtype=int32, numpy=array([18, 14,  8,  0], dtype=int32)>
 
   Args:
     x: A `Tensor`. Must be one of the following types: `float32`, `float64`,

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -3313,13 +3313,13 @@ def cumsum(x, axis=0, exclusive=False, reverse=False, name=None):
 
   >>> tf.cumsum(y, axis=0)
   <tf.Tensor: id=..., shape=(2, 4), dtype=int32, numpy=
-array([[ 2,  4,  6,  8],
-       [ 3,  7, 11, 15]], dtype=int32)>
+  array([[ 2,  4,  6,  8],
+         [ 3,  7, 11, 15]], dtype=int32)>
 
   >>> tf.cumsum(y, axis=1)
   <tf.Tensor: id=..., shape=(2, 4), dtype=int32, numpy=
-array([[ 2,  6, 12, 20],
-       [ 1,  4,  9, 16]], dtype=int32)>
+  array([[ 2,  6, 12, 20],
+         [ 1,  4,  9, 16]], dtype=int32)>
  
 
   By setting the `exclusive` kwarg to `True`, an exclusive cumsum is performed

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -320,12 +320,10 @@ def divide(x, y, name=None):
   """Computes Python style division of `x` by `y`.
   
   For example:
-  ```python
-  import tensorflow as tf
-  x = tf.constant([16, 12, 11])
-  y = tf.constant([4, 6, 2])
-  tf.divide(x,y)  # [4. , 2. , 5.5]
-  ```
+  >>> x = tf.constant([16, 12, 11])
+  >>> y = tf.constant([4, 6, 2])
+  >>> tf.divide(x,y)
+  <tf.Tensor: id=..., shape=(3,), dtype=float64, numpy=array([4. , 2. , 5.5])>
   Args:
     x: A `Tensor`
     y: A `Tensor`
@@ -3305,48 +3303,49 @@ def cumsum(x, axis=0, exclusive=False, reverse=False, name=None):
   By default, this op performs an inclusive cumsum, which means that the first
   element of the input is identical to the first element of the output:
 
-  ```python
   # tf.cumsum([a, b, c])   # [a, a + b, a + b + c]
-  x = tf.constant([2, 4, 6, 8])
-  tf.cumsum(x)    # [ 2,  6, 12, 20]
+  >>> x = tf.constant([2, 4, 6, 8])
+  >>> tf.cumsum(x)
+  <tf.Tensor: id=..., shape=(4,), dtype=int32, numpy=array([ 2,  6, 12, 20], dtype=int32)>
   
   # using varying `axis` values
-  y = tf.constant([[2, 4, 6, 8], [1,3,5,7]])
+  >>> y = tf.constant([[2, 4, 6, 8], [1,3,5,7]])
 
-  tf.cumsum(y, axis=0)    # [[ 2,  4,  6,  8],
-                          #  [ 3,  7, 11, 15]]
+  >>> tf.cumsum(y, axis=0)
+  <tf.Tensor: id=..., shape=(2, 4), dtype=int32, numpy=
+array([[ 2,  4,  6,  8],
+       [ 3,  7, 11, 15]], dtype=int32)>
 
-  tf.cumsum(y, axis=1)    # [[ 2,  6, 12, 20],
-                          #  [ 1,  4,  9, 16]]
-  ```
+  >>> tf.cumsum(y, axis=1)
+  <tf.Tensor: id=..., shape=(2, 4), dtype=int32, numpy=
+array([[ 2,  6, 12, 20],
+       [ 1,  4,  9, 16]], dtype=int32)>
+ 
 
   By setting the `exclusive` kwarg to `True`, an exclusive cumsum is performed
   instead:
 
-  ```python
   # tf.cumsum([a, b, c], exclusive=True)  => [0, a, a + b]
-  x = tf.constant([2, 4, 6, 8])
-  tf.cumsum(x, exclusive=True)   # [ 0,  2,  6, 12]
-  ```
+  >>> x = tf.constant([2, 4, 6, 8])
+  >>> tf.cumsum(x, exclusive=True)
+  <tf.Tensor: id=..., shape=(4,), dtype=int32, numpy=array([ 0,  2,  6, 12], dtype=int32)>
 
   By setting the `reverse` kwarg to `True`, the cumsum is performed in the
   opposite direction:
 
-  ```python
   # tf.cumsum([a, b, c], reverse=True)  # [a + b + c, b + c, c]
-  x = tf.constant([2, 4, 6, 8])
-  tf.cumsum(x, reverse=True)    # [20, 18, 14,  8]
-  ```
+  >>> x = tf.constant([2, 4, 6, 8])
+  >>> tf.cumsum(x, reverse=True) 
+  <tf.Tensor: id=..., shape=(4,), dtype=int32, numpy=array([20, 18, 14,  8], dtype=int32)>
 
   This is more efficient than using separate `tf.reverse` ops.
 
   The `reverse` and `exclusive` kwargs can also be combined:
 
-  ```python
   # tf.cumsum([a, b, c], exclusive=True, reverse=True)  # [b + c, c, 0]
-  x = tf.constant([2, 4, 6, 8])
-  tf.cumsum(x, exclusive=True, reverse=True)    # [18, 14,  8,  0]
-  ```
+  >>> x = tf.constant([2, 4, 6, 8])
+  >>> tf.cumsum(x, exclusive=True, reverse=True)
+  <tf.Tensor: id=..., shape=(4,), dtype=int32, numpy=array([18, 14,  8,  0], dtype=int32)>
 
   Args:
     x: A `Tensor`. Must be one of the following types: `float32`, `float64`,

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -320,12 +320,22 @@ def divide(x, y, name=None):
   """Computes Python style division of `x` by `y`.
   
   For example:
+<<<<<<< HEAD
   ```python
   import tensorflow as tf
   x = tf.constant([16, 12, 11])
   y = tf.constant([4, 6, 2])
   tf.divide(x,y)  # [4. , 2. , 5.5]
   ```
+=======
+  
+  >>> x = tf.constant([16, 12, 11])
+  >>> y = tf.constant([4, 6, 2])
+  >>> tf.divide(x,y)
+  <tf.Tensor: shape=(3,), dtype=float64, 
+  numpy=array([4. , 2. , 5.5])>
+  
+>>>>>>> 84209d4d47... make test pass
   Args:
     x: A `Tensor`
     y: A `Tensor`
@@ -3307,6 +3317,7 @@ def cumsum(x, axis=0, exclusive=False, reverse=False, name=None):
 
   ```python
   # tf.cumsum([a, b, c])   # [a, a + b, a + b + c]
+<<<<<<< HEAD
   x = tf.constant([2, 4, 6, 8])
   tf.cumsum(x)    # [ 2,  6, 12, 20]
   
@@ -3320,23 +3331,54 @@ def cumsum(x, axis=0, exclusive=False, reverse=False, name=None):
                           #  [ 1,  4,  9, 16]]
   ```
 
+=======
+  >>> x = tf.constant([2, 4, 6, 8])
+  >>> tf.cumsum(x)
+  <tf.Tensor: shape=(4,), dtype=int32, numpy=array([ 2,  6, 12, 20], dtype=int32)>
+  
+  # using varying `axis` values
+  >>> y = tf.constant([[2, 4, 6, 8], [1,3,5,7]])
+
+  >>> tf.cumsum(y, axis=0)
+  <tf.Tensor: shape=(2, 4), dtype=int32, numpy=
+  array([[ 2,  4,  6,  8],
+         [ 3,  7, 11, 15]], dtype=int32)>
+
+  >>> tf.cumsum(y, axis=1)
+  <tf.Tensor: shape=(2, 4), dtype=int32, numpy=
+  array([[ 2,  6, 12, 20],
+         [ 1,  4,  9, 16]], dtype=int32)>
+ 
+>>>>>>> 84209d4d47... make test pass
   By setting the `exclusive` kwarg to `True`, an exclusive cumsum is performed
   instead:
 
   ```python
   # tf.cumsum([a, b, c], exclusive=True)  => [0, a, a + b]
+<<<<<<< HEAD
   x = tf.constant([2, 4, 6, 8])
   tf.cumsum(x, exclusive=True)   # [ 0,  2,  6, 12]
   ```
+=======
+  >>> x = tf.constant([2, 4, 6, 8])
+  >>> tf.cumsum(x, exclusive=True)
+  <tf.Tensor: shape=(4,), dtype=int32, numpy=array([ 0,  2,  6, 12], dtype=int32)>
+>>>>>>> 84209d4d47... make test pass
 
   By setting the `reverse` kwarg to `True`, the cumsum is performed in the
   opposite direction:
 
   ```python
   # tf.cumsum([a, b, c], reverse=True)  # [a + b + c, b + c, c]
+<<<<<<< HEAD
   x = tf.constant([2, 4, 6, 8])
   tf.cumsum(x, reverse=True)    # [20, 18, 14,  8]
   ```
+=======
+  >>> x = tf.constant([2, 4, 6, 8])
+  >>> tf.cumsum(x, reverse=True) 
+  <tf.Tensor: shape=(4,), dtype=int32, numpy=array([20, 18, 14,  8], dtype=int32)>
+>>>>>>> 84209d4d47... make test pass
 
   This is more efficient than using separate `tf.reverse` ops.
 
@@ -3344,9 +3386,15 @@ def cumsum(x, axis=0, exclusive=False, reverse=False, name=None):
 
   ```python
   # tf.cumsum([a, b, c], exclusive=True, reverse=True)  # [b + c, c, 0]
+<<<<<<< HEAD
   x = tf.constant([2, 4, 6, 8])
   tf.cumsum(x, exclusive=True, reverse=True)    # [18, 14,  8,  0]
   ```
+=======
+  >>> x = tf.constant([2, 4, 6, 8])
+  >>> tf.cumsum(x, exclusive=True, reverse=True)
+  <tf.Tensor: shape=(4,), dtype=int32, numpy=array([18, 14,  8,  0], dtype=int32)>
+>>>>>>> 84209d4d47... make test pass
 
   Args:
     x: A `Tensor`. Must be one of the following types: `float32`, `float64`,

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -324,7 +324,8 @@ def divide(x, y, name=None):
   >>> x = tf.constant([16, 12, 11])
   >>> y = tf.constant([4, 6, 2])
   >>> tf.divide(x,y)
-  <tf.Tensor: id=..., shape=(3,), dtype=float64, numpy=array([4. , 2. , 5.5])>
+  <tf.Tensor: id=..., shape=(3,), dtype=float64, 
+  numpy=array([4. , 2. , 5.5])>
   
   Args:
     x: A `Tensor`

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -320,10 +320,12 @@ def divide(x, y, name=None):
   """Computes Python style division of `x` by `y`.
   
   For example:
+  
   >>> x = tf.constant([16, 12, 11])
   >>> y = tf.constant([4, 6, 2])
   >>> tf.divide(x,y)
   <tf.Tensor: id=..., shape=(3,), dtype=float64, numpy=array([4. , 2. , 5.5])>
+  
   Args:
     x: A `Tensor`
     y: A `Tensor`
@@ -3302,6 +3304,7 @@ def cumsum(x, axis=0, exclusive=False, reverse=False, name=None):
 
   By default, this op performs an inclusive cumsum, which means that the first
   element of the input is identical to the first element of the output:
+  For example:
 
   # tf.cumsum([a, b, c])   # [a, a + b, a + b + c]
   >>> x = tf.constant([2, 4, 6, 8])
@@ -3321,7 +3324,6 @@ def cumsum(x, axis=0, exclusive=False, reverse=False, name=None):
   array([[ 2,  6, 12, 20],
          [ 1,  4,  9, 16]], dtype=int32)>
  
-
   By setting the `exclusive` kwarg to `True`, an exclusive cumsum is performed
   instead:
 


### PR DESCRIPTION
Added usage examples to the tf.math.cumsum() docstring. What exists currently is syntax-like declarations and not  `self contained` code samples.