### PR TITLE
Change android.bzl indentation to 2

### DIFF
--- a/third_party/android/android.bzl.tpl
+++ b/third_party/android/android.bzl.tpl
@@ -1,9 +1,9 @@
 """Set up configurable Android SDK and NDK dependencies."""
 
 def android_workspace():
-    # String for replacement in Bazel template.
-    # These will either be replaced by android_sdk_repository if various ENV
-    # variables are set when `local_config_android` repo_rule is run, or they
-    # will be replaced by noops otherwise.
-    MAYBE_ANDROID_SDK_REPOSITORY
-    MAYBE_ANDROID_NDK_REPOSITORY
+  # String for replacement in Bazel template.
+  # These will either be replaced by android_sdk_repository if various ENV
+  # variables are set when `local_config_android` repo_rule is run, or they
+  # will be replaced by noops otherwise.
+  MAYBE_ANDROID_SDK_REPOSITORY
+  MAYBE_ANDROID_NDK_REPOSITORY


### PR DESCRIPTION
This commit changes the indent of android.bzl to 2. It fixes the error I encountered when building `r2.0` branch from source:

```
ERROR: /workspace/.cache/bazel/_bazel_mironov/141a83512af494886339dd95e1e5a7a2/external/local_config_android/android.bzl:10:2: indentation error                                                                                                
ERROR: error loading package '': Extension 'android.bzl' has errors                                                                                                                                                                             
ERROR: error loading package '': Extension 'android.bzl' has errors
```

The contents of android.bzl in `.cache` was:
```
"""Set up configurable Android SDK and NDK dependencies."""

def android_workspace():
    # String for replacement in Bazel template.
    # These will either be replaced by android_sdk_repository if various ENV
    # variables are set when `local_config_android` repo_rule is run, or they
    # will be replaced by noops otherwise.
    pass
    
  native.android_ndk_repository(
      name="androidndk",
      path="/workspace/Android/Sdk/ndk/android-ndk-r18b/",
      api_level=21,
  )
```
As you can see, we need to either increase the indent of `_ANDROID_SDK_REPO_TEMPLATE` or decrease the indent of `androiud.bzl`. I decided to do the latter because I note this syle in other Python sources.