### PR TITLE
[ROCm] Fix the ROCm CSB breakage - 200113 - 2

### DIFF
--- a/tensorflow/python/autograph/converters/control_flow.py
+++ b/tensorflow/python/autograph/converters/control_flow.py
@@ -156,19 +156,31 @@ class ControlFlowTransformer(converter.Base):
 
   def _create_state_functions(
       self, loop_vars, nonlocal_declarations, getter_name, setter_name):
-    template = """
-      def getter_name():
-        return state_vars,
-      def setter_name(loop_vars):
-        nonlocal_declarations
-        state_vars, = loop_vars
-    """
-    return templates.replace(
-        template,
-        nonlocal_declarations=nonlocal_declarations,
-        getter_name=getter_name,
-        setter_name=setter_name,
-        state_vars=tuple(loop_vars))
+    if loop_vars:
+      template = """
+        def getter_name():
+          return state_vars,
+        def setter_name(loop_vars):
+          nonlocal_declarations
+          state_vars, = loop_vars
+      """
+      return templates.replace(
+          template,
+          nonlocal_declarations=nonlocal_declarations,
+          getter_name=getter_name,
+          setter_name=setter_name,
+          state_vars=tuple(loop_vars))
+    else:
+      template = """
+        def getter_name():
+          return ()
+        def setter_name(loop_vars):
+          pass
+      """
+      return templates.replace(
+          template,
+          getter_name=getter_name,
+          setter_name=setter_name)
 
   def _create_loop_options(self, node):
     if not anno.hasanno(node, anno.Basic.DIRECTIVES):


### PR DESCRIPTION
The following commit breaks following tests in the ROCm nightly CSB testing

https://github.com/tensorflow/tensorflow/commit/e57c8e87f5203fa6ec49338e3ed639adb0e14c03

```
//tensorflow/python/debug:check_numerics_callback_test_gpu
//tensorflow/python/debug:debug_v2_ops_test_gpu
//tensorflow/python/distribute:ctl_correctness_test_gpu
//tensorflow/python/distribute:custom_training_loop_test_gpu
//tensorflow/python/eager:def_function_test_gpu
//tensorflow/python/eager:forwardprop_test_gpu
//tensorflow/python/eager:function_test_gpu
//tensorflow/python:loss_scaling_gradient_tape_test_gpu
//tensorflow/python:op_callbacks_test_gpu
```

They all fail with the following error

```
...
 File "/root/.cache/bazel/_bazel_root/efb88f6336d9c4a18216fb94287b8d97/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/op_callbacks_test_gpu.runfiles/org_tensorflow/tensorflow/python/autograph/pyct/loader.py", line 50, in load_source
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 661, in exec_module
  File "<frozen importlib._bootstrap_external>", line 767, in get_code
  File "<frozen importlib._bootstrap_external>", line 727, in source_to_code
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/tmp/tmp4r6l4f6a.py", line 19
    () = loop_vars
```

The fix is to properly handle the case when `loop_vars` is `None` (which was inadvertently? removed by the breakign commit)


------------


/cc @chsigg @cheshire @whchung 