### PR TITLE
tf.sparse.SparseTensor and tf.repeat doc

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -156,7 +156,7 @@ This enables writing forward compatible code: by explicitly importing either `te
   * `tf.keras.estimator.model_to_estimator` now supports exporting to tf.train.Checkpoint format, which allows the saved checkpoints to be compatible with `model.load_weights`.
   * Saving a Keras Model using `tf.saved_model.save` now saves the list of variables, trainable variables, regularization losses, and the call function.
   * Deprecated `tf.keras.experimental.export_saved_model` and `tf.keras.experimental.function`. Please use `tf.keras.models.save_model(..., save_format='tf')` and `tf.keras.models.load_model` instead.
-  * Add an `implementation=3` mode for `tf.keras.layers.LocallyConnected2D` and `tf.keras.layers.LocallyConnected1D` layers using `tf.SparseTensor` to store weights,  allowing a dramatic speedup for large sparse models.
+  * Add an `implementation=3` mode for `tf.keras.layers.LocallyConnected2D` and `tf.keras.layers.LocallyConnected1D` layers using `tf.sparse.SparseTensor` to store weights,  allowing a dramatic speedup for large sparse models.
   * Enable the Keras compile API `experimental_run_tf_function` flag by default. This flag enables single training/eval/predict execution path. With this 1. All input types are converted to `Dataset`. 2. When distribution strategy is not specified this goes through the no-op distribution strategy path. 3. Execution is wrapped in tf.function unless `run_eagerly=True` is set in compile.
   * Raise error if `batch_size` argument is used when input is dataset/generator/keras sequence.
 * `tf.lite`
@@ -448,7 +448,7 @@ If you experience any snags when using TF 2.0, please let us know at the [TF 2.0
         `keras.layers.Upsampling2D`) behavior has changed, a bug in the resizing
         implementation was fixed.
     *   Add an `implementation=3` mode for `tf.keras.layers.LocallyConnected2D`
-        and `tf.keras.layers.LocallyConnected1D` layers using `tf.SparseTensor`
+        and `tf.keras.layers.LocallyConnected1D` layers using `tf.sparse.SparseTensor`
         to store weights, allowing a dramatic speedup for large sparse models.
     *   Raise error if `batch_size` argument is used when input is
         dataset/generator/keras sequence.
@@ -1949,7 +1949,7 @@ Yoni Tsafir, yordun, Yuan (Terry) Tang, Yuxin Wu, zhengdi, Zhengsheng Wei, ç”°ä¼
     after successfully completing training, instead of throwing a RuntimeError.
   * Restandardize `DenseVariational` as simpler template for other probabilistic
     layers.
-  * `tf.data` now supports `tf.SparseTensor` components in dataset elements.
+  * `tf.data` now supports `tf.sparse.SparseTensor` components in dataset elements.
   * It is now possible to iterate over `Tensor`s.
   * Allow `SparseSegmentReduction` ops to have missing segment IDs.
   * Modify custom export strategy to account for multidimensional sparse float

--- a/tensorflow/core/api_def/base_api/api_def_SparseMatrixOrderingAMD.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_SparseMatrixOrderingAMD.pbtxt
@@ -45,7 +45,7 @@ Usage example:
 
     with tf.Session() as sess:
       # Define (COO format) SparseTensor over Numpy array.
-      a_st = tf.SparseTensor(a_indices, a_values, a_dense_shape)
+      a_st = tf.sparse.SparseTensor(a_indices, a_values, a_dense_shape)
 
       # Convert SparseTensors to CSR SparseMatrix.
       a_sm = sparse_csr_matrix_ops.sparse_tensor_to_csr_sparse_matrix(

--- a/tensorflow/core/api_def/base_api/api_def_SparseMatrixSparseCholesky.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_SparseMatrixSparseCholesky.pbtxt
@@ -58,7 +58,7 @@ Usage example:
 
     with tf.Session() as sess:
       # Define (COO format) SparseTensor over Numpy array.
-      a_st = tf.SparseTensor(a_indices, a_values, a_dense_shape)
+      a_st = tf.sparse.SparseTensor(a_indices, a_values, a_dense_shape)
 
       # Convert SparseTensors to CSR SparseMatrix.
       a_sm = sparse_csr_matrix_ops.sparse_tensor_to_csr_sparse_matrix(

--- a/tensorflow/core/api_def/base_api/api_def_SparseMatrixSparseMatMul.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_SparseMatrixSparseMatMul.pbtxt
@@ -71,8 +71,8 @@ Usage example:
 
     with tf.Session() as sess:
       # Define (COO format) Sparse Tensors over Numpy arrays
-      a_st = tf.SparseTensor(a_indices, a_values, a_dense_shape)
-      b_st = tf.SparseTensor(b_indices, b_values, b_dense_shape)
+      a_st = tf.sparse.SparseTensor(a_indices, a_values, a_dense_shape)
+      b_st = tf.sparse.SparseTensor(b_indices, b_values, b_dense_shape)
 
       # Convert SparseTensors to CSR SparseMatrix
       a_sm = sparse_csr_matrix_ops.sparse_tensor_to_csr_sparse_matrix(

--- a/tensorflow/examples/saved_model/integration_tests/export_simple_text_embedding.py
+++ b/tensorflow/examples/saved_model/integration_tests/export_simple_text_embedding.py
@@ -87,7 +87,7 @@ class TextEmbeddingModel(tf.train.Checkpoint):
 
     return tf.nn.safe_embedding_lookup_sparse(
         embedding_weights=self.embeddings,
-        sparse_ids=tf.SparseTensor(token_ids, token_values, token_dense_shape),
+        sparse_ids=tf.sparse.SparseTensor(token_ids, token_values, token_dense_shape),
         sparse_weights=None,
         combiner="sqrtn")
 

--- a/tensorflow/go/op/wrappers.go
+++ b/tensorflow/go/op/wrappers.go
@@ -20856,7 +20856,7 @@ func Print(scope *Scope, input tf.Output, data []tf.Output, optional ...PrintAtt
 //
 //     with tf.Session() as sess:
 //       # Define (COO format) SparseTensor over Numpy array.
-//       a_st = tf.SparseTensor(a_indices, a_values, a_dense_shape)
+//       a_st = tf.sparse.SparseTensor(a_indices, a_values, a_dense_shape)
 //
 //       # Convert SparseTensors to CSR SparseMatrix.
 //       a_sm = sparse_csr_matrix_ops.sparse_tensor_to_csr_sparse_matrix(
@@ -32149,8 +32149,8 @@ func SparseMatrixSparseMatMulAdjointB(value bool) SparseMatrixSparseMatMulAttr {
 //
 //     with tf.Session() as sess:
 //       # Define (COO format) Sparse Tensors over Numpy arrays
-//       a_st = tf.SparseTensor(a_indices, a_values, a_dense_shape)
-//       b_st = tf.SparseTensor(b_indices, b_values, b_dense_shape)
+//       a_st = tf.sparse.SparseTensor(a_indices, a_values, a_dense_shape)
+//       b_st = tf.sparse.SparseTensor(b_indices, b_values, b_dense_shape)
 //
 //       # Convert SparseTensors to CSR SparseMatrix
 //       a_sm = sparse_csr_matrix_ops.sparse_tensor_to_csr_sparse_matrix(
@@ -37776,7 +37776,7 @@ func RecvTPUEmbeddingActivations(scope *Scope, num_outputs int64, config string)
 //
 //     with tf.Session() as sess:
 //       # Define (COO format) SparseTensor over Numpy array.
-//       a_st = tf.SparseTensor(a_indices, a_values, a_dense_shape)
+//       a_st = tf.sparse.SparseTensor(a_indices, a_values, a_dense_shape)
 //
 //       # Convert SparseTensors to CSR SparseMatrix.
 //       a_sm = sparse_csr_matrix_ops.sparse_tensor_to_csr_sparse_matrix(

--- a/tensorflow/go/op/wrappers.go
+++ b/tensorflow/go/op/wrappers.go
@@ -20709,7 +20709,7 @@ func Print(scope *Scope, input tf.Output, data []tf.Output, optional ...PrintAtt
 //
 //     with tf.Session() as sess:
 //       # Define (COO format) SparseTensor over Numpy array.
-//       a_st = tf.SparseTensor(a_indices, a_values, a_dense_shape)
+//       a_st = tf.sparse.SparseTensor(a_indices, a_values, a_dense_shape)
 //
 //       # Convert SparseTensors to CSR SparseMatrix.
 //       a_sm = sparse_csr_matrix_ops.sparse_tensor_to_csr_sparse_matrix(
@@ -32445,8 +32445,8 @@ func SparseMatrixSparseMatMulAdjointB(value bool) SparseMatrixSparseMatMulAttr {
 //
 //     with tf.Session() as sess:
 //       # Define (COO format) Sparse Tensors over Numpy arrays
-//       a_st = tf.SparseTensor(a_indices, a_values, a_dense_shape)
-//       b_st = tf.SparseTensor(b_indices, b_values, b_dense_shape)
+//       a_st = tf.sparse.SparseTensor(a_indices, a_values, a_dense_shape)
+//       b_st = tf.sparse.SparseTensor(b_indices, b_values, b_dense_shape)
 //
 //       # Convert SparseTensors to CSR SparseMatrix
 //       a_sm = sparse_csr_matrix_ops.sparse_tensor_to_csr_sparse_matrix(
@@ -37648,7 +37648,7 @@ func RecvTPUEmbeddingActivations(scope *Scope, num_outputs int64, config string)
 //
 //     with tf.Session() as sess:
 //       # Define (COO format) SparseTensor over Numpy array.
-//       a_st = tf.SparseTensor(a_indices, a_values, a_dense_shape)
+//       a_st = tf.sparse.SparseTensor(a_indices, a_values, a_dense_shape)
 //
 //       # Convert SparseTensors to CSR SparseMatrix.
 //       a_sm = sparse_csr_matrix_ops.sparse_tensor_to_csr_sparse_matrix(

--- a/tensorflow/python/client/session.py
+++ b/tensorflow/python/client/session.py
@@ -862,7 +862,7 @@ class BaseSession(SessionInterface):
     * A `tf.Tensor`.
       The corresponding fetched value will be a numpy ndarray containing the
       value of that tensor.
-    * A `tf.SparseTensor`.
+    * A `tf.sparse.SparseTensor`.
       The corresponding fetched value will be a
       `tf.compat.v1.SparseTensorValue`
       containing the value of that sparse tensor.
@@ -907,7 +907,7 @@ class BaseSession(SessionInterface):
       `tf.compat.v1.placeholder`, the shape of
       the value will be checked for compatibility with the placeholder.
     * If the key is a
-      `tf.SparseTensor`,
+      `tf.sparse.SparseTensor`,
       the value should be a
       `tf.compat.v1.SparseTensorValue`.
     * If the key is a nested tuple of `Tensor`s or `SparseTensor`s, the value

--- a/tensorflow/python/data/experimental/ops/batching.py
+++ b/tensorflow/python/data/experimental/ops/batching.py
@@ -88,15 +88,15 @@ def dense_to_ragged_batch(batch_size,
 
 @tf_export("data.experimental.dense_to_sparse_batch")
 def dense_to_sparse_batch(batch_size, row_shape):
-  """A transformation that batches ragged elements into `tf.SparseTensor`s.
+  """A transformation that batches ragged elements into `tf.sparse.SparseTensor`s.
 
   Like `Dataset.padded_batch()`, this transformation combines multiple
   consecutive elements of the dataset, which might have different
   shapes, into a single element. The resulting element has three
   components (`indices`, `values`, and `dense_shape`), which
-  comprise a `tf.SparseTensor` that represents the same data. The
+  comprise a `tf.sparse.SparseTensor` that represents the same data. The
   `row_shape` represents the dense shape of each row in the
-  resulting `tf.SparseTensor`, to which the effective batch size is
+  resulting `tf.sparse.SparseTensor`, to which the effective batch size is
   prepended. For example:
 
   ```python
