### PR TITLE
Fix TypeError while importing tensorflow caused by site.USER_SITE is set to None

### DIFF
--- a/tensorflow/api_template.__init__.py
+++ b/tensorflow/api_template.__init__.py
@@ -116,7 +116,7 @@ from tensorflow.python.lib.io import file_io as _fi
 
 # Get sitepackages directories for the python installation.
 _site_packages_dirs = []
-_site_packages_dirs += [_site.USER_SITE]
+_site_packages_dirs += [] if _site.USER_SITE is None else [_site.USER_SITE]
 _site_packages_dirs += [_p for _p in _sys.path if 'site-packages' in _p]
 if 'getsitepackages' in dir(_site):
   _site_packages_dirs += _site.getsitepackages()

--- a/tensorflow/api_template_v1.__init__.py
+++ b/tensorflow/api_template_v1.__init__.py
@@ -126,7 +126,7 @@ from tensorflow.python.lib.io import file_io as _fi
 
 # Get sitepackages directories for the python installation.
 _site_packages_dirs = []
-_site_packages_dirs += [_site.USER_SITE]
+_site_packages_dirs += [] if _site.USER_SITE is None else [_site.USER_SITE]
 _site_packages_dirs += [_p for _p in _sys.path if 'site-packages' in _p]
 if 'getsitepackages' in dir(_site):
   _site_packages_dirs += _site.getsitepackages()


### PR DESCRIPTION

This PR tries to address the issue raised in #34643 where the following may cause
import error:
```
$ python3 -S
>>> import sys
>>> sys.path=['', '/usr/lib/python36.zip', '/usr/lib/python3.6', '/usr/lib/python3.6/lib-dynload', '/usr/local/lib/python3.6/dist-packages', '/usr/lib/python3/dist-packages']
>>> import tensorflow
2020-04-18 02:53:44.825113: W tensorflow/stream_executor/platform/default/dso_loader.cc:55] Could not load dynamic library 'libcuda.so.1'; dlerror: libcuda.so.1: cannot open shared object file: No such file or directory
2020-04-18 02:53:44.825163: E tensorflow/stream_executor/cuda/cuda_driver.cc:313] failed call to cuInit: UNKNOWN ERROR (303)
2020-04-18 02:53:44.825191: I tensorflow/stream_executor/cuda/cuda_diagnostics.cc:156] kernel driver does not appear to be running on this host (7d29dc61d5ee): /proc/driver/nvidia/version does not exist
2020-04-18 02:53:44.825441: I tensorflow/core/platform/cpu_feature_guard.cc:143] Your CPU supports instructions that this TensorFlow binary was not compiled to use: AVX2 FMA
2020-04-18 02:53:44.849778: I tensorflow/core/platform/profile_utils/cpu_utils.cc:102] CPU Frequency: 2199995000 Hz
2020-04-18 02:53:44.850142: I tensorflow/compiler/xla/service/service.cc:168] XLA service 0x7fc308000b20 initialized for platform Host (this does not guarantee that XLA will be used). Devices:
2020-04-18 02:53:44.850178: I tensorflow/compiler/xla/service/service.cc:176]   StreamExecutor device (0): Host, Default Version
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.6/dist-packages/tensorflow/__init__.py", line 417, in <module>
    if _running_from_pip_package():
  File "/usr/local/lib/python3.6/dist-packages/tensorflow/__init__.py", line 415, in _running_from_pip_package
    _current_file_location.startswith(dir_) for dir_ in _site_packages_dirs)
  File "/usr/local/lib/python3.6/dist-packages/tensorflow/__init__.py", line 415, in <genexpr>
    _current_file_location.startswith(dir_) for dir_ in _site_packages_dirs)
TypeError: startswith first arg must be str or a tuple of str, not NoneType
```

The reason was that `site.USER_SITE` could be None.

This PR removes None with:
```
_site_packages_dirs += [] if _site.USER_SITE is None else [_site.USER_SITE]
```

This PR fixes #34643

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>