### PR TITLE
[Docs] update mathjax for lbeta

### DIFF
--- a/tensorflow/python/ops/special_math_ops.py
+++ b/tensorflow/python/ops/special_math_ops.py
@@ -51,18 +51,24 @@ from tensorflow.python.util.tf_export import tf_export
 def lbeta(x, name=None):
   r"""Computes \\(ln(|Beta(x)|)\\), reducing along the last dimension.
 
-  Given one-dimensional `z = [z_0,...,z_{K-1}]`, we define
+  Given one-dimensional $z = [z_1,...,z_K]$, we define
 
-  $$Beta(z) = \prod_j Gamma(z_j) / Gamma(\sum_j z_j)$$
+  $$Beta(z) = \frac{\prod_j \Gamma(z_j)}{\Gamma(\sum_j z_j)},$$
 
-  And for `n + 1` dimensional `x` with shape `[N1, ..., Nn, K]`, we define
-  $$lbeta(x)[i1, ..., in] = Log(|Beta(x[i1, ..., in, :])|)$$.
+  where $\Gamma$ is the gamma function.
 
-  In other words, the last dimension is treated as the `z` vector.
+  And for $n + 1$ dimensional $x$ with shape $[N_1, ..., N_n, K]$, we define
 
-  Note that if `z = [u, v]`, then
-  \\(Beta(z) = int_0^1 t^{u-1} (1 - t)^{v-1} dt\\), which defines the
-  traditional bivariate beta function.
+  $$lbeta(x)[i_1, ..., i_n] = \log{|Beta(x[i_1, ..., i_n, :])|}.$$
+
+  In other words, the last dimension is treated as the $z$ vector.
+
+  Note that if $z = [u, v]$, then
+
+  $$Beta(z) = \frac{\Gamma(u)\Gamma(v)}{\Gamma(u + v)}
+    = \int_0^1 t^{u-1} (1 - t)^{v-1} \mathrm{d}t,$$
+
+  which defines the traditional bivariate beta function.
 
   If the last dimension is empty, we follow the convention that the sum over
   the empty set is zero, and the product is one.


### PR DESCRIPTION
This PR fixes some issues in the document of `tf.math.lbeta`, e.g., missing a `\` before `int`. Besides, the style of characters that appear at both interline and inline formulas should be consistent.  