### PR TITLE
Add aarch64 cross compile toolchain for TFLite

### DIFF
--- a/arm_compiler.BUILD
+++ b/arm_compiler.BUILD
@@ -2,58 +2,42 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "gcc",
-    srcs = [
-        "bin/arm-rpi-linux-gnueabihf-gcc",
-    ],
+    srcs = glob(["bin/*-gcc"]),
 )
 
 filegroup(
     name = "ar",
-    srcs = [
-        "bin/arm-rpi-linux-gnueabihf-ar",
-    ],
+    srcs = glob(["bin/*-ar"]),
 )
 
 filegroup(
     name = "ld",
-    srcs = [
-        "bin/arm-rpi-linux-gnueabihf-ld",
-    ],
+    srcs = glob(["bin/*-ld"]),
 )
 
 filegroup(
     name = "nm",
-    srcs = [
-        "bin/arm-rpi-linux-gnueabihf-nm",
-    ],
+    srcs = glob(["bin/*-nm"]),
 )
 
 filegroup(
     name = "objcopy",
-    srcs = [
-        "bin/arm-rpi-linux-gnueabihf-objcopy",
-    ],
+    srcs = glob(["bin/*-objcopy"]),
 )
 
 filegroup(
     name = "objdump",
-    srcs = [
-        "bin/arm-rpi-linux-gnueabihf-objdump",
-    ],
+    srcs = glob(["bin/*-objdump"]),
 )
 
 filegroup(
     name = "strip",
-    srcs = [
-        "bin/arm-rpi-linux-gnueabihf-strip",
-    ],
+    srcs = glob(["bin/*-strip"]),
 )
 
 filegroup(
     name = "as",
-    srcs = [
-        "bin/arm-rpi-linux-gnueabihf-as",
-    ],
+    srcs = glob(["bin/*-as"]),
 )
 
 filegroup(

--- a/arm_compiler.BUILD
+++ b/arm_compiler.BUILD
@@ -51,6 +51,16 @@ filegroup(
 )
 
 filegroup(
+    name = "aarch64_compiler_pieces",
+    srcs = glob([
+        "aarch64-none-linux-gnu/**",
+        "libexec/**",
+        "lib/gcc/aarch64-none-linux-gnu/**",
+        "include/**",
+    ]),
+)
+
+filegroup(
     name = "compiler_components",
     srcs = [
         ":ar",

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -110,7 +110,8 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
     arm_compiler_configure(
         name = "local_config_arm_compiler",
         build_file = clean_dep("//third_party/toolchains/cpus/arm:BUILD"),
-        remote_config_repo = "../arm_compiler",
+        remote_config_repo_arm = "../arm_compiler",
+        remote_config_repo_aarch64 = "../aarch64_compiler",
     )
 
     mkl_repository(
@@ -219,6 +220,20 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
         urls = [
             "https://storage.googleapis.com/mirror.tensorflow.org/github.com/rvagg/rpi-newer-crosstools/archive/eb68350c5c8ec1663b7fe52c742ac4271e3217c5.tar.gz",
             "https://github.com/rvagg/rpi-newer-crosstools/archive/eb68350c5c8ec1663b7fe52c742ac4271e3217c5.tar.gz",
+        ],
+    )
+
+    tf_http_archive(
+        # This is the latest `aarch64-none-linux-gnu` compiler provided by ARM
+        # See https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-a/downloads
+        # The archive contains GCC version 9.2.1
+        name = "aarch64_compiler",
+        build_file = "//:arm_compiler.BUILD",
+        sha256 = "8dfe681531f0bd04fb9c53cf3c0a3368c616aa85d48938eebe2b516376e06a66",
+        strip_prefix = "gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu",
+        urls = [
+            "https://storage.googleapis.com/mirror.tensorflow.org/developer.arm.com/-/media/Files/downloads/gnu-a/9.2-2019.12/binrel/gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu.tar.xz",
+            "https://developer.arm.com/-/media/Files/downloads/gnu-a/9.2-2019.12/binrel/gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu.tar.xz",
         ],
     )
 

--- a/third_party/toolchains/cpus/arm/BUILD
+++ b/third_party/toolchains/cpus/arm/BUILD
@@ -12,6 +12,7 @@ cc_toolchain_suite(
         "armeabi|compiler": ":cc-compiler-armeabi",
         "local|compiler": ":cc-compiler-local",
         "armeabi": ":cc-compiler-armeabi",
+        "aarch64": ":cc-compiler-aarch64",
         "k8": ":cc-compiler-local",
         "piii": ":cc-compiler-local",
         "arm": ":cc-compiler-local",
@@ -28,6 +29,13 @@ filegroup(
     name = "arm_linux_all_files",
     srcs = [
         "@arm_compiler//:compiler_pieces",
+    ],
+)
+
+filegroup(
+    name = "aarch64_linux_all_files",
+    srcs = [
+        "@aarch64_compiler//:aarch64_compiler_pieces",
     ],
 )
 
@@ -65,4 +73,22 @@ cc_toolchain(
     supports_param_files = 1,
     toolchain_config = ":armeabi_config",
     toolchain_identifier = "arm-linux-gnueabihf",
+)
+
+cc_toolchain_config(
+    name = "aarch64_config",
+    cpu = "aarch64",
+)
+
+cc_toolchain(
+    name = "cc-compiler-aarch64",
+    all_files = ":aarch64_linux_all_files",
+    compiler_files = ":aarch64_linux_all_files",
+    dwp_files = ":empty",
+    linker_files = ":aarch64_linux_all_files",
+    objcopy_files = "aarch64_linux_all_files",
+    strip_files = "aarch64_linux_all_files",
+    supports_param_files = 1,
+    toolchain_config = ":aarch64_config",
+    toolchain_identifier = "aarch64-linux-gnu",
 )

--- a/third_party/toolchains/cpus/arm/arm_compiler_configure.bzl
+++ b/third_party/toolchains/cpus/arm/arm_compiler_configure.bzl
@@ -22,7 +22,10 @@ def _arm_compiler_configure_impl(repository_ctx):
         python_include_path = "/usr/include/python2.7"
     _tpl(repository_ctx, "cc_config.bzl", {
         "%{ARM_COMPILER_PATH}%": str(repository_ctx.path(
-            repository_ctx.attr.remote_config_repo,
+            repository_ctx.attr.remote_config_repo_arm,
+        )),
+        "%{AARCH64_COMPILER_PATH}%": str(repository_ctx.path(
+            repository_ctx.attr.remote_config_repo_aarch64,
         )),
         "%{PYTHON_INCLUDE_PATH}%": python_include_path,
     })
@@ -31,7 +34,8 @@ def _arm_compiler_configure_impl(repository_ctx):
 arm_compiler_configure = repository_rule(
     implementation = _arm_compiler_configure_impl,
     attrs = {
-        "remote_config_repo": attr.string(mandatory = False, default = ""),
+        "remote_config_repo_arm": attr.string(mandatory = False, default = ""),
+        "remote_config_repo_aarch64": attr.string(mandatory = False, default = ""),
         "build_file": attr.label(),
     },
 )

--- a/third_party/toolchains/cpus/arm/cc_config.bzl.tpl
+++ b/third_party/toolchains/cpus/arm/cc_config.bzl.tpl
@@ -18,6 +18,8 @@ load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 def _impl(ctx):
     if (ctx.attr.cpu == "armeabi"):
         toolchain_identifier = "arm-linux-gnueabihf"
+    elif (ctx.attr.cpu == "aarch64"):
+        toolchain_identifier = "aarch64-linux-gnu"
     elif (ctx.attr.cpu == "local"):
         toolchain_identifier = "local_linux"
     else:
@@ -25,6 +27,8 @@ def _impl(ctx):
 
     if (ctx.attr.cpu == "armeabi"):
         host_system_name = "armeabi"
+    elif (ctx.attr.cpu == "aarch64"):
+        host_system_name = "aarch64"
     elif (ctx.attr.cpu == "local"):
         host_system_name = "local"
     else:
@@ -32,6 +36,8 @@ def _impl(ctx):
 
     if (ctx.attr.cpu == "armeabi"):
         target_system_name = "armeabi"
+    elif (ctx.attr.cpu == "aarch64"):
+        target_system_name = "aarch64"
     elif (ctx.attr.cpu == "local"):
         target_system_name = "local"
     else:
@@ -39,6 +45,8 @@ def _impl(ctx):
 
     if (ctx.attr.cpu == "armeabi"):
         target_cpu = "armeabi"
+    elif (ctx.attr.cpu == "aarch64"):
+        target_cpu = "aarch64"
     elif (ctx.attr.cpu == "local"):
         target_cpu = "local"
     else:
@@ -46,6 +54,8 @@ def _impl(ctx):
 
     if (ctx.attr.cpu == "armeabi"):
         target_libc = "armeabi"
+    elif (ctx.attr.cpu == "aarch64"):
+        target_libc = "aarch64"
     elif (ctx.attr.cpu == "local"):
         target_libc = "local"
     else:
@@ -55,6 +65,8 @@ def _impl(ctx):
 
     if (ctx.attr.cpu == "armeabi"):
         abi_version = "armeabi"
+    elif (ctx.attr.cpu == "aarch64"):
+        abi_version = "aarch64"
     elif (ctx.attr.cpu == "local"):
         abi_version = "local"
     else:
@@ -62,6 +74,8 @@ def _impl(ctx):
 
     if (ctx.attr.cpu == "armeabi"):
         abi_libc_version = "armeabi"
+    elif (ctx.attr.cpu == "aarch64"):
+        abi_libc_version = "aarch64"
     elif (ctx.attr.cpu == "local"):
         abi_libc_version = "local"
     else:
@@ -127,6 +141,8 @@ def _impl(ctx):
 
     if (ctx.attr.cpu == "armeabi"):
         action_configs = []
+    elif (ctx.attr.cpu == "aarch64"):
+        action_configs = []
     elif (ctx.attr.cpu == "local"):
         action_configs = [objcopy_embed_data_action]
     else:
@@ -165,7 +181,7 @@ def _impl(ctx):
         ],
     )
 
-    if (ctx.attr.cpu == "armeabi"):
+    if (ctx.attr.cpu == "armeabi" or ctx.attr.cpu == "aarch64"):
         unfiltered_compile_flags_feature = feature(
             name = "unfiltered_compile_flags",
             enabled = True,
@@ -340,6 +356,107 @@ def _impl(ctx):
 		                "%{ARM_COMPILER_PATH}%/arm-rpi-linux-gnueabihf/include/c++/6.5.0/",
                                 "-isystem",
                                 "%{PYTHON_INCLUDE_PATH}%",
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
+    elif (ctx.attr.cpu == "aarch64"):
+        default_compile_flags_feature = feature(
+            name = "default_compile_flags",
+            enabled = True,
+            flag_sets = [
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.assemble,
+                        ACTION_NAMES.preprocess_assemble,
+                        ACTION_NAMES.linkstamp_compile,
+                        ACTION_NAMES.c_compile,
+                        ACTION_NAMES.cpp_compile,
+                        ACTION_NAMES.cpp_header_parsing,
+                        ACTION_NAMES.cpp_module_compile,
+                        ACTION_NAMES.cpp_module_codegen,
+                        ACTION_NAMES.lto_backend,
+                        ACTION_NAMES.clif_match,
+                    ],
+                    flag_groups = [
+                        flag_group(
+                            flags = [
+                                "-U_FORTIFY_SOURCE",
+                                "-D_FORTIFY_SOURCE=1",
+                                "-fstack-protector",
+                                "-DRASPBERRY_PI",
+                            ],
+                        ),
+                    ],
+                ),
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.assemble,
+                        ACTION_NAMES.preprocess_assemble,
+                        ACTION_NAMES.linkstamp_compile,
+                        ACTION_NAMES.c_compile,
+                        ACTION_NAMES.cpp_compile,
+                        ACTION_NAMES.cpp_header_parsing,
+                        ACTION_NAMES.cpp_module_compile,
+                        ACTION_NAMES.cpp_module_codegen,
+                        ACTION_NAMES.lto_backend,
+                        ACTION_NAMES.clif_match,
+                    ],
+                    flag_groups = [flag_group(flags = ["-g"])],
+                    with_features = [with_feature_set(features = ["dbg"])],
+                ),
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.assemble,
+                        ACTION_NAMES.preprocess_assemble,
+                        ACTION_NAMES.linkstamp_compile,
+                        ACTION_NAMES.c_compile,
+                        ACTION_NAMES.cpp_compile,
+                        ACTION_NAMES.cpp_header_parsing,
+                        ACTION_NAMES.cpp_module_compile,
+                        ACTION_NAMES.cpp_module_codegen,
+                        ACTION_NAMES.lto_backend,
+                        ACTION_NAMES.clif_match,
+                    ],
+                    flag_groups = [
+                        flag_group(
+                            flags = [
+                                "-g0",
+                                "-O2",
+                                "-DNDEBUG",
+                                "-ffunction-sections",
+                                "-fdata-sections",
+                            ],
+                        ),
+                    ],
+                    with_features = [with_feature_set(features = ["opt"])],
+                ),
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.linkstamp_compile,
+                        ACTION_NAMES.cpp_compile,
+                        ACTION_NAMES.cpp_header_parsing,
+                        ACTION_NAMES.cpp_module_compile,
+                        ACTION_NAMES.cpp_module_codegen,
+                        ACTION_NAMES.lto_backend,
+                        ACTION_NAMES.clif_match,
+                    ],
+                    flag_groups = [
+                        flag_group(
+                            flags = [
+                                "-std=c++11",
+                                "-isystem",
+                                "%{AARCH64_COMPILER_PATH}%/aarch64-none-linux-gnu/include/c++/9.2.1/",
+                                "-isystem",
+                                "%{AARCH64_COMPILER_PATH}%/lib/gcc/aarch64-none-linux-gnu/9.2.1/include",
+                                "-isystem",
+                                "%{AARCH64_COMPILER_PATH}%/lib/gcc/aarch64-none-linux-gnu/9.2.1/include-fixed",
+                                "-isystem",
+                                "%{AARCH64_COMPILER_PATH}%/aarch64-none-linux-gnu/libc/usr/include/",
+                                "-isystem",
+                                "%{PYTHON_INCLUDE_PATH}%",
                                 "-isystem",
                                 "/usr/include/",
                             ],
@@ -467,7 +584,7 @@ def _impl(ctx):
                 ),
             ],
         )
