### PR TITLE
[ROCm] Fix for compile error in //tensorflow/compiler/xla:refcounting_hash_map_test

### DIFF
--- a/tensorflow/compiler/xla/refcounting_hash_map_test.cc
+++ b/tensorflow/compiler/xla/refcounting_hash_map_test.cc
@@ -77,7 +77,7 @@ TEST(RefcountingHashMapTest, CustomFactory) {
 
 TEST(RefcountingHashMapTest, ForEachEmpty) {
   RefcountingHashMap<int, int> m;
-  int64 count = 0;
+  int64_t count = 0;
   m.ForEach([&](const int&, std::shared_ptr<int>) { ++count; });
   EXPECT_EQ(count, 0);
 }


### PR DESCRIPTION
On the ROCm platform, we currently get the following compile failure for the test
`//tensorflow/compiler/xla:refcounting_hash_map_test`

```
...
ERROR: /root/tensorflow/tensorflow/compiler/xla/BUILD:928:1: C++ compilation of rule '//tensorflow/compiler/xla:refcounting_hash_map_test' failed (Exit 1)
tensorflow/compiler/xla/refcounting_hash_map_test.cc: In member function 'virtual void xla::{anonymous}::RefcountingHashMapTest_ForEachEmpty_Test::TestBody()':
tensorflow/compiler/xla/refcounting_hash_map_test.cc:80:3: error: 'int64' was not declared in this scope
   int64 count = 0;
...

```

This fix resolves the compile error, and gets the test passing again on the ROCm platform

On the ROCm platform, this test is compiled via the following gcc compiler

```
root@ixt-rack-04:/root/tensorflow# gcc --version
gcc (Ubuntu 5.4.0-6ubuntu1~16.04.12) 5.4.0 20160609
```

The crosstool setup / compile invocation on the ROCm platform is done via
* https://github.com/tensorflow/tensorflow/blob/master/third_party/gpus/rocm_configure.bzl
* https://github.com/tensorflow/tensorflow/blob/master/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl


/cc @cheshire @whchung 