### PR TITLE
optimizer_v2: Improve error when called in cross-replica context

### DIFF
--- a/tensorflow/python/keras/distribute/distribute_strategy_test.py
+++ b/tensorflow/python/keras/distribute/distribute_strategy_test.py
@@ -544,7 +544,7 @@ class TestDistributionStrategyWithNumpyArrays(test.TestCase,
       self.assertIsNotNone(grad_v2)
 
   @combinations.generate(combinations.combine(
-      distribution=strategies_minus_default_minus_tpu + tpu_strategies,
+      distribution=[strategy_combinations.one_device_strategy] + tpu_strategies,
       mode=['graph', 'eager']))
   def test_optimizer_in_cross_replica_context_raises_error(self, distribution):
 

--- a/tensorflow/python/keras/distribute/distribute_strategy_test.py
+++ b/tensorflow/python/keras/distribute/distribute_strategy_test.py
@@ -543,6 +543,23 @@ class TestDistributionStrategyWithNumpyArrays(test.TestCase,
       self.assertIsNotNone(grad_v1)
       self.assertIsNotNone(grad_v2)
 
+  @combinations.generate(combinations.combine(
+      distribution=strategies_minus_default_minus_tpu + tpu_strategies,
+      mode=['graph', 'eager']))
+  def test_optimizer_in_cross_replica_context_raises_error(self, distribution):
+
+    with self.cached_session(), distribution.scope():
+      model = keras.models.Sequential([keras.layers.Dense(1)])
+      x = np.array([[1.]])
+      with backprop.GradientTape() as tape:
+        y = model(x)
+      gradients = tape.gradient(y, model.trainable_variables)
+      optimizer = gradient_descent_keras.SGD()
+
+      with self.assertRaisesRegex(
+          RuntimeError, "cannot be called in cross-replica context"):
+        optimizer.apply_gradients(zip(gradients, model.trainable_variables))
+
   @combinations.generate(all_strategy_combinations_plus_run_distributed())
   def test_calling_model_with_nested_numpy_arrays(self, distribution,
                                                   experimental_run_tf_function):

--- a/tensorflow/python/keras/optimizer_v2/optimizer_v2.py
+++ b/tensorflow/python/keras/optimizer_v2/optimizer_v2.py
@@ -437,6 +437,13 @@ class OptimizerV2(trackable.Trackable):
         # Distribution strategy does not support reducing an empty list of
         # gradients
         return control_flow_ops.no_op()
+
+      if distribute_ctx.in_cross_replica_context():
+        raise RuntimeError(
+            "`apply_gradients() cannot be called in cross-replica context. "
+            "Use `_distributed_apply()` instead or enter replica context "
+            "by using `tf.distribute.Strategy.experimental_run_v2`.")
+
       apply_state = self._prepare(var_list)
       return distribute_ctx.get_replica_context().merge_call(
           functools.partial(self._distributed_apply, apply_state=apply_state),

--- a/tensorflow/python/keras/optimizer_v2/optimizer_v2.py
+++ b/tensorflow/python/keras/optimizer_v2/optimizer_v2.py
@@ -441,8 +441,8 @@ class OptimizerV2(trackable.Trackable):
       if distribute_ctx.in_cross_replica_context():
         raise RuntimeError(
             "`apply_gradients() cannot be called in cross-replica context. "
-            "Use `_distributed_apply()` instead or enter replica context "
-            "by using `tf.distribute.Strategy.experimental_run_v2`.")
+            "Use `tf.distribute.Strategy.experimental_run_v2` to enter replica "
+            "context.")
 
       apply_state = self._prepare(var_list)
       return distribute_ctx.get_replica_context().merge_call(


### PR DESCRIPTION
When calling `Optimizer.apply_gradients()` in a cross-replica distribution context
(with a non-default distribution strategy), `distribute_ctx.get_replica_context()`
returns `None`, so it would fail with the error

    [...]/optimizer_v2.py", line 448, in apply_gradients
        return distribute_ctx.get_replica_context().merge_call(
    AttributeError: 'NoneType' object has no attribute 'merge_call'

This commit changes the error to a `RuntimeError` with a more descriptive error
message guiding the user towards `tf.distribute.Strategy.experimental_run_v2`.