### PR TITLE
Add `--define=no_tensorflow_py_deps=true` to all `bazel build ...:bui…

### DIFF
--- a/tensorflow/tools/ci_build/builds/pip_new.sh
+++ b/tensorflow/tools/ci_build/builds/pip_new.sh
@@ -309,7 +309,8 @@ bazel clean
 # Clean up and update bazel flags
 update_bazel_flags
 # Build. This outputs the file `build_pip_package`.
-bazel build ${TF_BUILD_FLAGS} ${PIP_BUILD_TARGET} || \
+bazel build --define=no_tensorflow_py_deps=true \
+  ${TF_BUILD_FLAGS} ${PIP_BUILD_TARGET} || \
   die "Error: Bazel build failed for target: '${PIP_BUILD_TARGET}'"
 
 ###########################################################################

--- a/tensorflow/tools/ci_build/release/macos/cpu_py35_full/release.sh
+++ b/tensorflow/tools/ci_build/release/macos/cpu_py35_full/release.sh
@@ -32,7 +32,7 @@ export PYTHON_BIN_PATH=$(which python3.5)
 yes "" | "$PYTHON_BIN_PATH" configure.py
 
 # Build the pip package
-bazel build --config=opt tensorflow/tools/pip_package:build_pip_package
+bazel build --config=opt --define=no_tensorflow_py_deps tensorflow/tools/pip_package:build_pip_package
 mkdir pip_pkg
 ./bazel-bin/tensorflow/tools/pip_package/build_pip_package pip_pkg --nightly_flag
 

--- a/tensorflow/tools/ci_build/release/macos/cpu_py37_full/release.sh
+++ b/tensorflow/tools/ci_build/release/macos/cpu_py37_full/release.sh
@@ -31,7 +31,7 @@ export PYTHON_BIN_PATH=$(which python3.7)
 yes "" | "$PYTHON_BIN_PATH" configure.py
 
 # Build the pip package
-bazel build --config=opt tensorflow/tools/pip_package:build_pip_package
+bazel build --config=opt --define=no_tensorflow_py_deps tensorflow/tools/pip_package:build_pip_package
 mkdir pip_pkg
 ./bazel-bin/tensorflow/tools/pip_package/build_pip_package pip_pkg
 

--- a/tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows.sh
+++ b/tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows.sh
@@ -140,7 +140,8 @@ bazel build --announce_rc --config=opt ${EXTRA_BUILD_FLAGS}  \
   --output_filter=^$ \
   tensorflow/lite:framework tensorflow/lite/examples/minimal:minimal || exit $?
 
-bazel build -s --announce_rc --config=opt ${EXTRA_BUILD_FLAGS} \
+bazel build --announce_rc --config=opt ${EXTRA_BUILD_FLAGS} \
+  --define=no_tensorflow_py_deps=true \
   --output_filter=^$ \
   tensorflow/tools/pip_package:build_pip_package || exit $?
 

--- a/tensorflow/tools/ci_build/windows/gpu/pip/build_tf_windows.sh
+++ b/tensorflow/tools/ci_build/windows/gpu/pip/build_tf_windows.sh
@@ -139,6 +139,7 @@ fi
 run_configure_for_gpu_build
 
 bazel build --announce_rc --config=opt --define=no_tensorflow_py_deps=true \
+  --define=no_tensorflow_py_deps=true \
   --output_filter=^$ \
   ${EXTRA_BUILD_FLAGS} \
   tensorflow/tools/pip_package:build_pip_package || exit $?


### PR DESCRIPTION
…ld_pip_package` statements to trim size of pips