### PR TITLE
[MLIR/XLA] add a pass to outline kLoop/kInput fusion pattern in xla_hlo dialect

### DIFF
--- a/tensorflow/compiler/mlir/xla/BUILD
+++ b/tensorflow/compiler/mlir/xla/BUILD
@@ -35,6 +35,7 @@ filegroup(
         "ir/hlo_ops.td",
         "ir/hlo_ops_base.td",
         "ir/hlo_utils.td",
+        "ir/infer_fusibility_op_interface.td",
         "ir/lhlo_ops.td",
         "@llvm-project//mlir:OpBaseTdFiles",
         "@llvm-project//mlir:include/mlir/Interfaces/InferTypeOpInterface.td",
@@ -116,6 +117,42 @@ gentbl(
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "transforms/canonicalize.td",
     td_srcs = [":hlo_ops_td_files"],
+)
+
+gentbl(
+    name = "infer_fusibility_op_interface_gen",
+    tbl_outs = [
+        (
+            "-gen-op-interface-decls",
+            "ir/infer_fusibility_op_interface.h.inc",
+        ),
+        (
+            "-gen-op-interface-defs",
+            "ir/infer_fusibility_op_interface.cc.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "ir/infer_fusibility_op_interface.td",
+    td_srcs = [
+        ":hlo_ops_td_files",
+    ],
+)
+
+cc_library(
+    name = "infer_fusibility_op_interface",
+    srcs = [
+        "ir/infer_fusibility_op_interface.cc",
+    ],
+    hdrs = [
+        "ir/infer_fusibility_op_interface.h",
+        "ir/infer_fusibility_op_interface.h.inc",
+    ],
+    deps = [
+        ":infer_fusibility_op_interface_gen",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+    ],
+    alwayslink = 1,
 )
 
 cc_library(
@@ -369,6 +406,40 @@ cc_library(
     alwayslink = 1,
 )
 
+cc_library(
+    name = "cycle_detector",
+    srcs = ["transforms/cycle_detector.cc"],
+    hdrs = ["transforms/cycle_detector.h"],
+    deps = [
+        "@llvm-project//llvm:core",
+    ],
+    alwayslink = 1,
+)
+
+tf_cc_test(
+    name = "cycle_detector_test",
+    srcs = ["transforms/cycle_detector_test.cc"],
+    deps = [
+        ":cycle_detector",
+        "//tensorflow/compiler/xla:test",
+        "//tensorflow/core:test_main",
+    ],
+)
+
+cc_library(
+    name = "xla_hlo_fusion",
+    srcs = ["transforms/xla_hlo_fusion.cc"],
+    deps = [
+        ":cycle_detector",
+        ":hlo",
+        "@llvm-project//llvm:core",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:StandardOps",
+        "@llvm-project//mlir:Support",
+    ],
+    alwayslink = 1,
+)
+
 gentbl(
     name = "xla_legalize_to_standard_inc_gen",
     tbl_outs = [
@@ -555,6 +626,7 @@ cc_library(
         ":convert_op_folder",
         ":hlo_ops_base_inc_gen",
         ":hlo_ops_inc_gen",
+        ":infer_fusibility_op_interface",
         ":xla_canonicalize_inc_gen",
         "@com_google_absl//absl/container:flat_hash_set",
         "@llvm-project//llvm:support",
@@ -824,6 +896,7 @@ genrule(
         ":ir/hlo_ops.td",
         ":ir/hlo_ops_base.td",
         ":ir/hlo_utils.td",
+        ":ir/infer_fusibility_op_interface.td",
     ],
     outs = ["operator_writers.inc"],
     cmd = ("$(location :operator_writer_gen) " +
@@ -859,6 +932,7 @@ cc_library(
         ":lhlo_legalize_to_gpu",
         ":lhlo_legalize_to_parallel_loops",
         ":xla_dialect_registration",
+        ":xla_hlo_fusion",
         ":xla_hlo_to_lhlo_with_xla",
         ":xla_legalize_control_flow",
         ":xla_legalize_tf",

--- a/tensorflow/compiler/mlir/xla/ir/hlo_ops.h
+++ b/tensorflow/compiler/mlir/xla/ir/hlo_ops.h
@@ -30,6 +30,7 @@ limitations under the License.
 #include "mlir/IR/Types.h"  // from @llvm-project
 #include "mlir/Interfaces/InferTypeOpInterface.h"  // from @llvm-project
 #include "mlir/Interfaces/SideEffectInterfaces.h"  // from @llvm-project
+#include "tensorflow/compiler/mlir/xla/ir/infer_fusibility_op_interface.h"
 
 namespace mlir {
 class OpBuilder;

--- a/tensorflow/compiler/mlir/xla/ir/hlo_ops.td
+++ b/tensorflow/compiler/mlir/xla/ir/hlo_ops.td
@@ -26,6 +26,7 @@ include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "tensorflow/compiler/mlir/xla/ir/hlo_ops_base.td"
 include "tensorflow/compiler/mlir/xla/ir/hlo_utils.td"
+include "tensorflow/compiler/mlir/xla/ir/infer_fusibility_op_interface.td"
 
 def HLO_Dialect : Dialect {
   let name = "xla_hlo";
@@ -117,7 +118,7 @@ def HLO_CreateTokenOp : HLO_Op<"create_token", [NoSideEffect]> {
 
 class HLO_UnaryElementwiseOp<string mnemonic, list<OpTrait> traits,
       Type TensorType>: HLO_Op<mnemonic,
-        !listconcat(traits, [InferShapedTypeOpInterface])> {
+        !listconcat(traits, [InferShapedTypeOpInterface, InferFusibilityOpInterface])> {
     let arguments = (ins TensorType:$operand);
     let results = (outs TensorType);
     let extraClassDeclaration = [{
@@ -131,6 +132,12 @@ class HLO_UnaryElementwiseOp<string mnemonic, list<OpTrait> traits,
           OpBuilder& builder, SmallVectorImpl<Value>& reifiedReturnShapes) {
         return deriveShapeFromFirstOperand(&builder, getOperation(),
                                            &reifiedReturnShapes);
+      }
+      bool inferInputOutputShapeEquality(int input, int output) {
+        return true;
+      }
+      llvm::Optional<Value> inferEffectiveWorkloadShape() {
+        return getOperation()->getResult(0);
       }
     }];
 }
@@ -257,7 +264,7 @@ def HLO_TanhOp: HLO_UnaryElementwiseOp<"tanh",
 // See https://www.tensorflow.org/xla/operation_semantics#element-wise_binary_arithmetic_operations
 
 class HLO_BinaryElementwiseOp<string mnemonic, list<OpTrait> traits> :
-        HLO_Op<mnemonic, !listconcat(traits, [InferShapedTypeOpInterface])> {
+        HLO_Op<mnemonic, !listconcat(traits, [InferShapedTypeOpInterface, InferFusibilityOpInterface])> {
   let arguments = (ins
     HLO_Tensor:$lhs,
     HLO_Tensor:$rhs
@@ -274,6 +281,15 @@ class HLO_BinaryElementwiseOp<string mnemonic, list<OpTrait> traits> :
         OpBuilder& builder, SmallVectorImpl<Value>& reifiedReturnShapes) {
       return deriveShapeFromFirstOperand(&builder, getOperation(),
                                          &reifiedReturnShapes);
+    }
+    bool inferInputsShapeEquality(int lhs, int rhs) {
+      return true;
+    }
+    bool inferInputOutputShapeEquality(int input, int output) {
+      return true;
+    }
+    llvm::Optional<Value> inferEffectiveWorkloadShape() {
+      return getOperation()->getResult(0);
     }
   }];
 
@@ -598,7 +614,8 @@ def HLO_AllToAllOp : HLO_Op<"all_to_all",
 def HLO_ReduceOp: HLO_Op<"reduce", [
       RecursiveSideEffects,
       SameVariadicOperandSize,
-      SingleBlockImplicitTerminator<"ReturnOp">
+      SingleBlockImplicitTerminator<"ReturnOp">,
+      InferFusibilityOpInterface
     ]>, BASE_HLO_ReduceOp {
   let arguments = (ins
     Variadic<HLO_TensorOrTuple>:$operands,
@@ -612,6 +629,15 @@ def HLO_ReduceOp: HLO_Op<"reduce", [
     "OpBuilder &, OperationState &state, ValueRange operands, "
     "ValueRange init_values, DenseIntElementsAttr dimensions"
   >];
+
+  let extraClassDeclaration = [{
+    bool isFusibleWithConsumer() {
+      return false;
+    }
+    llvm::Optional<Value> inferEffectiveWorkloadShape() {
+      return getOperation()->getOperand(0);
+    }
+  }];
 
   let hasFolder = 1;
 
@@ -1357,6 +1383,29 @@ def HLO_DequantizeOp : HLO_Op<"dequantize", [NoSideEffect]>,
 
   let results = (outs TensorOf<[BF16]>:$output);
 
+  let hasCustomHLOConverter = 1;
+}
+
+def HLO_FusionOp : HLO_Op<"fusion", []> {
+  let summary = "Fusion operator";
+  let description = [{
+    Models the fusion instruction.
+
+    A fusion op is consists of a group of basic ops (represented as a region
+    attached to it). It serves as a hint to the backend that it is beneficial
+    to emit the contained ops into a single loop nest or kernel.
+  }];
+  let regions = (region SizedRegion<1>:$fused_computation);
+
+  let arguments = (ins
+    Variadic<HLO_TensorOrTuple>:$operands
+  );
+
+  let results = (outs
+    Variadic<HLO_TensorOrTuple>:$results
+  );
+
+  // FusionOp has special conversion logic to HLO.
   let hasCustomHLOConverter = 1;
 }
 

--- a/tensorflow/compiler/mlir/xla/ir/infer_fusibility_op_interface.cc
+++ b/tensorflow/compiler/mlir/xla/ir/infer_fusibility_op_interface.cc
@@ -1,0 +1,22 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/compiler/mlir/xla/ir/infer_fusibility_op_interface.h"
+
+namespace mlir {
+
+#include "tensorflow/compiler/mlir/xla/ir/infer_fusibility_op_interface.cc.inc"
+
+} // namespace mlir

--- a/tensorflow/compiler/mlir/xla/ir/infer_fusibility_op_interface.h
+++ b/tensorflow/compiler/mlir/xla/ir/infer_fusibility_op_interface.h
@@ -1,0 +1,28 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_COMPILER_MLIR_XLA_IR_INFER_FUSIBILITY_OP_INTERFACE_H_
+#define TENSORFLOW_COMPILER_MLIR_XLA_IR_INFER_FUSIBILITY_OP_INTERFACE_H_
+
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/StandardTypes.h"
+
+namespace mlir {
+
+#include "tensorflow/compiler/mlir/xla/ir/infer_fusibility_op_interface.h.inc"
+
+} // namespace mlir
+
+#endif // TENSORFLOW_COMPILER_MLIR_XLA_IR_INFER_FUSIBILITY_OP_INTERFACE_H_

--- a/tensorflow/compiler/mlir/xla/ir/infer_fusibility_op_interface.td
+++ b/tensorflow/compiler/mlir/xla/ir/infer_fusibility_op_interface.td
@@ -1,0 +1,161 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// This file contains inferFusiblityOpInterface, which is used to guide
+// fusion decision.
+
+#ifndef MLIR_INFER_FUSIBILITY_OP_INTERFACE
+#define MLIR_INFER_FUSIBILITY_OP_INTERFACE
+
+include "mlir/IR/OpBase.td"
+
+// OpInterface to query if an op is fusible and to query the shape equality
+// constraint among the inputs and outputs of an op.
+def InferFusibilityOpInterface : OpInterface<"InferFusibilityOpInterface"> {
+  let description = [{
+    Interface to query if an op is fusible and to query the shape equality
+    constraint among the inputs and outputs of an op.
+  }];
+
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/[{If true, this op can be fused with its operands
+      }],
+      /*retTy=*/"bool",
+      /*methodName=*/"isFusibleWithOperand",
+      /*args=*/(ins),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        /// Returns whether this op can be fused with its operands
+        return true;
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{If true, this op can be fused with its consumers
+      }],
+      /*retTy=*/"bool",
+      /*methodName=*/"isFusibleWithConsumer",
+      /*args=*/(ins),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        /// Return whether this op can be fused withh its consumers
+        return true;
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/"Return whether two inputs have the same shape (assuming no"
+               "implicit broadcasting).",
+      /*retTy=*/"bool",
+      /*methodName=*/"inferInputsShapeEquality",
+      /*args=*/(ins "int":$lhs, "int":$rhs),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        /// Return whether two inputs have the same shape.
+        Operation *op = this->getOperation();
+        assert(lhs < op->getNumOperands() && lhs >= 0 &&
+               rhs < op->getNumOperands() && rhs >= 0);
+        if (lhs == rhs) return true;
+
+        // if both lhs and rhs have static shapes, check them directly
+        Type lhs_ty = op->getOperand(lhs).getType();
+        Type rhs_ty = op->getOperand(rhs).getType();
+        auto lhs_shape_type = lhs_ty.dyn_cast_or_null<RankedTensorType>();
+        auto rhs_shape_type = rhs_ty.dyn_cast_or_null<RankedTensorType>();
+        if (!lhs_shape_type || !lhs_shape_type.hasStaticShape() ||
+            !rhs_shape_type || !rhs_shape_type.hasStaticShape() ||
+            lhs_shape_type.getRank() != rhs_shape_type.getRank()) {
+          return false;
+        }
+        return lhs_shape_type.getShape() == rhs_shape_type.getShape();
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/"Return whether two outputs have the same shape (assuming no"
+               " implicit broadcasting).",
+      /*retTy=*/"bool",
+      /*methodName=*/"inferOutputsShapeEquality",
+      /*args=*/(ins "int":$lhs, "int":$rhs),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        /// Return whether two outputs have the same shape.
+        Operation *op = this->getOperation();
+        assert(lhs < op->getNumResults() && lhs >= 0 &&
+               rhs < op->getNumResults() && rhs >= 0);
+        if (lhs == rhs) return true;
+
+        // if both lhs and rhs have static shapes, check them directly
+        Type lhs_ty = op->getResult(lhs).getType();
+        Type rhs_ty = op->getResult(rhs).getType();
+        auto lhs_shape_type = lhs_ty.dyn_cast_or_null<RankedTensorType>();
+        auto rhs_shape_type = rhs_ty.dyn_cast_or_null<RankedTensorType>();
+        if (!lhs_shape_type || !lhs_shape_type.hasStaticShape() ||
+            !rhs_shape_type || !rhs_shape_type.hasStaticShape() ||
+            lhs_shape_type.getRank() != rhs_shape_type.getRank()) {
+          return false;
+        }
+        return lhs_shape_type.getShape() == rhs_shape_type.getShape();
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/"Return whether the input and the output have the same"
+               " shape (assuming no implicit broadcasting).",
+      /*retTy=*/"bool",
+      /*methodName=*/"inferInputOutputShapeEquality",
+      /*args=*/(ins "int":$input, "int":$output),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        /// Return whether the input and the output have the same shape.
+        Operation *op = this->getOperation();
+        assert(input < op->getNumOperands() && input >= 0 &&
+               output < op->getNumResults() && output >= 0);
+
+        // if both input and output have static shapes, check them directly
+        Type input_ty = op->getOperand(input).getType();
+        Type output_ty = op->getResult(output).getType();
+        auto input_shape_type = input_ty.dyn_cast_or_null<RankedTensorType>();
+        auto output_shape_type = output_ty.dyn_cast_or_null<RankedTensorType>();
+        if (!input_shape_type || !input_shape_type.hasStaticShape() ||
+            !output_shape_type || !output_shape_type.hasStaticShape() ||
+            input_shape_type.getRank() != output_shape_type.getRank()) {
+          return false;
+        }
+        return input_shape_type.getShape() == output_shape_type.getShape();
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{Return the effective workload shape for the operation.
+
+      Here the effective workload shape roughly represents the maximum
+      parallelism can be used during the codegen stage. It's used to check
+      the shape-compatibility of the operation. During fusion, we only
+      try to fuse shape-compatible ops for performace.
+      For example, the effective workload shape of an elementwise op is its
+      output shape, while the effective workload shape of a reduction op may
+      be its operand shape.
+      Return None if such an inference is not possible.
+      }],
+      /*retTy=*/"llvm::Optional<Value>",
+      /*methodName=*/"inferEffectiveWorkloadShape",
+      /*args=*/(ins),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        /// Return effective workload size if possible, otherwise None.
+        return {};
+      }]
+    >,
+  ];
+}
+
+#endif

--- a/tensorflow/compiler/mlir/xla/mlir_hlo_to_hlo.cc
+++ b/tensorflow/compiler/mlir/xla/mlir_hlo_to_hlo.cc
@@ -937,6 +937,11 @@ LogicalResult ExportXlaOp(WhileOp op, OpLoweringContext ctx) {
   return success();
 }
 
+LogicalResult ExportXlaOp(FusionOp op, OpLoweringContext ctx) {
+  // TODO: currently not supported.
+  return failure();
+}
+
 }  // namespace
 }  // namespace xla_hlo
 }  // namespace mlir

--- a/tensorflow/compiler/mlir/xla/tests/xla-hlo-fusion.mlir
+++ b/tensorflow/compiler/mlir/xla/tests/xla-hlo-fusion.mlir
@@ -1,0 +1,97 @@
+// RUN: tf-opt %s -xla-hlo-fusion -split-input-file | FileCheck %s --dump-input-on-failure
+
+// CHECK-LABEL: func @multi_outputs_same
+func @multi_outputs_same(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) -> (tensor<?x?xf32>, tensor<?x?xf32>) {
+  %0 = "xla_hlo.add"(%arg0, %arg1) : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+  %1 = "xla_hlo.subtract"(%arg0, %0) : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+  %2 = "xla_hlo.add"(%1, %1) : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+  // CHECK: %[[RET:.*]]:2 = "xla_hlo.fusion"
+  // CHECK-NEXT: xla_hlo.add
+  // CHECK-NEXT: xla_hlo.subtract
+  // CHECK-NEXT: xla_hlo.add
+  // CHECK-NEXT: xla_hlo.return
+  return %1, %2 : tensor<?x?xf32>, tensor<?x?xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @multi_outputs_same_2
+func @multi_outputs_same_2(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) -> (tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>) {
+  %0 = "xla_hlo.abs"(%arg0) : (tensor<?x?xf32>) -> tensor<?x?xf32>
+  %1 = "xla_hlo.abs"(%arg1) : (tensor<?x?xf32>) -> tensor<?x?xf32>
+  %2 = "xla_hlo.add"(%0, %1) : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+  %3 = "xla_hlo.abs"(%0) : (tensor<?x?xf32>) -> tensor<?x?xf32>
+  %4 = "xla_hlo.abs"(%1) : (tensor<?x?xf32>) -> tensor<?x?xf32>
+  // CHECK: %[[RET:.*]]:3 = "xla_hlo.fusion"
+  // CHECK-NEXT: xla_hlo.abs
+  // CHECK-NEXT: xla_hlo.abs
+  // CHECK-NEXT: xla_hlo.add
+  // CHECK-NEXT: xla_hlo.abs
+  // CHECK-NEXT: xla_hlo.abs
+  // CHECK-NEXT: xla_hlo.return
+  return %2, %3, %4 : tensor<?x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @multi_outputs_not_sure_same
+func @multi_outputs_not_sure_same(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) -> (tensor<?x?xf32>, tensor<?x?xf32>) {
+  %0 = "xla_hlo.add"(%arg0, %arg0) : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+  // CHECK-NOT: xla_hlo.fusion
+  %1 = "xla_hlo.subtract"(%arg1, %arg1) : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %0, %1 : tensor<?x?xf32>, tensor<?x?xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @reduce
+func @reduce(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) -> (tensor<?x?xf32>, tensor<?xf32>) {
+  %0 = "xla_hlo.add"(%arg0, %arg1) : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+  %1 = "xla_hlo.subtract"(%arg0, %0) : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+  // CHECK: %[[RET0:.*]] = "xla_hlo.fusion"
+  // CHECK-NEXT: xla_hlo.add
+  // CHECK-NEXT: xla_hlo.subtract
+  // CHECK-NEXT: xla_hlo.return
+  // Currently we do not support fuse arguments and ops without direct producer-consumer
+  // relationship. Thus Reduce Op should not be fused with above two ops.
+
+  %2 = xla_hlo.constant dense<0.000000e+00> : tensor<f32>
+  %3 = "xla_hlo.reduce"(%arg0, %2) ( {
+  ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
+    %4 = "xla_hlo.add"(%arg2, %arg3) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+    "xla_hlo.return"(%4) : (tensor<f32>) -> ()
+  }) {dimensions = dense<[1]> : tensor<1xi64>} : (tensor<?x?xf32>, tensor<f32>) -> tensor<?xf32>
+  %4 = "xla_hlo.add"(%3, %3) : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+  // Above two ops should not be fused since reduce op can not be
+  // fused with its consumer.
+  // CHECK-NOT: xla_hlo.fusion
+
+  return %1, %4 : tensor<?x?xf32>, tensor<?xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @reduce_2
+func @reduce_2(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) -> (tensor<?x?xf32>, tensor<?xf32>) {
+  %0 = "xla_hlo.add"(%arg0, %arg1) : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+  %1 = "xla_hlo.subtract"(%arg0, %0) : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+
+  %2 = xla_hlo.constant dense<0.000000e+00> : tensor<f32>
+  %3 = "xla_hlo.reduce"(%1, %2) ( {
+  ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
+    %4 = "xla_hlo.add"(%arg2, %arg3) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+    "xla_hlo.return"(%4) : (tensor<f32>) -> ()
+  }) {dimensions = dense<[1]> : tensor<1xi64>} : (tensor<?x?xf32>, tensor<f32>) -> tensor<?xf32>
+  // CHECK: %[[RET0:.*]]:2 = "xla_hlo.fusion"
+  // CHECK-NEXT: xla_hlo.add
+  // CHECK-NEXT: xla_hlo.subtract
+  // CHECK-NEXT: xla_hlo.constant
+  // CHECK-NEXT: xla_hlo.reduce
+  // CHECK: xla_hlo.return
+
+  // Following op should not be fused with the above ops since reduce op can not be
+  // fused with its consumer.
+  // CHECK-NOT: xla_hlo.fusion
+  %4 = "xla_hlo.add"(%3, %3) : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+  return %1, %4 : tensor<?x?xf32>, tensor<?xf32>
+}

--- a/tensorflow/compiler/mlir/xla/transforms/cycle_detector.cc
+++ b/tensorflow/compiler/mlir/xla/transforms/cycle_detector.cc
@@ -1,0 +1,339 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/compiler/mlir/xla/transforms/cycle_detector.h"
+
+#include <algorithm>
+#include "llvm/ADT/DenseSet.h"
+
+namespace mlir {
+
+namespace {
+
+using NodeSet = llvm::DenseSet<int32_t>;
+using OrderedNodeSet = OrderedSet<int32_t>;
+
+template <typename T>
+struct VecStruct {
+  typedef llvm::SmallVector<T, 4> type;
+};
+template <typename T>
+using Vec = typename VecStruct<T>::type;
+
+struct Node {
+  // rank number assigned by Pearce-Kelly algorithm
+  int32_t rank;
+  // Temporary marker used by depth-first-search
+  bool visited;
+  // User-supplied data
+  void* data;
+  // List of immediate predecessor nodes in graph
+  OrderedNodeSet in;
+  // List of immediate successor nodes in graph
+  OrderedNodeSet out;
+};
+
+}  // namespace
+
+
+struct GraphCycles::Rep {
+  Vec<Node*> nodes;
+  // Indices for unused entries in nodes
+  Vec<int32_t> free_nodes;
+
+  // Temporary state.
+  // Results of forward DFS
+  Vec<int32_t> deltaf;
+  // Results of backward DFS
+  Vec<int32_t> deltab;
+  // All nodes to reprocess
+  Vec<int32_t> list;
+  // Rank values to assign to list entries
+  Vec<int32_t> merged;
+  // Emulates recursion stack when doing depth first search
+  Vec<int32_t> stack;
+};
+
+GraphCycles::GraphCycles(int32_t num_nodes) : rep_(new Rep) {
+  rep_->nodes.reserve(num_nodes);
+  for (int32_t i = 0; i < num_nodes; ++i) {
+    Node* n = new Node;
+    n->visited = false;
+    n->data = nullptr;
+    n->rank = rep_->nodes.size();
+    rep_->nodes.push_back(n);
+  }
+}
+
+GraphCycles::~GraphCycles() {
+  for (Vec<Node*>::size_type i = 0, e = rep_->nodes.size(); i < e; ++i) {
+    delete rep_->nodes[i];
+  }
+  delete rep_;
+}
+
+bool GraphCycles::HasEdge(int32_t x, int32_t y) const {
+  return rep_->nodes[x]->out.Contains(y);
+}
+
+void GraphCycles::RemoveEdge(int32_t x, int32_t y) {
+  rep_->nodes[x]->out.Erase(y);
+  rep_->nodes[y]->in.Erase(x);
+  // No need to update the rank assignment since a previous valid
+  // rank assignment remains valid after an edge deletion.
+}
+
+static bool ForwardDFS(GraphCycles::Rep* r, int32_t n, int32_t upper_bound);
+static void BackwardDFS(GraphCycles::Rep* r, int32_t n, int32_t lower_bound);
+static void Reorder(GraphCycles::Rep* r);
+static void Sort(const Vec<Node*>&, Vec<int32_t>* delta);
+static void MoveToList(GraphCycles::Rep* r, Vec<int32_t>* src, Vec<int32_t>* dst);
+static void ClearVisitedBits(GraphCycles::Rep* r, const Vec<int32_t>& nodes);
+
+bool GraphCycles::InsertEdge(int32_t x, int32_t y) {
+  if (x == y) return false;
+  Rep* r = rep_;
+  Node* nx = r->nodes[x];
+  if (!nx->out.Insert(y)) {
+    // Edge already exists.
+    return true;
+  }
+
+  Node* ny = r->nodes[y];
+  ny->in.Insert(x);
+
+  if (nx->rank <= ny->rank) {
+    // New edge is consistent with existing rank assignment.
+    return true;
+  }
+
+  // Current rank assignments are incompatible with the new edge.  Recompute.
+  // We only need to consider nodes that fall in the range [ny->rank,nx->rank].
+  if (ForwardDFS(r, y, nx->rank)) {
+    // Found a cycle.  Undo the insertion and tell caller.
+    nx->out.Erase(y);
+    ny->in.Erase(x);
+    // Since we do not call Reorder() on this path, clear any visited
+    // markers left by ForwardDFS.
+    ClearVisitedBits(r, r->deltaf);
+    return false;
+  }
+  BackwardDFS(r, x, ny->rank);
+  Reorder(r);
+  return true;
+}
+
+// Follows the edges from producer to consumer and searchs if the node having
+// rank `n` can reach the node having rank `upper_bound` using a DFS search.
+// When doing DFS search, We only consider the pathes that satisfy the ranks
+// of the nodes of the path are all smaller than `upper_bound`.
+//
+// Returns true if such path exists.
+static bool ForwardDFS(GraphCycles::Rep* r, int32_t n, int32_t upper_bound) {
+  // Avoid recursion since stack space might be limited.
+  // We instead keep a stack of nodes to visit.
+  r->deltaf.clear();
+  r->stack.clear();
+  r->stack.push_back(n);
+  while (!r->stack.empty()) {
+    n = r->stack.back();
+    r->stack.pop_back();
+    Node* nn = r->nodes[n];
+    if (nn->visited) continue;
+
+    nn->visited = true;
+    r->deltaf.push_back(n);
+
+    for (auto w : nn->out.GetSequence()) {
+      Node* nw = r->nodes[w];
+      if (nw->rank == upper_bound) {
+        return true;
+      }
+      if (!nw->visited && nw->rank < upper_bound) {
+        r->stack.push_back(w);
+      }
+    }
+  }
+  return false;
+}
+
+// Follows the edges from consumer to producer and visit all the nodes that
+// is reachable from node `n` and have rank larger than `lower_bound`.
+static void BackwardDFS(GraphCycles::Rep* r, int32_t n, int32_t lower_bound) {
+  r->deltab.clear();
+  r->stack.clear();
+  r->stack.push_back(n);
+  while (!r->stack.empty()) {
+    n = r->stack.back();
+    r->stack.pop_back();
+    Node* nn = r->nodes[n];
+    if (nn->visited) continue;
+
+    nn->visited = true;
+    r->deltab.push_back(n);
+
+    for (auto w : nn->in.GetSequence()) {
+      Node* nw = r->nodes[w];
+      if (!nw->visited && lower_bound < nw->rank) {
+        r->stack.push_back(w);
+      }
+    }
+  }
+}
+
+// Recomputes rank assignments to make them compatible with the edges (producer
+// has smaller rank than its consumer)
+static void Reorder(GraphCycles::Rep* r) {
+  Sort(r->nodes, &r->deltab);
+  Sort(r->nodes, &r->deltaf);
+
+  // Adds contents of delta lists to list (backwards deltas first).
+  r->list.clear();
+  MoveToList(r, &r->deltab, &r->list);
+  MoveToList(r, &r->deltaf, &r->list);
+
+  // Produce sorted list of all ranks that will be reassigned.
+  r->merged.resize(r->deltab.size() + r->deltaf.size());
+  std::merge(r->deltab.begin(), r->deltab.end(), r->deltaf.begin(),
+             r->deltaf.end(), r->merged.begin());
+
+  // Assign the ranks in order to the collected list.
+  for (Vec<int32_t>::size_type i = 0, e = r->list.size(); i < e; ++i) {
+    r->nodes[r->list[i]]->rank = r->merged[i];
+  }
+}
+
+// Sorts nodes in the vector according to their ranks. Small rank first.
+static void Sort(const Vec<Node*>& nodes, Vec<int32_t>* delta) {
+  struct ByRank {
+    const Vec<Node*>* nodes;
+    bool operator()(int32_t a, int32_t b) const {
+      return (*nodes)[a]->rank < (*nodes)[b]->rank;
+    }
+  };
+  ByRank cmp;
+  cmp.nodes = &nodes;
+  std::sort(delta->begin(), delta->end(), cmp);
+}
+
+// Collects ranks of nodes in vector `src` to vector `dst`
+static void MoveToList(GraphCycles::Rep* r, Vec<int32_t>* src, Vec<int32_t>* dst) {
+  for (Vec<int32_t>::size_type i = 0, e = src->size(); i < e; i++) {
+    int32_t w = (*src)[i];
+    // Replace src entry with its rank
+    (*src)[i] = r->nodes[w]->rank;
+    // Prepare for future DFS calls
+    r->nodes[w]->visited = false;
+    dst->push_back(w);
+  }
+}
+
+// Clears bookkeeping fileds used during the last DFS process.
+static void ClearVisitedBits(GraphCycles::Rep* r, const Vec<int32_t>& nodes) {
+  for (Vec<int32_t>::size_type i = 0, e = nodes.size(); i < e; i++) {
+    r->nodes[nodes[i]]->visited = false;
+  }
+}
+
+bool GraphCycles::IsReachable(int32_t x, int32_t y) {
+  if (x == y) return true;
+  Rep* r = rep_;
+  Node* nx = r->nodes[x];
+  Node* ny = r->nodes[y];
+
+  if (nx->rank >= ny->rank) {
+    // x cannot reach y since it is after it in the topological ordering
+    return false;
+  }
+
+  // See if x can reach y using a DFS search that is limited to y's rank
+  bool reachable = ForwardDFS(r, x, ny->rank);
+
+  // Clear any visited markers left by ForwardDFS.
+  ClearVisitedBits(r, r->deltaf);
+  return reachable;
+}
+
+llvm::Optional<int32_t> GraphCycles::ContractEdge(int32_t a, int32_t b) {
+  assert(HasEdge(a, b));
+  RemoveEdge(a, b);
+
+  if (IsReachable(a, b)) {
+    // Restore the graph to its original state.
+    InsertEdge(a, b);
+    return {};
+  }
+
+  if (rep_->nodes[b]->in.Size() + rep_->nodes[b]->out.Size() >
+      rep_->nodes[a]->in.Size() + rep_->nodes[a]->out.Size()) {
+    // Swap "a" and "b" to minimize copying.
+    std::swap(a, b);
+  }
+
+  Node* nb = rep_->nodes[b];
+  OrderedNodeSet out = std::move(nb->out);
+  OrderedNodeSet in = std::move(nb->in);
+  for (int32_t y : out.GetSequence()) {
+    rep_->nodes[y]->in.Erase(b);
+  }
+  for (int32_t y : in.GetSequence()) {
+    rep_->nodes[y]->out.Erase(b);
+  }
+  rep_->free_nodes.push_back(b);
+
+  rep_->nodes[a]->out.Reserve(rep_->nodes[a]->out.Size() + out.Size());
+  for (int32_t y : out.GetSequence()) {
+    InsertEdge(a, y);
+  }
+
+  rep_->nodes[a]->in.Reserve(rep_->nodes[a]->in.Size() + in.Size());
+  for (int32_t y : in.GetSequence()) {
+    InsertEdge(y, a);
+  }
+
+  // Note, if the swap happened it might be what originally was called "b".
+  return a;
+}
+
+std::vector<int32_t> GraphCycles::SuccessorsCopy(int32_t node) const {
+  return rep_->nodes[node]->out.GetSequence();
+}
+
+namespace {
+void SortInPostOrder(const Vec<Node*>& nodes,
+                     std::vector<int32_t>* to_sort) {
+  std::sort(to_sort->begin(), to_sort->end(), [&](int32_t a, int32_t b) {
+    return nodes[a]->rank > nodes[b]->rank;
+  });
+}
+}  // namespace
+
+std::vector<int32_t> GraphCycles::AllNodesInPostOrder() const {
+  llvm::DenseSet<int32_t> free_nodes_set;
+  for (int32_t n : rep_->free_nodes) free_nodes_set.insert(n);
+
+  std::vector<int32_t> all_nodes;
+  all_nodes.reserve(rep_->nodes.size() - free_nodes_set.size());
+  for (size_t i = 0, e = rep_->nodes.size(); i < e; i++) {
+    if (!free_nodes_set.count(i)) {
+      all_nodes.push_back(i);
+    }
+  }
+
+  SortInPostOrder(rep_->nodes, &all_nodes);
+  return all_nodes;
+}
+
+} // namespace mlir

--- a/tensorflow/compiler/mlir/xla/transforms/cycle_detector.h
+++ b/tensorflow/compiler/mlir/xla/transforms/cycle_detector.h
@@ -1,0 +1,164 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_COMPILER_MLIR_XLA_TRANSFORMS_CYCLE_DETECTOR_H_
+#define TENSORFLOW_COMPILER_MLIR_XLA_TRANSFORMS_CYCLE_DETECTOR_H_
+
+#include <vector>
+#include "llvm/ADT/DenseMap.h"
+
+namespace mlir {
+
+// -------------------------------------------------------------------
+
+// This file contains a light version of GraphCycles implemented in
+// tensorflow/compiler/jit/graphcycles/graphcycles.h
+//
+// We re-implement it here because we do not want to rely
+// on TensorFlow data structures, and hence we can move
+// corresponding passes to llvm repo. easily in case necessnary.
+
+// --------------------------------------------------------------------
+
+// This is a set data structure that provides a deterministic iteration order.
+// The iteration order of elements only depends on the sequence of
+// inserts/deletes, so as long as the inserts/deletes happen in the same
+// sequence, the set will have the same iteration order.
+//
+// Assumes that T can be cheaply copied for simplicity.
+template <typename T>
+class OrderedSet {
+ public:
+  // Inserts `value` into the ordered set.  Returns true if the value was not
+  // present in the set before the insertion.
+  bool Insert(T value) {
+    bool new_insertion =
+        value_to_index_.insert({value, value_sequence_.size()}).second;
+    if (new_insertion) {
+      value_sequence_.push_back(value);
+    }
+    return new_insertion;
+  }
+
+  // Removes `value` from the set.  Assumes `value` is already present in the
+  // set.
+  void Erase(T value) {
+    auto it = value_to_index_.find(value);
+
+    // Since we don't want to move values around in `value_sequence_` we swap
+    // the value in the last position and with value to be deleted and then
+    // pop_back.
+    value_to_index_[value_sequence_.back()] = it->second;
+    std::swap(value_sequence_[it->second], value_sequence_.back());
+    value_sequence_.pop_back();
+    value_to_index_.erase(it);
+  }
+
+  void Reserve(size_t new_size) {
+    value_to_index_.reserve(new_size);
+    value_sequence_.reserve(new_size);
+  }
+
+  void Clear() {
+    value_to_index_.clear();
+    value_sequence_.clear();
+  }
+
+  bool Contains(T value) const { return value_to_index_.count(value); }
+  size_t Size() const { return value_sequence_.size(); }
+
+  const std::vector<T>& GetSequence() const { return value_sequence_; }
+
+ private:
+  // The stable order that we maintain through insertions and deletions.
+  std::vector<T> value_sequence_;
+
+  // Maps values to their indices in `value_sequence_`.
+  llvm::DenseMap<T, int> value_to_index_;
+};
+
+// ---------------------------------------------------------------------
+
+// GraphCycles detects the introduction of a cycle into a directed
+// graph that is being built up incrementally.
+//
+// Nodes are identified by small integers.  It is not possible to
+// record multiple edges with the same (source, destination) pair;
+// requests to add an edge where one already exists are silently
+// ignored.
+//
+// It is also not possible to introduce a cycle; an attempt to insert
+// an edge that would introduce a cycle fails and returns false.
+//
+// GraphCycles uses no internal locking; calls into it should be
+// serialized externally.
+
+// Performance considerations:
+//   Works well on sparse graphs, poorly on dense graphs.
+//   Extra information is maintained incrementally to detect cycles quickly.
+//   InsertEdge() is very fast when the edge already exists, and reasonably fast
+//   otherwise.
+//   FindPath() is linear in the size of the graph.
+// The current implementation uses O(|V|+|E|) space.
+
+class GraphCycles {
+ public:
+  GraphCycles(int32_t num_nodes);
+  ~GraphCycles();
+
+  // Attempt to insert an edge from x to y.  If the
+  // edge would introduce a cycle, return false without making any
+  // changes. Otherwise add the edge and return true.
+  bool InsertEdge(int32_t x, int32_t y);
+
+  // Remove any edge that exists from x to y.
+  void RemoveEdge(int32_t x, int32_t y);
+
+  // Return whether there is an edge directly from x to y.
+  bool HasEdge(int32_t x, int32_t y) const;
+
+  // Contracts the edge from 'a' to node 'b', merging nodes 'a' and 'b'. One of
+  // the nodes is removed from the graph, and edges to/from it are added to
+  // the remaining one, which is returned. If contracting the edge would create
+  // a cycle, does nothing and return no value.
+  llvm::Optional<int32_t> ContractEdge(int32_t a, int32_t b);
+
+  // Return whether dest_node `y` is reachable from source_node `x`
+  // by following edges. This is non-thread-safe version.
+  bool IsReachable(int32_t x, int32_t y);
+
+  // Return a copy of the successors set. This is needed for code using the
+  // collection while modifying the GraphCycles.
+  std::vector<int32_t> SuccessorsCopy(int32_t node) const;
+
+  // Returns all nodes in post order.
+  //
+  // If there is a path from X to Y then X appears after Y in the
+  // returned vector.
+  std::vector<int32_t> AllNodesInPostOrder() const;
+
+  // ----------------------------------------------------
+  struct Rep;
+
+ private:
+  GraphCycles(const GraphCycles&) = delete;
+  GraphCycles& operator=(const GraphCycles&) = delete;
+
+  Rep *rep_;  // opaque representation
+};
+
+} // namespace mlir
+
+#endif // TENSORFLOW_COMPILER_MLIR_XLA_TRANSFORMS_CYCLE_DETECTOR_H_

--- a/tensorflow/compiler/mlir/xla/transforms/cycle_detector_test.cc
+++ b/tensorflow/compiler/mlir/xla/transforms/cycle_detector_test.cc
@@ -1,0 +1,91 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/compiler/mlir/xla/transforms/cycle_detector.h"
+
+#include "tensorflow/compiler/xla/test.h"
+
+class GraphCyclesTest : public ::testing::Test {
+ public:
+  GraphCyclesTest(): g_(100) { }
+
+  bool AddEdge(int x, int y) { return g_.InsertEdge(x, y); }
+
+  void AddMultiples() {
+    // For every node x > 0: add edge to 2*x, 3*x
+    for (int x = 1; x < 25; x++) {
+      EXPECT_TRUE(AddEdge(x, 2 * x)) << x;
+      EXPECT_TRUE(AddEdge(x, 3 * x)) << x;
+    }
+  }
+
+  mlir::GraphCycles g_;
+};
+
+TEST_F(GraphCyclesTest, NoCycle) {
+  AddMultiples();
+}
+
+TEST_F(GraphCyclesTest, SimpleCycle) {
+  AddMultiples();
+  EXPECT_FALSE(AddEdge(8, 4));
+}
+
+TEST_F(GraphCyclesTest, IndirectCycle) {
+  AddMultiples();
+  EXPECT_TRUE(AddEdge(16, 9));
+  EXPECT_FALSE(AddEdge(9, 2));
+}
+
+TEST_F(GraphCyclesTest, RemoveEdge) {
+  EXPECT_TRUE(AddEdge(1, 2));
+  EXPECT_TRUE(AddEdge(2, 3));
+  EXPECT_TRUE(AddEdge(3, 4));
+  EXPECT_TRUE(AddEdge(4, 5));
+  g_.RemoveEdge(2, 3);
+  EXPECT_FALSE(g_.HasEdge(2, 3));
+}
+
+TEST_F(GraphCyclesTest, IsReachable) {
+  EXPECT_TRUE(AddEdge(1, 2));
+  EXPECT_TRUE(AddEdge(2, 3));
+  EXPECT_TRUE(AddEdge(3, 4));
+  EXPECT_TRUE(AddEdge(4, 5));
+
+  EXPECT_TRUE(g_.IsReachable(1, 5));
+  EXPECT_FALSE(g_.IsReachable(5, 1));
+}
+
+TEST_F(GraphCyclesTest, ContractEdge) {
+  ASSERT_TRUE(AddEdge(1, 2));
+  ASSERT_TRUE(AddEdge(1, 3));
+  ASSERT_TRUE(AddEdge(2, 3));
+  ASSERT_TRUE(AddEdge(2, 4));
+  ASSERT_TRUE(AddEdge(3, 4));
+
+  // It will introduce a cycle if the edge is contracted
+  EXPECT_FALSE(g_.ContractEdge(1, 3).hasValue());
+  EXPECT_TRUE(g_.HasEdge(1, 3));
+
+  // Node (2) has more edges.
+  EXPECT_EQ(*g_.ContractEdge(1, 2), 2);
+  EXPECT_TRUE(g_.HasEdge(2, 3));
+  EXPECT_TRUE(g_.HasEdge(2, 4));
+  EXPECT_TRUE(g_.HasEdge(3, 4));
+
+  // Node (2) has more edges.
+  EXPECT_EQ(*g_.ContractEdge(2, 3), 2);
+  EXPECT_TRUE(g_.HasEdge(2, 4));
+}

--- a/tensorflow/compiler/mlir/xla/transforms/passes.h
+++ b/tensorflow/compiler/mlir/xla/transforms/passes.h
@@ -73,6 +73,9 @@ std::unique_ptr<OperationPass<FuncOp>> createTransformUnrankedHloPass();
 // necessary to export to XLA.
 std::unique_ptr<OperationPass<FuncOp>> createSinkConstantsToControlFlowPass();
 
+// fuse xla_hlo ops to kLoop/kInput fusion patterns
+std::unique_ptr<OperationPass<FuncOp>> createXlaHloFusionPass();
+
 }  // namespace xla_hlo
 
 namespace xla_lhlo {

--- a/tensorflow/compiler/mlir/xla/transforms/xla_hlo_fusion.cc
+++ b/tensorflow/compiler/mlir/xla/transforms/xla_hlo_fusion.cc
@@ -1,0 +1,568 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "mlir/Dialect/StandardOps/IR/Ops.h"  // TF:llvm-project
+#include "mlir/IR/MLIRContext.h"  // TF:llvm-project
+#include "mlir/IR/Matchers.h"
+#include "mlir/Transforms/RegionUtils.h"  // TF:llvm-project
+#include "mlir/Pass/Pass.h"  // TF:local_config_mlir
+#include "llvm/ADT/EquivalenceClasses.h"
+
+#include "tensorflow/compiler/mlir/xla/ir/hlo_ops.h"
+#include "tensorflow/compiler/mlir/xla/transforms/cycle_detector.h"
+
+#include <memory>
+#include <unordered_set>
+#include <unordered_map>
+#include <vector>
+
+// This pass has similar functionality of the fusion pass in XLA stack.
+// However, unlike XLA, it targets the fully dynamic shape scenario.
+// Currently, it implements the kLoop and kInput fusion templates.
+// During conversion, it tries to greedily find kLoop/kInput fusion
+// patterns.
+//
+// Similar to XLA, this pass supports fusion pattern having multiple outputs
+// if all the shape of outputs are consistent. Following are some examples.
+//
+//        kLoop                          kInput
+// +----+  +----+  +----+    +----+    +----+    +----+
+// |elem|  |elem|  |elem|    |elem<----+elem+---->elem+----+
+// +-+--+  +-+--+  +-+--+    +-+--+    +----+    +-+--+    |
+//   |       |       |         |                   |       |
+//   |               |         |                   |       |
+// +-v--+    |     +-v--+   +--v---+            +--v---+   |
+// |elem+<---+----<+elem|   |reduce|            |reduce|   |
+// +-+--+          +-+--+   +--+---+            +--+---+   |
+//   |               |         |                   |       |
+//   |               |         |                   |       |
+//   v               v         v                   v       v
+//
+// To this end, we also add an simple shape constraint analysis phase.
+// For kLoop fusion template, it requires all the outputs of the fused
+// pattern have the same shape. However, we don't know the actual value
+// of the shape at the compile time in the dynamic shape world.
+// Fortunately, we could still infer the relationship among different ops
+// according to their shape constrain traits. Currently, We only consider
+// shape equality propagation for elementwise ops (assuming that implicit
+// shape broadcast is forbidden). The above process could be built on the
+// shape dialect once it is ready.
+
+namespace mlir {
+
+// To support use EquivalenceClasses<Value> directly.
+bool operator<(Value lhs, Value rhs) {
+  return lhs.getAsOpaquePointer() < rhs.getAsOpaquePointer();
+}
+
+namespace xla_hlo {
+namespace {
+
+using llvm::EquivalenceClasses;
+using FusionPattern = std::vector<Operation*>;
+using FusionPlan = std::vector<FusionPattern>;
+
+bool IsFusible(Operation* op) {
+  if (matchPattern(op, m_Constant())) {
+    return true;
+  }
+  auto op_fusibility = dyn_cast<InferFusibilityOpInterface>(op);
+  return op_fusibility && (op_fusibility.isFusibleWithOperand() ||
+      op_fusibility.isFusibleWithConsumer());
+}
+
+SmallVector<Value, 4> GetInputsOfFusionPattern(const FusionPattern& pattern) {
+  SmallVector<Value, 4> inputs;
+  DenseSet<Value> input_set;
+  DenseSet<Operation*> op_set;
+  for (Operation* op : pattern) {
+    bool inserted = op_set.insert(op).second;
+    assert(inserted && "FusionPattern contains duplicate operations");
+  }
+
+  for (Operation* op : pattern) {
+    for (Value operand : op->getOperands()) {
+      Operation* operand_op = operand.getDefiningOp();
+      if (op_set.find(operand_op) != op_set.end()) {
+        // skip if defining op is in the pattern
+        continue;
+      }
+      if (input_set.insert(operand).second) {
+        inputs.push_back(operand);
+      }
+    }
+  }
+  return inputs;
+}
+
+SmallVector<Value, 4> GetOutputsOfFusionPattern(const FusionPattern& pattern) {
+  SmallVector<Value, 4> outputs;
+  DenseSet<Operation*> op_set;
+  for (Operation* op : pattern) {
+    bool inserted = op_set.insert(op).second;
+    assert(inserted && "FusionPattern contains duplicate operations");
+  }
+
+  for (Operation* op : pattern) {
+    for (Value result : op->getResults()) {
+      bool has_external_user =
+          llvm::any_of(result.getUses(), [&] (OpOperand &use) {
+        return !op_set.count(use.getOwner());
+      });
+      if (has_external_user) {
+        outputs.push_back(result);
+      }
+    }
+  }
+  return outputs;
+}
+
+FusionPattern MergeFusionPattern(
+    const FusionPattern& lhs, const FusionPattern& rhs) {
+  FusionPattern pattern(lhs);
+  pattern.insert(pattern.end(), rhs.begin(), rhs.end());
+  return pattern;
+}
+
+inline int EffectiveSize(const FusionPattern& pattern) {
+  return llvm::count_if(pattern, [](Operation* op) {
+    return !matchPattern(op, m_Constant());
+  });
+}
+
+// This is an simple shape constraint analysis, which is used to
+// guide fusion decision (e.g. we only fuse shape-compatible ops).
+//
+// Currently, We only consider shape equality propagation based
+// on the shape constrain traits of elementwise ops (assuming that
+// implicit shape broadcast is forbidden).
+class ShapeConstraintAnalysis {
+ public:
+   explicit ShapeConstraintAnalysis(const SmallVectorImpl<Operation *>& op_list) {
+     PropagateEquality(op_list);
+   }
+
+   // Returns true is `lhs` and `rhs` are supposed to have same shape.
+   bool HasSameShape(Value lhs, Value rhs) {
+     return impl_.isEquivalent(lhs, rhs);
+   }
+
+ private:
+  // shape equality propagation based on the shape constrains of
+  // elementwise ops.
+  void PropagateEquality(const SmallVectorImpl<Operation *>& op_list) {
+    bool converged = true;
+    do {
+      converged = true;
+      auto update = [&](Value lhs, Value rhs) {
+        if (!impl_.isEquivalent(lhs, rhs)) {
+          converged = false;
+          impl_.unionSets(lhs, rhs);
+        }
+      };
+      for (Operation* op : op_list) {
+        auto op_fusibility = dyn_cast<InferFusibilityOpInterface>(op);
+        if (!op_fusibility) continue;
+        int numInput = op->getNumOperands();
+        int numOutput = op->getNumResults();
+        // shape equality propagation between inputs.
+        for (int input1 = 0; input1 < numInput; ++input1)
+          for (int input2 = input1+1; input2 < numInput; ++input2)
+            if (op_fusibility.inferInputsShapeEquality(input1, input2))
+              update(op->getOperand(input1), op->getOperand(input2));
+
+        // shape equality propagation between outputs.
+        for (int output1 = 0; output1 < numOutput; ++output1)
+          for (int output2 = output1+1; output2 < numOutput; ++output2)
+            if (op_fusibility.inferOutputsShapeEquality(output1, output2))
+              update(op->getResult(output1), op->getResult(output2));
+
+        // shape equality propagation between input and output.
+        for (int input = 0; input < numInput; ++input)
+          for (int output = 0; output < numOutput; ++output)
+            if (op_fusibility.inferInputOutputShapeEquality(input, output))
+              update(op->getOperand(input), op->getResult(output));
+      }
+    } while (!converged);
+  }
+
+  // a UnionFind set
+  EquivalenceClasses<Value> impl_;
+};
+
+// A fusion planner that can propose a fusion plan for a block of ops.
+// The fusion plan is consisted of a group of fusion patterns.
+//
+// Currently all proposed patterns followed xla kLoop/kInput like fusion
+// templates while are adapted to the fully dynamic shape world.
+//
+// kLoop fusion template satifies:
+//   - all ops in the fusion pattern are element-wise.
+//   - all the shapes of outputs of fusion pattern are same, and thus can
+//     fit into a same parallel loop.
+//
+// kInput fusion template satifies:
+//   - any op in the fusion pattern is either element-wise or a reduction.
+//   - if a op is a reduction, its output cannot be consumered by other
+//     ops in the same fusion pattern.
+//   - all the effective shapes of outputs of fusion pattern are same.
+//     - For element-wise op, its effective shape is its output shape.
+//     - For reduction op, its effective shape is its operand shape.
+class FusionPlanner {
+ public:
+  explicit FusionPlanner(const SmallVectorImpl<Operation *>& op_list)
+      : op_list_(op_list),
+        shape_analysis_(op_list),
+        cycle_detector_(op_list.size()) {
+    BuildNodeMap();
+  }
+
+  // Returns a fusion plan if success, otherwise none.
+  llvm::Optional<FusionPlan> Run() {
+    // Greedily search connected fusible pattern, and ops belonging to
+    // a same fusion pattern are grouped into a cluster.
+    RunEdgeContractionLoop();
+
+    // After doing edge contraction, each unique cluster having size
+    // more than one represents a potential fusion pattern.
+    // We collect all these clusters and construct a fusion plan.
+    //
+    // Note that the ops in a fusion pattern are in topological ordering.
+    FusionPlan plan;
+    DenseMap<int, int> pattern_ids;
+    for (Operation* op : op_list_) {
+      Cluster* cluster = GetClusterForNode(op);
+      int node_id = cluster->cycles_graph_node_id();
+      if (!IsFusible(op_list_[node_id]) ||
+          EffectiveSize(GetClusterForNode(op)->fused_pattern()) <= 1) {
+        continue;
+      }
+      if (!pattern_ids.count(node_id)) {
+        int pattern_id = pattern_ids.size();
+        pattern_ids[node_id] = pattern_id;
+        plan.emplace_back();
+      }
+      plan[pattern_ids[node_id]].push_back(op);
+    }
+    return plan;
+  }
+
+  // Returns the op_list this planner operates on.
+  const SmallVectorImpl<Operation *>& op_list() const {
+    return op_list_;
+  }
+
+ private:
+  // Represent a (partial) fused pattern
+  class Cluster {
+   public:
+    Cluster(int node_id, FusionPlanner* planner)
+        : node_id_(node_id) {
+      const SmallVectorImpl<Operation *>& op_list = planner->op_list();
+      pattern_.push_back(op_list[node_id]);
+    }
+
+    // Merges `other` into this cluster, and clears `other`.
+    void Merge(Cluster* other) {
+      pattern_.insert(pattern_.end(),
+          other->pattern_.begin(), other->pattern_.end());
+      other->pattern_.clear();
+    }
+
+    // The number of nodes in this cluster.
+    int cluster_size() const { return pattern_.size(); }
+
+    // The ID of the cluster as represented in `cycle_detector_`.
+    int cycles_graph_node_id() const { return node_id_; }
+
+    // Sets the ID of the cluster as represented in `cycle_detector_`.
+    void set_cycles_graph_node_id(int cycles_graph_node_id) {
+      node_id_ = cycles_graph_node_id;
+    }
+
+    // Currently the fused pattern this cluster holds.
+    const FusionPattern& fused_pattern() {
+      return pattern_;
+    }
+
+   private:
+    // ID of the representative node of this cluster.
+    int node_id_;
+
+    // the fused pattern this cluster holds.
+    FusionPattern pattern_;
+  };
+
+ private:
+  Cluster* MakeCluster(int cycles_graph_node_id) {
+    cluster_storage_.emplace_back(
+        new Cluster(cycles_graph_node_id, this));
+    return cluster_storage_.back().get();
+  }
+
+  void BuildNodeMap() {
+    int num_nodes = op_list_.size();
+    for (int node_id = 0; node_id < num_nodes; ++node_id) {
+      Operation* op = op_list_[node_id];
+      MakeCluster(node_id);
+      op_to_node_id_[op] = node_id;
+      leader_for_node_.insert(node_id);
+      for (Value operand : op->getOperands()) {
+        Operation* operand_op = operand.getDefiningOp();
+        if (operand_op == nullptr) {
+          // skip block argument
+          continue;
+        }
+        auto iter = op_to_node_id_.find(operand_op);
+        assert(iter != op_to_node_id_.end());
+        cycle_detector_.InsertEdge(iter->second, node_id);
+      }
+    }
+  }
+
+  // Returns the cluster contains this op.
+  Cluster* GetClusterForNode(Operation* n) {
+    int id = op_to_node_id_.at(n);
+    id = leader_for_node_.getLeaderValue(id);
+    return cluster_storage_[id].get();
+  }
+
+  // Returns the cluster contains the op having `node_id`.
+  Cluster* GetClusterForCyclesGraphNode(int node_id) {
+    return cluster_storage_[leader_for_node_.getLeaderValue(node_id)].get();
+  }
+
+  // Merges the clusters `cluster_from` and `cluster_to`.
+  bool MergeClusters(Cluster* cluster_from, Cluster* cluster_to) {
+    int from = cluster_from->cycles_graph_node_id();
+    int to = cluster_to->cycles_graph_node_id();
+
+    auto optional_merged_node = cycle_detector_.ContractEdge(from, to);
+    if (!optional_merged_node.hasValue()) {
+      llvm::dbgs() << "Could not contract " << from << " -> " << to
+                   << " because contracting the edge would create a cycle.";
+      return false;
+    }
+
+    // Merge the clusters.
+    cluster_from->Merge(cluster_to);
+    cluster_from->set_cycles_graph_node_id(*optional_merged_node);
+
+    // Merge the UnionFind Set.
+    leader_for_node_.unionSets(from, to);
+    return true;
+  }
+
+  template <typename FnTy>
+  bool ForEachEdgeInPostOrder(FnTy fn) {
+    bool changed = false;
+    for (int32_t node : cycle_detector_.AllNodesInPostOrder()) {
+      Cluster* cluster_from = GetClusterForCyclesGraphNode(node);
+      // Make a copy of the set of successors because we may modify the graph in
+      // TryToContractEdge.
+      std::vector<int32_t> successors_copy =
+          cycle_detector_.SuccessorsCopy(cluster_from->cycles_graph_node_id());
+
+      for (int to : successors_copy) {
+        Cluster* cluster_to = GetClusterForCyclesGraphNode(to);
+        bool contracted_edge = fn(cluster_from, cluster_to);
+        changed |= contracted_edge;
+      }
+    }
+
+    return changed;
+  }
+
+  // returns the outputs if two cluster were merged
+  SmallVector<Value, 4> GetResultsOfFusedPattern(Cluster* from, Cluster* to) {
+    FusionPattern fused_pattern = MergeFusionPattern(
+        from->fused_pattern(), to->fused_pattern());
+    return GetOutputsOfFusionPattern(fused_pattern);
+  }
+
+  // This function check if fusing `from` with `to` is valid and if so perform
+  // the merge. The validity is based on the operations in the clusters and
+  // the compatibility of the shapes of the outputs of the would-be fused
+  // clusters.
+  // Returns true is the merge was performed.
+  bool TryToContractEdge(Cluster* from, Cluster* to) {
+    int node_to = to->cycles_graph_node_id();
+    int node_from = from->cycles_graph_node_id();
+
+    // Both node_to and node_from should be fusible
+    if (!IsFusible(op_list_[node_to]) || !IsFusible(op_list_[node_from])) {
+      return false;
+    }
+
+    auto op_from_fusibility = dyn_cast<InferFusibilityOpInterface>(op_list_[node_from]);
+    if (op_from_fusibility && !op_from_fusibility.isFusibleWithConsumer()) {
+      // This op cannot be fused with its consumers.
+      return false;
+    }
+
+    auto op_to_fusibility = dyn_cast<InferFusibilityOpInterface>(op_list_[node_to]);
+    if (op_to_fusibility && !op_to_fusibility.isFusibleWithOperand()) {
+      // This op cannot be fused with its operands.
+      return false;
+    }
+
+    // Output shapes of a fusion pattern should be compatible as described in
+    // the document of this class.
+    SmallVector<Value, 4> results = GetResultsOfFusedPattern(from, to);
+    auto get_workload_shape = [] (Value v) {
+      Operation* op = v.getDefiningOp();
+      // Block argument
+      if (!op) return v;
+      auto op_fusibility = dyn_cast<InferFusibilityOpInterface>(op);
+      // Const value
+      if (!op_fusibility) return v;
+      llvm::Optional<Value> workload = op_fusibility.inferEffectiveWorkloadShape();
+      return workload.hasValue() ? *workload : v;
+    };
+
+    Value ref = get_workload_shape(results[0]);
+    if (!llvm::all_of(results, [&] (Value result) {
+      Value val = get_workload_shape(result);
+      return shape_analysis_.HasSameShape(ref, val);
+    })) {
+      return false;
+    }
+
+    return MergeClusters(from, to);
+  }
+
+  // Greedily fuse connected node.
+  bool RunEdgeContractionLoop() {
+    using std::placeholders::_1;
+    using std::placeholders::_2;
+    return ForEachEdgeInPostOrder(
+        std::bind(&FusionPlanner::TryToContractEdge, this, _1, _2));
+  }
+
+  const SmallVectorImpl<Operation *>& op_list_;
+
+  // Shape equality checker
+  ShapeConstraintAnalysis shape_analysis_;
+
+  // op -> node_id
+  std::unordered_map<Operation*, int> op_to_node_id_;
+
+  // make sure not introduce cycle after fusion
+  GraphCycles cycle_detector_;
+  std::vector<std::unique_ptr<Cluster>> cluster_storage_;
+
+  // a UnionFind set. Each set represents a (partial) fused pattern
+  // and has a leader as representation.
+  EquivalenceClasses<int32_t> leader_for_node_;
+};
+
+struct XlaHloFusion : public mlir::PassWrapper<XlaHloFusion, FunctionPass> {
+  void runOnFunction() override {
+    FuncOp func = getFunction();
+    if (!IsTargetFunc(func)) {
+      return;
+    }
+
+    // process each block and do fusion within a block.
+    for (Block& block : func.getBlocks()) {
+      SmallVector<Operation*, 4> op_list;
+      for (Operation& op : block) {
+        op_list.push_back(&op);
+      }
+
+      FusionPlanner planner(op_list);
+      llvm::Optional<FusionPlan> plan = planner.Run();
+      if (!plan) {
+        emitError(func.getLoc(), "can't find a fusion plan");
+        signalPassFailure();
+        return;
+      }
+      if (!ApplyFusionPlan(*plan)) {
+        emitError(func.getLoc(), "apply fusion plan failed");
+        signalPassFailure();
+        return;
+      }
+    }
+  }
+
+  bool IsTargetFunc(FuncOp func) {
+    int num_fusible_ops = 0;
+    bool is_target_func = false;
+    // We only process the function having enough candidates
+    func.walk([&](Operation* op) {
+      num_fusible_ops += static_cast<int>(
+          dyn_cast<InferFusibilityOpInterface>(op) != nullptr);
+      is_target_func = (num_fusible_ops > 1);
+      // early stop
+      if (is_target_func) return WalkResult::interrupt();
+      return WalkResult::advance();
+    });
+    return is_target_func;
+  }
+
+  bool ApplyFusionPlan(const FusionPlan& plan) {
+    for (const FusionPattern& pattern: plan) {
+      OpBuilder b(pattern.back());
+
+      SmallVector<Location, 4> locations;
+      locations.reserve(pattern.size());
+      for (Operation* op : pattern) {
+        locations.push_back(op->getLoc());
+      }
+      Location fused_loc = FusedLoc::get(locations, pattern.back()->getContext());
+
+      SmallVector<Value, 4> inputs = GetInputsOfFusionPattern(pattern);
+      SmallVector<Value, 4> outputs = GetOutputsOfFusionPattern(pattern);
+      SmallVector<Type, 4> output_types;
+      output_types.reserve(outputs.size());
+      for(Value v : outputs) {
+        output_types.push_back(v.getType());
+      }
+
+      FusionOp fusion = b.create<xla_hlo::FusionOp>(fused_loc, output_types, inputs);
+      Region& region = fusion.fused_computation();
+      region.push_back(new Block);
+      Block& block = region.front();
+      for (Operation* op : pattern) {
+        op->moveBefore(&block, block.end());
+      }
+      b.setInsertionPoint(&block, block.end());
+      b.create<xla_hlo::ReturnOp>(fused_loc, outputs);
+
+      for (auto output_and_result : llvm::zip(outputs, fusion.getResults())) {
+        Value output = std::get<0>(output_and_result);
+        Value fusion_result = std::get<1>(output_and_result);
+        for (OpOperand &use : llvm::make_early_inc_range(output.getUses())) {
+          if (use.getOwner()->getBlock() != &block)
+            use.set(fusion_result);
+        }
+      }
+    }
+    return true;
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<OperationPass<FuncOp>> createXlaHloFusion() {
+  return std::make_unique<XlaHloFusion>();
+}
+
+static PassRegistration<XlaHloFusion> xla_hlo_fusion_pass(
+    "xla-hlo-fusion",
+    "fuse xla_hlo ops to kLoop/kInput fusion patterns.");
+
+}  // namespace xla_hlo
+}  // namespace mlir


### PR DESCRIPTION
This pass implements the basic kLoop/kInput fusion in fully dynamic shape scenario. Similar to XLA, this pass also supports fusion pattern having multiple outputs if all the shape of outputs are consistent. To this end, we also add a simple shape constrain analysis. This could be built on the shape dialect once it is ready.

![image](https://user-images.githubusercontent.com/15364516/76931205-1ed0e580-6923-11ea-8732-fe9d93c3bcaf.png)

