### PR TITLE
Fix bug in output ordering from interleave with num_parallel_calls

### DIFF
--- a/tensorflow/core/kernels/data/parallel_interleave_dataset_op.cc
+++ b/tensorflow/core/kernels/data/parallel_interleave_dataset_op.cc
@@ -261,7 +261,6 @@ class ParallelInterleaveDatasetOp::Dataset : public DatasetBase {
       if (num_parallel_calls_->value == model::kAutotune) {
         num_parallel_calls_->value = dataset()->cycle_length_;
       }
-      last_valid_current_element_ = dataset()->cycle_length_ - 1;
       ctx_ = std::make_unique<IteratorContext>(*ctx);
       TF_RETURN_IF_ERROR(
           dataset()->input_->MakeIterator(ctx, prefix(), &input_impl_));
@@ -437,10 +436,12 @@ class ParallelInterleaveDatasetOp::Dataset : public DatasetBase {
       if (!initial_elements_created_) {
         for (int i = 0; i < dataset()->cycle_length_; ++i) {
           current_elements_[i] = MakeElement();
-          if (current_elements_[i]) {
-            current_elements_[i]->cycle_index = i;
-            elements_to_process_.push_back(i);
+          if (!current_elements_[i]) {
+            break;
           }
+          current_elements_[i]->cycle_index = i;
+          elements_to_process_.push_back(i);
+          last_valid_current_element_ = i;
         }
         initial_elements_created_ = true;
       }
@@ -457,8 +458,9 @@ class ParallelInterleaveDatasetOp::Dataset : public DatasetBase {
     // Advances the position in the interleave cycle to the next cycle
     // element.
     void AdvanceToNextInCycle() EXCLUSIVE_LOCKS_REQUIRED(mu_) {
+      DCHECK_NE(last_valid_current_element_, -1);
       block_index_ = 0;
-      cycle_index_ = (cycle_index_ + 1) % dataset()->cycle_length_;
+      cycle_index_ = (cycle_index_ + 1) % (last_valid_current_element_ + 1);
     }
 
     // Advances the position in the interleave cycle by one.
@@ -494,6 +496,10 @@ class ParallelInterleaveDatasetOp::Dataset : public DatasetBase {
     bool ConsumeHelper(std::shared_ptr<Result>* result)
         EXCLUSIVE_LOCKS_REQUIRED(mu_) {
       while (true) {
+        if (last_valid_current_element_ == -1) {
+          // Reached end of input.
+          return true;
+        }
         for (int64 i = 0; i < (last_valid_current_element_ + 1); ++i) {
           int64 index = (cycle_index_ + i) % (last_valid_current_element_ + 1);
           if (current_elements_[index]) {
@@ -504,10 +510,7 @@ class ParallelInterleaveDatasetOp::Dataset : public DatasetBase {
             break;
           }
         }
-        if (!current_elements_[cycle_index_]) {
-          // Reached end of input.
-          return true;
-        }
+        DCHECK(current_elements_[cycle_index_]);
         std::shared_ptr<Element> element = current_elements_[cycle_index_];
         if (!element->results.empty()) {
           // We found a result.
@@ -551,9 +554,16 @@ class ParallelInterleaveDatasetOp::Dataset : public DatasetBase {
           while (last_valid_current_element_ >= 0 &&
                  !current_elements_[last_valid_current_element_]) {
             last_valid_current_element_--;
+            if (cycle_index_ > last_valid_current_element_) {
+              // We are about to move the cycle index below in
+              // AdvanceToNextInCycle().
+              cycle_index_ = last_valid_current_element_;
+            }
           }
         }
-        AdvanceToNextInCycle();
+        if (last_valid_current_element_ != -1) {
+          AdvanceToNextInCycle();
+        }
       }
     }
 
@@ -1152,7 +1162,7 @@ class ParallelInterleaveDatasetOp::Dataset : public DatasetBase {
     // TODO(aaudibert): Generalize this optimization by removing null elements
     // from `current_elements_`, e.g. by compacting the vector when x% of
     // its elements are null.
-    int64 last_valid_current_element_ GUARDED_BY(mu_);
+    int64 last_valid_current_element_ GUARDED_BY(mu_) = -1;
 
     const int per_iterator_prefetch_;
     const int future_elements_prefetch_;
@@ -1208,6 +1218,8 @@ class ParallelInterleaveDatasetOp::Dataset : public DatasetBase {
 
     // Identifies position in the interleave cycle.
     int64 block_index_ GUARDED_BY(mu_) = 0;
+    // It is an invariant that either `last_valid_current_element_ == -1` or
+    // `cycle_index_ <= last_valid_current_element_`.
     int64 cycle_index_ GUARDED_BY(mu_) = 0;
 
     // Elements of the current interleave cycle.

--- a/tensorflow/core/kernels/data/parallel_interleave_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/parallel_interleave_dataset_op_test.cc
@@ -364,6 +364,29 @@ ParallelInterleaveDatasetParams ParallelInterleaveDatasetParams10() {
       /*node_name=*/kNodeName);
 }
 
+ParallelInterleaveDatasetParams LongCycleDeteriministicParams() {
+  auto tensor_slice_dataset_params = TensorSliceDatasetParams(
+      /*components=*/{CreateTensor<tstring>(
+          TensorShape{3, 3, 1}, {"a", "b", "c", "d", "e", "f", "g", "h", "i"})},
+      /*node_name=*/"tensor_slice");
+  return ParallelInterleaveDatasetParams(
+      tensor_slice_dataset_params,
+      /*other_arguments=*/{},
+      /*cycle_length=*/11,
+      /*block_length=*/1,
+      /*num_parallel_calls=*/2,
+      /*func=*/
+      MakeTensorSliceDatasetFunc(
+          DataTypeVector({DT_STRING}),
+          std::vector<PartialTensorShape>({PartialTensorShape({1})})),
+      /*func_lib=*/{test::function::MakeTensorSliceDataset()},
+      /*type_arguments=*/{},
+      /*output_dtypes=*/{DT_STRING},
+      /*output_shapes=*/{PartialTensorShape({1})},
+      /*sloppy=*/false,
+      /*node_name=*/kNodeName);
+}
+
 // test case 11: cycle_length = 0, block_length = 1, num_parallel_calls = 2,
 // sloppy = true
 ParallelInterleaveDatasetParams
@@ -504,7 +527,14 @@ GetNextTestCases() {
            CreateTensors<tstring>(
                TensorShape{1},
                {{"a"}, {"b"}, {"c"}, {"d"}, {"e"}, {"f"}, {"g"}, {"h"}, {"i"}}),
-           /*compare_order=*/false}};
+           /*compare_order=*/false},
+          {/*dataset_params=*/
+           LongCycleDeteriministicParams(),
+           /*expected_outputs=*/
+           CreateTensors<tstring>(
+               TensorShape{1},
+               {{"a"}, {"d"}, {"g"}, {"b"}, {"e"}, {"h"}, {"c"}, {"f"}, {"i"}}),
+           /*compare_order=*/true}};
 }
 
 ITERATOR_GET_NEXT_TEST_P(ParallelInterleaveDatasetOpTest,


### PR DESCRIPTION
Before this fix, Dataset.interleave(..., num_parallel_calls=2) would result
in non-deterministic output order, even when
options.experimental_deterministic=True. The non-determinism is seen
when the cycle length of the interleave exceeds the number of input elements.

PiperOrigin-RevId: 279838573
Change-Id: I6dc94b071a8eeb269e24b192aa65be105022444c