### PR TITLE
[tflite] expose more NNAPI Delegate to Java

### DIFF
--- a/tensorflow/lite/delegates/nnapi/java/src/main/java/org/tensorflow/lite/nnapi/NnApiDelegate.java
+++ b/tensorflow/lite/delegates/nnapi/java/src/main/java/org/tensorflow/lite/nnapi/NnApiDelegate.java
@@ -25,8 +25,74 @@ public class NnApiDelegate implements Delegate, AutoCloseable {
 
   private long delegateHandle;
 
+  /** Delegate options. */
+  public static final class Options {
+    public Options() {}
+
+    /** undefined */
+    public static final int EXECUTION_PREFERENCE_UNDEFINED = -1;
+
+    /**
+     * Prefer executing in a way that minimizes battery drain. This is desirable for compilations
+     * that will be executed often.
+     */
+    public static final int EXECUTION_PREFERENCE_LOW_POWER = 0;
+
+    /**
+     * Prefer returning a single answer as fast as possible, even if this causes more power
+     * consumption.
+     */
+    public static final int EXECUTION_PREFERENCE_FAST_SINGLE_ANSWER = 1;
+
+    /**
+     * Prefer maximizing the throughput of successive frames, for example when processing successive
+     * frames coming from the camera.
+     */
+    public static final int EXECUTION_PREFERENCE_SUSTAINED_SPEED = 2;
+
+    /**
+     * Sets the inference preference for precision/compilation/runtime tradeoffs.
+     *
+     * @param preference One of EXECUTION_PREFERENCE_LOW_POWER,
+     *     EXECUTION_PREFERENCE_FAST_SINGLE_ANSWER, and EXECUTION_PREFERENCE_SUSTAINED_SPEED.
+     */
+    public Options setExecutionPreference(int preference) {
+      this.executionPreference = preference;
+      return this;
+    }
+
+    public Options setAcceleratorName(String name) {
+      this.accelerator_name = name;
+      return this;
+    }
+
+    public Options setCacheDir(String name) {
+      this.cache_dir = name;
+      return this;
+    }
+
+    public Options setModelToken(String name) {
+      this.model_token = name;
+      return this;
+    }
+
+    int executionPreference = EXECUTION_PREFERENCE_UNDEFINED;
+    String accelerator_name = null;
+    String cache_dir = null;
+    String model_token = null;
+  }
+
+  public NnApiDelegate(Options options) {
+    delegateHandle =
+        createDelegate(
+            options.executionPreference,
+            options.accelerator_name,
+            options.cache_dir,
+            options.model_token);
+  }
+
   public NnApiDelegate() {
-    delegateHandle = createDelegate();
+    this(new Options());
   }
 
   @Override
@@ -35,16 +101,22 @@ public class NnApiDelegate implements Delegate, AutoCloseable {
   }
 
   /**
-   * The NNAPI delegate is singleton. Nothing to delete for now, so mark the handle invalid only.
+   * Frees TFLite resources in C runtime.
+   *
+   * <p>User is expected to call this method explicitly.
    */
   @Override
   public void close() {
     if (delegateHandle != INVALID_DELEGATE_HANDLE) {
+      deleteDelegate(delegateHandle);
       delegateHandle = INVALID_DELEGATE_HANDLE;
     }
   }
 
-  private static native long createDelegate();
+  private static native long createDelegate(
+      int preference, String device_name, String cache_dir, String model_token);
+
+  private static native void deleteDelegate(long delegateHandle);
 
   static {
     // Ensure the native TensorFlow Lite libraries are available.

--- a/tensorflow/lite/delegates/nnapi/java/src/main/java/org/tensorflow/lite/nnapi/NnApiDelegate.java
+++ b/tensorflow/lite/delegates/nnapi/java/src/main/java/org/tensorflow/lite/nnapi/NnApiDelegate.java
@@ -29,7 +29,9 @@ public class NnApiDelegate implements Delegate, AutoCloseable {
   public static final class Options {
     public Options() {}
 
-    /** undefined */
+    /** undefined, specifies default behavior.
+     *  so far, the default setting of NNAPI is EXECUTION_PREFERENCE_FAST_SINGLE_ANSWER
+     */
     public static final int EXECUTION_PREFERENCE_UNDEFINED = -1;
 
     /**

--- a/tensorflow/lite/delegates/nnapi/java/src/main/native/BUILD
+++ b/tensorflow/lite/delegates/nnapi/java/src/main/native/BUILD
@@ -18,8 +18,6 @@ cc_library(
         "notap",
     ],
     deps = [
-        "//tensorflow/lite:context",
-        "//tensorflow/lite:framework",
         "//tensorflow/lite/delegates/nnapi:nnapi_delegate",
         "//tensorflow/lite/java/jni",
     ],

--- a/tensorflow/lite/delegates/nnapi/java/src/main/native/BUILD
+++ b/tensorflow/lite/delegates/nnapi/java/src/main/native/BUILD
@@ -18,6 +18,8 @@ cc_library(
         "notap",
     ],
     deps = [
+        "//tensorflow/lite:context",
+        "//tensorflow/lite:framework",
         "//tensorflow/lite/delegates/nnapi:nnapi_delegate",
         "//tensorflow/lite/java/jni",
     ],

--- a/tensorflow/lite/delegates/nnapi/java/src/main/native/nnapi_delegate_jni.cc
+++ b/tensorflow/lite/delegates/nnapi/java/src/main/native/nnapi_delegate_jni.cc
@@ -31,11 +31,31 @@ Java_org_tensorflow_lite_nnapi_NnApiDelegate_createDelegate(
   StatefulNnApiDelegate::Options options = StatefulNnApiDelegate::Options();
   options.execution_preference =
       (StatefulNnApiDelegate::Options::ExecutionPreference)preference;
-  options.accelerator_name = env->GetStringUTFChars(accelerator_name, NULL);
-  options.cache_dir = env->GetStringUTFChars(cache_dir, NULL);
-  options.model_token = env->GetStringUTFChars(model_token, NULL);
+  if (accelerator_name) {
+    options.accelerator_name = env->GetStringUTFChars(accelerator_name, NULL);
+  }
+  if (cache_dir) {
+    options.cache_dir = env->GetStringUTFChars(cache_dir, NULL);
+  }
+  if (model_token) {
+    options.model_token = env->GetStringUTFChars(model_token, NULL);
+  }
 
-  return reinterpret_cast<jlong>(new StatefulNnApiDelegate(options));
+  auto delegate = new StatefulNnApiDelegate(options);
+
+  if (options.accelerator_name) {
+    env->ReleaseStringUTFChars(accelerator_name, options.accelerator_name);
+  }
+
+  if (options.cache_dir) {
+    env->ReleaseStringUTFChars(cache_dir, options.accelerator_name);
+  }
+
+  if (options.model_token) {
+    env->ReleaseStringUTFChars(model_token, options.accelerator_name);
+  }
+
+  return reinterpret_cast<jlong>(delegate);
 }
 
 JNIEXPORT void JNICALL

--- a/tensorflow/lite/delegates/nnapi/java/src/main/native/nnapi_delegate_jni.cc
+++ b/tensorflow/lite/delegates/nnapi/java/src/main/native/nnapi_delegate_jni.cc
@@ -15,16 +15,36 @@ limitations under the License.
 
 #include <jni.h>
 
+#include "tensorflow/lite/context.h"
 #include "tensorflow/lite/delegates/nnapi/nnapi_delegate.h"
+#include "tensorflow/lite/model.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
 
+using namespace tflite;
+
 JNIEXPORT jlong JNICALL
-Java_org_tensorflow_lite_nnapi_NnApiDelegate_createDelegate(JNIEnv* env,
-                                                            jclass clazz) {
-  return reinterpret_cast<jlong>(tflite::NnApiDelegate());
+Java_org_tensorflow_lite_nnapi_NnApiDelegate_createDelegate(
+    JNIEnv* env, jclass clazz, jint preference, jstring accelerator_name,
+    jstring cache_dir, jstring model_token) {
+
+  StatefulNnApiDelegate::Options options = StatefulNnApiDelegate::Options();
+  options.execution_preference =
+      (StatefulNnApiDelegate::Options::ExecutionPreference)preference;
+  options.accelerator_name = env->GetStringUTFChars(accelerator_name, NULL);
+  options.cache_dir = env->GetStringUTFChars(cache_dir, NULL);
+  options.model_token = env->GetStringUTFChars(model_token, NULL);
+
+  return reinterpret_cast<jlong>(new StatefulNnApiDelegate(options));
+}
+
+JNIEXPORT void JNICALL
+Java_org_tensorflow_lite_nnapi_NnApiDelegate_deleteDelegate(JNIEnv* env,
+                                                            jclass clazz,
+                                                            jlong delegate) {
+  delete reinterpret_cast<TfLiteDelegate*>(delegate);
 }
 
 #ifdef __cplusplus

--- a/tensorflow/lite/delegates/nnapi/java/src/main/native/nnapi_delegate_jni.cc
+++ b/tensorflow/lite/delegates/nnapi/java/src/main/native/nnapi_delegate_jni.cc
@@ -15,9 +15,7 @@ limitations under the License.
 
 #include <jni.h>
 
-#include "tensorflow/lite/context.h"
 #include "tensorflow/lite/delegates/nnapi/nnapi_delegate.h"
-#include "tensorflow/lite/model.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
1. use StatefulNnApiDelegate instead of the deprecated `tflite::NnApiDelegate()`, see [here](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/delegates/nnapi/nnapi_delegate.h#L173-L181)
2. make it possible to specify NNAPI [execution preference](https://developer.android.com/ndk/reference/group/neural-networks#preferencecode) in Java.