### PR TITLE
r1.15 cherry-pick request: Fix linking issue on TFLite r1.15 branch.

### DIFF
--- a/tensorflow/lite/tools/make/Makefile
+++ b/tensorflow/lite/tools/make/Makefile
@@ -122,6 +122,7 @@ $(wildcard tensorflow/lite/kernels/internal/reference/*.cc) \
 $(PROFILER_SRCS) \
 tensorflow/lite/tools/make/downloads/farmhash/src/farmhash.cc \
 tensorflow/lite/tools/make/downloads/fft2d/fftsg.c \
+tensorflow/lite/tools/make/downloads/fft2d/fftsg2d.c \
 tensorflow/lite/tools/make/downloads/flatbuffers/src/util.cpp
 endif
 # Remove any duplicates.


### PR DESCRIPTION
…btensorflow-lite.a

lite/kernels/rfft2d.cc has reference to rdft2d.
As a consequence, libtensorflow-lite.a need to include fft2d/fftsg2d.c source
in its build.

If fftsg2d.c is not part of libtensorflow-lite.a, a C/C++ application
that use the libtensorflow-lite.a static library is not able to link
with the following error:
rfft2d.cc:(.text+0x594): undefined reference to `rdft2d'

Signed-off-by: Vincent ABRIOU <vincent.abriou@st.com>