### PR TITLE
Add `all` support for autograph with dataset

### DIFF
--- a/tensorflow/python/autograph/operators/py_builtins_test.py
+++ b/tensorflow/python/autograph/operators/py_builtins_test.py
@@ -316,6 +316,29 @@ class PyBuiltinsTest(test.TestCase):
     with self.assertRaises(ValueError):
       py_builtins.any_(dataset_mixed)
 
+  def test_all(self):
+    self.assertEqual(py_builtins.all_([False, True, False]), False)
+    self.assertEqual(py_builtins.all_([True, True, True]), True)
+
+  def test_all_dataset(self):
+    dataset_1 = dataset_ops.DatasetV2.from_tensor_slices([False, True, False])
+    dataset_2 = dataset_ops.DatasetV2.from_tensor_slices([True, True, True])
+    self.assertEqual(self.evaluate(py_builtins.all_(dataset_1)), False)
+    self.assertEqual(self.evaluate(py_builtins.all_(dataset_2)), True)
+
+    dataset_3 = dataset_ops.DatasetV2.from_tensor_slices([0, 1, 2])
+    with self.assertRaises(ValueError):
+      py_builtins.all_(dataset_3)
+
+    dataset_4 = dataset_ops.DatasetV2.from_tensor_slices([False, True, False])
+    dataset_zipped = dataset_ops.DatasetV2.zip((dataset_4, dataset_4))
+    with self.assertRaises(ValueError):
+      py_builtins.all_(dataset_zipped)
+
+    dataset_mixed = dataset_ops.DatasetV2.zip((dataset_3, dataset_4))
+    with self.assertRaises(ValueError):
+      py_builtins.all_(dataset_mixed)
+
 
 if __name__ == '__main__':
   test.main()


### PR DESCRIPTION
This PR is a follow up to PR #34089. In PR #34089 `any`
support for autograph with dataset has been added.

This PR add `all` in a similar way.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>