### PR TITLE
Add `abs` builtin support for dataset in autograph

### DIFF
--- a/tensorflow/python/autograph/operators/py_builtins.py
+++ b/tensorflow/python/autograph/operators/py_builtins.py
@@ -151,11 +151,17 @@ def super_in_original_context(f, args, caller_fn_scope):
 def abs_(x):
   if tensor_util.is_tensor(x):
     return _tf_abs(x)
+  if isinstance(x, dataset_ops.DatasetV2):
+    return _tf_dataset_abs(x)
   return _py_abs(x)
 
 
 def _tf_abs(x):
   return math_ops.abs(x)
+
+
+def _tf_dataset_abs(x):
+  return x.map(math_ops.abs)
 
 
 def _py_abs(x):

--- a/tensorflow/python/autograph/operators/py_builtins.py
+++ b/tensorflow/python/autograph/operators/py_builtins.py
@@ -161,7 +161,10 @@ def _tf_abs(x):
 
 
 def _tf_dataset_abs(x):
-  return x.map(math_ops.abs)
+  specs = nest.flatten(x.element_spec)
+  if len(specs) == 1:
+    return x.map(math_ops.abs)
+  return x.map(lambda *e: nest.map_structure(math_ops.abs, e))
 
 
 def _py_abs(x):

--- a/tensorflow/python/autograph/operators/py_builtins_test.py
+++ b/tensorflow/python/autograph/operators/py_builtins_test.py
@@ -52,6 +52,15 @@ class PyBuiltinsTest(test.TestCase):
       t = py_builtins.abs_(constant_op.constant([-1, 2, -3]))
       self.assertAllEqual(self.evaluate(t), [1, 2, 3])
 
+  def test_abs_dataset(self):
+    dataset = dataset_ops.DatasetV2.from_tensor_slices([-1, 2, 3])
+    dataset = py_builtins.abs_(dataset)
+    iterator = dataset_ops.make_one_shot_iterator(dataset)
+    with self.cached_session() as sess:
+      self.assertAllEqual(self.evaluate(iterator.get_next()), 1)
+      self.assertAllEqual(self.evaluate(iterator.get_next()), 2)
+      self.assertAllEqual(self.evaluate(iterator.get_next()), 3)
+
   def test_float(self):
     self.assertEqual(py_builtins.float_(10), 10.0)
     self.assertEqual(py_builtins.float_('10.0'), 10.0)

--- a/tensorflow/python/autograph/operators/py_builtins_test.py
+++ b/tensorflow/python/autograph/operators/py_builtins_test.py
@@ -61,6 +61,30 @@ class PyBuiltinsTest(test.TestCase):
       self.assertAllEqual(self.evaluate(iterator.get_next()), 2)
       self.assertAllEqual(self.evaluate(iterator.get_next()), 3)
 
+  def test_abs_dataset_zipped(self):
+    dataset_1 = dataset_ops.DatasetV2.from_tensor_slices([-1, 2, 3])
+    dataset_2 = dataset_ops.DatasetV2.from_tensor_slices([1, -2, 3])
+    dataset = dataset_ops.DatasetV2.zip((dataset_1, dataset_2))
+    dataset = py_builtins.abs_(dataset)
+    iterator = dataset_ops.make_one_shot_iterator(dataset)
+    with self.cached_session() as sess:
+      self.assertAllEqual(self.evaluate(iterator.get_next()), (1, 1))
+      self.assertAllEqual(self.evaluate(iterator.get_next()), (2, 2))
+      self.assertAllEqual(self.evaluate(iterator.get_next()), (3, 3))
+
+  def test_abs_dataset_mixed(self):
+    dataset_1 = dataset_ops.DatasetV2.from_tensor_slices([-1, 2, 3])
+    dataset_2 = dataset_ops.DatasetV2.from_tensor_slices([1, -2, 3])
+    dataset_3 = dataset_ops.DatasetV2.from_tensor_slices([-1, -2, -3])
+    dataset_4 = dataset_ops.DatasetV2.zip((dataset_1, dataset_2))
+    dataset = dataset_ops.DatasetV2.zip((dataset_3, dataset_4))
+    dataset = py_builtins.abs_(dataset)
+    iterator = dataset_ops.make_one_shot_iterator(dataset)
+    with self.cached_session() as sess:
+      self.assertAllEqual(self.evaluate(iterator.get_next()), (1, (1, 1)))
+      self.assertAllEqual(self.evaluate(iterator.get_next()), (2, (2, 2)))
+      self.assertAllEqual(self.evaluate(iterator.get_next()), (3, (3, 3)))
+
   def test_float(self):
     self.assertEqual(py_builtins.float_(10), 10.0)
     self.assertEqual(py_builtins.float_('10.0'), 10.0)

--- a/tensorflow/python/autograph/operators/py_builtins_test.py
+++ b/tensorflow/python/autograph/operators/py_builtins_test.py
@@ -81,9 +81,10 @@ class PyBuiltinsTest(test.TestCase):
     dataset = py_builtins.abs_(dataset)
     iterator = dataset_ops.make_one_shot_iterator(dataset)
     with self.cached_session() as sess:
-      self.assertAllEqual(self.evaluate(iterator.get_next()), (1, (1, 1)))
-      self.assertAllEqual(self.evaluate(iterator.get_next()), (2, (2, 2)))
-      self.assertAllEqual(self.evaluate(iterator.get_next()), (3, (3, 3)))
+      for i in range(1, 4):
+        actual = self.evaluate(iterator.get_next())
+        self.assertAllEqual(actual[0], i)
+        self.assertAllEqual(actual[1], (i, i))
 
   def test_float(self):
     self.assertEqual(py_builtins.float_(10), 10.0)


### PR DESCRIPTION
This PR add `abs` builtin support for dataset in autograph.
Before this PR, some of the builtin ops in autograph already
support dataset (e.g., any, all, zip, filter, map).

Since `abs` could be considered as a straightforward
`map(abs)`, it might make sense to add `abs`
as the supported list of ops as well.


Note as dataset could consist of a structure, this PR adds
the structured dataset support for abs with autograph,
by using nest.map_structure if applicable.


Signed-off-by: Yong Tang <yong.tang.github@outlook.com>