### PR TITLE
[ROCm] stateful random ops

### DIFF
--- a/tensorflow/core/kernels/stateful_random_ops.cc
+++ b/tensorflow/core/kernels/stateful_random_ops.cc
@@ -25,10 +25,14 @@ namespace tensorflow {
 template <typename Distribution>
 struct UpdateVariableAndFill_Philox<CPUDevice, Distribution> {
   void operator()(OpKernelContext* ctx, const CPUDevice& device,
-                  Distribution dist, int64 output_size, int64 alg_tag_skip,
-                  ScopedUnlockUnrefVar* state_var_guard, Tensor* state_tensor,
+                  Distribution dist, UpdateVariableAndFill_Philox_Arg* arg,
                   typename Distribution::ResultElementType* output_data)
       UNLOCK_FUNCTION() {
+    int64 output_size = arg->output_size;
+    int64 alg_tag_skip = arg->alg_tag_skip;
+    ScopedUnlockUnrefVar* state_var_guard = arg->not_used;
+    Tensor* state_tensor = arg->state_tensor;
+
     auto state_tensor_flat = state_tensor->flat<StateElementType>();
     auto state_data = state_tensor_flat.data();
     // Delegates to PhiloxRandom to do the actual increasing.
@@ -96,9 +100,14 @@ Status UpdateVariableAndFill(
     TF_RETURN_IF_ERROR(CheckPhiloxState(*var_tensor, alg_tag_skip));
     TF_RETURN_IF_ERROR(PrepareToUpdateVariable<Device, StateElementType>(
         ctx, var_tensor, var->copy_on_read_mode.load()));
+
+    UpdateVariableAndFill_Philox_Arg arg;
+    arg.output_size = output_size;
+    arg.alg_tag_skip = alg_tag_skip;
+    arg.not_used = &state_var_guard;
+    arg.state_tensor = var_tensor;
     UpdateVariableAndFill_Philox<Device, Distribution>()(
-        ctx, ctx->eigen_device<Device>(), dist, output_size, alg_tag_skip,
-        &state_var_guard, var_tensor, output_data);
+        ctx, ctx->eigen_device<Device>(), dist, &arg, output_data);
     return Status::OK();
   } else {
     return errors::InvalidArgument("Unsupported algorithm id: ", alg);
@@ -393,7 +402,7 @@ TF_CALL_uint64(REGISTER_StatefulUniformFullInt_CPU);
 
 REGISTER_RngSkip(CPU);
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 TF_CALL_half(REGISTER_FloatOps_GPU);
 TF_CALL_float(REGISTER_FloatOps_GPU);

--- a/tensorflow/core/kernels/stateful_random_ops_cpu_gpu.h
+++ b/tensorflow/core/kernels/stateful_random_ops_cpu_gpu.h
@@ -86,12 +86,19 @@ using CPUDevice = Eigen::ThreadPoolDevice;
 
 using GPUDevice = Eigen::GpuDevice;
 
+struct UpdateVariableAndFill_Philox_Arg {
+  int64 output_size;
+  int64 alg_tag_skip;
+  ScopedUnlockUnrefVar* not_used;
+  Tensor* state_tensor;
+};
+
 // Declares the partially GPU-specialized functor structs.
+// must be kept at <=6 arguments because of a gcc/clang ABI incompatibility bug
 template <typename Distribution>
 struct UpdateVariableAndFill_Philox<GPUDevice, Distribution> {
   void operator()(OpKernelContext* ctx, const GPUDevice& device,
-                  Distribution dist, int64 output_size, int64 alg_tag_skip,
-                  ScopedUnlockUnrefVar* not_used, Tensor* state_tensor,
+                  Distribution dist, UpdateVariableAndFill_Philox_Arg* arg,
                   typename Distribution::ResultElementType* output_data);
 };
 

--- a/tensorflow/core/kernels/stateful_random_ops_cpu_gpu.h
+++ b/tensorflow/core/kernels/stateful_random_ops_cpu_gpu.h
@@ -82,16 +82,16 @@ struct RngSkip_Philox;
 
 using CPUDevice = Eigen::ThreadPoolDevice;
 
-#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
-
-using GPUDevice = Eigen::GpuDevice;
-
 struct UpdateVariableAndFill_Philox_Arg {
   int64 output_size;
   int64 alg_tag_skip;
   ScopedUnlockUnrefVar* not_used;
   Tensor* state_tensor;
 };
+
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
+using GPUDevice = Eigen::GpuDevice;
 
 // Declares the partially GPU-specialized functor structs.
 // must be kept at <=6 arguments because of a gcc/clang ABI incompatibility bug

--- a/tensorflow/core/kernels/stateful_random_ops_gpu.cu.cc
+++ b/tensorflow/core/kernels/stateful_random_ops_gpu.cu.cc
@@ -112,7 +112,6 @@ void RngSkip_Philox<GPUDevice>::operator()(const GPUDevice& d, int64 delta,
 
 // clang-format off
 // NVCC cannot handle ">>" properly
-
 template struct UpdateVariableAndFill_Philox<
     GPUDevice, random::NormalDistribution<random::PhiloxRandom, Eigen::half> >;
 template struct UpdateVariableAndFill_Philox<

--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -3962,7 +3962,6 @@ cuda_py_test(
     size = "medium",
     srcs = ["ops/stateful_random_ops_test.py"],
     python_version = "PY3",
-    tags = ["no_rocm"],
     xla_enable_strict_auto_jit = False,
     deps = [
         ":client_testlib",


### PR DESCRIPTION
This test enables and fixes the //tensorflow/python:stateful_random_ops test on the ROCm platform.