### PR TITLE
Riscv 32 mcu

### DIFF
--- a/tensorflow/lite/micro/arduino/abi.cc
+++ b/tensorflow/lite/micro/arduino/abi.cc
@@ -1,0 +1,16 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+void* __dso_handle;

--- a/tensorflow/lite/micro/examples/hello_world/riscv32_mcu/Makefile.inc
+++ b/tensorflow/lite/micro/examples/hello_world/riscv32_mcu/Makefile.inc
@@ -11,7 +11,8 @@ ifeq ($(TARGET), riscv32_mcu)
     $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/env/freedom-e300-hifive1/init.c
 
   HELLO_WORLD_TEST_SRCS += $(MICRO_FE310_LIBWRAP_SRCS) $(MICRO_FE310_BSP_ENV_SRCS)
-  HELLO_WORLD_SRCS += $(MICRO_FE310_LIBWRAP_SRCS) $(MICRO_FE310_BSP_ENV_SRCS)
+  HELLO_WORLD_SRCS += $(MICRO_FE310_LIBWRAP_SRCS) $(MICRO_FE310_BSP_ENV_SRCS) \
+    tensorflow/lite/micro/arduino/abi.cc
 
   LIBWRAP_SYMS := malloc free \
                   open lseek read write fstat stat close link unlink \

