### PR TITLE
[ROCm] Fix for the broken ROCm CSB.

### DIFF
--- a/tensorflow/core/kernels/conv_2d_gpu_int.cu.cc
+++ b/tensorflow/core/kernels/conv_2d_gpu_int.cu.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #define EIGEN_USE_GPU
 
@@ -42,4 +42,4 @@ template struct SpatialConvolutionBackwardInputWithExplicitPaddingFunc<
 }  // namespace functor
 }  // namespace tensorflow
 
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/core/kernels/conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_input_ops.cc
@@ -217,7 +217,7 @@ struct LaunchConv2DBackpropInputOp<CPUDevice, T> {
   }
 };
 
-#ifdef GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 // Computes backprop input using Eigen::SpatialConvolutionBackwardInput on GPU
 // for int32 inputs.
 template <>
@@ -234,7 +234,7 @@ struct LaunchConv2DBackpropInputOp<GPUDevice, int32> {
              explicit_paddings, in_backprop, data_format);
   }
 };
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #ifdef TENSORFLOW_USE_LIBXSMM_CONVOLUTIONS
 template <typename Device, class T>

--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -176,7 +176,7 @@ struct LaunchConv2DOp<CPUDevice, T> {
   }
 };
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 template <>
 struct LaunchConv2DOp<GPUDevice, int32> {
   void operator()(OpKernelContext* ctx, bool use_cudnn, bool cudnn_use_autotune,
@@ -213,7 +213,7 @@ struct LaunchConv2DOp<GPUDevice, int32> {
         padding, explicit_paddings, output, data_format);
   }
 };
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 template <typename Device, typename T>
 class LaunchDeepConvOp {


### PR DESCRIPTION
The following commit breaks the `--config=rocm` build

https://github.com/tensorflow/tensorflow/commit/9d08b6bb4fc96073e00c84b0ad7d987a06a53fdb

The commit adds the implementation code for T=int32 within `#if GOOGLE_CUDA`, but the code that registers the op+kernel for T=int32 is within `#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM`. This discrepancy leads to build errors. The fix is trivial, which is to put the implementation code within `#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM` as well.

-------------------------------------------------------------------------


@whchung @chsigg 
