### PR TITLE
Pin ipykernel==5.1.1 in Dockerfiles

### DIFF
--- a/tensorflow/tools/dockerfiles/dockerfiles/cpu-jupyter.Dockerfile
+++ b/tensorflow/tools/dockerfiles/dockerfiles/cpu-jupyter.Dockerfile
@@ -58,7 +58,8 @@ RUN ${PIP} install ${TF_PACKAGE}${TF_PACKAGE_VERSION:+==${TF_PACKAGE_VERSION}}
 COPY bashrc /etc/bash.bashrc
 RUN chmod a+rwx /etc/bash.bashrc
 
-RUN ${PIP} install jupyter matplotlib
+# https://github.com/ipython/ipykernel/issues/422
+RUN ${PIP} install jupyter ipykernel==5.1.1 nbconvert==4.4.0 matplotlib
 RUN ${PIP} install jupyter_http_over_ws
 RUN jupyter serverextension enable --py jupyter_http_over_ws
 

--- a/tensorflow/tools/dockerfiles/dockerfiles/devel-cpu-jupyter.Dockerfile
+++ b/tensorflow/tools/dockerfiles/dockerfiles/devel-cpu-jupyter.Dockerfile
@@ -110,7 +110,8 @@ RUN mkdir /bazel && \
 COPY bashrc /etc/bash.bashrc
 RUN chmod a+rwx /etc/bash.bashrc
 
-RUN ${PIP} install jupyter matplotlib
+# https://github.com/ipython/ipykernel/issues/422
+RUN ${PIP} install jupyter ipykernel==5.1.1 nbconvert==4.4.0 matplotlib
 RUN ${PIP} install jupyter_http_over_ws
 RUN jupyter serverextension enable --py jupyter_http_over_ws
 

--- a/tensorflow/tools/dockerfiles/dockerfiles/devel-gpu-jupyter.Dockerfile
+++ b/tensorflow/tools/dockerfiles/dockerfiles/devel-gpu-jupyter.Dockerfile
@@ -152,7 +152,8 @@ RUN mkdir /bazel && \
 COPY bashrc /etc/bash.bashrc
 RUN chmod a+rwx /etc/bash.bashrc
 
-RUN ${PIP} install jupyter matplotlib
+# https://github.com/ipython/ipykernel/issues/422
+RUN ${PIP} install jupyter ipykernel==5.1.1 nbconvert==4.4.0 matplotlib
 RUN ${PIP} install jupyter_http_over_ws
 RUN jupyter serverextension enable --py jupyter_http_over_ws
 

--- a/tensorflow/tools/dockerfiles/dockerfiles/gpu-jupyter.Dockerfile
+++ b/tensorflow/tools/dockerfiles/dockerfiles/gpu-jupyter.Dockerfile
@@ -107,7 +107,8 @@ RUN ${PIP} install ${TF_PACKAGE}${TF_PACKAGE_VERSION:+==${TF_PACKAGE_VERSION}}
 COPY bashrc /etc/bash.bashrc
 RUN chmod a+rwx /etc/bash.bashrc
 
-RUN ${PIP} install jupyter matplotlib
+# https://github.com/ipython/ipykernel/issues/422
+RUN ${PIP} install jupyter ipykernel==5.1.1 nbconvert==4.4.0 matplotlib
 RUN ${PIP} install jupyter_http_over_ws
 RUN jupyter serverextension enable --py jupyter_http_over_ws
 

--- a/tensorflow/tools/dockerfiles/dockerfiles/mkl_horovod/devel-horovod-jupyter.Dockerfile
+++ b/tensorflow/tools/dockerfiles/dockerfiles/mkl_horovod/devel-horovod-jupyter.Dockerfile
@@ -99,7 +99,7 @@ RUN ${PIP} --no-cache-dir install \
     enum34
 
 # Install bazel
-ARG BAZEL_VERSION=1.1.0
+ARG BAZEL_VERSION=1.2.1
 RUN mkdir /bazel && \
     wget -O /bazel/installer.sh "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh" && \
     wget -O /bazel/LICENSE.txt "https://raw.githubusercontent.com/bazelbuild/bazel/master/LICENSE" && \
@@ -162,7 +162,8 @@ RUN test "${CHECKOUT_HOROVOD_SRC}" -eq 1 && git clone --recursive https://github
 COPY bashrc /etc/bash.bashrc
 RUN chmod a+rwx /etc/bash.bashrc
 
-RUN ${PIP} install jupyter matplotlib
+# https://github.com/ipython/ipykernel/issues/422
+RUN ${PIP} install jupyter ipykernel==5.1.1 nbconvert==4.4.0 matplotlib
 RUN ${PIP} install jupyter_http_over_ws
 RUN jupyter serverextension enable --py jupyter_http_over_ws
 

--- a/tensorflow/tools/dockerfiles/dockerfiles/mkl_horovod/devel-horovod.Dockerfile
+++ b/tensorflow/tools/dockerfiles/dockerfiles/mkl_horovod/devel-horovod.Dockerfile
@@ -99,7 +99,7 @@ RUN ${PIP} --no-cache-dir install \
     enum34
 
 # Install bazel
-ARG BAZEL_VERSION=1.1.0
+ARG BAZEL_VERSION=1.2.1
 RUN mkdir /bazel && \
     wget -O /bazel/installer.sh "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh" && \
     wget -O /bazel/LICENSE.txt "https://raw.githubusercontent.com/bazelbuild/bazel/master/LICENSE" && \

