### PR TITLE
[r2.2:CherryPick] Adding a missing dependency to version.cc, fixing an undefined_symbol_error in tensorflow_serving.

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -635,6 +635,7 @@ tf_python_pybind_extension(
             "//tensorflow/core:eager_service_proto_cc",
             "//tensorflow/core:master_proto_cc",
             "//tensorflow/core:worker_proto_cc",
+            "//tensorflow/core:version_lib",
         ],
         otherwise = [
             "//tensorflow/core:eager_service_proto_cc_headers_only",


### PR DESCRIPTION
PiperOrigin-RevId: 302783112
Change-Id: I472ec370963ac2d752ea3ccf23e066da3d090da4