### PR TITLE
Added example of from_tensors and from_tensor_slices

### DIFF
--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -534,13 +534,12 @@ class DatasetV2(tracking_base.Trackable, composite_tensor.CompositeTensor):
     >>> list(dataset.as_numpy_iterator())
     [(array([1, 2, 3], dtype=int32), b'A')]
 
-    >>> # `from_tensors` adds one more dimension to the shape
-    >>> # use `from_tensor_slices` to merge the input tensor.
-    >>> dataset = tf.data.Dataset.from_tensors(
-            [tf.random_uniform([2, 3]), tf.random_uniform([2, 3])]
-        )
-    >>> list(dataset.as_numpy_iterator())[0].shape
-    (2, 2, 3)
+    >>> # `from_tensors` does not change the shape of input tensor.
+    >>> # use `from_tensor_slices` to slice the input tensor.
+    >>> example = tf.constant([1,2,3])
+    >>> dataset = tf.data.Dataset.from_tensors(example).repeat(1000)
+    >>> np.array(list(dataset1.as_numpy_iterator())).shape
+    (1000, 3)
 
     Note that if `tensors` contains a NumPy array, and eager execution is not
     enabled, the values will be embedded in the graph as one or more
@@ -619,13 +618,12 @@ class DatasetV2(tracking_base.Trackable, composite_tensor.CompositeTensor):
            [3, 2]], dtype=int32), array([[b'A'],
            [b'B']], dtype=object))
 
-    >>> # `from_tensor_slices` merges the input tensor, unlike `from_tensors`
-    >>> # which increases dimensionality.
-    >>> dataset = tf.data.Dataset.from_tensor_slices(
-            [tf.random.uniform([2, 3]), tf.random.uniform([2, 3])]
-        )
-    >>> list(dataset.as_numpy_iterator())[0].shape
-    (2, 3)
+    >>> # `from_tensor_slices` slices the input tensor,
+    >>> # unlike `from_tensors` which retains the shape of input tensor.
+    >>> example = tf.constant([1,2,3])
+    >>> dataset = tf.data.Dataset.from_tensor_slices(example).repeat(1000)
+    >>> np.array(list(dataset1.as_numpy_iterator())).shape
+    (3000,)
 
     Note that if `tensors` contains a NumPy array, and eager execution is not
     enabled, the values will be embedded in the graph as one or more

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -621,14 +621,6 @@ class DatasetV2(tracking_base.Trackable, composite_tensor.CompositeTensor):
            [3, 2]], dtype=int32), array([[b'A'],
            [b'B']], dtype=object))
 
