### PR TITLE
Improve performance of NewTensor and Value for string tensors

### DIFF
--- a/tensorflow/go/tensor_test.go
+++ b/tensorflow/go/tensor_test.go
@@ -303,6 +303,7 @@ func BenchmarkTensor(b *testing.B) {
 	// Where input tensors correspond to a 224x224 RGB image
 	// flattened into a vector.
 	var vector [224 * 224 * 3]int32
+	var arrays [100][100][100]int32
 
 	l3 := make([][][]float32, 100)
 	l2 := make([][]float32, 100*100)
@@ -316,6 +317,7 @@ func BenchmarkTensor(b *testing.B) {
 
 	tests := []interface{}{
 		vector,
+		arrays,
 		l1,
 		l2,
 		l3,

--- a/tensorflow/go/tensor_test.go
+++ b/tensorflow/go/tensor_test.go
@@ -18,6 +18,7 @@ package tensorflow
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"reflect"
 	"testing"
@@ -276,6 +277,7 @@ func TestReadTensorReadAll(t *testing.T) {
 }
 
 func benchmarkNewTensor(b *testing.B, v interface{}) {
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		if t, err := NewTensor(v); err != nil || t == nil {
 			b.Fatalf("(%v, %v)", t, err)
@@ -283,32 +285,50 @@ func benchmarkNewTensor(b *testing.B, v interface{}) {
 	}
 }
 
-func BenchmarkNewTensor(b *testing.B) {
-	var (
-		// Some sample sizes from the Inception image labeling model.
-		// Where input tensors correspond to a 224x224 RGB image
-		// flattened into a vector.
-		vector [224 * 224 * 3]int32
-	)
-	b.Run("[150528]", func(b *testing.B) { benchmarkNewTensor(b, vector) })
-}
+func benchmarkValueTensor(b *testing.B, v interface{}) {
+	t, err := NewTensor(v)
+	if err != nil {
+		b.Fatalf("(%v, %v)", t, err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
 
-func benchmarkDecodeTensor(b *testing.B, t *Tensor) {
 	for i := 0; i < b.N; i++ {
 		_ = t.Value()
 	}
 }
 
-func BenchmarkDecodeTensor(b *testing.B) {
-	var (
-		// Some sample sizes from the Inception image labeling model.
-		// Where input tensors correspond to a 224x224 RGB image
-		// flattened into a vector.
-		vector [224 * 224 * 3]int32
-	)
-	t, err := NewTensor(vector)
-	if err != nil {
-		b.Fatalf("(%v, %v)", t, err)
+func BenchmarkTensor(b *testing.B) {
+	// Some sample sizes from the Inception image labeling model.
+	// Where input tensors correspond to a 224x224 RGB image
+	// flattened into a vector.
+	var vector [224 * 224 * 3]int32
+
+	l3 := make([][][]float32, 100)
+	l2 := make([][]float32, 100*100)
+	l1 := make([]float32, 100*100*100)
+	for i := range l2 {
+		l2[i] = l1[i*100 : (i+1)*100]
 	}
-	b.Run("[150528]", func(b *testing.B) { benchmarkDecodeTensor(b, t) })
+	for i := range l3 {
+		l3[i] = l2[i*100 : (i+1)*100]
+	}
+
+	tests := []interface{}{
+		vector,
+		l1,
+		l2,
+		l3,
+	}
+	b.Run("New", func(b *testing.B) {
+		for _, test := range tests {
+			b.Run(fmt.Sprintf("%T", test), func(b *testing.B) { benchmarkNewTensor(b, test) })
+		}
+	})
+	b.Run("Value", func(b *testing.B) {
+		for _, test := range tests {
+			b.Run(fmt.Sprintf("%T", test), func(b *testing.B) { benchmarkValueTensor(b, test) })
+		}
+	})
+
 }

--- a/tensorflow/go/tensor_test.go
+++ b/tensorflow/go/tensor_test.go
@@ -315,12 +315,28 @@ func BenchmarkTensor(b *testing.B) {
 		l3[i] = l2[i*100 : (i+1)*100]
 	}
 
+	s1 := make([]string, 100*100*100)
+	s2 := make([][]string, 100*100)
+	s3 := make([][][]string, 100)
+	for i := range s1 {
+		s1[i] = "cheesit"
+	}
+	for i := range s2 {
+		s2[i] = s1[i*100 : (i+1)*100]
+	}
+	for i := range s3 {
+		s3[i] = s2[i*100 : (i+1)*100]
+	}
+
 	tests := []interface{}{
 		vector,
 		arrays,
 		l1,
 		l2,
 		l3,
+		s1,
+		s2,
+		s3,
 	}
 	b.Run("New", func(b *testing.B) {
 		for _, test := range tests {


### PR DESCRIPTION
- add benchmark to highlight and track the issue
- follows on from a similar improvement for non-string tensors https://github.com/tensorflow/tensorflow/pull/36578
- avoids allocations forced by using encoding/binary
- avoids CGO calls encoding and decoding TF strings. Do this in Go instead.
- avoid allocations for individual slices
Performance improvements are significant

```name                          old time/op    new time/op    delta
Tensor/New/[]string-16           455ms ± 2%      33ms ± 2%   -92.74%  (p=0.001 n=7+7)
Tensor/New/[][]string-16         461ms ± 2%      35ms ± 5%   -92.51%  (p=0.000 n=8+8)
Tensor/New/[][][]string-16       461ms ± 1%      36ms ± 1%   -92.15%  (p=0.000 n=8+7)
Tensor/Value/[]string-16         289ms ± 1%      21ms ± 2%   -92.77%  (p=0.000 n=7+8)
Tensor/Value/[][]string-16       292ms ± 1%      21ms ± 2%   -92.89%  (p=0.000 n=8+8)
Tensor/Value/[][][]string-16     295ms ± 4%      21ms ± 1%   -92.92%  (p=0.001 n=8+6)

name                          old alloc/op   new alloc/op   delta
Tensor/New/[]string-16          48.0MB ± 0%     0.0MB ± 0%  -100.00%  (p=0.002 n=7+8)
Tensor/New/[][]string-16        48.3MB ± 0%     0.0MB ± 0%  -100.00%  (p=0.000 n=7+8)
Tensor/New/[][][]string-16      48.3MB ± 0%     0.0MB ± 0%  -100.00%  (p=0.000 n=8+8)
Tensor/Value/[]string-16        72.0MB ± 0%    23.0MB ± 0%   -68.04%  (p=0.001 n=6+7)
Tensor/Value/[][]string-16      74.5MB ± 0%    23.3MB ± 0%   -68.78%  (p=0.001 n=7+7)
Tensor/Value/[][][]string-16    74.5MB ± 0%    23.3MB ± 0%   -68.78%  (p=0.001 n=7+7)

name                          old allocs/op  new allocs/op  delta
Tensor/New/[]string-16           4.00M ± 0%     0.00M ± 0%  -100.00%  (p=0.000 n=8+8)
Tensor/New/[][]string-16         4.01M ± 0%     0.00M ± 0%  -100.00%  (p=0.002 n=7+8)
Tensor/New/[][][]string-16       4.01M ± 0%     0.00M ± 0%  -100.00%  (p=0.000 n=8+8)
Tensor/Value/[]string-16         6.00M ± 0%     0.00M ± 0%  -100.00%  (p=0.000 n=8+8)
Tensor/Value/[][]string-16       6.02M ± 0%     0.00M ± 0%  -100.00%  (p=0.000 n=8+8)
Tensor/Value/[][][]string-16     6.02M ± 0%     0.00M ± 0%  -100.00%  (p=0.000 n=8+8)```