### PR TITLE
Updating metrics_export_meta_graph.pb for fixing //tensorflow/python:framework_meta_graph_test

### DIFF
--- a/tensorflow/python/framework/testdata/metrics_export_meta_graph.pb
+++ b/tensorflow/python/framework/testdata/metrics_export_meta_graph.pb
@@ -503,7 +503,8 @@ graph_def {
               size: 2
             }
           }
-          tensor_content: "\000\000\000\000\000\000\200?"
+          float_val: 0.
+          float_val: 1.
         }
       }
     }
@@ -567,7 +568,8 @@ graph_def {
               size: 2
             }
           }
-          tensor_content: "ff\206\300\232\231\021A"
+          float_val: -4.2
+          float_val: 9.1
         }
       }
     }
@@ -631,7 +633,8 @@ graph_def {
               size: 2
             }
           }
-          tensor_content: "\000\000\320@\000\000\000\000"
+          float_val: 6.5
+          float_val: 0.
         }
       }
     }
@@ -695,7 +698,8 @@ graph_def {
               size: 2
             }
           }
-          tensor_content: "\315\314L\300\000\000\200@"
+          float_val: -3.2
+          float_val: 0.
         }
       }
     }
@@ -1158,7 +1162,8 @@ graph_def {
               size: 2
             }
           }
-          tensor_content: "\000\000\000\000\001\000\000\000"
+          int_val: 0
+          int_val: 1
         }
       }
     }


### PR DESCRIPTION
The testdata in [metrics_export_meta_graph.pb](https://github.com/tensorflow/tensorflow/blob/v2.0.0/tensorflow/python/framework/testdata/metrics_export_meta_graph.pb#L506) is consisting of tensors serialized in little endian format. This causes //tensorflow/python:framework_meta_graph_test to fail on big endian. By replacing the tensor_content bytes as float_val/int_val the test passes on x86_64 and s390x architectures.
