### PR TITLE
Fix Bug in MixedPrecisionLossScaleOptimizer

### DIFF
--- a/tensorflow/python/keras/optimizers_test.py
+++ b/tensorflow/python/keras/optimizers_test.py
@@ -241,7 +241,6 @@ class KerasOptimizersTest(keras_parameterized.TestCase):
     model = keras.models.Sequential()
     model.add(keras.layers.Dense(
         2, input_shape=(3,), kernel_constraint=keras.constraints.MaxNorm(1)))
-    # This is possible
     model.compile(
         loss='mean_squared_error',
         optimizer=optimizer,

--- a/tensorflow/python/keras/optimizers_test.py
+++ b/tensorflow/python/keras/optimizers_test.py
@@ -31,6 +31,7 @@ from tensorflow.python.keras import testing_utils
 from tensorflow.python.keras.utils import np_utils
 from tensorflow.python.platform import test
 from tensorflow.python.training.adam import AdamOptimizer
+from tensorflow.python.training.experimental.loss_scale_optimizer import MixedPrecisionLossScaleOptimizer
 
 
 def _get_model(input_dim, num_hidden, output_dim):
@@ -232,6 +233,24 @@ class KerasOptimizersTest(keras_parameterized.TestCase):
     with self.assertRaises(ValueError):
       _ = keras.optimizers.Adam(clipnorm=-2.0)
 
+  def test_mixed_precision_loss_scale_optimizer(self):
+    if context.executing_eagerly():
+      self.skipTest(
+          'v1 optimizer does not run in eager mode')
+    optimizer = MixedPrecisionLossScaleOptimizer(AdamOptimizer(), 'dynamic')
+    model = keras.models.Sequential()
+    model.add(keras.layers.Dense(
+        2, input_shape=(3,), kernel_constraint=keras.constraints.MaxNorm(1)))
+    # This is possible
+    model.compile(
+        loss='mean_squared_error',
+        optimizer=optimizer,
+        run_eagerly=testing_utils.should_run_eagerly())
+    model.fit(np.random.random((5, 3)),
+              np.random.random((5, 2)),
+              epochs=1,
+              batch_size=5,
+              verbose=0)
 
 if __name__ == '__main__':
   test.main()

--- a/tensorflow/python/training/experimental/loss_scale.py
+++ b/tensorflow/python/training/experimental/loss_scale.py
@@ -197,10 +197,6 @@ class LossScale(trackable.Trackable):
     """Creates the LossScale from its config."""
     return cls(**config)
 
-  def variables(self):
-    """Returns the variables defined in this LossScale."""
-    return list(self._weights.values())
-
 
 def get_loss_scale_weights(loss_scale):
   return loss_scale._weights.values()  # pylint: disable=protected-access

--- a/tensorflow/python/training/experimental/loss_scale.py
+++ b/tensorflow/python/training/experimental/loss_scale.py
@@ -197,6 +197,10 @@ class LossScale(trackable.Trackable):
     """Creates the LossScale from its config."""
     return cls(**config)
 
+  def variables(self):
+    """Returns the variables defined in this LossScale."""
+    return list(self._weights.values())
+
 
 def get_loss_scale_weights(loss_scale):
   return loss_scale._weights.values()  # pylint: disable=protected-access

--- a/tensorflow/python/training/experimental/loss_scale_optimizer.py
+++ b/tensorflow/python/training/experimental/loss_scale_optimizer.py
@@ -243,3 +243,7 @@ class MixedPrecisionLossScaleOptimizer(optimizer.Optimizer):
   def _resource_apply_dense(self, grad, handle):
     """This function should never be called."""
     raise RuntimeError('This function should never be called')
+
+  def variables(self):
+    """Returns the variables of the Optimizer."""
+    return self._optimizer.variables() + self._loss_scale.variables()

--- a/tensorflow/python/training/experimental/loss_scale_optimizer.py
+++ b/tensorflow/python/training/experimental/loss_scale_optimizer.py
@@ -246,5 +246,5 @@ class MixedPrecisionLossScaleOptimizer(optimizer.Optimizer):
 
   def variables(self):
     """Returns the variables of the Optimizer."""
-    return self._optimizer.variables() + \
-        list(self._loss_scale._weights.values()) # pylint: disable=protected-access
+    return (self._optimizer.variables() +
+        list(self._loss_scale._weights.values())) # pylint: disable=protected-access

--- a/tensorflow/python/training/experimental/loss_scale_optimizer.py
+++ b/tensorflow/python/training/experimental/loss_scale_optimizer.py
@@ -246,4 +246,5 @@ class MixedPrecisionLossScaleOptimizer(optimizer.Optimizer):
 
   def variables(self):
     """Returns the variables of the Optimizer."""
-    return self._optimizer.variables() + self._loss_scale.variables()
+    return self._optimizer.variables() + \
+        list(self._loss_scale._weights.values()) # pylint: disable=protected-access

--- a/tensorflow/python/training/experimental/loss_scale_optimizer.py
+++ b/tensorflow/python/training/experimental/loss_scale_optimizer.py
@@ -247,4 +247,4 @@ class MixedPrecisionLossScaleOptimizer(optimizer.Optimizer):
   def variables(self):
     """Returns the variables of the Optimizer."""
     return (self._optimizer.variables() +
-        list(self._loss_scale._weights.values())) # pylint: disable=protected-access
+            list(self._loss_scale._weights.values())) # pylint: disable=protected-access


### PR DESCRIPTION
This is a PR from JIZHI, the AI platform in Tencent.

This pr mainly fixed the error that when disable eager execution and use the `MixedPrecisionLossScaleOptimizer` as the opt for keras model will trigger
```bash
FailedPreconditionError: Error while reading resource variable current_loss_scale from Container: localhost. This could mean that the variable was uninitialized. Not found: Resource localhost/current_loss_scale/N10tensorflow3VarE does not exist.
	 [[{{node training/ReadVariableOp_1}}]]
```
The error is able to be replicated in tf-nightly, see gist [here](https://colab.research.google.com/gist/zhuzilin/f116e9689e2611333719fa753af31599/amp-opt-bug.ipynb)

The reason for this error is that the `MixedPrecisionLossScaleOptimizer` failed to pass the variables defined in its base optimizer and loss scale to keras backend and initialize them.

This PR fixed it by overwriting the `variables()` function, which is the function called to initialize variables.

Thank you for your time on reviewing this PR.