-    >>> # `from_tensor_slices` can also be used to repeat the examples
-    >>> # in the data. But it doesn't repeat the whole tensor like `from_tensors`,
-    >>> # instead it repeats the individual elements (slices) from the example.
-    >>> example = tf.constant([1,2,3])
-    >>> dataset = tf.data.Dataset.from_tensor_slices(example).repeat(2)
-    >>> list(dataset1.as_numpy_iterator())
-    [1, 2, 3, 1, 2, 3]
-
     Note that if `tensors` contains a NumPy array, and eager execution is not
     enabled, the values will be embedded in the graph as one or more
     `tf.constant` operations. For large datasets (> 1 GB), this can waste

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -527,6 +527,9 @@ class DatasetV2(tracking_base.Trackable, composite_tensor.CompositeTensor):
   def from_tensors(tensors):
     """Creates a `Dataset` with a single element, comprising the given tensors.
 
+    `from_tensors` produces a dataset containing only a single element. To slice
+    the input tensor into multiple elements, use `from_tensor_slices` instead.
+
     >>> dataset = tf.data.Dataset.from_tensors([1, 2, 3])
     >>> list(dataset.as_numpy_iterator())
     [array([1, 2, 3], dtype=int32)]
@@ -534,12 +537,12 @@ class DatasetV2(tracking_base.Trackable, composite_tensor.CompositeTensor):
     >>> list(dataset.as_numpy_iterator())
     [(array([1, 2, 3], dtype=int32), b'A')]
 
-    >>> # `from_tensors` does not change the shape of input tensor.
-    >>> # use `from_tensor_slices` to slice the input tensor.
+    >>> # You can use `from_tensors` to produce a dataset which repeats
+    >>> # the same example many times.
     >>> example = tf.constant([1,2,3])
-    >>> dataset = tf.data.Dataset.from_tensors(example).repeat(1000)
-    >>> np.array(list(dataset1.as_numpy_iterator())).shape
-    (1000, 3)
+    >>> dataset = tf.data.Dataset.from_tensors(example).repeat(2)
+    >>> list(dataset1.as_numpy_iterator())
+    [array([1, 2, 3], dtype=int32), array([1, 2, 3], dtype=int32)]
 
     Note that if `tensors` contains a NumPy array, and eager execution is not
     enabled, the values will be embedded in the graph as one or more
@@ -618,12 +621,13 @@ class DatasetV2(tracking_base.Trackable, composite_tensor.CompositeTensor):
            [3, 2]], dtype=int32), array([[b'A'],
            [b'B']], dtype=object))
 
-    >>> # `from_tensor_slices` slices the input tensor,
-    >>> # unlike `from_tensors` which retains the shape of input tensor.
+    >>> # `from_tensor_slices` can also be used to repeat the examples
+    >>> # in the data. But it doesn't repeat the whole tensor like `from_tensors`,
+    >>> # instead it repeats the individual elements (slices) from the example.
     >>> example = tf.constant([1,2,3])
-    >>> dataset = tf.data.Dataset.from_tensor_slices(example).repeat(1000)
-    >>> np.array(list(dataset1.as_numpy_iterator())).shape
-    (3000,)
+    >>> dataset = tf.data.Dataset.from_tensor_slices(example).repeat(2)
+    >>> list(dataset1.as_numpy_iterator())
+    [1, 2, 3, 1, 2, 3]
 
     Note that if `tensors` contains a NumPy array, and eager execution is not
     enabled, the values will be embedded in the graph as one or more

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -534,8 +534,8 @@ class DatasetV2(tracking_base.Trackable, composite_tensor.CompositeTensor):
     >>> list(dataset.as_numpy_iterator())
     [(array([1, 2, 3], dtype=int32), b'A')]
 
-    >>> # `from_tensors` creates 3D tensor in below example
-    >>> # unlike `from_tensor_slices` which merges the input tensor.
+    >>> # `from_tensors` adds one more dimension to the shape
+    >>> # use `from_tensor_slices` to merge the input tensor.
     >>> dataset = tf.data.Dataset.from_tensors([tf.random_uniform([2, 3]),
                                                tf.random_uniform([2, 3])])
     >>> list(dataset.as_numpy_iterator())[0].shape
@@ -618,8 +618,8 @@ class DatasetV2(tracking_base.Trackable, composite_tensor.CompositeTensor):
            [3, 2]], dtype=int32), array([[b'A'],
            [b'B']], dtype=object))
 
-    >>> # `from_tensor_slices` merges the input tensor 
-    >>> # unlike `from_tensors` which will create 3D tensor in below example.
+    >>> # `from_tensor_slices` merges the input tensor, unlike `from_tensors`
+    >>> # which increases dimensionality.
     >>> dataset = tf.data.Dataset.from_tensor_slices([tf.random.uniform([2, 3]),
                                                      tf.random.uniform([2, 3])])
     >>> list(dataset.as_numpy_iterator())[0].shape

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -541,7 +541,7 @@ class DatasetV2(tracking_base.Trackable, composite_tensor.CompositeTensor):
     >>> # the same example many times.
     >>> example = tf.constant([1,2,3])
     >>> dataset = tf.data.Dataset.from_tensors(example).repeat(2)
-    >>> list(dataset1.as_numpy_iterator())
+    >>> list(dataset.as_numpy_iterator())
     [array([1, 2, 3], dtype=int32), array([1, 2, 3], dtype=int32)]
 
     Note that if `tensors` contains a NumPy array, and eager execution is not

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -536,8 +536,9 @@ class DatasetV2(tracking_base.Trackable, composite_tensor.CompositeTensor):
 
     >>> # `from_tensors` adds one more dimension to the shape
     >>> # use `from_tensor_slices` to merge the input tensor.
-    >>> dataset = tf.data.Dataset.from_tensors([tf.random_uniform([2, 3]),
-                                               tf.random_uniform([2, 3])])
+    >>> dataset = tf.data.Dataset.from_tensors(
+            [tf.random_uniform([2, 3]), tf.random_uniform([2, 3])]
+        )
     >>> list(dataset.as_numpy_iterator())[0].shape
     (2, 2, 3)
 
@@ -620,8 +621,9 @@ class DatasetV2(tracking_base.Trackable, composite_tensor.CompositeTensor):
 
     >>> # `from_tensor_slices` merges the input tensor, unlike `from_tensors`
     >>> # which increases dimensionality.
-    >>> dataset = tf.data.Dataset.from_tensor_slices([tf.random.uniform([2, 3]),
-                                                     tf.random.uniform([2, 3])])
+    >>> dataset = tf.data.Dataset.from_tensor_slices(
+            [tf.random.uniform([2, 3]), tf.random.uniform([2, 3])]
+        )
     >>> list(dataset.as_numpy_iterator())[0].shape
     (2, 3)
 

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -534,6 +534,13 @@ class DatasetV2(tracking_base.Trackable, composite_tensor.CompositeTensor):
     >>> list(dataset.as_numpy_iterator())
     [(array([1, 2, 3], dtype=int32), b'A')]
 
+    >>> # `from_tensors` creates 3D tensor in below example
+    >>> # unlike `from_tensor_slices` which merges the input tensor.
+    >>> dataset = tf.data.Dataset.from_tensors([tf.random_uniform([2, 3]),
+                                               tf.random_uniform([2, 3])])
+    >>> list(dataset.as_numpy_iterator())[0].shape
+    (2, 2, 3)
+
     Note that if `tensors` contains a NumPy array, and eager execution is not
     enabled, the values will be embedded in the graph as one or more
     `tf.constant` operations. For large datasets (> 1 GB), this can waste
@@ -610,6 +617,13 @@ class DatasetV2(tracking_base.Trackable, composite_tensor.CompositeTensor):
     (array([[3, 3],
            [3, 2]], dtype=int32), array([[b'A'],
            [b'B']], dtype=object))
+
+    >>> # `from_tensor_slices` merges the input tensor 
+    >>> # unlike `from_tensors` which will create 3D tensor in below example.
+    >>> dataset = tf.data.Dataset.from_tensor_slices([tf.random.uniform([2, 3]),
+                                                     tf.random.uniform([2, 3])])
+    >>> list(dataset.as_numpy_iterator())[0].shape
+    (2, 3)
 
     Note that if `tensors` contains a NumPy array, and eager execution is not
     enabled, the values will be embedded in the graph as one or more


### PR DESCRIPTION
Added very important examples which differentiates `from_tensors` and `from_tensor_slices` in Dataset. The example describes the property of `from_tensor_slices` to merge the input tensor. In case of `from_tensors`, it doesn't merge input tensor.