### PR TITLE
2.1 cherry-pick request: Fix doc formatting in dataset_ops.py

### DIFF
--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -1176,7 +1176,6 @@ class DatasetV2(tracking_base.Trackable, composite_tensor.CompositeTensor):
     [1, 0, 2]
     >>> list(dataset.as_numpy_iterator())  # doctest: +SKIP
     [1, 0, 2]
-    ```
 
     Args:
       buffer_size: A `tf.int64` scalar `tf.Tensor`, representing the number of


### PR DESCRIPTION
The effect can be seen in the Args section of https://www.tensorflow.org/api_docs/python/tf/data/Dataset?version=nightly#shuffle

PiperOrigin-RevId: 286304265
Change-Id: I318caf0b33a92d881ad42065d0e4a7a603d91fc0