### PR TITLE
TFLu: Fixed convolution layer in the CMSIS-NN glue

### DIFF
--- a/tensorflow/lite/micro/kernels/cmsis-nn/conv.cc
+++ b/tensorflow/lite/micro/kernels/cmsis-nn/conv.cc
@@ -162,6 +162,8 @@ TfLiteStatus EvalQuantizedPerChannel(
   op_params.dilation_width_factor = params->dilation_width_factor;
   op_params.padding_values.height = data->padding.height;
   op_params.padding_values.width = data->padding.width;
+  op_params.quantized_activation_min = data->output_activation_min;
+  op_params.quantized_activation_max = data->output_activation_max;
 
 #if defined(ARM_MATH_DSP) && defined(ARM_MATH_LOOPUNROLL)
 


### PR DESCRIPTION
Missing min/max activation for the reference kernel