### PR TITLE
Fix flatbuffers link error

### DIFF
--- a/third_party/flatbuffers/BUILD.bazel
+++ b/third_party/flatbuffers/BUILD.bazel
@@ -8,6 +8,17 @@ exports_files(["LICENSE.txt"])
 
 licenses(["notice"])
 
+config_setting(
+    name = "freebsd",
+    values = {"cpu": "freebsd"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "windows",
+    values = {"cpu": "x64_windows"},
+)
+
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 
 # Public flatc library to compile flatbuffer files at runtime.

--- a/third_party/flatbuffers/BUILD.bazel
+++ b/third_party/flatbuffers/BUILD.bazel
@@ -50,6 +50,16 @@ cc_library(
 # Public flatc compiler.
 cc_binary(
     name = "flatc",
+    linkopts = select({
+        ":freebsd": [
+            "-lm",
+        ],
+        ":windows": [],
+        "//conditions:default": [
+            "-lm",
+            "-ldl",
+        ],
+    }),
     deps = [
         "@flatbuffers//src:flatc",
     ],


### PR DESCRIPTION
Fix flatbuffers link error

This commit:
tensorflow@adf6e22#diff-4bdae93a605044a27f9df49a92bcf398L129

Removed the linkopts section from the cc_binary 'flatc' from
third_party/flatbuffers/BUILD.bazel. That caused builds to fail with:

/usr/bin/ld: bazel-out/host/bin/external/flatbuffers/src/libflatbuffers.a(idl_parser.o): undefined reference to symbol 'cos@@GLIBC_2.17'
/dt7/lib/powerpc64le-linux-gnu/libm.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status

(This is GPU builds on ppc64le)

I tried passing `--linkopt=-lm` on the bazel build command but it still failed.
Restoring the original linkopts section does resolve this problem. (and it
seems better to have the linkopt here than globally for the entire build)

A simple `linkopts = ["-lm"],` works for ppc64le, but I figured for windows and
other platforms it was better to restore the original values.