### PR TITLE
NFC - minor spelling tweaks under lite/c directory

### DIFF
--- a/tensorflow/lite/c/builtin_op_data.h
+++ b/tensorflow/lite/c/builtin_op_data.h
@@ -109,7 +109,7 @@ typedef struct {
   //
   // The information can be deduced from the shape of input and the shape of
   // weights. Since the TFLiteConverter toolchain doesn't support partially
-  // specificed shapes, relying on `depth_multiplier` stops us from supporting
+  // specified shapes, relying on `depth_multiplier` stops us from supporting
   // graphs with dynamic shape tensors.
   //
   // Note: Some of the delegates (e.g. NNAPI, GPU) are still relying on this

--- a/tensorflow/lite/c/c_api_test.cc
+++ b/tensorflow/lite/c/c_api_test.cc
@@ -181,7 +181,7 @@ TEST(CApiSimple, Delegate) {
   // The delegate should have been applied.
   EXPECT_TRUE(delegate_prepared);
 
-  // Subsequent exectuion should behave properly (the delegate is a no-op).
+  // Subsequent execution should behave properly (the delegate is a no-op).
   TfLiteInterpreterOptionsDelete(options);
   TfLiteModelDelete(model);
   EXPECT_EQ(TfLiteInterpreterInvoke(interpreter), kTfLiteOk);

--- a/tensorflow/lite/c/common.h
+++ b/tensorflow/lite/c/common.h
@@ -15,7 +15,7 @@ limitations under the License.
 
 // This file defines common C types and APIs for implementing operations,
 // delegates and other constructs in TensorFlow Lite. The actual operations and
-// delegtes can be defined using C++, but the interface between the interpreter
+// delegates can be defined using C++, but the interface between the interpreter
 // and the operations are C.
 //
 // Summary of abstractions


### PR DESCRIPTION
This PR addresses minor spelling tweaks under 'tensorflow/lite/c' directory.
follow-on of #35286