### PR TITLE
[ROCm] Fix for compile error in //tensorflow/compiler/xla:debug_optio…

### DIFF
--- a/tensorflow/compiler/xla/debug_options_parsers_test.cc
+++ b/tensorflow/compiler/xla/debug_options_parsers_test.cc
@@ -26,8 +26,8 @@ namespace xla {
 
 // Test that the xla_backend_extra_options flag is parsed correctly.
 TEST(DebugOptionsFlags, ParseXlaBackendExtraOptions) {
-  std::unordered_map<string, string> test_map;
-  string test_string = "aa=bb,cc,dd=,ee=ff=gg";
+  std::unordered_map<std::string, std::string> test_map;
+  std::string test_string = "aa=bb,cc,dd=,ee=ff=gg";
   parse_xla_backend_extra_options(&test_map, test_string);
   EXPECT_EQ(test_map.size(), 4);
   EXPECT_EQ(test_map.at("aa"), "bb");


### PR DESCRIPTION
…ns_parsers_test

On the ROCm platform, we currently get the following compile failure for the test
`tensorflow/compiler/xla/debug_options_parsers_test`

```
...
external/com_google_googletest/googletest/include/gtest/internal/gtest-port.h:881:23: note:   'testing::internal::string'
 typedef ::std::string string;
                       ^
tensorflow/compiler/xla/debug_options_parsers_test.cc:29:33: error: 'test_map' was not declared in this scope
   unordered_map<string, string> test_map;
                                 ^
tensorflow/compiler/xla/debug_options_parsers_test.cc:30:10: error: expected ';' before 'test_string'
   string test_string = "aa=bb,cc,dd=,ee=ff=gg";
...

```

This fix resolves the compile error, and gets the test passing again on the ROCm platform

On the ROCm platform, this test is compiled via the following gcc compiler

```
root@ixt-rack-04:/root/tensorflow# gcc --version
gcc (Ubuntu 5.4.0-6ubuntu1~16.04.12) 5.4.0 20160609
```

The crosstool setup / compile invocation on the ROCm platform is done via
 * https://github.com/tensorflow/tensorflow/blob/master/third_party/gpus/rocm_configure.bzl
 * https://github.com/tensorflow/tensorflow/blob/master/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl



/cc @cheshire @whchung 