### PR TITLE
Usage example

### DIFF
--- a/tensorflow/python/keras/utils/np_utils.py
+++ b/tensorflow/python/keras/utils/np_utils.py
@@ -36,6 +36,17 @@ def to_categorical(y, num_classes=None, dtype='float32'):
   Returns:
       A binary matrix representation of the input. The classes axis is placed
       last.
+  
+  Usage Example:
+    ```python
+    import tensorflow as tf
+    y = [0, 2, 4, 3, 5, 0, 1, 1, 2]
+    tf.keras.utils.to_categorical(y, 6)
+    ```  
+
+  Raises:
+      Value Error: If input contains string value
+
   """
   y = np.array(y, dtype='int')
   input_shape = y.shape

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -354,6 +354,7 @@ def random_flip_up_down(image, seed=None):
 
   Returns:
     A tensor of the same type and shape as `image`.
+
   Raises:
     ValueError: if the shape of `image` not supported.
   """
@@ -1573,6 +1574,13 @@ def random_brightness(image, max_delta, seed=None):
 
   Returns:
     The brightness-adjusted image(s).
+  
+  Usage Example:
+    ```python
+    import tensorflow as tf
+    x = tf.random.normal(shape=(256, 256, 3))
+    tf.image.random_brightness(x, 1)
+    ```
 
   Raises:
     ValueError: if `max_delta` is negative.
@@ -1601,6 +1609,13 @@ def random_contrast(image, lower, upper, seed=None):
   Returns:
     The contrast-adjusted image(s).
 
+  Usage Example:
+    ```python
+    import tensorflow as tf
+    x = tf.random.normal(shape=(256, 256, 3))
+    tf.image.random_contrast(x, 0, 10)
+    ```
+    
   Raises:
     ValueError: if `upper <= lower` or if `lower < 0`.
   """
@@ -1938,6 +1953,13 @@ def random_hue(image, max_delta, seed=None):
   Returns:
     Adjusted image(s), same shape and DType as `image`.
 
+  Usage Example:
+    ```python
+    import tensorflow as tf
+    x = tf.random.normal(shape=(256, 256, 3))
+    tf.image.random_hue(x, 0.3)
+    ```
+
   Raises:
     ValueError: if `max_delta` is invalid.
   """
@@ -2016,6 +2038,13 @@ def random_jpeg_quality(image, min_jpeg_quality, max_jpeg_quality, seed=None):
 
   Returns:
     Adjusted image(s), same shape and DType as `image`.
+
+  Usage Example:
+    ```python
+    import tensorflow as tf
+    x = tf.random.normal(shape=(256, 256, 3))
+    tf.image.random_jpeg_quality(x, 25,75)
+    ```
 
   Raises:
     ValueError: if `min_jpeg_quality` or `max_jpeg_quality` is invalid.
@@ -2096,6 +2125,13 @@ def random_saturation(image, lower, upper, seed=None):
 
   Returns:
     Adjusted image(s), same shape and DType as `image`.
+
+  Usage Example:
+    ```python
+    import tensorflow as tf
+    x = tf.random.normal(shape=(256, 256, 3))
+    tf.image.random_saturation(x, 0.5, 1.5)
+    ```
 
   Raises:
     ValueError: if `upper <= lower` or if `lower < 0`.

--- a/tensorflow/python/ops/random_ops.py
+++ b/tensorflow/python/ops/random_ops.py
@@ -362,6 +362,14 @@ def random_crop(value, size, seed=None, name=None):
 
   Returns:
     A cropped tensor of the same rank as `value` and shape `size`.
+  
+  Usage Example:
+    ```python
+    import tensorflow as tf
+    x = tf.random.normal(shape=(256, 256, 3))
+    size=[64,64,3]
+    tf.image.random_crop(x, size)
+    ```
   """
   # TODO(shlens): Implement edge case to guarantee output size dimensions.
   # If size > value.shape, zero pad the result so that it always has shape


### PR DESCRIPTION
I was working on another GCI task and noticed that keras.utils.to_categorical didn't have a usage example or a raise-error(which I happened to get) so I updated the doc