### PR TITLE
Enable use of cudnn for Batchnorm by default

### DIFF
--- a/tensorflow/compiler/xla/debug_options_flags.cc
+++ b/tensorflow/compiler/xla/debug_options_flags.cc
@@ -42,9 +42,8 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_cpu_use_mkl_dnn(true);
 #endif  // INTEL_MKL
   opts.set_xla_gpu_max_kernel_unroll_factor(4);
-  // Set cudnn batchnorm off by default; it does not provide a performance win
-  // on average.
-  opts.set_xla_gpu_use_cudnn_batchnorm(false);
+  // Set cudnn batchnorm on by default.
+  opts.set_xla_gpu_use_cudnn_batchnorm(true);
 
   // Run all GPU work on one stream by default.  Using multiple streams
   // increases memory usage and we lack strong motivating benchmarks for tuning

--- a/tensorflow/compiler/xla/debug_options_flags.cc
+++ b/tensorflow/compiler/xla/debug_options_flags.cc
@@ -43,7 +43,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
 #endif  // INTEL_MKL
   opts.set_xla_gpu_max_kernel_unroll_factor(4);
   // Set cudnn batchnorm on by default.
-  opts.set_xla_gpu_use_cudnn_batchnorm(true);
+  opts.set_xla_gpu_use_cudnn_batchnorm(false);
 
   // Run all GPU work on one stream by default.  Using multiple streams
   // increases memory usage and we lack strong motivating benchmarks for tuning

--- a/tensorflow/compiler/xla/debug_options_flags.cc
+++ b/tensorflow/compiler/xla/debug_options_flags.cc
@@ -42,7 +42,8 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_cpu_use_mkl_dnn(true);
 #endif  // INTEL_MKL
   opts.set_xla_gpu_max_kernel_unroll_factor(4);
-  // Set cudnn batchnorm on by default.
+  // Set cudnn batchnorm off by default; it does not provide a performance win
+  // on average.
   opts.set_xla_gpu_use_cudnn_batchnorm(false);
 
   // Run all GPU work on one stream by default.  Using multiple streams

