### PR TITLE
Fix reduce op ut failure: root rank=-1

### DIFF
--- a/tensorflow/core/nccl/nccl_manager.cc
+++ b/tensorflow/core/nccl/nccl_manager.cc
@@ -452,6 +452,7 @@ void NcclManager::AddReduceSend(std::unique_ptr<Participant> participant,
 void NcclManager::AddReduceRecv(std::unique_ptr<Participant> participant,
                                 const Context& context,
                                 ncclRedOp_t reduction_op) {
+  participant->root = true;
   AddParticipant(std::move(participant), context, kReduce, reduction_op);
 }
 


### PR DESCRIPTION
I was running unit tests of nccl_ops.py with `bazel test tensorflow/python:nccl_ops_test` and got following errors. The failed test case was `SingleReduceTest.testSum`. 

![image](https://user-images.githubusercontent.com/4970790/79101916-383b4500-7d9c-11ea-864f-c5a9608ad58e.png)

It seems that `NcclManager::AddReduceRecv` at [nccl_manager.cc:L452](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/nccl/nccl_manager.cc#L452) does not set root rank as `NcclManager::AddBroadcastSend`.  I fixed it and `SingleReduceTest.testSum` passed.