### PR TITLE
[XLA] follow-up on GPU-deterministic reductions

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
@@ -343,11 +343,14 @@ Status GpuCompiler::PrepareHloModuleForIrEmitting(HloModule* hlo_module) {
 // TODO(cheshire): Duplication with gpu_conv_algorithm picker, figure out a
 // right way to share this.
 static bool RequireDeterminism() {
-  bool deterministic_ops = false;
-  TF_CHECK_OK(tensorflow::ReadBoolFromEnvVar("TF_DETERMINISTIC_OPS",
-                                             /*default_val=*/false,
-                                             &deterministic_ops));
-  return deterministic_ops;
+  static bool require_determinism = [] {
+    bool deterministic_ops = false;
+    TF_CHECK_OK(tensorflow::ReadBoolFromEnvVar("TF_DETERMINISTIC_OPS",
+                                               /*default_val=*/false,
+                                               &deterministic_ops));
+    return deterministic_ops;
+  }();
+  return require_determinism;
 }
 
 Status GpuCompiler::OptimizeHloPostLayoutAssignment(

--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -1677,7 +1677,6 @@ cuda_py_test(
     name = "bias_op_deterministic_test",
     size = "medium",
     srcs = ["bias_op_deterministic_test.py"],
-    xla_enable_strict_auto_jit = False,
     deps = [
         ":bias_op_base",
     ],


### PR DESCRIPTION
GPU-deterministic `tf.nn.bias_add` (enabled with `TF_DETERMINISTIC_OPS`) and its testing was introduced via [PR 31465](https://github.com/tensorflow/tensorflow/pull/31465). Operation on XLA:GPU was found to be non-deterministic at that time.

In response to [a conversation](https://github.com/tensorflow/tensorflow/pull/34887#discussion_r356259683) on [PR 34887](https://github.com/tensorflow/tensorflow/pull/34887) (Add info about `TF_DETERMINISTIC_OPS` to version 2.1 release notes), @cheshire committed a [change](https://github.com/tensorflow/tensorflow/commit/e31955d9fb34ae7273354dc2347ba99eea8c5280) that implemented deterministic reduction functionality when using XLA:GPU. He then committed [another change](https://github.com/tensorflow/tensorflow/commit/8b7a3db0b6e09415b5640be4986fb4d7c6e5209a) that caused this functionality to be enabled by `TF_DETERMINISTIC_OPS`. Both of these changes are in the `r2.2` branch.

This current pull-request is a [follow-up](https://github.com/tensorflow/tensorflow/pull/34887#discussion_r382293594) to that conversation. It does two things:

1. Enable the deterministic testing for `tf.nn.bias_add` to run on the XLA:GPU.
2. Modify the way that `tensorflow/compiler/xla/service/gpu/gpu_compiler.cc` listens to `TF_DETERMINISTIC_OPS` so that it's the same as all other uses (it caches the value).

It would be ideal to cherry-pick these changes into the `r2.2` branch so that they can accompany the rest of this feature implementation.