### PR TITLE
MKL DNN:  Fixing mkl compilation failure for commit e154f44

### DIFF
--- a/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite.cc
+++ b/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite.cc
@@ -143,7 +143,7 @@ Status MklEagerOpRewrite::SetupNewOp(
     (*new_mkl_op)->SetDevice(orig_op->Device());
   } else {
     string device_name = orig_op->GetDeviceName();
-    (*new_mkl_op)->SetDeviceName(device_name);
+    (*new_mkl_op)->SetDeviceName(device_name.c_str());
   }
   return Status::OK();
 }


### PR DESCRIPTION
The commit e154f4431e8283272a3b67c5ad59a2c6d50a506f in Nov 15, 2019 causes a failure in the Intel MKL build. We fixed it here. 