### PR TITLE
Implement Tell method of SnappyInputBuffer class.

### DIFF
--- a/tensorflow/core/lib/io/snappy/snappy_buffers_test.cc
+++ b/tensorflow/core/lib/io/snappy/snappy_buffers_test.cc
@@ -134,6 +134,50 @@ Status TestMultipleWrites(size_t compress_input_buf_size,
   return Status::OK();
 }
 
+void TestTell(size_t compress_input_buf_size,
+              size_t compress_output_buf_size,
+              size_t uncompress_input_buf_size,
+              size_t uncompress_output_buf_size,
+              int num_copies = 1) {
+  Env* env = Env::Default();
+  string fname = testing::TmpDir() + "/snappy_buffers_test";
+  string data = GenTestString(num_copies);
+
+  // Write the compressed file.
+  std::unique_ptr<WritableFile> file_writer;
+  TF_CHECK_OK(env->NewWritableFile(fname, &file_writer));
+  io::SnappyOutputBuffer out(file_writer.get(), compress_input_buf_size,
+                             compress_output_buf_size);
+  TF_CHECK_OK(out.Write(StringPiece(data)));
+  TF_CHECK_OK(out.Flush());
+  TF_CHECK_OK(file_writer->Flush());
+  TF_CHECK_OK(file_writer->Close());
+
+  tstring first_half(string(data, 0, data.size() / 2));
+  tstring bytes_read;
+  std::unique_ptr<RandomAccessFile> file_reader;
+  TF_CHECK_OK(env->NewRandomAccessFile(fname, &file_reader));
+  io::SnappyInputBuffer in(file_reader.get(), uncompress_input_buf_size,
+                           uncompress_output_buf_size);
+
+  // Read the first half of the uncompressed file and expect that Tell()
+  // returns half the uncompressed length of the file.
+  TF_CHECK_OK(in.ReadNBytes(first_half.size(), &bytes_read));
+  EXPECT_EQ(in.Tell(), first_half.size());
+  EXPECT_EQ(bytes_read, first_half);
+
+  // Read the remaining half of the uncompressed file and expect that
+  // Tell() points past the end of file.
+  tstring second_half;
+  TF_CHECK_OK(
+      in.ReadNBytes(data.size() - first_half.size(), &second_half));
+  EXPECT_EQ(in.Tell(), data.size());
+  bytes_read.append(second_half);
+
+  // Expect that the file is correctly read.
+  EXPECT_EQ(bytes_read, data);
+}
+
 static bool SnappyCompressionSupported() {
   string out;
   StringPiece in = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -184,6 +228,14 @@ TEST(SnappyBuffers, CorruptBlockLargeInputBuffer) {
   }
   CHECK_EQ(TestMultipleWrites(10000, 10000, 2000, 10000, 2, true, 1, true),
            errors::OutOfRange("EOF reached"));
+}
+
+TEST(SnappyBuffers, Tell) {
+  if (!SnappyCompressionSupported()) {
+    fprintf(stderr, "skipping compression tests\n");
+    return;
+  }
+  TestTell(10000, 10000, 2000, 10000, 2);
 }
 
 }  // namespace tensorflow

--- a/tensorflow/core/lib/io/snappy/snappy_inputbuffer.cc
+++ b/tensorflow/core/lib/io/snappy/snappy_inputbuffer.cc
@@ -27,7 +27,8 @@ SnappyInputBuffer::SnappyInputBuffer(
       output_buffer_capacity_(output_buffer_bytes),
       input_buffer_(new char[input_buffer_capacity_]),
       output_buffer_(new char[output_buffer_capacity_]),
-      next_in_(input_buffer_.get()) {}
+      next_in_(input_buffer_.get()),
+      bytes_read_(0) {}
 
 Status SnappyInputBuffer::ReadNBytes(int64 bytes_to_read, tstring* result) {
   result->clear();
@@ -47,17 +48,14 @@ Status SnappyInputBuffer::ReadNBytes(int64 bytes_to_read, tstring* result) {
   return Status::OK();
 }
 
-int64 SnappyInputBuffer::Tell() const {
-  // TODO(srbs): Implement this.
-  return -1;
-}
+int64 SnappyInputBuffer::Tell() const { return bytes_read_; }
 
 Status SnappyInputBuffer::Reset() {
   file_pos_ = 0;
   avail_in_ = 0;
   avail_out_ = 0;
   next_in_ = input_buffer_.get();
-
+  bytes_read_ = 0;
   return Status::OK();
 }
 
@@ -69,7 +67,7 @@ size_t SnappyInputBuffer::ReadBytesFromCache(size_t bytes_to_read,
     next_out_ += can_read_bytes;
     avail_out_ -= can_read_bytes;
   }
-
+  bytes_read_ += can_read_bytes;
   return can_read_bytes;
 }
 

--- a/tensorflow/core/lib/io/snappy/snappy_inputbuffer.h
+++ b/tensorflow/core/lib/io/snappy/snappy_inputbuffer.h
@@ -119,6 +119,9 @@ class SnappyInputBuffer : public InputStreamInterface {
   // Number of unread bytes bytes available at `next_out_` in `output_buffer_`.
   size_t avail_out_ = 0;
 
+  // Number of *uncompressed* bytes that have been read from this stream.
+  int64 bytes_read_;
+
   TF_DISALLOW_COPY_AND_ASSIGN(SnappyInputBuffer);
 };
 


### PR DESCRIPTION
Finish the [TODO](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/lib/io/snappy/snappy_inputbuffer.cc#L51) in `snappy_inputbuffer.cc`.
```cpp
int64 SnappyInputBuffer::Tell() const {
  // TODO(srbs): Implement this.
  return -1;
}
```
Then by involving `SnappyInputBuffer` like `ZlibInputStream`, Dataset operators can easily support snappy-compressed input.