### PR TITLE
Separate the global NUMA thread pools from the default thread pool 

### DIFF
--- a/tensorflow/core/common_runtime/local_device.h
+++ b/tensorflow/core/common_runtime/local_device.h
@@ -47,11 +47,13 @@ class LocalDevice : public Device {
   struct EigenThreadPoolInfo;
   std::unique_ptr<EigenThreadPoolInfo> owned_tp_info_;
 
+  static mutex global_tp_mu_;
+  static std::unique_ptr<EigenThreadPoolInfo> global_tp_info_
+      GUARDED_BY(global_tp_mu_);
   // All ThreadPoolDevices in the process associated with the same
   // NUMA node will share a single fixed sized threadpool for numerical
   // computations.
-  static mutex global_tp_mu_;
-  static gtl::InlinedVector<EigenThreadPoolInfo*, 4> global_tp_info_
+  static gtl::InlinedVector<EigenThreadPoolInfo*, 4> global_per_numa_tp_info_
       GUARDED_BY(global_tp_mu_);
 
   friend class test::Benchmark;


### PR DESCRIPTION
This patch allows devices configured with numa enabled to not share the thread pool with the default CPU device.

This has come around as I've been experimenting with NUMA aware datasets/iterators which share the same sessions, but we create a DeviceMgr and a dataset iterator with a CPU device per NUMA node. Without this change the CPU:0 from the new DeviceMgr might share a thread pool which was not created with NUMA awareness.