### PR TITLE
Adding progress bar also while evaluating the model

### DIFF
--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -97,12 +97,14 @@ def configure_callbacks(callbacks,
   if not callbacks:
     callbacks = []
 
-  # Add additional callbacks during training.
+  # Add additional callbacks during training and testing.
   if mode == ModeKeys.TRAIN:
     model.history = History()
     callbacks = [BaseLogger()] + (callbacks or []) + [model.history]
     if verbose:
       callbacks.append(ProgbarLogger(count_mode))
+  elif mode == ModeKeys.TEST and verbose:
+  	callbacks.append(ProgbarLogger(count_mode))
   callback_list = CallbackList(callbacks)
 
   # Set callback model


### PR DESCRIPTION
fixes tensorflow/addons issue [#1620](https://github.com/tensorflow/addons/issues/1620).  

@gabrieldemarmiesse, rather than changing methods like `on_test_batch_begin()`, I have changed the `configure_callback()` method which is used to add `ProgBar` in train, now with this change, it will add in test too. Also, there is not requirement of model history logs while test progress bar. So, I have not added that one.  

@gabrieldemarmiesse and @mihaimaruseac - Please review. 