### PR TITLE
Cherry-pick the release build scripts

### DIFF
--- a/tensorflow/tools/ci_build/presubmit/macos/py2_cc/build.sh
+++ b/tensorflow/tools/ci_build/presubmit/macos/py2_cc/build.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+# TODO(mihaimaruseac,hyey,ggadde): Convert to py3
+
+set -e
+
+# Error if we somehow forget to set the path to bazel_wrapper.py
+set -u
+BAZEL_WRAPPER_PATH=$1
+set +u
+
+# From this point on, logs can be publicly available
+set -x
+
+function setup_pip () {
+  install_pip2
+  python -m virtualenv tf_build_env --system-site-packages
+  source tf_build_env/bin/activate
+  install_macos_pip_deps
+}
+
+function run_build () {
+  # Run configure.
+  export TF_NEED_CUDA=0
+  export PYTHON_BIN_PATH=$(which python2)
+  yes "" | $PYTHON_BIN_PATH configure.py
+  tag_filters="-no_oss,-no_oss_py2,-gpu,-tpu,-benchmark-test,-nomac,-no_mac,-v1only"
+
+  # Get the default test targets for bazel.
+  source tensorflow/tools/ci_build/build_scripts/PRESUBMIT_BUILD_TARGETS.sh
+
+  "${BAZEL_WRAPPER_PATH}" \
+    test \
+    --build_tag_filters="${tag_filters}" \
+    --test_tag_filters="${tag_filters}" \
+    --action_env=PATH \
+    --remote_accept_cached=true \
+    --spawn_strategy=standalone \
+    --remote_local_fallback=false \
+    --remote_timeout=600 \
+    --strategy=Javac=standalone \
+    --strategy=Closure=standalone \
+    --genrule_strategy=standalone \
+    -- ${DEFAULT_BAZEL_TARGETS} -//tensorflow/lite/...
+
+  # Copy log to output to be available to GitHub
+  ls -la "$(bazel info output_base)/java.log"
+  cp "$(bazel info output_base)/java.log" "${KOKORO_ARTIFACTS_DIR}/"
+}
+
+source tensorflow/tools/ci_build/release/common.sh
+update_bazel_macos
+which bazel
+set_bazel_outdir
+
+setup_pip
+run_build

--- a/tensorflow/tools/ci_build/presubmit/ubuntu_16/android/build.sh
+++ b/tensorflow/tools/ci_build/presubmit/ubuntu_16/android/build.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+set -e
+
+# Error if we somehow forget to set the path to bazel_wrapper.py
+set -u
+BAZEL_WRAPPER_PATH=$1
+set +u
+
+# From this point on, logs can be publicly available
+set -x
+
+function run_build () {
+  export ANDROID_NDK_HOME="/opt/android-ndk-r17c"
+  export NDK_HOME=$ANDROID_NDK_HOME
+  export ANDROID_SDK_HOME="/opt/android-sdk/current"
+  export ANDROID_API_LEVEL="23"
+  export ANDROID_BUILD_TOOLS_VERSION="28.0.0"
+
+  ANDROID_OUT=android.out
+  ANDROID_OUT_TARGET=gen_android_out
+
+  # Run the presubmit android build.
+  tensorflow/tools/ci_build/builds/android.sh 2>&1 | tee tensorflow/tools/ci_build/builds/${ANDROID_OUT}
+  RC=${PIPESTATUS[0]}
+
+  # Since we are running the build remotely (rbe), we need to build a bazel
+  # target that would output the log generated above and return the expected
+  # error code.
+  cat << EOF > tensorflow/tools/ci_build/builds/BUILD
+package(default_visibility = ["//tensorflow:internal"])
+
+sh_test(
+    name = "${ANDROID_OUT_TARGET}",
+    srcs = ["${ANDROID_OUT_TARGET}.sh"],
+    data = ["${ANDROID_OUT}"],
+    tags = ["local"],
+)
+EOF
+
+  cat << EOF > tensorflow/tools/ci_build/builds/${ANDROID_OUT_TARGET}.sh
+#!/bin/bash
+cat tensorflow/tools/ci_build/builds/${ANDROID_OUT}
+exit ${RC}
+EOF
+
+  # Now trigger the rbe build that outputs the log
+  chmod +x tensorflow/tools/ci_build/builds/${ANDROID_OUT_TARGET}.sh
+
+  # Run bazel test command. Double test timeouts to avoid flakes.
+  # //tensorflow/core:platform_setround_test is not supported. See b/64264700
+  "${BAZEL_WRAPPER_PATH}" \
+    --host_jvm_args=-Dbazel.DigestFunction=SHA256 \
+    test \
+    --test_output=all \
+    tensorflow/tools/ci_build/builds:${ANDROID_OUT_TARGET}
+
+  # Copy log to output to be available to GitHub
+  ls -la "$(bazel info output_base)/java.log"
+  cp "$(bazel info output_base)/java.log" "${KOKORO_ARTIFACTS_DIR}/"
+}
+
+source tensorflow/tools/ci_build/release/common.sh
+update_bazel_linux
+which bazel
+
+run_build

