### PR TITLE
[ROCm] Fix for the broken ROCm CSB.

### DIFF
--- a/tensorflow/core/nccl/BUILD
+++ b/tensorflow/core/nccl/BUILD
@@ -31,7 +31,6 @@ cc_library(
     copts = tf_copts(),
     deps = if_cuda([
         "@local_config_nccl//:nccl",
-        "//tensorflow/core/profiler/lib:traceme",
     ]) + if_rocm([
         "@local_config_rocm//rocm:rccl",
         "//tensorflow/core:gpu_runtime",
@@ -43,6 +42,7 @@ cc_library(
         "//tensorflow/core:gpu_headers_lib",
         "//tensorflow/core:lib",
         "//tensorflow/core:stream_executor",
+        "//tensorflow/core/profiler/lib:traceme",
     ]),
     alwayslink = 1,
 )

--- a/tensorflow/core/nccl/nccl_manager.cc
+++ b/tensorflow/core/nccl/nccl_manager.cc
@@ -21,9 +21,9 @@ limitations under the License.
 #include "tensorflow/core/lib/core/refcount.h"
 #include "tensorflow/core/lib/core/threadpool.h"
 #include "tensorflow/core/platform/env.h"
+#include "tensorflow/core/profiler/lib/traceme.h"
 #if GOOGLE_CUDA
 #include "tensorflow/core/platform/cuda.h"
-#include "tensorflow/core/profiler/lib/traceme.h"
 #elif TENSORFLOW_USE_ROCM
 #include "tensorflow/core/platform/rocm.h"
 #endif


### PR DESCRIPTION
The following commit breaks the --config=rocm build

https://github.com/tensorflow/tensorflow/commit/921003e1c4ff0421b34a3db7ddd338eb376d213f

The above commit adds `//tensorflow/core/profiler/lib:traceme` as a build dependency on the CUDA side but not on the ROCm side, leading to bazel errors during the ROCm build.
The "fix" is the to add the dependency on the ROCm side as well.

**update:**

Also added a commit to revert the following commit https://github.com/tensorflow/tensorflow/commit/22a97f1ef5a8b10c72ba1ec8b463f063c6e5f22d#diff-2455058fada3b63ffc514e7038321516

The reverted commit also attempts to fix the same error (being fixed by this PR), but fails to do so correctly. The reverted commit introduces compile errors of the form

```
    tensorflow/core/nccl/nccl_manager.cc: In member function 'void tensorflow::NcclManager::LoopKernelLaunches(tensorflow::NcclManager::NcclStream*)':
    tensorflow/core/nccl/nccl_manager.cc:689:9: error: 'profiler' has not been declared
             profiler::TraceMe trace_me("ncclAllReduce");
             ^
    tensorflow/core/nccl/nccl_manager.cc:718:9: error: 'profiler' has not been declared
             profiler::TraceMe trace_me("ncclBroadcast");
             ^
    tensorflow/core/nccl/nccl_manager.cc:729:9: error: 'profiler' has not been declared
             profiler::TraceMe trace_me("ncclReduce");
             ^
    ...
```


---------------------------------

/cc @chsigg @whchung 