### PR TITLE
Modified documentation for SparseCategoricalCrossentropy

### DIFF
--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -490,8 +490,8 @@ class SparseCategoricalCrossentropy(LossFunctionWrapper):
   cce = tf.keras.losses.SparseCategoricalCrossentropy()
   loss = cce(
     tf.convert_to_tensor([0, 1, 2]),
-    tf.convert_to_tensor([[.9, .05, .05], [.5, .89, .6], [.05, .01, .94]]))
-  print('Loss: ', loss.numpy())  # Loss: 0.3239
+    tf.convert_to_tensor([[.9, .05, .05], [.05, .89, .06], [.05, .01, .94]]))
+  print('Loss: ', loss.numpy())  # Loss: 0.09458992
   ```
 
   Usage with the `compile` API:


### PR DESCRIPTION
The documentation example for SparseCategoricalCrossentropy is mathematically inconsistent with a parallel example given for CategoricalCrossentropy and also is confusing.  In particular the second element in the original SparseCategoricalCrossentropy example function call has component given by [.5, .89, .6] which is not normalized to be a probability (i.e. doesn't sum to 1.0).  I modified it to be [.05, .89, .06] which does sum to 1.0 and also recomputed the loss to be 0.09458992, preserving all the precision from the function call.  I hope this helps clarify things for users.  Thanks.