### PR TITLE
Updated DeviceSpec docstring and fixed typos

### DIFF
--- a/tensorflow/python/framework/device_spec.py
+++ b/tensorflow/python/framework/device_spec.py
@@ -47,10 +47,13 @@ def _as_device_str_or_none(device_type):
 @tf_export("DeviceSpec", v1=[])
 class DeviceSpecV2(object):
   """Represents a (possibly partial) specification for a TensorFlow device.
+  
   `DeviceSpec`s are used throughout TensorFlow to describe where state is stored
   and computations occur. Using `DeviceSpec` allows you to parse device spec
   strings to verify their validity, merge them or compose them programmatically.
+  
   Example:
+  
   ```python
   # Place the operations on device "GPU:0" in the "ps" job.
   device_spec = DeviceSpec(job="ps", device_type="GPU", device_index=0)
@@ -63,6 +66,7 @@ class DeviceSpecV2(object):
   With eager execution disabled (by default in TensorFlow 1.x and by calling
   disable_eager_execution() in TensorFlow 2.x), the following syntax
   can be used:
+  
   ```python
   # Location in TensorFlow 2.x
   from tensorflow.python.framework.ops import disable_eager_execution
@@ -75,10 +79,12 @@ class DeviceSpecV2(object):
     my_var = tf.Variable(..., name="my_variable")
     squared_var = tf.square(my_var)
    ```
+  
   If a `DeviceSpec` is partially specified, it will be merged with other
   `DeviceSpec`s according to the scope in which it is defined. `DeviceSpec`
   components defined in inner scopes take precedence over those defined in
   outer scopes.
+  
   ```python
   with tf.device(DeviceSpec(job="train", ).to_string()):
     with tf.device(DeviceSpec(job="ps", device_type="GPU", device_index=0).to_string()):
@@ -86,8 +92,10 @@ class DeviceSpecV2(object):
     with tf.device(DeviceSpec(device_type="GPU", device_index=1).to_string()):
       # Nodes created here will be assigned to /job:train/device:GPU:1.
   ```
-  A `DeviceSpec` consists of 5 components -- each of
+ 
+ A `DeviceSpec` consists of 5 components -- each of
   which is optionally specified:
+  
   * Job: The job name.
   * Replica: The replica index.
   * Task: The task index.

--- a/tensorflow/python/framework/device_spec.py
+++ b/tensorflow/python/framework/device_spec.py
@@ -84,8 +84,10 @@ class DeviceSpecV2(object):
   outer scopes.
 
   ```python
-  with tf.device(DeviceSpec(job="train", ).to_string()):
-    with tf.device(DeviceSpec(job="ps", device_type="GPU", device_index=0).to_string()):
+  gpu0_spec = DeviceSpec(job="ps", device_type="GPU", device_index=0)
+  
+  with tf.device(DeviceSpec(job="train").to_string()):
+    with tf.device(gpu0_spec.to_string()):
       # Nodes created here will be assigned to /job:ps/device:GPU:0.
     with tf.device(DeviceSpec(device_type="GPU", device_index=1).to_string()):
       # Nodes created here will be assigned to /job:train/device:GPU:1.

--- a/tensorflow/python/framework/device_spec.py
+++ b/tensorflow/python/framework/device_spec.py
@@ -91,7 +91,7 @@ class DeviceSpecV2(object):
       # Nodes created here will be assigned to /job:train/device:GPU:1.
   ```
 
- A `DeviceSpec` consists of 5 components -- each of
+  A `DeviceSpec` consists of 5 components -- each of
   which is optionally specified:
 
   * Job: The job name.

--- a/tensorflow/python/framework/device_spec.py
+++ b/tensorflow/python/framework/device_spec.py
@@ -85,7 +85,6 @@ class DeviceSpecV2(object):
 
   ```python
   gpu0_spec = DeviceSpec(job="ps", device_type="GPU", device_index=0)
-  
   with tf.device(DeviceSpec(job="train").to_string()):
     with tf.device(gpu0_spec.to_string()):
       # Nodes created here will be assigned to /job:ps/device:GPU:0.

--- a/tensorflow/python/framework/device_spec.py
+++ b/tensorflow/python/framework/device_spec.py
@@ -51,9 +51,9 @@ class DeviceSpecV2(object):
   `DeviceSpec`s are used throughout TensorFlow to describe where state is stored
   and computations occur. Using `DeviceSpec` allows you to parse device spec
   strings to verify their validity, merge them or compose them programmatically.
-  
+
   Example:
-  
+
   ```python
   # Place the operations on device "GPU:0" in the "ps" job.
   device_spec = DeviceSpec(job="ps", device_type="GPU", device_index=0)
@@ -62,14 +62,14 @@ class DeviceSpecV2(object):
     my_var = tf.Variable(..., name="my_variable")
     squared_var = tf.square(my_var)
   ```
-  
+
   With eager execution disabled (by default in TensorFlow 1.x and by calling
   disable_eager_execution() in TensorFlow 2.x), the following syntax
   can be used:
-  
+ 
   ```python
   tf.compat.v1.disable_eager_execution()
-  
+ 
   # Same as previous
   device_spec = DeviceSpec(job="ps", device_type="GPU", device_index=0)
   # No need of .to_string() method.
@@ -77,12 +77,12 @@ class DeviceSpecV2(object):
     my_var = tf.Variable(..., name="my_variable")
     squared_var = tf.square(my_var)
    ```
-  
+
   If a `DeviceSpec` is partially specified, it will be merged with other
   `DeviceSpec`s according to the scope in which it is defined. `DeviceSpec`
   components defined in inner scopes take precedence over those defined in
   outer scopes.
-  
+
   ```python
   with tf.device(DeviceSpec(job="train", ).to_string()):
     with tf.device(DeviceSpec(job="ps", device_type="GPU", device_index=0).to_string()):
@@ -90,10 +90,10 @@ class DeviceSpecV2(object):
     with tf.device(DeviceSpec(device_type="GPU", device_index=1).to_string()):
       # Nodes created here will be assigned to /job:train/device:GPU:1.
   ```
- 
+
  A `DeviceSpec` consists of 5 components -- each of
   which is optionally specified:
-  
+
   * Job: The job name.
   * Replica: The replica index.
   * Task: The task index.

--- a/tensorflow/python/framework/device_spec.py
+++ b/tensorflow/python/framework/device_spec.py
@@ -47,7 +47,7 @@ def _as_device_str_or_none(device_type):
 @tf_export("DeviceSpec", v1=[])
 class DeviceSpecV2(object):
   """Represents a (possibly partial) specification for a TensorFlow device.
