### PR TITLE
TFLite: static library: fix benchmark build issue

### DIFF
--- a/tensorflow/lite/tools/make/Makefile
+++ b/tensorflow/lite/tools/make/Makefile
@@ -109,6 +109,7 @@ PROFILER_SRCS := \
 
 PROFILE_SUMMARIZER_SRCS := \
 	tensorflow/lite/profiling/profile_summarizer.cc \
+	tensorflow/lite/profiling/profile_summary_formatter.cc \
 	tensorflow/core/util/stats_calculator.cc
 
 CMD_LINE_TOOLS_SRCS := \


### PR DESCRIPTION
Since the commit ee7642b2670e33a45cc3a6f6585cfab7f7d4f8f6, the benchmark
application is no more building due to the fact that some functions have
been moved.
Add profile_summary_formatter.cc in the PROFILE_SUMMARIZER_SRCS.
