### PR TITLE
Add self-contained hexagon delegate lib

### DIFF
--- a/tensorflow/lite/experimental/delegates/hexagon/BUILD
+++ b/tensorflow/lite/experimental/delegates/hexagon/BUILD
@@ -107,4 +107,23 @@ cc_test(
     ],
 )
 
+cc_binary(
+    name = "libtensorflowlite_hexagon_delegate.so",
+    linkopts = [
+        "-Wl,-soname=libtensorflowlite_hexagon_delegate.so",
+    ] + select({
+        "//tensorflow:windows": [],
+        "//conditions:default": [
+            "-fvisibility=hidden",
+        ],
+    }),
+    linkshared = 1,
+    linkstatic = 1,
+    tags = [
+        "nobuilder",
+        "notap",
+    ],
+    deps = [":hexagon_delegate"],
+)
+
 exports_files(["version_script.lds"])


### PR DESCRIPTION
Adds self-contained target for experimental hexagon delegate.
It is mostly the same as GPU delegate, so that C++ user could build it it in a similar fashion: single self-contained target

Hope you don't mind it.