### PR TITLE
tensor_bundle: Supply size hint to input buffer

### DIFF
--- a/tensorflow/core/lib/io/inputbuffer.cc
+++ b/tensorflow/core/lib/io/inputbuffer.cc
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 #include "tensorflow/core/lib/io/inputbuffer.h"
+
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/platform/logging.h"
 
@@ -194,6 +195,46 @@ Status InputBuffer::Seek(int64 position) {
     file_pos_ = position;
   }
   return Status::OK();
+}
+
+Status InputBuffer::Hint(int64 bytes_to_read) {
+  if (bytes_to_read < 0) {
+    return errors::InvalidArgument("Can't read a negative number of bytes: ",
+                                   bytes_to_read);
+  }
+
+  // The internal buffer is too small. Do nothing.
+  if (bytes_to_read > size_) {
+    return Status::OK();
+  }
+
+  const int64 bytes_remain_in_buf = static_cast<int64>(limit_ - pos_);
+
+  // There are enough data in the buffer. Do nothing.
+  if (bytes_to_read <= bytes_remain_in_buf) {
+    return Status::OK();
+  }
+
+  // Additional read from file is necessary. Make some room.
+  memmove(buf_, pos_, bytes_remain_in_buf);
+  pos_ = buf_;
+  limit_ = buf_ + bytes_remain_in_buf;
+  bytes_to_read -= bytes_remain_in_buf;
+
+  // Read the remaining bytes from file.
+  StringPiece data;
+  Status s = file_->Read(file_pos_, bytes_to_read, &data, limit_);
+  if (data.data() != limit_) {
+    memmove(limit_, data.data(), data.size());
+  }
+  limit_ += data.size();
+  file_pos_ += data.size();
+
+  if (errors::IsOutOfRange(s) && data.size() == bytes_to_read) {
+    return Status::OK();
+  } else {
+    return s;
+  }
 }
 
 }  // namespace io

--- a/tensorflow/core/lib/io/inputbuffer.h
+++ b/tensorflow/core/lib/io/inputbuffer.h
@@ -75,6 +75,9 @@ class InputBuffer {
   // read will trigger a File::Read().
   Status Seek(int64 position);
 
+  // Provides a hint about future reads, which may improve their performance.
+  Status Hint(int64 bytes_to_read);
+
   // Returns the position in the file.
   int64 Tell() const { return file_pos_ - (limit_ - pos_); }
 

--- a/tensorflow/core/util/tensor_bundle/tensor_bundle.cc
+++ b/tensorflow/core/util/tensor_bundle/tensor_bundle.cc
@@ -75,6 +75,7 @@ Status ReadStringTensor(io::InputBuffer* buffered_file, size_t num_elements,
 
   // Reads "num_elements" varint64's from "buffered_file".
   TF_RETURN_IF_ERROR(buffered_file->Seek(offset));
+  TF_RETURN_IF_ERROR(buffered_file->Hint(size));
   std::vector<uint64> string_lengths(num_elements);
   for (size_t i = 0; i < num_elements; ++i) {
     TF_RETURN_IF_ERROR(buffered_file->ReadVarint64(&string_lengths[i]));
@@ -150,6 +151,7 @@ Status ReadVariantTensor(io::InputBuffer* buffered_file, Tensor* ret,
 
   // Reads the actual string bytes.
   TF_RETURN_IF_ERROR(buffered_file->Seek(offset));
+  TF_RETURN_IF_ERROR(buffered_file->Hint(size));
   for (size_t i = 0; i < num_elements; ++i) {
     // Read the serialized variant length.
     uint64 string_length = 0;


### PR DESCRIPTION
This improves performance for random reads on string and variant tensors. Both rely on input buffering currently. If the buffer size is too large, it ends up reading too much data and throw most of them away doing next out-of-range Seek.

This is part of a patch series aiming to improve the performance for CacheDatasetV2. It does not support external shuffle or random reads now, but we plan to add it in the future (subject to the API review).