### PR TITLE
Fix TensorFlow on Python 3.8 logger issue

### DIFF
--- a/tensorflow/python/platform/tf_logging.py
+++ b/tensorflow/python/platform/tf_logging.py
@@ -57,7 +57,8 @@ def _get_caller(offset=3):
     f = f.f_back
   return None, None
 
-# The definition of `findCaller` changed in Python 3.2
+# The definition of `findCaller` changed in Python 3.2,
+# and further changed in Python 3.8
 if _sys.version_info.major >= 3 and _sys.version_info.minor >= 8:
   def _logger_find_caller(stack_info=False, stacklevel=1):  # pylint: disable=g-wrong-blank-lines
     code, frame = _get_caller(4)

--- a/tensorflow/python/platform/tf_logging.py
+++ b/tensorflow/python/platform/tf_logging.py
@@ -57,9 +57,18 @@ def _get_caller(offset=3):
     f = f.f_back
   return None, None
 
-
 # The definition of `findCaller` changed in Python 3.2
-if _sys.version_info.major >= 3 and _sys.version_info.minor >= 2:
+if _sys.version_info.major >= 3 and _sys.version_info.minor >= 8:
+  def _logger_find_caller(stack_info=False, stacklevel=1):  # pylint: disable=g-wrong-blank-lines
+    code, frame = _get_caller(4)
+    sinfo = None
+    if stack_info:
+      sinfo = '\n'.join(_traceback.format_stack())
+    if code:
+      return (code.co_filename, frame.f_lineno, code.co_name, sinfo)
+    else:
+      return '(unknown file)', 0, '(unknown function)', sinfo
+elif _sys.version_info.major >= 3 and _sys.version_info.minor >= 2:
   def _logger_find_caller(stack_info=False):  # pylint: disable=g-wrong-blank-lines
     code, frame = _get_caller(4)
     sinfo = None


### PR DESCRIPTION
This fix tries to address the issue raised in #33799 where running tensorflow on python 3.8 (Ubuntu 18.04) raised the following error:
```
TypeError: _logger_find_caller() takes from 0 to 1 positional arguments but 2 were given
```

The issue was that findCaller changed in Python 3.8

This PR fixes the issue.

This PR fixes #33799

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>