### PR TITLE
 TFLM: print micro interpreter's tensors and nodes info as tflite.

### DIFF
--- a/tensorflow/lite/experimental/micro/BUILD
+++ b/tensorflow/lite/experimental/micro/BUILD
@@ -18,9 +18,9 @@ cc_library(
         "micro_error_reporter.cc",
         "micro_interpreter.cc",
         "micro_mutable_op_resolver.cc",
+        "micro_optional_debug_tools.cc",
         "simple_memory_allocator.cc",
         "test_helpers.cc",
-        "micro_optional_debug_tools.cc",
     ],
     hdrs = [
         "compatibility.h",
@@ -31,9 +31,9 @@ cc_library(
         "micro_error_reporter.h",
         "micro_interpreter.h",
         "micro_mutable_op_resolver.h",
+        "micro_optional_debug_tools.h",
         "simple_memory_allocator.h",
         "test_helpers.h",
-        "micro_optional_debug_tools.h",
     ],
     copts = [
         "-Werror",

--- a/tensorflow/lite/experimental/micro/BUILD
+++ b/tensorflow/lite/experimental/micro/BUILD
@@ -20,6 +20,7 @@ cc_library(
         "micro_mutable_op_resolver.cc",
         "simple_memory_allocator.cc",
         "test_helpers.cc",
+        "micro_optional_debug_tools.cc",
     ],
     hdrs = [
         "compatibility.h",
@@ -32,6 +33,7 @@ cc_library(
         "micro_mutable_op_resolver.h",
         "simple_memory_allocator.h",
         "test_helpers.h",
+        "micro_optional_debug_tools.h",
     ],
     copts = [
         "-Werror",

--- a/tensorflow/lite/experimental/micro/micro_interpreter.cc
+++ b/tensorflow/lite/experimental/micro/micro_interpreter.cc
@@ -299,4 +299,42 @@ TfLiteTensor* MicroInterpreter::tensor(size_t index) {
   return &context_.tensors[index];
 }
 
+struct pairTfLiteNodeAndRegistration MicroInterpreter::node_and_registration(int node_index) {
+  TfLiteStatus status = kTfLiteOk;
+  struct pairTfLiteNodeAndRegistration tfNodeRegiPair;
+  auto opcodes = model_->operator_codes();
+  {
+    const auto* op = operators_->Get(node_index);
+    size_t index = op->opcode_index();
+    if (index < 0 || index >= opcodes->size()) {
+      error_reporter_->Report("Missing registration for opcode_index %d\n",
+                              index);
+    }
+    auto opcode = (*opcodes)[index];
+    const TfLiteRegistration* registration = nullptr;
+    status = GetRegistrationFromOpCode(opcode, op_resolver_, error_reporter_,
+                                       &registration);
+    if (status != kTfLiteOk) {
+      error_reporter_->Report("Missing registration for opcode_index %d\n",
+                              index);
+    }
+    if (registration == nullptr) {
+      error_reporter_->Report("Skipping op for opcode_index %d\n", index);
+    }
+
+    // Disregard const qualifier to workaround with existing API.
+    TfLiteIntArray* inputs_array = const_cast<TfLiteIntArray*>(
+        reinterpret_cast<const TfLiteIntArray*>(op->inputs()));
+    TfLiteIntArray* outputs_array = const_cast<TfLiteIntArray*>(
+        reinterpret_cast<const TfLiteIntArray*>(op->outputs()));
+
+    TfLiteNode node;
+    node.inputs = inputs_array;
+    node.outputs = outputs_array;
+    tfNodeRegiPair.node = node;
+    tfNodeRegiPair.registration = registration;
+  }
+  return tfNodeRegiPair;
+}
+
 }  // namespace tflite

--- a/tensorflow/lite/experimental/micro/micro_interpreter.h
+++ b/tensorflow/lite/experimental/micro/micro_interpreter.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include "tensorflow/lite/core/api/op_resolver.h"
 #include "tensorflow/lite/experimental/micro/micro_allocator.h"
 #include "tensorflow/lite/schema/schema_generated.h"
+#include "tensorflow/lite/experimental/micro/micro_optional_debug_tools.h"
 
 namespace tflite {
 
@@ -60,13 +61,18 @@ class MicroInterpreter {
 
   TfLiteTensor* input(size_t index);
   size_t inputs_size() const { return subgraph_->inputs()->Length(); }
+  const flatbuffers::Vector<int32_t>* inputs() { return subgraph_->inputs(); }
 
   TfLiteTensor* output(size_t index);
   size_t outputs_size() const { return subgraph_->outputs()->Length(); }
+  const flatbuffers::Vector<int32_t>* outputs() { return subgraph_->outputs(); }
 
   TfLiteStatus initialization_status() const { return initialization_status_; }
 
   ErrorReporter* error_reporter() { return error_reporter_; }
+
+  size_t operators_size() const {return operators_->size(); }
+  struct pairTfLiteNodeAndRegistration node_and_registration(int node_index);
 
  private:
   void CorrectTensorEndianness(TfLiteTensor* tensorCorr);

--- a/tensorflow/lite/experimental/micro/micro_optional_debug_tools.cc
+++ b/tensorflow/lite/experimental/micro/micro_optional_debug_tools.cc
@@ -1,0 +1,131 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/lite/experimental/micro/micro_optional_debug_tools.h"
+
+#include "tensorflow/lite/schema/schema_generated.h"
+namespace tflite {
+
+std::vector<int> flatbuffersVector2StdVector(const flatbuffers::Vector<int32_t>* fVector) {
+    std::vector<int> stdVector;
+    for (size_t i=0; i<fVector->size(); i++) {
+        stdVector.push_back(fVector->Get(i));
+    }
+    return stdVector;
+}
+
+void PrintIntVector(const std::vector<int>& v) {
+  for (const auto& it : v) {
+    printf(" %d", it);
+  }
+  printf("\n");
+}
+
+void PrintTfLiteIntVector(const TfLiteIntArray* v) {
+  if (!v) {
+    printf(" (null)\n");
+    return;
+  }
+  for (int k = 0; k < v->size; k++) {
+    printf(" %d", v->data[k]);
+  }
+  printf("\n");
+}
+
+const char* TensorTypeName(TfLiteType type) {
+  switch (type) {
+    case kTfLiteNoType:
+      return "kTfLiteNoType";
+    case kTfLiteFloat32:
+      return "kTfLiteFloat32";
+    case kTfLiteInt32:
+      return "kTfLiteInt32";
+    case kTfLiteUInt8:
+      return "kTfLiteUInt8";
+    case kTfLiteInt8:
+      return "kTfLiteInt8";
+    case kTfLiteInt64:
+      return "kTfLiteInt64";
+    case kTfLiteString:
+      return "kTfLiteString";
+    case kTfLiteBool:
+      return "kTfLiteBool";
+    case kTfLiteInt16:
+      return "kTfLiteInt16";
+    case kTfLiteComplex64:
+      return "kTfLiteComplex64";
+    case kTfLiteFloat16:
+      return "kTfLiteFloat16";
+  }
+  return "(invalid)";
+}
+
+const char* AllocTypeName(TfLiteAllocationType type) {
+  switch (type) {
+    case kTfLiteMemNone:
+      return "kTfLiteMemNone";
+    case kTfLiteMmapRo:
+      return "kTfLiteMmapRo";
+    case kTfLiteDynamic:
+      return "kTfLiteDynamic";
+    case kTfLiteArenaRw:
+      return "kTfLiteArenaRw";
+    case kTfLiteArenaRwPersistent:
+      return "kTfLiteArenaRwPersistent";
+  }
+  return "(invalid)";
+}
+
+// Prints a dump of what tensors and what nodes are in the interpreter.
+void PrintInterpreterState(MicroInterpreter* interpreter) {
+  printf("Interpreter has %zu tensors and %zu nodes\n",
+         interpreter->tensors_size(), interpreter->operators_size());
+  printf("Inputs:");
+  PrintIntVector(flatbuffersVector2StdVector(interpreter->inputs()));
+  printf("Outputs:");
+  PrintIntVector(flatbuffersVector2StdVector(interpreter->outputs()));
+  printf("\n");
+
+  for (size_t tensor_index = 0; tensor_index < interpreter->tensors_size();
+       tensor_index++) {
+    TfLiteTensor* tensor = interpreter->tensor(static_cast<int>(tensor_index));
+    printf("Tensor %3zu %-20s %10s %15s %10zu bytes (%4.1f MB) ", tensor_index,
+           tensor->name, TensorTypeName(tensor->type),
+           AllocTypeName(tensor->allocation_type), tensor->bytes,
+           static_cast<double>(tensor->bytes / (1 << 20)));
+    PrintTfLiteIntVector(tensor->dims);
+  }
+  printf("\n");
+
+  for (size_t node_index = 0; node_index < interpreter->operators_size();
+       node_index++) {
+    struct pairTfLiteNodeAndRegistration node_and_reg =
+        interpreter->node_and_registration(static_cast<int>(node_index));
+    const TfLiteNode& node = node_and_reg.node;
+    const TfLiteRegistration* reg = node_and_reg.registration;
+    if (reg->custom_name != nullptr) {
+      printf("Node %3zu Operator Custom Name %s\n", node_index,
+             reg->custom_name);
+    } else {
+      printf("Node %3zu Operator Builtin Code %3d %s\n", node_index,
+             reg->builtin_code, EnumNamesBuiltinOperator()[reg->builtin_code]);
+    }
+    printf("  Inputs:");
+    PrintTfLiteIntVector(node.inputs);
+    printf("  Outputs:");
+    PrintTfLiteIntVector(node.outputs);
+  }
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/experimental/micro/micro_optional_debug_tools.h
+++ b/tensorflow/lite/experimental/micro/micro_optional_debug_tools.h
@@ -1,0 +1,40 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+// Optional debugging functionality. For small sized binaries, these are not
+// needed.
+#ifndef TENSORFLOW_LITE_MICRO_OPTIONAL_DEBUG_TOOLS_H_
+#define TENSORFLOW_LITE_MICRO_OPTIONAL_DEBUG_TOOLS_H_
+
+#include "tensorflow/lite/experimental/micro/micro_interpreter.h"
+
+namespace tflite {
+// Prints a dump of what tensors and what nodes are in the interpreter.
+class MicroInterpreter;
+void PrintInterpreterState(MicroInterpreter* interpreter);
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+struct pairTfLiteNodeAndRegistration {
+    TfLiteNode node;
+    const TfLiteRegistration* registration;
+};
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+}  // namespace tflite
+
+#endif  // TENSORFLOW_LITE_MICRO_OPTIONAL_DEBUG_TOOLS_H_


### PR DESCRIPTION
@wangtz @suharshs 
Please review it again.
calling tflite::PrintInterpreterState(&interpreter); Next will be printed:

Interpreter has 8 tensors and 3 nodes
Inputs: 3
Outputs: 5

Tensor   0 Conv2D_bias          kTfLiteInt32  kTfLiteMemNone         32 bytes ( 0.0 MB)  8
Tensor   1 MatMul_bias          kTfLiteInt32  kTfLiteMemNone         16 bytes ( 0.0 MB)  4
Tensor   2 Relu                 kTfLiteUInt8  kTfLiteMemNone       4000 bytes ( 0.0 MB)  1 25 20 8
Tensor   3 Reshape_1            kTfLiteUInt8  kTfLiteMemNone       1960 bytes ( 0.0 MB)  1 49 40 1
Tensor   4 add_1                kTfLiteUInt8  kTfLiteMemNone          4 bytes ( 0.0 MB)  1 4
Tensor   5 labels_softmax       kTfLiteUInt8  kTfLiteMemNone          4 bytes ( 0.0 MB)  1 4
Tensor   6 weights_quant/FakeQuantWithMinMaxVars kTfLiteUInt8  kTfLiteMemNone        640 bytes ( 0.0 MB)  1 10 8 8
Tensor   7 weights_quant_1/FakeQuantWithMinMaxVars/transpose kTfLiteUInt8  kTfLiteMemNone      16000 bytes ( 0.0 MB)  4 4000

Node   0 Operator Builtin Code   4 DEPTHWISE_CONV_2D
  Inputs: 3 6 0
  Outputs: 2
Node   1 Operator Builtin Code   9 FULLY_CONNECTED
  Inputs: 2 7 1
  Outputs: 4
Node   2 Operator Builtin Code  25 SOFTMAX
  Inputs: 4
  Outputs: 5