### PR TITLE
Minor fix to logging message

### DIFF
--- a/tensorflow/core/platform/default/logging.cc
+++ b/tensorflow/core/platform/default/logging.cc
@@ -256,7 +256,7 @@ void LogMessage::GenerateLogMessage() {
              absl::base_internal::GetTID());
   }
   // TODO(jeff,sanjay): Replace this with something that logs through the env.
-  fprintf(stderr, "%s.%06d: %c%s %s:%d] %s\n", time_buffer, micros_remainder,
+  fprintf(stderr, "[%s.%06d: %c%s %s:%d] %s\n", time_buffer, micros_remainder,
           "IWEF"[severity_], tid_buffer, fname_, line_, str().c_str());
 }
 #endif


### PR DESCRIPTION
There seems to be a `[` missing in the LogMessage log generation. For example I get
`2020-02-10 11:20:35.474149: I tensorflow/core/platform/profile_utils/cpu_utils.cc:101] CPU Frequency: ...`
Imo this should be:
`[2020-02-10 11:20:35.474149: I tensorflow/core/platform/profile_utils/cpu_utils.cc:101] CPU Frequency: ...`