### PR TITLE
[ROCm][XLA] Disable ResizeBilinearTest in image_ops_test

### DIFF
--- a/tensorflow/compiler/tests/image_ops_test.py
+++ b/tensorflow/compiler/tests/image_ops_test.py
@@ -596,6 +596,9 @@ class ResizeBilinearTest(parameterized.TestCase, xla_test.XLATestCase):
   )
 
   def test(self, src_y, src_x, dst_y, dst_x):
+    if test.is_built_with_rocm():
+      self.skipTest('Disabled on ROCm, because it runs out of memory')
+
     max_y = max(src_y - 1, 1) * (dst_y - 1) + 1
     max_x = max(src_x - 1, 1) * (dst_x - 1) + 1
 


### PR DESCRIPTION
This CL disables `ResizeBilinearTest` as it runs out of memory in ROCm CI. I regressed locally and confirmed that it causes the whole test to fail, but can pass if running the single test case by itself.