### PR TITLE
[XLA] Enhancements to algebraic_simplifier

### DIFF
--- a/tensorflow/compiler/xla/service/algebraic_simplifier.cc
+++ b/tensorflow/compiler/xla/service/algebraic_simplifier.cc
@@ -80,8 +80,21 @@ bool IsAll(const HloInstruction* op, int8 value) {
   }
 }
 
+bool IsAnyOperandComplex(const HloInstruction* hlo) {
+  for (auto operand : hlo->operands()) {
+    if (ShapeUtil::ElementIsComplex(operand->shape())) {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool IsPositive(const HloInstruction* hlo,
                 const AlgebraicSimplifierOptions& options) {
+  // Utility only handles real types.
+  if (IsAnyOperandComplex(hlo)) {
+    return false;
+  }
   switch (hlo->opcode()) {
     case HloOpcode::kGetTupleElement: {
       const HloInstruction* gte_operand = hlo->operand(0);
@@ -113,6 +126,10 @@ bool IsPositive(const HloInstruction* hlo,
 
 bool IsNonNegative(const HloInstruction* hlo,
                    const AlgebraicSimplifierOptions& options) {
+  // Utility only handles real types.
+  if (IsAnyOperandComplex(hlo)) {
+    return false;
+  }
   switch (hlo->opcode()) {
     case HloOpcode::kMultiply: {
       return hlo->operand(0) == hlo->operand(1);

--- a/tensorflow/compiler/xla/service/algebraic_simplifier.h
+++ b/tensorflow/compiler/xla/service/algebraic_simplifier.h
@@ -108,6 +108,14 @@ class AlgebraicSimplifierOptions {
   }
 
  private:
+  // Metadata struct can be used to store any metadata information encapsulated
+  // with the AlgebraicSimplierOptions that can be later used in an
+  // AlgebraicSimplifier pass. For example,
+  // cudnn_batchnorm_forward_training_metadata can be used to store the name of
+  // a custom call. If the custom call is
+  // __cudnn$batchNormalizationForwardTraining, the output with index 2 is
+  // guaranteed to be postive. This property has been used to recursively
+  // determine if the operand of an instruction is always positive.
   struct Metadata {
     string cudnn_batchnorm_forward_training_metadata{""};
     Metadata() {}

--- a/tensorflow/compiler/xla/service/algebraic_simplifier.h
+++ b/tensorflow/compiler/xla/service/algebraic_simplifier.h
@@ -99,7 +99,19 @@ class AlgebraicSimplifierOptions {
 
   int64 very_small_gather_size() const { return very_small_gather_size_; }
 
+  void set_cudnn_batchnorm_forward_training_metadata(const string& c) {
+    metadata_.cudnn_batchnorm_forward_training_metadata = c;
+  }
+
+  const string& get_cudnn_batchnorm_forward_training_metadata() const {
+    return metadata_.cudnn_batchnorm_forward_training_metadata;
+  }
+
  private:
+  struct Metadata {
+    string cudnn_batchnorm_forward_training_metadata{""};
+    Metadata() {}
+  };
   ReshapeIsBitcastCallback reshape_is_bitcast_callback_;
   bool is_layout_sensitive_{false};
   bool enable_dot_strength_reduction_{true};
@@ -107,6 +119,7 @@ class AlgebraicSimplifierOptions {
   bool enable_conv_simplification_{true};
   bool enable_window_reduce_to_reduce_replacement_{true};
   int64 very_small_gather_size_{4};
+  Metadata metadata_;
 };
 
 // A pass which performs algebraic simplifications.

--- a/tensorflow/compiler/xla/service/algebraic_simplifier_test.cc
+++ b/tensorflow/compiler/xla/service/algebraic_simplifier_test.cc
@@ -5983,7 +5983,7 @@ TEST_F(AlgebraicSimplifierTest, AbsEliminationBatchnormTraining) {
   default_options_.set_cudnn_batchnorm_forward_training_metadata(
       "__cudnn$batchNormalizationForwardTraining");
   ASSERT_TRUE(AlgebraicSimplifier(default_options_).Run(m.get()).ValueOrDie());
-  // Verify that the graph build do not have abs node.
+  // Verify that the module doesn't have any abs node.
   EXPECT_EQ(FindInstruction(m.get(), HloOpcode::kAbs), nullptr);
   EXPECT_EQ(m->entry_computation()->root_instruction()->operand(2)->opcode(),
             HloOpcode::kGetTupleElement);
@@ -6042,8 +6042,8 @@ TEST_F(AlgebraicSimplifierTest, AbsEliminationPower2) {
   )";
   TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kModuleStr));
   ASSERT_TRUE(AlgebraicSimplifier(default_options_).Run(m.get()).ValueOrDie());
-  // Pow(A, 2) gets transformed to A*A, hence the final pattern transform is
-  // Abs(Power(A, 2)) => A*A.
+  // Pow(A, 2) is transformed to AA. As a result, Abs(Power(A, 2)) is
+  // transformed to AA.
   EXPECT_THAT(m->entry_computation()->root_instruction(),
               GmockMatch(m::Multiply(m::Parameter(0), m::Parameter(0))));
 }

--- a/tensorflow/compiler/xla/service/algebraic_simplifier_test.cc
+++ b/tensorflow/compiler/xla/service/algebraic_simplifier_test.cc
@@ -5849,7 +5849,7 @@ TEST_F(AlgebraicSimplifierTest, RsqrtOfRPower) {
   default_options_.set_cudnn_batchnorm_forward_training_metadata(
       "__cudnn$batchNormalizationForwardTraining");
   ASSERT_TRUE(AlgebraicSimplifier(default_options_).Run(m.get()).ValueOrDie());
-  // Expected transformation: rsqrt(power(gte.2,-2)) -> abs(gte.2)
+  // Expect transformation: rsqrt(power(gte.2,-2)) -> abs(gte.2)
   EXPECT_EQ(FindInstruction(m.get(), HloOpcode::kPower), nullptr);
   EXPECT_EQ(FindInstruction(m.get(), HloOpcode::kRsqrt), nullptr);
   auto computation = m->entry_computation();
@@ -5884,7 +5884,7 @@ TEST_F(AlgebraicSimplifierTest, RsqrtDivide) {
   default_options_.set_cudnn_batchnorm_forward_training_metadata(
       "__cudnn$batchNormalizationForwardTraining");
   ASSERT_TRUE(AlgebraicSimplifier(default_options_).Run(m.get()).ValueOrDie());
-  // Expected transformation: rsqrt(divide(1,gte.2)) -> sqrt(gte.2)
+  // Expect transformation: rsqrt(divide(1,gte.2)) -> sqrt(gte.2)
   EXPECT_EQ(FindInstruction(m.get(), HloOpcode::kDivide), nullptr);
   EXPECT_EQ(FindInstruction(m.get(), HloOpcode::kRsqrt), nullptr);
   auto computation = m->entry_computation();
@@ -5918,7 +5918,7 @@ TEST_F(AlgebraicSimplifierTest, MultiplySelfRsqrt) {
       "__cudnn$batchNormalizationForwardTraining");
   ASSERT_TRUE(AlgebraicSimplifier(default_options_).Run(m.get()).ValueOrDie());
 
-  // Expected transformation: multiply(rsqrt(gte.2), rsqrt(gte.2)) -> divide(1,
+  // Expect transformation: multiply(rsqrt(gte.2), rsqrt(gte.2)) -> divide(1,
   // gte.2)
   EXPECT_EQ(FindInstruction(m.get(), HloOpcode::kMultiply), nullptr);
   EXPECT_EQ(FindInstruction(m.get(), HloOpcode::kRsqrt), nullptr);

--- a/tensorflow/compiler/xla/service/gpu/nvptx_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/nvptx_compiler.cc
@@ -31,6 +31,7 @@ limitations under the License.
 #include "tensorflow/compiler/xla/service/gpu/gpu_conv_padding_legalization.h"
 #include "tensorflow/compiler/xla/service/gpu/gpu_conv_rewriter.h"
 #include "tensorflow/compiler/xla/service/gpu/gpu_layout_assignment.h"
+#include "tensorflow/compiler/xla/service/gpu/ir_emission_utils.h"
 #include "tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.h"
 #include "tensorflow/compiler/xla/service/gpu/stream_executor_util.h"
 #include "tensorflow/compiler/xla/service/gpu/target_constants.h"
@@ -131,6 +132,8 @@ Status NVPTXCompiler::OptimizeHloConvolutionCanonicalization(
                                           /*allow_mixed_precision=*/false);
 
     AlgebraicSimplifierOptions options;
+    options.set_cudnn_batchnorm_forward_training_metadata(
+        kCudnnBatchNormForwardTrainingCallTarget);
     pass.AddPass<AlgebraicSimplifier>(options);
   }
 

--- a/tensorflow/compiler/xla/tests/hlo_test_base.cc
+++ b/tensorflow/compiler/xla/tests/hlo_test_base.cc
@@ -501,6 +501,19 @@ HloInstruction* HloTestBase::FindInstruction(HloModule* module,
   return nullptr;
 }
 
+HloInstruction* HloTestBase::FindInstruction(HloModule* module,
+                                             HloOpcode opcode) {
+  for (const HloComputation* c : module->computations()) {
+    auto instructions = c->instructions();
+    auto it = absl::c_find_if(
+        instructions, [&](HloInstruction* i) { return i->opcode() == opcode; });
+    if (it != instructions.end()) {
+      return *it;
+    }
+  }
+  return nullptr;
+}
+
 Backend& HloTestBase::backend() { return test_runner_.backend(); }
 
 /* static */

--- a/tensorflow/compiler/xla/tests/hlo_test_base.h
+++ b/tensorflow/compiler/xla/tests/hlo_test_base.h
@@ -274,6 +274,7 @@ class HloTestBase : public ::testing::Test {
   // inspect a particular computation or instruction.
   HloComputation* FindComputation(HloModule* module, absl::string_view name);
   HloInstruction* FindInstruction(HloModule* module, absl::string_view name);
+  HloInstruction* FindInstruction(HloModule* module, HloOpcode opcode);
 
   // Return an HLO verifier constructed for the test backend.
   HloVerifier& verifier() const { return *hlo_verifier_; }

--- a/tensorflow/compiler/xla/tests/hlo_test_base.h
+++ b/tensorflow/compiler/xla/tests/hlo_test_base.h
@@ -274,6 +274,7 @@ class HloTestBase : public ::testing::Test {
   // inspect a particular computation or instruction.
   HloComputation* FindComputation(HloModule* module, absl::string_view name);
   HloInstruction* FindInstruction(HloModule* module, absl::string_view name);
+  // Gets the instruction from the given module with the given opcode.
   HloInstruction* FindInstruction(HloModule* module, HloOpcode opcode);
 
   // Return an HLO verifier constructed for the test backend.


### PR DESCRIPTION
Motivation: algebraic simplification => rsqrt(Inv(pow^2(rsqrt(pow^-2(x))))) = |x| => x
This pattern found in one of the consumers of BatchNormForwardTraining. The producer of this pattern is actually the inverse sqrt of variance+epsilon which is always positive. Encoded this condition along with a few others when handling the transform |x| = x.

I had been working on mobilenet performance on the batchnorm issue(enabling fp16 cudnn batchnorm thunk to half kernels) which lead me to this optimization opportunity. With this change the graph is cleaner and also avoids having a multioutput fused kernel. There are quite a few instances of this pattern occurring in the graph. The gains with this optimization is ~1-2% for mobilenet.

This PR adds cases to HandleRsqrt, HandleSqrt, HandleMultiply (pow^2 gets converted to multiply) and HandleAbs. HandleAbs does the transform |x|=x when x is positive.

<img width="1680" alt="Screen Shot 2019-11-14 at 11 42 03 AM" src="https://user-images.githubusercontent.com/42984676/68891150-26625280-06d5-11ea-894f-092f30400b18.png">
