### PR TITLE
Parsing: Remove stale forward compatibility checks

### DIFF
--- a/tensorflow/python/kernel_tests/parsing_ops_test.py
+++ b/tensorflow/python/kernel_tests/parsing_ops_test.py
@@ -114,7 +114,6 @@ class ParseExampleTest(test.TestCase):
           self.assertEqual(out[k].values.shape.as_list(), [None])
           self.assertEqual(out[k].dense_shape.shape.as_list(), [2])
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testEmptySerializedWithAllDefaults(self):
     sparse_name = "st_a"
     a_name = "a"
@@ -154,7 +153,6 @@ class ParseExampleTest(test.TestCase):
         }
     }, expected_output)
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testEmptySerializedWithoutDefaultsShouldFail(self):
     input_features = {
         "st_a":
@@ -195,7 +193,6 @@ class ParseExampleTest(test.TestCase):
             errors_impl.OpError,
             "Name: in1, Feature: c \\(data type: float\\) is required"))
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testDenseNotMatchingShapeShouldFail(self):
     original = [
         example(features=features({
@@ -220,7 +217,6 @@ class ParseExampleTest(test.TestCase):
         expected_err=(errors_impl.OpError,
                       "Name: failing, Key: a, Index: 1.  Number of float val"))
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testDenseDefaultNoShapeShouldFail(self):
     original = [
         example(features=features({
@@ -240,7 +236,6 @@ class ParseExampleTest(test.TestCase):
         },
         expected_err=(ValueError, "Missing shape for feature a"))
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSerializedContainingSparse(self):
     original = [
         example(features=features({
@@ -285,7 +280,6 @@ class ParseExampleTest(test.TestCase):
         }
     }, expected_output)
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSerializedContainingSparseFeature(self):
     original = [
         example(
@@ -330,7 +324,6 @@ class ParseExampleTest(test.TestCase):
         }
     }, expected_output)
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSerializedContainingSparseFeatureReuse(self):
     original = [
         example(
@@ -374,7 +367,6 @@ class ParseExampleTest(test.TestCase):
         }
     }, expected_output)
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSerializedContaining3DSparseFeature(self):
     original = [
         example(
@@ -427,7 +419,6 @@ class ParseExampleTest(test.TestCase):
         }
     }, expected_output)
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSerializedContainingDense(self):
     aname = "a"
     bname = "b*has+a:tricky_name"
@@ -466,7 +457,6 @@ class ParseExampleTest(test.TestCase):
 
   # This test is identical as the previous one except
   # for the creation of 'serialized'.
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSerializedContainingDenseWithConcat(self):
     aname = "a"
     bname = "b*has+a:tricky_name"
@@ -514,7 +504,6 @@ class ParseExampleTest(test.TestCase):
         }
     }, expected_output)
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSerializedContainingDenseScalar(self):
     original = [
         example(features=features({
@@ -539,7 +528,6 @@ class ParseExampleTest(test.TestCase):
         }
     }, expected_output)
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSerializedContainingDenseWithDefaults(self):
     original = [
         example(features=features({
@@ -576,7 +564,6 @@ class ParseExampleTest(test.TestCase):
         }
     }, expected_output)
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSerializedContainingSparseAndSparseFeatureAndDenseWithNoDefault(self):
     expected_st_a = (  # indices, values, shape
         np.empty((0, 2), dtype=np.int64),  # indices
@@ -637,7 +624,6 @@ class ParseExampleTest(test.TestCase):
         },
         expected_output)
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSerializedContainingSparseAndSparseFeatureWithReuse(self):
     expected_idx = (  # indices, values, shape
         np.array([[0, 0], [0, 1], [1, 0], [1, 1]], dtype=np.int64),
@@ -743,13 +729,11 @@ class ParseExampleTest(test.TestCase):
         }
     }, expected_output)
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSerializedContainingVarLenDenseLargerBatch(self):
     np.random.seed(3456)
     for batch_size in (1, 10, 20, 100, 256):
       self._testSerializedContainingVarLenDenseLargerBatch(batch_size)
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSerializedContainingVarLenDense(self):
     aname = "a"
     bname = "b"
