### PR TITLE
[TfLite] SPLIT_V quantization support for int8

### DIFF
--- a/tensorflow/lite/kernels/register.cc
+++ b/tensorflow/lite/kernels/register.cc
@@ -152,7 +152,9 @@ BuiltinOpResolver::BuiltinOpResolver() {
              /* max_version */ 2);
   AddBuiltin(BuiltinOperator_SPLIT, Register_SPLIT(), /* min_version */ 1,
              /* max_version */ 3);
-  AddBuiltin(BuiltinOperator_SPLIT_V, Register_SPLIT_V());
+  AddBuiltin(BuiltinOperator_SPLIT_V, Register_SPLIT_V(),
+            /* min_version */ 1,
+            /* max_version */ 2);
   AddBuiltin(BuiltinOperator_SQUEEZE, Register_SQUEEZE());
   AddBuiltin(BuiltinOperator_STRIDED_SLICE, Register_STRIDED_SLICE(),
              /* min_version */ 1,

--- a/tensorflow/lite/kernels/split_v.cc
+++ b/tensorflow/lite/kernels/split_v.cc
@@ -128,7 +128,7 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE(context,
                  input_type == kTfLiteFloat32 || input_type == kTfLiteUInt8 ||
                      input_type == kTfLiteInt16 || input_type == kTfLiteInt32 ||
-                     input_type == kTfLiteInt64);
+                     input_type == kTfLiteInt64 || input_type == kTfLiteInt8);
   for (int i = 0; i < NumOutputs(node); ++i) {
     GetOutput(context, node, i)->type = input_type;
   }
@@ -190,6 +190,10 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
     }
     case kTfLiteInt64: {
       TF_LITE_SPLIT_V(int64_t);
+      break;
+    }
+    case kTfLiteInt8: {
+      TF_LITE_SPLIT_V(int8_t);
       break;
     }
     default:

--- a/tensorflow/lite/kernels/split_v_test.cc
+++ b/tensorflow/lite/kernels/split_v_test.cc
@@ -12,8 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-#include <initializer_list>
 #include <gtest/gtest.h>
+#include <initializer_list>
 #include "tensorflow/lite/interpreter.h"
 #include "tensorflow/lite/kernels/register.h"
 #include "tensorflow/lite/kernels/test_util.h"
@@ -72,7 +72,7 @@ class SplitVOpModel : public SingleOpModel {
   std::vector<int> outputs_;
 };
 
