### PR TITLE
Support negative axis for tf.signal.fftshift

### DIFF
--- a/tensorflow/python/kernel_tests/signal/fft_ops_test.py
+++ b/tensorflow/python/kernel_tests/signal/fft_ops_test.py
@@ -662,6 +662,13 @@ class FFTShiftTest(test.TestCase, parameterized.TestCase):
     self.assertAllClose(y_fftshift_res, np.fft.fftshift(x_np, axes=axes))
     self.assertAllClose(y_ifftshift_res, np.fft.ifftshift(x_np, axes=axes))
 
+  def test_negative_axes(self):
+    with self.session():
+      freqs = [[0, 1, 2], [3, 4, -4], [-3, -2, -1]]
+      shifted = [[-1, -3, -2], [2, 0, 1], [-4, 3, 4]]
+      self.assertAllEqual(fft_ops.fftshift(freqs, axes=(0, -1)), shifted)
+      self.assertAllEqual(fft_ops.ifftshift(shifted, axes=(0, -1)), freqs)
+
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/kernel_tests/signal/fft_ops_test.py
+++ b/tensorflow/python/kernel_tests/signal/fft_ops_test.py
@@ -668,6 +668,12 @@ class FFTShiftTest(test.TestCase, parameterized.TestCase):
       shifted = [[-1, -3, -2], [2, 0, 1], [-4, 3, 4]]
       self.assertAllEqual(fft_ops.fftshift(freqs, axes=(0, -1)), shifted)
       self.assertAllEqual(fft_ops.ifftshift(shifted, axes=(0, -1)), freqs)
+      self.assertAllEqual(
+          fft_ops.fftshift(freqs, axes=-1),
+          fft_ops.fftshift(freqs, axes=(1,)))
+      self.assertAllEqual(
+          fft_ops.ifftshift(shifted, axes=-1),
+          fft_ops.ifftshift(shifted, axes=(1,)))
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/ops/signal/fft_ops.py
+++ b/tensorflow/python/ops/signal/fft_ops.py
@@ -442,6 +442,9 @@ def ifftshift(x, axes=None, name=None):
     elif isinstance(axes, int):
       shift = -(_array_ops.shape(x)[axes] // 2)
     else:
+      rank = _array_ops.rank(x)
+      # allows negative axis
+      axes = _array_ops.where(_math_ops.less(axes, 0), axes + rank, axes)
       shift = -(_array_ops.gather(_array_ops.shape(x), axes) // 2)
 
     return manip_ops.roll(x, shift, axes, name)

--- a/tensorflow/python/ops/signal/fft_ops.py
+++ b/tensorflow/python/ops/signal/fft_ops.py
@@ -398,6 +398,9 @@ def fftshift(x, axes=None, name=None):
     elif isinstance(axes, int):
       shift = _array_ops.shape(x)[axes] // 2
     else:
+      rank = _array_ops.rank(x)
+      # allows negative axis
+      axes = _array_ops.where(_math_ops.less(axes, 0), axes + rank, axes)
       shift = _array_ops.gather(_array_ops.shape(x), axes) // 2
 
     return manip_ops.roll(x, shift, axes, name)


### PR DESCRIPTION

This PR tries to address the issue raised in #38172 where
negative axis is not supported for tf.signal.fftshift

This PR use tf.where to adjust the axis when it is less than zero.

This PR fixes #38172.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>