### PR TITLE
Enhance SlurmClusterResolver

### DIFF
--- a/tensorflow/python/distribute/cluster_resolver/slurm_cluster_resolver.py
+++ b/tensorflow/python/distribute/cluster_resolver/slurm_cluster_resolver.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2018-2020 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,61 +21,153 @@ from __future__ import print_function
 import collections
 import os
 import subprocess
+import re
 
 from tensorflow.python.distribute.cluster_resolver.cluster_resolver import ClusterResolver
 from tensorflow.python.distribute.cluster_resolver.cluster_resolver import format_master_url
 from tensorflow.python.training.server_lib import ClusterSpec
 from tensorflow.python.util.tf_export import tf_export
 
-from hostlist import expand_hostlist, parse_slurm_tasks_per_node
+def expand_hostlist(hostlist):
+  """Create a list of hosts out of a SLURM hostlist
 
+  The order of nodes is preserved and no deduplication is done
+  Input: 'n[1-2],m5,o[3-4,6,7-9]')
+  Output: ['n1', 'n2', 'm5', 'o3', 'o4', 'o6', 'o7', 'o8', 'o9']
+  """
+  def split_hostlist(hostlist):
+    """Split hostlist at commas outside of range expressions ('[3-5]')"""
+    in_brackets = False
+    cur_host = ''
+    for c in hostlist:
+      if in_brackets:
+        assert c != '['
+        if c == ']':
+          in_brackets = False
+      elif c == '[':
+        in_brackets = True
+      elif c == ',':
+        assert cur_host != ''
+        yield cur_host
+        cur_host = ''
+        continue
+      cur_host += c
+    if cur_host:
+      yield cur_host
 
-def get_slurm_step_var(name):
-  """Get the SLURM step variable from the environment
+  def expand_range_expression(range_exp):
+    """Expand a range expression like '3-5' to values 3,4,5"""
+    for part in range_exp.split(','):
+      sub_range = part.split('-')
+      if len(sub_range) == 1:
+        sub_range = sub_range * 2
+      else:
+        assert len(sub_range) == 2
+      for i in range(int(sub_range[0]), int(sub_range[1]) + 1):
+        yield i
+
+  hosts = []
+  try:
+    for part in split_hostlist(hostlist):
+      # Match prefix (anything but a range expression) and range expression
+      # Both are optional
+      m = re.match(r'([^,[\]]*)(\[([^\]]+)\])?$', part)
+      if m is None:
+        raise ValueError('Invalid part: %s' % part)
+      prefix = m.group(1) or ''
+      if m.group(3) is None:
+        hosts.append(prefix)
+      else:
+        hosts.extend(prefix + str(i)
+                     for i in expand_range_expression(m.group(3))
+        )
+  except Exception as e:
+    raise ValueError('Invalid hostlist format "%s": %s' % (hostlist, e))
+  return hosts
+
+def expand_tasks_per_node(tasks_per_node):
+  """Expand the tasks per node expression from SLURM
+
+  The order is preserved so it can be matched to the hostlist
+  Input: '3(x2),2,1'
+  Output: [3, 3, 2, 1]
+  """
+  result = []
+  try:
+    for part in tasks_per_node.split(','):
+      m = re.match(r'(\d+)(\(x(\d+)\))?$', part)
+      assert m is not None
+      num_tasks = int(m.group(1))
+      num_repetitions = int(m.group(3) or 1)
+      result.extend([num_tasks] * num_repetitions)
+  except Exception as e:
+    raise ValueError('Invalid tasks-per-node list format "%s": %s'
+                     % (tasks_per_node, e))
+  return result
+
+def _get_slurm_var(name):
+  """Get the SLURM variable from the environment
 
   Args:
     name: Name of the step variable
   Returns:
-    SLURM_STEP_<name> from os.environ
+    SLURM_<name> from os.environ
   Raises:
     RuntimeError if variable is not found
   """
-  name = 'SLURM_STEP_' + name
+  name = 'SLURM_' + name
   try:
     return os.environ[name]
   except KeyError:
-    raise RuntimeError('%s not found in environment. Not running inside a SLURM step?' % name)
+    raise RuntimeError('%s not found in environment. '
+                       'Not running inside a SLURM step?' % name)
 
 def get_num_slurm_tasks():
-  return int(get_slurm_step_var('NUM_TASKS'))
-
-def _resolve_hostnames():
-  """Resolve host names of nodes allocated in current job step.
+  """Return the number of SLURM tasks of the current job step
 
   Returns:
-    A list of node names as strings.
+    The number of tasks as an int
   """
-  hostlist = expand_hostlist(get_slurm_step_var('NODELIST'))
-  return hostlist
+  return int(_get_slurm_var('STEP_NUM_TASKS'))
 
