### PR TITLE
Fix build breaks for S3 unit test

### DIFF
--- a/tensorflow/core/platform/s3/s3_file_system_test.cc
+++ b/tensorflow/core/platform/s3/s3_file_system_test.cc
@@ -55,7 +55,7 @@ class S3FileSystemTest : public ::testing::Test {
     content->resize(file_size);
     StringPiece result;
     TF_RETURN_IF_ERROR(
-        reader->Read(0, file_size, &result, gtl::string_as_array(content)));
+        reader->Read(0, file_size, &result, &(*content)[0]));
     if (file_size != result.size()) {
       return errors::DataLoss("expected ", file_size, " got ", result.size(),
                               " bytes");

--- a/tensorflow/core/platform/s3/s3_file_system_test.cc
+++ b/tensorflow/core/platform/s3/s3_file_system_test.cc
@@ -79,13 +79,13 @@ TEST_F(S3FileSystemTest, NewRandomAccessFile) {
   got.resize(content.size());
   StringPiece result;
   TF_EXPECT_OK(
-      reader->Read(0, content.size(), &result, gtl::string_as_array(&got)));
+      reader->Read(0, content.size(), &result, &got[0]));
   EXPECT_EQ(content.size(), result.size());
   EXPECT_EQ(content, result);
 
   got.clear();
   got.resize(4);
-  TF_EXPECT_OK(reader->Read(2, 4, &result, gtl::string_as_array(&got)));
+  TF_EXPECT_OK(reader->Read(2, 4, &result, &got[0]));
   EXPECT_EQ(4, result.size());
   EXPECT_EQ(content.substr(2, 4), result);
 }


### PR DESCRIPTION

This PR tries to address the issue raised in #35040 where
S3 unit test failed due to `gtl::string_as_array`.

This PR change `string_as_array` into getting the pointter of
the first char of the string. By std standard, `std::string`'s
memory is continuous so &s[0] will give the right memory location.

This PR fixes #35040.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>