### PR TITLE
Avoid unnecessary copy of the closure for runner (repeat 8834e4f)

### DIFF
--- a/tensorflow/core/kernels/data/dataset_test_base.cc
+++ b/tensorflow/core/kernels/data/dataset_test_base.cc
@@ -333,7 +333,7 @@ Status DatasetOpsTestBase::InitFunctionLibraryRuntime(
       nullptr /* cluster_flr */);
   flr_ = pflr_->GetFLR("/job:localhost/replica:0/task:0/cpu:0");
   if (thread_pool_ == nullptr) {
-    runner_ = [](const std::function<void()> fn) { fn(); };
+    runner_ = [](const std::function<void()>& fn) { fn(); };
   } else {
     runner_ = [this](std::function<void()> fn) {
       thread_pool_->Schedule(std::move(fn));

--- a/tensorflow/core/kernels/data/dataset_test_base.cc
+++ b/tensorflow/core/kernels/data/dataset_test_base.cc
@@ -333,7 +333,7 @@ Status DatasetOpsTestBase::InitFunctionLibraryRuntime(
       nullptr /* cluster_flr */);
   flr_ = pflr_->GetFLR("/job:localhost/replica:0/task:0/cpu:0");
   if (thread_pool_ == nullptr) {
-    runner_ = [](std::function<void()> fn) { fn(); };
+    runner_ = [](const std::function<void()> fn) { fn(); };
   } else {
     runner_ = [this](std::function<void()> fn) {
       thread_pool_->Schedule(std::move(fn));

--- a/tensorflow/core/kernels/data/single_threaded_executor_test.cc
+++ b/tensorflow/core/kernels/data/single_threaded_executor_test.cc
@@ -68,7 +68,7 @@ class ExecutorTest : public ::testing::Test {
     };
     delete exec_;
     TF_CHECK_OK(NewSingleThreadedExecutor(params, *graph, &exec_));
-    runner_ = [](const std::function<void()> fn) { fn(); };
+    runner_ = [](const std::function<void()>& fn) { fn(); };
     rendez_ = NewLocalRendezvous();
   }
 

--- a/tensorflow/core/kernels/data/single_threaded_executor_test.cc
+++ b/tensorflow/core/kernels/data/single_threaded_executor_test.cc
@@ -68,7 +68,7 @@ class ExecutorTest : public ::testing::Test {
     };
     delete exec_;
     TF_CHECK_OK(NewSingleThreadedExecutor(params, *graph, &exec_));
-    runner_ = [](std::function<void()> fn) { fn(); };
+    runner_ = [](const std::function<void()> fn) { fn(); };
     rendez_ = NewLocalRendezvous();
   }
 


### PR DESCRIPTION
Hello, this is very small changes that add const to the closure for Clang-tidy.
These changes just repeat the previous changes 8834e4f that was made by @mrry.
