### PR TITLE
Equality testing instead of identity

### DIFF
--- a/tensorflow/python/keras/layers/preprocessing/text_vectorization.py
+++ b/tensorflow/python/keras/layers/preprocessing/text_vectorization.py
@@ -549,7 +549,7 @@ class TextVectorization(CombinerPreprocessingLayer):
       self.set_vocabulary(updates[_VOCAB_NAME])
 
   def _preprocess(self, inputs):
-    if self._standardize is LOWER_AND_STRIP_PUNCTUATION:
+    if self._standardize == LOWER_AND_STRIP_PUNCTUATION:
       lowercase_inputs = gen_string_ops.string_lower(inputs)
       inputs = string_ops.regex_replace(lowercase_inputs, DEFAULT_STRIP_REGEX,
                                         "")
@@ -567,7 +567,7 @@ class TextVectorization(CombinerPreprocessingLayer):
       # so can be squeezed out. We do this here instead of after splitting for
       # performance reasons - it's more expensive to squeeze a ragged tensor.
       inputs = array_ops.squeeze(inputs, axis=1)
-      if self._split is SPLIT_ON_WHITESPACE:
+      if self._split == SPLIT_ON_WHITESPACE:
         # This treats multiple whitespaces as one whitespace, and strips leading
         # and trailing whitespace.
         inputs = ragged_string_ops.string_split_v2(inputs)

--- a/tensorflow/python/keras/layers/preprocessing/text_vectorization_test.py
+++ b/tensorflow/python/keras/layers/preprocessing/text_vectorization_test.py
@@ -476,7 +476,11 @@ class TextVectorizationPreprocessingTest(
 
     standardize = "".join(["lower", "_and_strip_punctuation"])
     layer = get_layer_class()(standardize=standardize)
-    output = layer(input_array).numpy()
+
+    input_data = keras.Input(shape=(1,), dtype=dtypes.string)
+    output_data = layer(input_data)
+    model = keras.Model(inputs=input_data, outputs=output_data)
+    output = model.predict(input_array)
 
     self.assertAllEqual(expected_output, output)
 
@@ -486,7 +490,11 @@ class TextVectorizationPreprocessingTest(
 
     split = "".join(["white", "space"])
     layer = get_layer_class()(split=split)
-    output = layer(input_array).numpy()
+
+    input_data = keras.Input(shape=(1,), dtype=dtypes.string)
+    output_data = layer(input_data)
+    model = keras.Model(inputs=input_data, outputs=output_data)
+    output = model.predict(input_array)
 
     self.assertAllEqual(expected_output, output)
 

--- a/tensorflow/python/keras/layers/preprocessing/text_vectorization_test.py
+++ b/tensorflow/python/keras/layers/preprocessing/text_vectorization_test.py
@@ -469,25 +469,25 @@ class TextVectorizationPreprocessingTest(
     layer._split = "unsuppported"
     with self.assertRaisesRegex(ValueError, ".*is not a supported splitting.*"):
       _ = layer(input_data)
-      
+
   def test_standardize_with_no_identical_argument(self):
     input_array = np.array([["hello world"]])
     expected_output = np.array([[1, 1]])
-    
+
     standardize = "".join(["lower", "_and_strip_punctuation"])
     layer = get_layer_class()(standardize=standardize)
     output = layer(input_array).numpy()
-    
+
     self.assertAllEqual(expected_output, output)
-  
+
   def test_splitting_with_no_identical_argument(self):
     input_array = np.array([["hello world"]])
     expected_output = np.array([[1, 1]])
-    
+
     split = "".join(["white", "space"])
     layer = get_layer_class()(split=split)
     output = layer(input_array).numpy()
-    
+
     self.assertAllEqual(expected_output, output)
 
 @keras_parameterized.run_all_keras_modes

--- a/tensorflow/python/keras/layers/preprocessing/text_vectorization_test.py
+++ b/tensorflow/python/keras/layers/preprocessing/text_vectorization_test.py
@@ -469,7 +469,26 @@ class TextVectorizationPreprocessingTest(
     layer._split = "unsuppported"
     with self.assertRaisesRegex(ValueError, ".*is not a supported splitting.*"):
       _ = layer(input_data)
-
+      
+  def test_standardize_with_no_identical_argument(self):
+    input_array = np.array([["hello world"]])
+    expected_output = np.array([[1,1]])
+    
+    standardize = "".join(["lower", "_and_strip_punctuation"])
+    layer = get_layer_class()(standardize=standardize)
+    output = layer(input_array).numpy()
+    
+    self.assertAllEqual(expected_output, output)
+  
+  def test_splitting_with_no_identical_argument(self):
+    input_array = np.array([["hello world"]])
+    expected_output = np.array([[1,1]])
+    
+    split = "".join(["white", "space"])
+    layer = get_layer_class()(split=split)
+    output = layer(input_array).numpy()
+    
+    self.assertAllEqual(expected_output, output)
 
 @keras_parameterized.run_all_keras_modes
 class TextVectorizationOutputTest(

--- a/tensorflow/python/keras/layers/preprocessing/text_vectorization_test.py
+++ b/tensorflow/python/keras/layers/preprocessing/text_vectorization_test.py
@@ -472,7 +472,7 @@ class TextVectorizationPreprocessingTest(
       
   def test_standardize_with_no_identical_argument(self):
     input_array = np.array([["hello world"]])
-    expected_output = np.array([[1,1]])
+    expected_output = np.array([[1, 1]])
     
     standardize = "".join(["lower", "_and_strip_punctuation"])
     layer = get_layer_class()(standardize=standardize)
@@ -482,7 +482,7 @@ class TextVectorizationPreprocessingTest(
   
   def test_splitting_with_no_identical_argument(self):
     input_array = np.array([["hello world"]])
-    expected_output = np.array([[1,1]])
+    expected_output = np.array([[1, 1]])
     
     split = "".join(["white", "space"])
     layer = get_layer_class()(split=split)


### PR DESCRIPTION
Identity comparing here will result in errors when the input string is created in non trivial ways. for example:

```
import tensorflow as tf
import tensorflow.keras as keras

standardize = ''.join(['lower', '_and_strip_punctuation'])
layer = keras.layers.experimental.preprocessing.TextVectorization(standardize=standardize)
layer(tf.constant([['hello'], ['hello world']]))

# ValueError: lower_and_strip_punctuation is not a supported standardization. TextVectorization supports the following options for `standardize`: None, 'lower_and_strip_punctuation', or a Callable.

split = ''.join('whitespace')
layer = keras.layers.experimental.preprocessing.TextVectorization(split=split)
layer(tf.constant([['hello'], ['hello world']]))

# ValueError: whitespace is not a supported splitting.TextVectorization supports the following options for `split`: None, 'whitespace', or a Callable.
```

This was tested with 

```
>>> tf.__version__
'2.1.0-dev20191119'
```

And Python3