### PR TITLE
[ROCm][XLA] Fixing binary_ops_test

### DIFF
--- a/tensorflow/compiler/tests/binary_ops_test.py
+++ b/tensorflow/compiler/tests/binary_ops_test.py
@@ -32,6 +32,7 @@ from tensorflow.python.ops import gen_nn_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import nn_ops
 from tensorflow.python.platform import googletest
+from tensorflow.python.platform import test as test_lib
 
 
 class BinaryOpsTest(xla_test.XLATestCase):
@@ -1069,6 +1070,10 @@ class BinaryOpsTest(xla_test.XLATestCase):
 
       # Regression test for b/31472796.
       if dtype != np.float16 and hasattr(np, "matmul"):
+        # Skipping bfloat16 as ROCM doesn't support bfloat16 GEMM yet.
+        if (test_lib.is_built_with_rocm() and
+            dtype == dtypes.bfloat16.as_numpy_dtype):
+          return
         x = np.arange(0, 3 * 5 * 2 * 7, dtype=dtype).reshape((3, 5, 2, 7))
         self._testBinary(
             lambda x, y: math_ops.matmul(x, y, adjoint_b=True),


### PR DESCRIPTION
This CL disabled bfloat16 GEMM to fix the `binary_ops_test`