### PR TITLE
Allow to specify the type of the tf.data.Dataset.range function

### DIFF
--- a/tensorflow/core/kernels/data/dataset_test_base.cc
+++ b/tensorflow/core/kernels/data/dataset_test_base.cc
@@ -817,8 +817,9 @@ RangeDatasetParams::RangeDatasetParams(
       stop_(stop),
       step_(step) {}
 
-RangeDatasetParams::RangeDatasetParams(int64 start, int64 stop, int64 step)
-    : DatasetParams({DT_INT64}, {PartialTensorShape({})}, "range_dataset"),
+RangeDatasetParams::RangeDatasetParams(int64 start, int64 stop, int64 step, 
+                                       DataTypeVector output_dtypes)
+    : DatasetParams(std::move(output_dtypes), {PartialTensorShape({})}, "range_dataset"),
       start_(start),
       stop_(stop),
       step_(step) {}

--- a/tensorflow/core/kernels/data/dataset_test_base.h
+++ b/tensorflow/core/kernels/data/dataset_test_base.h
@@ -170,7 +170,8 @@ class RangeDatasetParams : public DatasetParams {
                      std::vector<PartialTensorShape> output_shapes,
                      string node_name);
 
-  RangeDatasetParams(int64 start, int64 stop, int64 step);
+  RangeDatasetParams(int64 start, int64 stop, int64 step,
+                     DataTypeVector output_dtypes);
 
   std::vector<Tensor> GetInputTensors() const override;
 

--- a/tensorflow/core/kernels/data/range_dataset_op.h
+++ b/tensorflow/core/kernels/data/range_dataset_op.h
@@ -36,6 +36,7 @@ class RangeDatasetOp : public DatasetOpKernel {
 
  private:
   class Dataset;
+  DataTypeVector output_types_;
 };
 
 }  // namespace data

