### PR TITLE
[New Feature] tf.data pipeline serialization to json for performance analysis

### DIFF
--- a/tensorflow/python/data/benchmarks/from_tensor_slices_benchmark.py
+++ b/tensorflow/python/data/benchmarks/from_tensor_slices_benchmark.py
@@ -33,6 +33,11 @@ class SingleThreadedFlatMapDataset(dataset_ops.UnaryDataset):
   def __init__(self, input_dataset, map_func):
     """See `Dataset.flat_map()` for details."""
     self._input_dataset = input_dataset
+
+    self._save_configuration({
+      "map_func": str(map_func),
+    })
+
     self._map_func = dataset_ops.StructuredFunctionWrapper(
         map_func,
         self._transformation_name(),

--- a/tensorflow/python/data/experimental/ops/batching.py
+++ b/tensorflow/python/data/experimental/ops/batching.py
@@ -407,6 +407,10 @@ class _DenseToRaggedDataset(dataset_ops.UnaryDataset):
         have their row_splits dtype changed.
     """
 
+    self._save_configuration({
+      "row_splits_dtype": row_splits_dtype,
+    })
+
     # Replace each TensorSpec in the input dataset's structure with a
     # corresponding RaggedTensorSpec.
     def to_ragged_spec(spec):

--- a/tensorflow/python/data/experimental/ops/batching.py
+++ b/tensorflow/python/data/experimental/ops/batching.py
@@ -290,6 +290,12 @@ class _DenseToSparseBatchDataset(dataset_ops.UnaryDataset):
 
   def __init__(self, input_dataset, batch_size, row_shape):
     """See `Dataset.dense_to_sparse_batch()` for more details."""
+
+    self._save_configuration({
+      "batch_size": batch_size,
+      "row_shape": row_shape,
+    })
+
     if not isinstance(
         dataset_ops.get_legacy_output_types(input_dataset), dtypes.DType):
       raise TypeError("DenseToSparseDataset requires an input whose elements "
@@ -321,6 +327,18 @@ class _MapAndBatchDataset(dataset_ops.UnaryDataset):
   def __init__(self, input_dataset, map_func, batch_size, num_parallel_calls,
                drop_remainder, use_legacy_function=False):
     self._input_dataset = input_dataset
+
+    _num_parallel_calls = dataset_ops.parse_maybe_autotune_arg(
+        num_parallel_calls
+    )
+
+    self._save_configuration({
+      "map_func": str(map_func),
+      "batch_size": batch_size,
+      "num_parallel_calls": _num_parallel_calls,
+      "drop_remainder": drop_remainder,
+      "use_legacy_function": use_legacy_function,
+    })
 
     self._map_func = dataset_ops.StructuredFunctionWrapper(
         map_func,

--- a/tensorflow/python/data/experimental/ops/cardinality.py
+++ b/tensorflow/python/data/experimental/ops/cardinality.py
@@ -102,6 +102,11 @@ class _AssertCardinalityDataset(dataset_ops.UnaryUnchangedStructureDataset):
   """A `Dataset` that assert the cardinality of its input."""
 
   def __init__(self, input_dataset, expected_cardinality):
+
+    self._save_configuration({
+      "expected_cardinality": expected_cardinality,
+    })
+
     self._input_dataset = input_dataset
     self._expected_cardinality = ops.convert_to_tensor(
         expected_cardinality, dtype=dtypes.int64, name="expected_cardinality")

--- a/tensorflow/python/data/experimental/ops/distribute.py
+++ b/tensorflow/python/data/experimental/ops/distribute.py
@@ -47,6 +47,11 @@ class _AutoShardDataset(dataset_ops.UnaryDataset):
   def __init__(self, input_dataset, num_workers, index):
     self._input_dataset = input_dataset
 
+    self._save_configuration({
+      "num_workers": num_workers,
+      "index": index,
+    })
+
     self._element_spec = input_dataset.element_spec
     if (compat.forward_compatible(2019, 11, 25) or
         (input_dataset.options().experimental_distribute.auto_shard_policy !=
@@ -84,11 +89,12 @@ class _RebatchDataset(dataset_ops.UnaryDataset):
   """
 
   def __init__(self, input_dataset, num_replicas, use_fallback=True):
+    self._input_dataset = input_dataset
 
-    def recalculate_batch_size(output_shape):
-      """Recalculates the output_shape after dividing it by num_replicas."""
-      # If the output shape is unknown, we set the batch dimension to unknown.
-      if output_shape.rank is None:
+    self._save_configuration({
+      "num_replicas": num_replicas,
+      "use_fallback": use_fallback,
+    })
         return None
 
       if len(output_shape) < 1:
@@ -129,6 +135,13 @@ class _RemoteDataset(dataset_ops.DatasetSource):
   """Creates a dataset on a given `device` given a graph def."""
 
   def __init__(self, graph_def, device, element_spec):
+
+    self._save_configuration({
+      "graph_def": str(graph_def),
+      "device": device,
+      "element_spec": str(element_spec),
+    })
+
     self._elem_spec = element_spec
     with ops.device(device):
       variant_tensor = ged_ops.dataset_from_graph(graph_def)

--- a/tensorflow/python/data/experimental/ops/distribute.py
+++ b/tensorflow/python/data/experimental/ops/distribute.py
@@ -89,12 +89,16 @@ class _RebatchDataset(dataset_ops.UnaryDataset):
   """
 
   def __init__(self, input_dataset, num_replicas, use_fallback=True):
-    self._input_dataset = input_dataset
 
     self._save_configuration({
       "num_replicas": num_replicas,
       "use_fallback": use_fallback,
     })
+
+    def recalculate_batch_size(output_shape):
+      """Recalculates the output_shape after dividing it by num_replicas."""
+      # If the output shape is unknown, we set the batch dimension to unknown.
+      if output_shape.rank is None:
         return None
 
       if len(output_shape) < 1:

--- a/tensorflow/python/data/experimental/ops/grouping.py
+++ b/tensorflow/python/data/experimental/ops/grouping.py
@@ -250,6 +250,7 @@ class _GroupByReducerDataset(dataset_ops.UnaryDataset):
   def __init__(self, input_dataset, key_func, reducer):
     """See `group_by_reducer()` for details."""
     self._input_dataset = input_dataset
+
     self._save_configuration({
       "key_func": str(key_func),
       "reducer": str(reducer),
@@ -378,6 +379,7 @@ class _GroupByWindowDataset(dataset_ops.UnaryDataset):
   def __init__(self, input_dataset, key_func, reduce_func, window_size_func):
     """See `group_by_window()` for details."""
     self._input_dataset = input_dataset
+    
     self._save_configuration({
       "key_func": str(key_func),
       "reduce_func": str(reduce_func),

--- a/tensorflow/python/data/experimental/ops/grouping.py
+++ b/tensorflow/python/data/experimental/ops/grouping.py
@@ -250,6 +250,11 @@ class _GroupByReducerDataset(dataset_ops.UnaryDataset):
   def __init__(self, input_dataset, key_func, reducer):
     """See `group_by_reducer()` for details."""
     self._input_dataset = input_dataset
+    self._save_configuration({
+      "key_func": str(key_func),
+      "reducer": str(reducer),
+    })
+
     self._make_key_func(key_func, input_dataset)
     self._make_init_func(reducer.init_func)
     self._make_reduce_func(reducer.reduce_func, input_dataset)
@@ -373,6 +378,12 @@ class _GroupByWindowDataset(dataset_ops.UnaryDataset):
   def __init__(self, input_dataset, key_func, reduce_func, window_size_func):
     """See `group_by_window()` for details."""
     self._input_dataset = input_dataset
+    self._save_configuration({
+      "key_func": str(key_func),
+      "reduce_func": str(reduce_func),
+      "window_size_func": str(window_size_func),
+    })
+
     self._make_key_func(key_func, input_dataset)
     self._make_reduce_func(reduce_func, input_dataset)
     self._make_window_size_func(window_size_func)

--- a/tensorflow/python/data/experimental/ops/interleave_ops.py
+++ b/tensorflow/python/data/experimental/ops/interleave_ops.py
@@ -108,15 +108,20 @@ class _DirectedInterleaveDataset(dataset_ops.DatasetV2):
     self._selector_input = selector_input
     self._data_inputs = list(data_inputs)
 
-    first_output_types = dataset_ops.get_legacy_output_types(data_inputs[0])
-    first_output_classes = dataset_ops.get_legacy_output_classes(data_inputs[0])
-
     self._save_configuration({
       "inputs_count": len(list(data_inputs)),
-      "inputs_type": first_output_types,
-      "inputs_classes": first_output_classes,
+      "inputs_ds": [str(t) for t in data_inputs],
+      "inputs_ds_types": [
+        dataset_ops.get_legacy_output_types(t) for t in data_inputs
+      ],
+      "inputs_ds_classes": [
+        dataset_ops.get_legacy_output_classes(t) for t in data_inputs
+      ],
       "selector_input": str(selector_input)
     })
+
+    first_output_types = dataset_ops.get_legacy_output_types(data_inputs[0])
+    first_output_classes = dataset_ops.get_legacy_output_classes(data_inputs[0])
 
     for data_input in data_inputs[1:]:
       if (dataset_ops.get_legacy_output_types(data_input) != first_output_types

--- a/tensorflow/python/data/experimental/ops/interleave_ops.py
+++ b/tensorflow/python/data/experimental/ops/interleave_ops.py
@@ -111,6 +111,13 @@ class _DirectedInterleaveDataset(dataset_ops.DatasetV2):
     first_output_types = dataset_ops.get_legacy_output_types(data_inputs[0])
     first_output_classes = dataset_ops.get_legacy_output_classes(data_inputs[0])
 
+    self._save_configuration({
+      "inputs_count": len(list(data_inputs)),
+      "inputs_type": first_output_types,
+      "inputs_classes": first_output_classes,
+      "selector_input": str(selector_input)
+    })
+
     for data_input in data_inputs[1:]:
       if (dataset_ops.get_legacy_output_types(data_input) != first_output_types
           or dataset_ops.get_legacy_output_classes(data_input)

--- a/tensorflow/python/data/experimental/ops/matching_files.py
+++ b/tensorflow/python/data/experimental/ops/matching_files.py
@@ -29,6 +29,11 @@ class MatchingFilesDataset(dataset_ops.DatasetSource):
   """A `Dataset` that list the files according to the input patterns."""
 
   def __init__(self, patterns):
+
+    self._save_configuration({
+      "patterns": patterns,
+    })
+
     self._patterns = ops.convert_to_tensor(
         patterns, dtype=dtypes.string, name="patterns")
     variant_tensor = ged_ops.matching_files_dataset(self._patterns)

--- a/tensorflow/python/data/experimental/ops/optimization.py
+++ b/tensorflow/python/data/experimental/ops/optimization.py
@@ -86,6 +86,12 @@ class _ChooseFastestDataset(dataset_ops.DatasetV2):
     Returns:
       A `Dataset` that has the same elements the inputs.
     """
+
+    self._save_configuration({
+      "num_experiments": num_experiments,
+      "input_datasets": len(list(datasets))
+    })
+
     self._datasets = list(datasets)
     self._element_spec = self._datasets[0].element_spec
     variant_tensor = (
@@ -173,6 +179,14 @@ class _ChooseFastestBranchDataset(dataset_ops.UnaryDataset):
     Returns:
       A `Dataset` that has the same elements the inputs.
     """
+
+    self._save_configuration({
+      "input_function_count": len(list(functions)),
+      "ratio_numerator": ratio_numerator,
+      "ratio_denominator": ratio_denominator,
+      "num_elements_per_branch": num_elements_per_branch,
+    })
+
     input_structure = dataset_ops.DatasetSpec(input_dataset.element_spec)
     self._funcs = [
         dataset_ops.StructuredFunctionWrapper(

--- a/tensorflow/python/data/experimental/ops/optimization.py
+++ b/tensorflow/python/data/experimental/ops/optimization.py
@@ -88,8 +88,8 @@ class _ChooseFastestDataset(dataset_ops.DatasetV2):
     """
 
     self._save_configuration({
+      "num_input_ds": len(list(datasets)),
       "num_experiments": num_experiments,
-      "input_datasets": len(list(datasets))
     })
 
     self._datasets = list(datasets)
@@ -103,6 +103,14 @@ class _ChooseFastestDataset(dataset_ops.DatasetV2):
 
   def _inputs(self):
     return self._datasets
+
+  def _serialize_configuration(self):
+    config = super(_ChooseFastestDataset, self)._serialize_configuration()
+    config["input_ds"] = [
+      ds._serialize_configuration() for ds in self._datasets
+    ]
+
+    return config
 
   @property
   def element_spec(self):
@@ -182,6 +190,7 @@ class _ChooseFastestBranchDataset(dataset_ops.UnaryDataset):
 
     self._save_configuration({
       "input_function_count": len(list(functions)),
+      "functions": [str(f) for f in functions],
       "ratio_numerator": ratio_numerator,
       "ratio_denominator": ratio_denominator,
       "num_elements_per_branch": num_elements_per_branch,

--- a/tensorflow/python/data/experimental/ops/parsing_ops.py
+++ b/tensorflow/python/data/experimental/ops/parsing_ops.py
@@ -35,6 +35,15 @@ class _ParseExampleDataset(dataset_ops.UnaryDataset):
   def __init__(self, input_dataset, features, num_parallel_calls,
                deterministic):
     self._input_dataset = input_dataset
+    _num_parallel_calls = dataset_ops.parse_maybe_autotune_arg(
+      num_parallel_calls
+    )
+
+    self._save_configuration({
+      "features": features,
+      "num_parallel_calls": _num_parallel_calls,
+    })
+
     if not structure.are_compatible(
         input_dataset.element_spec,
         tensor_spec.TensorSpec([None], dtypes.string)):
@@ -64,10 +73,15 @@ class _ParseExampleDataset(dataset_ops.UnaryDataset):
     self._dense_defaults = params.dense_defaults_vec
     self._dense_shapes = params.dense_shapes_as_proto
     self._dense_types = params.dense_types
+
     input_dataset_shape = dataset_ops.get_legacy_output_shapes(
         self._input_dataset)
 
     self._element_spec = {}
+
+    self._save_configuration({
+      "input_dataset_shape": input_dataset_shape,
+    })
 
     for (key, value_type) in zip(params.sparse_keys, params.sparse_types):
       self._element_spec[key] = sparse_tensor.SparseTensorSpec(

--- a/tensorflow/python/data/experimental/ops/parsing_ops.py
+++ b/tensorflow/python/data/experimental/ops/parsing_ops.py
@@ -35,6 +35,7 @@ class _ParseExampleDataset(dataset_ops.UnaryDataset):
   def __init__(self, input_dataset, features, num_parallel_calls,
                deterministic):
     self._input_dataset = input_dataset
+    
     _num_parallel_calls = dataset_ops.parse_maybe_autotune_arg(
       num_parallel_calls
     )
@@ -42,6 +43,7 @@ class _ParseExampleDataset(dataset_ops.UnaryDataset):
     self._save_configuration({
       "features": features,
       "num_parallel_calls": _num_parallel_calls,
+      "deterministic": deterministic,
     })
 
     if not structure.are_compatible(

--- a/tensorflow/python/data/experimental/ops/prefetching_ops.py
+++ b/tensorflow/python/data/experimental/ops/prefetching_ops.py
@@ -95,6 +95,7 @@ class _CopyToDeviceDataset(dataset_ops.UnaryUnchangedStructureDataset):
       source_device: Device where input_dataset would be placed.
     """
     self._input_dataset = input_dataset
+    
     self._save_configuration({
       "target_device": target_device,
       "source_device": source_device,
@@ -236,6 +237,7 @@ class _MapOnGpuDataset(dataset_ops.UnaryDataset):
   def __init__(self, input_dataset, map_func, use_inter_op_parallelism=True):
     """See `Dataset.map()` for details."""
     self._input_dataset = input_dataset
+
     self._save_configuration({
       "map_func": str(map_func),
       "use_inter_op_parallelism": use_inter_op_parallelism,

--- a/tensorflow/python/data/experimental/ops/prefetching_ops.py
+++ b/tensorflow/python/data/experimental/ops/prefetching_ops.py
@@ -95,6 +95,11 @@ class _CopyToDeviceDataset(dataset_ops.UnaryUnchangedStructureDataset):
       source_device: Device where input_dataset would be placed.
     """
     self._input_dataset = input_dataset
+    self._save_configuration({
+      "target_device": target_device,
+      "source_device": source_device,
+    })
+
     self._target_device = target_device
     spec = framework_device.DeviceSpec().from_string(self._target_device)
     self._is_gpu_target = (spec.device_type == "GPU")
@@ -231,6 +236,11 @@ class _MapOnGpuDataset(dataset_ops.UnaryDataset):
   def __init__(self, input_dataset, map_func, use_inter_op_parallelism=True):
     """See `Dataset.map()` for details."""
     self._input_dataset = input_dataset
+    self._save_configuration({
+      "map_func": str(map_func),
+      "use_inter_op_parallelism": use_inter_op_parallelism,
+    })
+
     self._use_inter_op_parallelism = use_inter_op_parallelism
 
     self._map_func = dataset_ops.StructuredFunctionWrapper(

--- a/tensorflow/python/data/experimental/ops/random_ops.py
+++ b/tensorflow/python/data/experimental/ops/random_ops.py
@@ -34,6 +34,11 @@ class RandomDatasetV2(dataset_ops.DatasetSource):
 
   def __init__(self, seed=None):
     """A `Dataset` of pseudorandom values."""
+
+    self._save_configuration({
+      "seed": seed,
+    })
+
     self._seed, self._seed2 = random_seed.get_seed(seed)
     variant_tensor = gen_experimental_dataset_ops.random_dataset(
         seed=self._seed, seed2=self._seed2, **self._flat_structure)
@@ -50,6 +55,11 @@ class RandomDatasetV1(dataset_ops.DatasetV1Adapter):
 
   @functools.wraps(RandomDatasetV2.__init__)
   def __init__(self, seed=None):
+
+    self._save_configuration({
+      "seed": seed,
+    })
+
     wrapped = RandomDatasetV2(seed)
     super(RandomDatasetV1, self).__init__(wrapped)
 

--- a/tensorflow/python/data/experimental/ops/readers.py
+++ b/tensorflow/python/data/experimental/ops/readers.py
@@ -674,6 +674,19 @@ class CsvDatasetV2(dataset_ops.DatasetSource):
         the input data. If specified, only this subset of columns will be
         parsed. Defaults to parsing all columns.
     """
+
+    self._save_configuration({
+      "filenames": filenames,
+      "record_defaults": record_defaults,
+      "compression_type": compression_type or "",
+      "buffer_size": buffer_size or _DEFAULT_READER_BUFFER_SIZE_BYTES,
+      "header": header,
+      "field_delim": field_delim,
+      "use_quote_delim": use_quote_delim,
+      "na_value": na_value,
+      "select_cols": select_cols or [],
+    })
+
     self._filenames = ops.convert_to_tensor(
         filenames, dtype=dtypes.string, name="filenames")
     self._compression_type = convert.optional_param_to_tensor(
@@ -1013,6 +1026,14 @@ class SqlDatasetV2(dataset_ops.DatasetSource):
       output_types: A tuple of `tf.DType` objects representing the types of the
         columns returned by `query`.
     """
+
+    self._save_configuration({
+      "driver_name": driver_name,
+      "data_source_name": data_source_name,
+      "query": query,
+      "output_types": output_types,
+    })
+
     self._driver_name = ops.convert_to_tensor(
         driver_name, dtype=dtypes.string, name="driver_name")
     self._data_source_name = ops.convert_to_tensor(

--- a/tensorflow/python/data/experimental/ops/readers.py
+++ b/tensorflow/python/data/experimental/ops/readers.py
@@ -678,13 +678,13 @@ class CsvDatasetV2(dataset_ops.DatasetSource):
     self._save_configuration({
       "filenames": filenames,
       "record_defaults": record_defaults,
-      "compression_type": compression_type or "",
-      "buffer_size": buffer_size or _DEFAULT_READER_BUFFER_SIZE_BYTES,
+      "compression_type": compression_type,
+      "buffer_size": buffer_size,
       "header": header,
       "field_delim": field_delim,
       "use_quote_delim": use_quote_delim,
       "na_value": na_value,
-      "select_cols": select_cols or [],
+      "select_cols": select_cols,
     })
 
     self._filenames = ops.convert_to_tensor(

--- a/tensorflow/python/data/experimental/ops/scan_ops.py
+++ b/tensorflow/python/data/experimental/ops/scan_ops.py
@@ -36,6 +36,12 @@ class _ScanDataset(dataset_ops.UnaryDataset):
                use_default_device=None):
     """See `scan()` for details."""
     self._input_dataset = input_dataset
+    self._save_configuration({
+      "initial_state": initial_state,
+      "scan_func": str(scan_func),
+      "use_default_device": str(use_default_device),
+    })
+
     self._initial_state = structure.normalize_element(initial_state)
 
     # Compute initial values for the state classes, shapes and types based on

--- a/tensorflow/python/data/experimental/ops/scan_ops.py
+++ b/tensorflow/python/data/experimental/ops/scan_ops.py
@@ -36,6 +36,7 @@ class _ScanDataset(dataset_ops.UnaryDataset):
                use_default_device=None):
     """See `scan()` for details."""
     self._input_dataset = input_dataset
+
     self._save_configuration({
       "initial_state": initial_state,
       "scan_func": str(scan_func),

--- a/tensorflow/python/data/experimental/ops/shuffle_ops.py
+++ b/tensorflow/python/data/experimental/ops/shuffle_ops.py
@@ -32,6 +32,12 @@ class _ShuffleAndRepeatDataset(dataset_ops.UnaryUnchangedStructureDataset):
 
   def __init__(self, input_dataset, buffer_size, count=None, seed=None):
     self._input_dataset = input_dataset
+    self._save_configuration({
+      "buffer_size": buffer_size,
+      "count": count,
+      "seed": seed,
+    })
+
     self._buffer_size = ops.convert_to_tensor(
         buffer_size, dtype=dtypes.int64, name="buffer_size")
     if count is None:

--- a/tensorflow/python/data/experimental/ops/shuffle_ops.py
+++ b/tensorflow/python/data/experimental/ops/shuffle_ops.py
@@ -32,6 +32,7 @@ class _ShuffleAndRepeatDataset(dataset_ops.UnaryUnchangedStructureDataset):
 
   def __init__(self, input_dataset, buffer_size, count=None, seed=None):
     self._input_dataset = input_dataset
+    
     self._save_configuration({
       "buffer_size": buffer_size,
       "count": count,

--- a/tensorflow/python/data/experimental/ops/sleep.py
+++ b/tensorflow/python/data/experimental/ops/sleep.py
@@ -26,6 +26,7 @@ class _SleepDataset(dataset_ops.UnaryUnchangedStructureDataset):
 
   def __init__(self, input_dataset, sleep_microseconds):
     self._input_dataset = input_dataset
+    
     self._save_configuration({
       "sleep_microseconds": sleep_microseconds,
     })

--- a/tensorflow/python/data/experimental/ops/sleep.py
+++ b/tensorflow/python/data/experimental/ops/sleep.py
@@ -26,6 +26,10 @@ class _SleepDataset(dataset_ops.UnaryUnchangedStructureDataset):
 
   def __init__(self, input_dataset, sleep_microseconds):
     self._input_dataset = input_dataset
+    self._save_configuration({
+      "sleep_microseconds": sleep_microseconds,
+    })
+
     self._sleep_microseconds = sleep_microseconds
     variant_tensor = gen_experimental_dataset_ops.sleep_dataset(
         self._input_dataset._variant_tensor,  # pylint: disable=protected-access

--- a/tensorflow/python/data/experimental/ops/snapshot.py
+++ b/tensorflow/python/data/experimental/ops/snapshot.py
@@ -50,6 +50,22 @@ class _SnapshotDataset(dataset_ops.UnaryUnchangedStructureDataset):
                mode=None,
                snapshot_name=None):
 
+    self._save_configuration({
+      "path": path,
+      "compression": compression,
+      "reader_path_prefix": reader_path_prefix,
+      "writer_path_prefix": writer_path_prefix,
+      "shard_size_bytes": shard_size_bytes,
+      "pending_snapshot_expiry_seconds": pending_snapshot_expiry_seconds,
+      "num_reader_threads": num_reader_threads,
+      "reader_buffer_size": reader_buffer_size,
+      "num_writer_threads": num_writer_threads,
+      "shuffle_on_read": shuffle_on_read,
+      "shuffle_seed": shuffle_seed,
+      "mode": mode,
+      "snapshot_name": snapshot_name,
+    })
+
     self._compression = compression if compression is not None else ""
     self._reader_path_prefix = (
         reader_path_prefix if reader_path_prefix is not None else "")

--- a/tensorflow/python/data/experimental/ops/snapshot.py
+++ b/tensorflow/python/data/experimental/ops/snapshot.py
@@ -60,6 +60,7 @@ class _SnapshotDataset(dataset_ops.UnaryUnchangedStructureDataset):
       "num_reader_threads": num_reader_threads,
       "reader_buffer_size": reader_buffer_size,
       "num_writer_threads": num_writer_threads,
+      "writer_buffer_size": writer_buffer_size,
       "shuffle_on_read": shuffle_on_read,
       "shuffle_seed": shuffle_seed,
       "mode": mode,

--- a/tensorflow/python/data/experimental/ops/stats_ops.py
+++ b/tensorflow/python/data/experimental/ops/stats_ops.py
@@ -99,6 +99,7 @@ class _StatsDataset(dataset_ops.UnaryUnchangedStructureDataset):
 
   def __init__(self, input_dataset, op_function, tag):
     self._input_dataset = input_dataset
+    
     self._save_configuration({
       "op_function": str(op_function),
       "tag": tag,

--- a/tensorflow/python/data/experimental/ops/stats_ops.py
+++ b/tensorflow/python/data/experimental/ops/stats_ops.py
@@ -99,6 +99,11 @@ class _StatsDataset(dataset_ops.UnaryUnchangedStructureDataset):
 
   def __init__(self, input_dataset, op_function, tag):
     self._input_dataset = input_dataset
+    self._save_configuration({
+      "op_function": str(op_function),
+      "tag": tag,
+    })
+
     self._op_function = op_function
     self._tag = ops.convert_to_tensor(tag, dtype=dtypes.string)
     variant_tensor = self._op_function(

--- a/tensorflow/python/data/experimental/ops/take_while_ops.py
+++ b/tensorflow/python/data/experimental/ops/take_while_ops.py
@@ -31,6 +31,7 @@ class _TakeWhileDataset(dataset_ops.UnaryUnchangedStructureDataset):
     """See `take_while()` for details."""
 
     self._input_dataset = input_dataset
+    
     self._save_configuration({
       "predicate": str(predicate),
     })

--- a/tensorflow/python/data/experimental/ops/take_while_ops.py
+++ b/tensorflow/python/data/experimental/ops/take_while_ops.py
@@ -31,6 +31,10 @@ class _TakeWhileDataset(dataset_ops.UnaryUnchangedStructureDataset):
     """See `take_while()` for details."""
 
     self._input_dataset = input_dataset
+    self._save_configuration({
+      "predicate": str(predicate),
+    })
+
     wrapped_func = dataset_ops.StructuredFunctionWrapper(
         predicate,
         "tf.data.experimental.take_while()",

--- a/tensorflow/python/data/experimental/ops/testing.py
+++ b/tensorflow/python/data/experimental/ops/testing.py
@@ -83,6 +83,11 @@ class _AssertNextDataset(dataset_ops.UnaryUnchangedStructureDataset):
   def __init__(self, input_dataset, transformations):
     """See `assert_next()` for details."""
     self._input_dataset = input_dataset
+
+    self._save_configuration({
+      "transformations": transformations,
+    })
+
     if transformations is None:
       raise ValueError("At least one transformation should be specified")
     self._transformations = ops.convert_to_tensor(
@@ -113,11 +118,14 @@ class _SleepDataset(dataset_ops.UnaryUnchangedStructureDataset):
 
   def __init__(self, input_dataset, sleep_microseconds):
     self._input_dataset = input_dataset
+
+    self._save_configuration({
+      "sleep_microseconds": sleep_microseconds,
+    })
+
     self._sleep_microseconds = sleep_microseconds
     variant_tensor = gen_experimental_dataset_ops.sleep_dataset(
         self._input_dataset._variant_tensor,  # pylint: disable=protected-access
         self._sleep_microseconds,
         **self._flat_structure)
     super(_SleepDataset, self).__init__(input_dataset, variant_tensor)
-
-

--- a/tensorflow/python/data/experimental/ops/threadpool.py
+++ b/tensorflow/python/data/experimental/ops/threadpool.py
@@ -65,6 +65,7 @@ class _ThreadPoolDataset(dataset_ops.UnaryUnchangedStructureDataset):
 
   def __init__(self, input_dataset, thread_pool):
     self._input_dataset = input_dataset
+    
     self._save_configuration({
       "thread_pool": thread_pool,
     })

--- a/tensorflow/python/data/experimental/ops/threadpool.py
+++ b/tensorflow/python/data/experimental/ops/threadpool.py
@@ -65,6 +65,10 @@ class _ThreadPoolDataset(dataset_ops.UnaryUnchangedStructureDataset):
 
   def __init__(self, input_dataset, thread_pool):
     self._input_dataset = input_dataset
+    self._save_configuration({
+      "thread_pool": thread_pool,
+    })
+
     self._thread_pool = thread_pool
     variant_tensor = ged_ops.thread_pool_dataset(
         self._input_dataset._variant_tensor,  # pylint: disable=protected-access

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -3188,10 +3188,10 @@ class _VariantDataset(DatasetV2):
 
   def __init__(self, dataset_variant, structure):
 
-  self._save_configuration({
-    "dataset_variant": dataset_variant,
-    "structure": structure
-  })
+    self._save_configuration({
+      "dataset_variant": dataset_variant,
+      "structure": structure
+    })
 
     self._structure = structure
     super(_VariantDataset, self).__init__(dataset_variant)

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -65,8 +65,7 @@ from tensorflow.python.ops import gen_io_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import script_ops
 from tensorflow.python.ops import string_ops
-from tensorflow.python.platform import tf_logging as logging
-from tensorflow.python.pywrap_tensorflow_internal import __version__ \
+from tensorflow.python.client.pywrap_tf_session import __version__ \
   as tf_version
 from tensorflow.python.training.tracking import base as tracking_base
 from tensorflow.python.training.tracking import tracking

--- a/tensorflow/python/data/ops/multi_device_iterator_ops.py
+++ b/tensorflow/python/data/ops/multi_device_iterator_ops.py
@@ -40,6 +40,15 @@ class _PerDeviceGenerator(dataset_ops.DatasetV2):
 
   def __init__(self, shard_num, multi_device_iterator_resource, incarnation_id,
                source_device, element_spec):
+
+     self._save_configuration({
+       "shard_num": shard_num,
+       "multi_device_iterator_resource": multi_device_iterator_resource,
+       "incarnation_id": incarnation_id,
+       "source_device": source_device,
+       "element_spec": element_spec,
+     })
+
     self._element_spec = element_spec
 
     multi_device_iterator_string_handle = (
@@ -57,6 +66,12 @@ class _PerDeviceGenerator(dataset_ops.DatasetV2):
     @function.defun(autograph=False)  # Pure graph code.
     def _remote_init_func():
       return functional_ops.remote_call(
+          target=source_device,
+          target=source_device,
+          target=source_device,
+          target=source_device,
+          target=source_device,
+          target=source_device,
           target=source_device,
           args=init_func_concrete.captured_inputs,
           Tout=[dtypes.string],
@@ -156,6 +171,12 @@ class _ReincarnatedPerDeviceGenerator(dataset_ops.DatasetV2):
   """
 
   def __init__(self, per_device_dataset, incarnation_id):
+
+    self._save_configuration({
+      "per_device_dataset": per_device_dataset,
+      "incarnation_id": incarnation_id,
+    })
+
     # pylint: disable=protected-access
     self._element_spec = per_device_dataset.element_spec
     self._init_func = per_device_dataset._init_func

--- a/tensorflow/python/data/ops/multi_device_iterator_ops.py
+++ b/tensorflow/python/data/ops/multi_device_iterator_ops.py
@@ -41,13 +41,13 @@ class _PerDeviceGenerator(dataset_ops.DatasetV2):
   def __init__(self, shard_num, multi_device_iterator_resource, incarnation_id,
                source_device, element_spec):
 
-     self._save_configuration({
-       "shard_num": shard_num,
-       "multi_device_iterator_resource": multi_device_iterator_resource,
-       "incarnation_id": incarnation_id,
-       "source_device": source_device,
-       "element_spec": element_spec,
-     })
+    self._save_configuration({
+      "shard_num": shard_num,
+      "multi_device_iterator_resource": multi_device_iterator_resource,
+      "incarnation_id": incarnation_id,
+      "source_device": source_device,
+      "element_spec": element_spec,
+    })
 
     self._element_spec = element_spec
 
@@ -66,12 +66,6 @@ class _PerDeviceGenerator(dataset_ops.DatasetV2):
     @function.defun(autograph=False)  # Pure graph code.
     def _remote_init_func():
       return functional_ops.remote_call(
-          target=source_device,
-          target=source_device,
-          target=source_device,
-          target=source_device,
-          target=source_device,
-          target=source_device,
           target=source_device,
           args=init_func_concrete.captured_inputs,
           Tout=[dtypes.string],

--- a/tensorflow/python/data/ops/readers.py
+++ b/tensorflow/python/data/ops/readers.py
@@ -114,8 +114,8 @@ class _TextLineDataset(dataset_ops.DatasetSource):
 
     self._save_configuration({
       "filenames": filenames,
-      "compression_type": compression_type or "",
-      "buffer_size": buffer_size or _DEFAULT_READER_BUFFER_SIZE_BYTES,
+      "compression_type": compression_type,
+      "buffer_size": buffer_size,
     })
 
     self._filenames = filenames
@@ -235,8 +235,8 @@ class _TFRecordDataset(dataset_ops.DatasetSource):
 
     self._save_configuration({
       "filenames": filenames,
-      "compression_type": compression_type or "",
-      "buffer_size": buffer_size or _DEFAULT_READER_BUFFER_SIZE_BYTES,
+      "compression_type": compression_type,
+      "buffer_size": buffer_size,
     })
 
     self._filenames = filenames
@@ -266,13 +266,16 @@ class ParallelInterleaveDataset(dataset_ops.UnaryDataset):
                sloppy, buffer_output_elements, prefetch_input_elements):
     """See `tf.data.experimental.parallel_interleave()` for details."""
     self._input_dataset = input_dataset
+
+    _cycle_length = dataset_ops.parse_maybe_autotune_arg(cycle_length)
+
     self._save_configuration({
       "map_func": str(map_func),
       "cycle_length": cycle_length,
       "block_length": block_length,
       "sloppy": sloppy,
-      "buffer_output_elements": buffer_output_elements or (2 * block_length),
-      "prefetch_input_elements": prefetch_input_elements or (2 * cycle_length),
+      "buffer_output_elements": buffer_output_elements,
+      "prefetch_input_elements": prefetch_input_elements,
     })
 
     self._map_func = dataset_ops.StructuredFunctionWrapper(
@@ -477,10 +480,10 @@ class _FixedLengthRecordDataset(dataset_ops.DatasetSource):
     self._save_configuration({
       "filenames": filenames,
       "record_bytes": record_bytes,
-      "header_bytes": header_bytes or 0,
-      "footer_bytes": footer_bytes or 0,
-      "buffer_size": buffer_size or _DEFAULT_READER_BUFFER_SIZE_BYTES,
-      "compression_type": compression_type or "",
+      "header_bytes": header_bytes,
+      "footer_bytes": footer_bytes,
+      "buffer_size": buffer_size,
+      "compression_type": compression_type,
     })
 
     self._filenames = filenames
@@ -550,10 +553,10 @@ class FixedLengthRecordDatasetV2(dataset_ops.DatasetSource):
     self._save_configuration({
       "filenames": filenames,
       "record_bytes": record_bytes,
-      "header_bytes": header_bytes or 0,
-      "footer_bytes": footer_bytes or 0,
-      "buffer_size": buffer_size or _DEFAULT_READER_BUFFER_SIZE_BYTES,
-      "compression_type": compression_type or "",
+      "header_bytes": header_bytes,
+      "footer_bytes": footer_bytes,
+      "buffer_size": buffer_size,
+      "compression_type": compression_type,
       "num_parallel_reads": _num_parallel_reads,
     })
 

--- a/tensorflow/python/data/ops/readers.py
+++ b/tensorflow/python/data/ops/readers.py
@@ -111,6 +111,13 @@ class _TextLineDataset(dataset_ops.DatasetSource):
         to buffer. A value of 0 results in the default buffering values chosen
         based on the compression type.
     """
+
+    self._save_configuration({
+      "filenames": filenames,
+      "compression_type": compression_type or "",
+      "buffer_size": buffer_size or _DEFAULT_READER_BUFFER_SIZE_BYTES,
+    })
+
     self._filenames = filenames
     self._compression_type = convert.optional_param_to_tensor(
         "compression_type",
@@ -157,6 +164,18 @@ class TextLineDatasetV2(dataset_ops.DatasetSource):
         value greater than one to parallelize the I/O. If `None`, files will be
         read sequentially.
     """
+
+    _num_parallel_reads = dataset_ops.parse_maybe_autotune_arg(
+        num_parallel_reads
+    )
+
+    self._save_configuration({
+      "filenames": filenames,
+      "compression_type": compression_type,
+      "buffer_size": buffer_size,
+      "num_parallel_reads": _num_parallel_reads,
+    })
+
     filenames = _create_or_validate_filenames_dataset(filenames)
     self._filenames = filenames
     self._compression_type = compression_type
@@ -213,6 +232,13 @@ class _TFRecordDataset(dataset_ops.DatasetSource):
       buffer_size: (Optional.) A `tf.int64` scalar representing the number of
         bytes in the read buffer. 0 means no buffering.
     """
+
+    self._save_configuration({
+      "filenames": filenames,
+      "compression_type": compression_type or "",
+      "buffer_size": buffer_size or _DEFAULT_READER_BUFFER_SIZE_BYTES,
+    })
+
     self._filenames = filenames
     self._compression_type = convert.optional_param_to_tensor(
         "compression_type",
@@ -240,6 +266,15 @@ class ParallelInterleaveDataset(dataset_ops.UnaryDataset):
                sloppy, buffer_output_elements, prefetch_input_elements):
     """See `tf.data.experimental.parallel_interleave()` for details."""
     self._input_dataset = input_dataset
+    self._save_configuration({
+      "map_func": str(map_func),
+      "cycle_length": cycle_length,
+      "block_length": block_length,
+      "sloppy": sloppy,
+      "buffer_output_elements": buffer_output_elements or (2 * block_length),
+      "prefetch_input_elements": prefetch_input_elements or (2 * cycle_length),
+    })
+
     self._map_func = dataset_ops.StructuredFunctionWrapper(
         map_func, self._transformation_name(), dataset=input_dataset)
     if not isinstance(self._map_func.output_structure, dataset_ops.DatasetSpec):
@@ -335,6 +370,17 @@ class TFRecordDatasetV2(dataset_ops.DatasetV2):
     """
     filenames = _create_or_validate_filenames_dataset(filenames)
 
+    _num_parallel_reads = dataset_ops.parse_maybe_autotune_arg(
+        num_parallel_reads
+    )
+
+    self._save_configuration({
+      "filenames": filenames,
+      "compression_type": compression_type,
+      "buffer_size": buffer_size,
+      "num_parallel_reads": _num_parallel_reads,
+    })
+
     self._filenames = filenames
     self._compression_type = compression_type
     self._buffer_size = buffer_size
@@ -427,6 +473,16 @@ class _FixedLengthRecordDataset(dataset_ops.DatasetSource):
       compression_type: (Optional.) A `tf.string` scalar evaluating to one of
         `""` (no compression), `"ZLIB"`, or `"GZIP"`.
     """
+
+    self._save_configuration({
+      "filenames": filenames,
+      "record_bytes": record_bytes,
+      "header_bytes": header_bytes or 0,
+      "footer_bytes": footer_bytes or 0,
+      "buffer_size": buffer_size or _DEFAULT_READER_BUFFER_SIZE_BYTES,
+      "compression_type": compression_type or "",
+    })
+
     self._filenames = filenames
     self._record_bytes = ops.convert_to_tensor(
         record_bytes, dtype=dtypes.int64, name="record_bytes")
@@ -486,6 +542,20 @@ class FixedLengthRecordDatasetV2(dataset_ops.DatasetSource):
         read sequentially.
     """
     filenames = _create_or_validate_filenames_dataset(filenames)
+
+    _num_parallel_reads = dataset_ops.parse_maybe_autotune_arg(
+        num_parallel_reads
+    )
+
+    self._save_configuration({
+      "filenames": filenames,
+      "record_bytes": record_bytes,
+      "header_bytes": header_bytes or 0,
+      "footer_bytes": footer_bytes or 0,
+      "buffer_size": buffer_size or _DEFAULT_READER_BUFFER_SIZE_BYTES,
+      "compression_type": compression_type or "",
+      "num_parallel_reads": _num_parallel_reads,
+    })
 
     self._filenames = filenames
     self._record_bytes = record_bytes

--- a/tensorflow/python/data/util/options.py
+++ b/tensorflow/python/data/util/options.py
@@ -34,6 +34,14 @@ class OptionsBase(object):
     # NOTE: Cannot use `self._options` here as we override `__setattr__`
     object.__setattr__(self, "_options", {})
 
+  def _serialize_configuration(self):
+    return {
+      name: getattr(self, name)
+      if not isinstance(getattr(self, name), OptionsBase) else
+      getattr(self, name)._serialize_configuration()
+      for name in set(self._options)
+    }
+
   def __eq__(self, other):
     if not isinstance(other, self.__class__):
       return NotImplemented


### PR DESCRIPTION
This PR introduces changes to TF Data and aims to generate automatically a full dump of the TF Data API on request for static analysis.

# Motivations

## PR Background
Data loading remains one of the major pain point for users and one the place where the average users have little (if any) idea on what they are doing right / wrong in terms of performance and what they could do to improve. Given the number of blog articles / youtube just on this topic by Google, I think it's fair to assume that we all understand how critical this topic is.

## Objective
Provide a simple way (controlled by an env var, and not by a python API call) to dump the configuration of the `tf.data` pipeline requested by the user for a later analysis (aka. sort of a static code analyizer)

This PR proposes to _plug_ in the tf.data python in a fully transparent way to the user with no performance cost. And serialize the complete pipeline to a json file at a location determined by an env var: `TF_DATASET_SERIALIZE_OUTPUT_DIR=/path/to/export/dir`

## Fine, but why would I want to serialize my tf data pipeline ?
Once the serialization is embedded in Tensorflow, we can follow different routes:
- Provide a Tensorboard plugin that consumes this json file and produce recommendations
- Provide a custom python package that would do the job in a CLI way
- Integrate with already existing DL profiling solution such as DLProf: https://docs.nvidia.com/deeplearning/frameworks/dlprof-user-guide/

## What can I recommendation shall I expect from this:

These are few examples, and are far from a finite list:
- Did the user requested prefetch of CPU ?
- Did the user requested prefetch on device (e.g. GPU) ?
- Did the user process the data in a parallel fashion or still rely on sequential reading ?
- Did the user use any non TF native ops such as `Data.from_generator()` or any `py_func()`
- Did the user exploited any fused operation available (e.g. shuffle and repeat, map and batch, etc.)
- Did the user read from raw data or from TF Records ?
- Did the user use a sufficient number of CPU threads or rely of `tf.data.experimental.AUTOTUNE` ?

## Is this proposal only benefiting GPU users ?
This proposal is fully agnostic to the device used as data-loading is critical for any kind of device the user might use.
Nonetheless, optimization recommendations could slightly vary from a device to device basis.

## To be noted
TF Data serialization can't be the one stop solution to maximize tf.data performance, *however*, making sure that user apply best practices in their data loading pipeline and from their fine tune the number of threads or other parameters sounds reasonable. IMHO, if every users would already be following all the "rules" cited above that would already be amazing.

# Important implementation points:

### Typical Node JSON fomat:
```json
"00": {
           "__class__": "ParallelInterleaveDataset",
            "block_length": 8,
            "calling_context": {
                "filename": "/path/to/my/project/utils/dataloading.py",
                "function": "get_dataset",
                "line_number": 81
            },
            "cycle_length": "AUTOTUNE",
            "map_func": "<function get_dataset.<locals>.fake_data_gen at 0x7fa6b826b488>",
            "num_parallel_calls": "AUTOTUNE",
            "output_dtype": "(tf.float32, tf.int32)",
            "output_shape": "((3, 256, 256), ())",
            "variant_tensor_inputs": "Tensor(\"TensorSliceDataset:0\", shape=(), dtype=variant)",
            "variant_tensor_outputs": "Tensor(\"ParallelInterleaveDatasetV2:0\", shape=(), dtype=variant)"
        }
```
### We want to see the following information:
- Trace what python calls (not the CPP OPs) the user requested with which arguments
     - tf.data.DatasetV2 subclass (see `__class__` above)
     - `__init__` arguments
     - optimizations applied: tf.data Options
- Track *where* in the python code did the user do X, Y and Z (see `calling_context` above)
- Track the output dtype, shape and tensors
- Be able to see on what device is the output tensor
- Some datapoint related to runtime environment:
   - number of CPU threads
   - version of tensorflow
   - Is the model using distributed training ? If yes with `tf.distributed` or `horovod`  ?
   - if installed, version of libraries that might have an impact on data loading (NVIDIA DALI, Horovod, etc.)


# Example Output:

```json
{
    "DISTRIBUTED_MODE": null,
    "HOROVOD_VERSION": "0.19.0",
    "NVIDIA_DALI_VERSION": "0.19.0",
    "TENSORFLOW_VERSION": "1.15.2",
    "TF_DATA_PIPELINE": {
        "00": {
            "__class__": "TensorSliceDataset",
            "calling_context": {
                "filename": "/path/to/my/project/utils/dataloading.py",
                "function": "get_dataset",
                "line_number": 74
            },
            "output_dtype": "tf.int32",
            "output_shape": "()",
            "variant_tensor_outputs": "Tensor(\"TensorSliceDataset:0\", shape=(), dtype=variant)"
        },
        "01": {
            "__class__": "ParallelInterleaveDataset",
            "block_length": 8,
            "calling_context": {
                "filename": "/path/to/my/project/utils/dataloading.py",
                "function": "get_dataset",
                "line_number": 81
            },
            "cycle_length": "AUTOTUNE",
            "map_func": "<function get_dataset.<locals>.fake_data_gen at 0x7fa6b826b488>",
            "num_parallel_calls": "AUTOTUNE",
            "output_dtype": "(tf.float32, tf.int32)",
            "output_shape": "((3, 256, 256), ())",
            "variant_tensor_inputs": "Tensor(\"TensorSliceDataset:0\", shape=(), dtype=variant)",
            "variant_tensor_outputs": "Tensor(\"ParallelInterleaveDatasetV2:0\", shape=(), dtype=variant)"
        },
        "02": {
            "__class__": "_ShuffleAndRepeatDataset",
            "buffer_size": 2048,
            "calling_context": {
                "filename": "/path/to/my/project/utils/dataloading.py",
                "function": "get_dataset",
                "line_number": 93
            },
            "count": null,
            "output_dtype": "(tf.float32, tf.int32)",
            "output_shape": "((3, 256, 256), ())",
            "seed": null,
            "variant_tensor_inputs": "Tensor(\"ParallelInterleaveDatasetV2:0\", shape=(), dtype=variant)",
            "variant_tensor_outputs": "Tensor(\"ShuffleAndRepeatDataset:0\", shape=(), dtype=variant)"
        },
        "03": {
            "__class__": "_MapAndBatchDataset",
            "batch_size": 256,
            "calling_context": {
                "filename": "/path/to/my/project/utils/dataloading.py",
                "function": "get_dataset",
                "line_number": 116
            },
            "drop_remainder": true,
            "map_func": "<function get_dataset.<locals>.data_mapping_fn at 0x7fa6a37750d0>",
            "num_parallel_calls": "AUTOTUNE",
            "output_dtype": "(tf.float32, tf.int32)",
            "output_shape": "((256, 3, 256, 256), (256,))",
            "use_legacy_function": false,
            "variant_tensor_inputs": "Tensor(\"ShuffleAndRepeatDataset:0\", shape=(), dtype=variant)",
            "variant_tensor_outputs": "Tensor(\"MapAndBatchDataset:0\", shape=(), dtype=variant)"
        },
        "04": {
            "__class__": "PrefetchDataset",
            "buffer_size": "AUTOTUNE",
            "calling_context": {
                "filename": "/path/to/my/project/utils/dataloading.py",
                "function": "get_dataset",
                "line_number": 124
            },
            "output_dtype": "(tf.float32, tf.int32)",
            "output_shape": "((256, 3, 256, 256), (256,))",
            "slack_period": null,
            "variant_tensor_inputs": "Tensor(\"MapAndBatchDataset:0\", shape=(), dtype=variant)",
            "variant_tensor_outputs": "Tensor(\"PrefetchDataset:0\", shape=(), dtype=variant)"
        },
        "05": {
            "__class__": "_OptionsDataset",
            "calling_context": {
                "filename": "/path/to/my/project/utils/dataloading.py",
                "function": "get_dataset",
                "line_number": 157
            },
            "options": {
                "experimental_deterministic": false,
                "experimental_distribute": {
                    "auto_shard": true,
                    "num_devices": null
                },
                "experimental_optimization": {
                    "apply_default_optimizations": false,
                    "autotune": true,
                    "autotune_algorithm": null,
                    "autotune_buffers": true,
                    "autotune_cpu_budget": 20,
                    "filter_fusion": true,
                    "filter_with_random_uniform_fusion": null,
                    "hoist_random_uniform": true,
                    "map_and_batch_fusion": true,
                    "map_and_filter_fusion": true,
                    "map_fusion": true,
                    "map_parallelization": true,
                    "map_vectorization": {
                        "enabled": true,
                        "use_choose_fastest": true
                    },
                    "noop_elimination": true,
                    "parallel_batch": true,
                    "prefetch_to_device": "/gpu:0",
                    "prefetch_to_device_buffer": 2,
                    "shuffle_and_repeat_fusion": true
                },
                "experimental_slack": false,
                "experimental_stateful_whitelist": null,
                "experimental_stats": {
                    "aggregator": null,
                    "counter_prefix": "",
                    "latency_all_edges": null,
                    "prefix": ""
                },
                "experimental_threading": {
                    "max_intra_op_parallelism": 20,
                    "private_threadpool_size": 20
                }
            },
            "output_dtype": "(tf.float32, tf.int32)",
            "output_shape": "((256, 3, 256, 256), (256,))",
            "variant_tensor_inputs": "Tensor(\"PrefetchDataset:0\", shape=(), dtype=variant)",
            "variant_tensor_outputs": "Tensor(\"PrefetchDataset:0\", shape=(), dtype=variant)"
        },
        "06": {
            "__class__": "_MaxIntraOpParallelismDataset",
            "calling_context": {
                "filename": "/usr/local/lib/python3.6/dist-packages/tensorflow_core/python/data/ops/dataset_ops.py",
                "function": "_apply_options",
                "line_number": 527
            },
            "max_intra_op_parallelism": 20,
            "output_dtype": "(tf.float32, tf.int32)",
            "output_shape": "((256, 3, 256, 256), (256,))",
            "variant_tensor_inputs": "Tensor(\"PrefetchDataset:0\", shape=(), dtype=variant)",
            "variant_tensor_outputs": "Tensor(\"MaxIntraOpParallelismDataset:0\", shape=(), dtype=variant)"
        },
        "07": {
            "__class__": "_PrivateThreadPoolDataset",
            "calling_context": {
                "filename": "/usr/local/lib/python3.6/dist-packages/tensorflow_core/python/data/ops/dataset_ops.py",
                "function": "_apply_options",
                "line_number": 530
            },
            "num_threads": 20,
            "output_dtype": "(tf.float32, tf.int32)",
            "output_shape": "((256, 3, 256, 256), (256,))",
            "variant_tensor_inputs": "Tensor(\"MaxIntraOpParallelismDataset:0\", shape=(), dtype=variant)",
            "variant_tensor_outputs": "Tensor(\"PrivateThreadPoolDataset:0\", shape=(), dtype=variant)"
        },
        "08": {
            "__class__": "_OptimizeDataset",
            "calling_context": {
                "filename": "/usr/local/lib/python3.6/dist-packages/tensorflow_core/python/data/ops/dataset_ops.py",
                "function": "_apply_options",
                "line_number": 545
            },
            "optimization_configs": [
                "map_vectorization:use_choose_fastest:true"
            ],
            "optimizations": [
                "filter_fusion",
                "hoist_random_uniform",
                "inject_prefetch",
                "map_and_batch_fusion",
                "map_and_filter_fusion",
                "map_fusion",
                "map_parallelization",
                "map_vectorization",
                "noop_elimination",
                "parallel_batch",
                "shuffle_and_repeat_fusion",
                "make_sloppy"
            ],
            "output_dtype": "(tf.float32, tf.int32)",
            "output_shape": "((256, 3, 256, 256), (256,))",
            "variant_tensor_inputs": "Tensor(\"PrivateThreadPoolDataset:0\", shape=(), dtype=variant)",
            "variant_tensor_outputs": "Tensor(\"OptimizeDataset:0\", shape=(), dtype=variant)"
        },
        "09": {
            "__class__": "_ModelDataset",
            "autotune_algorithm": "HILL_CLIMB",
            "calling_context": {
                "filename": "/usr/local/lib/python3.6/dist-packages/tensorflow_core/python/data/ops/dataset_ops.py",
                "function": "_apply_options",
                "line_number": 559
            },
            "cpu_budget": 20,
            "output_dtype": "(tf.float32, tf.int32)",
            "output_shape": "((256, 3, 256, 256), (256,))",
            "variant_tensor_inputs": "Tensor(\"OptimizeDataset:0\", shape=(), dtype=variant)",
            "variant_tensor_outputs": "Tensor(\"ModelDataset:0\", shape=(), dtype=variant)"
        },
        "options": {
            "experimental_deterministic": false,
            "experimental_distribute": {},
            "experimental_optimization": {
                "apply_default_optimizations": false,
                "autotune": true,
                "autotune_algorithm": null,
                "autotune_buffers": true,
                "autotune_cpu_budget": 20,
                "filter_fusion": true,
                "filter_with_random_uniform_fusion": null,
                "hoist_random_uniform": true,
                "map_and_batch_fusion": true,
                "map_and_filter_fusion": true,
                "map_fusion": true,
                "map_parallelization": true,
                "map_vectorization": {
                    "enabled": true,
                    "use_choose_fastest": true
                },
                "noop_elimination": true,
                "parallel_batch": true,
                "prefetch_to_device": "/gpu:0",
                "prefetch_to_device_buffer": 2,
                "shuffle_and_repeat_fusion": true
            },
            "experimental_slack": false,
            "experimental_stateful_whitelist": null,
            "experimental_stats": {},
            "experimental_threading": {
                "max_intra_op_parallelism": 20,
                "private_threadpool_size": 20
            }
        }
    },
    "TOTAL_CPU_THREADS": 20
}
```