### PR TITLE
core: mark function `inline` (NFC)

### DIFF
--- a/tensorflow/core/platform/windows/subprocess.h
+++ b/tensorflow/core/platform/windows/subprocess.h
@@ -26,7 +26,8 @@ namespace tensorflow {
 // SubProcess is not yet implemented for Windows.
 class SubProcess {};
 
-std::unique_ptr<SubProcess> CreateSubProcess(const std::vector<string>& argv) {
+inline std::unique_ptr<SubProcess>
+CreateSubProcess(const std::vector<string>& argv) {
   LOG(FATAL) << "CreateSubProcess NOT IMPLEMENTED for Windows yet ! ";
   return nullptr;
 }


### PR DESCRIPTION
Mark this stub as `inline` to ensure that the body is emitted inline and
no symbol implementation is provided.  This is required as otherwise,
the function is emitted everywhere as a result of being defined in the
header, but is not given COMDAT resulting in a multiply defined symbol.

This allows linking tensorflow.dll on Windows with VS2019.