--- a/tensorflow/lite/micro/examples/hello_world/riscv32_mcu/Makefile.inc
+++ b/tensorflow/lite/micro/examples/hello_world/riscv32_mcu/Makefile.inc
@@ -1,0 +1,25 @@
+ifeq ($(TARGET), riscv32_mcu)
+  # Wrap functions
+  MICRO_FE310_LIBWRAP_SRCS := \
+    $(wildcard $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/libwrap/sys/*.c) \
+    $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/libwrap/misc/write_hex.c \
+    $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/libwrap/stdlib/malloc.c
+
+  MICRO_FE310_BSP_ENV_SRCS := \
+    $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/env/start.S \
+    $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/env/entry.S \
+    $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/env/freedom-e300-hifive1/init.c
+
+  HELLO_WORLD_TEST_SRCS += $(MICRO_FE310_LIBWRAP_SRCS) $(MICRO_FE310_BSP_ENV_SRCS)
+  HELLO_WORLD_SRCS += $(MICRO_FE310_LIBWRAP_SRCS) $(MICRO_FE310_BSP_ENV_SRCS)
+
+  LIBWRAP_SYMS := malloc free \
+                  open lseek read write fstat stat close link unlink \
+                  execve fork getpid kill wait \
+                  isatty times sbrk _exit puts
+
+  LDFLAGS += $(foreach s,$(LIBWRAP_SYMS),-Wl,--wrap=$(s))
+  LDFLAGS += $(foreach s,$(LIBWRAP_SYMS),-Wl,--wrap=_$(s))
+  LDFLAGS += -L. -Wl,--start-group -lc -Wl,--end-group
+endif
+

--- a/tensorflow/lite/micro/examples/magic_wand/riscv32_mcu/Makefile.inc
+++ b/tensorflow/lite/micro/examples/magic_wand/riscv32_mcu/Makefile.inc
@@ -1,0 +1,25 @@
+ifeq ($(TARGET), riscv32_mcu)
+  # Wrap functions
+  MICRO_FE310_LIBWRAP_SRCS := \
+    $(wildcard $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/libwrap/sys/*.c) \
+    $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/libwrap/misc/write_hex.c \
+    $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/libwrap/stdlib/malloc.c
+
+  MICRO_FE310_BSP_ENV_SRCS := \
+    $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/env/start.S \
+    $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/env/entry.S \
+    $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/env/freedom-e300-hifive1/init.c
+
+  magic_wand_TEST_SRCS += $(MICRO_FE310_LIBWRAP_SRCS) $(MICRO_FE310_BSP_ENV_SRCS)
+  magic_wand_SRCS += $(MICRO_FE310_LIBWRAP_SRCS) $(MICRO_FE310_BSP_ENV_SRCS)
+
+  LIBWRAP_SYMS := malloc free \
+                  open lseek read write fstat stat close link unlink \
+                  execve fork getpid kill wait \
+                  isatty times sbrk _exit puts
+
+  LDFLAGS += $(foreach s,$(LIBWRAP_SYMS),-Wl,--wrap=$(s))
+  LDFLAGS += $(foreach s,$(LIBWRAP_SYMS),-Wl,--wrap=_$(s))
+  LDFLAGS += -L. -Wl,--start-group -lc -Wl,--end-group
+endif
+

--- a/tensorflow/lite/micro/examples/magic_wand/riscv32_mcu/Makefile.inc
+++ b/tensorflow/lite/micro/examples/magic_wand/riscv32_mcu/Makefile.inc
@@ -10,8 +10,10 @@ ifeq ($(TARGET), riscv32_mcu)
     $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/env/entry.S \
     $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/env/freedom-e300-hifive1/init.c
 
-  magic_wand_TEST_SRCS += $(MICRO_FE310_LIBWRAP_SRCS) $(MICRO_FE310_BSP_ENV_SRCS)
-  magic_wand_SRCS += $(MICRO_FE310_LIBWRAP_SRCS) $(MICRO_FE310_BSP_ENV_SRCS)
+  magic_wand_TEST_SRCS += $(MICRO_FE310_LIBWRAP_SRCS) $(MICRO_FE310_BSP_ENV_SRCS) \
+    tensorflow/lite/micro/arduino/abi.cc
+  magic_wand_SRCS += $(MICRO_FE310_LIBWRAP_SRCS) $(MICRO_FE310_BSP_ENV_SRCS) \
+    tensorflow/lite/micro/arduino/abi.cc
 
   LIBWRAP_SYMS := malloc free \
                   open lseek read write fstat stat close link unlink \

--- a/tensorflow/lite/micro/examples/micro_speech/riscv32_mcu/Makefile.inc
+++ b/tensorflow/lite/micro/examples/micro_speech/riscv32_mcu/Makefile.inc
@@ -1,0 +1,24 @@
+ifeq ($(TARGET), riscv32_mcu)
+  # Wrap functions
+  MICRO_FE310_LIBWRAP_SRCS := \
+    $(wildcard $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/libwrap/sys/*.c) \
+    $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/libwrap/misc/write_hex.c \
+    $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/libwrap/stdlib/malloc.c
+
+  MICRO_FE310_BSP_ENV_SRCS := \
+    $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/env/start.S \
+    $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/env/entry.S \
+    $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/env/freedom-e300-hifive1/init.c
+
+  MICRO_SPEECH_TEST_SRCS += $(MICRO_FE310_LIBWRAP_SRCS) $(MICRO_FE310_BSP_ENV_SRCS)
+  MICRO_SPEECH_SRCS += $(MICRO_FE310_LIBWRAP_SRCS) $(MICRO_FE310_BSP_ENV_SRCS)
+
+  LIBWRAP_SYMS := malloc free \
+                  open lseek read write fstat stat close link unlink \
+                  execve fork getpid kill wait \
+                  isatty times sbrk _exit puts
+
+  LDFLAGS += $(foreach s,$(LIBWRAP_SYMS),-Wl,--wrap=$(s))
+  LDFLAGS += $(foreach s,$(LIBWRAP_SYMS),-Wl,--wrap=_$(s))
+  LDFLAGS += -L. -Wl,--start-group -lc -Wl,--end-group
+endif

--- a/tensorflow/lite/micro/examples/micro_speech/riscv32_mcu/Makefile.inc
+++ b/tensorflow/lite/micro/examples/micro_speech/riscv32_mcu/Makefile.inc
@@ -10,8 +10,10 @@ ifeq ($(TARGET), riscv32_mcu)
     $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/env/entry.S \
     $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/env/freedom-e300-hifive1/init.c
 
-  MICRO_SPEECH_TEST_SRCS += $(MICRO_FE310_LIBWRAP_SRCS) $(MICRO_FE310_BSP_ENV_SRCS)
-  MICRO_SPEECH_SRCS += $(MICRO_FE310_LIBWRAP_SRCS) $(MICRO_FE310_BSP_ENV_SRCS)
+  MICRO_SPEECH_TEST_SRCS += $(MICRO_FE310_LIBWRAP_SRCS) $(MICRO_FE310_BSP_ENV_SRCS) \
+    tensorflow/lite/micro/arduino/abi.cc
+  MICRO_SPEECH_SRCS += $(MICRO_FE310_LIBWRAP_SRCS) $(MICRO_FE310_BSP_ENV_SRCS) \
+    tensorflow/lite/micro/arduino/abi.cc
 
   LIBWRAP_SYMS := malloc free \
                   open lseek read write fstat stat close link unlink \

--- a/tensorflow/lite/micro/examples/person_detection/riscv32_mcu/Makefile.inc
+++ b/tensorflow/lite/micro/examples/person_detection/riscv32_mcu/Makefile.inc
@@ -10,8 +10,10 @@ ifeq ($(TARGET), riscv32_mcu)
     $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/env/entry.S \
     $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/env/freedom-e300-hifive1/init.c
 
-  person_detection_TEST_HDRS += $(MICRO_FE310_LIBWRAP_SRCS) $(MICRO_FE310_BSP_ENV_SRCS)
-  person_detection_SRCS += $(MICRO_FE310_LIBWRAP_SRCS) $(MICRO_FE310_BSP_ENV_SRCS)
+  person_detection_TEST_HDRS += $(MICRO_FE310_LIBWRAP_SRCS) $(MICRO_FE310_BSP_ENV_SRCS) \
+    tensorflow/lite/micro/arduino/abi.cc
+  person_detection_SRCS += $(MICRO_FE310_LIBWRAP_SRCS) $(MICRO_FE310_BSP_ENV_SRCS) \
+    tensorflow/lite/micro/arduino/abi.cc
 
   LIBWRAP_SYMS := malloc free \
                   open lseek read write fstat stat close link unlink \

--- a/tensorflow/lite/micro/examples/person_detection/riscv32_mcu/Makefile.inc
+++ b/tensorflow/lite/micro/examples/person_detection/riscv32_mcu/Makefile.inc
@@ -1,0 +1,24 @@
+ifeq ($(TARGET), riscv32_mcu)
+  # Wrap functions
+  MICRO_FE310_LIBWRAP_SRCS := \
+    $(wildcard $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/libwrap/sys/*.c) \
+    $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/libwrap/misc/write_hex.c \
+    $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/libwrap/stdlib/malloc.c
+
+  MICRO_FE310_BSP_ENV_SRCS := \
+    $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/env/start.S \
+    $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/env/entry.S \
+    $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/env/freedom-e300-hifive1/init.c
+
+  person_detection_TEST_HDRS += $(MICRO_FE310_LIBWRAP_SRCS) $(MICRO_FE310_BSP_ENV_SRCS)
+  person_detection_SRCS += $(MICRO_FE310_LIBWRAP_SRCS) $(MICRO_FE310_BSP_ENV_SRCS)
+
+  LIBWRAP_SYMS := malloc free \
+                  open lseek read write fstat stat close link unlink \
+                  execve fork getpid kill wait \
+                  isatty times sbrk _exit puts
+
+  LDFLAGS += $(foreach s,$(LIBWRAP_SYMS),-Wl,--wrap=$(s))
+  LDFLAGS += $(foreach s,$(LIBWRAP_SYMS),-Wl,--wrap=_$(s))
+  LDFLAGS += -L. -Wl,--start-group -lc -Wl,--end-group
+endif

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -239,6 +239,10 @@ CXX := $(CC_PREFIX)${TARGET_TOOLCHAIN_PREFIX}${CXX_TOOL}
 CC := $(CC_PREFIX)${TARGET_TOOLCHAIN_PREFIX}${CC_TOOL}
 AR := $(CC_PREFIX)${TARGET_TOOLCHAIN_PREFIX}${AR_TOOL}
 
+# The default Makefile target(all) must appear before any target,
+# which is compiled if there's no command-line arguments.
+all: $(MICROLITE_LIB_PATH)
+
 # Load the examples.
 include $(wildcard tensorflow/lite/micro/examples/*/Makefile.inc)
 
