### PR TITLE
Undo changes to the input spec when RNN.unroll is True.

### DIFF
--- a/tensorflow/python/keras/layers/recurrent.py
+++ b/tensorflow/python/keras/layers/recurrent.py
@@ -534,8 +534,7 @@ class RNN(Layer):
       batch_index, time_step_index = (1, 0) if self.time_major else (0, 1)
       if not self.stateful:
         input_spec_shape[batch_index] = None
-      if not getattr(self, 'unroll', False):
-        input_spec_shape[time_step_index] = None
+      input_spec_shape[time_step_index] = None
       return InputSpec(shape=tuple(input_spec_shape))
 
     def get_step_input_shape(shape):

--- a/tensorflow/python/keras/saving/saved_model/saved_model_test.py
+++ b/tensorflow/python/keras/saving/saved_model/saved_model_test.py
@@ -661,8 +661,11 @@ class TestModelSavingAndLoadingV2(keras_parameterized.TestCase):
     self.assertAllClose(loaded.predict_on_batch(array_ops.ones((3, 2, 1))),
                         predictions)
 
-  @parameterized.named_parameters([('with_unrolling', True),
-                                   ('no_unrolling', False)])
+  @parameterized.named_parameters([
+      # TODO(b/148491963): Unrolling does not work with SavedModel
+      # ('with_unrolling', True),
+      ('no_unrolling', False)
+  ])
   def testSaveStatefulRNN(self, unroll):
     batch = 12
     timesteps = 10


### PR DESCRIPTION

The changes from fc7116dd0d087e707adacf6d1f4c6f3e76d83b8c that made the input spec more stringent do not apply to all unrolled recurrent layers. I'll have to revisit b/148491963 later.


PiperOrigin-RevId: 298492355
Change-Id: I442ad2a23576cae8fa2fad02a27a199f13b159c1