### PR TITLE
Added several 'see also' references in Python API documentation

### DIFF
--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -199,6 +199,8 @@ def reshape(tensor, shape, name=None):  # pylint: disable=redefined-outer-name
 def fill(dims, value, name=None):
   r"""Creates a tensor filled with a scalar value.
 
+  See also `tf.ones`, `tf.zeroes`, `tf.one_hot`, `tf.eye`
+
   This operation creates a tensor of shape `dims` and fills it with `value`.
 
   For example:
@@ -2692,6 +2694,8 @@ def _tag_zeros_tensor(fun):
 def zeros(shape, dtype=dtypes.float32, name=None):
   """Creates a tensor with all elements set to zero.
 
+  See also `tf.zeros_like`, `tf.ones`, `tf.fill`, `tf.eye`
+
   This operation returns a tensor of type `dtype` with shape `shape` and
   all elements set to zero.
 
@@ -2941,7 +2945,7 @@ def ones_like_impl(tensor, dtype, name, optimize=True):
 def ones(shape, dtype=dtypes.float32, name=None):
   """Creates a tensor with all elements set to one (1).
 
-  See also `tf.ones_like`.
+  See also `tf.ones_like`, `tf.zeroes`, `tf.fill`, `tf.eye`.
 
   This operation returns a tensor of type `dtype` with shape `shape` and
   all elements set to one.
@@ -3865,6 +3869,8 @@ def one_hot(indices,
             dtype=None,
             name=None):
   """Returns a one-hot tensor.
+
+  See also `tf.fill`, `tf.eye`
 
   The locations represented by indices in `indices` take value `on_value`,
   while all other locations take value `off_value`.

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -1802,6 +1802,8 @@ def sparse_mask(a, mask_indices, name=None):
 def unique(x, out_idx=dtypes.int32, name=None):
   """Finds unique elements in a 1-D tensor.
 
+  See also `tf.unique_with_counts`
+
   This operation returns a tensor `y` containing all of the unique elements
   of `x` sorted in the same order that they occur in `x`. This operation
   also returns a tensor `idx` the same size as `x` that contains the index
@@ -1846,6 +1848,8 @@ unique.__doc__ = gen_array_ops.unique.__doc__
 @tf_export("unique_with_counts")
 def unique_with_counts(x, out_idx=dtypes.int32, name=None):
   """Finds unique elements in a 1-D tensor.
+
+  See also `tf.unique`
 
   This operation returns a tensor `y` containing all of the unique elements
   of `x` sorted in the same order that they occur in `x`. This operation

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -199,7 +199,7 @@ def reshape(tensor, shape, name=None):  # pylint: disable=redefined-outer-name
 def fill(dims, value, name=None):
   r"""Creates a tensor filled with a scalar value.
 
-  See also `tf.ones`, `tf.zeros`, `tf.one_hot`, `tf.eye`
+  See also `tf.ones`, `tf.zeros`, `tf.one_hot`, `tf.eye`.
 
   This operation creates a tensor of shape `dims` and fills it with `value`.
 
@@ -761,7 +761,7 @@ def rank(input, name=None):
   # pylint: disable=redefined-builtin
   """Returns the rank of a tensor.
 
-  See also `tf.shape`
+  See also `tf.shape`.
 
   Returns a 0-D `int32` `Tensor` representing the rank of `input`.
 
@@ -994,7 +994,7 @@ def slice(input_, begin, size, name=None):
   # pylint: disable=redefined-builtin
   """Extracts a slice from a tensor.
 
-  See also `tf.strided_slice`
+  See also `tf.strided_slice`.
 
   This operation extracts a slice of size `size` from a tensor `input_` starting
   at the location specified by `begin`. The slice `size` is represented as a
@@ -1058,7 +1058,7 @@ def strided_slice(input_,
                   name=None):
   """Extracts a strided slice of a tensor (generalized python array indexing).
 
-  See also `tf.slice`
+  See also `tf.slice`.
 
   **Instead of calling this op directly most users will want to use the
   NumPy-style slicing syntax (e.g. `tensor[..., 3:4:-1, tf.newaxis, 3]`), which
