### PR TITLE
 RBE: Use exec_properties to tag tests that require a GPU 

### DIFF
--- a/tensorflow/compiler/tests/build_defs.bzl
+++ b/tensorflow/compiler/tests/build_defs.bzl
@@ -6,7 +6,7 @@ load("//tensorflow/compiler/tests:plugin.bzl", "plugins")
 load(
     "//tensorflow/core/platform:build_config_root.bzl",
     "tf_cuda_tests_tags",
-    "tf_exec_compatible_with",
+    "tf_exec_properties",
 )
 
 def all_backends():
@@ -113,7 +113,7 @@ def tf_xla_py_test(
             data = data + backend_data,
             deps = deps + backend_deps,
             tags = test_tags,
-            exec_compatible_with = tf_exec_compatible_with({"tags": test_tags}),
+            exec_properties = tf_exec_properties({"tags": test_tags}),
             **kwargs
         )
         test_names.append(test_name)

--- a/tensorflow/core/platform/build_config_root.bzl
+++ b/tensorflow/core/platform/build_config_root.bzl
@@ -11,7 +11,7 @@ load(
     _tf_additional_plugin_deps = "tf_additional_plugin_deps",
     _tf_additional_xla_deps_py = "tf_additional_xla_deps_py",
     _tf_cuda_tests_tags = "tf_cuda_tests_tags",
-    _tf_exec_compatible_with = "tf_exec_compatible_with",
+    _tf_exec_properties = "tf_exec_properties",
     _tf_gpu_tests_tags = "tf_gpu_tests_tags",
     _tf_sycl_tests_tags = "tf_sycl_tests_tags",
 )
@@ -25,6 +25,6 @@ tf_additional_license_deps = _tf_additional_license_deps
 tf_additional_plugin_deps = _tf_additional_plugin_deps
 tf_additional_xla_deps_py = _tf_additional_xla_deps_py
 tf_cuda_tests_tags = _tf_cuda_tests_tags
-tf_exec_compatible_with = _tf_exec_compatible_with
+tf_exec_properties = _tf_exec_properties
 tf_gpu_tests_tags = _tf_gpu_tests_tags
 tf_sycl_tests_tags = _tf_sycl_tests_tags

--- a/tensorflow/core/platform/default/build_config_root.bzl
+++ b/tensorflow/core/platform/default/build_config_root.bzl
@@ -4,6 +4,13 @@
 
 load("@local_config_remote_execution//:remote_execution.bzl", "gpu_test_tags")
 
+# RBE settings for tests that require a GPU. This is used in exec_properties of rules
+# that need GPU access.
+GPU_TEST_PROPERTIES = {
+    "dockerRuntime": "nvidia",
+    "Pool": "gpu-pool",
+}
+
 def tf_gpu_tests_tags():
     return ["requires-gpu", "gpu"] + gpu_test_tags()
 
@@ -14,11 +21,11 @@ def tf_cuda_tests_tags():
 def tf_sycl_tests_tags():
     return ["requires-gpu", "gpu"] + gpu_test_tags()
 
-def tf_exec_compatible_with(kwargs):
+def tf_exec_properties(kwargs):
     if ("tags" in kwargs and kwargs["tags"] != None and
         "remote-gpu" in kwargs["tags"]):
