### PR TITLE
Inherit CMSIS CCFLAGS when generating mbed project

### DIFF
--- a/tensorflow/lite/micro/tools/make/helper_functions.inc
+++ b/tensorflow/lite/micro/tools/make/helper_functions.inc
@@ -2,6 +2,9 @@
 # Reverses a space-separated list of words.
 reverse = $(if $(1),$(call reverse,$(wordlist 2,$(words $(1)),$(1)))) $(firstword $(1))
 
+# Get macros only (i.e. the ones starting with -D) from two lists and remove duplicates
+getmacros = $(patsubst -D%,%,$(filter -D%,$(sort $(filter -D%, $(1)) $(filter -D%, $(2)))))
+
 # Look for platform or target-specific implementation files to replace reference
 # implementations with, given a tag. These are expected to occur in subfolders
 # of a directory where a reference implementation exists, and have the same
@@ -92,6 +95,12 @@ $(PRJDIR)$(3)/$(1)/.vscode/tasks.json : tensorflow/lite/micro/tools/make/templat
 	@cp $$< $$@
 
 generate_$(3)_$(1)_project: $(addprefix $(PRJDIR)$(3)/$(1)/, $(4) $(5) $(2))
+ifeq (mbed, $(1))
+	$(eval macrolist := $(call getmacros, $7, $8))
+	$(eval jsonfilename := $(PRJDIR)$(3)/$(1)/mbed_app)
+	@awk 'FNR==NR{ if (/}/) p=NR; next} 1; FNR==(p-1){ n=split("$(macrolist)",a," "); print("    ,\"macros\": [");for (i=1; i <= n; i++){ printf("        \"%s\"", a[i]); if(i<n){printf(",\n")}}printf("\n    ]\n")}' \
+        $(jsonfilename).json $(jsonfilename).json > $(jsonfilename).tmp && mv $(jsonfilename).tmp $(jsonfilename).json
+endif
 
 list_$(3)_$(1)_files:
 	@echo $(4) $(5)


### PR DESCRIPTION
In
tensorflow/lite/experimental/micro/tools/make/ext_libs/cmsis.inc
the flags LOOP_UNROLL and ARM_DSP aren't inherited when creating an mbed project.

Example: make -f tensorflow/lite/micro/tools/make/Makefile generate_hello_world_mbed_project TARGET_ARCH=cortex-m7 TAGS=cmsis-nn
