### PR TITLE
Remove unused private attributes from TensorBoard callback

### DIFF
--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -1719,10 +1719,6 @@ class TensorBoard(Callback):
     self.embeddings_freq = embeddings_freq
     self.embeddings_metadata = embeddings_metadata
 
-    self._samples_seen = 0
-    self._samples_seen_at_last_write = 0
-    self._current_batch = 0
-
     # A collection of file writers currently in use, to be closed when
     # training ends for this callback. Writers are keyed by the
     # directory name under the root logdir: e.g., "train" or


### PR DESCRIPTION
`self._samples_seen`, `self._samples_seen_at_last_write` and `self._current_batch` were used in version 1 of the TensorBoard callback, but are not necessary anymore.
This PR removes them.