### PR TITLE
Support CUDNN depthwise convolution

### DIFF
--- a/tensorflow/core/kernels/depthwise_conv_grad_op.cc
+++ b/tensorflow/core/kernels/depthwise_conv_grad_op.cc
@@ -610,7 +610,12 @@ class DepthwiseConv2dNativeBackpropInputOp : public OpKernel {
 
     // If in_depth==1, this operation is just a standard convolution.
     // Depthwise convolution is a special case of cuDNN's grouped convolution.
-    bool use_cudnn = use_cudnn_ && (in_depth == 1 || use_cudnn_grouped_conv_);
+    // Use CuDNN grouped conv when filter is 1x1, 3x3, 5x5, 7x7.
+    // See cudnn release note 7.6.3. (https://docs.nvidia.com/deeplearning/sdk/c
+    // udnn-release-notes/rel_763.html#rel_763)
+    bool use_cudnn = use_cudnn_ && (in_depth == 1 || (use_cudnn_grouped_conv_ &&
+        filter_rows == filter_cols && filter_rows == 1 && filter_rows == 3 &&
+        filter_rows == 5 && filter_rows == 7));
 
     VLOG(2) << "DepthwiseConv2dNativeBackpropInput: "
             << " Input: [" << batch << ", " << input_rows << ", " << input_cols
@@ -1095,7 +1100,12 @@ class DepthwiseConv2dNativeBackpropFilterOp : public OpKernel {
 
     // If in_depth==1, this operation is just a standard convolution.
     // Depthwise convolution is a special case of cuDNN's grouped convolution.
-    bool use_cudnn = use_cudnn_ && (in_depth == 1 || use_cudnn_grouped_conv_);
+    // Use CuDNN grouped conv when filter is 1x1, 3x3, 5x5, 7x7.
+    // See cudnn release note 7.6.3. (https://docs.nvidia.com/deeplearning/sdk/c
+    // udnn-release-notes/rel_763.html#rel_763)
+    bool use_cudnn = use_cudnn_ && (in_depth == 1 || (use_cudnn_grouped_conv_ &&
+        filter_rows == filter_cols && filter_rows == 1 && filter_rows == 3 &&
+        filter_rows == 5 && filter_rows == 7));
 
     VLOG(2) << "DepthwiseConv2dNativeBackpropFilter: "
             << " Input: [" << batch << ", " << input_rows << ", " << input_cols

--- a/tensorflow/core/kernels/depthwise_conv_grad_op.cc
+++ b/tensorflow/core/kernels/depthwise_conv_grad_op.cc
@@ -574,9 +574,13 @@ class DepthwiseConv2dNativeBackpropInputOp : public OpKernel {
     // Use CuDNN grouped conv (input gradient) when stride = 1, input/output is
     // NCHW and float16(half). See cudnn release note 7.6.3 (https://docs.nvidi
     // a.com/deeplearning/sdk/cudnn-release-notes/rel_763.html#rel_763).
-    use_cudnn_grouped_conv_ = CUDNN_VERSION >= 7603 &&
-        dtype_ == DT_HALF && data_format_ == FORMAT_NCHW && stride_ == 1 &&
-        stride_w == 1;
+#ifdef CUDNN_VERSION >= 7603
+    use_cudnn_grouped_conv_ = dtype_ == DT_HALF &&
+                              data_format_ == FORMAT_NCHW && stride_ == 1 &&
+                              stride_w == 1;
+#else
+    use_cudnn_grouped_conv_ = false;
+#endif
   }
 
   void Compute(OpKernelContext* context) override {
@@ -1066,7 +1070,11 @@ class DepthwiseConv2dNativeBackpropFilterOp : public OpKernel {
     // Use CuDNN grouped conv (filter gradients) when input/output is
     // float16(half). See cudnn release note 7.6.3. (https://docs.nvidia.com/dee
     // plearning/sdk/cudnn-release-notes/rel_763.html#rel_763)
-    use_cudnn_grouped_conv_ = CUDNN_VERSION >= 7603 && dtype_ == DT_HALF;
+#ifdef CUDNN_VERSION >= 7603
+    use_cudnn_grouped_conv_ = dtype_ == DT_HALF;
+#else
+    use_cudnn_grouped_conv_ = false;
+#endif
   }
 
   void Compute(OpKernelContext* context) override {

--- a/tensorflow/core/kernels/depthwise_conv_grad_op.cc
+++ b/tensorflow/core/kernels/depthwise_conv_grad_op.cc
@@ -610,12 +610,8 @@ class DepthwiseConv2dNativeBackpropInputOp : public OpKernel {
 
     // If in_depth==1, this operation is just a standard convolution.
     // Depthwise convolution is a special case of cuDNN's grouped convolution.
-    // Use CuDNN grouped conv when filter is 1x1, 3x3, 5x5, 7x7.
-    // See cudnn release note 7.6.3. (https://docs.nvidia.com/deeplearning/sdk/c
-    // udnn-release-notes/rel_763.html#rel_763)
     bool use_cudnn = use_cudnn_ && (in_depth == 1 || (use_cudnn_grouped_conv_ &&
-        filter_rows == filter_cols && (filter_rows == 1 || filter_rows == 3 ||
-        filter_rows == 5 || filter_rows == 7)));
+        IsCudnnSupportedFilterSize(filter_rows, filter_cols)));
 
     VLOG(2) << "DepthwiseConv2dNativeBackpropInput: "
             << " Input: [" << batch << ", " << input_rows << ", " << input_cols
@@ -1100,12 +1096,8 @@ class DepthwiseConv2dNativeBackpropFilterOp : public OpKernel {
 
     // If in_depth==1, this operation is just a standard convolution.
     // Depthwise convolution is a special case of cuDNN's grouped convolution.
-    // Use CuDNN grouped conv when filter is 1x1, 3x3, 5x5, 7x7.
-    // See cudnn release note 7.6.3. (https://docs.nvidia.com/deeplearning/sdk/c
-    // udnn-release-notes/rel_763.html#rel_763)
     bool use_cudnn = use_cudnn_ && (in_depth == 1 || (use_cudnn_grouped_conv_ &&
-        filter_rows == filter_cols && (filter_rows == 1 || filter_rows == 3 ||
-        filter_rows == 5 || filter_rows == 7)));
+        IsCudnnSupportedFilterSize(filter_rows, filter_cols)));
 
     VLOG(2) << "DepthwiseConv2dNativeBackpropFilter: "
             << " Input: [" << batch << ", " << input_rows << ", " << input_cols

--- a/tensorflow/core/kernels/depthwise_conv_grad_op.cc
+++ b/tensorflow/core/kernels/depthwise_conv_grad_op.cc
@@ -611,8 +611,10 @@ class DepthwiseConv2dNativeBackpropInputOp : public OpKernel {
     // If in_depth==1, this operation is just a standard convolution.
     // Depthwise convolution is a special case of cuDNN's grouped convolution.
     bool use_cudnn = use_cudnn_ && (in_depth == 1 || (use_cudnn_grouped_conv_ &&
-        IsCudnnSupportedFilterSize(filter_rows, filter_cols, in_depth,
-                                   out_depth)));
+        IsCudnnSupportedFilterSize(/*filter_rows=*/filter_rows,
+                                   /*filter_cols=*/filter_cols,
+                                   /*in_depth=*/in_depth,
+                                   /*out_depth=*/out_depth)));
 
     VLOG(2) << "DepthwiseConv2dNativeBackpropInput: "
             << " Input: [" << batch << ", " << input_rows << ", " << input_cols
@@ -1098,8 +1100,10 @@ class DepthwiseConv2dNativeBackpropFilterOp : public OpKernel {
     // If in_depth==1, this operation is just a standard convolution.
     // Depthwise convolution is a special case of cuDNN's grouped convolution.
     bool use_cudnn = use_cudnn_ && (in_depth == 1 || (use_cudnn_grouped_conv_ &&
-        IsCudnnSupportedFilterSize(filter_rows, filter_cols, in_depth,
-                                   out_depth)));
+        IsCudnnSupportedFilterSize(/*filter_rows=*/filter_rows,
+                                   /*filter_cols=*/filter_cols,
+                                   /*in_depth=*/in_depth,
+                                   /*out_depth=*/out_depth)));
 
     VLOG(2) << "DepthwiseConv2dNativeBackpropFilter: "
             << " Input: [" << batch << ", " << input_rows << ", " << input_cols

