### PR TITLE
[tflite] NNAPI Pow op allows scalar input

### DIFF
--- a/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
+++ b/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
@@ -149,6 +149,7 @@ bool IsScalarInputSupported(int builtin_code) {
     case kTfLiteBuiltinGreaterEqual:
     case kTfLiteBuiltinLess:
     case kTfLiteBuiltinLessEqual:
+    case kTfLiteBuiltinPow:
       return true;
     default:
       return false;


### PR DESCRIPTION
resolve the `NN API returned error ANEURALNETWORKS_BAD_DATA`  problem in https://github.com/tensorflow/tensorflow/issues/36645