### PR TITLE
[Intel MKL] Fix incorrect DNNL1.2 integration in pooling backprop

### DIFF
--- a/tensorflow/core/kernels/mkl_pooling_ops_common.cc
+++ b/tensorflow/core/kernels/mkl_pooling_ops_common.cc
@@ -172,8 +172,12 @@ void MklPoolingBwdPrimitive<T>::Setup(const MklPoolingParams& bwdParams) {
   // Create memory descriptor.
   context_.diff_src_md.reset(new memory::desc(
       {bwdParams.src_dims}, MklDnnType<T>(), MEMORY_FORMAT::any));
+#ifndef ENABLE_MKLDNN_V1
   context_.diff_dst_md.reset(new memory::desc(
       {bwdParams.dst_dims}, MklDnnType<T>(), bwdParams.src_format));
+#else
+  context_.diff_dst_md.reset(new memory::desc(bwdParams.diff_dst_md.data));
+#endif  // !ENABLE_MKLDNN_V1
 
 #ifndef ENABLE_MKLDNN_V1
   context_.bwd_desc.reset(new pooling_backward::desc(

--- a/tensorflow/core/kernels/mkl_pooling_ops_common.h
+++ b/tensorflow/core/kernels/mkl_pooling_ops_common.h
@@ -49,12 +49,18 @@ struct MklPoolingParams {
   mkldnn::prop_kind prop_kind;
   MEMORY_FORMAT src_format;
   memory::desc src_md;
+  memory::desc diff_dst_md;
 
   MklPoolingParams(memory::dims src_dims, memory::dims dst_dims,
                    memory::dims filter_dims, memory::dims strides,
                    memory::dims padding_left, memory::dims padding_right,
                    mkldnn::algorithm alg_kind, mkldnn::prop_kind prop_kind,
+#ifdef ENABLE_MKLDNN_V1
+                   MEMORY_FORMAT src_format, memory::desc src_md,
+                   memory::desc diff_dst_md = memory::desc())
+#else
                    MEMORY_FORMAT src_format, memory::desc src_md)
+#endif  // ENABLE_MKLDNN_V1
       : src_dims(src_dims),
         dst_dims(dst_dims),
         filter_dims(filter_dims),
@@ -64,7 +70,9 @@ struct MklPoolingParams {
         alg_kind(alg_kind),
         prop_kind(prop_kind),
         src_format(src_format),
-        src_md(src_md) {}
+        src_md(src_md),
+        diff_dst_md(diff_dst_md) {
+  }
 };
 
 template <typename T>

--- a/tensorflow/core/kernels/mkl_pooling_ops_common.h
+++ b/tensorflow/core/kernels/mkl_pooling_ops_common.h
@@ -49,7 +49,9 @@ struct MklPoolingParams {
   mkldnn::prop_kind prop_kind;
   MEMORY_FORMAT src_format;
   memory::desc src_md;
+#ifdef ENABLE_MKLDNN_V1
   memory::desc diff_dst_md;
+#endif  // ENABLE_MKLDNN_V1
 
   MklPoolingParams(memory::dims src_dims, memory::dims dst_dims,
                    memory::dims filter_dims, memory::dims strides,
@@ -70,9 +72,14 @@ struct MklPoolingParams {
         alg_kind(alg_kind),
         prop_kind(prop_kind),
         src_format(src_format),
+#ifdef ENABLE_MKLDNN_V1
         src_md(src_md),
         diff_dst_md(diff_dst_md) {
   }
+#else
+        src_md(src_md) {
+  }
+#endif  // ENABLE_MKLDNN_V1
 };
 
 template <typename T>


### PR DESCRIPTION
This PR removes the performance degradation caused by incorrect pooling
backprop integration in Intel-MKL CPU backend.