### PR TITLE
Fix invalid shape issue in random.uniform

### DIFF
--- a/tensorflow/python/grappler/cluster_test.py
+++ b/tensorflow/python/grappler/cluster_test.py
@@ -81,9 +81,9 @@ class ClusterTest(test.TestCase):
         self.assertLessEqual(1, len(peak_mem))
         snapshot = peak_mem['/job:localhost/replica:0/task:0/device:CPU:0']
         peak_usage = snapshot[0]
-        self.assertEqual(52, peak_usage)
+        self.assertEqual(68, peak_usage)
         live_tensors = snapshot[1]
-        self.assertEqual(15, len(live_tensors))
+        self.assertEqual(19, len(live_tensors))
 
   def testVirtualCluster(self):
     with ops.Graph().as_default() as g:
@@ -108,7 +108,7 @@ class ClusterTest(test.TestCase):
           devices=[named_device])
       op_perfs, run_time, _ = grappler_cluster.MeasureCosts(grappler_item)
       self.assertEqual(run_time, 0.000545)
-      self.assertEqual(len(op_perfs), 15)
+      self.assertEqual(len(op_perfs), 19)
 
       estimated_perf = grappler_cluster.EstimatePerformance(named_device)
       self.assertEqual(7680.0, estimated_perf)

--- a/tensorflow/python/kernel_tests/random/random_ops_test.py
+++ b/tensorflow/python/kernel_tests/random/random_ops_test.py
@@ -23,6 +23,7 @@ from six.moves import xrange  # pylint: disable=redefined-builtin
 
 from tensorflow.python.eager import context
 from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import errors
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import random_seed
 from tensorflow.python.framework import test_util
@@ -412,6 +413,15 @@ class RandomUniformTest(RandomOpTestCommon):
             200,
             use_gpu=use_gpu,
             graph_seed=965)
+
+  def testUniformWithInvalidMaxMindShape(self):
+    # Test case for GitHub issue 34363.
+    with self.assertRaisesRegexp(
+        errors.InvalidArgumentError,
+        "is not compatible with expected shape"):
+      array = array_ops.zeros(shape=(1,))
+      random_ops.random_uniform(shape=(), minval=array)
+
 
 
 class RandomShapeTest(test.TestCase):

