### PR TITLE
Adding generic Cortex m4f target to TFL micro

### DIFF
--- a/tensorflow/lite/micro/cortex-m4f-generic/debug_log.cc
+++ b/tensorflow/lite/micro/cortex-m4f-generic/debug_log.cc
@@ -1,0 +1,39 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Implementation for the DebugLog() function that prints to the debug logger on an
+// generic cortex-m4f device.
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+#include "tensorflow/lite/micro/cortex-m4f-generic/debug_log.h"
+
+static void (*DebugLog_callback)(const char* s) = nullptr;
+
+extern void DebugLog_register_callback(void (*cb)(const char* s)) {
+  DebugLog_callback = cb;
+}
+
+extern void DebugLog(const char* s) {
+  if (DebugLog_callback) {
+	  DebugLog_callback(s);
+  }
+}
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus

--- a/tensorflow/lite/micro/cortex-m4f-generic/debug_log.h
+++ b/tensorflow/lite/micro/cortex-m4f-generic/debug_log.h
@@ -1,0 +1,38 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_LITE_MICRO_CORTEX_M4F_GENERIC_DEBUG_LOG_H_
+#define TENSORFLOW_LITE_MICRO_CORTEX_M4F_GENERIC_DEBUG_LOG_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// This function is used to register a callback for debug logging.
+// It must be called before the first call to DebugLog().
+extern void DebugLog_register_callback(void (*cb)(const char* s));
+
+// This function should be implemented by each target platform, and provide a
+// way for strings to be output to some text stream. For more information, see
+// tensorflow/lite/micro/debug_log.cc.
+// Note that before the first call to DebugLog()
+// a callback function must be registered by calling DebugLog_register_callback().
+extern void DebugLog(const char* s);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // TENSORFLOW_LITE_MICRO_CORTEX_M4F_GENERIC_DEBUG_LOG_H_

--- a/tensorflow/lite/micro/tools/make/targets/cortex-m4f-generic_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/cortex-m4f-generic_makefile.inc
@@ -1,0 +1,83 @@
+# Settings for cortex-m4f generic device.
+ifeq ($(TARGET),$(filter $(TARGET),\
+  cortex-m4f-generic\
+  ))
+  export PATH := $(MAKEFILE_DIR)/downloads/gcc_embedded/bin/:$(PATH)
+  TARGET_ARCH := cortex-m4
+  TARGET_TOOLCHAIN_PREFIX := arm-none-eabi-
+  # Need a pointer to the GNU ARM toolchain for crtbegin.o for the fp functions
+  # with the hard interfaces.
+  GCC_ARM := $(MAKEFILE_DIR)/downloads/gcc_embedded/
+
+  $(eval $(call add_third_party_download,$(GCC_EMBEDDED_URL),$(GCC_EMBEDDED_MD5),gcc_embedded,))
+  $(eval $(call add_third_party_download,$(CMSIS_URL),$(CMSIS_MD5),cmsis,))
+
+  # Use the faster depthwise conv implementation.
+  ALL_TAGS += portable_optimized
+
+  PLATFORM_FLAGS = \
+    -DGEMMLOWP_ALLOW_SLOW_SCALAR_FALLBACK \
+    -DTF_LITE_STATIC_MEMORY \
+    -DNDEBUG \
+    -DTF_LITE_MCU_DEBUG_LOG \
+    -D __FPU_PRESENT=1 \
+    -DARM_MATH_CM4 \
+    -fno-rtti \
+    -fmessage-length=0 \
+    -fno-exceptions \
+    -fno-unwind-tables \
+    -fno-builtin \
+    -ffunction-sections \
+    -fdata-sections \
+    -funsigned-char \
+    -MMD \
+    -mcpu=cortex-m4 \
+    -mthumb \
+    -mfpu=fpv4-sp-d16 \
+    -mfloat-abi=hard \
+    -std=gnu++11 \
+    -Wvla \
+    -Wall \
+    -Wextra \
+    -Wsign-compare \
+    -Wdouble-promotion \
+    -Wunused-variable \
+    -Wshadow \
+    -Wmissing-field-initializers \
+    -Wno-unused-parameter \
+    -Wno-write-strings \
+    -fno-delete-null-pointer-checks \
+    -fomit-frame-pointer \
+    -fpermissive \
+    -nostdlib \
+    -ggdb \
+    -O3
+  CXXFLAGS += $(PLATFORM_FLAGS)
+  CCFLAGS += $(PLATFORM_FLAGS)
+
+  BUILD_TYPE := micro
+
+  MICROLITE_LIBS := \
+    -lm
+  INCLUDES += \
+    -isystem$(MAKEFILE_DIR)/downloads/cmsis/CMSIS/Core/Include/ \
+    -isystem$(MAKEFILE_DIR)/downloads/cmsis/CMSIS/DSP/Include/ \
+    -I$(GCC_ARM)/arm-none-eabi/ \
+
+  CMSIS_SRC_DIR := $(MAKEFILE_DIR)/downloads/cmsis/CMSIS/DSP/Source
+  CMSIS_SRCS := \
+  $(CMSIS_SRC_DIR)/BasicMathFunctions/arm_mult_q15.c \
+  $(CMSIS_SRC_DIR)/TransformFunctions/arm_rfft_init_q15.c \
+  $(CMSIS_SRC_DIR)/TransformFunctions/arm_rfft_q15.c \
+  $(CMSIS_SRC_DIR)/TransformFunctions/arm_cfft_q15.c \
+  $(CMSIS_SRC_DIR)/TransformFunctions/arm_cfft_radix4_q15.c \
+  $(CMSIS_SRC_DIR)/CommonTables/arm_const_structs.c \
+  $(CMSIS_SRC_DIR)/CommonTables/arm_common_tables.c \
+  $(CMSIS_SRC_DIR)/StatisticsFunctions/arm_mean_q15.c \
+  $(CMSIS_SRC_DIR)/StatisticsFunctions/arm_max_q7.c
+
+  # These are tests that don't currently work on the generic Coretax-M4F.
+  EXCLUDED_TESTS :=
+  MICROLITE_TEST_SRCS := $(filter-out $(EXCLUDED_TESTS), $(MICROLITE_TEST_SRCS))
+
+endif


### PR DESCRIPTION
All existing make targets generate binaries for dedicated hardware (chip, board) and make assumptions on the way, the debugging log is written. Porting an existing example application to a new hardware with the same core (e.g. Cortex M4F) requires the replacement of the pin/package/HAL layers. Such layers can be quite large, depending on the vendor's product portfolio and must be added to the TFL micro build. If the user needs only the microlite library (for use in a different build environment), he wants to generate the library without modifications of the sources.

This pull request provides a generic make target for Cortex-M4F without being specific on the debug log functions and without having to add any pin/package/HAL layers. The user can integrate the microlite library into his project and register a callback function for the debugging log. The big advantage is that the microlite library can be used off-the-shelf without doing customizations to a specific board hardware.

The microlite library for the generic Cortex M4F device is generated by the command

make -f tensorflow/lite/micro/tools/make/Makefile TARGET=cortex-m4f-generic microlite

The output is

tensorflow/lite/micro/tools/make/gen/cortex-m4f-generic_cortex-m4/lib/libtensorflow-microlite.a

In his build system, the user must register the callback function before actually using the debug log, e.g.:

void debug_log_printf(const char* s)
{
	printf(s);
}

void setup(void)
{
    DebugLog_register_callback(debug_log_printf);
    DebugLog("Make setup\r\n");
    ...
}