-def _resolve_tasks_per_node():
-  """Resolve the number of tasks per node as a list.
+def _get_num_nvidia_gpus():
+  """Get the number of NVIDIA GPUs by using CUDA_VISIBLE_DEVICES and nvidia-smi
 
   Returns:
-    A list of number of tasks in the same order as the hostlist
+    Number of GPUs available on the node
+  Raises:
+    RuntimeError if executing nvidia-smi failed
   """
-  return parse_slurm_tasks_per_node(get_slurm_step_var('TASKS_PER_NODE'))
+  try:
+    return len(os.environ['CUDA_VISIBLE_DEVICES'].split(','))
+  except KeyError:
+    pass  # Ignore and fallback to using nvidia-smi
+  try:
+    output = subprocess.check_output(['nvidia-smi', '--list-gpus'],
+                                     encoding='utf-8')
+    return sum(l.startswith('GPU ') for l in output.strip().split('\n'))
+  except subprocess.CalledProcessError as e:
+    raise RuntimeError('Could not get number of GPUs from nvidia-smi. '
+                       'Maybe it is missing?\nOutput: %s' % e.output)
+
+def get_num_gpus():
+  """Return the number of GPUs visible on the current node
+
+  Currently only implemented for NVIDIA GPUs
+  """
+  return _get_num_nvidia_gpus()
+
 
 @tf_export('distribute.cluster_resolver.SlurmClusterResolver')
 class SlurmClusterResolver(ClusterResolver):
   """ClusterResolver for system with Slurm workload manager.
 
-  This is an implementation of cluster resolvers for Slurm clusters. This allows
-  the specification of jobs and task counts, number of tasks per node, number of
-  GPUs on each node and number of GPUs for each task. It retrieves system
+  This is an implementation of ClusterResolver for Slurm clusters. This allows
+  the specification of jobs and task counts, number of tasks per node, number
+  of GPUs on each node and number of GPUs for each task. It retrieves system
   attributes by Slurm environment variables, resolves allocated computing node
   names, constructs a cluster and returns a ClusterResolver object which can be
-  use for distributed TensorFlow.
+  used for distributed TensorFlow.
   """
 
 
@@ -89,70 +181,76 @@ class SlurmClusterResolver(ClusterResolver):
                rpc_layer='grpc'):
     """Creates a new SlurmClusterResolver object.
 
-    This takes in parameters and creates a SlurmClusterResolver object. It uses
-    those parameters to check which nodes will processes reside on and resolves
-    their hostnames. With the number of the GPUs on each node and number of GPUs
-    for each task it offsets the port number for each process and allocates
-    GPUs to tasks by setting environment variables. The resolver currently
-    supports homogeneous tasks and default Slurm process allocation.
+    For any parameter not set it will query the environment for the value.
+    It uses those parameters to check which nodes have processes reside on and
+    resolves their hostnames.
+    With the number tasks per node it offsets the port number for each process.
+    With the number of GPUs per node and per task it allocates GPUs to tasks by
+    setting environment variables.
+    Using the resolver works best (and is easier) with homogeneous tasks but
+    heterogeneous tasks (number of tasks varying per node) are also possible as
+    long as the number of GPUs per task stays constant.
+
+    Used environment variables:
+      - SLURM_PROCID
+      - (opt) SLURM_STEP_NUM_TASKS
+      - (opt) SLURM_STEP_NODELIST
+      - (opt) SLURM_TASKS_PER_NODE
 
     Args:
       jobs: Dictionary with job names as key and number of tasks in the job as
-        value. Defaults to as many 'worker's as there are (SLURM) tasks.
+        value. Defaults to as many 'worker's as there are (Slurm) tasks.
       port_base: The first port number to start with for processes on a node.
-      gpus_per_node: Number of GPUs available on each node. Defaults
-        to the number of GPUs reported by nvidia-smi
-      gpus_per_task: Number of GPUs to be used for each task. Defaults is to evenly
-        distribute the gpus_per_node to tasks_per_node.
-      tasks_per_node: Number of tasks to run on each node, if not set defaults
-        to Slurm's output environment variable SLURM_NTASKS_PER_NODE.
+      gpus_per_node: Number of GPUs available on each node.
+        Defaults to the number of GPUs reported by nvidia-smi
+      gpus_per_task: Number of GPUs to be used for each task.
+        Default is to evenly distribute the gpus_per_node to tasks_per_node.
+      tasks_per_node: Number of tasks running on each node.
+        Can be an integer if the number of tasks per node is constant or
+        a dictionary mapping hostnames to number of tasks on that node.
+        If not set the Slurm environment is queried for the correct mapping.
       auto_set_gpu: Set the visible CUDA devices automatically while resolving
         the cluster by setting CUDA_VISIBLE_DEVICES environment variable.
         Defaults to True.