@@ -121,7 +121,7 @@ def dense_to_sparse_batch(batch_size, row_shape):
       consecutive elements of this dataset to combine in a single batch.
     row_shape: A `tf.TensorShape` or `tf.int64` vector tensor-like object
       representing the equivalent dense shape of a row in the resulting
-      `tf.SparseTensor`. Each element of this dataset must have the same rank as
+      `tf.sparse.SparseTensor`. Each element of this dataset must have the same rank as
       `row_shape`, and must have size less than or equal to `row_shape` in each
       dimension.
 
@@ -283,7 +283,7 @@ def unbatch():
 
 
 class _DenseToSparseBatchDataset(dataset_ops.UnaryDataset):
-  """A `Dataset` that batches ragged dense elements into `tf.SparseTensor`s."""
+  """A `Dataset` that batches ragged dense elements into `tf.sparse.SparseTensor`s."""
 
   def __init__(self, input_dataset, batch_size, row_shape):
     """See `Dataset.dense_to_sparse_batch()` for more details."""

--- a/tensorflow/python/data/experimental/ops/batching.py
+++ b/tensorflow/python/data/experimental/ops/batching.py
@@ -88,15 +88,15 @@ def dense_to_ragged_batch(batch_size,
 
 @tf_export("data.experimental.dense_to_sparse_batch")
 def dense_to_sparse_batch(batch_size, row_shape):
-  """A transformation that batches ragged elements into `tf.SparseTensor`s.
+  """A transformation that batches ragged elements into `tf.sparse.SparseTensor`s.
 
   Like `Dataset.padded_batch()`, this transformation combines multiple
   consecutive elements of the dataset, which might have different
   shapes, into a single element. The resulting element has three
   components (`indices`, `values`, and `dense_shape`), which
-  comprise a `tf.SparseTensor` that represents the same data. The
+  comprise a `tf.sparse.SparseTensor` that represents the same data. The
   `row_shape` represents the dense shape of each row in the
-  resulting `tf.SparseTensor`, to which the effective batch size is
+  resulting `tf.sparse.SparseTensor`, to which the effective batch size is
   prepended. For example:
 
   ```python
@@ -121,7 +121,7 @@ def dense_to_sparse_batch(batch_size, row_shape):
       consecutive elements of this dataset to combine in a single batch.
     row_shape: A `tf.TensorShape` or `tf.int64` vector tensor-like object
       representing the equivalent dense shape of a row in the resulting
-      `tf.SparseTensor`. Each element of this dataset must have the same rank as
+      `tf.sparse.SparseTensor`. Each element of this dataset must have the same rank as
       `row_shape`, and must have size less than or equal to `row_shape` in each
       dimension.
 
@@ -286,7 +286,7 @@ def unbatch():
 
 
 class _DenseToSparseBatchDataset(dataset_ops.UnaryDataset):
-  """A `Dataset` that batches ragged dense elements into `tf.SparseTensor`s."""
+  """A `Dataset` that batches ragged dense elements into `tf.sparse.SparseTensor`s."""
 
   def __init__(self, input_dataset, batch_size, row_shape):
     """See `Dataset.dense_to_sparse_batch()` for more details."""

--- a/tensorflow/python/data/experimental/ops/grouping.py
+++ b/tensorflow/python/data/experimental/ops/grouping.py
@@ -161,7 +161,7 @@ def bucket_by_sequence_length(element_length_func,
       bucket), and caller must ensure that the source `Dataset` does not contain
       any elements with length longer than `max(bucket_boundaries)`.
     no_padding: `bool`, indicates whether to pad the batch features (features
-      need to be either of type `tf.SparseTensor` or of same shape).
+      need to be either of type `tf.sparse.SparseTensor` or of same shape).
     drop_remainder: (Optional.) A `tf.bool` scalar `tf.Tensor`, representing
       whether the last batch should be dropped in the case it has fewer than
       `batch_size` elements; the default behavior is not to drop the smaller

--- a/tensorflow/python/data/kernel_tests/from_sparse_tensor_slices_test.py
+++ b/tensorflow/python/data/kernel_tests/from_sparse_tensor_slices_test.py
@@ -37,7 +37,7 @@ class FromSparseTensorSlicesTest(test_base.DatasetTestBase,
   @combinations.generate(
       combinations.combine(tf_api_version=1, mode=["graph"]))
   def testFromSparseTensorSlices(self):
-    """Test a dataset based on slices of a `tf.SparseTensor`."""
+    """Test a dataset based on slices of a `tf.sparse.SparseTensor`."""
     st = array_ops.sparse_placeholder(dtypes.float64)
     iterator = dataset_ops.make_initializable_iterator(
         dataset_ops.Dataset.from_sparse_tensor_slices(st))

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -158,7 +158,7 @@ class DatasetV2(tracking_base.Trackable, composite_tensor.CompositeTensor):
 
   Elements can be nested structures of tuples, named tuples, and dictionaries.
   Element components can be of any type representable by `tf.TypeSpec`,
-  including `tf.Tensor`, `tf.data.Dataset`, `tf.SparseTensor`,
+  including `tf.Tensor`, `tf.data.Dataset`, `tf.sparse.SparseTensor`,
   `tf.RaggedTensor`, and `tf.TensorArray`.
 
   >>> a = 1 # Integer element
@@ -1456,7 +1456,7 @@ class DatasetV2(tracking_base.Trackable, composite_tensor.CompositeTensor):
       array([[ 10, 100], [ 11,  12]], dtype=int32))]
 
     See also `tf.data.experimental.dense_to_sparse_batch`, which combines
-    elements that may have different shapes into a `tf.SparseTensor`.
+    elements that may have different shapes into a `tf.sparse.SparseTensor`.
 
     Args:
       batch_size: A `tf.int64` scalar `tf.Tensor`, representing the number of
@@ -2266,10 +2266,10 @@ class DatasetV1(DatasetV2):
   @staticmethod
   @deprecation.deprecated(None, "Use `tf.data.Dataset.from_tensor_slices()`.")
   def from_sparse_tensor_slices(sparse_tensor):
-    """Splits each rank-N `tf.SparseTensor` in this dataset row-wise.
+    """Splits each rank-N `tf.sparse.SparseTensor` in this dataset row-wise.
 
     Args:
-      sparse_tensor: A `tf.SparseTensor`.
+      sparse_tensor: A `tf.sparse.SparseTensor`.
 
     Returns:
       Dataset: A `Dataset` of rank-(N-1) sparse tensors.
@@ -2874,13 +2874,13 @@ class TensorSliceDataset(DatasetSource):
 
 
 class SparseTensorSliceDataset(DatasetSource):
-  """A `Dataset` that splits a rank-N `tf.SparseTensor` into its rows."""
+  """A `Dataset` that splits a rank-N `tf.sparse.SparseTensor` into its rows."""
 
   def __init__(self, sparse_tensor):
     """See `Dataset.from_sparse_tensor_slices()` for details."""
     if not isinstance(sparse_tensor, sparse_tensor_lib.SparseTensor):
       raise TypeError(
-          "`sparse_tensor` must be a `tf.SparseTensor` object. Was {}.".format(
+          "`sparse_tensor` must be a `tf.sparse.SparseTensor` object. Was {}.".format(
               sparse_tensor))
     self._sparse_tensor = sparse_tensor
 

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -157,7 +157,7 @@ class DatasetV2(tracking_base.Trackable, composite_tensor.CompositeTensor):
 
   Elements can be nested structures of tuples, named tuples, and dictionaries.
   Element components can be of any type representable by `tf.TypeSpec`,
-  including `tf.Tensor`, `tf.data.Dataset`, `tf.SparseTensor`,
+  including `tf.Tensor`, `tf.data.Dataset`, `tf.sparse.SparseTensor`,
   `tf.RaggedTensor`, and `tf.TensorArray`.
 
   >>> a = 1 # Integer element
@@ -1442,7 +1442,7 @@ class DatasetV2(tracking_base.Trackable, composite_tensor.CompositeTensor):
       array([[ 10, 100], [ 11,  12]], dtype=int32))]
 
     See also `tf.data.experimental.dense_to_sparse_batch`, which combines
-    elements that may have different shapes into a `tf.SparseTensor`.
+    elements that may have different shapes into a `tf.sparse.SparseTensor`.
 
     Args:
       batch_size: A `tf.int64` scalar `tf.Tensor`, representing the number of
@@ -2252,10 +2252,10 @@ class DatasetV1(DatasetV2):
   @staticmethod
   @deprecation.deprecated(None, "Use `tf.data.Dataset.from_tensor_slices()`.")
   def from_sparse_tensor_slices(sparse_tensor):
-    """Splits each rank-N `tf.SparseTensor` in this dataset row-wise.
+    """Splits each rank-N `tf.sparse.SparseTensor` in this dataset row-wise.
 
     Args:
-      sparse_tensor: A `tf.SparseTensor`.
+      sparse_tensor: A `tf.sparse.SparseTensor`.
 
     Returns:
       Dataset: A `Dataset` of rank-(N-1) sparse tensors.
@@ -2863,13 +2863,13 @@ class TensorSliceDataset(DatasetSource):
 
 
 class SparseTensorSliceDataset(DatasetSource):
-  """A `Dataset` that splits a rank-N `tf.SparseTensor` into its rows."""
+  """A `Dataset` that splits a rank-N `tf.sparse.SparseTensor` into its rows."""
 
   def __init__(self, sparse_tensor):
     """See `Dataset.from_sparse_tensor_slices()` for details."""
     if not isinstance(sparse_tensor, sparse_tensor_lib.SparseTensor):
       raise TypeError(
-          "`sparse_tensor` must be a `tf.SparseTensor` object. Was {}.".format(
+          "`sparse_tensor` must be a `tf.sparse.SparseTensor` object. Was {}.".format(
               sparse_tensor))
     self._sparse_tensor = sparse_tensor
 

--- a/tensorflow/python/data/ops/iterator_ops.py
+++ b/tensorflow/python/data/ops/iterator_ops.py
@@ -448,7 +448,7 @@ class Iterator(trackable.Trackable):
   def output_classes(self):
     """Returns the class of each component of an element of this iterator.
 
-    The expected values are `tf.Tensor` and `tf.SparseTensor`.
+    The expected values are `tf.Tensor` and `tf.sparse.SparseTensor`.
 
     Returns:
       A nested structure of Python `type` objects corresponding to each
@@ -677,7 +677,7 @@ class OwnedIterator(trackable.Trackable, composite_tensor.CompositeTensor):
   def output_classes(self):
     """Returns the class of each component of an element of this iterator.
 
-    The expected values are `tf.Tensor` and `tf.SparseTensor`.
+    The expected values are `tf.Tensor` and `tf.sparse.SparseTensor`.
 
     Returns:
       A nested structure of Python `type` objects corresponding to each

--- a/tensorflow/python/data/util/sparse.py
+++ b/tensorflow/python/data/util/sparse.py
@@ -47,7 +47,7 @@ def as_dense_shapes(shapes, classes):
   Returns:
     a structure matching the nested structure of `shapes`, containing
     `tensor_shape.unknown_shape()` at positions where `classes` contains
-    `tf.SparseTensor` and matching contents of `shapes` otherwise
+    `tf.sparse.SparseTensor` and matching contents of `shapes` otherwise
   """
   ret = nest.pack_sequence_as(shapes, [
       tensor_shape.unknown_shape() if c is sparse_tensor.SparseTensor else shape
@@ -65,7 +65,7 @@ def as_dense_types(types, classes):
 
   Returns:
     a structure matching the nested structure of `types`, containing
-    `dtypes.variant` at positions where `classes` contains `tf.SparseTensor` and
+    `dtypes.variant` at positions where `classes` contains `tf.sparse.SparseTensor` and
     matching contents of `types` otherwise
   """
   ret = nest.pack_sequence_as(types, [
@@ -106,7 +106,7 @@ def get_classes(tensors):
 
   Returns:
     a structure matching the nested structure of `tensors`, containing
-    `tf.SparseTensor` at positions where `tensors` contains a sparse tensor and
+    `tf.sparse.SparseTensor` at positions where `tensors` contains a sparse tensor and
     `tf.Tensor` otherwise
   """
   return nest.pack_sequence_as(tensors, [

--- a/tensorflow/python/feature_column/feature_column.py
+++ b/tensorflow/python/feature_column/feature_column.py
@@ -1969,7 +1969,7 @@ class _CategoricalColumn(_FeatureColumn):
   WARNING: Do not subclass this layer unless you know what you are doing:
   the API is subject to future changes.
 
-  A categorical feature typically handled with a `tf.SparseTensor` of IDs.
+  A categorical feature typically handled with a `tf.sparse.SparseTensor` of IDs.
   """
 
   IdWeightPair = collections.namedtuple(  # pylint: disable=invalid-name

--- a/tensorflow/python/feature_column/feature_column_v2.py
+++ b/tensorflow/python/feature_column/feature_column_v2.py
@@ -2495,7 +2495,7 @@ def _create_dense_column_weighted_sum(column, transformation_cache,
 class CategoricalColumn(FeatureColumn):
   """Represents a categorical feature.
 
-  A categorical feature typically handled with a `tf.SparseTensor` of IDs.
+  A categorical feature typically handled with a `tf.sparse.SparseTensor` of IDs.
   """
 
   IdWeightPair = collections.namedtuple(  # pylint: disable=invalid-name

--- a/tensorflow/python/feature_column/feature_column_v2.py
+++ b/tensorflow/python/feature_column/feature_column_v2.py
@@ -2515,7 +2515,7 @@ def _create_dense_column_weighted_sum(column, transformation_cache,
 class CategoricalColumn(FeatureColumn):
   """Represents a categorical feature.
 
-  A categorical feature typically handled with a `tf.SparseTensor` of IDs.
+  A categorical feature typically handled with a `tf.sparse.SparseTensor` of IDs.
   """
 
   IdWeightPair = collections.namedtuple(  # pylint: disable=invalid-name

--- a/tensorflow/python/framework/indexed_slices.py
+++ b/tensorflow/python/framework/indexed_slices.py
@@ -84,7 +84,7 @@ class IndexedSlices(_TensorLike, composite_tensor.CompositeTensor):
   (e.g. `tf.gather`).
 
   Contrast this representation with
-  `tf.SparseTensor`,
+  `tf.sparse.SparseTensor`,
   which uses multi-dimensional indices and scalar values.
   """
 

--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -338,7 +338,7 @@ class Tensor(_TensorLike):
   shape of a tensor at execution time.
 
   There are specialized tensors; for these, see `tf.Variable`, `tf.constant`,
-  `tf.placeholder`, `tf.SparseTensor`, and `tf.RaggedTensor`.
+  `tf.placeholder`, `tf.sparse.SparseTensor`, and `tf.RaggedTensor`.
 
   For more on Tensors, see the [guide](https://tensorflow.org/guide/tensor`).
   """

--- a/tensorflow/python/framework/sparse_tensor.py
+++ b/tensorflow/python/framework/sparse_tensor.py
@@ -298,14 +298,14 @@ _pywrap_utils.RegisterType("SparseTensorValue", SparseTensorValue)
 
 @tf_export("SparseTensorSpec")
 class SparseTensorSpec(type_spec.BatchableTypeSpec):
-  """Type specification for a `tf.SparseTensor`."""
+  """Type specification for a `tf.sparse.SparseTensor`."""
 
   __slots__ = ["_shape", "_dtype"]
 
   value_type = property(lambda self: SparseTensor)
 
   def __init__(self, shape=None, dtype=dtypes.float32):
-    """Constructs a type specification for a `tf.SparseTensor`.
+    """Constructs a type specification for a `tf.sparse.SparseTensor`.
 
     Args:
       shape: The dense shape of the `SparseTensor`, or `None` to allow
@@ -473,13 +473,13 @@ def convert_to_tensor_or_sparse_tensor(value, dtype=None, name=None):
 def is_sparse(x):
   """Check whether `x` is sparse.
 
