### PR TITLE
[INTEL MKL] parallel implementation of the resize nearest neighbor op

### DIFF
--- a/tensorflow/core/kernels/resize_nearest_neighbor_op.cc
+++ b/tensorflow/core/kernels/resize_nearest_neighbor_op.cc
@@ -165,12 +165,12 @@ struct ResizeNearestNeighbor<CPUDevice, T, half_pixel_centers, align_corners> {
       }
     };
     Eigen::Index N = batch_size * out_height * out_width;
-    const int input_bytes =
-        batch_size * in_height * in_width * channels * sizeof(T);
-    const int output_bytes = N * channels * sizeof(T);
+    const int input_bytes = channels * sizeof(T);
+    const int output_bytes = channels * sizeof(T);
     const int compute_cycles = (Eigen::TensorOpCost::ModCost<T>() * 2 +
-                                Eigen::TensorOpCost::DivCost<T>() * 5) *
-                               N;
+                                Eigen::TensorOpCost::DivCost<T>() * 3 +
+                                Eigen::TensorOpCost::AddCost<T>() * 2 +
+                                Eigen::TensorOpCost::MulCost<T>() * 2);
     const Eigen::TensorOpCost cost(input_bytes, output_bytes, compute_cycles);
     d.parallelFor(N, cost, ParallelResize);
     return true;

--- a/tensorflow/core/kernels/resize_nearest_neighbor_op.h
+++ b/tensorflow/core/kernels/resize_nearest_neighbor_op.h
@@ -16,6 +16,7 @@ limitations under the License.
 #ifndef TENSORFLOW_CORE_KERNELS_RESIZE_NEAREST_NEIGHBOR_OP_H_
 #define TENSORFLOW_CORE_KERNELS_RESIZE_NEAREST_NEIGHBOR_OP_H_
 
+#include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/tensor_types.h"
 #include "tensorflow/core/platform/types.h"
 
@@ -27,7 +28,8 @@ template <typename Device, typename T, bool half_pixel_centers,
 struct ResizeNearestNeighbor {
   bool operator()(const Device& d, typename TTypes<T, 4>::ConstTensor input,
                   const float height_scale, const float width_scale,
-                  typename TTypes<T, 4>::Tensor output);
+                  typename TTypes<T, 4>::Tensor output,
+                  OpKernelContext* context = NULL);
 };
 
 template <typename Device, typename T, bool half_pixel_centers,

--- a/tensorflow/core/kernels/resize_nearest_neighbor_op.h
+++ b/tensorflow/core/kernels/resize_nearest_neighbor_op.h
@@ -16,7 +16,6 @@ limitations under the License.
 #ifndef TENSORFLOW_CORE_KERNELS_RESIZE_NEAREST_NEIGHBOR_OP_H_
 #define TENSORFLOW_CORE_KERNELS_RESIZE_NEAREST_NEIGHBOR_OP_H_
 
-#include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/tensor_types.h"
 #include "tensorflow/core/platform/types.h"
 

--- a/tensorflow/core/kernels/resize_nearest_neighbor_op.h
+++ b/tensorflow/core/kernels/resize_nearest_neighbor_op.h
@@ -28,8 +28,7 @@ template <typename Device, typename T, bool half_pixel_centers,
 struct ResizeNearestNeighbor {
   bool operator()(const Device& d, typename TTypes<T, 4>::ConstTensor input,
                   const float height_scale, const float width_scale,
-                  typename TTypes<T, 4>::Tensor output,
-                  OpKernelContext* context = NULL);
+                  typename TTypes<T, 4>::Tensor output);
 };
 
 template <typename Device, typename T, bool half_pixel_centers,

--- a/tensorflow/core/kernels/resize_op_benchmark_test.cc
+++ b/tensorflow/core/kernels/resize_op_benchmark_test.cc
@@ -51,7 +51,7 @@ static Graph* BM_Resize(const char* algorithm, int batches, int width,
 BM_ResizeDev(cpu, ResizeNearestNeighbor, 10, 499, 499);
 BM_ResizeDev(cpu, ResizeBilinear, 10, 499, 499);
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 BM_ResizeDev(gpu, ResizeNearestNeighbor, 10, 499, 499);
 BM_ResizeDev(gpu, ResizeBilinear, 10, 499, 499);
 #endif

--- a/tensorflow/core/kernels/resize_op_benchmark_test.cc
+++ b/tensorflow/core/kernels/resize_op_benchmark_test.cc
@@ -49,9 +49,11 @@ static Graph* BM_Resize(const char* algorithm, int batches, int width,
   BENCHMARK(BM_Resize_##ALGORITHM##_##DEVICE##_##B##_##W##_##H)
 
 BM_ResizeDev(cpu, ResizeNearestNeighbor, 10, 499, 499);
-BM_ResizeDev(gpu, ResizeNearestNeighbor, 10, 499, 499);
-
 BM_ResizeDev(cpu, ResizeBilinear, 10, 499, 499);
+
+#if GOOGLE_CUDA
+BM_ResizeDev(gpu, ResizeNearestNeighbor, 10, 499, 499);
 BM_ResizeDev(gpu, ResizeBilinear, 10, 499, 499);
+#endif
 
 }  // namespace tensorflow


### PR DESCRIPTION
The origin resize_nearest_neighbor_op is running the resize operation in serial and here is the benchmark test result:
```
Executing tests from //tensorflow/core/kernels:resize_benchmark_test
-----------------------------------------------------------------------------
2019-11-12 11:50:12.127157: I tensorflow/core/platform/cpu_feature_guard.cc:142] Your CPU supports instructions that this TensorFlow binary was not compiled to use: SSE3 SSE4.1 SSE4.2 AVX AVX2 AVX512F FMA
Running main() from test_main.cc
Benchmark                                        Time(ns) Iterations
--------------------------------------------------------------------
BM_Resize_ResizeNearestNeighbor_cpu_10_499_499   48277810        100     154.7M items/s
BM_Resize_ResizeBilinear_cpu_10_499_499          39131850        100     190.9M items/s
```

Here we modified this operation into parallel implementation and here is the new benchmark test result:
```
Executing tests from //tensorflow/core/kernels:resize_benchmark_test
-----------------------------------------------------------------------------
2019-11-12 11:54:53.781602: I tensorflow/core/platform/cpu_feature_guard.cc:142] Your CPU supports instructions that this TensorFlow binary was not compiled to use: SSE3 SSE4.1 SSE4.2 AVX AVX2 AVX512F FMA
Running main() from test_main.cc
Benchmark                                        Time(ns) Iterations
--------------------------------------------------------------------
BM_Resize_ResizeNearestNeighbor_cpu_10_499_499    5076820        100     1471.4M items/s
BM_Resize_ResizeBilinear_cpu_10_499_499          38758780        100     192.7M items/s
```

Here we see almost **10x** performance improvement with this PR.