### PR TITLE
[INTEL MKL]  Enabling tf_cuda_cc_test to execute in CPU only builds also.

### DIFF
--- a/tensorflow/c/BUILD
+++ b/tensorflow/c/BUILD
@@ -517,7 +517,6 @@ tf_cuda_cc_test(
         ":test_op1.so",
         "//tensorflow/cc/saved_model:saved_model_half_plus_two",
     ],
-    kernels = [":test_op_kernel"],
     linkopts = select({
         "//tensorflow:macos": ["-headerpad_max_install_names"],
         "//conditions:default": [],
@@ -531,6 +530,7 @@ tf_cuda_cc_test(
     deps = [
         ":c_api",
         ":c_test_util",
+        ":test_op_kernel",
         "//tensorflow/cc:cc_ops",
         "//tensorflow/cc:grad_ops",
         "//tensorflow/cc/saved_model:signature_constants",

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -1128,7 +1128,7 @@ def tf_gpu_cc_test(
         kernels = kernels,
         linkopts = linkopts,
         linkstatic = linkstatic,
-        tags = tags + ["manual"],
+        tags = tags,
         deps = deps,
     )
     tf_cc_test(


### PR DESCRIPTION
Currently, tests using tf_cuda_cc_test do not run in CPU only builds (ex. when using MKL), unless the test is invoked manually with full test name (i.e //tensorflow/core/grappler/optimizers:remapper_test) 

Changed tf_gpu_cc_test to always execute the test in CPU only builds also.
This change exposed a bug that caused two tests -  CAPI.LibraryLoadFunctions and TestApiDef.TestCreateApiDef to fail in //tensorflow/c:c_api_test. Fix for the test is also included in this PR.