### PR TITLE
Fixes to `Wrapper.get_config` and `Wrapper.from_config`.

### DIFF
--- a/tensorflow/python/keras/layers/wrappers.py
+++ b/tensorflow/python/keras/layers/wrappers.py
@@ -68,10 +68,7 @@ class Wrapper(Layer):
 
   def get_config(self):
     config = {
-        'layer': {
-            'class_name': self.layer.__class__.__name__,
-            'config': self.layer.get_config()
-        }
+        'layer': generic_utils.serialize_keras_object(self.layer)
     }
     base_config = super(Wrapper, self).get_config()
     return dict(list(base_config.items()) + list(config.items()))
@@ -80,7 +77,7 @@ class Wrapper(Layer):
   def from_config(cls, config, custom_objects=None):
     from tensorflow.python.keras.layers import deserialize as deserialize_layer  # pylint: disable=g-import-not-at-top
     # Avoid mutating the input dict
-    config = config.copy()
+    config = copy.deepcopy(config)
     layer = deserialize_layer(
         config.pop('layer'), custom_objects=custom_objects)
     return cls(layer, **config)


### PR DESCRIPTION
This PR aims at solving two light issues I identified with the `tf.keras.layers.Wrapper` class.

This has been tested on both TensorFlow 2.1.0 and 2.2.0-rc0 for Python 3.6.9, both installed using `pip` on a Linux 64-bits system.

#### 1. Serialization through `get_config`.

**Issue**: The dict output by `Wrapper.get_config()` is designed to contain the config of the wrapped layer, in a format similar to that output by keras serialization utilities. However, the identifier of that layer (its `class_name`) is currently manually gathered within the `get_config`, which results in bugs such as  custom layers set for registration (using `tf.keras.utils.register_keras_serializable`) not being given their proper identifier.

**Fix**: I propose to replace the manual creation of the `layer` entry within the returned configuration by a direct call to `serialize_keras_object`.

**Minimal example**:
```python
import tensorflow as tf

@tf.keras.utils.register_keras_serializable(package='test')
class CustomLayer(tf.keras.layers.Layer):
    def call(self, inputs):
        return inputs

wrapper = tf.keras.layers.Wrapper(CustomLayer())
config = wrapper.get_config()
tf.keras.layers.Wrapper.from_config(config)
```
When run before the fix, this fails on the last line, raising `ValueError: Unknown layer: CustomLayer`.
When run after the fix, this runs successfully.

#### 2. Instantiation through `from_config`.

**Issue**: Contrary to what the source code suggests, `Wrapper.from_config` has side effects on the provided config dictionary; in short, it pops out its `layer` sub-dict.

**Fix**: Instead of calling `config.copy()`, I suggest using `copy.deepcopy(config)` before popping out the `layer` sub-dict of the (deep copy of the) input config dictionary.

**Minimal example**:
```python
import tensorflow as tf

dense = tf.keras.layers.Dense(32)
wrapper = tf.keras.layers.Wrapper(dense)
config = wrapper.get_config()
assert 'layer' in config, 'before wrapper instantiation'
tf.keras.layers.Wrapper.from_config(config)
assert 'layer' in config, 'after wrapper instantiation'
```
When run before the fix, the second assertion fails due to the side effect.
When run after the fix, this runs successfully.