### PR TITLE
Add TEST code for int16 Ops: {SPLIT, SQUEEZE, RESHAPE, EXPAND_DIMS}

### DIFF
--- a/tensorflow/lite/kernels/reshape_test.cc
+++ b/tensorflow/lite/kernels/reshape_test.cc
@@ -26,7 +26,7 @@ using ::testing::IsEmpty;
 
 // There are three ways to specify the output shape of a Reshape
 // op.
-enum ShapeSpecificationType {
+enum class ShapeSpecificationType {
   // The output shape is hardcoded in the ReshapeOptions object.
   kAsReshapeOption,
   // The output shape is specified as an input tensor, which is connected to a
@@ -39,10 +39,6 @@ enum ShapeSpecificationType {
   kAsTensor,
 };
 
-class ReshapeOpTest
-    : public ::testing::Test,
-      public ::testing::WithParamInterface<ShapeSpecificationType> {};
-
 template <typename T>
 class ReshapeOpModel : public SingleOpModel {
  public:
@@ -51,13 +47,13 @@ class ReshapeOpModel : public SingleOpModel {
                  std::initializer_list<int> shape_data,
                  ShapeSpecificationType shape_type) {
     switch (shape_type) {
-      case kAsTensor:
+      case ShapeSpecificationType::kAsTensor:
         BuildWithTensorShape(input_shape, shape_shape, shape_data);
         break;
-      case kAsConstantTensor:
+      case ShapeSpecificationType::kAsConstantTensor:
         BuildWithConstantTensorShape(input_shape, shape_shape, shape_data);
         break;
-      case kAsReshapeOption:
+      case ShapeSpecificationType::kAsReshapeOption:
         // In this case the shape of the new shape doesn't matter. It is
         // always hardcoded as a flat vector.
         BuildWithHardcodedShape(input_shape, shape_data);
@@ -123,93 +119,111 @@ class ReshapeOpModel : public SingleOpModel {
   int output_;
 };
 
-TEST_P(ReshapeOpTest, MismatchedDimensions) {
-  if (GetParam() == kAsTensor) {
-    ReshapeOpModel<float> m({1, 2, 4, 1}, {2}, {2, 1}, GetParam());
-    m.SetInput({3});
-    EXPECT_NE(m.InvokeUnchecked(), kTfLiteOk)
-        << "num_input_elements != num_output_elements";
-  } else {
+template <typename T>
+class ReshapeOpTest : public ::testing::Test {
+ public:
+  static std::vector<ShapeSpecificationType> _range_;
+};
+
+template <>
+std::vector<ShapeSpecificationType>
+    ReshapeOpTest<ShapeSpecificationType>::_range_{
+        ShapeSpecificationType::kAsReshapeOption,
+        ShapeSpecificationType::kAsConstantTensor,
+        ShapeSpecificationType::kAsTensor};
+
+using DataTypes = ::testing::Types<float, int8_t, int16_t, int32_t>;
+TYPED_TEST_SUITE(ReshapeOpTest, DataTypes);
+
+TYPED_TEST(ReshapeOpTest, MismatchedDimensions) {
+  for (ShapeSpecificationType shape_type :
+       ReshapeOpTest<ShapeSpecificationType>::_range_) {
+    if (shape_type == ShapeSpecificationType::kAsTensor) {
+      ReshapeOpModel<TypeParam> m({1, 2, 4, 1}, {2}, {2, 1}, shape_type);
+      m.SetInput({3});
+      EXPECT_NE(m.InvokeUnchecked(), kTfLiteOk)
+          << "num_input_elements != num_output_elements";
+    } else {
 #ifdef GTEST_HAS_DEATH_TEST
-    EXPECT_DEATH(ReshapeOpModel<float>({1, 2, 4, 1}, {2}, {2, 1}, GetParam()),
-                 "num_input_elements != num_output_elements");
+      EXPECT_DEATH(
+          ReshapeOpModel<TypeParam>({1, 2, 4, 1}, {2}, {2, 1}, shape_type),
+          "num_input_elements != num_output_elements");
+#endif
+    }
+  }
+}
+
+TYPED_TEST(ReshapeOpTest, TooManyDimensions) {
+  for (ShapeSpecificationType shape_type :
+       ReshapeOpTest<ShapeSpecificationType>::_range_) {
+#ifdef GTEST_HAS_DEATH_TEST
+    EXPECT_DEATH(
+        ReshapeOpModel<TypeParam>({1, 1, 2, 1, 1, 1, 1, 1, 1}, {9},
+                                  {1, 1, 1, 1, 1, 1, 1, 1, 2}, shape_type),
+        "Found too many dimensions");
 #endif
   }
 }
 
-TEST_P(ReshapeOpTest, TooManyDimensions) {
+TYPED_TEST(ReshapeOpTest, TooManySpecialDimensions) {
+  for (ShapeSpecificationType shape_type :
+       ReshapeOpTest<ShapeSpecificationType>::_range_) {
+    if (shape_type != ShapeSpecificationType::kAsTensor) {
 #ifdef GTEST_HAS_DEATH_TEST
-    EXPECT_DEATH(ReshapeOpModel<float>({1, 1, 2, 1, 1, 1, 1, 1, 1}, {9},
-                                       {1, 1, 1, 1, 1, 1, 1, 1, 2}, GetParam()),
-                 "Found too many dimensions");
+      EXPECT_DEATH(ReshapeOpModel<TypeParam>({1, 2, 4, 1}, {4}, {-1, -1, 2, 4},
+                                             shape_type),
+                   "stretch_dim != -1");
 #endif
-}
-
-TEST_P(ReshapeOpTest, TooManySpecialDimensions) {
-  if (GetParam() != kAsTensor) {
-#ifdef GTEST_HAS_DEATH_TEST
-    EXPECT_DEATH(
-        ReshapeOpModel<float>({1, 2, 4, 1}, {4}, {-1, -1, 2, 4}, GetParam()),
-        "stretch_dim != -1");
-#endif
-  } else {
-    ReshapeOpModel<float> m({1, 2, 4, 1}, {4}, {-1, -1, 2, 4}, GetParam());
-    EXPECT_NE(m.InvokeUnchecked(), kTfLiteOk) << "stretch_dim != -1";
+    } else {
+      ReshapeOpModel<TypeParam> m({1, 2, 4, 1}, {4}, {-1, -1, 2, 4},
+                                  shape_type);
+      EXPECT_NE(m.InvokeUnchecked(), kTfLiteOk) << "stretch_dim != -1";
+    }
   }
 }
 
 // Create the model with a 2x2 shape. Processing still works because the new
 // shape ends up being hardcoded as a flat vector.
-TEST_P(ReshapeOpTest, InvalidShape) {
-  ReshapeOpModel<float> m({1, 2, 2}, {2, 2}, {1, 2, 2, 1}, GetParam());
-  m.SetInput({5, 6, 7, 8});
-  m.Invoke();
-  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({1, 2, 2, 1}));
-  EXPECT_THAT(m.GetOutput(), ElementsAreArray({5, 6, 7, 8}));
+TYPED_TEST(ReshapeOpTest, InvalidShape) {
+  for (ShapeSpecificationType shape_type :
+       ReshapeOpTest<ShapeSpecificationType>::_range_) {
+    ReshapeOpModel<TypeParam> m({1, 2, 2}, {2, 2}, {1, 2, 2, 1}, shape_type);
+    m.SetInput({5, 6, 7, 8});
+    m.Invoke();
+    EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({1, 2, 2, 1}));
+    EXPECT_THAT(m.GetOutput(), ElementsAreArray({5, 6, 7, 8}));
+  }
 }
 
 // This is the normal scenario, where shape is a vector.
-TEST_P(ReshapeOpTest, RegularShapes) {
-  ReshapeOpModel<float> m({1, 2, 4, 1}, {3}, {2, 2, 2}, GetParam());
-  m.SetInput({1, 2, 3, 4, 5, 6, 7, 8});
-  m.Invoke();
-  EXPECT_THAT(m.GetOutput(), ElementsAreArray({1, 2, 3, 4, 5, 6, 7, 8}));
-  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 2, 2}));
+TYPED_TEST(ReshapeOpTest, RegularShapes) {
+  for (ShapeSpecificationType shape_type :
+       ReshapeOpTest<ShapeSpecificationType>::_range_) {
+    ReshapeOpModel<TypeParam> m({1, 2, 4, 1}, {3}, {2, 2, 2}, shape_type);
+    m.SetInput({1, 2, 3, 4, 5, 6, 7, 8});
+    m.Invoke();
+    EXPECT_THAT(m.GetOutput(), ElementsAreArray({1, 2, 3, 4, 5, 6, 7, 8}));
+    EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 2, 2}));
+  }
 }
 
-TEST_P(ReshapeOpTest, WithStretchDimension) {
-  ReshapeOpModel<float> m({1, 2, 4, 1}, {3}, {2, 1, -1}, GetParam());
-  m.SetInput({1, 2, 3, 4, 5, 6, 7, 8});
-  m.Invoke();
-  EXPECT_THAT(m.GetOutput(), ElementsAreArray({1, 2, 3, 4, 5, 6, 7, 8}));
-  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 1, 4}));
+TYPED_TEST(ReshapeOpTest, WithStretchDimension) {
+  for (ShapeSpecificationType shape_type :
+       ReshapeOpTest<ShapeSpecificationType>::_range_) {
+    ReshapeOpModel<TypeParam> m({1, 2, 4, 1}, {3}, {2, 1, -1}, shape_type);
+    m.SetInput({1, 2, 3, 4, 5, 6, 7, 8});
+    m.Invoke();
+    EXPECT_THAT(m.GetOutput(), ElementsAreArray({1, 2, 3, 4, 5, 6, 7, 8}));
+    EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 1, 4}));
+  }
 }
 
 // Shape is specified as '[]', which is the modern way to represent scalar
 // input and output.
