### PR TITLE
Implement slice input fusion.

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
@@ -244,7 +244,7 @@ bool IsInputFusibleSlices(const HloInstruction& unnested_hlo,
     return absl::c_all_of(strides, [](int stride) { return stride == 1; });
   };
 
-  const auto root = unnested_hlo.fused_expression_root();
+  const HloInstruction* root = unnested_hlo.fused_expression_root();
   if (root->opcode() == HloOpcode::kSlice) {
     return !verify_no_strides || is_non_strided(root->slice_strides());
   }
@@ -258,11 +258,8 @@ bool IsInputFusibleSlices(const HloInstruction& unnested_hlo,
         return insn->opcode() == HloOpcode::kSlice &&
                (!verify_no_strides || is_non_strided(insn->slice_strides()));
       });
-  if (!all_non_strided_slices) {
-    return false;
-  }
 
-  return true;
+  return all_non_strided_slices;
 }
 
 ReductionDimensions GetReductionKindAndContiguousComponents(

--- a/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
@@ -253,9 +253,9 @@ bool IsInputFusibleSlices(const HloInstruction& unnested_hlo,
     return false;
   }
 
-  return absl::c_all_of(root->operands(), [&](const HloInstruction* insn) {
-    return insn->opcode() == HloOpcode::kSlice &&
-           (!verify_no_strides || is_non_strided(insn->slice_strides()));
+  return absl::c_all_of(root->operands(), [&](const HloInstruction* instr) {
+    return instr->opcode() == HloOpcode::kSlice &&
+           (!verify_no_strides || is_non_strided(instr->slice_strides()));
   });
 }
 

--- a/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
@@ -253,13 +253,10 @@ bool IsInputFusibleSlices(const HloInstruction& unnested_hlo,
     return false;
   }
 
-  bool all_non_strided_slices =
-      absl::c_all_of(root->operands(), [&](const HloInstruction* insn) {
-        return insn->opcode() == HloOpcode::kSlice &&
-               (!verify_no_strides || is_non_strided(insn->slice_strides()));
-      });
-
-  return all_non_strided_slices;
+  return absl::c_all_of(root->operands(), [&](const HloInstruction* insn) {
+    return insn->opcode() == HloOpcode::kSlice &&
+           (!verify_no_strides || is_non_strided(insn->slice_strides()));
+  });
 }
 
 ReductionDimensions GetReductionKindAndContiguousComponents(

--- a/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
@@ -234,6 +234,37 @@ bool IsReductionFromOrToContiguousDimensions(const HloInstruction& reduce) {
   return reduction_dimensions.dimensions[1] >= kWarpSize;
 }
 
+bool IsInputFusibleSlices(const HloInstruction& unnested_hlo,
+                          bool verify_no_strides) {
+  if (!unnested_hlo.IsInputFusion()) {
+    return false;
+  }
+
+  auto is_non_strided = [](const std::vector<int64>& strides) -> bool {
+    return absl::c_all_of(strides, [](int stride) { return stride == 1; });
+  };
+
+  const auto root = unnested_hlo.fused_expression_root();
+  if (root->opcode() == HloOpcode::kSlice) {
+    return !verify_no_strides || is_non_strided(root->slice_strides());
+  }
+
+  if (root->opcode() != HloOpcode::kTuple) {
+    return false;
+  }
+
+  bool all_non_strided_slices =
+      absl::c_all_of(root->operands(), [&](const HloInstruction* insn) {
+        return insn->opcode() == HloOpcode::kSlice &&
+               (!verify_no_strides || is_non_strided(insn->slice_strides()));
+      });
+  if (!all_non_strided_slices) {
+    return false;
+  }
+
+  return true;
+}
+
 ReductionDimensions GetReductionKindAndContiguousComponents(
     const HloInstruction& reduce) {
   const Shape& input_shape = reduce.operand(0)->shape();

--- a/tensorflow/compiler/xla/service/gpu/ir_emission_utils.h
+++ b/tensorflow/compiler/xla/service/gpu/ir_emission_utils.h
@@ -158,7 +158,8 @@ bool ImplementedAsLibraryCall(const HloInstruction& hlo);
 bool IsReductionFromOrToContiguousDimensions(const HloInstruction& reduce);
 
 // Whether it is an input fusion whose root is either a non-strided slice
-// or a tuple of non-strided slices.
+// or a tuple of non-strided slices. If verify_no_strides is true, verify
+// that all ROOT slices have no strides.
 bool IsInputFusibleSlices(const HloInstruction& unnested_hlo,
                           bool verify_no_strides = false);
 

--- a/tensorflow/compiler/xla/service/gpu/ir_emission_utils.h
+++ b/tensorflow/compiler/xla/service/gpu/ir_emission_utils.h
@@ -158,8 +158,9 @@ bool ImplementedAsLibraryCall(const HloInstruction& hlo);
 bool IsReductionFromOrToContiguousDimensions(const HloInstruction& reduce);
 
 // Whether it is an input fusion whose root is either a non-strided slice
-// or a tuple of non-strided slices. If verify_no_strides is true, verify
-// that all ROOT slices have no strides.
+// or a tuple of non-strided slices. Returns whether unnested_hlo is a
+// slice input fusion or not. If verify_no_strides is true, return false
+// unless all ROOT slices have no strides.
 bool IsInputFusibleSlices(const HloInstruction& unnested_hlo,
                           bool verify_no_strides = false);
 

--- a/tensorflow/compiler/xla/service/gpu/ir_emission_utils.h
+++ b/tensorflow/compiler/xla/service/gpu/ir_emission_utils.h
@@ -158,7 +158,7 @@ bool ImplementedAsLibraryCall(const HloInstruction& hlo);
 bool IsReductionFromOrToContiguousDimensions(const HloInstruction& reduce);
 
 // Returns whether unnested_hlo is an input fusion whose root is either a slice
-// or a tuple of slices. If verify_no_strides is true, return false unless all
+// or a tuple of slices. If verify_no_strides is true, returns false unless all
 // ROOT slices have no strides.
 bool IsInputFusibleSlices(const HloInstruction& unnested_hlo,
                           bool verify_no_strides = false);

--- a/tensorflow/compiler/xla/service/gpu/ir_emission_utils.h
+++ b/tensorflow/compiler/xla/service/gpu/ir_emission_utils.h
@@ -157,6 +157,11 @@ bool ImplementedAsLibraryCall(const HloInstruction& hlo);
 // kept are contiguous in the input of the reduce instruction.
 bool IsReductionFromOrToContiguousDimensions(const HloInstruction& reduce);
 
+// Whether it is an input fusion whose root is either a non-strided slice
+// or a tuple of non-strided slices.
+bool IsInputFusibleSlices(const HloInstruction& unnested_hlo,
+                          bool verify_no_strides = false);
+
 struct ReductionDimensions {
   // Indicates whether the reduction is a row reduction or a column reduction.
   bool is_row_reduction;

--- a/tensorflow/compiler/xla/service/gpu/ir_emission_utils.h
+++ b/tensorflow/compiler/xla/service/gpu/ir_emission_utils.h
@@ -157,10 +157,9 @@ bool ImplementedAsLibraryCall(const HloInstruction& hlo);
 // kept are contiguous in the input of the reduce instruction.
 bool IsReductionFromOrToContiguousDimensions(const HloInstruction& reduce);
 
-// Whether it is an input fusion whose root is either a non-strided slice
-// or a tuple of non-strided slices. Returns whether unnested_hlo is a
-// slice input fusion or not. If verify_no_strides is true, return false
-// unless all ROOT slices have no strides.
+// Returns whether unnested_hlo is an input fusion whose root is either a slice
+// or a tuple of slices. If verify_no_strides is true, return false unless all
+// ROOT slices have no strides.
 bool IsInputFusibleSlices(const HloInstruction& unnested_hlo,
                           bool verify_no_strides = false);
 

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -301,12 +301,12 @@ llvm::Type* GetIndexTypeForKernel(const HloInstruction* hlo, int64 launch_size,
   return b->getInt32Ty();
 }
 
-// Get the input shape of the ROOT slices, which will be used as the kernel
+// Gets the input shape of the ROOT slices, which will be used as the kernel
 // launch dims. The slice input fusion requires the input shapes of the ROOT
 // slices to be the same although the (slice) output shapes can be different.
 //
-// Return the input shape of the ROOT slices if all the input shapes of ROOT
-// slices are the same and the slices are non-strided. Otherwise, return
+// Returns the input shape of the ROOT slices if all the input shapes of ROOT
+// slices are the same and the slices are non-strided. Otherwise, returns
 // FailedPrecondition.
 StatusOr<Shape> GetConsistentInputShapeForRootSlices(
     const HloInstruction& fusion) {

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.h
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.h
@@ -184,6 +184,19 @@ class IrEmitterUnnested : public IrEmitter,
   ReductionCodegenInfo ComputeReductionCodegenInfo(
       const HloInstruction* unnested_hlo, const HloInstruction* first_reduce);
 
+  // Generates code for input-fusible slices.
+  //
+  // Prerequisite: `IsInputFusibleNonStridedSlices(*unnested_hlo)`. We require
+  // that the slices are non-strided. It serves well the main use case where the
+  // slices are generated from split. Note that, on the other hand, we do
+  // support overlapping slices. Further generalizing the implementation when
+  // the needs arise in the future.
+  Status EmitInputFusibleNonStridedSlices(HloInstruction* unnested_hlo);
+
+  void EmitElementForInputFusibleSlices(
+      HloInstruction* unnested_hlo,
+      const llvm_ir::IrArray::Index& slice_input_index);
+
   // Emits code for an in-place scatter, modifying `thunk`s launch dimensions in
   // the process. `scatter` may be fused, scatter indices are taken from
   // `scatter_indices_gen`, updates from`updates_gen`. The output buffer is

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.h
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.h
@@ -186,11 +186,11 @@ class IrEmitterUnnested : public IrEmitter,
 
   // Generates code for input-fusible slices.
   //
-  // Prerequisite: `IsInputFusibleNonStridedSlices(*unnested_hlo)`. We require
-  // that the slices are non-strided. It serves well the main use case where the
-  // slices are generated from split. Note that, on the other hand, we do
-  // support overlapping slices. Further generalizing the implementation when
-  // the needs arise in the future.
+  // Prerequisite: ROOT is either a slice or a tuple of slices. The input shapes
+  // of all ROOT slices need to be the same while their output shapes can be
+  // different. On the other hand, the input ranges of slices can be
+  // overlapping. Further generalization/specialization when the needs are seen
+  // in the future.
   Status EmitInputFusibleNonStridedSlices(HloInstruction* unnested_hlo);
 
   void EmitElementForInputFusibleSlices(

--- a/tensorflow/compiler/xla/service/gpu/tests/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/tests/BUILD
@@ -284,6 +284,21 @@ tf_cc_test(
     ],
 )
 
+tf_cc_test(
+    name = "gpu_input_fusible_slice_test",
+    srcs = ["gpu_input_fusible_slice_test.cc"],
+    tags = tf_cuda_tests_tags(),
+    deps = [
+        ":gpu_codegen_test",
+        "//tensorflow/compiler/xla/service:hlo",
+        "//tensorflow/compiler/xla/service:hlo_module_config",
+        "//tensorflow/compiler/xla/service:hlo_parser",
+        "//tensorflow/compiler/xla/tests:hlo_test_base",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
+    ],
+)
+
 xla_test(
     name = "gpu_convolution_regression_test",
     srcs = ["gpu_convolution_regression_test.cc"],

--- a/tensorflow/compiler/xla/service/gpu/tests/gpu_input_fusible_slice_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/gpu_input_fusible_slice_test.cc
@@ -29,12 +29,11 @@ class GpuSliceInputFusionTest : public GpuCodegenTest {
  protected:
   GpuSliceInputFusionTest() {}
 
-  // Disable the layout assignment pass as it would throw away the layouts
-  // in the fusion computation.
   HloModuleConfig ConfigWithoutLayoutAssignment() {
     HloModuleConfig config;
     auto debug_options = HloTestBase::GetDebugOptionsForTest();
-    // Disable layout_assignment to use the preassigned layouts.
+    // Disable the layout_assignment pass to use the preassigned layouts;
+    // otherwise, the pass throws away the layouts in the fusion computation.
     debug_options.add_xla_disable_hlo_passes("layout-assignment");
     config.set_debug_options(debug_options);
     return config;
@@ -67,7 +66,7 @@ TEST_F(GpuSliceInputFusionTest, InputFusionWithOnlyOneSlice) {
   CompileAndVerifyIr(std::move(hlo_module),
                      R"(
 ; CHECK-LABEL: define void @fusion
-; CHECK: slice_id0
+; CHECK: slice0
 ; CHECK: }
 )",
                      /*match_optimized_ir=*/false);
@@ -104,7 +103,7 @@ TEST_F(GpuSliceInputFusionTest, InputFusionWithATupleOfSlices) {
   CompileAndVerifyIr(std::move(hlo_module),
                      R"(
 ; CHECK-LABEL: define void @fusion
-; CHECK: slice_id2
+; CHECK: slice2
 ; CHECK: }
 )",
                      /*match_optimized_ir=*/false);
@@ -146,7 +145,7 @@ TEST_F(GpuSliceInputFusionTest, ConcatThenSplit) {
   CompileAndVerifyIr(std::move(hlo_module),
                      R"(
 ; CHECK-LABEL: define void @fusion
-; CHECK: slice_id2
+; CHECK: slice2
 ; CHECK: }
 )",
                      /*match_optimized_ir=*/false);

--- a/tensorflow/compiler/xla/service/gpu/tests/gpu_input_fusible_slice_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/gpu_input_fusible_slice_test.cc
@@ -1,0 +1,159 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <utility>
+
+#include "tensorflow/compiler/xla/service/gpu/tests/gpu_codegen_test.h"
+#include "tensorflow/compiler/xla/service/hlo_module_config.h"
+#include "tensorflow/compiler/xla/service/hlo_parser.h"
+#include "tensorflow/compiler/xla/tests/hlo_test_base.h"
+#include "tensorflow/core/platform/test.h"
+
+namespace xla {
+namespace gpu {
+namespace {
+
+class GpuSliceInputFusionTest : public GpuCodegenTest {
+ protected:
+  GpuSliceInputFusionTest() {}
+
+  // Disable the layout assignment pass as it would throw away the layouts
+  // in the fusion computation.
+  HloModuleConfig ConfigWithoutLayoutAssignment() {
+    HloModuleConfig config;
+    auto debug_options = HloTestBase::GetDebugOptionsForTest();
+    // Disable layout_assignment to use the preassigned layouts.
+    debug_options.add_xla_disable_hlo_passes("layout-assignment");
+    config.set_debug_options(debug_options);
+    return config;
+  }
+};
+
+TEST_F(GpuSliceInputFusionTest, InputFusionWithOnlyOneSlice) {
+  const char *const kHloString = R"(
+  HloModule input_fusion_with_only_one_slice
+
+  fused_computation {
+    arg.1 = f16[1024,512]{1,0} parameter(0)
+    arg.2 = f16[1024,512]{1,0} parameter(1)
+    arg1.conv = f32[1024,512]{1,0} convert(arg.1)
+    arg2.conv = f32[1024,512]{1,0} convert(arg.2)
+    add.1 = f32[1024,512]{1,0} add(arg1.conv, arg2.conv)
+    ROOT slice.1 = f32[512,511]{1,0} slice(add.1), slice={[512:1024], [1:512]}
+  }
+
+  ENTRY kernel_entry {
+    arg.1 = f16[1024,512]{1,0} parameter(0)
+    arg.2 = f16[1024,512]{1,0} parameter(1)
+    ROOT fusion = f32[512, 511]{1,0} fusion(arg.1, arg.2), kind=kInput,
+        calls=fused_computation
+  })";
+
+  auto hlo_module =
+      ParseAndReturnVerifiedModule(kHloString, ConfigWithoutLayoutAssignment())
+          .ValueOrDie();
+  CompileAndVerifyIr(std::move(hlo_module),
+                     R"(
+; CHECK-LABEL: define void @fusion
+; CHECK: slice_id0
+; CHECK: }
+)",
+                     /*match_optimized_ir=*/false);
+  // Check that the kernel runs correctly.
+  EXPECT_TRUE(RunAndCompareNoHloPasses(kHloString, ErrorSpec{0, 0}));
+}
+
+TEST_F(GpuSliceInputFusionTest, InputFusionWithATupleOfSlices) {
+  const char *const kHloString = R"(
+  HloModule input_fusion_with_a_tuple_of_slices
+
+  fused_computation {
+    arg.1 = f16[1024,512]{1,0} parameter(0)
+    arg.2 = f16[1024,512]{1,0} parameter(1)
+    mul.1 = f16[1024,512]{1,0} multiply(arg.1, arg.2)
+    add.1 = f16[1024,512]{1,0} add(mul.1, arg.2)
+    slice.1 = f16[512,511]{1,0} slice(arg.1), slice={[512:1024], [1:512]}
+    slice.2 = f16[0,512]{1,0} slice(add.1), slice={[512:512], [0:512]}
+    slice.3 = f16[1,1]{1,0} slice(add.1), slice={[512:513], [511:512]}
+    ROOT tuple.1 = (f16[512,511]{1,0}, f16[0,512]{1,0}, f16[1,1]{1,0})
+        tuple(slice.1, slice.2, slice.3)
+  }
+
+  ENTRY kernel_entry {
+    arg.1 = f16[1024,512]{1,0} parameter(0)
+    arg.2 = f16[1024,512]{1,0} parameter(1)
+    ROOT fusion = (f16[512,511]{1,0}, f16[0,512]{1,0}, f16[1,1]{1,0})
+        fusion(arg.1, arg.2), kind=kInput, calls=fused_computation
+  })";
+
+  auto hlo_module =
+      ParseAndReturnVerifiedModule(kHloString, ConfigWithoutLayoutAssignment())
+          .ValueOrDie();
+  CompileAndVerifyIr(std::move(hlo_module),
+                     R"(
+; CHECK-LABEL: define void @fusion
+; CHECK: slice_id2
+; CHECK: }
+)",
+                     /*match_optimized_ir=*/false);
+  // Check that the kernel runs correctly.
+  EXPECT_TRUE(RunAndCompareNoHloPasses(kHloString, ErrorSpec{0, 0}));
+}
+
+TEST_F(GpuSliceInputFusionTest, ConcatThenSplit) {
+  const char *const kHloString = R"(
+  HloModule input_fusion_with_a_tuple_of_slices
+
+  fused_computation {
+    arg.1 = f16[1024]{0} parameter(0)
+    arg.2 = f16[1024]{0} parameter(1)
+    arg.3 = f16[1023]{0} parameter(2)
+    arg.4 = f16[1023]{0} parameter(3)
+    mul.1 = f16[1024]{0} multiply(arg.1, arg.2)
+    add.1 = f16[1023]{0} add(arg.3, arg.4)
+    concat.1 = f16[2047]{0} concatenate(mul.1, add.1), dimensions={0}
+    slice.1 = f16[1024]{0} slice(concat.1), slice={[0:1024]}
+    slice.2 = f16[1023]{0} slice(concat.1), slice={[1024:2047]}
+    slice.3 = f16[0]{0} slice(concat.1), slice={[2047:2047]}
+    ROOT tuple.1 = (f16[1024]{0}, f16[1023]{0}, f16[0]{0})
+        tuple(slice.1, slice.2, slice.3)
+  }
+
+  ENTRY kernel_entry {
+    arg.1 = f16[1024]{0} parameter(0)
+    arg.2 = f16[1024]{0} parameter(1)
+    arg.3 = f16[1023]{0} parameter(2)
+    arg.4 = f16[1023]{0} parameter(3)
+    ROOT fusion = (f16[1024]{0}, f16[1023]{0}, f16[0]{0})
+        fusion(arg.1, arg.2, arg.3, arg.4), kind=kInput, calls=fused_computation
+  })";
+
+  auto hlo_module =
+      ParseAndReturnVerifiedModule(kHloString, ConfigWithoutLayoutAssignment())
+          .ValueOrDie();
+  CompileAndVerifyIr(std::move(hlo_module),
+                     R"(
+; CHECK-LABEL: define void @fusion
+; CHECK: slice_id2
+; CHECK: }
+)",
+                     /*match_optimized_ir=*/false);
+  // Check that the kernel runs correctly.
+  EXPECT_TRUE(RunAndCompareNoHloPasses(kHloString, ErrorSpec{0, 0}));
+}
+
+}  // namespace
+}  // namespace gpu
+}  // namespace xla


### PR DESCRIPTION
Implement code generation for input-fusible slices. It is useful to support split-like semantic. Before this change, slices can only be fused into their successors. This change enables the slices to be fused with their predecessors.