### PR TITLE
Fix np.squeeze call with dimensionality check

### DIFF
--- a/tensorflow/python/keras/wrappers/scikit_learn.py
+++ b/tensorflow/python/keras/wrappers/scikit_learn.py
@@ -330,7 +330,10 @@ class KerasRegressor(BaseWrapper):
             Predictions.
     """
     kwargs = self.filter_sk_params(Sequential.predict, kwargs)
-    return np.squeeze(self.model.predict(x, **kwargs))
+    preds = np.array(self.model.predict(x, **kwargs))
+    if preds.shape[-1] == 1:
+      return np.squeeze(preds, axis=-1)
+    return preds
 
   def score(self, x, y, **kwargs):
     """Returns the mean loss on the given test data and labels.

--- a/tensorflow/python/keras/wrappers/scikit_learn.py
+++ b/tensorflow/python/keras/wrappers/scikit_learn.py
@@ -330,7 +330,7 @@ class KerasRegressor(BaseWrapper):
             Predictions.
     """
     kwargs = self.filter_sk_params(Sequential.predict, kwargs)
-    preds = np.array(self.model.predict(x, **kwargs))
+    preds = np.asarray(self.model.predict(x, **kwargs))
     if preds.shape[-1] == 1:
       return np.squeeze(preds, axis=-1)
     return preds


### PR DESCRIPTION
Calling `np.squeeze` is required only if `preds.shape[-1]` is equal to one.. Otherwise, the prediction can be returned as is. Added a conditional to check for this condition.