### PR TITLE
TFLite TOCO: Verify trivial operator has no activation function

### DIFF
--- a/tensorflow/lite/toco/graph_transformations/remove_trivial_binary.cc
+++ b/tensorflow/lite/toco/graph_transformations/remove_trivial_binary.cc
@@ -123,6 +123,9 @@ bool AreAllBufferElementsEqualTo(const std::vector<Scalar>& buffer_data,
                  AreAllBufferElementsEqualTo(constant_input_float_data, 1.f);
   }
 
+  is_trivial = is_trivial &&
+    binary_op->fused_activation_function == FusedActivationFunctionType::kNone;
+
   if (!is_trivial) {
     return ::tensorflow::Status::OK();
   }


### PR DESCRIPTION
Bug scenario:
Add layer with zero weights is omitted, despite having a fused activation function.