### PR TITLE
Fix `invalid syntax` error when `import carla` is present

### DIFF
--- a/tensorflow/python/framework/python_op_gen_internal.cc
+++ b/tensorflow/python/framework/python_op_gen_internal.cc
@@ -449,7 +449,12 @@ string AttrValueToPython(const string& type, const AttrValue& value,
       std::ostringstream s;
       s.imbue(std::locale::classic());
       s << std::setprecision(FLT_DIG) << value.f();
-      return s.str();
+      // If there is no I/O error for `std::ostringstream s` return s.str(),
+      // otherwise fallback to strings::StrCat(value.f()).
+      if (s.good()) {
+        return s.str();
+      }
+      return strings::StrCat(value.f());
     }
   } else if (type == "bool") {
     return value.b() ? "True" : "False";


### PR DESCRIPTION
This fix tries to address the issue raised in #34828 where
`import carla` followed by `import tensorflow` caused the
following:
```
SyntaxError: invalid syntax
```

The issue is that, when `import carla` is invoked,
I/O operation for `std::ostringstream s` might fail,
which caused the conversion of AttrValue to string as empty.

This PR check `s.good()` to make sure the I/O operation
is OK, and, fallback to normal conversion if locale-neutral I/O
operation fails.

This PR fixes #34828.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>