### PR TITLE
Fix flaky host_tracer_test with data race

### DIFF
--- a/tensorflow/core/profiler/internal/cpu/host_tracer_test.cc
+++ b/tensorflow/core/profiler/internal/cpu/host_tracer_test.cc
@@ -12,10 +12,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-#include <string>
-
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
+#include <atomic>
+#include <string>
+
 #include "absl/types/optional.h"
 #include "tensorflow/core/common_runtime/step_stats_collector.h"
 #include "tensorflow/core/framework/step_stats.pb.h"
@@ -107,7 +109,7 @@ TEST(HostTracerTest, CollectsTraceMeEventsAsRunMetadata) {
 }
 
 TEST(HostTracerTest, CollectsTraceMeEventsAsXSpace) {
-  int32 thread_id;
+  std::atomic<int32> thread_id;
   string thread_name = "MyThreadName";
   XSpace space;
 


### PR DESCRIPTION
In test `CollectsTraceMeEventsAsXSpace` added in 883b5becaced22f7dd9e3c23d9d259f55e087cb5, `thread_id` is not properly synchronized between threads, causing the following test flakiness:

```
tensorflow/core/profiler/internal/cpu/host_tracer_test.cc:150: Failure
Expected equality of these values:
  line.id()
    Which is: 3350296320
  thread_id
    Which is: -944670976
```