### PR TITLE
Update docstring for consine_similarity

### DIFF
--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -1216,9 +1216,11 @@ def cosine_similarity(y_true, y_pred, axis=-1):
   Note that it is a negative quantity between -1 and 0, where 0 indicates
   orthogonality and values closer to -1 indicate greater similarity. This makes
   it usable as a loss function in a setting where you try to maximize the
-  proximity between predictions and targets.
+  proximity between predictions and targets. If either `y_true` or `y_pred` 
+  is a zero vector, cosine similarity will be 0 regardless of the proximity
+  between predictions and targets.
 
-  `loss = -sum(y_true * y_pred)`
+  `loss = -sum(l2_norm(y_true) * l2_norm(y_pred))`
 
   Args:
     y_true: Tensor of true targets.


### PR DESCRIPTION
Addresses some of the issues discussed in tensorflow#33820 by editing the docstring for `consine_similarity`. The edited docstring correctly indicates the `y_true` and `y_pred` need not be normalized, and that passing a zero vector as one of the arguments will return 0 regardless of the proximity between true and predicted labels.