### PR TITLE
Fix gpu test filters when running the ./configure script

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1155,7 +1155,7 @@ def set_trisycl_include_dir(environ_cp):
   write_action_env_to_bazelrc('TRISYCL_INCLUDE_DIR', trisycl_include_dir)
 
 
-def system_specific_test_config(env):
+def system_specific_test_config(environ_cp):
   """Add default build and test flags required for TF tests to bazelrc."""
   write_to_bazelrc('test --flaky_test_attempts=3')
   write_to_bazelrc('test --test_size_filters=small,medium')
@@ -1171,14 +1171,14 @@ def system_specific_test_config(env):
   test_only_filters = ['-oss_serial']
   if is_windows():
     test_and_build_filters.append('-no_windows')
-    if env.get('TF_NEED_CUDA', None) == '1':
+    if environ_cp.get('TF_NEED_CUDA', None) == '1':
       test_and_build_filters += ['-no_windows_gpu', '-no_gpu']
     else:
       test_and_build_filters.append('-gpu')
   elif is_macos():
     test_and_build_filters += ['-gpu', '-nomac', '-no_mac']
   elif is_linux():
-    if env.get('TF_NEED_CUDA', None) == '1':
+    if environ_cp.get('TF_NEED_CUDA', None) == '1':
       test_and_build_filters.append('-no_gpu')
       write_to_bazelrc('test --test_env=LD_LIBRARY_PATH')
     else:
@@ -1523,7 +1523,7 @@ def main():
     create_android_ndk_rule(environ_cp)
     create_android_sdk_rule(environ_cp)
 
-  system_specific_test_config(os.environ)
+  system_specific_test_config(environ_cp)
 
   set_action_env_var(environ_cp, 'TF_CONFIGURE_IOS', 'iOS', False)
   if environ_cp.get('TF_CONFIGURE_IOS') == '1':


### PR DESCRIPTION
Today if you run the ./configure script without setting the
variable TF_NEED_CUDA, in the resulting .tf_configure.bazelrc
you get:

test:v1 --test_tag_filters=-benchmark-test,-no_oss,-gpu,-oss_serial
test:v1 --build_tag_filters=-benchmark-test,-no_oss,-gpu
test:v2 --test_tag_filters=-benchmark-test,-no_oss,-gpu,-oss_serial,-v1only
test:v2 --build_tag_filters=-benchmark-test,-no_oss,-gpu,-v1only

This is incorrect because -gpu means exclude the gpu test. It should be
-no_gpu.

Debugging the problem I found when the code was switched from using
os.env to using environ_cp, that the method system_specific_test_config
was never updated. So unless the environment variable TF_NEED_CUDA was
set before running ./configure then answering yes for CUDA would not
select the correct test filter for gpus.

With this change the test filters are correct:

test:v1 --test_tag_filters=-benchmark-test,-no_oss,-no_gpu,-oss_serial
test:v1 --build_tag_filters=-benchmark-test,-no_oss,-no_gpu
test:v2 --test_tag_filters=-benchmark-test,-no_oss,-no_gpu,-oss_serial,-v1only
test:v2 --build_tag_filters=-benchmark-test,-no_oss,-no_gpu,-v1only