### PR TITLE
Change TrtConversionParams to class from NamedTuple and export it

### DIFF
--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -192,10 +192,11 @@ class TrtConversionParams(object):
     set parameters:
       DEFAULT_TRT_CONVERSION_PARAMS._replace(...)
     """
+    trt_conversion_params = TrtConversionParams()
     for k, v in vars().items():
       if v and (k != "self"):
-        setattr(self, k, v)
-    return self
+        setattr(trt_conversion_params, k, v)
+    return trt_conversion_params
 
 
 DEFAULT_TRT_CONVERSION_PARAMS = TrtConversionParams()

--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -123,8 +123,7 @@ class TrtConversionParams(object):
                is_dynamic_op=True,
                maximum_cached_engines=1,
                use_calibration=True,
-               max_batch_size=1,
-               allow_build_at_runtime=True):
+               max_batch_size=1):
     """Initialize TrtConversionParams.
 
     Args:
@@ -159,11 +158,6 @@ class TrtConversionParams(object):
         tensors were trained with fake quantization.
       max_batch_size: max size for the input batch. This parameter is only
         effective when is_dynamic_op=False which is not supported in TF 2.0.
-      allow_build_at_runtime: whether to build TensorRT engines during runtime.
-        If no TensorRT engine can be found in cache that can handle the given
-        inputs during runtime, then a new TensorRT engine is built at runtime
-        if allow_build_at_runtime=True, and otherwise native TF is used. This
-        argument is only effective if is_dynamic_op=True.
     """
     self.rewriter_config_template = rewriter_config_template
     self.max_workspace_size_bytes = max_workspace_size_bytes
@@ -173,7 +167,6 @@ class TrtConversionParams(object):
     self.maximum_cached_engines = maximum_cached_engines
     self.use_calibration = use_calibration
     self.max_batch_size = max_batch_size
-    self.allow_build_at_runtime = allow_build_at_runtime
 
   def _replace(self,
                rewriter_config_template=None,
@@ -183,8 +176,7 @@ class TrtConversionParams(object):
                is_dynamic_op=None,
                maximum_cached_engines=None,
                use_calibration=None,
-               max_batch_size=None,
-               allow_build_at_runtime=None):
+               max_batch_size=None):
     """Set value of class data members only if they are passed as arguments.
 
     We need this function for backward compatibility with NamedTuple

--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -190,6 +190,9 @@ class TrtConversionParams(object):
         setattr(trt_conversion_params, k, v)
     return trt_conversion_params
 
+  def __repr__(self):
+    return "TrtConversionParams" + str(vars(self))
+
 
 DEFAULT_TRT_CONVERSION_PARAMS = TrtConversionParams()
 

--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import collections
 import os
 import platform
 import tempfile
@@ -184,7 +183,7 @@ class TrtConversionParams(object):
                maximum_cached_engines=None,
                use_calibration=None,
                max_batch_size=None,
-              allow_build_at_runtime=None):
+               allow_build_at_runtime=None):
     """Set value of class data members only if they are passed as arguments.
 
     We need this function for backward compatibility with NamedTuple
@@ -193,7 +192,7 @@ class TrtConversionParams(object):
       DEFAULT_TRT_CONVERSION_PARAMS._replace(...)
     """
     for k, v in vars().items():
-      if v and (k is not "self"):
+      if v and (k != "self"):
         setattr(self, k, v)
     return self
 

--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -986,7 +986,7 @@ class TrtGraphConverterV2(object):
                input_saved_model_dir=None,
                input_saved_model_tags=None,
                input_saved_model_signature_key=None,
-               conversion_params=TrtConversionParams()):
+               conversion_params=None):
     """Initialize the converter.
 
     Args:
@@ -1001,6 +1001,8 @@ class TrtGraphConverterV2(object):
       ValueError: if the combination of the parameters is invalid.
     """
     assert context.executing_eagerly()
+    if conversion_params is None:
+      conversion_params = TrtConversionParams()
     _check_trt_version_compatibility()
     _check_conversion_params(conversion_params, is_v2=True)
 

--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -111,6 +111,7 @@ class TrtPrecisionMode(object):
 DEFAULT_TRT_MAX_WORKSPACE_SIZE_BYTES = 1 << 30
 
 
+@tf_export("experimental.tensorrt.ConversionParams", v1=[])
 class TrtConversionParams(object):
   """ A class to encapsulate parameters that are used for TF-TRT conversion."""
 
