### PR TITLE
Add return statement to the micro-test framework.

### DIFF
--- a/tensorflow/lite/micro/testing/micro_test.h
+++ b/tensorflow/lite/micro/testing/micro_test.h
@@ -85,8 +85,10 @@ extern tflite::ErrorReporter* reporter;
       (micro_test::tests_failed + micro_test::tests_passed));  \
   if (micro_test::tests_failed == 0) {                         \
     micro_test::reporter->Report("~~~ALL TESTS PASSED~~~\n");  \
+    return kTfLiteOk;                                          \
   } else {                                                     \
     micro_test::reporter->Report("~~~SOME TESTS FAILED~~~\n"); \
+    return kTfLiteError;                                       \
   }                                                            \
   }
 


### PR DESCRIPTION
Return kTfLiteOk/kTfLiteError depending on if the test succeeded or not.