### PR TITLE
[MLIR/XLA] Add LhloLegalizeToLoopPass and InputInlineFusionPass to support kLoop…

### DIFF
--- a/tensorflow/compiler/mlir/BUILD
+++ b/tensorflow/compiler/mlir/BUILD
@@ -86,6 +86,8 @@ cc_library(
         "//tensorflow/compiler/mlir/xla:xla_legalize_tf_with_tf2xla",
         "//tensorflow/compiler/mlir/xla:xla_legalize_to_linalg",
         "//tensorflow/compiler/mlir/xla:xla_legalize_to_standard",
+        "//tensorflow/compiler/mlir/xla:lhlo_legalize_to_loop",
+        "//tensorflow/compiler/mlir/xla:input_inline_fusion",
         "//tensorflow/compiler/mlir/xla:xla_lower",
         "//tensorflow/compiler/mlir/xla:xla_materialize_broadcasts",
         "//tensorflow/compiler/mlir/xla:xla_test_passes",

--- a/tensorflow/compiler/mlir/xla/BUILD
+++ b/tensorflow/compiler/mlir/xla/BUILD
@@ -265,6 +265,41 @@ cc_library(
 )
 
 cc_library(
+    name = "lhlo_legalize_to_loop",
+    srcs = ["transforms/lhlo_legalize_to_loop.cc"],
+    deps = [
+        ":hlo",
+        ":lhlo",
+        "@com_google_absl//absl/memory",
+        "@llvm-project//llvm:support",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LoopOps",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:StandardOps",
+        "@llvm-project//mlir:Transforms",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "input_inline_fusion",
+    srcs = ["transforms/input_inline_fusion_pass.cc"],
+    deps = [
+        ":hlo",
+        ":lhlo",
+        ":map_xla_to_scalar_op",
+        "@com_google_absl//absl/memory",
+        "@llvm-project//llvm:support",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LoopOps",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:StandardOps",
+        "@llvm-project//mlir:Transforms",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
     name = "lhlo_legalize_to_gpu",
     srcs = ["transforms/lhlo_legalize_to_gpu.cc"],
     deps = [

--- a/tensorflow/compiler/mlir/xla/tests/input-inline-fusion.mlir
+++ b/tensorflow/compiler/mlir/xla/tests/input-inline-fusion.mlir
@@ -1,0 +1,41 @@
+// RUN: bazel-bin/tensorflow/compiler/mlir/tf-opt --lhlo-legalize-to-loops --input-inline-fusion %s
+
+func @main() {
+  %c4 = constant 1024 : index
+  %c5 = constant 1024 : index
+  %0 = alloc(%c4, %c5) : memref<?x?xf32>
+  %1 = alloc(%c4, %c5) : memref<?x?xf32>
+  %2 = alloc() : memref<f32>
+  %3:2 = call @lowered_tao_main(%0, %1, %2) : (memref<?x?xf32>, memref<?x?xf32>, memref<f32>) -> (memref<?xf32>, memref<?x?xf32>)
+  return
+}
+func @lowered_dhlo_fusion_xla_hlo_reduce(%arg0: memref<?x?xf32>, %arg1: memref<?x?xf32>, %arg2: memref<f32>, %arg3: memref<?x?xf32>, %arg4: memref<?xf32>) attributes {xla_dhlo.memref_func} {
+  %0 = dim %arg0, 0 : memref<?x?xf32>
+  %1 = dim %arg0, 1 : memref<?x?xf32>
+  %2 = dim %arg1, 0 : memref<?x?xf32>
+  %3 = dim %arg1, 1 : memref<?x?xf32>
+  %4 = dim %arg3, 0 : memref<?x?xf32>
+  %5 = dim %arg3, 1 : memref<?x?xf32>
+  %6 = dim %arg4, 0 : memref<?xf32>
+  %tmp0 = alloc(%0, %1) : memref<?x?xf32>
+  %tmp1 = alloc(%0, %1) : memref<?x?xf32>
+  "xla_lhlo.multiply"(%arg0, %arg1, %tmp0) : (memref<?x?xf32>, memref<?x?xf32>, memref<?x?xf32>) -> ()
+  "xla_lhlo.divide"(%arg0, %tmp0, %tmp1) : (memref<?x?xf32>, memref<?x?xf32>, memref<?x?xf32>) -> ()
+  "xla_lhlo.add"(%tmp0, %tmp1, %arg3) : (memref<?x?xf32>, memref<?x?xf32>, memref<?x?xf32>) -> ()
+  "xla_lhlo.reduce"(%arg3, %arg2, %arg4) ( {
+  ^bb0(%arg5: memref<f32>, %arg6: memref<f32>, %arg7: memref<f32>):	// no predecessors
+    "xla_lhlo.add"(%arg5, %arg6, %arg7) : (memref<f32>, memref<f32>, memref<f32>) -> ()
+    "xla_lhlo.terminator"() : () -> ()
+  }) {dimensions = dense<0> : tensor<1xi64>} : (memref<?x?xf32>, memref<f32>, memref<?xf32>) -> ()
+  return
+}
+func @lowered_tao_main(%arg0: memref<?x?xf32>, %arg1: memref<?x?xf32>, %arg2: memref<f32>) -> (memref<?xf32>, memref<?x?xf32>) {
+  %0 = dim %arg0, 0 : memref<?x?xf32>
+  %1 = dim %arg0, 1 : memref<?x?xf32>
+  %2 = dim %arg1, 0 : memref<?x?xf32>
+  %3 = dim %arg1, 1 : memref<?x?xf32>
+  %4 = alloc(%0, %1) : memref<?x?xf32>
+  %5 = alloc(%1) : memref<?xf32>
+  call @lowered_dhlo_fusion_xla_hlo_reduce(%arg0, %arg1, %arg2, %4, %5) : (memref<?x?xf32>, memref<?x?xf32>, memref<f32>, memref<?x?xf32>, memref<?xf32>) -> ()
+  return %5, %4 : memref<?xf32>, memref<?x?xf32>
+}

--- a/tensorflow/compiler/mlir/xla/transforms/input_inline_fusion_pass.cc
+++ b/tensorflow/compiler/mlir/xla/transforms/input_inline_fusion_pass.cc
@@ -1,0 +1,268 @@
+//===- LoopFusion.cpp - Code to perform loop fusion -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements loop fusion.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Analysis/AffineAnalysis.h"
+#include "mlir/Analysis/AffineStructures.h"
+#include "mlir/Analysis/LoopAnalysis.h"
+#include "mlir/Analysis/Utils.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/AffineExpr.h"
+#include "mlir/IR/AffineMap.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/LoopFusionUtils.h"
+#include "mlir/Transforms/LoopUtils.h"
+#include "mlir/Transforms/Passes.h"
+#include "mlir/Transforms/Utils.h"
+
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"  // TF:llvm-project
+#include "mlir/Dialect/LoopOps/EDSC/Builders.h" 
+#include "mlir/IR/Attributes.h"  // TF:llvm-project
+#include "mlir/IR/Location.h"  // TF:llvm-project
+#include "mlir/IR/MLIRContext.h"  // TF:llvm-project
+#include "mlir/IR/PatternMatch.h"  // TF:llvm-project
+#include "mlir/IR/StandardTypes.h"  // TF:llvm-project
+#include "mlir/Pass/Pass.h"  // TF:llvm-project
+#include "tensorflow/compiler/mlir/xla/ir/lhlo_ops.h"
+#include "tensorflow/compiler/mlir/xla/transforms/map_xla_to_scalar_op.h"
+#include <iostream>
+
+namespace mlir {
+namespace xla_lhlo {
+
+namespace {
+
+struct InputInlineFusion : public FunctionPass<InputInlineFusion> {
+  void runOnFunction() override;
+};
+
+} // end anonymous namespace
+
+std::unique_ptr<OpPassBase<FuncOp>> createInputInlineFusionPass() {
+  return std::make_unique<InputInlineFusion>();
+}
+
+namespace {
+
+class InputInlineFusionPattern: public RewritePattern {
+ public:
+  explicit InputInlineFusionPattern(MLIRContext *context)
+      : RewritePattern(loop::ForOp::getOperationName(), 1, context) {}
+
+  LogicalResult matchAndRewrite(Operation *op,
+                                PatternRewriter &rewriter) const override {
+    // skip if not the most outter ForOp
+    auto parent = op->getParentOp();
+    if (!isa<FuncOp>(parent)) {
+      return failure();
+    }
+
+
+    SmallVector<mlir::LoadOp, 4> load_ops;
+    op->walk([&](mlir::LoadOp load_op) {
+      load_ops.push_back(load_op);
+    });
+
+    for (auto load_op : load_ops) {
+      auto lhlo_op = getFusibleOperation(load_op);
+      if (lhlo_op != nullptr) {
+        // 1, in case of:
+        //      A = ...
+        //      B = op(A)
+        //      C = op(A, B)
+        //    C should fuse B first before fusing A.
+        //    This is the same logic as in instruction_fusion pass of XLA
+        //
+        // 2, When multiple loads consumes the same result of lhlo_op and 
+        //    the load indices are also identical, the ir should be
+        //    emitted only once. Other LoadOps should used cached Value.
+
+        // 'load_ops' that can consume the same cached value
+        std::vector<Operation*> load_ops;
+        bool can_remove_producer;
+        if (!checkIfFusible(op, lhlo_op, load_op,
+              can_remove_producer, load_ops)) {
+          continue;
+        }
+
+        // 'load_op' is always the one that locates in the most 
+        // external code block among all the 'load_ops', because the walker
+        // is in the post order sequence.
+        if (!failed(inlineFuseLhloOp(rewriter, op, lhlo_op,
+                load_op, load_ops))) {
+          if (can_remove_producer) {
+            rewriter.eraseOp(lhlo_op);
+          }
+          for (auto* to_be_removed : load_ops) {
+            rewriter.eraseOp(to_be_removed);
+          }
+          op->getParentOp()->dump();
+          return success();
+        } else {
+          assert(false && "inlineFuseLhloOp failed!");
+        }
+      }
+    }
+    return failure();
+  }
+
+ private:
+  Operation* getFusibleOperation(mlir::LoadOp load_op) const;
+  LogicalResult inlineFuseLhloOp(
+      PatternRewriter& b, Operation* user,
+      Operation* producer, mlir::LoadOp load_op,
+      std::vector<Operation*> load_ops) const;
+  bool checkIfFusible(Operation* user, Operation* producer,
+      mlir::LoadOp load_op, bool& can_remove_producer,
+      std::vector<Operation*>& load_ops) const;
+
+  FuncOp func_;
+};
+
+Operation* InputInlineFusionPattern::getFusibleOperation(
+    mlir::LoadOp load_op) const {
+  Operation* lhlo_op = nullptr;
+  for (auto *user : load_op.getMemRef().getUsers()) {
+    if ((user->getDialect()->getNamespace() == "xla_lhlo") &&
+        (user->getOperand(user->getNumOperands() - 1) ==
+         load_op.getOperation()->getOperand(0))) {
+      if (lhlo_op == nullptr) {
+        lhlo_op = user;
+      } else {
+        assert(false &&
+            "More than one lhlo_op write to one Memref within one fusion");
+      }
+    }
+  }
+  return lhlo_op;
+}
+
+// Check if there are no other consumers of the producer
+// except the ForOp.
+bool InputInlineFusionPattern::checkIfFusible(
+    Operation* user, Operation* producer, mlir::LoadOp load_op,
+    bool& can_remove_producer,
+    std::vector<Operation*>& load_ops) const {
+  assert(isa<loop::ForOp>(user) &&
+      "user is expected to be loop::ForOp");
+  load_ops.clear();
+  auto producer_result_memref =
+      producer->getOperand(producer->getNumOperands() - 1); 
+  can_remove_producer = true;
+  auto lhlo_dialect = user->getContext()->getRegisteredDialect("xla_lhlo");
+  for (auto* memref_user : producer_result_memref.getUsers()) {
+    if ((memref_user->getDialect() == lhlo_dialect) &&
+        (memref_user != producer)) {
+      return false;
+    } else if (isa<mlir::LoadOp>(memref_user)) {
+      // Check if the loads the same indices
+      if (memref_user->getOperands() ==
+          load_op.getOperation()->getOperands()) { 
+        load_ops.emplace_back(memref_user);
+      } else {
+        can_remove_producer = false;
+      }
+      //TODO:: check the memref_user is inside the loops
+    }
+  }
+  return true;
+}
+
+template <typename LHLO_OpTy>
+bool fuseHelper(
+    PatternRewriter &rewriter, Operation* user, Operation* producer,
+    mlir::LoadOp load_op, std::vector<Operation*>& load_ops) {
+  if (!isa<LHLO_OpTy>(producer)) {
+    return false;
+  }
+  auto loc = user->getLoc();
+  auto lhlo_op = cast<LHLO_OpTy>(producer);
+  SmallVector<Value, 4> operand_values;
+  // the last operand is the output memref
+  for (int i=0; i < producer->getNumOperands() - 1; ++i) {
+    auto producer_operand = producer->getOperand(i); 
+    // create an AffineMap and affine.apply it
+    rewriter.setInsertionPoint(load_op);
+    auto memref_type =
+        producer->getOperand(producer->getNumOperands()-1)
+        .getType().cast<MemRefType>();
+    auto rank = memref_type.getRank();
+    auto affine_map = rewriter.getMultiDimIdentityMap(rank);
+    SmallVector<Value, 4> operand_indices;
+    for (int dim=0; dim < rank; dim++) {
+      auto affine_apply_op = rewriter.create<AffineApplyOp>(
+          loc, affine_map.getSubMap({dim}), load_op.getIndices());
+      operand_indices.push_back(affine_apply_op);
+    }
+    operand_values.push_back(rewriter.create<LoadOp>(loc,
+        producer_operand, operand_indices));
+  }
+  auto inlined_result = xla_lhlo::XlaOpToStdScalarOp::map<LHLO_OpTy>(
+      llvm::cast<LHLO_OpTy>(producer),
+      producer->getOperand(2).getType().cast<MemRefType>().getElementType(),
+      operand_values, &rewriter);
+  for (auto* to_be_replaced : load_ops) {
+    llvm::cast<mlir::LoadOp>(to_be_replaced).
+        replaceAllUsesWith(inlined_result);
+  }
+  return true;
+}
+
+// load_op is among the load_ops, whose locates in the most
+// external code block
+LogicalResult InputInlineFusionPattern::inlineFuseLhloOp(
+    PatternRewriter& b, Operation* user, Operation* producer,
+    mlir::LoadOp load_op, std::vector<Operation*> load_ops) const {
+  if (fuseHelper<xla_lhlo::AddOp>(b, user, producer, load_op, load_ops) ||
+      fuseHelper<xla_lhlo::SubOp>(b, user, producer, load_op, load_ops) ||
+      fuseHelper<xla_lhlo::MulOp>(b, user, producer, load_op, load_ops) ||
+      fuseHelper<xla_lhlo::DivOp>(b, user, producer, load_op, load_ops)) {
+    return success();
+  } else {
+    assert(false && "unsupported lhlo_op");
+  }
+
+  return success();
+}
+
+void InputInlineFusion::runOnFunction() {
+
+  auto func = getFunction();
+  if (func.getBlocks().size() == 0) {
+    return;
+  }
+  // TODO(pifon): Remove assumption that the function has a single block.
+  if (func.getBlocks().size() != 1) {
+    emitError(func.getLoc(), "The function needs to have a single block.");
+    signalPassFailure();
+    return;
+  }
+
+  // TODO: how to tell that this func is a fusion func?
+
+  auto *context = &this->getContext();
+  OwningRewritePatternList patterns;
+  patterns.insert<InputInlineFusionPattern>(context);
+
+  // Just apply the patterns greedily. 
+  // There should always be one loop.ForOp in the func.
+  applyPatternsGreedily(func, patterns);
+
+}
+
+} // namespace
+
+static PassRegistration<InputInlineFusion> pass("input-inline-fusion", "greedy inline fusion");
+
+}  // namespace xla_lhlo
+}  // namespace mlir

--- a/tensorflow/compiler/mlir/xla/transforms/lhlo_legalize_to_loop.cc
+++ b/tensorflow/compiler/mlir/xla/transforms/lhlo_legalize_to_loop.cc
@@ -1,0 +1,397 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// This file implements logic for lowering LHLO dialect to Affine dialect.
+//
+#include <iostream>
+#include "absl/memory/memory.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"  // TF:llvm-project
+#include "mlir/Dialect/LoopOps/EDSC/Builders.h" 
+#include "mlir/IR/Attributes.h"  // TF:llvm-project
+#include "mlir/IR/Location.h"  // TF:llvm-project
+#include "mlir/IR/MLIRContext.h"  // TF:llvm-project
+#include "mlir/IR/PatternMatch.h"  // TF:llvm-project
+#include "mlir/IR/StandardTypes.h"  // TF:llvm-project
+#include "mlir/Pass/Pass.h"  // TF:llvm-project
+#include "tensorflow/compiler/mlir/xla/ir/lhlo_ops.h"
+
+namespace mlir {
+namespace xla_lhlo {
+
+namespace {
+
+constexpr StringRef kDhloMemrefFuncAttr = "xla_dhlo.memref_func";
+
+enum class ScheduleKind {
+  kLoop,
+  kRowReduction,
+  kColReduction,
+};
+
+std::vector<Operation*> getRootOps(FuncOp& func) {
+  std::vector<Operation*> root_ops;
+  auto arg_list = func.getArguments();
+  func.walk([&](Operation* op) {
+    if (op->getDialect() !=
+        op->getContext()->getRegisteredDialect("xla_lhlo")) {
+      return;
+    }
+    if (op->getParentOp() != func.getOperation()) {
+      return;
+    }
+    auto num_operands = op->getNumOperands();
+    if (num_operands == 0) return;
+    // for lhlo_op the last operand is always the result.
+    // TODO: any exceptions?
+    auto result = op->getOperand(num_operands - 1);
+    for (auto arg : arg_list) {
+      if (arg == result) {
+        root_ops.emplace_back(op);
+        return;
+      }
+    }
+  });
+  return root_ops;
+}
+
+// TODO: Only rank 2 to rank 1 reduction can be
+// supported for now
+bool isRowReduction(Operation* op) {
+  if (!isa<xla_lhlo::ReduceOp>(op)) {
+    return false;
+  }
+  auto reduce_op = cast<xla_lhlo::ReduceOp>(op);
+  if (reduce_op.dimensions().getNumElements() != 1) {
+    return false;
+  }
+  auto rank =
+      op->getOperand(0).getType().cast<MemRefType>().getRank();
+  auto dimensions = reduce_op.dimensions().getValues<int64_t>();
+  return ((*dimensions.begin() == 1) && (rank == 2));
+}
+
+// TODO: Only rank 2 to rank 1 reduction can be
+// supported for now
+bool isColReduction(Operation* op) {
+  if (!isa<xla_lhlo::ReduceOp>(op)) {
+    return false;
+  }
+  auto reduce_op = cast<xla_lhlo::ReduceOp>(op);
+  if (reduce_op.dimensions().getNumElements() != 1) {
+    return false;
+  }
+  auto rank =
+      op->getOperand(0).getType().cast<MemRefType>().getRank();
+  auto dimensions = reduce_op.dimensions().getValues<int64_t>();
+  return ((*(dimensions.begin() + 1) == 0) && (rank == 2));
+}
+
+bool hasLhloUsersOtherThan(
+    Operation* op, std::vector<Operation*>& ops) {
+  auto num_operands = op->getNumOperands();
+  auto memref = op->getOperand(num_operands - 1);
+  for (auto* user : memref.getUsers()) {
+    if ((user->getDialect()->getNamespace() == "xla_lhlo") &&
+        (user != op) &&
+        (std::find(ops.begin(), ops.end(), op) == ops.end())) {
+      return true;
+    }
+  }
+  return false;
+}
+
+Operation* chooseDominant(std::vector<Operation*> root_ops,
+                          ScheduleKind& schedule_kind) {
+  Operation* dominant = nullptr;
+  assert((root_ops.size()) > 0 && "root_ops is empty");
+  for (auto* root : root_ops) {
+    if (isRowReduction(root)) {
+      dominant = root;
+      schedule_kind = ScheduleKind::kRowReduction; 
+    } else if (isColReduction(root)) {
+      if (schedule_kind == ScheduleKind::kLoop) {
+        dominant = root;
+        schedule_kind = ScheduleKind::kColReduction; 
+      }
+    } else {
+      if (dominant == nullptr) {
+        dominant = root;
+        schedule_kind = ScheduleKind::kLoop; 
+      }
+    }
+  }
+  return dominant;
+}
+
+Value createLoadOrUseCachedValue(
+    Location loc, OpBuilder& b,
+    Value memref, ValueRange indices,
+    OpBuilder::InsertPoint insert_point) {
+  // Check if there are any cached value that can be reused, 
+  // within the current Block. In fact we can do this for
+  // all the Blocks that dominant this Block, but that will be
+  // compilacated anyway. 
+  std::vector<mlir::StoreOp> store_ops;
+  insert_point.getBlock()->walk(
+      insert_point.getBlock()->begin(),
+      insert_point.getPoint(),
+      [&](mlir::StoreOp store_op) {
+        if ((store_op.getMemRef() == memref) &&
+            (store_op.getIndices() == indices)) {
+          store_ops.emplace_back(store_op);
+        }
+      });
+  if (store_ops.size() > 0) {
+    return store_ops[0].getOperand(0); 
+  }
+  return b.create<LoadOp>(loc, memref, indices);
+}
+
+template <typename LHLO_OpTy>
+bool binaryLowerHelper(
+    OpBuilder &b, Location loc, Operation* op,
+    const SmallVector<Value, 4>& input_index) {
+  if (!isa<LHLO_OpTy>(op)) {
+    return false;
+  }
+  auto lhs_memref = *op->getOperands().begin();
+  auto rhs_memref = *(op->getOperands().begin() + 1);
+  auto res_memref = *(op->getOperands().begin() + 2);
+
+  auto lhs_data = createLoadOrUseCachedValue(
+          loc, b, lhs_memref, input_index, b.saveInsertionPoint());
+  auto rhs_data = createLoadOrUseCachedValue(
+          loc, b, rhs_memref, input_index, b.saveInsertionPoint());
+	auto res = b.create<AddFOp>(loc, lhs_data, rhs_data);
+  b.create<StoreOp>(loc, res, res_memref, input_index);
+  return true;
+}
+
+/*
+<h, w, w_i, h_i>
+loop.parallel %h = 0 to %sh step tile_h {
+	loop.parallel %w = 0 to %sw step tile_w {
+		loop.for %w_i = 0 to tile_w step 1 {
+			alloc %acc;
+			loop.for %h_i = 0 to tile_h step 1 {
+				if (w_inbound && h_inbound) {
+					%val = load %data[%h + %h_i, %w + %w_i]
+					%acc = std.addf %acc, %val
+				}
+			}
+			std.atomic_add %w*tile_w + %w_i, %acc     
+		}
+	}
+}
+*/
+LogicalResult lowerWithScheduleColReduction(OpBuilder& b,
+    std::vector<Operation*> root_ops, Operation* dominant_op) {
+
+  auto lhs = *dominant_op->getOperands().begin();
+  const auto& lhs_type = lhs.getType().template cast<MemRefType>();
+  const auto& element_type = lhs_type.getElementType();
+	const int c_tilesize_h = 128;
+	const int c_tilesize_w = 2;
+  if (!isColReduction(dominant_op)) {
+    return failure();
+  }
+  const auto& shape = lhs_type.getShape();
+  const auto loc = dominant_op->getLoc();
+  b.setInsertionPoint(dominant_op);
+	auto zero = b.create<ConstantOp>(
+      loc, b.getIndexType(),
+      b.getIntegerAttr(b.getIndexType(), 0)); 
+	auto one = b.create<ConstantOp>(
+      loc, b.getIndexType(),
+      b.getIntegerAttr(b.getIndexType(), 1)); 
+	auto tilesize_h = b.create<ConstantOp>(
+      loc, b.getIndexType(),
+      b.getIntegerAttr(b.getIndexType(), c_tilesize_h)); 
+	auto tilesize_w = b.create<ConstantOp>(
+      loc, b.getIndexType(),
+      b.getIntegerAttr(b.getIndexType(), c_tilesize_w)); 
+  auto shape_h = b.create<DimOp>(loc, lhs, 0);
+  auto shape_w = b.create<DimOp>(loc, lhs, 1);
+  
+	// h outter
+  auto forOp_ho = b.create<loop::ForOp>(loc, zero, shape_h, tilesize_h);
+  forOp_ho.getBody()->clear();
+  b.setInsertionPointToStart(forOp_ho.getBody());
+	auto var_ho = forOp_ho.getInductionVar();
+	// w outter
+  auto forOp_wo = b.create<loop::ForOp>(loc, zero, shape_w, tilesize_w);
+  forOp_wo.getBody()->clear();
+  b.setInsertionPointToStart(forOp_wo.getBody());
+	auto var_wo = forOp_wo.getInductionVar();
+	// w inner
+  auto forOp_wi = b.create<loop::ForOp>(loc, zero, tilesize_w, one);
+  forOp_wi.getBody()->clear();
+  b.setInsertionPointToStart(forOp_wi.getBody());
+	auto var_wi = forOp_wi.getInductionVar();
+	// w_inbound = wo + wi < size_w
+	auto w_idx = b.create<AddIOp>(loc, var_wo, var_wi);
+	auto w_inbound = b.create<CmpIOp>(
+  		loc, CmpIPredicate::slt, w_idx, shape_w);
+	// TODO: init value should be from rhs
+  SmallVector<Value, 4> init_values;
+  SmallVector<Type, 4> init_values_types;
+  for (auto* root_op : root_ops) {
+    if (isColReduction(root_op)) {
+      auto root_lhs = *(root_op->getOperands().begin());
+      const auto& root_lhs_type = root_lhs.getType().template cast<MemRefType>();
+      const auto& root_element_type = root_lhs_type.getElementType();
+	    auto init_value = b.create<ConstantOp>(
+          loc, root_element_type, b.getFloatAttr(root_element_type, 0.0)); 
+      init_values.push_back(init_value);
+      init_values_types.push_back(init_value.getType());
+    }
+  }
+  auto forOp_hi = b.create<loop::ForOp>(
+      loc, zero, tilesize_h, one, init_values);
+  forOp_hi.getBody()->clear();
+  b.setInsertionPointToStart(forOp_hi.getBody());
+	auto var_hi = forOp_hi.getInductionVar();
+	// h_inbound = ho + hi < size_h
+	auto h_idx = b.create<AddIOp>(loc, var_ho, var_hi);
+	auto h_inbound = b.create<CmpIOp>(
+  		loc, CmpIPredicate::slt, h_idx, shape_h);
+	auto inbound = b.create<mlir::AndOp>(loc, h_inbound, w_inbound);
+  auto if_inbound_op = b.create<loop::IfOp>(
+      loc, /*resultTypes*/init_values_types,
+      inbound, /*hasElseRegion*/true);
+  if_inbound_op.thenRegion().front().clear();
+  if_inbound_op.elseRegion().front().clear();
+  b.setInsertionPointToStart(&if_inbound_op.thenRegion().front());
+
+  // emit all the calculations of root_ops
+  // TODO: emit affine.apply if not all the shapes of root_ops are the same.
+  // for example, root_shapes like [16, 256] and [4, 4, 256] may exist in 
+  // one fused pattern.
+  SmallVector<Value, 4> input_index;
+  input_index.push_back(h_idx);
+  input_index.push_back(w_idx);
+  SmallVector<Value, 4> yield_values_then_branch;
+  SmallVector<Value, 4> yield_values_else_branch;
+  // TODO: check the order of root_ops by op.walk() is as expected
+  for (auto* root_op : root_ops) {
+    if (isColReduction(root_op)) {
+      // then branch
+      b.setInsertionPointToEnd(&if_inbound_op.thenRegion().front());
+      auto data = createLoadOrUseCachedValue(
+          loc, b, lhs, input_index, b.saveInsertionPoint());
+	    auto acc = b.create<AddFOp>(
+          loc, *forOp_hi.getRegionIterArgs().begin(), data);
+      yield_values_then_branch.push_back(acc);
+      // else branch 
+      b.setInsertionPointToEnd(&if_inbound_op.elseRegion().front());
+	    auto acc_init = *forOp_hi.getRegionIterArgs().begin();
+      yield_values_else_branch.push_back(acc_init);
+    } else if (isRowReduction(root_op)) {
+      assert(false && "unexpected row_reduction");
+    } else {
+      // then branch
+      b.setInsertionPointToEnd(&if_inbound_op.thenRegion().front());
+      // TODO: potential affine map and apply
+      if (binaryLowerHelper<xla_lhlo::AddOp>(b, loc, root_op, input_index) ||
+          binaryLowerHelper<xla_lhlo::SubOp>(b, loc, root_op, input_index) ||
+          binaryLowerHelper<xla_lhlo::MulOp>(b, loc, root_op, input_index) ||
+          binaryLowerHelper<xla_lhlo::DivOp>(b, loc, root_op, input_index)) {
+      } else {
+        assert(false && "unsupported lhlo_op");
+      }
+    }
+  }
+  b.setInsertionPointToEnd(&if_inbound_op.thenRegion().front());
+  b.create<loop::YieldOp>(loc, yield_values_then_branch);
+  b.setInsertionPointToEnd(&if_inbound_op.elseRegion().front());
+  b.create<loop::YieldOp>(loc, yield_values_else_branch);
+
+	b.setInsertionPointToEnd(forOp_hi.getBody());
+  b.create<loop::YieldOp>(
+      loc, ValueRange({*if_inbound_op.results().begin()}));
+
+	b.setInsertionPointToEnd(forOp_wi.getBody());
+	b.create<AtomicRMWOp>(loc, element_type,
+			AtomicRMWKind::addf, *forOp_hi.results().begin(),
+      dominant_op->getOperand(2), ValueRange({w_idx}));
+  b.create<loop::YieldOp>(loc, ValueRange({}));
+
+	b.setInsertionPointToEnd(forOp_wo.getBody());
+  b.create<loop::YieldOp>(loc, ValueRange({}));
+	
+	b.setInsertionPointToEnd(forOp_ho.getBody());
+  b.create<loop::YieldOp>(loc, ValueRange({}));
+
+  // remote the root_op if it has no other users except the memref
+  for (auto* root_op : root_ops) {
+    if (!hasLhloUsersOtherThan(root_op, root_ops)) {
+      root_op->erase();
+    }
+  }
+
+  return success();
+}
+
+}  // namespace
+
+struct LhloLegalizeToLoop : public FunctionPass<LhloLegalizeToLoop> {
+  
+  void runOnFunction() override {
+    auto func = getFunction();
+    if (!func.getAttrOfType<UnitAttr>(kDhloMemrefFuncAttr)) {
+      return;
+    }
+    auto root_ops = getRootOps(func);
+
+    // 1, If any reduce op among the 'root_ops', follow the schedule of it;
+    //    or else, follow the schedule of kLoop.
+    // 2, If there are a mixer of column reductions and row reductions,
+    //    follow the schedule of the row reduction, and implement all the 
+    //    column reduction with the 'pure atomic' way, which has no
+    //    requirement on the schedule.
+    // TODO: the support of row reduction and 'pure atomic' reduction
+    ScheduleKind schedule_kind;
+    auto dominant_op = chooseDominant(root_ops, schedule_kind);
+
+    OpBuilder b(func);
+    switch (schedule_kind) {
+      case ScheduleKind::kRowReduction: {
+        assert(false && "not implemented yet");
+        break;
+      }
+      case ScheduleKind::kColReduction: {
+        auto r = lowerWithScheduleColReduction(b, root_ops, dominant_op);
+        assert(!failed(r) && "lowerWithScheduleColReduction failed");
+        break;
+      }
+      case ScheduleKind::kLoop: {
+        assert(false && "not implemented yet");
+        break;
+      }
+      default:
+        assert(false && "unknown schedule_kind");
+    }
+  }
+};
+
+std::unique_ptr<OpPassBase<FuncOp>> createLhloLegalizeToLoopPass() {
+  return absl::make_unique<LhloLegalizeToLoop>();
+}
+
+static PassRegistration<LhloLegalizeToLoop> legalize_pass(
+    "lhlo-legalize-to-loops", "Legalize from LHLO dialect to loop dialect");
+
+}  // namespace xla_lhlo
+}  // namespace mlir

--- a/tensorflow/compiler/mlir/xla/transforms/passes.h
+++ b/tensorflow/compiler/mlir/xla/transforms/passes.h
@@ -94,6 +94,12 @@ std::unique_ptr<Pass> createLhloCopyRemovalPass();
 // Lowers from LHLO dialect to parallel loops.
 std::unique_ptr<OpPassBase<FuncOp>> createLegalizeLhloToParallelLoopsPass();
 
+// Lower the (multiple) root ops in a fusion pattern from LHLO to Loops
+std::unique_ptr<OpPassBase<FuncOp>> createLhloLegalizeToLoopPass();
+
+// input inline fusion for LHLO->Loops pattern in a fusion pattern
+std::unique_ptr<OpPassBase<FuncOp>> createInputInlineFusionPass();
+
 }  // namespace xla_lhlo
 }  // namespace mlir
 


### PR DESCRIPTION
Move kLoop/kInput style fusion of XLA to MLIR. This is part of work from:
[RFC: mlir dynamic shape codegen](https://groups.google.com/a/tensorflow.org/forum/#!topic/mlir/_X48poNcbDI).
And is intended to work with the fusion/shape inference pass in HLO layer:
[add a pass to outline kLoop/kInput fusion pattern in xla_hlo dialect](https://github.com/tensorflow/tensorflow/pull/37682)

The fusion codegen is seperated into two phases:
1, in LhloLegalizeToLoopPass, the (multiple) root ops is lowered into a set of nested loops.
      (1) find out all the root ops and choose a legal schedule (kColReduction/kRowReduction/kLoop etc);
      (2) Lower the root ops into nested loops with the selected schedule.
2, in InputInlineFusionPass, greedily perform input inline fusion on LHLO_Op->Loops patterns. The LHLO_Op is supported to be any fusible Ops in XLA codegen.