### PR TITLE
Fix typos conv2d, conv2d_v2 docstrings

### DIFF
--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -1850,7 +1850,7 @@ def conv2d_v2(input,  # pylint: disable=redefined-builtin
                           filter[di, dj, q, k]
 
   Must have `strides[0] = strides[3] = 1`.  For the most common case of the same
-  horizontal and vertices strides, `strides = [1, stride, stride, 1]`.
+  horizontal and vertical strides, `strides = [1, stride, stride, 1]`.
 
   Args:
     input: A `Tensor`. Must be one of the following types:
@@ -1936,7 +1936,7 @@ def conv2d(  # pylint: disable=redefined-builtin,dangerous-default-value
                           * filter[di, dj, q, k]
 
   Must have `strides[0] = strides[3] = 1`.  For the most common case of the same
-  horizontal and vertices strides, `strides = [1, stride, stride, 1]`.
+  horizontal and vertical strides, `strides = [1, stride, stride, 1]`.
 
   Args:
     input: A `Tensor`. Must be one of the following types:


### PR DESCRIPTION
Very minor typos in conv2d, con2d_v2 docstring. 

Currently:

  Must have `strides[0] = strides[3] = 1`.  For the most common case of the same
  horizontal and **vertices** strides, `strides = [1, stride, stride, 1]`.

Proposed fix:

  Must have `strides[0] = strides[3] = 1`.  For the most common case of the same
  horizontal and **vertical** strides, `strides = [1, stride, stride, 1]`.
