### PR TITLE
[tflite] fix missing dep for preprocess_coco_minival

### DIFF
--- a/tensorflow/lite/tools/evaluation/proto/BUILD
+++ b/tensorflow/lite/tools/evaluation/proto/BUILD
@@ -95,3 +95,11 @@ java_proto_library(
     name = "preprocessing_steps_java_proto",
     deps = ["preprocessing_steps_proto"],
 )
+
+tf_proto_library_py(
+    name = "preprocessing_steps",  # bzl adds _py
+    srcs = [
+        "preprocessing_steps.proto",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/tensorflow/lite/tools/evaluation/proto/BUILD
+++ b/tensorflow/lite/tools/evaluation/proto/BUILD
@@ -95,11 +95,3 @@ java_proto_library(
     name = "preprocessing_steps_java_proto",
     deps = ["preprocessing_steps_proto"],
 )
-
-tf_proto_library_py(
-    name = "preprocessing_steps",  # bzl adds _py
-    srcs = [
-        "preprocessing_steps.proto",
-    ],
-    visibility = ["//visibility:public"],
-)

--- a/tensorflow/lite/tools/evaluation/tasks/coco_object_detection/BUILD
+++ b/tensorflow/lite/tools/evaluation/tasks/coco_object_detection/BUILD
@@ -14,7 +14,10 @@ py_binary(
     python_version = "PY3",
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
-    deps = ["//tensorflow/lite/tools/evaluation/proto:evaluation_stages_py"],
+    deps = [
+        "//tensorflow/lite/tools/evaluation/proto:evaluation_stages_py",
+        "//tensorflow/lite/tools/evaluation/proto:preprocessing_steps_py",
+    ],
 )
 
 cc_library(


### PR DESCRIPTION
add missing dep for
```
//tensorflow/lite/tools/evaluation/tasks/coco_object_detection:preprocess_coco_minival
```

`preprocess_coco_minival` uses `evaluation_stages`. `evaluation_stages` uses
`preprocessing_steps` which is not generated.

Add the build rule and corresponding dependency so that
```
bazel run //tensorflow/lite/tools/evaluation/tasks/coco_object_detection:preprocess_coco_minival -- \
  --images_folder=/path/to/val2014 \
  --instances_file=/path/to/instances_val2014.json \
  --whitelist_file=/path/to/minival_whitelist.txt \
  --output_folder=/path/to/output/folder
```
will work again.