### PR TITLE
Use builtin compiler flags for CMSIS-NN and some more improvements

### DIFF
--- a/tensorflow/lite/micro/kernels/cmsis-nn/conv.cc
+++ b/tensorflow/lite/micro/kernels/cmsis-nn/conv.cc
@@ -163,8 +163,9 @@ TfLiteStatus EvalQuantizedPerChannel(
   op_params.padding_values.height = data->padding.height;
   op_params.padding_values.width = data->padding.width;
 
-#if defined(ARM_MATH_DSP) && defined(ARM_MATH_LOOPUNROLL)
 
+
+#if defined(__ARM_FEATURE_DSP)
   RuntimeShape filter_shape = GetTensorShape(filter);
   RuntimeShape input_shape = GetTensorShape(input);
   RuntimeShape output_shape = GetTensorShape(output);

--- a/tensorflow/lite/micro/kernels/cmsis-nn/depthwise_conv.cc
+++ b/tensorflow/lite/micro/kernels/cmsis-nn/depthwise_conv.cc
@@ -154,7 +154,7 @@ TfLiteStatus EvalQuantizedPerChannel(TfLiteContext* context, TfLiteNode* node,
   op_params.quantized_activation_min = std::numeric_limits<int8_t>::min();
   op_params.quantized_activation_max = std::numeric_limits<int8_t>::max();
 
-#if defined(ARM_MATH_DSP) && defined(ARM_MATH_LOOPUNROLL)
+#if defined(__ARM_FEATURE_DSP)
   RuntimeShape filter_shape = GetTensorShape(filter);
   const int filter_height = filter_shape.Dims(1);
   const int filter_width = filter_shape.Dims(2);
@@ -250,7 +250,7 @@ TfLiteStatus EvalQuantized(TfLiteContext* context, TfLiteNode* node,
   // Legacy ops used mixed left and right shifts. Now all are +ve-means-left.
   op_params.output_shift = -data->output_shift;
 
-#if defined(ARM_MATH_DSP)
+#if defined(__ARM_FEATURE_DSP)
   // optimizations utilize loop unrolling which requires the following power
   // of two kernel dimensions
   RuntimeShape filter_shape = GetTensorShape(filter);

--- a/tensorflow/lite/micro/kernels/cmsis-nn/fully_connected.cc
+++ b/tensorflow/lite/micro/kernels/cmsis-nn/fully_connected.cc
@@ -96,7 +96,7 @@ TfLiteStatus EvalQuantizedInt8(TfLiteContext* context, TfLiteNode* node,
   const int filter_dim_count = filter_shape.DimensionsCount();
   const int accum_depth = filter_shape.Dims(filter_dim_count - 1);
 
-#if defined(ARM_MATH_DSP) && defined(ARM_MATH_LOOPUNROLL)
+#if defined(__ARM_FEATURE_DSP)
   const int32_t buf_size = arm_fully_connected_s8_get_buffer_size(accum_depth);
   int16_t* buf = nullptr;
   TF_LITE_ENSURE_OK(context, get_cmsis_scratch_buffer(context, &buf, buf_size));

--- a/tensorflow/lite/micro/kernels/cmsis-nn/pooling.cc
+++ b/tensorflow/lite/micro/kernels/cmsis-nn/pooling.cc
@@ -107,7 +107,7 @@ TfLiteStatus AverageEvalInt8(TfLiteContext* context, const TfLiteNode* node,
 
   TFLITE_DCHECK_LE(activation_min, activation_max);
 
-#if defined(ARM_MATH_DSP) && defined(ARM_MATH_LOOPUNROLL)
+#if defined(__ARM_FEATURE_DSP)
   RuntimeShape input_shape = GetTensorShape(input);
   TFLITE_DCHECK_EQ(input_shape.DimensionsCount(), 4);
 
@@ -142,6 +142,9 @@ TfLiteStatus AverageEvalInt8(TfLiteContext* context, const TfLiteNode* node,
                      scratch_buffer, GetTensorData<int8_t>(output)),
       ARM_MATH_SUCCESS);
 #else
+#pragma message( \
+    "CMSIS-NN optimization for depthwise_conv not available for this target. Using reference kernel.")
+
   PoolParams op_params;
   op_params.stride_height = params->stride_height;
   op_params.stride_width = params->stride_width;

--- a/tensorflow/lite/micro/tools/make/ext_libs/README.md
+++ b/tensorflow/lite/micro/tools/make/ext_libs/README.md
@@ -1,0 +1,43 @@
+# Info
+
+To use CMSIS-NN optimized kernels instead of reference kernel add TAGS=cmsis-nn
+to the make line. Some micro architectures have optimizations (M4 or higher),
+others don't. The kernels that doesn't have optimization for a certain micro
+architecture fallback to use TFLu reference kernels.
+
+The optimizations are almost exclusively made for int8 (symmetric) model. For
+more details, please read [CMSIS-NN doc](https://github.com/ARM-software/CMSIS_5/blob/develop/CMSIS/NN/README.md)
+
+
+# Example 1
+
+```
+make -f tensorflow/lite/micro/tools/make/Makefile TAGS=cmsis-nn
+TARGET=apollo3evb person_detection_bin
+```
+
+# Example 2 - MBED
+
+```
+make -f tensorflow/lite/micro/tools/make/Makefile TAGS=cmsis-nn
+generate_person_detection_mbed_project
+```
+
+Go into the generated project's mbed folder.
+
+Note: Mbed has a dependency to an old version of arm_math.h. Therefore you need
+to copy the newer version as follows:
+
+```
+cp tensorflow/lite/micro/tools/make/downloads/cmsis/CMSIS/DSP/Include/
+arm_math.h mbed-os/cmsis/TARGET_CORTEX_M/arm_math.h
+```
+
+This issue will be resolved soon. Now type
+
+```
+mbed new .
+mbed compile -m DISCO_F746NG -DARM_MATH_LOOPUNROLL
+```
+
+Note: ARM_MATH_LOOPUNROLL requirement will be removed

--- a/tensorflow/lite/micro/tools/make/ext_libs/cmsis.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/cmsis.inc
@@ -14,7 +14,7 @@ ifneq ($(filter cmsis-nn,$(ALL_TAGS)),)
     CMSIS_PATH = $(MAKEFILE_DIR)/downloads/cmsis/
 
     # Include CMSIS-NN files
-    THIRD_PARTY_CC_SRCS := \
+    THIRD_PARTY_CC_SRCS += \
       $(call recursive_find,$(CMSIS_PATH)/CMSIS/NN/Source,*.c)
 
     THIRD_PARTY_CC_HDRS += \

--- a/tensorflow/lite/micro/tools/make/ext_libs/cmsis.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/cmsis.inc
@@ -1,115 +1,35 @@
 ifneq ($(filter cmsis-nn,$(ALL_TAGS)),)
     # Enable u-arch specfic behaviours
-    ifneq (,$(filter $(TARGET_ARCH), cortex-m3))
-        # CMSIS-NN optimizations not supported
-    endif
-    ifneq (,$(filter $(TARGET_ARCH), cortex-m4))
-        CCFLAGS += -DARM_MATH_DSP
-        CXXFLAGS += -DARM_MATH_DSP
-        CCFLAGS += -DARM_MATH_LOOPUNROLL
-        CXXFLAGS += -DARM_MATH_LOOPUNROLL
-    endif
-    ifneq (,$(filter $(TARGET_ARCH), cortex-m7))
-        CCFLAGS += -DARM_MATH_DSP
-        CXXFLAGS += -DARM_MATH_DSP
-        CCFLAGS += -DARM_MATH_LOOPUNROLL
-        CXXFLAGS += -DARM_MATH_LOOPUNROLL
-    endif
     ifneq (,$(filter $(TARGET_ARCH), x86_64))
         # CMSIS-NN optimizations not supported
     endif
+
+    CCFLAGS += -DARM_MATH_LOOPUNROLL
+    CXXFLAGS += -DARM_MATH_LOOPUNROLL
 
     # Setup CMSIS-NN lib and add required header files to microlite lib INCLUDE
     THIRD_PARTY_DOWNLOADS += \
       $(eval $(call add_third_party_download,$(CMSIS_URL),$(CMSIS_MD5),cmsis,))
 
     CMSIS_PATH = $(MAKEFILE_DIR)/downloads/cmsis/
-    # List created by running:
-    # find tensorflow/lite/micro/tools/make/downloads/cmsis/CMSIS/NN/Source/ -name *.c | sed -E 's#tensorflow/lite/micro/tools/make/downloads/cmsis(.*)$#      ${CMSIS_PATH}\1 \\#g'
-    THIRD_PARTY_CC_SRCS += \
-      $(CMSIS_PATH)/CMSIS/NN/Source/BasicMathFunctions/arm_elementwise_mul_s8.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/BasicMathFunctions/arm_elementwise_add_s8.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_q7_opt.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_s8.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_q15_opt.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_q15.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_mat_q7_vec_q15.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_q7.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_mat_q7_vec_q15_opt.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_u8_basic_ver1.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_s8.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_fast.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_mat_mult_kernel_q7_q15_reordered.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_mat_mult_kernel_q7_q15.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_RGB.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_HWC_q7_fast_nonsquare.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_basic.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_separable_conv_HWC_q7_nonsquare.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q15_fast_nonsquare.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_s8_opt.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_depthwise_conv_s8_core.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_mat_mult_s8.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_mat_mult_kernel_s8_s16.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q15_basic.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q15_fast.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_fast_nonsquare.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_mat_mult_kernel_s8_s16_reordered.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_separable_conv_HWC_q7.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_s8.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_basic_nonsquare.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/PoolingFunctions/arm_pool_q7_HWC.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/PoolingFunctions/arm_avgpool_s8.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/ActivationFunctions/arm_relu_q15.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/ActivationFunctions/arm_relu_q7.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/ActivationFunctions/arm_nn_activations_q7.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/ActivationFunctions/arm_nn_activations_q15.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/NNSupportFunctions/arm_nn_add_q7.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_reordered_no_shift.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/NNSupportFunctions/arm_nntables.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/NNSupportFunctions/arm_nn_accumulate_q7_to_q15.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mult_q7.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mult_q15.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_reordered_with_offset.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_with_offset.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_no_shift.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/SoftmaxFunctions/arm_softmax_q15.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/SoftmaxFunctions/arm_softmax_q7.c \
-      $(CMSIS_PATH)/CMSIS/NN/Source/SoftmaxFunctions/arm_softmax_with_batch_q7.c
 
-    # List created by running:
-    # find tensorflow/lite/micro/tools/make/downloads/cmsis/CMSIS/{Core,NN,DSP}/Include -name *.h | sed -E 's#tensorflow/lite/micro/tools/make/downloads/cmsis(.*)$#      ${CMSIS_PATH}\1 \\#g'
+    # Include CMSIS-NN files
+    THIRD_PARTY_CC_SRCS := \
+      $(call recursive_find,$(CMSIS_PATH)/CMSIS/NN/Source,*.c)
+
     THIRD_PARTY_CC_HDRS += \
-      ${CMSIS_PATH}/CMSIS/Core/Include/cmsis_compiler.h \
-      ${CMSIS_PATH}/CMSIS/Core/Include/cmsis_armclang.h \
-      ${CMSIS_PATH}/CMSIS/Core/Include/mpu_armv7.h \
-      ${CMSIS_PATH}/CMSIS/Core/Include/mpu_armv8.h \
-      ${CMSIS_PATH}/CMSIS/Core/Include/cmsis_gcc.h \
-      ${CMSIS_PATH}/CMSIS/Core/Include/core_armv8mbl.h \
-      ${CMSIS_PATH}/CMSIS/Core/Include/cmsis_version.h \
-      ${CMSIS_PATH}/CMSIS/Core/Include/core_cm33.h \
-      ${CMSIS_PATH}/CMSIS/Core/Include/core_cm0.h \
-      ${CMSIS_PATH}/CMSIS/Core/Include/core_armv8mml.h \
-      ${CMSIS_PATH}/CMSIS/Core/Include/core_cm3.h \
-      ${CMSIS_PATH}/CMSIS/Core/Include/core_cm7.h \
-      ${CMSIS_PATH}/CMSIS/Core/Include/cmsis_armcc.h \
-      ${CMSIS_PATH}/CMSIS/Core/Include/core_cm4.h \
-      ${CMSIS_PATH}/CMSIS/Core/Include/core_cm0plus.h \
-      ${CMSIS_PATH}/CMSIS/Core/Include/tz_context.h \
-      ${CMSIS_PATH}/CMSIS/Core/Include/core_cm23.h \
-      ${CMSIS_PATH}/CMSIS/Core/Include/cmsis_iccarm.h \
-      ${CMSIS_PATH}/CMSIS/Core/Include/core_sc300.h \
-      ${CMSIS_PATH}/CMSIS/Core/Include/core_sc000.h \
-      ${CMSIS_PATH}/CMSIS/NN/Include/arm_nnsupportfunctions.h \
-      ${CMSIS_PATH}/CMSIS/NN/Include/arm_nn_tables.h \
-      ${CMSIS_PATH}/CMSIS/NN/Include/arm_nnfunctions.h \
-      ${CMSIS_PATH}/CMSIS/DSP/Include/arm_common_tables.h \
-      ${CMSIS_PATH}/CMSIS/DSP/Include/arm_math.h \
-      ${CMSIS_PATH}/CMSIS/DSP/Include/arm_const_structs.h
+      $(call recursive_find,$(CMSIS_PATH)/CMSIS/NN/Include,*.h)
+    THIRD_PARTY_CC_HDRS += \
+      $(call recursive_find,$(CMSIS_PATH)/CMSIS/DSP/Include,*.h)
+    THIRD_PARTY_CC_HDRS += \
+      $(call recursive_find,$(CMSIS_PATH)/CMSIS/Core/Include,*.h)
 
-    # todo: remove the two lines below once context->AllocateTemporaryTensor() is implemented.
-    MICROLITE_CC_HDRS += tensorflow/lite/micro/kernels/cmsis-nn/scratch_buffer.h
-    MICROLITE_CC_SRCS += tensorflow/lite/micro/kernels/cmsis-nn/scratch_buffer.cc
+    # todo: remove the two lines below once context->AllocateTemporaryTensor()
+    # is implemented.
+    MICROLITE_CC_HDRS += \
+      tensorflow/lite/micro/kernels/cmsis-nn/scratch_buffer.h
+    MICROLITE_CC_SRCS += \
+      tensorflow/lite/micro/kernels/cmsis-nn/scratch_buffer.cc
 
     INCLUDES += -I$(CMSIS_PATH)/CMSIS/Core/Include \
                 -I$(CMSIS_PATH)/CMSIS/NN/Include \

--- a/tensorflow/lite/micro/tools/make/helper_functions.inc
+++ b/tensorflow/lite/micro/tools/make/helper_functions.inc
@@ -398,3 +398,9 @@ $(word 3, $(subst !, ,$(1))):
 	tensorflow/lite/micro/tools/make/download_and_extract.sh $(subst !, ,$(1))
 THIRD_PARTY_TARGETS += $(word 3, $(subst !, ,$(1)))
 endef
+
+# Recursively find all files of given pattern
+# Arguments are:
+# 1 - Starting path
+# 2 - File pattern, e.g: *.h
+recursive_find = $(wildcard $(1)$(2)) $(foreach dir,$(wildcard $(1)*),$(call recursive_find,$(dir)/,$(2)))

--- a/tensorflow/lite/micro/tools/make/templates/mbed_app.json.tpl
+++ b/tensorflow/lite/micro/tools/make/templates/mbed_app.json.tpl
@@ -3,5 +3,6 @@
 	"main-stack-size": {
             "value": 65536
 	}
-    }
+    },
+    "requires": ["bare-metal"]
 }


### PR DESCRIPTION
This PR fixes:
1) Use builtin compiler flags for CMSIS-NN instead of those defined in cmsis.inc
2) Adds a readme to the ext_lib folder to provide more details on CMSIS-NN optimizations
3) Includes 3rd party (arm github) CMSIS-NN related files recursively instead of having to include each individual file manually as the CMSIS-NN github project evolves.