### PR TITLE
Don't compile CUDA kernels in debug mode.

### DIFF
--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl
@@ -196,7 +196,7 @@ def InvokeNvcc(argv, log=False):
     return 1
 
   opt = (' -O2' if (len(opt_option) > 0 and int(opt_option[0]) > 0)
-         else ' -g -G')
+         else ' -g')
 
   includes = (' -I ' + ' -I '.join(include_options)
               if len(include_options) > 0

--- a/third_party/gpus/crosstool/windows/msvc_wrapper_for_nvcc.py.tpl
+++ b/third_party/gpus/crosstool/windows/msvc_wrapper_for_nvcc.py.tpl
@@ -123,7 +123,7 @@ def InvokeNvcc(argv, log=False):
   nvcc_compiler_options, argv = GetNvccOptions(argv)
 
   opt_option, argv = GetOptionValue(argv, 'O')
-  opt = ['-g', '-G']
+  opt = ['-g']
   if (len(opt_option) > 0 and opt_option[0] != 'd'):
     opt = ['-O2']
 


### PR DESCRIPTION
-G causes kernels to use more registers and memory.
This results in lots of kernels using too many resources,
causing them to fail when launched
This makes it impossible to run a TensorFlow debug build.