### PR TITLE
[Intel Mkl] Updating MKL implementation of Eager API.

### DIFF
--- a/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite.cc
+++ b/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite.cc
@@ -114,7 +114,8 @@ Status MklEagerOpRewrite::SetupNewOp(
     std::unique_ptr<EagerOperation>* new_mkl_op) {
   bool is_remote = false;
   new_mkl_op->reset(new tensorflow::EagerOperation(&orig_op->EagerContext()));
-  new_mkl_op->get()->Reset(mkl_op_name.c_str(), nullptr, is_remote, nullptr);
+  TF_RETURN_IF_ERROR(new_mkl_op->get()->Reset(mkl_op_name.c_str(),
+                                              nullptr, is_remote, nullptr));
 
   int num_inputs = orig_op->Inputs().size();
   // Add all inputs to the new op.

--- a/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite.cc
+++ b/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite.cc
@@ -112,13 +112,9 @@ Status MklEagerOpRewrite::Run(
 Status MklEagerOpRewrite::SetupNewOp(
     EagerOperation* orig_op, const string mkl_op_name,
     std::unique_ptr<EagerOperation>* new_mkl_op) {
-  const tensorflow::AttrTypeMap* types;
-  bool is_function = false;
-  TF_RETURN_IF_ERROR(
-      tensorflow::AttrTypeMapForOp(mkl_op_name.c_str(), &types, &is_function));
-  EagerContext* ctx = orig_op->EagerContext();
-  new_mkl_op->reset(new tensorflow::EagerOperation(ctx, mkl_op_name.c_str(),
-                                                   is_function, types));
+  bool is_remote = false;
+  new_mkl_op->reset(new tensorflow::EagerOperation(&orig_op->EagerContext()));
+  new_mkl_op->get()->Reset(mkl_op_name.c_str(), nullptr, is_remote, nullptr);
 
   int num_inputs = orig_op->Inputs().size();
   // Add all inputs to the new op.

--- a/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite_test.cc
+++ b/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite_test.cc
@@ -45,13 +45,9 @@ class EagerOpRewriteTest {
             GetDefaultCustomKernelCreator()));
 
     EagerExecutor executor_(false);
-    const tensorflow::AttrTypeMap* types;
-    bool is_function = false;
-    EXPECT_EQ(Status::OK(), tensorflow::AttrTypeMapForOp(op_name.c_str(),
-                                                         &types, &is_function));
     std::unique_ptr<tensorflow::EagerOperation> op(
-        new tensorflow::EagerOperation(eager_ctx.get(), op_name.c_str(),
-                                       is_function, types, &executor_));
+        new tensorflow::EagerOperation(eager_ctx.get()));
+    op.get()->Reset(op_name.c_str(), nullptr, false, &executor_);
     return op;
   }
 

--- a/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite_test.cc
+++ b/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite_test.cc
@@ -47,7 +47,8 @@ class EagerOpRewriteTest {
     EagerExecutor executor_(false);
     std::unique_ptr<tensorflow::EagerOperation> op(
         new tensorflow::EagerOperation(eager_ctx.get()));
-    op.get()->Reset(op_name.c_str(), nullptr, false, &executor_);
+    EXPECT_EQ(Status::OK(),
+              op.get()->Reset(op_name.c_str(), nullptr, false, &executor_));
     return op;
   }
 


### PR DESCRIPTION
Changes in Eager API broke the MKL builds (See below). This fixes the problem.

```[0m[91mERROR: /tensorflow/tensorflow/core/common_runtime/eager/BUILD:352:1: C++ compilation of rule '//tensorflow/core/common_runtime/eager:mkl_eager_op_rewrite' failed (Exit 1)
[0m[91mtensorflow/core/common_runtime/eager/mkl_eager_op_rewrite.cc: In static member function 'static tensorflow::Status tensorflow::MklEagerOpRewrite::SetupNewOp(tensorflow::EagerOperation*, std::string, std::unique_ptr<tensorflow::EagerOperation>*)':
tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite.cc:119:45: error: cannot convert 'tensorflow::EagerContext' to 'tensorflow::EagerContext*' in initialization
   EagerContext* ctx = orig_op->EagerContext();
                                             ^
tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite.cc:121:70: error: no matching function for call to 'tensorflow::EagerOperation::EagerOperation(tensorflow::EagerContext*&, const char*, bool&, const AttrTypeMap*&)'
                                                    is_function, types));
                                                                      ^
In file included from ./tensorflow/core/common_runtime/eager/eager_op_rewrite_registry.h:21:0,
                 from tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite.cc:18:
./tensorflow/core/common_runtime/eager/eager_operation.h:31:12: note: candidate: tensorflow::EagerOperation::EagerOperation(tensorflow::EagerContext*)
   explicit EagerOperation(tensorflow::EagerContext* ctx) : ctx_(*ctx) {}
            ^~~~~~~~~~~~~~
./tensorflow/core/common_runtime/eager/eager_operation.h:31:12: note:   candidate expects 1 argument, 4 provided
./tensorflow/core/common_runtime/eager/eager_operation.h:29:7: note: candidate: tensorflow::EagerOperation::EagerOperation(const tensorflow::EagerOperation&)
 class EagerOperation {
       ^~~~~~~~~~~~~~
./tensorflow/core/common_runtime/eager/eager_operation.h:29:7: note:   candidate expects 1 argument, 4 provided```