### PR TITLE
Support cross compilation of TFLite pip package

### DIFF
--- a/tensorflow/lite/tools/pip_package/Makefile
+++ b/tensorflow/lite/tools/pip_package/Makefile
@@ -47,7 +47,7 @@ docker-build: docker-image
 		--volume $(OUT_DIR):/out \
 		$(TAG_IMAGE) \
 		/bin/bash -c "tensorflow/tensorflow/lite/tools/pip_package/build_pip_package.sh && \
-		              (cp /tmp/tflite_pip/*.deb /tmp/tflite_pip/$(PYTHON)/dist/{*.whl,*.tar.gz} /out 2>/dev/null || true)"
+		              (cp ${MAKEFILE_DIR}/gen/tflite_pip/*.deb ${MAKEFILE_DIR}/gen/tflite_pip/python3/dist/{*.whl,*.tar.gz} /out 2>/dev/null || true)"
 
 clean:
 	rm -rf $(CURDIR)/out

--- a/tensorflow/lite/tools/pip_package/build_pip_package.sh
+++ b/tensorflow/lite/tools/pip_package/build_pip_package.sh
@@ -23,7 +23,7 @@ export TENSORFLOW_DIR="${SCRIPT_DIR}/../../../.."
 TENSORFLOW_LITE_DIR="${TENSORFLOW_DIR}/tensorflow/lite"
 TENSORFLOW_VERSION=$(grep "_VERSION = " "${TENSORFLOW_DIR}/tensorflow/tools/pip_package/setup.py" | cut -d= -f2 | sed "s/[ '-]//g")
 export PACKAGE_VERSION="${TENSORFLOW_VERSION}${VERSION_SUFFIX}"
-BUILD_DIR="/tmp/tflite_pip/${PYTHON}"
+BUILD_DIR="${SCRIPT_DIR}/gen/tflite_pip/python3"
 
 # Build source tree.
 rm -rf "${BUILD_DIR}" && mkdir -p "${BUILD_DIR}/tflite_runtime"

--- a/tensorflow/lite/tools/pip_package/build_pip_package.sh
+++ b/tensorflow/lite/tools/pip_package/build_pip_package.sh
@@ -49,7 +49,12 @@ case "${TENSORFLOW_TARGET}" in
                        bdist_wheel --plat-name=linux-aarch64
     ;;
   *)
-    ${PYTHON} setup.py bdist bdist_wheel
+    if [[ -n "${TENSORFLOW_TARGET}" ]] && [[ -n "${TENSORFLOW_TARGET_ARCH}" ]]; then
+      ${PYTHON} setup.py bdist --plat-name=${TENSORFLOW_TARGET}-${TENSORFLOW_TARGET_ARCH} \
+                         bdist_wheel --plat-name=${TENSORFLOW_TARGET}-${TENSORFLOW_TARGET_ARCH}
+    else
+      ${PYTHON} setup.py bdist bdist_wheel
+    fi
     ;;
 esac
 

--- a/tensorflow/lite/tools/pip_package/setup.py
+++ b/tensorflow/lite/tools/pip_package/setup.py
@@ -50,6 +50,27 @@ elif TARGET == 'aarch64':
   os.environ['CC'] = 'aarch64-linux-gnu-gcc'
 MAKE_CROSS_OPTIONS = ['TARGET=%s' % TARGET]  if TARGET else []
 
+TARGET_ARCH = (
+    os.environ['TENSORFLOW_TARGET_ARCH'] \
+    if 'TENSORFLOW_TARGET_ARCH' in os.environ
+    else None)
+MAKE_CROSS_OPTIONS += ['TARGET_ARCH=%s' % TARGET_ARCH] \
+        if TARGET_ARCH else []
+
+CC_PREFIX = (
+    os.environ['TENSORFLOW_CC_PREFIX'] \
+    if 'TENSORFLOW_CC_PREFIX' in os.environ
+    else None)
+MAKE_CROSS_OPTIONS += ['CC_PREFIX=%s' % CC_PREFIX] \
+        if CC_PREFIX else []
+
+EXTRA_CXXFLAGS = (
+    os.environ['TENSORFLOW_EXTRA_CXXFLAGS'] \
+    if 'TENSORFLOW_EXTRA_CXXFLAGS' in os.environ
+    else None)
+MAKE_CROSS_OPTIONS += ['EXTRA_CXXFLAGS=%s' % EXTRA_CXXFLAGS] \
+        if EXTRA_CXXFLAGS else []
+
 RELATIVE_MAKE_DIR = os.path.join('tensorflow', 'lite', 'tools', 'make')
 MAKE_DIR = os.path.join(TENSORFLOW_DIR, RELATIVE_MAKE_DIR)
 DOWNLOADS_DIR = os.path.join(MAKE_DIR, 'downloads')


### PR DESCRIPTION
This pull request add the support of cross compiling variables.
It allow to cross compile TFLite library and python module for platforms other than aarch64, Rpi and iOS.
It has been successfully tested with Yocto Openembedded environment to build TensorFlow Lite for the new STM32MP1 Microprocessor target from STMicroelectronics.

It also remove some bashisms in pip build script that prevent to build TFLite in server machine with a dash shell. 

BR
Vincent