### PR TITLE
[r2.2:Cherrypick][TF XLA AOT PIP] Fix windows build by properly including the env_time from platform/windows/.

### DIFF
--- a/tensorflow/compiler/tf2xla/BUILD
+++ b/tensorflow/compiler/tf2xla/BUILD
@@ -237,11 +237,11 @@ cc_library(
     features = ["fully_static_link"],
     linkstatic = 1,
     visibility = [":friends"],
-    # Note, we specifically remove MKL dependencies so the standalone does
-    # not require the MKL binary blob.
+    # Note, we specifically removed MKL and multithreaded dependencies so the
+    # standalone does not require the MKL binary blob or threading libraries.
     #
-    # TODO(ebrevdo): Remove tf_additoinal_tensor_coding_deps in favor of absl/strings:cord when
-    # we update absl to a newer version.
+    # TODO(ebrevdo): Remove tf_additoinal_tensor_coding_deps in favor of
+    # absl/strings:cord when we update absl to a newer version.
     deps = [
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/base:core_headers",

--- a/tensorflow/core/platform/BUILD
+++ b/tensorflow/core/platform/BUILD
@@ -39,6 +39,7 @@ load(
     "//tensorflow:tensorflow.bzl",
     "if_chromiumos",
     "if_not_android",
+    "if_windows",
     "tf_cc_test",
     "tf_cc_tests",
     "tf_copts",  # @unused
@@ -347,7 +348,9 @@ filegroup(
         "platform.h",
         "tstring.h",
         "types.h",
-    ],
+    ] + if_windows([
+        "//tensorflow/core/platform/windows:xla_cpu_runtime_srcs",
+    ]),
 )
 
 cc_library(

--- a/tensorflow/core/platform/default/BUILD
+++ b/tensorflow/core/platform/default/BUILD
@@ -1,6 +1,6 @@
 # Tensorflow default + linux implementations of tensorflow/core/platform libraries.
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("//tensorflow:tensorflow.bzl", "tf_copts")
+load("//tensorflow:tensorflow.bzl", "if_not_windows", "tf_copts")
 load(
     "//tensorflow/core/platform:rules_cc.bzl",
     "cc_library",
@@ -198,9 +198,8 @@ filegroup(
     srcs = [
         "cord.h",
         "dynamic_annotations.h",
-        "env_time.cc",
         "integral_types.h",
-    ],
+    ] + if_not_windows(["env_time.cc"]),
 )
 
 cc_library(

--- a/tensorflow/core/platform/windows/BUILD
+++ b/tensorflow/core/platform/windows/BUILD
@@ -236,6 +236,11 @@ cc_library(
     ],
 )
 
+filegroup(
+    name = "xla_cpu_runtime_srcs",
+    srcs = ["env_time.cc"],
+)
+
 exports_files(
     srcs = ["intrinsics_port.h"],
     visibility = ["//tensorflow/core/platform:__pkg__"],


### PR DESCRIPTION
PiperOrigin-RevId: 300186790
Change-Id: Iba5021aed9ed8679486ca78c7ce5089270592176