### PR TITLE
[r2.2:Cherrypick] Fix windows GPU build - revert absl update

### DIFF
--- a/tensorflow/compiler/tf2xla/BUILD
+++ b/tensorflow/compiler/tf2xla/BUILD
@@ -5,6 +5,7 @@ load(
 )
 load(
     "//tensorflow/core/platform:build_config.bzl",
+    "tf_additional_tensor_coding_deps",
     "tf_proto_library",
     "tf_proto_library_cc",
 )
@@ -238,16 +239,18 @@ cc_library(
     visibility = [":friends"],
     # Note, we specifically remove MKL dependencies so the standalone does
     # not require the MKL binary blob.
+    #
+    # TODO(ebrevdo): Remove tf_additoinal_tensor_coding_deps in favor of absl/strings:cord when
+    # we update absl to a newer version.
     deps = [
-        "//tensorflow/core/framework:numeric_types",
-        "//third_party/eigen3",
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/base:dynamic_annotations",
         "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/strings:cord",
         "@com_google_absl//absl/synchronization",
-    ],
+        "//third_party/eigen3",
+        "//tensorflow/core/framework:numeric_types",
+    ] + tf_additional_tensor_coding_deps(),
     alwayslink = 1,
 )
 

--- a/tensorflow/tools/pip_package/build_pip_package.sh
+++ b/tensorflow/tools/pip_package/build_pip_package.sh
@@ -45,8 +45,15 @@ function copy_xla_aot_runtime_sources() {
   local src_dir=$1
   local dst_dir=$2
 
+  local srcs_txt="tensorflow/tools/pip_package/xla_compiled_cpu_runtime_srcs.txt"
+
+  if [ ! -f "${src_dir}/${srcs_txt}" ]; then
+    echo Could not find source list file "${src_dir}/${srcs_txt}". 1>&2
+    return 0
+  fi
+
   pushd $src_dir
-  for file in $(cat tensorflow/tools/pip_package/xla_compiled_cpu_runtime_srcs.txt)
+  for file in $(cat "${srcs_txt}")
   do
     # Sometimes $file has a prefix bazel-out/host/ we want to remove.
     prefix=${file%%tensorflow/*}  # Find the location of "tensorflow/*"
@@ -134,7 +141,7 @@ function prepare_src() {
       bazel-bin/tensorflow/tools/pip_package/simple_console_for_window_unzip/runfiles \
       "${EXTERNAL_INCLUDES}/"
     copy_xla_aot_runtime_sources \
-      bazel-bin/tensorflow/tools/pip_package/simple_console_for_window_unzip/runfiles \
+      bazel-bin/tensorflow/tools/pip_package/simple_console_for_window_unzip/runfiles/org_tensorflow \
       "${XLA_AOT_RUNTIME_SOURCES}/"
     RUNFILES=bazel-bin/tensorflow/tools/pip_package/simple_console_for_window_unzip/runfiles/org_tensorflow
   else

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -189,11 +189,11 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
         # TODO: Remove the patch when https://github.com/abseil/abseil-cpp/issues/326 is resolved
         # and when TensorFlow is build against CUDA 10.2
         patch_file = clean_dep("//third_party:com_google_absl_fix_mac_and_nvcc_build.patch"),
-        sha256 = "dfe63f014801d5bb1be64c0f94545e3a4a957916a2d353e49f7b746c25636198",  # SHARED_ABSL_SHA
-        strip_prefix = "abseil-cpp-b69c7d880caddfc25bf348dbcfe9d45fdd8bc6e6",
+        sha256 = "acd93f6baaedc4414ebd08b33bebca7c7a46888916101d8c0b8083573526d070",  # SHARED_ABSL_SHA
+        strip_prefix = "abseil-cpp-43ef2148c0936ebf7cb4be6b19927a9d9d145b8f",
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/abseil/abseil-cpp/archive/b69c7d880caddfc25bf348dbcfe9d45fdd8bc6e6.tar.gz",
-            "https://github.com/abseil/abseil-cpp/archive/b69c7d880caddfc25bf348dbcfe9d45fdd8bc6e6.tar.gz",
+            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/abseil/abseil-cpp/archive/43ef2148c0936ebf7cb4be6b19927a9d9d145b8f.tar.gz",
+            "https://github.com/abseil/abseil-cpp/archive/43ef2148c0936ebf7cb4be6b19927a9d9d145b8f.tar.gz",
         ],
     )
 

--- a/third_party/com_google_absl_fix_mac_and_nvcc_build.patch
+++ b/third_party/com_google_absl_fix_mac_and_nvcc_build.patch
@@ -1,44 +1,6 @@
-diff -u -r old/absl/strings/string_view.h new/absl/strings/string_view.h
---- old/absl/strings/string_view.h	2020-02-21 12:56:04.000000000 -0800
-+++ new/absl/strings/string_view.h	2020-02-25 18:39:26.377782568 -0800
-@@ -292,11 +292,18 @@
-   // and an exception of type `std::out_of_range` will be thrown on invalid
-   // access.
-   constexpr const_reference at(size_type i) const {
-+#if defined(__NVCC__)
-+    // An nvcc bug treats the original return expression as a non-constant,
-+    // which is not allowed in a constexpr function. This only happens when
-+    // NDEBUG is not defined. This will be fixed in the CUDA 10.2 release.
-+    return ptr_[i];
-+#else
-     return ABSL_PREDICT_TRUE(i < size())
-                ? ptr_[i]
-                : ((void)base_internal::ThrowStdOutOfRange(
-                       "absl::string_view::at"),
-                   ptr_[i]);
-+#endif
-   }
- 
-   // string_view::front()
-@@ -519,7 +526,14 @@
-       (std::numeric_limits<difference_type>::max)();
- 
-   static constexpr size_type CheckLengthInternal(size_type len) {
-+#if defined(__NVCC__) && (__CUDACC_VER_MAJOR__<10 || (__CUDACC_VER_MAJOR__==10 && __CUDACC_VER_MINOR__<2)) && !defined(NDEBUG)
-+    // An nvcc bug treats the original return expression as a non-constant,
-+    // which is not allowed in a constexpr function. This only happens when
-+    // NDEBUG is not defined. This will be fixed in the CUDA 10.2 release.
-+    return len;
-+#else
-     return (void)ABSL_ASSERT(len <= kMaxSize), len;
-+#endif
-   }
- 
-   static constexpr size_type StrlenInternal(const char* str) {
-diff -u -r old/absl/time/internal/cctz/BUILD.bazel new/absl/time/internal/cctz/BUILD.bazel
---- old/absl/time/internal/cctz/BUILD.bazel	2020-02-21 12:56:04.000000000 -0800
-+++ new/absl/time/internal/cctz/BUILD.bazel	2020-02-25 15:19:29.013710932 -0800
-@@ -74,15 +74,6 @@
+--- ./absl/time/internal/cctz/BUILD.bazel	2019-09-23 13:20:52.000000000 -0700
++++ ./absl/time/internal/cctz/BUILD.bazel.fixed	2019-09-23 13:20:48.000000000 -0700
+@@ -76,15 +76,6 @@
          "include/cctz/time_zone.h",
          "include/cctz/zone_info_source.h",
      ],
@@ -52,5 +14,22 @@ diff -u -r old/absl/time/internal/cctz/BUILD.bazel new/absl/time/internal/cctz/B
 -        "//conditions:default": [],
 -    }),
      visibility = ["//visibility:public"],
-     deps = [
-         ":civil_time",
+     deps = [":civil_time"],
+ )
+--- ./absl/strings/string_view.h	2019-09-23 13:20:52.000000000 -0700
++++ ./absl/strings/string_view.h.fixed	2019-09-23 13:20:48.000000000 -0700
+@@ -492,7 +492,14 @@
+       (std::numeric_limits<difference_type>::max)();
+ 
+   static constexpr size_type CheckLengthInternal(size_type len) {
++#if defined(__NVCC__) && (__CUDACC_VER_MAJOR__<10 || (__CUDACC_VER_MAJOR__==10 && __CUDACC_VER_MINOR__<2)) && !defined(NDEBUG)
++    // An nvcc bug treats the original return expression as a non-constant,
++    // which is not allowed in a constexpr function. This only happens when
++    // NDEBUG is not defined. This will be fixed in the CUDA 10.2 release.
++    return len;
++#else
+     return ABSL_ASSERT(len <= kMaxSize), len;
++#endif
+   }
+ 
+   const char* ptr_;


### PR DESCRIPTION
Also:
* look for xla sources under org_tensorflow
* don't include absl strings:cord since the older version of absl lacks it.
PiperOrigin-RevId: 298638795
Change-Id: Ic85d55240aaa353db60bebea0f0919cbfc5208f1