### PR TITLE
[MLIR/XLA] fix wrong tilingSize dimension in lhlo-fuse-linalg pass

### DIFF
--- a/tensorflow/compiler/mlir/xla/transforms/lhlo_fuse_linalg.cc
+++ b/tensorflow/compiler/mlir/xla/transforms/lhlo_fuse_linalg.cc
@@ -64,7 +64,7 @@ class LhloFuseLinalg : public FunctionPass<LhloFuseLinalg> {
                                          tile_sizes_.end());
       if (tile_sizes.empty()) {
         tile_sizes =
-            SmallVector<int64_t, 2>(generic_op.getNumInputsAndOutputs(), 1);
+            SmallVector<int64_t, 2>(generic_op.getNumLoops(), 1);
       }
       auto op = cast<LinalgOp>(generic_op.getOperation());
       for (const Value result : op.getOutputBuffers()) {


### PR DESCRIPTION
The default action of lhlo-fuse-linalg pass is to tile all loops which is equal to `getNumLoops()` instead of `getNumInputsAndOutputs()`. The number of inputs and outputs has nothing to do with the dimension number.

As shown in the added test, for generic ops having 4-dimension operands , original behavior is to tile the first three loops which is equal to `getNumInputsAndOutputs()` (we have two inputs and one output), and new behavior is to tile all the four loops.