### PR TITLE
[Feature] use np.asarray_chkfinite in tf.keras.backend.cast_to_floatx

### DIFF
--- a/tensorflow/python/keras/backend.py
+++ b/tensorflow/python/keras/backend.py
@@ -196,7 +196,7 @@ def cast_to_floatx(x):
                     variables_module.Variable,
                     sparse_tensor.SparseTensor)):
     return math_ops.cast(x, dtype=floatx())
-  return np.asarray(x, dtype=floatx())
+  return np.asarray_chkfinite(x, dtype=floatx())
 
 
 # A global dictionary mapping graph objects to an index of counters used


### PR DESCRIPTION
Use `numpy.asarray_chkfinite` instead of `numpy.asarray` in `tf.keras.backend.cast_to_floatx`.

It can help prevent user pass value which contains None, `inf`, `np.nan` or `np.inf` as input.

related to issue #37196
fixes #37627