-        return ["@org_tensorflow//third_party/toolchains:gpu_test"]
-    return []
+        return GPU_TEST_PROPERTIES
+    return {}
 
 def tf_additional_plugin_deps():
     return select({

--- a/tensorflow/examples/adding_an_op/BUILD
+++ b/tensorflow/examples/adding_an_op/BUILD
@@ -4,7 +4,7 @@
 load(
     "//tensorflow/core/platform:build_config_root.bzl",
     "tf_cuda_tests_tags",
-    "tf_exec_compatible_with",
+    "tf_exec_properties",
 )
 load("//tensorflow:tensorflow.bzl", "tf_custom_op_library")
 load("//tensorflow:tensorflow.bzl", "tf_cc_binary")
@@ -133,7 +133,7 @@ py_test(
     name = "cuda_op_test",
     size = "small",
     srcs = ["cuda_op_test.py"],
-    exec_compatible_with = tf_exec_compatible_with({"tags": tf_cuda_tests_tags()}),
+    tf_exec_properties = tf_exec_properties({"tags": tf_cuda_tests_tags()}),
     python_version = "PY3",
     srcs_version = "PY2AND3",
     tags = tf_cuda_tests_tags() + [

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -7,7 +7,7 @@ load(
     "register_extension_info",
     "tf_additional_grpc_deps_py",
     "tf_additional_xla_deps_py",
-    "tf_exec_compatible_with",
+    "tf_exec_properties",
     "tf_gpu_tests_tags",
     "tf_sycl_tests_tags",
 )
@@ -1027,7 +1027,7 @@ def tf_cc_test(
         data = data +
                tf_binary_dynamic_kernel_dsos() +
                tf_binary_additional_srcs(),
-        exec_compatible_with = tf_exec_compatible_with(kwargs),
+        exec_properties = tf_exec_properties(kwargs),
         # Nested select() statements seem not to be supported when passed to
         # linkstatic, and we already have a cuda select() passed in to this
         # function.
@@ -1175,7 +1175,7 @@ def tf_gpu_only_cc_test(
             "//conditions:default": 0,
         }),
         tags = tags,
-        exec_compatible_with = tf_exec_compatible_with({"tags": tags}),
+        exec_properties = tf_exec_properties({"tags": tags}),
     )
 
 register_extension_info(
@@ -1262,7 +1262,7 @@ def tf_cc_test_mkl(
             }) + _rpath_linkopts(src_to_test_name(src)),
             deps = deps + tf_binary_dynamic_kernel_deps(kernels) + mkl_deps(),
             data = data + tf_binary_dynamic_kernel_dsos(),
-            exec_compatible_with = tf_exec_compatible_with({"tags": tags}),
+            exec_properties = tf_exec_properties({"tags": tags}),
             linkstatic = linkstatic,
             tags = tags,
             size = size,
@@ -2097,7 +2097,7 @@ def py_test(deps = [], data = [], kernels = [], **kwargs):
             "//conditions:default": kernels,
             clean_dep("//tensorflow:no_tensorflow_py_deps"): ["//tensorflow/tools/pip_package:win_pip_package_marker"],
         }),
-        exec_compatible_with = tf_exec_compatible_with(kwargs),
+        exec_properties = tf_exec_properties(kwargs),
         **kwargs
     )
 

--- a/third_party/toolchains/BUILD
+++ b/third_party/toolchains/BUILD
@@ -27,16 +27,10 @@ platform(
         "@bazel_tools//platforms:x86_64",
         "@bazel_tools//platforms:linux",
     ],
-    remote_execution_properties = """
-        properties: {
-            name: "container-image"
-            value:"docker://gcr.io/tensorflow-testing/nosla-ubuntu16.04@%s"
-        }
-        properties: {
-            name: "Pool"
-            value: "default"
-        }
-        """ % container_digests["ubuntu16.04"],
+    exec_properties = {
+        "container-image": "docker://gcr.io/tensorflow-testing/nosla-ubuntu16.04@%s" % container_digests["ubuntu16.04"],
+        "Pool": "default",
+    },
 )
 
 # Built with //tensorflow/tools/ci_build/Dockerfile.rbe.cpu-centos6.
@@ -46,16 +40,10 @@ platform(
         "@bazel_tools//platforms:x86_64",
         "@bazel_tools//platforms:linux",
     ],
-    remote_execution_properties = """
-        properties: {
-            name: "container-image"
-            value:"docker://gcr.io/tensorflow-testing/nosla-centos6@%s"
-        }
-        properties: {
-            name: "Pool"
-            value: "default"
-        }
-        """ % container_digests["centos6"],
+    exec_properties = {
+        "container-image": "docker://gcr.io/tensorflow-testing/nosla-centos6@%s" % container_digests["centos6"],
+        "Pool": "default",
+    },
 )
 
 # Built with //tensorflow/tools/ci_build/Dockerfile.rbe.cuda10.0-cudnn7-ubuntu14.04.
