### PR TITLE
[bugfix] Fix Quantized Leaky ReLU TFLite inference Ops.

### DIFF
--- a/tensorflow/lite/kernels/activations.cc
+++ b/tensorflow/lite/kernels/activations.cc
@@ -1093,35 +1093,34 @@ TfLiteStatus LeakyReluEval(TfLiteContext* context, TfLiteNode* node) {
   const LeakyReluOpData* data =
       reinterpret_cast<LeakyReluOpData*>(node->user_data);
 
+  LeakyReluParams op_params;
   switch (input->type) {
     case kTfLiteFloat32: {
-      LeakyReluParams op_params{params->alpha};
+      op_params.alpha = params->alpha;
       optimized_ops::LeakyRelu(
           op_params, GetTensorShape(input), GetTensorData<float>(input),
           GetTensorShape(output), GetTensorData<float>(output));
       return kTfLiteOk;
     } break;
     case kTfLiteUInt8: {
-      LeakyReluParams op_params{0.,
-                                input->params.zero_point,
-                                output->params.zero_point,
-                                data->output_multiplier_alpha,
-                                data->output_shift_alpha,
-                                data->output_multiplier_identity,
-                                data->output_shift_identity};
+      op_params.input_offset = input->params.zero_point;
+      op_params.output_offset = output->params.zero_point;
+      op_params.output_multiplier_alpha = data->output_multiplier_alpha;
+      op_params.output_shift_alpha = data->output_shift_alpha;
+      op_params.output_multiplier_identity = data->output_multiplier_identity;
+      op_params.output_shift_identity = data->output_shift_identity;
       reference_ops::QuantizeLeakyRelu(
           op_params, GetTensorShape(input), GetTensorData<uint8_t>(input),
           GetTensorShape(output), GetTensorData<uint8_t>(output));
       return kTfLiteOk;
     } break;
     case kTfLiteInt8: {
-      LeakyReluParams op_params{0.,
-                                input->params.zero_point,
-                                output->params.zero_point,
-                                data->output_multiplier_alpha,
-                                data->output_shift_alpha,
-                                data->output_multiplier_identity,
-                                data->output_shift_identity};
+      op_params.input_offset = input->params.zero_point;
+      op_params.output_offset = output->params.zero_point;
+      op_params.output_multiplier_alpha = data->output_multiplier_alpha;
+      op_params.output_shift_alpha = data->output_shift_alpha;
+      op_params.output_multiplier_identity = data->output_multiplier_identity;
+      op_params.output_shift_identity = data->output_shift_identity;
       reference_ops::QuantizeLeakyRelu(
           op_params, GetTensorShape(input), GetTensorData<int8_t>(input),
           GetTensorShape(output), GetTensorData<int8_t>(output));

--- a/tensorflow/lite/kernels/activations.cc
+++ b/tensorflow/lite/kernels/activations.cc
@@ -380,7 +380,7 @@ TfLiteStatus LeakyReluPrepare(TfLiteContext* context, TfLiteNode* node) {
     TF_LITE_ENSURE(context, q_alpha <= std::numeric_limits<uint8_t>::max());
     // q_alpha will be stored as uint8_t. It won't affect the input
     data->q_alpha = q_alpha;
-    std::cout << "Quantized Q alpha value is: " << int(data->q_alpha) << '\n';
+
     // q_identity is used to make sure those>0 get correct value after dequantization.
     data->q_identity = ZOOM_FACTOR;
     data->zero_point = ZERO_POINT;

--- a/tensorflow/lite/kernels/activations_test.cc
+++ b/tensorflow/lite/kernels/activations_test.cc
@@ -95,10 +95,11 @@ class BaseActivationsOpModel : public SingleOpModel {
   // A dedicated constructor for LeakyRelu, which does some options.
   BaseActivationsOpModel(TensorData input, float alpha) {
     input_ = AddInput(input);
-    if (input.type == TensorType_UINT8) {
-      output_ = AddOutput({input.type, {}, input.min, input.max});
-    } else if (input.type == TensorType_INT8) {
-      output_ = AddOutput({TensorType_INT8, {}, input.min, input.max});
+    // The output scale and input scale might be different.
+    if (input.type == TensorType_UINT8 || input.type == TensorType_INT8) {
+      auto output_min = (input.min >= 0)? input.min: input.min * alpha;
+      auto output_max = (input.max >= 0)? input.max: input.max * alpha;
+      output_ = AddOutput({input.type, {}, output_min, output_max});
     } else {
       output_ = AddOutput({input.type, {}});
     }
@@ -488,15 +489,35 @@ TEST(QuantizedActivationsOpTest, LeakyReluUint8) {
                       0.0f, 1.0f, 3.0f,    // Row 1
                       1.0f, -0.5f, -1.0f,  // Row 2
                   },
-                  kQuantizedTolerance)));
-  EXPECT_THAT(m.GetOutput<uint8_t>(), ElementsAreArray({
-                                          128,
-                                          144,
-                                          176,
-                                          144,
-                                          120,
-                                          112,
-                                      }));
+                  kQuantizedTolerance*8)));
+}
+
+
+TEST(QuantizedActivationsOpTest, LeakyReluInt8) {
+  const float kMin = -1;
+  const float kMax = 127.f / 128.f;
+
+  QuantizedActivationsOpModel m(
+      /*input=*/{TensorType_INT8, {5, 5}, 5 * kMin, 5 * kMax}, 0.1);
+
+  m.SetInput<int8_t>({
+                          -5.0f, -4.6f, -4.2f, -3.8f, -3.4f, // Row 1
+                          -3.0f, -2.6f, -2.2f, -1.8f, -1.4f, // Row 2
+                          -1.0f, -0.6f, -0.2f,  0.2f,  0.6f, // Row 3
+                           1.0f,  1.4f,  1.8f,  2.2f,  2.6f, // Row 4
+                           3.0f,  3.4f,  3.8f,  4.2f,  4.6f, // Row 5
+                      });
+  m.Invoke();
+  EXPECT_THAT(m.GetDequantizedOutput<int8_t>(),
+              ElementsAreArray(ArrayFloatNear(
+                  {
+                      -0.50f, -0.46f, -0.42f, -0.38f, -0.34f, // Row 1
+                      -0.30f, -0.26f, -0.22f, -0.18f, -0.14f, // Row 2
+                      -0.10f, -0.06f, -0.02f,  0.20f,  0.60f, // Row 3
+                       1.00f,  1.40f,  1.80f,  2.20f,  2.60f, // Row 4
+                       3.00f,  3.40f,  3.80f,  4.20f,  4.60f, // Row 5
+                  },
+                  kQuantizedTolerance*5)));
 }
 
 TEST(QuantizedActivationsOpTest, Relu1Int8) {

--- a/tensorflow/lite/kernels/activations_test.cc
+++ b/tensorflow/lite/kernels/activations_test.cc
@@ -97,8 +97,8 @@ class BaseActivationsOpModel : public SingleOpModel {
     input_ = AddInput(input);
     // The output scale and input scale might be different.
     if (input.type == TensorType_UINT8 || input.type == TensorType_INT8) {
-      auto output_min = (input.min >= 0)? input.min: input.min * alpha;
-      auto output_max = (input.max >= 0)? input.max: input.max * alpha;
+      auto output_min = (input.min >= 0) ? input.min : input.min * alpha;
+      auto output_max = (input.max >= 0) ? input.max : input.max * alpha;
       output_ = AddOutput({input.type, {}, output_min, output_max});
     } else {
       output_ = AddOutput({input.type, {}});
@@ -489,9 +489,8 @@ TEST(QuantizedActivationsOpTest, LeakyReluUint8) {
                       0.0f, 1.0f, 3.0f,    // Row 1
                       1.0f, -0.5f, -1.0f,  // Row 2
                   },
-                  kQuantizedTolerance*8)));
+                  kQuantizedTolerance * 8)));
 }
