### PR TITLE
[ROCm] Fix for the broken ROCm CSB - 191203 - eigen

### DIFF
--- a/third_party/eigen3/gpu_packet_math.patch
+++ b/third_party/eigen3/gpu_packet_math.patch
@@ -22,4 +22,27 @@
      return res;
    }
  };
- 
+--- a/Eigen/src/Core/GenericPacketMath.h
++++ b/Eigen/src/Core/GenericPacketMath.h
+@@ -247,7 +247,8 @@
+ template <typename Packet>
+ EIGEN_DEVICE_FUNC inline Packet pfrexp(const Packet& a, Packet& exponent) {
+   int exp;
+-  Packet result = std::frexp(a, &exp);
++  EIGEN_USING_STD_MATH(frexp);
++  Packet result = frexp(a, &exp);
+   exponent = static_cast<Packet>(exp);
+   return result;
+ }
+@@ -256,6 +257,9 @@
+   * See https://en.cppreference.com/w/cpp/numeric/math/ldexp
+   */
+ template<typename Packet> EIGEN_DEVICE_FUNC inline Packet
+-pldexp(const Packet &a, const Packet &exponent) { return std::ldexp(a, static_cast<int>(exponent)); }
++pldexp(const Packet &a, const Packet &exponent) {
++  EIGEN_USING_STD_MATH(ldexp);
++  return ldexp(a, static_cast<int>(exponent));
++}
+
+ /** \internal \returns zeros */
+ template<typename Packet> EIGEN_DEVICE_FUNC inline Packet


### PR DESCRIPTION
The following commit breaks the --config=rocm build

https://github.com/tensorflow/tensorflow/commit/3bc9dd3b776c26fbd8d4eba7917fe873a5596e40

The above commit moves the eigen repo pointer to a commit that breaks the ROCm build. The fix for the ROCm errors has been merged into the Eigen repo ( https://bitbucket.org/eigen/eigen/commits/177c403a361be18ab9ce76594b0ece232f1c8da4 ). Until the eigen repo pointer in workspace.bzl is moved to a commit that includes the above fix, we need to apply the same fix via a patch file to make the ROCm build functional again.


/cc @rmlarsen @whchung 