### PR TITLE
Fix the comparison of integer expressions of different signedness

### DIFF
--- a/tensorflow/compiler/jit/xla_kernel_creator_util.cc
+++ b/tensorflow/compiler/jit/xla_kernel_creator_util.cc
@@ -104,7 +104,7 @@ Status GetBodyAndConstantsAndResources(FunctionLibraryRuntime* flr,
       BackwardsConstAnalysis(*((*fbody)->graph), &const_args,
                              /*compile_time_const_nodes=*/nullptr, flr));
 
-  for (int i = 0; i < const_args.size(); ++i) {
+  for (size_t i = 0; i < const_args.size(); ++i) {
     if (const_args[i]) {
       constant_arg_indices->push_back(i);
     }
@@ -113,7 +113,7 @@ Status GetBodyAndConstantsAndResources(FunctionLibraryRuntime* flr,
   // There can be hundreds of resource variables. Reserve the space for them.
   // We don't reserve for constants above as they are usually few.
   resource_arg_indices->reserve(arg_types.size());
-  for (int i = 0; i < arg_types.size(); ++i) {
+  for (size_t i = 0; i < arg_types.size(); ++i) {
     if (arg_types[i] == DT_RESOURCE) {
       resource_arg_indices->push_back(i);
     }
@@ -177,7 +177,7 @@ Status CreateXlaKernel(FunctionLibraryRuntime* flr, const NodeDef& node_def,
   // 214 variables and a similar number of activations.
   SinglePassSearch constants_search(&constant_arg_indices);
   SinglePassSearch resources_search(&resource_arg_indices);
-  for (int i = 0; i < fbody->arg_types.size(); ++i) {
+  for (size_t i = 0; i < fbody->arg_types.size(); ++i) {
     if (resources_search.ScanForValue(i) || constants_search.ScanForValue(i)) {
       // Compile-time constants and resource handles are expected to be in
       // host memory.
@@ -207,7 +207,7 @@ Status CreateXlaKernel(FunctionLibraryRuntime* flr, const NodeDef& node_def,
   // XlaLaunch kernel keeps all outputs (including constants, which it copies),
   // in device memory except for resources.
   MemoryTypeVector output_memory_types(fbody->ret_types.size(), DEVICE_MEMORY);
-  for (int i = 0; i < fbody->ret_types.size(); ++i) {
+  for (size_t i = 0; i < fbody->ret_types.size(); ++i) {
     if (fbody->ret_types[i] == DT_RESOURCE) {
       output_memory_types[i] = HOST_MEMORY;
     }

--- a/tensorflow/core/platform/numbers.cc
+++ b/tensorflow/core/platform/numbers.cc
@@ -62,7 +62,7 @@ T locale_independent_strtonum(const char* str, const char** endptr) {
   string special_num_str;
   s >> special_num_str;
 
-  for (int i = 0; i < special_num_str.length(); ++i) {
+  for (size_t i = 0; i < special_num_str.length(); ++i) {
     special_num_str[i] =
         std::tolower(special_num_str[i], std::locale::classic());
   }

--- a/tensorflow/python/client/tf_session_wrapper.cc
+++ b/tensorflow/python/client/tf_session_wrapper.cc
@@ -71,7 +71,7 @@ TF_Buffer* ProtoStringToTFBuffer(PyObject* input) {
 tensorflow::NameVector ConvertPyListToNameVector(
     const std::vector<py::bytes>& py_vector) {
   tensorflow::NameVector temp;
-  for (int i = 0; i < py_vector.size(); ++i) {
+  for (size_t i = 0; i < py_vector.size(); ++i) {
     const char* string_elem = PyBytes_AsString(py_vector.at(i).ptr());
     temp.push_back(string_elem);
   }
@@ -231,7 +231,7 @@ PYBIND11_MODULE(_pywrap_tf_session, m) {
 
     // Create a python list from InlinedVector
     py::list py_list;
-    for (int i = 0; i < result.size(); ++i) {
+    for (size_t i = 0; i < result.size(); ++i) {
       py_list.append(py::cast(result[i]));
     }
 
@@ -296,7 +296,7 @@ PYBIND11_MODULE(_pywrap_tf_session, m) {
 
           // Convert shapes nested vector
           std::vector<std::vector<int64_t>> shapes_local;
-          for (int i = 0; i < shapes.size(); ++i) {
+          for (size_t i = 0; i < shapes.size(); ++i) {
             std::vector<int64_t> dims;
             std::vector<int64_t> item =
                 shapes[i].has_value() ? shapes[i].value() : dims;
@@ -455,7 +455,7 @@ PYBIND11_MODULE(_pywrap_tf_session, m) {
       PyErr_SetString(PyExc_MemoryError, "Failed to create a list.");
       throw py::error_already_set();
     }
-    for (int i = 0; i < py_outputs.size(); ++i) {
+    for (size_t i = 0; i < py_outputs.size(); ++i) {
       PyList_SET_ITEM(result, i, py_outputs.at(i));
     }
 
@@ -505,7 +505,7 @@ PYBIND11_MODULE(_pywrap_tf_session, m) {
       PyErr_SetString(PyExc_MemoryError, "Failed to create a list.");
       throw py::error_already_set();
     }
-    for (int i = 0; i < py_outputs.size(); ++i) {
+    for (size_t i = 0; i < py_outputs.size(); ++i) {
       PyList_SET_ITEM(result, i, py_outputs.at(i));
     }
 
@@ -539,7 +539,7 @@ PYBIND11_MODULE(_pywrap_tf_session, m) {
 
     // Return out_values
     py::list py_list;
-    for (int i = 0; i < out_values.size(); ++i) {
+    for (size_t i = 0; i < out_values.size(); ++i) {
       py::object obj = tensorflow::pyo(out_values.at(i));
       py_list.append(obj);
     }
@@ -725,7 +725,7 @@ PYBIND11_MODULE(_pywrap_tf_session, m) {
       "TF_AddInputList", [](TF_OperationDescription* desc, py::handle& inputs) {
         std::vector<TF_Output> vec;
         size_t size = PyList_Size(inputs.ptr());
-        for (int i = 0; i < size; ++i) {
+        for (size_t i = 0; i < size; ++i) {
           TF_Output item = py::cast<TF_Output>(PyList_GetItem(inputs.ptr(), i));
           vec.push_back(item);
         }

--- a/tensorflow/python/grappler/cluster_wrapper.cc
+++ b/tensorflow/python/grappler/cluster_wrapper.cc
@@ -197,7 +197,7 @@ PYBIND11_MODULE(_pywrap_tf_cluster, m) {
                     tensorflow::OpRegistry::Global(), dev_type, node,
                     &inp_mtypes, &out_mtypes);
                 if (s.ok()) {
-                  for (int i = 0; i < inp_mtypes.size(); ++i) {
+                  for (size_t i = 0; i < inp_mtypes.size(); ++i) {
                     if (inp_mtypes[i] == tensorflow::HOST_MEMORY) {
                       device_restrictions[tensorflow::grappler::NodeName(
                                               node.input(i))]
@@ -318,7 +318,7 @@ PYBIND11_MODULE(_pywrap_tf_cluster, m) {
           const tensorflow::grappler::GraphMemory::MemoryUsage& usage =
               memory.GetPeakMemoryUsage(device.first);
           std::vector<MemoryUsage> per_device;
-          for (int i = 0; i < usage.live_tensors.size(); ++i) {
+          for (size_t i = 0; i < usage.live_tensors.size(); ++i) {
             const auto& live_tensor = usage.live_tensors[i];
             per_device.push_back(std::make_tuple(
                 live_tensor.node, live_tensor.output_id,


### PR DESCRIPTION
This PR fixes a warning when building TF from source:
```
tensorflow/core/platform/numbers.cc:65:21: warning: comparison of integer expressions of different signedness: 'int' and 'std::basic_string<char>::size_type' {aka 'long unsigned int'} [-Wsign-compare]
```