### PR TITLE
Add TfLite micro ExpandDims reference kernel

### DIFF
--- a/tensorflow/lite/micro/kernels/all_ops_resolver.cc
+++ b/tensorflow/lite/micro/kernels/all_ops_resolver.cc
@@ -70,6 +70,7 @@ AllOpsResolver::AllOpsResolver() {
   AddBuiltin(BuiltinOperator_RELU, Register_RELU());
   AddBuiltin(BuiltinOperator_RELU6, Register_RELU6());
   AddBuiltin(BuiltinOperator_MEAN, Register_MEAN());
+  AddBuiltin(BuiltinOperator_EXPAND_DIMS, Register_EXPAND_DIMS());
 }
 
 }  // namespace micro

--- a/tensorflow/lite/micro/kernels/expand_dims.cc
+++ b/tensorflow/lite/micro/kernels/expand_dims.cc
@@ -1,0 +1,123 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/tensor.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/kernels/op_macros.h"
+
+namespace tflite {
+namespace ops {
+namespace micro {
+namespace expand_dims {
+
+constexpr int k_input_tensor = 0;
+constexpr int k_axis_tensor = 1;
+constexpr int k_output_tensor = 0;
+
+// TODO(See TfLiteSqueezeParams): We can't have dynamic data, at least not yet.
+// For now we will fix the maximum possible number of dimensions.
+constexpr int max_num_dims = 8;
+
+struct ExpandDimsContext {
+  ExpandDimsContext(TfLiteContext* context, TfLiteNode* node)
+      : input(GetInput(context, node, k_input_tensor)),
+        axis(GetInput(context, node, k_axis_tensor)),
+        output(GetOutput(context, node, k_output_tensor)) {}
+  const TfLiteTensor* const input;
+  const TfLiteTensor* const axis;
+  TfLiteTensor* output;
+};
+
+TfLiteStatus ExpandTensorDim(TfLiteContext* context, TfLiteNode* node,
+                             const TfLiteTensor* input, int axis,
+                             TfLiteTensor* output) {
+  const TfLiteIntArray* input_dims = input->dims;
+  TF_LITE_ENSURE(context, (0 < input_dims->size) &&
+                              (input_dims->size <= (max_num_dims - 1)));
+  if (axis < 0) {
+    axis = input_dims->size + 1 + axis;
+  }
+  TF_LITE_ENSURE(context, (axis <= input_dims->size) && (axis >= 0));
+
+  // Allocate new output_dims from node's temporaries buffer
+  TfLiteIntArray* output_dims = node->temporaries;
+  output_dims->size = input_dims->size + 1;
+  for (int i = 0; i < output_dims->size; ++i) {
+    if (i < axis) {
+      output_dims->data[i] = input_dims->data[i];
+    } else if (i == axis) {
+      output_dims->data[i] = 1;
+    } else {
+      output_dims->data[i] = input_dims->data[i - 1];
+    }
+  }
+
+  output->dims = output_dims;
+
+  return kTfLiteOk;
+}
+
+TfLiteStatus GetAxisValueFromTensor(TfLiteContext* context,
+                                    const TfLiteTensor* axis, int* axis_value) {
+  TF_LITE_ENSURE_EQ(context, NumElements(axis), 1);
+  switch (axis->type) {
+    case kTfLiteInt32:
+      *axis_value = *GetTensorData<int32_t>(axis);
+      return kTfLiteOk;
+    case kTfLiteInt64:
+      *axis_value = *GetTensorData<int64_t>(axis);
+      return kTfLiteOk;
+    default:
+      return kTfLiteError;
+  }
+}
+
+TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+  TF_LITE_ENSURE_EQ(context, NumInputs(node), 2);
+  TF_LITE_ENSURE_EQ(context, NumOutputs(node), 1);
+  return kTfLiteOk;
+}
+
+TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
+  ExpandDimsContext op_context(context, node);
+  int axis_value = 0;
+  if (GetAxisValueFromTensor(context, op_context.axis, &axis_value) !=
+      kTfLiteOk) {
+    return kTfLiteError;
+  }
+
+  if (ExpandTensorDim(context, node, op_context.input, axis_value,
+                      op_context.output) != kTfLiteOk) {
+    return kTfLiteError;
+  }
+  // Just copy input to output.
+  for (int i = 0; i < op_context.input->bytes; ++i) {
+    op_context.output->data.raw[i] = op_context.input->data.raw[i];
+  }
+  return kTfLiteOk;
+}
+
+}  // namespace expand_dims
+
+TfLiteRegistration* Register_EXPAND_DIMS() {
+  static TfLiteRegistration r = {nullptr, nullptr, expand_dims::Prepare,
+                                 expand_dims::Eval};
+  return &r;
+}
+
+}  // namespace micro
+}  // namespace ops
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/expand_dims_test.cc
+++ b/tensorflow/lite/micro/kernels/expand_dims_test.cc
@@ -119,12 +119,6 @@ void TestExpandDims(std::initializer_list<int> input_dims_data,
 
 TF_LITE_MICRO_TESTS_BEGIN
 
-#define TEST_EXPAND_DIMS(...)                                          \
-  using tflite::testing::TestExpandDims;                               \
-  tflite::testing::TestExpandDims<float, kTfLiteFloat32>(__VA_ARGS__); \
-  tflite::testing::TestExpandDims<uint8_t, kTfLiteUInt8>(__VA_ARGS__); \
-  tflite::testing::TestExpandDims<int8_t, kTfLiteInt8>(__VA_ARGS__);
-
 TF_LITE_MICRO_TEST(ExpandDimsPositiveAxis) {
   uint8_t output_data_buffer[4 * 4];
   constexpr int num_axis_dims = 1;
@@ -132,21 +126,23 @@ TF_LITE_MICRO_TEST(ExpandDimsPositiveAxis) {
   constexpr int num_expected_output_dims = 3;
 
   // expand_axis == 0
-  TEST_EXPAND_DIMS({num_input_dims, 2, 2},               // input_dims
-                   {1, 2, 3, 4},                         // input_data
-                   {num_axis_dims, 1},                   // expand axis dims
-                   {0},                                  // expand axis
-                   {num_expected_output_dims, 1, 2, 2},  // expected_output_dims
-                   {1, 2, 3, 4}, output_data_buffer      // expected_output
+  tflite::testing::TestExpandDims(
+      {num_input_dims, 2, 2},               // input_dims
+      {1, 2, 3, 4},                         // input_data
+      {num_axis_dims, 1},                   // expand axis dims
+      {0},                                  // expand axis
+      {num_expected_output_dims, 1, 2, 2},  // expected_output_dims
+      {1, 2, 3, 4}, output_data_buffer      // expected_output
   );
 
   // expand_axis == 2
-  TEST_EXPAND_DIMS({num_input_dims, 2, 2},               // input_dims
-                   {1, 2, 3, 4},                         // input_data
-                   {num_axis_dims, 1},                   // expand axis dims
-                   {2},                                  // expand axis
-                   {num_expected_output_dims, 2, 2, 1},  // expected_output_dims
-                   {1, 2, 3, 4}, output_data_buffer      // expected_output
+  tflite::testing::TestExpandDims(
+      {num_input_dims, 2, 2},               // input_dims
+      {1, 2, 3, 4},                         // input_data
+      {num_axis_dims, 1},                   // expand axis dims
+      {2},                                  // expand axis
+      {num_expected_output_dims, 2, 2, 1},  // expected_output_dims
+      {1, 2, 3, 4}, output_data_buffer      // expected_output
   );
 }
 
@@ -157,21 +153,23 @@ TF_LITE_MICRO_TEST(ExpandDimsNegativeAxis) {
   constexpr int num_expected_output_dims = 3;
 
   // expand_axis == -1
-  TEST_EXPAND_DIMS({num_input_dims, 2, 2},               // input_dims
-                   {1, 2, 3, 4},                         // input_data
-                   {num_axis_dims, 1},                   // expand axis dims
-                   {-1},                                 // expand axis
-                   {num_expected_output_dims, 2, 2, 1},  // expected_output_dims
-                   {1, 2, 3, 4}, output_data_buffer      // expected_output
+  tflite::testing::TestExpandDims(
+      {num_input_dims, 2, 2},               // input_dims
+      {1, 2, 3, 4},                         // input_data
+      {num_axis_dims, 1},                   // expand axis dims
+      {-1},                                 // expand axis
+      {num_expected_output_dims, 2, 2, 1},  // expected_output_dims
+      {1, 2, 3, 4}, output_data_buffer      // expected_output
   );
 
   // expand_axis == -3
-  TEST_EXPAND_DIMS({num_input_dims, 2, 2},               // input_dims
-                   {1, 2, 3, 4},                         // input_data
-                   {num_axis_dims, 1},                   // expand axis dims
-                   {-3},                                 // expand axis
-                   {num_expected_output_dims, 1, 2, 2},  // expected_output_dims
-                   {1, 2, 3, 4}, output_data_buffer      // expected_output
+  tflite::testing::TestExpandDims(
+      {num_input_dims, 2, 2},               // input_dims
+      {1, 2, 3, 4},                         // input_data
+      {num_axis_dims, 1},                   // expand axis dims
+      {-3},                                 // expand axis
+      {num_expected_output_dims, 1, 2, 2},  // expected_output_dims
+      {1, 2, 3, 4}, output_data_buffer      // expected_output
   );
 }
 
@@ -182,13 +180,14 @@ TF_LITE_MICRO_TEST(ExpandDimsPositiveInvalidRangeAxis) {
   constexpr int num_expected_output_dims = 3;
 
   // expand_axis == 3
-  TEST_EXPAND_DIMS({num_input_dims, 2, 2},      // input_dims
-                   {1, 2, 3, 4},                // input_data
-                   {num_axis_dims, 1},          // expand axis dims
-                   {3},                         // expand axis
-                   {num_expected_output_dims},  // expected_output_dims
-                   {}, output_data_buffer,      // expected_output
-                   true                         // expected fail
+  tflite::testing::TestExpandDims(
+      {num_input_dims, 2, 2},      // input_dims
+      {1, 2, 3, 4},                // input_data
+      {num_axis_dims, 1},          // expand axis dims
+      {3},                         // expand axis
+      {num_expected_output_dims},  // expected_output_dims
+      {}, output_data_buffer,      // expected_output
+      true                         // expected fail
   );
 }
 
@@ -199,13 +198,14 @@ TF_LITE_MICRO_TEST(ExpandDimsNegativeInvalidRangeAxis) {
   constexpr int num_expected_output_dims = 3;
 
   // expand_axis == -3
-  TEST_EXPAND_DIMS({num_input_dims, 2, 2},      // input_dims
-                   {1, 2, 3, 4},                // input_data
-                   {num_axis_dims, 1},          // expand axis dims
-                   {-4},                        // expand axis
-                   {num_expected_output_dims},  // expected_output_dims
-                   {}, output_data_buffer,      // expected_output
-                   true                         // expected fail
+  tflite::testing::TestExpandDims(
+      {num_input_dims, 2, 2},      // input_dims
+      {1, 2, 3, 4},                // input_data
+      {num_axis_dims, 1},          // expand axis dims
+      {-4},                        // expand axis
+      {num_expected_output_dims},  // expected_output_dims
+      {}, output_data_buffer,      // expected_output
+      true                         // expected fail
   );
 }
 
@@ -216,15 +216,15 @@ TF_LITE_MICRO_TEST(ExpandDimsInvalidNonScalarAxis) {
   constexpr int num_expected_output_dims = 3;
 
   // expand_axis == {0, 1}
-  TEST_EXPAND_DIMS({num_input_dims, 2, 2},      // input_dims
-                   {1, 2, 3, 4},                // input_data
-                   {num_axis_dims, 2},          // expand axis dims
-                   {0, 1},                      // expand axis
-                   {num_expected_output_dims},  // expected_output_dims
-                   {}, output_data_buffer,      // expected_output
-                   true                         // expected fail
+  tflite::testing::TestExpandDims(
+      {num_input_dims, 2, 2},      // input_dims
+      {1, 2, 3, 4},                // input_data
+      {num_axis_dims, 2},          // expand axis dims
+      {0, 1},                      // expand axis
+      {num_expected_output_dims},  // expected_output_dims
+      {}, output_data_buffer,      // expected_output
+      true                         // expected fail
   );
 }
 
-#undef TEST_EXPAND_DIMS
 TF_LITE_MICRO_TESTS_END

--- a/tensorflow/lite/micro/kernels/expand_dims_test.cc
+++ b/tensorflow/lite/micro/kernels/expand_dims_test.cc
@@ -1,0 +1,230 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include <initializer_list>
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/micro/kernels/all_ops_resolver.h"
+#include "tensorflow/lite/micro/testing/micro_test.h"
+#include "tensorflow/lite/micro/testing/test_utils.h"
+
+namespace tflite {
+namespace testing {
+namespace {
+
+// TODO(See TfLiteSqueezeParams): We can't have dynamic data, at least not
+// yet. For now we will fix the maximum possible number of dimensions.
+constexpr int max_num_dims = 8;
+
+template <typename T = float, TfLiteType tensor_input_type = kTfLiteFloat32>
+void TestExpandDims(std::initializer_list<int> input_dims_data,
+                    std::initializer_list<T> input_data,
+                    std::initializer_list<int> axis_dims_data,
+                    std::initializer_list<int> axis_data,
+                    std::initializer_list<int> expected_output_dims_data,
+                    std::initializer_list<T> expected_output,
+                    uint8_t* output_data_raw, bool expect_failure = false) {
+  TfLiteIntArray* input_dims = IntArrayFromInitializer(input_dims_data);
+  TfLiteIntArray* axis_dims = IntArrayFromInitializer(axis_dims_data);
+  TfLiteIntArray* initial_output_dims =
+      IntArrayFromInitializer(input_dims_data);
+  TfLiteIntArray* expected_output_dims =
+      IntArrayFromInitializer(expected_output_dims_data);
+  constexpr int inputs_size = 2;
+  constexpr int outputs_size = 1;
+  constexpr int tensors_size = inputs_size + outputs_size;
+  T* initial_output_data = reinterpret_cast<T*>(output_data_raw);
+  TfLiteTensor tensors[tensors_size] = {
+      CreateTensor<T, tensor_input_type>(input_data, input_dims,
+                                         "input_tensor"),
+      CreateTensor<int, kTfLiteInt32>(axis_data, axis_dims, "axis_tensor"),
+      CreateTensor<T, tensor_input_type>(initial_output_data,
+                                         initial_output_dims, "output_tensor"),
+  };
+  TfLiteContext context;
+  PopulateContext(tensors, tensors_size, &context);
+  ::tflite::ops::micro::AllOpsResolver resolver;
+  const TfLiteRegistration* registration =
+      resolver.FindOp(tflite::BuiltinOperator_EXPAND_DIMS, 1);
+  TF_LITE_MICRO_EXPECT_NE(nullptr, registration);
+
+  int inputs_array_data[] = {2, 0, 1};
+  TfLiteIntArray* inputs_array = IntArrayFromInts(inputs_array_data);
+  int outputs_array_data[] = {1, 2};
+  TfLiteIntArray* outputs_array = IntArrayFromInts(outputs_array_data);
+
+  // TODO(See TfLiteSqueezeParams): We can't have dynamic data, at least not
+  // yet. Thus we allocate space for outputs_dims_array in the temporaries
+  // buffer.
+  int outputs_dims_array_data[max_num_dims + 1] = {
+      max_num_dims, 0, 0, 0, 0, 0, 0, 0, 0};
+  TfLiteIntArray* outputs_dims_array =
+      IntArrayFromInts(outputs_dims_array_data);
+
+  // Run op
+  TfLiteNode node;
+  node.inputs = inputs_array;
+  node.outputs = outputs_array;
+  node.temporaries = outputs_dims_array;
+  node.user_data = nullptr;
+  node.builtin_data = nullptr;
+  node.custom_initial_data = nullptr;
+  node.custom_initial_data_size = 0;
+  node.delegate = nullptr;
+  TF_LITE_MICRO_EXPECT_NE(nullptr, registration->invoke);
+  if (expect_failure) {
+    TF_LITE_MICRO_EXPECT_EQ(kTfLiteError,
+                            registration->invoke(&context, &node));
+    return;
+  }
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, registration->invoke(&context, &node));
+
+  // Check the expanded dimensions are as expected
+  constexpr int outputs_index = 2;
+  TfLiteIntArray* output_dims = tensors[outputs_index].dims;
+
+  TF_LITE_MICRO_EXPECT_EQ(expected_output_dims->size, output_dims->size);
+  for (int i = 0; i < output_dims->size; ++i) {
+    TF_LITE_MICRO_EXPECT_EQ(expected_output_dims->data[i],
+                            output_dims->data[i]);
+  }
+
+  // Check that expand_dims does not mutate the data
+  const T* output_data = GetTensorData<T>(&tensors[outputs_index]);
+  int flat_size = 1;
+  for (int i = 0; i < output_dims->size; ++i) {
+    flat_size *= output_dims->data[i];
+  }
+  for (int i = 0; i < flat_size; ++i) {
+    TF_LITE_MICRO_EXPECT_NEAR(expected_output.begin()[i], output_data[i],
+                              1e-5f);
+  }
+}
+
+}  // namespace
+}  // namespace testing
+}  // namespace tflite
+
+TF_LITE_MICRO_TESTS_BEGIN
+
+#define TEST_EXPAND_DIMS(...)                                          \
+  using tflite::testing::TestExpandDims;                               \
+  tflite::testing::TestExpandDims<float, kTfLiteFloat32>(__VA_ARGS__); \
+  tflite::testing::TestExpandDims<uint8_t, kTfLiteUInt8>(__VA_ARGS__); \
+  tflite::testing::TestExpandDims<int8_t, kTfLiteInt8>(__VA_ARGS__);
+
+TF_LITE_MICRO_TEST(ExpandDimsPositiveAxis) {
+  uint8_t output_data_buffer[4 * 4];
+  constexpr int num_axis_dims = 1;
+  constexpr int num_input_dims = 2;
+  constexpr int num_expected_output_dims = 3;
+
+  // expand_axis == 0
+  TEST_EXPAND_DIMS({num_input_dims, 2, 2},               // input_dims
+                   {1, 2, 3, 4},                         // input_data
+                   {num_axis_dims, 1},                   // expand axis dims
+                   {0},                                  // expand axis
+                   {num_expected_output_dims, 1, 2, 2},  // expected_output_dims
+                   {1, 2, 3, 4}, output_data_buffer      // expected_output
+  );
+
+  // expand_axis == 2
+  TEST_EXPAND_DIMS({num_input_dims, 2, 2},               // input_dims
+                   {1, 2, 3, 4},                         // input_data
+                   {num_axis_dims, 1},                   // expand axis dims
+                   {2},                                  // expand axis
+                   {num_expected_output_dims, 2, 2, 1},  // expected_output_dims
+                   {1, 2, 3, 4}, output_data_buffer      // expected_output
+  );
+}
+
+TF_LITE_MICRO_TEST(ExpandDimsNegativeAxis) {
+  uint8_t output_data_buffer[4 * 4];
+  constexpr int num_axis_dims = 1;
+  constexpr int num_input_dims = 2;
+  constexpr int num_expected_output_dims = 3;
+
+  // expand_axis == -1
+  TEST_EXPAND_DIMS({num_input_dims, 2, 2},               // input_dims
+                   {1, 2, 3, 4},                         // input_data
+                   {num_axis_dims, 1},                   // expand axis dims
+                   {-1},                                 // expand axis
+                   {num_expected_output_dims, 2, 2, 1},  // expected_output_dims
+                   {1, 2, 3, 4}, output_data_buffer      // expected_output
+  );
+
+  // expand_axis == -3
+  TEST_EXPAND_DIMS({num_input_dims, 2, 2},               // input_dims
+                   {1, 2, 3, 4},                         // input_data
+                   {num_axis_dims, 1},                   // expand axis dims
+                   {-3},                                 // expand axis
+                   {num_expected_output_dims, 1, 2, 2},  // expected_output_dims
+                   {1, 2, 3, 4}, output_data_buffer      // expected_output
+  );
+}
+
+TF_LITE_MICRO_TEST(ExpandDimsPositiveInvalidRangeAxis) {
+  uint8_t output_data_buffer[4 * 4];
+  constexpr int num_axis_dims = 1;
+  constexpr int num_input_dims = 2;
+  constexpr int num_expected_output_dims = 3;
+
+  // expand_axis == 3
+  TEST_EXPAND_DIMS({num_input_dims, 2, 2},      // input_dims
+                   {1, 2, 3, 4},                // input_data
+                   {num_axis_dims, 1},          // expand axis dims
+                   {3},                         // expand axis
+                   {num_expected_output_dims},  // expected_output_dims
+                   {}, output_data_buffer,      // expected_output
+                   true                         // expected fail
+  );
+}
+
+TF_LITE_MICRO_TEST(ExpandDimsNegativeInvalidRangeAxis) {
+  uint8_t output_data_buffer[4 * 4];
+  constexpr int num_axis_dims = 1;
+  constexpr int num_input_dims = 2;
+  constexpr int num_expected_output_dims = 3;
+
+  // expand_axis == -3
+  TEST_EXPAND_DIMS({num_input_dims, 2, 2},      // input_dims
+                   {1, 2, 3, 4},                // input_data
+                   {num_axis_dims, 1},          // expand axis dims
+                   {-4},                        // expand axis
+                   {num_expected_output_dims},  // expected_output_dims
+                   {}, output_data_buffer,      // expected_output
+                   true                         // expected fail
+  );
+}
+
+TF_LITE_MICRO_TEST(ExpandDimsInvalidNonScalarAxis) {
+  uint8_t output_data_buffer[4 * 4];
+  constexpr int num_axis_dims = 1;
+  constexpr int num_input_dims = 2;
+  constexpr int num_expected_output_dims = 3;
+
+  // expand_axis == {0, 1}
+  TEST_EXPAND_DIMS({num_input_dims, 2, 2},      // input_dims
+                   {1, 2, 3, 4},                // input_data
+                   {num_axis_dims, 2},          // expand axis dims
+                   {0, 1},                      // expand axis
+                   {num_expected_output_dims},  // expected_output_dims
+                   {}, output_data_buffer,      // expected_output
+                   true                         // expected fail
+  );
+}
+
+#undef TEST_EXPAND_DIMS
+TF_LITE_MICRO_TESTS_END

--- a/tensorflow/lite/micro/kernels/micro_ops.h
+++ b/tensorflow/lite/micro/kernels/micro_ops.h
@@ -41,6 +41,7 @@ TfLiteRegistration* Register_COS();
 TfLiteRegistration* Register_DEPTHWISE_CONV_2D();
 TfLiteRegistration* Register_DEQUANTIZE();
 TfLiteRegistration* Register_EQUAL();
+TfLiteRegistration* Register_EXPAND_DIMS();
 TfLiteRegistration* Register_FLOOR();
 TfLiteRegistration* Register_FULLY_CONNECTED();
 TfLiteRegistration* Register_GREATER();


### PR DESCRIPTION
Add TfLite micro ExpandDims reference kernel and tests (int8, uint8, float32)

Signed-off-by: SiCongLi <sicong.li@arm.com>