### PR TITLE
Fix <unknown> shape issue for sparse.transpose

### DIFF
--- a/tensorflow/python/framework/sparse_tensor_test.py
+++ b/tensorflow/python/framework/sparse_tensor_test.py
@@ -59,6 +59,13 @@ class SparseTensorTest(test_util.TensorFlowTestCase):
         self.assertAllEqual(sess_run_value.values, value.values)
         self.assertAllEqual(sess_run_value.dense_shape, value.dense_shape)
 
+  @test_util.run_all_in_graph_and_eager_modes
+  def testShape(self):
+    tensor = sparse_tensor.SparseTensor(
+        indices=[[0, 0], [1, 2]], values=[1., 2], dense_shape=[3, 4])
+    tensor = sparse_ops.sparse_transpose(tensor)
+    self.assertTrue(tensor.shape.rank == 2)
+
   def testIsSparse(self):
     self.assertFalse(sparse_tensor.is_sparse(3))
     self.assertFalse(sparse_tensor.is_sparse("foo"))

--- a/tensorflow/python/framework/sparse_tensor_test.py
+++ b/tensorflow/python/framework/sparse_tensor_test.py
@@ -22,6 +22,7 @@ from absl.testing import parameterized
 import numpy as np
 
 from tensorflow.python.eager import context
+from tensorflow.python.eager import def_function
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import sparse_tensor
@@ -59,12 +60,15 @@ class SparseTensorTest(test_util.TensorFlowTestCase):
         self.assertAllEqual(sess_run_value.values, value.values)
         self.assertAllEqual(sess_run_value.dense_shape, value.dense_shape)
 
-  @test_util.run_all_in_graph_and_eager_modes
   def testShape(self):
+    @def_function.function
+    def test_fn(tensor):
+      tensor = sparse_ops.sparse_transpose(tensor)
+      self.assertEqual(tensor.shape.rank, 2)
+      return tensor
     tensor = sparse_tensor.SparseTensor(
         indices=[[0, 0], [1, 2]], values=[1., 2], dense_shape=[3, 4])
-    tensor = sparse_ops.sparse_transpose(tensor)
-    self.assertTrue(tensor.shape.rank == 2)
+    test_fn(tensor)
 
   def testIsSparse(self):
     self.assertFalse(sparse_tensor.is_sparse(3))

--- a/tensorflow/python/ops/sparse_ops.py
+++ b/tensorflow/python/ops/sparse_ops.py
@@ -2594,8 +2594,8 @@ def sparse_transpose(sp_input, perm=None, name=None):
   """
   with ops.name_scope(name, "SparseTranspose", [sp_input]) as name:
     if perm is None:
-      if sp_input.shape.is_fully_defined():
-        rank = len(sp_input.shape)
+      if sp_input.shape.rank is not None:
+        rank = sp_input.shape.rank
         perm = (rank - 1) - np.arange(0, rank, 1)
       else:
         rank = array_ops.rank(sp_input)


### PR DESCRIPTION
This PR tries to address the issue raised in #37638 where
the shape after sparse.transpose is <unknown> even though
the input shape's rank is known. This PR relexed the shape
to only use rank (vs. is_fully_defined) to populate the shape.

The other issue raised about `sparse.reduce_sum` is a little challanging
as the shape is inference from C++ `SparseReduceSumSparse` ops which
will output unknown shape anyway. For that reason this PR does not
address the `sparse.reduce_sum` issue.

This PR fixes #37638.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>