### PR TITLE
Update third_party/flatbuffers/BUILD.bazel flatc linkopts

### DIFF
--- a/third_party/flatbuffers/BUILD.bazel
+++ b/third_party/flatbuffers/BUILD.bazel
@@ -51,14 +51,13 @@ cc_library(
 cc_binary(
     name = "flatc",
     linkopts = select({
-        "@org_tensorflow//tensorflow:freebsd": [
-	        "-lm",
+        "@//tensorflow:freebsd": [
+            "-lm",
         ],
-        "@org_tensorflow//tensorflow:windows": [],
-        "@org_tensorflow//tensorflow:android": [],
+        "@//tensorflow:windows": [],
         "//conditions:default": [
-	        "-lm",
-	        "-ldl",
+            "-lm",
+            "-ldl",
         ],
     }),
     deps = [

--- a/third_party/flatbuffers/BUILD.bazel
+++ b/third_party/flatbuffers/BUILD.bazel
@@ -50,6 +50,10 @@ cc_library(
 # Public flatc compiler.
 cc_binary(
     name = "flatc",
+    linkopts = [
+        "-lm",
+        "-ldl",
+    ],
     deps = [
         "@flatbuffers//src:flatc",
     ],

--- a/third_party/flatbuffers/BUILD.bazel
+++ b/third_party/flatbuffers/BUILD.bazel
@@ -50,10 +50,17 @@ cc_library(
 # Public flatc compiler.
 cc_binary(
     name = "flatc",
-    linkopts = [
-        "-lm",
-        "-ldl",
-    ],
+    linkopts = select({
+        "@org_tensorflow//tensorflow:freebsd": [
+	        "-lm",
+        ],
+        "@org_tensorflow//tensorflow:windows": [],
+        "@org_tensorflow//tensorflow:android": [],
+        "//conditions:default": [
+	        "-lm",
+	        "-ldl",
+        ],
+    }),
     deps = [
         "@flatbuffers//src:flatc",
     ],


### PR DESCRIPTION
This is suggested for fixing issue #36170 .

I tried building after reverting the linkopts in file `third_party/flatbuffers/BUILD.bazel` to before  https://github.com/tensorflow/tensorflow/commit/adf6e22e4af83afd55e0da3caa7e7959def1e6b6 :
i.e. adding the following under “# Public flatc compiler.”
```
    linkopts = select({
         ":freebsd": [
             "-lm",
         ],
         ":windows": [],
         "//conditions:default": [
             "-lm",
             "-ldl",
         ],
     }),
```
I get the following build error:
```
ERROR: Analysis of target '//tensorflow/tools/pip_package:build_pip_package' failed; build aborted:
@flatbuffers//:freebsd is not a valid configuration key for @flatbuffers//:flatc
```
Then if I leave out the freebsd selection, I get the following build error:
```
ERROR: Analysis of target '//tensorflow/tools/pip_package:build_pip_package' failed; build aborted:
@flatbuffers//:windows is not a valid configuration key for @flatbuffers//:flatc
```
So I was able to build by just using `linkopts = [“-lm”,”-ldl”,],` under  “# Public flatc compiler.”