### PR TITLE
perfer python3 to compile

### DIFF
--- a/configure
+++ b/configure
@@ -4,7 +4,7 @@ set -e
 set -o pipefail
 
 if [ -z "$PYTHON_BIN_PATH" ]; then
-  PYTHON_BIN_PATH=$(which python || which python3 || true)
+  PYTHON_BIN_PATH=$(which python3 || which python || true)
 fi
 
 # Set all env variables


### PR DESCRIPTION
`which python` may direct to python2. make `which python3` ahead of `which python` may be better.