-      rpc_layer: The protocol TensorFlow uses to communicate between
-        nodes. Defaults to 'grpc'.
+      rpc_layer: The protocol TensorFlow used to communicate between nodes.
+        Defaults to 'grpc'.
 
     Returns:
       A ClusterResolver object which can be used with distributed TensorFlow.
 
     Raises:
-      RuntimeError: If requested more GPUs per node then available or requested
-      more tasks then assigned tasks.
+      RuntimeError: If requested more GPUs per node then available or
+        requested more tasks then assigned tasks or
+        resolving missing values from the environment failed.
     """
 
-    # check if launched by mpirun
-    if 'OMPI_COMM_WORLD_RANK' in os.environ:
-      self._rank = int(os.environ['OMPI_COMM_WORLD_RANK'])
-      num_tasks = int(os.environ['OMPI_COMM_WORLD_SIZE'])
-    else:
-      self._rank = int(os.environ['SLURM_PROCID'])
-      num_tasks = get_num_slurm_tasks()
+    self._rank = self._resolve_own_rank()
 
     if jobs is None:
-      jobs = {'worker': num_tasks}
-    if gpus_per_node is None:
-      gpus_per_node = sum(l.startswith('GPU ') for l in
-                          subprocess.check_output(['nvidia-smi', '--list-gpus']).
-                          decode('utf-8').strip().split('\n'))
+      jobs = {'worker': self._resolve_num_tasks()}
 
-    self._jobs = collections.OrderedDict(sorted(jobs.items()))
+    self._jobs = jobs
     self._port_base = port_base
 
-    self._hostlist = _resolve_hostnames()
-
-    # user specification overrides SLURM specification
-    if tasks_per_node is not None:
-      self._tasks_per_node = [
-                tasks_per_node for _ in range(len(self._hostlist))
-            ] if isinstance(tasks_per_node, int) else tasks_per_node
-    elif tasks_per_node is None and 'SLURM_TASKS_PER_NODE' in os.environ:
-      self._tasks_per_node = _resolve_tasks_per_node()
+    if tasks_per_node is None:
+      self._task_configuration = self._resolve_task_configuration()
+    elif isinstance(tasks_per_node, dict):
+      # User can pass in an explicit configuration as a dict
+      self._task_configuration = tasks_per_node
     else:
-      raise RuntimeError('Neither `tasks_per_node` or '
-                         'SLURM_TASKS_PER_NODE is set.')
+      # User can pass a fixed number of tasks per node
+      hostlist = self._resolve_hostlist()
+      self._task_configuration = {
+        host: int(tasks_per_node) for host in hostlist
+      }
 
+    max_tasks_per_node = max(self._task_configuration.values())
+    num_tasks = sum(self._task_configuration.values())
+
+    if gpus_per_node is None:
+      gpus_per_node = get_num_gpus()
     if gpus_per_task is None:
-      gpus_per_task = gpus_per_node // max(self._tasks_per_node)
+      gpus_per_task = gpus_per_node // max_tasks_per_node
     self._gpus_per_node = gpus_per_node
     self._gpus_per_task = gpus_per_task
 
@@ -164,12 +262,38 @@ class SlurmClusterResolver(ClusterResolver):
     self._gpu_allocation = []
     self._cluster_allocation = {}
 
-    if max(self._tasks_per_node) * self._gpus_per_task > self._gpus_per_node:
+    if max_tasks_per_node * self._gpus_per_task > self._gpus_per_node:
       raise RuntimeError('Requested more GPUs per node then available.')
 
     if sum(self._jobs.values()) != num_tasks:
       raise RuntimeError('Requested {} tasks but only {} were assigned.'.format(
                 sum(self._jobs.values()), num_tasks))
+
+  def _resolve_own_rank(self):
+    """Return the rank of the current task in range [0, num_tasks)"""
+    return int(_get_slurm_var('PROCID'))
+
+  def _resolve_num_tasks(self):
+    """Return the number of tasks for the current job step"""
+    return get_num_slurm_tasks()
+
+  def _resolve_hostlist(self):
+    """Return a list of hostnames for nodes running the current job step"""
+    return expand_hostlist(_get_slurm_var('STEP_NODELIST'))
+
+  def _resolve_task_configuration(self):
+    """Create a mapping of hostnames to the number of tasks allocated on it
+
+    Reads the SLURM environment to determine the nodes involved in the current
+    job step and number of tasks running on each node.
+
+    Returns a dictionary mapping each hostname to the number of tasks.
+    """
+    hostlist = self._resolve_hostlist()
+    tasks_per_node = expand_tasks_per_node(_get_slurm_var('STEP_TASKS_PER_NODE'))
+    return {
+      host: num_tasks for (host, num_tasks) in zip(hostlist, tasks_per_node)
+    }
 
   def cluster_spec(self):
     """Returns a ClusterSpec object based on the latest instance group info.
