### PR TITLE
Close filehandle to keras.json when initializing config

### DIFF
--- a/tensorflow/python/keras/backend.py
+++ b/tensorflow/python/keras/backend.py
@@ -5876,7 +5876,8 @@ else:
 _config_path = os.path.expanduser(os.path.join(_keras_dir, 'keras.json'))
 if os.path.exists(_config_path):
   try:
-    _config = json.load(open(_config_path))
+    with open(_config_path) as fh:
+      _config = json.load(fh)
   except ValueError:
     _config = {}
   _floatx = _config.get('floatx', floatx())


### PR DESCRIPTION
`json.load` does not close the file handle that is being passed in by the `open` statement. Using a context manager to open the file will guarantee that it is automatically closed as well. 