### PR TITLE
[XLA] Change the default SM in XLA.

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
+++ b/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
@@ -96,13 +96,13 @@ static string GetSmName(std::pair<int, int> compute_capability) {
   // most recent version before the unknown version.
   for (auto iter = m->begin(); iter != m->end(); ++iter) {
     auto k = iter->first;
-    if ((k.first < compute_capability.first) ||
+    if (k.first < compute_capability.first ||
 	(k.first == compute_capability.first &&
 	 k.second <= compute_capability.second)) {
       sm_version = iter->second;
     }
   }
-  std::cout << "SM " << sm_version;
+
   if (sm_version != compute_capability.first*10 + compute_capability.second) {
     LOG(WARNING) << "Unknown compute capability (" << compute_capability.first
                  << ", " << compute_capability.second << ") ."

--- a/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
+++ b/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
@@ -92,20 +92,18 @@ static string GetSmName(std::pair<int, int> compute_capability) {
       {{7, 5}, 75},
   });
   int sm_version = 35;
-  auto it = m->find(compute_capability);
-  if (it != m->end()) {
-    sm_version = it->second;
-  } else {
-    // Fallback to the most recent version before the unknown version.
-    for (auto iter = m->begin(); iter != m->end(); ++iter) {
-      auto k = iter->first;
-      if (iter->second > sm_version &&
-          ((k.first < compute_capability.first) ||
-           (k.first == compute_capability.first &&
-            k.second <= compute_capability.second))) {
-        sm_version = iter->second;
-      }
+  // If the current compute capability isn't known, fallback to the
+  // most recent version before the unknown version.
+  for (auto iter = m->begin(); iter != m->end(); ++iter) {
+    auto k = iter->first;
+    if ((k.first < compute_capability.first) ||
+	(k.first == compute_capability.first &&
+	 k.second <= compute_capability.second)) {
+      sm_version = iter->second;
     }
+  }
+  std::cout << "SM " << sm_version;
+  if (sm_version != compute_capability.first*10 + compute_capability.second) {
     LOG(WARNING) << "Unknown compute capability (" << compute_capability.first
                  << ", " << compute_capability.second << ") ."
                  << "Defaulting to telling LLVM that we're compiling for sm_"

--- a/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
+++ b/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
@@ -78,18 +78,19 @@ const int kDefaultInlineThreshold = 1100;
 // capability.  If we see an unrecognized compute capability, we
 // return the highest one that is known and below the selected device.
 static string GetSmName(std::pair<int, int> compute_capability) {
-  int ccv = compute_capability.first * 10 + compute_capability.second;
+  int compute_capability_version =
+      compute_capability.first * 10 + compute_capability.second;
   int sm_version = 35;
   // If the current compute capability isn't known, fallback to the
   // most recent version before it.
   for (int v : {75, 72, 70, 62, 61, 60, 53, 52, 50, 37, 35}) {
-    if (v <= ccv) {
+    if (v <= compute_capability_version) {
       sm_version = v;
       break;
     }
   }
 
-  if (sm_version != ccv) {
+  if (sm_version != compute_capability_version) {
     LOG(WARNING) << "Unknown compute capability (" << compute_capability.first
                  << ", " << compute_capability.second << ") ."
                  << "Defaulting to telling LLVM that we're compiling for sm_"

--- a/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
+++ b/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
@@ -78,32 +78,18 @@ const int kDefaultInlineThreshold = 1100;
 // capability.  If we see an unrecognized compute capability, we
 // return the highest one that is known and below the selected device.
 static string GetSmName(std::pair<int, int> compute_capability) {
-  static auto* m = new std::map<std::pair<int, int>, int>({
-      {{3, 5}, 35},
-      {{3, 7}, 37},
-      {{5, 0}, 50},
-      {{5, 2}, 52},
-      {{5, 3}, 53},
-      {{6, 0}, 60},
-      {{6, 1}, 61},
-      {{6, 2}, 62},
-      {{7, 0}, 70},
-      {{7, 2}, 72},
-      {{7, 5}, 75},
-  });
+  int ccv = compute_capability.first * 10 + compute_capability.second;
   int sm_version = 35;
   // If the current compute capability isn't known, fallback to the
-  // most recent version before the unknown version.
-  for (auto iter = m->begin(); iter != m->end(); ++iter) {
-    auto k = iter->first;
-    if (k.first < compute_capability.first ||
-	(k.first == compute_capability.first &&
-	 k.second <= compute_capability.second)) {
-      sm_version = iter->second;
+  // most recent version before it.
+  for (int v : {75, 72, 70, 62, 61, 60, 53, 52, 50, 37, 35}) {
+    if (v <= ccv) {
+      sm_version = v;
+      break;
     }
   }
 
-  if (sm_version != compute_capability.first*10 + compute_capability.second) {
+  if (sm_version != ccv) {
     LOG(WARNING) << "Unknown compute capability (" << compute_capability.first
                  << ", " << compute_capability.second << ") ."
                  << "Defaulting to telling LLVM that we're compiling for sm_"


### PR DESCRIPTION
It is better to use the most recent SM then an old one. The SM have always been backward compatible.