### PR TITLE
KeyError bug fixed

### DIFF
--- a/tensorflow/python/util/nest.py
+++ b/tensorflow/python/util/nest.py
@@ -87,7 +87,7 @@ def _get_attrs_items(obj):
 def _sorted(dict_):
   """Returns a sorted list of the dict keys, with error if keys not sortable."""
   try:
-    return sorted(dict_)
+    return sorted(dict_.keys())
   except TypeError:
     raise TypeError("nest only supports dicts with sortable keys.")
 


### PR DESCRIPTION
Using `dict.keys()` to iterate over dictionary keys is better than `dict.__iter__`. The former is the common interface for `dict` whereas the latter is not very clear.