### PR TITLE
Update docstring for Conv3DTranspose

### DIFF
--- a/tensorflow/python/keras/layers/convolutional.py
+++ b/tensorflow/python/keras/layers/convolutional.py
@@ -1083,12 +1083,6 @@ class Conv3DTranspose(Conv3D):
       It defaults to the `image_data_format` value found in your
       Keras config file at `~/.keras/keras.json`.
       If you never set it, then it will be "channels_last".
-    dilation_rate: an integer or tuple/list of 3 integers, specifying
-      the dilation rate to use for dilated convolution.
-      Can be a single integer to specify the same value for
-      all spatial dimensions.
-      Currently, specifying any `dilation_rate` value != 1 is
-      incompatible with specifying any stride value != 1.
     activation: Activation function to use.
       If you don't specify anything, no activation is applied (
       see `keras.activations`).


### PR DESCRIPTION
As mentioned in #29841, `dillation_rate` is not a supported feature for `Conv3DTranspose` as of yet. Until this feature is supported, it is misleading to show `dilation_rate` as an available parameter in the docstring.