@@ -1802,7 +1802,7 @@ def sparse_mask(a, mask_indices, name=None):
 def unique(x, out_idx=dtypes.int32, name=None):
   """Finds unique elements in a 1-D tensor.
 
-  See also `tf.unique_with_counts`
+  See also `tf.unique_with_counts`.
 
   This operation returns a tensor `y` containing all of the unique elements
   of `x` sorted in the same order that they occur in `x`. This operation
@@ -1849,7 +1849,7 @@ unique.__doc__ = gen_array_ops.unique.__doc__
 def unique_with_counts(x, out_idx=dtypes.int32, name=None):
   """Finds unique elements in a 1-D tensor.
 
-  See also `tf.unique`
+  See also `tf.unique`.
 
   This operation returns a tensor `y` containing all of the unique elements
   of `x` sorted in the same order that they occur in `x`. This operation
@@ -2698,7 +2698,7 @@ def _tag_zeros_tensor(fun):
 def zeros(shape, dtype=dtypes.float32, name=None):
   """Creates a tensor with all elements set to zero.
 
-  See also `tf.zeros_like`, `tf.ones`, `tf.fill`, `tf.eye`
+  See also `tf.zeros_like`, `tf.ones`, `tf.fill`, `tf.eye`.
 
   This operation returns a tensor of type `dtype` with shape `shape` and
   all elements set to zero.
@@ -3874,7 +3874,7 @@ def one_hot(indices,
             name=None):
   """Returns a one-hot tensor.
 
-  See also `tf.fill`, `tf.eye`
+  See also `tf.fill`, `tf.eye`.
 
   The locations represented by indices in `indices` take value `on_value`,
   while all other locations take value `off_value`.

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -990,6 +990,8 @@ def slice(input_, begin, size, name=None):
   # pylint: disable=redefined-builtin
   """Extracts a slice from a tensor.
 
+  See also `tf.strided_slice`
+
   This operation extracts a slice of size `size` from a tensor `input_` starting
   at the location specified by `begin`. The slice `size` is represented as a
   tensor shape, where `size[i]` is the number of elements of the 'i'th dimension
@@ -1051,6 +1053,8 @@ def strided_slice(input_,
                   var=None,
                   name=None):
   """Extracts a strided slice of a tensor (generalized python array indexing).
+
+  See also `tf.slice`
 
   **Instead of calling this op directly most users will want to use the
   NumPy-style slicing syntax (e.g. `tensor[..., 3:4:-1, tf.newaxis, 3]`), which

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -199,7 +199,7 @@ def reshape(tensor, shape, name=None):  # pylint: disable=redefined-outer-name
 def fill(dims, value, name=None):
   r"""Creates a tensor filled with a scalar value.
 
-  See also `tf.ones`, `tf.zeroes`, `tf.one_hot`, `tf.eye`
+  See also `tf.ones`, `tf.zeros`, `tf.one_hot`, `tf.eye`
 
   This operation creates a tensor of shape `dims` and fills it with `value`.
 
@@ -2945,7 +2945,7 @@ def ones_like_impl(tensor, dtype, name, optimize=True):
 def ones(shape, dtype=dtypes.float32, name=None):
   """Creates a tensor with all elements set to one (1).
 
-  See also `tf.ones_like`, `tf.zeroes`, `tf.fill`, `tf.eye`.
+  See also `tf.ones_like`, `tf.zeros`, `tf.fill`, `tf.eye`.
 
   This operation returns a tensor of type `dtype` with shape `shape` and
   all elements set to one.

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -535,7 +535,7 @@ def shape_v2(input, out_type=dtypes.int32, name=None):
   # pylint: disable=redefined-builtin
   """Returns the shape of a tensor.
   
-  See also `tf.size`.
+  See also `tf.size`, `tf.rank`.
 
   This operation returns a 1-D integer tensor representing the shape of `input`.
   This represents the minimal set of known information at definition time.
@@ -758,6 +758,8 @@ def size_internal(input, name=None, optimize=True, out_type=dtypes.int32):
 def rank(input, name=None):
   # pylint: disable=redefined-builtin
   """Returns the rank of a tensor.
+
+  See also `tf.shape`
 
   Returns a 0-D `int32` `Tensor` representing the rank of `input`.
 

