### PR TITLE
Address problems with use_deterministic_cudnn test decorator

### DIFF
--- a/tensorflow/python/framework/test_util.py
+++ b/tensorflow/python/framework/test_util.py
@@ -1623,7 +1623,7 @@ class ErrorLoggingSession(session.Session):
       raise
 
 
-def use_deterministic_cudnn(func):
+def disable_cudnn_autotune(func):
   """Disable autotuning during the call to this function.
 
   Some tests want to base assertions on a graph being isomorphic with a copy.
@@ -1639,10 +1639,10 @@ def use_deterministic_cudnn(func):
   def decorator(f):
 
     def decorated(self, *args, **kwargs):
-      original_var = os.environ.get("TF_CUDNN_DETERMINISTIC", "")
-      os.environ["TF_CUDNN_DETERMINISTIC"] = "true"
+      original_var = os.environ.get("TF_CUDNN_USE_AUTOTUNE", "")
+      os.environ["TF_CUDNN_USE_AUTOTUNE"] = "false"
       result = f(self, *args, **kwargs)
-      os.environ["TF_CUDNN_DETERMINISTIC"] = original_var
+      os.environ["TF_CUDNN_USE_AUTOTUNE"] = original_var
       return result
 
     return decorated

--- a/tensorflow/python/framework/test_util.py
+++ b/tensorflow/python/framework/test_util.py
@@ -1630,7 +1630,7 @@ def disable_cudnn_autotune(func):
   To ensure this, this decorator disables autotuning.
 
   Args:
-    func: Function to run with CUDNN autotuning turned off.
+    func: Function to run with CuDNN autotuning turned off.
 
   Returns:
     Decorated function.
@@ -1639,10 +1639,25 @@ def disable_cudnn_autotune(func):
   def decorator(f):
 
     def decorated(self, *args, **kwargs):
-      original_var = os.environ.get("TF_CUDNN_USE_AUTOTUNE", "")
+      original_tf_cudnn_use_autotune = os.environ.get("TF_CUDNN_USE_AUTOTUNE")
       os.environ["TF_CUDNN_USE_AUTOTUNE"] = "false"
+      original_xla_flags = os.environ.get("XLA_FLAGS")
+      new_xla_flags = "--xla_gpu_disable_autotune"
+      if original_xla_flags:
+        new_xla_flags += " " + original_xla_flags
+      os.environ["XLA_FLAGS"] = new_xla_flags
+
       result = f(self, *args, **kwargs)
-      os.environ["TF_CUDNN_USE_AUTOTUNE"] = original_var
+
+      if (original_tf_cudnn_use_autotune is None):
+        del os.environ["TF_CUDNN_USE_AUTOTUNE"]
+      else:
+        os.environ["TF_CUDNN_USE_AUTOTUNE"] = original_tf_cudnn_use_autotune
+      if (original_xla_flags is None):
+        del os.environ["XLA_FLAGS"]
+      else:
+        os.environ["XLA_FLAGS"] = original_xla_flags
+
       return result
 
     return decorated

--- a/tensorflow/python/keras/testing_utils.py
+++ b/tensorflow/python/keras/testing_utils.py
@@ -71,7 +71,7 @@ def get_test_data(train_samples,
           (x[train_samples:], y[train_samples:]))
 
 
-@test_util.use_deterministic_cudnn
+@test_util.disable_cudnn_autotune
 def layer_test(layer_cls, kwargs=None, input_shape=None, input_dtype=None,
                input_data=None, expected_output=None,
                expected_output_dtype=None, expected_output_shape=None,


### PR DESCRIPTION
There is something not right here, and I'm trying to figure out how best to fix it.

`use_deterministic_cudnn` in `tensorflow/python/framework/test_util.py` is a test decorator that was added in [this commit](https://github.com/tensorflow/tensorflow/commit/c27909ea80e8823dbf4f7176ab69991a630356a1) on 2019-03-13.

The only place it's used is to decorate `layer_test` in `tensorflow/python/keras/testing_utils.py`, which is called (only) from a bunch of test files in `tensorflow/python/keras/layers`.

I initially noticed that the docstring for `use_deterministic_cudnn` does not match what the decorator actually does, and I intended to fix that. The decorator sets `TF_CUDNN_DETERMINISTIC=true`, and that not only disables cuDNN auto-tuning (from an end-user perspective), but also ensures the deterministic selection of deterministic algorithms for the back-prop of cuDNN convolution and max-pooling.

But the problems go deeper. This decorator intends to enable `TF_CUDNN_DETERMINISTIC` only for the decorated test. However, `TF_CUDNN_DETERMINISTIC` is currently implemented so that its value is cached in a static variable the first time it's used. This means that the implied promise of the decorator code to restore the `TF_CUDNN_DETERMINISTIC` setting cannot be fulfilled. Worse still, if an earlier-running test causes `TF_CUDNN_DETERMINISTIC` to be cached (as "0" or "false") then the decorator will have no effect whatsoever.

Additionally, the underlying `TF_CUDNN_DETERMINISTIC` functionality is currently implemented in a way that leads to the caching of the chosen algorithms (for any given layer configuration), even if the environment variable itself were not cached.

In this current pull request, I'm proposing changing the decorator to use `TF_CUDNN_USE_AUTOTUNE=false` (instead of `TF_CUDNN_DETERMINISTIC=true`), which both makes the code match the docstring and works in terms of environment variable caching: I believe that `TF_CUDNN_USE_AUTOTUNE` is freshly re-evaluated every time a cuDNN convolution is launched.

Whether this proposed change is appropriate or not depends on what is meant by "Some tests want to base assertions on a graph being _isomorphic with a copy_." (from the docstring). What is meant by the graph being isomorphic with a copy? Is this requiring bit-exact determinism from the cuDNN convolution and max-pooling back-prop algorithms? If yes, then this per-test-decorator-based solution is probably not appropriate and `TF_CUDNN_DETERMINISTIC` should be set to "true" in a broader scope. An example approach is shown [here](https://github.com/tensorflow/tensorflow/blob/v2.0.0/tensorflow/python/kernel_tests/cudnn_determinism_test.py#L102).

I would like to work with the right person/people to help resolve this issue.