### PR TITLE
added usage example and errors raised

### DIFF
--- a/tensorflow/python/keras/utils/np_utils.py
+++ b/tensorflow/python/keras/utils/np_utils.py
@@ -36,6 +36,17 @@ def to_categorical(y, num_classes=None, dtype='float32'):
   Returns:
       A binary matrix representation of the input. The classes axis is placed
       last.
+
+  Usage Example:
+    ```python
+    import tensorflow as tf
+    y = [0, 2, 4, 3, 5, 0, 1, 1, 2]
+    tf.keras.utils.to_categorical(y, 6)
+    ```  
+
+  Raises:
+      Value Error: If input contains string value
+      
   """
   y = np.array(y, dtype='int')
   input_shape = y.shape

--- a/tensorflow/python/keras/utils/np_utils.py
+++ b/tensorflow/python/keras/utils/np_utils.py
@@ -37,7 +37,8 @@ def to_categorical(y, num_classes=None, dtype='float32'):
       A binary matrix representation of the input. The classes axis is placed
       last.
 
-  Usage Example:
+  Usage example:
+
   >>> y = [0, 1, 2, 3, 3, 1, 0]
   >>> tf.keras.utils.to_categorical(y, 4) 
   array([[1., 0., 0., 0.],

--- a/tensorflow/python/keras/utils/np_utils.py
+++ b/tensorflow/python/keras/utils/np_utils.py
@@ -38,15 +38,19 @@ def to_categorical(y, num_classes=None, dtype='float32'):
       last.
 
   Usage Example:
-    ```python
-    import tensorflow as tf
-    y = [0, 2, 4, 3, 5, 0, 1, 1, 2]
-    tf.keras.utils.to_categorical(y, 6)
-    ```  
-
+  >>> y = [0, 1, 2, 3, 3, 1, 0]
+  >>> tf.keras.utils.to_categorical(y, 4) 
+  array([[1., 0., 0., 0.],
+         [0., 1., 0., 0.],
+         [0., 0., 1., 0.],
+         [0., 0., 0., 1.],
+         [0., 0., 0., 1.],
+         [0., 1., 0., 0.],
+         [1., 0., 0., 0.]], dtype=float32)
+                       
   Raises:
       Value Error: If input contains string value
-      
+
   """
   y = np.array(y, dtype='int')
   input_shape = y.shape


### PR DESCRIPTION
I was working on another GCI task and noticed that keras.utils.to_categorical didn't have a usage example or a raise-error(which I happened to get) so I updated the doc