### PR TITLE
Sort layers by name to avoid conficts in h5 saving.

### DIFF
--- a/tensorflow/python/keras/saving/hdf5_format.py
+++ b/tensorflow/python/keras/saving/hdf5_format.py
@@ -621,7 +621,10 @@ def save_weights_to_hdf5_group(f, layers):
   f.attrs['backend'] = K.backend().encode('utf8')
   f.attrs['keras_version'] = str(keras_version).encode('utf8')
 
-  for layer in layers:
+
+  # Sort model layers by layer name to ensure that group names are strictly
+  # growing to avoid prefix issues.
+  for layer in sorted(layers, key=lambda x: x.name):
     g = f.create_group(layer.name)
     weights = _legacy_weights(layer)
     weight_values = K.batch_get_value(weights)


### PR DESCRIPTION
There is a bug while saving .h5 models. In a model, if a layer name is prefix of a previously defined layer name, then h5py will fail with error: "ValueError: Unable to create group (name already exists)".

This PR, like this one (https://github.com/keras-team/keras/pull/13477) in `keras`, solve this problem.