### PR TITLE
Adapting xla_legalize_to_linalg for using buffer assignment

### DIFF
--- a/tensorflow/compiler/mlir/xla/BUILD
+++ b/tensorflow/compiler/mlir/xla/BUILD
@@ -180,6 +180,7 @@ cc_library(
         ":hlo",
         ":lhlo",
         ":map_xla_to_scalar_op",
+        ":buffer_assignment",
         "@com_google_absl//absl/memory",
         "@llvm-project//llvm:support",
         "@llvm-project//mlir:IR",

--- a/tensorflow/compiler/mlir/xla/transforms/passes.h
+++ b/tensorflow/compiler/mlir/xla/transforms/passes.h
@@ -59,6 +59,10 @@ std::unique_ptr<OpPassBase<ModuleOp>> createLegalizeToLhloPass();
 // Lowers from HLO dialect to Linalg dialect.
 std::unique_ptr<OpPassBase<FuncOp>> createLegalizeHloToLinalgPass();
 
+// Lowers from HLO dialect to Linalg dialect by using memrefs instead of
+// tensors.
+std::unique_ptr<OpPassBase<FuncOp>> createLegalizeHloToLinalgWithBufferPass();
+
 // Removes unnecessary LHLO copies which copy from the allocated buffers to the
 // block arguments. These copies have been created by replacing TensorStoreOp
 // with LHLO.CopyOp in HLO to LHLO lowering.

--- a/tensorflow/compiler/mlir/xla/transforms/rewriters.h
+++ b/tensorflow/compiler/mlir/xla/transforms/rewriters.h
@@ -23,6 +23,17 @@ limitations under the License.
 #include "mlir/Transforms/DialectConversion.h"  // TF:llvm-project
 
 namespace mlir {
+
+enum LinalgTransition : unsigned int {
+  LHLO_TO_LINALG,
+  HLO_TO_LINALG_WITH_TENSOR,
+  HLO_TO_LINALG_WITH_BUFFER
+};
+
+namespace xla {
+class BufferAssignmentLegalizer;
+}  // namespace xla
+
 namespace xla_hlo {
 
 // Collection of rewrite patterns for lowering a general dot product.
@@ -42,8 +53,11 @@ void populateHLOToLHLOConversionPattern(MLIRContext *context,
                                         OwningRewritePatternList *patterns);
 
 // Collection of rewrite patterns for lowering of HLO to Linalg dialect.
-void populateHLOToLinalgConversionPattern(MLIRContext *context,
-                                          OwningRewritePatternList *patterns);
+template <LinalgTransition transition>
+void populateHLOToLinalgConversionPattern(
+    MLIRContext* context,
+    xla::BufferAssignmentLegalizer* bufferAssignment,
+    OwningRewritePatternList* patterns);
 
 // Sets up legality definitions for materializing broadcasts.
 void SetupMaterializeBroadcastsLegality(MLIRContext *context,


### PR DESCRIPTION
In this PR, we implemented our proposed [BufferAssignment](https://github.com/tensorflow/tensorflow/pull/37212) in HLO-to-Linalg legalization pipeline. Please note that this PR must be merged after BufferAssignment PR since it cannot be built.