### PR TITLE
Update XNNPACK for support Windows

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -148,11 +148,11 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
 
     tf_http_archive(
         name = "XNNPACK",
-        sha256 = "ee54bd30c86d3d959f9367d5a969ba20ca58eea7fe865785d358d5f776b99b2f",
-        strip_prefix = "XNNPACK-5b5a0624a80655e40aff8e96de97706aeb008281",
+        sha256 = "100f675c099c74da46dea8da025f6f9b5e0307370f3dde506d11bd78b2b7d171",
+        strip_prefix = "XNNPACK-4ea95bef8cdd942895f23f5cc09c778d10500551",
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/google/XNNPACK/archive/5b5a0624a80655e40aff8e96de97706aeb008281.zip",
-            "https://github.com/google/XNNPACK/archive/5b5a0624a80655e40aff8e96de97706aeb008281.zip",
+            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/google/XNNPACK/archive/4ea95bef8cdd942895f23f5cc09c778d10500551.zip",
+            "https://github.com/google/XNNPACK/archive/4ea95bef8cdd942895f23f5cc09c778d10500551.zip",
         ],
     )
 

--- a/third_party/pthreadpool/workspace.bzl
+++ b/third_party/pthreadpool/workspace.bzl
@@ -5,11 +5,11 @@ load("//third_party:repo.bzl", "third_party_http_archive")
 def repo():
     third_party_http_archive(
         name = "pthreadpool",
-        strip_prefix = "pthreadpool-4ea95bef8cdd942895f23f5cc09c778d10500551",
-        sha256 = "100f675c099c74da46dea8da025f6f9b5e0307370f3dde506d11bd78b2b7d171",
+        strip_prefix = "pthreadpool-ebd50d0cfa3664d454ffdf246fcd228c3b370a11",
+        sha256 = "ca4fc774cf2339cb739bba827de8ed4ccbd450c4608e05329e974153448aaf56",
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/Maratyszcza/pthreadpool/archive/4ea95bef8cdd942895f23f5cc09c778d10500551.tar.gz",
-            "https://github.com/Maratyszcza/pthreadpool/archive/4ea95bef8cdd942895f23f5cc09c778d10500551.tar.gz",
+            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/Maratyszcza/pthreadpool/archive/ebd50d0cfa3664d454ffdf246fcd228c3b370a11.tar.gz",
+            "https://github.com/Maratyszcza/pthreadpool/archive/ebd50d0cfa3664d454ffdf246fcd228c3b370a11.tar.gz",
         ],
         build_file = "//third_party/pthreadpool:BUILD.bazel",
     )

--- a/third_party/pthreadpool/workspace.bzl
+++ b/third_party/pthreadpool/workspace.bzl
@@ -5,11 +5,11 @@ load("//third_party:repo.bzl", "third_party_http_archive")
 def repo():
     third_party_http_archive(
         name = "pthreadpool",
-        strip_prefix = "pthreadpool-7ad026703b3109907ad124025918da15cfd3f100",
-        sha256 = "96eb4256fc438b7b8cab40541d383efaf546fae7bad380c24ea601c326c5f685",
+        strip_prefix = "pthreadpool-4ea95bef8cdd942895f23f5cc09c778d10500551",
+        sha256 = "100f675c099c74da46dea8da025f6f9b5e0307370f3dde506d11bd78b2b7d171",
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/Maratyszcza/pthreadpool/archive/7ad026703b3109907ad124025918da15cfd3f100.tar.gz",
-            "https://github.com/Maratyszcza/pthreadpool/archive/7ad026703b3109907ad124025918da15cfd3f100.tar.gz",
+            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/Maratyszcza/pthreadpool/archive/4ea95bef8cdd942895f23f5cc09c778d10500551.tar.gz",
+            "https://github.com/Maratyszcza/pthreadpool/archive/4ea95bef8cdd942895f23f5cc09c778d10500551.tar.gz",
         ],
         build_file = "//third_party/pthreadpool:BUILD.bazel",
     )


### PR DESCRIPTION
This change add support Windows of XNNPACK delegate.

https://github.com/google/XNNPACK/pull/383

XNNPACK did not support Windows until yesterday. I sent pull-request to XNNPACK and pthreadpool and the pull-requests were merged. Now XNNPACK works on Windows. So this change update commit-id to enable Windows support of XNNPACK delegate.