### PR TITLE
[TFLite] Introduce ruy_profiler to Makefile

### DIFF
--- a/tensorflow/lite/tools/make/Makefile
+++ b/tensorflow/lite/tools/make/Makefile
@@ -184,6 +184,14 @@ ifeq ($(BUILD_WITH_RUY),true)
   CXXFLAGS += -DTFLITE_WITH_RUY
 endif
 
+BUILD_WITH_RUY_PROFILER ?= false
+ifeq ($(BUILD_WITH_RUY_PROFILER),true)
+  CORE_CC_ALL_SRCS += tensorflow/lite/tools/make/downloads/ruy/ruy/profiler/instrumentation.cc
+  CORE_CC_ALL_SRCS += tensorflow/lite/tools/make/downloads/ruy/ruy/profiler/profiler.cc
+  CORE_CC_ALL_SRCS += tensorflow/lite/tools/make/downloads/ruy/ruy/profiler/treeview.cc
+  CXXFLAGS += -DRUY_PROFILER
+endif
+
 # Not to include XNNPACK.
 CXXFLAGS += -DTFLITE_WITHOUT_XNNPACK
 


### PR DESCRIPTION
TFLite can use [ruy_profiler](https://github.com/google/ruy/tree/master/ruy/profiler) to measure where code is spending time.
However, it is only supported on bazel build, not by Makefile.

This PR introduces `BUILD_WITH_RUY_PROFILER` option to enable ruy_profiler.

**Usage**
```bash
BUILD_WITH_RUY_PROFILER=true ./tensorflow/lite/tools/make/build_rpi_lib.sh
```

**Execution result**
```bash
$ ./rpi_armv7l/bin/benchmark_model --graph=../models/mobilenet_v2_1.0_224_quant/mobilenet_v2_1.0_224_quant.tflite
STARTING!
...

Profile (1 threads):

Thread 0 (5025 samples)

* 76.78% Conv/8bit
  * 71.22% cpu_backend_gemm::Gemm
    * 70.55% cpu_backend_gemm::Gemm: general GEMM
    * 0.68% cpu_backend_gemm::Gemm: CustomGemv
  * 5.55% Im2col
    * 3.70% ExtractPatchIntoBufferColumn
    * 1.85% [other]
* 21.85% DepthwiseConv
  * 21.83% DepthwiseConv/8bit
    * 21.83% DepthwiseConv/8bit/General
      * 15.08% void tflite::optimized_ops::depthwise_conv::QuantizedDepthwiseConvAccumRow(int, int, int, int, const uint8*, int16, int, int, int, const uint8*, int16, int, int, int, int32*) [with bool kAllowStrided = true; int kFixedInputDepth = 0; int kFixedDepthMultiplier = 1; uint8 = unsigned char; int16 = short int; int32 = int]
      * 4.60% downquantize+store
      * 2.15% [other]
  * 0.02% [other]
* 1.35% Add/8bit
  * 1.35% AddElementwise/8bit
* 0.02% AveragePool/8bit
```