### PR TITLE
Add leaky_relu operator property

### DIFF
--- a/tensorflow/lite/tools/optimize/operator_property.cc
+++ b/tensorflow/lite/tools/optimize/operator_property.cc
@@ -792,6 +792,7 @@ OperatorProperty GetOperatorProperty(const ModelT* model, int subgraph_index,
       property.outputs = {{0, {}}};
       property.version = 2;
       break;
+    case BuiltinOperator_LEAKY_RELU:
     case BuiltinOperator_RELU:
     case BuiltinOperator_RELU6:
       property.inputs = {{0, {}}};


### PR DESCRIPTION
Adding Leaky_Relu into operator property, which was missing, although quantized leaky relu was implemented. This resolve the issue: https://github.com/tensorflow/tensorflow/issues/33397