### PR TITLE
Fix for compute_capability_from_device_desc on AMD cards

### DIFF
--- a/tensorflow/python/framework/gpu_util.py
+++ b/tensorflow/python/framework/gpu_util.py
@@ -51,7 +51,7 @@ def compute_capability_from_device_desc(device_attrs):
   match = _PHYSICAL_DEVICE_DESCRIPTION_REGEX.search(
       device_attrs.physical_device_desc)
   # LINT.ThenChange(//tensorflow/core/common_runtime/gpu/gpu_device.cc)
-  if not match:
+  if not match or match.group(2)==None or match.group(3)==None:
     return GpuInfo(None, None)
   cc = int(match.group(2)), int(match.group(3)) if match.group(2) else None
   return GpuInfo(match.group(1), cc)


### PR DESCRIPTION
At present, compute_capability_from_device_desc causes an unhandled error on AMD cards.
I am seeing the following:

physical_device_desc is "device: 0, name: Vega 20, pci bus id: 0000:2b:00.0"
match.groups() is (u'Vega 20', None, None)

Which results in int(match.group(2)) throwing a "TypeError: int() argument must be a string or a number, not 'NoneType'".
