### PR TITLE
revert the gitignore due to build failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,9 @@ gradleBuild
 *.pbxproj
 *.xcworkspace
 /*.podspec
-/tensorflow/lite/**/[ios|objc|swift]*/BUILD
+/tensorflow/lite/**/ios/BUILD
+/tensorflow/lite/**/objc/BUILD
+/tensorflow/lite/**/swift/BUILD
 /tensorflow/lite/examples/ios/simple/data/*.tflite
 /tensorflow/lite/examples/ios/simple/data/*.txt
 Podfile.lock


### PR DESCRIPTION
Hi, the .gitignore cannot resolve ```/tensorflow/lite/**/[ios|objc|swift]*/BUILD``` this code but ignore all BUILD file in /tensorflow/lite/**, and it will lead to build failure when I push the code to my repo and pull it again to build.