@@ -65,40 +53,21 @@ platform(
         "@bazel_tools//platforms:x86_64",
         "@bazel_tools//platforms:linux",
     ],
-    remote_execution_properties = """
-        properties: {
-            name: "container-image"
-            value:"docker://gcr.io/tensorflow-testing/nosla-cuda10.0-cudnn7-ubuntu14.04@%s"
-        }
-        properties: {
-            name: "Pool"
-            value: "default"
-        }
-        """ % container_digests["cuda10.0-cudnn7-ubuntu14.04"],
+    exec_properties = {
+        "container-image": "docker://gcr.io/tensorflow-testing/nosla-cuda10.0-cudnn7-ubuntu14.04@%s" % container_digests["cuda10.0-cudnn7-ubuntu14.04"],
+        "Pool": "default",
+    },
 )
 
 # The above platform with GPU support.
 platform(
     name = "rbe_cuda10.0-cudnn7-ubuntu14.04-gpu",
-    constraint_values = [
-        "@bazel_tools//platforms:x86_64",
-        "@bazel_tools//platforms:linux",
-        ":gpu_test",
-    ],
-    remote_execution_properties = """
-        properties: {
-            name: "container-image"
-            value: "docker://gcr.io/tensorflow-testing/nosla-cuda10.0-cudnn7-ubuntu14.04@%s"
-        }
-        properties: {
-            name: "dockerRuntime"
-            value: "nvidia"
-        }
-        properties: {
-            name: "Pool"
-            value: "gpu-pool"
-        }
-        """ % container_digests["cuda10.0-cudnn7-ubuntu14.04"],
+    constraint_values = [":gpu_test"],
+    exec_properties = {
+        "dockerRuntime": "nvidia",
+        "Pool": "gpu-pool",
+    },
+    parents = [":rbe_cuda10.0-cudnn7-ubuntu14.04"],
 )
 
 # Built with //tensorflow/tools/ci_build/Dockerfile.rbe.cuda10.0-cudnn7-centos6.
@@ -108,40 +77,21 @@ platform(
         "@bazel_tools//platforms:x86_64",
         "@bazel_tools//platforms:linux",
     ],
-    remote_execution_properties = """
-        properties: {
-            name: "container-image"
-            value:"docker://gcr.io/tensorflow-testing/nosla-cuda10.0-cudnn7-centos6@%s"
-        }
-        properties: {
-            name: "Pool"
-            value: "default"
-        }
-        """ % container_digests["cuda10.0-cudnn7-centos6"],
+    exec_properties = {
+        "container-image": "docker://gcr.io/tensorflow-testing/nosla-cuda10.0-cudnn7-centos6@%s" % container_digests["cuda10.0-cudnn7-centos6"],
+        "Pool": "default",
+    },
 )
 
 # The above platform with GPU support.
 platform(
     name = "rbe_cuda10.0-cudnn7-centos6-gpu",
-    constraint_values = [
-        "@bazel_tools//platforms:x86_64",
-        "@bazel_tools//platforms:linux",
-        ":gpu_test",
-    ],
-    remote_execution_properties = """
-        properties: {
-            name: "container-image"
-            value: "docker://gcr.io/tensorflow-testing/nosla-cuda10.0-cudnn7-centos6@%s"
-        }
-        properties: {
-            name: "dockerRuntime"
-            value: "nvidia"
-        }
-        properties: {
-            name: "Pool"
-            value: "gpu-pool"
-        }
-        """ % container_digests["cuda10.0-cudnn7-centos6"],
+    constraint_values = [":gpu_test"],
+    exec_properties = {
+        "dockerRuntime": "nvidia",
+        "Pool": "gpu-pool",
+    },
+    parents = [":rbe_cuda10.0-cudnn7-centos6"],
 )
 
 # Built with //tensorflow/tools/ci_build/Dockerfile.rbe.ubuntu16.04-manylinux2010.