--- a/tensorflow/core/kernels/depthwise_conv_grad_op.cc
+++ b/tensorflow/core/kernels/depthwise_conv_grad_op.cc
@@ -614,8 +614,8 @@ class DepthwiseConv2dNativeBackpropInputOp : public OpKernel {
     // See cudnn release note 7.6.3. (https://docs.nvidia.com/deeplearning/sdk/c
     // udnn-release-notes/rel_763.html#rel_763)
     bool use_cudnn = use_cudnn_ && (in_depth == 1 || (use_cudnn_grouped_conv_ &&
-        filter_rows == filter_cols && filter_rows == 1 && filter_rows == 3 &&
-        filter_rows == 5 && filter_rows == 7));
+        filter_rows == filter_cols && (filter_rows == 1 || filter_rows == 3 ||
+        filter_rows == 5 || filter_rows == 7)));
 
     VLOG(2) << "DepthwiseConv2dNativeBackpropInput: "
             << " Input: [" << batch << ", " << input_rows << ", " << input_cols
@@ -1104,8 +1104,8 @@ class DepthwiseConv2dNativeBackpropFilterOp : public OpKernel {
     // See cudnn release note 7.6.3. (https://docs.nvidia.com/deeplearning/sdk/c
     // udnn-release-notes/rel_763.html#rel_763)
     bool use_cudnn = use_cudnn_ && (in_depth == 1 || (use_cudnn_grouped_conv_ &&
-        filter_rows == filter_cols && filter_rows == 1 && filter_rows == 3 &&
-        filter_rows == 5 && filter_rows == 7));
+        filter_rows == filter_cols && (filter_rows == 1 || filter_rows == 3 ||
+        filter_rows == 5 || filter_rows == 7)));
 
     VLOG(2) << "DepthwiseConv2dNativeBackpropFilter: "
             << " Input: [" << batch << ", " << input_rows << ", " << input_cols

