### PR TITLE
Enable `model.add_metrics` with non-default floatx symbolic tensors.

### DIFF
--- a/tensorflow/python/keras/engine/base_layer_utils.py
+++ b/tensorflow/python/keras/engine/base_layer_utils.py
@@ -44,7 +44,7 @@ def create_mean_metric(value, name=None):
   # import keras will import base_layer and then this module, and metric relies
   # on base_layer, which result into a cyclic dependency.
   from tensorflow.python.keras import metrics as metrics_module  # pylint: disable=g-import-not-at-top
-  metric_obj = metrics_module.Mean(name=name)
+  metric_obj = metrics_module.Mean(name=name, dtype=value.dtype)
   return metric_obj, metric_obj(value)
 
 

--- a/tensorflow/python/keras/engine/network.py
+++ b/tensorflow/python/keras/engine/network.py
@@ -1477,7 +1477,8 @@ class Network(base_layer.Layer):
     new_nodes, new_layers = _map_subgraph_network(self.inputs, [symbolic_loss])
     # Losses must be keyed on inputs no matter what in order to be supported in
     # DistributionStrategy.
-    add_loss_layer = base_layer.AddLoss(unconditional=False)
+    add_loss_layer = base_layer.AddLoss(unconditional=False,
+                                        dtype=symbolic_loss.dtype)
     add_loss_layer(symbolic_loss)
     new_nodes.extend(add_loss_layer.inbound_nodes)
     new_layers.append(add_loss_layer)
@@ -1485,7 +1486,8 @@ class Network(base_layer.Layer):
 
   def _graph_network_add_metric(self, value, aggregation, name):
     new_nodes, new_layers = _map_subgraph_network(self.inputs, [value])
-    add_metric_layer = base_layer.AddMetric(aggregation, name)
+    add_metric_layer = base_layer.AddMetric(aggregation, name,
+                                            dtype=value.dtype)
     add_metric_layer(value)
     new_nodes.extend(add_metric_layer.inbound_nodes)
     new_layers.append(add_metric_layer)


### PR DESCRIPTION
#### General context:

The keras API allows to instantiate layers and, more generally, objects (such as `Mean` metrics) with an arbitrary `dtype`, which can be very practical to build `float64` (for high-precision computing) or `float16` (for limited memory usage) layers and models *without* tweaking the backend default `floatx` value. However, in a number of places, dtype selection is not working as one would expect; this PR aims at fixing one of those cases.

This specific issue can otherwise be avoided by temporarily hijacking the floatx value (_i.e._ using `tf.keras.backend.set_floatx(my_tensor.dtype)` before calling `model.add_metric(my_tensor, ...)` and calling `set_floatx` again afterwards to reset the prior value), but this feels like an improper hack, especially with the keras API enforcing dtype modularity in most places.

#### Specific issue:

When building a custom model, one might want to add some metrics tensor(s) using the `tf.keras.Model.add_metrics` method, _e.g._ in the case of a multi-output model built using the functional approach with symbolic tensors. In that case, the current implementation will reject said symbolic tensors if their dtype is not that of `tf.keras.backend.floatx()`, due to the use (in the private backend) of either a `Mean` or `AddMetric` wrapper.

Note that a similar problem could emerge when using the `add_loss` method (due to the backend use of `AddLoss` in certain cases), however I personally never encountered it.

#### Submitted fix:

This PR fixes the issue when adding symbolic tensors as losses or metrics, simply by having the aforementioned wrappers' `dtype` instantiation kwarg set equal to the wrapped tensor's `dtype` attribute. This results in no user-side nor backend function signature change.

#### Notes on testing:

I believe that dtype-changes-targetted tests could, in general, be beneficial to TensorFlow, as this is not the first (nor the last) issue of the sort I come across. I am, however, unsure as to how to integrate this in the current tests workflow, hence the lack of additional unit tests in the initial commit submitted with this PR.

It would seem to me that adding some dtype modularity to existing tests would be the proper way, but this might result in extensive increases of testing runtimes (it could, however, be a way to identify the dtype support issues that seem to be found here and there). IMHO, this could constitute a separate task altogether.