### PR TITLE
[r2.2:CherryPick] Check for None spec in module_util.py.

### DIFF
--- a/tensorflow/python/tools/module_util.py
+++ b/tensorflow/python/tools/module_util.py
@@ -59,7 +59,7 @@ def get_parent_dir_for_name(module_name):
       spec = importlib.util.find_spec(name_split[0])
     except ValueError:
       return None
-    if not spec.origin:
+    if not spec or not spec.origin:
       return None
     base_path = os.path.dirname(spec.origin)
   return os.path.join(base_path, *name_split[1:-1])


### PR DESCRIPTION
PiperOrigin-RevId: 303904448
Change-Id: Ib4a8cd50819aef30b1172b8b03aa461b48d88bca