--- a/tensorflow/core/kernels/depthwise_conv_grad_op.cc
+++ b/tensorflow/core/kernels/depthwise_conv_grad_op.cc
@@ -574,7 +574,7 @@ class DepthwiseConv2dNativeBackpropInputOp : public OpKernel {
     // Use CuDNN grouped conv (input gradient) when stride = 1, input/output is
     // NCHW and float16(half). See cudnn release note 7.6.3 (https://docs.nvidi
     // a.com/deeplearning/sdk/cudnn-release-notes/rel_763.html#rel_763).
-#ifdef CUDNN_VERSION >= 7603
+#if CUDNN_VERSION >= 7603
     use_cudnn_grouped_conv_ = dtype_ == DT_HALF &&
                               data_format_ == FORMAT_NCHW && stride_ == 1 &&
                               stride_w == 1;
@@ -1070,7 +1070,7 @@ class DepthwiseConv2dNativeBackpropFilterOp : public OpKernel {
     // Use CuDNN grouped conv (filter gradients) when input/output is
     // float16(half). See cudnn release note 7.6.3. (https://docs.nvidia.com/dee
     // plearning/sdk/cudnn-release-notes/rel_763.html#rel_763)
-#ifdef CUDNN_VERSION >= 7603
+#if CUDNN_VERSION >= 7603
     use_cudnn_grouped_conv_ = dtype_ == DT_HALF;
 #else
     use_cudnn_grouped_conv_ = false;

--- a/tensorflow/core/kernels/depthwise_conv_grad_op.cc
+++ b/tensorflow/core/kernels/depthwise_conv_grad_op.cc
@@ -571,15 +571,12 @@ class DepthwiseConv2dNativeBackpropInputOp : public OpKernel {
     use_cudnn_ = CanUseCudnn() && std::is_same<Device, GPUDevice>::value;
     cudnn_use_autotune_ = CudnnUseAutotune();
     dtype_ = DataTypeToEnum<T>::value;
-#if CUDNN_VERSION >= 7603
     // Use CuDNN grouped conv (input gradient) when stride = 1, input/output is
-    // NCHW and float16(half). See cudnn release note 7.6.3.
-    use_cudnn_grouped_conv_ =
+    // NCHW and float16(half). See cudnn release note 7.6.3 (https://docs.nvidi
+    // a.com/deeplearning/sdk/cudnn-release-notes/rel_763.html#rel_763).
+    use_cudnn_grouped_conv_ = CUDNN_VERSION >= 7603 &&
         dtype_ == DT_HALF && data_format_ == FORMAT_NCHW && stride_ == 1 &&
         stride_w == 1;
-#else
-    use_cudnn_grouped_conv_ = false;
-#endif
   }
 
   void Compute(OpKernelContext* context) override {
@@ -1062,13 +1059,10 @@ class DepthwiseConv2dNativeBackpropFilterOp : public OpKernel {
     } else {
       LOG(ERROR) << "Only half, float, and double are supported.";
     }
-#if CUDNN_VERSION >= 7603
     // Use CuDNN grouped conv (filter gradients) when input/output is
-    // float16(half). See cudnn release note 7.6.3.
-    use_cudnn_grouped_conv_ = dtype_ == DT_HALF;
-#else
-    use_cudnn_grouped_conv_ = false;
-#endif
+    // float16(half). See cudnn release note 7.6.3. (https://docs.nvidia.com/dee
+    // plearning/sdk/cudnn-release-notes/rel_763.html#rel_763)
+    use_cudnn_grouped_conv_ = CUDNN_VERSION >= 7603 && dtype_ == DT_HALF;
   }
 
   void Compute(OpKernelContext* context) override {

--- a/tensorflow/core/kernels/depthwise_conv_grad_op.cc
+++ b/tensorflow/core/kernels/depthwise_conv_grad_op.cc
@@ -611,7 +611,8 @@ class DepthwiseConv2dNativeBackpropInputOp : public OpKernel {
     // If in_depth==1, this operation is just a standard convolution.
     // Depthwise convolution is a special case of cuDNN's grouped convolution.
     bool use_cudnn = use_cudnn_ && (in_depth == 1 || (use_cudnn_grouped_conv_ &&
-        IsCudnnSupportedFilterSize(filter_rows, filter_cols)));
+        IsCudnnSupportedFilterSize(filter_rows, filter_cols, in_depth,
+                                   out_depth)));
 
     VLOG(2) << "DepthwiseConv2dNativeBackpropInput: "
             << " Input: [" << batch << ", " << input_rows << ", " << input_cols
@@ -1097,7 +1098,8 @@ class DepthwiseConv2dNativeBackpropFilterOp : public OpKernel {
     // If in_depth==1, this operation is just a standard convolution.
     // Depthwise convolution is a special case of cuDNN's grouped convolution.
     bool use_cudnn = use_cudnn_ && (in_depth == 1 || (use_cudnn_grouped_conv_ &&
-        IsCudnnSupportedFilterSize(filter_rows, filter_cols)));
+        IsCudnnSupportedFilterSize(filter_rows, filter_cols, in_depth,
+                                   out_depth)));
 
     VLOG(2) << "DepthwiseConv2dNativeBackpropFilter: "
             << " Input: [" << batch << ", " << input_rows << ", " << input_cols

--- a/tensorflow/core/kernels/depthwise_conv_op.cc
+++ b/tensorflow/core/kernels/depthwise_conv_op.cc
@@ -297,13 +297,11 @@ class DepthwiseConv2dNativeOp : public BinaryOp<T> {
     use_cudnn_ = CanUseCudnn() && std::is_same<Device, GPUDevice>::value;
     cudnn_use_autotune_ = CudnnUseAutotune();
     dtype_ = DataTypeToEnum<T>::value;
-#if CUDNN_VERSION >= 7603
     // Use CuDNN grouped conv only when input/output is NCHW and float16(half).
-    // See cudnn release note 7.6.3.
-    use_cudnn_grouped_conv_ = dtype_ == DT_HALF && data_format_ == FORMAT_NCHW;
-#else
-    use_cudnn_grouped_conv_ = false;
-#endif
+    // See cudnn release note 7.6.3. (https://docs.nvidia.com/deeplearning/sdk/c
+    // udnn-release-notes/rel_763.html#rel_763)
+    use_cudnn_grouped_conv_ = CUDNN_VERSION >= 7603 && dtype_ == DT_HALF &&
+        data_format_ == FORMAT_NCHW;
   }
 
   void Compute(OpKernelContext* context) override {

--- a/tensorflow/core/kernels/depthwise_conv_op.cc
+++ b/tensorflow/core/kernels/depthwise_conv_op.cc
@@ -384,8 +384,8 @@ class DepthwiseConv2dNativeOp : public BinaryOp<T> {
     // See cudnn release note 7.6.3. (https://docs.nvidia.com/deeplearning/sdk/c
     // udnn-release-notes/rel_763.html#rel_763)
     bool use_cudnn = use_cudnn_ && (in_depth == 1 || (use_cudnn_grouped_conv_ &&
-        filter_rows == filter_cols && filter_rows == 1 && filter_rows == 3 &&
-        filter_rows == 5 && filter_rows == 7));
+        filter_rows == filter_cols && (filter_rows == 1 || filter_rows == 3 ||
+        filter_rows == 5 || filter_rows == 7)));
 
     VLOG(2) << "DepthwiseConv2dNative: "
             << " Input: [" << batch << ", " << input_rows << ", " << input_cols

--- a/tensorflow/core/kernels/depthwise_conv_op.cc
+++ b/tensorflow/core/kernels/depthwise_conv_op.cc
@@ -381,7 +381,8 @@ class DepthwiseConv2dNativeOp : public BinaryOp<T> {
     // If in_depth==1, this operation is just a standard convolution.
     // Depthwise convolution is a special case of cuDNN's grouped convolution.
     bool use_cudnn = use_cudnn_ && (in_depth == 1 || (use_cudnn_grouped_conv_ &&
-        IsCudnnSupportedFilterSize(filter_rows, filter_cols)));
+        IsCudnnSupportedFilterSize(filter_rows, filter_cols, in_depth,
+                                   out_depth)));
 
     VLOG(2) << "DepthwiseConv2dNative: "
             << " Input: [" << batch << ", " << input_rows << ", " << input_cols

