### PR TITLE
[MLIR][XLA] Fix ops erase bug in DeadTempBufferRemoval

### DIFF
--- a/tensorflow/compiler/xla/service/mlir_gpu/kernel_lowering.cc
+++ b/tensorflow/compiler/xla/service/mlir_gpu/kernel_lowering.cc
@@ -244,14 +244,19 @@ struct DeadTempBufferRemoval : mlir::FunctionPass<DeadTempBufferRemoval> {
   }
 
   void runOnFunction() override {
+    llvm::SmallVector<mlir::Operation *, 8> opsToErase;
     getFunction().walk([&](mlir::AllocOp allocOp) {
       if (!operationConsideredDead(allocOp)) {
         return;
       }
 
-      // TODO(herhut): There should be a generic helper for this.
-      recursiveErase(allocOp);
+      opsToErase.push_back(allocOp);
     });
+
+    for (auto *op : opsToErase) {
+      // TODO(herhut): There should be a generic helper for this.
+      recursiveErase(op);
+    }
   }
 };
 


### PR DESCRIPTION
This is a PR from JIZHI, the AI platform in Tencent.
@sherhut @River707 

I think it will break the DAG struct that recursiveErase called directly when function.walk
The operation which needs erasing should be put in a vector when function.walk firstly and erased after function.walk