### PR TITLE
[ROCm][XLA] Adding address space cast to generate correct llvm

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/hlo_to_ir_bindings.cc
+++ b/tensorflow/compiler/xla/service/gpu/hlo_to_ir_bindings.cc
@@ -171,7 +171,8 @@ llvm::Value* HloToIrBindings::GetTypedIrValue(const HloInstruction& hlo,
     typed_ir_value = llvm::ConstantExpr::getPointerBitCastOrAddrSpaceCast(
         llvm::cast<llvm::GlobalVariable>(ir_value), dest_type);
   } else {
-    typed_ir_value = b_->CreateBitCast(ir_value, pointee_type->getPointerTo());
+    typed_ir_value = b_->CreatePointerBitCastOrAddrSpaceCast(
+        ir_value, pointee_type->getPointerTo());
   }
   if (!HasMeaningfulName(ir_value)) {
     ir_value->setName(llvm_ir::IrName(&hlo, "raw"));


### PR DESCRIPTION
Background: Kernel variables in Nvdia/OpenCL side are represented as address space 0, whereas in AMDGPU side is represented as address space 5.

This PR replaced `CreateBitCast()` to `CreatePointerBitCastOrAddrSpaceCast()`, aiming to fix AMDGPU address space. Without this change, the generated llvm IR will have a mismatch in address space, causing widespread failures in unit tests. E,g:

> Invalid bitcast
   %add.typed = bitcast float addrspace(5)* %add.raw to float*

@whchung @cheshire 

