### PR TITLE
2.1-RC0 cherry-pick request: [tf.data] iterator life cycle management bug fix

### DIFF
--- a/tensorflow/python/data/ops/iterator_ops.py
+++ b/tensorflow/python/data/ops/iterator_ops.py
@@ -585,11 +585,6 @@ class OwnedIterator(trackable.Trackable, composite_tensor.CompositeTensor):
       self._flat_output_shapes = structure.get_flat_tensor_shapes(
           self._element_spec)
       self._iterator_resource, self._deleter = components
-      # Delete the resource when this object is deleted
-      self._resource_deleter = IteratorResourceDeleter(
-          handle=self._iterator_resource,
-          device=self._device,
-          deleter=self._deleter)
     else:
       if (components is not None or element_spec is not None):
         raise ValueError(error_message)

--- a/tensorflow/python/data/ops/multi_device_iterator_ops.py
+++ b/tensorflow/python/data/ops/multi_device_iterator_ops.py
@@ -425,7 +425,7 @@ class MultiDeviceIteratorSpec(type_spec.TypeSpec):
   def _component_specs(self):
     specs = [
         tensor_spec.TensorSpec([], dtypes.resource),
-        tensor_spec.TensorSpec([], dtypes.scalar)
+        tensor_spec.TensorSpec([], dtypes.variant)
     ]
     for _ in range(len(self._devices)):
       specs.append(iterator_ops.IteratorSpec(self._element_spec))
@@ -565,11 +565,11 @@ class OwnedMultiDeviceIterator(composite_tensor.CompositeTensor):
           self._device_iterators.append(iterator)
           iterator_handles.append(iterator._iterator_resource)  # pylint: disable=protected-access
 
-    self._resource_deleter = MultiDeviceIteratorResourceDeleter(
-        multi_device_iterator=self._multi_device_iterator_resource,
-        iterators=iterator_handles,
-        device=self._source_device,
-        deleter=self._deleter)
+      self._resource_deleter = MultiDeviceIteratorResourceDeleter(
+          multi_device_iterator=self._multi_device_iterator_resource,
+          iterators=iterator_handles,
+          device=self._source_device,
+          deleter=self._deleter)
 
   def get_next(self, device=None):
     """Returns the next element given a `device`, else returns all in a list."""


### PR DESCRIPTION
OwnedIterators and OwnedMultiDeviceIterators get created using their components at least twice during function tracing. We don't want to run the deleter in those cases as they are just referring to the original resource and not creating a new one. So we just create the deleter the first time.

PiperOrigin-RevId: 280071920
Change-Id: I266ac500246354e6e4d6145835c4f90926ec5715