### PR TITLE
Fix invalid XLA_FLAGS documentation

### DIFF
--- a/tensorflow/compiler/xla/g3doc/index.md
+++ b/tensorflow/compiler/xla/g3doc/index.md
@@ -109,7 +109,7 @@ programs. To dump the generated programs, use the environment variable
 `XLA_FLAGS`:
 
 ```
-$ XLA_FLAGS="--dump_hlo_as_text --xla_dump_to=/tmp/generated"
+$ XLA_FLAGS="--xla_dump_hlo_as_text --xla_dump_to=/tmp/generated"
 TF_XLA_FLAGS="--tf_xla_auto_jit=2" my/tensorflow/program
 ```
 


### PR DESCRIPTION
Setting `XLA_FLAGS="--dump_hlo_as_text"` is invalid and causes a catastrophic error; `--xla_dump_hlo_as_text` is the correct flag.