### PR TITLE
[mlir]

### DIFF
--- a/third_party/mlir/lib/Dialect/StandardOps/Ops.cpp
+++ b/third_party/mlir/lib/Dialect/StandardOps/Ops.cpp
@@ -2729,21 +2729,6 @@ SubViewOp::getStaticStrides(SmallVectorImpl<int64_t> &staticStrides) {
   return success();
 }
 
-static bool hasConstantOffsetSizesAndStrides(MemRefType memrefType) {
-  if (memrefType.getNumDynamicDims() > 0)
-    return false;
-  // Get offset and strides.
-  int64_t offset;
-  llvm::SmallVector<int64_t, 4> strides;
-  if (failed(getStridesAndOffset(memrefType, strides, offset)))
-    return false;
-  // Return 'false' if any of offset or strides is dynamic.
-  if (offset == MemRefType::getDynamicStrideOrOffset() ||
-      llvm::is_contained(strides, MemRefType::getDynamicStrideOrOffset()))
-    return false;
-  return true;
-}
-
 namespace {
 
 /// Pattern to rewrite a subview op with constant size arguments.

--- a/third_party/mlir/lib/Dialect/VectorOps/VectorOps.cpp
+++ b/third_party/mlir/lib/Dialect/VectorOps/VectorOps.cpp
@@ -1505,7 +1505,7 @@ static void print(OpAsmPrinter &p, TupleGetOp op) {
 
 static LogicalResult verify(TupleGetOp op) {
   auto tupleType = op.getOperand()->getType().cast<TupleType>();
-  if (op.getIndex() < 0 || op.getIndex() >= tupleType.size())
+  if (op.getIndex() >= tupleType.size())
     return op.emitOpError("tuple get index out of range");
   return success();
 }


### PR DESCRIPTION
1.the type of op.getIndex() is unsigned, the value is always greater than or equal to 0
2.the function hasConstantoffsetSizesAndStrides is defined but not used