--- a/tensorflow/tools/ci_build/presubmit/ubuntu_16/cpu_py36_full/build.sh
+++ b/tensorflow/tools/ci_build/presubmit/ubuntu_16/cpu_py36_full/build.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+set -e
+
+# Error if we somehow forget to set the path to bazel_wrapper.py
+set -u
+BAZEL_WRAPPER_PATH=$1
+set +u
+
+# From this point on, logs can be publicly available
+set -x
+
+function run_build () {
+  # Build a unique cache silo string.
+  UBUNTU_VERSION=$(lsb_release -a | grep Release | awk '{print $2}')
+  IMAGE_VERSION=$(cat /VERSION)
+  CACHE_SILO_VAL="cpu-py3-ubuntu-16-${UBUNTU_VERSION}-${IMAGE_VERSION}"
+
+  # Run configure.
+  # Do not run configure.py when doing remote build & test:
+  # Most things we set with configure.py are not used in a remote build setting,
+  # as the build will be defined by pre-configured build files that are checked
+  # in.
+  # TODO(klimek): Allow using the right set of bazel flags without the need to
+  # run configure.py; currently we need to carefully copy them, which is brittle.
+  export TF_NEED_GCP=0
+  export TF_NEED_HDFS=0
+  export TF_NEED_CUDA=0
+  export ACTION_PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+  export PYTHON_BIN_PATH="/usr/bin/python3"
+  export TF2_BEHAVIOR=1
+  tag_filters="-no_oss,-oss_serial,-gpu,-tpu,-benchmark-test""$(maybe_skip_v1)"
+
+  # Get the default test targets for bazel.
+  source tensorflow/tools/ci_build/build_scripts/PRESUBMIT_BUILD_TARGETS.sh
+
+  # Run bazel test command. Double test timeouts to avoid flakes.
+  # //tensorflow/core:platform_setround_test is not supported. See b/64264700
+  "${BAZEL_WRAPPER_PATH}" \
+    test \
+    --config=rbe \
+    --python_path="${PYTHON_BIN_PATH}" \
+    --action_env=PATH="${ACTION_PATH}" \
+    --action_env=PYTHON_BIN_PATH="${PYTHON_BIN_PATH}" \
+    --action_env=TF2_BEHAVIOR="${TF2_BEHAVIOR}" \
+    --action_env=TF_PYTHON_CONFIG_REPO=@org_tensorflow//third_party/toolchains/preconfig/ubuntu16.04/py3 \
+    --action_env=TF_ENABLE_XLA=1 \
+    --test_tag_filters="${tag_filters}" \
+    --build_tag_filters="${tag_filters}" \
+    --test_lang_filters=cc,py \
+    --define=with_default_optimizations=true \
+    --define=framework_shared_object=true \
+    --define=with_xla_support=true \
+    -c opt \
+    --copt="-w" \
+    --copt=-mavx \
+    --linkopt=-lrt \
+    --distinct_host_configuration=false \
+    --remote_default_platform_properties="properties:{name:\"build\" value:\"${CACHE_SILO_VAL}\"}" \
+    --crosstool_top=//third_party/toolchains/preconfig/ubuntu16.04/gcc7_manylinux2010:toolchain \
+    --host_javabase=@bazel_toolchains//configs/ubuntu16_04_clang/1.1:jdk8 \
+    --javabase=@bazel_toolchains//configs/ubuntu16_04_clang/1.1:jdk8 \
+    --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8 \
+    --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8 \
+    --extra_toolchains=//third_party/toolchains/preconfig/ubuntu16.04/gcc7_manylinux2010:cc-toolchain-k8 \
+    --extra_execution_platforms=@org_tensorflow//third_party/toolchains:rbe_ubuntu16.04-manylinux2010 \
+    --host_platform=@org_tensorflow//third_party/toolchains:rbe_ubuntu16.04-manylinux2010 \
+    --remote_timeout=3600 \
+    --platforms=@org_tensorflow//third_party/toolchains:rbe_ubuntu16.04-manylinux2010 \
+    -- \
+    ${DEFAULT_BAZEL_TARGETS} -//tensorflow/lite/...
+
+  # Copy log to output to be available to GitHub
+  ls -la "$(bazel info output_base)/java.log"
+  cp "$(bazel info output_base)/java.log" "${KOKORO_ARTIFACTS_DIR}/"
+}
+
+source tensorflow/tools/ci_build/release/common.sh
+update_bazel_linux
+which bazel
+
+run_build

