### PR TITLE
Add doc summary for tf.strings.upper and tf.strings.lower.

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_StringLower.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_StringLower.pbtxt
@@ -1,3 +1,4 @@
 op {
   graph_op_name: "StringLower"
+  description: "Converts each string in the input Tensor to lowercase."
 }

--- a/tensorflow/core/api_def/base_api/api_def_StringUpper.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_StringUpper.pbtxt
@@ -1,3 +1,4 @@
 op {
   graph_op_name: "StringUpper"
+  description: "Converts each string in the input Tensor to uppercase."
 }


### PR DESCRIPTION
I think this is the right way of fixing #35647.

Recompiling and previewing the documentation is taking quite a while (following the instructions from [here](https://github.com/tensorflow/tensorflow/blob/f40a875355557483aeae60ffcf757fc9626c752b/tensorflow/g3doc/README.txt)), so I figured I'll just open the pull request now, and check out the preview tomorrow.