### PR TITLE
Go: NewTensor & Value performance improvement

### DIFF
--- a/tensorflow/go/tensor_test.go
+++ b/tensorflow/go/tensor_test.go
@@ -303,6 +303,7 @@ func BenchmarkTensor(b *testing.B) {
 	// Where input tensors correspond to a 224x224 RGB image
 	// flattened into a vector.
 	var vector [224 * 224 * 3]int32
+	var arrays [100][100][100]int32
 
 	l3 := make([][][]float32, 100)
 	l2 := make([][]float32, 100*100)
@@ -316,6 +317,7 @@ func BenchmarkTensor(b *testing.B) {
 
 	tests := []interface{}{
 		vector,
+		arrays,
 		l1,
 		l2,
 		l3,

--- a/tensorflow/go/tensor_test.go
+++ b/tensorflow/go/tensor_test.go
@@ -18,6 +18,7 @@ package tensorflow
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"reflect"
 	"testing"
@@ -276,6 +277,7 @@ func TestReadTensorReadAll(t *testing.T) {
 }
 
 func benchmarkNewTensor(b *testing.B, v interface{}) {
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		if t, err := NewTensor(v); err != nil || t == nil {
 			b.Fatalf("(%v, %v)", t, err)
@@ -283,32 +285,50 @@ func benchmarkNewTensor(b *testing.B, v interface{}) {
 	}
 }
 
-func BenchmarkNewTensor(b *testing.B) {
-	var (
-		// Some sample sizes from the Inception image labeling model.
-		// Where input tensors correspond to a 224x224 RGB image
-		// flattened into a vector.
-		vector [224 * 224 * 3]int32
-	)
-	b.Run("[150528]", func(b *testing.B) { benchmarkNewTensor(b, vector) })
-}
+func benchmarkValueTensor(b *testing.B, v interface{}) {
+	t, err := NewTensor(v)
+	if err != nil {
+		b.Fatalf("(%v, %v)", t, err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
 
-func benchmarkDecodeTensor(b *testing.B, t *Tensor) {
 	for i := 0; i < b.N; i++ {
 		_ = t.Value()
 	}
 }
 
-func BenchmarkDecodeTensor(b *testing.B) {
-	var (
-		// Some sample sizes from the Inception image labeling model.
-		// Where input tensors correspond to a 224x224 RGB image
-		// flattened into a vector.
-		vector [224 * 224 * 3]int32
-	)
-	t, err := NewTensor(vector)
-	if err != nil {
-		b.Fatalf("(%v, %v)", t, err)
+func BenchmarkTensor(b *testing.B) {
+	// Some sample sizes from the Inception image labeling model.
+	// Where input tensors correspond to a 224x224 RGB image
+	// flattened into a vector.
+	var vector [224 * 224 * 3]int32
+
+	l3 := make([][][]float32, 100)
+	l2 := make([][]float32, 100*100)
+	l1 := make([]float32, 100*100*100)
+	for i := range l2 {
+		l2[i] = l1[i*100 : (i+1)*100]
 	}
-	b.Run("[150528]", func(b *testing.B) { benchmarkDecodeTensor(b, t) })
+	for i := range l3 {
+		l3[i] = l2[i*100 : (i+1)*100]
+	}
+
+	tests := []interface{}{
+		vector,
+		l1,
+		l2,
+		l3,
+	}
+	b.Run("New", func(b *testing.B) {
+		for _, test := range tests {
+			b.Run(fmt.Sprintf("%T", test), func(b *testing.B) { benchmarkNewTensor(b, test) })
+		}
+	})
+	b.Run("Value", func(b *testing.B) {
+		for _, test := range tests {
+			b.Run(fmt.Sprintf("%T", test), func(b *testing.B) { benchmarkValueTensor(b, test) })
+		}
+	})
+
 }


### PR DESCRIPTION
Considerable improvements in NewTensor & Value performance for non-String Tensors. 

```
name                           old time/op    new time/op    delta
Tensor/New/[150528]int32-16      1.95ms ± 1%    0.11ms ±14%   -94.12%  (p=0.000 n=8+7)
Tensor/New/[]float32-16          12.2ms ± 1%     0.8ms ±66%   -93.68%  (p=0.000 n=7+8)
Tensor/New/[][]float32-16        14.0ms ± 1%     1.2ms ±14%   -91.36%  (p=0.000 n=8+8)
Tensor/New/[][][]float32-16      13.9ms ± 1%     1.3ms ± 7%   -90.81%  (p=0.000 n=8+8)
Tensor/Value/[150528]int32-16     549µs ± 5%      61µs ± 2%   -88.83%  (p=0.000 n=8+8)
Tensor/Value/[]float32-16        11.9ms ± 0%     0.5ms ± 1%   -95.89%  (p=0.000 n=7+8)
Tensor/Value/[][]float32-16      14.9ms ± 1%     0.5ms ± 1%   -96.35%  (p=0.000 n=8+8)
Tensor/Value/[][][]float32-16    14.9ms ± 1%     0.5ms ± 2%   -96.33%  (p=0.000 n=8+8)

name                           old alloc/op   new alloc/op   delta
Tensor/New/[150528]int32-16       606kB ± 0%       0kB ± 0%   -99.99%  (p=0.000 n=8+8)
Tensor/New/[]float32-16          4.01MB ± 0%    0.00MB ± 0%  -100.00%  (p=0.000 n=8+8)
Tensor/New/[][]float32-16        4.48MB ± 0%    0.00MB ± 0%  -100.00%  (p=0.000 n=8+8)
Tensor/New/[][][]float32-16      4.48MB ± 0%    0.00MB ± 0%  -100.00%  (p=0.000 n=8+8)
Tensor/Value/[150528]int32-16    1.21MB ± 0%    0.61MB ± 0%   -50.00%  (p=0.000 n=8+8)
Tensor/Value/[]float32-16        8.01MB ± 0%    4.01MB ± 0%   -50.00%  (p=0.000 n=8+8)
Tensor/Value/[][]float32-16      9.21MB ± 0%    4.25MB ± 0%   -53.82%  (p=0.000 n=8+8)
Tensor/Value/[][][]float32-16    9.23MB ± 0%    4.25MB ± 0%   -53.93%  (p=0.000 n=8+8)

name                           old allocs/op  new allocs/op  delta
Tensor/New/[150528]int32-16        4.00 ± 0%      3.00 ± 0%   -25.00%  (p=0.000 n=8+8)
Tensor/New/[]float32-16            4.00 ± 0%      3.00 ± 0%   -25.00%  (p=0.000 n=8+8)
Tensor/New/[][]float32-16         20.0k ± 0%      0.0k ± 0%   -99.98%  (p=0.000 n=8+8)
Tensor/New/[][][]float32-16       20.0k ± 0%      0.0k ± 0%   -99.98%  (p=0.000 n=8+8)
Tensor/Value/[150528]int32-16      7.00 ± 0%      2.00 ± 0%   -71.43%  (p=0.000 n=8+8)
Tensor/Value/[]float32-16          7.00 ± 0%      2.00 ± 0%   -71.43%  (p=0.000 n=8+8)
Tensor/Value/[][]float32-16       40.0k ± 0%      0.0k ± 0%   -99.99%  (p=0.000 n=8+8)
Tensor/Value/[][][]float32-16     40.2k ± 0%      0.0k ± 0%   -99.99%  (p=0.000 n=8+8)
```
Discussed in https://github.com/tensorflow/tensorflow/issues/36288. We avoid using binary.Write as this is both quite wordy and causes a large number of allocations with tensors of order 2 or above. What we do instead is just copy the memory directly when we can. Note since we're looking for native byte order for the machine copying memory is OK as it is in native byte order and Go primitive types are fundamentally the same as C primitive types as these are the machine's primitive types.