### PR TITLE
[ROCm] Workaround for a known CPU/GPU kernel interface args passing bug

### DIFF
--- a/tensorflow/core/kernels/relu_op.cc
+++ b/tensorflow/core/kernels/relu_op.cc
@@ -105,9 +105,7 @@ namespace functor {
   extern template struct Relu6Grad<GPUDevice, T>;                              \
                                                                                \
   template <>                                                                  \
-  void LeakyRelu<GPUDevice, T>::operator()(                                    \
-      const GPUDevice& d, typename TTypes<T>::ConstTensor features, T alpha,   \
-      typename TTypes<T>::Tensor activations);                                 \
+  void LeakyRelu<GPUDevice, T>::operator()(LeakyReluArgs args);                \
   extern template struct LeakyRelu<GPUDevice, T>;                              \
                                                                                \
   template <>                                                                  \

--- a/tensorflow/core/kernels/relu_op.h
+++ b/tensorflow/core/kernels/relu_op.h
@@ -143,8 +143,8 @@ class LeakyReluOp : public UnaryElementWiseOp<T, LeakyReluOp<Device, T>> {
 
   void Operate(OpKernelContext* context, const Tensor& input, Tensor* output) {
     functor::LeakyRelu<Device, T> functor;
-    functor(context->eigen_device<Device>(), input.flat<T>(), alpha_,
-            output->flat<T>());
+    functor({context->eigen_device<Device>(), input.flat<T>(), alpha_,
+             output->flat<T>()});
   }
 
  private:


### PR DESCRIPTION
I am working on submitting an update to Eigen to enable fp16 packet optimization for the ROCm platform. When testing those updates with TF, they result in the manifestation of a known bug in the CPU/GPU kernel interface args passing bug.

Basically the CPU code (`.cc` files) is compiled with an old version of gcc (`v5.4`, i.e. the that comes default with `Ubuntu 16.04`) and the GPU code (`.cu.cc` files) is compiled with HCC (which is clang10 based). This results in the GPU kernel arguments sometimes getting corrupted malformed. We do not have a fix for the issue, short of using a newer gcc version which does not have this "bug".  We have discovered that packing all the arguments within a struct seems to workaround the bug, and that is what this PR does.

----------------

/cc @whchung @chsigg @nvining-work 
