### PR TITLE
Remove clone with new values for saving distributed variables

### DIFF
--- a/tensorflow/python/distribute/values.py
+++ b/tensorflow/python/distribute/values.py
@@ -783,9 +783,6 @@ class DistributedVariable(DistributedDelegate, variables_lib.Variable):
     """Pass resource_variable_ops.is_resource_variable check."""
     pass
 
-  def _clone_with_new_values(self, new_values):
-    raise NotImplementedError("Must be implemented in descendents.")
-
 
 ops.register_dense_tensor_like_type(DistributedVariable)
 
@@ -1167,10 +1164,6 @@ class MirroredVariable(DistributedVariable, Mirrored):
     return ops.convert_to_tensor(
         self.get(), dtype=dtype, name=name, as_ref=as_ref)
 
-  def _clone_with_new_values(self, new_values):
-    return type(self)(self._distribute_strategy, self._device_map, new_values,
-                      self._aggregation, logical_device=self._logical_device)
-
 
 # Register a conversion function which reads the value of the variable,
 # allowing instances of the class to be used as tensors.
@@ -1371,10 +1364,6 @@ class SyncOnReadVariable(DistributedVariable):
     """Converts a variable to a tensor."""
     return ops.convert_to_tensor(
         self.get(), dtype=dtype, name=name, as_ref=as_ref)
-
-  def _clone_with_new_values(self, new_values):
-    return type(self)(self._distribute_strategy, self._device_map, new_values,
-                      self._aggregation, logical_device=self._logical_device)
 
 
 # Register a conversion function for SyncOnReadVariable which allows as_ref to

--- a/tensorflow/python/keras/mixed_precision/experimental/autocast_variable.py
+++ b/tensorflow/python/keras/mixed_precision/experimental/autocast_variable.py
@@ -345,23 +345,6 @@ def create_autocast_variable(variable):
   class AutoCastDistributedVariable(AutoCastVariable, variable.__class__):
     """An AutoCastVariable that also subclasses from DistributedVariable."""
 
-    def __init__(self, maybe_variable, *args, **kwargs):
-      if not args and not kwargs:
-        # The common case: We call the super constructor with a single argument,
-        # which is a variable.
-        super(AutoCastDistributedVariable, self).__init__(maybe_variable)
-      else:
-        # This 'else' branch is needed, as distribution strategies sometimes
-        # clone a distributed variable by doing the following:
-        #
-        #    var = type(var)(var._distribute_strategy, var._device_map, ...)
-        #
-        # In this case, `maybe_variable` will instead be a distribution
-        # strategy. We create the DistributedVariable before wrapping it.
-        distribution_strategy = maybe_variable
-        inner_var = variable.__class__(distribution_strategy, *args, **kwargs)
-        super(AutoCastDistributedVariable, self).__init__(inner_var)
-
     def __repr__(self):
       # pylint: disable=missing-format-attribute
       return ('<AutoCastDistributedVariable dtype={v.dtype.name} '


### PR DESCRIPTION
This PR removes the unused `_clone_with_new_values` method of distributed variables and allows us to simplify `AutoCastDistributedVariable`.

**Related Changes**
- 6801a4b2fbc3cbe6bbfde2a82c7ed17d8997ed9f introduced `_clone_with_new_values` which calls `type(var)(var._distribute_strategy, var._device_map, ...)` in order to handle saving of distributed variables
- Therefor c3300a21cc3c136741e3c020169ff904c58ca4bf needed to overwrite `AutoCastDistributedVariable.__init__` in order to handle this case
- Since a3fd013fe9df291c6a461001a4570f5ab15102d1 distribute variables go through the resource variable code path for saving which and doesn't rely on `_clone_with_new_values` anymore
- Thus `_clone_with_new_values` is not used anywhere else in the code base and is a private method so it can be safely removed
- As far as I can tell the `type(var)(var._distribute_strategy, var._device_map, ...)` pattern is not used anywhere else in the code which allows us to cleanup `AutoCastDistributedVariable` if I am not missing something. This would allow us to further simplify `AutoCastVariable` in the future or allow us to get rid of the `create_autocast_variable` helper.


/cc @guptapriya @reedwm @rchao 