### PR TITLE
Reset best weights in EarlyStopping.on_train_begin

### DIFF
--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -1524,6 +1524,7 @@ class EarlyStopping(Callback):
       self.best = self.baseline
     else:
       self.best = np.Inf if self.monitor_op == np.less else -np.Inf
+    self.best_weights = None
 
   def on_epoch_end(self, epoch, logs=None):
     current = self.get_monitor_value(logs)


### PR DESCRIPTION
EarlyStopping callback instances can be reused in different training loops, but the `on_train_begin` hook forgets to reset the `self.best_weights` state.