### PR TITLE
exit bashrc if not running interactively

### DIFF
--- a/tensorflow/tools/dockerfiles/bashrc
+++ b/tensorflow/tools/dockerfiles/bashrc
@@ -14,6 +14,9 @@
 #
 # ==============================================================================
 
+# If not running interactively, don't do anything
+[ -z "$PS1" ] && return
+
 export PS1="\[\e[31m\]tf-docker\[\e[m\] \[\e[33m\]\w\[\e[m\] > "
 export TERM=xterm-256color
 alias grep="grep --color=auto"


### PR DESCRIPTION
Addresses issue #30495; enables sftp access to container. The added line of code is already present in the `~/.bashrc` upon building the docker container. However, the `/etc/bash.bashrc` file does not contain this, and thus does not currently allow sftp access.