### PR TITLE
[XLA:GPU][ROCm]Fixing address space cast in reduction epilog

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -2346,7 +2346,9 @@ void IrEmitterUnnested::EmitEpilogueForReduction(
               shared_cache,
               {b_.getInt32(0), constant(j), thread_id_info.lane_id}));
           llvm::Value* initial_value = reduction_info.GetInitialValues()[i];
-          llvm::Value* initial_value_addr = b_.CreateAlloca(element_type);
+          llvm::Value* initial_value_addr =
+              shared_to_global(llvm_ir::EmitAllocaAtFunctionEntry(
+                  element_type, "initial_value_addr", &b_));
           b_.CreateStore(initial_value, initial_value_addr);
 
           llvm::Value* warp_exists = b_.CreateICmpULT(


### PR DESCRIPTION
Introduced by commit 0c3feb1. 10+ regressions in the unit test that complained below:

> Internal: RET_CHECK failure (tensorflow/compiler/xla/service/gpu/gpu_compiler.cc:425) !llvm::verifyModule(llvm_module, &err_stream) Invalid LLVM IR before optimizations:
Invalid operands for select instruction!
  %635 = select i1 %634, float* %632, float addrspace(5)* %633

This CL does two things:
- Make sure there is a address space cast for the newly allocated local, by `shared_to_global` helper function
- Make sure the allocation happens at function entry

/cc: @whchung 