--- a/tensorflow/tools/ci_build/presubmit/ubuntu_16/gpu_py36_full/build.sh
+++ b/tensorflow/tools/ci_build/presubmit/ubuntu_16/gpu_py36_full/build.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+set -e
+
+# Error if we somehow forget to set the path to bazel_wrapper.py
+set -u
+BAZEL_WRAPPER_PATH=$1
+set +u
+
+# From this point on, logs can be publicly available
+set -x
+
+function run_build () {
+  # Build a unique cache silo string.
+  UBUNTU_VERSION=$(lsb_release -a | grep Release | awk '{print $2}')
+  IMAGE_VERSION=$(cat /VERSION)
+  CACHE_SILO_VAL="gpu-py3-ubuntu-16-${UBUNTU_VERSION}-${IMAGE_VERSION}"
+
+  # Run configure.
+  # Do not run configure.py when doing remote build & test:
+  # Most things we set with configure.py are not used in a remote build setting,
+  # as the build will be defined by pre-configured build files that are checked
+  # in.
+  # TODO(klimek): Allow using the right set of bazel flags without the need to
+  # run configure.py; currently we need to carefully copy them, which is brittle.
+  export LD_LIBRARY_PATH="/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64"
+  # TODO(klimek): Remove once we don't try to read it while setting up the remote
+  # config for cuda (we currently don't use it, as it's only used when compiling
+  # with clang, but we still require it to be set anyway).
+  export TF_CUDA_COMPUTE_CAPABILITIES=6.0
+  export ACTION_PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+  export PYTHON_BIN_PATH="/usr/bin/python3"
+  export TF2_BEHAVIOR=1
+  tag_filters="gpu,-no_gpu,-nogpu,-benchmark-test,-no_oss,-oss_serial""$(maybe_skip_v1)"
+
+  # Get the default test targets for bazel.
+  source tensorflow/tools/ci_build/build_scripts/PRESUBMIT_BUILD_TARGETS.sh
+
+  # Run bazel test command. Double test timeouts to avoid flakes.
+  # //tensorflow/core:platform_setround_test is not supported. See b/64264700
+  # TODO(klimek): Re-enable tensorrt tests (with different runtime image) once
+  # we can build them.
+  # TODO(klimek): Stop using action_env for things that are only needed during
+  # setup - we're artificially poisoning the cache.
+  "${BAZEL_WRAPPER_PATH}" \
+    test \
+    --config=rbe \
+    --python_path="${PYTHON_BIN_PATH}" \
+    --action_env=PATH="${ACTION_PATH}" \
+    --action_env=PYTHON_BIN_PATH="${PYTHON_BIN_PATH}" \
+    --action_env=TF2_BEHAVIOR="${TF2_BEHAVIOR}" \
+    --action_env=REMOTE_GPU_TESTING=1 \
+    --action_env=TF_CUDA_COMPUTE_CAPABILITIES="${TF_CUDA_COMPUTE_CAPABILITIES}" \
+    --action_env=TF_CUDA_CONFIG_REPO=@org_tensorflow//third_party/toolchains/preconfig/ubuntu16.04/cuda10.0-cudnn7 \
+    --action_env=TF_CUDA_VERSION=10 \
+    --action_env=TF_CUDNN_VERSION=7 \
+    --action_env=TF_NEED_TENSORRT=0 \
+    --action_env=TF_NEED_CUDA=1 \
+    --action_env=TF_PYTHON_CONFIG_REPO=@org_tensorflow//third_party/toolchains/preconfig/ubuntu16.04/py3 \
+    --test_env=LD_LIBRARY_PATH \
+    --test_tag_filters="${tag_filters}" \
+    --build_tag_filters="${tag_filters}" \
+    --test_lang_filters=cc,py \
+    --define=with_default_optimizations=true \
+    --define=framework_shared_object=true \
+    --define=with_xla_support=true \
+    --define=using_cuda_nvcc=true \
+    --define=use_fast_cpp_protos=true \
+    --define=allow_oversize_protos=true \
+    --define=grpc_no_ares=true \
+    -c opt \
+    --copt="-w" \
+    --copt=-mavx \
+    --linkopt=-lrt \
+    --distinct_host_configuration=false \
+    --remote_default_platform_properties="properties:{name:\"build\" value:\"${CACHE_SILO_VAL}\"}" \
+    --crosstool_top=//third_party/toolchains/preconfig/ubuntu16.04/gcc7_manylinux2010-nvcc-cuda10.0:toolchain \
+    --host_javabase=@bazel_toolchains//configs/ubuntu16_04_clang/1.1:jdk8 \
+    --javabase=@bazel_toolchains//configs/ubuntu16_04_clang/1.0:jdk8 \
+    --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8 \
+    --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8 \
+    --extra_toolchains=//third_party/toolchains/preconfig/ubuntu16.04/gcc7_manylinux2010-nvcc-cuda10.0:toolchain-linux-x86_64 \
+    --extra_execution_platforms=@org_tensorflow//third_party/toolchains:rbe_cuda10.0-cudnn7-ubuntu16.04-manylinux2010,@org_tensorflow//third_party/toolchains:rbe_cuda10.0-cudnn7-ubuntu16.04-manylinux2010-gpu \
+    --host_platform=@org_tensorflow//third_party/toolchains:rbe_cuda10.0-cudnn7-ubuntu16.04-manylinux2010 \
+    --local_test_jobs=4 \
+    --remote_timeout=3600 \
+    --platforms=@org_tensorflow//third_party/toolchains:rbe_cuda10.0-cudnn7-ubuntu16.04-manylinux2010 \
+    -- \
+    ${DEFAULT_BAZEL_TARGETS} -//tensorflow/lite/...
+
+  # Copy log to output to be available to GitHub
+  ls -la "$(bazel info output_base)/java.log"
+  cp "$(bazel info output_base)/java.log" "${KOKORO_ARTIFACTS_DIR}/"
+}
+
+source tensorflow/tools/ci_build/release/common.sh
+update_bazel_linux
+which bazel
+
+run_build