--- a/tensorflow/core/kernels/depthwise_conv_op.cc
+++ b/tensorflow/core/kernels/depthwise_conv_op.cc
@@ -300,7 +300,7 @@ class DepthwiseConv2dNativeOp : public BinaryOp<T> {
     // Use CuDNN grouped conv only when input/output is NCHW and float16(half).
     // See cudnn release note 7.6.3. (https://docs.nvidia.com/deeplearning/sdk/c
     // udnn-release-notes/rel_763.html#rel_763)
-#ifdef CUDNN_VERSION >= 7603
+#if CUDNN_VERSION >= 7603
     use_cudnn_grouped_conv_ = dtype_ == DT_HALF && data_format_ == FORMAT_NCHW;
 #else
     use_cudnn_grouped_conv_ = false;

--- a/tensorflow/core/kernels/depthwise_conv_op.cc
+++ b/tensorflow/core/kernels/depthwise_conv_op.cc
@@ -380,12 +380,8 @@ class DepthwiseConv2dNativeOp : public BinaryOp<T> {
     // TODO(csigg): Have autotune decide if native is faster than cuDNN.
     // If in_depth==1, this operation is just a standard convolution.
     // Depthwise convolution is a special case of cuDNN's grouped convolution.
-    // Use CuDNN grouped conv when filter is 1x1, 3x3, 5x5, 7x7.
-    // See cudnn release note 7.6.3. (https://docs.nvidia.com/deeplearning/sdk/c
-    // udnn-release-notes/rel_763.html#rel_763)
     bool use_cudnn = use_cudnn_ && (in_depth == 1 || (use_cudnn_grouped_conv_ &&
-        filter_rows == filter_cols && (filter_rows == 1 || filter_rows == 3 ||
-        filter_rows == 5 || filter_rows == 7)));
+        IsCudnnSupportedFilterSize(filter_rows, filter_cols)));
 
     VLOG(2) << "DepthwiseConv2dNative: "
             << " Input: [" << batch << ", " << input_rows << ", " << input_cols

