### PR TITLE
[SEGFAULT]: root_node nullptr check

### DIFF
--- a/tensorflow/compiler/xla/service/hlo_parser.cc
+++ b/tensorflow/compiler/xla/service/hlo_parser.cc
@@ -636,8 +636,7 @@ bool HloParserImpl::ParseInstructionList(HloComputation** computation,
     // the pool, which should not happen.
     if (root_node == nullptr) {
       LOG(FATAL) << "instruction " << root_name
-                 << " was marked as ROOT but the parser has not seen it before";
-      return false;
+                 << " was marked as ROOT but the parser has not seen it before"; // abort()
     }
     root = root_node->first;
   }

--- a/tensorflow/compiler/xla/service/hlo_parser.cc
+++ b/tensorflow/compiler/xla/service/hlo_parser.cc
@@ -636,7 +636,7 @@ bool HloParserImpl::ParseInstructionList(HloComputation** computation,
     // the pool, which should not happen.
     if (root_node == nullptr) {
       LOG(FATAL) << "instruction " << root_name
-                 << " was marked as ROOT but the parser has not seen it before"; // abort()
+                 << " was marked as ROOT but the parser has not seen it before"; // LOG(FATAL) crashes the program by calling abort()
     }
     root = root_node->first;
   }

--- a/tensorflow/compiler/xla/service/hlo_parser.cc
+++ b/tensorflow/compiler/xla/service/hlo_parser.cc
@@ -637,6 +637,7 @@ bool HloParserImpl::ParseInstructionList(HloComputation** computation,
     if (root_node == nullptr) {
       LOG(FATAL) << "instruction " << root_name
                  << " was marked as ROOT but the parser has not seen it before";
+      return false;
     }
     root = root_node->first;
   }

--- a/tensorflow/compiler/xla/service/hlo_parser.cc
+++ b/tensorflow/compiler/xla/service/hlo_parser.cc
@@ -636,7 +636,7 @@ bool HloParserImpl::ParseInstructionList(HloComputation** computation,
     // the pool, which should not happen.
     if (root_node == nullptr) {
       LOG(FATAL) << "instruction " << root_name
-                 << " was marked as ROOT but the parser has not seen it before"; // LOG(FATAL) crashes the program by calling abort()
+                 << " was marked as ROOT but the parser has not seen it before"; // LOG(FATAL) crashes the program by calling abort().
     }
     root = root_node->first;
   }

--- a/tensorflow/compiler/xla/service/hlo_parser.cc
+++ b/tensorflow/compiler/xla/service/hlo_parser.cc
@@ -635,8 +635,9 @@ bool HloParserImpl::ParseInstructionList(HloComputation** computation,
     // This means some instruction was marked as ROOT but we didn't find it in
     // the pool, which should not happen.
     if (root_node == nullptr) {
+      // LOG(FATAL) crashes the program by calling abort().
       LOG(FATAL) << "instruction " << root_name
-                 << " was marked as ROOT but the parser has not seen it before"; // LOG(FATAL) crashes the program by calling abort().
+                 << " was marked as ROOT but the parser has not seen it before"; 
     }
     root = root_node->first;
   }


### PR DESCRIPTION
Accessing root_node after it may possibly still be nullptr.