### PR TITLE
tflite: java wrapper for xnnpack delegate

### DIFF
--- a/tensorflow/lite/BUILD
+++ b/tensorflow/lite/BUILD
@@ -322,6 +322,7 @@ cc_library(
     alwayslink = 1,
 )
 
+
 cc_test(
     name = "string_util_test",
     size = "small",

--- a/tensorflow/lite/delegates/xnnpack/BUILD
+++ b/tensorflow/lite/delegates/xnnpack/BUILD
@@ -24,6 +24,7 @@ cc_library(
         "//tensorflow/lite:util",
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/schema:schema_fbs",
+        "//tensorflow/lite:minimal_logging",
         "@XNNPACK",
     ],
 )

--- a/tensorflow/lite/delegates/xnnpack/java/src/main/java/org/tensorflow/lite/xnnpack/BUILD
+++ b/tensorflow/lite/delegates/xnnpack/java/src/main/java/org/tensorflow/lite/xnnpack/BUILD
@@ -1,0 +1,9 @@
+package(
+    licenses = ["notice"],  # Apache 2.0
+)
+
+filegroup(
+    name = "xnnpack_delegate",
+    srcs = ["XNNPackDelegate.java"],
+    visibility = ["//visibility:public"],
+)

--- a/tensorflow/lite/delegates/xnnpack/java/src/main/java/org/tensorflow/lite/xnnpack/XNNPackDelegate.java
+++ b/tensorflow/lite/delegates/xnnpack/java/src/main/java/org/tensorflow/lite/xnnpack/XNNPackDelegate.java
@@ -1,0 +1,83 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+package org.tensorflow.lite.xnnpack;
+
+import java.io.Closeable;
+import org.tensorflow.lite.Delegate;
+
+/**
+ * {@link Delegate} for XNNPACK inference.
+ *
+ * <p>Note: When calling {@code Interpreter.modifyGraphWithDelegate()}/
+ * {@code Interpreter.Options.addDelegate()} and {@code Interpreter.run()}, the caller must have an
+ * {@code EGLContext} in the <b>current thread</b> and {@code Interpreter.run()} must be called from
+ * the same {@code EGLContext}. If an {@code EGLContext} does not exist, the delegate will
+ * internally create one, but then the developer must ensure that {@code Interpreter.run()} is
+ * always called from the same thread in which {@code Interpreter.modifyGraphWithDelegate()} was
+ * called.
+ */
+public class XNNPackDelegate implements Delegate, Closeable {
+
+  private static final long INVALID_DELEGATE_HANDLE = 0;
+  private static final String TFLITE_XNNPACK_LIB = "tensorflowlite_xnnpack_jni";
+
+  private long delegateHandle;
+
+  /** Delegate options. */
+  public static final class Options {
+    public Options() {}
+
+    int nthreads = 0;
+
+    public void setNumThreads(int threads) {
+        this.nthreads = threads;
+    }
+  }
+
+  public XNNPackDelegate(Options options) {
+    delegateHandle = createDelegate(options.nthreads);
+  }
+
+  public XNNPackDelegate() {
+    this(new Options());
+  }
+
+  @Override
+  public long getNativeHandle() {
+    return delegateHandle;
+  }
+
+  /**
+   * Frees TFLite resources in C runtime.
+   *
+   * <p>User is expected to call this method explicitly.
+   */
+  @Override
+  public void close() {
+    if (delegateHandle != INVALID_DELEGATE_HANDLE) {
+      deleteDelegate(delegateHandle);
+      delegateHandle = INVALID_DELEGATE_HANDLE;
+    }
+  }
+
+  static {
+    System.loadLibrary(TFLITE_XNNPACK_LIB);
+  }
+
+  private static native long createDelegate(int nthreads);
+
+  private static native void deleteDelegate(long delegateHandle);
+}

--- a/tensorflow/lite/delegates/xnnpack/java/src/main/native/BUILD
+++ b/tensorflow/lite/delegates/xnnpack/java/src/main/native/BUILD
@@ -1,0 +1,25 @@
+# Description:
+# Java Native Interface (JNI) library intended for implementing the
+# TensorFlow Lite XNNPACK delegate Java API using the TensorFlow Lite CC library.
+
+load("//tensorflow/lite:build_def.bzl", "tflite_copts")
+
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+cc_library(
+    name = "native",
+    srcs = ["xnnpack_delegate_jni.cc"],
+    copts = tflite_copts(),
+    tags = [
+        "manual",
+        "notap",
+    ],
+    deps = [
+        "//tensorflow/lite/delegates/xnnpack:xnnpack_delegate",
+        "//tensorflow/lite/java/jni",
+    ],
+    alwayslink = 1,
+)

--- a/tensorflow/lite/delegates/xnnpack/java/src/main/native/xnnpack_delegate_jni.cc
+++ b/tensorflow/lite/delegates/xnnpack/java/src/main/native/xnnpack_delegate_jni.cc
@@ -1,0 +1,40 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <jni.h>
+
+#include "tensorflow/lite/delegates/xnnpack/xnnpack_delegate.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+JNIEXPORT jlong JNICALL Java_org_tensorflow_lite_xnnpack_XNNPackDelegate_createDelegate(
+    JNIEnv* env, jclass clazz, jint nthreads) {
+
+  TfLiteXNNPackDelegateOptions options = TfLiteXNNPackDelegateOptionsDefault();
+  options.num_threads = nthreads;
+
+  return reinterpret_cast<jlong>(TfLiteXNNPackDelegateCreate(&options));
+}
+
+JNIEXPORT void JNICALL Java_org_tensorflow_lite_xnnpack_XNNPackDelegate_deleteDelegate(
+    JNIEnv* env, jclass clazz, jlong delegate) {
+  TfLiteXNNPackDelegateDelete(reinterpret_cast<TfLiteDelegate*>(delegate));
+}
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus

