### PR TITLE
tflite: Fix typo of RPI build

### DIFF
--- a/tensorflow/lite/tools/make/targets/rpi_makefile.inc
+++ b/tensorflow/lite/tools/make/targets/rpi_makefile.inc
@@ -55,7 +55,7 @@ ifeq ($(TARGET),rpi)
   endif
 
   LIBS := \
-    -atomic \
+    -latomic \
     -lstdc++ \
     -lpthread \
     -lm \


### PR DESCRIPTION
There was typo on RPI build of TFLite. This PR fixes it.