### PR TITLE
Ensured buffer encapsulation

### DIFF
--- a/tensorflow/lite/experimental/micro/kernels/cmsis-nn/scratch_buffer.cc
+++ b/tensorflow/lite/experimental/micro/kernels/cmsis-nn/scratch_buffer.cc
@@ -24,11 +24,14 @@ limitations under the License.
 // network.
 #define SCRATCH_BUFFER_BYTES 13000
 
-__attribute__((aligned(
-    4))) static int16_t cmsis_scratch_buffer[SCRATCH_BUFFER_BYTES / 2] = {0};
 
 TfLiteStatus get_cmsis_scratch_buffer(TfLiteContext* context, int16_t** buf,
                                       int32_t buf_size_bytes) {
+
+  __attribute__((aligned(
+    4))) static int16_t cmsis_scratch_buffer[SCRATCH_BUFFER_BYTES / 2] = {0};
+
+
   TF_LITE_ENSURE(context, buf_size_bytes <= SCRATCH_BUFFER_BYTES);
   *buf = cmsis_scratch_buffer;
   return kTfLiteOk;


### PR DESCRIPTION
I removed the buffer from global scope. Which I think makes more sense in case of future changes.