### PR TITLE
[s3_file_system] set sync_needed_ as false after Sync()

### DIFF
--- a/tensorflow/core/platform/s3/s3_file_system.cc
+++ b/tensorflow/core/platform/s3/s3_file_system.cc
@@ -265,6 +265,7 @@ class S3WritableFile : public WritableFile {
       return errors::Unknown(putObjectOutcome.GetError().GetExceptionName(),
                              ": ", putObjectOutcome.GetError().GetMessage());
     }
+    sync_needed_ = false;
     return Status::OK();
   }
 


### PR DESCRIPTION
In file systems like s3 and gcs, `sync_needed` is meant to track whether an upload is needed. GCS file system correctly implemented it, but it's not actually in effect in s3_file_system.

This looks like a bug in s3, and this fix should correct it.


I don't have the historic context of whether this is intentional. Please let me know if I am wrong.
