### PR TITLE
fix: set srcs_version to PY2

### DIFF
--- a/third_party/functools32.BUILD
+++ b/third_party/functools32.BUILD
@@ -13,6 +13,6 @@ py_library(
         "functools32/functools32.py",
         "functools32/reprlib32.py",
     ],
-    srcs_version = "PY2AND3",
+    srcs_version = "PY2",
     visibility = ["//visibility:public"],
 )

--- a/third_party/systemlibs/functools32.BUILD
+++ b/third_party/systemlibs/functools32.BUILD
@@ -11,5 +11,5 @@ filegroup(
 
 py_library(
     name = "functools32",
-    srcs_version = "PY2AND3",
+    srcs_version = "PY2",
 )


### PR DESCRIPTION
When creating lock file using pipenv on Python3 (Ubuntu 19.10), locking fails because functools32 is added to the list of dependencies. This PR sets the py_library srcs_versions config for functools32 correctly to PY2. Wondering if also changes need to be made to the _special_math_ops_ py_library under tensorflow/python/BUILD (it also explicitly mentions functools32 as a dep, which might cause pipenv to want to install it)