### PR TITLE
[ROCm] Add ROCm support for CSR Sparse Matrix Ops

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -3459,14 +3459,18 @@ tf_kernel_library(
 
 tf_kernel_library(
     name = "cuda_sparse",
-    srcs = ["cuda_sparse.cc"],
+    srcs = if_cuda(["cuda_sparse.cc"]) + if_rocm(["rocm_sparse.cc"]),
     hdrs = ["cuda_sparse.h"],
     deps = [
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",
         "//tensorflow/core/kernels:cuda_solvers",
+    ] + if_cuda([
         "//tensorflow/stream_executor/cuda:cusparse_lib",
-    ] + if_cuda(["@cub_archive//:cub"]),
+        "@cub_archive//:cub",
+    ]) + if_rocm([
+        "@local_config_rocm//rocm:hipsparse",
+    ]),
 )
 
 LINALG_DEPS = [

--- a/tensorflow/core/kernels/cuda_sparse.cc
+++ b/tensorflow/core/kernels/cuda_sparse.cc
@@ -69,7 +69,7 @@ inline typename CudaComplexT<T>::type* AsCudaComplex(T* p) {
 }
 
 // A set of initialized handles to the underlying Cuda libraries used by
-// CudaSparse. We maintain one such set of handles per unique stream.
+// GpuSparse. We maintain one such set of handles per unique stream.
 class CudaSparseHandles {
  public:
   explicit CudaSparseHandles(cudaStream_t stream)
@@ -96,8 +96,8 @@ class CudaSparseHandles {
 
   Status Initialize() {
     if (initialized_) return Status::OK();
-    TF_RETURN_IF_CUSPARSE_ERROR(cusparseCreate(&cusparse_handle_));
-    TF_RETURN_IF_CUSPARSE_ERROR(cusparseSetStream(cusparse_handle_, stream_));
+    TF_RETURN_IF_GPUSPARSE_ERROR(cusparseCreate(&cusparse_handle_));
+    TF_RETURN_IF_GPUSPARSE_ERROR(cusparseSetStream(cusparse_handle_, stream_));
     initialized_ = true;
     return Status::OK();
   }
@@ -149,7 +149,7 @@ HandleMap* GetHandleMapSingleton() {
 
 }  // namespace
 
-CudaSparse::CudaSparse(OpKernelContext* context)
+GpuSparse::GpuSparse(OpKernelContext* context)
     : initialized_(false), context_(context) {
   auto cuda_stream_ptr =
       reinterpret_cast<const cudaStream_t*>(context->op_device_context()
@@ -157,25 +157,24 @@ CudaSparse::CudaSparse(OpKernelContext* context)
                                                 ->implementation()
                                                 ->GpuStreamMemberHack());
   DCHECK(cuda_stream_ptr);
-  cuda_stream_ = *cuda_stream_ptr;
+  gpu_stream_ = *cuda_stream_ptr;
 }
 
-Status CudaSparse::Initialize() {
+Status GpuSparse::Initialize() {
   HandleMap* handle_map = GetHandleMapSingleton();
   DCHECK(handle_map);
   mutex_lock lock(handle_map_mutex);
-  auto it = handle_map->find(cuda_stream_);
+  auto it = handle_map->find(gpu_stream_);
   if (it == handle_map->end()) {
-    LOG(INFO) << "Creating CudaSparse handles for stream " << cuda_stream_;
+    LOG(INFO) << "Creating CudaSparse handles for stream " << gpu_stream_;
     // Previously unseen Cuda stream. Initialize a set of Cuda sparse library
     // handles for it.
-    CudaSparseHandles new_handles(cuda_stream_);
+    CudaSparseHandles new_handles(gpu_stream_);
     TF_RETURN_IF_ERROR(new_handles.Initialize());
-    it =
-        handle_map->insert(std::make_pair(cuda_stream_, std::move(new_handles)))
-            .first;
+    it = handle_map->insert(std::make_pair(gpu_stream_, std::move(new_handles)))
+             .first;
   }
-  cusparse_handle_ = &it->second.handle();
+  gpusparse_handle_ = &it->second.handle();
   initialized_ = true;
   return Status::OK();
 }
@@ -205,32 +204,32 @@ template <typename Scalar, typename SparseFn>
 static inline Status GtsvImpl(SparseFn op, cusparseHandle_t cusparse_handle,
                               int m, int n, const Scalar* dl, const Scalar* d,
                               const Scalar* du, Scalar* B, int ldb) {
-  TF_RETURN_IF_CUSPARSE_ERROR(op(cusparse_handle, m, n, AsCudaComplex(dl),
-                                 AsCudaComplex(d), AsCudaComplex(du),
-                                 AsCudaComplex(B), ldb));
+  TF_RETURN_IF_GPUSPARSE_ERROR(op(cusparse_handle, m, n, AsCudaComplex(dl),
+                                  AsCudaComplex(d), AsCudaComplex(du),
+                                  AsCudaComplex(B), ldb));
   return Status::OK();
 }
 
-#define GTSV_INSTANCE(Scalar, sparse_prefix)                                 \
-  template <>                                                                \
-  Status CudaSparse::Gtsv<Scalar>(int m, int n, const Scalar* dl,            \
-                                  const Scalar* d, const Scalar* du,         \
-                                  Scalar* B, int ldb) const {                \
-    DCHECK(initialized_);                                                    \
-    return GtsvImpl(SPARSE_FN(gtsv, sparse_prefix), *cusparse_handle_, m, n, \
-                    dl, d, du, B, ldb);                                      \
+#define GTSV_INSTANCE(Scalar, sparse_prefix)                                   \
+  template <>                                                                  \
+  Status GpuSparse::Gtsv<Scalar>(int m, int n, const Scalar* dl,               \
+                                 const Scalar* d, const Scalar* du, Scalar* B, \
+                                 int ldb) const {                              \
+    DCHECK(initialized_);                                                      \
+    return GtsvImpl(SPARSE_FN(gtsv, sparse_prefix), *gpusparse_handle_, m, n,  \
+                    dl, d, du, B, ldb);                                        \
   }
 
 TF_CALL_LAPACK_TYPES(GTSV_INSTANCE);
 
-#define GTSV_NO_PIVOT_INSTANCE(Scalar, sparse_prefix)                          \
-  template <>                                                                  \
-  Status CudaSparse::GtsvNoPivot<Scalar>(int m, int n, const Scalar* dl,       \
-                                         const Scalar* d, const Scalar* du,    \
-                                         Scalar* B, int ldb) const {           \
-    DCHECK(initialized_);                                                      \
-    return GtsvImpl(SPARSE_FN(gtsv_nopivot, sparse_prefix), *cusparse_handle_, \
-                    m, n, dl, d, du, B, ldb);                                  \
+#define GTSV_NO_PIVOT_INSTANCE(Scalar, sparse_prefix)                      \
+  template <>                                                              \
+  Status GpuSparse::GtsvNoPivot<Scalar>(int m, int n, const Scalar* dl,    \
+                                        const Scalar* d, const Scalar* du, \
+                                        Scalar* B, int ldb) const {        \
+    DCHECK(initialized_);                                                  \
+    return GtsvImpl(SPARSE_FN(gtsv_nopivot, sparse_prefix),                \
+                    *gpusparse_handle_, m, n, dl, d, du, B, ldb);          \
   }
 
 TF_CALL_LAPACK_TYPES(GTSV_NO_PIVOT_INSTANCE);
@@ -242,20 +241,20 @@ static inline Status GtsvStridedBatchImpl(SparseFn op,
                                           const Scalar* d, const Scalar* du,
                                           Scalar* x, int batchCount,
                                           int batchStride) {
-  TF_RETURN_IF_CUSPARSE_ERROR(op(cusparse_handle, m, AsCudaComplex(dl),
-                                 AsCudaComplex(d), AsCudaComplex(du),
-                                 AsCudaComplex(x), batchCount, batchStride));
+  TF_RETURN_IF_GPUSPARSE_ERROR(op(cusparse_handle, m, AsCudaComplex(dl),
+                                  AsCudaComplex(d), AsCudaComplex(du),
+                                  AsCudaComplex(x), batchCount, batchStride));
   return Status::OK();
 }
 
 #define GTSV_STRIDED_BATCH_INSTANCE(Scalar, sparse_prefix)                   \
   template <>                                                                \
-  Status CudaSparse::GtsvStridedBatch<Scalar>(                               \
+  Status GpuSparse::GtsvStridedBatch<Scalar>(                                \
       int m, const Scalar* dl, const Scalar* d, const Scalar* du, Scalar* x, \
       int batchCount, int batchStride) const {                               \
     DCHECK(initialized_);                                                    \
     return GtsvStridedBatchImpl(SPARSE_FN(gtsvStridedBatch, sparse_prefix),  \
-                                *cusparse_handle_, m, dl, d, du, x,          \
+                                *gpusparse_handle_, m, dl, d, du, x,         \
                                 batchCount, batchStride);                    \
   }
 
@@ -266,32 +265,32 @@ static inline Status Gtsv2Impl(SparseFn op, cusparseHandle_t cusparse_handle,
                                int m, int n, const Scalar* dl, const Scalar* d,
                                const Scalar* du, Scalar* B, int ldb,
                                void* pBuffer) {
-  TF_RETURN_IF_CUSPARSE_ERROR(op(cusparse_handle, m, n, AsCudaComplex(dl),
-                                 AsCudaComplex(d), AsCudaComplex(du),
-                                 AsCudaComplex(B), ldb, pBuffer));
+  TF_RETURN_IF_GPUSPARSE_ERROR(op(cusparse_handle, m, n, AsCudaComplex(dl),
+                                  AsCudaComplex(d), AsCudaComplex(du),
+                                  AsCudaComplex(B), ldb, pBuffer));
   return Status::OK();
 }
 
-#define GTSV2_INSTANCE(Scalar, sparse_prefix)                                  \
-  template <>                                                                  \
-  Status CudaSparse::Gtsv2<Scalar>(int m, int n, const Scalar* dl,             \
-                                   const Scalar* d, const Scalar* du,          \
-                                   Scalar* B, int ldb, void* pBuffer) const {  \
-    DCHECK(initialized_);                                                      \
-    return Gtsv2Impl(SPARSE_FN(gtsv2, sparse_prefix), *cusparse_handle_, m, n, \
-                     dl, d, du, B, ldb, pBuffer);                              \
+#define GTSV2_INSTANCE(Scalar, sparse_prefix)                                \
+  template <>                                                                \
+  Status GpuSparse::Gtsv2<Scalar>(int m, int n, const Scalar* dl,            \
+                                  const Scalar* d, const Scalar* du,         \
+                                  Scalar* B, int ldb, void* pBuffer) const { \
+    DCHECK(initialized_);                                                    \
+    return Gtsv2Impl(SPARSE_FN(gtsv2, sparse_prefix), *gpusparse_handle_, m, \
+                     n, dl, d, du, B, ldb, pBuffer);                         \
   }
 
 TF_CALL_LAPACK_TYPES(GTSV2_INSTANCE);
 
-#define GTSV2_NO_PIVOT_INSTANCE(Scalar, sparse_prefix)                     \
-  template <>                                                              \
-  Status CudaSparse::Gtsv2NoPivot<Scalar>(                                 \
-      int m, int n, const Scalar* dl, const Scalar* d, const Scalar* du,   \
-      Scalar* B, int ldb, void* pBuffer) const {                           \
-    DCHECK(initialized_);                                                  \
-    return Gtsv2Impl(SPARSE_FN(gtsv2_nopivot, sparse_prefix),              \
-                     *cusparse_handle_, m, n, dl, d, du, B, ldb, pBuffer); \
+#define GTSV2_NO_PIVOT_INSTANCE(Scalar, sparse_prefix)                      \
+  template <>                                                               \
+  Status GpuSparse::Gtsv2NoPivot<Scalar>(                                   \
+      int m, int n, const Scalar* dl, const Scalar* d, const Scalar* du,    \
+      Scalar* B, int ldb, void* pBuffer) const {                            \
+    DCHECK(initialized_);                                                   \
+    return Gtsv2Impl(SPARSE_FN(gtsv2_nopivot, sparse_prefix),               \
+                     *gpusparse_handle_, m, n, dl, d, du, B, ldb, pBuffer); \
   }
 
 TF_CALL_LAPACK_TYPES(GTSV2_NO_PIVOT_INSTANCE);
@@ -303,34 +302,34 @@ static inline Status Gtsv2BufferSizeExtImpl(SparseFn op,
                                             const Scalar* d, const Scalar* du,
                                             const Scalar* B, int ldb,
                                             size_t* bufferSizeInBytes) {
-  TF_RETURN_IF_CUSPARSE_ERROR(op(cusparse_handle, m, n, AsCudaComplex(dl),
-                                 AsCudaComplex(d), AsCudaComplex(du),
-                                 AsCudaComplex(B), ldb, bufferSizeInBytes));
+  TF_RETURN_IF_GPUSPARSE_ERROR(op(cusparse_handle, m, n, AsCudaComplex(dl),
+                                  AsCudaComplex(d), AsCudaComplex(du),
+                                  AsCudaComplex(B), ldb, bufferSizeInBytes));
   return Status::OK();
 }
 
-#define GTSV2_BUFFER_SIZE_INSTANCE(Scalar, sparse_prefix)                    \
-  template <>                                                                \
-  Status CudaSparse::Gtsv2BufferSizeExt<Scalar>(                             \
-      int m, int n, const Scalar* dl, const Scalar* d, const Scalar* du,     \
-      const Scalar* B, int ldb, size_t* bufferSizeInBytes) const {           \
-    DCHECK(initialized_);                                                    \
-    return Gtsv2BufferSizeExtImpl(                                           \
-        SPARSE_FN(gtsv2_bufferSizeExt, sparse_prefix), *cusparse_handle_, m, \
-        n, dl, d, du, B, ldb, bufferSizeInBytes);                            \
+#define GTSV2_BUFFER_SIZE_INSTANCE(Scalar, sparse_prefix)                     \
+  template <>                                                                 \
+  Status GpuSparse::Gtsv2BufferSizeExt<Scalar>(                               \
+      int m, int n, const Scalar* dl, const Scalar* d, const Scalar* du,      \
+      const Scalar* B, int ldb, size_t* bufferSizeInBytes) const {            \
+    DCHECK(initialized_);                                                     \
+    return Gtsv2BufferSizeExtImpl(                                            \
+        SPARSE_FN(gtsv2_bufferSizeExt, sparse_prefix), *gpusparse_handle_, m, \
+        n, dl, d, du, B, ldb, bufferSizeInBytes);                             \
   }
 
 TF_CALL_LAPACK_TYPES(GTSV2_BUFFER_SIZE_INSTANCE);
 
 #define GTSV2_NO_PIVOT_BUFFER_SIZE_INSTANCE(Scalar, sparse_prefix)       \
   template <>                                                            \
-  Status CudaSparse::Gtsv2NoPivotBufferSizeExt<Scalar>(                  \
+  Status GpuSparse::Gtsv2NoPivotBufferSizeExt<Scalar>(                   \
       int m, int n, const Scalar* dl, const Scalar* d, const Scalar* du, \
       const Scalar* B, int ldb, size_t* bufferSizeInBytes) const {       \
     DCHECK(initialized_);                                                \
     return Gtsv2BufferSizeExtImpl(                                       \
         SPARSE_FN(gtsv2_nopivot_bufferSizeExt, sparse_prefix),           \
-        *cusparse_handle_, m, n, dl, d, du, B, ldb, bufferSizeInBytes);  \
+        *gpusparse_handle_, m, n, dl, d, du, B, ldb, bufferSizeInBytes); \
   }
 
 TF_CALL_LAPACK_TYPES(GTSV2_NO_PIVOT_BUFFER_SIZE_INSTANCE);
@@ -342,7 +341,7 @@ static inline Status Gtsv2StridedBatchImpl(SparseFn op,
                                            const Scalar* d, const Scalar* du,
                                            Scalar* x, int batchCount,
                                            int batchStride, void* pBuffer) {
-  TF_RETURN_IF_CUSPARSE_ERROR(op(
+  TF_RETURN_IF_GPUSPARSE_ERROR(op(
       cusparse_handle, m, AsCudaComplex(dl), AsCudaComplex(d),
       AsCudaComplex(du), AsCudaComplex(x), batchCount, batchStride, pBuffer));
   return Status::OK();
@@ -350,12 +349,12 @@ static inline Status Gtsv2StridedBatchImpl(SparseFn op,
 
 #define GTSV2_STRIDED_BATCH_INSTANCE(Scalar, sparse_prefix)                   \
   template <>                                                                 \
-  Status CudaSparse::Gtsv2StridedBatch<Scalar>(                               \
+  Status GpuSparse::Gtsv2StridedBatch<Scalar>(                                \
       int m, const Scalar* dl, const Scalar* d, const Scalar* du, Scalar* x,  \
       int batchCount, int batchStride, void* pBuffer) const {                 \
     DCHECK(initialized_);                                                     \
     return Gtsv2StridedBatchImpl(SPARSE_FN(gtsv2StridedBatch, sparse_prefix), \
-                                 *cusparse_handle_, m, dl, d, du, x,          \
+                                 *gpusparse_handle_, m, dl, d, du, x,         \
                                  batchCount, batchStride, pBuffer);           \
   }
 
@@ -366,30 +365,30 @@ static inline Status Gtsv2StridedBatchBufferSizeImpl(
     SparseFn op, cusparseHandle_t cusparse_handle, int m, const Scalar* dl,
     const Scalar* d, const Scalar* du, const Scalar* x, int batchCount,
     int batchStride, size_t* bufferSizeInBytes) {
-  TF_RETURN_IF_CUSPARSE_ERROR(op(cusparse_handle, m, AsCudaComplex(dl),
-                                 AsCudaComplex(d), AsCudaComplex(du),
-                                 AsCudaComplex(x), batchCount, batchStride,
-                                 bufferSizeInBytes));
+  TF_RETURN_IF_GPUSPARSE_ERROR(op(cusparse_handle, m, AsCudaComplex(dl),
+                                  AsCudaComplex(d), AsCudaComplex(du),
+                                  AsCudaComplex(x), batchCount, batchStride,
+                                  bufferSizeInBytes));
   return Status::OK();
 }
 
 #define GTSV2_STRIDED_BATCH_BUFFER_SIZE_INSTANCE(Scalar, sparse_prefix) \
   template <>                                                           \
-  Status CudaSparse::Gtsv2StridedBatchBufferSizeExt<Scalar>(            \
+  Status GpuSparse::Gtsv2StridedBatchBufferSizeExt<Scalar>(             \
       int m, const Scalar* dl, const Scalar* d, const Scalar* du,       \
       const Scalar* x, int batchCount, int batchStride,                 \
       size_t* bufferSizeInBytes) const {                                \
     DCHECK(initialized_);                                               \
     return Gtsv2StridedBatchBufferSizeImpl(                             \
         SPARSE_FN(gtsv2StridedBatch_bufferSizeExt, sparse_prefix),      \
-        *cusparse_handle_, m, dl, d, du, x, batchCount, batchStride,    \
+        *gpusparse_handle_, m, dl, d, du, x, batchCount, batchStride,   \
         bufferSizeInBytes);                                             \
   }
 
 TF_CALL_LAPACK_TYPES(GTSV2_STRIDED_BATCH_BUFFER_SIZE_INSTANCE);
 
-Status CudaSparse::Coo2csr(const int* cooRowInd, int nnz, int m,
-                           int* csrRowPtr) const {
+Status GpuSparse::Coo2csr(const int* cooRowInd, int nnz, int m,
+                          int* csrRowPtr) const {
   // cusparseStatus_t CUSPARSEAPI cusparseXcoo2csr(cusparseHandle_t handle,
   //                                               const int *cooRowInd,
   //                                               int nnz,
@@ -398,14 +397,14 @@ Status CudaSparse::Coo2csr(const int* cooRowInd, int nnz, int m,
   //                                               cusparseIndexBase_t
   //                                               idxBase);
   DCHECK(initialized_);
-  TF_RETURN_IF_CUSPARSE_ERROR(cusparseXcoo2csr(*cusparse_handle_, cooRowInd,
-                                               nnz, m, csrRowPtr,
-                                               CUSPARSE_INDEX_BASE_ZERO));
+  TF_RETURN_IF_GPUSPARSE_ERROR(cusparseXcoo2csr(*gpusparse_handle_, cooRowInd,
+                                                nnz, m, csrRowPtr,
+                                                CUSPARSE_INDEX_BASE_ZERO));
   return Status::OK();
 }
 
-Status CudaSparse::Csr2coo(const int* csrRowPtr, int nnz, int m,
-                           int* cooRowInd) const {
+Status GpuSparse::Csr2coo(const int* csrRowPtr, int nnz, int m,
+                          int* cooRowInd) const {
   // cusparseStatus_t CUSPARSEAPI cusparseXcsr2coo(cusparseHandle_t handle,
   //                                               const int *csrRowPtr,
   //                                               int nnz,
@@ -414,26 +413,26 @@ Status CudaSparse::Csr2coo(const int* csrRowPtr, int nnz, int m,
   //                                               cusparseIndexBase_t
   //                                               idxBase);
   DCHECK(initialized_);
-  TF_RETURN_IF_CUSPARSE_ERROR(cusparseXcsr2coo(*cusparse_handle_, csrRowPtr,
-                                               nnz, m, cooRowInd,
-                                               CUSPARSE_INDEX_BASE_ZERO));
+  TF_RETURN_IF_GPUSPARSE_ERROR(cusparseXcsr2coo(*gpusparse_handle_, csrRowPtr,
+                                                nnz, m, cooRowInd,
+                                                CUSPARSE_INDEX_BASE_ZERO));
   return Status::OK();
 }
 
-Status CudaSparse::CsrgeamNnz(int m, int n, const cusparseMatDescr_t descrA,
-                              int nnzA, const int* csrSortedRowPtrA,
-                              const int* csrSortedColIndA,
-                              const cusparseMatDescr_t descrB, int nnzB,
-                              const int* csrSortedRowPtrB,
-                              const int* csrSortedColIndB,
-                              const cusparseMatDescr_t descrC,
-                              int* csrSortedRowPtrC, int* nnzTotalDevHostPtr) {
+Status GpuSparse::CsrgeamNnz(int m, int n, const cusparseMatDescr_t descrA,
+                             int nnzA, const int* csrSortedRowPtrA,
+                             const int* csrSortedColIndA,
+                             const cusparseMatDescr_t descrB, int nnzB,
+                             const int* csrSortedRowPtrB,
+                             const int* csrSortedColIndB,
+                             const cusparseMatDescr_t descrC,
+                             int* csrSortedRowPtrC, int* nnzTotalDevHostPtr) {
   DCHECK(initialized_);
   DCHECK(nnzTotalDevHostPtr != nullptr);
-  TF_RETURN_IF_CUSPARSE_ERROR(cusparseXcsrgeamNnz(
-      *cusparse_handle_, m, n, descrA, nnzA, csrSortedRowPtrA, csrSortedColIndA,
-      descrB, nnzB, csrSortedRowPtrB, csrSortedColIndB, descrC,
-      csrSortedRowPtrC, nnzTotalDevHostPtr));
+  TF_RETURN_IF_GPUSPARSE_ERROR(cusparseXcsrgeamNnz(
+      *gpusparse_handle_, m, n, descrA, nnzA, csrSortedRowPtrA,
+      csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB, csrSortedColIndB,
+      descrC, csrSortedRowPtrC, nnzTotalDevHostPtr));
   return Status::OK();
 }
 
@@ -452,7 +451,7 @@ static inline Status CsrmmImpl(
   //     const float* csrSortedValA, const int* csrSortedRowPtrA,
   //     const int* csrSortedColIndA, const float* B, int ldb, const float*
   //     beta, float* C, int ldc);
-  TF_RETURN_IF_CUSPARSE_ERROR(op(
+  TF_RETURN_IF_GPUSPARSE_ERROR(op(
       cusparse_handle, transA, transB, m, n, k, nnz, AsCudaComplex(alpha_host),
       descrA, AsCudaComplex(csrSortedValA), csrSortedRowPtrA, csrSortedColIndA,
       AsCudaComplex(B), ldb, AsCudaComplex(beta_host), AsCudaComplex(C), ldc));
@@ -461,7 +460,7 @@ static inline Status CsrmmImpl(
 
 #define CSRMM_INSTANCE(Scalar, sparse_prefix)                                \
   template <>                                                                \
-  Status CudaSparse::Csrmm<Scalar>(                                          \
+  Status GpuSparse::Csrmm<Scalar>(                                           \
       cusparseOperation_t transA, cusparseOperation_t transB, int m, int n,  \
       int k, int nnz, const Scalar* alpha_host,                              \
       const cusparseMatDescr_t descrA, const Scalar* csrSortedValA,          \
@@ -470,7 +469,7 @@ static inline Status CsrmmImpl(
       const {                                                                \
     DCHECK(initialized_);                                                    \
     return CsrmmImpl(SPARSE_FN(csrmm2, sparse_prefix), context_,             \
-                     *cusparse_handle_, transA, transB, m, n, k, nnz,        \
+                     *gpusparse_handle_, transA, transB, m, n, k, nnz,       \
                      alpha_host, descrA, csrSortedValA, csrSortedRowPtrA,    \
                      csrSortedColIndA, B, ldb, beta_host, C, ldc);           \
   }
@@ -484,7 +483,7 @@ static inline Status CsrmvImpl(
     const cusparseMatDescr_t descrA, const Scalar* csrSortedValA,
     const int* csrSortedRowPtrA, const int* csrSortedColIndA, const Scalar* x,
     const Scalar* beta_host, Scalar* y) {
-  TF_RETURN_IF_CUSPARSE_ERROR(
+  TF_RETURN_IF_GPUSPARSE_ERROR(
       op(cusparse_handle, transA, m, n, nnz, AsCudaComplex(alpha_host), descrA,
          AsCudaComplex(csrSortedValA), csrSortedRowPtrA, csrSortedColIndA,
          AsCudaComplex(x), AsCudaComplex(beta_host), AsCudaComplex(y)));
@@ -494,7 +493,7 @@ static inline Status CsrmvImpl(
 // TODO(ebrevdo,rmlarsen): Use csrmv_mp for all cases when available in CUDA 9.
 #define CSRMV_INSTANCE(Scalar, sparse_prefix)                                \
   template <>                                                                \
-  Status CudaSparse::Csrmv<Scalar>(                                          \
+  Status GpuSparse::Csrmv<Scalar>(                                           \
       cusparseOperation_t transA, int m, int n, int nnz,                     \
       const Scalar* alpha_host, const cusparseMatDescr_t descrA,             \
       const Scalar* csrSortedValA, const int* csrSortedRowPtrA,              \
@@ -503,12 +502,12 @@ static inline Status CsrmvImpl(
     DCHECK(initialized_);                                                    \
     if (transA == CUSPARSE_OPERATION_NON_TRANSPOSE) {                        \
       return CsrmvImpl(SPARSE_FN(csrmv_mp, sparse_prefix), context_,         \
-                       *cusparse_handle_, transA, m, n, nnz, alpha_host,     \
+                       *gpusparse_handle_, transA, m, n, nnz, alpha_host,    \
                        descrA, csrSortedValA, csrSortedRowPtrA,              \
                        csrSortedColIndA, x, beta_host, y);                   \
     } else {                                                                 \
       return CsrmvImpl(SPARSE_FN(csrmv, sparse_prefix), context_,            \
-                       *cusparse_handle_, transA, m, n, nnz, alpha_host,     \
+                       *gpusparse_handle_, transA, m, n, nnz, alpha_host,    \
                        descrA, csrSortedValA, csrSortedRowPtrA,              \
                        csrSortedColIndA, x, beta_host, y);                   \
     }                                                                        \
@@ -526,7 +525,7 @@ static inline Status CsrgeamImpl(
     const int* csrSortedRowPtrB, const int* csrSortedColIndB,
     const cusparseMatDescr_t descrC, Scalar* csrSortedValC,
     int* csrSortedRowPtrC, int* csrSortedColIndC) {
-  TF_RETURN_IF_CUSPARSE_ERROR(
+  TF_RETURN_IF_GPUSPARSE_ERROR(
       op(cusparse_handle, m, n, AsCudaComplex(alpha), descrA, nnzA,
          AsCudaComplex(csrSortedValA), csrSortedRowPtrA, csrSortedColIndA,
          AsCudaComplex(beta), descrB, nnzB, AsCudaComplex(csrSortedValB),
@@ -537,7 +536,7 @@ static inline Status CsrgeamImpl(
 
 #define CSRGEAM_INSTANCE(Scalar, sparse_prefix)                               \
   template <>                                                                 \
-  Status CudaSparse::Csrgeam<Scalar>(                                         \
+  Status GpuSparse::Csrgeam<Scalar>(                                          \
       int m, int n, const Scalar* alpha, const cusparseMatDescr_t descrA,     \
       int nnzA, const Scalar* csrSortedValA, const int* csrSortedRowPtrA,     \
       const int* csrSortedColIndA, const Scalar* beta,                        \
@@ -547,7 +546,7 @@ static inline Status CsrgeamImpl(
       int* csrSortedRowPtrC, int* csrSortedColIndC) {                         \
     DCHECK(initialized_);                                                     \
     return CsrgeamImpl(SPARSE_FN(csrgeam, sparse_prefix), context_,           \
-                       *cusparse_handle_, m, n, alpha, descrA, nnzA,          \
+                       *gpusparse_handle_, m, n, alpha, descrA, nnzA,         \
                        csrSortedValA, csrSortedRowPtrA, csrSortedColIndA,     \
                        beta, descrB, nnzB, csrSortedValB, csrSortedRowPtrB,   \
                        csrSortedColIndB, descrC, csrSortedValC,               \
@@ -556,7 +555,7 @@ static inline Status CsrgeamImpl(
 
 TF_CALL_LAPACK_TYPES(CSRGEAM_INSTANCE);
 
-Status CudaSparse::CsrgemmNnz(
+Status GpuSparse::CsrgemmNnz(
     cusparseOperation_t transA, cusparseOperation_t transB, int m, int k, int n,
     const cusparseMatDescr_t descrA, int nnzA, const int* csrSortedRowPtrA,
     const int* csrSortedColIndA, const cusparseMatDescr_t descrB, int nnzB,
@@ -565,8 +564,8 @@ Status CudaSparse::CsrgemmNnz(
     int* nnzTotalDevHostPtr) {
   DCHECK(initialized_);
   DCHECK(nnzTotalDevHostPtr != nullptr);
-  TF_RETURN_IF_CUSPARSE_ERROR(cusparseXcsrgemmNnz(
-      *cusparse_handle_, transA, transB, m, k, n, descrA, nnzA,
+  TF_RETURN_IF_GPUSPARSE_ERROR(cusparseXcsrgemmNnz(
+      *gpusparse_handle_, transA, transB, m, k, n, descrA, nnzA,
       csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB,
       csrSortedColIndB, descrC, csrSortedRowPtrC, nnzTotalDevHostPtr));
   return Status::OK();
@@ -582,7 +581,7 @@ static inline Status CsrgemmImpl(
     const int* csrSortedRowPtrB, const int* csrSortedColIndB,
     const cusparseMatDescr_t descrC, Scalar* csrSortedValC,
     int* csrSortedRowPtrC, int* csrSortedColIndC) {
-  TF_RETURN_IF_CUSPARSE_ERROR(
+  TF_RETURN_IF_GPUSPARSE_ERROR(
       op(cusparse_handle, transA, transB, m, k, n, descrA, nnzA,
          AsCudaComplex(csrSortedValA), csrSortedRowPtrA, csrSortedColIndA,
          descrB, nnzB, AsCudaComplex(csrSortedValB), csrSortedRowPtrB,
@@ -593,7 +592,7 @@ static inline Status CsrgemmImpl(
 
 #define CSRGEMM_INSTANCE(Scalar, sparse_prefix)                               \
   template <>                                                                 \
-  Status CudaSparse::Csrgemm<Scalar>(                                         \
+  Status GpuSparse::Csrgemm<Scalar>(                                          \
       cusparseOperation_t transA, cusparseOperation_t transB, int m, int k,   \
       int n, const cusparseMatDescr_t descrA, int nnzA,                       \
       const Scalar* csrSortedValA, const int* csrSortedRowPtrA,               \
@@ -603,7 +602,7 @@ static inline Status CsrgemmImpl(
       Scalar* csrSortedValC, int* csrSortedRowPtrC, int* csrSortedColIndC) {  \
     DCHECK(initialized_);                                                     \
     return CsrgemmImpl(SPARSE_FN(csrgemm, sparse_prefix), context_,           \
-                       *cusparse_handle_, transA, transB, m, k, n, descrA,    \
+                       *gpusparse_handle_, transA, transB, m, k, n, descrA,   \
                        nnzA, csrSortedValA, csrSortedRowPtrA,                 \
                        csrSortedColIndA, descrB, nnzB, csrSortedValB,         \
                        csrSortedRowPtrB, csrSortedColIndB, descrC,            \
@@ -620,12 +619,12 @@ static inline Status Csru2csrImpl(SparseFnT op, BufferSizeFnT buffer_size_op,
                                   const cusparseMatDescr_t descrA,
                                   Scalar* csrVal, const int* csrRowPtr,
                                   int* csrColInd) {
-  CudaSparseCsrSortingConversionInfo info;
+  GpuSparseCsrSortingConversionInfo info;
   TF_RETURN_IF_ERROR(info.Initialize());
 
   size_t pBufferSizeInBytes = 0;
 
-  TF_RETURN_IF_CUSPARSE_ERROR(
+  TF_RETURN_IF_GPUSPARSE_ERROR(
       buffer_size_op(cusparse_handle, m, n, nnz, AsCudaComplex(csrVal),
                      csrRowPtr, csrColInd, info.info(), &pBufferSizeInBytes));
 
@@ -636,22 +635,22 @@ static inline Status Csru2csrImpl(SparseFnT op, BufferSizeFnT buffer_size_op,
   auto pBuffer = pBuffer_t.flat<int8>();
   DCHECK(pBuffer.data() != nullptr);
 
-  TF_RETURN_IF_CUSPARSE_ERROR(op(cusparse_handle, m, n, nnz, descrA,
-                                 AsCudaComplex(csrVal), csrRowPtr, csrColInd,
-                                 info.info(), pBuffer.data()));
+  TF_RETURN_IF_GPUSPARSE_ERROR(op(cusparse_handle, m, n, nnz, descrA,
+                                  AsCudaComplex(csrVal), csrRowPtr, csrColInd,
+                                  info.info(), pBuffer.data()));
 
   return Status::OK();
 }
 
 #define CSRU2CSR_INSTANCE(Scalar, sparse_prefix)                              \
   template <>                                                                 \
-  Status CudaSparse::Csru2csr<Scalar>(                                        \
+  Status GpuSparse::Csru2csr<Scalar>(                                         \
       int m, int n, int nnz, const cusparseMatDescr_t descrA, Scalar* csrVal, \
       const int* csrRowPtr, int* csrColInd) {                                 \
     DCHECK(initialized_);                                                     \
     return Csru2csrImpl(SPARSE_FN(csru2csr, sparse_prefix),                   \
                         BUFSIZE_FN(csru2csr, sparse_prefix), context_,        \
-                        *cusparse_handle_, m, n, nnz, descrA, csrVal,         \
+                        *gpusparse_handle_, m, n, nnz, descrA, csrVal,        \
                         csrRowPtr, csrColInd);                                \
   }
 
@@ -664,22 +663,22 @@ static inline Status Csr2cscImpl(SparseFnT op, OpKernelContext* context,
                                  const int* csrRowPtr, const int* csrColInd,
                                  Scalar* cscVal, int* cscRowInd, int* cscColPtr,
                                  const cusparseAction_t copyValues) {
-  TF_RETURN_IF_CUSPARSE_ERROR(op(cusparse_handle, m, n, nnz,
-                                 AsCudaComplex(csrVal), csrRowPtr, csrColInd,
-                                 AsCudaComplex(cscVal), cscRowInd, cscColPtr,
-                                 copyValues, CUSPARSE_INDEX_BASE_ZERO));
+  TF_RETURN_IF_GPUSPARSE_ERROR(op(cusparse_handle, m, n, nnz,
+                                  AsCudaComplex(csrVal), csrRowPtr, csrColInd,
+                                  AsCudaComplex(cscVal), cscRowInd, cscColPtr,
+                                  copyValues, CUSPARSE_INDEX_BASE_ZERO));
   return Status::OK();
 }
 
 #define CSR2CSC_INSTANCE(Scalar, sparse_prefix)                              \
   template <>                                                                \
-  Status CudaSparse::Csr2csc<Scalar>(                                        \
+  Status GpuSparse::Csr2csc<Scalar>(                                         \
       int m, int n, int nnz, const Scalar* csrVal, const int* csrRowPtr,     \
       const int* csrColInd, Scalar* cscVal, int* cscRowInd, int* cscColPtr,  \
       const cusparseAction_t copyValues) {                                   \
     DCHECK(initialized_);                                                    \
     return Csr2cscImpl(SPARSE_FN(csr2csc, sparse_prefix), context_,          \
-                       *cusparse_handle_, m, n, nnz, csrVal, csrRowPtr,      \
+                       *gpusparse_handle_, m, n, nnz, csrVal, csrRowPtr,     \
                        csrColInd, cscVal, cscRowInd, cscColPtr, copyValues); \
   }
 

--- a/tensorflow/core/kernels/rocm_sparse.cc
+++ b/tensorflow/core/kernels/rocm_sparse.cc
@@ -1,0 +1,330 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if TENSORFLOW_USE_ROCM
+
+#include <complex>
+#include <memory>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "tensorflow/core/common_runtime/gpu/gpu_event_mgr.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/types.h"
+#include "tensorflow/core/kernels/cuda_solvers.h"
+#include "tensorflow/core/kernels/cuda_sparse.h"
+#include "tensorflow/core/lib/core/blocking_counter.h"
+#include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/lib/core/stringpiece.h"
+#include "tensorflow/core/lib/gtl/inlined_vector.h"
+#include "tensorflow/core/lib/strings/strcat.h"
+#include "tensorflow/core/platform/macros.h"
+#include "tensorflow/core/platform/mutex.h"
+#include "tensorflow/core/platform/stream_executor.h"
+#include "tensorflow/core/platform/types.h"
+
+namespace tensorflow {
+namespace {
+
+// A set of initialized handles to the underlying ROCm libraries used by
+// GpuSparse. We maintain one such set of handles per unique stream.
+class HipSparseHandles {
+ public:
+  explicit HipSparseHandles(hipStream_t stream)
+      : initialized_(false), stream_(stream) {}
+
+  HipSparseHandles(HipSparseHandles&& rhs)
+      : initialized_(rhs.initialized_),
+        stream_(std::move(rhs.stream_)),
+        hipsparse_handle_(rhs.hipsparse_handle_) {
+    rhs.initialized_ = false;
+  }
+
+  HipSparseHandles& operator=(HipSparseHandles&& rhs) {
+    if (this == &rhs) return *this;
+    Release();
+    stream_ = std::move(rhs.stream_);
+    hipsparse_handle_ = std::move(rhs.hipsparse_handle_);
+    initialized_ = rhs.initialized_;
+    rhs.initialized_ = false;
+    return *this;
+  }
+
+  ~HipSparseHandles() { Release(); }
+
+  Status Initialize() {
+    if (initialized_) return Status::OK();
+    TF_RETURN_IF_GPUSPARSE_ERROR(hipsparseCreate(&hipsparse_handle_));
+    TF_RETURN_IF_GPUSPARSE_ERROR(
+        hipsparseSetStream(hipsparse_handle_, stream_));
+    initialized_ = true;
+    return Status::OK();
+  }
+
+  hipsparseHandle_t& handle() {
+    DCHECK(initialized_);
+    return hipsparse_handle_;
+  }
+
+  const hipsparseHandle_t& handle() const {
+    DCHECK(initialized_);
+    return hipsparse_handle_;
+  }
+
+ private:
+  void Release() {
+    if (initialized_) {
+      // This should never return anything other than success
+      auto err = hipsparseDestroy(hipsparse_handle_);
+      DCHECK(err == HIPSPARSE_STATUS_SUCCESS)
+          << "Failed to destroy hipSPARSE instance.";
+      initialized_ = false;
+    }
+  }
+  bool initialized_;
+  hipStream_t stream_;
+  hipsparseHandle_t hipsparse_handle_;
+
+  TF_DISALLOW_COPY_AND_ASSIGN(HipSparseHandles);
+};
+
+// TODO(ebrevdo): Replace global mutex guarding CudaSparseHandles
+// lookup with one of:
+//    1. Adding the handle to the CudaStream structure; do the lookup there.
+//    2. Add a thread-local cusparse, set it to the current stream
+//       upon each call.
+// #1 seems like the cleanest option but will need to wait until this
+// is moved into TF core.
+static mutex handle_map_mutex(LINKER_INITIALIZED);
+
+using HandleMap = std::unordered_map<hipStream_t, HipSparseHandles>;
+
+// Returns a singleton map used for storing initialized handles for each unique
+// cuda stream.
+HandleMap* GetHandleMapSingleton() {
+  static HandleMap* cm = new HandleMap;
+  return cm;
+}
+
+}  // namespace
+
+GpuSparse::GpuSparse(OpKernelContext* context)
+    : initialized_(false), context_(context) {
+  auto hip_stream_ptr =
+      reinterpret_cast<const hipStream_t*>(context->op_device_context()
+                                               ->stream()
+                                               ->implementation()
+                                               ->GpuStreamMemberHack());
+  DCHECK(hip_stream_ptr);
+  gpu_stream_ = *hip_stream_ptr;
+}
+
+Status GpuSparse::Initialize() {
+  HandleMap* handle_map = GetHandleMapSingleton();
+  DCHECK(handle_map);
+  mutex_lock lock(handle_map_mutex);
+  auto it = handle_map->find(gpu_stream_);
+  if (it == handle_map->end()) {
+    LOG(INFO) << "Creating GpuSparse handles for stream " << gpu_stream_;
+    // Previously unseen ROCm stream. Initialize a set of ROCm sparse library
+    // handles for it.
+    HipSparseHandles new_handles(gpu_stream_);
+    TF_RETURN_IF_ERROR(new_handles.Initialize());
+    it = handle_map->insert(std::make_pair(gpu_stream_, std::move(new_handles)))
+             .first;
+  }
+  gpusparse_handle_ = &it->second.handle();
+  initialized_ = true;
+  return Status::OK();
+}
+
+// Macro that specializes a sparse method for all 4 standard
+// numeric types.
+#define TF_CALL_HIP_LAPACK_TYPES(m) m(float, S) m(double, D)
+
+// Macros to construct hipsparse method names.
+#define SPARSE_FN(method, sparse_prefix) hipsparse##sparse_prefix##method
+
+Status GpuSparse::Coo2csr(const int* cooRowInd, int nnz, int m,
+                          int* csrRowPtr) const {
+  DCHECK(initialized_);
+  TF_RETURN_IF_GPUSPARSE_ERROR(hipsparseXcoo2csr(*gpusparse_handle_, cooRowInd,
+                                                 nnz, m, csrRowPtr,
+                                                 HIPSPARSE_INDEX_BASE_ZERO));
+  return Status::OK();
+}
+
+Status GpuSparse::Csr2coo(const int* csrRowPtr, int nnz, int m,
+                          int* cooRowInd) const {
+  DCHECK(initialized_);
+  TF_RETURN_IF_GPUSPARSE_ERROR(hipsparseXcsr2coo(*gpusparse_handle_, csrRowPtr,
+                                                 nnz, m, cooRowInd,
+                                                 HIPSPARSE_INDEX_BASE_ZERO));
+  return Status::OK();
+}
+
+template <typename Scalar, typename SparseFnT>
+static inline Status CsrmmImpl(
+    SparseFnT op, OpKernelContext* context, hipsparseHandle_t hipsparse_handle,
+    hipsparseOperation_t transA, hipsparseOperation_t transB, int m, int n,
+    int k, int nnz, const Scalar* alpha_host, const hipsparseMatDescr_t descrA,
+    const Scalar* csrSortedValA, const int* csrSortedRowPtrA,
+    const int* csrSortedColIndA, const Scalar* B, int ldb,
+    const Scalar* beta_host, Scalar* C, int ldc) {
+  TF_RETURN_IF_GPUSPARSE_ERROR(op(hipsparse_handle, transA, transB, m, n, k,
+                                  nnz, alpha_host, descrA, csrSortedValA,
+                                  csrSortedRowPtrA, csrSortedColIndA, B, ldb,
+                                  beta_host, C, ldc));
+  return Status::OK();
+}
+
+#define CSRMM_INSTANCE(Scalar, sparse_prefix)                                 \
+  template <>                                                                 \
+  Status GpuSparse::Csrmm<Scalar>(                                            \
+      hipsparseOperation_t transA, hipsparseOperation_t transB, int m, int n, \
+      int k, int nnz, const Scalar* alpha_host,                               \
+      const hipsparseMatDescr_t descrA, const Scalar* csrSortedValA,          \
+      const int* csrSortedRowPtrA, const int* csrSortedColIndA,               \
+      const Scalar* B, int ldb, const Scalar* beta_host, Scalar* C, int ldc)  \
+      const {                                                                 \
+    DCHECK(initialized_);                                                     \
+    return CsrmmImpl(SPARSE_FN(csrmm2, sparse_prefix), context_,              \
+                     *gpusparse_handle_, transA, transB, m, n, k, nnz,        \
+                     alpha_host, descrA, csrSortedValA, csrSortedRowPtrA,     \
+                     csrSortedColIndA, B, ldb, beta_host, C, ldc);            \
+  }
+
+TF_CALL_HIP_LAPACK_TYPES(CSRMM_INSTANCE);
+
+template <typename Scalar, typename SparseFnT>
+static inline Status CsrmvImpl(SparseFnT op, OpKernelContext* context,
+                               hipsparseHandle_t hipsparse_handle,
+                               hipsparseOperation_t transA, int m, int n,
+                               int nnz, const Scalar* alpha_host,
+                               const hipsparseMatDescr_t descrA,
+                               const Scalar* csrSortedValA,
+                               const int* csrSortedRowPtrA,
+                               const int* csrSortedColIndA, const Scalar* x,
+                               const Scalar* beta_host, Scalar* y) {
+  TF_RETURN_IF_GPUSPARSE_ERROR(
+      op(hipsparse_handle, transA, m, n, nnz, alpha_host, descrA, csrSortedValA,
+         csrSortedRowPtrA, csrSortedColIndA, x, beta_host, y));
+  return Status::OK();
+}
+
+// TODO(ebrevdo,rmlarsen): Use csrmv_mp for all cases when available in CUDA 9.
+#define CSRMV_INSTANCE(Scalar, sparse_prefix)                                \
+  template <>                                                                \
+  Status GpuSparse::Csrmv<Scalar>(                                           \
+      hipsparseOperation_t transA, int m, int n, int nnz,                    \
+      const Scalar* alpha_host, const hipsparseMatDescr_t descrA,            \
+      const Scalar* csrSortedValA, const int* csrSortedRowPtrA,              \
+      const int* csrSortedColIndA, const Scalar* x, const Scalar* beta_host, \
+      Scalar* y) const {                                                     \
+    DCHECK(initialized_);                                                    \
+    return CsrmvImpl(SPARSE_FN(csrmv, sparse_prefix), context_,              \
+                     *gpusparse_handle_, transA, m, n, nnz, alpha_host,      \
+                     descrA, csrSortedValA, csrSortedRowPtrA,                \
+                     csrSortedColIndA, x, beta_host, y);                     \
+  }
+
+TF_CALL_HIP_LAPACK_TYPES(CSRMV_INSTANCE);
+
+Status GpuSparse::CsrgemmNnz(
+    hipsparseOperation_t transA, hipsparseOperation_t transB, int m, int n,
+    int k, const hipsparseMatDescr_t descrA, int nnzA,
+    const int* csrSortedRowPtrA, const int* csrSortedColIndA,
+    const hipsparseMatDescr_t descrB, int nnzB, const int* csrSortedRowPtrB,
+    const int* csrSortedColIndB, const hipsparseMatDescr_t descrC,
+    int* csrSortedRowPtrC, int* nnzTotalDevHostPtr) {
+  DCHECK(initialized_);
+  DCHECK(nnzTotalDevHostPtr != nullptr);
+  TF_RETURN_IF_GPUSPARSE_ERROR(hipsparseXcsrgemmNnz(
+      *gpusparse_handle_, transA, transB, m, n, k, descrA, nnzA,
+      csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB,
+      csrSortedColIndB, descrC, csrSortedRowPtrC, nnzTotalDevHostPtr));
+  return Status::OK();
+}
+
+template <typename Scalar, typename SparseFnT>
+static inline Status CsrgemmImpl(
+    SparseFnT op, OpKernelContext* context, hipsparseHandle_t hipsparse_handle,
+    hipsparseOperation_t transA, hipsparseOperation_t transB, int m, int n,
+    int k, const hipsparseMatDescr_t descrA, int nnzA,
+    const Scalar* csrSortedValA, const int* csrSortedRowPtrA,
+    const int* csrSortedColIndA, const hipsparseMatDescr_t descrB, int nnzB,
+    const Scalar* csrSortedValB, const int* csrSortedRowPtrB,
+    const int* csrSortedColIndB, const hipsparseMatDescr_t descrC,
+    Scalar* csrSortedValC, int* csrSortedRowPtrC, int* csrSortedColIndC) {
+  TF_RETURN_IF_GPUSPARSE_ERROR(
+      op(hipsparse_handle, transA, transB, m, n, k, descrA, nnzA, csrSortedValA,
+         csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedValB,
+         csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC,
+         csrSortedRowPtrC, csrSortedColIndC));
+  return Status::OK();
+}
+
+#define CSRGEMM_INSTANCE(Scalar, sparse_prefix)                                \
+  template <>                                                                  \
+  Status GpuSparse::Csrgemm<Scalar>(                                           \
+      hipsparseOperation_t transA, hipsparseOperation_t transB, int m, int n,  \
+      int k, const hipsparseMatDescr_t descrA, int nnzA,                       \
+      const Scalar* csrSortedValA, const int* csrSortedRowPtrA,                \
+      const int* csrSortedColIndA, const hipsparseMatDescr_t descrB, int nnzB, \
+      const Scalar* csrSortedValB, const int* csrSortedRowPtrB,                \
+      const int* csrSortedColIndB, const hipsparseMatDescr_t descrC,           \
+      Scalar* csrSortedValC, int* csrSortedRowPtrC, int* csrSortedColIndC) {   \
+    DCHECK(initialized_);                                                      \
+    return CsrgemmImpl(SPARSE_FN(csrgemm, sparse_prefix), context_,            \
+                       *gpusparse_handle_, transA, transB, m, n, k, descrA,    \
+                       nnzA, csrSortedValA, csrSortedRowPtrA,                  \
+                       csrSortedColIndA, descrB, nnzB, csrSortedValB,          \
+                       csrSortedRowPtrB, csrSortedColIndB, descrC,             \
+                       csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);     \
+  }
+
+TF_CALL_HIP_LAPACK_TYPES(CSRGEMM_INSTANCE);
+
+template <typename Scalar, typename SparseFnT>
+static inline Status Csr2cscImpl(SparseFnT op, OpKernelContext* context,
+                                 hipsparseHandle_t hipsparse_handle, int m,
+                                 int n, int nnz, const Scalar* csrVal,
+                                 const int* csrRowPtr, const int* csrColInd,
+                                 Scalar* cscVal, int* cscRowInd, int* cscColPtr,
+                                 const hipsparseAction_t copyValues) {
+  TF_RETURN_IF_GPUSPARSE_ERROR(
+      op(hipsparse_handle, m, n, nnz, csrVal, csrRowPtr, csrColInd, cscVal,
+         cscRowInd, cscColPtr, copyValues, HIPSPARSE_INDEX_BASE_ZERO));
+  return Status::OK();
+}
+
+#define CSR2CSC_INSTANCE(Scalar, sparse_prefix)                              \
+  template <>                                                                \
+  Status GpuSparse::Csr2csc<Scalar>(                                         \
+      int m, int n, int nnz, const Scalar* csrVal, const int* csrRowPtr,     \
+      const int* csrColInd, Scalar* cscVal, int* cscRowInd, int* cscColPtr,  \
+      const hipsparseAction_t copyValues) {                                  \
+    DCHECK(initialized_);                                                    \
+    return Csr2cscImpl(SPARSE_FN(csr2csc, sparse_prefix), context_,          \
+                       *gpusparse_handle_, m, n, nnz, csrVal, csrRowPtr,     \
+                       csrColInd, cscVal, cscRowInd, cscColPtr, copyValues); \
+  }
+
+TF_CALL_HIP_LAPACK_TYPES(CSR2CSC_INSTANCE);
+
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_USE_ROCM

--- a/tensorflow/core/kernels/sparse/BUILD
+++ b/tensorflow/core/kernels/sparse/BUILD
@@ -2,6 +2,7 @@
 
 load(
     "//tensorflow:tensorflow.bzl",
+    "if_cuda_or_rocm",
     "tf_cc_test",
     "tf_kernel_library",
 )
@@ -77,7 +78,7 @@ tf_kernel_library(
         "//tensorflow/core/kernels:scatter_nd_op",
         "//tensorflow/core/kernels:slice_op",
         "//tensorflow/core/kernels:transpose_functor",
-    ] + if_cuda([
+    ] + if_cuda_or_rocm([
         "//tensorflow/core/kernels:cuda_solvers",
         "//tensorflow/core/kernels:cuda_sparse",
     ]),

--- a/tensorflow/core/kernels/sparse/add_op.cc
+++ b/tensorflow/core/kernels/sparse/add_op.cc
@@ -15,7 +15,7 @@ limitations under the License.
 
 #define EIGEN_USE_THREADS
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #define EIGEN_USE_GPU
 #endif
 
@@ -31,7 +31,7 @@ limitations under the License.
 #include "tensorflow/core/kernels/sparse/sparse_matrix.h"
 #include "tensorflow/core/kernels/fill_functor.h"
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #include "tensorflow/core/kernels/cuda_solvers.h"
 #include "tensorflow/core/kernels/cuda_sparse.h"
 #endif
@@ -233,8 +233,10 @@ class CSRAddOp : public OpKernel {
 
 REGISTER_GPU(float)
 REGISTER_GPU(double)
+#if GOOGLE_CUDA
 REGISTER_GPU(complex64)
 REGISTER_GPU(complex128)
+#endif
 
 #undef REGISTER_GPU
 
@@ -246,7 +248,7 @@ REGISTER_UNARY_VARIANT_BINARY_OP_FUNCTION(
 
 #undef REGISTER
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 namespace functor {
 template <typename T>
 struct CSRSparseMatrixAdd<GPUDevice, T>
@@ -337,6 +339,6 @@ struct CSRSparseMatrixAdd<GPUDevice, T>
 
 }  // namespace functor
 
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/sparse/add_op.cc
+++ b/tensorflow/core/kernels/sparse/add_op.cc
@@ -324,10 +324,10 @@ struct CSRSparseMatrixAdd<GPUDevice, T>
 
  private:
   OpKernelContext* ctx_;
-  CudaSparse cuda_sparse_;
-  CudaSparseMatrixDescriptor descrA_;
-  CudaSparseMatrixDescriptor descrB_;
-  CudaSparseMatrixDescriptor descrC_;
+  GpuSparse cuda_sparse_;
+  GpuSparseMatrixDescriptor descrA_;
+  GpuSparseMatrixDescriptor descrB_;
+  GpuSparseMatrixDescriptor descrC_;
   const T alpha_;
   const T beta_;
   bool initialized_;

--- a/tensorflow/core/kernels/sparse/conj_op.cc
+++ b/tensorflow/core/kernels/sparse/conj_op.cc
@@ -15,7 +15,7 @@ limitations under the License.
 
 #define EIGEN_USE_THREADS
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #define EIGEN_USE_GPU
 #endif
 
@@ -31,7 +31,7 @@ limitations under the License.
 #include "tensorflow/core/kernels/sparse/kernels.h"
 #include "tensorflow/core/kernels/sparse/sparse_matrix.h"
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #include "tensorflow/core/kernels/cuda_solvers.h"
 #include "tensorflow/core/kernels/cuda_sparse.h"
 #endif
@@ -92,12 +92,12 @@ REGISTER_UNARY_VARIANT_UNARY_OP_FUNCTION(
     CONJ_VARIANT_UNARY_OP, DEVICE_CPU, CSRSparseMatrix,
     (CSRSparseMatrixUnaryHelper<CPUDevice, CSRSparseMatrixConjFunctor>));
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 REGISTER_UNARY_VARIANT_UNARY_OP_FUNCTION(
     CONJ_VARIANT_UNARY_OP, DEVICE_GPU, CSRSparseMatrix,
     (CSRSparseMatrixUnaryHelper<GPUDevice, CSRSparseMatrixConjFunctor>));
 
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/sparse/csr_sparse_matrix_to_dense_op.cc
+++ b/tensorflow/core/kernels/sparse/csr_sparse_matrix_to_dense_op.cc
@@ -15,7 +15,7 @@ limitations under the License.
 
 #define EIGEN_USE_THREADS
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #define EIGEN_USE_GPU
 #endif
 
@@ -33,7 +33,7 @@ limitations under the License.
 #include "tensorflow/core/kernels/sparse/sparse_matrix.h"
 #include "tensorflow/core/util/work_sharder.h"
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #include "tensorflow/core/kernels/cuda_solvers.h"
 #include "tensorflow/core/kernels/cuda_sparse.h"
 #endif
@@ -220,19 +220,21 @@ REGISTER_CPU(double)
 REGISTER_CPU(complex64)
 REGISTER_CPU(complex128)
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 REGISTER_GPU(float)
 REGISTER_GPU(double)
+#if GOOGLE_CUDA
 REGISTER_GPU(complex64)
 REGISTER_GPU(complex128)
+#endif
 
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #undef REGISTER_CPU
 #undef REGISTER_GPU
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 namespace functor {
 template <>
@@ -256,6 +258,6 @@ extern template struct CSRSparseMatrixToCOOSparseMatrix<GPUDevice>;
 
 }  // namespace functor
 
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/sparse/csr_sparse_matrix_to_sparse_tensor_op.cc
+++ b/tensorflow/core/kernels/sparse/csr_sparse_matrix_to_sparse_tensor_op.cc
@@ -15,7 +15,7 @@ limitations under the License.
 
 #define EIGEN_USE_THREADS
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #define EIGEN_USE_GPU
 #endif
 
@@ -31,7 +31,7 @@ limitations under the License.
 #include "tensorflow/core/kernels/sparse/sparse_matrix.h"
 #include "tensorflow/core/util/work_sharder.h"
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #include "tensorflow/core/kernels/cuda_solvers.h"
 #include "tensorflow/core/kernels/cuda_sparse.h"
 #endif
@@ -205,18 +205,20 @@ class CSRSparseMatrixToSparseTensorGPUOp : public OpKernel {
                               .HostMemory("dense_shape"),       \
                           CSRSparseMatrixToSparseTensorGPUOp<GPUDevice, T>);
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 REGISTER_GPU(float)
 REGISTER_GPU(double)
+#if GOOGLE_CUDA
 REGISTER_GPU(complex64)
 REGISTER_GPU(complex128)
+#endif
 
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #undef REGISTER_GPU
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 namespace functor {
 template <>
@@ -240,7 +242,7 @@ extern template struct CSRSparseMatrixToCOOSparseMatrix<GPUDevice>;
 
 }  // namespace functor
 
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #define REGISTER_CPU(T)                                         \
   REGISTER_KERNEL_BUILDER(Name("CSRSparseMatrixToSparseTensor") \

--- a/tensorflow/core/kernels/sparse/dense_to_csr_sparse_matrix_op.cc
+++ b/tensorflow/core/kernels/sparse/dense_to_csr_sparse_matrix_op.cc
@@ -380,7 +380,7 @@ struct COOSparseMatrixToCSRSparseMatrix<GPUDevice> {
   Status operator()(OpKernelContext* c, const int rows, const int cols,
                     TTypes<int>::UnalignedVec coo_row_ind,
                     TTypes<int>::UnalignedVec csr_row_ptr) {
-    CudaSparse cuda_sparse(c);
+    GpuSparse cuda_sparse(c);
     TF_RETURN_IF_ERROR(cuda_sparse.Initialize());
     return cuda_sparse.Coo2csr(coo_row_ind.data(),
                                /*nnz*/ coo_row_ind.size(),

--- a/tensorflow/core/kernels/sparse/kernels_gpu.cu.cc
+++ b/tensorflow/core/kernels/sparse/kernels_gpu.cu.cc
@@ -128,7 +128,7 @@ template <>
 Status CSRSparseMatrixToCOOSparseMatrix<GPUDevice>::operator()(
     OpKernelContext* c, TTypes<const int>::UnalignedVec csr_row_ptr,
     TTypes<int>::UnalignedVec coo_row_ind) {
-  CudaSparse cuda_sparse(c);
+  GpuSparse cuda_sparse(c);
   const int nnz = coo_row_ind.size();
   TF_RETURN_IF_ERROR(cuda_sparse.Initialize());
   const int m = csr_row_ptr.size() - 1;  // rows

--- a/tensorflow/core/kernels/sparse/mul_op.cc
+++ b/tensorflow/core/kernels/sparse/mul_op.cc
@@ -15,7 +15,7 @@ limitations under the License.
 
 #define EIGEN_USE_THREADS
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #define EIGEN_USE_GPU
 #endif
 
@@ -28,7 +28,7 @@ limitations under the License.
 #include "tensorflow/core/kernels/sparse/kernels.h"
 #include "tensorflow/core/kernels/sparse/sparse_matrix.h"
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #include "tensorflow/core/kernels/cuda_sparse.h"
 #endif
 
@@ -101,22 +101,24 @@ class CSRMulOp : public OpKernel {
       Name("SparseMatrixMul").Device(DEVICE_##DEV).TypeConstraint<T>("T"), \
       CSRMulOp<DEV##Device, T>);
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #define REGISTER_GPU(T) REGISTER(GPU, T)
 
 REGISTER_GPU(float)
 REGISTER_GPU(double)
+#if GOOGLE_CUDA
 REGISTER_GPU(complex64)
 REGISTER_GPU(complex128)
+#endif
 
 #undef REGISTER_GPU
 
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #undef REGISTER
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 namespace functor {
 
@@ -159,13 +161,15 @@ class CSRSparseMatrixMulScalar<GPUDevice, T> {
 
 DECLARE_GPU_SPEC(float);
 DECLARE_GPU_SPEC(double);
+#if GOOGLE_CUDA
 DECLARE_GPU_SPEC(std::complex<float>);
 DECLARE_GPU_SPEC(std::complex<double>);
+#endif
 
 #undef DECLARE_GPU_SPEC
 
 }  // namespace functor
 
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/sparse/nnz_op.cc
+++ b/tensorflow/core/kernels/sparse/nnz_op.cc
@@ -15,7 +15,7 @@ limitations under the License.
 
 #define EIGEN_USE_THREADS
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #define EIGEN_USE_GPU
 #endif
 
@@ -28,7 +28,7 @@ limitations under the License.
 #include "tensorflow/core/kernels/sparse/kernels.h"
 #include "tensorflow/core/kernels/sparse/sparse_matrix.h"
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #include "tensorflow/core/kernels/cuda_solvers.h"
 #include "tensorflow/core/kernels/cuda_sparse.h"
 #endif
@@ -67,11 +67,11 @@ class CSRNNZOp : public OpKernel {
 
 REGISTER(CPU)
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 REGISTER(GPU)
 
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #undef REGISTER
 

--- a/tensorflow/core/kernels/sparse/softmax_op.cc
+++ b/tensorflow/core/kernels/sparse/softmax_op.cc
@@ -19,7 +19,7 @@ limitations under the License.
 
 #define EIGEN_USE_THREADS
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #include "tensorflow/core/kernels/cuda_sparse.h"
 #define EIGEN_USE_GPU
 #endif
@@ -84,7 +84,7 @@ class CSRSoftmaxOp : public OpKernel {
   }
 };
 
-#ifdef GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #define REGISTER(DEV, T)                                  \
   REGISTER_KERNEL_BUILDER(Name("SparseMatrixSoftmax")     \
                               .Device(DEVICE_##DEV)       \
@@ -110,7 +110,7 @@ DECLARE_GPU_SPEC(double);
 #undef DECLARE_GPU_SPEC
 }  // namespace functor
 
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 template <typename Device, typename T>
 class CSRSoftmaxGradOp : public OpKernel {
@@ -193,7 +193,7 @@ class CSRSoftmaxGradOp : public OpKernel {
   }
 };
 
-#ifdef GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #define REGISTER(DEV, T)                                  \
   REGISTER_KERNEL_BUILDER(Name("SparseMatrixSoftmaxGrad") \
                               .Device(DEVICE_##DEV)       \
@@ -220,6 +220,6 @@ DECLARE_GPU_SPEC(double);
 #undef DECLARE_GPU_SPEC
 }  // namespace functor
 
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/sparse/sparse_mat_mul_op.cc
+++ b/tensorflow/core/kernels/sparse/sparse_mat_mul_op.cc
@@ -632,16 +632,16 @@ struct CSRSparseSparseMatrixMatMul<GPUDevice, T>
 
  private:
   OpKernelContext* ctx_;
-  CudaSparse cuda_sparse_;
+  GpuSparse cuda_sparse_;
   bool initialized_;
   bool transpose_a_;
   bool adjoint_a_;
   bool transpose_b_;
-  CudaSparseMatrixDescriptor descrA_;
-  CudaSparseMatrixDescriptor descrB_;
-  CudaSparseMatrixDescriptor descrC_;
-  cusparseOperation_t transA_;
-  cusparseOperation_t transB_;
+  GpuSparseMatrixDescriptor descrA_;
+  GpuSparseMatrixDescriptor descrB_;
+  GpuSparseMatrixDescriptor descrC_;
+  gpusparseOperation_t transA_;
+  gpusparseOperation_t transB_;
 };
 
 }  // namespace functor

--- a/tensorflow/core/kernels/sparse/sparse_matrix.cc
+++ b/tensorflow/core/kernels/sparse/sparse_matrix.cc
@@ -15,7 +15,7 @@ limitations under the License.
 
 #define EIGEN_USE_THREADS
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #define EIGEN_USE_GPU
 #endif
 

--- a/tensorflow/core/kernels/sparse/sparse_matrix.h
+++ b/tensorflow/core/kernels/sparse/sparse_matrix.h
@@ -18,7 +18,7 @@ limitations under the License.
 
 #define EIGEN_USE_THREADS
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #define EIGEN_USE_GPU
 #endif
 

--- a/tensorflow/core/kernels/sparse/sparse_matrix_components_op.cc
+++ b/tensorflow/core/kernels/sparse/sparse_matrix_components_op.cc
@@ -15,7 +15,7 @@ limitations under the License.
 
 #define EIGEN_USE_THREADS
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #define EIGEN_USE_GPU
 #endif
 
@@ -29,7 +29,7 @@ limitations under the License.
 #include "tensorflow/core/kernels/sparse/kernels.h"
 #include "tensorflow/core/kernels/sparse/sparse_matrix.h"
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #include "tensorflow/core/kernels/cuda_solvers.h"
 #include "tensorflow/core/kernels/cuda_sparse.h"
 #endif
@@ -116,12 +116,14 @@ REGISTER(CPU, double)
 REGISTER(CPU, complex64)
 REGISTER(CPU, complex128)
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 REGISTER(GPU, float)
 REGISTER(GPU, double)
+#if GOOGLE_CUDA
 REGISTER(GPU, complex64)
 REGISTER(GPU, complex128)
+#endif
 
 #undef REGISTER
 
@@ -139,12 +141,14 @@ namespace functor {
 DECLARE_GPU_SPEC(int32);
 DECLARE_GPU_SPEC(float);
 DECLARE_GPU_SPEC(double);
+#if GOOGLE_CUDA
 DECLARE_GPU_SPEC(complex64);
 DECLARE_GPU_SPEC(complex128);
+#endif
 
 #undef DECLARE_GPU_SPEC
 }  // namespace functor
 
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/sparse/sparse_tensor_to_csr_sparse_matrix_op.cc
+++ b/tensorflow/core/kernels/sparse/sparse_tensor_to_csr_sparse_matrix_op.cc
@@ -302,7 +302,7 @@ struct COOSparseMatrixToCSRSparseMatrix<GPUDevice> {
   Status operator()(OpKernelContext* c, const int rows, const int cols,
                     TTypes<int>::UnalignedVec coo_row_ind,
                     TTypes<int>::UnalignedVec csr_row_ptr) {
-    CudaSparse cuda_sparse(c);
+    GpuSparse cuda_sparse(c);
     TF_RETURN_IF_ERROR(cuda_sparse.Initialize());
     return cuda_sparse.Coo2csr(coo_row_ind.data(),
                                /*nnz*/ coo_row_ind.size(),

--- a/tensorflow/core/kernels/sparse/transpose_op.cc
+++ b/tensorflow/core/kernels/sparse/transpose_op.cc
@@ -257,9 +257,9 @@ struct CSRSparseMatrixTransposeComponent<GPUDevice, T> {
   Status operator()(OpKernelContext* ctx, const ConstCSRComponent<T>& x,
                     CSRComponent<T>* y) {
     TF_RETURN_IF_ERROR(ValidateTransposeInputs(x, *y));
-    CudaSparse cuda_sparse(ctx);
+    GpuSparse cuda_sparse(ctx);
     TF_RETURN_IF_ERROR(cuda_sparse.Initialize());
-    const cusparseAction_t copyValues = CUSPARSE_ACTION_NUMERIC;
+    const gpusparseAction_t copyValues = CUSPARSE_ACTION_NUMERIC;
     const int rank = x.dense_shape_host.size();
     const int m = x.row_ptr.size() - 1;
     const int n = x.dense_shape_host(rank - 1);

--- a/tensorflow/core/kernels/sparse/zeros_op.cc
+++ b/tensorflow/core/kernels/sparse/zeros_op.cc
@@ -15,7 +15,7 @@ limitations under the License.
 
 #define EIGEN_USE_THREADS
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #define EIGEN_USE_GPU
 #endif
 
@@ -74,7 +74,7 @@ Status CSRSparseMatrixZerosLikeHelper(OpKernelContext* ctx,
 
 }  // namespace
 
-#ifdef GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #define REGISTER(DEV)                                     \
   REGISTER_KERNEL_BUILDER(Name("SparseMatrixZeros")       \
                               .Device(DEVICE_##DEV)       \
@@ -88,6 +88,6 @@ REGISTER_UNARY_VARIANT_UNARY_OP_FUNCTION(
     CSRSparseMatrixZerosLikeHelper<GPUDevice>);
 
 #undef REGISTER
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/sparse/zeros_op.h
+++ b/tensorflow/core/kernels/sparse/zeros_op.h
@@ -18,7 +18,7 @@ limitations under the License.
 
 #define EIGEN_USE_THREADS
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #define EIGEN_USE_GPU
 #endif
 

--- a/tensorflow/python/kernel_tests/linalg/sparse/BUILD
+++ b/tensorflow/python/kernel_tests/linalg/sparse/BUILD
@@ -28,7 +28,6 @@ cuda_py_test(
     size = "medium",
     srcs = ["csr_sparse_matrix_test.py"],
     main = "csr_sparse_matrix_test.py",
-    tags = ["no_rocm"],
     deps = [
         "//tensorflow/python/ops/linalg/sparse",
     ],
@@ -40,7 +39,6 @@ cuda_py_test(
     srcs = ["csr_sparse_matrix_ops_test.py"],
     main = "csr_sparse_matrix_ops_test.py",
     shard_count = 10,
-    tags = ["no_rocm"],
     deps = [
         "//tensorflow/python/ops/linalg/sparse",
         "//tensorflow/python/ops/linalg/sparse:gen_sparse_csr_matrix_ops",
@@ -53,7 +51,6 @@ cuda_py_test(
     srcs = ["csr_sparse_matrix_grad_test.py"],
     main = "csr_sparse_matrix_grad_test.py",
     shard_count = 50,
-    tags = ["no_rocm"],
     deps = [
         "//tensorflow/python/ops/linalg/sparse",
     ],
@@ -65,7 +62,6 @@ cuda_py_test(
     srcs = ["csr_sparse_matrix_dense_mat_mul_grad_test.py"],
     main = "csr_sparse_matrix_dense_mat_mul_grad_test.py",
     shard_count = 50,
-    tags = ["no_rocm"],
     deps = [
         "//tensorflow/python/ops/linalg/sparse",
     ],
@@ -77,7 +73,6 @@ cuda_py_test(
     srcs = ["csr_sparse_matrix_sparse_mat_mul_grad_test.py"],
     main = "csr_sparse_matrix_sparse_mat_mul_grad_test.py",
     shard_count = 50,
-    tags = ["no_rocm"],
     deps = [
         "//tensorflow/python/ops/linalg/sparse",
     ],

--- a/tensorflow/python/kernel_tests/linalg/sparse/csr_sparse_matrix_dense_mat_mul_grad_test.py
+++ b/tensorflow/python/kernel_tests/linalg/sparse/csr_sparse_matrix_dense_mat_mul_grad_test.py
@@ -106,7 +106,11 @@ class CSRSparseMatrixDenseMatMulGradTest(test.TestCase):
 
 # These tests are refactored from sparse_csr_matrix_grad_test to keep its size
 # "medium".
-for dtype in (np.float32, np.complex64):
+dtypes_to_test = [np.float32]
+if not test.is_built_with_rocm:
+  # complex type is not supported on the ROCm platform
+  dtypes_to_test += [np.complex64]
+for dtype in dtypes_to_test:
   for (t_a, t_b, adj_a, adj_b, t_out,
        conj_out) in itertools.product(*(([False, True],) * 6)):
 

--- a/tensorflow/python/kernel_tests/linalg/sparse/csr_sparse_matrix_grad_test.py
+++ b/tensorflow/python/kernel_tests/linalg/sparse/csr_sparse_matrix_grad_test.py
@@ -85,7 +85,6 @@ class CSRSparseMatrixGradTest(test.TestCase):
       return
 
     if test.is_built_with_rocm():
-      # sparse-matrix-add op is not yet supported on the ROCm platform
       self.skipTest("sparse-matrix-add op not supported on ROCm")
 
     sparsify = lambda m: m * (m > 0)

--- a/tensorflow/python/kernel_tests/linalg/sparse/csr_sparse_matrix_grad_test.py
+++ b/tensorflow/python/kernel_tests/linalg/sparse/csr_sparse_matrix_grad_test.py
@@ -84,6 +84,10 @@ class CSRSparseMatrixGradTest(test.TestCase):
     if not self._gpu_available:
       return
 
+    if test.is_built_with_rocm():
+      # sparse-matrix-add op is not yet supported on the ROCm platform
+      self.skipTest("sparse-matrix-add op not supported on ROCm")
+
     sparsify = lambda m: m * (m > 0)
     for dense_shape in ([53, 65, 127], [127, 65]):
       a_mats_val = sparsify(np.random.randn(*dense_shape))

--- a/tensorflow/python/kernel_tests/linalg/sparse/csr_sparse_matrix_ops_test.py
+++ b/tensorflow/python/kernel_tests/linalg/sparse/csr_sparse_matrix_ops_test.py
@@ -433,7 +433,6 @@ class CSRSparseMatrixOpsTest(test.TestCase):
       return
 
     if test.is_built_with_rocm():
-      # sparse-matrix-add op is not yet supported on the ROCm platform
       self.skipTest("sparse-matrix-add op not supported on ROCm")
 
     a_indices = np.array([[0, 0], [2, 3]])
@@ -474,7 +473,6 @@ class CSRSparseMatrixOpsTest(test.TestCase):
       return
 
     if test.is_built_with_rocm():
-      # sparse-matrix-add op is not yet supported on the ROCm platform
       self.skipTest("sparse-matrix-add op not supported on ROCm")
 
     sparsify = lambda m: m * (m > 0)
@@ -520,7 +518,6 @@ class CSRSparseMatrixOpsTest(test.TestCase):
   @test_util.run_in_graph_and_eager_modes
   def testSparseMatrixMatMulConjugateOutput(self):
     if test.is_built_with_rocm():
-      # complex types are not yet supported on the ROCm platform
       self.skipTest("complex type not supported on ROCm")
 
     for shapes in [[(5, 6), (6, 1)], [(5, 6), (6, 2)]]:
@@ -552,6 +549,8 @@ class CSRSparseMatrixOpsTest(test.TestCase):
 
     if test.is_built_with_rocm():
       # TODO(rocm): fix this
+      # This test is currently failing on the ROCm platform
+      # Ren-enable it once the fix is available
       self.skipTest("hipSPARSE all failure on the ROCm platform")
 
     sparsify = lambda m: m * (m > 0)
@@ -612,6 +611,8 @@ class CSRSparseMatrixOpsTest(test.TestCase):
 
     if test.is_built_with_rocm():
       # TODO(rocm): fix this
+      # This test is currently failing on the ROCm platform
+      # Ren-enable it once the fix is available
       self.skipTest("hipSPARSE all failure on the ROCm platform")
 
     sparsify = lambda m: m * (m > 0)

--- a/tensorflow/python/kernel_tests/linalg/sparse/csr_sparse_matrix_ops_test.py
+++ b/tensorflow/python/kernel_tests/linalg/sparse/csr_sparse_matrix_ops_test.py
@@ -432,6 +432,10 @@ class CSRSparseMatrixOpsTest(test.TestCase):
     if not self._gpu_available:
       return
 
+    if test.is_built_with_rocm():
+      # sparse-matrix-add op is not yet supported on the ROCm platform
+      self.skipTest("sparse-matrix-add op not supported on ROCm")
+
     a_indices = np.array([[0, 0], [2, 3]])
     a_values = np.array([1.0, 5.0]).astype(np.float32)
     a_dense_shape = [5, 6]
@@ -468,6 +472,10 @@ class CSRSparseMatrixOpsTest(test.TestCase):
   def testLargeBatchSparseMatrixAdd(self):
     if not self._gpu_available:
       return
+
+    if test.is_built_with_rocm():
+      # sparse-matrix-add op is not yet supported on the ROCm platform
+      self.skipTest("sparse-matrix-add op not supported on ROCm")
 
     sparsify = lambda m: m * (m > 0)
     dense_shape = [53, 65, 127]
@@ -511,6 +519,10 @@ class CSRSparseMatrixOpsTest(test.TestCase):
 
   @test_util.run_in_graph_and_eager_modes
   def testSparseMatrixMatMulConjugateOutput(self):
+    if test.is_built_with_rocm():
+      # complex types are not yet supported on the ROCm platform
+      self.skipTest("complex type not supported on ROCm")
+
     for shapes in [[(5, 6), (6, 1)], [(5, 6), (6, 2)]]:
       a_indices = np.array([[0, 0], [2, 3]])
       a_values = np.array([1.0 + 1.j, 5.0 - 2.j]).astype(np.complex64)
@@ -533,8 +545,17 @@ class CSRSparseMatrixOpsTest(test.TestCase):
 
   @test_util.run_in_graph_and_eager_modes
   def testLargeBatchSparseMatrixMatMul(self):
+    dtypes_to_test = [np.float32]
+    if not test.is_built_with_rocm():
+      # complex types is not supported on the ROCm platform
+      dtypes_to_test += [np.complex64]
+
+    if test.is_built_with_rocm():
+      # TODO(rocm): fix this
+      self.skipTest("hipSPARSE all failure on the ROCm platform")
+
     sparsify = lambda m: m * (m > 0)
-    for dtype in np.float32, np.complex64:
+    for dtype in dtypes_to_test:
       for (transpose_a, transpose_b) in ((False, False), (False, True),
                                          (True, False), (True, True)):
         for (adjoint_a, adjoint_b) in ((False, False), (False, True),
@@ -584,8 +605,17 @@ class CSRSparseMatrixOpsTest(test.TestCase):
 
   @test_util.run_in_graph_and_eager_modes
   def testLargeBatchSparseMatrixMatMulTransposed(self):
+    dtypes_to_test = [np.float32]
+    if not test.is_built_with_rocm():
+      # complex types is not supported on the ROCm platform
+      dtypes_to_test += [np.complex64]
+
+    if test.is_built_with_rocm():
+      # TODO(rocm): fix this
+      self.skipTest("hipSPARSE all failure on the ROCm platform")
+
     sparsify = lambda m: m * (m > 0)
-    for dtype in np.float32, np.complex64:
+    for dtype in dtypes_to_test:
       for (transpose_a, transpose_b) in ((False, False), (False, True),
                                          (True, False), (True, True)):
         for (adjoint_a, adjoint_b) in ((False, False), (False, True),
@@ -636,6 +666,10 @@ class CSRSparseMatrixOpsTest(test.TestCase):
 
   @test_util.run_in_graph_and_eager_modes
   def testLargeBatchSparseMatrixMatMulConjugate(self):
+    if test.is_built_with_rocm():
+      # complex types are not yet supported on the ROCm platform
+      self.skipTest("complex type not supported on ROCm")
+
     sparsify = lambda m: m * (m > 0)
     a_dense_shape = [53, 65, 127]
     b_dense_shape = [53, 127, 67]
@@ -766,6 +800,10 @@ class CSRSparseMatrixOpsTest(test.TestCase):
   def testLargeBatchRegisteredAddN(self):
     if not self._gpu_available:
       return
+
+    if test.is_built_with_rocm():
+      # sparse-matrix-add op is not yet supported on the ROCm platform
+      self.skipTest("sparse-matrix-add op not supported on ROCm")
 
     sparsify = lambda m: m * (m > 0)
     dense_shape = [53, 65, 127]
@@ -1154,9 +1192,10 @@ class CSRSparseMatrixOpsTest(test.TestCase):
         ]  #
     ]).astype(np.complex128)
 
-    data_types = [
-        dtypes.float32, dtypes.float64, dtypes.complex64, dtypes.complex128
-    ]
+    data_types = [dtypes.float32, dtypes.float64]
+    if not test.is_built_with_rocm():
+      # complex type is not supported on the ROCm platform
+      data_types += [dtypes.complex64, dtypes.complex128]
     for dtype in data_types:
       sparse_matrix = dense_to_csr_sparse_matrix(
           math_ops.cast(dense_mat, dtype))

--- a/tensorflow/python/kernel_tests/linalg/sparse/csr_sparse_matrix_test.py
+++ b/tensorflow/python/kernel_tests/linalg/sparse/csr_sparse_matrix_test.py
@@ -154,7 +154,11 @@ class SparseMatrixMatmulTest(test.TestCase):
     sparsify = lambda m: m * (m > 0)
     dense_shape_a = [5, 13, 7] if transpose_a or adjoint_a else [5, 7, 13]
     dense_shape_b = [5, 15, 13] if transpose_b or adjoint_b else [5, 13, 15]
-    for dtype in np.float32, np.complex64:
+    dtypes_to_test = [np.float32]
+    if not test.is_built_with_rocm():
+      # complex type is not supported on the ROCm platform
+      dtypes_to_test += [np.complex64]
+    for dtype in dtypes_to_test:
       a_mats = sparsify((np.random.randn(*dense_shape_a) +
                          1.j * np.random.randn(*dense_shape_a))).astype(dtype)
       b_mats = sparsify((np.random.randn(*dense_shape_b) +
@@ -194,7 +198,11 @@ class SparseMatrixMatmulTest(test.TestCase):
     sparsify = lambda m: m * (m > 0)
     dense_shape_a = [5, 13, 7] if transpose_a or adjoint_a else [5, 7, 13]
     dense_shape_b = [5, 15, 13] if transpose_b or adjoint_b else [5, 13, 15]
-    for dtype in np.float32, np.complex64:
+    dtypes_to_test = [np.float32]
+    if not test.is_built_with_rocm():
+      # complex type is not supported on the ROCm platform
+      dtypes_to_test += [np.complex64]
+    for dtype in dtypes_to_test:
       a_mats = sparsify((np.random.randn(*dense_shape_a) +
                          1.j * np.random.randn(*dense_shape_a))).astype(dtype)
       b_mats = (np.random.randn(*dense_shape_b) +
@@ -231,7 +239,11 @@ class SparseMatrixMatmulTest(test.TestCase):
     sparsify = lambda m: m * (m > 0)
     dense_shape_a = [5, 13, 7] if transpose_a or adjoint_a else [5, 7, 13]
     dense_shape_b = [5, 15, 13] if transpose_b or adjoint_b else [5, 13, 15]
-    for dtype in np.float32, np.complex64:
+    dtypes_to_test = [np.float32]
+    if not test.is_built_with_rocm():
+      # complex type is not supported on the ROCm platform
+      dtypes_to_test += [np.complex64]
+    for dtype in dtypes_to_test:
       a_mats = (np.random.randn(*dense_shape_a) +
                 1.j * np.random.randn(*dense_shape_a)).astype(dtype)
       b_mats = sparsify((np.random.randn(*dense_shape_b) +

--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -137,4 +137,11 @@ cc_library(
     ],
 )
 
+cc_import(
+    name = "hipsparse",
+    hdrs = glob(["rocm/include/hipsparse/**",]),
+    shared_library = "rocm/lib/%{hipsparse_lib}",
+    visibility = ["//visibility:public"],
+)
+
 %{copy_rules}

--- a/third_party/gpus/rocm/rocm_config.h.tpl
+++ b/third_party/gpus/rocm/rocm_config.h.tpl
@@ -16,6 +16,6 @@ limitations under the License.
 #ifndef ROCM_ROCM_CONFIG_H_
 #define ROCM_ROCM_CONFIG_H_
 
-#define TF_ROCM_TOOLKIT_PATH "/opt/rocm"
+#define TF_ROCM_TOOLKIT_PATH "%{rocm_toolkit_path}"
 
 #endif  // ROCM_ROCM_CONFIG_H_

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -238,7 +238,7 @@ def _rocm_include_path(repository_ctx, rocm_config):
 
     return inc_dirs
 
-def enable_rocm(repository_ctx):
+def _enable_rocm(repository_ctx):
     if "TF_NEED_ROCM" in repository_ctx.os.environ:
         enable_rocm = repository_ctx.os.environ["TF_NEED_ROCM"].strip()
         if enable_rocm == "1":
@@ -895,7 +895,7 @@ def _create_remote_rocm_repository(repository_ctx, remote_config_repo):
 
 def _rocm_autoconf_impl(repository_ctx):
     """Implementation of the rocm_autoconf repository rule."""
-    if not enable_rocm(repository_ctx):
+    if not _enable_rocm(repository_ctx):
         _create_dummy_repository(repository_ctx)
     elif _TF_ROCM_CONFIG_REPO in repository_ctx.os.environ:
         _create_remote_rocm_repository(

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -191,54 +191,54 @@ def _rocm_include_path(repository_ctx, rocm_config):
     inc_dirs.append(rocm_config.rocm_toolkit_path + "/include")
 
     # Add HSA headers
-    inc_dirs.append("/opt/rocm/hsa/include")
+    inc_dirs.append(rocm_config.rocm_toolkit_path + "/hsa/include")
 
     # Add HIP headers
-    inc_dirs.append("/opt/rocm/include/hip")
-    inc_dirs.append("/opt/rocm/include/hip/hcc_detail")
-    inc_dirs.append("/opt/rocm/hip/include")
+    inc_dirs.append(rocm_config.rocm_toolkit_path + "/include/hip")
+    inc_dirs.append(rocm_config.rocm_toolkit_path + "/include/hip/hcc_detail")
+    inc_dirs.append(rocm_config.rocm_toolkit_path + "/hip/include")
 
     # Add HIP-Clang headers
-    inc_dirs.append("/opt/rocm/llvm/lib/clang/8.0/include")
-    inc_dirs.append("/opt/rocm/llvm/lib/clang/9.0.0/include")
-    inc_dirs.append("/opt/rocm/llvm/lib/clang/10.0.0/include")
+    inc_dirs.append(rocm_config.rocm_toolkit_path + "/llvm/lib/clang/8.0/include")
+    inc_dirs.append(rocm_config.rocm_toolkit_path + "/llvm/lib/clang/9.0.0/include")
+    inc_dirs.append(rocm_config.rocm_toolkit_path + "/llvm/lib/clang/10.0.0/include")
 
     # Add rocrand and hiprand headers
-    inc_dirs.append("/opt/rocm/rocrand/include")
-    inc_dirs.append("/opt/rocm/hiprand/include")
+    inc_dirs.append(rocm_config.rocm_toolkit_path + "/rocrand/include")
+    inc_dirs.append(rocm_config.rocm_toolkit_path + "/hiprand/include")
 
     # Add rocfft headers
-    inc_dirs.append("/opt/rocm/rocfft/include")
+    inc_dirs.append(rocm_config.rocm_toolkit_path + "/rocfft/include")
 
     # Add rocBLAS headers
-    inc_dirs.append("/opt/rocm/rocblas/include")
+    inc_dirs.append(rocm_config.rocm_toolkit_path + "/rocblas/include")
 
     # Add MIOpen headers
-    inc_dirs.append("/opt/rocm/miopen/include")
+    inc_dirs.append(rocm_config.rocm_toolkit_path + "/miopen/include")
 
     # Add RCCL headers
-    inc_dirs.append("/opt/rocm/rccl/include")
+    inc_dirs.append(rocm_config.rocm_toolkit_path + "/rccl/include")
 
     # Add hcc headers
-    inc_dirs.append("/opt/rocm/hcc/include")
-    inc_dirs.append("/opt/rocm/hcc/compiler/lib/clang/7.0.0/include/")
-    inc_dirs.append("/opt/rocm/hcc/lib/clang/7.0.0/include")
+    inc_dirs.append(rocm_config.rocm_toolkit_path + "/hcc/include")
+    inc_dirs.append(rocm_config.rocm_toolkit_path + "/hcc/compiler/lib/clang/7.0.0/include/")
+    inc_dirs.append(rocm_config.rocm_toolkit_path + "/hcc/lib/clang/7.0.0/include")
 
     # Newer hcc builds use/are based off of clang 8.0.0.
-    inc_dirs.append("/opt/rocm/hcc/compiler/lib/clang/8.0.0/include/")
-    inc_dirs.append("/opt/rocm/hcc/lib/clang/8.0.0/include")
+    inc_dirs.append(rocm_config.rocm_toolkit_path + "/hcc/compiler/lib/clang/8.0.0/include/")
+    inc_dirs.append(rocm_config.rocm_toolkit_path + "/hcc/lib/clang/8.0.0/include")
 
     # Support hcc based off clang 9.0.0, included in ROCm2.2
-    inc_dirs.append("/opt/rocm/hcc/compiler/lib/clang/9.0.0/include/")
-    inc_dirs.append("/opt/rocm/hcc/lib/clang/9.0.0/include")
+    inc_dirs.append(rocm_config.rocm_toolkit_path + "/hcc/compiler/lib/clang/9.0.0/include/")
+    inc_dirs.append(rocm_config.rocm_toolkit_path + "/hcc/lib/clang/9.0.0/include")
 
     # Support hcc based off clang 10.0.0, included in ROCm2.8
-    inc_dirs.append("/opt/rocm/hcc/compiler/lib/clang/10.0.0/include/")
-    inc_dirs.append("/opt/rocm/hcc/lib/clang/10.0.0/include")
+    inc_dirs.append(rocm_config.rocm_toolkit_path + "/hcc/compiler/lib/clang/10.0.0/include/")
+    inc_dirs.append(rocm_config.rocm_toolkit_path + "/hcc/lib/clang/10.0.0/include")
 
     return inc_dirs
 
-def _enable_rocm(repository_ctx):
+def enable_rocm(repository_ctx):
     if "TF_NEED_ROCM" in repository_ctx.os.environ:
         enable_rocm = repository_ctx.os.environ["TF_NEED_ROCM"].strip()
         if enable_rocm == "1":
@@ -300,11 +300,12 @@ def _hipcc_env(repository_ctx):
                          repository_ctx.os.environ[name].strip() + "\";")
     return hipcc_env.strip()
 
-def _hipcc_is_hipclang(repository_ctx):
+def _hipcc_is_hipclang(repository_ctx, rocm_config):
     """Returns if hipcc is based on hip-clang toolchain.
 
     Args:
         repository_ctx: The repository context.
+        rocm_config: The path to the hip compiler.
 
     Returns:
         A string "True" if hipcc is based on hip-clang toolchain.
@@ -319,7 +320,7 @@ def _hipcc_is_hipclang(repository_ctx):
     # grep for "HIP_COMPILER=clang" in /opt/rocm/hip/lib/.hipInfo
     grep_result = _execute(
         repository_ctx,
-        ["grep", "HIP_COMPILER=clang", "/opt/rocm/hip/lib/.hipInfo"],
+        ["grep", "HIP_COMPILER=clang", rocm_config.rocm_toolkit_path + "/hip/lib/.hipInfo"],
         empty_stdout_fine = True,
     )
     result = grep_result.stdout
@@ -327,13 +328,14 @@ def _hipcc_is_hipclang(repository_ctx):
         return "True"
     return "False"
 
-def _if_hipcc_is_hipclang(repository_ctx, if_true, if_false = []):
+def _if_hipcc_is_hipclang(repository_ctx, rocm_config, if_true, if_false = []):
     """
     Returns either the if_true or if_false arg based on whether hipcc
     is based on the hip-clang toolchain
 
     Args :
         repository_ctx: The repository context.
+        rocm_config: The path to the hip compiler.
         if_true : value to return if hipcc is hip-clang based
         if_false : value to return if hipcc is not hip-clang based
                    (optional, defaults to empty list)
@@ -341,7 +343,7 @@ def _if_hipcc_is_hipclang(repository_ctx, if_true, if_false = []):
     Returns :
         either the if_true arg or the of_False arg
     """
-    if _hipcc_is_hipclang(repository_ctx) == "True":
+    if _hipcc_is_hipclang(repository_ctx, rocm_config) == "True":
         return if_true
     return if_false
 
@@ -478,6 +480,11 @@ def _find_libs(repository_ctx, rocm_config):
             repository_ctx,
             rocm_config.rocm_toolkit_path + "/rccl",
         ),
+        "hipsparse": _find_rocm_lib(
+            "hipsparse",
+            repository_ctx,
+            rocm_config.rocm_toolkit_path + "/hipsparse",
+        ),
     }
 
 def _get_rocm_config(repository_ctx):
@@ -558,6 +565,7 @@ def _create_dummy_repository(repository_ctx):
             "%{rccl_lib}": _lib_name("rccl"),
             "%{rocfft_lib}": _lib_name("rocfft"),
             "%{hiprand_lib}": _lib_name("hiprand"),
+            "%{hipsparse_lib}": _lib_name("hipsparse"),
             "%{copy_rules}": "",
             "%{rocm_headers}": "",
         },
@@ -703,6 +711,12 @@ def _create_local_rocm_repository(repository_ctx):
             src_dir = rocm_toolkit_path + "/rccl/include",
             out_dir = "rocm/include/rccl",
         ),
+        make_copy_dir_rule(
+            repository_ctx,
+            name = "hipsparse-include",
+            src_dir = rocm_toolkit_path + "/hipsparse/include",
+            out_dir = "rocm/include/hipsparse",
+        ),
     ]
 
     rocm_libs = _find_libs(repository_ctx, rocm_config)
@@ -740,16 +754,19 @@ def _create_local_rocm_repository(repository_ctx):
             "%{hiprand_lib}": rocm_libs["hiprand"].file_name,
             "%{miopen_lib}": rocm_libs["miopen"].file_name,
             "%{rccl_lib}": rocm_libs["rccl"].file_name,
+            "%{hipsparse_lib}": rocm_libs["hipsparse"].file_name,
             "%{copy_rules}": "\n".join(copy_rules),
             "%{rocm_headers}": ('":rocm-include",\n' +
                                 '":rocfft-include",\n' +
                                 '":rocblas-include",\n' +
                                 '":miopen-include",\n' +
-                                '":rccl-include",'),
+                                '":rccl-include",\n' +
+                                '":hipsparse-include",'),
         },
     )
 
     # Set up crosstool/
+
     cc = find_cc(repository_ctx)
 
     host_compiler_includes = get_cxx_inc_directories(repository_ctx, cc)
@@ -762,7 +779,7 @@ def _create_local_rocm_repository(repository_ctx):
 
     rocm_defines["%{host_compiler_prefix}"] = host_compiler_prefix
 
-    rocm_defines["%{linker_bin_path}"] = "/opt/rocm/hcc/compiler/bin"
+    rocm_defines["%{linker_bin_path}"] = rocm_config.rocm_toolkit_path + "/hcc/compiler/bin"
 
     # For gcc, do not canonicalize system header paths; some versions of gcc
     # pick the shortest possible path for system includes when creating the
@@ -775,7 +792,7 @@ def _create_local_rocm_repository(repository_ctx):
         "-DTENSORFLOW_USE_ROCM=1",
         "-D__HIP_PLATFORM_HCC__",
         "-DEIGEN_USE_HIP",
-    ] + _if_hipcc_is_hipclang(repository_ctx, [
+    ] + _if_hipcc_is_hipclang(repository_ctx, rocm_config, [
         #
         # define "TENSORFLOW_COMPILER_IS_HIP_CLANG" when we are using clang
         # based hipcc to compile/build tensorflow
@@ -815,14 +832,14 @@ def _create_local_rocm_repository(repository_ctx):
         "crosstool:clang/bin/crosstool_wrapper_driver_rocm",
         {
             "%{cpu_compiler}": str(cc),
-            "%{hipcc_path}": "/opt/rocm/bin/hipcc",
+            "%{hipcc_path}": rocm_config.rocm_toolkit_path + "/bin/hipcc",
             "%{hipcc_env}": _hipcc_env(repository_ctx),
-            "%{hipcc_is_hipclang}": _hipcc_is_hipclang(repository_ctx),
-            "%{rocr_runtime_path}": "/opt/rocm/lib",
+            "%{hipcc_is_hipclang}": _hipcc_is_hipclang(repository_ctx, rocm_config),
+            "%{rocr_runtime_path}": rocm_config.rocm_toolkit_path + "/lib",
             "%{rocr_runtime_library}": "hsa-runtime64",
-            "%{hip_runtime_path}": "/opt/rocm/hip/lib",
+            "%{hip_runtime_path}": rocm_config.rocm_toolkit_path + "/hip/lib",
             "%{hip_runtime_library}": "hip_hcc",
-            "%{hcc_runtime_path}": "/opt/rocm/hcc/lib",
+            "%{hcc_runtime_path}": rocm_config.rocm_toolkit_path + "/hcc/lib",
             "%{hcc_runtime_library}": "mcwamp",
             "%{crosstool_verbose}": _crosstool_verbose(repository_ctx),
             "%{gcc_host_compiler_path}": str(cc),
@@ -878,7 +895,7 @@ def _create_remote_rocm_repository(repository_ctx, remote_config_repo):
 
 def _rocm_autoconf_impl(repository_ctx):
     """Implementation of the rocm_autoconf repository rule."""
-    if not _enable_rocm(repository_ctx):
+    if not enable_rocm(repository_ctx):
         _create_dummy_repository(repository_ctx)
     elif _TF_ROCM_CONFIG_REPO in repository_ctx.os.environ:
         _create_remote_rocm_repository(


### PR DESCRIPTION
This PR adds ROCm support for CSR Sparse Matrix Ops.

The PR has 6 commits which organize the changes as per functionality being changed. Please review the commits indidvidually.

The file `cuda_sparse.h` should ideally be renamed to `gpu_sparse.h` once this PR is taken. I have not made that change a part of this PR. I can add a commit to make that change, assuming the reviewers are okay with it...please let me know if that is needed.

---------------------------

/cc @whchung @chsigg 