### PR TITLE
Fix the progress bar of keras.Model.evaluate()

### DIFF
--- a/tensorflow/python/keras/callbacks_test.py
+++ b/tensorflow/python/keras/callbacks_test.py
@@ -1377,6 +1377,15 @@ class KerasCallbacksTest(keras_parameterized.TestCase):
             validation_data=(x_test, y_test),
             callbacks=cbks,
             epochs=1)
+        
+  def test_callback_params_samples(self):
+    x, y = np.ones((64, 3)), np.ones((64, 2))
+    model = testing_utils.get_small_sequential_mlp(
+        num_hidden=10, num_classes=2, input_dim=3)
+    model.compile('sgd', 'mse')
+    callback = keras.callbacks.Callback()
+    model.evaluate(x, y, callbacks=[callback])
+    self.assertEqual(callback.params['samples'], 64)
 
 
 # A summary that was emitted during a test. Fields:

--- a/tensorflow/python/keras/engine/training_v2.py
+++ b/tensorflow/python/keras/engine/training_v2.py
@@ -445,7 +445,7 @@ class Loop(training_utils.TrainingLoop):
           batch_size=batch_size,
           epochs=1,
           steps_per_epoch=steps,
-          samples=use_sample,
+          samples=total_samples,
           count_mode='samples' if use_sample else 'steps',
           verbose=0,  # Handle ProgBarLogger separately in this loop.
           mode=mode)


### PR DESCRIPTION
Fix #32320 and #32286

I also wrote a simple test case to check the value of `params.['samples']` after `model.evaluate()`.
```python
import numpy as np
from tensorflow.python import keras
from tensorflow.python.keras import keras_parameterized
from tensorflow.python.keras import testing_utils
from tensorflow.python.keras.callbacks import Callback
from tensorflow.python.platform import test


class TestCase(keras_parameterized.TestCase):
  def test_callback_params_samples(self):
    x, y = np.ones((64, 3)), np.ones((64, 2))
    model = testing_utils.get_small_sequential_mlp(
        num_hidden=10, num_classes=2, input_dim=3)
    model.compile('sgd', 'mse')
    callback = Callback()
    model.evaluate(x, y, callbacks=[callback])
    self.assertEqual(callback.params['samples'], 64)


if __name__ == '__main__':
  test.main()
```
Where should I put this test case?

The test output before this PR:
```
64/1 [================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================] - 0s 845us/sample - loss: 0.3011
[  FAILED  ] TestCase.test_callback_params_samples
[ RUN      ] TestCase.test_session
[  SKIPPED ] TestCase.test_session
======================================================================
FAIL: test_callback_params_samples (__main__.TestCase)
test_callback_params_samples (__main__.TestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "d.py", line 17, in test_callback_params_samples
    self.assertEqual(callback.params['samples'], 64)
AssertionError: True != 64

----------------------------------------------------------------------
Ran 2 tests in 0.240s

FAILED (failures=1, skipped=1)
```
The test output after this PR:
```
64/64 [==============================] - 0s 1ms/sample - loss: 0.3011
[       OK ] TestCase.test_callback_params_samples
[ RUN      ] TestCase.test_session
[  SKIPPED ] TestCase.test_session
----------------------------------------------------------------------
Ran 2 tests in 0.261s

OK (skipped=1)
```