### PR TITLE
[ROCm][XLA:GPU] Fixing xla executable buffer creation

### DIFF
--- a/tensorflow/compiler/xla/service/interpreter/executable.cc
+++ b/tensorflow/compiler/xla/service/interpreter/executable.cc
@@ -59,9 +59,10 @@ StatusOr<ExecutionOutput> InterpreterExecutable::ExecuteAsyncOnStream(
   std::vector<ShapedBuffer> argument_buffers;
   argument_buffers.reserve(arguments.size());
   for (const ShapeTree<MaybeOwningDeviceMemory>& arg : arguments) {
-    argument_buffers.push_back(ShapedBuffer(arg.shape(), arg.shape(),
-                                            /*platform=*/nullptr,
-                                            /*device_ordinal=*/0));
+    argument_buffers.push_back(
+        ShapedBuffer(arg.shape(), arg.shape(),
+                     /*platform=*/platform,
+                     /*device_ordinal=*/executor->device_ordinal()));
     auto in_it = arg.begin();
     auto out_it = argument_buffers.back().buffers().begin();
     for (; in_it != arg.end(); ++in_it, ++out_it) {


### PR DESCRIPTION
Discovered this when having VLOG on. (line 76 will de-reference the nullptr, causing a segmentation fault) This commit also fixed some intermittent ROCm CI failures.

/cc: @whchung @cheshire 