--- a/tensorflow/tools/dockerfiles/dockerfiles/mkl_horovod/horovod-jupyter.Dockerfile
+++ b/tensorflow/tools/dockerfiles/dockerfiles/mkl_horovod/horovod-jupyter.Dockerfile
@@ -110,7 +110,8 @@ RUN ${PIP} install --no-cache-dir horovod==${HOROVOD_VERSION}
 COPY bashrc /etc/bash.bashrc
 RUN chmod a+rwx /etc/bash.bashrc
 
-RUN ${PIP} install jupyter matplotlib
+# https://github.com/ipython/ipykernel/issues/422
+RUN ${PIP} install jupyter ipykernel==5.1.1 nbconvert==4.4.0 matplotlib
 RUN ${PIP} install jupyter_http_over_ws
 RUN jupyter serverextension enable --py jupyter_http_over_ws
 

--- a/tensorflow/tools/dockerfiles/dockerfiles/ppc64le/cpu-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/tools/dockerfiles/dockerfiles/ppc64le/cpu-ppc64le-jupyter.Dockerfile
@@ -76,7 +76,8 @@ RUN if [ ${TF_PACKAGE} = tensorflow-gpu ]; then \
 COPY bashrc /etc/bash.bashrc
 RUN chmod a+rwx /etc/bash.bashrc
 
-RUN ${PIP} install jupyter matplotlib
+# https://github.com/ipython/ipykernel/issues/422
+RUN ${PIP} install jupyter ipykernel==5.1.1 nbconvert==4.4.0 matplotlib
 RUN ${PIP} install jupyter_http_over_ws
 RUN jupyter serverextension enable --py jupyter_http_over_ws
 

--- a/tensorflow/tools/dockerfiles/dockerfiles/ppc64le/devel-cpu-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/tools/dockerfiles/dockerfiles/ppc64le/devel-cpu-ppc64le-jupyter.Dockerfile
@@ -111,7 +111,8 @@ RUN mkdir /bazel && \
 COPY bashrc /etc/bash.bashrc
 RUN chmod a+rwx /etc/bash.bashrc
 
-RUN ${PIP} install jupyter matplotlib
+# https://github.com/ipython/ipykernel/issues/422
+RUN ${PIP} install jupyter ipykernel==5.1.1 nbconvert==4.4.0 matplotlib
 RUN ${PIP} install jupyter_http_over_ws
 RUN jupyter serverextension enable --py jupyter_http_over_ws
 

--- a/tensorflow/tools/dockerfiles/dockerfiles/ppc64le/devel-gpu-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/tools/dockerfiles/dockerfiles/ppc64le/devel-gpu-ppc64le-jupyter.Dockerfile
@@ -153,7 +153,8 @@ RUN mkdir /bazel && \
 COPY bashrc /etc/bash.bashrc
 RUN chmod a+rwx /etc/bash.bashrc
 
-RUN ${PIP} install jupyter matplotlib
+# https://github.com/ipython/ipykernel/issues/422
+RUN ${PIP} install jupyter ipykernel==5.1.1 nbconvert==4.4.0 matplotlib
 RUN ${PIP} install jupyter_http_over_ws
 RUN jupyter serverextension enable --py jupyter_http_over_ws
 

--- a/tensorflow/tools/dockerfiles/dockerfiles/ppc64le/gpu-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/tools/dockerfiles/dockerfiles/ppc64le/gpu-ppc64le-jupyter.Dockerfile
@@ -125,7 +125,8 @@ RUN if [ ${TF_PACKAGE} = tensorflow-gpu ]; then \
 COPY bashrc /etc/bash.bashrc
 RUN chmod a+rwx /etc/bash.bashrc
 
-RUN ${PIP} install jupyter matplotlib
+# https://github.com/ipython/ipykernel/issues/422
+RUN ${PIP} install jupyter ipykernel==5.1.1 nbconvert==4.4.0 matplotlib
 RUN ${PIP} install jupyter_http_over_ws
 RUN jupyter serverextension enable --py jupyter_http_over_ws
 

--- a/tensorflow/tools/dockerfiles/partials/jupyter.partial.Dockerfile
+++ b/tensorflow/tools/dockerfiles/partials/jupyter.partial.Dockerfile
@@ -1,4 +1,5 @@
-RUN ${PIP} install jupyter matplotlib
+# https://github.com/ipython/ipykernel/issues/422
+RUN ${PIP} install jupyter ipykernel==5.1.1 nbconvert==4.4.0 matplotlib
 RUN ${PIP} install jupyter_http_over_ws
 RUN jupyter serverextension enable --py jupyter_http_over_ws
 


### PR DESCRIPTION
The latest ipykernel has a bug, see https://github.com/ipython/ipykernel/issues/422.
This change pins ipykernel in the Jupyter Dockerfiles to avoid the error
when executing notebooks, e.g. this raises the error:

```
git clone http://github.com/tensorflow/docs /tmp/docs
cd /tmp/docs
docker run -it --rm -v $PWD:/tmp -w /tmp tensorflow/tensorflow:latest-py3-jupyter \
  jupyter nbconvert --to notebook --execute ./site/en/tutorials/quickstart/beginner.ipynb
```

It goes away with this change:

```
docker build . -f ./dockerfiles/cpu-jupyter.Dockerfile -t test-jupyter \
    --build-arg USE_PYTHON_3_NOT_2=1
git clone http://github.com/tensorflow/docs /tmp/docs
cd /tmp/docs
docker run -it --rm -v $PWD:/tmp -w /tmp test-jupyter \
  jupyter nbconvert --to notebook --execute ./site/en/tutorials/quickstart/beginner.ipynb
```