### PR TITLE
Fix micro_speech header path in OSX makefile

### DIFF
--- a/tensorflow/lite/micro/examples/micro_speech/osx/Makefile.inc
+++ b/tensorflow/lite/micro/examples/micro_speech/osx/Makefile.inc
@@ -5,5 +5,5 @@ ifeq ($(TARGET), osx)
     -framework AudioToolbox
 
   MICROLITE_LIBS += $(LINKER_FLAGS)
-  MICRO_SPEECH_HDRS += tensorflow/lite/experimental/micro/examples/micro_speech/simple_features/simple_model_settings.h
+  MICRO_SPEECH_HDRS += tensorflow/lite/micro/examples/micro_speech/simple_features/simple_model_settings.h
 endif


### PR DESCRIPTION
I tried to run the following command:
```
make -f tensorflow/lite/micro/tools/make/Makefile generate_projects
tensorflow/lite/micro/tools/make/download_and_extract.sh "https://github.com/google/gemmlowp/archive/719139ce755a0f31cbf1c37f7f98adcc7fc9f425.zip" "7e8191b24853d75de2af87622ad293ba" tensorflow/lite/micro/tools/make/downloads/gemmlowp
downloading https://github.com/google/gemmlowp/archive/719139ce755a0f31cbf1c37f7f98adcc7fc9f425.zip
tensorflow/lite/micro/tools/make/download_and_extract.sh "https://storage.googleapis.com/mirror.tensorflow.org/github.com/google/flatbuffers/archive/v1.11.0.tar.gz" "02c64880acb89dbd57eebacfd67200d8" tensorflow/lite/micro/tools/make/downloads/flatbuffers
downloading https://storage.googleapis.com/mirror.tensorflow.org/github.com/google/flatbuffers/archive/v1.11.0.tar.gz
tensorflow/lite/micro/tools/make/download_and_extract.sh "https://storage.googleapis.com/download.tensorflow.org/data/tf_lite_micro_person_data_grayscale_2019_11_21.zip" "fe2934bd0788f1dcc7af3f0a954542ab" tensorflow/lite/micro/tools/make/downloads/person_model_grayscale
downloading https://storage.googleapis.com/download.tensorflow.org/data/tf_lite_micro_person_data_grayscale_2019_11_21.zip
tensorflow/lite/micro/tools/make/download_and_extract.sh "https://storage.googleapis.com/download.tensorflow.org/data/tf_lite_micro_person_data_int8_grayscale_2020_01_13.zip" "8a7d2c70325f53136faea6dde517b8cc" tensorflow/lite/micro/tools/make/downloads/person_model_int8
downloading https://storage.googleapis.com/download.tensorflow.org/data/tf_lite_micro_person_data_int8_grayscale_2020_01_13.zip
tensorflow/lite/micro/tools/make/download_and_extract.sh "https://github.com/mborgerding/kissfft/archive/v130.zip" "438ba1fef5783cc5f5f201395cc477ca" tensorflow/lite/micro/tools/make/downloads/kissfft patch_kissfft
downloading https://github.com/mborgerding/kissfft/archive/v130.zip
Finished patching kissfft
cp -r tensorflow/lite/micro/tools/make/gen/osx_x86_64/prj/person_detection/arduino tensorflow/lite/micro/tools/make/gen/osx_x86_64/prj/person_detection/tensorflow_lite
python tensorflow/lite/micro/tools/make/fix_arduino_subfolders.py tensorflow/lite/micro/tools/make/gen/osx_x86_64/prj/person_detection/tensorflow_lite
cp -r tensorflow/lite/micro/tools/make/gen/osx_x86_64/prj/hello_world/arduino tensorflow/lite/micro/tools/make/gen/osx_x86_64/prj/hello_world/tensorflow_lite
python tensorflow/lite/micro/tools/make/fix_arduino_subfolders.py tensorflow/lite/micro/tools/make/gen/osx_x86_64/prj/hello_world/tensorflow_lite
cp -r tensorflow/lite/micro/tools/make/gen/osx_x86_64/prj/magic_wand/arduino tensorflow/lite/micro/tools/make/gen/osx_x86_64/prj/magic_wand/tensorflow_lite
python tensorflow/lite/micro/tools/make/fix_arduino_subfolders.py tensorflow/lite/micro/tools/make/gen/osx_x86_64/prj/magic_wand/tensorflow_lite
cp -r tensorflow/lite/micro/tools/make/gen/osx_x86_64/prj/person_detection_int8/arduino tensorflow/lite/micro/tools/make/gen/osx_x86_64/prj/person_detection_int8/tensorflow_lite
python tensorflow/lite/micro/tools/make/fix_arduino_subfolders.py tensorflow/lite/micro/tools/make/gen/osx_x86_64/prj/person_detection_int8/tensorflow_lite
make: *** No rule to make target 'tensorflow/lite/micro/tools/make/gen/osx_x86_64/prj/micro_speech/make/tensorflow/lite/experimental/micro/examples/micro_speech/simple_features/simple_model_settings.h', needed by 'generate_micro_speech_make_project'.  Stop.
```
But it failed, I figured after moving the `micro` out of the experimental directory this Makefile was not properly edited.
This PR will solve this particular issue on MacOS and projects are generated properly.