@@ -267,9 +271,6 @@ $(OBJDIR)%.o: %.c $(THIRD_PARTY_TARGETS)
 $(OBJDIR)%.o: %.S $(THIRD_PARTY_TARGETS)
 	@mkdir -p $(dir $@)
 	$(CC) $(CCFLAGS) $(INCLUDES) -c $< -o $@
-
-# The target that's compiled if there's no command-line arguments.
-all: $(MICROLITE_LIB_PATH)
 
 microlite: $(MICROLITE_LIB_PATH)
 

--- a/tensorflow/lite/micro/tools/make/helper_functions.inc
+++ b/tensorflow/lite/micro/tools/make/helper_functions.inc
@@ -357,7 +357,7 @@ $(1)_LOCAL_SRCS := $$(call specialize,$$($(1)_LOCAL_SRCS))
 ALL_SRCS += $$($(1)_LOCAL_SRCS)
 $(1)_LOCAL_HDRS := $(3)
 $(1)_LOCAL_OBJS := $$(addprefix $$(OBJDIR), \
-$$(patsubst %.cc,%.o,$$(patsubst %.c,%.o,$$($(1)_LOCAL_SRCS))))
+$$(patsubst %.S,%.o,$$(patsubst %.cc,%.o,$$(patsubst %.c,%.o,$$($(1)_LOCAL_SRCS)))))
 $(1)_BINARY := $$(BINDIR)$(1)
 $$($(1)_BINARY): $$($(1)_LOCAL_OBJS) $$(MICROLITE_LIB_PATH)
 	@mkdir -p $$(dir $$@)

