### PR TITLE
Throw error on build_pip_package --cpu --gpu

### DIFF
--- a/tensorflow/tools/pip_package/build_pip_package.sh
+++ b/tensorflow/tools/pip_package/build_pip_package.sh
@@ -262,6 +262,13 @@ function main() {
     elif [[ "$1" == "--nightly_flag" ]]; then
       NIGHTLY_BUILD=1
     elif [[ "$1" == "--gpu" ]]; then
+      # Check that --cpu has not been passed.
+      if [[ ${PROJECT_NAME_CPU} == "1" ]]; then
+        echo "Specifying both --cpu and --gpu to build_pip_package is not allowed."
+        usage
+        exit 1
+      fi
+
       GPU_BUILD=1
     elif [[ "$1" == "--cpu" ]]; then
       # Check that --gpu has not been passed.

--- a/tensorflow/tools/pip_package/build_pip_package.sh
+++ b/tensorflow/tools/pip_package/build_pip_package.sh
@@ -293,7 +293,7 @@ function main() {
     fi
   done
 
-  if [[ $(( GPU_BUILD + CPU_BUILD + GPUDIRECT_BUILD + ROCM_BUILD )) -le "1" ]]; then
+  if [[ $(( GPU_BUILD + CPU_BUILD + GPUDIRECT_BUILD + ROCM_BUILD )) -gt "1" ]]; then
     echo "Only one of [--gpu, --cpu, --gpudirect, --rocm] may be provided."
     usage
     exit 1

--- a/tensorflow/tools/pip_package/build_pip_package.sh
+++ b/tensorflow/tools/pip_package/build_pip_package.sh
@@ -248,8 +248,9 @@ function usage() {
 function main() {
   PKG_NAME_FLAG=""
   PROJECT_NAME=""
+  CPU_BUILD=0
   GPU_BUILD=0
-  PROJECT_NAME_CPU=0
+  GPUDIRECT_BUILD=0
   ROCM_BUILD=0
   NIGHTLY_BUILD=0
   SRCDIR=""
@@ -262,25 +263,11 @@ function main() {
     elif [[ "$1" == "--nightly_flag" ]]; then
       NIGHTLY_BUILD=1
     elif [[ "$1" == "--gpu" ]]; then
-      # Check that --cpu has not been passed.
-      if [[ ${PROJECT_NAME_CPU} == "1" ]]; then
-        echo "Specifying both --cpu and --gpu to build_pip_package is not allowed."
-        usage
-        exit 1
-      fi
-
       GPU_BUILD=1
     elif [[ "$1" == "--cpu" ]]; then
-      # Check that --gpu has not been passed.
-      if [[ ${GPU_BUILD} == "1" ]]; then
-        echo "Specifying both --cpu and --gpu to build_pip_package is not allowed."
-        usage
-        exit 1
-      fi
-
-      PROJECT_NAME_CPU=1
+      CPU_BUILD=1
     elif [[ "$1" == "--gpudirect" ]]; then
-      PKG_NAME_FLAG="--project_name tensorflow_gpudirect"
+      GPUDIRECT_BUILD=1
     elif [[ "$1" == "--rocm" ]]; then
       ROCM_BUILD=1
     elif [[ "$1" == "--project_name" ]]; then
@@ -306,6 +293,12 @@ function main() {
     fi
   done
 
+  if [[ $(( GPU_BUILD + CPU_BUILD + GPUDIRECT_BUILD + ROCM_BUILD )) -le "1" ]]; then
+    echo "Only one of [--gpu, --cpu, --gpudirect, --rocm] may be provided."
+    usage
+    exit 1
+  fi
+
   if [[ -z "$DSTDIR" ]] && [[ -z "$SRCDIR" ]]; then
     echo "No destination dir provided"
     usage
@@ -328,17 +321,21 @@ function main() {
     PKG_NAME_FLAG="--project_name ${PROJECT_NAME}"
   elif [[ ${NIGHTLY_BUILD} == "1" && ${GPU_BUILD} == "1" ]]; then
     PKG_NAME_FLAG="--project_name tf_nightly_gpu"
+  elif [[ ${NIGHTLY_BUILD} == "1" && ${GPUDIRECT_BUILD} == "1" ]]; then
+    PKG_NAME_FLAG="--project_name tf_nightly_gpudirect"
   elif [[ ${NIGHTLY_BUILD} == "1" && ${ROCM_BUILD} == "1" ]]; then
     PKG_NAME_FLAG="--project_name tf_nightly_rocm"
-  elif [[ ${NIGHTLY_BUILD} == "1" && ${PROJECT_NAME_CPU} == "1" ]]; then
+  elif [[ ${NIGHTLY_BUILD} == "1" && ${CPU_BUILD} == "1" ]]; then
     PKG_NAME_FLAG="--project_name tf_nightly_cpu"
   elif [[ ${NIGHTLY_BUILD} == "1" ]]; then
     PKG_NAME_FLAG="--project_name tf_nightly"
   elif [[ ${GPU_BUILD} == "1" ]]; then
     PKG_NAME_FLAG="--project_name tensorflow_gpu"
+  elif [[ ${GPUDIRECT_BUILD} == "1" ]]; then
+    PKG_NAME_FLAG="--project_name tensorflow_gpudirect"
   elif [[ ${ROCM_BUILD} == "1" ]]; then
     PKG_NAME_FLAG="--project_name tensorflow_rocm"
-  elif [[ ${PROJECT_NAME_CPU} == "1" ]]; then
+  elif [[ ${CPU_BUILD} == "1" ]]; then
     PKG_NAME_FLAG="--project_name tensorflow_cpu"
   fi
 


### PR DESCRIPTION
Previously, running
`./bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/tensorflow_pkg --gpu --cpu`
would fail as desired, but 
`./bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/tensorflow_pkg --cpu --gpu`
would succeed.

This simple bash script change checks both cases.