### PR TITLE
[ROCm] Updating ROCm CI scripts to skip //tensorflow/lite/...

### DIFF
--- a/tensorflow/lite/python/BUILD
+++ b/tensorflow/lite/python/BUILD
@@ -143,7 +143,6 @@ py_test(
     shard_count = 4,
     srcs_version = "PY2AND3",
     tags = [
-        "no_rocm",
         "no_windows",
     ],
     deps = [
@@ -160,7 +159,6 @@ py_test(
     python_version = "PY3",
     srcs_version = "PY2AND3",
     tags = [
-        "no_rocm",
         "no_windows",
     ],
     deps = [

--- a/tensorflow/tools/ci_build/linux/rocm/run_cc_core.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_cc_core.sh
@@ -52,8 +52,7 @@ bazel test \
       -- \
       //tensorflow/... \
       -//tensorflow/compiler/... \
-      -//tensorflow/lite/delegates/gpu/gl/... \
-      -//tensorflow/lite/delegates/gpu/cl/... \
+      -//tensorflow/lite/... \
 && bazel test \
       --config=rocm \
       -k \

--- a/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
@@ -51,4 +51,5 @@ bazel test \
       --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute \
       -- \
       //tensorflow/... \
-      -//tensorflow/compiler/...
+      -//tensorflow/compiler/... \
+      -//tensorflow/lite/...


### PR DESCRIPTION
tensorflow CI scritps already skip tests under `//tensorflow/lite`. 

This PR is to update the ROCM CI scripts to do the same.


/cc @cheshire @chsigg @nvining-work