### PR TITLE
comp:micro - Set g_pdm_dma_error_reporter pointer to the error_reporter passed to InitAudioRecording()

### DIFF
--- a/tensorflow/lite/micro/examples/micro_speech/apollo3evb/audio_provider.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/apollo3evb/audio_provider.cc
@@ -247,7 +247,6 @@ void pdm_start_dma(tflite::ErrorReporter* error_reporter) {
 
   // Reset the PDM DMA flags.
   g_pdm_dma_error = false;
-  g_pdm_dma_error_reporter = error_reporter;
 }
 
 #if USE_MAYA
@@ -460,11 +459,12 @@ TfLiteStatus InitAudioRecording(tflite::ErrorReporter* error_reporter) {
 #endif  // USE_TIME_STAMP
 
   // Configure, turn on PDM
+  g_pdm_dma_error_reporter = error_reporter;
   pdm_init();
   am_hal_interrupt_master_enable();
   am_hal_pdm_fifo_flush(g_pdm_handle);
   // Trigger the PDM DMA for the first time manually.
-  pdm_start_dma(g_pdm_dma_error_reporter);
+  pdm_start_dma(error_reporter);
 
   error_reporter->Report("\nPDM DMA Threshold = %d", PDMn(0)->FIFOTHR);
 


### PR DESCRIPTION
Fix for micro_speech example on apollo3evb boards:

The pointer g_pdm_dma_error_reporter is used to report DMA errors on apollo3evb boards.
However currently it is always set to a nullptr due to an initialization bug.
This causes crashes on DMA errors like fifo overflows.
 
Please add the following labels:
**comp:lite**
**comp:micro**