### PR TITLE
Reduce code duplication tpu_embedding

### DIFF
--- a/tensorflow/python/tpu/tpu_embedding.py
+++ b/tensorflow/python/tpu/tpu_embedding.py
@@ -1264,7 +1264,7 @@ class TPUEmbedding(object):
     """Validate `enqueue_datas_list`."""
 
     def _check_agreement(data, name, feature, enqueue_data):
-      # Helper function to check device agreement
+      """Helper function to check device agreement."""
       if (data is not None and
           data.device != enqueue_data.embedding_indices.device):
         raise ValueError(

--- a/tensorflow/python/tpu/tpu_embedding.py
+++ b/tensorflow/python/tpu/tpu_embedding.py
@@ -1262,6 +1262,15 @@ class TPUEmbedding(object):
   def _validate_generate_enqueue_ops_enqueue_datas_list(self,
                                                         enqueue_datas_list):
     """Validate `enqueue_datas_list`."""
+
+    def _check_agreement(data, name, feature, enqueue_data):
+      # Helper function to check device agreement
+      if (data is not None and
+          data.device != enqueue_data.embedding_indices.device):
+        raise ValueError(
+            'Device of {0} does not agree with that of'
+            'embedding_indices for feature {1}.'.format(name, feature))
+
     feature_set = set(self._feature_to_config_dict.keys())
     contiguous_device = None
     for i, enqueue_datas in enumerate(enqueue_datas_list):
@@ -1280,13 +1289,6 @@ class TPUEmbedding(object):
                          'in `feature_to_config_dict`: {}.'.format(
                              i, extra_feature_set))
 
-      def _check_agreement(data, name, feature, enqueue_data):
-        # Helper function to check device agreement
-        if (data is not None and
-            data.device != enqueue_data.embedding_indices.device):
-          raise ValueError(
-              'Device of {0} does not agree with that of'
-              'embedding_indices for feature {1}.'.format(name, feature))
 
       device = None
       device_feature = None

--- a/tensorflow/python/tpu/tpu_embedding.py
+++ b/tensorflow/python/tpu/tpu_embedding.py
@@ -1289,7 +1289,6 @@ class TPUEmbedding(object):
                          'in `feature_to_config_dict`: {}.'.format(
                              i, extra_feature_set))
 
-
       device = None
       device_feature = None
       for feature, enqueue_data in six.iteritems(enqueue_datas):


### PR DESCRIPTION
I was browsing over the code of the `tpu_embedding.py` file and noticed some code duplication in the `_validate_generate_enqueue_ops_enqueue_datas_list` method which I thought could be simplified. 
Also removed an unnecessary `else` statement.

Let me know what you think, cheers!