### PR TITLE
[tflite] bump SPLIT op ver from 1 to 3 in NNAPI delegate

### DIFF
--- a/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
+++ b/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
@@ -2023,7 +2023,7 @@ bool NNAPIDelegateKernel::Validate(
              "NNAPI only supports constant int32 axis tensor.", &val_ctx);
     } break;
     case kTfLiteBuiltinSplit: {
-      ExpectOpVersion(version, 1, &val_ctx);
+      ExpectOpVersion(version, 3, &val_ctx);
       ExpectMinAndroidSdkVersion(android_sdk_version, kMinSdkVersionForNNAPI12,
                                  &val_ctx);
       // Tensor indices: split_dim: 0, value: 1


### PR DESCRIPTION
I need SPLIT op version 3. Since it's supported by TFLite and
NNAPI 1.2. It should be safe to bump the op version so that
I can delegate SPLIT ops to accelerators.