### PR TITLE
[ROCm] Reverting ROCm to use MIOpen Find Mode APIs (be default) for convolution

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/gpu_conv_algorithm_picker.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_conv_algorithm_picker.cc
@@ -121,11 +121,11 @@ std::vector<AlgorithmDesc> GetAlgorithms(CudnnConvKind kind,
   return algorithms;
 }
 
-StatusOr<std::vector<se::dnn::ProfileResult>> GetAlgorithms(
+StatusOr<std::vector<se::dnn::ProfileResult>> GetMIOpenAlgorithms(
     const HloCustomCallInstruction* conv,
     absl::Span<se::DeviceMemoryBase> operand_buffers,
     se::DeviceMemoryBase result_buffer, se::StreamExecutor* stream_exec,
-    se::Stream* stream) {
+    ScratchAllocator* scratch_allocator, se::Stream* stream) {
   std::vector<se::dnn::ProfileResult> algorithms;
 
   TF_ASSIGN_OR_RETURN(se::dnn::ConvolutionKind kind,
@@ -137,8 +137,9 @@ StatusOr<std::vector<se::dnn::ProfileResult>> GetAlgorithms(
                       GetGpuConvParams(conv, operand_buffers, result_buffer));
 
   bool succ = stream_exec->GetMIOpenConvolveAlgorithms(
-      kind, stream, dtype, params.input_descriptor, params.filter_descriptor,
-      params.conv_desc, params.output_descriptor, &algorithms);
+      kind, dtype, stream, params.input_descriptor, params.input_buf,
+      params.filter_descriptor, params.filter_buf, params.output_descriptor,
+      params.output_buf, params.conv_desc, scratch_allocator, &algorithms);
   DCHECK(succ);
 
   return algorithms;
@@ -680,9 +681,12 @@ GpuConvAlgorithmPicker::PickBestAlgorithmNoCacheRocm(
           ShapeUtil::ByteSizeOf(instr->shape().tuple_shapes(0))));
   initialize_buffer(result_buffer);
 
-  TF_ASSIGN_OR_RETURN(std::vector<se::dnn::ProfileResult> algorithms,
-                      GetAlgorithms(instr, absl::MakeSpan(operand_buffers),
-                                    result_buffer, stream_exec_, stream));
+  ScratchAllocator scratch_allocator(device_ordinal, allocator);
+
+  TF_ASSIGN_OR_RETURN(
+      std::vector<se::dnn::ProfileResult> algorithms,
+      GetMIOpenAlgorithms(instr, absl::MakeSpan(operand_buffers), result_buffer,
+                          stream_exec_, &scratch_allocator, stream));
 
   std::vector<AutotuneResult> profile_results;
 
@@ -705,7 +709,6 @@ GpuConvAlgorithmPicker::PickBestAlgorithmNoCacheRocm(
                        AlgorithmToString(alg)),
           2);
 
-      ScratchAllocator scratch_allocator(device_ordinal, allocator);
       se::dnn::ProfileResult profile_result;
       VLOG(3) << "Trying algorithm " << AlgorithmToString(alg) << " for "
               << instr->ToString();

