### PR TITLE
Add a usage example for tf.is_tensor

### DIFF
--- a/tensorflow/python/framework/tensor_util.py
+++ b/tensorflow/python/framework/tensor_util.py
@@ -983,14 +983,14 @@ def is_tensor(x):  # pylint: disable=invalid-name
   can be converted to a tensor using `ops.convert_to_tensor(x)`.
   
   Usage example:  
-    >>> x = tf.constant([[1,2,3],[4,5,6],[7,8,9]])
-    >>> print(x.shape)
-    (3, 3)
-    >>> print(tf.is_tensor(x))
-    True
-    >>> y = "Hello World"
-    >>> print(tf.is_tensor(y))
-    False
+  >>> x = tf.constant([[1,2,3],[4,5,6],[7,8,9]])
+  >>> print(x.shape)
+  (3, 3)
+  >>> print(tf.is_tensor(x))
+  True
+  >>> y = "Hello World"
+  >>> print(tf.is_tensor(y))
+  False
     
   Args:
     x: A python object to check.

--- a/tensorflow/python/framework/tensor_util.py
+++ b/tensorflow/python/framework/tensor_util.py
@@ -983,7 +983,7 @@ def is_tensor(x):  # pylint: disable=invalid-name
   can be converted to a tensor using `ops.convert_to_tensor(x)`.
   
   Usage example:  
-  >>> tf.is_tensor(constant([[1,2,3],[4,5,6],[7,8,9]])) 
+  >>> tf.is_tensor(tf.constant([[1,2,3],[4,5,6],[7,8,9]])) 
   True
   >>> tf.is_tensor("Hello World")
   False

--- a/tensorflow/python/framework/tensor_util.py
+++ b/tensorflow/python/framework/tensor_util.py
@@ -982,7 +982,8 @@ def is_tensor(x):  # pylint: disable=invalid-name
   If `is_tensor(x)` returns `True`, it is safe to assume that `x` is a tensor or
   can be converted to a tensor using `ops.convert_to_tensor(x)`.
   
-  Usage example:  
+  Usage example:
+  
   >>> tf.is_tensor(tf.constant([[1,2,3],[4,5,6],[7,8,9]])) 
   True
   >>> tf.is_tensor("Hello World")

--- a/tensorflow/python/framework/tensor_util.py
+++ b/tensorflow/python/framework/tensor_util.py
@@ -983,13 +983,9 @@ def is_tensor(x):  # pylint: disable=invalid-name
   can be converted to a tensor using `ops.convert_to_tensor(x)`.
   
   Usage example:  
-  >>> x = tf.constant([[1,2,3],[4,5,6],[7,8,9]])
-  >>> print(x.shape)
-  (3, 3)
-  >>> print(tf.is_tensor(x))
+  >>> tf.is_tensor(constant([[1,2,3],[4,5,6],[7,8,9]])) 
   True
-  >>> y = "Hello World"
-  >>> print(tf.is_tensor(y))
+  >>> tf.is_tensor("Hello World"))
   False
     
   Args:

--- a/tensorflow/python/framework/tensor_util.py
+++ b/tensorflow/python/framework/tensor_util.py
@@ -985,7 +985,7 @@ def is_tensor(x):  # pylint: disable=invalid-name
   Usage example:  
   >>> tf.is_tensor(constant([[1,2,3],[4,5,6],[7,8,9]])) 
   True
-  >>> tf.is_tensor("Hello World"))
+  >>> tf.is_tensor("Hello World")
   False
     
   Args:

--- a/tensorflow/python/framework/tensor_util.py
+++ b/tensorflow/python/framework/tensor_util.py
@@ -981,7 +981,17 @@ def is_tensor(x):  # pylint: disable=invalid-name
 
   If `is_tensor(x)` returns `True`, it is safe to assume that `x` is a tensor or
   can be converted to a tensor using `ops.convert_to_tensor(x)`.
-
+  
+  Usage example:  
+    >>> x = tf.constant([[1,2,3],[4,5,6],[7,8,9]])
+    >>> print(x.shape)
+    (3, 3)
+    >>> print(tf.is_tensor(x))
+    True
+    >>> y = "Hello World"
+    >>> print(tf.is_tensor(y))
+    False
+    
   Args:
     x: A python object to check.
 


### PR DESCRIPTION
Added a usage example for tf.is_tensor. 

Tested on local machine with python3 ./tf_doctest.py --file=../../python/framework/tensor_util.py