### PR TITLE
Fixed inconsistencies between int and int32_t type uses

### DIFF
--- a/tensorflow/lite/c/c_api.cc
+++ b/tensorflow/lite/c/c_api.cc
@@ -145,7 +145,7 @@ void TfLiteInterpreterDelete(TfLiteInterpreter* interpreter) {
 
 int32_t TfLiteInterpreterGetInputTensorCount(
     const TfLiteInterpreter* interpreter) {
-  return static_cast<int>(interpreter->impl->inputs().size());
+  return static_cast<int32_t>(interpreter->impl->inputs().size());
 }
 
 TfLiteTensor* TfLiteInterpreterGetInputTensor(
@@ -172,7 +172,7 @@ TfLiteStatus TfLiteInterpreterInvoke(TfLiteInterpreter* interpreter) {
 
 int32_t TfLiteInterpreterGetOutputTensorCount(
     const TfLiteInterpreter* interpreter) {
-  return static_cast<int>(interpreter->impl->outputs().size());
+  return static_cast<int32_t>(interpreter->impl->outputs().size());
 }
 
 const TfLiteTensor* TfLiteInterpreterGetOutputTensor(

--- a/tensorflow/lite/c/c_api.h
+++ b/tensorflow/lite/c/c_api.h
@@ -164,7 +164,7 @@ TFL_CAPI_EXPORT extern void TfLiteInterpreterDelete(
     TfLiteInterpreter* interpreter);
 
 // Returns the number of input tensors associated with the model.
-TFL_CAPI_EXPORT extern int TfLiteInterpreterGetInputTensorCount(
+TFL_CAPI_EXPORT extern int32_t TfLiteInterpreterGetInputTensorCount(
     const TfLiteInterpreter* interpreter);
 
 // Returns the tensor associated with the input index.

--- a/tensorflow/lite/c/c_api_experimental.cc
+++ b/tensorflow/lite/c/c_api_experimental.cc
@@ -45,7 +45,7 @@ void TfLiteInterpreterOptionsAddBuiltinOp(
 void TfLiteInterpreterOptionsAddCustomOp(TfLiteInterpreterOptions* options,
                                          const char* name,
                                          const TfLiteRegistration* registration,
-                                         int min_version, int max_version) {
+                                         int32_t min_version, int32_t max_version) {
   options->op_resolver.AddCustom(name, registration, min_version, max_version);
 }
 

--- a/tensorflow/lite/c/c_api_experimental.h
+++ b/tensorflow/lite/c/c_api_experimental.h
@@ -35,7 +35,7 @@ TFL_CAPI_EXPORT extern TfLiteStatus TfLiteInterpreterResetVariableTensors(
 // making the provided TfLiteRegistration instance static.
 TFL_CAPI_EXPORT void TfLiteInterpreterOptionsAddBuiltinOp(
     TfLiteInterpreterOptions* options, TfLiteBuiltinOperator op,
-    const TfLiteRegistration* registration, int min_version, int max_version);
+    const TfLiteRegistration* registration, int32_t min_version, int32_t max_version);
 
 // Adds an op registration for a custom operator.
 //
@@ -45,7 +45,7 @@ TFL_CAPI_EXPORT void TfLiteInterpreterOptionsAddBuiltinOp(
 // practice is making the provided TfLiteRegistration instance static.
 TFL_CAPI_EXPORT void TfLiteInterpreterOptionsAddCustomOp(
     TfLiteInterpreterOptions* options, const char* name,
-    const TfLiteRegistration* registration, int min_version, int max_version);
+    const TfLiteRegistration* registration, int32_t min_version, int32_t max_version);
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
Inconsistencies threw errors when building TFlite micro for STM32 project.