@@ -151,16 +101,10 @@ platform(
         "@bazel_tools//platforms:x86_64",
         "@bazel_tools//platforms:linux",
     ],
-    remote_execution_properties = """
-        properties: {
-            name: "container-image"
-            value:"docker://gcr.io/tensorflow-testing/nosla-ubuntu16.04-manylinux2010@%s"
-        }
-        properties: {
-            name: "Pool"
-            value: "default"
-        }
-        """ % container_digests["ubuntu16.04-manylinux2010"],
+    exec_properties = {
+        "container-image": "docker://gcr.io/tensorflow-testing/nosla-ubuntu16.04-manylinux2010@%s" % container_digests["ubuntu16.04-manylinux2010"],
+        "Pool": "default",
+    },
 )
 
 # Built with //tensorflow/tools/ci_build/Dockerfile.rbe.cuda10.0-cudnn7-ubuntu16.04-manylinux2010.
@@ -170,40 +114,21 @@ platform(
         "@bazel_tools//platforms:x86_64",
         "@bazel_tools//platforms:linux",
     ],
-    remote_execution_properties = """
-        properties: {
-            name: "container-image"
-            value:"docker://gcr.io/tensorflow-testing/nosla-cuda10.0-cudnn7-ubuntu16.04-manylinux2010@%s"
-        }
-        properties: {
-            name: "Pool"
-            value: "default"
-        }
-        """ % container_digests["cuda10.0-cudnn7-ubuntu16.04-manylinux2010"],
+    exec_properties = {
+        "container-image": "docker://gcr.io/tensorflow-testing/nosla-cuda10.0-cudnn7-ubuntu16.04-manylinux2010@%s" % container_digests["cuda10.0-cudnn7-ubuntu16.04-manylinux2010"],
+        "Pool": "default",
+    },
 )
 
 # The above platform with GPU support.
 platform(
     name = "rbe_cuda10.0-cudnn7-ubuntu16.04-manylinux2010-gpu",
-    constraint_values = [
-        "@bazel_tools//platforms:x86_64",
-        "@bazel_tools//platforms:linux",
-        ":gpu_test",
-    ],
-    remote_execution_properties = """
-        properties: {
-            name: "container-image"
-            value: "docker://gcr.io/tensorflow-testing/nosla-cuda10.0-cudnn7-ubuntu16.04-manylinux2010@%s"
-        }
-        properties: {
-            name: "dockerRuntime"
-            value: "nvidia"
-        }
-        properties: {
-            name: "Pool"
-            value: "gpu-pool"
-        }
-        """ % container_digests["cuda10.0-cudnn7-ubuntu16.04-manylinux2010"],
+    constraint_values = [":gpu_test"],
+    exec_properties = {
+        "dockerRuntime": "nvidia",
+        "Pool": "gpu-pool",
+    },
+    parents = [":rbe_cuda10.0-cudnn7-ubuntu16.04-manylinux2010"],
 )
 
 # Built with //tensorflow/tools/ci_build/Dockerfile.rbe.cuda10.1-cudnn7-ubuntu16.04-manylinux2010.
@@ -213,40 +138,21 @@ platform(
         "@bazel_tools//platforms:x86_64",
         "@bazel_tools//platforms:linux",
     ],
