### PR TITLE
[tflite] add Hexagon delegate to label_image

### DIFF
--- a/tensorflow/lite/examples/label_image/BUILD
+++ b/tensorflow/lite/examples/label_image/BUILD
@@ -23,7 +23,7 @@ cc_binary(
         "//tensorflow:android": [
             "-pie",  # Android 5.0 and later supports only PIE
             "-lm",  # some builtin ops, e.g., tanh, need -lm
-            "-Wl,-rpath=/data/local/tmp", # for hexagon delegate
+            "-Wl,-rpath=/data/local/tmp",  # for hexagon delegate
         ],
         "//conditions:default": [],
     }),

--- a/tensorflow/lite/examples/label_image/BUILD
+++ b/tensorflow/lite/examples/label_image/BUILD
@@ -23,6 +23,7 @@ cc_binary(
         "//tensorflow:android": [
             "-pie",  # Android 5.0 and later supports only PIE
             "-lm",  # some builtin ops, e.g., tanh, need -lm
+            "-Wl,-rpath=/data/local/tmp", # for hexagon delegate
         ],
         "//conditions:default": [],
     }),
@@ -35,7 +36,17 @@ cc_binary(
         "//tensorflow/lite/profiling:profiler",
         "//tensorflow/lite/tools/evaluation:utils",
         "@com_google_absl//absl/memory",
-    ]
+    ] + select({
+        "//tensorflow:android": [
+            "//tensorflow/lite/delegates/gpu:gl_delegate",
+            "//tensorflow/lite/experimental/delegates/hexagon:hexagon_delegate",
+        ],
+        "//tensorflow:android_arm64": [
+            "//tensorflow/lite/delegates/gpu:gl_delegate",
+            "//tensorflow/lite/experimental/delegates/hexagon:hexagon_delegte",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 cc_library(
@@ -53,7 +64,17 @@ cc_library(
         "//tensorflow/lite:string_util",
         "//tensorflow/lite/kernels:builtin_ops",
         "//tensorflow/lite/schema:schema_fbs",
-    ]
+    ] + select({
+        "//tensorflow:android": [
+            "//tensorflow/lite/delegates/gpu:gl_delegate",
+            "//tensorflow/lite/experimental/delegates/hexagon:hexagon_delegate",
+        ],
+        "//tensorflow:android_arm64": [
+            "//tensorflow/lite/delegates/gpu:gl_delegate",
+            "//tensorflow/lite/experimental/delegates/hexagon:hexagon_delegte",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 cc_test(

--- a/tensorflow/lite/examples/label_image/BUILD
+++ b/tensorflow/lite/examples/label_image/BUILD
@@ -35,11 +35,7 @@ cc_binary(
         "//tensorflow/lite/profiling:profiler",
         "//tensorflow/lite/tools/evaluation:utils",
         "@com_google_absl//absl/memory",
-    ] + select({
-        "//tensorflow:android": ["//tensorflow/lite/delegates/gpu:gl_delegate"],
-        "//tensorflow:android_arm64": ["//tensorflow/lite/delegates/gpu:gl_delegate"],
-        "//conditions:default": [],
-    }),
+    ]
 )
 
 cc_library(
@@ -57,11 +53,7 @@ cc_library(
         "//tensorflow/lite:string_util",
         "//tensorflow/lite/kernels:builtin_ops",
         "//tensorflow/lite/schema:schema_fbs",
-    ] + select({
-        "//tensorflow:android": ["//tensorflow/lite/delegates/gpu:gl_delegate"],
-        "//tensorflow:android_arm64": ["//tensorflow/lite/delegates/gpu:gl_delegate"],
-        "//conditions:default": [],
-    }),
+    ]
 )
 
 cc_test(

--- a/tensorflow/lite/examples/label_image/BUILD
+++ b/tensorflow/lite/examples/label_image/BUILD
@@ -43,7 +43,7 @@ cc_binary(
         ],
         "//tensorflow:android_arm64": [
             "//tensorflow/lite/delegates/gpu:gl_delegate",
-            "//tensorflow/lite/experimental/delegates/hexagon:hexagon_delegte",
+            "//tensorflow/lite/experimental/delegates/hexagon:hexagon_delegate",
         ],
         "//conditions:default": [],
     }),
@@ -71,7 +71,7 @@ cc_library(
         ],
         "//tensorflow:android_arm64": [
             "//tensorflow/lite/delegates/gpu:gl_delegate",
-            "//tensorflow/lite/experimental/delegates/hexagon:hexagon_delegte",
+            "//tensorflow/lite/experimental/delegates/hexagon:hexagon_delegate",
         ],
         "//conditions:default": [],
     }),

--- a/tensorflow/lite/examples/label_image/README.md
+++ b/tensorflow/lite/examples/label_image/README.md
@@ -6,7 +6,7 @@ TensorFlow Lite model and use it to recognize objects in images.
 Before you begin,
 make sure you [have TensorFlow installed](https://www.tensorflow.org/install).
 
-You also need to [install Bazel 26.1](https://docs.bazel.build/versions/master/install.html)
+You also need to [install Bazel](https://docs.bazel.build/versions/master/install.html)
 in order to build this example code. And be sure you have the Python `future`
 module installed:
 
@@ -23,20 +23,20 @@ Android NDK or configure NDK setting in
 Build it for desktop machines (tested on Ubuntu and OS X):
 
 ```
-bazel build -c opt --cxxopt=-std=c++11 //tensorflow/lite/examples/label_image:label_image
+bazel build -c opt //tensorflow/lite/examples/label_image:label_image
 ```
 
 Build it for Android ARMv8:
 
 ```
-bazel build -c opt --cxxopt=-std=c++11 --config=android_arm64 \
+bazel build -c opt --config=android_arm64 \
   //tensorflow/lite/examples/label_image:label_image
 ```
 
 Build it for Android arm-v7a:
 
 ```
-bazel build -c opt --cxxopt=-std=c++11 --config=android_arm \
+bazel build -c opt --config=android_arm \
   //tensorflow/lite/examples/label_image:label_image
 ```
 
@@ -55,13 +55,13 @@ curl https://storage.googleapis.com/download.tensorflow.org/models/mobilenet_v1_
 mv /tmp/mobilenet_v1_1.0_224/labels.txt /tmp/
 ```
 
-## Run the sample
+## Run the sample on a desktop
 
 ```
 bazel-bin/tensorflow/lite/examples/label_image/label_image \
   --tflite_model /tmp/mobilenet_v1_1.0_224.tflite \
   --labels /tmp/labels.txt \
-  --image testdata/grace_hopper.bmp
+  --image tensorflow/lite/examples/label_image/testdata/grace_hopper.bmp
 ```
 
 You should see results like this:
@@ -76,6 +76,88 @@ average time: 68.12 ms
 0.00786704: 466 466:bulletproof vest
 0.00644932: 514 514:cornet, horn, trumpet, trump
 0.00608029: 543 543:drumstick
+```
+
+## Run the sample on an Android device
+Prepare data on devices, e.g.,
+
+```
+adb push bazel-bin/tensorflow/lite/examples/label_image/label_image  /data/local/tmp
+adb push /tmp/mobilenet_v1_1.0_224.tflite  /data/local/tmp
+adb push tensorflow/lite/examples/label_image/testdata/grace_hopper.bmp  /data/local/tmp
+adb push /tmp/labels.txt /data/local/tmp
+```
+
+Run it,
+```
+adb shell "/data/local/tmp/label_image \
+-m /data/local/tmp/mobilenet_v1_1.0_224.tflite \
+-i /data/local/tmp/grace_hopper.bmp \
+-l /data/local/tmp/labels.txt"
+```
+then you should see something like the followings:
+```
+Loaded model /data/local/tmp/mobilenet_v1_1.0_224.tflite
+resolved reporter
+INFO: Initialized TensorFlow Lite runtime.
+invoked
+average time: 25.03 ms
+0.907071: 653 military uniform
+0.0372416: 907 Windsor tie
+0.00733753: 466 bulletproof vest
+0.00592852: 458 bow tie
+0.00414091: 514 cornet
+```
+
+Run the model with NNAPI delegate (`-a 1`),
+```
+adb shell "/data/local/tmp/label_image \
+-m /data/local/tmp/mobilenet_v1_1.0_224.tflite \
+-i /data/local/tmp/grace_hopper.bmp \
+-l /data/local/tmp/labels.txt -a 1 -f 1"
+```
+then you should see something like the followings:
+```
+Loaded model /data/local/tmp/mobilenet_v1_1.0_224.tflite
+resolved reporter
+INFO: Initialized TensorFlow Lite runtime.
+INFO: Created TensorFlow Lite delegate for NNAPI.
+Applied NNAPI delegate.invoked
+average time: 10.348 ms
+0.905401: 653 military uniform
+0.0379589: 907 Windsor tie
+0.00735866: 466 bulletproof vest
+0.00605307: 458 bow tie
+0.00422573: 514 cornet
+```
+
+To run a model with the Hexagon Delegate, assuming we have
+followed the
+[Hexagon Delegate doc](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/performance/hexagon_delegate.md)
+and installed Hexagon libraries in `/data/local/tmp`. Run it
+```
+adb shell "export LD_LIBRARY_PATH=/data/local/tmp/; \
+/data/local/tmp/label_image \
+-m /data/local/tmp/mobilenet_v1_1.0_224_quant.tflite \
+-i /data/local/tmp/grace_hopper.bmp \
+-l /data/local/tmp/labels.txt -j 1"
+```
+then you should see something like the followings:
+```
+Loaded model /data/local/tmp/mobilenet_v1_1.0_224_quant.tflite
+resolved reporter
+INFO: Initialized TensorFlow Lite runtime.
+INFO: Created TensorFlow Lite delegate for Hexagon.
+INFO: Hexagon delegate: 31 nodes delegated out of 31 nodes.
+
+remote_handle_control available and used
+Applied Hexagon delegate.invoked
+average time: 8.307 ms
+0.729412: 653 military uniform
+0.0980392: 907 Windsor tie
+0.0313726: 466 bulletproof vest
+0.0313726: 458 bow tie
+0.0117647: 700 panpipe
 ```
 
 See the `label_image.cc` source code for other command line options.

--- a/tensorflow/lite/examples/label_image/README.md
+++ b/tensorflow/lite/examples/label_image/README.md
@@ -133,11 +133,10 @@ average time: 10.348 ms
 
 To run a model with the Hexagon Delegate, assuming we have
 followed the
-[Hexagon Delegate doc](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/performance/hexagon_delegate.md)
+[Hexagon Delegate Guide](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/performance/hexagon_delegate.md)
 and installed Hexagon libraries in `/data/local/tmp`. Run it
 ```
-adb shell "export LD_LIBRARY_PATH=/data/local/tmp/; \
-/data/local/tmp/label_image \
+adb shell "/data/local/tmp/label_image \
 -m /data/local/tmp/mobilenet_v1_1.0_224_quant.tflite \
 -i /data/local/tmp/grace_hopper.bmp \
 -l /data/local/tmp/labels.txt -j 1"

--- a/tensorflow/lite/examples/label_image/label_image.cc
+++ b/tensorflow/lite/examples/label_image/label_image.cc
@@ -85,9 +85,21 @@ TfLiteDelegatePtrMap GetDelegates(Settings* s) {
     if (!delegate) {
       LOG(INFO) << "NNAPI acceleration is unsupported on this platform.";
     } else {
-      delegates.emplace("NNAPI", evaluation::CreateNNAPIDelegate());
+      delegates.emplace("NNAPI", std::move(delegate));
     }
   }
+
+  if (s->hexagon_delegate) {
+    const std::string libhexagon_path("/data/local/tmp");
+    auto delegate = evaluation::CreateHexagonDelegate(libhexagon_path);
+
+    if (!delegate) {
+      LOG(INFO) << "Hexagon acceleration is unsupported on this platform.";
+    } else {
+      delegates.emplace("Hexagon", std::move(delegate));
+    }
+  }
+
   return delegates;
 }
 
@@ -326,6 +338,7 @@ void display_usage() {
       << "--allow_fp16, -f: [0|1], allow running fp32 models with fp16 or not\n"
       << "--count, -c: loop interpreter->Invoke() for certain times\n"
       << "--gl_backend, -g: use GL GPU Delegate on Android\n"
+      << "--hexagon_delegate: use Hexagon Delegate on Android\n"
       << "--input_mean, -b: input mean\n"
       << "--input_std, -s: input standard deviation\n"
       << "--image, -i: image_name.bmp\n"
@@ -361,13 +374,14 @@ int Main(int argc, char** argv) {
         {"max_profiling_buffer_entries", required_argument, nullptr, 'e'},
         {"warmup_runs", required_argument, nullptr, 'w'},
         {"gl_backend", required_argument, nullptr, 'g'},
+        {"hexagon_delegate", required_argument, nullptr, 'j'},
         {nullptr, 0, nullptr, 0}};
 
     /* getopt_long stores the option index here. */
     int option_index = 0;
 
     c = getopt_long(argc, argv,
-                    "a:b:c:d:e:f:g:i:l:m:p:r:s:t:v:w:", long_options,
+                    "a:b:c:d:e:f:g:i:j:l:m:p:r:s:t:v:w:", long_options,
                     &option_index);
 
     /* Detect the end of the options. */
@@ -402,6 +416,9 @@ int Main(int argc, char** argv) {
         break;
       case 'i':
         s.input_bmp_name = optarg;
+        break;
+      case 'j':
+        s.hexagon_delegate = optarg;
         break;
       case 'l':
         s.labels_file_name = optarg;

--- a/tensorflow/lite/examples/label_image/label_image.cc
+++ b/tensorflow/lite/examples/label_image/label_image.cc
@@ -91,7 +91,8 @@ TfLiteDelegatePtrMap GetDelegates(Settings* s) {
 
   if (s->hexagon_delegate) {
     const std::string libhexagon_path("/data/local/tmp");
-    auto delegate = evaluation::CreateHexagonDelegate(libhexagon_path);
+    auto delegate =
+        evaluation::CreateHexagonDelegate(libhexagon_path, s->profiling);
 
     if (!delegate) {
       LOG(INFO) << "Hexagon acceleration is unsupported on this platform.";

--- a/tensorflow/lite/examples/label_image/label_image.h
+++ b/tensorflow/lite/examples/label_image/label_image.h
@@ -30,6 +30,7 @@ struct Settings {
   bool profiling = false;
   bool allow_fp16 = false;
   bool gl_backend = false;
+  bool hexagon_delegate = false;
   int loop_count = 1;
   float input_mean = 127.5f;
   float input_std = 127.5f;


### PR DESCRIPTION
add Hexagon Delegte support to label_image and remove unnecessary
depependency in //tensorflow/lite/examples/label_image/BUILD