### PR TITLE
[ROCm] Fix for a test failure on the ROCm platform - 200211 - 1

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/tests/gpu_kernel_tiling_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/gpu_kernel_tiling_test.cc
@@ -374,12 +374,12 @@ TEST_F(GpuKernelTilingTest, ColumnReductionWithPowerOf2OutputElementsUnrolled) {
   auto expected_ir = is_built_with_rocm_ ? R"(
 ; CHECK-LABEL: define amdgpu_kernel void @fusion
 ;
-; CHECK-LABEL: atomic_op_loop_body{{.*}}:
+; CHECK-LABEL: atomic_op_loop_body{{[0-9]*}}.atomic_op_loop_body{{[0-9]*}}_crit_edge:
 ; CHECK: %[[fadd:.*]] = fadd float %{{.*}}, %{{.*}}
 ; CHECK: %[[bitcast:.*]] = bitcast float %[[fadd]] to i32
 ; CHECK: %{{.*}} = cmpxchg i32* %{{.*}}, i32 %{{.*}}, i32 %[[bitcast]]
 ;
-; CHECK-LABEL: atomic_op_loop_body{{.*}}:
+; CHECK-LABEL: atomic_op_loop_body{{[0-9]*}}.atomic_op_loop_body{{[0-9]*}}_crit_edge:
 ; CHECK: %[[fadd:.*]] = fadd float %{{.*}}, %{{.*}}
 ; CHECK: %[[bitcast:.*]] = bitcast float %[[fadd]] to i32
 ; CHECK: %{{.*}} = cmpxchg i32* %{{.*}}, i32 %{{.*}}, i32 %[[bitcast]]
@@ -498,22 +498,22 @@ TEST_F(GpuKernelTilingTest, ColumnReductionMOFUnrolled) {
   auto expected_ir = is_built_with_rocm_ ? R"(
 ; CHECK-LABEL: define amdgpu_kernel void @fusion
 ;
-; CHECK-LABEL: atomic_op_loop_body{{.*}}:
+; CHECK-LABEL: atomic_op_loop_body{{[0-9]*}}.atomic_op_loop_body{{[0-9]*}}_crit_edge:
 ; CHECK: %[[fadd:.*]] = fadd float %{{.*}}, %{{.*}}
 ; CHECK: %[[bitcast:.*]] = bitcast float %[[fadd]] to i32
 ; CHECK: %{{.*}} = cmpxchg i32* %{{.*}}, i32 %{{.*}}, i32 %[[bitcast]]
 ;
-; CHECK-LABEL: atomic_op_loop_body{{.*}}:
+; CHECK-LABEL: atomic_op_loop_body{{[0-9]*}}.atomic_op_loop_body{{[0-9]*}}_crit_edge:
 ; CHECK: %[[fadd:.*]] = fadd float %{{.*}}, %{{.*}}
 ; CHECK: %[[bitcast:.*]] = bitcast float %[[fadd]] to i32
 ; CHECK: %{{.*}} = cmpxchg i32* %{{.*}}, i32 %{{.*}}, i32 %[[bitcast]]
 ;
-; CHECK-LABEL: atomic_op_loop_body{{.*}}:
+; CHECK-LABEL: atomic_op_loop_body{{[0-9]*}}.atomic_op_loop_body{{[0-9]*}}_crit_edge:
 ; CHECK: %[[fadd:.*]] = fadd float %{{.*}}, %{{.*}}
 ; CHECK: %[[bitcast:.*]] = bitcast float %[[fadd]] to i32
 ; CHECK: %{{.*}} = cmpxchg i32* %{{.*}}, i32 %{{.*}}, i32 %[[bitcast]]
 ;
-; CHECK-LABEL: atomic_op_loop_body{{.*}}:
+; CHECK-LABEL: atomic_op_loop_body{{[0-9]*}}.atomic_op_loop_body{{[0-9]*}}_crit_edge:
 ; CHECK: %[[fadd:.*]] = fadd float %{{.*}}, %{{.*}}
 ; CHECK: %[[bitcast:.*]] = bitcast float %[[fadd]] to i32
 ; CHECK: %{{.*}} = cmpxchg i32* %{{.*}}, i32 %{{.*}}, i32 %[[bitcast]]


### PR DESCRIPTION
The IR emitted by the AMDGPU backend, for the atomic-compare-and-swap operation, seems to have changed recently
(perhaps by the new LLVM version being picked up as a recent frequent updates to the LLVM repo commit pointer)

The new IR results in a failure of a couple of subtests with the test `//tensorflow/compiler/xla/service/gpu/tests:gpu_kernel_tiling_test`.

Updating the regexp within the file-check pattern to account for the updated IR generation

----------------

/cc @whchung @jerryyin @cheshire 
