### PR TITLE
LayernormSimpleRNN added

### DIFF
--- a/tensorflow/python/keras/layers/recurrent.py
+++ b/tensorflow/python/keras/layers/recurrent.py
@@ -3218,7 +3218,7 @@ class LayernormSimpleRNNCell(DropoutRNNCellMixin, Layer):
 
 
 @keras_export('keras.experimental.LayernormSimpleRNN')
-class LayernormSimpleRNN(RNN):
+class LayernormSimpleRNN(SimpleRNN):
   """Fully-connected RNN where the output is to be fed back to input.
 
   Motivation:
@@ -3378,7 +3378,7 @@ class LayernormSimpleRNN(RNN):
         recurrent_dropout=recurrent_dropout,
         dtype=kwargs.get('dtype'),
         trainable=kwargs.get('trainable', True))
-    super(LayernormSimpleRNN, self).__init__(  # TMP(!)
+    super(SimpleRNN, self).__init__(  # TMP(!)
         cell,
         return_sequences=return_sequences,
         return_state=return_state,
@@ -3388,23 +3388,8 @@ class LayernormSimpleRNN(RNN):
         **kwargs)
     self.activity_regularizer = regularizers.get(activity_regularizer)
     self.input_spec = [InputSpec(ndim=3)]
-
-  def call(self, inputs, mask=None, training=None, initial_state=None):
-    self._maybe_reset_cell_dropout_mask(self.cell)
-    return super(LayernormSimpleRNN, self).call(  # TMP(!)
-        inputs, mask=mask, training=training, initial_state=initial_state)
-
-  @property
-  def units(self):
-    return self.cell.units
-
-  @property
-  def activation(self):
-    return self.cell.activation
-
-  @property
-  def use_bias(self):
-    return self.cell.use_bias
+  
+  # use SimpleRNN's call() method
 
   @property
   def use_layernorm(self):
@@ -3415,110 +3400,19 @@ class LayernormSimpleRNN(RNN):
     return self.cell.layernorm_epsilon  # NEW(!)
 
   @property
-  def kernel_initializer(self):
-    return self.cell.kernel_initializer
-
-  @property
-  def recurrent_initializer(self):
-    return self.cell.recurrent_initializer
-
-  @property
-  def bias_initializer(self):
-    return self.cell.bias_initializer
-
-  @property
   def gamma_initializer(self):
     return self.cell.gamma_initializer  # NEW(!)
-
-  @property
-  def kernel_regularizer(self):
-    return self.cell.kernel_regularizer
-
-  @property
-  def recurrent_regularizer(self):
-    return self.cell.recurrent_regularizer
-
-  @property
-  def bias_regularizer(self):
-    return self.cell.bias_regularizer
 
   @property
   def gamma_regularizer(self):
     return self.cell.gamma_regularizer  # NEW(!)
 
   @property
-  def kernel_constraint(self):
-    return self.cell.kernel_constraint
-
-  @property
-  def recurrent_constraint(self):
-    return self.cell.recurrent_constraint
-
-  @property
-  def bias_constraint(self):
-    return self.cell.bias_constraint
-
-  @property
   def gamma_constraint(self):
     return self.cell.gamma_constraint  # NEW(!)
 
-  @property
-  def dropout(self):
-    return self.cell.dropout
-
-  @property
-  def recurrent_dropout(self):
-    return self.cell.recurrent_dropout
-
   def get_config(self):
-    config = {
-        'units':
-            self.units,
-        'activation':
-            activations.serialize(self.activation),
-        'use_bias':
-            self.use_bias,
-        'use_layernorm':
-            self.use_layernorm,  # NEW(!)
-        'layernorm_epsilon':
-            self.layernorm_epsilon,  # NEW(!)
-        'kernel_initializer':
-            initializers.serialize(self.kernel_initializer),
-        'recurrent_initializer':
-            initializers.serialize(self.recurrent_initializer),
-        'bias_initializer':
-            initializers.serialize(self.bias_initializer),
-        'gamma_initializer':
-            initializers.serialize(self.gamma_initializer),  # NEW(!)
-        'kernel_regularizer':
-            regularizers.serialize(self.kernel_regularizer),
-        'recurrent_regularizer':
-            regularizers.serialize(self.recurrent_regularizer),
-        'bias_regularizer':
-            regularizers.serialize(self.bias_regularizer),
-        'gamma_regularizer':
-            regularizers.serialize(self.gamma_regularizer),  # NEW(!)
-        'activity_regularizer':
-            regularizers.serialize(self.activity_regularizer),
-        'kernel_constraint':
-            constraints.serialize(self.kernel_constraint),
-        'recurrent_constraint':
-            constraints.serialize(self.recurrent_constraint),
-        'bias_constraint':
-            constraints.serialize(self.bias_constraint),
-        'gamma_constraint':
-            constraints.serialize(self.gamma_constraint),  # NEW(!)
-        'dropout':
-            self.dropout,
-        'recurrent_dropout':
-            self.recurrent_dropout
-    }
-    base_config = super(LayernormSimpleRNN, self).get_config()  # TMP(!)
+    base_config = super(SimpleRNN, self).get_config()
     del base_config['cell']
-    return dict(list(base_config.items()) + list(config.items()))
-
-  @classmethod
-  def from_config(cls, config):
-    if 'implementation' in config:
-      config.pop('implementation')
-    return cls(**config)
+    cell_config = self.cell.get_config()
+    return dict(list(base_config.items()) + list(cell_config.items()))

--- a/tensorflow/python/keras/layers/recurrent.py
+++ b/tensorflow/python/keras/layers/recurrent.py
@@ -3244,8 +3244,8 @@ class LayernormSimpleRNN(SimpleRNN):
       used for the linear transformation of the inputs. Default:
       `glorot_uniform`.
     recurrent_initializer: Initializer for the `recurrent_kernel`
-      weights matrix, used for the linear transformation of the recurrent state.
-      Default: `orthogonal`.
+      weights matrix, used for the linear transformation of the recurrent
+      state. Default: `orthogonal`.
     bias_initializer: Initializer for the bias vector (`use_bias=True`) or
        for the beta vector in layer normalization (`use_layernorm=True`).
        Default: `zeros`.
@@ -3274,8 +3274,8 @@ class LayernormSimpleRNN(SimpleRNN):
        of the layer normalization layer (`use_layernorm=True`).
        Default: `None`.
     dropout: Float between 0 and 1.
-      Fraction of the units to drop for the linear transformation of the inputs.
-      Default: 0.
+      Fraction of the units to drop for the linear transformation of the
+      inputs. Default: 0.
     recurrent_dropout: Float between 0 and 1.
       Fraction of the units to drop for the linear transformation of the
       recurrent state. Default: 0.
@@ -3351,12 +3351,8 @@ class LayernormSimpleRNN(SimpleRNN):
                stateful=False,
                unroll=False,
                **kwargs):
-    if 'implementation' in kwargs:
-      kwargs.pop('implementation')
-      logging.warning('The `implementation` argument '
-                      'in `LayernormSimpleRNN` has been deprecated. '  # TMP(!)
-                      'Please remove it from your layer call.')
-    cell = LayernormSimpleRNNCell(  # TMP(!)
+    # 'implementation' warning was never relevant for LayernormSimpleRNN
+    cell = LayernormSimpleRNNCell(
         units,
         activation=activation,
         use_bias=use_bias,
@@ -3378,7 +3374,7 @@ class LayernormSimpleRNN(SimpleRNN):
         recurrent_dropout=recurrent_dropout,
         dtype=kwargs.get('dtype'),
         trainable=kwargs.get('trainable', True))
-    super(SimpleRNN, self).__init__(  # TMP(!)
+    super(SimpleRNN, self).__init__(  # call RNN's init
         cell,
         return_sequences=return_sequences,
         return_state=return_state,
@@ -3393,26 +3389,26 @@ class LayernormSimpleRNN(SimpleRNN):
 
   @property
   def use_layernorm(self):
-    return self.cell.use_layernorm  # NEW(!)
+    return self.cell.use_layernorm
 
   @property
   def layernorm_epsilon(self):
-    return self.cell.layernorm_epsilon  # NEW(!)
+    return self.cell.layernorm_epsilon
 
   @property
   def gamma_initializer(self):
-    return self.cell.gamma_initializer  # NEW(!)
+    return self.cell.gamma_initializer
 
   @property
   def gamma_regularizer(self):
-    return self.cell.gamma_regularizer  # NEW(!)
+    return self.cell.gamma_regularizer
 
   @property
   def gamma_constraint(self):
-    return self.cell.gamma_constraint  # NEW(!)
+    return self.cell.gamma_constraint
 
   def get_config(self):
-    base_config = super(SimpleRNN, self).get_config()
+    base_config = super(SimpleRNN, self).get_config()  # get RNN's config
     del base_config['cell']
     cell_config = self.cell.get_config()
     return dict(list(base_config.items()) + list(cell_config.items()))

--- a/tensorflow/python/keras/layers/simplernn_layernorm_test.py
+++ b/tensorflow/python/keras/layers/simplernn_layernorm_test.py
@@ -1,0 +1,242 @@
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for LayernormSimpleRNN layer."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+
+from tensorflow.python import keras
+from tensorflow.python.eager import context
+from tensorflow.python.framework import test_util as tf_test_util
+from tensorflow.python.keras import keras_parameterized
+from tensorflow.python.keras import testing_utils
+from tensorflow.python.platform import test
+from tensorflow.python.training import gradient_descent
+
+
+@keras_parameterized.run_all_keras_modes
+class LayernormSimpleRNNLayerTest(keras_parameterized.TestCase):
+
+  def test_return_sequences_layernorm_rnn(self):
+    num_samples = 2
+    timesteps = 3
+    embedding_dim = 4
+    units = 2
+    testing_utils.layer_test(
+        keras.experimental.LayernormSimpleRNN,
+        kwargs={'units': units,
+                'use_layernorm': True,  # CHANGED(!)
+                'return_sequences': True},
+        input_shape=(num_samples, timesteps, embedding_dim))
+
+  @tf_test_util.run_v2_only
+  def test_float64_layernorm_rnn(self):
+    num_samples = 2
+    timesteps = 3
+    embedding_dim = 4
+    units = 2
+    testing_utils.layer_test(
+        keras.experimental.LayernormSimpleRNN,
+        kwargs={'units': units,
+                'use_layernorm': True,  # CHANGED(!)
+                'return_sequences': True,
+                'dtype': 'float64'},
+        input_shape=(num_samples, timesteps, embedding_dim),
+        input_dtype='float64')
+
+  def test_dynamic_behavior_layernorm_rnn(self):
+    num_samples = 2
+    timesteps = 3
+    embedding_dim = 4
+    units = 2
+    layer = keras.experimental.LayernormSimpleRNN(
+        units,
+        use_layernorm=True,  # CHANGED(!)
+        input_shape=(None, embedding_dim))
+    model = keras.models.Sequential()
+    model.add(layer)
+    model.compile('rmsprop', 'mse')
+    x = np.random.random((num_samples, timesteps, embedding_dim))
+    y = np.random.random((num_samples, units))
+    model.train_on_batch(x, y)
+
+  def test_dropout_layernorm_rnn(self):
+    num_samples = 2
+    timesteps = 3
+    embedding_dim = 4
+    units = 2
+    testing_utils.layer_test(
+        keras.experimental.LayernormSimpleRNN,
+        kwargs={'units': units,
+                'use_layernorm': True,  # CHANGED(!)
+                'dropout': 0.1,
+                'recurrent_dropout': 0.1},
+        input_shape=(num_samples, timesteps, embedding_dim))
+
+  def test_implementation_mode_layernorm_rnn(self):
+    num_samples = 2
+    timesteps = 3
+    embedding_dim = 4
+    units = 2
+    for mode in [0, 1, 2]:
+      testing_utils.layer_test(
+          keras.experimental.LayernormSimpleRNN,
+          kwargs={'units': units,
+                  'use_layernorm': True,  # CHANGED(!)
+                  'implementation': mode},
+          input_shape=(num_samples, timesteps, embedding_dim))
+
+  def test_constraints_layernorm_rnn(self):
+    embedding_dim = 4
+    layer_class = keras.experimental.LayernormSimpleRNN
+    k_constraint = keras.constraints.max_norm(0.01)
+    r_constraint = keras.constraints.max_norm(0.01)
+    b_constraint = keras.constraints.max_norm(0.01)
+    layer = layer_class(
+        5,
+        use_layernorm=True,  # CHANGED(!)
+        return_sequences=False,
+        weights=None,
+        input_shape=(None, embedding_dim),
+        kernel_constraint=k_constraint,
+        recurrent_constraint=r_constraint,
+        bias_constraint=b_constraint)
+    layer.build((None, None, embedding_dim))
+    self.assertEqual(layer.cell.kernel.constraint, k_constraint)
+    self.assertEqual(layer.cell.recurrent_kernel.constraint, r_constraint)
+    self.assertEqual(layer.cell.bias.constraint, b_constraint)
+
+  def test_with_masking_layer_layernorm_rnn(self):
+    layer_class = keras.experimental.LayernormSimpleRNN
+    inputs = np.random.random((2, 3, 4))
+    targets = np.abs(np.random.random((2, 3, 5)))
+    targets /= targets.sum(axis=-1, keepdims=True)
+    model = keras.models.Sequential()
+    model.add(keras.layers.Masking(input_shape=(3, 4)))
+    model.add(layer_class(
+        units=5,
+        use_layernorm=True,  # CHANGED(!)
+        return_sequences=True,
+        unroll=False))
+    model.compile(loss='categorical_crossentropy', optimizer='rmsprop')
+    model.fit(inputs, targets, epochs=1, batch_size=2, verbose=1)
+
+  def test_from_config_layernorm_rnn(self):
+    layer_class = keras.experimental.LayernormSimpleRNN
+    for stateful in (False, True):
+      l1 = layer_class(
+          units=1,
+          use_layernorm=True,  # CHANGED(!)
+          stateful=stateful)
+      l2 = layer_class.from_config(l1.get_config())
+      assert l1.get_config() == l2.get_config()
+
+  def test_regularizers_layernorm_rnn(self):
+    embedding_dim = 4
+    layer_class = keras.experimental.LayernormSimpleRNN
+    layer = layer_class(
+        5,
+        use_layernorm=True,  # CHANGED(!)
+        return_sequences=False,
+        weights=None,
+        input_shape=(None, embedding_dim),
+        kernel_regularizer=keras.regularizers.l1(0.01),
+        recurrent_regularizer=keras.regularizers.l1(0.01),
+        bias_regularizer='l2',
+        activity_regularizer='l1')
+    layer.build((None, None, 2))
+    self.assertEqual(len(layer.losses), 3)
+
+    x = keras.backend.variable(np.ones((2, 3, 2)))
+    layer(x)
+    if context.executing_eagerly():
+      self.assertEqual(len(layer.losses), 4)
+    else:
+      self.assertEqual(len(layer.get_losses_for(x)), 1)
+
+  def test_statefulness_layernorm_rnn(self):
+    num_samples = 2
+    timesteps = 3
+    embedding_dim = 4
+    units = 2
+    layer_class = keras.experimental.LayernormSimpleRNN
+    model = keras.models.Sequential()
+    model.add(
+        keras.layers.Embedding(
+            4,
+            embedding_dim,
+            mask_zero=True,
+            input_length=timesteps,
+            batch_input_shape=(num_samples, timesteps)))
+    layer = layer_class(
+        units,
+        use_layernorm=True,  # CHANGED(!)
+        return_sequences=False,
+        stateful=True,
+        weights=None)
+    model.add(layer)
+    model.compile(
+        optimizer=gradient_descent.GradientDescentOptimizer(0.01),
+        loss='mse',
+        run_eagerly=testing_utils.should_run_eagerly(),
+        experimental_run_tf_function=testing_utils.should_run_tf_function())
+    out1 = model.predict(np.ones((num_samples, timesteps)))
+    self.assertEqual(out1.shape, (num_samples, units))
+
+    # train once so that the states change
+    model.train_on_batch(
+        np.ones((num_samples, timesteps)), np.ones((num_samples, units)))
+    out2 = model.predict(np.ones((num_samples, timesteps)))
+
+    # if the state is not reset, output should be different
+    self.assertNotEqual(out1.max(), out2.max())
+
+    # check that output changes after states are reset
+    # (even though the model itself didn't change)
+    layer.reset_states()
+    out3 = model.predict(np.ones((num_samples, timesteps)))
+    self.assertNotEqual(out2.max(), out3.max())
+
+    # check that container-level reset_states() works
+    model.reset_states()
+    out4 = model.predict(np.ones((num_samples, timesteps)))
+    np.testing.assert_allclose(out3, out4, atol=1e-5)
+
+    # check that the call to `predict` updated the states
+    out5 = model.predict(np.ones((num_samples, timesteps)))
+    self.assertNotEqual(out4.max(), out5.max())
+
+    # Check masking
+    layer.reset_states()
+
+    left_padded_input = np.ones((num_samples, timesteps))
+    left_padded_input[0, :1] = 0
+    left_padded_input[1, :2] = 0
+    out6 = model.predict(left_padded_input)
+
+    layer.reset_states()
+
+    right_padded_input = np.ones((num_samples, timesteps))
+    right_padded_input[0, -1:] = 0
+    right_padded_input[1, -2:] = 0
+    out7 = model.predict(right_padded_input)
+
+    np.testing.assert_allclose(out7, out6, atol=1e-5)
+
+if __name__ == '__main__':
+  test.main()


### PR DESCRIPTION
tf.keras.experimental.LayernormSimpleRNN is based on tf.keras.layers.SimpleRNN and can apply tf.keras.layers.LayerNormalization instead of bias before the activation function of the recurrent kernel. 

LayernormSimpleRNN is a proposal how to extend SimpleRNN (and other RNN layers) with layer normalization. 