### PR TITLE
NFC - minor spelling tweaks under lite/python directory

### DIFF
--- a/tensorflow/lite/python/interpreter.py
+++ b/tensorflow/lite/python/interpreter.py
@@ -517,7 +517,7 @@ class Interpreter(object):
 class InterpreterWithCustomOps(Interpreter):
   """Interpreter interface for TensorFlow Lite Models that accepts custom ops.
 
-  The interface provided by this class is experimenal and therefore not exposed
+  The interface provided by this class is experimental and therefore not exposed
   as part of the public API.
 
   Wraps the tf.lite.Interpreter class and adds the ability to load custom ops

--- a/tensorflow/lite/python/lite_test.py
+++ b/tensorflow/lite/python/lite_test.py
@@ -971,7 +971,7 @@ class FromSessionTest(TestModels, parameterized.TestCase):
     quantized_converter.experimental_new_converter = enable_mlir
     quantized_converter.optimizations = [lite.Optimize.DEFAULT]
     quantized_converter.target_spec.supported_types = [lite.constants.FLOAT16]
-    # Specifiy only int8 builtin ops
+    # Specify only int8 builtin ops
     quantized_converter.target_spec.supported_ops = [
         lite.OpsSet.TFLITE_BUILTINS_INT8
     ]

--- a/tensorflow/lite/python/op_hint.py
+++ b/tensorflow/lite/python/op_hint.py
@@ -587,7 +587,7 @@ class _LiteAggregateOperand(_LiteOperand):
 
     In particular, if you have 4 inputs to a hint stub, this will be the
     node that you can use as an output. I.e. you have 4 timesteps from a
-    static rnn, then a fused UnidriecitonalLSTM will expect 1 input with
+    static rnn, then a fused UnidirectionalLSTM will expect 1 input with
     all 4 time steps. So here we make a pack and return the output name of
     that pack.
 

--- a/tensorflow/lite/python/tflite_convert.py
+++ b/tensorflow/lite/python/tflite_convert.py
@@ -500,10 +500,10 @@ def _get_tf1_flags(parser):
   parser.add_argument(
       "--conversion_summary_dir",
       type=str,
-      help=("Full filepath to store the conversion logs, which inclues graphviz"
-            " of the model before/after the conversion, an HTML report and the "
-            "conversion proto buffers. This will only be generated when passing"
-            " --experimental_new_converter"))
+      help=("Full filepath to store the conversion logs, which includes "
+            "graphviz of the model before/after the conversion, an HTML report "
+            "and the conversion proto buffers. This will only be generated "
+            "when passing --experimental_new_converter"))
 
 
 def _get_tf2_flags(parser):

--- a/tensorflow/lite/python/util.py
+++ b/tensorflow/lite/python/util.py
@@ -362,7 +362,7 @@ def get_debug_info(nodes_to_debug_info_func, converted_graph):
   Args:
     nodes_to_debug_info_func: The method to collect the op debug info for the
       nodes.
-    converted_graph: A `GraphDef` after optimization and transfermation.
+    converted_graph: A `GraphDef` after optimization and transformation.
 
   Returns:
     `GraphDebugInfo` for all the original nodes in `converted_graph`.

--- a/tensorflow/lite/python/util_test.py
+++ b/tensorflow/lite/python/util_test.py
@@ -176,7 +176,7 @@ class TensorFunctionsTest(test_util.TensorFlowTestCase):
 
   @test_util.run_deprecated_v1
   def testSetTensorShapeDimensionInvalid(self):
-    # Tests set_tensor_shape where the shape passed in is incompatiable.
+    # Tests set_tensor_shape where the shape passed in is incompatible.
     with ops.Graph().as_default():
       tensor = array_ops.placeholder(shape=[None, 3, 5], dtype=dtypes.float32)
     self.assertEqual([None, 3, 5], tensor.shape.as_list())

--- a/tensorflow/lite/python/wrap_toco.py
+++ b/tensorflow/lite/python/wrap_toco.py
@@ -18,7 +18,7 @@ from __future__ import division
 from __future__ import print_function
 
 # We need to import pywrap_tensorflow prior to the toco wrapper.
-# pylint: disable=invalud-import-order,g-bad-import-order
+# pylint: disable=invalid-import-order,g-bad-import-order
 from tensorflow.python import pywrap_tensorflow  # pylint: disable=unused-import
 from tensorflow.python import _pywrap_toco_api
 


### PR DESCRIPTION
This PR addresses minor spelling tweaks under `tensorflow/lite/python` directory.
follow-on of #35286