### PR TITLE
Modified TensorScatterAdd to correctly specify examples for shape of tensor

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_TensorScatterAdd.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_TensorScatterAdd.pbtxt
@@ -33,16 +33,17 @@ are added onto an existing tensor (as opposed to a variable). If the memory
 for the existing tensor cannot be re-used, a copy is made and updated.
 
 `indices` is an integer tensor containing indices into a new tensor of shape
-`shape`.  The last dimension of `indices` can be at most the rank of `shape`:
+`tensor.shape`.  The last dimension of `indices` can be at most the rank of
+`tensor.shape`:
 
-    indices.shape[-1] <= shape.rank
+    indices.shape[-1] <= tensor.shape.rank
 
 The last dimension of `indices` corresponds to indices into elements
-(if `indices.shape[-1] = shape.rank`) or slices
-(if `indices.shape[-1] < shape.rank`) along dimension `indices.shape[-1]` of
-`shape`.  `updates` is a tensor with shape
+(if `indices.shape[-1] = tensor.shape.rank`) or slices
+(if `indices.shape[-1] < tensor.shape.rank`) along dimension
+`indices.shape[-1]` of `tensor.shape`.  `updates` is a tensor with shape
 
-    indices.shape[:-1] + shape[indices.shape[-1]:]
+    indices.shape[:-1] + tensor.shape[indices.shape[-1]:]
 
 The simplest form of tensor_scatter_add is to add individual elements to a
 tensor by index. For example, say we want to add 4 elements in a rank-1


### PR DESCRIPTION
Fixes #37669. 
@mihaimaruseac and @karllessard , Please review this one.