-TEST_P(ReshapeOpTest, ScalarOutput) {
-  ReshapeOpModel<float> m({1}, {0}, {}, GetParam());
-  m.SetInput({3});
-  m.Invoke();
-  EXPECT_THAT(m.GetOutput(), ElementsAreArray({3}));
-  EXPECT_THAT(m.GetOutputShape(), IsEmpty());
-}
-
-// Some old models specify '[0]' as the new shape, indicating that both input
-// and output are scalars.
-TEST_P(ReshapeOpTest, LegacyScalarOutput) {
-  if (GetParam() == kAsConstantTensor) {
-#ifdef GTEST_HAS_DEATH_TEST
-    EXPECT_DEATH(ReshapeOpModel<float>({1}, {1}, {0}, GetParam()),
-                 "num_input_elements != num_output_elements");
-#endif
-  } else if (GetParam() == kAsTensor) {
-    ReshapeOpModel<float> m({1}, {1}, {0}, GetParam());
-    m.SetInput({3});
-    ASSERT_NE(m.InvokeUnchecked(), kTfLiteOk)
-        << "num_input_elements != num_output_elements";
-  } else {
-    ReshapeOpModel<float> m({1}, {1}, {0}, GetParam());
+TYPED_TEST(ReshapeOpTest, ScalarOutput) {
+  for (ShapeSpecificationType shape_type :
+       ReshapeOpTest<ShapeSpecificationType>::_range_) {
+    ReshapeOpModel<TypeParam> m({1}, {0}, {}, shape_type);
     m.SetInput({3});
     m.Invoke();
     EXPECT_THAT(m.GetOutput(), ElementsAreArray({3}));
@@ -217,17 +231,42 @@ TEST_P(ReshapeOpTest, LegacyScalarOutput) {
   }
 }
 
-TEST_P(ReshapeOpTest, Strings) {
-  ReshapeOpModel<string> m({1, 2, 4, 1}, {3}, {2, 2, 2}, GetParam());
-  m.SetStringInput({"1", "2", "3", "4", "5", "6", "7", "8"});
-  m.Invoke();
-  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 2, 2}));
-  EXPECT_THAT(m.GetOutput(),
-              ElementsAreArray({"1", "2", "3", "4", "5", "6", "7", "8"}));
+// Some old models specify '[0]' as the new shape, indicating that both input
+// and output are scalars.
+TYPED_TEST(ReshapeOpTest, LegacyScalarOutput) {
+  for (ShapeSpecificationType shape_type :
+       ReshapeOpTest<ShapeSpecificationType>::_range_) {
+    if (shape_type == ShapeSpecificationType::kAsConstantTensor) {
+#ifdef GTEST_HAS_DEATH_TEST
+      EXPECT_DEATH(ReshapeOpModel<TypeParam>({1}, {1}, {0}, shape_type),
+                   "num_input_elements != num_output_elements");
+#endif
+    } else if (shape_type == ShapeSpecificationType::kAsTensor) {
+      ReshapeOpModel<TypeParam> m({1}, {1}, {0}, shape_type);
+      m.SetInput({3});
+      ASSERT_NE(m.InvokeUnchecked(), kTfLiteOk)
+          << "num_input_elements != num_output_elements";
+    } else {
+      ReshapeOpModel<TypeParam> m({1}, {1}, {0}, shape_type);
+      m.SetInput({3});
+      m.Invoke();
+      EXPECT_THAT(m.GetOutput(), ElementsAreArray({3}));
+      EXPECT_THAT(m.GetOutputShape(), IsEmpty());
+    }
+  }
 }
 
-INSTANTIATE_TEST_SUITE_P(VariedShapeSpec, ReshapeOpTest,
-                         ::testing::Values(kAsReshapeOption, kAsConstantTensor,
-                                           kAsTensor));
+TYPED_TEST(ReshapeOpTest, Strings) {
+  for (ShapeSpecificationType shape_type :
+       ReshapeOpTest<ShapeSpecificationType>::_range_) {
+    ReshapeOpModel<string> m({1, 2, 4, 1}, {3}, {2, 2, 2}, shape_type);
+    m.SetStringInput({"1", "2", "3", "4", "5", "6", "7", "8"});
+    m.Invoke();
+    EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 2, 2}));
+    EXPECT_THAT(m.GetOutput(),
+                ElementsAreArray({"1", "2", "3", "4", "5", "6", "7", "8"}));
+  }
+}
+
 }  // namespace
 }  // namespace tflite

