### PR TITLE
TFLite: add cmake support

### DIFF
--- a/tensorflow/lite/delegates/gpu/api.cc
+++ b/tensorflow/lite/delegates/gpu/api.cc
@@ -25,7 +25,7 @@ struct ObjectTypeGetter {
   ObjectType operator()(OpenGlTexture) const {
     return ObjectType::OPENGL_TEXTURE;
   }
-#if defined(TFLITE_GPU_DELEGATE_CL_ENABLED)
+#if defined(TFLITE_CONFIG_GPU_CL)
   ObjectType operator()(OpenClBuffer) const {
     return ObjectType::OPENCL_BUFFER;
   }
@@ -42,7 +42,7 @@ struct ObjectValidityChecker {
   bool operator()(OpenGlTexture obj) const {
     return obj.id != GL_INVALID_INDEX && obj.format != GL_INVALID_ENUM;
   }
-#if defined(TFLITE_GPU_DELEGATE_CL_ENABLED)
+#if defined(TFLITE_CONFIG_GPU_CL)
   bool operator()(OpenClBuffer obj) const { return obj.memobj; }
   bool operator()(OpenClTexture obj) const { return obj.memobj; }
 #endif
@@ -81,7 +81,7 @@ bool IsObjectPresent(ObjectType type, const TensorObject& obj) {
       return absl::get_if<OpenGlBuffer>(&obj);
     case ObjectType::OPENGL_TEXTURE:
       return absl::get_if<OpenGlTexture>(&obj);
-#if defined(TFLITE_GPU_DELEGATE_CL_ENABLED)
+#if defined(TFLITE_CONFIG_GPU_CL)
     case ObjectType::OPENCL_BUFFER:
       return absl::get_if<OpenClBuffer>(&obj);
     case ObjectType::OPENCL_TEXTURE:

--- a/tensorflow/lite/delegates/gpu/api.cc
+++ b/tensorflow/lite/delegates/gpu/api.cc
@@ -21,31 +21,35 @@ namespace {
 
 struct ObjectTypeGetter {
   ObjectType operator()(absl::monostate) const { return ObjectType::UNKNOWN; }
+#if defined(__ANDROID__) || defined(TFLITE_CONFIG_GPU_GL)
   ObjectType operator()(OpenGlBuffer) const { return ObjectType::OPENGL_SSBO; }
   ObjectType operator()(OpenGlTexture) const {
     return ObjectType::OPENGL_TEXTURE;
   }
-#if defined(TFLITE_CONFIG_GPU_CL)
+#endif // defined(__ANDROID__) || defined(TFLITE_CONFIG_GPU_GL)
+#if defined(__ANDROID__) || defined(TFLITE_CONFIG_GPU_CL)
   ObjectType operator()(OpenClBuffer) const {
     return ObjectType::OPENCL_BUFFER;
   }
   ObjectType operator()(OpenClTexture) const {
     return ObjectType::OPENCL_TEXTURE;
   }
-#endif
+#endif // defined(__ANDROID__) || defined(TFLITE_CONFIG_GPU_CL)
   ObjectType operator()(CpuMemory) const { return ObjectType::CPU_MEMORY; }
 };
 
 struct ObjectValidityChecker {
   bool operator()(absl::monostate) const { return false; }
+#if defined(__ANDROID__) || defined(TFLITE_CONFIG_GPU_GL)
   bool operator()(OpenGlBuffer obj) const { return obj.id != GL_INVALID_INDEX; }
   bool operator()(OpenGlTexture obj) const {
     return obj.id != GL_INVALID_INDEX && obj.format != GL_INVALID_ENUM;
   }
-#if defined(TFLITE_CONFIG_GPU_CL)
+#endif // defined(__ANDROID__) || defined(TFLITE_CONFIG_GPU_GL)
+#if defined(__ANDROID__) || defined(TFLITE_CONFIG_GPU_CL)
   bool operator()(OpenClBuffer obj) const { return obj.memobj; }
   bool operator()(OpenClTexture obj) const { return obj.memobj; }
-#endif
+#endif // defined(__ANDROID__) || defined(TFLITE_CONFIG_GPU_CL)
   bool operator()(CpuMemory obj) const {
     return obj.data != nullptr && obj.size_bytes > 0 &&
            (data_type == DataType::UNKNOWN ||
@@ -77,16 +81,18 @@ bool IsObjectPresent(ObjectType type, const TensorObject& obj) {
   switch (type) {
     case ObjectType::CPU_MEMORY:
       return absl::get_if<CpuMemory>(&obj);
+#if defined(__ANDROID__) || defined(TFLITE_CONFIG_GPU_GL)
     case ObjectType::OPENGL_SSBO:
       return absl::get_if<OpenGlBuffer>(&obj);
     case ObjectType::OPENGL_TEXTURE:
       return absl::get_if<OpenGlTexture>(&obj);
-#if defined(TFLITE_CONFIG_GPU_CL)
+#endif // defined(__ANDROID__) || defined(TFLITE_CONFIG_GPU_GL)
+#if defined(__ANDROID__) || defined(TFLITE_CONFIG_GPU_CL)
     case ObjectType::OPENCL_BUFFER:
       return absl::get_if<OpenClBuffer>(&obj);
     case ObjectType::OPENCL_TEXTURE:
       return absl::get_if<OpenClTexture>(&obj);
-#endif
+#endif // defined(__ANDROID__) || defined(TFLITE_CONFIG_GPU_CL)
     case ObjectType::UNKNOWN:
       return false;
   }

--- a/tensorflow/lite/delegates/gpu/api.cc
+++ b/tensorflow/lite/delegates/gpu/api.cc
@@ -25,12 +25,14 @@ struct ObjectTypeGetter {
   ObjectType operator()(OpenGlTexture) const {
     return ObjectType::OPENGL_TEXTURE;
   }
+#if defined(TFLITE_GPU_DELEGATE_CL_ENABLED)
   ObjectType operator()(OpenClBuffer) const {
     return ObjectType::OPENCL_BUFFER;
   }
   ObjectType operator()(OpenClTexture) const {
     return ObjectType::OPENCL_TEXTURE;
   }
+#endif
   ObjectType operator()(CpuMemory) const { return ObjectType::CPU_MEMORY; }
 };
 
@@ -40,8 +42,10 @@ struct ObjectValidityChecker {
   bool operator()(OpenGlTexture obj) const {
     return obj.id != GL_INVALID_INDEX && obj.format != GL_INVALID_ENUM;
   }
+#if defined(TFLITE_GPU_DELEGATE_CL_ENABLED)
   bool operator()(OpenClBuffer obj) const { return obj.memobj; }
   bool operator()(OpenClTexture obj) const { return obj.memobj; }
+#endif
   bool operator()(CpuMemory obj) const {
     return obj.data != nullptr && obj.size_bytes > 0 &&
            (data_type == DataType::UNKNOWN ||
@@ -77,10 +81,12 @@ bool IsObjectPresent(ObjectType type, const TensorObject& obj) {
       return absl::get_if<OpenGlBuffer>(&obj);
     case ObjectType::OPENGL_TEXTURE:
       return absl::get_if<OpenGlTexture>(&obj);
+#if defined(TFLITE_GPU_DELEGATE_CL_ENABLED)
     case ObjectType::OPENCL_BUFFER:
       return absl::get_if<OpenClBuffer>(&obj);
     case ObjectType::OPENCL_TEXTURE:
       return absl::get_if<OpenClTexture>(&obj);
+#endif
     case ObjectType::UNKNOWN:
       return false;
   }

--- a/tensorflow/lite/delegates/gpu/api.h
+++ b/tensorflow/lite/delegates/gpu/api.h
@@ -212,7 +212,7 @@ uint32_t NumElements(const TensorObjectDef& def);
 
 using TensorObject = absl::variant<absl::monostate
 #if defined(__ANDROID__) || defined(TFLITE_CONFIG_GPU_GL)
-                                   , OpenGlBuffer, OpenGlTexture,
+                                   , OpenGlBuffer, OpenGlTexture
 #endif // defined(__ANDROID__) || defined(TFLITE_CONFIG_GPU_GL)
                                    , CpuMemory
 #if defined(__ANDROID__) || defined(TFLITE_CONFIG_GPU_CL)

--- a/tensorflow/lite/delegates/gpu/api.h
+++ b/tensorflow/lite/delegates/gpu/api.h
@@ -39,7 +39,7 @@ limitations under the License.
 
 #include "absl/types/span.h"
 #include "absl/types/variant.h"
-#if defined(TFLITE_GPU_DELEGATE_CL_ENABLED)
+#if defined(TFLITE_CONFIG_GPU_CL)
 #include <CL/cl.h>
 #endif
 #include "tensorflow/lite/delegates/gpu/common/data_type.h"
@@ -71,7 +71,7 @@ enum class ObjectType {
   OPENGL_SSBO,
   OPENGL_TEXTURE,
   CPU_MEMORY,
-#if defined(TFLITE_GPU_DELEGATE_CL_ENABLED)
+#if defined(TFLITE_CONFIG_GPU_CL)
   OPENCL_TEXTURE,
   OPENCL_BUFFER,
 #endif
@@ -93,7 +93,7 @@ struct OpenGlTexture {
   GLenum format = GL_INVALID_ENUM;
 };
 
-#if defined(TFLITE_GPU_DELEGATE_CL_ENABLED)
+#if defined(TFLITE_CONFIG_GPU_CL)
 struct OpenClBuffer {
   OpenClBuffer() = default;
   explicit OpenClBuffer(cl_mem new_memobj) : memobj(new_memobj) {}
@@ -203,7 +203,7 @@ uint32_t NumElements(const TensorObjectDef& def);
 
 using TensorObject = absl::variant<absl::monostate, OpenGlBuffer, OpenGlTexture,
                                    CpuMemory
-#if defined(TFLITE_GPU_DELEGATE_CL_ENABLED)
+#if defined(TFLITE_CONFIG_GPU_CL)
                                    ,OpenClBuffer, OpenClTexture
 #endif
                                    >;

--- a/tensorflow/lite/delegates/gpu/api.h
+++ b/tensorflow/lite/delegates/gpu/api.h
@@ -39,7 +39,9 @@ limitations under the License.
 
 #include "absl/types/span.h"
 #include "absl/types/variant.h"
+#if defined(TFLITE_GPU_DELEGATE_CL_ENABLED)
 #include <CL/cl.h>
+#endif
 #include "tensorflow/lite/delegates/gpu/common/data_type.h"
 #include "tensorflow/lite/delegates/gpu/common/status.h"
 #include "tensorflow/lite/delegates/gpu/common/util.h"
@@ -69,8 +71,10 @@ enum class ObjectType {
   OPENGL_SSBO,
   OPENGL_TEXTURE,
   CPU_MEMORY,
+#if defined(TFLITE_GPU_DELEGATE_CL_ENABLED)
   OPENCL_TEXTURE,
   OPENCL_BUFFER,
+#endif
 };
 
 struct OpenGlBuffer {
@@ -89,6 +93,7 @@ struct OpenGlTexture {
   GLenum format = GL_INVALID_ENUM;
 };
 
+#if defined(TFLITE_GPU_DELEGATE_CL_ENABLED)
 struct OpenClBuffer {
   OpenClBuffer() = default;
   explicit OpenClBuffer(cl_mem new_memobj) : memobj(new_memobj) {}
@@ -103,6 +108,7 @@ struct OpenClTexture {
   cl_mem memobj = nullptr;
   // TODO(akulik): should it specify texture format?
 };
+#endif
 
 struct VulkanMemory {
   VulkanMemory() = default;
@@ -196,7 +202,11 @@ bool IsValid(const TensorObjectDef& def);
 uint32_t NumElements(const TensorObjectDef& def);
 
 using TensorObject = absl::variant<absl::monostate, OpenGlBuffer, OpenGlTexture,
-                                   CpuMemory, OpenClBuffer, OpenClTexture>;
+                                   CpuMemory
+#if defined(TFLITE_GPU_DELEGATE_CL_ENABLED)
+                                   ,OpenClBuffer, OpenClTexture
+#endif
+                                   >;
 
 // @return true if object is set and corresponding values are defined.
 bool IsValid(const TensorObjectDef& def, const TensorObject& object);

--- a/tensorflow/lite/delegates/gpu/cl/api.h
+++ b/tensorflow/lite/delegates/gpu/cl/api.h
@@ -19,7 +19,9 @@ limitations under the License.
 #include <cstdint>
 #include <memory>
 
+#ifndef TFLITE_CONFIG_GPU_NO_EGL
 #include <EGL/egl.h>
+#endif // TFLITE_CONFIG_GPU_NO_EGL
 #include "absl/types/span.h"
 #include "tensorflow/lite/delegates/gpu/api.h"
 #include "tensorflow/lite/delegates/gpu/common/model.h"
@@ -90,6 +92,7 @@ struct InferenceEnvironmentOptions {
   cl_context context = nullptr;
   cl_command_queue command_queue = nullptr;
 
+#ifndef TFLITE_CONFIG_GPU_NO_EGL´
   // Whenever input and/or output is GL object, EGL display and context must be
   // set to create GL aware OpenCL context. Do not set these variables whenever
   // GL interoperability is not needed.
@@ -98,6 +101,7 @@ struct InferenceEnvironmentOptions {
   // GL-aware CL context.
   EGLDisplay egl_display = EGL_NO_DISPLAY;
   EGLContext egl_context = EGL_NO_CONTEXT;
+#endif
 
   // Should contain data returned from
   // InferenceEnvironment::GetSerializedBinaryCache method.
@@ -105,9 +109,11 @@ struct InferenceEnvironmentOptions {
   // incompatible when GPU driver is updated.
   absl::Span<const uint8_t> serialized_binary_cache;
 
+#ifndef TFLITE_CONFIG_GPU_NO_EGL
   bool IsGlAware() const {
     return egl_context != EGL_NO_CONTEXT && egl_display != EGL_NO_DISPLAY;
   }
+#endif
 };
 
 // Creates new OpenCL environment that needs to stay around until all inference

--- a/tensorflow/lite/delegates/gpu/delegate.cc
+++ b/tensorflow/lite/delegates/gpu/delegate.cc
@@ -23,10 +23,10 @@ limitations under the License.
 #include "tensorflow/lite/builtin_ops.h"
 #include "tensorflow/lite/delegates/gpu/api.h"
 #include "tensorflow/lite/delegates/gpu/cl/api.h"
-#if defined(TFLITE_CONFIG_GPU_CL)
+#if defined(__ANDROID__) || defined(TFLITE_CONFIG_GPU_CL)
 # include "tensorflow/lite/delegates/gpu/cl/opencl_wrapper.h"
 # include "tensorflow/lite/delegates/gpu/cl/tensor_type_util.h"
-#endif
+#endif // defined(__ANDROID__) || defined(TFLITE_CONFIG_GPU_CL)
 #include "tensorflow/lite/delegates/gpu/common/model.h"
 #include "tensorflow/lite/delegates/gpu/common/model_builder.h"
 #include "tensorflow/lite/delegates/gpu/common/model_transformer.h"

--- a/tensorflow/lite/delegates/gpu/delegate.cc
+++ b/tensorflow/lite/delegates/gpu/delegate.cc
@@ -23,7 +23,7 @@ limitations under the License.
 #include "tensorflow/lite/builtin_ops.h"
 #include "tensorflow/lite/delegates/gpu/api.h"
 #include "tensorflow/lite/delegates/gpu/cl/api.h"
-#if defined(TFLITE_GPU_DELEGATE_CL_ENABLED)
+#if defined(TFLITE_CONFIG_GPU_CL)
 # include "tensorflow/lite/delegates/gpu/cl/opencl_wrapper.h"
 # include "tensorflow/lite/delegates/gpu/cl/tensor_type_util.h"
 #endif
@@ -96,7 +96,7 @@ class Delegate {
     }
 
     std::unique_ptr<InferenceBuilder> builder;
-#if defined(TFLITE_GPU_DELEGATE_CL_ENABLED)
+#if defined(TFLITE_CONFIG_GPU_CL)
     bool graph_is_destroyed;
     Status status = InitializeOpenClApi(&graph, &builder, &graph_is_destroyed);
     if (!status.ok()) {
@@ -171,7 +171,7 @@ class Delegate {
   TfLiteDelegate* tflite_delegate() { return &delegate_; }
 
  private:
-#if defined(TFLITE_GPU_DELEGATE_CL_ENABLED)
+#if defined(TFLITE_CONFIG_GPU_CL)
   Status InitializeOpenClApi(GraphFloat32* graph,
                              std::unique_ptr<InferenceBuilder>* builder,
                              bool* graph_is_destroyed) {

--- a/tensorflow/lite/delegates/gpu/gl/api2.h
+++ b/tensorflow/lite/delegates/gpu/gl/api2.h
@@ -23,7 +23,9 @@ limitations under the License.
 #include "tensorflow/lite/delegates/gpu/api.h"
 #include "tensorflow/lite/delegates/gpu/common/model.h"
 #include "tensorflow/lite/delegates/gpu/common/status.h"
+#if defined(__ANDROID__) || defined(TFLITE_CONFIG_GPU_GL)
 #include "tensorflow/lite/delegates/gpu/gl/command_queue.h"
+#endif // defined(__ANDROID__) || defined(TFLITE_CONFIG_GPU_GL)
 
 namespace tflite {
 namespace gpu {
@@ -47,7 +49,9 @@ class InferenceEnvironment {
 };
 
 struct InferenceEnvironmentOptions {
+#if defined(__ANDROID__) || defined(TFLITE_CONFIG_GPU_GL)
   CommandQueue* queue = nullptr;
+#endif // defined(__ANDROID__) || defined(TFLITE_CONFIG_GPU_GL)
 };
 
 // Creates a new OpenGL environment that needs to stay around until all

--- a/tensorflow/lite/delegates/gpu/gl/portable_egl.h
+++ b/tensorflow/lite/delegates/gpu/gl/portable_egl.h
@@ -18,5 +18,6 @@ limitations under the License.
 
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
+#undef Status // X11 Status
 
 #endif  // TENSORFLOW_LITE_DELEGATES_GPU_GL_PORTABLE_EGL_H_

--- a/tensorflow/lite/delegates/gpu/gl/portable_gl31.h
+++ b/tensorflow/lite/delegates/gpu/gl/portable_gl31.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include <EGL/egl.h>
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
+#undef Status // X11 Status
 
 #ifdef __ANDROID__
 // Weak-link all GL APIs included from this point on.

--- a/tensorflow/lite/delegates/gpu/gl_delegate.cc
+++ b/tensorflow/lite/delegates/gpu/gl_delegate.cc
@@ -24,6 +24,8 @@ limitations under the License.
 
 #include <EGL/egl.h>
 #include <GLES3/gl31.h>
+#undef Status // X11 Status
+
 #include "absl/types/span.h"
 #include "tensorflow/lite/builtin_ops.h"
 #include "tensorflow/lite/c/common.h"

--- a/tensorflow/lite/tools/CMakeLists.txt
+++ b/tensorflow/lite/tools/CMakeLists.txt
@@ -182,10 +182,10 @@ target_link_libraries(tensorflow-lite PUBLIC
 )
 
 ## minimal example
-add_executable(tflite-minimal
-  ${TENSORFLOW_LITE_DIR}/examples/minimal/minimal.cc
-)
-target_link_libraries(tflite-minimal tensorflow-lite gl_delegate EGL GLESv2)
+#add_executable(tflite-minimal
+#  ${TENSORFLOW_LITE_DIR}/examples/minimal/minimal.cc
+#)
+#target_link_libraries(tflite-minimal tensorflow-lite gl_delegate EGL GLESv2)
 
 ## GPU delegate
 if(NOT CMAKE_CROSSCOMPILING)
@@ -202,6 +202,7 @@ add_custom_command(
           ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiled_model.fbs
           ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/metadata.fbs
           ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/workgroups.fbs
+          ${CMAKE_CURRENT_BINARY_DIR}/make/downloads/flatbuffers/flatc
   COMMAND ${CMAKE_CURRENT_BINARY_DIR}/make/downloads/flatbuffers/flatc
           --cpp --scoped-enums -o ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/
           ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/common.fbs
@@ -211,9 +212,13 @@ add_custom_command(
 )
 
 add_library(gl_delegate
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/api.cc
   ${TENSORFLOW_LITE_DIR}/delegates/gpu/delegate.cc
   ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl_delegate.cc
   ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/gl_program.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/request_gpu_info.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/converter.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/custom_registry.cc
   ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/lstm.cc
   ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/max_unpooling.cc
   ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/conv.cc
@@ -239,6 +244,7 @@ add_library(gl_delegate
   ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/serialization.cc
   ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/gl_shader.cc
   ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/api.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/api2.cc
   ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/converters/phwc4_to_bhwc.cc
   ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/converters/bhwc_to_phwc4.cc
   ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/egl_surface.cc
@@ -267,6 +273,12 @@ add_library(gl_delegate
   ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/convert.cc
   ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/data_type.cc
   ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/gpu_info.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/memory_management.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/memory_management/greedy_by_breadth_assignment.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/memory_management/greedy_by_size_assignment.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/memory_management/internal.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/memory_management/min_cost_flow_assignment.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/memory_management/types.cc
   ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/model_builder.cc
   ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/model_transformer.cc
   ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/operations.cc
@@ -283,34 +295,6 @@ add_library(gl_delegate
   ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/transformations/fuse_add_to_conv.cc
   # headers
   ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/metadata_generated.h
-  # abseil
-  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/base/internal/raw_logging.cc
-  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/base/internal/throw_delegate.cc
-  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/numeric/int128.cc
-  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/types/bad_variant_access.cc
-  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/types/bad_any_cast.cc
-  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/ascii.cc
-  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/charconv.cc
-  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/escaping.cc
-  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/match.cc
-  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/numbers.cc
-  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/substitute.cc
-  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/str_cat.cc
-  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/str_replace.cc
-  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/str_split.cc
-  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/string_view.cc
-  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/internal/charconv_bigint.cc
-  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/internal/charconv_parse.cc
-  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/internal/memutil.cc
-  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/internal/ostringstream.cc
-  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/internal/pow10_helper.cc
-  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/internal/utf8.cc
-  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/internal/str_format/arg.cc
-  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/internal/str_format/bind.cc
-  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/internal/str_format/extension.cc
-  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/internal/str_format/float_conversion.cc
-  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/internal/str_format/output.cc
-  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/internal/str_format/parser.cc
 )
 target_include_directories(gl_delegate PUBLIC
   /usr/local/include/
@@ -323,6 +307,8 @@ target_link_libraries(gl_delegate tensorflow-lite)
 
 ## global compile option
 target_compile_options(tensorflow-lite PUBLIC -O3 -DNDEBUG -fPIC -DTFLITE_GPU_DELEGATE_ENABLED)
+
+add_subdirectory(${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl)
 
 ## benchmark
 add_executable(tflite-benchmark
@@ -337,4 +323,8 @@ add_executable(tflite-benchmark
   ${TENSORFLOW_LITE_DIR}/profiling/time.cc
   ${TENSORFLOW_LITE_DIR}/../core/util/stats_calculator.cc
 )
-target_link_libraries(tflite-benchmark tensorflow-lite gl_delegate EGL GLESv2)
+target_link_libraries(tflite-benchmark
+  tensorflow-lite gl_delegate
+  EGL GLESv2
+  absl::strings absl::container absl::hash absl::any absl::str_format absl::flat_hash_set
+)

--- a/tensorflow/lite/tools/CMakeLists.txt
+++ b/tensorflow/lite/tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(TENSORFLOW_LITE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../)
+set(TENSORFLOW_LITE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/..)
 set(CMAKE_CXX_STANDARD 11)
 
 add_library(tensorflow-lite
@@ -158,17 +158,16 @@ add_library(tensorflow-lite
   ${TENSORFLOW_LITE_DIR}/kernels/internal/optimized/sse_tensor_utils.cc
   ${TENSORFLOW_LITE_DIR}/kernels/internal/reference/portable_tensor_utils.cc
   ${TENSORFLOW_LITE_DIR}/profiling/time.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/nnapi/nnapi_delegate_disabled.cc
+  ${TENSORFLOW_LITE_DIR}/nnapi/nnapi_implementation_disabled.cc
   ${TENSORFLOW_LITE_DIR}/tools/make/downloads/farmhash/src/farmhash.cc
   ${TENSORFLOW_LITE_DIR}/tools/make/downloads/fft2d/fftsg.c
   ${TENSORFLOW_LITE_DIR}/tools/make/downloads/flatbuffers/src/util.cpp
-  ${TENSORFLOW_LITE_DIR}/delegates/nnapi/nnapi_delegate_disabled.cc
-  ${TENSORFLOW_LITE_DIR}/nnapi/nnapi_implementation_disabled.cc
 )
 
 target_include_directories(tensorflow-lite PUBLIC
   ${TENSORFLOW_LITE_DIR}/../..
   ${TENSORFLOW_LITE_DIR}/tools/make/downloads/flatbuffers/include
-  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl
 )
 target_include_directories(tensorflow-lite PRIVATE
   ${TENSORFLOW_LITE_DIR}/tools/make/downloads/
@@ -181,18 +180,6 @@ target_link_libraries(tensorflow-lite PUBLIC
   stdc++ m z
 )
 
-## minimal example
-#add_executable(tflite-minimal
-#  ${TENSORFLOW_LITE_DIR}/examples/minimal/minimal.cc
-#)
-#target_link_libraries(tflite-minimal tensorflow-lite gl_delegate EGL GLESv2)
-
-## GPU delegate
-if(NOT CMAKE_CROSSCOMPILING)
-  set(FLATBUFFERS_BUILD_FLATC ON)
-  add_subdirectory(${TENSORFLOW_LITE_DIR}/tools/make/downloads/flatbuffers)
-endif()
-
 add_custom_command(
   OUTPUT  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/common_generated.h
   OUTPUT  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiled_model_generated.h
@@ -202,8 +189,7 @@ add_custom_command(
           ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiled_model.fbs
           ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/metadata.fbs
           ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/workgroups.fbs
-          ${CMAKE_CURRENT_BINARY_DIR}/make/downloads/flatbuffers/flatc
-  COMMAND ${CMAKE_CURRENT_BINARY_DIR}/make/downloads/flatbuffers/flatc
+  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/host/flatc
           --cpp --scoped-enums -o ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/
           ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/common.fbs
           ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiled_model.fbs
@@ -296,14 +282,13 @@ add_library(gl_delegate
   # headers
   ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/metadata_generated.h
 )
-target_include_directories(gl_delegate PUBLIC
-  /usr/local/include/
-)
 target_include_directories(gl_delegate PRIVATE
   ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl
   ${TENSORFLOW_LITE_DIR}/tools/make/downloads/fp16/include
 )
-target_link_libraries(gl_delegate tensorflow-lite)
+target_link_libraries(gl_delegate
+  tensorflow-lite
+)
 
 ## global compile option
 target_compile_options(tensorflow-lite PUBLIC -O3 -DNDEBUG -fPIC -DTFLITE_GPU_DELEGATE_ENABLED)

--- a/tensorflow/lite/tools/CMakeLists.txt
+++ b/tensorflow/lite/tools/CMakeLists.txt
@@ -291,7 +291,7 @@ target_link_libraries(gl_delegate
 )
 
 ## global compile option
-target_compile_options(tensorflow-lite PUBLIC -O3 -DNDEBUG -fPIC -DTFLITE_GPU_DELEGATE_ENABLED)
+target_compile_options(tensorflow-lite PUBLIC -O3 -DNDEBUG -fPIC -DTFLITE_CONFIG_GPU_GLES)
 
 add_subdirectory(${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl)
 

--- a/tensorflow/lite/tools/CMakeLists.txt
+++ b/tensorflow/lite/tools/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(tensorflow-lite
   ${TENSORFLOW_LITE_DIR}/experimental/ruy/block_map.cc
   ${TENSORFLOW_LITE_DIR}/experimental/ruy/blocking_counter.cc
   ${TENSORFLOW_LITE_DIR}/experimental/ruy/context.cc
+  ${TENSORFLOW_LITE_DIR}/experimental/ruy/detect_arm.cc
   ${TENSORFLOW_LITE_DIR}/experimental/ruy/have_built_path_for_avx2.cc
   ${TENSORFLOW_LITE_DIR}/experimental/ruy/have_built_path_for_avx512.cc
   ${TENSORFLOW_LITE_DIR}/experimental/ruy/kernel_arm32.cc
@@ -177,7 +178,7 @@ target_include_directories(tensorflow-lite PRIVATE
   ${TENSORFLOW_LITE_DIR}/tools/make/downloads/farmhash/src
 )
 target_link_libraries(tensorflow-lite PUBLIC
-  stdc++ pthread m z
+  stdc++ m z
 )
 
 ## minimal example
@@ -185,11 +186,12 @@ add_executable(tflite-minimal
   ${TENSORFLOW_LITE_DIR}/examples/minimal/minimal.cc
 )
 target_link_libraries(tflite-minimal tensorflow-lite gl_delegate EGL GLESv2)
-target_link_directories(tflite-minimal PUBLIC /usr/local/lib)
 
 ## GPU delegate
-set(FLATBUFFERS_BUILD_FLATC ON)
-add_subdirectory(${TENSORFLOW_LITE_DIR}/tools/make/downloads/flatbuffers)
+if(NOT CMAKE_CROSSCOMPILING)
+  set(FLATBUFFERS_BUILD_FLATC ON)
+  add_subdirectory(${TENSORFLOW_LITE_DIR}/tools/make/downloads/flatbuffers)
+endif()
 
 add_custom_command(
   OUTPUT  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/common_generated.h
@@ -336,4 +338,3 @@ add_executable(tflite-benchmark
   ${TENSORFLOW_LITE_DIR}/../core/util/stats_calculator.cc
 )
 target_link_libraries(tflite-benchmark tensorflow-lite gl_delegate EGL GLESv2)
-target_link_directories(tflite-benchmark PUBLIC /usr/local/lib)

--- a/tensorflow/lite/tools/CMakeLists.txt
+++ b/tensorflow/lite/tools/CMakeLists.txt
@@ -168,6 +168,7 @@ add_library(tensorflow-lite
 target_include_directories(tensorflow-lite PUBLIC
   ${TENSORFLOW_LITE_DIR}/../..
   ${TENSORFLOW_LITE_DIR}/tools/make/downloads/flatbuffers/include
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl
 )
 target_include_directories(tensorflow-lite PRIVATE
   ${TENSORFLOW_LITE_DIR}/tools/make/downloads/
@@ -180,118 +181,214 @@ target_link_libraries(tensorflow-lite PUBLIC
   stdc++ m z
 )
 
-add_custom_command(
-  OUTPUT  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/common_generated.h
-  OUTPUT  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiled_model_generated.h
-          ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/metadata_generated.h
-          ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/workgroups_generated.h
-  DEPENDS ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/common.fbs
-          ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiled_model.fbs
-          ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/metadata.fbs
-          ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/workgroups.fbs
-  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/host/flatc
-          --cpp --scoped-enums -o ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/
-          ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/common.fbs
-          ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiled_model.fbs
-          ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/metadata.fbs
-          ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/workgroups.fbs
-)
+include(CheckIncludeFile)
+CHECK_INCLUDE_FILE('GLES3/gl31.h' ENABLE_GLES_DELEGATE)
+find_package(OpenCL)
 
-add_library(gl_delegate
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/api.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/delegate.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl_delegate.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/gl_program.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/request_gpu_info.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/converter.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/custom_registry.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/lstm.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/max_unpooling.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/conv.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/depthwise_conv.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/softmax.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/prelu.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/transpose_conv.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/fully_connected.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/pad.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/mul.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/relu.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/reshape.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/registry.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/elementwise.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/pooling.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/slice.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/concat.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/upsampling_bilinear.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/add.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/gl_texture.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/egl_context.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/command_queue.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/serialization.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/gl_shader.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/api.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/api2.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/converters/phwc4_to_bhwc.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/converters/bhwc_to_phwc4.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/egl_surface.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/workgroups/default_calculator.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/workgroups/best_effort_calculator.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/workgroups/calculator.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/workgroups/ideal_workgroup_picker.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/workgroups/calculator_from_metadata.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/object_manager.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/runtime.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/gl_errors.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/egl_environment.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/float16_conversions.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/gl_buffer.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/gl_sync.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiler/compiled_node.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiler/fuse_inline.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiler/fuse_inplace.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiler/fuse_auto_input.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiler/variable_accessor.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiler/shader_codegen.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiler/preprocessor.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiler/rename.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiler/object_accessor.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiler.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/convert.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/data_type.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/gpu_info.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/memory_management.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/memory_management/greedy_by_breadth_assignment.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/memory_management/greedy_by_size_assignment.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/memory_management/internal.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/memory_management/min_cost_flow_assignment.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/memory_management/types.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/model_builder.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/model_transformer.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/operations.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/shape.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/transformations/general_transformations.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/transformations/remove_noop.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/transformations/fuse_mul_to_conv.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/transformations/add_bias.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/transformations/match_dilated_convolution.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/transformations/make_fully_connected.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/transformations/merge_padding_with.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/transformations/make_padding.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/transformations/general_transformations.cc
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/transformations/fuse_add_to_conv.cc
-  # headers
-  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/metadata_generated.h
-)
-target_include_directories(gl_delegate PRIVATE
-  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl
-  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/fp16/include
-)
-target_link_libraries(gl_delegate
-  tensorflow-lite
-)
+#### OpenGLES delegate
+if(${ENABLE_GLES_DELEGATE})
+  add_custom_command(
+    OUTPUT  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/common_generated.h
+    OUTPUT  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiled_model_generated.h
+            ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/metadata_generated.h
+            ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/workgroups_generated.h
+    DEPENDS ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/common.fbs
+            ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiled_model.fbs
+            ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/metadata.fbs
+            ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/workgroups.fbs
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/host/flatc
+            --cpp --scoped-enums -o ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/
+            ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/common.fbs
+            ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiled_model.fbs
+            ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/metadata.fbs
+            ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/workgroups.fbs
+  )
+  
+  add_library(gl_delegate
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl_delegate.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/gl_program.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/request_gpu_info.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/converter.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/custom_registry.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/lstm.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/max_unpooling.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/conv.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/depthwise_conv.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/softmax.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/prelu.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/transpose_conv.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/fully_connected.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/pad.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/mul.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/relu.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/reshape.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/registry.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/elementwise.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/pooling.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/slice.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/concat.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/upsampling_bilinear.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/add.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/gl_texture.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/egl_context.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/command_queue.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/serialization.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/gl_shader.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/api.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/api2.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/converters/phwc4_to_bhwc.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/converters/bhwc_to_phwc4.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/egl_surface.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/workgroups/default_calculator.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/workgroups/best_effort_calculator.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/workgroups/calculator.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/workgroups/ideal_workgroup_picker.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/workgroups/calculator_from_metadata.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/object_manager.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/runtime.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/gl_errors.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/egl_environment.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/float16_conversions.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/gl_buffer.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/gl_sync.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiler/compiled_node.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiler/fuse_inline.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiler/fuse_inplace.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiler/fuse_auto_input.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiler/variable_accessor.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiler/shader_codegen.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiler/preprocessor.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiler/rename.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiler/object_accessor.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiler.cc
+    # headers
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/metadata_generated.h
+  )
+  target_link_libraries(gl_delegate
+    gpu_delegate
+  )
+endif()
+
+#### OpenCL delegate
+if(OpenCL_FOUND)
+  add_library(cl_delegate
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/lstm.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/sigmoid.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/max_unpooling.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/softmax.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/padding.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/strided_slice.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/prelu.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/convolution_transposed.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/transpose.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/depth_wise_conv_3x3.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/conv_texture.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/conv_buffer.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/convolution_transposed_thin.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/fully_connected_texture.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/convolution_transposed_3x3_thin.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/relu.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/gpu_operation.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/reshape.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/depth_wise_conv.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/softmax1x1.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/util.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/upsample.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/abs.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/concat_z.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/converter.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/multiply_add.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/pooling.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/conv_powervr.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/flt_type.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/concat_xy.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/conv_buffer_1x1.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/apply_mask.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/conv_constants.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/reshapex4.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/work_group_picking.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/add.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/texture2d.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/linear_storage.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/cl_event.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/gl_interop.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/inference_context.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/tensor.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/cl_command_queue.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/precision.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/api.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/environment.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/buffer.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/cl_program.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/testing/performance_profiling.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/util.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/cl_context.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/cl_device.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/opencl_wrapper.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/tensor_type.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/program_cache.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/egl_sync.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/cl_kernel.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/cl_image_format.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/cl_memory.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/gpu_api_delegate.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/tensor_type_util.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/selectors/fully_connected_selector.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/selectors/dw_convolution_selector.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/selectors/operation_selector.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/selectors/convolution_transposed_selector.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/selectors/convolution_selector.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/selectors/simple_selectors.cc
+  )
+  target_link_libraries(cl_delegate
+    gpu_delegate
+  )
+endif()
+
+if((OpenCL_FOUND) OR (${ENABLE_GLES_DELEGATE}))
+  add_library(gpu_delegate
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/api.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/delegate.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/convert.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/data_type.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/gpu_info.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/memory_management.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/memory_management/greedy_by_breadth_assignment.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/memory_management/greedy_by_size_assignment.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/memory_management/internal.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/memory_management/min_cost_flow_assignment.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/memory_management/types.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/model_builder.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/model_transformer.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/operations.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/shape.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/transformations/general_transformations.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/transformations/remove_noop.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/transformations/fuse_mul_to_conv.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/transformations/add_bias.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/transformations/match_dilated_convolution.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/transformations/make_fully_connected.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/transformations/merge_padding_with.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/transformations/make_padding.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/transformations/general_transformations.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/transformations/fuse_add_to_conv.cc
+  )
+  target_link_libraries(gpu_delegate
+    tensorflow-lite
+  )
+  target_include_directories(gpu_delegate PUBLIC
+    ${TENSORFLOW_LITE_DIR}/tools/make/downloads/fp16/include
+  )
+  if(OpenCL_FOUND)
+    target_compile_options(gpu_delegate PUBLIC -DTFLITE_CONFIG_GPU_CL -DTFLITE_CONFIG_GPU_NO_EGL -framework OpenCL)
+  endif()
+  if(${ENABLE_GLES_DELEGATE})
+    target_compile_options(gpu_delegate PUBLIC -DTFLITE_CONFIG_GPU_GLES)
+  endif()
+endif()
 
 ## global compile option
-target_compile_options(tensorflow-lite PUBLIC -O3 -DNDEBUG -fPIC -DTFLITE_CONFIG_GPU_GLES)
+target_compile_options(tensorflow-lite PUBLIC -O3 -DNDEBUG -fPIC)
 
 add_subdirectory(${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl)
 
@@ -309,7 +406,7 @@ add_executable(tflite-benchmark
   ${TENSORFLOW_LITE_DIR}/../core/util/stats_calculator.cc
 )
 target_link_libraries(tflite-benchmark
-  tensorflow-lite gl_delegate
-  EGL GLESv2
+  tensorflow-lite
+#  gl_delegate EGL GLESv2
   absl::strings absl::container absl::hash absl::any absl::str_format absl::flat_hash_set
 )

--- a/tensorflow/lite/tools/CMakeLists.txt
+++ b/tensorflow/lite/tools/CMakeLists.txt
@@ -209,6 +209,7 @@ add_custom_command(
 )
 
 add_library(gl_delegate
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/delegate.cc
   ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl_delegate.cc
   ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/gl_program.cc
   ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/lstm.cc

--- a/tensorflow/lite/tools/CMakeLists.txt
+++ b/tensorflow/lite/tools/CMakeLists.txt
@@ -1,0 +1,338 @@
+set(TENSORFLOW_LITE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../)
+set(CMAKE_CXX_STANDARD 11)
+
+add_library(tensorflow-lite
+  ${TENSORFLOW_LITE_DIR}/allocation.cc
+  ${TENSORFLOW_LITE_DIR}/arena_planner.cc
+  ${TENSORFLOW_LITE_DIR}/external_cpu_backend_context.cc
+  ${TENSORFLOW_LITE_DIR}/graph_info.cc
+  ${TENSORFLOW_LITE_DIR}/interpreter.cc
+  ${TENSORFLOW_LITE_DIR}/minimal_logging.cc
+  ${TENSORFLOW_LITE_DIR}/minimal_logging_default.cc
+  ${TENSORFLOW_LITE_DIR}/mmap_allocation.cc
+  ${TENSORFLOW_LITE_DIR}/mmap_allocation_disabled.cc
+  ${TENSORFLOW_LITE_DIR}/model.cc
+  ${TENSORFLOW_LITE_DIR}/mutable_op_resolver.cc
+  ${TENSORFLOW_LITE_DIR}/optional_debug_tools.cc
+  ${TENSORFLOW_LITE_DIR}/simple_memory_arena.cc
+  ${TENSORFLOW_LITE_DIR}/stderr_reporter.cc
+  ${TENSORFLOW_LITE_DIR}/string_util.cc
+  ${TENSORFLOW_LITE_DIR}/util.cc
+  ${TENSORFLOW_LITE_DIR}/c/c_api_internal.c
+  ${TENSORFLOW_LITE_DIR}/experimental/c/c_api_experimental.cc
+  ${TENSORFLOW_LITE_DIR}/experimental/c/c_api.cc
+  ${TENSORFLOW_LITE_DIR}/core/subgraph.cc
+  ${TENSORFLOW_LITE_DIR}/core/api/error_reporter.cc
+  ${TENSORFLOW_LITE_DIR}/core/api/flatbuffer_conversions.cc
+  ${TENSORFLOW_LITE_DIR}/core/api/op_resolver.cc
+  ${TENSORFLOW_LITE_DIR}/core/api/tensor_utils.cc
+  ${TENSORFLOW_LITE_DIR}/experimental/resource_variable/resource_variable.cc
+  ${TENSORFLOW_LITE_DIR}/experimental/ruy/allocator.cc
+  ${TENSORFLOW_LITE_DIR}/experimental/ruy/block_map.cc
+  ${TENSORFLOW_LITE_DIR}/experimental/ruy/blocking_counter.cc
+  ${TENSORFLOW_LITE_DIR}/experimental/ruy/context.cc
+  ${TENSORFLOW_LITE_DIR}/experimental/ruy/have_built_path_for_avx2.cc
+  ${TENSORFLOW_LITE_DIR}/experimental/ruy/have_built_path_for_avx512.cc
+  ${TENSORFLOW_LITE_DIR}/experimental/ruy/kernel_arm32.cc
+  ${TENSORFLOW_LITE_DIR}/experimental/ruy/kernel_arm64.cc
+  ${TENSORFLOW_LITE_DIR}/experimental/ruy/kernel_avx2.cc
+  ${TENSORFLOW_LITE_DIR}/experimental/ruy/kernel_avx512.cc
+  ${TENSORFLOW_LITE_DIR}/experimental/ruy/pack_arm.cc
+  ${TENSORFLOW_LITE_DIR}/experimental/ruy/pack_avx2.cc
+  ${TENSORFLOW_LITE_DIR}/experimental/ruy/pack_avx512.cc
+  ${TENSORFLOW_LITE_DIR}/experimental/ruy/pmu.cc
+  ${TENSORFLOW_LITE_DIR}/experimental/ruy/thread_pool.cc
+  ${TENSORFLOW_LITE_DIR}/experimental/ruy/trace.cc
+  ${TENSORFLOW_LITE_DIR}/experimental/ruy/trmul.cc
+  ${TENSORFLOW_LITE_DIR}/experimental/ruy/tune.cc
+  ${TENSORFLOW_LITE_DIR}/experimental/ruy/wait.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/activations.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/add.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/add_n.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/arg_min_max.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/assign_variable.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/audio_spectrogram.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/basic_rnn.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/batch_to_space_nd.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/bidirectional_sequence_lstm.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/bidirectional_sequence_rnn.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/cast.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/ceil.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/comparisons.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/concatenation.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/conv.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/cpu_backend_context.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/cpu_backend_gemm_eigen.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/depthwise_conv.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/depth_to_space.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/dequantize.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/detection_postprocess.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/div.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/eigen_support.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/elementwise.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/embedding_lookup.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/embedding_lookup_sparse.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/exp.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/expand_dims.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/fake_quant.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/fill.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/floor.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/floor_div.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/floor_mod.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/fully_connected.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/gather.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/gather_nd.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/hashtable_lookup.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/if.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/kernel_util.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/l2norm.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/local_response_norm.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/logical.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/lsh_projection.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/lstm.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/lstm_eval.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/matrix_diag.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/matrix_set_diag.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/maximum_minimum.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/mfcc.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/mirror_pad.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/mul.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/neg.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/non_max_suppression.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/one_hot.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/pack.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/pad.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/pooling.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/pow.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/quantize.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/range.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/rank.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/read_variable.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/reduce.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/register.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/register_ref.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/reshape.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/resize_bilinear.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/resize_nearest_neighbor.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/reverse.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/reverse_sequence.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/rfft2d.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/round.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/select.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/shape.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/skip_gram.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/slice.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/space_to_batch_nd.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/space_to_depth.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/sparse_to_dense.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/split.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/split_v.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/squared_difference.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/squeeze.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/strided_slice.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/sub.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/svdf.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/tile.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/topk_v2.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/transpose.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/transpose_conv.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/unidirectional_sequence_lstm.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/unidirectional_sequence_rnn.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/unique.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/unpack.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/where.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/while.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/zeros_like.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/internal/spectrogram.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/internal/mfcc.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/internal/mfcc_dct.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/internal/tensor_utils.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/internal/optimized/neon_tensor_utils.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/internal/optimized/sse_tensor_utils.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/internal/mfcc_mel_filterbank.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/internal/reference/portable_tensor_utils.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/internal/kernel_utils.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/internal/quantization_util.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/internal/optimized/neon_tensor_utils.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/internal/optimized/sse_tensor_utils.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/internal/reference/portable_tensor_utils.cc
+  ${TENSORFLOW_LITE_DIR}/profiling/time.cc
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/farmhash/src/farmhash.cc
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/fft2d/fftsg.c
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/flatbuffers/src/util.cpp
+  ${TENSORFLOW_LITE_DIR}/delegates/nnapi/nnapi_delegate_disabled.cc
+  ${TENSORFLOW_LITE_DIR}/nnapi/nnapi_implementation_disabled.cc
+)
+
+target_include_directories(tensorflow-lite PUBLIC
+  ${TENSORFLOW_LITE_DIR}/../..
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/flatbuffers/include
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl
+)
+target_include_directories(tensorflow-lite PRIVATE
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/eigen
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/gemmlowp
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/neon_2_sse
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/farmhash/src
+)
+target_link_libraries(tensorflow-lite PUBLIC
+  stdc++ pthread m z
+)
+
+## minimal example
+add_executable(tflite-minimal
+  ${TENSORFLOW_LITE_DIR}/examples/minimal/minimal.cc
+)
+target_link_libraries(tflite-minimal tensorflow-lite gl_delegate EGL GLESv2)
+target_link_directories(tflite-minimal PUBLIC /usr/local/lib)
+
+## GPU delegate
+set(FLATBUFFERS_BUILD_FLATC ON)
+add_subdirectory(${TENSORFLOW_LITE_DIR}/tools/make/downloads/flatbuffers)
+
+add_custom_command(
+  OUTPUT  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/common_generated.h
+  OUTPUT  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiled_model_generated.h
+          ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/metadata_generated.h
+          ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/workgroups_generated.h
+  DEPENDS ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/common.fbs
+          ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiled_model.fbs
+          ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/metadata.fbs
+          ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/workgroups.fbs
+  COMMAND ${CMAKE_CURRENT_BINARY_DIR}/make/downloads/flatbuffers/flatc
+          --cpp --scoped-enums -o ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/
+          ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/common.fbs
+          ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiled_model.fbs
+          ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/metadata.fbs
+          ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/workgroups.fbs
+)
+
+add_library(gl_delegate
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl_delegate.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/gl_program.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/lstm.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/max_unpooling.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/conv.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/depthwise_conv.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/softmax.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/prelu.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/transpose_conv.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/fully_connected.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/pad.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/mul.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/relu.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/reshape.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/registry.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/elementwise.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/pooling.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/slice.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/concat.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/upsampling_bilinear.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/kernels/add.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/gl_texture.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/egl_context.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/command_queue.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/serialization.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/gl_shader.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/api.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/converters/phwc4_to_bhwc.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/converters/bhwc_to_phwc4.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/egl_surface.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/workgroups/default_calculator.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/workgroups/best_effort_calculator.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/workgroups/calculator.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/workgroups/ideal_workgroup_picker.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/workgroups/calculator_from_metadata.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/object_manager.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/runtime.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/gl_errors.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/egl_environment.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/float16_conversions.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/gl_buffer.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/gl_sync.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiler/compiled_node.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiler/fuse_inline.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiler/fuse_inplace.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiler/fuse_auto_input.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiler/variable_accessor.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiler/shader_codegen.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiler/preprocessor.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiler/rename.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiler/object_accessor.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiler.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/convert.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/data_type.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/gpu_info.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/model_builder.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/model_transformer.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/operations.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/shape.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/transformations/general_transformations.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/transformations/remove_noop.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/transformations/fuse_mul_to_conv.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/transformations/add_bias.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/transformations/match_dilated_convolution.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/transformations/make_fully_connected.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/transformations/merge_padding_with.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/transformations/make_padding.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/transformations/general_transformations.cc
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/transformations/fuse_add_to_conv.cc
+  # headers
+  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/metadata_generated.h
+  # abseil
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/base/internal/raw_logging.cc
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/base/internal/throw_delegate.cc
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/numeric/int128.cc
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/types/bad_variant_access.cc
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/types/bad_any_cast.cc
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/ascii.cc
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/charconv.cc
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/escaping.cc
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/match.cc
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/numbers.cc
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/substitute.cc
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/str_cat.cc
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/str_replace.cc
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/str_split.cc
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/string_view.cc
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/internal/charconv_bigint.cc
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/internal/charconv_parse.cc
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/internal/memutil.cc
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/internal/ostringstream.cc
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/internal/pow10_helper.cc
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/internal/utf8.cc
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/internal/str_format/arg.cc
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/internal/str_format/bind.cc
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/internal/str_format/extension.cc
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/internal/str_format/float_conversion.cc
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/internal/str_format/output.cc
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl/absl/strings/internal/str_format/parser.cc
+)
+target_include_directories(gl_delegate PUBLIC
+  /usr/local/include/
+)
+target_include_directories(gl_delegate PRIVATE
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/absl
+  ${TENSORFLOW_LITE_DIR}/tools/make/downloads/fp16/include
+)
+target_link_libraries(gl_delegate tensorflow-lite)
+
+## global compile option
+target_compile_options(tensorflow-lite PUBLIC -O3 -DNDEBUG -fPIC -DTFLITE_GPU_DELEGATE_ENABLED)
+
+## benchmark
+add_executable(tflite-benchmark
+  ${TENSORFLOW_LITE_DIR}/tools/benchmark/benchmark_main.cc
+  ${TENSORFLOW_LITE_DIR}/tools/benchmark/benchmark_model.cc
+  ${TENSORFLOW_LITE_DIR}/tools/benchmark/benchmark_params.cc
+  ${TENSORFLOW_LITE_DIR}/tools/benchmark/benchmark_tflite_model.cc
+  ${TENSORFLOW_LITE_DIR}/tools/benchmark/benchmark_utils.cc
+  ${TENSORFLOW_LITE_DIR}/tools/evaluation/utils.cc
+  ${TENSORFLOW_LITE_DIR}/tools/command_line_flags.cc
+  ${TENSORFLOW_LITE_DIR}/profiling/profile_summarizer.cc
+  ${TENSORFLOW_LITE_DIR}/profiling/time.cc
+  ${TENSORFLOW_LITE_DIR}/../core/util/stats_calculator.cc
+)
+target_link_libraries(tflite-benchmark tensorflow-lite gl_delegate EGL GLESv2)
+target_link_directories(tflite-benchmark PUBLIC /usr/local/lib)

--- a/tensorflow/lite/tools/CMakeLists.txt
+++ b/tensorflow/lite/tools/CMakeLists.txt
@@ -18,15 +18,15 @@ add_library(tensorflow-lite
   ${TENSORFLOW_LITE_DIR}/stderr_reporter.cc
   ${TENSORFLOW_LITE_DIR}/string_util.cc
   ${TENSORFLOW_LITE_DIR}/util.cc
-  ${TENSORFLOW_LITE_DIR}/c/c_api_internal.c
-  ${TENSORFLOW_LITE_DIR}/experimental/c/c_api_experimental.cc
-  ${TENSORFLOW_LITE_DIR}/experimental/c/c_api.cc
+  ${TENSORFLOW_LITE_DIR}/c/c_api_experimental.cc
+  ${TENSORFLOW_LITE_DIR}/c/c_api.cc
+  ${TENSORFLOW_LITE_DIR}/c/common.c
   ${TENSORFLOW_LITE_DIR}/core/subgraph.cc
   ${TENSORFLOW_LITE_DIR}/core/api/error_reporter.cc
   ${TENSORFLOW_LITE_DIR}/core/api/flatbuffer_conversions.cc
   ${TENSORFLOW_LITE_DIR}/core/api/op_resolver.cc
   ${TENSORFLOW_LITE_DIR}/core/api/tensor_utils.cc
-  ${TENSORFLOW_LITE_DIR}/experimental/resource_variable/resource_variable.cc
+  ${TENSORFLOW_LITE_DIR}/experimental/resource/resource_variable.cc
   ${TENSORFLOW_LITE_DIR}/experimental/ruy/allocator.cc
   ${TENSORFLOW_LITE_DIR}/experimental/ruy/block_map.cc
   ${TENSORFLOW_LITE_DIR}/experimental/ruy/blocking_counter.cc
@@ -42,6 +42,7 @@ add_library(tensorflow-lite
   ${TENSORFLOW_LITE_DIR}/experimental/ruy/pack_avx2.cc
   ${TENSORFLOW_LITE_DIR}/experimental/ruy/pack_avx512.cc
   ${TENSORFLOW_LITE_DIR}/experimental/ruy/pmu.cc
+  ${TENSORFLOW_LITE_DIR}/experimental/ruy/prepacked_cache.cc
   ${TENSORFLOW_LITE_DIR}/experimental/ruy/thread_pool.cc
   ${TENSORFLOW_LITE_DIR}/experimental/ruy/trace.cc
   ${TENSORFLOW_LITE_DIR}/experimental/ruy/trmul.cc
@@ -64,6 +65,7 @@ add_library(tensorflow-lite
   ${TENSORFLOW_LITE_DIR}/kernels/conv.cc
   ${TENSORFLOW_LITE_DIR}/kernels/cpu_backend_context.cc
   ${TENSORFLOW_LITE_DIR}/kernels/cpu_backend_gemm_eigen.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/densify.cc
   ${TENSORFLOW_LITE_DIR}/kernels/depthwise_conv.cc
   ${TENSORFLOW_LITE_DIR}/kernels/depth_to_space.cc
   ${TENSORFLOW_LITE_DIR}/kernels/dequantize.cc
@@ -100,6 +102,7 @@ add_library(tensorflow-lite
   ${TENSORFLOW_LITE_DIR}/kernels/mul.cc
   ${TENSORFLOW_LITE_DIR}/kernels/neg.cc
   ${TENSORFLOW_LITE_DIR}/kernels/non_max_suppression.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/numeric_verify.cc
   ${TENSORFLOW_LITE_DIR}/kernels/one_hot.cc
   ${TENSORFLOW_LITE_DIR}/kernels/pack.cc
   ${TENSORFLOW_LITE_DIR}/kernels/pad.cc
@@ -119,6 +122,7 @@ add_library(tensorflow-lite
   ${TENSORFLOW_LITE_DIR}/kernels/reverse_sequence.cc
   ${TENSORFLOW_LITE_DIR}/kernels/rfft2d.cc
   ${TENSORFLOW_LITE_DIR}/kernels/round.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/scatter_nd.cc
   ${TENSORFLOW_LITE_DIR}/kernels/select.cc
   ${TENSORFLOW_LITE_DIR}/kernels/shape.cc
   ${TENSORFLOW_LITE_DIR}/kernels/skip_gram.cc
@@ -154,10 +158,12 @@ add_library(tensorflow-lite
   ${TENSORFLOW_LITE_DIR}/kernels/internal/reference/portable_tensor_utils.cc
   ${TENSORFLOW_LITE_DIR}/kernels/internal/kernel_utils.cc
   ${TENSORFLOW_LITE_DIR}/kernels/internal/quantization_util.cc
+  ${TENSORFLOW_LITE_DIR}/kernels/internal/transpose_utils.cc
   ${TENSORFLOW_LITE_DIR}/kernels/internal/optimized/neon_tensor_utils.cc
   ${TENSORFLOW_LITE_DIR}/kernels/internal/optimized/sse_tensor_utils.cc
   ${TENSORFLOW_LITE_DIR}/kernels/internal/reference/portable_tensor_utils.cc
   ${TENSORFLOW_LITE_DIR}/profiling/time.cc
+  ${TENSORFLOW_LITE_DIR}/profiling/memory_info.cc
   ${TENSORFLOW_LITE_DIR}/delegates/nnapi/nnapi_delegate_disabled.cc
   ${TENSORFLOW_LITE_DIR}/nnapi/nnapi_implementation_disabled.cc
   ${TENSORFLOW_LITE_DIR}/tools/make/downloads/farmhash/src/farmhash.cc
@@ -192,7 +198,7 @@ if(${TFLITE_DELEGATE_GL})
             ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiled_model.fbs
             ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/metadata.fbs
             ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/workgroups.fbs
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/host/flatc
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/cmake/host/flatc
             --cpp --scoped-enums -o ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/
             ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/common.fbs
             ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiled_model.fbs
@@ -356,6 +362,7 @@ if((${TFLITE_DELEGATE_GL}) OR (${TFLITE_DELEGATE_CL}))
     ${TENSORFLOW_LITE_DIR}/delegates/gpu/api.cc
     ${TENSORFLOW_LITE_DIR}/delegates/gpu/delegate.cc
     ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/convert.cc
+    ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/custom_parsers.cc
     ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/data_type.cc
     ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/gpu_info.cc
     ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/memory_management.cc

--- a/tensorflow/lite/tools/CMakeLists.txt
+++ b/tensorflow/lite/tools/CMakeLists.txt
@@ -181,12 +181,8 @@ target_link_libraries(tensorflow-lite PUBLIC
   stdc++ m z
 )
 
-include(CheckIncludeFile)
-CHECK_INCLUDE_FILE('GLES3/gl31.h' ENABLE_GLES_DELEGATE)
-find_package(OpenCL)
-
 #### OpenGLES delegate
-if(${ENABLE_GLES_DELEGATE})
+if(${TFLITE_DELEGATE_GL})
   add_custom_command(
     OUTPUT  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/common_generated.h
     OUTPUT  ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/compiled_model_generated.h
@@ -204,7 +200,7 @@ if(${ENABLE_GLES_DELEGATE})
             ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/workgroups.fbs
   )
   
-  add_library(gl_delegate
+  set(GL_DELEGATE_SOURCES
     ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl_delegate.cc
     ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/gl_program.cc
     ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/request_gpu_info.cc
@@ -264,14 +260,19 @@ if(${ENABLE_GLES_DELEGATE})
     # headers
     ${TENSORFLOW_LITE_DIR}/delegates/gpu/gl/metadata_generated.h
   )
-  target_link_libraries(gl_delegate
-    gpu_delegate
+  set(GL_DELEGATE_LIBS
+    EGL GLESv2
   )
+  set(GL_DELEGATE_DEFINES
+    "-DTFLITE_CONFIG_GPU_GL"
+  )
+  set(GL_DELEGATE_LIBS    EGL GLESv2)
+  set(GL_DELEGATE_DEFINES "-DTFLITE_CONFIG_GPU_GL")
 endif()
 
 #### OpenCL delegate
-if(OpenCL_FOUND)
-  add_library(cl_delegate
+if(${TFLITE_DELEGATE_CL})
+  set(CL_DELEGATE_SOURCES
     ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/lstm.cc
     ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/sigmoid.cc
     ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/kernels/max_unpooling.cc
@@ -340,13 +341,18 @@ if(OpenCL_FOUND)
     ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/selectors/convolution_selector.cc
     ${TENSORFLOW_LITE_DIR}/delegates/gpu/cl/selectors/simple_selectors.cc
   )
-  target_link_libraries(cl_delegate
-    gpu_delegate
+  set(CL_DELEGATE_LIBS
+    CL
+  )
+  set(CL_DELEGATE_DEFINES
+    "-DTFLITE_CONFIG_GPU_CL -DTFLITE_CONFIG_GPU_NO_EGL"
   )
 endif()
 
-if((OpenCL_FOUND) OR (${ENABLE_GLES_DELEGATE}))
+if((${TFLITE_DELEGATE_GL}) OR (${TFLITE_DELEGATE_CL}))
   add_library(gpu_delegate
+    ${GL_DELEGATE_SOURCES}
+    ${CL_DELEGATE_SOURCES}
     ${TENSORFLOW_LITE_DIR}/delegates/gpu/api.cc
     ${TENSORFLOW_LITE_DIR}/delegates/gpu/delegate.cc
     ${TENSORFLOW_LITE_DIR}/delegates/gpu/common/convert.cc
@@ -375,16 +381,14 @@ if((OpenCL_FOUND) OR (${ENABLE_GLES_DELEGATE}))
   )
   target_link_libraries(gpu_delegate
     tensorflow-lite
+    ${GL_DELEGATE_LIBS}
+    ${CL_DELEGATE_LIBS}
   )
   target_include_directories(gpu_delegate PUBLIC
     ${TENSORFLOW_LITE_DIR}/tools/make/downloads/fp16/include
   )
-  if(OpenCL_FOUND)
-    target_compile_options(gpu_delegate PUBLIC -DTFLITE_CONFIG_GPU_CL -DTFLITE_CONFIG_GPU_NO_EGL -framework OpenCL)
-  endif()
-  if(${ENABLE_GLES_DELEGATE})
-    target_compile_options(gpu_delegate PUBLIC -DTFLITE_CONFIG_GPU_GLES)
-  endif()
+  target_compile_options(gpu_delegate PUBLIC ${GL_DELEGATE_DEFINES} ${CL_DELEGATE_DEFINES})
+  set(GPU_DELEGATE_LIBS gpu_delegate)
 endif()
 
 ## global compile option
@@ -407,6 +411,6 @@ add_executable(tflite-benchmark
 )
 target_link_libraries(tflite-benchmark
   tensorflow-lite
-#  gl_delegate EGL GLESv2
+  ${GPU_DELEGATE_LIBS}
   absl::strings absl::container absl::hash absl::any absl::str_format absl::flat_hash_set
 )

--- a/tensorflow/lite/tools/cmake/build.sh
+++ b/tensorflow/lite/tools/cmake/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
+
+echo "Building host tools now..."
+mkdir -p host && cd host
+cmake ${SCRIPT_DIR}/../make/downloads/flatbuffers
+cmake --build .
+cd ..
+
+echo "Building target libraries and tools now..."
+mkdir -p target && cd target
+cmake "$@" ${SCRIPT_DIR}/..
+cmake --build .
+cd ..

--- a/tensorflow/lite/tools/evaluation/utils.cc
+++ b/tensorflow/lite/tools/evaluation/utils.cc
@@ -119,7 +119,7 @@ Interpreter::TfLiteDelegatePtr CreateNNAPIDelegate(
 #endif  // defined(__ANDROID__)
 }
 
-#if defined(__ANDROID__) || defined(TFLITE_CONFIG_GPU_GLES)
+#if defined(__ANDROID__) || defined(TFLITE_CONFIG_GPU_GL)
 Interpreter::TfLiteDelegatePtr CreateGPUDelegate(
     TfLiteGpuDelegateOptionsV2* options) {
   return Interpreter::TfLiteDelegatePtr(TfLiteGpuDelegateV2Create(options),
@@ -128,7 +128,7 @@ Interpreter::TfLiteDelegatePtr CreateGPUDelegate(
 #endif  // defined(__ANDROID__)
 
 Interpreter::TfLiteDelegatePtr CreateGPUDelegate() {
-#if defined(__ANDROID__) || defined(TFLITE_CONFIG_GPU_GLES)
+#if defined(__ANDROID__) || defined(TFLITE_CONFIG_GPU_GL)
   TfLiteGpuDelegateOptionsV2 options = TfLiteGpuDelegateOptionsV2Default();
   options.inference_priority1 = TFLITE_GPU_INFERENCE_PRIORITY_MIN_LATENCY;
   options.inference_preference =

--- a/tensorflow/lite/tools/evaluation/utils.cc
+++ b/tensorflow/lite/tools/evaluation/utils.cc
@@ -119,7 +119,7 @@ Interpreter::TfLiteDelegatePtr CreateNNAPIDelegate(
 #endif  // defined(__ANDROID__)
 }
 
-#if defined(__ANDROID__) || defined(TFLITE_GPU_DELEGATE_ENABLED)
+#if defined(__ANDROID__) || defined(TFLITE_CONFIG_GPU_GLES)
 Interpreter::TfLiteDelegatePtr CreateGPUDelegate(
     TfLiteGpuDelegateOptionsV2* options) {
   return Interpreter::TfLiteDelegatePtr(TfLiteGpuDelegateV2Create(options),
@@ -128,7 +128,7 @@ Interpreter::TfLiteDelegatePtr CreateGPUDelegate(
 #endif  // defined(__ANDROID__)
 
 Interpreter::TfLiteDelegatePtr CreateGPUDelegate() {
-#if defined(__ANDROID__) || defined(TFLITE_GPU_DELEGATE_ENABLED)
+#if defined(__ANDROID__) || defined(TFLITE_CONFIG_GPU_GLES)
   TfLiteGpuDelegateOptionsV2 options = TfLiteGpuDelegateOptionsV2Default();
   options.inference_priority1 = TFLITE_GPU_INFERENCE_PRIORITY_MIN_LATENCY;
   options.inference_preference =

--- a/tensorflow/lite/tools/evaluation/utils.cc
+++ b/tensorflow/lite/tools/evaluation/utils.cc
@@ -117,7 +117,7 @@ Interpreter::TfLiteDelegatePtr CreateNNAPIDelegate(
 #endif  // defined(__ANDROID__)
 }
 
-#if defined(__ANDROID__)
+#if defined(__ANDROID__) || defined(TFLITE_GPU_DELEGATE_ENABLED)
 Interpreter::TfLiteDelegatePtr CreateGPUDelegate(
     TfLiteGpuDelegateOptionsV2* options) {
   return Interpreter::TfLiteDelegatePtr(TfLiteGpuDelegateV2Create(options),
@@ -126,7 +126,7 @@ Interpreter::TfLiteDelegatePtr CreateGPUDelegate(
 #endif  // defined(__ANDROID__)
 
 Interpreter::TfLiteDelegatePtr CreateGPUDelegate() {
-#if defined(__ANDROID__)
+#if defined(__ANDROID__) || defined(TFLITE_GPU_DELEGATE_ENABLED)
   TfLiteGpuDelegateOptionsV2 options = TfLiteGpuDelegateOptionsV2Default();
   options.inference_priority1 = TFLITE_GPU_INFERENCE_PRIORITY_MIN_LATENCY;
   options.inference_preference =

--- a/tensorflow/lite/tools/evaluation/utils.cc
+++ b/tensorflow/lite/tools/evaluation/utils.cc
@@ -73,7 +73,9 @@ TfLiteStatus GetSortedFileNames(
   std::string dir_path = StripTrailingSlashes(directory);
   if ((dir = opendir(dir_path.c_str())) != nullptr) {
     while ((ent = readdir(dir)) != nullptr) {
+#ifndef __QNX__
       if (ent->d_type == DT_DIR) continue;
+#endif
       std::string filename(std::string(ent->d_name));
       size_t lastdot = filename.find_last_of(".");
       std::string ext = lastdot != std::string::npos ? filename.substr(lastdot)

--- a/tensorflow/lite/tools/evaluation/utils.h
+++ b/tensorflow/lite/tools/evaluation/utils.h
@@ -20,7 +20,7 @@ limitations under the License.
 #include <unordered_set>
 #include <vector>
 
-#if defined(__ANDROID__) || defined(TFLITE_CONFIG_GPU_GLES)
+#if defined(__ANDROID__) || defined(TFLITE_CONFIG_GPU_GL)
 #include "tensorflow/lite/delegates/gpu/delegate.h"
 #if (defined(__arm__) || defined(__aarch64__))
 #include "tensorflow/lite/experimental/delegates/hexagon/hexagon_delegate.h"

--- a/tensorflow/lite/tools/evaluation/utils.h
+++ b/tensorflow/lite/tools/evaluation/utils.h
@@ -20,7 +20,7 @@ limitations under the License.
 #include <unordered_set>
 #include <vector>
 
-#if defined(__ANDROID__) || defined(TFLITE_GPU_DELEGATE_ENABLED)
+#if defined(__ANDROID__) || defined(TFLITE_CONFIG_GPU_GLES)
 #include "tensorflow/lite/delegates/gpu/delegate.h"
 #if (defined(__arm__) || defined(__aarch64__))
 #include "tensorflow/lite/experimental/delegates/hexagon/hexagon_delegate.h"

--- a/tensorflow/lite/tools/evaluation/utils.h
+++ b/tensorflow/lite/tools/evaluation/utils.h
@@ -20,7 +20,7 @@ limitations under the License.
 #include <unordered_set>
 #include <vector>
 
-#if defined(__ANDROID__)
+#if defined(__ANDROID__) || defined(TFLITE_GPU_DELEGATE_ENABLED)
 #include "tensorflow/lite/delegates/gpu/delegate.h"
 #if (defined(__arm__) || defined(__aarch64__))
 #include "tensorflow/lite/experimental/delegates/hexagon/hexagon_delegate.h"


### PR DESCRIPTION
Motivation:
Raspberry Pi4 is gaining OpenGL ES3.1 support with Mesa 19.3. Additionally, many SoC's in the embedded space also supporting 3.1 or OpenCL 2.0. Also, there are desktop GPUs which support OpenCL 2.0. Make it possible to compile the GL & CL delegates easily and separatly (e.g. if just OpenGL ES3.1 is available).

This PR adds support for compiling TF Lite with CMake. CMake was choosen, because it's a settled build system, used very often in embedded area and also support by abseil & flatbuffers (which are requirements for GL & CL delegates). It mainly adds a lot of #ifdefs to the code... The PR isn't complete yet, but I quickly want to discuss, if CMake support is desired and if yes, we should deprecate Makefile support.

To use it:
1. run download_dependencies.sh in tools/make
2. run build.sh in tools/cmake (this will run cmake twice, first compiling flatc for the host, then TFLite for the target; additional parameters of build.sh are passed to the "target"-cmake run)

Missing stuff: documentation/README.md, don't compile flatc when no delegate is built, etc.