### PR TITLE
Edited docstring, y_pred for SparseCategoricalAcc

### DIFF
--- a/tensorflow/python/keras/metrics.py
+++ b/tensorflow/python/keras/metrics.py
@@ -769,8 +769,11 @@ class CategoricalAccuracy(MeanMetricWrapper):
 @keras_export('keras.metrics.SparseCategoricalAccuracy')
 class SparseCategoricalAccuracy(MeanMetricWrapper):
   """Calculates how often predictions matches integer labels.
-
-  You can provide logits of classes as `y_pred`, since argmax of
+  
+  For example, if `y_true` is `[[2], [1]]` and `y_pred` is
+  `[[0.1, 0.6, 0.3], [0.05, 0.95, 0]]` then the categorical accuracy is 1/2 or .5.
+  If the weights were specified as `[0.7, 0.3]` then the categorical accuracy
+  would be .3. You can provide logits of classes as `y_pred`, since argmax of
   logits and probabilities are same.
 
   This metric creates two local variables, `total` and `count` that are used to
@@ -784,12 +787,12 @@ class SparseCategoricalAccuracy(MeanMetricWrapper):
   Usage:
 
   >>> m = tf.keras.metrics.SparseCategoricalAccuracy()
-  >>> _ = m.update_state([[2], [1]], [[0.1, 0.9, 0.8], [0.05, 0.95, 0]])
+  >>> _ = m.update_state([[2], [1]], [[0.1, 0.6, 0.3], [0.05, 0.95, 0]])
   >>> m.result().numpy()
   0.5
 
   >>> m.reset_states()
-  >>> _ = m.update_state([[2], [1]], [[0.1, 0.9, 0.8], [0.05, 0.95, 0]],
+  >>> _ = m.update_state([[2], [1]], [[0.1, 0.6, 0.3], [0.05, 0.95, 0]],
   ...                    sample_weight=[0.7, 0.3])
   >>> m.result().numpy()
   0.3

--- a/tensorflow/python/keras/metrics.py
+++ b/tensorflow/python/keras/metrics.py
@@ -770,8 +770,8 @@ class CategoricalAccuracy(MeanMetricWrapper):
 class SparseCategoricalAccuracy(MeanMetricWrapper):
   """Calculates how often predictions matches integer labels.
 
-  `acc = np.dot(sample_weight, np.equal(y_true, np.argmax(y_pred, axis=1))`
-
+  ```python
+  acc = np.dot(sample_weight, np.equal(y_true, np.argmax(y_pred, axis=1))
   You can provide logits of classes as `y_pred`, since argmax of
   logits and probabilities are same.
 

--- a/tensorflow/python/keras/metrics.py
+++ b/tensorflow/python/keras/metrics.py
@@ -772,6 +772,8 @@ class SparseCategoricalAccuracy(MeanMetricWrapper):
 
   ```python
   acc = np.dot(sample_weight, np.equal(y_true, np.argmax(y_pred, axis=1))
+  ```
+  
   You can provide logits of classes as `y_pred`, since argmax of
   logits and probabilities are same.
 

--- a/tensorflow/python/keras/metrics.py
+++ b/tensorflow/python/keras/metrics.py
@@ -770,8 +770,7 @@ class CategoricalAccuracy(MeanMetricWrapper):
 class SparseCategoricalAccuracy(MeanMetricWrapper):
   """Calculates how often predictions matches integer labels.
 
-  `acc = dot(sample_weight, (y_true == argmax(y_pred)) / n_pred`
-  where `n_pred = len(y_true)` 
+  `acc = np.dot(sample_weight, np.equal(y_true, np.argmax(y_pred, axis=1))`
 
   You can provide logits of classes as `y_pred`, since argmax of
   logits and probabilities are same.

--- a/tensorflow/python/keras/metrics.py
+++ b/tensorflow/python/keras/metrics.py
@@ -769,11 +769,11 @@ class CategoricalAccuracy(MeanMetricWrapper):
 @keras_export('keras.metrics.SparseCategoricalAccuracy')
 class SparseCategoricalAccuracy(MeanMetricWrapper):
   """Calculates how often predictions matches integer labels.
-  
-  For example, if `y_true` is `[[2], [1]]` and `y_pred` is
-  `[[0.1, 0.6, 0.3], [0.05, 0.95, 0]]` then the categorical accuracy is 1/2 or .5.
-  If the weights were specified as `[0.7, 0.3]` then the categorical accuracy
-  would be .3. You can provide logits of classes as `y_pred`, since argmax of
+
+  `acc = dot(sample_weight, (y_true == argmax(y_pred)) / n_pred`
+  where `n_pred = len(y_true)` 
+
+  You can provide logits of classes as `y_pred`, since argmax of
   logits and probabilities are same.
 
   This metric creates two local variables, `total` and `count` that are used to


### PR DESCRIPTION
1. The `y_pred` example was previously given as `[0.1, 0.9, 0.8]`, which is odd given that the probabilities should sum up to one after passing through softmax. Edited to `[0.1, 0.6, 0.3]` to maintain integrity of example while posing a probable result.
2. The docstring for master was not up-to-date with that of Tag 2.1.0. Made changes so that they are even.

Relates to #36844.