### PR TITLE
[XLA] clean up generated LLVM reduction code.

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -1956,12 +1956,10 @@ static void EmitTile(
   IrArray::Index source_idx = tile_origin_index.AddOffsetToDim(
       start_offset_x, KernelMappingScheme::DimX, b);
 
-  // True when we all threads will always completly unroll.
+  // True when all threads will always execute all instructions.
   // So we do not need to emit condition.
-  bool always_full_unroll = false;
-  if (mapping_scheme.GetDimsInElems()[2] % tile_size_x == 0){
-    always_full_unroll = true;
-  }
+  bool always_full_tile =
+      mapping_scheme.GetDimsInElems()[2] % tile_size_x == 0;
 
   ksl->For(
       loop_name + "_y_in_tile",
@@ -1977,7 +1975,7 @@ static void EmitTile(
               constant(j * step_x), KernelMappingScheme::DimX, b);
           // The if-statement below always evaluates to true for the blocks
           // where the entire processed tile fits within the input buffer.
-          if (!always_full_unroll) {
+          if (!always_full_tile) {
             ksl->If(loop_name + "_x_in_tile", b->CreateICmpULT(x_loc, tile_width),
                     [&] { emit_elem_function(source_idx_x, y_loc, x_loc, j); });
           } else {

--- a/tensorflow/compiler/xla/service/llvm_ir/kernel_support_library.cc
+++ b/tensorflow/compiler/xla/service/llvm_ir/kernel_support_library.cc
@@ -60,11 +60,14 @@ Status KernelSupportLibrary::IfWithStatus(
     absl::string_view name, llvm::Value* condition,
     const std::function<Status()>& true_block_generator,
     const std::function<Status()>& false_block_generator) {
-  llvm_ir::LlvmIfData if_data = llvm_ir::EmitIfThenElse(condition, name, b_);
+  llvm_ir::LlvmIfData if_data = llvm_ir::EmitIfThenElse(
+      condition, name, b_, false_block_generator != nullptr);
   b_->SetInsertPoint(&if_data.true_block->back());
   TF_RETURN_IF_ERROR(true_block_generator());
-  b_->SetInsertPoint(&if_data.false_block->back());
-  TF_RETURN_IF_ERROR(false_block_generator());
+  if (false_block_generator != nullptr) {
+    b_->SetInsertPoint(&if_data.false_block->back());
+    TF_RETURN_IF_ERROR(false_block_generator());
+  }
   llvm_ir::SetToLastInsertPoint(if_data.after_block, b_);
   return Status::OK();
 }

--- a/tensorflow/compiler/xla/service/llvm_ir/kernel_support_library.cc
+++ b/tensorflow/compiler/xla/service/llvm_ir/kernel_support_library.cc
@@ -60,8 +60,9 @@ Status KernelSupportLibrary::IfWithStatus(
     absl::string_view name, llvm::Value* condition,
     const std::function<Status()>& true_block_generator,
     const std::function<Status()>& false_block_generator) {
-  llvm_ir::LlvmIfData if_data = llvm_ir::EmitIfThenElse(
-      condition, name, b_, false_block_generator != nullptr);
+  llvm_ir::LlvmIfData if_data =
+      llvm_ir::EmitIfThenElse(condition, name, b_,
+                              /*emit_else=*/false_block_generator != nullptr);
   b_->SetInsertPoint(&if_data.true_block->back());
   TF_RETURN_IF_ERROR(true_block_generator());
   if (false_block_generator != nullptr) {


### PR DESCRIPTION
This ease reading the non-optimized LLVM code.

@cheshire 