-    elif (ctx.attr.cpu == "armeabi"):
+    elif (ctx.attr.cpu == "armeabi" or ctx.attr.cpu == "aarch64"):
         default_link_flags_feature = feature(
             name = "default_link_flags",
             enabled = True,
@@ -542,7 +659,7 @@ def _impl(ctx):
                 sysroot_feature,
                 unfiltered_compile_flags_feature,
             ]
-    elif (ctx.attr.cpu == "armeabi"):
+    elif (ctx.attr.cpu == "armeabi" or ctx.attr.cpu == "aarch64"):
         features = [
                 default_compile_flags_feature,
                 default_link_flags_feature,
@@ -563,6 +680,15 @@ def _impl(ctx):
                 "%{ARM_COMPILER_PATH}%/lib/gcc/arm-rpi-linux-gnueabihf/6.5.0/include-fixed",
                 "%{ARM_COMPILER_PATH}%/arm-rpi-linux-gnueabihf/sysroot/usr/include/",
 		"%{ARM_COMPILER_PATH}%/arm-rpi-linux-gnueabihf/include/c++/6.5.0/",
+                "/usr/include",
+                "/tmp/openblas_install/include/",
+            ]
+    elif (ctx.attr.cpu == "aarch64"):
+        cxx_builtin_include_directories = [
+                "%{AARCH64_COMPILER_PATH}%/aarch64-none-linux-gnu/include/c++/9.2.1/",
+                "%{AARCH64_COMPILER_PATH}%/lib/gcc/aarch64-none-linux-gnu/9.2.1/include",
+                "%{AARCH64_COMPILER_PATH}%/lib/gcc/aarch64-none-linux-gnu/9.2.1/include-fixed",
+                "%{AARCH64_COMPILER_PATH}%/aarch64-none-linux-gnu/libc/usr/include/",
                 "/usr/include",
                 "/tmp/openblas_install/include/",
             ]
