### PR TITLE
List deterministic op functionality bug fixes in version 2.2 release notes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -121,7 +121,9 @@
   * Add check for memory alignment to MemoryAllocation::MemoryAllocation() on 32-bit ARM. This ensures a deterministic early exit instead of a hard to debug bus error later.
   * `saved_model_cli aot_compile_cpu` allows you to compile saved models to XLA header+object files and include them in your C++ programs.
   * Enable `Igamma`, `Igammac` for XLA.
-  * XLA reduction emitter is deterministic when the environment variable `TF_DETERMINISTIC_OPS` is set.
+* Deterministic Op Functionality:
+  * XLA reduction emitter is deterministic when the environment variable `TF_DETERMINISTIC_OPS` is set to "true" or "1". This extends deterministic `tf.nn.bias_add` back-prop functionality (and therefore also deterministic back-prop of bias-addition in Keras layers) to include when XLA JIT complilation is enabled.
+  * Fix problem, when running on a CUDA GPU and when either environment variable `TF_DETERMINSTIC_OPS` or environment variable `TF_CUDNN_DETERMINISTIC` is set to "true" or "1", in which some layer configurations led to an exception with the message "No algorithm worked!"
 * Tracing and Debugging:
   * Add source, destination name to `_send` traceme to allow easier debugging.
   * Add traceme event to `fastpathexecute`.


### PR DESCRIPTION
The changes in this current PR refer to the following commits and PR:

* Commit [e31955](https://github.com/tensorflow/tensorflow/commit/e31955d9fb34ae7273354dc2347ba99eea8c5280): [XLA/GPU] Convert reduction into tree reduction using padding + bitcast-reshape
* Commit [8b7a3](https://github.com/tensorflow/tensorflow/commit/8b7a3db0b6e09415b5640be4986fb4d7c6e5209a
): [XLA] Respect TF_DETERMINISTIC_OPS environment variable for reductions
* PR [34951](https://github.com/tensorflow/tensorflow/pull/34951): Add multi-algorithm deterministic cuDNN convolutions

Thanks to @goldiegadde for getting `RELEASE.md` committed in the `r2.2` branch so that I could submit this current PR.