### PR TITLE
Clear caches on eager context reset.

### DIFF
--- a/tensorflow/python/eager/context.py
+++ b/tensorflow/python/eager/context.py
@@ -1637,6 +1637,7 @@ def _reset_context():
   global _context
   with _context_lock:
     if _context is not None:
+      _context._clear_caches()
       _context = None
   _create_context()
   pywrap_tfe.TFE_ClearScalarCache()


### PR DESCRIPTION
Clear the caches of the existing eager context before deleting it as some of these caches are cpp static (TFE_TensorHandleCache) and will therefore be inherited by future contexts with some out of date content which might lead to some segfaults.

For example in these Keras tests some constant tensors generated by the `add_weights` function inside the convolutions are re-used across tests leading to some segfault because the eager context has been reset between tests and the device they point to no longer exist.

[sequential_test.py.txt](https://github.com/tensorflow/tensorflow/files/4127467/sequential_test.py.txt)

PS: The eager context reset for these tests is needed in order to clear the XLA executable cache between tests.