### PR TITLE
[ROCm] Fixing a bug in the previous commit to nccl_manager_test.cc file. 

### DIFF
--- a/tensorflow/core/nccl/nccl_manager_test.cc
+++ b/tensorflow/core/nccl/nccl_manager_test.cc
@@ -663,8 +663,8 @@ TYPED_TEST(NcclManagerTest, MultiNodeBroadcast) {
   this->RunMultiNodeBroadcastTest(num_nodes, num_ranks_per_node,
                                   /*src_node=*/0, /*src_local_rank=*/0,
                                   /*in_place=*/true);
-#endif
 }
+#endif
 
 // Checks that we return error status if a collective_key is used for different
 // types of collectives, e.g.a reduction and a broadcast.

--- a/tensorflow/tools/ci_build/linux/rocm/run_cc_core.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_cc_core.sh
@@ -56,7 +56,7 @@ bazel test \
 && bazel test \
       --config=rocm \
       -k \
-      --test_tag_filters=-no_gpu,-no_rocm,-v1only \
+      --test_tag_filters=gpu \
       --jobs=${N_JOBS} \
       --local_test_jobs=1 \
       --test_timeout 600,900,2400,7200 \


### PR DESCRIPTION
This test has not been compiling (in ROCm mode) since this commit broke it :
https://github.com/tensorflow/tensorflow/commit/d65a5f1bdf5dc536efe9cfcdd64acc2d6273b6e2

Also updating the run_cc_core.sh file to not filter out `//tensorflow/core/nccl:nccl_manager_test`
That test has the `no_rocm` tag on it (in the upstream repo)

/cc @cheshire @whchung 