### PR TITLE
Added usage examples for multiple API symbols

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -942,9 +942,9 @@ def resize_image_with_crop_or_pad(image, target_height, target_width):
   
   Usage Example:
     ```python
-    >> import tensorflow as tf
-    >> x = tf.random.normal(shape=(256, 256, 3))
-    >> tf.image.resize_with_crop_or_pad(x, 200, 200)
+    >>> import tensorflow as tf
+    >>> x = tf.random.normal(shape=(256, 256, 3))
+    >>> tf.image.resize_with_crop_or_pad(x, 200, 200)
     ```
 
   Args:
@@ -1496,9 +1496,9 @@ def resize_image_with_pad_v2(image,
   
   Usage Example:
     ```python
-    >> import tensorflow as tf
-    >> x = tf.random.normal(shape=(256, 256, 3))
-    >> tf.image.resize_with_pad(x, 200, 200, tf.image.ResizeMethod.BILINEAR, False)
+    >>> import tensorflow as tf
+    >>> x = tf.random.normal(shape=(256, 256, 3))
+    >>> tf.image.resize_with_pad(x, 200, 200, tf.image.ResizeMethod.BILINEAR, False)
     ```
 
   Args:
@@ -1581,9 +1581,9 @@ def random_brightness(image, max_delta, seed=None):
   
   Usage Example:
     ```python
-    >> import tensorflow as tf
-    >> x = tf.random.normal(shape=(256, 256, 3))
-    >> tf.image.random_brightness(x, 0.8, 1)
+    >>> import tensorflow as tf
+    >>> x = tf.random.normal(shape=(256, 256, 3))
+    >>> tf.image.random_brightness(x, 0.8, 1)
     ```
 
   Args:
@@ -1614,9 +1614,9 @@ def random_contrast(image, lower, upper, seed=None):
   
   Usage Example:
     ```python
-    >> import tensorflow as tf
-    >> x = tf.random.normal(shape=(256, 256, 3))
-    >> tf.image.random_contrast(x, 0.2, 0.8, 1)
+    >>> import tensorflow as tf
+    >>> x = tf.random.normal(shape=(256, 256, 3))
+    >>> tf.image.random_contrast(x, 0.2, 0.8, 1)
     ```
 
   Args:

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -955,6 +955,13 @@ def resize_image_with_crop_or_pad(image, target_height, target_width):
     `[batch, new_height, new_width, channels]`.
     If `images` was 3-D, a 3-D float Tensor of shape
     `[new_height, new_width, channels]`.
+	
+  Usage Example:
+    ```python
+    >> import tensorflow as tf
+    >> x = tf.random.normal(shape=(256, 256, 3))
+    >> tf.image.resize_with_crop_or_pad(x, 200, 200)
+    ```
   """
   with ops.name_scope(None, 'resize_image_with_crop_or_pad', [image]):
     image = ops.convert_to_tensor(image, name='image')
@@ -1504,6 +1511,13 @@ def resize_image_with_pad_v2(image,
     `[batch, new_height, new_width, channels]`.
     If `images` was 3-D, a 3-D float Tensor of shape
     `[new_height, new_width, channels]`.
+	
+  Usage Example:
+    ```python
+    >> import tensorflow as tf
+    >> x = tf.random.normal(shape=(256, 256, 3))
+    >> tf.image.resize_with_pad(x, 200, 200, tf.image.ResizeMethod.BILINEAR, False)
+    ```
   """
 
   def _resize_fn(im, new_size):
@@ -1576,6 +1590,13 @@ def random_brightness(image, max_delta, seed=None):
 
   Raises:
     ValueError: if `max_delta` is negative.
+	
+  Usage Example:
+    ```python
+    >> import tensorflow as tf
+    >> x = tf.random.normal(shape=(256, 256, 3))
+    >> tf.image.random_brightness(x, 0.8, 1)
+    ```
   """
   if max_delta < 0:
     raise ValueError('max_delta must be non-negative.')
@@ -1603,6 +1624,13 @@ def random_contrast(image, lower, upper, seed=None):
 
   Raises:
     ValueError: if `upper <= lower` or if `lower < 0`.
+	
+  Usage Example:
+    ```python
+    >> import tensorflow as tf
+    >> x = tf.random.normal(shape=(256, 256, 3))
+    >> tf.image.random_contrast(x, 0.2, 0.8, 1)
+    ```
   """
   if upper <= lower:
     raise ValueError('upper must be > lower.')

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1517,7 +1517,7 @@ def resize_image_with_pad_v2(image,
     If `images` was 4-D, a 4-D float Tensor of shape
     `[batch, new_height, new_width, channels]`.
     If `images` was 3-D, a 3-D float Tensor of shape
-    `[new_height, new_width, channels]`
+    `[new_height, new_width, channels]`.
   """
 
   def _resize_fn(im, new_size):

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -939,6 +939,13 @@ def resize_image_with_crop_or_pad(image, target_height, target_width):
   If `width` or `height` is smaller than the specified `target_width` or
   `target_height` respectively, this op centrally pads with 0 along that
   dimension.
+  
+  Usage Example:
+    ```python
+    >> import tensorflow as tf
+    >> x = tf.random.normal(shape=(256, 256, 3))
+    >> tf.image.resize_with_crop_or_pad(x, 200, 200)
+    ```
 
   Args:
     image: 4-D Tensor of shape `[batch, height, width, channels]` or 3-D Tensor
@@ -955,13 +962,6 @@ def resize_image_with_crop_or_pad(image, target_height, target_width):
     `[batch, new_height, new_width, channels]`.
     If `images` was 3-D, a 3-D float Tensor of shape
     `[new_height, new_width, channels]`.
-	
-  Usage Example:
-    ```python
-    >> import tensorflow as tf
-    >> x = tf.random.normal(shape=(256, 256, 3))
-    >> tf.image.resize_with_crop_or_pad(x, 200, 200)
-    ```
   """
   with ops.name_scope(None, 'resize_image_with_crop_or_pad', [image]):
     image = ops.convert_to_tensor(image, name='image')
@@ -1493,6 +1493,13 @@ def resize_image_with_pad_v2(image,
   dimensions don't match the image dimensions, the image
   is resized and then padded with zeroes to match requested
   dimensions.
+  
+  Usage Example:
+    ```python
+    >> import tensorflow as tf
+    >> x = tf.random.normal(shape=(256, 256, 3))
+    >> tf.image.resize_with_pad(x, 200, 200, tf.image.ResizeMethod.BILINEAR, False)
+    ```
 
   Args:
     image: 4-D Tensor of shape `[batch, height, width, channels]` or 3-D Tensor
@@ -1510,14 +1517,7 @@ def resize_image_with_pad_v2(image,
     If `images` was 4-D, a 4-D float Tensor of shape
     `[batch, new_height, new_width, channels]`.
     If `images` was 3-D, a 3-D float Tensor of shape
-    `[new_height, new_width, channels]`.
-	
-  Usage Example:
-    ```python
-    >> import tensorflow as tf
-    >> x = tf.random.normal(shape=(256, 256, 3))
-    >> tf.image.resize_with_pad(x, 200, 200, tf.image.ResizeMethod.BILINEAR, False)
-    ```
+    `[new_height, new_width, channels]`
   """
 
   def _resize_fn(im, new_size):
@@ -1578,6 +1578,13 @@ def random_brightness(image, max_delta, seed=None):
 
   Equivalent to `adjust_brightness()` using a `delta` randomly picked in the
   interval `[-max_delta, max_delta)`.
+  
+  Usage Example:
+    ```python
+    >> import tensorflow as tf
+    >> x = tf.random.normal(shape=(256, 256, 3))
+    >> tf.image.random_brightness(x, 0.8, 1)
+    ```
 
   Args:
     image: An image or images to adjust.
@@ -1590,13 +1597,6 @@ def random_brightness(image, max_delta, seed=None):
 
   Raises:
     ValueError: if `max_delta` is negative.
-	
-  Usage Example:
-    ```python
-    >> import tensorflow as tf
-    >> x = tf.random.normal(shape=(256, 256, 3))
-    >> tf.image.random_brightness(x, 0.8, 1)
-    ```
   """
   if max_delta < 0:
     raise ValueError('max_delta must be non-negative.')
@@ -1611,6 +1611,13 @@ def random_contrast(image, lower, upper, seed=None):
 
   Equivalent to `adjust_contrast()` but uses a `contrast_factor` randomly
   picked in the interval `[lower, upper]`.
+  
+  Usage Example:
+    ```python
+    >> import tensorflow as tf
+    >> x = tf.random.normal(shape=(256, 256, 3))
+    >> tf.image.random_contrast(x, 0.2, 0.8, 1)
+    ```
 
   Args:
     image: An image tensor with 3 or more dimensions.
@@ -1624,13 +1631,6 @@ def random_contrast(image, lower, upper, seed=None):
 
   Raises:
     ValueError: if `upper <= lower` or if `lower < 0`.
-	
-  Usage Example:
-    ```python
-    >> import tensorflow as tf
-    >> x = tf.random.normal(shape=(256, 256, 3))
-    >> tf.image.random_contrast(x, 0.2, 0.8, 1)
-    ```
   """
   if upper <= lower:
     raise ValueError('upper must be > lower.')

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -1139,10 +1139,8 @@ def multiply_no_nan(x, y, name=None):
   
   Usage Example:
     ```python
-    >> import tensorflow as tf
-    >> x = tf.constant([[1.0, 3.0], [5.0, 4.0]])
-    >> y = tf.constant([[7.0, 2.0], [1.0, 9.0]])
-    >> tf.math.multiply_no_nan(x, y) # [[7, 6] [5, 36]]
+    >>> import tensorflow as tf
+    >>> tf.math.multiply_no_nan([[1.0, 3.0], [5.0, 4.0]], [[7.0, 2.0], [1.0, 9.0]]) # [[7, 6] [5, 36]]
     ```
 
   Args:
@@ -4211,9 +4209,9 @@ def reciprocal_no_nan(x, name=None):
   
   Usage Example:
     ```python
-    >> import tensorflow as tf
-    >> x = tf.constant([1.0, 2.0, 4.0])
-    >> tf.math.reciprocal_no_nan(x) # [1, 0.5, 0.25]
+    >>> import tensorflow as tf
+    >>> x = tf.constant([1.0, 2.0, 4.0])
+    >>> tf.math.reciprocal_no_nan(x) # [1, 0.5, 0.25]
     ```
 
   Args:

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -1136,6 +1136,14 @@ def div_no_nan(x, y, name=None):
 @dispatch.add_dispatch_support
 def multiply_no_nan(x, y, name=None):
   """Computes the product of x and y and returns 0 if the y is zero, even if x is NaN or infinite.
+  
+  Usage Example:
+    ```python
+    >> import tensorflow as tf
+    >> x = tf.constant([[1.0, 3.0], [5.0, 4.0]])
+    >> y = tf.constant([[7.0, 2.0], [1.0, 9.0]])
+    >> tf.math.multiply_no_nan(x, y) # [[7, 6] [5, 36]]
+    ```
 
   Args:
     x: A `Tensor`. Must be one of the following types: `float32`, `float64`.
@@ -1144,14 +1152,6 @@ def multiply_no_nan(x, y, name=None):
 
   Returns:
     The element-wise value of the x times y.
-
-  Usage Example:
-    ```python
-    >> import tensorflow as tf
-    >> x = tf.constant([[1.0, 3.0], [5.0, 4.0]])
-    >> y = tf.constant([[7.0, 2.0], [1.0, 9.0]])
-    >> tf.math.multiply_no_nan(x, y) # [[7, 6] [5, 36]]
-    ```
   """
 
   with ops.name_scope(name, "multiply_no_nan", [x, y]) as name:
@@ -4208,6 +4208,13 @@ def reciprocal_no_nan(x, name=None):
   x = tf.constant([2.0, 0.5, 0, 1], dtype=tf.float32)
   tf.math.reciprocal_no_nan(x)  # [ 0.5, 2, 0.0, 1.0 ]
   ```
+  
+  Usage Example:
+    ```python
+    >> import tensorflow as tf
+    >> x = tf.constant([1.0, 2.0, 4.0])
+    >> tf.math.reciprocal_no_nan(x) # [1, 0.5, 0.25]
+    ```
 
   Args:
     x: A `Tensor` of type `float16`, `float32`, `float64` `complex64` or
@@ -4219,13 +4226,6 @@ def reciprocal_no_nan(x, name=None):
 
   Raises:
     TypeError: x must be of a valid dtype.
-
-  Usage Example:
-    ```python
-    >> import tensorflow as tf
-    >> x = tf.constant([1.0, 2.0, 4.0])
-    >> tf.math.reciprocal_no_nan(x) # [1, 0.5, 0.25]
-    ```
   """
 
   with ops.name_scope(name, "reciprocal_no_nan", [x]) as scope:

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -1144,6 +1144,14 @@ def multiply_no_nan(x, y, name=None):
 
   Returns:
     The element-wise value of the x times y.
+
+  Usage Example:
+    ```python
+    >> import tensorflow as tf
+    >> x = tf.constant([[1.0, 3.0], [5.0, 4.0]])
+    >> y = tf.constant([[7.0, 2.0], [1.0, 9.0]])
+    >> tf.math.multiply_no_nan(x, y) # [[7, 6] [5, 36]]
+    ```
   """
 
   with ops.name_scope(name, "multiply_no_nan", [x, y]) as name:
@@ -4212,6 +4220,12 @@ def reciprocal_no_nan(x, name=None):
   Raises:
     TypeError: x must be of a valid dtype.
 
+  Usage Example:
+    ```python
+    >> import tensorflow as tf
+    >> x = tf.constant([1.0, 2.0, 4.0])
+    >> tf.math.reciprocal_no_nan(x) # [1, 0.5, 0.25]
+    ```
   """
 
   with ops.name_scope(name, "reciprocal_no_nan", [x]) as scope:

--- a/tensorflow/python/ops/random_ops.py
+++ b/tensorflow/python/ops/random_ops.py
@@ -354,9 +354,9 @@ def random_crop(value, size, seed=None, name=None):
   
   Usage Example:
     ```python
-    >> import tensorflow as tf
-    >> x = tf.random.normal(shape=(256, 256, 3))
-    >> tf.image.random_crop(x, size=[200, 200, 3])
+    >>> import tensorflow as tf
+    >>> x = tf.random.normal(shape=(256, 256, 3))
+    >>> tf.image.random_crop(x, size=[200, 200, 3])
     ```
 
   Args:

--- a/tensorflow/python/ops/random_ops.py
+++ b/tensorflow/python/ops/random_ops.py
@@ -362,6 +362,13 @@ def random_crop(value, size, seed=None, name=None):
 
   Returns:
     A cropped tensor of the same rank as `value` and shape `size`.
+	
+  Usage Example:
+    ```python
+    >> import tensorflow as tf
+    >> x = tf.random.normal(shape=(256, 256, 3))
+    >> tf.image.random_crop(x, size=[200, 200, 3])
+    ```
   """
   # TODO(shlens): Implement edge case to guarantee output size dimensions.
   # If size > value.shape, zero pad the result so that it always has shape

--- a/tensorflow/python/ops/random_ops.py
+++ b/tensorflow/python/ops/random_ops.py
@@ -351,6 +351,13 @@ def random_crop(value, size, seed=None, name=None):
   If a dimension should not be cropped, pass the full size of that dimension.
   For example, RGB images can be cropped with
   `size = [crop_height, crop_width, 3]`.
+  
+  Usage Example:
+    ```python
+    >> import tensorflow as tf
+    >> x = tf.random.normal(shape=(256, 256, 3))
+    >> tf.image.random_crop(x, size=[200, 200, 3])
+    ```
 
   Args:
     value: Input tensor to crop.
@@ -362,13 +369,6 @@ def random_crop(value, size, seed=None, name=None):
 
   Returns:
     A cropped tensor of the same rank as `value` and shape `size`.
-	
-  Usage Example:
-    ```python
-    >> import tensorflow as tf
-    >> x = tf.random.normal(shape=(256, 256, 3))
-    >> tf.image.random_crop(x, size=[200, 200, 3])
-    ```
   """
   # TODO(shlens): Implement edge case to guarantee output size dimensions.
   # If size > value.shape, zero pad the result so that it always has shape


### PR DESCRIPTION
Added usage examples for image.resize_with_crop_or_pad, image.resize_with_pad, image.random_brightness, image.random_contrast, image.random_crop, math.multiply_no_nan, and math.reciprocal_no_nan.