### PR TITLE
[ROCm] Fix for a test regression on the ROCm platform - 200207 - 1

### DIFF
--- a/tensorflow/lite/kernels/concatenation_test.cc
+++ b/tensorflow/lite/kernels/concatenation_test.cc
@@ -273,7 +273,7 @@ struct ConcatenationOpTestTyped : public testing::Test {
   using TestType = Type;
 
   enum TensorType tensor_type =
-      std::is_same<Type, int16_t>::value ? TensorType_INT16 : TensorType_INT8;
+      (std::is_same<Type, int16_t>::value ? TensorType_INT16 : TensorType_INT8);
 };
 
 using TestTypes = testing::Types<int8_t, int16_t>;


### PR DESCRIPTION
The following commit introduces a test regression on the ROCm platform
https://github.com/tensorflow/tensorflow/pull/36058/commits/a2aa5e3f045a5916b20a63b58f824ed59710845a

After the commit, the test fails to build with the following error.

```
ERROR: /root/tensorflow/tensorflow/lite/kernels/BUILD:846:1: Couldn't build file tensorflow/lite/kernels/_objs/concatenation_test/concatenation_test.o: C++ compilation of rule '//tensorflow/lite/kernels:concatenation_test' failed (Exit 1)
tensorflow/lite/kernels/concatenation_test.cc:276:26: error: expected ';' at end of member declaration
       std::is_same<Type, int16_t>::value ? TensorType_INT16 : TensorType_INT8;
                          ^
tensorflow/lite/kernels/concatenation_test.cc:276:33: error: expected unqualified-id before '>' token
       std::is_same<Type, int16_t>::value ? TensorType_INT16 : TensorType_INT8;
                                 ^
tensorflow/lite/kernels/concatenation_test.cc:276:20: error: wrong number of template arguments (1, should be 2)
       std::is_same<Type, int16_t>::value ? TensorType_INT16 : TensorType_INT8;
                    ^
In file included from /usr/include/c++/5/bits/move.h:57:0,
                 from /usr/include/c++/5/bits/stl_pair.h:59,
                 from /usr/include/c++/5/bits/stl_algobase.h:64,
                 from /usr/include/c++/5/memory:62,
                 from external/com_google_googletest/googletest/include/gtest/gtest.h:56,
                 from tensorflow/lite/kernels/concatenation_test.cc:17:
/usr/include/c++/5/type_traits:958:12: note: provided for 'template<class, class> struct std::is_same'
     struct is_same;
            ^
```

The fix is to put parens around the RHS expr, to fox what seems to be a parsing error. Don't think this error was ROCm specific.


----------


/cc @whchung @cheshire @chsigg 