### PR TITLE
[XLA:GPU] Expand batchnorm inference by default 

### DIFF
--- a/tensorflow/compiler/xla/debug_options_flags.cc
+++ b/tensorflow/compiler/xla/debug_options_flags.cc
@@ -42,8 +42,9 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_cpu_use_mkl_dnn(true);
 #endif  // INTEL_MKL
   opts.set_xla_gpu_max_kernel_unroll_factor(4);
-  // Set cudnn batchnorm on by default.
-  opts.set_xla_gpu_use_cudnn_batchnorm(true);
+  // Set cudnn batchnorm off by default; it does not provide a performance win
+  // on average.
+  opts.set_xla_gpu_use_cudnn_batchnorm(false);
 
   // Run all GPU work on one stream by default.  Using multiple streams
   // increases memory usage and we lack strong motivating benchmarks for tuning

--- a/tensorflow/compiler/xla/debug_options_flags.cc
+++ b/tensorflow/compiler/xla/debug_options_flags.cc
@@ -42,9 +42,8 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_cpu_use_mkl_dnn(true);
 #endif  // INTEL_MKL
   opts.set_xla_gpu_max_kernel_unroll_factor(4);
-  // Set cudnn batchnorm off by default; it does not provide a performance win
-  // on average.
-  opts.set_xla_gpu_use_cudnn_batchnorm(false);
+  // Set cudnn batchnorm on by default.
+  opts.set_xla_gpu_use_cudnn_batchnorm(true);
 
   // Run all GPU work on one stream by default.  Using multiple streams
   // increases memory usage and we lack strong motivating benchmarks for tuning

--- a/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
@@ -165,6 +165,10 @@ Status GpuCompiler::OptimizeHloModule(
       // where possible.  Not every batchnorm op can be implemented as a call to
       // cudnn, so decompose any remaining batchnorm ops into a soup of HLOs.
       if (hlo_module->config().debug_options().xla_gpu_use_cudnn_batchnorm()) {
+        pass.AddPass<BatchNormExpander>(
+          /*rewrite_training_op=*/false,
+          /*rewrite_inference_op=*/true,
+          /*rewrite_grad_op=*/false);
         pass.AddPass<CudnnBatchNormRewriter>();
       }
       pass.AddPass<BatchNormExpander>(

--- a/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
@@ -165,6 +165,8 @@ Status GpuCompiler::OptimizeHloModule(
       // where possible.  Not every batchnorm op can be implemented as a call to
       // cudnn, so decompose any remaining batchnorm ops into a soup of HLOs.
       if (hlo_module->config().debug_options().xla_gpu_use_cudnn_batchnorm()) {
+        // Since BatchNorm inference is essentially pointwise operations, it is
+        // always advantageous to use kernel fusion rather than cudnn.
         pass.AddPass<BatchNormExpander>(
           /*rewrite_training_op=*/false,
           /*rewrite_inference_op=*/true,


### PR DESCRIPTION
When  using cudnn for BN inference, there seems to be some constraints imposed on dimension 0 of the input descriptor for `cudnnBatchNormalizationInference` that causes `CUDNN_STATUS_NOT_SUPPORTED` error. The best solution for this is to NOT use cudnn for inference since it is basically pointwise operations that would be much better handled by kernel fusion itself.


~While investigating performance of mobilenet, it was found that enabling cuDNN for Batchnorm improves performance by around 10-12%. Running the numbers for a set of convolutional networks in addition to mobilenet with cuDNN turned on for Batchnorm, showed that enabling cuDNN, either improves performance or keeps it the same. This PR enables cudnn for batchnorm by default based on the above-mentioned performance enhancements.~

~All necessary changes for use of cudnn for fp16 have been made in #32887 and #33259~