### PR TITLE
[XLA] vectorize row reduction for even row size

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -2101,7 +2101,7 @@ static IrArray::Index GetUnnormalizedIndex(
   DCHECK_EQ(normalized_shape_index.size(), 3);
   // If the normalization only add a new dimensions of size 1,
   // generate simpler indexing. LLVM doesn't always simplify the more
-  // complicated indexing and this prevent him from vectorizing some
+  // complicated indexing and this prevents it from vectorizing some
   // cases.
   if (unnormalized_shape.rank() == 2) {
     DCHECK_EQ(normalized_shape_index.dims()[0], 0);
@@ -3199,8 +3199,8 @@ ReductionCodegenInfo IrEmitterUnnested::ComputeReductionCodegenInfo(
   int num_partial_results = 1;
   KernelMappingScheme::IndexingOrder indexing_order = [&]() {
     if (reduction_dimensions.is_row_reduction &&
-        // P100, only ttry to vectorize+coales memory access when the
-        // tile size fit exactly and dtypes <= 32 bits
+        // P100, only try to vectorize+coales memory access when the
+        // tile size fits exactly and dtypes <= 32 bits
         ((cc_major == 6 && smallest_input_dtype_bits <= 32 && tile_fit) ||
          // On V100, only try to vectorize+coales memory access for
          // rows of even size.  For odd row sizes, every other row

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -2151,23 +2151,6 @@ void IrEmitterUnnested::EmitTileElementForFusion(
   }
 }
 
-// Gets the number of partial results accumulated by a single thread performing
-// reduction.
-static int GetNumberOfPartialResults(
-    const ReductionCodegenInfo& reduction_info) {
-  const KernelMappingScheme& mapping_scheme =
-      reduction_info.GetKernelMappingScheme();
-  if (reduction_info.IsRowReduction()) {
-    return 1;
-  }
-  int64 num_partial_results =
-      mapping_scheme.GetIndexingOrder() == kLinearIndexingX ? 2 : 1;
-
-  CHECK_EQ(num_partial_results,
-           (mapping_scheme.GetTileSizeX() / mapping_scheme.GetNumThreadsX()));
-  return num_partial_results;
-}
-
 void IrEmitterUnnested::EmitPrologueForReduction(
     HloInstruction* unnested_hlo, ReductionCodegenInfo* reduction_info,
     absl::Span<HloInstruction* const> reduce_instructions,
@@ -2194,7 +2177,7 @@ void IrEmitterUnnested::EmitPrologueForReduction(
     llvm::AllocaInst* reduction_input_address = Alloca(element_type);
     reduction_input_addresses->push_back(reduction_input_address);
 
-    int num_partial_results = GetNumberOfPartialResults(*reduction_info);
+    int num_partial_results = reduction_info->GetNumPartialResults();
     AddressVector* partial_result_addresses =
         reduction_info->GetMutablePartialResultAddresses();
     llvm::AllocaInst* partial_result_address =
@@ -2346,7 +2329,7 @@ void IrEmitterUnnested::EmitEpilogueForReduction(
   absl::Span<llvm::AllocaInst* const> partial_result_addresses =
       reduction_info.GetPartialResultAddresses();
 
-  int num_partial_results = GetNumberOfPartialResults(reduction_info);
+  int num_partial_results = reduction_info.GetNumPartialResults();
 
   // Emit an atomic operation that accumulates the partial reduction to the
   // output element. For row reduction, this is only for lane 0 due to the
@@ -2560,7 +2543,7 @@ void IrEmitterUnnested::EmitTileElementForReduction(
   // GetElementPointer with array types. This enables the vectorization of
   // the computation for different partial results. Use this index if
   // 'num_partial_results > 1'.
-  int num_partial_results = GetNumberOfPartialResults(reduction_info);
+  int num_partial_results = reduction_info.GetNumPartialResults();
   auto index_without_linear = IrArray::Index(
       input_index.multidim(), reduction_operand_shape, input_index.GetType());
 
@@ -3213,6 +3196,7 @@ ReductionCodegenInfo IrEmitterUnnested::ComputeReductionCodegenInfo(
   ir_emitter_context_->device_description().cuda_compute_capability(&cc_major,
                                                                     &cc_minor);
 
+  int num_partial_results = 1;
   KernelMappingScheme::IndexingOrder indexing_order = [&]() {
     if (reduction_dimensions.is_row_reduction &&
         // P100, only ttry to vectorize+coales memory access when the
@@ -3227,7 +3211,8 @@ ReductionCodegenInfo IrEmitterUnnested::ComputeReductionCodegenInfo(
                IsUnrollingColumnReductionBeneficial(
                    unnested_hlo, input_shape,
                    reduction_dimensions.dimensions[2])) {
-      reduction_tiling[2] *= 2;
+      num_partial_results = 2;
+      reduction_tiling[2] *= num_partial_results;
       return kLinearIndexingX;
     } else {
       return kStridedIndexingX;
@@ -3250,7 +3235,7 @@ ReductionCodegenInfo IrEmitterUnnested::ComputeReductionCodegenInfo(
       {reduction_tiling[0], reduction_tiling[1] * num_threads_y,
        reduction_tiling[2] * num_threads_x},
       num_threads_y, num_threads_x, indexing_order, vector_size);
-  return ReductionCodegenInfo(mapping_scheme,
+  return ReductionCodegenInfo(mapping_scheme, num_partial_results,
                               reduction_dimensions.is_row_reduction);
 }
 

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -2102,8 +2102,11 @@ static IrArray::Index GetUnnormalizedIndex(
   // If the normalization only add a new dimensions of size 1,
   // generate simpler indexing. LLVM doesn't always simplify the more
   // complicated indexing and this prevents it from vectorizing some
-  // cases.
-  if (unnormalized_shape.rank() == 2) {
+  // cases. We do this only for major_to_minor memory layout.
+  if (unnormalized_shape.rank() == 2 && unnormalized_shape.has_layout() &&
+      unnormalized_shape.dimensions()[0] == normalized_shape_index.dims()[1] &&
+      unnormalized_shape.dimensions()[1] == normalized_shape_index.dims()[2] &&
+      unnormalized_shape.layout().minor_to_major(1) == 0) {
     DCHECK_EQ(normalized_shape_index.dims()[0], 0);
     auto multidim = normalized_shape_index.multidim();
     return IrArray::Index({multidim[1], multidim[2]}, unnormalized_shape,

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -3255,21 +3255,21 @@ ReductionCodegenInfo IrEmitterUnnested::ComputeReductionCodegenInfo(
 
   int tile_size_x = reduction_tiling[2] * num_threads_x;
 
-  int vec_stride = 1;
-  char* env = getenv("VEC_STRIDE");
+  int vector_size = 1;
+  char* env = getenv("VECTOR_SIZE");
   if (indexing_order == KernelMappingScheme::LinearDilatedIndexingX) {
     if (reduction_dimensions.dimensions[2] % tile_size_x == 0 &&
         // As XLA unroll and suppose LLVM will vectorize,
         // disable the unroll for case that LLVM doesn't vectorize.
         !MayPreventVectorization(*unnested_hlo, /*tolerate_reduce*/true)) {
-      vec_stride = 2;
+      vector_size = 2;
     } else {
       indexing_order = KernelMappingScheme::DilatedIndexingX;
     }
   }
   if (env) {
-    vec_stride = atoi(env);
-    if (vec_stride > 1) {
+    vector_size = atoi(env);
+    if (vector_size > 1) {
       indexing_order = KernelMappingScheme::LinearDilatedIndexingX;
     }
   }
@@ -3277,7 +3277,7 @@ ReductionCodegenInfo IrEmitterUnnested::ComputeReductionCodegenInfo(
       reduction_dimensions.dimensions,
       {reduction_tiling[0], reduction_tiling[1] * num_threads_y, tile_size_x},
       num_threads_y, num_threads_x, indexing_order,
-      vec_stride);
+      vector_size);
   return ReductionCodegenInfo(mapping_scheme,
                               reduction_dimensions.is_row_reduction);
 }

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -2013,7 +2013,7 @@ void IrEmitterUnnested::EmitTile(
                 source_idx_x = source_idx_x_base.AddOffsetToDim(constant(i), kDimX, &b_);
               }
               auto emit_element = [&] {
-                return emit_elem_function(source_idx_x, y_loc, x_loc, j);
+                return emit_elem_function(source_idx_x, y_loc, x_loc, old_j);
               };
               if (add_if) {
                 ksl->If(loop_name + "_x_in_tile",

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -3213,16 +3213,16 @@ ReductionCodegenInfo IrEmitterUnnested::ComputeReductionCodegenInfo(
 
   KernelMappingScheme::IndexingOrder indexing_order = [&]() {
     if (reduction_dimensions.is_row_reduction &&
-	// P100, only ttry to vectorize+coales memory access when the
-	// tile size fit exactly and dtypes <= 32 bits
-	((cc_major == 6 && smallest_input_dtype_bits <= 32 && tile_fit) ||
-	 // On V100, only try to vectorize+coales memory access for
-	 // rows of even size.  For odd row sizes, every other row
-	 // isn't aligned, so it can't be vectorized.
-	 (cc_major >= 7 && reduction_dimensions.dimensions[2] % 2 == 0))) {
+        // P100, only ttry to vectorize+coales memory access when the
+        // tile size fit exactly and dtypes <= 32 bits
+        ((cc_major == 6 && smallest_input_dtype_bits <= 32 && tile_fit) ||
+         // On V100, only try to vectorize+coales memory access for
+         // rows of even size.  For odd row sizes, every other row
+         // isn't aligned, so it can't be vectorized.
+         (cc_major >= 7 && reduction_dimensions.dimensions[2] % 2 == 0))) {
       return kLinearStridedIndexingX;
     } else if (!reduction_dimensions.is_row_reduction &&
-	       IsUnrollingColumnReductionBeneficial(
+               IsUnrollingColumnReductionBeneficial(
                    unnested_hlo, input_shape,
                    reduction_dimensions.dimensions[2])) {
       return kLinearIndexingX;

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -2011,6 +2011,7 @@ void IrEmitterUnnested::EmitTile(
             }
           }
         } else {
+          auto unroll = [&](bool add_if, int64 max_element, int64 vec_stride) {
           for (int64 j = 0; j < x_num_steps/vec_stride; j++) {
             //Prep some values. If we do not do this, LLVM doesn't vectorize.
             llvm::Value* x_loc_base =
@@ -2027,7 +2028,7 @@ void IrEmitterUnnested::EmitTile(
               auto emit_element = [&] {
                 return emit_elem_function(source_idx_x, y_loc, x_loc, j);
               };
-              if (!x_tile_fits) {
+              if (add_if) {
                 ksl->If(loop_name + "_x_in_tile",
                         b_.CreateICmpULT(x_loc, tile_width), emit_element);
               } else {
@@ -2035,8 +2036,77 @@ void IrEmitterUnnested::EmitTile(
               }
             }
           }
-        }
-      });
+          };
+
+          char * env_if = getenv("RED_IF");
+          int red_if = 1;
+          if (env_if) {
+            red_if = atoi(env_if);
+            printf("RED_IF2 = %d %s\n", red_if, env_if);
+          }
+          if (red_if == 1) {
+            std::cout << "IF_NB 1: " << std::endl;
+            unroll(!x_tile_fits, x_num_steps, vec_stride);
+          } else if (red_if == 2) {
+            std::cout << "IF_NB 2" << std::endl;
+            ksl->If(loop_name + "_is_full_tile",
+                    //b->CreateICmpULT(last_element, tile_width),
+                    b_.CreateICmpEQ(constant(mapping_scheme.GetTileSizeFor(2)), tile_width),
+                    [&] {unroll(false, x_num_steps, vec_stride);},
+                    [&] {unroll(true, x_num_steps, vec_stride);});
+          } else {
+            std::cout << "IF_NB 3" << std::endl;
+            //b->CreateICmpULT(start_offset_x+j * step_x * vec_stride + i, tile_width)
+            int last_block_left_element = mapping_scheme.GetDimsInElems()[2] % x_num_steps;
+            std::cout << "MAPPING " << mapping_scheme.GetDimsInElems()[0] << " "
+                      << mapping_scheme.GetDimsInElems()[1] << " "
+                      << mapping_scheme.GetDimsInElems()[2] << std::endl;
+            std::cout << "LAST_BLOCK x_num_steps " << x_num_steps
+                      << " last_block" << last_block_left_element << std::endl;
+            // NB block per reduction.
+            int nb_block = CeilOfRatio(mapping_scheme.GetDimsInElems()[2],
+                                       tile_size_x);
+            std::cout << "NB_BLOCK" << nb_block << std::endl;
+            if (x_tile_fits) {
+              // All threads will completly unroll
+              unroll(false, x_num_steps, vec_stride);
+            } else if(nb_block == 1) {
+              // No thread will completly unroll.
+              // TODO: unroll by the right amount
+              unroll(true, x_num_steps, vec_stride);
+            } else {
+              // For some blocks, all threads will will completly unroll.
+              // For other blocks, some of its threads will completly unroll, others will partially and some won't be used.
+              // So do an if(thread fully unroll) {code with no if between elements} else {code with if between each elements}
+              // TODO: in the else part, unroll without if but with the right number of elements left.
+
+              llvm::Value* block_id = gpu::EmitCallToTargetIntrinsic(
+                  gpu::TargetIntrinsicID::kBlockIdx, {}, {}, &b_);
+              llvm::Value* last_element = b_.CreateAdd(constant(x_num_steps * tile_size_x),
+                                                       start_offset_x, "last_element");
+              int x_num_steps_partial = mapping_scheme.GetDimsInElems()[2] % tile_size_x;
+              x_num_steps_partial *= 2;
+              //x_num_steps_partial = x_num_steps;
+              ksl->If(loop_name + "_is_full_tile",
+                      // Test if all the elements of this thread is withing tile.
+                      b_.CreateICmpULT(last_element, tile_width),
+                      // Not the last block, so unroll without ifs.
+                      [&] {unroll(false, x_num_steps, vec_stride);},
+                      // The last block isn't completly unrolled.
+
+                      // TODO: unroll the right size. Take care
+                      // vec_stride must match the above unroll for
+                      // now.
+                      // TODO: after unroll of the right size, remove the IFs.
+                      // ONGOING, try to make it work with less
+                      // then unroll x_num_steps
+
+                       [&] {unroll(true, x_num_steps, vec_stride);}); // works
+              //[&] {unroll(true, x_num_steps, x_num_steps);});
+              //[&] {unroll(true, x_num_steps_partial, vec_stride);});
+            }
+          }
+        }});
 }
 
 // Emits code to process a tensor element in a tile for the given kCopy HLO that

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -2051,6 +2051,7 @@ void IrEmitterUnnested::EmitTile(
             std::cout << "IF_NB 2" << std::endl;
             ksl->If(loop_name + "_is_full_tile",
                     //b->CreateICmpULT(last_element, tile_width),
+                    // If (the thread fully unrolled) {no condition path} else {condition path}
                     b_.CreateICmpEQ(constant(mapping_scheme.GetTileSizeFor(2)), tile_width),
                     [&] {unroll(false, x_num_steps, vec_stride);},
                     [&] {unroll(true, x_num_steps, vec_stride);});

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -3207,7 +3207,8 @@ ReductionCodegenInfo IrEmitterUnnested::ComputeReductionCodegenInfo(
         // dtypes.
         ((cc_major == 6 && smallest_input_dtype_bits <= 16) || cc_major >= 7)) {
       return kLinearStridedIndexingX;
-    } else if (IsUnrollingColumnReductionBeneficial(
+    } else if (!reduction_dimensions.is_row_reduction &&
+	       IsUnrollingColumnReductionBeneficial(
                    unnested_hlo, input_shape,
                    reduction_dimensions.dimensions[2])) {
       return kLinearIndexingX;

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -1935,6 +1935,7 @@ static llvm::Value* GetStartOffsetX(const KernelMappingScheme& mapping_scheme,
   } else if (mapping_scheme.GetIndexingOrder() == kLinearStridedIndexingX) {
     return b->CreateMul(thread_id_x, constant(mapping_scheme.GetVectorSize()));
   }
+  CHECK_EQ(mapping_scheme.GetIndexingOrder(), kLinearIndexingX);
   int64 x_num_steps =
       mapping_scheme.GetTileSizeX() / mapping_scheme.GetNumThreadsX();
   return b->CreateMul(thread_id_x, constant(x_num_steps));

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -2015,13 +2015,9 @@ void IrEmitterUnnested::EmitTile(
 
             for (int i = 0; i < vector_size; i++) {
               int old_j = j * vector_size + i;
-              llvm::Value* x_loc = x_loc_base;
-              IrArray::Index source_idx_x = source_idx_x_base;
-              if (i > 0) {
-                x_loc = b_.CreateAdd(constant(i), x_loc_base, "x_loc");
-                source_idx_x =
-                    source_idx_x_base.AddOffsetToDim(constant(i), kDimX, &b_);
-              }
+              llvm::Value* x_loc = b_.CreateAdd(constant(i), x_loc_base, "x_loc");
+              IrArray::Index source_idx_x =
+                  source_idx_x_base.AddOffsetToDim(constant(i), kDimX, &b_);
               auto emit_element = [&] {
                 return emit_elem_function(source_idx_x, y_loc, x_loc, old_j);
               };

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -3258,7 +3258,7 @@ ReductionCodegenInfo IrEmitterUnnested::ComputeReductionCodegenInfo(
   int vector_size = 1;
   char* env = getenv("VECTOR_SIZE");
   if (indexing_order == KernelMappingScheme::LinearDilatedIndexingX) {
-    if (reduction_dimensions.dimensions[2] % tile_size_x == 0 &&
+    if (reduction_dimensions.dimensions[2] % 2 == 0 &&
         // As XLA unroll and suppose LLVM will vectorize,
         // disable the unroll for case that LLVM doesn't vectorize.
         !MayPreventVectorization(*unnested_hlo, /*tolerate_reduce*/true)) {

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -1865,14 +1865,13 @@ namespace {
 
 // Returns true if the fusion contains any instruction that is likely
 // translated to complex LLVM IR, such as loops, and prevent vectorization.
-bool MayPreventVectorization(const HloInstruction& hlo,
-                             bool tolerate_reduce = false) {
+bool MayPreventVectorization(const HloInstruction& hlo) {
   if (hlo.opcode() == HloOpcode::kFusion) {
     return absl::c_any_of(hlo.fused_instructions_computation()->instructions(),
                           [&](const HloInstruction* instr) {
                             switch (instr->opcode()) {
                               case HloOpcode::kReduce:
-                                return !tolerate_reduce;
+                                return false;
                               case HloOpcode::kReduceWindow:
                               case HloOpcode::kSort:
                               case HloOpcode::kDot:
@@ -1900,7 +1899,7 @@ bool MayPreventVectorization(const HloInstruction& hlo,
         return false;
     }
   } else if (hlo.opcode() == HloOpcode::kReduce) {
-    return !tolerate_reduce;
+    return false;
   }
   return true;
 }
@@ -3213,7 +3212,7 @@ ReductionCodegenInfo IrEmitterUnnested::ComputeReductionCodegenInfo(
     if (reduction_dimensions.dimensions[2] % 2 == 0 &&
         // As XLA unroll and suppose LLVM will vectorize,
         // disable the unroll for case that LLVM doesn't vectorize.
-        !MayPreventVectorization(*unnested_hlo, /*tolerate_reduce*/ true)) {
+        !MayPreventVectorization(*unnested_hlo)) {
       vector_size = 2;
     } else {
       indexing_order = kStridedIndexingX;

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -2004,20 +2004,15 @@ void IrEmitterUnnested::EmitTile(
         auto unroll = [&](bool add_index_boundary_condition,
                           int64 vector_size) {
           for (int64 j = 0; j < x_num_steps / vector_size; j++) {
-            // Prep some values. If we do not do this, LLVM doesn't vectorize.
-            llvm::Value* x_loc_base =
-                b_.CreateAdd(constant(j * step_x * vector_size), start_offset_x,
-                             "x_loc_base");
-            IrArray::Index source_idx_x_base =
-                source_idx.AddOffsetToDim(y_loc, kDimY, &b_)
-                    .AddOffsetToDim(constant(j * step_x * vector_size), kDimX,
-                                    &b_);
-
             for (int i = 0; i < vector_size; i++) {
               int old_j = j * vector_size + i;
-              llvm::Value* x_loc = b_.CreateAdd(constant(i), x_loc_base, "x_loc");
+              llvm::Value* x_loc =
+                  b_.CreateAdd(constant(j * step_x * vector_size + i),
+                               start_offset_x, "x_loc");
               IrArray::Index source_idx_x =
-                  source_idx_x_base.AddOffsetToDim(constant(i), kDimX, &b_);
+                  source_idx.AddOffsetToDim(y_loc, kDimY, &b_)
+                      .AddOffsetToDim(constant(j * step_x * vector_size + i),
+                                      kDimX, &b_);
               auto emit_element = [&] {
                 return emit_elem_function(source_idx_x, y_loc, x_loc, old_j);
               };

--- a/tensorflow/compiler/xla/service/gpu/kernel_mapping_scheme.h
+++ b/tensorflow/compiler/xla/service/gpu/kernel_mapping_scheme.h
@@ -77,13 +77,13 @@ class KernelMappingScheme {
  public:
   enum { DimZ = 0, DimY, DimX, DimTot };
   enum IndexingOrder {
-  // Threads read consecutive elements.
+    // Thread reads consecutive elements.
     LinearIndexingX,
-  // Threads read strided elements while keeping memory coalescing.
+    // Thread reads strided elements while keeping memory coalescing.
     StridedIndexingX,
-  // Threads read a few consecutive elements then take a strided
-  // step. This can trigger vectorized reads and keep memory
-  // coalescing.
+    // Thread reads a few consecutive elements then take a strided
+    // step. This can trigger vectorized reads and keep memory
+    // coalescing.
     LinearStridedIndexingX
   };
 
@@ -152,11 +152,12 @@ class KernelMappingScheme {
   // elements in the X dimension of a tile, each threads process
   // n=tile_size_x/num_threads_x elements.
   // indexing_order_ define which tile's elements each thread reads.
+
   const IndexingOrder indexing_order_;
-  // vector_size_ only supported for row reduction.
-  // Must be a divisor of tile_sizes_[2]/num_threads_x.
-  // Interesting values are 2 and 4 to trigger vectorized loads on GPUs
-  // while keeping memory coalescing.
+  // vector_size_ only supported for row reduction and must be a divisor
+  // of tile_sizes_[2]/num_threads_x.  Interesting values are 2 and 4
+  // to trigger vectorized loads on GPUs while keeping memory
+  // coalescing.
   const int vector_size_;
 };
 

--- a/tensorflow/compiler/xla/service/gpu/kernel_mapping_scheme.h
+++ b/tensorflow/compiler/xla/service/gpu/kernel_mapping_scheme.h
@@ -77,6 +77,12 @@ class KernelMappingScheme {
  public:
   enum { DimZ = 0, DimY, DimX, DimTot };
   // TODO: rename Dilated to Strided?
+  // LinearIndexing mean each thread reads consecutive elements.
+  // DilatedIndexingX mean each thread reads Dilated(Strided)
+  //   elements. This conserve memory coalescing.
+  // LinearDilatedIndexingX mean each thread read a few consecutive
+  //   elements then take a bigger step. The goal is to trigger
+  //   vectorized reads and keep memory coalescing.
   enum IndexingOrder {
     LinearIndexingX,
     DilatedIndexingX,
@@ -146,14 +152,8 @@ class KernelMappingScheme {
 
   // When num_threads_x threads process a total of tile_size_x
   // elements in the X dimension of a tile, each threads process
-  // n=tile_size_x/num_threads_x elements. When indexing_order_ have
-  // the value LinearIndexingX, the n elements processed by a thread
-  // are contiguous. When the value is DilatedIndexingX, the n
-  // elements are dilated by a factor of num_threads_x. When the value
-  // is LinearDilatedIndexingX, it is a mix of both to enable
-  // vectorizing while keeping memory coalescing. It reads
-  // vector_size_ elements, then do a step to the next vector_size_
-  // elements.
+  // n=tile_size_x/num_threads_x elements.
+  // indexing_order_ define which tile's elements each thread reads.
   const IndexingOrder indexing_order_;
   // vector_size_ only supported for row reduction.
   // Must be a divisor of tile_sizes_[2]/num_threads_x.

--- a/tensorflow/compiler/xla/service/gpu/kernel_mapping_scheme.h
+++ b/tensorflow/compiler/xla/service/gpu/kernel_mapping_scheme.h
@@ -76,17 +76,16 @@ namespace gpu {
 class KernelMappingScheme {
  public:
   enum { DimZ = 0, DimY, DimX, DimTot };
-  // TODO: rename Dilated to Strided?
   // LinearIndexing mean each thread reads consecutive elements.
-  // DilatedIndexingX mean each thread reads Dilated(Strided)
-  //   elements. This conserve memory coalescing.
-  // LinearDilatedIndexingX mean each thread read a few consecutive
+  // StridedIndexingX mean each thread reads strided elements.
+  //   This conserve memory coalescing.
+  // LinearStridedIndexingX mean each thread read a few consecutive
   //   elements then take a bigger step. The goal is to trigger
   //   vectorized reads and keep memory coalescing.
   enum IndexingOrder {
     LinearIndexingX,
-    DilatedIndexingX,
-    LinearDilatedIndexingX
+    StridedIndexingX,
+    LinearStridedIndexingX
   };
 
   KernelMappingScheme(absl::Span<const int64> dims_in_elems,
@@ -103,7 +102,7 @@ class KernelMappingScheme {
     CHECK_EQ(tile_sizes[2] % num_threads_x_, 0);
     VLOG(10) << "dims_in_elems_ = " << absl::StrJoin(dims_in_elems_, ",");
     if (indexing_order != LinearIndexingX) {
-      // DilatedIndexingX, and LinearDilatedIndexingX
+      // StridedIndexingX, and LinearStridedIndexingX
       // is for the purpose of vectorization, which requires
       // GetTileSizeFor(DimX) to be a multiplier of num_threads_x_.
       CHECK_EQ(GetTileSizeFor(DimX) % num_threads_x_, 0);

--- a/tensorflow/compiler/xla/service/gpu/kernel_mapping_scheme.h
+++ b/tensorflow/compiler/xla/service/gpu/kernel_mapping_scheme.h
@@ -77,7 +77,11 @@ class KernelMappingScheme {
  public:
   enum { DimZ = 0, DimY, DimX, DimTot };
   // TODO: rename Dilated to Strided?
-  enum IndexingOrder { LinearIndexingX, DilatedIndexingX, LinearDilatedIndexingX };
+  enum IndexingOrder {
+    LinearIndexingX,
+    DilatedIndexingX,
+    LinearDilatedIndexingX
+  };
 
   KernelMappingScheme(absl::Span<const int64> dims_in_elems,
                       absl::Span<const int64> tile_sizes, int64 num_threads_y,
@@ -88,7 +92,7 @@ class KernelMappingScheme {
         num_threads_x_(num_threads_x),
         num_threads_y_(num_threads_y),
         indexing_order_(indexing_order),
-        vector_size_(vector_size){
+        vector_size_(vector_size) {
     CHECK_EQ(tile_sizes[1] % num_threads_y_, 0);
     CHECK_EQ(tile_sizes[2] % num_threads_x_, 0);
     VLOG(10) << "dims_in_elems_ = " << absl::StrJoin(dims_in_elems_, ",");
@@ -124,12 +128,8 @@ class KernelMappingScheme {
     return GetNumThreadsX() * GetNumThreadsY();
   }
 
-  IndexingOrder GetIndexingOrder() const {
-    return indexing_order_;
-  }
-  int GetVectorSize() const {
-    return vector_size_;
-  }
+  IndexingOrder GetIndexingOrder() const { return indexing_order_; }
+  int GetVectorSize() const { return vector_size_; }
 
  private:
   // The number of elements in each dimension.

--- a/tensorflow/compiler/xla/service/gpu/kernel_mapping_scheme.h
+++ b/tensorflow/compiler/xla/service/gpu/kernel_mapping_scheme.h
@@ -76,15 +76,14 @@ namespace gpu {
 class KernelMappingScheme {
  public:
   enum { DimZ = 0, DimY, DimX, DimTot };
-  // LinearIndexing mean each thread reads consecutive elements.
-  // StridedIndexingX mean each thread reads strided elements.
-  //   This conserve memory coalescing.
-  // LinearStridedIndexingX mean each thread read a few consecutive
-  //   elements then take a bigger step. The goal is to trigger
-  //   vectorized reads and keep memory coalescing.
   enum IndexingOrder {
+  // Threads read consecutive elements.
     LinearIndexingX,
+  // Threads read strided elements while keeping memory coalescing.
     StridedIndexingX,
+  // Threads read a few consecutive elements then take a strided
+  // step. This can trigger vectorized reads and keep memory
+  // coalescing.
     LinearStridedIndexingX
   };
 

--- a/tensorflow/compiler/xla/service/gpu/kernel_mapping_scheme.h
+++ b/tensorflow/compiler/xla/service/gpu/kernel_mapping_scheme.h
@@ -158,7 +158,7 @@ class KernelMappingScheme {
   // vector_size_ only supported for row reduction.
   // Must be a divisor of tile_sizes_[2]/num_threads_x.
   // Interesting values are 2 and 4 to trigger vectorized loads on GPUs
-  // While keeping memory coalescing.
+  // while keeping memory coalescing.
   const int vector_size_;
 };
 

--- a/tensorflow/compiler/xla/service/gpu/kernel_mapping_scheme.h
+++ b/tensorflow/compiler/xla/service/gpu/kernel_mapping_scheme.h
@@ -166,8 +166,14 @@ using AddressVector = absl::InlinedVector<llvm::AllocaInst*, 1>;
 class ReductionCodegenInfo {
  public:
   explicit ReductionCodegenInfo(KernelMappingScheme mapping_scheme,
+                                int num_partial_results,
                                 bool is_row_reduction)
-      : mapping_scheme_(mapping_scheme), is_row_reduction_(is_row_reduction) {}
+      : mapping_scheme_(mapping_scheme), num_partial_results_(num_partial_results), is_row_reduction_(is_row_reduction) {
+    if (num_partial_results > 1) {
+      CHECK_EQ(num_partial_results,
+               (mapping_scheme.GetTileSizeX() / mapping_scheme.GetNumThreadsX()));
+    }
+  }
 
   const KernelMappingScheme& GetKernelMappingScheme() const {
     return mapping_scheme_;
@@ -203,6 +209,7 @@ class ReductionCodegenInfo {
     return reduction_input_addresses_;
   }
 
+  int GetNumPartialResults() const { return num_partial_results_; }
   bool IsRowReduction() const { return is_row_reduction_; }
 
   // Gets a pointer to a mutable shared cache used by reduction.
@@ -221,6 +228,7 @@ class ReductionCodegenInfo {
   const KernelMappingScheme mapping_scheme_;
   AddressVector partial_result_addresses_;
   AddressVector reduction_input_addresses_;
+  int num_partial_results_;
   bool is_row_reduction_;
 };
 

--- a/tensorflow/compiler/xla/service/gpu/kernel_mapping_scheme.h
+++ b/tensorflow/compiler/xla/service/gpu/kernel_mapping_scheme.h
@@ -151,9 +151,9 @@ class KernelMappingScheme {
   // When num_threads_x threads process a total of tile_size_x
   // elements in the X dimension of a tile, each threads process
   // n=tile_size_x/num_threads_x elements.
-  // indexing_order_ define which tile's elements each thread reads.
-
+  // indexing_order defines which tile's elements each thread reads.
   const IndexingOrder indexing_order_;
+
   // vector_size_ only supported for row reduction and must be a divisor
   // of tile_sizes_[2]/num_threads_x.  Interesting values are 2 and 4
   // to trigger vectorized loads on GPUs while keeping memory

--- a/tensorflow/compiler/xla/service/gpu/tests/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/tests/BUILD
@@ -165,6 +165,33 @@ tf_cc_test(
 )
 
 tf_cc_test(
+    name = "reduction_vectorization_test",
+    srcs = [
+        "reduction_vectorization_test.cc",
+    ],
+    tags = tf_cuda_tests_tags() + ["no_rocm"],
+    deps = [
+        ":gpu_codegen_test",
+        "//tensorflow/compiler/xla:debug_options_flags",
+        "//tensorflow/compiler/xla:statusor",
+        "//tensorflow/compiler/xla/service:gpu_plugin",
+        "//tensorflow/compiler/xla/service:hlo",
+        "//tensorflow/compiler/xla/service:hlo_module_config",
+        "//tensorflow/compiler/xla/service:hlo_parser",
+        "//tensorflow/compiler/xla/service/gpu:gemm_rewriter",
+        "//tensorflow/compiler/xla/service/gpu:gpu_executable",
+        "//tensorflow/compiler/xla/tests:filecheck",
+        "//tensorflow/compiler/xla/tests:hlo_test_base",
+        "//tensorflow/compiler/xla/tests:llvm_irgen_test_base",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
+        "//tensorflow/stream_executor/lib",
+        "@com_google_absl//absl/memory",
+    ],
+)
+
+tf_cc_test(
     name = "reduction_dimension_grouper_test",
     srcs = [
         "reduction_dimension_grouper_test.cc",

--- a/tensorflow/compiler/xla/service/gpu/tests/reduction_vectorization_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/reduction_vectorization_test.cc
@@ -52,13 +52,32 @@ ENTRY %main {
 )";
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> optimized_module,
                           ParseAndReturnVerifiedModule(hlo_text));
-  CompileAndOptionallyVerifyPtx(std::move(optimized_module),
-                                R"(
+  se::StreamExecutor* executor = backend().default_stream_executor();
+  int cc_major = 0, cc_minor = 0;
+  executor->GetDeviceDescription().cuda_compute_capability(&cc_major,
+                                                           &cc_minor);
+  string expected_ptx;
+  if (cc_major >= 6) {
+    expected_ptx = R"(
 CHECK: ld.global.nc.v2.f32
 CHECK: ld.global.nc.v2.f32
 CHECK: ld.global.nc.v2.f32
 CHECK: ld.global.nc.v2.f32
-)");
+)";
+  } else {
+    expected_ptx = R"(
+CHECK-NOT: ld.global.nc.v2.f32
+CHECK: ld.global.nc.f32
+CHECK: ld.global.nc.f32
+CHECK: ld.global.nc.f32
+CHECK: ld.global.nc.f32
+CHECK: ld.global.nc.f32
+CHECK: ld.global.nc.f32
+CHECK: ld.global.nc.f32
+CHECK: ld.global.nc.f32
+)";
+  }
+  CompileAndOptionallyVerifyPtx(std::move(optimized_module), expected_ptx);
 
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
 }
@@ -81,13 +100,32 @@ ENTRY %main {
 )";
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> optimized_module,
                           ParseAndReturnVerifiedModule(hlo_text));
-  CompileAndOptionallyVerifyPtx(std::move(optimized_module),
-                                R"(
+  se::StreamExecutor* executor = backend().default_stream_executor();
+  int cc_major = 0, cc_minor = 0;
+  executor->GetDeviceDescription().cuda_compute_capability(&cc_major,
+                                                           &cc_minor);
+  string expected_ptx;
+  if (cc_major >= 6) {
+    expected_ptx = R"(
 CHECK: ld.global.nc.v2.f32
 CHECK: ld.global.nc.v2.f32
 CHECK: ld.global.nc.v2.f32
 CHECK: ld.global.nc.v2.f32
-)");
+)";
+  } else {
+    expected_ptx = R"(
+CHECK-NOT: ld.global.nc.v2.f32
+CHECK: ld.global.nc.f32
+CHECK: ld.global.nc.f32
+CHECK: ld.global.nc.f32
+CHECK: ld.global.nc.f32
+CHECK: ld.global.nc.f32
+CHECK: ld.global.nc.f32
+CHECK: ld.global.nc.f32
+CHECK: ld.global.nc.f32
+)";
+  }
+  CompileAndOptionallyVerifyPtx(std::move(optimized_module), expected_ptx);
 
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
 }
@@ -110,8 +148,13 @@ ENTRY %main {
 )";
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> optimized_module,
                           ParseAndReturnVerifiedModule(hlo_text));
-  CompileAndOptionallyVerifyPtx(std::move(optimized_module),
-                                R"(
+  se::StreamExecutor* executor = backend().default_stream_executor();
+  int cc_major = 0, cc_minor = 0;
+  executor->GetDeviceDescription().cuda_compute_capability(&cc_major,
+                                                           &cc_minor);
+  string expected_ptx;
+  if (cc_major >= 7) {
+    expected_ptx = R"(
 CHECK: ld.global.nc.f32
 CHECK: ld.global.nc.f32
 CHECK: ld.global.nc.v2.f32
@@ -121,7 +164,22 @@ CHECK-NOT: ld.global.nc.v2.f32
 // TODO: Make this a vectorized load
 CHECK: ld.global.nc.f32
 CHECK: ld.global.nc.f32
-)");
+)";
+  } else {
+    expected_ptx = R"(
+CHECK-NOT: ld.global.nc.f32
+CHECK: ld.global.nc.f32
+CHECK: ld.global.nc.f32
+CHECK: ld.global.nc.f32
+CHECK: ld.global.nc.f32
+CHECK: ld.global.nc.f32
+CHECK: ld.global.nc.f32
+CHECK: ld.global.nc.f32
+CHECK: ld.global.nc.f32
+CHECK: ld.global.nc.f32
+)";
+  }
+  CompileAndOptionallyVerifyPtx(std::move(optimized_module), expected_ptx);
 
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
 }
@@ -175,10 +233,32 @@ ENTRY %main {
 
   TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> optimized_module,
                           ParseAndReturnVerifiedModule(hlo_text));
-  CompileAndOptionallyVerifyPtx(std::move(optimized_module),
-                                R"(
+  se::StreamExecutor* executor = backend().default_stream_executor();
+  int cc_major = 0, cc_minor = 0;
+  executor->GetDeviceDescription().cuda_compute_capability(&cc_major,
+                                                           &cc_minor);
+  string expected_ptx;
+  if (cc_major >= 6) {
+    expected_ptx = R"(
 CHECK: ld.global.nc.v2.f32
-)");
+CHECK: ld.global.nc.v2.f32
+CHECK: ld.global.nc.v2.f32
+CHECK: ld.global.nc.v2.f32
+)";
+  } else {
+    expected_ptx = R"(
+CHECK-NOT: ld.global.nc.v2.f32
+CHECK: ld.global.nc.f32
+CHECK: ld.global.nc.f32
+CHECK: ld.global.nc.f32
+CHECK: ld.global.nc.f32
+CHECK: ld.global.nc.f32
+CHECK: ld.global.nc.f32
+CHECK: ld.global.nc.f32
+CHECK: ld.global.nc.f32
+)";
+  }
+  CompileAndOptionallyVerifyPtx(std::move(optimized_module), expected_ptx);
 
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
 }

--- a/tensorflow/compiler/xla/service/gpu/tests/reduction_vectorization_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/reduction_vectorization_test.cc
@@ -32,19 +32,7 @@ namespace gpu {
 
 namespace {
 
-class ReductionVectorizationTest : public GpuCodegenTest {
- protected:
-  void EnsureDeterminism(absl::string_view hlo_text) {
-    std::vector<ExecutionProfile> profiles;
-    profiles.emplace_back();
-    profiles.emplace_back();
-    EXPECT_TRUE(RunMultipleTimes(hlo_text,
-                                 /*run_hlo_passes=*/true,
-                                 /*profiles=*/&profiles,
-                                 /*backend_config=*/"",
-                                 /*assert_determinism=*/true));
-  }
-};
+class ReductionVectorizationTest : public GpuCodegenTest {};
 
 TEST_F(ReductionVectorizationTest, Power2) {
   const char* hlo_text = R"(

--- a/tensorflow/compiler/xla/service/gpu/tests/reduction_vectorization_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/reduction_vectorization_test.cc
@@ -1,0 +1,192 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <utility>
+
+#include "tensorflow/compiler/xla/service/gpu/gpu_executable.h"
+#include "tensorflow/compiler/xla/service/gpu/tests/gpu_codegen_test.h"
+#include "tensorflow/compiler/xla/service/hlo_instruction.h"
+#include "tensorflow/compiler/xla/service/hlo_module_config.h"
+#include "tensorflow/compiler/xla/service/hlo_parser.h"
+#include "tensorflow/compiler/xla/statusor.h"
+#include "tensorflow/compiler/xla/tests/filecheck.h"
+#include "tensorflow/compiler/xla/tests/hlo_test_base.h"
+#include "tensorflow/core/lib/core/status_test_util.h"
+#include "tensorflow/core/platform/test.h"
+#include "tensorflow/stream_executor/lib/statusor.h"
+
+namespace xla {
+namespace gpu {
+
+namespace {
+
+class ReductionVectorizationTest : public GpuCodegenTest {
+
+ protected:
+  void EnsureDeterminism(absl::string_view hlo_text) {
+    std::vector<ExecutionProfile> profiles;
+    profiles.emplace_back();
+    profiles.emplace_back();
+    EXPECT_TRUE(RunMultipleTimes(hlo_text,
+                                 /*run_hlo_passes=*/true,
+                                 /*profiles=*/&profiles,
+                                 /*backend_config=*/"",
+                                 /*assert_determinism=*/true));
+  }
+};
+
+TEST_F(ReductionVectorizationTest, Power2) {
+  const char* hlo_text = R"(
+HloModule ReducePower2
+
+%max_ (x.5: f32[], y.6: f32[]) -> f32[] {
+  %x = f32[] parameter(0)
+  %y = f32[] parameter(1)
+  ROOT %maximum.7 = f32[] maximum(f32[] %x, f32[] %y)
+}
+
+ENTRY %cluster_0__XlaCompiledKernel_true__XlaNumConstantArgs_0__XlaNumResourceArgs_0_.25 (param_0: f32[5,131072]) -> f32[5]{0} {
+  %param_0 = f32[5,131072]{1,0} parameter(0), parameter_replication={false}
+  %constant.3 = f32[] constant(0)
+  ROOT %reduce.8 = f32[5]{0} reduce(f32[5,131072]{1,0} %param_0, f32[] %constant.3), dimensions={1}, to_apply=%max_
+}
+)";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> optimized_module,
+                          ParseAndReturnVerifiedModule(hlo_text));
+  CompileAndOptionallyVerifyPtx(std::move(optimized_module),
+                                R"(
+CHECK: ld.global.nc.v2.f32
+)");
+
+  EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
+}
+
+TEST_F(ReductionVectorizationTest, TileFit) {
+  const char* hlo_text = R"(
+HloModule ReduceTileFit
+
+%max_ (x.5: f32[], y.6: f32[]) -> f32[] {
+  %x = f32[] parameter(0)
+  %y = f32[] parameter(1)
+  ROOT %maximum.7 = f32[] maximum(f32[] %x, f32[] %y)
+}
+
+ENTRY %cluster_0__XlaCompiledKernel_true__XlaNumConstantArgs_0__XlaNumResourceArgs_0_.25 (param_0: f32[5,122880]) -> f32[5]{0} {
+  %param_0 = f32[5,122880]{1,0} parameter(0), parameter_replication={false}
+  %constant.3 = f32[] constant(0)
+  ROOT %reduce.8 = f32[5]{0} reduce(f32[5,122880]{1,0} %param_0, f32[] %constant.3), dimensions={1}, to_apply=%max_
+}
+)";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> optimized_module,
+                          ParseAndReturnVerifiedModule(hlo_text));
+  CompileAndOptionallyVerifyPtx(std::move(optimized_module),
+                                R"(
+CHECK: ld.global.nc.v2.f32
+)");
+
+  EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
+}
+
+TEST_F(ReductionVectorizationTest, DisableOddColumns) {
+  const char* hlo_text = R"(
+HloModule ReduceTileFit
+
+%max_ {
+  %x = f32[] parameter(0)
+  %y = f32[] parameter(1)
+  ROOT %maximum.7 = f32[] maximum(%x, %y)
+}
+
+ENTRY %cluster_0__XlaCompiledKernel_true__XlaNumConstantArgs_0__XlaNumResourceArgs_0_.25 (param_0: f32[5,131071]) -> f32[5]{0} {
+  %param_0 = f32[5,131071]{1,0} parameter(0), parameter_replication={false}
+  %constant.3 = f32[] constant(0)
+  ROOT %reduce.8 = f32[5]{0} reduce(f32[5,131071]{1,0} %param_0, f32[] %constant.3), dimensions={1}, to_apply=%max_
+}
+)";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> optimized_module,
+                          ParseAndReturnVerifiedModule(hlo_text));
+  CompileAndOptionallyVerifyPtx(std::move(optimized_module),
+                                R"(
+CHECK-NOT: ld.global.nc.v2.f32
+CHECK-NOT: ld.global.nc.v4.f32
+CHECK-NOT: ld.global.nc.u64
+CHECK-NOT: ld.global.u64
+)");
+
+  EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
+}
+
+TEST_F(ReductionVectorizationTest, Exp) {
+  const char* hlo_text = R"(
+HloModule DisableSin
+
+%add_float {
+  %x = f32[] parameter(0)
+  %y = f32[] parameter(1)
+  ROOT %add.17 = f32[] add(f32[] %x, f32[] %y)
+}
+
+ENTRY %cluster_0 {
+  %arg0.1 = f32[5,131072]{1,0} parameter(0)
+  %sine = f32[5,131072]{1,0} exponential(f32[5,131072]{1,0} %arg0.1)
+  %constant.0 = f32[] constant(0)
+  ROOT %reduce.18 = f32[5]{0} reduce(f32[5,131072]{1,0} %sine, f32[] %constant.0), dimensions={1}, to_apply=%add_float
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> optimized_module,
+                          ParseAndReturnVerifiedModule(hlo_text));
+  CompileAndOptionallyVerifyPtx(std::move(optimized_module),
+                                R"(
+CHECK: ld.global.nc.v2.f32
+)");
+
+  EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
+}
+
+TEST_F(ReductionVectorizationTest, DisableSin) {
+  const char* hlo_text = R"(
+HloModule DisableSin
+
+%add_float {
+  %x = f32[] parameter(0)
+  %y = f32[] parameter(1)
+  ROOT %add.17 = f32[] add(f32[] %x, f32[] %y)
+}
+
+ENTRY %cluster_0 {
+  %arg0.1 = f32[5,131072]{1,0} parameter(0)
+  %sine = f32[5,131072]{1,0} sine(f32[5,131072]{1,0} %arg0.1)
+  %constant.0 = f32[] constant(0)
+  ROOT %reduce.18 = f32[5]{0} reduce(f32[5,131072]{1,0} %sine, f32[] %constant.0), dimensions={1}, to_apply=%add_float
+}
+)";
+
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> optimized_module,
+                          ParseAndReturnVerifiedModule(hlo_text));
+  CompileAndOptionallyVerifyPtx(std::move(optimized_module),
+                                R"(
+CHECK-NOT: ld.global.nc.v2.f32
+CHECK-NOT: ld.global.nc.v4.f32
+CHECK-NOT: ld.global.nc.u64
+CHECK-NOT: ld.global.u64
+)");
+
+  EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
+}
+
+}  // namespace
+}  // namespace gpu
+}  // namespace xla

--- a/tensorflow/compiler/xla/service/gpu/tests/reduction_vectorization_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/reduction_vectorization_test.cc
@@ -106,7 +106,7 @@ CHECK: ld.global.nc.v2.f32
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
 }
 
-TEST_F(ReductionVectorizationTest, EvenColums) {
+TEST_F(ReductionVectorizationTest, EvenColumns) {
   const char* hlo_text = R"(
 HloModule ReducePower2
 
@@ -133,7 +133,7 @@ CHECK-NOT: ld.global.nc.v2.f32
 CHECK: ld.global.nc.v2.f32
 CHECK: ld.global.nc.v2.f32
 CHECK-NOT: ld.global.nc.v2.f32
-// TODO: find how to modify LLVM/opt to get this merged? vectorize before some loop opt?
+// TODO: Make this a vectorized load
 CHECK: ld.global.nc.f32
 CHECK: ld.global.nc.f32
 )");

--- a/tensorflow/compiler/xla/service/gpu/tests/reduction_vectorization_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/reduction_vectorization_test.cc
@@ -33,7 +33,6 @@ namespace gpu {
 namespace {
 
 class ReductionVectorizationTest : public GpuCodegenTest {
-
  protected:
   void EnsureDeterminism(absl::string_view hlo_text) {
     std::vector<ExecutionProfile> profiles;

--- a/tensorflow/compiler/xla/service/gpu/tests/reduction_vectorization_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/reduction_vectorization_test.cc
@@ -83,9 +83,7 @@ ENTRY %main {
                           ParseAndReturnVerifiedModule(hlo_text));
   CompileAndOptionallyVerifyPtx(std::move(optimized_module),
                                 R"(
-// TODO: Make this a vectorized load
-CHECK: ld.global.nc.f32
-CHECK: ld.global.nc.f32
+CHECK: ld.global.nc.v2.f32
 CHECK: ld.global.nc.v2.f32
 CHECK: ld.global.nc.v2.f32
 CHECK: ld.global.nc.v2.f32
@@ -116,8 +114,7 @@ ENTRY %main {
                                 R"(
 CHECK: ld.global.nc.f32
 CHECK: ld.global.nc.f32
-// TODO: Make this a vectorized load
-CHECK-NOT: ld.global.nc.v2.f32
+CHECK: ld.global.nc.v2.f32
 CHECK: ld.global.nc.v2.f32
 CHECK: ld.global.nc.v2.f32
 CHECK-NOT: ld.global.nc.v2.f32


### PR DESCRIPTION
This depend on LLVM commit: https://reviews.llvm.org/D74444 that is recently merged in XLA.

This PR vectorize row reduction for even row size.
For odd row size, every other row is unaligned. So would need a more complicated fix.
On a reduction of size 32x131070, I have no speed up for a max reduction, but I have 1.21x speed on the sum+pw reduction from the softmax in float16.

This was benchmarked on the row major "Softmax" TF operations.
The optimized graph contain 3 main operations: reduce_8 (the max reduction), fusion_1 (the exponential and sum reduction), fusion (the post normalization pw operations, ignored).
This was benchmarked with a matrix of input shape (32x131070) with float16 dtype:

| Kernel     | Before PR | After PR | Speed up |
| ---------- | ---------- | ---------- | ---------- |
| fusion_1  | 39.827us  | 33.843us | 1.18x |
| reduce_8 | 22.112us  | 22.047us | 1x |

Here is the not optimized HLO:
```
HloModule cluster_0
%max_ {
  %x = f16[] parameter(0)
  %y = f16[] parameter(1)
  ROOT %maximum = f16[] maximum(%x, %y)
}

%add_ {
  %x = f32[] parameter(0)
  %y = f32[] parameter(1)
  ROOT %add = f32[] add(%x, %y)
}

ENTRY %main {
  %arg0.1 = f16[32,131070]{1,0} parameter(0)
  %constant.3 = f16[] constant(-inf)
  %pad1 = f16[32,131070] pad(%arg0.1, %constant.3), padding=0_0_0x0_0_0
  %reduce.8 = f16[32]{0} reduce(%pad1, %constant.3), dimensions={1}, to_apply=%max_
  %broadcast.9 = f16[32,131070]{1,0} broadcast(%reduce.8), dimensions={0}
  %subtract.131070 = f16[32,131070]{1,0} subtract(%arg0.1, %broadcast.9)
  %exponential.11 = f16[32,131070]{1,0} exponential(%subtract.131070)
  %convert.12 = f32[32,131070]{1,0} convert(%exponential.11)
  %constant.13 = f32[] constant(0)
  %pad2 = f32[32,131070] pad(%convert.12, %constant.13), padding=0_0_0x0_0_0
  %reduce.18 = f32[32]{0} reduce(%pad2, %constant.13), dimensions={1}, to_apply=%add_
  %convert.19 = f16[32]{0} convert(%reduce.18)
  %broadcast.20 = f16[32,131070]{1,0} broadcast(%convert.19), dimensions={0}
  ROOT %divide.21 = f16[32,131070]{1,0} divide(%exponential.11, f16[32,131070]{1,0} %broadcast.20)
}
```



