### PR TITLE
[Grappler] Add Einsum to auto_mixed_precision whitelist

### DIFF
--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
@@ -69,6 +69,7 @@ class AutoMixedPrecisionLists {
         "CudnnRNNBackpropV3",
         "CudnnRNNV2",
         "CudnnRNNV3",
+        "Einsum",
         "GRUBlockCell",
         "GRUBlockCellGrad",
         "LSTMBlockCell",


### PR DESCRIPTION
Einsum is used in some of the official NLP models, and without whitelisting it they see no speedup from auto_mixed_precision.
The op calls into blas gemm routines, and so it should be treated the same as MatMul.

cc @reedwm @nluehr 