### PR TITLE
[ROCm][XLA] Adding address space cast in ir_emitter

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/ir_emitter.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter.cc
@@ -50,6 +50,24 @@ limitations under the License.
 #include "tensorflow/compiler/xla/window_util.h"
 #include "tensorflow/core/lib/core/errors.h"
 
+namespace {
+
+static llvm::Value* MayAddrSpaceCastArg(llvm::Value* arg,
+                                        llvm::IRBuilder<>& builder) {
+  llvm::Type* arg_type = arg->getType();
+  CHECK_EQ(true, arg_type->isPointerTy());
+  if (arg_type->getPointerAddressSpace() != 0) {
+    llvm::Type* generic_arg_type =
+        arg_type->getPointerElementType()->getPointerTo(0);
+    llvm::Value* addrspacecast_arg =
+        builder.CreateAddrSpaceCast(arg, generic_arg_type);
+    return addrspacecast_arg;
+  }
+  return arg;
+}
+
+}  // namespace
+
 namespace xla {
 
 using llvm_ir::IrName;
@@ -164,8 +182,19 @@ Status IrEmitter::EmitCallToNestedComputation(
     emitted_function = ir_emitter_nested.GetEmittedFunction();
   }
 
-  std::vector<llvm::Value*> arguments(operands.begin(), operands.end());
-  arguments.push_back(output);
+  // For AMDGPU target, may need to addrspacecast alloca variables from
+  // addrspace 5 to addrspace 0
+  std::vector<llvm::Value*> arguments;
+  for (auto& arg : operands) {
+    llvm::Value* casted_arg = MayAddrSpaceCastArg(arg, b_);
+    arguments.push_back(casted_arg);
+  }
+
+  llvm::Value* casted_output = MayAddrSpaceCastArg(output, b_);
+  arguments.push_back(casted_output);
+
+  // temp buffer base is always in addrspace 0 so it's not required to
+  // do addrspacecast
   arguments.push_back(bindings_.GetTempBufferBase());
   Call(emitted_function, arguments);
 

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter.cc
@@ -50,23 +50,22 @@ limitations under the License.
 #include "tensorflow/compiler/xla/window_util.h"
 #include "tensorflow/core/lib/core/errors.h"
 
-namespace {
-
-static llvm::Value* MayAddrSpaceCastArg(llvm::Value* arg,
-                                        llvm::IRBuilder<>& builder) {
+// Convenient function to cast the provided llvm::Value* using IRBuilder
+// to default address space. This is useful in particular for generating
+// IR for AMDGPU target, as its kernel variables are in address space 5
+// instead of the default address space.
+static llvm::Value* AddrCastToDefault(llvm::Value* arg, llvm::IRBuilder<>& b) {
   llvm::Type* arg_type = arg->getType();
-  CHECK_EQ(true, arg_type->isPointerTy());
+  CHECK(arg_type->isPointerTy());
   if (arg_type->getPointerAddressSpace() != 0) {
     llvm::Type* generic_arg_type =
         arg_type->getPointerElementType()->getPointerTo(0);
     llvm::Value* addrspacecast_arg =
-        builder.CreateAddrSpaceCast(arg, generic_arg_type);
+        b.CreateAddrSpaceCast(arg, generic_arg_type);
     return addrspacecast_arg;
   }
   return arg;
 }
-
-}  // namespace
 
 namespace xla {
 
@@ -182,19 +181,19 @@ Status IrEmitter::EmitCallToNestedComputation(
     emitted_function = ir_emitter_nested.GetEmittedFunction();
   }
 
-  // For AMDGPU target, may need to addrspacecast alloca variables from
-  // addrspace 5 to addrspace 0
+  // Operands are in default address space for non-AMDGPU target.
+  // However for AMDGPU target, addrspacecast alloca variables from
+  // addrspace 5 to addrspace 0 is needed.
   std::vector<llvm::Value*> arguments;
-  for (auto& arg : operands) {
-    llvm::Value* casted_arg = MayAddrSpaceCastArg(arg, b_);
-    arguments.push_back(casted_arg);
-  }
+  absl::c_transform(
+      operands, std::back_inserter(arguments),
+      [this](llvm::Value* arg) { return AddrCastToDefault(arg, b_); });
 
-  llvm::Value* casted_output = MayAddrSpaceCastArg(output, b_);
+  llvm::Value* casted_output = AddrCastToDefault(output, b_);
   arguments.push_back(casted_output);
 
-  // temp buffer base is always in addrspace 0 so it's not required to
-  // do addrspacecast
+  // It is not required to do address space cast because TempBufferBase
+  // is always in addrspace 0.
   arguments.push_back(bindings_.GetTempBufferBase());
   Call(emitted_function, arguments);
 

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -1497,7 +1497,7 @@ std::unique_ptr<KernelThunk> IrEmitterUnnested::BuildKernelThunk(
     llvm::Type* int8_double_pointer =
         llvm::PointerType::get(b_.getInt8PtrTy(), /*AddressSpace=*/0);
     for (int64 idx : gte_index) {
-      loc = BitCast(loc, int8_double_pointer);
+      loc = PointerBitCastOrAddrSpaceCast(loc, int8_double_pointer);
       loc = Load(InBoundsGEP(loc, {b_.getInt64(idx)}));
     }
 
@@ -2150,7 +2150,8 @@ void IrEmitterUnnested::EmitFullWarpShuffleDownLoopForReduce(
     llvm::Type* shuffled_value_type =
         element_type->isStructTy() ? b_.getIntNTy(bit_width) : element_type;
     auto convert_pointer_for_shuffle = [&](llvm::Value* ptr) {
-      return BitCast(ptr, shuffled_value_type->getPointerTo());
+      return PointerBitCastOrAddrSpaceCast(
+            ptr, shuffled_value_type->getPointerTo());
     };
     llvm::Value* partial_result =
         Load(convert_pointer_for_shuffle(partial_result_address),

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -1497,7 +1497,7 @@ std::unique_ptr<KernelThunk> IrEmitterUnnested::BuildKernelThunk(
     llvm::Type* int8_double_pointer =
         llvm::PointerType::get(b_.getInt8PtrTy(), /*AddressSpace=*/0);
     for (int64 idx : gte_index) {
-      loc = PointerBitCastOrAddrSpaceCast(loc, int8_double_pointer);
+      loc = b_.CreatePointerBitCastOrAddrSpaceCast(loc, int8_double_pointer);
       loc = Load(InBoundsGEP(loc, {b_.getInt64(idx)}));
     }
 
@@ -2150,7 +2150,7 @@ void IrEmitterUnnested::EmitFullWarpShuffleDownLoopForReduce(
     llvm::Type* shuffled_value_type =
         element_type->isStructTy() ? b_.getIntNTy(bit_width) : element_type;
     auto convert_pointer_for_shuffle = [&](llvm::Value* ptr) {
-      return PointerBitCastOrAddrSpaceCast(
+      return b_.CreatePointerBitCastOrAddrSpaceCast(
             ptr, shuffled_value_type->getPointerTo());
     };
     llvm::Value* partial_result =

--- a/tensorflow/compiler/xla/service/llvm_ir/ir_builder_mixin.h
+++ b/tensorflow/compiler/xla/service/llvm_ir/ir_builder_mixin.h
@@ -75,12 +75,6 @@ class IrBuilderMixin {
   }
 
   template <class... Args>
-  llvm::Value* PointerBitCastOrAddrSpaceCast(Args&&... args) {
-    return mixin_builder()->CreatePointerBitCastOrAddrSpaceCast(
-        std::forward<Args>(args)...);
-  }
-
-  template <class... Args>
   llvm::Value* Br(Args&&... args) {
     return mixin_builder()->CreateBr(std::forward<Args>(args)...);
   }

--- a/tensorflow/compiler/xla/service/llvm_ir/ir_builder_mixin.h
+++ b/tensorflow/compiler/xla/service/llvm_ir/ir_builder_mixin.h
@@ -75,6 +75,12 @@ class IrBuilderMixin {
   }
 
   template <class... Args>
+  llvm::Value* PointerBitCastOrAddrSpaceCast(Args&&... args) {
+    return mixin_builder()->CreatePointerBitCastOrAddrSpaceCast(
+        std::forward<Args>(args)...);
+  }
+
+  template <class... Args>
   llvm::Value* Br(Args&&... args) {
     return mixin_builder()->CreateBr(std::forward<Args>(args)...);
   }


### PR DESCRIPTION
This is a follow-up to #35881 

----------

Background: Kernel variables in Nvdia/OpenCL side are represented as address space 0, whereas in AMDGPU side is represented as address space 5.

This PR replaced `CreateBitCast()` to `CreatePointerBitCastOrAddrSpaceCast()`, aiming to fix AMDGPU address space. Without this change, the generated llvm IR will have a mismatch in address space, causing widespread failures in unit tests. E,g:

> Invalid bitcast
   %add.typed = bitcast float addrspace(5)* %add.raw to float*

@whchung @cheshire 