### PR TITLE
[r2.2:Cherrypick] Reject code containing the for/else pattern, which is not being faithfully converted at the moment. This replaces silently incorrect behavior with a warning. Also whitelist known urllib module.

### DIFF
--- a/tensorflow/python/autograph/core/config.py
+++ b/tensorflow/python/autograph/core/config.py
@@ -45,6 +45,7 @@ CONVERSION_RULES = (
     DoNotConvert('pstats'),
     DoNotConvert('re'),
     DoNotConvert('threading'),
+    DoNotConvert('urllib'),
 
     # Known libraries
     DoNotConvert('matplotlib'),

--- a/tensorflow/python/autograph/core/unsupported_features_checker.py
+++ b/tensorflow/python/autograph/core/unsupported_features_checker.py
@@ -33,17 +33,28 @@ class UnsupportedFeaturesChecker(gast.NodeVisitor):
     if (node.attr is not None
         and node.attr.startswith('__') and not node.attr.endswith('__')):
       raise errors.UnsupportedLanguageElementError(
-          'mangled names are not yet supported by AutoGraph')
+          'mangled names are not yet supported')
+    self.generic_visit(node)
+
+  def visit_For(self, node):
+    if node.orelse:
+      raise errors.UnsupportedLanguageElementError(
+          'for/else statement not yet supported')
+    self.generic_visit(node)
+
+  def visit_While(self, node):
+    if node.orelse:
+      raise errors.UnsupportedLanguageElementError(
+          'while/else statement not yet supported')
+    self.generic_visit(node)
 
   # These checks could potentially be replaced with inspect.isgeneratorfunction
   # to avoid a getsource/parse/ast-walk round trip.
   def visit_Yield(self, node):
-    raise errors.UnsupportedLanguageElementError(
-        'generators are not supported by AutoGraph')
+    raise errors.UnsupportedLanguageElementError('generators are not supported')
 
   def visit_YieldFrom(self, node):
-    raise errors.UnsupportedLanguageElementError(
-        'generators are not supported by AutoGraph')
+    raise errors.UnsupportedLanguageElementError('generators are not supported')
 
 
 def verify(node):


### PR DESCRIPTION
PiperOrigin-RevId: 298586574
Change-Id: Idd9113ccc699eb6b13cd5ec76c563a79b20b7aef