--- a/tensorflow/tools/ci_build/presubmit/ubuntu_16/sanity/build.sh
+++ b/tensorflow/tools/ci_build/presubmit/ubuntu_16/sanity/build.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+set -e
+
+# Error if we somehow forget to set the path to bazel_wrapper.py
+set -u
+BAZEL_WRAPPER_PATH=$1
+set +u
+
+# From this point on, logs can be publicly available
+set -x
+
+function install_pylint () {
+  # TODO(gunan): figure out why we get stuck with later versions of pylint.
+  # TODO(mihaimaruseac): this is used in the release build in the same way,
+  # maybe extract out to a common?
+  sudo python2 -m pip install pylint==1.6.4
+  sudo python3 -m pip install pylint==1.6.4
+}
+
+function run_sanity_checks () {
+  SANITY_OUT=ci_sanity.out
+  SANITY_OUT_TARGET=gen_ci_sanity_out
+
+  # Run tensorflow sanity checks.
+  tensorflow/tools/ci_build/ci_sanity.sh 2>&1 | tee tensorflow/tools/ci_build/${SANITY_OUT}
+  RC=${PIPESTATUS[0]}
+
+  # Since we are running the sanity build remotely (rbe), we need to build a bazel
+  # target that would output the log generated above and return the expected
+  # error code.
+  cat << EOF > tensorflow/tools/ci_build/BUILD
+package(default_visibility = ["//tensorflow:internal"])
+
+sh_test(
+    name = "${SANITY_OUT_TARGET}",
+    srcs = ["${SANITY_OUT_TARGET}.sh"],
+    data = ["${SANITY_OUT}"],
+    tags = ["local"],
+)
+EOF
+
+  cat << EOF > tensorflow/tools/ci_build/${SANITY_OUT_TARGET}.sh
+#!/bin/bash
+cat tensorflow/tools/ci_build/${SANITY_OUT}
+exit ${RC}
+EOF
+
+  # Now trigger the rbe build that outputs the log
+  chmod +x tensorflow/tools/ci_build/${SANITY_OUT_TARGET}.sh
+
+  # Run bazel test command. Double test timeouts to avoid flakes.
+  # //tensorflow/core:platform_setround_test is not supported. See b/64264700
+  "${BAZEL_WRAPPER_PATH}" \
+    --host_jvm_args=-Dbazel.DigestFunction=SHA256 \
+    test \
+    --test_output=all \
+    tensorflow/tools/ci_build:${SANITY_OUT_TARGET}
+
+  # Copy log to output to be available to GitHub
+  ls -la "$(bazel info output_base)/java.log"
+  cp "$(bazel info output_base)/java.log" "${KOKORO_ARTIFACTS_DIR}/"
+}
+
+
+source tensorflow/tools/ci_build/release/common.sh
+update_bazel_linux
+which bazel
+
+install_pylint
+
+run_sanity_checks

