### PR TITLE
Docs: Update Readme.md to reflect pip package changes with TF 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,23 +37,21 @@ See the [TensorFlow install guide](https://www.tensorflow.org/install) for the
 [Docker container](https://www.tensorflow.org/install/docker), and
 [build from source](https://www.tensorflow.org/install/source).
 
-To install the current release for CPU-only:
+To install the current release, which includes support for [CUDA-enabled GPU cards](https://www.tensorflow.org/install/gpu) *(Ubuntu and Windows)*:
 
 ```
 $ pip install tensorflow
 ```
 
-Use the GPU package for
-[CUDA-enabled GPU cards](https://www.tensorflow.org/install/gpu) *(Ubuntu and
-Windows)*:
+A smaller CPU-only package is also available:
 
 ```
-$ pip install tensorflow-gpu
+$ pip install tensorflow-cpu
 ```
 
 *Nightly binaries are available for testing using the
 [tf-nightly](https://pypi.python.org/pypi/tf-nightly) and
-[tf-nightly-gpu](https://pypi.python.org/pypi/tf-nightly-gpu) packages on PyPi.*
+[tf-nightly-cpu](https://pypi.python.org/pypi/tf-nightly-cpu) packages on PyPi.*
 
 #### *Try your first TensorFlow program*
 


### PR DESCRIPTION
As requested in https://github.com/tensorflow/tensorflow/pull/34967#issuecomment-563348994.

Describes that the main TF package now contains CUDA GPU support, and that a smaller CPU-only package can be used.

Based on the changes announced in https://github.com/tensorflow/tensorflow/releases/tag/v2.1.0-rc0