--- a/tensorflow/core/kernels/data/range_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/range_dataset_op_test.cc
@@ -23,15 +23,23 @@ namespace {
 class RangeDatasetOpTest : public DatasetOpsTestBase {};
 
 RangeDatasetParams PositiveStepRangeDatasetParams() {
-  return RangeDatasetParams(/*start=*/0, /*stop=*/10, /*step=*/3);
+  return RangeDatasetParams(/*start=*/0, /*stop=*/10, /*step=*/3,
+                            /*output_dtypes=*/{DT_INT64});
 }
 
 RangeDatasetParams NegativeStepRangeDatasetParams() {
-  return RangeDatasetParams(/*start=*/10, /*stop=*/0, /*step=*/-3);
+  return RangeDatasetParams(/*start=*/10, /*stop=*/0, /*step=*/-3, 
+                            /*output_dtypes=*/{DT_INT64});
 }
 
 RangeDatasetParams ZeroStepRangeDatasetParams() {
-  return RangeDatasetParams(/*start=*/10, /*stop=*/0, /*step=*/0);
+  return RangeDatasetParams(/*start=*/10, /*stop=*/0, /*step=*/0,
+                            /*output_dtypes=*/{DT_INT64});
+}
+
+RangeDatasetParams PositiveStepRangeInt32DatasetParams() {
+  return RangeDatasetParams(/*start=*/0, /*stop=*/10, /*step=*/3, 
+                            /*output_dtypes=*/{DT_INT32});
 }
 
 std::vector<GetNextTestCase<RangeDatasetParams>> GetNextTestCases() {
@@ -65,6 +73,12 @@ TEST_F(RangeDatasetOpTest, DatasetOutputDtypes) {
   TF_ASSERT_OK(CheckDatasetOutputDtypes({DT_INT64}));
 }
 
+TEST_F(RangeDatasetOpTest, DatasetOutputDtypesInt32) {
+  auto range_dataset_params = PositiveStepRangeInt32DatasetParams();
+  TF_ASSERT_OK(Initialize(range_dataset_params));
+  TF_ASSERT_OK(CheckDatasetOutputDtypes({DT_INT32}));
+}
+
 TEST_F(RangeDatasetOpTest, DatasetOutputShapes) {
   auto range_dataset_params = PositiveStepRangeDatasetParams();
   TF_ASSERT_OK(Initialize(range_dataset_params));
@@ -85,6 +99,12 @@ TEST_F(RangeDatasetOpTest, IteratorOutputDtypes) {
   auto range_dataset_params = PositiveStepRangeDatasetParams();
   TF_ASSERT_OK(Initialize(range_dataset_params));
   TF_ASSERT_OK(CheckIteratorOutputDtypes({DT_INT64}));
+}
+
+TEST_F(RangeDatasetOpTest, IteratorOutputDtypesInt32) {
+  auto range_dataset_params = PositiveStepRangeInt32DatasetParams();
+  TF_ASSERT_OK(Initialize(range_dataset_params));
+  TF_ASSERT_OK(CheckIteratorOutputDtypes({DT_INT32}));
 }
 
 TEST_F(RangeDatasetOpTest, IteratorOutputShapes) {

--- a/tensorflow/python/data/kernel_tests/range_test.py
+++ b/tensorflow/python/data/kernel_tests/range_test.py
@@ -21,6 +21,7 @@ from tensorflow.python.data.kernel_tests import test_base
 from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.framework import errors
 from tensorflow.python.framework import test_util
+from tensorflow.python.framework import dtypes
 from tensorflow.python.platform import test
 
 
@@ -66,6 +67,13 @@ class RangeTest(test_base.DatasetTestBase):
     start, stop, step = 10, 2, -1
     dataset = dataset_ops.Dataset.range(start, stop, step)
     self.assertDatasetProduces(dataset, expected_output=range(10, 2, -1))
+
+  def testOutputType(self):
+    expected_types = dtypes.int32
+    dataset = dataset_ops.Dataset.range(5, expected_types)
+    self.assertDatasetProduces(dataset, expected_output=range(5))
+    self.assertEqual(expected_types,
+                     dataset_ops.get_legacy_output_types(dataset))
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -880,7 +880,7 @@ class DatasetV2(tracking_base.Trackable, composite_tensor.CompositeTensor):
     return id_dataset.flat_map(flat_map_fn)
 
   @staticmethod
-  def range(*args):
+  def range(*args, output_types=dtypes.int64):
     """Creates a `Dataset` of a step-separated range of values.
 
     >>> list(Dataset.range(5).as_numpy_iterator())
@@ -908,7 +908,7 @@ class DatasetV2(tracking_base.Trackable, composite_tensor.CompositeTensor):
     Raises:
       ValueError: if len(args) == 0.
     """
-    return RangeDataset(*args)
+    return RangeDataset(*args, output_types=output_types)
 
   @staticmethod
   def zip(datasets):
@@ -2238,8 +2238,8 @@ class DatasetV1(DatasetV2):
 
   @staticmethod
   @functools.wraps(DatasetV2.range)
-  def range(*args):
-    return DatasetV1Adapter(DatasetV2.range(*args))
+  def range(*args, output_types=dtypes.int64):
+    return DatasetV1Adapter(DatasetV2.range(*args, output_types))
 
   @staticmethod
   @functools.wraps(DatasetV2.zip)
@@ -3345,10 +3345,10 @@ class RepeatDataset(UnaryUnchangedStructureDataset):
 class RangeDataset(DatasetSource):
   """A `Dataset` of a step separated range of values."""
 
-  def __init__(self, *args):
+  def __init__(self, *args, output_types=dtypes.int64):
     """See `Dataset.range()` for details."""
     self._parse_args(*args)
-    self._structure = tensor_spec.TensorSpec([], dtypes.int64)
+    self._structure = tensor_spec.TensorSpec([], output_types)
     variant_tensor = gen_dataset_ops.range_dataset(
         start=self._start,
         stop=self._stop,


### PR DESCRIPTION
Hi @jsimsa ,
This PR is just allow to specify the type of the tf.data.Dataset.range function, see issue  #33414 

I also add test code to range_dataset_op_test.cc and range_test.py.
