### PR TITLE
tflite:experimental:micro:riscv: Fix default target bug in Makefile.

### DIFF
--- a/tensorflow/lite/experimental/micro/tools/make/Makefile
+++ b/tensorflow/lite/experimental/micro/tools/make/Makefile
@@ -225,6 +225,10 @@ CXX := $(CC_PREFIX)${TARGET_TOOLCHAIN_PREFIX}${CXX_TOOL}
 CC := $(CC_PREFIX)${TARGET_TOOLCHAIN_PREFIX}${CC_TOOL}
 AR := $(CC_PREFIX)${TARGET_TOOLCHAIN_PREFIX}${AR_TOOL}
 
+# Default target must appear before any target, 
+# which is compiled if there's no command-line arguments
+all: $(MICROLITE_LIB_PATH)
+
 # Load the examples.
 include $(wildcard tensorflow/lite/experimental/micro/examples/*/Makefile.inc)
 
@@ -253,9 +257,6 @@ $(OBJDIR)%.o: %.c third_party_downloads
 $(OBJDIR)%.o: %.S third_party_downloads
 	@mkdir -p $(dir $@)
 	$(CC) $(CCFLAGS) $(INCLUDES) -c $< -o $@
-
-# The target that's compiled if there's no command-line arguments.
-all: $(MICROLITE_LIB_PATH)
 
 microlite: $(MICROLITE_LIB_PATH)
 


### PR DESCRIPTION
The default target (`all`) should appear before any target in Makefile, to let
`make -f tensorflow/lite/experimental/micro/tools/make/Makefile TARGET=riscv32_mcu`
get to the intendend `all` target by default.

This patch fix the issue #33677 
