### PR TITLE
[TFLite int16] 16-bit version of MUL reference kernel operator

### DIFF
--- a/tensorflow/lite/kernels/internal/reference/integer_ops/mul.h
+++ b/tensorflow/lite/kernels/internal/reference/integer_ops/mul.h
@@ -22,9 +22,10 @@ limitations under the License.
 namespace tflite {
 namespace reference_integer_ops {
 
+template <typename T>
 inline void MulElementwise(int size, const ArithmeticParams& params,
-                           const int8_t* input1_data, const int8_t* input2_data,
-                           int8_t* output_data) {
+                           const T* input1_data, const T* input2_data,
+                           T* output_data) {
   for (int i = 0; i < size; ++i) {
     const int32 input1_val = params.input1_offset + input1_data[i];
     const int32 input2_val = params.input2_offset + input2_data[i];
@@ -36,14 +37,15 @@ inline void MulElementwise(int size, const ArithmeticParams& params,
     const int32 clamped_output =
         std::min(params.quantized_activation_max,
                  std::max(params.quantized_activation_min, unclamped_result));
-    output_data[i] = static_cast<int8_t>(clamped_output);
+    output_data[i] = static_cast<T>(clamped_output);
   }
 }
 
+template <typename T>
 inline void Mul(const ArithmeticParams& params,
-                const RuntimeShape& input1_shape, const int8_t* input1_data,
-                const RuntimeShape& input2_shape, const int8_t* input2_data,
-                const RuntimeShape& output_shape, int8_t* output_data) {
+                const RuntimeShape& input1_shape, const T* input1_data,
+                const RuntimeShape& input2_shape, const T* input2_data,
+                const RuntimeShape& output_shape, T* output_data) {
   TFLITE_DCHECK_LE(params.quantized_activation_min,
                    params.quantized_activation_max);
   ruy::profiler::ScopeLabel label("Mul/8bit");
@@ -83,14 +85,13 @@ inline void Mul(const ArithmeticParams& params,
   }
 }
 
-inline void BroadcastMul4DSlow(const ArithmeticParams& params,
-                               const RuntimeShape& input1_shape,
-                               const int8_t* input1_data,
-                               const RuntimeShape& input2_shape,
-                               const int8_t* input2_data,
-                               const RuntimeShape& output_shape,
-                               int8_t* output_data) {
-  ruy::profiler::ScopeLabel label("BroadcastMul4DSlow/8bit");
+template <typename T>
+inline void BroadcastMul4DSlow(
+    const ArithmeticParams& params, const RuntimeShape& input1_shape,
+    const T* input1_data, const RuntimeShape& input2_shape,
+    const T* input2_data, const RuntimeShape& output_shape, T* output_data) {
+  ruy::profiler::ScopeLabel label("BroadcastMul4DSlow");
+
   NdArrayDesc<4> desc1;
   NdArrayDesc<4> desc2;
   // The input shapes are extended as part of NdArrayDesc initialization.
@@ -118,7 +119,7 @@ inline void BroadcastMul4DSlow(const ArithmeticParams& params,
               params.quantized_activation_max,
               std::max(params.quantized_activation_min, unclamped_result));
           output_data[Offset(extended_output_shape, b, y, x, c)] =
-              static_cast<int8_t>(clamped_output);
+              static_cast<T>(clamped_output);
         }
       }
     }

--- a/tensorflow/lite/kernels/internal/reference/reference_ops.h
+++ b/tensorflow/lite/kernels/internal/reference/reference_ops.h
@@ -26,7 +26,6 @@ limitations under the License.
 #include <memory>
 #include <type_traits>
 
-#include "third_party/eigen3/Eigen/Core"
 #include "fixedpoint/fixedpoint.h"
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/experimental/ruy/profiler/instrumentation.h"
@@ -59,6 +58,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/strided_slice_logic.h"
 #include "tensorflow/lite/kernels/internal/tensor.h"
 #include "tensorflow/lite/kernels/internal/types.h"
+#include "third_party/eigen3/Eigen/Core"
 
 namespace tflite {
 

--- a/tensorflow/lite/kernels/mul_test.cc
+++ b/tensorflow/lite/kernels/mul_test.cc
@@ -339,7 +339,7 @@ TEST(QuantizedMulOpTest, NoActivationInt16) {
 
 TEST(QuantizedMulOpTest, NoActivationInt16Scaled) {
   const float kMin = -2.f;
-  const float kMax = 2.f*32767.f / 32768.f;;
+  const float kMax = 2.f*32767.f / 32768.f;
   QuantizedMulOpModel m({TensorType_INT16, {1, 2, 3, 1}, kMin, kMax},
                         {TensorType_INT16, {1, 2, 3, 1}, 2*kMin, 2*kMax},
                         {TensorType_INT16, {}, 8*kMin, 8*kMax},

--- a/tensorflow/lite/kernels/mul_test.cc
+++ b/tensorflow/lite/kernels/mul_test.cc
@@ -337,6 +337,25 @@ TEST(QuantizedMulOpTest, NoActivationInt16) {
                                               kQuantizedToleranceInt16)));
 }
 
+TEST(QuantizedMulOpTest, NoActivationInt16Scaled) {
+  const float kMin = -2.f;
+  const float kMax = 2.f*32767.f / 32768.f;;
+  QuantizedMulOpModel m({TensorType_INT16, {1, 2, 3, 1}, kMin, kMax},
+                        {TensorType_INT16, {1, 2, 3, 1}, 2*kMin, 2*kMax},
+                        {TensorType_INT16, {}, 8*kMin, 8*kMax},
+                        ActivationFunctionType_NONE);
+  m.QuantizeAndPopulate<int16_t>(m.input1(), {-1.8, 0.2, 0.9, 1.7, 0.1, -1.95});
+  m.QuantizeAndPopulate<int16_t>(m.input2(), {3.6, -3.4, 3.9, 0.8, -1.0, -3.95});
+  m.Invoke();
+
+  const float kQuantizedToleranceInt16Scaled =
+    6.0 * kQuantizedStepInt16 + kQuantizedStepInt16 * kQuantizedStepInt16;
+
+  EXPECT_THAT(m.GetDequantizedOutputInt16(),
+              ElementsAreArray(ArrayFloatNear({-6.48, -0.68, 3.51, 1.36, -0.1, 7.7025},
+                                              kQuantizedToleranceInt16Scaled)));
+}
+
 template <TensorType tensor_type, typename integer_dtype>
 void NoActivationInt16With8BitOutput() {
   const float kMinInt16 = -1.f;


### PR DESCRIPTION
This PR is one of steps to extend 8-bit quantization to support symmetric 16-bit activations.

Each activation is of type int16 and symmetric around zero. The weight tensor precision remains at 8-bit signed values. The bias is set to int64 precision.

In this PR we introduce implementation and tests for MUL kernel reference function.
The specification of this operator:

MUL 
  Input 0: 
    data_type  : int16 
    range      : [-32768, 32767] 
    granularity: per-tensor, zero_point=0 
  Input 1: 
    data_type  : int16 
    range      : [-32768, 32767] 
    granularity: per-tensor, zero_point=0 
  Output 0: 
    data_type  : int16 
    range      : [-32768, 32767] 
    granularity: per-tensor, zero_point=0 
 32767]
    granularity: per-tensor, zero_point=0
