### PR TITLE
[ROCm] Fix for //tensorflow/python/kernel_tests/signal:mel_ops_test

### DIFF
--- a/tensorflow/python/ops/signal/mel_ops.py
+++ b/tensorflow/python/ops/signal/mel_ops.py
@@ -45,9 +45,7 @@ def _mel_to_hertz(mel_values, name=None):
   """
   with ops.name_scope(name, 'mel_to_hertz', [mel_values]):
     mel_values = ops.convert_to_tensor(mel_values)
-    return _MEL_BREAK_FREQUENCY_HERTZ * (
-        math_ops.exp(mel_values / _MEL_HIGH_FREQUENCY_Q) - 1.0
-    )
+    return _MEL_BREAK_FREQUENCY_HERTZ * math_ops.expm1(mel_values / _MEL_HIGH_FREQUENCY_Q)
 
 
 def _hertz_to_mel(frequencies_hertz, name=None):
@@ -63,8 +61,7 @@ def _hertz_to_mel(frequencies_hertz, name=None):
   """
   with ops.name_scope(name, 'hertz_to_mel', [frequencies_hertz]):
     frequencies_hertz = ops.convert_to_tensor(frequencies_hertz)
-    return _MEL_HIGH_FREQUENCY_Q * math_ops.log(
-        1.0 + (frequencies_hertz / _MEL_BREAK_FREQUENCY_HERTZ))
+    return _MEL_HIGH_FREQUENCY_Q * math_ops.log1p(frequencies_hertz / _MEL_BREAK_FREQUENCY_HERTZ)
 
 
 def _validate_arguments(num_mel_bins, sample_rate,

--- a/tensorflow/python/ops/signal/mel_ops.py
+++ b/tensorflow/python/ops/signal/mel_ops.py
@@ -45,11 +45,13 @@ def _mel_to_hertz(mel_values, name=None):
   """
   with ops.name_scope(name, 'mel_to_hertz', [mel_values]):
     mel_values = ops.convert_to_tensor(mel_values)
-    return _MEL_BREAK_FREQUENCY_HERTZ * math_ops.expm1(mel_values / _MEL_HIGH_FREQUENCY_Q)
+    return _MEL_BREAK_FREQUENCY_HERTZ * math_ops.expm1(mel_values / 
+      _MEL_HIGH_FREQUENCY_Q)
 
 
 def _hertz_to_mel(frequencies_hertz, name=None):
   """Converts frequencies in `frequencies_hertz` in Hertz to the mel scale.
+
 
   Args:
     frequencies_hertz: A `Tensor` of frequencies in Hertz.
@@ -61,7 +63,8 @@ def _hertz_to_mel(frequencies_hertz, name=None):
   """
   with ops.name_scope(name, 'hertz_to_mel', [frequencies_hertz]):
     frequencies_hertz = ops.convert_to_tensor(frequencies_hertz)
-    return _MEL_HIGH_FREQUENCY_Q * math_ops.log1p(frequencies_hertz / _MEL_BREAK_FREQUENCY_HERTZ)
+    return _MEL_HIGH_FREQUENCY_Q * math_ops.log1p(frequencies_hertz /
+      _MEL_BREAK_FREQUENCY_HERTZ)
 
 
 def _validate_arguments(num_mel_bins, sample_rate,

--- a/tensorflow/python/ops/signal/mel_ops.py
+++ b/tensorflow/python/ops/signal/mel_ops.py
@@ -46,7 +46,7 @@ def _mel_to_hertz(mel_values, name=None):
   with ops.name_scope(name, 'mel_to_hertz', [mel_values]):
     mel_values = ops.convert_to_tensor(mel_values)
     return _MEL_BREAK_FREQUENCY_HERTZ * math_ops.expm1(mel_values / 
-      _MEL_HIGH_FREQUENCY_Q)
+                                                       _MEL_HIGH_FREQUENCY_Q)
 
 
 def _hertz_to_mel(frequencies_hertz, name=None):
@@ -64,7 +64,7 @@ def _hertz_to_mel(frequencies_hertz, name=None):
   with ops.name_scope(name, 'hertz_to_mel', [frequencies_hertz]):
     frequencies_hertz = ops.convert_to_tensor(frequencies_hertz)
     return _MEL_HIGH_FREQUENCY_Q * math_ops.log1p(frequencies_hertz /
-      _MEL_BREAK_FREQUENCY_HERTZ)
+                                                  _MEL_BREAK_FREQUENCY_HERTZ)
 
 
 def _validate_arguments(num_mel_bins, sample_rate,


### PR DESCRIPTION
The test //tensorflow/python/kernel_tests/signal:mel_ops_test fails on ROCm in eager mode by slightly exceeding the error tolerance.
This patch replaces the calls to exp and log with more accurate expm1 and log1p (which is something that occurs automatically in graph mode but not in eager mode), bringing the error back below threshold.