-  Check whether an object is a `tf.SparseTensor` or
+  Check whether an object is a `tf.sparse.SparseTensor` or
   `tf.compat.v1.SparseTensorValue`.
 
   Args:
     x: A python object to check.
 
   Returns:
-    `True` iff `x` is a `tf.SparseTensor` or `tf.compat.v1.SparseTensorValue`.
+    `True` iff `x` is a `tf.sparse.SparseTensor` or `tf.compat.v1.SparseTensorValue`.
   """
   return isinstance(x, (SparseTensor, SparseTensorValue))

--- a/tensorflow/python/keras/engine/input_layer.py
+++ b/tensorflow/python/keras/engine/input_layer.py
@@ -44,7 +44,7 @@ class InputLayer(base_layer.Layer):
   When using InputLayer with Keras Sequential model, it can be skipped by
   moving the input_shape parameter to the first layer after the InputLayer.
 
-  This class can create placeholders for tf.Tensors, tf.SparseTensors, and
+  This class can create placeholders for tf.Tensors, tf.sparse.SparseTensors, and
   tf.RaggedTensors by choosing 'sparse=True' or 'ragged=True'. Note that
   'sparse' and 'ragged' can't be configured to True at same time.
   Usage:

--- a/tensorflow/python/keras/layers/local.py
+++ b/tensorflow/python/keras/layers/local.py
@@ -782,7 +782,7 @@ def local_conv_sparse_matmul(inputs, kernel, kernel_idxs, kernel_shape,
                              output_shape):
   """Apply N-D convolution with un-shared weights using a single sparse matmul.
 
