### PR TITLE
Allow listing an bucket for S3 Filesystem backend.

### DIFF
--- a/tensorflow/core/platform/s3/s3_file_system.cc
+++ b/tensorflow/core/platform/s3/s3_file_system.cc
@@ -400,7 +400,7 @@ Status S3FileSystem::GetChildren(const string& dir,
   string bucket, prefix;
   TF_RETURN_IF_ERROR(ParseS3Path(dir, true, &bucket, &prefix));
 
-  if (prefix.back() != '/') {
+  if (prefix.empty() || prefix.back() != '/') {
     prefix.push_back('/');
   }
 

--- a/tensorflow/core/platform/s3/s3_file_system.cc
+++ b/tensorflow/core/platform/s3/s3_file_system.cc
@@ -398,7 +398,7 @@ Status S3FileSystem::FileExists(const string& fname) {
 Status S3FileSystem::GetChildren(const string& dir,
                                  std::vector<string>* result) {
   string bucket, prefix;
-  TF_RETURN_IF_ERROR(ParseS3Path(dir, false, &bucket, &prefix));
+  TF_RETURN_IF_ERROR(ParseS3Path(dir, true, &bucket, &prefix));
 
   if (prefix.back() != '/') {
     prefix.push_back('/');

--- a/tensorflow/core/platform/s3/s3_file_system.cc
+++ b/tensorflow/core/platform/s3/s3_file_system.cc
@@ -400,7 +400,7 @@ Status S3FileSystem::GetChildren(const string& dir,
   string bucket, prefix;
   TF_RETURN_IF_ERROR(ParseS3Path(dir, true, &bucket, &prefix));
 
-  if (prefix.empty() || prefix.back() != '/') {
+  if (!prefix.empty() && prefix.back() != '/') {
     prefix.push_back('/');
   }
 


### PR DESCRIPTION
Currently, when mounting S3 with an custom backend (e.g minio), tf.io.gfile.listdir("s3://my_bucket") won't work as it will throw an error on empty object name.