### PR TITLE
Fix build breakage due to missing static member definitions

### DIFF
--- a/tensorflow/stream_executor/dnn.cc
+++ b/tensorflow/stream_executor/dnn.cc
@@ -22,6 +22,12 @@ limitations under the License.
 namespace stream_executor {
 namespace dnn {
 
+constexpr DataType ToDataType<float>::value;
+constexpr DataType ToDataType<double>::value;
+constexpr DataType ToDataType<Eigen::half>::value;
+constexpr DataType ToDataType<int8>::value;
+constexpr DataType ToDataType<int32>::value;
+
 uint64 AlgorithmDesc::hash() const {
   auto p = std::make_pair(algo_id(), tensor_ops_enabled());
   return absl::Hash<decltype(p)>()(p);


### PR DESCRIPTION
The static constexpr datamember declarations in the various ToDataType
specialiations (in stream_executor/dnn.h) do not have a corresponding
definition outside of the class.
This results in compilation failures in debug mode