### PR TITLE
NFC - minor spelling tweaks under lite and lite/examples directories

### DIFF
--- a/tensorflow/lite/examples/label_image/label_image.cc
+++ b/tensorflow/lite/examples/label_image/label_image.cc
@@ -132,7 +132,7 @@ void PrintProfilingInfo(const profiling::ProfileEvent* e,
                         uint32_t subgraph_index, uint32_t op_index,
                         TfLiteRegistration registration) {
   // output something like
-  // time (ms) , Node xxx, OpCode xxx, symblic name
+  // time (ms) , Node xxx, OpCode xxx, symbolic name
   //      5.352, Node   5, OpCode   4, DEPTHWISE_CONV_2D
 
   LOG(INFO) << std::fixed << std::setw(10) << std::setprecision(3)

--- a/tensorflow/lite/external_cpu_backend_context.h
+++ b/tensorflow/lite/external_cpu_backend_context.h
@@ -25,7 +25,7 @@ namespace tflite {
 // This is the base class for TF Lite internal backend contexts (like a
 // RUY-based cpu backend context class). A derived internal backend context is
 // generally a collection of utilities (i.e. a thread pool etc.) for TF Lite to
-// use certain keneral libraries, such as Gemmlowp, RUY, etc., to implement TF
+// use certain kernel libraries, such as Gemmlowp, RUY, etc., to implement TF
 // Lite operators.
 class TfLiteInternalBackendContext {
  public:
@@ -68,7 +68,7 @@ class TfLiteInternalBackendContext {
 // the #thread info in the global cpu backend context (i.e. 'global_ctxt' above)
 // that affects how much parallelism an interpreter invocation will use.
 // Therefore, if different number of threads are used among different
-// interpreters, don't call 'SetNumThreads' consectutively but call it
+// interpreters, don't call 'SetNumThreads' consecutively but call it
 // separately between each interpreter's invocation as illustrated above.
 //
 // Note: it is the responsibility of the user of this context (i.e. a

--- a/tensorflow/lite/graph_info.h
+++ b/tensorflow/lite/graph_info.h
@@ -41,7 +41,7 @@ class GraphInfo {
   // num_nodes().
   virtual const TfLiteNode& node(size_t index) const = 0;
 
-  // Returns an implementation-speicfic node index which may be different from
+  // Returns an implementation-specific node index which may be different from
   // index.
   virtual size_t node_index(size_t index) const = 0;
 

--- a/tensorflow/lite/interpreter.cc
+++ b/tensorflow/lite/interpreter.cc
@@ -136,7 +136,7 @@ void Interpreter::SetExternalContext(TfLiteExternalContextType type,
   // If it's overwritten here, we will release the resource of the internally
   // owned external context.
   // Note: the 'max thread count' info associated with the overwritten context
-  // will be lost here, and such info is now detemined by the new context, thus
+  // will be lost here, and such info is now determined by the new context, thus
   // affecting how much parallelism a TFLite op would have.
   if (kTfLiteCpuBackendContext == type &&
       external_contexts_[kTfLiteCpuBackendContext] ==

--- a/tensorflow/lite/model_test.cc
+++ b/tensorflow/lite/model_test.cc
@@ -71,7 +71,7 @@ class TrivialResolver : public OpResolver {
   TfLiteRegistration* constant_return_;
 };
 
-TEST(BasicFlatBufferModel, TestNonExistantFiles) {
+TEST(BasicFlatBufferModel, TestNonExistentFiles) {
   ASSERT_TRUE(!FlatBufferModel::BuildFromFile("/tmp/tflite_model_1234"));
 }
 

--- a/tensorflow/lite/util.h
+++ b/tensorflow/lite/util.h
@@ -44,7 +44,7 @@ TfLiteIntArray* ConvertVectorToTfLiteIntArray(const std::vector<int>& input);
 
 // Converts an array (of the given size) to a `TfLiteIntArray`. The caller
 // takes ownership of the returned pointer, and must make sure 'dims' has at
-// least 'rank' elemnts.
+// least 'rank' elements.
 TfLiteIntArray* ConvertArrayToTfLiteIntArray(const int rank, const int* dims);
 
 // Checks whether a `TfLiteIntArray` and an int array have matching elements.
@@ -66,8 +66,8 @@ TfLiteStatus GetSizeOfType(TfLiteContext* context, const TfLiteType type,
                            size_t* bytes);
 
 // Creates a stub TfLiteRegistration instance with the provided
-// `custom_op_name`. The op will fail if invoked, and is useful as a placeholde
-// to defer op resolution.
+// `custom_op_name`. The op will fail if invoked, and is useful as a
+// placeholder to defer op resolution.
 // Note that `custom_op_name` must remain valid for the returned op's lifetime..
 TfLiteRegistration CreateUnresolvedCustomOp(const char* custom_op_name);
 


### PR DESCRIPTION
This PR addresses minor spelling tweaks under `tensorflow/lite` and `tensorflow/lite/examples` directories.
follow-on of #35286