### PR TITLE
[DOCS] Updated documentation for the versioning of the TensorFlow Lite operators.

### DIFF
--- a/tensorflow/lite/g3doc/guide/ops_version.md
+++ b/tensorflow/lite/g3doc/guide/ops_version.md
@@ -62,12 +62,13 @@ table Conv2DOptions {
   dilation_height_factor:int = 1;
 }
 ```
+The file `lite/schema/schema_generated.h` should be re-generated for the new schema.
 
 ### Change C Structures and Kernel Implementation
 
 In TensorFlow Lite, the kernel implementation is decoupled from
 FlatBuffer definition. The kernels read the parameter from C structures defined
-in `lite/builtin_op_data.h`.
+in `lite/c/builtin_op_data.h`.
 
 The original convolution parameter is as follows:
 
@@ -102,7 +103,7 @@ from the C structures. The details are omitted here.
 
 ### Change the FlatBuffer Reading Code
 
-The logic to read FlatBuffer and produce C structure is in `lite/model.cc`.
+The logic to read FlatBuffer and produce C structure is in `lite/core/api/flatbuffer_conversions.cc`.
 
 Update the file to handle the new parameters, as shown below:
 
@@ -162,7 +163,7 @@ execute the op. In this example, it means:
 *   Populate version=1 when dilation factors are all 1.
 *   Populate version=2 otherwise.
 
-To do this, you need to override `GetVersion` function for the operator class in
+To do this, you need to override `GetBuiltinOperatorVersion` function for the operator class in
 `lite/tools/versioning/op_version.cc`.
 
 For ops with only one version, the `GetVersion` function is defined as:
@@ -192,7 +193,7 @@ step is required because we need generate the model's minimum required runtime
 version based on this version map.
 
 To do this, you need to add a new map entry in
-`lite/tools/versioning/op_version.cc`.
+`lite/toco/tflite/op_version.cc`.
 
 In this example, it means you need to add the following into `op_version_map`:
 ```


### PR DESCRIPTION
I was going through the document for the TensorFlow Lite operators versioning
https://www.tensorflow.org/lite/guide/ops_version
and noticed that some mentioned files/functions are out-of-dated.
I have corrected them in this PR.