### PR TITLE
Decrease tolerance of TF-TRT python tests for TFv2

### DIFF
--- a/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
+++ b/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
@@ -347,7 +347,9 @@ class TfTrtIntegrationTestBase(test_util.TensorFlowTestCase):
         for expected_shape, actual_val in zip(expected_shapes, new_val):
           self.assertEqual(list(expected_shape), list(actual_val.shape))
         if val is not None:
-          self.assertAllClose(val, new_val, atol=1.e-06, rtol=1.e-06)
+          # Some ops may have nondeterministic output. E.g. Conv2D may use
+          # winograd algorithm. So we set atol/rtol be larger than 1.e-06.
+          self.assertAllClose(val, new_val, atol=1.e-05, rtol=1.e-05)
         val = new_val
       results.append(val)
 


### PR DESCRIPTION
TFv1 had already reduced tolerance