### PR TITLE
[INTEL MKL] Fix quantize accuracy loss

### DIFF
--- a/tensorflow/core/kernels/mkl_quantize_op.cc
+++ b/tensorflow/core/kernels/mkl_quantize_op.cc
@@ -254,9 +254,8 @@ class MklQuantizeV2Op : public OpKernel {
   explicit MklQuantizeV2Op(OpKernelConstruction* ctx) : OpKernel(ctx) {
     string mode_string;
     OP_REQUIRES_OK(ctx, ctx->GetAttr("mode", &mode_string));
-    OP_REQUIRES(ctx,
-                (mode_string == "MIN_COMBINED" || mode_string == "MIN_FIRST" ||
-                 mode_string == "SCALED"),
+    OP_REQUIRES(ctx, (mode_string == "MIN_COMBINED" ||
+                      mode_string == "MIN_FIRST" || mode_string == "SCALED"),
                 errors::InvalidArgument("Mode string must be 'MIN_COMBINED',"
                                         " 'MIN_FIRST', or 'SCALED', is '" +
                                         mode_string + "'"));
@@ -270,9 +269,8 @@ class MklQuantizeV2Op : public OpKernel {
 
     string round_mode_string;
     OP_REQUIRES_OK(ctx, ctx->GetAttr("round_mode", &round_mode_string));
-    OP_REQUIRES(ctx,
-                (round_mode_string == "HALF_AWAY_FROM_ZERO" ||
-                 round_mode_string == "HALF_TO_EVEN"),
+    OP_REQUIRES(ctx, (round_mode_string == "HALF_AWAY_FROM_ZERO" ||
+                      round_mode_string == "HALF_TO_EVEN"),
                 errors::InvalidArgument("Round mode string must be "
                                         "'HALF_AWAY_FROM_ZERO' or "
                                         "'HALF_TO_EVEN', is '" +
@@ -291,26 +289,6 @@ class MklQuantizeV2Op : public OpKernel {
     OP_REQUIRES_OK(ctx, ctx->GetAttr("axis", &axis_));
     OP_REQUIRES_OK(
         ctx, ctx->GetAttr("ensure_minimum_range", &ensure_minimum_range_));
-  }
-
-  ~MklQuantizeV2Op() {
-    if (minfirst_input_ != nullptr) {
-      delete minfirst_input_;
-      minfirst_input_ = nullptr;
-    }
-  }
-
-  float* GetMinfirstInputBuf(int size) {
-    if (!minfirst_input_) {
-      minfirst_input_ = new float[size];
-      minfirst_input_size_ = size;
-    } else if (size > minfirst_input_size_) {
-      delete minfirst_input_;
-      minfirst_input_ = new float[size];
-      minfirst_input_size_ = size;
-    }
-
-    return minfirst_input_;
   }
 
   void ComputeScalar(OpKernelContext* ctx, float min_range, float max_range) {
@@ -434,8 +412,11 @@ class MklQuantizeV2Op : public OpKernel {
     // If the mode is min_first, input data has to be subtracted from
     // min_range, before being scaled
     auto flat_input = input.flat<float>().data();
+    Tensor minfirst_tmpinput;
+    OP_REQUIRES_OK(
+        ctx, ctx->allocate_temp(DT_FLOAT, input.shape(), &minfirst_tmpinput));
     if (mode_ == QUANTIZE_MODE_MIN_FIRST) {
-      float* minfirst_input = GetMinfirstInputBuf(input.NumElements());
+      auto minfirst_input = minfirst_tmpinput.flat<float>().data();
       const Eigen::TensorOpCost cost(
           sizeof(float), /*load bytes*/
           sizeof(float), /*saved bytes*/
@@ -557,8 +538,6 @@ class MklQuantizeV2Op : public OpKernel {
   int round_mode_;
   int axis_;
   bool narrow_range_;
-  float* minfirst_input_ = nullptr;
-  int minfirst_input_size_;
 };
 
 REGISTER_KERNEL_BUILDER(Name("_MklQuantizeV2")


### PR DESCRIPTION
Allocate quantize min first mode tmp buffer every time, to avoid the
accuracy loss  with batches run in parallel