--- a/tensorflow/core/kernels/depthwise_conv_op.cc
+++ b/tensorflow/core/kernels/depthwise_conv_op.cc
@@ -381,8 +381,10 @@ class DepthwiseConv2dNativeOp : public BinaryOp<T> {
     // If in_depth==1, this operation is just a standard convolution.
     // Depthwise convolution is a special case of cuDNN's grouped convolution.
     bool use_cudnn = use_cudnn_ && (in_depth == 1 || (use_cudnn_grouped_conv_ &&
-        IsCudnnSupportedFilterSize(filter_rows, filter_cols, in_depth,
-                                   out_depth)));
+        IsCudnnSupportedFilterSize(/*filter_rows=*/filter_rows,
+                                   /*filter_cols=*/filter_cols,
+                                   /*in_depth=*/in_depth,
+                                   /*out_depth=*/out_depth)));
 
     VLOG(2) << "DepthwiseConv2dNative: "
             << " Input: [" << batch << ", " << input_rows << ", " << input_cols

--- a/tensorflow/core/kernels/depthwise_conv_op.cc
+++ b/tensorflow/core/kernels/depthwise_conv_op.cc
@@ -300,8 +300,11 @@ class DepthwiseConv2dNativeOp : public BinaryOp<T> {
     // Use CuDNN grouped conv only when input/output is NCHW and float16(half).
     // See cudnn release note 7.6.3. (https://docs.nvidia.com/deeplearning/sdk/c
     // udnn-release-notes/rel_763.html#rel_763)
-    use_cudnn_grouped_conv_ = CUDNN_VERSION >= 7603 && dtype_ == DT_HALF &&
-        data_format_ == FORMAT_NCHW;
+#ifdef CUDNN_VERSION >= 7603
+    use_cudnn_grouped_conv_ = dtype_ == DT_HALF && data_format_ == FORMAT_NCHW;
+#else
+    use_cudnn_grouped_conv_ = false;
+#endif
   }
 
   void Compute(OpKernelContext* context) override {

--- a/tensorflow/core/kernels/depthwise_conv_op.cc
+++ b/tensorflow/core/kernels/depthwise_conv_op.cc
@@ -380,7 +380,12 @@ class DepthwiseConv2dNativeOp : public BinaryOp<T> {
     // TODO(csigg): Have autotune decide if native is faster than cuDNN.
     // If in_depth==1, this operation is just a standard convolution.
     // Depthwise convolution is a special case of cuDNN's grouped convolution.
-    bool use_cudnn = use_cudnn_ && (in_depth == 1 || use_cudnn_grouped_conv_);
+    // Use CuDNN grouped conv when filter is 1x1, 3x3, 5x5, 7x7.
+    // See cudnn release note 7.6.3. (https://docs.nvidia.com/deeplearning/sdk/c
+    // udnn-release-notes/rel_763.html#rel_763)
+    bool use_cudnn = use_cudnn_ && (in_depth == 1 || (use_cudnn_grouped_conv_ &&
+        filter_rows == filter_cols && filter_rows == 1 && filter_rows == 3 &&
+        filter_rows == 5 && filter_rows == 7));
 
     VLOG(2) << "DepthwiseConv2dNative: "
             << " Input: [" << batch << ", " << input_rows << ", " << input_cols

--- a/tensorflow/core/util/use_cudnn.cc
+++ b/tensorflow/core/util/use_cudnn.cc
@@ -90,4 +90,13 @@ FP16ConvMode CudnnConvComputeMode() {
   return FP16ConvMode::kAccurate;
 }
 
+// Use CuDNN depthwise conv when filter is 1x1, 3x3, 5x5, or 7x7.
+// See cudnn release note 7.6.3. (https://docs.nvidia.com/deeplearning/sdk/c
+// udnn-release-notes/rel_763.html#rel_763)
+bool IsCudnnSupportedFilterSize(const int32 filter_rows,
+                                const int32 filter_cols) {
+  return filter_rows == filter_cols && (filter_rows == 1 || filter_rows == 3 ||
+                                        filter_rows == 5 || filter_rows == 7);
+}
+
 }  // namespace tensorflow

--- a/tensorflow/core/util/use_cudnn.cc
+++ b/tensorflow/core/util/use_cudnn.cc
@@ -90,9 +90,6 @@ FP16ConvMode CudnnConvComputeMode() {
   return FP16ConvMode::kAccurate;
 }
 
-// Use CuDNN depthwise conv when filter is 1x1, 3x3, 5x5, or 7x7.
-// See cudnn release note 7.6.3. (https://docs.nvidia.com/deeplearning/sdk/c
-// udnn-release-notes/rel_763.html#rel_763)
 bool IsCudnnSupportedFilterSize(const int32 filter_rows,
                                 const int32 filter_cols) {
   return filter_rows == filter_cols && (filter_rows == 1 || filter_rows == 3 ||

--- a/tensorflow/core/util/use_cudnn.cc
+++ b/tensorflow/core/util/use_cudnn.cc
@@ -91,9 +91,12 @@ FP16ConvMode CudnnConvComputeMode() {
 }
 
 bool IsCudnnSupportedFilterSize(const int32 filter_rows,
-                                const int32 filter_cols) {
-  return filter_rows == filter_cols && (filter_rows == 1 || filter_rows == 3 ||
-                                        filter_rows == 5 || filter_rows == 7);
+                                const int32 filter_cols,
+                                const int32 in_depth,
+                                const int32 out_depth) {
+  return in_depth == out_depth && filter_rows == filter_cols &&
+         (filter_rows == 1 || filter_rows == 3 || filter_rows == 5 ||
+          filter_rows == 7);
 }
 
 }  // namespace tensorflow

--- a/tensorflow/core/util/use_cudnn.h
+++ b/tensorflow/core/util/use_cudnn.h
@@ -39,6 +39,8 @@ FP16ConvMode CudnnConvComputeMode();
 bool DebugCudnnRnn();
 bool DebugCudnnRnnUseTensorOps();
 int64 DebugCudnnRnnAlgo();
+bool IsCudnnSupportedFilterSize(const int32 filter_rows,
+                                const int32 filter_cols);
 }  // namespace tensorflow
 
 #endif  // TENSORFLOW_CORE_UTIL_USE_CUDNN_H_

--- a/tensorflow/core/util/use_cudnn.h
+++ b/tensorflow/core/util/use_cudnn.h
@@ -40,8 +40,8 @@ bool DebugCudnnRnn();
 bool DebugCudnnRnnUseTensorOps();
 int64 DebugCudnnRnnAlgo();
 
-// Return true if the filter is 1x1, 3x3, 5x5 or 7x7. This function is used
-// before calling the CuDNN depthwise convolution. See cudnn release note 7.6.3.
+// Return true if the CuDNN depthwise convolution can be used. See cudnn release
+// note 7.6.3.
 // (https://docs.nvidia.com/deeplearning/sdk/cudnn-release-notes/rel_763.html)
 bool IsCudnnSupportedFilterSize(const int32 filter_rows,
                                 const int32 filter_cols);

--- a/tensorflow/core/util/use_cudnn.h
+++ b/tensorflow/core/util/use_cudnn.h
@@ -44,7 +44,9 @@ int64 DebugCudnnRnnAlgo();
 // release note 7.6.3.
 // (https://docs.nvidia.com/deeplearning/sdk/cudnn-release-notes/rel_763.html)
 bool IsCudnnSupportedFilterSize(const int32 filter_rows,
-                                const int32 filter_cols);
+                                const int32 filter_cols,
+                                const int32 in_depth,
+                                const int32 out_depth);
 }  // namespace tensorflow
 
 #endif  // TENSORFLOW_CORE_UTIL_USE_CUDNN_H_

