### PR TITLE
Include casting to desired type to prevent dtype mismatch error.

### DIFF
--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -1043,7 +1043,7 @@ def logcosh(y_true, y_pred):
   y_true = math_ops.cast(y_true, y_pred.dtype)
 
   def _logcosh(x):
-    return x + nn.softplus(-2. * x) - math_ops.log(2.)
+    return x + nn.softplus(-2. * x) - math_ops.cast(math_ops.log(2.), x.dtype)
 
   return K.mean(_logcosh(y_pred - y_true), axis=-1)
 


### PR DESCRIPTION
If using a mixed datatype the _logcosh function will throw an error as below:
`Input 'y' of 'Sub' Op has type float32 that does not match type float64 of argument 'x'.`

Added a typecast to overcome the issue.