### PR TITLE
[ROCm] Fix for the broken ROCm CSB - 191203 - XLA

### DIFF
--- a/tensorflow/compiler/xla/service/cpu/cpu_executable.cc
+++ b/tensorflow/compiler/xla/service/cpu/cpu_executable.cc
@@ -147,8 +147,8 @@ CpuExecutable::CreateBufferTable(
       }
     }
   }
-  return {{std::move(unowning_buffers), std::move(owning_buffers),
-           std::move(buffers_to_free)}};
+  return std::make_tuple(std::move(unowning_buffers), std::move(owning_buffers),
+                         std::move(buffers_to_free));
 }
 
 Status CpuExecutable::ExecuteComputeFunction(


### PR DESCRIPTION
The following commit breaks the ROCm CSB

https://github.com/tensorflow/tensorflow/commit/1c03f956c5851b60fe4fcf16fb4e50bed0fb653b

It leads to the following compile error

```
ERROR: /root/tensorflow/tensorflow/compiler/xla/service/cpu/BUILD:225:1:
C++ compilation of rule '//tensorflow/compiler/xla/service/cpu:cpu_executable' failed (Exit 1)

tensorflow/compiler/xla/service/cpu/cpu_executable.cc:
In member function 'xla::StatusOr<std::tuple<std::vector<stream_executor::DeviceMemoryBase, std::allocator<stream_executor::DeviceMemoryBase> >, std::vector<stream_executor::ScopedDeviceMemory<unsigned char>, std::allocator<stream_executor::ScopedDeviceMemory<unsigned char> > >, std::vector<stream_executor::ScopedDeviceMemory<unsigned char>, std::allocator<stream_executor::ScopedDeviceMemory<unsigned char> > > > > xla::cpu::CpuExecutable::CreateBufferTable(stream_executor::DeviceMemoryAllocator*, int, std::vector<xla::ShapeTree<xla::MaybeOwningDeviceMemory> >)':

tensorflow/compiler/xla/service/cpu/cpu_executable.cc:151:39:

error: converting to 'std::tuple<std::vector<stream_executor::DeviceMemoryBase, std::allocator<stream_executor::DeviceMemoryBase> >, std::vector<stream_executor::ScopedDeviceMemory<unsigned char>, std::allocator<stream_executor::ScopedDeviceMemory<unsigned char> > >, std::vector<stream_executor::ScopedDeviceMemory<unsigned char>, std::allocator<stream_executor::ScopedDeviceMemory<unsigned char> > > >'

from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...)
[with _UElements = {std::vector<stream_executor::DeviceMemoryBase, std::allocator<stream_executor::DeviceMemoryBase> >, std::vector<stream_executor::ScopedDeviceMemory<unsigned char>, std::allocator<stream_executor::ScopedDeviceMemory<unsigned char> > >, std::vector<stream_executor::ScopedDeviceMemory<unsigned char>, std::allocator<stream_executor::ScopedDeviceMemory<unsigned char> > >}; <template-parameter-2-2> = void; _Elements = {std::vector<stream_executor::DeviceMemoryBase, std::allocator<stream_executor::DeviceMemoryBase> >, std::vector<stream_executor::ScopedDeviceMemory<unsigned char>, std::allocator<stream_executor::ScopedDeviceMemory<unsigned char> > >, std::vector<stream_executor::ScopedDeviceMemory<unsigned char>, std::allocator<stream_executor::ScopedDeviceMemory<unsigned char> > >}]'
            std::move(buffers_to_free)}};
```

The break does not seem ROCm specific, it is very likley breaking other builds too.

The fix is to explicitly call `std::make_tuple` at the point of error.


/cc @chsigg @whchung 