### PR TITLE
add "variables" argument to `argspec.kwonlyaards`

### DIFF
--- a/tensorflow/python/ops/custom_gradient.py
+++ b/tensorflow/python/ops/custom_gradient.py
@@ -344,7 +344,7 @@ def _graph_mode_decorator(f, args, kwargs):
 
   grad_argspec = tf_inspect.getfullargspec(grad_fn)
   variables_in_signature = ("variables" in grad_argspec.args or
-                            grad_argspec.varkw)
+                            grad_argspec.varkw or "variables" in grad_argspec.kwonlyargs)
   if variables and not variables_in_signature:
     raise TypeError("If using @custom_gradient with a function that "
                     "uses variables, then grad_fn must accept a keyword "


### PR DESCRIPTION
**no unit tests written**
**not tested locally**

This is related to these two pull issues:

https://github.com/tensorflow/tensorflow/issues/31945
https://github.com/tensorflow/tensorflow/issues/38622

What this should do is force the input of `grad()` function of class `Loss` to forget an extra argument required when instantiating a `Variable()` with the custom loss function.

Ideally I'd implement the patch and build from source, but I'm encountering build from source issues via bazel: `https://github.com/tensorflow/tensorflow/issues/38736`, likely due to Fedora.

Let me know what need be changed.

It'd be awesome to be able to build from source so that I can test the patch, but bazel is still messing up, if one of the devs knows a quick fix I can implement it.
