### PR TITLE
[ROCm] Fix for the broken ROCm CSB.

### DIFF
--- a/third_party/gpus/crosstool/hipcc_cc_toolchain_config.bzl.tpl
+++ b/third_party/gpus/crosstool/hipcc_cc_toolchain_config.bzl.tpl
@@ -114,7 +114,7 @@ def _impl(ctx):
 
     cc_target_os = None
 
-    builtin_sysroot = None
+    builtin_sysroot = ctx.attr.builtin_sysroot
 
     all_link_actions = [
         ACTION_NAMES.cpp_link_executable,
@@ -1493,6 +1493,8 @@ cc_toolchain_config = rule(
         "host_compiler_warnings": attr.string_list(),
         "host_unfiltered_compile_flags": attr.string_list(),
         "linker_bin_path": attr.string(),
+        "builtin_sysroot": attr.string(),
+        "cuda_path": attr.string(),
         "msvc_cl_path": attr.string(default = "msvc_not_used"),
         "msvc_env_include": attr.string(default = "msvc_not_used"),
         "msvc_env_lib": attr.string(default = "msvc_not_used"),


### PR DESCRIPTION
The following commit breaks the `--config=rocm` build

https://github.com/tensorflow/tensorflow/commit/a2323c1b1f0f857fd40fff7a481dfa300b8f7e02

The commit above adds the "builtin_sysroot" and "cuda_path" arguments to the "cc_toolchain_config" rule within the crosstool/BUILD.tpl template. That template generates the BULD file which is used to setup both ROCm and CUDA configurations. The commit above updates the cuda_configure.bzl file to pass in the new arguments when calling the "cc_toolchain_config" rule, but does not make the same updates to the rocm_configure.bzl file, leading to the breakage in the ROCm build.

This commit simply makes the corresponding updates in the rocm_configure.bzl file.

----------------------------------

@whchung @chsigg 

Note this PR is in addition PR #33806 , which addresses different breakages in the ROCm CSB. 

Both PRs are needed to get the ROCm CSB passing again. Please review this PR and PR #33806. 

thanks.