### PR TITLE
[ROCm] Fix for a test regression on the ROCm platform - 200207 - 2

### DIFF
--- a/tensorflow/python/eager/profiler_test.py
+++ b/tensorflow/python/eager/profiler_test.py
@@ -47,7 +47,8 @@ class ProfilerTest(test_util.TensorFlowTestCase):
     profile_pb.ParseFromString(profile_result)
     devices = frozenset(device.name for device in profile_pb.devices.values())
     self.assertIn('/host:CPU', devices)
-    if config.list_physical_devices('GPU'):
+    if not test_util.IsBuiltWithROCm() and config.list_physical_devices('GPU'):
+      # device tracing is not yet supported on the ROCm platform
       self.assertIn('/device:GPU:0', devices)
     events = frozenset(event.name for event in profile_pb.trace_events)
     self.assertIn('three_times_five', events)


### PR DESCRIPTION
The following commit introduces a test regression on the ROCm platform
https://github.com/tensorflow/tensorflow/commit/7a931a2349591f4e2250ac2d3b6c3ca66538b740

That commit adds an explicit check for GPU device in the profiler output (if a GPU is present in the list of physical devices).

Since ROCm platform does not yet support device tracing, this test now fails on the ROCm platform

The "fix" (until ROCm adds support for device tracing) is to disable that check on the ROCm platform


--------------------------

/cc @whchung @chsigg 