### PR TITLE
toolchains: migrate platforms to use exec_properties

### DIFF
--- a/third_party/toolchains/BUILD
+++ b/third_party/toolchains/BUILD
@@ -27,16 +27,10 @@ platform(
         "@bazel_tools//platforms:x86_64",
         "@bazel_tools//platforms:linux",
     ],
-    remote_execution_properties = """
-        properties: {
-            name: "container-image"
-            value:"docker://gcr.io/tensorflow-testing/nosla-ubuntu16.04@%s"
-        }
-        properties: {
-            name: "Pool"
-            value: "default"
-        }
-        """ % container_digests["ubuntu16.04"],
+    exec_properties = {
+        "container-image": "docker://gcr.io/tensorflow-testing/nosla-ubuntu16.04@%s" % container_digests["ubuntu16.04"],
+        "Pool": "default",
+    },
 )
 
 # Built with //tensorflow/tools/ci_build/Dockerfile.rbe.cpu-centos6.
@@ -46,16 +40,10 @@ platform(
         "@bazel_tools//platforms:x86_64",
         "@bazel_tools//platforms:linux",
     ],
-    remote_execution_properties = """
-        properties: {
-            name: "container-image"
-            value:"docker://gcr.io/tensorflow-testing/nosla-centos6@%s"
-        }
-        properties: {
-            name: "Pool"
-            value: "default"
-        }
-        """ % container_digests["centos6"],
+    exec_properties = {
+        "container-image": "docker://gcr.io/tensorflow-testing/nosla-centos6@%s" % container_digests["centos6"],
+        "Pool": "default",
+    },
 )
 
 # Built with //tensorflow/tools/ci_build/Dockerfile.rbe.cuda10.0-cudnn7-ubuntu14.04.
@@ -65,40 +53,21 @@ platform(
         "@bazel_tools//platforms:x86_64",
         "@bazel_tools//platforms:linux",
     ],
-    remote_execution_properties = """
-        properties: {
-            name: "container-image"
-            value:"docker://gcr.io/tensorflow-testing/nosla-cuda10.0-cudnn7-ubuntu14.04@%s"
-        }
-        properties: {
-            name: "Pool"
-            value: "default"
-        }
-        """ % container_digests["cuda10.0-cudnn7-ubuntu14.04"],
+    exec_properties = {
+        "container-image": "docker://gcr.io/tensorflow-testing/nosla-cuda10.0-cudnn7-ubuntu14.04@%s" % container_digests["cuda10.0-cudnn7-ubuntu14.04"],
+        "Pool": "default",
+    },
 )
 
 # The above platform with GPU support.
 platform(
     name = "rbe_cuda10.0-cudnn7-ubuntu14.04-gpu",
-    constraint_values = [
-        "@bazel_tools//platforms:x86_64",
-        "@bazel_tools//platforms:linux",
-        ":gpu_test",
-    ],
-    remote_execution_properties = """
-        properties: {
-            name: "container-image"
-            value: "docker://gcr.io/tensorflow-testing/nosla-cuda10.0-cudnn7-ubuntu14.04@%s"
-        }
-        properties: {
-            name: "dockerRuntime"
-            value: "nvidia"
-        }
-        properties: {
-            name: "Pool"
-            value: "gpu-pool"
-        }
-        """ % container_digests["cuda10.0-cudnn7-ubuntu14.04"],
+    constraint_values = [":gpu_test"],
+    exec_properties = {
+        "dockerRuntime": "nvidia",
+        "Pool": "gpu-pool",
+    },
+    parents = [":rbe_cuda10.0-cudnn7-ubuntu14.04"],
 )
 
 # Built with //tensorflow/tools/ci_build/Dockerfile.rbe.cuda10.0-cudnn7-centos6.
@@ -108,40 +77,21 @@ platform(
         "@bazel_tools//platforms:x86_64",
         "@bazel_tools//platforms:linux",
     ],
