### PR TITLE
[r2.2 Cherrypick] Support building XNNPACK delegate for Linux/AArch64

### DIFF
--- a/third_party/cpuinfo/BUILD.bazel
+++ b/third_party/cpuinfo/BUILD.bazel
@@ -16,8 +16,8 @@ C99OPTS = [
 # Source code common to all platforms.
 COMMON_SRCS = [
     "src/api.c",
-    "src/cache.c",
     "src/init.c",
+    "src/cache.c",
 ]
 
 # Architecture-specific sources and headers.
@@ -60,10 +60,6 @@ EMSCRIPTEN_SRCS = [
     "src/emscripten/init.c",
 ]
 
-PNACL_SRCS = [
-    "src/pnacl/init.c",
-]
-
 LINUX_X86_SRCS = [
     "src/x86/linux/cpuinfo.c",
     "src/x86/linux/init.c",
@@ -102,6 +98,7 @@ cc_library(
     name = "cpuinfo_impl",
     srcs = select({
         ":linux_x86_64": COMMON_SRCS + X86_SRCS + LINUX_SRCS + LINUX_X86_SRCS,
+        ":linux_aarch64": COMMON_SRCS + ARM_SRCS + LINUX_SRCS + LINUX_ARM64_SRCS,
         ":macos_x86_64": COMMON_SRCS + X86_SRCS + MACH_SRCS + MACH_X86_SRCS,
         ":android_armv7": COMMON_SRCS + ARM_SRCS + LINUX_SRCS + LINUX_ARM32_SRCS + ANDROID_ARM_SRCS,
         ":android_arm64": COMMON_SRCS + ARM_SRCS + LINUX_SRCS + LINUX_ARM64_SRCS + ANDROID_ARM_SRCS,
@@ -116,6 +113,8 @@ cc_library(
         ":watchos_x86": COMMON_SRCS + X86_SRCS + MACH_SRCS + MACH_X86_SRCS,
         ":watchos_armv7k": COMMON_SRCS + MACH_SRCS + MACH_ARM_SRCS,
         ":watchos_arm64_32": COMMON_SRCS + MACH_SRCS + MACH_ARM_SRCS,
+        ":tvos_x86_64": COMMON_SRCS + X86_SRCS + MACH_SRCS + MACH_X86_SRCS,
+        ":tvos_arm64": COMMON_SRCS + MACH_SRCS + MACH_ARM_SRCS,
         ":emscripten_wasm": COMMON_SRCS + EMSCRIPTEN_SRCS,
     }),
     copts = C99OPTS + [
@@ -162,7 +161,11 @@ cc_library(
 config_setting(
     name = "linux_x86_64",
     values = {"cpu": "k8"},
-    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "linux_aarch64",
+    values = {"cpu": "aarch64"},
 )
 
 config_setting(


### PR DESCRIPTION
This cherry-picks the build fixes from @Maratyszcza onto the r2.2 branch.
It restores support for building the [tflite model benchmark tool](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/tools/benchmark) on AArch64 which was possible in 2.1, but broke due to XNNPACK in the 2.2-rc.

@Maratyszcza It would be great to get a review on this, maybe I am missing something here and cfc31e324c8de6b52f752a39cb161d99d853ca99 should be included as well?

PiperOrigin-RevId: 302938776
Change-Id: I77c10706be866bebcee1d0ac7c696c3fa55f42ea