### PR TITLE
[INTEL MKL] Refactor the implementation of forward conv ops w MKL-DNN v1.0 integration

### DIFF
--- a/tensorflow/core/kernels/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl_conv_ops.cc
@@ -16,16 +16,14 @@ limitations under the License.
 // See docs in ../ops/nn_ops.cc.
 #ifdef INTEL_MKL
 
-#include "tensorflow/core/kernels/mkl_conv_ops.h"
-
-#include <string.h>
-
 #include <algorithm>
 #include <map>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
-#include "mkldnn.hpp"
 #include "absl/strings/str_join.h"
+#include "mkldnn.hpp"
 #include "tensorflow/core/framework/bounds_check.h"
 #include "tensorflow/core/framework/numeric_op.h"
 #include "tensorflow/core/framework/op_kernel.h"
@@ -33,6 +31,7 @@ limitations under the License.
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/framework/tensor_shape.h"
 #include "tensorflow/core/framework/tensor_slice.h"
+#include "tensorflow/core/kernels/mkl_conv_ops.h"
 #include "tensorflow/core/kernels/mkl_quantized_conv_ops.h"
 #include "tensorflow/core/kernels/no_op.h"
 #include "tensorflow/core/kernels/ops_util.h"
@@ -43,6 +42,7 @@ limitations under the License.
 #include "tensorflow/core/lib/strings/strcat.h"
 #include "tensorflow/core/platform/logging.h"
 #include "tensorflow/core/platform/macros.h"
+#include "tensorflow/core/util/mkl_types.h"
 #include "tensorflow/core/util/mkl_util.h"
 #include "tensorflow/core/util/padding.h"
 #include "tensorflow/core/util/tensor_format.h"
