### PR TITLE
Add int16 support for tf.math.minimum and tf.math.maximum

### DIFF
--- a/tensorflow/core/kernels/cwise_op_gpu_maximum.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_maximum.cu.cc
@@ -19,7 +19,7 @@ limitations under the License.
 
 namespace tensorflow {
 namespace functor {
-DEFINE_BINARY4(maximum, Eigen::half, float, double, int64);
+DEFINE_BINARY5(maximum, Eigen::half, float, double, int16, int64);
 }  // namespace functor
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/cwise_op_gpu_minimum.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_minimum.cu.cc
@@ -19,7 +19,7 @@ limitations under the License.
 
 namespace tensorflow {
 namespace functor {
-DEFINE_BINARY4(minimum, Eigen::half, float, double, int64);
+DEFINE_BINARY5(minimum, Eigen::half, float, double, int16, int64);
 }  // namespace functor
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/cwise_op_maximum.cc
+++ b/tensorflow/core/kernels/cwise_op_maximum.cc
@@ -16,8 +16,8 @@ limitations under the License.
 #include "tensorflow/core/kernels/cwise_ops_common.h"
 
 namespace tensorflow {
-REGISTER6(BinaryOp, CPU, "Maximum", functor::maximum, float, Eigen::half,
-          bfloat16, double, int32, int64);
+REGISTER7(BinaryOp, CPU, "Maximum", functor::maximum, float, Eigen::half,
+          bfloat16, double, int16, int32, int64);
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 REGISTER4(BinaryOp, GPU, "Maximum", functor::maximum, float, Eigen::half,
           double, int64);

--- a/tensorflow/core/kernels/cwise_op_maximum.cc
+++ b/tensorflow/core/kernels/cwise_op_maximum.cc
@@ -19,8 +19,8 @@ namespace tensorflow {
 REGISTER7(BinaryOp, CPU, "Maximum", functor::maximum, float, Eigen::half,
           bfloat16, double, int16, int32, int64);
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
-REGISTER4(BinaryOp, GPU, "Maximum", functor::maximum, float, Eigen::half,
-          double, int64);
+REGISTER5(BinaryOp, GPU, "Maximum", functor::maximum, float, Eigen::half,
+          double, int16, int64);
 
 // A special GPU kernel for int32.
 // TODO(b/25387198): Also enable int32 in device memory. This kernel

--- a/tensorflow/core/kernels/cwise_op_minimum.cc
+++ b/tensorflow/core/kernels/cwise_op_minimum.cc
@@ -16,8 +16,8 @@ limitations under the License.
 #include "tensorflow/core/kernels/cwise_ops_common.h"
 
 namespace tensorflow {
-REGISTER6(BinaryOp, CPU, "Minimum", functor::minimum, float, Eigen::half,
-          bfloat16, double, int32, int64);
+REGISTER7(BinaryOp, CPU, "Minimum", functor::minimum, float, Eigen::half,
+          bfloat16, double, int16, int32, int64);
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 REGISTER4(BinaryOp, GPU, "Minimum", functor::minimum, float, Eigen::half,
           double, int64);

--- a/tensorflow/core/kernels/cwise_op_minimum.cc
+++ b/tensorflow/core/kernels/cwise_op_minimum.cc
@@ -19,8 +19,8 @@ namespace tensorflow {
 REGISTER7(BinaryOp, CPU, "Minimum", functor::minimum, float, Eigen::half,
           bfloat16, double, int16, int32, int64);
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
-REGISTER4(BinaryOp, GPU, "Minimum", functor::minimum, float, Eigen::half,
-          double, int64);
+REGISTER5(BinaryOp, GPU, "Minimum", functor::minimum, float, Eigen::half,
+          double, int16, int64);
 
 // A special GPU kernel for int32.
 // TODO(b/25387198): Also enable int32 in device memory. This kernel

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -549,7 +549,7 @@ REGISTER_OP("Maximum")
     .Input("x: T")
     .Input("y: T")
     .Output("z: T")
-    .Attr("T: {bfloat16, half, float, double, int32, int64}")
+    .Attr("T: {bfloat16, half, float, double, int16, int32, int64}")
     .SetShapeFn(shape_inference::BroadcastBinaryOpShapeFn);
 
 // Note: This op is not commutative w.r.t. to all its inputs.
@@ -573,7 +573,7 @@ REGISTER_OP("Minimum")
     .Input("x: T")
     .Input("y: T")
     .Output("z: T")
-    .Attr("T: {bfloat16, half, float, double, int32, int64}")
+    .Attr("T: {bfloat16, half, float, double, int16, int32, int64}")
     .SetShapeFn(shape_inference::BroadcastBinaryOpShapeFn);
 
 REGISTER_OP("Mod")

--- a/tensorflow/core/ops/ops.pbtxt
+++ b/tensorflow/core/ops/ops.pbtxt
@@ -23598,6 +23598,7 @@ op {
         type: DT_HALF
         type: DT_FLOAT
         type: DT_DOUBLE
+        type: DT_INT16
         type: DT_INT32
         type: DT_INT64
       }
@@ -23853,6 +23854,7 @@ op {
         type: DT_HALF
         type: DT_FLOAT
         type: DT_DOUBLE
+        type: DT_INT16
         type: DT_INT32
         type: DT_INT64
       }

--- a/tensorflow/python/kernel_tests/cwise_ops_test.py
+++ b/tensorflow/python/kernel_tests/cwise_ops_test.py
@@ -733,7 +733,7 @@ class MinMaxOpTest(test.TestCase):
   def testBasic(self):
     x = np.random.rand(1, 3, 2) * 100.
     y = np.random.rand(1, 3, 2) * 100.
-    for t in [np.float16, np.float32, np.float64, np.int32, np.int64]:
+    for t in [np.float16, np.float32, np.float64, np.int16, np.int32, np.int64]:
       self._compare(x.astype(t), y.astype(t), use_gpu=False)
       self._compare(x.astype(t), y.astype(t), use_gpu=True)
 


### PR DESCRIPTION

I was working on lossless audio data which is primary int16 PCM data,
when trying to do a simple minimum to my surprise I noticed that in16
is not supported:
```
>>> x = tf.constant(1, tf.int16)
>>> y = tf.constant(2, tf.int16)
>>> tf.math.minimum(x, y)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Library/Python/3.7/site-packages/tensorflow/python/ops/gen_math_ops.py", line 5961, in minimum
    _ops.raise_from_not_ok_status(e, name)
  File "/Library/Python/3.7/site-packages/tensorflow/python/framework/ops.py", line 6653, in raise_from_not_ok_status
    six.raise_from(core._status_to_exception(e.code, message), None)
  File "<string>", line 3, in raise_from
tensorflow.python.framework.errors_impl.NotFoundError: Could not find valid device for node.
Node:{{node Minimum}}
All kernels registered for op Minimum :
  device='XLA_CPU_JIT'; T in [DT_FLOAT, DT_DOUBLE, DT_INT32, DT_INT64, DT_BFLOAT16, DT_HALF]
  device='CPU'; T in [DT_FLOAT]
  device='CPU'; T in [DT_HALF]
  device='CPU'; T in [DT_BFLOAT16]
  device='CPU'; T in [DT_DOUBLE]
  device='CPU'; T in [DT_INT32]
  device='CPU'; T in [DT_INT64]
  device='XLA_CPU'; T in [DT_FLOAT, DT_DOUBLE, DT_INT32, DT_INT64, DT_BFLOAT16, DT_HALF]
 [Op:Minimum]
```

As such I used a workardound which looks quite awkward:
```
>>> x = tf.constant(1, tf.int16)
>>> y = tf.constant(2, tf.int16)
>>> z = tf.stack([x, y])
>>> tf.math.reduce_min(z)
<tf.Tensor: shape=(), dtype=int16, numpy=1>
>>>
```

This PR adds int16 support for `tf.math.minimum` and `tf.math.maximum`.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>