### PR TITLE
support tf.Unique legalize throught hlo/lhlo 

### DIFF
--- a/tensorflow/compiler/mlir/BUILD
+++ b/tensorflow/compiler/mlir/BUILD
@@ -83,6 +83,7 @@ cc_library(
         "//tensorflow/compiler/mlir/xla:xla_legalize_tf",
         "//tensorflow/compiler/mlir/xla:xla_legalize_tf_with_tf2xla",
         "//tensorflow/compiler/mlir/xla:xla_legalize_to_linalg",
+        "//tensorflow/compiler/mlir/xla:lhlo_legalize_to_std",
         "//tensorflow/compiler/mlir/xla:xla_legalize_to_standard",
         "//tensorflow/compiler/mlir/xla:xla_lower",
         "//tensorflow/compiler/mlir/xla:xla_materialize_broadcasts",

--- a/tensorflow/compiler/mlir/tensorflow/BUILD
+++ b/tensorflow/compiler/mlir/tensorflow/BUILD
@@ -552,6 +552,19 @@ cc_library(
 )
 
 cc_library(
+    name = "runner_utils",
+    srcs = [
+        "utils/runner_utils.cc",
+    ],
+    hdrs = [
+        "utils/runner_utils.h",
+    ],
+    deps = [
+        "@llvm-project//mlir:mlir_c_runner_utils",
+    ],
+)
+
+cc_library(
     name = "translate_utils",
     srcs = [
         "utils/translate_utils.cc",

--- a/tensorflow/compiler/mlir/tensorflow/utils/runner_utils.cc
+++ b/tensorflow/compiler/mlir/tensorflow/utils/runner_utils.cc
@@ -1,0 +1,183 @@
+#include <iostream>
+#include <unordered_map>
+#include <unordered_set>
+#include "tensorflow/compiler/mlir/tensorflow/utils/runner_utils.h"
+
+
+extern "C"
+int64_t _global_get_unique_ids_count(
+    StridedMemRefType<int64_t, 1> *ids, /*StridedMemRefType<int64_t, 0> *N*/int64_t N) {
+  int64_t unique_count = 0;
+  int64_t *data = ids->data;
+  std::unordered_set<int64_t> m;
+  int64_t real_n = N; //*((int64_t*)(N->data));
+  for (int64_t i = 0; i < real_n; ++i) {
+    if (m.find(*(data+i)) == m.end()) {
+      ++unique_count;
+      m.insert(*(data+i));
+    }
+  }
+
+  return unique_count;
+}
+
+extern "C"
+void _global_unique_ids(
+    StridedMemRefType<int64_t, 1> *input_ids,
+    StridedMemRefType<int64_t, 0> *id_count,
+    StridedMemRefType<int64_t, 1> *output_ids) {
+  int32_t cur_idx = -1;
+  std::unordered_map<int64_t, int64_t> m;
+  int64_t real_n = input_ids->sizes[0]; 
+  for (int64_t i = 0; i < real_n; ++i) {
+    int64_t spec_id = (*(input_ids->data + i));
+    if (m.find(spec_id) == m.end()) {
+      m[spec_id] = ++cur_idx;
+      *(output_ids->data + cur_idx) = spec_id;
+    } else {
+      continue;
+    }
+  }
+}
+
+extern "C"
+void _global_unique_index32(
+    StridedMemRefType<int64_t, 1> *ids,
+    StridedMemRefType<int64_t, 1> *unique_ids,
+    StridedMemRefType<int32_t, 1> *ids_index) {
+  std::unordered_map<int64_t, int32_t> m;
+  int64_t unique_N = unique_ids->sizes[0]; 
+
+  for (int32_t i = 0; i < unique_N; ++i) {
+    m[*(unique_ids->data + i)] = i;
+  }
+  int64_t input_N = ids->sizes[0]; 
+  for(int64_t i = 0; i < input_N; i++) {
+    *(ids_index->data + i) = m[*(ids->data + i)];
+  }
+}
+
+extern "C"
+void _global_unique_index64(
+    StridedMemRefType<int64_t, 1> *ids,
+    StridedMemRefType<int64_t, 1> *unique_ids,
+    StridedMemRefType<int64_t, 1> *ids_index) {
+  std::unordered_map<int64_t, int64_t> m;
+  int64_t unique_N = unique_ids->sizes[0]; 
+
+  for (int64_t i = 0; i < unique_N; ++i) {
+    m[*(unique_ids->data + i)] = i;
+  }
+  int64_t input_N = ids->sizes[0]; 
+  for(int64_t i = 0; i < input_N; i++) {
+    *(ids_index->data + i) = m[*(ids->data + i)];
+  }
+}
+
+extern "C"
+void _global_unique_i64_i64(
+    StridedMemRefType<int64_t, 1> *input,
+    StridedMemRefType<int64_t, 1> *unique_ids,
+    StridedMemRefType<int64_t, 1> *idx) {
+  std::unordered_map<int64_t, int64_t> m;
+  int64_t N = input->sizes[0];
+  int64_t* data = (int64_t*)(input->data);
+  int64_t* unique_data = (int64_t*)(unique_ids->data);
+  int64_t uniqueN = unique_ids->sizes[0];
+  int64_t cur = 0;
+  for (int64_t i = 0; i < N; ++i) {
+    if (m.find(data[i]) == m.end()) {
+      m[data[i]] = cur;
+      unique_data[cur++] = data[i];
+    }
+  }
+  if (cur != uniqueN) {
+    assert(false && "_global_unique_i64_i64 failed.");
+  }
+
+  int64_t* idx_data = (int64_t*)(idx->data);
+  for (int64_t i = 0; i < N; ++i) {
+    idx_data[i] = m[data[i]];
+  }
+}
+
+extern "C"
+void _global_unique_i64_i32(
+    StridedMemRefType<int64_t, 1> *input,
+    StridedMemRefType<int64_t, 1> *unique_ids,
+    StridedMemRefType<int32_t, 1> *idx) {
+  std::unordered_map<int64_t, int32_t> m;
+  int64_t N = input->sizes[0];
+  int64_t* data = (int64_t*)(input->data);
+  int64_t* unique_data = (int64_t*)(unique_ids->data);
+  int64_t uniqueN = unique_ids->sizes[0];
+  int cur = 0;
+  for (int64_t i = 0; i < N; ++i) {
+    if (m.find(data[i]) == m.end()) {
+      m[data[i]] = cur;
+      unique_data[cur++] = data[i];
+    }
+  }
+  if (cur != uniqueN) {
+    assert(false && "_global_unique_i64_i32 failed.");
+  }
+
+  int32_t* idx_data = (int32_t*)(idx->data);
+  for (int64_t i = 0; i < N; ++i) {
+    idx_data[i] = m[data[i]];
+  }
+}
+
+extern "C"
+void _global_unique_i32_i64(
+    StridedMemRefType<int32_t, 1> *input,
+    StridedMemRefType<int32_t, 1> *unique_ids,
+    StridedMemRefType<int64_t, 1> *idx) {
+  std::unordered_map<int32_t, int64_t> m;
+  int64_t N = input->sizes[0];
+  int32_t* data = (int32_t*)(input->data);
+  int32_t* unique_data = (int32_t*)(unique_ids->data);
+  int64_t uniqueN = unique_ids->sizes[0];
+  int64_t cur = 0;
+  for (int64_t i = 0; i < N; ++i) {
+    if (m.find(data[i]) == m.end()) {
+      m[data[i]] = cur;
+      unique_data[cur++] = data[i];
+    }
+  }
+  if (cur != uniqueN) {
+    assert(false && "_global_unique_i32_i64 failed.");
+  }
+
+  int64_t* idx_data = (int64_t*)(idx->data);
+  for (int64_t i = 0; i < N; ++i) {
+    idx_data[i] = m[data[i]];
+  }
+}
+
+extern "C"
+void _global_unique_i32_i32(
+    StridedMemRefType<int32_t, 1> *input,
+    StridedMemRefType<int32_t, 1> *unique_ids,
+    StridedMemRefType<int32_t, 1> *idx) {
+  std::unordered_map<int32_t, int32_t> m;
+  int64_t N = input->sizes[0];
+  int32_t* data = (int32_t*)(input->data);
+  int32_t* unique_data = (int32_t*)(unique_ids->data);
+  int64_t uniqueN = unique_ids->sizes[0];
+  int cur = 0;
+  for (int64_t i = 0; i < N; ++i) {
+    if (m.find(data[i]) == m.end()) {
+      m[data[i]] = cur;
+      unique_data[cur++] = data[i];
+    }
+  }
+  if (cur != uniqueN) {
+    assert(false && "_global_unique_i32_i32 failed.");
+  }
+
+  int32_t* idx_data = (int32_t*)(idx->data);
+  for (int64_t i = 0; i < N; ++i) {
+    idx_data[i] = m[data[i]];
+  }
+}

--- a/tensorflow/compiler/mlir/tensorflow/utils/runner_utils.h
+++ b/tensorflow/compiler/mlir/tensorflow/utils/runner_utils.h
@@ -1,0 +1,69 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_COMPILER_MLIR_TENSORFLOW_UTILS_RUNNER_UTILS_H_
+#define TENSORFLOW_COMPILER_MLIR_TENSORFLOW_UTILS_RUNNER_UTILS_H_
+
+#include <assert.h>
+#include <cstdint>
+#include <string>
+#include <iostream>
+
+#include "mlir/ExecutionEngine/CRunnerUtils.h"  // TF:llvm-project
+
+
+extern "C" 
+void _global_unique_ids(
+    StridedMemRefType<int64_t, 1> *intput_ids,
+    StridedMemRefType<int64_t, 0> *id_count,
+    StridedMemRefType<int64_t, 1> *output_ids); 
+
+extern "C" 
+void _global_unique_index32(
+    StridedMemRefType<int64_t, 1> *ids,
+    StridedMemRefType<int64_t, 1> *unique_ids,
+    StridedMemRefType<int32_t, 1> *ids_index); 
+
+extern "C" 
+void _global_unique_index64(
+    StridedMemRefType<int64_t, 1> *ids,
+    StridedMemRefType<int64_t, 1> *unique_ids,
+    StridedMemRefType<int64_t, 1> *ids_index); 
+
+extern "C" 
+void _global_unique_i64_i64(
+    StridedMemRefType<int64_t, 1> *input,
+    StridedMemRefType<int64_t, 1> *unique_ids,
+    StridedMemRefType<int64_t, 1> *idx);
+
+extern "C" 
+void _global_unique_i64_i32(
+    StridedMemRefType<int64_t, 1> *input,
+    StridedMemRefType<int64_t, 1> *unique_ids,
+    StridedMemRefType<int32_t, 1> *idx);
+
+extern "C" 
+void _global_unique_i32_i64(
+    StridedMemRefType<int32_t, 1> *input,
+    StridedMemRefType<int32_t, 1> *unique_ids,
+    StridedMemRefType<int64_t, 1> *idx);
+
+extern "C" 
+void _global_unique_i32_i32(
+    StridedMemRefType<int32_t, 1> *input,
+    StridedMemRefType<int32_t, 1> *unique_ids,
+    StridedMemRefType<int32_t, 1> *idx);
+
+#endif TENSORFLOW_COMPILER_MLIR_TENSORFLOW_UTILS_RUNNER_UTILS_H_

--- a/tensorflow/compiler/mlir/xla/BUILD
+++ b/tensorflow/compiler/mlir/xla/BUILD
@@ -223,6 +223,24 @@ cc_library(
 )
 
 cc_library(
+    name = "lhlo_legalize_to_std",
+    srcs = ["transforms/lhlo_legalize_to_std.cc"],
+    hdrs = ["transforms/map_xla_to_scalar_op.h"],
+    deps = [
+        ":hlo",
+        ":lhlo",
+        "//tensorflow/compiler/xla:status",
+        "@com_google_absl//absl/memory",
+        "@llvm-project//llvm:support",
+        "@llvm-project//mlir:AffineOps",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:StandardOps",
+        "@llvm-project//mlir:Transforms",
+    ],
+    alwayslink = 1,
+)
+cc_library(
     name = "xla_legalize_to_linalg",
     srcs = ["transforms/xla_legalize_to_linalg.cc"],
     deps = [

--- a/tensorflow/compiler/mlir/xla/ir/hlo_ops.td
+++ b/tensorflow/compiler/mlir/xla/ir/hlo_ops.td
@@ -648,6 +648,27 @@ def HLO_CompareOp: HLO_Op<"compare",
   >];
 }
 
+def HLO_UniqueCountOp: HLO_UnaryElementwiseOp<"unique_count",
+      [NoSideEffect], HLO_IntTensor> {
+    let builders = [OpBuilder<
+    "Builder *builder, OperationState &result, Value operand"
+    >];
+}
+
+def HLO_UniqueOp: HLO_Op<"unique",
+      [NoSideEffect]> {
+  let arguments = (ins
+    HLO_Tensor:$x,
+    HLO_IntTensor:$count
+  );
+  let builders = [
+    OpBuilder<"Builder *builder, OperationState &result, Value left, Value right">,
+  ];
+  let results = (outs
+    HLO_Tensor:$y,
+    HLO_Tensor:$idx);
+}
+
 //===----------------------------------------------------------------------===//
 // XLA Slice definitions.
 //===----------------------------------------------------------------------===//

--- a/tensorflow/compiler/mlir/xla/ir/lhlo_ops.td
+++ b/tensorflow/compiler/mlir/xla/ir/lhlo_ops.td
@@ -103,6 +103,18 @@ def LHLO_SignOp: LHLO_UnaryElementwiseOp<"sign">, BASE_HLO_SignOp;
 
 def LHLO_TanhOp: LHLO_UnaryElementwiseOp<"tanh">, BASE_HLO_TanhOp;
 
+def LHLO_UniqueCountOp:  LHLO_Op<"unique_count", [NoSideEffect]> {
+  let arguments = (ins LHLO_Buffer:$input,
+                       LHLO_Buffer:$output);
+
+}
+
+def LHLO_UniqueOp: LHLO_Op<"unique", [NoSideEffect]> {
+  let arguments = (ins LHLO_Buffer:$x,
+                       LHLO_Buffer:$y,
+                       LHLO_Buffer:$idx);
+}
+
 //===----------------------------------------------------------------------===//
 // XLA binary elementwise op definitions.
 //===----------------------------------------------------------------------===//

--- a/tensorflow/compiler/mlir/xla/transforms/lhlo_legalize_to_std.cc
+++ b/tensorflow/compiler/mlir/xla/transforms/lhlo_legalize_to_std.cc
@@ -1,0 +1,208 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// This file implements logic for lowering LHLO dialect to Affine dialect.
+
+#include "absl/memory/memory.h"
+#include "mlir/Dialect/AffineOps/AffineOps.h"  // TF:llvm-project
+#include "mlir/Dialect/StandardOps/IR/Ops.h"  // TF:llvm-project
+#include "mlir/IR/Attributes.h"  // TF:llvm-project
+#include "mlir/IR/Location.h"  // TF:llvm-project
+#include "mlir/IR/MLIRContext.h"  // TF:llvm-project
+#include "mlir/IR/PatternMatch.h"  // TF:llvm-project
+#include "mlir/IR/StandardTypes.h"  // TF:llvm-project
+#include "mlir/Transforms/DialectConversion.h"  // TF:llvm-project
+#include "mlir/Pass/Pass.h"  // TF:llvm-project
+#include "tensorflow/compiler/mlir/xla/ir/lhlo_ops.h"
+
+namespace mlir {
+namespace xla_lhlo {
+namespace {
+
+FlatSymbolRefAttr CallExternalFunc(
+    PatternRewriter &rewriter,
+    ModuleOp module,
+    Location loc,
+    const std::string& func_name,
+    std::vector<Type> &input_types,
+    std::vector<Type> &result_types,
+    ArrayRef<NamedAttribute> attrs) {
+
+  // TODO: FIXME, how about the same function name, by differernt params ?
+  // External function symbol is existed
+  FlatSymbolRefAttr func_name_attr = rewriter.getSymbolRefAttr(func_name);
+  if (module.lookupSymbol(func_name)) {
+    return func_name_attr;
+  }
+
+  auto context = rewriter.getContext();
+  // function type
+  auto func_type = FunctionType::get(input_types, result_types, context);
+
+  // create func op
+  OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPointToStart(module.getBody());
+  rewriter.create<mlir::FuncOp>(loc, func_name_attr.getValue(),
+                                func_type, attrs);
+
+  return func_name_attr;
+}
+
+
+struct UniqueCountConverter : public OpRewritePattern<UniqueCountOp> {
+  using OpRewritePattern<UniqueCountOp>::OpRewritePattern;
+
+  PatternMatchResult matchAndRewrite(UniqueCountOp op,
+                                     PatternRewriter& rewriter) const override {
+
+
+    auto context = rewriter.getContext();
+    auto loc = op.getLoc();
+    std::vector<Type> input_types;
+    std::vector<Type> result_types;
+    input_types.push_back(op.input().getType());
+    input_types.push_back(rewriter.getIndexType());
+    result_types.push_back(op.input().getType().dyn_cast<MemRefType>().getElementType());
+    FlatSymbolRefAttr output_func_ref = CallExternalFunc(
+        rewriter, op.getParentOfType<ModuleOp>(), loc,
+        "_global_get_unique_ids_count",
+        input_types, result_types,
+        ArrayRef<NamedAttribute>{});
+
+    // Create a CallOp to call `_global_get_unique_ids_count`
+    auto runtime_ids_count = rewriter.create<mlir::DimOp>(op.getLoc(), op.input(), 0);
+    SmallVector<Value, 4> unique_ids_count_func_param;
+    unique_ids_count_func_param.push_back(op.input());
+    unique_ids_count_func_param.push_back(runtime_ids_count);
+    // get unique ids count, params: ids memref + runtime ids count
+
+    auto get_unique_count_op = rewriter.create<mlir::CallOp>(
+        loc, output_func_ref.getValue(),
+        result_types,
+        unique_ids_count_func_param);
+
+    rewriter.create<StoreOp>(op.getLoc(), get_unique_count_op.getResult(0), op.output());
+    rewriter.eraseOp(op);
+    return this->matchSuccess();
+  }
+ 
+};
+
+struct UniqueConverter : public OpRewritePattern<UniqueOp> {
+  using OpRewritePattern<UniqueOp>::OpRewritePattern;
+
+  PatternMatchResult matchAndRewrite(
+      UniqueOp op,
+      PatternRewriter& rewriter) const override {
+    auto context = rewriter.getContext();
+    auto loc = op.getLoc();
+
+    std::vector<Type> input_types;
+    std::vector<Type> result_types;
+    input_types.push_back(op.x().getType());
+    input_types.push_back(op.y().getType());
+    input_types.push_back(op.idx().getType());
+ 
+    auto tensor_type = op.y().getType().dyn_cast<MemRefType>().getElementType();
+    auto idx_type = op.idx().getType().dyn_cast<MemRefType>().getElementType();
+    std::string func_name("_global_unique");
+    if (tensor_type.isInteger(64)) {
+      func_name += "_i64";
+    } else if (tensor_type.isInteger(32)) {
+      func_name += "_i32";
+    } else {
+      llvm::errs() << "Now only support int32 and int64 type.\n";
+      return this->matchFailure();
+    }
+    if (idx_type.isInteger(64)) {
+      func_name += "_i64";
+    } else if (idx_type.isInteger(32)) {
+      func_name += "_i32";
+    } else {
+      llvm::errs() << "Unique only support int32 and int64 index type.\n";
+      return this->matchFailure();
+    }
+
+    FlatSymbolRefAttr output_func_ref = CallExternalFunc(
+        rewriter, op.getParentOfType<ModuleOp>(), loc,
+        func_name, input_types, result_types,
+        ArrayRef<NamedAttribute>{});
+
+    // Create a CallOp to call `_global_unique_i64_i32`
+    SmallVector<Value, 4> func_param;
+    func_param.push_back(op.x());
+    func_param.push_back(op.y());
+    func_param.push_back(op.idx());
+
+    rewriter.create<mlir::CallOp>(
+        loc, output_func_ref.getValue(),
+        result_types,
+        func_param);
+
+    rewriter.eraseOp(op);
+
+    return this->matchSuccess();
+  }
+};
+
+void populateLHLOToStdConversionPattern(MLIRContext* context,
+                                           OwningRewritePatternList* patterns) {
+  // clang-format off
+  patterns->insert<
+      UniqueCountConverter,
+      UniqueConverter
+    >(context);
+  // clang-format on
+}
+
+struct LhloLegalizeToStd: public FunctionPass<LhloLegalizeToStd> {
+  void runOnFunction() override {
+    OwningRewritePatternList patterns;
+    ConversionTarget target(getContext());
+    target.addLegalDialect<StandardOpsDialect>();
+    // NOTE(jiankeng.pt): Advanced skills: prevent the error of UniqueOp lowering process.
+    // Cause the `func` op here has no one legalize pattern.
+    // If you don't want the Op with concrete information which you specify
+    // in the anonymous function be lowered at the pass, please do this.
+    target.addDynamicallyLegalOp<FuncOp>(
+        [&](FuncOp op) { return
+        op.getName() == "_global_unique_i64_i64" ||
+        op.getName() == "_global_unique_i64_i32" ||
+        op.getName() == "_global_unique_i32_i64" ||
+        op.getName() == "_global_unique_i32_i32" ||
+        op.getName() == "_global_unique_index32" ||
+        op.getName() == "_global_unique_index64" ||
+        op.getName() == "_global_get_unique_ids_count" ||
+        op.getName() == "_global_unique_ids";}); 
+    auto func = getFunction();
+    populateLHLOToStdConversionPattern(func.getContext(), &patterns);
+    if (failed(applyPartialConversion(func, target, patterns, nullptr))) {
+      signalPassFailure();
+    }
+    // applyPatternsGreedily(func, patterns);
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<OpPassBase<FuncOp>> createLegalizeToStdPass() {
+  return absl::make_unique<LhloLegalizeToStd>();
+}
+
+static PassRegistration<LhloLegalizeToStd> legalize_pass(
+    "lhlo-legalize-to-std", "Legalize from LHLO dialect to stdandard dialect");
+
+}  // namespace xla_lhlo
+}  // namespace mlir

--- a/tensorflow/compiler/mlir/xla/transforms/map_hlo_to_lhlo_op.h
+++ b/tensorflow/compiler/mlir/xla/transforms/map_hlo_to_lhlo_op.h
@@ -63,6 +63,7 @@ MAP_HLO_TO_LHLO(SignOp);
 MAP_HLO_TO_LHLO(SqrtOp);
 MAP_HLO_TO_LHLO(SubOp);
 MAP_HLO_TO_LHLO(TanhOp);
+MAP_HLO_TO_LHLO(UniqueCountOp);
 
 #undef MAP_HLO_TO_LHLO
 


### PR DESCRIPTION
This pr purposed a way to lower tf.Unqiue down to mlir core dialect, by adding relevant hlo/lhlo op, and a runner_utils which call a external function to actually do the unique thing with a hashmap, any discussion is welcomed for this pr as  we are trying to get things done right .
The reason why we import a external function to lower the relevant unique logic is that the hashmap type is not supported  currently in mlir core, a discussion is purposed in llvm discussion https://llvm.discourse.group/t/will-mlir-support-hashmap-type-in-near-future/691/2  
So for code like 
```
%1:2 = "tf.Unique"(%arg0)  : (tensor<?xi64>) -> (tensor<?xi64>, tensor<?xi64>)
```
will be first lowered to lhlo code 
```
%0 = alloc() {temp = true} : memref<i64>
    "xla_lhlo.unique_count"(%arg0, %0) : (memref<?xi64>, memref<i64>) -> ()
    %1 = load %0[] : memref<i64>
    %2 = index_cast %1 : i64 to index
    %3 = alloc(%2) {temp = true} : memref<?xi64>
    %4 = dim %arg0, 0 : memref<?xi64>
    %5 = alloc(%4) {temp = true} : memref<?xi64>
    "xla_lhlo.unique"(%arg0, %3, %5) : (memref<?xi64>, memref<?xi64>, memref<?xi64>) -> ()
    dealloc %0 : memref<i64>
    dealloc %3 : memref<?xi64>
    dealloc %5 : memref<?xi64>
```
and then be lowered by newly added -lhlo-legalize-to-std pass to code like
```
%0 = alloc() {temp = true} : memref<i64>
    %1 = dim %arg0, 0 : memref<?xi64>
    %2 = call @_global_get_unique_ids_count(%arg0, %1) : (memref<?xi64>, index) -> i64
    store %2, %0[] : memref<i64>
    %3 = load %0[] : memref<i64>
    %4 = index_cast %3 : i64 to index
    %5 = alloc(%4) {temp = true} : memref<?xi64>
    %6 = dim %arg0, 0 : memref<?xi64>
    %7 = alloc(%6) {temp = true} : memref<?xi64>
    call @_global_unique_i64_i64(%arg0, %5, %7) : (memref<?xi64>, memref<?xi64>, memref<?xi64>) -> ()
    dealloc %0 : memref<i64>
    dealloc %5 : memref<?xi64>
    dealloc %7 : memref<?xi64>
```
so the two external function  _global_get_unique_ids_count and _global_unique_i64_i64 is called to actually do unique , which is now located in runner_utils lib