### PR TITLE
tfconfig_cluster_resolver: Fix task index override

### DIFF
--- a/tensorflow/python/distribute/cluster_resolver/tfconfig_cluster_resolver.py
+++ b/tensorflow/python/distribute/cluster_resolver/tfconfig_cluster_resolver.py
@@ -88,7 +88,7 @@ class TFConfigClusterResolver(ClusterResolver):
 
   @property
   def task_id(self):
-    if self._task_type is None:
+    if self._task_id is None:
       task_info = _get_value_in_tfconfig(_TASK_KEY, {})
       return int(task_info['index']) if 'index' in task_info else None
     else:

--- a/tensorflow/python/distribute/cluster_resolver/tfconfig_cluster_resolver_test.py
+++ b/tensorflow/python/distribute/cluster_resolver/tfconfig_cluster_resolver_test.py
@@ -224,6 +224,21 @@ class TFConfigClusterResolverTest(test.TestCase):
     cluster_resolver = TFConfigClusterResolver()
     self.assertEqual(1, cluster_resolver.task_id)
 
+  def testTaskIndexOverride(self):
+    os.environ['TF_CONFIG'] = """
+    {
+      "cluster": {
+        "worker": ["worker0:2222", "worker1:2222"]
+      },
+      "task": {
+        "type": "worker",
+        "index": "0"
+      }
+    }
+    """
+    cluster_resolver = TFConfigClusterResolver(task_id=1)
+    self.assertEqual(1, cluster_resolver.task_id)
+
   def testZeroItemsInClusterSpecMasterRead(self):
     os.environ['TF_CONFIG'] = """
     {}


### PR DESCRIPTION
The `task_id` method checked `self._task_type` instead of `self._task_id`.