@@ -191,7 +315,8 @@ class SlurmClusterResolver(ClusterResolver):
     self._gpu_allocation = []
     self._cluster_allocation = {}
 
-    for host, num_tasks in zip(self._hostlist, self._tasks_per_node):
+    # Sort to make sure the order is the same for each run
+    for host, num_tasks in sorted(self._task_configuration.items()):
       for port_offset, gpu_offset in zip(
           range(num_tasks),
           range(0, self._gpus_per_node, self._gpus_per_task)):
@@ -208,7 +333,8 @@ class SlurmClusterResolver(ClusterResolver):
     cluster_rank_offset_start = 0
     cluster_rank_offset_end = 0
 
-    for task_type, num_tasks in self._jobs.items():
+    # Sort to make sure the order is the same for each run
+    for task_type, num_tasks in sorted(self._jobs.items()):
       cluster_rank_offset_end = cluster_rank_offset_start + num_tasks
 
       self._cluster_allocation[task_type] = (
@@ -234,7 +360,7 @@ class SlurmClusterResolver(ClusterResolver):
     defaults to None.
 
     Returns:
-      A string specifying job name the process belongs to and an integner
+      A string specifying job name the process belongs to and an integer
         specifying the task index the process belongs to in that job.
     """
     return self.task_type, self.task_id

--- a/tensorflow/python/distribute/cluster_resolver/slurm_cluster_resolver.py
+++ b/tensorflow/python/distribute/cluster_resolver/slurm_cluster_resolver.py
@@ -79,8 +79,7 @@ def expand_hostlist(hostlist):
         hosts.append(prefix)
       else:
         hosts.extend(prefix + str(i)
-                     for i in expand_range_expression(m.group(3))
-        )
+                     for i in expand_range_expression(m.group(3)))
   except Exception as e:
     raise ValueError('Invalid hostlist format "%s": %s' % (hostlist, e))
   return hosts

--- a/tensorflow/python/distribute/cluster_resolver/slurm_cluster_resolver.py
+++ b/tensorflow/python/distribute/cluster_resolver/slurm_cluster_resolver.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import collections
 import os
 import subprocess
 import re
@@ -240,7 +239,7 @@ class SlurmClusterResolver(ClusterResolver):
       # User can pass a fixed number of tasks per node
       hostlist = self._resolve_hostlist()
       self._task_configuration = {
-        host: int(tasks_per_node) for host in hostlist
+          host: int(tasks_per_node) for host in hostlist
       }
 
     max_tasks_per_node = max(self._task_configuration.values())
@@ -266,7 +265,7 @@ class SlurmClusterResolver(ClusterResolver):
 
     if sum(self._jobs.values()) != num_tasks:
       raise RuntimeError('Requested {} tasks but only {} were assigned.'.format(
-                sum(self._jobs.values()), num_tasks))
+          sum(self._jobs.values()), num_tasks))
 
   def _resolve_own_rank(self):
     """Return the rank of the current task in range [0, num_tasks)"""
@@ -289,9 +288,10 @@ class SlurmClusterResolver(ClusterResolver):
     Returns a dictionary mapping each hostname to the number of tasks.
     """
     hostlist = self._resolve_hostlist()
-    tasks_per_node = expand_tasks_per_node(_get_slurm_var('STEP_TASKS_PER_NODE'))
+    tasks_per_node = expand_tasks_per_node(
+        _get_slurm_var('STEP_TASKS_PER_NODE'))
     return {
-      host: num_tasks for (host, num_tasks) in zip(hostlist, tasks_per_node)
+        host: num_tasks for (host, num_tasks) in zip(hostlist, tasks_per_node)
     }
 
   def cluster_spec(self):

--- a/tensorflow/python/distribute/cluster_resolver/slurm_cluster_resolver_test.py
+++ b/tensorflow/python/distribute/cluster_resolver/slurm_cluster_resolver_test.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ from __future__ import print_function
 import os
 
 from tensorflow.python.distribute.cluster_resolver import SlurmClusterResolver
+from tensorflow.python.distribute.cluster_resolver.slurm_cluster_resolver import expand_hostlist, expand_tasks_per_node
 from tensorflow.python.platform import test
 from tensorflow.python.training import server_lib
 
@@ -30,7 +31,6 @@ mock = test.mock
 class SlurmClusterResolverTest(test.TestCase):
 
   def test_expand_hostlist(self):
-    from tensorflow.python.distribute.cluster_resolver.slurm_cluster_resolver import expand_hostlist
     self.assertEqual(expand_hostlist('n1'), ['n1'])
     self.assertEqual(expand_hostlist('n[1,3]'), ['n1', 'n3'])
     self.assertEqual(expand_hostlist('n[1-3]'), ['n1', 'n2', 'n3'])
@@ -38,7 +38,6 @@ class SlurmClusterResolverTest(test.TestCase):
                      ['n1', 'n2', 'm5', 'o3', 'o4', 'o6', 'o7', 'o8', 'o9'])
 
   def test_expand_tasks_per_node(self):
