### PR TITLE
Added _estimator_type property for KerasClassifier and KerasRegressor…

### DIFF
--- a/tensorflow/python/keras/wrappers/scikit_learn.py
+++ b/tensorflow/python/keras/wrappers/scikit_learn.py
@@ -191,6 +191,8 @@ class BaseWrapper(object):
 class KerasClassifier(BaseWrapper):
   """Implementation of the scikit-learn classifier API for Keras.
   """
+  
+  _estimator_type = "classifier"
 
   def fit(self, x, y, **kwargs):
     """Constructs a new model with `build_fn` & fit the model to `(x, y)`.
@@ -314,6 +316,8 @@ class KerasClassifier(BaseWrapper):
 class KerasRegressor(BaseWrapper):
   """Implementation of the scikit-learn regressor API for Keras.
   """
+  
+  _estimator_type = "regressor"
 
   def predict(self, x, **kwargs):
     """Returns predictions for the given test data.


### PR DESCRIPTION
… classes

In order to use VotingClassifier and VotingRegressor (and probably many others) sklearn classes, the property _estimator_type must be defined as "classifier" and "regressor" respectively. Sklearn classes normally inherit this property from ClassifierMixin and RegressorMixin