### PR TITLE
[r2.1 Cherrypick]: Support DistributionStrategy in LossScaleGradientTape, take 2.

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -3551,24 +3551,26 @@ py_library(
         ":loss_scale",
         ":unconnected_gradients",
         ":util",
+        "//tensorflow/python/distribute:distribute_lib",
         "//tensorflow/python/eager:backprop",
     ],
 )
 
-py_test(
+cuda_py_test(
     name = "loss_scaling_gradient_tape_test",
     size = "medium",
     srcs = ["training/experimental/loss_scaling_gradient_tape_test.py"],
-    python_version = "PY3",
-    deps = [
+    additional_deps = [
         ":client_testlib",
         ":constant_op",
+        ":framework_test_combinations_lib",
         ":loss_scale",
         ":loss_scaling_gradient_tape",
-        "//tensorflow/python/compat:v2_compat",
-        "//tensorflow/python/eager:def_function",
-        "//third_party/py/numpy",
         "@absl_py//absl/testing:parameterized",
+        "//third_party/py/numpy",
+        "//tensorflow/python/compat:v2_compat",
+        "//tensorflow/python/distribute:mirrored_strategy",
+        "//tensorflow/python/eager:def_function",
     ],
 )
 

--- a/tensorflow/python/training/experimental/loss_scaling_gradient_tape.py
+++ b/tensorflow/python/training/experimental/loss_scaling_gradient_tape.py
@@ -18,8 +18,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from tensorflow.python.distribute import distribution_strategy_context
 from tensorflow.python.eager import backprop
-from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import control_flow_ops
+from tensorflow.python.ops import math_ops
 from tensorflow.python.ops.unconnected_gradients import UnconnectedGradients
 from tensorflow.python.training.experimental import loss_scale as loss_scale_module
 from tensorflow.python.util import nest
@@ -60,6 +62,13 @@ class LossScaleGradientTape(backprop.GradientTape):
     grads = tape.gradient(loss, vars)
     opt.apply_gradients(zip(grads, vars))
   ```
+
+  WARNING: Computing second-order (or higher) gradients with a
+  `LossScaleGradientTape` does not yet work properly when a
+  `tf.distribute.Strategy` is used. Computing second-order gradients will return
+  None instead of the gradient tensors. This only occurs when you nest multiple
+  gradient tapes under each other; if you do not nest them, this issue will not
+  occur.
   """
 
   def __init__(self,
@@ -133,22 +142,90 @@ class LossScaleGradientTape(backprop.GradientTape):
     if self._tape is None:  # pylint: disable=access-member-before-definition
       raise RuntimeError("GradientTape.gradient can only be called once on "
                          "non-persistent tapes.")
+    if distribution_strategy_context.in_cross_replica_context():
+      raise ValueError("LossScaleGradientTape.gradient() must be called in a "
+                       "replica context.")
 
-    ready_to_update = False
-    grads = nest.map_structure(array_ops.zeros_like, sources)
-
-    while not ready_to_update and self._loss_scale() > 1:
-      with self:  # re-enter the gradient tape so it sees the loss scaling
-        loss_scale = self._loss_scale()
-        scaled_target = nest.map_structure(lambda t: t * loss_scale, target)
-
-      old_grads = super(LossScaleGradientTape, self).gradient(
-          scaled_target, sources, output_gradients, unconnected_gradients)
-      inv_loss_scale = 1.0 / self._loss_scale()
-      grads = nest.map_structure(lambda g: inv_loss_scale * g, old_grads)
-      # Check for non-finite gradients possibly resulting from scaling
-      _, ready_to_update = self._loss_scale.update(grads)
+    # Note: DistributionStrategy does not support running a while loop in a
+    # replica context. So, we call `_compute_gradients_until_finite` in a cross-
+    # replica context.
+    replica_context = distribution_strategy_context.get_replica_context()
+    grads = replica_context.merge_call(
+        _compute_gradients_until_finite,
+        args=(self, self._loss_scale, target, sources, output_gradients,
+              unconnected_gradients))
 
     if not self._outer_persistent:
       self._tape = None  # free up resources if a persistent tape was not needed
     return grads
+
+
+def _compute_gradients_until_finite(
+    distribution, loss_scale_gradient_tapes, loss_scale, target, sources,
+    output_gradients, unconnected_gradients):
+  """Compute gradients and update the loss scale until the gradients are finite.
+
+  This must be called in a cross-replica context.
+
+  This is a function instead of a method of LossScaleGradientTape, as the `self`
+  parameter would be meaningless. There is one LossScaleGradientTape per
+  replica, but this function is called once total (not per replica), so there
+  cannot be a singular `self` parameter.
+
+  Args:
+    distribution: The distribution strategy in effect.
+    loss_scale_gradient_tapes: A PerReplica value of LossScaleGradientTapes.
+      Contains the LossScaleGradientTape of each replica.
+    loss_scale: The loss scale to use to scale the loss and unscale the
+      gradient.
+    target: a list or nested structure of Tensors or Variables to be
+      differentiated.
+    sources: a list or nested structure of Tensors or Variables. `target` will
+      be differentiated against elements in `sources`.
+    output_gradients: Passed to GradientTape.gradient
+    unconnected_gradients: Pass to GradientTape.gradient.
+
+  Returns:
+    The gradients of `target` with respect to `sources`.
+  """
+  # Autograph cannot convert this function, so we must use an explicit
+  # tf.while_loop.
+  # TODO(b/143572314): Fix Autograph so that it can convert this function, then
+  # replace the tf.while_loop with a Python while loop.
+
+  def cond(grads, ready_to_update):
+    """The condition of the while loop."""
+    del grads
+    # Equivalent to: `not ready_to_update and loss_scale() > 1`
+    return math_ops.logical_and(math_ops.logical_not(ready_to_update),
+                                math_ops.greater(loss_scale(), 1))
+
+  def body(grads, ready_to_update):
+    """The body of the while loop."""
+    del grads, ready_to_update
+    def replica_fn(gradient_tape, target, sources, output_gradients):
+      """Scales the loss, computes the gradients, and unscales the gradients."""
+      loss_scale_val = loss_scale()
+      with gradient_tape:  # re-enter gradient tape so it sees the loss scaling
+        scaled_target = nest.map_structure(lambda t: t * loss_scale_val, target)
+      old_grads = super(LossScaleGradientTape, gradient_tape).gradient(
+          scaled_target, sources, output_gradients, unconnected_gradients)
+      inv_loss_scale = 1.0 / loss_scale_val
+      grads = nest.map_structure(lambda g: inv_loss_scale * g, old_grads)
+      return grads
+
+    # Switch to a replica-context to compute gradients once per replica.
+    grads = distribution.experimental_run_v2(
+        replica_fn, args=(loss_scale_gradient_tapes, target, sources,
+                          output_gradients))
+    # Check for non-finite gradients possibly resulting from scaling
+    _, ready_to_update = loss_scale.update(grads)
+    return grads, ready_to_update
+
+  # Dummy value for initial_grads. The first iteration of the loop will
+  # overwrite `grads` to the actual gradients.
+  initial_grads = sources
+  initial_ready_to_update = False
+  grads, _ = control_flow_ops.while_loop(
+      cond, body, [initial_grads, initial_ready_to_update])
+  return grads

--- a/tensorflow/python/training/experimental/loss_scaling_gradient_tape_test.py
+++ b/tensorflow/python/training/experimental/loss_scaling_gradient_tape_test.py
@@ -20,58 +20,137 @@ from __future__ import print_function
 from absl.testing import parameterized
 import numpy as np
 from tensorflow.python.compat import v2_compat
+from tensorflow.python.distribute import distribution_strategy_context
+from tensorflow.python.distribute import mirrored_strategy
+from tensorflow.python.distribute import values
+from tensorflow.python.eager import context
 from tensorflow.python.eager import def_function
 from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import test_combinations
 from tensorflow.python.platform import test
 from tensorflow.python.training.experimental import loss_scale as loss_scale_module
 from tensorflow.python.training.experimental import loss_scaling_gradient_tape as lsgt
+from tensorflow.python.util import nest
+
+
+# If called outside any strategy.scope() calls, this will return the default
+# strategy.
+default_strategy_fn = distribution_strategy_context.get_strategy
+
+
+def create_mirrored_strategy():
+  if context.num_gpus() >= 1:
+    return mirrored_strategy.MirroredStrategy(['cpu:0', 'gpu:0'])
+  else:
+    return mirrored_strategy.MirroredStrategy(['cpu:0'])
 
 
 class LossScaleGradientTapeTest(test.TestCase, parameterized.TestCase):
 
-  @parameterized.parameters(loss_scale_module.FixedLossScale,
-                            loss_scale_module.DynamicLossScale)
-  def test_basic_tapes_eager_mode(self, loss_scale):
-    x = constant_op.constant(3.0)
-    with lsgt.LossScaleGradientTape(loss_scale(32)) as g:
-      g.watch(x)
-      y = x * x
-    dy_dx = g.gradient(y, x)
-    self.assertEqual(self.evaluate(dy_dx), 6.0)
+  def _run_with_strategy(self, run_fn, strategy, use_tf_function=False):
+    """Runs `run_fn` under the DistributionStrategy `strategy`.
 
-  @parameterized.parameters(loss_scale_module.FixedLossScale,
-                            loss_scale_module.DynamicLossScale)
-  def test_basic_tapes_graph_mode(self, loss_scale):
+    Runs `run_fn` with `strategy.experimental_run_v2`. Returns a list of the
+    return values of `run_fn`, one per replica.
+
+    Args:
+      run_fn: The function to run.
+      strategy: The DistributionStrategy to run `run_fn` with.
+      use_tf_function: If True, call `run_fn` under a tf.function.
+
+    Returns:
+      A list of tensors, each being the return value of `run_fn` from one
+      replica. If a nested structure is returned from `run_fn`, returns a
+      nested structure, where each element is a list of tensors.
+    """
+    strategy_fn = lambda: strategy.experimental_run_v2(run_fn)
+    if use_tf_function:
+      strategy_fn = def_function.function(strategy_fn)
+
+    results = strategy_fn()
+
+    def convert_tensor_to_list(tensor):
+      if isinstance(tensor, values.DistributedValues):
+        return tensor.values
+      else:
+        return [tensor]
+    return nest.map_structure(convert_tensor_to_list, results)
+
+  @test_combinations.generate(test_combinations.combine(
+      loss_scale=[loss_scale_module.FixedLossScale,
+                  loss_scale_module.DynamicLossScale],
+      strategy_fn=[default_strategy_fn, create_mirrored_strategy],
+      use_tf_function=[True, False]
+  ))
+  def test_basic_tapes(self, loss_scale, strategy_fn, use_tf_function):
     loss_scale = loss_scale(32)
-
-    @def_function.function
-    def _inner_test():
+    def run_fn():
       x = constant_op.constant(3.0)
       with lsgt.LossScaleGradientTape(loss_scale) as g:
         g.watch(x)
         y = x * x
       return g.gradient(y, x)
-    self.assertEqual(self.evaluate(_inner_test()), 6.0)
+    dy_dx_list = self._run_with_strategy(run_fn, strategy_fn(), use_tf_function)
+    self.assertEqual(loss_scale(), 32)
+    for dy_dx in dy_dx_list:
+      self.assertEqual(dy_dx, 6.0)
 
-  @parameterized.parameters(loss_scale_module.FixedLossScale,
-                            loss_scale_module.DynamicLossScale)
-  def test_nested_tapes(self, loss_scale):
-    x = constant_op.constant(3.0)
-    with lsgt.LossScaleGradientTape(loss_scale(32)) as g:
-      g.watch(x)
-      with lsgt.LossScaleGradientTape(loss_scale(32)) as gg:
-        gg.watch(x)
+  @test_combinations.generate(test_combinations.combine(
+      loss_scale=[loss_scale_module.FixedLossScale,
+                  loss_scale_module.DynamicLossScale],
+      strategy_fn=[default_strategy_fn, create_mirrored_strategy],
+      use_tf_function=[True, False]
+  ))
+  def test_output_gradients(self, loss_scale, strategy_fn, use_tf_function):
+    loss_scale = loss_scale(32)
+    def run_fn():
+      x = constant_op.constant(3.0)
+      with lsgt.LossScaleGradientTape(loss_scale) as g:
+        g.watch(x)
         y = x * x
-      dy_dx = gg.gradient(y, x)
-      self.assertEqual(self.evaluate(dy_dx), 6.0)
-    d2y_dx2 = g.gradient(dy_dx, x)
-    self.assertEqual(self.evaluate(d2y_dx2), 2.0)
+      return g.gradient(y, x, output_gradients=constant_op.constant(2.0))
+    dy_dx_list = self._run_with_strategy(run_fn, strategy_fn(), use_tf_function)
+    self.assertEqual(loss_scale(), 32)
+    for dy_dx in dy_dx_list:
+      self.assertEqual(dy_dx, 12.0)
 
-  @parameterized.parameters(loss_scale_module.FixedLossScale,
-                            loss_scale_module.DynamicLossScale)
-  def test_non_persistent_tapes_error(self, loss_scale):
+  @test_combinations.generate(test_combinations.combine(
+      loss_scale=[loss_scale_module.FixedLossScale,
+                  loss_scale_module.DynamicLossScale],
+      strategy_fn=[default_strategy_fn],
+      use_tf_function=[True, False]
+  ))
+  def test_nested_tapes(self, loss_scale, strategy_fn, use_tf_function):
+    # TODO(reedwm): Support nested tapes with mirrored strategy. Currently this
+    # does not work, as the set of active gradient tapes is a thread-local
+    # variable. Mirrored strategy spawns new threads, making the outer gradient
+    # tape non-active when using the inner gradient tape.
+    outer_loss_scale = loss_scale(32)
+    inner_loss_scale = loss_scale(32)
+    def run_fn():
+      x = constant_op.constant(3.0)
+      with lsgt.LossScaleGradientTape(outer_loss_scale) as g:
+        g.watch(x)
+        with lsgt.LossScaleGradientTape(inner_loss_scale) as gg:
+          gg.watch(x)
+          y = x * x
+        dy_dx = gg.gradient(y, x)
+      d2y_dx2 = g.gradient(dy_dx, x)
+      return dy_dx, d2y_dx2
+
+    dy_dx_list, d2y_dx2_list = self._run_with_strategy(run_fn, strategy_fn(),
+                                                       use_tf_function)
+    self.assertEqual(outer_loss_scale(), 32)
+    self.assertEqual(inner_loss_scale(), 32)
+    for dy_dx in dy_dx_list:
+      self.assertEqual(dy_dx, 6.0)
+    for d2y_dx2 in d2y_dx2_list:
+      self.assertEqual(d2y_dx2, 2.0)
+
+  def test_non_persistent_tapes_error(self):
     x = constant_op.constant(3.0)
-    with lsgt.LossScaleGradientTape(loss_scale(32), persistent=False) as g:
+    with lsgt.LossScaleGradientTape(loss_scale_module.FixedLossScale(32),
+                                    persistent=False) as g:
       g.watch(x)
       y = x * x
       z = y * y
@@ -79,21 +158,36 @@ class LossScaleGradientTapeTest(test.TestCase, parameterized.TestCase):
     with self.assertRaisesRegexp(RuntimeError, 'persistent'):
       g.gradient(y, x)
 
-  @parameterized.parameters(loss_scale_module.FixedLossScale,
-                            loss_scale_module.DynamicLossScale)
-  def test_persistent_tapes(self, loss_scale):
-    x = constant_op.constant(3.0)
-    with lsgt.LossScaleGradientTape(loss_scale(32), persistent=True) as g:
-      g.watch(x)
-      y = x * x
-      z = y * y
-    dz_dx = g.gradient(z, x)
-    self.assertEqual(self.evaluate(dz_dx), 108.0)
-    dy_dx = g.gradient(y, x)
-    self.assertEqual(self.evaluate(dy_dx), 6.0)
+  @test_combinations.generate(test_combinations.combine(
+      loss_scale=[loss_scale_module.FixedLossScale,
+                  loss_scale_module.DynamicLossScale],
+      strategy_fn=[default_strategy_fn, create_mirrored_strategy],
+      use_tf_function=[True, False]
+  ))
+  def test_persistent_tapes(self, loss_scale, strategy_fn, use_tf_function):
 
-  @parameterized.parameters(loss_scale_module.FixedLossScale,
-                            loss_scale_module.DynamicLossScale)
+    ls = loss_scale(32)
+    def run_fn():
+      x = constant_op.constant(3.0)
+      with lsgt.LossScaleGradientTape(ls, persistent=True) as g:
+        g.watch(x)
+        y = x * x
+        z = y * y
+      dz_dx = g.gradient(z, x)
+      dy_dx = g.gradient(y, x)
+      return dz_dx, dy_dx
+
+    dz_dx_list, dy_dx_list = self._run_with_strategy(run_fn, strategy_fn(),
+                                                     use_tf_function)
+    for dz_dx in dz_dx_list:
+      self.assertEqual(dz_dx, 108.0)
+    for dy_dx in dy_dx_list:
+      self.assertEqual(dy_dx, 6.0)
+
+  @test_combinations.generate(test_combinations.combine(
+      loss_scale=[loss_scale_module.FixedLossScale,
+                  loss_scale_module.DynamicLossScale],
+  ))
   def test_nested_sources(self, loss_scale):
     x = (constant_op.constant(19.0), (constant_op.constant(8.),
                                       constant_op.constant(9.)))
@@ -103,8 +197,10 @@ class LossScaleGradientTapeTest(test.TestCase, parameterized.TestCase):
     dy_dx = g.gradient(y, x)
     self.assertEqual(self.evaluate(dy_dx), (13., (13., 13.)))
 
-  @parameterized.parameters(loss_scale_module.FixedLossScale,
-                            loss_scale_module.DynamicLossScale)
+  @test_combinations.generate(test_combinations.combine(
+      loss_scale=[loss_scale_module.FixedLossScale,
+                  loss_scale_module.DynamicLossScale],
+  ))
   def test_nested_targets(self, loss_scale):
     w = constant_op.constant(3.0)
     with lsgt.LossScaleGradientTape(loss_scale(32)) as g:
@@ -115,67 +211,130 @@ class LossScaleGradientTapeTest(test.TestCase, parameterized.TestCase):
     grad = g.gradient([x, (y, z)], w)
     self.assertEqual(self.evaluate(grad), 23)
 
-  @parameterized.parameters(loss_scale_module.FixedLossScale,
-                            loss_scale_module.DynamicLossScale)
-  def test_scaling_inf_gradient(self, loss_scale):
-    x = constant_op.constant(1.0)
-    with lsgt.LossScaleGradientTape(loss_scale(32)) as g:
-      g.watch(x)
-      y = x * np.inf
-    dy_dx = g.gradient(y, x)
-    self.assertEqual(self.evaluate(dy_dx), np.inf)
+  @test_combinations.generate(test_combinations.combine(
+      loss_scale=[loss_scale_module.FixedLossScale,
+                  loss_scale_module.DynamicLossScale],
+      strategy_fn=[default_strategy_fn, create_mirrored_strategy],
+      non_finite_term=[np.inf, np.nan],
+  ))
+  def test_scaling_non_finite_gradient(self, loss_scale, strategy_fn,
+                                       non_finite_term):
+    loss_scale = loss_scale(32)
+    def run_fn():
+      x = constant_op.constant(1.0)
+      with lsgt.LossScaleGradientTape(loss_scale) as g:
+        g.watch(x)
+        y = x * non_finite_term
+      return g.gradient(y, x)
 
-  @parameterized.parameters(loss_scale_module.FixedLossScale,
-                            loss_scale_module.DynamicLossScale)
-  def test_scaling_nan_gradient(self, loss_scale):
-    x = constant_op.constant(1.0)
-    with lsgt.LossScaleGradientTape(loss_scale(32)) as g:
-      g.watch(x)
-      y = x * np.nan
-    dy_dx = g.gradient(y, x)
-    self.assertTrue(np.isnan(self.evaluate(dy_dx)))
+    dy_dx_list = self._run_with_strategy(run_fn, strategy_fn())
+    check_fn = np.isposinf if non_finite_term == np.inf else np.isnan
+    for dy_dx in dy_dx_list:
+      self.assertTrue(check_fn(dy_dx))
 
-  @parameterized.parameters(np.inf, np.nan)
-  def test_dynamic_scale_to_one_on_non_finite_gradient(self, non_finite_term):
+  @test_combinations.generate(test_combinations.combine(
+      strategy_fn=[default_strategy_fn, create_mirrored_strategy],
+      non_finite_term=[np.inf, np.nan],
+      use_tf_function=[True, False],
+  ))
+  def test_dynamic_scale_to_one_on_non_finite_gradient(
+      self, strategy_fn, non_finite_term, use_tf_function):
     loss_scale = loss_scale_module.DynamicLossScale(initial_loss_scale=32)
-    x = constant_op.constant(1.0)
-    with lsgt.LossScaleGradientTape(loss_scale) as g:
-      g.watch(x)
-      y = x * non_finite_term
-    g.gradient(y, x)
+    def run_fn():
+      x = constant_op.constant(1.0)
+      with lsgt.LossScaleGradientTape(loss_scale) as g:
+        g.watch(x)
+        y = x * non_finite_term
+      g.gradient(y, x)
+
+    self._run_with_strategy(run_fn, strategy_fn(), use_tf_function)
     self.assertEqual(self.evaluate(loss_scale()), 1.0)
 
-  @parameterized.parameters([np.inf, np.isposinf], [np.nan, np.isnan])
-  def test_fixed_scaling_no_change_non_finite_gradient(self, non_finite_term,
-                                                       is_non_finite):
-    loss_scale = loss_scale_module.FixedLossScale(32)
-    x = constant_op.constant(1.0)
-    with lsgt.LossScaleGradientTape(loss_scale) as g:
-      g.watch(x)
-      y = x * non_finite_term
-    dy_dx = g.gradient(y, x)
-    self.assertTrue(is_non_finite(self.evaluate(dy_dx)))
-    self.assertEqual(self.evaluate(loss_scale()), 32.0)
-
-  def test_dynamic_loss_scaling_down_loop(self):
+  @test_combinations.generate(test_combinations.combine(
+      use_tf_function=[True, False],
+  ))
+  def test_dynamic_scale_to_one_on_non_finite_gradient_on_last_replica(
+      self, use_tf_function):
+    if context.num_gpus() < 1:
+      # Requires the mirrored strategy to have two replicas: one on the CPU and
+      # one on the GPU
+      self.skipTest('Test requires at least 1 GPU')
     loss_scale = loss_scale_module.DynamicLossScale(initial_loss_scale=32)
-    x = constant_op.constant(1.0)
-    with lsgt.LossScaleGradientTape(loss_scale) as g:
-      g.watch(x)
-      y = x * (3.0 * (10**37))  # grad will be inf after scaling
-    dy_dx = g.gradient(y, x)
-    self.assertEqual(self.evaluate(loss_scale()), 8.0)
-    self.assertAllClose(self.evaluate(dy_dx), (3.0 * (10**37)), atol=1e-06)
+    def run_fn():
+      x = constant_op.constant(1.0)
+      with lsgt.LossScaleGradientTape(loss_scale) as g:
+        g.watch(x)
+        # The gradient will be finite on the first replica, and infinite on the
+        # second
+        rep_ctx = distribution_strategy_context.get_replica_context()
+        if rep_ctx.replica_id_in_sync_group == rep_ctx.num_replicas_in_sync - 1:
+          y = x * np.inf
+        else:
+          y = x * 2
+      return g.gradient(y, x)
 
-  def test_dynamic_loss_scaling_inf_target_post_scale(self):
-    loss_scale = loss_scale_module.DynamicLossScale(initial_loss_scale=32.0)
-    x = constant_op.constant(3.0 * (10**37))
-    with lsgt.LossScaleGradientTape(loss_scale) as g:
-      g.watch(x)
-      y = x * 3.0  # target will be inf after scaling
-    dy_dx = g.gradient(y, x)
-    self.assertAllClose(self.evaluate(dy_dx), 3.0)
+    replica0_grad, replica1_grad = self._run_with_strategy(
+        run_fn, create_mirrored_strategy(), use_tf_function)
+    self.assertEqual(self.evaluate(loss_scale()), 1.0)
+    self.assertEqual(replica0_grad, 2.0)
+    self.assertEqual(replica1_grad, np.inf)
+
+  @test_combinations.generate(test_combinations.combine(
+      strategy_fn=[default_strategy_fn, create_mirrored_strategy],
+      non_finite_term=[np.inf, np.nan],
+  ))
+  def test_fixed_scaling_no_change_non_finite_gradient(self, strategy_fn,
+                                                       non_finite_term):
+    loss_scale = loss_scale_module.FixedLossScale(32)
+    def run_fn():
+      x = constant_op.constant(1.0)
+      with lsgt.LossScaleGradientTape(loss_scale) as g:
+        g.watch(x)
+        y = x * non_finite_term
+      return g.gradient(y, x)
+
+    dy_dx_list = self._run_with_strategy(run_fn, strategy_fn())
+    check_fn = np.isposinf if non_finite_term == np.inf else np.isnan
+    for dy_dx in dy_dx_list:
+      self.assertTrue(check_fn(self.evaluate(dy_dx)))
     self.assertEqual(self.evaluate(loss_scale()), 32.0)
+
+  @test_combinations.generate(test_combinations.combine(
+      strategy_fn=[default_strategy_fn, create_mirrored_strategy],
+      use_tf_function=[True, False]
+  ))
+  def test_dynamic_loss_scaling_down_loop(self, strategy_fn, use_tf_function):
+    loss_scale = loss_scale_module.DynamicLossScale(initial_loss_scale=32)
+    def run_fn():
+      x = constant_op.constant(1.0)
+      with lsgt.LossScaleGradientTape(loss_scale) as g:
+        g.watch(x)
+        y = x * (3.0 * (10**37))  # grad will be inf after scaling
+      return g.gradient(y, x)
+
+    dy_dx_list = self._run_with_strategy(run_fn, strategy_fn(), use_tf_function)
+    self.assertEqual(self.evaluate(loss_scale()), 8.0)
+    for dy_dx in dy_dx_list:
+      self.assertAllClose(self.evaluate(dy_dx), (3.0 * (10**37)), atol=1e-06)
+
+  @test_combinations.generate(test_combinations.combine(
+      strategy_fn=[default_strategy_fn, create_mirrored_strategy],
+      use_tf_function=[True, False]
+  ))
+  def test_dynamic_loss_scaling_inf_target_post_scale(self, strategy_fn,
+                                                      use_tf_function):
+    loss_scale = loss_scale_module.DynamicLossScale(initial_loss_scale=32.0)
+    def run_fn():
+      x = constant_op.constant(3.0 * (10**37))
+      with lsgt.LossScaleGradientTape(loss_scale) as g:
+        g.watch(x)
+        y = x * 3.0  # target will be inf after scaling
+      return g.gradient(y, x)
+
+    dy_dx_list = self._run_with_strategy(run_fn, strategy_fn(), use_tf_function)
+    self.assertEqual(self.evaluate(loss_scale()), 32.0)
+    for dy_dx in dy_dx_list:
+      self.assertAllClose(self.evaluate(dy_dx), 3.0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Without this cherrypick, LossScaleGradientTape crashes with a cryptic error when DistributionStrategy is used.

PiperOrigin-RevId: 284116353
Change-Id: Ia5ef17ae8ddf36af3244c157ebc0ecbd807eccb0