-    from tensorflow.python.distribute.cluster_resolver.slurm_cluster_resolver import expand_tasks_per_node
     self.assertEqual(expand_tasks_per_node('2'), [2])
     self.assertEqual(expand_tasks_per_node('2,1,3'), [2, 1, 3])
     self.assertEqual(expand_tasks_per_node('3(x2),2,1'), [3, 3, 2, 1])

--- a/tensorflow/python/distribute/cluster_resolver/slurm_cluster_resolver_test.py
+++ b/tensorflow/python/distribute/cluster_resolver/slurm_cluster_resolver_test.py
@@ -59,12 +59,12 @@ class SlurmClusterResolverTest(test.TestCase):
         server_lib.ClusterSpec(cluster_spec.as_dict()).as_cluster_def())
 
   @mock.patch.dict(os.environ, {
-    'SLURM_PROCID': '0',
-    'SLURM_STEP_NUM_TASKS': '3',
-    'SLURM_STEP_TASKS_PER_NODE': '1(x3)',
-    'SLURM_STEP_NODELIST': 't02n13,t02n41,t02n43',
-    'CUDA_VISIBLE_DEVICES': '0',
-    })
+      'SLURM_PROCID': '0',
+      'SLURM_STEP_NUM_TASKS': '3',
+      'SLURM_STEP_TASKS_PER_NODE': '1(x3)',
+      'SLURM_STEP_NODELIST': 't02n13,t02n41,t02n43',
+      'CUDA_VISIBLE_DEVICES': '0',
+      })
   def testSimpleRetrievalFromEnv(self):
     slurm_cluster_resolver = SlurmClusterResolver()
 
