### PR TITLE
Lower case c++1z config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -19,7 +19,7 @@
 # Compiler options:
 #     cuda_clang:             Use clang when building CUDA code.
 #     c++17:                  Build with C++17 options
-#     C++1z:                  Build with C++17 options
+#     c++1z:                  Build with C++17 options
 #     avx_linux:              Build with avx instruction set on linux.
 #     avx2_linux:             Build with avx2 instruction set on linux.
 #     arch_native_linux:      Build with instruction sets available to the host machine on linux


### PR DESCRIPTION
The `.bazelrc` actually checks for `c++1z` and not `C++1z` (mind the capital `C`) so this should be accounted for in the docs.