--- a/tensorflow/core/util/use_cudnn.h
+++ b/tensorflow/core/util/use_cudnn.h
@@ -40,8 +40,8 @@ bool DebugCudnnRnn();
 bool DebugCudnnRnnUseTensorOps();
 int64 DebugCudnnRnnAlgo();
 
-// Return true if the CuDNN depthwise convolution can be used. See cudnn release
-// note 7.6.3.
+// Returns true if the CuDNN depthwise convolution can be used. See cudnn
+// release note 7.6.3.
 // (https://docs.nvidia.com/deeplearning/sdk/cudnn-release-notes/rel_763.html)
 bool IsCudnnSupportedFilterSize(const int32 filter_rows,
                                 const int32 filter_cols);

--- a/tensorflow/core/util/use_cudnn.h
+++ b/tensorflow/core/util/use_cudnn.h
@@ -39,6 +39,10 @@ FP16ConvMode CudnnConvComputeMode();
 bool DebugCudnnRnn();
 bool DebugCudnnRnnUseTensorOps();
 int64 DebugCudnnRnnAlgo();
+
+// Return true if the filter is 1x1, 3x3, 5x5 or 7x7. This function is used
+// before calling the CuDNN depthwise convolution. See cudnn release note 7.6.3.
+// (https://docs.nvidia.com/deeplearning/sdk/cudnn-release-notes/rel_763.html)
 bool IsCudnnSupportedFilterSize(const int32 filter_rows,
                                 const int32 filter_cols);
 }  // namespace tensorflow

