### PR TITLE
[XLA] Update the path for the LLVM FileCheck executable

### DIFF
--- a/tensorflow/compiler/xla/tests/filecheck.cc
+++ b/tensorflow/compiler/xla/tests/filecheck.cc
@@ -40,7 +40,7 @@ StatusOr<bool> RunFileCheck(const std::string& input,
 
   // Invoke FileCheck to check whether input matches `pattern`.
   const char* file_check_path_suffix =
-      "org_tensorflow/external/llvm/FileCheck";
+      "org_tensorflow/external/llvm-project/llvm/FileCheck";
   string file_check_path;
   if (const char* test_srcdir = getenv("TEST_SRCDIR")) {
     file_check_path = JoinPath(test_srcdir, file_check_path_suffix);


### PR DESCRIPTION
The path for the `FileCheck` executbale needs to be updated as a consequence of the following commit.

https://github.com/tensorflow/tensorflow/commit/d6ba353dd974f3d883734e96653cdee7fe6abfbc

After that commit the following test (and many others) start failing with the following error

```
bazel test //tensorflow/compiler/xla/service/cpu/tests:cpu_intrinsic_test
...
...
2020-01-10 19:48:15.756796: W tensorflow/compiler/xla/tests/filecheck.cc:72]
Tried to execute FileCheck at /root/.cache/bazel/_bazel_root/efb88f6336d9c4a18216fb94287b8d97/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/compiler/xla/service/cpu/tests/cpu_intrinsic_test.runfiles/org_tensorflow/external/llvm/FileCheck

2020-01-10 19:48:15.756884: W tensorflow/compiler/xla/tests/filecheck.cc:74]
NOTE: FileCheck binary does not exist!
...
...
```

This fix updates the path of the LLVM FileCheck executable to the correct one.


------------------

/cc @cheshire @whchung 

@cheshire , the `bazel test` command above was failing in the upstream repo as of a few minutes ago. Note that I was running without `--config=rocm` (i.e. with a CPU only TF build)