### PR TITLE
[ROCm] Fix for a test failure on the ROCm platform - 200210 - 1

### DIFF
--- a/tensorflow/python/distribute/mirrored_strategy_test.py
+++ b/tensorflow/python/distribute/mirrored_strategy_test.py
@@ -57,6 +57,7 @@ from tensorflow.python.ops import gradients
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import variable_scope
 from tensorflow.python.ops import variables
+from tensorflow.python.platform import test
 from tensorflow.python.training import gradient_descent
 from tensorflow.python.training import optimizer as optimizer_lib
 from tensorflow.python.training import server_lib
@@ -1363,6 +1364,11 @@ class FunctionTest(test.TestCase):
       self.assertSetEqual(devices_for_this_node, set(devices))
 
   def testFuctionPreservesAutoGraph(self):
+    # This test fails on the ROCm platform with the following error
+    # RuntimeError: Virtual devices cannot be modified after being initialized
+    # So skipping it on the ROCM platform for now
+    if test.is_built_with_rocm():
+      self.skipTest("Test fails on the ROCm platform")
     config.set_logical_device_configuration(
         config.list_physical_devices("CPU")[0],
         [context.LogicalDeviceConfiguration()] * 2)


### PR DESCRIPTION
The test `//tensorflow/python/distribute:mirrored_strategy_test_gpu ` currently fails on the ROCm platform.
It has one failing subtest ( `testFuctionPreservesAutoGraph (__main__.FunctionTest)` ), which fails with the following error
```
Traceback (most recent call last):
  File "/root/.cache/bazel/_bazel_root/efb88f6336d9c4a18216fb94287b8d97/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/distribute/mirrored_strategy_test_gpu.runfiles/org_tensorflow/tensorflow/python/distribute/mirrored_strategy_test.py", line 1369, in testFuctionPreservesAutoGraph
    [context.LogicalDeviceConfiguration()] * 2)
  File "/root/.cache/bazel/_bazel_root/efb88f6336d9c4a18216fb94287b8d97/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/distribute/mirrored_strategy_test_gpu.runfiles/org_tensorflow/tensorflow/python/framework/config.py", line 609, in set_logical_device_configuration
    context.context().set_logical_device_configuration(device, logical_devices)
  File "/root/.cache/bazel/_bazel_root/efb88f6336d9c4a18216fb94287b8d97/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/distribute/mirrored_strategy_test_gpu.runfiles/org_tensorflow/tensorflow/python/eager/context.py", line 1326, in set_logical_device_configuration
    "Virtual devices cannot be modified after being initialized")
RuntimeError: Virtual devices cannot be modified after being initialized
```

The failure does not seem to ROCm specific, and the error seems legit, so am not sure how to go about "fixing" it.

Skipping the subtest on the ROCm platform for now.

-------------------

/cc @whchung @chsigg 