### PR TITLE
[TF XLA AOT] Make sure required sources are included in pip package.

### DIFF
--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -2710,7 +2710,7 @@ def tf_external_workspace_visible(visibility):
     # External workspaces can see this target.
     return ["//visibility:public"]
 
-def _filegroup_as_file(ctx):
+def _filegroup_as_file_impl(ctx):
     out = ctx.actions.declare_file(ctx.label.name)
     ctx.actions.write(
         output = out,
@@ -2718,9 +2718,18 @@ def _filegroup_as_file(ctx):
     )
     return DefaultInfo(files = depset([out]))
 
-filegroup_as_file = rule(
-    implementation = _filegroup_as_file,
+_filegroup_as_file = rule(
+    implementation = _filegroup_as_file_impl,
     attrs = {
         "dep": attr.label(),
     },
 )
+
+def filegroup_as_file(name, dep, visibility = []):
+    """Creates a filegroup ${name}_file which contains the file ${name}."""
+    _filegroup_as_file(name = name, dep = dep)
+    native.filegroup(
+        name = name + "_file",
+        srcs = [name],
+        visibility = visibility,
+    )

--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -82,7 +82,7 @@ COMMON_PIP_DEPS = [
     "README",
     "setup.py",
     ":included_headers",
-    ":xla_compiled_cpu_runtime_srcs.txt",
+    ":xla_compiled_cpu_runtime_srcs.txt_file",
     "//tensorflow:tensorflow_py",
     "//tensorflow/compiler/tf2xla:xla_compiled_cpu_runtime_hdrs",
     "//tensorflow/compiler/tf2xla:xla_compiled_cpu_runtime_srcs",

--- a/tensorflow/tools/pip_package/MANIFEST.in
+++ b/tensorflow/tools/pip_package/MANIFEST.in
@@ -20,4 +20,5 @@ recursive-include tensorflow/include/google *.inc
 recursive-include tensorflow/include/include *.h
 recursive-include tensorflow/include/third_party *
 recursive-include tensorflow/include/unsupported *
+recursive-include tensorflow/xla_aot_runtime_src *
 


### PR DESCRIPTION
(bugfix) We thought the previous CL ensured this, but looks like there
were some missing pieces in the genrule & MANIFEST files.

PiperOrigin-RevId: 298715688
Change-Id: Ib0a20cb10fb3b36686419b02c2f8ab6afd438d57