--- a/tensorflow/python/ops/matmul_benchmark_test.py
+++ b/tensorflow/python/ops/matmul_benchmark_test.py
@@ -80,9 +80,11 @@ class MatmulBenchmarkTest(googletest.TestCase):
       node { name: "random_uniform/min" op: "Const" device: \"""" + dev + """\" }
       node { name: "random_uniform/max" op: "Const" device: \"""" + dev + """\" }
       node { name: "random_uniform/RandomUniform" op: "RandomUniform" input: "random_uniform/shape" device: \"""" + dev + """\" }
-      node { name: "random_uniform/sub" op: "Sub" input: "random_uniform/max" input: "random_uniform/min" device: \"""" + dev + """\" }
+      node { name: "random_uniform/EnsureShape" op: "EnsureShape" input: "random_uniform/max" device: \"""" + dev + """\" }
+      node { name: "random_uniform/EnsureShape_1" op: "EnsureShape" input: "random_uniform/min" device: \"""" + dev + """\" }
+      node { name: "random_uniform/sub" op: "Sub" input: "random_uniform/EnsureShape" input: "random_uniform/EnsureShape_1" device: \"""" + dev + """\" }
       node { name: "random_uniform/mul" op: "Mul" input: "random_uniform/RandomUniform" input: "random_uniform/sub" device: \"""" + dev + """\" }
-      node { name: "random_uniform" op: "Add" input: "random_uniform/mul" input: "random_uniform/min" device: \"""" + dev + """\" }
+      node { name: "random_uniform" op: "Add" input: "random_uniform/mul" input: "random_uniform/EnsureShape_1" device: \"""" + dev + """\" }
       node { name: "Variable" op: "VariableV2" device: \"""" + dev + """\" }
       node { name: "Variable/Assign" op: "Assign" input: "Variable" input: "random_uniform" device: \"""" + dev + """\" }
       node { name: "Variable/read" op: "Identity" input: "Variable" device: \"""" + dev + """\" }
@@ -90,9 +92,11 @@ class MatmulBenchmarkTest(googletest.TestCase):
       node { name: "random_uniform_1/min" op: "Const" device: \"""" + dev + """\" }
       node { name: "random_uniform_1/max" op: "Const" device: \"""" + dev + """\" }
       node { name: "random_uniform_1/RandomUniform" op: "RandomUniform" input: "random_uniform_1/shape" device: \"""" + dev + """\" }
-      node { name: "random_uniform_1/sub" op: "Sub" input: "random_uniform_1/max" input: "random_uniform_1/min" device: \"""" + dev + """\" }
+      node { name: "random_uniform_1/EnsureShape" op: "EnsureShape" input: "random_uniform_1/max" device: \"""" + dev + """\" }
+      node { name: "random_uniform_1/EnsureShape_1" op: "EnsureShape" input: "random_uniform_1/min" device: \"""" + dev + """\" }
+      node { name: "random_uniform_1/sub" op: "Sub" input: "random_uniform_1/EnsureShape" input: "random_uniform_1/EnsureShape_1" device: \"""" + dev + """\" }
       node { name: "random_uniform_1/mul" op: "Mul" input: "random_uniform_1/RandomUniform" input: "random_uniform_1/sub" device: \"""" + dev + """\" }
-      node { name: "random_uniform_1" op: "Add" input: "random_uniform_1/mul" input: "random_uniform_1/min" device: \"""" + dev + """\" }
+      node { name: "random_uniform_1" op: "Add" input: "random_uniform_1/mul" input: "random_uniform_1/EnsureShape_1" device: \"""" + dev + """\" }
       node { name: "Variable_1" op: "VariableV2" device: \"""" + dev + """\" }
       node { name: "Variable_1/Assign" op: "Assign" input: "Variable_1" input: "random_uniform_1" device: \"""" + dev + """\" }
       node { name: "Variable_1/read" op: "Identity" input: "Variable_1" device: \"""" + dev + """\" }

--- a/tensorflow/python/ops/random_ops.py
+++ b/tensorflow/python/ops/random_ops.py
@@ -285,6 +285,8 @@ def random_uniform(shape,
           if not maxval_is_one:
             result = result * maxval
         else:
+          maxval = array_ops.ensure_shape(maxval, (), "max")
+          minval = array_ops.ensure_shape(minval, (), "min")
           result = math_ops.add(result * (maxval - minval), minval, name=name)
     else:
       minval = ops.convert_to_tensor(minval, dtype=dtype, name="min")
@@ -296,6 +298,8 @@ def random_uniform(shape,
       else:
         rnd = gen_random_ops.random_uniform(
             shape, dtype, seed=seed1, seed2=seed2)
+        maxval = array_ops.ensure_shape(maxval, (), "max")
+        minval = array_ops.ensure_shape(minval, (), "min")
         result = math_ops.add(rnd * (maxval - minval), minval, name=name)
     # TODO(b/132092188): C++ shape inference inside functional ops does not
     # cross FuncGraph boundaries since that information is only available in

--- a/tensorflow/python/ops/random_ops.py
+++ b/tensorflow/python/ops/random_ops.py
@@ -285,8 +285,8 @@ def random_uniform(shape,
           if not maxval_is_one:
             result = result * maxval
         else:
-          maxval = array_ops.ensure_shape(maxval, (), "max")
-          minval = array_ops.ensure_shape(minval, (), "min")
+          maxval = array_ops.ensure_shape(maxval, ())
+          minval = array_ops.ensure_shape(minval, ())
           result = math_ops.add(result * (maxval - minval), minval, name=name)
     else:
       minval = ops.convert_to_tensor(minval, dtype=dtype, name="min")
@@ -298,8 +298,8 @@ def random_uniform(shape,
       else:
         rnd = gen_random_ops.random_uniform(
             shape, dtype, seed=seed1, seed2=seed2)
-        maxval = array_ops.ensure_shape(maxval, (), "max")
-        minval = array_ops.ensure_shape(minval, (), "min")
+        maxval = array_ops.ensure_shape(maxval, ())
+        minval = array_ops.ensure_shape(minval, ())
         result = math_ops.add(rnd * (maxval - minval), minval, name=name)
     # TODO(b/132092188): C++ shape inference inside functional ops does not
     # cross FuncGraph boundaries since that information is only available in


### PR DESCRIPTION
This PR tries to address the issue raised in #34363 where
invalid shape passed to minval/maxval (expected to be 0-D)
does not raise an error.

The issue was that in most of the scenarios the shape was
checked inside the C++ kernel ops.

However, in one condition math_ops.add was used which will
implicitly do broadcast when necessarily.
This results in maxval/minval's shape getting carried.

This PR adds the shape check before math_ops.add, to make
sure the shape is guaranteed.

This PR fixes #34363.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>