### PR TITLE
Revert "[r2.1 cherry-pick] Fix pip package API generation"

### DIFF
--- a/tensorflow/api_template.__init__.py
+++ b/tensorflow/api_template.__init__.py
@@ -119,11 +119,11 @@ def _running_from_pip_package():
       _current_file_location.startswith(dir_) for dir_ in _site_packages_dirs)
 
 if _running_from_pip_package():
-  for _s in _site_packages_dirs:
+  for s in _site_packages_dirs:
     # TODO(gunan): Add sanity checks to loaded modules here.
-    _plugin_dir = _os.path.join(_s, 'tensorflow-plugins')
-    if _fi.file_exists(_plugin_dir):
-      _ll.load_library(_plugin_dir)
+    plugin_dir = _os.path.join(s, 'tensorflow-plugins')
+    if _fi.file_exists(plugin_dir):
+      _ll.load_library(plugin_dir)
 
 # Add module aliases
 if hasattr(_current_module, 'keras'):
@@ -136,5 +136,3 @@ if hasattr(_current_module, 'keras'):
   setattr(_current_module, "optimizers", optimizers)
   setattr(_current_module, "initializers", initializers)
 # pylint: enable=undefined-variable
-
-# __all__ PLACEHOLDER

--- a/tensorflow/api_template_v1.__init__.py
+++ b/tensorflow/api_template_v1.__init__.py
@@ -132,10 +132,9 @@ def _running_from_pip_package():
       _current_file_location.startswith(dir_) for dir_ in _site_packages_dirs)
 
 if _running_from_pip_package():
-  for _s in _site_packages_dirs:
+  for s in _site_packages_dirs:
     # TODO(gunan): Add sanity checks to loaded modules here.
-    _plugin_dir = _os.path.join(_s, 'tensorflow-plugins')
-    if _fi.file_exists(_plugin_dir):
-      _ll.load_library(_plugin_dir)
+    plugin_dir = _os.path.join(s, 'tensorflow-plugins')
+    if _fi.file_exists(plugin_dir):
+      _ll.load_library(plugin_dir)
 
-# __all__ PLACEHOLDER

--- a/tensorflow/python/tools/api/generator/create_python_api_test.py
+++ b/tensorflow/python/tools/api/generator/create_python_api_test.py
@@ -62,7 +62,7 @@ class CreatePythonApiTest(test.TestCase):
     del sys.modules[_MODULE_NAME]
 
   def testFunctionImportIsAdded(self):
-    imports, _, _ = create_python_api.get_api_init_text(
+    imports, _ = create_python_api.get_api_init_text(
         packages=[create_python_api._DEFAULT_PACKAGE],
         output_package='tensorflow',
         api_name='tensorflow',
@@ -97,7 +97,7 @@ class CreatePythonApiTest(test.TestCase):
                      msg='compat.v1 in %s' % str(imports.keys()))
 
   def testClassImportIsAdded(self):
-    imports, _, _ = create_python_api.get_api_init_text(
+    imports, _ = create_python_api.get_api_init_text(
         packages=[create_python_api._DEFAULT_PACKAGE],
         output_package='tensorflow',
         api_name='tensorflow',
@@ -116,7 +116,7 @@ class CreatePythonApiTest(test.TestCase):
         msg='%s not in %s' % (expected_import, str(imports)))
 
   def testConstantIsAdded(self):
-    imports, _, _ = create_python_api.get_api_init_text(
+    imports, _ = create_python_api.get_api_init_text(
         packages=[create_python_api._DEFAULT_PACKAGE],
         output_package='tensorflow',
         api_name='tensorflow',
@@ -132,7 +132,7 @@ class CreatePythonApiTest(test.TestCase):
                     msg='%s not in %s' % (expected, str(imports)))
 
   def testCompatModuleIsAdded(self):
-    imports, _, _ = create_python_api.get_api_init_text(
+    imports, _ = create_python_api.get_api_init_text(
         packages=[create_python_api._DEFAULT_PACKAGE],
         output_package='tensorflow',
         api_name='tensorflow',
@@ -144,7 +144,7 @@ class CreatePythonApiTest(test.TestCase):
                     msg='compat.v1.test not in %s' % str(imports.keys()))
 
   def testNestedCompatModulesAreAdded(self):
-    imports, _, _ = create_python_api.get_api_init_text(
+    imports, _ = create_python_api.get_api_init_text(
         packages=[create_python_api._DEFAULT_PACKAGE],
         output_package='tensorflow',
         api_name='tensorflow',

--- a/tensorflow/virtual_root_template_v1.__init__.py
+++ b/tensorflow/virtual_root_template_v1.__init__.py
@@ -132,4 +132,7 @@ try:
 except NameError:
   pass
 
+# Manually patch keras and estimator so tf.keras and tf.estimator work
+keras = _sys.modules["tensorflow.keras"]
+if not _root_estimator: estimator = _sys.modules["tensorflow.estimator"]
 # LINT.ThenChange(//tensorflow/virtual_root_template_v2.__init__.py.oss)

--- a/tensorflow/virtual_root_template_v2.__init__.py
+++ b/tensorflow/virtual_root_template_v2.__init__.py
@@ -126,4 +126,14 @@ try:
 except NameError:
   pass
 
+# TODO(mihaimaruseac): Revisit all of this once we release 2.1
+# Manually patch keras and estimator so tf.keras and tf.estimator work
+keras = _sys.modules["tensorflow.keras"]
+if not _root_estimator: estimator = _sys.modules["tensorflow.estimator"]
+# Also import module aliases
+try:
+  from tensorflow_core import losses, metrics, initializers, optimizers
+except ImportError:
+  pass
+
 # LINT.ThenChange(//tensorflow/virtual_root_template_v1.__init__.py.oss)


### PR DESCRIPTION
Reverts tensorflow/tensorflow#34822

Unfortunately having #34822 in in a pip package causes segfaults on `python -c "import scipy; import tensorflow"`.