### PR TITLE
Static filesystem registration (modular filesystems)

### DIFF
--- a/tensorflow/c/experimental/filesystem/BUILD
+++ b/tensorflow/c/experimental/filesystem/BUILD
@@ -27,6 +27,9 @@ cc_library(
         "modular_filesystem_registration.h",
     ],
     hdrs = ["modular_filesystem.h"],
+    # TODO(mihaimaruseac): Visibility should be more restrictive once we
+    # convert to modular filesystems everywhere
+    visibility = ["//visibility:public"],
     deps = [
         ":filesystem_interface",
         "//tensorflow/c:tf_status_helper",

--- a/tensorflow/c/experimental/filesystem/modular_filesystem_registration.h
+++ b/tensorflow/c/experimental/filesystem/modular_filesystem_registration.h
@@ -15,12 +15,13 @@ limitations under the License.
 #ifndef TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_MODULAR_FILESYSTEM_REGISTRATION_H_
 #define TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_MODULAR_FILESYSTEM_REGISTRATION_H_
 
+#include "tensorflow/c/experimental/filesystem/filesystem_interface.h"
 #include "tensorflow/core/platform/status.h"
 
 namespace tensorflow {
 namespace filesystem_registration {
 
-Status RegisterFilesystemPluginImpl(const std::string& dso_path);
+Status RegisterFilesystemPluginImpl(const TF_FilesystemPluginInfo* info);
 
 }  // namespace filesystem_registration
 }  // namespace tensorflow

--- a/tensorflow/c/experimental/filesystem/plugins/posix/BUILD
+++ b/tensorflow/c/experimental/filesystem/plugins/posix/BUILD
@@ -19,6 +19,7 @@ tf_cc_shared_object(
 cc_library(
     name = "posix_filesystem_impl",
     srcs = ["posix_filesystem.cc"],
+    hdrs = ["posix_filesystem.h"],
     deps = [
         ":posix_filesystem_helper",
         "//tensorflow/c:tf_status",

--- a/tensorflow/c/experimental/filesystem/plugins/posix/BUILD
+++ b/tensorflow/c/experimental/filesystem/plugins/posix/BUILD
@@ -38,6 +38,7 @@ cc_library(
         "//tensorflow/c/experimental/filesystem:filesystem_interface",
         "//tensorflow/c/experimental/filesystem:modular_filesystem",
     ],
+    alwayslink = 1,
 )
 
 # Library implementing helper functionality, so that the above only contains

--- a/tensorflow/c/experimental/filesystem/plugins/posix/BUILD
+++ b/tensorflow/c/experimental/filesystem/plugins/posix/BUILD
@@ -27,6 +27,19 @@ cc_library(
     ],
 )
 
+# Since building pip package and API tests require a filesystem, we provide a
+# static registration target that they should link against.
+cc_library(
+    name = "posix_filesystem_static",
+    srcs = ["posix_filesystem_static.cc"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":posix_filesystem_impl",
+        "//tensorflow/c/experimental/filesystem:filesystem_interface",
+        "//tensorflow/c/experimental/filesystem:modular_filesystem",
+    ],
+)
+
 # Library implementing helper functionality, so that the above only contains
 # the API implementation for modular filesystems.
 cc_library(

--- a/tensorflow/c/experimental/filesystem/plugins/posix/posix_filesystem.h
+++ b/tensorflow/c/experimental/filesystem/plugins/posix/posix_filesystem.h
@@ -1,0 +1,29 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_PLUGINS_POSIX_POSIX_FILESYSTEM_H_
+#define TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_PLUGINS_POSIX_POSIX_FILESYSTEM_H_
+
+// Initialize the POSIX filesystem.
+//
+// In general, the `TF_InitPlugin` symbol doesn't need to be exposed in a header
+// file, since the plugin registration will look for the symbol in the DSO file
+// that provides the filesystem functionality. However, the POSIX filesystem
+// needs to be statically registered in some tests and utilities for building
+// the API files at the time of creating the pip package. Hence, we need to
+// expose this function so that this filesystem can be statically registered
+// when needed.
+void TF_InitPlugin(TF_FilesystemPluginInfo* info);
+
+#endif  // TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_MODULAR_FILESYSTEM_H_

--- a/tensorflow/c/experimental/filesystem/plugins/posix/posix_filesystem_static.cc
+++ b/tensorflow/c/experimental/filesystem/plugins/posix/posix_filesystem_static.cc
@@ -1,0 +1,33 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/c/experimental/filesystem/filesystem_interface.h"
+#include "tensorflow/c/experimental/filesystem/modular_filesystem_registration.h"
+#include "tensorflow/c/experimental/filesystem/plugins/posix/posix_filesystem.h"
+
+namespace tensorflow {
+
+// Register the POSIX filesystems statically.
+// Return value will be unused
+Status StaticallyRegisterLocalFilesystems() {
+  TF_FilesystemPluginInfo info;
+  TF_InitPlugin(&info);
+  return filesystem_registration::RegisterFilesystemPluginImpl(&info);
+}
+
+// Perform the actual registration
+static Status unused = StaticallyRegisterLocalFilesystems();
+
+}  // namespace tensorflow


### PR DESCRIPTION
When using modular filesystems, the filesystem registration in `core/platform/default/env.cc` (and similar) is no longer valid. We expect filesystems to be loaded from DSOs.

However, we need a filesystem while building the pip package as the `genrule`s for created the `api_def` files need to write to disk. Furthermore, there are a few tests around API generation that depend on having a filesystem around.

This PR only adds a method to statically register a filesystem if a Bazel target is added as a dependency to a `cc_library`/`cc_binary`. We recommend adding this target to `cc_binary` to prevent registering the same filesystem multiple times (multiple registrations result in error but the program can still continue safely) or potential ODR violations.

Tested in the following ways:

1. Applying this diff, we can run the modular filesystem tests while loading the filesystem plugin:

    ```diff
    diff --git a/tensorflow/core/platform/default/env.cc b/tensorflow/core/platform/default/env.cc
    index 5f7822f658..4bf331b607 100644
    --- a/tensorflow/core/platform/default/env.cc
    +++ b/tensorflow/core/platform/default/env.cc
    @@ -212,8 +212,8 @@ class PosixEnv : public Env {
     }  // namespace
 
     #if defined(PLATFORM_POSIX) || defined(__APPLE__) || defined(__ANDROID__)
    -REGISTER_FILE_SYSTEM("", PosixFileSystem);
    -REGISTER_FILE_SYSTEM("file", LocalPosixFileSystem);
    +//REGISTER_FILE_SYSTEM("", PosixFileSystem);
    +//REGISTER_FILE_SYSTEM("file", LocalPosixFileSystem);
     Env* Env::Default() {
       static Env* default_env = new PosixEnv;
       return default_env;
    ```

    where the test is done via

    ```bash
    (tf) [tensorflow] λ bazel build //tensorflow/c/experimental/filesystem/plugins/posix:libposix_filesystem.so
    ...
    (tf) [tensorflow] λ bazel build //tensorflow/c/experimental/filesystem:modular_filesystem_test
    ...
    (tf) [tensorflow] λ bazel-bin/tensorflow/c/experimental/filesystem/modular_filesystem_test --scheme=file --dso=bazel-bin/tensorflow/c/experimental/filesystem/plugins/posix/libposix_filesystem.so
    ...
    [----------] 104 tests from ModularFileSystem/ModularFileSystemTest (32 ms total)

    [----------] Global test environment tear-down
    [==========] 104 tests from 1 test suite ran. (32 ms total)
    [  PASSED  ] 104 tests.
    ```

1. Without the above diff or with it, `bazel test //tensorflow/cc:cc_op_gen_test` fails with ` Non-OK-status: env->NewWritableFile(dot_h_fname, &h) status: Unimplemented: File system scheme '[local]' not implemented`. However, with this additional diff (to do static registration) the test passes

    ```diff
    diff --git a/tensorflow/cc/BUILD b/tensorflow/cc/BUILD
    index 5251ccdf1c..13b60f62fa 100644
    --- a/tensorflow/cc/BUILD
    +++ b/tensorflow/cc/BUILD
    @@ -672,6 +672,7 @@ tf_cc_test(
             "framework/cc_op_gen_test.cc",
         ],
         deps = [
    +        "//tensorflow/c/experimental/filesystem/plugins/posix:posix_filesystem_static",
             "//tensorflow/core:framework",
             "//tensorflow/core:lib",
             "//tensorflow/core:lib_internal",
    ```

    ```bash
    (tf) [tensorflow] λ bazel test //tensorflow/cc:cc_op_gen_test
    ...
    INFO: Build completed successfully, 9 total actions
    //tensorflow/cc:cc_op_gen_test                                           PASSED in 0.0s

    Executed 1 out of 1 test: 1 test passes.
    INFO: Build completed successfully, 9 total actions
    ```

1. Adding the same static target to the `cc_op_gen_main` and to the `xla_ops` targets allows us to build the pip package successfully

    ```diff
    diff --git a/tensorflow/cc/BUILD b/tensorflow/cc/BUILD
    index 5251ccdf1c..7a7f7865d1 100644
    --- a/tensorflow/cc/BUILD
    +++ b/tensorflow/cc/BUILD
    @@ -655,6 +655,7 @@ cc_library(
             "//tensorflow/core/api_def:base_api_def",
         ],
         deps = [
    +        "//tensorflow/c/experimental/filesystem/plugins/posix:posix_filesystem_static",
             "//tensorflow/core:framework_headers_lib",
             "//tensorflow/core:lib",
             "//tensorflow/core:lib_internal",
    diff --git a/tensorflow/compiler/tf2xla/ops/BUILD b/tensorflow/compiler/tf2xla/ops/BUILD
    index b116a09dd0..16c43ead2d 100644
    --- a/tensorflow/compiler/tf2xla/ops/BUILD
    +++ b/tensorflow/compiler/tf2xla/ops/BUILD
    @@ -13,6 +13,7 @@ cc_library(
         name = "xla_ops",
         srcs = ["xla_ops.cc"],
         deps = [
    +        "//tensorflow/c/experimental/filesystem/plugins/posix:posix_filesystem_static",
             "//tensorflow/compiler/xla:xla_data_proto_cc",
             "//tensorflow/core:framework",
             "//tensorflow/core:lib",
    ```

    ```bash
    (tf) [tensorflow] λ bazel build  //tensorflow/tools/pip_package:build_pip_package
    ...
    Target //tensorflow/tools/pip_package:build_pip_package up-to-date:
      bazel-bin/tensorflow/tools/pip_package/build_pip_package
    INFO: Elapsed time: 3904.842s, Critical Path: 539.10s
    INFO: 1478 processes: 1478 local.
    INFO: Build completed successfully, 1494 total actions
    ```

Note: the diffs mentioned in the testins section will need to be applied when all filesystems are converted to modular world, as the switch commit/PR. We cannot effectively apply them before unless we want to accept some divergence (some filesystem modular, some still static as in the old world).

See tensorflow/community#101 for the general modular filesystems design RFC.