### PR TITLE
Grpc server uses provided host name/ip instead of localhost if possible

### DIFF
--- a/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.cc
+++ b/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.cc
@@ -132,7 +132,9 @@ GrpcServer::~GrpcServer() {
 void GrpcServer::MaybeMutateBuilder(::grpc::ServerBuilder* builder) {}
 
 // Look up the port that has been requested for this task in `server_def`.
-Status GrpcServer::GetHostAndPort(const ServerDef& server_def, string* host_name, int* port) const {
+Status GrpcServer::GetHostAndPort(const ServerDef& server_def,
+                                  string* host_name,
+                                  int* port) const {
   *port = -1;
   *host_name = "localhost";
   for (const auto& job : server_def.cluster().job()) {
@@ -180,9 +182,7 @@ Status GrpcServer::Init(const GrpcServerOptions& opts) {
   // otherwise if 'task_index=-1' the program will abort.
 
   int requested_port;
-  string host_name;
-  TF_RETURN_IF_ERROR(GetHostAndPort(server_def_, &host_name, &requested_port));
-  host_name_ = host_name;
+  TF_RETURN_IF_ERROR(GetHostAndPort(server_def_, &host_name_, &requested_port));
 
   SessionOptions sess_opts;
   ConfigProto config = server_def_.default_session_config();

--- a/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.h
+++ b/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.h
@@ -104,7 +104,7 @@ class GrpcServer : public ServerInterface {
   Status UpdateServerDef(const ServerDef& server_def);
 
  protected:
-  virtual Status GetPort(const ServerDef& server_def, int* port) const;
+  virtual Status GetHostAndPort(const ServerDef& server_def, string* host_name, int* port) const;
   Status Init(const GrpcServerOptions& opts = GrpcServerOptions());
 
   // A subclass can override this method to support secure credentials.
@@ -135,6 +135,9 @@ class GrpcServer : public ServerInterface {
 
   // The port to which this server is bound.
   int bound_port_ = 0;
+
+  // The host name of this server
+  string host_name_;
 
   // Guards server configuration, server, and state.
   mutex mu_;

--- a/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.h
+++ b/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.h
@@ -104,7 +104,9 @@ class GrpcServer : public ServerInterface {
   Status UpdateServerDef(const ServerDef& server_def);
 
  protected:
-  virtual Status GetHostAndPort(const ServerDef& server_def, string* host_name, int* port) const;
+  virtual Status GetHostAndPort(const ServerDef& server_def,
+                                string* host_name,
+                                int* port) const;
   Status Init(const GrpcServerOptions& opts = GrpcServerOptions());
 
   // A subclass can override this method to support secure credentials.


### PR DESCRIPTION
Now grpc server ignores use provided host name/ip and always return "localhost" as server target. This makes cluster spec propagation propagates "localhost" to remote. See #38519 