### PR TITLE
Fix TF-TRT control edges between TRTEngineOp nodes

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_graph.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_graph.cc
@@ -103,6 +103,15 @@ std::pair<TfGpuId, PlatformGpuId> GetFirstValidDeviceId() {
   return std::make_pair(TfGpuId(-1), PlatformGpuId(-1));
 }
 
+// Returns false for const nodes (we intend to drop control edges from those).
+bool ShallKeepControlEdgeFrom(const Node* input_node) {
+  if (!input_node) {
+    VLOG(2) << "Node pointer is null, this should not happen";
+    return false;
+  }
+  return input_node->type_string() != "Const";
+}
+
 // Function to get subsegment information structure.
 Status GetEngineInfo(const Graph* g,
                      const grappler::GraphProperties& graph_properties,
@@ -172,7 +181,7 @@ Status GetEngineInfo(const Graph* g,
         continue;
       }
       if (edge->IsControlEdge()) {
-        if (input_node->type_string() != "Const") {
+        if (ShallKeepControlEdgeFrom(input_node)) {
           // Non-Const control input.
           info->connections.emplace_back(input_node->name(), input_node->id(),
                                          node_name, node_id,
@@ -221,7 +230,7 @@ Status GetEngineInfo(const Graph* g,
       }
       if (edge->IsControlEdge()) {
         // Control output.
-        if (node->type_string() != "Const") {
+        if (ShallKeepControlEdgeFrom(node)) {
           info->connections.emplace_back(output_node->name(), output_node->id(),
                                          node_name, node_id,
                                          /*input_edge=*/false);

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_graph.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_graph.cc
@@ -106,7 +106,7 @@ std::pair<TfGpuId, PlatformGpuId> GetFirstValidDeviceId() {
 // Returns false for const nodes (we intend to drop control edges from those).
 bool ShallKeepControlEdgeFrom(const Node* input_node) {
   if (!input_node) {
-    VLOG(2) << "Node pointer is null, this should not happen";
+    LOG(FATAL) << "Node pointer is null, this should not happen";
     return false;
   }
   return input_node->type_string() != "Const";

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_graph.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_graph.cc
@@ -221,9 +221,11 @@ Status GetEngineInfo(const Graph* g,
       }
       if (edge->IsControlEdge()) {
         // Control output.
-        info->connections.emplace_back(output_node->name(), output_node->id(),
-                                       node_name, node_id,
-                                       /*input_edge=*/false);
+        if (node->type_string() != "Const") {
+          info->connections.emplace_back(output_node->name(), output_node->id(),
+                                         node_name, node_id,
+                                         /*input_edge=*/false);
+        }
       } else {
         // Data output.
         int port = Graph::kControlSlot - 1;


### PR DESCRIPTION
This PR fixes https://github.com/tensorflow/tensorrt/issues/181. 

There is a bug in handling control edges between two TRTEngineOp nodes. Tagging @aaroey for review since he was the last one changing the [input edge handling](https://github.com/tensorflow/tensorflow/commit/93bf7372515057204fdadc4db367cfb7136f8e85), and this PR is about doing the same for the output edges. 

**Problem description**
After the graph is segmented, an EngineInfo struct is created for each segment, which list the connections with nodes outside of the segment.

1. For some reason input control edges from const nodes are omitted here: https://github.com/tensorflow/tensorflow/blob/c1915ebc2ad8115636f88b69884194da2f111fa8/tensorflow/compiler/tf2tensorrt/convert/convert_graph.cc#L174-L180
2. At the same time output control edges from const nodes are not omitted: https://github.com/tensorflow/tensorflow/blob/c1915ebc2ad8115636f88b69884194da2f111fa8/tensorflow/compiler/tf2tensorrt/convert/convert_graph.cc#L222-L227

This leads fatal error in the following case:
- there is a control edge from TRTEngineOp_0 --> TRTEngineOp_1 and
- the original node int TRTEngineOp_0 was const.

So let's consider such a case:
- const node A in TRTEgineOp_0
- node B in TRTEngineOp_1, and 
- a control edge A->B in between. 

The error occurs the following way: 
Because of (2.), the A->B edge is listed for TRTEngineOp_0, and we try to rewire this edge for TRTEngineOp_0 [here](https://github.com/tensorflow/tensorflow/blob/c1915ebc2ad8115636f88b69884194da2f111fa8/tensorflow/compiler/tf2tensorrt/convert/convert_graph.cc#L515). `UpdateToEngineNode` tries to look up edge A->B in the EnigineInfo->connections list for TRTEngineOp_1. This was not not added to the list (1.), and UpdateToEngineNode returns with a fatal error.

**Fix**
The problem can be fixed by omitting control edges from const nodes. Alternatively one could consider keeping the control input edges from const nodes. 

**Note**
It seems the way the control edges are wired for the same high level (Keras) network changes between different TensorFlow versions. It can also change during Grappler transformations. The TensorFlow version that is used for NVIDIA's NGC 20.02 docker image happens to wire problematic control edges, and therefore that causes TF-TRT to fail. 

The current upstream master version has changed control edge handling, and the problem does not show up if you compile that.

**Code to reproduce teh issue**
To reproduce the problem, run the following code in the nvcr.io/nvidia/tensorflow:20.02-tf2-py3 docker container (or see https://github.com/tensorflow/tensorrt/issues/181). 

```python
import tensorflow as tf
from tensorflow.python.compiler.tensorrt import trt_convert as trt

inputs = tf.keras.Input(shape=(512, 512, 1))
x = tf.keras.layers.Conv2D(filters=64, kernel_size=(3, 3),
                           activation=None, padding='same', use_bias=False)(inputs)
output = tf.keras.layers.Conv2DTranspose(filters=32, kernel_size=(3, 3),
                                         strides=(2, 2), padding='same',
                                         activation=tf.nn.relu)(x)
model = tf.keras.Model(inputs=inputs, outputs=output)

model.save_weights("results/checkpoint")
tf.keras.models.save_model(model, "results/SavedModel", save_format="tf",
                           overwrite=True, include_optimizer=False)
print("Model saved to SavedModel")

converter = trt.TrtGraphConverterV2(input_saved_model_dir="results/SavedModel")
converter.convert()
converter.save("results/trt_model")
print("Model exported to TRT")
```
