### PR TITLE
Fixing test that fails on AVX512

### DIFF
--- a/tensorflow/python/keras/backend.py
+++ b/tensorflow/python/keras/backend.py
@@ -4482,12 +4482,11 @@ def categorical_crossentropy(target, output, from_logits=False, axis=-1):
      [0.5  0.89 0.6 ]
      [0.05 0.01 0.94]], shape=(3, 3), dtype=float32)
   >>> loss = tf.keras.backend.categorical_crossentropy(a, b)
-  >>> print(loss)
-  tf.Tensor([0.10536055 0.8046684  0.06187541], shape=(3,), dtype=float32)
+  >>> print(np.around(loss, 5))
+  [0.10536 0.80467 0.06188]
   >>> loss = tf.keras.backend.categorical_crossentropy(a, a)
-  >>> print(loss)
-  tf.Tensor([1.1920929e-07 1.1920929e-07 1.1920930e-07], shape=(3,),
-  dtype=float32)
+  >>> print(np.around(loss, 5))
+  [0. 0. 0.]
 
   """
   if from_logits:


### PR DESCRIPTION
The operation categorical_crossentropy requires taking log as an intermediate
step. Due to the rank (2) and shape (3, 3) of the tensors used in this example,
on AVX2 and older builds, the log operation uses plog, Eigen's packet log
method, whereas on AVX512 build, the log operation is not vectorized and ends
up using std::log.

Due to the precision mismatch between std::log and Eigen's plog, the results do
not match exactly. The loss values comes out to be equal to [0.10536055
0.8046685 0.06187541], instead of [0.10536055 0.8046684 0.06187541]. This is an
expected mismatch and should not fail the test.

The absolutely correct way to test would be to compare hex values and make sure
that the results are within the expected range of the ULP error. An easier fix
would be to reduce the precision of the test to account for such mismatches
between the implementation of operators in the underlying math libraries.

We are taking the second approach and will compare results after rounding to 5
decimal places.