### PR TITLE
Direct feed from GPU memory in Java

### DIFF
--- a/tensorflow/java/BUILD
+++ b/tensorflow/java/BUILD
@@ -392,6 +392,32 @@ tf_java_test(
     ],
 )
 
+tf_java_test(
+    name = "GPUTensorTest",
+    size = "small",
+    srcs = ["src/test/java/org/tensorflow/GPUTensorTest.java"],
+    javacopts = JAVACOPTS,
+    test_class = "org.tensorflow.GPUTensorTest",
+    deps = [
+        ":tensorflow",
+        ":testutil",
+        "@junit",
+    ],
+)
+
+tf_java_test(
+    name = "DirectSessionTest",
+    size = "small",
+    srcs = ["src/test/java/org/tensorflow/DirectSessionTest.java"],
+    javacopts = JAVACOPTS,
+    test_class = "org.tensorflow.DirectSessionTest",
+    deps = [
+        ":tensorflow",
+        ":testutil",
+        "@junit",
+    ],
+)
+
 filegroup(
     name = "processor_test_resources",
     srcs = glob([

--- a/tensorflow/java/src/main/java/org/tensorflow/Session.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/Session.java
@@ -81,13 +81,14 @@ public final class Session implements AutoCloseable {
     graphRef = g.ref();
   }
 
+  /** wrap native method */
   public long makeCallable(byte[] config){
     return makeCallable(this.nativeHandle, config);
   }
 
   /**
    * Pull the following string into Java: '/job:localhost/replica:0/task:0/device:GPU:0'
-   * to be able to assign the feed/fetch allocation in CallableOptions
+   * to be able to assign the feed/fetch tensors allocation in CallableOptions
    */
   public String GPUDeviceName(){
     return getGPUDeviceName(this.nativeHandle);
@@ -566,18 +567,20 @@ public final class Session implements AutoCloseable {
    *
    * @param nativeHandle to the C API TF_Session object (Session.nativeHandle)
    * @param config serialized representation of a CallableOptions protocol buffer
-   * @return 2
+   * @return callable handle
    */
   private static native long makeCallable(long nativeHandle, byte[] config);
 
   /**
-   * Run
+   * Run callable. This method is derived from run().
    *
    * @param sessionHandle to the C API TF_Session object (Session.nativeHandle)
-   * @param
-   * @param
-   * @param
-   * @return
+   * @param callableHandle callable handle
+   * @param inputTensorHandles specifies the values
+   *     that are being "fed" (do not need to be computed) during graph execution.
+   *     see run() above
+   * @param outputTensorHandles will be filled in with handles to the outputs requested.
+   * @return nullptr
    */
   private static native byte[] runCallable(
       long sessionHandle,

--- a/tensorflow/java/src/main/java/org/tensorflow/Session.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/Session.java
@@ -377,9 +377,6 @@ public final class Session implements AutoCloseable {
         long[] inputTensorHandles = new long[inputTensors.size()];
         long[] outputTensorHandles = new long[outputs.size()];
 
-        System.out.println("Number of input handles: "+inputTensors.size());
-        System.out.println("Number of output handles: "+outputs.size());
-
         // It's okay to use Operation.getUnsafeNativeHandle() here since the safety depends on the
         // validity of the Graph and graphRef ensures that.
         int idx = 0;

--- a/tensorflow/java/src/main/java/org/tensorflow/Tensor.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/Tensor.java
@@ -429,6 +429,13 @@ public final class Tensor<T> implements AutoCloseable {
   }
 
   /**
+   * Check if a Tensor is allocated in GPU memory
+   */
+  public boolean isGPUTensor(){
+    return isGPUTensor(getNativeHandle());
+  }
+
+  /**
    * Copies the contents of the tensor to {@code dst} and returns {@code dst}.
    *
    * <p>For non-scalar tensors, this method copies the contents of the underlying tensor to a Java
@@ -857,6 +864,8 @@ public final class Tensor<T> implements AutoCloseable {
   private static native long allocateGPU(long[] shape, int dtype);
 
   private static native long getGPUPointer(long handle);
+
+  private static native boolean isGPUTensor(long handle);
 
   static {
     TensorFlow.init();

--- a/tensorflow/java/src/main/java/org/tensorflow/Tensor.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/Tensor.java
@@ -167,6 +167,10 @@ public final class Tensor<T> implements AutoCloseable {
     return t;
   }
 
+  public void setValueGPU(Object obj){
+    setValueGPU(getNativeHandle(), obj);
+  }
+
   /**
    * Create a {@link Integer} Tensor with data from the given buffer.
    *
@@ -862,6 +866,8 @@ public final class Tensor<T> implements AutoCloseable {
   private static native void readNDArray(long handle, Object value);
 
   private static native long allocateGPU(long[] shape, int dtype);
+
+  private static native void setValueGPU(long handle, Object value);
 
   private static native long getGPUPointer(long handle);
 

--- a/tensorflow/java/src/main/java/org/tensorflow/Tensor.java
+++ b/tensorflow/java/src/main/java/org/tensorflow/Tensor.java
@@ -155,6 +155,19 @@ public final class Tensor<T> implements AutoCloseable {
   }
 
   /**
+   * Create a Tensor of data type in GPU
+   */
+  public static Tensor<?> createGPU(long[] shape, DataType dtype){
+    @SuppressWarnings("rawtypes")
+    Tensor<?> t = new Tensor(dtype);
+    t.shapeCopy = shape;
+    long nativeHandle;
+    nativeHandle = allocateGPU(t.shapeCopy,t.dtype.c());
+    t.nativeRef = new NativeReference(nativeHandle);
+    return t;
+  }
+
+  /**
    * Create a {@link Integer} Tensor with data from the given buffer.
    *
    * <p>Creates a Tensor with the given shape by copying elements from the buffer (starting from its
@@ -406,6 +419,13 @@ public final class Tensor<T> implements AutoCloseable {
    */
   public byte[] bytesValue() {
     return scalarBytes(getNativeHandle());
+  }
+
+  /**
+   * Return the pointer to GPU memory
+   */
+  public long GPUPointer(){
+    return getGPUPointer(getNativeHandle());
   }
 
   /**
@@ -833,6 +853,10 @@ public final class Tensor<T> implements AutoCloseable {
   private static native byte[] scalarBytes(long handle);
 
   private static native void readNDArray(long handle, Object value);
+
+  private static native long allocateGPU(long[] shape, int dtype);
+
+  private static native long getGPUPointer(long handle);
 
   static {
     TensorFlow.init();

--- a/tensorflow/java/src/main/native/session_jni.cc
+++ b/tensorflow/java/src/main/native/session_jni.cc
@@ -290,7 +290,7 @@ JNIEXPORT jbyteArray JNICALL Java_org_tensorflow_Session_runCallable(
     TF_Status* status = TF_NewStatus();
 
     for (int i = 0; i < noutputs; ++i) {
-        output_values[i] = TF_TensorFromTensor(outputs[i], status);
+        output_values[i] = TF_TensorFromTensor(outputs[i], &status->status);
         t[i] = reinterpret_cast<jlong>(output_values[i]);
     }
     env->ReleaseLongArrayElements(output_tensor_handles, t, 0);

--- a/tensorflow/java/src/main/native/session_jni.cc
+++ b/tensorflow/java/src/main/native/session_jni.cc
@@ -15,8 +15,10 @@ limitations under the License.
 
 #include <string.h>
 #include <memory>
+#include <iostream>
 
 #include "tensorflow/c/c_api.h"
+#include "tensorflow/c/c_api_internal.h"
 #include "tensorflow/java/src/main/native/utils_jni.h"
 #include "tensorflow/java/src/main/native/exception_jni.h"
 #include "tensorflow/java/src/main/native/session_jni.h"

--- a/tensorflow/java/src/main/native/session_jni.h
+++ b/tensorflow/java/src/main/native/session_jni.h
@@ -56,6 +56,39 @@ JNIEXPORT jbyteArray JNICALL Java_org_tensorflow_Session_run(
     JNIEnv *, jclass, jlong, jbyteArray, jlongArray, jlongArray, jintArray,
     jlongArray, jintArray, jlongArray, jboolean, jlongArray);
 
+/*
+ * Class:     org_tensorflow_Session
+ * Method:    run
+ * Signature: (J[B[J[J[I[J[I[JZ[J)[B
+ */
+JNIEXPORT jbyteArray JNICALL Java_org_tensorflow_Session_run(
+    JNIEnv *, jclass, jlong, jbyteArray, jlongArray, jlongArray, jintArray,
+    jlongArray, jintArray, jlongArray, jboolean, jlongArray);
+
+/*
+ * Class:     org_tensorflow_Session
+ * Method:    getGPUDeviceName
+ * Signature: -
+ */
+JNIEXPORT jstring JNICALL Java_org_tensorflow_Session_getGPUDeviceName(
+    JNIEnv*, jclass, jlong handle);
+
+/*
+ * Class:     org_tensorflow_Session
+ * Method:    makeCallable
+ * Signature: -
+ */
+JNIEXPORT jlong JNICALL Java_org_tensorflow_Session_makeCallable(
+    JNIEnv*, jclass, jlong, jbyteArray);
+
+/*
+ * Class:     org_tensorflow_Session
+ * Method:    runCallable
+ * Signature: -
+ */
+JNIEXPORT jbyteArray JNICALL Java_org_tensorflow_Session_runCallable(
+    JNIEnv*, jclass, jlong, jlong, jlongArray, jlongArray);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/tensorflow/java/src/main/native/tensor_jni.cc
+++ b/tensorflow/java/src/main/native/tensor_jni.cc
@@ -726,7 +726,7 @@ JNIEXPORT jlong JNICALL Java_org_tensorflow_Tensor_allocateGPU(JNIEnv* env,
     Tensor t_gpu = Tensor(allocator, dt_dtype, ts_shape);
 
     TF_Status* status = TF_NewStatus();
-    TF_Tensor* t = TF_TensorFromTensor(t_gpu,status);
+    TF_Tensor* t = TF_TensorFromTensor(t_gpu, &status->status);
     return reinterpret_cast<jlong>(t);
 }
 

--- a/tensorflow/java/src/main/native/tensor_jni.h
+++ b/tensorflow/java/src/main/native/tensor_jni.h
@@ -150,6 +150,22 @@ JNIEXPORT jbyteArray JNICALL Java_org_tensorflow_Tensor_scalarBytes(JNIEnv *,
 JNIEXPORT void JNICALL Java_org_tensorflow_Tensor_readNDArray(JNIEnv *, jclass,
                                                               jlong, jobject);
 
+/*
+ * Class:     org_tensorflow_Tensor
+ * Method:    allocateGPU
+ * Signature: -
+ */
+JNIEXPORT jlong JNICALL Java_org_tensorflow_Tensor_allocateGPU(JNIEnv *, jclass,
+                                                               jlongArray, jint);
+
+/*
+ * Class:     org_tensorflow_Tensor
+ * Method:    getGPUPointer
+ * Signature: -
+ */
+JNIEXPORT jlong JNICALL Java_org_tensorflow_Tensor_getGPUPointer(JNIEnv*, jclass,
+                                                                 jlong);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/tensorflow/java/src/main/native/tensor_jni.h
+++ b/tensorflow/java/src/main/native/tensor_jni.h
@@ -166,6 +166,14 @@ JNIEXPORT jlong JNICALL Java_org_tensorflow_Tensor_allocateGPU(JNIEnv *, jclass,
 JNIEXPORT jlong JNICALL Java_org_tensorflow_Tensor_getGPUPointer(JNIEnv*, jclass,
                                                                  jlong);
 
+/*
+ * Class:     org_tensorflow_Tensor
+ * Method:    isGPUTensor
+ * Signature: -
+ */
+JNIEXPORT jboolean JNICALL Java_org_tensorflow_Tensor_isGPUTensor(JNIEnv*, jclass,
+                                                                  jlong);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/tensorflow/java/src/main/native/tensor_jni.h
+++ b/tensorflow/java/src/main/native/tensor_jni.h
@@ -160,6 +160,14 @@ JNIEXPORT jlong JNICALL Java_org_tensorflow_Tensor_allocateGPU(JNIEnv *, jclass,
 
 /*
  * Class:     org_tensorflow_Tensor
+ * Method:    setValueGPU
+ * Signature: -
+ */
+JNIEXPORT void JNICALL Java_org_tensorflow_Tensor_setValueGPU(JNIEnv *, jclass,
+                                                              jlong, jobject);
+
+/*
+ * Class:     org_tensorflow_Tensor
  * Method:    getGPUPointer
  * Signature: -
  */

--- a/tensorflow/java/src/test/java/org/tensorflow/DirectSessionTest.java
+++ b/tensorflow/java/src/test/java/org/tensorflow/DirectSessionTest.java
@@ -5,7 +5,7 @@ package org.tensorflow;
 //import static org.junit.Assert.assertTrue;
 //import static org.junit.Assert.assertFalse;
 //import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+//import static org.junit.Assert.fail;
 
 import java.nio.FloatBuffer;
 import java.util.Arrays;
@@ -128,8 +128,6 @@ public class DirectSessionTest {
 
       float [] res2 = new float[floats.length];
       res_gpu.copyTo(res2);
-
-      // print-that-crap!
       System.out.println(Arrays.toString(res2));
 
     }

--- a/tensorflow/java/src/test/java/org/tensorflow/DirectSessionTest.java
+++ b/tensorflow/java/src/test/java/org/tensorflow/DirectSessionTest.java
@@ -1,3 +1,8 @@
+/* Copyright 2020 Elphel, Inc.
+
+SPDX-License-Identifier: Apache-2.0
+==============================================================================*/
+
 package org.tensorflow;
 
 import static org.junit.Assert.assertEquals;

--- a/tensorflow/java/src/test/java/org/tensorflow/DirectSessionTest.java
+++ b/tensorflow/java/src/test/java/org/tensorflow/DirectSessionTest.java
@@ -1,0 +1,140 @@
+package org.tensorflow;
+
+//import static java.nio.charset.StandardCharsets.UTF_8;
+
+//import static org.junit.Assert.assertTrue;
+//import static org.junit.Assert.assertFalse;
+//import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.nio.FloatBuffer;
+import java.util.Arrays;
+
+//import org.tensorflow.framework.CallableOptions;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class DirectSessionTest {
+  private static final double EPSILON = 1e-7;
+
+  @Test
+  public void DirectSessionTest() {
+    try (Graph g = new Graph();
+        Session s = new Session(g)) {
+
+      Operation input1 = g.opBuilder("Placeholder","input1")
+                          .setAttr("dtype",DataType.FLOAT)
+                          .build();
+
+      Operation input2 = g.opBuilder("Const", "input2")
+                          .setAttr("dtype", DataType.FLOAT)
+                          .setAttr("value", Tensor.<Float>create((float) 2.0, Float.class))
+                          .build();
+
+
+      Operation output = g.opBuilder("Mul", "output1")
+                          .addInput(input1.output(0))
+                          .addInput(input2.output(0))
+                          .build();
+
+      int size = 256;
+
+      long[] shape = {size};
+      float[] floats = new float[size];
+      float[] expected = new float[size];
+
+      for (int i = 0; i < size; ++i) {
+        floats[i] = i+1;
+        expected[i] = 2*floats[i];
+      }
+
+      Tensor<Float> t_cpu = Tensor.create(shape,FloatBuffer.wrap(floats));
+
+      // dummy run
+      Tensor<?> res_cpu = s.runner().fetch("output1").feed("input1", t_cpu).run().get(0);
+
+      // don't have to test anything here
+      /*
+      float [] res1 = new float[floats.length];
+      res_cpu.copyTo(res1);
+
+      for (int i = 0; i < size; ++i) {
+        assertEquals(expected[i], res1[i], EPSILON);
+      }
+      */
+
+      // now we need to teleport data to GPU;
+
+      //String gpuDeviceName = s.GPUDeviceName();
+      // Expecting but not insisting on "/job:localhost/replica:0/task:0/device:GPU:0"
+      //byte[] gpuName = gpuDeviceName.getBytes(UTF_8);
+
+      /*
+       * The following message is found in SavedModelBundleTest.java, enjoy:
+       */
+
+      // Ideally this would use the generated Java sources for protocol buffers
+      // and end up with something like the snippet below. However, generating
+      // the Java files for the .proto files in tensorflow/core:protos_all is
+      // a bit cumbersome in bazel until the proto_library rule is setup.
+      //
+      // See https://github.com/bazelbuild/bazel/issues/52#issuecomment-194341866
+      // https://github.com/bazelbuild/rules_go/pull/121#issuecomment-251515362
+      // https://github.com/bazelbuild/rules_go/pull/121#issuecomment-251692558
+      //
+      // For this test, for now, the use of specific bytes suffices.
+
+      /*
+       * In other words, "package org.tensorflow.framework does not exist".
+       * The following will work in a standalone program, but will not work in the test:
+       */
+
+      /*
+       *  CallableOptions callableOpts1 = CallableOptions.newBuilder()
+       *                                                .addFetch("output1:0")
+       *                                                .addFeed("input1:0")
+       *                                                .putFetchDevices("output1:0", gpuDeviceName)
+       *                                                .build();
+       */
+
+      /*
+       * "For this test, for now, the use of specific bytes suffices."
+       */
+      byte[] opts = {
+        0x0a, 0x08, 0x69, 0x6e, 0x70, 0x75, 0x74, 0x31, 0x3a, 0x30, 0x12, 0x09, 0x6f, 0x75, 0x74, 0x70,
+        0x75, 0x74, 0x31, 0x3a, 0x30, 0x32, 0x38, 0x0a, 0x08, 0x69, 0x6e, 0x70, 0x75, 0x74, 0x31, 0x3a,
+        0x30, 0x12, 0x2c, 0x2f, 0x6a, 0x6f, 0x62, 0x3a, 0x6c, 0x6f, 0x63, 0x61, 0x6c, 0x68, 0x6f, 0x73,
+        0x74, 0x2f, 0x72, 0x65, 0x70, 0x6c, 0x69, 0x63, 0x61, 0x3a, 0x30, 0x2f, 0x74, 0x61, 0x73, 0x6b,
+        0x3a, 0x30, 0x2f, 0x64, 0x65, 0x76, 0x69, 0x63, 0x65, 0x3a, 0x47, 0x50, 0x55, 0x3a, 0x30
+      };
+
+      /*
+      feed from GPU options:
+      {
+        0x0a, 0x08, "input1:0",
+        0x12, 0x09, "output1:0",
+        0x32, 0x38,
+          0x0a, 0x08, "input1:0",
+          0x12, 0x2c, "/job:localhost/replica:0/task:0/device:GPU:0"
+      }
+      */
+
+      Tensor<?> t_gpu = Tensor.createGPU(new long[]{256},DataType.FLOAT);
+
+      long handle = s.makeCallable(opts);
+      Tensor<?> res_gpu = s.runner().fetch("output1").feed("input1",t_gpu).runCallable(handle).get(0);
+
+      float [] res2 = new float[floats.length];
+      res_gpu.copyTo(res2);
+
+      // print-that-crap!
+      System.out.println(Arrays.toString(res2));
+
+    }
+
+  }
+
+}

--- a/tensorflow/java/src/test/java/org/tensorflow/DirectSessionTest.java
+++ b/tensorflow/java/src/test/java/org/tensorflow/DirectSessionTest.java
@@ -18,7 +18,7 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class DirectSessionTest {
-  private static final double EPSILON = 1e-7;
+  private static final float EPSILON_F = 1e-7f;
 
   @Test
   public void DirectSessionTest() {
@@ -33,7 +33,6 @@ public class DirectSessionTest {
                           .setAttr("dtype", DataType.FLOAT)
                           .setAttr("value", Tensor.<Float>create((float) 2.0, Float.class))
                           .build();
-
 
       Operation output = g.opBuilder("Mul", "output1")
                           .addInput(input1.output(0))
@@ -56,13 +55,13 @@ public class DirectSessionTest {
       // dummy run
       Tensor<?> res_cpu = s.runner().fetch("output1").feed("input1", t_cpu).run().get(0);
 
-      // don't have to test anything here
+      // don't have to test regular run
       /*
       float [] res1 = new float[floats.length];
       res_cpu.copyTo(res1);
 
       for (int i = 0; i < size; ++i) {
-        assertEquals(expected[i], res1[i], EPSILON);
+        assertEquals(expected[i], res1[i], EPSILON_F);
       }
       */
 

--- a/tensorflow/java/src/test/java/org/tensorflow/GPUTensorTest.java
+++ b/tensorflow/java/src/test/java/org/tensorflow/GPUTensorTest.java
@@ -1,0 +1,57 @@
+package org.tensorflow;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class GPUTensorTest {
+
+  @Test
+  public void allocateInGPU() {
+
+    long[] valid_shape = new long[]{256};
+    long[] invalid_shape = new long[]{255};
+
+    // not supposed to fail
+    allocateInGPUMemory(valid_shape,DataType.UINT8,true);
+    allocateInGPUMemory(valid_shape,DataType.INT32,true);
+    allocateInGPUMemory(valid_shape,DataType.FLOAT,true);
+
+    // NullPointerException fail is expected
+    allocateInGPUMemory(  valid_shape,DataType.DOUBLE,false);
+    allocateInGPUMemory(  valid_shape,DataType.INT64,false);
+    allocateInGPUMemory(invalid_shape,DataType.UINT8,false);
+    allocateInGPUMemory(invalid_shape,DataType.INT32,false);
+    allocateInGPUMemory(invalid_shape,DataType.FLOAT,false);
+
+  }
+
+  private static void allocateInGPUMemory(long[] shape, DataType dtype, boolean failOnException){
+    try(
+      Tensor<?> t = Tensor.createGPU(shape,dtype)
+    ){
+      assertTrue(t.isGPUTensor());
+    } catch (NullPointerException e){
+      if (failOnException){
+        fail("Failed to check GPU allocation of the tensor");
+      }else{
+        // expected exception.
+      }
+    }
+  }
+
+  @Test
+  public void checkCPUTensorAllocation() {
+    try(
+      Tensor<Integer> t = Tensors.create(new int[] {1, 2, 3, 4});
+    ){
+      assertFalse(t.isGPUTensor());
+    }
+  }
+
+}

--- a/tensorflow/java/src/test/java/org/tensorflow/GPUTensorTest.java
+++ b/tensorflow/java/src/test/java/org/tensorflow/GPUTensorTest.java
@@ -1,3 +1,8 @@
+/* Copyright 2020 Elphel, Inc.
+
+SPDX-License-Identifier: Apache-2.0
+==============================================================================*/
+
 package org.tensorflow;
 
 import static org.junit.Assert.assertTrue;


### PR DESCRIPTION
- PR adds 2 things to Java API:
  - allocating tensor in GPU (GPUBFCAllocator)
  - directly feeding tensors allocated in GPU (makeCallable/runCallable with CallableOptions)
- Originally posted as a feature request [#37909](https://github.com/tensorflow/tensorflow/issues/37909).
- Testing:
```
bazel test //tensorflow/java:DirectSessionTest //tensorflow/java:GPUTensorTest
```

It might not be the best implementation. Please, review and advise.
Thanks