### PR TITLE
Fix a bug related to build TF Lite on RPI Zero.

### DIFF
--- a/tensorflow/lite/g3doc/guide/build_rpi.md
+++ b/tensorflow/lite/g3doc/guide/build_rpi.md
@@ -29,7 +29,7 @@ To cross compile TensorFlow Lite follow the steps:
 2. Clone TensorFlow repository:
 
     ```bash
-    git clone --depth 1 https://github.com/tensorflow/tensorflow.git tensorflow_src
+    git clone https://github.com/tensorflow/tensorflow.git tensorflow_src
 
     ```
 
@@ -74,7 +74,14 @@ To natively compile TensorFlow Lite follow the steps:
     sudo apt-get install build-essential
     ```
 
-2. Run following script at the root of the TensorFlow repository to download all the
+2. Clone TensorFlow repository:
+
+    ```bash
+    git clone https://github.com/tensorflow/tensorflow.git tensorflow_src
+
+    ```
+
+3. Run following script at the root of the TensorFlow repository to download all the
 build dependencies:
 
     ```bash
@@ -83,11 +90,11 @@ build dependencies:
 
     **Note:** You only need to do this once.
 
-3. You should then be able to compile TensorFlow Lite with:
+4. You should then be able to compile TensorFlow Lite with:
 
     ```bash
     ./tensorflow/lite/tools/make/build_rpi_lib.sh
     ```
 
     **Note:** This should compile a static library in:
-    `tensorflow/lite/tools/make/gen/lib/rpi_armv7/libtensorflow-lite.a`.
+    `tensorflow/lite/tools/make/gen/lib/rpi_armv6/libtensorflow-lite.a`.

--- a/tensorflow/lite/g3doc/guide/build_rpi.md
+++ b/tensorflow/lite/g3doc/guide/build_rpi.md
@@ -23,7 +23,7 @@ To cross compile TensorFlow Lite follow the steps:
 1. Clone official Raspberry Pi cross-compilation toolchain:
 
     ```bash
-    git clone --depth 1 https://github.com/raspberrypi/tools.git rpi_tools
+    git clone https://github.com/raspberrypi/tools.git rpi_tools
     ```
 
 2. Clone TensorFlow repository:
@@ -39,7 +39,7 @@ To cross compile TensorFlow Lite follow the steps:
 build dependencies:
 
     ```bash
-    cd tensor_src && ./tensorflow/lite/tools/make/download_dependencies.sh
+    cd tensorflow_src && ./tensorflow/lite/tools/make/download_dependencies.sh
     ```
 
     **Note:** You only need to do this once.
@@ -47,7 +47,7 @@ build dependencies:
 4. To build ARMv7 binary for Raspberry Pi 2, 3 and 4 execute:
 
     ```bash
-    PATH=$PATH:../rpi_tools/arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf/bin/ ./tensorflow/lite/tools/make/build_rpi_lib.sh
+    PATH=../rpi_tools/arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf/bin:$PATH ./tensorflow/lite/tools/make/build_rpi_lib.sh
     ```
 
     **Note:** This should compile a static library in:
@@ -56,7 +56,7 @@ build dependencies:
 5. To build ARMv6 binary for Raspberry Pi Zero execute:
 
     ```bash
-    PATH=$PATH:../rpi_tools/arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf/bin/ ./tensorflow/lite/tools/make/build_rpi_lib.sh TARGET_ARCH=armv6
+    PATH=../rpi_tools/arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf/bin:$PATH ./tensorflow/lite/tools/make/build_rpi_lib.sh TARGET_ARCH=armv6
     ```
 
     **Note:** This should compile a static library in:
@@ -64,7 +64,7 @@ build dependencies:
 
 ## Compile natively on Raspberry Pi
 