--- a/tensorflow/python/ops/functional_ops.py
+++ b/tensorflow/python/ops/functional_ops.py
@@ -443,7 +443,7 @@ def scan(fn,
          name=None):
   """scan on the list of tensors unpacked from `elems` on dimension 0.
 
-  See also `tf.map_fn`
+  See also `tf.map_fn`.
 
   The simplest version of `scan` repeatedly applies the callable `fn` to a
   sequence of elements from first to last. The elements are made of the tensors

--- a/tensorflow/python/ops/functional_ops.py
+++ b/tensorflow/python/ops/functional_ops.py
@@ -443,6 +443,8 @@ def scan(fn,
          name=None):
   """scan on the list of tensors unpacked from `elems` on dimension 0.
 
+  See also `tf.map_fn`
+
   The simplest version of `scan` repeatedly applies the callable `fn` to a
   sequence of elements from first to last. The elements are made of the tensors
   unpacked from `elems` on dimension 0. The callable fn takes two tensors as

--- a/tensorflow/python/ops/linalg_ops.py
+++ b/tensorflow/python/ops/linalg_ops.py
@@ -194,7 +194,7 @@ def eye(num_rows,
         name=None):
   """Construct an identity matrix, or a batch of matrices.
 
-  See also `tf.ones`, `tf.zeros`, `tf.fill`, `tf.one_hot`
+  See also `tf.ones`, `tf.zeros`, `tf.fill`, `tf.one_hot`.
 
   ```python
   # Construct one identity matrix.

--- a/tensorflow/python/ops/linalg_ops.py
+++ b/tensorflow/python/ops/linalg_ops.py
@@ -194,7 +194,7 @@ def eye(num_rows,
         name=None):
   """Construct an identity matrix, or a batch of matrices.
 
-  See also `tf.ones`, `tf.zeroes`, `tf.fill`, `tf.one_hot`
+  See also `tf.ones`, `tf.zeros`, `tf.fill`, `tf.one_hot`
 
   ```python
   # Construct one identity matrix.

--- a/tensorflow/python/ops/linalg_ops.py
+++ b/tensorflow/python/ops/linalg_ops.py
@@ -194,6 +194,8 @@ def eye(num_rows,
         name=None):
   """Construct an identity matrix, or a batch of matrices.
 
+  See also `tf.ones`, `tf.zeroes`, `tf.fill`, `tf.one_hot`
+
   ```python
   # Construct one identity matrix.
   tf.eye(2)

--- a/tensorflow/python/ops/map_fn.py
+++ b/tensorflow/python/ops/map_fn.py
@@ -53,6 +53,8 @@ def map_fn(fn,
            fn_output_signature=None):
   """Transforms `elems` by applying `fn` to each element unstacked on axis 0.
 
+  See also `tf.scan`
+
   `map_fn` unstacks `elems` on axis 0 to obtain a sequence of elements;
   calls `fn` to transform each element; and then stacks the transformed
   values back together.

--- a/tensorflow/python/ops/map_fn.py
+++ b/tensorflow/python/ops/map_fn.py
@@ -53,7 +53,7 @@ def map_fn(fn,
            fn_output_signature=None):
   """Transforms `elems` by applying `fn` to each element unstacked on axis 0.
 
-  See also `tf.scan`
+  See also `tf.scan`.
 
   `map_fn` unstacks `elems` on axis 0 to obtain a sequence of elements;
   calls `fn` to transform each element; and then stacks the transformed


### PR DESCRIPTION
In relation to issue #36786 and PR #37121 I have added some additional 'see also' references between functions in the Python API docs. 

These references make it easier for newcomers to learn about existing alternatives to functions that might better fit their use case and also reminds intermediate users about different options. This style of referencing is similar to what is seen in PyTorch and Arduino documentation. Any feedback is welcome. 

For your convenience, these are roughly the functions which I have referred to each other 

- `tf.slice` and `tf.strided_slice`
- `tf.rank` and `tf.shape`
- `tf.scan` and `tf.map_fn`
- `tf.unqiue` and `tf.unique_with_counts`
- `tf.fill`, `tf.ones`, `tf.zeros`, `tf.eye`, `tf.one_hot` 

For the last group, I left out certain references if they seemed unnecessary (e.g. `tf.one_hot` and `tf.zeros`).

