### PR TITLE
Correctly counting the number of params for TextVectorization

### DIFF
--- a/tensorflow/python/keras/layers/preprocessing/text_vectorization.py
+++ b/tensorflow/python/keras/layers/preprocessing/text_vectorization.py
@@ -296,21 +296,24 @@ class TextVectorization(CombinerPreprocessingLayer):
       raise NotImplementedError(
           "Saving is not yet supported for TextVectorization layers.")
     self._table._list_extra_dependencies_for_serialization = fail  # pylint: disable=protected-access
+    self._table.shape = tensor_shape.TensorShape((0,))  # pylint: disable=protected-access
 
     self._add_trackable(self._table, trainable=False)
 
     # We are adding this here instead of in build() since it does not depend
     # on the input shape at all.
     if self._output_mode == TFIDF:
-      # Create the TFIDF weight, but use a (None,) tensorshape. This creates
+      # Create the TFIDF weight, but use a (0,) tensorshape. This creates
       # a 1D variable with arbitrary shape, which we can assign any weight to
       # so long as it has 1 dimension. In order to properly initialize this
       # weight in Keras, we need to provide a custom callable initializer which
       # does not depend on the shape of the weight (as all other initializers
       # do) since the weight is not known. Hence the lambda shape, dtype: [0].
+      # Furthermore, using (0,) instead of (None,) so we can sucessfully
+      # compute the number of trainable parameters via count_params(self).
       self._tf_idf_weights = self.add_weight(
           name="tfidf_data",
-          shape=tensor_shape.TensorShape((None,)),
+          shape=tensor_shape.TensorShape((0,)),
           dtype=K.floatx(),
           trainable=False,
           initializer=lambda shape, dtype: [0])

--- a/tensorflow/python/keras/layers/preprocessing/text_vectorization_test.py
+++ b/tensorflow/python/keras/layers/preprocessing/text_vectorization_test.py
@@ -289,6 +289,19 @@ class TextVectorizationPreprocessingTest(
     keras_parameterized.TestCase,
     preprocessing_test_utils.PreprocessingLayerTest):
 
+def test_init_layer(self):
+    input_data = keras.Input(shape=(None,), dtype=dtypes.string)
+    layer = get_layer_class()(
+        max_tokens=None,
+        standardize=text_vectorization.LOWER_AND_STRIP_PUNCTUATION,
+        split=None,
+        ngrams=None,
+        output_mode=None)
+    int_data = layer(input_data)
+    model = keras.Model(inputs=input_data, outputs=int_data)
+    assert int_data.count_params() == 0
+    model.summary()
+
   def test_normalization(self):
     input_array = np.array([["Earth", "wInD", "aNd", "firE"],
                             ["fire|", "an<>d", "{earth}", "michigan@%$"]])


### PR DESCRIPTION
When calling a `model.summary()` using a `TextVectorization` layer, for every layer it is needed to compute the number of parameters via `layer.count_params()`. Currently, an exception is raised.

To accomplish a successful `tf.keras.Model.summary()`, internally followed by `TextVectorization.count_params()`:
* `lookup_ops.MutableHashTable` should have a `shape` attribute
* using `tensor_shape.TensorShape((None,))` on both weights (table and tf-idf) raises a `np.prod` exception - `tensor_shape.TensorShape((0,))` is required

## Test
When running `model.summary()`:

Before:
```
_________________________________________________________________
Layer (type)                 Output Shape              Param #   
=================================================================
text (InputLayer)            [(None, 1)]               0         
_________________________________________________________________
---------------------------------------------------------------------------
AttributeError: 'TrackableWeightHandler' object has no attribute 'shape'
```

Now:
```
_________________________________________________________________
Layer (type)                 Output Shape              Param #   
=================================================================
text (InputLayer)            [(None, 1)]               0         
_________________________________________________________________
text_vectorization_2 (TextVe (None, 400)               0         
_________________________________________________________________
...
=================================================================
Total params: ...
Trainable params: ...
Non-trainable params: ...
_________________________________________________________________
```