### PR TITLE
[r2.2:Cherrypick]Disable failing tests in py38 version.

### DIFF
--- a/tensorflow/python/debug/BUILD
+++ b/tensorflow/python/debug/BUILD
@@ -871,7 +871,10 @@ py_test(
     srcs = ["lib/source_utils_test.py"],
     python_version = "PY3",
     srcs_version = "PY2AND3",
-    tags = ["no_windows"],
+    tags = [
+        "no_oss_py38",  #TODO(b/151449908)
+        "no_windows",
+    ],
     deps = [
         ":debug_data",
         ":debug_utils",

--- a/tensorflow/python/keras/engine/BUILD
+++ b/tensorflow/python/keras/engine/BUILD
@@ -193,6 +193,7 @@ tf_py_test(
     srcs = ["data_adapter_test.py"],
     python_version = "PY3",
     tags = [
+        "no_oss_py38",  # TODO(b/150615192)
         "nomac",  # TODO(mihaimaruseac): b/127695564
     ],
     deps = [

--- a/tensorflow/python/kernel_tests/signal/BUILD
+++ b/tensorflow/python/kernel_tests/signal/BUILD
@@ -150,6 +150,7 @@ cuda_py_tests(
     python_version = "PY3",
     shard_count = 4,
     tags = [
+        "no_oss_py38",  #TODO(b/151631881)
         "no_windows_gpu",
     ],
     deps = [


### PR DESCRIPTION
PiperOrigin-RevId: 301195707
Change-Id: I43f5fad45b709b4fe0230bbd98fe0122dbc80ea1