### PR TITLE
Fix for compilation error in cmsis-nn/pooling.cc

### DIFF
--- a/tensorflow/lite/micro/kernels/cmsis-nn/pooling.cc
+++ b/tensorflow/lite/micro/kernels/cmsis-nn/pooling.cc
@@ -97,24 +97,23 @@ void AverageEvalUint8(const TfLiteContext* context, const TfLiteNode* node,
       GetTensorShape(output), GetTensorData<uint8_t>(output));
 }
 
-TfLiteStatus AverageEvalInt8(const TfLiteContext* context,
+TfLiteStatus AverageEvalInt8(TfLiteContext* context,
                              const TfLiteNode* node,
                              const TfLitePoolParams* params, const OpData* data,
-                             const TfLiteTensor* input, TfLiteTensor* output) {
+                             TfLiteTensor* input, TfLiteTensor* output) {
   int32_t activation_min, activation_max;
   CalculateActivationRangeInt8(params->activation, output, &activation_min,
                                &activation_max);
 
-  TFLITE_DCHECK_LE(params->quantized_activation_min,
-                   params->quantized_activation_max);
+  TFLITE_DCHECK_LE(activation_min, activation_max);
 
+#if defined(ARM_MATH_DSP) && defined(ARM_MATH_LOOPUNROLL)
   RuntimeShape input_shape = GetTensorShape(input);
   TFLITE_DCHECK_EQ(input_shape.DimensionsCount(), 4);
 
   RuntimeShape output_shape = GetTensorShape(output);
   TFLITE_DCHECK_EQ(output_shape.DimensionsCount(), 4);
 
-  const int batches = MatchingDim(input_shape, 0, output_shape, 0);
   const int depth = MatchingDim(input_shape, 3, output_shape, 3);
   const int input_height = input_shape.Dims(1);
   const int input_width = input_shape.Dims(2);
@@ -128,9 +127,8 @@ TfLiteStatus AverageEvalInt8(const TfLiteContext* context,
   const int padding_height = data->padding.height;
   const int padding_width = data->padding.width;
 
-#if defined(ARM_MATH_DSP) && defined(ARM_MATH_LOOPUNROLL)
   int16_t* scratch_buffer = nullptr;
-  const int32_t buffer_size =
+  int32_t buffer_size =
       arm_avgpool_s8_get_buffer_size(output_width, depth);
 
   TF_LITE_ENSURE_OK(
@@ -145,6 +143,15 @@ TfLiteStatus AverageEvalInt8(const TfLiteContext* context,
                      scratch_buffer, GetTensorData<int8_t>(output)),
       ARM_MATH_SUCCESS);
 #else
+  PoolParams op_params;
+  op_params.stride_height = params->stride_height;
+  op_params.stride_width = params->stride_width;
+  op_params.filter_height = params->filter_height;
+  op_params.filter_width = params->filter_width;
+  op_params.padding_values.height = data->padding.height;
+  op_params.padding_values.width = data->padding.width;
+  op_params.quantized_activation_min = activation_min;
+  op_params.quantized_activation_max = activation_max;
   reference_integer_ops::AveragePool(
       op_params, GetTensorShape(input), GetTensorData<int8_t>(input),
       GetTensorShape(output), GetTensorData<int8_t>(output));
@@ -211,7 +218,9 @@ TfLiteStatus AverageEval(TfLiteContext* context, TfLiteNode* node) {
   auto* params = reinterpret_cast<TfLitePoolParams*>(node->builtin_data);
   OpData data;
 
-  const TfLiteTensor* input = GetInput(context, node, kInputTensor);
+  // Todo: make 'input' const once CMSIS-reuse is fixed
+  TfLiteTensor* input = &context->tensors[flatbuffers::EndianScalar(
+                          node->inputs->data[kInputTensor])];
   TfLiteTensor* output = GetOutput(context, node, kOutputTensor);
 
   TF_LITE_ENSURE_STATUS(CalculateOpData(context, params, input, output, &data));

--- a/tensorflow/lite/micro/tools/make/ext_libs/cmsis.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/cmsis.inc
@@ -48,6 +48,8 @@ ifneq ($(filter cmsis-nn,$(ALL_TAGS)),)
       $(CMSIS_PATH)/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_separable_conv_HWC_q7_nonsquare.c \
       $(CMSIS_PATH)/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q15_fast_nonsquare.c \
       $(CMSIS_PATH)/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_s8_opt.c \
+      $(CMSIS_PATH)/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_depthwise_conv_s8_core.c \
+      $(CMSIS_PATH)/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_mat_mult_s8.c \
       $(CMSIS_PATH)/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_mat_mult_kernel_s8_s16.c \
       $(CMSIS_PATH)/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q15_basic.c \
       $(CMSIS_PATH)/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q15_fast.c \

--- a/tensorflow/lite/micro/tools/make/third_party_downloads.inc
+++ b/tensorflow/lite/micro/tools/make/third_party_downloads.inc
@@ -20,8 +20,8 @@ LEON_BCC2_MD5 := "cdf78082be4882da2a92c9baa82fe765"
 TSIM_URL := "https://www.gaisler.com/anonftp/tsim/tsim-eval-2.0.63.tar.gz"
 TSIM_MD5 := "afa0095d3ed989a949e1467f94e41d2f"
 
-CMSIS_URL := "https://github.com/ARM-software/CMSIS_5/archive/5deff575d14ed255616d23b61d7b95f3b6dd19a8.zip"
-CMSIS_MD5 := "3adb1a3d4b7aabfbb40972c609730c9e"
+CMSIS_URL := "https://github.com/ARM-software/CMSIS_5/archive/d76d5e3acb87cf089daf50b31f991026149ecb6c.zip"
+CMSIS_MD5 := "866f79cfb86f7aee29a320aeda530aca"
 
 AM_SDK_URL := "http://s3.asia.ambiqmicro.com/downloads/AmbiqSuite-Rel2.0.0.zip"
 AM_SDK_MD5 := "70332bc6968602bd85bee600ca81d06f"


### PR DESCRIPTION
There was a couple of compilation errors that needed to be fixed. One of the issues is that arm_avgpool_s8() returned void. I had to fix that in the CMSIS repo. Hence I had to step up the downloaded CMSIS commit id. On top of that I added two .c file that are utilized in CMSIS for MVE optimizations.