-
 
 TEST(QuantizedActivationsOpTest, LeakyReluInt8) {
   const float kMin = -1;
@@ -501,23 +500,23 @@ TEST(QuantizedActivationsOpTest, LeakyReluInt8) {
       /*input=*/{TensorType_INT8, {5, 5}, 5 * kMin, 5 * kMax}, 0.1);
 
   m.SetInput<int8_t>({
-                          -5.0f, -4.6f, -4.2f, -3.8f, -3.4f, // Row 1
-                          -3.0f, -2.6f, -2.2f, -1.8f, -1.4f, // Row 2
-                          -1.0f, -0.6f, -0.2f,  0.2f,  0.6f, // Row 3
-                           1.0f,  1.4f,  1.8f,  2.2f,  2.6f, // Row 4
-                           3.0f,  3.4f,  3.8f,  4.2f,  4.6f, // Row 5
-                      });
+      -5.0f, -4.6f, -4.2f, -3.8f, -3.4f,  // Row 1
+      -3.0f, -2.6f, -2.2f, -1.8f, -1.4f,  // Row 2
+      -1.0f, -0.6f, -0.2f, 0.2f,  0.6f,   // Row 3
+      1.0f,  1.4f,  1.8f,  2.2f,  2.6f,   // Row 4
+      3.0f,  3.4f,  3.8f,  4.2f,  4.6f,   // Row 5
+  });
   m.Invoke();
   EXPECT_THAT(m.GetDequantizedOutput<int8_t>(),
               ElementsAreArray(ArrayFloatNear(
                   {
-                      -0.50f, -0.46f, -0.42f, -0.38f, -0.34f, // Row 1
-                      -0.30f, -0.26f, -0.22f, -0.18f, -0.14f, // Row 2
-                      -0.10f, -0.06f, -0.02f,  0.20f,  0.60f, // Row 3
-                       1.00f,  1.40f,  1.80f,  2.20f,  2.60f, // Row 4
-                       3.00f,  3.40f,  3.80f,  4.20f,  4.60f, // Row 5
+                      -0.50f, -0.46f, -0.42f, -0.38f, -0.34f,  // Row 1
+                      -0.30f, -0.26f, -0.22f, -0.18f, -0.14f,  // Row 2
+                      -0.10f, -0.06f, -0.02f, 0.20f,  0.60f,   // Row 3
+                      1.00f,  1.40f,  1.80f,  2.20f,  2.60f,   // Row 4
+                      3.00f,  3.40f,  3.80f,  4.20f,  4.60f,   // Row 5
                   },
-                  kQuantizedTolerance*5)));
+                  kQuantizedTolerance * 5)));
 }
 
 TEST(QuantizedActivationsOpTest, Relu1Int8) {

--- a/tensorflow/lite/kernels/internal/reference/reference_ops.h
+++ b/tensorflow/lite/kernels/internal/reference/reference_ops.h
@@ -26,7 +26,6 @@ limitations under the License.
 #include <memory>
 #include <type_traits>
 
-#include "third_party/eigen3/Eigen/Core"
 #include "fixedpoint/fixedpoint.h"
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/experimental/ruy/profiler/instrumentation.h"
@@ -60,6 +59,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/strided_slice_logic.h"
 #include "tensorflow/lite/kernels/internal/tensor.h"
 #include "tensorflow/lite/kernels/internal/types.h"
+#include "third_party/eigen3/Eigen/Core"
 
 namespace tflite {
 
@@ -265,7 +265,7 @@ inline void LeakyRelu(const tflite::LeakyReluParams& params,
 }
 
 template <typename T>
-inline void QuantizeLeakyRelu(const LeakyReluParamsQuant& params,
+inline void QuantizeLeakyRelu(const LeakyReluParams& params,
                               const RuntimeShape& input_shape,
                               const T* input_data,
                               const RuntimeShape& output_shape,
@@ -279,16 +279,14 @@ inline void QuantizeLeakyRelu(const LeakyReluParamsQuant& params,
     int32 unclamped_output;
     if (input_value >= 0) {
       unclamped_output = params.output_offset +
-          MultiplyByQuantizedMultiplier(
-              input_value,
-              params.output_multiplier_identity,
-              params.output_shift_identity);
+                         MultiplyByQuantizedMultiplier(
+                             input_value, params.output_multiplier_identity,
+                             params.output_shift_identity);
     } else {
       unclamped_output = params.output_offset +
-          MultiplyByQuantizedMultiplier(
-              input_value,
-              params.output_multiplier_alpha,
-              params.output_shift_alpha);
+                         MultiplyByQuantizedMultiplier(
+                             input_value, params.output_multiplier_alpha,
+                             params.output_shift_alpha);
     }
     const T clamped_output =
         std::min(quantized_max, std::max(quantized_min, unclamped_output));

--- a/tensorflow/lite/kernels/internal/types.h
+++ b/tensorflow/lite/kernels/internal/types.h
@@ -1081,16 +1081,12 @@ struct UnpackParams {
 
 struct LeakyReluParams {
   float alpha;
-};
-
-
-struct LeakyReluParamsQuant {
   int32 input_offset;
   int32 output_offset;
   int32 output_multiplier_alpha;
-  int output_shift_alpha;
+  int32 output_shift_alpha;
   int32 output_multiplier_identity;
-  int output_shift_identity;
+  int32 output_shift_identity;
 };
 
 template <typename P>

--- a/tensorflow/lite/kernels/internal/types.h
+++ b/tensorflow/lite/kernels/internal/types.h
@@ -1081,8 +1081,14 @@ struct UnpackParams {
 
 struct LeakyReluParams {
   float alpha;
-  int32 input_offset;
+};
+
+
+struct LeakyReluParamsQuant {
+  uint8_t q_alpha;
+  uint8_t q_identity;
   int32 alpha_offset;
+  int32 input_offset;
   int32 output_offset;
   int32 output_multiplier;
   int output_shift;

--- a/tensorflow/lite/kernels/internal/types.h
+++ b/tensorflow/lite/kernels/internal/types.h
@@ -1085,13 +1085,12 @@ struct LeakyReluParams {
 
 
 struct LeakyReluParamsQuant {
-  uint8_t q_alpha;
-  uint8_t q_identity;
-  int32 alpha_offset;
   int32 input_offset;
   int32 output_offset;
-  int32 output_multiplier;
-  int output_shift;
+  int32 output_multiplier_alpha;
+  int output_shift_alpha;
+  int32 output_multiplier_identity;
+  int output_shift_identity;
 };
 
 template <typename P>

--- a/tensorflow/lite/kernels/register.cc
+++ b/tensorflow/lite/kernels/register.cc
@@ -258,8 +258,8 @@ BuiltinOpResolver::BuiltinOpResolver() {
   AddBuiltin(BuiltinOperator_FLOOR_MOD, Register_FLOOR_MOD());
   AddBuiltin(BuiltinOperator_RANGE, Register_RANGE());
   AddBuiltin(BuiltinOperator_LEAKY_RELU, Register_LEAKY_RELU(),
-          /* min_version */ 1,
-          /* max_version */ 2);
+             /* min_version */ 1,
+             /* max_version */ 2);
   AddBuiltin(BuiltinOperator_SQUARED_DIFFERENCE, Register_SQUARED_DIFFERENCE());
   AddBuiltin(BuiltinOperator_FILL, Register_FILL());
   AddBuiltin(BuiltinOperator_MIRROR_PAD, Register_MIRROR_PAD());

--- a/tensorflow/lite/kernels/register.cc
+++ b/tensorflow/lite/kernels/register.cc
@@ -257,7 +257,9 @@ BuiltinOpResolver::BuiltinOpResolver() {
   AddBuiltin(BuiltinOperator_ZEROS_LIKE, Register_ZEROS_LIKE());
   AddBuiltin(BuiltinOperator_FLOOR_MOD, Register_FLOOR_MOD());
   AddBuiltin(BuiltinOperator_RANGE, Register_RANGE());
-  AddBuiltin(BuiltinOperator_LEAKY_RELU, Register_LEAKY_RELU());
+  AddBuiltin(BuiltinOperator_LEAKY_RELU, Register_LEAKY_RELU(),
+          /* min_version */ 1,
+          /* max_version */ 2);
   AddBuiltin(BuiltinOperator_SQUARED_DIFFERENCE, Register_SQUARED_DIFFERENCE());
   AddBuiltin(BuiltinOperator_FILL, Register_FILL());
   AddBuiltin(BuiltinOperator_MIRROR_PAD, Register_MIRROR_PAD());


### PR DESCRIPTION
This PR addresses TFLite Leaky ReLU inference failure when the input/output type is INT8. See https://github.com/tensorflow/tensorflow/issues/33397. 

Firstly, BuiltIn LeakyReLU OP v2 was included in the register list.

Secondly, the INT8 version of Leaky ReLU inference was implemented. Also, the initially implementation (UINT8) was only correct when the input and output scale are the same, which was fixed. A few test cases was added to test UINT8 and INT8 version.