### PR TITLE
Add builtin len() support of tf.data.Dataset for autograph

### DIFF
--- a/tensorflow/python/autograph/operators/py_builtins.py
+++ b/tensorflow/python/autograph/operators/py_builtins.py
@@ -285,7 +285,8 @@ def _tf_dataset_len(s):
   l = cardinality.cardinality(s)
 
   def raise_infinite_cardinality_error():
-    with ops.control_dependencies([control_flow_ops.Assert(False, ['len requires non-infinite dataset'])]):
+    msg = "len requires non-infinite dataset"
+    with ops.control_dependencies([control_flow_ops.Assert(False, [msg])]):
       return constant_op.constant(-1, dtype=dtypes.int32)
 
   def reduce_unknown_cardinality_dataset(d):

--- a/tensorflow/python/autograph/operators/py_builtins.py
+++ b/tensorflow/python/autograph/operators/py_builtins.py
@@ -286,6 +286,9 @@ def _tf_dataset_len(s):
   msg = gen_string_ops.string_join(
       ["len requires dataset with definitive cardinality, got ",
        gen_string_ops.as_string(l)])
+  # TODO (yongtang): UNKNOWN is treated as an error.
+  # In case there are more UNKNOWN cases for dataset, we could
+  # use dataset.reduce() to find out the length (in an expensive way).
   with ops.control_dependencies([control_flow_ops.Assert(
       math_ops.logical_and(
           math_ops.not_equal(l, cardinality.INFINITE),

--- a/tensorflow/python/autograph/operators/py_builtins.py
+++ b/tensorflow/python/autograph/operators/py_builtins.py
@@ -283,15 +283,16 @@ def _tf_tensor_len(s):
 
 def _tf_dataset_len(s):
   l = cardinality.cardinality(s)
+  msg = gen_string_ops.string_join(
+      ["len requires dataset with definitive cardinality, got ",
+       gen_string_ops.as_string(l)])
+  with ops.control_dependencies([control_flow_ops.Assert(
+      math_ops.logical_and(
+          math_ops.not_equal(l, cardinality.INFINITE),
+          math_ops.not_equal(l, cardinality.UNKNOWN)), [msg])]):
+    l = array_ops.identity(l)
 
-  def raise_cardinality_error():
-    msg = gen_string_ops.string_join(
-        ["len requires dataset with definitive cardinality, got ",
-         gen_string_ops.as_string(l)])
-    with ops.control_dependencies([control_flow_ops.Assert(False, [msg])]):
-      return constant_op.constant(-1, dtype=dtypes.int32)
-
-  return control_flow_ops.cond(l == cardinality.INFINITE or l == cardinality.UNKNOWN, raise_cardinality_error, lambda: l)
+  return l
 
 
 def _py_len(s):

--- a/tensorflow/python/autograph/operators/py_builtins.py
+++ b/tensorflow/python/autograph/operators/py_builtins.py
@@ -234,6 +234,8 @@ def len_(s):
     return _tf_tensor_list_len(s)
   elif tensor_util.is_tensor(s):
     return _tf_tensor_len(s)
+  if isinstance(s, dataset_ops.DatasetV2):
+    return _tf_dataset_len(s)
   return _py_len(s)
 
 
@@ -276,6 +278,10 @@ def _tf_tensor_len(s):
 
   return control_flow_ops.cond(rank > 0, lambda: array_ops.shape(s)[0],
                                raise_zero_rank_error)
+
+
+def _tf_dataset_len(s):
+  return s.reduce(constant_op.constant(0, dtype=dtypes.int32), lambda x, _: x + 1)
 
 
 def _py_len(s):

--- a/tensorflow/python/autograph/operators/py_builtins.py
+++ b/tensorflow/python/autograph/operators/py_builtins.py
@@ -288,7 +288,12 @@ def _tf_dataset_len(s):
     with ops.control_dependencies([control_flow_ops.Assert(False, ['len requires non-infinite dataset'])]):
       return constant_op.constant(-1, dtype=dtypes.int32)
 
+  def reduce_unknown_cardinality_dataset(d):
+    return d.reduce(constant_op.constant(0, dtype=dtypes.int32), lambda x, _: x + 1)
+
   l = control_flow_ops.cond(l != cardinality.INFINITE, lambda: l, raise_infinite_cardinality_error)
+
+  l = control_flow_ops.cond(l != cardinality.UNKNOWN, lambda: l, lambda: reduce_unknown_cardinality_dataset(s))
 
   return l
 

--- a/tensorflow/python/autograph/operators/py_builtins_test.py
+++ b/tensorflow/python/autograph/operators/py_builtins_test.py
@@ -123,6 +123,13 @@ class PyBuiltinsTest(test.TestCase):
       tl = py_builtins.len_(data_structures.tf_tensor_list_new([3, 4, 5]))
       self.assertEqual(self.evaluate(tl), 3)
 
+  def test_len_dataset(self):
+    dataset = dataset_ops.DatasetV2.from_tensor_slices([3, 2, 1])
+    self.assertEqual(py_builtins.len_(dataset), 3)
+    with self.cached_session() as sess:
+      t = py_builtins.len_(dataset)
+      self.assertAllEqual(self.evaluate(t), 3)
+
   def test_len_scalar(self):
     with self.assertRaises(ValueError):
       py_builtins.len_(constant_op.constant(1))

--- a/tensorflow/python/autograph/operators/py_builtins_test.py
+++ b/tensorflow/python/autograph/operators/py_builtins_test.py
@@ -140,10 +140,11 @@ class PyBuiltinsTest(test.TestCase):
 
   def test_len_dataset_unknown(self):
     dataset = dataset_ops.DatasetV2.range(5).filter(lambda _: True).batch(2)
-    self.assertEqual(py_builtins.len_(dataset), 3)
+    with self.assertRaises(errors_impl.InvalidArgumentError):
+      _ = py_builtins.len_(dataset)
     with self.cached_session() as sess:
-      t = py_builtins.len_(dataset)
-      self.assertAllEqual(self.evaluate(t), 3)
+      with self.assertRaises(errors_impl.InvalidArgumentError):
+        _ = py_builtins.len_(dataset)
 
   def test_len_scalar(self):
     with self.assertRaises(ValueError):

--- a/tensorflow/python/autograph/operators/py_builtins_test.py
+++ b/tensorflow/python/autograph/operators/py_builtins_test.py
@@ -125,19 +125,19 @@ class PyBuiltinsTest(test.TestCase):
 
   def test_len_dataset(self):
     dataset = dataset_ops.DatasetV2.from_tensor_slices([3, 2, 1])
-    self.assertEqual(py_builtins.len_(dataset), 3)
+    self.assertEqual(self.evaluate(py_builtins.len_(dataset)), 3)
 
     # graph mode
     @def_function.function(autograph=False)
     def test_fn():
       dataset = dataset_ops.DatasetV2.from_tensor_slices([3, 2, 1])
       return py_builtins.len_(dataset)
-    self.assertEqual(test_fn(), 3)
+    self.assertEqual(self.evaluate(test_fn()), 3)
 
   def test_len_dataset_infinite(self):
     dataset = dataset_ops.DatasetV2.range(5).repeat().batch(2)
     with self.assertRaises(errors_impl.InvalidArgumentError):
-      _ = py_builtins.len_(dataset)
+      _ = self.evaluate(py_builtins.len_(dataset))
 
     # graph mode
     @def_function.function
@@ -145,12 +145,12 @@ class PyBuiltinsTest(test.TestCase):
       dataset = dataset_ops.DatasetV2.range(5).repeat().batch(2)
       return py_builtins.len_(dataset)
     with self.assertRaises(errors_impl.InvalidArgumentError):
-      test_fn()
+      self.evaluate(test_fn())
 
   def test_len_dataset_unknown(self):
     dataset = dataset_ops.DatasetV2.range(5).filter(lambda _: True).batch(2)
     with self.assertRaises(errors_impl.InvalidArgumentError):
-      _ = py_builtins.len_(dataset)
+      _ = self.evaluate(py_builtins.len_(dataset))
 
     # graph mode
     @def_function.function(autograph=False)
@@ -158,7 +158,7 @@ class PyBuiltinsTest(test.TestCase):
       dataset = dataset_ops.DatasetV2.range(5).filter(lambda _: True).batch(2)
       return py_builtins.len_(dataset)
     with self.assertRaises(errors_impl.InvalidArgumentError):
-      test_fn()
+      self.evaluate(test_fn())
 
   def test_len_scalar(self):
     with self.assertRaises(ValueError):

--- a/tensorflow/python/autograph/operators/py_builtins_test.py
+++ b/tensorflow/python/autograph/operators/py_builtins_test.py
@@ -130,6 +130,21 @@ class PyBuiltinsTest(test.TestCase):
       t = py_builtins.len_(dataset)
       self.assertAllEqual(self.evaluate(t), 3)
 
+  def test_len_dataset_infinite(self):
+    dataset = dataset_ops.DatasetV2.range(5).repeat().batch(2)
+    with self.assertRaises(errors_impl.InvalidArgumentError):
+      _ = py_builtins.len_(dataset)
+    with self.cached_session() as sess:
+      with self.assertRaises(errors_impl.InvalidArgumentError):
+        _ = py_builtins.len_(dataset)
+
+  def test_len_dataset_unknown(self):
+    dataset = dataset_ops.DatasetV2.range(5).filter(lambda _: True).batch(2)
+    self.assertEqual(py_builtins.len_(dataset), 3)
+    with self.cached_session() as sess:
+      t = py_builtins.len_(dataset)
+      self.assertAllEqual(self.evaluate(t), 3)
+
   def test_len_scalar(self):
     with self.assertRaises(ValueError):
       py_builtins.len_(constant_op.constant(1))


### PR DESCRIPTION

While working on autograph was looking for calculating the average
of a tf.data.Dataset, noticed that `len()` in autograph
only support tensor, tensorarray and tensorlist, but not tf.data.Dataset.

I think it makes sense to add tf.data.Dataset as well as `len()` is too widely
used in many cases.

This PR adds `len()` support of tf.data.Dataset for autograph.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>