--- a/tensorflow/lite/kernels/squeeze_test.cc
+++ b/tensorflow/lite/kernels/squeeze_test.cc
@@ -44,74 +44,77 @@ class BaseSqueezeOpModel : public SingleOpModel {
   int output_;
 };
 
-class FloatSqueezeOpModel : public BaseSqueezeOpModel {
+template <typename T>
+class SqueezeOpModel : public BaseSqueezeOpModel {
  public:
   using BaseSqueezeOpModel::BaseSqueezeOpModel;
 
-  void SetInput(std::initializer_list<float> data) {
-    PopulateTensor(input_, data);
-  }
+  void SetInput(std::initializer_list<T> data) { PopulateTensor(input_, data); }
 
-  std::vector<float> GetOutput() { return ExtractVector<float>(output_); }
+  std::vector<T> GetOutput() { return ExtractVector<T>(output_); }
   std::vector<int> GetOutputShape() { return GetTensorShape(output_); }
 };
 
-TEST(FloatSqueezeOpTest, SqueezeAll) {
-  std::initializer_list<float> data = {
-      1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,  9.0,  10.0, 11.0, 12.0,
-      13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0};
-  FloatSqueezeOpModel m({TensorType_FLOAT32, {1, 24, 1}},
-                        {TensorType_FLOAT32, {24}}, {});
+template <typename T>
+class SqueezeOpTest : public ::testing::Test {};
+
+using DataTypes = ::testing::Types<float, int8_t, int16_t, int32_t>;
+TYPED_TEST_SUITE(SqueezeOpTest, DataTypes);
+
+TYPED_TEST(SqueezeOpTest, SqueezeAll) {
+  std::initializer_list<TypeParam> data = {1,  2,  3,  4,  5,  6,  7,  8,
+                                           9,  10, 11, 12, 13, 14, 15, 16,
+                                           17, 18, 19, 20, 21, 22, 23, 24};
+  SqueezeOpModel<TypeParam> m({GetTensorType<TypeParam>(), {1, 24, 1}},
+                              {GetTensorType<TypeParam>(), {24}}, {});
   m.SetInput(data);
   m.Invoke();
   EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({24}));
   EXPECT_THAT(
       m.GetOutput(),
-      ElementsAreArray({1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,
-                        9.0,  10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
-                        17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0}));
+      ElementsAreArray({1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
+                        13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24}));
 }
 