@@ -619,6 +745,50 @@ def _impl(ctx):
                 path = "%{ARM_COMPILER_PATH}%/bin/arm-rpi-linux-gnueabihf-strip",
             ),
         ]
+    elif (ctx.attr.cpu == "aarch64"):
+        tool_paths = [
+            tool_path(
+                name = "ar",
+                path = "%{AARCH64_COMPILER_PATH}%/bin/aarch64-none-linux-gnu-ar",
+            ),
+            tool_path(name = "compat-ld", path = "/bin/false"),
+            tool_path(
+                name = "cpp",
+                path = "%{AARCH64_COMPILER_PATH}%/bin/aarch64-none-linux-gnu-cpp",
+            ),
+            tool_path(
+                name = "dwp",
+                path = "%{AARCH64_COMPILER_PATH}%/bin/aarch64-none-linux-gnu-dwp",
+            ),
+            tool_path(
+                name = "gcc",
+                path = "%{AARCH64_COMPILER_PATH}%/bin/aarch64-none-linux-gnu-gcc",
+            ),
+            tool_path(
+                name = "gcov",
+                path = "%{AARCH64_COMPILER_PATH}%/bin/aarch64-none-linux-gnu-gcov",
+            ),
+            tool_path(
+                name = "ld",
+                path = "%{AARCH64_COMPILER_PATH}%/bin/aarch64-none-linux-gnu-ld",
+            ),
+            tool_path(
+                name = "nm",
+                path = "%{AARCH64_COMPILER_PATH}%/bin/aarch64-none-linux-gnu-nm",
+            ),
+            tool_path(
+                name = "objcopy",
+                path = "%{AARCH64_COMPILER_PATH}%/bin/aarch64-none-linux-gnu-objcopy",
+            ),
+            tool_path(
+                name = "objdump",
+                path = "%{AARCH64_COMPILER_PATH}%/bin/aarch64-none-linux-gnu-objdump",
+            ),
+            tool_path(
+                name = "strip",
+                path = "%{AARCH64_COMPILER_PATH}%/bin/aarch64-none-linux-gnu-strip",
+            ),
+        ]
     elif (ctx.attr.cpu == "local"):
         tool_paths = [
             tool_path(name = "ar", path = "/usr/bin/ar"),
@@ -666,7 +836,7 @@ def _impl(ctx):
 cc_toolchain_config =  rule(
     implementation = _impl,
     attrs = {
-        "cpu": attr.string(mandatory=True, values=["armeabi", "local"]),
+        "cpu": attr.string(mandatory=True, values=["armeabi", "aarch64", "local"]),
     },
     provides = [CcToolchainConfigInfo],
     executable = True,


### PR DESCRIPTION
This PR extends the current Arm toolchain by adding an `aarch64` bazel toolchain based on [Arm GCC 9.2](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-a/downloads). This e.g. allows to cross compile TFLite with `bazel` for the Raspberry Pi 4 running on a 64-bit OS.

This has can be tested by compiling the TFLite benchmark binary on Linux by running:
```
bazelisk build -c opt tensorflow/lite/tools/benchmark:benchmark_model \
    --cpu=aarch64 --crosstool_top=@local_config_arm_compiler//:toolchain
```