### PR TITLE
Add step argument to SummaryWriter.(set_)as_default.

### DIFF
--- a/tensorflow/python/kernel_tests/summary_ops_test.py
+++ b/tensorflow/python/kernel_tests/summary_ops_test.py
@@ -323,7 +323,7 @@ class SummaryOpsCoreTest(test_util.TensorFlowTestCase):
             summary_ops.set_step(3)
           summary_ops.write('tag', 1.0)
       events = events_from_logdir(logdir)
-      self.assertListEqual([1, 1, 2, 1, 3], [event.step for event in events[1:]])
+      self.assertListEqual([1, 1, 2, 1, 3], [e.step for e in events[1:]])
     finally:
       # Reset to default state for other tests.
       summary_ops.set_step(None)
@@ -345,7 +345,7 @@ class SummaryOpsCoreTest(test_util.TensorFlowTestCase):
             mystep.assign(4)
           summary_ops.write('tag', 1.0)
       events = events_from_logdir(logdir)
-      self.assertListEqual([1, 2, 3, 2, 4], [event.step for event in events[1:]])
+      self.assertListEqual([1, 2, 3, 2, 4], [e.step for e in events[1:]])
     finally:
       # Reset to default state for other tests.
       summary_ops.set_step(None)
@@ -364,7 +364,7 @@ class SummaryOpsCoreTest(test_util.TensorFlowTestCase):
         summary_ops.write('tag', 1.0)
         writer.flush()
       events = events_from_logdir(logdir)
-      self.assertListEqual([1, 2, 3], [event.step for event in events[1:]])
+      self.assertListEqual([1, 2, 3], [e.step for e in events[1:]])
     finally:
       # Reset to default state for other tests.
       summary_ops.set_step(None)
@@ -382,7 +382,7 @@ class SummaryOpsCoreTest(test_util.TensorFlowTestCase):
         summary_ops.write('tag', 1.0)
         writer.flush()
       events = events_from_logdir(logdir)
-      self.assertListEqual([1, 2, 2], [event.step for event in events[1:]])
+      self.assertListEqual([1, 2, 2], [e.step for e in events[1:]])
     finally:
       # Reset to default state for other tests.
       summary_ops.set_step(None)

--- a/tensorflow/python/ops/summary_ops_v2.py
+++ b/tensorflow/python/ops/summary_ops_v2.py
@@ -200,7 +200,15 @@ class SummaryWriter(object):
   def set_as_default(self, step=None):
     """Enables this summary writer for the current thread.
 
-    For the `step` argument, see `tf.summary.experimental.set_step()`.
+    For convenience, if `step` is not None, this function also sets a default
+    value for the `step` parameter used in summary-writing functions elsewhere
+    in the API so that it need not be explicitly passed in every such
+    invocation. The value can be a constant or a variable.
+
+    Note: when setting `step` in a @tf.function, the step value will be
+    captured at the time the function is traced, so changes to the step outside
+    the function will not be reflected inside the function unless using
+    a `tf.Variable` step.
 
     Args:
       step: An `int64`-castable default step value, or `None`.
@@ -214,12 +222,30 @@ class SummaryWriter(object):
   def as_default(self, step=None):
     """Returns a context manager that enables summary writing.
 
-    For the `step` argument, see `tf.summary.experimental.set_step()`.
+    For convenience, if `step` is not None, this function also sets a default
+    value for the `step` parameter used in summary-writing functions elsewhere
+    in the API so that it need not be explicitly passed in every such
+    invocation. The value can be a constant or a variable.
+
+    Note: when setting `step` in a @tf.function, the step value will be
+    captured at the time the function is traced, so changes to the step outside
+    the function will not be reflected inside the function unless using
+    a `tf.Variable` step.
+
+    For example, `step` can be used as:
+
+    ```python
+    with writer_a.as_default(step=10):
+      tf.summary.scalar(tag, value)   # Logged to writer_a with step 10
+      with writer_b.as_default(step=20):
+        tf.summary.scalar(tag, value) # Logged to writer_b with step 20
+      tf.summary.scalar(tag, value)   # Logged to writer_a with step 10
+    ```
 
     Args:
       step: An `int64`-castable default step value, or `None`.
         When not `None`, the current step is captured, replaced by a given one,
-        and the original one is restored when the context manager exists.
+        and the original one is restored when the context manager exits.
         When `None`, the current step is not modified (and not restored
         when the context manager exits).
     """
@@ -264,7 +290,15 @@ class ResourceSummaryWriter(SummaryWriter):
   def set_as_default(self, step=None):
     """Enables this summary writer for the current thread.
 
-    For the `step` argument, see `tf.summary.experimental.set_step()`.
+    For convenience, if `step` is not None, this function also sets a default
+    value for the `step` parameter used in summary-writing functions elsewhere
+    in the API so that it need not be explicitly passed in every such
+    invocation. The value can be a constant or a variable.
+
+    Note: when setting `step` in a @tf.function, the step value will be
+    captured at the time the function is traced, so changes to the step outside
+    the function will not be reflected inside the function unless using
+    a `tf.Variable` step.
 
     Args:
       step: An `int64`-castable default step value, or `None`.
@@ -281,12 +315,30 @@ class ResourceSummaryWriter(SummaryWriter):
   def as_default(self, step=None):
     """Returns a context manager that enables summary writing.
 
-    For the `step` argument, see `tf.summary.experimental.set_step()`.
+    For convenience, if `step` is not None, this function also sets a default
+    value for the `step` parameter used in summary-writing functions elsewhere
+    in the API so that it need not be explicitly passed in every such
+    invocation. The value can be a constant or a variable.
+
+    Note: when setting `step` in a @tf.function, the step value will be
+    captured at the time the function is traced, so changes to the step outside
+    the function will not be reflected inside the function unless using
+    a `tf.Variable` step.
+
+    For example, `step` can be used as:
+
+    ```python
+    with writer_a.as_default(step=10):
+      tf.summary.scalar(tag, value)   # Logged to writer_a with step 10
+      with writer_b.as_default(step=20):
+        tf.summary.scalar(tag, value) # Logged to writer_b with step 20
+      tf.summary.scalar(tag, value)   # Logged to writer_a with step 10
+    ```
 
     Args:
       step: An `int64`-castable default step value, or `None`.
         When not `None`, the current step is captured, replaced by a given one,
-        and the original one is restored when the context manager exists.
+        and the original one is restored when the context manager exits.
         When `None`, the current step is not modified (and not restored
         when the context manager exits).
     """

--- a/tensorflow/tools/api/golden/v2/tensorflow.summary.-summary-writer.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.summary.-summary-writer.pbtxt
@@ -7,7 +7,7 @@ tf_class {
   }
   member_method {
     name: "as_default"
-    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+    argspec: "args=[\'self\', \'step\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
     name: "close"
@@ -23,6 +23,6 @@ tf_class {
   }
   member_method {
     name: "set_as_default"
-    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+    argspec: "args=[\'self\', \'step\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
 }


### PR DESCRIPTION
As a followup to #26406, here is a simple proposed solution which adds `step` argument to `SummaryWriter.as_default` and `SummaryWriter.set_as_default`. The default value is `None` which means the argument is ignored, so the change is backward compatible.

The current code is extremely simple, yet useful. Given lack of response in #26406, I submitted this PR, but I am happy to update it (or scrap it) if a different consensus is reached. For reasons to this change, see #26406.

BTW, the `get_step` and `set_step` methods could be used inside the implementation instead of manual manipulation with `_summary_state`.