### PR TITLE
fix: functools32 srcs_version to PY2 only

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -4055,7 +4055,23 @@ py_library(
 py_library(
     name = "special_math_ops",
     srcs = ["ops/special_math_ops.py"],
-    srcs_version = "PY2AND3",
+    srcs_version = "PY3ONLY",
+    deps = [
+        ":array_ops",
+        ":check_ops",
+        ":control_flow_ops",
+        ":framework_for_generated_wrappers",
+        ":math_ops",
+        ":platform",
+        "//tensorflow/compiler/tf2xla/ops:gen_xla_ops",
+        "@opt_einsum_archive//:opt_einsum",
+    ],
+)
+
+py_library(
+    name = "special_math_ops",
+    srcs = ["ops/special_math_ops.py"],
+    srcs_version = "PY2ONLY",
     deps = [
         ":array_ops",
         ":check_ops",

--- a/third_party/functools32.BUILD
+++ b/third_party/functools32.BUILD
@@ -13,6 +13,6 @@ py_library(
         "functools32/functools32.py",
         "functools32/reprlib32.py",
     ],
-    srcs_version = "PY2AND3",
+    srcs_version = "PY2",
     visibility = ["//visibility:public"],
 )

--- a/third_party/functools32.BUILD
+++ b/third_party/functools32.BUILD
@@ -13,6 +13,6 @@ py_library(
         "functools32/functools32.py",
         "functools32/reprlib32.py",
     ],
-    srcs_version = "PY2",
+    srcs_version = "PY2ONLY",
     visibility = ["//visibility:public"],
 )

--- a/third_party/systemlibs/functools32.BUILD
+++ b/third_party/systemlibs/functools32.BUILD
@@ -11,5 +11,5 @@ filegroup(
 
 py_library(
     name = "functools32",
-    srcs_version = "PY2AND3",
+    srcs_version = "PY2",
 )

--- a/third_party/systemlibs/functools32.BUILD
+++ b/third_party/systemlibs/functools32.BUILD
@@ -11,5 +11,5 @@ filegroup(
 
 py_library(
     name = "functools32",
-    srcs_version = "PY2",
+    srcs_version = "PY2ONLY",
 )


### PR DESCRIPTION
On Ubuntu 19.10, when locking dependencies using pipenv for a python3.7 project, pipenv detects functools32 as a required dependency and fails installing it. This should not happen for Python >= 3. Specified the srcs_version of the functools32 py_library to PY2.
Aside from this change, maybe the py_library of special_math_ops under /tensorflow/python/BUILD also needs to be changed as it explicitly lists functools32 as a dependency, which might cause pipenv to want to install it.