### PR TITLE
Add documentation for undocumented exception

### DIFF
--- a/tensorflow/python/autograph/impl/conversion.py
+++ b/tensorflow/python/autograph/impl/conversion.py
@@ -496,6 +496,7 @@ def convert_entity_to_ast(o, program_ctx):
             keyed by their symbol name.
 
   Raises:
+    NotImplementedError: if the object conversion is not yet supported.
     ValueError: if the entity type is not supported.
   """
   logging.log(1, 'Converting %s', o)

--- a/tensorflow/python/autograph/impl/conversion.py
+++ b/tensorflow/python/autograph/impl/conversion.py
@@ -497,7 +497,6 @@ def convert_entity_to_ast(o, program_ctx):
 
   Raises:
     NotImplementedError: if the object conversion is not yet supported.
-    ValueError: if the entity type is not supported.
   """
   logging.log(1, 'Converting %s', o)
 
@@ -514,7 +513,7 @@ def convert_entity_to_ast(o, program_ctx):
         'cannot convert entity "{}": object conversion is not yet'
         ' supported.'.format(o))
   else:
-    raise ValueError(
+    raise NotImplementedError(
         'Entity "%s" has unsupported type "%s". Only functions and classes are '
         'supported for now.' % (o, type(o)))
 

--- a/tensorflow/python/autograph/impl/conversion.py
+++ b/tensorflow/python/autograph/impl/conversion.py
@@ -496,7 +496,7 @@ def convert_entity_to_ast(o, program_ctx):
             keyed by their symbol name.
 
   Raises:
-    NotImplementedError: if the object conversion is not yet supported.
+    NotImplementedError: if entity is of a type that is not yet supported.
   """
   logging.log(1, 'Converting %s', o)
 


### PR DESCRIPTION
The undocumented exception was:
NotImplementedError

The exception is raised when conversion in
the function ´convert_entity_to_ast´ is not supported