### PR TITLE
[INTEL MKL] Fixed MKL QuantizeV2 operator.

### DIFF
--- a/tensorflow/core/graph/mkl_layout_pass.cc
+++ b/tensorflow/core/graph/mkl_layout_pass.cc
@@ -1355,8 +1355,10 @@ rinfo_.push_back({csinfo_.tanh_grad,
                 node->name()));
             return false;
           }
+          // Current fusion only supports 4D or 5D tensors according to `perm`
+          // vector, return false otherwise.
+          if (tensor.dim_size(0) != perm.size()) return false;
           DCHECK_EQ(tensor.dims(), 1);
-          DCHECK_EQ(tensor.dim_size(0), perm.size());
           if (type == DT_INT32) {
             const auto tensor_content = tensor.flat<int>().data();
             for (int i = 0; i < perm.size(); ++i)

--- a/tensorflow/core/kernels/mkl_quantize_op.cc
+++ b/tensorflow/core/kernels/mkl_quantize_op.cc
@@ -65,12 +65,6 @@ template <typename Device, typename T>
 class MklQuantizeV2Op : public OpKernel {
  public:
   explicit MklQuantizeV2Op(OpKernelConstruction* ctx) : OpKernel(ctx) {
-    half_range_ =
-        !std::is_signed<T>::value
-            ? 0.0f
-            : (static_cast<double>(std::numeric_limits<T>::max()) -
-               static_cast<double>(std::numeric_limits<T>::min()) + 1) /
-                  2.0f;
     string mode_string;
     OP_REQUIRES_OK(ctx, ctx->GetAttr("mode", &mode_string));
     OP_REQUIRES(ctx, (mode_string == "MIN_COMBINED" ||
@@ -252,7 +246,6 @@ class MklQuantizeV2Op : public OpKernel {
   }
 
  private:
-  float half_range_;
   float ensure_minimum_range_;
   int mode_;
   int round_mode_;

--- a/tensorflow/core/kernels/mkl_quantize_op.cc
+++ b/tensorflow/core/kernels/mkl_quantize_op.cc
@@ -35,8 +35,18 @@ using mkldnn::reorder;
 using mkldnn::stream;
 
 namespace {
-enum { QUANTIZE_MODE_SCALED };
 enum {
+  QUANTIZE_MODE_MIN_COMBINED,
+  QUANTIZE_MODE_MIN_FIRST,
+  QUANTIZE_MODE_SCALED,
+};
+enum {
+  // Round half away from zero: if the fraction of y is exactly 0.5, then
+  // round(y) = y + 0.5 if y > 0
+  // round(y) = y - 0.5 if y < 0
+  // E.g., -5.5 gets rounded to -6, -5.4 goes to -5,
+  // 5.4 goes to 5, and 5.5 goes to 6.
+  ROUND_HALF_AWAY_FROM_ZERO,
   // Round half to even: if the fraction of y is exactly 0.5, then round(y) is
   // the nearest even integer to y.
   // E.g., 23.5 gets rounded to 24, 24.5 gets rounded to 24, while -23.5 becomes
@@ -55,16 +65,49 @@ template <typename Device, typename T>
 class MklQuantizeV2Op : public OpKernel {
  public:
   explicit MklQuantizeV2Op(OpKernelConstruction* ctx) : OpKernel(ctx) {
+    half_range_ =
+        !std::is_signed<T>::value
+            ? 0.0f
+            : (static_cast<double>(std::numeric_limits<T>::max()) -
+               static_cast<double>(std::numeric_limits<T>::min()) + 1) /
+                  2.0f;
     string mode_string;
     OP_REQUIRES_OK(ctx, ctx->GetAttr("mode", &mode_string));
-    OP_REQUIRES(ctx, (mode_string == "SCALED"),
-                errors::InvalidArgument("mode must be scaled"));
-    mode_ = QUANTIZE_MODE_SCALED;
+    OP_REQUIRES(ctx, (mode_string == "MIN_COMBINED" ||
+                      mode_string == "MIN_FIRST" || mode_string == "SCALED"),
+                errors::InvalidArgument("Mode string must be 'MIN_COMBINED',"
+                                        " 'MIN_FIRST', or 'SCALED', is '" +
+                                        mode_string + "'"));
+    if (mode_string == "MIN_COMBINED") {
+      mode_ = QUANTIZE_MODE_MIN_COMBINED;
+    } else if (mode_string == "MIN_FIRST") {
+      mode_ = QUANTIZE_MODE_MIN_FIRST;
+    } else if (mode_string == "SCALED") {
+      mode_ = QUANTIZE_MODE_SCALED;
+    }
+
     string round_mode_string;
     OP_REQUIRES_OK(ctx, ctx->GetAttr("round_mode", &round_mode_string));
-    OP_REQUIRES(ctx, (round_mode_string == "HALF_TO_EVEN"),
-                errors::InvalidArgument("Round mode must be half to even"));
-    round_mode_ = ROUND_HALF_TO_EVEN;
+    OP_REQUIRES(ctx, (round_mode_string == "HALF_AWAY_FROM_ZERO" ||
+                      round_mode_string == "HALF_TO_EVEN"),
+                errors::InvalidArgument("Round mode string must be "
+                                        "'HALF_AWAY_FROM_ZERO' or "
+                                        "'HALF_TO_EVEN', is '" +
+                                        round_mode_string + "'"));
+    if (round_mode_string == "HALF_AWAY_FROM_ZERO") {
+      round_mode_ = ROUND_HALF_AWAY_FROM_ZERO;
+    } else if (round_mode_string == "HALF_TO_EVEN") {
+      OP_REQUIRES(ctx, mode_string == "SCALED",
+                  errors::InvalidArgument("Round mode 'HALF_TO_EVEN' "
+                                          "only supported for mode 'SCALED', "
+                                          "but mode is '" +
+                                          mode_string + "'."));
+      round_mode_ = ROUND_HALF_TO_EVEN;
+    }
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("narrow_range", &narrow_range_));
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("axis", &axis_));
+    OP_REQUIRES_OK(
+        ctx, ctx->GetAttr("ensure_minimum_range", &ensure_minimum_range_));
   }
 
   ~MklQuantizeV2Op() {}
@@ -88,8 +131,8 @@ class MklQuantizeV2Op : public OpKernel {
     // represented when we promote the quantized value to a higher
     // intermediate bit depth, since that's a common requirement.
     const float epsilon = std::max(1.0f, std::max(fabsf(input_min_range),
-                                                  fabsf(input_max_range))) /
-                          100.0f;
+                                                  fabsf(input_max_range))) *
+                          ensure_minimum_range_;
     max_range = std::max(input_max_range, min_range + epsilon);
     // Clamping the max_range to zero since max_range can also be negative.
     max_range = std::max(0.0f, max_range);
@@ -209,8 +252,12 @@ class MklQuantizeV2Op : public OpKernel {
   }
 
  private:
+  float half_range_;
+  float ensure_minimum_range_;
   int mode_;
   int round_mode_;
+  int axis_;
+  bool narrow_range_;
 };
 
 REGISTER_KERNEL_BUILDER(Name("_MklQuantizeV2")

--- a/tensorflow/core/ops/mkl_array_ops.cc
+++ b/tensorflow/core/ops/mkl_array_ops.cc
@@ -108,13 +108,27 @@ REGISTER_OP("_MklQuantizeV2")
         "'HALF_TO_EVEN'")
     .Attr("narrow_range: bool = false")
     .Attr("axis: int = -1")
+    .Attr("ensure_minimum_range: float = 0.01")
     .SetShapeFn([](InferenceContext* c) {
+      int axis = -1;
+      Status s = c->GetAttr("axis", &axis);
+      if (!s.ok() && s.code() != error::NOT_FOUND) {
+        return s;
+      }
+      const int minmax_rank = (axis == -1) ? 0 : 1;
       TF_RETURN_IF_ERROR(shape_inference::UnchangedShape(c));
-      ShapeHandle unused;
-      TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 0, &unused));
-      TF_RETURN_IF_ERROR(c->WithRank(c->input(2), 0, &unused));
-      c->set_output(1, c->Scalar());
-      c->set_output(2, c->Scalar());
+      ShapeHandle minmax;
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(1), minmax_rank, &minmax));
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(2), minmax_rank, &minmax));
+      if (axis != -1) {
+        ShapeHandle input;
+        TF_RETURN_IF_ERROR(c->WithRankAtLeast(c->input(0), axis + 1, &input));
+        DimensionHandle depth;
+        TF_RETURN_IF_ERROR(
+            c->Merge(c->Dim(minmax, 0), c->Dim(input, axis), &depth));
+      }
+      c->set_output(1, minmax);
+      c->set_output(2, minmax);
       return Status::OK();
     });
 


### PR DESCRIPTION
There has been a new attribute added to QuantizeV2 (commit id: 4a8064512ca53c). Since MKL version was not updated accordingly, all quantization models with MKLDNN have been failing. This PR updates the MKL version to adapt those changes.

This PR also contains a small fix to `tensorflow/core/graph/mkl_layout_pass.cc` that was causing an abort in debug mode.