### PR TITLE
[ROCm] Fix for compile error in //tensorflow/compiler/xla/service:dynamic_padder_test

### DIFF
--- a/tensorflow/compiler/xla/service/dynamic_padder_test.cc
+++ b/tensorflow/compiler/xla/service/dynamic_padder_test.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "tensorflow/compiler/xla/service/dynamic_padder.h"
 
+#include "absl/strings/str_replace.h"
 #include "tensorflow/compiler/xla/client/xla_builder.h"
 #include "tensorflow/compiler/xla/literal.h"
 #include "tensorflow/compiler/xla/service/hlo_computation.h"


### PR DESCRIPTION

On the ROCm platform, we currently get the following compile failure for the test
`//tensorflow/compiler/xla/service:dynamic_padder_test`

```
...
INFO: Deleting stale sandbox base /root/.cache/bazel/_bazel_root/efb88f6336d9c4a18216fb94287b8d97/sandbox
ERROR: /root/tensorflow/tensorflow/compiler/xla/service/BUILD:2311:1: C++ compilation of rule '//tensorflow/compiler/xla/service:dynamic_padder_test_gpu' failed (Exit 1)
tensorflow/compiler/xla/service/dynamic_padder_test.cc: In member function 'virtual void xla::{anonymous}::ExecutionTest_ScatterUpdate_Test::TestBody()':
tensorflow/compiler/xla/service/dynamic_padder_test.cc:266:7: error: 'StrReplaceAll' is not a member of 'absl'
       absl::StrReplaceAll(hlo_text, {{"INDICES_BOUND", "2"}});
       ^
tensorflow/compiler/xla/service/dynamic_padder_test.cc:281:7: error: 'StrReplaceAll' is not a member of 'absl'
       absl::StrReplaceAll(hlo_text, {{"INDICES_BOUND", "4"}});
...

```

This fix resolves the compile error, and gets the test passing again on the ROCm platform

On the ROCm platform, this test is compiled via the following gcc compiler

```
root@ixt-rack-04:/root/tensorflow# gcc --version
gcc (Ubuntu 5.4.0-6ubuntu1~16.04.12) 5.4.0 20160609
```

The crosstool setup / compile invocation on the ROCm platform is done via
* https://github.com/tensorflow/tensorflow/blob/master/third_party/gpus/rocm_configure.bzl
* https://github.com/tensorflow/tensorflow/blob/master/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl


/cc @cheshire @whchung 