### PR TITLE
Add missing dependencies download command

### DIFF
--- a/tensorflow/lite/tools/pip_package/README.md
+++ b/tensorflow/lite/tools/pip_package/README.md
@@ -8,6 +8,7 @@ Python without requiring the rest of TensorFlow.
 To build a binary wheel run this script:
 ```
 sudo apt install swig libjpeg-dev zlib1g-dev python3-dev python3-numpy
+sh tensorflow/lite/tools/make/download_dependencies.sh
 sh tensorflow/lite/tools/pip_package/build_pip_package.sh
 ```
 That will print out some output and a .whl file. You can then install that


### PR DESCRIPTION
It takes me a lot time to fix this issue:

```
./tensorflow/lite/schema/schema_generated.h:21:37: fatal error: flatbuffers/flatbuffers.h: No such file or directory
```
And finally, I found this: https://www.tensorflow.org/lite/guide/build_rpi
So there is a missing command to download dependencies before build in the README file.

By the way, this pr should close #33983 and close #34423