### PR TITLE
Add more documentation and a usage example for tf.math.sigmoid

### DIFF
--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -3203,7 +3203,7 @@ def _accumulate_n_grad(op, grad):
 def sigmoid(x, name=None):
   """Computes sigmoid of `x` element-wise.
 
-  Specifically, `y = 1 / (1 + exp(-x))`.
+  Specifically, computes `y = 1 / (1 + exp(-x))`.
   
   The sigmoid function is a function that outputs between `[0, 1]` and is often
   used as the logistic activation function of the last layer in a 
@@ -3213,7 +3213,7 @@ def sigmoid(x, name=None):
   are negative, the function outputs a value `< 0.5` (and as `x` approaches 
   negative infinity, the value approaches `0`). At `x = 0`, the value is `0.5`.
   Due to this behavior, the sigmoid function is often used to map a tensor to 
-  a list of probabilities (since probabilities, as well, are between `[0, 1]`).
+  a list of probabilities (since probabilities are also between `[0, 1]`).
 
   Args:
     x: A Tensor with type `float16`, `float32`, `float64`, `complex64`, or
@@ -3225,11 +3225,9 @@ def sigmoid(x, name=None):
     
   Usage Example:
 
-  >>> y = tf.math.sigmoid(1.0)
-  >>> print(y)
+  >>> tf.math.sigmoid(1.0)
   tf.Tensor(0.73..., shape=(), dtype=float32)
-  >>> y = tf.math.sigmoid(-1.0)
-  >>> print(y)
+  >>> tf.math.sigmoid(-1.0)
   tf.Tensor(0.26..., shape=(), dtype=float32)
 
   @compatibility(scipy)

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -3204,6 +3204,12 @@ def sigmoid(x, name=None):
   """Computes sigmoid of `x` element-wise.
 
   Specifically, `y = 1 / (1 + exp(-x))`.
+  
+  The sigmoid function is a function that outputs between `[0, 1]` and is often used as the logistic activation function of the last layer in a classification model. 
+  This is due to the nature of its range - for values of `x` that are positive, the function outputs a value `> 0.5` (and as `x` approaches infinity, the value 
+  approaches `1`), and for values of `x` that are negative, the function outputs a value `< 0.5` (and as `x` approaches negative infinity, the value approaches `0`). 
+  At `x = 0`, the value is `0.5`. Due to this behavior, the sigmoid function is often used to map a tensor to a list of probabilities (since probabilities, as well, 
+  are between `[0, 1]`).
 
   Args:
     x: A Tensor with type `float16`, `float32`, `float64`, `complex64`, or
@@ -3212,6 +3218,15 @@ def sigmoid(x, name=None):
 
   Returns:
     A Tensor with the same type as `x`.
+    
+  Usage Example:
+
+  >>> y = tf.math.sigmoid(10.0)
+  >>> print(y)
+  tf.Tensor(0.9999546, shape=(), dtype=float32)
+  >>> y = tf.math.sigmoid(-10.0)
+  >>> print(y)
+  tf.Tensor(4.5397872e-05, shape=(), dtype=float32)
 
   @compatibility(scipy)
   Equivalent to scipy.special.expit

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -3205,11 +3205,15 @@ def sigmoid(x, name=None):
 
   Specifically, `y = 1 / (1 + exp(-x))`.
   
-  The sigmoid function is a function that outputs between `[0, 1]` and is often used as the logistic activation function of the last layer in a classification model. 
-  This is due to the nature of its range - for values of `x` that are positive, the function outputs a value `> 0.5` (and as `x` approaches infinity, the value 
-  approaches `1`), and for values of `x` that are negative, the function outputs a value `< 0.5` (and as `x` approaches negative infinity, the value approaches `0`). 
-  At `x = 0`, the value is `0.5`. Due to this behavior, the sigmoid function is often used to map a tensor to a list of probabilities (since probabilities, as well, 
-  are between `[0, 1]`).
+  The sigmoid function is a function that outputs between `[0, 1]` and is often
+  used as the logistic activation function of the last layer in a 
+  classification model. This is due to the nature of its range - for values of 
+  `x` that are positive, the function outputs a value `> 0.5` (and as `x` 
+  approaches infinity, the value approaches `1`), and for values of `x` that 
+  are negative, the function outputs a value `< 0.5` (and as `x` approaches 
+  negative infinity, the value approaches `0`). At `x = 0`, the value is `0.5`.
+  Due to this behavior, the sigmoid function is often used to map a tensor to 
+  a list of probabilities (since probabilities, as well, are between `[0, 1]`).
 
   Args:
     x: A Tensor with type `float16`, `float32`, `float64`, `complex64`, or
@@ -3221,12 +3225,12 @@ def sigmoid(x, name=None):
     
   Usage Example:
 
-  >>> y = tf.math.sigmoid(10.0)
+  >>> y = tf.math.sigmoid(1.0)
   >>> print(y)
-  tf.Tensor(0.9999546, shape=(), dtype=float32)
-  >>> y = tf.math.sigmoid(-10.0)
+  tf.Tensor(0.73..., shape=(), dtype=float32)
+  >>> y = tf.math.sigmoid(-1.0)
   >>> print(y)
-  tf.Tensor(4.5397872e-05, shape=(), dtype=float32)
+  tf.Tensor(0.26..., shape=(), dtype=float32)
 
   @compatibility(scipy)
   Equivalent to scipy.special.expit

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -3226,9 +3226,9 @@ def sigmoid(x, name=None):
   Usage Example:
 
   >>> tf.math.sigmoid(1.0)
-  tf.Tensor(0.73..., shape=(), dtype=float32)
+  <tf.Tensor: shape=(), dtype=float32, numpy=0.73...>
   >>> tf.math.sigmoid(-1.0)
-  tf.Tensor(0.26..., shape=(), dtype=float32)
+  <tf.Tensor: shape=(), dtype=float32, numpy=0.26...>
 
   @compatibility(scipy)
   Equivalent to scipy.special.expit


### PR DESCRIPTION
This change is to add documentation and a usage example for a key logistic activation, `tf.math.sigmoid`, so machine learning enthusiasts will be able to better understand the use of this function.