### PR TITLE
Replace effect with affect in docstring

### DIFF
--- a/tensorflow/python/lib/io/tf_record.py
+++ b/tensorflow/python/lib/io/tf_record.py
@@ -62,7 +62,7 @@ class TFRecordOptions(object):
     # pylint: disable=line-too-long
     """Creates a `TFRecordOptions` instance.
 
-    Options only effect TFRecordWriter when compression_type is not `None`.
+    Options only affect TFRecordWriter when compression_type is not `None`.
     Documentation, details, and defaults can be found in
     [`zlib_compression_options.h`](https://www.tensorflow.org/code/tensorflow/core/lib/io/zlib_compression_options.h)
     and in the [zlib manual](http://www.zlib.net/manual.html).


### PR DESCRIPTION
In the docstring of `tf.io.TFRecordOptions` initializer, effect should be replaced with affect