### PR TITLE
fixed KeyError issue for tf.Module.variables

### DIFF
--- a/tensorflow/python/util/nest.py
+++ b/tensorflow/python/util/nest.py
@@ -87,7 +87,7 @@ def _get_attrs_items(obj):
 def _sorted(dict_):
   """Returns a sorted list of the dict keys, with error if keys not sortable."""
   try:
-    return sorted(dict_)
+    return sorted(dict_.keys())
   except TypeError:
     raise TypeError("nest only supports dicts with sortable keys.")
 


### PR DESCRIPTION
Fixed `KeyError` issue caused by the dictionary that the `__iter__` function does not iterate over dictionary keys when it is assigned to a class that inherit from`tf.Module` as an attribute.

Using `dict.keys()` to iterate over dictionary keys is much safer than `dict.__iter__`, since `dict.keys()` is a common interface for `dict` and for those key/value paired containers inherited from `collections.abc.Mapping` (which is used in the file [nest.py#L194](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/util/nest.py#L194)) to retrieve keys, and its functionality is clearly stated in [cpython/_collections_abc.py#L673](https://github.com/python/cpython/blob/master/Lib/_collections_abc.py#L673), while `__iter__` is just an abstract method that have no clear definitions.

Here is the minimal code that would cause the `KeyError` exception when calling `tf.Module.variables`
```python
import tensorflow as tf #tf2.0
from collections import OrderedDict

class MyNamedTuple(OrderedDict):
    def __init__(self, *args, **kwargs):
        super(MyNamedTuple, self).__init__(*args, **kwargs)
        self.__dict__ = self
    def __iter__(self):  # iterate over values (not keys)
        for v in self.values():
            yield v
          
class MyModule(tf.Module):
    def __call__(self):
        self.myargs = MyNamedTuple({'arg': 'hello'}) # cause KeyError
        self.v = tf.Variable([1, 2, 3]) # some variables
        
module = MyModule('my_module')
module()
my_vars = module.variables #KeyError
```

And the exception traceback:
```
Traceback (most recent call last):
  File "keyerror.py", line 16, in <module>
    my_vars = module.variables #KeyError
  File "/home/joehsiao/lib/venv/tf2_env/lib/python3.6/site-packages/tensorflow_core/python/module/module.py", line 155, in variables
    return tuple(self._flatten(predicate=_is_variable))
  File "/home/joehsiao/lib/venv/tf2_env/lib/python3.6/site-packages/tensorflow_core/python/module/module.py", line 339, in _flatten_module
    for leaf_path, leaf in nest.flatten_with_tuple_paths(module_dict[key]):
  File "/home/joehsiao/lib/venv/tf2_env/lib/python3.6/site-packages/tensorflow_core/python/util/nest.py", line 1326, in flatten_with_tuple_paths
    flatten(structure, expand_composites=expand_composites)))
  File "/home/joehsiao/lib/venv/tf2_env/lib/python3.6/site-packages/tensorflow_core/python/util/nest.py", line 1275, in yield_flat_paths
    for k, _ in _yield_flat_up_to(nest, nest, is_seq):
  File "/home/joehsiao/lib/venv/tf2_env/lib/python3.6/site-packages/tensorflow_core/python/util/nest.py", line 640, in _yield_flat_up_to
    input_tree = dict(_yield_sorted_items(input_tree))
  File "/home/joehsiao/lib/venv/tf2_env/lib/python3.6/site-packages/tensorflow_core/python/util/nest.py", line 191, in _yield_sorted_items
    yield key, iterable[key]
KeyError: 'hello'
```