### PR TITLE
Fix for check_pydot when Graphviz is not installed

### DIFF
--- a/tensorflow/python/keras/utils/vis_utils.py
+++ b/tensorflow/python/keras/utils/vis_utils.py
@@ -49,7 +49,7 @@ def check_pydot():
     # to check the pydot/graphviz installation.
     pydot.Dot.create(pydot.Dot())
     return True
-  except OSError:
+  except (OSError, pydot.InvocationException):
     return False
 
 

--- a/tensorflow/python/keras/utils/vis_utils_test.py
+++ b/tensorflow/python/keras/utils/vis_utils_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Tests for Keras Layer utils."""
+"""Tests for Keras Vis utils."""
 
 from __future__ import absolute_import
 from __future__ import division


### PR DESCRIPTION
Currently, if `pydot` is installed, but `Graphviz` is not, `check_pydot` will raise a `pydot.InvocationException` instead of returning False. This PR should fix this issue.

Should probably add a test to confirm the issue, but I wasn't entirely sure how best to go about it, so holding off on it for now.