--- a/tensorflow/lite/micro/tools/make/targets/mcu_riscv_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/mcu_riscv_makefile.inc
@@ -48,22 +48,7 @@ ifeq ($(TARGET), riscv32_mcu)
 
   MICROLITE_CC_SRCS += \
     $(wildcard tensorflow/lite/micro/riscv32_mcu/*.cc)
-  MICRO_SPEECH_TEST_SRCS += \
-    $(wildcard $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/libwrap/sys/*.c) \
-    $(wildcard $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/libwrap/sys/*.cc) \
-    $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/libwrap/misc/write_hex.c \
-    $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/libwrap/stdlib/malloc.c \
-    $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/env/start.S \
-    $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/env/entry.S \
-    $(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/env/freedom-e300-hifive1/init.c
-  LIBWRAP_SYMS := malloc free \
-                  open lseek read write fstat stat close link unlink \
-                  execve fork getpid kill wait \
-                  isatty times sbrk _exit puts
 
-  LDFLAGS += $(foreach s,$(LIBWRAP_SYMS),-Wl,--wrap=$(s))
-  LDFLAGS += $(foreach s,$(LIBWRAP_SYMS),-Wl,--wrap=_$(s))
-  LDFLAGS += -L. -Wl,--start-group -lc -Wl,--end-group
   LDFLAGS += \
    -T$(MAKEFILE_DIR)/downloads/sifive_fe310_lib/bsp/env/freedom-e300-hifive1/flash.lds \
    -nostartfiles \


### PR DESCRIPTION
Update for this pull request(reviewed by @nkreeger before):
https://github.com/tensorflow/tensorflow/pull/33680  (Will close) 
https://github.com/tensorflow/tensorflow/pull/36095 (by @jpienaar before) 

related issues:
https://github.com/tensorflow/tensorflow/issues/32041
https://github.com/tensorflow/tensorflow/issues/33677

If possible, pls review as soon as possible, the tensorflow repo is very easy to get conflict because update so quickly.  Thanks,

About the three patches for review:
1) lite:micro:tools:make: Move the default target(all) up before any others.
    
 The default Makefile target `all` is compiled if there's no command-line arguments.

2) lite:micro:riscv32_mcu:Fix build failure of undefined references.
    
    Fix the ld error:
    undefined references to `__wrap_puts` for build commands like `make -f tensorflow/lite/micro/tools/make/Makefile TARGET=riscv32_mcu hello_world_bin`
    The related issue is tensorflow#32041

    Refactoring, suggested by Nick Kreeger(nick.kreeger@gmail.com):
    The targets/mcu_riscv_makefile.inc should only include the bare-bones parts for building for this platform.
    So move platform specific items from targets/mcu_riscv_makefile.inc to the actual example folder.
    Create a riscv32_mcu folder in each example directory. In those directories, create a new Makefile.inc that adds these rules moved out.    

    The bug's original reasons:
    The Makefile variables XXX_TEST_SRCS/XXX_SRCS in targets/mcu_riscv_makefile.inc are overridden by the the examples's respective makefile.inc (eg. hello_world/Makefile.inc), which leads to the   architecture special __wrap__funs are not included correctly.

3) lite:micro:riscv32_mcu: Fix hidden symbol `__dso_handle' isn't defined.
 For arduino sketch in riscv_mcu examples, this patch fix by declare the global variable `void* __dso_handle;`.

