### PR TITLE
[ROCm] Fix for the broken ROCm CSB - 191223

### DIFF
--- a/tensorflow/python/framework/gpu_util.py
+++ b/tensorflow/python/framework/gpu_util.py
@@ -53,5 +53,5 @@ def compute_capability_from_device_desc(device_attrs):
   # LINT.ThenChange(//tensorflow/core/common_runtime/gpu/gpu_device.cc)
   if not match:
     return GpuInfo(None, None)
-  cc = int(match.group(2)), int(match.group(3)) if match.group(2) else None
+  cc = (int(match.group(2)), int(match.group(3))) if match.group(2) else None
   return GpuInfo(match.group(1), cc)


### PR DESCRIPTION
The following commit breaks the ROCm CSB

https://github.com/tensorflow/tensorflow/commit/b32c69cb54595991058c9210ab4f08f6b70030ef

It leads to the following runtime error in many tests

```
Traceback (most recent call last):
  File "/home/jenkins/workspace/tensorflow-rocm-nightly/bazel-ci_build-cache/.cache/bazel/_bazel_jenkins/eab0d61a99b6696edb3d2aff87b585e8/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/config_test_gpu.runfiles/org_tensorflow/tensorflow/python/framework/test_util.py", line 1377, in decorated
    if not is_gpu_available():
  File "/home/jenkins/workspace/tensorflow-rocm-nightly/bazel-ci_build-cache/.cache/bazel/_bazel_jenkins/eab0d61a99b6696edb3d2aff87b585e8/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/config_test_gpu.runfiles/org_tensorflow/tensorflow/python/util/deprecation.py", line 324, in new_func
    return func(*args, **kwargs)
  File "/home/jenkins/workspace/tensorflow-rocm-nightly/bazel-ci_build-cache/.cache/bazel/_bazel_jenkins/eab0d61a99b6696edb3d2aff87b585e8/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/config_test_gpu.runfiles/org_tensorflow/tensorflow/python/framework/test_util.py", line 1494, in is_gpu_available
    gpu_info = gpu_util.compute_capability_from_device_desc(local_device)
  File "/home/jenkins/workspace/tensorflow-rocm-nightly/bazel-ci_build-cache/.cache/bazel/_bazel_jenkins/eab0d61a99b6696edb3d2aff87b585e8/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/config_test_gpu.runfiles/org_tensorflow/tensorflow/python/framework/gpu_util.py", line 56, in compute_capability_from_device_desc
    cc = int(match.group(2)), int(match.group(3)) if match.group(2) else None
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'

```

This is because, the way it is written, the `if` check in file `gpu_util.py:56`
applies only to `int(match.group(3))` instead of to the tuple
`int(match.group(2)), int(match.group(3))`, which I believe is the intent here.

This results in runtime failures on ROCm platform where `match.group(2)` is indeed `None`

The fix is to make the tuple explicit to ensure the if condition is applied as intended


---------------------

/cc @whchung @chsigg 

