### PR TITLE
[ROCm] Fix for the broken ROCm CSB - 191127

### DIFF
--- a/tensorflow/python/ops/linalg/linear_operator_test_util.py
+++ b/tensorflow/python/ops/linalg/linear_operator_test_util.py
@@ -452,6 +452,11 @@ def _test_cond(use_placeholder, shapes_info, dtype):
       if 0 in shapes_info.shape[-2:]:
         return
 
+      # ROCm platform does not yet support complex types
+      if test.is_built_with_rocm() and \
+         ((dtype == dtypes.complex64) or (dtype == dtypes.complex128)):
+        return
+
       sess.graph.seed = random_seed.DEFAULT_GRAPH_SEED
       # Ensure self-adjoint and PD so we get finite condition numbers.
       operator, mat = self.operator_and_matrix(


### PR DESCRIPTION
The following commit breaks the ROCm CSB

https://github.com/tensorflow/tensorflow/commit/4b4bf4223d50cb28da44f081722520889b72583e

It introduces new functionality (condition number method) and unit-tests to check the same. The unit-tests need support for the complex number types, which is currently not supported on the ROCm platform, and hence the consequent breakage.

The "fix" is to skip testing the complex types when running the newly added unit-test on the ROCm platform

------

@chsigg @whchung 