### PR TITLE
Fixing issue with EarlyStopping not working after CustomCallback

### DIFF
--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -117,7 +117,9 @@ def configure_callbacks(callbacks,
       verbose=verbose,
       mode=mode)
 
-  callback_list.model.stop_training = False
+  if not hasattr(callback_list.model, 'stop_training'):
+    callback_list.model.stop_training = False
+
   return callback_list
 
 

--- a/tensorflow/python/keras/engine/training_v2.py
+++ b/tensorflow/python/keras/engine/training_v2.py
@@ -741,7 +741,8 @@ class TrainingContext(object):
         model, 'samples' if use_samples else 'steps')
     progbar.params = callbacks.params
     progbar.params['verbose'] = verbose
-    callbacks.model.stop_training = False
+    if not hasattr(callbacks.model, 'stop_training'):
+      callbacks.model.stop_training = False
     callbacks._call_begin_hook(mode)
     progbar.on_train_begin()
 


### PR DESCRIPTION
When a CustomCallback uses internally model.predict or model.evaluate as part of on_epoch_end, for instance, to track a custom evaluation on an test dataset, model.stop_training is reset to False even if it was previously set to True by Early Stopping. And then the training does not stop. Current workaround is putting EarlyStopping as the last callback of the list.

Check this colab with the full example: https://colab.research.google.com/drive/1lw943Ggwkp_wvGxVX-5XqaEJ5qXmrHlA

This patch fixes this by checking first if stop_training exists, and only if it doesn't, it initializes it to False. 
Fixes #37587