### PR TITLE
Updated typo (?) on documentation for Attention layer

### DIFF
--- a/tensorflow/python/keras/layers/dense_attention.py
+++ b/tensorflow/python/keras/layers/dense_attention.py
@@ -365,7 +365,7 @@ class AdditiveAttention(BaseDenseAttention):
   # Query embeddings of shape [batch_size, Tq, dimension].
   query_embeddings = token_embedding(query_input)
   # Value embeddings of shape [batch_size, Tv, dimension].
-  value_embeddings = token_embedding(query_input)
+  value_embeddings = token_embedding(value_input)
 
   # CNN layer.
   cnn_layer = tf.keras.layers.Conv1D(


### PR DESCRIPTION
Isn't value_input should be used instead query_input in value_embeddings? It feels like a typo error?