-  This method outputs `inputs . tf.SparseTensor(indices=kernel_idxs,
+  This method outputs `inputs . tf.sparse.SparseTensor(indices=kernel_idxs,
   values=kernel, dense_shape=kernel_shape)`, with `.` standing for
   matrix-multiply. It also reshapes `inputs` to 2-D and `output` to (N+2)-D.
 

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -3069,7 +3069,7 @@ def sparse_placeholder(dtype, shape=None, name=None):
     print(sess.run(y, feed_dict={
       x: (indices, values, shape)}))  # Will succeed.
 
-    sp = tf.SparseTensor(indices=indices, values=values, dense_shape=shape)
+    sp = tf.sparse.SparseTensor(indices=indices, values=values, dense_shape=shape)
     sp_value = sp.eval(session=sess)
     print(sess.run(y, feed_dict={x: sp_value}))  # Will succeed.
   ```
@@ -3471,7 +3471,7 @@ def edit_distance(hypothesis, truth, normalize=True, name="edit_distance"):
   # 'hypothesis' is a tensor of shape `[2, 1]` with variable-length values:
   #   (0,0) = ["a"]
   #   (1,0) = ["b"]
-  hypothesis = tf.SparseTensor(
+  hypothesis = tf.sparse.SparseTensor(
       [[0, 0, 0],
        [1, 0, 0]],
       ["a", "b"],
@@ -3482,7 +3482,7 @@ def edit_distance(hypothesis, truth, normalize=True, name="edit_distance"):
   #   (0,1) = ["a"]
   #   (1,0) = ["b", "c"]
   #   (1,1) = ["a"]
-  truth = tf.SparseTensor(
+  truth = tf.sparse.SparseTensor(
       [[0, 1, 0],
        [1, 0, 0],
        [1, 0, 1],

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -5480,17 +5480,17 @@ def repeat_with_axis(data, repeats, axis, name=None):
 
   Example usage:
 
-  >>> repeat(['a', 'b', 'c'], repeats=[3, 0, 2], axis=0)
+  >>> tf.repeat(['a', 'b', 'c'], repeats=[3, 0, 2], axis=0)
   <tf.Tensor: shape=(5,), dtype=string,
   numpy=array([b'a', b'a', b'a', b'c', b'c'], dtype=object)>
-  >>> repeat([[1, 2], [3, 4]], repeats=[2, 3], axis=0)
+  >>> tf.repeat([[1, 2], [3, 4]], repeats=[2, 3], axis=0)
   <tf.Tensor: shape=(5, 2), dtype=int32, numpy=
   array([[1, 2],
          [1, 2],
          [3, 4],
          [3, 4],
          [3, 4]], dtype=int32)>
-  >>> repeat([[1, 2], [3, 4]], repeats=[2, 3], axis=1)
+  >>> tf.repeat([[1, 2], [3, 4]], repeats=[2, 3], axis=1)
   <tf.Tensor: shape=(2, 5), dtype=int32, numpy=
   array([[1, 1, 2, 2, 2],
          [3, 3, 4, 4, 4]], dtype=int32)>
@@ -5613,11 +5613,11 @@ def repeat(input, repeats, axis=None, name=None):  # pylint: disable=redefined-b
 
   Example usage:
 
-  >>> repeat(['a', 'b', 'c'], repeats=[3, 0, 2], axis=0)
+  >>> tf.repeat(['a', 'b', 'c'], repeats=[3, 0, 2], axis=0)
   <tf.Tensor: shape=(5,), dtype=string,
   numpy=array([b'a', b'a', b'a', b'c', b'c'], dtype=object)>
 
-  >>> repeat([[1, 2], [3, 4]], repeats=[2, 3], axis=0)
+  >>> tf.repeat([[1, 2], [3, 4]], repeats=[2, 3], axis=0)
   <tf.Tensor: shape=(5, 2), dtype=int32, numpy=
   array([[1, 2],
          [1, 2],
@@ -5625,15 +5625,15 @@ def repeat(input, repeats, axis=None, name=None):  # pylint: disable=redefined-b
          [3, 4],
          [3, 4]], dtype=int32)>
 
-  >>> repeat([[1, 2], [3, 4]], repeats=[2, 3], axis=1)
+  >>> tf.repeat([[1, 2], [3, 4]], repeats=[2, 3], axis=1)
   <tf.Tensor: shape=(2, 5), dtype=int32, numpy=
   array([[1, 1, 2, 2, 2],
          [3, 3, 4, 4, 4]], dtype=int32)>
 
-  >>> repeat(3, repeats=4)
+  >>> tf.repeat(3, repeats=4)
   <tf.Tensor: shape=(4,), dtype=int32, numpy=array([3, 3, 3, 3], dtype=int32)>
 
-  >>> repeat([[1,2], [3,4]], repeats=2)
+  >>> tf.repeat([[1,2], [3,4]], repeats=2)
   <tf.Tensor: shape=(8,), dtype=int32,
   numpy=array([1, 1, 2, 2, 3, 3, 4, 4], dtype=int32)>
 

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -5456,17 +5456,17 @@ def repeat_with_axis(data, repeats, axis, name=None):
 
   Example usage:
 
-  >>> repeat(['a', 'b', 'c'], repeats=[3, 0, 2], axis=0)
+  >>> tf.repeat(['a', 'b', 'c'], repeats=[3, 0, 2], axis=0)
   <tf.Tensor: shape=(5,), dtype=string,
   numpy=array([b'a', b'a', b'a', b'c', b'c'], dtype=object)>
-  >>> repeat([[1, 2], [3, 4]], repeats=[2, 3], axis=0)
+  >>> tf.repeat([[1, 2], [3, 4]], repeats=[2, 3], axis=0)
   <tf.Tensor: shape=(5, 2), dtype=int32, numpy=
   array([[1, 2],
          [1, 2],
          [3, 4],
          [3, 4],
          [3, 4]], dtype=int32)>
-  >>> repeat([[1, 2], [3, 4]], repeats=[2, 3], axis=1)
+  >>> tf.repeat([[1, 2], [3, 4]], repeats=[2, 3], axis=1)
   <tf.Tensor: shape=(2, 5), dtype=int32, numpy=
   array([[1, 1, 2, 2, 2],
          [3, 3, 4, 4, 4]], dtype=int32)>
@@ -5587,11 +5587,11 @@ def repeat(input, repeats, axis=None, name=None):  # pylint: disable=redefined-b
 
   Example usage:
 
-  >>> repeat(['a', 'b', 'c'], repeats=[3, 0, 2], axis=0)
+  >>> tf.repeat(['a', 'b', 'c'], repeats=[3, 0, 2], axis=0)
   <tf.Tensor: shape=(5,), dtype=string,
   numpy=array([b'a', b'a', b'a', b'c', b'c'], dtype=object)>
 
-  >>> repeat([[1, 2], [3, 4]], repeats=[2, 3], axis=0)
+  >>> tf.repeat([[1, 2], [3, 4]], repeats=[2, 3], axis=0)
   <tf.Tensor: shape=(5, 2), dtype=int32, numpy=
   array([[1, 2],
          [1, 2],
@@ -5599,15 +5599,15 @@ def repeat(input, repeats, axis=None, name=None):  # pylint: disable=redefined-b
          [3, 4],
          [3, 4]], dtype=int32)>
 
-  >>> repeat([[1, 2], [3, 4]], repeats=[2, 3], axis=1)
+  >>> tf.repeat([[1, 2], [3, 4]], repeats=[2, 3], axis=1)
   <tf.Tensor: shape=(2, 5), dtype=int32, numpy=
   array([[1, 1, 2, 2, 2],
          [3, 3, 4, 4, 4]], dtype=int32)>
 
-  >>> repeat(3, repeats=4)
+  >>> tf.repeat(3, repeats=4)
   <tf.Tensor: shape=(4,), dtype=int32, numpy=array([3, 3, 3, 3], dtype=int32)>
 
-  >>> repeat([[1,2], [3,4]], repeats=2)
+  >>> tf.repeat([[1,2], [3,4]], repeats=2)
   <tf.Tensor: shape=(8,), dtype=int32,
   numpy=array([1, 1, 2, 2, 3, 3, 4, 4], dtype=int32)>
 

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -3049,7 +3049,7 @@ def sparse_placeholder(dtype, shape=None, name=None):
     print(sess.run(y, feed_dict={
       x: (indices, values, shape)}))  # Will succeed.
 
-    sp = tf.SparseTensor(indices=indices, values=values, dense_shape=shape)
+    sp = tf.sparse.SparseTensor(indices=indices, values=values, dense_shape=shape)
     sp_value = sp.eval(session=sess)
     print(sess.run(y, feed_dict={x: sp_value}))  # Will succeed.
   ```
@@ -3451,7 +3451,7 @@ def edit_distance(hypothesis, truth, normalize=True, name="edit_distance"):
   # 'hypothesis' is a tensor of shape `[2, 1]` with variable-length values:
   #   (0,0) = ["a"]
   #   (1,0) = ["b"]
-  hypothesis = tf.SparseTensor(
+  hypothesis = tf.sparse.SparseTensor(
       [[0, 0, 0],
        [1, 0, 0]],
       ["a", "b"],
@@ -3462,7 +3462,7 @@ def edit_distance(hypothesis, truth, normalize=True, name="edit_distance"):
   #   (0,1) = ["a"]
   #   (1,0) = ["b", "c"]
   #   (1,1) = ["a"]
-  truth = tf.SparseTensor(
+  truth = tf.sparse.SparseTensor(
       [[0, 1, 0],
        [1, 0, 0],
        [1, 0, 1],

--- a/tensorflow/python/ops/ctc_ops.py
+++ b/tensorflow/python/ops/ctc_ops.py
@@ -1126,7 +1126,7 @@ def dense_labels_to_sparse(dense, length):
     length: int tensor of shape [batch] The length of each sequence in dense.
 
   Returns:
-    tf.SparseTensor with values only for the valid elements of sequences.
+    tf.sparse.SparseTensor with values only for the valid elements of sequences.
   """
 
   flat_values = array_ops.reshape(dense, [-1])

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -1432,8 +1432,8 @@ def equal(x, y, name=None):
   <tf.Tensor: shape=(2,), dtype=bool, numpy=array([ True,  True])>
 
   Args:
-    x: A `tf.Tensor` or `tf.SparseTensor` or `tf.IndexedSlices`.
-    y: A `tf.Tensor` or `tf.SparseTensor` or `tf.IndexedSlices`.
+    x: A `tf.Tensor` or `tf.sparse.SparseTensor` or `tf.IndexedSlices`.
+    y: A `tf.Tensor` or `tf.sparse.SparseTensor` or `tf.IndexedSlices`.
     name: A name for the operation (optional).
 
   Returns:
@@ -1468,8 +1468,8 @@ def not_equal(x, y, name=None):
   <tf.Tensor: shape=(2,), dtype=bool, numpy=array([False,  False])>
 
   Args:
-    x: A `tf.Tensor` or `tf.SparseTensor` or `tf.IndexedSlices`.
-    y: A `tf.Tensor` or `tf.SparseTensor` or `tf.IndexedSlices`.
+    x: A `tf.Tensor` or `tf.sparse.SparseTensor` or `tf.IndexedSlices`.
+    y: A `tf.Tensor` or `tf.sparse.SparseTensor` or `tf.IndexedSlices`.
     name: A name for the operation (optional).
 
   Returns:
@@ -2886,12 +2886,12 @@ def matmul(a,
       **does not support `tf.sparse.SparseTensor`**, it just makes optimizations
       that assume most values in `a` are zero.
       See `tf.sparse.sparse_dense_matmul`
-      for some support for `tf.SparseTensor` multiplication.
+      for some support for `tf.sparse.SparseTensor` multiplication.
     b_is_sparse: If `True`, `b` is treated as a sparse matrix. Notice, this
       **does not support `tf.sparse.SparseTensor`**, it just makes optimizations
       that assume most values in `a` are zero.
       See `tf.sparse.sparse_dense_matmul`
-      for some support for `tf.SparseTensor` multiplication.
+      for some support for `tf.sparse.SparseTensor` multiplication.
     name: Name for the operation (optional).
 
   Returns:

--- a/tensorflow/python/ops/parallel_for/pfor.py
+++ b/tensorflow/python/ops/parallel_for/pfor.py
@@ -1217,10 +1217,10 @@ class PFor(object):
     the new dense shape will be (N, max_i(x_i), max_i(y_i), max_i(z_i)).
 
     Args:
-      y: A tf.SparseTensor.
+      y: A tf.sparse.SparseTensor.
 
     Returns:
-      A tf.SparseTensor that is the converted value corresponding to y.
+      A tf.sparse.SparseTensor that is the converted value corresponding to y.
     """
     outputs = [
         self._convert_helper(t) for t in (y.indices, y.values, y.dense_shape)

--- a/tensorflow/python/ops/ragged/ragged_tensor.py
+++ b/tensorflow/python/ops/ragged/ragged_tensor.py
@@ -1629,7 +1629,7 @@ class RaggedTensor(composite_tensor.CompositeTensor):
 
   @classmethod
   def from_sparse(cls, st_input, name=None, row_splits_dtype=dtypes.int64):
-    """Converts a 2D `tf.SparseTensor` to a `RaggedTensor`.
+    """Converts a 2D `tf.sparse.SparseTensor` to a `RaggedTensor`.
 
     Each row of the `output` `RaggedTensor` will contain the explicit values
     from the same row in `st_input`.  `st_input` must be ragged-right.  If not
@@ -1637,7 +1637,7 @@ class RaggedTensor(composite_tensor.CompositeTensor):
 
     Example:
 
-    >>> st = tf.SparseTensor(indices=[[0, 0], [0, 1], [0, 2], [1, 0], [3, 0]],
+    >>> st = tf.sparse.SparseTensor(indices=[[0, 0], [0, 1], [0, 2], [1, 0], [3, 0]],
     ...                      values=[1, 2, 3, 4, 5],
     ...                      dense_shape=[4, 3])
     >>> tf.RaggedTensor.from_sparse(st).to_list()
@@ -1690,7 +1690,7 @@ class RaggedTensor(composite_tensor.CompositeTensor):
             st_input.values, segment_ids, num_segments, validate=False)
 
   def to_sparse(self, name=None):
-    """Converts this `RaggedTensor` into a `tf.SparseTensor`.
+    """Converts this `RaggedTensor` into a `tf.sparse.SparseTensor`.
 
     Example:
 

--- a/tensorflow/python/ops/ragged/ragged_tensor.py
+++ b/tensorflow/python/ops/ragged/ragged_tensor.py
@@ -1827,7 +1827,7 @@ class RaggedTensor(composite_tensor.CompositeTensor):
 
   @classmethod
   def from_sparse(cls, st_input, name=None, row_splits_dtype=dtypes.int64):
-    """Converts a 2D `tf.SparseTensor` to a `RaggedTensor`.
+    """Converts a 2D `tf.sparse.SparseTensor` to a `RaggedTensor`.
 
     Each row of the `output` `RaggedTensor` will contain the explicit values
     from the same row in `st_input`.  `st_input` must be ragged-right.  If not
@@ -1835,7 +1835,7 @@ class RaggedTensor(composite_tensor.CompositeTensor):
 
     Example:
 
-    >>> st = tf.SparseTensor(indices=[[0, 0], [0, 1], [0, 2], [1, 0], [3, 0]],
+    >>> st = tf.sparse.SparseTensor(indices=[[0, 0], [0, 1], [0, 2], [1, 0], [3, 0]],
     ...                      values=[1, 2, 3, 4, 5],
     ...                      dense_shape=[4, 3])
     >>> tf.RaggedTensor.from_sparse(st).to_list()
@@ -1888,7 +1888,7 @@ class RaggedTensor(composite_tensor.CompositeTensor):
             st_input.values, segment_ids, num_segments, validate=False)
 
   def to_sparse(self, name=None):
-    """Converts this `RaggedTensor` into a `tf.SparseTensor`.
+    """Converts this `RaggedTensor` into a `tf.sparse.SparseTensor`.
 
     Example:
 

--- a/tensorflow/python/ops/sets_impl.py
+++ b/tensorflow/python/ops/sets_impl.py
@@ -156,7 +156,7 @@ def set_intersection(a, b, validate_indices=True):
         ((1, 1, 0), 5),
         ((1, 1, 1), 6),
     ])
-    a = tf.SparseTensor(list(a.keys()), list(a.values()), dense_shape=[2,2,2])
+    a = tf.sparse.SparseTensor(list(a.keys()), list(a.values()), dense_shape=[2,2,2])
 
     # b = np.array([[{1}, {}], [{4}, {5, 6, 7, 8}]])
     b = collections.OrderedDict([
@@ -167,7 +167,7 @@ def set_intersection(a, b, validate_indices=True):
         ((1, 1, 2), 7),
         ((1, 1, 3), 8),
     ])
-    b = tf.SparseTensor(list(b.keys()), list(b.values()), dense_shape=[2, 2, 4])
+    b = tf.sparse.SparseTensor(list(b.keys()), list(b.values()), dense_shape=[2, 2, 4])
 
     # `tf.sets.intersection` is applied to each aligned pair of sets.
     tf.sets.intersection(a, b)
@@ -224,7 +224,7 @@ def set_difference(a, b, aminusb=True, validate_indices=True):
         ((1, 1, 0), 5),
         ((1, 1, 1), 6),
     ])
-    a = tf.SparseTensor(list(a.keys()), list(a.values()), dense_shape=[2, 2, 2])
+    a = tf.sparse.SparseTensor(list(a.keys()), list(a.values()), dense_shape=[2, 2, 2])
 
     # np.array([[{1, 3}, {2}], [{4, 5}, {5, 6, 7, 8}]])
     b = collections.OrderedDict([
@@ -238,7 +238,7 @@ def set_difference(a, b, aminusb=True, validate_indices=True):
         ((1, 1, 2), 7),
         ((1, 1, 3), 8),
     ])
-    b = tf.SparseTensor(list(b.keys()), list(b.values()), dense_shape=[2, 2, 4])
+    b = tf.sparse.SparseTensor(list(b.keys()), list(b.values()), dense_shape=[2, 2, 4])
 
     # `set_difference` is applied to each aligned pair of sets.
     tf.sets.difference(a, b)
@@ -302,7 +302,7 @@ def set_union(a, b, validate_indices=True):
         ((1, 1, 0), 5),
         ((1, 1, 1), 6),
     ])
-    a = tf.SparseTensor(list(a.keys()), list(a.values()), dense_shape=[2, 2, 2])
+    a = tf.sparse.SparseTensor(list(a.keys()), list(a.values()), dense_shape=[2, 2, 2])
 
     # [[{1, 3}, {2}], [{4, 5}, {5, 6, 7, 8}]]
     b = collections.OrderedDict([
@@ -316,7 +316,7 @@ def set_union(a, b, validate_indices=True):
         ((1, 1, 2), 7),
         ((1, 1, 3), 8),
     ])
-    b = tf.SparseTensor(list(b.keys()), list(b.values()), dense_shape=[2, 2, 4])
+    b = tf.sparse.SparseTensor(list(b.keys()), list(b.values()), dense_shape=[2, 2, 4])
 
     # `set_union` is applied to each aligned pair of sets.
     tf.sets.union(a, b)

--- a/tensorflow/python/ops/sparse_ops.py
+++ b/tensorflow/python/ops/sparse_ops.py
@@ -16,7 +16,7 @@
 # pylint: disable=g-short-docstring-punctuation
 """Sparse Tensor Representation.
 
-See also `tf.SparseTensor`.
+See also `tf.sparse.SparseTensor`.
 """
 
 from __future__ import absolute_import
@@ -2460,7 +2460,7 @@ def sparse_softmax(sp_input, name=None):
   values = np.asarray([[[0., np.e], [1., 0.]], [[np.e, 0.], [np.e, np.e]]])
   indices = np.vstack(np.where(values)).astype(np.int64).T
 
-  result = tf.sparse.softmax(tf.SparseTensor(indices, values, shape))
+  result = tf.sparse.softmax(tf.sparse.SparseTensor(indices, values, shape))
   # ...returning a 3-D SparseTensor, equivalent to:
   # [?   1.]     [1    ?]
   # [1.  ? ] and [.5  .5]

--- a/tensorflow/python/util/nest.py
+++ b/tensorflow/python/util/nest.py
@@ -310,7 +310,7 @@ def flatten(structure, expand_composites=False):
   Args:
     structure: an arbitrarily nested structure. Note, numpy arrays are
       considered atoms and are not flattened.
-    expand_composites: If true, then composite tensors such as tf.SparseTensor
+    expand_composites: If true, then composite tensors such as tf.sparse.SparseTensor
        and tf.RaggedTensor are expanded into their component tensors.
 
   Returns:
@@ -364,7 +364,7 @@ def assert_same_structure(nest1, nest2, check_types=True,
         considered the same if they are both list subtypes (which allows "list"
         and "_ListWrapper" from trackable dependency tracking to compare
         equal).
-    expand_composites: If true, then composite tensors such as `tf.SparseTensor`
+    expand_composites: If true, then composite tensors such as `tf.sparse.SparseTensor`
         and `tf.RaggedTensor` are expanded into their component tensors.
 
   Raises:
@@ -537,7 +537,7 @@ def pack_sequence_as(structure, flat_sequence, expand_composites=False):
         tuples, and dicts. Note: numpy arrays and strings are considered
         scalars.
     flat_sequence: flat sequence to pack.
-    expand_composites: If true, then composite tensors such as `tf.SparseTensor`
+    expand_composites: If true, then composite tensors such as `tf.sparse.SparseTensor`
         and `tf.RaggedTensor` are expanded into their component tensors.
 
   Returns:
@@ -574,7 +574,7 @@ def map_structure(func, *structure, **kwargs):
         Note that namedtuples with identical name and fields are always
         considered to have the same shallow structure.
       * `expand_composites`: If set to `True`, then composite tensors such
-        as `tf.SparseTensor` and `tf.RaggedTensor` are expanded into their
+        as `tf.sparse.SparseTensor` and `tf.RaggedTensor` are expanded into their
         component tensors.  If `False` (the default), then composite tensors
         are not expanded.
 
@@ -762,7 +762,7 @@ def assert_shallow_structure(shallow_tree,
       `input_tree` have to be the same. Note that even with check_types==True,
       this function will consider two different namedtuple classes with the same
       name and _fields attribute to be the same class.
-    expand_composites: If true, then composite tensors such as tf.SparseTensor
+    expand_composites: If true, then composite tensors such as tf.sparse.SparseTensor
        and tf.RaggedTensor are expanded into their component tensors.
   Raises:
     TypeError: If `shallow_tree` is a sequence but `input_tree` is not.
@@ -911,7 +911,7 @@ def flatten_up_to(shallow_tree, input_tree, check_types=True,
       Note, numpy arrays are considered scalars.
     check_types: bool. If True, check that each node in shallow_tree has the
       same type as the corresponding node in input_tree.
-    expand_composites: If true, then composite tensors such as tf.SparseTensor
+    expand_composites: If true, then composite tensors such as tf.sparse.SparseTensor
        and tf.RaggedTensor are expanded into their component tensors.
 
   Returns:
@@ -1015,7 +1015,7 @@ def flatten_with_tuple_paths_up_to(shallow_tree,
       Note, numpy arrays are considered scalars.
     check_types: bool. If True, check that each node in shallow_tree has the
       same type as the corresponding node in input_tree.
-    expand_composites: If true, then composite tensors such as tf.SparseTensor
+    expand_composites: If true, then composite tensors such as tf.sparse.SparseTensor
        and tf.RaggedTensor are expanded into their component tensors.
 
   Returns:
@@ -1233,7 +1233,7 @@ def get_traverse_shallow_structure(traverse_fn, structure,
       shallow structure of the same type, describing which parts of the
       substructure to traverse.
     structure: The structure to traverse.
-    expand_composites: If true, then composite tensors such as tf.SparseTensor
+    expand_composites: If true, then composite tensors such as tf.sparse.SparseTensor
        and tf.RaggedTensor are expanded into their component tensors.
 
   Returns:
@@ -1313,7 +1313,7 @@ def yield_flat_paths(nest, expand_composites=False):
 
   Args:
     nest: the value to produce a flattened paths list for.
-    expand_composites: If true, then composite tensors such as tf.SparseTensor
+    expand_composites: If true, then composite tensors such as tf.sparse.SparseTensor
        and tf.RaggedTensor are expanded into their component tensors.
 
   Yields:
@@ -1338,7 +1338,7 @@ def flatten_with_joined_string_paths(structure, separator="/",
     structure: the nested structure to flatten.
     separator: string to separate levels of hierarchy in the results, defaults
       to '/'.
-    expand_composites: If true, then composite tensors such as tf.SparseTensor
+    expand_composites: If true, then composite tensors such as tf.sparse.SparseTensor
        and tf.RaggedTensor are expanded into their component tensors.
 
   Returns:
@@ -1362,7 +1362,7 @@ def flatten_with_tuple_paths(structure, expand_composites=False):
 
   Args:
     structure: the nested structure to flatten.
-    expand_composites: If true, then composite tensors such as tf.SparseTensor
+    expand_composites: If true, then composite tensors such as tf.sparse.SparseTensor
        and tf.RaggedTensor are expanded into their component tensors.
 
   Returns:

--- a/tensorflow/python/util/util.h
+++ b/tensorflow/python/util/util.h
@@ -234,7 +234,7 @@ PyObject* AssertSameStructure(PyObject* o1, PyObject* o2, bool check_types,
 //   nest: an arbitrarily nested structure or a scalar object. Note, numpy
 //       arrays are considered scalars.
 //   expand_composites: If true, then composite tensors (such as
-//       `tf.SparseTensor` and `tf.RaggedTensor` are flattened into their
+//       `tf.sparse.SparseTensor` and `tf.RaggedTensor` are flattened into their
 //       component tensors.
 //
 // Returns:

--- a/tensorflow/python/util/util_wrapper.cc
+++ b/tensorflow/python/util/util_wrapper.cc
@@ -244,7 +244,7 @@ PYBIND11_MODULE(_pywrap_utils, m) {
       Args:
         nest: an arbitrarily nested structure or a scalar object. Note, numpy
             arrays are considered scalars.
-        expand_composites: If true, then composite tensors such as `tf.SparseTensor`
+        expand_composites: If true, then composite tensors such as `tf.sparse.SparseTensor`
             and `tf.RaggedTensor` are expanded into their component tensors.
 
       Returns:

--- a/tensorflow/tools/compatibility/testdata/test_file_v1_12.py
+++ b/tensorflow/tools/compatibility/testdata/test_file_v1_12.py
@@ -40,7 +40,7 @@ class TestUpgrade(test_util.TensorFlowTestCase):
     self.assertAllClose(0.5, tf.rsqrt(4.0))
 
   def testSerializeSparseTensor(self):
-    sp_input = tf.SparseTensor(
+    sp_input = tf.sparse.SparseTensor(
         indices=tf.constant([[1]], dtype=tf.int64),
         values=tf.constant([2], dtype=tf.int64),
         dense_shape=[2])
@@ -51,7 +51,7 @@ class TestUpgrade(test_util.TensorFlowTestCase):
       self.assertTrue(serialized_sp[0].numpy())  # check non-empty
 
   def testSerializeManySparse(self):
-    sp_input = tf.SparseTensor(
+    sp_input = tf.sparse.SparseTensor(
         indices=tf.constant([[0, 1]], dtype=tf.int64),
         values=tf.constant([2], dtype=tf.int64),
         dense_shape=[1, 2])


### PR DESCRIPTION
- Afaik, tf.SparseTensor is currently just an alias for tf.sparse.SparseTensor. But since the later might get removed in the future, suggest replacing usage with the more consistent alias.

- Change "repeat" to "tf.repeat" for consistency in this doc and easier to copy and experiment with the code.