### PR TITLE
lite/kernels/concatenation: use tflite::TfLiteRound instead of std::round

### DIFF
--- a/tensorflow/lite/kernels/internal/reference/concatenation.h
+++ b/tensorflow/lite/kernels/internal/reference/concatenation.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/common.h"
 #include "tensorflow/lite/kernels/internal/compatibility.h"
 #include "tensorflow/lite/kernels/internal/types.h"
+#include "tensorflow/lite/kernels/internal/round.h"
 
 namespace tflite {
 namespace reference_ops {
@@ -122,7 +123,7 @@ inline void ConcatenationWithScaling(const ConcatenationParams& params,
         const float bias = -input_zeropoint[i] * scale;
         for (int j = 0; j < copy_size; ++j) {
           const int32_t value =
-              static_cast<int32_t>(std::round(input_ptr[j] * scale + bias)) +
+              static_cast<int32_t>(tflite::TfLiteRound(input_ptr[j] * scale + bias)) +
               output_zeropoint;
           output_ptr[j] = static_cast<uint8_t>(
               std::max<int32_t>(std::min<int32_t>(255, value), 0));


### PR DESCRIPTION
I recently started to port tensorflow-lite on RIOT, an operating system for microcontrollers, (see https://github.com/RIOT-OS/RIOT/pull/12847 to follow this work) and had a build issue with the RISC-V toolchain where `std::round` is not defined (I'm using `riscv-none-embed-gcc` version 8.2.0).

This PR replaces a call to `std::round` with the global `tflite::TfLiteRound` function that internally handles this miss in case `TF_LITE_USE_GLOBAL_ROUND` is defined.

`git grep` is reporting other uses of `std::round` in the `lite` directory but they doesn't break the build on RISC-V. I'm not sure if they should be updated as well.

<details><summary>git grep -n "std::round" tensorflow/lite/</summary>

```
tensorflow/lite/experimental/ruy/test.h:1414:  auto q_fixed = static_cast<std::int64_t>(std::round(q * (1ll << 31)));
tensorflow/lite/kernels/activations.cc:123:    const float rescaled = std::round(transformed * inverse_scale);
tensorflow/lite/kernels/activations.cc:373:                        std::round(input->params.zero_point +
tensorflow/lite/kernels/activations_test.cc:361:      std::round(std::numeric_limits<QuantizedType>::min() +
tensorflow/lite/kernels/activations_test.cc:364:      std::round(std::numeric_limits<QuantizedType>::min() +
tensorflow/lite/kernels/internal/logsoftmax_quantized_test.cc:62:               255 + std::round(16.0f * reference_output_float_data[i])));
tensorflow/lite/kernels/internal/logsoftmax_quantized_test.cc:96:                  127 + std::round(16.0f * reference_output_float_data[i])));
tensorflow/lite/kernels/internal/optimized/neon_tensor_utils.cc:2163:    //    std::round(*scaling_factor * values[i]));
tensorflow/lite/kernels/internal/optimized/optimized_ops.h:4025:  const int32_t prob_rnd = static_cast<int32_t>(std::round(prob_rescaled));
tensorflow/lite/kernels/internal/optimized/optimized_ops.h:4184:      // Use std::rint over std::round (which is used in
tensorflow/lite/kernels/internal/optimized/optimized_ops.h:6474:    const int int_exponent = static_cast<int>(std::round(exponent));
tensorflow/lite/kernels/internal/quantization_util.cc:374:  // Using TfLiteRound instead of std::round and std::log instead of
tensorflow/lite/kernels/internal/reference/reduce.h:371:            static_cast<U>(std::round(temp_sum[idx] * scale + bias)) +
tensorflow/lite/kernels/internal/reference/reduce.h:381:            std::min(std::round(float_mean * scale + bias) + output_zero_point,
tensorflow/lite/kernels/internal/reference/reference_ops.h:1096:              static_cast<int32_t>(std::round(input_ptr[j] * scale + bias)) +
tensorflow/lite/kernels/internal/round.h:34:  return std::round(x);
tensorflow/lite/kernels/internal/softmax_quantized_test.cc:62:        static_cast<int>(std::round(256.0f * reference_output_float_data[i])));
tensorflow/lite/kernels/test_util.h:54:                        std::round(zero_point + (f / scale))))));
tensorflow/lite/kernels/test_util.h:443:      nudged_zero_point = static_cast<T>(std::round(zero_point_double));
tensorflow/lite/toco/graph_transformations/quantization_util.cc:152:    auto integer_val = tflite::SafeCast<DataType<A>>(std::round(scaled_val));
tensorflow/lite/toco/graph_transformations/quantize.cc:308:      scaled_value - std::round(scaled_value);
tensorflow/lite/toco/graph_transformations/quantize.cc:312:  const double rounded_scaled_value = std::round(scaled_value);
tensorflow/lite/tools/optimize/quantization_utils.cc:80:    zero_point = static_cast<int64_t>(std::round(zero_point_from_min));
```

</details>