### PR TITLE
Add checking of kwonlyargs in keras has_arg

### DIFF
--- a/tensorflow/python/keras/utils/generic_utils.py
+++ b/tensorflow/python/keras/utils/generic_utils.py
@@ -476,7 +476,7 @@ def has_arg(fn, name, accept_all=False):
   arg_spec = tf_inspect.getfullargspec(fn)
   if accept_all and arg_spec.varkw is not None:
     return True
-  return name in arg_spec.args
+  return name in arg_spec.args or name in arg_spec.kwonlyargs
 
 
 @keras_export('keras.utils.Progbar')

--- a/tensorflow/python/keras/utils/generic_utils_test.py
+++ b/tensorflow/python/keras/utils/generic_utils_test.py
@@ -18,6 +18,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from functools import partial
+
 import numpy as np
 
 from tensorflow.python import keras
@@ -38,6 +40,11 @@ class HasArgTest(test.TestCase):
     def f_x_kwargs(x, **kwargs):
       _ = kwargs
       return x
+    
+    def f(a, b, c):
+      return a + b + c
+
+    partial_f = partial(f, b=1)
 
     self.assertTrue(keras.utils.generic_utils.has_arg(
         f_x, 'x', accept_all=False))
@@ -53,6 +60,8 @@ class HasArgTest(test.TestCase):
         f_x_kwargs, 'y', accept_all=False))
     self.assertTrue(keras.utils.generic_utils.has_arg(
         f_x_kwargs, 'y', accept_all=True))
+    self.assertTrue(keras.utils.generic_utils.has_arg(
+        partial_f, 'c', accept_all=True))
 
 
 class TestCustomObjectScope(test.TestCase):


### PR DESCRIPTION
I ran into an issue with `tensorflow.keras.utils.generic_utils.has_arg` when using in conjunction with `functools.partial`. Minimum reproducible example:
```python3
from functools import partial

from tensorflow.python.keras.utils.generic_utils import has_arg


def f(a, b, c):
      return a + b + c

partial_f = partial(f, b=1)

assert has_arg(partial_f, 'c', accept_all=True)
```

I would expect `c` to be in the args, even though it has been converted to a keyword-only argument by partial due to its position after a keyword argument (`b`). It appears that `has_arg` does not check keyword-only arguments. I'm assuming this is not by design but rather a bug, based on what I see in keras-team/keras#7035. I'm submitting this PR as a tentative fix, and I added the above code snippet to the tests. There are much more extensive tests in `tensorflow/tensorflow/python/util/tf_inspect_test.py`; it might be worth checking some of the edge cases there in `has_arg` tests (for a future PR).