### PR TITLE
[ROCm] Fix for the broken ROCm CSB.

### DIFF
--- a/third_party/gpus/crosstool/BUILD.rocm.tpl
+++ b/third_party/gpus/crosstool/BUILD.rocm.tpl
@@ -90,7 +90,7 @@ cc_toolchain_config(
         "-lm",
     ],
     link_libs = [],
-    opt_link_flags = ["-Wl,--gc-sections"],
+    opt_link_flags = [],
     unfiltered_compile_flags = [
         "-fno-canonical-system-headers",
         "-Wno-builtin-macro-redefined",


### PR DESCRIPTION
The following commit breaks the --config=rocm build

https://github.com/tensorflow/tensorflow/commit/72d0facc37e377d89d8034bb825bf0e93a4f810d

The above commit introduces a new linker flag `-Wl,--gc-sections` which seems to result in the linker discarding? some of the information related to the gpu kernel binary blobs, consequently leading to the runtime errors (example shown below) in most (all?) of the regression tests.

```
terminate called after throwing an instance of 'std::runtime_error'
what():  Missing metadata for __global__ function: _ZN5Eigen8internal15EigenMetaKernelINS_15TensorEvaluatorIKNS_14TensorAssignOpINS_9TensorMapINS_6TensorIfLi1ELi1EiEELi16ENS_11MakePointerEEEKNS_18TensorCwiseUnaryOpINS0_12scalar_rightIffNS0_17scalar_product\
_opIffEELb0EEEKNS4_INS5_IKfLi1ELi1EiEELi16ES7_EEEEEENS_9GpuDeviceEEEiEEvT_T0_
Fatal Python error: Aborted
```

The "fix" is to remove that linker flag from the ROCm build.

Note that the flag in question was not used for the ROCm build, prior to the commit mentioned above.


---------------------

/cc @chsigg @meteorcloudy @whchung 