### PR TITLE
updated code snippets for tensor scatter operation

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_ScatterNd.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ScatterNd.pbtxt
@@ -70,8 +70,7 @@ In Python, this scatter operation would look like this:
     updates = tf.constant([9, 10, 11, 12])
     shape = tf.constant([8])
     scatter = tf.scatter_nd(indices, updates, shape)
-    with tf.Session() as sess:
-      print(sess.run(scatter))
+    print(scatter)
 ```
 
 The resulting tensor would look like this:
@@ -96,8 +95,7 @@ In Python, this scatter operation would look like this:
                             [7, 7, 7, 7], [8, 8, 8, 8]]])
     shape = tf.constant([4, 4, 4])
     scatter = tf.scatter_nd(indices, updates, shape)
-    with tf.Session() as sess:
-      print(sess.run(scatter))
+    print(scatter)
 ```
 
 The resulting tensor would look like this:

--- a/tensorflow/core/api_def/base_api/api_def_TensorScatterAdd.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_TensorScatterAdd.pbtxt
@@ -54,9 +54,8 @@ In Python, this scatter add operation would look like this:
     indices = tf.constant([[4], [3], [1], [7]])
     updates = tf.constant([9, 10, 11, 12])
     tensor = tf.ones([8], dtype=tf.int32)
-    updated = tf.tensor_scatter_add(tensor, indices, updates)
-    with tf.Session() as sess:
-      print(sess.run(updated))
+    updated = tf.tensor_scatter_nd_add(tensor, indices, updates)
+    print(updated)
 ```
 
 The resulting tensor would look like this:
@@ -75,10 +74,9 @@ In Python, this scatter add operation would look like this:
                             [7, 7, 7, 7], [8, 8, 8, 8]],
                            [[5, 5, 5, 5], [6, 6, 6, 6],
                             [7, 7, 7, 7], [8, 8, 8, 8]]])
-    tensor = tf.ones([4, 4, 4])
-    updated = tf.tensor_scatter_add(tensor, indices, updates)
-    with tf.Session() as sess:
-      print(sess.run(updated))
+    tensor = tf.ones([4, 4, 4],dtype=tf.int32)
+    updated = tf.tensor_scatter_nd_add(tensor, indices, updates)
+    print(updated)
 ```
 
 The resulting tensor would look like this:

--- a/tensorflow/core/api_def/base_api/api_def_TensorScatterSub.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_TensorScatterSub.pbtxt
@@ -54,9 +54,8 @@ In Python, this scatter subtract operation would look like this:
     indices = tf.constant([[4], [3], [1], [7]])
     updates = tf.constant([9, 10, 11, 12])
     tensor = tf.ones([8], dtype=tf.int32)
-    updated = tf.tensor_scatter_sub(tensor, indices, updates)
-    with tf.Session() as sess:
-      print(sess.run(scatter))
+    updated = tf.tensor_scatter_nd_sub(tensor, indices, updates)
+    print(updated)
 ```
 
 The resulting tensor would look like this:
@@ -75,10 +74,9 @@ In Python, this scatter add operation would look like this:
                             [7, 7, 7, 7], [8, 8, 8, 8]],
                            [[5, 5, 5, 5], [6, 6, 6, 6],
                             [7, 7, 7, 7], [8, 8, 8, 8]]])
-    tensor = tf.ones([4, 4, 4])
-    updated = tf.tensor_scatter_sub(tensor, indices, updates)
-    with tf.Session() as sess:
-      print(sess.run(scatter))
+    tensor = tf.ones([4, 4, 4],dtype=tf.int32)
+    updated = tf.tensor_scatter_nd_sub(tensor, indices, updates)
+    print(updated)
 ```
 
 The resulting tensor would look like this:

--- a/tensorflow/core/api_def/base_api/api_def_TensorScatterUpdate.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_TensorScatterUpdate.pbtxt
@@ -66,9 +66,8 @@ In Python, this scatter operation would look like this:
     indices = tf.constant([[4], [3], [1], [7]])
     updates = tf.constant([9, 10, 11, 12])
     tensor = tf.ones([8], dtype=tf.int32)
-    updated = tf.tensor_scatter_update(tensor, indices, updates)
-    with tf.Session() as sess:
-      print(sess.run(scatter))
+    updated = tf.tensor_scatter_nd_update(tensor, indices, updates)
+    print(updated)
 ```
 
 The resulting tensor would look like this:
@@ -87,10 +86,9 @@ In Python, this scatter operation would look like this:
                             [7, 7, 7, 7], [8, 8, 8, 8]],
                            [[5, 5, 5, 5], [6, 6, 6, 6],
                             [7, 7, 7, 7], [8, 8, 8, 8]]])
-    tensor = tf.ones([4, 4, 4])
-    updated = tf.tensor_scatter_update(tensor, indices, updates)
-    with tf.Session() as sess:
-      print(sess.run(scatter))
+    tensor = tf.ones([4, 4, 4],dtype=tf.int32)
+    updated = tf.tensor_scatter_nd_update(tensor, indices, updates)
+    print(updated)
 ```
 
 The resulting tensor would look like this:


### PR DESCRIPTION
Docs code snippets updated to work with TensorFlow 2.0

Docs updated for following TensorFlow operations : 
- `tf.scatter_nd`
- `tf.tensor_scatter_nd_add`
- `tf.tensor_scatter_nd_sub`
- `tf.tensor_scatter_nd_update`

Changes :
 - Removed tf.Session() 
 - Added `tf.int32` dtype for `tensor` variable as it should be same dtype as `updates` . By default tf.ones() create tensor of dtype `tf.float32`