--- a/tensorflow/python/kernel_tests/depthwise_conv_op_test.py
+++ b/tensorflow/python/kernel_tests/depthwise_conv_op_test.py
@@ -187,6 +187,20 @@ class DepthwiseConv2DTest(test.TestCase):
     self.assertShapeEqual(native_result, conv_interface)
 
   @test_util.run_v1_only("b/120545219")
+  def testDepthwiseConv2DCudnn(self):
+    for index, (input_size, filter_size, _, stride,
+                padding) in enumerate(ConfigsToTest()):
+      # The CuDNN depthwise conv is turned on only when input/output is NCHW and
+      # float16(half). See cudnn release note 7.6.3.
+      tf_logging.info(
+          "Testing DepthwiseConv2DCudnn, %dth config: %r * %r, stride: %d, "
+          "padding: %s", index, input_size, filter_size, stride, padding)
+      data_type = dtypes.float16
+      self._VerifyValues(
+          input_size, filter_size, stride, padding, data_type, use_gpu=True,
+          data_format='NCHW')
+
+  @test_util.run_v1_only("b/120545219")
   def testDepthwiseConv2D(self):
     for index, (input_size, filter_size, _, stride,
                 padding) in enumerate(ConfigsToTest()):
@@ -439,6 +453,31 @@ class DepthwiseConv2DTest(test.TestCase):
       self.assertLess(err, tolerance)
 
   @test_util.run_v1_only("b/120545219")
