### PR TITLE
[MLIR] Swap target names MlirOptLib and MlirOptMain

### DIFF
--- a/tensorflow/compiler/mlir/BUILD
+++ b/tensorflow/compiler/mlir/BUILD
@@ -46,7 +46,7 @@ cc_library(
         "@llvm-project//llvm:support",
         "@llvm-project//mlir:AffineDialectRegistration",
         "@llvm-project//mlir:LoopDialectRegistration",
-        "@llvm-project//mlir:MlirOptLib",
+        "@llvm-project//mlir:MlirOptMain",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:QuantOpsDialectRegistration",
         "@llvm-project//mlir:Support",

--- a/third_party/mlir/BUILD
+++ b/third_party/mlir/BUILD
@@ -1707,7 +1707,7 @@ cc_library(
 
 # TODO(jpienaar): Update this.
 cc_library(
-    name = "MlirOptLib",
+    name = "MlirOptMain",
     srcs = [
         "lib/Support/MlirOptMain.cpp",
     ],
@@ -1784,13 +1784,13 @@ cc_binary(
 
 # TODO(jpienaar): This library should be removed.
 cc_library(
-    name = "MlirOptMain",
+    name = "MlirOptLib",
     srcs = [
         "tools/mlir-opt/mlir-opt.cpp",
     ],
     deps = [
         ":Analysis",
-        ":MlirOptLib",
+        ":MlirOptMain",
         ":Pass",
         ":Support",
         "@llvm-project//llvm:support",


### PR DESCRIPTION
This commit swaps the targets name in the Bazel configuration to match with CMake. In MLIR's CMake configuration the targets `MLIRMlirOptLib` and `MLIROptMain` map to source files as follows:
* `MLIRMlirOptLib`	-> `mlir-opt.cpp`
https://github.com/llvm/llvm-project/blob/e06444d982f031ed2de20b8d5d3de2dfadb09e96/mlir/tools/mlir-opt/CMakeLists.txt#L13-L14

* `MLIROptMain` -> `MlirOptMain.cpp`
https://github.com/llvm/llvm-project/blob/e06444d982f031ed2de20b8d5d3de2dfadb09e96/mlir/lib/Support/CMakeLists.txt#L20-L21

In the current Bazel configuration it is the other way around:
https://github.com/tensorflow/tensorflow/blob/6e4972c241791067c3094bde9d40604b29da872b/third_party/mlir/BUILD#L1710-L1713

https://github.com/tensorflow/tensorflow/blob/6e4972c241791067c3094bde9d40604b29da872b/third_party/mlir/BUILD#L1786-L1790