### PR TITLE
[tflite] fix hexagon delegate profiling unit

### DIFF
--- a/tensorflow/lite/experimental/delegates/hexagon/hexagon_delegate_kernel.cc
+++ b/tensorflow/lite/experimental/delegates/hexagon/hexagon_delegate_kernel.cc
@@ -376,7 +376,7 @@ void HexagonDelegateKernel::PrintPerformanceData(Profiler* profiler) {
     if (node_id != -1 && op_type_id >= 0) {
       profiler->AddEvent((op_type_id < 0 ? "" : op_name.data()),
                          Profiler::EventType::OPERATOR_INVOKE_EVENT, node_id, 0,
-                         counter);
+                         counter / 1000);
     }
   }
 }


### PR DESCRIPTION
it seems the unit of the number returned by GetCycles() is
microsecond instead of millisecond. Dividing it by 1,000 so
that we can get more reasonable numbers when doing
something like

```
./benchmark_model --graph=... --use_hexagon=1 --hexagon_profiling=1
```