--- a/tensorflow/compiler/xla/service/gpu/cudnn_batchnorm_rewriter.cc
+++ b/tensorflow/compiler/xla/service/gpu/cudnn_batchnorm_rewriter.cc
@@ -92,10 +92,9 @@ Status Visitor::HandleBatchNormInference(HloInstruction* batch_norm) {
   std::vector<HloInstruction*> operands(batch_norm->operands().begin(),
                                         batch_norm->operands().end());
 
-  bool is_batchnorm_with_fp16_inputs = false;
-  if (IsF32BatchNormWithFP16Inputs(batch_norm)) {
+  bool is_batchnorm_with_fp16_inputs = IsF32BatchNormWithFP16Inputs(batch_norm);
+  if (is_batchnorm_with_fp16_inputs) {
     operands[0] = AddConvert(batch_norm->mutable_operand(0), F16);
-    is_batchnorm_with_fp16_inputs = true;
   }
   operands.push_back(epsilon);
   operands.push_back(feature_index);
@@ -144,10 +143,9 @@ Status Visitor::HandleBatchNormTraining(HloInstruction* batch_norm) {
 
   std::vector<HloInstruction*> operands(batch_norm->operands().begin(),
                                         batch_norm->operands().end());
-  bool is_batchnorm_with_fp16_inputs = false;
-  if (IsF32BatchNormWithFP16Inputs(batch_norm)) {
+  bool is_batchnorm_with_fp16_inputs = IsF32BatchNormWithFP16Inputs(batch_norm);
+  if (is_batchnorm_with_fp16_inputs) {
     operands[0] = AddConvert(batch_norm->mutable_operand(0), F16);
-    is_batchnorm_with_fp16_inputs = true;
   }
   operands.push_back(epsilon);
   operands.push_back(feature_index);
@@ -246,8 +244,8 @@ Status Visitor::HandleBatchNormGrad(HloInstruction* batch_norm) {
 
   std::vector<HloInstruction*> operands(batch_norm->operands().begin(),
                                         batch_norm->operands().end());
-  bool is_batchnorm_with_fp16_inputs = false;
-  if (IsF32BatchNormWithFP16Inputs(batch_norm)) {
+  bool is_batchnorm_with_fp16_inputs = IsF32BatchNormWithFP16Inputs(batch_norm);
+  if (is_batchnorm_with_fp16_inputs) {
     HloInstruction* operand_0_convert = batch_norm->mutable_operand(0);
     operands[0] = AddConvert(operand_0_convert, F16);
     for (auto index = 1; index < operands.size(); index++) {
@@ -259,7 +257,6 @@ Status Visitor::HandleBatchNormGrad(HloInstruction* batch_norm) {
         operands[index] = AddConvert(batch_norm->mutable_operand(index), F16);
       }
     }
-    is_batchnorm_with_fp16_inputs = true;
   }
   operands[3] = inverse_stddev;
   operands.push_back(epsilon);

--- a/tensorflow/compiler/xla/service/gpu/cudnn_batchnorm_rewriter.cc
+++ b/tensorflow/compiler/xla/service/gpu/cudnn_batchnorm_rewriter.cc
@@ -45,12 +45,25 @@ class Visitor : public DfsHloVisitorWithDefault {
  private:
   bool changed_ = false;
   HloComputation* computation_;
+  HloInstruction* AddConvert(HloInstruction* hlo, PrimitiveType elem_type) {
+    const Shape& shape_ = ShapeUtil::ChangeElementType(hlo->shape(), elem_type);
+    return this->computation_->AddInstruction(
+        HloInstruction::CreateConvert(shape_, hlo));
+  }
 };
 
 // cudnn defines CUDNN_BN_MIN_EPSILON = 1e-5 as the minimum acceptable epsilon
 // for calls to its batchnorm ops.
 bool EpsilonInRange(HloInstruction* batch_norm) {
   return batch_norm->epsilon() >= 1e-5;
+}
+
+bool IsF32BatchNormWithFP16Inputs(HloInstruction* batch_norm) {
+  auto convert = batch_norm->operand(0);
+  if (convert->opcode() != HloOpcode::kConvert) {
+    return false;
+  }
+  return convert->operand(0)->shape().element_type() == F16;
 }
 
 Status Visitor::HandleBatchNormInference(HloInstruction* batch_norm) {
@@ -78,13 +91,28 @@ Status Visitor::HandleBatchNormInference(HloInstruction* batch_norm) {
 
   std::vector<HloInstruction*> operands(batch_norm->operands().begin(),
                                         batch_norm->operands().end());
+
+  if (IsF32BatchNormWithFP16Inputs(batch_norm)) {
+    operands[0] = AddConvert(batch_norm->mutable_operand(0), F16);
+  }
   operands.push_back(epsilon);
   operands.push_back(feature_index);
 
-  std::unique_ptr<HloInstruction> libcall = HloInstruction::CreateCustomCall(
-      batch_norm->shape(), operands, kCudnnBatchNormForwardInferenceCallTarget);
-  TF_RETURN_IF_ERROR(
-      computation_->ReplaceWithNewInstruction(batch_norm, std::move(libcall)));
+  auto batch_norm_shape = ShapeUtil::MakeShape(
+      operands[0]->shape().element_type(), batch_norm->shape().dimensions());
+
+  auto batchnorm_inference_result = HloInstruction::CreateCustomCall(
+      batch_norm_shape, operands, kCudnnBatchNormForwardInferenceCallTarget);
+  if (IsF32BatchNormWithFP16Inputs(batch_norm)) {
+    HloInstruction* libcall =
+        computation_->AddInstruction(std::move(batchnorm_inference_result));
+    Shape shape_f32 = ShapeUtil::ChangeElementType(libcall->shape(), F32);
+    batchnorm_inference_result =
+        HloInstruction::CreateConvert(shape_f32, libcall);
+  }
+
+  TF_RETURN_IF_ERROR(computation_->ReplaceWithNewInstruction(
+      batch_norm, std::move(batchnorm_inference_result)));
   changed_ = true;
   return Status::OK();
 }
@@ -114,12 +142,26 @@ Status Visitor::HandleBatchNormTraining(HloInstruction* batch_norm) {
 
   std::vector<HloInstruction*> operands(batch_norm->operands().begin(),
                                         batch_norm->operands().end());
+
+  if (IsF32BatchNormWithFP16Inputs(batch_norm)) {
+    operands[0] = AddConvert(batch_norm->mutable_operand(0), F16);
+  }
   operands.push_back(epsilon);
   operands.push_back(feature_index);
 
+  std::vector<Shape> batch_norm_tuple_shape;
+  batch_norm_tuple_shape.push_back(
+      ShapeUtil::MakeShape(operands[0]->shape().element_type(),
+                           batch_norm->shape().tuple_shapes(0).dimensions()));
+  for (int i = 1; i < batch_norm->shape().tuple_shapes_size(); i++) {
+    batch_norm_tuple_shape.push_back(batch_norm->shape().tuple_shapes(i));
+  }
+  const Shape& batch_norm_shape =
+      ShapeUtil::MakeTupleShape(batch_norm_tuple_shape);
+
   HloInstruction* libcall =
       computation_->AddInstruction(HloInstruction::CreateCustomCall(
-          batch_norm->shape(), operands,
+          batch_norm_shape, operands,
           kCudnnBatchNormForwardTrainingCallTarget));
 
   // The cudnn libcall returns a tuple
@@ -143,17 +185,33 @@ Status Visitor::HandleBatchNormTraining(HloInstruction* batch_norm) {
           computation_->AddInstruction(HloInstruction::CreateBroadcast(
               variance_plus_epsilon->shape(), epsilon, {}))));
 
-  // Repackage the results.
-  std::unique_ptr<HloInstruction> new_tuple = HloInstruction::CreateTuple({
+  HloInstruction* new_tuple =
+      computation_->AddInstruction(HloInstruction::CreateTuple({
+          computation_->AddInstruction(HloInstruction::CreateGetTupleElement(
+              libcall->shape().tuple_shapes(0), libcall, 0)),
+          computation_->AddInstruction(HloInstruction::CreateGetTupleElement(
+              libcall->shape().tuple_shapes(1), libcall, 1)),
+          variance,
+      }));
+
+  HloInstruction* new_gte =
       computation_->AddInstruction(HloInstruction::CreateGetTupleElement(
-          libcall->shape().tuple_shapes(0), libcall, 0)),
-      computation_->AddInstruction(HloInstruction::CreateGetTupleElement(
-          libcall->shape().tuple_shapes(1), libcall, 1)),
-      variance,
-  });
+          new_tuple->shape().tuple_shapes(0), new_tuple, 0));
+
+  if (IsF32BatchNormWithFP16Inputs(batch_norm)) {
+    new_gte = AddConvert(new_gte, F32);
+  }
+  // Repackage the results. Athough this tuple is redundant when convert is not
+  // inserted, TupleSimplifier eliminates the Tuple eventually
+  std::unique_ptr<HloInstruction> replacing_tuple = HloInstruction::CreateTuple(
+      {new_gte,
+       computation_->AddInstruction(HloInstruction::CreateGetTupleElement(
+           new_tuple->shape().tuple_shapes(1), new_tuple, 1)),
+       computation_->AddInstruction(HloInstruction::CreateGetTupleElement(
+           new_tuple->shape().tuple_shapes(1), new_tuple, 2))});
 
   TF_RETURN_IF_ERROR(computation_->ReplaceWithNewInstruction(
-      batch_norm, std::move(new_tuple)));
+      batch_norm, std::move(replacing_tuple)));
   changed_ = true;
   return Status::OK();
 }
@@ -195,15 +253,54 @@ Status Visitor::HandleBatchNormGrad(HloInstruction* batch_norm) {
 
   std::vector<HloInstruction*> operands(batch_norm->operands().begin(),
                                         batch_norm->operands().end());
+  if (IsF32BatchNormWithFP16Inputs(batch_norm)) {
+    HloInstruction* operand_0_convert = batch_norm->mutable_operand(0);
+    operands[0] = AddConvert(operand_0_convert, F16);
+    for (auto index = 1; index < operands.size(); index++) {
+      if (batch_norm->operand(index)->opcode() == HloOpcode::kConvert &&
+          batch_norm->operand(index)->operand(0)->shape().element_type() ==
+              F16 &&
+          ShapeUtil::Compatible(operand_0_convert->shape(),
+                                batch_norm->mutable_operand(index)->shape())) {
+        operands[index] = AddConvert(batch_norm->mutable_operand(index), F16);
+      }
+    }
+  }
   operands[3] = inverse_stddev;
   operands.push_back(epsilon);
   operands.push_back(feature_index);
 
-  std::unique_ptr<HloInstruction> libcall = HloInstruction::CreateCustomCall(
-      batch_norm->shape(), operands, kCudnnBatchNormBackwardCallTarget);
+  std::vector<Shape> batch_norm_tuple_shape;
+  batch_norm_tuple_shape.push_back(
+      ShapeUtil::MakeShape(operands[0]->shape().element_type(),
+                           batch_norm->shape().tuple_shapes(0).dimensions()));
+  for (int i = 1; i < batch_norm->shape().tuple_shapes_size(); i++) {
+    batch_norm_tuple_shape.push_back(batch_norm->shape().tuple_shapes(i));
+  }
+  const Shape& batch_norm_shape =
+      ShapeUtil::MakeTupleShape(batch_norm_tuple_shape);
+  HloInstruction* libcall =
+      computation_->AddInstruction(HloInstruction::CreateCustomCall(
+          batch_norm_shape, operands, kCudnnBatchNormBackwardCallTarget));
 
-  TF_RETURN_IF_ERROR(
-      computation_->ReplaceWithNewInstruction(batch_norm, std::move(libcall)));
+  HloInstruction* new_gte =
+      computation_->AddInstruction(HloInstruction::CreateGetTupleElement(
+          libcall->shape().tuple_shapes(0), libcall, 0));
+
+  if (IsF32BatchNormWithFP16Inputs(batch_norm)) {
+    new_gte = AddConvert(new_gte, F32);
+  }
+  // Repackage the results. Athough this tuple is redundant when convert is not
+  // inserted, TupleSimplifier eliminates the Tuple eventually
+  std::unique_ptr<HloInstruction> replacing_tuple = HloInstruction::CreateTuple(
+      {new_gte,
+       computation_->AddInstruction(HloInstruction::CreateGetTupleElement(
+           libcall->shape().tuple_shapes(1), libcall, 1)),
+       computation_->AddInstruction(HloInstruction::CreateGetTupleElement(
+           libcall->shape().tuple_shapes(1), libcall, 2))});
+
+  TF_RETURN_IF_ERROR(computation_->ReplaceWithNewInstruction(
+      batch_norm, std::move(replacing_tuple)));
   changed_ = true;
   return Status::OK();
 }


### PR DESCRIPTION
While investigating performance of mobilenet, it was found that enabling cuDNN for Batchnorm improves performance by around 10-12%. Running the numbers for a set of convolutional networks in addition to mobilenet with cuDNN turned on for Batchnorm, showed that enabling cuDNN, either improves performance or keeps it the same. This PR enables cudnn for batchnorm by default based on the above-mentioned performance enhancements.

All necessary changes have been made in https://github.com/tensorflow/tensorflow/pull/32887 and https://github.com/tensorflow/tensorflow/pull/33259