### PR TITLE
systemlibs: unbundle astunparse and small syslibs updates

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -562,6 +562,11 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
         sha256 = "b956598d8cbe168b5ee717b5dafa56563eb5201a947856a6688bbeac9cac4e1f",
         strip_prefix = "grpc-b54a5b338637f92bfcf4b0bc05e0f57a5fd8fadd",
         system_build_file = clean_dep("//third_party/systemlibs:grpc.BUILD"),
+        system_link_files = {
+            "//third_party/systemlibs:BUILD": "bazel/BUILD",
+            "//third_party/systemlibs:grpc.BUILD": "src/compiler/BUILD",
+            "//third_party/systemlibs:grpc.bazel.grpc_deps.bzl": "bazel/grpc_deps.bzl",
+        },
         urls = [
             "https://storage.googleapis.com/mirror.tensorflow.org/github.com/grpc/grpc/archive/b54a5b338637f92bfcf4b0bc05e0f57a5fd8fadd.tar.gz",
             "https://github.com/grpc/grpc/archive/b54a5b338637f92bfcf4b0bc05e0f57a5fd8fadd.tar.gz",

--- a/third_party/systemlibs/astunparse.BUILD
+++ b/third_party/systemlibs/astunparse.BUILD
@@ -1,0 +1,15 @@
+# Description:
+#   AST round-trip manipulation for Python.
+
+licenses(["notice"])
+
+py_library(
+    name = "astunparse",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "LICENSE",
+    visibility = ["//visibility:public"],
+)
+

--- a/third_party/systemlibs/grpc.bazel.grpc_deps.bzl
+++ b/third_party/systemlibs/grpc.bazel.grpc_deps.bzl
@@ -1,0 +1,7 @@
+"""Load dependencies needed to compile and test the grpc library as a 3rd-party consumer."""
+
+def grpc_deps():
+    """Loads dependencies need to compile and test the grpc library."""
+
+    pass
+

--- a/third_party/systemlibs/protobuf.bzl
+++ b/third_party/systemlibs/protobuf.bzl
@@ -93,6 +93,7 @@ def _proto_gen_impl(ctx):
         args += ["--python_out=" + gen_dir]
 
     inputs = srcs + deps
+    tools = [ctx.executable.protoc]
     if ctx.executable.plugin:
         plugin = ctx.executable.plugin
         lang = ctx.attr.plugin_language
@@ -106,7 +107,7 @@ def _proto_gen_impl(ctx):
             outdir = ",".join(ctx.attr.plugin_options) + ":" + outdir
         args += ["--plugin=protoc-gen-%s=%s" % (lang, plugin.path)]
         args += ["--%s_out=%s" % (lang, outdir)]
-        inputs += [plugin]
+        tools.append(plugin)
 
     if args:
         ctx.actions.run(
@@ -115,6 +116,7 @@ def _proto_gen_impl(ctx):
             arguments = args + import_flags + [s.path for s in srcs],
             executable = ctx.executable.protoc,
             mnemonic = "ProtoCompile",
+            tools = tools,
             use_default_shell_env = True,
         )
 

--- a/third_party/systemlibs/syslibs_configure.bzl
+++ b/third_party/systemlibs/syslibs_configure.bzl
@@ -11,6 +11,7 @@ _TF_SYSTEM_LIBS = "TF_SYSTEM_LIBS"
 VALID_LIBS = [
     "absl_py",
     "astor_archive",
+    "astunparse_archive",
     "boringssl",
     "com_github_googleapis_googleapis",
     "com_github_googlecloudplatform_google_cloud_cpp",


### PR DESCRIPTION
A series of small changes needed for systemlibs for TF-2.2, there are also a few bigger changes needed but will be done in separate PRs.

Bundled GRPC was updated and needs some minor new rules to build against the system version of grpc

The bundled protobuf rules needed some minor updates to work with bazel --incompatible_no_support_tools_in_action_inputs.

astunparse is unbundled like all other python packages

@angerson 