### PR TITLE
Update bucketized_column documentation comment to fix markdown

### DIFF
--- a/tensorflow/python/feature_column/feature_column.py
+++ b/tensorflow/python/feature_column/feature_column.py
@@ -1053,8 +1053,8 @@ def _bucketized_column(source_column, boundaries):
   dense_tensor = input_layer(features, columns)
   ```
 
-  A `bucketized_column` can also be crossed with another categorical column using
-  `crossed_column`:
+  A `bucketized_column` can also be crossed with another categorical column
+  using `crossed_column`:
 
   ```python
   price = numeric_column('price')

--- a/tensorflow/python/feature_column/feature_column.py
+++ b/tensorflow/python/feature_column/feature_column.py
@@ -1053,7 +1053,7 @@ def _bucketized_column(source_column, boundaries):
   dense_tensor = input_layer(features, columns)
   ```
 
-  `bucketized_column` can also be crossed with another categorical column using
+  A `bucketized_column` can also be crossed with another categorical column using
   `crossed_column`:
 
   ```python

--- a/tensorflow/python/feature_column/feature_column_v2.py
+++ b/tensorflow/python/feature_column/feature_column_v2.py
@@ -1430,7 +1430,7 @@ def bucketized_column(source_column, boundaries):
   dense_tensor = tf.keras.layers.DenseFeatures(columns)(features)
   ```
 
-  `bucketized_column` can also be crossed with another categorical column using
+  A `bucketized_column` can also be crossed with another categorical column using
   `crossed_column`:
 
   ```python

--- a/tensorflow/python/feature_column/feature_column_v2.py
+++ b/tensorflow/python/feature_column/feature_column_v2.py
@@ -1430,8 +1430,8 @@ def bucketized_column(source_column, boundaries):
   dense_tensor = tf.keras.layers.DenseFeatures(columns)(features)
   ```
 
-  A `bucketized_column` can also be crossed with another categorical column using
-  `crossed_column`:
+  A `bucketized_column` can also be crossed with another categorical column
+  using `crossed_column`:
 
   ```python
   price = tf.feature_column.numeric_column('price')


### PR DESCRIPTION
The documentation generator was merging the prose with the preceding and ensuing code blocks, resulting in rather curious formatting.

This tries to fix it by starting the non-code sentence with a something that does not have code markdown (back-plings).