### PR TITLE
[lite] fix nnapi:nnapi_delegate_verbose_validation

### DIFF
--- a/tensorflow/lite/delegates/nnapi/BUILD
+++ b/tensorflow/lite/delegates/nnapi/BUILD
@@ -73,6 +73,7 @@ cc_library(
         "//tensorflow/lite/nnapi:nnapi_lib",
         "//tensorflow/lite/nnapi:nnapi_util",
         "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:optional",
     ],
 )


### PR DESCRIPTION
without `@com_google_absl//absl/strings`, when building `//tensorflow/lite/delegates/nnapi:nnapi_delegate_verbose_validation`, I met

```
ERROR: /hack/freedom/tensorflow/tf-clean/tensorflow/lite/delegates/nnapi/BUILD:45:1: undeclared inclusion(s) in rule '//tensorflow/lite/delegates/nnapi:nnapi_delegate_verbose_validation':
this rule is missing dependency declarations for the following files included by 'tensorflow/lite/delegates/nnapi/quant_lstm_sup.cc':
  'external/com_google_absl/absl/strings/string_view.h'
  'external/com_google_absl/absl/base/internal/throw_delegate.h'
Target //tensorflow/lite/delegates/nnapi:nnapi_delegate_verbose_validation failed to build
```