### PR TITLE
[tflite] enable INT8 for Java binding

### DIFF
--- a/tensorflow/lite/java/src/main/java/org/tensorflow/lite/DataType.java
+++ b/tensorflow/lite/java/src/main/java/org/tensorflow/lite/DataType.java
@@ -30,7 +30,10 @@ public enum DataType {
   INT64(4),
 
   /** Strings. */
-  STRING(5);
+  STRING(5),
+
+  /** 8-bit signed integer. */
+  INT8(9);
 
   private final int value;
 
@@ -45,6 +48,7 @@ public enum DataType {
         return 4;
       case INT32:
         return 4;
+      case INT8:
       case UINT8:
         return 1;
       case INT64:
@@ -83,6 +87,7 @@ public enum DataType {
         return "float";
       case INT32:
         return "int";
+      case INT8:
       case UINT8:
         return "byte";
       case INT64:

--- a/tensorflow/lite/java/src/main/java/org/tensorflow/lite/Tensor.java
+++ b/tensorflow/lite/java/src/main/java/org/tensorflow/lite/Tensor.java
@@ -311,6 +311,11 @@ public final class Tensor {
       return;
     }
     DataType oType = dataTypeOf(o);
+
+    // INT8 and UINT8 have the same string name, "byte"
+    if (oType.toStringName() == dtype.toStringName()) {
+      return;
+    }
     if (oType != dtype) {
       throw new IllegalArgumentException(
           String.format(

--- a/tensorflow/lite/java/src/main/java/org/tensorflow/lite/Tensor.java
+++ b/tensorflow/lite/java/src/main/java/org/tensorflow/lite/Tensor.java
@@ -312,11 +312,12 @@ public final class Tensor {
     }
     DataType oType = dataTypeOf(o);
 
-    // INT8 and UINT8 have the same string name, "byte"
-    if (oType.toStringName().equals(dtype.toStringName())) {
-      return;
-    }
     if (oType != dtype) {
+      // INT8 and UINT8 have the same string name, "byte"
+      if (oType.toStringName().equals(dtype.toStringName())) {
+        return;
+      }
+
       throw new IllegalArgumentException(
           String.format(
               "Cannot convert between a TensorFlowLite tensor with type %s and a Java "

--- a/tensorflow/lite/java/src/main/java/org/tensorflow/lite/Tensor.java
+++ b/tensorflow/lite/java/src/main/java/org/tensorflow/lite/Tensor.java
@@ -313,7 +313,7 @@ public final class Tensor {
     DataType oType = dataTypeOf(o);
 
     // INT8 and UINT8 have the same string name, "byte"
-    if (oType.toStringName() == dtype.toStringName()) {
+    if (oType.toStringName().equals(dtype.toStringName())) {
       return;
     }
     if (oType != dtype) {

--- a/tensorflow/lite/java/src/main/native/tensor_jni.cc
+++ b/tensorflow/lite/java/src/main/native/tensor_jni.cc
@@ -126,6 +126,7 @@ size_t WriteOneDimensionalArray(JNIEnv* env, jobject object, TfLiteType type,
       env->GetLongArrayRegion(long_array, 0, num_elements, long_dst);
       return to_copy;
     }
+    case kTfLiteInt8:
     case kTfLiteUInt8: {
       jbyteArray byte_array = static_cast<jbyteArray>(array);
       jbyte* byte_dst = static_cast<jbyte*>(dst);
@@ -174,6 +175,7 @@ size_t ReadOneDimensionalArray(JNIEnv* env, TfLiteType data_type,
                               static_cast<const jlong*>(src));
       return size;
     }
+    case kTfLiteInt8:
     case kTfLiteUInt8: {
       jbyteArray byte_array = static_cast<jbyteArray>(dst);
       env->SetByteArrayRegion(byte_array, 0, len,

--- a/tensorflow/lite/java/src/test/java/org/tensorflow/lite/DataTypeTest.java
+++ b/tensorflow/lite/java/src/test/java/org/tensorflow/lite/DataTypeTest.java
@@ -39,4 +39,11 @@ public final class DataTypeTest {
       assertThat(DataType.fromC(dataType.c())).isEqualTo(dataType);
     }
   }
+
+  @Test
+  public void testINT8AndUINT8() {
+    assertThat(DataType.INT8.toStringName()).isEqualTo("byte");
+    assertThat(DataType.UINT8.toStringName()).isEqualTo("byte");
+    assertThat(DataType.INT8.toStringName()).isEqualTo(DataType.UINT8.toStringName());
+  }
 }


### PR DESCRIPTION
some models created by full-integer post training quantization,
e.g., the mobilenet v3 edgetpu one [1], have INT8 input and
output tensors.

See also https://github.com/tensorflow/models/issues/7887

[1] https://storage.cloud.google.com/mobilenet_edgetpu/checkpoints/mobilenet_edgetpu_224_1.0.tgz