### PR TITLE
Add usage examples and improve documentation on tf.keras.applications models

### DIFF
--- a/tensorflow/python/keras/applications/densenet.py
+++ b/tensorflow/python/keras/applications/densenet.py
@@ -438,16 +438,16 @@ DOC = """
   features = model.predict(x)
   ```
 
-  >>>model = DenseNet121(weights = None)
-  >>>model.name
+  >>> model = DenseNet121(weights = None)
+  >>> model.name
   'densenet121'
 
-  >>>model = DenseNet169(weights = None)
-  >>>model.name
+  >>> model = DenseNet169(weights = None)
+  >>> model.name
   'densenet169'
 
-  >>>model = DenseNet201(weights = None)
-  >>>model.name
+  >>> model = DenseNet201(weights = None)
+  >>> model.name
   'densenet201'
 
   Raises:

--- a/tensorflow/python/keras/applications/densenet.py
+++ b/tensorflow/python/keras/applications/densenet.py
@@ -430,6 +430,40 @@ DOC = """
 
   Returns:
     A Keras model instance.
+
+  ```python
+  #Extract image features with DenseNet121
+  from keras.applications.DenseNet121 import DenseNet121
+  from keras.preprocessing import image
+  from keras.applications.DenseNet121 import preprocess_input
+  import numpy as np
+
+  #create a DenseNet121 model pre-trained on imagenet
+  model = DenseNet121(weights='imagenet', include_top=False)
+
+  #process the input
+  img_path = 'elephant_example.jpg'
+  img = image.load_img(img_path, target_size=(224, 224))
+  x = image.img_to_array(img)
+  x = np.expand_dims(x, axis=0)
+  x = preprocess_input(x)
+
+  #extract the features
+  features = model.predict(x)
+  ```
+
+  >>>model = DenseNet121(weights = None)
+  >>>model.name
+  'densenet121'
+
+  >>>model = DenseNet169(weights = None)
+  >>>model.name
+  'densenet169'
+
+  >>>model = DenseNet201(weights = None)
+  >>>model.name
+  'densenet201'
+
 """
 
 setattr(DenseNet121, '__doc__', DenseNet121.__doc__ + DOC)

--- a/tensorflow/python/keras/applications/densenet.py
+++ b/tensorflow/python/keras/applications/densenet.py
@@ -397,7 +397,7 @@ DOC = """
   Optionally loads weights pre-trained on ImageNet.
   Note that the data format convention used by the model is
   the one specified in your Keras config at `~/.keras/keras.json`.
-  
+
   Arguments:
     include_top: whether to include the fully-connected
       layer at the top of the network.
@@ -433,9 +433,9 @@ DOC = """
 
   ```python
   #Extract image features with DenseNet121
-  from keras.applications.densenet import DenseNet121
-  from keras.preprocessing import image
-  from keras.applications.densenet import preprocess_input
+  from tensorflow.keras.applications.densenet import DenseNet121
+  from tensorflow.keras.preprocessing import image
+  from tensorflow.keras.applications.densenet import preprocess_input
   import numpy as np
 
   #create a DenseNet121 model pre-trained on imagenet

--- a/tensorflow/python/keras/applications/densenet.py
+++ b/tensorflow/python/keras/applications/densenet.py
@@ -414,7 +414,7 @@ DOC = """
       and width and height should be no smaller than 32.
       E.g. `(200, 200, 3)` would be one valid value.
     pooling: Optional pooling mode for feature extraction
-      when `include_top` is `False`.
+      when `include_top` is `False`. It could be:
       - `None` means that the output of the model will be
           the 4D tensor output of the
           last convolutional block.