-Instruction has been tested on Raspberry Pi 3b, Raspbian GNU/Linux 9.1 (stretch), gcc version 6.3.0 20170516 (Raspbian 6.3.0-18+rpi1):
+Instruction has been tested on Raspberry Pi Zero, Raspbian GNU/Linux 10 (buster), gcc version 8.3.0 (Raspbian 8.3.0-6+rpi1):
 
 To natively compile TensorFlow Lite follow the steps:
 
@@ -78,7 +78,7 @@ To natively compile TensorFlow Lite follow the steps:
 build dependencies:
 
     ```bash
-    cd tensor_src && ./tensorflow/lite/tools/make/download_dependencies.sh
+    cd tensorflow_src && ./tensorflow/lite/tools/make/download_dependencies.sh
     ```
 
     **Note:** You only need to do this once.

--- a/tensorflow/lite/g3doc/guide/build_rpi.md
+++ b/tensorflow/lite/g3doc/guide/build_rpi.md
@@ -5,87 +5,89 @@ Raspberry Pi. If you just want to start using TensorFlow Lite to execute your
 models, the fastest option is to install the TensorFlow Lite runtime package as
 shown in the [Python quickstart](python.md).
 
-Note: This page shows how to compile only the C++ static library for
+**Note:** This page shows how to compile only the C++ static library for
 TensorFlow Lite. Alternative install options include: [install just the Python
 interpreter API](python.md) (for inferencing only); [install the full
 TensorFlow package from pip](https://www.tensorflow.org/install/pip);
 or [build the full TensorFlow package](
 https://www.tensorflow.org/install/source_rpi).
 
-
 ## Cross-compile for Raspberry Pi
 
-This has been tested on Ubuntu 16.04.3 64bit and TensorFlow devel docker image
+Instruction has been tested on Ubuntu 16.04.3 64-bit PC (AMD64) and TensorFlow devel
+docker image
 [tensorflow/tensorflow:nightly-devel](https://hub.docker.com/r/tensorflow/tensorflow/tags/).
 
-To cross compile TensorFlow Lite, first install the toolchain and libs:
+To cross compile TensorFlow Lite follow the steps:
 
-```bash
-sudo apt-get update
-sudo apt-get install crossbuild-essential-armhf
-# The following is only needed for Pi Zero build.
-sudo apt-get install crossbuild-essential-armel
-```
+1. Clone official Raspberry Pi cross-compilation toolchain:
 
-If you are using Docker, you may not use `sudo`.
+    ```bash
+    git clone --depth 1 https://github.com/raspberrypi/tools.git rpi_tools
+    ```
 
-Now git-clone the TensorFlow repository
-(`https://github.com/tensorflow/tensorflow`)—if you're using the TensorFlow
-Docker image, the repo is already provided in `/tensorflow_src/`—and then run
-this script at the root of the TensorFlow repository to download all the
+2. Clone TensorFlow repository:
+
+    ```bash
+    git clone --depth 1 https://github.com/tensorflow/tensorflow.git tensorflow_src
+
+    ```
+
+    **Note:** If you're using the TensorFlow Docker image, the repo is already provided in `/tensorflow_src/`.
+
+3. Run following script at the root of the TensorFlow repository to download all the
 build dependencies:
 
-```bash
-./tensorflow/lite/tools/make/download_dependencies.sh
-```
+    ```bash
+    cd tensor_src && ./tensorflow/lite/tools/make/download_dependencies.sh
+    ```
 
-Note that you only need to do this once.
+    **Note:** You only need to do this once.
 
-You should then be able to compile:
+4. To build ARMv7 binary for Raspberry Pi 2, 3 and 4 execute:
 
-To build ARMv7 binary for Raspberry Pi 2, 3 and 4:
+    ```bash
+    PATH=$PATH:../rpi_tools/arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf/bin/ ./tensorflow/lite/tools/make/build_rpi_lib.sh
+    ```
 
-```bash
-./tensorflow/lite/tools/make/build_rpi_lib.sh
-```
+    **Note:** This should compile a static library in:
+    `tensorflow/lite/tools/make/gen/rpi_armv7l/lib/libtensorflow-lite.a`.
 
-This should compile a static library in:
-`tensorflow/lite/tools/make/gen/rpi_armv7l/lib/libtensorflow-lite.a`.
+5. To build ARMv6 binary for Raspberry Pi Zero execute:
 
-To build ARMv6 binary for Raspberry Pi Zero:
+    ```bash
+    PATH=$PATH:../rpi_tools/arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf/bin/ ./tensorflow/lite/tools/make/build_rpi_lib.sh TARGET_ARCH=armv6
+    ```
 
-```bash
-./tensorflow/lite/tools/make/build_rpi_lib.sh TARGET_ARCH=armv6
-```
-
-This should compile a static library in:
-`tensorflow/lite/tools/make/gen/rpi_armv6/lib/libtensorflow-lite.a`.
+    **Note:** This should compile a static library in:
+    `tensorflow/lite/tools/make/gen/rpi_armv6/lib/libtensorflow-lite.a`.
 
 ## Compile natively on Raspberry Pi
 
-This has been tested on Raspberry Pi 3b, Raspbian GNU/Linux 9.1 (stretch), gcc version 6.3.0 20170516 (Raspbian 6.3.0-18+rpi1).
+Instruction has been tested on Raspberry Pi 3b, Raspbian GNU/Linux 9.1 (stretch), gcc version 6.3.0 20170516 (Raspbian 6.3.0-18+rpi1):
 
-Log in to your Raspberry Pi and install the toolchain:
+To natively compile TensorFlow Lite follow the steps:
 
-```bash
-sudo apt-get install build-essential
-```
+1. Log in to your Raspberry Pi and install the toolchain:
 
-Now git-clone the TensorFlow repository
-(`https://github.com/tensorflow/tensorflow`) and run this at the root of
-the repository:
+    ```bash
+    sudo apt-get install build-essential
+    ```
 
-```bash
-./tensorflow/lite/tools/make/download_dependencies.sh
-```
+2. Run following script at the root of the TensorFlow repository to download all the
+build dependencies:
 
-Note that you only need to do this once.
+    ```bash
+    cd tensor_src && ./tensorflow/lite/tools/make/download_dependencies.sh
+    ```
 
-You should then be able to compile:
+    **Note:** You only need to do this once.
 
-```bash
-./tensorflow/lite/tools/make/build_rpi_lib.sh
-```
+3. You should then be able to compile TensorFlow Lite with:
 
-This should compile a static library in:
-`tensorflow/lite/tools/make/gen/lib/rpi_armv7/libtensorflow-lite.a`.
+    ```bash
+    ./tensorflow/lite/tools/make/build_rpi_lib.sh
+    ```
+
+    **Note:** This should compile a static library in:
+    `tensorflow/lite/tools/make/gen/lib/rpi_armv7/libtensorflow-lite.a`.

--- a/tensorflow/lite/tools/make/targets/rpi_makefile.inc
+++ b/tensorflow/lite/tools/make/targets/rpi_makefile.inc
@@ -32,7 +32,7 @@ ifeq ($(TARGET),rpi)
   # TODO(petewarden) In the future, we'll want to use OpenBLAS as a faster
   # alternative to Eigen on non-NEON ARM hardware like armv6.
   ifeq ($(TARGET_ARCH), armv6)
-    TARGET_TOOLCHAIN_PREFIX := arm-linux-gnueabi-
+    TARGET_TOOLCHAIN_PREFIX := arm-linux-gnueabihf-
     CXXFLAGS += \
       -march=armv6 \
       -mfpu=vfp \


### PR DESCRIPTION
Why:

* Enable to build TF Lite on RPI Zero.

This change addresses the need by:

* Changing compiler from arm-linux-gnueabi- to arm-linux-gnueabihf-.