### PR TITLE
Fix bug in NCCL broadcast wrapper

### DIFF
--- a/tensorflow/core/nccl/nccl_manager.cc
+++ b/tensorflow/core/nccl/nccl_manager.cc
@@ -703,6 +703,9 @@ void NcclManager::LoopKernelLaunches(NcclStream* nccl_stream) {
         if (p->output) {
           recvbuff = const_cast<char*>(p->output->tensor_data().data());
           num_elements = p->output->NumElements();
+        } else {
+          // Operate in-place if no output (for the src node).
+          recvbuff = const_cast<void*>(sendbuff);
         }
         if (num_elements < 0) {
           p->done_callback(errors::Internal(


### PR DESCRIPTION
The recvbuf passed to ncclBroadcast must not be nullptr, else it causes CUDA_ERROR_ILLEGAL_ADDRESS. This issue arises if the source node of the broadcast has no output.

attn @dubey 
cc @nluehr 