### PR TITLE
[lite] check index channel before accessing center_frequencies_

### DIFF
--- a/tensorflow/lite/kernels/internal/mfcc_mel_filterbank.cc
+++ b/tensorflow/lite/kernels/internal/mfcc_mel_filterbank.cc
@@ -99,8 +99,8 @@ bool MfccMelFilterbank::Initialize(int input_length, double input_sample_rate,
     if ((i < start_index_) || (i > end_index_)) {
       band_mapper_[i] = -2;  // Indicate an unused Fourier coefficient.
     } else {
-      while ((center_frequencies_[channel] < melf) &&
-             (channel < num_channels_)) {
+      while ((channel < num_channels_) &&
+             (center_frequencies_[channel] < melf)) {
         ++channel;
       }
       band_mapper_[i] = channel - 1;  // Can be == -1


### PR DESCRIPTION
Check index channel before accessing center_frequencies_ since the order of execution for the expression is always left to right.