### PR TITLE
Handle CUPTI_ERROR_MAX_LIMIT_REACHED and disable TF tracing

### DIFF
--- a/tensorflow/core/profiler/internal/gpu/cupti_tracer.h
+++ b/tensorflow/core/profiler/internal/gpu/cupti_tracer.h
@@ -241,6 +241,8 @@ class CuptiTracer {
   bool IsAvailable() const;
   bool NeedRootAccess() const { return need_root_access_; }
 
+  bool ExternalProfilerInUse() const;
+
   void Enable(const CuptiTracerOptions& option, CuptiTraceCollector* collector);
   void Disable();
 

--- a/tensorflow/core/profiler/internal/gpu/device_tracer.cc
+++ b/tensorflow/core/profiler/internal/gpu/device_tracer.cc
@@ -513,6 +513,7 @@ class GpuTracer : public profiler::ProfilerInterface {
   Status Stop() override;
   Status CollectData(RunMetadata* run_metadata) override;
   Status CollectData(XSpace* space) override;
+  bool ExternalProfilerInUse() override;
 
  private:
   Status DoStart();
@@ -672,6 +673,13 @@ Status GpuTracer::CollectData(XSpace* space) {
     }
   }
   return errors::Internal("Invalid profiling state: ", profiling_state_);
+}
+
+bool GpuTracer::ExternalProfilerInUse() {
+  if (cupti_tracer_->ExternalProfilerInUse()) {
+    return true;
+  }
+  return false;
 }
 
 // Not in anonymous namespace for testing purposes.

--- a/tensorflow/core/profiler/internal/profiler_interface.h
+++ b/tensorflow/core/profiler/internal/profiler_interface.h
@@ -50,6 +50,11 @@ class ProfilerInterface {
   // After this or the overload above are called once, subsequent calls might
   // return empty data.
   virtual Status CollectData(XSpace* space) = 0;
+
+  // Finds if external profiler that prevents internal profiling exists.
+  virtual bool ExternalProfilerInUse() {
+    return false;
+  } 
 };
 
 }  // namespace profiler

--- a/tensorflow/core/profiler/lib/profiler_session.cc
+++ b/tensorflow/core/profiler/lib/profiler_session.cc
@@ -158,12 +158,23 @@ ProfilerSession::ProfilerSession(const ProfileOptions& options)
 #endif
   status_ = Status::OK();
 
+  bool external_profiler = false;
   for (auto& profiler : profilers_) {
-    auto start_status = profiler->Start();
-    if (!start_status.ok()) {
-      LOG(WARNING) << "Encountered error while starting profiler: "
-                   << start_status.ToString();
+    if (profiler->ExternalProfilerInUse()) {
+      external_profiler = true;
     }
+  }
+  if (!external_profiler) {
+    for (auto& profiler : profilers_) {
+      auto start_status = profiler->Start();
+      if (!start_status.ok()) {
+        LOG(WARNING) << "Encountered error while starting profiler: "
+                     << start_status.ToString();
+      }
+    }
+  } else {
+    LOG(WARNING) << "TensorFlow profiling disabled because an external profiler"
+                 << " is already in use.";
   }
 }
 


### PR DESCRIPTION
This PR fixes an issue caused by multiple processes attempting to use CUPTI simultaneously. For example, when using NVIDIA Nsight System with TF tracing at the same time (both rely on CUPTI APIs), users will get wrong TF tracing and incomplete Nsight reports.

According to https://docs.nvidia.com/cupti/Cupti/r_limitations.html#r_limitations:

> The application which calls CUPTI APIs cannot be used with Nvidia tools like nvprof, Nvidia Visual Profiler, Nsight Compute, Nsight Systems, Nvidia Nsight Visual Studio Edition, cuda-gdb and cuda-memcheck.

So, we should avoid calling CUPTI APIs if the function cuptiSubscribe() detects CUPTI_ERROR_MAX_LIMIT_REACHED.

In this PR, we let TensorFlow issue a warning when that CUPTI_ERROR_MAX_LIMIT_REACHED is detected and skip all the following CUPTI calls. Then, the external profiling tool can have exclusive access to CUPTI APIs.

FYI. @nluehr 