### PR TITLE
[XLA] Speed up row reduction on P100/V100 for float16 and [u]int8

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
@@ -146,9 +146,10 @@ std::array<int64, 3> GetReductionTiling(
           &cc_major, &cc_minor);
     }
     int unroll_x = 8;
-    if (cc_major >= 7 && smallest_input_dtype_bits <= 16) {
-      // TODO: Benchmark with int8 too.
+    if (cc_major >= 6 && smallest_input_dtype_bits == 16) {
       unroll_x = 32;
+    } else if (cc_major >= 6 && smallest_input_dtype_bits == 8) {
+      unroll_x = 64;
     }
     return {tile_z, 1, unroll_x};
   }

--- a/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
@@ -147,7 +147,7 @@ std::array<int64, 3> GetReductionTiling(
     }
     int unroll_x = 8;
     if (cc_major >= 6 && smallest_input_dtype_bits == 16) {
-      unroll_x = 32;
+      unroll_x = 16;
     } else if (cc_major >= 6 && smallest_input_dtype_bits == 8) {
       unroll_x = 64;
     }

--- a/tensorflow/compiler/xla/service/gpu/ir_emission_utils.h
+++ b/tensorflow/compiler/xla/service/gpu/ir_emission_utils.h
@@ -23,6 +23,7 @@ limitations under the License.
 #include "tensorflow/compiler/xla/service/hlo_instruction.h"
 #include "tensorflow/compiler/xla/service/hlo_instructions.h"
 #include "tensorflow/core/platform/stream_executor_no_cuda.h"
+#include "tensorflow/stream_executor/device_description.h"
 
 // TODO(jlebar): Move functions related to cublas/cudnn to a separate file; they
 // don't belong in "ir_emission_utils".
@@ -193,8 +194,11 @@ ReductionDimensions GetReductionKindAndContiguousComponents(
 
 // Get tiling per thread for the given reduction in dimensions [D, H, W] per
 // thread.
+// If the device isn't known pass null for device_description and you will get
+// non-optimized value.
 std::array<int64, 3> GetReductionTiling(
-    const ReductionDimensions& reduction_dimensions);
+    const ReductionDimensions& reduction_dimensions,
+    const stream_executor::DeviceDescription* device_description);
 
 // Emits call to "vprintf" with given format and arguments.
 llvm::Value* EmitPrintf(absl::string_view fmt,

--- a/tensorflow/compiler/xla/service/gpu/ir_emission_utils.h
+++ b/tensorflow/compiler/xla/service/gpu/ir_emission_utils.h
@@ -198,6 +198,7 @@ ReductionDimensions GetReductionKindAndContiguousComponents(
 // non-optimized value.
 std::array<int64, 3> GetReductionTiling(
     const ReductionDimensions& reduction_dimensions,
+    int smallest_input_dtype_bits,
     const stream_executor::DeviceDescription* device_description);
 
 // Emits call to "vprintf" with given format and arguments.

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -3074,9 +3074,18 @@ ReductionCodegenInfo IrEmitterUnnested::ComputeReductionCodegenInfo(
            << " " << reduction_dimensions.dimensions[0] << " "
            << reduction_dimensions.dimensions[1] << " "
            << reduction_dimensions.dimensions[2];
+  auto get_dtype_bits = [](const HloInstruction *i) {
+    return primitive_util::BitWidth(i->shape().element_type());};
 
+  // For fusion with multiple inputs, use the smallest input dtype to
+  // select the reduction_tiling.
+  int smallest_input_dtype_bits = get_dtype_bits(first_reduce->operand(0));
+  for (auto input: unnested_hlo->operands()) {
+    smallest_input_dtype_bits = std::min(get_dtype_bits(input),
+                                         smallest_input_dtype_bits);
+  }
   std::array<int64, 3> reduction_tiling =
-      GetReductionTiling(reduction_dimensions,
+      GetReductionTiling(reduction_dimensions, smallest_input_dtype_bits,
                          &ir_emitter_context_->device_description());
   bool dilated_x =
       reduction_dimensions.is_row_reduction ||

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -3080,7 +3080,7 @@ ReductionCodegenInfo IrEmitterUnnested::ComputeReductionCodegenInfo(
   // For fusion with multiple inputs, use the smallest input dtype to
   // select the reduction_tiling.
   int smallest_input_dtype_bits = get_dtype_bits(first_reduce->operand(0));
-  for (auto input: unnested_hlo->operands()) {
+  for (xla::HloInstruction* input: unnested_hlo->operands()) {
     smallest_input_dtype_bits = std::min(get_dtype_bits(input),
                                          smallest_input_dtype_bits);
   }

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -3076,7 +3076,8 @@ ReductionCodegenInfo IrEmitterUnnested::ComputeReductionCodegenInfo(
            << reduction_dimensions.dimensions[2];
 
   std::array<int64, 3> reduction_tiling =
-      GetReductionTiling(reduction_dimensions);
+      GetReductionTiling(reduction_dimensions,
+                         &ir_emitter_context_->device_description());
   bool dilated_x =
       reduction_dimensions.is_row_reduction ||
       !IsUnrollingColumnReductionBeneficial(unnested_hlo, input_shape,

--- a/tensorflow/compiler/xla/tests/reduce_test.cc
+++ b/tensorflow/compiler/xla/tests/reduce_test.cc
@@ -112,10 +112,7 @@ class ReduceTest : public ClientLibraryTestBase {
     std::unique_ptr<GlobalData> input_global_data =
         client_->TransferToServer(input_literal).ConsumeValueOrDie();
 
-    float expected = 0.0;
-    for (float item : input_data) {
-      expected += item;
-    }
+    float expected = absl::c_accumulate(input_data, 0.0f);
     ComputeAndCompareR0<float>(&builder, expected, {input_global_data.get()},
                                ErrorSpec(0.001));
   }


### PR DESCRIPTION
This PR make the unroll factor per thread dependent of the dtype and the GPU generation.
Idem for the number of threads per blocks.

This give me an 1.82x speed up for float16 and 3x for [u]int8 on V100.
This give me an 1.33x speed up for float16 and 2.39x for [u]int8 on P100.

UPDATE: this PR only contain the change about the unroll factor. The blocks size changes will be moved to another PR.