### PR TITLE
[XLA] Small update on the vectorisation of elementwise operations

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -1835,21 +1835,40 @@ namespace {
 
 // Returns true if the fusion contains any instruction that is likely
 // translated to complex LLVM IR, such as loops, and prevent vectorization.
-bool MayPreventVectorization(const HloInstruction& fusion_hlo) {
-  CHECK_EQ(fusion_hlo.opcode(), HloOpcode::kFusion);
-  return absl::c_any_of(
-      fusion_hlo.fused_instructions_computation()->instructions(),
-      [&](const HloInstruction* instr) {
-        switch (instr->opcode()) {
-          case HloOpcode::kReduce:
-          case HloOpcode::kReduceWindow:
-          case HloOpcode::kSort:
-          case HloOpcode::kDot:
-            return true;
-          default:
-            return false;
-        }
-      });
+bool MayPreventVectorization(const HloInstruction& hlo) {
+  if (hlo.opcode() == HloOpcode::kFusion) {
+    return absl::c_any_of(hlo.fused_instructions_computation()->instructions(),
+                          [&](const HloInstruction* instr) {
+                            switch (instr->opcode()) {
+                              case HloOpcode::kReduce:
+                              case HloOpcode::kReduceWindow:
+                              case HloOpcode::kSort:
+                              case HloOpcode::kDot:
+                              case HloOpcode::kSin:
+                              case HloOpcode::kCos:
+                              case HloOpcode::kPower:
+                              case HloOpcode::kAtan2:
+                                return true;
+                              default:
+                                return false;
+                            }
+                          });
+  } else if (hlo.IsElementwise()) {
+    // Unfused elementwise operations are usually memory bound, unroll them.
+    switch (hlo.opcode()) {
+        // The following elementwise operations implementation contain branches.
+        // LLVM vectorizer doesn't work in that case.
+        // The unrolled code is faster when it isn't vectorized.
+      case HloOpcode::kSin:
+      case HloOpcode::kCos:
+      case HloOpcode::kPower:
+      case HloOpcode::kAtan2:
+        return true;
+      default:
+        return false;
+    }
+  }
+  return true;
 }
 
 }  // namespace
@@ -1858,9 +1877,7 @@ Status IrEmitterUnnested::EmitTargetElementLoop(
     const HloInstruction& hlo,
     const llvm_ir::ElementGenerator& element_generator) {
   int unroll_factor = 1;
-  // Unfused elementwise operations are usually memory bound, unroll them.
-  if (hlo.IsElementwise() ||
-      (hlo.opcode() == HloOpcode::kFusion && !MayPreventVectorization(hlo))) {
+  if (!MayPreventVectorization(hlo)) {
     unroll_factor = ComputeMaxUnrollFactor(&hlo);
   }
 

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -1838,7 +1838,7 @@ namespace {
 bool MayPreventVectorization(const HloInstruction& hlo) {
   if (hlo.opcode() == HloOpcode::kFusion) {
     return absl::c_any_of(hlo.fused_instructions_computation()->instructions(),
-                          [&](const HloInstruction* instr) {
+                          [](const HloInstruction* instr) {
                             switch (instr->opcode()) {
                               case HloOpcode::kReduce:
                               case HloOpcode::kReduceWindow:
@@ -1856,7 +1856,7 @@ bool MayPreventVectorization(const HloInstruction& hlo) {
   } else if (hlo.IsElementwise()) {
     // Unfused elementwise operations are usually memory bound, unroll them.
     switch (hlo.opcode()) {
-        // The following elementwise operations implementation contain branches.
+        // The following elementwise operation implementations contain branches.
         // LLVM vectorizer doesn't work in that case.
         // The unrolled code is faster when it isn't vectorized.
       case HloOpcode::kSin:

--- a/tensorflow/compiler/xla/service/gpu/tests/gpu_unrolling_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/gpu_unrolling_test.cc
@@ -138,6 +138,108 @@ TEST_F(GpuUnrollingTest, UnrollUnfusedAdd) {
                      /*match_optimized_ir=*/true);
 }
 
+TEST_F(GpuUnrollingTest, DisabledUnrollUnfusedSine) {
+  HloModuleConfig config;
+  auto debug_options = HloTestBase::GetDebugOptionsForTest();
+  debug_options.set_xla_gpu_max_kernel_unroll_factor(4);
+  config.set_debug_options(debug_options);
+
+  const char *const kUnfusedAddModule = R"(
+    HloModule test_module
+
+    ENTRY SineFunc {
+      p0 = f32[160000]{0} parameter(0)
+      ROOT s = f32[160000]{0} sine(p0)
+    })";
+  auto hlo_module =
+      ParseAndReturnVerifiedModule(kUnfusedAddModule, config).ValueOrDie();
+
+  CompileAndVerifyIr(std::move(hlo_module),
+                     R"(
+; CHECK: load float
+; CHECK-NOT: load float
+}
+      )",
+                     /*match_optimized_ir=*/true);
+}
+
+TEST_F(GpuUnrollingTest, DisabledUnrollUnfusedCosine) {
+  HloModuleConfig config;
+  auto debug_options = HloTestBase::GetDebugOptionsForTest();
+  debug_options.set_xla_gpu_max_kernel_unroll_factor(4);
+  config.set_debug_options(debug_options);
+
+  const char *const kUnfusedAddModule = R"(
+    HloModule test_module
+
+    ENTRY SineFunc {
+      p0 = f32[160000]{0} parameter(0)
+      ROOT s = f32[160000]{0} cosine(p0)
+    })";
+  auto hlo_module =
+      ParseAndReturnVerifiedModule(kUnfusedAddModule, config).ValueOrDie();
+
+  CompileAndVerifyIr(std::move(hlo_module),
+                     R"(
+; CHECK: load float
+; CHECK-NOT: load float
+}
+      )",
+                     /*match_optimized_ir=*/true);
+}
+
+
+TEST_F(GpuUnrollingTest, DisabledUnrollUnfusedPower) {
+  HloModuleConfig config;
+  auto debug_options = HloTestBase::GetDebugOptionsForTest();
+  debug_options.set_xla_gpu_max_kernel_unroll_factor(4);
+  config.set_debug_options(debug_options);
+
+  const char *const kUnfusedAddModule = R"(
+    HloModule test_module
+
+    ENTRY SineFunc {
+      p0 = f32[160000]{0} parameter(0)
+      ROOT s = f32[160000]{0} power(p0, p0)
+    })";
+  auto hlo_module =
+      ParseAndReturnVerifiedModule(kUnfusedAddModule, config).ValueOrDie();
+
+  CompileAndVerifyIr(std::move(hlo_module),
+                     R"(
+; CHECK: load float
+; CHECK-NOT: load float
+}
+      )",
+                     /*match_optimized_ir=*/true);
+}
+
+
+TEST_F(GpuUnrollingTest, DisabledUnrollUnfusedAtan2) {
+  HloModuleConfig config;
+  auto debug_options = HloTestBase::GetDebugOptionsForTest();
+  debug_options.set_xla_gpu_max_kernel_unroll_factor(4);
+  config.set_debug_options(debug_options);
+
+  const char *const kUnfusedAddModule = R"(
+    HloModule test_module
+
+    ENTRY SineFunc {
+      p0 = f32[160000]{0} parameter(0)
+      ROOT s = f32[160000]{0} atan2(p0, p0)
+    })";
+  auto hlo_module =
+      ParseAndReturnVerifiedModule(kUnfusedAddModule, config).ValueOrDie();
+
+  CompileAndVerifyIr(std::move(hlo_module),
+                     R"(
+; CHECK: load float
+; CHECK-NOT: load float
+}
+      )",
+                     /*match_optimized_ir=*/true);
+}
+
 TEST_F(GpuUnrollingTest, UnrollMultiOutputFusion) {
   HloModuleConfig config;
   auto debug_options = HloTestBase::GetDebugOptionsForTest();

--- a/tensorflow/compiler/xla/service/hlo_cost_analysis.cc
+++ b/tensorflow/compiler/xla/service/hlo_cost_analysis.cc
@@ -102,7 +102,10 @@ Status HloCostAnalysis::HandleElementwiseOp(
   if (opcode == HloOpcode::kExp || opcode == HloOpcode::kLog ||
       opcode == HloOpcode::kPower || opcode == HloOpcode::kSqrt ||
       opcode == HloOpcode::kRsqrt || opcode == HloOpcode::kTanh ||
-      opcode == HloOpcode::kSin || opcode == HloOpcode::kCos) {
+      opcode == HloOpcode::kSin || opcode == HloOpcode::kCos ||
+      opcode == HloOpcode::kExpm1 ||  opcode == HloOpcode::kLog1p ||
+      opcode == HloOpcode::kAtan2) {
+
     current_properties_[kTranscendentalsKey] = computation_count;
   } else {
     // Note: transcendental operations are considered a separate category from


### PR DESCRIPTION
- XLA was unrolling the sin, cos, power and atan2 operations, but LLVM doesn't vectorize them as they have branches inside the elementwise computation.
As the unrolling hurt performance, block the unrolling for those operations.
By default on a Titan V, when doing the Sin of 16m elements, it takes 274us. Now it takes 224us.
- Also fix XLA profiler to display correctly some operation as TFLOPS isntead of FLOPS.