@@ -888,7 +889,7 @@ class TrtGraphConverterV2(object):
   1. FP32/FP16 precision
 
      ```python
-     params = DEFAULT_TRT_CONVERSION_PARAMS._replace(
+     params = tf.experimental.tensorrt.ConversionParams(
          precision_mode='FP16')
      converter = tf.experimental.tensorrt.Converter(
          input_saved_model_dir="my_dir", conversion_params=params)
@@ -904,7 +905,7 @@ class TrtGraphConverterV2(object):
   2. FP32/FP16 precision with pre-built engines
 
      ```python
-     params = DEFAULT_TRT_CONVERSION_PARAMS._replace(
+     params = tf.experimental.tensorrt.ConversionParams(
          precision_mode='FP16',
          # Set this to a large enough number so it can cache all the engines.
          maximum_cached_engines=16)
@@ -936,7 +937,7 @@ class TrtGraphConverterV2(object):
   3. INT8 precision and calibration with pre-built engines
 
      ```python
-     params = DEFAULT_TRT_CONVERSION_PARAMS._replace(
+     params = tf.experimental.tensorrt.ConversionParams(
          precision_mode='INT8',
          # Currently only one INT8 engine is supported in this mode.
          maximum_cached_engines=1,
@@ -974,7 +975,7 @@ class TrtGraphConverterV2(object):
                input_saved_model_dir=None,
                input_saved_model_tags=None,
                input_saved_model_signature_key=None,
-               conversion_params=DEFAULT_TRT_CONVERSION_PARAMS):
+               conversion_params=TrtConversionParams()):
     """Initialize the converter.
 
     Args:

--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -159,14 +159,28 @@ class TrtConversionParams(object):
       max_batch_size: max size for the input batch. This parameter is only
         effective when is_dynamic_op=False which is not supported in TF 2.0.
     """
-    self.rewriter_config_template = rewriter_config_template
-    self.max_workspace_size_bytes = max_workspace_size_bytes
-    self.precision_mode = precision_mode
-    self.minimum_segment_size = minimum_segment_size
-    self.is_dynamic_op = is_dynamic_op
-    self.maximum_cached_engines = maximum_cached_engines
-    self.use_calibration = use_calibration
-    self.max_batch_size = max_batch_size
+    super(TrtConversionParams, self).__setattr__(
+        "rewriter_config_template", rewriter_config_template)
+    super(TrtConversionParams, self).__setattr__(
+        "max_workspace_size_bytes", max_workspace_size_bytes)
+    super(TrtConversionParams, self).__setattr__(
+        "precision_mode", precision_mode)
+    super(TrtConversionParams, self).__setattr__(
+        "minimum_segment_size", minimum_segment_size)
+    super(TrtConversionParams, self).__setattr__(
+        "is_dynamic_op", is_dynamic_op)
+    super(TrtConversionParams, self).__setattr__(
+        "maximum_cached_engines", maximum_cached_engines)
+    super(TrtConversionParams, self).__setattr__(
+        "use_calibration", use_calibration)
+    super(TrtConversionParams, self).__setattr__(
+        "max_batch_size", max_batch_size)
+
+  def __setattr__(self, key, value):
+    """Override __setattr__ to make class immutable."""
+    raise AttributeError(
+        "{} is immutable and thus cannot change its attributes".format(
+            self.__class__))
 
   def _replace(self,
                rewriter_config_template=None,
@@ -184,10 +198,11 @@ class TrtConversionParams(object):
     set parameters:
       DEFAULT_TRT_CONVERSION_PARAMS._replace(...)
     """
-    trt_conversion_params = TrtConversionParams()
+    conv_params_dict = {}
     for k, v in vars().items():
-      if v and (k != "self"):
-        setattr(trt_conversion_params, k, v)
+      if (v != None) and (k not in ("self", "conv_params_dict")):
+        conv_params_dict[k] = v
+    trt_conversion_params = TrtConversionParams(**conv_params_dict)
     return trt_conversion_params
 
   def __repr__(self):

--- a/tensorflow/python/compiler/tensorrt/trt_convert_windows.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert_windows.py
@@ -26,6 +26,66 @@ if platform.system() != "Windows":
   raise RuntimeError(
       "This module is expected to be loaded only on Windows platform.")
 
+@tf_export("experimental.tensorrt.ConversionParams", v1=[])
+class TrtConversionParams(object):
+  """ A class to encapsulate parameters that are used for TF-TRT conversion."""
+
+  def __init__(self,
+               rewriter_config_template=None,
+               max_workspace_size_bytes=DEFAULT_TRT_MAX_WORKSPACE_SIZE_BYTES,
+               precision_mode=TrtPrecisionMode.FP32,
+               minimum_segment_size=3,
+               is_dynamic_op=True,
+               maximum_cached_engines=1,
+               use_calibration=True,
+               max_batch_size=1,
+               allow_build_at_runtime=True):
+    """Initialize TrtConversionParams.
+
+    Args:
+      rewriter_config_template: a template RewriterConfig proto used to create a
+        TRT-enabled RewriterConfig. If None, it will use a default one.
+      max_workspace_size_bytes: the maximum GPU temporary memory which the TRT
+        engine can use at execution time. This corresponds to the
+        'workspaceSize' parameter of nvinfer1::IBuilder::setMaxWorkspaceSize().
+      precision_mode: one of TrtPrecisionMode.supported_precision_modes().
+      minimum_segment_size: the minimum number of nodes required for a subgraph
+        to be replaced by TRTEngineOp.
+      is_dynamic_op: whether to generate dynamic TRT ops which will build the
+        TRT network and engine at run time. i.e. Since TensorRT version < 6.0
+        does not support dynamic dimensions other than the batch dimension,
+        when the TensorFlow graph has a non-batch dimension of dynamic size,
+        we would need to enable this option. This option should be set to True
+        in TF 2.0.
+      maximum_cached_engines: max number of cached TRT engines for dynamic TRT
+        ops. Created TRT engines for a dynamic dimension are cached. This is
+        the maximum number of engines that can be cached. If the number of
+        cached engines is already at max but none of them supports the input
+        shapes, the TRTEngineOp will fall back to run the original TF subgraph
+        that corresponds to the TRTEngineOp.
+      use_calibration: this argument is ignored if precision_mode is not INT8.
+        If set to True, a calibration graph will be created to calibrate the
+        missing ranges. The calibration graph must be converted to an inference
+        graph by running calibration with calibrate(). If set to False,
+        quantization nodes will be expected for every tensor in the graph
+        (exlcuding those which will be fused). If a range is missing, an error
+        will occur. Please note that accuracy may be negatively affected if
+        there is a mismatch between which tensors TRT quantizes and which
+        tensors were trained with fake quantization.
+      max_batch_size: max size for the input batch. This parameter is only
+        effective when is_dynamic_op=False which is not supported in TF 2.0.
+      allow_build_at_runtime: whether to build TensorRT engines during runtime.
+        If no TensorRT engine can be found in cache that can handle the given
+        inputs during runtime, then a new TensorRT engine is built at runtime
+        if allow_build_at_runtime=True, and otherwise native TF is used. This
+        argument is only effective if is_dynamic_op=True.
+
+    Raises:
+      NotImplementedError: TRT is not supported on Windows.
+    """
+    raise NotImplementedError(
+        "TensorRT integration is not available on Windows.")
+
 
 @tf_export("experimental.tensorrt.Converter", v1=[])
 class TrtConverterWindows(object):

--- a/tensorflow/python/compiler/tensorrt/trt_convert_windows.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert_windows.py
@@ -26,6 +26,18 @@ if platform.system() != "Windows":
   raise RuntimeError(
       "This module is expected to be loaded only on Windows platform.")
 
+
+class TrtPrecisionMode(object):
+  FP32 = "FP32"
+  FP16 = "FP16"
+  INT8 = "INT8"
+
+
+# Use a large enough number as the default max_workspace_size for TRT engines,
+# so it can produce reasonable performance results with the default.
+DEFAULT_TRT_MAX_WORKSPACE_SIZE_BYTES = 1 << 30
+
+
 @tf_export("experimental.tensorrt.ConversionParams", v1=[])
 class TrtConversionParams(object):
   """ A class to encapsulate parameters that are used for TF-TRT conversion."""

--- a/tensorflow/python/compiler/tensorrt/trt_convert_windows.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert_windows.py
@@ -38,8 +38,7 @@ class TrtConversionParams(object):
                is_dynamic_op=True,
                maximum_cached_engines=1,
                use_calibration=True,
-               max_batch_size=1,
-               allow_build_at_runtime=True):
+               max_batch_size=1):
     """Initialize TrtConversionParams.
 
     Args:
@@ -74,11 +73,6 @@ class TrtConversionParams(object):
         tensors were trained with fake quantization.
       max_batch_size: max size for the input batch. This parameter is only
         effective when is_dynamic_op=False which is not supported in TF 2.0.
-      allow_build_at_runtime: whether to build TensorRT engines during runtime.
-        If no TensorRT engine can be found in cache that can handle the given
-        inputs during runtime, then a new TensorRT engine is built at runtime
-        if allow_build_at_runtime=True, and otherwise native TF is used. This
-        argument is only effective if is_dynamic_op=True.
 
     Raises:
       NotImplementedError: TRT is not supported on Windows.

--- a/tensorflow/tools/api/golden/v2/tensorflow.experimental.tensorrt.-conversion-params.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.experimental.tensorrt.-conversion-params.pbtxt
@@ -1,0 +1,9 @@
+path: "tensorflow.experimental.tensorrt.ConversionParams"
+tf_class {
+  is_instance: "<class \'tensorflow.python.compiler.tensorrt.trt_convert.TrtConversionParams\'>"
+  is_instance: "<type \'object\'>"
+  member_method {
+    name: "__init__"
+    argspec: "args=[\'self\', \'rewriter_config_template\', \'max_workspace_size_bytes\', \'precision_mode\', \'minimum_segment_size\', \'is_dynamic_op\', \'maximum_cached_engines\', \'use_calibration\', \'max_batch_size\'], varargs=None, keywords=None, defaults=[\'None\', \'1073741824\', \'FP32\', \'3\', \'True\', \'1\', \'True\', \'1\'], "
+  }
+}

--- a/tensorflow/tools/api/golden/v2/tensorflow.experimental.tensorrt.-converter.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.experimental.tensorrt.-converter.pbtxt
@@ -4,7 +4,7 @@ tf_class {
   is_instance: "<type \'object\'>"
   member_method {
     name: "__init__"
-    argspec: "args=[\'self\', \'input_saved_model_dir\', \'input_saved_model_tags\', \'input_saved_model_signature_key\', \'conversion_params\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\', \"TrtConversionParams{\'rewriter_config_template\': None, \'max_workspace_size_bytes\': 1073741824, \'precision_mode\': \'FP32\', \'minimum_segment_size\': 3, \'is_dynamic_op\': True, \'maximum_cached_engines\': 1, \'use_calibration\': True, \'max_batch_size\': 1}\"], "
+    argspec: "args=[\'self\', \'input_saved_model_dir\', \'input_saved_model_tags\', \'input_saved_model_signature_key\', \'conversion_params\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\', \'None\'], "
   }
   member_method {
     name: "build"

--- a/tensorflow/tools/api/golden/v2/tensorflow.experimental.tensorrt.-converter.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.experimental.tensorrt.-converter.pbtxt
@@ -4,7 +4,7 @@ tf_class {
   is_instance: "<type \'object\'>"
   member_method {
     name: "__init__"
-    argspec: "args=[\'self\', \'input_saved_model_dir\', \'input_saved_model_tags\', \'input_saved_model_signature_key\', \'conversion_params\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\', \"TrtConversionParams(rewriter_config_template=None, max_workspace_size_bytes=1073741824, precision_mode=\'FP32\', minimum_segment_size=3, is_dynamic_op=True, maximum_cached_engines=1, use_calibration=True, max_batch_size=1)\"], "
+    argspec: "args=[\'self\', \'input_saved_model_dir\', \'input_saved_model_tags\', \'input_saved_model_signature_key\', \'conversion_params\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\', \'<tensorflow.python.compiler.tensorrt.trt_convert.TrtConversionParams object instance>\'], "
   }
   member_method {
     name: "build"

--- a/tensorflow/tools/api/golden/v2/tensorflow.experimental.tensorrt.-converter.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.experimental.tensorrt.-converter.pbtxt
@@ -4,7 +4,7 @@ tf_class {
   is_instance: "<type \'object\'>"
   member_method {
     name: "__init__"
-    argspec: "args=[\'self\', \'input_saved_model_dir\', \'input_saved_model_tags\', \'input_saved_model_signature_key\', \'conversion_params\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\', \'<tensorflow.python.compiler.tensorrt.trt_convert.TrtConversionParams object instance>\'], "
+    argspec: "args=[\'self\', \'input_saved_model_dir\', \'input_saved_model_tags\', \'input_saved_model_signature_key\', \'conversion_params\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\', \"TrtConversionParams{\'rewriter_config_template\': None, \'max_workspace_size_bytes\': 1073741824, \'precision_mode\': \'FP32\', \'minimum_segment_size\': 3, \'is_dynamic_op\': True, \'maximum_cached_engines\': 1, \'use_calibration\': True, \'max_batch_size\': 1}\"], "
   }
   member_method {
     name: "build"

--- a/tensorflow/tools/api/golden/v2/tensorflow.experimental.tensorrt.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.experimental.tensorrt.pbtxt
@@ -1,6 +1,10 @@
 path: "tensorflow.experimental.tensorrt"
 tf_module {
   member {
+    name: "ConversionParams"
+    mtype: "<type \'type\'>"
+  }
+  member {
     name: "Converter"
     mtype: "<type \'type\'>"
   }


### PR DESCRIPTION
- Changes NamedTuple to a class.
- Supports backward compatibility by providing _replace() method to emulate the behavior of _replace() in NamedTuple.
- Exports ConversionParams to API