### PR TITLE
support broadcast in xla_legalize_to_linalg

### DIFF
--- a/tensorflow/compiler/mlir/xla/transforms/hlo_shape_derivation.h
+++ b/tensorflow/compiler/mlir/xla/transforms/hlo_shape_derivation.h
@@ -39,6 +39,16 @@ namespace xla_hlo {
 // functions in templated code.
 
 namespace impl {
+namespace {
+Value FindDynamicsOperand(Operation* op) {
+  for (auto operand : op->getOperands()) {
+    auto argtype = operand.getType().dyn_cast<ShapedType>();
+    if (!argtype.hasStaticShape()) {
+      return operand;
+    }
+  }
+}
+}
 
 struct UnknownShape {
   // Default shape derivation function that simply fails with a runtime error.
@@ -65,7 +75,8 @@ struct SameShapeAsFirstOperand {
   // and returns %4 as the shape value.
   static Value deriveShapeFromOp(Operation* op, int result_postion,
                                  ConversionPatternRewriter* rewriter) {
-    Value operand = op->getOperand(0);
+
+    Value operand = FindDynamicsOperand(op);
     ShapedType operand_type = operand.getType().dyn_cast<ShapedType>();
     if (!operand_type) {
       op->emitOpError() << "first operand has no shaped type";
@@ -126,6 +137,9 @@ SAME_SHAPE_AS_FIRST_OPERAND(SinOp)
 SAME_SHAPE_AS_FIRST_OPERAND(SqrtOp)
 SAME_SHAPE_AS_FIRST_OPERAND(SubOp)
 SAME_SHAPE_AS_FIRST_OPERAND(TanhOp)
+SAME_SHAPE_AS_FIRST_OPERAND(CompareOp)
+SAME_SHAPE_AS_FIRST_OPERAND(SelectOp)
+SAME_SHAPE_AS_FIRST_OPERAND(ConvertOp)
 
 #undef SAME_SHAPE_AS_FIRST_OPERAND
 


### PR DESCRIPTION
This pr is  mainly a discussion to find a suitable way which can lower implicit broadcast in hlo dialect
now, for code like:
```
 "xla_lhlo.add"(%29, %14, %30) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (memref<?xi64>, memref<i64>, memref<?xi64>) -> ()
```
cannot be lowered in to linalg dialect in current implementation.
This pr purposed a way to transform implicit broadcast in lhlo by adding convertor in xla_legalize_to_linalg pass, that is, when constructing loop by linalg.generic, use a LoadOp to load the actually value from  scalar tensor and passed it into the block which compose the linalg.generic. This way prevents the additional  memory allocation in converting implicit broadcast to explicit broadcast , so the code above will be lowered to 
```
 %44 = load %14[] : memref<i64>
    linalg.generic {args_in = 1 : i64, args_out = 1 : i64, indexing_maps = [#map0, #map0], iterator_types = ["parallel"]} %35, %43 {
    ^bb0(%arg1: i64, %arg2: i64):   // no predecessors
      %120 = addi %arg1, %44 : i64
      linalg.yield %120 : i64
    }: memref<?xi64>, memref<?xi64>
```

Also, for shape derivation, for elementwise op, the SameShapeAsFirstOperand may be not enough for code like
```
   "xla_lhlo.add"(%21, %56, %61) {broadcast_dimensions = dense<[]> : tensor<0xi64>} : (memref<i64>, memref<?xi64>, memref<?xi64>) -> ()
```
because the first operand is scalar . For this is also a broadcast case, I extended  SameShapeAsFirstOperand to first find the first dynamic operand, and then use it as the shape as result shape .(by doing this SameShapeAsFirstOperand may be not suitable, so a new name is needed afterwards)