### PR TITLE
release 2.2-<rc2> cherry-pick request:Do not constant-fold nodes that will use ScopedAllocator.

### DIFF
--- a/tensorflow/core/common_runtime/constant_folding.cc
+++ b/tensorflow/core/common_runtime/constant_folding.cc
@@ -13,13 +13,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include "tensorflow/core/common_runtime/constant_folding.h"
+
 #include <algorithm>
 #include <atomic>
 #include <set>
 #include <unordered_map>
 #include <vector>
-
-#include "tensorflow/core/common_runtime/constant_folding.h"
 
 #include "tensorflow/core/common_runtime/device_factory.h"
 #include "tensorflow/core/common_runtime/executor.h"
@@ -44,6 +44,8 @@ limitations under the License.
 namespace tensorflow {
 
 namespace {
+
+const char kScopedAllocatorAttrName[] = "_scoped_allocator";
 
 // Test to see if the Op is one that turns into a constant when its
 // inputs' shapes are known.
@@ -254,6 +256,15 @@ bool IsConstantFoldable(
   // TODO(phawkins): allow constant-folding for functions; functions may
   // be arbitrarily expensive to execute.
   if (!KernelDefAvailable(DeviceType(DEVICE_CPU), n->def())) {
+    return false;
+  }
+  // Do not constant fold nodes which will be allocated by ScopedAllocator.
+  // This is because the constant-folding graph will not contain the
+  // `_ScopedAllocator` node, and that is necessary to be able to run a node
+  // that will use this allocator.
+  if (n->attrs().Find(kScopedAllocatorAttrName) != nullptr) {
+    VLOG(2) << "Skip node [" << n->DebugString()
+            << "] for constant folding due to scoped allocator";
     return false;
   }
   return true;

--- a/tensorflow/python/ops/collective_ops_test.py
+++ b/tensorflow/python/ops/collective_ops_test.py
@@ -466,6 +466,39 @@ class CollectiveOpTest(test.TestCase):
         in_tensor, group_size, group_key, instance_key)
     self.assertAllEqual(in_value, gathered_tensor.numpy())
 
+  @test_util.run_deprecated_v1
+  def testConstantWithScopedAllocator(self):
+    group_size = 2
+    group_key = 1
+    instance_key1 = 1
+    instance_key2 = 2
+
+    graph_options = config_pb2.GraphOptions(
+        optimizer_options=config_pb2.OptimizerOptions(do_constant_folding=True))
+    cfg = config_pb2.ConfigProto(device_count={'CPU': group_size},
+                                 graph_options=graph_options)
+    rewrite_options = cfg.graph_options.rewrite_options
+    rewrite_options.scoped_allocator_optimization = (
+        rewriter_config_pb2.RewriterConfig.ON)
+    del rewrite_options.scoped_allocator_opts.enable_op[:]
+    rewrite_options.scoped_allocator_opts.enable_op.append('CollectiveReduce')
+
+    with self.session(config=cfg) as sess:
+      run_ops = []
+      for i in range(group_size):
+        with ops.device('CPU:%d' % i):
+          constant = constant_op.constant(i + 1.)
+          input_tensor1 = array_ops.identity(constant)
+          input_tensor2 = array_ops.identity(constant)
+          reduced_tensor1 = collective_ops.all_reduce(
+              input_tensor1, group_size, group_key, instance_key1, 'Add', 'Id')
+          reduced_tensor2 = collective_ops.all_reduce(
+              input_tensor2, group_size, group_key, instance_key2, 'Add', 'Id')
+          run_ops.append(array_ops.identity(reduced_tensor1))
+          run_ops.append(array_ops.identity(reduced_tensor2))
+      results = sess.run(run_ops)
+      self.assertEqual(results, [3., 3., 3., 3.])
+
 
 if __name__ == '__main__':
   test.main()


### PR DESCRIPTION
The constant folding optimizer creates a subgraph with constant foldable nodes,
and runs them on the CPU using `GraphRunner`.  If any of the nodes in the
subgraph contain `_scoped_allocator` attribute, they are intended to be
allocated with a ScopedAllocator.  However, the `_ScopedAllocator` node is
absent from this graph, which causes the execution of this subgraph to error
out.

This change skips nodes that are marked with `_scoped_allocator` attribute in
the constant folding optimizer.

PiperOrigin-RevId: 299421744
Change-Id: Ic8e5896dbd5612d7782b9aa2e078e0128ad02f90

Reasons for requesting a cherrypick: This bug fix is needed to run an ObjectDetection model with MultiWorkerMirroredStrategy on CAIP Deep learning VMs. We need an official release to be able to create VM images that can be pushed onto these Deep learning VMs. These are set to be used as part of an upcoming launch. 