-    remote_execution_properties = """
-        properties: {
-            name: "container-image"
-            value:"docker://gcr.io/tensorflow-testing/nosla-cuda10.0-cudnn7-centos6@%s"
-        }
-        properties: {
-            name: "Pool"
-            value: "default"
-        }
-        """ % container_digests["cuda10.0-cudnn7-centos6"],
+    exec_properties = {
+        "container-image": "docker://gcr.io/tensorflow-testing/nosla-cuda10.0-cudnn7-centos6@%s" % container_digests["cuda10.0-cudnn7-centos6"],
+        "Pool": "default",
+    },
 )
 
 # The above platform with GPU support.
 platform(
     name = "rbe_cuda10.0-cudnn7-centos6-gpu",
-    constraint_values = [
-        "@bazel_tools//platforms:x86_64",
-        "@bazel_tools//platforms:linux",
-        ":gpu_test",
-    ],
-    remote_execution_properties = """
-        properties: {
-            name: "container-image"
-            value: "docker://gcr.io/tensorflow-testing/nosla-cuda10.0-cudnn7-centos6@%s"
-        }
-        properties: {
-            name: "dockerRuntime"
-            value: "nvidia"
-        }
-        properties: {
-            name: "Pool"
-            value: "gpu-pool"
-        }
-        """ % container_digests["cuda10.0-cudnn7-centos6"],
+    constraint_values = [":gpu_test"],
+    exec_properties = {
+        "dockerRuntime": "nvidia",
+        "Pool": "gpu-pool",
+    },
+    parents = [":rbe_cuda10.0-cudnn7-centos6"],
 )
 
 # Built with //tensorflow/tools/ci_build/Dockerfile.rbe.ubuntu16.04-manylinux2010.
@@ -151,16 +101,10 @@ platform(
         "@bazel_tools//platforms:x86_64",
         "@bazel_tools//platforms:linux",
     ],
-    remote_execution_properties = """
-        properties: {
-            name: "container-image"
-            value:"docker://gcr.io/tensorflow-testing/nosla-ubuntu16.04-manylinux2010@%s"
-        }
-        properties: {
-            name: "Pool"
-            value: "default"
-        }
-        """ % container_digests["ubuntu16.04-manylinux2010"],
+    exec_properties = {
+        "container-image": "docker://gcr.io/tensorflow-testing/nosla-ubuntu16.04-manylinux2010@%s" % container_digests["ubuntu16.04-manylinux2010"],
+        "Pool": "default",
+    },
 )
 
 # Built with //tensorflow/tools/ci_build/Dockerfile.rbe.cuda10.0-cudnn7-ubuntu16.04-manylinux2010.
@@ -170,40 +114,21 @@ platform(
         "@bazel_tools//platforms:x86_64",
         "@bazel_tools//platforms:linux",
     ],
-    remote_execution_properties = """
-        properties: {
-            name: "container-image"
-            value:"docker://gcr.io/tensorflow-testing/nosla-cuda10.0-cudnn7-ubuntu16.04-manylinux2010@%s"
-        }
-        properties: {
-            name: "Pool"
-            value: "default"
-        }
-        """ % container_digests["cuda10.0-cudnn7-ubuntu16.04-manylinux2010"],
+    exec_properties = {
+        "container-image": "docker://gcr.io/tensorflow-testing/nosla-cuda10.0-cudnn7-ubuntu16.04-manylinux2010@%s" % container_digests["cuda10.0-cudnn7-ubuntu16.04-manylinux2010"],
+        "Pool": "default",
+    },
 )
 
 # The above platform with GPU support.
 platform(
     name = "rbe_cuda10.0-cudnn7-ubuntu16.04-manylinux2010-gpu",
-    constraint_values = [
-        "@bazel_tools//platforms:x86_64",
-        "@bazel_tools//platforms:linux",
-        ":gpu_test",
-    ],
-    remote_execution_properties = """
-        properties: {
-            name: "container-image"
-            value: "docker://gcr.io/tensorflow-testing/nosla-cuda10.0-cudnn7-ubuntu16.04-manylinux2010@%s"
-        }
-        properties: {
-            name: "dockerRuntime"
-            value: "nvidia"
-        }
-        properties: {
-            name: "Pool"
-            value: "gpu-pool"
-        }
-        """ % container_digests["cuda10.0-cudnn7-ubuntu16.04-manylinux2010"],
+    constraint_values = [":gpu_test"],
+    exec_properties = {
+        "dockerRuntime": "nvidia",
+        "Pool": "gpu-pool",
+    },
+    parents = [":rbe_cuda10.0-cudnn7-ubuntu16.04-manylinux2010"],
 )
 
 # Built with //tensorflow/tools/ci_build/Dockerfile.rbe.cuda10.1-cudnn7-ubuntu16.04-manylinux2010.
@@ -213,40 +138,21 @@ platform(
         "@bazel_tools//platforms:x86_64",
         "@bazel_tools//platforms:linux",
     ],
