### PR TITLE
[tflite] add xnnpack delegate to label_image

### DIFF
--- a/tensorflow/lite/examples/label_image/BUILD
+++ b/tensorflow/lite/examples/label_image/BUILD
@@ -62,6 +62,7 @@ cc_library(
         "//tensorflow/lite:framework",
         "//tensorflow/lite:string",
         "//tensorflow/lite:string_util",
+        "//tensorflow/lite/delegates/xnnpack:xnnpack_delegate",
         "//tensorflow/lite/kernels:builtin_ops",
         "//tensorflow/lite/schema:schema_fbs",
     ] + select({

--- a/tensorflow/lite/examples/label_image/BUILD
+++ b/tensorflow/lite/examples/label_image/BUILD
@@ -32,6 +32,7 @@ cc_binary(
         "//tensorflow/lite:framework",
         "//tensorflow/lite:string_util",
         "//tensorflow/lite/delegates/nnapi:nnapi_delegate",
+        "//tensorflow/lite/delegates/xnnpack:xnnpack_delegate",
         "//tensorflow/lite/kernels:builtin_ops",
         "//tensorflow/lite/profiling:profiler",
         "//tensorflow/lite/tools/evaluation:utils",
@@ -62,7 +63,6 @@ cc_library(
         "//tensorflow/lite:framework",
         "//tensorflow/lite:string",
         "//tensorflow/lite:string_util",
-        "//tensorflow/lite/delegates/xnnpack:xnnpack_delegate",
         "//tensorflow/lite/kernels:builtin_ops",
         "//tensorflow/lite/schema:schema_fbs",
     ] + select({

--- a/tensorflow/lite/examples/label_image/README.md
+++ b/tensorflow/lite/examples/label_image/README.md
@@ -90,39 +90,96 @@ adb push tensorflow/lite/examples/label_image/testdata/grace_hopper.bmp  /data/l
 adb push /tmp/labels.txt /data/local/tmp
 ```
 
-Run it, `adb shell "/data/local/tmp/label_image \ -m
-/data/local/tmp/mobilenet_v1_1.0_224.tflite \ -i
-/data/local/tmp/grace_hopper.bmp \ -l /data/local/tmp/labels.txt"` then you
-should see something like the followings: `Loaded model
-/data/local/tmp/mobilenet_v1_1.0_224.tflite resolved reporter INFO: Initialized
-TensorFlow Lite runtime. invoked average time: 25.03 ms 0.907071: 653 military
-uniform 0.0372416: 907 Windsor tie 0.00733753: 466 bulletproof vest 0.00592852:
-458 bow tie 0.00414091: 514 cornet`
+Run it,
+```
+adb shell "/data/local/tmp/label_image \
+  -m /data/local/tmp/mobilenet_v1_1.0_224.tflite \
+  -i /data/local/tmp/grace_hopper.bmp \
+  -l /data/local/tmp/labels.txt"
+```
+then you should see something like the followings:
+```
+Loaded model
+/data/local/tmp/mobilenet_v1_1.0_224.tflite
+resolved reporter
+INFO: Initialized TensorFlow Lite runtime.
+invoked
+average time: 25.03 ms
+0.907071: 653 military uniform
+0.0372416: 907 Windsor tie
+0.00733753: 466 bulletproof vest
+0.00592852: 458 bow tie
+0.00414091: 514 cornet
+```
 
-Run the model with NNAPI delegate (`-a 1`), `adb shell
-"/data/local/tmp/label_image \ -m /data/local/tmp/mobilenet_v1_1.0_224.tflite \
--i /data/local/tmp/grace_hopper.bmp \ -l /data/local/tmp/labels.txt -a 1 -f 1"`
-then you should see something like the followings: `Loaded model
-/data/local/tmp/mobilenet_v1_1.0_224.tflite resolved reporter INFO: Initialized
-TensorFlow Lite runtime. INFO: Created TensorFlow Lite delegate for NNAPI.
-Applied NNAPI delegate.invoked average time: 10.348 ms 0.905401: 653 military
-uniform 0.0379589: 907 Windsor tie 0.00735866: 466 bulletproof vest 0.00605307:
-458 bow tie 0.00422573: 514 cornet`
+Run the model with NNAPI delegate (`-a 1`),
+```
+adb shell "/data/local/tmp/label_image \
+  -m /data/local/tmp/mobilenet_v1_1.0_224.tflite \
+  -i /data/local/tmp/grace_hopper.bmp \
+  -l /data/local/tmp/labels.txt -a 1 -f 1"
+```
+then you should see something like the followings:
+```
+Loaded model /data/local/tmp/mobilenet_v1_1.0_224.tflite
+resolved reporter
+INFO: Initialized TensorFlow Lite runtime.
+INFO: Created TensorFlow Lite delegate for NNAPI.
+Applied NNAPI delegate.
+invoked average time:10.348 ms
+0.905401: 653 military uniform
+0.0379589: 907 Windsor tie
+0.00735866: 466 bulletproof vest
+0.00605307: 458 bow tie
+0.00422573: 514 cornet
+```
 
 To run a model with the Hexagon Delegate, assuming we have followed the
 [Hexagon Delegate Guide](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/performance/hexagon_delegate.md)
-and installed Hexagon libraries in `/data/local/tmp`. Run it `adb shell
-"/data/local/tmp/label_image \ -m
-/data/local/tmp/mobilenet_v1_1.0_224_quant.tflite \ -i
-/data/local/tmp/grace_hopper.bmp \ -l /data/local/tmp/labels.txt -j 1"` then you
-should see something like the followings: ``` Loaded model
-/data/local/tmp/mobilenet_v1_1.0_224_quant.tflite resolved reporter INFO:
-Initialized TensorFlow Lite runtime. INFO: Created TensorFlow Lite delegate for
-Hexagon. INFO: Hexagon delegate: 31 nodes delegated out of 31 nodes.
+and installed Hexagon libraries in `/data/local/tmp`. Run it
+```
+adb shell "/data/local/tmp/label_image \
+  -m /data/local/tmp/mobilenet_v1_1.0_224_quant.tflite \
+  -i /data/local/tmp/grace_hopper.bmp \
+  -l /data/local/tmp/labels.txt -j 1"
+```
+then you should see something like the followings:
+```
+Loaded model /data/local/tmp/mobilenet_v1_1.0_224_quant.tflite
+resolved reporter
+INFO: Initialized TensorFlow Lite runtime.
+INFO: Created TensorFlow Lite delegate for Hexagon.
+INFO: Hexagon delegate: 31 nodes delegated out of 31 nodes.
 
-remote_handle_control available and used Applied Hexagon delegate.invoked
-average time: 8.307 ms 0.729412: 653 military uniform 0.0980392: 907 Windsor tie
-0.0313726: 466 bulletproof vest 0.0313726: 458 bow tie 0.0117647: 700 panpipe
+remote_handle_control available and used
+Applied Hexagon delegate.invoked
+average time: 8.307 ms
+0.729412: 653 military uniform
+0.0980392: 907 Windsor tie
+0.0313726: 466 bulletproof vest
+0.0313726: 458 bow tie
+0.0117647: 700 panpipe
+```
+
+Run the model with the XNNPACK delegate (`-x 1`),
+```
+adb shell "/data/local/tmp/label_image \
+  -m /data/local/tmp/mobilenet_v1_1.0_224.tflite \
+  -i /data/local/tmp/grace_hopper.bmp \
+  -l /data/local/tmp/labels.txt -x 1"
+```
+then you should see something like the followings:
+```
+Loaded model /data/local/tmp/mobilenet_v1_1.0_224.tflite
+resolved reporter
+INFO: Initialized TensorFlow Lite runtime.
+Applied XNNPACK delegate.invoked
+average time: 11.0237 ms
+0.90707: 653 military uniform
+0.0372418: 907 Windsor tie
+0.0073376: 466 bulletproof vest
+0.00592856: 458 bow tie
+0.00414093: 514 cornet
 ```
 
 See the `label_image.cc` source code for other command line options.

--- a/tensorflow/lite/examples/label_image/label_image.cc
+++ b/tensorflow/lite/examples/label_image/label_image.cc
@@ -107,11 +107,7 @@ TfLiteDelegatePtrMap GetDelegates(Settings* s) {
         TfLiteXNNPackDelegateOptionsDefault();
     xnnpack_options.num_threads = s->number_of_threads;
 
-    auto xnnpack_delegate = TfLiteXNNPackDelegateCreate(&xnnpack_options);
-    auto delegate = Interpreter::TfLiteDelegatePtr(
-        xnnpack_delegate, [](TfLiteDelegate* delegate) {
-          TfLiteXNNPackDelegateDelete(delegate);
-        });
+    auto delegate = evaluation::CreateXNNPACKDelegate(&xnnpack_options);
     if (!delegate) {
       LOG(INFO) << "XNNPACK acceleration is unsupported on this platform.";
     } else {

--- a/tensorflow/lite/examples/label_image/label_image.cc
+++ b/tensorflow/lite/examples/label_image/label_image.cc
@@ -37,6 +37,7 @@ limitations under the License.
 
 #include "absl/memory/memory.h"
 #include "tensorflow/lite/delegates/nnapi/nnapi_delegate.h"
+#include "tensorflow/lite/delegates/xnnpack/xnnpack_delegate.h"
 #include "tensorflow/lite/examples/label_image/bitmap_helpers.h"
 #include "tensorflow/lite/examples/label_image/get_top_n.h"
 #include "tensorflow/lite/kernels/register.h"
@@ -98,6 +99,23 @@ TfLiteDelegatePtrMap GetDelegates(Settings* s) {
       LOG(INFO) << "Hexagon acceleration is unsupported on this platform.";
     } else {
       delegates.emplace("Hexagon", std::move(delegate));
+    }
+  }
+
+  if (s->xnnpack_delegate) {
+    TfLiteXNNPackDelegateOptions xnnpack_options =
+        TfLiteXNNPackDelegateOptionsDefault();
+    xnnpack_options.num_threads = s->number_of_threads;
+
+    auto xnnpack_delegate = TfLiteXNNPackDelegateCreate(&xnnpack_options);
+    auto delegate = Interpreter::TfLiteDelegatePtr(
+        xnnpack_delegate, [](TfLiteDelegate* delegate) {
+          TfLiteXNNPackDelegateDelete(delegate);
+        });
+    if (!delegate) {
+      LOG(INFO) << "XNNPACK acceleration is unsupported on this platform.";
+    } else {
+      delegates.emplace("XNNPACK", std::move(delegate));
     }
   }
 
@@ -350,6 +368,7 @@ void display_usage() {
       << "--threads, -t: number of threads\n"
       << "--verbose, -v: [0|1] print more information\n"
       << "--warmup_runs, -w: number of warmup runs\n"
+      << "--xnnpack_delegate, -x: xnnpack delegate\n"
       << "\n";
 }
 
@@ -376,13 +395,14 @@ int Main(int argc, char** argv) {
         {"warmup_runs", required_argument, nullptr, 'w'},
         {"gl_backend", required_argument, nullptr, 'g'},
         {"hexagon_delegate", required_argument, nullptr, 'j'},
+        {"xnnpack_delegate", required_argument, nullptr, 'x'},
         {nullptr, 0, nullptr, 0}};
 
     /* getopt_long stores the option index here. */
     int option_index = 0;
 
     c = getopt_long(argc, argv,
-                    "a:b:c:d:e:f:g:i:j:l:m:p:r:s:t:v:w:", long_options,
+                    "a:b:c:d:e:f:g:i:j:l:m:p:r:s:t:v:w:x:", long_options,
                     &option_index);
 
     /* Detect the end of the options. */
@@ -449,6 +469,9 @@ int Main(int argc, char** argv) {
       case 'w':
         s.number_of_warmup_runs =
             strtol(optarg, nullptr, 10);  // NOLINT(runtime/deprecated_fn)
+        break;
+      case 'x':
+        s.xnnpack_delegate = optarg;
         break;
       case 'h':
       case '?':

--- a/tensorflow/lite/examples/label_image/label_image.h
+++ b/tensorflow/lite/examples/label_image/label_image.h
@@ -31,6 +31,7 @@ struct Settings {
   bool allow_fp16 = false;
   bool gl_backend = false;
   bool hexagon_delegate = false;
+  bool xnnpack_delegate = false;
   int loop_count = 1;
   float input_mean = 127.5f;
   float input_std = 127.5f;

--- a/tensorflow/lite/tools/evaluation/BUILD
+++ b/tensorflow/lite/tools/evaluation/BUILD
@@ -43,6 +43,7 @@ cc_library(
         "//tensorflow/lite:context",
         "//tensorflow/lite:framework",
         "//tensorflow/lite/delegates/nnapi:nnapi_delegate",
+        "//tensorflow/lite/delegates/xnnpack:xnnpack_delegate",
     ] + select({
         "//tensorflow:android": [
             "//tensorflow/lite/delegates/gpu:delegate",

--- a/tensorflow/lite/tools/evaluation/utils.cc
+++ b/tensorflow/lite/tools/evaluation/utils.cc
@@ -164,5 +164,19 @@ Interpreter::TfLiteDelegatePtr CreateHexagonDelegate(
 #endif  // defined(__ANDROID__)
 }
 
+Interpreter::TfLiteDelegatePtr CreateXNNPACKDelegate() {
+  TfLiteXNNPackDelegateOptions xnnpack_options =
+      TfLiteXNNPackDelegateOptionsDefault();
+  return CreateXNNPACKDelegate(&xnnpack_options);
+}
+
+Interpreter::TfLiteDelegatePtr CreateXNNPACKDelegate(
+    const TfLiteXNNPackDelegateOptions* xnnpack_options) {
+  auto xnnpack_delegate = TfLiteXNNPackDelegateCreate(xnnpack_options);
+  return Interpreter::TfLiteDelegatePtr(
+      xnnpack_delegate,
+      [](TfLiteDelegate* delegate) { TfLiteXNNPackDelegateDelete(delegate); });
+}
+
 }  // namespace evaluation
 }  // namespace tflite

--- a/tensorflow/lite/tools/evaluation/utils.h
+++ b/tensorflow/lite/tools/evaluation/utils.h
@@ -29,6 +29,7 @@ limitations under the License.
 
 #include "tensorflow/lite/context.h"
 #include "tensorflow/lite/delegates/nnapi/nnapi_delegate.h"
+#include "tensorflow/lite/delegates/xnnpack/xnnpack_delegate.h"
 #include "tensorflow/lite/model.h"
 
 namespace tflite {
@@ -63,6 +64,10 @@ Interpreter::TfLiteDelegatePtr CreateGPUDelegate(
 
 Interpreter::TfLiteDelegatePtr CreateHexagonDelegate(
     const std::string& library_directory_path, bool profiling);
+
+Interpreter::TfLiteDelegatePtr CreateXNNPACKDelegate();
+Interpreter::TfLiteDelegatePtr CreateXNNPACKDelegate(
+    const TfLiteXNNPackDelegateOptions* options);
 
 }  // namespace evaluation
 }  // namespace tflite

--- a/third_party/cpuinfo/BUILD.bazel
+++ b/third_party/cpuinfo/BUILD.bazel
@@ -101,6 +101,8 @@ MACH_ARM_SRCS = [
 cc_library(
     name = "cpuinfo_impl",
     srcs = select({
+        ":linux_aarch64": COMMON_SRCS + ARM_SRCS + LINUX_SRCS + LINUX_ARM64_SRCS,
+        ":linux_arm": COMMON_SRCS + ARM_SRCS + LINUX_SRCS + LINUX_ARM32_SRCS,
         ":linux_x86_64": COMMON_SRCS + X86_SRCS + LINUX_SRCS + LINUX_X86_SRCS,
         ":macos_x86_64": COMMON_SRCS + X86_SRCS + MACH_SRCS + MACH_X86_SRCS,
         ":android_armv7": COMMON_SRCS + ARM_SRCS + LINUX_SRCS + LINUX_ARM32_SRCS + ANDROID_ARM_SRCS,
@@ -158,6 +160,18 @@ cc_library(
 )
 
 ############################# Build configurations #############################
+
+config_setting(
+    name = "linux_aarch64",
+    values = {"cpu": "aarch64"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "linux_arm",
+    values = {"cpu": "arm"},
+    visibility = ["//visibility:public"],
+)
 
 config_setting(
     name = "linux_x86_64",


### PR DESCRIPTION
The [XNNPACK Delegate](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/delegates/xnnpack) uses [XNNPACK](https://github.com/google/XNNPACK), a fairly optimized floating point library, to run some inference operators (see the delegate's [README](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/delegates/xnnpack/README.md) for currently supported ops). With XNNPACK, I was able to get performance numbers similar to what @Maratyszcza described at [XNNPACK's readme](https://github.com/google/XNNPACK/README.md). I also got good numbers on Pixel 4 and Oppo Reno 3. Numbers on x86 machines are also good.

- **Single-threaded**, `label_image -m MODEL_NAME -x 1 -c 50 -t 1`

Model |  Pixel 3a, ms | Pixel 4, ms| Oppo Reno 3, ms |
-- | --: | --: | --:
MobileNet v1 1.0X |  88.02 | 29.95 | 36.23 |
MobileNet v2 1.0X |  55.13 | 19.13 | 21.69 |
MobileNet v3 Large |  44.84 | 15.69 | 17.65 |
MobileNet v3 Small |   14.23 | 5.58 | 5.66|

- **multi-threaded**, the number of threads is set to be the number of big cores. `label_image -m MODEL_NAME -x 1 -c 50 -t NUMBER_OF_BIG_CORES`

Model |  Pixel 3a, ms | Pixel 4, ms| Oppo Reno 3, ms|
-- | --: | --: | --:
MobileNet v1 1.0X |  46.00 | 10.60 | 13.23 |
MobileNet v2 1.0X |  28.57 | 6.89 | 7.56 |
MobileNet v3 Large |  24.62 | 6.52 | 6.88 |
MobileNet v3 Small |   8.24 | 2.47 |  2.37 |

