### PR TITLE
Make LossScaleOpimtizer wrapper compatible with decoupled weight decay

### DIFF
--- a/tensorflow/python/keras/mixed_precision/experimental/loss_scale_optimizer.py
+++ b/tensorflow/python/keras/mixed_precision/experimental/loss_scale_optimizer.py
@@ -495,6 +495,14 @@ class LossScaleOptimizer(_DelegatingTrackableMixin, optimizer_v2.OptimizerV2):
   # individual subclasses like Adam. However, although "learning_rate" and "lr"
   # properties are not part of the base OptimizerV2 class, they are part of most
   # subclasses, so we expose them here for convenience.
+  
+  @property
+  def weight_decay(self):
+    return self._optimizer.weight_decay
+
+  @weight_decay.setter
+  def weight_decay(self, weight_decay):
+    self._optimizer.weight_decay = weight_decay
 
   @property
   def learning_rate(self):


### PR DESCRIPTION
This allows for us to use decoupled weight decay optimizers with mixed precision.

https://www.tensorflow.org/addons/api_docs/python/tfa/optimizers/weight_decay_optimizers/DecoupledWeightDecayExtension