### PR TITLE
Fix invalid shape issue in random.uniform

### DIFF
--- a/tensorflow/python/kernel_tests/random/random_ops_test.py
+++ b/tensorflow/python/kernel_tests/random/random_ops_test.py
@@ -416,9 +416,8 @@ class RandomUniformTest(RandomOpTestCommon):
 
   def testUniformWithInvalidMaxMindShape(self):
     # Test case for GitHub issue 34363.
-    with self.assertRaisesRegexp(
-        errors.InvalidArgumentError,
-        "must be no greater than rank of output shape"):
+    with self.assertRaises(
+        (errors.InvalidArgumentError, errors.UnknownError, ValueError)):
       array = array_ops.zeros(shape=(1,))
       random_ops.random_uniform(shape=(), minval=array)
 

--- a/tensorflow/python/kernel_tests/random/random_ops_test.py
+++ b/tensorflow/python/kernel_tests/random/random_ops_test.py
@@ -23,6 +23,7 @@ from six.moves import xrange  # pylint: disable=redefined-builtin
 
 from tensorflow.python.eager import context
 from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import errors
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import random_seed
 from tensorflow.python.framework import test_util
@@ -412,6 +413,14 @@ class RandomUniformTest(RandomOpTestCommon):
             200,
             use_gpu=use_gpu,
             graph_seed=965)
+
+  def testUniformWithInvalidMaxMindShape(self):
+    # Test case for GitHub issue 34363.
+    with self.assertRaisesRegexp(
+        errors.InvalidArgumentError,
+        "is not compatible with expected shape"):
+      array = array_ops.zeros(shape=(1,))
+      random_ops.random_uniform(shape=(), minval=array)
 
 
 class RandomShapeTest(test.TestCase):

--- a/tensorflow/python/kernel_tests/random/random_ops_test.py
+++ b/tensorflow/python/kernel_tests/random/random_ops_test.py
@@ -418,7 +418,7 @@ class RandomUniformTest(RandomOpTestCommon):
     # Test case for GitHub issue 34363.
     with self.assertRaisesRegexp(
         errors.InvalidArgumentError,
-        "is not compatible with expected shape"):
+        "must be no greater than rank of output shape"):
       array = array_ops.zeros(shape=(1,))
       random_ops.random_uniform(shape=(), minval=array)
 

--- a/tensorflow/python/ops/random_ops.py
+++ b/tensorflow/python/ops/random_ops.py
@@ -300,6 +300,8 @@ def random_uniform(shape,
         if not maxval_is_one:
           result = math_ops.multiply(result, maxval)
       else:
+        maxval = array_ops.ensure_shape(maxval, ())
+        minval = array_ops.ensure_shape(minval, ())
         result = math_ops.add(result * (maxval - minval), minval, name=name)
     # TODO(b/132092188): C++ shape inference inside functional ops does not
     # cross FuncGraph boundaries since that information is only available in

--- a/tensorflow/python/ops/random_ops.py
+++ b/tensorflow/python/ops/random_ops.py
@@ -300,8 +300,12 @@ def random_uniform(shape,
         if not maxval_is_one:
           result = math_ops.multiply(result, maxval)
       else:
-        maxval = array_ops.ensure_shape(maxval, ())
-        minval = array_ops.ensure_shape(minval, ())
+        # Use explicit "broadcast_to" so that any shape incompatibility
+        # are returned with InvalidArgument error.
+        # This prevent "slient broadcast" that may cause the shape of
+        # result "overflow" when minval or maxval is larger than expected shape
+        maxval = array_ops.broadcast_to(maxval, shape)
+        minval = array_ops.broadcast_to(minval, shape)
         result = math_ops.add(result * (maxval - minval), minval, name=name)
     # TODO(b/132092188): C++ shape inference inside functional ops does not
     # cross FuncGraph boundaries since that information is only available in


### PR DESCRIPTION
Note: This PR is a resubmission from #34399

This PR tries to address the issue raised in #34363 where
invalid shape passed to minval/maxval (expected to be 0-D)
does not raise an error.

The issue was that in most of the scenarios the shape was
checked inside the C++ kernel ops.

However, in one condition math_ops.add was used which will
implicitly do broadcast when necessarily.
This results in maxval/minval's shape getting carried.

This PR adds the shape check before math_ops.add, to make
sure the shape is guaranteed.

This PR fixes #34363.

Signed-off-by: Yong Tang yong.tang.github@outlook.com