### PR TITLE
Patch @com_google_absl to always export //absl/time:time symbols

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -157,8 +157,13 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
     tf_http_archive(
         name = "com_google_absl",
         build_file = clean_dep("//third_party:com_google_absl.BUILD"),
-        # TODO: Remove patch #1 when https://github.com/abseil/abseil-cpp/issues/326 is resolved.
-        # Patch #2 needs to stay until we have a better control over which symbols to export.
+        # TODO: Remove everything but the patch to absl/time/BUILD.bazel when
+        # https://github.com/abseil/abseil-cpp/issues/326 is resolved.
+        # The patch to absl/time/BUILD.bazel serves to export absl symbols, as changes
+        # on Bazel side (https://github.com/bazelbuild/bazel/issues/7362) caused the linker
+        # to not link the whole library by default (see
+        # https://github.com/tensorflow/addons/issues/663).
+        # We can get rid of it once we have mechanism to control which symbols to export.
         patch_file = clean_dep("//third_party:com_google_absl.patch"),
         sha256 = "acd93f6baaedc4414ebd08b33bebca7c7a46888916101d8c0b8083573526d070",
         strip_prefix = "abseil-cpp-43ef2148c0936ebf7cb4be6b19927a9d9d145b8f",

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -157,8 +157,9 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
     tf_http_archive(
         name = "com_google_absl",
         build_file = clean_dep("//third_party:com_google_absl.BUILD"),
-        # TODO: Remove the patch when https://github.com/abseil/abseil-cpp/issues/326 is resolved.
-        patch_file = clean_dep("//third_party:com_google_absl_fix_mac_build.patch"),
+        # TODO: Remove patch #1 when https://github.com/abseil/abseil-cpp/issues/326 is resolved.
+        # Patch #2 needs to stay until we have a better control over which symbols to export.
+        patch_file = clean_dep("//third_party:com_google_absl.patch"),
         sha256 = "acd93f6baaedc4414ebd08b33bebca7c7a46888916101d8c0b8083573526d070",
         strip_prefix = "abseil-cpp-43ef2148c0936ebf7cb4be6b19927a9d9d145b8f",
         urls = [

--- a/third_party/com_google_absl.patch
+++ b/third_party/com_google_absl.patch
@@ -16,3 +16,11 @@
      visibility = ["//visibility:public"],
      deps = [":civil_time"],
  )
+--- ./absl/time/BUILD.bazel	2019-11-06 14:47:19.534845941 +0100
++++ ./absl/time/BUILD.bazel.fixed	2019-11-06 14:46:52.682912347 +0100
+@@ -53,6 +53,7 @@
+         "//absl/time/internal/cctz:civil_time",
+         "//absl/time/internal/cctz:time_zone",
+     ],
++    alwayslink = 1,
+ )


### PR DESCRIPTION
This should fix tensorflow/addons#663, caused by changing logic in Bazel on which symbols we export (see https://github.com/bazelbuild/bazel/issues/7362).