### PR TITLE
Fixes issue #34398, equation from BTRS paper

### DIFF
--- a/tensorflow/core/kernels/random_binomial_op.cc
+++ b/tensorflow/core/kernels/random_binomial_op.cc
@@ -96,7 +96,7 @@ double stirling_approx_tail(double k) {
     return kTailValues[static_cast<int>(k)];
   }
   double kp1sq = (k + 1) * (k + 1);
-  return (1.0 / 12 - (1.0 / 360 + 1.0 / 1260 / kp1sq) / kp1sq) / (k + 1);
+  return (1.0 / 12 - (1.0 / 360 - 1.0 / 1260 / kp1sq) / kp1sq) / (k + 1);
 }
 
 // We use a transformation-rejection algorithm from


### PR DESCRIPTION
Fixed a equation of the TF implementation of BTRS [paper](https://epub.wu.ac.at/1242/1/document.pdf). Equation is available on page 7 of the paper