### PR TITLE
Fix for issue #35318: zero offset for weights should be zero for int8…

### DIFF
--- a/tensorflow/lite/micro/kernels/fully_connected_test.cc
+++ b/tensorflow/lite/micro/kernels/fully_connected_test.cc
@@ -328,8 +328,8 @@ TF_LITE_MICRO_TEST(SimpleTestQuantizedInt8) {
 
   const float input_min = -63.5f;
   const float input_max = 64.0f;
-  const float weights_min = -63.5f;
-  const float weights_max = 64.0f;
+  const float weights_min = -64.0f;
+  const float weights_max = 63.5f;
   const float bias_scale = 0.25f;
   const float output_min = -127.0f;
   const float output_max = 128.0f;
@@ -458,8 +458,8 @@ TF_LITE_MICRO_TEST(SimpleTestQuantizedInt8Relu) {
 
   const float input_min = -63.5f;
   const float input_max = 64.0f;
-  const float weights_min = -63.5f;
-  const float weights_max = 64.0f;
+  const float weights_min = -64.0f;
+  const float weights_max = 63.5f;
   const float bias_scale = 0.25f;
   const float output_min = -127.0f;
   const float output_max = 128.0f;
@@ -588,8 +588,8 @@ TF_LITE_MICRO_TEST(SimpleTestQuantizedInt8OutputMultiplierGreaterThan1) {
 
   const float input_min = -127.0f;
   const float input_max = 128.0f;
-  const float weights_min = -127.0f;
-  const float weights_max = 128.0f;
+  const float weights_min = -128.0f;
+  const float weights_max = 127.0f;
   const float bias_scale = 1.0f;
   const float output_min = -63.5f;
   const float output_max = 64.0f;
@@ -745,8 +745,8 @@ TF_LITE_MICRO_TEST(SimpleTest4DInputQuantizedInt8) {
 
   const float input_min = -63.5f;
   const float input_max = 64.0f;
-  const float weights_min = -63.5f;
-  const float weights_max = 64.0f;
+  const float weights_min = -64.0f;
+  const float weights_max = 63.5f;
   const float bias_scale = 0.25f;
   const float output_min = -127.0f;
   const float output_max = 128.0f;
@@ -876,8 +876,8 @@ TF_LITE_MICRO_TEST(SimpleTest4DInputQuantizedInt8OutputMultiplierGreaterThan1) {
 
   const float input_min = -127.0f;
   const float input_max = 128.0f;
-  const float weights_min = -127.0f;
-  const float weights_max = 128.0f;
+  const float weights_min = -128.0f;
+  const float weights_max = 127.0f;
   const float bias_scale = 1.0f;
   const float output_min = -63.5f;
   const float output_max = 64.0f;


### PR DESCRIPTION
… fully connect tests

For asymmetric data types, the fully connect kernel expects the zero offset of the weights tensor to be zero. this PR updates the test parameters to fix this.