### PR TITLE
[S3] Allow configuration of certificate files when accessing S3

### DIFF
--- a/tensorflow/core/platform/s3/s3_file_system.cc
+++ b/tensorflow/core/platform/s3/s3_file_system.cc
@@ -124,6 +124,14 @@ Aws::Client::ClientConfiguration& GetDefaultClientConfig() {
         cfg.requestTimeoutMs = timeout;
       }
     }
+    const char* ca_file = getenv("S3_CA_FILE");
+    if (ca_file) {
+      cfg.caFile = Aws::String(ca_file);
+    }
+    const char* ca_path = getenv("S3_CA_PATH");
+    if (ca_path) {
+      cfg.caPath = Aws::String(ca_path);
+    }
 
     init = true;
   }


### PR DESCRIPTION
Description of these from the [AWS CPP SDK's page](https://sdk.amazonaws.com/cpp/api/LATEST/struct_aws_1_1_client_1_1_client_configuration.html#a246583f705480c7e708393d6ebf76426): 

- caFile: If you certificate file is different from the default, you can tell clients that aren't using the default trust store where to find your ca file. 
- caPath: If your Certificate Authority path is different from the default, you can tell clients that aren't using the default trust store where to find your CA trust store. 