### PR TITLE
TfLite GL delegate is built with visibility hidden

### DIFF
--- a/tensorflow/lite/delegates/gpu/BUILD
+++ b/tensorflow/lite/delegates/gpu/BUILD
@@ -106,7 +106,7 @@ objc_library(
     ],
 )
 
-# build -c opt --config android_arm64 --copt -Os --copt -DTFLITE_GPU_BINARY_RELEASE --copt -fvisibility=hidden --linkopt -s --strip always :libtensorflowlite_gpu_gl.so
+# build -c opt --config android_arm64 --copt -Os --copt -DTFLITE_GPU_BINARY_RELEASE --copt --linkopt -s --strip always :libtensorflowlite_gpu_gl.so
 cc_binary(
     name = "libtensorflowlite_gpu_gl.so",
     linkopts = [
@@ -116,7 +116,10 @@ cc_binary(
             "-lEGL",
             "-lGLESv3",
         ],
-        "//conditions:default": [],
+        "//tensorflow:windows": [],
+        "//conditions:default": [
+            "-fvisibility=hidden",
+        ],
     }),
     linkshared = 1,
     linkstatic = 1,
@@ -127,7 +130,7 @@ cc_binary(
     deps = [":gl_delegate"],
 )
 
-# build -c opt --config android_arm64 --copt -Os --copt -DTFLITE_GPU_BINARY_RELEASE --copt -fvisibility=hidden --linkopt -s --strip always :libtensorflowlite_gpu_delegate.so
+# build -c opt --config android_arm64 --copt -Os --copt -DTFLITE_GPU_BINARY_RELEASE --copt --linkopt -s --strip always :libtensorflowlite_gpu_delegate.so
 cc_binary(
     name = "libtensorflowlite_gpu_delegate.so",
     linkopts = [
@@ -137,7 +140,10 @@ cc_binary(
             "-lEGL",
             "-lGLESv3",
         ],
-        "//conditions:default": [],
+        "//tensorflow:windows": [],
+        "//conditions:default": [
+            "-fvisibility=hidden",
+        ],
     }),
     linkshared = 1,
     linkstatic = 1,

--- a/tensorflow/lite/delegates/gpu/BUILD
+++ b/tensorflow/lite/delegates/gpu/BUILD
@@ -115,6 +115,7 @@ cc_binary(
         "//tensorflow:android": [
             "-lEGL",
             "-lGLESv3",
+            "-fvisibility=hidden",
         ],
         "//tensorflow:windows": [],
         "//conditions:default": [
@@ -139,6 +140,7 @@ cc_binary(
         "//tensorflow:android": [
             "-lEGL",
             "-lGLESv3",
+            "-fvisibility=hidden",
         ],
         "//tensorflow:windows": [],
         "//conditions:default": [


### PR DESCRIPTION
Fixes #33676

There is no C++ API in OpenGL delegate code and it manually exports necessary symbols.
So `visibility=hidden` should suffice on gcc/clang targets
On msvc symbols are hidden by default.