### PR TITLE
added usage example to pad_to_bounding_box()

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -778,7 +778,12 @@ def pad_to_bounding_box(image, offset_height, offset_width, target_height,
 
     >>> x=tf.constant([[[1,2,3]]])
     >>> tf.image.pad_to_bounding_box(x, 1, 1, 2, 2)
-    <tf.Tensor: shape=(2, 2, 3), dtype=int32, numpy=array([[[0, 0, 0],[0, 0, 0]],[[0, 0, 0],[1, 2, 3]]], dtype=int32)>
+        <tf.Tensor: shape=(2, 2, 3), dtype=int32, numpy=
+    array([[[0, 0, 0],
+            [0, 0, 0]],
+
+           [[0, 0, 0],
+            [1, 2, 3]]], dtype=int32)>
 
   Args:
     image: 4-D Tensor of shape `[batch, height, width, channels]` or 3-D Tensor

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -773,25 +773,27 @@ def pad_to_bounding_box(image, offset_height, offset_width, target_height,
   
   This op does nothing if `offset_*` is zero and the image already has size
   `target_height` by `target_width`.
-  
+
   Usage example:
-    
+
     >>> x = tf.random.uniform((28, 28, 1))
     >>> tf.image.pad_to_bounding_box(x, 28, 28, 100, 100).shape
     TensorShape([100, 100, 1])
-    
+
   Args:
     image: 4-D Tensor of shape `[batch, height, width, channels]` or 3-D Tensor
-      of shape `[height, width, channels]`.
+    of shape `[height, width, channels]`.
     offset_height: Number of rows of zeros to add on top.
     offset_width: Number of columns of zeros to add on the left.
     target_height: Height of output image.
     target_width: Width of output image.
+
   Returns:
     If `image` was 4-D, a 4-D float Tensor of shape
     `[batch, target_height, target_width, channels]`
     If `image` was 3-D, a 3-D float Tensor of shape
     `[target_height, target_width, channels]`
+
   Raises:
     ValueError: If the shape of `image` is incompatible with the `offset_*` or
     `target_*` arguments, or either `offset_height` or `offset_width` is

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -794,7 +794,7 @@ def pad_to_bounding_box(image, offset_height, offset_width, target_height,
       negative.
       
   Usage example:
-    import tensorflow as tf
+    
     x=tf.random.uniform((28,28,1))
     tf.image.pad_to_bounding_box(x,28,28,100,100)
     

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -766,14 +766,16 @@ def central_crop(image, central_fraction):
 def pad_to_bounding_box(image, offset_height, offset_width, target_height,
                         target_width):
   """Pad `image` with zeros to the specified `height` and `width`.
-
   Adds `offset_height` rows of zeros on top, `offset_width` columns of
   zeros on the left, and then pads the image on the bottom and right
   with zeros until it has dimensions `target_height`, `target_width`.
-
   This op does nothing if `offset_*` is zero and the image already has size
   `target_height` by `target_width`.
-  
+  Usage example:
+    
+    >>> x = tf.random.uniform((28, 28, 1))
+    >>> tf.image.pad_to_bounding_box(x, 28, 28, 100, 100).shape
+    TensorShape([100, 100, 1])
   Args:
     image: 4-D Tensor of shape `[batch, height, width, channels]` or 3-D Tensor
       of shape `[height, width, channels]`.
@@ -781,26 +783,15 @@ def pad_to_bounding_box(image, offset_height, offset_width, target_height,
     offset_width: Number of columns of zeros to add on the left.
     target_height: Height of output image.
     target_width: Width of output image.
-
   Returns:
     If `image` was 4-D, a 4-D float Tensor of shape
     `[batch, target_height, target_width, channels]`
     If `image` was 3-D, a 3-D float Tensor of shape
     `[target_height, target_width, channels]`
-
   Raises:
     ValueError: If the shape of `image` is incompatible with the `offset_*` or
     `target_*` arguments, or either `offset_height` or `offset_width` is
-    negative.
-      
-  Usage example:
-  
-  python
-    
-    >>> x = tf.random.uniform((28, 28, 1))
-    >>> tf.image.pad_to_bounding_box(x, 28, 28, 100, 100).shape
-    >>> TensorShape([100, 100, 1])
-    
+    negative.    
   """
   with ops.name_scope(None, 'pad_to_bounding_box', [image]):
     image = ops.convert_to_tensor(image, name='image')

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -766,11 +766,11 @@ def central_crop(image, central_fraction):
 def pad_to_bounding_box(image, offset_height, offset_width, target_height,
                         target_width):
   """Pad `image` with zeros to the specified `height` and `width`.
-  
+
   Adds `offset_height` rows of zeros on top, `offset_width` columns of
   zeros on the left, and then pads the image on the bottom and right
   with zeros until it has dimensions `target_height`, `target_width`.
-  
+
   This op does nothing if `offset_*` is zero and the image already has size
   `target_height` by `target_width`.
 

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -798,6 +798,7 @@ def pad_to_bounding_box(image, offset_height, offset_width, target_height,
     
     >>> x = tf.random.uniform((28, 28, 1))
     >>> tf.image.pad_to_bounding_box(x, 28, 28, 100, 100).shape
+    >>> # TensorShape([100, 100, 1])
     ```
     
   """

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -798,6 +798,7 @@ def pad_to_bounding_box(image, offset_height, offset_width, target_height,
     
     >>> x = tf.random.uniform((28, 28, 1))
     >>> tf.image.pad_to_bounding_box(x, 28, 28, 100, 100)
+    ```
     
   """
   with ops.name_scope(None, 'pad_to_bounding_box', [image]):

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -797,7 +797,7 @@ def pad_to_bounding_box(image, offset_height, offset_width, target_height,
   ```python
     
     >>> x = tf.random.uniform((28, 28, 1))
-    tf.image.pad_to_bounding_box(x,28,28,100,100)
+    >>> tf.image.pad_to_bounding_box(x, 28, 28, 100, 100)
     
   """
   with ops.name_scope(None, 'pad_to_bounding_box', [image]):

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -776,13 +776,9 @@ def pad_to_bounding_box(image, offset_height, offset_width, target_height,
 
   Usage example:
 
-    >>> x=tf.constant([
-    ...        [[1,2,3],[4,5,6],[7,8,9]],
-    ...        [[1,2,3],[4,5,6],[7,8,9]],
-    ...        [[1,2,3],[4,5,6],[7,8,9]]
-    ...        ])
-    >>> tf.image.pad_to_bounding_box(x, 28, 28, 100, 100)
-    <tf.Tensor: shape=(9, 9, 3), dtype=int32, numpy=array([[[0, 0, 0],(...)],(...)]], dtype=int32)>
+    >>> x=tf.constant([[[1,2,3]]])
+    >>> tf.image.pad_to_bounding_box(x, 1, 1, 2, 2)
+    <tf.Tensor: shape=(2, 2, 3), dtype=int32, numpy=array([[[0, 0, 0],[0, 0, 0]],[[0, 0, 0],[1, 2, 3]]], dtype=int32)>
 
   Args:
     image: 4-D Tensor of shape `[batch, height, width, channels]` or 3-D Tensor

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -766,16 +766,20 @@ def central_crop(image, central_fraction):
 def pad_to_bounding_box(image, offset_height, offset_width, target_height,
                         target_width):
   """Pad `image` with zeros to the specified `height` and `width`.
+  
   Adds `offset_height` rows of zeros on top, `offset_width` columns of
   zeros on the left, and then pads the image on the bottom and right
   with zeros until it has dimensions `target_height`, `target_width`.
+  
   This op does nothing if `offset_*` is zero and the image already has size
   `target_height` by `target_width`.
+  
   Usage example:
     
     >>> x = tf.random.uniform((28, 28, 1))
     >>> tf.image.pad_to_bounding_box(x, 28, 28, 100, 100).shape
     TensorShape([100, 100, 1])
+    
   Args:
     image: 4-D Tensor of shape `[batch, height, width, channels]` or 3-D Tensor
       of shape `[height, width, channels]`.
@@ -791,7 +795,7 @@ def pad_to_bounding_box(image, offset_height, offset_width, target_height,
   Raises:
     ValueError: If the shape of `image` is incompatible with the `offset_*` or
     `target_*` arguments, or either `offset_height` or `offset_width` is
-    negative.    
+    negative.
   """
   with ops.name_scope(None, 'pad_to_bounding_box', [image]):
     image = ops.convert_to_tensor(image, name='image')

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -773,7 +773,7 @@ def pad_to_bounding_box(image, offset_height, offset_width, target_height,
 
   This op does nothing if `offset_*` is zero and the image already has size
   `target_height` by `target_width`.
-
+  
   Args:
     image: 4-D Tensor of shape `[batch, height, width, channels]` or 3-D Tensor
       of shape `[height, width, channels]`.
@@ -792,6 +792,12 @@ def pad_to_bounding_box(image, offset_height, offset_width, target_height,
     ValueError: If the shape of `image` is incompatible with the `offset_*` or
       `target_*` arguments, or either `offset_height` or `offset_width` is
       negative.
+      
+  Usage example:
+    import tensorflow as tf
+    x=tf.random.uniform((28,28,1))
+    tf.image.pad_to_bounding_box(x,28,28,100,100)
+    
   """
   with ops.name_scope(None, 'pad_to_bounding_box', [image]):
     image = ops.convert_to_tensor(image, name='image')

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -796,7 +796,7 @@ def pad_to_bounding_box(image, offset_height, offset_width, target_height,
   Usage example:
   ```python
     
-    x=tf.random.uniform((28,28,1))
+    >>> x = tf.random.uniform((28, 28, 1))
     tf.image.pad_to_bounding_box(x,28,28,100,100)
     
   """

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -797,7 +797,7 @@ def pad_to_bounding_box(image, offset_height, offset_width, target_height,
   ```python
     
     >>> x = tf.random.uniform((28, 28, 1))
-    >>> tf.image.pad_to_bounding_box(x, 28, 28, 100, 100)
+    >>> tf.image.pad_to_bounding_box(x, 28, 28, 100, 100).shape
     ```
     
   """

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -798,7 +798,7 @@ def pad_to_bounding_box(image, offset_height, offset_width, target_height,
     
     >>> x = tf.random.uniform((28, 28, 1))
     >>> tf.image.pad_to_bounding_box(x, 28, 28, 100, 100).shape
-    >>> # TensorShape([100, 100, 1])
+    >>> TensorShape([100, 100, 1])
     ```
     
   """

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -794,6 +794,7 @@ def pad_to_bounding_box(image, offset_height, offset_width, target_height,
       negative.
       
   Usage example:
+  ```python
     
     x=tf.random.uniform((28,28,1))
     tf.image.pad_to_bounding_box(x,28,28,100,100)

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -790,16 +790,16 @@ def pad_to_bounding_box(image, offset_height, offset_width, target_height,
 
   Raises:
     ValueError: If the shape of `image` is incompatible with the `offset_*` or
-      `target_*` arguments, or either `offset_height` or `offset_width` is
-      negative.
+    `target_*` arguments, or either `offset_height` or `offset_width` is
+    negative.
       
   Usage example:
-  ```python
+  
+  python
     
     >>> x = tf.random.uniform((28, 28, 1))
     >>> tf.image.pad_to_bounding_box(x, 28, 28, 100, 100).shape
     >>> TensorShape([100, 100, 1])
-    ```
     
   """
   with ops.name_scope(None, 'pad_to_bounding_box', [image]):

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -776,9 +776,13 @@ def pad_to_bounding_box(image, offset_height, offset_width, target_height,
 
   Usage example:
 
-    >>> x = tf.random.uniform((28, 28, 1))
-    >>> tf.image.pad_to_bounding_box(x, 28, 28, 100, 100).shape
-    TensorShape([100, 100, 1])
+    >>> x=tf.constant([
+    ...        [[1,2,3],[4,5,6],[7,8,9]],
+    ...        [[1,2,3],[4,5,6],[7,8,9]],
+    ...        [[1,2,3],[4,5,6],[7,8,9]]
+    ...        ])
+    >>> tf.image.pad_to_bounding_box(x, 28, 28, 100, 100)
+    <tf.Tensor: shape=(9, 9, 3), dtype=int32, numpy=array([[[0, 0, 0],(...)],(...)]], dtype=int32)>
 
   Args:
     image: 4-D Tensor of shape `[batch, height, width, channels]` or 3-D Tensor


### PR DESCRIPTION
I added a usage example to tf.image.pad_to_bounding_box() function. I tested it on colab so I know there aren't syntax errors.😄🖖