### PR TITLE
undef TranslateName for c file_system as well

### DIFF
--- a/tensorflow/c/experimental/filesystem/modular_filesystem_test.cc
+++ b/tensorflow/c/experimental/filesystem/modular_filesystem_test.cc
@@ -36,6 +36,7 @@ limitations under the License.
 #undef LoadLibrary
 #undef CopyFile
 #undef DeleteFile
+#undef TranslateName
 #endif  // defined(PLATFORM_WINDOWS)
 
 // The tests defined here test the compliance of filesystems with the API


### PR DESCRIPTION
This PR applies PR #35947 to C verson of the file_system, to undef TranslateName.

TranslateName under Windows are defined as `TranslateNameA` or `TranslateNameW` and it might be enabled depending on Visual Studio's configurations. It would be safe to undef TranslateName when possible.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>