### PR TITLE
Fix plot_model for .pdf files

### DIFF
--- a/tensorflow/python/keras/utils/vis_utils.py
+++ b/tensorflow/python/keras/utils/vis_utils.py
@@ -293,8 +293,9 @@ def plot_model(model,
   # Return the image as a Jupyter Image object, to be displayed in-line.
   # Note that we cannot easily detect whether the code is running in a
   # notebook, and thus we always return the Image if Jupyter is available.
-  try:
-    from IPython import display
-    return display.Image(filename=to_file)
-  except ImportError:
-    pass
+  if extension != 'pdf':
+    try:
+      from IPython import display
+      return display.Image(filename=to_file)
+    except ImportError:
+      pass


### PR DESCRIPTION
If `plot_model` is asked for a .pdf file in Jupyter via the command `plot_model(model, to_file='model.pdf')`, a value error is raised:

```
ValueError: Cannot embed the 'pdf' image format
```

This is presumably because Jupyter Notebook does not support .pdf format. This PR fixes this issue by adding an additional check for the `extension` argument.