### PR TITLE
Correct phrasing on CuDNN conditions

### DIFF
--- a/tensorflow/python/keras/layers/recurrent_v2.py
+++ b/tensorflow/python/keras/layers/recurrent_v2.py
@@ -204,7 +204,7 @@ class GRU(recurrent.DropoutRNNCellMixin, recurrent.GRU):
   4. `unroll` is `False`
   5. `use_bias` is `True`
   6. `reset_after` is `True`
-  7. Inputs are not masked or strictly right padded.
+  7. Inputs, if use masking, are strictly right-padded.
 
   There are two variants of the GRU implementation. The default one is based on
   [v3](https://arxiv.org/abs/1406.1078v3) and has reset gate applied to hidden
@@ -933,7 +933,7 @@ class LSTM(recurrent.DropoutRNNCellMixin, recurrent.LSTM):
   3. `recurrent_dropout` == 0
   4. `unroll` is `False`
   5. `use_bias` is `True`
-  6. Inputs are not masked or strictly right padded.
+  6. Inputs, if use masking, are strictly right-padded.
 
   For example:
 


### PR DESCRIPTION
As-is, the condition means "inputs are not masked" AND "inputs are not strictly right-padded", which isn't the actual condition, and is thereby misleading.