### PR TITLE
libtensorfow-lite.a linking issue

### DIFF
--- a/tensorflow/lite/tools/make/Makefile
+++ b/tensorflow/lite/tools/make/Makefile
@@ -117,7 +117,7 @@ tensorflow/lite/tools/make/downloads/fft2d/fftsg.c \
 tensorflow/lite/tools/make/downloads/flatbuffers/src/util.cpp
 CORE_CC_ALL_SRCS += \
 	$(shell find tensorflow/lite/tools/make/downloads/absl/absl/ \
-	             -type f -name \*.cc | grep -v test | grep -v benchmark | grep -v synchronization | grep -v debugging)
+	             -type f -name \*.cc | grep -v test | grep -v benchmark | grep -v synchronization | grep -v debugging | grep -v hash | grep -v flags)
 endif
 # Remove any duplicates.
 CORE_CC_ALL_SRCS := $(sort $(CORE_CC_ALL_SRCS))
@@ -132,7 +132,6 @@ $(wildcard tensorflow/lite/*/*/*/*test.cc) \
 $(wildcard tensorflow/lite/kernels/*test_main.cc) \
 $(wildcard tensorflow/lite/kernels/*test_util*.cc) \
 tensorflow/lite/experimental/ruy/tune_tool.cc \
-tensorflow/lite/tools/make/downloads/absl/absl/hash/internal/print_hash_of.cc \
 $(MINIMAL_SRCS)
 
 BUILD_WITH_MMAP ?= true

--- a/tensorflow/lite/tools/make/Makefile
+++ b/tensorflow/lite/tools/make/Makefile
@@ -114,6 +114,7 @@ $(wildcard tensorflow/lite/tools/optimize/sparsity/*.cc) \
 $(PROFILER_SRCS) \
 tensorflow/lite/tools/make/downloads/farmhash/src/farmhash.cc \
 tensorflow/lite/tools/make/downloads/fft2d/fftsg.c \
+tensorflow/lite/tools/make/downloads/fft2d/fftsg2d.c \
 tensorflow/lite/tools/make/downloads/flatbuffers/src/util.cpp
 CORE_CC_ALL_SRCS += \
 	$(shell find tensorflow/lite/tools/make/downloads/absl/absl/ \


### PR DESCRIPTION
This pull request fix issues encounter while linking the generated libtensorflow-lite.a into a C/C++ application.
Multiple symbols where not defined such as:
- type_erased.cc:(.text+0x36c): undefined reference to 'absl::Mutex::Lock()
- rfft2d.cc:(.text+0x594): undefined reference to 'rdft2d'

absl/hash and absl/flags that where referencing absl/synchronization have been removed from the build and fft2d/fftsg2d.c has been added to the build.

This has been successfully tested against the STM32MP1 OpenSTLinux distribution.

BR
Vincent