### PR TITLE
NFC - minor spelling tweaks under lite/g3doc directory 

### DIFF
--- a/tensorflow/lite/g3doc/microcontrollers/get_started.md
+++ b/tensorflow/lite/g3doc/microcontrollers/get_started.md
@@ -303,7 +303,7 @@ TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, invoke_status);
 ### Obtain the output
 
 The model's output tensor can be obtained by calling `output(0)` on the
-`tflite::MicroIntepreter`, where `0` represents the first (and only) output
+`tflite::MicroInterpreter`, where `0` represents the first (and only) output
 tensor.
 
 In the example, the model's output is a single floating point value contained


### PR DESCRIPTION
This PR addresses minor spelling tweaks under 'tensorflow/lite/g3doc' directory.
follow-on of #35286