### PR TITLE
Duplicating tf.keras.layers.Layer inputs to prevent "Graph disconnected" errors

### DIFF
--- a/tensorflow/python/keras/engine/base_layer.py
+++ b/tensorflow/python/keras/engine/base_layer.py
@@ -651,6 +651,10 @@ class Layer(module.Module):
       ValueError: if the layer's `call` method returns None (an invalid value).
     """
     call_context = base_layer_utils.call_context()
+
+    if isinstance(inputs, list):
+      inputs = inputs[:]
+
     input_list = nest.flatten(inputs)
 
     # We will attempt to build a TF graph if & only if all inputs are symbolic.

--- a/tensorflow/python/keras/layers/merge_test.py
+++ b/tensorflow/python/keras/layers/merge_test.py
@@ -189,6 +189,11 @@ class MergeLayersTest(keras_parameterized.TestCase):
                 concat_layer.compute_mask(
                     [i1, i2], [K.variable(x1), K.variable(x2)]))))
 
+    concat_list = [i1, i1]
+    concat_list += [concat_layer(concat_list)]
+    recursive_output = concat_layer(concat_list)
+    keras.models.Model([i1, i2], recursive_output)
+
     with self.assertRaisesRegexp(ValueError, '`mask` should be a list.'):
       concat_layer.compute_mask([i1, i2], x1)
     with self.assertRaisesRegexp(ValueError, '`inputs` should be a list.'):


### PR DESCRIPTION
To prevent disconnected graph errors, which can occur if the list input to (concatenate) layers is modified after calling them, as it a common approach to build certain types of network graphs, e.g. DenseNets.

Fixes #30355 and #32023. Similar to https://github.com/keras-team/keras/pull/6035 of standalone Keras.