### PR TITLE
[Intel MKL]Fix MatMul and Elu fusion issue relate to #33451.

### DIFF
--- a/tensorflow/core/kernels/mkl_matmul_ops_common.h
+++ b/tensorflow/core/kernels/mkl_matmul_ops_common.h
@@ -312,7 +312,8 @@ class MklDnnMatMulFwdPrimitiveFactory : public MklPrimitiveFactory<T> {
 
     // Generate keys for post-ops
     for (auto const& post_op_param : mkldnn_matmul_fwd_dims.post_op_params) {
-      if (post_op_param.name == "relu") {
+      if (post_op_param.name == "relu" || post_op_param.name == "relu6" ||
+          post_op_param.name == "elu") {
         DCHECK_EQ(post_op_param.param.size(), 3);
         key_creator.AddAsKey(post_op_param.name);
         key_creator.AddAsKey(post_op_param.param[0]);


### PR DESCRIPTION
In previous work we split MatMul and Relu/Relu6/Elu fusion(#33451 ) and Elu issue fix(#34535 ) to 2 different PR, but I wrongly reverted code after the splitting. It will get random failure because we didn't set post operator for MKL-DNN primitive.

Here's the PR to fix the random failures of MatMul and Elu fusion - in fact it should be part of #33451 .

Modified:
- tensorflow/core/kernels/mkl_matmul_ops_common.h

Signed-off-by: Lu Teng teng.lu@intel.com