### PR TITLE
Make test tag filters behave as intended

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1155,29 +1155,33 @@ def system_specific_test_config(env):
   """Add default build and test flags required for TF tests to bazelrc."""
   write_to_bazelrc('test --flaky_test_attempts=3')
   write_to_bazelrc('test --test_size_filters=small,medium')
-  write_to_bazelrc(
-      'test --test_tag_filters=-benchmark-test,-no_oss,-oss_serial')
-  write_to_bazelrc('test --build_tag_filters=-benchmark-test,-no_oss')
+
+  # Each instance of --test_tag_filters or --build_tag_filters overrides all
+  # previous instances, so we need to build up a complete list and write a
+  # single list of filters for the .bazelrc file.
+
+  # Filters to use with both --test_tag_filters and --build_tag_filters
+  common_filters = ['-benchmark-test', '-no_oss']
+  # Additional filters for --test_tag_filters beyond those in common_filters
+  addl_test_filters = ['-oss_serial']
   if is_windows():
+    common_filters.append('-no_windows')
     if env.get('TF_NEED_CUDA', None) == '1':
-      write_to_bazelrc(
-          'test --test_tag_filters=-no_windows,-no_windows_gpu,-no_gpu')
-      write_to_bazelrc(
-          'test --build_tag_filters=-no_windows,-no_windows_gpu,-no_gpu')
+      common_filters += ['-no_windows_gpu', '-no_gpu']
     else:
-      write_to_bazelrc('test --test_tag_filters=-no_windows,-gpu')
-      write_to_bazelrc('test --build_tag_filters=-no_windows,-gpu')
+      common_filters.append('-gpu')
   elif is_macos():
-    write_to_bazelrc('test --test_tag_filters=-gpu,-nomac,-no_mac')
-    write_to_bazelrc('test --build_tag_filters=-gpu,-nomac,-no_mac')
+    common_filters += ['-gpu', '-nomac', '-no_mac']
   elif is_linux():
     if env.get('TF_NEED_CUDA', None) == '1':
-      write_to_bazelrc('test --test_tag_filters=-no_gpu')
-      write_to_bazelrc('test --build_tag_filters=-no_gpu')
+      common_filters.append('-no_gpu')
       write_to_bazelrc('test --test_env=LD_LIBRARY_PATH')
     else:
-      write_to_bazelrc('test --test_tag_filters=-gpu')
-      write_to_bazelrc('test --build_tag_filters=-gpu')
+      common_filters.append('-gpu')
+  write_to_bazelrc('test --test_tag_filters=%s'
+                   % ','.join(common_filters + addl_test_filters))
+  write_to_bazelrc('test --build_tag_filters=%s'
+                   % ','.join(common_filters))
 
 
 def set_system_libs_flag(environ_cp):

--- a/configure.py
+++ b/configure.py
@@ -1161,27 +1161,28 @@ def system_specific_test_config(env):
   # single list of filters for the .bazelrc file.
 
   # Filters to use with both --test_tag_filters and --build_tag_filters
-  common_filters = ['-benchmark-test', '-no_oss']
-  # Additional filters for --test_tag_filters beyond those in common_filters
-  addl_test_filters = ['-oss_serial']
+  test_and_build_filters = ['-benchmark-test', '-no_oss']
+  # Additional filters for --test_tag_filters beyond those in
+  # test_and_build_filters
+  test_only_filters = ['-oss_serial']
   if is_windows():
-    common_filters.append('-no_windows')
+    test_and_build_filters.append('-no_windows')
     if env.get('TF_NEED_CUDA', None) == '1':
-      common_filters += ['-no_windows_gpu', '-no_gpu']
+      test_and_build_filters += ['-no_windows_gpu', '-no_gpu']
     else:
-      common_filters.append('-gpu')
+      test_and_build_filters.append('-gpu')
   elif is_macos():
-    common_filters += ['-gpu', '-nomac', '-no_mac']
+    test_and_build_filters += ['-gpu', '-nomac', '-no_mac']
   elif is_linux():
     if env.get('TF_NEED_CUDA', None) == '1':
-      common_filters.append('-no_gpu')
+      test_and_build_filters.append('-no_gpu')
       write_to_bazelrc('test --test_env=LD_LIBRARY_PATH')
     else:
-      common_filters.append('-gpu')
+      test_and_build_filters.append('-gpu')
   write_to_bazelrc('test --test_tag_filters=%s'
-                   % ','.join(common_filters + addl_test_filters))
+                   % ','.join(test_and_build_filters + test_only_filters))
   write_to_bazelrc('test --build_tag_filters=%s'
-                   % ','.join(common_filters))
+                   % ','.join(test_and_build_filters))
 
 
 def set_system_libs_flag(environ_cp):


### PR DESCRIPTION
`configure.py` adds multiple instances of the `--test_tag_filters` and `--build_tag_filters` arguments to the bottom of `.tf_configure.bazelrc`. For example, on a Mac, the configuration file contains the lines:
```
test --test_tag_filters=-benchmark-test,-no_oss,-oss_serial
test --build_tag_filters=-benchmark-test,-no_oss
test --test_tag_filters=-gpu,-nomac,-no_mac
test --build_tag_filters=-gpu,-nomac,-no_mac
```
These lines are intended to disable tests with the tags `benchmark-test`, `no_oss`, `oss_serial`, `gpu`, `nomac`, and `no_mac`. Unfortunately, Bazel's `--test_tag_filters` and `--build_tag_filters` commands replace their respective lists of filters instead of adding to them. So only the last set of filters (`-gpu,-nomac,-no_mac` in this case) ends up getting applied. As a result the default Bazel configuration will run tests that shouldn't run.

This PR modifies `configure.py` so that the script generates a single value for the `--test_tag_filters` and `--build_tag_filters` arguments. After this change, the lines of `.tf_configure.bazelrc` described above turn into:
```
test --test_tag_filters=-benchmark-test,-no_oss,-gpu,-nomac,-no_mac,-oss_serial
test --build_tag_filters=-benchmark-test,-no_oss,-gpu,-nomac,-no_mac
```