@@ -55,91 +55,6 @@ using ConvFwdPd = mkldnn::convolution_forward::primitive_desc;
 using ReorderPd = mkldnn::reorder::primitive_desc;
 
 namespace tensorflow {
-
-#ifdef ENABLE_MKLDNN_V1
-#define ADD_MD add_md
-#define ALGORITHM mkldnn::algorithm
-#define ALGORITHM_UNDEF ALGORITHM::undef
-#define CPU_STREAM(engine) stream(engine)
-#define DATA_WITH_ENGINE(data, engine) data, engine
-#define DST_MD dst_md
-#define ENGINE_CPU engine::kind::cpu
-#define GET_DESC get_desc()
-#define GET_MEMORY_DESC_CONSTRUCTOR(dims, type, fm) \
-  { {dims}, MklDnnType<type>(), memory::format_tag::fm }
-#define GET_SRC_DESC_FROM_OP_PD(op_pd) op_pd->src_desc()
-#define GET_WEIGHTS_DESC_FROM_OP_PD(op_pd) op_pd->weights_desc()
-#define GET_WEIGHTS_FORMAT_FROM_OP_PD(op_pd, op_primitive) \
-  GET_WEIGHTS_DESC_FROM_OP_PD(op_pd)
-#define IS_FILTER_REORDER_NEEDED(filter_md, op_pd, op_primitive) \
-  filter_md != op_pd->weights_desc()
-#define IS_SRC_REORDER_NEEDED(src_md, op_pd, op_primitive) \
-  src_md != op_pd->src_desc()
-#define MEMORY_CONSTRUCTOR(mem_desc, engine, data) \
-  memory(mem_desc, engine, data)
-#define MEMORY_CONSTRUCTOR_USING_MEM_PD(dims, type, fm, engine, data) \
-  memory(GET_MEMORY_DESC_CONSTRUCTOR(dims, type, fm), engine, data)
-#define MEMORY_CONSTRUCTOR_WITHOUT_DATA(mem_desc, engine) \
-  memory(mem_desc, engine)
-#define MEMORY_DESC memory::desc
-#define MEMORY_FORMAT mkldnn::memory::format_tag
-#define MEMORY_PD_CONSTRUCTOR(dims, type, fm, engine) \
-  memory::desc({dims}, MklDnnType<type>(), memory::format_tag::fm)
-#define MEMORY_PD_WITHOUT_DATA(md, engine) md, engine
-#define MKL_TENSOR_FORMAT MklTensorFormat
-#define MKL_TENSOR_FORMAT_BLOCKED MklTensorFormat::FORMAT_BLOCKED
-#define MKL_TENSOR_FORMAT_IN_C MKL_TENSOR_FORMAT
-#define OUTPUT_TF_MD output_tf_md
-#define PRIMITIVE_DESC_BIAS bias_desc()
-#define PRIMITIVE_DESC_DST dst_desc()
-#define PRIMITIVE_DESC_SRC src_desc()
-#define PRIMITIVE_DESC_WEIGHTS weights_desc()
-#define REORDER_PD_CONSTRUCTOR(src_md, dst_md, engine) \
-  ReorderPd(engine, src_md, engine, dst_md)
-#define REORDER_PD_CONSTRUCTOR_WITH_ATTR(src_md, dst_md, engine, prim_attr) \
-  ReorderPd(engine, src_md, engine, dst_md, prim_attr)
-#define SUMMAND_MD summand_md
-#else
-#define ADD_MD add_pd
-#define ALGORITHM mkldnn
-#define ALGORITHM_UNDEF ALGORITHM::algorithm_undef
-#define CPU_STREAM(engine) stream(stream::kind::eager)
-#define DATA_WITH_ENGINE(data, engine) data
-#define DST_MD dst_pd
-#define ENGINE_CPU engine::cpu
-#define GET_DESC get_primitive_desc()
-#define GET_MEMORY_DESC_CONSTRUCTOR(dims, type, fm) \
-  { {dims}, MklDnnType<type>(), memory::format::fm }
-#define GET_SRC_DESC_FROM_OP_PD(op_pd) op_pd.get()->src_primitive_desc()
-#define GET_WEIGHTS_DESC_FROM_OP_PD(op_pd) op_pd.get()->weights_primitive_desc()
-#define GET_WEIGHTS_FORMAT_FROM_OP_PD(op_pd, op_primitive) \
-  op_primitive->GetFilterMemoryFormat()
-#define IS_FILTER_REORDER_NEEDED(filter_md, op_pd, op_primitive) \
-  filter_md.data.format != op_primitive->GetFilterMemoryFormat()
-#define IS_SRC_REORDER_NEEDED(src_md, op_pd, op_primitive) \
-  src_md.data.format != op_primitive->GetSrcMemoryFormat()
-#define MEMORY_CONSTRUCTOR(mem_pd, engine, data) memory(mem_pd, data)
-#define MEMORY_CONSTRUCTOR_USING_MEM_PD(dims, type, fm, engine, data) \
-  memory({GET_MEMORY_DESC_CONSTRUCTOR(dims, type, fm), engine}, data)
-#define MEMORY_CONSTRUCTOR_WITHOUT_DATA(mem_pd, engine) memory(mem_pd)
-#define MEMORY_DESC memory::format
-#define MEMORY_FORMAT mkldnn::memory::format
-#define MEMORY_PD_CONSTRUCTOR(dims, type, fm, engine) \
-  memory::primitive_desc(GET_MEMORY_DESC_CONSTRUCTOR(dims, type, fm), engine)
-#define MEMORY_PD_WITHOUT_DATA(pd, engine) pd
-#define MKL_TENSOR_FORMAT memory::format
-#define MKL_TENSOR_FORMAT_BLOCKED memory::format::blocked
-#define MKL_TENSOR_FORMAT_IN_C mkldnn_memory_format_t
-#define OUTPUT_TF_MD output_tf_pd
-#define PRIMITIVE_DESC_BIAS bias_primitive_desc()
-#define PRIMITIVE_DESC_DST dst_primitive_desc()
-#define PRIMITIVE_DESC_SRC src_primitive_desc()
-#define PRIMITIVE_DESC_WEIGHTS weights_primitive_desc()
-#define REORDER_PD_CONSTRUCTOR(src_pd, dst_pd, engine) ReorderPd(src_pd, dst_pd)
-#define REORDER_PD_CONSTRUCTOR_WITH_ATTR(src_pd, dst_pd, engine, prim_attr) \
-  ReorderPd(src_pd, dst_pd, prim_attr)
-#define SUMMAND_MD summand_pd
-#endif  // ENABLE_MKLDNN_V1
 
 // This structure aggregates multiple inputs to Conv2DFwd* methods.
 struct MklConvFwdParams {
@@ -156,7 +71,6 @@ struct MklConvFwdParams {
     string name;
     mkldnn::algorithm alg;
     std::vector<float> param;
-    std::string partial_key;
   };
   std::vector<PostOpParam> post_op_params;
 
@@ -395,7 +309,8 @@ class MklConvFwdPrimitive : public MklPrimitive {
     // Create convolution primitive and add it to net
     if (!convFwdDims.bias_dims.empty()) {
       context_.bias_mem.reset(new MEMORY_CONSTRUCTOR_USING_MEM_PD(
-          convFwdDims.bias_dims, Tbias, x, cpu_engine_, DummyData));
+          convFwdDims.bias_dims, Tbias, MEMORY_FORMAT::x, cpu_engine_,
+          DummyData));
 #ifdef ENABLE_MKLDNN_V1
       context_.conv_fwd.reset(new convolution_forward(*context_.fwd_pd));
       context_.fwd_primitives_args.push_back(
@@ -489,21 +404,16 @@ class MklConvFwdPrimitiveFactory : public MklPrimitiveFactory<float> {
 
     // Generate keys for post-ops
     for (auto const& post_op_param : convFwdDims.post_op_params) {
-      key_creator.AddAsKey(post_op_param.name);
       if (post_op_param.name == "activation") {
         DCHECK_EQ(post_op_param.param.size(), 3);
-        for (auto& param : post_op_param.param) {
-          key_creator.AddAsKey(param);
-        }
       } else if (post_op_param.name == "sum") {
         DCHECK_EQ(post_op_param.param.size(), 1);
-        for (auto& param : post_op_param.param) {
-          key_creator.AddAsKey(param);
-        }
-      } else if (post_op_param.name == "output_scale") {
-        key_creator.AddAsKey(post_op_param.partial_key);
-      } else {
+      } else if (post_op_param.name != "output_scale") {
         return string("not_a_key");
+      }
+      key_creator.AddAsKey(post_op_param.name);
+      for (auto& param : post_op_param.param) {
+        key_creator.AddAsKey(param);
       }
     }
 
@@ -576,17 +486,15 @@ class MklConvOp : public OpKernel {
       OP_REQUIRES(context, dilations_.size() == 5,
                   errors::InvalidArgument("Dilation rates field must "
                                           "specify 5 dimensions"));
-      OP_REQUIRES(context,
-                  (GetTensorDim(dilations_, data_format_, 'N') == 1 &&
-                   GetTensorDim(dilations_, data_format_, 'C') == 1),
+      OP_REQUIRES(context, (GetTensorDim(dilations_, data_format_, 'N') == 1 &&
+                            GetTensorDim(dilations_, data_format_, 'C') == 1),
                   errors::InvalidArgument(
                       "Current implementation does not yet support "
                       "dilations rates in the batch and depth dimensions."));
       OP_REQUIRES(
-          context,
-          (GetTensorDim(dilations_, data_format_, '0') > 0 &&
-           GetTensorDim(dilations_, data_format_, '1') > 0 &&
-           GetTensorDim(dilations_, data_format_, '2') > 0),
+          context, (GetTensorDim(dilations_, data_format_, '0') > 0 &&
+                    GetTensorDim(dilations_, data_format_, '1') > 0 &&
+                    GetTensorDim(dilations_, data_format_, '2') > 0),
           errors::InvalidArgument("Dilated rates should be larger than 0."));
     }
   }
@@ -679,7 +587,7 @@ class MklConvOp : public OpKernel {
             errors::InvalidArgument("Pad+Conv fusion only works for 2D"));
       }
 
-      // TODO 3-D support for Depthwise is not there
+      // TODO(gzmkl) 3-D support for Depthwise is not there
       if (is_depthwise) {
         OP_REQUIRES(context, is_conv2d,
                     errors::InvalidArgument(
@@ -779,10 +687,9 @@ class MklConvOp : public OpKernel {
       Ttemp_output* dst_data =
           reinterpret_cast<Ttemp_output*>(dst_tensor->flat<Toutput>().data());
 
-      // Check whether src and filter need to be reordered
+      // Check whether src and filter need to be reordered.
       Tinput* src_data = nullptr;
       if (IS_SRC_REORDER_NEEDED(src_md, conv_fwd_pd, conv_fwd)) {
-        // Reorder src
         src.SetUsrMem(src_md, &src_tensor);
         src.CheckReorderToOpMem(MEMORY_PD_WITHOUT_DATA(
             GET_SRC_DESC_FROM_OP_PD(conv_fwd_pd), cpu_engine_));
@@ -791,6 +698,7 @@ class MklConvOp : public OpKernel {
         src_data = static_cast<Tinput*>(
             const_cast<Tinput*>(src_tensor.flat<Tinput>().data()));
       }
+
       Tfilter* filter_data = nullptr;
       if (IS_FILTER_REORDER_NEEDED(filter_md, conv_fwd_pd, conv_fwd)) {
         bool is_filter_cached = false;
@@ -863,6 +771,7 @@ class MklConvOp : public OpKernel {
                                   cpu_engine_);
         }
       }
+
       // Delete primitive since it is not cached.
       if (do_not_cache) delete conv_fwd;
     } catch (mkldnn::error& e) {
@@ -952,11 +861,11 @@ class MklConvOp : public OpKernel {
     // NOTE: Fusion of BiasAdd is handled directly inside MklConvOp by
     // checking `fuse_biasadd_` flag.
     if (fuse_add_) {
-      params.post_op_params.push_back({"sum", ALGORITHM_UNDEF, {1.0}, ""});
+      params.post_op_params.push_back({"sum", ALGORITHM_UNDEF, {1.0}});
     }
     if (fuse_activation_) {
       params.post_op_params.push_back(
-          {"activation", activation_alg_, {1.0, relu_up_bound_, 0.0}, ""});
+          {"activation", activation_alg_, {1.0, relu_up_bound_, 0.0}});
     }
   }
 
@@ -1313,8 +1222,8 @@ class MklConvOp : public OpKernel {
         *cached_filter_md_ptensor_.AccessTensor(context);
 
 // Check if the memory descriptor of the cached weights is same as
-// filter_md. If so, we can use the cached weights; otherwise
-// return NULL.
+// filter_md. If so, we can used the cached weights; otherwise
+// return nullptr.
 #ifdef ENABLE_MKLDNN_V1
     if (cached_filter_md.scalar<int64>().size() &&
         AreMemoryDescriptorsEqual(filter_md, cached_filter_md)) {
@@ -1528,6 +1437,7 @@ class MklQuantizedConv2DOp
     MklConvOp<Device, Tinput, qint8, Tbias, Toutput, Ttemp_output, int32,
               bias_enabled, false, is_depthwise,
               false>::ExtendConvFwdParams(context, params);
+
     // When the output type is quint8, the output data id requantized
     // into quint8. A post_op "output_scale" is added to do the conversion.
     if (std::is_same<Toutput, quint8>::value ||
@@ -1570,19 +1480,8 @@ class MklQuantizedConv2DOp
         scales[i] = int_output_limit * float_input_range * float_filter_range /
                     (int_const_scale_limit * float_output_range);
       }
-      // we are creating a partial key here to use with primitive key caching to
-      // improve key creation performance. Instead of using actual values we are
-      // using the pointers for min/max_filter_vector, and this works since the
-      // filter vector here is a constant.
-      FactoryKeyCreator param_key;
-      param_key.AddAsKey<float>(min_input);
-      param_key.AddAsKey<float>(max_input);
-      param_key.AddAsKey<float>(min_freezed_output);
-      param_key.AddAsKey<float>(max_freezed_output);
-      param_key.AddAsKey<const Tensor*>(&min_filter_vector);
-      param_key.AddAsKey<const Tensor*>(&max_filter_vector);
       params.post_op_params.push_back(
-          {"output_scale", ALGORITHM_UNDEF, scales, param_key.GetKey()});
+          {"output_scale", ALGORITHM_UNDEF, scales});
     }
   }
 
@@ -1607,6 +1506,8 @@ class MklQuantizedConv2DOp
     const Tensor& max_filter_vector = context->input(5 + bias_index_offset);
     const float* min_filter = min_filter_vector.flat<float>().data();
     const float* max_filter = max_filter_vector.flat<float>().data();
+
+    std::vector<mkldnn::primitive> net;
 
     const float int_const_scale_limit =
         (std::is_same<Tinput, quint8>::value) ? 255.0 * 127.0 : 127.0 * 127.0;
@@ -1637,7 +1538,7 @@ class MklQuantizedConv2DOp
 
       auto bias_md =
           MEMORY_PD_CONSTRUCTOR(static_cast<int>(bias_tensor.NumElements()),
-                                Tbias, x, this->cpu_engine_);
+                                Tbias, MEMORY_FORMAT::x, this->cpu_engine_);
       void* bias_buf = static_cast<void*>(
           const_cast<Tbias*>(bias_tensor.flat<Tbias>().data()));
       if (!input_bias_) {
@@ -1693,7 +1594,7 @@ class MklQuantizedConv2DOp
     DCHECK(bias_tensor);
     TensorShape bias_tf_shape;
     bias_tf_shape.AddDim(
-        (conv_prim_desc.bias_primitive_desc().get_size() / sizeof(Tbias)));
+        (conv_prim_desc.PRIMITIVE_DESC_BIAS.get_size() / sizeof(Tbias)));
     OP_REQUIRES_OK(context, context->allocate_persistent(
                                 DataTypeToEnum<Tbias>::value, bias_tf_shape,
                                 &cached_bias_data_ptensor_, bias_tensor));
@@ -1726,7 +1627,7 @@ class MklQuantizedConv2DOp
     AllocatePersistentTensor(context, *conv_fwd_pd, &bias_tensor_ptr);
     void* cached_bias_data = const_cast<void*>(
         static_cast<const void*>(bias_tensor_ptr->flat<Tbias>().data()));
-    size_t cached_bias_data_size = scaled_bias->get_primitive_desc().get_size();
+    size_t cached_bias_data_size = scaled_bias->GET_DESC.get_size();
     memcpy(cached_bias_data, bias_data, cached_bias_data_size);
   }
 
@@ -1759,8 +1660,9 @@ class MklQuantizedConv2DReluOp
     MklQuantizedConv2DOp<Device, Tinput, Tbias, Toutput, Ttemp_output,
                          bias_enabled,
                          is_depthwise>::ExtendConvFwdParams(context, params);
+
     params.post_op_params.push_back(
-        {"activation", ALGORITHM::eltwise_relu, {1.0, 0.0, 0.0}, ""});
+        {"activation", ALGORITHM::eltwise_relu, {1.0, 0.0, 0.0}});
   }
 };
 