-template <typename T, TensorType T1>
+template <typename T>
 void Check(int axis, std::initializer_list<int> input_shape,
            std::initializer_list<int> size_splits_shape,
            std::vector<std::initializer_list<int>> output_shapes,
@@ -80,8 +80,9 @@ void Check(int axis, std::initializer_list<int> input_shape,
            const std::initializer_list<int>& size_splits_data,
            const std::vector<std::initializer_list<T>>& output_data) {
   int num_splits = size_splits_data.size();
-  SplitVOpModel m({T1, input_shape}, {TensorType_INT32, size_splits_shape},
-                  num_splits, kAxisIsATensor);
+  SplitVOpModel m({GetTensorType<T>(), input_shape},
+                  {TensorType_INT32, size_splits_shape}, num_splits,
+                  kAxisIsATensor);
   m.SetInput<T>(input_data);
   m.SetSizeSplits(size_splits_data);
   m.SetAxis(axis);
@@ -91,7 +92,7 @@ void Check(int axis, std::initializer_list<int> input_shape,
     EXPECT_THAT(m.GetOutputShape(i), ElementsAreArray(output_shapes[i]));
   }
 
-  SplitVOpModel const_m({T1, input_shape},
+  SplitVOpModel const_m({GetTensorType<T>(), input_shape},
                         {TensorType_INT32, size_splits_shape}, num_splits,
                         axis);
   const_m.SetInput<T>(input_data);
@@ -103,7 +104,13 @@ void Check(int axis, std::initializer_list<int> input_shape,
   }
 }
 
-TEST(SplitVOpTest, TwoDimensional) {
+template <typename T>
+class SplitVOpTypedTest : public ::testing::Test {};
+
+using DataTypes = ::testing::Types<float, uint8_t, int8_t, int16_t, int32_t>;
+TYPED_TEST_SUITE(SplitVOpTypedTest, DataTypes);
+
+TYPED_TEST(SplitVOpTypedTest, TwoDimensional) {
   // Input shape: {4, 3}
   // size_splits: {1, 1, 2}
   // axis: 0
@@ -111,35 +118,35 @@ TEST(SplitVOpTest, TwoDimensional) {
   //  output 1 : {1, 3}
   //  output 2 : {1, 3}
   //  output 3 : {2, 3}
-  Check<float, TensorType_FLOAT32>(
+  Check<TypeParam>(
       /*axis=*/0, {4, 3}, {3}, {{1, 3}, {1, 3}, {2, 3}},
       {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}, {1, 1, 2},
       {{1, 2, 3}, {4, 5, 6}, {7, 8, 9, 10, 11, 12}});
 }
 
-TEST(SplitVOpTest, FourDimensional) {
-  Check<float, TensorType_FLOAT32>(
+TYPED_TEST(SplitVOpTypedTest, FourDimensional) {
+  Check<TypeParam>(
       /*axis=*/0, {2, 2, 2, 2}, {2}, {{1, 2, 2, 2}, {1, 2, 2, 2}},
       {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}, {1, 1},
       {
           {1, 2, 3, 4, 5, 6, 7, 8},
           {9, 10, 11, 12, 13, 14, 15, 16},
       });
-  Check<float, TensorType_FLOAT32>(
+  Check<TypeParam>(
       /*axis=*/1, {2, 2, 2, 2}, {2}, {{2, 1, 2, 2}, {2, 1, 2, 2}},
       {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}, {1, -1},
       {
           {1, 2, 3, 4, 9, 10, 11, 12},
           {5, 6, 7, 8, 13, 14, 15, 16},
       });
-  Check<float, TensorType_FLOAT32>(
+  Check<TypeParam>(
       /*axis=*/2, {2, 2, 2, 2}, {2}, {{2, 2, 1, 2}, {2, 2, 1, 2}},
       {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}, {1, 1},
       {
           {1, 2, 5, 6, 9, 10, 13, 14},
           {3, 4, 7, 8, 11, 12, 15, 16},
       });
-  Check<float, TensorType_FLOAT32>(
+  Check<TypeParam>(
       /*axis=*/3, {2, 2, 2, 2}, {2}, {{2, 2, 2, 1}, {2, 2, 2, 1}},
       {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}, {1, 1},
       {
@@ -148,84 +155,28 @@ TEST(SplitVOpTest, FourDimensional) {
       });
 }
 
-TEST(SplitVOpTest, OneDimensional) {
-  Check<float, TensorType_FLOAT32>(
+TYPED_TEST(SplitVOpTypedTest, OneDimensional) {
+  Check<TypeParam>(
       /*axis=*/0, {8}, {8}, {{1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}},
       {1, 2, 3, 4, 5, 6, 7, 8}, {1, 1, 1, 1, 1, 1, 1, 1},
       {{1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}});
 }
 
-TEST(SplitVOpTest, OneDimensional2) {
-  Check<float, TensorType_FLOAT32>(
+TYPED_TEST(SplitVOpTypedTest, OneDimensional2) {
+  Check<TypeParam>(
       /*axis=*/0, {8}, {8}, {{1}, {1}, {1}, {1}, {1}, {1}, {2}, {0}},
       {1, 2, 3, 4, 5, 6, 7, 8}, {1, 1, 1, 1, 1, 1, 2, -1},
       {{1}, {2}, {3}, {4}, {5}, {6}, {7, 8}, {}});
 }
 
-TEST(SplitVOpTest, NegativeAxis) {
-  Check<float, TensorType_FLOAT32>(
+TYPED_TEST(SplitVOpTypedTest, NegativeAxis) {
+  Check<TypeParam>(
       /*axis=*/-4, {2, 2, 2, 2}, {2}, {{1, 2, 2, 2}, {1, 2, 2, 2}},
       {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}, {1, 1},
       {
           {1, 2, 3, 4, 5, 6, 7, 8},
           {9, 10, 11, 12, 13, 14, 15, 16},
       });
-}
-
-TEST(SplitVOpTest, TwoDimensionalUint8) {
-  // Input shape: {4, 3}
-  // size_splits: {1, 1, 2}
-  // axis: 0
-  // We should have 3 outpus with shapes respectively:
-  //  output 1 : {1, 3}
-  //  output 2 : {1, 3}
-  //  output 3 : {2, 3}
-  Check<uint8_t, TensorType_UINT8>(
-      /*axis=*/0, {4, 3}, {3}, {{1, 3}, {1, 3}, {2, 3}},
-      {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}, {1, 1, 2},
-      {{1, 2, 3}, {4, 5, 6}, {7, 8, 9, 10, 11, 12}});
-}
-
-TEST(SplitVOpTest, TwoDimensionalInt16) {
-  // Input shape: {4, 3}
-  // size_splits: {1, 1, 2}
-  // axis: 0
-  // We should have 3 outpus with shapes respectively:
-  //  output 1 : {1, 3}
-  //  output 2 : {1, 3}
-  //  output 3 : {2, 3}
-  Check<int16_t, TensorType_INT16>(
-      /*axis=*/0, {4, 3}, {3}, {{1, 3}, {1, 3}, {2, 3}},
-      {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}, {1, 1, 2},
-      {{1, 2, 3}, {4, 5, 6}, {7, 8, 9, 10, 11, 12}});
-}
-
-TEST(SplitVOpTest, TwoDimensionalInt32) {
-  // Input shape: {4, 3}
-  // size_splits: {1, 1, 2}
-  // axis: 0
-  // We should have 3 outpus with shapes respectively:
-  //  output 1 : {1, 3}
-  //  output 2 : {1, 3}
-  //  output 3 : {2, 3}
-  Check<int32_t, TensorType_INT32>(
-      /*axis=*/0, {4, 3}, {3}, {{1, 3}, {1, 3}, {2, 3}},
-      {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}, {1, 1, 2},
-      {{1, 2, 3}, {4, 5, 6}, {7, 8, 9, 10, 11, 12}});
-}
-
-TEST(SplitVOpTest, TwoDimensionalInt64) {
-  // Input shape: {4, 3}
-  // size_splits: {1, 1, 2}
-  // axis: 0
-  // We should have 3 outpus with shapes respectively:
-  //  output 1 : {1, 3}
-  //  output 2 : {1, 3}
-  //  output 3 : {2, 3}
-  Check<int64_t, TensorType_INT64>(
-      /*axis=*/0, {4, 3}, {3}, {{1, 3}, {1, 3}, {2, 3}},
-      {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}, {1, 1, 2},
-      {{1, 2, 3}, {4, 5, 6}, {7, 8, 9, 10, 11, 12}});
 }
 
 }  // namespace

--- a/tensorflow/lite/toco/tflite/op_version.cc
+++ b/tensorflow/lite/toco/tflite/op_version.cc
@@ -145,7 +145,7 @@ string GetMinimumRuntimeVersionForModel(const Model& model) {
           {{OperatorType::kSplit, 1}, "1.5.0"},
           {{OperatorType::kSplit, 2}, "1.14.0"},
           {{OperatorType::kSplit, 3}, "1.14.0"},
-          {{OperatorType::kSplitV, 1}, "1.13.1"},
+          {{OperatorType::kSplitV, 2}, kPendingReleaseOpVersion},
           {{OperatorType::kStridedSlice, 1}, "1.6.0"},
           {{OperatorType::kStridedSlice, 2}, "1.14.0"},
           {{OperatorType::kStridedSlice, 3}, "2.1.0"},

--- a/tensorflow/lite/tools/optimize/operator_property.cc
+++ b/tensorflow/lite/tools/optimize/operator_property.cc
@@ -92,6 +92,12 @@ OperatorProperty GetOperatorProperty(const ModelT* model, int subgraph_index,
       property.restrict_same_input_output_scale = true;
       property.version = 2;
       break;
+    case BuiltinOperator_SPLIT_V:
+      property.inputs = {{0, {}}};
+      property.outputs = {{0, {}}};
+      property.restrict_same_input_output_scale = true;
+      property.version = 1;
+      break;
     case BuiltinOperator_CONCATENATION:
       property.arbitrary_inputs = true;
       property.outputs = {{0, {}}};

--- a/tensorflow/lite/tools/optimize/operator_property.cc
+++ b/tensorflow/lite/tools/optimize/operator_property.cc
@@ -96,7 +96,7 @@ OperatorProperty GetOperatorProperty(const ModelT* model, int subgraph_index,
       property.inputs = {{0, {}}};
       property.arbitrary_outputs = true;
       property.restrict_same_input_output_scale = true;
-      property.version = 1;
+      property.version = 2;
       break;
     case BuiltinOperator_CONCATENATION:
       property.arbitrary_inputs = true;

--- a/tensorflow/lite/tools/optimize/operator_property.cc
+++ b/tensorflow/lite/tools/optimize/operator_property.cc
@@ -94,7 +94,7 @@ OperatorProperty GetOperatorProperty(const ModelT* model, int subgraph_index,
       break;
     case BuiltinOperator_SPLIT_V:
       property.inputs = {{0, {}}};
-      property.outputs = {{0, {}}};
+      property.arbitrary_outputs = true;
       property.restrict_same_input_output_scale = true;
       property.version = 1;
       break;

--- a/tensorflow/lite/tools/versioning/op_version.cc
+++ b/tensorflow/lite/tools/versioning/op_version.cc
@@ -306,6 +306,7 @@ int GetBuiltinOperatorVersion(const OpSignature& op_sig) {
     case BuiltinOperator_PADV2:
     case BuiltinOperator_SOFTMAX:
     case BuiltinOperator_SPACE_TO_DEPTH:
+    case BuiltinOperator_SPLIT_V:
     case BuiltinOperator_MEAN:
     case BuiltinOperator_SUM:
     case BuiltinOperator_REDUCE_MAX:


### PR DESCRIPTION
This PR adds int8 quantization for SPLIT_V operator. See issue https://github.com/tensorflow/tensorflow/issues/36965
I added tests as for split_v for int8 by refactoring the existing one, so that they are not Copy&Paste.

