### PR TITLE
Do not assume order on std::unordered_map

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op_test.cc
@@ -135,7 +135,7 @@ TEST_F(TRTEngineOpTestBase, DynamicShapes) {
   // It should contain only one engine.
   auto cache = &cache_resource->cache_;
   EXPECT_EQ(1, cache->size());
-  EXPECT_THAT(cache->begin()->first, ElementsAre(TensorShape({2, 2})));
+  EXPECT_EQ(1, cache->count({TensorShape({2, 2})}));
 
   // Execute the op with batch size 1. It should reuse existing engine to
   // execute.
@@ -143,15 +143,15 @@ TEST_F(TRTEngineOpTestBase, DynamicShapes) {
   TRTEngineOpTestBase::AddSimpleInput<float>(TensorShape({1, 2}));
   TF_ASSERT_OK(OpsTestBase::RunOpKernel());
   EXPECT_EQ(1, cache->size());
-  EXPECT_THAT(cache->begin()->first, ElementsAre(TensorShape({2, 2})));
+  EXPECT_EQ(1, cache->count({TensorShape({2, 2})}));
 
   // Execute the op with a larger batch size.
   ResetInputs();
   TRTEngineOpTestBase::AddSimpleInput<float>(TensorShape({3, 2}));
   TF_ASSERT_OK(OpsTestBase::RunOpKernel());
   EXPECT_EQ(2, cache->size());
-  EXPECT_THAT(cache->begin()->first, ElementsAre(TensorShape({3, 2})));
-  EXPECT_THAT((++cache->begin())->first, ElementsAre(TensorShape({2, 2})));
+  EXPECT_EQ(1, cache->count({TensorShape({2, 2})}));
+  EXPECT_EQ(1, cache->count({TensorShape({3, 2})}));
 
   // Execute the op with an input that has different non-batch dimension.
   ResetInputs();
@@ -163,10 +163,9 @@ TEST_F(TRTEngineOpTestBase, DynamicShapes) {
   TRTEngineOpTestBase::AddSimpleInput<float>(TensorShape({1, 10}));
   TF_ASSERT_OK(OpsTestBase::RunOpKernel());
   EXPECT_EQ(3, cache->size());  // Should only create 3 engines in total.
-  auto iter = cache->begin();
-  EXPECT_THAT(iter->first, ElementsAre(TensorShape({10, 10})));
-  EXPECT_THAT((++iter)->first, ElementsAre(TensorShape({3, 2})));
-  EXPECT_THAT((++iter)->first, ElementsAre(TensorShape({2, 2})));
+  EXPECT_EQ(1, cache->count({TensorShape({2, 2})}));
+  EXPECT_EQ(1, cache->count({TensorShape({3, 2})}));
+  EXPECT_EQ(1, cache->count({TensorShape({10, 10})}));
 }
 
 template <typename T>


### PR DESCRIPTION
This fixes TF-TRT unit test TRTEngineOpTestBase.DynamicShapes