@@ -1808,18 +1710,17 @@ class MklQuantizedConv2DSumReluOp
       // If it is not then  it is DT_INT8 and is scaled appropriately.
       if (summand_type == DT_QUINT8)
         params.post_op_params.push_back(
-            {"sum", ALGORITHM_UNDEF, {scale_summand / scale_output}, ""});
+            {"sum", ALGORITHM_UNDEF, {scale_summand / scale_output}});
       else
         params.post_op_params.push_back(
             {"sum",
              ALGORITHM_UNDEF,
-             {255.0f * scale_summand / (scale_output * 127.0f)},
-             ""});
+             {255.0f * scale_summand / (scale_output * 127.0f)}});
     } else {
-      params.post_op_params.push_back({"sum", ALGORITHM_UNDEF, {1.0}, ""});
+      params.post_op_params.push_back({"sum", ALGORITHM_UNDEF, {1.0}});
     }
     params.post_op_params.push_back(
-        {"activation", ALGORITHM::eltwise_relu, {1.0, 0.0, 0.0}, ""});
+        {"activation", ALGORITHM::eltwise_relu, {1.0, 0.0, 0.0}});
   }
 
   void AllocateOutputTensor(OpKernelContext* context,
@@ -2473,36 +2374,5 @@ TF_CALL_bfloat16(REGISTER_MKL_CPU_2D_FUSED);
 TF_CALL_float(REGISTER_MKL_CPU_3D);
 TF_CALL_bfloat16(REGISTER_MKL_CPU_3D);
 
-#undef ADD_MD
-#undef ALGORITHM
-#undef ALGORITHM_UNDEF
-#undef CPU_STREAM
-#undef DATA_WITH_ENGINE
-#undef DST_MD
-#undef ENGINE_CPU
-#undef GET_DESC
-#undef GET_MEMORY_DESC_CONSTRUCTOR
-#undef GET_SRC_DESC_FROM_OP_PD
-#undef GET_WEIGHTS_DESC_FROM_OP_PD
-#undef GET_WEIGHTS_FORMAT_FROM_OP_PD
-#undef IS_FILTER_REORDER_NEEDED
-#undef IS_SRC_REORDER_NEEDED
-#undef MEMORY_CONSTRUCTOR
-#undef MEMORY_CONSTRUCTOR_USING_MEM_PD
-#undef MEMORY_CONSTRUCTOR_WITHOUT_DATA
-#undef MEMORY_DESC
-#undef MEMORY_FORMAT
-#undef MEMORY_PD_CONSTRUCTOR
-#undef MEMORY_PD_WITHOUT_DATA
-#undef MKL_TENSOR_FORMAT
-#undef MKL_TENSOR_FORMAT_BLOCKED
-#undef MKL_TENSOR_FORMAT_IN_C
-#undef PRIMITIVE_DESC_BIAS
-#undef PRIMITIVE_DESC_DST
-#undef PRIMITIVE_DESC_SRC
-#undef PRIMITIVE_DESC_WEIGHTS
-#undef REORDER_PD_CONSTRUCTOR
-#undef REORDER_PD_CONSTRUCTOR_WITH_ATTR
-#undef SUMMAND_MD
 }  // namespace tensorflow
 #endif  // INTEL_MKL

