### PR TITLE
add trainable property to AggregatingVariable

### DIFF
--- a/tensorflow/python/distribute/values.py
+++ b/tensorflow/python/distribute/values.py
@@ -1422,6 +1422,10 @@ class AggregatingVariable(variables_lib.Variable):
     return self._v.name
 
   @property
+  def trainable(self):
+    return self._v.trainable
+
+  @property
   def dtype(self):
     return self._v.dtype
 


### PR DESCRIPTION
#35442 #35017
When i tried to train a keras model using ParameterServerStrategy, i found the error message described in above issue. It says that 'trainable' property is not implemented.
And i found AggregatingVariable which is a wrapper class used in ParameterServerStrategy doesn't override 'trainable' property. It should be fixed by overriding 'trainable' property.
So i simply fixed it by using unwrapped value's 'trainable' property.