### PR TITLE
fix readability (newlines) on github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/00-bug-issue.md
+++ b/.github/ISSUE_TEMPLATE/00-bug-issue.md
@@ -11,25 +11,24 @@ we only address code/doc bugs, performance issues, feature requests and
 build/installation issues on GitHub. tag:bug_template</em>
 
 **System information** 
-- Have I written custom code (as opposed to using a stock
-example script provided in TensorFlow): 
-- OS Platform and Distribution (e.g.,
-Linux Ubuntu 16.04): 
-- Mobile device (e.g. iPhone 8, Pixel 2, Samsung Galaxy) if
-the issue happens on mobile device: 
-- TensorFlow installed from (source or
-binary): - TensorFlow version (use command below): 
-- Python version: - Bazel
-version (if compiling from source):
-- GCC/Compiler version (if compiling from
-source): 
-- CUDA/cuDNN version: - GPU model and memory:
+- Have I written custom code (as opposed to using a stock example script
+  provided in TensorFlow): 
+- OS Platform and Distribution (e.g., Linux Ubuntu 16.04): 
+- Mobile device (e.g. iPhone 8, Pixel 2, Samsung Galaxy) if the issue happens
+  on mobile device: 
+- TensorFlow installed from (source or binary):
+- TensorFlow version (use command below): 
+- Python version:
+- Bazel version (if compiling from source):
+- GCC/Compiler version (if compiling from source): 
+- CUDA/cuDNN version:
+- GPU model and memory:
 
 You can collect some of this information using our environment capture
 [script](https://github.com/tensorflow/tensorflow/tree/master/tools/tf_env_collect.sh)
-You can also obtain the TensorFlow version with: 1. TF 1.0: `python -c "import
-tensorflow as tf; print(tf.GIT_VERSION, tf.VERSION)"` 2. TF 2.0: `python -c
-"import tensorflow as tf; print(tf.version.GIT_VERSION, tf.version.VERSION)"`
+You can also obtain the TensorFlow version with:
+1. TF 1.0: `python -c "import tensorflow as tf; print(tf.GIT_VERSION, tf.VERSION)"`
+2. TF 2.0: `python -c "import tensorflow as tf; print(tf.version.GIT_VERSION, tf.version.VERSION)"`
 
 **Describe the current behavior**
 

--- a/.github/ISSUE_TEMPLATE/80-performance-issue.md
+++ b/.github/ISSUE_TEMPLATE/80-performance-issue.md
@@ -12,25 +12,24 @@ we only address code/doc bugs, performance issues, feature requests and
 build/installation issues on GitHub. tag:performance_template</em>
 
 **System information** 
-- Have I written custom code (as opposed to using a stock
-example script provided in TensorFlow): 
-- OS Platform and Distribution (e.g.,
-Linux Ubuntu 16.04): 
-- Mobile device (e.g. iPhone 8, Pixel 2, Samsung Galaxy) if
-the issue happens on mobile device: 
-- TensorFlow installed from (source or
-binary): - TensorFlow version (use command below): 
-- Python version: - Bazel
-version (if compiling from source):
-- GCC/Compiler version (if compiling from
-source): 
-- CUDA/cuDNN version: - GPU model and memory:
+- Have I written custom code (as opposed to using a stock example script
+  provided in TensorFlow): 
+- OS Platform and Distribution (e.g., Linux Ubuntu 16.04): 
+- Mobile device (e.g. iPhone 8, Pixel 2, Samsung Galaxy) if the issue happens
+  on mobile device: 
+- TensorFlow installed from (source or binary):
+- TensorFlow version (use command below): 
+- Python version:
+- Bazel version (if compiling from source):
+- GCC/Compiler version (if compiling from source): 
+- CUDA/cuDNN version:
+- GPU model and memory:
 
 You can collect some of this information using our environment capture
 [script](https://github.com/tensorflow/tensorflow/tree/master/tools/tf_env_collect.sh)
-You can also obtain the TensorFlow version with: 1. TF 1.0: `python -c "import
-tensorflow as tf; print(tf.GIT_VERSION, tf.VERSION)"` 2. TF 2.0: `python -c
-"import tensorflow as tf; print(tf.version.GIT_VERSION, tf.version.VERSION)"`
+You can also obtain the TensorFlow version with:
+1. TF 1.0: `python -c "import tensorflow as tf; print(tf.GIT_VERSION, tf.VERSION)"`
+2. TF 2.0: `python -c "import tensorflow as tf; print(tf.version.GIT_VERSION, tf.version.VERSION)"`
 
 **Describe the current behavior**
 


### PR DESCRIPTION
The bug-issue and performance-issue templates currently have some issues that make them difficult to work with when submitting new github issues. Mainly the usage (or lack thereof) of newlines. There are several places in the templates where newlines should obviously be present and are not. And several other places where newlines should not be present but are (wrapping *way* before 80 chars).

While I don't know that wrapping at 80 chars makes much sense, as these files are primarily rendered in a browser which will both auto-wrap for you, as well as has a wider viewport, I mostly kept them wrapped at 80. The exception is for the 2 version commands, which I felt made more sense keeping each on a whole line (which they already were before, just on the same line). But I can wrap these too if desired.

I would also like to point out that while these are markdown files, the primary audience (the author) is consuming them in their text form. Thus things like that `<em>` at the top don't work, and the formatting needs to be clean in text form.

![image](https://user-images.githubusercontent.com/1826947/79249301-0e8d2700-7e4b-11ea-87da-7d543b3c87a6.png)
