### PR TITLE
Correctly access the vocab_size

### DIFF
--- a/tensorflow/python/keras/layers/preprocessing/text_vectorization.py
+++ b/tensorflow/python/keras/layers/preprocessing/text_vectorization.py
@@ -419,7 +419,7 @@ class TextVectorization(CombinerPreprocessingLayer):
     super(TextVectorization, self).adapt(preprocessed_inputs, reset_state)
 
   def get_vocabulary(self):
-    if self.vocab_size == 0:
+    if self._vocab_size == 0:
       return []
 
     keys, values = self._get_table_data()


### PR DESCRIPTION
Whenever I run:

```
import tensorflow.keras as keras
l = keras.layers.experimental.preprocessing.TextVectorization()
l.set_vocabulary(["hello", "world"])
l.get_vocabulary()
```

I get:

> AttributeError: 'TextVectorization' object has no attribute 'vocab_size'

This PR fixes it.