@@ -943,7 +927,6 @@ class ParseExampleTest(test.TestCase):
                       "Unsupported: FixedLenSequenceFeature requires "
                       "allow_missing to be True."))
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSerializedContainingRaggedFeatureWithNoPartitions(self):
     original = [
         example(features=features({"rt_c": float_feature([3, 4])})),
@@ -1002,7 +985,6 @@ class ParseExampleTest(test.TestCase):
             "features": test_features
         }, batch_expected_out)
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSerializedContainingRaggedFeature(self):
     original = [
         example(
@@ -1121,7 +1103,6 @@ class ParseExampleTest(test.TestCase):
         "features": test_features
     }, expected_output)
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSerializedContainingNestedRaggedFeature(self):
     """Test RaggedFeature with 3 partitions."""
     original = [
@@ -1203,7 +1184,6 @@ class ParseSingleExampleTest(test.TestCase):
           self.assertEqual(tuple(out[k].values.shape.as_list()), (None,))
           self.assertEqual(tuple(out[k].dense_shape.shape.as_list()), (1,))
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSingleExampleWithSparseAndSparseFeatureAndDense(self):
     original = example(
         features=features({
@@ -1272,7 +1252,6 @@ class ParseSingleExampleTest(test.TestCase):
             "features": test_features,
         }, expected_output)
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSingleExampleWithAllFeatureTypes(self):
     original = example(
         features=features({
@@ -1562,7 +1541,6 @@ class ParseSequenceExampleTest(test.TestCase):
         expected_err=expected_err,
         batch=True)
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSequenceExampleWithSparseAndDenseContext(self):
     original = sequence_example(
         context=features({
@@ -1606,7 +1584,6 @@ class ParseSequenceExampleTest(test.TestCase):
         },
         expected_context_values=expected_context_output)
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSequenceExampleWithMultipleSizeFeatureLists(self):
     original = sequence_example(
         feature_lists=feature_lists({
@@ -1670,7 +1647,6 @@ class ParseSequenceExampleTest(test.TestCase):
         },
         expected_feat_list_values=expected_feature_list_output)
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSequenceExampleWithoutDebugName(self):
     original = sequence_example(
         feature_lists=feature_lists({
@@ -1728,7 +1704,6 @@ class ParseSequenceExampleTest(test.TestCase):
         },
         expected_feat_list_values=expected_feature_list_output)
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSequenceExampleWithSparseAndDenseFeatureLists(self):
     original = sequence_example(
         feature_lists=feature_lists({
@@ -1787,7 +1762,6 @@ class ParseSequenceExampleTest(test.TestCase):
         },
         expected_feat_list_values=expected_feature_list_output)
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSequenceExampleWithEmptyFeatureInFeatureLists(self):
     original = sequence_example(
         feature_lists=feature_lists({
@@ -1820,7 +1794,6 @@ class ParseSequenceExampleTest(test.TestCase):
         },
         expected_feat_list_values=expected_feature_list_output)
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSequenceExampleListWithInconsistentDataFails(self):
     original = sequence_example(
         feature_lists=feature_lists({
@@ -1841,7 +1814,6 @@ class ParseSequenceExampleTest(test.TestCase):
         expected_err=(errors_impl.OpError, "Feature list: a, Index: 1."
                       "  Data types don't match. Expected type: int64"))
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSequenceExampleListWithWrongDataTypeFails(self):
     original = sequence_example(
         feature_lists=feature_lists({
@@ -1862,7 +1834,6 @@ class ParseSequenceExampleTest(test.TestCase):
                       "Feature list: a, Index: 0.  Data types don't match."
                       " Expected type: int64"))
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSequenceExampleListWithWrongSparseDataTypeFails(self):
     original = sequence_example(
         feature_lists=feature_lists({
@@ -1888,7 +1859,6 @@ class ParseSequenceExampleTest(test.TestCase):
                       "Name: in1, Feature list: a, Index: 2."
                       "  Data types don't match. Expected type: int64"))
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSequenceExampleListWithWrongShapeFails(self):
     original = sequence_example(
         feature_lists=feature_lists({
@@ -1918,7 +1888,6 @@ class ParseSequenceExampleTest(test.TestCase):
             r"Total values size: 5 is not consistent with output "
             r"shape: \[\?,2\]"))
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSequenceExampleListWithWrongShapeFails2(self):
     # This exercises a different code path for FastParseSequenceExample than
     # testSequenceExampleListWithWrongShapeFails (in that test, we can tell that
@@ -1944,7 +1913,6 @@ class ParseSequenceExampleTest(test.TestCase):
                       r"  Number of (int64 )?values != expected."
                       r"  values size: 1 but output shape: \[2\]"))
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSequenceExampleWithMissingFeatureListFails(self):
     original = sequence_example(feature_lists=feature_lists({}))
 
@@ -1965,7 +1933,6 @@ class ParseSequenceExampleTest(test.TestCase):
             " feature_list_dense_missing_assumed_empty or"
             " feature_list_dense_defaults?"))
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSequenceExampleBatch(self):
     first = sequence_example(
         feature_lists=feature_lists({
@@ -2046,7 +2013,6 @@ class ParseSequenceExampleTest(test.TestCase):
         },
         batch=True)
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSerializedContainingRaggedFeatureWithNoPartitions(self):
     original = [
         sequence_example(
@@ -2147,7 +2113,6 @@ class ParseSequenceExampleTest(test.TestCase):
         batch_feature_list_expected_out,
         batch=True)
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSerializedContainingNestedRaggedFeature(self):
     """Test RaggedFeatures with nested partitions."""
     original = [
@@ -2271,7 +2236,6 @@ class ParseSequenceExampleTest(test.TestCase):
         },
         batch=False)
 
-  @test_util.with_forward_compatibility_horizons(None, [2019, 10, 31])
   def testSerializedContainingMisalignedNestedRaggedFeature(self):
     """FeatureList with 2 value tensors but only one splits tensor."""
     original = sequence_example(

--- a/tensorflow/python/ops/parsing_ops.py
+++ b/tensorflow/python/ops/parsing_ops.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from tensorflow.python.compat import compat
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import sparse_tensor
 from tensorflow.python.ops import array_ops
@@ -609,83 +608,54 @@ def _parse_sequence_example_raw(serialized,
       feature_list_dense_missing_assumed_empty.append(k)
 
     has_ragged = context.ragged_keys or feature_list.ragged_keys
-    if compat.forward_compatible(2019, 10, 26) or has_ragged:
-      serialized = ops.convert_to_tensor(serialized, name="serialized")
-      if has_ragged and serialized.shape.ndims is None:
-        raise ValueError("serialized must have statically-known rank to "
-                         "parse ragged features.")
-      feature_list_dense_missing_assumed_empty_vector = [
-          key in feature_list_dense_missing_assumed_empty
-          for key in feature_list.dense_keys
-      ]
-      outputs = gen_parsing_ops.parse_sequence_example_v2(
-          # Inputs
-          serialized=serialized,
-          debug_name=debug_name,
-          context_sparse_keys=context.sparse_keys,
-          context_dense_keys=context.dense_keys,
-          context_ragged_keys=context.ragged_keys,
-          feature_list_sparse_keys=feature_list.sparse_keys,
-          feature_list_dense_keys=feature_list.dense_keys,
-          feature_list_ragged_keys=feature_list.ragged_keys,
-          feature_list_dense_missing_assumed_empty=(
-              feature_list_dense_missing_assumed_empty_vector),
-          context_dense_defaults=context.dense_defaults_vec,
-          # Attrs
-          Ncontext_sparse=len(context.sparse_keys),
-          Nfeature_list_sparse=len(feature_list.sparse_keys),
-          Nfeature_list_dense=len(feature_list.dense_keys),
-          context_sparse_types=context.sparse_types,
-          context_ragged_value_types=context.ragged_value_types,
-          context_ragged_split_types=context.ragged_split_types,
-          feature_list_dense_types=feature_list.dense_types,
-          feature_list_sparse_types=feature_list.sparse_types,
-          feature_list_ragged_value_types=feature_list.ragged_value_types,
-          feature_list_ragged_split_types=feature_list.ragged_split_types,
-          context_dense_shapes=context.dense_shapes_as_proto,
-          feature_list_dense_shapes=feature_list.dense_shapes,
-          name=name)
-      (context_sparse_indices, context_sparse_values, context_sparse_shapes,
-       context_dense_values, context_ragged_values, context_ragged_row_splits,
-       feature_list_sparse_indices, feature_list_sparse_values,
-       feature_list_sparse_shapes, feature_list_dense_values,
-       feature_list_dense_lengths, feature_list_ragged_values,
-       feature_list_ragged_outer_splits,
-       feature_list_ragged_inner_splits) = outputs
-      # pylint: disable=protected-access
-      context_ragged_tensors = parsing_config._build_ragged_tensors(
-          serialized.shape, context_ragged_values, context_ragged_row_splits)
-      feature_list_ragged_tensors = parsing_config._build_ragged_tensors(
-          serialized.shape, feature_list_ragged_values,
-          feature_list_ragged_outer_splits, feature_list_ragged_inner_splits)
-    else:
-      outputs = gen_parsing_ops.parse_sequence_example(
-          serialized=serialized,
-          debug_name=debug_name,
-          Ncontext_sparse=len(context.sparse_keys),
-          Ncontext_dense=len(context.dense_keys),
-          Nfeature_list_sparse=len(feature_list.sparse_keys),
-          Nfeature_list_dense=len(feature_list.dense_keys),
-          context_dense_defaults=context.dense_defaults_vec,
-          context_sparse_keys=context.sparse_keys,
-          context_sparse_types=context.sparse_types,
-          context_dense_keys=context.dense_keys,
-          context_dense_shapes=context.dense_shapes_as_proto,
-          feature_list_sparse_keys=feature_list.sparse_keys,
-          feature_list_sparse_types=feature_list.sparse_types,
-          feature_list_dense_keys=feature_list.dense_keys,
-          feature_list_dense_types=feature_list.dense_types,
-          feature_list_dense_shapes=feature_list.dense_shapes,
-          feature_list_dense_missing_assumed_empty=(
-              feature_list_dense_missing_assumed_empty),
-          name=name)
-
-      (context_sparse_indices, context_sparse_values, context_sparse_shapes,
-       context_dense_values, feature_list_sparse_indices,
-       feature_list_sparse_values, feature_list_sparse_shapes,
-       feature_list_dense_values, feature_list_dense_lengths) = outputs
-      context_ragged_tensors = []
-      feature_list_ragged_tensors = []
+    serialized = ops.convert_to_tensor(serialized, name="serialized")
+    if has_ragged and serialized.shape.ndims is None:
+      raise ValueError("serialized must have statically-known rank to "
+                       "parse ragged features.")
+    feature_list_dense_missing_assumed_empty_vector = [
+        key in feature_list_dense_missing_assumed_empty
+        for key in feature_list.dense_keys
+    ]
+    outputs = gen_parsing_ops.parse_sequence_example_v2(
+        # Inputs
+        serialized=serialized,
+        debug_name=debug_name,
+        context_sparse_keys=context.sparse_keys,
+        context_dense_keys=context.dense_keys,
+        context_ragged_keys=context.ragged_keys,
+        feature_list_sparse_keys=feature_list.sparse_keys,
+        feature_list_dense_keys=feature_list.dense_keys,
+        feature_list_ragged_keys=feature_list.ragged_keys,
+        feature_list_dense_missing_assumed_empty=(
+            feature_list_dense_missing_assumed_empty_vector),
+        context_dense_defaults=context.dense_defaults_vec,
+        # Attrs
+        Ncontext_sparse=len(context.sparse_keys),
+        Nfeature_list_sparse=len(feature_list.sparse_keys),
+        Nfeature_list_dense=len(feature_list.dense_keys),
+        context_sparse_types=context.sparse_types,
+        context_ragged_value_types=context.ragged_value_types,
+        context_ragged_split_types=context.ragged_split_types,
+        feature_list_dense_types=feature_list.dense_types,
+        feature_list_sparse_types=feature_list.sparse_types,
+        feature_list_ragged_value_types=feature_list.ragged_value_types,
+        feature_list_ragged_split_types=feature_list.ragged_split_types,
+        context_dense_shapes=context.dense_shapes_as_proto,
+        feature_list_dense_shapes=feature_list.dense_shapes,
+        name=name)
+    (context_sparse_indices, context_sparse_values, context_sparse_shapes,
+     context_dense_values, context_ragged_values, context_ragged_row_splits,
+     feature_list_sparse_indices, feature_list_sparse_values,
+     feature_list_sparse_shapes, feature_list_dense_values,
+     feature_list_dense_lengths, feature_list_ragged_values,
+     feature_list_ragged_outer_splits,
+     feature_list_ragged_inner_splits) = outputs
+    # pylint: disable=protected-access
+    context_ragged_tensors = parsing_config._build_ragged_tensors(
+        serialized.shape, context_ragged_values, context_ragged_row_splits)
+    feature_list_ragged_tensors = parsing_config._build_ragged_tensors(
+        serialized.shape, feature_list_ragged_values,
+        feature_list_ragged_outer_splits, feature_list_ragged_inner_splits)
 
     # pylint: disable=g-complex-comprehension
     context_sparse_tensors = [
@@ -857,71 +827,11 @@ def _parse_single_sequence_example_raw(serialized,
   Raises:
     TypeError: if feature_list.dense_defaults is not either None or a dict.
   """
-  has_ragged = context.ragged_keys or feature_list.ragged_keys
-  if compat.forward_compatible(2019, 10, 26) or has_ragged:
-    with ops.name_scope(name, "ParseSingleExample", [serialized, debug_name]):
-      serialized = ops.convert_to_tensor(serialized, name="serialized")
-      serialized = _assert_scalar(serialized, "serialized")
-    return _parse_sequence_example_raw(serialized, debug_name, context,
-                                       feature_list, name)[:2]
-
-  if context.num_features + feature_list.num_features == 0:
-    raise ValueError("Must provide at least one feature key")
-  with ops.name_scope(name, "ParseSingleSequenceExample", [serialized]):
-    debug_name = "" if debug_name is None else debug_name
-
-    # Internal
-    feature_list_dense_missing_assumed_empty = []
-    for k, v in feature_list.dense_defaults.items():
-      if v is not None:
-        raise ValueError("Value feature_list.dense_defaults[%s] must be None" %
-                         k)
-      feature_list_dense_missing_assumed_empty.append(k)
-
-    outputs = gen_parsing_ops.parse_single_sequence_example(
-        serialized=serialized,
-        debug_name=debug_name,
-        context_dense_defaults=context.dense_defaults_vec,
-        context_sparse_keys=context.sparse_keys,
-        context_sparse_types=context.sparse_types,
-        context_dense_keys=context.dense_keys,
-        context_dense_shapes=context.dense_shapes,
-        feature_list_sparse_keys=feature_list.sparse_keys,
-        feature_list_sparse_types=feature_list.sparse_types,
-        feature_list_dense_keys=feature_list.dense_keys,
-        feature_list_dense_types=feature_list.dense_types,
-        feature_list_dense_shapes=feature_list.dense_shapes,
-        feature_list_dense_missing_assumed_empty=(
-            feature_list_dense_missing_assumed_empty),
-        name=name)
-
-    (context_sparse_indices, context_sparse_values,
-     context_sparse_shapes, context_dense_values,
-     feature_list_sparse_indices, feature_list_sparse_values,
-     feature_list_sparse_shapes, feature_list_dense_values) = outputs
-
-    # pylint: disable=g-complex-comprehension
-    context_sparse_tensors = [
-        sparse_tensor.SparseTensor(ix, val, shape) for (ix, val, shape)
-        in zip(context_sparse_indices,
-               context_sparse_values,
-               context_sparse_shapes)]
-
-    feature_list_sparse_tensors = [
-        sparse_tensor.SparseTensor(ix, val, shape) for (ix, val, shape)
-        in zip(feature_list_sparse_indices,
-               feature_list_sparse_values,
-               feature_list_sparse_shapes)]
-    # pylint: enable=g-complex-comprehension
-
-    context_output = dict(
-        zip(context.sparse_keys + context.dense_keys,
-            context_sparse_tensors + context_dense_values))
-    feature_list_output = dict(
-        zip(feature_list.sparse_keys + feature_list.dense_keys,
-            feature_list_sparse_tensors + feature_list_dense_values))
-
-    return (context_output, feature_list_output)
+  with ops.name_scope(name, "ParseSingleExample", [serialized, debug_name]):
+    serialized = ops.convert_to_tensor(serialized, name="serialized")
+    serialized = _assert_scalar(serialized, "serialized")
+  return _parse_sequence_example_raw(serialized, debug_name, context,
+                                     feature_list, name)[:2]
 
 
 @tf_export("io.decode_raw", v1=[])


### PR DESCRIPTION
`compat.forward_compatible(2019, 10, 26)` always evaluates to `True` so a bit of stale code can be removed.