### PR TITLE
fix debug_events_writer: avoid possible NULL pointer dereference

### DIFF
--- a/tensorflow/core/util/debug_events_writer.cc
+++ b/tensorflow/core/util/debug_events_writer.cc
@@ -306,7 +306,7 @@ void DebugEventsWriter::WriteSerializedExecutionDebugEvent(
       mu = &graph_execution_trace_buffer_mu_;
       break;
     default:
-      break;
+      return;
   }
 
   if (circular_buffer_size_ <= 0) {


### PR DESCRIPTION
```cpp
void DebugEventsWriter::WriteSerializedExecutionDebugEvent(
    const string& debug_event_str, DebugEventFileType type) {
  const std::unique_ptr<SingleDebugEventFileWriter>* writer = nullptr;
  std::deque<string>* buffer = nullptr;
  mutex* mu = nullptr;
  switch (type) {
    case EXECUTION:
      writer = &execution_writer_;
      buffer = &execution_buffer_;
      mu = &execution_buffer_mu_;
      break;
    case GRAPH_EXECUTION_TRACES:
      writer = &graph_execution_traces_writer_;
      buffer = &graph_execution_trace_buffer_;
      mu = &graph_execution_trace_buffer_mu_;
      break;
// 1. suppose default case was chosen
    default:
      break;
  }

  if (circular_buffer_size_ <= 0) {
    // No cyclic-buffer behavior.

// 2. null is passed as the this pointer to function operator->
    (*writer)->WriteSerializedDebugEvent(debug_event_str);
  } else {
    // Circular buffer behavior.
    mutex_lock l(*mu);

// 3. null is passed as the this pointer to function push_back
    buffer->push_back(debug_event_str);
    if (buffer->size() > circular_buffer_size_) {
      buffer->pop_front();
    }
  }
}
```