### PR TITLE
Add missing V2 ops to auto mixed precision list

### DIFF
--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
@@ -260,6 +260,7 @@ class AutoMixedPrecisionLists {
         "ReverseV2",
         "Round",
         "Select",
+        "SelectV2",
         "Shape",
         "ShapeN",
         "Sign",

--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
@@ -56,8 +56,8 @@ class AutoMixedPrecisionLists {
         &to_remove));
 
     auto list = gtl::FlatSet<string> {
-          "BlockLSTM", "BlockLSTMGrad", "Conv2D", "Conv2DBackpropFilter",
-          "Conv2DBackpropInput",
+          "BlockLSTM", "BlockLSTMV2", "BlockLSTMGrad", "BlockLSTMGradV2",
+          "Conv2D", "Conv2DBackpropFilter", "Conv2DBackpropInput",
           "CudnnRNN", "CudnnRNNBackprop", "CudnnRNNBackpropV2",
           "CudnnRNNBackpropV3", "CudnnRNNV2", "CudnnRNNV3", "GRUBlockCell",
           "GRUBlockCellGrad", "LSTMBlockCell", "LSTMBlockCellGrad",


### PR DESCRIPTION
This PR adds `BlockLSTMV2`, `BlockLSTMGradV2` to the auto mixed precision white list and `SelectV2` to the clear list.

The corresponding `*V1` ops are already part of respective lists.
@reedwm @benbarsdell Is there a reason not to include them?