### PR TITLE
fix variable name in log

### DIFF
--- a/tensorflow/lite/examples/label_image/label_image.cc
+++ b/tensorflow/lite/examples/label_image/label_image.cc
@@ -301,7 +301,7 @@ void RunInference(Settings* s) {
       break;
     default:
       LOG(FATAL) << "cannot handle output type "
-                 << interpreter->tensor(input)->type << " yet";
+                 << interpreter->tensor(output)->type << " yet";
       exit(-1);
   }
 


### PR DESCRIPTION
should log the output type instead of the input type.