### PR TITLE
Fix out-of-sync issue in ignore_errors with tf.data.Dataset.zip

### DIFF
--- a/tensorflow/core/kernels/data/zip_dataset_op.cc
+++ b/tensorflow/core/kernels/data/zip_dataset_op.cc
@@ -141,11 +141,8 @@ class ZipDatasetOp::Dataset : public DatasetBase {
       for (const auto& input_impl : input_impls_) {
         std::vector<Tensor> input_tensors;
         bool component_end_of_sequence = false;
-        Status component_status = input_impl->GetNext(ctx, &input_tensors, &component_end_of_sequence);
+        status.Update(input_impl->GetNext(ctx, &input_tensors, &component_end_of_sequence));
         *end_of_sequence |= component_end_of_sequence;
-        if (!component_status.ok() && status.ok()) {
-          status.Update(component_status);
-        }
         // Even if an error is encountered for one of the components,
         // we need to make sure to advance all components, to keep them in sync.
         if (!status.ok()) {
@@ -153,7 +150,7 @@ class ZipDatasetOp::Dataset : public DatasetBase {
         }
         if (*end_of_sequence) {
           break;
-	}
+        }
         out_tensors->insert(out_tensors->end(), input_tensors.begin(),
                             input_tensors.end());
       }

--- a/tensorflow/core/kernels/data/zip_dataset_op.cc
+++ b/tensorflow/core/kernels/data/zip_dataset_op.cc
@@ -140,22 +140,20 @@ class ZipDatasetOp::Dataset : public DatasetBase {
       *end_of_sequence = false;
       for (const auto& input_impl : input_impls_) {
         std::vector<Tensor> input_tensors;
-        bool end_of_sequence_component = false;
-        Status status_component = input_impl->GetNext(ctx, &input_tensors, &end_of_sequence_component);
-        if (end_of_sequence_component) {
-          *end_of_sequence = end_of_sequence_component;
+        bool component_end_of_sequence = false;
+        Status component_status = input_impl->GetNext(ctx, &input_tensors, &component_end_of_sequence);
+        *end_of_sequence |= component_end_of_sequence;
+        if (!component_status.ok() && status.ok()) {
+          status.Update(component_status);
         }
-        if (!status_component.ok() && status.ok()) {
-          status = status_component;
-        }
-        // Even if there is error or end_of_sequence encountered,
-        // we should still run to "flush out" any record
-        // for each component, so that ignore_errors could be processed
-        // correctly.
-        // No need to copy the component data though so just continue here.
-        if (*end_of_sequence || !status.ok()) {
+        // Even if an error is encountered for one of the components,
+        // we need to make sure to advance all components, to keep them in sync.
+        if (!status.ok()) {
           continue;
         }
+        if (*end_of_sequence) {
+          break;
+	}
         out_tensors->insert(out_tensors->end(), input_tensors.begin(),
                             input_tensors.end());
       }

--- a/tensorflow/python/data/experimental/kernel_tests/ignore_errors_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/ignore_errors_test.py
@@ -126,6 +126,19 @@ class IgnoreErrorsTest(test_base.DatasetTestBase):
     with self.assertRaises(errors.OutOfRangeError):
       self.evaluate(get_next())
 
+  def testZipIgnoreError(self):
+    a = dataset_ops.Dataset.from_tensor_slices([1., 2., 0., 4.])
+    b = a.map(lambda x: array_ops.check_numerics(1. / x, "error"))
+
+    dataset = dataset_ops.Dataset.zip(
+        (b, a)).apply(error_ops.ignore_errors())
+    get_next = self.getNext(dataset)
+
+    for x in [1., 2., 4.]:
+      self.assertEqual((1. / x, x), self.evaluate(get_next()))
+    with self.assertRaises(errors.OutOfRangeError):
+      self.evaluate(get_next())
+
 
 if __name__ == "__main__":
   test.main()


### PR DESCRIPTION
This PR tries to address the issue raised in #33383 where ignore_errors combined with tf.data.Dataset.zip will be out-of-sync for component.

The issue was that, in case of zip, remaining components were
not flushed out when end-of-sequence of error encountered.

This PR fixes the isuse.

This PR fixes #33383.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>