### PR TITLE
Add additional padding layer to deconv converter to fix output_shape

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -2229,24 +2229,33 @@ Status ConvertConv2DHelper(OpConverterParams* params, int group,
     layer->setDilation(dilation);
     conv_layer = layer;
   }
-  nvinfer1::ITensor* conv_output_tensor = conv_layer->getOutput(0);
-  nvinfer1::ITensor* output_tensor;
+  nvinfer1::ITensor* output_tensor = conv_layer->getOutput(0);
   // Add an extra padding for Deconv because TRT doesn't accept the
   // argument output_shape and thus the TRT output shape could be wrong
   // in case of strides>1.
   if (is_conv2d_backprop_input) {
     auto tf_output_shape = backprop_output_size.GetTrtDims();
-    nvinfer1::Dims trt_output_shape = conv_output_tensor->getDimensions();
-    const int heightDiff = tf_output_shape.d[h_index - 1] - trt_output_shape.d[1];
-    const int widthDiff = tf_output_shape.d[w_index - 1] - trt_output_shape.d[2];
-    nvinfer1::DimsHW pre_padding(0, 0);
-    nvinfer1::DimsHW post_padding(heightDiff, widthDiff);
-    nvinfer1::IPaddingLayer* padding_layer = params->converter->network()->addPadding(
-        *conv_output_tensor, pre_padding, post_padding);
-    output_tensor = padding_layer->getOutput(0);
-  }
-  else {
-    output_tensor = conv_output_tensor;
+    nvinfer1::Dims trt_output_shape = output_tensor->getDimensions();
+    // What determines the padding size is the difference between the given
+    // input_sizes (tf_output_shape) and TRT computed size.
+    const int height_diff = tf_output_shape.d[h_index - 1] - trt_output_shape.d[1];
+    const int width_diff = tf_output_shape.d[w_index - 1] - trt_output_shape.d[2];
+    if ((height_diff < 0) || (width_diff < 0)) {
+      return errors::InvalidArgument(
+          "input_sizes argument of Conv2DBackprop (i.e. output_shape argument of conv2d_transpose)",
+          "is too small for the given out_backprop argument of Conv2DBackprop (i.e. input argument of conv2d_transpose).",
+          "(", tf_output_shape.d[h_index - 1], ", ", tf_output_shape.d[w_index - 1], ") >= ",
+          "(", trt_output_shape.d[1], ", ", trt_output_shape.d[2], ")",
+          node_def.name());
+    }
+    // Only add a padding layer if padding sizes are larger than 0
+    if ((height_diff > 0) || (width_diff > 0)) {
+      nvinfer1::DimsHW pre_padding(0, 0);
+      nvinfer1::DimsHW post_padding(height_diff, width_diff);
+      nvinfer1::IPaddingLayer* padding_layer = params->converter->network()->addPadding(
+          *output_tensor, pre_padding, post_padding);
+      output_tensor = padding_layer->getOutput(0);
+    }
   }
   // Restore transpose.
   if (need_transpose) {

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -3942,6 +3942,31 @@ TEST_F(OpConverterTest, ConvertConv2D) {
                  /*is_conv2d_backprop_input=*/true,
                  /*expected_output_dims=*/{1, 2, 4},
                  /*expected_output=*/{0, 0, -1, 1, -2, 2, -3, 3}},
+      // Transpose Strided NHWC
+      TestParams{/*input_dims=*/{2, 2, 1},
+                 /*input=*/{0, 1, 2, 3},
+                 /*filter_dims=*/{1, 2, 1, 1},
+                 /*filter=*/{-1, 1},
+                 /*strides=*/{1, 1, 2, 1},
+                 /*padding=*/"SAME",
+                 /*data_format=*/"NHWC",
+                 /*dilations=*/{1, 1, 1, 1},
+                 /*is_conv2d_backprop_input=*/true,
+                 /*expected_output_dims=*/{2, 4, 1},
+                 /*expected_output=*/{0, 0, -1, 1, -2, 2, -3, 3}},
+      // Transpose Strided NHWC with VALID padding
+      TestParams{/*input_dims=*/{3, 1, 1},
+                 /*input=*/{0, 1, 2},
+                 /*filter_dims=*/{2, 1, 1, 1},
+                 /*filter=*/{-1, 1},
+                 /*strides=*/{1, 2, 1, 1},
+                 /*padding=*/"VALID",
+                 /*data_format=*/"NHWC",
+                 /*dilations=*/{1, 1, 1, 1},
+                 /*is_conv2d_backprop_input=*/true,
+                 /*expected_output_dims=*/{7, 1, 1},
+                 /*expected_output=*/{0, 0, -1, 1, -2, 2, 0}},
+
   };
 
   for (int i = 0; i < kConv2DOKCases; i++) {
@@ -3955,7 +3980,7 @@ TEST_F(OpConverterTest, ConvertConv2D) {
     if (ok_params[i].is_conv2d_backprop_input) {
       AddTestWeights<float>(
           "input_sizes",
-          {static_cast<int>(ok_params[i].expected_output.size())},
+          ok_params[i].expected_output_dims,
           ok_params[i].expected_output);
     }
     RunValidationAndConversion(node_def);


### PR DESCRIPTION
- TensorFlow has the argument output_shape in Deconv API (conv2d_transpose) that specifies the output size, otherwise the output size is ambiguous if strides>1.
- TRT API for IDeconvolution doesn't have such an argument, and thus the size of the TRT output tensor is off if stride>1.
- This PR adds a padding layer on the output of Deconv if needed, in order to fix the output size.

