### PR TITLE
Fix misformatted markdown in Model.fit docstring

### DIFF
--- a/tensorflow/python/keras/engine/training.py
+++ b/tensorflow/python/keras/engine/training.py
@@ -676,6 +676,7 @@ class Model(network.Network, version_utils.VersionSelector):
               - tuple `(x_val, y_val)` of Numpy arrays or tensors
               - tuple `(x_val, y_val, val_sample_weights)` of Numpy arrays
               - dataset
+              
             For the first two cases, `batch_size` must be provided.
             For the last case, `validation_steps` could be provided.
         shuffle: Boolean (whether to shuffle the training data


### PR DESCRIPTION
The current documentation of `tf.keras.models.Model.fit` contains misformatted markdown in the description of the `validation_data` attribute: it is missing a line break after the list enumerating the possible types of accepted arguments, which hurts legibility upon rendering.

See [keras documentation](https://www.tensorflow.org/api_docs/python/tf/keras/Model#fit).

This commit fixes that problem.