### PR TITLE
Added reference papers in docstring

### DIFF
--- a/tensorflow/python/keras/applications/densenet.py
+++ b/tensorflow/python/keras/applications/densenet.py
@@ -137,6 +137,10 @@ def DenseNet(
 ):
   """Instantiates the DenseNet architecture.
 
+  Reference paper:
+  - [Densely Connected Convolutional Networks]
+    (https://arxiv.org/abs/1608.06993) (CVPR 2017 Best Paper Award)
+
   Optionally loads weights pre-trained on ImageNet.
   Note that the data format convention used by the model is
   the one specified in your Keras config at `~/.keras/keras.json`.
@@ -393,6 +397,10 @@ preprocess_input.__doc__ = imagenet_utils.PREPROCESS_INPUT_DOC.format(
 decode_predictions.__doc__ = imagenet_utils.decode_predictions.__doc__
 
 DOC = """
+
+  Reference paper:
+  - [Densely Connected Convolutional Networks]
+    (https://arxiv.org/abs/1608.06993) (CVPR 2017 Best Paper Award)
 
   Optionally loads weights pre-trained on ImageNet.
   Note that the data format convention used by the model is

--- a/tensorflow/python/keras/applications/efficientnet.py
+++ b/tensorflow/python/keras/applications/efficientnet.py
@@ -161,6 +161,10 @@ def EfficientNet(
 ):
   """Instantiates the EfficientNet architecture using given scaling coefficients.
 
+  Reference paper:
+  - [EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks]
+    (https://arxiv.org/abs/1905.11946) (ICML 2019)
+
   Optionally loads weights pre-trained on ImageNet.
   Note that the data format convention used by the model is
   the one specified in your Keras config at `~/.keras/keras.json`.

--- a/tensorflow/python/keras/applications/inception_resnet_v2.py
+++ b/tensorflow/python/keras/applications/inception_resnet_v2.py
@@ -52,6 +52,11 @@ def InceptionResNetV2(include_top=True,
                       **kwargs):
   """Instantiates the Inception-ResNet v2 architecture.
 
+  Reference paper:
+  - [Inception-v4, Inception-ResNet and the Impact of
+     Residual Connections on Learning](https://arxiv.org/abs/1602.07261)
+    (AAAI 2017)
+
   Optionally loads weights pre-trained on ImageNet.
   Note that the data format convention used by the model is
   the one specified in your Keras config at `~/.keras/keras.json`.

--- a/tensorflow/python/keras/applications/mobilenet_v2.py
+++ b/tensorflow/python/keras/applications/mobilenet_v2.py
@@ -69,6 +69,9 @@ MACs stands for Multiply Adds
 | [mobilenet_v2_0.35_128] | 20  | 1.66 |          50.8 | 75.0 |
 | [mobilenet_v2_0.35_96]  | 11  | 1.66 |          45.5 | 70.4 |
 
+  Reference paper:
+  - [MobileNetV2: Inverted Residuals and Linear Bottlenecks]
+  (https://arxiv.org/abs/1801.04381) (CVPR 2018)
 """
 from __future__ import absolute_import
 from __future__ import division

--- a/tensorflow/python/keras/applications/nasnet.py
+++ b/tensorflow/python/keras/applications/nasnet.py
@@ -33,7 +33,7 @@ The below table describes the performance on ImageNet 2012:
 |   NASNet-A (6 @ 4032)  |   82.7 %  |   96.2 %  |      23.8 B    |    88.9    |
 --------------------------------------------------------------------------------
 
-References:
+Reference paper:
   - [Learning Transferable Architectures for Scalable Image Recognition]
     (https://arxiv.org/abs/1707.07012) (CVPR 2018)
 """
@@ -77,6 +77,10 @@ def NASNet(
     classifier_activation='softmax',
 ):
   """Instantiates a NASNet model.
+
+  Reference paper:
+  - [Learning Transferable Architectures for Scalable Image Recognition]
+    (https://arxiv.org/abs/1707.07012) (CVPR 2018)
 
   Optionally loads weights pre-trained on ImageNet.
   Note that the data format convention used by the model is

--- a/tensorflow/python/keras/applications/resnet.py
+++ b/tensorflow/python/keras/applications/resnet.py
@@ -13,7 +13,12 @@
 # limitations under the License.
 # ==============================================================================
 # pylint: disable=invalid-name
-"""ResNet models for Keras."""
+"""ResNet models for Keras.
+
+Reference paper:
+  - [Deep Residual Learning for Image Recognition]
+    (https://arxiv.org/abs/1512.03385) (CVPR 2015)
+"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -64,6 +69,10 @@ def ResNet(stack_fn,
            classifier_activation='softmax',
            **kwargs):
   """Instantiates the ResNet, ResNetV2, and ResNeXt architecture.
+
+  Reference paper:
+  - [Deep Residual Learning for Image Recognition]
+    (https://arxiv.org/abs/1512.03385) (CVPR 2015)
 
   Optionally loads weights pre-trained on ImageNet.
   Note that the data format convention used by the model is
@@ -548,6 +557,10 @@ preprocess_input.__doc__ = imagenet_utils.PREPROCESS_INPUT_DOC.format(
 decode_predictions.__doc__ = imagenet_utils.decode_predictions.__doc__
 
 DOC = """
+
+  Reference paper:
+  - [Deep Residual Learning for Image Recognition]
+  (https://arxiv.org/abs/1512.03385) (CVPR 2015)
 
   Optionally loads weights pre-trained on ImageNet.
   Note that the data format convention used by the model is

--- a/tensorflow/python/keras/applications/resnet_v2.py
+++ b/tensorflow/python/keras/applications/resnet_v2.py
@@ -13,7 +13,12 @@
 # limitations under the License.
 # ==============================================================================
 # pylint: disable=invalid-name
-"""ResNet v2 models for Keras."""
+"""ResNet v2 models for Keras.
+
+Reference paper:
+  - [Identity Mappings in Deep Residual Networks]
+    (https://arxiv.org/abs/1603.05027) (CVPR 2016)
+"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -163,6 +168,10 @@ preprocess_input.__doc__ = imagenet_utils.PREPROCESS_INPUT_DOC.format(
 decode_predictions.__doc__ = imagenet_utils.decode_predictions.__doc__
 
 DOC = """
+
+  Reference paper:
+  - [Identity Mappings in Deep Residual Networks]
+    (https://arxiv.org/abs/1603.05027) (CVPR 2016)
 
   Optionally loads weights pre-trained on ImageNet.
   Note that the data format convention used by the model is

--- a/tensorflow/python/keras/applications/vgg16.py
+++ b/tensorflow/python/keras/applications/vgg16.py
@@ -13,7 +13,12 @@
 # limitations under the License.
 # ==============================================================================
 # pylint: disable=invalid-name
-"""VGG16 model for Keras."""
+"""VGG16 model for Keras.
+
+Reference paper:
+  - [Very Deep Convolutional Networks for Large-Scale Image Recognition]
+    (https://arxiv.org/abs/1409.1556) (ICLR 2015)
+"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -47,6 +52,10 @@ def VGG16(
     classifier_activation='softmax',
 ):
   """Instantiates the VGG16 model.
+
+  Reference paper:
+  - [Very Deep Convolutional Networks for Large-Scale Image Recognition](
+  https://arxiv.org/abs/1409.1556) (ICLR 2015)
 
   By default, it loads weights pre-trained on ImageNet. Check 'weights' for
   other options.

--- a/tensorflow/python/keras/applications/vgg19.py
+++ b/tensorflow/python/keras/applications/vgg19.py
@@ -53,6 +53,10 @@ def VGG19(
 ):
   """Instantiates the VGG19 architecture.
 
+  Reference:
+  - [Very Deep Convolutional Networks for Large-Scale Image Recognition](
+      https://arxiv.org/abs/1409.1556) (ICLR 2015)
+
   By default, it loads weights pre-trained on ImageNet. Check 'weights' for
   other options.
 


### PR DESCRIPTION
Added reference papers in docstring for models in `keras.appliactions`. Some models had reference papers, while others did not. Edited the docstrings such that the descriptions would appear consistent throughout all models.