### PR TITLE
[lite] Remove possible nullptr sum_op

### DIFF
--- a/tensorflow/lite/toco/graph_transformations/hardcode_min_max.cc
+++ b/tensorflow/lite/toco/graph_transformations/hardcode_min_max.cc
@@ -279,7 +279,7 @@ bool MinMaxApproximatelyEqual(const MinMax& minmax1, const MinMax& minmax2) {
 // If multiple of these arrays have MinMax, then these are required
 // to agree with each other.
 bool PropagateMinMaxAmongArrays(Model* model,
-                                const std::vector<string> array_names) {
+                                const std::vector<string> &array_names) {
   string reference_array_name;
   MinMax* reference_minmax = nullptr;
   for (const string& array_name : array_names) {

--- a/tensorflow/lite/toco/graph_transformations/hardcode_min_max.cc
+++ b/tensorflow/lite/toco/graph_transformations/hardcode_min_max.cc
@@ -279,7 +279,7 @@ bool MinMaxApproximatelyEqual(const MinMax& minmax1, const MinMax& minmax2) {
 // If multiple of these arrays have MinMax, then these are required
 // to agree with each other.
 bool PropagateMinMaxAmongArrays(Model* model,
-                                const std::vector<string> &array_names) {
+                                const std::vector<string> array_names) {
   string reference_array_name;
   MinMax* reference_minmax = nullptr;
   for (const string& array_name : array_names) {

--- a/tensorflow/lite/toco/graph_transformations/identify_l2_normalization.cc
+++ b/tensorflow/lite/toco/graph_transformations/identify_l2_normalization.cc
@@ -60,11 +60,9 @@ namespace toco {
   // There may be an Add or a Maximum here, adding or clamping to a "small"
   // constant scalar.
   // Reported bug: b/29395854
-  Operator* add_op = nullptr;
   Operator* op_producing_add_input = nullptr;
   if (op_producing_sqrt_or_rsqrt_input->type == OperatorType::kAdd ||
       op_producing_sqrt_or_rsqrt_input->type == OperatorType::kMaximum) {
-    add_op = op_producing_sqrt_or_rsqrt_input;
     bool add_can_be_removed = false;
     CHECK_EQ(op_producing_sqrt_or_rsqrt_input->inputs.size(), 2);
     for (int i = 0; i < 2; i++) {
@@ -85,7 +83,7 @@ namespace toco {
         continue;
       }
       add_can_be_removed = true;
-      op_producing_add_input = GetOpWithOutput(*model, add_op->inputs[1 - i]);
+      op_producing_add_input = GetOpWithOutput(*model, op_producing_sqrt_or_rsqrt_input->inputs[1 - i]);
       break;
     }
     if (!add_can_be_removed) {
@@ -99,7 +97,7 @@ namespace toco {
   }
 
   Operator* sum_op =
-      add_op ? op_producing_add_input : op_producing_sqrt_or_rsqrt_input;
+      op_producing_add_input ? op_producing_add_input : op_producing_sqrt_or_rsqrt_input;
   if (sum_op->type != OperatorType::kSum) {
     AddMessageF(
         "Giving up trying to identify L2Normalization subgraph: "


### PR DESCRIPTION
op_producing_add_input can still be null  while sum_op is not null - due to multiple 'continue' statements within the for loop.