### PR TITLE
[r2.2:CherryPick] Ensure saved_model_cli and deps are included in pip package.

### DIFF
--- a/tensorflow/python/tools/BUILD
+++ b/tensorflow/python/tools/BUILD
@@ -26,6 +26,7 @@ py_library(
         "//tensorflow/tools/compatibility:tf_upgrade_v2",
     ],
     deps = [
+        ":saved_model_aot_compile",
         ":saved_model_utils",
         # The following py_library are needed because
         # py_binary may not depend on them when --define=no_tensorflow_py_deps=true
@@ -322,6 +323,10 @@ py_library(
     srcs = ["saved_model_cli.py"],
     srcs_version = "PY2AND3",
     deps = [
+        # Note: if you make any changes here, make corresponding changes to the
+        # deps of the "tools_pip" target in this file.  Otherwise release builds
+        # (built with --define=no_tensorflow_py_deps=true) may end up with a
+        # broken saved_model_cli.
         ":saved_model_aot_compile",
         ":saved_model_utils",
         "//tensorflow/python",


### PR DESCRIPTION
Unbreaks tf2.2 rc's saved_model_cli (fixes #38042)

PiperOrigin-RevId: 304724007
Change-Id: I832653cfc63d0d5338f7ca82e823987337fee429