### PR TITLE
Fix concatenation_test

### DIFF
--- a/tensorflow/lite/kernels/concatenation_test.cc
+++ b/tensorflow/lite/kernels/concatenation_test.cc
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 #include <cstdarg>
+#include <type_traits>
 
 #include <gtest/gtest.h>
 #include "tensorflow/lite/interpreter.h"
@@ -271,9 +272,12 @@ TEST(ConcatenationOpTest, FourInputsQuantizedUint8) {
 template <typename Type>
 struct ConcatenationOpTestTyped : public testing::Test {
   using TestType = Type;
+  enum TensorType tensor_type;
 
-  enum TensorType tensor_type =
-      std::is_same<Type, int16_t>::value ? TensorType_INT16 : TensorType_INT8;
+  ConcatenationOpTestTyped() {
+    tensor_type =
+        std::is_same<Type, int16_t>::value ? TensorType_INT16 : TensorType_INT8;
+  }
 };
 
 using TestTypes = testing::Types<int8_t, int16_t>;


### PR DESCRIPTION
Commit a2aa5e3f045a5916b20a63b58f824ed59710845a broke `ROCm` CI build. The member variable should be initialized in a constructor.

/cc @whchung @deven-amd 