-TEST(FloatSqueezeOpTest, SqueezeSelectedAxis) {
-  std::initializer_list<float> data = {
-      1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,  9.0,  10.0, 11.0, 12.0,
-      13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0};
-  FloatSqueezeOpModel m({TensorType_FLOAT32, {1, 24, 1}},
-                        {TensorType_FLOAT32, {24}}, {2});
+TYPED_TEST(SqueezeOpTest, SqueezeSelectedAxis) {
+  std::initializer_list<TypeParam> data = {1,  2,  3,  4,  5,  6,  7,  8,
+                                           9,  10, 11, 12, 13, 14, 15, 16,
+                                           17, 18, 19, 20, 21, 22, 23, 24};
+  SqueezeOpModel<TypeParam> m({GetTensorType<TypeParam>(), {1, 24, 1}},
+                              {GetTensorType<TypeParam>(), {24}}, {2});
   m.SetInput(data);
   m.Invoke();
   EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({1, 24}));
   EXPECT_THAT(
       m.GetOutput(),
-      ElementsAreArray({1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,
-                        9.0,  10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
-                        17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0}));
+      ElementsAreArray({1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
+                        13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24}));
 }
 
-TEST(FloatSqueezeOpTest, SqueezeNegativeAxis) {
-  std::initializer_list<float> data = {
-      1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,  9.0,  10.0, 11.0, 12.0,
-      13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0};
-  FloatSqueezeOpModel m({TensorType_FLOAT32, {1, 24, 1}},
-                        {TensorType_FLOAT32, {24}}, {-1, 0});
+TYPED_TEST(SqueezeOpTest, SqueezeNegativeAxis) {
+  std::initializer_list<TypeParam> data = {1,  2,  3,  4,  5,  6,  7,  8,
+                                           9,  10, 11, 12, 13, 14, 15, 16,
+                                           17, 18, 19, 20, 21, 22, 23, 24};
+  SqueezeOpModel<TypeParam> m({GetTensorType<TypeParam>(), {1, 24, 1}},
+                              {GetTensorType<TypeParam>(), {24}}, {-1, 0});
   m.SetInput(data);
   m.Invoke();
   EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({24}));
   EXPECT_THAT(
       m.GetOutput(),
-      ElementsAreArray({1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,
-                        9.0,  10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
-                        17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0}));
+      ElementsAreArray({1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
+                        13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24}));
 }
 
-TEST(FloatSqueezeOpTest, SqueezeAllDims) {
-  std::initializer_list<float> data = {3.85};
-  FloatSqueezeOpModel m({TensorType_FLOAT32, {1, 1, 1, 1, 1, 1, 1}},
-                        {TensorType_FLOAT32, {1}}, {});
+TYPED_TEST(SqueezeOpTest, SqueezeAllDims) {
+  std::initializer_list<TypeParam> data = {3};
+  SqueezeOpModel<TypeParam> m(
+      {GetTensorType<TypeParam>(), {1, 1, 1, 1, 1, 1, 1}},
+      {GetTensorType<TypeParam>(), {1}}, {});
   m.SetInput(data);
   m.Invoke();
   EXPECT_THAT(m.GetOutputShape(), IsEmpty());
-  EXPECT_THAT(m.GetOutput(), ElementsAreArray({3.85}));
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray({3}));
 }
 
 }  // namespace


### PR DESCRIPTION
This PR is one of steps to extend TFLite to support symmetric 16-bit activations.
 
In this PR we introduce tests for INT16 operators list below:
  - SPLIT
  - SQUEEZE
  - RESHAPE
  - EXPAND_DIMS