### PR TITLE
Add Python 2 EOL notice

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # Release 2.2.0
 
+TensorFlow 2.2 discontinues support for Python 2, [previously announced](https://groups.google.com/a/tensorflow.org/d/msg/announce/gVwS5RC8mds/dCt1ka2XAAAJ) as following [Python 2's EOL on January 1, 2020](https://www.python.org/dev/peps/pep-0373/#update).
+
+Coinciding with this change, new releases of [TensorFlow's Docker images](https://hub.docker.com/r/tensorflow/tensorflow/) provide Python 3 exclusively. Because all images now use Python 3, Docker tags containing `-py3` will no longer be provided and existing `-py3` tags like `latest-py3` will not be updated.   
+
 ## Major Features and Improvements
 
 * Replaced the scalar type for string tensors from `std::string` to `tensorflow::tstring` which is now ABI stable.


### PR DESCRIPTION
Since 2.2 is the first full version without Python 2 support, I feel like it could be a good idea to note it, even though 2.1 was announced to lose Python 2 support. Since this coincides with the removal of `-py3` docker images I think it's a fitting place for both.