### PR TITLE
[ROCm] Reenable the zero division test

### DIFF
--- a/tensorflow/python/kernel_tests/zero_division_test.py
+++ b/tensorflow/python/kernel_tests/zero_division_test.py
@@ -54,11 +54,7 @@ class ZeroDivisionTest(test.TestCase):
             #
             # XLA constant folds integer division by zero to 1.
             self.assertTrue(test.is_gpu_available())
-            if not test.is_built_with_rocm():
-              # division by zero yields a different pattern on AMD GPUs
-              # TODO(rocm) : investigate whether the resulting bit pattern on
-              # AMD GPUs is deterministic
-              self.assertIn(result, (-1, 1, 0xff, 0xffffffff))
+            self.assertIn(result, (-1, 1, 2, 0xff, 0xffffffff))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR enables the zero division test for ROCm and adds the observed value to the list of valid results.