### PR TITLE
change tf.image.decode_image to tf.io.decode_image

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_DecodeGif.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_DecodeGif.pbtxt
@@ -21,6 +21,6 @@ uncompressed by running:
     convert $src.gif -coalesce $dst.gif
 
 This op also supports decoding JPEGs and PNGs, though it is cleaner to use
-`tf.image.decode_image`.
+`tf.io.decode_image`.
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_DecodeJpeg.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_DecodeJpeg.pbtxt
@@ -75,6 +75,6 @@ downscaling the image later.
 
 
 This op also supports decoding PNGs and non-animated GIFs since the interface is
-the same, though it is cleaner to use `tf.image.decode_image`.
+the same, though it is cleaner to use `tf.io.decode_image`.
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_DecodePng.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_DecodePng.pbtxt
@@ -34,6 +34,6 @@ If needed, the PNG-encoded image is transformed to match the requested number
 of color channels.
 
 This op also supports decoding JPEGs and non-animated GIFs since the interface
-is the same, though it is cleaner to use `tf.image.decode_image`.
+is the same, though it is cleaner to use `tf.io.decode_image`.
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_SparseMatrixOrderingAMD.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_SparseMatrixOrderingAMD.pbtxt
@@ -45,7 +45,7 @@ Usage example:
 
     with tf.Session() as sess:
       # Define (COO format) SparseTensor over Numpy array.
-      a_st = tf.SparseTensor(a_indices, a_values, a_dense_shape)
+      a_st = tf.sparse.SparseTensor(a_indices, a_values, a_dense_shape)
 
       # Convert SparseTensors to CSR SparseMatrix.
       a_sm = sparse_csr_matrix_ops.sparse_tensor_to_csr_sparse_matrix(

--- a/tensorflow/core/api_def/base_api/api_def_SparseMatrixSparseCholesky.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_SparseMatrixSparseCholesky.pbtxt
@@ -58,7 +58,7 @@ Usage example:
 
     with tf.Session() as sess:
       # Define (COO format) SparseTensor over Numpy array.
-      a_st = tf.SparseTensor(a_indices, a_values, a_dense_shape)
+      a_st = tf.sparse.SparseTensor(a_indices, a_values, a_dense_shape)
 
       # Convert SparseTensors to CSR SparseMatrix.
       a_sm = sparse_csr_matrix_ops.sparse_tensor_to_csr_sparse_matrix(

--- a/tensorflow/core/api_def/base_api/api_def_SparseMatrixSparseMatMul.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_SparseMatrixSparseMatMul.pbtxt
@@ -71,8 +71,8 @@ Usage example:
 
     with tf.Session() as sess:
       # Define (COO format) Sparse Tensors over Numpy arrays
-      a_st = tf.SparseTensor(a_indices, a_values, a_dense_shape)
-      b_st = tf.SparseTensor(b_indices, b_values, b_dense_shape)
+      a_st = tf.sparse.SparseTensor(a_indices, a_values, a_dense_shape)
+      b_st = tf.sparse.SparseTensor(b_indices, b_values, b_dense_shape)
 
       # Convert SparseTensors to CSR SparseMatrix
       a_sm = sparse_csr_matrix_ops.sparse_tensor_to_csr_sparse_matrix(

--- a/tensorflow/core/kernels/decode_image_op.cc
+++ b/tensorflow/core/kernels/decode_image_op.cc
@@ -317,8 +317,8 @@ class DecodeImageOp : public OpKernel {
                       } else {
                         status = errors::InvalidArgument(
                             "Got ", num_frames, " frames, but animated gifs ",
-                            "can only be decoded by tf.image.decode_gif or ",
-                            "tf.image.decode_image");
+                            "can only be decoded by tf.io.decode_gif or ",
+                            "tf.io.decode_image");
                       }
                       if (!status.ok()) {
                         VLOG(1) << status;

--- a/tensorflow/examples/label_image/label_image.py
+++ b/tensorflow/examples/label_image/label_image.py
@@ -44,15 +44,15 @@ def read_tensor_from_image_file(file_name,
   output_name = "normalized"
   file_reader = tf.read_file(file_name, input_name)
   if file_name.endswith(".png"):
-    image_reader = tf.image.decode_png(
+    image_reader = tf.io.decode_png(
         file_reader, channels=3, name="png_reader")
   elif file_name.endswith(".gif"):
     image_reader = tf.squeeze(
-        tf.image.decode_gif(file_reader, name="gif_reader"))
+        tf.io.decode_gif(file_reader, name="gif_reader"))
   elif file_name.endswith(".bmp"):
-    image_reader = tf.image.decode_bmp(file_reader, name="bmp_reader")
+    image_reader = tf.io.decode_bmp(file_reader, name="bmp_reader")
   else:
-    image_reader = tf.image.decode_jpeg(
+    image_reader = tf.io.decode_jpeg(
         file_reader, channels=3, name="jpeg_reader")
   float_caster = tf.cast(image_reader, tf.float32)
   dims_expander = tf.expand_dims(float_caster, 0)

--- a/tensorflow/examples/saved_model/integration_tests/export_simple_text_embedding.py
+++ b/tensorflow/examples/saved_model/integration_tests/export_simple_text_embedding.py
@@ -87,7 +87,7 @@ class TextEmbeddingModel(tf.train.Checkpoint):
 
     return tf.nn.safe_embedding_lookup_sparse(
         embedding_weights=self.embeddings,
-        sparse_ids=tf.SparseTensor(token_ids, token_values, token_dense_shape),
+        sparse_ids=tf.sparse.SparseTensor(token_ids, token_values, token_dense_shape),
         sparse_weights=None,
         combiner="sqrtn")
 

--- a/tensorflow/lite/g3doc/models/style_transfer/overview.ipynb
+++ b/tensorflow/lite/g3doc/models/style_transfer/overview.ipynb
@@ -240,7 +240,7 @@
         "# Function to load an image from a file, and add a batch dimension.\n",
         "def load_img(path_to_img):\n",
         "  img = tf.io.read_file(path_to_img)\n",
-        "  img = tf.image.decode_image(img, channels=3)\n",
+        "  img = tf.io.decode_image(img, channels=3)\n",
         "  img = tf.image.convert_image_dtype(img, tf.float32)\n",
         "  img = img[tf.newaxis, :]\n",
         "\n",

--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -605,7 +605,7 @@ class Tensor(_TensorLike):
 
     ```python
     _, image_data = tf.compat.v1.TFRecordReader(...).read(...)
-    image = tf.image.decode_png(image_data, channels=3)
+    image = tf.io.decode_png(image_data, channels=3)
 
     # The height and width dimensions of `image` are data dependent, and
     # cannot be computed without executing the op.


### PR DESCRIPTION
tf.image.decode_image to tf.io.decode_image for API migration and consistency which include decode_ jpeg, decode_gif, and decode_png.
Please see https://www.tensorflow.org/api_docs/python/tf/io/decode_image