-    remote_execution_properties = """
-        properties: {
-            name: "container-image"
-            value:"docker://gcr.io/tensorflow-testing/nosla-cuda10.1-cudnn7-ubuntu16.04-manylinux2010@%s"
-        }
-        properties: {
-            name: "Pool"
-            value: "default"
-        }
-        """ % container_digests["cuda10.1-cudnn7-ubuntu16.04-manylinux2010"],
+    exec_properties = {
+        "container-image": "docker://gcr.io/tensorflow-testing/nosla-cuda10.1-cudnn7-ubuntu16.04-manylinux2010@%s" % container_digests["cuda10.1-cudnn7-ubuntu16.04-manylinux2010"],
+        "Pool": "default",
+    },
 )
 
 # The above platform with GPU support.
 platform(
     name = "rbe_cuda10.1-cudnn7-ubuntu16.04-manylinux2010-gpu",
-    constraint_values = [
-        "@bazel_tools//platforms:x86_64",
-        "@bazel_tools//platforms:linux",
-        ":gpu_test",
-    ],
-    remote_execution_properties = """
-        properties: {
-            name: "container-image"
-            value: "docker://gcr.io/tensorflow-testing/nosla-cuda10.1-cudnn7-ubuntu16.04-manylinux2010@%s"
-        }
-        properties: {
-            name: "dockerRuntime"
-            value: "nvidia"
-        }
-        properties: {
-            name: "Pool"
-            value: "gpu-pool"
-        }
-        """ % container_digests["cuda10.1-cudnn7-ubuntu16.04-manylinux2010"],
+    constraint_values = [":gpu_test"],
+    exec_properties = {
+        "dockerRuntime": "nvidia",
+        "Pool": "gpu-pool",
+    },
+    parents = [":rbe_cuda10.1-cudnn7-ubuntu16.04-manylinux2010"],
 )
 
 # Built with //tensorflow/tools/ci_build/Dockerfile.rbe.rocm-ubuntu16.04
@@ -256,14 +162,8 @@ platform(
         "@bazel_tools//platforms:x86_64",
         "@bazel_tools//platforms:linux",
     ],
-    remote_execution_properties = """
-        properties: {
-            name: "container-image"
-            value:"docker://gcr.io/tensorflow-testing/nosla-rocm-ubuntu16.04@%s"
-        }
-        properties: {
-            name: "Pool"
-            value: "default"
-        }
-        """ % container_digests["rocm-ubuntu16.04"],
+    exec_properties = {
+        "container-image": "docker://gcr.io/tensorflow-testing/nosla-rocm-ubuntu16.04@%s" % container_digests["rocm-ubuntu16.04"],
+        "Pool": "default",
+    },
 )

--- a/third_party/toolchains/BUILD
+++ b/third_party/toolchains/BUILD
@@ -4,17 +4,6 @@ package(default_visibility = ["//visibility:public"])
 
 load("//third_party/toolchains/preconfig/generate:containers.bzl", "container_digests")
 
-# Constraint used for platforms below so we can force certain rules to be executed
-# on specific platforms.
-constraint_setting(name = "custom_platforms")
-
-# Constraint for platforms that allow GPU testing (i.e. have a GPU available).
-# This is used in exec_compatible_with of rules that need GPU access.
-constraint_value(
-    name = "gpu_test",
-    constraint_setting = ":custom_platforms",
-)
-
 # Remote build platforms.
 # Each of the platform rules here provide a platform definition that is bound to a docker image.
 # The result of the skylark configuration is checked into
@@ -59,17 +48,6 @@ platform(
     },
 )
 
-# The above platform with GPU support.
-platform(
-    name = "rbe_cuda10.0-cudnn7-ubuntu14.04-gpu",
-    constraint_values = [":gpu_test"],
-    exec_properties = {
-        "dockerRuntime": "nvidia",
-        "Pool": "gpu-pool",
-    },
-    parents = [":rbe_cuda10.0-cudnn7-ubuntu14.04"],
-)
-
 # Built with //tensorflow/tools/ci_build/Dockerfile.rbe.cuda10.0-cudnn7-centos6.
 platform(
     name = "rbe_cuda10.0-cudnn7-centos6",
@@ -81,17 +59,6 @@ platform(
         "container-image": "docker://gcr.io/tensorflow-testing/nosla-cuda10.0-cudnn7-centos6@%s" % container_digests["cuda10.0-cudnn7-centos6"],
         "Pool": "default",
     },
-)
-
-# The above platform with GPU support.
-platform(
-    name = "rbe_cuda10.0-cudnn7-centos6-gpu",
-    constraint_values = [":gpu_test"],
-    exec_properties = {
-        "dockerRuntime": "nvidia",
-        "Pool": "gpu-pool",
-    },
-    parents = [":rbe_cuda10.0-cudnn7-centos6"],
 )
 
 # Built with //tensorflow/tools/ci_build/Dockerfile.rbe.ubuntu16.04-manylinux2010.
