### PR TITLE
[MLIR][XLA] Add ConcatenateOp to LHLO/HLO emitters

### DIFF
--- a/tensorflow/compiler/xla/service/mlir_gpu/hlo_dialect_emitter.cc
+++ b/tensorflow/compiler/xla/service/mlir_gpu/hlo_dialect_emitter.cc
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 #include "tensorflow/compiler/xla/service/mlir_gpu/hlo_dialect_emitter.h"
+#include <utility>
 
 #include "llvm/ADT/STLExtras.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"  // from @llvm-project
@@ -131,6 +132,22 @@ Status HloDialectEmitter::HandleBroadcast(HloInstruction* instr) {
   instruction_to_values_[instr] = builder_.create<hlo::BroadcastInDimOp>(
       getLocation(instr), llvm::makeArrayRef(res_type),
       instruction_to_values_[instr->operand(0)], broadcast_dim);
+  return Status::OK();
+}
+
+Status HloDialectEmitter::HandleConcatenate(HloInstruction* instr) {
+  int64 concatenate_dim = instr->concatenate_dimension();
+  TF_ASSIGN_OR_RETURN(Type res_type, ConvertTensorShapeToType<RankedTensorType>(
+                                         instr->shape(), builder_));
+
+  llvm::SmallVector<Value, 4> arguments;
+  for (auto operand : instr->operands()) {
+    arguments.push_back(instruction_to_values_[operand]);
+  }
+
+  instruction_to_values_[instr] = builder_.create<hlo::ConcatenateOp>(
+      getLocation(instr), llvm::makeArrayRef(res_type),
+      arguments, builder_.getI64IntegerAttr(concatenate_dim));
   return Status::OK();
 }
 

--- a/tensorflow/compiler/xla/service/mlir_gpu/hlo_dialect_emitter.cc
+++ b/tensorflow/compiler/xla/service/mlir_gpu/hlo_dialect_emitter.cc
@@ -113,6 +113,7 @@ Status HloDialectEmitter::DefaultAction(HloInstruction* instr) {
   TF_ASSIGN_OR_RETURN(auto res_type, ConvertTensorShapeToType<RankedTensorType>(
                                          instr->shape(), builder_));
   llvm::SmallVector<Value, 4> arguments;
+  arguments.reserve(instr->operand_count());
   for (auto operand : instr->operands()) {
     arguments.push_back(instruction_to_values_[operand]);
   }
@@ -141,6 +142,7 @@ Status HloDialectEmitter::HandleConcatenate(HloInstruction* instr) {
                                          instr->shape(), builder_));
 
   llvm::SmallVector<Value, 4> arguments;
+  arguments.reserve(instr->operand_count());
   for (auto operand : instr->operands()) {
     arguments.push_back(instruction_to_values_[operand]);
   }
@@ -221,6 +223,7 @@ Status HloDialectEmitter::HandleCompare(HloInstruction* instr) {
       builder_.getStringAttr(
           ComparisonDirectionToString(instr->comparison_direction())));
   llvm::SmallVector<Value, 4> arguments;
+  arguments.reserve(instr->operand_count());
   for (auto operand : instr->operands()) {
     arguments.push_back(instruction_to_values_[operand]);
   }

--- a/tensorflow/compiler/xla/service/mlir_gpu/hlo_dialect_emitter.h
+++ b/tensorflow/compiler/xla/service/mlir_gpu/hlo_dialect_emitter.h
@@ -54,6 +54,7 @@ class HloDialectEmitter : public DfsHloVisitorWithDefault {
   Status DefaultAction(HloInstruction* instr) override;
   Status HandleBroadcast(HloInstruction* instr) override;
   Status HandleCompare(HloInstruction* instr) override;
+  Status HandleConcatenate(HloInstruction* instr) override;
   Status HandleConstant(HloInstruction* instr) override;
   Status HandleIota(HloInstruction* instr) override;
   Status HandleParameter(HloInstruction* instr) override;

--- a/tensorflow/compiler/xla/service/mlir_gpu/lhlo_dialect_emitter.cc
+++ b/tensorflow/compiler/xla/service/mlir_gpu/lhlo_dialect_emitter.cc
@@ -261,11 +261,9 @@ Status LhloDialectEmitter::HandleConcatenate(HloInstruction* instr) {
 
   TF_ASSIGN_OR_RETURN(auto function, CreateFunction(*instr));
   OpBuilder func_builder(function.getBody());
-  llvm::SmallVector<Value, 4> arg_values{function.args_begin(),
-                                         function.args_end()};
-  Value result_memref = function.getArgument(function.getNumArguments() - 1);
   func_builder.create<lhlo::ConcatenateOp>(
-      getLocation(instr), arg_values, result_memref, concatenate_dim);
+      getLocation(instr), function.getArguments().drop_back(),
+      function.getArguments().back(), concatenate_dim);
   return Status::OK();
 }
 
