### PR TITLE
Return new instance of AutoCastVariable after assignment

### DIFF
--- a/tensorflow/python/keras/mixed_precision/experimental/autocast_variable.py
+++ b/tensorflow/python/keras/mixed_precision/experimental/autocast_variable.py
@@ -186,65 +186,59 @@ class AutoCastVariable(variables.Variable):
 
   def assign(self, value, use_locking=None, name=None, read_value=True):
     assign_op = self._variable.assign(value, use_locking, name, read_value)
-    if read_value and resource_variable_ops.is_resource_variable(assign_op):
-      return create_autocast_variable(assign_op)
-    return assign_op
+    return _maybe_wrap(assign_op, wrap=read_value)
 
   def assign_add(self, delta, use_locking=None, name=None, read_value=True):
     assign_op = self._variable.assign_add(delta, use_locking, name, read_value)
-    if read_value and resource_variable_ops.is_resource_variable(assign_op):
-      return create_autocast_variable(assign_op)
-    return assign_op
+    return _maybe_wrap(assign_op, wrap=read_value)
 
   def assign_sub(self, delta, use_locking=None, name=None, read_value=True):
     assign_op = self._variable.assign_sub(delta, use_locking, name, read_value)
-    if read_value and resource_variable_ops.is_resource_variable(assign_op):
-      return create_autocast_variable(assign_op)
-    return assign_op
+    return _maybe_wrap(assign_op, wrap=read_value)
 
   def scatter_sub(self, sparse_delta, use_locking=False, name=None):
     var = self._variable.scatter_sub(sparse_delta, use_locking, name)
-    return create_autocast_variable(var)
+    return _maybe_wrap(var)
 
   def scatter_add(self, sparse_delta, use_locking=False, name=None):
     var = self._variable.scatter_add(sparse_delta, use_locking, name)
-    return create_autocast_variable(var)
+    return _maybe_wrap(var)
 
   def scatter_max(self, sparse_delta, use_locking=False, name=None):
     var = self._variable.scatter_max(sparse_delta, use_locking, name)
-    return create_autocast_variable(var)
+    return _maybe_wrap(var)
 
   def scatter_min(self, sparse_delta, use_locking=False, name=None):
     var = self._variable.scatter_min(sparse_delta, use_locking, name)
-    return create_autocast_variable(var)
+    return _maybe_wrap(var)
 
   def scatter_mul(self, sparse_delta, use_locking=False, name=None):
     var = self._variable.scatter_mul(sparse_delta, use_locking, name)
-    return create_autocast_variable(var)
+    return _maybe_wrap(var)
 
   def scatter_div(self, sparse_delta, use_locking=False, name=None):
     var = self._variable.scatter_div(sparse_delta, use_locking, name)
-    return create_autocast_variable(var)
+    return _maybe_wrap(var)
 
   def scatter_update(self, sparse_delta, use_locking=False, name=None):
     var = self._variable.scatter_update(sparse_delta, use_locking, name)
-    return create_autocast_variable(var)
+    return _maybe_wrap(var)
 
   def batch_scatter_update(self, sparse_delta, use_locking=False, name=None):
     var = self._variable.batch_scatter_update(sparse_delta, use_locking, name)
-    return create_autocast_variable(var)
+    return _maybe_wrap(var)
 
   def scatter_nd_sub(self, indices, updates, name=None):
     var = self._variable.scatter_nd_sub(indices, updates, name)
-    return create_autocast_variable(var)
+    return _maybe_wrap(var)
 
   def scatter_nd_add(self, indices, updates, name=None):
     var = self._variable.scatter_nd_add(indices, updates, name)
-    return create_autocast_variable(var)
+    return _maybe_wrap(var)
 
   def scatter_nd_update(self, indices, updates, name=None):
     var = self._variable.scatter_nd_update(indices, updates, name)
-    return create_autocast_variable(var)
+    return _maybe_wrap(var)
 
   def load(self, value, session=None):
     return self._variable.load(value, session)
@@ -430,3 +424,24 @@ def create_autocast_variable(variable):
       # pylint: enable=missing-format-attribute
 
   return AutoCastDistributedVariable(variable)
