### PR TITLE
Clean up DatasetOpsTestBase and refactor AutoShardDatasetOpTest

### DIFF
--- a/tensorflow/core/kernels/data/batch_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/batch_dataset_op_test.cc
@@ -19,7 +19,7 @@ namespace {
 
 constexpr char kNodeName[] = "batch_dataset";
 
-class BatchDatasetOpTest : public DatasetOpsTestBaseV2 {};
+class BatchDatasetOpTest : public DatasetOpsTestBase {};
 
 // Test Case 1: test BatchDatasetV2 with `drop_remainder` = false and a batch
 // size that can evenly split the input dataset.

--- a/tensorflow/core/kernels/data/cache_dataset_ops_test.cc
+++ b/tensorflow/core/kernels/data/cache_dataset_ops_test.cc
@@ -62,10 +62,10 @@ class CacheDatasetParams : public DatasetParams {
   string filename_;
 };
 
-class CacheDatasetOpTest : public DatasetOpsTestBaseV2 {
+class CacheDatasetOpTest : public DatasetOpsTestBase {
  public:
   Status Initialize(const DatasetParams& dataset_params) {
-    TF_RETURN_IF_ERROR(DatasetOpsTestBaseV2::Initialize(dataset_params));
+    TF_RETURN_IF_ERROR(DatasetOpsTestBase::Initialize(dataset_params));
     auto params = static_cast<const CacheDatasetParams&>(dataset_params);
     cache_filename_ = params.filename();
     return Status::OK();

--- a/tensorflow/core/kernels/data/concatenate_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/concatenate_dataset_op_test.cc
@@ -76,7 +76,7 @@ ConcatenateDatasetParams DifferentDtypeConcatenateDatasetParams() {
                                   /*node_name=*/kNodeName);
 }
 
-class ConcatenateDatasetOpTest : public DatasetOpsTestBaseV2 {};
+class ConcatenateDatasetOpTest : public DatasetOpsTestBase {};
 
 std::vector<GetNextTestCase<ConcatenateDatasetParams>> GetNextTestCases() {
   return {{/*dataset_params=*/SameShapeConcatenateDatasetParams(),

--- a/tensorflow/core/kernels/data/dataset_test_base.cc
+++ b/tensorflow/core/kernels/data/dataset_test_base.cc
@@ -236,97 +236,6 @@ Status DatasetOpsTestBase::ExpectEqual(std::vector<Tensor> produced_tensors,
   return Status::OK();
 }
 
-Status DatasetOpsTestBase::CreateTensorSliceDatasetKernel(
-    StringPiece node_name, const DataTypeVector& dtypes,
-    const std::vector<PartialTensorShape>& shapes,
-    std::unique_ptr<OpKernel>* tensor_slice_dataset_kernel) {
-  std::vector<string> components;
-  components.reserve(dtypes.size());
-  for (int i = 0; i < dtypes.size(); ++i) {
-    // Create the placeholder names for the input components of
-    // `TensorSliceDataset`.
-    components.emplace_back(strings::StrCat("component_", i));
-  }
-  NodeDef node_def = test::function::NDef(
-      node_name, "TensorSliceDataset", components,
-      {{"Toutput_types", dtypes}, {"output_shapes", shapes}});
-  TF_RETURN_IF_ERROR(CreateOpKernel(node_def, tensor_slice_dataset_kernel));
-  return Status::OK();
-}
-
-Status DatasetOpsTestBase::CreateTensorSliceDataset(
-    StringPiece node_name, std::vector<Tensor>* const components,
-    DatasetBase** tensor_slice_dataset) {
-  std::unique_ptr<OpKernel> tensor_slice_dataset_kernel;
-  DataTypeVector dtypes;
-  dtypes.reserve(components->size());
-  std::vector<PartialTensorShape> shapes;
-  shapes.reserve(components->size());
-  for (const auto& t : *components) {
-    dtypes.push_back(t.dtype());
-    gtl::InlinedVector<int64, 4> partial_dim_sizes;
-    for (int i = 1; i < t.dims(); ++i) {
-      partial_dim_sizes.push_back(t.dim_size(i));
-    }
-    shapes.emplace_back(std::move(partial_dim_sizes));
-  }
-  TF_RETURN_IF_ERROR(CreateTensorSliceDatasetKernel(
-      node_name, dtypes, shapes, &tensor_slice_dataset_kernel));
-  gtl::InlinedVector<TensorValue, 4> inputs;
-  for (auto& tensor : *components) {
-    inputs.emplace_back(&tensor);
-  }
-  TF_RETURN_IF_ERROR(CheckOpKernelInput(*tensor_slice_dataset_kernel, inputs));
-  std::unique_ptr<OpKernelContext::Params> context_params;
-  std::unique_ptr<OpKernelContext> context;
-  TF_RETURN_IF_ERROR(CreateOpKernelContext(tensor_slice_dataset_kernel.get(),
-                                           &inputs, &context_params, &context));
-  TF_RETURN_IF_ERROR(
-      RunOpKernel(tensor_slice_dataset_kernel.get(), context.get()));
-  TF_RETURN_IF_ERROR(
-      GetDatasetFromContext(context.get(), 0, tensor_slice_dataset));
-  return Status::OK();
-}
-
-Status DatasetOpsTestBase::MakeRangeDataset(
-    const Tensor& start, const Tensor& stop, const Tensor& step,
-    const DataTypeVector& output_types,
-    const std::vector<PartialTensorShape>& output_shapes,
-    Tensor* range_dataset) {
-  GraphConstructorOptions graph_opts;
-  graph_opts.allow_internal_ops = true;
-  graph_opts.expect_device_spec = false;
-  TF_RETURN_IF_ERROR(
-      RunFunction(test::function::MakeRangeDataset(),
-                  /*attrs*/
-                  {{RangeDatasetOp::kOutputTypes, output_types},
-                   {RangeDatasetOp::kOutputShapes, output_shapes}},
-                  /*inputs*/ {start, stop, step}, graph_opts,
-                  /*rets*/ {range_dataset}));
-  return Status::OK();
-}
-
-// Create a `TakeDataset` dataset as a variant tensor.
-Status DatasetOpsTestBase::MakeTakeDataset(
-    const Tensor& input_dataset, int64 count,
-    const DataTypeVector& output_types,
-    const std::vector<PartialTensorShape>& output_shapes,
-    Tensor* take_dataset) {
-  GraphConstructorOptions graph_opts;
-  graph_opts.allow_internal_ops = true;
-  graph_opts.expect_device_spec = false;
-
-  Tensor count_tensor = CreateTensor<int64>(TensorShape({}), {count});
-  TF_RETURN_IF_ERROR(
-      RunFunction(test::function::MakeTakeDataset(),
-                  /*attrs*/
-                  {{TakeDatasetOp::kOutputTypes, output_types},
-                   {TakeDatasetOp::kOutputShapes, output_shapes}},
-                  /*inputs*/ {input_dataset, count_tensor}, graph_opts,
-                  /*rets*/ {take_dataset}));
-  return Status::OK();
-}
-
 Status DatasetOpsTestBase::CreateOpKernel(
     const NodeDef& node_def, std::unique_ptr<OpKernel>* op_kernel) {
   OpKernel* kernel;
@@ -716,7 +625,7 @@ Status DatasetOpsTestBase::CheckIteratorSaveAndRestore(
   return Status::OK();
 }
 
-Status DatasetOpsTestBaseV2::Initialize(const DatasetParams& dataset_params) {
+Status DatasetOpsTestBase::Initialize(const DatasetParams& dataset_params) {
   if (initialized_) {
     return errors::Internal(
         "The fields (e.g. dataset_kernel_, dataset_ctx_, dataset_, "
@@ -732,7 +641,7 @@ Status DatasetOpsTestBaseV2::Initialize(const DatasetParams& dataset_params) {
   return Status::OK();
 }
 
-Status DatasetOpsTestBaseV2::InitializeRuntime(
+Status DatasetOpsTestBase::InitializeRuntime(
     const DatasetParams& dataset_params) {
   TF_RETURN_IF_ERROR(InitThreadPool(thread_num_));
   TF_RETURN_IF_ERROR(
@@ -740,9 +649,8 @@ Status DatasetOpsTestBaseV2::InitializeRuntime(
   return Status::OK();
 }
 
-Status DatasetOpsTestBaseV2::MakeDataset(
-    const DatasetParams& dataset_params,
-    std::unique_ptr<TestDataset>* dataset) {
+Status DatasetOpsTestBase::MakeDataset(const DatasetParams& dataset_params,
+                                       std::unique_ptr<TestDataset>* dataset) {
   DatasetBase* dataset_base;
   std::unique_ptr<OpKernel> dataset_kernel;
   std::unique_ptr<OpKernelContext::Params> dataset_ctx_params;
@@ -757,7 +665,7 @@ Status DatasetOpsTestBaseV2::MakeDataset(
   return Status::OK();
 }
 
-Status DatasetOpsTestBaseV2::RunDatasetOp(
+Status DatasetOpsTestBase::RunDatasetOp(
     const DatasetParams& dataset_params,
     std::unique_ptr<OpKernel>* dataset_kernel,
     std::unique_ptr<OpKernelContext::Params>* dataset_ctx_params,
@@ -790,7 +698,7 @@ Status DatasetOpsTestBaseV2::RunDatasetOp(
   return Status::OK();
 }
 
-Status DatasetOpsTestBaseV2::MakeDataset(
+Status DatasetOpsTestBase::MakeDataset(
     const DatasetParams& dataset_params,
     std::unique_ptr<OpKernel>* dataset_kernel,
     std::unique_ptr<OpKernelContext::Params>* dataset_ctx_params,
@@ -806,7 +714,7 @@ Status DatasetOpsTestBaseV2::MakeDataset(
   return Status::OK();
 }
 
-Status DatasetOpsTestBaseV2::MakeIterator(
+Status DatasetOpsTestBase::MakeIterator(
     const DatasetParams& dataset_params, const TestDataset& dataset,
     std::unique_ptr<TestIterator>* iterator) {
   std::unique_ptr<IteratorContext> iterator_ctx;
@@ -820,8 +728,8 @@ Status DatasetOpsTestBaseV2::MakeIterator(
   return Status::OK();
 }
 
-Status DatasetOpsTestBaseV2::RunDatasetOp(const DatasetParams& dataset_params,
-                                          std::vector<Tensor>* outputs) {
+Status DatasetOpsTestBase::RunDatasetOp(const DatasetParams& dataset_params,
+                                        std::vector<Tensor>* outputs) {
   TF_RETURN_IF_ERROR(RunDatasetOp(dataset_params, &dataset_kernel_, &params_,
                                   &tensors_, &dataset_ctx_));
   for (int i = 0; i < dataset_ctx_->num_outputs(); ++i) {
@@ -830,7 +738,7 @@ Status DatasetOpsTestBaseV2::RunDatasetOp(const DatasetParams& dataset_params,
   return Status::OK();
 }
 
-Status DatasetOpsTestBaseV2::MakeDatasetOpKernel(
+Status DatasetOpsTestBase::MakeDatasetOpKernel(
     const DatasetParams& dataset_params,
     std::unique_ptr<OpKernel>* dataset_kernel) {
   name_utils::OpNameParams params;
@@ -847,7 +755,7 @@ Status DatasetOpsTestBaseV2::MakeDatasetOpKernel(
   return Status::OK();
 }
 
-Status DatasetOpsTestBaseV2::MakeDatasetTensor(
+Status DatasetOpsTestBase::MakeDatasetTensor(
     const DatasetParams& dataset_params,
     std::vector<std::unique_ptr<Tensor>>* created_tensors,
     std::unique_ptr<Tensor>* dataset) {

--- a/tensorflow/core/kernels/data/dataset_test_base.h
+++ b/tensorflow/core/kernels/data/dataset_test_base.h
@@ -52,7 +52,6 @@ typedef std::vector<
 
 constexpr int kDefaultCPUNum = 2;
 constexpr int kDefaultThreadNum = 2;
-constexpr char kDefaultIteratorPrefix[] = "Iterator";
 
 // Creates a tensor with the specified dtype, shape, and value.
 template <typename T>
@@ -404,12 +403,6 @@ struct DatasetSaveTestCase {
 };
 
 template <typename T>
-struct IsStatefulTestCase {
-  T dataset_params;
-  bool expected_stateful;
-};
-
-template <typename T>
 struct IteratorOutputDtypesTestCase {
   T dataset_params;
   DataTypeVector expected_output_dtypes;
@@ -506,11 +499,29 @@ class DatasetOpsTestBase : public ::testing::Test {
     allocator_ = device_->GetAllocator(AllocatorAttributes());
   }
 
-  ~DatasetOpsTestBase() {
-    if (dataset_) {
-      dataset_->Unref();
-    }
-  }
+  // Initializes the runtime and creates a dataset and iterator.
+  Status Initialize(const DatasetParams& dataset_params);
+
+  // Initializes the parts of the runtime needed to run dataset ops.
+  Status InitializeRuntime(const DatasetParams& dataset_params);
+
+  // Creates a dataset.
+  Status MakeDataset(const DatasetParams& dataset_params,
+                     std::unique_ptr<TestDataset>* dataset);
+
+  // Creates an iterator for the given dataset.
+  Status MakeIterator(const DatasetParams& dataset_params,
+                      const TestDataset& dataset,
+                      std::unique_ptr<TestIterator>* iterator);
+
+  // Runs the dataset operation according to the predefined dataset params and
+  // produces outputs. Different from `MakeDataset()` which returns a Dataset
+  // object, `RunDatasetOp()` executes the dataset kernel based on the input
+  // DatasetParams and returns the produced outputs as a tensor vector. It can
+  // be used to run some dataset operations that do not have an internal
+  // customized `Dataset` class (e.g. `ReduceDatasetOp`).
+  Status RunDatasetOp(const DatasetParams& dataset_params,
+                      std::vector<Tensor>* outputs);
 
   // The method validates whether the two tensors have the same shape, dtype,
   // and value.
@@ -522,105 +533,6 @@ class DatasetOpsTestBase : public ::testing::Test {
   static Status ExpectEqual(std::vector<Tensor> produced_tensors,
                             std::vector<Tensor> expected_tensors,
                             bool compare_order);
-
-  // Creates a new op kernel based on the node definition.
-  Status CreateOpKernel(const NodeDef& node_def,
-                        std::unique_ptr<OpKernel>* op_kernel);
-
-  // Creates a new op kernel context.
-  Status CreateDatasetContext(
-      OpKernel* const dateset_kernel,
-      gtl::InlinedVector<TensorValue, 4>* const inputs,
-      std::unique_ptr<OpKernelContext::Params>* dataset_context_params,
-      std::unique_ptr<OpKernelContext>* dataset_context);
-
-  // Creates a new dataset.
-  Status CreateDataset(OpKernel* kernel, OpKernelContext* context,
-                       DatasetBase** const dataset);
-
-  // Restores the state of the input iterator. It resets the iterator before
-  // restoring it to make sure the input iterator does not hold any
-  // resources or tasks. Otherwise, restoring an existing iterator may cause
-  // the timeout issue or duplicated elements.
-  Status RestoreIterator(IteratorContext* ctx, IteratorStateReader* reader,
-                         const string& output_prefix,
-                         const DatasetBase& dataset,
-                         std::unique_ptr<IteratorBase>* iterator);
-
-  // Creates a new RangeDataset op kernel. `T` specifies the output dtype of the
-  // op kernel.
-  template <typename T>
-  Status CreateRangeDatasetOpKernel(
-      StringPiece node_name, std::unique_ptr<OpKernel>* range_op_kernel) {
-    DataTypeVector dtypes({tensorflow::DataTypeToEnum<T>::value});
-    std::vector<PartialTensorShape> shapes({{}});
-    NodeDef node_def = test::function::NDef(
-        node_name, name_utils::OpName(RangeDatasetOp::kDatasetType),
-        {RangeDatasetOp::kStart, RangeDatasetOp::kStop, RangeDatasetOp::kStep},
-        {{RangeDatasetOp::kOutputTypes, dtypes},
-         {RangeDatasetOp::kOutputShapes, shapes}});
-
-    TF_RETURN_IF_ERROR(CreateOpKernel(node_def, range_op_kernel));
-    return Status::OK();
-  }
-
-  // Creates a new RangeDataset dataset. `T` specifies the output dtype of the
-  // RangeDataset op kernel.
-  template <typename T>
-  Status CreateRangeDataset(int64 start, int64 end, int64 step,
-                            StringPiece node_name,
-                            DatasetBase** range_dataset) {
-    std::unique_ptr<OpKernel> range_kernel;
-    TF_RETURN_IF_ERROR(CreateRangeDatasetOpKernel<T>(node_name, &range_kernel));
-    gtl::InlinedVector<TensorValue, 4> range_inputs;
-    TF_RETURN_IF_ERROR(AddDatasetInputFromArray<int64>(
-        &range_inputs, range_kernel->input_types(), TensorShape({}), {start}));
-    TF_RETURN_IF_ERROR(AddDatasetInputFromArray<int64>(
-        &range_inputs, range_kernel->input_types(), TensorShape({}), {end}));
-    TF_RETURN_IF_ERROR(AddDatasetInputFromArray<int64>(
-        &range_inputs, range_kernel->input_types(), TensorShape({}), {step}));
-    std::unique_ptr<OpKernelContext::Params> context_params;
-    std::unique_ptr<OpKernelContext> range_context;
-    TF_RETURN_IF_ERROR(CreateOpKernelContext(range_kernel.get(), &range_inputs,
-                                             &context_params, &range_context));
-    TF_RETURN_IF_ERROR(CheckOpKernelInput(*range_kernel, range_inputs));
-    TF_RETURN_IF_ERROR(RunOpKernel(range_kernel.get(), range_context.get()));
-    TF_RETURN_IF_ERROR(
-        GetDatasetFromContext(range_context.get(), 0, range_dataset));
-    return Status::OK();
-  }
-
-  // Creates a new TensorSliceDataset op kernel.
-  Status CreateTensorSliceDatasetKernel(
-      StringPiece node_name, const DataTypeVector& dtypes,
-      const std::vector<PartialTensorShape>& shapes,
-      std::unique_ptr<OpKernel>* tensor_slice_dataset_kernel);
-
-  // Creates a new TensorSliceDataset.
-  Status CreateTensorSliceDataset(StringPiece node_name,
-                                  std::vector<Tensor>* const components,
-                                  DatasetBase** tensor_slice_dataset);
-
-  // TODO(feihugis): remove this function after all related tests switch to
-  // `DatasetOpsTestBaseV2`.
-  // Creates a `RangeDataset` dataset as a variant tensor.
-  Status MakeRangeDataset(const Tensor& start, const Tensor& stop,
-                          const Tensor& step,
-                          const DataTypeVector& output_types,
-                          const std::vector<PartialTensorShape>& output_shapes,
-                          Tensor* range_dataset);
-
-  // TODO(feihugis): remove this function after all related tests switch to
-  // `DatasetOpsTestBaseV2`.
-  // Creates a `TakeDataset` dataset as a variant tensor.
-  Status MakeTakeDataset(const Tensor& input_dataset, int64 count,
-                         const DataTypeVector& output_types,
-                         const std::vector<PartialTensorShape>& output_shapes,
-                         Tensor* take_dataset);
-
-  // Fetches the dataset from the operation context.
-  Status GetDatasetFromContext(OpKernelContext* context, int output_index,
-                               DatasetBase** const dataset);
 
   // Checks `IteratorBase::GetNext()`.
   Status CheckIteratorGetNext(const std::vector<Tensor>& expected_outputs,
@@ -670,6 +582,14 @@ class DatasetOpsTestBase : public ::testing::Test {
       const std::vector<int>& breakpoints, bool compare_order);
 
  protected:
+  // Make destructor protected so that DatasetOpsTestBase objects cannot
+  // be instantiated directly. Only subclasses can be instantiated.
+  virtual ~DatasetOpsTestBase() {
+    if (dataset_) {
+      dataset_->Unref();
+    }
+  }
+
   // Creates a thread pool for parallel tasks.
   Status InitThreadPool(int thread_num);
 
@@ -678,6 +598,34 @@ class DatasetOpsTestBase : public ::testing::Test {
   // before this method if we want to run the tasks in parallel.
   Status InitFunctionLibraryRuntime(const std::vector<FunctionDef>& flib,
                                     int cpu_num);
+
+  // Creates a new op kernel based on the node definition.
+  Status CreateOpKernel(const NodeDef& node_def,
+                        std::unique_ptr<OpKernel>* op_kernel);
+
+  // Creates a new op kernel context.
+  Status CreateDatasetContext(
+      OpKernel* const dateset_kernel,
+      gtl::InlinedVector<TensorValue, 4>* const inputs,
+      std::unique_ptr<OpKernelContext::Params>* dataset_context_params,
+      std::unique_ptr<OpKernelContext>* dataset_context);
+
+  // Creates a new dataset.
+  Status CreateDataset(OpKernel* kernel, OpKernelContext* context,
+                       DatasetBase** const dataset);
+
+  // Restores the state of the input iterator. It resets the iterator before
+  // restoring it to make sure the input iterator does not hold any
+  // resources or tasks. Otherwise, restoring an existing iterator may cause
+  // the timeout issue or duplicated elements.
+  Status RestoreIterator(IteratorContext* ctx, IteratorStateReader* reader,
+                         const string& output_prefix,
+                         const DatasetBase& dataset,
+                         std::unique_ptr<IteratorBase>* iterator);
+
+  // Fetches the dataset from the operation context.
+  Status GetDatasetFromContext(OpKernelContext* context, int output_index,
+                               DatasetBase** const dataset);
 
   // Runs an operation producing outputs.
   Status RunOpKernel(OpKernel* op_kernel, OpKernelContext* context);
@@ -713,22 +661,34 @@ class DatasetOpsTestBase : public ::testing::Test {
   Status CreateSerializationContext(
       std::unique_ptr<SerializationContext>* context);
 
-  // Adds an arrayslice of data into the input vector. `input_types` describes
-  // the required data type for each input tensor. `shape` and `data`
-  // describes the shape and values of the current input tensor. `T` specifies
-  // the dtype of the input data.
-  template <typename T>
-  Status AddDatasetInputFromArray(gtl::InlinedVector<TensorValue, 4>* inputs,
-                                  DataTypeVector input_types,
-                                  const TensorShape& shape,
-                                  const gtl::ArraySlice<T>& data) {
-    TF_RETURN_IF_ERROR(
-        AddDatasetInput(inputs, input_types, DataTypeToEnum<T>::v(), shape));
-    test::FillValues<T>(inputs->back().tensor, data);
-    return Status::OK();
-  }
-
  private:
+  // Runs the dataset operation according to the predefined dataset params and
+  // the produced outputs will be stored in `dataset_ctx`.
+  Status RunDatasetOp(
+      const DatasetParams& dataset_params,
+      std::unique_ptr<OpKernel>* dataset_kernel,
+      std::unique_ptr<OpKernelContext::Params>* dataset_ctx_params,
+      std::vector<std::unique_ptr<Tensor>>* created_tensors,
+      std::unique_ptr<OpKernelContext>* dataset_ctx);
+
+  Status MakeDataset(
+      const DatasetParams& dataset_params,
+      std::unique_ptr<OpKernel>* dataset_kernel,
+      std::unique_ptr<OpKernelContext::Params>* dataset_ctx_params,
+      std::unique_ptr<OpKernelContext>* dataset_ctx,
+      std::vector<std::unique_ptr<Tensor>>* created_tensors,
+      DatasetBase** dataset);
+
+  // Creates the dataset op kernel.
+  Status MakeDatasetOpKernel(const DatasetParams& dataset_params,
+                             std::unique_ptr<OpKernel>* dataset_kernel);
+
+  // Creates a dataset tensor according to the input dataset params.
+  Status MakeDatasetTensor(
+      const DatasetParams& dataset_params,
+      std::vector<std::unique_ptr<Tensor>>* created_tensors,
+      std::unique_ptr<Tensor>* dataset);
+
   // Adds an empty tensor with the specified dtype and shape to the input
   // vector.
   Status AddDatasetInput(gtl::InlinedVector<TensorValue, 4>* inputs,
@@ -767,68 +727,6 @@ class DatasetOpsTestBase : public ::testing::Test {
   DatasetBase* dataset_ = nullptr;
   std::unique_ptr<IteratorContext> iterator_ctx_;
   std::unique_ptr<IteratorBase> iterator_;
-};
-
-// TODO(feihugis): merge `DatasetOpsTestBaseV2` into `DatasetOpsTestBase` once
-// `DatasetOpsTestBaseV2` becomes stable.
-class DatasetOpsTestBaseV2 : public DatasetOpsTestBase {
- public:
-  // Initializes the runtime and creates a dataset and iterator.
-  Status Initialize(const DatasetParams& dataset_params);
-
-  // Initializes the parts of the runtime needed to run dataset ops.
-  Status InitializeRuntime(const DatasetParams& dataset_params);
-
-  // Creates a dataset.
-  Status MakeDataset(const DatasetParams& dataset_params,
-                     std::unique_ptr<TestDataset>* dataset);
-
-  // Creates an iterator for the given dataset.
-  Status MakeIterator(const DatasetParams& dataset_params,
-                      const TestDataset& dataset,
-                      std::unique_ptr<TestIterator>* iterator);
-
-  // Runs the dataset operation according to the predefined dataset params and
-  // produces outputs. Different from `MakeDataset()` which returns a Dataset
-  // object, `RunDatasetOp()` executes the dataset kernel based on the input
-  // DatasetParams and returns the produced outputs as a tensor vector. It can
-  // be used to run some dataset operations that do not have an internal
-  // customized `Dataset` class (e.g. `ReduceDatasetOp`).
-  Status RunDatasetOp(const DatasetParams& dataset_params,
-                      std::vector<Tensor>* outputs);
-
- protected:
-  // Make destructor protected so that DatasetOpsTestBaseV2 objects cannot
-  // be instantiated directly. Only subclasses can be instantiated.
-  virtual ~DatasetOpsTestBaseV2(){};
-
- private:
-  // Runs the dataset operation according to the predefined dataset params and
-  // the produced outputs will be stored in `dataset_ctx`.
-  Status RunDatasetOp(
-      const DatasetParams& dataset_params,
-      std::unique_ptr<OpKernel>* dataset_kernel,
-      std::unique_ptr<OpKernelContext::Params>* dataset_ctx_params,
-      std::vector<std::unique_ptr<Tensor>>* created_tensors,
-      std::unique_ptr<OpKernelContext>* dataset_ctx);
-
-  Status MakeDataset(
-      const DatasetParams& dataset_params,
-      std::unique_ptr<OpKernel>* dataset_kernel,
-      std::unique_ptr<OpKernelContext::Params>* dataset_ctx_params,
-      std::unique_ptr<OpKernelContext>* dataset_ctx,
-      std::vector<std::unique_ptr<Tensor>>* created_tensors,
-      DatasetBase** dataset);
-
-  // Creates the dataset op kernel.
-  Status MakeDatasetOpKernel(const DatasetParams& dataset_params,
-                             std::unique_ptr<OpKernel>* dataset_kernel);
-
-  // Creates a dataset tensor according to the input dataset params.
-  Status MakeDatasetTensor(
-      const DatasetParams& dataset_params,
-      std::vector<std::unique_ptr<Tensor>>* created_tensors,
-      std::unique_ptr<Tensor>* dataset);
 };
 
 #define ITERATOR_GET_NEXT_TEST_P(dataset_op_test_class, dataset_params_class, \

--- a/tensorflow/core/kernels/data/experimental/assert_next_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/experimental/assert_next_dataset_op_test.cc
@@ -65,7 +65,7 @@ class AssertNextDatasetParams : public DatasetParams {
   std::vector<tstring> transformations_;
 };
 
-class AssertNextDatasetOpTest : public DatasetOpsTestBaseV2 {};
+class AssertNextDatasetOpTest : public DatasetOpsTestBase {};
 
 AssertNextDatasetParams AssertNextDatasetParams1() {
   TakeDatasetParams take_dataset_params =

--- a/tensorflow/core/kernels/data/experimental/auto_shard_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/experimental/auto_shard_dataset_op_test.cc
@@ -20,260 +20,160 @@ namespace experimental {
 namespace {
 
 constexpr char kNodeName[] = "auto_shard_dataset";
-constexpr char kIteratorPrefix[] = "Iterator";
 
-class AutoShardDatasetOpTest : public DatasetOpsTestBase {
- protected:
-  // Creates a new `AutoShardDataset` op kernel.
-  Status CreateAutoShardDatasetOpKernel(
-      const DataTypeVector& output_types,
-      const std::vector<PartialTensorShape>& output_shapes,
-      std::unique_ptr<OpKernel>* op_kernel) {
-    NodeDef node_def = test::function::NDef(
-        kNodeName, name_utils::OpName(AutoShardDatasetOp::kDatasetType),
-        {AutoShardDatasetOp::kInputDataset, AutoShardDatasetOp::kNumWorkers,
-         AutoShardDatasetOp::kIndex},
-        {{AutoShardDatasetOp::kAutoShardPolicy, 0},  // AutoShardPolicy == AUTO
-         {AutoShardDatasetOp::kOutputTypes, output_types},
-         {AutoShardDatasetOp::kOutputShapes, output_shapes}});
-    TF_RETURN_IF_ERROR(CreateOpKernel(node_def, op_kernel));
+class AutoShardDatasetParams : public DatasetParams {
+ public:
+  template <typename T>
+  AutoShardDatasetParams(T input_dataset_params, int64 num_workers, int64 index,
+                         int auto_shard_policy, DataTypeVector output_dtypes,
+                         std::vector<PartialTensorShape> output_shapes,
+                         string node_name)
+      : DatasetParams(std::move(output_dtypes), std::move(output_shapes),
+                      std::move(node_name)),
+        num_workers_(num_workers),
+        index_(index),
+        auto_shard_policy_(auto_shard_policy) {
+    input_dataset_params_.push_back(absl::make_unique<T>(input_dataset_params));
+    iterator_prefix_ =
+        name_utils::IteratorPrefix(input_dataset_params.dataset_type(),
+                                   input_dataset_params.iterator_prefix());
+  }
+
+  std::vector<Tensor> GetInputTensors() const override {
+    return CreateTensors<int64>(TensorShape({}), {{num_workers_}, {index_}});
+  }
+
+  Status GetInputNames(std::vector<string>* input_names) const override {
+    input_names->clear();
+    input_names->emplace_back(AutoShardDatasetOp::kInputDataset);
+    input_names->emplace_back(AutoShardDatasetOp::kNumWorkers);
+    input_names->emplace_back(AutoShardDatasetOp::kIndex);
     return Status::OK();
   }
 
-  // Create a new `AutoShardDataset` op kernel context
-  Status CreateAutoShardDatasetContext(
-      OpKernel* const op_kernel,
-      gtl::InlinedVector<TensorValue, 4>* const inputs,
-      std::unique_ptr<OpKernelContext>* context) {
-    TF_RETURN_IF_ERROR(CheckOpKernelInput(*op_kernel, *inputs));
-    TF_RETURN_IF_ERROR(CreateOpKernelContext(op_kernel, inputs, context));
+  Status GetAttributes(AttributeVector* attr_vector) const override {
+    attr_vector->clear();
+    attr_vector->emplace_back(AutoShardDatasetOp::kAutoShardPolicy,
+                              auto_shard_policy_);
+    attr_vector->emplace_back(AutoShardDatasetOp::kOutputTypes, output_dtypes_);
+    attr_vector->emplace_back(AutoShardDatasetOp::kOutputShapes,
+                              output_shapes_);
     return Status::OK();
   }
+
+  string dataset_type() const override {
+    return AutoShardDatasetOp::kDatasetType;
+  }
+
+ private:
+  int64 num_workers_;
+  int64 index_;
+  int auto_shard_policy_;
 };
 
-struct TestCase {
-  TestCase(int64 start, int64 stop, int64 step, int64 num_workers, int64 index,
-           std::vector<Tensor> expected_outputs,
-           DataTypeVector expected_output_dtypes,
-           std::vector<PartialTensorShape> expected_output_shapes,
-           int64 expected_cardinality, std::vector<int> breakpoints)
-      : start(CreateTensor<int64>(TensorShape({}), {start})),
-        stop(CreateTensor<int64>(TensorShape({}), {stop})),
-        step(CreateTensor<int64>(TensorShape({}), {step})),
-        num_workers(CreateTensor<int64>(TensorShape({}), {num_workers})),
-        index(CreateTensor<int64>(TensorShape({}), {index})),
-        expected_outputs(std::move(expected_outputs)),
-        expected_output_dtypes(std::move(expected_output_dtypes)),
-        expected_output_shapes(std::move(expected_output_shapes)),
-        expected_cardinality(expected_cardinality),
-        breakpoints(std::move(breakpoints)) {}
-
-  Tensor start;
-  Tensor stop;
-  Tensor step;
-  Tensor num_workers;
-  Tensor index;
-  std::vector<Tensor> expected_outputs;
-  DataTypeVector expected_output_dtypes;
-  std::vector<PartialTensorShape> expected_output_shapes;
-  int64 expected_cardinality;
-  std::vector<int> breakpoints;
-};
+class AutoShardDatasetOpTest : public DatasetOpsTestBase {};
 
 // Test Case 1: simple case.
-TestCase SimpleCase() {
-  return {/*start=*/0,
-          /*stop=*/10,
-          /*step=*/1,
-          /*num_workers=*/5,
-          /*index=*/2,
-          /*expected_outputs=*/
-          {CreateTensor<int64>(TensorShape({}), {2}),
-           CreateTensor<int64>(TensorShape({}), {7})},
-          /*expected_output_dtypes=*/{DT_INT64},
-          /*expected_output_shapes=*/{PartialTensorShape({})},
-          /*expected_cardinality=*/2,
-          /*breakpoints=*/{0, 1, 5}};
+AutoShardDatasetParams AutoShardDatasetParams1() {
+  return AutoShardDatasetParams(RangeDatasetParams(0, 10, 1),
+                                /*num_workers=*/5,
+                                /*index=*/2,
+                                /*auto_shard_policy=*/0,
+                                /*output_dtypes=*/{DT_INT64},
+                                /*output_shapes=*/{PartialTensorShape({})},
+                                /*node_name=*/kNodeName);
 }
 
 // Test Case 2: the index is larger than the available elements.
-TestCase IndexLargerThanAvailableElementsCase() {
-  return {/*start=*/0,
-          /*stop=*/1,
-          /*step=*/1,
-          /*num_workers=*/5,
-          /*index=*/2,
-          /*expected_outputs=*/{},
-          /*expected_output_dtypes=*/{DT_INT64},
-          /*expected_output_shapes=*/{PartialTensorShape({})},
-          /*expected_cardinality=*/2,
-          /*breakpoints=*/{0, 1}};
+AutoShardDatasetParams AutoShardDatasetParams2() {
+  return AutoShardDatasetParams(RangeDatasetParams(0, 1, 1),
+                                /*num_workers=*/5,
+                                /*index=*/2,
+                                /*auto_shard_policy=*/0,
+                                /*output_dtypes=*/{DT_INT64},
+                                /*output_shapes=*/{PartialTensorShape({})},
+                                /*node_name=*/kNodeName);
 }
 
 // Test Case 3: the number of outputs could not be evenly divided by
 // num_workers.
-TestCase ElementsUnequallyDividedCase() {
-  return {/*start=*/0,
-          /*stop=*/10,
-          /*step=*/1,
-          /*num_workers=*/4,
-          /*index=*/3,
-          /*expected_outputs=*/
-          {CreateTensor<int64>(TensorShape({}), {3}),
-           CreateTensor<int64>(TensorShape({}), {7})},
-          /*expected_output_dtypes=*/{DT_INT64},
-          /*expected_output_shapes=*/{PartialTensorShape({})},
-          /*expected_cardinality=*/2,
-          /*breakpoints=*/{0, 1, 5}};
+AutoShardDatasetParams AutoShardDatasetParams3() {
+  return AutoShardDatasetParams(RangeDatasetParams(0, 10, 1),
+                                /*num_workers=*/4,
+                                /*index=*/3,
+                                /*auto_shard_policy=*/0,
+                                /*output_dtypes=*/{DT_INT64},
+                                /*output_shapes=*/{PartialTensorShape({})},
+                                /*node_name=*/kNodeName);
 }
 
 // TODO(feihugis): add more test cases that have ReaderDatasets (e.g. a
 // CSVDataset or a TFRecordDataset) in the pipeline.
 
-TestCase IndexGreaterNumWorkersCase() {
-  return {/*start=*/0,
-          /*stop=*/10,
-          /*step=*/1,
-          /*num_workers=*/5,
-          /*index=*/7,
-          /*expected_outputs=*/{},
-          /*expected_output_dtypes=*/{DT_INT64},
-          /*expected_output_shapes=*/{PartialTensorShape({})},
-          /*expected_cardinality=*/0,
-          /*breakpoints=*/{}};
+// Test case 4: the index is greater than the number of workers.
+AutoShardDatasetParams AutoShardDatasetParams4() {
+  return AutoShardDatasetParams(RangeDatasetParams(0, 10, 1),
+                                /*num_workers=*/5,
+                                /*index=*/7,
+                                /*auto_shard_policy=*/0,
+                                /*output_dtypes=*/{DT_INT64},
+                                /*output_shapes=*/{PartialTensorShape({})},
+                                /*node_name=*/kNodeName);
 }
 
-TestCase NegativeIndexTestCase() {
-  return {/*start=*/0,
-          /*stop=*/10,
-          /*step=*/1,
-          /*num_workers=*/5,
-          /*index=*/-3,
-          /*expected_outputs=*/{},
-          /*expected_output_dtypes=*/{DT_INT64},
-          /*expected_output_shapes=*/{PartialTensorShape({})},
-          /*expected_cardinality=*/0,
-          /*breakpoints=*/{}};
+// Test case 5: the index is negative.
+AutoShardDatasetParams AutoShardDatasetParams5() {
+  return AutoShardDatasetParams(RangeDatasetParams(0, 10, 1),
+                                /*num_workers=*/5,
+                                /*index=*/-3,
+                                /*auto_shard_policy=*/0,
+                                /*output_dtypes=*/{DT_INT64},
+                                /*output_shapes=*/{PartialTensorShape({})},
+                                /*node_name=*/kNodeName);
 }
 
-TestCase NegativeNumWorkersTestCase() {
-  return {/*start=*/0,
-          /*stop=*/10,
-          /*step=*/1,
-          /*num_workers=*/-3,
-          /*index=*/1,
-          /*expected_outputs=*/{},
-          /*expected_output_dtypes=*/{DT_INT64},
-          /*expected_output_shapes=*/{PartialTensorShape({})},
-          /*expected_cardinality=*/0,
-          /*breakpoints=*/{}};
+// Test case 6: num_workers is negative.
+AutoShardDatasetParams AutoShardDatasetParams6() {
+  return AutoShardDatasetParams(RangeDatasetParams(0, 10, 1),
+                                /*num_workers=*/-3,
+                                /*index=*/1,
+                                /*auto_shard_policy=*/0,
+                                /*output_dtypes=*/{DT_INT64},
+                                /*output_shapes=*/{PartialTensorShape({})},
+                                /*node_name=*/kNodeName);
 }
 
-TestCase ZeroNumWorkersTestCase() {
-  return {/*start=*/0,
-          /*stop=*/10,
-          /*step=*/1,
-          /*num_workers=*/0,
-          /*index=*/1,
-          /*expected_outputs=*/{},
-          /*expected_output_dtypes=*/{DT_INT64},
-          /*expected_output_shapes=*/{PartialTensorShape({})},
-          /*expected_cardinality=*/0,
-          /*breakpoints=*/{}};
+// Test case 7: num_workers is zero.
+AutoShardDatasetParams AutoShardDatasetParams7() {
+  return AutoShardDatasetParams(RangeDatasetParams(0, 10, 1),
+                                /*num_workers=*/0,
+                                /*index=*/1,
+                                /*auto_shard_policy=*/0,
+                                /*output_dtypes=*/{DT_INT64},
+                                /*output_shapes=*/{PartialTensorShape({})},
+                                /*node_name=*/kNodeName);
 }
 
-class ParameterizedAutoShardDatasetOpTest
-    : public AutoShardDatasetOpTest,
-      public ::testing::WithParamInterface<TestCase> {};
-
-TEST_P(ParameterizedAutoShardDatasetOpTest, GetNext) {
-  int thread_num = 2, cpu_num = 2;
-  TestCase test_case = GetParam();
-  TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
-
-  std::unique_ptr<OpKernel> auto_shard_dataset_kernel;
-  TF_ASSERT_OK(CreateAutoShardDatasetOpKernel(test_case.expected_output_dtypes,
-                                              test_case.expected_output_shapes,
-                                              &auto_shard_dataset_kernel));
-
-  Tensor range_dataset_tensor(DT_VARIANT, TensorShape({}));
-  TF_ASSERT_OK(MakeRangeDataset(test_case.start, test_case.stop, test_case.step,
-                                {DT_INT64}, {TensorShape({})},
-                                &range_dataset_tensor));
-  gtl::InlinedVector<TensorValue, 4> inputs(
-      {TensorValue(&range_dataset_tensor), TensorValue(&test_case.num_workers),
-       TensorValue(&test_case.index)});
-  std::unique_ptr<OpKernelContext> auto_shard_dataset_context;
-  TF_ASSERT_OK(CreateAutoShardDatasetContext(
-      auto_shard_dataset_kernel.get(), &inputs, &auto_shard_dataset_context));
-
-  DatasetBase* auto_shard_dataset;
-  TF_ASSERT_OK(CreateDataset(auto_shard_dataset_kernel.get(),
-                             auto_shard_dataset_context.get(),
-                             &auto_shard_dataset));
-  core::ScopedUnref scoped_unref_auto_shard_dataset(auto_shard_dataset);
-
-  std::unique_ptr<IteratorContext> iterator_ctx;
-  TF_ASSERT_OK(
-      CreateIteratorContext(auto_shard_dataset_context.get(), &iterator_ctx));
-  std::unique_ptr<IteratorBase> iterator;
-  TF_ASSERT_OK(auto_shard_dataset->MakeIterator(iterator_ctx.get(),
-                                                kIteratorPrefix, &iterator));
-
-  bool end_of_sequence = false;
-  auto expected_outputs_it = test_case.expected_outputs.begin();
-  std::vector<Tensor> out_tensors;
-  while (!end_of_sequence) {
-    TF_EXPECT_OK(
-        iterator->GetNext(iterator_ctx.get(), &out_tensors, &end_of_sequence));
-    if (!end_of_sequence) {
-      EXPECT_LT(expected_outputs_it, test_case.expected_outputs.end());
-      TF_EXPECT_OK(ExpectEqual(out_tensors.back(), *expected_outputs_it));
-      expected_outputs_it++;
-    }
-  }
-  EXPECT_EQ(expected_outputs_it, test_case.expected_outputs.end());
+std::vector<GetNextTestCase<AutoShardDatasetParams>> GetNextTestCases() {
+  return {
+      {/*dataset_params=*/AutoShardDatasetParams1(),
+       /*expected_outputs=*/CreateTensors<int64>(TensorShape{}, {{2}, {7}})},
+      {/*dataset_params=*/AutoShardDatasetParams2(),
+       /*expected_outputs=*/{}},
+      {/*dataset_params=*/AutoShardDatasetParams3(),
+       /*expected_outputs=*/CreateTensors<int64>(TensorShape{}, {{3}, {7}})}};
 }
 
-INSTANTIATE_TEST_SUITE_P(AutoShardDatasetOpTest,
-                         ParameterizedAutoShardDatasetOpTest,
-                         ::testing::ValuesIn(std::vector<TestCase>(
-                             {SimpleCase(),
-                              IndexLargerThanAvailableElementsCase(),
-                              ElementsUnequallyDividedCase()})));
+ITERATOR_GET_NEXT_TEST_P(AutoShardDatasetOpTest, AutoShardDatasetParams,
+                         GetNextTestCases())
 
 TEST_F(AutoShardDatasetOpTest, InvalidArguments) {
-  int thread_num = 2, cpu_num = 2;
-  TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime({}, cpu_num));
-
-  std::vector<TestCase> test_cases = {
-      IndexGreaterNumWorkersCase(), NegativeIndexTestCase(),
-      NegativeNumWorkersTestCase(), ZeroNumWorkersTestCase()};
-  for (auto& test_case : test_cases) {
-    std::unique_ptr<OpKernel> auto_shard_dataset_kernel;
-    TF_ASSERT_OK(CreateAutoShardDatasetOpKernel(
-        test_case.expected_output_dtypes, test_case.expected_output_shapes,
-        &auto_shard_dataset_kernel));
-
-    Tensor range_dataset_tensor(DT_VARIANT, TensorShape({}));
-    TF_ASSERT_OK(MakeRangeDataset(test_case.start, test_case.stop,
-                                  test_case.step, {DT_INT64}, {TensorShape({})},
-                                  &range_dataset_tensor));
-    gtl::InlinedVector<TensorValue, 4> inputs(
-        {TensorValue(&range_dataset_tensor),
-         TensorValue(&test_case.num_workers), TensorValue(&test_case.index)});
-    std::unique_ptr<OpKernelContext> auto_shard_dataset_context;
-    TF_ASSERT_OK(CreateAutoShardDatasetContext(
-        auto_shard_dataset_kernel.get(), &inputs, &auto_shard_dataset_context));
-
-    DatasetBase* auto_shard_dataset;
-    EXPECT_EQ(
-        CreateDataset(auto_shard_dataset_kernel.get(),
-                      auto_shard_dataset_context.get(), &auto_shard_dataset)
-            .code(),
-        tensorflow::error::INVALID_ARGUMENT);
+  std::vector<AutoShardDatasetParams> invalid_dataset_params = {
+      AutoShardDatasetParams4(), AutoShardDatasetParams5(),
+      AutoShardDatasetParams6(), AutoShardDatasetParams7()};
+  for (const auto& dataset_params : invalid_dataset_params) {
+    EXPECT_EQ(Initialize(dataset_params).code(),
+              tensorflow::error::INVALID_ARGUMENT);
   }
 }
 

--- a/tensorflow/core/kernels/data/experimental/map_and_batch_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/experimental/map_and_batch_dataset_op_test.cc
@@ -97,7 +97,7 @@ class MapAndBatchDatasetParams : public DatasetParams {
   bool preserve_cardinality_;
 };
 
-class MapAndBatchDatasetOpTest : public DatasetOpsTestBaseV2 {};
+class MapAndBatchDatasetOpTest : public DatasetOpsTestBase {};
 
 FunctionDefHelper::AttrValueWrapper MapFunc(const string& func_name,
                                             const DataType& dtype) {

--- a/tensorflow/core/kernels/data/experimental/random_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/experimental/random_dataset_op_test.cc
@@ -77,7 +77,7 @@ class RandomDatasetParams : public DatasetParams {
   Tensor seed2_;
 };
 
-class RandomDatasetOpTest : public DatasetOpsTestBaseV2 {};
+class RandomDatasetOpTest : public DatasetOpsTestBase {};
 
 RandomDatasetParams FortyTwo() {
   return {/*seed=*/42,

--- a/tensorflow/core/kernels/data/experimental/sampling_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/experimental/sampling_dataset_op_test.cc
@@ -70,7 +70,7 @@ class SamplingDatasetParams : public DatasetParams {
   int64 seed2_tensor_ = kRandomSeed2;
 };
 
-class SamplingDatasetOpTest : public DatasetOpsTestBaseV2 {};
+class SamplingDatasetOpTest : public DatasetOpsTestBase {};
 
 SamplingDatasetParams OneHundredPercentSampleParams() {
   return SamplingDatasetParams(RangeDatasetParams(0, 3, 1),

--- a/tensorflow/core/kernels/data/experimental/unique_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/experimental/unique_dataset_op_test.cc
@@ -52,7 +52,7 @@ class UniqueDatasetParams : public DatasetParams {
   string dataset_type() const override { return UniqueDatasetOp::kDatasetType; }
 };
 
-class UniqueDatasetOpTest : public DatasetOpsTestBaseV2 {};
+class UniqueDatasetOpTest : public DatasetOpsTestBase {};
 
 UniqueDatasetParams NormalCaseParams() {
   auto tensor_slice_dataset_params = TensorSliceDatasetParams(

--- a/tensorflow/core/kernels/data/filter_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/filter_dataset_op_test.cc
@@ -78,7 +78,7 @@ class FilterDatasetParams : public DatasetParams {
   DataTypeVector type_arguments_;
 };
 
-class FilterDatasetOpTest : public DatasetOpsTestBaseV2 {};
+class FilterDatasetOpTest : public DatasetOpsTestBase {};
 
 // Test case 1: norm case.
 FilterDatasetParams FilterDatasetParams1() {

--- a/tensorflow/core/kernels/data/fixed_length_record_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/fixed_length_record_dataset_op_test.cc
@@ -78,7 +78,7 @@ class FixedLengthRecordDatasetParams : public DatasetParams {
   CompressionType compression_type_;
 };
 
-class FixedLengthRecordDatasetOpTest : public DatasetOpsTestBaseV2 {};
+class FixedLengthRecordDatasetOpTest : public DatasetOpsTestBase {};
 
 Status CreateTestFiles(const std::vector<tstring>& filenames,
                        const std::vector<string>& contents,

--- a/tensorflow/core/kernels/data/flat_map_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/flat_map_dataset_op_test.cc
@@ -76,7 +76,7 @@ class FlatMapDatasetParams : public DatasetParams {
   DataTypeVector type_arguments_;
 };
 
-class FlatMapDatasetOpTest : public DatasetOpsTestBaseV2 {};
+class FlatMapDatasetOpTest : public DatasetOpsTestBase {};
 
 // Test case 1: normal case.
 FlatMapDatasetParams FlatMapDatasetParams1() {

--- a/tensorflow/core/kernels/data/interleave_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/interleave_dataset_op_test.cc
@@ -91,7 +91,7 @@ class InterleaveDatasetParams : public DatasetParams {
   DataTypeVector type_arguments_;
 };
 
-class InterleaveDatasetOpTest : public DatasetOpsTestBaseV2 {};
+class InterleaveDatasetOpTest : public DatasetOpsTestBase {};
 
 FunctionDefHelper::AttrValueWrapper MakeTensorSliceDatasetFunc(
     const DataTypeVector& output_types,

--- a/tensorflow/core/kernels/data/map_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/map_dataset_op_test.cc
@@ -22,7 +22,7 @@ namespace {
 
 constexpr char kNodeName[] = "map_dataset";
 
-class MapDatasetOpTest : public DatasetOpsTestBaseV2 {};
+class MapDatasetOpTest : public DatasetOpsTestBase {};
 
 MapDatasetParams MapDatasetParams1() {
   auto map_dataset_params_0 = MapDatasetParams(

--- a/tensorflow/core/kernels/data/map_defun_op_test.cc
+++ b/tensorflow/core/kernels/data/map_defun_op_test.cc
@@ -87,7 +87,7 @@ class MapDefunOpParams : public DatasetParams {
   int max_intra_op_parallelism_;
 };
 
-class MapDefunOpTest : public DatasetOpsTestBaseV2 {
+class MapDefunOpTest : public DatasetOpsTestBase {
  protected:
   // Creates a new `MapDefun` op kernel
   Status CreateMapDefunOpKernel(const MapDefunOpParams& params,

--- a/tensorflow/core/kernels/data/optimize_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/optimize_dataset_op_test.cc
@@ -67,7 +67,7 @@ class OptimizeDatasetParams : public DatasetParams {
   std::vector<tstring> optimization_configs_;
 };
 
-class OptimizeDatasetOpTest : public DatasetOpsTestBaseV2 {};
+class OptimizeDatasetOpTest : public DatasetOpsTestBase {};
 
 TEST_F(OptimizeDatasetOpTest, NoopElimination) {
   auto take_dataset_parmas =

--- a/tensorflow/core/kernels/data/padded_batch_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/padded_batch_dataset_op_test.cc
@@ -20,7 +20,7 @@ namespace {
 constexpr char kNodeName[] = "padded_batch_dataset";
 constexpr int kOpVersion = 2;
 
-class PaddedBatchDatasetOpTest : public DatasetOpsTestBaseV2 {};
+class PaddedBatchDatasetOpTest : public DatasetOpsTestBase {};
 
 class PaddedBatchDatasetParams : public DatasetParams {
  public:

--- a/tensorflow/core/kernels/data/parallel_interleave_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/parallel_interleave_dataset_op_test.cc
@@ -102,7 +102,7 @@ class ParallelInterleaveDatasetParams : public DatasetParams {
   bool sloppy_;
 };
 
-class ParallelInterleaveDatasetOpTest : public DatasetOpsTestBaseV2 {};
+class ParallelInterleaveDatasetOpTest : public DatasetOpsTestBase {};
 
 FunctionDefHelper::AttrValueWrapper MakeTensorSliceDatasetFunc(
     const DataTypeVector& output_types,

--- a/tensorflow/core/kernels/data/parallel_map_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/parallel_map_dataset_op_test.cc
@@ -95,7 +95,7 @@ class ParallelMapDatasetParams : public DatasetParams {
   bool preserve_cardinality_;
 };
 
-class ParallelMapDatasetOpTest : public DatasetOpsTestBaseV2 {};
+class ParallelMapDatasetOpTest : public DatasetOpsTestBase {};
 
 FunctionDefHelper::AttrValueWrapper MapFunc(const string& func_name,
                                             const DataType& dtype) {

--- a/tensorflow/core/kernels/data/prefetch_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/prefetch_dataset_op_test.cc
@@ -20,7 +20,7 @@ namespace {
 
 constexpr char kNodeName[] = "prefetch_dataset";
 
-class PrefetchDatasetOpTest : public DatasetOpsTestBaseV2 {};
+class PrefetchDatasetOpTest : public DatasetOpsTestBase {};
 
 class PrefetchDatasetParams : public DatasetParams {
  public:

--- a/tensorflow/core/kernels/data/range_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/range_dataset_op_test.cc
@@ -20,7 +20,7 @@ namespace tensorflow {
 namespace data {
 namespace {
 
-class RangeDatasetOpTest : public DatasetOpsTestBaseV2 {};
+class RangeDatasetOpTest : public DatasetOpsTestBase {};
 
 RangeDatasetParams PositiveStepRangeDatasetParams() {
   return RangeDatasetParams(/*start=*/0, /*stop=*/10, /*step=*/3);

--- a/tensorflow/core/kernels/data/reduce_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/reduce_dataset_op_test.cc
@@ -91,7 +91,7 @@ class ReduceDatasetParams : public DatasetParams {
   bool use_inter_op_parallelism_;
 };
 
-class ReduceDatasetOpTest : public DatasetOpsTestBaseV2 {};
+class ReduceDatasetOpTest : public DatasetOpsTestBase {};
 
 // Test case 1: the input function has one output.
 ReduceDatasetParams ReduceDatasetParams1() {

--- a/tensorflow/core/kernels/data/repeat_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/repeat_dataset_op_test.cc
@@ -62,7 +62,7 @@ class RepeatDatasetParams : public DatasetParams {
   int64 count_;
 };
 
-class RepeatDatasetOpTest : public DatasetOpsTestBaseV2 {};
+class RepeatDatasetOpTest : public DatasetOpsTestBase {};
 
 RepeatDatasetParams FiniteRepeatDatasetParams() {
   auto tensor_slice_dataset_params = TensorSliceDatasetParams(

--- a/tensorflow/core/kernels/data/shard_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/shard_dataset_op_test.cc
@@ -66,7 +66,7 @@ class ShardDatasetParams : public DatasetParams {
   bool require_non_empty_;
 };
 
-class ShardDatasetOpTest : public DatasetOpsTestBaseV2 {};
+class ShardDatasetOpTest : public DatasetOpsTestBase {};
 
 // Test Case 1: simple case.
 ShardDatasetParams ShardDatasetParams1() {

--- a/tensorflow/core/kernels/data/shuffle_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/shuffle_dataset_op_test.cc
@@ -95,7 +95,7 @@ class ShuffleDatasetParams : public DatasetParams {
   bool reshuffle_each_iteration_;
 };
 
-class ShuffleDatasetOpTest : public DatasetOpsTestBaseV2 {};
+class ShuffleDatasetOpTest : public DatasetOpsTestBase {};
 
 // Test case 1: test shuffle_dataset with reshuffle_each_iteration = false.
 ShuffleDatasetParams ShuffleDatasetParams1() {

--- a/tensorflow/core/kernels/data/skip_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/skip_dataset_op_test.cc
@@ -59,7 +59,7 @@ class SkipDatasetParams : public DatasetParams {
   int64 count_;
 };
 
-class SkipDatasetOpTest : public DatasetOpsTestBaseV2 {};
+class SkipDatasetOpTest : public DatasetOpsTestBase {};
 
 // Test case 1: skip fewer than input size.
 SkipDatasetParams SkipDatasetParams1() {

--- a/tensorflow/core/kernels/data/sparse_tensor_slice_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/sparse_tensor_slice_dataset_op_test.cc
@@ -63,7 +63,7 @@ class SparseTensorSliceDatasetParams : public DatasetParams {
   DataType tvalues_;
 };
 
-class SparseTensorSliceDatasetOpTest : public DatasetOpsTestBaseV2 {};
+class SparseTensorSliceDatasetOpTest : public DatasetOpsTestBase {};
 
 SparseTensorSliceDatasetParams TwoDimsSparseTensorSliceDatasetParams() {
   return SparseTensorSliceDatasetParams(

--- a/tensorflow/core/kernels/data/take_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/take_dataset_op_test.cc
@@ -19,7 +19,7 @@ namespace {
 
 constexpr char kNodeName[] = "take_dataset";
 
-class TakeDatasetOpTest : public DatasetOpsTestBaseV2 {};
+class TakeDatasetOpTest : public DatasetOpsTestBase {};
 
 // Test case 1: take fewer than input size.
 TakeDatasetParams TakeLessTakeDatasetParams() {

--- a/tensorflow/core/kernels/data/tensor_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/tensor_dataset_op_test.cc
@@ -70,7 +70,7 @@ class TensorDatasetParams : public DatasetParams {
   std::vector<Tensor> components_;
 };
 
-class TensorDatasetOpTest : public DatasetOpsTestBaseV2 {};
+class TensorDatasetOpTest : public DatasetOpsTestBase {};
 
 // Test case 1: test a dataset that represents a single tuple of plain tensors.
 TensorDatasetParams PlainTensorDatasetParams() {

--- a/tensorflow/core/kernels/data/tensor_slice_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/tensor_slice_dataset_op_test.cc
@@ -22,7 +22,7 @@ namespace {
 
 constexpr char kNodeName[] = "tensor_slice_dataset";
 
-class TensorSliceDatasetOpTest : public DatasetOpsTestBaseV2 {};
+class TensorSliceDatasetOpTest : public DatasetOpsTestBase {};
 
 TensorSliceDatasetParams PlainTensorSliceDatasetParams() {
   std::vector<Tensor> components = {

--- a/tensorflow/core/kernels/data/text_line_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/text_line_dataset_op_test.cc
@@ -63,7 +63,7 @@ class TextLineDatasetParams : public DatasetParams {
   int64 buffer_size_;
 };
 
-class TextLineDatasetOpTest : public DatasetOpsTestBaseV2 {};
+class TextLineDatasetOpTest : public DatasetOpsTestBase {};
 
 Status CreateTestFiles(const std::vector<tstring>& filenames,
                        const std::vector<string>& contents,

--- a/tensorflow/core/kernels/data/tf_record_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/tf_record_dataset_op_test.cc
@@ -63,7 +63,7 @@ class TFRecordDatasetParams : public DatasetParams {
   int64 buffer_size_;
 };
 
-class TFRecordDatasetOpTest : public DatasetOpsTestBaseV2 {};
+class TFRecordDatasetOpTest : public DatasetOpsTestBase {};
 
 Status CreateTestFiles(const std::vector<tstring>& filenames,
                        const std::vector<std::vector<string>>& contents,

--- a/tensorflow/core/kernels/data/window_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/window_dataset_op_test.cc
@@ -72,7 +72,7 @@ class WindowDatasetParams : public DatasetParams {
   bool drop_remainder_;
 };
 
-class WindowDatasetOpTest : public DatasetOpsTestBaseV2 {};
+class WindowDatasetOpTest : public DatasetOpsTestBase {};
 
 // Test case 1: size=2, shift=2, stride=1, drop_remainder=false.
 WindowDatasetParams WindowDatasetParams1() {

--- a/tensorflow/core/kernels/data/zip_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/zip_dataset_op_test.cc
@@ -67,7 +67,7 @@ class ZipDatasetParams : public DatasetParams {
   int32 num_input_datasets_;
 };
 
-class ZipDatasetOpTest : public DatasetOpsTestBaseV2 {};
+class ZipDatasetOpTest : public DatasetOpsTestBase {};
 
 // Test case 1: the input datasets with same number of outputs.
 ZipDatasetParams ZipDatasetParams1() {


### PR DESCRIPTION
As all the tests for tf.data kernels have been switched to be using DatasetParams, this PR merges `DatasetOpsTestBaseV2` into `DatasetOpsTestBase` and cleans up the codes. Also, `AutoShardDatasetOpTest` is refactored. 