### PR TITLE
loose shape check in PointwiseToLinalgConverter

### DIFF
--- a/tensorflow/compiler/mlir/xla/tests/lhlo-legalize-to-linalg.mlir
+++ b/tensorflow/compiler/mlir/xla/tests/lhlo-legalize-to-linalg.mlir
@@ -15,6 +15,20 @@ func @element_wise(%lhs: memref<2x2xf32>, %rhs: memref<2x2xf32>,
 
 // -----
 
+// CHECK-LABEL: func @element_wise_with_dynamic_shape
+func @element_wise_with_dynamic_shape(%lhs: memref<?x?xf32>, %rhs: memref<?x?xf32>,
+          %result: memref<?x?xf32>) {
+  "xla_lhlo.add"(%lhs, %rhs, %result)
+      : (memref<?x?xf32>, memref<?x?xf32>, memref<?x?xf32>) -> ()
+  return
+}
+// CHECK: linalg.generic
+// CHECK-NEXT: ^bb0(%[[LHS_IN:.*]]: f32, %[[RHS_IN:.*]]: f32, %[[RESULT_OUT:.*]]: f32):
+// CHECK-NEXT:   %[[RESULT:.*]] = addf %[[LHS_IN]], %[[RHS_IN]] : f32
+// CHECK-NEXT:   linalg.yield %[[RESULT]] : f32
+
+// -----
+
 // CHECK-LABEL: func @element_wise_scalar
 func @element_wise_scalar(%lhs: memref<f32>, %rhs: memref<f32>,
           %result: memref<f32>) {

--- a/tensorflow/compiler/mlir/xla/transforms/lhlo_legalize_to_linalg.cc
+++ b/tensorflow/compiler/mlir/xla/transforms/lhlo_legalize_to_linalg.cc
@@ -58,9 +58,9 @@ class PointwiseToLinalgConverter : public OpConversionPattern<LhloOp> {
     auto loc = lhlo_op.getLoc();
     auto argType =
         lhlo_op.getOperand(0).getType().template dyn_cast<ShapedType>();
-    if (!argType || !argType.hasStaticShape()) {
+    if (!argType || !argType.hasRank()) {
       emitError(loc,
-                "lhlo to linalg conversion expects statically shaped args");
+                "lhlo to linalg conversion expects ranked args");
       return ConversionPattern::matchFailure();
     }
     if (!argType || !argType.getElementType().isIntOrFloat()) {


### PR DESCRIPTION
PointwiseToLinalgConverter only needs static rank not static shape, change accordingly to loose the restriction.