### PR TITLE
lite/micro: Fix bug in tensor lifetime calculation.

### DIFF
--- a/tensorflow/lite/micro/micro_allocator.cc
+++ b/tensorflow/lite/micro/micro_allocator.cc
@@ -140,14 +140,14 @@ AllocationInfo* AllocateAndCalculateAllocationInfo(
     for (size_t n = 0; n < op->inputs()->size(); ++n) {
       const int tensor_index = op->inputs()->Get(n);
       AllocationInfo* current = &allocation_info[tensor_index];
-      if (((current->last_used == -1) || (current->last_used > i))) {
+      if (((current->last_used == -1) || (current->last_used < i))) {
         current->last_used = i;
       }
     }
     for (size_t n = 0; n < op->outputs()->size(); ++n) {
       const int tensor_index = op->outputs()->Get(n);
       AllocationInfo* current = &allocation_info[tensor_index];
-      if ((current->first_created == -1) || (current->first_created < i)) {
+      if ((current->first_created == -1) || (current->first_created > i)) {
         current->first_created = i;
       }
     }

--- a/tensorflow/lite/micro/micro_allocator_test.cc
+++ b/tensorflow/lite/micro/micro_allocator_test.cc
@@ -143,7 +143,7 @@ TF_LITE_MICRO_TEST(TestFinishTensorAllocation) {
   uint8_t arena[arena_size];
   tflite::MicroAllocator allocator(&context, model, arena, arena_size,
                                    micro_test::reporter);
-  TF_LITE_MICRO_EXPECT_EQ(3, context.tensors_size);
+  TF_LITE_MICRO_EXPECT_EQ(4, context.tensors_size);
 
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, allocator.FinishTensorAllocation());
   // No allocation to be done afterwards.
@@ -153,12 +153,19 @@ TF_LITE_MICRO_TEST(TestFinishTensorAllocation) {
   tflite::testing::VerifyMockTensor(&context.tensors[0]);
   tflite::testing::VerifyMockWeightTensor(&context.tensors[1]);
   tflite::testing::VerifyMockTensor(&context.tensors[2]);
+  tflite::testing::VerifyMockTensor(&context.tensors[3]);
 
   TF_LITE_MICRO_EXPECT_NE(context.tensors[1].data.raw,
                           context.tensors[0].data.raw);
   TF_LITE_MICRO_EXPECT_NE(context.tensors[2].data.raw,
                           context.tensors[0].data.raw);
   TF_LITE_MICRO_EXPECT_NE(context.tensors[1].data.raw,
+                          context.tensors[2].data.raw);
+  TF_LITE_MICRO_EXPECT_NE(context.tensors[3].data.raw,
+                          context.tensors[0].data.raw);
+  TF_LITE_MICRO_EXPECT_NE(context.tensors[3].data.raw,
+                          context.tensors[1].data.raw);
+  TF_LITE_MICRO_EXPECT_NE(context.tensors[3].data.raw,
                           context.tensors[2].data.raw);
 }
 

--- a/tensorflow/lite/micro/test_helpers.cc
+++ b/tensorflow/lite/micro/test_helpers.cc
@@ -76,7 +76,7 @@ const Model* BuildSimpleMockModel() {
                    builder->CreateVector(buffer_data, buffer_data_size))};
   constexpr size_t tensor_shape_size = 1;
   const int32_t tensor_shape[tensor_shape_size] = {1};
-  constexpr size_t tensors_size = 3;
+  constexpr size_t tensors_size = 4;
   const Offset<Tensor> tensors[tensors_size] = {
       CreateTensor(*builder,
                    builder->CreateVector(tensor_shape, tensor_shape_size),
@@ -90,20 +90,36 @@ const Model* BuildSimpleMockModel() {
                    builder->CreateVector(tensor_shape, tensor_shape_size),
                    TensorType_INT32, 0,
                    builder->CreateString("test_output_tensor"), 0, false),
+      CreateTensor(*builder,
+                   builder->CreateVector(tensor_shape, tensor_shape_size),
+                   TensorType_INT32, 0,
+                   builder->CreateString("test_output2_tensor"), 0, false),
   };
   constexpr size_t inputs_size = 1;
   const int32_t inputs[inputs_size] = {0};
-  constexpr size_t outputs_size = 1;
-  const int32_t outputs[outputs_size] = {2};
+  constexpr size_t outputs_size = 2;
+  const int32_t outputs[outputs_size] = {2, 3};
   constexpr size_t operator_inputs_size = 2;
   const int32_t operator_inputs[operator_inputs_size] = {0, 1};
   constexpr size_t operator_outputs_size = 1;
   const int32_t operator_outputs[operator_outputs_size] = {2};
-  constexpr size_t operators_size = 1;
-  const Offset<Operator> operators[operators_size] = {CreateOperator(
-      *builder, 0, builder->CreateVector(operator_inputs, operator_inputs_size),
-      builder->CreateVector(operator_outputs, operator_outputs_size),
-      BuiltinOptions_NONE)};
+  const int32_t operator2_outputs[operator_outputs_size] = {3};
+  constexpr size_t operators_size = 2;
+  const Offset<Operator> operators[operators_size] = {
+      CreateOperator(*builder, 0,
+		     builder->CreateVector(operator_inputs,
+					   operator_inputs_size),
+		     builder->CreateVector(operator_outputs,
+					   operator_outputs_size),
+		     BuiltinOptions_NONE),
+      CreateOperator(
+		     *builder, 0,
+		     builder->CreateVector(operator_inputs,
+					   operator_inputs_size),
+		     builder->CreateVector(operator2_outputs,
+					   operator_outputs_size),
+		     BuiltinOptions_NONE),
+  };
   constexpr size_t subgraphs_size = 1;
   const Offset<SubGraph> subgraphs[subgraphs_size] = {
       CreateSubGraph(*builder, builder->CreateVector(tensors, tensors_size),


### PR DESCRIPTION
Fix for issue #35121

The tensor lifetime may be incorrectly calculated in MicroAllocator::FinishTensorAllocation() if the same sensor is used multiple times as inputs to different operations or is used as input/output or variable of the graph.