### PR TITLE
Update BinaryAccuracy for assert

### DIFF
--- a/tensorflow/python/keras/metrics.py
+++ b/tensorflow/python/keras/metrics.py
@@ -585,6 +585,8 @@ class MeanMetricWrapper(Mean):
     [y_true, y_pred], sample_weight = \
         metrics_utils.ragged_assert_compatible_and_get_flat_values(
             [y_true, y_pred], sample_weight)
+    #raises error if `y_true` and `y_pred` have different shapes
+    y_pred.shape.assert_is_compatible_with(y_true.shape)
     y_pred, y_true = tf_losses_utils.squeeze_or_expand_dimensions(
         y_pred, y_true)
 


### PR DESCRIPTION
fixes #35490 
Raises value error if `y_true` and `y_pred` have different shapes for computing BinaryAccuracy metric.