### PR TITLE
Force psutil version to 5.6.3 for python2

### DIFF
--- a/tensorflow/tools/ci_build/install/install_pip_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_pip_packages.sh
@@ -87,7 +87,7 @@ pip2 install pandas==0.19.2
 pip3 install pandas==0.19.2
 
 # Benchmark tests require the following:
-pip2 install psutil
+pip2 install psutil==5.6.3
 pip3 install psutil
 pip2 install py-cpuinfo
 pip3 install py-cpuinfo


### PR DESCRIPTION
The latest (5.6.4) is broken on python2:
```
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
Collecting psutil
  Using cached https://files.pythonhosted.org/packages/47/ea/d3b6d6fd0b4a6c12984df652525f394e68c8678d2b05075219144eb3a1cf/psutil-5.6.4.tar.gz
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... error
    ERROR: Command errored out with exit status 1:
     command: /localdata/anthonyb/workspace/external/tf_python_python2/bin/python2 /localdata/anthonyb/workspace/external/tf_python_python2/local/lib/python2.7/site-packages/pip/_vendor/pep517/_in_process.py prepare_metadata_for_build_wheel /tmp/tmpbqQ5kk
         cwd: /tmp/pip-install-Rk4IAs/psutil
    Complete output (2 lines):
    running dist_info
    error: 'egg_base' must be a directory name (got )
```