### PR TITLE
r2.2-rc3 cherry-pick request: Fix a bug that profile XLA gpu crashes OOM.

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/gpu_executable.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_executable.cc
@@ -96,10 +96,8 @@ void GpuExecutable::ComputeThunkAnnotations() {
     const HloInstruction* hlo = thunk->hlo_instruction();
     CHECK(hlo);
     thunk_annotations_[thunk] =
-        absl::StrFormat("%s:#hlo_op=%s,hlo_module=%s#",
-                        hlo->ToStringWithCanonicalNameMap(
-                            HloPrintOptions::Canonical(), &canonical_name_map),
-                        hlo->name(), hlo->GetModule()->name());
+        absl::StrFormat("Thunk#hlo_op=%s,hlo_module=%s#", hlo->name(),
+                        hlo->GetModule()->name());
   }
 }
 

--- a/tensorflow/core/profiler/internal/gpu/cupti_tracer.cc
+++ b/tensorflow/core/profiler/internal/gpu/cupti_tracer.cc
@@ -1348,7 +1348,7 @@ absl::string_view AnnotationMap::LookUp(uint32 device_id,
 }
 
 bool CuptiTracer::IsAvailable() const {
-  return !activity_tracing_enabled_ && !api_tracing_enabled_;
+  return NumGpus() && !activity_tracing_enabled_ && !api_tracing_enabled_;
 }
 
 int CuptiTracer::NumGpus() {


### PR DESCRIPTION
Remove data redundancy by remove xla expression in trunk annotation.
Don't create device tracer when there's no GPU in the system.