### PR TITLE
Fix TFE_OpReset doesn't clear inputs completely

### DIFF
--- a/tensorflow/c/eager/c_api_experimental.cc
+++ b/tensorflow/c/eager/c_api_experimental.cc
@@ -31,6 +31,7 @@ using tensorflow::string;
 void TFE_OpReset(TFE_Op* op_to_reset, const char* op_or_function_name,
                  const char* raw_device_name, TF_Status* status) {
   if (op_to_reset) {
+    op_to_reset->operation->Clear();
     status->status =
         op_to_reset->operation->Reset(op_or_function_name, raw_device_name);
   } else {


### PR DESCRIPTION
Cherrypick of #38000 but done manually as #38000 has multiple commits for a net of 1 line change, so it is not worth cherrypicking each commit individually.