### PR TITLE
Disable tests tagged 'v1only' on v2 builds

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1179,10 +1179,17 @@ def system_specific_test_config(env):
       write_to_bazelrc('test --test_env=LD_LIBRARY_PATH')
     else:
       test_and_build_filters.append('-gpu')
-  write_to_bazelrc('test --test_tag_filters=%s' %
+
+  # Disable tests with "v1only" tag in "v2" Bazel config, but not in "v1" config
+  write_to_bazelrc('test:v1 --test_tag_filters=%s' %
                    ','.join(test_and_build_filters + test_only_filters))
-  write_to_bazelrc('test --build_tag_filters=%s' %
+  write_to_bazelrc('test:v1 --build_tag_filters=%s' %
                    ','.join(test_and_build_filters))
+  write_to_bazelrc('test:v2 --test_tag_filters=%s' %
+                   ','.join(test_and_build_filters + test_only_filters
+                            + ["-v1only"]))
+  write_to_bazelrc('test:v2 --build_tag_filters=%s' %
+                   ','.join(test_and_build_filters + ["-v1only"]))
 
 
 def set_system_libs_flag(environ_cp):


### PR DESCRIPTION
If one runs regression tests for the TensorFlow V2 APIs via:
```
bazel test --config=v2 //tensorflow/...
```
the build will run several tests that are only supposed to work with the V1 APIs. These tests are tagged `v1only`, but the default build configuration does not disable them when the `v2` build config is activated.

This pull modifies the Bazel configuration so that test targets that have the tag `v1only` are not run by default when the `v2` build configuration is active.