### PR TITLE
Remove adding of /usr/bin to compiler paths

### DIFF
--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -1148,19 +1148,6 @@ def _create_local_cuda_repository(repository_ctx):
         host_compiler_prefix = repository_ctx.os.environ[_GCC_HOST_COMPILER_PREFIX].strip()
     cuda_defines["%{host_compiler_prefix}"] = host_compiler_prefix
 
-    # Bazel sets '-B/usr/bin' flag to workaround build errors on RHEL (see
-    # https://github.com/bazelbuild/bazel/issues/760).
-    # However, this stops our custom clang toolchain from picking the provided
-    # LLD linker, so we're only adding '-B/usr/bin' when using non-downloaded
-    # toolchain.
-    # TODO: when bazel stops adding '-B/usr/bin' by default, remove this
-    #       flag from the CROSSTOOL completely (see
-    #       https://github.com/bazelbuild/bazel/issues/5634)
-    if should_download_clang:
-        cuda_defines["%{linker_bin_path}"] = ""
-    else:
-        cuda_defines["%{linker_bin_path}"] = host_compiler_prefix
-
     cuda_defines["%{extra_no_canonical_prefixes_flags}"] = ""
     cuda_defines["%{unfiltered_compile_flags}"] = ""
     if is_cuda_clang:


### PR DESCRIPTION
As the underlying Bazel issue https://github.com/bazelbuild/bazel/issues/5634 is resolved, this code can (and should) go now

This allows for better compatibility on RHEL systems with CUDA.

See https://github.com/bazelbuild/bazel/commit/c6ec22f94faaf1320f576d5658a106483b2bf19f#diff-f6852ce579394c610a139a1f38783138L158

This has been in since Bazel 0.20 and should be picked for the next TF release