### PR TITLE
Set TRT network name to builder configs

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -335,7 +335,6 @@ tf_cuda_library(
         ":trt_logging",
         ":trt_resources",
         ":utils",
-        ":py_utils",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "//tensorflow/core/grappler/clusters:cluster",

--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -335,6 +335,7 @@ tf_cuda_library(
         ":trt_logging",
         ":trt_resources",
         ":utils",
+        ":py_utils",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "//tensorflow/core/grappler/clusters:cluster",

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -1374,13 +1374,13 @@ Status Converter::BuildCudaEngine(
   TF_RETURN_IF_ERROR(TrtPrecisionModeToName(
       precision_mode_, &precision_mode_str));
   string trt_version_str = GetLoadedTensorRTVersion();
-  string trt_network_name =
-      "TF" + string(TF_VERSION_STRING) + "-" +
-      "TRT" + trt_version_str + "-" +
-      "Precision-" + precision_mode_str + "-" +
-      "Calibration-" + std::to_string(use_calibration_) + "-" +
-      "Max-Batch-Size-" + std::to_string(max_batch_size) + "-" +
-      "Max-Workspace-Size-" + std::to_string(max_workspace_size_bytes);
+  string trt_network_name = StrCat(
+      "TF:", string(TF_VERSION_STRING), ", ",
+      "TRT:", trt_version_str, "-",
+      "Precision:", precision_mode_str, ", ",
+      "Calibration:", std::to_string(use_calibration_), ", ",
+      "Max-Batch-Size:", std::to_string(max_batch_size), ", ",
+      "Max-Workspace-Size:", std::to_string(max_workspace_size_bytes));
   VLOG(1) << "Setting TensorRT network name to " << trt_network_name;
   network()->setName(trt_network_name.c_str());
 

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -1370,6 +1370,7 @@ Status Converter::BuildCudaEngine(
     }
   }
 
+#if IS_TRT_VERSION_GE(6, 0, 0, 0)
   string precision_mode_str;
   TF_RETURN_IF_ERROR(TrtPrecisionModeToName(
       precision_mode_, &precision_mode_str));
@@ -1382,6 +1383,7 @@ Status Converter::BuildCudaEngine(
       "Max-Workspace-Size:", max_workspace_size_bytes);
   VLOG(1) << "Setting TensorRT network name to " << trt_network_name;
   network()->setName(trt_network_name.c_str());
+#endif  // #if IS_TRT_VERSION_GE(6, 0, 0, 0)
 
   VLOG(1) << "Building TensorRT engine";
   engine->reset(trt_builder_->buildCudaEngine(*network()));

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -1373,14 +1373,13 @@ Status Converter::BuildCudaEngine(
   string precision_mode_str;
   TF_RETURN_IF_ERROR(TrtPrecisionModeToName(
       precision_mode_, &precision_mode_str));
-  string trt_version_str = GetLoadedTensorRTVersion();
   string trt_network_name = StrCat(
-      "TF:", string(TF_VERSION_STRING), ", ",
-      "TRT:", trt_version_str, "-",
+      "TF:", TF_VERSION_STRING, ", ",
+      "TRT:", GetLoadedTensorRTVersion(), "-",
       "Precision:", precision_mode_str, ", ",
-      "Calibration:", std::to_string(use_calibration_), ", ",
-      "Max-Batch-Size:", std::to_string(max_batch_size), ", ",
-      "Max-Workspace-Size:", std::to_string(max_workspace_size_bytes));
+      "Calibration:", use_calibration_, ", ",
+      "Max-Batch-Size:", max_batch_size, ", ",
+      "Max-Workspace-Size:", max_workspace_size_bytes);
   VLOG(1) << "Setting TensorRT network name to " << trt_network_name;
   network()->setName(trt_network_name.c_str());
 

--- a/tensorflow/compiler/tf2tensorrt/convert/utils.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/utils.cc
@@ -119,5 +119,41 @@ string DebugString(const nvinfer1::ITensor& tensor) {
 
 #endif
 
+string GetLinkedTensorRTVersion() {
+  int major, minor, patch;
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+  major = NV_TENSORRT_MAJOR;
+  minor = NV_TENSORRT_MINOR;
+  patch = NV_TENSORRT_PATCH;
+#else
+  major = 0;
+  minor = 0;
+  patch = 0;
+#endif
+  string trt_version = std::to_string(major) + "." +
+                       std::to_string(minor) + "." +
+                       std::to_string(patch);
+  return trt_version;
+}
+
+string GetLoadedTensorRTVersion() {
+  int major, minor, patch;
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+  int ver = getInferLibVersion();
+  major = ver / 1000;
+  ver = ver - major * 1000;
+  minor = ver / 100;
+  patch = ver - minor * 100;
+#else
+  major = 0;
+  minor = 0;
+  patch = 0;
+#endif
+  string trt_version = std::to_string(major) + "." +
+                       std::to_string(minor) + "." +
+                       std::to_string(patch);
+  return trt_version;
+}
+
 }  // namespace tensorrt
 }  // namespace tensorflow

--- a/tensorflow/compiler/tf2tensorrt/convert/utils.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/utils.cc
@@ -130,10 +130,7 @@ string GetLinkedTensorRTVersion() {
   minor = 0;
   patch = 0;
 #endif
-  string trt_version = absl::StrCat(std::to_string(major), ".",
-                              std::to_string(minor), ".",
-                              std::to_string(patch));
-  return trt_version;
+  return absl::StrCat(major, ".", minor, ".", patch);
 }
 
 string GetLoadedTensorRTVersion() {
@@ -149,10 +146,7 @@ string GetLoadedTensorRTVersion() {
   minor = 0;
   patch = 0;
 #endif
-  string trt_version = absl::StrCat(std::to_string(major), ".",
-                              std::to_string(minor), ".",
-                              std::to_string(patch));
-  return trt_version;
+  return absl::StrCat(major, ".", minor, ".", patch);
 }
 
 }  // namespace tensorrt

--- a/tensorflow/compiler/tf2tensorrt/convert/utils.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/utils.cc
@@ -130,9 +130,9 @@ string GetLinkedTensorRTVersion() {
   minor = 0;
   patch = 0;
 #endif
-  string trt_version = std::to_string(major) + "." +
-                       std::to_string(minor) + "." +
-                       std::to_string(patch);
+  string trt_version = absl::StrCat(std::to_string(major), ".",
+                              std::to_string(minor), ".",
+                              std::to_string(patch));
   return trt_version;
 }
 
@@ -149,9 +149,9 @@ string GetLoadedTensorRTVersion() {
   minor = 0;
   patch = 0;
 #endif
-  string trt_version = std::to_string(major) + "." +
-                       std::to_string(minor) + "." +
-                       std::to_string(patch);
+  string trt_version = absl::StrCat(std::to_string(major), ".",
+                              std::to_string(minor), ".",
+                              std::to_string(patch));
   return trt_version;
 }
 

--- a/tensorflow/compiler/tf2tensorrt/convert/utils.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/utils.h
@@ -94,6 +94,15 @@ inline nvinfer1::Dims TensorShapeToTrtDims(const TensorShapeType& shape,
   trt_dims.nbDims = shape.dims() - offset;
   return trt_dims;
 }
+
+// Return a string that includes compile time
+// TensorRT library version information {Maj, Min, Patch}.
+string GetLinkedTensorRTVersion();
+
+// Return a string that includes runtime time
+// TensorRT library version information {Maj, Min, Patch}.
+string GetLoadedTensorRTVersion();
+
 #endif  // GOOGLE_CUDA && GOOGLE_TENSORRT
 
 }  // namespace tensorrt

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
@@ -529,6 +529,20 @@ bool TRTEngineOp::ExecuteTrtEngine(OpKernelContext* ctx,
                                    EngineContext* engine_context) {
   VLOG(1) << "Executing TRT engine: " << name();
   auto& cuda_engine = engine_context->cuda_engine;
+
+  if (VLOG_IS_ON(2)) {
+    VLOG(2) << "  Network name: " << cuda_engine->getName();
+    VLOG(2) << "  Activation size: " << cuda_engine->getDeviceMemorySize() << " bytes";
+    VLOG(2) << "  Workspace size: " << cuda_engine->getWorkspaceSize() << " bytes";
+    VLOG(2) << "  Datatype of " << cuda_engine->getNbBindings() << " inputs/outputs";
+    string binding_types = "";
+    for (int i=0; i < cuda_engine->getNbBindings(); i++) {
+      binding_types += "    " + string(cuda_engine->getBindingName(i))
+                    + ": " + convert::DebugString(cuda_engine->getBindingDataType(i)) + "\n";
+    }
+    VLOG(2) << binding_types;
+  }
+
   const bool kRetry = true;
   // All inputs must have the same batch size, so just get it from the first
   // input.

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
@@ -531,7 +531,9 @@ bool TRTEngineOp::ExecuteTrtEngine(OpKernelContext* ctx,
   auto& cuda_engine = engine_context->cuda_engine;
 
   if (VLOG_IS_ON(2)) {
+#if IS_TRT_VERSION_GE(6, 0, 0, 0)
     VLOG(2) << "  Network name: " << cuda_engine->getName();
+#endif  // #if IS_TRT_VERSION_GE(6, 0, 0, 0)
     VLOG(2) << "  Activation size: " << cuda_engine->getDeviceMemorySize() << " bytes";
     VLOG(2) << "  Workspace size: " << cuda_engine->getWorkspaceSize() << " bytes";
     VLOG(2) << "  Datatype of " << cuda_engine->getNbBindings() << " inputs/outputs";

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
@@ -538,7 +538,7 @@ bool TRTEngineOp::ExecuteTrtEngine(OpKernelContext* ctx,
     string binding_types = "";
     for (int i=0; i < cuda_engine->getNbBindings(); i++) {
       binding_types += "    " + string(cuda_engine->getBindingName(i))
-                    + ": " + convert::DebugString(cuda_engine->getBindingDataType(i)) + "\n";
+                    + ": " + DebugString(cuda_engine->getBindingDataType(i)) + "\n";
     }
     VLOG(2) << binding_types;
   }


### PR DESCRIPTION
This is useful for debugging to tell what builder configs were used when building the engine.