### PR TITLE
lite/third_party/kiss_fft: fix include patches

### DIFF
--- a/tensorflow/lite/micro/tools/make/download_and_extract.sh
+++ b/tensorflow/lite/micro/tools/make/download_and_extract.sh
@@ -65,6 +65,7 @@ patch_kissfft() {
   sed -i -E "s@#define KISS_FFT_FREE free@#define KISS_FFT_FREE(X) /* Patched. */@g" tensorflow/lite/micro/tools/make/downloads/kissfft/kiss_fft.h
   sed -ir -E "s@(fprintf.*\);)@/* \1 */@g" tensorflow/lite/micro/tools/make/downloads/kissfft/tools/kiss_fftr.c
   sed -ir -E "s@(exit.*\);)@return; /* \1 */@g" tensorflow/lite/micro/tools/make/downloads/kissfft/tools/kiss_fftr.c
+  sed -i -E "s@#include <string.h>@#include <string.h>\n#include <stdint.h> /* Patched. */@" tensorflow/lite/micro/tools/make/downloads/kissfft/kiss_fft.h
   echo "Finished patching kissfft"
 }
 

--- a/tensorflow/lite/micro/tools/make/helper_functions.inc
+++ b/tensorflow/lite/micro/tools/make/helper_functions.inc
@@ -179,13 +179,6 @@ $(PRJDIR)$(2)/arduino/src/third_party/flatbuffers/include/flatbuffers/base.h: te
         --third_party_headers="$(4)" < $$< | \
         sed -E 's/utility\.h/utility/g' > $$@
 
-$(PRJDIR)$(2)/arduino/src/third_party/kissfft/kiss_fft.h: tensorflow/lite/micro/tools/make/downloads/kissfft/kiss_fft.h third_party_downloads
-	@mkdir -p $$(dir $$@)
-	@python tensorflow/lite/micro/tools/make/transform_source.py \
-        --platform=arduino \
-        --third_party_headers="$(4)" < $$< | \
-        sed -E 's@#include <string.h>@//#include <string.h> /* Patched by helper_functions.inc for Arduino compatibility */@g' > $$@
-
 $(PRJDIR)$(2)/arduino/%: tensorflow/lite/micro/tools/make/templates/%
 	@mkdir -p $$(dir $$@)
 	@sed -E 's#\%\{SRCS\}\%#$(3)#g' $$< | \


### PR DESCRIPTION
- remove commented out `string.h` include
- add missing `stdint.h` include

This fixes compilation with the esp32 core arduino toolchain.

Tested that the `nano33ble` build still work (modulo #34748), after manually applying the patches.

/cc @dansitu @khanhlvg 