--- a/tensorflow/python/keras/applications/densenet.py
+++ b/tensorflow/python/keras/applications/densenet.py
@@ -162,9 +162,9 @@ def DenseNet(
       and width and height should be no smaller than 32.
       E.g. `(200, 200, 3)` would be one valid value.
     pooling: optional pooling mode for feature extraction when `include_top` is
-      `False`. If `'max'` or `'avg'` pooling is applied, output of the model will
-      be a 2D tensor. `None` will directly output the last convolutional layer,
-      a 4D tensor.
+      `False`. If `'max'` or `'avg'` pooling is applied, output of the model
+      will be a 2D tensor. `None` will directly output the last convolutional
+      layer, a 4D tensor.
     classes: optional number of classes to classify images
       into, only to be specified if `include_top` is True, and
       if no `weights` argument is specified.
@@ -407,9 +407,9 @@ DOC = """
       and width and height should be no smaller than 32.
       E.g. `(200, 200, 3)` would be one valid value.
     pooling: optional pooling mode for feature extraction when `include_top` is
-      `False`. If `'max'` or `'avg'` pooling is applied, output of the model will
-      be a 2D tensor. `None` will directly output the last convolutional layer,
-      a 4D tensor.
+      `False`. If `'max'` or `'avg'` pooling is applied, the output of the model
+      will be a 2D tensor. `None` will directly output the last convolutional
+      layer, a 4D tensor.
     classes: optional number of classes to classify images
       into, only to be specified if `include_top` is True, and
       if no `weights` argument is specified.

--- a/tensorflow/python/keras/applications/densenet.py
+++ b/tensorflow/python/keras/applications/densenet.py
@@ -433,9 +433,9 @@ DOC = """
 
   ```python
   #Extract image features with DenseNet121
-  from keras.applications.DenseNet121 import DenseNet121
+  from keras.applications.densenet import DenseNet121
   from keras.preprocessing import image
-  from keras.applications.DenseNet121 import preprocess_input
+  from keras.applications.densenet import preprocess_input
   import numpy as np
 
   #create a DenseNet121 model pre-trained on imagenet

--- a/tensorflow/python/keras/applications/densenet.py
+++ b/tensorflow/python/keras/applications/densenet.py
@@ -162,7 +162,7 @@ def DenseNet(
       and width and height should be no smaller than 32.
       E.g. `(200, 200, 3)` would be one valid value.
     pooling: optional pooling mode for feature extraction
-      when `include_top` is `False`.
+      when `include_top` is `False`. It could be:
       - `None` means that the output of the model will be
           the 4D tensor output of the
           last convolutional block.
@@ -469,7 +469,6 @@ DOC = """
       or invalid input shape.
     ValueError: if `classifier_activation` is not `softmax` or `None` when
       using a pretrained top layer.
-
 """
 
 setattr(DenseNet121, '__doc__', DenseNet121.__doc__ + DOC)

--- a/tensorflow/python/keras/applications/densenet.py
+++ b/tensorflow/python/keras/applications/densenet.py
@@ -464,6 +464,12 @@ DOC = """
   >>>model.name
   'densenet201'
 
+  Raises:
+    ValueError: in case of invalid argument for `weights`,
+      or invalid input shape.
+    ValueError: if `classifier_activation` is not `softmax` or `None` when
+      using a pretrained top layer.
+
 """
 
 setattr(DenseNet121, '__doc__', DenseNet121.__doc__ + DOC)

--- a/tensorflow/python/keras/applications/densenet.py
+++ b/tensorflow/python/keras/applications/densenet.py
@@ -161,17 +161,10 @@ def DenseNet(
       It should have exactly 3 inputs channels,
       and width and height should be no smaller than 32.
       E.g. `(200, 200, 3)` would be one valid value.
-    pooling: optional pooling mode for feature extraction
-      when `include_top` is `False`. It could be:
-      - `None` means that the output of the model will be
-          the 4D tensor output of the
-          last convolutional block.
-      - `avg` means that global average pooling
-          will be applied to the output of the
-          last convolutional block, and thus
-          the output of the model will be a 2D tensor.
-      - `max` means that global max pooling will
-          be applied.
+    pooling: optional pooling mode for feature extraction when `include_top` is
+      `False`. If `'max'` or `'avg'` pooling is applied, output of the model will
+      be a 2D tensor. `None` will directly output the last convolutional layer,
+      a 4D tensor.
     classes: optional number of classes to classify images
       into, only to be specified if `include_top` is True, and
       if no `weights` argument is specified.
@@ -413,17 +406,10 @@ DOC = """
       It should have exactly 3 inputs channels,
       and width and height should be no smaller than 32.
       E.g. `(200, 200, 3)` would be one valid value.
-    pooling: Optional pooling mode for feature extraction
-      when `include_top` is `False`. It could be:
-      - `None` means that the output of the model will be
-          the 4D tensor output of the
-          last convolutional block.
-      - `avg` means that global average pooling
-          will be applied to the output of the
-          last convolutional block, and thus
-          the output of the model will be a 2D tensor.
-      - `max` means that global max pooling will
-          be applied.
+    pooling: optional pooling mode for feature extraction when `include_top` is
+      `False`. If `'max'` or `'avg'` pooling is applied, output of the model will
+      be a 2D tensor. `None` will directly output the last convolutional layer,
+      a 4D tensor.
     classes: optional number of classes to classify images
       into, only to be specified if `include_top` is True, and
       if no `weights` argument is specified.

--- a/tensorflow/python/keras/applications/efficientnet.py
+++ b/tensorflow/python/keras/applications/efficientnet.py
@@ -186,17 +186,10 @@ def EfficientNet(
     input_shape: optional shape tuple, only to be specified
         if `include_top` is False.
         It should have exactly 3 inputs channels.
-    pooling: optional pooling mode for feature extraction
-        when `include_top` is `False`. It could be:
-        - `None` means that the output of the model will be
-            the 4D tensor output of the
-            last convolutional layer.
-        - `avg` means that global average pooling
-            will be applied to the output of the
-            last convolutional layer, and thus
-            the output of the model will be a 2D tensor.
-        - `max` means that global max pooling will
-            be applied.
+    pooling: optional pooling mode for feature extraction when `include_top` is
+        `False`. If `'max'` or `'avg'` pooling is applied, the output of the
+        model will be a 2D tensor. `None` will directly output the last
+        convolutional layer, a 4D tensor.
     classes: optional number of classes to classify images
         into, only to be specified if `include_top` is True, and
         if no `weights` argument is specified.

--- a/tensorflow/python/keras/applications/efficientnet.py
+++ b/tensorflow/python/keras/applications/efficientnet.py
@@ -187,7 +187,7 @@ def EfficientNet(
         if `include_top` is False.
         It should have exactly 3 inputs channels.
     pooling: optional pooling mode for feature extraction
-        when `include_top` is `False`.
+        when `include_top` is `False`. It could be:
         - `None` means that the output of the model will be
             the 4D tensor output of the
             last convolutional layer.

--- a/tensorflow/python/keras/applications/inception_resnet_v2.py
+++ b/tensorflow/python/keras/applications/inception_resnet_v2.py
@@ -112,8 +112,8 @@ def InceptionResNetV2(include_top=True,
   features = model.predict(x)
   ```
 
-  >>>model = InceptionResNetV2(weights = None)
-  >>>model.name
+  >>> model = InceptionResNetV2(weights = None)
+  >>> model.name
   'inception_resnet_v2'
 
   Raises:

--- a/tensorflow/python/keras/applications/inception_resnet_v2.py
+++ b/tensorflow/python/keras/applications/inception_resnet_v2.py
@@ -74,15 +74,10 @@ def InceptionResNetV2(include_top=True,
       It should have exactly 3 inputs channels,
       and width and height should be no smaller than 75.
       E.g. `(150, 150, 3)` would be one valid value.
-    pooling: Optional pooling mode for feature extraction
-      when `include_top` is `False`. It could be:
-      - `None` means that the output of the model will be
-          the 4D tensor output of the last convolutional block.
-      - `'avg'` means that global average pooling
-          will be applied to the output of the
-          last convolutional block, and thus
-          the output of the model will be a 2D tensor.
-      - `'max'` means that global max pooling will be applied.
+    pooling: optional pooling mode for feature extraction when `include_top` is
+        `False`. If `max` or `avg` pooling is applied, output of the model will
+        be a 2D tensor. `None` will directly output the last convolutional layer,
+        a 4D tensor.
     classes: optional number of classes to classify images
       into, only to be specified if `include_top` is `True`, and
       if no `weights` argument is specified.

--- a/tensorflow/python/keras/applications/inception_resnet_v2.py
+++ b/tensorflow/python/keras/applications/inception_resnet_v2.py
@@ -75,7 +75,7 @@ def InceptionResNetV2(include_top=True,
       and width and height should be no smaller than 75.
       E.g. `(150, 150, 3)` would be one valid value.
     pooling: Optional pooling mode for feature extraction
-      when `include_top` is `False`.
+      when `include_top` is `False`. It could be:
       - `None` means that the output of the model will be
           the 4D tensor output of the last convolutional block.
       - `'avg'` means that global average pooling

--- a/tensorflow/python/keras/applications/inception_resnet_v2.py
+++ b/tensorflow/python/keras/applications/inception_resnet_v2.py
@@ -75,9 +75,9 @@ def InceptionResNetV2(include_top=True,
       and width and height should be no smaller than 75.
       E.g. `(150, 150, 3)` would be one valid value.
     pooling: optional pooling mode for feature extraction when `include_top` is
-        `False`. If `max` or `avg` pooling is applied, output of the model will
-        be a 2D tensor. `None` will directly output the last convolutional layer,
-        a 4D tensor.
+        `False`. If `'max'` or `'avg'` pooling is applied, the output of the
+        model will be a 2D tensor. `None` will directly output the last
+        convolutional layer, a 4D tensor.
     classes: optional number of classes to classify images
       into, only to be specified if `include_top` is `True`, and
       if no `weights` argument is specified.
@@ -93,7 +93,8 @@ def InceptionResNetV2(include_top=True,
 
   ```python
   #Extract image features with InceptionResNetV2
-  from tensorflow.keras.applications.inception_resnet_v2 import InceptionResNetV2
+  from tensorflow.keras.applications.inception_resnet_v2 \
+  import InceptionResNetV2
   from tensorflow.keras.preprocessing import image
   from tensorflow.keras.applications.inception_resnet_v2 import preprocess_input
   import numpy as np

--- a/tensorflow/python/keras/applications/inception_resnet_v2.py
+++ b/tensorflow/python/keras/applications/inception_resnet_v2.py
@@ -94,6 +94,33 @@ def InceptionResNetV2(include_top=True,
   Returns:
     A `keras.Model` instance.
 
+  Example:
+
+  ```python
+  #Extract image features with InceptionResNetV2
+  from tensorflow.keras.applications.inception_resnet_v2 import InceptionResNetV2
+  from tensorflow.keras.preprocessing import image
+  from tensorflow.keras.applications.inception_resnet_v2 import preprocess_input
+  import numpy as np
+
+  #create a InceptionResNetV2 model pre-trained on imagenet
+  model = InceptionResNetV2(weights='imagenet', include_top=False)
+
+  #process the input
+  img_path = 'elephant_example.jpg'
+  img = image.load_img(img_path, target_size=(224, 224))
+  x = image.img_to_array(img)
+  x = np.expand_dims(x, axis=0)
+  x = preprocess_input(x)
+
+  #extract the features
+  features = model.predict(x)
+  ```
+
+  >>>model = InceptionResNetV2(weights = None)
+  >>>model.name
+  'inception_resnet_v2'
+
   Raises:
     ValueError: in case of invalid argument for `weights`,
       or invalid input shape.

--- a/tensorflow/python/keras/applications/inception_v3.py
+++ b/tensorflow/python/keras/applications/inception_v3.py
@@ -120,8 +120,8 @@ def InceptionV3(
   features = model.predict(x)
   ```
 
-  >>>model = InceptionV3(weights = None)
-  >>>model.name
+  >>> model = InceptionV3(weights = None)
+  >>> model.name
   'inception_v3'
 
   Raises:

--- a/tensorflow/python/keras/applications/inception_v3.py
+++ b/tensorflow/python/keras/applications/inception_v3.py
@@ -102,6 +102,33 @@ def InceptionV3(
   Returns:
     A `keras.Model` instance.
 
+  Example:
+
+  ```python
+  #Extract image features with InceptionV3
+  from tensorflow.keras.applications.inception_v3 import InceptionV3
+  from tensorflow.keras.preprocessing import image
+  from tensorflow.keras.applications.inception_v3 import preprocess_input
+  import numpy as np
+
+  #create a InceptionV3 model pre-trained on imagenet
+  model = InceptionV3(weights='imagenet', include_top=False)
+
+  #process the input
+  img_path = 'elephant_example.jpg'
+  img = image.load_img(img_path, target_size=(224, 224))
+  x = image.img_to_array(img)
+  x = np.expand_dims(x, axis=0)
+  x = preprocess_input(x)
+
+  #extract the features
+  features = model.predict(x)
+  ```
+
+  >>>model = InceptionV3(weights = None)
+  >>>model.name
+  'inception_v3'
+
   Raises:
     ValueError: in case of invalid argument for `weights`,
       or invalid input shape.

--- a/tensorflow/python/keras/applications/inception_v3.py
+++ b/tensorflow/python/keras/applications/inception_v3.py
@@ -84,9 +84,9 @@ def InceptionV3(
       E.g. `(150, 150, 3)` would be one valid value.
       `input_shape` will be ignored if the `input_tensor` is provided.
     pooling: optional pooling mode for feature extraction when `include_top` is
-        `False`. If `max` or `avg` pooling is applied, output of the model will
-        be a 2D tensor. `None` will directly output the last convolutional layer,
-        a 4D tensor.
+        `False`. If `'max'` or `'avg'` pooling is applied, the output of the
+        model will be a 2D tensor. `None` will directly output the last
+        convolutional layer, a 4D tensor.
     classes: optional number of classes to classify images
       into, only to be specified if `include_top` is True, and
       if no `weights` argument is specified. Default to 1000.

--- a/tensorflow/python/keras/applications/inception_v3.py
+++ b/tensorflow/python/keras/applications/inception_v3.py
@@ -84,7 +84,7 @@ def InceptionV3(
       E.g. `(150, 150, 3)` would be one valid value.
       `input_shape` will be ignored if the `input_tensor` is provided.
     pooling: Optional pooling mode for feature extraction
-      when `include_top` is `False`.
+      when `include_top` is `False`. It could be:
       - `None` (default) means that the output of the model will be
           the 4D tensor output of the last convolutional block.
       - `avg` means that global average pooling

--- a/tensorflow/python/keras/applications/inception_v3.py
+++ b/tensorflow/python/keras/applications/inception_v3.py
@@ -83,15 +83,10 @@ def InceptionV3(
       and width and height should be no smaller than 75.
       E.g. `(150, 150, 3)` would be one valid value.
       `input_shape` will be ignored if the `input_tensor` is provided.
-    pooling: Optional pooling mode for feature extraction
-      when `include_top` is `False`. It could be:
-      - `None` (default) means that the output of the model will be
-          the 4D tensor output of the last convolutional block.
-      - `avg` means that global average pooling
-          will be applied to the output of the
-          last convolutional block, and thus
-          the output of the model will be a 2D tensor.
-      - `max` means that global max pooling will be applied.
+    pooling: optional pooling mode for feature extraction when `include_top` is
+        `False`. If `max` or `avg` pooling is applied, output of the model will
+        be a 2D tensor. `None` will directly output the last convolutional layer,
+        a 4D tensor.
     classes: optional number of classes to classify images
       into, only to be specified if `include_top` is True, and
       if no `weights` argument is specified. Default to 1000.

--- a/tensorflow/python/keras/applications/mobilenet.py
+++ b/tensorflow/python/keras/applications/mobilenet.py
@@ -149,6 +149,33 @@ def MobileNet(input_shape=None,
   Returns:
     A `keras.Model` instance.
 
+  Example:
+
+  ```python
+  #Extract image features with MobileNet-224
+  from tensorflow.keras.applications.mobilenet import MobileNet
+  from tensorflow.keras.preprocessing import image
+  from tensorflow.keras.applications.mobilenet import preprocess_input
+  import numpy as np
+
+  #create a MobileNet model pre-trained on imagenet
+  model = MobileNet(weights='imagenet', include_top=False, input_shape=[224,224,3])
+
+  #process the input
+  img_path = 'elephant_example.jpg'
+  img = image.load_img(img_path, target_size=(224, 224))
+  x = image.img_to_array(img)
+  x = np.expand_dims(x, axis=0)
+  x = preprocess_input(x)
+
+  #extract the features
+  features = model.predict(x)
+  ```
+
+  >>>model = MobileNet(weights = None, input_shape=[224,224,3])
+  >>>model.name
+  'mobilenet_1.00_224'
+
   Raises:
     ValueError: in case of invalid argument for `weights`,
       or invalid input shape.

--- a/tensorflow/python/keras/applications/mobilenet.py
+++ b/tensorflow/python/keras/applications/mobilenet.py
@@ -167,8 +167,8 @@ def MobileNet(input_shape=None,
   features = model.predict(x)
   ```
 
-  >>>model = MobileNet(weights = None, input_shape=[224,224,3])
-  >>>model.name
+  >>> model = MobileNet(weights = None, input_shape=[224,224,3])
+  >>> model.name
   'mobilenet_1.00_224'
 
   Raises:

--- a/tensorflow/python/keras/applications/mobilenet.py
+++ b/tensorflow/python/keras/applications/mobilenet.py
@@ -131,9 +131,9 @@ def MobileNet(input_shape=None,
       use as image input for the model. `input_tensor` is useful for sharing
       inputs between multiple different networks. Default to None.
     pooling: optional pooling mode for feature extraction when `include_top` is
-        `False`. If `max` or `avg` pooling is applied, output of the model will
-        be a 2D tensor. `None` will directly output the last convolutional layer,
-        a 4D tensor.
+        `False`. If `'max'` or `'avg'` pooling is applied, the output of the
+        model will be a 2D tensor. `None` will directly output the last
+        convolutional layer, a 4D tensor.
     classes: Optional number of classes to classify images into, only to be
       specified if `include_top` is True, and if no `weights` argument is
       specified. Defaults to 1000.
@@ -154,7 +154,9 @@ def MobileNet(input_shape=None,
   import numpy as np
 
   #create a MobileNet model pre-trained on imagenet
-  model = MobileNet(weights='imagenet', include_top=False, input_shape=[224,224,3])
+  model = MobileNet(weights='imagenet',
+                    include_top=False,
+                    input_shape=[224,224,3])
 
   #process the input
   img_path = 'elephant_example.jpg'

--- a/tensorflow/python/keras/applications/mobilenet.py
+++ b/tensorflow/python/keras/applications/mobilenet.py
@@ -130,15 +130,10 @@ def MobileNet(input_shape=None,
     input_tensor: Optional Keras tensor (i.e. output of `layers.Input()`) to
       use as image input for the model. `input_tensor` is useful for sharing
       inputs between multiple different networks. Default to None.
-    pooling: Optional pooling mode for feature extraction when `include_top`
-      is `False`. It could be:
-      - `None` (default) means that the output of the model will be
-          the 4D tensor output of the last convolutional block.
-      - `avg` means that global average pooling
-          will be applied to the output of the
-          last convolutional block, and thus
-          the output of the model will be a 2D tensor.
-      - `max` means that global max pooling will be applied.
+    pooling: optional pooling mode for feature extraction when `include_top` is
+        `False`. If `max` or `avg` pooling is applied, output of the model will
+        be a 2D tensor. `None` will directly output the last convolutional layer,
+        a 4D tensor.
     classes: Optional number of classes to classify images into, only to be
       specified if `include_top` is True, and if no `weights` argument is
       specified. Defaults to 1000.

--- a/tensorflow/python/keras/applications/mobilenet.py
+++ b/tensorflow/python/keras/applications/mobilenet.py
@@ -131,7 +131,7 @@ def MobileNet(input_shape=None,
       use as image input for the model. `input_tensor` is useful for sharing
       inputs between multiple different networks. Default to None.
     pooling: Optional pooling mode for feature extraction when `include_top`
-      is `False`.
+      is `False`. It could be:
       - `None` (default) means that the output of the model will be
           the 4D tensor output of the last convolutional block.
       - `avg` means that global average pooling

--- a/tensorflow/python/keras/applications/mobilenet_v2.py
+++ b/tensorflow/python/keras/applications/mobilenet_v2.py
@@ -178,8 +178,8 @@ def MobileNetV2(input_shape=None,
   features = model.predict(x)
   ```
 
-  >>>model = MobileNetV2(weights = None, input_shape=[224,224,3])
-  >>>model.name
+  >>> model = MobileNetV2(weights = None, input_shape=[224,224,3])
+  >>> model.name
   'mobilenetv2_1.00_224'
 
   Raises:

--- a/tensorflow/python/keras/applications/mobilenet_v2.py
+++ b/tensorflow/python/keras/applications/mobilenet_v2.py
@@ -141,7 +141,7 @@ def MobileNetV2(input_shape=None,
       `layers.Input()`)
       to use as image input for the model.
     pooling: String, optional pooling mode for feature extraction
-      when `include_top` is `False`.
+      when `include_top` is `False`. It could be:
       - `None` means that the output of the model
           will be the 4D tensor output of the
           last convolutional block.

--- a/tensorflow/python/keras/applications/mobilenet_v2.py
+++ b/tensorflow/python/keras/applications/mobilenet_v2.py
@@ -140,18 +140,10 @@ def MobileNetV2(input_shape=None,
     input_tensor: Optional Keras tensor (i.e. output of
       `layers.Input()`)
       to use as image input for the model.
-    pooling: String, optional pooling mode for feature extraction
-      when `include_top` is `False`. It could be:
-      - `None` means that the output of the model
-          will be the 4D tensor output of the
-          last convolutional block.
-      - `avg` means that global average pooling
-          will be applied to the output of the
-          last convolutional block, and thus
-          the output of the model will be a
-          2D tensor.
-      - `max` means that global max pooling will
-          be applied.
+    pooling: optional pooling mode for feature extraction when `include_top` is
+        `False`. If `max` or `avg` pooling is applied, output of the model will
+        be a 2D tensor. `None` will directly output the last convolutional layer,
+        a 4D tensor.
     classes: Integer, optional number of classes to classify images
       into, only to be specified if `include_top` is True, and
       if no `weights` argument is specified.

--- a/tensorflow/python/keras/applications/mobilenet_v2.py
+++ b/tensorflow/python/keras/applications/mobilenet_v2.py
@@ -141,9 +141,9 @@ def MobileNetV2(input_shape=None,
       `layers.Input()`)
       to use as image input for the model.
     pooling: optional pooling mode for feature extraction when `include_top` is
-        `False`. If `max` or `avg` pooling is applied, output of the model will
-        be a 2D tensor. `None` will directly output the last convolutional layer,
-        a 4D tensor.
+        `False`. If `'max'` or `'avg'` pooling is applied, the output of the
+        model will be a 2D tensor. `None` will directly output the last
+        convolutional layer, a 4D tensor.
     classes: Integer, optional number of classes to classify images
       into, only to be specified if `include_top` is True, and
       if no `weights` argument is specified.
@@ -165,7 +165,9 @@ def MobileNetV2(input_shape=None,
   import numpy as np
 
   #create a MobileNetV2 model pre-trained on imagenet
-  model = MobileNetV2(weights='imagenet', include_top=False, input_shape=[224,224,3])
+  model = MobileNetV2(weights='imagenet',
+                      include_top=False,
+                      input_shape=[224,224,3])
 
   #process the input
   img_path = 'elephant_example.jpg'

--- a/tensorflow/python/keras/applications/mobilenet_v2.py
+++ b/tensorflow/python/keras/applications/mobilenet_v2.py
@@ -163,6 +163,33 @@ def MobileNetV2(input_shape=None,
   Returns:
     A `keras.Model` instance.
 
+  Example:
+
+  ```python
+  #Extract image features with MobileNetV2-224
+  from tensorflow.keras.applications.mobilenet_v2 import MobileNetV2
+  from tensorflow.keras.preprocessing import image
+  from tensorflow.keras.applications.mobilenet_v2 import preprocess_input
+  import numpy as np
+
+  #create a MobileNetV2 model pre-trained on imagenet
+  model = MobileNetV2(weights='imagenet', include_top=False, input_shape=[224,224,3])
+
+  #process the input
+  img_path = 'elephant_example.jpg'
+  img = image.load_img(img_path, target_size=(224, 224))
+  x = image.img_to_array(img)
+  x = np.expand_dims(x, axis=0)
+  x = preprocess_input(x)
+
+  #extract the features
+  features = model.predict(x)
+  ```
+
+  >>>model = MobileNetV2(weights = None, input_shape=[224,224,3])
+  >>>model.name
+  'mobilenetv2_1.00_224'
+
   Raises:
     ValueError: in case of invalid argument for `weights`,
       or invalid input shape or invalid alpha, rows when

--- a/tensorflow/python/keras/applications/nasnet.py
+++ b/tensorflow/python/keras/applications/nasnet.py
@@ -347,7 +347,7 @@ def NASNetMobile(input_shape=None,
           `layers.Input()`)
           to use as image input for the model.
       pooling: Optional pooling mode for feature extraction
-          when `include_top` is `False`.
+          when `include_top` is `False`. It could be:
           - `None` means that the output of the model
               will be the 4D tensor output of the
               last convolutional layer.
@@ -438,7 +438,7 @@ def NASNetLarge(input_shape=None,
           `layers.Input()`)
           to use as image input for the model.
       pooling: Optional pooling mode for feature extraction
-          when `include_top` is `False`.
+          when `include_top` is `False`. It could be:
           - `None` means that the output of the model
               will be the 4D tensor output of the
               last convolutional layer.

--- a/tensorflow/python/keras/applications/nasnet.py
+++ b/tensorflow/python/keras/applications/nasnet.py
@@ -118,7 +118,7 @@ def NASNet(
       `layers.Input()`)
       to use as image input for the model.
     pooling: Optional pooling mode for feature extraction
-      when `include_top` is `False`.
+      when `include_top` is `False`. It could be:
       - `None` means that the output of the model
           will be the 4D tensor output of the
           last convolutional block.

--- a/tensorflow/python/keras/applications/nasnet.py
+++ b/tensorflow/python/keras/applications/nasnet.py
@@ -118,9 +118,9 @@ def NASNet(
       `layers.Input()`)
       to use as image input for the model.
     pooling: optional pooling mode for feature extraction when `include_top` is
-      `False`. If `'max'` or `'avg'` pooling is applied, output of the model will
-      be a 2D tensor. `None` will directly output the last convolutional layer,
-      a 4D tensor.
+      `False`. If `'max'` or `'avg'` pooling is applied, the output of the
+      model will be a 2D tensor. `None` will directly output the last
+      convolutional layer, a 4D tensor.
     classes: Optional number of classes to classify images
       into, only to be specified if `include_top` is True, and
       if no `weights` argument is specified.
@@ -338,10 +338,10 @@ def NASNetMobile(input_shape=None,
       input_tensor: Optional Keras tensor (i.e. output of
           `layers.Input()`)
           to use as image input for the model.
-      pooling: optional pooling mode for feature extraction when `include_top` is
-          `False`. If `max` or `avg` pooling is applied, output of the model will
-          be a 2D tensor. `None` will directly output the last convolutional layer,
-          a 4D tensor.
+      pooling: optional pooling mode for feature extraction when `include_top`
+          is `False`. If `'max'` or `'avg'` pooling is applied, the output of
+          the model will be a 2D tensor. `None` will directly output the last
+          convolutional layer, a 4D tensor.
       classes: Optional number of classes to classify images
           into, only to be specified if `include_top` is True, and
           if no `weights` argument is specified.
@@ -421,10 +421,10 @@ def NASNetLarge(input_shape=None,
       input_tensor: Optional Keras tensor (i.e. output of
           `layers.Input()`)
           to use as image input for the model.
-      pooling: optional pooling mode for feature extraction when `include_top` is
-          `False`. If `max` or `avg` pooling is applied, output of the model will
-          be a 2D tensor. `None` will directly output the last convolutional layer,
-          a 4D tensor.
+      pooling: optional pooling mode for feature extraction when `include_top`
+          is `False`. If `'max'` or `'avg'` pooling is applied, the output of
+          the model will be a 2D tensor. `None` will directly output the last
+          convolutional layer, a 4D tensor.
       classes: Optional number of classes to classify images
           into, only to be specified if `include_top` is True, and
           if no `weights` argument is specified.

--- a/tensorflow/python/keras/applications/nasnet.py
+++ b/tensorflow/python/keras/applications/nasnet.py
@@ -365,6 +365,29 @@ def NASNetMobile(input_shape=None,
   Returns:
       A Keras model instance.
 
+  Example:
+
+  ```python
+  #Extract image features with NASNetMobile
+  from tensorflow.keras.applications.nasnet import NASNetMobile
+  from tensorflow.keras.preprocessing import image
+  from tensorflow.keras.applications.nasnet import preprocess_input
+  import numpy as np
+
+  #create a NASNetMobile model pre-trained on imagenet
+  model = NASNetMobile(weights='imagenet', include_top=False)
+
+  #process the input
+  img_path = 'elephant_example.jpg'
+  img = image.load_img(img_path, target_size=(224, 224))
+  x = image.img_to_array(img)
+  x = np.expand_dims(x, axis=0)
+  x = preprocess_input(x)
+
+  #extract the features
+  features = model.predict(x)
+  ```
+
   Raises:
       ValueError: In case of invalid argument for `weights`,
           or invalid input shape.
@@ -432,6 +455,29 @@ def NASNetLarge(input_shape=None,
 
   Returns:
       A Keras model instance.
+
+  Example:
+
+  ```python
+  #Extract image features with NASNetLarge
+  from tensorflow.keras.applications.nasnet import NASNetLarge
+  from tensorflow.keras.preprocessing import image
+  from tensorflow.keras.applications.nasnet import preprocess_input
+  import numpy as np
+
+  #create a NASNetLarge model pre-trained on imagenet
+  model = NASNetLarge(weights='imagenet', include_top=False)
+
+  #process the input
+  img_path = 'elephant_example.jpg'
+  img = image.load_img(img_path, target_size=(331, 331))
+  x = image.img_to_array(img)
+  x = np.expand_dims(x, axis=0)
+  x = preprocess_input(x)
+
+  #extract the features
+  features = model.predict(x)
+  ```
 
   Raises:
       ValueError: in case of invalid argument for `weights`,

--- a/tensorflow/python/keras/applications/nasnet.py
+++ b/tensorflow/python/keras/applications/nasnet.py
@@ -117,18 +117,10 @@ def NASNet(
     input_tensor: Optional Keras tensor (i.e. output of
       `layers.Input()`)
       to use as image input for the model.
-    pooling: Optional pooling mode for feature extraction
-      when `include_top` is `False`. It could be:
-      - `None` means that the output of the model
-          will be the 4D tensor output of the
-          last convolutional block.
-      - `avg` means that global average pooling
-          will be applied to the output of the
-          last convolutional block, and thus
-          the output of the model will be a
-          2D tensor.
-      - `max` means that global max pooling will
-          be applied.
+    pooling: optional pooling mode for feature extraction when `include_top` is
+      `False`. If `'max'` or `'avg'` pooling is applied, output of the model will
+      be a 2D tensor. `None` will directly output the last convolutional layer,
+      a 4D tensor.
     classes: Optional number of classes to classify images
       into, only to be specified if `include_top` is True, and
       if no `weights` argument is specified.
@@ -346,18 +338,10 @@ def NASNetMobile(input_shape=None,
       input_tensor: Optional Keras tensor (i.e. output of
           `layers.Input()`)
           to use as image input for the model.
-      pooling: Optional pooling mode for feature extraction
-          when `include_top` is `False`. It could be:
-          - `None` means that the output of the model
-              will be the 4D tensor output of the
-              last convolutional layer.
-          - `avg` means that global average pooling
-              will be applied to the output of the
-              last convolutional layer, and thus
-              the output of the model will be a
-              2D tensor.
-          - `max` means that global max pooling will
-              be applied.
+      pooling: optional pooling mode for feature extraction when `include_top` is
+          `False`. If `max` or `avg` pooling is applied, output of the model will
+          be a 2D tensor. `None` will directly output the last convolutional layer,
+          a 4D tensor.
       classes: Optional number of classes to classify images
           into, only to be specified if `include_top` is True, and
           if no `weights` argument is specified.
@@ -437,18 +421,10 @@ def NASNetLarge(input_shape=None,
       input_tensor: Optional Keras tensor (i.e. output of
           `layers.Input()`)
           to use as image input for the model.
-      pooling: Optional pooling mode for feature extraction
-          when `include_top` is `False`. It could be:
-          - `None` means that the output of the model
-              will be the 4D tensor output of the
-              last convolutional layer.
-          - `avg` means that global average pooling
-              will be applied to the output of the
-              last convolutional layer, and thus
-              the output of the model will be a
-              2D tensor.
-          - `max` means that global max pooling will
-              be applied.
+      pooling: optional pooling mode for feature extraction when `include_top` is
+          `False`. If `max` or `avg` pooling is applied, output of the model will
+          be a 2D tensor. `None` will directly output the last convolutional layer,
+          a 4D tensor.
       classes: Optional number of classes to classify images
           into, only to be specified if `include_top` is True, and
           if no `weights` argument is specified.

--- a/tensorflow/python/keras/applications/resnet.py
+++ b/tensorflow/python/keras/applications/resnet.py
@@ -570,16 +570,16 @@ DOC = """
   features = model.predict(x)
   ```
 
-  >>>model = ResNet101(weights = None)
-  >>>model.name
+  >>> model = ResNet101(weights = None)
+  >>> model.name
   'resnet101'
 
-  >>>model = ResNet152(weights = None)
-  >>>model.name
+  >>> model = ResNet152(weights = None)
+  >>> model.name
   'resnet152'
 
-  >>>model = ResNet50(weights = None)
-  >>>model.name
+  >>> model = ResNet50(weights = None)
+  >>> model.name
   'resnet50'
 
   Raises:

--- a/tensorflow/python/keras/applications/resnet.py
+++ b/tensorflow/python/keras/applications/resnet.py
@@ -94,9 +94,9 @@ def ResNet(stack_fn,
       or `(3, 224, 224)` (with `channels_first` data format).
       It should have exactly 3 inputs channels.
     pooling: optional pooling mode for feature extraction when `include_top` is
-      `False`. If `'max'` or `'avg'` pooling is applied, output of the model will
-      be a 2D tensor. `None` will directly output the last convolutional layer,
-      a 4D tensor.
+      `False`. If `'max'` or `'avg'` pooling is applied, the output of the
+      model will be a 2D tensor. `None` will directly output the last
+      convolutional layer, a 4D tensor.
     classes: optional number of classes to classify images
       into, only to be specified if `include_top` is True, and
       if no `weights` argument is specified.
@@ -537,9 +537,9 @@ DOC = """
       and width and height should be no smaller than 32.
       E.g. `(200, 200, 3)` would be one valid value.
     pooling: optional pooling mode for feature extraction when `include_top` is
-      `False`. If `'max'` or `'avg'` pooling is applied, output of the model will
-      be a 2D tensor. `None` will directly output the last convolutional layer,
-      a 4D tensor.
+      `False`. If `'max'` or `'avg'` pooling is applied, the output of the
+      model will be a 2D tensor. `None` will directly output the last
+      convolutional layer, a 4D tensor.
     classes: optional number of classes to classify images
       into, only to be specified if `include_top` is True, and
       if no `weights` argument is specified.

--- a/tensorflow/python/keras/applications/resnet.py
+++ b/tensorflow/python/keras/applications/resnet.py
@@ -94,7 +94,7 @@ def ResNet(stack_fn,
       or `(3, 224, 224)` (with `channels_first` data format).
       It should have exactly 3 inputs channels.
     pooling: optional pooling mode for feature extraction
-      when `include_top` is `False`.
+      when `include_top` is `False`. It could be:
       - `None` means that the output of the model will be
           the 4D tensor output of the
           last convolutional layer.

--- a/tensorflow/python/keras/applications/resnet.py
+++ b/tensorflow/python/keras/applications/resnet.py
@@ -93,17 +93,10 @@ def ResNet(stack_fn,
       has to be `(224, 224, 3)` (with `channels_last` data format)
       or `(3, 224, 224)` (with `channels_first` data format).
       It should have exactly 3 inputs channels.
-    pooling: optional pooling mode for feature extraction
-      when `include_top` is `False`. It could be:
-      - `None` means that the output of the model will be
-          the 4D tensor output of the
-          last convolutional layer.
-      - `avg` means that global average pooling
-          will be applied to the output of the
-          last convolutional layer, and thus
-          the output of the model will be a 2D tensor.
-      - `max` means that global max pooling will
-          be applied.
+    pooling: optional pooling mode for feature extraction when `include_top` is
+      `False`. If `'max'` or `'avg'` pooling is applied, output of the model will
+      be a 2D tensor. `None` will directly output the last convolutional layer,
+      a 4D tensor.
     classes: optional number of classes to classify images
       into, only to be specified if `include_top` is True, and
       if no `weights` argument is specified.
@@ -543,17 +536,10 @@ DOC = """
       It should have exactly 3 inputs channels,
       and width and height should be no smaller than 32.
       E.g. `(200, 200, 3)` would be one valid value.
-    pooling: Optional pooling mode for feature extraction
-      when `include_top` is `False`. It could be:
-      - `None` means that the output of the model will be
-          the 4D tensor output of the
-          last convolutional block.
-      - `avg` means that global average pooling
-          will be applied to the output of the
-          last convolutional block, and thus
-          the output of the model will be a 2D tensor.
-      - `max` means that global max pooling will
-          be applied.
+    pooling: optional pooling mode for feature extraction when `include_top` is
+      `False`. If `'max'` or `'avg'` pooling is applied, output of the model will
+      be a 2D tensor. `None` will directly output the last convolutional layer,
+      a 4D tensor.
     classes: optional number of classes to classify images
       into, only to be specified if `include_top` is True, and
       if no `weights` argument is specified.

--- a/tensorflow/python/keras/applications/resnet.py
+++ b/tensorflow/python/keras/applications/resnet.py
@@ -527,7 +527,7 @@ DOC = """
   Optionally loads weights pre-trained on ImageNet.
   Note that the data format convention used by the model is
   the one specified in your Keras config at `~/.keras/keras.json`.
-  
+
   Arguments:
     include_top: whether to include the fully-connected
       layer at the top of the network.
@@ -544,7 +544,7 @@ DOC = """
       and width and height should be no smaller than 32.
       E.g. `(200, 200, 3)` would be one valid value.
     pooling: Optional pooling mode for feature extraction
-      when `include_top` is `False`.
+      when `include_top` is `False`. It could be:
       - `None` means that the output of the model will be
           the 4D tensor output of the
           last convolutional block.

--- a/tensorflow/python/keras/applications/resnet.py
+++ b/tensorflow/python/keras/applications/resnet.py
@@ -560,6 +560,48 @@ DOC = """
 
   Returns:
     A Keras model instance.
+
+  Example:
+
+  ```python
+  #Extract image features with ResNet50
+  from tensorflow.keras.applications.resnet import ResNet50
+  from tensorflow.keras.preprocessing import image
+  from tensorflow.keras.applications.resnet import preprocess_input
+  import numpy as np
+
+  #create a ResNet50 model pre-trained on imagenet
+  model = ResNet50(weights='imagenet', include_top=False)
+
+  #process the input
+  img_path = 'elephant_example.jpg'
+  img = image.load_img(img_path, target_size=(224, 224))
+  x = image.img_to_array(img)
+  x = np.expand_dims(x, axis=0)
+  x = preprocess_input(x)
+
+  #extract the features
+  features = model.predict(x)
+  ```
+
+  >>>model = ResNet101(weights = None)
+  >>>model.name
+  'resnet101'
+
+  >>>model = ResNet152(weights = None)
+  >>>model.name
+  'resnet152'
+
+  >>>model = ResNet50(weights = None)
+  >>>model.name
+  'resnet50'
+
+  Raises:
+    ValueError: in case of invalid argument for `weights`,
+      or invalid input shape.
+    ValueError: if `classifier_activation` is not `softmax` or `None` when
+      using a pretrained top layer.
+
 """
 
 setattr(ResNet50, '__doc__', ResNet50.__doc__ + DOC)

--- a/tensorflow/python/keras/applications/resnet_v2.py
+++ b/tensorflow/python/keras/applications/resnet_v2.py
@@ -162,7 +162,7 @@ DOC = """
       and width and height should be no smaller than 32.
       E.g. `(200, 200, 3)` would be one valid value.
     pooling: Optional pooling mode for feature extraction
-      when `include_top` is `False`.
+      when `include_top` is `False`. It could be:
       - `None` means that the output of the model will be
           the 4D tensor output of the
           last convolutional block.

--- a/tensorflow/python/keras/applications/resnet_v2.py
+++ b/tensorflow/python/keras/applications/resnet_v2.py
@@ -220,7 +220,6 @@ DOC = """
       or invalid input shape.
     ValueError: if `classifier_activation` is not `softmax` or `None` when
       using a pretrained top layer.
-
 """
 
 setattr(ResNet50V2, '__doc__', ResNet50V2.__doc__ + DOC)

--- a/tensorflow/python/keras/applications/resnet_v2.py
+++ b/tensorflow/python/keras/applications/resnet_v2.py
@@ -161,17 +161,10 @@ DOC = """
       It should have exactly 3 inputs channels,
       and width and height should be no smaller than 32.
       E.g. `(200, 200, 3)` would be one valid value.
-    pooling: Optional pooling mode for feature extraction
-      when `include_top` is `False`. It could be:
-      - `None` means that the output of the model will be
-          the 4D tensor output of the
-          last convolutional block.
-      - `avg` means that global average pooling
-          will be applied to the output of the
-          last convolutional block, and thus
-          the output of the model will be a 2D tensor.
-      - `max` means that global max pooling will
-          be applied.
+    pooling: optional pooling mode for feature extraction when `include_top` is
+        `False`. If `max` or `avg` pooling is applied, output of the model will
+        be a 2D tensor. `None` will directly output the last convolutional layer,
+        a 4D tensor.
     classes: optional number of classes to classify images
       into, only to be specified if `include_top` is True, and
       if no `weights` argument is specified.

--- a/tensorflow/python/keras/applications/resnet_v2.py
+++ b/tensorflow/python/keras/applications/resnet_v2.py
@@ -196,16 +196,16 @@ DOC = """
   features = model.predict(x)
   ```
 
-  >>>model = ResNet101V2(weights = None)
-  >>>model.name
+  >>> model = ResNet101V2(weights = None)
+  >>> model.name
   'resnet101v2'
 
-  >>>model = ResNet152V2(weights = None)
-  >>>model.name
+  >>> model = ResNet152V2(weights = None)
+  >>> model.name
   'resnet152v2'
 
-  >>>model = ResNet50V2(weights = None)
-  >>>model.name
+  >>> model = ResNet50V2(weights = None)
+  >>> model.name
   'resnet50v2'
 
   Raises:

--- a/tensorflow/python/keras/applications/resnet_v2.py
+++ b/tensorflow/python/keras/applications/resnet_v2.py
@@ -181,6 +181,46 @@ DOC = """
 
   Returns:
     A `keras.Model` instance.
+
+  ```python
+  #Extract image features with ResNet50V2
+  from tensorflow.keras.applications.resnet_v2 import ResNet50V2
+  from tensorflow.keras.preprocessing import image
+  from tensorflow.keras.applications.resnet_v2 import preprocess_input
+  import numpy as np
+
+  #create a ResNet50V2 model pre-trained on imagenet
+  model = ResNet50V2(weights='imagenet', include_top=False)
+
+  #process the input
+  img_path = 'elephant_example.jpg'
+  img = image.load_img(img_path, target_size=(224, 224))
+  x = image.img_to_array(img)
+  x = np.expand_dims(x, axis=0)
+  x = preprocess_input(x)
+
+  #extract the features
+  features = model.predict(x)
+  ```
+
+  >>>model = ResNet101V2(weights = None)
+  >>>model.name
+  'resnet101v2'
+
+  >>>model = ResNet152V2(weights = None)
+  >>>model.name
+  'resnet152v2'
+
+  >>>model = ResNet50V2(weights = None)
+  >>>model.name
+  'resnet50v2'
+
+  Raises:
+    ValueError: in case of invalid argument for `weights`,
+      or invalid input shape.
+    ValueError: if `classifier_activation` is not `softmax` or `None` when
+      using a pretrained top layer.
+
 """
 
 setattr(ResNet50V2, '__doc__', ResNet50V2.__doc__ + DOC)

--- a/tensorflow/python/keras/applications/resnet_v2.py
+++ b/tensorflow/python/keras/applications/resnet_v2.py
@@ -162,9 +162,9 @@ DOC = """
       and width and height should be no smaller than 32.
       E.g. `(200, 200, 3)` would be one valid value.
     pooling: optional pooling mode for feature extraction when `include_top` is
-        `False`. If `max` or `avg` pooling is applied, output of the model will
-        be a 2D tensor. `None` will directly output the last convolutional layer,
-        a 4D tensor.
+        `False`. If `'max'` or `'avg'` pooling is applied, the output of the
+        model will be a 2D tensor. `None` will directly output the last
+        convolutional layer, a 4D tensor.
     classes: optional number of classes to classify images
       into, only to be specified if `include_top` is True, and
       if no `weights` argument is specified.

--- a/tensorflow/python/keras/applications/vgg16.py
+++ b/tensorflow/python/keras/applications/vgg16.py
@@ -98,6 +98,33 @@ def VGG16(
   Returns:
     A `keras.Model` instance.
 
+  Example:
+
+  ```python
+  #Extract image features with VGG16
+  from keras.applications.vgg16 import VGG16
+  from keras.preprocessing import image
+  from keras.applications.vgg16 import preprocess_input
+  import numpy as np
+
+  #create a VGG16 model pre-trained on imagenet
+  model = VGG16(weights='imagenet', include_top=False)
+
+  #process the input
+  img_path = 'elephant_example.jpg'
+  img = image.load_img(img_path, target_size=(224, 224))
+  x = image.img_to_array(img)
+  x = np.expand_dims(x, axis=0)
+  x = preprocess_input(x)
+
+  #extract the features
+  features = model.predict(x)
+  ```
+
+  >>>model = VGG16(weights = None)
+  >>>model.name
+  'vgg16'
+
   Raises:
     ValueError: in case of invalid argument for `weights`,
       or invalid input shape.

--- a/tensorflow/python/keras/applications/vgg16.py
+++ b/tensorflow/python/keras/applications/vgg16.py
@@ -77,10 +77,10 @@ def VGG16(
           It should have exactly 3 input channels,
           and width and height should be no smaller than 32.
           E.g. `(200, 200, 3)` would be one valid value.
-      pooling: optional pooling mode for feature extraction when `include_top` is
-        `False`. If `'max'` or `'avg'` pooling is applied, output of the model will
-        be a 2D tensor. `None` will directly output the last convolutional layer,
-        a 4D tensor.
+      pooling: optional pooling mode for feature extraction when `include_top`
+          is `False`. If `'max'` or `'avg'` pooling is applied, the output of
+          the model will be a 2D tensor. `None` will directly output the last
+          convolutional layer, a 4D tensor.
       classes: optional number of classes to classify images
           into, only to be specified if `include_top` is True, and
           if no `weights` argument is specified.

--- a/tensorflow/python/keras/applications/vgg16.py
+++ b/tensorflow/python/keras/applications/vgg16.py
@@ -77,17 +77,10 @@ def VGG16(
           It should have exactly 3 input channels,
           and width and height should be no smaller than 32.
           E.g. `(200, 200, 3)` would be one valid value.
-      pooling: Optional pooling mode for feature extraction
-          when `include_top` is `False`. It could be:
-          - `None` means that the output of the model will be
-              the 4D tensor output of the
-              last convolutional block.
-          - `avg` means that global average pooling
-              will be applied to the output of the
-              last convolutional block, and thus
-              the output of the model will be a 2D tensor.
-          - `max` means that global max pooling will
-              be applied.
+      pooling: optional pooling mode for feature extraction when `include_top` is
+        `False`. If `'max'` or `'avg'` pooling is applied, output of the model will
+        be a 2D tensor. `None` will directly output the last convolutional layer,
+        a 4D tensor.
       classes: optional number of classes to classify images
           into, only to be specified if `include_top` is True, and
           if no `weights` argument is specified.

--- a/tensorflow/python/keras/applications/vgg16.py
+++ b/tensorflow/python/keras/applications/vgg16.py
@@ -114,8 +114,8 @@ def VGG16(
   features = model.predict(x)
   ```
 
-  >>>model = VGG16(weights = None)
-  >>>model.name
+  >>> model = VGG16(weights = None)
+  >>> model.name
   'vgg16'
 
   Raises:

--- a/tensorflow/python/keras/applications/vgg16.py
+++ b/tensorflow/python/keras/applications/vgg16.py
@@ -102,9 +102,9 @@ def VGG16(
 
   ```python
   #Extract image features with VGG16
-  from keras.applications.vgg16 import VGG16
-  from keras.preprocessing import image
-  from keras.applications.vgg16 import preprocess_input
+  from tensorflow.keras.applications.vgg16 import VGG16
+  from tensorflow.keras.preprocessing import image
+  from tensorflow.keras.applications.vgg16 import preprocess_input
   import numpy as np
 
   #create a VGG16 model pre-trained on imagenet

--- a/tensorflow/python/keras/applications/vgg16.py
+++ b/tensorflow/python/keras/applications/vgg16.py
@@ -78,7 +78,7 @@ def VGG16(
           and width and height should be no smaller than 32.
           E.g. `(200, 200, 3)` would be one valid value.
       pooling: Optional pooling mode for feature extraction
-          when `include_top` is `False`.
+          when `include_top` is `False`. It could be:
           - `None` means that the output of the model will be
               the 4D tensor output of the
               last convolutional block.

--- a/tensorflow/python/keras/applications/vgg19.py
+++ b/tensorflow/python/keras/applications/vgg19.py
@@ -83,7 +83,7 @@ def VGG19(
       and width and height should be no smaller than 32.
       E.g. `(200, 200, 3)` would be one valid value.
     pooling: Optional pooling mode for feature extraction
-      when `include_top` is `False`.
+      when `include_top` is `False`. It could be:
       - `None` means that the output of the model will be
           the 4D tensor output of the
           last convolutional block.

--- a/tensorflow/python/keras/applications/vgg19.py
+++ b/tensorflow/python/keras/applications/vgg19.py
@@ -119,8 +119,8 @@ def VGG19(
   features = model.predict(x)
   ```
 
-  >>>model = VGG19(weights = None)
-  >>>model.name
+  >>> model = VGG19(weights = None)
+  >>> model.name
   'vgg19'
 
   Raises:

--- a/tensorflow/python/keras/applications/vgg19.py
+++ b/tensorflow/python/keras/applications/vgg19.py
@@ -103,6 +103,33 @@ def VGG19(
   Returns:
     A `keras.Model` instance.
 
+  Example:
+
+  ```python
+  #Extract image features with VGG19
+  from tensorflow.keras.applications.vgg19 import VGG19
+  from tensorflow.keras.preprocessing import image
+  from tensorflow.keras.applications.vgg19 import preprocess_input
+  import numpy as np
+
+  #create a VGG19 model pre-trained on imagenet
+  model = VGG19(weights='imagenet', include_top=False)
+
+  #process the input
+  img_path = 'elephant_example.jpg'
+  img = image.load_img(img_path, target_size=(224, 224))
+  x = image.img_to_array(img)
+  x = np.expand_dims(x, axis=0)
+  x = preprocess_input(x)
+
+  #extract the features
+  features = model.predict(x)
+  ```
+
+  >>>model = VGG19(weights = None)
+  >>>model.name
+  'vgg19'
+
   Raises:
     ValueError: in case of invalid argument for `weights`,
       or invalid input shape.

--- a/tensorflow/python/keras/applications/vgg19.py
+++ b/tensorflow/python/keras/applications/vgg19.py
@@ -83,9 +83,9 @@ def VGG19(
       and width and height should be no smaller than 32.
       E.g. `(200, 200, 3)` would be one valid value.
     pooling: optional pooling mode for feature extraction when `include_top` is
-      `False`. If `'max'` or `'avg'` pooling is applied, output of the model will
-      be a 2D tensor. `None` will directly output the last convolutional layer,
-      a 4D tensor.
+      `False`. If `'max'` or `'avg'` pooling is applied, the output of the
+      model will be a 2D tensor. `None` will directly output the last
+      convolutional layer, a 4D tensor.
     classes: optional number of classes to classify images
       into, only to be specified if `include_top` is True, and
       if no `weights` argument is specified.

--- a/tensorflow/python/keras/applications/vgg19.py
+++ b/tensorflow/python/keras/applications/vgg19.py
@@ -82,17 +82,10 @@ def VGG19(
       It should have exactly 3 inputs channels,
       and width and height should be no smaller than 32.
       E.g. `(200, 200, 3)` would be one valid value.
-    pooling: Optional pooling mode for feature extraction
-      when `include_top` is `False`. It could be:
-      - `None` means that the output of the model will be
-          the 4D tensor output of the
-          last convolutional block.
-      - `avg` means that global average pooling
-          will be applied to the output of the
-          last convolutional block, and thus
-          the output of the model will be a 2D tensor.
-      - `max` means that global max pooling will
-          be applied.
+    pooling: optional pooling mode for feature extraction when `include_top` is
+      `False`. If `'max'` or `'avg'` pooling is applied, output of the model will
+      be a 2D tensor. `None` will directly output the last convolutional layer,
+      a 4D tensor.
     classes: optional number of classes to classify images
       into, only to be specified if `include_top` is True, and
       if no `weights` argument is specified.

--- a/tensorflow/python/keras/applications/xception.py
+++ b/tensorflow/python/keras/applications/xception.py
@@ -83,7 +83,7 @@ def Xception(
       and width and height should be no smaller than 71.
       E.g. `(150, 150, 3)` would be one valid value.
     pooling: Optional pooling mode for feature extraction
-      when `include_top` is `False`.
+      when `include_top` is `False`. It could be:
       - `None` means that the output of the model will be
           the 4D tensor output of the
           last convolutional block.

--- a/tensorflow/python/keras/applications/xception.py
+++ b/tensorflow/python/keras/applications/xception.py
@@ -103,6 +103,33 @@ def Xception(
   Returns:
     A `keras.Model` instance.
 
+  Example:
+
+  ```python
+  #Extract image features with Xception
+  from tensorflow.keras.applications.xception import Xception
+  from tensorflow.keras.preprocessing import image
+  from tensorflow.keras.applications.xception import preprocess_input
+  import numpy as np
+
+  #create a Xception model pre-trained on imagenet
+  model = Xception(weights='imagenet', include_top=False)
+
+  #process the input
+  img_path = 'elephant_example.jpg'
+  img = image.load_img(img_path, target_size=(224, 224))
+  x = image.img_to_array(img)
+  x = np.expand_dims(x, axis=0)
+  x = preprocess_input(x)
+
+  #extract the features
+  features = model.predict(x)
+  ```
+
+  >>>model = Xception(weights = None)
+  >>>model.name
+  'xception'
+
   Raises:
     ValueError: in case of invalid argument for `weights`,
       or invalid input shape.

--- a/tensorflow/python/keras/applications/xception.py
+++ b/tensorflow/python/keras/applications/xception.py
@@ -119,8 +119,8 @@ def Xception(
   features = model.predict(x)
   ```
 
-  >>>model = Xception(weights = None)
-  >>>model.name
+  >>> model = Xception(weights = None)
+  >>> model.name
   'xception'
 
   Raises:

--- a/tensorflow/python/keras/applications/xception.py
+++ b/tensorflow/python/keras/applications/xception.py
@@ -82,17 +82,10 @@ def Xception(
       It should have exactly 3 inputs channels,
       and width and height should be no smaller than 71.
       E.g. `(150, 150, 3)` would be one valid value.
-    pooling: Optional pooling mode for feature extraction
-      when `include_top` is `False`. It could be:
-      - `None` means that the output of the model will be
-          the 4D tensor output of the
-          last convolutional block.
-      - `avg` means that global average pooling
-          will be applied to the output of the
-          last convolutional block, and thus
-          the output of the model will be a 2D tensor.
-      - `max` means that global max pooling will
-          be applied.
+    pooling: optional pooling mode for feature extraction when `include_top` is
+      `False`. If `'max'` or `'avg'` pooling is applied, output of the model will
+      be a 2D tensor. `None` will directly output the last convolutional layer,
+      a 4D tensor.
     classes: optional number of classes to classify images
       into, only to be specified if `include_top` is True,
       and if no `weights` argument is specified.

--- a/tensorflow/python/keras/applications/xception.py
+++ b/tensorflow/python/keras/applications/xception.py
@@ -83,9 +83,9 @@ def Xception(
       and width and height should be no smaller than 71.
       E.g. `(150, 150, 3)` would be one valid value.
     pooling: optional pooling mode for feature extraction when `include_top` is
-      `False`. If `'max'` or `'avg'` pooling is applied, output of the model will
-      be a 2D tensor. `None` will directly output the last convolutional layer,
-      a 4D tensor.
+      `False`. If `'max'` or `'avg'` pooling is applied, the output of the
+      model will be a 2D tensor. `None` will directly output the last
+      convolutional layer, a 4D tensor.
     classes: optional number of classes to classify images
       into, only to be specified if `include_top` is True,
       and if no `weights` argument is specified.


### PR DESCRIPTION
Related issue: #37996
Added some basic usage examples for models in Keras.Applications. The arguments were already added to the nightly so the changes made are:

- Add example of extracting features using premade models
- <del>Fix the issue were argument option sublist was not at the right indent level</del>
- Reworded the pooling mode argument in models' description to be more concise
- Add raises exception list where absent
- Add doctest example of creating a model and what type of model it should return

