### PR TITLE
Allow passing custom image preprocessing config to the TFL eval tool.

### DIFF
--- a/tensorflow/lite/tools/evaluation/stages/image_classification_stage.cc
+++ b/tensorflow/lite/tools/evaluation/stages/image_classification_stage.cc
@@ -67,12 +67,16 @@ TfLiteStatus ImageClassificationStage::Init(
   }
 
   // ImagePreprocessingStage
-  tflite::evaluation::ImagePreprocessingConfigBuilder builder(
-      "image_preprocessing", input_type);
-  builder.AddCroppingStep(kCroppingFraction, true /*square*/);
-  builder.AddResizingStep(input_shape->data[2], input_shape->data[1], false);
-  builder.AddDefaultNormalizationStep();
-  preprocessing_stage_.reset(new ImagePreprocessingStage(builder.build()));
+  if (!config_.specification().has_image_preprocessing_params()) {
+    tflite::evaluation::ImagePreprocessingConfigBuilder builder(
+        "image_preprocessing", input_type);
+    builder.AddCroppingStep(kCroppingFraction, true /*square*/);
+    builder.AddResizingStep(input_shape->data[2], input_shape->data[1], false);
+    builder.AddDefaultNormalizationStep();
+    preprocessing_stage_.reset(new ImagePreprocessingStage(builder.build()));
+  } else {
+    preprocessing_stage_.reset(new ImagePreprocessingStage(config_));
+  }
   if (preprocessing_stage_->Init() != kTfLiteOk) return kTfLiteError;
 
   // TopkAccuracyEvalStage.


### PR DESCRIPTION
At the moment the `ImageClassificationStage` of the TFLite evaluation tool ignores any existing image preprocessing parameters set on the `EvaluationStageConfig` and instead instantiates the `ImagePreprocessingStage` using hard-coded configuration.

This PR changes this behaviour to instead instantiate the `ImagePreprocessingStage` using existing image preprocessing parameters, if provided, and fall back to the old behaviour if not.