### PR TITLE
Fix typo in wrapper.py

### DIFF
--- a/tensorflow/python/keras/layers/wrappers.py
+++ b/tensorflow/python/keras/layers/wrappers.py
@@ -394,8 +394,8 @@ class Bidirectional(Wrapper):
    # With custom backward layer
    model = Sequential()
    forward_layer = LSTM(10, return_sequences=True)
-   backard_layer = LSTM(10, activation='relu', return_sequences=True,
-                        go_backwards=True)
+   backward_layer = LSTM(10, activation='relu', return_sequences=True,
+                         go_backwards=True)
    model.add(Bidirectional(forward_layer, backward_layer=backward_layer,
                            input_shape=(5, 10)))
    model.add(Dense(5))


### PR DESCRIPTION
Fix a typo, from "backard_layer" to "backward_layer"
in an example of bidirectional custom backward layer.