### PR TITLE
[GPU][ROCm] Fix hip-clang build

### DIFF
--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -322,7 +322,7 @@ def _hipcc_is_hipclang(repository_ctx):
         ["grep", "HIP_COMPILER=clang", "/opt/rocm/hip/lib/.hipInfo"],
         empty_stdout_fine = True,
     )
-    result = grep_result.stdout
+    result = grep_result.stdout.strip()
     if result == "HIP_COMPILER=clang":
         return "True"
     return "False"


### PR DESCRIPTION
This patches fixes a bug which causes build failure for hip-clang.

Basically in third_party/gpus/rocm_configure.bzl a string is checked to determine whether the compiler is hip-clang. Comparison fails due to new line not being stripped. This patch strips new line so that comparison succeeds.