### PR TITLE
fix the core_dump in reduce_max with input type tf.complex64  

### DIFF
--- a/tensorflow/compiler/tf2xla/kernels/reduction_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/reduction_ops.cc
@@ -88,11 +88,12 @@ class MaxOp : public XlaReductionOp {
     OP_REQUIRES_OK(ctx, TypeCheck(xla_reduction_type_));
   }
 
-  Status TypeCheck(xla::PrimitiveType xla_reduction_type_){
-    if(xla_reduction_type_ == xla::C64){
-	  return errors::InvalidArgument(
-		"Unsupported type in xla_reduction_type_");
-	}else{
+  Status TypeCheck(xla::PrimitiveType xla_reduction_type_) {
+    if (xla_reduction_type_ == xla::C64) {
+      return errors::InvalidArgument(
+          "Unsupported PrimitiveType in MaxOp: '",
+          xla::PrimitiveType_Name(xla_reduction_type_), "'");
+    } else {
       return Status::OK();
     }
   }

--- a/tensorflow/compiler/tf2xla/kernels/reduction_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/reduction_ops.cc
@@ -84,7 +84,18 @@ REGISTER_XLA_OP(Name("Min").CompileTimeConstantInput("reduction_indices"),
 class MaxOp : public XlaReductionOp {
  public:
   explicit MaxOp(OpKernelConstruction* ctx)
-      : XlaReductionOp(ctx, ctx->input_type(0)) {}
+      : XlaReductionOp(ctx, ctx->input_type(0)) {
+    OP_REQUIRES_OK(ctx, TypeCheck(xla_reduction_type_));
+  }
+
+  Status TypeCheck(xla::PrimitiveType xla_reduction_type_){
+    if(xla_reduction_type_ == xla::C64){
+	  return errors::InvalidArgument(
+		"Unsupported type in xla_reduction_type_");
+	}else{
+      return Status::OK();
+    }
+  }
 
   xla::XlaOp InitialValue(xla::XlaBuilder* builder) override {
     return xla::MinValue(builder, xla_reduction_type_);

--- a/tensorflow/compiler/tf2xla/kernels/reduction_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/reduction_ops.cc
@@ -85,16 +85,16 @@ class MaxOp : public XlaReductionOp {
  public:
   explicit MaxOp(OpKernelConstruction* ctx)
       : XlaReductionOp(ctx, ctx->input_type(0)) {
-    OP_REQUIRES_OK(ctx, TypeCheck(xla_reduction_type_));
+    OP_REQUIRES_OK(ctx, PrimitiveTypeCheck(xla_reduction_type_));
   }
 
-  Status TypeCheck(xla::PrimitiveType xla_reduction_type_) {
-    if (xla_reduction_type_ == xla::C64 || xla_reduction_type_ == xla::C128 ||
-        xla_reduction_type_ == xla::TUPLE ||
-        xla_reduction_type_ == xla::OPAQUE_TYPE) {
+  static Status PrimitiveTypeCheck(xla::PrimitiveType xla_reduction_type) {
+    if (xla_reduction_type == xla::C64 || xla_reduction_type == xla::C128 ||
+        xla_reduction_type == xla::TUPLE ||
+        xla_reduction_type == xla::OPAQUE_TYPE) {
       return errors::InvalidArgument(
           "Unsupported PrimitiveType in MaxOp: '",
-          xla::PrimitiveType_Name(xla_reduction_type_), "'");
+          xla::PrimitiveType_Name(xla_reduction_type), "'");
     } else {
       return Status::OK();
     }

--- a/tensorflow/compiler/tf2xla/kernels/reduction_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/reduction_ops.cc
@@ -89,7 +89,9 @@ class MaxOp : public XlaReductionOp {
   }
 
   Status TypeCheck(xla::PrimitiveType xla_reduction_type_) {
-    if (xla_reduction_type_ == xla::C64) {
+    if (xla_reduction_type_ == xla::C64 || xla_reduction_type_ == xla::C128 ||
+        xla_reduction_type_ == xla::TUPLE ||
+        xla_reduction_type_ == xla::OPAQUE_TYPE) {
       return errors::InvalidArgument(
           "Unsupported PrimitiveType in MaxOp: '",
           xla::PrimitiveType_Name(xla_reduction_type_), "'");


### PR DESCRIPTION
As report in this issue: https://github.com/tensorflow/tensorflow/issues/37446
When the input type of tf.complex64 , reduce_max op will core dump.
This PR add the condition judgement to avoid core-dump directly. 