### PR TITLE
Fix tf.cast issue when python native data type is combined with dtype=tf.float64

### DIFF
--- a/tensorflow/python/kernel_tests/cast_op_test.py
+++ b/tensorflow/python/kernel_tests/cast_op_test.py
@@ -213,6 +213,13 @@ class CastOpTest(test.TestCase):
           err = gradient_checker.compute_gradient_error(x, [], y, [])
           self.assertLess(err, 1e-3)
 
+  def testPythonDataTypes(self):
+    with self.cached_session():
+      # GitHub issue 35938, a of 0.2 is for python native type.
+      a = 0.2
+      b = math_ops.cast(a, dtypes.float64)
+      self.assertAllEqual(a, self.evaluate(b))
+
 
 class SparseTensorCastTest(test.TestCase):
 

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -745,7 +745,7 @@ def cast(x, dtype, name=None):
       # ops.convert_to_tensor(x, dtype=dtype, ...)  here, but that
       # allows some conversions that cast() can't do, e.g. casting numbers to
       # strings.
-      x = ops.convert_to_tensor(x, name="x")
+      x = ops.convert_to_tensor(x, dtype_hint=base_type, name="x")
       if x.dtype.base_dtype != base_type:
         x = gen_math_ops.cast(x, base_type, name=name)
     if x.dtype.is_complex and base_type.is_floating:


### PR DESCRIPTION
This fix tries to address the issue raised in 35938 where the following issue exist:
```
>>> tf.cast(0.2, tf.float64)
<tf.Tensor: id=37, shape=(), dtype=float64, numpy=0.20000000298023224>
```

The issue was that, in tf.cast, 0.2 was first converted to a float32 dtype tensor,
then cast to float64 tensor.

This fix adds dtype_hint=dtype to convert_to_tensor so that native dtype is preserved.

This fix fixes #35938.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>