### PR TITLE
Fix issue with ReLU layer and integer dtype

### DIFF
--- a/tensorflow/python/keras/backend.py
+++ b/tensorflow/python/keras/backend.py
@@ -4425,7 +4425,7 @@ def relu(x, alpha=0., max_value=None, threshold=0):
 
   if clip_max:
     max_value = _constant_to_tensor(max_value, x.dtype.base_dtype)
-    zero = _constant_to_tensor(0., x.dtype.base_dtype)
+    zero = _constant_to_tensor(0, x.dtype.base_dtype)
     x = clip_ops.clip_by_value(x, zero, max_value)
 
   if alpha != 0.:

--- a/tensorflow/python/keras/backend_test.py
+++ b/tensorflow/python/keras/backend_test.py
@@ -544,6 +544,10 @@ class BackendLinearAlgebraTest(test.TestCase, parameterized.TestCase):
     relu_op = keras.backend.relu(x, alpha=0.25, threshold=4, max_value=5)
     self.assertAllClose(keras.backend.eval(relu_op), [[-2, -1], [-0.5, 5]])
 
+    # Test case for GitHub issue 35430, with integer dtype
+    x = keras.Input(shape=(), name='x', dtype='int64')
+    y = keras.layers.ReLU(max_value=100, dtype='int64')(x)
+
 
 @test_util.run_all_in_graph_and_eager_modes
 class BackendShapeOpsTest(test.TestCase):

--- a/tensorflow/python/keras/engine/base_layer_test.py
+++ b/tensorflow/python/keras/engine/base_layer_test.py
@@ -630,11 +630,6 @@ class BaseLayerTest(keras_parameterized.TestCase):
     out = self.evaluate(layer(x=x, y=y))
     self.assertAllClose(out, 2 * np.ones((10, 1)))
 
-  def test_relu_layer_with_dtype(self):
-    # Test case for GitHub issue 35430
-    x = keras.Input(shape=(), name='x', dtype='int64')
-    y = keras.layers.ReLU(max_value=100, dtype='int64')(x)
-
 
 class SymbolicSupportTest(test.TestCase):
 

--- a/tensorflow/python/keras/engine/base_layer_test.py
+++ b/tensorflow/python/keras/engine/base_layer_test.py
@@ -630,6 +630,11 @@ class BaseLayerTest(keras_parameterized.TestCase):
     out = self.evaluate(layer(x=x, y=y))
     self.assertAllClose(out, 2 * np.ones((10, 1)))
 
+  def test_relu_layer_with_dtype(self):
+    # Test case for GitHub issue 35430
+    x = keras.Input(shape=(), name='x', dtype='int64')
+    y = keras.layers.ReLU(max_value=100, dtype='int64')(x)
+
 
 class SymbolicSupportTest(test.TestCase):
 


### PR DESCRIPTION

This fix tries to address the issue raised in #35430 where
ReLU layer + integer dtype causes conversion error.
This PR fixes the isse by replacing float `0.` with `0`.

This fix fixes #35430.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>