--- a/tensorflow/lite/delegates/xnnpack/xnnpack_delegate.cc
+++ b/tensorflow/lite/delegates/xnnpack/xnnpack_delegate.cc
@@ -28,6 +28,7 @@ limitations under the License.
 #include "tensorflow/lite/builtin_ops.h"
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/minimal_logging.h"
 
 namespace tflite {
 namespace xnnpack {
@@ -1358,13 +1359,20 @@ TfLiteXNNPackDelegateOptions TfLiteXNNPackDelegateOptionsDefault() {
 
 TfLiteDelegate* TfLiteXNNPackDelegateCreate(
     const TfLiteXNNPackDelegateOptions* options) {
+
   xnn_status status = xnn_initialize(/*allocator=*/nullptr);
   if (status != xnn_status_success) {
     return nullptr;
   }
 
   auto* xnnpack_delegate = new ::tflite::xnnpack::Delegate(options);
-  return xnnpack_delegate ? xnnpack_delegate->tflite_delegate() : nullptr;
+  if (xnnpack_delegate) {
+      TFLITE_LOG_PROD_ONCE(tflite::TFLITE_LOG_INFO,
+              "Created TensorFlow Lite delegate for XNNPACK.");
+      return xnnpack_delegate->tflite_delegate();
+  } 
+
+  return nullptr;
 }
 
 void TfLiteXNNPackDelegateDelete(TfLiteDelegate* delegate) {

--- a/tensorflow/lite/java/BUILD
+++ b/tensorflow/lite/java/BUILD
@@ -55,6 +55,14 @@ aar_with_jni(
     ],
 )
 
+aar_with_jni(
+    name = "tensorflow-lite-xnnpack",
+    android_library = ":tensorflowlite_xnnpack",
+    headers = [
+        "//tensorflow/lite/delegates/xnnpack:xnnpack_delegate.h",
+    ],
+)
+
 android_library(
     name = "tensorflowlite",
     srcs = JAVA_SRCS,
@@ -92,6 +100,18 @@ android_library(
     deps = [
         ":tensorflowlite_java",
         ":tensorflowlite_native_gpu",
+        "@org_checkerframework_qual",
+    ],
+)
+
+android_library(
+    name = "tensorflowlite_xnnpack",
+    srcs = ["//tensorflow/lite/delegates/xnnpack/java/src/main/java/org/tensorflow/lite/xnnpack:xnnpack_delegate"],
+    manifest = "AndroidManifest.xml",
+    proguard_specs = ["proguard.flags"],
+    deps = [
+        ":tensorflowlite_java",
+        ":tensorflowlite_native_xnnpack",
         "@org_checkerframework_qual",
     ],
 )
@@ -374,6 +394,12 @@ cc_library(
     visibility = ["//visibility:private"],
 )
 
+cc_library(
+    name = "tensorflowlite_native_xnnpack",
+    srcs = ["libtensorflowlite_xnnpack_jni.so"],
+    visibility = ["//visibility:private"],
+)
+
 tflite_jni_binary(
     name = "libtensorflowlite_jni.so",
     linkscript = ":tflite_version_script.lds",
@@ -383,7 +409,7 @@ tflite_jni_binary(
         "//tensorflow/lite/c:c_api",
         "//tensorflow/lite/c:c_api_experimental",
         "//tensorflow/lite/delegates/nnapi/java/src/main/native",
-        "//tensorflow/lite/java/src/main/native",
+        "//tensorflow/lite/java/src/main/native"
     ],
 )
 
@@ -401,5 +427,13 @@ tflite_jni_binary(
     linkscript = ":gpu_version_script.lds",
     deps = [
         "//tensorflow/lite/delegates/gpu/java/src/main/native",
+    ],
+)
+
+tflite_jni_binary(
+    name = "libtensorflowlite_xnnpack_jni.so",
+    linkscript = ":xnn_version_script.lds",
+    deps = [
+        "//tensorflow/lite/delegates/xnnpack/java/src/main/native",
     ],
 )

--- a/tensorflow/lite/java/xnn_version_script.lds
+++ b/tensorflow/lite/java/xnn_version_script.lds
@@ -1,0 +1,12 @@
+VERS_1.0 {
+  # Export JNI and native C symbols.
+  global:
+    Java_*;
+    JNI_OnLoad;
+    JNI_OnUnload;
+    TfLiteXNNPack*;
+
+  # Hide everything else.
+  local:
+    *;
+};


### PR DESCRIPTION
I've implemented a java wrapper for tflite xnnpack delegate (analogous to gpu delegate)

Usage example (Kotlin):
```{kotlin} 
import org.tensorflow.lite.xnnpack.XNNPackDelegate

...

val xnnOptions = XNNPackDelegate.Options()
xnnOptions.setNumThreads(4) 

val xnnDelegate = XNNPackDelegate(xnnOptions)!! // create the delegate
interpreter.modifyGraphWithDelegate(xnnDelegate) // register the delegate
```