### PR TITLE
Refactor ExecuteTrtEngine.

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -90,6 +90,7 @@ cc_library(
     deps = [
         ":trt_allocator",
         ":trt_conversion",
+        ":trt_engine_utils",
         ":trt_logging",
         ":trt_plugins",
         ":trt_resources",
@@ -215,7 +216,22 @@ cc_library(
     deps = [
         ":get_calibration_data_op_op_lib",
         ":trt_engine_op_op_lib",
+        ":trt_engine_utils"
     ],
+)
+
+tf_cuda_library(
+    name = "trt_engine_utils",
+    srcs = ["utils/trt_engine_utils.cc"],
+    hdrs = ["utils/trt_engine_utils.h"],
+    deps = [
+        ":trt_logging",
+        ":utils",
+        "@com_google_absl//absl/strings",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib",
+        "//tensorflow/core/platform:status",
+    ] + if_tensorrt([":tensorrt_lib"]),
 )
 
 tf_cuda_library(

--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -216,7 +216,7 @@ cc_library(
     deps = [
         ":get_calibration_data_op_op_lib",
         ":trt_engine_op_op_lib",
-        ":trt_engine_utils"
+        ":trt_engine_utils",
     ],
 )
 

--- a/tensorflow/compiler/tf2tensorrt/convert/utils.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/utils.cc
@@ -163,6 +163,26 @@ bool AreShapesCompatible(const std::vector<TensorShape>& actual_shapes,
   return true;
 }
 
+TensorShape TrtDimsToTensorShape(const std::vector<int>& trt_dims,
+                                 bool use_implicit_batch, int batch_size) {
+  TensorShape shape;
+  TensorShapeUtils::MakeShape(trt_dims.data(), trt_dims.size(), &shape);
+  if (use_implicit_batch) {
+    shape.InsertDim(0, batch_size);
+  }
+  return shape;
+}
+
+TensorShape TrtDimsToTensorShape(const nvinfer1::Dims trt_dims,
+                                 bool use_implicit_batch, int batch_size) {
+  TensorShape shape;
+  TensorShapeUtils::MakeShape(trt_dims.d, trt_dims.nbDims, &shape);
+  if (use_implicit_batch) {
+    shape.InsertDim(0, batch_size);
+  }
+  return shape;
+}
+
 int GetNumberOfEngineInputs(const nvinfer1::ICudaEngine* engine) {
   int n_bindings = engine->getNbBindings();
   int n_input = 0;

--- a/tensorflow/compiler/tf2tensorrt/convert/utils.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/utils.cc
@@ -163,24 +163,26 @@ bool AreShapesCompatible(const std::vector<TensorShape>& actual_shapes,
   return true;
 }
 
-TensorShape TrtDimsToTensorShape(const std::vector<int>& trt_dims,
-                                 bool use_implicit_batch, int batch_size) {
-  TensorShape shape;
-  TensorShapeUtils::MakeShape(trt_dims.data(), trt_dims.size(), &shape);
+Status TrtDimsToTensorShape(const std::vector<int>& trt_dims,
+                            bool use_implicit_batch, int batch_size,
+                            TensorShape& shape) {
+  TF_RETURN_IF_ERROR(
+      TensorShapeUtils::MakeShape(trt_dims.data(), trt_dims.size(), &shape));
   if (use_implicit_batch) {
     shape.InsertDim(0, batch_size);
   }
-  return shape;
+  return Status::OK();
 }
 
-TensorShape TrtDimsToTensorShape(const nvinfer1::Dims trt_dims,
-                                 bool use_implicit_batch, int batch_size) {
-  TensorShape shape;
-  TensorShapeUtils::MakeShape(trt_dims.d, trt_dims.nbDims, &shape);
+Status TrtDimsToTensorShape(const nvinfer1::Dims trt_dims,
+                            bool use_implicit_batch, int batch_size,
+                            TensorShape& shape) {
+  TF_RETURN_IF_ERROR(
+      TensorShapeUtils::MakeShape(trt_dims.d, trt_dims.nbDims, &shape));
   if (use_implicit_batch) {
     shape.InsertDim(0, batch_size);
   }
-  return shape;
+  return Status::OK();
 }
 
 int GetNumberOfEngineInputs(const nvinfer1::ICudaEngine* engine) {

--- a/tensorflow/compiler/tf2tensorrt/convert/utils.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/utils.h
@@ -98,11 +98,13 @@ inline nvinfer1::Dims TensorShapeToTrtDims(const TensorShapeType& shape,
   return trt_dims;
 }
 
-TensorShape TrtDimsToTensorShape(const std::vector<int>& trt_dims,
-                                 bool use_implicit_batch, int batch_size = 1);
+Status TrtDimsToTensorShape(const std::vector<int>& trt_dims,
+                            bool use_implicit_batch, int batch_size,
+                            TensorShape& shape);
 
-TensorShape TrtDimsToTensorShape(const nvinfer1::Dims trt_dims,
-                                 bool use_implicit_batch, int batch_size = 1);
+Status TrtDimsToTensorShape(const nvinfer1::Dims trt_dims,
+                            bool use_implicit_batch, int batch_size,
+                            TensorShape& shape);
 
 // Returns a string that includes compile time TensorRT library version
 // information {Maj, Min, Patch}.

--- a/tensorflow/compiler/tf2tensorrt/convert/utils.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/utils.h
@@ -98,6 +98,12 @@ inline nvinfer1::Dims TensorShapeToTrtDims(const TensorShapeType& shape,
   return trt_dims;
 }
 
+TensorShape TrtDimsToTensorShape(const std::vector<int>& trt_dims,
+                                 bool use_implicit_batch, int batch_size = 1);
+
+TensorShape TrtDimsToTensorShape(const nvinfer1::Dims trt_dims,
+                                 bool use_implicit_batch, int batch_size = 1);
+
 // Returns a string that includes compile time TensorRT library version
 // information {Maj, Min, Patch}.
 string GetLinkedTensorRTVersion();

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h"
 #include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
 #include "tensorflow/compiler/tf2tensorrt/utils/trt_allocator.h"
+#include "tensorflow/compiler/tf2tensorrt/utils/trt_engine_utils.h"
 #include "tensorflow/compiler/tf2tensorrt/utils/trt_logger.h"
 #include "tensorflow/compiler/tf2tensorrt/utils/trt_lru_cache.h"
 #include "tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.h"
@@ -109,8 +110,8 @@ class TRTEngineOp : public AsyncOpKernel {
 
   // Executes the tensorrt engine. Returns whether we need to retry by running
   // the native segment.
-  bool ExecuteTrtEngine(OpKernelContext* ctx, EngineContext* engine_context,
-                        int trt_context_idx);
+  Status ExecuteTrtEngine(OpKernelContext* ctx, EngineContext* engine_context,
+                          int trt_context_idx);
 
   // Allocates necessary resources for calibration.
   Status AllocateCalibrationResources(OpKernelContext* ctx,
@@ -602,11 +603,10 @@ void TRTEngineOp::ComputeAsync(OpKernelContext* ctx,
     ExecuteNativeSegment(ctx, helper);
     return;
   }
-
-  const bool retry = ExecuteTrtEngine(ctx, engine_context, trt_context_idx);
-  if (retry) {
-    LOG(WARNING) << "Failed to execute engine, "
-                 << "retrying with native segment for " << name();
+  Status stat = ExecuteTrtEngine(ctx, engine_context, trt_context_idx);
+  if (!stat.ok()) {
+    LOG(WARNING) << "Failed to execute engine: " << stat
+                 << " Retrying with native segment for " << name();
     // Release any outputs that are allocated, ExecuteNativeSegment will
     // re-allocate them and fail if they are currently allocated.
     for (int i = 0; i < ctx->num_outputs(); i++) {
@@ -617,42 +617,9 @@ void TRTEngineOp::ComputeAsync(OpKernelContext* ctx,
   }
 }
 
-// Gets the binding index of a tensor in an engine.
-//
-// The binding index is looked up using the tensor's name and the profile index.
-// Profile index should be set to zero, if we do not have optimization profiles.
-Status GetTrtBindingIndex(const char* tensor_name, int profile_index,
-                          const nvinfer1::ICudaEngine* cuda_engine,
-                          int* binding_index) {
-  // If the engine has been built for K profiles, the first getNbBindings() / K
-  // bindings are used by profile number 0, the following getNbBindings() / K
-  // bindings are used by profile number 1 etc.
-  //
-  // GetBindingIndex(tensor_name) returns the binding index for the progile 0.
-  // We can also consider it as a "binding_index_within_profile".
-  *binding_index = cuda_engine->getBindingIndex(tensor_name);
-  if (*binding_index == -1) {
-    const string msg = StrCat("Input node ", tensor_name, " not found");
-    LOG(ERROR) << msg;
-    return errors::NotFound(msg);
-  }
-#if IS_TRT_VERSION_GE(6, 0, 0, 0)
-  int n_profiles = cuda_engine->getNbOptimizationProfiles();
-#else
-  int n_profiles = 1;
-#endif
-  // If we have more then one optimization profile, then we need to shift the
-  // binding index according to the following formula:
-  // binding_index_within_engine = binding_index_within_profile +
-  //                               profile_index * bindings_per_profile
-  const int bindings_per_profile = cuda_engine->getNbBindings() / n_profiles;
-  *binding_index = *binding_index + profile_index * bindings_per_profile;
-  return Status::OK();
-}
-
-bool TRTEngineOp::ExecuteTrtEngine(OpKernelContext* ctx,
-                                   EngineContext* engine_context,
-                                   int trt_context_idx) {
+Status TRTEngineOp::ExecuteTrtEngine(OpKernelContext* ctx,
+                                     EngineContext* engine_context,
+                                     int trt_context_idx) {
   VLOG(1) << "Executing TRT engine: " << name();
   auto& cuda_engine = engine_context->cuda_engine;
 
@@ -677,163 +644,24 @@ bool TRTEngineOp::ExecuteTrtEngine(OpKernelContext* ctx,
   const int num_binding = cuda_engine->getNbBindings();
   std::vector<void*> buffers(num_binding);
 
+  // nvinfer1::IExecutionContext::enqueue is not thread safe and we need a mutex
+  // for it.
   mutex_lock lock(engine_context->mu);
   nvinfer1::IExecutionContext* execution_context;
-  Status status =
-      engine_context->GetExecutionContext(trt_context_idx, &execution_context);
-  const bool kRetry = true;
-  if (!status.ok()) {
-    // TODO(Tamas) let ExecuteTrtEngine return a status, and do the logging at
-    // the call site
-    LOG(ERROR) << status;
-    return kRetry;
-  }
+  TF_RETURN_IF_ERROR(
+      engine_context->GetExecutionContext(trt_context_idx, &execution_context));
 
-  // Setup engine inputs.
-  for (int i = 0; i < ctx->num_inputs(); i++) {
-    const string input_name = StrCat(IONamePrefixes::kInputPHName, i);
-    int binding_index;
-    auto status = GetTrtBindingIndex(input_name.c_str(), trt_context_idx,
-                                     cuda_engine.get(), &binding_index);
-    if (!status.ok()) {
-      ctx->SetStatus(status);
-      return !kRetry;
-    }
+  const int num_batch =
+      use_implicit_batch_ ? ctx->input(0).shape().dim_size(0) : 0;
 
-    const Tensor& input_tensor = ctx->input(i);
-    const TensorShape& input_shape = input_tensor.shape();
+  TF_RETURN_IF_ERROR(SetTrtEngineInputs(cuda_engine.get(), execution_context,
+                                        trt_context_idx, buffers,
+                                        use_implicit_batch_, num_batch, ctx));
 
-    if (use_implicit_batch_) {
-      // Ensure all inputs have the same batch size
-      const int num_batch = ctx->input(0).shape().dim_size(0);
-      if (num_batch != input_shape.dim_size(0)) {
-        LOG(ERROR) << "Input data has inconsistent batch size: " << num_batch
-                   << " vs " << input_shape.dim_size(0);
-        return kRetry;
-      }
-    }
-#if IS_TRT_VERSION_GE(6, 0, 0, 0)
-    // Set known input dimensions. This is necessary because TRT network
-    // could be made with dynamic dimensions.
-    if (!use_implicit_batch_) {
-      nvinfer1::Dims trt_dims;
-      trt_dims.nbDims = input_shape.dims();
-      for (int k = 0; k < input_shape.dims(); k++) {
-        trt_dims.d[k] = input_shape.dim_size(k);
-      }
-      execution_context->setBindingDimensions(binding_index, trt_dims);
-    }
-#endif
-    // Setup input bindings.
-    auto dtype = cuda_engine->getBindingDataType(binding_index);
-    switch (dtype) {
-      case nvinfer1::DataType::kFLOAT:
-        buffers[binding_index] =
-            const_cast<float*>(input_tensor.flat<float>().data());
-        break;
-      case nvinfer1::DataType::kHALF:
-        buffers[binding_index] =
-            const_cast<Eigen::half*>(input_tensor.flat<Eigen::half>().data());
-        break;
-      case nvinfer1::DataType::kINT8:
-        LOG(ERROR) << "INT8 inputs are not supported yet!";
-        return kRetry;
-      case nvinfer1::DataType::kINT32:
-        buffers[binding_index] =
-            const_cast<int32*>(input_tensor.flat<int32>().data());
-        break;
-      default:
-        LOG(ERROR) << "Unknown TRT data type: " << static_cast<int>(dtype);
-        return kRetry;
-    }
-  }
+  TF_RETURN_IF_ERROR(SetTrtEngineOutputs(cuda_engine.get(), execution_context,
+                                         trt_context_idx, buffers,
+                                         use_implicit_batch_, num_batch, ctx));
 
-#if IS_TRT_VERSION_GE(6, 0, 0, 0)
-  // Ensure all network dynamic dimensions (if any) are set in execution
-  // context.
-  if (!execution_context->allInputDimensionsSpecified()) {
-    LOG(WARNING) << "Failed to set dimensions for all dynamic input tensors.";
-    return kRetry;
-  }
-  if (!execution_context->allInputShapesSpecified()) {
-    LOG(WARNING) << "Failed to set dimensions for all shape input tensors.";
-    return kRetry;
-  }
-#endif
-
-  // Setup engine outputs.
-  for (int i = 0; i < ctx->num_outputs(); i++) {
-    const string output_name = StrCat(IONamePrefixes::kOutputPHName, i);
-    int binding_index;
-    auto status = GetTrtBindingIndex(output_name.c_str(), trt_context_idx,
-                                     cuda_engine.get(), &binding_index);
-    if (!status.ok()) {
-      ctx->SetStatus(status);
-      return !kRetry;
-    }
-    // Get TRT output shapes for allocating output memory.
-    std::vector<int> trt_shape;
-    if (!use_implicit_batch_) {
-      // Explicit batch mode just copy output dims to trt_shape
-#if IS_TRT_VERSION_GE(6, 0, 0, 0)
-      // Get dims from context instead of engine in explicit batch mode
-      // because engine might have dynamic shapes.
-      auto dims = execution_context->getBindingDimensions(binding_index);
-      for (int j = 0; j < dims.nbDims; j++) {
-        trt_shape.push_back(dims.d[j]);
-      }
-#else
-      LOG(ERROR)
-          << "Explicit batch mode is only supported with TensorRT 6 and above.";
-      return kRetry;
-#endif
-    } else {
-      // Implicit batch mode, it's assumed that first dimension of all inputs
-      // and outputs is batch size. We prepend the batch dim to trt_shape.
-      auto dims = cuda_engine->getBindingDimensions(binding_index);
-      trt_shape.push_back(ctx->input(0).shape().dim_size(0));
-      for (int j = 0; j < dims.nbDims; j++) {
-        trt_shape.push_back(dims.d[j]);
-      }
-    }
-    // Allocate output tensor of TRTEngineOp.
-    Tensor* output_tensor = nullptr;
-    TensorShape output_shape;
-    status = TensorShapeUtils::MakeShape(trt_shape.data(), trt_shape.size(),
-                                         &output_shape);
-    if (!status.ok()) {
-      LOG(ERROR) << "Failed to get output shape: " << status;
-      return kRetry;
-    }
-    status = ctx->allocate_output(i, output_shape, &output_tensor);
-    if (!status.ok()) {
-      LOG(ERROR) << "Allocating output failed with " << status;
-      ctx->SetStatus(status);
-      return kRetry;
-    }
-    // Setup output bindings.
-    auto dtype = cuda_engine->getBindingDataType(binding_index);
-    switch (dtype) {
-      case nvinfer1::DataType::kFLOAT:
-        buffers[binding_index] =
-            const_cast<float*>(output_tensor->flat<float>().data());
-        break;
-      case nvinfer1::DataType::kHALF:
-        buffers[binding_index] =
-            const_cast<Eigen::half*>(output_tensor->flat<Eigen::half>().data());
-        break;
-      case nvinfer1::DataType::kINT8:
-        LOG(WARNING) << "int8 is not supported yet!";
-        return kRetry;
-      case nvinfer1::DataType::kINT32:
-        buffers[binding_index] =
-            const_cast<int32*>(output_tensor->flat<int32>().data());
-        break;
-      default:
-        LOG(WARNING) << "Unknown TRT data type: " << static_cast<int>(dtype);
-        return kRetry;
-    }
-  }
   // Copied from cuda_kernel_helper since it seems only valid in *.cu.cc files
   const cudaStream_t* stream = CHECK_NOTNULL(
       reinterpret_cast<const cudaStream_t*>(ctx->op_device_context()
@@ -841,29 +669,9 @@ bool TRTEngineOp::ExecuteTrtEngine(OpKernelContext* ctx,
                                                 ->implementation()
                                                 ->GpuStreamMemberHack()));
 
-  // nvinfer1::IExecutionContext::enqueue is not thread safe and we need a mutex
-  // for it.
-  bool ret = false;
-  if (use_implicit_batch_) {
-    const int num_batch = ctx->input(0).shape().dim_size(0);
-    ret = execution_context->enqueue(num_batch, &buffers[0], *stream, nullptr);
-    VLOG(1) << "Called IExecutionContext::enqueue";
-  } else {
-#if IS_TRT_VERSION_GE(6, 0, 0, 0)
-    ret = execution_context->enqueueV2(&buffers[0], *stream, nullptr);
-    VLOG(1) << "Called IExecutionContext::enqueueV2";
-#else
-    LOG(ERROR)
-        << "Explicit batch mode is only supported with TensorRT 6 and above.";
-    return kRetry;
-#endif
-  }
-  if (!ret) {
-    LOG(WARNING) << "Failed to enqueue batch for TRT engine: " << name();
-    return kRetry;
-  }
-  // Synchronization will be done by TF.
-  return !kRetry;
+  TF_RETURN_IF_ERROR(TrtEnqueue(execution_context, buffers, *stream,
+                                use_implicit_batch_, num_batch));
+  return Status::OK();
 }
 
 Status TRTEngineOp::GetEngineCacheResource(OpKernelContext* ctx,

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_engine_utils.cc
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_engine_utils.cc
@@ -51,7 +51,8 @@ Status GetTrtBindingShape(const nvinfer1::ICudaEngine* cuda_engine,
         "Explicit batch mode is only supported with TensorRT 6 and above.");
 #endif
   }
-  shape = TrtDimsToTensorShape(dims, use_implicit_batch, batch_size);
+  TF_RETURN_IF_ERROR(
+      TrtDimsToTensorShape(dims, use_implicit_batch, batch_size, shape));
   return Status::OK();
 }
 

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_engine_utils.cc
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_engine_utils.cc
@@ -1,0 +1,252 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/compiler/tf2tensorrt/utils/trt_engine_utils.h"
+
+#include <string>
+#include <vector>
+
+#include "absl/strings/str_cat.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/platform/errors.h"
+
+#if GOOGLE_CUDA
+#if GOOGLE_TENSORRT
+#include "third_party/tensorrt/NvInfer.h"
+
+namespace tensorflow {
+namespace tensorrt {
+
+using absl::StrCat;
+
+Status GetTrtBindingShape(const nvinfer1::ICudaEngine* cuda_engine,
+                          const nvinfer1::IExecutionContext* execution_context,
+                          int binding_index, bool use_implicit_batch,
+                          int batch_size, TensorShape& shape) {
+  nvinfer1::Dims dims;
+  if (use_implicit_batch) {
+    dims = cuda_engine->getBindingDimensions(binding_index);
+  } else {
+#if IS_TRT_VERSION_GE(6, 0, 0, 0)
+    // Get dims from context instead of engine in explicit batch mode because
+    // the engine might have dynamic shapes.
+    dims = execution_context->getBindingDimensions(binding_index);
+#else
+    return errors::Internal(
+        "Explicit batch mode is only supported with TensorRT 6 and above.");
+#endif
+  }
+  shape = TrtDimsToTensorShape(dims, use_implicit_batch, batch_size);
+  return Status::OK();
+}
+
+Status GetTrtBindingIndex(const char* tensor_name, int profile_index,
+                          const nvinfer1::ICudaEngine* cuda_engine,
+                          int* binding_index) {
+  // If the engine has been built for K profiles, the first getNbBindings() / K
+  // bindings are used by profile number 0, the following getNbBindings() / K
+  // bindings are used by profile number 1 etc.
+  //
+  // GetBindingIndex(tensor_name) returns the binding index for the progile 0.
+  // We can also consider it as a "binding_index_within_profile".
+  *binding_index = cuda_engine->getBindingIndex(tensor_name);
+  if (*binding_index == -1) {
+    const string msg = StrCat("Input node ", tensor_name, " not found");
+    LOG(ERROR) << msg;
+    return errors::NotFound(msg);
+  }
+#if IS_TRT_VERSION_GE(6, 0, 0, 0)
+  int n_profiles = cuda_engine->getNbOptimizationProfiles();
+#else
+  int n_profiles = 1;
+#endif
+  // If we have more then one optimization profile, then we need to shift the
+  // binding index according to the following formula:
+  // binding_index_within_engine = binding_index_within_profile +
+  //                               profile_index * bindings_per_profile
+  const int bindings_per_profile = cuda_engine->getNbBindings() / n_profiles;
+  *binding_index = *binding_index + profile_index * bindings_per_profile;
+  return Status::OK();
+}
+
+Status SetTrtEngineInputs(nvinfer1::ICudaEngine* cuda_engine,
+                          nvinfer1::IExecutionContext* execution_context,
+                          const int trt_profile_idx,
+                          std::vector<void*>& buffers, bool use_implicit_batch,
+                          int num_batch, OpKernelContext* ctx,
+                          const DataVec* input_vec) {
+  int n_inputs = ctx ? ctx->num_inputs() : (input_vec ? input_vec->size() : 0);
+  // Setup engine inputs.
+  for (int i = 0; i < n_inputs; i++) {
+    const string input_name =
+        ctx ? StrCat(IONamePrefixes::kInputPHName, i) : input_vec->at(i).name;
+    int binding_index;
+    TF_RETURN_IF_ERROR(GetTrtBindingIndex(input_name.c_str(), trt_profile_idx,
+                                          cuda_engine, &binding_index));
+    const Tensor& input_tensor = ctx ? ctx->input(i) : input_vec->at(i).tensor;
+    const TensorShape& input_shape = input_tensor.shape();
+
+    if (use_implicit_batch && ctx) {
+      // Ensure all inputs have the same batch size
+      if (num_batch != input_shape.dim_size(0)) {
+        const string msg =
+            StrCat("Input data has inconsistent batch size: ", num_batch,
+                   " vs ", input_shape.dim_size(0));
+        return errors::NotFound(msg);
+      }
+    }
+#if IS_TRT_VERSION_GE(6, 0, 0, 0)
+    // Set known input dimensions. This is necessary because TRT network
+    // could be made with dynamic dimensions.
+    if (!use_implicit_batch) {
+      nvinfer1::Dims trt_dims;
+      trt_dims.nbDims = input_shape.dims();
+      for (int k = 0; k < input_shape.dims(); k++) {
+        trt_dims.d[k] = input_shape.dim_size(k);
+      }
+      execution_context->setBindingDimensions(binding_index, trt_dims);
+    }
+#endif
+    // Setup input bindings.
+    auto dtype = cuda_engine->getBindingDataType(binding_index);
+    switch (dtype) {
+      case nvinfer1::DataType::kFLOAT:
+        buffers[binding_index] =
+            const_cast<float*>(input_tensor.flat<float>().data());
+        break;
+      case nvinfer1::DataType::kHALF:
+        buffers[binding_index] =
+            const_cast<Eigen::half*>(input_tensor.flat<Eigen::half>().data());
+        break;
+      case nvinfer1::DataType::kINT8:
+        return errors::Internal("INT8 inputs are not supported yet!");
+      case nvinfer1::DataType::kINT32:
+        buffers[binding_index] =
+            const_cast<int32*>(input_tensor.flat<int32>().data());
+        break;
+      default:
+        return errors::Internal("Unknown TRT data type: ",
+                                static_cast<int>(dtype));
+    }
+  }
+
+#if IS_TRT_VERSION_GE(6, 0, 0, 0)
+  // Ensure all network dynamic dimensions (if any) are set in execution
+  // context.
+  if (!execution_context->allInputDimensionsSpecified()) {
+    return errors::Internal(
+        "Failed to set dimensions for all dynamic input tensors");
+  }
+  if (!execution_context->allInputShapesSpecified()) {
+    return errors::Internal(
+        "Failed to set dimensions for all shape input tensors.");
+  }
+#endif
+  return Status::OK();
+}
+
+Status SetTrtEngineOutputs(nvinfer1::ICudaEngine* cuda_engine,
+                           nvinfer1::IExecutionContext* execution_context,
+                           int trt_profile_idx, std::vector<void*>& buffers,
+                           bool use_implicit_batch, int batch_size,
+                           OpKernelContext* ctx, DataVec* outputs) {
+  // Either one of ctx or outpus should be specified
+  int n_outputs = ctx ? ctx->num_outputs() : (outputs ? outputs->size() : 0);
+  for (int i = 0; i < n_outputs; i++) {
+    const string output_name =
+        ctx ? StrCat(IONamePrefixes::kOutputPHName, i) : outputs->at(i).name;
+    int binding_index;
+    TF_RETURN_IF_ERROR(GetTrtBindingIndex(output_name.c_str(), trt_profile_idx,
+                                          cuda_engine, &binding_index));
+
+    // Get TRT output shapes for allocating output memory.
+    TensorShape output_shape;
+    TF_RETURN_IF_ERROR(GetTrtBindingShape(cuda_engine, execution_context,
+                                          binding_index, use_implicit_batch,
+                                          batch_size, output_shape));
+
+    // Allocate output tensor of TRTEngineOp.
+    Tensor* output_tensor = nullptr;
+    if (ctx) {
+      TF_RETURN_IF_ERROR(ctx->allocate_output(i, output_shape, &output_tensor));
+    } else {
+      // This path is used for unit tests. The tensor is already allocated.
+      // Its shape is not necessarily set correctly, we fix that.
+      VLOG(2) << "Applying shape " << output_shape.DebugString()
+              << " on output.";
+      output_tensor = &(outputs->at(i).tensor);
+      bool status = output_tensor->CopyFrom(*output_tensor, output_shape);
+      if (!status) {
+        return errors::Internal(
+            "Buffer size do not match while reshaping output tensors");
+      }
+    }
+
+    // Setup output bindings.
+    auto dtype = cuda_engine->getBindingDataType(binding_index);
+    switch (dtype) {
+      case nvinfer1::DataType::kFLOAT:
+        buffers[binding_index] =
+            const_cast<float*>(output_tensor->flat<float>().data());
+        break;
+      case nvinfer1::DataType::kHALF:
+        buffers[binding_index] =
+            const_cast<Eigen::half*>(output_tensor->flat<Eigen::half>().data());
+        break;
+      case nvinfer1::DataType::kINT8:
+        return errors::Internal("int8 is not supported yet!");
+      case nvinfer1::DataType::kINT32:
+        buffers[binding_index] =
+            const_cast<int32*>(output_tensor->flat<int32>().data());
+        break;
+      default:
+        return errors::Internal("Unknown TRT data type: ",
+                                static_cast<int>(dtype));
+    }
+  }
+  return Status::OK();
+}
+
+Status TrtEnqueue(nvinfer1::IExecutionContext* execution_context,
+                  std::vector<void*>& buffers, cudaStream_t stream,
+                  bool use_implicit_batch, int batch_size) {
+  bool ret = false;
+  if (use_implicit_batch) {
+    ret = execution_context->enqueue(batch_size, &buffers[0], stream, nullptr);
+    VLOG(1) << "Called IExecutionContext::enqueue";
+  } else {
+#if IS_TRT_VERSION_GE(6, 0, 0, 0)
+    ret = execution_context->enqueueV2(&buffers[0], stream, nullptr);
+    VLOG(1) << "Called IExecutionContext::enqueueV2";
+#else
+    return errors::Internal(
+        "Explicit batch mode is only supported with TensorRT 6 and above.");
+#endif
+  }
+  if (!ret) {
+    return errors::Internal("Failed to enqueue batch for TRT engine");
+  }
+  // Synchronization will be done by TF.
+  return Status::OK();
+}
+
+}  // namespace tensorrt
+}  // namespace tensorflow
+
+#endif  // GOOGLE_TENSORRT
+#endif  // GOOGLE_CUDA

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_engine_utils.h
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_engine_utils.h
@@ -1,0 +1,97 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_COMPILER_TF2TENSORRT_UTILS_TRT_ENGINE_UTILS_H_
+#define TENSORFLOW_COMPILER_TF2TENSORRT_UTILS_TRT_ENGINE_UTILS_H_
+
+#include <string>
+#include <vector>
+
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/lib/core/status.h"
+
+#if GOOGLE_CUDA
+#if GOOGLE_TENSORRT
+#include "third_party/tensorrt/NvInfer.h"
+
+namespace tensorflow {
+namespace tensorrt {
+
+// Input/output data format for OpConverterTest::BuildAndRun().
+struct InputOutputData {
+  void* Buffer() const {
+    return const_cast<char*>(tensor.tensor_data().data());
+  }
+
+  size_t TotalBytes() const { return tensor.TotalBytes(); }
+
+  string name;
+  Tensor tensor;
+};
+
+using DataVec = std::vector<InputOutputData>;
+
+// Gets the binding index of a tensor in an engine.
+//
+// The binding index is looked up using the tensor's name and the profile index.
+// Profile index should be set to zero, if we do not have optimization profiles.
+Status GetTrtBindingIndex(const char* tensor_name, int profile_index,
+                          const nvinfer1::ICudaEngine* cuda_engine,
+                          int* binding_index);
+
+// Set input buffers for TRT from a list of input tensors. The input tensors
+// are either defined by ctx or by input_vec.
+Status SetTrtEngineInputs(nvinfer1::ICudaEngine* cuda_engine,
+                          nvinfer1::IExecutionContext* execution_context,
+                          const int trt_profile_idx,
+                          std::vector<void*>& buffers, bool use_implicit_batch,
+                          int num_batch, OpKernelContext* ctx = nullptr,
+                          const DataVec* input_vec = nullptr);
+
+// Returns the shape of a binding from TensorRT.
+//
+// The binding is identified by its binding_index. The batch_size argument is
+// ignored if use_implicit_batch==false. The shape is returned in the last
+// argument.
+Status GetTrtBindingShape(const nvinfer1::ICudaEngine* cuda_engine,
+                          const nvinfer1::IExecutionContext* execution_context,
+                          int binding_index, bool use_implicit_batch,
+                          int batch_size, TensorShape& shape);
+
+// Defines output buffers for TRT. The buffers are allocated by ctx, if ctx is
+// not null. Otherwise it is expected that the outputs DataVec is not null, and
+// the Tensors in outputs are already allocated.
+Status SetTrtEngineOutputs(nvinfer1::ICudaEngine* cuda_engine,
+                           nvinfer1::IExecutionContext* execution_context,
+                           int trt_profile_idx, std::vector<void*>& buffers,
+                           bool use_implicit_batch, int batch_size = 0,
+                           OpKernelContext* ctx = nullptr,
+                           DataVec* outputs = nullptr);
+
+// Enqueues TensorRT inference job. The batch_size argument is only relevant in
+// implicit batch mode.
+Status TrtEnqueue(nvinfer1::IExecutionContext* execution_context,
+                  std::vector<void*>& buffers, cudaStream_t stream,
+                  bool use_implicit_batch, int batch_size = 1);
+
+}  // namespace tensorrt
+}  // namespace tensorflow
+
+#endif  // GOOGLE_TENSORRT
+#endif  // GOOGLE_CUDA
+
+#endif  // TENSORFLOW_COMPILER_TF2TENSORRT_UTILS_TRT_ENGINE_UTILS_H_

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_engine_utils.h
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_engine_utils.h
@@ -53,7 +53,7 @@ Status GetTrtBindingIndex(const char* tensor_name, int profile_index,
                           const nvinfer1::ICudaEngine* cuda_engine,
                           int* binding_index);
 
-// Set input buffers for TRT from a list of input tensors. The input tensors
+// Sets input buffers for TRT from a list of input tensors. The input tensors
 // are either defined by ctx or by input_vec.
 Status SetTrtEngineInputs(nvinfer1::ICudaEngine* cuda_engine,
                           nvinfer1::IExecutionContext* execution_context,


### PR DESCRIPTION
This PR refactors [ExecuteTrtEngine](https://github.com/tensorflow/tensorflow/blob/34b86e53d7faaa62a9b62946a3a0a6d65c517eba/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc#L653-L867) so that its components can be reused from [BuildAndRun](https://github.com/tensorflow/tensorflow/blob/34b86e53d7faaa62a9b62946a3a0a6d65c517eba/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc#L1287-L1353).

BuildAndRun is used by the TF-TRT op converter tests to initialize TRT bindings and execute inference. Its role is roughly equivalent to ExecuteTrtEngine. Recently ExecuteTrtEngine was modified to handle inference using dynamic shapes (PRs #36379, #36434, #36435), the same was not done for the opconverter's BuildAndRun. To allow unit testing of op converters in dynamic shape mode, one needs the extend BuildAndRun with similar changes.

This PR refactors ExecuteTRTEngine, so that both BuildAndRun and ExecuteTrtEngie can use a common set of utility functions to run inference. While doing these changes, the logging is streamlined: we return a status with the log message if an error occurs.  

For easier comparison, one could do something like:
```
git show master:tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc | sed -n '619,868p' > ExecuteTrtEngine_master.cc && diff ExecuteTrtEngine_master.cc tensorflow/compiler/tf2tensorrt/utils/trt_engine_utils.cc
```

This PR does not add new tests, nor does it modify any existing behavior. This PR is a prerequisite of op converter tests in dynamic shape mode. 

An alternative solution to this PR would be to copy the relevant code to BuildAndRun, but this would further increase the already existing code duplication between ExecuteTrtEngine and BuildAndRun. Furthermore, the exact way of specifying the input shapes is subject to change (for example currently we do not specify [input shape bindings](https://docs.nvidia.com/deeplearning/sdk/tensorrt-api/c_api/classnvinfer1_1_1_i_execution_context.html#a306a7c94521d6a211be715ceb07c8c80), and it might be required in the future). Therefore it is preferred to reuse code between BuildAndRun and ExecuteTrtEngine.

Tagging @DEKHTIARJonathan and @bixia1 for review.
