### PR TITLE
Fix deprecation warnings in image_ops by replacing div with divide or floordiv

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1554,7 +1554,7 @@ def per_image_standardization(image):
     adjusted_stddev = math_ops.maximum(stddev, min_stddev)
 
     image -= image_mean
-    image = math_ops.div(image, adjusted_stddev, name=scope)
+    image = math_ops.divide(image, adjusted_stddev, name=scope)
     return convert_image_dtype(image, orig_dtype, saturate=True)
 
 
@@ -1823,7 +1823,7 @@ def convert_image_dtype(image, dtype, saturate=False, name=None):
         # cause in.max to be mapped to above out.max but below out.max+1,
         # so that the output is safely in the supported range.
         scale = (scale_in + 1) // (scale_out + 1)
-        scaled = math_ops.div(image, scale)
+        scaled = math_ops.floordiv(image, scale)
 
         if saturate:
           return math_ops.saturate_cast(scaled, dtype, name=name)


### PR DESCRIPTION
Using `tf.image.per_image_standardization` or certain calls (depending on arguments) to `tf.image.convert_image_dtype` will yield a deprecation warning, e.g.:

```python
import tensorflow as tf
tf.image.per_image_standardization(tf.zeros((32, 32, 1)))
# WARNING:tensorflow:From tensorflow_core/python/ops/image_ops_impl.py:1557: div (from tensorflow.python.ops.math_ops) is deprecated and will be removed in a future version.
# Instructions for updating:
# Deprecated in favor of operator or tf.math.divide.
```
or
```python
import tensorflow as tf
tf.image.convert_image_dtype(tf.zeros((32, 32, 1), dtype=tf.uint16), tf.uint8)
# WARNING:tensorflow:From tensorflow_core/python/ops/image_ops_impl.py:1826: div (from tensorflow.python.ops.math_ops) is deprecated and will be removed in a future version.
# Instructions for updating:
# Deprecated in favor of operator or tf.math.divide.
```

This PR addresses those two occurrences. In `per_image_standardization`, `div` is exchanged with `divide`, as within the function, it is ensured that the dtype is a floating point type; in `convert_image_dtype` on the other hand, the call comes in a branch ensuring the dtype is a integer type.

In general, there are quite some (`grep -R '\.div(' | wc` => 40) usages of `div()`, which would all yield the deprecation warning, probably someone who is more familiar with the TensorFlow codebase should seek through them and replace them with the desired, current division call.