+
+
+def _maybe_wrap(variable, wrap=True):
+  """Creates an AutoCastVariable that wraps another variable if applicable.
+
+  This function is used to wrap the return value of AutoCastVariable.assign.
+  Unfortunately MirroredVariable.assign will (incorrectly) return a Mirrored
+  value instead of a MirroredVariable. So we cannot properly wrap it in an
+  AutoCastVariable. We return the original variable in that case.
+
+  Args:
+    variable: A tf.Variable or op.
+    wrap: A boolean to define whether to wrap the variable in an
+      AutoCastVariable or not.
+
+  Returns:
+    An AutoCastVariable if wrap is True and variable is a resource variable.
+  """
+  if wrap and resource_variable_ops.is_resource_variable(variable):
+    return create_autocast_variable(variable)
+  return variable

--- a/tensorflow/python/keras/mixed_precision/experimental/autocast_variable.py
+++ b/tensorflow/python/keras/mixed_precision/experimental/autocast_variable.py
@@ -185,46 +185,60 @@ class AutoCastVariable(variables.Variable):
     return self._variable.constraint
 
   def assign(self, value, use_locking=None, name=None, read_value=True):
-    return self._variable.assign(value, use_locking, name, read_value)
+    assign_op = self._variable.assign(value, use_locking, name, read_value)
+    return create_autocast_variable(assign_op) if read_value else assign_op
 
   def assign_add(self, delta, use_locking=None, name=None, read_value=True):
-    return self._variable.assign_add(delta, use_locking, name, read_value)
+    assign_op = self._variable.assign_add(delta, use_locking, name, read_value)
+    return create_autocast_variable(assign_op) if read_value else assign_op
 
   def assign_sub(self, delta, use_locking=None, name=None, read_value=True):
-    return self._variable.assign_sub(delta, use_locking, name, read_value)
+    assign_op = self._variable.assign_sub(delta, use_locking, name, read_value)
+    return create_autocast_variable(assign_op) if read_value else assign_op
 
   def scatter_sub(self, sparse_delta, use_locking=False, name=None):
-    return self._variable.scatter_sub(sparse_delta, use_locking, name)
+    var = self._variable.scatter_sub(sparse_delta, use_locking, name)
+    return create_autocast_variable(var)
 
   def scatter_add(self, sparse_delta, use_locking=False, name=None):
-    return self._variable.scatter_add(sparse_delta, use_locking, name)
+    var = self._variable.scatter_add(sparse_delta, use_locking, name)
+    return create_autocast_variable(var)
 
   def scatter_max(self, sparse_delta, use_locking=False, name=None):
-    return self._variable.scatter_max(sparse_delta, use_locking, name)
+    var = self._variable.scatter_max(sparse_delta, use_locking, name)
+    return create_autocast_variable(var)
 
   def scatter_min(self, sparse_delta, use_locking=False, name=None):
-    return self._variable.scatter_min(sparse_delta, use_locking, name)
+    var = self._variable.scatter_min(sparse_delta, use_locking, name)
+    return create_autocast_variable(var)
 
   def scatter_mul(self, sparse_delta, use_locking=False, name=None):
-    return self._variable.scatter_mul(sparse_delta, use_locking, name)
+    var = self._variable.scatter_mul(sparse_delta, use_locking, name)
+    return create_autocast_variable(var)
 
   def scatter_div(self, sparse_delta, use_locking=False, name=None):
-    return self._variable.scatter_div(sparse_delta, use_locking, name)
+    var = self._variable.scatter_div(sparse_delta, use_locking, name)
+    return create_autocast_variable(var)
 
   def scatter_update(self, sparse_delta, use_locking=False, name=None):
-    return self._variable.scatter_update(sparse_delta, use_locking, name)
+    var = self._variable.scatter_update(sparse_delta, use_locking, name)
+    return create_autocast_variable(var)
 
   def batch_scatter_update(self, sparse_delta, use_locking=False, name=None):
-    return self._variable.batch_scatter_update(sparse_delta, use_locking, name)
+    var = self._variable.batch_scatter_update(sparse_delta, use_locking, name)
+    return create_autocast_variable(var)
 
   def scatter_nd_sub(self, indices, updates, name=None):
-    return self._variable.scatter_nd_sub(indices, updates, name)
+    var = self._variable.scatter_nd_sub(indices, updates, name)
+    return create_autocast_variable(var)
 
   def scatter_nd_add(self, indices, updates, name=None):
