### PR TITLE
Avoid hard coding in getMajorVersionNumber

### DIFF
--- a/tensorflow/java/BUILD
+++ b/tensorflow/java/BUILD
@@ -5,6 +5,7 @@ load(":build_defs.bzl", "JAVACOPTS")
 load(":src/gen/gen_ops.bzl", "tf_java_op_gen_srcjar")
 load(
     "//tensorflow:tensorflow.bzl",
+    "VERSION",
     "tf_binary_additional_srcs",
     "tf_cc_binary",
     "tf_cc_test",
@@ -27,7 +28,24 @@ java_library(
     data = tf_binary_additional_srcs() + [":libtensorflow_jni"],
     javacopts = JAVACOPTS,
     plugins = [":processor"],
+    resources = [":java_resources"],
     visibility = ["//visibility:public"],
+)
+
+genrule(
+    name = "version-info",
+    outs = ["src/main/resources/tensorflow-version-info"],
+    cmd = "echo version=%s > $@" % VERSION,
+    output_to_bindir = 1,
+)
+
+filegroup(
+    name = "java_resources",
+    srcs = [":version-info"],
+    visibility = [
+        "//tensorflow/contrib/android:__pkg__",
+        "//tensorflow/java:__pkg__",
+    ],
 )
 
 # NOTE(ashankar): Rule to include the Java API in the Android Inference Library


### PR DESCRIPTION
fix #34256

Currently, `NativeLibrary.getMajorVersionNumber` return "1" by hard coding. It is very ugly and not friendly for tf-2.x. we can pack version info to jar, and load the version at runtime.