### PR TITLE
Fix hwloc build for ppc64le

### DIFF
--- a/third_party/hwloc/BUILD.bazel
+++ b/third_party/hwloc/BUILD.bazel
@@ -262,6 +262,10 @@ cc_library(
             "hwloc/topology-x86.c",
             "include/private/cpuid-x86.h",
         ],
+        "@org_tensorflow//tensorflow:linux_ppc64le": [
+            "hwloc/topology-linux.c",
+            "include/hwloc/linux.h",
+        ],
         "@org_tensorflow//tensorflow:freebsd": [
             "hwloc/topology-freebsd.c",
             "hwloc/topology-x86.c",


### PR DESCRIPTION
This commit: https://github.com/tensorflow/tensorflow/commit/41df105#diff-6fb2e55075204b47da0460ea2abbc32f
broke the CPU unit test build for ppc64le. The compiler error was:

.../libexternal_Shwloc_Slibhwloc.so: error: undefined reference to 'hwloc_linux_component'
.../libexternal_Shwloc_Slibhwloc.so: error: undefined reference to 'hwloc_linuxio_component'

These methods are defined in topology-linux.c, adding the necessary bazel select statement
so they are built during a ppc64le build.