### PR TITLE
Improve resize_bilinear CPU back-prop kernel comment

### DIFF
--- a/tensorflow/core/kernels/resize_bilinear_op.cc
+++ b/tensorflow/core/kernels/resize_bilinear_op.cc
@@ -309,13 +309,16 @@ struct ResizeBilinearGrad<CPUDevice, T> {
 
     output_grad.setZero();
 
-    // Each resized pixel was computed as a weighted average of four input
-    // pixels. Here we find the pixels that contributed to each output pixel
-    // and add the corresponding coefficient to the gradient.
-    // resized(b, y, x, c) = top_left * (1 - y) * (1 - x)
-    //                       +  top_right * (1 - y) * x
-    //                       +  bottom_left * y * (1 - x)
-    //                       +  bottom_right * y * x
+    // Each resized output pixel was computed as a weighted average of four
+    // input pixels. Here we find the four input pixel locations that
+    // contributed to each output pixel and propgate the gradient at the output
+    // pixel location to each of those four input pixels locations in the same
+    // proportions that they originally contributed to the output pixel.
+    // Here is the forward-propagation pseudo-code, for reference:
+    // resized(b, y, x, c) = top_left     * (1 - y) * (1 - x)
+    //                     + top_right    * (1 - y) *      x
+    //                     + bottom_left  *      y  * (1 - x)
+    //                     + bottom_right *      y  *      x
     for (Eigen::Index b = 0; b < batch; ++b) {
       for (Eigen::Index y = 0; y < resized_height; ++y) {
         const float in_y = scaler(y, height_scale);

--- a/tensorflow/core/kernels/resize_bilinear_op.cc
+++ b/tensorflow/core/kernels/resize_bilinear_op.cc
@@ -312,7 +312,7 @@ struct ResizeBilinearGrad<CPUDevice, T> {
     // Each resized output pixel was computed as a weighted average of four
     // input pixels. Here we find the four input pixel locations that
     // contributed to each output pixel and propgate the gradient at the output
-    // pixel location to each of those four input pixels locations in the same
+    // pixel location to each of those four input pixel locations in the same
     // proportions that they originally contributed to the output pixel.
     // Here is the forward-propagation pseudo-code, for reference:
     // resized(b, y, x, c) = top_left     * (1 - y) * (1 - x)


### PR DESCRIPTION
I believe that the proposed change is both easier to understand and more correct.