-    remote_execution_properties = """
-        properties: {
-            name: "container-image"
-            value:"docker://gcr.io/tensorflow-testing/nosla-cuda10.1-cudnn7-ubuntu16.04-manylinux2010@%s"
-        }
-        properties: {
-            name: "Pool"
-            value: "default"
-        }
-        """ % container_digests["cuda10.1-cudnn7-ubuntu16.04-manylinux2010"],
+    exec_properties = {
+        "container-image": "docker://gcr.io/tensorflow-testing/nosla-cuda10.1-cudnn7-ubuntu16.04-manylinux2010@%s" % container_digests["cuda10.1-cudnn7-ubuntu16.04-manylinux2010"],
+        "Pool": "default",
+    },
 )
 
 # The above platform with GPU support.
 platform(
     name = "rbe_cuda10.1-cudnn7-ubuntu16.04-manylinux2010-gpu",
-    constraint_values = [
-        "@bazel_tools//platforms:x86_64",
-        "@bazel_tools//platforms:linux",
-        ":gpu_test",
-    ],
-    remote_execution_properties = """
-        properties: {
-            name: "container-image"
-            value: "docker://gcr.io/tensorflow-testing/nosla-cuda10.1-cudnn7-ubuntu16.04-manylinux2010@%s"
-        }
-        properties: {
-            name: "dockerRuntime"
-            value: "nvidia"
-        }
-        properties: {
-            name: "Pool"
-            value: "gpu-pool"
-        }
-        """ % container_digests["cuda10.1-cudnn7-ubuntu16.04-manylinux2010"],
+    constraint_values = [":gpu_test"],
+    exec_properties = {
+        "dockerRuntime": "nvidia",
+        "Pool": "gpu-pool",
+    },
+    parents = [":rbe_cuda10.1-cudnn7-ubuntu16.04-manylinux2010"],
 )
 
 # Built with //tensorflow/tools/ci_build/Dockerfile.rbe.rocm-ubuntu16.04
@@ -256,14 +162,8 @@ platform(
         "@bazel_tools//platforms:x86_64",
         "@bazel_tools//platforms:linux",
     ],
-    remote_execution_properties = """
-        properties: {
-            name: "container-image"
-            value:"docker://gcr.io/tensorflow-testing/nosla-rocm-ubuntu16.04@%s"
-        }
-        properties: {
-            name: "Pool"
-            value: "default"
-        }
-        """ % container_digests["rocm-ubuntu16.04"],
+    exec_properties = {
+        "container-image": "docker://gcr.io/tensorflow-testing/nosla-rocm-ubuntu16.04@%s" % container_digests["rocm-ubuntu16.04"],
+        "Pool": "default",
+    },
 )

--- a/third_party/toolchains/preconfig/win_1803/BUILD
+++ b/third_party/toolchains/preconfig/win_1803/BUILD
@@ -14,15 +14,10 @@ platform(
         "@bazel_tools//platforms:x86_64",
         "@bazel_tools//platforms:windows",
     ],
-    remote_execution_properties = """
-        properties:{
-          name:"container-image"
-          value:"docker://gcr.io/tensorflow-testing/tf-win-rbe@sha256:6bee34693b356baf3b0ba700f4eb27a23d3a04e0c47cbb9de813c61ef30c0b9f"
-        }
-        properties:{
-          name: "OSFamily" value: "Windows"
-        }
-        """,
+    exec_properties = {
+        "container-image" : "docker://gcr.io/tensorflow-testing/tf-win-rbe@sha256:6bee34693b356baf3b0ba700f4eb27a23d3a04e0c47cbb9de813c61ef30c0b9f",
+        "OSFamily" : "Windows",
+    },
 )
 
 platform(
@@ -31,17 +26,9 @@ platform(
         "@bazel_tools//platforms:x86_64",
         "@bazel_tools//platforms:windows",
     ],
-    remote_execution_properties = """
-        properties:{
-          name:"container-image"
-          value:""
-        }
-        properties:{
-          name:"sandbox"
-          value:"none"
-        }
-        properties:{
-          name: "OSFamily" value: "Windows"
-        }
-        """,
+    exec_properties = {
+        "container-image" : "",
+        "sandbox" : "none",
+        "OSFamily" : "Windows",
+    },
 )


### PR DESCRIPTION
- remote_execution_properties has been deprecated in favor
of exec_properties [1].

- have gpu platforms inherit from the cpu platform in order
to avoid duplication.

[1] https://docs.bazel.build/versions/master/be/platform.html#platform.exec_properties

@r4nt @gunan 