### PR TITLE
Update TFLu (micro) to use AmbiqSuite SDK Release 2.2.0 for Apollo3

### DIFF
--- a/tensorflow/lite/micro/examples/hello_world/README.md
+++ b/tensorflow/lite/micro/examples/hello_world/README.md
@@ -163,14 +163,14 @@ Enter the following command to set up some dummy cryptographic keys we can use
 for development:
 
 ```
-cp tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.0.0/tools/apollo3_scripts/keys_info0.py \
-tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.0.0/tools/apollo3_scripts/keys_info.py
+cp tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.2.0/tools/apollo3_scripts/keys_info0.py \
+tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.2.0/tools/apollo3_scripts/keys_info.py
 ```
 
 Next, run the following command to create a signed binary:
 
 ```
-python3 tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.0.0/tools/apollo3_scripts/create_cust_image_blob.py \
+python3 tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.2.0/tools/apollo3_scripts/create_cust_image_blob.py \
 --bin tensorflow/lite/micro/tools/make/gen/sparkfun_edge_cortex-m4/bin/hello_world.bin \
 --load-address 0xC000 \
 --magic-num 0xCB \
@@ -183,7 +183,7 @@ command to create a final version of the file that can be used to flash our
 device with the bootloader script we will use in the next step:
 
 ```
-python3 tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.0.0/tools/apollo3_scripts/create_cust_wireupdate_blob.py \
+python3 tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.2.0/tools/apollo3_scripts/create_cust_wireupdate_blob.py \
 --load-address 0x20000 \
 --bin main_nonsecure_ota.bin \
 -i 6 \
@@ -219,7 +219,7 @@ hit the button marked `RST`. Continue holding the button marked `14` while
 running the following command:
 
 ```
-python3 tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.0.0/tools/apollo3_scripts/uart_wired_update.py \
+python3 tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.2.0/tools/apollo3_scripts/uart_wired_update.py \
 -b ${BAUD_RATE} ${DEVICENAME} \
 -r 1 \
 -f main_nonsecure_wire.bin \

--- a/tensorflow/lite/micro/examples/magic_wand/README.md
+++ b/tensorflow/lite/micro/examples/magic_wand/README.md
@@ -179,14 +179,14 @@ Enter the following command to set up some dummy cryptographic keys we can use
 for development:
 
 ```
-cp tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.0.0/tools/apollo3_scripts/keys_info0.py \
-tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.0.0/tools/apollo3_scripts/keys_info.py
+cp tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.2.0/tools/apollo3_scripts/keys_info0.py \
+tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.2.0/tools/apollo3_scripts/keys_info.py
 ```
 
 Next, run the following command to create a signed binary:
 
 ```
-python3 tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.0.0/tools/apollo3_scripts/create_cust_image_blob.py \
+python3 tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.2.0/tools/apollo3_scripts/create_cust_image_blob.py \
 --bin tensorflow/lite/micro/tools/make/gen/sparkfun_edge_cortex-m4/bin/magic_wand.bin \
 --load-address 0xC000 \
 --magic-num 0xCB \
@@ -199,7 +199,7 @@ command to create a final version of the file that can be used to flash our
 device with the bootloader script we will use in the next step:
 
 ```
-python3 tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.0.0/tools/apollo3_scripts/create_cust_wireupdate_blob.py \
+python3 tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.2.0/tools/apollo3_scripts/create_cust_wireupdate_blob.py \
 --load-address 0x20000 \
 --bin main_nonsecure_ota.bin \
 -i 6 \
@@ -237,7 +237,7 @@ hit the button marked `RST`. Continue holding the button marked `14` while
 running the following command:
 
 ```
-python3 tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.0.0/tools/apollo3_scripts/uart_wired_update.py \
+python3 tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.2.0/tools/apollo3_scripts/uart_wired_update.py \
 -b ${BAUD_RATE} ${DEVICENAME} \
 -r 1 \
 -f main_nonsecure_wire.bin \

--- a/tensorflow/lite/micro/examples/magic_wand/sparkfun_edge/output_handler.cc
+++ b/tensorflow/lite/micro/examples/magic_wand/sparkfun_edge/output_handler.cc
@@ -15,11 +15,11 @@ limitations under the License.
 
 #include "tensorflow/lite/micro/examples/magic_wand/output_handler.h"
 
