### PR TITLE
NFC - minor spelling tweaks

### DIFF
--- a/tensorflow/core/distributed_runtime/rpc/grpc_state.h
+++ b/tensorflow/core/distributed_runtime/rpc/grpc_state.h
@@ -325,7 +325,7 @@ class ExchangeQueue {
                protobuf::Message* response, StatusCallback cb,
                std::string debug_string);
 
-  // Returns an exchange for which we can initiated request writing, if any.
+  // Returns an exchange for which we can initiate request writing, if any.
   // Returns nullptr if there is no such exchange.
   Exchange* GetReadyForRequestWriting();
 

--- a/tensorflow/core/kernels/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl_conv_ops.cc
@@ -1315,7 +1315,7 @@ class MklConvOp : public OpKernel {
         *cached_filter_md_ptensor_.AccessTensor(context);
 
 // Check if the memory descriptor of the cached weights is same as
-// filter_md. If so, we can used the cached weights; otherwise
+// filter_md. If so, we can use the cached weights; otherwise
 // return NULL.
 #ifdef ENABLE_MKLDNN_V1
     if (cached_filter_md.scalar<int64>().size() &&

--- a/tensorflow/lite/tools/benchmark/android/README.md
+++ b/tensorflow/lite/tools/benchmark/android/README.md
@@ -14,7 +14,7 @@ binary executed via `adb shell ...`. This tailored behavior is most evident when
 enabling multi-threaded CPU execution with TensorFlow Lite.
 
 To that end, this app offers perhaps a more faithful view of runtime performance
-that developers can expected when deploying TensorFlow Lite with their
+that developers can expect when deploying TensorFlow Lite with their
 application.
 
 ## To build/install/run

--- a/tensorflow/python/autograph/operators/symbols.py
+++ b/tensorflow/python/autograph/operators/symbols.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Abstract representation of composite symbols that can used in staging code.
+"""Abstract representation of composite symbols that can be used in staging code.
 
 This provides a way to checkpoint the values of symbols that may be undefined
 entering staged control flow. This checkpointing is necessary to prevent some

--- a/tensorflow/python/framework/test_combinations.py
+++ b/tensorflow/python/framework/test_combinations.py
@@ -39,7 +39,7 @@ The execution of generated tests can be customized in a number of ways:
 -  The test can be skipped if it is not running in the correct environment.
 -  The arguments that are passed to the test can be additionaly transformed.
 -  The test can be run with specific Python context managers.
-These behaviors can customized by providing instances of `TestCombination` to
+These behaviors can be customized by providing instances of `TestCombination` to
 `generate()`.
 """
 

--- a/tensorflow/python/ops/resource_variable_ops.py
+++ b/tensorflow/python/ops/resource_variable_ops.py
@@ -811,7 +811,7 @@ class BaseResourceVariable(variables.VariableV1):
       it will return the `Operation` that does the assignment, and when in eager
       mode it will return `None`.
     """
-    # Note: not depending on the cached value here since this can used to
+    # Note: not depending on the cached value here since this can be used to
     # initialize the variable.
     with _handle_graph(self.handle):
       value_tensor = ops.convert_to_tensor(value, dtype=self.dtype)


### PR DESCRIPTION
This PR addresses minor spelling tweaks like:
`can ..ed` -> `can be ..ed`
`can ..ed` -> `can ..`