### PR TITLE
Allow unbounded work queue to be spawned on a specific NUMA node

### DIFF
--- a/tensorflow/core/kernels/data/unbounded_thread_pool.h
+++ b/tensorflow/core/kernels/data/unbounded_thread_pool.h
@@ -35,7 +35,7 @@ namespace data {
 class UnboundedThreadPool : public thread::ThreadPoolInterface {
  public:
   UnboundedThreadPool(Env* env, const string& thread_name,
-                      const ThreadOptions thread_options = {})
+                      const ThreadOptions& thread_options = {})
       : unbounded_work_queue_(env, thread_name, thread_options) {}
   ~UnboundedThreadPool() = default;
 

--- a/tensorflow/core/kernels/data/unbounded_thread_pool.h
+++ b/tensorflow/core/kernels/data/unbounded_thread_pool.h
@@ -34,8 +34,9 @@ namespace data {
 // `UnboundedWorkQueue`.
 class UnboundedThreadPool : public thread::ThreadPoolInterface {
  public:
-  UnboundedThreadPool(Env* env, const string& thread_name)
-      : unbounded_work_queue_(env, thread_name) {}
+  UnboundedThreadPool(Env* env, const string& thread_name,
+                      const ThreadOptions thread_options = {})
+      : unbounded_work_queue_(env, thread_name, thread_options) {}
   ~UnboundedThreadPool() = default;
 
   // Returns an implementation of `ThreadFactory` that can be used to create

--- a/tensorflow/core/platform/default/unbounded_work_queue.cc
+++ b/tensorflow/core/platform/default/unbounded_work_queue.cc
@@ -23,7 +23,7 @@ limitations under the License.
 namespace tensorflow {
 
 UnboundedWorkQueue::UnboundedWorkQueue(Env* env, const string& thread_name,
-                                       const ThreadOptions thread_options)
+                                       const ThreadOptions& thread_options)
     : env_(env), thread_name_(thread_name), thread_options_(thread_options) {}
 
 UnboundedWorkQueue::~UnboundedWorkQueue() {

--- a/tensorflow/core/platform/default/unbounded_work_queue.cc
+++ b/tensorflow/core/platform/default/unbounded_work_queue.cc
@@ -18,11 +18,13 @@ limitations under the License.
 #include "absl/memory/memory.h"
 #include "tensorflow/core/platform/env.h"
 #include "tensorflow/core/platform/mutex.h"
+#include "tensorflow/core/platform/numa.h"
 
 namespace tensorflow {
 
-UnboundedWorkQueue::UnboundedWorkQueue(Env* env, const string& thread_name)
-    : env_(env), thread_name_(thread_name) {}
+UnboundedWorkQueue::UnboundedWorkQueue(Env* env, const string& thread_name,
+                                       const ThreadOptions thread_options)
+    : env_(env), thread_name_(thread_name), thread_options_(thread_options) {}
 
 UnboundedWorkQueue::~UnboundedWorkQueue() {
   {
@@ -71,6 +73,11 @@ void UnboundedWorkQueue::Schedule(WorkFunction fn) {
 }
 
 void UnboundedWorkQueue::PooledThreadFunc() {
+  // If specified, make sure the thread runs on the correct NUMA node.
+  if (thread_options_.numa_node != port::kNUMANoAffinity) {
+    port::NUMASetThreadNodeAffinity(thread_options_.numa_node);
+  }
+
   while (true) {
     WorkFunction fn;
     {

--- a/tensorflow/core/platform/default/unbounded_work_queue.h
+++ b/tensorflow/core/platform/default/unbounded_work_queue.h
@@ -36,7 +36,8 @@ namespace tensorflow {
 // fragmentation that can result from excessive thread creation.
 class UnboundedWorkQueue {
  public:
-  UnboundedWorkQueue(Env* env, const string& thread_name);
+  UnboundedWorkQueue(Env* env, const string& thread_name,
+                     const ThreadOptions thread_options = {});
   ~UnboundedWorkQueue();
 
   using WorkFunction = std::function<void()>;
@@ -51,6 +52,7 @@ class UnboundedWorkQueue {
 
   Env* const env_;  // Not owned.
   const string thread_name_;
+  const ThreadOptions thread_options_;
   mutex work_queue_mu_;
   condition_variable work_queue_cv_ GUARDED_BY(work_queue_mu_);
   size_t num_idle_threads_ GUARDED_BY(work_queue_mu_) = 0;

--- a/tensorflow/core/platform/default/unbounded_work_queue.h
+++ b/tensorflow/core/platform/default/unbounded_work_queue.h
@@ -37,7 +37,7 @@ namespace tensorflow {
 class UnboundedWorkQueue {
  public:
   UnboundedWorkQueue(Env* env, const string& thread_name,
-                     const ThreadOptions thread_options = {});
+                     const ThreadOptions& thread_options = {});
   ~UnboundedWorkQueue();
 
   using WorkFunction = std::function<void()>;


### PR DESCRIPTION
This patch allows us to create unbounded thread pools pinned to a specific node. This is useful when we want to pin workloads to a specific CPU node (for example NUMA aware dataset iterators, which are similar to `MultiDeviceIterator` where there is an iterator per NUMA node).

This should not break the public release but I assume the non-default internal implementation will need updating.