### PR TITLE
suppress unused result in s3_filesystem (-Wunused-result)

### DIFF
--- a/tensorflow/core/platform/s3/s3_file_system.cc
+++ b/tensorflow/core/platform/s3/s3_file_system.cc
@@ -357,10 +357,10 @@ Status S3FileSystem::NewAppendableFile(const string& fname,
     status = reader->Read(offset, kS3ReadAppendableFileBufferSize, &read_chunk,
                           buffer.get());
     if (status.ok()) {
-      (*result)->Append(read_chunk);
+      (void)(*result)->Append(read_chunk);
       offset += kS3ReadAppendableFileBufferSize;
     } else if (status.code() == error::OUT_OF_RANGE) {
-      (*result)->Append(read_chunk);
+      (void)(*result)->Append(read_chunk);
       break;
     } else {
       (*result).reset();


### PR DESCRIPTION
Building tensorflow with additional warnings as errors.  Suppress the warning to build the library.

```
error: ignoring return value of function declared with 'warn_unused_result' attribute [-Werror,-Wunused-result]
```