### PR TITLE
[Intel MKL] Enable TF_NUM_INTEROP_THREADS for MKL-DNN backend.

### DIFF
--- a/tensorflow/core/common_runtime/process_util.cc
+++ b/tensorflow/core/common_runtime/process_util.cc
@@ -34,10 +34,15 @@ namespace tensorflow {
 
 namespace {
 
+// Use environment setting if specified (init once)
+int32 GetEnvNumInterOpThreads() {
+  static int32 env_num_threads = NumInterOpThreadsFromEnvironment();
+  return env_num_threads;
+}
+
 int32 DefaultNumInterOpThreads() {
 #ifndef __ANDROID__
-  // Use environment setting if specified (init once)
-  static int env_num_threads = NumInterOpThreadsFromEnvironment();
+  int32 env_num_threads = GetEnvNumInterOpThreads();
   if (env_num_threads > 0) {
     return env_num_threads;
   }
@@ -121,6 +126,9 @@ int32 DefaultNumIntraOpThreads() {
 int32 NumInterOpThreadsFromSessionOptions(const SessionOptions& options) {
   const int32 inter_op = options.config.inter_op_parallelism_threads();
   if (inter_op > 0) return inter_op;
+  const int32 env_inter_op = GetEnvNumInterOpThreads();
+  if (env_inter_op > 0) return env_inter_op;
+
 #ifdef INTEL_MKL
   if (!DisableMKL()) {
     // MKL library executes ops in parallel using OMP threads.
@@ -163,7 +171,7 @@ void SchedClosure(std::function<void()> closure) {
   uint64 id = tracing::GetUniqueArg();
   tracing::RecordEvent(tracing::EventCategory::kScheduleClosure, id);
 
-  Env::Default()->SchedClosure([id, closure = std::move(closure)]() {
+  Env::Default()->SchedClosure([ id, closure = std::move(closure) ]() {
     tracing::ScopedRegion region(tracing::EventCategory::kRunClosure, id);
     closure();
   });


### PR DESCRIPTION
Usually we need to modify model to support inter/intra thread setting for CPU Tensorflow.  This PR enables environment to set intra/inter instead of modifying model with session config:

```TF_NUM_INTEROP_THREADS=1 TF_NUM_INTRAOP_THREADS=28 python model.py```

TF r1.14 has already supported TF_NUM_INTRAOP_THREADS for MKL-DNN backend, this PR is only to enable TF_NUM_INTEROP_THREADS.

Modified:
- tensorflow/core/common_runtime/process_util.cc

Signed-off-by: Lu Teng teng.lu@intel.com