### PR TITLE
[ROCm] Fix for broken ROCm CSB - 200311

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -68,6 +68,7 @@ load(
     "cc_header_only_library",
     "if_android",
     "if_chromiumos",
+    "if_cuda_or_rocm",
     "if_ios",
     "if_mobile",
     "if_not_windows",
@@ -1097,8 +1098,9 @@ cc_library(
         "//tensorflow/core/kernels:mkl_matmul_op",
         "//tensorflow/core/kernels:mkl_tfconv_op",
         "//tensorflow/core/kernels:mkl_tmp_bf16_ops",
-    ]) + if_cuda([
+    ]) + if_cuda_or_rocm([
         "//tensorflow/core/kernels:cudnn_rnn_kernels",
+    ]) + if_cuda([
         "//tensorflow/core/grappler/optimizers:gpu_swapping_kernels",
         "//tensorflow/core/grappler/optimizers:gpu_swapping_ops",
     ]) + if_nccl([


### PR DESCRIPTION
This commit fixes regressions introduced in the ROCm CSB by th following commit :

https://github.com/tensorflow/tensorflow/commit/df00d7ebbfb1ac799d1f98dd724fce10cb84329e

The above commit classifies puts "cudnn_rnn_kernels" under "if_cuda" in the tensorflow/core/BUILD file. That target is mis-named (should really be gpu_rnn_kernels) and is required by ROCm too. This commit simply changes the condition from "if_cuda" to "if_cuda_or_rocm"

--------------------------

/cc @whchung @chsigg @nvining-work 