-  
+
   `DeviceSpec`s are used throughout TensorFlow to describe where state is stored
   and computations occur. Using `DeviceSpec` allows you to parse device spec
   strings to verify their validity, merge them or compose them programmatically.

--- a/tensorflow/python/framework/device_spec.py
+++ b/tensorflow/python/framework/device_spec.py
@@ -68,9 +68,7 @@ class DeviceSpecV2(object):
   can be used:
   
   ```python
-  # Location in TensorFlow 2.x
-  from tensorflow.python.framework.ops import disable_eager_execution
-  disable_eager_execution()
+  tf.compat.v1.disable_eager_execution()
   
   # Same as previous
   device_spec = DeviceSpec(job="ps", device_type="GPU", device_index=0)

--- a/tensorflow/python/framework/device_spec.py
+++ b/tensorflow/python/framework/device_spec.py
@@ -47,38 +47,47 @@ def _as_device_str_or_none(device_type):
 @tf_export("DeviceSpec", v1=[])
 class DeviceSpecV2(object):
   """Represents a (possibly partial) specification for a TensorFlow device.
-
   `DeviceSpec`s are used throughout TensorFlow to describe where state is stored
   and computations occur. Using `DeviceSpec` allows you to parse device spec
   strings to verify their validity, merge them or compose them programmatically.
-
   Example:
-
   ```python
   # Place the operations on device "GPU:0" in the "ps" job.
   device_spec = DeviceSpec(job="ps", device_type="GPU", device_index=0)
-  with tf.device(device_spec):
+  with tf.device(device_spec.to_string()):
     # Both my_var and squared_var will be placed on /job:ps/device:GPU:0.
     my_var = tf.Variable(..., name="my_variable")
     squared_var = tf.square(my_var)
   ```
-
+  
+  With eager execution disabled (by default in TensorFlow 1.x and by calling
+  disable_eager_execution() in TensorFlow 2.x), the following syntax
+  can be used:
+  ```python
+  # Location in TensorFlow 2.x
+  from tensorflow.python.framework.ops import disable_eager_execution
+  disable_eager_execution()
+  
+  # Same as previous
+  device_spec = DeviceSpec(job="ps", device_type="GPU", device_index=0)
+  # No need of .to_string() method.
+  with tf.device(device_spec):
+    my_var = tf.Variable(..., name="my_variable")
+    squared_var = tf.square(my_var)
+   ```
   If a `DeviceSpec` is partially specified, it will be merged with other
   `DeviceSpec`s according to the scope in which it is defined. `DeviceSpec`
   components defined in inner scopes take precedence over those defined in
   outer scopes.
-
   ```python
-  with tf.device(DeviceSpec(job="train", )):
-    with tf.device(DeviceSpec(job="ps", device_type="GPU", device_index=0):
+  with tf.device(DeviceSpec(job="train", ).to_string()):
+    with tf.device(DeviceSpec(job="ps", device_type="GPU", device_index=0).to_string()):
       # Nodes created here will be assigned to /job:ps/device:GPU:0.
-    with tf.device(DeviceSpec(device_type="GPU", device_index=1):
+    with tf.device(DeviceSpec(device_type="GPU", device_index=1).to_string()):
       # Nodes created here will be assigned to /job:train/device:GPU:1.
   ```
-
   A `DeviceSpec` consists of 5 components -- each of
   which is optionally specified:
-
   * Job: The job name.
   * Replica: The replica index.
   * Task: The task index.


### PR DESCRIPTION
Updated docstring (as per #34124), adding instructions for using `device_spec.to_string()` method with eager execution enabled. Fixed missing parentheses in example.