### PR TITLE
Add Label for XlaOp

### DIFF
--- a/tensorflow/compiler/tf2xla/kernels/data_format_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/data_format_ops.cc
@@ -143,6 +143,11 @@ class DataFormatVecPermuteOp : public XlaOpKernel {
 REGISTER_XLA_OP(
     Name("DataFormatVecPermute").TypeConstraint("T", {DT_INT32, DT_INT64}),
     DataFormatVecPermuteOp);
+REGISTER_XLA_OP(
+    Name("DataFormatVecPermute")
+        .Label("host")
+        .TypeConstraint("T", {DT_INT32, DT_INT64}),
+    DataFormatVecPermuteOp);
 
 }  // namespace
 }  // namespace tensorflow

--- a/tensorflow/compiler/tf2xla/xla_compiler.cc
+++ b/tensorflow/compiler/tf2xla/xla_compiler.cc
@@ -723,17 +723,6 @@ Status XlaCompiler::CompileFunction(
 
   std::unique_ptr<Graph> graph = GetGraph(fbody);
 
-  // Clear the "_kernel" attribute if it is set to "host". This is used to
-  // indicate that a computation should happen on the host instead of the
-  // accelerator, but doesn't make sense in XLA.
-  const char* const kKernelAttr = "_kernel";
-  for (Node* n : graph->nodes()) {
-    string value;
-    if (TryGetNodeAttr(n->attrs(), kKernelAttr, &value) && value == "host") {
-      n->ClearAttr(kKernelAttr);
-    }
-  }
-
   // _Arg and _Retval nodes don't exist in the stored subgraph for the function;
   // they are added by the function body looked up.  Therefore, they don't have
   // core assignments here.

--- a/tensorflow/compiler/tf2xla/xla_op_registry.cc
+++ b/tensorflow/compiler/tf2xla/xla_op_registry.cc
@@ -542,8 +542,8 @@ XlaOpRegistrationBuilder& XlaOpRegistrationBuilder::IsMetadataOp() {
 }
 
 XlaOpRegistrationBuilder& XlaOpRegistrationBuilder::Label(
-    absl::string_view label) {
-  registration_->label = string(label);
+    std::string label) {
+  registration_->label = label;
   return *this;
 }
 

--- a/tensorflow/compiler/tf2xla/xla_op_registry.cc
+++ b/tensorflow/compiler/tf2xla/xla_op_registry.cc
@@ -61,6 +61,7 @@ XlaOpRegistry::~XlaOpRegistry() = default;
 /* static */ bool XlaOpRegistry::IsCompatible(const OpRegistration& x,
                                               const OpRegistration& y) {
   if (x.name != y.name) return true;
+  if (x.label != y.label) return true;
   // The registrations refer to the same Op: ensures they are compatible and
   // are restricted to different device whitelists.
   if (x.compilation_only != y.compilation_only) {
@@ -256,6 +257,7 @@ void XlaOpRegistry::RegisterCompilationKernels() {
         std::unique_ptr<KernelDef> kdef(new KernelDef);
         kdef->set_op(op_registration->name);
         kdef->set_device_type(backend.first);
+        kdef->set_label(op_registration->label);
 
         // Constrain each type attribute to the intersection of:
         // a) the types supported by the backend, and
@@ -536,6 +538,12 @@ XlaOpRegistrationBuilder& XlaOpRegistrationBuilder::CompileTimeConstantInput(
 
 XlaOpRegistrationBuilder& XlaOpRegistrationBuilder::IsMetadataOp() {
   registration_->is_metadata_op = true;
+  return *this;
+}
+
+XlaOpRegistrationBuilder& XlaOpRegistrationBuilder::Label(
+    absl::string_view label) {
+  registration_->label = string(label);
   return *this;
 }
 

--- a/tensorflow/compiler/tf2xla/xla_op_registry.h
+++ b/tensorflow/compiler/tf2xla/xla_op_registry.h
@@ -270,7 +270,7 @@ class XlaOpRegistry {
     // operands and not their values.
     bool is_metadata_op = false;
 
-    string label;
+    std::string label;
 
     // Factory used to build OpKernels that perform symbolic execution.
     Factory factory;
@@ -353,7 +353,7 @@ class XlaOpRegistrationBuilder {
   XlaOpRegistrationBuilder& IsMetadataOp();
 
   // Specifies a particular value for the "_kernel" attr.  
-  XlaOpRegistrationBuilder& Label(absl::string_view label);
+  XlaOpRegistrationBuilder& Label(std::string label);
 
   std::unique_ptr<XlaOpRegistry::OpRegistration> Build(
       XlaOpRegistry::Factory factory);

--- a/tensorflow/compiler/tf2xla/xla_op_registry.h
+++ b/tensorflow/compiler/tf2xla/xla_op_registry.h
@@ -270,6 +270,8 @@ class XlaOpRegistry {
     // operands and not their values.
     bool is_metadata_op = false;
 
+    string label;
+
     // Factory used to build OpKernels that perform symbolic execution.
     Factory factory;
   };
@@ -349,6 +351,9 @@ class XlaOpRegistrationBuilder {
   // Mark this op as a "metadata" op, one that only looks at the shapes of its
   // operands and not their values.
   XlaOpRegistrationBuilder& IsMetadataOp();
+
+  // Specifies a particular value for the "_kernel" attr.  
+  XlaOpRegistrationBuilder& Label(absl::string_view label);
 
   std::unique_ptr<XlaOpRegistry::OpRegistration> Build(
       XlaOpRegistry::Factory factory);


### PR DESCRIPTION
This is a PR from JIZHI, the AI platform in Tencent.

Add Label for XlaOp, because it may lead to fail to find XLAOpKernel, such as `DataFormatVecPermute`. @akuegel 