### PR TITLE
Sort layers before the loop

### DIFF
--- a/tensorflow/python/keras/saving/hdf5_format.py
+++ b/tensorflow/python/keras/saving/hdf5_format.py
@@ -22,6 +22,8 @@ from __future__ import print_function
 import json
 import os
 
+from operator import attrgetter
+
 import numpy as np
 from six.moves import zip  # pylint: disable=redefined-builtin
 
@@ -621,6 +623,7 @@ def save_weights_to_hdf5_group(f, layers):
   f.attrs['backend'] = K.backend().encode('utf8')
   f.attrs['keras_version'] = str(keras_version).encode('utf8')
 
+  layers.sort(key=attrgetter('name'))
   for layer in layers:
     g = f.create_group(layer.name)
     weights = _legacy_weights(layer)


### PR DESCRIPTION
Issue #34479, #32672

Layer names sometimes contain hierarchy char "/", e.g., "Layer1", "Layer1/SubLayer1", etc.. Since for each layer, we create a new group, so if we pass layers whose name like "Layer1/SubLayer1", it would create both "Layer1" and "Layer1/SubLayer1", afterwards, if we pass "Layer1", it will throw "Unable to create group (name already exists)" error. 

This commit solves the issue by sorting the layers by name before the loop.