### PR TITLE
[XLA] Use EmitWriteArrayElement that add LLVM annotation. 

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -826,17 +826,10 @@ Status IrEmitterUnnested::HandleRngGetAndUpdateState(
       Cast<HloRngGetAndUpdateStateInstruction>(rng_state)->delta(), module_,
       &b_);
 
-  llvm::Value* output_address =
-      GetIrArray(*rng_state, *rng_state)
-          .EmitArrayElementAddress(
-              llvm_ir::IrArray::Index(
-                  /*linear=*/b_.getInt64(0), rng_state->shape(), &b_),
-              &b_, "rng_state_address");
-  output_address = BitCast(
-      output_address, llvm::PointerType::get(
-                          old_state->getType(),
-                          output_address->getType()->getPointerAddressSpace()));
-  Store(old_state, output_address);
+  GetIrArray(*rng_state, *rng_state).EmitWriteArrayElement(
+      llvm_ir::IrArray::Index(/*linear=*/b_.getInt64(0), rng_state->shape(), &b_),
+      old_state,
+      &b_, true);
 
   return Status::OK();
 }
@@ -3354,9 +3347,7 @@ void IrEmitterUnnested::EmitElementForInputFusibleSlices(
           GetIrArray(*unnested_hlo, *unnested_hlo, shape_index);
       IrArray::Index slice_dst_index(dst_multidim, slice->shape(),
                                      index.GetType());
-      llvm::Value* dst_addr = src_ir_array.EmitArrayElementAddress(
-          slice_dst_index, &b_, "slice.dest");
-      b_.CreateStore(input_ir_values[i], dst_addr);
+      src_ir_array.EmitWriteArrayElement(slice_dst_index, input_ir_values[i], &b_);
     };
 
     ksl.If(StrCat("slice", i), guarding_cond, emit_slice_elem_func);

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -826,10 +826,17 @@ Status IrEmitterUnnested::HandleRngGetAndUpdateState(
       Cast<HloRngGetAndUpdateStateInstruction>(rng_state)->delta(), module_,
       &b_);
 
-  GetIrArray(*rng_state, *rng_state).EmitWriteArrayElement(
-      llvm_ir::IrArray::Index(/*linear=*/b_.getInt64(0), rng_state->shape(), &b_),
-      old_state,
-      &b_, true);
+  llvm::Value* output_address =
+      GetIrArray(*rng_state, *rng_state)
+          .EmitArrayElementAddress(
+              llvm_ir::IrArray::Index(
+                  /*linear=*/b_.getInt64(0), rng_state->shape(), &b_),
+              &b_, "rng_state_address");
+  output_address = BitCast(
+      output_address, llvm::PointerType::get(
+                          old_state->getType(),
+                          output_address->getType()->getPointerAddressSpace()));
+  Store(old_state, output_address);
 
   return Status::OK();
 }
@@ -3347,7 +3354,8 @@ void IrEmitterUnnested::EmitElementForInputFusibleSlices(
           GetIrArray(*unnested_hlo, *unnested_hlo, shape_index);
       IrArray::Index slice_dst_index(dst_multidim, slice->shape(),
                                      index.GetType());
-      src_ir_array.EmitWriteArrayElement(slice_dst_index, input_ir_values[i], &b_);
+      src_ir_array.EmitWriteArrayElement(slice_dst_index, input_ir_values[i],
+                                         &b_);
     };
 
     ksl.If(StrCat("slice", i), guarding_cond, emit_slice_elem_func);


### PR DESCRIPTION
This could help LLVM to vectorize.

See one commit in https://github.com/tensorflow/tensorflow/pull/38136

@cheshire 
I looked at all "Store(" and "CreateStore(" under xla/service/gpu to fix all missed annotation cases.