@@ -292,7 +290,7 @@ Status LhloDialectEmitter::HandleFusion(HloInstruction* instr) {
   // Insert the write-back from the HLO computation to the result argument
   // buffer.
   body_builder.setInsertionPoint(fusion_op.region().back().getTerminator());
-  Value result_memref = function.getArgument(function.getNumArguments() - 1);
+  Value result_memref = function.getArguments().back();
   body_builder.create<::mlir::TensorStoreOp>(getLocation(instr), result,
                                              result_memref);
 

--- a/tensorflow/compiler/xla/service/mlir_gpu/lhlo_dialect_emitter.h
+++ b/tensorflow/compiler/xla/service/mlir_gpu/lhlo_dialect_emitter.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define TENSORFLOW_COMPILER_XLA_SERVICE_MLIR_GPU_LHLO_DIALECT_EMITTER_H_
 
 #include <memory>
+#include <utility>
 
 #include "absl/container/flat_hash_map.h"
 #include "mlir/IR/Builders.h"  // from @llvm-project
@@ -55,6 +56,7 @@ class LhloDialectEmitter : public DfsHloVisitorWithDefault,
   Status DefaultAction(HloInstruction* instr) override;
   Status HandleBroadcast(HloInstruction* instr) override;
   Status HandleCompare(HloInstruction* instr) override;
+  Status HandleConcatenate(HloInstruction* instr) override;
   Status HandleConstant(HloInstruction* instr) override;
   Status HandleCustomCall(HloInstruction* instr) override;
   Status HandleFusion(HloInstruction* instr) override;

--- a/tensorflow/compiler/xla/service/mlir_gpu/tests/BUILD
+++ b/tensorflow/compiler/xla/service/mlir_gpu/tests/BUILD
@@ -37,6 +37,7 @@ tf_cc_test(
         "broken_add.hlo",
         "ceil.hlo",
         "compare.hlo",
+        "concatenate.hlo",
         "const.hlo",
         "copy.hlo",
         "copy_transpose.hlo",

--- a/tensorflow/compiler/xla/service/mlir_gpu/tests/concatenate.hlo
+++ b/tensorflow/compiler/xla/service/mlir_gpu/tests/concatenate.hlo
@@ -1,0 +1,12 @@
+HloModule Concatenate
+
+ENTRY %Concatenate (x: f32[2,3], y: f32[2,2]) -> f32[2,5] {
+  %x = f32[2,3]{1,0} parameter(0)
+  %y = f32[2,2]{1,0} parameter(1)
+  ROOT %concatenate = f32[2,5]{1,0} concatenate(f32[2,3]{1,0} %x, f32[2,2]{1,0} %y), dimensions={1}
+}
+
+// CHECK: func @concatenate(%[[ARG0:.*]]: [[TYPE0:.*]], %[[ARG1:.*]]: [[TYPE1:.*]], %[[RESULT:.*]]: [[RTYPE:.*]]) {
+// CHECK:   "xla_lhlo.concatenate"(%[[ARG0]], %[[ARG1]], %[[RESULT]])
+// CHECK:   {dimension = 1 : i64} : ([[TYPE0]], [[TYPE1]], [[RTYPE]]) -> ()
+// CHECK: }

--- a/tensorflow/compiler/xla/service/mlir_gpu/tests/mlir_gpu_lhlo_gen_test.cc
+++ b/tensorflow/compiler/xla/service/mlir_gpu/tests/mlir_gpu_lhlo_gen_test.cc
@@ -218,5 +218,11 @@ TEST_F(LhloGenTest, Tanh) {
                                               "tanh.hlo"));
 }
 
+TEST_F(LhloGenTest, Concatenate) {
+  CompileAndVerifyIr(tensorflow::io::JoinPath("tensorflow", "compiler", "xla",
+                                              "service", "mlir_gpu", "tests",
+                                              "concatenate.hlo"));
+}
+
 }  // namespace mlir_gpu
 }  // namespace xla


### PR DESCRIPTION
This is a PR from JIZHI, the AI platform in Tencent.
@sherhut @pifon2a 

We work on TensorFlow/MLIR to make mlir_gpu enable.