### PR TITLE
Add reminder to test deterministic cuDNN CTC loss

### DIFF
--- a/tensorflow/python/kernel_tests/cudnn_deterministic_base.py
+++ b/tensorflow/python/kernel_tests/cudnn_deterministic_base.py
@@ -50,7 +50,8 @@ from tensorflow.python.platform import test
 # algorithms, for a given layer configuration, are always used (i.e. that
 # algorithm selection is deterministic / reproducible), this is not tested.
 
-# TODO(duncanriach): Add test for deterministic cuDNN max-pooling
+# TODO(duncanriach): (1) Add test for deterministic cuDNN max-pooling
+#                    (2) Add test for deterministic cuDNN CTC loss
 
 LayerShapeNHWC = collections.namedtuple('LayerShapeNHWC',
                                         'batch, height, width, channels')


### PR DESCRIPTION
@sanjoy added deterministic cuDNN CTC loss, enabled via `TF_DETERMINISTIC_OPS`, with [this commit](https://github.com/tensorflow/tensorflow/commit/9e096debc4a0909deb69970f38bee7b77e5e5f7d). This current pull request places a reminder in `cudnn_deterministic_base.py` for me to add a test for it.