### PR TITLE
undef TranslateName to avoid name collision on Windows

### DIFF
--- a/tensorflow/core/platform/file_system.h
+++ b/tensorflow/core/platform/file_system.h
@@ -34,6 +34,7 @@ limitations under the License.
 #ifdef PLATFORM_WINDOWS
 #undef DeleteFile
 #undef CopyFile
+#undef TranslateName
 #endif
 
 namespace tensorflow {


### PR DESCRIPTION
On WIN32, many APIs are defined with suffix `A` or `W`
to accomodate ASCII (CHAR) or wide char (WCHAR), e.g.
`CopyFile` could be `CopyFileA` or `CopyFileW` depending
on Visual Studio configuration.

While working on porting our Azure file system from Linux
to Windows, we noticed the following errors:
```
azfs_ops.lo.lib(azfs_ops.obj) : error LNK2001: unresolved external symbol "public: virtual class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > __cdecl tensorflow::FileSystem::TranslateNameA(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &)const " (?TranslateNameA@FileSystem@tensorflow@@UEBA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@AEBV34@@Z)
```

The issue was that TranslateName is also a WIN32 API that was defined
as TranslateNameA (or TranslateNameW) on Visual Studio when certain header
file are configured.

This PR undef TranslateName before `class FileSystem`, similiar to already undef'ed
`CopyFile` and `DeleteFile` (see source code), to avoid name collision.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>