### PR TITLE
Add complex number support for tf.extract_image_patches

### DIFF
--- a/tensorflow/core/kernels/extract_image_patches_op.cc
+++ b/tensorflow/core/kernels/extract_image_patches_op.cc
@@ -126,7 +126,7 @@ class ExtractImagePatchesOp : public UnaryOp<T> {
       Name("ExtractImagePatches").Device(DEVICE_CPU).TypeConstraint<T>("T"), \
       ExtractImagePatchesOp<CPUDevice, T>);
 
-TF_CALL_REAL_NUMBER_TYPES(REGISTER);
+TF_CALL_NUMBER_TYPES(REGISTER);
 
 #undef REGISTER
 
@@ -145,7 +145,7 @@ namespace functor {
       typename TTypes<T, 4>::Tensor output);                            \
   extern template struct ExtractImagePatchesForward<GPUDevice, T>;
 
-TF_CALL_GPU_NUMBER_TYPES(DECLARE_GPU_SPEC);
+TF_CALL_GPU_ALL_TYPES(DECLARE_GPU_SPEC);
 
 #undef DECLARE_GPU_SPEC
 
@@ -157,7 +157,7 @@ TF_CALL_GPU_NUMBER_TYPES(DECLARE_GPU_SPEC);
       Name("ExtractImagePatches").Device(DEVICE_GPU).TypeConstraint<T>("T"), \
       ExtractImagePatchesOp<GPUDevice, T>);
 
-TF_CALL_GPU_NUMBER_TYPES(REGISTER);
+TF_CALL_GPU_ALL_TYPES(REGISTER);
 
 #undef REGISTER
 

--- a/tensorflow/core/kernels/extract_image_patches_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/extract_image_patches_op_gpu.cu.cc
@@ -29,7 +29,7 @@ namespace functor {
 
 #define REGISTER(T) template struct ExtractImagePatchesForward<GPUDevice, T>;
 
-TF_CALL_GPU_NUMBER_TYPES(REGISTER);
+TF_CALL_GPU_ALL_TYPES(REGISTER);
 
 #undef REGISTER
 

--- a/tensorflow/core/ops/array_ops.cc
+++ b/tensorflow/core/ops/array_ops.cc
@@ -2525,7 +2525,9 @@ REGISTER_OP("ExtractImagePatches")
     .Attr("ksizes: list(int) >= 4")
     .Attr("strides: list(int) >= 4")
     .Attr("rates: list(int) >= 4")
-    .Attr("T: realnumbertype")
+    .Attr(
+        "T: {bfloat16, half, float, double, int8, int16, int32, int64, "
+        "uint8, uint16, uint32, uint64, complex64, complex128, bool}")
     .Attr(GetPaddingAttrString())
     .SetShapeFn([](InferenceContext* c) {
       ShapeHandle input_shape;

--- a/tensorflow/python/kernel_tests/extract_image_patches_op_test.py
+++ b/tensorflow/python/kernel_tests/extract_image_patches_op_test.py
@@ -128,8 +128,12 @@ class ExtractImagePatches(test.TestCase):
   def testComplexDataTypes(self):
     """Test for complex data types"""
     for dtype in [np.complex64, np.complex128]:
-      image = np.reshape(range(120), [2, 3, 4, 5]).astype(dtype)
-      patches = np.reshape(range(120), [2, 3, 4, 5]).astype(dtype)
+      image = (
+          np.reshape(range(120), [2, 3, 4, 5]).astype(dtype) +
+          np.reshape(range(120, 240), [2, 3, 4, 5]).astype(dtype) * 1j)
+      patches = (
+          np.reshape(range(120), [2, 3, 4, 5]).astype(dtype) +
+          np.reshape(range(120, 240), [2, 3, 4, 5]).astype(dtype) * 1j)
       for padding in ["VALID", "SAME"]:
         self._VerifyValues(
             image,

--- a/tensorflow/python/kernel_tests/extract_image_patches_op_test.py
+++ b/tensorflow/python/kernel_tests/extract_image_patches_op_test.py
@@ -125,5 +125,20 @@ class ExtractImagePatches(test.TestCase):
         padding="VALID",
         patches=patches)
 
+  def testComplexDataTypes(self):
+    """Test for complex data types"""
+    for dtype in [np.complex64, np.complex128]:
+      image = np.reshape(range(120), [2, 3, 4, 5]).astype(dtype)
+      patches = np.reshape(range(120), [2, 3, 4, 5]).astype(dtype)
+      for padding in ["VALID", "SAME"]:
+        self._VerifyValues(
+            image,
+            ksizes=[1, 1],
+            strides=[1, 1],
+            rates=[1, 1],
+            padding=padding,
+            patches=patches)
+
+
 if __name__ == "__main__":
   test.main()


### PR DESCRIPTION

This PR tries to address the issue raised in #35955 where
there was no complex number support for tf.extract_image_patches.
The op `tf.extract_image_patches` itself could be used in many
ways than just image so it makes sense to add complex support.

This fix fixes #35955.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>