### PR TITLE
Fix ValueError with tf.data.Dataset and model.fit

### DIFF
--- a/tensorflow/python/keras/engine/training_utils.py
+++ b/tensorflow/python/keras/engine/training_utils.py
@@ -262,7 +262,12 @@ def standardize_single_array(x, expected_shape=None):
   if x is None:
     return None
 
-  if (x.shape is not None and len(x.shape) == 1 and
+  if tensor_util.is_tensor(x):
+    x_shape_ndims = x.shape.rank
+  else:
+    x_shape_ndims = len(x.shape)
+
+  if (x_shape_ndims == 1 and
       (expected_shape is None or len(expected_shape) != 1)):
     if tensor_util.is_tensor(x):
       x = array_ops.expand_dims(x, axis=1)


### PR DESCRIPTION
This fix, like its predecessor PR tensorflow#24522, tries to address issue
no. tensorflow#24520, where passing tf.data.Dataset into model.fit may result
in `ValueError: Cannot take the length of Shape with unknown rank.`.

This fixes the error by using `shape.rank` rather than checking
`len(shape)`. This PR's predecessor tensorflow#24522 did this incorrectly,
and was never merged.