### PR TITLE
Fix only pass RunOptions to keras will trigger core

### DIFF
--- a/tensorflow/python/client/tf_session_helper.cc
+++ b/tensorflow/python/client/tf_session_helper.cc
@@ -235,18 +235,13 @@ void RunCallableHelper(tensorflow::Session* session, int64_t handle,
     }
   }
 
-  // Allocate a RunMetadata protobuf object to receive the metadata,
-  // if the caller is expecting any.
-  std::unique_ptr<RunMetadata> run_metadata_proto;
-  if (run_metadata != nullptr) {
-    run_metadata_proto.reset(new RunMetadata);
-  }
+  RunMetadata run_metadata_proto;
 
   // Run the callable.
   std::vector<Tensor> output_tensors;
   Py_BEGIN_ALLOW_THREADS;
   s = session->RunCallable(handle, input_tensors, &output_tensors,
-                           run_metadata_proto.get());
+                           &run_metadata_proto);
   Py_END_ALLOW_THREADS;
 
   if (!s.ok()) {
@@ -256,7 +251,7 @@ void RunCallableHelper(tensorflow::Session* session, int64_t handle,
 
   // If requested, serialize the RunMetadata to pass it back to the caller.
   if (run_metadata != nullptr) {
-    s = MessageToBuffer(*run_metadata_proto, run_metadata);
+    s = MessageToBuffer(run_metadata_proto, run_metadata);
     if (!s.ok()) {
       Set_TF_Status_from_Status(out_status, s);
       return;


### PR DESCRIPTION
This is a PR from JIZHI, the AI platform in Tencent.

Right now, keras will trigger segmentation fault when only pass `RunOptions` but no `RunMetadata`. This bug can be replicated in tf-nightly in this [gist](https://colab.research.google.com/gist/zhuzilin/a6f71f2240a60769e1a6e054e8733145/untitled3.ipynb)

If you cannot open the gist, the code to replicate the bug is
```python
import tensorflow as tf
mnist = tf.keras.datasets.mnist

tf.compat.v1.disable_eager_execution()

(x_train, y_train),(x_test, y_test) = mnist.load_data()
x_train, x_test = x_train / 255.0, x_test / 255.0

model = tf.keras.models.Sequential([
  tf.keras.layers.Flatten(input_shape=(28, 28)),
  tf.keras.layers.Dense(128, activation='relu'),
  tf.keras.layers.Dropout(0.2),
  tf.keras.layers.Dense(10, activation='softmax')
])

run_options = tf.compat.v1.RunOptions(trace_level=tf.compat.v1.RunOptions.FULL_TRACE)

model.compile(optimizer='adam',
              loss='sparse_categorical_crossentropy',
              metrics=['accuracy'],
              options=run_options)

model.fit(x_train,
          y_train,
          epochs=2)
```

The reason for this problem is that keras use the `TF_SessionRunCallable` api instead of `TF_Run`. While the former was using an `unique_ptr` to represent the `run_metadata` and will only new one when `RunMetadata` was passed. However, the `RunOption` will need an `RunMetadata` for tracing. This PR modified the implementation of `TF_SessionRunCallable` to that of `TF_Run` and fix this bug.

Thank you for your time on reviewing this PR.