-    return self._variable.scatter_nd_add(indices, updates, name)
+    var = self._variable.scatter_nd_add(indices, updates, name)
+    return create_autocast_variable(var)
 
   def scatter_nd_update(self, indices, updates, name=None):
-    return self._variable.scatter_nd_update(indices, updates, name)
+    var = self._variable.scatter_nd_update(indices, updates, name)
+    return create_autocast_variable(var)
 
   def load(self, value, session=None):
     return self._variable.load(value, session)

--- a/tensorflow/python/keras/mixed_precision/experimental/autocast_variable.py
+++ b/tensorflow/python/keras/mixed_precision/experimental/autocast_variable.py
@@ -186,15 +186,21 @@ class AutoCastVariable(variables.Variable):
 
   def assign(self, value, use_locking=None, name=None, read_value=True):
     assign_op = self._variable.assign(value, use_locking, name, read_value)
-    return create_autocast_variable(assign_op) if read_value else assign_op
+    if read_value and resource_variable_ops.is_resource_variable(assign_op):
+      return create_autocast_variable(assign_op)
+    return assign_op
 
   def assign_add(self, delta, use_locking=None, name=None, read_value=True):
     assign_op = self._variable.assign_add(delta, use_locking, name, read_value)
-    return create_autocast_variable(assign_op) if read_value else assign_op
+    if read_value and resource_variable_ops.is_resource_variable(assign_op):
+      return create_autocast_variable(assign_op)
+    return assign_op
 
   def assign_sub(self, delta, use_locking=None, name=None, read_value=True):
     assign_op = self._variable.assign_sub(delta, use_locking, name, read_value)
-    return create_autocast_variable(assign_op) if read_value else assign_op
+    if read_value and resource_variable_ops.is_resource_variable(assign_op):
+      return create_autocast_variable(assign_op)
+    return assign_op
 
   def scatter_sub(self, sparse_delta, use_locking=False, name=None):
     var = self._variable.scatter_sub(sparse_delta, use_locking, name)

--- a/tensorflow/python/keras/mixed_precision/experimental/autocast_variable_test.py
+++ b/tensorflow/python/keras/mixed_precision/experimental/autocast_variable_test.py
@@ -311,6 +311,25 @@ class AutoCastVariableTest(test.TestCase, parameterized.TestCase):
         self.assertAllClose(3.14 * 2, self.evaluate(x.assign_add(3.14)))
         self.assertAllClose(3.14, self.evaluate(x.assign_sub(3.14)))
 
+        # Assign multiple times
+        assign = x.assign(1.)
+        self.assertAllClose(1., self.evaluate(assign))
+        self.assertAllClose(0., self.evaluate(assign.assign(0.)))
+        assign_add = x.assign_add(3.14)
+        self.assertAllClose(3.14, self.evaluate(assign_add))
+        self.assertAllClose(3.14 * 2, self.evaluate(assign_add.assign_add(3.14)))
+        assign_sub = x.assign_sub(3.14)
+        self.assertAllClose(3.14, self.evaluate(assign_sub))
+        self.assertAllClose(0., self.evaluate(assign_sub.assign_sub(3.14)))
+
+        # Assign with read_value=False
+        self.assertIsNone(self.evaluate(x.assign(1., read_value=False)))
+        self.assertAllClose(1., self.evaluate(x))
+        self.assertIsNone(self.evaluate(x.assign_add(2., read_value=False)))
+        self.assertAllClose(3., self.evaluate(x))
+        self.assertIsNone(self.evaluate(x.assign_sub(3., read_value=False)))
+        self.assertAllClose(0., self.evaluate(x))
+
         # Use the tf.assign functions instead of the var.assign methods.
         self.assertAllClose(0., self.evaluate(state_ops.assign(x, 0.)))
         self.assertAllClose(3.14, self.evaluate(state_ops.assign(x, 3.14)))


### PR DESCRIPTION
Assignments and sparse updates will now return a new instance of `AutoCastVariable`, wrapping the [`_UnreadVariable`](https://github.com/tensorflow/tensorflow/blob/2692ea8ec1953e42952597adb5b5099181a679b2/tensorflow/python/ops/resource_variable_ops.py#L1806) returned from the assignment op, so that the `dtype` is preserved.

Closes #34332

/cc @reedwm @alextp