@@ -120,17 +87,6 @@ platform(
     },
 )
 
-# The above platform with GPU support.
-platform(
-    name = "rbe_cuda10.0-cudnn7-ubuntu16.04-manylinux2010-gpu",
-    constraint_values = [":gpu_test"],
-    exec_properties = {
-        "dockerRuntime": "nvidia",
-        "Pool": "gpu-pool",
-    },
-    parents = [":rbe_cuda10.0-cudnn7-ubuntu16.04-manylinux2010"],
-)
-
 # Built with //tensorflow/tools/ci_build/Dockerfile.rbe.cuda10.1-cudnn7-ubuntu16.04-manylinux2010.
 platform(
     name = "rbe_cuda10.1-cudnn7-ubuntu16.04-manylinux2010",
@@ -142,17 +98,6 @@ platform(
         "container-image": "docker://gcr.io/tensorflow-testing/nosla-cuda10.1-cudnn7-ubuntu16.04-manylinux2010@%s" % container_digests["cuda10.1-cudnn7-ubuntu16.04-manylinux2010"],
         "Pool": "default",
     },
-)
-
-# The above platform with GPU support.
-platform(
-    name = "rbe_cuda10.1-cudnn7-ubuntu16.04-manylinux2010-gpu",
-    constraint_values = [":gpu_test"],
-    exec_properties = {
-        "dockerRuntime": "nvidia",
-        "Pool": "gpu-pool",
-    },
-    parents = [":rbe_cuda10.1-cudnn7-ubuntu16.04-manylinux2010"],
 )
 
 # Built with //tensorflow/tools/ci_build/Dockerfile.rbe.rocm-ubuntu16.04

--- a/third_party/toolchains/preconfig/win_1803/BUILD
+++ b/third_party/toolchains/preconfig/win_1803/BUILD
@@ -14,15 +14,10 @@ platform(
         "@bazel_tools//platforms:x86_64",
         "@bazel_tools//platforms:windows",
     ],
-    remote_execution_properties = """
-        properties:{
-          name:"container-image"
-          value:"docker://gcr.io/tensorflow-testing/tf-win-rbe@sha256:6bee34693b356baf3b0ba700f4eb27a23d3a04e0c47cbb9de813c61ef30c0b9f"
-        }
-        properties:{
-          name: "OSFamily" value: "Windows"
-        }
-        """,
+    exec_properties = {
+        "container-image" : "docker://gcr.io/tensorflow-testing/tf-win-rbe@sha256:6bee34693b356baf3b0ba700f4eb27a23d3a04e0c47cbb9de813c61ef30c0b9f",
+        "OSFamily" : "Windows",
+    },
 )
 
 platform(
@@ -31,17 +26,9 @@ platform(
         "@bazel_tools//platforms:x86_64",
         "@bazel_tools//platforms:windows",
     ],
-    remote_execution_properties = """
-        properties:{
-          name:"container-image"
-          value:""
-        }
-        properties:{
-          name:"sandbox"
-          value:"none"
-        }
-        properties:{
-          name: "OSFamily" value: "Windows"
-        }
-        """,
+    exec_properties = {
+        "container-image" : "",
+        "sandbox" : "none",
+        "OSFamily" : "Windows",
+    },
 )


### PR DESCRIPTION
This change replaces all uses of the exec_compatible_with attribute for GPU tests with the exec_properties attribute. exec_properties are passed through as platform properties to the remote execution backend. This makes creating special platforms for GPU tests obsolete.

This change is rebased on https://github.com/tensorflow/tensorflow/pull/36239

@r4nt @gunan 