### PR TITLE
Fix `GetMatchingPaths` with special chars bug.

### DIFF
--- a/tensorflow/python/lib/io/file_io_test.py
+++ b/tensorflow/python/lib/io/file_io_test.py
@@ -159,6 +159,18 @@ class FileIoTest(test.TestCase):
     file_io.delete_recursively(dir_path)
     self.assertFalse(file_io.file_exists(os.path.join(dir_path, "file3.txt")))
 
+  def testGetMatchingFilesWhenParentDirContainsParantheses(self):
+    dir_path = os.path.join(self._base_dir, "dir_(special)")
+    file_io.create_dir(dir_path)
+    files = ["file1.txt", "file(2).txt"]
+    for name in files:
+      file_path = os.path.join(dir_path, name)
+      file_io.FileIO(file_path, mode="w").write("testing")
+    expected_match = [os.path.join(dir_path, name) for name in files]
+    glob_pattern = os.path.join(dir_path, "*")
+    self.assertItemsEqual(
+        file_io.get_matching_files(glob_pattern), expected_match)
+
   def testCreateRecursiveDir(self):
     dir_path = os.path.join(self._base_dir, "temp_dir/temp_dir1/temp_dir2")
     file_io.recursive_create_dir(dir_path)


### PR DESCRIPTION
After 5659465166daa218168c1f50f1d63c30f9f2bbd9, `GetMatchingPaths` was converted to use RE2 instead of `fnmatch` as that allows non-local filesystems (e.g., GCS, Hadoop, S3) to also be used from Windows. However, this breaks compatibility between `tf.io.gfile.glob` and Python `glob` and that results in tests silently failing or examples being silently skipped during training.

The fix is two-pronged. First, to fix #37758 only, we add regexp replacements for `(` and `)` in the pattern, escaping them before matching. After testing and seeing that this works, we then re-enable `fnmatch` on POSIX environments to reduce binary size, just like we did for mobile platforms.

Fixes #37758 (everywhere) and tensorflow/tensorboard#3260 (on posix platforms).

Tested via `bazel run //tensorflow/python:file_io_test` after adding a test for the pattern in #37758.

Will need to be cherry-picked onto `r2.2` branch.

PiperOrigin-RevId: 303009914
Change-Id: Ieab047f63e9ba6bb0ec0499e0fa864f6ca6090ff