--- a/tensorflow/core/kernels/mkl_conv_ops.h
+++ b/tensorflow/core/kernels/mkl_conv_ops.h
@@ -55,6 +55,8 @@ namespace tensorflow {
 #define MKLDNN_SIZE_DTYPE int
 #endif  // ENABLE_MKLDNN_V1
 
+using ConvFwdPd = mkldnn::convolution_forward::primitive_desc;
+
 class MklDnnConvUtil {
  protected:
   OpKernelContext* context_;  // We don't own this.
@@ -79,7 +81,7 @@ class MklDnnConvUtil {
   virtual inline void GetStridesInMklOrder(memory::dims* strides) {
     // For now we take the stride from the second and third dimensions only
     // (we do not support striding on the batch or depth dimension).
-    CHECK_NOTNULL(strides);
+    DCHECK(strides);
     if (strides_.size() == 4) {
       int stride_rows = GetTensorDim(strides_, data_format_, 'H');
       int stride_cols = GetTensorDim(strides_, data_format_, 'W');
@@ -96,7 +98,7 @@ class MklDnnConvUtil {
   virtual inline void GetDilationsInMklOrder(memory::dims* dilations) {
     // For now we take the dilation from the second and third dimensions only
     // (we do not support dilation on the batch or depth dimension).
-    CHECK_NOTNULL(dilations);
+    DCHECK(dilations);
     if (dilations_.size() == 4) {
       int dilations_rows = GetTensorDim(dilations_, data_format_, 'H');
       int dilations_cols = GetTensorDim(dilations_, data_format_, 'W');
@@ -122,7 +124,7 @@ class MklDnnConvUtil {
                 errors::InvalidArgument(err_msg));                     \
   } while (0)
 
-    CHECK_NOTNULL(input_dims);
+    DCHECK(input_dims);
 
     // Input channel
     int64 input_depth_raw = GetTensorDim(input_shape, data_format_, 'C');
@@ -195,7 +197,7 @@ class MklDnnConvUtil {
                                               const TensorShape& filter_shape,
                                               memory::dims* filter_dims,
                                               bool is_depthwise) {
-    CHECK_NOTNULL(filter_dims);
+    DCHECK(filter_dims);
 
     OP_REQUIRES(context_, filter_shape.dims() == strides_.size(),
                 errors::InvalidArgument((strides_.size() == 4)
@@ -204,9 +206,8 @@ class MklDnnConvUtil {
                                         filter_shape.DebugString()));
 
     for (int i = 0; i < ((strides_.size() == 4) ? 3 : 5); i++) {
-      OP_REQUIRES(context_,
-                  FastBoundsCheck(filter_shape.dim_size(i),
-                                  std::numeric_limits<int>::max()),
+      OP_REQUIRES(context_, FastBoundsCheck(filter_shape.dim_size(i),
+                                            std::numeric_limits<int>::max()),
                   errors::InvalidArgument("filter too large"));
     }
 
@@ -289,7 +290,7 @@ class MklDnnConvUtil {
                                               size_t filter_index,
                                               memory::dims* filter_dims,
                                               bool is_depthwise) {
-    CHECK_NOTNULL(filter_dims);
+    DCHECK(filter_dims);
     GetFilterSizeInMklOrder(GetTfShape(context_, src_index),
                             GetTfShape(context_, filter_index), filter_dims,
                             is_depthwise);
@@ -323,10 +324,10 @@ class MklDnnConvUtil {
       memory::dims* output_dims_tf_order, memory::dims* output_dims_mkl_order,
       memory::dims* pad_l, memory::dims* pad_r, bool pad_enabled = false,
       bool is_depthwise = false) {
-    CHECK_NOTNULL(output_dims_tf_order);
-    CHECK_NOTNULL(output_dims_mkl_order);
-    CHECK_NOTNULL(pad_l);
-    CHECK_NOTNULL(pad_r);
+    DCHECK(output_dims_tf_order);
+    DCHECK(output_dims_mkl_order);
+    DCHECK(pad_l);
+    DCHECK(pad_r);
 
     bool is_conv2d = (strides_.size() == 4);
     int input_planes, input_rows, input_cols;
@@ -489,10 +490,10 @@ class MklDnnConvUtil {
       const memory::dims& dilations, memory::dims* output_dims_tf_order,
       memory::dims* output_dims_mkl_order, memory::dims* pad_l,
       memory::dims* pad_r, bool is_depthwise) {
-    CHECK_NOTNULL(output_dims_tf_order);
-    CHECK_NOTNULL(output_dims_mkl_order);
-    CHECK_NOTNULL(pad_l);
-    CHECK_NOTNULL(pad_r);
+    DCHECK(output_dims_tf_order);
+    DCHECK(output_dims_mkl_order);
+    DCHECK(pad_l);
+    DCHECK(pad_r);
 
     auto input_tf_shape = GetTfShape(context_, src_index);
     auto filter_tf_shape = GetTfShape(context_, filter_index);
@@ -530,14 +531,14 @@ class MklDnnConvUtil {
       memory::dims* output_dims_tf_order, memory::dims* output_dims_mkl_order,
       memory::dims* pad_l, memory::dims* pad_r, bool pad_enabled = false,
       bool is_depthwise = false) {
-    CHECK_NOTNULL(input_dims);
-    CHECK_NOTNULL(filter_dims);
-    CHECK_NOTNULL(strides);
-    CHECK_NOTNULL(dilations);
-    CHECK_NOTNULL(output_dims_tf_order);
-    CHECK_NOTNULL(output_dims_mkl_order);
-    CHECK_NOTNULL(pad_l);
-    CHECK_NOTNULL(pad_r);
+    DCHECK(input_dims);
+    DCHECK(filter_dims);
+    DCHECK(strides);
+    DCHECK(dilations);
+    DCHECK(output_dims_tf_order);
+    DCHECK(output_dims_mkl_order);
+    DCHECK(pad_l);
+    DCHECK(pad_r);
 
     GetInputSizeInMklOrder(input_shape, input_dims);
     if (!context_->status().ok()) return;

--- a/tensorflow/core/util/mkl_types.h
+++ b/tensorflow/core/util/mkl_types.h
@@ -1,0 +1,208 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORE_UTIL_MKL_TYPES_H_
+#define TENSORFLOW_CORE_UTIL_MKL_TYPES_H_
+#ifdef INTEL_MKL
+
+namespace tensorflow {
+
+#ifdef ENABLE_MKLDNN_V1
+typedef uint16_t mkldnn_bfloat16_t;
+#define ADD_MD add_md
+#define ALGORITHM mkldnn::algorithm
+#define ALGORITHM_UNDEF ALGORITHM::undef
+#define CPU_STREAM(engine) stream(engine)
+#define DATA_WITH_ENGINE(data, engine) data, engine
+#define DST_MD dst_md
+#define ENGINE_CPU engine::kind::cpu
+#define GET_CHECK_REORDER_MEM_ARGS(md, tensor, net, net_args, engine) \
+  md, tensor, net, net_args, engine
+#define GET_CHECK_REORDER_TO_OP_MEM_ARGS(md, tensor, net, net_args, engine) \
+  md, tensor, net, net_args, engine
+#define GET_DESC get_desc()
+#define GET_FORMAT_FROM_SHAPE(src_mkl_shape) MklTensorFormat::FORMAT_BLOCKED
+#define GET_MEMORY_DESC_CONSTRUCTOR(dims, type, fm) \
+  { {dims}, MklDnnType<type>(), fm }
+#define GET_MEMORY_DESC_FROM_MEM_PTR(mem_ptr) mem_ptr->get_desc()
+#define GET_MEMORY_PRIMITIVE_DESC_FROM_MEM_PTR(mem_ptr) \
+  GET_MEMORY_DESC_FROM_MEM_PTR(mem_ptr)
+#define GET_SRC_DESC_FROM_OP_PD(op_pd) op_pd->src_desc()
+#define GET_DIFF_DST_DESC_FROM_OP_PD(op_pd) op_pd->diff_dst_desc()
+#define GET_WORKSPACE_DESC_FROM_OP_PD(op_pd) op_pd->workspace_desc()
+#define GET_TENSOR_FORMAT(fmt) MklTensorFormatToMklDnnDataFormat(fmt)
+#define GET_TF_DATA_FORMAT(shape, mem_desc) shape.GetTfDataFormat()
+#define GET_WEIGHTS_DESC_FROM_OP_PD(op_pd) op_pd->weights_desc()
+#define GET_WEIGHTS_FORMAT_FROM_OP_PD(op_pd, op) \
+  GET_WEIGHTS_DESC_FROM_OP_PD(op_pd)
+#define IS_DIFF_DST_REORDER_NEEDED(diff_dst_md, op_pd, op) \
+  diff_dst_md != op_pd->diff_dst_desc()
+#define IS_DIFF_FILTER_REORDER_NEEDED(diff_filter_md, fmt, op_pd, op) \
+  diff_filter_md != op_pd->diff_weights_desc()
+#define IS_FILTER_REORDER_NEEDED(filter_md, op_pd, op) \
+  filter_md != op_pd->weights_desc()
+#define IS_SRC_REORDER_NEEDED(src_md, op_pd, op) src_md != op_pd->src_desc()
+#define IS_WEIGHTS_REORDER_NEEDED(weights_md, op_pd, op) \
+  weights_md != op_pd->weights_desc()
+#define MEMORY_CONSTRUCTOR(mem_desc, engine, data) \
+  memory(mem_desc, engine, data)
+#define MEMORY_CONSTRUCTOR_PD(mem_desc, engine, data) \
+  MEMORY_CONSTRUCTOR(mem_desc, engine, data)
+#define MEMORY_CONSTRUCTOR_USING_MEM_PD(dims, type, fm, engine, data) \
+  memory(GET_MEMORY_DESC_CONSTRUCTOR(dims, type, fm), engine, data)
+#define MEMORY_CONSTRUCTOR_USING_MD(md, engine, data) memory(md, engine, data)
+#define MEMORY_CONSTRUCTOR_WITH_MEM_PD(mem_ptr, cpu_engine, data) \
+  memory(GET_MEMORY_DESC_FROM_MEM_PTR(mem_ptr), cpu_engine, data)
+#define MEMORY_CONSTRUCTOR_WITHOUT_DATA(mem_desc, engine) \
+  memory(mem_desc, engine)
+#define MEMORY_DATA_TYPE_UNDEF memory::data_type::undef
+#define MEMORY_DESC memory::desc
+#define MEMORY_FORMAT mkldnn::memory::format_tag
+#define MEMORY_FORMAT_DESC format_desc
+#define MEMORY_FORMAT_UNDEF mkldnn::memory::format_tag::undef
+#define MEMORY_PD_CONSTRUCTOR(dims, type, fm, engine) \
+  memory::desc({dims}, MklDnnType<type>(), fm)
+#define MEMORY_PD_WITHOUT_DATA(md, engine) md, engine
+#define MEMORY_PRIMITIVE_DESC memory::desc
+#define MKL_FMT_TAG mkl_fmt_tag
+#define MKL_TENSOR_FORMAT MklTensorFormat
+#define MKL_TENSOR_FORMAT_BLOCKED MklTensorFormat::FORMAT_BLOCKED
+#define MKL_TENSOR_FORMAT_IN_C MKL_TENSOR_FORMAT
+#define MKL_TENSOR_FORMAT_INVALID MklTensorFormat::FORMAT_INVALID
+#define MKL_TENSOR_FORMAT_NC MklTensorFormat::FORMAT_NC
+#define MKL_TENSOR_FORMAT_NCHW MklTensorFormat::FORMAT_NCHW
+#define MKL_TENSOR_FORMAT_NCDHW MklTensorFormat::FORMAT_NCDHW
+#define MKL_TENSOR_FORMAT_NDHWC MklTensorFormat::FORMAT_NDHWC
+#define MKL_TENSOR_FORMAT_NHWC MklTensorFormat::FORMAT_NHWC
+#define MKL_TENSOR_FORMAT_TNC MklTensorFormat::FORMAT_TNC
+#define MKL_TENSOR_FORMAT_X MklTensorFormat::FORMAT_X
+#define MKL_TENSOR_FORMAT_UNDEF MKL_TENSOR_FORMAT_BLOCKED
+#define NET_ARGS_PTR &net_args
+#define OUTPUT_TF_MD output_tf_md
+#define PRIMITIVE_DESC_BIAS bias_desc()
+#define PRIMITIVE_DESC_DIFF_DST diff_dst_desc()
+#define PRIMITIVE_DESC_DIFF_SRC diff_src_desc()
+#define PRIMITIVE_DESC_DIFF_WEIGHTS diff_weights_desc()
+#define PRIMITIVE_DESC_DST dst_desc()
+#define PRIMITIVE_DESC_SRC src_desc()
+#define PRIMITIVE_DESC_WORKSPACE workspace_desc()
+#define PRIMITIVE_DESC_WEIGHTS weights_desc()
+#define REORDER_PD_CONSTRUCTOR(src_md, dst_md, engine) \
+  ReorderPd(engine, src_md, engine, dst_md)
+#define REORDER_PD_CONSTRUCTOR_WITH_ATTR(src_md, dst_md, engine, prim_attr) \
+  ReorderPd(engine, src_md, engine, dst_md, prim_attr)
+#define SKIP_INPUT_REORDER(input_mkl_shape, input_md) \
+  input_mkl_shape.GetTfDataFormat() == MKL_TENSOR_FORMAT_BLOCKED
+#define SUMMAND_MD summand_md
+#define TENSOR_FORMAT MKL_TENSOR_FORMAT
+#define TENSOR_FORMAT_NHWC MKL_TENSOR_FORMAT_NHWC
+
+#else
+
+#define ADD_MD add_pd
+#define ALGORITHM mkldnn
+#define ALGORITHM_UNDEF ALGORITHM::algorithm_undef
+#define CPU_STREAM(engine) stream(stream::kind::eager)
+#define DATA_WITH_ENGINE(data, engine) data
+#define DST_MD dst_pd
+#define ENGINE_CPU engine::cpu
+#define GET_CHECK_REORDER_MEM_ARGS(md, tensor, net_ptr, net_args, engine) \
+  memory::primitive_desc(md, engine), tensor, &net_ptr
+#define GET_CHECK_REORDER_TO_OP_MEM_ARGS(pd, tensor, net_ptr, net_args, \
+                                         engine)                        \
+  pd, tensor, &net_ptr
+#define GET_DESC get_primitive_desc()
+#define GET_FORMAT_FROM_SHAPE(src_mkl_shape) \
+  static_cast<memory::format>(src_mkl_shape.GetMklLayout().data.format)
+#define GET_MEMORY_DESC_CONSTRUCTOR(dims, type, fm) \
+  { {dims}, MklDnnType<type>(), fm }
+#define GET_SRC_DESC_FROM_OP_PD(op_pd) op_pd.get()->src_primitive_desc()
+#define GET_DIFF_DST_DESC_FROM_OP_PD(op_pd) \
+  op_pd.get()->diff_dst_primitive_desc()
+#define GET_WORKSPACE_DESC_FROM_OP_PD(op_pd) \
+  op_pd.get()->workspace_primitive_desc()
+#define GET_TENSOR_FORMAT(fmt) fmt
+#define GET_TF_DATA_FORMAT(shape, mem_desc) mem_desc.data.format
+#define GET_WEIGHTS_DESC_FROM_OP_PD(op_pd) op_pd.get()->weights_primitive_desc()
+#define GET_WEIGHTS_FORMAT_FROM_OP_PD(op_pd, op) op->GetFilterMemoryFormat()
+#define IS_DIFF_DST_REORDER_NEEDED(diff_dst_md, op_pd, op) \
+  diff_dst_md.data.format != op->GetDiffDstMemoryFormat()
+#define IS_DIFF_FILTER_REORDER_NEEDED(diff_filter_md, fmt, op_pd, op) \
+  fmt != op->GetDiffFilterMemoryFormat()
+#define IS_FILTER_REORDER_NEEDED(filter_md, op_pd, op) \
+  filter_md.data.format != op->GetFilterMemoryFormat()
+#define IS_SRC_REORDER_NEEDED(src_md, op_pd, op) \
+  src_md.data.format != op->GetSrcMemoryFormat()
+#define IS_WEIGHTS_REORDER_NEEDED(weights_md, op_pd, op) \
+  weights_md.data.format != op->GetWeightsMemoryFormat()
+#define GET_MEMORY_DESC_FROM_MEM_PTR(mem_ptr) \
+  mem_ptr->get_primitive_desc().desc()
+#define GET_MEMORY_PRIMITIVE_DESC_FROM_MEM_PTR(mem_ptr) \
+  mem_ptr->get_primitive_desc()
+#define MEMORY_CONSTRUCTOR(mem_pd, engine, data) memory(mem_pd, data)
+#define MEMORY_CONSTRUCTOR_PD(mem_pd, engine, data) memory(mem_pd, data)
+#define MEMORY_CONSTRUCTOR_WITH_MEM_PD(mem_ptr, cpu_engine, data) \
+  memory({GET_MEMORY_DESC_FROM_MEM_PTR(mem_ptr), cpu_engine}, data)
+#define MEMORY_CONSTRUCTOR_USING_MD(md, engine, data) memory({md, engine}, data)
+#define MEMORY_CONSTRUCTOR_USING_MEM_PD(dims, type, fm, engine, data) \
+  memory({GET_MEMORY_DESC_CONSTRUCTOR(dims, type, fm), engine}, data)
+#define MEMORY_CONSTRUCTOR_WITHOUT_DATA(mem_pd, engine) memory(mem_pd)
+#define MEMORY_DATA_TYPE_UNDEF memory::data_type::data_undef
+#define MEMORY_DESC memory::format
+#define MEMORY_FORMAT mkldnn::memory::format
+#define MEMORY_FORMAT_DESC layout_desc
+#define MEMORY_FORMAT_UNDEF mkldnn::memory::format::format_undef
+#define MEMORY_PD_CONSTRUCTOR(dims, type, fm, engine) \
+  memory::primitive_desc(GET_MEMORY_DESC_CONSTRUCTOR(dims, type, fm), engine)
+#define MEMORY_PD_WITHOUT_DATA(pd, engine) pd
+#define MEMORY_PRIMITIVE_DESC memory::primitive_desc
+#define MKL_FMT_TAG tf_fmt
+#define MKL_TENSOR_FORMAT memory::format
+#define MKL_TENSOR_FORMAT_BLOCKED memory::format::blocked
+#define MKL_TENSOR_FORMAT_IN_C mkldnn_memory_format_t
+#define MKL_TENSOR_FORMAT_INVALID memory::format::format_undef
+#define MKL_TENSOR_FORMAT_NC memory::format::nc
+#define MKL_TENSOR_FORMAT_NCHW memory::format::nchw
+#define MKL_TENSOR_FORMAT_NCDHW memory::format::ncdhw
+#define MKL_TENSOR_FORMAT_NDHWC memory::format::ndhwc
+#define MKL_TENSOR_FORMAT_NHWC memory::format::nhwc
+#define MKL_TENSOR_FORMAT_TNC memory::format::tnc
+#define MKL_TENSOR_FORMAT_X memory::format::x
+#define MKL_TENSOR_FORMAT_UNDEF MKL_TENSOR_FORMAT_INVALID
+#define NET_ARGS_PTR nullptr
+#define OUTPUT_TF_MD output_tf_pd
+#define PRIMITIVE_DESC_BIAS bias_primitive_desc()
+#define PRIMITIVE_DESC_WEIGHTS weights_primitive_desc()
+#define PRIMITIVE_DESC_DIFF_DST diff_dst_primitive_desc()
+#define PRIMITIVE_DESC_DIFF_SRC diff_src_primitive_desc()
+#define PRIMITIVE_DESC_DIFF_WEIGHTS diff_weights_primitive_desc()
+#define PRIMITIVE_DESC_DST dst_primitive_desc()
+#define PRIMITIVE_DESC_SRC src_primitive_desc()
+#define PRIMITIVE_DESC_WORKSPACE workspace_primitive_desc()
+#define REORDER_PD_CONSTRUCTOR(src_pd, dst_pd, engine) ReorderPd(src_pd, dst_pd)
+#define REORDER_PD_CONSTRUCTOR_WITH_ATTR(src_pd, dst_pd, engine, prim_attr) \
+  ReorderPd(src_pd, dst_pd, prim_attr)
+#define SKIP_INPUT_REORDER(input_mkl_shape, input_md)           \
+  (input_mkl_shape.GetTfDataFormat() == input_md.data.format && \
+   input_mkl_shape.GetTfDataFormat() != MKL_TENSOR_FORMAT_BLOCKED)
+#define SUMMAND_MD summand_pd
+#define TENSOR_FORMAT TensorFormat
+#define TENSOR_FORMAT_NHWC FORMAT_NHWC
+#endif  // ENABLE_MKLDNN_V1
+
+}  // namespace tensorflow
+
+#endif  // INTEL_MKL
+#endif  // TENSORFLOW_CORE_UTIL_MKL_TYPES_H_


### PR DESCRIPTION
This PR is intended to refactor the current implementation of forward conv ops with MKL-DNN
v1.0 integration:
(1) Abstract macro definitions from individual source files to a common header file (mkl_types)
for better code reuse (in coming PR's)
(2) Refactor based on Google coding style. For instance, replace CHECK_NOTNULL to DCHECK.

Background:
We (Intel) will submit a sequence of PR's with MKL-DNN v1.0 integration (around 24 MKL ops).
And this PR will be fundamental for the near future PR's.

Reference of previously merged PR:
#30549