### PR TITLE
[TFLite] Fix for the segmentation fault. when quantize CONV_2D with dilation != 1.

### DIFF
--- a/tensorflow/lite/toco/graph_transformations/identify_dilated_conv.cc
+++ b/tensorflow/lite/toco/graph_transformations/identify_dilated_conv.cc
@@ -86,7 +86,7 @@ bool ResolveDilatedConv(Model* model, Operator* conv_base_op, Operator* stb_op,
                            ? GetOpWithInput(*model, post_conv_op->outputs[0])
                            : GetOpWithInput(*model, conv_op->outputs[0]);
   bool has_pad_op = false;
-  if (pad_op->type == OperatorType::kPad) {
+  if (pad_op && pad_op->type == OperatorType::kPad) {
     has_pad_op = true;
     CHECK_EQ(pad_op->inputs.size(), 2);
     CHECK_EQ(pad_op->outputs.size(), 1);
@@ -128,7 +128,7 @@ bool ResolveDilatedConv(Model* model, Operator* conv_base_op, Operator* stb_op,
   if (!has_pad_op) {
     auto* pre_stb_pad_op = GetOpWithOutput(*model, stb_op->inputs[0]);
     // If it is a Pad Op then just rewire the Input of Pad Op with Input of STB
-    if (pre_stb_pad_op->type == OperatorType::kPad) {
+    if (pre_stb_pad_op && pre_stb_pad_op->type == OperatorType::kPad) {
       stb_op->inputs[0] = pre_stb_pad_op->inputs[0];
       has_pad_op = true;
       pad_op = pre_stb_pad_op;


### PR DESCRIPTION
This change fixes the crash "segmentation fault" raised here:
https://github.com/tensorflow/tensorflow/issues/36692
The issue contains the script that reproduces the crash. The crash is in the Python subprocess that has been launched in convert.py, when binary toco_from_proto is called. I listed the script here as well.

I have not added a test, but I am happy to do this - please let me know where it should be added. 

```
import numpy
import tensorflow as tf

import os
print("ID is {}".format(os.getpid()))

def representative_dataset_gen():
    yield [numpy.random.uniform(low=-1, high=1, size=(1,28,28,16)).astype(numpy.float32)]

model=tf.keras.Sequential()
model.add(
    tf.keras.layers.Conv2D(
        filters=16, kernel_size=7, dilation_rate=(2,2), input_shape=(28,28,16),
        use_bias=True, bias_initializer='ones'
    )
)

converter = tf.lite.TFLiteConverter.from_keras_model(model)
converter.optimizations = [tf.lite.Optimize.DEFAULT]
converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]
converter.representative_dataset = representative_dataset_gen
converter.experimental_new_converter = False

tflite_model = converter.convert()

```