### PR TITLE
[tflite] fix a dilated dw conv problem in tflite_convert

### DIFF
--- a/tensorflow/lite/toco/graph_transformations/identify_dilated_conv.cc
+++ b/tensorflow/lite/toco/graph_transformations/identify_dilated_conv.cc
@@ -112,11 +112,19 @@ bool ResolveDilatedConv(Model* model, Operator* conv_base_op, Operator* stb_op,
 
   // Post-BatchToSpace Bias Op
   Operator* bias_add_op = !has_bias_before_bts ? final_op : next_op;
-  if (bias_add_op->type != OperatorType::kAdd) {
-    // Bias op is required before or after BatchToSpace
+  if ((bias_add_op->type != OperatorType::kAdd) &&
+      (bias_add_op->type != OperatorType::kBatchNormalization)) {
+    // Bias op or Batch Norm is required before or after BatchToSpace
     return false;
   }
-  CHECK_EQ(bias_add_op->inputs.size(), 2);
+  switch (bias_add_op->type) {
+    case OperatorType::kAdd:
+      CHECK_EQ(bias_add_op->inputs.size(), 2);
+    case OperatorType::kBatchNormalization:
+      CHECK_EQ(bias_add_op->inputs.size(), 4);
+    default:
+      break;
+  }
   CHECK_EQ(bias_add_op->outputs.size(), 1);
 
   // 2. RE-WIRE OPERATORS


### PR DESCRIPTION
In tflite_convert/toco, it's assumed that there is a BiasAdd
before or after a BatchToSpaceND. However, in some frozen
graph_def files, e.g., DeepLab V3 mobilenet v2 coco
checkpoints [1], it's a fused BatchNormalization rather than
a BiasAdd.

This patch adds the BatchNorm case.

[1] https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/model_zoo.md