### PR TITLE
[Intel MKL] Fixes an issue with tensorflow bfloat16 scope that create…

### DIFF
--- a/tensorflow/python/tpu/bfloat16.py
+++ b/tensorflow/python/tpu/bfloat16.py
@@ -76,5 +76,5 @@ def bfloat16_scope():
   This enables variables to be read as bfloat16 type when using get_variable.
   """
   with variable_scope.variable_scope(
-      '', custom_getter=_get_custom_getter()) as varscope:
+      'bfloat16', custom_getter=_get_custom_getter()) as varscope:
     yield varscope

--- a/tensorflow/python/tpu/bfloat16_test.py
+++ b/tensorflow/python/tpu/bfloat16_test.py
@@ -31,7 +31,7 @@ class BFloat16ScopeTest(test.TestCase):
   def testScopeName(self):
     """Test if name for the variable scope is propagated correctly."""
     with bfloat16.bfloat16_scope() as bf:
-      self.assertEqual(bf.name, "")
+      self.assertEqual(bf.name, "bfloat16")
 
   @test_util.run_deprecated_v1
   def testRequestedDType(self):


### PR DESCRIPTION
…s node names with '//', which causes unknown node name problem when run inference from a trained checkpoint