### PR TITLE
Added code to pass appropriate logs to on_test|train_end() methods

### DIFF
--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -715,8 +715,9 @@ class Callback(object):
     Subclasses should override for any actions to run.
 
     Arguments:
-        logs: Dict. Currently no data is passed to this argument for this method
-          but that may change in the future.
+        logs: Dict. Currently the output of the last call to `on_epoch_end()`
+          is passed to this argument for this method but that may change in
+          the future.
     """
 
   @doc_controls.for_subclass_implementers
@@ -737,7 +738,8 @@ class Callback(object):
     Subclasses should override for any actions to run.
 
     Arguments:
-        logs: Dict. Currently no data is passed to this argument for this method
+        logs: Dict. Currently the output of the last call to
+          `on_test_batch_end()` is passed to this argument for this method
           but that may change in the future.
     """
 

--- a/tensorflow/python/keras/engine/training.py
+++ b/tensorflow/python/keras/engine/training.py
@@ -949,7 +949,7 @@ class Model(network.Network, version_utils.ModelVersionSelector):
         if self.stop_training:
           break
 
-      callbacks.on_train_end(training_logs)
+      callbacks.on_train_end(logs=training_logs)
       return self.history
 
   def test_step(self, data):

--- a/tensorflow/python/keras/engine/training.py
+++ b/tensorflow/python/keras/engine/training.py
@@ -1180,7 +1180,7 @@ class Model(network.Network, version_utils.ModelVersionSelector):
               end_step = step + data_handler.step_increment
               callbacks.on_test_batch_end(end_step, logs)
       logs = tf_utils.to_numpy_or_python_type(logs)
-      callbacks.on_test_end(logs)
+      callbacks.on_test_end(logs=logs)
       
       if return_dict:
         return logs

--- a/tensorflow/python/keras/engine/training.py
+++ b/tensorflow/python/keras/engine/training.py
@@ -900,6 +900,7 @@ class Model(network.Network, version_utils.ModelVersionSelector):
       train_function = self.make_train_function()
       self._train_counter.assign(0)
       callbacks.on_train_begin()
+      training_logs = None
       # Handle fault-tolerance for multi-worker.
       # TODO(omalleyt): Fix the ordering issues that mean this has to
       # happen after `callbacks.on_train_begin`.
@@ -944,10 +945,11 @@ class Model(network.Network, version_utils.ModelVersionSelector):
           epoch_logs.update(val_logs)
 
         callbacks.on_epoch_end(epoch, epoch_logs)
+        training_logs = epoch_logs
         if self.stop_training:
           break
 
-      callbacks.on_train_end()
+      callbacks.on_train_end(training_logs)
       return self.history
 
   def test_step(self, data):
@@ -1177,9 +1179,9 @@ class Model(network.Network, version_utils.ModelVersionSelector):
               logs = tmp_logs  # No error, now safe to assign to logs.
               end_step = step + data_handler.step_increment
               callbacks.on_test_batch_end(end_step, logs)
-      callbacks.on_test_end()
-
       logs = tf_utils.to_numpy_or_python_type(logs)
+      callbacks.on_test_end(logs)
+      
       if return_dict:
         return logs
       else:


### PR DESCRIPTION
fixes #38498 .  
@mihaimaruseac , please review.