### PR TITLE
[Intel MKL] Enable remapper unit tests for CPU builds.

### DIFF
--- a/tensorflow/core/grappler/optimizers/BUILD
+++ b/tensorflow/core/grappler/optimizers/BUILD
@@ -869,7 +869,7 @@ tf_kernel_library(
     ],
 )
 
-tf_cuda_cc_test(
+tf_cc_test(
     name = "remapper_test",
     srcs = ["remapper_test.cc"],
     deps = [

--- a/tensorflow/core/grappler/optimizers/remapper_test.cc
+++ b/tensorflow/core/grappler/optimizers/remapper_test.cc
@@ -851,7 +851,7 @@ TEST_F(RemapperTest, FuseConv2DWithSqueezeAndBias) {
   ASSERT_EQ(tensors.size(), 1);
   test::ExpectTensorNear<float>(tensors[0], tensors_expected[0], 1e-6);
 }
-#endif  // INEL_MKL
+#endif  // INTEL_MKL
 
 }  // namespace grappler
 }  // namespace tensorflow

--- a/tensorflow/core/grappler/optimizers/remapper_test.cc
+++ b/tensorflow/core/grappler/optimizers/remapper_test.cc
@@ -607,6 +607,7 @@ TEST_F(RemapperTest, FuseMatMulWithBiasAndActivation) {
   }
 }
 
+#ifndef INTEL_MKL
 TEST_F(RemapperTest, FuseConv2DWithBatchNorm) {
   using ops::Placeholder;
 
@@ -850,6 +851,7 @@ TEST_F(RemapperTest, FuseConv2DWithSqueezeAndBias) {
   ASSERT_EQ(tensors.size(), 1);
   test::ExpectTensorNear<float>(tensors[0], tensors_expected[0], 1e-6);
 }
+#endif  // INEL_MKL
 
 }  // namespace grappler
 }  // namespace tensorflow


### PR DESCRIPTION
This PR enables remapper tests for CPU only builds also. In addition PR disables remapper tests for fusions that MKL DNN doesn't support.