### PR TITLE
[DOCS] Building Tensorflow with Select Ops Update

### DIFF
--- a/tensorflow/lite/g3doc/guide/ops_select.md
+++ b/tensorflow/lite/g3doc/guide/ops_select.md
@@ -105,7 +105,7 @@ environment</a>, build the Android AAR with select TensorFlow ops as follows:
 ```sh
 bazel build --cxxopt='--std=c++11' -c opt \
   --config=android_arm --config=monolithic \
-  //tensorflow/lite/java:tensorflow-lite-with-select-tf-ops
+  //tensorflow/lite/java:tensorflow-lite-select-tf-ops
 ```
 
 This will generate an AAR file in `bazel-bin/tensorflow/lite/java/`. From there,
@@ -114,9 +114,9 @@ AAR to your local Maven repository:
 
 ```sh
 mvn install:install-file \
-  -Dfile=bazel-bin/tensorflow/lite/java/tensorflow-lite-with-select-tf-ops.aar \
+  -Dfile=bazel-bin/tensorflow/lite/java/tensorflow-lite-select-tf-ops.aar \
   -DgroupId=org.tensorflow \
-  -DartifactId=tensorflow-lite-with-select-tf-ops -Dversion=0.1.100 -Dpackaging=aar
+  -DartifactId=tensorflow-lite-select-tf-ops -Dversion=0.1.100 -Dpackaging=aar
 ```
 
 Finally, in your app's `build.gradle`, ensure you have the `mavenLocal()`
@@ -132,7 +132,7 @@ allprojects {
 }
 
 dependencies {
-    implementation 'org.tensorflow:tensorflow-lite-with-select-tf-ops:0.1.100'
+    implementation 'org.tensorflow:tensorflow-lite-select-tf-ops:0.1.100'
 }
 ```
 


### PR DESCRIPTION
The Android AAR `tensorflow-lite-with-select-tf-ops` target with select TensorFlow ops has been removed. Now `tensorflow-lite-select-tf-ops` should used. Updating the documentation to match what's in master branch.