-#include "tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.0.0/boards/SparkFun_TensorFlow_Apollo3_BSP/bsp/am_bsp.h"
-#include "tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.0.0/boards/SparkFun_TensorFlow_Apollo3_BSP/examples/example1_edge_test/src/tf_accelerometer/tf_accelerometer.h"
-#include "tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.0.0/boards/SparkFun_TensorFlow_Apollo3_BSP/examples/example1_edge_test/src/tf_adc/tf_adc.h"
-#include "tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.0.0/mcu/apollo3/am_mcu_apollo.h"
-#include "tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.0.0/utils/am_util.h"
+#include "tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.2.0/boards/SparkFun_TensorFlow_Apollo3_BSP/bsp/am_bsp.h"
+#include "tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.2.0/boards/SparkFun_TensorFlow_Apollo3_BSP/examples/example1_edge_test/src/tf_accelerometer/tf_accelerometer.h"
+#include "tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.2.0/boards/SparkFun_TensorFlow_Apollo3_BSP/examples/example1_edge_test/src/tf_adc/tf_adc.h"
+#include "tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.2.0/mcu/apollo3/am_mcu_apollo.h"
+#include "tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.2.0/utils/am_util.h"
 
 void HandleOutput(tflite::ErrorReporter* error_reporter, int kind) {
   // The first time this method runs, set up our LEDs correctly

--- a/tensorflow/lite/micro/examples/micro_speech/README.md
+++ b/tensorflow/lite/micro/examples/micro_speech/README.md
@@ -121,14 +121,14 @@ Enter the following command to set up some dummy cryptographic keys we can use
 for development:
 
 ```
-cp tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.0.0/tools/apollo3_scripts/keys_info0.py \
-tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.0.0/tools/apollo3_scripts/keys_info.py
+cp tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.2.0/tools/apollo3_scripts/keys_info0.py \
+tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.2.0/tools/apollo3_scripts/keys_info.py
 ```
 
 Next, run the following command to create a signed binary:
 
 ```
-python3 tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.0.0/tools/apollo3_scripts/create_cust_image_blob.py \
+python3 tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.2.0/tools/apollo3_scripts/create_cust_image_blob.py \
 --bin tensorflow/lite/micro/tools/make/gen/sparkfun_edge_cortex-m4/bin/micro_speech.bin \
 --load-address 0xC000 \
 --magic-num 0xCB \
@@ -141,7 +141,7 @@ command to create a final version of the file that can be used to flash our
 device with the bootloader script we will use in the next step:
 
 ```
-python3 tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.0.0/tools/apollo3_scripts/create_cust_wireupdate_blob.py \
+python3 tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.2.0/tools/apollo3_scripts/create_cust_wireupdate_blob.py \
 --load-address 0x20000 \
 --bin main_nonsecure_ota.bin \
 -i 6 \
@@ -177,7 +177,7 @@ hit the button marked `RST`. Continue holding the button marked `14` while
 running the following command:
 
 ```
-python3 tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.0.0/tools/apollo3_scripts/uart_wired_update.py \
+python3 tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.2.0/tools/apollo3_scripts/uart_wired_update.py \
 -b ${BAUD_RATE} ${DEVICENAME} \
 -r 1 \
 -f main_nonsecure_wire.bin \

--- a/tensorflow/lite/micro/examples/person_detection/README.md
+++ b/tensorflow/lite/micro/examples/person_detection/README.md
@@ -208,14 +208,14 @@ Enter the following command to set up some dummy cryptographic keys we can use
 for development:
 
 ```
-cp tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.0.0/tools/apollo3_scripts/keys_info0.py \
-tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.0.0/tools/apollo3_scripts/keys_info.py
+cp tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.2.0/tools/apollo3_scripts/keys_info0.py \
+tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.2.0/tools/apollo3_scripts/keys_info.py
 ```
 
 Next, run the following command to create a signed binary:
 
 ```
-python3 tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.0.0/tools/apollo3_scripts/create_cust_image_blob.py \
+python3 tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.2.0/tools/apollo3_scripts/create_cust_image_blob.py \
 --bin tensorflow/lite/micro/tools/make/gen/sparkfun_edge_cortex-m4/bin/person_detection.bin \
 --load-address 0xC000 \
 --magic-num 0xCB \
@@ -228,7 +228,7 @@ command to create a final version of the file that can be used to flash our
 device with the bootloader script we will use in the next step:
 
 ```
-python3 tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.0.0/tools/apollo3_scripts/create_cust_wireupdate_blob.py \
+python3 tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.2.0/tools/apollo3_scripts/create_cust_wireupdate_blob.py \
 --load-address 0x20000 \
 --bin main_nonsecure_ota.bin \
 -i 6 \
@@ -264,7 +264,7 @@ hit the button marked `RST`. Continue holding the button marked `14` while
 running the following command:
 
 ```
-python3 tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.0.0/tools/apollo3_scripts/uart_wired_update.py \
+python3 tensorflow/lite/micro/tools/make/downloads/AmbiqSuite-Rel2.2.0/tools/apollo3_scripts/uart_wired_update.py \
 -b ${BAUD_RATE} ${DEVICENAME} \
 -r 1 \
 -f main_nonsecure_wire.bin \

--- a/tensorflow/lite/micro/tools/make/download_and_extract.sh
+++ b/tensorflow/lite/micro/tools/make/download_and_extract.sh
@@ -49,9 +49,6 @@ patch_am_sdk() {
   sed -i -e $'22s/\*(.text\*)/\*(.text\*)\\\n\\\n\\\t\/\* These are the C++ global constructors.  Stick them all here and\\\n\\\t \* then walk through the array in main() calling them all.\\\n\\\t \*\/\\\n\\\t_init_array_start = .;\\\n\\\tKEEP (\*(SORT(.init_array\*)))\\\n\\\t_init_array_end = .;\\\n\\\n\\\t\/\* XXX Currently not doing anything for global destructors. \*\/\\\n/g' "${dest_dir}/apollo3evb.ld"
   sed -i -e $'70s/} > SRAM/} > SRAM\\\n    \/\* Add this to satisfy reference to symbol "end" from libnosys.a(sbrk.o)\\\n     \* to denote the HEAP start.\\\n     \*\/\\\n   end = .;/g' "${dest_dir}/apollo3evb.ld"
 
-  # Workaround for bug in 2.0.0 SDK, remove once that's fixed.
-  sed -i -e $'s/#ifndef AM_HAL_GPIO_H/#ifdef __cplusplus\\\nextern "C" {\\\n#endif\\\n#ifndef AM_HAL_GPIO_H/g' ${am_dir}/mcu/apollo3/hal/am_hal_gpio.h
-
   # Add a delay after establishing serial connection
   sed -ir -E $'s/    with serial\.Serial\(args\.port, args\.baud, timeout=12\) as ser:/    with serial.Serial(args.port, args.baud, timeout=12) as ser:\\\n        # Patched.\\\n        import time\\\n        time.sleep(0.25)\\\n        # End patch./g' "${am_dir}/tools/apollo3_scripts/uart_wired_update.py"
 

--- a/tensorflow/lite/micro/tools/make/targets/apollo3evb_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/apollo3evb_makefile.inc
@@ -5,21 +5,21 @@ ifeq ($(TARGET),$(filter $(TARGET),apollo3evb sparkfun_edge))
   TARGET_TOOLCHAIN_PREFIX := arm-none-eabi-
   # Download the Ambiq Apollo3 SDK and set this variable to find the header
   # files:
-  APOLLO3_SDK := $(MAKEFILE_DIR)/downloads/AmbiqSuite-Rel2.2.0
+  APOLLO3_SDK := $(MAKEFILE_DIR)/downloads/$(AM_SDK_DEST)
   # Need a pointer to the GNU ARM toolchain for crtbegin.o for the fp functions
   # with the hard interfaces.
   GCC_ARM := $(MAKEFILE_DIR)/downloads/gcc_embedded/
 
   $(eval $(call add_third_party_download,$(GCC_EMBEDDED_URL),$(GCC_EMBEDDED_MD5),gcc_embedded,))
   $(eval $(call add_third_party_download,$(CMSIS_URL),$(CMSIS_MD5),cmsis,))
-  $(eval $(call add_third_party_download,$(AM_SDK_URL),$(AM_SDK_MD5),AmbiqSuite-Rel2.2.0,patch_am_sdk))
+  $(eval $(call add_third_party_download,$(AM_SDK_URL),$(AM_SDK_MD5),$(AM_SDK_DEST),patch_am_sdk))
   $(eval $(call add_third_party_download,$(AP3_URL),$(AP3_MD5),apollo3_ext,))
   $(eval $(call add_third_party_download,$(CUST_CMSIS_URL),$(CUST_CMSIS_MD5),CMSIS_ext,))
 
   ifeq ($(TARGET), sparkfun_edge)
-    $(eval $(call add_third_party_download,$(SPARKFUN_EDGE_BSP_URL),$(SPARKFUN_EDGE_BSP_MD5),AmbiqSuite-Rel2.2.0/boards/SparkFun_TensorFlow_Apollo3_BSP,))
+    $(eval $(call add_third_party_download,$(SPARKFUN_EDGE_BSP_URL),$(SPARKFUN_EDGE_BSP_MD5),$(AM_SDK_DEST)/boards/SparkFun_TensorFlow_Apollo3_BSP,))
     # Make sure that we download the full Ambiq SDK before the SparkFun one.
-$(MAKEFILE_DIR)/downloads/AmbiqSuite-Rel2.2.0/boards/SparkFun_TensorFlow_Apollo3_BSP: $(MAKEFILE_DIR)/downloads/AmbiqSuite-Rel2.2.0
+$(MAKEFILE_DIR)/downloads/$(AM_SDK_DEST)/boards/SparkFun_TensorFlow_Apollo3_BSP: $(MAKEFILE_DIR)/downloads/$(AM_SDK_DEST)
   endif
 
   # Use the faster depthwise conv implementation.

--- a/tensorflow/lite/micro/tools/make/targets/apollo3evb_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/apollo3evb_makefile.inc
@@ -5,21 +5,21 @@ ifeq ($(TARGET),$(filter $(TARGET),apollo3evb sparkfun_edge))
   TARGET_TOOLCHAIN_PREFIX := arm-none-eabi-
   # Download the Ambiq Apollo3 SDK and set this variable to find the header
   # files:
-  APOLLO3_SDK := $(MAKEFILE_DIR)/downloads/AmbiqSuite-Rel2.0.0
+  APOLLO3_SDK := $(MAKEFILE_DIR)/downloads/AmbiqSuite-Rel2.2.0
   # Need a pointer to the GNU ARM toolchain for crtbegin.o for the fp functions
   # with the hard interfaces.
   GCC_ARM := $(MAKEFILE_DIR)/downloads/gcc_embedded/
 
   $(eval $(call add_third_party_download,$(GCC_EMBEDDED_URL),$(GCC_EMBEDDED_MD5),gcc_embedded,))
   $(eval $(call add_third_party_download,$(CMSIS_URL),$(CMSIS_MD5),cmsis,))
-  $(eval $(call add_third_party_download,$(AM_SDK_URL),$(AM_SDK_MD5),AmbiqSuite-Rel2.0.0,patch_am_sdk))
+  $(eval $(call add_third_party_download,$(AM_SDK_URL),$(AM_SDK_MD5),AmbiqSuite-Rel2.2.0,patch_am_sdk))
   $(eval $(call add_third_party_download,$(AP3_URL),$(AP3_MD5),apollo3_ext,))
   $(eval $(call add_third_party_download,$(CUST_CMSIS_URL),$(CUST_CMSIS_MD5),CMSIS_ext,))
 
   ifeq ($(TARGET), sparkfun_edge)
-    $(eval $(call add_third_party_download,$(SPARKFUN_EDGE_BSP_URL),$(SPARKFUN_EDGE_BSP_MD5),AmbiqSuite-Rel2.0.0/boards/SparkFun_TensorFlow_Apollo3_BSP,))
+    $(eval $(call add_third_party_download,$(SPARKFUN_EDGE_BSP_URL),$(SPARKFUN_EDGE_BSP_MD5),AmbiqSuite-Rel2.2.0/boards/SparkFun_TensorFlow_Apollo3_BSP,))
     # Make sure that we download the full Ambiq SDK before the SparkFun one.
-$(MAKEFILE_DIR)/downloads/AmbiqSuite-Rel2.0.0/boards/SparkFun_TensorFlow_Apollo3_BSP: $(MAKEFILE_DIR)/downloads/AmbiqSuite-Rel2.0.0
+$(MAKEFILE_DIR)/downloads/AmbiqSuite-Rel2.2.0/boards/SparkFun_TensorFlow_Apollo3_BSP: $(MAKEFILE_DIR)/downloads/AmbiqSuite-Rel2.2.0
   endif
 
   # Use the faster depthwise conv implementation.

--- a/tensorflow/lite/micro/tools/make/third_party_downloads.inc
+++ b/tensorflow/lite/micro/tools/make/third_party_downloads.inc
@@ -25,6 +25,7 @@ CMSIS_MD5 := "866f79cfb86f7aee29a320aeda530aca"
 
 AM_SDK_URL := "http://s3.asia.ambiqmicro.com/downloads/AmbiqSuite-Rel2.2.0.zip"
 AM_SDK_MD5 := "7605fa2d4d97e6bb7a1190c92b66b597"
+AM_SDK_DEST := AmbiqSuite-Rel2.2.0
 
 AP3_URL := "https://github.com/AmbiqMicro/TFLiteMicro_Apollo3/archive/dfbcef9a57276c087d95aab7cb234f1d4c9eaaba.zip"
 AP3_MD5 := "fc9cbda4562ea97ce21b6df542b66597"

--- a/tensorflow/lite/micro/tools/make/third_party_downloads.inc
+++ b/tensorflow/lite/micro/tools/make/third_party_downloads.inc
@@ -33,8 +33,8 @@ AP3_MD5 := "fc9cbda4562ea97ce21b6df542b66597"
 CUST_CMSIS_URL := "https://github.com/AmbiqMicro/TFLiteMicro_CustCMSIS/archive/8f63966c5692e6a3a83956efd2e4aed77c4c9949.zip"
 CUST_CMSIS_MD5 := "4fb327201034ee0a820b72de1e807d27"
 
-SPARKFUN_EDGE_BSP_URL := "https://github.com/sparkfun/SparkFun_Edge_BSP/archive/620f5f7a69fc69e38cda8132b69302d9c28ba0dd.zip"
-SPARKFUN_EDGE_BSP_MD5 := "10fb37d721c782327edc981d3b5b07cf"
+SPARKFUN_EDGE_BSP_URL := "https://github.com/sparkfun/SparkFun_Edge_BSP/archive/6ea7ef137132bb0cb4b27abe837c913c7643f11e.zip"
+SPARKFUN_EDGE_BSP_MD5 := "66635efe137298c2e1aebc2479bb8931"
 
 STM32_BARE_LIB_URL := "https://github.com/google/stm32_bare_lib/archive/c07d611fb0af58450c5a3e0ab4d52b47f99bc82d.zip"
 STM32_BARE_LIB_MD5 := "282bff40d4d0b92278fd123a3b6e3123"

--- a/tensorflow/lite/micro/tools/make/third_party_downloads.inc
+++ b/tensorflow/lite/micro/tools/make/third_party_downloads.inc
@@ -23,8 +23,8 @@ TSIM_MD5 := "afa0095d3ed989a949e1467f94e41d2f"
 CMSIS_URL := "https://github.com/ARM-software/CMSIS_5/archive/d76d5e3acb87cf089daf50b31f991026149ecb6c.zip"
 CMSIS_MD5 := "866f79cfb86f7aee29a320aeda530aca"
 
-AM_SDK_URL := "http://s3.asia.ambiqmicro.com/downloads/AmbiqSuite-Rel2.0.0.zip"
-AM_SDK_MD5 := "70332bc6968602bd85bee600ca81d06f"
+AM_SDK_URL := "http://s3.asia.ambiqmicro.com/downloads/AmbiqSuite-Rel2.2.0.zip"
+AM_SDK_MD5 := "7605fa2d4d97e6bb7a1190c92b66b597"
 
 AP3_URL := "https://github.com/AmbiqMicro/TFLiteMicro_Apollo3/archive/dfbcef9a57276c087d95aab7cb234f1d4c9eaaba.zip"
 AP3_MD5 := "fc9cbda4562ea97ce21b6df542b66597"


### PR DESCRIPTION
We can update to the latest SDK release from Ambiq to stay current. This will make it easier to build/maintain additional functionality in the future if needed.