### PR TITLE
Update systemlibs protobuf vars

### DIFF
--- a/third_party/systemlibs/protobuf.BUILD
+++ b/third_party/systemlibs/protobuf.BUILD
@@ -31,7 +31,6 @@ HEADERS = [
     "google/protobuf/io/zero_copy_stream.h",
     "google/protobuf/io/zero_copy_stream_impl_lite.h",
     "google/protobuf/map.h",
-    "google/protobuf/port_def.inc",
     "google/protobuf/repeated_field.h",
     "google/protobuf/text_format.h",
     "google/protobuf/timestamp.pb.h",

--- a/third_party/systemlibs/protobuf.bzl
+++ b/third_party/systemlibs/protobuf.bzl
@@ -274,8 +274,8 @@ def internal_gen_well_known_protos_java(srcs):
     Args:
       srcs: the well known protos
     """
-    root = Label("%s//protobuf_java" % (REPOSITORY_NAME)).workspace_root
-    pkg = PACKAGE_NAME + "/" if PACKAGE_NAME else ""
+    root = Label("%s//protobuf_java" % (native.repository_name())).workspace_root
+    pkg = native.package_name() + "/" if native.package_name() else ""
     if root == "":
         include = " -I%ssrc " % pkg
     else:


### PR DESCRIPTION
Small patch to enable latest master builds using external ```protoc```

```REPOSITORY_NAME``` and ```PACKAGE_NAME``` are no longer valid in newer bazel.

Bringing the attention of @perfinion .
