### PR TITLE
[TFLite 16x8] Small tidy up for FULLY_CONNECTED operator.

### DIFF
--- a/tensorflow/lite/kernels/fully_connected.cc
+++ b/tensorflow/lite/kernels/fully_connected.cc
@@ -195,6 +195,11 @@ TfLiteStatus PrepareImpl(TfLiteContext* context, TfLiteNode* node) {
         &data->output_activation_max));
   }
 
+  if (input->type == kTfLiteInt16 && output->type == kTfLiteInt16) {
+    TF_LITE_ENSURE_EQ(context, input->params.zero_point, 0);
+    TF_LITE_ENSURE_EQ(context, output->params.zero_point, 0);
+  }
+
   // If we have to perform on-the-fly quantization (with quantized weights and
   // float inputs) first we need to quantize the inputs. Allocate a temporary
   // buffer to store the intermediate quantized values.
@@ -432,9 +437,7 @@ void FullyConnectedInt16(const OpData* data, const TfLiteTensor* input,
                          const TfLiteTensor* filter, const TfLiteTensor* bias,
                          TfLiteTensor* output) {
   FullyConnectedParams op_params;
-  op_params.input_offset = -input->params.zero_point;
   op_params.weights_offset = -filter->params.zero_point;
-  op_params.output_offset = output->params.zero_point;
   op_params.output_multiplier = data->output_multiplier;
   op_params.output_shift = data->output_shift;
   op_params.quantized_activation_min = data->output_activation_min;

--- a/tensorflow/lite/kernels/fully_connected_test.cc
+++ b/tensorflow/lite/kernels/fully_connected_test.cc
@@ -540,11 +540,11 @@ TEST_P(QuantizedFullyConnectedOpTest, SimpleTestQuantizedInt8) {
 }
 
 TEST_P(QuantizedFullyConnectedOpTest, SimpleTestQuantizedInt16) {
-  const float ulp = (float)1 / (float)512;
+  const float scale = 128.0 / 65536;
   QuantizedFullyConnectedOpModel m(
       GetRegistration(), /*units=*/3, /*batches*/ 2,
-      /*input=*/{TensorType_INT16, {2, 10}, -64 + ulp, 64},
-      /*output=*/{TensorType_INT16, {}, -128 + 2 * ulp, 128});
+      /*input=*/{TensorType_INT16, {2, 10}, 0, 0, scale, 0},
+      /*output=*/{TensorType_INT16, {}, 0, 0, scale, 0});
 
   // input_product_scale < output_scale was not true.
   m.SetWeights<int8_t>({
@@ -564,8 +564,7 @@ TEST_P(QuantizedFullyConnectedOpTest, SimpleTestQuantizedInt16) {
   EXPECT_THAT(m.GetDequantizedOutput<int16_t>(),
               ElementsAreArray(ArrayFloatNear({24, 25, 26, 58, 59, 60})));
   EXPECT_THAT(m.GetOutput<int16_t>(),
-              ElementsAre(24 * 256 - 1, 25 * 256 - 1, 26 * 256 - 1,
-                          58 * 256 - 1, 59 * 256 - 1, 60 * 256 - 1));
+              ElementsAre(12288, 12800, 13312, 29696, 30208, 30720));
 }
 
 TEST_P(QuantizedFullyConnectedOpTest, SimpleTestQuantizedInt8NoBias) {

--- a/tensorflow/lite/kernels/internal/reference/integer_ops/fully_connected.h
+++ b/tensorflow/lite/kernels/internal/reference/integer_ops/fully_connected.h
@@ -68,9 +68,7 @@ inline void FullyConnected(
     const int8_t* filter_data, const RuntimeShape& bias_shape,
     const int64_t* bias_data, const RuntimeShape& output_shape,
     int16_t* output_data) {
-  const int32 input_offset = params.input_offset;
   const int32 filter_offset = params.weights_offset;
-  const int32 output_offset = params.output_offset;
   const int32 output_multiplier = params.output_multiplier;
   const int output_shift = params.output_shift;
   const int32 output_activation_min = params.quantized_activation_min;
@@ -90,14 +88,13 @@ inline void FullyConnected(
       for (int d = 0; d < accum_depth; ++d) {
         int32 input_val = input_data[b * accum_depth + d];
         int32 filter_val = filter_data[out_c * accum_depth + d];
-        acc += (filter_val + filter_offset) * (input_val + input_offset);
+        acc += (filter_val + filter_offset) * input_val;
       }
       if (bias_data) {
         acc += bias_data[out_c];
       }
       int32_t acc_scaled =
           MultiplyByQuantizedMultiplier(acc, output_multiplier, output_shift);
-      acc_scaled += output_offset;
       acc_scaled = std::max(acc_scaled, output_activation_min);
       acc_scaled = std::min(acc_scaled, output_activation_max);
       output_data[out_c + output_depth * b] = static_cast<int16_t>(acc_scaled);


### PR DESCRIPTION
This is a small tidy up for the operator FULLY_CONNECTED that has been merged [here](https://github.com/tensorflow/tensorflow/pull/36131).
In case of 16-bit activations zero_point is zero.
I check this here and remove from the kernel.