### PR TITLE
Enable GPUNMS v3 and v4

### DIFF
--- a/tensorflow/core/kernels/non_max_suppression_op.cu.cc
+++ b/tensorflow/core/kernels/non_max_suppression_op.cu.cc
@@ -743,23 +743,23 @@ REGISTER_KERNEL_BUILDER(Name("NonMaxSuppressionV2")
                         NonMaxSuppressionV2GPUOp);
 
 // TODO(laigd): enable once b/141559125 is fixed.
-// REGISTER_KERNEL_BUILDER(Name("NonMaxSuppressionV3")
-//                             .TypeConstraint<float>("T")
-//                             .Device(DEVICE_GPU)
-//                             .HostMemory("iou_threshold")
-//                             .HostMemory("max_output_size")
-//                             .HostMemory("score_threshold"),
-//                         NonMaxSuppressionV3GPUOp);
+REGISTER_KERNEL_BUILDER(Name("NonMaxSuppressionV3")
+                            .TypeConstraint<float>("T")
+                            .Device(DEVICE_GPU)
+                            .HostMemory("iou_threshold")
+                            .HostMemory("max_output_size")
+                            .HostMemory("score_threshold"),
+                        NonMaxSuppressionV3GPUOp);
 
 // TODO(b/143610288): this op tries to allocate 4GB of memory for the mask for
 // some model and cause OOM.
-// REGISTER_KERNEL_BUILDER(Name("NonMaxSuppressionV4")
-//                             .TypeConstraint<float>("T")
-//                             .Device(DEVICE_GPU)
-//                             .HostMemory("iou_threshold")
-//                             .HostMemory("max_output_size")
-//                             .HostMemory("score_threshold"),
-//                         NonMaxSuppressionV4GPUOp);
+REGISTER_KERNEL_BUILDER(Name("NonMaxSuppressionV4")
+                            .TypeConstraint<float>("T")
+                            .Device(DEVICE_GPU)
+                            .HostMemory("iou_threshold")
+                            .HostMemory("max_output_size")
+                            .HostMemory("score_threshold"),
+                        NonMaxSuppressionV4GPUOp);
 
 }  // namespace tensorflow
 #endif


### PR DESCRIPTION
This PR enables GPU implementation for NonMaxSuppresion ops v3 and v4 which was disabled due to high memory utilization at extremely large input counts (~8GB for 256000 boxes). Op has modest memory requirements for most models having about O(10k) inputs.