### PR TITLE
Grappler: Remove FusedBatchNorm from NeverForwardsInputs list

### DIFF
--- a/tensorflow/core/grappler/op_types.cc
+++ b/tensorflow/core/grappler/op_types.cc
@@ -943,8 +943,6 @@ bool NeverForwardsInputs(const NodeDef& node) {
                                 "Bucketize",
                                 "AvgPool",
                                 "BatchNormWithGlobalNormalization",
-                                "FusedBatchNorm",
-                                "FusedBatchNormV2",
                                 "Conv2D",
                                 "RandomUniform",
                                 "RandomUniformInt",


### PR DESCRIPTION
@reedwm Mentioned in https://github.com/tensorflow/tensorflow/pull/33698#discussion_r338777281 that all versions of FusedBatchNorm can forward their inputs [here](https://github.com/tensorflow/tensorflow/blob/a12d05f82de28dceb62eaf4bb4b8b9daf3a3057b/tensorflow/core/kernels/fused_batch_norm_op.cc#L1185).
@rmlarsen Is this correct?

If this isn't a bug, this list should also include `FusedBatchNormV3`.