### PR TITLE
Add `socketpair.c` to curl buildable files to fix Windows builds.

### DIFF
--- a/third_party/curl.BUILD
+++ b/third_party/curl.BUILD
@@ -186,6 +186,7 @@ cc_library(
         "lib/smtp.h",
         "lib/sockaddr.h",
         "lib/socketpair.h",
+        "lib/socketpair.c",
         "lib/socks.c",
         "lib/socks.h",
         "lib/speedcheck.c",


### PR DESCRIPTION
Follow-up from bfb0e49d5844d835ab757a1709a1bcfc216d78f8

PiperOrigin-RevId: 305351839
Change-Id: Ic7a8b4942394d6d030e93b3ad9179e0bffdc434c