### PR TITLE
[XLA][ROCm] Disable test that invokes rocBlas TRSM

### DIFF
--- a/tensorflow/compiler/xla/tests/triangular_solve_test.cc
+++ b/tensorflow/compiler/xla/tests/triangular_solve_test.cc
@@ -349,7 +349,11 @@ XLA_TEST_F(TriangularSolveTest, SimpleLeftUpperNotransposeUnitDiagonal) {
                              ErrorSpec(1e-2, 1e-2));
 }
 
-XLA_TEST_F(TriangularSolveTest, SimpleRightLowerTransposeConjugate) {
+// The following test will results in a call to "BlasTrsm".
+// That operation is currently not supported for the complex type on the ROCm
+// platform.
+XLA_TEST_F(TriangularSolveTest,
+           DISABLED_ON_GPU_ROCM(SimpleRightLowerTransposeConjugate)) {
   XlaBuilder builder(TestName());
 
   XlaOp a, b;
@@ -375,7 +379,11 @@ XLA_TEST_F(TriangularSolveTest, SimpleRightLowerTransposeConjugate) {
       &builder, expected, {a_data.get(), b_data.get()}, ErrorSpec(1e-2, 1e-2));
 }
 
-XLA_TEST_F(TriangularSolveTest, SimpleLeftUpperTransposeNoconjugate) {
+// The following test will results in a call to "BlasTrsm".
+// That operation is currently not supported for the complex type on the ROCm
+// platform.
+XLA_TEST_F(TriangularSolveTest,
+           DISABLED_ON_GPU_ROCM(SimpleLeftUpperTransposeNoconjugate)) {
   XlaBuilder builder(TestName());
 
   XlaOp a, b;


### PR DESCRIPTION
Fixing `Triangular_solve_test` by disable unit test, since `BlasTrsm` for complext type is unsupported in `rocBlas`.