### PR TITLE
[TF-TRT] - Adding user control to blacklist OP conversion

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/segment/segment.cc
+++ b/tensorflow/compiler/tf2tensorrt/segment/segment.cc
@@ -436,7 +436,7 @@ Status SegmentGraph(const Graph* tf_graph,
   // Getting the nodes blacklisted for conversion
   string tftrt_node_blacklist_str;
   TF_CHECK_OK(ReadStringFromEnvVar(
-    "TF_TRT_BLACKLIST_OP", "", &tftrt_node_blacklist_str
+    "TF_TRT_BLACKLIST_OPS", "", &tftrt_node_blacklist_str
   ));
 
   auto tftrt_node_blacklist = gtl::FlatSet<string>{};
@@ -472,7 +472,7 @@ Status SegmentGraph(const Graph* tf_graph,
         LOG(WARNING) << "Blacklisted as TF-TRT candidate, "
                 << "(Op type: " << node->tf_node()->type_string() << "), "
                 << "(Op name: " << node->name() << "), "
-                << "(Reason: Blacklisted with the env var TF_TRT_BLACKLIST_OP)";
+                << "(Reason: Blacklisted with the env var TF_TRT_BLACKLIST_OPS)";
         unsupported_ops.emplace(node->tf_node()->type_string());
         num_unsupported_ops++;
         node = nullptr;

--- a/tensorflow/compiler/tf2tensorrt/segment/segment.cc
+++ b/tensorflow/compiler/tf2tensorrt/segment/segment.cc
@@ -404,13 +404,6 @@ void ContractEdge(SimpleEdge* edge, SimpleGraph* graph,
   }
 }
 
-namespace {
-static void UpdateList(gtl::FlatSet<string>* list, const string& values_to_add){
-
-}
-
-} // namespace
-
 Status SegmentGraph(const Graph* tf_graph,
                     const std::function<Status(const Node*)>& candidate_fn,
                     const std::function<bool(const Edge*)>& input_candidate_fn,

--- a/tensorflow/compiler/tf2tensorrt/segment/segment.cc
+++ b/tensorflow/compiler/tf2tensorrt/segment/segment.cc
@@ -429,7 +429,7 @@ Status SegmentGraph(const Graph* tf_graph,
   // Getting the nodes blacklisted for conversion
   string tftrt_node_blacklist_str;
   TF_CHECK_OK(ReadStringFromEnvVar(
-    "TF_TRT_BLACKLIST_OPS", "", &tftrt_node_blacklist_str
+    "TF_TRT_OP_BLACKLIST", "", &tftrt_node_blacklist_str
   ));
 
   auto tftrt_node_blacklist = gtl::FlatSet<string>{};
@@ -465,7 +465,7 @@ Status SegmentGraph(const Graph* tf_graph,
         LOG(WARNING) << "Blacklisted as TF-TRT candidate, "
                 << "(Op type: " << node->tf_node()->type_string() << "), "
                 << "(Op name: " << node->name() << "), "
-                << "(Reason: Blacklisted with the env var TF_TRT_BLACKLIST_OPS)";
+                << "(Reason: Blacklisted with the env var TF_TRT_OP_BLACKLIST)";
         unsupported_ops.emplace(node->tf_node()->type_string());
         num_unsupported_ops++;
         node = nullptr;

--- a/tensorflow/compiler/tf2tensorrt/segment/segment.cc
+++ b/tensorflow/compiler/tf2tensorrt/segment/segment.cc
@@ -27,8 +27,11 @@ limitations under the License.
 #include "tensorflow/core/graph/graph_constructor.h"
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/lib/gtl/flatset.h"
 #include "tensorflow/core/lib/strings/strcat.h"
+#include "tensorflow/core/lib/strings/str_util.h"
 #include "tensorflow/core/platform/types.h"
+#include "tensorflow/core/util/env_var.h"
 
 #if GOOGLE_CUDA
 #if GOOGLE_TENSORRT
@@ -401,6 +404,13 @@ void ContractEdge(SimpleEdge* edge, SimpleGraph* graph,
   }
 }
 
+namespace {
+static void UpdateList(gtl::FlatSet<string>* list, const string& values_to_add){
+
+}
+
+} // namespace
+
 Status SegmentGraph(const Graph* tf_graph,
                     const std::function<Status(const Node*)>& candidate_fn,
                     const std::function<bool(const Edge*)>& input_candidate_fn,
@@ -422,6 +432,20 @@ Status SegmentGraph(const Graph* tf_graph,
   // for TRT.
   std::unordered_set<string> unsupported_ops;
   int num_unsupported_ops = 0;
+
+  // Getting the nodes blacklisted for conversion
+  string tftrt_node_blacklist_str;
+  TF_CHECK_OK(ReadStringFromEnvVar(
+    "TF_TRT_BLACKLIST_OP", "", &tftrt_node_blacklist_str
+  ));
+
+  auto tftrt_node_blacklist = gtl::FlatSet<string>{};
+
+  for (const auto& x : str_util::Split(tftrt_node_blacklist_str, ",")) {
+    tftrt_node_blacklist.insert(x);
+  }
+
+  // Parsing each node of the graph
   std::vector<UnionFind<SimpleNode*>> node_segments;
   for (int i = 0; i < graph->num_node_ids(); ++i) {
     SimpleNode* node = graph->FindNodeId(i);
@@ -440,6 +464,15 @@ Status SegmentGraph(const Graph* tf_graph,
                 << "(Op type: " << node->tf_node()->type_string() << "), "
                 << "(Op name: " << node->name() << "), "
                 << "(Reason: " << status << ")";
+        unsupported_ops.emplace(node->tf_node()->type_string());
+        num_unsupported_ops++;
+        node = nullptr;
+      } else if (tftrt_node_blacklist.count(node->tf_node()->type_string())) {
+        // WARNING verbosity since the user explicitly requests this behavior.
+        LOG(WARNING) << "Blacklisted as TF-TRT candidate, "
+                << "(Op type: " << node->tf_node()->type_string() << "), "
+                << "(Op name: " << node->name() << "), "
+                << "(Reason: Blacklisted with the env var TF_TRT_BLACKLIST_OP)";
         unsupported_ops.emplace(node->tf_node()->type_string());
         num_unsupported_ops++;
         node = nullptr;


### PR DESCRIPTION
@tfeher FYI
@bixia1 for review

As discussed, I introduce in this PR the env var `TF_TRT_OP_BLACKLIST`.

Objective: In addition to allow users to carefully deactivate some OPs to be converted for whatever reasons. It will be much helpful to debug some weird behavior without having to recompile TF.

Basically, you use it as follows: 
```bash
export TF_TRT_OP_BLACKLIST="Conv2D,BiasAdd"  # Comma Separated
python main.py
```

Example warning printed on the console to confirm the behavior:
```bash
2020-04-21 02:25:00.148330: W tensorflow/compiler/tf2tensorrt/segment/segment.cc:472] Blacklisted as TF-TRT candidate, (Op type: Conv2D), (Op name: my_block/my_layer/Conv2D), (Reason: Blacklisted with the env var TF_TRT_OP_BLACKLIST)
```

And it will block TF-TRT converter from converting any Conv2D or BiasAdd OP.

**Question 1:** should we introduce the same kind of behavior for OP fusing (see: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc#L1697-L1726) ?

**Question 2:** Do you all agree with the name: `TF_TRT_OP_BLACKLIST` or do you prefer something else (please propose an alternative if so) ?
