### PR TITLE
Fix broken numa build

### DIFF
--- a/tensorflow/core/platform/default/BUILD
+++ b/tensorflow/core/platform/default/BUILD
@@ -287,7 +287,7 @@ cc_library(
         "@snappy",
     ] + select({
         # TF Additional NUMA dependencies
-        "//tensorflow:with_numa_support": ["//third_party/hwloc"],
+        "//tensorflow:with_numa_support": ["@hwloc"],
         "//conditions:default": [],
     }),
 )

--- a/tensorflow/tools/lib_package/BUILD
+++ b/tensorflow/tools/lib_package/BUILD
@@ -190,7 +190,7 @@ genrule(
         "//conditions:default": [],
     }) + select({
         "//tensorflow:with_numa_support": [
-            "//third_party/hwloc:COPYING",
+            "@hwloc//:COPYING",
         ],
         "//conditions:default": [],
     }) + if_cuda([
@@ -270,7 +270,7 @@ genrule(
         "//conditions:default": [],
     }) + select({
         "//tensorflow:with_numa_support": [
-            "//third_party/hwloc:COPYING",
+            "@hwloc//:COPYING",
         ],
         "//conditions:default": [],
     }) + if_cuda([

--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -192,7 +192,7 @@ filegroup(
         "//conditions:default": [],
     }) + select({
         "//tensorflow:with_numa_support": [
-            "//third_party/hwloc:COPYING",
+            "@hwloc//:COPYING",
         ],
         "//conditions:default": [],
     }) + if_cuda([


### PR DESCRIPTION
After 37f0ac13bdaf6f5c0015885ab70d49b4094feca5 my build was broken with the following error:

```
[0 / 21] [Prepa] BazelWorkspaceStatusAction stable-status.txt
ERROR: missing input file '//third_party/hwloc:include/private/autogen/config.h.in'
ERROR: /tensorflow_src/third_party/hwloc/BUILD.bazel:212:1: //third_party/hwloc:include_private_hwloc_autogen__config_h: missing input file '//third_party/hwloc:include/private/autogen/config.h.in'
ERROR: /tensorflow_src/tensorflow/cc/BUILD:507:1: Creating runfiles tree bazel-out/host/bin/tensorflow/cc/ops/parsing_ops_gen_cc.runfiles [for host] failed: build-runfiles failed: error executing command 
  (cd /home/byronyi/.cache/bazel/_bazel_byronyi/8c9ffbe253caf5ffa98d6d412a0cbaa1/execroot/org_tensorflow && \
  exec env - \
    PATH=/usr/local/bin:/usr/bin:/bin \
  /home/byronyi/.cache/bazel/_bazel_byronyi/install/84defa6eb1e9416bf92d6f89ab2d4f31/build-runfiles bazel-out/host/bin/tensorflow/cc/ops/parsing_ops_gen_cc.runfiles_manifest bazel-out/host/bin/tensorflow/cc/ops/parsing_ops_gen_cc.runfiles): Process terminated by signal 15: Process terminated by signal 15
ERROR: /tensorflow_src/third_party/hwloc/BUILD.bazel:212:1 1 input file(s) do not exist
INFO: Elapsed time: 39.257s, Critical Path: 1.42s
INFO: 4 processes: 4 remote cache hit.
FAILED: Build did NOT complete successfully
FAILED: Build did NOT complete successfully
```

This PR fixes the error above.