### PR TITLE
allow Tensors in the RNN state size

### DIFF
--- a/tensorflow/python/keras/layers/recurrent.py
+++ b/tensorflow/python/keras/layers/recurrent.py
@@ -581,9 +581,14 @@ class RNN(Layer):
       # initial_state was passed in call, check compatibility
       self._validate_state_spec(state_size, self.state_spec)
     else:
+      def get_state_spec(dim):
+        if isinstance(dim, ops.Tensor):
+          return dim.shape
+        else:
+          return tensor_shape.as_shape(dim)
       self.state_spec = [
-          InputSpec(shape=[None] + tensor_shape.as_shape(dim).as_list())
-          for dim in state_size
+        InputSpec(shape=[None] + get_state_spec(dim).as_list())
+        for dim in state_size
       ]
     if self.stateful:
       self.reset_states()


### PR DESCRIPTION
Currently, the RNN class does not allow a RNN cell wrapped with an AttentionWrapper, since the `AttentionWrapper.state_size` property produces Tensors for[ two of its sub-states](https://github.com/tensorflow/addons/blob/caa0454578ac276918f7bce73ee62c5e70a8a780/tensorflow_addons/seq2seq/attention_wrapper.py#L1906) (specifically the alignments & alignment_history, whose size is a Tensor calculated as `tf.shape(self.keys)[1]`.
