### PR TITLE
Fix test that should only be running in v1

### DIFF
--- a/tensorflow/python/ops/nn_fused_batchnorm_test.py
+++ b/tensorflow/python/ops/nn_fused_batchnorm_test.py
@@ -466,6 +466,7 @@ class BatchNormalizationTest(test.TestCase):
     x_shape = [0, 131, 127, 6]
     self._runtests(x_shape, True)
 
+  @test_util.run_deprecated_v1
   def testBatchNormGradInferenceShape1(self):
     x_shape = [1, 1, 6, 1]
     self._runtests(x_shape, is_training=False, gradient_test=True)


### PR DESCRIPTION
After https://github.com/tensorflow/tensorflow/commit/84f2ec1d60b5bb14a59ccef8f8fa7eb5a1096e8f#diff-42d3946a49d3adc16b4a37e844f986e0R469-R473 the test `testBatchNormGradInferenceShape1 ` is incorrectly enabled in v2, causing the following error:

```
[  FAILED  ] BatchNormalizationTest.testBatchNormGradInferenceShape1
======================================================================
ERROR: testBatchNormGradInferenceShape1 (__main__.BatchNormalizationTest)
testBatchNormGradInferenceShape1 (__main__.BatchNormalizationTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/run/bazel-buildfarm/default/operations/9d248bd8-a122-4dee-8f35-b5c55d793f8f/bazel-out/k8-opt/bin/tensorflow/python/nn_fused_batchnorm_test_gpu.runfiles/org_tensorflow/tensorflow/python/ops/nn_fused_batchnorm_test.py", line 471, in testBatchNormGradInferenceShape1
    self._runtests(x_shape, is_training=False, gradient_test=True)
  File "/run/bazel-buildfarm/default/operations/9d248bd8-a122-4dee-8f35-b5c55d793f8f/bazel-out/k8-opt/bin/tensorflow/python/nn_fused_batchnorm_test_gpu.runfiles/org_tensorflow/tensorflow/python/ops/nn_fused_batchnorm_test.py", line 407, in _runtests
    exponential_avg_factor=exponential_avg_factor)
  File "/run/bazel-buildfarm/default/operations/9d248bd8-a122-4dee-8f35-b5c55d793f8f/bazel-out/k8-opt/bin/tensorflow/python/nn_fused_batchnorm_test_gpu.runfiles/org_tensorflow/tensorflow/python/ops/nn_fused_batchnorm_test.py", line 263, in _test_gradient
    x_shape)
  File "/run/bazel-buildfarm/default/operations/9d248bd8-a122-4dee-8f35-b5c55d793f8f/bazel-out/k8-opt/bin/tensorflow/python/nn_fused_batchnorm_test_gpu.runfiles/org_tensorflow/tensorflow/python/ops/nn_fused_batchnorm_test.py", line 203, in _compute_gradient_error_float16
    x, x_shape, y, y_shape, delta=1e-3, x_init_value=x_init_val)
  File "/run/bazel-buildfarm/default/operations/9d248bd8-a122-4dee-8f35-b5c55d793f8f/bazel-out/k8-opt/bin/tensorflow/python/nn_fused_batchnorm_test_gpu.runfiles/org_tensorflow/tensorflow/python/util/deprecation.py", line 324, in new_func
    return func(*args, **kwargs)
  File "/run/bazel-buildfarm/default/operations/9d248bd8-a122-4dee-8f35-b5c55d793f8f/bazel-out/k8-opt/bin/tensorflow/python/nn_fused_batchnorm_test_gpu.runfiles/org_tensorflow/tensorflow/python/ops/gradient_checker.py", line 332, in compute_gradient
    dx, dy = _compute_dx_and_dy(x, y, y_shape)
  File "/run/bazel-buildfarm/default/operations/9d248bd8-a122-4dee-8f35-b5c55d793f8f/bazel-out/k8-opt/bin/tensorflow/python/nn_fused_batchnorm_test_gpu.runfiles/org_tensorflow/tensorflow/python/ops/gradient_checker.py", line 202, in _compute_dx_and_dy
    with x.graph.as_default():
  File "/run/bazel-buildfarm/default/operations/9d248bd8-a122-4dee-8f35-b5c55d793f8f/bazel-out/k8-opt/bin/tensorflow/python/nn_fused_batchnorm_test_gpu.runfiles/org_tensorflow/tensorflow/python/framework/ops.py", line 1118, in graph
    "Tensor.graph is meaningless when eager execution is enabled.")
AttributeError: Tensor.graph is meaningless when eager execution is enabled.
```