+  def testDepthwiseConv2DInputGradCudnn(self):
+    for index, (input_size, filter_size, output_size, stride,
+                padding) in enumerate(CheckGradConfigsToTest()):
+      # The CuDNN depthwise conv (input gradient) is turned on only when
+      # stride = 1, input/output is NCHW and float16(half). See cudnn release
+      # note 7.6.3.
+      if stride != 1:
+        continue
+      tf_logging.info(
+          "Testing DepthwiseConv2DInputGradCudnn, %dth config: %r * %r, "
+          "stride: %d, padding: %s", index, input_size, filter_size, stride,
+          padding)
+      data_type = dtypes.float16
+      self._ConstructAndTestGradient(
+          input_size,
+          filter_size,
+          output_size,
+          stride,
+          padding,
+          data_type,
+          test_input=True,
+          use_gpu=True,
+          data_format='NCHW')
+
+  @test_util.run_v1_only("b/120545219")
   def testDepthwiseConv2DInputGrad(self):
     for index, (input_size, filter_size, output_size, stride,
                 padding) in enumerate(CheckGradConfigsToTest()):
@@ -494,6 +533,38 @@ class DepthwiseConv2DTest(test.TestCase):
             test_input=True,
             use_gpu=True,
             data_format="NCHW")
+
+  @test_util.run_v1_only("b/120545219")
+  def testDepthwiseConv2DFilterGradCudnn(self):
+    for index, (input_size, filter_size, output_size, stride,
+                padding) in enumerate(CheckGradConfigsToTest()):
+      # The CuDNN depthwise conv (filter gradient) is turned on only when
+      # input/output is float16(half). See cudnn release note 7.6.3.
+      tf_logging.info(
+          "Testing DepthwiseConv2DFilterGradCudnn, %dth config: %r * %r, "
+          "stride: %d, padding: %s", index, input_size, filter_size, stride,
+          padding)
+      data_type = dtypes.float16
+      self._ConstructAndTestGradient(
+          input_size,
+          filter_size,
+          output_size,
+          stride,
+          padding,
+          data_type,
+          test_input=False,
+          use_gpu=True,
+          data_format='NCHW')
+      self._ConstructAndTestGradient(
+          input_size,
+          filter_size,
+          output_size,
+          stride,
+          padding,
+          data_type,
+          test_input=False,
+          use_gpu=True,
+          data_format='NHWC')
 
   @test_util.run_v1_only("b/120545219")
   def testDepthwiseConv2DFilterGrad(self):


### PR DESCRIPTION
This PR adds the CUDNN depthwise convolution as the default implementations of DepthwiseConv2dNative, DepthwiseConv2dNativeBackpropInput, DepthwiseConv2dNativeBackpropFilter.

CuDNN 7.6.3 improves the performance of some cases for the depthwise convolution. Details at:
https://docs.nvidia.com/deeplearning/sdk/cudnn-release-notes/rel_763.html#rel_763

@nluehr 