### PR TITLE
[tflite] fix handling of avgpool in NNAPI delegate

### DIFF
--- a/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
+++ b/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
@@ -1310,10 +1310,11 @@ bool NNAPIDelegateKernel::Validate(
       auto builtin = reinterpret_cast<TfLitePoolParams*>(node->builtin_data);
       // TODO(b/138756912): Large filter window would overflow on the
       // reference CPU path.
-      Expect(is_accelerator_specified ||
+      Expect(android_sdk_version >= kMinSdkVersionForNNAPI12 ||
                  (builtin->filter_width * builtin->filter_height <= 256),
              NNAPIValidationFailureType::kUnsupportedOperandSize,
-             "Large filter window would overflow on the reference CPU path",
+             "Before NNAPI 1.2, large filter window would overflow on the "
+             "reference CPU path",
              &val_ctx);
     } break;
     case kTfLiteBuiltinMaxPool2d: {


### PR DESCRIPTION
After NNAPI 1.2, the h * w <= 256 limit is gone, see its CPU avgpool kernel [code](https://android.googlesource.com/platform/external/tensorflow/+/3589bbfbc68ddb8a4c87f90bf7c8dc87c5a50556%5E%21/tensorflow/lite/kernels/internal/optimized/optimized_ops.h) here