### PR TITLE
[INTEL MKL] Create a partial key for output_scale.

### DIFF
--- a/tensorflow/core/kernels/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl_conv_ops.cc
@@ -156,7 +156,7 @@ struct MklConvFwdParams {
     string name;
     mkldnn::algorithm alg;
     std::vector<float> param;
-    std::string param_key;
+    std::string partial_key;
   };
   std::vector<PostOpParam> post_op_params;
 
@@ -501,8 +501,8 @@ class MklConvFwdPrimitiveFactory : public MklPrimitiveFactory<float> {
           key_creator.AddAsKey(param);
         }
       } else if (post_op_param.name == "output_scale") {
-        key_creator.AddAsKey(post_op_param.param_key);
-      } else if (post_op_param.name != "output_scale") {
+        key_creator.AddAsKey(post_op_param.partial_key);
+      } else {
         return string("not_a_key");
       }
     }


### PR DESCRIPTION
MKL Conv2d's primitive key creation has significant overhead, especially for quantized conv2d which has an extraordinary long `output_scale` post ops (for re-quantization). Instead of using actual values of `output_scale` vector, we are using the pointers of min/max_filter_vector as a partial key, and this works well since the filter vector is always a constant in `MklQuantizedConv2DOp`.

This feature could improve the performance for models with small workloads. For example, mobilenet will improve ~30%, and ssd-mobilenet will improve ~10%.
