### PR TITLE
micro: Fix typo in missing op code error message

### DIFF
--- a/tensorflow/lite/micro/micro_allocator.cc
+++ b/tensorflow/lite/micro/micro_allocator.cc
@@ -141,7 +141,7 @@ TfLiteStatus MicroAllocator::AllocateNodeAndRegistrations(
     status = GetRegistrationFromOpCode(opcode, op_resolver, error_reporter_,
                                        &(output[i].registration));
     if (status != kTfLiteOk) {
-      error_reporter_->Report("Failed to get registration from op code % d\n ",
+      error_reporter_->Report("Failed to get registration from op code %d\n ",
                               opcode);
       return status;
     }


### PR DESCRIPTION
From '% d' to '%d' to correct message