### PR TITLE
Micro: Add the missing TF_LITE_STATIC_MEMORY-macro to mbed_app.json.tpl.

### DIFF
--- a/tensorflow/lite/experimental/micro/tools/make/templates/mbed_app.json.tpl
+++ b/tensorflow/lite/experimental/micro/tools/make/templates/mbed_app.json.tpl
@@ -3,5 +3,6 @@
 	"main-stack-size": {
             "value": 65536
 	}
-    }
+    },
+    "macros": ["TF_LITE_STATIC_MEMORY"]
 }


### PR DESCRIPTION
Compiling Tensorflow Lite Micro with Arm Mbed OS fails due to a missing compile flag. This PR adds that compile flag to the mbed_app.json template file.