### PR TITLE
Debug log implementation to use the STM32 HAL UART implementation. Re…

### DIFF
--- a/tensorflow/lite/micro/stm32f4HAL/debug_log.cc
+++ b/tensorflow/lite/micro/stm32f4HAL/debug_log.cc
@@ -20,18 +20,20 @@ limitations under the License.
 
 #include <cstdio>
 
-#ifdef __GNUC__
-#define PUTCHAR_PROTOTYPE int __io_putchar(int ch)
-#else
-#define PUTCHAR_PROTOTYPE int fputc(int ch, FILE *f)
-#endif /* __GNUC__ */
-
 extern UART_HandleTypeDef DEBUG_UART_HANDLE;
 
-PUTCHAR_PROTOTYPE {
+#ifdef __GNUC__
+int __io_putchar(int ch) {
   HAL_UART_Transmit(&DEBUG_UART_HANDLE, (uint8_t *)&ch, 1, HAL_MAX_DELAY);
 
   return ch;
 }
+#else
+int fputc(int ch, FILE *f) {
+  HAL_UART_Transmit(&DEBUG_UART_HANDLE, (uint8_t *)&ch, 1, HAL_MAX_DELAY);
+
+  return ch;
+}
+#endif /* __GNUC__ */
 
 extern "C" void DebugLog(const char *s) { fprintf(stderr, "%s", s); }

--- a/tensorflow/lite/micro/stm32f4HAL/debug_log.cc
+++ b/tensorflow/lite/micro/stm32f4HAL/debug_log.cc
@@ -1,0 +1,37 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/micro/debug_log.h"
+
+#include <stm32f4xx_hal.h>
+#include <stm32f4xx_hal_uart.h>
+
+#include <cstdio>
+
+#ifdef __GNUC__
+#define PUTCHAR_PROTOTYPE int __io_putchar(int ch)
+#else
+#define PUTCHAR_PROTOTYPE int fputc(int ch, FILE *f)
+#endif /* __GNUC__ */
+
+extern UART_HandleTypeDef DEBUG_UART_HANDLE;
+
+PUTCHAR_PROTOTYPE {
+  HAL_UART_Transmit(&DEBUG_UART_HANDLE, (uint8_t *)&ch, 1, HAL_MAX_DELAY);
+
+  return ch;
+}
+
+extern "C" void DebugLog(const char *s) { fprintf(stderr, "%s", s); }


### PR DESCRIPTION
…directs (f)printf HAL_UART_Transmit using a UART_HandleTypeDef that must be provided as DEBUG_UART_HANDLE

Debug log to be used with the STM32F4 HAL libraries instead of mbed. Tested working with the project [here](https://github.com/alxhoff/STM3240G-EVAL-TensorFlow) and the STM3240G-EVAL board, not using the TF make system though. I will look at completely integrating STM32 HAL into TF make soon.