### PR TITLE
Remove redundant cusolverDnIRSInfosGetNiters

### DIFF
--- a/tensorflow/stream_executor/cuda/cusolver_dense_10_2.inc
+++ b/tensorflow/stream_executor/cuda/cusolver_dense_10_2.inc
@@ -199,16 +199,6 @@ cusolverStatus_t CUSOLVERAPI cusolverDnIRSInfosGetNiters(
   return func_ptr(params, infos, niters);
 }
 
-cusolverStatus_t CUSOLVERAPI cusolverDnIRSInfosGetNiters(
-    cusolverDnIRSParams_t params, cusolverDnIRSInfos_t infos,
-    cusolver_int_t *niters) {
-  using FuncPtr = cusolverStatus_t(CUSOLVERAPI *)(
-      cusolverDnIRSParams_t, cusolverDnIRSInfos_t, cusolver_int_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusolverDnIRSInfosGetNiters");
-  if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(params, infos, niters);
-}
-
 cusolverStatus_t CUSOLVERAPI cusolverDnIRSInfosGetOuterNiters(
     cusolverDnIRSParams_t params, cusolverDnIRSInfos_t infos,
     cusolver_int_t *outer_niters) {


### PR DESCRIPTION
It seems to be defined twice.

TEST:build tensorflow with cuda 10.2