### PR TITLE
Support options(environment variable) to enable grpc reuse port.

### DIFF
--- a/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.cc
+++ b/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.cc
@@ -70,7 +70,7 @@ class NoReusePortOption : public ::grpc::ServerBuilderOption {
                          plugins) override {}
 };
 
-// Define an option subclass in order to disable SO_REUSEPORT for the
+// Define an option subclass in order to enable SO_REUSEPORT for the
 // server socket.
 class ReusePortOption : public ::grpc::ServerBuilderOption {
  public:

--- a/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.cc
+++ b/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.cc
@@ -238,7 +238,7 @@ Status GrpcServer::Init(const GrpcServerOptions& opts) {
   auto server_build_option = reuse_port ?
       std::unique_ptr<::grpc::ServerBuilderOption>(new ReusePortOption) :
       std::unique_ptr<::grpc::ServerBuilderOption>(new NoReusePortOption);
-  builder.SetOption(server_build_option);
+  builder.SetOption(std::move(server_build_option));
 
   // Allow subclasses to specify more args to pass to the gRPC server.
   MaybeMutateBuilder(&builder);

--- a/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.cc
+++ b/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.cc
@@ -70,6 +70,18 @@ class NoReusePortOption : public ::grpc::ServerBuilderOption {
                          plugins) override {}
 };
 
+// Define an option subclass in order to disable SO_REUSEPORT for the
+// server socket.
+class ReusePortOption : public ::grpc::ServerBuilderOption {
+ public:
+  void UpdateArguments(::grpc::ChannelArguments* args) override {
+    args->SetInt(GRPC_ARG_ALLOW_REUSEPORT, 1);
+  }
+
+  void UpdatePlugins(std::vector<std::unique_ptr<::grpc::ServerBuilderPlugin>>*
+                         plugins) override {}
+};
+
 // static utility function
 RendezvousMgrInterface* NewRpcRendezvousMgr(const WorkerEnv* env) {
   return new RpcRendezvousMgr(env);
@@ -220,8 +232,14 @@ Status GrpcServer::Init(const GrpcServerOptions& opts) {
                            GetServerCredentials(server_def_), &bound_port_);
   builder.SetMaxMessageSize(std::numeric_limits<int32>::max());
 
-  builder.SetOption(
-      std::unique_ptr<::grpc::ServerBuilderOption>(new NoReusePortOption));
+  bool reuse_port = false;
+  ReadBoolFromEnvVar("TF_GRPC_REUSE_PORT", false, &reuse_port)
+      .IgnoreError();
+  auto server_build_option = reuse_port ?
+      std::unique_ptr<::grpc::ServerBuilderOption>(new ReusePortOption) :
+      std::unique_ptr<::grpc::ServerBuilderOption>(new NoReusePortOption);
+  builder.SetOption(server_build_option);
+
   // Allow subclasses to specify more args to pass to the gRPC server.
   MaybeMutateBuilder(&builder);
   master_impl_ = CreateMaster(&master_env_);

--- a/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.cc
+++ b/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.cc
@@ -233,8 +233,11 @@ Status GrpcServer::Init(const GrpcServerOptions& opts) {
   builder.SetMaxMessageSize(std::numeric_limits<int32>::max());
 
   bool reuse_port = false;
-  ReadBoolFromEnvVar("TF_GRPC_REUSE_PORT", false, &reuse_port)
-      .IgnoreError();
+  const Status status = ReadBoolFromEnvVar("TF_GRPC_REUSE_PORT", false,
+      &reuse_port);
+  if (!status.ok()) {
+    LOG(ERROR) << status.error_message();
+  }
   auto server_build_option = reuse_port ?
       std::unique_ptr<::grpc::ServerBuilderOption>(new ReusePortOption) :
       std::unique_ptr<::grpc::ServerBuilderOption>(new NoReusePortOption);


### PR DESCRIPTION
ReusePort scenario: parent process occupies the port, then share
the port through service such as ZooKeeper, and then child
process (TensorFlow process) reuse the port.