### PR TITLE
Added a warning note in tf.where documentation for 'NaN' gradient issue with workaround

### DIFF
--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -4352,6 +4352,18 @@ def where_v2(condition, x=None, y=None, name=None):
   <tf.Tensor: shape=(4,), dtype=int32, numpy=array([100, 100, 100, 100],
   dtype=int32)>
 
+  Note that if any of the input to a tf.where contains 'NaN's, then the gradient will always
+  be 'NaN', regardless whether the input is actually used or not. The workaround will be to
+  use an inner tf.where to ensure the function has no asymptote.
+
+  Instead of this
+
+  >>> tf.where(x_ok, ops_that_can_nan(x), safe_f(x))
+
+  Use this
+
+  >>> tf.where(x_ok, ops_that_can_nan(tf.where(x_ok, x, safe_x)), safe_f(x))
+
   Args:
     condition: A `tf.Tensor` of type `bool`
     x: If provided, a Tensor which is of the same type as `y`, and has a shape
@@ -4370,8 +4382,7 @@ def where_v2(condition, x=None, y=None, name=None):
     ValueError: When exactly one of `x` or `y` is non-None, or the shapes
       are not all broadcastable.
 
-  Note that if the input to a tf.where contains 'NaN's, then the gradient will always
-  be 'NaN', regardless whether the input is actually used or not.
+
   """
   if x is None and y is None:
     with ops.name_scope(name, "Where", [condition]) as name:

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -4360,7 +4360,7 @@ def where_v2(condition, x=None, y=None, name=None):
 
   Instead of this
 
-  >>>  y = -1
+  >>> y = -1
   >>> tf.where(y > 0, tf.sqrt(y), y)
 
   Use this

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -4352,9 +4352,10 @@ def where_v2(condition, x=None, y=None, name=None):
   <tf.Tensor: shape=(4,), dtype=int32, numpy=array([100, 100, 100, 100],
   dtype=int32)>
 
-  Note that if any of the input to a tf.where contains 'NaN's, then the gradient will always
-  be 'NaN', regardless whether the input is actually used or not. The workaround will be to
-  use an inner tf.where to ensure the function has no asymptote.
+  Note that if the gradient of either branch of the tf.where generates a NaN then the gradient
+  of the entire tf.where will be NaN. The workaround will be to use an inner tf.where to ensure
+  the function has no asymptote and to avoid computing a value whose gradient is NaN by replacing
+  dangerous inputs with safe inputs.
 
   Instead of this
 

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -552,7 +552,7 @@ def broadcast_static_shape(shape_x, shape_y):
 def shape_v2(input, out_type=dtypes.int32, name=None):
   # pylint: disable=redefined-builtin
   """Returns the shape of a tensor.
-  
+
   See also `tf.size`, `tf.rank`.
 
   This operation returns a 1-D integer tensor representing the shape of `input`.
@@ -672,7 +672,7 @@ def shape_n(input, out_type=dtypes.int32, name=None):
 def size_v2(input, out_type=dtypes.int32, name=None):
   # pylint: disable=redefined-builtin
   """Returns the size of a tensor.
-  
+
   See also `tf.shape`.
 
   Returns a 0-D `Tensor` representing the number of elements in `input`
@@ -4369,6 +4369,9 @@ def where_v2(condition, x=None, y=None, name=None):
   Raises:
     ValueError: When exactly one of `x` or `y` is non-None, or the shapes
       are not all broadcastable.
+
+  Note that if the input to a tf.where contains 'NaN's, then the gradient will always
+  be 'NaN', regardless whether the input is actually used or not.
   """
   if x is None and y is None:
     with ops.name_scope(name, "Where", [condition]) as name:
@@ -5638,7 +5641,7 @@ def _with_nonzero_rank(data):
 @tf_export("repeat")
 def repeat(input, repeats, axis=None, name=None):  # pylint: disable=redefined-builtin
   """Repeat elements of `input`.
-  
+
   See also `tf.concat`, `tf.stack`, `tf.tile`.
 
   Args:

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -4359,11 +4359,12 @@ def where_v2(condition, x=None, y=None, name=None):
 
   Instead of this
 
-  >>> tf.where(x_ok, ops_that_can_nan(x), safe_f(x))
+  >>>  y = -1
+  >>> tf.where(y > 0, tf.sqrt(y), y)
 
   Use this
 
-  >>> tf.where(x_ok, ops_that_can_nan(tf.where(x_ok, x, safe_x)), safe_f(x))
+  >>> tf.where(y > 0, tf.sqrt(tf.where(y > 0, y, 1)), y)
 
   Args:
     condition: A `tf.Tensor` of type `bool`
@@ -4382,8 +4383,6 @@ def where_v2(condition, x=None, y=None, name=None):
   Raises:
     ValueError: When exactly one of `x` or `y` is non-None, or the shapes
       are not all broadcastable.
-
-
   """
   if x is None and y is None:
     with ops.name_scope(name, "Where", [condition]) as name:

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -4352,10 +4352,11 @@ def where_v2(condition, x=None, y=None, name=None):
   <tf.Tensor: shape=(4,), dtype=int32, numpy=array([100, 100, 100, 100],
   dtype=int32)>
 
-  Note that if the gradient of either branch of the tf.where generates a NaN then the gradient
-  of the entire tf.where will be NaN. The workaround will be to use an inner tf.where to ensure
-  the function has no asymptote and to avoid computing a value whose gradient is NaN by replacing
-  dangerous inputs with safe inputs.
+  Note that if the gradient of either branch of the tf.where generates
+  a NaN then the gradient of the entire tf.where will be NaN. The
+  workaround will be to use an inner tf.where to ensure the function has
+  no asymptote and to avoid computing a value whose gradient is NaN by
+  replacing dangerous inputs with safe inputs.
 
   Instead of this
 


### PR DESCRIPTION
This is to solve the issue `nan` gradient when `tf.where` is used #38349