### PR TITLE
Fix compilation crash of replay_computation

### DIFF
--- a/tensorflow/compiler/xla/tools/replay_computation.cc
+++ b/tensorflow/compiler/xla/tools/replay_computation.cc
@@ -349,7 +349,7 @@ StatusOr<std::vector<HloSnapshot>> ParseRecordIoFile(absl::string_view filename,
   tensorflow::tstring record;
   while (reader.ReadRecord(&offset, &record).ok()) {
     HloSnapshot snapshot;
-    if (snapshot.mutable_hlo()->ParseFromStringPiece(record)) {
+    if (snapshot.mutable_hlo()->ParseFromString(record)) {
       snapshots.push_back(std::move(snapshot));
     } else {
       LOG(ERROR) << "Encountered bad proto";


### PR DESCRIPTION
ParseFromStringPiece isn't defined.
Crash introduced in f62a214c2202573fb13b0b601f721c6d757fad68

@thomasjoerg @sanjoy 