### PR TITLE
Update backend.py -> unique_object_name method's docstring section

### DIFF
--- a/tensorflow/python/keras/backend.py
+++ b/tensorflow/python/keras/backend.py
@@ -933,8 +933,8 @@ def unique_object_name(name,
   Example:
 
 
-  _unique_layer_name('dense')  # dense_1
-  _unique_layer_name('dense')  # dense_2
+  unique_object_name('dense')  # dense_1
+  unique_object_name('dense')  # dense_2
 
   """
   if name_uid_map is None:


### PR DESCRIPTION
"unique_object_name" methods' docstring example section typo is fixed, example section was using "_unique_layer_name" method name instead of "unique_object_name" method name