### PR TITLE
[TFLite int16] Requantize node for the case: 16-bit activations and 8-bit weights

### DIFF
--- a/tensorflow/lite/kernels/quantize.cc
+++ b/tensorflow/lite/kernels/quantize.cc
@@ -117,7 +117,8 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   } else {
     // Requantize use case.
     if (input->type == kTfLiteInt16) {
-      TF_LITE_ENSURE(context, output->type == kTfLiteInt8);
+      TF_LITE_ENSURE(
+          context, output->type == kTfLiteInt8 || output->type == kTfLiteInt16);
     } else {
       TF_LITE_ENSURE(context,
                      input->type == kTfLiteInt8 || input->type == kTfLiteUInt8);
@@ -174,7 +175,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       }
     }
     case kTfLiteInt16: {
-      // int16 to int8.
+      // int16 to int8 or int16.
       switch (output->type) {
         case kTfLiteInt8:
           Requantize<kernel_type>(GetTensorData<int16_t>(input),
@@ -183,6 +184,14 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
                                   input->params.zero_point,
                                   output->params.zero_point,
                                   GetTensorData<int8_t>(output));
+          return kTfLiteOk;
+        case kTfLiteInt16:
+          Requantize<kernel_type>(GetTensorData<int16_t>(input),
+                                  MatchingFlatSize(input_shape, output_shape),
+                                  data->output_multiplier, data->output_shift,
+                                  input->params.zero_point,
+                                  output->params.zero_point,
+                                  GetTensorData<int16_t>(output));
           return kTfLiteOk;
         default:
           ReportError(context, input->type, output->type);

--- a/tensorflow/lite/kernels/quantize_test.cc
+++ b/tensorflow/lite/kernels/quantize_test.cc
@@ -90,6 +90,28 @@ TEST(QuantizeOpTest, INT16) {
                                 12700, 12800}));
 }
 
+// rescale factor is around 2
+TEST(QuantizeOpTest, Int16Int16) {
+  QuantizeOpModel m({TensorType_INT16, {1, 1, 2, 5}, -16383, 16384},
+                    {TensorType_INT16, {1, 1, 2, 5}, 0, 16384});
+
+  m.SetInputAndQuantize<int16_t>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+  m.Invoke();
+  EXPECT_THAT(m.GetOutput<int16_t>(),
+              ElementsAreArray({-32764, -32760, -32756, -32752, -32748, -32744,
+                                -32740, -32736, -32732, -32728}));
+}
+
+// zero point is -1, scale is 0.5
+TEST(QuantizeOpTest, Int16Int16SameScale) {
+  QuantizeOpModel m({TensorType_INT16, {1, 1, 2, 5}, -16384, 16384},
+                    {TensorType_INT16, {1, 1, 2, 5}, -16384, 16384});
+  m.SetInputAndQuantize<int16_t>({0, 1, 2, 3, 4, 5, 6, 7, 8, 37767});
+  m.Invoke();
+  EXPECT_THAT(m.GetOutput<int16_t>(),
+              ElementsAreArray({-1, 1, 3, 5, 7, 9, 11, 13, 15, 32767}));
+}
+
 // Input scale 0.500000, output scale 0.500000, input zeropoint -1, output
 // zeropoint -1
 TEST(QuantizeOpTest, Int8Int8SameScale) {


### PR DESCRIPTION
This PR is one of steps to extend 8-bit quantization to support symmetric 16-bit activations.

Each activation is of type int16 and symmetric around zero. The weight tensor precision remains at 8-bit signed values. The bias is set to int64 precision.

In this PR we enable 16-bit version of Requantize Operator.