@@ -82,10 +82,10 @@ class SlurmClusterResolverTest(test.TestCase):
     self.assertEqual(os.environ['CUDA_VISIBLE_DEVICES'], '0')
 
   @mock.patch.dict(os.environ, {
-    'SLURM_PROCID': '0',
-    'SLURM_STEP_NUM_TASKS': '3',
-    'SLURM_STEP_NODELIST': 't02n13,t02n41,t02n43',
-    })
+      'SLURM_PROCID': '0',
+      'SLURM_STEP_NUM_TASKS': '3',
+      'SLURM_STEP_NODELIST': 't02n13,t02n41,t02n43',
+      })
   def testSimpleSuccessfulRetrieval(self):
     slurm_cluster_resolver = SlurmClusterResolver(
         jobs={
@@ -107,10 +107,10 @@ class SlurmClusterResolverTest(test.TestCase):
     self._verifyClusterSpecEquality(actual_cluster_spec, expected_proto)
 
   @mock.patch.dict(os.environ, {
-    'SLURM_PROCID': '0',
-    'SLURM_STEP_NUM_TASKS': '3',
-    'SLURM_STEP_NODELIST': 't02n13,t02n41,t02n43',
-    })
+      'SLURM_PROCID': '0',
+      'SLURM_STEP_NUM_TASKS': '3',
+      'SLURM_STEP_NODELIST': 't02n13,t02n41,t02n43',
+      })
   def testSimpleMasterRetrieval(self):
     slurm_cluster_resolver = SlurmClusterResolver(
         jobs={
@@ -134,11 +134,11 @@ class SlurmClusterResolverTest(test.TestCase):
         'test://t02n13:8888')
 
   @mock.patch.dict(os.environ, {
-    'SLURM_PROCID': '0',
-    'SLURM_STEP_NUM_TASKS': '3',
-    'SLURM_STEP_TASKS_PER_NODE': '1(x3)',
-    'SLURM_STEP_NODELIST': 't02n13,t02n41,t02n43',
-    })
+      'SLURM_PROCID': '0',
+      'SLURM_STEP_NUM_TASKS': '3',
+      'SLURM_STEP_TASKS_PER_NODE': '1(x3)',
+      'SLURM_STEP_NODELIST': 't02n13,t02n41,t02n43',
+      })
   def testTaskPerNodeNotSetRetrieval(self):
     slurm_cluster_resolver = SlurmClusterResolver(
         jobs={
@@ -159,12 +159,12 @@ class SlurmClusterResolverTest(test.TestCase):
     self._verifyClusterSpecEquality(actual_cluster_spec, expected_proto)
 
   @mock.patch.dict(os.environ, {
-    'SLURM_PROCID': '1',
-    'SLURM_STEP_NUM_TASKS': '5',
-    'SLURM_STEP_TASKS_PER_NODE': '2(x2),1',
-    'SLURM_STEP_NODELIST': 't02n13,t02n41,t02n43',
-    'CUDA_VISIBLE_DEVICES': '',
-    })
+      'SLURM_PROCID': '1',
+      'SLURM_STEP_NUM_TASKS': '5',
+      'SLURM_STEP_TASKS_PER_NODE': '2(x2),1',
+      'SLURM_STEP_NODELIST': 't02n13,t02n41,t02n43',
+      'CUDA_VISIBLE_DEVICES': '',
+      })
   def testMultiTaskPerNodeRetrieval(self):
     slurm_cluster_resolver = SlurmClusterResolver(
         jobs={
@@ -189,12 +189,12 @@ class SlurmClusterResolverTest(test.TestCase):
     assert os.environ['CUDA_VISIBLE_DEVICES'] == '1'
 
   @mock.patch.dict(os.environ, {
-    'SLURM_PROCID': '1',
-    'SLURM_STEP_NUM_TASKS': '5',
-    'SLURM_STEP_TASKS_PER_NODE': '2(x2),1',
-    'SLURM_STEP_NODELIST': 't02n13,t02n41,t02n43',
-    'CUDA_VISIBLE_DEVICES': '',
-    })
+      'SLURM_PROCID': '1',
+      'SLURM_STEP_NUM_TASKS': '5',
+      'SLURM_STEP_TASKS_PER_NODE': '2(x2),1',
+      'SLURM_STEP_NODELIST': 't02n13,t02n41,t02n43',
+      'CUDA_VISIBLE_DEVICES': '',
+      })
   def testMultipleGpusPerTaskRetrieval(self):
     slurm_cluster_resolver = SlurmClusterResolver(
         jobs={

--- a/tensorflow/python/distribute/cluster_resolver/slurm_cluster_resolver_test.py
+++ b/tensorflow/python/distribute/cluster_resolver/slurm_cluster_resolver_test.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2018-2020 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,8 +29,23 @@ mock = test.mock
 
 class SlurmClusterResolverTest(test.TestCase):
 
-  def mock_resolve_hostnames_output(self):
-    return ['t02n13', 't02n41', 't02n43', 't02n44']
+  def test_expand_hostlist(self):
+    from tensorflow.python.distribute.cluster_resolver.slurm_cluster_resolver import expand_hostlist
+    self.assertEqual(expand_hostlist('n1'), ['n1'])
+    self.assertEqual(expand_hostlist('n[1,3]'), ['n1', 'n3'])
+    self.assertEqual(expand_hostlist('n[1-3]'), ['n1', 'n2', 'n3'])
+    self.assertEqual(expand_hostlist('n[1-2],m5,o[3-4,6,7-9]'),
+                     ['n1', 'n2', 'm5', 'o3', 'o4', 'o6', 'o7', 'o8', 'o9'])
+
+  def test_expand_tasks_per_node(self):
+    from tensorflow.python.distribute.cluster_resolver.slurm_cluster_resolver import expand_tasks_per_node
+    self.assertEqual(expand_tasks_per_node('2'), [2])
+    self.assertEqual(expand_tasks_per_node('2,1,3'), [2, 1, 3])
+    self.assertEqual(expand_tasks_per_node('3(x2),2,1'), [3, 3, 2, 1])
+    self.assertEqual(expand_tasks_per_node('3(x2),2,11(x4)'),
+                     [3, 3, 2, 11, 11, 11, 11])
+    self.assertEqual(expand_tasks_per_node('13(x10)'),
+                     [13, 13, 13, 13, 13, 13, 13, 13, 13, 13])
 
   def _verifyClusterSpecEquality(self, cluster_spec, expected_proto):
     self.assertProtoEquals(expected_proto, cluster_spec.as_cluster_def())
@@ -44,9 +59,34 @@ class SlurmClusterResolverTest(test.TestCase):
         expected_proto,
         server_lib.ClusterSpec(cluster_spec.as_dict()).as_cluster_def())
 
-  @mock.patch.dict(os.environ, {'SLURM_PROCID': '0', 'SLURM_NTASKS': '3'})
-  @mock.patch.object(SlurmClusterResolver, '_resolve_hostnames',
-                     mock_resolve_hostnames_output)
+  @mock.patch.dict(os.environ, {
+    'SLURM_PROCID': '0',
+    'SLURM_STEP_NUM_TASKS': '3',
+    'SLURM_STEP_TASKS_PER_NODE': '1(x3)',
+    'SLURM_STEP_NODELIST': 't02n13,t02n41,t02n43',
+    'CUDA_VISIBLE_DEVICES': '0',
+    })
+  def testSimpleRetrievalFromEnv(self):
+    slurm_cluster_resolver = SlurmClusterResolver()
+
+    actual_cluster_spec = slurm_cluster_resolver.cluster_spec()
+    expected_proto = """
+    job { name: 'worker' tasks { key: 0 value: 't02n13:8888' }
+                         tasks { key: 1 value: 't02n41:8888' }
+                         tasks { key: 2 value: 't02n43:8888' } }
+    """
+    self._verifyClusterSpecEquality(actual_cluster_spec, expected_proto)
+    self.assertEqual(
+        slurm_cluster_resolver.master('worker', 0, rpc_layer='grpc'),
+        'grpc://t02n13:8888')
+    self.assertEqual(slurm_cluster_resolver.num_accelerators(), {'GPU': 1})
+    self.assertEqual(os.environ['CUDA_VISIBLE_DEVICES'], '0')
+
+  @mock.patch.dict(os.environ, {
+    'SLURM_PROCID': '0',
+    'SLURM_STEP_NUM_TASKS': '3',
+    'SLURM_STEP_NODELIST': 't02n13,t02n41,t02n43',
+    })
   def testSimpleSuccessfulRetrieval(self):
     slurm_cluster_resolver = SlurmClusterResolver(
         jobs={
@@ -67,9 +107,11 @@ class SlurmClusterResolverTest(test.TestCase):
     """
     self._verifyClusterSpecEquality(actual_cluster_spec, expected_proto)
 
-  @mock.patch.dict(os.environ, {'SLURM_PROCID': '0', 'SLURM_NTASKS': '3'})
-  @mock.patch.object(SlurmClusterResolver, '_resolve_hostnames',
-                     mock_resolve_hostnames_output)
+  @mock.patch.dict(os.environ, {
+    'SLURM_PROCID': '0',
+    'SLURM_STEP_NUM_TASKS': '3',
+    'SLURM_STEP_NODELIST': 't02n13,t02n41,t02n43',
+    })
   def testSimpleMasterRetrieval(self):
     slurm_cluster_resolver = SlurmClusterResolver(
         jobs={
@@ -93,12 +135,11 @@ class SlurmClusterResolverTest(test.TestCase):
         'test://t02n13:8888')
 
   @mock.patch.dict(os.environ, {
-      'SLURM_PROCID': '0',
-      'SLURM_NTASKS': '3',
-      'SLURM_NTASKS_PER_NODE': '1'
-  })
-  @mock.patch.object(SlurmClusterResolver, '_resolve_hostnames',
-                     mock_resolve_hostnames_output)
+    'SLURM_PROCID': '0',
+    'SLURM_STEP_NUM_TASKS': '3',
+    'SLURM_STEP_TASKS_PER_NODE': '1(x3)',
+    'SLURM_STEP_NODELIST': 't02n13,t02n41,t02n43',
+    })
   def testTaskPerNodeNotSetRetrieval(self):
     slurm_cluster_resolver = SlurmClusterResolver(
         jobs={
@@ -118,15 +159,13 @@ class SlurmClusterResolverTest(test.TestCase):
     """
     self._verifyClusterSpecEquality(actual_cluster_spec, expected_proto)
 
-  @mock.patch.dict(
-      os.environ, {
-          'SLURM_PROCID': '1',
-          'SLURM_NTASKS': '5',
-          'SLURM_NTASKS_PER_NODE': '2',
-          'CUDA_VISIBLE_DEVICES': ''
-      })
-  @mock.patch.object(SlurmClusterResolver, '_resolve_hostnames',
-                     mock_resolve_hostnames_output)
+  @mock.patch.dict(os.environ, {
+    'SLURM_PROCID': '1',
+    'SLURM_STEP_NUM_TASKS': '5',
+    'SLURM_STEP_TASKS_PER_NODE': '2(x2),1',
+    'SLURM_STEP_NODELIST': 't02n13,t02n41,t02n43',
+    'CUDA_VISIBLE_DEVICES': '',
+    })
   def testMultiTaskPerNodeRetrieval(self):
     slurm_cluster_resolver = SlurmClusterResolver(
         jobs={
@@ -150,15 +189,13 @@ class SlurmClusterResolverTest(test.TestCase):
     self._verifyClusterSpecEquality(actual_cluster_spec, expected_proto)
     assert os.environ['CUDA_VISIBLE_DEVICES'] == '1'
 
-  @mock.patch.dict(
-      os.environ, {
-          'SLURM_PROCID': '1',
-          'SLURM_NTASKS': '5',
-          'SLURM_NTASKS_PER_NODE': '2',
-          'CUDA_VISIBLE_DEVICES': ''
-      })
-  @mock.patch.object(SlurmClusterResolver, '_resolve_hostnames',
-                     mock_resolve_hostnames_output)
+  @mock.patch.dict(os.environ, {
+    'SLURM_PROCID': '1',
+    'SLURM_STEP_NUM_TASKS': '5',
+    'SLURM_STEP_TASKS_PER_NODE': '2(x2),1',
+    'SLURM_STEP_NODELIST': 't02n13,t02n41,t02n43',
+    'CUDA_VISIBLE_DEVICES': '',
+    })
   def testMultipleGpusPerTaskRetrieval(self):
     slurm_cluster_resolver = SlurmClusterResolver(
         jobs={

--- a/tensorflow/tools/api/golden/v1/tensorflow.distribute.cluster_resolver.-slurm-cluster-resolver.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.distribute.cluster_resolver.-slurm-cluster-resolver.pbtxt
@@ -9,7 +9,7 @@ tf_class {
   }
   member_method {
     name: "__init__"
-    argspec: "args=[\'self\', \'jobs\', \'port_base\', \'gpus_per_node\', \'gpus_per_task\', \'tasks_per_node\', \'auto_set_gpu\', \'rpc_layer\'], varargs=None, keywords=None, defaults=[\'8888\', \'1\', \'1\', \'None\', \'True\', \'grpc\'], "
+    argspec: "args=[\'self\', \'jobs\', \'port_base\', \'gpus_per_node\', \'gpus_per_task\', \'tasks_per_node\', \'auto_set_gpu\', \'rpc_layer\'], varargs=None, keywords=None, defaults=[\'None\', \'8888\', \'None\', \'None\', \'None\', \'True\', \'grpc\'], "
   }
   member_method {
     name: "cluster_spec"

--- a/tensorflow/tools/api/golden/v2/tensorflow.distribute.cluster_resolver.-slurm-cluster-resolver.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.distribute.cluster_resolver.-slurm-cluster-resolver.pbtxt
@@ -9,7 +9,7 @@ tf_class {
   }
   member_method {
     name: "__init__"
-    argspec: "args=[\'self\', \'jobs\', \'port_base\', \'gpus_per_node\', \'gpus_per_task\', \'tasks_per_node\', \'auto_set_gpu\', \'rpc_layer\'], varargs=None, keywords=None, defaults=[\'8888\', \'1\', \'1\', \'None\', \'True\', \'grpc\'], "
+    argspec: "args=[\'self\', \'jobs\', \'port_base\', \'gpus_per_node\', \'gpus_per_task\', \'tasks_per_node\', \'auto_set_gpu\', \'rpc_layer\'], varargs=None, keywords=None, defaults=[\'None\', \'8888\', \'None\', \'None\', \'None\', \'True\', \'grpc\'], "
   }
   member_method {
     name: "cluster_spec"

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -77,6 +77,7 @@ REQUIRED_PACKAGES = [
     # Latest scipy pip for py2 is scipy==1.2.2
     'scipy == 1.4.1;python_version>="3"',
     'scipy == 1.2.2;python_version<"3"',
+    'python-hostlist >= 1.20.0',
 ]
 
 if sys.byteorder == 'little':

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -77,7 +77,6 @@ REQUIRED_PACKAGES = [
     # Latest scipy pip for py2 is scipy==1.2.2
     'scipy == 1.4.1;python_version>="3"',
     'scipy == 1.2.2;python_version<"3"',
-    'python-hostlist >= 1.20.0',
 ]
 
 if sys.byteorder == 'little':


### PR DESCRIPTION
This enhances the SlurmClusterResolver and fixes its bugs, see #36094

The design goal is that the user simply creates an instance of the class when the python script is run by `srun` (the `mpirun` wrapper on SLURM). As all information is available in the environment this is certainly possible.

- Default all arguments to something reasonable
- Use Slurm step env variables to fill in data

This has been tested (kinda) successfully on a SLURM cluster with TF 2.1.0 and MultiWorkerMirroredStrategy. It works with artificial data. I couldn't test it fully with MNIST due to https://github.com/tensorflow/tensorflow/issues/36153

What should be discussed besides the code:
- Usage of `nvidia-smi` to query the number of GPUs. I couldn't use `context.num_gpus()` at this point because this initializes the context including collectives which is not wanted as collectives might be overwritten later when creating a strategy