### PR TITLE
Add `any` support for autograph with dataset

### DIFF
--- a/tensorflow/python/autograph/operators/py_builtins.py
+++ b/tensorflow/python/autograph/operators/py_builtins.py
@@ -396,10 +396,10 @@ def any_(iterable):
 # as tf.data's filter+take is done in pipeline so it will stop
 # as soon as `take(1)` returns.
 def _tf_dataset_any(iterable):
-  return iterable.filter(
-      lambda x: x).take(1).reduce(
-          constant_op.constant(False, dtype=dtypes.bool),
-          lambda x, y: math_ops.logical_or(x, y))
+  ds = iterable.filter(lambda x: x)
+  ds = ds.take(1)
+  ds = ds.reduce(constant_op.constant(False, dtype=dtypes.bool), lambda _, y: y)
+  return ds
 
 
 def _py_any(iterable):

--- a/tensorflow/python/autograph/operators/py_builtins.py
+++ b/tensorflow/python/autograph/operators/py_builtins.py
@@ -397,8 +397,10 @@ def any_(iterable):
 # as tf.data's filter+take is done in pipeline so it will stop
 # as soon as `take(1)` returns.
 def _tf_dataset_any(iterable):
+  # check and make sure iterable.element_spec only consists of one
+  # element of tf.bool.
   specs = nest.flatten(iterable.element_spec)
-  if not all([spec.dtype == dtypes.bool for spec in specs]):
+  if len(specs) != 1 or specs[0].dtype != dtypes.bool:
     raise ValueError(
         'in graph mode, the "any" builtin only supports datasets '
         'that return bool scalars; got: {}'.format(iterable.element_spec))

--- a/tensorflow/python/autograph/operators/py_builtins.py
+++ b/tensorflow/python/autograph/operators/py_builtins.py
@@ -396,7 +396,10 @@ def any_(iterable):
 # as tf.data's filter+take is done in pipeline so it will stop
 # as soon as `take(1)` returns.
 def _tf_dataset_any(iterable):
-    return iterable.filter(lambda x: x).take(1).reduce(constant_op.constant(False, dtype=dtypes.bool), lambda x, y: math_ops.logical_or(x, y))
+  return iterable.filter(
+      lambda x: x).take(1).reduce(
+          constant_op.constant(False, dtype=dtypes.bool),
+          lambda x, y: math_ops.logical_or(x, y))
 
 
 def _py_any(iterable):

--- a/tensorflow/python/autograph/operators/py_builtins_test.py
+++ b/tensorflow/python/autograph/operators/py_builtins_test.py
@@ -303,9 +303,9 @@ class PyBuiltinsTest(test.TestCase):
     dataset_1 = dataset_ops.DatasetV2.from_tensor_slices([False, True, False])
     dataset_2 = dataset_ops.DatasetV2.from_tensor_slices([False, False, False])
     self.assertEqual(
-        py_builtins.any_(dataset_1), True)
+        self.evaluate(py_builtins.any_(dataset_1)), True)
     self.assertEqual(
-        py_builtins.any_(dataset_2), False)
+        self.evaluate(py_builtins.any_(dataset_2)), False)
 
     dataset_3 = dataset_ops.DatasetV2.from_tensor_slices([0, 1, 2])
     with self.assertRaises(ValueError):

--- a/tensorflow/python/autograph/operators/py_builtins_test.py
+++ b/tensorflow/python/autograph/operators/py_builtins_test.py
@@ -307,6 +307,12 @@ class PyBuiltinsTest(test.TestCase):
     self.assertEqual(
         py_builtins.any_(dataset_2), False)
 
+    dataset_3 = dataset_ops.DatasetV2.from_tensor_slices([False, True, False])
+    dataset_4 = dataset_ops.DatasetV2.from_tensor_slices([0, 1, 2])
+    dataset_invalid = dataset_ops.DatasetV2.zip((dataset_3, dataset_4))
+    with self.assertRaises(ValueError):
+      py_builtins.any_(dataset_invalid)
+
 
 if __name__ == '__main__':
   test.main()

--- a/tensorflow/python/autograph/operators/py_builtins_test.py
+++ b/tensorflow/python/autograph/operators/py_builtins_test.py
@@ -293,6 +293,20 @@ class PyBuiltinsTest(test.TestCase):
       self.assertAllEqual(self.evaluate(iterator.get_next()), 2)
       self.assertAllEqual(self.evaluate(iterator.get_next()), 1)
 
+  def test_any(self):
+    self.assertEqual(
+        py_builtins.any_([False, True, False]), True)
+    self.assertEqual(
+        py_builtins.any_([False, False, False]), False)
+
+  def test_any_dataset(self):
+    dataset_1 = dataset_ops.DatasetV2.from_tensor_slices([False, True, False])
+    dataset_2 = dataset_ops.DatasetV2.from_tensor_slices([False, False, False])
+    self.assertEqual(
+        py_builtins.any_(dataset_1), True)
+    self.assertEqual(
+        py_builtins.any_(dataset_2), False)
+
 
 if __name__ == '__main__':
   test.main()

--- a/tensorflow/python/autograph/operators/py_builtins_test.py
+++ b/tensorflow/python/autograph/operators/py_builtins_test.py
@@ -307,11 +307,19 @@ class PyBuiltinsTest(test.TestCase):
     self.assertEqual(
         py_builtins.any_(dataset_2), False)
 
-    dataset_3 = dataset_ops.DatasetV2.from_tensor_slices([False, True, False])
-    dataset_4 = dataset_ops.DatasetV2.from_tensor_slices([0, 1, 2])
-    dataset_invalid = dataset_ops.DatasetV2.zip((dataset_3, dataset_4))
+    dataset_3 = dataset_ops.DatasetV2.from_tensor_slices([0, 1, 2])
     with self.assertRaises(ValueError):
-      py_builtins.any_(dataset_invalid)
+      py_builtins.any_(dataset_3)
+
+    dataset_4 = dataset_ops.DatasetV2.from_tensor_slices([False, True, False])
+    dataset_zipped = dataset_ops.DatasetV2.zip((dataset_4, dataset_4))
+    with self.assertRaises(ValueError):
+      py_builtins.any_(dataset_zipped)
+
+    dataset_mixed = dataset_ops.DatasetV2.zip((dataset_3, dataset_4))
+    with self.assertRaises(ValueError):
+      py_builtins.any_(dataset_mixed)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION

This PR tries to address the issue where `any` in autograph
does not work with tf.data:
```
import tensorflow as tf
def g():
  dataset = tf.data.Dataset.from_tensor_slices([False, True, False])
  return any(dataset)
print("G: ", g())
@tf.function
def f():
  dataset = tf.data.Dataset.from_tensor_slices([False, True, False])
  return any(dataset)
print("F: ", f())
..........
    OperatorNotAllowedInGraphError: using a `tf.Tensor` as a Python `bool` is not allowed: AutoGraph did not convert this function. Try decorating it directly with @tf.function.
```

This PR translate `any(dataset)` to
```
dataset.filter(lambda x: x).take(1).reduce
```
which works in tf.data's pipeline.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>