### PR TITLE
[Intel MKL] Fixing a memory leak problem

### DIFF
--- a/tensorflow/core/kernels/mkl_aggregate_ops.cc
+++ b/tensorflow/core/kernels/mkl_aggregate_ops.cc
@@ -155,10 +155,10 @@ class MklAddNOp : public OpKernel {
       auto cpu_engine = engine(engine::cpu, 0);
       std::vector<float> coeff(num_inputs, 1.0);
       std::vector<memory::primitive_desc> srcs_pd;
+      std::vector<MklDnnData<T>> srcs(num_inputs, MklDnnData<T>(&cpu_engine));
       std::vector<primitive::at> inputs;
 
       MklDnnData<T> dst(&cpu_engine);
-      MklDnnData<T> src(&cpu_engine);
       bool has_mkl_input = false;
       int mkl_input_index = FindMKLInputIndex(ctx);
       memory::format mkl_data_format;
@@ -178,7 +178,6 @@ class MklAddNOp : public OpKernel {
         MklDnnShape src_mkl_shape;
         GetMklShape(ctx, src_idx, &src_mkl_shape);
         memory::desc md({}, memory::data_undef, memory::format_undef);
-        src = MklDnnData<T>(&cpu_engine);
         const Tensor& src_tensor = MklGetInput(ctx, src_idx);
 
         if (src_mkl_shape.IsMklTensor()) {
@@ -203,8 +202,8 @@ class MklAddNOp : public OpKernel {
           }
         }
         srcs_pd.push_back(memory::primitive_desc(md, cpu_engine));
-        src.SetUsrMem(md, &src_tensor);
-        inputs.push_back(src.GetOpMem());
+        srcs[src_idx].SetUsrMem(md, &src_tensor);
+        inputs.push_back(srcs[src_idx].GetOpMem());
       }
 
       auto sum_pd = sum::primitive_desc(coeff, srcs_pd);
@@ -232,9 +231,9 @@ class MklAddNOp : public OpKernel {
       net.push_back(sum(sum_pd, inputs, dst.GetOpMem()));
       stream(stream::kind::eager).submit(net).wait();
     } catch (mkldnn::error& e) {
-      string error_msg = "Status: " + std::to_string(e.status) +
-                         ", message: " + string(e.message) + ", in file " +
-                         string(__FILE__) + ":" + std::to_string(__LINE__);
+      string error_msg = "Status: " + std::to_string(e.status) + ", message: " +
+                         string(e.message) + ", in file " + string(__FILE__) +
+                         ":" + std::to_string(__LINE__);
       OP_REQUIRES_OK(
           ctx, errors::Aborted("Operation received an exception:", error_msg));
     }

--- a/tensorflow/core/kernels/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl_conv_ops.cc
@@ -1626,7 +1626,7 @@ class MklQuantizedConv2DOp
       }
 
       if (!scaled_bias_buf)
-        AllocTmpBuffer<Tbias>(context, &scaled_bias_tensor,
+        AllocTmpBuffer<Tbias>(context, &scaled_bias_tensor_,
                               conv_fwd_pd->bias_primitive_desc(),
                               &scaled_bias_buf);
       if (!scaled_bias_) {
@@ -1657,7 +1657,7 @@ class MklQuantizedConv2DOp
   memory* input_bias_ = nullptr;
   memory* scaled_bias_ = nullptr;
 
-  Tensor scaled_bias_tensor;
+  Tensor scaled_bias_tensor_;
   void* scaled_bias_buf = nullptr;
 
  private:

--- a/tensorflow/core/kernels/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl_conv_ops.cc
@@ -1625,15 +1625,15 @@ class MklQuantizedConv2DOp
         input_bias_->set_data_handle(bias_buf);
       }
 
-      if (!scaled_bias_buf)
+      if (!scaled_bias_buf_)
         AllocTmpBuffer<Tbias>(context, &scaled_bias_tensor_,
                               conv_fwd_pd->bias_primitive_desc(),
-                              &scaled_bias_buf);
+                              &scaled_bias_buf_);
       if (!scaled_bias_) {
         scaled_bias_ =
-            new MEMORY_CONSTRUCTOR(bias_md, this->cpu_engine_, scaled_bias_buf);
+            new MEMORY_CONSTRUCTOR(bias_md, this->cpu_engine_, scaled_bias_buf_);
       } else {
-        scaled_bias_->set_data_handle(scaled_bias_buf);
+        scaled_bias_->set_data_handle(scaled_bias_buf_);
       }
       auto reorder_desc = REORDER_PD_CONSTRUCTOR_WITH_ATTR(
           input_bias_->GET_DESC, scaled_bias_->GET_DESC, this->cpu_engine_,
@@ -1658,7 +1658,7 @@ class MklQuantizedConv2DOp
   memory* scaled_bias_ = nullptr;
 
   Tensor scaled_bias_tensor_;
-  void* scaled_bias_buf = nullptr;
+  void* scaled_bias_buf_ = nullptr;
 
  private:
   std::vector<float> scales_;


### PR DESCRIPTION
The changes in this PR fix a potential memory leak by reusing the same variable instead of creating new one each iteration. This change is owned by @guizili0 who can advise if it is possible to write a unit test for that.