### PR TITLE
TFLite: use the int8 type for no_float quantization

### DIFF
--- a/tensorflow/lite/python/lite.py
+++ b/tensorflow/lite/python/lite.py
@@ -704,8 +704,8 @@ class TFLiteConverterV2(TFLiteConverterBase):
         **converter_kwargs)
 
     if quant_mode.post_training_int8_no_float():
-      result = self._calibrate_quantize_model(result, constants.FLOAT,
-                                              constants.FLOAT, False)
+      result = self._calibrate_quantize_model(result, constants.INT8,
+                                              constants.INT8, False)
     elif quant_mode.post_training_int8_allow_float():
       result = self._calibrate_quantize_model(result, constants.FLOAT,
                                               constants.FLOAT, True)


### PR DESCRIPTION
use the int8 type for inference input and output when quantizing with int8_no_float mode