### PR TITLE
[r2.2:Cherrypick] Remove the trailing 'm' , since the tag for py38 is not cp38m but cp38.

### DIFF
--- a/tensorflow/tools/ci_build/release/windows/gpu_py38_full/release_pip_rename.sh
+++ b/tensorflow/tools/ci_build/release/windows/gpu_py38_full/release_pip_rename.sh
@@ -19,6 +19,6 @@ set -x
 source tensorflow/tools/ci_build/release/common.sh
 
 # Copy and rename to tensorflow
-for f in $(ls py_test_dir/tensorflow-*cp3*-cp3*m-win_amd64.whl); do
+for f in $(ls py_test_dir/tensorflow-*cp3*-cp3*-win_amd64.whl); do
   copy_to_new_project_name "${f}" tensorflow_gpu
 done


### PR DESCRIPTION
PiperOrigin-RevId: 301682546
Change-Id: I86e3632702ee77f82e3a59ba489a298930588ab9