### PR TITLE
[ROCm] Updating ROCm CI scripts to include large tests

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -2221,6 +2221,7 @@ tf_py_test(
     srcs = ["framework/importer_test.py"],
     main = "framework/importer_test.py",
     python_version = "PY3",
+    tags = ["no_rocm"],
     deps = [
         ":array_ops",
         ":client_testlib",
@@ -5007,6 +5008,7 @@ cuda_py_test(
     srcs = ["ops/nn_fused_batchnorm_test.py"],
     python_version = "PY3",
     shard_count = 24,
+    tags = ["no_rocm"],
     deps = [
         ":array_ops",
         ":client_testlib",

--- a/tensorflow/python/distribute/BUILD
+++ b/tensorflow/python/distribute/BUILD
@@ -1351,7 +1351,7 @@ py_library(
 
 distribute_py_test(
     name = "saved_model_save_load_test",
-    size = "medium",
+    size = "large",
     srcs = ["saved_model_save_load_test.py"],
     full_precision = True,
     main = "saved_model_save_load_test.py",
@@ -1368,7 +1368,7 @@ distribute_py_test(
 
 distribute_py_test(
     name = "keras_save_load_test",
-    size = "medium",
+    size = "large",
     srcs = ["keras_save_load_test.py"],
     full_precision = True,
     main = "keras_save_load_test.py",
@@ -1384,7 +1384,7 @@ distribute_py_test(
 
 distribute_py_test(
     name = "saved_model_mixed_api_test",
-    size = "medium",
+    size = "large",
     srcs = ["saved_model_mixed_api_test.py"],
     full_precision = True,
     main = "saved_model_mixed_api_test.py",

--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -2913,7 +2913,7 @@ cuda_py_test(
 
 cuda_py_test(
     name = "conv_ops_test",
-    size = "medium",
+    size = "large",
     srcs = ["conv_ops_test.py"],
     shard_count = 4,
     tags = [

--- a/tensorflow/tools/ci_build/linux/rocm/run_cc_core.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_cc_core.sh
@@ -42,11 +42,11 @@ bazel test \
       --test_lang_filters=cc \
       --jobs=${N_JOBS} \
       --local_test_jobs=${TF_GPU_COUNT}\
-      --test_timeout 300,450,1200,3600 \
+      --test_timeout 600,900,2400,7200 \
       --build_tests_only \
       --test_output=errors \
       --test_sharding_strategy=disabled \
-      --test_size_filters=small,medium \
+      --test_size_filters=small,medium,large \
       --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute \
       -- \
       //tensorflow/... \

--- a/tensorflow/tools/ci_build/linux/rocm/run_csb_tests.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_csb_tests.sh
@@ -38,12 +38,13 @@ yes "" | $PYTHON_BIN_PATH configure.py
 bazel test \
       --config=rocm \
       -k \
-      --test_tag_filters=gpu,-no_gpu,-no_rocm,-benchmark-test,-no_oss,-oss_serial,-rocm_multi_gpu, \
-      --test_timeout 600,900,2400,7200 \
-      --test_output=errors \
+      --test_tag_filters=gpu,-no_oss,-oss_serial,-no_gpu,-no_rocm,-benchmark-test,-rocm_multi_gpu,-v1only \
       --jobs=${N_JOBS} \
       --local_test_jobs=${TF_GPU_COUNT} \
+      --test_timeout 600,900,2400,7200 \
+      --test_output=errors \
       --test_sharding_strategy=disabled \
+      --test_size_filters=small,medium,large \
       --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute \
       -- \
       //tensorflow/... \

--- a/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
@@ -46,6 +46,7 @@ bazel test \
       --build_tests_only \
       --test_output=errors \
       --test_sharding_strategy=disabled \
+      --test_size_filters=small,medium,large \
       --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute \
       -- \
       //tensorflow/... \

--- a/tensorflow/tools/ci_build/xla/linux/rocm/run_py3.sh
+++ b/tensorflow/tools/ci_build/xla/linux/rocm/run_py3.sh
@@ -47,6 +47,7 @@ bazel test \
       --build_tests_only \
       --test_output=errors \
       --test_sharding_strategy=disabled \
+      --test_size_filters=small,medium,large \
       --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute \
       -- \
       //tensorflow/compiler/... \


### PR DESCRIPTION
This PR updates the ROCm CI scripts to include `large` tests.

On the ROCm platform, the CI scripts run tests with `sharding` disabled, in order to prevent the same test from running more than one subtest concurrently on the same GPU . Note that tests are still run in parallel (with number of tests in parellel == the number of GPUs available on the testing machine), just not on individual GPUs.

Because `sharding` is disabled (and all subtests within a given test execute serially on the GPU), some tests that have a lot of subtests, take much longer to run with the `sharding` disabled. Some of these tests were getting timed out, and need to re-classified as `large` (to raise their timeout limit). 

There does not seem to be a way to conditionally specify the value of the `size` arg (i.e. `large` for ROCm, but `medium` for everybody else), and hence the change to `large` is unconditional.

------

/cc @whchung @chsigg @nvining-work 