### PR TITLE
Comments for alternate implementation in Adadelta Paper #36785

### DIFF
--- a/tensorflow/python/keras/optimizer_v2/adadelta.py
+++ b/tensorflow/python/keras/optimizer_v2/adadelta.py
@@ -57,7 +57,8 @@ class Adadelta(optimizer_v2.OptimizerV2):
       ([pdf](http://arxiv.org/pdf/1212.5701v1.pdf))
 
   """
-
+  #def __init__(self, lr=1.0, rho=0.95, epsilon=None, decay=0., **kwargs):
+  #Adadelta function definition as per paper by M.D. Zeiler (https://arxiv.org/pdf/1212.5701.pdf) where epsilon=1e-6and learning rate=1.0
   def __init__(self,
                learning_rate=0.001,
                rho=0.95,


### PR DESCRIPTION
The original implementation of Adadelta by M.D Zeiler (https://arxiv.org/pdf/1212.5701.pdf) had a eta of 1.0 and epsilon of 1e-6 which is not matching with the function mentioned here. Hence commented the original implementation according to paper. Reference Issue #36785