### PR TITLE
Trigger sync only if exiting async_scope without exception.

### DIFF
--- a/tensorflow/python/eager/context.py
+++ b/tensorflow/python/eager/context.py
@@ -2180,8 +2180,11 @@ def async_scope():
   try:
     os.environ[remote_async_env_var] = str(True)
     yield
-  finally:
+    # Note: sync local and remote executors iff the async block does not raise
+    # an exception. Triggering sync after an exception may lead to derived
+    # runtime errors and unexpected exception types.
     context().sync_executors()
+  finally:
     if old_policy is None:
       del os.environ[remote_async_env_var]
     else:


### PR DESCRIPTION
If code in async_scope already throws an exception, triggering another remote sync might cause derived errors to be returned and lead to unexpected exception types. (Fixed b/151117430)

PiperOrigin-RevId: 300013192
Change-Id: Id310ca105ce2fdfbc0f19c5362834a56906fb35f