### PR TITLE
tf.image.decode_image to tf.io.decode_image

### DIFF
--- a/tensorflow/lite/g3doc/models/style_transfer/overview.ipynb
+++ b/tensorflow/lite/g3doc/models/style_transfer/overview.ipynb
@@ -250,7 +250,7 @@
         "# Function to load an image from a file, and add a batch dimension.\n",
         "def load_img(path_to_img):\n",
         "  img = tf.io.read_file(path_to_img)\n",
-        "  img = tf.image.decode_image(img, channels=3)\n",
+        "  img = tf.io.decode_image(img, channels=3)\n",
         "  img = tf.image.convert_image_dtype(img, tf.float32)\n",
         "  img = img[tf.newaxis, :]\n",
         "\n",


### PR DESCRIPTION
tf.image.decode_image to tf.io.decode_image for API migration and consistency.