### PR TITLE
Update cohen's Kappa to allow for batch dimension

### DIFF
--- a/tensorflow/contrib/metrics/python/ops/metric_ops.py
+++ b/tensorflow/contrib/metrics/python/ops/metric_ops.py
@@ -3855,7 +3855,7 @@ def cohen_kappa(labels,
                                      (labels, predictions_idx, weights)):
     # Convert 2-dim (num, 1) to 1-dim (num,)
     labels.get_shape().with_rank_at_most(2)
-    if labels.get_shape().ndims == 2:
+    if labels.get_shape().ndims == 2 and labels.get_shape()[1] == 1:
       labels = array_ops.squeeze(labels, axis=[-1])
     predictions_idx, labels, weights = (
         metrics_impl._remove_squeezable_dimensions(  # pylint: disable=protected-access


### PR DESCRIPTION
Not sure if we're still able to make changes to TF1, but I have to use it for AWS Sagemaker unfortunately.

I see in the Cohen's Kappa function, line 3857, we squeeze 2-dimensional label tensors (num, 1) down to 1-dim (num,). Unfortunately, in my case my label tensor is (batch_size, num), and then this function squeezes that down unnecessarily.

My current workaround is to call the function as follows:

```
kappa = tf.contrib.metrics.cohen_kappa(labels=tf.reshape(labels, [-1]),
                                           predictions_idx=tf.reshape(predictions, [-1]),
                                           num_classes=N_CLASSES,
                                           name='kappa_op')
```

Which seems to work fine.