### PR TITLE
infer profiler_outdir for tf.summary.trace_export from SummaryWriter

### DIFF
--- a/tensorflow/python/ops/summary_ops_v2.py
+++ b/tensorflow/python/ops/summary_ops_v2.py
@@ -223,13 +223,14 @@ class SummaryWriter(object):
 class ResourceSummaryWriter(SummaryWriter):
   """Implementation of SummaryWriter using a SummaryWriterInterface resource."""
 
-  def  __init__(self, shared_name, init_op_fn, name=None, v2=False):
+  def  __init__(self, shared_name, init_op_fn, name=None, v2=False, metadata=None):
     self._resource = gen_summary_ops.summary_writer(
         shared_name=shared_name, name=name)
     # TODO(nickfelt): cache other constructed ops in graph mode
     self._init_op_fn = init_op_fn
     self._init_op = init_op_fn(self._resource)
     self._v2 = v2
+    self._metadata = {} if metadata is None else metadata
     self._closed = False
     if context.executing_eagerly():
       self._resource_deleter = resource_variable_ops.EagerResourceDeleter(
@@ -406,7 +407,8 @@ def create_file_writer_v2(logdir,
               flush_millis=flush_millis,
               filename_suffix=filename_suffix),
           name=name,
-          v2=True)
+          v2=True,
+          metadata={'logdir': logdir})
 
 
 def create_file_writer(logdir,
@@ -1204,9 +1206,10 @@ def trace_export(name, step=None, profiler_outdir=None):
     step: Explicit `int64`-castable monotonic step value for this summary. If
       omitted, this defaults to `tf.summary.experimental.get_step()`, which must
       not be None.
-    profiler_outdir: Output directory for profiler. It is required when profiler
-      is enabled when trace was started. Otherwise, it is ignored. If you never
-      set it, the logdir set to the current SummaryWriter will be set.
+    profiler_outdir: Output directory for profiler. This is only used when the
+      profiler was enabled when the trace was started. In that case, if there
+      is a logdir-based default SummaryWriter, this defaults to the same directory,
+      but otherwise the argument must be passed.
 
   Raises:
     ValueError: if a default writer exists, but no step was provided and
@@ -1227,7 +1230,9 @@ def trace_export(name, step=None, profiler_outdir=None):
     graph, profiler = _current_trace_context  # pylint: disable=redefined-outer-name
     if profiler_outdir is None \
         and isinstance(_summary_state.writer, ResourceSummaryWriter):
-      profiler_outdir = _summary_state.writer._init_op_fn.keywords.get('logdir')  # pylint: disable=protected-access
+      logdir = _summary_state.writer._metadata.get('logdir')  # pylint: disable=protected-access
+      if logdir is not None:
+        profiler_outdir = logdir
     if profiler and profiler_outdir is None:
       raise ValueError("Must set profiler_outdir or "
                        "enable summary writer with logdir.")

--- a/tensorflow/python/ops/summary_ops_v2.py
+++ b/tensorflow/python/ops/summary_ops_v2.py
@@ -223,7 +223,8 @@ class SummaryWriter(object):
 class ResourceSummaryWriter(SummaryWriter):
   """Implementation of SummaryWriter using a SummaryWriterInterface resource."""
 
-  def  __init__(self, shared_name, init_op_fn, name=None, v2=False, metadata=None):
+  def  __init__(self, shared_name, init_op_fn,
+                name=None, v2=False, metadata=None):
     self._resource = gen_summary_ops.summary_writer(
         shared_name=shared_name, name=name)
     # TODO(nickfelt): cache other constructed ops in graph mode
@@ -1207,8 +1208,8 @@ def trace_export(name, step=None, profiler_outdir=None):
       omitted, this defaults to `tf.summary.experimental.get_step()`, which must
       not be None.
     profiler_outdir: Output directory for profiler. This is only used when the
-      profiler was enabled when the trace was started. In that case, if there
-      is a logdir-based default SummaryWriter, this defaults to the same directory,
+      profiler was enabled when the trace was started. In that case, if there is
+      a logdir-based default SummaryWriter, this defaults to the same directory,
       but otherwise the argument must be passed.
 
   Raises:


### PR DESCRIPTION
First of all, I want to thank everyone who develops tensorflow.
I really like tensorflow because it is very easy to use and powerful.

---
`trace_export` is required to set `profiler_outdir`.
However, in many cases the `profiler_outdir` and the directory set by `tf.summary.create_file_writer` are the same.
So, I thought that if the `SummaryWriter` was set, it should use the `logdir` set here.
please confirm.