### PR TITLE
[Intel MKL] Avoid unnecessary data reorders

### DIFF
--- a/tensorflow/core/kernels/mkl_avgpooling_op.cc
+++ b/tensorflow/core/kernels/mkl_avgpooling_op.cc
@@ -108,10 +108,10 @@ class MklAvgPoolingOp : public MklPoolingForwardOpBase<T> {
         pooling_prop_kind = prop_kind::forward_inference;
       else
         pooling_prop_kind = prop_kind::forward_training;
-      MklPoolingParams fwdParams(src_dims, output_dims_mkl_order, filter_dims,
-                                 strides, padding_left, padding_right,
-                                 algorithm::pooling_avg_exclude_padding,
-                                 pooling_prop_kind);
+      MklPoolingParams fwdParams(
+          src_dims, output_dims_mkl_order, filter_dims, strides, padding_left,
+          padding_right, algorithm::pooling_avg_exclude_padding,
+          pooling_prop_kind, static_cast<memory::format>(input_md.data.format));
       pooling_fwd = MklPoolingFwdPrimitiveFactory<T>::Get(fwdParams);
 
       // allocate output tensor
@@ -122,18 +122,7 @@ class MklAvgPoolingOp : public MklPoolingForwardOpBase<T> {
 
       OP_REQUIRES_OK(context, context->status());
 
-      // check whether we need to reorder src
       const T* src_data = input_tensor.flat<T>().data();
-      if (input_md.data.format != pooling_fwd->GetSrcMemoryFormat()) {
-        dnn_data_input.SetUsrMem(input_md, &input_tensor);
-        auto src_target_primitive_desc = memory::primitive_desc(
-            {{src_dims}, MklDnnType<T>(), pooling_fwd->GetSrcMemoryFormat()},
-            cpu_engine_);
-        dnn_data_input.CheckReorderToOpMem(src_target_primitive_desc);
-        src_data = const_cast<T*>(
-            reinterpret_cast<T*>(dnn_data_input.GetOpMem().get_data_handle()));
-      }
-
       T* dst_data = output_tensor->flat<T>().data();
 
       // execute pooling
@@ -159,9 +148,9 @@ class MklAvgPoolingOp : public MklPoolingForwardOpBase<T> {
         output_max->flat<float>()(0) = max_input;
       }
     } catch (mkldnn::error& e) {
-      string error_msg = "Status: " + std::to_string(e.status) +
-                         ", message: " + string(e.message) + ", in file " +
-                         string(__FILE__) + ":" + std::to_string(__LINE__);
+      string error_msg = "Status: " + std::to_string(e.status) + ", message: " +
+                         string(e.message) + ", in file " + string(__FILE__) +
+                         ":" + std::to_string(__LINE__);
       OP_REQUIRES_OK(
           context,
           errors::Aborted("Operation received an exception:", error_msg));
@@ -225,12 +214,20 @@ class MklAvgPoolingGradOp : public MklPoolingBackwardOpBase<T> {
       memory::dims output_dims_mkl_order;
       this->GetOutputDims(pool_params, &output_dims_mkl_order);
 
+      // get src memory::desc
+      memory::desc src_md =
+          orig_input_mkl_shape.IsMklTensor()
+              ? orig_input_mkl_shape.GetMklLayout()
+              : memory::desc(orig_input_dims_mkl_order, MklDnnType<T>(),
+                             this->data_format_mkldnn_);
+
       // Pass prop_kind::forward_training to create a forward primitive
       // that is used in the backward pass
       MklPoolingParams bwdParams(
           orig_input_dims_mkl_order, output_dims_mkl_order, filter_dims,
           strides, padding_left, padding_right,
-          algorithm::pooling_avg_exclude_padding, prop_kind::forward_training);
+          algorithm::pooling_avg_exclude_padding, prop_kind::forward_training,
+          static_cast<memory::format>(src_md.data.format));
       MklPoolingBwdPrimitive<T>* pooling_bwd =
           MklPoolingBwdPrimitiveFactory<T>::Get(bwdParams);
 
@@ -261,9 +258,9 @@ class MklAvgPoolingGradOp : public MklPoolingBackwardOpBase<T> {
       // execute pooling op
       pooling_bwd->Execute(diff_dst_data, diff_src_data);
     } catch (mkldnn::error& e) {
-      string error_msg = "Status: " + std::to_string(e.status) +
-                         ", message: " + string(e.message) + ", in file " +
-                         string(__FILE__) + ":" + std::to_string(__LINE__);
+      string error_msg = "Status: " + std::to_string(e.status) + ", message: " +
+                         string(e.message) + ", in file " + string(__FILE__) +
+                         ":" + std::to_string(__LINE__);
       OP_REQUIRES_OK(context, errors::Aborted("Compute received an exception:",
                                               error_msg));
     }
@@ -282,15 +279,13 @@ class MklAvgPoolingGradOp : public MklPoolingBackwardOpBase<T> {
                          const MklDnnShape& original_input_mkl_shape,
                          const MklDnnShape& input_gradient_mkl_shape) {
     if (!original_input_mkl_shape.IsMklTensor()) {
-      OP_REQUIRES(
-          context,
-          tensor_in_shape.dims() == 1 && tensor_in_shape.NumElements() == 4,
-          errors::InvalidArgument("original input shape must be "
-                                  "1-dimensional and 4 elements"));
+      OP_REQUIRES(context, tensor_in_shape.dims() == 1 &&
+                               tensor_in_shape.NumElements() == 4,
+                  errors::InvalidArgument("original input shape must be "
+                                          "1-dimensional and 4 elements"));
     } else {
-      OP_REQUIRES(context,
-                  original_input_mkl_shape.GetDimension() == 1 &&
-                      original_input_mkl_shape.DimSize(0) == 4,
+      OP_REQUIRES(context, original_input_mkl_shape.GetDimension() == 1 &&
+                               original_input_mkl_shape.DimSize(0) == 4,
                   errors::InvalidArgument("original input shape must be "
                                           "1-dimensional and 4 elements"));
     }

--- a/tensorflow/core/kernels/mkl_maxpooling_op.cc
+++ b/tensorflow/core/kernels/mkl_maxpooling_op.cc
@@ -135,9 +135,10 @@ class MklMaxPoolingOp : public MklPoolingForwardOpBase<T> {
         pooling_prop_kind = prop_kind::forward_inference;
       else
         pooling_prop_kind = prop_kind::forward_training;
-      MklPoolingParams fwdParams(src_dims, output_dims_mkl_order, filter_dims,
-                                 strides, padding_left, padding_right,
-                                 algorithm::pooling_max, pooling_prop_kind);
+      MklPoolingParams fwdParams(
+          src_dims, output_dims_mkl_order, filter_dims, strides, padding_left,
+          padding_right, algorithm::pooling_max, pooling_prop_kind,
+          static_cast<memory::format>(input_md.data.format));
       pooling_fwd = MklPoolingFwdPrimitiveFactory<T>::Get(fwdParams);
 
       // allocate output tensor
@@ -149,18 +150,7 @@ class MklMaxPoolingOp : public MklPoolingForwardOpBase<T> {
                                 pooling_fwd->GetDstMemoryFormat(),
                                 output_tensor);
 
-      // check wehther we need to reorder src
       const T* src_data = input_tensor.flat<T>().data();
-      if (input_md.data.format != pooling_fwd->GetSrcMemoryFormat()) {
-        dnn_data_input.SetUsrMem(input_md, &input_tensor);
-        auto src_target_primitive_desc = memory::primitive_desc(
-            {{src_dims}, MklDnnType<T>(), pooling_fwd->GetSrcMemoryFormat()},
-            cpu_engine);
-        dnn_data_input.CheckReorderToOpMem(src_target_primitive_desc);
-        src_data = const_cast<T*>(
-            reinterpret_cast<T*>(dnn_data_input.GetOpMem().get_data_handle()));
-      }
-
       T* dst_data = output_tensor->flat<T>().data();
 
       if (int8_forward_inference) {
@@ -196,9 +186,9 @@ class MklMaxPoolingOp : public MklPoolingForwardOpBase<T> {
         pooling_fwd->Execute(src_data, dst_data, ws_data);
       }
     } catch (mkldnn::error& e) {
-      string error_msg = "Status: " + std::to_string(e.status) +
-                         ", message: " + string(e.message) + ", in file " +
-                         string(__FILE__) + ":" + std::to_string(__LINE__);
+      string error_msg = "Status: " + std::to_string(e.status) + ", message: " +
+                         string(e.message) + ", in file " + string(__FILE__) +
+                         ":" + std::to_string(__LINE__);
       OP_REQUIRES_OK(context, errors::Aborted("Compute received an exception:",
                                               error_msg));
     }
@@ -287,10 +277,18 @@ class MklMaxPoolingGradOp : public MklPoolingBackwardOpBase<T> {
       memory::dims output_dims_mkl_order;
       this->GetOutputDims(pool_params, &output_dims_mkl_order);
 
+      // get src mem desc
+      memory::desc src_md =
+          orig_input_mkl_shape.IsMklTensor()
+              ? orig_input_mkl_shape.GetMklLayout()
+              : memory::desc(orig_input_dims_mkl_order, MklDnnType<T>(),
+                             this->data_format_mkldnn_);
+
       MklPoolingParams bwdParams(
           orig_input_dims_mkl_order, output_dims_mkl_order, filter_dims,
           strides, padding_left, padding_right, algorithm::pooling_max,
-          prop_kind::forward_training);
+          prop_kind::forward_training,
+          static_cast<memory::format>(src_md.data.format));
       MklPoolingBwdPrimitive<T>* pooling_bwd =
           MklPoolingBwdPrimitiveFactory<T>::Get(bwdParams);
 
@@ -340,9 +338,9 @@ class MklMaxPoolingGradOp : public MklPoolingBackwardOpBase<T> {
       // execute pooling
       pooling_bwd->Execute(diff_dst_data, diff_src_data, ws_data);
     } catch (mkldnn::error& e) {
-      string error_msg = "Status:" + std::to_string(e.status) +
-                         ", message: " + string(e.message) + ". in file " +
-                         string(__FILE__) + ":" + std::to_string(__LINE__);
+      string error_msg = "Status:" + std::to_string(e.status) + ", message: " +
+                         string(e.message) + ". in file " + string(__FILE__) +
+                         ":" + std::to_string(__LINE__);
       OP_REQUIRES_OK(context, errors::Aborted("Compute received an exception:",
                                               error_msg));
     }

--- a/tensorflow/core/kernels/mkl_pooling_ops_common.h
+++ b/tensorflow/core/kernels/mkl_pooling_ops_common.h
@@ -47,11 +47,13 @@ struct MklPoolingParams {
   memory::dims padding_right;
   mkldnn::algorithm alg_kind;
   mkldnn::prop_kind prop_kind;
+  memory::format src_format;
 
   MklPoolingParams(memory::dims src_dims, memory::dims dst_dims,
                    memory::dims filter_dims, memory::dims strides,
                    memory::dims padding_left, memory::dims padding_right,
-                   mkldnn::algorithm alg_kind, mkldnn::prop_kind prop_kind)
+                   mkldnn::algorithm alg_kind, mkldnn::prop_kind prop_kind,
+                   memory::format src_format)
       : src_dims(src_dims),
         dst_dims(dst_dims),
         filter_dims(filter_dims),
@@ -59,7 +61,8 @@ struct MklPoolingParams {
         padding_left(padding_left),
         padding_right(padding_right),
         alg_kind(alg_kind),
-        prop_kind(prop_kind) {}
+        prop_kind(prop_kind),
+        src_format(src_format) {}
 };
 
 template <typename T>
@@ -663,9 +666,8 @@ class MklPoolingForwardOpBase : public MklPoolingOpBase<T> {
                   errors::InvalidArgument("Input must be 4 or 5-dimensional"));
     } else {
       OP_REQUIRES(
-          context,
-          input_mkl_shape.GetDimension() == 4 ||
-              input_mkl_shape.GetDimension() == 5,
+          context, input_mkl_shape.GetDimension() == 4 ||
+                       input_mkl_shape.GetDimension() == 5,
           errors::InvalidArgument("Input shape must be 4 or 5-dimensional"));
     }
   }

--- a/tensorflow/core/util/mkl_util.h
+++ b/tensorflow/core/util/mkl_util.h
@@ -766,9 +766,9 @@ inline Status ConvertMklToTF(OpKernelContext* context,
     }
     return Status::OK();
   } catch (mkldnn::error& e) {
-    string error_msg = "Status: " + std::to_string(e.status) +
-                       ", message: " + string(e.message) + ", in file " +
-                       string(__FILE__) + ":" + std::to_string(__LINE__);
+    string error_msg = "Status: " + std::to_string(e.status) + ", message: " +
+                       string(e.message) + ", in file " + string(__FILE__) +
+                       ":" + std::to_string(__LINE__);
     LOG(FATAL) << "Operation received an exception: " << error_msg;
   }
 }
@@ -2044,21 +2044,6 @@ class FactoryKeyCreator {
     key_.append(1, delimiter);
   }
 };
-
-static inline MEMORY_FORMAT get_desired_format(int channel, bool is_2d = true) {
-  MEMORY_FORMAT fmt_desired = MEMORY_FORMAT::any;
-
-  if (port::TestCPUFeature(port::CPUFeature::AVX512F)) {
-    fmt_desired = is_2d ? MEMORY_FORMAT::nChw16c : MEMORY_FORMAT::nCdhw16c;
-  } else if (port::TestCPUFeature(port::CPUFeature::AVX2) &&
-             (channel % 8) == 0) {
-    fmt_desired = is_2d ? MEMORY_FORMAT::nChw8c
-                        : MEMORY_FORMAT::ncdhw;  // no avx2 support for 3d yet.
-  } else {
-    fmt_desired = is_2d ? MEMORY_FORMAT::nchw : MEMORY_FORMAT::ncdhw;
-  }
-  return fmt_desired;
-}
 
 class MklReorderPrimitive : public MklPrimitive {
  public:


### PR DESCRIPTION
This PR improves performance by avoiding some unnecessary input reorders since MKL-DNN now performs well on plain format (like NHWC). This improves performance for pooling and batch norm ops.