### PR TITLE
 fixed static sized arrays with variable length

### DIFF
--- a/tensorflow/lite/micro/kernels/neg.cc
+++ b/tensorflow/lite/micro/kernels/neg.cc
@@ -31,15 +31,21 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   const TfLiteTensor* input = GetInput(context, node, kInputTensor);
   TfLiteTensor* output = GetOutput(context, node, kOutputTensor);
   switch (input->type) {
-    // TODO(wangtz): handle for kTfLiteInt8
+    case kTfLiteInt8:
+      reference_ops::Negate(GetTensorShape(input), GetTensorData<int8_t>(input),
+                            GetTensorShape(output),
+                            GetTensorData<int8_t>(output));
+
     case kTfLiteFloat32:
       reference_ops::Negate(GetTensorShape(input), GetTensorData<float>(input),
                             GetTensorShape(output),
                             GetTensorData<float>(output));
       break;
+      
     default:
       context->ReportError(
-          context, "Neg only currently supports float32, got %d.", input->type);
+          context, "Neg only currently supports float32 and int8, got %d.",
+          input->type);
       return kTfLiteError;
   }
   return kTfLiteOk;

--- a/tensorflow/lite/micro/kernels/neg.cc
+++ b/tensorflow/lite/micro/kernels/neg.cc
@@ -35,13 +35,14 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       reference_ops::Negate(GetTensorShape(input), GetTensorData<int8_t>(input),
                             GetTensorShape(output),
                             GetTensorData<int8_t>(output));
+      break;
 
     case kTfLiteFloat32:
       reference_ops::Negate(GetTensorShape(input), GetTensorData<float>(input),
                             GetTensorShape(output),
                             GetTensorData<float>(output));
       break;
-      
+
     default:
       context->ReportError(
           context, "Neg only currently supports float32 and int8, got %d.",

--- a/tensorflow/lite/micro/micro_utils_test.cc
+++ b/tensorflow/lite/micro/micro_utils_test.cc
@@ -82,7 +82,7 @@ TF_LITE_MICRO_TEST(FloatToAsymmetricQuantizedInt32Test) {
 TF_LITE_MICRO_TEST(AsymmetricQuantizeInt8) {
   float values[] = {-10.3, -3.1, -2.1, -1.9, -0.9, 0.1, 0.9, 1.85, 2.9, 4.1};
   int8_t goldens[] = {-20, -5, -3, -3, -1, 1, 3, 5, 7, 9};
-  const int length = sizeof(values) / sizeof(float);
+  constexpr int length = sizeof(values) / sizeof(float);
   int8_t quantized[length];
   tflite::AsymmetricQuantize(values, quantized, length, 0.5, 1);
   for (int i = 0; i < length; i++) {
@@ -93,7 +93,7 @@ TF_LITE_MICRO_TEST(AsymmetricQuantizeInt8) {
 TF_LITE_MICRO_TEST(AsymmetricQuantizeUInt8) {
   float values[] = {-10.3, -3.1, -2.1, -1.9, -0.9, 0.1, 0.9, 1.85, 2.9, 4.1};
   uint8_t goldens[] = {106, 121, 123, 123, 125, 127, 129, 131, 133, 135};
-  const int length = sizeof(values) / sizeof(float);
+  constexpr int length = sizeof(values) / sizeof(float);
   uint8_t quantized[length];
   tflite::AsymmetricQuantize(values, quantized, length, 0.5, 127);
   for (int i = 0; i < length; i++) {
@@ -104,7 +104,7 @@ TF_LITE_MICRO_TEST(AsymmetricQuantizeUInt8) {
 TF_LITE_MICRO_TEST(SymmetricQuantizeInt32) {
   float values[] = {-10.3, -3.1, -2.1, -1.9, -0.9, 0.1, 0.9, 1.85, 2.9, 4.1};
   int32_t goldens[] = {-21, -6, -4, -4, -2, 0, 2, 4, 6, 8};
-  const int length = sizeof(values) / sizeof(float);
+  constexpr int length = sizeof(values) / sizeof(float);
   int32_t quantized[length];
   tflite::SymmetricQuantize(values, quantized, length, 0.5);
   for (int i = 0; i < length; i++) {

--- a/tensorflow/lite/micro/testing/micro_test.h
+++ b/tensorflow/lite/micro/testing/micro_test.h
@@ -191,7 +191,7 @@ extern tflite::ErrorReporter* reporter;
 
 #define TF_LITE_MICRO_EXPECT_TRUE(x)                                   \
   do {                                                                 \
-    if (!x) {                                                          \
+    if (!(x)) {                                                          \
       micro_test::reporter->Report(#x " was not true failed at %s:%d", \
                                    __FILE__, __LINE__);                \
       micro_test::did_test_fail = true;                                \

--- a/tensorflow/lite/micro/testing_helpers_test.cc
+++ b/tensorflow/lite/micro/testing_helpers_test.cc
@@ -21,7 +21,7 @@ TF_LITE_MICRO_TESTS_BEGIN
 TF_LITE_MICRO_TEST(CreateQuantizedBiasTensor) {
   float input_scale = 0.5;
   float weight_scale = 0.5;
-  const int tensor_size = 12;
+  constexpr int tensor_size = 12;
   int dims_arr[] = {4, 2, 3, 2, 1};
   const char* tensor_name = "test_tensor";
   int32_t quantized[tensor_size];
@@ -45,7 +45,7 @@ TF_LITE_MICRO_TEST(CreateQuantizedBiasTensor) {
 TF_LITE_MICRO_TEST(CreatePerChannelQuantizedBiasTensor) {
   float input_scale = 0.5;
   float weight_scales[] = {0.5, 1, 2, 4};
-  const int tensor_size = 12;
+  constexpr int tensor_size = 12;
   const int channels = 4;
   int dims_arr[] = {4, 4, 3, 1, 1};
   const char* tensor_name = "test_tensor";
@@ -78,7 +78,7 @@ TF_LITE_MICRO_TEST(CreatePerChannelQuantizedBiasTensor) {
 
 TF_LITE_MICRO_TEST(CreateSymmetricPerChannelQuantizedTensor) {
   const int tensor_size = 12;
-  const int channels = 2;
+  constexpr int channels = 2;
   const int dims_arr[] = {4, channels, 3, 2, 1};
   const char* tensor_name = "test_tensor";
   int8_t quantized[12];


### PR DESCRIPTION
using const int or int for the size of an array implies that it has variable length (ill-formed, https://en.cppreference.com/w/cpp/language/ub), static arrays' lengths should be constexpr or a macro constant