### PR TITLE
Updated DeviceSpec docstring and fixed typos

### DIFF
--- a/tensorflow/python/framework/device_spec.py
+++ b/tensorflow/python/framework/device_spec.py
@@ -64,9 +64,13 @@ class DeviceSpecV2(object):
   ```
   
   With eager execution disabled (by default in TensorFlow 1.x and by calling
-  tf.disable_eager_execution() in TensorFlow 2.x), the following syntax
+  disable_eager_execution() in TensorFlow 2.x), the following syntax
   can be used:
   ```python
+  # Location in TensorFlow 2.x
+  from tensorflow.python.framework.ops import disable_eager_execution
+  disable_eager_execution()
+  
   # Same as previous
   device_spec = DeviceSpec(job="ps", device_type="GPU", device_index=0)
   # No need of .to_string() method.

--- a/tensorflow/python/framework/device_spec.py
+++ b/tensorflow/python/framework/device_spec.py
@@ -74,7 +74,6 @@ class DeviceSpecV2(object):
     my_var = tf.Variable(..., name="my_variable")
     squared_var = tf.square(my_var)
    ```
-    
 
   If a `DeviceSpec` is partially specified, it will be merged with other
   `DeviceSpec`s according to the scope in which it is defined. `DeviceSpec`

--- a/tensorflow/python/framework/device_spec.py
+++ b/tensorflow/python/framework/device_spec.py
@@ -57,11 +57,24 @@ class DeviceSpecV2(object):
   ```python
   # Place the operations on device "GPU:0" in the "ps" job.
   device_spec = DeviceSpec(job="ps", device_type="GPU", device_index=0)
-  with tf.device(device_spec):
+  with tf.device(device_spec.to_string()):
     # Both my_var and squared_var will be placed on /job:ps/device:GPU:0.
     my_var = tf.Variable(..., name="my_variable")
     squared_var = tf.square(my_var)
   ```
+  
+  With eager execution disabled (by default in TensorFlow 1.x and by calling
+  tf.disable_eager_execution() in TensorFlow 2.x), the following syntax
+  can be used:
+  ```python
+  # Same as previous
+  device_spec = DeviceSpec(job="ps", device_type="GPU", device_index=0)
+  # No need of .to_string() method.
+  with tf.device(device_spec):
+    my_var = tf.Variable(..., name="my_variable")
+    squared_var = tf.square(my_var)
+   ```
+    
 
   If a `DeviceSpec` is partially specified, it will be merged with other
   `DeviceSpec`s according to the scope in which it is defined. `DeviceSpec`
@@ -69,10 +82,10 @@ class DeviceSpecV2(object):
   outer scopes.
 
   ```python
-  with tf.device(DeviceSpec(job="train", )):
-    with tf.device(DeviceSpec(job="ps", device_type="GPU", device_index=0):
+  with tf.device(DeviceSpec(job="train", ).to_string()):
+    with tf.device(DeviceSpec(job="ps", device_type="GPU", device_index=0).to_string()):
       # Nodes created here will be assigned to /job:ps/device:GPU:0.
-    with tf.device(DeviceSpec(device_type="GPU", device_index=1):
+    with tf.device(DeviceSpec(device_type="GPU", device_index=1).to_string()):
       # Nodes created here will be assigned to /job:train/device:GPU:1.
   ```
 


### PR DESCRIPTION
Updated docstring (as per https://github.com/tensorflow/tensorflow/issues/34124), adding instructions for using `device_spec.to_string()` method with eager execution enabled. Fixed missing parentheses in example.