--- a/tensorflow/compiler/xla/service/gpu/gpu_conv_algorithm_picker.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_conv_algorithm_picker.cc
@@ -714,6 +714,7 @@ GpuConvAlgorithmPicker::PickBestAlgorithmNoCacheRocm(
       RunConvOptions options;
       options.profile_result = &profile_result;
       options.algo_override = alg;
+      options.scratch_size_override = miopen_alg.scratch_size();
       Status launch_status =
           RunGpuConv(instr, absl::MakeSpan(operand_buffers), result_buffer,
                      &scratch_allocator, stream, options);

--- a/tensorflow/compiler/xla/service/gpu/gpu_conv_runner.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_conv_runner.cc
@@ -225,6 +225,9 @@ Status RunGpuConvImpl(const GpuConvParams& params,
 
   if (options.algo_override.has_value()) {
     algorithm = AlgorithmConfig(*options.algo_override);
+    if (options.scratch_size_override.has_value()) {
+      algorithm.set_scratch_size(*options.scratch_size_override);
+    }
   }
 
   Status run_status = RunGpuConvInternalImpl<ElementType, BiasType, OutputType>(

--- a/tensorflow/compiler/xla/service/gpu/gpu_conv_runner.h
+++ b/tensorflow/compiler/xla/service/gpu/gpu_conv_runner.h
@@ -35,6 +35,9 @@ struct RunConvOptions {
 
   // Use this algorithm, instead of the one from the instruction.
   absl::optional<se::dnn::AlgorithmDesc> algo_override;
+
+  // Use this scratch_bytes size, instead of the one from the instruction.
+  absl::optional<size_t> scratch_size_override;
 };
 
 // Implementation struct exposed for debugging and log analysis.

--- a/tensorflow/core/kernels/conv_grad_filter_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_filter_ops.cc
@@ -1076,7 +1076,9 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
                 ->ThenConvolveBackwardFilterWithAlgorithm(
                     input_desc, input_ptr, output_desc, out_backprop_ptr,
                     conv_desc, filter_desc, &filter_backprop_ptr,
-                    &scratch_allocator, AlgorithmConfig(profile_algorithm),
+                    &scratch_allocator,
+                    AlgorithmConfig(profile_algorithm,
+                                    miopen_algorithm.scratch_size()),
                     &profile_result)
                 .ok();
 

--- a/tensorflow/core/kernels/conv_grad_filter_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_filter_ops.cc
@@ -1040,16 +1040,21 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
       }
     }
 #elif TENSORFLOW_USE_ROCM
+    DnnScratchAllocator scratch_allocator(ConvolveBackwardFilterScratchSize,
+                                          ctx);
+
     std::vector<ProfileResult> algorithms;
-    OP_REQUIRES(ctx,
-                stream->parent()->GetMIOpenConvolveAlgorithms(
-                    se::dnn::ConvolutionKind::BACKWARD_FILTER, stream,
-                    se::dnn::ToDataType<T>::value, input_desc, filter_desc,
-                    conv_desc, output_desc, &algorithms),
-                errors::Unknown(
-                    "Failed to get convolution algorithm. This is probably "
-                    "because MIOpen failed to initialize, so try looking to "
-                    "see if a warning log message was printed above."));
+    OP_REQUIRES(
+        ctx,
+        stream->parent()->GetMIOpenConvolveAlgorithms(
+            se::dnn::ConvolutionKind::BACKWARD_FILTER,
+            se::dnn::ToDataType<T>::value, stream, input_desc, input_ptr,
+            filter_desc, filter_backprop_ptr, output_desc, out_backprop_ptr,
+            conv_desc, &scratch_allocator, &algorithms),
+        errors::Unknown(
+            "Failed to get convolution algorithm. This is probably "
+            "because MIOpen failed to initialize, so try looking to "
+            "see if a warning log message was printed above."));
 
     std::vector<tensorflow::AutotuneResult> results;
     if (algorithms.size() == 1) {
@@ -1067,8 +1072,6 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
     } else {
       for (auto miopen_algorithm : algorithms) {
         auto profile_algorithm = miopen_algorithm.algorithm();
-        DnnScratchAllocator scratch_allocator(ConvolveBackwardFilterScratchSize,
-                                              ctx);
         ProfileResult profile_result;
         bool miopen_launch_status = true;
         miopen_launch_status =

--- a/tensorflow/core/kernels/conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_input_ops.cc
@@ -1202,16 +1202,19 @@ void LaunchConv2DBackpropInputOp<GPUDevice, T>::operator()(
       }
     }
 #elif TENSORFLOW_USE_ROCM
+    DnnScratchAllocator scratch_allocator(ConvolveBackwardDataScratchSize, ctx);
     std::vector<ProfileResult> algorithms;
-    OP_REQUIRES(ctx,
-                stream->parent()->GetMIOpenConvolveAlgorithms(
-                    se::dnn::ConvolutionKind::BACKWARD_DATA, stream,
-                    se::dnn::ToDataType<T>::value, input_desc, filter_desc,
-                    conv_desc, output_desc, &algorithms),
-                errors::Unknown(
-                    "Failed to get convolution algorithm. This is probably "
-                    "because MIOpen failed to initialize, so try looking to "
-                    "see if a warning log message was printed above."));
+    OP_REQUIRES(
+        ctx,
+        stream->parent()->GetMIOpenConvolveAlgorithms(
+            se::dnn::ConvolutionKind::BACKWARD_DATA,
+            se::dnn::ToDataType<T>::value, stream, input_desc, in_backprop_ptr,
+            filter_desc, filter_ptr, output_desc, out_backprop_ptr, conv_desc,
+            &scratch_allocator, &algorithms),
+        errors::Unknown(
+            "Failed to get convolution algorithm. This is probably "
+            "because MIOpen failed to initialize, so try looking to "
+            "see if a warning log message was printed above."));
 
     std::vector<tensorflow::AutotuneResult> results;
     if (algorithms.size() == 1) {
@@ -1229,8 +1232,6 @@ void LaunchConv2DBackpropInputOp<GPUDevice, T>::operator()(
     } else {
       for (auto miopen_algorithm : algorithms) {
         auto profile_algorithm = miopen_algorithm.algorithm();
-        DnnScratchAllocator scratch_allocator(ConvolveBackwardDataScratchSize,
-                                              ctx);
         ProfileResult profile_result;
         bool miopen_launch_status = true;
         miopen_launch_status =

--- a/tensorflow/core/kernels/conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_input_ops.cc
@@ -1238,7 +1238,9 @@ void LaunchConv2DBackpropInputOp<GPUDevice, T>::operator()(
                 ->ThenConvolveBackwardDataWithAlgorithm(
                     filter_desc, filter_ptr, output_desc, out_backprop_ptr,
                     conv_desc, input_desc, &in_backprop_ptr, &scratch_allocator,
-                    AlgorithmConfig(profile_algorithm), &profile_result)
+                    AlgorithmConfig(profile_algorithm,
+                                    miopen_algorithm.scratch_size()),
+                    &profile_result)
                 .ok();
 
         if (miopen_launch_status && profile_result.is_valid()) {

--- a/tensorflow/core/kernels/conv_grad_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_grad_ops_3d.cc
@@ -1449,7 +1449,9 @@ class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
                 ->ThenConvolveBackwardDataWithAlgorithm(
                     filter_desc, filter_ptr, output_desc, out_backprop_ptr,
                     conv_desc, input_desc, &in_backprop_ptr, &scratch_allocator,
-                    AlgorithmConfig(profile_algorithm), &profile_result)
+                    AlgorithmConfig(profile_algorithm,
+                                    miopen_algorithm.scratch_size()),
+                    &profile_result)
                 .ok();
         if (miopen_launch_status) {
           if (profile_result.is_valid()) {
@@ -1896,7 +1898,9 @@ class Conv3DBackpropFilterOp<GPUDevice, T> : public OpKernel {
                     input_desc, input_ptr, output_desc, out_backprop_ptr,
                     conv_desc, filter_desc, &filter_backprop_ptr,
                     &scratch_allocator,
-                    AlgorithmConfig(profile_algorithm), &profile_result)
+                    AlgorithmConfig(profile_algorithm,
+                                    miopen_algorithm.scratch_size()),
+                    &profile_result)
                 .ok();
         if (cudnn_launch_status) {
           if (profile_result.is_valid()) {

--- a/tensorflow/core/kernels/conv_grad_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_grad_ops_3d.cc
@@ -1389,8 +1389,7 @@ class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
           conv_parameters.ShouldIncludeWinogradNonfusedAlgo<T>(
               stream->parent()),
           &algorithms));
-      ProfileResult best_result;
-      ProfileResult best_result_no_scratch;
+
       std::vector<tensorflow::AutotuneResult> results;
       for (const auto& profile_algorithm : algorithms) {
         // TODO(zhengxq): profile each algorithm multiple times to better
@@ -1427,15 +1426,6 @@ class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
             *result.mutable_run_time() = proto_utils::ToDurationProto(
                 absl::Milliseconds(profile_result.elapsed_time_in_ms()));
 
-            if (profile_result.elapsed_time_in_ms() <
-                best_result.elapsed_time_in_ms()) {
-              best_result = profile_result;
-            }
-            if (scratch_allocator.TotalByteSize() == 0 &&
-                profile_result.elapsed_time_in_ms() <
-                    best_result_no_scratch.elapsed_time_in_ms()) {
-              best_result_no_scratch = profile_result;
-            }
             // TODO(george): they don't do results at all??
             CheckRedzones(rz_scratch_allocator, &result);
             CheckRedzones(rz_allocator, &result);
@@ -1448,8 +1438,6 @@ class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
           se::dnn::ConvolutionKind::BACKWARD_DATA, stream,
           se::dnn::ToDataType<T>::value, input_desc, filter_desc, conv_desc,
           output_desc, &algorithms));
-      ProfileResult best_result;
-      ProfileResult best_result_no_scratch;
       std::vector<tensorflow::AutotuneResult> results;
       for (auto miopen_algorithm : algorithms) {
         auto profile_algorithm = miopen_algorithm.algorithm();
@@ -1473,16 +1461,6 @@ class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
             result.set_scratch_bytes(scratch_allocator.TotalByteSize());
             *result.mutable_run_time() = proto_utils::ToDurationProto(
                 absl::Milliseconds(profile_result.elapsed_time_in_ms()));
-
-            if (profile_result.elapsed_time_in_ms() <
-                best_result.elapsed_time_in_ms()) {
-              best_result = profile_result;
-            }
-            if (scratch_allocator.TotalByteSize() == 0 &&
-                profile_result.elapsed_time_in_ms() <
-                    best_result_no_scratch.elapsed_time_in_ms()) {
-              best_result_no_scratch = profile_result;
-            }
           }
         }
       }
@@ -1492,16 +1470,8 @@ class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
                              filter_ptr, out_backprop_ptr, input_desc,
                              filter_desc, output_desc, conv_desc,
                              stream->parent(), results);
-      OP_REQUIRES(context,
-                  best_result.is_valid() || best_result_no_scratch.is_valid(),
-                  errors::NotFound("No algorithm worked!"));
-      if (best_result.is_valid()) {
-        algorithm_config.set_algorithm(best_result.algorithm());
-      }
-      if (best_result_no_scratch.is_valid()) {
-        algorithm_config.set_algorithm_no_scratch(
-            best_result_no_scratch.algorithm());
-      }
+      OP_REQUIRES_OK(context,
+                     BestCudnnConvAlgorithm(results, &algorithm_config));
       AutoTuneConv3dBwdData::GetInstance()->Insert(conv_parameters,
                                                    algorithm_config);
     }
@@ -1878,8 +1848,8 @@ class Conv3DBackpropFilterOp<GPUDevice, T> : public OpKernel {
           conv_parameters.ShouldIncludeWinogradNonfusedAlgo<T>(
               stream->parent()),
           &algorithms));
-      ProfileResult best_result;
-      ProfileResult best_result_no_scratch;
+
+      std::vector<tensorflow::AutotuneResult> results;
       for (const auto& profile_algorithm : algorithms) {
         // TODO(zhengxq): profile each algorithm multiple times to better
         // accuracy.
@@ -1896,15 +1866,14 @@ class Conv3DBackpropFilterOp<GPUDevice, T> : public OpKernel {
                 .ok();
         if (cudnn_launch_status) {
           if (profile_result.is_valid()) {
-            if (profile_result.elapsed_time_in_ms() <
-                best_result.elapsed_time_in_ms()) {
-              best_result = profile_result;
-            }
-            if (scratch_allocator.TotalByteSize() == 0 &&
-                profile_result.elapsed_time_in_ms() <
-                    best_result_no_scratch.elapsed_time_in_ms()) {
-              best_result_no_scratch = profile_result;
-            }
+            results.emplace_back();
+            auto& result = results.back();
+            result.mutable_conv()->set_algorithm(profile_algorithm.algo_id());
+            result.mutable_conv()->set_tensor_ops_enabled(
+                profile_algorithm.tensor_ops_enabled());
+            result.set_scratch_bytes(scratch_allocator.TotalByteSize());
+            *result.mutable_run_time() = proto_utils::ToDurationProto(
+                absl::Milliseconds(profile_result.elapsed_time_in_ms()));
           }
         }
       }
@@ -1914,50 +1883,42 @@ class Conv3DBackpropFilterOp<GPUDevice, T> : public OpKernel {
           se::dnn::ConvolutionKind::BACKWARD_FILTER, stream,
           se::dnn::ToDataType<T>::value, input_desc, filter_desc, conv_desc,
           output_desc, &algorithms));