--- a/tensorflow/tools/ci_build/presubmit/windows/cpu_py36_full/build.bat
+++ b/tensorflow/tools/ci_build/presubmit/windows/cpu_py36_full/build.bat
@@ -1,0 +1,44 @@
+echo on
+setlocal enableextensions enabledelayedexpansion
+
+@REM This is the path to bazel_wrapper.py, should be set as an argument
+set BAZEL_WRAPPER_PATH=%~f1
+
+@REM Load common definitions, install bazel
+CALL tensorflow\tools\ci_build\release\common_win.bat
+
+@REM Set up common variables used through the script
+set WIN_OUT=win.out
+set WIN_OUT_TARGET=gen_win_out
+set BUILD_PATH=tensorflow/tools/ci_build/builds
+set GEN_SCRIPT=%BUILD_PATH%/%WIN_OUT_TARGET%.sh
+set GEN_BUILD=%BUILD_PATH%/BUILD
+
+@REM Run the presubmit win build.
+CALL tensorflow\tools\ci_build\windows\cpu\pip\run.bat --enable_remote_cache %* > %BUILD_PATH%/%WIN_OUT% 2>&1
+set RC=%errorlevel%
+
+@REM Since we are running the sanity build remotely (rbe), we need to build a bazel
+@REM target that would output the log generated above and return the expected
+@REM error code.
+echo package(default_visibility = ["//visibility:public"]) > %GEN_BUILD%
+echo. >> %GEN_BUILD%
+echo sh_test( >> %GEN_BUILD%
+echo     name = "%WIN_OUT_TARGET%", >> %GEN_BUILD%
+echo     srcs = ["%WIN_OUT_TARGET%.sh"], >> %GEN_BUILD%
+echo     data = ["%WIN_OUT%"], >> %GEN_BUILD%
+echo     tags = ["local"], >> %GEN_BUILD%
+echo ) >> %GEN_BUILD%
+
+echo #!/bin/bash > %GEN_SCRIPT%
+echo function rlocation() { >> %GEN_SCRIPT%
+echo   fgrep -m1 "$1 " "$RUNFILES_MANIFEST_FILE" ^| cut -d' ' -f2- >> %GEN_SCRIPT%
+echo } >> %GEN_SCRIPT%
+echo cat $(rlocation %BUILD_PATH%/%WIN_OUT%) >> %GEN_SCRIPT%
+echo exit %RC% >> %GEN_SCRIPT%
+
+@REM Now trigger the rbe build that outputs the log
+chmod +x %GEN_SCRIPT%
+
+@REM Run bazel test command.
+%PY_EXE% %BAZEL_WRAPPER_PATH% --output_user_root=%TMPDIR% --host_jvm_args=-Dbazel.DigestFunction=SHA256 test %BUILD_PATH%:%WIN_OUT_TARGET% --test_output=all

