### PR TITLE
Add gelu

### DIFF
--- a/tensorflow/python/keras/activations.py
+++ b/tensorflow/python/keras/activations.py
@@ -302,6 +302,27 @@ def relu(x, alpha=0., max_value=None, threshold=0):
   return K.relu(x, alpha=alpha, max_value=max_value, threshold=threshold)
 
 
+@keras_export('keras.activations.gelu')
+@dispatch.add_dispatch_support
+def gelu(x, approximate=True):
+  """Gaussian Error Linear Unit.
+
+  Arguments:
+      x: Input tensor.
+
+  Returns:
+      The gaussian error linear activation:
+      `0.5 * x * (1 + tanh(sqrt(2 / pi) * (x + 0.044715 * x^3)))`
+      if `approximate` is `True` or
+      `x * P(X <= x) = 0.5 * x * (1 + erf(x / sqrt(2)))`, where P(X) ~ N(0, 1),
+      if `approximate` is `False`.
+
+  Reference:
+    - [Gaussian Error Linear Units (GELUs)](https://arxiv.org/abs/1606.08415)
+  """
+  return nn.gelu(x, approximate)
+
+
 @keras_export('keras.activations.tanh')
 @dispatch.add_dispatch_support
 def tanh(x):

--- a/tensorflow/python/keras/activations_test.py
+++ b/tensorflow/python/keras/activations_test.py
@@ -43,7 +43,7 @@ class KerasActivationsTest(test.TestCase, parameterized.TestCase):
   def test_serialization(self):
     all_activations = ['softmax', 'relu', 'elu', 'tanh',
                        'sigmoid', 'hard_sigmoid', 'linear',
-                       'softplus', 'softsign', 'selu']
+                       'softplus', 'softsign', 'selu', 'gelu']
     for name in all_activations:
       fn = activations.get(name)
       ref_fn = getattr(activations, name)
@@ -168,6 +168,27 @@ class KerasActivationsTest(test.TestCase, parameterized.TestCase):
     negative_values = np.random.uniform(-1, 0, (2, 5))
     result = f([negative_values])[0]
     expected = np.zeros((2, 5))
+    self.assertAllClose(result, expected, rtol=1e-05)
+
+  def test_gelu(self):
+    def gelu(x, approximate=True):
+      if approximate:
+        return 0.5 * x * (1.0 + np.tanh(np.sqrt(2.0 / np.pi) *
+                                        (x + 0.044715 * np.power(x, 3))))
+      else:
+        from scipy.stats import norm  # pylint: disable=g-import-not-at-top
+        return x * norm.cdf(x)
+    x = backend.placeholder(ndim=2)
+    f = backend.function([x], [activations.gelu(x)])
+    test_values = np.random.random((2, 5))
+    result = f([test_values])[0]
+    expected = gelu(test_values)
+    self.assertAllClose(result, expected, rtol=1e-05)
+
+    f = backend.function([x], [activations.gelu(x, False)])
+    test_values = np.random.random((2, 5))
+    result = f([test_values])[0]
+    expected = gelu(test_values, False)
     self.assertAllClose(result, expected, rtol=1e-05)
 
   def test_elu(self):

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -3493,6 +3493,36 @@ def leaky_relu(features, alpha=0.2, name=None):
     return gen_nn_ops.leaky_relu(features, alpha=alpha, name=name)
 
 
+@tf_export("nn.gelu")
+@dispatch.add_dispatch_support
+def gelu(features, approximate=True, name=None):
+  """Compute the Gaussian Error Linear Unit (GELU) activation function.
+
+  Args:
+    features: A `Tensor` representing preactivation values.
+    approximate: An optional `bool`. Defaults to `True`.
+      Whether to enable approximation.
+    name: A name for the operation (optional).
+
+  Returns:
+    A `Tensor` with the same type as `features`.
+
+  References:
+    [Gaussian Error Linear Units (GELUs)](https://arxiv.org/abs/1606.08415).
+  """
+  with ops.name_scope(name, "Gelu", [features]):
+    features = ops.convert_to_tensor(features, name="features")
+    if approximate:
+      pi = math_ops.cast(np.pi, features.dtype)
+      coeff = math_ops.cast(0.044715, features.dtype)
+      return 0.5 * features * (1.0 + math_ops.tanh(
+        math_ops.sqrt(2.0 / pi) *
+        (features + coeff * math_ops.pow(features, 3))))
+    else:
+      return 0.5 * features * (1.0 + math_ops.erf(
+        features / math_ops.cast(1.4142135623730951, features.dtype)))
+
+
 def _flatten_outer_dims(logits):
   """Flattens logits' outer dimensions and keep its last dimension."""
   rank = array_ops.rank(logits)

--- a/tensorflow/python/ops/nn_test.py
+++ b/tensorflow/python/ops/nn_test.py
@@ -1059,6 +1059,29 @@ class LeakyReluTest(test_lib.TestCase):
     self.assertEqual(outputs_without_name_set.name, 'LeakyRelu:0')
 
 
+class GeluTest(test_lib.TestCase):
+
+  def test(self):
+
+    def gelu(x, approximate=True):
+      if approximate:
+        return 0.5 * x * (1.0 + np.tanh(np.sqrt(2.0 / np.pi) *
+                                        (x + 0.044715 * np.power(x, 3))))
+      else:
+        from scipy.stats import norm  # pylint: disable=g-import-not-at-top
+        return x * norm.cdf(x)
+
+    np.random.seed(1)  # Make it reproducible.
+    x = np.random.randn(3, 4).astype(np.float32)
+    y = gelu(x)
+    z = self.evaluate(nn_ops.gelu(x))
+    self.assertAllClose(y, z)
+
+    y = gelu(x, False)
+    z = self.evaluate(nn_ops.gelu(x, False))
+    self.assertAllClose(y, z)
+
+
 class SwishTest(test_lib.TestCase):
 
   @test_util.run_deprecated_v1


### PR DESCRIPTION
Closes #32783. Migrate gelu activation from addons https://github.com/tensorflow/addons/issues/550.

Some benchmark between C++ and python implementation.

Without XLA: 10 times faster than composite python operations 
https://colab.research.google.com/drive/1P14w9KjnBLjnyEIs2k7Oy3w0QAa5BxKM

With XLA: 2 times faster than python operations when enabling XLA
https://colab.research.google.com/drive/1pQFOp5sEp3Gw0LGHlZ6dPsNGfZPWXcgc

Note that addons implementation does not have XLA ops. Would like to deal with XLA and mixed precision part if this gets merges.