-      ProfileResult best_result;
-      ProfileResult best_result_no_scratch;
-      if (algorithms.size() == 1) {
-        best_result = algorithms[0];
-      } else {
-        for (auto miopen_algorithm : algorithms) {
-          auto profile_algorithm = miopen_algorithm.algorithm();
-          DnnScratchAllocator scratch_allocator(
-              ConvolveBackwardFilterScratchSize, context);
-          ProfileResult profile_result;
-          bool cudnn_launch_status =
-              stream
-                  ->ThenConvolveBackwardFilterWithAlgorithm(
-                      input_desc, input_ptr, output_desc, out_backprop_ptr,
-                      conv_desc, filter_desc, &filter_backprop_ptr,
-                      &scratch_allocator, AlgorithmConfig(profile_algorithm),
-                      &profile_result)
-                  .ok();
-          if (cudnn_launch_status) {
-            if (profile_result.is_valid()) {
-              if (profile_result.elapsed_time_in_ms() <
-                  best_result.elapsed_time_in_ms()) {
-                best_result = profile_result;
-              }
-              if (scratch_allocator.TotalByteSize() == 0 &&
-                  profile_result.elapsed_time_in_ms() <
-                      best_result_no_scratch.elapsed_time_in_ms()) {
-                best_result_no_scratch = profile_result;
-              }
-            }
+
+      std::vector<tensorflow::AutotuneResult> results;
+      for (auto miopen_algorithm : algorithms) {
+        auto profile_algorithm = miopen_algorithm.algorithm();
+        DnnScratchAllocator scratch_allocator(ConvolveBackwardFilterScratchSize,
+                                              context);
+        ProfileResult profile_result;
+        bool cudnn_launch_status =
+            stream
+                ->ThenConvolveBackwardFilterWithAlgorithm(
+                    input_desc, input_ptr, output_desc, out_backprop_ptr,
+                    conv_desc, filter_desc, &filter_backprop_ptr,
+                    &scratch_allocator,
+                    AlgorithmConfig(profile_algorithm), &profile_result)
+                .ok();
+        if (cudnn_launch_status) {
+          if (profile_result.is_valid()) {
+            results.emplace_back();
+            auto& result = results.back();
+            result.mutable_conv()->set_algorithm(profile_algorithm.algo_id());
+            result.mutable_conv()->set_tensor_ops_enabled(
+                profile_algorithm.tensor_ops_enabled());
+            result.set_scratch_bytes(scratch_allocator.TotalByteSize());
+            *result.mutable_run_time() = proto_utils::ToDurationProto(
+                absl::Milliseconds(profile_result.elapsed_time_in_ms()));
           }
         }
       }
 #endif
-      OP_REQUIRES(context,
-                  best_result.is_valid() || best_result_no_scratch.is_valid(),
-                  errors::NotFound("No algorithm worked!"));
-      if (best_result.is_valid()) {
-        algorithm_config.set_algorithm(best_result.algorithm());
-      }
-      if (best_result_no_scratch.is_valid()) {
-        algorithm_config.set_algorithm_no_scratch(
-            best_result_no_scratch.algorithm());
-      }
+      LogConvAutotuneResults(se::dnn::ConvolutionKind::BACKWARD_FILTER,
+                             se::dnn::ToDataType<T>::value, input_ptr,
+                             filter_backprop_ptr, out_backprop_ptr, input_desc,
+                             filter_desc, output_desc, conv_desc,
+                             stream->parent(), results);
+      OP_REQUIRES_OK(context,
+                     BestCudnnConvAlgorithm(results, &algorithm_config));
       AutoTuneConv3dBwdFilter::GetInstance()->Insert(conv_parameters,
                                                      algorithm_config);
     }

--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -1052,16 +1052,19 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
     }
 
 #elif TENSORFLOW_USE_ROCM
+    DnnScratchAllocator scratch_allocator(ConvolveScratchSize, ctx);
+
     std::vector<ProfileResult> algorithms;
-    OP_REQUIRES(ctx,
-                stream->parent()->GetMIOpenConvolveAlgorithms(
-                    se::dnn::ConvolutionKind::FORWARD, stream,
-                    se::dnn::ToDataType<T>::value, input_desc, filter_desc,
-                    conv_desc, output_desc, &algorithms),
-                errors::Unknown(
-                    "Failed to get convolution algorithm. This is probably "
-                    "because MIOpen failed to initialize, so try looking to "
-                    "see if a warning log message was printed above."));
+    OP_REQUIRES(
+        ctx,
+        stream->parent()->GetMIOpenConvolveAlgorithms(
+            se::dnn::ConvolutionKind::FORWARD, se::dnn::ToDataType<T>::value,
+            stream, input_desc, input_ptr, filter_desc, filter_ptr, output_desc,
+            output_ptr, conv_desc, &scratch_allocator, &algorithms),
+        errors::Unknown(
+            "Failed to get convolution algorithm. This is probably "
+            "because MIOpen failed to initialize, so try looking to "
+            "see if a warning log message was printed above."));
     se::DeviceMemory<T> output_tensor = output_ptr;
 
     std::vector<tensorflow::AutotuneResult> results;
@@ -1080,7 +1083,6 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
     } else {
       for (auto miopen_algorithm : algorithms) {
         auto profile_algorithm = miopen_algorithm.algorithm();
-        DnnScratchAllocator scratch_allocator(ConvolveScratchSize, ctx);
         ProfileResult profile_result;
         bool miopen_launch_status = false;
         miopen_launch_status =

--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -1088,7 +1088,9 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
                 ->ThenConvolveWithAlgorithm(
                     input_desc, input_ptr, filter_desc, filter_ptr, conv_desc,
                     output_desc, &output_ptr, &scratch_allocator,
-                    AlgorithmConfig(profile_algorithm), &profile_result)
+                    AlgorithmConfig(profile_algorithm,
+                                    miopen_algorithm.scratch_size()),
+                    &profile_result)
                 .ok();
         if (miopen_launch_status && profile_result.is_valid()) {
           results.emplace_back();

--- a/tensorflow/core/kernels/conv_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_ops_3d.cc
@@ -377,12 +377,15 @@ struct LaunchConvOp<GPUDevice, T, OpKernelContext> {
         }
       }
 #elif TENSORFLOW_USE_ROCM
+      DnnScratchAllocator scratch_allocator(ConvolveScratchSize, ctx);
+
       std::vector<ProfileResult> algorithms;
       OP_REQUIRES(ctx,
                   stream->parent()->GetMIOpenConvolveAlgorithms(
-                      se::dnn::ConvolutionKind::FORWARD, stream,
-                      se::dnn::ToDataType<T>::value, input_desc, filter_desc,
-                      conv_desc, output_desc, &algorithms),
+                      se::dnn::ConvolutionKind::FORWARD,
+                      se::dnn::ToDataType<T>::value, stream, input_desc,
+                      input_ptr, filter_desc, filter_ptr, output_desc,
+                      output_ptr, conv_desc, &scratch_allocator, &algorithms),
                   errors::Unknown(
                       "Failed to get convolution algorithm. This is probably "
                       "because MIOpen failed to initialize, so try looking to "
@@ -403,7 +406,6 @@ struct LaunchConvOp<GPUDevice, T, OpKernelContext> {
       } else {
         for (auto miopen_algorithm : algorithms) {
           auto profile_algorithm = miopen_algorithm.algorithm();
-          DnnScratchAllocator scratch_allocator(ConvolveScratchSize, ctx);
           ProfileResult profile_result;
           bool miopen_launch_status =
               stream

--- a/tensorflow/core/kernels/conv_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_ops_3d.cc
@@ -410,7 +410,9 @@ struct LaunchConvOp<GPUDevice, T, OpKernelContext> {
                   ->ThenConvolveWithAlgorithm(
                       input_desc, input_ptr, filter_desc, filter_ptr, conv_desc,
                       output_desc, &output_ptr, &scratch_allocator,
-                      AlgorithmConfig(profile_algorithm), &profile_result)
+                      AlgorithmConfig(profile_algorithm,
+                                      miopen_algorithm.scratch_size()),
+                      &profile_result)
                   .ok();
           if (miopen_launch_status) {
             if (profile_result.is_valid()) {

--- a/tensorflow/core/kernels/gpu_utils.cc
+++ b/tensorflow/core/kernels/gpu_utils.cc
@@ -270,6 +270,7 @@ Status BestCudnnConvAlgorithm(absl::Span<const AutotuneResult> results,
 
   algo->set_algorithm({selected_result->conv().algorithm(),
                        selected_result->conv().tensor_ops_enabled()});
+  algo->set_scratch_size(selected_result->scratch_bytes());
   if (selected_result_no_scratch != filtered_results_no_scratch.end()) {
     algo->set_algorithm_no_scratch(
         {selected_result_no_scratch->conv().algorithm(),

--- a/tensorflow/python/debug/lib/check_numerics_callback_test.py
+++ b/tensorflow/python/debug/lib/check_numerics_callback_test.py
@@ -41,6 +41,7 @@ from tensorflow.python.ops import gradient_checker_v2
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import variables
 from tensorflow.python.platform import googletest
+from tensorflow.python.platform import test as test_lib
 
 
 class LimitStringLengthTest(test_util.TensorFlowTestCase):
@@ -155,6 +156,13 @@ class CheckNumericsCallbackTest(test_util.TensorFlowTestCase):
   @test_util.run_in_graph_and_eager_modes
   def testMobileNetV2Fit(self):
     """Test training Keras MobileNetV2 application works w/ check numerics."""
+
+    if test_lib.is_built_with_rocm():
+      # This test passes with MIOpen Find Mode (which is the default)
+      # This bug is being tracked via MLOpen Issue #2379, re-enable this
+      # test once the fix for that issue is available in a ROCm release
+      self.skipTest("MIOpen bug results in test failure")
+
     check_numerics_callback.enable_check_numerics()
     model = mobilenet_v2.MobileNetV2(alpha=0.1, weights=None)
 

--- a/tensorflow/stream_executor/dnn.cc
+++ b/tensorflow/stream_executor/dnn.cc
@@ -48,12 +48,15 @@ bool DnnSupport::GetConvolveAlgorithms(
 }
 
 bool DnnSupport::GetMIOpenConvolveAlgorithms(
-    dnn::ConvolutionKind /*kind*/, Stream* /*stream*/,
-    dnn::DataType /*element_type*/,
-    const dnn::BatchDescriptor& /*input_descriptor*/,
+    dnn::ConvolutionKind /*kind*/, dnn::DataType /*element_type*/,
+    Stream* /*stream*/, const dnn::BatchDescriptor& /*input_descriptor*/,
+    DeviceMemoryBase input_data,
     const dnn::FilterDescriptor& /*filter_descriptor*/,
-    const dnn::ConvolutionDescriptor& /*convolution_descriptor*/,
+    DeviceMemoryBase filter_data,
     const dnn::BatchDescriptor& /*output_descriptor*/,
+    DeviceMemoryBase output_data,
+    const dnn::ConvolutionDescriptor& /*convolution_descriptor*/,
+    ScratchAllocator* scratch_allocator,
     std::vector<ProfileResult>* /*out_algorithms*/) {
   return false;
 }

--- a/tensorflow/stream_executor/dnn.h
+++ b/tensorflow/stream_executor/dnn.h
@@ -1346,11 +1346,14 @@ class DnnSupport {
       std::vector<AlgorithmDesc>* out_algorithms);
 
   virtual bool GetMIOpenConvolveAlgorithms(
-      dnn::ConvolutionKind kind, Stream* stream, dnn::DataType element_type,
-      const dnn::BatchDescriptor& input_descriptor,
+      dnn::ConvolutionKind kind, dnn::DataType element_type, Stream* stream,
+      const dnn::BatchDescriptor& input_descriptor, DeviceMemoryBase input_data,
       const dnn::FilterDescriptor& filter_descriptor,
-      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      DeviceMemoryBase filter_data,
       const dnn::BatchDescriptor& output_descriptor,
+      DeviceMemoryBase output_data,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      ScratchAllocator* scratch_allocator,
       std::vector<ProfileResult>* out_algorithms);
 
   // Returns a list of supported rnn algorithms.

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -600,13 +600,11 @@ MIOpenSupport::MIOpenSupport(GpuExecutor* parent) : parent_(parent) {
   tensorflow::ReadBoolFromEnvVar("TF_ROCM_RETURN_BEST_ALGO_ONLY", false,
                                  &return_best_algo_only_);
 
-  // by default, use Immediate Mode APIs for convolution
-  use_immediate_mode_ = true;
-  // swich to Find Mode if env var TF_ROCM_USE_FIND_MODE is set
-  bool use_find_mode = false;
-  tensorflow::ReadBoolFromEnvVar("TF_ROCM_USE_FIND_MODE", false,
-                                 &use_find_mode);
-  use_immediate_mode_ = !use_find_mode;
+  // by default, use Find Mode APIs for convolution
+  use_immediate_mode_ = false;
+  // swich to Find Mode if env var TF_ROCM_USE_IMMEDIATE_MODE is set
+  tensorflow::ReadBoolFromEnvVar("TF_ROCM_USE_IMMEDIATE_MODE", false,
+                                 &use_immediate_mode_);
 }
 
 port::Status MIOpenSupport::Init() {

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -2769,20 +2769,6 @@ port::Status MIOpenSupport::DoPrepareForConvolution(
     const dnn::AlgorithmConfig& algorithm_config,
     ScratchAllocator* scratch_allocator, dnn::AlgorithmDesc* algorithm_desc,
     DeviceMemory<uint8>* scratch_memory) {
-  ScopedTensorDescriptor input_nd{
-      input_descriptor,
-      ToMIOpenDataType(element_type, input_descriptor.layout())};
-  ScopedFilterDescriptor filter{
-      filter_descriptor, input_descriptor,
-      ToMIOpenDataType(element_type, filter_descriptor.layout())};
-  ScopedTensorDescriptor output_nd{
-      output_descriptor,
-      ToMIOpenDataType(element_type, output_descriptor.layout())};
-  ScopedConvolutionDescriptor conv{
-      convolution_descriptor,
-      ToMIOpenDataType(GetConvAccumulatorType(element_type))};
-
-  auto miopen = miopen_->GetHandle(parent_, stream);
 
   absl::optional<dnn::AlgorithmDesc> input_algo_desc =
       algorithm_config.algorithm();
@@ -2792,64 +2778,9 @@ port::Status MIOpenSupport::DoPrepareForConvolution(
   // An algorithm has been specified.
   *algorithm_desc = *input_algo_desc;
 
-  const uint64_t solution_id = algorithm_desc->algo_id();
+  assert(algorithm_config.scratch_size().has_value());
 
-  size_t scratch_memory_size = 0;
-
-  switch (kind) {
-    case dnn::ConvolutionKind::FORWARD: {
-      auto status = wrap::miopenConvolutionForwardGetSolutionWorkspaceSize(
-          miopen.handle(), filter.handle(), input_nd.handle(), conv.handle(),
-          output_nd.handle(), solution_id, &scratch_memory_size);
-
-      if (status != miopenStatusSuccess) {
-        return port::InternalError(absl::StrCat(
-            "call to miopenConvolutionForwardGetSolutionWorkspaceSize "
-            "failed: ",
-            ToString(status)));
-      }
-      break;
-    }
-
-    case dnn::ConvolutionKind::BACKWARD_DATA: {
-      auto status = wrap::miopenConvolutionBackwardDataGetSolutionWorkspaceSize(
-          miopen.handle(), output_nd.handle(), filter.handle(), conv.handle(),
-          input_nd.handle(), solution_id, &scratch_memory_size);
-
-      if (status != miopenStatusSuccess) {
-        return port::InternalError(absl::StrCat(
-            "call to miopenConvolutionabckwardDataGetSolutionWorkspaceSize "
-            "failed: ",
-            ToString(status)));
-      }
-      break;
-    }
-
-    case dnn::ConvolutionKind::BACKWARD_FILTER: {
-      auto status =
-          wrap::miopenConvolutionBackwardWeightsGetSolutionWorkspaceSize(
-              miopen.handle(), output_nd.handle(), input_nd.handle(),
-              conv.handle(), filter.handle(), solution_id,
-              &scratch_memory_size);
-
-      if (status != miopenStatusSuccess) {
-        return port::InternalError(absl::StrCat(
-            "call to miopenConvolutionabckwardWeightsGetSolutionWorkspaceSize "
-            "failed: ",
-            ToString(status)));
-      }
-      break;
-    }
-
-    default: {
-      return port::InternalError(
-          absl::StrCat("Unexpected convolution kind ", static_cast<int>(kind)));
-      break;
-    }
-  }
-
-  VLOG(2) << "miopen...GetSolutionWorkspaceSize returned "
-          << scratch_memory_size << " for solution_id " << solution_id;
+  size_t scratch_memory_size = *(algorithm_config.scratch_size());
 
   // allocate scratch memory
   if (scratch_memory_size != 0) {

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -2989,7 +2989,12 @@ port::Status MIOpenSupport::DoConvolve(
             scratch_memory.size(),
             static_cast<uint64_t>(algorithm_desc.algo_id()));
       } else {
- 	// PLACEHOLDER FOR FIND MODE IMPLEMENTATION
+        status = wrap::miopenConvolutionForward(
+            miopen.handle(), &alpha, input_nd.handle(), input_data.opaque(),
+            filter.handle(), filter_data.opaque(), conv.handle(),
+            static_cast<miopenConvFwdAlgorithm_t>(algorithm_desc.algo_id()),
+            &beta, output_nd.handle(), output_data.opaque(),
+            scratch_memory.opaque(), scratch_memory.size());
       }
 
       break;
@@ -3011,7 +3016,12 @@ port::Status MIOpenSupport::DoConvolve(
             scratch_memory.size(),
             static_cast<uint64_t>(algorithm_desc.algo_id()));
       } else {
-	// PLACEHOLDER FOR FIND MODE IMPLEMENTATION
+        status = wrap::miopenConvolutionBackwardData(
+            miopen.handle(), &alpha, output_nd.handle(), output_data.opaque(),
+            filter.handle(), filter_data.opaque(), conv.handle(),
+            static_cast<miopenConvBwdDataAlgorithm_t>(algorithm_desc.algo_id()),
+            &beta, input_nd.handle(), input_data.opaque(),
+            scratch_memory.opaque(), scratch_memory.size());
       }
       break;
     }
@@ -3032,7 +3042,13 @@ port::Status MIOpenSupport::DoConvolve(
             scratch_memory.size(),
             static_cast<uint64_t>(algorithm_desc.algo_id()));
       } else {
-	// PLACEHOLDER FOR FIND MODE IMPLEMENTATION
+        status = wrap::miopenConvolutionBackwardWeights(
+            miopen.handle(), &alpha, output_nd.handle(), output_data.opaque(),
+            input_nd.handle(), input_data.opaque(), conv.handle(),
+            static_cast<miopenConvBwdWeightsAlgorithm_t>(
+                algorithm_desc.algo_id()),
+            &beta, filter.handle(), filter_data.opaque(),
+            scratch_memory.opaque(), scratch_memory.size());
       }
       break;
     }
@@ -3319,9 +3335,153 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithmsFindMode(
     const dnn::ConvolutionDescriptor& convolution_descriptor,
     ScratchAllocator* scratch_allocator,
     std::vector<dnn::ProfileResult>* out_algorithms) {
+  auto miopen = miopen_->GetHandle(parent_, stream);
 
-  // PLACEHOLDER FOR FIND MODE IMPLEMENTATION
-  
+  ScopedTensorDescriptor input_nd{input_descriptor,
+                                  ToMIOpenDataType(element_type)};
+  ScopedTensorDescriptor output_nd{output_descriptor,
+                                   ToMIOpenDataType(element_type)};
+  ScopedFilterDescriptor filter{filter_descriptor, input_descriptor,
+                                ToMIOpenDataType(element_type)};
+  ScopedConvolutionDescriptor conv{convolution_descriptor,
+                                   ToMIOpenDataType(element_type)};
+
+  // Determine the workspace memory size that will need by the call to Find
+  size_t scratch_memory_size = 0;
+  switch (kind) {
+    case dnn::ConvolutionKind::FORWARD: {
+      auto status = wrap::miopenConvolutionForwardGetWorkSpaceSize(
+          miopen.handle(), filter.handle(), input_nd.handle(), conv.handle(),
+          output_nd.handle(), &scratch_memory_size);
+      if (status != miopenStatusSuccess) {
+        LOG(FATAL)
+            << "call to miopenConvolutionForwardGetWorkspaceSize failed: "
+            << ToString(status);
+        return false;
+      }
+      break;
+    }
+    case dnn::ConvolutionKind::BACKWARD_DATA: {
+      auto status = wrap::miopenConvolutionBackwardDataGetWorkSpaceSize(
+          miopen.handle(), output_nd.handle(), filter.handle(), conv.handle(),
+          input_nd.handle(), &scratch_memory_size);
+      if (status != miopenStatusSuccess) {
+        LOG(FATAL)
+            << "call to miopenConvolutionBackwardDataGetWorkspaceSize failed: "
+            << ToString(status);
+        return false;
+      }
+      break;
+    }
+    case dnn::ConvolutionKind::BACKWARD_FILTER: {
+      auto status = wrap::miopenConvolutionBackwardWeightsGetWorkSpaceSize(
+          miopen.handle(), output_nd.handle(), input_nd.handle(), conv.handle(),
+          filter.handle(), &scratch_memory_size);
+      if (status != miopenStatusSuccess) {
+        LOG(FATAL)
+            << "call to miopenConvolutionBackwardWeightsGetWorkspaceSize "
+               "failed: "
+            << ToString(status);
+        return false;
+      }
+      break;
+    }
+    default: {
+      LOG(FATAL) << "Unexpected convolution kind " << static_cast<int>(kind);
+      return false;
+      break;
+    }
+  }
+
+  // allocate scratch memory
+  DeviceMemory<uint8> scratch_memory;
+  if (scratch_memory_size != 0) {
+    if (scratch_allocator == nullptr) {
+      LOG(FATAL)
+          << "An allocator must be specified when scratch memory is needed";
+      return false;
+    }
+    auto allocated = scratch_allocator->AllocateBytes(scratch_memory_size);
+    if (allocated.ok()) {
+      scratch_memory = allocated.ValueOrDie();
+    } else {
+      LOG(FATAL)
+          << "Failed to allocate scratch memory - "
+          << allocated.status().error_message() << "\n"
+          << "\tYou can set the env var TF_CUDNN_WORKSPACE_LIMIT_IN_MB to a "
+             "larger number (e.g. 8192) to increase the max memory limit.\n"
+          << "\tIncreasing the max memory limit might help resolve this "
+             "error";
+      return false;
+    }
+  }
+
+  // Only get the best algorithm for Find Mode
+  size_t requestedAlgorithmCount = 1;
+
+  VLOG(kConvDebugVlogLevel)
+      << "Number of conv algortihms to request: " << requestedAlgorithmCount;
+
+  miopenConvAlgoPerf_t returnedAlgorithm;
+
+  int returnedAlgorithmCount = 0;
+  bool exhaustiveSearch = false;
+
+  switch (kind) {
+    case dnn::ConvolutionKind::FORWARD: {
+      auto status = wrap::miopenFindConvolutionForwardAlgorithm(
+          miopen.handle(), input_nd.handle(), input_data.opaque(),
+          filter.handle(), filter_data.opaque(), conv.handle(),
+          output_nd.handle(), output_data.opaque(), requestedAlgorithmCount,
+          &returnedAlgorithmCount, &returnedAlgorithm, scratch_memory.opaque(),
+          scratch_memory_size, exhaustiveSearch);
+      if (status != miopenStatusSuccess) {
+        LOG(FATAL) << "call to miopenFindConvolutionForwardAlgorithm failed: "
+                   << ToString(status);
+        return false;
+      }
+      break;
+    }
+    case dnn::ConvolutionKind::BACKWARD_DATA: {
+      auto status = wrap::miopenFindConvolutionBackwardDataAlgorithm(
+          miopen.handle(), output_nd.handle(), output_data.opaque(),
+          filter.handle(), filter_data.opaque(), conv.handle(),
+          input_nd.handle(), input_data.opaque(), requestedAlgorithmCount,
+          &returnedAlgorithmCount, &returnedAlgorithm, scratch_memory.opaque(),
+          scratch_memory_size, exhaustiveSearch);
+      if (status != miopenStatusSuccess) {
+        LOG(FATAL)
+            << "call to miopenFindConvolutionBackwardDataAlgorithm failed: "
+            << ToString(status);
+        return false;
+      }
+      break;
+    }
+    case dnn::ConvolutionKind::BACKWARD_FILTER: {
+      auto status = wrap::miopenFindConvolutionBackwardWeightsAlgorithm(
+          miopen.handle(), output_nd.handle(), output_data.opaque(),
+          input_nd.handle(), input_data.opaque(), conv.handle(),
+          filter.handle(), filter_data.opaque(), requestedAlgorithmCount,
+          &returnedAlgorithmCount, &returnedAlgorithm, scratch_memory.opaque(),
+          scratch_memory_size, exhaustiveSearch);
+      if (status != miopenStatusSuccess) {
+        LOG(FATAL) << "call to miopenConvolutionBackwardWeightsAlgorithm "
+                      "failed: "
+                   << ToString(status);
+        return false;
+      }
+      break;
+    }
+    default: {
+      LOG(FATAL) << "Unexpected convolution kind " << static_cast<int>(kind);
+      return false;
+      break;
+    }
+  }
+
+  out_algorithms->emplace_back(
+      GetProfileResultFromConvAlgoPerf(kind, returnedAlgorithm));
+
   return true;
 }
 

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -95,6 +95,75 @@ string ToString(miopenStatus_t status) {
   }
 }
 
+string ToString(miopenConvFwdAlgorithm_t algorithm) {
+  string s;
+  switch (algorithm) {
+    case miopenConvolutionFwdAlgoGEMM:
+      s = "GEMM";
+      break;
+    case miopenConvolutionFwdAlgoDirect:
+      s = "Direct";
+      break;
+    case miopenConvolutionFwdAlgoFFT:
+      s = "FFT";
+      break;
+    case miopenConvolutionFwdAlgoWinograd:
+      s = "Winograd";
+      break;
+    case miopenConvolutionFwdAlgoImplicitGEMM:
+      s = "Implicit GEMM";
+      break;
+    case miopenConvolutionFwdAlgoStaticCompiledGEMM:
+      s = "Static Compiled GEMM";
+      break;
+  }
+  return s;
+}
+
+string ToString(miopenConvBwdWeightsAlgorithm_t algorithm) {
+  string s;
+  switch (algorithm) {
+    case miopenConvolutionBwdWeightsAlgoGEMM:
+      s = "GEMM";
+      break;
+    case miopenConvolutionBwdWeightsAlgoDirect:
+      s = "Direct";
+      break;
+    case miopenConvolutionBwdWeightsAlgoWinograd:
+      s = "Winograd";
+      break;
+    case miopenConvolutionBwdWeightsAlgoImplicitGEMM:
+      s = "Implicit GEMM";
+      break;
+  }
+  return s;
+}
+
+string ToString(miopenConvBwdDataAlgorithm_t algorithm) {
+  string s;
+  switch (algorithm) {
+    case miopenConvolutionBwdDataAlgoGEMM:
+      s = "GEMM";
+      break;
+    case miopenConvolutionBwdDataAlgoDirect:
+      s = "Direct";
+      break;
+    case miopenConvolutionBwdDataAlgoFFT:
+      s = "FFT";
+      break;
+    case miopenConvolutionBwdDataAlgoWinograd:
+      s = "Winograd";
+      break;
+    case miopenTransposeBwdDataAlgoGEMM:
+      s = "Transpose GEMM";
+      break;
+    case miopenConvolutionBwdDataAlgoImplicitGEMM:
+      s = "Implicit GEMM";
+      break;
+  }
+  return s;
+}
+
 string ToString(miopenConvAlgorithm_t algorithm) {
   string s;
   switch (algorithm) {
@@ -119,6 +188,7 @@ string ToString(miopenConvAlgorithm_t algorithm) {
   }
   return s;
 }
+
 // RAII wrapper for all calls to MIOpen with a MIOpen handle argument.
 //
 // See MIOpenAccess::GetHandle() for details.
@@ -447,6 +517,31 @@ dnn::ProfileResult GetProfileResultFromConvSolution(
   return profile_result;
 }
 
+dnn::ProfileResult GetProfileResultFromConvAlgoPerf(
+    dnn::ConvolutionKind kind, miopenConvAlgoPerf_t algorithm) {
+  dnn::ProfileResult profile_result;
+  switch (kind) {
+    case dnn::ConvolutionKind::FORWARD:
+      profile_result.set_algorithm(
+          {static_cast<AlgorithmDesc::Index>(algorithm.fwd_algo), false});
+      break;
+    case dnn::ConvolutionKind::BACKWARD_DATA:
+      profile_result.set_algorithm(
+          {static_cast<AlgorithmDesc::Index>(algorithm.bwd_data_algo), false});
+      break;
+    case dnn::ConvolutionKind::BACKWARD_FILTER:
+      profile_result.set_algorithm(
+          {static_cast<AlgorithmDesc::Index>(algorithm.bwd_weights_algo),
+           false});
+      break;
+    default:
+      LOG(FATAL) << "Unexpected convolution kind " << static_cast<int>(kind);
+      break;
+  }
+  profile_result.set_elapsed_time_in_ms(algorithm.time);
+  profile_result.set_scratch_size(algorithm.memory);
+  return profile_result;
+}
 }  // namespace
 
 // Wraps a MIOpen handle and provides access to it through miopenHandle_t
@@ -504,6 +599,14 @@ MIOpenSupport::MIOpenSupport(GpuExecutor* parent) : parent_(parent) {
   // (i.e. most efficient) algorithm will be returned
   tensorflow::ReadBoolFromEnvVar("TF_ROCM_RETURN_BEST_ALGO_ONLY", false,
                                  &return_best_algo_only_);
+
+  // by default, use Immediate Mode APIs for convolution
+  use_immediate_mode_ = true;
+  // swich to Find Mode if env var TF_ROCM_USE_FIND_MODE is set
+  bool use_find_mode = false;
+  tensorflow::ReadBoolFromEnvVar("TF_ROCM_USE_FIND_MODE", false,
+                                 &use_find_mode);
+  use_immediate_mode_ = !use_find_mode;
 }
 
 port::Status MIOpenSupport::Init() {
@@ -1555,11 +1658,6 @@ miopenDataType_t ToMIOpenDataType(
   }
 }
 
-miopenDataType_t ToMIOpenDataType(dnn::DataType data_type,
-                                  dnn::FilterLayout filter_layout) {
-  return ToMIOpenDataType(data_type);
-}
-
 miopenRNNInputMode_t ToMIOpenRnnInputMode(dnn::RnnInputMode input_mode) {
   switch (input_mode) {
     case dnn::RnnInputMode::kRnnLinearSkip:
@@ -1603,22 +1701,6 @@ template <typename Base>
 class MixinBase : public Base {};
 template <>
 class MixinBase<void> {};
-
-dnn::DataType GetConvAccumulatorType(dnn::DataType data_type) {
-  switch (data_type) {
-    case dnn::DataType::kFloat:
-    case dnn::DataType::kDouble:
-      return data_type;
-    case dnn::DataType::kHalf:
-      // FIXME: Check if MIOpen can switch dynamically change accumulator type
-      return dnn::DataType::kFloat;
-    case dnn::DataType::kInt8:
-    case dnn::DataType::kInt32:
-      return dnn::DataType::kInt32;
-    default:
-      LOG(FATAL) << "Invalid DNN data type: " << static_cast<int>(data_type);
-  }
-}
 
 }  // namespace
 
@@ -2769,7 +2851,6 @@ port::Status MIOpenSupport::DoPrepareForConvolution(
     const dnn::AlgorithmConfig& algorithm_config,
     ScratchAllocator* scratch_allocator, dnn::AlgorithmDesc* algorithm_desc,
     DeviceMemory<uint8>* scratch_memory) {
-
   absl::optional<dnn::AlgorithmDesc> input_algo_desc =
       algorithm_config.algorithm();
 
@@ -2875,6 +2956,11 @@ port::Status MIOpenSupport::DoConvolve(
   ScopedConvolutionDescriptor conv{convolution_descriptor,
                                    ToMIOpenDataType(element_type)};
 
+  // Alpha is the scaling factor for input.
+  float alpha = 1.0;
+  // Beta is the scaling factor for output.
+  float beta = 0.0;
+
   const bool is_profiling = output_profile_result != nullptr;
 
   std::unique_ptr<GpuTimer> timer;
@@ -2892,16 +2978,19 @@ port::Status MIOpenSupport::DoConvolve(
     }
   }
 
-  const uint64_t solution_id = algorithm_desc.algo_id();
-
   miopenStatus_t status = miopenStatusSuccess;
   switch (kind) {
     case dnn::ConvolutionKind::FORWARD: {
-      status = wrap::miopenConvolutionForwardImmediate(
-          miopen.handle(), filter.handle(), filter_data.opaque(),
-          input_nd.handle(), input_data.opaque(), conv.handle(),
-          output_nd.handle(), output_data.opaque(), scratch_memory.opaque(),
-          scratch_memory.size(), solution_id);
+      if (use_immediate_mode_) {
+        status = wrap::miopenConvolutionForwardImmediate(
+            miopen.handle(), filter.handle(), filter_data.opaque(),
+            input_nd.handle(), input_data.opaque(), conv.handle(),
+            output_nd.handle(), output_data.opaque(), scratch_memory.opaque(),
+            scratch_memory.size(),
+            static_cast<uint64_t>(algorithm_desc.algo_id()));
+      } else {
+ 	// PLACEHOLDER FOR FIND MODE IMPLEMENTATION
+      }
 
       break;
     }
@@ -2914,11 +3003,16 @@ port::Status MIOpenSupport::DoConvolve(
           stream, miopen.handle(), ToMIOpenDataType(element_type),
           &output_back_descriptor, output_data, &transform_scratch);
 
-      status = wrap::miopenConvolutionBackwardDataImmediate(
-          miopen.handle(), output_nd.handle(), output_data.opaque(),
-          filter.handle(), filter_data.opaque(), conv.handle(),
-          input_nd.handle(), input_data.opaque(), scratch_memory.opaque(),
-          scratch_memory.size(), solution_id);
+      if (use_immediate_mode_) {
+        status = wrap::miopenConvolutionBackwardDataImmediate(
+            miopen.handle(), output_nd.handle(), output_data.opaque(),
+            filter.handle(), filter_data.opaque(), conv.handle(),
+            input_nd.handle(), input_data.opaque(), scratch_memory.opaque(),
+            scratch_memory.size(),
+            static_cast<uint64_t>(algorithm_desc.algo_id()));
+      } else {
+	// PLACEHOLDER FOR FIND MODE IMPLEMENTATION
+      }
       break;
     }
     case dnn::ConvolutionKind::BACKWARD_FILTER: {
@@ -2930,11 +3024,16 @@ port::Status MIOpenSupport::DoConvolve(
           stream, miopen.handle(), ToMIOpenDataType(element_type),
           &output_back_descriptor, output_data, &transform_scratch);
 
-      status = wrap::miopenConvolutionBackwardWeightsImmediate(
-          miopen.handle(), output_nd.handle(), output_data.opaque(),
-          input_nd.handle(), input_data.opaque(), conv.handle(),
-          filter.handle(), filter_data.opaque(), scratch_memory.opaque(),
-          scratch_memory.size(), solution_id);
+      if (use_immediate_mode_) {
+        status = wrap::miopenConvolutionBackwardWeightsImmediate(
+            miopen.handle(), output_nd.handle(), output_data.opaque(),
+            input_nd.handle(), input_data.opaque(), conv.handle(),
+            filter.handle(), filter_data.opaque(), scratch_memory.opaque(),
+            scratch_memory.size(),
+            static_cast<uint64_t>(algorithm_desc.algo_id()));
+      } else {
+	// PLACEHOLDER FOR FIND MODE IMPLEMENTATION
+      }
       break;
     }
     default:
@@ -2981,11 +3080,35 @@ bool MIOpenSupport::GetConvolveAlgorithms(
 }
 
 bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
-    dnn::ConvolutionKind kind, Stream* stream, dnn::DataType element_type,
-    const dnn::BatchDescriptor& input_descriptor,
+    dnn::ConvolutionKind kind, dnn::DataType element_type, Stream* stream,
+    const dnn::BatchDescriptor& input_descriptor, DeviceMemoryBase input_data,
     const dnn::FilterDescriptor& filter_descriptor,
+    DeviceMemoryBase filter_data, const dnn::BatchDescriptor& output_descriptor,
+    DeviceMemoryBase output_data,
     const dnn::ConvolutionDescriptor& convolution_descriptor,
-    const dnn::BatchDescriptor& output_descriptor,
+    ScratchAllocator* scratch_allocator,
+    std::vector<dnn::ProfileResult>* out_algorithms) {
+  return use_immediate_mode_
+             ? GetMIOpenConvolveAlgorithmsImmediateMode(
+                   kind, element_type, stream, input_descriptor, input_data,
+                   filter_descriptor, filter_data, output_descriptor,
+                   output_data, convolution_descriptor, scratch_allocator,
+                   out_algorithms)
+             : GetMIOpenConvolveAlgorithmsFindMode(
+                   kind, element_type, stream, input_descriptor, input_data,
+                   filter_descriptor, filter_data, output_descriptor,
+                   output_data, convolution_descriptor, scratch_allocator,
+                   out_algorithms);
+}
+
+bool MIOpenSupport::GetMIOpenConvolveAlgorithmsImmediateMode(
+    dnn::ConvolutionKind kind, dnn::DataType element_type, Stream* stream,
+    const dnn::BatchDescriptor& input_descriptor, DeviceMemoryBase input_data,
+    const dnn::FilterDescriptor& filter_descriptor,
+    DeviceMemoryBase filter_data, const dnn::BatchDescriptor& output_descriptor,
+    DeviceMemoryBase output_data,
+    const dnn::ConvolutionDescriptor& convolution_descriptor,
+    ScratchAllocator* scratch_allocator,
     std::vector<dnn::ProfileResult>* out_algorithms) {
   auto miopen = miopen_->GetHandle(parent_, stream);
 
@@ -3184,6 +3307,21 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
     }
   }
 
+  return true;
+}
+
+bool MIOpenSupport::GetMIOpenConvolveAlgorithmsFindMode(
+    dnn::ConvolutionKind kind, dnn::DataType element_type, Stream* stream,
+    const dnn::BatchDescriptor& input_descriptor, DeviceMemoryBase input_data,
+    const dnn::FilterDescriptor& filter_descriptor,
+    DeviceMemoryBase filter_data, const dnn::BatchDescriptor& output_descriptor,
+    DeviceMemoryBase output_data,
+    const dnn::ConvolutionDescriptor& convolution_descriptor,
+    ScratchAllocator* scratch_allocator,
+    std::vector<dnn::ProfileResult>* out_algorithms) {
+
+  // PLACEHOLDER FOR FIND MODE IMPLEMENTATION
+  
   return true;
 }
 

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -60,6 +60,7 @@ const int kConvDebugVlogLevel = 3;
 
 namespace stream_executor {
 
+using dnn::AlgorithmDesc;
 using dnn::BatchDescriptor;
 using dnn::ConvolutionDescriptor;
 using dnn::FilterDescriptor;
@@ -108,6 +109,12 @@ string ToString(miopenConvAlgorithm_t algorithm) {
       break;
     case miopenConvolutionAlgoWinograd:
       s = "Winograd";
+      break;
+    case miopenConvolutionAlgoImplicitGEMM:
+      s = "Implicit GEMM";
+      break;
+    case miopenConvolutionAlgoStaticCompiledGEMM:
+      s = "Static Compiled GEMM";
       break;
   }
   return s;
@@ -433,64 +440,11 @@ std::set<uint64> CachedFusionPlans::unsupported_plans;
 dnn::ProfileResult GetProfileResultFromConvSolution(
     miopenConvSolution_t solution) {
   dnn::ProfileResult profile_result;
-  profile_result.set_algorithm({solution.solution_id, false});
+  profile_result.set_algorithm(
+      {static_cast<AlgorithmDesc::Index>(solution.solution_id), false});
   profile_result.set_elapsed_time_in_ms(solution.time);
   profile_result.set_scratch_size(solution.workspace_size);
   return profile_result;
-}
-
-}  // namespace
-
-namespace {
-
-miopenHandle_t ToHandle(void* opaque_handle) {
-  return static_cast<miopenHandle_t>(opaque_handle);
-}
-
-miopenConvFwdAlgorithm_t ToConvForwardAlgo(dnn::AlgorithmDesc algorithm) {
-  miopenConvFwdAlgorithm_t algo = miopenConvFwdAlgorithm_t(algorithm.algo_id());
-  switch (algo) {
-    case miopenConvolutionFwdAlgoGEMM:
-    case miopenConvolutionFwdAlgoDirect:
-    case miopenConvolutionFwdAlgoFFT:
-    case miopenConvolutionFwdAlgoWinograd:
-      return algo;
-    default:
-      LOG(FATAL) << "Unsupported MIOpen convolution forward algorithm: "
-                 << algorithm.algo_id();
-  }
-}
-
-miopenConvBwdDataAlgorithm_t ToConvBackwardDataAlgo(
-    dnn::AlgorithmDesc algorithm) {
-  miopenConvBwdDataAlgorithm_t algo =
-      miopenConvBwdDataAlgorithm_t(algorithm.algo_id());
-  switch (algo) {
-    case miopenConvolutionBwdDataAlgoGEMM:
-    case miopenConvolutionBwdDataAlgoDirect:
-    case miopenConvolutionBwdDataAlgoFFT:
-    case miopenConvolutionBwdDataAlgoWinograd:
-      return algo;
-    default:
-      LOG(FATAL)
-          << "Unsupported MIOpen convolution backward algorithm for data: "
-          << algorithm.algo_id();
-  }
-}
-
-miopenConvBwdWeightsAlgorithm_t ToConvBackwardFilterAlgo(
-    dnn::AlgorithmDesc algorithm) {
-  miopenConvBwdWeightsAlgorithm_t algo =
-      miopenConvBwdWeightsAlgorithm_t(algorithm.algo_id());
-  switch (algo) {
-    case miopenConvolutionBwdWeightsAlgoGEMM:
-    case miopenConvolutionBwdWeightsAlgoDirect:
-      return algo;
-    default:
-      LOG(FATAL)
-          << "Unsupported MIOpen convolution backward algorithm for filter: "
-          << algorithm.algo_id();
-  }
 }
 
 }  // namespace
@@ -1642,17 +1596,6 @@ miopenRNNMode_t ToMIOpenRnnMode(dnn::RnnMode rnn_mode) {
       return miopenGRU;
     default:
       LOG(FATAL) << "Invalid RNN Mode: " << static_cast<int>(rnn_mode);
-  }
-}
-
-int MIOpenDataTypeToByteSize(miopenDataType_t data_type) {
-  switch (data_type) {
-    case miopenFloat:
-      return sizeof(float);
-    case miopenHalf:
-      return sizeof(Eigen::half);
-    default:
-      LOG(FATAL) << "Invalid DNN data type: " << static_cast<int>(data_type);
   }
 }
 
@@ -3001,11 +2944,6 @@ port::Status MIOpenSupport::DoConvolve(
   ScopedConvolutionDescriptor conv{convolution_descriptor,
                                    ToMIOpenDataType(element_type)};
 
-  // Alpha is the scaling factor for input.
-  float alpha = 1.0;
-  // Beta is the scaling factor for output.
-  float beta = 0.0;
-
   const bool is_profiling = output_profile_result != nullptr;
 
   std::unique_ptr<GpuTimer> timer;
@@ -3206,7 +3144,7 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
       VLOG(kConvDebugVlogLevel)
           << "Number of conv solutions actual: " << solutionCount;
 
-      for (int i = 0; i < solutionCount; i++) {
+      for (size_t i = 0; i < solutionCount; i++) {
         miopenConvSolution_t solution = solutions[i];
 
         VLOG(kConvDebugVlogLevel)
@@ -3245,7 +3183,7 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
       VLOG(kConvDebugVlogLevel)
           << "Number of conv solutions actual: " << solutionCount;
 
-      for (int i = 0; i < solutionCount; i++) {
+      for (size_t i = 0; i < solutionCount; i++) {
         miopenConvSolution_t solution = solutions[i];
 
         VLOG(kConvDebugVlogLevel)
@@ -3283,7 +3221,7 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
       VLOG(kConvDebugVlogLevel)
           << "Number of conv solutions actual: " << solutionCount;
 
-      for (int i = 0; i < solutionCount; i++) {
+      for (size_t i = 0; i < solutionCount; i++) {
         miopenConvSolution_t solution = solutions[i];
 
         VLOG(kConvDebugVlogLevel)

--- a/tensorflow/stream_executor/rocm/rocm_dnn.h
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.h
@@ -198,11 +198,14 @@ class MIOpenSupport : public dnn::DnnSupport {
       std::vector<dnn::AlgorithmDesc>* out_algorithms) override;
 
   bool GetMIOpenConvolveAlgorithms(
-      dnn::ConvolutionKind kind, Stream* stream, dnn::DataType element_type,
-      const dnn::BatchDescriptor& input_descriptor,
+      dnn::ConvolutionKind kind, dnn::DataType element_type, Stream* stream,
+      const dnn::BatchDescriptor& input_descriptor, DeviceMemoryBase input_data,
       const dnn::FilterDescriptor& filter_descriptor,
-      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      DeviceMemoryBase filter_data,
       const dnn::BatchDescriptor& output_descriptor,
+      DeviceMemoryBase output_data,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      ScratchAllocator* scratch_allocator,
       std::vector<dnn::ProfileResult>* out_algorithms) override;
 
   bool GetRnnAlgorithms(
@@ -654,6 +657,9 @@ class MIOpenSupport : public dnn::DnnSupport {
   // the best algorithm (as opposed to a list of all applicable ones)
   bool return_best_algo_only_;
 
+  // Flag to indicate whether to use Immediate (or Find) mode for Convolutions
+  bool use_immediate_mode_;
+
   // Provide access to the MIOpen handle.
   std::unique_ptr<class MIOpenAccess> miopen_;
 
@@ -817,6 +823,28 @@ class MIOpenSupport : public dnn::DnnSupport {
       absl::Span<const int> input_lengths_data,
       ScratchAllocator* scratch_allocator,
       DeviceMemory<uint8>* scratch_memory) override;
+
+  bool GetMIOpenConvolveAlgorithmsImmediateMode(
+      dnn::ConvolutionKind kind, dnn::DataType element_type, Stream* stream,
+      const dnn::BatchDescriptor& input_descriptor, DeviceMemoryBase input_data,
+      const dnn::FilterDescriptor& filter_descriptor,
+      DeviceMemoryBase filter_data,
+      const dnn::BatchDescriptor& output_descriptor,
+      DeviceMemoryBase output_data,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      ScratchAllocator* scratch_allocator,
+      std::vector<dnn::ProfileResult>* out_algorithms);
+
+  bool GetMIOpenConvolveAlgorithmsFindMode(
+      dnn::ConvolutionKind kind, dnn::DataType element_type, Stream* stream,
+      const dnn::BatchDescriptor& input_descriptor, DeviceMemoryBase input_data,
+      const dnn::FilterDescriptor& filter_descriptor,
+      DeviceMemoryBase filter_data,
+      const dnn::BatchDescriptor& output_descriptor,
+      DeviceMemoryBase output_data,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      ScratchAllocator* scratch_allocator,
+      std::vector<dnn::ProfileResult>* out_algorithms);
 
   SE_DISALLOW_COPY_AND_ASSIGN(MIOpenSupport);
 };

--- a/tensorflow/stream_executor/rocm/rocm_dnn.h
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.h
@@ -650,6 +650,10 @@ class MIOpenSupport : public dnn::DnnSupport {
  private:
   GpuExecutor* parent_;  // Parent executor object. Not owned.
 
+  // Flag to indicate whether Get*Algorithm routines should only return
+  // the best algorithm (as opposed to a list of all applicable ones)
+  bool return_best_algo_only_;
+
   // Provide access to the MIOpen handle.
   std::unique_ptr<class MIOpenAccess> miopen_;
 

--- a/tensorflow/stream_executor/stream_executor_pimpl.cc
+++ b/tensorflow/stream_executor/stream_executor_pimpl.cc
@@ -291,19 +291,22 @@ bool StreamExecutor::GetConvolveAlgorithms(
 }
 
 bool StreamExecutor::GetMIOpenConvolveAlgorithms(
-    dnn::ConvolutionKind kind, Stream *stream, dnn::DataType element_type,
-    const dnn::BatchDescriptor &input_descriptor,
-    const dnn::FilterDescriptor &filter_descriptor,
-    const dnn::ConvolutionDescriptor &convolution_descriptor,
-    const dnn::BatchDescriptor &output_descriptor,
-    std::vector<dnn::ProfileResult> *out_algorithms) {
+    dnn::ConvolutionKind kind, dnn::DataType element_type, Stream* stream,
+    const dnn::BatchDescriptor& input_descriptor, DeviceMemoryBase input_data,
+    const dnn::FilterDescriptor& filter_descriptor,
+    DeviceMemoryBase filter_data, const dnn::BatchDescriptor& output_descriptor,
+    DeviceMemoryBase output_data,
+    const dnn::ConvolutionDescriptor& convolution_descriptor,
+    ScratchAllocator* scratch_allocator,
+    std::vector<dnn::ProfileResult>* out_algorithms) {
   dnn::DnnSupport *dnn_support = AsDnn();
   if (!dnn_support) {
     return false;
   }
   return dnn_support->GetMIOpenConvolveAlgorithms(
-      kind, stream, element_type, input_descriptor, filter_descriptor,
-      convolution_descriptor, output_descriptor, out_algorithms);
+      kind, element_type, stream, input_descriptor, input_data,
+      filter_descriptor, filter_data, output_descriptor, output_data,
+      convolution_descriptor, scratch_allocator, out_algorithms);
 }
 
 bool StreamExecutor::GetRnnAlgorithms(

--- a/tensorflow/stream_executor/stream_executor_pimpl.h
+++ b/tensorflow/stream_executor/stream_executor_pimpl.h
@@ -376,12 +376,15 @@ class StreamExecutor {
   // Returns the list of supported algorithms for the forward convolution
   // operation.
   bool GetMIOpenConvolveAlgorithms(
-      dnn::ConvolutionKind kind, Stream *stream, dnn::DataType element_type,
-      const dnn::BatchDescriptor &input_descriptor,
-      const dnn::FilterDescriptor &filter_descriptor,
-      const dnn::ConvolutionDescriptor &convolution_descriptor,
-      const dnn::BatchDescriptor &output_descriptor,
-      std::vector<dnn::ProfileResult> *out_algorithms);
+      dnn::ConvolutionKind kind, dnn::DataType element_type, Stream* stream,
+      const dnn::BatchDescriptor& input_descriptor, DeviceMemoryBase input_data,
+      const dnn::FilterDescriptor& filter_descriptor,
+      DeviceMemoryBase filter_data,
+      const dnn::BatchDescriptor& output_descriptor,
+      DeviceMemoryBase output_data,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      ScratchAllocator* scratch_allocator,
+      std::vector<dnn::ProfileResult>* out_algorithms);
 
   // Returns the list of supported algorithms for rnn operation.
   bool GetRnnAlgorithms(std::vector<dnn::AlgorithmDesc> *out_algorithms);


### PR DESCRIPTION
This PR reverts ROCm to use MIOpen Find Mode APIs (be default) for convolution.  The use of MIOpen Immediate Mode API (instead of the Find Mode APIs) can be specified by the setting the env var `TF_ROCM_USE_IMMEDIATE_MODE=1`.

Almost all of the changes in this PR are within code that is specific to the ROCm platform, so this PR should not have any impact on non ROCm builds.

----------------


/cc @chsigg @whchung 