### PR TITLE
[tflite] make gpu delegate build

### DIFF
--- a/tensorflow/lite/delegates/gpu/cl/selectors/BUILD
+++ b/tensorflow/lite/delegates/gpu/cl/selectors/BUILD
@@ -119,6 +119,7 @@ cc_library(
         "//tensorflow/lite/delegates/gpu/cl/kernels:resize",
         "//tensorflow/lite/delegates/gpu/cl/kernels:softmax",
         "//tensorflow/lite/delegates/gpu/cl/kernels:softmax1x1",
+        "//tensorflow/lite/delegates/gpu/cl/kernels:space_to_depth",
         "//tensorflow/lite/delegates/gpu/cl/kernels:strided_slice",
         "//tensorflow/lite/delegates/gpu/cl/kernels:transpose",
         "//tensorflow/lite/delegates/gpu/common:operations",


### PR DESCRIPTION
This resolves https://github.com/tensorflow/tensorflow/issues/36967.

It seems this line was forgotten when adding the space_to_depth kernel.
Without this, all the programs use the GPU delegeate don't build.

@impjdi: it seems you checked in the space_to_depth kernel.