--- a/tensorflow/tools/ci_build/presubmit/windows/gpu_py36_full/build.bat
+++ b/tensorflow/tools/ci_build/presubmit/windows/gpu_py36_full/build.bat
@@ -1,0 +1,45 @@
+echo on
+setlocal enableextensions enabledelayedexpansion
+
+@REM This is the path to bazel_wrapper.py, should be set as an argument
+set BAZEL_WRAPPER_PATH=%~f1
+
+@REM Load common definitions, install bazel
+CALL tensorflow\tools\ci_build\release\common_win.bat
+
+@REM Set up common variables used through the script
+set WIN_OUT=win.out
+set WIN_OUT_TARGET=gen_win_out
+set BUILD_PATH=tensorflow/tools/ci_build/builds
+set GEN_SCRIPT=%BUILD_PATH%/%WIN_OUT_TARGET%.sh
+set GEN_BUILD=%BUILD_PATH%/BUILD
+
+@REM Run the presubmit win build.
+CALL tensorflow\tools\ci_build\windows\gpu\pip\run.bat --enable_remote_cache %* > %BUILD_PATH%/%WIN_OUT% 2>&1
+set RC=%errorlevel%
+
+@REM Since we are running the sanity build remotely (rbe), we need to build a bazel
+@REM target that would output the log generated above and return the expected
+@REM error code.
+echo package(default_visibility = ["//visibility:public"]) > %GEN_BUILD%
+echo. >> %GEN_BUILD%
+echo sh_test( >> %GEN_BUILD%
+echo     name = "%WIN_OUT_TARGET%", >> %GEN_BUILD%
+echo     srcs = ["%WIN_OUT_TARGET%.sh"], >> %GEN_BUILD%
+echo     data = ["%WIN_OUT%"], >> %GEN_BUILD%
+echo     tags = ["local"], >> %GEN_BUILD%
+echo ) >> %GEN_BUILD%
+
+echo #!/bin/bash > %GEN_SCRIPT%
+echo function rlocation() { >> %GEN_SCRIPT%
+echo   fgrep -m1 "$1 " "$RUNFILES_MANIFEST_FILE" ^| cut -d' ' -f2- >> %GEN_SCRIPT%
+echo } >> %GEN_SCRIPT%
+echo cat $(rlocation %BUILD_PATH%/%WIN_OUT%) >> %GEN_SCRIPT%
+echo exit %RC% >> %GEN_SCRIPT%
+
+@REM Now trigger the rbe build that outputs the log
+chmod +x %GEN_SCRIPT%
+
+@REM Run bazel test command.
+%PY_EXE% %BAZEL_WRAPPER_PATH% --output_user_root=%TMPDIR% --host_jvm_args=-Dbazel.DigestFunction=SHA256 test %BUILD_PATH%:%WIN_OUT_TARGET% --test_output=all
+


### PR DESCRIPTION
We forgot to cherry-pick these on `r2.1`. Without this, all PRs on this branch will fail CI as the real scripts for CI testing don't exist where CI is expecting them to be.