### PR TITLE
Ensure sorted=true in top_k converter

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -5084,6 +5084,10 @@ Status ConvertTopK(OpConverterParams* params) {
   TFAttrs attrs(node_def);
   const bool sorted = attrs.get<bool>("sorted");
   if (!sorted) {
+    // TensorRT only supports sorted output. Although TensorFlow API 
+    // doesn't specify the order of output elements in case sorted=false,
+    // but it's safer to not convert because the output of TensorRT might
+    // be different with TensorFlow which can cause confusion.
     return errors::InvalidArgument("Only sorted=True is supported, at",
                                    node_def.name());
   }

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -5081,6 +5081,13 @@ Status ConvertTopK(OpConverterParams* params) {
       CheckInputsWeights(*params, {{"input", false}, {"k", true}}));
   TF_RETURN_IF_ERROR(
       AllowDataTypes(*params, {DataType::DT_FLOAT, DataType::DT_HALF}));
+  TFAttrs attrs(node_def);
+  const bool sorted = attrs.get<bool>("sorted");
+  if (!sorted) {
+    return errors::InvalidArgument("Only sorted=True is supported, at",
+                                   node_def.name());
+  }
+
   nvinfer1::ITensor* tensor = inputs.at(0).tensor();
   const int num_dims = tensor->getDimensions().nbDims;
   if (num_dims == 0) {


### PR DESCRIPTION
This PR adds a check for a `TopK` argument that is not supported by TensorRT.