### PR TITLE
add usage example to reduce_min

### DIFF
--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -2222,6 +2222,11 @@ def reduce_min(input_tensor, axis=None, keepdims=False, name=None):
   Returns:
     The reduced tensor.
 
+  For example:
+    >>> a = tf.constant([[1, 2], [3, 4]])
+    >>> tf.reduce_min(a)
+    <tf.Tensor: id=2, shape=(), dtype=int32, numpy=1>
+
   @compatibility(numpy)
   Equivalent to np.min
   @end_compatibility

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -2225,7 +2225,7 @@ def reduce_min(input_tensor, axis=None, keepdims=False, name=None):
   For example:
     >>> a = tf.constant([[1, 2], [3, 4]])
     >>> tf.reduce_min(a)
-    <tf.Tensor: id=2, shape=(), dtype=int32, numpy=1>
+    <tf.Tensor: shape=(), dtype=int32, numpy=1>
 
   @compatibility(numpy)
   Equivalent to np.min


### PR DESCRIPTION
I'm participating in GCI '19 (handle: jimmy_page). Task: [Advanced] Add a usage example to TensorFlow 2.0 API documentation.

I have added a usage example to tf.math.reduce_min.