### PR TITLE
Do not use memcpy in Go

### DIFF
--- a/tensorflow/go/graph.go
+++ b/tensorflow/go/graph.go
@@ -128,12 +128,7 @@ func (g *Graph) ImportWithOptions(def []byte, options GraphImportOptions) error 
 	// with "go vet" till https://github.com/golang/go/issues/17201 is
 	// resolved.
 	buf.length = C.size_t(len(def))
-	buf.data = C.malloc(buf.length)
-	if buf.data == nil {
-		return fmt.Errorf("unable to allocate memory")
-	}
-	defer C.free(buf.data)
-	C.memcpy(buf.data, C.CBytes(def), buf.length)
+	buf.data = C.CBytes(def)
 
 	status := newStatus()
 

--- a/tensorflow/go/graph.go
+++ b/tensorflow/go/graph.go
@@ -133,7 +133,8 @@ func (g *Graph) ImportWithOptions(def []byte, options GraphImportOptions) error 
 		return fmt.Errorf("unable to allocate memory")
 	}
 	defer C.free(buf.data)
-	C.memcpy(buf.data, unsafe.Pointer(&def[0]), buf.length)
+	pbuf := (*[1 << 30]byte)(buf.data)
+	copy(pbuf[:], def)
 
 	status := newStatus()
 

--- a/tensorflow/go/graph.go
+++ b/tensorflow/go/graph.go
@@ -124,11 +124,12 @@ func (g *Graph) ImportWithOptions(def []byte, options GraphImportOptions) error 
 
 	buf := C.TF_NewBuffer()
 	defer C.TF_DeleteBuffer(buf)
-	// Would have preferred to use C.CBytes, but that does not play well
-	// with "go vet" till https://github.com/golang/go/issues/17201 is
-	// resolved.
 	buf.length = C.size_t(len(def))
 	buf.data = C.CBytes(def)
+	if buf.data == nil {
+		return fmt.Errorf("unable to allocate memory")
+	}
+	defer C.free(buf.data)
 
 	status := newStatus()
 

--- a/tensorflow/go/graph.go
+++ b/tensorflow/go/graph.go
@@ -133,8 +133,7 @@ func (g *Graph) ImportWithOptions(def []byte, options GraphImportOptions) error 
 		return fmt.Errorf("unable to allocate memory")
 	}
 	defer C.free(buf.data)
-	pbuf := (*[1 << 30]byte)(buf.data)
-	copy(pbuf[:], def)
+	C.memcpy(buf.data, C.CBytes(def), buf.length)
 
 	status := newStatus()
 


### PR DESCRIPTION
Recently, Go added new cgocheck for doubtful usage of pointer.

https://github.com/golang/go/commit/f9226454b9830dd7fe6405bdb2953a6747dce41b

```
fatal error: can't happen

goroutine 1 [running]:
runtime.throw(0x640e64, 0xc)
	C:/dev/go/src/runtime/panic.go:774 +0x79 fp=0xc00007f970 sp=0xc00007f940 pc=0x430e49
runtime.cgoCheckPointer(0x5eec00, 0xc0000c0000, 0xc000044460, 0x1)
	C:/dev/go/src/runtime/cgocall.go:448 +0x1b9 fp=0xc00007f9b8 sp=0xc00007f970 pc=0x404a79
github.com/tensorflow/tensorflow/tensorflow/go.(*Graph).ImportWithOptions.func8(0x3260cb0, 0xc00007fba0, 0xf86f60)
	C:/Users/mattn/go/src/github.com/tensorflow/tensorflow/tensorflow/go/graph.go:136 +0x10d fp=0xc00007fa10 sp=0xc00007f9b8 pc=0x5a3a3d
github.com/tensorflow/tensorflow/tensorflow/go.(*Graph).ImportWithOptions(0xc000006088, 0xc0000c0000, 0x1bd5509, 0x1bd5709, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	C:/Users/mattn/go/src/github.com/tensorflow/tensorflow/tensorflow/go/graph.go:136 +0x1f3 fp=0xc00007fb98 sp=0xc00007fa10 pc=0x598563
github.com/tensorflow/tensorflow/tensorflow/go.(*Graph).Import(...)
	C:/Users/mattn/go/src/github.com/tensorflow/tensorflow/tensorflow/go/graph.go:153
main.main()
	C:/Users/mattn/go/src/github.com/mattn/go-object-detect-from-image/main.go:159 +0x577 fp=0xc00007ff60 sp=0xc00007fb98 pc=0x5ac4d7
runtime.main()
	C:/dev/go/src/runtime/proc.go:203 +0x21e fp=0xc00007ffe0 sp=0xc00007ff60 pc=0x43281e
runtime.goexit()
	C:/dev/go/src/runtime/asm_amd64.s:1375 +0x1 fp=0xc00007ffe8 sp=0xc00007ffe0 pc=0x45b4e1
```

This pull-request fix to not use memcpy. cc: @mdempsky 