### PR TITLE
[tf.data] Fix OOM when tf.data map_and_batch is used with num_paralle…

### DIFF
--- a/tensorflow/core/kernels/data/experimental/BUILD
+++ b/tensorflow/core/kernels/data/experimental/BUILD
@@ -184,6 +184,7 @@ tf_kernel_library(
         "//tensorflow/core:core_cpu_internal",
         "//tensorflow/core:dataset_ops_op_lib",
         "//tensorflow/core:framework",
+        "//tensorflow/core:framework_internal",
         "//tensorflow/core:lib",
         "//tensorflow/core:lib_internal",
         "//tensorflow/core:nn_ops_op_lib",


### PR DESCRIPTION
…l_calls = autotune, batch_size = 1.

Closes #33516.

PiperOrigin-RevId: 281775472
Change-Id: Ie10cea0ef1515d5aff8e3dddadc069ddee1a5a76