### PR TITLE
2.2-rc2 cherry-pick request: Delegate _aggregate_gradients in LossScaleOptimizer.

### DIFF
--- a/tensorflow/python/keras/mixed_precision/experimental/loss_scale_optimizer.py
+++ b/tensorflow/python/keras/mixed_precision/experimental/loss_scale_optimizer.py
@@ -329,6 +329,9 @@ class LossScaleOptimizer(optimizer_v2.OptimizerV2):
   def set_weights(self, weights):
     return self._optimizer.set_weights(weights)
 
+  def _aggregate_gradients(self, grads_and_vars):
+    return self._optimizer._aggregate_gradients(grads_and_vars)  # pylint: disable=protected-access
+
   # For the most part, we only expose methods in the base OptimizerV2, not
   # individual subclasses like Adam. However, although "learning_rate" and "lr"
   # properties are not part of the base OptimizerV2 class, they are part of most


### PR DESCRIPTION
Fixes https://github.com/tensorflow/tensorflow/issues/37765 for real. This time I actually tested it fixes it by running the code example in the first post.