### PR TITLE
Remove calls to deprecated cusparse APIs

### DIFF
--- a/tensorflow/core/kernels/cuda_sparse.cc
+++ b/tensorflow/core/kernels/cuda_sparse.cc
@@ -23,8 +23,6 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include "third_party/gpus/cuda/include/cusparse.h"
-#include "third_party/gpus/cuda/include/library_types.h"
 #include "tensorflow/core/common_runtime/gpu/gpu_event_mgr.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/types.h"
@@ -38,6 +36,8 @@ limitations under the License.
 #include "tensorflow/core/platform/mutex.h"
 #include "tensorflow/core/platform/stream_executor.h"
 #include "tensorflow/core/platform/types.h"
+#include "third_party/gpus/cuda/include/cusparse.h"
+#include "third_party/gpus/cuda/include/library_types.h"
 
 // TODO(rmlarsen,penporn): Investigate using newer kernels in CUDA 10.1+.
 
@@ -180,11 +180,9 @@ Status GpuSparse::Initialize() {
   return Status::OK();
 }
 
-#define TF_CALL_CUSPARSE_DTYPES(m) \
-  m(float, CUDA_R_32F) \
-  m(double, CUDA_R_64F) \
-  m(std::complex<float>, CUDA_C_32F) \
-  m(std::complex<double>, CUDA_C_64F)
+#define TF_CALL_CUSPARSE_DTYPES(m)           \
+  m(float, CUDA_R_32F) m(double, CUDA_R_64F) \
+      m(std::complex<float>, CUDA_C_32F) m(std::complex<double>, CUDA_C_64F)
 
 // Macro that specializes a sparse method for all 4 standard
 // numeric types.
@@ -366,15 +364,12 @@ Status GpuSparse::Csr2coo(const int* csrRowPtr, int nnz, int m,
   return Status::OK();
 }
 
-Status GpuSparse::CsrgeamNnz(int m, int n, const cusparseMatDescr_t descrA,
-                             int nnzA, const int* csrSortedRowPtrA,
-                             const int* csrSortedColIndA,
-                             const cusparseMatDescr_t descrB, int nnzB,
-                             const int* csrSortedRowPtrB,
-                             const int* csrSortedColIndB,
-                             const cusparseMatDescr_t descrC,
-                             int* csrSortedRowPtrC, int* nnzTotalDevHostPtr,
-                             void* workspace) {
+Status GpuSparse::CsrgeamNnz(
+    int m, int n, const cusparseMatDescr_t descrA, int nnzA,
+    const int* csrSortedRowPtrA, const int* csrSortedColIndA,
+    const cusparseMatDescr_t descrB, int nnzB, const int* csrSortedRowPtrB,
+    const int* csrSortedColIndB, const cusparseMatDescr_t descrC,
+    int* csrSortedRowPtrC, int* nnzTotalDevHostPtr, void* workspace) {
   DCHECK(initialized_);
   DCHECK(nnzTotalDevHostPtr != nullptr);
 #if CUDA_VERSION >= 10000
@@ -435,36 +430,35 @@ TF_CALL_LAPACK_TYPES(CSRMM_INSTANCE);
 
 #else
 
-#define SPMM_BUFFERSIZE_INSTANCE(Scalar, dtype)                               \
-  template<>                                                                  \
-  Status GpuSparse::SpMMBufferSize<Scalar>(                                   \
-      cusparseOperation_t transA, cusparseOperation_t transB,                 \
-      const Scalar* alpha, const cusparseSpMatDescr_t matA,                   \
-      const gpusparseDnMatDescr_t matB, const Scalar* beta,                   \
-      gpusparseDnMatDescr_t matC, cusparseSpMMAlg_t alg,                      \
-      size_t* bufferSize) const {                                             \
-    DCHECK(initialized_);                                                     \
-    TF_RETURN_IF_GPUSPARSE_ERROR(cusparseSpMM_bufferSize(                     \
-        *gpusparse_handle_, transA, transB, alpha, matA, matB, beta,          \
-        matC, dtype, alg, bufferSize));                                       \
-    return Status::OK();                                                      \
+#define SPMM_BUFFERSIZE_INSTANCE(Scalar, dtype)                              \
+  template <>                                                                \
+  Status GpuSparse::SpMMBufferSize<Scalar>(                                  \
+      cusparseOperation_t transA, cusparseOperation_t transB,                \
+      const Scalar* alpha, const cusparseSpMatDescr_t matA,                  \
+      const gpusparseDnMatDescr_t matB, const Scalar* beta,                  \
+      gpusparseDnMatDescr_t matC, cusparseSpMMAlg_t alg, size_t* bufferSize) \
+      const {                                                                \
+    DCHECK(initialized_);                                                    \
+    TF_RETURN_IF_GPUSPARSE_ERROR(cusparseSpMM_bufferSize(                    \
+        *gpusparse_handle_, transA, transB, alpha, matA, matB, beta, matC,   \
+        dtype, alg, bufferSize));                                            \
+    return Status::OK();                                                     \
   }
 
 TF_CALL_CUSPARSE_DTYPES(SPMM_BUFFERSIZE_INSTANCE);
 
-#define SPMM_INSTANCE(Scalar, dtype)                                          \
-  template<>                                                                  \
-  Status GpuSparse::SpMM<Scalar>(                                             \
-      cusparseOperation_t transA, cusparseOperation_t transB,                 \
-      const Scalar* alpha, const cusparseSpMatDescr_t matA,                   \
-      const gpusparseDnMatDescr_t matB, const Scalar* beta,                   \
-      gpusparseDnMatDescr_t matC, cusparseSpMMAlg_t alg,                      \
-      int8* buffer) const {                                                   \
-    DCHECK(initialized_);                                                     \
-    TF_RETURN_IF_GPUSPARSE_ERROR(cusparseSpMM(                                \
-        *gpusparse_handle_, transA, transB, alpha, matA, matB, beta,          \
-        matC, dtype, alg, buffer));                                           \
-    return Status::OK();                                                      \
+#define SPMM_INSTANCE(Scalar, dtype)                                           \
+  template <>                                                                  \
+  Status GpuSparse::SpMM<Scalar>(                                              \
+      cusparseOperation_t transA, cusparseOperation_t transB,                  \
+      const Scalar* alpha, const cusparseSpMatDescr_t matA,                    \
+      const gpusparseDnMatDescr_t matB, const Scalar* beta,                    \
+      gpusparseDnMatDescr_t matC, cusparseSpMMAlg_t alg, int8* buffer) const { \
+    DCHECK(initialized_);                                                      \
+    TF_RETURN_IF_GPUSPARSE_ERROR(cusparseSpMM(*gpusparse_handle_, transA,      \
+                                              transB, alpha, matA, matB, beta, \
+                                              matC, dtype, alg, buffer));      \
+    return Status::OK();                                                       \
   }
 
 TF_CALL_CUSPARSE_DTYPES(SPMM_INSTANCE);
@@ -515,11 +509,14 @@ TF_CALL_LAPACK_TYPES(CSRMV_INSTANCE);
 #else
 
 template <typename Scalar>
-static inline Status CsrmvExImpl(
-    cudaDataType_t dtype, OpKernelContext* context, cusparseHandle_t cusparse_handle,
-    cusparseOperation_t transA, int m, int n, int nnz, const Scalar* alpha_host,
-    const Scalar* csrSortedValA, const int* csrSortedRowPtrA, const int* csrSortedColIndA,
-    const Scalar* x, const Scalar* beta_host, Scalar* y) {
+static inline Status CsrmvExImpl(cudaDataType_t dtype, OpKernelContext* context,
+                                 cusparseHandle_t cusparse_handle,
+                                 cusparseOperation_t transA, int m, int n,
+                                 int nnz, const Scalar* alpha_host,
+                                 const Scalar* csrSortedValA,
+                                 const int* csrSortedRowPtrA,
+                                 const int* csrSortedColIndA, const Scalar* x,
+                                 const Scalar* beta_host, Scalar* y) {
   cusparseMatDescr_t descrA;
   TF_RETURN_IF_GPUSPARSE_ERROR(cusparseCreateMatDescr(&descrA));
   TF_RETURN_IF_GPUSPARSE_ERROR(
@@ -531,10 +528,9 @@ static inline Status CsrmvExImpl(
 
   size_t bufferSize;
   TF_RETURN_IF_GPUSPARSE_ERROR(cusparseCsrmvEx_bufferSize(
-      cusparse_handle, CUSPARSE_ALG_MERGE_PATH, transA, m, n, nnz,
-      alpha_host, dtype, descrA, csrSortedValA, dtype, csrSortedRowPtrA,
-      csrSortedColIndA, x, dtype, beta_host, dtype, y, dtype, dtype,
-      &bufferSize));
+      cusparse_handle, CUSPARSE_ALG_MERGE_PATH, transA, m, n, nnz, alpha_host,
+      dtype, descrA, csrSortedValA, dtype, csrSortedRowPtrA, csrSortedColIndA,
+      x, dtype, beta_host, dtype, y, dtype, dtype, &bufferSize));
 
   Tensor buffer;
   TF_RETURN_IF_ERROR(context->allocate_temp(
@@ -543,40 +539,40 @@ static inline Status CsrmvExImpl(
   DCHECK(pBuffer.data() != nullptr);
 
   TF_RETURN_IF_GPUSPARSE_ERROR(cusparseCsrmvEx(
-      cusparse_handle, CUSPARSE_ALG_MERGE_PATH, transA, m, n, nnz,
-      alpha_host, dtype, descrA, csrSortedValA, dtype, csrSortedRowPtrA,
-      csrSortedColIndA, x, dtype, beta_host, dtype, y, dtype, dtype,
-      pBuffer.data()));
+      cusparse_handle, CUSPARSE_ALG_MERGE_PATH, transA, m, n, nnz, alpha_host,
+      dtype, descrA, csrSortedValA, dtype, csrSortedRowPtrA, csrSortedColIndA,
+      x, dtype, beta_host, dtype, y, dtype, dtype, pBuffer.data()));
 
   TF_RETURN_IF_GPUSPARSE_ERROR(cusparseDestroyMatDescr(descrA));
   return Status::OK();
 }
 
 template <typename Scalar>
-static inline Status SpMVImpl(
-    cudaDataType_t dtype, OpKernelContext* context, cusparseHandle_t cusparse_handle,
-    cusparseOperation_t transA, int m, int n, int nnz, const Scalar* alpha_host,
-    const Scalar* csrSortedValA, const int* csrSortedRowPtrA, const int* csrSortedColIndA,
-    const Scalar* x, const Scalar* beta_host, Scalar* y) {
+static inline Status SpMVImpl(cudaDataType_t dtype, OpKernelContext* context,
+                              cusparseHandle_t cusparse_handle,
+                              cusparseOperation_t transA, int m, int n, int nnz,
+                              const Scalar* alpha_host,
+                              const Scalar* csrSortedValA,
+                              const int* csrSortedRowPtrA,
+                              const int* csrSortedColIndA, const Scalar* x,
+                              const Scalar* beta_host, Scalar* y) {
   cusparseSpMatDescr_t matA;
-  TF_RETURN_IF_GPUSPARSE_ERROR(cusparseCreateCsr(&matA, m, n, nnz,
-                              const_cast<int*>(csrSortedRowPtrA),
-                              const_cast<int*>(csrSortedColIndA),
-                              const_cast<Scalar*>(csrSortedValA),
-                              CUSPARSE_INDEX_32I, CUSPARSE_INDEX_32I,
-                              CUSPARSE_INDEX_BASE_ZERO, dtype));
+  TF_RETURN_IF_GPUSPARSE_ERROR(cusparseCreateCsr(
+      &matA, m, n, nnz, const_cast<int*>(csrSortedRowPtrA),
+      const_cast<int*>(csrSortedColIndA), const_cast<Scalar*>(csrSortedValA),
+      CUSPARSE_INDEX_32I, CUSPARSE_INDEX_32I, CUSPARSE_INDEX_BASE_ZERO, dtype));
 
   cusparseDnVecDescr_t vecX, vecY;
   int sizeX = (transA == CUSPARSE_OPERATION_NON_TRANSPOSE) ? n : m;
   int sizeY = (transA == CUSPARSE_OPERATION_NON_TRANSPOSE) ? m : n;
-  TF_RETURN_IF_GPUSPARSE_ERROR(cusparseCreateDnVec(
-                              &vecX, sizeX, const_cast<Scalar*>(x), dtype));
+  TF_RETURN_IF_GPUSPARSE_ERROR(
+      cusparseCreateDnVec(&vecX, sizeX, const_cast<Scalar*>(x), dtype));
   TF_RETURN_IF_GPUSPARSE_ERROR(cusparseCreateDnVec(&vecY, sizeY, y, dtype));
 
   size_t bufferSize;
   TF_RETURN_IF_GPUSPARSE_ERROR(cusparseSpMV_bufferSize(
-      cusparse_handle, transA, alpha_host, matA, vecX,
-      beta_host, vecY, dtype, CUSPARSE_CSRMV_ALG1, &bufferSize));
+      cusparse_handle, transA, alpha_host, matA, vecX, beta_host, vecY, dtype,
+      CUSPARSE_CSRMV_ALG1, &bufferSize));
 
   Tensor buffer;
   TF_RETURN_IF_ERROR(context->allocate_temp(
@@ -584,9 +580,9 @@ static inline Status SpMVImpl(
   auto pBuffer = buffer.flat<int8>();
   DCHECK(pBuffer.data() != nullptr);
 
-  TF_RETURN_IF_GPUSPARSE_ERROR(cusparseSpMV(
-      cusparse_handle, transA, alpha_host, matA, vecX,
-      beta_host, vecY, dtype, CUSPARSE_CSRMV_ALG1, pBuffer.data()));
+  TF_RETURN_IF_GPUSPARSE_ERROR(
+      cusparseSpMV(cusparse_handle, transA, alpha_host, matA, vecX, beta_host,
+                   vecY, dtype, CUSPARSE_CSRMV_ALG1, pBuffer.data()));
 
   TF_RETURN_IF_GPUSPARSE_ERROR(cusparseDestroyDnVec(vecY));
   TF_RETURN_IF_GPUSPARSE_ERROR(cusparseDestroyDnVec(vecX));
@@ -594,25 +590,23 @@ static inline Status SpMVImpl(
   return Status::OK();
 }
 
-#define CSRMV_INSTANCE(Scalar, cudaDataType)                                 \
-  template <>                                                                \
-  Status GpuSparse::Csrmv<Scalar>(                                           \
-      cusparseOperation_t transA, int m, int n, int nnz,                     \
-      const Scalar* alpha_host, const Scalar* csrSortedValA,                 \
-      const int* csrSortedRowPtrA, const int* csrSortedColIndA,              \
-      const Scalar* x, const Scalar* beta_host, Scalar* y) const {           \
-    DCHECK(initialized_);                                                    \
-    if (transA == CUSPARSE_OPERATION_NON_TRANSPOSE) {                        \
-      return CsrmvExImpl(cudaDataType, context_, *gpusparse_handle_,         \
-                         transA, m, n, nnz, alpha_host,                      \
-                         csrSortedValA, csrSortedRowPtrA, csrSortedColIndA,  \
-                         x, beta_host, y);                                   \
-    } else {                                                                 \
-      return SpMVImpl(cudaDataType, context_, *gpusparse_handle_,            \
-                      transA, m, n, nnz, alpha_host,                         \
-                      csrSortedValA, csrSortedRowPtrA, csrSortedColIndA,     \
-                      x, beta_host, y);                                      \
-    }                                                                        \
+#define CSRMV_INSTANCE(Scalar, cudaDataType)                                   \
+  template <>                                                                  \
+  Status GpuSparse::Csrmv<Scalar>(                                             \
+      cusparseOperation_t transA, int m, int n, int nnz,                       \
+      const Scalar* alpha_host, const Scalar* csrSortedValA,                   \
+      const int* csrSortedRowPtrA, const int* csrSortedColIndA,                \
+      const Scalar* x, const Scalar* beta_host, Scalar* y) const {             \
+    DCHECK(initialized_);                                                      \
+    if (transA == CUSPARSE_OPERATION_NON_TRANSPOSE) {                          \
+      return CsrmvExImpl(cudaDataType, context_, *gpusparse_handle_, transA,   \
+                         m, n, nnz, alpha_host, csrSortedValA,                 \
+                         csrSortedRowPtrA, csrSortedColIndA, x, beta_host, y); \
+    } else {                                                                   \
+      return SpMVImpl(cudaDataType, context_, *gpusparse_handle_, transA, m,   \
+                      n, nnz, alpha_host, csrSortedValA, csrSortedRowPtrA,     \
+                      csrSortedColIndA, x, beta_host, y);                      \
+    }                                                                          \
   }
 
 TF_CALL_CUSPARSE_DTYPES(CSRMV_INSTANCE);
@@ -671,17 +665,16 @@ static inline Status Csrgeam2Impl(
     const int* csrSortedRowPtrB, const int* csrSortedColIndB,
     const cusparseMatDescr_t descrC, Scalar* csrSortedValC,
     int* csrSortedRowPtrC, int* csrSortedColIndC, void* workspace) {
-  TF_RETURN_IF_GPUSPARSE_ERROR(
-      op(cusparse_handle, m, n, AsCudaComplex(alpha), descrA, nnzA,
-         AsCudaComplex(csrSortedValA), csrSortedRowPtrA, csrSortedColIndA,
-         AsCudaComplex(beta), descrB, nnzB, AsCudaComplex(csrSortedValB),
-         csrSortedRowPtrB, csrSortedColIndB, descrC,
-         AsCudaComplex(csrSortedValC), csrSortedRowPtrC, csrSortedColIndC,
-         workspace));
+  TF_RETURN_IF_GPUSPARSE_ERROR(op(
+      cusparse_handle, m, n, AsCudaComplex(alpha), descrA, nnzA,
+      AsCudaComplex(csrSortedValA), csrSortedRowPtrA, csrSortedColIndA,
+      AsCudaComplex(beta), descrB, nnzB, AsCudaComplex(csrSortedValB),
+      csrSortedRowPtrB, csrSortedColIndB, descrC, AsCudaComplex(csrSortedValC),
+      csrSortedRowPtrC, csrSortedColIndC, workspace));
   return Status::OK();
 }
 
-#define CSRGEAM_INSTANCE(Scalar, sparse_prefix)                              \
+#define CSRGEAM_INSTANCE(Scalar, sparse_prefix)                               \
   template <>                                                                 \
   Status GpuSparse::Csrgeam<Scalar>(                                          \
       int m, int n, const Scalar* alpha, const cusparseMatDescr_t descrA,     \
@@ -733,34 +726,32 @@ static inline Status CsrgeamBufferSizeExtImpl(
     const int* csrSortedRowPtrB, const int* csrSortedColIndB,
     const cusparseMatDescr_t descrC, Scalar* csrSortedValC,
     int* csrSortedRowPtrC, int* csrSortedColIndC, size_t* bufferSize) {
-  TF_RETURN_IF_GPUSPARSE_ERROR(
-      op(sparse_handle, m, n, AsCudaComplex(alpha), descrA, nnzA,
-         AsCudaComplex(csrSortedValA), csrSortedRowPtrA, csrSortedColIndA,
-         AsCudaComplex(beta), descrB, nnzB, AsCudaComplex(csrSortedValB),
-         csrSortedRowPtrB, csrSortedColIndB, descrC,
-         AsCudaComplex(csrSortedValC), csrSortedRowPtrC, csrSortedColIndC,
-         bufferSize));
+  TF_RETURN_IF_GPUSPARSE_ERROR(op(
+      sparse_handle, m, n, AsCudaComplex(alpha), descrA, nnzA,
+      AsCudaComplex(csrSortedValA), csrSortedRowPtrA, csrSortedColIndA,
+      AsCudaComplex(beta), descrB, nnzB, AsCudaComplex(csrSortedValB),
+      csrSortedRowPtrB, csrSortedColIndB, descrC, AsCudaComplex(csrSortedValC),
+      csrSortedRowPtrC, csrSortedColIndC, bufferSize));
   return Status::OK();
 }
 
-#define CSRGEAM_BUFFERSIZE_INSTANCE(Scalar, sparse_prefix)                    \
-  template <>                                                                 \
-  Status GpuSparse::CsrgeamBufferSizeExt<Scalar>(                            \
-      int m, int n, const Scalar* alpha, const cusparseMatDescr_t descrA,     \
-      int nnzA, const Scalar* csrSortedValA, const int* csrSortedRowPtrA,     \
-      const int* csrSortedColIndA, const Scalar* beta,                        \
-      const cusparseMatDescr_t descrB, int nnzB, const Scalar* csrSortedValB, \
-      const int* csrSortedRowPtrB, const int* csrSortedColIndB,               \
-      const cusparseMatDescr_t descrC, Scalar* csrSortedValC,                 \
-      int* csrSortedRowPtrC, int* csrSortedColIndC, size_t* bufferSize) {     \
-    DCHECK(initialized_);                                                     \
-    return CsrgeamBufferSizeExtImpl(SPARSE_FN(csrgeam2_bufferSizeExt,        \
-                       sparse_prefix), context_, *gpusparse_handle_, m, n,    \
-                       alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA,  \
-                       csrSortedColIndA, beta, descrB, nnzB, csrSortedValB,   \
-                       csrSortedRowPtrB, csrSortedColIndB, descrC,            \
-                       csrSortedValC, csrSortedRowPtrC, csrSortedColIndC,     \
-                       bufferSize);                                           \
+#define CSRGEAM_BUFFERSIZE_INSTANCE(Scalar, sparse_prefix)                     \
+  template <>                                                                  \
+  Status GpuSparse::CsrgeamBufferSizeExt<Scalar>(                              \
+      int m, int n, const Scalar* alpha, const cusparseMatDescr_t descrA,      \
+      int nnzA, const Scalar* csrSortedValA, const int* csrSortedRowPtrA,      \
+      const int* csrSortedColIndA, const Scalar* beta,                         \
+      const cusparseMatDescr_t descrB, int nnzB, const Scalar* csrSortedValB,  \
+      const int* csrSortedRowPtrB, const int* csrSortedColIndB,                \
+      const cusparseMatDescr_t descrC, Scalar* csrSortedValC,                  \
+      int* csrSortedRowPtrC, int* csrSortedColIndC, size_t* bufferSize) {      \
+    DCHECK(initialized_);                                                      \
+    return CsrgeamBufferSizeExtImpl(                                           \
+        SPARSE_FN(csrgeam2_bufferSizeExt, sparse_prefix), context_,            \
+        *gpusparse_handle_, m, n, alpha, descrA, nnzA, csrSortedValA,          \
+        csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB, csrSortedValB, \
+        csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC,             \
+        csrSortedRowPtrC, csrSortedColIndC, bufferSize);                       \
   }
 
 #endif
@@ -827,13 +818,13 @@ TF_CALL_LAPACK_TYPES(CSRGEMM_INSTANCE);
 
 #else
 
-template<typename T>
+template <typename T>
 static const T* one_ptr() {
   static const T one = static_cast<T>(1);
   return &one;
 }
 
-template<typename T>
+template <typename T>
 static const T* null_ptr() {
   return nullptr;
 }
@@ -847,55 +838,53 @@ static const T* null_ptr() {
       const int* csrSortedColIndB, csrgemm2Info_t info,                        \
       size_t* workspaceBytes) {                                                \
     DCHECK(initialized_);                                                      \
-    TF_RETURN_IF_GPUSPARSE_ERROR(                                              \
-        SPARSE_FN(csrgemm2_bufferSizeExt, sparse_prefix)(                      \
-            *gpusparse_handle_, m, n, k, AsCudaComplex(one_ptr<Scalar>()),     \
-            descrA, nnzA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB,    \
-            csrSortedRowPtrB, csrSortedColIndB,                                \
-            AsCudaComplex(null_ptr<Scalar>()), descrA, 0, null_ptr<int>(),     \
-            null_ptr<int>(), info, workspaceBytes));                           \
+    TF_RETURN_IF_GPUSPARSE_ERROR(SPARSE_FN(csrgemm2_bufferSizeExt,             \
+                                           sparse_prefix)(                     \
+        *gpusparse_handle_, m, n, k, AsCudaComplex(one_ptr<Scalar>()), descrA, \
+        nnzA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB,                \
+        csrSortedRowPtrB, csrSortedColIndB, AsCudaComplex(null_ptr<Scalar>()), \
+        descrA, 0, null_ptr<int>(), null_ptr<int>(), info, workspaceBytes));   \
     return Status::OK();                                                       \
   }
 
 TF_CALL_LAPACK_TYPES(CSRGEMM_BUFFERSIZE_INSTANCE);
 
-
 Status GpuSparse::CsrgemmNnz(
     int m, int n, int k, const cusparseMatDescr_t descrA, int nnzA,
     const int* csrSortedRowPtrA, const int* csrSortedColIndA,
-    const cusparseMatDescr_t descrB, int nnzB,
-    const int* csrSortedRowPtrB, const int* csrSortedColIndB,
-    const cusparseMatDescr_t descrC, int* csrSortedRowPtrC,
-    int* nnzTotalDevHostPtr, csrgemm2Info_t info, void* workspace) {
+    const cusparseMatDescr_t descrB, int nnzB, const int* csrSortedRowPtrB,
+    const int* csrSortedColIndB, const cusparseMatDescr_t descrC,
+    int* csrSortedRowPtrC, int* nnzTotalDevHostPtr, csrgemm2Info_t info,
+    void* workspace) {
   DCHECK(initialized_);
   DCHECK(nnzTotalDevHostPtr != nullptr);
 
   TF_RETURN_IF_GPUSPARSE_ERROR(cusparseXcsrgemm2Nnz(
       *gpusparse_handle_, m, n, k, descrA, nnzA, csrSortedRowPtrA,
       csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB, csrSortedColIndB,
-      descrA, 0, null_ptr<int>(), null_ptr<int>(), descrC,
-      csrSortedRowPtrC, nnzTotalDevHostPtr, info, workspace));
+      descrA, 0, null_ptr<int>(), null_ptr<int>(), descrC, csrSortedRowPtrC,
+      nnzTotalDevHostPtr, info, workspace));
   return Status::OK();
 }
 
 template <typename Scalar, typename SparseFnT>
 static inline Status CsrgemmImpl(
     SparseFnT op, OpKernelContext* context, cusparseHandle_t cusparse_handle,
-    int m, int n, int k, const cusparseMatDescr_t descrA,
-    int nnzA, const Scalar* csrSortedValA, const int* csrSortedRowPtrA,
+    int m, int n, int k, const cusparseMatDescr_t descrA, int nnzA,
+    const Scalar* csrSortedValA, const int* csrSortedRowPtrA,
     const int* csrSortedColIndA, const cusparseMatDescr_t descrB, int nnzB,
     const Scalar* csrSortedValB, const int* csrSortedRowPtrB,
     const int* csrSortedColIndB, const cusparseMatDescr_t descrC,
     Scalar* csrSortedValC, int* csrSortedRowPtrC, int* csrSortedColIndC,
     const csrgemm2Info_t info, void* workspace) {
   TF_RETURN_IF_GPUSPARSE_ERROR(
-      op(cusparse_handle, m, n, k, AsCudaComplex(one_ptr<Scalar>()),
-         descrA, nnzA, AsCudaComplex(csrSortedValA), csrSortedRowPtrA, csrSortedColIndA,
-         descrB, nnzB, AsCudaComplex(csrSortedValB), csrSortedRowPtrB,  csrSortedColIndB,
-         AsCudaComplex(null_ptr<Scalar>()),
-         descrA, 0, AsCudaComplex(null_ptr<Scalar>()), null_ptr<int>(), null_ptr<int>(),
-         descrC, AsCudaComplex(csrSortedValC), csrSortedRowPtrC, csrSortedColIndC,
-         info, workspace));
+      op(cusparse_handle, m, n, k, AsCudaComplex(one_ptr<Scalar>()), descrA,
+         nnzA, AsCudaComplex(csrSortedValA), csrSortedRowPtrA, csrSortedColIndA,
+         descrB, nnzB, AsCudaComplex(csrSortedValB), csrSortedRowPtrB,
+         csrSortedColIndB, AsCudaComplex(null_ptr<Scalar>()), descrA, 0,
+         AsCudaComplex(null_ptr<Scalar>()), null_ptr<int>(), null_ptr<int>(),
+         descrC, AsCudaComplex(csrSortedValC), csrSortedRowPtrC,
+         csrSortedColIndC, info, workspace));
   return Status::OK();
 }
 
@@ -1008,11 +997,9 @@ static inline Status Csr2cscImpl(cudaDataType_t dtype, OpKernelContext* context,
                                  const cusparseAction_t copyValues) {
   size_t bufferSize;
   TF_RETURN_IF_GPUSPARSE_ERROR(cusparseCsr2cscEx2_bufferSize(
-                         cusparse_handle, m, n, nnz,
-                         AsCudaComplex(csrVal), csrRowPtr, csrColInd,
-                         AsCudaComplex(cscVal), cscColPtr, cscRowInd,
-                         dtype, copyValues, CUSPARSE_INDEX_BASE_ZERO,
-                         CUSPARSE_CSR2CSC_ALG2, &bufferSize));
+      cusparse_handle, m, n, nnz, AsCudaComplex(csrVal), csrRowPtr, csrColInd,
+      AsCudaComplex(cscVal), cscColPtr, cscRowInd, dtype, copyValues,
+      CUSPARSE_INDEX_BASE_ZERO, CUSPARSE_CSR2CSC_ALG2, &bufferSize));
 
   Tensor buffer;
   TF_RETURN_IF_ERROR(context->allocate_temp(
@@ -1021,27 +1008,25 @@ static inline Status Csr2cscImpl(cudaDataType_t dtype, OpKernelContext* context,
 
   DCHECK(buffer.flat<Scalar>().data() != nullptr);
 
-  TF_RETURN_IF_GPUSPARSE_ERROR(cusparseCsr2cscEx2(
-                         cusparse_handle, m, n, nnz,
-                         AsCudaComplex(csrVal), csrRowPtr, csrColInd,
-                         AsCudaComplex(cscVal), cscColPtr, cscRowInd,
-                         dtype, copyValues, CUSPARSE_INDEX_BASE_ZERO,
-                         CUSPARSE_CSR2CSC_ALG2,
-                          buffer.flat<Scalar>().data()));
+  TF_RETURN_IF_GPUSPARSE_ERROR(
+      cusparseCsr2cscEx2(cusparse_handle, m, n, nnz, AsCudaComplex(csrVal),
+                         csrRowPtr, csrColInd, AsCudaComplex(cscVal), cscColPtr,
+                         cscRowInd, dtype, copyValues, CUSPARSE_INDEX_BASE_ZERO,
+                         CUSPARSE_CSR2CSC_ALG2, buffer.flat<Scalar>().data()));
 
   return Status::OK();
 }
 
-#define CSR2CSC_INSTANCE(Scalar, cudaDataType)                               \
-  template <>                                                                \
-  Status GpuSparse::Csr2csc<Scalar>(                                         \
-      int m, int n, int nnz, const Scalar* csrVal, const int* csrRowPtr,     \
-      const int* csrColInd, Scalar* cscVal, int* cscRowInd, int* cscColPtr,  \
-      const cusparseAction_t copyValues) {                                   \
-    DCHECK(initialized_);                                                    \
-    return Csr2cscImpl(cudaDataType, context_,                               \
-                       *gpusparse_handle_, m, n, nnz, csrVal, csrRowPtr,     \
-                       csrColInd, cscVal, cscRowInd, cscColPtr, copyValues); \
+#define CSR2CSC_INSTANCE(Scalar, cudaDataType)                                \
+  template <>                                                                 \
+  Status GpuSparse::Csr2csc<Scalar>(                                          \
+      int m, int n, int nnz, const Scalar* csrVal, const int* csrRowPtr,      \
+      const int* csrColInd, Scalar* cscVal, int* cscRowInd, int* cscColPtr,   \
+      const cusparseAction_t copyValues) {                                    \
+    DCHECK(initialized_);                                                     \
+    return Csr2cscImpl(cudaDataType, context_, *gpusparse_handle_, m, n, nnz, \
+                       csrVal, csrRowPtr, csrColInd, cscVal, cscRowInd,       \
+                       cscColPtr, copyValues);                                \
   }
 
 TF_CALL_CUSPARSE_DTYPES(CSR2CSC_INSTANCE);

--- a/tensorflow/core/kernels/cuda_sparse.cc
+++ b/tensorflow/core/kernels/cuda_sparse.cc
@@ -537,7 +537,8 @@ static inline Status CsrmvExImpl(
       &bufferSize));
 
   Tensor buffer;
-  TF_RETURN_IF_ERROR(context->allocate_temp(DT_INT8, {bufferSize}, &buffer));
+  TF_RETURN_IF_ERROR(context->allocate_temp(
+      DT_INT8, TensorShape({static_cast<int64>(bufferSize)}), &buffer));
   auto pBuffer = buffer.flat<int8>();
   DCHECK(pBuffer.data() != nullptr);
 
@@ -578,7 +579,8 @@ static inline Status SpMVImpl(
       beta_host, vecY, dtype, CUSPARSE_CSRMV_ALG1, &bufferSize));
 
   Tensor buffer;
-  TF_RETURN_IF_ERROR(context->allocate_temp(DT_INT8, {bufferSize}, &buffer));
+  TF_RETURN_IF_ERROR(context->allocate_temp(
+      DT_INT8, TensorShape({static_cast<int64>(bufferSize)}), &buffer));
   auto pBuffer = buffer.flat<int8>();
   DCHECK(pBuffer.data() != nullptr);
 
@@ -1013,8 +1015,9 @@ static inline Status Csr2cscImpl(cudaDataType_t dtype, OpKernelContext* context,
                          CUSPARSE_CSR2CSC_ALG2, &bufferSize));
 
   Tensor buffer;
-  TF_RETURN_IF_ERROR(context->allocate_temp(DataTypeToEnum<Scalar>::value,
-                                           {bufferSize}, &buffer));
+  TF_RETURN_IF_ERROR(context->allocate_temp(
+      DataTypeToEnum<Scalar>::value,
+      TensorShape({static_cast<int64>(bufferSize)}), &buffer));
 
   DCHECK(buffer.flat<Scalar>().data() != nullptr);
 

--- a/tensorflow/core/kernels/cuda_sparse.h
+++ b/tensorflow/core/kernels/cuda_sparse.h
@@ -305,12 +305,20 @@ class GpuSparse {
   // http://docs.nvidia.com/cuda/cusparse/index.html#cusparse-lt-t-gt-csrmv_mergepath
   //
   // **NOTE** This is an in-place operation for data in y.
+#if CUDA_VERSION < 10020
   template <typename Scalar>
   Status Csrmv(gpusparseOperation_t transA, int m, int n, int nnz,
                const Scalar* alpha_host, const gpusparseMatDescr_t descrA,
                const Scalar* csrSortedValA, const int* csrSortedRowPtrA,
                const int* csrSortedColIndA, const Scalar* x,
                const Scalar* beta_host, Scalar* y) const;
+#else
+  template <typename Scalar>
+  Status Csrmv(gpusparseOperation_t transA, int m, int n, int nnz,
+               const Scalar* alpha_host, const Scalar* csrSortedValA,
+               const int* csrSortedRowPtrA, const int* csrSortedColIndA,
+               const Scalar* x, const Scalar* beta_host, Scalar* y) const;
+#endif  // CUDA_VERSION < 10020
 
   // Computes workspace size for sparse - sparse matrix addition of matrices
   // stored in CSR format.

--- a/tensorflow/core/kernels/cuda_sparse.h
+++ b/tensorflow/core/kernels/cuda_sparse.h
@@ -27,6 +27,7 @@ limitations under the License.
 #if GOOGLE_CUDA
 
 #include "third_party/gpus/cuda/include/cusparse.h"
+#include "third_party/gpus/cuda/include/cuda.h"
 
 using gpusparseStatus_t = cusparseStatus_t;
 using gpusparseOperation_t = cusparseOperation_t;
@@ -279,6 +280,19 @@ class GpuSparse {
                const int* csrSortedColIndA, const Scalar* x,
                const Scalar* beta_host, Scalar* y) const;
 
+  // Computes workspace size for sparse - sparse matrix addition of matrices
+  // stored in CSR format.
+  template <typename Scalar>
+  Status CsrgeamBufferSizeExt(int m, int n, const Scalar* alpha,
+                 const gpusparseMatDescr_t descrA, int nnzA,
+                 const Scalar* csrSortedValA, const int* csrSortedRowPtrA,
+                 const int* csrSortedColIndA, const Scalar* beta,
+                 const gpusparseMatDescr_t descrB, int nnzB,
+                 const Scalar* csrSortedValB, const int* csrSortedRowPtrB,
+                 const int* csrSortedColIndB, const gpusparseMatDescr_t descrC,
+                 Scalar* csrSortedValC, int* csrSortedRowPtrC,
+                 int* csrSortedColIndC, size_t* bufferSize);
+
   // Computes sparse-sparse matrix addition of matrices
   // stored in CSR format.  This is part one: calculate nnz of the
   // output.  csrSortedRowPtrC must be preallocated on device with
@@ -289,7 +303,7 @@ class GpuSparse {
                     const gpusparseMatDescr_t descrB, int nnzB,
                     const int* csrSortedRowPtrB, const int* csrSortedColIndB,
                     const gpusparseMatDescr_t descrC, int* csrSortedRowPtrC,
-                    int* nnzTotalDevHostPtr);
+                    int* nnzTotalDevHostPtr, void* workspace);
 
   // Computes sparse - sparse matrix addition of matrices
   // stored in CSR format.  This is part two: perform sparse-sparse
@@ -305,7 +319,7 @@ class GpuSparse {
                  const Scalar* csrSortedValB, const int* csrSortedRowPtrB,
                  const int* csrSortedColIndB, const gpusparseMatDescr_t descrC,
                  Scalar* csrSortedValC, int* csrSortedRowPtrC,
-                 int* csrSortedColIndC);
+                 int* csrSortedColIndC, void* workspace);
 
   // Computes sparse-sparse matrix multiplication of matrices
   // stored in CSR format.  This is part one: calculate nnz of the

--- a/tensorflow/core/kernels/cuda_sparse.h
+++ b/tensorflow/core/kernels/cuda_sparse.h
@@ -26,8 +26,8 @@ limitations under the License.
 
 #if GOOGLE_CUDA
 
-#include "third_party/gpus/cuda/include/cusparse.h"
 #include "third_party/gpus/cuda/include/cuda.h"
+#include "third_party/gpus/cuda/include/cusparse.h"
 
 using gpusparseStatus_t = cusparseStatus_t;
 using gpusparseOperation_t = cusparseOperation_t;
@@ -253,7 +253,6 @@ class GpuSparse {
   // http://docs.nvidia.com/cuda/cusparse/index.html#cusparse-lt-t-gt-coo2csr.
   Status Coo2csr(const int* cooRowInd, int nnz, int m, int* csrRowPtr) const;
 
-
 #if CUDA_VERSION < 10020
   // Sparse-dense matrix multiplication C = alpha * op(A) * op(B)  + beta * C,
   // where A is a sparse matrix in CSR format, B and C are dense tall
@@ -275,13 +274,14 @@ class GpuSparse {
                const Scalar* B, int ldb, const Scalar* beta_host, Scalar* C,
                int ldc) const;
 #else
-  // Workspace size query for sparse-dense matrix multiplication. Helper function
-  // for SpMM which computes y = alpha * op(A) * op(B) + beta * C, where A is
-  // a sparse matrix in CSR format, B and C are dense matricies in column-major
-  // format. Returns needed workspace size in bytes.
+  // Workspace size query for sparse-dense matrix multiplication. Helper
+  // function for SpMM which computes y = alpha * op(A) * op(B) + beta * C,
+  // where A is a sparse matrix in CSR format, B and C are dense matricies in
+  // column-major format. Returns needed workspace size in bytes.
   template <typename Scalar>
-  Status SpMMBufferSize(gpusparseOperation_t transA, gpusparseOperation_t transB,
-                        const Scalar* alpha, const gpusparseSpMatDescr_t matA,
+  Status SpMMBufferSize(gpusparseOperation_t transA,
+                        gpusparseOperation_t transB, const Scalar* alpha,
+                        const gpusparseSpMatDescr_t matA,
                         const gpusparseDnMatDescr_t matB, const Scalar* beta,
                         gpusparseDnMatDescr_t matC, gpusparseSpMMAlg_t alg,
                         size_t* bufferSize) const;
@@ -323,15 +323,14 @@ class GpuSparse {
   // Computes workspace size for sparse - sparse matrix addition of matrices
   // stored in CSR format.
   template <typename Scalar>
-  Status CsrgeamBufferSizeExt(int m, int n, const Scalar* alpha,
-                 const gpusparseMatDescr_t descrA, int nnzA,
-                 const Scalar* csrSortedValA, const int* csrSortedRowPtrA,
-                 const int* csrSortedColIndA, const Scalar* beta,
-                 const gpusparseMatDescr_t descrB, int nnzB,
-                 const Scalar* csrSortedValB, const int* csrSortedRowPtrB,
-                 const int* csrSortedColIndB, const gpusparseMatDescr_t descrC,
-                 Scalar* csrSortedValC, int* csrSortedRowPtrC,
-                 int* csrSortedColIndC, size_t* bufferSize);
+  Status CsrgeamBufferSizeExt(
+      int m, int n, const Scalar* alpha, const gpusparseMatDescr_t descrA,
+      int nnzA, const Scalar* csrSortedValA, const int* csrSortedRowPtrA,
+      const int* csrSortedColIndA, const Scalar* beta,
+      const gpusparseMatDescr_t descrB, int nnzB, const Scalar* csrSortedValB,
+      const int* csrSortedRowPtrB, const int* csrSortedColIndB,
+      const gpusparseMatDescr_t descrC, Scalar* csrSortedValC,
+      int* csrSortedRowPtrC, int* csrSortedColIndC, size_t* bufferSize);
 
   // Computes sparse-sparse matrix addition of matrices
   // stored in CSR format.  This is part one: calculate nnz of the
@@ -365,15 +364,12 @@ class GpuSparse {
   // Computes sparse-sparse matrix multiplication of matrices
   // stored in CSR format.  This is part zero: calculate required workspace
   // size.
-  template<typename Scalar>
-  Status CsrgemmBufferSize(int m, int n, int k,
-                           const gpusparseMatDescr_t descrA, int nnzA,
-                           const int* csrSortedRowPtrA,
-                           const int* csrSortedColIndA,
-                           const gpusparseMatDescr_t descrB, int nnzB,
-                           const int* csrSortedRowPtrB,
-                           const int* csrSortedColIndB,
-                           csrgemm2Info_t info, size_t* workspaceBytes);
+  template <typename Scalar>
+  Status CsrgemmBufferSize(
+      int m, int n, int k, const gpusparseMatDescr_t descrA, int nnzA,
+      const int* csrSortedRowPtrA, const int* csrSortedColIndA,
+      const gpusparseMatDescr_t descrB, int nnzB, const int* csrSortedRowPtrB,
+      const int* csrSortedColIndB, csrgemm2Info_t info, size_t* workspaceBytes);
 #endif
 
   // Computes sparse-sparse matrix multiplication of matrices
@@ -419,13 +415,12 @@ class GpuSparse {
                  int* csrSortedColIndC);
 #else
   template <typename Scalar>
-  Status Csrgemm(int m, int n, int k,
-                 const gpusparseMatDescr_t descrA, int nnzA,
-                 const Scalar* csrSortedValA, const int* csrSortedRowPtrA,
-                 const int* csrSortedColIndA, const gpusparseMatDescr_t descrB,
-                 int nnzB, const Scalar* csrSortedValB,
-                 const int* csrSortedRowPtrB, const int* csrSortedColIndB,
-                 const gpusparseMatDescr_t descrC,
+  Status Csrgemm(int m, int n, int k, const gpusparseMatDescr_t descrA,
+                 int nnzA, const Scalar* csrSortedValA,
+                 const int* csrSortedRowPtrA, const int* csrSortedColIndA,
+                 const gpusparseMatDescr_t descrB, int nnzB,
+                 const Scalar* csrSortedValB, const int* csrSortedRowPtrB,
+                 const int* csrSortedColIndB, const gpusparseMatDescr_t descrC,
                  Scalar* csrSortedValC, int* csrSortedRowPtrC,
                  int* csrSortedColIndC, const csrgemm2Info_t info,
                  void* workspace);

--- a/tensorflow/core/kernels/sparse/add_op.cc
+++ b/tensorflow/core/kernels/sparse/add_op.cc
@@ -107,6 +107,25 @@ class CSRSparseMatrixAddFunctor {
     const Device& d = ctx_->eigen_device<Device>();
     set_zero(d, c_row_ptr_t.flat<int32>());
 
+    size_t maxWorkspaceSize = 0;
+    for (int i=0; i < batch_size; ++i) {
+      ConstCSRComponent<T> a_comp{a.row_pointers_vec(i), a.col_indices_vec(i),
+                                  a.values_vec<T>(i), a_dense_shape};
+      ConstCSRComponent<T> b_comp{b.row_pointers_vec(i), b.col_indices_vec(i),
+                                  b.values_vec<T>(i), b_dense_shape};
+
+      size_t thisWorkspaceSize;
+      csr_geam.GetWorkspaceSize(a_comp, b_comp, &thisWorkspaceSize);
+      if (thisWorkspaceSize > maxWorkspaceSize) {
+        maxWorkspaceSize = thisWorkspaceSize;
+      }
+    }
+
+    Tensor temp;
+    TF_RETURN_IF_ERROR(ctx_->allocate_temp(DT_INT8, {maxWorkspaceSize},
+                       &temp));
+    void* workspace = temp.flat<int8>().data();
+
     for (int i = 0; i < batch_size; ++i) {
       // Calculate output sizes for all minibatch entries.
       // Store in c_batch_ptr and update c_row_ptrs.
@@ -123,7 +142,7 @@ class CSRSparseMatrixAddFunctor {
       int c_nnz_i;
       TF_RETURN_IF_ERROR(
           csr_geam.GetOutputStructure(a_comp, b_comp, c_row_ptr_i, &c_nnz_i,
-                                      nullptr));
+                                      workspace));
       c_batch_ptr(i + 1) = c_batch_ptr(i) + c_nnz_i;
     }
 
@@ -152,7 +171,7 @@ class CSRSparseMatrixAddFunctor {
       CSRComponent<T> c_comp{c->row_pointers_vec(i), c->col_indices_vec(i),
                              c->values_vec<T>(i), c_dense_shape_t.vec<int64>()};
 
-      TF_RETURN_IF_ERROR(csr_geam.Compute(a_comp, b_comp, &c_comp, nullptr));
+      TF_RETURN_IF_ERROR(csr_geam.Compute(a_comp, b_comp, &c_comp, workspace));
     }
 
     return Status::OK();
@@ -274,8 +293,29 @@ struct CSRSparseMatrixAdd<GPUDevice, T>
                           const ConstCSRComponent<T>& b,
                           size_t* bufferSize) {
     DCHECK(initialized_);
-    *bufferSize = 0;
+
+    const int m = a.row_ptr.size() - 1;
+    DCHECK_EQ(m, b.row_ptr.size() - 1);
+    const int row_dim = a.dense_shape_host.size() == 2 ? 0 : 1;
+    DCHECK_EQ(m, a.dense_shape_host(row_dim));
+    DCHECK_EQ(m, b.dense_shape_host(row_dim));
+    const int nnzA = a.col_ind.size();
+    const int nnzB = b.col_ind.size();
+
+    const int n = a.dense_shape_host(row_dim + 1);
+    DCHECK_EQ(n, b.dense_shape_host(row_dim + 1));
+    T* null_T = nullptr;
+    int* null_int = nullptr;
+
+    TF_RETURN_IF_ERROR(cuda_sparse_.CsrgeamBufferSizeExt(
+        m, n, &alpha_, descrA_.descr(), nnzA, a.values.data(), a.row_ptr.data(),
+        a.col_ind.data(), &beta_, descrB_.descr(), nnzB, b.values.data(),
+        b.row_ptr.data(), b.col_ind.data(), descrC_.descr(), null_T,
+        null_int, null_int, bufferSize));
+
+    return Status::OK();
   }
+
 
   Status GetOutputStructure(const ConstCSRComponent<T>& a,
                             const ConstCSRComponent<T>& b,
@@ -298,7 +338,7 @@ struct CSRSparseMatrixAdd<GPUDevice, T>
     TF_RETURN_IF_ERROR(cuda_sparse_.CsrgeamNnz(
         m, n, descrA_.descr(), nnzA, a.row_ptr.data(), a.col_ind.data(),
         descrB_.descr(), nnzB, b.row_ptr.data(), b.col_ind.data(),
-        descrC_.descr(), c_row_ptr.data(), output_nnz));
+        descrC_.descr(), c_row_ptr.data(), output_nnz, workspace));
 
     if (*output_nnz < 0) {
       return errors::Internal(
@@ -327,7 +367,7 @@ struct CSRSparseMatrixAdd<GPUDevice, T>
         m, n, &alpha_, descrA_.descr(), nnzA, a.values.data(), a.row_ptr.data(),
         a.col_ind.data(), &beta_, descrB_.descr(), nnzB, b.values.data(),
         b.row_ptr.data(), b.col_ind.data(), descrC_.descr(), c->values.data(),
-        c->row_ptr.data(), c->col_ind.data()));
+        c->row_ptr.data(), c->col_ind.data(), workspace));
 
     return Status::OK();
   }

--- a/tensorflow/core/kernels/sparse/add_op.cc
+++ b/tensorflow/core/kernels/sparse/add_op.cc
@@ -122,8 +122,8 @@ class CSRSparseMatrixAddFunctor {
     }
 
     Tensor temp;
-    TF_RETURN_IF_ERROR(ctx_->allocate_temp(DT_INT8, {maxWorkspaceSize},
-                       &temp));
+    TF_RETURN_IF_ERROR(ctx_->allocate_temp(
+        DT_INT8, TensorShape({static_cast<int64>(maxWorkspaceSize)}), &temp));
     void* workspace = temp.flat<int8>().data();
 
     for (int i = 0; i < batch_size; ++i) {

--- a/tensorflow/core/kernels/sparse/add_op.cc
+++ b/tensorflow/core/kernels/sparse/add_op.cc
@@ -108,7 +108,7 @@ class CSRSparseMatrixAddFunctor {
     set_zero(d, c_row_ptr_t.flat<int32>());
 
     size_t maxWorkspaceSize = 0;
-    for (int i=0; i < batch_size; ++i) {
+    for (int i = 0; i < batch_size; ++i) {
       ConstCSRComponent<T> a_comp{a.row_pointers_vec(i), a.col_indices_vec(i),
                                   a.values_vec<T>(i), a_dense_shape};
       ConstCSRComponent<T> b_comp{b.row_pointers_vec(i), b.col_indices_vec(i),
@@ -140,9 +140,8 @@ class CSRSparseMatrixAddFunctor {
       TTypes<int32>::UnalignedVec c_row_ptr_i(&c_row_ptr(i * (rows + 1)),
                                               rows + 1);
       int c_nnz_i;
-      TF_RETURN_IF_ERROR(
-          csr_geam.GetOutputStructure(a_comp, b_comp, c_row_ptr_i, &c_nnz_i,
-                                      workspace));
+      TF_RETURN_IF_ERROR(csr_geam.GetOutputStructure(
+          a_comp, b_comp, c_row_ptr_i, &c_nnz_i, workspace));
       c_batch_ptr(i + 1) = c_batch_ptr(i) + c_nnz_i;
     }
 
@@ -290,8 +289,7 @@ struct CSRSparseMatrixAdd<GPUDevice, T>
   }
 
   Status GetWorkspaceSize(const ConstCSRComponent<T>& a,
-                          const ConstCSRComponent<T>& b,
-                          size_t* bufferSize) {
+                          const ConstCSRComponent<T>& b, size_t* bufferSize) {
     DCHECK(initialized_);
 
     const int m = a.row_ptr.size() - 1;
@@ -310,12 +308,11 @@ struct CSRSparseMatrixAdd<GPUDevice, T>
     TF_RETURN_IF_ERROR(cuda_sparse_.CsrgeamBufferSizeExt(
         m, n, &alpha_, descrA_.descr(), nnzA, a.values.data(), a.row_ptr.data(),
         a.col_ind.data(), &beta_, descrB_.descr(), nnzB, b.values.data(),
-        b.row_ptr.data(), b.col_ind.data(), descrC_.descr(), null_T,
-        null_int, null_int, bufferSize));
+        b.row_ptr.data(), b.col_ind.data(), descrC_.descr(), null_T, null_int,
+        null_int, bufferSize));
 
     return Status::OK();
   }
-
 
   Status GetOutputStructure(const ConstCSRComponent<T>& a,
                             const ConstCSRComponent<T>& b,

--- a/tensorflow/core/kernels/sparse/kernels.h
+++ b/tensorflow/core/kernels/sparse/kernels.h
@@ -167,13 +167,19 @@ struct CSRStructureModifyingFunctor {
 
   virtual Status Initialize() = 0;
 
+  virtual Status GetWorkspaceSize(const ConstCSRComponent<T>& a,
+                                  const ConstCSRComponent<T>& b,
+                                  size_t* bufferSize) = 0;
+
   virtual Status GetOutputStructure(const ConstCSRComponent<T>& a,
                                     const ConstCSRComponent<T>& b,
                                     TTypes<int32>::UnalignedVec c_row_ptr,
-                                    int* output_nnz) = 0;
+                                    int* output_nnz,
+                                    void* workspace) = 0;
 
   virtual Status Compute(const ConstCSRComponent<T>& a,
-                         const ConstCSRComponent<T>& b, CSRComponent<T>* c) = 0;
+                         const ConstCSRComponent<T>& b, CSRComponent<T>* c,
+                         void* workspace) = 0;
 };
 
 // Calculates C = alpha * A + beta * B, where A and B are in CSR

--- a/tensorflow/core/kernels/sparse/kernels.h
+++ b/tensorflow/core/kernels/sparse/kernels.h
@@ -174,8 +174,7 @@ struct CSRStructureModifyingFunctor {
   virtual Status GetOutputStructure(const ConstCSRComponent<T>& a,
                                     const ConstCSRComponent<T>& b,
                                     TTypes<int32>::UnalignedVec c_row_ptr,
-                                    int* output_nnz,
-                                    void* workspace) = 0;
+                                    int* output_nnz, void* workspace) = 0;
 
   virtual Status Compute(const ConstCSRComponent<T>& a,
                          const ConstCSRComponent<T>& b, CSRComponent<T>* c,

--- a/tensorflow/core/kernels/sparse/mat_mul_op.cc
+++ b/tensorflow/core/kernels/sparse/mat_mul_op.cc
@@ -721,6 +721,56 @@ REGISTER_GPU(complex128)
 
 namespace functor {
 
+namespace {
+
+// CUDADataType<T>::type translates from a C++ type (e.g. float) to a
+// cudaDataType_t (e.g. CUDA_R_32F).
+template <typename T>
+struct CUDADataType;
+
+template <>
+struct CUDADataType<Eigen::half> {
+  static constexpr cudaDataType_t type = CUDA_R_16F;
+};
+
+template <>
+struct CUDADataType<float> {
+#if GOOGLE_CUDA
+  static constexpr cudaDataType_t type = CUDA_R_32F;
+#elif TENSORFLOW_USE_ROCM
+  static constexpr cudaDataType_t type = HIPBLAS_R_32F;
+#endif
+};
+
+template <>
+struct CUDADataType<std::complex<float>> {
+#if GOOGLE_CUDA
+  static constexpr cudaDataType_t type = CUDA_C_32F;
+#elif TENSORFLOW_USE_ROCM
+  static constexpr cudaDataType_t type = HIPBLAS_C_32F;
+#endif
+};
+
+template <>
+struct CUDADataType<double> {
+#if GOOGLE_CUDA
+  static constexpr cudaDataType_t type = CUDA_R_64F;
+#elif TENSORFLOW_USE_ROCM
+  static constexpr cudaDataType_t type = HIPBLAS_R_64F;
+#endif
+};
+
+template <>
+struct CUDADataType<std::complex<double>> {
+#if GOOGLE_CUDA
+  static constexpr cudaDataType_t type = CUDA_C_64F;
+#elif TENSORFLOW_USE_ROCM
+  static constexpr cudaDataType_t type = HIPBLAS_C_64F;
+#endif
+};
+
+}  // namespace
+
 template <typename T>
 class CSRSparseMatrixMatMul<GPUDevice, T> {
  public:
@@ -733,10 +783,10 @@ class CSRSparseMatrixMatMul<GPUDevice, T> {
     GpuSparse cuda_sparse(ctx);
     TF_RETURN_IF_ERROR(cuda_sparse.Initialize());
     {
-      // Use Csrmm to calculate:
+      // Use Csrmm/SpMM to calculate:
       //   C = alpha * op(A) * op(B) + beta * C
       // where alpha = 1.0, beta = 0.0, A is sparse and B and C are dense.
-      // Note that Csrmm assumes B and C are in column-major form; so we
+      // Note that Csrmm/Spmm assumes B and C are in column-major form; so we
       // use transB == true, and manually transpose the output in place
       // using blas<t>geam.
       // TODO(ebrevdo,rmlarsen): Add support for transposition and adjoint.
@@ -745,37 +795,6 @@ class CSRSparseMatrixMatMul<GPUDevice, T> {
       // TODO(ebrevdo,rmlarsen): Add support for non-trivial alpha and beta.
       const T alpha = 1;
       const T beta = 0;
-
-      // transA must be non-transpose if transB is transpose (cusparse
-      // limitation).
-#if GOOGLE_CUDA
-      const gpusparseOperation_t transA = CUSPARSE_OPERATION_NON_TRANSPOSE;
-#elif TENSORFLOW_USE_ROCM
-      const gpusparseOperation_t transA = HIPSPARSE_OPERATION_NON_TRANSPOSE;
-#endif
-
-      // transB: b is row-major, and cusparse requires col-major b (or
-      // equivalently transB == transpose).  this version is actually more
-      // efficient.
-#if GOOGLE_CUDA
-      const gpusparseOperation_t transB = CUSPARSE_OPERATION_TRANSPOSE;
-
-      gpusparseMatDescr_t descrA;
-      TF_RETURN_IF_GPUSPARSE_ERROR(cusparseCreateMatDescr(&descrA));
-      TF_RETURN_IF_GPUSPARSE_ERROR(
-          cusparseSetMatType(descrA, CUSPARSE_MATRIX_TYPE_GENERAL));
-      TF_RETURN_IF_GPUSPARSE_ERROR(
-          cusparseSetMatIndexBase(descrA, CUSPARSE_INDEX_BASE_ZERO));
-#elif TENSORFLOW_USE_ROCM
-      const gpusparseOperation_t transB = HIPSPARSE_OPERATION_TRANSPOSE;
-
-      gpusparseMatDescr_t descrA;
-      TF_RETURN_IF_GPUSPARSE_ERROR(hipsparseCreateMatDescr(&descrA));
-      TF_RETURN_IF_GPUSPARSE_ERROR(
-          hipsparseSetMatType(descrA, HIPSPARSE_MATRIX_TYPE_GENERAL));
-      TF_RETURN_IF_GPUSPARSE_ERROR(
-          hipsparseSetMatIndexBase(descrA, HIPSPARSE_INDEX_BASE_ZERO));
-#endif
 
       // A is (m, k), Bt is (ldb, k) and Ct is (ldc, n)
       const int k = b.dimension(0);
@@ -801,10 +820,90 @@ class CSRSparseMatrixMatMul<GPUDevice, T> {
       // op(A) = A and at least max(1, k) otherwise.
       const int ldc = m;
 
+      // transA must be non-transpose if transB is transpose (cusparse
+      // limitation).
+#if GOOGLE_CUDA
+      const gpusparseOperation_t transA = CUSPARSE_OPERATION_NON_TRANSPOSE;
+#elif TENSORFLOW_USE_ROCM
+      const gpusparseOperation_t transA = HIPSPARSE_OPERATION_NON_TRANSPOSE;
+#endif
+
+      // transB: b is row-major, and cusparse requires col-major b (or
+      // equivalently transB == transpose).  this version is actually more
+      // efficient.
+#if GOOGLE_CUDA && CUDA_VERSION >= 10020
+
+      const gpusparseOperation_t transB = CUSPARSE_OPERATION_TRANSPOSE;
+      gpusparseSpMatDescr_t matA;
+      gpusparseDnMatDescr_t matB, matC;
+
+      // NOTE: the following APIs are not available in ROCM
+      TF_RETURN_IF_GPUSPARSE_ERROR(cusparseCreateCsr(&matA, m, k, nnz,
+                                  const_cast<int*>(a.row_ptr.data()),
+                                  const_cast<int*>(a.col_ind.data()),
+                                  const_cast<T*>(a.values.data()),
+                                  CUSPARSE_INDEX_32I, CUSPARSE_INDEX_32I,
+                                  CUSPARSE_INDEX_BASE_ZERO, CUDADataType<T>::type));
+
+      TF_RETURN_IF_GPUSPARSE_ERROR(cusparseCreateDnMat(&matB, n, k, ldb,
+                                  const_cast<T*>(b.data()),
+                                  CUDADataType<T>::type, CUSPARSE_ORDER_COL));
+
+      TF_RETURN_IF_GPUSPARSE_ERROR(cusparseCreateDnMat(&matC, m, n, ldc, c.data(),
+                                  CUDADataType<T>::type, CUSPARSE_ORDER_COL));
+
+      size_t bufferSize = 0;
+      TF_RETURN_IF_ERROR(
+          cuda_sparse.SpMMBufferSize(transA, transB, &alpha, matA, matB, &beta,
+                                     matC, CUSPARSE_MM_ALG_DEFAULT,
+                                     &bufferSize));
+
+      Tensor buffer;
+      TF_RETURN_IF_ERROR(ctx->allocate_temp(DT_INT8, {bufferSize}, &buffer));
+      DCHECK(buffer.flat<int8>().data() != nullptr);
+
+      TF_RETURN_IF_ERROR(
+          cuda_sparse.SpMM(transA, transB, &alpha, matA, matB, &beta,
+                           matC, CUSPARSE_MM_ALG_DEFAULT,
+                           buffer.flat<int8>().data()));
+
+      TF_RETURN_IF_GPUSPARSE_ERROR(cusparseDestroyDnMat(matB));
+      TF_RETURN_IF_GPUSPARSE_ERROR(cusparseDestroyDnMat(matC));
+      TF_RETURN_IF_GPUSPARSE_ERROR(cusparseDestroySpMat(matA));
+
+#else
+
+#if GOOGLE_CUDA
+
+      const gpusparseOperation_t transB = CUSPARSE_OPERATION_TRANSPOSE;
+
+      gpusparseMatDescr_t descrA;
+      TF_RETURN_IF_GPUSPARSE_ERROR(cusparseCreateMatDescr(&descrA));
+      TF_RETURN_IF_GPUSPARSE_ERROR(
+          cusparseSetMatType(descrA, CUSPARSE_MATRIX_TYPE_GENERAL));
+      TF_RETURN_IF_GPUSPARSE_ERROR(
+          cusparseSetMatIndexBase(descrA, CUSPARSE_INDEX_BASE_ZERO));
+
+#elif TENSORFLOW_USE_ROCM
+
+      const gpusparseOperation_t transB = HIPSPARSE_OPERATION_TRANSPOSE;
+
+      gpusparseMatDescr_t descrA;
+      TF_RETURN_IF_GPUSPARSE_ERROR(hipsparseCreateMatDescr(&descrA));
+      TF_RETURN_IF_GPUSPARSE_ERROR(
+          hipsparseSetMatType(descrA, HIPSPARSE_MATRIX_TYPE_GENERAL));
+      TF_RETURN_IF_GPUSPARSE_ERROR(
+          hipsparseSetMatIndexBase(descrA, HIPSPARSE_INDEX_BASE_ZERO));
+#endif  // GOOGLE_CUDA
+
+
       TF_RETURN_IF_ERROR(
           cuda_sparse.Csrmm(transA, transB, m, n, k, nnz, &alpha, descrA,
                             a.values.data(), a.row_ptr.data(), a.col_ind.data(),
                             b.data(), ldb, &beta, c.data(), ldc));
+
+#endif  // GOOGLE_CUDA && CUDA_VERSION >= 10020
+
     }
 
     return Status::OK();

--- a/tensorflow/core/kernels/sparse/mat_mul_op.cc
+++ b/tensorflow/core/kernels/sparse/mat_mul_op.cc
@@ -859,7 +859,8 @@ class CSRSparseMatrixMatMul<GPUDevice, T> {
                                      &bufferSize));
 
       Tensor buffer;
-      TF_RETURN_IF_ERROR(ctx->allocate_temp(DT_INT8, {bufferSize}, &buffer));
+      TF_RETURN_IF_ERROR(ctx->allocate_temp(
+          DT_INT8, TensorShape({static_cast<int64>(bufferSize)}), &buffer));
       DCHECK(buffer.flat<int8>().data() != nullptr);
 
       TF_RETURN_IF_ERROR(

--- a/tensorflow/core/kernels/sparse/sparse_mat_mul_op.cc
+++ b/tensorflow/core/kernels/sparse/sparse_mat_mul_op.cc
@@ -437,8 +437,10 @@ class CSRSparseMatMulGPUOp : public OpKernel {
     }
 
     Tensor temp;
-    OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_INT8, {maxWorkspaceSize},
-                                           &temp));
+    OP_REQUIRES_OK(
+        ctx, ctx->allocate_temp(
+                 DT_INT8, TensorShape({static_cast<int64>(maxWorkspaceSize)}),
+                 &temp));
     void* workspace = temp.flat<int8>().data();
 #else
     void* workspace = nullptr;

--- a/tensorflow/core/kernels/sparse/sparse_mat_mul_op.cc
+++ b/tensorflow/core/kernels/sparse/sparse_mat_mul_op.cc
@@ -462,9 +462,9 @@ class CSRSparseMatMulGPUOp : public OpKernel {
                                               rows + 1);
 
       int c_nnz_i;
-      OP_REQUIRES_OK(ctx, csr_gemm.GetOutputStructure(a_comp, b_comp,
-                                                      c_row_ptr_i, &c_nnz_i,
-                                                      workspace));
+      OP_REQUIRES_OK(ctx,
+                     csr_gemm.GetOutputStructure(a_comp, b_comp, c_row_ptr_i,
+                                                 &c_nnz_i, workspace));
       c_batch_ptr(i + 1) = c_batch_ptr(i) + c_nnz_i;
     }
 
@@ -604,8 +604,7 @@ struct CSRSparseSparseMatrixMatMul<GPUDevice, T>
   }
 
   Status GetWorkspaceSize(const ConstCSRComponent<T>& a,
-                          const ConstCSRComponent<T>& b,
-                          size_t* bufferSize) {
+                          const ConstCSRComponent<T>& b, size_t* bufferSize) {
     DCHECK(initialized_);
     const int m =
         a.dense_shape_host(a.dense_shape_host.size() - (transpose_a_ ? 1 : 2));
@@ -624,9 +623,9 @@ struct CSRSparseSparseMatrixMatMul<GPUDevice, T>
         b.dense_shape_host(b.dense_shape_host.size() - (transpose_b_ ? 2 : 1));
 
     TF_RETURN_IF_ERROR(cuda_sparse_.CsrgemmBufferSize<T>(
-        m, n, k, descrA_.descr(), nnzA, a.row_ptr.data(),
-        a.col_ind.data(), descrB_.descr(), nnzB, b.row_ptr.data(),
-        b.col_ind.data(), info_, bufferSize));
+        m, n, k, descrA_.descr(), nnzA, a.row_ptr.data(), a.col_ind.data(),
+        descrB_.descr(), nnzB, b.row_ptr.data(), b.col_ind.data(), info_,
+        bufferSize));
 
     return Status::OK();
   }
@@ -663,10 +662,9 @@ struct CSRSparseSparseMatrixMatMul<GPUDevice, T>
         b.col_ind.data(), descrC_.descr(), c_row_ptr.data(), output_nnz));
 #else
     TF_RETURN_IF_ERROR(cuda_sparse_.CsrgemmNnz(
-        m, n, k, descrA_.descr(), nnzA, a.row_ptr.data(),
-        a.col_ind.data(), descrB_.descr(), nnzB, b.row_ptr.data(),
-        b.col_ind.data(), descrC_.descr(), c_row_ptr.data(), output_nnz,
-        info_, workspace));
+        m, n, k, descrA_.descr(), nnzA, a.row_ptr.data(), a.col_ind.data(),
+        descrB_.descr(), nnzB, b.row_ptr.data(), b.col_ind.data(),
+        descrC_.descr(), c_row_ptr.data(), output_nnz, info_, workspace));
 #endif
 
     if (*output_nnz < 0) {
@@ -708,11 +706,10 @@ struct CSRSparseSparseMatrixMatMul<GPUDevice, T>
         c->values.data(), c->row_ptr.data(), c->col_ind.data()));
 #else
     TF_RETURN_IF_ERROR(cuda_sparse_.Csrgemm(
-        m, n, k, descrA_.descr(), nnzA, a.values.data(),
-        a.row_ptr.data(), a.col_ind.data(), descrB_.descr(), nnzB,
-        b.values.data(), b.row_ptr.data(), b.col_ind.data(),
-        descrC_.descr(), c->values.data(), c->row_ptr.data(), c->col_ind.data(),
-        info_, workspace));
+        m, n, k, descrA_.descr(), nnzA, a.values.data(), a.row_ptr.data(),
+        a.col_ind.data(), descrB_.descr(), nnzB, b.values.data(),
+        b.row_ptr.data(), b.col_ind.data(), descrC_.descr(), c->values.data(),
+        c->row_ptr.data(), c->col_ind.data(), info_, workspace));
 #endif
 
     // TODO(ebrevdo): Add a flag to CSRSparseMatrix whether matrix

--- a/tensorflow/stream_executor/cuda/cusparse_10_1.inc
+++ b/tensorflow/stream_executor/cuda/cusparse_10_1.inc
@@ -1,5803 +1,6675 @@
 // Auto-generated, do not edit.
 
 extern "C" {
-
 cusparseStatus_t CUSPARSEAPI cusparseCreate(cusparseHandle_t *handle) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreate");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDestroy(cusparseHandle_t handle) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroy");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseGetVersion(cusparseHandle_t handle,
-                                                int *version) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseGetVersion(cusparseHandle_t handle, int *version) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseGetVersion");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, version);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseGetProperty(libraryPropertyType type,
-                                                 int *value) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(libraryPropertyType, int *);
+cusparseStatus_t CUSPARSEAPI cusparseGetProperty(libraryPropertyType type, int *value) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(libraryPropertyType, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseGetProperty");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(type, value);
 }
 
-const char *CUSPARSEAPI cusparseGetErrorName(cusparseStatus_t status) {
-  using FuncPtr = const char *(CUSPARSEAPI *)(cusparseStatus_t);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseGetErrorName");
-  if (!func_ptr) return "cusparseGetErrorName symbol not found.";
-  return func_ptr(status);
-}
-
-const char *CUSPARSEAPI cusparseGetErrorString(cusparseStatus_t status) {
-  using FuncPtr = const char *(CUSPARSEAPI *)(cusparseStatus_t);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseGetErrorString");
-  if (!func_ptr) return "cusparseGetErrorString symbol not found.";
-  return func_ptr(status);
-}
-
-cusparseStatus_t CUSPARSEAPI cusparseSetStream(cusparseHandle_t handle,
-                                               cudaStream_t streamId) {
-  using FuncPtr =
-      cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, cudaStream_t);
+cusparseStatus_t CUSPARSEAPI cusparseSetStream(cusparseHandle_t handle, cudaStream_t streamId) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cudaStream_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSetStream");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, streamId);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseGetStream(cusparseHandle_t handle,
-                                               cudaStream_t *streamId) {
-  using FuncPtr =
-      cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, cudaStream_t *);
+cusparseStatus_t CUSPARSEAPI cusparseGetStream(cusparseHandle_t handle, cudaStream_t *streamId) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cudaStream_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseGetStream");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, streamId);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseGetPointerMode(cusparseHandle_t handle, cusparsePointerMode_t *mode) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t,
-                                                  cusparsePointerMode_t *);
+cusparseStatus_t CUSPARSEAPI cusparseGetPointerMode(cusparseHandle_t handle, cusparsePointerMode_t *mode) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparsePointerMode_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseGetPointerMode");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, mode);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseSetPointerMode(cusparseHandle_t handle, cusparsePointerMode_t mode) {
-  using FuncPtr =
-      cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, cusparsePointerMode_t);
+cusparseStatus_t CUSPARSEAPI cusparseSetPointerMode(cusparseHandle_t handle, cusparsePointerMode_t mode) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparsePointerMode_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSetPointerMode");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, mode);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseCreateMatDescr(cusparseMatDescr_t *descrA) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseMatDescr_t *);
+cusparseStatus_t CUSPARSEAPI cusparseCreateMatDescr(cusparseMatDescr_t *descrA) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseMatDescr_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateMatDescr");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(descrA);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseDestroyMatDescr(cusparseMatDescr_t descrA) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseMatDescr_t);
+cusparseStatus_t CUSPARSEAPI cusparseDestroyMatDescr (cusparseMatDescr_t descrA) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseMatDescr_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyMatDescr");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(descrA);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseCopyMatDescr(cusparseMatDescr_t dest, const cusparseMatDescr_t src) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseMatDescr_t,
-                                                  const cusparseMatDescr_t);
+cusparseStatus_t CUSPARSEAPI cusparseCopyMatDescr(cusparseMatDescr_t dest, const cusparseMatDescr_t src) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseMatDescr_t, const cusparseMatDescr_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCopyMatDescr");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(dest, src);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSetMatType(cusparseMatDescr_t descrA,
-                                                cusparseMatrixType_t type) {
-  using FuncPtr =
-      cusparseStatus_t(CUSPARSEAPI *)(cusparseMatDescr_t, cusparseMatrixType_t);
+cusparseStatus_t CUSPARSEAPI cusparseSetMatType(cusparseMatDescr_t descrA, cusparseMatrixType_t type) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseMatDescr_t, cusparseMatrixType_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSetMatType");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(descrA, type);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseSetMatFillMode(cusparseMatDescr_t descrA, cusparseFillMode_t fillMode) {
-  using FuncPtr =
-      cusparseStatus_t(CUSPARSEAPI *)(cusparseMatDescr_t, cusparseFillMode_t);
+cusparseStatus_t CUSPARSEAPI cusparseSetMatFillMode(cusparseMatDescr_t descrA, cusparseFillMode_t fillMode) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseMatDescr_t, cusparseFillMode_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSetMatFillMode");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(descrA, fillMode);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseSetMatDiagType(cusparseMatDescr_t descrA, cusparseDiagType_t diagType) {
-  using FuncPtr =
-      cusparseStatus_t(CUSPARSEAPI *)(cusparseMatDescr_t, cusparseDiagType_t);
+cusparseStatus_t CUSPARSEAPI cusparseSetMatDiagType(cusparseMatDescr_t  descrA, cusparseDiagType_t diagType) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseMatDescr_t, cusparseDiagType_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSetMatDiagType");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(descrA, diagType);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSetMatIndexBase(cusparseMatDescr_t descrA,
-                                                     cusparseIndexBase_t base) {
-  using FuncPtr =
-      cusparseStatus_t(CUSPARSEAPI *)(cusparseMatDescr_t, cusparseIndexBase_t);
+cusparseStatus_t CUSPARSEAPI cusparseSetMatIndexBase(cusparseMatDescr_t descrA, cusparseIndexBase_t base) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseMatDescr_t, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSetMatIndexBase");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(descrA, base);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseCreateSolveAnalysisInfo(cusparseSolveAnalysisInfo_t *info) {
-  using FuncPtr =
-      cusparseStatus_t(CUSPARSEAPI *)(cusparseSolveAnalysisInfo_t *);
+cusparseStatus_t CUSPARSEAPI cusparseCreateSolveAnalysisInfo(cusparseSolveAnalysisInfo_t *info) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseSolveAnalysisInfo_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateSolveAnalysisInfo");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseDestroySolveAnalysisInfo(cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseSolveAnalysisInfo_t);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseDestroySolveAnalysisInfo");
+cusparseStatus_t CUSPARSEAPI cusparseDestroySolveAnalysisInfo(cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseSolveAnalysisInfo_t);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroySolveAnalysisInfo");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseGetLevelInfo(cusparseHandle_t handle, cusparseSolveAnalysisInfo_t info,
-                     int *nlevels, int **levelPtr, int **levelInd) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseSolveAnalysisInfo_t, int *, int **, int **);
+cusparseStatus_t CUSPARSEAPI cusparseGetLevelInfo(cusparseHandle_t handle,
+                                                  cusparseSolveAnalysisInfo_t info,
+                                                  int *nlevels,
+                                                  int **levelPtr,
+                                                  int **levelInd) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseSolveAnalysisInfo_t, int *, int **, int **);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseGetLevelInfo");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, nlevels, levelPtr, levelInd);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCreateCsrsv2Info(csrsv2Info_t *info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(csrsv2Info_t *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(csrsv2Info_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateCsrsv2Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDestroyCsrsv2Info(csrsv2Info_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(csrsv2Info_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(csrsv2Info_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyCsrsv2Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCreateCsric02Info(csric02Info_t *info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(csric02Info_t *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(csric02Info_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateCsric02Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDestroyCsric02Info(csric02Info_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(csric02Info_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(csric02Info_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyCsric02Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCreateBsric02Info(bsric02Info_t *info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(bsric02Info_t *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(bsric02Info_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateBsric02Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDestroyBsric02Info(bsric02Info_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(bsric02Info_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(bsric02Info_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyBsric02Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCreateCsrilu02Info(csrilu02Info_t *info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(csrilu02Info_t *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(csrilu02Info_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateCsrilu02Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDestroyCsrilu02Info(csrilu02Info_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(csrilu02Info_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(csrilu02Info_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyCsrilu02Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCreateBsrilu02Info(bsrilu02Info_t *info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(bsrilu02Info_t *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(bsrilu02Info_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateBsrilu02Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDestroyBsrilu02Info(bsrilu02Info_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(bsrilu02Info_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(bsrilu02Info_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyBsrilu02Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCreateBsrsv2Info(bsrsv2Info_t *info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(bsrsv2Info_t *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(bsrsv2Info_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateBsrsv2Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDestroyBsrsv2Info(bsrsv2Info_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(bsrsv2Info_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(bsrsv2Info_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyBsrsv2Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCreateBsrsm2Info(bsrsm2Info_t *info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(bsrsm2Info_t *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(bsrsm2Info_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateBsrsm2Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDestroyBsrsm2Info(bsrsm2Info_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(bsrsm2Info_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(bsrsm2Info_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyBsrsm2Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCreateHybMat(cusparseHybMat_t *hybA) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseHybMat_t *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHybMat_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateHybMat");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(hybA);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDestroyHybMat(cusparseHybMat_t hybA) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseHybMat_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHybMat_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyHybMat");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(hybA);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCreateCsru2csrInfo(csru2csrInfo_t *info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(csru2csrInfo_t *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(csru2csrInfo_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateCsru2csrInfo");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDestroyCsru2csrInfo(csru2csrInfo_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(csru2csrInfo_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(csru2csrInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyCsru2csrInfo");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseCreateColorInfo(cusparseColorInfo_t *info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseColorInfo_t *);
+cusparseStatus_t CUSPARSEAPI cusparseCreateColorInfo(cusparseColorInfo_t *info) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseColorInfo_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateColorInfo");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseDestroyColorInfo(cusparseColorInfo_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseColorInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseDestroyColorInfo(cusparseColorInfo_t info) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseColorInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyColorInfo");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSetColorAlgs(cusparseColorInfo_t info,
-                                                  cusparseColorAlg_t alg) {
-  using FuncPtr =
-      cusparseStatus_t(CUSPARSEAPI *)(cusparseColorInfo_t, cusparseColorAlg_t);
+cusparseStatus_t CUSPARSEAPI cusparseSetColorAlgs(cusparseColorInfo_t info, cusparseColorAlg_t alg) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseColorInfo_t, cusparseColorAlg_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSetColorAlgs");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info, alg);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseGetColorAlgs(cusparseColorInfo_t info,
-                                                  cusparseColorAlg_t *alg) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseColorInfo_t,
-                                                  cusparseColorAlg_t *);
+cusparseStatus_t CUSPARSEAPI cusparseGetColorAlgs(cusparseColorInfo_t info, cusparseColorAlg_t *alg) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseColorInfo_t, cusparseColorAlg_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseGetColorAlgs");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info, alg);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCreatePruneInfo(pruneInfo_t *info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(pruneInfo_t *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(pruneInfo_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreatePruneInfo");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDestroyPruneInfo(pruneInfo_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(pruneInfo_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(pruneInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyPruneInfo");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSaxpyi(cusparseHandle_t handle, int nnz,
+cusparseStatus_t CUSPARSEAPI cusparseSaxpyi(cusparseHandle_t handle,
+                                            int nnz,
                                             const float *alpha,
-                                            const float *xVal, const int *xInd,
+                                            const float *xVal,
+                                            const int *xInd,
                                             float *y,
                                             cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const float *, const float *, const int *, float *,
-      cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const float *, const float *, const int *, float *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSaxpyi");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, alpha, xVal, xInd, y, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDaxpyi(cusparseHandle_t handle, int nnz,
+cusparseStatus_t CUSPARSEAPI cusparseDaxpyi(cusparseHandle_t handle,
+                                            int nnz,
                                             const double *alpha,
-                                            const double *xVal, const int *xInd,
+                                            const double *xVal,
+                                            const int *xInd,
                                             double *y,
                                             cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const double *, const double *, const int *,
-      double *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const double *, const double *, const int *, double *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDaxpyi");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, alpha, xVal, xInd, y, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCaxpyi(cusparseHandle_t handle, int nnz,
+cusparseStatus_t CUSPARSEAPI cusparseCaxpyi(cusparseHandle_t handle,
+                                            int nnz,
                                             const cuComplex *alpha,
                                             const cuComplex *xVal,
-                                            const int *xInd, cuComplex *y,
+                                            const int *xInd,
+                                            cuComplex *y,
                                             cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const cuComplex *, const cuComplex *, const int *,
-      cuComplex *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuComplex *, const cuComplex *, const int *, cuComplex *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCaxpyi");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, alpha, xVal, xInd, y, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZaxpyi(cusparseHandle_t handle, int nnz,
+cusparseStatus_t CUSPARSEAPI cusparseZaxpyi(cusparseHandle_t handle,
+                                            int nnz,
                                             const cuDoubleComplex *alpha,
                                             const cuDoubleComplex *xVal,
-                                            const int *xInd, cuDoubleComplex *y,
+                                            const int *xInd,
+                                            cuDoubleComplex *y,
                                             cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const cuDoubleComplex *, const cuDoubleComplex *,
-      const int *, cuDoubleComplex *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuDoubleComplex *, const cuDoubleComplex *, const int *, cuDoubleComplex *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZaxpyi");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, alpha, xVal, xInd, y, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSdoti(cusparseHandle_t handle, int nnz,
-                                           const float *xVal, const int *xInd,
+cusparseStatus_t CUSPARSEAPI cusparseSdoti(cusparseHandle_t handle,
+                                           int nnz,
+                                           const float *xVal,
+                                           const int *xInd,
                                            const float *y,
                                            float *resultDevHostPtr,
                                            cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const float *, const int *, const float *, float *,
-      cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const float *, const int *, const float *, float *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSdoti");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, xVal, xInd, y, resultDevHostPtr, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDdoti(cusparseHandle_t handle, int nnz,
-                                           const double *xVal, const int *xInd,
+cusparseStatus_t CUSPARSEAPI cusparseDdoti(cusparseHandle_t handle,
+                                           int nnz,
+                                           const double *xVal,
+                                           const int *xInd,
                                            const double *y,
                                            double *resultDevHostPtr,
                                            cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const double *, const int *, const double *,
-      double *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const double *, const int *, const double *, double *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDdoti");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, xVal, xInd, y, resultDevHostPtr, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCdoti(cusparseHandle_t handle, int nnz,
+cusparseStatus_t CUSPARSEAPI cusparseCdoti(cusparseHandle_t handle,
+                                           int nnz,
                                            const cuComplex *xVal,
-                                           const int *xInd, const cuComplex *y,
+                                           const int *xInd,
+                                           const cuComplex *y,
                                            cuComplex *resultDevHostPtr,
                                            cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const cuComplex *, const int *, const cuComplex *,
-      cuComplex *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuComplex *, const int *, const cuComplex *, cuComplex *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCdoti");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, xVal, xInd, y, resultDevHostPtr, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZdoti(cusparseHandle_t handle, int nnz,
+cusparseStatus_t CUSPARSEAPI cusparseZdoti(cusparseHandle_t handle,
+                                           int nnz,
                                            const cuDoubleComplex *xVal,
                                            const int *xInd,
                                            const cuDoubleComplex *y,
                                            cuDoubleComplex *resultDevHostPtr,
                                            cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const cuDoubleComplex *, const int *,
-      const cuDoubleComplex *, cuDoubleComplex *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuDoubleComplex *, const int *, const cuDoubleComplex *, cuDoubleComplex *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZdoti");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, xVal, xInd, y, resultDevHostPtr, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCdotci(cusparseHandle_t handle, int nnz,
+cusparseStatus_t CUSPARSEAPI cusparseCdotci(cusparseHandle_t handle,
+                                            int nnz,
                                             const cuComplex *xVal,
-                                            const int *xInd, const cuComplex *y,
+                                            const int *xInd,
+                                            const cuComplex *y,
                                             cuComplex *resultDevHostPtr,
                                             cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const cuComplex *, const int *, const cuComplex *,
-      cuComplex *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuComplex *, const int *, const cuComplex *, cuComplex *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCdotci");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, xVal, xInd, y, resultDevHostPtr, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZdotci(cusparseHandle_t handle, int nnz,
+cusparseStatus_t CUSPARSEAPI cusparseZdotci(cusparseHandle_t handle,
+                                            int nnz,
                                             const cuDoubleComplex *xVal,
                                             const int *xInd,
                                             const cuDoubleComplex *y,
                                             cuDoubleComplex *resultDevHostPtr,
                                             cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const cuDoubleComplex *, const int *,
-      const cuDoubleComplex *, cuDoubleComplex *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuDoubleComplex *, const int *, const cuDoubleComplex *, cuDoubleComplex *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZdotci");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, xVal, xInd, y, resultDevHostPtr, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSgthr(cusparseHandle_t handle, int nnz,
-                                           const float *y, float *xVal,
+cusparseStatus_t CUSPARSEAPI cusparseSgthr(cusparseHandle_t handle,
+                                           int nnz,
+                                           const float *y,
+                                           float *xVal,
                                            const int *xInd,
                                            cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const float *, float *, const int *,
-      cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const float *, float *, const int *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgthr");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, y, xVal, xInd, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDgthr(cusparseHandle_t handle, int nnz,
-                                           const double *y, double *xVal,
+cusparseStatus_t CUSPARSEAPI cusparseDgthr(cusparseHandle_t handle,
+                                           int nnz,
+                                           const double *y,
+                                           double *xVal,
                                            const int *xInd,
                                            cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const double *, double *, const int *,
-      cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const double *, double *, const int *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgthr");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, y, xVal, xInd, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCgthr(cusparseHandle_t handle, int nnz,
-                                           const cuComplex *y, cuComplex *xVal,
+cusparseStatus_t CUSPARSEAPI cusparseCgthr(cusparseHandle_t handle,
+                                           int nnz,
+                                           const cuComplex *y,
+                                           cuComplex *xVal,
                                            const int *xInd,
                                            cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const cuComplex *, cuComplex *, const int *,
-      cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuComplex *, cuComplex *, const int *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgthr");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, y, xVal, xInd, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZgthr(cusparseHandle_t handle, int nnz,
+cusparseStatus_t CUSPARSEAPI cusparseZgthr(cusparseHandle_t handle,
+                                           int nnz,
                                            const cuDoubleComplex *y,
                                            cuDoubleComplex *xVal,
                                            const int *xInd,
                                            cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const cuDoubleComplex *, cuDoubleComplex *,
-      const int *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuDoubleComplex *, cuDoubleComplex *, const int *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgthr");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, y, xVal, xInd, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSgthrz(cusparseHandle_t handle, int nnz,
-                                            float *y, float *xVal,
+cusparseStatus_t CUSPARSEAPI cusparseSgthrz(cusparseHandle_t handle,
+                                            int nnz,
+                                            float *y,
+                                            float *xVal,
                                             const int *xInd,
                                             cusparseIndexBase_t idxBase) {
-  using FuncPtr =
-      cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, int, float *, float *,
-                                      const int *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, float *, float *, const int *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgthrz");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, y, xVal, xInd, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDgthrz(cusparseHandle_t handle, int nnz,
-                                            double *y, double *xVal,
+cusparseStatus_t CUSPARSEAPI cusparseDgthrz(cusparseHandle_t handle,
+                                            int nnz,
+                                            double *y,
+                                            double *xVal,
                                             const int *xInd,
                                             cusparseIndexBase_t idxBase) {
-  using FuncPtr =
-      cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, int, double *, double *,
-                                      const int *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, double *, double *, const int *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgthrz");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, y, xVal, xInd, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCgthrz(cusparseHandle_t handle, int nnz,
-                                            cuComplex *y, cuComplex *xVal,
+cusparseStatus_t CUSPARSEAPI cusparseCgthrz(cusparseHandle_t handle,
+                                            int nnz,
+                                            cuComplex *y,
+                                            cuComplex *xVal,
                                             const int *xInd,
                                             cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, cuComplex *, cuComplex *, const int *,
-      cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, cuComplex *, cuComplex *, const int *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgthrz");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, y, xVal, xInd, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZgthrz(cusparseHandle_t handle, int nnz,
+cusparseStatus_t CUSPARSEAPI cusparseZgthrz(cusparseHandle_t handle,
+                                            int nnz,
                                             cuDoubleComplex *y,
                                             cuDoubleComplex *xVal,
                                             const int *xInd,
                                             cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, cuDoubleComplex *, cuDoubleComplex *, const int *,
-      cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, cuDoubleComplex *, cuDoubleComplex *, const int *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgthrz");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, y, xVal, xInd, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSsctr(cusparseHandle_t handle, int nnz,
-                                           const float *xVal, const int *xInd,
+cusparseStatus_t CUSPARSEAPI cusparseSsctr(cusparseHandle_t handle,
+                                           int nnz,
+                                           const float *xVal,
+                                           const int *xInd,
                                            float *y,
                                            cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, int,
-                                                  const float *, const int *,
-                                                  float *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const float *, const int *, float *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSsctr");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, xVal, xInd, y, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDsctr(cusparseHandle_t handle, int nnz,
-                                           const double *xVal, const int *xInd,
+cusparseStatus_t CUSPARSEAPI cusparseDsctr(cusparseHandle_t handle,
+                                           int nnz,
+                                           const double *xVal,
+                                           const int *xInd,
                                            double *y,
                                            cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const double *, const int *, double *,
-      cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const double *, const int *, double *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDsctr");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, xVal, xInd, y, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCsctr(cusparseHandle_t handle, int nnz,
+cusparseStatus_t CUSPARSEAPI cusparseCsctr(cusparseHandle_t handle,
+                                           int nnz,
                                            const cuComplex *xVal,
-                                           const int *xInd, cuComplex *y,
+                                           const int *xInd,
+                                           cuComplex *y,
                                            cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const cuComplex *, const int *, cuComplex *,
-      cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuComplex *, const int *, cuComplex *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCsctr");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, xVal, xInd, y, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZsctr(cusparseHandle_t handle, int nnz,
+cusparseStatus_t CUSPARSEAPI cusparseZsctr(cusparseHandle_t handle,
+                                           int nnz,
                                            const cuDoubleComplex *xVal,
-                                           const int *xInd, cuDoubleComplex *y,
+                                           const int *xInd,
+                                           cuDoubleComplex *y,
                                            cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const cuDoubleComplex *, const int *,
-      cuDoubleComplex *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuDoubleComplex *, const int *, cuDoubleComplex *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZsctr");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, xVal, xInd, y, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSroti(cusparseHandle_t handle, int nnz,
-                                           float *xVal, const int *xInd,
-                                           float *y, const float *c,
-                                           const float *s,
-                                           cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, float *, const int *, float *, const float *,
-      const float *, cusparseIndexBase_t);
+cusparseStatus_t CUSPARSEAPI cusparseSroti(cusparseHandle_t handle,
+                                              int nnz,
+                                              float *xVal,
+                                              const int *xInd,
+                                              float *y,
+                                              const float *c,
+                                              const float *s,
+                                              cusparseIndexBase_t idxBase) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, float *, const int *, float *, const float *, const float *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSroti");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, xVal, xInd, y, c, s, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDroti(cusparseHandle_t handle, int nnz,
-                                           double *xVal, const int *xInd,
-                                           double *y, const double *c,
-                                           const double *s,
-                                           cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, double *, const int *, double *, const double *,
-      const double *, cusparseIndexBase_t);
+cusparseStatus_t CUSPARSEAPI cusparseDroti(cusparseHandle_t handle,
+                                              int nnz,
+                                              double *xVal,
+                                              const int *xInd,
+                                              double *y,
+                                              const double *c,
+                                              const double *s,
+                                              cusparseIndexBase_t idxBase) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, double *, const int *, double *, const double *, const double *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDroti");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, xVal, xInd, y, c, s, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseSgemvi(cusparseHandle_t handle, cusparseOperation_t transA, int m,
-               int n, const float *alpha, const float *A, int lda, int nnz,
-               const float *xVal, const int *xInd, const float *beta, float *y,
-               cusparseIndexBase_t idxBase, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const float *,
-      const float *, int, int, const float *, const int *, const float *,
-      float *, cusparseIndexBase_t, void *);
+cusparseStatus_t  CUSPARSEAPI cusparseSgemvi(cusparseHandle_t handle,
+                                    cusparseOperation_t transA,
+                                    int m,
+                                    int n,
+                                    const float *alpha, /* host or device pointer */
+                                    const float *A,
+                                    int lda,
+                                    int nnz,
+                                    const float *xVal,
+                                    const int *xInd,
+                                    const float *beta, /* host or device pointer */
+                                    float *y,
+                                    cusparseIndexBase_t   idxBase,
+                                    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const float *, const float *, int, int, const float *, const int *, const float *, float *, cusparseIndexBase_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgemvi");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, alpha, A, lda, nnz, xVal, xInd, beta, y,
-                  idxBase, pBuffer);
+  return func_ptr(handle, transA, m, n, alpha, A, lda, nnz, xVal, xInd, beta, y, idxBase, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseSgemvi_bufferSize(cusparseHandle_t handle, cusparseOperation_t transA,
-                          int m, int n, int nnz, int *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, int, int *);
+cusparseStatus_t CUSPARSEAPI cusparseSgemvi_bufferSize( cusparseHandle_t handle,
+    cusparseOperation_t transA,
+    int m,
+    int n,
+    int nnz,
+    int *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgemvi_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, transA, m, n, nnz, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseDgemvi(cusparseHandle_t handle, cusparseOperation_t transA, int m,
-               int n, const double *alpha, const double *A, int lda, int nnz,
-               const double *xVal, const int *xInd, const double *beta,
-               double *y, cusparseIndexBase_t idxBase, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const double *,
-      const double *, int, int, const double *, const int *, const double *,
-      double *, cusparseIndexBase_t, void *);
+cusparseStatus_t  CUSPARSEAPI cusparseDgemvi(cusparseHandle_t handle,
+                                    cusparseOperation_t transA,
+                                    int m,
+                                    int n,
+                                    const double *alpha, /* host or device pointer */
+                                    const double *A,
+                                    int lda,
+                                    int nnz,
+                                    const double *xVal,
+                                    const int *xInd,
+                                    const double *beta, /* host or device pointer */
+                                    double *y,
+                                    cusparseIndexBase_t   idxBase,
+                                    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const double *, const double *, int, int, const double *, const int *, const double *, double *, cusparseIndexBase_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgemvi");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, alpha, A, lda, nnz, xVal, xInd, beta, y,
-                  idxBase, pBuffer);
+  return func_ptr(handle, transA, m, n, alpha, A, lda, nnz, xVal, xInd, beta, y, idxBase, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseDgemvi_bufferSize(cusparseHandle_t handle, cusparseOperation_t transA,
-                          int m, int n, int nnz, int *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, int, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDgemvi_bufferSize( cusparseHandle_t handle,
+    cusparseOperation_t transA,
+    int m,
+    int n,
+    int nnz,
+    int *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgemvi_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, transA, m, n, nnz, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCgemvi(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int n,
-    const cuComplex *alpha, const cuComplex *A, int lda, int nnz,
-    const cuComplex *xVal, const int *xInd, const cuComplex *beta, cuComplex *y,
-    cusparseIndexBase_t idxBase, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const cuComplex *,
-      const cuComplex *, int, int, const cuComplex *, const int *,
-      const cuComplex *, cuComplex *, cusparseIndexBase_t, void *);
+cusparseStatus_t  CUSPARSEAPI cusparseCgemvi(cusparseHandle_t handle,
+                                    cusparseOperation_t transA,
+                                    int m,
+                                    int n,
+                                    const cuComplex *alpha, /* host or device pointer */
+                                    const cuComplex *A,
+                                    int lda,
+                                    int nnz,
+                                    const cuComplex *xVal,
+                                    const int *xInd,
+                                    const cuComplex *beta, /* host or device pointer */
+                                    cuComplex *y,
+                                    cusparseIndexBase_t   idxBase,
+                                    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cuComplex *, const cuComplex *, int, int, const cuComplex *, const int *, const cuComplex *, cuComplex *, cusparseIndexBase_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgemvi");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, alpha, A, lda, nnz, xVal, xInd, beta, y,
-                  idxBase, pBuffer);
+  return func_ptr(handle, transA, m, n, alpha, A, lda, nnz, xVal, xInd, beta, y, idxBase, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseCgemvi_bufferSize(cusparseHandle_t handle, cusparseOperation_t transA,
-                          int m, int n, int nnz, int *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, int, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCgemvi_bufferSize( cusparseHandle_t handle,
+    cusparseOperation_t transA,
+    int m,
+    int n,
+    int nnz,
+    int *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgemvi_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, transA, m, n, nnz, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZgemvi(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int n,
-    const cuDoubleComplex *alpha, const cuDoubleComplex *A, int lda, int nnz,
-    const cuDoubleComplex *xVal, const int *xInd, const cuDoubleComplex *beta,
-    cuDoubleComplex *y, cusparseIndexBase_t idxBase, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const cuDoubleComplex *,
-      const cuDoubleComplex *, int, int, const cuDoubleComplex *, const int *,
-      const cuDoubleComplex *, cuDoubleComplex *, cusparseIndexBase_t, void *);
+cusparseStatus_t  CUSPARSEAPI cusparseZgemvi(cusparseHandle_t handle,
+                                    cusparseOperation_t transA,
+                                    int m,
+                                    int n,
+                                    const cuDoubleComplex *alpha, /* host or device pointer */
+                                    const cuDoubleComplex *A,
+                                    int lda,
+                                    int nnz,
+                                    const cuDoubleComplex *xVal,
+                                    const int *xInd,
+                                    const cuDoubleComplex *beta, /* host or device pointer */
+                                    cuDoubleComplex *y,
+                                    cusparseIndexBase_t   idxBase,
+                                    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cuDoubleComplex *, const cuDoubleComplex *, int, int, const cuDoubleComplex *, const int *, const cuDoubleComplex *, cuDoubleComplex *, cusparseIndexBase_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgemvi");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, alpha, A, lda, nnz, xVal, xInd, beta, y,
-                  idxBase, pBuffer);
+  return func_ptr(handle, transA, m, n, alpha, A, lda, nnz, xVal, xInd, beta, y, idxBase, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseZgemvi_bufferSize(cusparseHandle_t handle, cusparseOperation_t transA,
-                          int m, int n, int nnz, int *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, int, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZgemvi_bufferSize( cusparseHandle_t handle,
+    cusparseOperation_t transA,
+    int m,
+    int n,
+    int nnz,
+    int *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgemvi_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, transA, m, n, nnz, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrmv(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int nnz,
-    const float *alpha, const cusparseMatDescr_t descrA,
-    const float *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, const float *x, const float *beta, float *y) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, int, const float *,
-      const cusparseMatDescr_t, const float *, const int *, const int *,
-      const float *, const float *, float *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrmv(cusparseHandle_t handle,
+                                            cusparseOperation_t transA,
+                                            int m,
+                                            int n,
+                                            int nnz,
+                                            const float *alpha,
+                                            const cusparseMatDescr_t descrA,
+                                            const float *csrSortedValA,
+                                            const int *csrSortedRowPtrA,
+                                            const int *csrSortedColIndA,
+                                            const float *x,
+                                            const float *beta,
+                                            float *y) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, const float *, const float *, float *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrmv");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
+  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseDcsrmv(cusparseHandle_t handle, cusparseOperation_t transA, int m,
-               int n, int nnz, const double *alpha,
-               const cusparseMatDescr_t descrA, const double *csrSortedValA,
-               const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-               const double *x, const double *beta, double *y) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, int, const double *,
-      const cusparseMatDescr_t, const double *, const int *, const int *,
-      const double *, const double *, double *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrmv(cusparseHandle_t handle,
+                                            cusparseOperation_t transA,
+                                            int m,
+                                            int n,
+                                            int nnz,
+                                            const double *alpha,
+                                            const cusparseMatDescr_t descrA,
+                                            const double *csrSortedValA,
+                                            const int *csrSortedRowPtrA,
+                                            const int *csrSortedColIndA,
+                                            const double *x,
+                                            const double *beta,
+                                            double *y) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, const double *, const double *, double *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrmv");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
+  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseCcsrmv(cusparseHandle_t handle, cusparseOperation_t transA, int m,
-               int n, int nnz, const cuComplex *alpha,
-               const cusparseMatDescr_t descrA, const cuComplex *csrSortedValA,
-               const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-               const cuComplex *x, const cuComplex *beta, cuComplex *y) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, int, const cuComplex *,
-      const cusparseMatDescr_t, const cuComplex *, const int *, const int *,
-      const cuComplex *, const cuComplex *, cuComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrmv(cusparseHandle_t handle,
+                                            cusparseOperation_t transA,
+                                            int m,
+                                            int n,
+                                            int nnz,
+                                            const cuComplex *alpha,
+                                            const cusparseMatDescr_t descrA,
+                                            const cuComplex *csrSortedValA,
+                                            const int *csrSortedRowPtrA,
+                                            const int *csrSortedColIndA,
+                                            const cuComplex *x,
+                                            const cuComplex *beta,
+                                            cuComplex *y) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, const cuComplex *, const cuComplex *, cuComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrmv");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
+  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrmv(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int nnz,
-    const cuDoubleComplex *alpha, const cusparseMatDescr_t descrA,
-    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, const cuDoubleComplex *x,
-    const cuDoubleComplex *beta, cuDoubleComplex *y) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, int,
-      const cuDoubleComplex *, const cusparseMatDescr_t,
-      const cuDoubleComplex *, const int *, const int *,
-      const cuDoubleComplex *, const cuDoubleComplex *, cuDoubleComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrmv(cusparseHandle_t handle,
+                                            cusparseOperation_t transA,
+                                            int m,
+                                            int n,
+                                            int nnz,
+                                            const cuDoubleComplex *alpha,
+                                            const cusparseMatDescr_t descrA,
+                                            const cuDoubleComplex *csrSortedValA,
+                                            const int *csrSortedRowPtrA,
+                                            const int *csrSortedColIndA,
+                                            const cuDoubleComplex *x,
+                                            const cuDoubleComplex *beta,
+                                            cuDoubleComplex *y) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, const cuDoubleComplex *, const cuDoubleComplex *, cuDoubleComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrmv");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
+  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCsrmvEx_bufferSize(
-    cusparseHandle_t handle, cusparseAlgMode_t alg, cusparseOperation_t transA,
-    int m, int n, int nnz, const void *alpha, cudaDataType alphatype,
-    const cusparseMatDescr_t descrA, const void *csrValA,
-    cudaDataType csrValAtype, const int *csrRowPtrA, const int *csrColIndA,
-    const void *x, cudaDataType xtype, const void *beta, cudaDataType betatype,
-    void *y, cudaDataType ytype, cudaDataType executiontype,
-    size_t *bufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseAlgMode_t, cusparseOperation_t, int, int, int,
-      const void *, cudaDataType, const cusparseMatDescr_t, const void *,
-      cudaDataType, const int *, const int *, const void *, cudaDataType,
-      const void *, cudaDataType, void *, cudaDataType, cudaDataType, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseCsrmvEx_bufferSize(cusparseHandle_t handle,
+                                                        cusparseAlgMode_t alg,
+                                                        cusparseOperation_t transA,
+                                                        int m,
+                                                        int n,
+                                                        int nnz,
+                                                        const void *alpha,
+                                                        cudaDataType alphatype,
+                                                        const cusparseMatDescr_t descrA,
+                                                        const void *csrValA,
+                                                        cudaDataType csrValAtype,
+                                                        const int *csrRowPtrA,
+                                                        const int *csrColIndA,
+                                                        const void *x,
+                                                        cudaDataType xtype,
+                                                        const void *beta,
+                                                        cudaDataType betatype,
+                                                        void *y,
+                                                        cudaDataType ytype,
+                                                        cudaDataType executiontype,
+                                                        size_t *bufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseAlgMode_t, cusparseOperation_t, int, int, int, const void *, cudaDataType, const cusparseMatDescr_t, const void *, cudaDataType, const int *, const int *, const void *, cudaDataType, const void *, cudaDataType, void *, cudaDataType, cudaDataType, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCsrmvEx_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, alg, transA, m, n, nnz, alpha, alphatype, descrA,
-                  csrValA, csrValAtype, csrRowPtrA, csrColIndA, x, xtype, beta,
-                  betatype, y, ytype, executiontype, bufferSizeInBytes);
+  return func_ptr(handle, alg, transA, m, n, nnz, alpha, alphatype, descrA, csrValA, csrValAtype, csrRowPtrA, csrColIndA, x, xtype, beta, betatype, y, ytype, executiontype, bufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCsrmvEx(
-    cusparseHandle_t handle, cusparseAlgMode_t alg, cusparseOperation_t transA,
-    int m, int n, int nnz, const void *alpha, cudaDataType alphatype,
-    const cusparseMatDescr_t descrA, const void *csrValA,
-    cudaDataType csrValAtype, const int *csrRowPtrA, const int *csrColIndA,
-    const void *x, cudaDataType xtype, const void *beta, cudaDataType betatype,
-    void *y, cudaDataType ytype, cudaDataType executiontype, void *buffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseAlgMode_t, cusparseOperation_t, int, int, int,
-      const void *, cudaDataType, const cusparseMatDescr_t, const void *,
-      cudaDataType, const int *, const int *, const void *, cudaDataType,
-      const void *, cudaDataType, void *, cudaDataType, cudaDataType, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCsrmvEx(cusparseHandle_t handle,
+                                             cusparseAlgMode_t alg,
+                                             cusparseOperation_t transA,
+                                             int m,
+                                             int n,
+                                             int nnz,
+                                             const void *alpha,
+                                             cudaDataType alphatype,
+                                             const cusparseMatDescr_t descrA,
+                                             const void *csrValA,
+                                             cudaDataType csrValAtype,
+                                             const int *csrRowPtrA,
+                                             const int *csrColIndA,
+                                             const void *x,
+                                             cudaDataType xtype,
+                                             const void *beta,
+                                             cudaDataType betatype,
+                                             void *y,
+                                             cudaDataType ytype,
+                                             cudaDataType executiontype,
+                                             void* buffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseAlgMode_t, cusparseOperation_t, int, int, int, const void *, cudaDataType, const cusparseMatDescr_t, const void *, cudaDataType, const int *, const int *, const void *, cudaDataType, const void *, cudaDataType, void *, cudaDataType, cudaDataType, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCsrmvEx");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, alg, transA, m, n, nnz, alpha, alphatype, descrA,
-                  csrValA, csrValAtype, csrRowPtrA, csrColIndA, x, xtype, beta,
-                  betatype, y, ytype, executiontype, buffer);
+  return func_ptr(handle, alg, transA, m, n, nnz, alpha, alphatype, descrA, csrValA, csrValAtype, csrRowPtrA, csrColIndA, x, xtype, beta, betatype, y, ytype, executiontype, buffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrmv_mp(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int nnz,
-    const float *alpha, const cusparseMatDescr_t descrA,
-    const float *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, const float *x, const float *beta, float *y) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, int, const float *,
-      const cusparseMatDescr_t, const float *, const int *, const int *,
-      const float *, const float *, float *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrmv_mp(cusparseHandle_t handle,
+                                            cusparseOperation_t transA,
+                                            int m,
+                                            int n,
+                                            int nnz,
+                                            const float *alpha,
+                                            const cusparseMatDescr_t descrA,
+                                            const float *csrSortedValA,
+                                            const int *csrSortedRowPtrA,
+                                            const int *csrSortedColIndA,
+                                            const float *x,
+                                            const float *beta,
+                                            float *y) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, const float *, const float *, float *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrmv_mp");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
+  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseDcsrmv_mp(cusparseHandle_t handle, cusparseOperation_t transA, int m,
-                  int n, int nnz, const double *alpha,
-                  const cusparseMatDescr_t descrA, const double *csrSortedValA,
-                  const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-                  const double *x, const double *beta, double *y) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, int, const double *,
-      const cusparseMatDescr_t, const double *, const int *, const int *,
-      const double *, const double *, double *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrmv_mp(cusparseHandle_t handle,
+                                            cusparseOperation_t transA,
+                                            int m,
+                                            int n,
+                                            int nnz,
+                                            const double *alpha,
+                                            const cusparseMatDescr_t descrA,
+                                            const double *csrSortedValA,
+                                            const int *csrSortedRowPtrA,
+                                            const int *csrSortedColIndA,
+                                            const double *x,
+                                            const double *beta,
+                                            double *y) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, const double *, const double *, double *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrmv_mp");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
+  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrmv_mp(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int nnz,
-    const cuComplex *alpha, const cusparseMatDescr_t descrA,
-    const cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, const cuComplex *x, const cuComplex *beta,
-    cuComplex *y) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, int, const cuComplex *,
-      const cusparseMatDescr_t, const cuComplex *, const int *, const int *,
-      const cuComplex *, const cuComplex *, cuComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrmv_mp(cusparseHandle_t handle,
+                                            cusparseOperation_t transA,
+                                            int m,
+                                            int n,
+                                            int nnz,
+                                            const cuComplex *alpha,
+                                            const cusparseMatDescr_t descrA,
+                                            const cuComplex *csrSortedValA,
+                                            const int *csrSortedRowPtrA,
+                                            const int *csrSortedColIndA,
+                                            const cuComplex *x,
+                                            const cuComplex *beta,
+                                            cuComplex *y) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, const cuComplex *, const cuComplex *, cuComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrmv_mp");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
+  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrmv_mp(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int nnz,
-    const cuDoubleComplex *alpha, const cusparseMatDescr_t descrA,
-    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, const cuDoubleComplex *x,
-    const cuDoubleComplex *beta, cuDoubleComplex *y) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, int,
-      const cuDoubleComplex *, const cusparseMatDescr_t,
-      const cuDoubleComplex *, const int *, const int *,
-      const cuDoubleComplex *, const cuDoubleComplex *, cuDoubleComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrmv_mp(cusparseHandle_t handle,
+                                            cusparseOperation_t transA,
+                                            int m,
+                                            int n,
+                                            int nnz,
+                                            const cuDoubleComplex *alpha,
+                                            const cusparseMatDescr_t descrA,
+                                            const cuDoubleComplex *csrSortedValA,
+                                            const int *csrSortedRowPtrA,
+                                            const int *csrSortedColIndA,
+                                            const cuDoubleComplex *x,
+                                            const cuDoubleComplex *beta,
+                                            cuDoubleComplex *y) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, const cuDoubleComplex *, const cuDoubleComplex *, cuDoubleComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrmv_mp");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
+  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseShybmv(
-    cusparseHandle_t handle, cusparseOperation_t transA, const float *alpha,
-    const cusparseMatDescr_t descrA, const cusparseHybMat_t hybA,
-    const float *x, const float *beta, float *y) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, const float *,
-      const cusparseMatDescr_t, const cusparseHybMat_t, const float *,
-      const float *, float *);
+cusparseStatus_t CUSPARSEAPI cusparseShybmv(cusparseHandle_t handle,
+                                            cusparseOperation_t transA,
+                                            const float *alpha,
+                                            const cusparseMatDescr_t descrA,
+                                            const cusparseHybMat_t hybA,
+                                            const float *x,
+                                            const float *beta,
+                                            float *y) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, const float *, const cusparseMatDescr_t, const cusparseHybMat_t, const float *, const float *, float *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseShybmv");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, transA, alpha, descrA, hybA, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDhybmv(
-    cusparseHandle_t handle, cusparseOperation_t transA, const double *alpha,
-    const cusparseMatDescr_t descrA, const cusparseHybMat_t hybA,
-    const double *x, const double *beta, double *y) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, const double *,
-      const cusparseMatDescr_t, const cusparseHybMat_t, const double *,
-      const double *, double *);
+cusparseStatus_t CUSPARSEAPI cusparseDhybmv(cusparseHandle_t handle,
+                                            cusparseOperation_t transA,
+                                            const double *alpha,
+                                            const cusparseMatDescr_t descrA,
+                                            const cusparseHybMat_t hybA,
+                                            const double *x,
+                                            const double *beta,
+                                            double *y) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, const double *, const cusparseMatDescr_t, const cusparseHybMat_t, const double *, const double *, double *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDhybmv");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, transA, alpha, descrA, hybA, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseChybmv(
-    cusparseHandle_t handle, cusparseOperation_t transA, const cuComplex *alpha,
-    const cusparseMatDescr_t descrA, const cusparseHybMat_t hybA,
-    const cuComplex *x, const cuComplex *beta, cuComplex *y) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, const cuComplex *,
-      const cusparseMatDescr_t, const cusparseHybMat_t, const cuComplex *,
-      const cuComplex *, cuComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseChybmv(cusparseHandle_t handle,
+                                            cusparseOperation_t transA,
+                                            const cuComplex *alpha,
+                                            const cusparseMatDescr_t descrA,
+                                            const cusparseHybMat_t hybA,
+                                            const cuComplex *x,
+                                            const cuComplex *beta,
+                                            cuComplex *y) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, const cuComplex *, const cusparseMatDescr_t, const cusparseHybMat_t, const cuComplex *, const cuComplex *, cuComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseChybmv");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, transA, alpha, descrA, hybA, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseZhybmv(cusparseHandle_t handle, cusparseOperation_t transA,
-               const cuDoubleComplex *alpha, const cusparseMatDescr_t descrA,
-               const cusparseHybMat_t hybA, const cuDoubleComplex *x,
-               const cuDoubleComplex *beta, cuDoubleComplex *y) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, const cuDoubleComplex *,
-      const cusparseMatDescr_t, const cusparseHybMat_t, const cuDoubleComplex *,
-      const cuDoubleComplex *, cuDoubleComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseZhybmv(cusparseHandle_t handle,
+                                            cusparseOperation_t transA,
+                                            const cuDoubleComplex *alpha,
+                                            const cusparseMatDescr_t descrA,
+                                            const cusparseHybMat_t hybA,
+                                            const cuDoubleComplex *x,
+                                            const cuDoubleComplex *beta,
+                                            cuDoubleComplex *y) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, const cuDoubleComplex *, const cusparseMatDescr_t, const cusparseHybMat_t, const cuDoubleComplex *, const cuDoubleComplex *, cuDoubleComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZhybmv");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, transA, alpha, descrA, hybA, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsrmv(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, int mb, int nb, int nnzb, const float *alpha,
-    const cusparseMatDescr_t descrA, const float *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
-    const float *x, const float *beta, float *y) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int,
-      const float *, const cusparseMatDescr_t, const float *, const int *,
-      const int *, int, const float *, const float *, float *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsrmv(cusparseHandle_t handle,
+                                            cusparseDirection_t dirA,
+                                            cusparseOperation_t transA,
+                                            int mb,
+                                            int nb,
+                                            int nnzb,
+                                            const float *alpha,
+                                            const cusparseMatDescr_t descrA,
+                                            const float *bsrSortedValA,
+                                            const int *bsrSortedRowPtrA,
+                                            const int *bsrSortedColIndA,
+                                            int  blockDim,
+                                            const float *x,
+                                            const float *beta,
+                                            float *y) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, int, const float *, const float *, float *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrmv");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nb, nnzb, alpha, descrA,
-                  bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim,
-                  x, beta, y);
+  return func_ptr(handle, dirA, transA, mb, nb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsrmv(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, int mb, int nb, int nnzb, const double *alpha,
-    const cusparseMatDescr_t descrA, const double *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
-    const double *x, const double *beta, double *y) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int,
-      const double *, const cusparseMatDescr_t, const double *, const int *,
-      const int *, int, const double *, const double *, double *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsrmv(cusparseHandle_t handle,
+                                            cusparseDirection_t dirA,
+                                            cusparseOperation_t transA,
+                                            int mb,
+                                            int nb,
+                                            int nnzb,
+                                            const double *alpha,
+                                            const cusparseMatDescr_t descrA,
+                                            const double *bsrSortedValA,
+                                            const int *bsrSortedRowPtrA,
+                                            const int *bsrSortedColIndA,
+                                            int  blockDim,
+                                            const double *x,
+                                            const double *beta,
+                                            double *y) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, int, const double *, const double *, double *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrmv");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nb, nnzb, alpha, descrA,
-                  bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim,
-                  x, beta, y);
+  return func_ptr(handle, dirA, transA, mb, nb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseCbsrmv(cusparseHandle_t handle, cusparseDirection_t dirA,
-               cusparseOperation_t transA, int mb, int nb, int nnzb,
-               const cuComplex *alpha, const cusparseMatDescr_t descrA,
-               const cuComplex *bsrSortedValA, const int *bsrSortedRowPtrA,
-               const int *bsrSortedColIndA, int blockDim, const cuComplex *x,
-               const cuComplex *beta, cuComplex *y) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int,
-      const cuComplex *, const cusparseMatDescr_t, const cuComplex *,
-      const int *, const int *, int, const cuComplex *, const cuComplex *,
-      cuComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsrmv(cusparseHandle_t handle,
+                                            cusparseDirection_t dirA,
+                                            cusparseOperation_t transA,
+                                            int mb,
+                                            int nb,
+                                            int nnzb,
+                                            const cuComplex *alpha,
+                                            const cusparseMatDescr_t descrA,
+                                            const cuComplex *bsrSortedValA,
+                                            const int *bsrSortedRowPtrA,
+                                            const int *bsrSortedColIndA,
+                                            int  blockDim,
+                                            const cuComplex *x,
+                                            const cuComplex *beta,
+                                            cuComplex *y) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, int, const cuComplex *, const cuComplex *, cuComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrmv");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nb, nnzb, alpha, descrA,
-                  bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim,
-                  x, beta, y);
+  return func_ptr(handle, dirA, transA, mb, nb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrmv(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, int mb, int nb, int nnzb,
-    const cuDoubleComplex *alpha, const cusparseMatDescr_t descrA,
-    const cuDoubleComplex *bsrSortedValA, const int *bsrSortedRowPtrA,
-    const int *bsrSortedColIndA, int blockDim, const cuDoubleComplex *x,
-    const cuDoubleComplex *beta, cuDoubleComplex *y) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int,
-      const cuDoubleComplex *, const cusparseMatDescr_t,
-      const cuDoubleComplex *, const int *, const int *, int,
-      const cuDoubleComplex *, const cuDoubleComplex *, cuDoubleComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrmv(cusparseHandle_t handle,
+                                            cusparseDirection_t dirA,
+                                            cusparseOperation_t transA,
+                                            int mb,
+                                            int nb,
+                                            int nnzb,
+                                            const cuDoubleComplex *alpha,
+                                            const cusparseMatDescr_t descrA,
+                                            const cuDoubleComplex *bsrSortedValA,
+                                            const int *bsrSortedRowPtrA,
+                                            const int *bsrSortedColIndA,
+                                            int  blockDim,
+                                            const cuDoubleComplex *x,
+                                            const cuDoubleComplex *beta,
+                                            cuDoubleComplex *y) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, int, const cuDoubleComplex *, const cuDoubleComplex *, cuDoubleComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrmv");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nb, nnzb, alpha, descrA,
-                  bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim,
-                  x, beta, y);
+  return func_ptr(handle, dirA, transA, mb, nb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseSbsrxmv(cusparseHandle_t handle, cusparseDirection_t dirA,
-                cusparseOperation_t transA, int sizeOfMask, int mb, int nb,
-                int nnzb, const float *alpha, const cusparseMatDescr_t descrA,
-                const float *bsrSortedValA, const int *bsrSortedMaskPtrA,
-                const int *bsrSortedRowPtrA, const int *bsrSortedEndPtrA,
-                const int *bsrSortedColIndA, int blockDim, const float *x,
-                const float *beta, float *y) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int,
-      int, const float *, const cusparseMatDescr_t, const float *, const int *,
-      const int *, const int *, const int *, int, const float *, const float *,
-      float *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsrxmv(cusparseHandle_t handle,
+                                             cusparseDirection_t dirA,
+                                             cusparseOperation_t transA,
+                                             int sizeOfMask,
+                                             int mb,
+                                             int nb,
+                                             int nnzb,
+                                             const float *alpha,
+                                             const cusparseMatDescr_t descrA,
+                                             const float *bsrSortedValA,
+                                             const int *bsrSortedMaskPtrA,
+                                             const int *bsrSortedRowPtrA,
+                                             const int *bsrSortedEndPtrA,
+                                             const int *bsrSortedColIndA,
+                                             int  blockDim,
+                                             const float *x,
+                                             const float *beta,
+                                             float *y) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int, int, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, const int *, const int *, int, const float *, const float *, float *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrxmv");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, sizeOfMask, mb, nb, nnzb, alpha, descrA,
-                  bsrSortedValA, bsrSortedMaskPtrA, bsrSortedRowPtrA,
-                  bsrSortedEndPtrA, bsrSortedColIndA, blockDim, x, beta, y);
+  return func_ptr(handle, dirA, transA, sizeOfMask, mb, nb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedMaskPtrA, bsrSortedRowPtrA, bsrSortedEndPtrA, bsrSortedColIndA, blockDim, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseDbsrxmv(cusparseHandle_t handle, cusparseDirection_t dirA,
-                cusparseOperation_t transA, int sizeOfMask, int mb, int nb,
-                int nnzb, const double *alpha, const cusparseMatDescr_t descrA,
-                const double *bsrSortedValA, const int *bsrSortedMaskPtrA,
-                const int *bsrSortedRowPtrA, const int *bsrSortedEndPtrA,
-                const int *bsrSortedColIndA, int blockDim, const double *x,
-                const double *beta, double *y) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int,
-      int, const double *, const cusparseMatDescr_t, const double *,
-      const int *, const int *, const int *, const int *, int, const double *,
-      const double *, double *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsrxmv(cusparseHandle_t handle,
+                                             cusparseDirection_t dirA,
+                                             cusparseOperation_t transA,
+                                             int sizeOfMask,
+                                             int mb,
+                                             int nb,
+                                             int nnzb,
+                                             const double *alpha,
+                                             const cusparseMatDescr_t descrA,
+                                             const double *bsrSortedValA,
+                                             const int *bsrSortedMaskPtrA,
+                                             const int *bsrSortedRowPtrA,
+                                             const int *bsrSortedEndPtrA,
+                                             const int *bsrSortedColIndA,
+                                             int  blockDim,
+                                             const double *x,
+                                             const double *beta,
+                                             double *y) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, const int *, const int *, int, const double *, const double *, double *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrxmv");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, sizeOfMask, mb, nb, nnzb, alpha, descrA,
-                  bsrSortedValA, bsrSortedMaskPtrA, bsrSortedRowPtrA,
-                  bsrSortedEndPtrA, bsrSortedColIndA, blockDim, x, beta, y);
+  return func_ptr(handle, dirA, transA, sizeOfMask, mb, nb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedMaskPtrA, bsrSortedRowPtrA, bsrSortedEndPtrA, bsrSortedColIndA, blockDim, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsrxmv(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, int sizeOfMask, int mb, int nb, int nnzb,
-    const cuComplex *alpha, const cusparseMatDescr_t descrA,
-    const cuComplex *bsrSortedValA, const int *bsrSortedMaskPtrA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedEndPtrA,
-    const int *bsrSortedColIndA, int blockDim, const cuComplex *x,
-    const cuComplex *beta, cuComplex *y) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int,
-      int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *,
-      const int *, const int *, const int *, const int *, int,
-      const cuComplex *, const cuComplex *, cuComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsrxmv(cusparseHandle_t handle,
+                                             cusparseDirection_t dirA,
+                                             cusparseOperation_t transA,
+                                             int sizeOfMask,
+                                             int mb,
+                                             int nb,
+                                             int nnzb,
+                                             const cuComplex *alpha,
+                                             const cusparseMatDescr_t descrA,
+                                             const cuComplex *bsrSortedValA,
+                                             const int *bsrSortedMaskPtrA,
+                                             const int *bsrSortedRowPtrA,
+                                             const int *bsrSortedEndPtrA,
+                                             const int *bsrSortedColIndA,
+                                             int  blockDim,
+                                             const cuComplex *x,
+                                             const cuComplex *beta,
+                                             cuComplex *y) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int, int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, const int *, const int *, int, const cuComplex *, const cuComplex *, cuComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrxmv");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, sizeOfMask, mb, nb, nnzb, alpha, descrA,
-                  bsrSortedValA, bsrSortedMaskPtrA, bsrSortedRowPtrA,
-                  bsrSortedEndPtrA, bsrSortedColIndA, blockDim, x, beta, y);
+  return func_ptr(handle, dirA, transA, sizeOfMask, mb, nb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedMaskPtrA, bsrSortedRowPtrA, bsrSortedEndPtrA, bsrSortedColIndA, blockDim, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrxmv(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, int sizeOfMask, int mb, int nb, int nnzb,
-    const cuDoubleComplex *alpha, const cusparseMatDescr_t descrA,
-    const cuDoubleComplex *bsrSortedValA, const int *bsrSortedMaskPtrA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedEndPtrA,
-    const int *bsrSortedColIndA, int blockDim, const cuDoubleComplex *x,
-    const cuDoubleComplex *beta, cuDoubleComplex *y) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int,
-      int, const cuDoubleComplex *, const cusparseMatDescr_t,
-      const cuDoubleComplex *, const int *, const int *, const int *,
-      const int *, int, const cuDoubleComplex *, const cuDoubleComplex *,
-      cuDoubleComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrxmv(cusparseHandle_t handle,
+                                             cusparseDirection_t dirA,
+                                             cusparseOperation_t transA,
+                                             int sizeOfMask,
+                                             int mb,
+                                             int nb,
+                                             int nnzb,
+                                             const cuDoubleComplex *alpha,
+                                             const cusparseMatDescr_t descrA,
+                                             const cuDoubleComplex *bsrSortedValA,
+                                             const int *bsrSortedMaskPtrA,
+                                             const int *bsrSortedRowPtrA,
+                                             const int *bsrSortedEndPtrA,
+                                             const int *bsrSortedColIndA,
+                                             int  blockDim,
+                                             const cuDoubleComplex *x,
+                                             const cuDoubleComplex *beta,
+                                             cuDoubleComplex *y) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, const int *, const int *, int, const cuDoubleComplex *, const cuDoubleComplex *, cuDoubleComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrxmv");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, sizeOfMask, mb, nb, nnzb, alpha, descrA,
-                  bsrSortedValA, bsrSortedMaskPtrA, bsrSortedRowPtrA,
-                  bsrSortedEndPtrA, bsrSortedColIndA, blockDim, x, beta, y);
+  return func_ptr(handle, dirA, transA, sizeOfMask, mb, nb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedMaskPtrA, bsrSortedRowPtrA, bsrSortedEndPtrA, bsrSortedColIndA, blockDim, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCsrsv_analysisEx(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
-    const cusparseMatDescr_t descrA, const void *csrSortedValA,
-    cudaDataType csrSortedValAtype, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, cusparseSolveAnalysisInfo_t info,
-    cudaDataType executiontype) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
-      const void *, cudaDataType, const int *, const int *,
-      cusparseSolveAnalysisInfo_t, cudaDataType);
+cusparseStatus_t CUSPARSEAPI cusparseCsrsv_analysisEx(cusparseHandle_t handle,
+                                                     cusparseOperation_t transA,
+                                                     int m,
+                                                     int nnz,
+                                                     const cusparseMatDescr_t descrA,
+                                                     const void *csrSortedValA,
+                                                     cudaDataType csrSortedValAtype,
+                                                     const int *csrSortedRowPtrA,
+                                                     const int *csrSortedColIndA,
+                                                     cusparseSolveAnalysisInfo_t info,
+                                                     cudaDataType executiontype) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const void *, cudaDataType, const int *, const int *, cusparseSolveAnalysisInfo_t, cudaDataType);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCsrsv_analysisEx");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
-                  csrSortedValAtype, csrSortedRowPtrA, csrSortedColIndA, info,
-                  executiontype);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedValAtype, csrSortedRowPtrA, csrSortedColIndA, info, executiontype);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrsv_analysis(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
-    const cusparseMatDescr_t descrA, const float *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
-      const float *, const int *, const int *, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseScsrsv_analysis(cusparseHandle_t handle,
+                                                     cusparseOperation_t transA,
+                                                     int m,
+                                                     int nnz,
+                                                     const cusparseMatDescr_t descrA,
+                                                     const float *csrSortedValA,
+                                                     const int *csrSortedRowPtrA,
+                                                     const int *csrSortedColIndA,
+                                                     cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrsv_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrsv_analysis(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
-    const cusparseMatDescr_t descrA, const double *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
-      const double *, const int *, const int *, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrsv_analysis(cusparseHandle_t handle,
+                                                     cusparseOperation_t transA,
+                                                     int m,
+                                                     int nnz,
+                                                     const cusparseMatDescr_t descrA,
+                                                     const double *csrSortedValA,
+                                                     const int *csrSortedRowPtrA,
+                                                     const int *csrSortedColIndA,
+                                                     cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrsv_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrsv_analysis(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
-    const cusparseMatDescr_t descrA, const cuComplex *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
-      const cuComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrsv_analysis(cusparseHandle_t handle,
+                                                     cusparseOperation_t transA,
+                                                     int m,
+                                                     int nnz,
+                                                     const cusparseMatDescr_t descrA,
+                                                     const cuComplex *csrSortedValA,
+                                                     const int *csrSortedRowPtrA,
+                                                     const int *csrSortedColIndA,
+                                                     cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrsv_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrsv_analysis(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
-    const cusparseMatDescr_t descrA, const cuDoubleComplex *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
-      const cuDoubleComplex *, const int *, const int *,
-      cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrsv_analysis(cusparseHandle_t handle,
+                                                     cusparseOperation_t transA,
+                                                     int m,
+                                                     int nnz,
+                                                     const cusparseMatDescr_t descrA,
+                                                     const cuDoubleComplex *csrSortedValA,
+                                                     const int *csrSortedRowPtrA,
+                                                     const int *csrSortedColIndA,
+                                                     cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrsv_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCsrsv_solveEx(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m,
-    const void *alpha, cudaDataType alphatype, const cusparseMatDescr_t descrA,
-    const void *csrSortedValA, cudaDataType csrSortedValAtype,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    cusparseSolveAnalysisInfo_t info, const void *f, cudaDataType ftype,
-    void *x, cudaDataType xtype, cudaDataType executiontype) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, const void *, cudaDataType,
-      const cusparseMatDescr_t, const void *, cudaDataType, const int *,
-      const int *, cusparseSolveAnalysisInfo_t, const void *, cudaDataType,
-      void *, cudaDataType, cudaDataType);
+cusparseStatus_t CUSPARSEAPI cusparseCsrsv_solveEx(cusparseHandle_t handle,
+                                                   cusparseOperation_t transA,
+                                                   int m,
+                                                   const void *alpha,
+                                                   cudaDataType alphatype,
+                                                   const cusparseMatDescr_t descrA,
+                                                   const void *csrSortedValA,
+                                                   cudaDataType csrSortedValAtype,
+                                                   const int *csrSortedRowPtrA,
+                                                   const int *csrSortedColIndA,
+                                                   cusparseSolveAnalysisInfo_t info,
+                                                   const void *f,
+                                                   cudaDataType ftype,
+                                                   void *x,
+                                                   cudaDataType xtype,
+                                                   cudaDataType executiontype) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, const void *, cudaDataType, const cusparseMatDescr_t, const void *, cudaDataType, const int *, const int *, cusparseSolveAnalysisInfo_t, const void *, cudaDataType, void *, cudaDataType, cudaDataType);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCsrsv_solveEx");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, alpha, alphatype, descrA, csrSortedValA,
-                  csrSortedValAtype, csrSortedRowPtrA, csrSortedColIndA, info,
-                  f, ftype, x, xtype, executiontype);
+  return func_ptr(handle, transA, m, alpha, alphatype, descrA, csrSortedValA, csrSortedValAtype, csrSortedRowPtrA, csrSortedColIndA, info, f, ftype, x, xtype, executiontype);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrsv_solve(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m,
-    const float *alpha, const cusparseMatDescr_t descrA,
-    const float *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, cusparseSolveAnalysisInfo_t info,
-    const float *f, float *x) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, const float *,
-      const cusparseMatDescr_t, const float *, const int *, const int *,
-      cusparseSolveAnalysisInfo_t, const float *, float *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrsv_solve(cusparseHandle_t handle,
+                                                  cusparseOperation_t transA,
+                                                  int m,
+                                                  const float *alpha,
+                                                  const cusparseMatDescr_t descrA,
+                                                  const float *csrSortedValA,
+                                                  const int *csrSortedRowPtrA,
+                                                  const int *csrSortedColIndA,
+                                                  cusparseSolveAnalysisInfo_t info,
+                                                  const float *f,
+                                                  float *x) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, cusparseSolveAnalysisInfo_t, const float *, float *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrsv_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, alpha, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info, f, x);
+  return func_ptr(handle, transA, m, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, f, x);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrsv_solve(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m,
-    const double *alpha, const cusparseMatDescr_t descrA,
-    const double *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, cusparseSolveAnalysisInfo_t info,
-    const double *f, double *x) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, const double *,
-      const cusparseMatDescr_t, const double *, const int *, const int *,
-      cusparseSolveAnalysisInfo_t, const double *, double *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrsv_solve(cusparseHandle_t handle,
+                                                  cusparseOperation_t transA,
+                                                  int m,
+                                                  const double *alpha,
+                                                  const cusparseMatDescr_t descrA,
+                                                  const double *csrSortedValA,
+                                                  const int *csrSortedRowPtrA,
+                                                  const int *csrSortedColIndA,
+                                                  cusparseSolveAnalysisInfo_t info,
+                                                  const double *f,
+                                                  double *x) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, cusparseSolveAnalysisInfo_t, const double *, double *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrsv_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, alpha, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info, f, x);
+  return func_ptr(handle, transA, m, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, f, x);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrsv_solve(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m,
-    const cuComplex *alpha, const cusparseMatDescr_t descrA,
-    const cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, cusparseSolveAnalysisInfo_t info,
-    const cuComplex *f, cuComplex *x) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, const cuComplex *,
-      const cusparseMatDescr_t, const cuComplex *, const int *, const int *,
-      cusparseSolveAnalysisInfo_t, const cuComplex *, cuComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrsv_solve(cusparseHandle_t handle,
+                                                  cusparseOperation_t transA,
+                                                  int m,
+                                                  const cuComplex *alpha,
+                                                  const cusparseMatDescr_t descrA,
+                                                  const cuComplex *csrSortedValA,
+                                                  const int *csrSortedRowPtrA,
+                                                  const int *csrSortedColIndA,
+                                                  cusparseSolveAnalysisInfo_t info,
+                                                  const cuComplex *f,
+                                                  cuComplex *x) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t, const cuComplex *, cuComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrsv_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, alpha, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info, f, x);
+  return func_ptr(handle, transA, m, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, f, x);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrsv_solve(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m,
-    const cuDoubleComplex *alpha, const cusparseMatDescr_t descrA,
-    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, cusparseSolveAnalysisInfo_t info,
-    const cuDoubleComplex *f, cuDoubleComplex *x) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, const cuDoubleComplex *,
-      const cusparseMatDescr_t, const cuDoubleComplex *, const int *,
-      const int *, cusparseSolveAnalysisInfo_t, const cuDoubleComplex *,
-      cuDoubleComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrsv_solve(cusparseHandle_t handle,
+                                                  cusparseOperation_t transA,
+                                                  int m,
+                                                  const cuDoubleComplex *alpha,
+                                                  const cusparseMatDescr_t descrA,
+                                                  const cuDoubleComplex *csrSortedValA,
+                                                  const int *csrSortedRowPtrA,
+                                                  const int *csrSortedColIndA,
+                                                  cusparseSolveAnalysisInfo_t info,
+                                                  const cuDoubleComplex *f,
+                                                  cuDoubleComplex *x) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, const cuDoubleComplex *, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t, const cuDoubleComplex *, cuDoubleComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrsv_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, alpha, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info, f, x);
+  return func_ptr(handle, transA, m, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, f, x);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseXcsrsv2_zeroPivot(cusparseHandle_t handle,
                                                        csrsv2Info_t info,
                                                        int *position) {
-  using FuncPtr =
-      cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, csrsv2Info_t, int *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, csrsv2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcsrsv2_zeroPivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, position);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrsv2_bufferSize(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
-    const cusparseMatDescr_t descrA, float *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, csrsv2Info_t info,
-    int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
-      float *, const int *, const int *, csrsv2Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrsv2_bufferSize(cusparseHandle_t handle,
+                                                        cusparseOperation_t transA,
+                                                        int m,
+                                                        int nnz,
+                                                        const cusparseMatDescr_t descrA,
+                                                        float *csrSortedValA,
+                                                        const int *csrSortedRowPtrA,
+                                                        const int *csrSortedColIndA,
+                                                        csrsv2Info_t info,
+                                                        int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, csrsv2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrsv2_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrsv2_bufferSize(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
-    const cusparseMatDescr_t descrA, double *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, csrsv2Info_t info,
-    int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
-      double *, const int *, const int *, csrsv2Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrsv2_bufferSize(cusparseHandle_t handle,
+                                                        cusparseOperation_t transA,
+                                                        int m,
+                                                        int nnz,
+                                                        const cusparseMatDescr_t descrA,
+                                                        double *csrSortedValA,
+                                                        const int *csrSortedRowPtrA,
+                                                        const int *csrSortedColIndA,
+                                                        csrsv2Info_t info,
+                                                        int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, csrsv2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrsv2_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrsv2_bufferSize(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
-    const cusparseMatDescr_t descrA, cuComplex *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, csrsv2Info_t info,
-    int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
-      cuComplex *, const int *, const int *, csrsv2Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrsv2_bufferSize(cusparseHandle_t handle,
+                                                        cusparseOperation_t transA,
+                                                        int m,
+                                                        int nnz,
+                                                        const cusparseMatDescr_t descrA,
+                                                        cuComplex *csrSortedValA,
+                                                        const int *csrSortedRowPtrA,
+                                                        const int *csrSortedColIndA,
+                                                        csrsv2Info_t info,
+                                                        int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, csrsv2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrsv2_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrsv2_bufferSize(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
-    const cusparseMatDescr_t descrA, cuDoubleComplex *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, csrsv2Info_t info,
-    int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
-      cuDoubleComplex *, const int *, const int *, csrsv2Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrsv2_bufferSize(cusparseHandle_t handle,
+                                                        cusparseOperation_t transA,
+                                                        int m,
+                                                        int nnz,
+                                                        const cusparseMatDescr_t descrA,
+                                                        cuDoubleComplex *csrSortedValA,
+                                                        const int *csrSortedRowPtrA,
+                                                        const int *csrSortedColIndA,
+                                                        csrsv2Info_t info,
+                                                        int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, csrsv2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrsv2_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrsv2_bufferSizeExt(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
-    const cusparseMatDescr_t descrA, float *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, csrsv2Info_t info,
-    size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
-      float *, const int *, const int *, csrsv2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrsv2_bufferSizeExt(cusparseHandle_t handle,
+                                                        cusparseOperation_t transA,
+                                                        int m,
+                                                        int nnz,
+                                                        const cusparseMatDescr_t descrA,
+                                                        float *csrSortedValA,
+                                                        const int *csrSortedRowPtrA,
+                                                        const int *csrSortedColIndA,
+                                                        csrsv2Info_t info,
+                                                        size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, csrsv2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrsv2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info, pBufferSize);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrsv2_bufferSizeExt(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
-    const cusparseMatDescr_t descrA, double *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, csrsv2Info_t info,
-    size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
-      double *, const int *, const int *, csrsv2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrsv2_bufferSizeExt(cusparseHandle_t handle,
+                                                        cusparseOperation_t transA,
+                                                        int m,
+                                                        int nnz,
+                                                        const cusparseMatDescr_t descrA,
+                                                        double *csrSortedValA,
+                                                        const int *csrSortedRowPtrA,
+                                                        const int *csrSortedColIndA,
+                                                        csrsv2Info_t info,
+                                                        size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, csrsv2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrsv2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info, pBufferSize);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrsv2_bufferSizeExt(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
-    const cusparseMatDescr_t descrA, cuComplex *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, csrsv2Info_t info,
-    size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
-      cuComplex *, const int *, const int *, csrsv2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrsv2_bufferSizeExt(cusparseHandle_t handle,
+                                                        cusparseOperation_t transA,
+                                                        int m,
+                                                        int nnz,
+                                                        const cusparseMatDescr_t descrA,
+                                                        cuComplex *csrSortedValA,
+                                                        const int *csrSortedRowPtrA,
+                                                        const int *csrSortedColIndA,
+                                                        csrsv2Info_t info,
+                                                        size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, csrsv2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrsv2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info, pBufferSize);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrsv2_bufferSizeExt(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
-    const cusparseMatDescr_t descrA, cuDoubleComplex *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, csrsv2Info_t info,
-    size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
-      cuDoubleComplex *, const int *, const int *, csrsv2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrsv2_bufferSizeExt(cusparseHandle_t handle,
+                                                        cusparseOperation_t transA,
+                                                        int m,
+                                                        int nnz,
+                                                        const cusparseMatDescr_t descrA,
+                                                        cuDoubleComplex *csrSortedValA,
+                                                        const int *csrSortedRowPtrA,
+                                                        const int *csrSortedColIndA,
+                                                        csrsv2Info_t info,
+                                                        size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, csrsv2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrsv2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info, pBufferSize);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrsv2_analysis(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
-    const cusparseMatDescr_t descrA, const float *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, csrsv2Info_t info,
-    cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
-      const float *, const int *, const int *, csrsv2Info_t,
-      cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrsv2_analysis(cusparseHandle_t handle,
+                                                      cusparseOperation_t transA,
+                                                      int m,
+                                                      int nnz,
+                                                      const cusparseMatDescr_t descrA,
+                                                      const float *csrSortedValA,
+                                                      const int *csrSortedRowPtrA,
+                                                      const int *csrSortedColIndA,
+                                                      csrsv2Info_t info,
+                                                      cusparseSolvePolicy_t policy,
+                                                      void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, csrsv2Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrsv2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrsv2_analysis(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
-    const cusparseMatDescr_t descrA, const double *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, csrsv2Info_t info,
-    cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
-      const double *, const int *, const int *, csrsv2Info_t,
-      cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrsv2_analysis(cusparseHandle_t handle,
+                                                      cusparseOperation_t transA,
+                                                      int m,
+                                                      int nnz,
+                                                      const cusparseMatDescr_t descrA,
+                                                      const double *csrSortedValA,
+                                                      const int *csrSortedRowPtrA,
+                                                      const int *csrSortedColIndA,
+                                                      csrsv2Info_t info,
+                                                      cusparseSolvePolicy_t policy,
+                                                      void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, csrsv2Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrsv2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrsv2_analysis(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
-    const cusparseMatDescr_t descrA, const cuComplex *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, csrsv2Info_t info,
-    cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
-      const cuComplex *, const int *, const int *, csrsv2Info_t,
-      cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrsv2_analysis(cusparseHandle_t handle,
+                                                      cusparseOperation_t transA,
+                                                      int m,
+                                                      int nnz,
+                                                      const cusparseMatDescr_t descrA,
+                                                      const cuComplex *csrSortedValA,
+                                                      const int *csrSortedRowPtrA,
+                                                      const int *csrSortedColIndA,
+                                                      csrsv2Info_t info,
+                                                      cusparseSolvePolicy_t policy,
+                                                      void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, csrsv2Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrsv2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrsv2_analysis(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
-    const cusparseMatDescr_t descrA, const cuDoubleComplex *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, csrsv2Info_t info,
-    cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
-      const cuDoubleComplex *, const int *, const int *, csrsv2Info_t,
-      cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrsv2_analysis(cusparseHandle_t handle,
+                                                      cusparseOperation_t transA,
+                                                      int m,
+                                                      int nnz,
+                                                      const cusparseMatDescr_t descrA,
+                                                      const cuDoubleComplex *csrSortedValA,
+                                                      const int *csrSortedRowPtrA,
+                                                      const int *csrSortedColIndA,
+                                                      csrsv2Info_t info,
+                                                      cusparseSolvePolicy_t policy,
+                                                      void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, csrsv2Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrsv2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrsv2_solve(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
-    const float *alpha, const cusparseMatDescr_t descrA,
-    const float *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, csrsv2Info_t info, const float *f, float *x,
-    cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const float *,
-      const cusparseMatDescr_t, const float *, const int *, const int *,
-      csrsv2Info_t, const float *, float *, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrsv2_solve(cusparseHandle_t handle,
+                                                   cusparseOperation_t transA,
+                                                   int m,
+                                                   int nnz,
+                                                   const float *alpha,
+                                                   const cusparseMatDescr_t descrA,
+                                                   const float *csrSortedValA,
+                                                   const int *csrSortedRowPtrA,
+                                                   const int *csrSortedColIndA,
+                                                   csrsv2Info_t info,
+                                                   const float *f,
+                                                   float *x,
+                                                   cusparseSolvePolicy_t policy,
+                                                   void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, csrsv2Info_t, const float *, float *, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrsv2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, alpha, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info, f, x, policy,
-                  pBuffer);
+  return func_ptr(handle, transA, m, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, f, x, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrsv2_solve(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
-    const double *alpha, const cusparseMatDescr_t descrA,
-    const double *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, csrsv2Info_t info, const double *f, double *x,
-    cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const double *,
-      const cusparseMatDescr_t, const double *, const int *, const int *,
-      csrsv2Info_t, const double *, double *, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrsv2_solve(cusparseHandle_t handle,
+                                                   cusparseOperation_t transA,
+                                                   int m,
+                                                   int nnz,
+                                                   const double *alpha,
+                                                   const cusparseMatDescr_t descrA,
+                                                   const double *csrSortedValA,
+                                                   const int *csrSortedRowPtrA,
+                                                   const int *csrSortedColIndA,
+                                                   csrsv2Info_t info,
+                                                   const double *f,
+                                                   double *x,
+                                                   cusparseSolvePolicy_t policy,
+                                                   void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, csrsv2Info_t, const double *, double *, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrsv2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, alpha, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info, f, x, policy,
-                  pBuffer);
+  return func_ptr(handle, transA, m, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, f, x, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrsv2_solve(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
-    const cuComplex *alpha, const cusparseMatDescr_t descrA,
-    const cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, csrsv2Info_t info, const cuComplex *f,
-    cuComplex *x, cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const cuComplex *,
-      const cusparseMatDescr_t, const cuComplex *, const int *, const int *,
-      csrsv2Info_t, const cuComplex *, cuComplex *, cusparseSolvePolicy_t,
-      void *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrsv2_solve(cusparseHandle_t handle,
+                                                   cusparseOperation_t transA,
+                                                   int m,
+                                                   int nnz,
+                                                   const cuComplex *alpha,
+                                                   const cusparseMatDescr_t descrA,
+                                                   const cuComplex *csrSortedValA,
+                                                   const int *csrSortedRowPtrA,
+                                                   const int *csrSortedColIndA,
+                                                   csrsv2Info_t info,
+                                                   const cuComplex *f,
+                                                   cuComplex *x,
+                                                   cusparseSolvePolicy_t policy,
+                                                   void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, csrsv2Info_t, const cuComplex *, cuComplex *, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrsv2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, alpha, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info, f, x, policy,
-                  pBuffer);
+  return func_ptr(handle, transA, m, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, f, x, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrsv2_solve(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
-    const cuDoubleComplex *alpha, const cusparseMatDescr_t descrA,
-    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, csrsv2Info_t info, const cuDoubleComplex *f,
-    cuDoubleComplex *x, cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const cuDoubleComplex *,
-      const cusparseMatDescr_t, const cuDoubleComplex *, const int *,
-      const int *, csrsv2Info_t, const cuDoubleComplex *, cuDoubleComplex *,
-      cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrsv2_solve(cusparseHandle_t handle,
+                                                   cusparseOperation_t transA,
+                                                   int m,
+                                                   int nnz,
+                                                   const cuDoubleComplex *alpha,
+                                                   const cusparseMatDescr_t descrA,
+                                                   const cuDoubleComplex *csrSortedValA,
+                                                   const int *csrSortedRowPtrA,
+                                                   const int *csrSortedColIndA,
+                                                   csrsv2Info_t info,
+                                                   const cuDoubleComplex *f,
+                                                   cuDoubleComplex *x,
+                                                   cusparseSolvePolicy_t policy,
+                                                   void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, csrsv2Info_t, const cuDoubleComplex *, cuDoubleComplex *, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrsv2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, alpha, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info, f, x, policy,
-                  pBuffer);
+  return func_ptr(handle, transA, m, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, f, x, policy, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseXbsrsv2_zeroPivot(cusparseHandle_t handle,
                                                        bsrsv2Info_t info,
                                                        int *position) {
-  using FuncPtr =
-      cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, bsrsv2Info_t, int *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, bsrsv2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXbsrsv2_zeroPivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, position);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsrsv2_bufferSize(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, float *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
-    bsrsv2Info_t info, int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
-      const cusparseMatDescr_t, float *, const int *, const int *, int,
-      bsrsv2Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsrsv2_bufferSize(cusparseHandle_t handle,
+                                                        cusparseDirection_t dirA,
+                                                        cusparseOperation_t transA,
+                                                        int mb,
+                                                        int nnzb,
+                                                        const cusparseMatDescr_t descrA,
+                                                        float *bsrSortedValA,
+                                                        const int *bsrSortedRowPtrA,
+                                                        const int *bsrSortedColIndA,
+                                                        int blockDim,
+                                                        bsrsv2Info_t info,
+                                                        int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, int, bsrsv2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrsv2_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA,
-                  bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info,
-                  pBufferSizeInBytes);
+  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsrsv2_bufferSize(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, double *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
-    bsrsv2Info_t info, int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
-      const cusparseMatDescr_t, double *, const int *, const int *, int,
-      bsrsv2Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsrsv2_bufferSize(cusparseHandle_t handle,
+                                                        cusparseDirection_t dirA,
+                                                        cusparseOperation_t transA,
+                                                        int mb,
+                                                        int nnzb,
+                                                        const cusparseMatDescr_t descrA,
+                                                        double *bsrSortedValA,
+                                                        const int *bsrSortedRowPtrA,
+                                                        const int *bsrSortedColIndA,
+                                                        int blockDim,
+                                                        bsrsv2Info_t info,
+                                                        int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, int, bsrsv2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrsv2_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA,
-                  bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info,
-                  pBufferSizeInBytes);
+  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsrsv2_bufferSize(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, cuComplex *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
-    bsrsv2Info_t info, int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
-      const cusparseMatDescr_t, cuComplex *, const int *, const int *, int,
-      bsrsv2Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsrsv2_bufferSize(cusparseHandle_t handle,
+                                                        cusparseDirection_t dirA,
+                                                        cusparseOperation_t transA,
+                                                        int mb,
+                                                        int nnzb,
+                                                        const cusparseMatDescr_t descrA,
+                                                        cuComplex *bsrSortedValA,
+                                                        const int *bsrSortedRowPtrA,
+                                                        const int *bsrSortedColIndA,
+                                                        int blockDim,
+                                                        bsrsv2Info_t info,
+                                                        int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, int, bsrsv2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrsv2_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA,
-                  bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info,
-                  pBufferSizeInBytes);
+  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrsv2_bufferSize(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, cuDoubleComplex *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
-    bsrsv2Info_t info, int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
-      const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *,
-      int, bsrsv2Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrsv2_bufferSize(cusparseHandle_t handle,
+                                                        cusparseDirection_t dirA,
+                                                        cusparseOperation_t transA,
+                                                        int mb,
+                                                        int nnzb,
+                                                        const cusparseMatDescr_t descrA,
+                                                        cuDoubleComplex *bsrSortedValA,
+                                                        const int *bsrSortedRowPtrA,
+                                                        const int *bsrSortedColIndA,
+                                                        int blockDim,
+                                                        bsrsv2Info_t info,
+                                                        int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, int, bsrsv2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrsv2_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA,
-                  bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info,
-                  pBufferSizeInBytes);
+  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsrsv2_bufferSizeExt(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, float *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockSize,
-    bsrsv2Info_t info, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
-      const cusparseMatDescr_t, float *, const int *, const int *, int,
-      bsrsv2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsrsv2_bufferSizeExt(cusparseHandle_t handle,
+                                                        cusparseDirection_t dirA,
+                                                        cusparseOperation_t transA,
+                                                        int mb,
+                                                        int nnzb,
+                                                        const cusparseMatDescr_t descrA,
+                                                        float *bsrSortedValA,
+                                                        const int *bsrSortedRowPtrA,
+                                                        const int *bsrSortedColIndA,
+                                                        int blockSize,
+                                                        bsrsv2Info_t info,
+                                                        size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, int, bsrsv2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrsv2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA,
-                  bsrSortedRowPtrA, bsrSortedColIndA, blockSize, info,
-                  pBufferSize);
+  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockSize, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsrsv2_bufferSizeExt(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, double *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockSize,
-    bsrsv2Info_t info, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
-      const cusparseMatDescr_t, double *, const int *, const int *, int,
-      bsrsv2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsrsv2_bufferSizeExt(cusparseHandle_t handle,
+                                                        cusparseDirection_t dirA,
+                                                        cusparseOperation_t transA,
+                                                        int mb,
+                                                        int nnzb,
+                                                        const cusparseMatDescr_t descrA,
+                                                        double *bsrSortedValA,
+                                                        const int *bsrSortedRowPtrA,
+                                                        const int *bsrSortedColIndA,
+                                                        int blockSize,
+                                                        bsrsv2Info_t info,
+                                                        size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, int, bsrsv2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrsv2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA,
-                  bsrSortedRowPtrA, bsrSortedColIndA, blockSize, info,
-                  pBufferSize);
+  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockSize, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsrsv2_bufferSizeExt(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, cuComplex *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockSize,
-    bsrsv2Info_t info, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
-      const cusparseMatDescr_t, cuComplex *, const int *, const int *, int,
-      bsrsv2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsrsv2_bufferSizeExt(cusparseHandle_t handle,
+                                                        cusparseDirection_t dirA,
+                                                        cusparseOperation_t transA,
+                                                        int mb,
+                                                        int nnzb,
+                                                        const cusparseMatDescr_t descrA,
+                                                        cuComplex *bsrSortedValA,
+                                                        const int *bsrSortedRowPtrA,
+                                                        const int *bsrSortedColIndA,
+                                                        int blockSize,
+                                                        bsrsv2Info_t info,
+                                                        size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, int, bsrsv2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrsv2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA,
-                  bsrSortedRowPtrA, bsrSortedColIndA, blockSize, info,
-                  pBufferSize);
+  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockSize, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrsv2_bufferSizeExt(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, cuDoubleComplex *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockSize,
-    bsrsv2Info_t info, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
-      const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *,
-      int, bsrsv2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrsv2_bufferSizeExt(cusparseHandle_t handle,
+                                                        cusparseDirection_t dirA,
+                                                        cusparseOperation_t transA,
+                                                        int mb,
+                                                        int nnzb,
+                                                        const cusparseMatDescr_t descrA,
+                                                        cuDoubleComplex *bsrSortedValA,
+                                                        const int *bsrSortedRowPtrA,
+                                                        const int *bsrSortedColIndA,
+                                                        int blockSize,
+                                                        bsrsv2Info_t info,
+                                                        size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, int, bsrsv2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrsv2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA,
-                  bsrSortedRowPtrA, bsrSortedColIndA, blockSize, info,
-                  pBufferSize);
+  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockSize, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsrsv2_analysis(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, const float *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
-    bsrsv2Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
-      const cusparseMatDescr_t, const float *, const int *, const int *, int,
-      bsrsv2Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsrsv2_analysis(cusparseHandle_t handle,
+                                                      cusparseDirection_t dirA,
+                                                      cusparseOperation_t transA,
+                                                      int mb,
+                                                      int nnzb,
+                                                      const cusparseMatDescr_t descrA,
+                                                      const float *bsrSortedValA,
+                                                      const int *bsrSortedRowPtrA,
+                                                      const int *bsrSortedColIndA,
+                                                      int blockDim,
+                                                      bsrsv2Info_t info,
+                                                      cusparseSolvePolicy_t policy,
+                                                      void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, int, bsrsv2Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrsv2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA,
-                  bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, policy,
-                  pBuffer);
+  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsrsv2_analysis(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, const double *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
-    bsrsv2Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
-      const cusparseMatDescr_t, const double *, const int *, const int *, int,
-      bsrsv2Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsrsv2_analysis(cusparseHandle_t handle,
+                                                      cusparseDirection_t dirA,
+                                                      cusparseOperation_t transA,
+                                                      int mb,
+                                                      int nnzb,
+                                                      const cusparseMatDescr_t descrA,
+                                                      const double *bsrSortedValA,
+                                                      const int *bsrSortedRowPtrA,
+                                                      const int *bsrSortedColIndA,
+                                                      int blockDim,
+                                                      bsrsv2Info_t info,
+                                                      cusparseSolvePolicy_t policy,
+                                                      void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, int, bsrsv2Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrsv2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA,
-                  bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, policy,
-                  pBuffer);
+  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsrsv2_analysis(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, const cuComplex *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
-    bsrsv2Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
-      const cusparseMatDescr_t, const cuComplex *, const int *, const int *,
-      int, bsrsv2Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsrsv2_analysis(cusparseHandle_t handle,
+                                                      cusparseDirection_t dirA,
+                                                      cusparseOperation_t transA,
+                                                      int mb,
+                                                      int nnzb,
+                                                      const cusparseMatDescr_t descrA,
+                                                      const cuComplex *bsrSortedValA,
+                                                      const int *bsrSortedRowPtrA,
+                                                      const int *bsrSortedColIndA,
+                                                      int blockDim,
+                                                      bsrsv2Info_t info,
+                                                      cusparseSolvePolicy_t policy,
+                                                      void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, int, bsrsv2Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrsv2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA,
-                  bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, policy,
-                  pBuffer);
+  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrsv2_analysis(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, const cuDoubleComplex *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
-    bsrsv2Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
-      const cusparseMatDescr_t, const cuDoubleComplex *, const int *,
-      const int *, int, bsrsv2Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrsv2_analysis(cusparseHandle_t handle,
+                                                      cusparseDirection_t dirA,
+                                                      cusparseOperation_t transA,
+                                                      int mb,
+                                                      int nnzb,
+                                                      const cusparseMatDescr_t descrA,
+                                                      const cuDoubleComplex *bsrSortedValA,
+                                                      const int *bsrSortedRowPtrA,
+                                                      const int *bsrSortedColIndA,
+                                                      int blockDim,
+                                                      bsrsv2Info_t info,
+                                                      cusparseSolvePolicy_t policy,
+                                                      void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, int, bsrsv2Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrsv2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA,
-                  bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, policy,
-                  pBuffer);
+  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsrsv2_solve(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, int mb, int nnzb, const float *alpha,
-    const cusparseMatDescr_t descrA, const float *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
-    bsrsv2Info_t info, const float *f, float *x, cusparseSolvePolicy_t policy,
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
-      const float *, const cusparseMatDescr_t, const float *, const int *,
-      const int *, int, bsrsv2Info_t, const float *, float *,
-      cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsrsv2_solve(cusparseHandle_t handle,
+                                                   cusparseDirection_t dirA,
+                                                   cusparseOperation_t transA,
+                                                   int mb,
+                                                   int nnzb,
+                                                   const float *alpha,
+                                                   const cusparseMatDescr_t descrA,
+                                                   const float *bsrSortedValA,
+                                                   const int *bsrSortedRowPtrA,
+                                                   const int *bsrSortedColIndA,
+                                                   int blockDim,
+                                                   bsrsv2Info_t info,
+                                                   const float *f,
+                                                   float *x,
+                                                   cusparseSolvePolicy_t policy,
+                                                   void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, int, bsrsv2Info_t, const float *, float *, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrsv2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, alpha, descrA, bsrSortedValA,
-                  bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, f, x,
-                  policy, pBuffer);
+  return func_ptr(handle, dirA, transA, mb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, f, x, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsrsv2_solve(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, int mb, int nnzb, const double *alpha,
-    const cusparseMatDescr_t descrA, const double *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
-    bsrsv2Info_t info, const double *f, double *x, cusparseSolvePolicy_t policy,
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
-      const double *, const cusparseMatDescr_t, const double *, const int *,
-      const int *, int, bsrsv2Info_t, const double *, double *,
-      cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsrsv2_solve(cusparseHandle_t handle,
+                                                   cusparseDirection_t dirA,
+                                                   cusparseOperation_t transA,
+                                                   int mb,
+                                                   int nnzb,
+                                                   const double *alpha,
+                                                   const cusparseMatDescr_t descrA,
+                                                   const double *bsrSortedValA,
+                                                   const int *bsrSortedRowPtrA,
+                                                   const int *bsrSortedColIndA,
+                                                   int blockDim,
+                                                   bsrsv2Info_t info,
+                                                   const double *f,
+                                                   double *x,
+                                                   cusparseSolvePolicy_t policy,
+                                                   void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, int, bsrsv2Info_t, const double *, double *, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrsv2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, alpha, descrA, bsrSortedValA,
-                  bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, f, x,
-                  policy, pBuffer);
+  return func_ptr(handle, dirA, transA, mb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, f, x, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsrsv2_solve(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, int mb, int nnzb, const cuComplex *alpha,
-    const cusparseMatDescr_t descrA, const cuComplex *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
-    bsrsv2Info_t info, const cuComplex *f, cuComplex *x,
-    cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
-      const cuComplex *, const cusparseMatDescr_t, const cuComplex *,
-      const int *, const int *, int, bsrsv2Info_t, const cuComplex *,
-      cuComplex *, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsrsv2_solve(cusparseHandle_t handle,
+                                                   cusparseDirection_t dirA,
+                                                   cusparseOperation_t transA,
+                                                   int mb,
+                                                   int nnzb,
+                                                   const cuComplex *alpha,
+                                                   const cusparseMatDescr_t descrA,
+                                                   const cuComplex *bsrSortedValA,
+                                                   const int *bsrSortedRowPtrA,
+                                                   const int *bsrSortedColIndA,
+                                                   int blockDim,
+                                                   bsrsv2Info_t info,
+                                                   const cuComplex *f,
+                                                   cuComplex *x,
+                                                   cusparseSolvePolicy_t policy,
+                                                   void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, int, bsrsv2Info_t, const cuComplex *, cuComplex *, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrsv2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, alpha, descrA, bsrSortedValA,
-                  bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, f, x,
-                  policy, pBuffer);
+  return func_ptr(handle, dirA, transA, mb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, f, x, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrsv2_solve(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, int mb, int nnzb, const cuDoubleComplex *alpha,
-    const cusparseMatDescr_t descrA, const cuDoubleComplex *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
-    bsrsv2Info_t info, const cuDoubleComplex *f, cuDoubleComplex *x,
-    cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
-      const cuDoubleComplex *, const cusparseMatDescr_t,
-      const cuDoubleComplex *, const int *, const int *, int, bsrsv2Info_t,
-      const cuDoubleComplex *, cuDoubleComplex *, cusparseSolvePolicy_t,
-      void *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrsv2_solve(cusparseHandle_t handle,
+                                                   cusparseDirection_t dirA,
+                                                   cusparseOperation_t transA,
+                                                   int mb,
+                                                   int nnzb,
+                                                   const cuDoubleComplex *alpha,
+                                                   const cusparseMatDescr_t descrA,
+                                                   const cuDoubleComplex *bsrSortedValA,
+                                                   const int *bsrSortedRowPtrA,
+                                                   const int *bsrSortedColIndA,
+                                                   int blockDim,
+                                                   bsrsv2Info_t info,
+                                                   const cuDoubleComplex *f,
+                                                   cuDoubleComplex *x,
+                                                   cusparseSolvePolicy_t policy,
+                                                   void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, int, bsrsv2Info_t, const cuDoubleComplex *, cuDoubleComplex *, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrsv2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, alpha, descrA, bsrSortedValA,
-                  bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, f, x,
-                  policy, pBuffer);
+  return func_ptr(handle, dirA, transA, mb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, f, x, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseShybsv_analysis(cusparseHandle_t handle, cusparseOperation_t transA,
-                        const cusparseMatDescr_t descrA, cusparseHybMat_t hybA,
-                        cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, const cusparseMatDescr_t,
-      cusparseHybMat_t, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseShybsv_analysis(cusparseHandle_t handle,
+                                                     cusparseOperation_t transA,
+                                                     const cusparseMatDescr_t descrA,
+                                                     cusparseHybMat_t hybA,
+                                                     cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, const cusparseMatDescr_t, cusparseHybMat_t, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseShybsv_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, transA, descrA, hybA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseDhybsv_analysis(cusparseHandle_t handle, cusparseOperation_t transA,
-                        const cusparseMatDescr_t descrA, cusparseHybMat_t hybA,
-                        cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, const cusparseMatDescr_t,
-      cusparseHybMat_t, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseDhybsv_analysis(cusparseHandle_t handle,
+                                                     cusparseOperation_t transA,
+                                                     const cusparseMatDescr_t descrA,
+                                                     cusparseHybMat_t hybA,
+                                                     cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, const cusparseMatDescr_t, cusparseHybMat_t, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDhybsv_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, transA, descrA, hybA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseChybsv_analysis(cusparseHandle_t handle, cusparseOperation_t transA,
-                        const cusparseMatDescr_t descrA, cusparseHybMat_t hybA,
-                        cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, const cusparseMatDescr_t,
-      cusparseHybMat_t, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseChybsv_analysis(cusparseHandle_t handle,
+                                                     cusparseOperation_t transA,
+                                                     const cusparseMatDescr_t descrA,
+                                                     cusparseHybMat_t hybA,
+                                                     cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, const cusparseMatDescr_t, cusparseHybMat_t, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseChybsv_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, transA, descrA, hybA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseZhybsv_analysis(cusparseHandle_t handle, cusparseOperation_t transA,
-                        const cusparseMatDescr_t descrA, cusparseHybMat_t hybA,
-                        cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, const cusparseMatDescr_t,
-      cusparseHybMat_t, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseZhybsv_analysis(cusparseHandle_t handle,
+                                                     cusparseOperation_t transA,
+                                                     const cusparseMatDescr_t descrA,
+                                                     cusparseHybMat_t hybA,
+                                                     cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, const cusparseMatDescr_t, cusparseHybMat_t, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZhybsv_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, transA, descrA, hybA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseShybsv_solve(
-    cusparseHandle_t handle, cusparseOperation_t trans, const float *alpha,
-    const cusparseMatDescr_t descrA, const cusparseHybMat_t hybA,
-    cusparseSolveAnalysisInfo_t info, const float *f, float *x) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, const float *,
-      const cusparseMatDescr_t, const cusparseHybMat_t,
-      cusparseSolveAnalysisInfo_t, const float *, float *);
+cusparseStatus_t CUSPARSEAPI cusparseShybsv_solve(cusparseHandle_t handle,
+                                                  cusparseOperation_t trans,
+                                                  const float *alpha,
+                                                  const cusparseMatDescr_t descrA,
+                                                  const cusparseHybMat_t hybA,
+                                                  cusparseSolveAnalysisInfo_t info,
+                                                  const float *f,
+                                                  float *x) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, const float *, const cusparseMatDescr_t, const cusparseHybMat_t, cusparseSolveAnalysisInfo_t, const float *, float *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseShybsv_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, trans, alpha, descrA, hybA, info, f, x);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseChybsv_solve(
-    cusparseHandle_t handle, cusparseOperation_t trans, const cuComplex *alpha,
-    const cusparseMatDescr_t descrA, const cusparseHybMat_t hybA,
-    cusparseSolveAnalysisInfo_t info, const cuComplex *f, cuComplex *x) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, const cuComplex *,
-      const cusparseMatDescr_t, const cusparseHybMat_t,
-      cusparseSolveAnalysisInfo_t, const cuComplex *, cuComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseChybsv_solve(cusparseHandle_t handle,
+                                                  cusparseOperation_t trans,
+                                                  const cuComplex *alpha,
+                                                  const cusparseMatDescr_t descrA,
+                                                  const cusparseHybMat_t hybA,
+                                                  cusparseSolveAnalysisInfo_t info,
+                                                  const cuComplex *f,
+                                                  cuComplex *x) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, const cuComplex *, const cusparseMatDescr_t, const cusparseHybMat_t, cusparseSolveAnalysisInfo_t, const cuComplex *, cuComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseChybsv_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, trans, alpha, descrA, hybA, info, f, x);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDhybsv_solve(
-    cusparseHandle_t handle, cusparseOperation_t trans, const double *alpha,
-    const cusparseMatDescr_t descrA, const cusparseHybMat_t hybA,
-    cusparseSolveAnalysisInfo_t info, const double *f, double *x) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, const double *,
-      const cusparseMatDescr_t, const cusparseHybMat_t,
-      cusparseSolveAnalysisInfo_t, const double *, double *);
+cusparseStatus_t CUSPARSEAPI cusparseDhybsv_solve(cusparseHandle_t handle,
+                                                  cusparseOperation_t trans,
+                                                  const double *alpha,
+                                                  const cusparseMatDescr_t descrA,
+                                                  const cusparseHybMat_t hybA,
+                                                  cusparseSolveAnalysisInfo_t info,
+                                                  const double *f,
+                                                  double *x) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, const double *, const cusparseMatDescr_t, const cusparseHybMat_t, cusparseSolveAnalysisInfo_t, const double *, double *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDhybsv_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, trans, alpha, descrA, hybA, info, f, x);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZhybsv_solve(
-    cusparseHandle_t handle, cusparseOperation_t trans,
-    const cuDoubleComplex *alpha, const cusparseMatDescr_t descrA,
-    const cusparseHybMat_t hybA, cusparseSolveAnalysisInfo_t info,
-    const cuDoubleComplex *f, cuDoubleComplex *x) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, const cuDoubleComplex *,
-      const cusparseMatDescr_t, const cusparseHybMat_t,
-      cusparseSolveAnalysisInfo_t, const cuDoubleComplex *, cuDoubleComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseZhybsv_solve(cusparseHandle_t handle,
+                                                  cusparseOperation_t trans,
+                                                  const cuDoubleComplex *alpha,
+                                                  const cusparseMatDescr_t descrA,
+                                                  const cusparseHybMat_t hybA,
+                                                  cusparseSolveAnalysisInfo_t info,
+                                                  const cuDoubleComplex *f,
+                                                  cuDoubleComplex *x) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, const cuDoubleComplex *, const cusparseMatDescr_t, const cusparseHybMat_t, cusparseSolveAnalysisInfo_t, const cuDoubleComplex *, cuDoubleComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZhybsv_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, trans, alpha, descrA, hybA, info, f, x);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseScsrmm(cusparseHandle_t handle, cusparseOperation_t transA, int m,
-               int n, int k, int nnz, const float *alpha,
-               const cusparseMatDescr_t descrA, const float *csrSortedValA,
-               const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-               const float *B, int ldb, const float *beta, float *C, int ldc) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, int, int, const float *,
-      const cusparseMatDescr_t, const float *, const int *, const int *,
-      const float *, int, const float *, float *, int);
+cusparseStatus_t CUSPARSEAPI cusparseScsrmm(cusparseHandle_t handle,
+                                            cusparseOperation_t transA,
+                                            int m,
+                                            int n,
+                                            int k,
+                                            int nnz,
+                                            const float *alpha,
+                                            const cusparseMatDescr_t descrA,
+                                            const float  *csrSortedValA,
+                                            const int *csrSortedRowPtrA,
+                                            const int *csrSortedColIndA,
+                                            const float *B,
+                                            int ldb,
+                                            const float *beta,
+                                            float *C,
+                                            int ldc) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, int, const float *, const cusparseMatDescr_t, const float  *, const int *, const int *, const float *, int, const float *, float *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrmm");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, k, nnz, alpha, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, B, ldb, beta, C, ldc);
+  return func_ptr(handle, transA, m, n, k, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, beta, C, ldc);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrmm(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int k,
-    int nnz, const double *alpha, const cusparseMatDescr_t descrA,
-    const double *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, const double *B, int ldb, const double *beta,
-    double *C, int ldc) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, int, int, const double *,
-      const cusparseMatDescr_t, const double *, const int *, const int *,
-      const double *, int, const double *, double *, int);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrmm(cusparseHandle_t handle,
+                                            cusparseOperation_t transA,
+                                            int m,
+                                            int n,
+                                            int k,
+                                            int nnz,
+                                            const double *alpha,
+                                            const cusparseMatDescr_t descrA,
+                                            const double *csrSortedValA,
+                                            const int *csrSortedRowPtrA,
+                                            const int *csrSortedColIndA,
+                                            const double *B,
+                                            int ldb,
+                                            const double *beta,
+                                            double *C,
+                                            int ldc) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, const double *, int, const double *, double *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrmm");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, k, nnz, alpha, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, B, ldb, beta, C, ldc);
+  return func_ptr(handle, transA, m, n, k, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, beta, C, ldc);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrmm(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int k,
-    int nnz, const cuComplex *alpha, const cusparseMatDescr_t descrA,
-    const cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, const cuComplex *B, int ldb,
-    const cuComplex *beta, cuComplex *C, int ldc) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, int, int,
-      const cuComplex *, const cusparseMatDescr_t, const cuComplex *,
-      const int *, const int *, const cuComplex *, int, const cuComplex *,
-      cuComplex *, int);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrmm(cusparseHandle_t handle,
+                                            cusparseOperation_t transA,
+                                            int m,
+                                            int n,
+                                            int k,
+                                            int nnz,
+                                            const cuComplex *alpha,
+                                            const cusparseMatDescr_t descrA,
+                                            const cuComplex  *csrSortedValA,
+                                            const int *csrSortedRowPtrA,
+                                            const int *csrSortedColIndA,
+                                            const cuComplex *B,
+                                            int ldb,
+                                            const cuComplex *beta,
+                                            cuComplex *C,
+                                            int ldc) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, int, const cuComplex *, const cusparseMatDescr_t, const cuComplex  *, const int *, const int *, const cuComplex *, int, const cuComplex *, cuComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrmm");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, k, nnz, alpha, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, B, ldb, beta, C, ldc);
+  return func_ptr(handle, transA, m, n, k, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, beta, C, ldc);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrmm(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int k,
-    int nnz, const cuDoubleComplex *alpha, const cusparseMatDescr_t descrA,
-    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, const cuDoubleComplex *B, int ldb,
-    const cuDoubleComplex *beta, cuDoubleComplex *C, int ldc) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, int, int,
-      const cuDoubleComplex *, const cusparseMatDescr_t,
-      const cuDoubleComplex *, const int *, const int *,
-      const cuDoubleComplex *, int, const cuDoubleComplex *, cuDoubleComplex *,
-      int);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrmm(cusparseHandle_t handle,
+                                            cusparseOperation_t transA,
+                                            int m,
+                                            int n,
+                                            int k,
+                                            int nnz,
+                                            const cuDoubleComplex *alpha,
+                                            const cusparseMatDescr_t descrA,
+                                            const cuDoubleComplex  *csrSortedValA,
+                                            const int *csrSortedRowPtrA,
+                                            const int *csrSortedColIndA,
+                                            const cuDoubleComplex *B,
+                                            int ldb,
+                                            const cuDoubleComplex *beta,
+                                            cuDoubleComplex *C,
+                                            int ldc) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, const cuDoubleComplex  *, const int *, const int *, const cuDoubleComplex *, int, const cuDoubleComplex *, cuDoubleComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrmm");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, k, nnz, alpha, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, B, ldb, beta, C, ldc);
+  return func_ptr(handle, transA, m, n, k, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, beta, C, ldc);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseScsrmm2(cusparseHandle_t handle, cusparseOperation_t transA,
-                cusparseOperation_t transB, int m, int n, int k, int nnz,
-                const float *alpha, const cusparseMatDescr_t descrA,
-                const float *csrSortedValA, const int *csrSortedRowPtrA,
-                const int *csrSortedColIndA, const float *B, int ldb,
-                const float *beta, float *C, int ldc) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int,
-      int, const float *, const cusparseMatDescr_t, const float *, const int *,
-      const int *, const float *, int, const float *, float *, int);
+cusparseStatus_t CUSPARSEAPI cusparseScsrmm2(cusparseHandle_t handle,
+                                             cusparseOperation_t transA,
+                                             cusparseOperation_t transB,
+                                             int m,
+                                             int n,
+                                             int k,
+                                             int nnz,
+                                             const float *alpha,
+                                             const cusparseMatDescr_t descrA,
+                                             const float *csrSortedValA,
+                                             const int *csrSortedRowPtrA,
+                                             const int *csrSortedColIndA,
+                                             const float *B,
+                                             int ldb,
+                                             const float *beta,
+                                             float *C,
+                                             int ldc) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int, int, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, const float *, int, const float *, float *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrmm2");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, transB, m, n, k, nnz, alpha, descrA,
-                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
-                  beta, C, ldc);
+  return func_ptr(handle, transA, transB, m, n, k, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, beta, C, ldc);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseDcsrmm2(cusparseHandle_t handle, cusparseOperation_t transA,
-                cusparseOperation_t transB, int m, int n, int k, int nnz,
-                const double *alpha, const cusparseMatDescr_t descrA,
-                const double *csrSortedValA, const int *csrSortedRowPtrA,
-                const int *csrSortedColIndA, const double *B, int ldb,
-                const double *beta, double *C, int ldc) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int,
-      int, const double *, const cusparseMatDescr_t, const double *,
-      const int *, const int *, const double *, int, const double *, double *,
-      int);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrmm2(cusparseHandle_t handle,
+                                             cusparseOperation_t transA,
+                                             cusparseOperation_t transB,
+                                             int m,
+                                             int n,
+                                             int k,
+                                             int nnz,
+                                             const double *alpha,
+                                             const cusparseMatDescr_t descrA,
+                                             const double *csrSortedValA,
+                                             const int *csrSortedRowPtrA,
+                                             const int *csrSortedColIndA,
+                                             const double *B,
+                                             int ldb,
+                                             const double *beta,
+                                             double *C,
+                                             int ldc) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, const double *, int, const double *, double *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrmm2");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, transB, m, n, k, nnz, alpha, descrA,
-                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
-                  beta, C, ldc);
+  return func_ptr(handle, transA, transB, m, n, k, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, beta, C, ldc);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseCcsrmm2(cusparseHandle_t handle, cusparseOperation_t transA,
-                cusparseOperation_t transB, int m, int n, int k, int nnz,
-                const cuComplex *alpha, const cusparseMatDescr_t descrA,
-                const cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
-                const int *csrSortedColIndA, const cuComplex *B, int ldb,
-                const cuComplex *beta, cuComplex *C, int ldc) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int,
-      int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *,
-      const int *, const int *, const cuComplex *, int, const cuComplex *,
-      cuComplex *, int);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrmm2(cusparseHandle_t handle,
+                                             cusparseOperation_t transA,
+                                             cusparseOperation_t transB,
+                                             int m,
+                                             int n,
+                                             int k,
+                                             int nnz,
+                                             const cuComplex *alpha,
+                                             const cusparseMatDescr_t descrA,
+                                             const cuComplex *csrSortedValA,
+                                             const int *csrSortedRowPtrA,
+                                             const int *csrSortedColIndA,
+                                             const cuComplex *B,
+                                             int ldb,
+                                             const cuComplex *beta,
+                                             cuComplex *C,
+                                             int ldc) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int, int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, const cuComplex *, int, const cuComplex *, cuComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrmm2");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, transB, m, n, k, nnz, alpha, descrA,
-                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
-                  beta, C, ldc);
+  return func_ptr(handle, transA, transB, m, n, k, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, beta, C, ldc);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrmm2(
-    cusparseHandle_t handle, cusparseOperation_t transA,
-    cusparseOperation_t transB, int m, int n, int k, int nnz,
-    const cuDoubleComplex *alpha, const cusparseMatDescr_t descrA,
-    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, const cuDoubleComplex *B, int ldb,
-    const cuDoubleComplex *beta, cuDoubleComplex *C, int ldc) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int,
-      int, const cuDoubleComplex *, const cusparseMatDescr_t,
-      const cuDoubleComplex *, const int *, const int *,
-      const cuDoubleComplex *, int, const cuDoubleComplex *, cuDoubleComplex *,
-      int);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrmm2(cusparseHandle_t handle,
+                                             cusparseOperation_t transA,
+                                             cusparseOperation_t transB,
+                                             int m,
+                                             int n,
+                                             int k,
+                                             int nnz,
+                                             const cuDoubleComplex *alpha,
+                                             const cusparseMatDescr_t descrA,
+                                             const cuDoubleComplex *csrSortedValA,
+                                             const int *csrSortedRowPtrA,
+                                             const int *csrSortedColIndA,
+                                             const cuDoubleComplex *B,
+                                             int ldb,
+                                             const cuDoubleComplex *beta,
+                                             cuDoubleComplex *C,
+                                             int ldc) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, const cuDoubleComplex *, int, const cuDoubleComplex *, cuDoubleComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrmm2");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, transB, m, n, k, nnz, alpha, descrA,
-                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
-                  beta, C, ldc);
+  return func_ptr(handle, transA, transB, m, n, k, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, beta, C, ldc);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsrmm(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, cusparseOperation_t transB, int mb, int n,
-    int kb, int nnzb, const float *alpha, const cusparseMatDescr_t descrA,
-    const float *bsrSortedValA, const int *bsrSortedRowPtrA,
-    const int *bsrSortedColIndA, const int blockSize, const float *B,
-    const int ldb, const float *beta, float *C, int ldc) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
-      cusparseOperation_t, int, int, int, int, const float *,
-      const cusparseMatDescr_t, const float *, const int *, const int *,
-      const int, const float *, const int, const float *, float *, int);
+cusparseStatus_t CUSPARSEAPI cusparseSbsrmm(cusparseHandle_t handle,
+                                            cusparseDirection_t dirA,
+                                            cusparseOperation_t transA,
+                                            cusparseOperation_t transB,
+                                            int mb,
+                                            int n,
+                                            int kb,
+                                            int nnzb,
+                                            const float *alpha,
+                                            const cusparseMatDescr_t descrA,
+                                            const float *bsrSortedValA,
+                                            const int *bsrSortedRowPtrA,
+                                            const int *bsrSortedColIndA,
+                                            const int  blockSize,
+                                            const float *B,
+                                            const int ldb,
+                                            const float *beta,
+                                            float *C,
+                                            int ldc) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, int, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, const int, const float *, const int, const float *, float *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrmm");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transB, mb, n, kb, nnzb, alpha, descrA,
-                  bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockSize,
-                  B, ldb, beta, C, ldc);
+  return func_ptr(handle, dirA, transA, transB, mb, n, kb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockSize, B, ldb, beta, C, ldc);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsrmm(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, cusparseOperation_t transB, int mb, int n,
-    int kb, int nnzb, const double *alpha, const cusparseMatDescr_t descrA,
-    const double *bsrSortedValA, const int *bsrSortedRowPtrA,
-    const int *bsrSortedColIndA, const int blockSize, const double *B,
-    const int ldb, const double *beta, double *C, int ldc) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
-      cusparseOperation_t, int, int, int, int, const double *,
-      const cusparseMatDescr_t, const double *, const int *, const int *,
-      const int, const double *, const int, const double *, double *, int);
+cusparseStatus_t CUSPARSEAPI cusparseDbsrmm(cusparseHandle_t handle,
+                                            cusparseDirection_t dirA,
+                                            cusparseOperation_t transA,
+                                            cusparseOperation_t transB,
+                                            int mb,
+                                            int n,
+                                            int kb,
+                                            int nnzb,
+                                            const double *alpha,
+                                            const cusparseMatDescr_t descrA,
+                                            const double *bsrSortedValA,
+                                            const int *bsrSortedRowPtrA,
+                                            const int *bsrSortedColIndA,
+                                            const int  blockSize,
+                                            const double *B,
+                                            const int ldb,
+                                            const double *beta,
+                                            double *C,
+                                            int ldc) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, const int, const double *, const int, const double *, double *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrmm");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transB, mb, n, kb, nnzb, alpha, descrA,
-                  bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockSize,
-                  B, ldb, beta, C, ldc);
+  return func_ptr(handle, dirA, transA, transB, mb, n, kb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockSize, B, ldb, beta, C, ldc);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsrmm(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, cusparseOperation_t transB, int mb, int n,
-    int kb, int nnzb, const cuComplex *alpha, const cusparseMatDescr_t descrA,
-    const cuComplex *bsrSortedValA, const int *bsrSortedRowPtrA,
-    const int *bsrSortedColIndA, const int blockSize, const cuComplex *B,
-    const int ldb, const cuComplex *beta, cuComplex *C, int ldc) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
-      cusparseOperation_t, int, int, int, int, const cuComplex *,
-      const cusparseMatDescr_t, const cuComplex *, const int *, const int *,
-      const int, const cuComplex *, const int, const cuComplex *, cuComplex *,
-      int);
+cusparseStatus_t CUSPARSEAPI cusparseCbsrmm(cusparseHandle_t handle,
+                                            cusparseDirection_t dirA,
+                                            cusparseOperation_t transA,
+                                            cusparseOperation_t transB,
+                                            int mb,
+                                            int n,
+                                            int kb,
+                                            int nnzb,
+                                            const cuComplex *alpha,
+                                            const cusparseMatDescr_t descrA,
+                                            const cuComplex *bsrSortedValA,
+                                            const int *bsrSortedRowPtrA,
+                                            const int *bsrSortedColIndA,
+                                            const int  blockSize,
+                                            const cuComplex *B,
+                                            const int ldb,
+                                            const cuComplex *beta,
+                                            cuComplex *C,
+                                            int ldc) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, const int, const cuComplex *, const int, const cuComplex *, cuComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrmm");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transB, mb, n, kb, nnzb, alpha, descrA,
-                  bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockSize,
-                  B, ldb, beta, C, ldc);
+  return func_ptr(handle, dirA, transA, transB, mb, n, kb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockSize, B, ldb, beta, C, ldc);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrmm(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, cusparseOperation_t transB, int mb, int n,
-    int kb, int nnzb, const cuDoubleComplex *alpha,
-    const cusparseMatDescr_t descrA, const cuDoubleComplex *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA,
-    const int blockSize, const cuDoubleComplex *B, const int ldb,
-    const cuDoubleComplex *beta, cuDoubleComplex *C, int ldc) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
-      cusparseOperation_t, int, int, int, int, const cuDoubleComplex *,
-      const cusparseMatDescr_t, const cuDoubleComplex *, const int *,
-      const int *, const int, const cuDoubleComplex *, const int,
-      const cuDoubleComplex *, cuDoubleComplex *, int);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrmm(cusparseHandle_t handle,
+                                            cusparseDirection_t dirA,
+                                            cusparseOperation_t transA,
+                                            cusparseOperation_t transB,
+                                            int mb,
+                                            int n,
+                                            int kb,
+                                            int nnzb,
+                                            const cuDoubleComplex *alpha,
+                                            const cusparseMatDescr_t descrA,
+                                            const cuDoubleComplex *bsrSortedValA,
+                                            const int *bsrSortedRowPtrA,
+                                            const int *bsrSortedColIndA,
+                                            const int  blockSize,
+                                            const cuDoubleComplex *B,
+                                            const int ldb,
+                                            const cuDoubleComplex *beta,
+                                            cuDoubleComplex *C,
+                                            int ldc) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, const int, const cuDoubleComplex *, const int, const cuDoubleComplex *, cuDoubleComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrmm");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transB, mb, n, kb, nnzb, alpha, descrA,
-                  bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockSize,
-                  B, ldb, beta, C, ldc);
+  return func_ptr(handle, dirA, transA, transB, mb, n, kb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockSize, B, ldb, beta, C, ldc);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSgemmi(
-    cusparseHandle_t handle, int m, int n, int k, int nnz, const float *alpha,
-    const float *A, int lda, const float *cscValB, const int *cscColPtrB,
-    const int *cscRowIndB, const float *beta, float *C, int ldc) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, int, const float *, const float *, int,
-      const float *, const int *, const int *, const float *, float *, int);
+cusparseStatus_t  CUSPARSEAPI cusparseSgemmi(cusparseHandle_t handle,
+                                             int m,
+                                             int n,
+					     int k,
+					     int nnz,
+                                             const float *alpha, /* host or device pointer */
+                                             const float *A,
+                                             int lda,
+                                             const float *cscValB,
+					     const int *cscColPtrB,
+					     const int *cscRowIndB,
+                                             const float *beta, /* host or device pointer */
+                                             float *C,
+                                             int ldc) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, int, const float *, const float *, int, const float *, const int *, const int *, const float *, float *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgemmi");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, k, nnz, alpha, A, lda, cscValB, cscColPtrB,
-                  cscRowIndB, beta, C, ldc);
+  return func_ptr(handle, m, n, k, nnz, alpha, A, lda, cscValB, cscColPtrB, cscRowIndB, beta, C, ldc);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDgemmi(
-    cusparseHandle_t handle, int m, int n, int k, int nnz, const double *alpha,
-    const double *A, int lda, const double *cscValB, const int *cscColPtrB,
-    const int *cscRowIndB, const double *beta, double *C, int ldc) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, int, const double *, const double *, int,
-      const double *, const int *, const int *, const double *, double *, int);
+cusparseStatus_t  CUSPARSEAPI cusparseDgemmi(cusparseHandle_t handle,
+                                             int m,
+                                             int n,
+					     int k,
+					     int nnz,
+                                             const double *alpha, /* host or device pointer */
+                                             const double *A,
+                                             int lda,
+                                             const double *cscValB,
+					     const int *cscColPtrB,
+					     const int *cscRowIndB,
+                                             const double *beta, /* host or device pointer */
+                                             double *C,
+                                             int ldc) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, int, const double *, const double *, int, const double *, const int *, const int *, const double *, double *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgemmi");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, k, nnz, alpha, A, lda, cscValB, cscColPtrB,
-                  cscRowIndB, beta, C, ldc);
+  return func_ptr(handle, m, n, k, nnz, alpha, A, lda, cscValB, cscColPtrB, cscRowIndB, beta, C, ldc);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCgemmi(
-    cusparseHandle_t handle, int m, int n, int k, int nnz,
-    const cuComplex *alpha, const cuComplex *A, int lda,
-    const cuComplex *cscValB, const int *cscColPtrB, const int *cscRowIndB,
-    const cuComplex *beta, cuComplex *C, int ldc) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, int, const cuComplex *,
-      const cuComplex *, int, const cuComplex *, const int *, const int *,
-      const cuComplex *, cuComplex *, int);
+cusparseStatus_t  CUSPARSEAPI cusparseCgemmi(cusparseHandle_t handle,
+                                             int m,
+                                             int n,
+					     int k,
+					     int nnz,
+                                             const cuComplex *alpha, /* host or device pointer */
+                                             const cuComplex *A,
+                                             int lda,
+                                             const cuComplex *cscValB,
+					     const int *cscColPtrB,
+					     const int *cscRowIndB,
+                                             const cuComplex *beta, /* host or device pointer */
+                                             cuComplex *C,
+                                             int ldc) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, int, const cuComplex *, const cuComplex *, int, const cuComplex *, const int *, const int *, const cuComplex *, cuComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgemmi");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, k, nnz, alpha, A, lda, cscValB, cscColPtrB,
-                  cscRowIndB, beta, C, ldc);
+  return func_ptr(handle, m, n, k, nnz, alpha, A, lda, cscValB, cscColPtrB, cscRowIndB, beta, C, ldc);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseZgemmi(cusparseHandle_t handle, int m, int n, int k, int nnz,
-               const cuDoubleComplex *alpha, const cuDoubleComplex *A, int lda,
-               const cuDoubleComplex *cscValB, const int *cscColPtrB,
-               const int *cscRowIndB, const cuDoubleComplex *beta,
-               cuDoubleComplex *C, int ldc) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, int, const cuDoubleComplex *,
-      const cuDoubleComplex *, int, const cuDoubleComplex *, const int *,
-      const int *, const cuDoubleComplex *, cuDoubleComplex *, int);
+cusparseStatus_t  CUSPARSEAPI cusparseZgemmi(cusparseHandle_t handle,
+                                             int m,
+                                             int n,
+					     int k,
+					     int nnz,
+                                             const cuDoubleComplex *alpha, /* host or device pointer */
+                                             const cuDoubleComplex *A,
+                                             int lda,
+                                             const cuDoubleComplex *cscValB,
+					     const int *cscColPtrB,
+					     const int *cscRowIndB,
+                                             const cuDoubleComplex *beta, /* host or device pointer */
+                                             cuDoubleComplex *C,
+                                             int ldc) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, int, const cuDoubleComplex *, const cuDoubleComplex *, int, const cuDoubleComplex *, const int *, const int *, const cuDoubleComplex *, cuDoubleComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgemmi");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, k, nnz, alpha, A, lda, cscValB, cscColPtrB,
-                  cscRowIndB, beta, C, ldc);
+  return func_ptr(handle, m, n, k, nnz, alpha, A, lda, cscValB, cscColPtrB, cscRowIndB, beta, C, ldc);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrsm_analysis(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
-    const cusparseMatDescr_t descrA, const float *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
-      const float *, const int *, const int *, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseScsrsm_analysis(cusparseHandle_t handle,
+                                                     cusparseOperation_t transA,
+                                                     int m,
+                                                     int nnz,
+                                                     const cusparseMatDescr_t descrA,
+                                                     const float *csrSortedValA,
+                                                     const int *csrSortedRowPtrA,
+                                                     const int *csrSortedColIndA,
+                                                     cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrsm_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrsm_analysis(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
-    const cusparseMatDescr_t descrA, const double *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
-      const double *, const int *, const int *, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrsm_analysis(cusparseHandle_t handle,
+                                                     cusparseOperation_t transA,
+                                                     int m,
+                                                     int nnz,
+                                                     const cusparseMatDescr_t descrA,
+                                                     const double *csrSortedValA,
+                                                     const int *csrSortedRowPtrA,
+                                                     const int *csrSortedColIndA,
+                                                     cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrsm_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrsm_analysis(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
-    const cusparseMatDescr_t descrA, const cuComplex *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
-      const cuComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrsm_analysis(cusparseHandle_t handle,
+                                                     cusparseOperation_t transA,
+                                                     int m,
+                                                     int nnz,
+                                                     const cusparseMatDescr_t descrA,
+                                                     const cuComplex *csrSortedValA,
+                                                     const int *csrSortedRowPtrA,
+                                                     const int *csrSortedColIndA,
+                                                     cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrsm_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrsm_analysis(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
-    const cusparseMatDescr_t descrA, const cuDoubleComplex *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
-      const cuDoubleComplex *, const int *, const int *,
-      cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrsm_analysis(cusparseHandle_t handle,
+                                                     cusparseOperation_t transA,
+                                                     int m,
+                                                     int nnz,
+                                                     const cusparseMatDescr_t descrA,
+                                                     const cuDoubleComplex *csrSortedValA,
+                                                     const int *csrSortedRowPtrA,
+                                                     const int *csrSortedColIndA,
+                                                     cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrsm_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrsm_solve(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int n,
-    const float *alpha, const cusparseMatDescr_t descrA,
-    const float *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, cusparseSolveAnalysisInfo_t info,
-    const float *B, int ldb, float *X, int ldx) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const float *,
-      const cusparseMatDescr_t, const float *, const int *, const int *,
-      cusparseSolveAnalysisInfo_t, const float *, int, float *, int);
+cusparseStatus_t CUSPARSEAPI cusparseScsrsm_solve(cusparseHandle_t handle,
+                                                  cusparseOperation_t transA,
+                                                  int m,
+                                                  int n,
+                                                  const float *alpha,
+                                                  const cusparseMatDescr_t descrA,
+                                                  const float *csrSortedValA,
+                                                  const int *csrSortedRowPtrA,
+                                                  const int *csrSortedColIndA,
+                                                  cusparseSolveAnalysisInfo_t info,
+                                                  const float *B,
+                                                  int ldb,
+                                                  float *X,
+                                                  int ldx) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, cusparseSolveAnalysisInfo_t, const float *, int, float *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrsm_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, alpha, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info, B, ldb, X, ldx);
+  return func_ptr(handle, transA, m, n, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, B, ldb, X, ldx);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrsm_solve(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int n,
-    const double *alpha, const cusparseMatDescr_t descrA,
-    const double *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, cusparseSolveAnalysisInfo_t info,
-    const double *B, int ldb, double *X, int ldx) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const double *,
-      const cusparseMatDescr_t, const double *, const int *, const int *,
-      cusparseSolveAnalysisInfo_t, const double *, int, double *, int);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrsm_solve(cusparseHandle_t handle,
+                                                  cusparseOperation_t transA,
+                                                  int m,
+                                                  int n,
+                                                  const double *alpha,
+                                                  const cusparseMatDescr_t descrA,
+                                                  const double *csrSortedValA,
+                                                  const int *csrSortedRowPtrA,
+                                                  const int *csrSortedColIndA,
+                                                  cusparseSolveAnalysisInfo_t info,
+                                                  const double *B,
+                                                  int ldb,
+                                                  double *X,
+                                                  int ldx) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, cusparseSolveAnalysisInfo_t, const double *, int, double *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrsm_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, alpha, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info, B, ldb, X, ldx);
+  return func_ptr(handle, transA, m, n, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, B, ldb, X, ldx);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrsm_solve(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int n,
-    const cuComplex *alpha, const cusparseMatDescr_t descrA,
-    const cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, cusparseSolveAnalysisInfo_t info,
-    const cuComplex *B, int ldb, cuComplex *X, int ldx) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const cuComplex *,
-      const cusparseMatDescr_t, const cuComplex *, const int *, const int *,
-      cusparseSolveAnalysisInfo_t, const cuComplex *, int, cuComplex *, int);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrsm_solve(cusparseHandle_t handle,
+                                                  cusparseOperation_t transA,
+                                                  int m,
+                                                  int n,
+                                                  const cuComplex *alpha,
+                                                  const cusparseMatDescr_t descrA,
+                                                  const cuComplex *csrSortedValA,
+                                                  const int *csrSortedRowPtrA,
+                                                  const int *csrSortedColIndA,
+                                                  cusparseSolveAnalysisInfo_t info,
+                                                  const cuComplex *B,
+                                                  int ldb,
+                                                  cuComplex *X,
+                                                  int ldx) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t, const cuComplex *, int, cuComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrsm_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, alpha, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info, B, ldb, X, ldx);
+  return func_ptr(handle, transA, m, n, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, B, ldb, X, ldx);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrsm_solve(
-    cusparseHandle_t handle, cusparseOperation_t transA, int m, int n,
-    const cuDoubleComplex *alpha, const cusparseMatDescr_t descrA,
-    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, cusparseSolveAnalysisInfo_t info,
-    const cuDoubleComplex *B, int ldb, cuDoubleComplex *X, int ldx) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, int, const cuDoubleComplex *,
-      const cusparseMatDescr_t, const cuDoubleComplex *, const int *,
-      const int *, cusparseSolveAnalysisInfo_t, const cuDoubleComplex *, int,
-      cuDoubleComplex *, int);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrsm_solve(cusparseHandle_t handle,
+                                                  cusparseOperation_t transA,
+                                                  int m,
+                                                  int n,
+                                                  const cuDoubleComplex *alpha,
+                                                  const cusparseMatDescr_t descrA,
+                                                  const cuDoubleComplex *csrSortedValA,
+                                                  const int *csrSortedRowPtrA,
+                                                  const int *csrSortedColIndA,
+                                                  cusparseSolveAnalysisInfo_t info,
+                                                  const cuDoubleComplex *B,
+                                                  int ldb,
+                                                  cuDoubleComplex *X,
+                                                  int ldx) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t, const cuDoubleComplex *, int, cuDoubleComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrsm_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, alpha, descrA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, info, B, ldb, X, ldx);
+  return func_ptr(handle, transA, m, n, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, B, ldb, X, ldx);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCreateCsrsm2Info(csrsm2Info_t *info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(csrsm2Info_t *);
+cusparseStatus_t CUSPARSEAPI cusparseCreateCsrsm2Info(
+    csrsm2Info_t *info) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(csrsm2Info_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateCsrsm2Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDestroyCsrsm2Info(csrsm2Info_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(csrsm2Info_t);
+cusparseStatus_t CUSPARSEAPI cusparseDestroyCsrsm2Info(
+    csrsm2Info_t info) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(csrsm2Info_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyCsrsm2Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseXcsrsm2_zeroPivot(cusparseHandle_t handle,
-                                                       csrsm2Info_t info,
-                                                       int *position) {
-  using FuncPtr =
-      cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, csrsm2Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseXcsrsm2_zeroPivot(
+    cusparseHandle_t handle,
+    csrsm2Info_t info,
+    int *position) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, csrsm2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcsrsm2_zeroPivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, position);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseScsrsm2_bufferSizeExt(
-    cusparseHandle_t handle, int algo, cusparseOperation_t transA,
-    cusparseOperation_t transB, int m, int nrhs, int nnz, const float *alpha,
-    const cusparseMatDescr_t descrA, const float *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, const float *B,
-    int ldb, csrsm2Info_t info, cusparseSolvePolicy_t policy,
+    cusparseHandle_t handle,
+    int algo, /* algo = 0, 1 */
+    cusparseOperation_t transA,
+    cusparseOperation_t transB,
+    int m,
+    int nrhs,
+    int nnz,
+    const float *alpha,
+    const cusparseMatDescr_t descrA,
+    const float *csrSortedValA,
+    const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA,
+    const float *B,
+    int ldb,
+    csrsm2Info_t info,
+    cusparseSolvePolicy_t policy,
     size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int,
-      int, const float *, const cusparseMatDescr_t, const float *, const int *,
-      const int *, const float *, int, csrsm2Info_t, cusparseSolvePolicy_t,
-      size_t *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int, int, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, const float *, int, csrsm2Info_t, cusparseSolvePolicy_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrsm2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA,
-                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
-                  info, policy, pBufferSize);
+  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, info, policy, pBufferSize);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDcsrsm2_bufferSizeExt(
-    cusparseHandle_t handle, int algo, cusparseOperation_t transA,
-    cusparseOperation_t transB, int m, int nrhs, int nnz, const double *alpha,
-    const cusparseMatDescr_t descrA, const double *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, const double *B,
-    int ldb, csrsm2Info_t info, cusparseSolvePolicy_t policy,
+    cusparseHandle_t handle,
+    int algo, /* algo = 0, 1 */
+    cusparseOperation_t transA,
+    cusparseOperation_t transB,
+    int m,
+    int nrhs,
+    int nnz,
+    const double *alpha,
+    const cusparseMatDescr_t descrA,
+    const double *csrSortedValA,
+    const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA,
+    const double *B,
+    int ldb,
+    csrsm2Info_t info,
+    cusparseSolvePolicy_t policy,
     size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int,
-      int, const double *, const cusparseMatDescr_t, const double *,
-      const int *, const int *, const double *, int, csrsm2Info_t,
-      cusparseSolvePolicy_t, size_t *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, const double *, int, csrsm2Info_t, cusparseSolvePolicy_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrsm2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA,
-                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
-                  info, policy, pBufferSize);
+  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, info, policy, pBufferSize);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCcsrsm2_bufferSizeExt(
-    cusparseHandle_t handle, int algo, cusparseOperation_t transA,
-    cusparseOperation_t transB, int m, int nrhs, int nnz,
-    const cuComplex *alpha, const cusparseMatDescr_t descrA,
-    const cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, const cuComplex *B, int ldb, csrsm2Info_t info,
-    cusparseSolvePolicy_t policy, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int,
-      int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *,
-      const int *, const int *, const cuComplex *, int, csrsm2Info_t,
-      cusparseSolvePolicy_t, size_t *);
+    cusparseHandle_t handle,
+    int algo, /* algo = 0, 1 */
+    cusparseOperation_t transA,
+    cusparseOperation_t transB,
+    int m,
+    int nrhs,
+    int nnz,
+    const cuComplex *alpha,
+    const cusparseMatDescr_t descrA,
+    const cuComplex *csrSortedValA,
+    const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA,
+    const cuComplex *B,
+    int ldb,
+    csrsm2Info_t info,
+    cusparseSolvePolicy_t policy,
+    size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int, int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, const cuComplex *, int, csrsm2Info_t, cusparseSolvePolicy_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrsm2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA,
-                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
-                  info, policy, pBufferSize);
+  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, info, policy, pBufferSize);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseZcsrsm2_bufferSizeExt(
-    cusparseHandle_t handle, int algo, cusparseOperation_t transA,
-    cusparseOperation_t transB, int m, int nrhs, int nnz,
-    const cuDoubleComplex *alpha, const cusparseMatDescr_t descrA,
-    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, const cuDoubleComplex *B, int ldb,
-    csrsm2Info_t info, cusparseSolvePolicy_t policy, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int,
-      int, const cuDoubleComplex *, const cusparseMatDescr_t,
-      const cuDoubleComplex *, const int *, const int *,
-      const cuDoubleComplex *, int, csrsm2Info_t, cusparseSolvePolicy_t,
-      size_t *);
+    cusparseHandle_t handle,
+    int algo, /* algo = 0, 1 */
+    cusparseOperation_t transA,
+    cusparseOperation_t transB,
+    int m,
+    int nrhs,
+    int nnz,
+    const cuDoubleComplex *alpha,
+    const cusparseMatDescr_t descrA,
+    const cuDoubleComplex *csrSortedValA,
+    const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA,
+    const cuDoubleComplex *B,
+    int ldb,
+    csrsm2Info_t info,
+    cusparseSolvePolicy_t policy,
+    size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, const cuDoubleComplex *, int, csrsm2Info_t, cusparseSolvePolicy_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrsm2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA,
-                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
-                  info, policy, pBufferSize);
+  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, info, policy, pBufferSize);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseScsrsm2_analysis(
-    cusparseHandle_t handle, int algo, cusparseOperation_t transA,
-    cusparseOperation_t transB, int m, int nrhs, int nnz, const float *alpha,
-    const cusparseMatDescr_t descrA, const float *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, const float *B,
-    int ldb, csrsm2Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int,
-      int, const float *, const cusparseMatDescr_t, const float *, const int *,
-      const int *, const float *, int, csrsm2Info_t, cusparseSolvePolicy_t,
-      void *);
+    cusparseHandle_t handle,
+    int algo, /* algo = 0, 1 */
+    cusparseOperation_t transA,
+    cusparseOperation_t transB,
+    int m,
+    int nrhs,
+    int nnz,
+    const float *alpha,
+    const cusparseMatDescr_t descrA,
+    const float *csrSortedValA,
+    const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA,
+    const float *B,
+    int ldb,
+    csrsm2Info_t info,
+    cusparseSolvePolicy_t policy,
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int, int, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, const float *, int, csrsm2Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrsm2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA,
-                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
-                  info, policy, pBuffer);
+  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, info, policy, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDcsrsm2_analysis(
-    cusparseHandle_t handle, int algo, cusparseOperation_t transA,
-    cusparseOperation_t transB, int m, int nrhs, int nnz, const double *alpha,
-    const cusparseMatDescr_t descrA, const double *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, const double *B,
-    int ldb, csrsm2Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int,
-      int, const double *, const cusparseMatDescr_t, const double *,
-      const int *, const int *, const double *, int, csrsm2Info_t,
-      cusparseSolvePolicy_t, void *);
+    cusparseHandle_t handle,
+    int algo, /* algo = 0, 1 */
+    cusparseOperation_t transA,
+    cusparseOperation_t transB,
+    int m,
+    int nrhs,
+    int nnz,
+    const double *alpha,
+    const cusparseMatDescr_t descrA,
+    const double *csrSortedValA,
+    const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA,
+    const double *B,
+    int ldb,
+    csrsm2Info_t info,
+    cusparseSolvePolicy_t policy,
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, const double *, int, csrsm2Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrsm2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA,
-                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
-                  info, policy, pBuffer);
+  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, info, policy, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCcsrsm2_analysis(
-    cusparseHandle_t handle, int algo, cusparseOperation_t transA,
-    cusparseOperation_t transB, int m, int nrhs, int nnz,
-    const cuComplex *alpha, const cusparseMatDescr_t descrA,
-    const cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, const cuComplex *B, int ldb, csrsm2Info_t info,
-    cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int,
-      int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *,
-      const int *, const int *, const cuComplex *, int, csrsm2Info_t,
-      cusparseSolvePolicy_t, void *);
+    cusparseHandle_t handle,
+    int algo, /* algo = 0, 1 */
+    cusparseOperation_t transA,
+    cusparseOperation_t transB,
+    int m,
+    int nrhs,
+    int nnz,
+    const cuComplex *alpha,
+    const cusparseMatDescr_t descrA,
+    const cuComplex *csrSortedValA,
+    const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA,
+    const cuComplex *B,
+    int ldb,
+    csrsm2Info_t info,
+    cusparseSolvePolicy_t policy,
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int, int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, const cuComplex *, int, csrsm2Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrsm2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA,
-                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
-                  info, policy, pBuffer);
+  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, info, policy, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseZcsrsm2_analysis(
-    cusparseHandle_t handle, int algo, cusparseOperation_t transA,
-    cusparseOperation_t transB, int m, int nrhs, int nnz,
-    const cuDoubleComplex *alpha, const cusparseMatDescr_t descrA,
-    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, const cuDoubleComplex *B, int ldb,
-    csrsm2Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int,
-      int, const cuDoubleComplex *, const cusparseMatDescr_t,
-      const cuDoubleComplex *, const int *, const int *,
-      const cuDoubleComplex *, int, csrsm2Info_t, cusparseSolvePolicy_t,
-      void *);
+    cusparseHandle_t handle,
+    int algo, /* algo = 0, 1 */
+    cusparseOperation_t transA,
+    cusparseOperation_t transB,
+    int m,
+    int nrhs,
+    int nnz,
+    const cuDoubleComplex *alpha,
+    const cusparseMatDescr_t descrA,
+    const cuDoubleComplex *csrSortedValA,
+    const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA,
+    const cuDoubleComplex *B,
+    int ldb,
+    csrsm2Info_t info,
+    cusparseSolvePolicy_t policy,
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, const cuDoubleComplex *, int, csrsm2Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrsm2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA,
-                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
-                  info, policy, pBuffer);
+  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, info, policy, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseScsrsm2_solve(
-    cusparseHandle_t handle, int algo, cusparseOperation_t transA,
-    cusparseOperation_t transB, int m, int nrhs, int nnz, const float *alpha,
-    const cusparseMatDescr_t descrA, const float *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, float *B, int ldb,
-    csrsm2Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int,
-      int, const float *, const cusparseMatDescr_t, const float *, const int *,
-      const int *, float *, int, csrsm2Info_t, cusparseSolvePolicy_t, void *);
+    cusparseHandle_t handle,
+    int algo, /* algo = 0, 1 */
+    cusparseOperation_t transA,
+    cusparseOperation_t transB,
+    int m,
+    int nrhs,
+    int nnz,
+    const float *alpha,
+    const cusparseMatDescr_t descrA,
+    const float *csrSortedValA,
+    const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA,
+    float *B,
+    int ldb,
+    csrsm2Info_t info,
+    cusparseSolvePolicy_t policy,
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int, int, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, float *, int, csrsm2Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrsm2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA,
-                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
-                  info, policy, pBuffer);
+  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, info, policy, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDcsrsm2_solve(
-    cusparseHandle_t handle, int algo, cusparseOperation_t transA,
-    cusparseOperation_t transB, int m, int nrhs, int nnz, const double *alpha,
-    const cusparseMatDescr_t descrA, const double *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, double *B,
-    int ldb, csrsm2Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int,
-      int, const double *, const cusparseMatDescr_t, const double *,
-      const int *, const int *, double *, int, csrsm2Info_t,
-      cusparseSolvePolicy_t, void *);
+    cusparseHandle_t handle,
+    int algo, /* algo = 0, 1 */
+    cusparseOperation_t transA,
+    cusparseOperation_t transB,
+    int m,
+    int nrhs,
+    int nnz,
+    const double *alpha,
+    const cusparseMatDescr_t descrA,
+    const double *csrSortedValA,
+    const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA,
+    double *B,
+    int ldb,
+    csrsm2Info_t info,
+    cusparseSolvePolicy_t policy,
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, double *, int, csrsm2Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrsm2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA,
-                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
-                  info, policy, pBuffer);
+  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, info, policy, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCcsrsm2_solve(
-    cusparseHandle_t handle, int algo, cusparseOperation_t transA,
-    cusparseOperation_t transB, int m, int nrhs, int nnz,
-    const cuComplex *alpha, const cusparseMatDescr_t descrA,
-    const cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, cuComplex *B, int ldb, csrsm2Info_t info,
-    cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int,
-      int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *,
-      const int *, const int *, cuComplex *, int, csrsm2Info_t,
-      cusparseSolvePolicy_t, void *);
+    cusparseHandle_t handle,
+    int algo, /* algo = 0, 1 */
+    cusparseOperation_t transA,
+    cusparseOperation_t transB,
+    int m,
+    int nrhs,
+    int nnz,
+    const cuComplex *alpha,
+    const cusparseMatDescr_t descrA,
+    const cuComplex *csrSortedValA,
+    const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA,
+    cuComplex *B,
+    int ldb,
+    csrsm2Info_t info,
+    cusparseSolvePolicy_t policy,
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int, int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, cuComplex *, int, csrsm2Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrsm2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA,
-                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
-                  info, policy, pBuffer);
+  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, info, policy, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseZcsrsm2_solve(
-    cusparseHandle_t handle, int algo, cusparseOperation_t transA,
-    cusparseOperation_t transB, int m, int nrhs, int nnz,
-    const cuDoubleComplex *alpha, const cusparseMatDescr_t descrA,
-    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, cuDoubleComplex *B, int ldb, csrsm2Info_t info,
-    cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int,
-      int, const cuDoubleComplex *, const cusparseMatDescr_t,
-      const cuDoubleComplex *, const int *, const int *, cuDoubleComplex *, int,
-      csrsm2Info_t, cusparseSolvePolicy_t, void *);
+    cusparseHandle_t handle,
+    int algo, /* algo = 0, 1 */
+    cusparseOperation_t transA,
+    cusparseOperation_t transB,
+    int m,
+    int nrhs,
+    int nnz,
+    const cuDoubleComplex *alpha,
+    const cusparseMatDescr_t descrA,
+    const cuDoubleComplex *csrSortedValA,
+    const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA,
+    cuDoubleComplex *B,
+    int ldb,
+    csrsm2Info_t info,
+    cusparseSolvePolicy_t policy,
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, cuDoubleComplex *, int, csrsm2Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrsm2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA,
-                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
-                  info, policy, pBuffer);
+  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, info, policy, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseXbsrsm2_zeroPivot(cusparseHandle_t handle,
                                                        bsrsm2Info_t info,
                                                        int *position) {
-  using FuncPtr =
-      cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, bsrsm2Info_t, int *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, bsrsm2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXbsrsm2_zeroPivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, position);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsrsm2_bufferSize(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, cusparseOperation_t transXY, int mb, int n,
-    int nnzb, const cusparseMatDescr_t descrA, float *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
-    bsrsm2Info_t info, int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
-      cusparseOperation_t, int, int, int, const cusparseMatDescr_t, float *,
-      const int *, const int *, int, bsrsm2Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsrsm2_bufferSize(cusparseHandle_t handle,
+                                                        cusparseDirection_t dirA,
+                                                        cusparseOperation_t transA,
+                                                        cusparseOperation_t transXY,
+                                                        int mb,
+                                                        int n,
+                                                        int nnzb,
+                                                        const cusparseMatDescr_t descrA,
+                                                        float *bsrSortedVal,
+                                                        const int *bsrSortedRowPtr,
+                                                        const int *bsrSortedColInd,
+                                                        int blockSize,
+                                                        bsrsm2Info_t info,
+                                                        int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, float *, const int *, const int *, int, bsrsm2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrsm2_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA,
-                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
-                  info, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsrsm2_bufferSize(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, cusparseOperation_t transXY, int mb, int n,
-    int nnzb, const cusparseMatDescr_t descrA, double *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
-    bsrsm2Info_t info, int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
-      cusparseOperation_t, int, int, int, const cusparseMatDescr_t, double *,
-      const int *, const int *, int, bsrsm2Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsrsm2_bufferSize(cusparseHandle_t handle,
+                                                        cusparseDirection_t dirA,
+                                                        cusparseOperation_t transA,
+                                                        cusparseOperation_t transXY,
+                                                        int mb,
+                                                        int n,
+                                                        int nnzb,
+                                                        const cusparseMatDescr_t descrA,
+                                                        double *bsrSortedVal,
+                                                        const int *bsrSortedRowPtr,
+                                                        const int *bsrSortedColInd,
+                                                        int blockSize,
+                                                        bsrsm2Info_t info,
+                                                        int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, double *, const int *, const int *, int, bsrsm2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrsm2_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA,
-                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
-                  info, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsrsm2_bufferSize(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, cusparseOperation_t transXY, int mb, int n,
-    int nnzb, const cusparseMatDescr_t descrA, cuComplex *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
-    bsrsm2Info_t info, int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
-      cusparseOperation_t, int, int, int, const cusparseMatDescr_t, cuComplex *,
-      const int *, const int *, int, bsrsm2Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsrsm2_bufferSize(cusparseHandle_t handle,
+                                                        cusparseDirection_t dirA,
+                                                        cusparseOperation_t transA,
+                                                        cusparseOperation_t transXY,
+                                                        int mb,
+                                                        int n,
+                                                        int nnzb,
+                                                        const cusparseMatDescr_t descrA,
+                                                        cuComplex *bsrSortedVal,
+                                                        const int *bsrSortedRowPtr,
+                                                        const int *bsrSortedColInd,
+                                                        int blockSize,
+                                                        bsrsm2Info_t info,
+                                                        int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, int, bsrsm2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrsm2_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA,
-                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
-                  info, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrsm2_bufferSize(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, cusparseOperation_t transXY, int mb, int n,
-    int nnzb, const cusparseMatDescr_t descrA, cuDoubleComplex *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
-    bsrsm2Info_t info, int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
-      cusparseOperation_t, int, int, int, const cusparseMatDescr_t,
-      cuDoubleComplex *, const int *, const int *, int, bsrsm2Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrsm2_bufferSize(cusparseHandle_t handle,
+                                                        cusparseDirection_t dirA,
+                                                        cusparseOperation_t transA,
+                                                        cusparseOperation_t transXY,
+                                                        int mb,
+                                                        int n,
+                                                        int nnzb,
+                                                        const cusparseMatDescr_t descrA,
+                                                        cuDoubleComplex *bsrSortedVal,
+                                                        const int *bsrSortedRowPtr,
+                                                        const int *bsrSortedColInd,
+                                                        int blockSize,
+                                                        bsrsm2Info_t info,
+                                                        int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, int, bsrsm2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrsm2_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA,
-                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
-                  info, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsrsm2_bufferSizeExt(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, cusparseOperation_t transB, int mb, int n,
-    int nnzb, const cusparseMatDescr_t descrA, float *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
-    bsrsm2Info_t info, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
-      cusparseOperation_t, int, int, int, const cusparseMatDescr_t, float *,
-      const int *, const int *, int, bsrsm2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsrsm2_bufferSizeExt(cusparseHandle_t handle,
+                                                           cusparseDirection_t dirA,
+                                                           cusparseOperation_t transA,
+                                                           cusparseOperation_t transB,
+                                                           int mb,
+                                                           int n,
+                                                           int nnzb,
+                                                           const cusparseMatDescr_t descrA,
+                                                           float *bsrSortedVal,
+                                                           const int *bsrSortedRowPtr,
+                                                           const int *bsrSortedColInd,
+                                                           int blockSize,
+                                                           bsrsm2Info_t info,
+                                                           size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, float *, const int *, const int *, int, bsrsm2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrsm2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transB, mb, n, nnzb, descrA,
-                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
-                  info, pBufferSize);
+  return func_ptr(handle, dirA, transA, transB, mb, n, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsrsm2_bufferSizeExt(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, cusparseOperation_t transB, int mb, int n,
-    int nnzb, const cusparseMatDescr_t descrA, double *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
-    bsrsm2Info_t info, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
-      cusparseOperation_t, int, int, int, const cusparseMatDescr_t, double *,
-      const int *, const int *, int, bsrsm2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsrsm2_bufferSizeExt(cusparseHandle_t handle,
+                                                           cusparseDirection_t dirA,
+                                                           cusparseOperation_t transA,
+                                                           cusparseOperation_t transB,
+                                                           int mb,
+                                                           int n,
+                                                           int nnzb,
+                                                           const cusparseMatDescr_t descrA,
+                                                           double *bsrSortedVal,
+                                                           const int *bsrSortedRowPtr,
+                                                           const int *bsrSortedColInd,
+                                                           int blockSize,
+                                                           bsrsm2Info_t info,
+                                                           size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, double *, const int *, const int *, int, bsrsm2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrsm2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transB, mb, n, nnzb, descrA,
-                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
-                  info, pBufferSize);
+  return func_ptr(handle, dirA, transA, transB, mb, n, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsrsm2_bufferSizeExt(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, cusparseOperation_t transB, int mb, int n,
-    int nnzb, const cusparseMatDescr_t descrA, cuComplex *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
-    bsrsm2Info_t info, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
-      cusparseOperation_t, int, int, int, const cusparseMatDescr_t, cuComplex *,
-      const int *, const int *, int, bsrsm2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsrsm2_bufferSizeExt(cusparseHandle_t handle,
+                                                           cusparseDirection_t dirA,
+                                                           cusparseOperation_t transA,
+                                                           cusparseOperation_t transB,
+                                                           int mb,
+                                                           int n,
+                                                           int nnzb,
+                                                           const cusparseMatDescr_t descrA,
+                                                           cuComplex *bsrSortedVal,
+                                                           const int *bsrSortedRowPtr,
+                                                           const int *bsrSortedColInd,
+                                                           int blockSize,
+                                                           bsrsm2Info_t info,
+                                                           size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, int, bsrsm2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrsm2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transB, mb, n, nnzb, descrA,
-                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
-                  info, pBufferSize);
+  return func_ptr(handle, dirA, transA, transB, mb, n, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrsm2_bufferSizeExt(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, cusparseOperation_t transB, int mb, int n,
-    int nnzb, const cusparseMatDescr_t descrA, cuDoubleComplex *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
-    bsrsm2Info_t info, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
-      cusparseOperation_t, int, int, int, const cusparseMatDescr_t,
-      cuDoubleComplex *, const int *, const int *, int, bsrsm2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrsm2_bufferSizeExt(cusparseHandle_t handle,
+                                                           cusparseDirection_t dirA,
+                                                           cusparseOperation_t transA,
+                                                           cusparseOperation_t transB,
+                                                           int mb,
+                                                           int n,
+                                                           int nnzb,
+                                                           const cusparseMatDescr_t descrA,
+                                                           cuDoubleComplex *bsrSortedVal,
+                                                           const int *bsrSortedRowPtr,
+                                                           const int *bsrSortedColInd,
+                                                           int blockSize,
+                                                           bsrsm2Info_t info,
+                                                           size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, int, bsrsm2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrsm2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transB, mb, n, nnzb, descrA,
-                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
-                  info, pBufferSize);
+  return func_ptr(handle, dirA, transA, transB, mb, n, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsrsm2_analysis(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, cusparseOperation_t transXY, int mb, int n,
-    int nnzb, const cusparseMatDescr_t descrA, const float *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
-    bsrsm2Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
-      cusparseOperation_t, int, int, int, const cusparseMatDescr_t,
-      const float *, const int *, const int *, int, bsrsm2Info_t,
-      cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsrsm2_analysis(cusparseHandle_t handle,
+                                                      cusparseDirection_t dirA,
+                                                      cusparseOperation_t transA,
+                                                      cusparseOperation_t transXY,
+                                                      int mb,
+                                                      int n,
+                                                      int nnzb,
+                                                      const cusparseMatDescr_t descrA,
+                                                      const float *bsrSortedVal,
+                                                      const int *bsrSortedRowPtr,
+                                                      const int *bsrSortedColInd,
+                                                      int blockSize,
+                                                      bsrsm2Info_t info,
+                                                      cusparseSolvePolicy_t policy,
+                                                      void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, int, bsrsm2Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrsm2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA,
-                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
-                  info, policy, pBuffer);
+  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsrsm2_analysis(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, cusparseOperation_t transXY, int mb, int n,
-    int nnzb, const cusparseMatDescr_t descrA, const double *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
-    bsrsm2Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
-      cusparseOperation_t, int, int, int, const cusparseMatDescr_t,
-      const double *, const int *, const int *, int, bsrsm2Info_t,
-      cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsrsm2_analysis(cusparseHandle_t handle,
+                                                      cusparseDirection_t dirA,
+                                                      cusparseOperation_t transA,
+                                                      cusparseOperation_t transXY,
+                                                      int mb,
+                                                      int n,
+                                                      int nnzb,
+                                                      const cusparseMatDescr_t descrA,
+                                                      const double *bsrSortedVal,
+                                                      const int *bsrSortedRowPtr,
+                                                      const int *bsrSortedColInd,
+                                                      int blockSize,
+                                                      bsrsm2Info_t info,
+                                                      cusparseSolvePolicy_t policy,
+                                                      void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, int, bsrsm2Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrsm2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA,
-                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
-                  info, policy, pBuffer);
+  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsrsm2_analysis(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, cusparseOperation_t transXY, int mb, int n,
-    int nnzb, const cusparseMatDescr_t descrA, const cuComplex *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
-    bsrsm2Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
-      cusparseOperation_t, int, int, int, const cusparseMatDescr_t,
-      const cuComplex *, const int *, const int *, int, bsrsm2Info_t,
-      cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsrsm2_analysis(cusparseHandle_t handle,
+                                                      cusparseDirection_t dirA,
+                                                      cusparseOperation_t transA,
+                                                      cusparseOperation_t transXY,
+                                                      int mb,
+                                                      int n,
+                                                      int nnzb,
+                                                      const cusparseMatDescr_t descrA,
+                                                      const cuComplex *bsrSortedVal,
+                                                      const int *bsrSortedRowPtr,
+                                                      const int *bsrSortedColInd,
+                                                      int blockSize,
+                                                      bsrsm2Info_t info,
+                                                      cusparseSolvePolicy_t policy,
+                                                      void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, int, bsrsm2Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrsm2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA,
-                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
-                  info, policy, pBuffer);
+  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrsm2_analysis(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, cusparseOperation_t transXY, int mb, int n,
-    int nnzb, const cusparseMatDescr_t descrA,
-    const cuDoubleComplex *bsrSortedVal, const int *bsrSortedRowPtr,
-    const int *bsrSortedColInd, int blockSize, bsrsm2Info_t info,
-    cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
-      cusparseOperation_t, int, int, int, const cusparseMatDescr_t,
-      const cuDoubleComplex *, const int *, const int *, int, bsrsm2Info_t,
-      cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrsm2_analysis(cusparseHandle_t handle,
+                                                      cusparseDirection_t dirA,
+                                                      cusparseOperation_t transA,
+                                                      cusparseOperation_t transXY,
+                                                      int mb,
+                                                      int n,
+                                                      int nnzb,
+                                                      const cusparseMatDescr_t descrA,
+                                                      const cuDoubleComplex *bsrSortedVal,
+                                                      const int *bsrSortedRowPtr,
+                                                      const int *bsrSortedColInd,
+                                                      int blockSize,
+                                                      bsrsm2Info_t info,
+                                                      cusparseSolvePolicy_t policy,
+                                                      void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, int, bsrsm2Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrsm2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA,
-                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
-                  info, policy, pBuffer);
+  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsrsm2_solve(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, cusparseOperation_t transXY, int mb, int n,
-    int nnzb, const float *alpha, const cusparseMatDescr_t descrA,
-    const float *bsrSortedVal, const int *bsrSortedRowPtr,
-    const int *bsrSortedColInd, int blockSize, bsrsm2Info_t info,
-    const float *B, int ldb, float *X, int ldx, cusparseSolvePolicy_t policy,
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
-      cusparseOperation_t, int, int, int, const float *,
-      const cusparseMatDescr_t, const float *, const int *, const int *, int,
-      bsrsm2Info_t, const float *, int, float *, int, cusparseSolvePolicy_t,
-      void *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsrsm2_solve(cusparseHandle_t handle,
+                                                   cusparseDirection_t dirA,
+                                                   cusparseOperation_t transA,
+                                                   cusparseOperation_t transXY,
+                                                   int mb,
+                                                   int n,
+                                                   int nnzb,
+                                                   const float *alpha,
+                                                   const cusparseMatDescr_t descrA,
+                                                   const float *bsrSortedVal,
+                                                   const int *bsrSortedRowPtr,
+                                                   const int *bsrSortedColInd,
+                                                   int blockSize,
+                                                   bsrsm2Info_t info,
+                                                   const float *B,
+                                                   int ldb,
+                                                   float *X,
+                                                   int ldx,
+                                                   cusparseSolvePolicy_t policy,
+                                                   void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, int, bsrsm2Info_t, const float *, int, float *, int, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrsm2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, alpha, descrA,
-                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
-                  info, B, ldb, X, ldx, policy, pBuffer);
+  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, alpha, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, B, ldb, X, ldx, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsrsm2_solve(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, cusparseOperation_t transXY, int mb, int n,
-    int nnzb, const double *alpha, const cusparseMatDescr_t descrA,
-    const double *bsrSortedVal, const int *bsrSortedRowPtr,
-    const int *bsrSortedColInd, int blockSize, bsrsm2Info_t info,
-    const double *B, int ldb, double *X, int ldx, cusparseSolvePolicy_t policy,
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
-      cusparseOperation_t, int, int, int, const double *,
-      const cusparseMatDescr_t, const double *, const int *, const int *, int,
-      bsrsm2Info_t, const double *, int, double *, int, cusparseSolvePolicy_t,
-      void *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsrsm2_solve(cusparseHandle_t handle,
+                                                   cusparseDirection_t dirA,
+                                                   cusparseOperation_t transA,
+                                                   cusparseOperation_t transXY,
+                                                   int mb,
+                                                   int n,
+                                                   int nnzb,
+                                                   const double *alpha,
+                                                   const cusparseMatDescr_t descrA,
+                                                   const double *bsrSortedVal,
+                                                   const int *bsrSortedRowPtr,
+                                                   const int *bsrSortedColInd,
+                                                   int blockSize,
+                                                   bsrsm2Info_t info,
+                                                   const double *B,
+                                                   int ldb,
+                                                   double *X,
+                                                   int ldx,
+                                                   cusparseSolvePolicy_t policy,
+                                                   void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, int, bsrsm2Info_t, const double *, int, double *, int, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrsm2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, alpha, descrA,
-                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
-                  info, B, ldb, X, ldx, policy, pBuffer);
+  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, alpha, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, B, ldb, X, ldx, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsrsm2_solve(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, cusparseOperation_t transXY, int mb, int n,
-    int nnzb, const cuComplex *alpha, const cusparseMatDescr_t descrA,
-    const cuComplex *bsrSortedVal, const int *bsrSortedRowPtr,
-    const int *bsrSortedColInd, int blockSize, bsrsm2Info_t info,
-    const cuComplex *B, int ldb, cuComplex *X, int ldx,
-    cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
-      cusparseOperation_t, int, int, int, const cuComplex *,
-      const cusparseMatDescr_t, const cuComplex *, const int *, const int *,
-      int, bsrsm2Info_t, const cuComplex *, int, cuComplex *, int,
-      cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsrsm2_solve(cusparseHandle_t handle,
+                                                   cusparseDirection_t dirA,
+                                                   cusparseOperation_t transA,
+                                                   cusparseOperation_t transXY,
+                                                   int mb,
+                                                   int n,
+                                                   int nnzb,
+                                                   const cuComplex *alpha,
+                                                   const cusparseMatDescr_t descrA,
+                                                   const cuComplex *bsrSortedVal,
+                                                   const int *bsrSortedRowPtr,
+                                                   const int *bsrSortedColInd,
+                                                   int blockSize,
+                                                   bsrsm2Info_t info,
+                                                   const cuComplex *B,
+                                                   int ldb,
+                                                   cuComplex *X,
+                                                   int ldx,
+                                                   cusparseSolvePolicy_t policy,
+                                                   void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, int, bsrsm2Info_t, const cuComplex *, int, cuComplex *, int, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrsm2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, alpha, descrA,
-                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
-                  info, B, ldb, X, ldx, policy, pBuffer);
+  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, alpha, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, B, ldb, X, ldx, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrsm2_solve(
-    cusparseHandle_t handle, cusparseDirection_t dirA,
-    cusparseOperation_t transA, cusparseOperation_t transXY, int mb, int n,
-    int nnzb, const cuDoubleComplex *alpha, const cusparseMatDescr_t descrA,
-    const cuDoubleComplex *bsrSortedVal, const int *bsrSortedRowPtr,
-    const int *bsrSortedColInd, int blockSize, bsrsm2Info_t info,
-    const cuDoubleComplex *B, int ldb, cuDoubleComplex *X, int ldx,
-    cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
-      cusparseOperation_t, int, int, int, const cuDoubleComplex *,
-      const cusparseMatDescr_t, const cuDoubleComplex *, const int *,
-      const int *, int, bsrsm2Info_t, const cuDoubleComplex *, int,
-      cuDoubleComplex *, int, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrsm2_solve(cusparseHandle_t handle,
+                                                   cusparseDirection_t dirA,
+                                                   cusparseOperation_t transA,
+                                                   cusparseOperation_t transXY,
+                                                   int mb,
+                                                   int n,
+                                                   int nnzb,
+                                                   const cuDoubleComplex *alpha,
+                                                   const cusparseMatDescr_t descrA,
+                                                   const cuDoubleComplex *bsrSortedVal,
+                                                   const int *bsrSortedRowPtr,
+                                                   const int *bsrSortedColInd,
+                                                   int blockSize,
+                                                   bsrsm2Info_t info,
+                                                   const cuDoubleComplex *B,
+                                                   int ldb,
+                                                   cuDoubleComplex *X,
+                                                   int ldx,
+                                                   cusparseSolvePolicy_t policy,
+                                                   void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, int, bsrsm2Info_t, const cuDoubleComplex *, int, cuDoubleComplex *, int, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrsm2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, alpha, descrA,
-                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
-                  info, B, ldb, X, ldx, policy, pBuffer);
+  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, alpha, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, B, ldb, X, ldx, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCsrilu0Ex(
-    cusparseHandle_t handle, cusparseOperation_t trans, int m,
-    const cusparseMatDescr_t descrA, void *csrSortedValA_ValM,
-    cudaDataType csrSortedValA_ValMtype, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, cusparseSolveAnalysisInfo_t info,
-    cudaDataType executiontype) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t,
-      void *, cudaDataType, const int *, const int *,
-      cusparseSolveAnalysisInfo_t, cudaDataType);
+cusparseStatus_t CUSPARSEAPI cusparseCsrilu0Ex(cusparseHandle_t handle,
+                                              cusparseOperation_t trans,
+                                              int m,
+                                              const cusparseMatDescr_t descrA,
+                                              void *csrSortedValA_ValM,
+                                              cudaDataType csrSortedValA_ValMtype,
+                                              /* matrix A values are updated inplace
+                                                 to be the preconditioner M values */
+                                              const int *csrSortedRowPtrA,
+                                              const int *csrSortedColIndA,
+                                              cusparseSolveAnalysisInfo_t info,
+                                              cudaDataType executiontype) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t, void *, cudaDataType, const int *, const int *, cusparseSolveAnalysisInfo_t, cudaDataType);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCsrilu0Ex");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM,
-                  csrSortedValA_ValMtype, csrSortedRowPtrA, csrSortedColIndA,
-                  info, executiontype);
+  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM, csrSortedValA_ValMtype, csrSortedRowPtrA, csrSortedColIndA, info, executiontype);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseScsrilu0(cusparseHandle_t handle, cusparseOperation_t trans, int m,
-                 const cusparseMatDescr_t descrA, float *csrSortedValA_ValM,
-                 const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-                 cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t,
-      float *, const int *, const int *, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseScsrilu0(cusparseHandle_t handle,
+                                              cusparseOperation_t trans,
+                                              int m,
+                                              const cusparseMatDescr_t descrA,
+                                              float *csrSortedValA_ValM,
+                                              /* matrix A values are updated inplace
+                                                 to be the preconditioner M values */
+                                              const int *csrSortedRowPtrA,
+                                              const int *csrSortedColIndA,
+                                              cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t, float *, const int *, const int *, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrilu0");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM,
-                  csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM, csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseDcsrilu0(cusparseHandle_t handle, cusparseOperation_t trans, int m,
-                 const cusparseMatDescr_t descrA, double *csrSortedValA_ValM,
-                 const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-                 cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t,
-      double *, const int *, const int *, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrilu0(cusparseHandle_t handle,
+                                              cusparseOperation_t trans,
+                                              int m,
+                                              const cusparseMatDescr_t descrA,
+                                              double *csrSortedValA_ValM,
+                                              /* matrix A values are updated inplace
+                                                 to be the preconditioner M values */
+                                              const int *csrSortedRowPtrA,
+                                              const int *csrSortedColIndA,
+                                              cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t, double *, const int *, const int *, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrilu0");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM,
-                  csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM, csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseCcsrilu0(cusparseHandle_t handle, cusparseOperation_t trans, int m,
-                 const cusparseMatDescr_t descrA, cuComplex *csrSortedValA_ValM,
-                 const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-                 cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t,
-      cuComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrilu0(cusparseHandle_t handle,
+                                              cusparseOperation_t trans,
+                                              int m,
+                                              const cusparseMatDescr_t descrA,
+                                              cuComplex *csrSortedValA_ValM,
+                                              /* matrix A values are updated inplace
+                                                 to be the preconditioner M values */
+                                              const int *csrSortedRowPtrA,
+                                              const int *csrSortedColIndA,
+                                              cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrilu0");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM,
-                  csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM, csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrilu0(
-    cusparseHandle_t handle, cusparseOperation_t trans, int m,
-    const cusparseMatDescr_t descrA, cuDoubleComplex *csrSortedValA_ValM,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t,
-      cuDoubleComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrilu0(cusparseHandle_t handle,
+                                              cusparseOperation_t trans,
+                                              int m,
+                                              const cusparseMatDescr_t descrA,
+                                              cuDoubleComplex *csrSortedValA_ValM,
+                                              /* matrix A values are updated inplace
+                                                 to be the preconditioner M values */
+                                              const int *csrSortedRowPtrA,
+                                              const int *csrSortedColIndA,
+                                              cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrilu0");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM,
-                  csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM, csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrilu02_numericBoost(
-    cusparseHandle_t handle, csrilu02Info_t info, int enable_boost, double *tol,
-    float *boost_val) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, csrilu02Info_t, int, double *, float *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrilu02_numericBoost(cusparseHandle_t handle,
+                                                            csrilu02Info_t info,
+                                                            int enable_boost,
+                                                            double *tol,
+                                                            float *boost_val) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, csrilu02Info_t, int, double *, float *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrilu02_numericBoost");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, enable_boost, tol, boost_val);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrilu02_numericBoost(
-    cusparseHandle_t handle, csrilu02Info_t info, int enable_boost, double *tol,
-    double *boost_val) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, csrilu02Info_t, int, double *, double *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrilu02_numericBoost(cusparseHandle_t handle,
+                                                            csrilu02Info_t info,
+                                                            int enable_boost,
+                                                            double *tol,
+                                                            double *boost_val) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, csrilu02Info_t, int, double *, double *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrilu02_numericBoost");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, enable_boost, tol, boost_val);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrilu02_numericBoost(
-    cusparseHandle_t handle, csrilu02Info_t info, int enable_boost, double *tol,
-    cuComplex *boost_val) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, csrilu02Info_t, int, double *, cuComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrilu02_numericBoost(cusparseHandle_t handle,
+                                                            csrilu02Info_t info,
+                                                            int enable_boost,
+                                                            double *tol,
+                                                            cuComplex *boost_val) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, csrilu02Info_t, int, double *, cuComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrilu02_numericBoost");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, enable_boost, tol, boost_val);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrilu02_numericBoost(
-    cusparseHandle_t handle, csrilu02Info_t info, int enable_boost, double *tol,
-    cuDoubleComplex *boost_val) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, csrilu02Info_t, int, double *, cuDoubleComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrilu02_numericBoost(cusparseHandle_t handle,
+                                                            csrilu02Info_t info,
+                                                            int enable_boost,
+                                                            double *tol,
+                                                            cuDoubleComplex *boost_val) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, csrilu02Info_t, int, double *, cuDoubleComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrilu02_numericBoost");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, enable_boost, tol, boost_val);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseXcsrilu02_zeroPivot(
-    cusparseHandle_t handle, csrilu02Info_t info, int *position) {
-  using FuncPtr =
-      cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, csrilu02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseXcsrilu02_zeroPivot(cusparseHandle_t handle,
+                                                         csrilu02Info_t info,
+                                                         int *position) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, csrilu02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcsrilu02_zeroPivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, position);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrilu02_bufferSize(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    float *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, csrilu02Info_t info, int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, float *,
-      const int *, const int *, csrilu02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrilu02_bufferSize(cusparseHandle_t handle,
+                                                          int m,
+                                                          int nnz,
+                                                          const cusparseMatDescr_t descrA,
+                                                          float *csrSortedValA,
+                                                          const int *csrSortedRowPtrA,
+                                                          const int *csrSortedColIndA,
+                                                          csrilu02Info_t info,
+                                                          int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, csrilu02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrilu02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrilu02_bufferSize(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    double *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, csrilu02Info_t info, int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, double *,
-      const int *, const int *, csrilu02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrilu02_bufferSize(cusparseHandle_t handle,
+                                                          int m,
+                                                          int nnz,
+                                                          const cusparseMatDescr_t descrA,
+                                                          double *csrSortedValA,
+                                                          const int *csrSortedRowPtrA,
+                                                          const int *csrSortedColIndA,
+                                                          csrilu02Info_t info,
+                                                          int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, csrilu02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrilu02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrilu02_bufferSize(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, csrilu02Info_t info, int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, cuComplex *,
-      const int *, const int *, csrilu02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrilu02_bufferSize(cusparseHandle_t handle,
+                                                          int m,
+                                                          int nnz,
+                                                          const cusparseMatDescr_t descrA,
+                                                          cuComplex *csrSortedValA,
+                                                          const int *csrSortedRowPtrA,
+                                                          const int *csrSortedColIndA,
+                                                          csrilu02Info_t info,
+                                                          int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, csrilu02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrilu02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrilu02_bufferSize(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, csrilu02Info_t info, int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *,
-      const int *, const int *, csrilu02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrilu02_bufferSize(cusparseHandle_t handle,
+                                                          int m,
+                                                          int nnz,
+                                                          const cusparseMatDescr_t descrA,
+                                                          cuDoubleComplex *csrSortedValA,
+                                                          const int *csrSortedRowPtrA,
+                                                          const int *csrSortedColIndA,
+                                                          csrilu02Info_t info,
+                                                          int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, csrilu02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrilu02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrilu02_bufferSizeExt(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    float *csrSortedVal, const int *csrSortedRowPtr, const int *csrSortedColInd,
-    csrilu02Info_t info, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, float *,
-      const int *, const int *, csrilu02Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrilu02_bufferSizeExt(cusparseHandle_t handle,
+                                                             int m,
+                                                             int nnz,
+                                                             const cusparseMatDescr_t descrA,
+                                                             float *csrSortedVal,
+                                                             const int *csrSortedRowPtr,
+                                                             const int *csrSortedColInd,
+                                                             csrilu02Info_t info,
+                                                             size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, csrilu02Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrilu02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr,
-                  csrSortedColInd, info, pBufferSize);
+  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr, csrSortedColInd, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrilu02_bufferSizeExt(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    double *csrSortedVal, const int *csrSortedRowPtr,
-    const int *csrSortedColInd, csrilu02Info_t info, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, double *,
-      const int *, const int *, csrilu02Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrilu02_bufferSizeExt(cusparseHandle_t handle,
+                                                             int m,
+                                                             int nnz,
+                                                             const cusparseMatDescr_t descrA,
+                                                             double *csrSortedVal,
+                                                             const int *csrSortedRowPtr,
+                                                             const int *csrSortedColInd,
+                                                             csrilu02Info_t info,
+                                                             size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, csrilu02Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrilu02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr,
-                  csrSortedColInd, info, pBufferSize);
+  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr, csrSortedColInd, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrilu02_bufferSizeExt(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    cuComplex *csrSortedVal, const int *csrSortedRowPtr,
-    const int *csrSortedColInd, csrilu02Info_t info, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, cuComplex *,
-      const int *, const int *, csrilu02Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrilu02_bufferSizeExt(cusparseHandle_t handle,
+                                                             int m,
+                                                             int nnz,
+                                                             const cusparseMatDescr_t descrA,
+                                                             cuComplex *csrSortedVal,
+                                                             const int *csrSortedRowPtr,
+                                                             const int *csrSortedColInd,
+                                                             csrilu02Info_t info,
+                                                             size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, csrilu02Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrilu02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr,
-                  csrSortedColInd, info, pBufferSize);
+  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr, csrSortedColInd, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrilu02_bufferSizeExt(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    cuDoubleComplex *csrSortedVal, const int *csrSortedRowPtr,
-    const int *csrSortedColInd, csrilu02Info_t info, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *,
-      const int *, const int *, csrilu02Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrilu02_bufferSizeExt(cusparseHandle_t handle,
+                                                             int m,
+                                                             int nnz,
+                                                             const cusparseMatDescr_t descrA,
+                                                             cuDoubleComplex *csrSortedVal,
+                                                             const int *csrSortedRowPtr,
+                                                             const int *csrSortedColInd,
+                                                             csrilu02Info_t info,
+                                                             size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, csrilu02Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrilu02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr,
-                  csrSortedColInd, info, pBufferSize);
+  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr, csrSortedColInd, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrilu02_analysis(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    const float *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, csrilu02Info_t info,
-    cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *,
-      const int *, const int *, csrilu02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrilu02_analysis(cusparseHandle_t handle,
+                                                        int m,
+                                                        int nnz,
+                                                        const cusparseMatDescr_t descrA,
+                                                        const float *csrSortedValA,
+                                                        const int *csrSortedRowPtrA,
+                                                        const int *csrSortedColIndA,
+                                                        csrilu02Info_t info,
+                                                        cusparseSolvePolicy_t policy,
+                                                        void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, csrilu02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrilu02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrilu02_analysis(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    const double *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, csrilu02Info_t info,
-    cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *,
-      const int *, const int *, csrilu02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrilu02_analysis(cusparseHandle_t handle,
+                                                        int m,
+                                                        int nnz,
+                                                        const cusparseMatDescr_t descrA,
+                                                        const double *csrSortedValA,
+                                                        const int *csrSortedRowPtrA,
+                                                        const int *csrSortedColIndA,
+                                                        csrilu02Info_t info,
+                                                        cusparseSolvePolicy_t policy,
+                                                        void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, csrilu02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrilu02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrilu02_analysis(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    const cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, csrilu02Info_t info,
-    cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *,
-      const int *, const int *, csrilu02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrilu02_analysis(cusparseHandle_t handle,
+                                                        int m,
+                                                        int nnz,
+                                                        const cusparseMatDescr_t descrA,
+                                                        const cuComplex *csrSortedValA,
+                                                        const int *csrSortedRowPtrA,
+                                                        const int *csrSortedColIndA,
+                                                        csrilu02Info_t info,
+                                                        cusparseSolvePolicy_t policy,
+                                                        void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, csrilu02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrilu02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrilu02_analysis(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, csrilu02Info_t info,
-    cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t,
-      const cuDoubleComplex *, const int *, const int *, csrilu02Info_t,
-      cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrilu02_analysis(cusparseHandle_t handle,
+                                                        int m,
+                                                        int nnz,
+                                                        const cusparseMatDescr_t descrA,
+                                                        const cuDoubleComplex *csrSortedValA,
+                                                        const int *csrSortedRowPtrA,
+                                                        const int *csrSortedColIndA,
+                                                        csrilu02Info_t info,
+                                                        cusparseSolvePolicy_t policy,
+                                                        void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, csrilu02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrilu02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrilu02(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    float *csrSortedValA_valM, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, csrilu02Info_t info,
-    cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, float *,
-      const int *, const int *, csrilu02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrilu02(cusparseHandle_t handle,
+                                               int m,
+                                               int nnz,
+                                               const cusparseMatDescr_t descrA,
+                                               float *csrSortedValA_valM,
+                                               /* matrix A values are updated inplace
+                                                  to be the preconditioner M values */
+                                               const int *csrSortedRowPtrA,
+                                               const int *csrSortedColIndA,
+                                               csrilu02Info_t info,
+                                               cusparseSolvePolicy_t policy,
+                                               void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, csrilu02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrilu02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA,
-                  csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrilu02(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    double *csrSortedValA_valM, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, csrilu02Info_t info,
-    cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, double *,
-      const int *, const int *, csrilu02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrilu02(cusparseHandle_t handle,
+                                               int m,
+                                               int nnz,
+                                               const cusparseMatDescr_t descrA,
+                                               double *csrSortedValA_valM,
+                                               /* matrix A values are updated inplace
+                                                  to be the preconditioner M values */
+                                               const int *csrSortedRowPtrA,
+                                               const int *csrSortedColIndA,
+                                               csrilu02Info_t info,
+                                               cusparseSolvePolicy_t policy,
+                                               void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, csrilu02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrilu02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA,
-                  csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrilu02(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    cuComplex *csrSortedValA_valM, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, csrilu02Info_t info,
-    cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, cuComplex *,
-      const int *, const int *, csrilu02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrilu02(cusparseHandle_t handle,
+                                               int m,
+                                               int nnz,
+                                               const cusparseMatDescr_t descrA,
+                                               cuComplex *csrSortedValA_valM,
+                                               /* matrix A values are updated inplace
+                                                  to be the preconditioner M values */
+                                               const int *csrSortedRowPtrA,
+                                               const int *csrSortedColIndA,
+                                               csrilu02Info_t info,
+                                               cusparseSolvePolicy_t policy,
+                                               void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, csrilu02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrilu02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA,
-                  csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrilu02(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    cuDoubleComplex *csrSortedValA_valM, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, csrilu02Info_t info,
-    cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *,
-      const int *, const int *, csrilu02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrilu02(cusparseHandle_t handle,
+                                               int m,
+                                               int nnz,
+                                               const cusparseMatDescr_t descrA,
+                                               cuDoubleComplex *csrSortedValA_valM,
+                                               /* matrix A values are updated inplace
+                                                  to be the preconditioner M values */
+                                               const int *csrSortedRowPtrA,
+                                               const int *csrSortedColIndA,
+                                               csrilu02Info_t info,
+                                               cusparseSolvePolicy_t policy,
+                                               void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, csrilu02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrilu02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA,
-                  csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsrilu02_numericBoost(
-    cusparseHandle_t handle, bsrilu02Info_t info, int enable_boost, double *tol,
-    float *boost_val) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, bsrilu02Info_t, int, double *, float *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsrilu02_numericBoost(cusparseHandle_t handle,
+                                                            bsrilu02Info_t info,
+                                                            int enable_boost,
+                                                            double *tol,
+                                                            float *boost_val) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, bsrilu02Info_t, int, double *, float *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrilu02_numericBoost");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, enable_boost, tol, boost_val);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsrilu02_numericBoost(
-    cusparseHandle_t handle, bsrilu02Info_t info, int enable_boost, double *tol,
-    double *boost_val) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, bsrilu02Info_t, int, double *, double *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsrilu02_numericBoost(cusparseHandle_t handle,
+                                                            bsrilu02Info_t info,
+                                                            int enable_boost,
+                                                            double *tol,
+                                                            double *boost_val) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, bsrilu02Info_t, int, double *, double *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrilu02_numericBoost");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, enable_boost, tol, boost_val);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsrilu02_numericBoost(
-    cusparseHandle_t handle, bsrilu02Info_t info, int enable_boost, double *tol,
-    cuComplex *boost_val) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, bsrilu02Info_t, int, double *, cuComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsrilu02_numericBoost(cusparseHandle_t handle,
+                                                            bsrilu02Info_t info,
+                                                            int enable_boost,
+                                                            double *tol,
+                                                            cuComplex *boost_val) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, bsrilu02Info_t, int, double *, cuComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrilu02_numericBoost");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, enable_boost, tol, boost_val);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrilu02_numericBoost(
-    cusparseHandle_t handle, bsrilu02Info_t info, int enable_boost, double *tol,
-    cuDoubleComplex *boost_val) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, bsrilu02Info_t, int, double *, cuDoubleComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrilu02_numericBoost(cusparseHandle_t handle,
+                                                            bsrilu02Info_t info,
+                                                            int enable_boost,
+                                                            double *tol,
+                                                            cuDoubleComplex *boost_val) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, bsrilu02Info_t, int, double *, cuDoubleComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrilu02_numericBoost");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, enable_boost, tol, boost_val);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseXbsrilu02_zeroPivot(
-    cusparseHandle_t handle, bsrilu02Info_t info, int *position) {
-  using FuncPtr =
-      cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, bsrilu02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseXbsrilu02_zeroPivot(cusparseHandle_t handle,
+                                                         bsrilu02Info_t info,
+                                                         int *position) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, bsrilu02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXbsrilu02_zeroPivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, position);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsrilu02_bufferSize(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, float *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
-    bsrilu02Info_t info, int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      float *, const int *, const int *, int, bsrilu02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsrilu02_bufferSize(cusparseHandle_t handle,
+                                                          cusparseDirection_t dirA,
+                                                          int mb,
+                                                          int nnzb,
+                                                          const cusparseMatDescr_t descrA,
+                                                          float *bsrSortedVal,
+                                                          const int *bsrSortedRowPtr,
+                                                          const int *bsrSortedColInd,
+                                                          int blockDim,
+                                                          bsrilu02Info_t info,
+                                                          int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, int, bsrilu02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrilu02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsrilu02_bufferSize(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, double *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
-    bsrilu02Info_t info, int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      double *, const int *, const int *, int, bsrilu02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsrilu02_bufferSize(cusparseHandle_t handle,
+                                                          cusparseDirection_t dirA,
+                                                          int mb,
+                                                          int nnzb,
+                                                          const cusparseMatDescr_t descrA,
+                                                          double *bsrSortedVal,
+                                                          const int *bsrSortedRowPtr,
+                                                          const int *bsrSortedColInd,
+                                                          int blockDim,
+                                                          bsrilu02Info_t info,
+                                                          int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, int, bsrilu02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrilu02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsrilu02_bufferSize(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, cuComplex *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
-    bsrilu02Info_t info, int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      cuComplex *, const int *, const int *, int, bsrilu02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsrilu02_bufferSize(cusparseHandle_t handle,
+                                                          cusparseDirection_t dirA,
+                                                          int mb,
+                                                          int nnzb,
+                                                          const cusparseMatDescr_t descrA,
+                                                          cuComplex *bsrSortedVal,
+                                                          const int *bsrSortedRowPtr,
+                                                          const int *bsrSortedColInd,
+                                                          int blockDim,
+                                                          bsrilu02Info_t info,
+                                                          int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, int, bsrilu02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrilu02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrilu02_bufferSize(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, cuDoubleComplex *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
-    bsrilu02Info_t info, int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      cuDoubleComplex *, const int *, const int *, int, bsrilu02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrilu02_bufferSize(cusparseHandle_t handle,
+                                                          cusparseDirection_t dirA,
+                                                          int mb,
+                                                          int nnzb,
+                                                          const cusparseMatDescr_t descrA,
+                                                          cuDoubleComplex *bsrSortedVal,
+                                                          const int *bsrSortedRowPtr,
+                                                          const int *bsrSortedColInd,
+                                                          int blockDim,
+                                                          bsrilu02Info_t info,
+                                                          int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, int, bsrilu02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrilu02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsrilu02_bufferSizeExt(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, float *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
-    bsrilu02Info_t info, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      float *, const int *, const int *, int, bsrilu02Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsrilu02_bufferSizeExt(cusparseHandle_t handle,
+                                                          cusparseDirection_t dirA,
+                                                          int mb,
+                                                          int nnzb,
+                                                          const cusparseMatDescr_t descrA,
+                                                          float *bsrSortedVal,
+                                                          const int *bsrSortedRowPtr,
+                                                          const int *bsrSortedColInd,
+                                                          int blockSize,
+                                                          bsrilu02Info_t info,
+                                                          size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, int, bsrilu02Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrilu02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockSize, info, pBufferSize);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsrilu02_bufferSizeExt(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, double *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
-    bsrilu02Info_t info, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      double *, const int *, const int *, int, bsrilu02Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsrilu02_bufferSizeExt(cusparseHandle_t handle,
+                                                          cusparseDirection_t dirA,
+                                                          int mb,
+                                                          int nnzb,
+                                                          const cusparseMatDescr_t descrA,
+                                                          double *bsrSortedVal,
+                                                          const int *bsrSortedRowPtr,
+                                                          const int *bsrSortedColInd,
+                                                          int blockSize,
+                                                          bsrilu02Info_t info,
+                                                          size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, int, bsrilu02Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrilu02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockSize, info, pBufferSize);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsrilu02_bufferSizeExt(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, cuComplex *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
-    bsrilu02Info_t info, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      cuComplex *, const int *, const int *, int, bsrilu02Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsrilu02_bufferSizeExt(cusparseHandle_t handle,
+                                                          cusparseDirection_t dirA,
+                                                          int mb,
+                                                          int nnzb,
+                                                          const cusparseMatDescr_t descrA,
+                                                          cuComplex *bsrSortedVal,
+                                                          const int *bsrSortedRowPtr,
+                                                          const int *bsrSortedColInd,
+                                                          int blockSize,
+                                                          bsrilu02Info_t info,
+                                                          size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, int, bsrilu02Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrilu02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockSize, info, pBufferSize);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrilu02_bufferSizeExt(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, cuDoubleComplex *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
-    bsrilu02Info_t info, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      cuDoubleComplex *, const int *, const int *, int, bsrilu02Info_t,
-      size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrilu02_bufferSizeExt(cusparseHandle_t handle,
+                                                          cusparseDirection_t dirA,
+                                                          int mb,
+                                                          int nnzb,
+                                                          const cusparseMatDescr_t descrA,
+                                                          cuDoubleComplex *bsrSortedVal,
+                                                          const int *bsrSortedRowPtr,
+                                                          const int *bsrSortedColInd,
+                                                          int blockSize,
+                                                          bsrilu02Info_t info,
+                                                          size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, int, bsrilu02Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrilu02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockSize, info, pBufferSize);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsrilu02_analysis(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, float *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
-    bsrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      float *, const int *, const int *, int, bsrilu02Info_t,
-      cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsrilu02_analysis(cusparseHandle_t handle,
+                                                        cusparseDirection_t dirA,
+                                                        int mb,
+                                                        int nnzb,
+                                                        const cusparseMatDescr_t descrA,
+                                                        float *bsrSortedVal,
+                                                        const int *bsrSortedRowPtr,
+                                                        const int *bsrSortedColInd,
+                                                        int blockDim,
+                                                        bsrilu02Info_t info,
+                                                        cusparseSolvePolicy_t policy,
+                                                        void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, int, bsrilu02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrilu02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockDim, info, policy, pBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsrilu02_analysis(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, double *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
-    bsrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      double *, const int *, const int *, int, bsrilu02Info_t,
-      cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsrilu02_analysis(cusparseHandle_t handle,
+                                                        cusparseDirection_t dirA,
+                                                        int mb,
+                                                        int nnzb,
+                                                        const cusparseMatDescr_t descrA,
+                                                        double *bsrSortedVal,
+                                                        const int *bsrSortedRowPtr,
+                                                        const int *bsrSortedColInd,
+                                                        int blockDim,
+                                                        bsrilu02Info_t info,
+                                                        cusparseSolvePolicy_t policy,
+                                                        void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, int, bsrilu02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrilu02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockDim, info, policy, pBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsrilu02_analysis(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, cuComplex *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
-    bsrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      cuComplex *, const int *, const int *, int, bsrilu02Info_t,
-      cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsrilu02_analysis(cusparseHandle_t handle,
+                                                        cusparseDirection_t dirA,
+                                                        int mb,
+                                                        int nnzb,
+                                                        const cusparseMatDescr_t descrA,
+                                                        cuComplex *bsrSortedVal,
+                                                        const int *bsrSortedRowPtr,
+                                                        const int *bsrSortedColInd,
+                                                        int blockDim,
+                                                        bsrilu02Info_t info,
+                                                        cusparseSolvePolicy_t policy,
+                                                        void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, int, bsrilu02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrilu02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockDim, info, policy, pBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrilu02_analysis(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, cuDoubleComplex *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
-    bsrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      cuDoubleComplex *, const int *, const int *, int, bsrilu02Info_t,
-      cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrilu02_analysis(cusparseHandle_t handle,
+                                                        cusparseDirection_t dirA,
+                                                        int mb,
+                                                        int nnzb,
+                                                        const cusparseMatDescr_t descrA,
+                                                        cuDoubleComplex *bsrSortedVal,
+                                                        const int *bsrSortedRowPtr,
+                                                        const int *bsrSortedColInd,
+                                                        int blockDim,
+                                                        bsrilu02Info_t info,
+                                                        cusparseSolvePolicy_t policy,
+                                                        void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, int, bsrilu02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrilu02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockDim, info, policy, pBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsrilu02(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, float *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
-    bsrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      float *, const int *, const int *, int, bsrilu02Info_t,
-      cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsrilu02(cusparseHandle_t handle,
+                                               cusparseDirection_t dirA,
+                                               int mb,
+                                               int nnzb,
+                                               const cusparseMatDescr_t descrA,
+                                               float *bsrSortedVal,
+                                               const int *bsrSortedRowPtr,
+                                               const int *bsrSortedColInd,
+                                               int blockDim,
+                                               bsrilu02Info_t info,
+                                               cusparseSolvePolicy_t policy,
+                                               void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, int, bsrilu02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrilu02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockDim, info, policy, pBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsrilu02(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, double *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
-    bsrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      double *, const int *, const int *, int, bsrilu02Info_t,
-      cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsrilu02(cusparseHandle_t handle,
+                                               cusparseDirection_t dirA,
+                                               int mb,
+                                               int nnzb,
+                                               const cusparseMatDescr_t descrA,
+                                               double *bsrSortedVal,
+                                               const int *bsrSortedRowPtr,
+                                               const int *bsrSortedColInd,
+                                               int blockDim,
+                                               bsrilu02Info_t info,
+                                               cusparseSolvePolicy_t policy,
+                                               void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, int, bsrilu02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrilu02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockDim, info, policy, pBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsrilu02(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, cuComplex *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
-    bsrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      cuComplex *, const int *, const int *, int, bsrilu02Info_t,
-      cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsrilu02(cusparseHandle_t handle,
+                                               cusparseDirection_t dirA,
+                                               int mb,
+                                               int nnzb,
+                                               const cusparseMatDescr_t descrA,
+                                               cuComplex *bsrSortedVal,
+                                               const int *bsrSortedRowPtr,
+                                               const int *bsrSortedColInd,
+                                               int blockDim,
+                                               bsrilu02Info_t info,
+                                               cusparseSolvePolicy_t policy,
+                                               void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, int, bsrilu02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrilu02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockDim, info, policy, pBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrilu02(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, cuDoubleComplex *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
-    bsrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      cuDoubleComplex *, const int *, const int *, int, bsrilu02Info_t,
-      cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrilu02(cusparseHandle_t handle,
+                                               cusparseDirection_t dirA,
+                                               int mb,
+                                               int nnzb,
+                                               const cusparseMatDescr_t descrA,
+                                               cuDoubleComplex *bsrSortedVal,
+                                               const int *bsrSortedRowPtr,
+                                               const int *bsrSortedColInd,
+                                               int blockDim,
+                                               bsrilu02Info_t info,
+                                               cusparseSolvePolicy_t policy,
+                                               void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, int, bsrilu02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrilu02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockDim, info, policy, pBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseScsric0(cusparseHandle_t handle,
-                                             cusparseOperation_t trans, int m,
-                                             const cusparseMatDescr_t descrA,
-                                             float *csrSortedValA_ValM,
-                                             const int *csrSortedRowPtrA,
-                                             const int *csrSortedColIndA,
-                                             cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t,
-      float *, const int *, const int *, cusparseSolveAnalysisInfo_t);
+                                              cusparseOperation_t trans,
+                                              int m,
+                                              const cusparseMatDescr_t descrA,
+                                              float *csrSortedValA_ValM,
+                                              /* matrix A values are updated inplace
+                                                 to be the preconditioner M values */
+                                              const int *csrSortedRowPtrA,
+                                              const int *csrSortedColIndA,
+                                              cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t, float *, const int *, const int *, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsric0");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM,
-                  csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM, csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDcsric0(cusparseHandle_t handle,
-                                             cusparseOperation_t trans, int m,
-                                             const cusparseMatDescr_t descrA,
-                                             double *csrSortedValA_ValM,
-                                             const int *csrSortedRowPtrA,
-                                             const int *csrSortedColIndA,
-                                             cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t,
-      double *, const int *, const int *, cusparseSolveAnalysisInfo_t);
+                                              cusparseOperation_t trans,
+                                              int m,
+                                              const cusparseMatDescr_t descrA,
+                                              double *csrSortedValA_ValM,
+                                              /* matrix A values are updated inplace
+                                                 to be the preconditioner M values */
+                                              const int *csrSortedRowPtrA,
+                                              const int *csrSortedColIndA,
+                                              cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t, double *, const int *, const int *, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsric0");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM,
-                  csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM, csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCcsric0(cusparseHandle_t handle,
-                                             cusparseOperation_t trans, int m,
-                                             const cusparseMatDescr_t descrA,
-                                             cuComplex *csrSortedValA_ValM,
-                                             const int *csrSortedRowPtrA,
-                                             const int *csrSortedColIndA,
-                                             cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t,
-      cuComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t);
+                                              cusparseOperation_t trans,
+                                              int m,
+                                              const cusparseMatDescr_t descrA,
+                                              cuComplex *csrSortedValA_ValM,
+                                              /* matrix A values are updated inplace
+                                                 to be the preconditioner M values */
+                                              const int *csrSortedRowPtrA,
+                                              const int *csrSortedColIndA,
+                                              cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsric0");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM,
-                  csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM, csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsric0(
-    cusparseHandle_t handle, cusparseOperation_t trans, int m,
-    const cusparseMatDescr_t descrA, cuDoubleComplex *csrSortedValA_ValM,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t,
-      cuDoubleComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseZcsric0(cusparseHandle_t handle,
+                                              cusparseOperation_t trans,
+                                              int m,
+                                              const cusparseMatDescr_t descrA,
+                                              cuDoubleComplex *csrSortedValA_ValM,
+                                              /* matrix A values are updated inplace
+                                                 to be the preconditioner M values */
+                                              const int *csrSortedRowPtrA,
+                                              const int *csrSortedColIndA,
+                                              cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsric0");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM,
-                  csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM, csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseXcsric02_zeroPivot(cusparseHandle_t handle,
                                                         csric02Info_t info,
                                                         int *position) {
-  using FuncPtr =
-      cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, csric02Info_t, int *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, csric02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcsric02_zeroPivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, position);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsric02_bufferSize(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    float *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, csric02Info_t info, int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, float *,
-      const int *, const int *, csric02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseScsric02_bufferSize(cusparseHandle_t handle,
+                                                         int m,
+                                                         int nnz,
+                                                         const cusparseMatDescr_t descrA,
+                                                         float *csrSortedValA,
+                                                         const int *csrSortedRowPtrA,
+                                                         const int *csrSortedColIndA,
+                                                         csric02Info_t info,
+                                                         int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, csric02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsric02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsric02_bufferSize(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    double *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, csric02Info_t info, int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, double *,
-      const int *, const int *, csric02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsric02_bufferSize(cusparseHandle_t handle,
+                                                         int m,
+                                                         int nnz,
+                                                         const cusparseMatDescr_t descrA,
+                                                         double *csrSortedValA,
+                                                         const int *csrSortedRowPtrA,
+                                                         const int *csrSortedColIndA,
+                                                         csric02Info_t info,
+                                                         int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, csric02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsric02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsric02_bufferSize(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, csric02Info_t info, int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, cuComplex *,
-      const int *, const int *, csric02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsric02_bufferSize(cusparseHandle_t handle,
+                                                         int m,
+                                                         int nnz,
+                                                         const cusparseMatDescr_t descrA,
+                                                         cuComplex *csrSortedValA,
+                                                         const int *csrSortedRowPtrA,
+                                                         const int *csrSortedColIndA,
+                                                         csric02Info_t info,
+                                                         int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, csric02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsric02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsric02_bufferSize(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, csric02Info_t info, int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *,
-      const int *, const int *, csric02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsric02_bufferSize(cusparseHandle_t handle,
+                                                         int m,
+                                                         int nnz,
+                                                         const cusparseMatDescr_t descrA,
+                                                         cuDoubleComplex *csrSortedValA,
+                                                         const int *csrSortedRowPtrA,
+                                                         const int *csrSortedColIndA,
+                                                         csric02Info_t info,
+                                                         int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, csric02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsric02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsric02_bufferSizeExt(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    float *csrSortedVal, const int *csrSortedRowPtr, const int *csrSortedColInd,
-    csric02Info_t info, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, float *,
-      const int *, const int *, csric02Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseScsric02_bufferSizeExt(cusparseHandle_t handle,
+                                                            int m,
+                                                            int nnz,
+                                                            const cusparseMatDescr_t descrA,
+                                                            float *csrSortedVal,
+                                                            const int *csrSortedRowPtr,
+                                                            const int *csrSortedColInd,
+                                                            csric02Info_t info,
+                                                            size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, csric02Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsric02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr,
-                  csrSortedColInd, info, pBufferSize);
+  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr, csrSortedColInd, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsric02_bufferSizeExt(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    double *csrSortedVal, const int *csrSortedRowPtr,
-    const int *csrSortedColInd, csric02Info_t info, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, double *,
-      const int *, const int *, csric02Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsric02_bufferSizeExt(cusparseHandle_t handle,
+                                                            int m,
+                                                            int nnz,
+                                                            const cusparseMatDescr_t descrA,
+                                                            double *csrSortedVal,
+                                                            const int *csrSortedRowPtr,
+                                                            const int *csrSortedColInd,
+                                                            csric02Info_t info,
+                                                            size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, csric02Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsric02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr,
-                  csrSortedColInd, info, pBufferSize);
+  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr, csrSortedColInd, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsric02_bufferSizeExt(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    cuComplex *csrSortedVal, const int *csrSortedRowPtr,
-    const int *csrSortedColInd, csric02Info_t info, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, cuComplex *,
-      const int *, const int *, csric02Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsric02_bufferSizeExt(cusparseHandle_t handle,
+                                                            int m,
+                                                            int nnz,
+                                                            const cusparseMatDescr_t descrA,
+                                                            cuComplex *csrSortedVal,
+                                                            const int *csrSortedRowPtr,
+                                                            const int *csrSortedColInd,
+                                                            csric02Info_t info,
+                                                            size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, csric02Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsric02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr,
-                  csrSortedColInd, info, pBufferSize);
+  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr, csrSortedColInd, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsric02_bufferSizeExt(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    cuDoubleComplex *csrSortedVal, const int *csrSortedRowPtr,
-    const int *csrSortedColInd, csric02Info_t info, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *,
-      const int *, const int *, csric02Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsric02_bufferSizeExt(cusparseHandle_t handle,
+                                                            int m,
+                                                            int nnz,
+                                                            const cusparseMatDescr_t descrA,
+                                                            cuDoubleComplex *csrSortedVal,
+                                                            const int *csrSortedRowPtr,
+                                                            const int *csrSortedColInd,
+                                                            csric02Info_t info,
+                                                            size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, csric02Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsric02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr,
-                  csrSortedColInd, info, pBufferSize);
+  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr, csrSortedColInd, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsric02_analysis(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    const float *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, csric02Info_t info,
-    cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *,
-      const int *, const int *, csric02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseScsric02_analysis(cusparseHandle_t handle,
+                                                       int m,
+                                                       int nnz,
+                                                       const cusparseMatDescr_t descrA,
+                                                       const float *csrSortedValA,
+                                                       const int *csrSortedRowPtrA,
+                                                       const int *csrSortedColIndA,
+                                                       csric02Info_t info,
+                                                       cusparseSolvePolicy_t policy,
+                                                       void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, csric02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsric02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsric02_analysis(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    const double *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, csric02Info_t info,
-    cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *,
-      const int *, const int *, csric02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsric02_analysis(cusparseHandle_t handle,
+                                                       int m,
+                                                       int nnz,
+                                                       const cusparseMatDescr_t descrA,
+                                                       const double *csrSortedValA,
+                                                       const int *csrSortedRowPtrA,
+                                                       const int *csrSortedColIndA,
+                                                       csric02Info_t info,
+                                                       cusparseSolvePolicy_t policy,
+                                                       void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, csric02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsric02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsric02_analysis(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    const cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, csric02Info_t info,
-    cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *,
-      const int *, const int *, csric02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsric02_analysis(cusparseHandle_t handle,
+                                                       int m,
+                                                       int nnz,
+                                                       const cusparseMatDescr_t descrA,
+                                                       const cuComplex *csrSortedValA,
+                                                       const int *csrSortedRowPtrA,
+                                                       const int *csrSortedColIndA,
+                                                       csric02Info_t info,
+                                                       cusparseSolvePolicy_t policy,
+                                                       void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, csric02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsric02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsric02_analysis(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, csric02Info_t info,
-    cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t,
-      const cuDoubleComplex *, const int *, const int *, csric02Info_t,
-      cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsric02_analysis(cusparseHandle_t handle,
+                                                       int m,
+                                                       int nnz,
+                                                       const cusparseMatDescr_t descrA,
+                                                       const cuDoubleComplex *csrSortedValA,
+                                                       const int *csrSortedRowPtrA,
+                                                       const int *csrSortedColIndA,
+                                                       csric02Info_t info,
+                                                       cusparseSolvePolicy_t policy,
+                                                       void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, csric02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsric02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsric02(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    float *csrSortedValA_valM, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, csric02Info_t info,
-    cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, float *,
-      const int *, const int *, csric02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseScsric02(cusparseHandle_t handle,
+                                              int m,
+                                              int nnz,
+                                              const cusparseMatDescr_t descrA,
+                                              float *csrSortedValA_valM,
+                                              /* matrix A values are updated inplace
+                                                 to be the preconditioner M values */
+                                              const int *csrSortedRowPtrA,
+                                              const int *csrSortedColIndA,
+                                              csric02Info_t info,
+                                              cusparseSolvePolicy_t policy,
+                                              void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, csric02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsric02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA,
-                  csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsric02(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    double *csrSortedValA_valM, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, csric02Info_t info,
-    cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, double *,
-      const int *, const int *, csric02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsric02(cusparseHandle_t handle,
+                                              int m,
+                                              int nnz,
+                                              const cusparseMatDescr_t descrA,
+                                              double *csrSortedValA_valM,
+                                              /* matrix A values are updated inplace
+                                                 to be the preconditioner M values */
+                                              const int *csrSortedRowPtrA,
+                                              const int *csrSortedColIndA,
+                                              csric02Info_t info,
+                                              cusparseSolvePolicy_t policy,
+                                              void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, csric02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsric02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA,
-                  csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsric02(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    cuComplex *csrSortedValA_valM, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, csric02Info_t info,
-    cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, cuComplex *,
-      const int *, const int *, csric02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsric02(cusparseHandle_t handle,
+                                              int m,
+                                              int nnz,
+                                              const cusparseMatDescr_t descrA,
+                                              cuComplex *csrSortedValA_valM,
+                                              /* matrix A values are updated inplace
+                                                 to be the preconditioner M values */
+                                              const int *csrSortedRowPtrA,
+                                              const int *csrSortedColIndA,
+                                              csric02Info_t info,
+                                              cusparseSolvePolicy_t policy,
+                                              void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, csric02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsric02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA,
-                  csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsric02(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    cuDoubleComplex *csrSortedValA_valM, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, csric02Info_t info,
-    cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *,
-      const int *, const int *, csric02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsric02(cusparseHandle_t handle,
+                                              int m,
+                                              int nnz,
+                                              const cusparseMatDescr_t descrA,
+                                              cuDoubleComplex *csrSortedValA_valM,
+                                              /* matrix A values are updated inplace
+                                                 to be the preconditioner M values */
+                                              const int *csrSortedRowPtrA,
+                                              const int *csrSortedColIndA,
+                                              csric02Info_t info,
+                                              cusparseSolvePolicy_t policy,
+                                              void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, csric02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsric02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA,
-                  csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseXbsric02_zeroPivot(cusparseHandle_t handle,
                                                         bsric02Info_t info,
                                                         int *position) {
-  using FuncPtr =
-      cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, bsric02Info_t, int *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, bsric02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXbsric02_zeroPivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, position);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsric02_bufferSize(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, float *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
-    bsric02Info_t info, int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      float *, const int *, const int *, int, bsric02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsric02_bufferSize(cusparseHandle_t handle,
+                                                         cusparseDirection_t dirA,
+                                                         int mb,
+                                                         int nnzb,
+                                                         const cusparseMatDescr_t descrA,
+                                                         float *bsrSortedVal,
+                                                         const int *bsrSortedRowPtr,
+                                                         const int *bsrSortedColInd,
+                                                         int blockDim,
+                                                         bsric02Info_t info,
+                                                         int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, int, bsric02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsric02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsric02_bufferSize(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, double *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
-    bsric02Info_t info, int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      double *, const int *, const int *, int, bsric02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsric02_bufferSize(cusparseHandle_t handle,
+                                                         cusparseDirection_t dirA,
+                                                         int mb,
+                                                         int nnzb,
+                                                         const cusparseMatDescr_t descrA,
+                                                         double *bsrSortedVal,
+                                                         const int *bsrSortedRowPtr,
+                                                         const int *bsrSortedColInd,
+                                                         int blockDim,
+                                                         bsric02Info_t info,
+                                                         int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, int, bsric02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsric02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsric02_bufferSize(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, cuComplex *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
-    bsric02Info_t info, int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      cuComplex *, const int *, const int *, int, bsric02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsric02_bufferSize(cusparseHandle_t handle,
+                                                         cusparseDirection_t dirA,
+                                                         int mb,
+                                                         int nnzb,
+                                                         const cusparseMatDescr_t descrA,
+                                                         cuComplex *bsrSortedVal,
+                                                         const int *bsrSortedRowPtr,
+                                                         const int *bsrSortedColInd,
+                                                         int blockDim,
+                                                         bsric02Info_t info,
+                                                         int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, int, bsric02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsric02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsric02_bufferSize(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, cuDoubleComplex *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
-    bsric02Info_t info, int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      cuDoubleComplex *, const int *, const int *, int, bsric02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsric02_bufferSize(cusparseHandle_t handle,
+                                                         cusparseDirection_t dirA,
+                                                         int mb,
+                                                         int nnzb,
+                                                         const cusparseMatDescr_t descrA,
+                                                         cuDoubleComplex *bsrSortedVal,
+                                                         const int *bsrSortedRowPtr,
+                                                         const int *bsrSortedColInd,
+                                                         int blockDim,
+                                                         bsric02Info_t info,
+                                                         int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, int, bsric02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsric02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsric02_bufferSizeExt(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, float *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
-    bsric02Info_t info, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      float *, const int *, const int *, int, bsric02Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsric02_bufferSizeExt(cusparseHandle_t handle,
+                                                         cusparseDirection_t dirA,
+                                                         int mb,
+                                                         int nnzb,
+                                                         const cusparseMatDescr_t descrA,
+                                                         float *bsrSortedVal,
+                                                         const int *bsrSortedRowPtr,
+                                                         const int *bsrSortedColInd,
+                                                         int blockSize,
+                                                         bsric02Info_t info,
+                                                         size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, int, bsric02Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsric02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockSize, info, pBufferSize);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsric02_bufferSizeExt(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, double *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
-    bsric02Info_t info, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      double *, const int *, const int *, int, bsric02Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsric02_bufferSizeExt(cusparseHandle_t handle,
+                                                         cusparseDirection_t dirA,
+                                                         int mb,
+                                                         int nnzb,
+                                                         const cusparseMatDescr_t descrA,
+                                                         double *bsrSortedVal,
+                                                         const int *bsrSortedRowPtr,
+                                                         const int *bsrSortedColInd,
+                                                         int blockSize,
+                                                         bsric02Info_t info,
+                                                         size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, int, bsric02Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsric02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockSize, info, pBufferSize);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsric02_bufferSizeExt(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, cuComplex *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
-    bsric02Info_t info, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      cuComplex *, const int *, const int *, int, bsric02Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsric02_bufferSizeExt(cusparseHandle_t handle,
+                                                         cusparseDirection_t dirA,
+                                                         int mb,
+                                                         int nnzb,
+                                                         const cusparseMatDescr_t descrA,
+                                                         cuComplex *bsrSortedVal,
+                                                         const int *bsrSortedRowPtr,
+                                                         const int *bsrSortedColInd,
+                                                         int blockSize,
+                                                         bsric02Info_t info,
+                                                         size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, int, bsric02Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsric02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockSize, info, pBufferSize);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsric02_bufferSizeExt(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, cuDoubleComplex *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
-    bsric02Info_t info, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      cuDoubleComplex *, const int *, const int *, int, bsric02Info_t,
-      size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsric02_bufferSizeExt(cusparseHandle_t handle,
+                                                         cusparseDirection_t dirA,
+                                                         int mb,
+                                                         int nnzb,
+                                                         const cusparseMatDescr_t descrA,
+                                                         cuDoubleComplex *bsrSortedVal,
+                                                         const int *bsrSortedRowPtr,
+                                                         const int *bsrSortedColInd,
+                                                         int blockSize,
+                                                         bsric02Info_t info,
+                                                         size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, int, bsric02Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsric02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockSize, info, pBufferSize);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsric02_analysis(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, const float *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
-    bsric02Info_t info, cusparseSolvePolicy_t policy, void *pInputBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const float *, const int *, const int *, int, bsric02Info_t,
-      cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsric02_analysis(cusparseHandle_t handle,
+                                                       cusparseDirection_t dirA,
+                                                       int mb,
+                                                       int nnzb,
+                                                       const cusparseMatDescr_t descrA,
+                                                       const float *bsrSortedVal,
+                                                       const int *bsrSortedRowPtr,
+                                                       const int *bsrSortedColInd,
+                                                       int blockDim,
+                                                       bsric02Info_t info,
+                                                       cusparseSolvePolicy_t policy,
+                                                       void *pInputBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, int, bsric02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsric02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockDim, info, policy, pInputBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pInputBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsric02_analysis(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, const double *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
-    bsric02Info_t info, cusparseSolvePolicy_t policy, void *pInputBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const double *, const int *, const int *, int, bsric02Info_t,
-      cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsric02_analysis(cusparseHandle_t handle,
+                                                       cusparseDirection_t dirA,
+                                                       int mb,
+                                                       int nnzb,
+                                                       const cusparseMatDescr_t descrA,
+                                                       const double *bsrSortedVal,
+                                                       const int *bsrSortedRowPtr,
+                                                       const int *bsrSortedColInd,
+                                                       int blockDim,
+                                                       bsric02Info_t info,
+                                                       cusparseSolvePolicy_t policy,
+                                                       void *pInputBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, int, bsric02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsric02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockDim, info, policy, pInputBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pInputBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsric02_analysis(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, const cuComplex *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
-    bsric02Info_t info, cusparseSolvePolicy_t policy, void *pInputBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const cuComplex *, const int *, const int *, int, bsric02Info_t,
-      cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsric02_analysis(cusparseHandle_t handle,
+                                                       cusparseDirection_t dirA,
+                                                       int mb,
+                                                       int nnzb,
+                                                       const cusparseMatDescr_t descrA,
+                                                       const cuComplex *bsrSortedVal,
+                                                       const int *bsrSortedRowPtr,
+                                                       const int *bsrSortedColInd,
+                                                       int blockDim,
+                                                       bsric02Info_t info,
+                                                       cusparseSolvePolicy_t policy,
+                                                       void *pInputBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, int, bsric02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsric02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockDim, info, policy, pInputBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pInputBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsric02_analysis(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, const cuDoubleComplex *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
-    bsric02Info_t info, cusparseSolvePolicy_t policy, void *pInputBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const cuDoubleComplex *, const int *, const int *, int, bsric02Info_t,
-      cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsric02_analysis(cusparseHandle_t handle,
+                                                       cusparseDirection_t dirA,
+                                                       int mb,
+                                                       int nnzb,
+                                                       const cusparseMatDescr_t descrA,
+                                                       const cuDoubleComplex *bsrSortedVal,
+                                                       const int *bsrSortedRowPtr,
+                                                       const int *bsrSortedColInd,
+                                                       int blockDim,
+                                                       bsric02Info_t info,
+                                                       cusparseSolvePolicy_t policy,
+                                                       void *pInputBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, int, bsric02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsric02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockDim, info, policy, pInputBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pInputBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsric02(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, float *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
-    bsric02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      float *, const int *, const int *, int, bsric02Info_t,
-      cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsric02(cusparseHandle_t handle,
+                                              cusparseDirection_t dirA,
+                                              int mb,
+                                              int nnzb,
+                                              const cusparseMatDescr_t descrA,
+                                              float *bsrSortedVal,
+                                              const int *bsrSortedRowPtr,
+                                              const int *bsrSortedColInd,
+                                              int blockDim,
+                                              bsric02Info_t info,
+                                              cusparseSolvePolicy_t policy,
+                                              void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, int, bsric02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsric02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockDim, info, policy, pBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsric02(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, double *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
-    bsric02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      double *, const int *, const int *, int, bsric02Info_t,
-      cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsric02(cusparseHandle_t handle,
+                                              cusparseDirection_t dirA,
+                                              int mb,
+                                              int nnzb,
+                                              const cusparseMatDescr_t descrA,
+                                              double *bsrSortedVal,
+                                              const int *bsrSortedRowPtr,
+                                              const int *bsrSortedColInd,
+                                              int blockDim,
+                                              bsric02Info_t info,
+                                              cusparseSolvePolicy_t policy,
+                                              void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, int, bsric02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsric02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockDim, info, policy, pBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsric02(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, cuComplex *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
-    bsric02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      cuComplex *, const int *, const int *, int, bsric02Info_t,
-      cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsric02(cusparseHandle_t handle,
+                                              cusparseDirection_t dirA,
+                                              int mb,
+                                              int nnzb,
+                                              const cusparseMatDescr_t descrA,
+                                              cuComplex *bsrSortedVal,
+                                              const int *bsrSortedRowPtr,
+                                              const int *bsrSortedColInd,
+                                              int blockDim,
+                                              bsric02Info_t info,
+                                              cusparseSolvePolicy_t policy,
+                                              void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, int, bsric02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsric02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockDim, info, policy, pBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsric02(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
-    const cusparseMatDescr_t descrA, cuDoubleComplex *bsrSortedVal,
-    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
-    bsric02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      cuDoubleComplex *, const int *, const int *, int, bsric02Info_t,
-      cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsric02(cusparseHandle_t handle,
+                                              cusparseDirection_t dirA,
+                                              int mb,
+                                              int nnzb,
+                                              const cusparseMatDescr_t descrA,
+                                              cuDoubleComplex *bsrSortedVal,
+                                              const int *bsrSortedRowPtr,
+                                              const int *bsrSortedColInd,
+                                              int blockDim,
+                                              bsric02Info_t info,
+                                              cusparseSolvePolicy_t policy,
+                                              void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, int, bsric02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsric02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, blockDim, info, policy, pBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSgtsv(cusparseHandle_t handle, int m,
-                                           int n, const float *dl,
-                                           const float *d, const float *du,
-                                           float *B, int ldb) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, int, int,
-                                                  const float *, const float *,
-                                                  const float *, float *, int);
+cusparseStatus_t CUSPARSEAPI cusparseSgtsv(
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const float *dl,
+    const float  *d,
+    const float *du,
+    float *B,
+    int ldb) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, const float  *, const float *, float *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgtsv");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDgtsv(cusparseHandle_t handle, int m,
-                                           int n, const double *dl,
-                                           const double *d, const double *du,
-                                           double *B, int ldb) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const double *, const double *,
-      const double *, double *, int);
+cusparseStatus_t CUSPARSEAPI cusparseDgtsv(
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const double *dl,
+    const double  *d,
+    const double *du,
+    double *B,
+    int ldb) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, const double  *, const double *, double *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgtsv");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCgtsv(cusparseHandle_t handle, int m,
-                                           int n, const cuComplex *dl,
-                                           const cuComplex *d,
-                                           const cuComplex *du, cuComplex *B,
-                                           int ldb) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cuComplex *, const cuComplex *,
-      const cuComplex *, cuComplex *, int);
+cusparseStatus_t CUSPARSEAPI cusparseCgtsv(
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const cuComplex *dl,
+    const cuComplex  *d,
+    const cuComplex *du,
+    cuComplex *B,
+    int ldb) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuComplex *, const cuComplex  *, const cuComplex *, cuComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgtsv");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZgtsv(cusparseHandle_t handle, int m,
-                                           int n, const cuDoubleComplex *dl,
-                                           const cuDoubleComplex *d,
-                                           const cuDoubleComplex *du,
-                                           cuDoubleComplex *B, int ldb) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cuDoubleComplex *,
-      const cuDoubleComplex *, const cuDoubleComplex *, cuDoubleComplex *, int);
+cusparseStatus_t CUSPARSEAPI cusparseZgtsv(
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const cuDoubleComplex *dl,
+    const cuDoubleComplex  *d,
+    const cuDoubleComplex *du,
+    cuDoubleComplex *B,
+    int ldb) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuDoubleComplex *, const cuDoubleComplex  *, const cuDoubleComplex *, cuDoubleComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgtsv");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSgtsv2_bufferSizeExt(
-    cusparseHandle_t handle, int m, int n, const float *dl, const float *d,
-    const float *du, const float *B, int ldb, size_t *bufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const float *, const float *, const float *,
-      const float *, int, size_t *);
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const float *dl,
+    const float  *d,
+    const float *du,
+    const float *B,
+    int ldb,
+    size_t *bufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, const float  *, const float *, const float *, int, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgtsv2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, bufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDgtsv2_bufferSizeExt(
-    cusparseHandle_t handle, int m, int n, const double *dl, const double *d,
-    const double *du, const double *B, int ldb, size_t *bufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const double *, const double *,
-      const double *, const double *, int, size_t *);
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const double *dl,
+    const double  *d,
+    const double *du,
+    const double *B,
+    int ldb,
+    size_t *bufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, const double  *, const double *, const double *, int, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgtsv2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, bufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCgtsv2_bufferSizeExt(
-    cusparseHandle_t handle, int m, int n, const cuComplex *dl,
-    const cuComplex *d, const cuComplex *du, const cuComplex *B, int ldb,
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const cuComplex *dl,
+    const cuComplex  *d,
+    const cuComplex *du,
+    const cuComplex *B,
+    int ldb,
     size_t *bufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cuComplex *, const cuComplex *,
-      const cuComplex *, const cuComplex *, int, size_t *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuComplex *, const cuComplex  *, const cuComplex *, const cuComplex *, int, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgtsv2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, bufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseZgtsv2_bufferSizeExt(
-    cusparseHandle_t handle, int m, int n, const cuDoubleComplex *dl,
-    const cuDoubleComplex *d, const cuDoubleComplex *du,
-    const cuDoubleComplex *B, int ldb, size_t *bufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cuDoubleComplex *,
-      const cuDoubleComplex *, const cuDoubleComplex *, const cuDoubleComplex *,
-      int, size_t *);
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const cuDoubleComplex *dl,
+    const cuDoubleComplex  *d,
+    const cuDoubleComplex *du,
+    const cuDoubleComplex *B,
+    int ldb,
+    size_t *bufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuDoubleComplex *, const cuDoubleComplex  *, const cuDoubleComplex *, const cuDoubleComplex *, int, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgtsv2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, bufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSgtsv2(cusparseHandle_t handle, int m,
-                                            int n, const float *dl,
-                                            const float *d, const float *du,
-                                            float *B, int ldb, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const float *, const float *, const float *,
-      float *, int, void *);
+cusparseStatus_t CUSPARSEAPI cusparseSgtsv2(
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const float *dl,
+    const float  *d,
+    const float *du,
+    float *B,
+    int ldb,
+    void* pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, const float  *, const float *, float *, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgtsv2");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDgtsv2(cusparseHandle_t handle, int m,
-                                            int n, const double *dl,
-                                            const double *d, const double *du,
-                                            double *B, int ldb, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const double *, const double *,
-      const double *, double *, int, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDgtsv2(
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const double *dl,
+    const double  *d,
+    const double *du,
+    double *B,
+    int ldb,
+    void* pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, const double  *, const double *, double *, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgtsv2");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCgtsv2(cusparseHandle_t handle, int m,
-                                            int n, const cuComplex *dl,
-                                            const cuComplex *d,
-                                            const cuComplex *du, cuComplex *B,
-                                            int ldb, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cuComplex *, const cuComplex *,
-      const cuComplex *, cuComplex *, int, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCgtsv2(
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const cuComplex *dl,
+    const cuComplex  *d,
+    const cuComplex *du,
+    cuComplex *B,
+    int ldb,
+    void* pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuComplex *, const cuComplex  *, const cuComplex *, cuComplex *, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgtsv2");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZgtsv2(cusparseHandle_t handle, int m,
-                                            int n, const cuDoubleComplex *dl,
-                                            const cuDoubleComplex *d,
-                                            const cuDoubleComplex *du,
-                                            cuDoubleComplex *B, int ldb,
-                                            void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cuDoubleComplex *,
-      const cuDoubleComplex *, const cuDoubleComplex *, cuDoubleComplex *, int,
-      void *);
+cusparseStatus_t CUSPARSEAPI cusparseZgtsv2(
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const cuDoubleComplex *dl,
+    const cuDoubleComplex  *d,
+    const cuDoubleComplex *du,
+    cuDoubleComplex *B,
+    int ldb,
+    void* pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuDoubleComplex *, const cuDoubleComplex  *, const cuDoubleComplex *, cuDoubleComplex *, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgtsv2");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseSgtsv_nopivot(cusparseHandle_t handle, int m, int n, const float *dl,
-                      const float *d, const float *du, float *B, int ldb) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, int, int,
-                                                  const float *, const float *,
-                                                  const float *, float *, int);
+cusparseStatus_t CUSPARSEAPI cusparseSgtsv_nopivot(
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const float *dl,
+    const float  *d,
+    const float *du,
+    float *B,
+    int ldb) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, const float  *, const float *, float *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgtsv_nopivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseDgtsv_nopivot(cusparseHandle_t handle, int m, int n, const double *dl,
-                      const double *d, const double *du, double *B, int ldb) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const double *, const double *,
-      const double *, double *, int);
+cusparseStatus_t CUSPARSEAPI cusparseDgtsv_nopivot(
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const double *dl,
+    const double  *d,
+    const double *du,
+    double *B,
+    int ldb) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, const double  *, const double *, double *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgtsv_nopivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCgtsv_nopivot(
-    cusparseHandle_t handle, int m, int n, const cuComplex *dl,
-    const cuComplex *d, const cuComplex *du, cuComplex *B, int ldb) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cuComplex *, const cuComplex *,
-      const cuComplex *, cuComplex *, int);
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const cuComplex *dl,
+    const cuComplex  *d,
+    const cuComplex *du,
+    cuComplex *B,
+    int ldb) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuComplex *, const cuComplex  *, const cuComplex *, cuComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgtsv_nopivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseZgtsv_nopivot(cusparseHandle_t handle, int m, int n,
-                      const cuDoubleComplex *dl, const cuDoubleComplex *d,
-                      const cuDoubleComplex *du, cuDoubleComplex *B, int ldb) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cuDoubleComplex *,
-      const cuDoubleComplex *, const cuDoubleComplex *, cuDoubleComplex *, int);
+cusparseStatus_t CUSPARSEAPI cusparseZgtsv_nopivot(
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const cuDoubleComplex *dl,
+    const cuDoubleComplex  *d,
+    const cuDoubleComplex *du,
+    cuDoubleComplex *B,
+    int ldb) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuDoubleComplex *, const cuDoubleComplex  *, const cuDoubleComplex *, cuDoubleComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgtsv_nopivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSgtsv2_nopivot_bufferSizeExt(
-    cusparseHandle_t handle, int m, int n, const float *dl, const float *d,
-    const float *du, const float *B, int ldb, size_t *bufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const float *, const float *, const float *,
-      const float *, int, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseSgtsv2_nopivot_bufferSizeExt");
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const float *dl,
+    const float  *d,
+    const float *du,
+    const float *B,
+    int ldb,
+    size_t *bufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, const float  *, const float *, const float *, int, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgtsv2_nopivot_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, bufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDgtsv2_nopivot_bufferSizeExt(
-    cusparseHandle_t handle, int m, int n, const double *dl, const double *d,
-    const double *du, const double *B, int ldb, size_t *bufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const double *, const double *,
-      const double *, const double *, int, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseDgtsv2_nopivot_bufferSizeExt");
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const double *dl,
+    const double  *d,
+    const double *du,
+    const double *B,
+    int ldb,
+    size_t *bufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, const double  *, const double *, const double *, int, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgtsv2_nopivot_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, bufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCgtsv2_nopivot_bufferSizeExt(
-    cusparseHandle_t handle, int m, int n, const cuComplex *dl,
-    const cuComplex *d, const cuComplex *du, const cuComplex *B, int ldb,
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const cuComplex *dl,
+    const cuComplex  *d,
+    const cuComplex *du,
+    const cuComplex *B,
+    int ldb,
     size_t *bufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cuComplex *, const cuComplex *,
-      const cuComplex *, const cuComplex *, int, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseCgtsv2_nopivot_bufferSizeExt");
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuComplex *, const cuComplex  *, const cuComplex *, const cuComplex *, int, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgtsv2_nopivot_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, bufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseZgtsv2_nopivot_bufferSizeExt(
-    cusparseHandle_t handle, int m, int n, const cuDoubleComplex *dl,
-    const cuDoubleComplex *d, const cuDoubleComplex *du,
-    const cuDoubleComplex *B, int ldb, size_t *bufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cuDoubleComplex *,
-      const cuDoubleComplex *, const cuDoubleComplex *, const cuDoubleComplex *,
-      int, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseZgtsv2_nopivot_bufferSizeExt");
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const cuDoubleComplex *dl,
+    const cuDoubleComplex  *d,
+    const cuDoubleComplex *du,
+    const cuDoubleComplex *B,
+    int ldb,
+    size_t *bufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuDoubleComplex *, const cuDoubleComplex  *, const cuDoubleComplex *, const cuDoubleComplex *, int, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgtsv2_nopivot_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, bufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSgtsv2_nopivot(
-    cusparseHandle_t handle, int m, int n, const float *dl, const float *d,
-    const float *du, float *B, int ldb, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const float *, const float *, const float *,
-      float *, int, void *);
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const float *dl,
+    const float  *d,
+    const float *du,
+    float *B,
+    int ldb,
+    void* pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, const float  *, const float *, float *, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgtsv2_nopivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDgtsv2_nopivot(
-    cusparseHandle_t handle, int m, int n, const double *dl, const double *d,
-    const double *du, double *B, int ldb, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const double *, const double *,
-      const double *, double *, int, void *);
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const double *dl,
+    const double  *d,
+    const double *du,
+    double *B,
+    int ldb,
+    void* pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, const double  *, const double *, double *, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgtsv2_nopivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCgtsv2_nopivot(
-    cusparseHandle_t handle, int m, int n, const cuComplex *dl,
-    const cuComplex *d, const cuComplex *du, cuComplex *B, int ldb,
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cuComplex *, const cuComplex *,
-      const cuComplex *, cuComplex *, int, void *);
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const cuComplex *dl,
+    const cuComplex  *d,
+    const cuComplex *du,
+    cuComplex *B,
+    int ldb,
+    void* pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuComplex *, const cuComplex  *, const cuComplex *, cuComplex *, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgtsv2_nopivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseZgtsv2_nopivot(
-    cusparseHandle_t handle, int m, int n, const cuDoubleComplex *dl,
-    const cuDoubleComplex *d, const cuDoubleComplex *du, cuDoubleComplex *B,
-    int ldb, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cuDoubleComplex *,
-      const cuDoubleComplex *, const cuDoubleComplex *, cuDoubleComplex *, int,
-      void *);
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const cuDoubleComplex *dl,
+    const cuDoubleComplex  *d,
+    const cuDoubleComplex *du,
+    cuDoubleComplex *B,
+    int ldb,
+    void* pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuDoubleComplex *, const cuDoubleComplex  *, const cuDoubleComplex *, cuDoubleComplex *, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgtsv2_nopivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSgtsvStridedBatch(
-    cusparseHandle_t handle, int m, const float *dl, const float *d,
-    const float *du, float *x, int batchCount, int batchStride) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const float *, const float *, const float *,
-      float *, int, int);
+    cusparseHandle_t handle,
+    int m,
+    const float *dl,
+    const float  *d,
+    const float *du,
+    float *x,
+    int batchCount,
+    int batchStride) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const float *, const float  *, const float *, float *, int, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgtsvStridedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDgtsvStridedBatch(
-    cusparseHandle_t handle, int m, const double *dl, const double *d,
-    const double *du, double *x, int batchCount, int batchStride) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const double *, const double *, const double *,
-      double *, int, int);
+    cusparseHandle_t handle,
+    int m,
+    const double *dl,
+    const double  *d,
+    const double *du,
+    double *x,
+    int batchCount,
+    int batchStride) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const double *, const double  *, const double *, double *, int, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgtsvStridedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCgtsvStridedBatch(
-    cusparseHandle_t handle, int m, const cuComplex *dl, const cuComplex *d,
-    const cuComplex *du, cuComplex *x, int batchCount, int batchStride) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const cuComplex *, const cuComplex *,
-      const cuComplex *, cuComplex *, int, int);
+    cusparseHandle_t handle,
+    int m,
+    const cuComplex *dl,
+    const cuComplex  *d,
+    const cuComplex *du,
+    cuComplex *x,
+    int batchCount,
+    int batchStride) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuComplex *, const cuComplex  *, const cuComplex *, cuComplex *, int, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgtsvStridedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseZgtsvStridedBatch(
-    cusparseHandle_t handle, int m, const cuDoubleComplex *dl,
-    const cuDoubleComplex *d, const cuDoubleComplex *du, cuDoubleComplex *x,
-    int batchCount, int batchStride) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const cuDoubleComplex *, const cuDoubleComplex *,
-      const cuDoubleComplex *, cuDoubleComplex *, int, int);
+    cusparseHandle_t handle,
+    int m,
+    const cuDoubleComplex *dl,
+    const cuDoubleComplex  *d,
+    const cuDoubleComplex *du,
+    cuDoubleComplex *x,
+    int batchCount,
+    int batchStride) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuDoubleComplex *, const cuDoubleComplex  *, const cuDoubleComplex *, cuDoubleComplex *, int, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgtsvStridedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSgtsv2StridedBatch_bufferSizeExt(
-    cusparseHandle_t handle, int m, const float *dl, const float *d,
-    const float *du, const float *x, int batchCount, int batchStride,
+    cusparseHandle_t handle,
+    int m,
+    const float *dl,
+    const float  *d,
+    const float *du,
+    const float *x,
+    int batchCount,
+    int batchStride,
     size_t *bufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const float *, const float *, const float *,
-      const float *, int, int, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseSgtsv2StridedBatch_bufferSizeExt");
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const float *, const float  *, const float *, const float *, int, int, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgtsv2StridedBatch_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride,
-                  bufferSizeInBytes);
+  return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride, bufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDgtsv2StridedBatch_bufferSizeExt(
-    cusparseHandle_t handle, int m, const double *dl, const double *d,
-    const double *du, const double *x, int batchCount, int batchStride,
+    cusparseHandle_t handle,
+    int m,
+    const double *dl,
+    const double  *d,
+    const double *du,
+    const double *x,
+    int batchCount,
+    int batchStride,
     size_t *bufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const double *, const double *, const double *,
-      const double *, int, int, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseDgtsv2StridedBatch_bufferSizeExt");
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const double *, const double  *, const double *, const double *, int, int, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgtsv2StridedBatch_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride,
-                  bufferSizeInBytes);
+  return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride, bufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCgtsv2StridedBatch_bufferSizeExt(
-    cusparseHandle_t handle, int m, const cuComplex *dl, const cuComplex *d,
-    const cuComplex *du, const cuComplex *x, int batchCount, int batchStride,
+    cusparseHandle_t handle,
+    int m,
+    const cuComplex *dl,
+    const cuComplex  *d,
+    const cuComplex *du,
+    const cuComplex *x,
+    int batchCount,
+    int batchStride,
     size_t *bufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const cuComplex *, const cuComplex *,
-      const cuComplex *, const cuComplex *, int, int, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseCgtsv2StridedBatch_bufferSizeExt");
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuComplex *, const cuComplex  *, const cuComplex *, const cuComplex *, int, int, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgtsv2StridedBatch_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride,
-                  bufferSizeInBytes);
+  return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride, bufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseZgtsv2StridedBatch_bufferSizeExt(
-    cusparseHandle_t handle, int m, const cuDoubleComplex *dl,
-    const cuDoubleComplex *d, const cuDoubleComplex *du,
-    const cuDoubleComplex *x, int batchCount, int batchStride,
+    cusparseHandle_t handle,
+    int m,
+    const cuDoubleComplex *dl,
+    const cuDoubleComplex  *d,
+    const cuDoubleComplex *du,
+    const cuDoubleComplex *x,
+    int batchCount,
+    int batchStride,
     size_t *bufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const cuDoubleComplex *, const cuDoubleComplex *,
-      const cuDoubleComplex *, const cuDoubleComplex *, int, int, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseZgtsv2StridedBatch_bufferSizeExt");
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuDoubleComplex *, const cuDoubleComplex  *, const cuDoubleComplex *, const cuDoubleComplex *, int, int, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgtsv2StridedBatch_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride,
-                  bufferSizeInBytes);
+  return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride, bufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSgtsv2StridedBatch(
-    cusparseHandle_t handle, int m, const float *dl, const float *d,
-    const float *du, float *x, int batchCount, int batchStride, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const float *, const float *, const float *,
-      float *, int, int, void *);
+    cusparseHandle_t handle,
+    int m,
+    const float *dl,
+    const float  *d,
+    const float *du,
+    float *x,
+    int batchCount,
+    int batchStride,
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const float *, const float  *, const float *, float *, int, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgtsv2StridedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseDgtsv2StridedBatch(cusparseHandle_t handle, int m, const double *dl,
-                           const double *d, const double *du, double *x,
-                           int batchCount, int batchStride, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const double *, const double *, const double *,
-      double *, int, int, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDgtsv2StridedBatch(
+    cusparseHandle_t handle,
+    int m,
+    const double *dl,
+    const double  *d,
+    const double *du,
+    double *x,
+    int batchCount,
+    int batchStride,
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const double *, const double  *, const double *, double *, int, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgtsv2StridedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCgtsv2StridedBatch(
-    cusparseHandle_t handle, int m, const cuComplex *dl, const cuComplex *d,
-    const cuComplex *du, cuComplex *x, int batchCount, int batchStride,
+    cusparseHandle_t handle,
+    int m,
+    const cuComplex *dl,
+    const cuComplex  *d,
+    const cuComplex *du,
+    cuComplex *x,
+    int batchCount,
+    int batchStride,
     void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const cuComplex *, const cuComplex *,
-      const cuComplex *, cuComplex *, int, int, void *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuComplex *, const cuComplex  *, const cuComplex *, cuComplex *, int, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgtsv2StridedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseZgtsv2StridedBatch(
-    cusparseHandle_t handle, int m, const cuDoubleComplex *dl,
-    const cuDoubleComplex *d, const cuDoubleComplex *du, cuDoubleComplex *x,
-    int batchCount, int batchStride, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const cuDoubleComplex *, const cuDoubleComplex *,
-      const cuDoubleComplex *, cuDoubleComplex *, int, int, void *);
+    cusparseHandle_t handle,
+    int m,
+    const cuDoubleComplex *dl,
+    const cuDoubleComplex  *d,
+    const cuDoubleComplex *du,
+    cuDoubleComplex *x,
+    int batchCount,
+    int batchStride,
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuDoubleComplex *, const cuDoubleComplex  *, const cuDoubleComplex *, cuDoubleComplex *, int, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgtsv2StridedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSgtsvInterleavedBatch_bufferSizeExt(
-    cusparseHandle_t handle, int algo, int m, const float *dl, const float *d,
-    const float *du, const float *x, int batchCount,
+    cusparseHandle_t handle,
+    int algo,
+    int m,
+    const float *dl,
+    const float  *d,
+    const float *du,
+    const float *x,
+    int batchCount,
     size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const float *, const float *, const float *,
-      const float *, int, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseSgtsvInterleavedBatch_bufferSizeExt");
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, const float  *, const float *, const float *, int, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgtsvInterleavedBatch_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, m, dl, d, du, x, batchCount,
-                  pBufferSizeInBytes);
+  return func_ptr(handle, algo, m, dl, d, du, x, batchCount, pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDgtsvInterleavedBatch_bufferSizeExt(
-    cusparseHandle_t handle, int algo, int m, const double *dl, const double *d,
-    const double *du, const double *x, int batchCount,
+    cusparseHandle_t handle,
+    int algo,
+    int m,
+    const double *dl,
+    const double  *d,
+    const double *du,
+    const double *x,
+    int batchCount,
     size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const double *, const double *,
-      const double *, const double *, int, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseDgtsvInterleavedBatch_bufferSizeExt");
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, const double  *, const double *, const double *, int, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgtsvInterleavedBatch_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, m, dl, d, du, x, batchCount,
-                  pBufferSizeInBytes);
+  return func_ptr(handle, algo, m, dl, d, du, x, batchCount, pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCgtsvInterleavedBatch_bufferSizeExt(
-    cusparseHandle_t handle, int algo, int m, const cuComplex *dl,
-    const cuComplex *d, const cuComplex *du, const cuComplex *x, int batchCount,
+    cusparseHandle_t handle,
+    int algo,
+    int m,
+    const cuComplex *dl,
+    const cuComplex  *d,
+    const cuComplex *du,
+    const cuComplex *x,
+    int batchCount,
     size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cuComplex *, const cuComplex *,
-      const cuComplex *, const cuComplex *, int, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseCgtsvInterleavedBatch_bufferSizeExt");
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuComplex *, const cuComplex  *, const cuComplex *, const cuComplex *, int, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgtsvInterleavedBatch_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, m, dl, d, du, x, batchCount,
-                  pBufferSizeInBytes);
+  return func_ptr(handle, algo, m, dl, d, du, x, batchCount, pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseZgtsvInterleavedBatch_bufferSizeExt(
-    cusparseHandle_t handle, int algo, int m, const cuDoubleComplex *dl,
-    const cuDoubleComplex *d, const cuDoubleComplex *du,
-    const cuDoubleComplex *x, int batchCount, size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cuDoubleComplex *,
-      const cuDoubleComplex *, const cuDoubleComplex *, const cuDoubleComplex *,
-      int, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseZgtsvInterleavedBatch_bufferSizeExt");
+    cusparseHandle_t handle,
+    int algo,
+    int m,
+    const cuDoubleComplex *dl,
+    const cuDoubleComplex  *d,
+    const cuDoubleComplex *du,
+    const cuDoubleComplex *x,
+    int batchCount,
+    size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuDoubleComplex *, const cuDoubleComplex  *, const cuDoubleComplex *, const cuDoubleComplex *, int, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgtsvInterleavedBatch_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, m, dl, d, du, x, batchCount,
-                  pBufferSizeInBytes);
+  return func_ptr(handle, algo, m, dl, d, du, x, batchCount, pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSgtsvInterleavedBatch(
-    cusparseHandle_t handle, int algo, int m, float *dl, float *d, float *du,
-    float *x, int batchCount, void *pBuffer) {
-  using FuncPtr =
-      cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, int, int, float *,
-                                      float *, float *, float *, int, void *);
+    cusparseHandle_t handle,
+    int algo,
+    int m,
+    float *dl,
+    float  *d,
+    float *du,
+    float *x,
+    int batchCount,
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, float *, float  *, float *, float *, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgtsvInterleavedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, algo, m, dl, d, du, x, batchCount, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDgtsvInterleavedBatch(
-    cusparseHandle_t handle, int algo, int m, double *dl, double *d, double *du,
-    double *x, int batchCount, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, int, int,
-                                                  double *, double *, double *,
-                                                  double *, int, void *);
+    cusparseHandle_t handle,
+    int algo,
+    int m,
+    double *dl,
+    double  *d,
+    double *du,
+    double *x,
+    int batchCount,
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, double *, double  *, double *, double *, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgtsvInterleavedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, algo, m, dl, d, du, x, batchCount, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCgtsvInterleavedBatch(
-    cusparseHandle_t handle, int algo, int m, cuComplex *dl, cuComplex *d,
-    cuComplex *du, cuComplex *x, int batchCount, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, cuComplex *, cuComplex *, cuComplex *,
-      cuComplex *, int, void *);
+    cusparseHandle_t handle,
+    int algo,
+    int m,
+    cuComplex *dl,
+    cuComplex  *d,
+    cuComplex *du,
+    cuComplex *x,
+    int batchCount,
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, cuComplex *, cuComplex  *, cuComplex *, cuComplex *, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgtsvInterleavedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, algo, m, dl, d, du, x, batchCount, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseZgtsvInterleavedBatch(
-    cusparseHandle_t handle, int algo, int m, cuDoubleComplex *dl,
-    cuDoubleComplex *d, cuDoubleComplex *du, cuDoubleComplex *x, int batchCount,
+    cusparseHandle_t handle,
+    int algo,
+    int m,
+    cuDoubleComplex *dl,
+    cuDoubleComplex  *d,
+    cuDoubleComplex *du,
+    cuDoubleComplex *x,
+    int batchCount,
     void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, cuDoubleComplex *, cuDoubleComplex *,
-      cuDoubleComplex *, cuDoubleComplex *, int, void *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, cuDoubleComplex *, cuDoubleComplex  *, cuDoubleComplex *, cuDoubleComplex *, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgtsvInterleavedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, algo, m, dl, d, du, x, batchCount, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSgpsvInterleavedBatch_bufferSizeExt(
-    cusparseHandle_t handle, int algo, int m, const float *ds, const float *dl,
-    const float *d, const float *du, const float *dw, const float *x,
-    int batchCount, size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const float *, const float *, const float *,
-      const float *, const float *, const float *, int, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseSgpsvInterleavedBatch_bufferSizeExt");
-  if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, m, ds, dl, d, du, dw, x, batchCount,
-                  pBufferSizeInBytes);
-}
-
-cusparseStatus_t CUSPARSEAPI cusparseDgpsvInterleavedBatch_bufferSizeExt(
-    cusparseHandle_t handle, int algo, int m, const double *ds,
-    const double *dl, const double *d, const double *du, const double *dw,
-    const double *x, int batchCount, size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const double *, const double *,
-      const double *, const double *, const double *, const double *, int,
-      size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseDgpsvInterleavedBatch_bufferSizeExt");
-  if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, m, ds, dl, d, du, dw, x, batchCount,
-                  pBufferSizeInBytes);
-}
-
-cusparseStatus_t CUSPARSEAPI cusparseCgpsvInterleavedBatch_bufferSizeExt(
-    cusparseHandle_t handle, int algo, int m, const cuComplex *ds,
-    const cuComplex *dl, const cuComplex *d, const cuComplex *du,
-    const cuComplex *dw, const cuComplex *x, int batchCount,
+cusparseStatus_t  CUSPARSEAPI cusparseSgpsvInterleavedBatch_bufferSizeExt(
+    cusparseHandle_t handle,
+    int algo,
+    int m,
+    const float *ds,
+    const float *dl,
+    const float  *d,
+    const float *du,
+    const float *dw,
+    const float *x,
+    int batchCount,
     size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cuComplex *, const cuComplex *,
-      const cuComplex *, const cuComplex *, const cuComplex *,
-      const cuComplex *, int, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseCgpsvInterleavedBatch_bufferSizeExt");
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, const float *, const float  *, const float *, const float *, const float *, int, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgpsvInterleavedBatch_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, m, ds, dl, d, du, dw, x, batchCount,
-                  pBufferSizeInBytes);
+  return func_ptr(handle, algo, m, ds, dl, d, du, dw, x, batchCount, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZgpsvInterleavedBatch_bufferSizeExt(
-    cusparseHandle_t handle, int algo, int m, const cuDoubleComplex *ds,
-    const cuDoubleComplex *dl, const cuDoubleComplex *d,
-    const cuDoubleComplex *du, const cuDoubleComplex *dw,
-    const cuDoubleComplex *x, int batchCount, size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cuDoubleComplex *,
-      const cuDoubleComplex *, const cuDoubleComplex *, const cuDoubleComplex *,
-      const cuDoubleComplex *, const cuDoubleComplex *, int, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseZgpsvInterleavedBatch_bufferSizeExt");
+cusparseStatus_t  CUSPARSEAPI cusparseDgpsvInterleavedBatch_bufferSizeExt(
+    cusparseHandle_t handle,
+    int algo,
+    int m,
+    const double *ds,
+    const double *dl,
+    const double  *d,
+    const double *du,
+    const double *dw,
+    const double *x,
+    int batchCount,
+    size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, const double *, const double  *, const double *, const double *, const double *, int, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgpsvInterleavedBatch_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, m, ds, dl, d, du, dw, x, batchCount,
-                  pBufferSizeInBytes);
+  return func_ptr(handle, algo, m, ds, dl, d, du, dw, x, batchCount, pBufferSizeInBytes);
+}
+
+cusparseStatus_t  CUSPARSEAPI cusparseCgpsvInterleavedBatch_bufferSizeExt(
+    cusparseHandle_t handle,
+    int algo,
+    int m,
+    const cuComplex *ds,
+    const cuComplex *dl,
+    const cuComplex  *d,
+    const cuComplex *du,
+    const cuComplex *dw,
+    const cuComplex *x,
+    int batchCount,
+    size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuComplex *, const cuComplex *, const cuComplex  *, const cuComplex *, const cuComplex *, const cuComplex *, int, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgpsvInterleavedBatch_bufferSizeExt");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(handle, algo, m, ds, dl, d, du, dw, x, batchCount, pBufferSizeInBytes);
+}
+
+cusparseStatus_t  CUSPARSEAPI cusparseZgpsvInterleavedBatch_bufferSizeExt(
+    cusparseHandle_t handle,
+    int algo,
+    int m,
+    const cuDoubleComplex *ds,
+    const cuDoubleComplex *dl,
+    const cuDoubleComplex  *d,
+    const cuDoubleComplex *du,
+    const cuDoubleComplex *dw,
+    const cuDoubleComplex *x,
+    int batchCount,
+    size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuDoubleComplex *, const cuDoubleComplex *, const cuDoubleComplex  *, const cuDoubleComplex *, const cuDoubleComplex *, const cuDoubleComplex *, int, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgpsvInterleavedBatch_bufferSizeExt");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(handle, algo, m, ds, dl, d, du, dw, x, batchCount, pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSgpsvInterleavedBatch(
-    cusparseHandle_t handle, int algo, int m, float *ds, float *dl, float *d,
-    float *du, float *dw, float *x, int batchCount, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, float *, float *, float *, float *, float *,
-      float *, int, void *);
+    cusparseHandle_t handle,
+    int algo,
+    int m,
+    float *ds,
+    float *dl,
+    float  *d,
+    float *du,
+    float *dw,
+    float *x,
+    int batchCount,
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, float *, float *, float  *, float *, float *, float *, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgpsvInterleavedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, algo, m, ds, dl, d, du, dw, x, batchCount, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDgpsvInterleavedBatch(
-    cusparseHandle_t handle, int algo, int m, double *ds, double *dl, double *d,
-    double *du, double *dw, double *x, int batchCount, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, double *, double *, double *, double *,
-      double *, double *, int, void *);
+    cusparseHandle_t handle,
+    int algo,
+    int m,
+    double *ds,
+    double *dl,
+    double  *d,
+    double *du,
+    double *dw,
+    double *x,
+    int batchCount,
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, double *, double *, double  *, double *, double *, double *, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgpsvInterleavedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, algo, m, ds, dl, d, du, dw, x, batchCount, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCgpsvInterleavedBatch(
-    cusparseHandle_t handle, int algo, int m, cuComplex *ds, cuComplex *dl,
-    cuComplex *d, cuComplex *du, cuComplex *dw, cuComplex *x, int batchCount,
+    cusparseHandle_t handle,
+    int algo,
+    int m,
+    cuComplex *ds,
+    cuComplex *dl,
+    cuComplex  *d,
+    cuComplex *du,
+    cuComplex *dw,
+    cuComplex *x,
+    int batchCount,
     void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, cuComplex *, cuComplex *, cuComplex *,
-      cuComplex *, cuComplex *, cuComplex *, int, void *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, cuComplex *, cuComplex *, cuComplex  *, cuComplex *, cuComplex *, cuComplex *, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgpsvInterleavedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, algo, m, ds, dl, d, du, dw, x, batchCount, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseZgpsvInterleavedBatch(
-    cusparseHandle_t handle, int algo, int m, cuDoubleComplex *ds,
-    cuDoubleComplex *dl, cuDoubleComplex *d, cuDoubleComplex *du,
-    cuDoubleComplex *dw, cuDoubleComplex *x, int batchCount, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, cuDoubleComplex *, cuDoubleComplex *,
-      cuDoubleComplex *, cuDoubleComplex *, cuDoubleComplex *,
-      cuDoubleComplex *, int, void *);
+    cusparseHandle_t handle,
+    int algo,
+    int m,
+    cuDoubleComplex *ds,
+    cuDoubleComplex *dl,
+    cuDoubleComplex  *d,
+    cuDoubleComplex *du,
+    cuDoubleComplex *dw,
+    cuDoubleComplex *x,
+    int batchCount,
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, cuDoubleComplex *, cuDoubleComplex *, cuDoubleComplex  *, cuDoubleComplex *, cuDoubleComplex *, cuDoubleComplex *, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgpsvInterleavedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, algo, m, ds, dl, d, du, dw, x, batchCount, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseXcsrgemmNnz(cusparseHandle_t handle, cusparseOperation_t transA,
-                    cusparseOperation_t transB, int m, int n, int k,
-                    const cusparseMatDescr_t descrA, const int nnzA,
-                    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-                    const cusparseMatDescr_t descrB, const int nnzB,
-                    const int *csrSortedRowPtrB, const int *csrSortedColIndB,
-                    const cusparseMatDescr_t descrC, int *csrSortedRowPtrC,
-                    int *nnzTotalDevHostPtr) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int,
-      const cusparseMatDescr_t, const int, const int *, const int *,
-      const cusparseMatDescr_t, const int, const int *, const int *,
-      const cusparseMatDescr_t, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseXcsrgemmNnz(cusparseHandle_t handle,
+                                                 cusparseOperation_t transA,
+                                                 cusparseOperation_t transB,
+                                                 int m,
+                                                 int n,
+                                                 int k,
+                                                 const cusparseMatDescr_t descrA,
+                                                 const int nnzA,
+                                                 const int *csrSortedRowPtrA,
+                                                 const int *csrSortedColIndA,
+                                                 const cusparseMatDescr_t descrB,
+                                                 const int nnzB,
+                                                 const int *csrSortedRowPtrB,
+                                                 const int *csrSortedColIndB,
+                                                 const cusparseMatDescr_t descrC,
+                                                 int *csrSortedRowPtrC,
+                                                 int *nnzTotalDevHostPtr) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, const int, const int *, const int *, const cusparseMatDescr_t, const int, const int *, const int *, const cusparseMatDescr_t, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcsrgemmNnz");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, transB, m, n, k, descrA, nnzA,
-                  csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB,
-                  csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedRowPtrC,
-                  nnzTotalDevHostPtr);
+  return func_ptr(handle, transA, transB, m, n, k, descrA, nnzA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedRowPtrC, nnzTotalDevHostPtr);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrgemm(
-    cusparseHandle_t handle, cusparseOperation_t transA,
-    cusparseOperation_t transB, int m, int n, int k,
-    const cusparseMatDescr_t descrA, const int nnzA, const float *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    const cusparseMatDescr_t descrB, const int nnzB, const float *csrSortedValB,
-    const int *csrSortedRowPtrB, const int *csrSortedColIndB,
-    const cusparseMatDescr_t descrC, float *csrSortedValC,
-    const int *csrSortedRowPtrC, int *csrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int,
-      const cusparseMatDescr_t, const int, const float *, const int *,
-      const int *, const cusparseMatDescr_t, const int, const float *,
-      const int *, const int *, const cusparseMatDescr_t, float *, const int *,
-      int *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrgemm(cusparseHandle_t handle,
+                                              cusparseOperation_t transA,
+                                              cusparseOperation_t transB,
+                                              int m,
+                                              int n,
+                                              int k,
+                                              const cusparseMatDescr_t descrA,
+                                              const int nnzA,
+                                              const float *csrSortedValA,
+                                              const int *csrSortedRowPtrA,
+                                              const int *csrSortedColIndA,
+                                              const cusparseMatDescr_t descrB,
+                                              const int nnzB,
+                                              const float *csrSortedValB,
+                                              const int *csrSortedRowPtrB,
+                                              const int *csrSortedColIndB,
+                                              const cusparseMatDescr_t descrC,
+                                              float *csrSortedValC,
+                                              const int *csrSortedRowPtrC,
+                                              int *csrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, const int, const float *, const int *, const int *, const cusparseMatDescr_t, const int, const float *, const int *, const int *, const cusparseMatDescr_t, float *, const int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrgemm");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, transB, m, n, k, descrA, nnzA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB,
-                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
-                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, transA, transB, m, n, k, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrgemm(
-    cusparseHandle_t handle, cusparseOperation_t transA,
-    cusparseOperation_t transB, int m, int n, int k,
-    const cusparseMatDescr_t descrA, int nnzA, const double *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    const cusparseMatDescr_t descrB, int nnzB, const double *csrSortedValB,
-    const int *csrSortedRowPtrB, const int *csrSortedColIndB,
-    const cusparseMatDescr_t descrC, double *csrSortedValC,
-    const int *csrSortedRowPtrC, int *csrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int,
-      const cusparseMatDescr_t, int, const double *, const int *, const int *,
-      const cusparseMatDescr_t, int, const double *, const int *, const int *,
-      const cusparseMatDescr_t, double *, const int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrgemm(cusparseHandle_t handle,
+                                              cusparseOperation_t transA,
+                                              cusparseOperation_t transB,
+                                              int m,
+                                              int n,
+                                              int k,
+                                              const cusparseMatDescr_t descrA,
+                                              int nnzA,
+                                              const double *csrSortedValA,
+                                              const int *csrSortedRowPtrA,
+                                              const int *csrSortedColIndA,
+                                              const cusparseMatDescr_t descrB,
+                                              int nnzB,
+                                              const double *csrSortedValB,
+                                              const int *csrSortedRowPtrB,
+                                              const int *csrSortedColIndB,
+                                              const cusparseMatDescr_t descrC,
+                                              double *csrSortedValC,
+                                              const int *csrSortedRowPtrC,
+                                              int *csrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, int, const double *, const int *, const int *, const cusparseMatDescr_t, int, const double *, const int *, const int *, const cusparseMatDescr_t, double *, const int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrgemm");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, transB, m, n, k, descrA, nnzA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB,
-                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
-                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, transA, transB, m, n, k, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrgemm(
-    cusparseHandle_t handle, cusparseOperation_t transA,
-    cusparseOperation_t transB, int m, int n, int k,
-    const cusparseMatDescr_t descrA, int nnzA, const cuComplex *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    const cusparseMatDescr_t descrB, int nnzB, const cuComplex *csrSortedValB,
-    const int *csrSortedRowPtrB, const int *csrSortedColIndB,
-    const cusparseMatDescr_t descrC, cuComplex *csrSortedValC,
-    const int *csrSortedRowPtrC, int *csrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int,
-      const cusparseMatDescr_t, int, const cuComplex *, const int *,
-      const int *, const cusparseMatDescr_t, int, const cuComplex *,
-      const int *, const int *, const cusparseMatDescr_t, cuComplex *,
-      const int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrgemm(cusparseHandle_t handle,
+                                              cusparseOperation_t transA,
+                                              cusparseOperation_t transB,
+                                              int m,
+                                              int n,
+                                              int k,
+                                              const cusparseMatDescr_t descrA,
+                                              int nnzA,
+                                              const cuComplex *csrSortedValA,
+                                              const int *csrSortedRowPtrA,
+                                              const int *csrSortedColIndA,
+                                              const cusparseMatDescr_t descrB,
+                                              int nnzB,
+                                              const cuComplex *csrSortedValB,
+                                              const int *csrSortedRowPtrB,
+                                              const int *csrSortedColIndB,
+                                              const cusparseMatDescr_t descrC,
+                                              cuComplex *csrSortedValC,
+                                              const int *csrSortedRowPtrC,
+                                              int *csrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, int, const cuComplex *, const int *, const int *, const cusparseMatDescr_t, int, const cuComplex *, const int *, const int *, const cusparseMatDescr_t, cuComplex *, const int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrgemm");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, transB, m, n, k, descrA, nnzA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB,
-                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
-                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, transA, transB, m, n, k, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrgemm(
-    cusparseHandle_t handle, cusparseOperation_t transA,
-    cusparseOperation_t transB, int m, int n, int k,
-    const cusparseMatDescr_t descrA, int nnzA,
-    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, const cusparseMatDescr_t descrB, int nnzB,
-    const cuDoubleComplex *csrSortedValB, const int *csrSortedRowPtrB,
-    const int *csrSortedColIndB, const cusparseMatDescr_t descrC,
-    cuDoubleComplex *csrSortedValC, const int *csrSortedRowPtrC,
-    int *csrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int,
-      const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *,
-      const int *, const cusparseMatDescr_t, int, const cuDoubleComplex *,
-      const int *, const int *, const cusparseMatDescr_t, cuDoubleComplex *,
-      const int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrgemm(cusparseHandle_t handle,
+                                              cusparseOperation_t transA,
+                                              cusparseOperation_t transB,
+                                              int m,
+                                              int n,
+                                              int k,
+                                              const cusparseMatDescr_t descrA,
+                                              int nnzA,
+                                              const cuDoubleComplex *csrSortedValA,
+                                              const int *csrSortedRowPtrA,
+                                              const int *csrSortedColIndA,
+                                              const cusparseMatDescr_t descrB,
+                                              int nnzB,
+                                              const cuDoubleComplex *csrSortedValB,
+                                              const int *csrSortedRowPtrB,
+                                              const int *csrSortedColIndB,
+                                              const cusparseMatDescr_t descrC,
+                                              cuDoubleComplex *csrSortedValC,
+                                              const int *csrSortedRowPtrC,
+                                              int *csrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *, const int *, const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *, const int *, const cusparseMatDescr_t, cuDoubleComplex *, const int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrgemm");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, transB, m, n, k, descrA, nnzA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB,
-                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
-                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, transA, transB, m, n, k, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCreateCsrgemm2Info(csrgemm2Info_t *info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(csrgemm2Info_t *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(csrgemm2Info_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateCsrgemm2Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDestroyCsrgemm2Info(csrgemm2Info_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(csrgemm2Info_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(csrgemm2Info_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyCsrgemm2Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrgemm2_bufferSizeExt(
-    cusparseHandle_t handle, int m, int n, int k, const float *alpha,
-    const cusparseMatDescr_t descrA, int nnzA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, const cusparseMatDescr_t descrB, int nnzB,
-    const int *csrSortedRowPtrB, const int *csrSortedColIndB, const float *beta,
-    const cusparseMatDescr_t descrD, int nnzD, const int *csrSortedRowPtrD,
-    const int *csrSortedColIndD, csrgemm2Info_t info,
-    size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const float *, const cusparseMatDescr_t,
-      int, const int *, const int *, const cusparseMatDescr_t, int, const int *,
-      const int *, const float *, const cusparseMatDescr_t, int, const int *,
-      const int *, csrgemm2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrgemm2_bufferSizeExt(cusparseHandle_t handle,
+                                                             int m,
+                                                             int n,
+                                                             int k,
+                                                             const float *alpha,
+                                                             const cusparseMatDescr_t descrA,
+                                                             int nnzA,
+                                                             const int *csrSortedRowPtrA,
+                                                             const int *csrSortedColIndA,
+                                                             const cusparseMatDescr_t descrB,
+                                                             int nnzB,
+                                                             const int *csrSortedRowPtrB,
+                                                             const int *csrSortedColIndB,
+                                                             const float *beta,
+                                                             const cusparseMatDescr_t descrD,
+                                                             int nnzD,
+                                                             const int *csrSortedRowPtrD,
+                                                             const int *csrSortedColIndD,
+                                                             csrgemm2Info_t info,
+                                                             size_t *pBufferSizeInBytes ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const float *, const cusparseMatDescr_t, int, const int *, const int *, const cusparseMatDescr_t, int, const int *, const int *, const float *, const cusparseMatDescr_t, int, const int *, const int *, csrgemm2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrgemm2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedRowPtrA,
-                  csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB,
-                  csrSortedColIndB, beta, descrD, nnzD, csrSortedRowPtrD,
-                  csrSortedColIndD, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB, csrSortedColIndB, beta, descrD, nnzD, csrSortedRowPtrD, csrSortedColIndD, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrgemm2_bufferSizeExt(
-    cusparseHandle_t handle, int m, int n, int k, const double *alpha,
-    const cusparseMatDescr_t descrA, int nnzA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, const cusparseMatDescr_t descrB, int nnzB,
-    const int *csrSortedRowPtrB, const int *csrSortedColIndB,
-    const double *beta, const cusparseMatDescr_t descrD, int nnzD,
-    const int *csrSortedRowPtrD, const int *csrSortedColIndD,
-    csrgemm2Info_t info, size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const double *, const cusparseMatDescr_t,
-      int, const int *, const int *, const cusparseMatDescr_t, int, const int *,
-      const int *, const double *, const cusparseMatDescr_t, int, const int *,
-      const int *, csrgemm2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrgemm2_bufferSizeExt(cusparseHandle_t handle,
+                                                             int m,
+                                                             int n,
+                                                             int k,
+                                                             const double *alpha,
+                                                             const cusparseMatDescr_t descrA,
+                                                             int nnzA,
+                                                             const int *csrSortedRowPtrA,
+                                                             const int *csrSortedColIndA,
+                                                             const cusparseMatDescr_t descrB,
+                                                             int nnzB,
+                                                             const int *csrSortedRowPtrB,
+                                                             const int *csrSortedColIndB,
+                                                             const double *beta,
+                                                             const cusparseMatDescr_t descrD,
+                                                             int nnzD,
+                                                             const int *csrSortedRowPtrD,
+                                                             const int *csrSortedColIndD,
+                                                             csrgemm2Info_t info,
+                                                             size_t *pBufferSizeInBytes ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const double *, const cusparseMatDescr_t, int, const int *, const int *, const cusparseMatDescr_t, int, const int *, const int *, const double *, const cusparseMatDescr_t, int, const int *, const int *, csrgemm2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrgemm2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedRowPtrA,
-                  csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB,
-                  csrSortedColIndB, beta, descrD, nnzD, csrSortedRowPtrD,
-                  csrSortedColIndD, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB, csrSortedColIndB, beta, descrD, nnzD, csrSortedRowPtrD, csrSortedColIndD, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrgemm2_bufferSizeExt(
-    cusparseHandle_t handle, int m, int n, int k, const cuComplex *alpha,
-    const cusparseMatDescr_t descrA, int nnzA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, const cusparseMatDescr_t descrB, int nnzB,
-    const int *csrSortedRowPtrB, const int *csrSortedColIndB,
-    const cuComplex *beta, const cusparseMatDescr_t descrD, int nnzD,
-    const int *csrSortedRowPtrD, const int *csrSortedColIndD,
-    csrgemm2Info_t info, size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cuComplex *,
-      const cusparseMatDescr_t, int, const int *, const int *,
-      const cusparseMatDescr_t, int, const int *, const int *,
-      const cuComplex *, const cusparseMatDescr_t, int, const int *,
-      const int *, csrgemm2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrgemm2_bufferSizeExt(cusparseHandle_t handle,
+                                                             int m,
+                                                             int n,
+                                                             int k,
+                                                             const cuComplex *alpha,
+                                                             const cusparseMatDescr_t descrA,
+                                                             int nnzA,
+                                                             const int *csrSortedRowPtrA,
+                                                             const int *csrSortedColIndA,
+                                                             const cusparseMatDescr_t descrB,
+                                                             int nnzB,
+                                                             const int *csrSortedRowPtrB,
+                                                             const int *csrSortedColIndB,
+                                                             const cuComplex *beta,
+                                                             const cusparseMatDescr_t descrD,
+                                                             int nnzD,
+                                                             const int *csrSortedRowPtrD,
+                                                             const int *csrSortedColIndD,
+                                                             csrgemm2Info_t info,
+                                                             size_t *pBufferSizeInBytes ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cuComplex *, const cusparseMatDescr_t, int, const int *, const int *, const cusparseMatDescr_t, int, const int *, const int *, const cuComplex *, const cusparseMatDescr_t, int, const int *, const int *, csrgemm2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrgemm2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedRowPtrA,
-                  csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB,
-                  csrSortedColIndB, beta, descrD, nnzD, csrSortedRowPtrD,
-                  csrSortedColIndD, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB, csrSortedColIndB, beta, descrD, nnzD, csrSortedRowPtrD, csrSortedColIndD, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrgemm2_bufferSizeExt(
-    cusparseHandle_t handle, int m, int n, int k, const cuDoubleComplex *alpha,
-    const cusparseMatDescr_t descrA, int nnzA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, const cusparseMatDescr_t descrB, int nnzB,
-    const int *csrSortedRowPtrB, const int *csrSortedColIndB,
-    const cuDoubleComplex *beta, const cusparseMatDescr_t descrD, int nnzD,
-    const int *csrSortedRowPtrD, const int *csrSortedColIndD,
-    csrgemm2Info_t info, size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cuDoubleComplex *,
-      const cusparseMatDescr_t, int, const int *, const int *,
-      const cusparseMatDescr_t, int, const int *, const int *,
-      const cuDoubleComplex *, const cusparseMatDescr_t, int, const int *,
-      const int *, csrgemm2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrgemm2_bufferSizeExt(cusparseHandle_t handle,
+                                                             int m,
+                                                             int n,
+                                                             int k,
+                                                             const cuDoubleComplex *alpha,
+                                                             const cusparseMatDescr_t descrA,
+                                                             int nnzA,
+                                                             const int *csrSortedRowPtrA,
+                                                             const int *csrSortedColIndA,
+                                                             const cusparseMatDescr_t descrB,
+                                                             int nnzB,
+                                                             const int *csrSortedRowPtrB,
+                                                             const int *csrSortedColIndB,
+                                                             const cuDoubleComplex *beta,
+                                                             const cusparseMatDescr_t descrD,
+                                                             int nnzD,
+                                                             const int *csrSortedRowPtrD,
+                                                             const int *csrSortedColIndD,
+                                                             csrgemm2Info_t info,
+                                                             size_t *pBufferSizeInBytes ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, int, const int *, const int *, const cusparseMatDescr_t, int, const int *, const int *, const cuDoubleComplex *, const cusparseMatDescr_t, int, const int *, const int *, csrgemm2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrgemm2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedRowPtrA,
-                  csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB,
-                  csrSortedColIndB, beta, descrD, nnzD, csrSortedRowPtrD,
-                  csrSortedColIndD, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB, csrSortedColIndB, beta, descrD, nnzD, csrSortedRowPtrD, csrSortedColIndD, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseXcsrgemm2Nnz(
-    cusparseHandle_t handle, int m, int n, int k,
-    const cusparseMatDescr_t descrA, int nnzA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, const cusparseMatDescr_t descrB, int nnzB,
-    const int *csrSortedRowPtrB, const int *csrSortedColIndB,
-    const cusparseMatDescr_t descrD, int nnzD, const int *csrSortedRowPtrD,
-    const int *csrSortedColIndD, const cusparseMatDescr_t descrC,
-    int *csrSortedRowPtrC, int *nnzTotalDevHostPtr, const csrgemm2Info_t info,
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, int,
-      const int *, const int *, const cusparseMatDescr_t, int, const int *,
-      const int *, const cusparseMatDescr_t, int, const int *, const int *,
-      const cusparseMatDescr_t, int *, int *, const csrgemm2Info_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseXcsrgemm2Nnz(cusparseHandle_t handle,
+                                                  int m,
+                                                  int n,
+                                                  int k,
+                                                  const cusparseMatDescr_t descrA,
+                                                  int nnzA,
+                                                  const int *csrSortedRowPtrA,
+                                                  const int *csrSortedColIndA,
+                                                  const cusparseMatDescr_t descrB,
+                                                  int nnzB,
+                                                  const int *csrSortedRowPtrB,
+                                                  const int *csrSortedColIndB,
+                                                  const cusparseMatDescr_t descrD,
+                                                  int nnzD,
+                                                  const int *csrSortedRowPtrD,
+                                                  const int *csrSortedColIndD,
+                                                  const cusparseMatDescr_t descrC,
+                                                  int *csrSortedRowPtrC,
+                                                  int *nnzTotalDevHostPtr,
+                                                  const csrgemm2Info_t info,
+                                                  void *pBuffer ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, int, const int *, const int *, const cusparseMatDescr_t, int, const int *, const int *, const cusparseMatDescr_t, int, const int *, const int *, const cusparseMatDescr_t, int *, int *, const csrgemm2Info_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcsrgemm2Nnz");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, k, descrA, nnzA, csrSortedRowPtrA,
-                  csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB,
-                  csrSortedColIndB, descrD, nnzD, csrSortedRowPtrD,
-                  csrSortedColIndD, descrC, csrSortedRowPtrC,
-                  nnzTotalDevHostPtr, info, pBuffer);
+  return func_ptr(handle, m, n, k, descrA, nnzA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB, csrSortedColIndB, descrD, nnzD, csrSortedRowPtrD, csrSortedColIndD, descrC, csrSortedRowPtrC, nnzTotalDevHostPtr, info, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrgemm2(
-    cusparseHandle_t handle, int m, int n, int k, const float *alpha,
-    const cusparseMatDescr_t descrA, int nnzA, const float *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    const cusparseMatDescr_t descrB, int nnzB, const float *csrSortedValB,
-    const int *csrSortedRowPtrB, const int *csrSortedColIndB, const float *beta,
-    const cusparseMatDescr_t descrD, int nnzD, const float *csrSortedValD,
-    const int *csrSortedRowPtrD, const int *csrSortedColIndD,
-    const cusparseMatDescr_t descrC, float *csrSortedValC,
-    const int *csrSortedRowPtrC, int *csrSortedColIndC,
-    const csrgemm2Info_t info, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const float *, const cusparseMatDescr_t,
-      int, const float *, const int *, const int *, const cusparseMatDescr_t,
-      int, const float *, const int *, const int *, const float *,
-      const cusparseMatDescr_t, int, const float *, const int *, const int *,
-      const cusparseMatDescr_t, float *, const int *, int *,
-      const csrgemm2Info_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrgemm2(cusparseHandle_t handle,
+                                               int m,
+                                               int n,
+                                               int k,
+                                               const float *alpha,
+                                               const cusparseMatDescr_t descrA,
+                                               int nnzA,
+                                               const float *csrSortedValA,
+                                               const int *csrSortedRowPtrA,
+                                               const int *csrSortedColIndA,
+                                               const cusparseMatDescr_t descrB,
+                                               int nnzB,
+                                               const float *csrSortedValB,
+                                               const int *csrSortedRowPtrB,
+                                               const int *csrSortedColIndB,
+                                               const float *beta,
+                                               const cusparseMatDescr_t descrD,
+                                               int nnzD,
+                                               const float *csrSortedValD,
+                                               const int *csrSortedRowPtrD,
+                                               const int *csrSortedColIndD,
+                                               const cusparseMatDescr_t descrC,
+                                               float *csrSortedValC,
+                                               const int *csrSortedRowPtrC,
+                                               int *csrSortedColIndC,
+                                               const csrgemm2Info_t info,
+                                               void *pBuffer ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const float *, const cusparseMatDescr_t, int, const float *, const int *, const int *, const cusparseMatDescr_t, int, const float *, const int *, const int *, const float *, const cusparseMatDescr_t, int, const float *, const int *, const int *, const cusparseMatDescr_t, float *, const int *, int *, const csrgemm2Info_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrgemm2");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB,
-                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, beta,
-                  descrD, nnzD, csrSortedValD, csrSortedRowPtrD,
-                  csrSortedColIndD, descrC, csrSortedValC, csrSortedRowPtrC,
-                  csrSortedColIndC, info, pBuffer);
+  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, beta, descrD, nnzD, csrSortedValD, csrSortedRowPtrD, csrSortedColIndD, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, info, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrgemm2(
-    cusparseHandle_t handle, int m, int n, int k, const double *alpha,
-    const cusparseMatDescr_t descrA, int nnzA, const double *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    const cusparseMatDescr_t descrB, int nnzB, const double *csrSortedValB,
-    const int *csrSortedRowPtrB, const int *csrSortedColIndB,
-    const double *beta, const cusparseMatDescr_t descrD, int nnzD,
-    const double *csrSortedValD, const int *csrSortedRowPtrD,
-    const int *csrSortedColIndD, const cusparseMatDescr_t descrC,
-    double *csrSortedValC, const int *csrSortedRowPtrC, int *csrSortedColIndC,
-    const csrgemm2Info_t info, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const double *, const cusparseMatDescr_t,
-      int, const double *, const int *, const int *, const cusparseMatDescr_t,
-      int, const double *, const int *, const int *, const double *,
-      const cusparseMatDescr_t, int, const double *, const int *, const int *,
-      const cusparseMatDescr_t, double *, const int *, int *,
-      const csrgemm2Info_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrgemm2(cusparseHandle_t handle,
+                                               int m,
+                                               int n,
+                                               int k,
+                                               const double *alpha,
+                                               const cusparseMatDescr_t descrA,
+                                               int nnzA,
+                                               const double *csrSortedValA,
+                                               const int *csrSortedRowPtrA,
+                                               const int *csrSortedColIndA,
+                                               const cusparseMatDescr_t descrB,
+                                               int nnzB,
+                                               const double *csrSortedValB,
+                                               const int *csrSortedRowPtrB,
+                                               const int *csrSortedColIndB,
+                                               const double *beta,
+                                               const cusparseMatDescr_t descrD,
+                                               int nnzD,
+                                               const double *csrSortedValD,
+                                               const int *csrSortedRowPtrD,
+                                               const int *csrSortedColIndD,
+                                               const cusparseMatDescr_t descrC,
+                                               double *csrSortedValC,
+                                               const int *csrSortedRowPtrC,
+                                               int *csrSortedColIndC,
+                                               const csrgemm2Info_t info,
+                                               void *pBuffer ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const double *, const cusparseMatDescr_t, int, const double *, const int *, const int *, const cusparseMatDescr_t, int, const double *, const int *, const int *, const double *, const cusparseMatDescr_t, int, const double *, const int *, const int *, const cusparseMatDescr_t, double *, const int *, int *, const csrgemm2Info_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrgemm2");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB,
-                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, beta,
-                  descrD, nnzD, csrSortedValD, csrSortedRowPtrD,
-                  csrSortedColIndD, descrC, csrSortedValC, csrSortedRowPtrC,
-                  csrSortedColIndC, info, pBuffer);
+  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, beta, descrD, nnzD, csrSortedValD, csrSortedRowPtrD, csrSortedColIndD, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, info, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrgemm2(
-    cusparseHandle_t handle, int m, int n, int k, const cuComplex *alpha,
-    const cusparseMatDescr_t descrA, int nnzA, const cuComplex *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    const cusparseMatDescr_t descrB, int nnzB, const cuComplex *csrSortedValB,
-    const int *csrSortedRowPtrB, const int *csrSortedColIndB,
-    const cuComplex *beta, const cusparseMatDescr_t descrD, int nnzD,
-    const cuComplex *csrSortedValD, const int *csrSortedRowPtrD,
-    const int *csrSortedColIndD, const cusparseMatDescr_t descrC,
-    cuComplex *csrSortedValC, const int *csrSortedRowPtrC,
-    int *csrSortedColIndC, const csrgemm2Info_t info, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cuComplex *,
-      const cusparseMatDescr_t, int, const cuComplex *, const int *,
-      const int *, const cusparseMatDescr_t, int, const cuComplex *,
-      const int *, const int *, const cuComplex *, const cusparseMatDescr_t,
-      int, const cuComplex *, const int *, const int *,
-      const cusparseMatDescr_t, cuComplex *, const int *, int *,
-      const csrgemm2Info_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrgemm2(cusparseHandle_t handle,
+                                               int m,
+                                               int n,
+                                               int k,
+                                               const cuComplex *alpha,
+                                               const cusparseMatDescr_t descrA,
+                                               int nnzA,
+                                               const cuComplex *csrSortedValA,
+                                               const int *csrSortedRowPtrA,
+                                               const int *csrSortedColIndA,
+                                               const cusparseMatDescr_t descrB,
+                                               int nnzB,
+                                               const cuComplex *csrSortedValB,
+                                               const int *csrSortedRowPtrB,
+                                               const int *csrSortedColIndB,
+                                               const cuComplex *beta,
+                                               const cusparseMatDescr_t descrD,
+                                               int nnzD,
+                                               const cuComplex *csrSortedValD,
+                                               const int *csrSortedRowPtrD,
+                                               const int *csrSortedColIndD,
+                                               const cusparseMatDescr_t descrC,
+                                               cuComplex *csrSortedValC,
+                                               const int *csrSortedRowPtrC,
+                                               int *csrSortedColIndC,
+                                               const csrgemm2Info_t info,
+                                               void *pBuffer ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cuComplex *, const cusparseMatDescr_t, int, const cuComplex *, const int *, const int *, const cusparseMatDescr_t, int, const cuComplex *, const int *, const int *, const cuComplex *, const cusparseMatDescr_t, int, const cuComplex *, const int *, const int *, const cusparseMatDescr_t, cuComplex *, const int *, int *, const csrgemm2Info_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrgemm2");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB,
-                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, beta,
-                  descrD, nnzD, csrSortedValD, csrSortedRowPtrD,
-                  csrSortedColIndD, descrC, csrSortedValC, csrSortedRowPtrC,
-                  csrSortedColIndC, info, pBuffer);
+  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, beta, descrD, nnzD, csrSortedValD, csrSortedRowPtrD, csrSortedColIndD, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, info, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrgemm2(
-    cusparseHandle_t handle, int m, int n, int k, const cuDoubleComplex *alpha,
-    const cusparseMatDescr_t descrA, int nnzA,
-    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, const cusparseMatDescr_t descrB, int nnzB,
-    const cuDoubleComplex *csrSortedValB, const int *csrSortedRowPtrB,
-    const int *csrSortedColIndB, const cuDoubleComplex *beta,
-    const cusparseMatDescr_t descrD, int nnzD,
-    const cuDoubleComplex *csrSortedValD, const int *csrSortedRowPtrD,
-    const int *csrSortedColIndD, const cusparseMatDescr_t descrC,
-    cuDoubleComplex *csrSortedValC, const int *csrSortedRowPtrC,
-    int *csrSortedColIndC, const csrgemm2Info_t info, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cuDoubleComplex *,
-      const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *,
-      const int *, const cusparseMatDescr_t, int, const cuDoubleComplex *,
-      const int *, const int *, const cuDoubleComplex *,
-      const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *,
-      const int *, const cusparseMatDescr_t, cuDoubleComplex *, const int *,
-      int *, const csrgemm2Info_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrgemm2(cusparseHandle_t handle,
+                                               int m,
+                                               int n,
+                                               int k,
+                                               const cuDoubleComplex *alpha,
+                                               const cusparseMatDescr_t descrA,
+                                               int nnzA,
+                                               const cuDoubleComplex *csrSortedValA,
+                                               const int *csrSortedRowPtrA,
+                                               const int *csrSortedColIndA,
+                                               const cusparseMatDescr_t descrB,
+                                               int nnzB,
+                                               const cuDoubleComplex *csrSortedValB,
+                                               const int *csrSortedRowPtrB,
+                                               const int *csrSortedColIndB,
+                                               const cuDoubleComplex *beta,
+                                               const cusparseMatDescr_t descrD,
+                                               int nnzD,
+                                               const cuDoubleComplex *csrSortedValD,
+                                               const int *csrSortedRowPtrD,
+                                               const int *csrSortedColIndD,
+                                               const cusparseMatDescr_t descrC,
+                                               cuDoubleComplex *csrSortedValC,
+                                               const int *csrSortedRowPtrC,
+                                               int *csrSortedColIndC,
+                                               const csrgemm2Info_t info,
+                                               void *pBuffer ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *, const int *, const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *, const int *, const cuDoubleComplex *, const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *, const int *, const cusparseMatDescr_t, cuDoubleComplex *, const int *, int *, const csrgemm2Info_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrgemm2");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB,
-                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, beta,
-                  descrD, nnzD, csrSortedValD, csrSortedRowPtrD,
-                  csrSortedColIndD, descrC, csrSortedValC, csrSortedRowPtrC,
-                  csrSortedColIndC, info, pBuffer);
+  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, beta, descrD, nnzD, csrSortedValD, csrSortedRowPtrD, csrSortedColIndD, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, info, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseXcsrgeamNnz(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    int nnzA, const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    const cusparseMatDescr_t descrB, int nnzB, const int *csrSortedRowPtrB,
-    const int *csrSortedColIndB, const cusparseMatDescr_t descrC,
-    int *csrSortedRowPtrC, int *nnzTotalDevHostPtr) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, int, const int *,
-      const int *, const cusparseMatDescr_t, int, const int *, const int *,
-      const cusparseMatDescr_t, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseXcsrgeamNnz(cusparseHandle_t handle,
+                                                 int m,
+                                                 int n,
+                                                 const cusparseMatDescr_t descrA,
+                                                 int nnzA,
+                                                 const int *csrSortedRowPtrA,
+                                                 const int *csrSortedColIndA,
+                                                 const cusparseMatDescr_t descrB,
+                                                 int nnzB,
+                                                 const int *csrSortedRowPtrB,
+                                                 const int *csrSortedColIndB,
+                                                 const cusparseMatDescr_t descrC,
+                                                 int *csrSortedRowPtrC,
+                                                 int *nnzTotalDevHostPtr) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, int, const int *, const int *, const cusparseMatDescr_t, int, const int *, const int *, const cusparseMatDescr_t, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcsrgeamNnz");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, nnzA, csrSortedRowPtrA,
-                  csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB,
-                  csrSortedColIndB, descrC, csrSortedRowPtrC,
-                  nnzTotalDevHostPtr);
+  return func_ptr(handle, m, n, descrA, nnzA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedRowPtrC, nnzTotalDevHostPtr);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrgeam(
-    cusparseHandle_t handle, int m, int n, const float *alpha,
-    const cusparseMatDescr_t descrA, int nnzA, const float *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, const float *beta,
-    const cusparseMatDescr_t descrB, int nnzB, const float *csrSortedValB,
-    const int *csrSortedRowPtrB, const int *csrSortedColIndB,
-    const cusparseMatDescr_t descrC, float *csrSortedValC,
-    int *csrSortedRowPtrC, int *csrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const float *, const cusparseMatDescr_t, int,
-      const float *, const int *, const int *, const float *,
-      const cusparseMatDescr_t, int, const float *, const int *, const int *,
-      const cusparseMatDescr_t, float *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrgeam(cusparseHandle_t handle,
+                                              int m,
+                                              int n,
+                                              const float *alpha,
+                                              const cusparseMatDescr_t descrA,
+                                              int nnzA,
+                                              const float *csrSortedValA,
+                                              const int *csrSortedRowPtrA,
+                                              const int *csrSortedColIndA,
+                                              const float *beta,
+                                              const cusparseMatDescr_t descrB,
+                                              int nnzB,
+                                              const float *csrSortedValB,
+                                              const int *csrSortedRowPtrB,
+                                              const int *csrSortedColIndB,
+                                              const cusparseMatDescr_t descrC,
+                                              float *csrSortedValC,
+                                              int *csrSortedRowPtrC,
+                                              int *csrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, const cusparseMatDescr_t, int, const float *, const int *, const int *, const float *, const cusparseMatDescr_t, int, const float *, const int *, const int *, const cusparseMatDescr_t, float *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrgeam");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB,
-                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
-                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrgeam(
-    cusparseHandle_t handle, int m, int n, const double *alpha,
-    const cusparseMatDescr_t descrA, int nnzA, const double *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    const double *beta, const cusparseMatDescr_t descrB, int nnzB,
-    const double *csrSortedValB, const int *csrSortedRowPtrB,
-    const int *csrSortedColIndB, const cusparseMatDescr_t descrC,
-    double *csrSortedValC, int *csrSortedRowPtrC, int *csrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const double *, const cusparseMatDescr_t, int,
-      const double *, const int *, const int *, const double *,
-      const cusparseMatDescr_t, int, const double *, const int *, const int *,
-      const cusparseMatDescr_t, double *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrgeam(cusparseHandle_t handle,
+                                              int m,
+                                              int n,
+                                              const double *alpha,
+                                              const cusparseMatDescr_t descrA,
+                                              int nnzA,
+                                              const double *csrSortedValA,
+                                              const int *csrSortedRowPtrA,
+                                              const int *csrSortedColIndA,
+                                              const double *beta,
+                                              const cusparseMatDescr_t descrB,
+                                              int nnzB,
+                                              const double *csrSortedValB,
+                                              const int *csrSortedRowPtrB,
+                                              const int *csrSortedColIndB,
+                                              const cusparseMatDescr_t descrC,
+                                              double *csrSortedValC,
+                                              int *csrSortedRowPtrC,
+                                              int *csrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, const cusparseMatDescr_t, int, const double *, const int *, const int *, const double *, const cusparseMatDescr_t, int, const double *, const int *, const int *, const cusparseMatDescr_t, double *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrgeam");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB,
-                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
-                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrgeam(
-    cusparseHandle_t handle, int m, int n, const cuComplex *alpha,
-    const cusparseMatDescr_t descrA, int nnzA, const cuComplex *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    const cuComplex *beta, const cusparseMatDescr_t descrB, int nnzB,
-    const cuComplex *csrSortedValB, const int *csrSortedRowPtrB,
-    const int *csrSortedColIndB, const cusparseMatDescr_t descrC,
-    cuComplex *csrSortedValC, int *csrSortedRowPtrC, int *csrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cuComplex *, const cusparseMatDescr_t,
-      int, const cuComplex *, const int *, const int *, const cuComplex *,
-      const cusparseMatDescr_t, int, const cuComplex *, const int *,
-      const int *, const cusparseMatDescr_t, cuComplex *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrgeam(cusparseHandle_t handle,
+                                              int m,
+                                              int n,
+                                              const cuComplex *alpha,
+                                              const cusparseMatDescr_t descrA,
+                                              int nnzA,
+                                              const cuComplex *csrSortedValA,
+                                              const int *csrSortedRowPtrA,
+                                              const int *csrSortedColIndA,
+                                              const cuComplex *beta,
+                                              const cusparseMatDescr_t descrB,
+                                              int nnzB,
+                                              const cuComplex *csrSortedValB,
+                                              const int *csrSortedRowPtrB,
+                                              const int *csrSortedColIndB,
+                                              const cusparseMatDescr_t descrC,
+                                              cuComplex *csrSortedValC,
+                                              int *csrSortedRowPtrC,
+                                              int *csrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuComplex *, const cusparseMatDescr_t, int, const cuComplex *, const int *, const int *, const cuComplex *, const cusparseMatDescr_t, int, const cuComplex *, const int *, const int *, const cusparseMatDescr_t, cuComplex *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrgeam");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB,
-                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
-                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrgeam(
-    cusparseHandle_t handle, int m, int n, const cuDoubleComplex *alpha,
-    const cusparseMatDescr_t descrA, int nnzA,
-    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, const cuDoubleComplex *beta,
-    const cusparseMatDescr_t descrB, int nnzB,
-    const cuDoubleComplex *csrSortedValB, const int *csrSortedRowPtrB,
-    const int *csrSortedColIndB, const cusparseMatDescr_t descrC,
-    cuDoubleComplex *csrSortedValC, int *csrSortedRowPtrC,
-    int *csrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cuDoubleComplex *,
-      const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *,
-      const int *, const cuDoubleComplex *, const cusparseMatDescr_t, int,
-      const cuDoubleComplex *, const int *, const int *,
-      const cusparseMatDescr_t, cuDoubleComplex *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrgeam(cusparseHandle_t handle,
+                                              int m,
+                                              int n,
+                                              const cuDoubleComplex *alpha,
+                                              const cusparseMatDescr_t descrA,
+                                              int nnzA,
+                                              const cuDoubleComplex *csrSortedValA,
+                                              const int *csrSortedRowPtrA,
+                                              const int *csrSortedColIndA,
+                                              const cuDoubleComplex *beta,
+                                              const cusparseMatDescr_t descrB,
+                                              int nnzB,
+                                              const cuDoubleComplex *csrSortedValB,
+                                              const int *csrSortedRowPtrB,
+                                              const int *csrSortedColIndB,
+                                              const cusparseMatDescr_t descrC,
+                                              cuDoubleComplex *csrSortedValC,
+                                              int *csrSortedRowPtrC,
+                                              int *csrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *, const int *, const cuDoubleComplex *, const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *, const int *, const cusparseMatDescr_t, cuDoubleComplex *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrgeam");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB,
-                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
-                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseScsrgeam2_bufferSizeExt(
-    cusparseHandle_t handle, int m, int n, const float *alpha,
-    const cusparseMatDescr_t descrA, int nnzA, const float *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, const float *beta,
-    const cusparseMatDescr_t descrB, int nnzB, const float *csrSortedValB,
-    const int *csrSortedRowPtrB, const int *csrSortedColIndB,
-    const cusparseMatDescr_t descrC, const float *csrSortedValC,
-    const int *csrSortedRowPtrC, const int *csrSortedColIndC,
-    size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const float *, const cusparseMatDescr_t, int,
-      const float *, const int *, const int *, const float *,
-      const cusparseMatDescr_t, int, const float *, const int *, const int *,
-      const cusparseMatDescr_t, const float *, const int *, const int *,
-      size_t *);
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const float *alpha,
+    const cusparseMatDescr_t descrA,
+    int nnzA,
+    const float *csrSortedValA,
+    const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA,
+    const float *beta,
+    const cusparseMatDescr_t descrB,
+    int nnzB,
+    const float *csrSortedValB,
+    const int *csrSortedRowPtrB,
+    const int *csrSortedColIndB,
+    const cusparseMatDescr_t descrC,
+    const float *csrSortedValC,
+    const int *csrSortedRowPtrC,
+    const int *csrSortedColIndC,
+    size_t *pBufferSizeInBytes ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, const cusparseMatDescr_t, int, const float *, const int *, const int *, const float *, const cusparseMatDescr_t, int, const float *, const int *, const int *, const cusparseMatDescr_t, const float *, const int *, const int *, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrgeam2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB,
-                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
-                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC,
-                  pBufferSizeInBytes);
+  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDcsrgeam2_bufferSizeExt(
-    cusparseHandle_t handle, int m, int n, const double *alpha,
-    const cusparseMatDescr_t descrA, int nnzA, const double *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    const double *beta, const cusparseMatDescr_t descrB, int nnzB,
-    const double *csrSortedValB, const int *csrSortedRowPtrB,
-    const int *csrSortedColIndB, const cusparseMatDescr_t descrC,
-    const double *csrSortedValC, const int *csrSortedRowPtrC,
-    const int *csrSortedColIndC, size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const double *, const cusparseMatDescr_t, int,
-      const double *, const int *, const int *, const double *,
-      const cusparseMatDescr_t, int, const double *, const int *, const int *,
-      const cusparseMatDescr_t, const double *, const int *, const int *,
-      size_t *);
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const double *alpha,
+    const cusparseMatDescr_t descrA,
+    int nnzA,
+    const double *csrSortedValA,
+    const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA,
+    const double *beta,
+    const cusparseMatDescr_t descrB,
+    int nnzB,
+    const double *csrSortedValB,
+    const int *csrSortedRowPtrB,
+    const int *csrSortedColIndB,
+    const cusparseMatDescr_t descrC,
+    const double *csrSortedValC,
+    const int *csrSortedRowPtrC,
+    const int *csrSortedColIndC,
+    size_t *pBufferSizeInBytes ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, const cusparseMatDescr_t, int, const double *, const int *, const int *, const double *, const cusparseMatDescr_t, int, const double *, const int *, const int *, const cusparseMatDescr_t, const double *, const int *, const int *, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrgeam2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB,
-                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
-                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC,
-                  pBufferSizeInBytes);
+  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCcsrgeam2_bufferSizeExt(
-    cusparseHandle_t handle, int m, int n, const cuComplex *alpha,
-    const cusparseMatDescr_t descrA, int nnzA, const cuComplex *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    const cuComplex *beta, const cusparseMatDescr_t descrB, int nnzB,
-    const cuComplex *csrSortedValB, const int *csrSortedRowPtrB,
-    const int *csrSortedColIndB, const cusparseMatDescr_t descrC,
-    const cuComplex *csrSortedValC, const int *csrSortedRowPtrC,
-    const int *csrSortedColIndC, size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cuComplex *, const cusparseMatDescr_t,
-      int, const cuComplex *, const int *, const int *, const cuComplex *,
-      const cusparseMatDescr_t, int, const cuComplex *, const int *,
-      const int *, const cusparseMatDescr_t, const cuComplex *, const int *,
-      const int *, size_t *);
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const cuComplex *alpha,
+    const cusparseMatDescr_t descrA,
+    int nnzA,
+    const cuComplex *csrSortedValA,
+    const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA,
+    const cuComplex *beta,
+    const cusparseMatDescr_t descrB,
+    int nnzB,
+    const cuComplex *csrSortedValB,
+    const int *csrSortedRowPtrB,
+    const int *csrSortedColIndB,
+    const cusparseMatDescr_t descrC,
+    const cuComplex *csrSortedValC,
+    const int *csrSortedRowPtrC,
+    const int *csrSortedColIndC,
+    size_t *pBufferSizeInBytes ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuComplex *, const cusparseMatDescr_t, int, const cuComplex *, const int *, const int *, const cuComplex *, const cusparseMatDescr_t, int, const cuComplex *, const int *, const int *, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrgeam2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB,
-                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
-                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC,
-                  pBufferSizeInBytes);
+  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseZcsrgeam2_bufferSizeExt(
-    cusparseHandle_t handle, int m, int n, const cuDoubleComplex *alpha,
-    const cusparseMatDescr_t descrA, int nnzA,
-    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, const cuDoubleComplex *beta,
-    const cusparseMatDescr_t descrB, int nnzB,
-    const cuDoubleComplex *csrSortedValB, const int *csrSortedRowPtrB,
-    const int *csrSortedColIndB, const cusparseMatDescr_t descrC,
-    const cuDoubleComplex *csrSortedValC, const int *csrSortedRowPtrC,
-    const int *csrSortedColIndC, size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cuDoubleComplex *,
-      const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *,
-      const int *, const cuDoubleComplex *, const cusparseMatDescr_t, int,
-      const cuDoubleComplex *, const int *, const int *,
-      const cusparseMatDescr_t, const cuDoubleComplex *, const int *,
-      const int *, size_t *);
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const cuDoubleComplex *alpha,
+    const cusparseMatDescr_t descrA,
+    int nnzA,
+    const cuDoubleComplex *csrSortedValA,
+    const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA,
+    const cuDoubleComplex *beta,
+    const cusparseMatDescr_t descrB,
+    int nnzB,
+    const cuDoubleComplex *csrSortedValB,
+    const int *csrSortedRowPtrB,
+    const int *csrSortedColIndB,
+    const cusparseMatDescr_t descrC,
+    const cuDoubleComplex *csrSortedValC,
+    const int *csrSortedRowPtrC,
+    const int *csrSortedColIndC,
+    size_t *pBufferSizeInBytes ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *, const int *, const cuDoubleComplex *, const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *, const int *, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrgeam2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB,
-                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
-                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC,
-                  pBufferSizeInBytes);
+  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseXcsrgeam2Nnz(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    int nnzA, const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    const cusparseMatDescr_t descrB, int nnzB, const int *csrSortedRowPtrB,
-    const int *csrSortedColIndB, const cusparseMatDescr_t descrC,
-    int *csrSortedRowPtrC, int *nnzTotalDevHostPtr, void *workspace) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, int, const int *,
-      const int *, const cusparseMatDescr_t, int, const int *, const int *,
-      const cusparseMatDescr_t, int *, int *, void *);
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const cusparseMatDescr_t descrA,
+    int nnzA,
+    const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA,
+    const cusparseMatDescr_t descrB,
+    int nnzB,
+    const int *csrSortedRowPtrB,
+    const int *csrSortedColIndB,
+    const cusparseMatDescr_t descrC,
+    int *csrSortedRowPtrC,
+    int *nnzTotalDevHostPtr,
+    void *workspace ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, int, const int *, const int *, const cusparseMatDescr_t, int, const int *, const int *, const cusparseMatDescr_t, int *, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcsrgeam2Nnz");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, nnzA, csrSortedRowPtrA,
-                  csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB,
-                  csrSortedColIndB, descrC, csrSortedRowPtrC,
-                  nnzTotalDevHostPtr, workspace);
+  return func_ptr(handle, m, n, descrA, nnzA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedRowPtrC, nnzTotalDevHostPtr, workspace);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseScsrgeam2(
-    cusparseHandle_t handle, int m, int n, const float *alpha,
-    const cusparseMatDescr_t descrA, int nnzA, const float *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, const float *beta,
-    const cusparseMatDescr_t descrB, int nnzB, const float *csrSortedValB,
-    const int *csrSortedRowPtrB, const int *csrSortedColIndB,
-    const cusparseMatDescr_t descrC, float *csrSortedValC,
-    int *csrSortedRowPtrC, int *csrSortedColIndC, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const float *, const cusparseMatDescr_t, int,
-      const float *, const int *, const int *, const float *,
-      const cusparseMatDescr_t, int, const float *, const int *, const int *,
-      const cusparseMatDescr_t, float *, int *, int *, void *);
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const float *alpha,
+    const cusparseMatDescr_t descrA,
+    int nnzA,
+    const float *csrSortedValA,
+    const int   *csrSortedRowPtrA,
+    const int   *csrSortedColIndA,
+    const float *beta,
+    const cusparseMatDescr_t descrB,
+    int nnzB,
+    const float *csrSortedValB,
+    const int   *csrSortedRowPtrB,
+    const int   *csrSortedColIndB,
+    const cusparseMatDescr_t descrC,
+    float       *csrSortedValC,
+    int         *csrSortedRowPtrC,
+    int         *csrSortedColIndC,
+    void *pBuffer ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, const cusparseMatDescr_t, int, const float *, const int   *, const int   *, const float *, const cusparseMatDescr_t, int, const float *, const int   *, const int   *, const cusparseMatDescr_t, float       *, int         *, int         *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrgeam2");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB,
-                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
-                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBuffer);
+  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrgeam2(
-    cusparseHandle_t handle, int m, int n, const double *alpha,
-    const cusparseMatDescr_t descrA, int nnzA, const double *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    const double *beta, const cusparseMatDescr_t descrB, int nnzB,
-    const double *csrSortedValB, const int *csrSortedRowPtrB,
-    const int *csrSortedColIndB, const cusparseMatDescr_t descrC,
-    double *csrSortedValC, int *csrSortedRowPtrC, int *csrSortedColIndC,
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const double *, const cusparseMatDescr_t, int,
-      const double *, const int *, const int *, const double *,
-      const cusparseMatDescr_t, int, const double *, const int *, const int *,
-      const cusparseMatDescr_t, double *, int *, int *, void *);
+cusparseStatus_t  CUSPARSEAPI cusparseDcsrgeam2(
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const double *alpha,
+    const cusparseMatDescr_t descrA,
+    int nnzA,
+    const double *csrSortedValA,
+    const int    *csrSortedRowPtrA,
+    const int    *csrSortedColIndA,
+    const double *beta,
+    const cusparseMatDescr_t descrB,
+    int nnzB,
+    const double *csrSortedValB,
+    const int    *csrSortedRowPtrB,
+    const int    *csrSortedColIndB,
+    const cusparseMatDescr_t descrC,
+    double *csrSortedValC,
+    int    *csrSortedRowPtrC,
+    int    *csrSortedColIndC,
+    void *pBuffer ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, const cusparseMatDescr_t, int, const double *, const int    *, const int    *, const double *, const cusparseMatDescr_t, int, const double *, const int    *, const int    *, const cusparseMatDescr_t, double *, int    *, int    *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrgeam2");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB,
-                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
-                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBuffer);
+  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCcsrgeam2(
-    cusparseHandle_t handle, int m, int n, const cuComplex *alpha,
-    const cusparseMatDescr_t descrA, int nnzA, const cuComplex *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    const cuComplex *beta, const cusparseMatDescr_t descrB, int nnzB,
-    const cuComplex *csrSortedValB, const int *csrSortedRowPtrB,
-    const int *csrSortedColIndB, const cusparseMatDescr_t descrC,
-    cuComplex *csrSortedValC, int *csrSortedRowPtrC, int *csrSortedColIndC,
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cuComplex *, const cusparseMatDescr_t,
-      int, const cuComplex *, const int *, const int *, const cuComplex *,
-      const cusparseMatDescr_t, int, const cuComplex *, const int *,
-      const int *, const cusparseMatDescr_t, cuComplex *, int *, int *, void *);
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const cuComplex *alpha,
+    const cusparseMatDescr_t descrA,
+    int nnzA,
+    const cuComplex *csrSortedValA,
+    const int       *csrSortedRowPtrA,
+    const int       *csrSortedColIndA,
+    const cuComplex *beta,
+    const cusparseMatDescr_t descrB,
+    int nnzB,
+    const cuComplex *csrSortedValB,
+    const int       *csrSortedRowPtrB,
+    const int       *csrSortedColIndB,
+    const cusparseMatDescr_t descrC,
+    cuComplex *csrSortedValC,
+    int       *csrSortedRowPtrC,
+    int       *csrSortedColIndC,
+    void *pBuffer ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuComplex *, const cusparseMatDescr_t, int, const cuComplex *, const int       *, const int       *, const cuComplex *, const cusparseMatDescr_t, int, const cuComplex *, const int       *, const int       *, const cusparseMatDescr_t, cuComplex *, int       *, int       *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrgeam2");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB,
-                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
-                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBuffer);
+  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrgeam2(
-    cusparseHandle_t handle, int m, int n, const cuDoubleComplex *alpha,
-    const cusparseMatDescr_t descrA, int nnzA,
-    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, const cuDoubleComplex *beta,
-    const cusparseMatDescr_t descrB, int nnzB,
-    const cuDoubleComplex *csrSortedValB, const int *csrSortedRowPtrB,
-    const int *csrSortedColIndB, const cusparseMatDescr_t descrC,
-    cuDoubleComplex *csrSortedValC, int *csrSortedRowPtrC,
-    int *csrSortedColIndC, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cuDoubleComplex *,
-      const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *,
-      const int *, const cuDoubleComplex *, const cusparseMatDescr_t, int,
-      const cuDoubleComplex *, const int *, const int *,
-      const cusparseMatDescr_t, cuDoubleComplex *, int *, int *, void *);
+cusparseStatus_t  CUSPARSEAPI cusparseZcsrgeam2(
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const cuDoubleComplex *alpha,
+    const cusparseMatDescr_t descrA,
+    int nnzA,
+    const cuDoubleComplex *csrSortedValA,
+    const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA,
+    const cuDoubleComplex *beta,
+    const cusparseMatDescr_t descrB,
+    int nnzB,
+    const cuDoubleComplex *csrSortedValB,
+    const int *csrSortedRowPtrB,
+    const int *csrSortedColIndB,
+    const cusparseMatDescr_t descrC,
+    cuDoubleComplex *csrSortedValC,
+    int *csrSortedRowPtrC,
+    int *csrSortedColIndC,
+    void *pBuffer ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *, const int *, const cuDoubleComplex *, const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *, const int *, const cusparseMatDescr_t, cuDoubleComplex *, int *, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrgeam2");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB,
-                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
-                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBuffer);
+  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrcolor(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    const float *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, const float *fractionToColor, int *ncolors,
-    int *coloring, int *reordering, const cusparseColorInfo_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *,
-      const int *, const int *, const float *, int *, int *, int *,
-      const cusparseColorInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseScsrcolor(cusparseHandle_t handle,
+                                               int m,
+                                               int nnz,
+                                               const cusparseMatDescr_t descrA,
+                                               const float *csrSortedValA,
+                                               const int *csrSortedRowPtrA,
+                                               const int *csrSortedColIndA,
+                                               const float *fractionToColor,
+                                               int *ncolors,
+                                               int *coloring,
+                                               int *reordering,
+                                               const cusparseColorInfo_t info) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, const float *, int *, int *, int *, const cusparseColorInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrcolor");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, fractionToColor, ncolors, coloring,
-                  reordering, info);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, fractionToColor, ncolors, coloring, reordering, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrcolor(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    const double *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, const double *fractionToColor, int *ncolors,
-    int *coloring, int *reordering, const cusparseColorInfo_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *,
-      const int *, const int *, const double *, int *, int *, int *,
-      const cusparseColorInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrcolor(cusparseHandle_t handle,
+                                               int m,
+                                               int nnz,
+                                               const cusparseMatDescr_t descrA,
+                                               const double *csrSortedValA,
+                                               const int *csrSortedRowPtrA,
+                                               const int *csrSortedColIndA,
+                                               const double *fractionToColor,
+                                               int *ncolors,
+                                               int *coloring,
+                                               int *reordering,
+                                               const cusparseColorInfo_t info) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, const double *, int *, int *, int *, const cusparseColorInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrcolor");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, fractionToColor, ncolors, coloring,
-                  reordering, info);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, fractionToColor, ncolors, coloring, reordering, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrcolor(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    const cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, const float *fractionToColor, int *ncolors,
-    int *coloring, int *reordering, const cusparseColorInfo_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *,
-      const int *, const int *, const float *, int *, int *, int *,
-      const cusparseColorInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrcolor(cusparseHandle_t handle,
+                                               int m,
+                                               int nnz,
+                                               const cusparseMatDescr_t descrA,
+                                               const cuComplex *csrSortedValA,
+                                               const int *csrSortedRowPtrA,
+                                               const int *csrSortedColIndA,
+                                               const float *fractionToColor,
+                                               int *ncolors,
+                                               int *coloring,
+                                               int *reordering,
+                                               const cusparseColorInfo_t info) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, const float *, int *, int *, int *, const cusparseColorInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrcolor");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, fractionToColor, ncolors, coloring,
-                  reordering, info);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, fractionToColor, ncolors, coloring, reordering, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrcolor(
-    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
-    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, const double *fractionToColor, int *ncolors,
-    int *coloring, int *reordering, const cusparseColorInfo_t info) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t,
-      const cuDoubleComplex *, const int *, const int *, const double *, int *,
-      int *, int *, const cusparseColorInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrcolor(cusparseHandle_t handle,
+                                               int m,
+                                               int nnz,
+                                               const cusparseMatDescr_t descrA,
+                                               const cuDoubleComplex *csrSortedValA,
+                                               const int *csrSortedRowPtrA,
+                                               const int *csrSortedColIndA,
+                                               const double *fractionToColor,
+                                               int *ncolors,
+                                               int *coloring,
+                                               int *reordering,
+                                               const cusparseColorInfo_t info) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, const double *, int *, int *, int *, const cusparseColorInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrcolor");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, fractionToColor, ncolors, coloring,
-                  reordering, info);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, fractionToColor, ncolors, coloring, reordering, info);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseSnnz(cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
-             const cusparseMatDescr_t descrA, const float *A, int lda,
-             int *nnzPerRowCol, int *nnzTotalDevHostPtr) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const float *, int, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseSnnz(cusparseHandle_t handle,
+                                          cusparseDirection_t dirA,
+                                          int m,
+                                          int n,
+                                          const cusparseMatDescr_t  descrA,
+                                          const float *A,
+                                          int lda,
+                                          int *nnzPerRowCol,
+                                          int *nnzTotalDevHostPtr) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const float *, int, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSnnz");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, A, lda, nnzPerRowCol,
-                  nnzTotalDevHostPtr);
+  return func_ptr(handle, dirA, m, n, descrA, A, lda, nnzPerRowCol, nnzTotalDevHostPtr);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseDnnz(cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
-             const cusparseMatDescr_t descrA, const double *A, int lda,
-             int *nnzPerRowCol, int *nnzTotalDevHostPtr) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const double *, int, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDnnz(cusparseHandle_t handle,
+                                          cusparseDirection_t dirA,
+                                          int m,
+                                          int n,
+                                          const cusparseMatDescr_t  descrA,
+                                          const double *A,
+                                          int lda,
+                                          int *nnzPerRowCol,
+                                          int *nnzTotalDevHostPtr) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const double *, int, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDnnz");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, A, lda, nnzPerRowCol,
-                  nnzTotalDevHostPtr);
+  return func_ptr(handle, dirA, m, n, descrA, A, lda, nnzPerRowCol, nnzTotalDevHostPtr);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseCnnz(cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
-             const cusparseMatDescr_t descrA, const cuComplex *A, int lda,
-             int *nnzPerRowCol, int *nnzTotalDevHostPtr) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const cuComplex *, int, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCnnz(cusparseHandle_t handle,
+                                          cusparseDirection_t dirA,
+                                          int m,
+                                          int n,
+                                          const cusparseMatDescr_t  descrA,
+                                          const cuComplex *A,
+                                          int lda,
+                                          int *nnzPerRowCol,
+                                          int *nnzTotalDevHostPtr) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuComplex *, int, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCnnz");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, A, lda, nnzPerRowCol,
-                  nnzTotalDevHostPtr);
+  return func_ptr(handle, dirA, m, n, descrA, A, lda, nnzPerRowCol, nnzTotalDevHostPtr);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseZnnz(cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
-             const cusparseMatDescr_t descrA, const cuDoubleComplex *A, int lda,
-             int *nnzPerRowCol, int *nnzTotalDevHostPtr) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const cuDoubleComplex *, int, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZnnz(cusparseHandle_t handle,
+                                          cusparseDirection_t dirA,
+                                          int m,
+                                          int n,
+                                          const cusparseMatDescr_t  descrA,
+                                          const cuDoubleComplex *A,
+                                          int lda,
+                                          int *nnzPerRowCol,
+                                          int *nnzTotalDevHostPtr) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, int, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZnnz");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, A, lda, nnzPerRowCol,
-                  nnzTotalDevHostPtr);
+  return func_ptr(handle, dirA, m, n, descrA, A, lda, nnzPerRowCol, nnzTotalDevHostPtr);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSnnz_compress(
-    cusparseHandle_t handle, int m, const cusparseMatDescr_t descr,
-    const float *csrSortedValA, const int *csrSortedRowPtrA, int *nnzPerRow,
-    int *nnzC, float tol) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const cusparseMatDescr_t, const float *,
-      const int *, int *, int *, float);
+cusparseStatus_t CUSPARSEAPI cusparseSnnz_compress(cusparseHandle_t handle,
+                                          int m,
+                                          const cusparseMatDescr_t descr,
+                                          const float *csrSortedValA,
+                                          const int *csrSortedRowPtrA,
+                                          int *nnzPerRow,
+                                          int *nnzC,
+                                          float tol) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cusparseMatDescr_t, const float *, const int *, int *, int *, float);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSnnz_compress");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, descr, csrSortedValA, csrSortedRowPtrA, nnzPerRow,
-                  nnzC, tol);
+  return func_ptr(handle, m, descr, csrSortedValA, csrSortedRowPtrA, nnzPerRow, nnzC, tol);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDnnz_compress(
-    cusparseHandle_t handle, int m, const cusparseMatDescr_t descr,
-    const double *csrSortedValA, const int *csrSortedRowPtrA, int *nnzPerRow,
-    int *nnzC, double tol) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const cusparseMatDescr_t, const double *,
-      const int *, int *, int *, double);
+cusparseStatus_t CUSPARSEAPI cusparseDnnz_compress(cusparseHandle_t handle,
+                                          int m,
+                                          const cusparseMatDescr_t descr,
+                                          const double *csrSortedValA,
+                                          const int *csrSortedRowPtrA,
+                                          int *nnzPerRow,
+                                          int *nnzC,
+                                          double tol) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cusparseMatDescr_t, const double *, const int *, int *, int *, double);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDnnz_compress");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, descr, csrSortedValA, csrSortedRowPtrA, nnzPerRow,
-                  nnzC, tol);
+  return func_ptr(handle, m, descr, csrSortedValA, csrSortedRowPtrA, nnzPerRow, nnzC, tol);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCnnz_compress(
-    cusparseHandle_t handle, int m, const cusparseMatDescr_t descr,
-    const cuComplex *csrSortedValA, const int *csrSortedRowPtrA, int *nnzPerRow,
-    int *nnzC, cuComplex tol) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const cusparseMatDescr_t, const cuComplex *,
-      const int *, int *, int *, cuComplex);
+cusparseStatus_t CUSPARSEAPI cusparseCnnz_compress(cusparseHandle_t handle,
+                                          int m,
+                                          const cusparseMatDescr_t descr,
+                                          const cuComplex *csrSortedValA,
+                                          const int *csrSortedRowPtrA,
+                                          int *nnzPerRow,
+                                          int *nnzC,
+                                          cuComplex tol) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cusparseMatDescr_t, const cuComplex *, const int *, int *, int *, cuComplex);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCnnz_compress");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, descr, csrSortedValA, csrSortedRowPtrA, nnzPerRow,
-                  nnzC, tol);
+  return func_ptr(handle, m, descr, csrSortedValA, csrSortedRowPtrA, nnzPerRow, nnzC, tol);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZnnz_compress(
-    cusparseHandle_t handle, int m, const cusparseMatDescr_t descr,
-    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    int *nnzPerRow, int *nnzC, cuDoubleComplex tol) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, const cusparseMatDescr_t, const cuDoubleComplex *,
-      const int *, int *, int *, cuDoubleComplex);
+cusparseStatus_t CUSPARSEAPI cusparseZnnz_compress(cusparseHandle_t handle,
+                                          int m,
+                                          const cusparseMatDescr_t descr,
+                                          const cuDoubleComplex *csrSortedValA,
+                                          const int *csrSortedRowPtrA,
+                                          int *nnzPerRow,
+                                          int *nnzC,
+                                          cuDoubleComplex tol) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, int *, int *, cuDoubleComplex);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZnnz_compress");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, descr, csrSortedValA, csrSortedRowPtrA, nnzPerRow,
-                  nnzC, tol);
+  return func_ptr(handle, m, descr, csrSortedValA, csrSortedRowPtrA, nnzPerRow, nnzC, tol);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsr2csr_compress(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    const float *csrSortedValA, const int *csrSortedColIndA,
-    const int *csrSortedRowPtrA, int nnzA, const int *nnzPerRow,
-    float *csrSortedValC, int *csrSortedColIndC, int *csrSortedRowPtrC,
-    float tol) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *,
-      const int *, const int *, int, const int *, float *, int *, int *, float);
+cusparseStatus_t CUSPARSEAPI cusparseScsr2csr_compress(cusparseHandle_t handle,
+                                                      int m,
+                                                      int n,
+                                                      const cusparseMatDescr_t descrA,
+                                                      const float *csrSortedValA,
+                                                      const int *csrSortedColIndA,
+                                                      const int *csrSortedRowPtrA,
+                                                      int nnzA,
+                                                      const int *nnzPerRow,
+                                                      float *csrSortedValC,
+                                                      int *csrSortedColIndC,
+                                                      int *csrSortedRowPtrC,
+                                                      float tol) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, int, const int *, float *, int *, int *, float);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsr2csr_compress");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedColIndA,
-                  csrSortedRowPtrA, nnzA, nnzPerRow, csrSortedValC,
-                  csrSortedColIndC, csrSortedRowPtrC, tol);
+  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedColIndA, csrSortedRowPtrA, nnzA, nnzPerRow, csrSortedValC, csrSortedColIndC, csrSortedRowPtrC, tol);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsr2csr_compress(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    const double *csrSortedValA, const int *csrSortedColIndA,
-    const int *csrSortedRowPtrA, int nnzA, const int *nnzPerRow,
-    double *csrSortedValC, int *csrSortedColIndC, int *csrSortedRowPtrC,
-    double tol) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *,
-      const int *, const int *, int, const int *, double *, int *, int *,
-      double);
+cusparseStatus_t CUSPARSEAPI cusparseDcsr2csr_compress(cusparseHandle_t handle,
+                                                      int m,
+                                                      int n,
+                                                      const cusparseMatDescr_t descrA,
+                                                      const double *csrSortedValA,
+                                                      const int *csrSortedColIndA,
+                                                      const int * csrSortedRowPtrA,
+                                                      int  nnzA,
+                                                      const int *nnzPerRow,
+                                                      double *csrSortedValC,
+                                                      int *csrSortedColIndC,
+                                                      int *csrSortedRowPtrC,
+                                                      double tol) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, int, const int *, double *, int *, int *, double);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsr2csr_compress");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedColIndA,
-                  csrSortedRowPtrA, nnzA, nnzPerRow, csrSortedValC,
-                  csrSortedColIndC, csrSortedRowPtrC, tol);
+  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedColIndA, csrSortedRowPtrA, nnzA, nnzPerRow, csrSortedValC, csrSortedColIndC, csrSortedRowPtrC, tol);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsr2csr_compress(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    const cuComplex *csrSortedValA, const int *csrSortedColIndA,
-    const int *csrSortedRowPtrA, int nnzA, const int *nnzPerRow,
-    cuComplex *csrSortedValC, int *csrSortedColIndC, int *csrSortedRowPtrC,
-    cuComplex tol) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *,
-      const int *, const int *, int, const int *, cuComplex *, int *, int *,
-      cuComplex);
+cusparseStatus_t CUSPARSEAPI cusparseCcsr2csr_compress(cusparseHandle_t handle,
+                                                        int m,
+                                                        int n,
+                                                        const cusparseMatDescr_t descrA,
+                                                        const cuComplex *csrSortedValA,
+                                                        const int *csrSortedColIndA,
+                                                        const int * csrSortedRowPtrA,
+                                                        int nnzA,
+                                                        const int *nnzPerRow,
+                                                        cuComplex *csrSortedValC,
+                                                        int *csrSortedColIndC,
+                                                        int *csrSortedRowPtrC,
+                                                        cuComplex tol) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, int, const int *, cuComplex *, int *, int *, cuComplex);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsr2csr_compress");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedColIndA,
-                  csrSortedRowPtrA, nnzA, nnzPerRow, csrSortedValC,
-                  csrSortedColIndC, csrSortedRowPtrC, tol);
+  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedColIndA, csrSortedRowPtrA, nnzA, nnzPerRow, csrSortedValC, csrSortedColIndC, csrSortedRowPtrC, tol);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsr2csr_compress(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    const cuDoubleComplex *csrSortedValA, const int *csrSortedColIndA,
-    const int *csrSortedRowPtrA, int nnzA, const int *nnzPerRow,
-    cuDoubleComplex *csrSortedValC, int *csrSortedColIndC,
-    int *csrSortedRowPtrC, cuDoubleComplex tol) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t,
-      const cuDoubleComplex *, const int *, const int *, int, const int *,
-      cuDoubleComplex *, int *, int *, cuDoubleComplex);
+cusparseStatus_t CUSPARSEAPI cusparseZcsr2csr_compress(cusparseHandle_t handle,
+                                                      int m,
+                                                      int n,
+                                                      const cusparseMatDescr_t descrA,
+                                                      const cuDoubleComplex *csrSortedValA,
+                                                      const int *csrSortedColIndA,
+                                                      const int * csrSortedRowPtrA,
+                                                      int  nnzA,
+                                                      const int *nnzPerRow,
+                                                      cuDoubleComplex *csrSortedValC,
+                                                      int *csrSortedColIndC,
+                                                      int *csrSortedRowPtrC,
+                                                      cuDoubleComplex tol) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, int, const int *, cuDoubleComplex *, int *, int *, cuDoubleComplex);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsr2csr_compress");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedColIndA,
-                  csrSortedRowPtrA, nnzA, nnzPerRow, csrSortedValC,
-                  csrSortedColIndC, csrSortedRowPtrC, tol);
+  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedColIndA, csrSortedRowPtrA, nnzA, nnzPerRow, csrSortedValC, csrSortedColIndC, csrSortedRowPtrC, tol);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSdense2csr(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    const float *A, int lda, const int *nnzPerRow, float *csrSortedValA,
-    int *csrSortedRowPtrA, int *csrSortedColIndA) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *, int,
-      const int *, float *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseSdense2csr(cusparseHandle_t handle,
+                                                int m,
+                                                int n,
+                                                const cusparseMatDescr_t descrA,
+                                                const float *A,
+                                                int lda,
+                                                const int *nnzPerRow,
+                                                float *csrSortedValA,
+                                                int *csrSortedRowPtrA,
+                                                int *csrSortedColIndA) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *, int, const int *, float *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSdense2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA);
+  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDdense2csr(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    const double *A, int lda, const int *nnzPerRow, double *csrSortedValA,
-    int *csrSortedRowPtrA, int *csrSortedColIndA) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *, int,
-      const int *, double *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDdense2csr(cusparseHandle_t handle,
+                                                int m,
+                                                int n,
+                                                const cusparseMatDescr_t descrA,
+                                                const double *A,
+                                                int lda,
+                                                const int *nnzPerRow,
+                                                double *csrSortedValA,
+                                                int *csrSortedRowPtrA,
+                                                int *csrSortedColIndA) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *, int, const int *, double *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDdense2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA);
+  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCdense2csr(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    const cuComplex *A, int lda, const int *nnzPerRow, cuComplex *csrSortedValA,
-    int *csrSortedRowPtrA, int *csrSortedColIndA) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *,
-      int, const int *, cuComplex *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCdense2csr(cusparseHandle_t handle,
+                                                int m,
+                                                int n,
+                                                const cusparseMatDescr_t descrA,
+                                                const cuComplex *A,
+                                                int lda,
+                                                const int *nnzPerRow,
+                                                cuComplex *csrSortedValA,
+                                                int *csrSortedRowPtrA,
+                                                int *csrSortedColIndA) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *, int, const int *, cuComplex *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCdense2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA);
+  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZdense2csr(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    const cuDoubleComplex *A, int lda, const int *nnzPerRow,
-    cuDoubleComplex *csrSortedValA, int *csrSortedRowPtrA,
-    int *csrSortedColIndA) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t,
-      const cuDoubleComplex *, int, const int *, cuDoubleComplex *, int *,
-      int *);
+cusparseStatus_t CUSPARSEAPI cusparseZdense2csr(cusparseHandle_t handle,
+                                                int m,
+                                                int n,
+                                                const cusparseMatDescr_t descrA,
+                                                const cuDoubleComplex *A,
+                                                int lda,
+                                                const int *nnzPerRow,
+                                                cuDoubleComplex *csrSortedValA,
+                                                int *csrSortedRowPtrA,
+                                                int *csrSortedColIndA) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, int, const int *, cuDoubleComplex *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZdense2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, csrSortedValA,
-                  csrSortedRowPtrA, csrSortedColIndA);
+  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsr2dense(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    const float *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, float *A, int lda) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *,
-      const int *, const int *, float *, int);
+cusparseStatus_t CUSPARSEAPI cusparseScsr2dense(cusparseHandle_t handle,
+                                                int m,
+                                                int n,
+                                                const cusparseMatDescr_t descrA,
+                                                const float *csrSortedValA,
+                                                const int *csrSortedRowPtrA,
+                                                const int *csrSortedColIndA,
+                                                float *A,
+                                                int lda) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, float *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsr2dense");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, A, lda);
+  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, A, lda);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsr2dense(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    const double *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, double *A, int lda) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *,
-      const int *, const int *, double *, int);
+cusparseStatus_t CUSPARSEAPI cusparseDcsr2dense(cusparseHandle_t handle,
+                                                int m,
+                                                int n,
+                                                const cusparseMatDescr_t descrA,
+                                                const double *csrSortedValA,
+                                                const int *csrSortedRowPtrA,
+                                                const int *csrSortedColIndA,
+                                                double *A,
+                                                int lda) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, double *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsr2dense");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, A, lda);
+  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, A, lda);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsr2dense(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    const cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, cuComplex *A, int lda) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *,
-      const int *, const int *, cuComplex *, int);
+cusparseStatus_t CUSPARSEAPI cusparseCcsr2dense(cusparseHandle_t handle,
+                                                int m,
+                                                int n,
+                                                const cusparseMatDescr_t descrA,
+                                                const cuComplex *csrSortedValA,
+                                                const int *csrSortedRowPtrA,
+                                                const int *csrSortedColIndA,
+                                                cuComplex *A,
+                                                int lda) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, cuComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsr2dense");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, A, lda);
+  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, A, lda);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsr2dense(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, cuDoubleComplex *A, int lda) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t,
-      const cuDoubleComplex *, const int *, const int *, cuDoubleComplex *,
-      int);
+cusparseStatus_t CUSPARSEAPI cusparseZcsr2dense(cusparseHandle_t handle,
+                                                int m,
+                                                int n,
+                                                const cusparseMatDescr_t descrA,
+                                                const cuDoubleComplex *csrSortedValA,
+                                                const int *csrSortedRowPtrA,
+                                                const int *csrSortedColIndA,
+                                                cuDoubleComplex *A,
+                                                int lda) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, cuDoubleComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsr2dense");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, A, lda);
+  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, A, lda);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSdense2csc(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    const float *A, int lda, const int *nnzPerCol, float *cscSortedValA,
-    int *cscSortedRowIndA, int *cscSortedColPtrA) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *, int,
-      const int *, float *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseSdense2csc(cusparseHandle_t handle,
+                                                int m,
+                                                int n,
+                                                const cusparseMatDescr_t descrA,
+                                                const float *A,
+                                                int lda,
+                                                const int *nnzPerCol,
+                                                float *cscSortedValA,
+                                                int *cscSortedRowIndA,
+                                                int *cscSortedColPtrA) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *, int, const int *, float *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSdense2csc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, A, lda, nnzPerCol, cscSortedValA,
-                  cscSortedRowIndA, cscSortedColPtrA);
+  return func_ptr(handle, m, n, descrA, A, lda, nnzPerCol, cscSortedValA, cscSortedRowIndA, cscSortedColPtrA);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDdense2csc(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    const double *A, int lda, const int *nnzPerCol, double *cscSortedValA,
-    int *cscSortedRowIndA, int *cscSortedColPtrA) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *, int,
-      const int *, double *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDdense2csc(cusparseHandle_t handle,
+                                                int m,
+                                                int n,
+                                                const cusparseMatDescr_t descrA,
+                                                const double *A,
+                                                int lda,
+                                                const int *nnzPerCol,
+                                                double *cscSortedValA,
+                                                int *cscSortedRowIndA,
+                                                int *cscSortedColPtrA) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *, int, const int *, double *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDdense2csc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, A, lda, nnzPerCol, cscSortedValA,
-                  cscSortedRowIndA, cscSortedColPtrA);
+  return func_ptr(handle, m, n, descrA, A, lda, nnzPerCol, cscSortedValA, cscSortedRowIndA, cscSortedColPtrA);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCdense2csc(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    const cuComplex *A, int lda, const int *nnzPerCol, cuComplex *cscSortedValA,
-    int *cscSortedRowIndA, int *cscSortedColPtrA) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *,
-      int, const int *, cuComplex *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCdense2csc(cusparseHandle_t handle,
+                                                int m,
+                                                int n,
+                                                const cusparseMatDescr_t descrA,
+                                                const cuComplex *A,
+                                                int lda,
+                                                const int *nnzPerCol,
+                                                cuComplex *cscSortedValA,
+                                                int *cscSortedRowIndA,
+                                                int *cscSortedColPtrA) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *, int, const int *, cuComplex *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCdense2csc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, A, lda, nnzPerCol, cscSortedValA,
-                  cscSortedRowIndA, cscSortedColPtrA);
+  return func_ptr(handle, m, n, descrA, A, lda, nnzPerCol, cscSortedValA, cscSortedRowIndA, cscSortedColPtrA);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZdense2csc(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    const cuDoubleComplex *A, int lda, const int *nnzPerCol,
-    cuDoubleComplex *cscSortedValA, int *cscSortedRowIndA,
-    int *cscSortedColPtrA) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t,
-      const cuDoubleComplex *, int, const int *, cuDoubleComplex *, int *,
-      int *);
+cusparseStatus_t CUSPARSEAPI cusparseZdense2csc(cusparseHandle_t handle,
+                                                int m,
+                                                int n,
+                                                const cusparseMatDescr_t descrA,
+                                                const cuDoubleComplex *A,
+                                                int lda,
+                                                const int *nnzPerCol,
+                                                cuDoubleComplex *cscSortedValA,
+                                                int *cscSortedRowIndA,
+                                                int *cscSortedColPtrA) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, int, const int *, cuDoubleComplex *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZdense2csc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, A, lda, nnzPerCol, cscSortedValA,
-                  cscSortedRowIndA, cscSortedColPtrA);
+  return func_ptr(handle, m, n, descrA, A, lda, nnzPerCol, cscSortedValA, cscSortedRowIndA, cscSortedColPtrA);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsc2dense(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    const float *cscSortedValA, const int *cscSortedRowIndA,
-    const int *cscSortedColPtrA, float *A, int lda) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *,
-      const int *, const int *, float *, int);
+cusparseStatus_t CUSPARSEAPI cusparseScsc2dense(cusparseHandle_t handle,
+                                                int m,
+                                                int n,
+                                                const cusparseMatDescr_t descrA,
+                                                const float *cscSortedValA,
+                                                const int *cscSortedRowIndA,
+                                                const int *cscSortedColPtrA,
+                                                float *A,
+                                                int lda) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, float *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsc2dense");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA,
-                  cscSortedColPtrA, A, lda);
+  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA, cscSortedColPtrA, A, lda);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsc2dense(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    const double *cscSortedValA, const int *cscSortedRowIndA,
-    const int *cscSortedColPtrA, double *A, int lda) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *,
-      const int *, const int *, double *, int);
+cusparseStatus_t CUSPARSEAPI cusparseDcsc2dense(cusparseHandle_t handle,
+                                                int m,
+                                                int n,
+                                                const cusparseMatDescr_t descrA,
+                                                const double *cscSortedValA,
+                                                const int *cscSortedRowIndA,
+                                                const int *cscSortedColPtrA,
+                                                double *A,
+                                                int lda) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, double *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsc2dense");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA,
-                  cscSortedColPtrA, A, lda);
+  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA, cscSortedColPtrA, A, lda);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsc2dense(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    const cuComplex *cscSortedValA, const int *cscSortedRowIndA,
-    const int *cscSortedColPtrA, cuComplex *A, int lda) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *,
-      const int *, const int *, cuComplex *, int);
+cusparseStatus_t CUSPARSEAPI cusparseCcsc2dense(cusparseHandle_t handle,
+                                                int m,
+                                                int n,
+                                                const cusparseMatDescr_t descrA,
+                                                const cuComplex *cscSortedValA,
+                                                const int *cscSortedRowIndA,
+                                                const int *cscSortedColPtrA,
+                                                cuComplex *A,
+                                                int lda) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, cuComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsc2dense");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA,
-                  cscSortedColPtrA, A, lda);
+  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA, cscSortedColPtrA, A, lda);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsc2dense(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    const cuDoubleComplex *cscSortedValA, const int *cscSortedRowIndA,
-    const int *cscSortedColPtrA, cuDoubleComplex *A, int lda) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t,
-      const cuDoubleComplex *, const int *, const int *, cuDoubleComplex *,
-      int);
+cusparseStatus_t CUSPARSEAPI cusparseZcsc2dense(cusparseHandle_t handle,
+                                                int m,
+                                                int n,
+                                                const cusparseMatDescr_t descrA,
+                                                const cuDoubleComplex *cscSortedValA,
+                                                const int *cscSortedRowIndA,
+                                                const int *cscSortedColPtrA,
+                                                cuDoubleComplex *A,
+                                                int lda) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, cuDoubleComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsc2dense");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA,
-                  cscSortedColPtrA, A, lda);
+  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA, cscSortedColPtrA, A, lda);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseXcoo2csr(cusparseHandle_t handle,
-                                              const int *cooRowInd, int nnz,
-                                              int m, int *csrSortedRowPtr,
+                                              const int *cooRowInd,
+                                              int nnz,
+                                              int m,
+                                              int *csrSortedRowPtr,
                                               cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, const int *, int, int, int *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, const int *, int, int, int *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcoo2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, cooRowInd, nnz, m, csrSortedRowPtr, idxBase);
@@ -5805,159 +6677,179 @@ cusparseStatus_t CUSPARSEAPI cusparseXcoo2csr(cusparseHandle_t handle,
 
 cusparseStatus_t CUSPARSEAPI cusparseXcsr2coo(cusparseHandle_t handle,
                                               const int *csrSortedRowPtr,
-                                              int nnz, int m, int *cooRowInd,
+                                              int nnz,
+                                              int m,
+                                              int *cooRowInd,
                                               cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, const int *, int, int, int *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, const int *, int, int, int *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcsr2coo");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, csrSortedRowPtr, nnz, m, cooRowInd, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCsr2cscEx(
-    cusparseHandle_t handle, int m, int n, int nnz, const void *csrSortedVal,
-    cudaDataType csrSortedValtype, const int *csrSortedRowPtr,
-    const int *csrSortedColInd, void *cscSortedVal,
-    cudaDataType cscSortedValtype, int *cscSortedRowInd, int *cscSortedColPtr,
-    cusparseAction_t copyValues, cusparseIndexBase_t idxBase,
-    cudaDataType executiontype) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const void *, cudaDataType, const int *,
-      const int *, void *, cudaDataType, int *, int *, cusparseAction_t,
-      cusparseIndexBase_t, cudaDataType);
+cusparseStatus_t CUSPARSEAPI cusparseCsr2cscEx(cusparseHandle_t handle,
+                                              int m,
+                                              int n,
+                                              int nnz,
+                                              const void  *csrSortedVal,
+                                              cudaDataType csrSortedValtype,
+                                              const int *csrSortedRowPtr,
+                                              const int *csrSortedColInd,
+                                              void *cscSortedVal,
+                                              cudaDataType cscSortedValtype,
+                                              int *cscSortedRowInd,
+                                              int *cscSortedColPtr,
+                                              cusparseAction_t copyValues,
+                                              cusparseIndexBase_t idxBase,
+                                              cudaDataType executiontype) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const void  *, cudaDataType, const int *, const int *, void *, cudaDataType, int *, int *, cusparseAction_t, cusparseIndexBase_t, cudaDataType);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCsr2cscEx");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, csrSortedVal, csrSortedValtype,
-                  csrSortedRowPtr, csrSortedColInd, cscSortedVal,
-                  cscSortedValtype, cscSortedRowInd, cscSortedColPtr,
-                  copyValues, idxBase, executiontype);
+  return func_ptr(handle, m, n, nnz, csrSortedVal, csrSortedValtype, csrSortedRowPtr, csrSortedColInd, cscSortedVal, cscSortedValtype, cscSortedRowInd, cscSortedColPtr, copyValues, idxBase, executiontype);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsr2csc(
-    cusparseHandle_t handle, int m, int n, int nnz, const float *csrSortedVal,
-    const int *csrSortedRowPtr, const int *csrSortedColInd, float *cscSortedVal,
-    int *cscSortedRowInd, int *cscSortedColPtr, cusparseAction_t copyValues,
-    cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const float *, const int *, const int *,
-      float *, int *, int *, cusparseAction_t, cusparseIndexBase_t);
+cusparseStatus_t CUSPARSEAPI cusparseScsr2csc(cusparseHandle_t handle,
+                                              int m,
+                                              int n,
+                                              int nnz,
+                                              const float  *csrSortedVal,
+                                              const int *csrSortedRowPtr,
+                                              const int *csrSortedColInd,
+                                              float *cscSortedVal,
+                                              int *cscSortedRowInd,
+                                              int *cscSortedColPtr,
+                                              cusparseAction_t copyValues,
+                                              cusparseIndexBase_t idxBase) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const float  *, const int *, const int *, float *, int *, int *, cusparseAction_t, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsr2csc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, csrSortedVal, csrSortedRowPtr,
-                  csrSortedColInd, cscSortedVal, cscSortedRowInd,
-                  cscSortedColPtr, copyValues, idxBase);
+  return func_ptr(handle, m, n, nnz, csrSortedVal, csrSortedRowPtr, csrSortedColInd, cscSortedVal, cscSortedRowInd, cscSortedColPtr, copyValues, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsr2csc(
-    cusparseHandle_t handle, int m, int n, int nnz, const double *csrSortedVal,
-    const int *csrSortedRowPtr, const int *csrSortedColInd,
-    double *cscSortedVal, int *cscSortedRowInd, int *cscSortedColPtr,
-    cusparseAction_t copyValues, cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const double *, const int *, const int *,
-      double *, int *, int *, cusparseAction_t, cusparseIndexBase_t);
+cusparseStatus_t CUSPARSEAPI cusparseDcsr2csc(cusparseHandle_t handle,
+                                              int m,
+                                              int n,
+                                              int nnz,
+                                              const double  *csrSortedVal,
+                                              const int *csrSortedRowPtr,
+                                              const int *csrSortedColInd,
+                                              double *cscSortedVal,
+                                              int *cscSortedRowInd,
+                                              int *cscSortedColPtr,
+                                              cusparseAction_t copyValues,
+                                              cusparseIndexBase_t idxBase) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const double  *, const int *, const int *, double *, int *, int *, cusparseAction_t, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsr2csc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, csrSortedVal, csrSortedRowPtr,
-                  csrSortedColInd, cscSortedVal, cscSortedRowInd,
-                  cscSortedColPtr, copyValues, idxBase);
+  return func_ptr(handle, m, n, nnz, csrSortedVal, csrSortedRowPtr, csrSortedColInd, cscSortedVal, cscSortedRowInd, cscSortedColPtr, copyValues, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseCcsr2csc(cusparseHandle_t handle, int m, int n, int nnz,
-                 const cuComplex *csrSortedVal, const int *csrSortedRowPtr,
-                 const int *csrSortedColInd, cuComplex *cscSortedVal,
-                 int *cscSortedRowInd, int *cscSortedColPtr,
-                 cusparseAction_t copyValues, cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cuComplex *, const int *,
-      const int *, cuComplex *, int *, int *, cusparseAction_t,
-      cusparseIndexBase_t);
+cusparseStatus_t CUSPARSEAPI cusparseCcsr2csc(cusparseHandle_t handle,
+                                              int m,
+                                              int n,
+                                              int nnz,
+                                              const cuComplex  *csrSortedVal,
+                                              const int *csrSortedRowPtr,
+                                              const int *csrSortedColInd,
+                                              cuComplex *cscSortedVal,
+                                              int *cscSortedRowInd,
+                                              int *cscSortedColPtr,
+                                              cusparseAction_t copyValues,
+                                              cusparseIndexBase_t idxBase) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cuComplex  *, const int *, const int *, cuComplex *, int *, int *, cusparseAction_t, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsr2csc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, csrSortedVal, csrSortedRowPtr,
-                  csrSortedColInd, cscSortedVal, cscSortedRowInd,
-                  cscSortedColPtr, copyValues, idxBase);
+  return func_ptr(handle, m, n, nnz, csrSortedVal, csrSortedRowPtr, csrSortedColInd, cscSortedVal, cscSortedRowInd, cscSortedColPtr, copyValues, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsr2csc(
-    cusparseHandle_t handle, int m, int n, int nnz,
-    const cuDoubleComplex *csrSortedVal, const int *csrSortedRowPtr,
-    const int *csrSortedColInd, cuDoubleComplex *cscSortedVal,
-    int *cscSortedRowInd, int *cscSortedColPtr, cusparseAction_t copyValues,
-    cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cuDoubleComplex *, const int *,
-      const int *, cuDoubleComplex *, int *, int *, cusparseAction_t,
-      cusparseIndexBase_t);
+cusparseStatus_t CUSPARSEAPI cusparseZcsr2csc(cusparseHandle_t handle,
+                                              int m,
+                                              int n,
+                                              int nnz,
+                                              const cuDoubleComplex *csrSortedVal,
+                                              const int *csrSortedRowPtr,
+                                              const int *csrSortedColInd,
+                                              cuDoubleComplex *cscSortedVal,
+                                              int *cscSortedRowInd,
+                                              int *cscSortedColPtr,
+                                              cusparseAction_t copyValues,
+                                              cusparseIndexBase_t idxBase) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cuDoubleComplex *, const int *, const int *, cuDoubleComplex *, int *, int *, cusparseAction_t, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsr2csc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, csrSortedVal, csrSortedRowPtr,
-                  csrSortedColInd, cscSortedVal, cscSortedRowInd,
-                  cscSortedColPtr, copyValues, idxBase);
+  return func_ptr(handle, m, n, nnz, csrSortedVal, csrSortedRowPtr, csrSortedColInd, cscSortedVal, cscSortedRowInd, cscSortedColPtr, copyValues, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSdense2hyb(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    const float *A, int lda, const int *nnzPerRow, cusparseHybMat_t hybA,
-    int userEllWidth, cusparseHybPartition_t partitionType) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *, int,
-      const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
+cusparseStatus_t CUSPARSEAPI cusparseSdense2hyb(cusparseHandle_t handle,
+                                                int m,
+                                                int n,
+                                                const cusparseMatDescr_t descrA,
+                                                const float *A,
+                                                int lda,
+                                                const int *nnzPerRow,
+                                                cusparseHybMat_t hybA,
+                                                int userEllWidth,
+                                                cusparseHybPartition_t partitionType) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *, int, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSdense2hyb");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, hybA, userEllWidth,
-                  partitionType);
+  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, hybA, userEllWidth, partitionType);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDdense2hyb(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    const double *A, int lda, const int *nnzPerRow, cusparseHybMat_t hybA,
-    int userEllWidth, cusparseHybPartition_t partitionType) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *, int,
-      const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
+cusparseStatus_t CUSPARSEAPI cusparseDdense2hyb(cusparseHandle_t handle,
+                                                int m,
+                                                int n,
+                                                const cusparseMatDescr_t descrA,
+                                                const double *A,
+                                                int lda,
+                                                const int *nnzPerRow,
+                                                cusparseHybMat_t hybA,
+                                                int userEllWidth,
+                                                cusparseHybPartition_t partitionType) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *, int, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDdense2hyb");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, hybA, userEllWidth,
-                  partitionType);
+  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, hybA, userEllWidth, partitionType);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCdense2hyb(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    const cuComplex *A, int lda, const int *nnzPerRow, cusparseHybMat_t hybA,
-    int userEllWidth, cusparseHybPartition_t partitionType) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *,
-      int, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
+cusparseStatus_t CUSPARSEAPI cusparseCdense2hyb(cusparseHandle_t handle,
+                                                int m,
+                                                int n,
+                                                const cusparseMatDescr_t descrA,
+                                                const cuComplex *A,
+                                                int lda,
+                                                const int *nnzPerRow,
+                                                cusparseHybMat_t hybA,
+                                                int userEllWidth,
+                                                cusparseHybPartition_t partitionType) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *, int, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCdense2hyb");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, hybA, userEllWidth,
-                  partitionType);
+  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, hybA, userEllWidth, partitionType);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseZdense2hyb(cusparseHandle_t handle, int m, int n,
-                   const cusparseMatDescr_t descrA, const cuDoubleComplex *A,
-                   int lda, const int *nnzPerRow, cusparseHybMat_t hybA,
-                   int userEllWidth, cusparseHybPartition_t partitionType) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t,
-      const cuDoubleComplex *, int, const int *, cusparseHybMat_t, int,
-      cusparseHybPartition_t);
+cusparseStatus_t CUSPARSEAPI cusparseZdense2hyb(cusparseHandle_t handle,
+                                                int m,
+                                                int n,
+                                                const cusparseMatDescr_t descrA,
+                                                const cuDoubleComplex *A,
+                                                int lda,
+                                                const int *nnzPerRow,
+                                                cusparseHybMat_t hybA,
+                                                int userEllWidth,
+                                                cusparseHybPartition_t partitionType) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, int, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZdense2hyb");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, hybA, userEllWidth,
-                  partitionType);
+  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, hybA, userEllWidth, partitionType);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseShyb2dense(cusparseHandle_t handle,
                                                 const cusparseMatDescr_t descrA,
                                                 const cusparseHybMat_t hybA,
-                                                float *A, int lda) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t,
-      float *, int);
+                                                float *A,
+                                                int lda) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t, float *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseShyb2dense");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, descrA, hybA, A, lda);
@@ -5966,10 +6858,9 @@ cusparseStatus_t CUSPARSEAPI cusparseShyb2dense(cusparseHandle_t handle,
 cusparseStatus_t CUSPARSEAPI cusparseDhyb2dense(cusparseHandle_t handle,
                                                 const cusparseMatDescr_t descrA,
                                                 const cusparseHybMat_t hybA,
-                                                double *A, int lda) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t,
-      double *, int);
+                                                double *A,
+                                                int lda) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t, double *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDhyb2dense");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, descrA, hybA, A, lda);
@@ -5978,10 +6869,9 @@ cusparseStatus_t CUSPARSEAPI cusparseDhyb2dense(cusparseHandle_t handle,
 cusparseStatus_t CUSPARSEAPI cusparseChyb2dense(cusparseHandle_t handle,
                                                 const cusparseMatDescr_t descrA,
                                                 const cusparseHybMat_t hybA,
-                                                cuComplex *A, int lda) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t,
-      cuComplex *, int);
+                                                cuComplex *A,
+                                                int lda) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t, cuComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseChyb2dense");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, descrA, hybA, A, lda);
@@ -5990,70 +6880,76 @@ cusparseStatus_t CUSPARSEAPI cusparseChyb2dense(cusparseHandle_t handle,
 cusparseStatus_t CUSPARSEAPI cusparseZhyb2dense(cusparseHandle_t handle,
                                                 const cusparseMatDescr_t descrA,
                                                 const cusparseHybMat_t hybA,
-                                                cuDoubleComplex *A, int lda) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t,
-      cuDoubleComplex *, int);
+                                                cuDoubleComplex *A,
+                                                int lda) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t, cuDoubleComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZhyb2dense");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, descrA, hybA, A, lda);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsr2hyb(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    const float *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, cusparseHybMat_t hybA, int userEllWidth,
-    cusparseHybPartition_t partitionType) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *,
-      const int *, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
+cusparseStatus_t CUSPARSEAPI cusparseScsr2hyb(cusparseHandle_t handle,
+                                              int m,
+                                              int n,
+                                              const cusparseMatDescr_t descrA,
+                                              const float *csrSortedValA,
+                                              const int *csrSortedRowPtrA,
+                                              const int *csrSortedColIndA,
+                                              cusparseHybMat_t hybA,
+                                              int userEllWidth,
+                                              cusparseHybPartition_t partitionType) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsr2hyb");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, hybA, userEllWidth, partitionType);
+  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, hybA, userEllWidth, partitionType);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsr2hyb(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    const double *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, cusparseHybMat_t hybA, int userEllWidth,
-    cusparseHybPartition_t partitionType) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *,
-      const int *, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
+cusparseStatus_t CUSPARSEAPI cusparseDcsr2hyb(cusparseHandle_t handle,
+                                              int m,
+                                              int n,
+                                              const cusparseMatDescr_t descrA,
+                                              const double *csrSortedValA,
+                                              const int *csrSortedRowPtrA,
+                                              const int *csrSortedColIndA,
+                                              cusparseHybMat_t hybA,
+                                              int userEllWidth,
+                                              cusparseHybPartition_t partitionType) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsr2hyb");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, hybA, userEllWidth, partitionType);
+  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, hybA, userEllWidth, partitionType);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsr2hyb(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    const cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, cusparseHybMat_t hybA, int userEllWidth,
-    cusparseHybPartition_t partitionType) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *,
-      const int *, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
+cusparseStatus_t CUSPARSEAPI cusparseCcsr2hyb(cusparseHandle_t handle,
+                                              int m,
+                                              int n,
+                                              const cusparseMatDescr_t descrA,
+                                              const cuComplex *csrSortedValA,
+                                              const int *csrSortedRowPtrA,
+                                              const int *csrSortedColIndA,
+                                              cusparseHybMat_t hybA,
+                                              int userEllWidth,
+                                              cusparseHybPartition_t partitionType) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsr2hyb");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, hybA, userEllWidth, partitionType);
+  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, hybA, userEllWidth, partitionType);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsr2hyb(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, cusparseHybMat_t hybA, int userEllWidth,
-    cusparseHybPartition_t partitionType) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t,
-      const cuDoubleComplex *, const int *, const int *, cusparseHybMat_t, int,
-      cusparseHybPartition_t);
+cusparseStatus_t CUSPARSEAPI cusparseZcsr2hyb(cusparseHandle_t handle,
+                                              int m,
+                                              int n,
+                                              const cusparseMatDescr_t descrA,
+                                              const cuDoubleComplex *csrSortedValA,
+                                              const int *csrSortedRowPtrA,
+                                              const int *csrSortedColIndA,
+                                              cusparseHybMat_t hybA,
+                                              int userEllWidth,
+                                              cusparseHybPartition_t partitionType) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsr2hyb");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, hybA, userEllWidth, partitionType);
+  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, hybA, userEllWidth, partitionType);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseShyb2csr(cusparseHandle_t handle,
@@ -6062,13 +6958,10 @@ cusparseStatus_t CUSPARSEAPI cusparseShyb2csr(cusparseHandle_t handle,
                                               float *csrSortedValA,
                                               int *csrSortedRowPtrA,
                                               int *csrSortedColIndA) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t,
-      float *, int *, int *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t, float *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseShyb2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, descrA, hybA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA);
+  return func_ptr(handle, descrA, hybA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDhyb2csr(cusparseHandle_t handle,
@@ -6077,13 +6970,10 @@ cusparseStatus_t CUSPARSEAPI cusparseDhyb2csr(cusparseHandle_t handle,
                                               double *csrSortedValA,
                                               int *csrSortedRowPtrA,
                                               int *csrSortedColIndA) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t,
-      double *, int *, int *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t, double *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDhyb2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, descrA, hybA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA);
+  return func_ptr(handle, descrA, hybA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseChyb2csr(cusparseHandle_t handle,
@@ -6092,13 +6982,10 @@ cusparseStatus_t CUSPARSEAPI cusparseChyb2csr(cusparseHandle_t handle,
                                               cuComplex *csrSortedValA,
                                               int *csrSortedRowPtrA,
                                               int *csrSortedColIndA) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t,
-      cuComplex *, int *, int *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t, cuComplex *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseChyb2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, descrA, hybA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA);
+  return func_ptr(handle, descrA, hybA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseZhyb2csr(cusparseHandle_t handle,
@@ -6107,70 +6994,74 @@ cusparseStatus_t CUSPARSEAPI cusparseZhyb2csr(cusparseHandle_t handle,
                                               cuDoubleComplex *csrSortedValA,
                                               int *csrSortedRowPtrA,
                                               int *csrSortedColIndA) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t,
-      cuDoubleComplex *, int *, int *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t, cuDoubleComplex *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZhyb2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, descrA, hybA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA);
+  return func_ptr(handle, descrA, hybA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsc2hyb(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    const float *cscSortedValA, const int *cscSortedRowIndA,
-    const int *cscSortedColPtrA, cusparseHybMat_t hybA, int userEllWidth,
-    cusparseHybPartition_t partitionType) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *,
-      const int *, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
+cusparseStatus_t CUSPARSEAPI cusparseScsc2hyb(cusparseHandle_t handle,
+                                              int m,
+                                              int n,
+                                              const cusparseMatDescr_t descrA,
+                                              const float *cscSortedValA,
+                                              const int *cscSortedRowIndA,
+                                              const int *cscSortedColPtrA,
+                                              cusparseHybMat_t hybA,
+                                              int userEllWidth,
+                                              cusparseHybPartition_t partitionType) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsc2hyb");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA,
-                  cscSortedColPtrA, hybA, userEllWidth, partitionType);
+  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA, cscSortedColPtrA, hybA, userEllWidth, partitionType);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsc2hyb(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    const double *cscSortedValA, const int *cscSortedRowIndA,
-    const int *cscSortedColPtrA, cusparseHybMat_t hybA, int userEllWidth,
-    cusparseHybPartition_t partitionType) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *,
-      const int *, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
+cusparseStatus_t CUSPARSEAPI cusparseDcsc2hyb(cusparseHandle_t handle,
+                                              int m,
+                                              int n,
+                                              const cusparseMatDescr_t descrA,
+                                              const double *cscSortedValA,
+                                              const int *cscSortedRowIndA,
+                                              const int *cscSortedColPtrA,
+                                              cusparseHybMat_t hybA,
+                                              int userEllWidth,
+                                              cusparseHybPartition_t partitionType) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsc2hyb");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA,
-                  cscSortedColPtrA, hybA, userEllWidth, partitionType);
+  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA, cscSortedColPtrA, hybA, userEllWidth, partitionType);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsc2hyb(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    const cuComplex *cscSortedValA, const int *cscSortedRowIndA,
-    const int *cscSortedColPtrA, cusparseHybMat_t hybA, int userEllWidth,
-    cusparseHybPartition_t partitionType) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *,
-      const int *, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
+cusparseStatus_t CUSPARSEAPI cusparseCcsc2hyb(cusparseHandle_t handle,
+                                              int m,
+                                              int n,
+                                              const cusparseMatDescr_t descrA,
+                                              const cuComplex *cscSortedValA,
+                                              const int *cscSortedRowIndA,
+                                              const int *cscSortedColPtrA,
+                                              cusparseHybMat_t hybA,
+                                              int userEllWidth,
+                                              cusparseHybPartition_t partitionType) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsc2hyb");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA,
-                  cscSortedColPtrA, hybA, userEllWidth, partitionType);
+  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA, cscSortedColPtrA, hybA, userEllWidth, partitionType);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsc2hyb(
-    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
-    const cuDoubleComplex *cscSortedValA, const int *cscSortedRowIndA,
-    const int *cscSortedColPtrA, cusparseHybMat_t hybA, int userEllWidth,
-    cusparseHybPartition_t partitionType) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const cusparseMatDescr_t,
-      const cuDoubleComplex *, const int *, const int *, cusparseHybMat_t, int,
-      cusparseHybPartition_t);
+cusparseStatus_t CUSPARSEAPI cusparseZcsc2hyb(cusparseHandle_t handle,
+                                              int m,
+                                              int n,
+                                              const cusparseMatDescr_t descrA,
+                                              const cuDoubleComplex *cscSortedValA,
+                                              const int *cscSortedRowIndA,
+                                              const int *cscSortedColPtrA,
+                                              cusparseHybMat_t hybA,
+                                              int userEllWidth,
+                                              cusparseHybPartition_t partitionType) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsc2hyb");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA,
-                  cscSortedColPtrA, hybA, userEllWidth, partitionType);
+  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA, cscSortedColPtrA, hybA, userEllWidth, partitionType);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseShyb2csc(cusparseHandle_t handle,
@@ -6179,13 +7070,10 @@ cusparseStatus_t CUSPARSEAPI cusparseShyb2csc(cusparseHandle_t handle,
                                               float *cscSortedVal,
                                               int *cscSortedRowInd,
                                               int *cscSortedColPtr) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t,
-      float *, int *, int *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t, float *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseShyb2csc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, descrA, hybA, cscSortedVal, cscSortedRowInd,
-                  cscSortedColPtr);
+  return func_ptr(handle, descrA, hybA, cscSortedVal, cscSortedRowInd, cscSortedColPtr);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDhyb2csc(cusparseHandle_t handle,
@@ -6194,13 +7082,10 @@ cusparseStatus_t CUSPARSEAPI cusparseDhyb2csc(cusparseHandle_t handle,
                                               double *cscSortedVal,
                                               int *cscSortedRowInd,
                                               int *cscSortedColPtr) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t,
-      double *, int *, int *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t, double *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDhyb2csc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, descrA, hybA, cscSortedVal, cscSortedRowInd,
-                  cscSortedColPtr);
+  return func_ptr(handle, descrA, hybA, cscSortedVal, cscSortedRowInd, cscSortedColPtr);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseChyb2csc(cusparseHandle_t handle,
@@ -6209,13 +7094,10 @@ cusparseStatus_t CUSPARSEAPI cusparseChyb2csc(cusparseHandle_t handle,
                                               cuComplex *cscSortedVal,
                                               int *cscSortedRowInd,
                                               int *cscSortedColPtr) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t,
-      cuComplex *, int *, int *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t, cuComplex *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseChyb2csc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, descrA, hybA, cscSortedVal, cscSortedRowInd,
-                  cscSortedColPtr);
+  return func_ptr(handle, descrA, hybA, cscSortedVal, cscSortedRowInd, cscSortedColPtr);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseZhyb2csc(cusparseHandle_t handle,
@@ -6224,1875 +7106,1943 @@ cusparseStatus_t CUSPARSEAPI cusparseZhyb2csc(cusparseHandle_t handle,
                                               cuDoubleComplex *cscSortedVal,
                                               int *cscSortedRowInd,
                                               int *cscSortedColPtr) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t,
-      cuDoubleComplex *, int *, int *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t, cuDoubleComplex *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZhyb2csc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, descrA, hybA, cscSortedVal, cscSortedRowInd,
-                  cscSortedColPtr);
+  return func_ptr(handle, descrA, hybA, cscSortedVal, cscSortedRowInd, cscSortedColPtr);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseXcsr2bsrNnz(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
-    const cusparseMatDescr_t descrA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, int blockDim, const cusparseMatDescr_t descrC,
-    int *bsrSortedRowPtrC, int *nnzTotalDevHostPtr) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const int *, const int *, int, const cusparseMatDescr_t, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseXcsr2bsrNnz(cusparseHandle_t handle,
+                                                 cusparseDirection_t dirA,
+                                                 int m,
+                                                 int n,
+                                                 const cusparseMatDescr_t descrA,
+                                                 const int *csrSortedRowPtrA,
+                                                 const int *csrSortedColIndA,
+                                                 int blockDim,
+                                                 const cusparseMatDescr_t descrC,
+                                                 int *bsrSortedRowPtrC,
+                                                 int *nnzTotalDevHostPtr) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const int *, const int *, int, const cusparseMatDescr_t, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcsr2bsrNnz");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedRowPtrA,
-                  csrSortedColIndA, blockDim, descrC, bsrSortedRowPtrC,
-                  nnzTotalDevHostPtr);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedRowPtrA, csrSortedColIndA, blockDim, descrC, bsrSortedRowPtrC, nnzTotalDevHostPtr);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsr2bsr(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
-    const cusparseMatDescr_t descrA, const float *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, int blockDim,
-    const cusparseMatDescr_t descrC, float *bsrSortedValC,
-    int *bsrSortedRowPtrC, int *bsrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const float *, const int *, const int *, int, const cusparseMatDescr_t,
-      float *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseScsr2bsr(cusparseHandle_t handle,
+                                              cusparseDirection_t dirA,
+                                              int m,
+                                              int n,
+                                              const cusparseMatDescr_t descrA,
+                                              const float *csrSortedValA,
+                                              const int *csrSortedRowPtrA,
+                                              const int *csrSortedColIndA,
+                                              int blockDim,
+                                              const cusparseMatDescr_t descrC,
+                                              float *bsrSortedValC,
+                                              int *bsrSortedRowPtrC,
+                                              int *bsrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, int, const cusparseMatDescr_t, float *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsr2bsr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, blockDim, descrC, bsrSortedValC,
-                  bsrSortedRowPtrC, bsrSortedColIndC);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, blockDim, descrC, bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsr2bsr(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
-    const cusparseMatDescr_t descrA, const double *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, int blockDim,
-    const cusparseMatDescr_t descrC, double *bsrSortedValC,
-    int *bsrSortedRowPtrC, int *bsrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const double *, const int *, const int *, int, const cusparseMatDescr_t,
-      double *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsr2bsr(cusparseHandle_t handle,
+                                              cusparseDirection_t dirA,
+                                              int m,
+                                              int n,
+                                              const cusparseMatDescr_t descrA,
+                                              const double *csrSortedValA,
+                                              const int *csrSortedRowPtrA,
+                                              const int *csrSortedColIndA,
+                                              int blockDim,
+                                              const cusparseMatDescr_t descrC,
+                                              double *bsrSortedValC,
+                                              int *bsrSortedRowPtrC,
+                                              int *bsrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, int, const cusparseMatDescr_t, double *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsr2bsr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, blockDim, descrC, bsrSortedValC,
-                  bsrSortedRowPtrC, bsrSortedColIndC);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, blockDim, descrC, bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsr2bsr(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
-    const cusparseMatDescr_t descrA, const cuComplex *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, int blockDim,
-    const cusparseMatDescr_t descrC, cuComplex *bsrSortedValC,
-    int *bsrSortedRowPtrC, int *bsrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const cuComplex *, const int *, const int *, int,
-      const cusparseMatDescr_t, cuComplex *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsr2bsr(cusparseHandle_t handle,
+                                              cusparseDirection_t dirA,
+                                              int m,
+                                              int n,
+                                              const cusparseMatDescr_t descrA,
+                                              const cuComplex *csrSortedValA,
+                                              const int *csrSortedRowPtrA,
+                                              const int *csrSortedColIndA,
+                                              int blockDim,
+                                              const cusparseMatDescr_t descrC,
+                                              cuComplex *bsrSortedValC,
+                                              int *bsrSortedRowPtrC,
+                                              int *bsrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, int, const cusparseMatDescr_t, cuComplex *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsr2bsr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, blockDim, descrC, bsrSortedValC,
-                  bsrSortedRowPtrC, bsrSortedColIndC);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, blockDim, descrC, bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsr2bsr(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
-    const cusparseMatDescr_t descrA, const cuDoubleComplex *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, int blockDim,
-    const cusparseMatDescr_t descrC, cuDoubleComplex *bsrSortedValC,
-    int *bsrSortedRowPtrC, int *bsrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const cuDoubleComplex *, const int *, const int *, int,
-      const cusparseMatDescr_t, cuDoubleComplex *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsr2bsr(cusparseHandle_t handle,
+                                              cusparseDirection_t dirA,
+                                              int m,
+                                              int n,
+                                              const cusparseMatDescr_t descrA,
+                                              const cuDoubleComplex *csrSortedValA,
+                                              const int *csrSortedRowPtrA,
+                                              const int *csrSortedColIndA,
+                                              int blockDim,
+                                              const cusparseMatDescr_t descrC,
+                                              cuDoubleComplex *bsrSortedValC,
+                                              int *bsrSortedRowPtrC,
+                                              int *bsrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, int, const cusparseMatDescr_t, cuDoubleComplex *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsr2bsr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, blockDim, descrC, bsrSortedValC,
-                  bsrSortedRowPtrC, bsrSortedColIndC);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, blockDim, descrC, bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsr2csr(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb,
-    const cusparseMatDescr_t descrA, const float *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
-    const cusparseMatDescr_t descrC, float *csrSortedValC,
-    int *csrSortedRowPtrC, int *csrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const float *, const int *, const int *, int, const cusparseMatDescr_t,
-      float *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsr2csr(cusparseHandle_t handle,
+                                              cusparseDirection_t dirA,
+                                              int mb,
+                                              int nb,
+                                              const cusparseMatDescr_t descrA,
+                                              const float *bsrSortedValA,
+                                              const int *bsrSortedRowPtrA,
+                                              const int *bsrSortedColIndA,
+                                              int blockDim,
+                                              const cusparseMatDescr_t descrC,
+                                              float *csrSortedValC,
+                                              int *csrSortedRowPtrC,
+                                              int *csrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, int, const cusparseMatDescr_t, float *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsr2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA,
-                  bsrSortedColIndA, blockDim, descrC, csrSortedValC,
-                  csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsr2csr(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb,
-    const cusparseMatDescr_t descrA, const double *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
-    const cusparseMatDescr_t descrC, double *csrSortedValC,
-    int *csrSortedRowPtrC, int *csrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const double *, const int *, const int *, int, const cusparseMatDescr_t,
-      double *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsr2csr(cusparseHandle_t handle,
+                                              cusparseDirection_t dirA,
+                                              int mb,
+                                              int nb,
+                                              const cusparseMatDescr_t descrA,
+                                              const double *bsrSortedValA,
+                                              const int *bsrSortedRowPtrA,
+                                              const int *bsrSortedColIndA,
+                                              int   blockDim,
+                                              const cusparseMatDescr_t descrC,
+                                              double *csrSortedValC,
+                                              int *csrSortedRowPtrC,
+                                              int *csrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, int, const cusparseMatDescr_t, double *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsr2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA,
-                  bsrSortedColIndA, blockDim, descrC, csrSortedValC,
-                  csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsr2csr(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb,
-    const cusparseMatDescr_t descrA, const cuComplex *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
-    const cusparseMatDescr_t descrC, cuComplex *csrSortedValC,
-    int *csrSortedRowPtrC, int *csrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const cuComplex *, const int *, const int *, int,
-      const cusparseMatDescr_t, cuComplex *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsr2csr(cusparseHandle_t handle,
+                                              cusparseDirection_t dirA,
+                                              int mb,
+                                              int nb,
+                                              const cusparseMatDescr_t descrA,
+                                              const cuComplex *bsrSortedValA,
+                                              const int *bsrSortedRowPtrA,
+                                              const int *bsrSortedColIndA,
+                                              int blockDim,
+                                              const cusparseMatDescr_t descrC,
+                                              cuComplex *csrSortedValC,
+                                              int *csrSortedRowPtrC,
+                                              int *csrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, int, const cusparseMatDescr_t, cuComplex *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsr2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA,
-                  bsrSortedColIndA, blockDim, descrC, csrSortedValC,
-                  csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsr2csr(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb,
-    const cusparseMatDescr_t descrA, const cuDoubleComplex *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
-    const cusparseMatDescr_t descrC, cuDoubleComplex *csrSortedValC,
-    int *csrSortedRowPtrC, int *csrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const cuDoubleComplex *, const int *, const int *, int,
-      const cusparseMatDescr_t, cuDoubleComplex *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsr2csr(cusparseHandle_t handle,
+                                              cusparseDirection_t dirA,
+                                              int mb,
+                                              int nb,
+                                              const cusparseMatDescr_t descrA,
+                                              const cuDoubleComplex *bsrSortedValA,
+                                              const int *bsrSortedRowPtrA,
+                                              const int *bsrSortedColIndA,
+                                              int blockDim,
+                                              const cusparseMatDescr_t descrC,
+                                              cuDoubleComplex *csrSortedValC,
+                                              int *csrSortedRowPtrC,
+                                              int *csrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, int, const cusparseMatDescr_t, cuDoubleComplex *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsr2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA,
-                  bsrSortedColIndA, blockDim, descrC, csrSortedValC,
-                  csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSgebsr2gebsc_bufferSize(
-    cusparseHandle_t handle, int mb, int nb, int nnzb,
-    const float *bsrSortedVal, const int *bsrSortedRowPtr,
-    const int *bsrSortedColInd, int rowBlockDim, int colBlockDim,
-    int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const float *, const int *, const int *,
-      int, int, int *);
+cusparseStatus_t CUSPARSEAPI cusparseSgebsr2gebsc_bufferSize(cusparseHandle_t handle,
+                                                             int mb,
+                                                             int nb,
+                                                             int nnzb,
+                                                             const float *bsrSortedVal,
+                                                             const int *bsrSortedRowPtr,
+                                                             const int *bsrSortedColInd,
+                                                             int rowBlockDim,
+                                                             int colBlockDim,
+                                                             int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const float *, const int *, const int *, int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgebsr2gebsc_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, rowBlockDim, colBlockDim,
-                  pBufferSizeInBytes);
+  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, rowBlockDim, colBlockDim, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDgebsr2gebsc_bufferSize(
-    cusparseHandle_t handle, int mb, int nb, int nnzb,
-    const double *bsrSortedVal, const int *bsrSortedRowPtr,
-    const int *bsrSortedColInd, int rowBlockDim, int colBlockDim,
-    int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const double *, const int *, const int *,
-      int, int, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDgebsr2gebsc_bufferSize(cusparseHandle_t handle,
+                                                             int mb,
+                                                             int nb,
+                                                             int nnzb,
+                                                             const double *bsrSortedVal,
+                                                             const int *bsrSortedRowPtr,
+                                                             const int *bsrSortedColInd,
+                                                             int rowBlockDim,
+                                                             int colBlockDim,
+                                                             int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const double *, const int *, const int *, int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgebsr2gebsc_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, rowBlockDim, colBlockDim,
-                  pBufferSizeInBytes);
+  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, rowBlockDim, colBlockDim, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCgebsr2gebsc_bufferSize(
-    cusparseHandle_t handle, int mb, int nb, int nnzb,
-    const cuComplex *bsrSortedVal, const int *bsrSortedRowPtr,
-    const int *bsrSortedColInd, int rowBlockDim, int colBlockDim,
-    int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cuComplex *, const int *,
-      const int *, int, int, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCgebsr2gebsc_bufferSize(cusparseHandle_t handle,
+                                                             int mb,
+                                                             int nb,
+                                                             int nnzb,
+                                                             const cuComplex *bsrSortedVal,
+                                                             const int *bsrSortedRowPtr,
+                                                             const int *bsrSortedColInd,
+                                                             int rowBlockDim,
+                                                             int colBlockDim,
+                                                             int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cuComplex *, const int *, const int *, int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgebsr2gebsc_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, rowBlockDim, colBlockDim,
-                  pBufferSizeInBytes);
+  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, rowBlockDim, colBlockDim, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZgebsr2gebsc_bufferSize(
-    cusparseHandle_t handle, int mb, int nb, int nnzb,
-    const cuDoubleComplex *bsrSortedVal, const int *bsrSortedRowPtr,
-    const int *bsrSortedColInd, int rowBlockDim, int colBlockDim,
-    int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cuDoubleComplex *, const int *,
-      const int *, int, int, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZgebsr2gebsc_bufferSize(cusparseHandle_t handle,
+                                                             int mb,
+                                                             int nb,
+                                                             int nnzb,
+                                                             const cuDoubleComplex *bsrSortedVal,
+                                                             const int *bsrSortedRowPtr,
+                                                             const int *bsrSortedColInd,
+                                                             int rowBlockDim,
+                                                             int colBlockDim,
+                                                             int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cuDoubleComplex *, const int *, const int *, int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgebsr2gebsc_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, rowBlockDim, colBlockDim,
-                  pBufferSizeInBytes);
+  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, rowBlockDim, colBlockDim, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSgebsr2gebsc_bufferSizeExt(
-    cusparseHandle_t handle, int mb, int nb, int nnzb,
-    const float *bsrSortedVal, const int *bsrSortedRowPtr,
-    const int *bsrSortedColInd, int rowBlockDim, int colBlockDim,
-    size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const float *, const int *, const int *,
-      int, int, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseSgebsr2gebsc_bufferSizeExt");
+cusparseStatus_t CUSPARSEAPI cusparseSgebsr2gebsc_bufferSizeExt(cusparseHandle_t handle,
+                                                                int mb,
+                                                                int nb,
+                                                                int nnzb,
+                                                                const float *bsrSortedVal,
+                                                                const int *bsrSortedRowPtr,
+                                                                const int *bsrSortedColInd,
+                                                                int rowBlockDim,
+                                                                int colBlockDim,
+                                                                size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const float *, const int *, const int *, int, int, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgebsr2gebsc_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, rowBlockDim, colBlockDim, pBufferSize);
+  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, rowBlockDim, colBlockDim, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDgebsr2gebsc_bufferSizeExt(
-    cusparseHandle_t handle, int mb, int nb, int nnzb,
-    const double *bsrSortedVal, const int *bsrSortedRowPtr,
-    const int *bsrSortedColInd, int rowBlockDim, int colBlockDim,
-    size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const double *, const int *, const int *,
-      int, int, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseDgebsr2gebsc_bufferSizeExt");
+cusparseStatus_t CUSPARSEAPI cusparseDgebsr2gebsc_bufferSizeExt(cusparseHandle_t handle,
+                                                                int mb,
+                                                                int nb,
+                                                                int nnzb,
+                                                                const double *bsrSortedVal,
+                                                                const int *bsrSortedRowPtr,
+                                                                const int *bsrSortedColInd,
+                                                                int rowBlockDim,
+                                                                int colBlockDim,
+                                                                size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const double *, const int *, const int *, int, int, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgebsr2gebsc_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, rowBlockDim, colBlockDim, pBufferSize);
+  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, rowBlockDim, colBlockDim, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCgebsr2gebsc_bufferSizeExt(
-    cusparseHandle_t handle, int mb, int nb, int nnzb,
-    const cuComplex *bsrSortedVal, const int *bsrSortedRowPtr,
-    const int *bsrSortedColInd, int rowBlockDim, int colBlockDim,
-    size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cuComplex *, const int *,
-      const int *, int, int, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseCgebsr2gebsc_bufferSizeExt");
+cusparseStatus_t CUSPARSEAPI cusparseCgebsr2gebsc_bufferSizeExt(cusparseHandle_t handle,
+                                                                int mb,
+                                                                int nb,
+                                                                int nnzb,
+                                                                const cuComplex *bsrSortedVal,
+                                                                const int *bsrSortedRowPtr,
+                                                                const int *bsrSortedColInd,
+                                                                int rowBlockDim,
+                                                                int colBlockDim,
+                                                                size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cuComplex *, const int *, const int *, int, int, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgebsr2gebsc_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, rowBlockDim, colBlockDim, pBufferSize);
+  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, rowBlockDim, colBlockDim, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZgebsr2gebsc_bufferSizeExt(
-    cusparseHandle_t handle, int mb, int nb, int nnzb,
-    const cuDoubleComplex *bsrSortedVal, const int *bsrSortedRowPtr,
-    const int *bsrSortedColInd, int rowBlockDim, int colBlockDim,
-    size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cuDoubleComplex *, const int *,
-      const int *, int, int, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseZgebsr2gebsc_bufferSizeExt");
+cusparseStatus_t CUSPARSEAPI cusparseZgebsr2gebsc_bufferSizeExt(cusparseHandle_t handle,
+                                                                int mb,
+                                                                int nb,
+                                                                int nnzb,
+                                                                const cuDoubleComplex *bsrSortedVal,
+                                                                const int *bsrSortedRowPtr,
+                                                                const int *bsrSortedColInd,
+                                                                int rowBlockDim,
+                                                                int colBlockDim,
+                                                                size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cuDoubleComplex *, const int *, const int *, int, int, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgebsr2gebsc_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, rowBlockDim, colBlockDim, pBufferSize);
+  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, rowBlockDim, colBlockDim, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSgebsr2gebsc(
-    cusparseHandle_t handle, int mb, int nb, int nnzb,
-    const float *bsrSortedVal, const int *bsrSortedRowPtr,
-    const int *bsrSortedColInd, int rowBlockDim, int colBlockDim, float *bscVal,
-    int *bscRowInd, int *bscColPtr, cusparseAction_t copyValues,
-    cusparseIndexBase_t idxBase, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const float *, const int *, const int *,
-      int, int, float *, int *, int *, cusparseAction_t, cusparseIndexBase_t,
-      void *);
+cusparseStatus_t CUSPARSEAPI cusparseSgebsr2gebsc(cusparseHandle_t handle,
+                                                  int mb,
+                                                  int nb,
+                                                  int nnzb,
+                                                  const float *bsrSortedVal,
+                                                  const int *bsrSortedRowPtr,
+                                                  const int *bsrSortedColInd,
+                                                  int rowBlockDim,
+                                                  int colBlockDim,
+                                                  float *bscVal,
+                                                  int *bscRowInd,
+                                                  int *bscColPtr,
+                                                  cusparseAction_t copyValues,
+                                                  cusparseIndexBase_t idxBase,
+                                                  void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const float *, const int *, const int *, int, int, float *, int *, int *, cusparseAction_t, cusparseIndexBase_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgebsr2gebsc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, rowBlockDim, colBlockDim, bscVal, bscRowInd,
-                  bscColPtr, copyValues, idxBase, pBuffer);
+  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, rowBlockDim, colBlockDim, bscVal, bscRowInd, bscColPtr, copyValues, idxBase, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDgebsr2gebsc(
-    cusparseHandle_t handle, int mb, int nb, int nnzb,
-    const double *bsrSortedVal, const int *bsrSortedRowPtr,
-    const int *bsrSortedColInd, int rowBlockDim, int colBlockDim,
-    double *bscVal, int *bscRowInd, int *bscColPtr, cusparseAction_t copyValues,
-    cusparseIndexBase_t idxBase, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const double *, const int *, const int *,
-      int, int, double *, int *, int *, cusparseAction_t, cusparseIndexBase_t,
-      void *);
+cusparseStatus_t CUSPARSEAPI cusparseDgebsr2gebsc(cusparseHandle_t handle,
+                                                  int mb,
+                                                  int nb,
+                                                  int nnzb,
+                                                  const double *bsrSortedVal,
+                                                  const int *bsrSortedRowPtr,
+                                                  const int *bsrSortedColInd,
+                                                  int rowBlockDim,
+                                                  int colBlockDim,
+                                                  double *bscVal,
+                                                  int *bscRowInd,
+                                                  int *bscColPtr,
+                                                  cusparseAction_t copyValues,
+                                                  cusparseIndexBase_t idxBase,
+                                                  void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const double *, const int *, const int *, int, int, double *, int *, int *, cusparseAction_t, cusparseIndexBase_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgebsr2gebsc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, rowBlockDim, colBlockDim, bscVal, bscRowInd,
-                  bscColPtr, copyValues, idxBase, pBuffer);
+  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, rowBlockDim, colBlockDim, bscVal, bscRowInd, bscColPtr, copyValues, idxBase, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCgebsr2gebsc(
-    cusparseHandle_t handle, int mb, int nb, int nnzb,
-    const cuComplex *bsrSortedVal, const int *bsrSortedRowPtr,
-    const int *bsrSortedColInd, int rowBlockDim, int colBlockDim,
-    cuComplex *bscVal, int *bscRowInd, int *bscColPtr,
-    cusparseAction_t copyValues, cusparseIndexBase_t idxBase, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cuComplex *, const int *,
-      const int *, int, int, cuComplex *, int *, int *, cusparseAction_t,
-      cusparseIndexBase_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCgebsr2gebsc(cusparseHandle_t handle,
+                                                  int mb,
+                                                  int nb,
+                                                  int nnzb,
+                                                  const cuComplex *bsrSortedVal,
+                                                  const int *bsrSortedRowPtr,
+                                                  const int *bsrSortedColInd,
+                                                  int rowBlockDim,
+                                                  int colBlockDim,
+                                                  cuComplex *bscVal,
+                                                  int *bscRowInd,
+                                                  int *bscColPtr,
+                                                  cusparseAction_t copyValues,
+                                                  cusparseIndexBase_t idxBase,
+                                                  void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cuComplex *, const int *, const int *, int, int, cuComplex *, int *, int *, cusparseAction_t, cusparseIndexBase_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgebsr2gebsc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, rowBlockDim, colBlockDim, bscVal, bscRowInd,
-                  bscColPtr, copyValues, idxBase, pBuffer);
+  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, rowBlockDim, colBlockDim, bscVal, bscRowInd, bscColPtr, copyValues, idxBase, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZgebsr2gebsc(
-    cusparseHandle_t handle, int mb, int nb, int nnzb,
-    const cuDoubleComplex *bsrSortedVal, const int *bsrSortedRowPtr,
-    const int *bsrSortedColInd, int rowBlockDim, int colBlockDim,
-    cuDoubleComplex *bscVal, int *bscRowInd, int *bscColPtr,
-    cusparseAction_t copyValues, cusparseIndexBase_t idxBase, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cuDoubleComplex *, const int *,
-      const int *, int, int, cuDoubleComplex *, int *, int *, cusparseAction_t,
-      cusparseIndexBase_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZgebsr2gebsc(cusparseHandle_t handle,
+                                                  int mb,
+                                                  int nb,
+                                                  int nnzb,
+                                                  const cuDoubleComplex *bsrSortedVal,
+                                                  const int *bsrSortedRowPtr,
+                                                  const int *bsrSortedColInd,
+                                                  int rowBlockDim,
+                                                  int colBlockDim,
+                                                  cuDoubleComplex *bscVal,
+                                                  int *bscRowInd,
+                                                  int *bscColPtr,
+                                                  cusparseAction_t copyValues,
+                                                  cusparseIndexBase_t idxBase,
+                                                  void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cuDoubleComplex *, const int *, const int *, int, int, cuDoubleComplex *, int *, int *, cusparseAction_t, cusparseIndexBase_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgebsr2gebsc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
-                  bsrSortedColInd, rowBlockDim, colBlockDim, bscVal, bscRowInd,
-                  bscColPtr, copyValues, idxBase, pBuffer);
+  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, rowBlockDim, colBlockDim, bscVal, bscRowInd, bscColPtr, copyValues, idxBase, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseXgebsr2csr(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb,
-    const cusparseMatDescr_t descrA, const int *bsrSortedRowPtrA,
-    const int *bsrSortedColIndA, int rowBlockDim, int colBlockDim,
-    const cusparseMatDescr_t descrC, int *csrSortedRowPtrC,
-    int *csrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const int *, const int *, int, int, const cusparseMatDescr_t, int *,
-      int *);
+cusparseStatus_t CUSPARSEAPI cusparseXgebsr2csr(cusparseHandle_t handle,
+                                                cusparseDirection_t dirA,
+                                                int mb,
+                                                int nb,
+                                                const cusparseMatDescr_t descrA,
+                                                const int    *bsrSortedRowPtrA,
+                                                const int    *bsrSortedColIndA,
+                                                int   rowBlockDim,
+                                                int   colBlockDim,
+                                                const cusparseMatDescr_t descrC,
+                                                int    *csrSortedRowPtrC,
+                                                int    *csrSortedColIndC ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const int    *, const int    *, int, int, const cusparseMatDescr_t, int    *, int    *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXgebsr2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedRowPtrA,
-                  bsrSortedColIndA, rowBlockDim, colBlockDim, descrC,
-                  csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDim, colBlockDim, descrC, csrSortedRowPtrC, csrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSgebsr2csr(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb,
-    const cusparseMatDescr_t descrA, const float *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDim,
-    int colBlockDim, const cusparseMatDescr_t descrC, float *csrSortedValC,
-    int *csrSortedRowPtrC, int *csrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const float *, const int *, const int *, int, int,
-      const cusparseMatDescr_t, float *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseSgebsr2csr(cusparseHandle_t handle,
+                                                cusparseDirection_t dirA,
+                                                int mb,
+                                                int nb,
+                                                const cusparseMatDescr_t descrA,
+                                                const float *bsrSortedValA,
+                                                const int    *bsrSortedRowPtrA,
+                                                const int    *bsrSortedColIndA,
+                                                int   rowBlockDim,
+                                                int   colBlockDim,
+                                                const cusparseMatDescr_t descrC,
+                                                float  *csrSortedValC,
+                                                int    *csrSortedRowPtrC,
+                                                int    *csrSortedColIndC ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const float *, const int    *, const int    *, int, int, const cusparseMatDescr_t, float  *, int    *, int    *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgebsr2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA,
-                  bsrSortedColIndA, rowBlockDim, colBlockDim, descrC,
-                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDim, colBlockDim, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDgebsr2csr(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb,
-    const cusparseMatDescr_t descrA, const double *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDim,
-    int colBlockDim, const cusparseMatDescr_t descrC, double *csrSortedValC,
-    int *csrSortedRowPtrC, int *csrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const double *, const int *, const int *, int, int,
-      const cusparseMatDescr_t, double *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDgebsr2csr(cusparseHandle_t handle,
+                                                cusparseDirection_t dirA,
+                                                int mb,
+                                                int nb,
+                                                const cusparseMatDescr_t descrA,
+                                                const double *bsrSortedValA,
+                                                const int    *bsrSortedRowPtrA,
+                                                const int    *bsrSortedColIndA,
+                                                int   rowBlockDim,
+                                                int   colBlockDim,
+                                                const cusparseMatDescr_t descrC,
+                                                double  *csrSortedValC,
+                                                int    *csrSortedRowPtrC,
+                                                int    *csrSortedColIndC ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const double *, const int    *, const int    *, int, int, const cusparseMatDescr_t, double  *, int    *, int    *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgebsr2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA,
-                  bsrSortedColIndA, rowBlockDim, colBlockDim, descrC,
-                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDim, colBlockDim, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCgebsr2csr(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb,
-    const cusparseMatDescr_t descrA, const cuComplex *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDim,
-    int colBlockDim, const cusparseMatDescr_t descrC, cuComplex *csrSortedValC,
-    int *csrSortedRowPtrC, int *csrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const cuComplex *, const int *, const int *, int, int,
-      const cusparseMatDescr_t, cuComplex *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCgebsr2csr(cusparseHandle_t handle,
+                                                cusparseDirection_t dirA,
+                                                int mb,
+                                                int nb,
+                                                const cusparseMatDescr_t descrA,
+                                                const cuComplex *bsrSortedValA,
+                                                const int    *bsrSortedRowPtrA,
+                                                const int    *bsrSortedColIndA,
+                                                int   rowBlockDim,
+                                                int   colBlockDim,
+                                                const cusparseMatDescr_t descrC,
+                                                cuComplex  *csrSortedValC,
+                                                int    *csrSortedRowPtrC,
+                                                int    *csrSortedColIndC ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int    *, const int    *, int, int, const cusparseMatDescr_t, cuComplex  *, int    *, int    *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgebsr2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA,
-                  bsrSortedColIndA, rowBlockDim, colBlockDim, descrC,
-                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDim, colBlockDim, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZgebsr2csr(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb,
-    const cusparseMatDescr_t descrA, const cuDoubleComplex *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDim,
-    int colBlockDim, const cusparseMatDescr_t descrC,
-    cuDoubleComplex *csrSortedValC, int *csrSortedRowPtrC,
-    int *csrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const cuDoubleComplex *, const int *, const int *, int, int,
-      const cusparseMatDescr_t, cuDoubleComplex *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZgebsr2csr(cusparseHandle_t handle,
+                                                cusparseDirection_t dirA,
+                                                int mb,
+                                                int nb,
+                                                const cusparseMatDescr_t descrA,
+                                                const cuDoubleComplex *bsrSortedValA,
+                                                const int    *bsrSortedRowPtrA,
+                                                const int    *bsrSortedColIndA,
+                                                int   rowBlockDim,
+                                                int   colBlockDim,
+                                                const cusparseMatDescr_t descrC,
+                                                cuDoubleComplex  *csrSortedValC,
+                                                int    *csrSortedRowPtrC,
+                                                int    *csrSortedColIndC ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int    *, const int    *, int, int, const cusparseMatDescr_t, cuDoubleComplex  *, int    *, int    *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgebsr2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA,
-                  bsrSortedColIndA, rowBlockDim, colBlockDim, descrC,
-                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDim, colBlockDim, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsr2gebsr_bufferSize(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
-    const cusparseMatDescr_t descrA, const float *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, int rowBlockDim,
-    int colBlockDim, int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const float *, const int *, const int *, int, int, int *);
+cusparseStatus_t CUSPARSEAPI cusparseScsr2gebsr_bufferSize(cusparseHandle_t handle,
+                                                           cusparseDirection_t dirA,
+                                                           int m,
+                                                           int n,
+                                                           const cusparseMatDescr_t descrA,
+                                                           const float *csrSortedValA,
+                                                           const int *csrSortedRowPtrA,
+                                                           const int *csrSortedColIndA,
+                                                           int rowBlockDim,
+                                                           int colBlockDim,
+                                                           int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsr2gebsr_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, rowBlockDim, colBlockDim,
-                  pBufferSizeInBytes);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, rowBlockDim, colBlockDim, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsr2gebsr_bufferSize(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
-    const cusparseMatDescr_t descrA, const double *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, int rowBlockDim,
-    int colBlockDim, int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const double *, const int *, const int *, int, int, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsr2gebsr_bufferSize(cusparseHandle_t handle,
+                                                           cusparseDirection_t dirA,
+                                                           int m,
+                                                           int n,
+                                                           const cusparseMatDescr_t descrA,
+                                                           const double *csrSortedValA,
+                                                           const int *csrSortedRowPtrA,
+                                                           const int *csrSortedColIndA,
+                                                           int rowBlockDim,
+                                                           int colBlockDim,
+                                                           int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsr2gebsr_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, rowBlockDim, colBlockDim,
-                  pBufferSizeInBytes);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, rowBlockDim, colBlockDim, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsr2gebsr_bufferSize(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
-    const cusparseMatDescr_t descrA, const cuComplex *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, int rowBlockDim,
-    int colBlockDim, int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const cuComplex *, const int *, const int *, int, int, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsr2gebsr_bufferSize(cusparseHandle_t handle,
+                                                           cusparseDirection_t dirA,
+                                                           int m,
+                                                           int n,
+                                                           const cusparseMatDescr_t descrA,
+                                                           const cuComplex *csrSortedValA,
+                                                           const int *csrSortedRowPtrA,
+                                                           const int *csrSortedColIndA,
+                                                           int rowBlockDim,
+                                                           int colBlockDim,
+                                                           int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsr2gebsr_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, rowBlockDim, colBlockDim,
-                  pBufferSizeInBytes);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, rowBlockDim, colBlockDim, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsr2gebsr_bufferSize(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
-    const cusparseMatDescr_t descrA, const cuDoubleComplex *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, int rowBlockDim,
-    int colBlockDim, int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const cuDoubleComplex *, const int *, const int *, int, int, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsr2gebsr_bufferSize(cusparseHandle_t handle,
+                                                           cusparseDirection_t dirA,
+                                                           int m,
+                                                           int n,
+                                                           const cusparseMatDescr_t descrA,
+                                                           const cuDoubleComplex *csrSortedValA,
+                                                           const int *csrSortedRowPtrA,
+                                                           const int *csrSortedColIndA,
+                                                           int rowBlockDim,
+                                                           int colBlockDim,
+                                                           int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsr2gebsr_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, rowBlockDim, colBlockDim,
-                  pBufferSizeInBytes);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, rowBlockDim, colBlockDim, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsr2gebsr_bufferSizeExt(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
-    const cusparseMatDescr_t descrA, const float *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, int rowBlockDim,
-    int colBlockDim, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const float *, const int *, const int *, int, int, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseScsr2gebsr_bufferSizeExt");
+cusparseStatus_t CUSPARSEAPI cusparseScsr2gebsr_bufferSizeExt(cusparseHandle_t handle,
+                                                              cusparseDirection_t dirA,
+                                                              int m,
+                                                              int n,
+                                                              const cusparseMatDescr_t descrA,
+                                                              const float *csrSortedValA,
+                                                              const int *csrSortedRowPtrA,
+                                                              const int *csrSortedColIndA,
+                                                              int rowBlockDim,
+                                                              int colBlockDim,
+                                                              size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, int, int, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsr2gebsr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, rowBlockDim, colBlockDim, pBufferSize);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, rowBlockDim, colBlockDim, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsr2gebsr_bufferSizeExt(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
-    const cusparseMatDescr_t descrA, const double *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, int rowBlockDim,
-    int colBlockDim, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const double *, const int *, const int *, int, int, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseDcsr2gebsr_bufferSizeExt");
+cusparseStatus_t CUSPARSEAPI cusparseDcsr2gebsr_bufferSizeExt(cusparseHandle_t handle,
+                                                              cusparseDirection_t dirA,
+                                                              int m,
+                                                              int n,
+                                                              const cusparseMatDescr_t descrA,
+                                                              const double *csrSortedValA,
+                                                              const int *csrSortedRowPtrA,
+                                                              const int *csrSortedColIndA,
+                                                              int rowBlockDim,
+                                                              int colBlockDim,
+                                                              size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, int, int, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsr2gebsr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, rowBlockDim, colBlockDim, pBufferSize);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, rowBlockDim, colBlockDim, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsr2gebsr_bufferSizeExt(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
-    const cusparseMatDescr_t descrA, const cuComplex *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, int rowBlockDim,
-    int colBlockDim, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const cuComplex *, const int *, const int *, int, int, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseCcsr2gebsr_bufferSizeExt");
+cusparseStatus_t CUSPARSEAPI cusparseCcsr2gebsr_bufferSizeExt(cusparseHandle_t handle,
+                                                              cusparseDirection_t dirA,
+                                                              int m,
+                                                              int n,
+                                                              const cusparseMatDescr_t descrA,
+                                                              const cuComplex *csrSortedValA,
+                                                              const int *csrSortedRowPtrA,
+                                                              const int *csrSortedColIndA,
+                                                              int rowBlockDim,
+                                                              int colBlockDim,
+                                                              size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, int, int, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsr2gebsr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, rowBlockDim, colBlockDim, pBufferSize);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, rowBlockDim, colBlockDim, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsr2gebsr_bufferSizeExt(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
-    const cusparseMatDescr_t descrA, const cuDoubleComplex *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, int rowBlockDim,
-    int colBlockDim, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const cuDoubleComplex *, const int *, const int *, int, int, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseZcsr2gebsr_bufferSizeExt");
+cusparseStatus_t CUSPARSEAPI cusparseZcsr2gebsr_bufferSizeExt(cusparseHandle_t handle,
+                                                              cusparseDirection_t dirA,
+                                                              int m,
+                                                              int n,
+                                                              const cusparseMatDescr_t descrA,
+                                                              const cuDoubleComplex *csrSortedValA,
+                                                              const int *csrSortedRowPtrA,
+                                                              const int *csrSortedColIndA,
+                                                              int rowBlockDim,
+                                                              int colBlockDim,
+                                                              size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, int, int, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsr2gebsr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, rowBlockDim, colBlockDim, pBufferSize);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, rowBlockDim, colBlockDim, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseXcsr2gebsrNnz(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
-    const cusparseMatDescr_t descrA, const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA, const cusparseMatDescr_t descrC,
-    int *bsrSortedRowPtrC, int rowBlockDim, int colBlockDim,
-    int *nnzTotalDevHostPtr, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const int *, const int *, const cusparseMatDescr_t, int *, int, int,
-      int *, void *);
+cusparseStatus_t CUSPARSEAPI cusparseXcsr2gebsrNnz(cusparseHandle_t handle,
+                                                   cusparseDirection_t dirA,
+                                                   int m,
+                                                   int n,
+                                                   const cusparseMatDescr_t descrA,
+                                                   const int *csrSortedRowPtrA,
+                                                   const int *csrSortedColIndA,
+                                                   const cusparseMatDescr_t descrC,
+                                                   int *bsrSortedRowPtrC,
+                                                   int rowBlockDim,
+                                                   int colBlockDim,
+                                                   int *nnzTotalDevHostPtr,
+                                                   void *pBuffer ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const int *, const int *, const cusparseMatDescr_t, int *, int, int, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcsr2gebsrNnz");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedRowPtrA,
-                  csrSortedColIndA, descrC, bsrSortedRowPtrC, rowBlockDim,
-                  colBlockDim, nnzTotalDevHostPtr, pBuffer);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedRowPtrA, csrSortedColIndA, descrC, bsrSortedRowPtrC, rowBlockDim, colBlockDim, nnzTotalDevHostPtr, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsr2gebsr(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
-    const cusparseMatDescr_t descrA, const float *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    const cusparseMatDescr_t descrC, float *bsrSortedValC,
-    int *bsrSortedRowPtrC, int *bsrSortedColIndC, int rowBlockDim,
-    int colBlockDim, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const float *, const int *, const int *, const cusparseMatDescr_t,
-      float *, int *, int *, int, int, void *);
+cusparseStatus_t CUSPARSEAPI cusparseScsr2gebsr(cusparseHandle_t handle,
+                                                cusparseDirection_t dirA,
+                                                int m,
+                                                int n,
+                                                const cusparseMatDescr_t descrA,
+                                                const float *csrSortedValA,
+                                                const int *csrSortedRowPtrA,
+                                                const int *csrSortedColIndA,
+                                                const cusparseMatDescr_t descrC,
+                                                float *bsrSortedValC,
+                                                int *bsrSortedRowPtrC,
+                                                int *bsrSortedColIndC,
+                                                int rowBlockDim,
+                                                int colBlockDim,
+                                                void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, const cusparseMatDescr_t, float *, int *, int *, int, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsr2gebsr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, descrC, bsrSortedValC, bsrSortedRowPtrC,
-                  bsrSortedColIndC, rowBlockDim, colBlockDim, pBuffer);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, descrC, bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC, rowBlockDim, colBlockDim, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsr2gebsr(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
-    const cusparseMatDescr_t descrA, const double *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    const cusparseMatDescr_t descrC, double *bsrSortedValC,
-    int *bsrSortedRowPtrC, int *bsrSortedColIndC, int rowBlockDim,
-    int colBlockDim, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const double *, const int *, const int *, const cusparseMatDescr_t,
-      double *, int *, int *, int, int, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsr2gebsr(cusparseHandle_t handle,
+                                                cusparseDirection_t dirA,
+                                                int m,
+                                                int n,
+                                                const cusparseMatDescr_t descrA,
+                                                const double *csrSortedValA,
+                                                const int *csrSortedRowPtrA,
+                                                const int *csrSortedColIndA,
+                                                const cusparseMatDescr_t descrC,
+                                                double *bsrSortedValC,
+                                                int *bsrSortedRowPtrC,
+                                                int *bsrSortedColIndC,
+                                                int rowBlockDim,
+                                                int colBlockDim,
+                                                void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, const cusparseMatDescr_t, double *, int *, int *, int, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsr2gebsr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, descrC, bsrSortedValC, bsrSortedRowPtrC,
-                  bsrSortedColIndC, rowBlockDim, colBlockDim, pBuffer);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, descrC, bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC, rowBlockDim, colBlockDim, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsr2gebsr(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
-    const cusparseMatDescr_t descrA, const cuComplex *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    const cusparseMatDescr_t descrC, cuComplex *bsrSortedValC,
-    int *bsrSortedRowPtrC, int *bsrSortedColIndC, int rowBlockDim,
-    int colBlockDim, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const cuComplex *, const int *, const int *, const cusparseMatDescr_t,
-      cuComplex *, int *, int *, int, int, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsr2gebsr(cusparseHandle_t handle,
+                                                cusparseDirection_t dirA,
+                                                int m,
+                                                int n,
+                                                const cusparseMatDescr_t descrA,
+                                                const cuComplex *csrSortedValA,
+                                                const int *csrSortedRowPtrA,
+                                                const int *csrSortedColIndA,
+                                                const cusparseMatDescr_t descrC,
+                                                cuComplex *bsrSortedValC,
+                                                int *bsrSortedRowPtrC,
+                                                int *bsrSortedColIndC,
+                                                int rowBlockDim,
+                                                int colBlockDim,
+                                                void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, const cusparseMatDescr_t, cuComplex *, int *, int *, int, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsr2gebsr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, descrC, bsrSortedValC, bsrSortedRowPtrC,
-                  bsrSortedColIndC, rowBlockDim, colBlockDim, pBuffer);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, descrC, bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC, rowBlockDim, colBlockDim, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsr2gebsr(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
-    const cusparseMatDescr_t descrA, const cuDoubleComplex *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    const cusparseMatDescr_t descrC, cuDoubleComplex *bsrSortedValC,
-    int *bsrSortedRowPtrC, int *bsrSortedColIndC, int rowBlockDim,
-    int colBlockDim, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
-      const cuDoubleComplex *, const int *, const int *,
-      const cusparseMatDescr_t, cuDoubleComplex *, int *, int *, int, int,
-      void *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsr2gebsr(cusparseHandle_t handle,
+                                                cusparseDirection_t dirA,
+                                                int m,
+                                                int n,
+                                                const cusparseMatDescr_t descrA,
+                                                const cuDoubleComplex *csrSortedValA,
+                                                const int *csrSortedRowPtrA,
+                                                const int *csrSortedColIndA,
+                                                const cusparseMatDescr_t descrC,
+                                                cuDoubleComplex *bsrSortedValC,
+                                                int *bsrSortedRowPtrC,
+                                                int *bsrSortedColIndC,
+                                                int rowBlockDim,
+                                                int colBlockDim,
+                                                void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, const cusparseMatDescr_t, cuDoubleComplex *, int *, int *, int, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsr2gebsr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, descrC, bsrSortedValC, bsrSortedRowPtrC,
-                  bsrSortedColIndC, rowBlockDim, colBlockDim, pBuffer);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, descrC, bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC, rowBlockDim, colBlockDim, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSgebsr2gebsr_bufferSize(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb, int nnzb,
-    const cusparseMatDescr_t descrA, const float *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDimA,
-    int colBlockDimA, int rowBlockDimC, int colBlockDimC,
-    int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, int,
-      const cusparseMatDescr_t, const float *, const int *, const int *, int,
-      int, int, int, int *);
+cusparseStatus_t CUSPARSEAPI cusparseSgebsr2gebsr_bufferSize(cusparseHandle_t handle,
+                                                             cusparseDirection_t dirA,
+                                                             int mb,
+                                                             int nb,
+                                                             int nnzb,
+                                                             const cusparseMatDescr_t descrA,
+                                                             const float *bsrSortedValA,
+                                                             const int *bsrSortedRowPtrA,
+                                                             const int *bsrSortedColIndA,
+                                                             int rowBlockDimA,
+                                                             int colBlockDimA,
+                                                             int rowBlockDimC,
+                                                             int colBlockDimC,
+                                                             int *pBufferSizeInBytes ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, int, int, int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgebsr2gebsr_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA,
-                  bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA,
-                  colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA, colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDgebsr2gebsr_bufferSize(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb, int nnzb,
-    const cusparseMatDescr_t descrA, const double *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDimA,
-    int colBlockDimA, int rowBlockDimC, int colBlockDimC,
-    int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, int,
-      const cusparseMatDescr_t, const double *, const int *, const int *, int,
-      int, int, int, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDgebsr2gebsr_bufferSize(cusparseHandle_t handle,
+                                                             cusparseDirection_t dirA,
+                                                             int mb,
+                                                             int nb,
+                                                             int nnzb,
+                                                             const cusparseMatDescr_t descrA,
+                                                             const double *bsrSortedValA,
+                                                             const int *bsrSortedRowPtrA,
+                                                             const int *bsrSortedColIndA,
+                                                             int rowBlockDimA,
+                                                             int colBlockDimA,
+                                                             int rowBlockDimC,
+                                                             int colBlockDimC,
+                                                             int *pBufferSizeInBytes ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, int, int, int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgebsr2gebsr_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA,
-                  bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA,
-                  colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA, colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCgebsr2gebsr_bufferSize(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb, int nnzb,
-    const cusparseMatDescr_t descrA, const cuComplex *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDimA,
-    int colBlockDimA, int rowBlockDimC, int colBlockDimC,
-    int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, int,
-      const cusparseMatDescr_t, const cuComplex *, const int *, const int *,
-      int, int, int, int, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCgebsr2gebsr_bufferSize(cusparseHandle_t handle,
+                                                             cusparseDirection_t dirA,
+                                                             int mb,
+                                                             int nb,
+                                                             int nnzb,
+                                                             const cusparseMatDescr_t descrA,
+                                                             const cuComplex *bsrSortedValA,
+                                                             const int *bsrSortedRowPtrA,
+                                                             const int *bsrSortedColIndA,
+                                                             int rowBlockDimA,
+                                                             int colBlockDimA,
+                                                             int rowBlockDimC,
+                                                             int colBlockDimC,
+                                                             int *pBufferSizeInBytes ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, int, int, int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgebsr2gebsr_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA,
-                  bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA,
-                  colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA, colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZgebsr2gebsr_bufferSize(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb, int nnzb,
-    const cusparseMatDescr_t descrA, const cuDoubleComplex *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDimA,
-    int colBlockDimA, int rowBlockDimC, int colBlockDimC,
-    int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, int,
-      const cusparseMatDescr_t, const cuDoubleComplex *, const int *,
-      const int *, int, int, int, int, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZgebsr2gebsr_bufferSize(cusparseHandle_t handle,
+                                                             cusparseDirection_t dirA,
+                                                             int mb,
+                                                             int nb,
+                                                             int nnzb,
+                                                             const cusparseMatDescr_t descrA,
+                                                             const cuDoubleComplex *bsrSortedValA,
+                                                             const int *bsrSortedRowPtrA,
+                                                             const int *bsrSortedColIndA,
+                                                             int rowBlockDimA,
+                                                             int colBlockDimA,
+                                                             int rowBlockDimC,
+                                                             int colBlockDimC,
+                                                             int *pBufferSizeInBytes ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, int, int, int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgebsr2gebsr_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA,
-                  bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA,
-                  colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA, colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSgebsr2gebsr_bufferSizeExt(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb, int nnzb,
-    const cusparseMatDescr_t descrA, const float *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDimA,
-    int colBlockDimA, int rowBlockDimC, int colBlockDimC, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, int,
-      const cusparseMatDescr_t, const float *, const int *, const int *, int,
-      int, int, int, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseSgebsr2gebsr_bufferSizeExt");
+cusparseStatus_t CUSPARSEAPI cusparseSgebsr2gebsr_bufferSizeExt(cusparseHandle_t handle,
+                                                                cusparseDirection_t dirA,
+                                                                int mb,
+                                                                int nb,
+                                                                int nnzb,
+                                                                const cusparseMatDescr_t descrA,
+                                                                const float *bsrSortedValA,
+                                                                const int    *bsrSortedRowPtrA,
+                                                                const int    *bsrSortedColIndA,
+                                                                int   rowBlockDimA,
+                                                                int   colBlockDimA,
+                                                                int   rowBlockDimC,
+                                                                int   colBlockDimC,
+                                                                size_t  *pBufferSize ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, int, const cusparseMatDescr_t, const float *, const int    *, const int    *, int, int, int, int, size_t  *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgebsr2gebsr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA,
-                  bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA,
-                  colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSize);
+  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA, colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDgebsr2gebsr_bufferSizeExt(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb, int nnzb,
-    const cusparseMatDescr_t descrA, const double *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDimA,
-    int colBlockDimA, int rowBlockDimC, int colBlockDimC, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, int,
-      const cusparseMatDescr_t, const double *, const int *, const int *, int,
-      int, int, int, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseDgebsr2gebsr_bufferSizeExt");
+cusparseStatus_t CUSPARSEAPI cusparseDgebsr2gebsr_bufferSizeExt(cusparseHandle_t handle,
+                                                                cusparseDirection_t dirA,
+                                                                int mb,
+                                                                int nb,
+                                                                int nnzb,
+                                                                const cusparseMatDescr_t descrA,
+                                                                const double *bsrSortedValA,
+                                                                const int    *bsrSortedRowPtrA,
+                                                                const int    *bsrSortedColIndA,
+                                                                int   rowBlockDimA,
+                                                                int   colBlockDimA,
+                                                                int   rowBlockDimC,
+                                                                int   colBlockDimC,
+                                                                size_t  *pBufferSize ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, int, const cusparseMatDescr_t, const double *, const int    *, const int    *, int, int, int, int, size_t  *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgebsr2gebsr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA,
-                  bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA,
-                  colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSize);
+  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA, colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCgebsr2gebsr_bufferSizeExt(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb, int nnzb,
-    const cusparseMatDescr_t descrA, const cuComplex *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDimA,
-    int colBlockDimA, int rowBlockDimC, int colBlockDimC, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, int,
-      const cusparseMatDescr_t, const cuComplex *, const int *, const int *,
-      int, int, int, int, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseCgebsr2gebsr_bufferSizeExt");
+cusparseStatus_t CUSPARSEAPI cusparseCgebsr2gebsr_bufferSizeExt(cusparseHandle_t handle,
+                                                                cusparseDirection_t dirA,
+                                                                int mb,
+                                                                int nb,
+                                                                int nnzb,
+                                                                const cusparseMatDescr_t descrA,
+                                                                const cuComplex *bsrSortedValA,
+                                                                const int    *bsrSortedRowPtrA,
+                                                                const int    *bsrSortedColIndA,
+                                                                int   rowBlockDimA,
+                                                                int   colBlockDimA,
+                                                                int   rowBlockDimC,
+                                                                int   colBlockDimC,
+                                                                size_t  *pBufferSize ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, int, const cusparseMatDescr_t, const cuComplex *, const int    *, const int    *, int, int, int, int, size_t  *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgebsr2gebsr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA,
-                  bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA,
-                  colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSize);
+  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA, colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZgebsr2gebsr_bufferSizeExt(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb, int nnzb,
-    const cusparseMatDescr_t descrA, const cuDoubleComplex *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDimA,
-    int colBlockDimA, int rowBlockDimC, int colBlockDimC, size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, int,
-      const cusparseMatDescr_t, const cuDoubleComplex *, const int *,
-      const int *, int, int, int, int, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseZgebsr2gebsr_bufferSizeExt");
+cusparseStatus_t CUSPARSEAPI cusparseZgebsr2gebsr_bufferSizeExt(cusparseHandle_t handle,
+                                                                cusparseDirection_t dirA,
+                                                                int mb,
+                                                                int nb,
+                                                                int nnzb,
+                                                                const cusparseMatDescr_t descrA,
+                                                                const cuDoubleComplex *bsrSortedValA,
+                                                                const int    *bsrSortedRowPtrA,
+                                                                const int    *bsrSortedColIndA,
+                                                                int   rowBlockDimA,
+                                                                int   colBlockDimA,
+                                                                int   rowBlockDimC,
+                                                                int   colBlockDimC,
+                                                                size_t  *pBufferSize ) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int    *, const int    *, int, int, int, int, size_t  *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgebsr2gebsr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA,
-                  bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA,
-                  colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSize);
+  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA, colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseXgebsr2gebsrNnz(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb, int nnzb,
-    const cusparseMatDescr_t descrA, const int *bsrSortedRowPtrA,
-    const int *bsrSortedColIndA, int rowBlockDimA, int colBlockDimA,
-    const cusparseMatDescr_t descrC, int *bsrSortedRowPtrC, int rowBlockDimC,
-    int colBlockDimC, int *nnzTotalDevHostPtr, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, int,
-      const cusparseMatDescr_t, const int *, const int *, int, int,
-      const cusparseMatDescr_t, int *, int, int, int *, void *);
+cusparseStatus_t CUSPARSEAPI cusparseXgebsr2gebsrNnz(cusparseHandle_t handle,
+                                                     cusparseDirection_t dirA,
+                                                     int mb,
+                                                     int nb,
+                                                     int nnzb,
+                                                     const cusparseMatDescr_t descrA,
+                                                     const int *bsrSortedRowPtrA,
+                                                     const int *bsrSortedColIndA,
+                                                     int rowBlockDimA,
+                                                     int colBlockDimA,
+                                                     const cusparseMatDescr_t descrC,
+                                                     int *bsrSortedRowPtrC,
+                                                     int rowBlockDimC,
+                                                     int colBlockDimC,
+                                                     int *nnzTotalDevHostPtr,
+                                                     void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, int, const cusparseMatDescr_t, const int *, const int *, int, int, const cusparseMatDescr_t, int *, int, int, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXgebsr2gebsrNnz");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedRowPtrA,
-                  bsrSortedColIndA, rowBlockDimA, colBlockDimA, descrC,
-                  bsrSortedRowPtrC, rowBlockDimC, colBlockDimC,
-                  nnzTotalDevHostPtr, pBuffer);
+  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA, colBlockDimA, descrC, bsrSortedRowPtrC, rowBlockDimC, colBlockDimC, nnzTotalDevHostPtr, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSgebsr2gebsr(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb, int nnzb,
-    const cusparseMatDescr_t descrA, const float *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDimA,
-    int colBlockDimA, const cusparseMatDescr_t descrC, float *bsrSortedValC,
-    int *bsrSortedRowPtrC, int *bsrSortedColIndC, int rowBlockDimC,
-    int colBlockDimC, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, int,
-      const cusparseMatDescr_t, const float *, const int *, const int *, int,
-      int, const cusparseMatDescr_t, float *, int *, int *, int, int, void *);
+cusparseStatus_t CUSPARSEAPI cusparseSgebsr2gebsr(cusparseHandle_t handle,
+                                                  cusparseDirection_t dirA,
+                                                  int mb,
+                                                  int nb,
+                                                  int nnzb,
+                                                  const cusparseMatDescr_t descrA,
+                                                  const float *bsrSortedValA,
+                                                  const int *bsrSortedRowPtrA,
+                                                  const int *bsrSortedColIndA,
+                                                  int rowBlockDimA,
+                                                  int colBlockDimA,
+                                                  const cusparseMatDescr_t descrC,
+                                                  float *bsrSortedValC,
+                                                  int *bsrSortedRowPtrC,
+                                                  int *bsrSortedColIndC,
+                                                  int rowBlockDimC,
+                                                  int colBlockDimC,
+                                                  void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, int, int, const cusparseMatDescr_t, float *, int *, int *, int, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgebsr2gebsr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA,
-                  bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA,
-                  colBlockDimA, descrC, bsrSortedValC, bsrSortedRowPtrC,
-                  bsrSortedColIndC, rowBlockDimC, colBlockDimC, pBuffer);
+  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA, colBlockDimA, descrC, bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC, rowBlockDimC, colBlockDimC, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDgebsr2gebsr(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb, int nnzb,
-    const cusparseMatDescr_t descrA, const double *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDimA,
-    int colBlockDimA, const cusparseMatDescr_t descrC, double *bsrSortedValC,
-    int *bsrSortedRowPtrC, int *bsrSortedColIndC, int rowBlockDimC,
-    int colBlockDimC, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, int,
-      const cusparseMatDescr_t, const double *, const int *, const int *, int,
-      int, const cusparseMatDescr_t, double *, int *, int *, int, int, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDgebsr2gebsr(cusparseHandle_t handle,
+                                                  cusparseDirection_t dirA,
+                                                  int mb,
+                                                  int nb,
+                                                  int nnzb,
+                                                  const cusparseMatDescr_t descrA,
+                                                  const double *bsrSortedValA,
+                                                  const int *bsrSortedRowPtrA,
+                                                  const int *bsrSortedColIndA,
+                                                  int rowBlockDimA,
+                                                  int colBlockDimA,
+                                                  const cusparseMatDescr_t descrC,
+                                                  double *bsrSortedValC,
+                                                  int *bsrSortedRowPtrC,
+                                                  int *bsrSortedColIndC,
+                                                  int rowBlockDimC,
+                                                  int colBlockDimC,
+                                                  void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, int, int, const cusparseMatDescr_t, double *, int *, int *, int, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgebsr2gebsr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA,
-                  bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA,
-                  colBlockDimA, descrC, bsrSortedValC, bsrSortedRowPtrC,
-                  bsrSortedColIndC, rowBlockDimC, colBlockDimC, pBuffer);
+  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA, colBlockDimA, descrC, bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC, rowBlockDimC, colBlockDimC, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCgebsr2gebsr(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb, int nnzb,
-    const cusparseMatDescr_t descrA, const cuComplex *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDimA,
-    int colBlockDimA, const cusparseMatDescr_t descrC, cuComplex *bsrSortedValC,
-    int *bsrSortedRowPtrC, int *bsrSortedColIndC, int rowBlockDimC,
-    int colBlockDimC, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, int,
-      const cusparseMatDescr_t, const cuComplex *, const int *, const int *,
-      int, int, const cusparseMatDescr_t, cuComplex *, int *, int *, int, int,
-      void *);
+cusparseStatus_t CUSPARSEAPI cusparseCgebsr2gebsr(cusparseHandle_t handle,
+                                                  cusparseDirection_t dirA,
+                                                  int mb,
+                                                  int nb,
+                                                  int nnzb,
+                                                  const cusparseMatDescr_t descrA,
+                                                  const cuComplex *bsrSortedValA,
+                                                  const int *bsrSortedRowPtrA,
+                                                  const int *bsrSortedColIndA,
+                                                  int rowBlockDimA,
+                                                  int colBlockDimA,
+                                                  const cusparseMatDescr_t descrC,
+                                                  cuComplex *bsrSortedValC,
+                                                  int *bsrSortedRowPtrC,
+                                                  int *bsrSortedColIndC,
+                                                  int rowBlockDimC,
+                                                  int colBlockDimC,
+                                                  void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, int, int, const cusparseMatDescr_t, cuComplex *, int *, int *, int, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgebsr2gebsr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA,
-                  bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA,
-                  colBlockDimA, descrC, bsrSortedValC, bsrSortedRowPtrC,
-                  bsrSortedColIndC, rowBlockDimC, colBlockDimC, pBuffer);
+  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA, colBlockDimA, descrC, bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC, rowBlockDimC, colBlockDimC, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZgebsr2gebsr(
-    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb, int nnzb,
-    const cusparseMatDescr_t descrA, const cuDoubleComplex *bsrSortedValA,
-    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDimA,
-    int colBlockDimA, const cusparseMatDescr_t descrC,
-    cuDoubleComplex *bsrSortedValC, int *bsrSortedRowPtrC,
-    int *bsrSortedColIndC, int rowBlockDimC, int colBlockDimC, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseDirection_t, int, int, int,
-      const cusparseMatDescr_t, const cuDoubleComplex *, const int *,
-      const int *, int, int, const cusparseMatDescr_t, cuDoubleComplex *, int *,
-      int *, int, int, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZgebsr2gebsr(cusparseHandle_t handle,
+                                                  cusparseDirection_t dirA,
+                                                  int mb,
+                                                  int nb,
+                                                  int nnzb,
+                                                  const cusparseMatDescr_t descrA,
+                                                  const cuDoubleComplex *bsrSortedValA,
+                                                  const int *bsrSortedRowPtrA,
+                                                  const int *bsrSortedColIndA,
+                                                  int rowBlockDimA,
+                                                  int colBlockDimA,
+                                                  const cusparseMatDescr_t descrC,
+                                                  cuDoubleComplex *bsrSortedValC,
+                                                  int *bsrSortedRowPtrC,
+                                                  int *bsrSortedColIndC,
+                                                  int rowBlockDimC,
+                                                  int colBlockDimC,
+                                                  void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, int, int, const cusparseMatDescr_t, cuDoubleComplex *, int *, int *, int, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgebsr2gebsr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA,
-                  bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA,
-                  colBlockDimA, descrC, bsrSortedValC, bsrSortedRowPtrC,
-                  bsrSortedColIndC, rowBlockDimC, colBlockDimC, pBuffer);
+  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA, colBlockDimA, descrC, bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC, rowBlockDimC, colBlockDimC, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseCreateIdentityPermutation(cusparseHandle_t handle, int n, int *p) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, int, int *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseCreateIdentityPermutation");
+cusparseStatus_t CUSPARSEAPI cusparseCreateIdentityPermutation(cusparseHandle_t handle,
+                                                               int n,
+                                                               int *p) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateIdentityPermutation");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, n, p);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseXcoosort_bufferSizeExt(
-    cusparseHandle_t handle, int m, int n, int nnz, const int *cooRowsA,
-    const int *cooColsA, size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const int *, const int *, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseXcoosort_bufferSizeExt(cusparseHandle_t handle,
+                                                            int m,
+                                                            int n,
+                                                            int nnz,
+                                                            const int *cooRowsA,
+                                                            const int *cooColsA,
+                                                            size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const int *, const int *, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcoosort_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, nnz, cooRowsA, cooColsA, pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseXcoosortByRow(cusparseHandle_t handle,
-                                                   int m, int n, int nnz,
-                                                   int *cooRowsA, int *cooColsA,
-                                                   int *P, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, int *, int *, int *, void *);
+                                                   int m,
+                                                   int n,
+                                                   int nnz,
+                                                   int *cooRowsA,
+                                                   int *cooColsA,
+                                                   int *P,
+                                                   void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, int *, int *, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcoosortByRow");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, nnz, cooRowsA, cooColsA, P, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseXcoosortByColumn(cusparseHandle_t handle,
-                                                      int m, int n, int nnz,
+                                                      int m,
+                                                      int n,
+                                                      int nnz,
                                                       int *cooRowsA,
-                                                      int *cooColsA, int *P,
+                                                      int *cooColsA,
+                                                      int *P,
                                                       void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, int *, int *, int *, void *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, int *, int *, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcoosortByColumn");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, nnz, cooRowsA, cooColsA, P, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseXcsrsort_bufferSizeExt(
-    cusparseHandle_t handle, int m, int n, int nnz, const int *csrRowPtrA,
-    const int *csrColIndA, size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const int *, const int *, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseXcsrsort_bufferSizeExt(cusparseHandle_t handle,
+                                                            int m,
+                                                            int n,
+                                                            int nnz,
+                                                            const int *csrRowPtrA,
+                                                            const int *csrColIndA,
+                                                            size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const int *, const int *, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcsrsort_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, csrRowPtrA, csrColIndA,
-                  pBufferSizeInBytes);
+  return func_ptr(handle, m, n, nnz, csrRowPtrA, csrColIndA, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseXcsrsort(cusparseHandle_t handle, int m,
-                                              int n, int nnz,
+cusparseStatus_t CUSPARSEAPI cusparseXcsrsort(cusparseHandle_t handle,
+                                              int m,
+                                              int n,
+                                              int nnz,
                                               const cusparseMatDescr_t descrA,
                                               const int *csrRowPtrA,
-                                              int *csrColIndA, int *P,
+                                              int *csrColIndA,
+                                              int *P,
                                               void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const int *,
-      int *, int *, void *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const int *, int *, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcsrsort");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, descrA, csrRowPtrA, csrColIndA, P,
-                  pBuffer);
+  return func_ptr(handle, m, n, nnz, descrA, csrRowPtrA, csrColIndA, P, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseXcscsort_bufferSizeExt(
-    cusparseHandle_t handle, int m, int n, int nnz, const int *cscColPtrA,
-    const int *cscRowIndA, size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const int *, const int *, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseXcscsort_bufferSizeExt(cusparseHandle_t handle,
+                                                            int m,
+                                                            int n,
+                                                            int nnz,
+                                                            const int *cscColPtrA,
+                                                            const int *cscRowIndA,
+                                                            size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const int *, const int *, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcscsort_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, cscColPtrA, cscRowIndA,
-                  pBufferSizeInBytes);
+  return func_ptr(handle, m, n, nnz, cscColPtrA, cscRowIndA, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseXcscsort(cusparseHandle_t handle, int m,
-                                              int n, int nnz,
+cusparseStatus_t CUSPARSEAPI cusparseXcscsort(cusparseHandle_t handle,
+                                              int m,
+                                              int n,
+                                              int nnz,
                                               const cusparseMatDescr_t descrA,
                                               const int *cscColPtrA,
-                                              int *cscRowIndA, int *P,
+                                              int *cscRowIndA,
+                                              int *P,
                                               void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const int *,
-      int *, int *, void *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const int *, int *, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcscsort");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, descrA, cscColPtrA, cscRowIndA, P,
-                  pBuffer);
+  return func_ptr(handle, m, n, nnz, descrA, cscColPtrA, cscRowIndA, P, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsru2csr_bufferSizeExt(
-    cusparseHandle_t handle, int m, int n, int nnz, float *csrVal,
-    const int *csrRowPtr, int *csrColInd, csru2csrInfo_t info,
-    size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, float *, const int *, int *,
-      csru2csrInfo_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseScsru2csr_bufferSizeExt(cusparseHandle_t handle,
+                                                             int m,
+                                                             int n,
+                                                             int nnz,
+                                                             float *csrVal,
+                                                             const int *csrRowPtr,
+                                                             int *csrColInd,
+                                                             csru2csrInfo_t  info,
+                                                             size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, float *, const int *, int *, csru2csrInfo_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsru2csr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, csrVal, csrRowPtr, csrColInd, info,
-                  pBufferSizeInBytes);
+  return func_ptr(handle, m, n, nnz, csrVal, csrRowPtr, csrColInd, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsru2csr_bufferSizeExt(
-    cusparseHandle_t handle, int m, int n, int nnz, double *csrVal,
-    const int *csrRowPtr, int *csrColInd, csru2csrInfo_t info,
-    size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, double *, const int *, int *,
-      csru2csrInfo_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsru2csr_bufferSizeExt(cusparseHandle_t handle,
+                                                             int m,
+                                                             int n,
+                                                             int nnz,
+                                                             double *csrVal,
+                                                             const int *csrRowPtr,
+                                                             int *csrColInd,
+                                                             csru2csrInfo_t  info,
+                                                             size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, double *, const int *, int *, csru2csrInfo_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsru2csr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, csrVal, csrRowPtr, csrColInd, info,
-                  pBufferSizeInBytes);
+  return func_ptr(handle, m, n, nnz, csrVal, csrRowPtr, csrColInd, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsru2csr_bufferSizeExt(
-    cusparseHandle_t handle, int m, int n, int nnz, cuComplex *csrVal,
-    const int *csrRowPtr, int *csrColInd, csru2csrInfo_t info,
-    size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, cuComplex *, const int *, int *,
-      csru2csrInfo_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsru2csr_bufferSizeExt(cusparseHandle_t handle,
+                                                             int m,
+                                                             int n,
+                                                             int nnz,
+                                                             cuComplex *csrVal,
+                                                             const int *csrRowPtr,
+                                                             int *csrColInd,
+                                                             csru2csrInfo_t  info,
+                                                             size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, cuComplex *, const int *, int *, csru2csrInfo_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsru2csr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, csrVal, csrRowPtr, csrColInd, info,
-                  pBufferSizeInBytes);
+  return func_ptr(handle, m, n, nnz, csrVal, csrRowPtr, csrColInd, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsru2csr_bufferSizeExt(
-    cusparseHandle_t handle, int m, int n, int nnz, cuDoubleComplex *csrVal,
-    const int *csrRowPtr, int *csrColInd, csru2csrInfo_t info,
-    size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, cuDoubleComplex *, const int *, int *,
-      csru2csrInfo_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsru2csr_bufferSizeExt(cusparseHandle_t handle,
+                                                             int m,
+                                                             int n,
+                                                             int nnz,
+                                                             cuDoubleComplex *csrVal,
+                                                             const int *csrRowPtr,
+                                                             int *csrColInd,
+                                                             csru2csrInfo_t  info,
+                                                             size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, cuDoubleComplex *, const int *, int *, csru2csrInfo_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsru2csr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, csrVal, csrRowPtr, csrColInd, info,
-                  pBufferSizeInBytes);
+  return func_ptr(handle, m, n, nnz, csrVal, csrRowPtr, csrColInd, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsru2csr(
-    cusparseHandle_t handle, int m, int n, int nnz,
-    const cusparseMatDescr_t descrA, float *csrVal, const int *csrRowPtr,
-    int *csrColInd, csru2csrInfo_t info, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, float *,
-      const int *, int *, csru2csrInfo_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseScsru2csr(cusparseHandle_t handle,
+                                               int m,
+                                               int n,
+                                               int nnz,
+                                               const cusparseMatDescr_t descrA,
+                                               float *csrVal,
+                                               const int *csrRowPtr,
+                                               int *csrColInd,
+                                               csru2csrInfo_t  info,
+                                               void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, float *, const int *, int *, csru2csrInfo_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsru2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info,
-                  pBuffer);
+  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsru2csr(
-    cusparseHandle_t handle, int m, int n, int nnz,
-    const cusparseMatDescr_t descrA, double *csrVal, const int *csrRowPtr,
-    int *csrColInd, csru2csrInfo_t info, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, double *,
-      const int *, int *, csru2csrInfo_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsru2csr(cusparseHandle_t handle,
+                                               int m,
+                                               int n,
+                                               int nnz,
+                                               const cusparseMatDescr_t descrA,
+                                               double *csrVal,
+                                               const int *csrRowPtr,
+                                               int *csrColInd,
+                                               csru2csrInfo_t  info,
+                                               void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, double *, const int *, int *, csru2csrInfo_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsru2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info,
-                  pBuffer);
+  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsru2csr(
-    cusparseHandle_t handle, int m, int n, int nnz,
-    const cusparseMatDescr_t descrA, cuComplex *csrVal, const int *csrRowPtr,
-    int *csrColInd, csru2csrInfo_t info, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, cuComplex *,
-      const int *, int *, csru2csrInfo_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsru2csr(cusparseHandle_t handle,
+                                               int m,
+                                               int n,
+                                               int nnz,
+                                               const cusparseMatDescr_t descrA,
+                                               cuComplex *csrVal,
+                                               const int *csrRowPtr,
+                                               int *csrColInd,
+                                               csru2csrInfo_t  info,
+                                               void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, cuComplex *, const int *, int *, csru2csrInfo_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsru2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info,
-                  pBuffer);
+  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsru2csr(
-    cusparseHandle_t handle, int m, int n, int nnz,
-    const cusparseMatDescr_t descrA, cuDoubleComplex *csrVal,
-    const int *csrRowPtr, int *csrColInd, csru2csrInfo_t info, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cusparseMatDescr_t,
-      cuDoubleComplex *, const int *, int *, csru2csrInfo_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsru2csr(cusparseHandle_t handle,
+                                               int m,
+                                               int n,
+                                               int nnz,
+                                               const cusparseMatDescr_t descrA,
+                                               cuDoubleComplex *csrVal,
+                                               const int *csrRowPtr,
+                                               int *csrColInd,
+                                               csru2csrInfo_t  info,
+                                               void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, int *, csru2csrInfo_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsru2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info,
-                  pBuffer);
+  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsr2csru(
-    cusparseHandle_t handle, int m, int n, int nnz,
-    const cusparseMatDescr_t descrA, float *csrVal, const int *csrRowPtr,
-    int *csrColInd, csru2csrInfo_t info, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, float *,
-      const int *, int *, csru2csrInfo_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseScsr2csru(cusparseHandle_t handle,
+                                               int m,
+                                               int n,
+                                               int nnz,
+                                               const cusparseMatDescr_t descrA,
+                                               float *csrVal,
+                                               const int *csrRowPtr,
+                                               int *csrColInd,
+                                               csru2csrInfo_t  info,
+                                               void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, float *, const int *, int *, csru2csrInfo_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsr2csru");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info,
-                  pBuffer);
+  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsr2csru(
-    cusparseHandle_t handle, int m, int n, int nnz,
-    const cusparseMatDescr_t descrA, double *csrVal, const int *csrRowPtr,
-    int *csrColInd, csru2csrInfo_t info, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, double *,
-      const int *, int *, csru2csrInfo_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsr2csru(cusparseHandle_t handle,
+                                               int m,
+                                               int n,
+                                               int nnz,
+                                               const cusparseMatDescr_t descrA,
+                                               double *csrVal,
+                                               const int *csrRowPtr,
+                                               int *csrColInd,
+                                               csru2csrInfo_t  info,
+                                               void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, double *, const int *, int *, csru2csrInfo_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsr2csru");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info,
-                  pBuffer);
+  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsr2csru(
-    cusparseHandle_t handle, int m, int n, int nnz,
-    const cusparseMatDescr_t descrA, cuComplex *csrVal, const int *csrRowPtr,
-    int *csrColInd, csru2csrInfo_t info, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, cuComplex *,
-      const int *, int *, csru2csrInfo_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsr2csru(cusparseHandle_t handle,
+                                               int m,
+                                               int n,
+                                               int nnz,
+                                               const cusparseMatDescr_t descrA,
+                                               cuComplex *csrVal,
+                                               const int *csrRowPtr,
+                                               int *csrColInd,
+                                               csru2csrInfo_t  info,
+                                               void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, cuComplex *, const int *, int *, csru2csrInfo_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsr2csru");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info,
-                  pBuffer);
+  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsr2csru(
-    cusparseHandle_t handle, int m, int n, int nnz,
-    const cusparseMatDescr_t descrA, cuDoubleComplex *csrVal,
-    const int *csrRowPtr, int *csrColInd, csru2csrInfo_t info, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cusparseMatDescr_t,
-      cuDoubleComplex *, const int *, int *, csru2csrInfo_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsr2csru(cusparseHandle_t handle,
+                                               int m,
+                                               int n,
+                                               int nnz,
+                                               const cusparseMatDescr_t descrA,
+                                               cuDoubleComplex *csrVal,
+                                               const int *csrRowPtr,
+                                               int *csrColInd,
+                                               csru2csrInfo_t  info,
+                                               void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, int *, csru2csrInfo_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsr2csru");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info,
-                  pBuffer);
+  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSpruneDense2csr_bufferSizeExt(
-    cusparseHandle_t handle, int m, int n, const float *A, int lda,
-    const float *threshold, const cusparseMatDescr_t descrC,
-    const float *csrSortedValC, const int *csrSortedRowPtrC,
-    const int *csrSortedColIndC, size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const float *, int, const float *,
-      const cusparseMatDescr_t, const float *, const int *, const int *,
-      size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseSpruneDense2csr_bufferSizeExt");
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const float *A,
+    int lda,
+    const float *threshold,
+    const cusparseMatDescr_t descrC,
+    const float *csrSortedValC,
+    const int *csrSortedRowPtrC,
+    const int *csrSortedColIndC,
+    size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, int, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpruneDense2csr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, A, lda, threshold, descrC, csrSortedValC,
-                  csrSortedRowPtrC, csrSortedColIndC, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, A, lda, threshold, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDpruneDense2csr_bufferSizeExt(
-    cusparseHandle_t handle, int m, int n, const double *A, int lda,
-    const double *threshold, const cusparseMatDescr_t descrC,
-    const double *csrSortedValC, const int *csrSortedRowPtrC,
-    const int *csrSortedColIndC, size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const double *, int, const double *,
-      const cusparseMatDescr_t, const double *, const int *, const int *,
-      size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseDpruneDense2csr_bufferSizeExt");
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const double *A,
+    int lda,
+    const double *threshold,
+    const cusparseMatDescr_t descrC,
+    const double *csrSortedValC,
+    const int *csrSortedRowPtrC,
+    const int *csrSortedColIndC,
+    size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDpruneDense2csr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, A, lda, threshold, descrC, csrSortedValC,
-                  csrSortedRowPtrC, csrSortedColIndC, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, A, lda, threshold, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSpruneDense2csrNnz(
-    cusparseHandle_t handle, int m, int n, const float *A, int lda,
-    const float *threshold, const cusparseMatDescr_t descrC, int *csrRowPtrC,
-    int *nnzTotalDevHostPtr, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const float *, int, const float *,
-      const cusparseMatDescr_t, int *, int *, void *);
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const float *A,
+    int lda,
+    const float *threshold,
+    const cusparseMatDescr_t descrC,
+    int *csrRowPtrC,
+    int *nnzTotalDevHostPtr,
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, int, const float *, const cusparseMatDescr_t, int *, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpruneDense2csrNnz");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, A, lda, threshold, descrC, csrRowPtrC,
-                  nnzTotalDevHostPtr, pBuffer);
+  return func_ptr(handle, m, n, A, lda, threshold, descrC, csrRowPtrC, nnzTotalDevHostPtr, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDpruneDense2csrNnz(
-    cusparseHandle_t handle, int m, int n, const double *A, int lda,
-    const double *threshold, const cusparseMatDescr_t descrC,
-    int *csrSortedRowPtrC, int *nnzTotalDevHostPtr, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const double *, int, const double *,
-      const cusparseMatDescr_t, int *, int *, void *);
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const double *A,
+    int lda,
+    const double *threshold,
+    const cusparseMatDescr_t descrC,
+    int *csrSortedRowPtrC,
+    int *nnzTotalDevHostPtr,
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, int, const double *, const cusparseMatDescr_t, int *, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDpruneDense2csrNnz");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, A, lda, threshold, descrC, csrSortedRowPtrC,
-                  nnzTotalDevHostPtr, pBuffer);
+  return func_ptr(handle, m, n, A, lda, threshold, descrC, csrSortedRowPtrC, nnzTotalDevHostPtr, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSpruneDense2csr(
-    cusparseHandle_t handle, int m, int n, const float *A, int lda,
-    const float *threshold, const cusparseMatDescr_t descrC,
-    float *csrSortedValC, const int *csrSortedRowPtrC, int *csrSortedColIndC,
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const float *A,
+    int lda,
+    const float *threshold,
+    const cusparseMatDescr_t descrC,
+    float *csrSortedValC,
+    const int *csrSortedRowPtrC,
+    int *csrSortedColIndC,
     void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const float *, int, const float *,
-      const cusparseMatDescr_t, float *, const int *, int *, void *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, int, const float *, const cusparseMatDescr_t, float *, const int *, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpruneDense2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, A, lda, threshold, descrC, csrSortedValC,
-                  csrSortedRowPtrC, csrSortedColIndC, pBuffer);
+  return func_ptr(handle, m, n, A, lda, threshold, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDpruneDense2csr(
-    cusparseHandle_t handle, int m, int n, const double *A, int lda,
-    const double *threshold, const cusparseMatDescr_t descrC,
-    double *csrSortedValC, const int *csrSortedRowPtrC, int *csrSortedColIndC,
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const double *A,
+    int lda,
+    const double *threshold,
+    const cusparseMatDescr_t descrC,
+    double *csrSortedValC,
+    const int *csrSortedRowPtrC,
+    int *csrSortedColIndC,
     void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const double *, int, const double *,
-      const cusparseMatDescr_t, double *, const int *, int *, void *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, int, const double *, const cusparseMatDescr_t, double *, const int *, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDpruneDense2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, A, lda, threshold, descrC, csrSortedValC,
-                  csrSortedRowPtrC, csrSortedColIndC, pBuffer);
+  return func_ptr(handle, m, n, A, lda, threshold, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSpruneCsr2csr_bufferSizeExt(
-    cusparseHandle_t handle, int m, int n, int nnzA,
-    const cusparseMatDescr_t descrA, const float *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    const float *threshold, const cusparseMatDescr_t descrC,
-    const float *csrSortedValC, const int *csrSortedRowPtrC,
-    const int *csrSortedColIndC, size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const float *,
-      const int *, const int *, const float *, const cusparseMatDescr_t,
-      const float *, const int *, const int *, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseSpruneCsr2csr_bufferSizeExt");
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    int nnzA,
+    const cusparseMatDescr_t descrA,
+    const float *csrSortedValA,
+    const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA,
+    const float *threshold,
+    const cusparseMatDescr_t descrC,
+    const float *csrSortedValC,
+    const int *csrSortedRowPtrC,
+    const int *csrSortedColIndC,
+    size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpruneCsr2csr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, threshold, descrC, csrSortedValC,
-                  csrSortedRowPtrC, csrSortedColIndC, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, threshold, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDpruneCsr2csr_bufferSizeExt(
-    cusparseHandle_t handle, int m, int n, int nnzA,
-    const cusparseMatDescr_t descrA, const double *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    const double *threshold, const cusparseMatDescr_t descrC,
-    const double *csrSortedValC, const int *csrSortedRowPtrC,
-    const int *csrSortedColIndC, size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const double *,
-      const int *, const int *, const double *, const cusparseMatDescr_t,
-      const double *, const int *, const int *, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseDpruneCsr2csr_bufferSizeExt");
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    int nnzA,
+    const cusparseMatDescr_t descrA,
+    const double *csrSortedValA,
+    const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA,
+    const double *threshold,
+    const cusparseMatDescr_t descrC,
+    const double *csrSortedValC,
+    const int *csrSortedRowPtrC,
+    const int *csrSortedColIndC,
+    size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDpruneCsr2csr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, threshold, descrC, csrSortedValC,
-                  csrSortedRowPtrC, csrSortedColIndC, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, threshold, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSpruneCsr2csrNnz(
-    cusparseHandle_t handle, int m, int n, int nnzA,
-    const cusparseMatDescr_t descrA, const float *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    const float *threshold, const cusparseMatDescr_t descrC,
-    int *csrSortedRowPtrC, int *nnzTotalDevHostPtr, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const float *,
-      const int *, const int *, const float *, const cusparseMatDescr_t, int *,
-      int *, void *);
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    int nnzA,
+    const cusparseMatDescr_t descrA,
+    const float *csrSortedValA,
+    const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA,
+    const float *threshold,
+    const cusparseMatDescr_t descrC,
+    int *csrSortedRowPtrC,
+    int *nnzTotalDevHostPtr, /* can be on host or device */
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, const float *, const cusparseMatDescr_t, int *, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpruneCsr2csrNnz");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, threshold, descrC, csrSortedRowPtrC,
-                  nnzTotalDevHostPtr, pBuffer);
+  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, threshold, descrC, csrSortedRowPtrC, nnzTotalDevHostPtr, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDpruneCsr2csrNnz(
-    cusparseHandle_t handle, int m, int n, int nnzA,
-    const cusparseMatDescr_t descrA, const double *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    const double *threshold, const cusparseMatDescr_t descrC,
-    int *csrSortedRowPtrC, int *nnzTotalDevHostPtr, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const double *,
-      const int *, const int *, const double *, const cusparseMatDescr_t, int *,
-      int *, void *);
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    int nnzA,
+    const cusparseMatDescr_t descrA,
+    const double *csrSortedValA,
+    const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA,
+    const double *threshold,
+    const cusparseMatDescr_t descrC,
+    int *csrSortedRowPtrC,
+    int *nnzTotalDevHostPtr, /* can be on host or device */
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, const double *, const cusparseMatDescr_t, int *, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDpruneCsr2csrNnz");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, threshold, descrC, csrSortedRowPtrC,
-                  nnzTotalDevHostPtr, pBuffer);
+  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, threshold, descrC, csrSortedRowPtrC, nnzTotalDevHostPtr, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSpruneCsr2csr(
-    cusparseHandle_t handle, int m, int n, int nnzA,
-    const cusparseMatDescr_t descrA, const float *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    const float *threshold, const cusparseMatDescr_t descrC,
-    float *csrSortedValC, const int *csrSortedRowPtrC, int *csrSortedColIndC,
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    int nnzA,
+    const cusparseMatDescr_t descrA,
+    const float *csrSortedValA,
+    const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA,
+    const float *threshold,
+    const cusparseMatDescr_t descrC,
+    float *csrSortedValC,
+    const int *csrSortedRowPtrC,
+    int *csrSortedColIndC,
     void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const float *,
-      const int *, const int *, const float *, const cusparseMatDescr_t,
-      float *, const int *, int *, void *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, const float *, const cusparseMatDescr_t, float *, const int *, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpruneCsr2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, threshold, descrC, csrSortedValC,
-                  csrSortedRowPtrC, csrSortedColIndC, pBuffer);
+  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, threshold, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDpruneCsr2csr(
-    cusparseHandle_t handle, int m, int n, int nnzA,
-    const cusparseMatDescr_t descrA, const double *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
-    const double *threshold, const cusparseMatDescr_t descrC,
-    double *csrSortedValC, const int *csrSortedRowPtrC, int *csrSortedColIndC,
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    int nnzA,
+    const cusparseMatDescr_t descrA,
+    const double *csrSortedValA,
+    const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA,
+    const double *threshold,
+    const cusparseMatDescr_t descrC,
+    double *csrSortedValC,
+    const int *csrSortedRowPtrC,
+    int *csrSortedColIndC,
     void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const double *,
-      const int *, const int *, const double *, const cusparseMatDescr_t,
-      double *, const int *, int *, void *);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, const double *, const cusparseMatDescr_t, double *, const int *, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDpruneCsr2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, threshold, descrC, csrSortedValC,
-                  csrSortedRowPtrC, csrSortedColIndC, pBuffer);
+  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, threshold, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSpruneDense2csrByPercentage_bufferSizeExt(
-    cusparseHandle_t handle, int m, int n, const float *A, int lda,
-    float percentage, const cusparseMatDescr_t descrC,
-    const float *csrSortedValC, const int *csrSortedRowPtrC,
-    const int *csrSortedColIndC, pruneInfo_t info, size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const float *, int, float,
-      const cusparseMatDescr_t, const float *, const int *, const int *,
-      pruneInfo_t, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseSpruneDense2csrByPercentage_bufferSizeExt");
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const float *A,
+    int lda,
+    float percentage, /* between 0 to 100 */
+    const cusparseMatDescr_t descrC,
+    const float *csrSortedValC,
+    const int *csrSortedRowPtrC,
+    const int *csrSortedColIndC,
+    pruneInfo_t info,
+    size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, int, float, const cusparseMatDescr_t, const float *, const int *, const int *, pruneInfo_t, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpruneDense2csrByPercentage_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, A, lda, percentage, descrC, csrSortedValC,
-                  csrSortedRowPtrC, csrSortedColIndC, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, A, lda, percentage, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, info, pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDpruneDense2csrByPercentage_bufferSizeExt(
-    cusparseHandle_t handle, int m, int n, const double *A, int lda,
-    float percentage, const cusparseMatDescr_t descrC,
-    const double *csrSortedValC, const int *csrSortedRowPtrC,
-    const int *csrSortedColIndC, pruneInfo_t info, size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const double *, int, float,
-      const cusparseMatDescr_t, const double *, const int *, const int *,
-      pruneInfo_t, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseDpruneDense2csrByPercentage_bufferSizeExt");
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const double *A,
+    int lda,
+    float percentage, /* between 0 to 100 */
+    const cusparseMatDescr_t descrC,
+    const double *csrSortedValC,
+    const int *csrSortedRowPtrC,
+    const int *csrSortedColIndC,
+    pruneInfo_t info,
+    size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, int, float, const cusparseMatDescr_t, const double *, const int *, const int *, pruneInfo_t, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDpruneDense2csrByPercentage_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, A, lda, percentage, descrC, csrSortedValC,
-                  csrSortedRowPtrC, csrSortedColIndC, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, A, lda, percentage, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, info, pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSpruneDense2csrNnzByPercentage(
-    cusparseHandle_t handle, int m, int n, const float *A, int lda,
-    float percentage, const cusparseMatDescr_t descrC, int *csrRowPtrC,
-    int *nnzTotalDevHostPtr, pruneInfo_t info, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const float *, int, float,
-      const cusparseMatDescr_t, int *, int *, pruneInfo_t, void *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseSpruneDense2csrNnzByPercentage");
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const float *A,
+    int lda,
+    float percentage, /* between 0 to 100 */
+    const cusparseMatDescr_t descrC,
+    int *csrRowPtrC,
+    int *nnzTotalDevHostPtr, /* can be on host or device */
+    pruneInfo_t info,
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, int, float, const cusparseMatDescr_t, int *, int *, pruneInfo_t, void *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpruneDense2csrNnzByPercentage");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, A, lda, percentage, descrC, csrRowPtrC,
-                  nnzTotalDevHostPtr, info, pBuffer);
+  return func_ptr(handle, m, n, A, lda, percentage, descrC, csrRowPtrC, nnzTotalDevHostPtr, info, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDpruneDense2csrNnzByPercentage(
-    cusparseHandle_t handle, int m, int n, const double *A, int lda,
-    float percentage, const cusparseMatDescr_t descrC, int *csrRowPtrC,
-    int *nnzTotalDevHostPtr, pruneInfo_t info, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const double *, int, float,
-      const cusparseMatDescr_t, int *, int *, pruneInfo_t, void *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseDpruneDense2csrNnzByPercentage");
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const double *A,
+    int lda,
+    float percentage, /* between 0 to 100 */
+    const cusparseMatDescr_t descrC,
+    int *csrRowPtrC,
+    int *nnzTotalDevHostPtr, /* can be on host or device */
+    pruneInfo_t info,
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, int, float, const cusparseMatDescr_t, int *, int *, pruneInfo_t, void *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDpruneDense2csrNnzByPercentage");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, A, lda, percentage, descrC, csrRowPtrC,
-                  nnzTotalDevHostPtr, info, pBuffer);
+  return func_ptr(handle, m, n, A, lda, percentage, descrC, csrRowPtrC, nnzTotalDevHostPtr, info, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSpruneDense2csrByPercentage(
-    cusparseHandle_t handle, int m, int n, const float *A, int lda,
-    float percentage, const cusparseMatDescr_t descrC, float *csrSortedValC,
-    const int *csrSortedRowPtrC, int *csrSortedColIndC, pruneInfo_t info,
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const float *A,
+    int lda,
+    float percentage, /* between 0 to 100 */
+    const cusparseMatDescr_t descrC,
+    float *csrSortedValC,
+    const int *csrSortedRowPtrC,
+    int *csrSortedColIndC,
+    pruneInfo_t info,
     void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const float *, int, float,
-      const cusparseMatDescr_t, float *, const int *, int *, pruneInfo_t,
-      void *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseSpruneDense2csrByPercentage");
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, int, float, const cusparseMatDescr_t, float *, const int *, int *, pruneInfo_t, void *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpruneDense2csrByPercentage");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, A, lda, percentage, descrC, csrSortedValC,
-                  csrSortedRowPtrC, csrSortedColIndC, info, pBuffer);
+  return func_ptr(handle, m, n, A, lda, percentage, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, info, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDpruneDense2csrByPercentage(
-    cusparseHandle_t handle, int m, int n, const double *A, int lda,
-    float percentage, const cusparseMatDescr_t descrC, double *csrSortedValC,
-    const int *csrSortedRowPtrC, int *csrSortedColIndC, pruneInfo_t info,
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    const double *A,
+    int lda,
+    float percentage, /* between 0 to 100 */
+    const cusparseMatDescr_t descrC,
+    double *csrSortedValC,
+    const int *csrSortedRowPtrC,
+    int *csrSortedColIndC,
+    pruneInfo_t info,
     void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, const double *, int, float,
-      const cusparseMatDescr_t, double *, const int *, int *, pruneInfo_t,
-      void *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseDpruneDense2csrByPercentage");
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, int, float, const cusparseMatDescr_t, double *, const int *, int *, pruneInfo_t, void *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDpruneDense2csrByPercentage");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, A, lda, percentage, descrC, csrSortedValC,
-                  csrSortedRowPtrC, csrSortedColIndC, info, pBuffer);
+  return func_ptr(handle, m, n, A, lda, percentage, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, info, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSpruneCsr2csrByPercentage_bufferSizeExt(
-    cusparseHandle_t handle, int m, int n, int nnzA,
-    const cusparseMatDescr_t descrA, const float *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, float percentage,
-    const cusparseMatDescr_t descrC, const float *csrSortedValC,
-    const int *csrSortedRowPtrC, const int *csrSortedColIndC, pruneInfo_t info,
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    int nnzA,
+    const cusparseMatDescr_t descrA,
+    const float *csrSortedValA,
+    const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA,
+    float percentage, /* between 0 to 100 */
+    const cusparseMatDescr_t descrC,
+    const float *csrSortedValC,
+    const int *csrSortedRowPtrC,
+    const int *csrSortedColIndC,
+    pruneInfo_t info,
     size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const float *,
-      const int *, const int *, float, const cusparseMatDescr_t, const float *,
-      const int *, const int *, pruneInfo_t, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseSpruneCsr2csrByPercentage_bufferSizeExt");
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, float, const cusparseMatDescr_t, const float *, const int *, const int *, pruneInfo_t, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpruneCsr2csrByPercentage_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, percentage, descrC, csrSortedValC,
-                  csrSortedRowPtrC, csrSortedColIndC, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, percentage, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, info, pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDpruneCsr2csrByPercentage_bufferSizeExt(
-    cusparseHandle_t handle, int m, int n, int nnzA,
-    const cusparseMatDescr_t descrA, const double *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, float percentage,
-    const cusparseMatDescr_t descrC, const double *csrSortedValC,
-    const int *csrSortedRowPtrC, const int *csrSortedColIndC, pruneInfo_t info,
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    int nnzA,
+    const cusparseMatDescr_t descrA,
+    const double *csrSortedValA,
+    const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA,
+    float percentage, /* between 0 to 100 */
+    const cusparseMatDescr_t descrC,
+    const double *csrSortedValC,
+    const int *csrSortedRowPtrC,
+    const int *csrSortedColIndC,
+    pruneInfo_t info,
     size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const double *,
-      const int *, const int *, float, const cusparseMatDescr_t, const double *,
-      const int *, const int *, pruneInfo_t, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseDpruneCsr2csrByPercentage_bufferSizeExt");
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, float, const cusparseMatDescr_t, const double *, const int *, const int *, pruneInfo_t, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDpruneCsr2csrByPercentage_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, percentage, descrC, csrSortedValC,
-                  csrSortedRowPtrC, csrSortedColIndC, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, percentage, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, info, pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSpruneCsr2csrNnzByPercentage(
-    cusparseHandle_t handle, int m, int n, int nnzA,
-    const cusparseMatDescr_t descrA, const float *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, float percentage,
-    const cusparseMatDescr_t descrC, int *csrSortedRowPtrC,
-    int *nnzTotalDevHostPtr, pruneInfo_t info, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const float *,
-      const int *, const int *, float, const cusparseMatDescr_t, int *, int *,
-      pruneInfo_t, void *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseSpruneCsr2csrNnzByPercentage");
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    int nnzA,
+    const cusparseMatDescr_t descrA,
+    const float *csrSortedValA,
+    const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA,
+    float percentage, /* between 0 to 100 */
+    const cusparseMatDescr_t descrC,
+    int *csrSortedRowPtrC,
+    int *nnzTotalDevHostPtr, /* can be on host or device */
+    pruneInfo_t info,
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, float, const cusparseMatDescr_t, int *, int *, pruneInfo_t, void *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpruneCsr2csrNnzByPercentage");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, percentage, descrC, csrSortedRowPtrC,
-                  nnzTotalDevHostPtr, info, pBuffer);
+  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, percentage, descrC, csrSortedRowPtrC, nnzTotalDevHostPtr, info, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDpruneCsr2csrNnzByPercentage(
-    cusparseHandle_t handle, int m, int n, int nnzA,
-    const cusparseMatDescr_t descrA, const double *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, float percentage,
-    const cusparseMatDescr_t descrC, int *csrSortedRowPtrC,
-    int *nnzTotalDevHostPtr, pruneInfo_t info, void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const double *,
-      const int *, const int *, float, const cusparseMatDescr_t, int *, int *,
-      pruneInfo_t, void *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseDpruneCsr2csrNnzByPercentage");
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    int nnzA,
+    const cusparseMatDescr_t descrA,
+    const double *csrSortedValA,
+    const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA,
+    float percentage, /* between 0 to 100 */
+    const cusparseMatDescr_t descrC,
+    int *csrSortedRowPtrC,
+    int *nnzTotalDevHostPtr, /* can be on host or device */
+    pruneInfo_t info,
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, float, const cusparseMatDescr_t, int *, int *, pruneInfo_t, void *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDpruneCsr2csrNnzByPercentage");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, percentage, descrC, csrSortedRowPtrC,
-                  nnzTotalDevHostPtr, info, pBuffer);
+  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, percentage, descrC, csrSortedRowPtrC, nnzTotalDevHostPtr, info, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSpruneCsr2csrByPercentage(
-    cusparseHandle_t handle, int m, int n, int nnzA,
-    const cusparseMatDescr_t descrA, const float *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, float percentage,
-    const cusparseMatDescr_t descrC, float *csrSortedValC,
-    const int *csrSortedRowPtrC, int *csrSortedColIndC, pruneInfo_t info,
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    int nnzA,
+    const cusparseMatDescr_t descrA,
+    const float *csrSortedValA,
+    const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA,
+    float percentage, /* between 0 to 100 */
+    const cusparseMatDescr_t descrC,
+    float *csrSortedValC,
+    const int *csrSortedRowPtrC,
+    int *csrSortedColIndC,
+    pruneInfo_t info,
     void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const float *,
-      const int *, const int *, float, const cusparseMatDescr_t, float *,
-      const int *, int *, pruneInfo_t, void *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseSpruneCsr2csrByPercentage");
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, float, const cusparseMatDescr_t, float *, const int *, int *, pruneInfo_t, void *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpruneCsr2csrByPercentage");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, percentage, descrC, csrSortedValC,
-                  csrSortedRowPtrC, csrSortedColIndC, info, pBuffer);
+  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, percentage, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, info, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDpruneCsr2csrByPercentage(
-    cusparseHandle_t handle, int m, int n, int nnzA,
-    const cusparseMatDescr_t descrA, const double *csrSortedValA,
-    const int *csrSortedRowPtrA, const int *csrSortedColIndA, float percentage,
-    const cusparseMatDescr_t descrC, double *csrSortedValC,
-    const int *csrSortedRowPtrC, int *csrSortedColIndC, pruneInfo_t info,
+    cusparseHandle_t handle,
+    int m,
+    int n,
+    int nnzA,
+    const cusparseMatDescr_t descrA,
+    const double *csrSortedValA,
+    const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA,
+    float percentage, /* between 0 to 100 */
+    const cusparseMatDescr_t descrC,
+    double *csrSortedValC,
+    const int *csrSortedRowPtrC,
+    int *csrSortedColIndC,
+    pruneInfo_t info,
     void *pBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const double *,
-      const int *, const int *, float, const cusparseMatDescr_t, double *,
-      const int *, int *, pruneInfo_t, void *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseDpruneCsr2csrByPercentage");
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, float, const cusparseMatDescr_t, double *, const int *, int *, pruneInfo_t, void *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDpruneCsr2csrByPercentage");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA,
-                  csrSortedColIndA, percentage, descrC, csrSortedValC,
-                  csrSortedRowPtrC, csrSortedColIndC, info, pBuffer);
+  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, percentage, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, info, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCsr2cscEx2(
-    cusparseHandle_t handle, int m, int n, int nnz, const void *csrVal,
-    const int *csrRowPtr, const int *csrColInd, void *cscVal, int *cscColPtr,
-    int *cscRowInd, cudaDataType valType, cusparseAction_t copyValues,
-    cusparseIndexBase_t idxBase, cusparseCsr2CscAlg_t alg, void *buffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const void *, const int *, const int *,
-      void *, int *, int *, cudaDataType, cusparseAction_t, cusparseIndexBase_t,
-      cusparseCsr2CscAlg_t, void *);
+cusparseStatus_t CUSPARSEAPI
+cusparseCsr2cscEx2(cusparseHandle_t     handle,
+                   int                  m,
+                   int                  n,
+                   int                  nnz,
+                   const void*          csrVal,
+                   const int*           csrRowPtr,
+                   const int*           csrColInd,
+                   void*                cscVal,
+                   int*                 cscColPtr,
+                   int*                 cscRowInd,
+                   cudaDataType         valType,
+                   cusparseAction_t     copyValues,
+                   cusparseIndexBase_t  idxBase,
+                   cusparseCsr2CscAlg_t alg,
+                   void*                buffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const void *, const int *, const int *, void *, int *, int *, cudaDataType, cusparseAction_t, cusparseIndexBase_t, cusparseCsr2CscAlg_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCsr2cscEx2");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, csrVal, csrRowPtr, csrColInd, cscVal,
-                  cscColPtr, cscRowInd, valType, copyValues, idxBase, alg,
-                  buffer);
+  return func_ptr(handle, m, n, nnz, csrVal, csrRowPtr, csrColInd, cscVal, cscColPtr, cscRowInd, valType, copyValues, idxBase, alg, buffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCsr2cscEx2_bufferSize(
-    cusparseHandle_t handle, int m, int n, int nnz, const void *csrVal,
-    const int *csrRowPtr, const int *csrColInd, void *cscVal, int *cscColPtr,
-    int *cscRowInd, cudaDataType valType, cusparseAction_t copyValues,
-    cusparseIndexBase_t idxBase, cusparseCsr2CscAlg_t alg, size_t *bufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, int, int, int, const void *, const int *, const int *,
-      void *, int *, int *, cudaDataType, cusparseAction_t, cusparseIndexBase_t,
-      cusparseCsr2CscAlg_t, size_t *);
+cusparseStatus_t CUSPARSEAPI
+cusparseCsr2cscEx2_bufferSize(cusparseHandle_t     handle,
+                              int                  m,
+                              int                  n,
+                              int                  nnz,
+                              const void*          csrVal,
+                              const int*           csrRowPtr,
+                              const int*           csrColInd,
+                              void*                cscVal,
+                              int*                 cscColPtr,
+                              int*                 cscRowInd,
+                              cudaDataType         valType,
+                              cusparseAction_t     copyValues,
+                              cusparseIndexBase_t  idxBase,
+                              cusparseCsr2CscAlg_t alg,
+                              size_t*              bufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const void *, const int *, const int *, void *, int *, int *, cudaDataType, cusparseAction_t, cusparseIndexBase_t, cusparseCsr2CscAlg_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCsr2cscEx2_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, csrVal, csrRowPtr, csrColInd, cscVal,
-                  cscColPtr, cscRowInd, valType, copyValues, idxBase, alg,
-                  bufferSize);
-}
-
-#if !defined(_WIN32)
-
-cusparseStatus_t CUSPARSEAPI
-cusparseCreateSpVec(cusparseSpVecDescr_t *spVecDescr, int64_t size, int64_t nnz,
-                    void *indices, void *values, cusparseIndexType_t idxType,
-                    cusparseIndexBase_t idxBase, cudaDataType valueType) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseSpVecDescr_t *, int64_t, int64_t, void *, void *,
-      cusparseIndexType_t, cusparseIndexBase_t, cudaDataType);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateSpVec");
-  if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(spVecDescr, size, nnz, indices, values, idxType, idxBase,
-                  valueType);
+  return func_ptr(handle, m, n, nnz, csrVal, csrRowPtr, csrColInd, cscVal, cscColPtr, cscRowInd, valType, copyValues, idxBase, alg, bufferSize);
 }
 
 cusparseStatus_t CUSPARSEAPI
-cusparseDestroySpVec(cusparseSpVecDescr_t spVecDescr) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseSpVecDescr_t);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroySpVec");
-  if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(spVecDescr);
-}
-
-cusparseStatus_t CUSPARSEAPI cusparseSpVecGet(
-    const cusparseSpVecDescr_t spVecDescr, int64_t *size, int64_t *nnz,
-    void **indices, void **values, cusparseIndexType_t *idxType,
-    cusparseIndexBase_t *idxBase, cudaDataType *valueType) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      const cusparseSpVecDescr_t, int64_t *, int64_t *, void **, void **,
-      cusparseIndexType_t *, cusparseIndexBase_t *, cudaDataType *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpVecGet");
-  if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(spVecDescr, size, nnz, indices, values, idxType, idxBase,
-                  valueType);
-}
-
-cusparseStatus_t CUSPARSEAPI cusparseSpVecGetIndexBase(
-    const cusparseSpVecDescr_t spVecDescr, cusparseIndexBase_t *idxBase) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(const cusparseSpVecDescr_t,
-                                                  cusparseIndexBase_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpVecGetIndexBase");
-  if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(spVecDescr, idxBase);
-}
-
-cusparseStatus_t CUSPARSEAPI
-cusparseSpVecGetValues(const cusparseSpVecDescr_t spVecDescr, void **values) {
-  using FuncPtr =
-      cusparseStatus_t(CUSPARSEAPI *)(const cusparseSpVecDescr_t, void **);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpVecGetValues");
-  if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(spVecDescr, values);
-}
-
-cusparseStatus_t CUSPARSEAPI
-cusparseSpVecSetValues(cusparseSpVecDescr_t spVecDescr, void *values) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseSpVecDescr_t, void *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpVecSetValues");
-  if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(spVecDescr, values);
-}
-
-cusparseStatus_t CUSPARSEAPI
-cusparseCreateDnVec(cusparseDnVecDescr_t *dnVecDescr, int64_t size,
-                    void *values, cudaDataType valueType) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseDnVecDescr_t *, int64_t, void *, cudaDataType);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateDnVec");
-  if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(dnVecDescr, size, values, valueType);
-}
-
-cusparseStatus_t CUSPARSEAPI
-cusparseDestroyDnVec(cusparseDnVecDescr_t dnVecDescr) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseDnVecDescr_t);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyDnVec");
-  if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(dnVecDescr);
-}
-
-cusparseStatus_t CUSPARSEAPI
-cusparseDnVecGet(const cusparseDnVecDescr_t dnVecDescr, int64_t *size,
-                 void **values, cudaDataType *valueType) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      const cusparseDnVecDescr_t, int64_t *, void **, cudaDataType *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDnVecGet");
-  if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(dnVecDescr, size, values, valueType);
-}
-
-cusparseStatus_t CUSPARSEAPI
-cusparseDnVecGetValues(const cusparseDnVecDescr_t dnVecDescr, void **values) {
-  using FuncPtr =
-      cusparseStatus_t(CUSPARSEAPI *)(const cusparseDnVecDescr_t, void **);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDnVecGetValues");
-  if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(dnVecDescr, values);
-}
-
-cusparseStatus_t CUSPARSEAPI
-cusparseDnVecSetValues(cusparseDnVecDescr_t dnVecDescr, void *values) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseDnVecDescr_t, void *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDnVecSetValues");
-  if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(dnVecDescr, values);
-}
-
-cusparseStatus_t CUSPARSEAPI cusparseCreateCoo(cusparseSpMatDescr_t *spMatDescr,
-                                               int64_t rows, int64_t cols,
-                                               int64_t nnz, void *cooRowInd,
-                                               void *cooColInd, void *cooValues,
-                                               cusparseIndexType_t cooIdxType,
-                                               cusparseIndexBase_t idxBase,
-                                               cudaDataType valueType) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseSpMatDescr_t *, int64_t, int64_t, int64_t, void *, void *, void *,
-      cusparseIndexType_t, cusparseIndexBase_t, cudaDataType);
+cusparseCreateCoo(cusparseSpMatDescr_t* spMatDescr,
+                  int                   rows,
+                  int                   cols,
+                  int                   nnz,
+                  void*                 cooRowInd,  // COO row indices
+                  void*                 cooColInd,  // COO column indices
+                  void*                 cooValues,  // COO values
+                  cusparseIndexType_t   cooIdxType,
+                  cusparseIndexBase_t   idxBase,
+                  cudaDataType          valueType) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseSpMatDescr_t *, int, int, int, void *, // COO row indices
+                  void *, // COO column indices
+                  void *, // COO values
+                  cusparseIndexType_t, cusparseIndexBase_t, cudaDataType);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateCoo");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(spMatDescr, rows, cols, nnz, cooRowInd, cooColInd, cooValues,
-                  cooIdxType, idxBase, valueType);
-}
-
-cusparseStatus_t CUSPARSEAPI cusparseCreateCsr(
-    cusparseSpMatDescr_t *spMatDescr, int64_t rows, int64_t cols, int64_t nnz,
-    void *csrRowOffsets, void *csrColInd, void *csrValues,
-    cusparseIndexType_t csrRowOffsetsType, cusparseIndexType_t csrColIndType,
-    cusparseIndexBase_t idxBase, cudaDataType valueType) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseSpMatDescr_t *, int64_t, int64_t, int64_t, void *, void *, void *,
-      cusparseIndexType_t, cusparseIndexType_t, cusparseIndexBase_t,
-      cudaDataType);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateCsr");
-  if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(spMatDescr, rows, cols, nnz, csrRowOffsets, csrColInd,
-                  csrValues, csrRowOffsetsType, csrColIndType, idxBase,
-                  valueType);
-}
-
-cusparseStatus_t CUSPARSEAPI cusparseCreateCooAoS(
-    cusparseSpMatDescr_t *spMatDescr, int64_t rows, int64_t cols, int64_t nnz,
-    void *cooInd, void *cooValues, cusparseIndexType_t cooIdxType,
-    cusparseIndexBase_t idxBase, cudaDataType valueType) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseSpMatDescr_t *, int64_t, int64_t, int64_t, void *, void *,
-      cusparseIndexType_t, cusparseIndexBase_t, cudaDataType);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateCooAoS");
-  if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(spMatDescr, rows, cols, nnz, cooInd, cooValues, cooIdxType,
-                  idxBase, valueType);
+  return func_ptr(spMatDescr, rows, cols, nnz, cooRowInd, cooColInd, cooValues, cooIdxType, idxBase, valueType);
 }
 
 cusparseStatus_t CUSPARSEAPI
 cusparseDestroySpMat(cusparseSpMatDescr_t spMatDescr) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseSpMatDescr_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseSpMatDescr_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroySpMat");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(spMatDescr);
 }
 
 cusparseStatus_t CUSPARSEAPI
-cusparseCooGet(const cusparseSpMatDescr_t spMatDescr, int64_t *rows,
-               int64_t *cols, int64_t *nnz,
-               void **cooRowInd,  // COO row indices
-               void **cooColInd,  // COO column indices
-               void **cooValues,  // COO values
-               cusparseIndexType_t *idxType, cusparseIndexBase_t *idxBase,
-               cudaDataType *valueType) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      const cusparseSpMatDescr_t, int64_t *, int64_t *, int64_t *, void **,
-      void **, void **, cusparseIndexType_t *, cusparseIndexBase_t *,
-      cudaDataType *);
+cusparseCooGet(const cusparseSpMatDescr_t spMatDescr,
+               int*                       rows,
+               int*                       cols,
+               int*                       nnz,
+               void**                     cooRowInd,  // COO row indices
+               void**                     cooColInd,  // COO column indices
+               void**                     cooValues,  // COO values
+               cusparseIndexType_t*       idxType,
+               cusparseIndexBase_t*       idxBase,
+               cudaDataType*              valueType) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(const cusparseSpMatDescr_t, int *, int *, int *, void **, // COO row indices
+               void **, // COO column indices
+               void **, // COO values
+               cusparseIndexType_t *, cusparseIndexBase_t *, cudaDataType *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCooGet");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(spMatDescr, rows, cols, nnz, cooRowInd, cooColInd, cooValues,
-                  idxType, idxBase, valueType);
+  return func_ptr(spMatDescr, rows, cols, nnz, cooRowInd, cooColInd, cooValues, idxType, idxBase, valueType);
 }
 
 cusparseStatus_t CUSPARSEAPI
-cusparseCooAoSGet(const cusparseSpMatDescr_t spMatDescr, int64_t *rows,
-                  int64_t *cols, int64_t *nnz,
-                  void **cooInd,     // COO indices
-                  void **cooValues,  // COO values
-                  cusparseIndexType_t *idxType, cusparseIndexBase_t *idxBase,
-                  cudaDataType *valueType) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      const cusparseSpMatDescr_t, int64_t *, int64_t *, int64_t *, void **,
-      void **, cusparseIndexType_t *, cusparseIndexBase_t *, cudaDataType *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCooAoSGet");
-  if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(spMatDescr, rows, cols, nnz, cooInd, cooValues, idxType,
-                  idxBase, valueType);
-}
-
-cusparseStatus_t CUSPARSEAPI cusparseCsrGet(
-    const cusparseSpMatDescr_t spMatDescr, int64_t *rows, int64_t *cols,
-    int64_t *nnz, void **csrRowOffsets, void **csrColInd, void **csrValues,
-    cusparseIndexType_t *csrRowOffsetsType, cusparseIndexType_t *csrColIndType,
-    cusparseIndexBase_t *idxBase, cudaDataType *valueType) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      const cusparseSpMatDescr_t, int64_t *, int64_t *, int64_t *, void **,
-      void **, void **, cusparseIndexType_t *, cusparseIndexType_t *,
-      cusparseIndexBase_t *, cudaDataType *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCsrGet");
-  if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(spMatDescr, rows, cols, nnz, csrRowOffsets, csrColInd,
-                  csrValues, csrRowOffsetsType, csrColIndType, idxBase,
-                  valueType);
-}
-
-cusparseStatus_t CUSPARSEAPI cusparseSpMatGetFormat(
-    const cusparseSpMatDescr_t spMatDescr, cusparseFormat_t *format) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(const cusparseSpMatDescr_t,
-                                                  cusparseFormat_t *);
+cusparseSpMatGetFormat(const cusparseSpMatDescr_t spMatDescr,
+                       cusparseFormat_t*          format) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(const cusparseSpMatDescr_t, cusparseFormat_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpMatGetFormat");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(spMatDescr, format);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSpMatGetIndexBase(
-    const cusparseSpMatDescr_t spMatDescr, cusparseIndexBase_t *idxBase) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(const cusparseSpMatDescr_t,
-                                                  cusparseIndexBase_t *);
+cusparseStatus_t CUSPARSEAPI
+cusparseSpMatGetIndexBase(const cusparseSpMatDescr_t spMatDescr,
+                          cusparseIndexBase_t*       idxBase) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(const cusparseSpMatDescr_t, cusparseIndexBase_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpMatGetIndexBase");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(spMatDescr, idxBase);
 }
 
 cusparseStatus_t CUSPARSEAPI
-cusparseSpMatGetValues(const cusparseSpMatDescr_t spMatDescr, void **values) {
-  using FuncPtr =
-      cusparseStatus_t(CUSPARSEAPI *)(const cusparseSpMatDescr_t, void **);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpMatGetValues");
-  if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(spMatDescr, values);
-}
-
-cusparseStatus_t CUSPARSEAPI
-cusparseSpMatSetValues(cusparseSpMatDescr_t spMatDescr, void *values) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseSpMatDescr_t, void *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpMatSetValues");
-  if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(spMatDescr, values);
-}
-
-cusparseStatus_t CUSPARSEAPI
-cusparseSpMatSetStridedBatch(cusparseSpMatDescr_t spMatDescr, int batchCount) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseSpMatDescr_t, int);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpMatSetStridedBatch");
+cusparseSpMatSetNumBatches(cusparseSpMatDescr_t spMatDescr,
+                           int                  batchCount) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseSpMatDescr_t, int);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpMatSetNumBatches");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(spMatDescr, batchCount);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSpMatGetStridedBatch(
-    const cusparseSpMatDescr_t spMatDescr, int *batchCount) {
-  using FuncPtr =
-      cusparseStatus_t(CUSPARSEAPI *)(const cusparseSpMatDescr_t, int *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpMatGetStridedBatch");
+cusparseStatus_t CUSPARSEAPI
+cusparseSpMatGetNumBatches(const cusparseSpMatDescr_t spMatDescr,
+                           int*                       batchCount) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(const cusparseSpMatDescr_t, int *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpMatGetNumBatches");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(spMatDescr, batchCount);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCreateDnMat(
-    cusparseDnMatDescr_t *dnMatDescr, int64_t rows, int64_t cols, int64_t ld,
-    void *values, cudaDataType valueType, cusparseOrder_t order) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseDnMatDescr_t *, int64_t, int64_t, int64_t, void *, cudaDataType,
-      cusparseOrder_t);
+cusparseStatus_t CUSPARSEAPI
+cusparseCreateDnMat(cusparseDnMatDescr_t* dnMatDescr,
+                    size_t                rows,
+                    size_t                cols,
+                    int64_t               ld,
+                    void*                 valuesPtr,
+                    cudaDataType          type,
+                    cusparseOrder_t       order) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseDnMatDescr_t *, size_t, size_t, int64_t, void *, cudaDataType, cusparseOrder_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateDnMat");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(dnMatDescr, rows, cols, ld, values, valueType, order);
+  return func_ptr(dnMatDescr, rows, cols, ld, valuesPtr, type, order);
 }
 
 cusparseStatus_t CUSPARSEAPI
 cusparseDestroyDnMat(cusparseDnMatDescr_t dnMatDescr) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseDnMatDescr_t);
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseDnMatDescr_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyDnMat");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(dnMatDescr);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDnMatGet(
-    const cusparseDnMatDescr_t dnMatDescr, int64_t *rows, int64_t *cols,
-    int64_t *ld, void **values, cudaDataType *type, cusparseOrder_t *order) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      const cusparseDnMatDescr_t, int64_t *, int64_t *, int64_t *, void **,
-      cudaDataType *, cusparseOrder_t *);
+cusparseStatus_t CUSPARSEAPI
+cusparseDnMatGet(const cusparseDnMatDescr_t dnMatDescr,
+                 size_t*                    rows,
+                 size_t*                    cols,
+                 int64_t*                   ld,
+                 void**                     valuesPtr,
+                 cudaDataType*              type,
+                 cusparseOrder_t*           order) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(const cusparseDnMatDescr_t, size_t *, size_t *, int64_t *, void **, cudaDataType *, cusparseOrder_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDnMatGet");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(dnMatDescr, rows, cols, ld, values, type, order);
+  return func_ptr(dnMatDescr, rows, cols, ld, valuesPtr, type, order);
 }
 
 cusparseStatus_t CUSPARSEAPI
-cusparseDnMatGetValues(const cusparseDnMatDescr_t dnMatDescr, void **values) {
-  using FuncPtr =
-      cusparseStatus_t(CUSPARSEAPI *)(const cusparseDnMatDescr_t, void **);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDnMatGetValues");
-  if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(dnMatDescr, values);
-}
-
-cusparseStatus_t CUSPARSEAPI
-cusparseDnMatSetValues(cusparseDnMatDescr_t dnMatDescr, void *values) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseDnMatDescr_t, void *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDnMatSetValues");
-  if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(dnMatDescr, values);
-}
-
-cusparseStatus_t CUSPARSEAPI cusparseDnMatSetStridedBatch(
-    cusparseDnMatDescr_t dnMatDescr, int batchCount, int64_t batchStride) {
-  using FuncPtr =
-      cusparseStatus_t(CUSPARSEAPI *)(cusparseDnMatDescr_t, int, int64_t);
+cusparseDnMatSetStridedBatch(cusparseDnMatDescr_t dnMatDescr,
+                             int                  batchCount,
+                             size_t               batchStride) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseDnMatDescr_t, int, size_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDnMatSetStridedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(dnMatDescr, batchCount, batchStride);
@@ -8100,131 +9050,48 @@ cusparseStatus_t CUSPARSEAPI cusparseDnMatSetStridedBatch(
 
 cusparseStatus_t CUSPARSEAPI
 cusparseDnMatGetStridedBatch(const cusparseDnMatDescr_t dnMatDescr,
-                             int *batchCount, int64_t *batchStride) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(const cusparseDnMatDescr_t,
-                                                  int *, int64_t *);
+                             int*                       batchCount,
+                             size_t*                    batchStride) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(const cusparseDnMatDescr_t, int *, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDnMatGetStridedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(dnMatDescr, batchCount, batchStride);
 }
 
 cusparseStatus_t CUSPARSEAPI
-cusparseSpVV(cusparseHandle_t handle, cusparseOperation_t opX,
-             const cusparseSpVecDescr_t vecX, const cusparseDnVecDescr_t vecY,
-             void *result, cudaDataType computeType, void *externalBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, const cusparseSpVecDescr_t,
-      const cusparseDnVecDescr_t, void *, cudaDataType, void *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpVV");
-  if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, opX, vecX, vecY, result, computeType, externalBuffer);
-}
-
-cusparseStatus_t CUSPARSEAPI cusparseSpVV_bufferSize(
-    cusparseHandle_t handle, cusparseOperation_t opX,
-    const cusparseSpVecDescr_t vecX, const cusparseDnVecDescr_t vecY,
-    const void *result, cudaDataType computeType, size_t *bufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, const cusparseSpVecDescr_t,
-      const cusparseDnVecDescr_t, const void *, cudaDataType, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpVV_bufferSize");
-  if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, opX, vecX, vecY, result, computeType, bufferSize);
-}
-
-cusparseStatus_t CUSPARSEAPI cusparseSpMV(
-    cusparseHandle_t handle, cusparseOperation_t opA, const void *alpha,
-    const cusparseSpMatDescr_t matA, const cusparseDnVecDescr_t vecX,
-    const void *beta, const cusparseDnVecDescr_t vecY, cudaDataType computeType,
-    cusparseSpMVAlg_t alg, void *externalBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, const void *,
-      const cusparseSpMatDescr_t, const cusparseDnVecDescr_t, const void *,
-      const cusparseDnVecDescr_t, cudaDataType, cusparseSpMVAlg_t, void *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpMV");
-  if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, opA, alpha, matA, vecX, beta, vecY, computeType, alg,
-                  externalBuffer);
-}
-
-cusparseStatus_t CUSPARSEAPI cusparseSpMV_bufferSize(
-    cusparseHandle_t handle, cusparseOperation_t opA, const void *alpha,
-    const cusparseSpMatDescr_t matA, const cusparseDnVecDescr_t vecX,
-    const void *beta, const cusparseDnVecDescr_t vecY, cudaDataType computeType,
-    cusparseSpMVAlg_t alg, size_t *bufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, const void *,
-      const cusparseSpMatDescr_t, const cusparseDnVecDescr_t, const void *,
-      const cusparseDnVecDescr_t, cudaDataType, cusparseSpMVAlg_t, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpMV_bufferSize");
-  if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, opA, alpha, matA, vecX, beta, vecY, computeType, alg,
-                  bufferSize);
-}
-
-cusparseStatus_t CUSPARSEAPI cusparseSpMM(
-    cusparseHandle_t handle, cusparseOperation_t opA, cusparseOperation_t opB,
-    const void *alpha, const cusparseSpMatDescr_t matA,
-    const cusparseDnMatDescr_t matB, const void *beta,
-    cusparseDnMatDescr_t matC, cudaDataType computeType, cusparseSpMMAlg_t alg,
-    void *externalBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, const void *,
-      const cusparseSpMatDescr_t, const cusparseDnMatDescr_t, const void *,
-      cusparseDnMatDescr_t, cudaDataType, cusparseSpMMAlg_t, void *);
+cusparseSpMM(cusparseHandle_t           handle,
+             cusparseOperation_t        transA,
+             cusparseOperation_t        transB,
+             const void*                alpha,
+             const cusparseSpMatDescr_t matA,
+             const cusparseDnMatDescr_t matB,
+             const void*                beta,
+             cusparseDnMatDescr_t       matC,
+             cudaDataType               computeType,
+             cusparseSpMMAlg_t          alg,
+             void*                      externalBuffer) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, const void *, const cusparseSpMatDescr_t, const cusparseDnMatDescr_t, const void *, cusparseDnMatDescr_t, cudaDataType, cusparseSpMMAlg_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpMM");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, opA, opB, alpha, matA, matB, beta, matC, computeType,
-                  alg, externalBuffer);
+  return func_ptr(handle, transA, transB, alpha, matA, matB, beta, matC, computeType, alg, externalBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSpMM_bufferSize(
-    cusparseHandle_t handle, cusparseOperation_t opA, cusparseOperation_t opB,
-    const void *alpha, const cusparseSpMatDescr_t matA,
-    const cusparseDnMatDescr_t matB, const void *beta,
-    cusparseDnMatDescr_t matC, cudaDataType computeType, cusparseSpMMAlg_t alg,
-    size_t *bufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, const void *,
-      const cusparseSpMatDescr_t, const cusparseDnMatDescr_t, const void *,
-      cusparseDnMatDescr_t, cudaDataType, cusparseSpMMAlg_t, size_t *);
+cusparseStatus_t CUSPARSEAPI
+cusparseSpMM_bufferSize(cusparseHandle_t           handle,
+                        cusparseOperation_t        transA,
+                        cusparseOperation_t        transB,
+                        const void*                alpha,
+                        const cusparseSpMatDescr_t matA,
+                        const cusparseDnMatDescr_t matB,
+                        const void*                beta,
+                        cusparseDnMatDescr_t       matC,
+                        cudaDataType               computeType,
+                        cusparseSpMMAlg_t          alg,
+                        size_t*                    bufferSize) {
+  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, const void *, const cusparseSpMatDescr_t, const cusparseDnMatDescr_t, const void *, cusparseDnMatDescr_t, cudaDataType, cusparseSpMMAlg_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpMM_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, opA, opB, alpha, matA, matB, beta, matC, computeType,
-                  alg, bufferSize);
+  return func_ptr(handle, transA, transB, alpha, matA, matB, beta, matC, computeType, alg, bufferSize);
 }
-
-cusparseStatus_t CUSPARSEAPI cusparseConstrainedGeMM(
-    cusparseHandle_t handle, cusparseOperation_t opA, cusparseOperation_t opB,
-    const void *alpha, const cusparseDnMatDescr_t matA,
-    const cusparseDnMatDescr_t matB, const void *beta,
-    cusparseSpMatDescr_t matC, cudaDataType computeType, void *externalBuffer) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, const void *,
-      const cusparseDnMatDescr_t, const cusparseDnMatDescr_t, const void *,
-      cusparseSpMatDescr_t, cudaDataType, void *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseConstrainedGeMM");
-  if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, opA, opB, alpha, matA, matB, beta, matC, computeType,
-                  externalBuffer);
-}
-
-cusparseStatus_t CUSPARSEAPI cusparseConstrainedGeMM_bufferSize(
-    cusparseHandle_t handle, cusparseOperation_t opA, cusparseOperation_t opB,
-    const void *alpha, const cusparseDnMatDescr_t matA,
-    const cusparseDnMatDescr_t matB, const void *beta,
-    cusparseSpMatDescr_t matC, cudaDataType computeType, size_t *bufferSize) {
-  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
-      cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, const void *,
-      const cusparseDnMatDescr_t, const cusparseDnMatDescr_t, const void *,
-      cusparseSpMatDescr_t, cudaDataType, size_t *);
-  static auto func_ptr =
-      LoadSymbol<FuncPtr>("cusparseConstrainedGeMM_bufferSize");
-  if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, opA, opB, alpha, matA, matB, beta, matC, computeType,
-                  bufferSize);
-}
-
-#endif // _WIN32
 
 }  // extern "C"

--- a/tensorflow/stream_executor/cuda/cusparse_10_1.inc
+++ b/tensorflow/stream_executor/cuda/cusparse_10_1.inc
@@ -1,6675 +1,5803 @@
 // Auto-generated, do not edit.
 
 extern "C" {
+
 cusparseStatus_t CUSPARSEAPI cusparseCreate(cusparseHandle_t *handle) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreate");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDestroy(cusparseHandle_t handle) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroy");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseGetVersion(cusparseHandle_t handle, int *version) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseGetVersion(cusparseHandle_t handle,
+                                                int *version) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseGetVersion");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, version);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseGetProperty(libraryPropertyType type, int *value) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(libraryPropertyType, int *);
+cusparseStatus_t CUSPARSEAPI cusparseGetProperty(libraryPropertyType type,
+                                                 int *value) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(libraryPropertyType, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseGetProperty");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(type, value);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSetStream(cusparseHandle_t handle, cudaStream_t streamId) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cudaStream_t);
+const char *CUSPARSEAPI cusparseGetErrorName(cusparseStatus_t status) {
+  using FuncPtr = const char *(CUSPARSEAPI *)(cusparseStatus_t);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseGetErrorName");
+  if (!func_ptr) return "cusparseGetErrorName symbol not found.";
+  return func_ptr(status);
+}
+
+const char *CUSPARSEAPI cusparseGetErrorString(cusparseStatus_t status) {
+  using FuncPtr = const char *(CUSPARSEAPI *)(cusparseStatus_t);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseGetErrorString");
+  if (!func_ptr) return "cusparseGetErrorString symbol not found.";
+  return func_ptr(status);
+}
+
+cusparseStatus_t CUSPARSEAPI cusparseSetStream(cusparseHandle_t handle,
+                                               cudaStream_t streamId) {
+  using FuncPtr =
+      cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, cudaStream_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSetStream");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, streamId);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseGetStream(cusparseHandle_t handle, cudaStream_t *streamId) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cudaStream_t *);
+cusparseStatus_t CUSPARSEAPI cusparseGetStream(cusparseHandle_t handle,
+                                               cudaStream_t *streamId) {
+  using FuncPtr =
+      cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, cudaStream_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseGetStream");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, streamId);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseGetPointerMode(cusparseHandle_t handle, cusparsePointerMode_t *mode) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparsePointerMode_t *);
+cusparseStatus_t CUSPARSEAPI
+cusparseGetPointerMode(cusparseHandle_t handle, cusparsePointerMode_t *mode) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t,
+                                                  cusparsePointerMode_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseGetPointerMode");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, mode);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSetPointerMode(cusparseHandle_t handle, cusparsePointerMode_t mode) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparsePointerMode_t);
+cusparseStatus_t CUSPARSEAPI
+cusparseSetPointerMode(cusparseHandle_t handle, cusparsePointerMode_t mode) {
+  using FuncPtr =
+      cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, cusparsePointerMode_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSetPointerMode");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, mode);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCreateMatDescr(cusparseMatDescr_t *descrA) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseMatDescr_t *);
+cusparseStatus_t CUSPARSEAPI
+cusparseCreateMatDescr(cusparseMatDescr_t *descrA) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseMatDescr_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateMatDescr");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(descrA);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDestroyMatDescr (cusparseMatDescr_t descrA) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseMatDescr_t);
+cusparseStatus_t CUSPARSEAPI
+cusparseDestroyMatDescr(cusparseMatDescr_t descrA) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseMatDescr_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyMatDescr");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(descrA);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCopyMatDescr(cusparseMatDescr_t dest, const cusparseMatDescr_t src) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseMatDescr_t, const cusparseMatDescr_t);
+cusparseStatus_t CUSPARSEAPI
+cusparseCopyMatDescr(cusparseMatDescr_t dest, const cusparseMatDescr_t src) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseMatDescr_t,
+                                                  const cusparseMatDescr_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCopyMatDescr");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(dest, src);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSetMatType(cusparseMatDescr_t descrA, cusparseMatrixType_t type) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseMatDescr_t, cusparseMatrixType_t);
+cusparseStatus_t CUSPARSEAPI cusparseSetMatType(cusparseMatDescr_t descrA,
+                                                cusparseMatrixType_t type) {
+  using FuncPtr =
+      cusparseStatus_t(CUSPARSEAPI *)(cusparseMatDescr_t, cusparseMatrixType_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSetMatType");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(descrA, type);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSetMatFillMode(cusparseMatDescr_t descrA, cusparseFillMode_t fillMode) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseMatDescr_t, cusparseFillMode_t);
+cusparseStatus_t CUSPARSEAPI
+cusparseSetMatFillMode(cusparseMatDescr_t descrA, cusparseFillMode_t fillMode) {
+  using FuncPtr =
+      cusparseStatus_t(CUSPARSEAPI *)(cusparseMatDescr_t, cusparseFillMode_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSetMatFillMode");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(descrA, fillMode);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSetMatDiagType(cusparseMatDescr_t  descrA, cusparseDiagType_t diagType) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseMatDescr_t, cusparseDiagType_t);
+cusparseStatus_t CUSPARSEAPI
+cusparseSetMatDiagType(cusparseMatDescr_t descrA, cusparseDiagType_t diagType) {
+  using FuncPtr =
+      cusparseStatus_t(CUSPARSEAPI *)(cusparseMatDescr_t, cusparseDiagType_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSetMatDiagType");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(descrA, diagType);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSetMatIndexBase(cusparseMatDescr_t descrA, cusparseIndexBase_t base) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseMatDescr_t, cusparseIndexBase_t);
+cusparseStatus_t CUSPARSEAPI cusparseSetMatIndexBase(cusparseMatDescr_t descrA,
+                                                     cusparseIndexBase_t base) {
+  using FuncPtr =
+      cusparseStatus_t(CUSPARSEAPI *)(cusparseMatDescr_t, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSetMatIndexBase");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(descrA, base);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCreateSolveAnalysisInfo(cusparseSolveAnalysisInfo_t *info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseSolveAnalysisInfo_t *);
+cusparseStatus_t CUSPARSEAPI
+cusparseCreateSolveAnalysisInfo(cusparseSolveAnalysisInfo_t *info) {
+  using FuncPtr =
+      cusparseStatus_t(CUSPARSEAPI *)(cusparseSolveAnalysisInfo_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateSolveAnalysisInfo");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDestroySolveAnalysisInfo(cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseSolveAnalysisInfo_t);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroySolveAnalysisInfo");
+cusparseStatus_t CUSPARSEAPI
+cusparseDestroySolveAnalysisInfo(cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseSolveAnalysisInfo_t);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseDestroySolveAnalysisInfo");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseGetLevelInfo(cusparseHandle_t handle,
-                                                  cusparseSolveAnalysisInfo_t info,
-                                                  int *nlevels,
-                                                  int **levelPtr,
-                                                  int **levelInd) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseSolveAnalysisInfo_t, int *, int **, int **);
+cusparseStatus_t CUSPARSEAPI
+cusparseGetLevelInfo(cusparseHandle_t handle, cusparseSolveAnalysisInfo_t info,
+                     int *nlevels, int **levelPtr, int **levelInd) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseSolveAnalysisInfo_t, int *, int **, int **);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseGetLevelInfo");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, nlevels, levelPtr, levelInd);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCreateCsrsv2Info(csrsv2Info_t *info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(csrsv2Info_t *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(csrsv2Info_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateCsrsv2Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDestroyCsrsv2Info(csrsv2Info_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(csrsv2Info_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(csrsv2Info_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyCsrsv2Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCreateCsric02Info(csric02Info_t *info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(csric02Info_t *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(csric02Info_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateCsric02Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDestroyCsric02Info(csric02Info_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(csric02Info_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(csric02Info_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyCsric02Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCreateBsric02Info(bsric02Info_t *info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(bsric02Info_t *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(bsric02Info_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateBsric02Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDestroyBsric02Info(bsric02Info_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(bsric02Info_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(bsric02Info_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyBsric02Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCreateCsrilu02Info(csrilu02Info_t *info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(csrilu02Info_t *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(csrilu02Info_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateCsrilu02Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDestroyCsrilu02Info(csrilu02Info_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(csrilu02Info_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(csrilu02Info_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyCsrilu02Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCreateBsrilu02Info(bsrilu02Info_t *info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(bsrilu02Info_t *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(bsrilu02Info_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateBsrilu02Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDestroyBsrilu02Info(bsrilu02Info_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(bsrilu02Info_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(bsrilu02Info_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyBsrilu02Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCreateBsrsv2Info(bsrsv2Info_t *info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(bsrsv2Info_t *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(bsrsv2Info_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateBsrsv2Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDestroyBsrsv2Info(bsrsv2Info_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(bsrsv2Info_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(bsrsv2Info_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyBsrsv2Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCreateBsrsm2Info(bsrsm2Info_t *info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(bsrsm2Info_t *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(bsrsm2Info_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateBsrsm2Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDestroyBsrsm2Info(bsrsm2Info_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(bsrsm2Info_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(bsrsm2Info_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyBsrsm2Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCreateHybMat(cusparseHybMat_t *hybA) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHybMat_t *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseHybMat_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateHybMat");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(hybA);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDestroyHybMat(cusparseHybMat_t hybA) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHybMat_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseHybMat_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyHybMat");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(hybA);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCreateCsru2csrInfo(csru2csrInfo_t *info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(csru2csrInfo_t *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(csru2csrInfo_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateCsru2csrInfo");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDestroyCsru2csrInfo(csru2csrInfo_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(csru2csrInfo_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(csru2csrInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyCsru2csrInfo");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCreateColorInfo(cusparseColorInfo_t *info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseColorInfo_t *);
+cusparseStatus_t CUSPARSEAPI
+cusparseCreateColorInfo(cusparseColorInfo_t *info) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseColorInfo_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateColorInfo");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDestroyColorInfo(cusparseColorInfo_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseColorInfo_t);
+cusparseStatus_t CUSPARSEAPI
+cusparseDestroyColorInfo(cusparseColorInfo_t info) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseColorInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyColorInfo");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSetColorAlgs(cusparseColorInfo_t info, cusparseColorAlg_t alg) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseColorInfo_t, cusparseColorAlg_t);
+cusparseStatus_t CUSPARSEAPI cusparseSetColorAlgs(cusparseColorInfo_t info,
+                                                  cusparseColorAlg_t alg) {
+  using FuncPtr =
+      cusparseStatus_t(CUSPARSEAPI *)(cusparseColorInfo_t, cusparseColorAlg_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSetColorAlgs");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info, alg);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseGetColorAlgs(cusparseColorInfo_t info, cusparseColorAlg_t *alg) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseColorInfo_t, cusparseColorAlg_t *);
+cusparseStatus_t CUSPARSEAPI cusparseGetColorAlgs(cusparseColorInfo_t info,
+                                                  cusparseColorAlg_t *alg) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseColorInfo_t,
+                                                  cusparseColorAlg_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseGetColorAlgs");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info, alg);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCreatePruneInfo(pruneInfo_t *info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(pruneInfo_t *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(pruneInfo_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreatePruneInfo");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDestroyPruneInfo(pruneInfo_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(pruneInfo_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(pruneInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyPruneInfo");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSaxpyi(cusparseHandle_t handle,
-                                            int nnz,
+cusparseStatus_t CUSPARSEAPI cusparseSaxpyi(cusparseHandle_t handle, int nnz,
                                             const float *alpha,
-                                            const float *xVal,
-                                            const int *xInd,
+                                            const float *xVal, const int *xInd,
                                             float *y,
                                             cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const float *, const float *, const int *, float *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const float *, const float *, const int *, float *,
+      cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSaxpyi");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, alpha, xVal, xInd, y, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDaxpyi(cusparseHandle_t handle,
-                                            int nnz,
+cusparseStatus_t CUSPARSEAPI cusparseDaxpyi(cusparseHandle_t handle, int nnz,
                                             const double *alpha,
-                                            const double *xVal,
-                                            const int *xInd,
+                                            const double *xVal, const int *xInd,
                                             double *y,
                                             cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const double *, const double *, const int *, double *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const double *, const double *, const int *,
+      double *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDaxpyi");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, alpha, xVal, xInd, y, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCaxpyi(cusparseHandle_t handle,
-                                            int nnz,
+cusparseStatus_t CUSPARSEAPI cusparseCaxpyi(cusparseHandle_t handle, int nnz,
                                             const cuComplex *alpha,
                                             const cuComplex *xVal,
-                                            const int *xInd,
-                                            cuComplex *y,
+                                            const int *xInd, cuComplex *y,
                                             cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuComplex *, const cuComplex *, const int *, cuComplex *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const cuComplex *, const cuComplex *, const int *,
+      cuComplex *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCaxpyi");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, alpha, xVal, xInd, y, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZaxpyi(cusparseHandle_t handle,
-                                            int nnz,
+cusparseStatus_t CUSPARSEAPI cusparseZaxpyi(cusparseHandle_t handle, int nnz,
                                             const cuDoubleComplex *alpha,
                                             const cuDoubleComplex *xVal,
-                                            const int *xInd,
-                                            cuDoubleComplex *y,
+                                            const int *xInd, cuDoubleComplex *y,
                                             cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuDoubleComplex *, const cuDoubleComplex *, const int *, cuDoubleComplex *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const cuDoubleComplex *, const cuDoubleComplex *,
+      const int *, cuDoubleComplex *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZaxpyi");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, alpha, xVal, xInd, y, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSdoti(cusparseHandle_t handle,
-                                           int nnz,
-                                           const float *xVal,
-                                           const int *xInd,
+cusparseStatus_t CUSPARSEAPI cusparseSdoti(cusparseHandle_t handle, int nnz,
+                                           const float *xVal, const int *xInd,
                                            const float *y,
                                            float *resultDevHostPtr,
                                            cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const float *, const int *, const float *, float *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const float *, const int *, const float *, float *,
+      cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSdoti");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, xVal, xInd, y, resultDevHostPtr, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDdoti(cusparseHandle_t handle,
-                                           int nnz,
-                                           const double *xVal,
-                                           const int *xInd,
+cusparseStatus_t CUSPARSEAPI cusparseDdoti(cusparseHandle_t handle, int nnz,
+                                           const double *xVal, const int *xInd,
                                            const double *y,
                                            double *resultDevHostPtr,
                                            cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const double *, const int *, const double *, double *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const double *, const int *, const double *,
+      double *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDdoti");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, xVal, xInd, y, resultDevHostPtr, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCdoti(cusparseHandle_t handle,
-                                           int nnz,
+cusparseStatus_t CUSPARSEAPI cusparseCdoti(cusparseHandle_t handle, int nnz,
                                            const cuComplex *xVal,
-                                           const int *xInd,
-                                           const cuComplex *y,
+                                           const int *xInd, const cuComplex *y,
                                            cuComplex *resultDevHostPtr,
                                            cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuComplex *, const int *, const cuComplex *, cuComplex *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const cuComplex *, const int *, const cuComplex *,
+      cuComplex *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCdoti");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, xVal, xInd, y, resultDevHostPtr, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZdoti(cusparseHandle_t handle,
-                                           int nnz,
+cusparseStatus_t CUSPARSEAPI cusparseZdoti(cusparseHandle_t handle, int nnz,
                                            const cuDoubleComplex *xVal,
                                            const int *xInd,
                                            const cuDoubleComplex *y,
                                            cuDoubleComplex *resultDevHostPtr,
                                            cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuDoubleComplex *, const int *, const cuDoubleComplex *, cuDoubleComplex *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const cuDoubleComplex *, const int *,
+      const cuDoubleComplex *, cuDoubleComplex *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZdoti");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, xVal, xInd, y, resultDevHostPtr, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCdotci(cusparseHandle_t handle,
-                                            int nnz,
+cusparseStatus_t CUSPARSEAPI cusparseCdotci(cusparseHandle_t handle, int nnz,
                                             const cuComplex *xVal,
-                                            const int *xInd,
-                                            const cuComplex *y,
+                                            const int *xInd, const cuComplex *y,
                                             cuComplex *resultDevHostPtr,
                                             cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuComplex *, const int *, const cuComplex *, cuComplex *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const cuComplex *, const int *, const cuComplex *,
+      cuComplex *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCdotci");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, xVal, xInd, y, resultDevHostPtr, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZdotci(cusparseHandle_t handle,
-                                            int nnz,
+cusparseStatus_t CUSPARSEAPI cusparseZdotci(cusparseHandle_t handle, int nnz,
                                             const cuDoubleComplex *xVal,
                                             const int *xInd,
                                             const cuDoubleComplex *y,
                                             cuDoubleComplex *resultDevHostPtr,
                                             cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuDoubleComplex *, const int *, const cuDoubleComplex *, cuDoubleComplex *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const cuDoubleComplex *, const int *,
+      const cuDoubleComplex *, cuDoubleComplex *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZdotci");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, xVal, xInd, y, resultDevHostPtr, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSgthr(cusparseHandle_t handle,
-                                           int nnz,
-                                           const float *y,
-                                           float *xVal,
+cusparseStatus_t CUSPARSEAPI cusparseSgthr(cusparseHandle_t handle, int nnz,
+                                           const float *y, float *xVal,
                                            const int *xInd,
                                            cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const float *, float *, const int *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const float *, float *, const int *,
+      cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgthr");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, y, xVal, xInd, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDgthr(cusparseHandle_t handle,
-                                           int nnz,
-                                           const double *y,
-                                           double *xVal,
+cusparseStatus_t CUSPARSEAPI cusparseDgthr(cusparseHandle_t handle, int nnz,
+                                           const double *y, double *xVal,
                                            const int *xInd,
                                            cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const double *, double *, const int *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const double *, double *, const int *,
+      cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgthr");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, y, xVal, xInd, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCgthr(cusparseHandle_t handle,
-                                           int nnz,
-                                           const cuComplex *y,
-                                           cuComplex *xVal,
+cusparseStatus_t CUSPARSEAPI cusparseCgthr(cusparseHandle_t handle, int nnz,
+                                           const cuComplex *y, cuComplex *xVal,
                                            const int *xInd,
                                            cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuComplex *, cuComplex *, const int *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const cuComplex *, cuComplex *, const int *,
+      cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgthr");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, y, xVal, xInd, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZgthr(cusparseHandle_t handle,
-                                           int nnz,
+cusparseStatus_t CUSPARSEAPI cusparseZgthr(cusparseHandle_t handle, int nnz,
                                            const cuDoubleComplex *y,
                                            cuDoubleComplex *xVal,
                                            const int *xInd,
                                            cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuDoubleComplex *, cuDoubleComplex *, const int *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const cuDoubleComplex *, cuDoubleComplex *,
+      const int *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgthr");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, y, xVal, xInd, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSgthrz(cusparseHandle_t handle,
-                                            int nnz,
-                                            float *y,
-                                            float *xVal,
+cusparseStatus_t CUSPARSEAPI cusparseSgthrz(cusparseHandle_t handle, int nnz,
+                                            float *y, float *xVal,
                                             const int *xInd,
                                             cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, float *, float *, const int *, cusparseIndexBase_t);
+  using FuncPtr =
+      cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, int, float *, float *,
+                                      const int *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgthrz");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, y, xVal, xInd, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDgthrz(cusparseHandle_t handle,
-                                            int nnz,
-                                            double *y,
-                                            double *xVal,
+cusparseStatus_t CUSPARSEAPI cusparseDgthrz(cusparseHandle_t handle, int nnz,
+                                            double *y, double *xVal,
                                             const int *xInd,
                                             cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, double *, double *, const int *, cusparseIndexBase_t);
+  using FuncPtr =
+      cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, int, double *, double *,
+                                      const int *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgthrz");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, y, xVal, xInd, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCgthrz(cusparseHandle_t handle,
-                                            int nnz,
-                                            cuComplex *y,
-                                            cuComplex *xVal,
+cusparseStatus_t CUSPARSEAPI cusparseCgthrz(cusparseHandle_t handle, int nnz,
+                                            cuComplex *y, cuComplex *xVal,
                                             const int *xInd,
                                             cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, cuComplex *, cuComplex *, const int *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, cuComplex *, cuComplex *, const int *,
+      cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgthrz");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, y, xVal, xInd, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZgthrz(cusparseHandle_t handle,
-                                            int nnz,
+cusparseStatus_t CUSPARSEAPI cusparseZgthrz(cusparseHandle_t handle, int nnz,
                                             cuDoubleComplex *y,
                                             cuDoubleComplex *xVal,
                                             const int *xInd,
                                             cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, cuDoubleComplex *, cuDoubleComplex *, const int *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, cuDoubleComplex *, cuDoubleComplex *, const int *,
+      cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgthrz");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, y, xVal, xInd, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSsctr(cusparseHandle_t handle,
-                                           int nnz,
-                                           const float *xVal,
-                                           const int *xInd,
+cusparseStatus_t CUSPARSEAPI cusparseSsctr(cusparseHandle_t handle, int nnz,
+                                           const float *xVal, const int *xInd,
                                            float *y,
                                            cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const float *, const int *, float *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, int,
+                                                  const float *, const int *,
+                                                  float *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSsctr");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, xVal, xInd, y, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDsctr(cusparseHandle_t handle,
-                                           int nnz,
-                                           const double *xVal,
-                                           const int *xInd,
+cusparseStatus_t CUSPARSEAPI cusparseDsctr(cusparseHandle_t handle, int nnz,
+                                           const double *xVal, const int *xInd,
                                            double *y,
                                            cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const double *, const int *, double *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const double *, const int *, double *,
+      cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDsctr");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, xVal, xInd, y, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCsctr(cusparseHandle_t handle,
-                                           int nnz,
+cusparseStatus_t CUSPARSEAPI cusparseCsctr(cusparseHandle_t handle, int nnz,
                                            const cuComplex *xVal,
-                                           const int *xInd,
-                                           cuComplex *y,
+                                           const int *xInd, cuComplex *y,
                                            cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuComplex *, const int *, cuComplex *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const cuComplex *, const int *, cuComplex *,
+      cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCsctr");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, xVal, xInd, y, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZsctr(cusparseHandle_t handle,
-                                           int nnz,
+cusparseStatus_t CUSPARSEAPI cusparseZsctr(cusparseHandle_t handle, int nnz,
                                            const cuDoubleComplex *xVal,
-                                           const int *xInd,
-                                           cuDoubleComplex *y,
+                                           const int *xInd, cuDoubleComplex *y,
                                            cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuDoubleComplex *, const int *, cuDoubleComplex *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const cuDoubleComplex *, const int *,
+      cuDoubleComplex *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZsctr");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, xVal, xInd, y, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSroti(cusparseHandle_t handle,
-                                              int nnz,
-                                              float *xVal,
-                                              const int *xInd,
-                                              float *y,
-                                              const float *c,
-                                              const float *s,
-                                              cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, float *, const int *, float *, const float *, const float *, cusparseIndexBase_t);
+cusparseStatus_t CUSPARSEAPI cusparseSroti(cusparseHandle_t handle, int nnz,
+                                           float *xVal, const int *xInd,
+                                           float *y, const float *c,
+                                           const float *s,
+                                           cusparseIndexBase_t idxBase) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, float *, const int *, float *, const float *,
+      const float *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSroti");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, xVal, xInd, y, c, s, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDroti(cusparseHandle_t handle,
-                                              int nnz,
-                                              double *xVal,
-                                              const int *xInd,
-                                              double *y,
-                                              const double *c,
-                                              const double *s,
-                                              cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, double *, const int *, double *, const double *, const double *, cusparseIndexBase_t);
+cusparseStatus_t CUSPARSEAPI cusparseDroti(cusparseHandle_t handle, int nnz,
+                                           double *xVal, const int *xInd,
+                                           double *y, const double *c,
+                                           const double *s,
+                                           cusparseIndexBase_t idxBase) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, double *, const int *, double *, const double *,
+      const double *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDroti");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, nnz, xVal, xInd, y, c, s, idxBase);
 }
 
-cusparseStatus_t  CUSPARSEAPI cusparseSgemvi(cusparseHandle_t handle,
-                                    cusparseOperation_t transA,
-                                    int m,
-                                    int n,
-                                    const float *alpha, /* host or device pointer */
-                                    const float *A,
-                                    int lda,
-                                    int nnz,
-                                    const float *xVal,
-                                    const int *xInd,
-                                    const float *beta, /* host or device pointer */
-                                    float *y,
-                                    cusparseIndexBase_t   idxBase,
-                                    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const float *, const float *, int, int, const float *, const int *, const float *, float *, cusparseIndexBase_t, void *);
+cusparseStatus_t CUSPARSEAPI
+cusparseSgemvi(cusparseHandle_t handle, cusparseOperation_t transA, int m,
+               int n, const float *alpha, const float *A, int lda, int nnz,
+               const float *xVal, const int *xInd, const float *beta, float *y,
+               cusparseIndexBase_t idxBase, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const float *,
+      const float *, int, int, const float *, const int *, const float *,
+      float *, cusparseIndexBase_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgemvi");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, alpha, A, lda, nnz, xVal, xInd, beta, y, idxBase, pBuffer);
+  return func_ptr(handle, transA, m, n, alpha, A, lda, nnz, xVal, xInd, beta, y,
+                  idxBase, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSgemvi_bufferSize( cusparseHandle_t handle,
-    cusparseOperation_t transA,
-    int m,
-    int n,
-    int nnz,
-    int *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, int *);
+cusparseStatus_t CUSPARSEAPI
+cusparseSgemvi_bufferSize(cusparseHandle_t handle, cusparseOperation_t transA,
+                          int m, int n, int nnz, int *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgemvi_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, transA, m, n, nnz, pBufferSize);
 }
 
-cusparseStatus_t  CUSPARSEAPI cusparseDgemvi(cusparseHandle_t handle,
-                                    cusparseOperation_t transA,
-                                    int m,
-                                    int n,
-                                    const double *alpha, /* host or device pointer */
-                                    const double *A,
-                                    int lda,
-                                    int nnz,
-                                    const double *xVal,
-                                    const int *xInd,
-                                    const double *beta, /* host or device pointer */
-                                    double *y,
-                                    cusparseIndexBase_t   idxBase,
-                                    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const double *, const double *, int, int, const double *, const int *, const double *, double *, cusparseIndexBase_t, void *);
+cusparseStatus_t CUSPARSEAPI
+cusparseDgemvi(cusparseHandle_t handle, cusparseOperation_t transA, int m,
+               int n, const double *alpha, const double *A, int lda, int nnz,
+               const double *xVal, const int *xInd, const double *beta,
+               double *y, cusparseIndexBase_t idxBase, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const double *,
+      const double *, int, int, const double *, const int *, const double *,
+      double *, cusparseIndexBase_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgemvi");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, alpha, A, lda, nnz, xVal, xInd, beta, y, idxBase, pBuffer);
+  return func_ptr(handle, transA, m, n, alpha, A, lda, nnz, xVal, xInd, beta, y,
+                  idxBase, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDgemvi_bufferSize( cusparseHandle_t handle,
-    cusparseOperation_t transA,
-    int m,
-    int n,
-    int nnz,
-    int *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, int *);
+cusparseStatus_t CUSPARSEAPI
+cusparseDgemvi_bufferSize(cusparseHandle_t handle, cusparseOperation_t transA,
+                          int m, int n, int nnz, int *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgemvi_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, transA, m, n, nnz, pBufferSize);
 }
 
-cusparseStatus_t  CUSPARSEAPI cusparseCgemvi(cusparseHandle_t handle,
-                                    cusparseOperation_t transA,
-                                    int m,
-                                    int n,
-                                    const cuComplex *alpha, /* host or device pointer */
-                                    const cuComplex *A,
-                                    int lda,
-                                    int nnz,
-                                    const cuComplex *xVal,
-                                    const int *xInd,
-                                    const cuComplex *beta, /* host or device pointer */
-                                    cuComplex *y,
-                                    cusparseIndexBase_t   idxBase,
-                                    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cuComplex *, const cuComplex *, int, int, const cuComplex *, const int *, const cuComplex *, cuComplex *, cusparseIndexBase_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCgemvi(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int n,
+    const cuComplex *alpha, const cuComplex *A, int lda, int nnz,
+    const cuComplex *xVal, const int *xInd, const cuComplex *beta, cuComplex *y,
+    cusparseIndexBase_t idxBase, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const cuComplex *,
+      const cuComplex *, int, int, const cuComplex *, const int *,
+      const cuComplex *, cuComplex *, cusparseIndexBase_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgemvi");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, alpha, A, lda, nnz, xVal, xInd, beta, y, idxBase, pBuffer);
+  return func_ptr(handle, transA, m, n, alpha, A, lda, nnz, xVal, xInd, beta, y,
+                  idxBase, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCgemvi_bufferSize( cusparseHandle_t handle,
-    cusparseOperation_t transA,
-    int m,
-    int n,
-    int nnz,
-    int *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, int *);
+cusparseStatus_t CUSPARSEAPI
+cusparseCgemvi_bufferSize(cusparseHandle_t handle, cusparseOperation_t transA,
+                          int m, int n, int nnz, int *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgemvi_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, transA, m, n, nnz, pBufferSize);
 }
 
-cusparseStatus_t  CUSPARSEAPI cusparseZgemvi(cusparseHandle_t handle,
-                                    cusparseOperation_t transA,
-                                    int m,
-                                    int n,
-                                    const cuDoubleComplex *alpha, /* host or device pointer */
-                                    const cuDoubleComplex *A,
-                                    int lda,
-                                    int nnz,
-                                    const cuDoubleComplex *xVal,
-                                    const int *xInd,
-                                    const cuDoubleComplex *beta, /* host or device pointer */
-                                    cuDoubleComplex *y,
-                                    cusparseIndexBase_t   idxBase,
-                                    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cuDoubleComplex *, const cuDoubleComplex *, int, int, const cuDoubleComplex *, const int *, const cuDoubleComplex *, cuDoubleComplex *, cusparseIndexBase_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZgemvi(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int n,
+    const cuDoubleComplex *alpha, const cuDoubleComplex *A, int lda, int nnz,
+    const cuDoubleComplex *xVal, const int *xInd, const cuDoubleComplex *beta,
+    cuDoubleComplex *y, cusparseIndexBase_t idxBase, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const cuDoubleComplex *,
+      const cuDoubleComplex *, int, int, const cuDoubleComplex *, const int *,
+      const cuDoubleComplex *, cuDoubleComplex *, cusparseIndexBase_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgemvi");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, alpha, A, lda, nnz, xVal, xInd, beta, y, idxBase, pBuffer);
+  return func_ptr(handle, transA, m, n, alpha, A, lda, nnz, xVal, xInd, beta, y,
+                  idxBase, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZgemvi_bufferSize( cusparseHandle_t handle,
-    cusparseOperation_t transA,
-    int m,
-    int n,
-    int nnz,
-    int *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, int *);
+cusparseStatus_t CUSPARSEAPI
+cusparseZgemvi_bufferSize(cusparseHandle_t handle, cusparseOperation_t transA,
+                          int m, int n, int nnz, int *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgemvi_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, transA, m, n, nnz, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrmv(cusparseHandle_t handle,
-                                            cusparseOperation_t transA,
-                                            int m,
-                                            int n,
-                                            int nnz,
-                                            const float *alpha,
-                                            const cusparseMatDescr_t descrA,
-                                            const float *csrSortedValA,
-                                            const int *csrSortedRowPtrA,
-                                            const int *csrSortedColIndA,
-                                            const float *x,
-                                            const float *beta,
-                                            float *y) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, const float *, const float *, float *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrmv(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int nnz,
+    const float *alpha, const cusparseMatDescr_t descrA,
+    const float *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, const float *x, const float *beta, float *y) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, int, const float *,
+      const cusparseMatDescr_t, const float *, const int *, const int *,
+      const float *, const float *, float *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrmv");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
+  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrmv(cusparseHandle_t handle,
-                                            cusparseOperation_t transA,
-                                            int m,
-                                            int n,
-                                            int nnz,
-                                            const double *alpha,
-                                            const cusparseMatDescr_t descrA,
-                                            const double *csrSortedValA,
-                                            const int *csrSortedRowPtrA,
-                                            const int *csrSortedColIndA,
-                                            const double *x,
-                                            const double *beta,
-                                            double *y) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, const double *, const double *, double *);
+cusparseStatus_t CUSPARSEAPI
+cusparseDcsrmv(cusparseHandle_t handle, cusparseOperation_t transA, int m,
+               int n, int nnz, const double *alpha,
+               const cusparseMatDescr_t descrA, const double *csrSortedValA,
+               const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+               const double *x, const double *beta, double *y) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, int, const double *,
+      const cusparseMatDescr_t, const double *, const int *, const int *,
+      const double *, const double *, double *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrmv");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
+  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrmv(cusparseHandle_t handle,
-                                            cusparseOperation_t transA,
-                                            int m,
-                                            int n,
-                                            int nnz,
-                                            const cuComplex *alpha,
-                                            const cusparseMatDescr_t descrA,
-                                            const cuComplex *csrSortedValA,
-                                            const int *csrSortedRowPtrA,
-                                            const int *csrSortedColIndA,
-                                            const cuComplex *x,
-                                            const cuComplex *beta,
-                                            cuComplex *y) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, const cuComplex *, const cuComplex *, cuComplex *);
+cusparseStatus_t CUSPARSEAPI
+cusparseCcsrmv(cusparseHandle_t handle, cusparseOperation_t transA, int m,
+               int n, int nnz, const cuComplex *alpha,
+               const cusparseMatDescr_t descrA, const cuComplex *csrSortedValA,
+               const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+               const cuComplex *x, const cuComplex *beta, cuComplex *y) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, int, const cuComplex *,
+      const cusparseMatDescr_t, const cuComplex *, const int *, const int *,
+      const cuComplex *, const cuComplex *, cuComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrmv");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
+  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrmv(cusparseHandle_t handle,
-                                            cusparseOperation_t transA,
-                                            int m,
-                                            int n,
-                                            int nnz,
-                                            const cuDoubleComplex *alpha,
-                                            const cusparseMatDescr_t descrA,
-                                            const cuDoubleComplex *csrSortedValA,
-                                            const int *csrSortedRowPtrA,
-                                            const int *csrSortedColIndA,
-                                            const cuDoubleComplex *x,
-                                            const cuDoubleComplex *beta,
-                                            cuDoubleComplex *y) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, const cuDoubleComplex *, const cuDoubleComplex *, cuDoubleComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrmv(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int nnz,
+    const cuDoubleComplex *alpha, const cusparseMatDescr_t descrA,
+    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, const cuDoubleComplex *x,
+    const cuDoubleComplex *beta, cuDoubleComplex *y) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, int,
+      const cuDoubleComplex *, const cusparseMatDescr_t,
+      const cuDoubleComplex *, const int *, const int *,
+      const cuDoubleComplex *, const cuDoubleComplex *, cuDoubleComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrmv");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
+  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCsrmvEx_bufferSize(cusparseHandle_t handle,
-                                                        cusparseAlgMode_t alg,
-                                                        cusparseOperation_t transA,
-                                                        int m,
-                                                        int n,
-                                                        int nnz,
-                                                        const void *alpha,
-                                                        cudaDataType alphatype,
-                                                        const cusparseMatDescr_t descrA,
-                                                        const void *csrValA,
-                                                        cudaDataType csrValAtype,
-                                                        const int *csrRowPtrA,
-                                                        const int *csrColIndA,
-                                                        const void *x,
-                                                        cudaDataType xtype,
-                                                        const void *beta,
-                                                        cudaDataType betatype,
-                                                        void *y,
-                                                        cudaDataType ytype,
-                                                        cudaDataType executiontype,
-                                                        size_t *bufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseAlgMode_t, cusparseOperation_t, int, int, int, const void *, cudaDataType, const cusparseMatDescr_t, const void *, cudaDataType, const int *, const int *, const void *, cudaDataType, const void *, cudaDataType, void *, cudaDataType, cudaDataType, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseCsrmvEx_bufferSize(
+    cusparseHandle_t handle, cusparseAlgMode_t alg, cusparseOperation_t transA,
+    int m, int n, int nnz, const void *alpha, cudaDataType alphatype,
+    const cusparseMatDescr_t descrA, const void *csrValA,
+    cudaDataType csrValAtype, const int *csrRowPtrA, const int *csrColIndA,
+    const void *x, cudaDataType xtype, const void *beta, cudaDataType betatype,
+    void *y, cudaDataType ytype, cudaDataType executiontype,
+    size_t *bufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseAlgMode_t, cusparseOperation_t, int, int, int,
+      const void *, cudaDataType, const cusparseMatDescr_t, const void *,
+      cudaDataType, const int *, const int *, const void *, cudaDataType,
+      const void *, cudaDataType, void *, cudaDataType, cudaDataType, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCsrmvEx_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, alg, transA, m, n, nnz, alpha, alphatype, descrA, csrValA, csrValAtype, csrRowPtrA, csrColIndA, x, xtype, beta, betatype, y, ytype, executiontype, bufferSizeInBytes);
+  return func_ptr(handle, alg, transA, m, n, nnz, alpha, alphatype, descrA,
+                  csrValA, csrValAtype, csrRowPtrA, csrColIndA, x, xtype, beta,
+                  betatype, y, ytype, executiontype, bufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCsrmvEx(cusparseHandle_t handle,
-                                             cusparseAlgMode_t alg,
-                                             cusparseOperation_t transA,
-                                             int m,
-                                             int n,
-                                             int nnz,
-                                             const void *alpha,
-                                             cudaDataType alphatype,
-                                             const cusparseMatDescr_t descrA,
-                                             const void *csrValA,
-                                             cudaDataType csrValAtype,
-                                             const int *csrRowPtrA,
-                                             const int *csrColIndA,
-                                             const void *x,
-                                             cudaDataType xtype,
-                                             const void *beta,
-                                             cudaDataType betatype,
-                                             void *y,
-                                             cudaDataType ytype,
-                                             cudaDataType executiontype,
-                                             void* buffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseAlgMode_t, cusparseOperation_t, int, int, int, const void *, cudaDataType, const cusparseMatDescr_t, const void *, cudaDataType, const int *, const int *, const void *, cudaDataType, const void *, cudaDataType, void *, cudaDataType, cudaDataType, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCsrmvEx(
+    cusparseHandle_t handle, cusparseAlgMode_t alg, cusparseOperation_t transA,
+    int m, int n, int nnz, const void *alpha, cudaDataType alphatype,
+    const cusparseMatDescr_t descrA, const void *csrValA,
+    cudaDataType csrValAtype, const int *csrRowPtrA, const int *csrColIndA,
+    const void *x, cudaDataType xtype, const void *beta, cudaDataType betatype,
+    void *y, cudaDataType ytype, cudaDataType executiontype, void *buffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseAlgMode_t, cusparseOperation_t, int, int, int,
+      const void *, cudaDataType, const cusparseMatDescr_t, const void *,
+      cudaDataType, const int *, const int *, const void *, cudaDataType,
+      const void *, cudaDataType, void *, cudaDataType, cudaDataType, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCsrmvEx");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, alg, transA, m, n, nnz, alpha, alphatype, descrA, csrValA, csrValAtype, csrRowPtrA, csrColIndA, x, xtype, beta, betatype, y, ytype, executiontype, buffer);
+  return func_ptr(handle, alg, transA, m, n, nnz, alpha, alphatype, descrA,
+                  csrValA, csrValAtype, csrRowPtrA, csrColIndA, x, xtype, beta,
+                  betatype, y, ytype, executiontype, buffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrmv_mp(cusparseHandle_t handle,
-                                            cusparseOperation_t transA,
-                                            int m,
-                                            int n,
-                                            int nnz,
-                                            const float *alpha,
-                                            const cusparseMatDescr_t descrA,
-                                            const float *csrSortedValA,
-                                            const int *csrSortedRowPtrA,
-                                            const int *csrSortedColIndA,
-                                            const float *x,
-                                            const float *beta,
-                                            float *y) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, const float *, const float *, float *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrmv_mp(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int nnz,
+    const float *alpha, const cusparseMatDescr_t descrA,
+    const float *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, const float *x, const float *beta, float *y) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, int, const float *,
+      const cusparseMatDescr_t, const float *, const int *, const int *,
+      const float *, const float *, float *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrmv_mp");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
+  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrmv_mp(cusparseHandle_t handle,
-                                            cusparseOperation_t transA,
-                                            int m,
-                                            int n,
-                                            int nnz,
-                                            const double *alpha,
-                                            const cusparseMatDescr_t descrA,
-                                            const double *csrSortedValA,
-                                            const int *csrSortedRowPtrA,
-                                            const int *csrSortedColIndA,
-                                            const double *x,
-                                            const double *beta,
-                                            double *y) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, const double *, const double *, double *);
+cusparseStatus_t CUSPARSEAPI
+cusparseDcsrmv_mp(cusparseHandle_t handle, cusparseOperation_t transA, int m,
+                  int n, int nnz, const double *alpha,
+                  const cusparseMatDescr_t descrA, const double *csrSortedValA,
+                  const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+                  const double *x, const double *beta, double *y) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, int, const double *,
+      const cusparseMatDescr_t, const double *, const int *, const int *,
+      const double *, const double *, double *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrmv_mp");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
+  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrmv_mp(cusparseHandle_t handle,
-                                            cusparseOperation_t transA,
-                                            int m,
-                                            int n,
-                                            int nnz,
-                                            const cuComplex *alpha,
-                                            const cusparseMatDescr_t descrA,
-                                            const cuComplex *csrSortedValA,
-                                            const int *csrSortedRowPtrA,
-                                            const int *csrSortedColIndA,
-                                            const cuComplex *x,
-                                            const cuComplex *beta,
-                                            cuComplex *y) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, const cuComplex *, const cuComplex *, cuComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrmv_mp(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int nnz,
+    const cuComplex *alpha, const cusparseMatDescr_t descrA,
+    const cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, const cuComplex *x, const cuComplex *beta,
+    cuComplex *y) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, int, const cuComplex *,
+      const cusparseMatDescr_t, const cuComplex *, const int *, const int *,
+      const cuComplex *, const cuComplex *, cuComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrmv_mp");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
+  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrmv_mp(cusparseHandle_t handle,
-                                            cusparseOperation_t transA,
-                                            int m,
-                                            int n,
-                                            int nnz,
-                                            const cuDoubleComplex *alpha,
-                                            const cusparseMatDescr_t descrA,
-                                            const cuDoubleComplex *csrSortedValA,
-                                            const int *csrSortedRowPtrA,
-                                            const int *csrSortedColIndA,
-                                            const cuDoubleComplex *x,
-                                            const cuDoubleComplex *beta,
-                                            cuDoubleComplex *y) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, const cuDoubleComplex *, const cuDoubleComplex *, cuDoubleComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrmv_mp(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int nnz,
+    const cuDoubleComplex *alpha, const cusparseMatDescr_t descrA,
+    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, const cuDoubleComplex *x,
+    const cuDoubleComplex *beta, cuDoubleComplex *y) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, int,
+      const cuDoubleComplex *, const cusparseMatDescr_t,
+      const cuDoubleComplex *, const int *, const int *,
+      const cuDoubleComplex *, const cuDoubleComplex *, cuDoubleComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrmv_mp");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
+  return func_ptr(handle, transA, m, n, nnz, alpha, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseShybmv(cusparseHandle_t handle,
-                                            cusparseOperation_t transA,
-                                            const float *alpha,
-                                            const cusparseMatDescr_t descrA,
-                                            const cusparseHybMat_t hybA,
-                                            const float *x,
-                                            const float *beta,
-                                            float *y) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, const float *, const cusparseMatDescr_t, const cusparseHybMat_t, const float *, const float *, float *);
+cusparseStatus_t CUSPARSEAPI cusparseShybmv(
+    cusparseHandle_t handle, cusparseOperation_t transA, const float *alpha,
+    const cusparseMatDescr_t descrA, const cusparseHybMat_t hybA,
+    const float *x, const float *beta, float *y) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, const float *,
+      const cusparseMatDescr_t, const cusparseHybMat_t, const float *,
+      const float *, float *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseShybmv");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, transA, alpha, descrA, hybA, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDhybmv(cusparseHandle_t handle,
-                                            cusparseOperation_t transA,
-                                            const double *alpha,
-                                            const cusparseMatDescr_t descrA,
-                                            const cusparseHybMat_t hybA,
-                                            const double *x,
-                                            const double *beta,
-                                            double *y) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, const double *, const cusparseMatDescr_t, const cusparseHybMat_t, const double *, const double *, double *);
+cusparseStatus_t CUSPARSEAPI cusparseDhybmv(
+    cusparseHandle_t handle, cusparseOperation_t transA, const double *alpha,
+    const cusparseMatDescr_t descrA, const cusparseHybMat_t hybA,
+    const double *x, const double *beta, double *y) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, const double *,
+      const cusparseMatDescr_t, const cusparseHybMat_t, const double *,
+      const double *, double *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDhybmv");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, transA, alpha, descrA, hybA, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseChybmv(cusparseHandle_t handle,
-                                            cusparseOperation_t transA,
-                                            const cuComplex *alpha,
-                                            const cusparseMatDescr_t descrA,
-                                            const cusparseHybMat_t hybA,
-                                            const cuComplex *x,
-                                            const cuComplex *beta,
-                                            cuComplex *y) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, const cuComplex *, const cusparseMatDescr_t, const cusparseHybMat_t, const cuComplex *, const cuComplex *, cuComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseChybmv(
+    cusparseHandle_t handle, cusparseOperation_t transA, const cuComplex *alpha,
+    const cusparseMatDescr_t descrA, const cusparseHybMat_t hybA,
+    const cuComplex *x, const cuComplex *beta, cuComplex *y) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, const cuComplex *,
+      const cusparseMatDescr_t, const cusparseHybMat_t, const cuComplex *,
+      const cuComplex *, cuComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseChybmv");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, transA, alpha, descrA, hybA, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZhybmv(cusparseHandle_t handle,
-                                            cusparseOperation_t transA,
-                                            const cuDoubleComplex *alpha,
-                                            const cusparseMatDescr_t descrA,
-                                            const cusparseHybMat_t hybA,
-                                            const cuDoubleComplex *x,
-                                            const cuDoubleComplex *beta,
-                                            cuDoubleComplex *y) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, const cuDoubleComplex *, const cusparseMatDescr_t, const cusparseHybMat_t, const cuDoubleComplex *, const cuDoubleComplex *, cuDoubleComplex *);
+cusparseStatus_t CUSPARSEAPI
+cusparseZhybmv(cusparseHandle_t handle, cusparseOperation_t transA,
+               const cuDoubleComplex *alpha, const cusparseMatDescr_t descrA,
+               const cusparseHybMat_t hybA, const cuDoubleComplex *x,
+               const cuDoubleComplex *beta, cuDoubleComplex *y) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, const cuDoubleComplex *,
+      const cusparseMatDescr_t, const cusparseHybMat_t, const cuDoubleComplex *,
+      const cuDoubleComplex *, cuDoubleComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZhybmv");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, transA, alpha, descrA, hybA, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsrmv(cusparseHandle_t handle,
-                                            cusparseDirection_t dirA,
-                                            cusparseOperation_t transA,
-                                            int mb,
-                                            int nb,
-                                            int nnzb,
-                                            const float *alpha,
-                                            const cusparseMatDescr_t descrA,
-                                            const float *bsrSortedValA,
-                                            const int *bsrSortedRowPtrA,
-                                            const int *bsrSortedColIndA,
-                                            int  blockDim,
-                                            const float *x,
-                                            const float *beta,
-                                            float *y) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, int, const float *, const float *, float *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsrmv(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, int mb, int nb, int nnzb, const float *alpha,
+    const cusparseMatDescr_t descrA, const float *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
+    const float *x, const float *beta, float *y) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int,
+      const float *, const cusparseMatDescr_t, const float *, const int *,
+      const int *, int, const float *, const float *, float *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrmv");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, x, beta, y);
+  return func_ptr(handle, dirA, transA, mb, nb, nnzb, alpha, descrA,
+                  bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim,
+                  x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsrmv(cusparseHandle_t handle,
-                                            cusparseDirection_t dirA,
-                                            cusparseOperation_t transA,
-                                            int mb,
-                                            int nb,
-                                            int nnzb,
-                                            const double *alpha,
-                                            const cusparseMatDescr_t descrA,
-                                            const double *bsrSortedValA,
-                                            const int *bsrSortedRowPtrA,
-                                            const int *bsrSortedColIndA,
-                                            int  blockDim,
-                                            const double *x,
-                                            const double *beta,
-                                            double *y) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, int, const double *, const double *, double *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsrmv(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, int mb, int nb, int nnzb, const double *alpha,
+    const cusparseMatDescr_t descrA, const double *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
+    const double *x, const double *beta, double *y) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int,
+      const double *, const cusparseMatDescr_t, const double *, const int *,
+      const int *, int, const double *, const double *, double *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrmv");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, x, beta, y);
+  return func_ptr(handle, dirA, transA, mb, nb, nnzb, alpha, descrA,
+                  bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim,
+                  x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsrmv(cusparseHandle_t handle,
-                                            cusparseDirection_t dirA,
-                                            cusparseOperation_t transA,
-                                            int mb,
-                                            int nb,
-                                            int nnzb,
-                                            const cuComplex *alpha,
-                                            const cusparseMatDescr_t descrA,
-                                            const cuComplex *bsrSortedValA,
-                                            const int *bsrSortedRowPtrA,
-                                            const int *bsrSortedColIndA,
-                                            int  blockDim,
-                                            const cuComplex *x,
-                                            const cuComplex *beta,
-                                            cuComplex *y) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, int, const cuComplex *, const cuComplex *, cuComplex *);
+cusparseStatus_t CUSPARSEAPI
+cusparseCbsrmv(cusparseHandle_t handle, cusparseDirection_t dirA,
+               cusparseOperation_t transA, int mb, int nb, int nnzb,
+               const cuComplex *alpha, const cusparseMatDescr_t descrA,
+               const cuComplex *bsrSortedValA, const int *bsrSortedRowPtrA,
+               const int *bsrSortedColIndA, int blockDim, const cuComplex *x,
+               const cuComplex *beta, cuComplex *y) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int,
+      const cuComplex *, const cusparseMatDescr_t, const cuComplex *,
+      const int *, const int *, int, const cuComplex *, const cuComplex *,
+      cuComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrmv");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, x, beta, y);
+  return func_ptr(handle, dirA, transA, mb, nb, nnzb, alpha, descrA,
+                  bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim,
+                  x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrmv(cusparseHandle_t handle,
-                                            cusparseDirection_t dirA,
-                                            cusparseOperation_t transA,
-                                            int mb,
-                                            int nb,
-                                            int nnzb,
-                                            const cuDoubleComplex *alpha,
-                                            const cusparseMatDescr_t descrA,
-                                            const cuDoubleComplex *bsrSortedValA,
-                                            const int *bsrSortedRowPtrA,
-                                            const int *bsrSortedColIndA,
-                                            int  blockDim,
-                                            const cuDoubleComplex *x,
-                                            const cuDoubleComplex *beta,
-                                            cuDoubleComplex *y) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, int, const cuDoubleComplex *, const cuDoubleComplex *, cuDoubleComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrmv(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, int mb, int nb, int nnzb,
+    const cuDoubleComplex *alpha, const cusparseMatDescr_t descrA,
+    const cuDoubleComplex *bsrSortedValA, const int *bsrSortedRowPtrA,
+    const int *bsrSortedColIndA, int blockDim, const cuDoubleComplex *x,
+    const cuDoubleComplex *beta, cuDoubleComplex *y) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int,
+      const cuDoubleComplex *, const cusparseMatDescr_t,
+      const cuDoubleComplex *, const int *, const int *, int,
+      const cuDoubleComplex *, const cuDoubleComplex *, cuDoubleComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrmv");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, x, beta, y);
+  return func_ptr(handle, dirA, transA, mb, nb, nnzb, alpha, descrA,
+                  bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim,
+                  x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsrxmv(cusparseHandle_t handle,
-                                             cusparseDirection_t dirA,
-                                             cusparseOperation_t transA,
-                                             int sizeOfMask,
-                                             int mb,
-                                             int nb,
-                                             int nnzb,
-                                             const float *alpha,
-                                             const cusparseMatDescr_t descrA,
-                                             const float *bsrSortedValA,
-                                             const int *bsrSortedMaskPtrA,
-                                             const int *bsrSortedRowPtrA,
-                                             const int *bsrSortedEndPtrA,
-                                             const int *bsrSortedColIndA,
-                                             int  blockDim,
-                                             const float *x,
-                                             const float *beta,
-                                             float *y) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int, int, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, const int *, const int *, int, const float *, const float *, float *);
+cusparseStatus_t CUSPARSEAPI
+cusparseSbsrxmv(cusparseHandle_t handle, cusparseDirection_t dirA,
+                cusparseOperation_t transA, int sizeOfMask, int mb, int nb,
+                int nnzb, const float *alpha, const cusparseMatDescr_t descrA,
+                const float *bsrSortedValA, const int *bsrSortedMaskPtrA,
+                const int *bsrSortedRowPtrA, const int *bsrSortedEndPtrA,
+                const int *bsrSortedColIndA, int blockDim, const float *x,
+                const float *beta, float *y) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int,
+      int, const float *, const cusparseMatDescr_t, const float *, const int *,
+      const int *, const int *, const int *, int, const float *, const float *,
+      float *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrxmv");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, sizeOfMask, mb, nb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedMaskPtrA, bsrSortedRowPtrA, bsrSortedEndPtrA, bsrSortedColIndA, blockDim, x, beta, y);
+  return func_ptr(handle, dirA, transA, sizeOfMask, mb, nb, nnzb, alpha, descrA,
+                  bsrSortedValA, bsrSortedMaskPtrA, bsrSortedRowPtrA,
+                  bsrSortedEndPtrA, bsrSortedColIndA, blockDim, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsrxmv(cusparseHandle_t handle,
-                                             cusparseDirection_t dirA,
-                                             cusparseOperation_t transA,
-                                             int sizeOfMask,
-                                             int mb,
-                                             int nb,
-                                             int nnzb,
-                                             const double *alpha,
-                                             const cusparseMatDescr_t descrA,
-                                             const double *bsrSortedValA,
-                                             const int *bsrSortedMaskPtrA,
-                                             const int *bsrSortedRowPtrA,
-                                             const int *bsrSortedEndPtrA,
-                                             const int *bsrSortedColIndA,
-                                             int  blockDim,
-                                             const double *x,
-                                             const double *beta,
-                                             double *y) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, const int *, const int *, int, const double *, const double *, double *);
+cusparseStatus_t CUSPARSEAPI
+cusparseDbsrxmv(cusparseHandle_t handle, cusparseDirection_t dirA,
+                cusparseOperation_t transA, int sizeOfMask, int mb, int nb,
+                int nnzb, const double *alpha, const cusparseMatDescr_t descrA,
+                const double *bsrSortedValA, const int *bsrSortedMaskPtrA,
+                const int *bsrSortedRowPtrA, const int *bsrSortedEndPtrA,
+                const int *bsrSortedColIndA, int blockDim, const double *x,
+                const double *beta, double *y) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int,
+      int, const double *, const cusparseMatDescr_t, const double *,
+      const int *, const int *, const int *, const int *, int, const double *,
+      const double *, double *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrxmv");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, sizeOfMask, mb, nb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedMaskPtrA, bsrSortedRowPtrA, bsrSortedEndPtrA, bsrSortedColIndA, blockDim, x, beta, y);
+  return func_ptr(handle, dirA, transA, sizeOfMask, mb, nb, nnzb, alpha, descrA,
+                  bsrSortedValA, bsrSortedMaskPtrA, bsrSortedRowPtrA,
+                  bsrSortedEndPtrA, bsrSortedColIndA, blockDim, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsrxmv(cusparseHandle_t handle,
-                                             cusparseDirection_t dirA,
-                                             cusparseOperation_t transA,
-                                             int sizeOfMask,
-                                             int mb,
-                                             int nb,
-                                             int nnzb,
-                                             const cuComplex *alpha,
-                                             const cusparseMatDescr_t descrA,
-                                             const cuComplex *bsrSortedValA,
-                                             const int *bsrSortedMaskPtrA,
-                                             const int *bsrSortedRowPtrA,
-                                             const int *bsrSortedEndPtrA,
-                                             const int *bsrSortedColIndA,
-                                             int  blockDim,
-                                             const cuComplex *x,
-                                             const cuComplex *beta,
-                                             cuComplex *y) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int, int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, const int *, const int *, int, const cuComplex *, const cuComplex *, cuComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsrxmv(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, int sizeOfMask, int mb, int nb, int nnzb,
+    const cuComplex *alpha, const cusparseMatDescr_t descrA,
+    const cuComplex *bsrSortedValA, const int *bsrSortedMaskPtrA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedEndPtrA,
+    const int *bsrSortedColIndA, int blockDim, const cuComplex *x,
+    const cuComplex *beta, cuComplex *y) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int,
+      int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *,
+      const int *, const int *, const int *, const int *, int,
+      const cuComplex *, const cuComplex *, cuComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrxmv");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, sizeOfMask, mb, nb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedMaskPtrA, bsrSortedRowPtrA, bsrSortedEndPtrA, bsrSortedColIndA, blockDim, x, beta, y);
+  return func_ptr(handle, dirA, transA, sizeOfMask, mb, nb, nnzb, alpha, descrA,
+                  bsrSortedValA, bsrSortedMaskPtrA, bsrSortedRowPtrA,
+                  bsrSortedEndPtrA, bsrSortedColIndA, blockDim, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrxmv(cusparseHandle_t handle,
-                                             cusparseDirection_t dirA,
-                                             cusparseOperation_t transA,
-                                             int sizeOfMask,
-                                             int mb,
-                                             int nb,
-                                             int nnzb,
-                                             const cuDoubleComplex *alpha,
-                                             const cusparseMatDescr_t descrA,
-                                             const cuDoubleComplex *bsrSortedValA,
-                                             const int *bsrSortedMaskPtrA,
-                                             const int *bsrSortedRowPtrA,
-                                             const int *bsrSortedEndPtrA,
-                                             const int *bsrSortedColIndA,
-                                             int  blockDim,
-                                             const cuDoubleComplex *x,
-                                             const cuDoubleComplex *beta,
-                                             cuDoubleComplex *y) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, const int *, const int *, int, const cuDoubleComplex *, const cuDoubleComplex *, cuDoubleComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrxmv(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, int sizeOfMask, int mb, int nb, int nnzb,
+    const cuDoubleComplex *alpha, const cusparseMatDescr_t descrA,
+    const cuDoubleComplex *bsrSortedValA, const int *bsrSortedMaskPtrA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedEndPtrA,
+    const int *bsrSortedColIndA, int blockDim, const cuDoubleComplex *x,
+    const cuDoubleComplex *beta, cuDoubleComplex *y) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, int,
+      int, const cuDoubleComplex *, const cusparseMatDescr_t,
+      const cuDoubleComplex *, const int *, const int *, const int *,
+      const int *, int, const cuDoubleComplex *, const cuDoubleComplex *,
+      cuDoubleComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrxmv");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, sizeOfMask, mb, nb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedMaskPtrA, bsrSortedRowPtrA, bsrSortedEndPtrA, bsrSortedColIndA, blockDim, x, beta, y);
+  return func_ptr(handle, dirA, transA, sizeOfMask, mb, nb, nnzb, alpha, descrA,
+                  bsrSortedValA, bsrSortedMaskPtrA, bsrSortedRowPtrA,
+                  bsrSortedEndPtrA, bsrSortedColIndA, blockDim, x, beta, y);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCsrsv_analysisEx(cusparseHandle_t handle,
-                                                     cusparseOperation_t transA,
-                                                     int m,
-                                                     int nnz,
-                                                     const cusparseMatDescr_t descrA,
-                                                     const void *csrSortedValA,
-                                                     cudaDataType csrSortedValAtype,
-                                                     const int *csrSortedRowPtrA,
-                                                     const int *csrSortedColIndA,
-                                                     cusparseSolveAnalysisInfo_t info,
-                                                     cudaDataType executiontype) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const void *, cudaDataType, const int *, const int *, cusparseSolveAnalysisInfo_t, cudaDataType);
+cusparseStatus_t CUSPARSEAPI cusparseCsrsv_analysisEx(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
+    const cusparseMatDescr_t descrA, const void *csrSortedValA,
+    cudaDataType csrSortedValAtype, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, cusparseSolveAnalysisInfo_t info,
+    cudaDataType executiontype) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
+      const void *, cudaDataType, const int *, const int *,
+      cusparseSolveAnalysisInfo_t, cudaDataType);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCsrsv_analysisEx");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedValAtype, csrSortedRowPtrA, csrSortedColIndA, info, executiontype);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
+                  csrSortedValAtype, csrSortedRowPtrA, csrSortedColIndA, info,
+                  executiontype);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrsv_analysis(cusparseHandle_t handle,
-                                                     cusparseOperation_t transA,
-                                                     int m,
-                                                     int nnz,
-                                                     const cusparseMatDescr_t descrA,
-                                                     const float *csrSortedValA,
-                                                     const int *csrSortedRowPtrA,
-                                                     const int *csrSortedColIndA,
-                                                     cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseScsrsv_analysis(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
+    const cusparseMatDescr_t descrA, const float *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
+      const float *, const int *, const int *, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrsv_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrsv_analysis(cusparseHandle_t handle,
-                                                     cusparseOperation_t transA,
-                                                     int m,
-                                                     int nnz,
-                                                     const cusparseMatDescr_t descrA,
-                                                     const double *csrSortedValA,
-                                                     const int *csrSortedRowPtrA,
-                                                     const int *csrSortedColIndA,
-                                                     cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrsv_analysis(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
+    const cusparseMatDescr_t descrA, const double *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
+      const double *, const int *, const int *, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrsv_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrsv_analysis(cusparseHandle_t handle,
-                                                     cusparseOperation_t transA,
-                                                     int m,
-                                                     int nnz,
-                                                     const cusparseMatDescr_t descrA,
-                                                     const cuComplex *csrSortedValA,
-                                                     const int *csrSortedRowPtrA,
-                                                     const int *csrSortedColIndA,
-                                                     cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrsv_analysis(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
+    const cusparseMatDescr_t descrA, const cuComplex *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
+      const cuComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrsv_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrsv_analysis(cusparseHandle_t handle,
-                                                     cusparseOperation_t transA,
-                                                     int m,
-                                                     int nnz,
-                                                     const cusparseMatDescr_t descrA,
-                                                     const cuDoubleComplex *csrSortedValA,
-                                                     const int *csrSortedRowPtrA,
-                                                     const int *csrSortedColIndA,
-                                                     cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrsv_analysis(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
+    const cusparseMatDescr_t descrA, const cuDoubleComplex *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
+      const cuDoubleComplex *, const int *, const int *,
+      cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrsv_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCsrsv_solveEx(cusparseHandle_t handle,
-                                                   cusparseOperation_t transA,
-                                                   int m,
-                                                   const void *alpha,
-                                                   cudaDataType alphatype,
-                                                   const cusparseMatDescr_t descrA,
-                                                   const void *csrSortedValA,
-                                                   cudaDataType csrSortedValAtype,
-                                                   const int *csrSortedRowPtrA,
-                                                   const int *csrSortedColIndA,
-                                                   cusparseSolveAnalysisInfo_t info,
-                                                   const void *f,
-                                                   cudaDataType ftype,
-                                                   void *x,
-                                                   cudaDataType xtype,
-                                                   cudaDataType executiontype) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, const void *, cudaDataType, const cusparseMatDescr_t, const void *, cudaDataType, const int *, const int *, cusparseSolveAnalysisInfo_t, const void *, cudaDataType, void *, cudaDataType, cudaDataType);
+cusparseStatus_t CUSPARSEAPI cusparseCsrsv_solveEx(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m,
+    const void *alpha, cudaDataType alphatype, const cusparseMatDescr_t descrA,
+    const void *csrSortedValA, cudaDataType csrSortedValAtype,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    cusparseSolveAnalysisInfo_t info, const void *f, cudaDataType ftype,
+    void *x, cudaDataType xtype, cudaDataType executiontype) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, const void *, cudaDataType,
+      const cusparseMatDescr_t, const void *, cudaDataType, const int *,
+      const int *, cusparseSolveAnalysisInfo_t, const void *, cudaDataType,
+      void *, cudaDataType, cudaDataType);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCsrsv_solveEx");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, alpha, alphatype, descrA, csrSortedValA, csrSortedValAtype, csrSortedRowPtrA, csrSortedColIndA, info, f, ftype, x, xtype, executiontype);
+  return func_ptr(handle, transA, m, alpha, alphatype, descrA, csrSortedValA,
+                  csrSortedValAtype, csrSortedRowPtrA, csrSortedColIndA, info,
+                  f, ftype, x, xtype, executiontype);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrsv_solve(cusparseHandle_t handle,
-                                                  cusparseOperation_t transA,
-                                                  int m,
-                                                  const float *alpha,
-                                                  const cusparseMatDescr_t descrA,
-                                                  const float *csrSortedValA,
-                                                  const int *csrSortedRowPtrA,
-                                                  const int *csrSortedColIndA,
-                                                  cusparseSolveAnalysisInfo_t info,
-                                                  const float *f,
-                                                  float *x) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, cusparseSolveAnalysisInfo_t, const float *, float *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrsv_solve(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m,
+    const float *alpha, const cusparseMatDescr_t descrA,
+    const float *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, cusparseSolveAnalysisInfo_t info,
+    const float *f, float *x) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, const float *,
+      const cusparseMatDescr_t, const float *, const int *, const int *,
+      cusparseSolveAnalysisInfo_t, const float *, float *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrsv_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, f, x);
+  return func_ptr(handle, transA, m, alpha, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info, f, x);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrsv_solve(cusparseHandle_t handle,
-                                                  cusparseOperation_t transA,
-                                                  int m,
-                                                  const double *alpha,
-                                                  const cusparseMatDescr_t descrA,
-                                                  const double *csrSortedValA,
-                                                  const int *csrSortedRowPtrA,
-                                                  const int *csrSortedColIndA,
-                                                  cusparseSolveAnalysisInfo_t info,
-                                                  const double *f,
-                                                  double *x) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, cusparseSolveAnalysisInfo_t, const double *, double *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrsv_solve(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m,
+    const double *alpha, const cusparseMatDescr_t descrA,
+    const double *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, cusparseSolveAnalysisInfo_t info,
+    const double *f, double *x) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, const double *,
+      const cusparseMatDescr_t, const double *, const int *, const int *,
+      cusparseSolveAnalysisInfo_t, const double *, double *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrsv_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, f, x);
+  return func_ptr(handle, transA, m, alpha, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info, f, x);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrsv_solve(cusparseHandle_t handle,
-                                                  cusparseOperation_t transA,
-                                                  int m,
-                                                  const cuComplex *alpha,
-                                                  const cusparseMatDescr_t descrA,
-                                                  const cuComplex *csrSortedValA,
-                                                  const int *csrSortedRowPtrA,
-                                                  const int *csrSortedColIndA,
-                                                  cusparseSolveAnalysisInfo_t info,
-                                                  const cuComplex *f,
-                                                  cuComplex *x) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t, const cuComplex *, cuComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrsv_solve(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m,
+    const cuComplex *alpha, const cusparseMatDescr_t descrA,
+    const cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, cusparseSolveAnalysisInfo_t info,
+    const cuComplex *f, cuComplex *x) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, const cuComplex *,
+      const cusparseMatDescr_t, const cuComplex *, const int *, const int *,
+      cusparseSolveAnalysisInfo_t, const cuComplex *, cuComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrsv_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, f, x);
+  return func_ptr(handle, transA, m, alpha, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info, f, x);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrsv_solve(cusparseHandle_t handle,
-                                                  cusparseOperation_t transA,
-                                                  int m,
-                                                  const cuDoubleComplex *alpha,
-                                                  const cusparseMatDescr_t descrA,
-                                                  const cuDoubleComplex *csrSortedValA,
-                                                  const int *csrSortedRowPtrA,
-                                                  const int *csrSortedColIndA,
-                                                  cusparseSolveAnalysisInfo_t info,
-                                                  const cuDoubleComplex *f,
-                                                  cuDoubleComplex *x) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, const cuDoubleComplex *, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t, const cuDoubleComplex *, cuDoubleComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrsv_solve(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m,
+    const cuDoubleComplex *alpha, const cusparseMatDescr_t descrA,
+    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, cusparseSolveAnalysisInfo_t info,
+    const cuDoubleComplex *f, cuDoubleComplex *x) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, const cuDoubleComplex *,
+      const cusparseMatDescr_t, const cuDoubleComplex *, const int *,
+      const int *, cusparseSolveAnalysisInfo_t, const cuDoubleComplex *,
+      cuDoubleComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrsv_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, f, x);
+  return func_ptr(handle, transA, m, alpha, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info, f, x);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseXcsrsv2_zeroPivot(cusparseHandle_t handle,
                                                        csrsv2Info_t info,
                                                        int *position) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, csrsv2Info_t, int *);
+  using FuncPtr =
+      cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, csrsv2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcsrsv2_zeroPivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, position);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrsv2_bufferSize(cusparseHandle_t handle,
-                                                        cusparseOperation_t transA,
-                                                        int m,
-                                                        int nnz,
-                                                        const cusparseMatDescr_t descrA,
-                                                        float *csrSortedValA,
-                                                        const int *csrSortedRowPtrA,
-                                                        const int *csrSortedColIndA,
-                                                        csrsv2Info_t info,
-                                                        int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, csrsv2Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrsv2_bufferSize(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
+    const cusparseMatDescr_t descrA, float *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, csrsv2Info_t info,
+    int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
+      float *, const int *, const int *, csrsv2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrsv2_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrsv2_bufferSize(cusparseHandle_t handle,
-                                                        cusparseOperation_t transA,
-                                                        int m,
-                                                        int nnz,
-                                                        const cusparseMatDescr_t descrA,
-                                                        double *csrSortedValA,
-                                                        const int *csrSortedRowPtrA,
-                                                        const int *csrSortedColIndA,
-                                                        csrsv2Info_t info,
-                                                        int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, csrsv2Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrsv2_bufferSize(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
+    const cusparseMatDescr_t descrA, double *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, csrsv2Info_t info,
+    int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
+      double *, const int *, const int *, csrsv2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrsv2_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrsv2_bufferSize(cusparseHandle_t handle,
-                                                        cusparseOperation_t transA,
-                                                        int m,
-                                                        int nnz,
-                                                        const cusparseMatDescr_t descrA,
-                                                        cuComplex *csrSortedValA,
-                                                        const int *csrSortedRowPtrA,
-                                                        const int *csrSortedColIndA,
-                                                        csrsv2Info_t info,
-                                                        int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, csrsv2Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrsv2_bufferSize(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
+    const cusparseMatDescr_t descrA, cuComplex *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, csrsv2Info_t info,
+    int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
+      cuComplex *, const int *, const int *, csrsv2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrsv2_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrsv2_bufferSize(cusparseHandle_t handle,
-                                                        cusparseOperation_t transA,
-                                                        int m,
-                                                        int nnz,
-                                                        const cusparseMatDescr_t descrA,
-                                                        cuDoubleComplex *csrSortedValA,
-                                                        const int *csrSortedRowPtrA,
-                                                        const int *csrSortedColIndA,
-                                                        csrsv2Info_t info,
-                                                        int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, csrsv2Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrsv2_bufferSize(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
+    const cusparseMatDescr_t descrA, cuDoubleComplex *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, csrsv2Info_t info,
+    int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
+      cuDoubleComplex *, const int *, const int *, csrsv2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrsv2_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrsv2_bufferSizeExt(cusparseHandle_t handle,
-                                                        cusparseOperation_t transA,
-                                                        int m,
-                                                        int nnz,
-                                                        const cusparseMatDescr_t descrA,
-                                                        float *csrSortedValA,
-                                                        const int *csrSortedRowPtrA,
-                                                        const int *csrSortedColIndA,
-                                                        csrsv2Info_t info,
-                                                        size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, csrsv2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrsv2_bufferSizeExt(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
+    const cusparseMatDescr_t descrA, float *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, csrsv2Info_t info,
+    size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
+      float *, const int *, const int *, csrsv2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrsv2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSize);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrsv2_bufferSizeExt(cusparseHandle_t handle,
-                                                        cusparseOperation_t transA,
-                                                        int m,
-                                                        int nnz,
-                                                        const cusparseMatDescr_t descrA,
-                                                        double *csrSortedValA,
-                                                        const int *csrSortedRowPtrA,
-                                                        const int *csrSortedColIndA,
-                                                        csrsv2Info_t info,
-                                                        size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, csrsv2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrsv2_bufferSizeExt(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
+    const cusparseMatDescr_t descrA, double *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, csrsv2Info_t info,
+    size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
+      double *, const int *, const int *, csrsv2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrsv2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSize);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrsv2_bufferSizeExt(cusparseHandle_t handle,
-                                                        cusparseOperation_t transA,
-                                                        int m,
-                                                        int nnz,
-                                                        const cusparseMatDescr_t descrA,
-                                                        cuComplex *csrSortedValA,
-                                                        const int *csrSortedRowPtrA,
-                                                        const int *csrSortedColIndA,
-                                                        csrsv2Info_t info,
-                                                        size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, csrsv2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrsv2_bufferSizeExt(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
+    const cusparseMatDescr_t descrA, cuComplex *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, csrsv2Info_t info,
+    size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
+      cuComplex *, const int *, const int *, csrsv2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrsv2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSize);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrsv2_bufferSizeExt(cusparseHandle_t handle,
-                                                        cusparseOperation_t transA,
-                                                        int m,
-                                                        int nnz,
-                                                        const cusparseMatDescr_t descrA,
-                                                        cuDoubleComplex *csrSortedValA,
-                                                        const int *csrSortedRowPtrA,
-                                                        const int *csrSortedColIndA,
-                                                        csrsv2Info_t info,
-                                                        size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, csrsv2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrsv2_bufferSizeExt(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
+    const cusparseMatDescr_t descrA, cuDoubleComplex *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, csrsv2Info_t info,
+    size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
+      cuDoubleComplex *, const int *, const int *, csrsv2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrsv2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSize);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrsv2_analysis(cusparseHandle_t handle,
-                                                      cusparseOperation_t transA,
-                                                      int m,
-                                                      int nnz,
-                                                      const cusparseMatDescr_t descrA,
-                                                      const float *csrSortedValA,
-                                                      const int *csrSortedRowPtrA,
-                                                      const int *csrSortedColIndA,
-                                                      csrsv2Info_t info,
-                                                      cusparseSolvePolicy_t policy,
-                                                      void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, csrsv2Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrsv2_analysis(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
+    const cusparseMatDescr_t descrA, const float *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, csrsv2Info_t info,
+    cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
+      const float *, const int *, const int *, csrsv2Info_t,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrsv2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrsv2_analysis(cusparseHandle_t handle,
-                                                      cusparseOperation_t transA,
-                                                      int m,
-                                                      int nnz,
-                                                      const cusparseMatDescr_t descrA,
-                                                      const double *csrSortedValA,
-                                                      const int *csrSortedRowPtrA,
-                                                      const int *csrSortedColIndA,
-                                                      csrsv2Info_t info,
-                                                      cusparseSolvePolicy_t policy,
-                                                      void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, csrsv2Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrsv2_analysis(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
+    const cusparseMatDescr_t descrA, const double *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, csrsv2Info_t info,
+    cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
+      const double *, const int *, const int *, csrsv2Info_t,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrsv2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrsv2_analysis(cusparseHandle_t handle,
-                                                      cusparseOperation_t transA,
-                                                      int m,
-                                                      int nnz,
-                                                      const cusparseMatDescr_t descrA,
-                                                      const cuComplex *csrSortedValA,
-                                                      const int *csrSortedRowPtrA,
-                                                      const int *csrSortedColIndA,
-                                                      csrsv2Info_t info,
-                                                      cusparseSolvePolicy_t policy,
-                                                      void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, csrsv2Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrsv2_analysis(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
+    const cusparseMatDescr_t descrA, const cuComplex *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, csrsv2Info_t info,
+    cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
+      const cuComplex *, const int *, const int *, csrsv2Info_t,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrsv2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrsv2_analysis(cusparseHandle_t handle,
-                                                      cusparseOperation_t transA,
-                                                      int m,
-                                                      int nnz,
-                                                      const cusparseMatDescr_t descrA,
-                                                      const cuDoubleComplex *csrSortedValA,
-                                                      const int *csrSortedRowPtrA,
-                                                      const int *csrSortedColIndA,
-                                                      csrsv2Info_t info,
-                                                      cusparseSolvePolicy_t policy,
-                                                      void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, csrsv2Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrsv2_analysis(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
+    const cusparseMatDescr_t descrA, const cuDoubleComplex *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, csrsv2Info_t info,
+    cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
+      const cuDoubleComplex *, const int *, const int *, csrsv2Info_t,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrsv2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrsv2_solve(cusparseHandle_t handle,
-                                                   cusparseOperation_t transA,
-                                                   int m,
-                                                   int nnz,
-                                                   const float *alpha,
-                                                   const cusparseMatDescr_t descrA,
-                                                   const float *csrSortedValA,
-                                                   const int *csrSortedRowPtrA,
-                                                   const int *csrSortedColIndA,
-                                                   csrsv2Info_t info,
-                                                   const float *f,
-                                                   float *x,
-                                                   cusparseSolvePolicy_t policy,
-                                                   void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, csrsv2Info_t, const float *, float *, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrsv2_solve(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
+    const float *alpha, const cusparseMatDescr_t descrA,
+    const float *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, csrsv2Info_t info, const float *f, float *x,
+    cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const float *,
+      const cusparseMatDescr_t, const float *, const int *, const int *,
+      csrsv2Info_t, const float *, float *, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrsv2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, f, x, policy, pBuffer);
+  return func_ptr(handle, transA, m, nnz, alpha, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info, f, x, policy,
+                  pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrsv2_solve(cusparseHandle_t handle,
-                                                   cusparseOperation_t transA,
-                                                   int m,
-                                                   int nnz,
-                                                   const double *alpha,
-                                                   const cusparseMatDescr_t descrA,
-                                                   const double *csrSortedValA,
-                                                   const int *csrSortedRowPtrA,
-                                                   const int *csrSortedColIndA,
-                                                   csrsv2Info_t info,
-                                                   const double *f,
-                                                   double *x,
-                                                   cusparseSolvePolicy_t policy,
-                                                   void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, csrsv2Info_t, const double *, double *, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrsv2_solve(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
+    const double *alpha, const cusparseMatDescr_t descrA,
+    const double *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, csrsv2Info_t info, const double *f, double *x,
+    cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const double *,
+      const cusparseMatDescr_t, const double *, const int *, const int *,
+      csrsv2Info_t, const double *, double *, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrsv2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, f, x, policy, pBuffer);
+  return func_ptr(handle, transA, m, nnz, alpha, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info, f, x, policy,
+                  pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrsv2_solve(cusparseHandle_t handle,
-                                                   cusparseOperation_t transA,
-                                                   int m,
-                                                   int nnz,
-                                                   const cuComplex *alpha,
-                                                   const cusparseMatDescr_t descrA,
-                                                   const cuComplex *csrSortedValA,
-                                                   const int *csrSortedRowPtrA,
-                                                   const int *csrSortedColIndA,
-                                                   csrsv2Info_t info,
-                                                   const cuComplex *f,
-                                                   cuComplex *x,
-                                                   cusparseSolvePolicy_t policy,
-                                                   void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, csrsv2Info_t, const cuComplex *, cuComplex *, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrsv2_solve(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
+    const cuComplex *alpha, const cusparseMatDescr_t descrA,
+    const cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, csrsv2Info_t info, const cuComplex *f,
+    cuComplex *x, cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const cuComplex *,
+      const cusparseMatDescr_t, const cuComplex *, const int *, const int *,
+      csrsv2Info_t, const cuComplex *, cuComplex *, cusparseSolvePolicy_t,
+      void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrsv2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, f, x, policy, pBuffer);
+  return func_ptr(handle, transA, m, nnz, alpha, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info, f, x, policy,
+                  pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrsv2_solve(cusparseHandle_t handle,
-                                                   cusparseOperation_t transA,
-                                                   int m,
-                                                   int nnz,
-                                                   const cuDoubleComplex *alpha,
-                                                   const cusparseMatDescr_t descrA,
-                                                   const cuDoubleComplex *csrSortedValA,
-                                                   const int *csrSortedRowPtrA,
-                                                   const int *csrSortedColIndA,
-                                                   csrsv2Info_t info,
-                                                   const cuDoubleComplex *f,
-                                                   cuDoubleComplex *x,
-                                                   cusparseSolvePolicy_t policy,
-                                                   void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, csrsv2Info_t, const cuDoubleComplex *, cuDoubleComplex *, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrsv2_solve(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
+    const cuDoubleComplex *alpha, const cusparseMatDescr_t descrA,
+    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, csrsv2Info_t info, const cuDoubleComplex *f,
+    cuDoubleComplex *x, cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const cuDoubleComplex *,
+      const cusparseMatDescr_t, const cuDoubleComplex *, const int *,
+      const int *, csrsv2Info_t, const cuDoubleComplex *, cuDoubleComplex *,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrsv2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, f, x, policy, pBuffer);
+  return func_ptr(handle, transA, m, nnz, alpha, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info, f, x, policy,
+                  pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseXbsrsv2_zeroPivot(cusparseHandle_t handle,
                                                        bsrsv2Info_t info,
                                                        int *position) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, bsrsv2Info_t, int *);
+  using FuncPtr =
+      cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, bsrsv2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXbsrsv2_zeroPivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, position);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsrsv2_bufferSize(cusparseHandle_t handle,
-                                                        cusparseDirection_t dirA,
-                                                        cusparseOperation_t transA,
-                                                        int mb,
-                                                        int nnzb,
-                                                        const cusparseMatDescr_t descrA,
-                                                        float *bsrSortedValA,
-                                                        const int *bsrSortedRowPtrA,
-                                                        const int *bsrSortedColIndA,
-                                                        int blockDim,
-                                                        bsrsv2Info_t info,
-                                                        int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, int, bsrsv2Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsrsv2_bufferSize(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, float *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
+    bsrsv2Info_t info, int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
+      const cusparseMatDescr_t, float *, const int *, const int *, int,
+      bsrsv2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrsv2_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA,
+                  bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info,
+                  pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsrsv2_bufferSize(cusparseHandle_t handle,
-                                                        cusparseDirection_t dirA,
-                                                        cusparseOperation_t transA,
-                                                        int mb,
-                                                        int nnzb,
-                                                        const cusparseMatDescr_t descrA,
-                                                        double *bsrSortedValA,
-                                                        const int *bsrSortedRowPtrA,
-                                                        const int *bsrSortedColIndA,
-                                                        int blockDim,
-                                                        bsrsv2Info_t info,
-                                                        int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, int, bsrsv2Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsrsv2_bufferSize(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, double *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
+    bsrsv2Info_t info, int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
+      const cusparseMatDescr_t, double *, const int *, const int *, int,
+      bsrsv2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrsv2_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA,
+                  bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info,
+                  pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsrsv2_bufferSize(cusparseHandle_t handle,
-                                                        cusparseDirection_t dirA,
-                                                        cusparseOperation_t transA,
-                                                        int mb,
-                                                        int nnzb,
-                                                        const cusparseMatDescr_t descrA,
-                                                        cuComplex *bsrSortedValA,
-                                                        const int *bsrSortedRowPtrA,
-                                                        const int *bsrSortedColIndA,
-                                                        int blockDim,
-                                                        bsrsv2Info_t info,
-                                                        int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, int, bsrsv2Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsrsv2_bufferSize(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, cuComplex *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
+    bsrsv2Info_t info, int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
+      const cusparseMatDescr_t, cuComplex *, const int *, const int *, int,
+      bsrsv2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrsv2_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA,
+                  bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info,
+                  pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrsv2_bufferSize(cusparseHandle_t handle,
-                                                        cusparseDirection_t dirA,
-                                                        cusparseOperation_t transA,
-                                                        int mb,
-                                                        int nnzb,
-                                                        const cusparseMatDescr_t descrA,
-                                                        cuDoubleComplex *bsrSortedValA,
-                                                        const int *bsrSortedRowPtrA,
-                                                        const int *bsrSortedColIndA,
-                                                        int blockDim,
-                                                        bsrsv2Info_t info,
-                                                        int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, int, bsrsv2Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrsv2_bufferSize(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, cuDoubleComplex *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
+    bsrsv2Info_t info, int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
+      const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *,
+      int, bsrsv2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrsv2_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA,
+                  bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info,
+                  pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsrsv2_bufferSizeExt(cusparseHandle_t handle,
-                                                        cusparseDirection_t dirA,
-                                                        cusparseOperation_t transA,
-                                                        int mb,
-                                                        int nnzb,
-                                                        const cusparseMatDescr_t descrA,
-                                                        float *bsrSortedValA,
-                                                        const int *bsrSortedRowPtrA,
-                                                        const int *bsrSortedColIndA,
-                                                        int blockSize,
-                                                        bsrsv2Info_t info,
-                                                        size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, int, bsrsv2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsrsv2_bufferSizeExt(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, float *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockSize,
+    bsrsv2Info_t info, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
+      const cusparseMatDescr_t, float *, const int *, const int *, int,
+      bsrsv2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrsv2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockSize, info, pBufferSize);
+  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA,
+                  bsrSortedRowPtrA, bsrSortedColIndA, blockSize, info,
+                  pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsrsv2_bufferSizeExt(cusparseHandle_t handle,
-                                                        cusparseDirection_t dirA,
-                                                        cusparseOperation_t transA,
-                                                        int mb,
-                                                        int nnzb,
-                                                        const cusparseMatDescr_t descrA,
-                                                        double *bsrSortedValA,
-                                                        const int *bsrSortedRowPtrA,
-                                                        const int *bsrSortedColIndA,
-                                                        int blockSize,
-                                                        bsrsv2Info_t info,
-                                                        size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, int, bsrsv2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsrsv2_bufferSizeExt(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, double *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockSize,
+    bsrsv2Info_t info, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
+      const cusparseMatDescr_t, double *, const int *, const int *, int,
+      bsrsv2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrsv2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockSize, info, pBufferSize);
+  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA,
+                  bsrSortedRowPtrA, bsrSortedColIndA, blockSize, info,
+                  pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsrsv2_bufferSizeExt(cusparseHandle_t handle,
-                                                        cusparseDirection_t dirA,
-                                                        cusparseOperation_t transA,
-                                                        int mb,
-                                                        int nnzb,
-                                                        const cusparseMatDescr_t descrA,
-                                                        cuComplex *bsrSortedValA,
-                                                        const int *bsrSortedRowPtrA,
-                                                        const int *bsrSortedColIndA,
-                                                        int blockSize,
-                                                        bsrsv2Info_t info,
-                                                        size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, int, bsrsv2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsrsv2_bufferSizeExt(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, cuComplex *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockSize,
+    bsrsv2Info_t info, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
+      const cusparseMatDescr_t, cuComplex *, const int *, const int *, int,
+      bsrsv2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrsv2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockSize, info, pBufferSize);
+  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA,
+                  bsrSortedRowPtrA, bsrSortedColIndA, blockSize, info,
+                  pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrsv2_bufferSizeExt(cusparseHandle_t handle,
-                                                        cusparseDirection_t dirA,
-                                                        cusparseOperation_t transA,
-                                                        int mb,
-                                                        int nnzb,
-                                                        const cusparseMatDescr_t descrA,
-                                                        cuDoubleComplex *bsrSortedValA,
-                                                        const int *bsrSortedRowPtrA,
-                                                        const int *bsrSortedColIndA,
-                                                        int blockSize,
-                                                        bsrsv2Info_t info,
-                                                        size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, int, bsrsv2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrsv2_bufferSizeExt(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, cuDoubleComplex *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockSize,
+    bsrsv2Info_t info, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
+      const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *,
+      int, bsrsv2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrsv2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockSize, info, pBufferSize);
+  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA,
+                  bsrSortedRowPtrA, bsrSortedColIndA, blockSize, info,
+                  pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsrsv2_analysis(cusparseHandle_t handle,
-                                                      cusparseDirection_t dirA,
-                                                      cusparseOperation_t transA,
-                                                      int mb,
-                                                      int nnzb,
-                                                      const cusparseMatDescr_t descrA,
-                                                      const float *bsrSortedValA,
-                                                      const int *bsrSortedRowPtrA,
-                                                      const int *bsrSortedColIndA,
-                                                      int blockDim,
-                                                      bsrsv2Info_t info,
-                                                      cusparseSolvePolicy_t policy,
-                                                      void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, int, bsrsv2Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsrsv2_analysis(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, const float *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
+    bsrsv2Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
+      const cusparseMatDescr_t, const float *, const int *, const int *, int,
+      bsrsv2Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrsv2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, policy, pBuffer);
+  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA,
+                  bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, policy,
+                  pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsrsv2_analysis(cusparseHandle_t handle,
-                                                      cusparseDirection_t dirA,
-                                                      cusparseOperation_t transA,
-                                                      int mb,
-                                                      int nnzb,
-                                                      const cusparseMatDescr_t descrA,
-                                                      const double *bsrSortedValA,
-                                                      const int *bsrSortedRowPtrA,
-                                                      const int *bsrSortedColIndA,
-                                                      int blockDim,
-                                                      bsrsv2Info_t info,
-                                                      cusparseSolvePolicy_t policy,
-                                                      void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, int, bsrsv2Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsrsv2_analysis(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, const double *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
+    bsrsv2Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
+      const cusparseMatDescr_t, const double *, const int *, const int *, int,
+      bsrsv2Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrsv2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, policy, pBuffer);
+  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA,
+                  bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, policy,
+                  pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsrsv2_analysis(cusparseHandle_t handle,
-                                                      cusparseDirection_t dirA,
-                                                      cusparseOperation_t transA,
-                                                      int mb,
-                                                      int nnzb,
-                                                      const cusparseMatDescr_t descrA,
-                                                      const cuComplex *bsrSortedValA,
-                                                      const int *bsrSortedRowPtrA,
-                                                      const int *bsrSortedColIndA,
-                                                      int blockDim,
-                                                      bsrsv2Info_t info,
-                                                      cusparseSolvePolicy_t policy,
-                                                      void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, int, bsrsv2Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsrsv2_analysis(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, const cuComplex *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
+    bsrsv2Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
+      const cusparseMatDescr_t, const cuComplex *, const int *, const int *,
+      int, bsrsv2Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrsv2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, policy, pBuffer);
+  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA,
+                  bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, policy,
+                  pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrsv2_analysis(cusparseHandle_t handle,
-                                                      cusparseDirection_t dirA,
-                                                      cusparseOperation_t transA,
-                                                      int mb,
-                                                      int nnzb,
-                                                      const cusparseMatDescr_t descrA,
-                                                      const cuDoubleComplex *bsrSortedValA,
-                                                      const int *bsrSortedRowPtrA,
-                                                      const int *bsrSortedColIndA,
-                                                      int blockDim,
-                                                      bsrsv2Info_t info,
-                                                      cusparseSolvePolicy_t policy,
-                                                      void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, int, bsrsv2Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrsv2_analysis(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, const cuDoubleComplex *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
+    bsrsv2Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
+      const cusparseMatDescr_t, const cuDoubleComplex *, const int *,
+      const int *, int, bsrsv2Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrsv2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, policy, pBuffer);
+  return func_ptr(handle, dirA, transA, mb, nnzb, descrA, bsrSortedValA,
+                  bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, policy,
+                  pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsrsv2_solve(cusparseHandle_t handle,
-                                                   cusparseDirection_t dirA,
-                                                   cusparseOperation_t transA,
-                                                   int mb,
-                                                   int nnzb,
-                                                   const float *alpha,
-                                                   const cusparseMatDescr_t descrA,
-                                                   const float *bsrSortedValA,
-                                                   const int *bsrSortedRowPtrA,
-                                                   const int *bsrSortedColIndA,
-                                                   int blockDim,
-                                                   bsrsv2Info_t info,
-                                                   const float *f,
-                                                   float *x,
-                                                   cusparseSolvePolicy_t policy,
-                                                   void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, int, bsrsv2Info_t, const float *, float *, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsrsv2_solve(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, int mb, int nnzb, const float *alpha,
+    const cusparseMatDescr_t descrA, const float *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
+    bsrsv2Info_t info, const float *f, float *x, cusparseSolvePolicy_t policy,
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
+      const float *, const cusparseMatDescr_t, const float *, const int *,
+      const int *, int, bsrsv2Info_t, const float *, float *,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrsv2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, f, x, policy, pBuffer);
+  return func_ptr(handle, dirA, transA, mb, nnzb, alpha, descrA, bsrSortedValA,
+                  bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, f, x,
+                  policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsrsv2_solve(cusparseHandle_t handle,
-                                                   cusparseDirection_t dirA,
-                                                   cusparseOperation_t transA,
-                                                   int mb,
-                                                   int nnzb,
-                                                   const double *alpha,
-                                                   const cusparseMatDescr_t descrA,
-                                                   const double *bsrSortedValA,
-                                                   const int *bsrSortedRowPtrA,
-                                                   const int *bsrSortedColIndA,
-                                                   int blockDim,
-                                                   bsrsv2Info_t info,
-                                                   const double *f,
-                                                   double *x,
-                                                   cusparseSolvePolicy_t policy,
-                                                   void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, int, bsrsv2Info_t, const double *, double *, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsrsv2_solve(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, int mb, int nnzb, const double *alpha,
+    const cusparseMatDescr_t descrA, const double *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
+    bsrsv2Info_t info, const double *f, double *x, cusparseSolvePolicy_t policy,
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
+      const double *, const cusparseMatDescr_t, const double *, const int *,
+      const int *, int, bsrsv2Info_t, const double *, double *,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrsv2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, f, x, policy, pBuffer);
+  return func_ptr(handle, dirA, transA, mb, nnzb, alpha, descrA, bsrSortedValA,
+                  bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, f, x,
+                  policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsrsv2_solve(cusparseHandle_t handle,
-                                                   cusparseDirection_t dirA,
-                                                   cusparseOperation_t transA,
-                                                   int mb,
-                                                   int nnzb,
-                                                   const cuComplex *alpha,
-                                                   const cusparseMatDescr_t descrA,
-                                                   const cuComplex *bsrSortedValA,
-                                                   const int *bsrSortedRowPtrA,
-                                                   const int *bsrSortedColIndA,
-                                                   int blockDim,
-                                                   bsrsv2Info_t info,
-                                                   const cuComplex *f,
-                                                   cuComplex *x,
-                                                   cusparseSolvePolicy_t policy,
-                                                   void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, int, bsrsv2Info_t, const cuComplex *, cuComplex *, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsrsv2_solve(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, int mb, int nnzb, const cuComplex *alpha,
+    const cusparseMatDescr_t descrA, const cuComplex *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
+    bsrsv2Info_t info, const cuComplex *f, cuComplex *x,
+    cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
+      const cuComplex *, const cusparseMatDescr_t, const cuComplex *,
+      const int *, const int *, int, bsrsv2Info_t, const cuComplex *,
+      cuComplex *, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrsv2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, f, x, policy, pBuffer);
+  return func_ptr(handle, dirA, transA, mb, nnzb, alpha, descrA, bsrSortedValA,
+                  bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, f, x,
+                  policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrsv2_solve(cusparseHandle_t handle,
-                                                   cusparseDirection_t dirA,
-                                                   cusparseOperation_t transA,
-                                                   int mb,
-                                                   int nnzb,
-                                                   const cuDoubleComplex *alpha,
-                                                   const cusparseMatDescr_t descrA,
-                                                   const cuDoubleComplex *bsrSortedValA,
-                                                   const int *bsrSortedRowPtrA,
-                                                   const int *bsrSortedColIndA,
-                                                   int blockDim,
-                                                   bsrsv2Info_t info,
-                                                   const cuDoubleComplex *f,
-                                                   cuDoubleComplex *x,
-                                                   cusparseSolvePolicy_t policy,
-                                                   void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, int, bsrsv2Info_t, const cuDoubleComplex *, cuDoubleComplex *, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrsv2_solve(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, int mb, int nnzb, const cuDoubleComplex *alpha,
+    const cusparseMatDescr_t descrA, const cuDoubleComplex *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
+    bsrsv2Info_t info, const cuDoubleComplex *f, cuDoubleComplex *x,
+    cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, int, int,
+      const cuDoubleComplex *, const cusparseMatDescr_t,
+      const cuDoubleComplex *, const int *, const int *, int, bsrsv2Info_t,
+      const cuDoubleComplex *, cuDoubleComplex *, cusparseSolvePolicy_t,
+      void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrsv2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, mb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, f, x, policy, pBuffer);
+  return func_ptr(handle, dirA, transA, mb, nnzb, alpha, descrA, bsrSortedValA,
+                  bsrSortedRowPtrA, bsrSortedColIndA, blockDim, info, f, x,
+                  policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseShybsv_analysis(cusparseHandle_t handle,
-                                                     cusparseOperation_t transA,
-                                                     const cusparseMatDescr_t descrA,
-                                                     cusparseHybMat_t hybA,
-                                                     cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, const cusparseMatDescr_t, cusparseHybMat_t, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI
+cusparseShybsv_analysis(cusparseHandle_t handle, cusparseOperation_t transA,
+                        const cusparseMatDescr_t descrA, cusparseHybMat_t hybA,
+                        cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, const cusparseMatDescr_t,
+      cusparseHybMat_t, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseShybsv_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, transA, descrA, hybA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDhybsv_analysis(cusparseHandle_t handle,
-                                                     cusparseOperation_t transA,
-                                                     const cusparseMatDescr_t descrA,
-                                                     cusparseHybMat_t hybA,
-                                                     cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, const cusparseMatDescr_t, cusparseHybMat_t, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI
+cusparseDhybsv_analysis(cusparseHandle_t handle, cusparseOperation_t transA,
+                        const cusparseMatDescr_t descrA, cusparseHybMat_t hybA,
+                        cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, const cusparseMatDescr_t,
+      cusparseHybMat_t, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDhybsv_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, transA, descrA, hybA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseChybsv_analysis(cusparseHandle_t handle,
-                                                     cusparseOperation_t transA,
-                                                     const cusparseMatDescr_t descrA,
-                                                     cusparseHybMat_t hybA,
-                                                     cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, const cusparseMatDescr_t, cusparseHybMat_t, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI
+cusparseChybsv_analysis(cusparseHandle_t handle, cusparseOperation_t transA,
+                        const cusparseMatDescr_t descrA, cusparseHybMat_t hybA,
+                        cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, const cusparseMatDescr_t,
+      cusparseHybMat_t, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseChybsv_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, transA, descrA, hybA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZhybsv_analysis(cusparseHandle_t handle,
-                                                     cusparseOperation_t transA,
-                                                     const cusparseMatDescr_t descrA,
-                                                     cusparseHybMat_t hybA,
-                                                     cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, const cusparseMatDescr_t, cusparseHybMat_t, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI
+cusparseZhybsv_analysis(cusparseHandle_t handle, cusparseOperation_t transA,
+                        const cusparseMatDescr_t descrA, cusparseHybMat_t hybA,
+                        cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, const cusparseMatDescr_t,
+      cusparseHybMat_t, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZhybsv_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, transA, descrA, hybA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseShybsv_solve(cusparseHandle_t handle,
-                                                  cusparseOperation_t trans,
-                                                  const float *alpha,
-                                                  const cusparseMatDescr_t descrA,
-                                                  const cusparseHybMat_t hybA,
-                                                  cusparseSolveAnalysisInfo_t info,
-                                                  const float *f,
-                                                  float *x) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, const float *, const cusparseMatDescr_t, const cusparseHybMat_t, cusparseSolveAnalysisInfo_t, const float *, float *);
+cusparseStatus_t CUSPARSEAPI cusparseShybsv_solve(
+    cusparseHandle_t handle, cusparseOperation_t trans, const float *alpha,
+    const cusparseMatDescr_t descrA, const cusparseHybMat_t hybA,
+    cusparseSolveAnalysisInfo_t info, const float *f, float *x) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, const float *,
+      const cusparseMatDescr_t, const cusparseHybMat_t,
+      cusparseSolveAnalysisInfo_t, const float *, float *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseShybsv_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, trans, alpha, descrA, hybA, info, f, x);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseChybsv_solve(cusparseHandle_t handle,
-                                                  cusparseOperation_t trans,
-                                                  const cuComplex *alpha,
-                                                  const cusparseMatDescr_t descrA,
-                                                  const cusparseHybMat_t hybA,
-                                                  cusparseSolveAnalysisInfo_t info,
-                                                  const cuComplex *f,
-                                                  cuComplex *x) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, const cuComplex *, const cusparseMatDescr_t, const cusparseHybMat_t, cusparseSolveAnalysisInfo_t, const cuComplex *, cuComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseChybsv_solve(
+    cusparseHandle_t handle, cusparseOperation_t trans, const cuComplex *alpha,
+    const cusparseMatDescr_t descrA, const cusparseHybMat_t hybA,
+    cusparseSolveAnalysisInfo_t info, const cuComplex *f, cuComplex *x) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, const cuComplex *,
+      const cusparseMatDescr_t, const cusparseHybMat_t,
+      cusparseSolveAnalysisInfo_t, const cuComplex *, cuComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseChybsv_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, trans, alpha, descrA, hybA, info, f, x);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDhybsv_solve(cusparseHandle_t handle,
-                                                  cusparseOperation_t trans,
-                                                  const double *alpha,
-                                                  const cusparseMatDescr_t descrA,
-                                                  const cusparseHybMat_t hybA,
-                                                  cusparseSolveAnalysisInfo_t info,
-                                                  const double *f,
-                                                  double *x) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, const double *, const cusparseMatDescr_t, const cusparseHybMat_t, cusparseSolveAnalysisInfo_t, const double *, double *);
+cusparseStatus_t CUSPARSEAPI cusparseDhybsv_solve(
+    cusparseHandle_t handle, cusparseOperation_t trans, const double *alpha,
+    const cusparseMatDescr_t descrA, const cusparseHybMat_t hybA,
+    cusparseSolveAnalysisInfo_t info, const double *f, double *x) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, const double *,
+      const cusparseMatDescr_t, const cusparseHybMat_t,
+      cusparseSolveAnalysisInfo_t, const double *, double *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDhybsv_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, trans, alpha, descrA, hybA, info, f, x);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZhybsv_solve(cusparseHandle_t handle,
-                                                  cusparseOperation_t trans,
-                                                  const cuDoubleComplex *alpha,
-                                                  const cusparseMatDescr_t descrA,
-                                                  const cusparseHybMat_t hybA,
-                                                  cusparseSolveAnalysisInfo_t info,
-                                                  const cuDoubleComplex *f,
-                                                  cuDoubleComplex *x) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, const cuDoubleComplex *, const cusparseMatDescr_t, const cusparseHybMat_t, cusparseSolveAnalysisInfo_t, const cuDoubleComplex *, cuDoubleComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseZhybsv_solve(
+    cusparseHandle_t handle, cusparseOperation_t trans,
+    const cuDoubleComplex *alpha, const cusparseMatDescr_t descrA,
+    const cusparseHybMat_t hybA, cusparseSolveAnalysisInfo_t info,
+    const cuDoubleComplex *f, cuDoubleComplex *x) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, const cuDoubleComplex *,
+      const cusparseMatDescr_t, const cusparseHybMat_t,
+      cusparseSolveAnalysisInfo_t, const cuDoubleComplex *, cuDoubleComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZhybsv_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, trans, alpha, descrA, hybA, info, f, x);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrmm(cusparseHandle_t handle,
-                                            cusparseOperation_t transA,
-                                            int m,
-                                            int n,
-                                            int k,
-                                            int nnz,
-                                            const float *alpha,
-                                            const cusparseMatDescr_t descrA,
-                                            const float  *csrSortedValA,
-                                            const int *csrSortedRowPtrA,
-                                            const int *csrSortedColIndA,
-                                            const float *B,
-                                            int ldb,
-                                            const float *beta,
-                                            float *C,
-                                            int ldc) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, int, const float *, const cusparseMatDescr_t, const float  *, const int *, const int *, const float *, int, const float *, float *, int);
+cusparseStatus_t CUSPARSEAPI
+cusparseScsrmm(cusparseHandle_t handle, cusparseOperation_t transA, int m,
+               int n, int k, int nnz, const float *alpha,
+               const cusparseMatDescr_t descrA, const float *csrSortedValA,
+               const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+               const float *B, int ldb, const float *beta, float *C, int ldc) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, int, int, const float *,
+      const cusparseMatDescr_t, const float *, const int *, const int *,
+      const float *, int, const float *, float *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrmm");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, k, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, beta, C, ldc);
+  return func_ptr(handle, transA, m, n, k, nnz, alpha, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, B, ldb, beta, C, ldc);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrmm(cusparseHandle_t handle,
-                                            cusparseOperation_t transA,
-                                            int m,
-                                            int n,
-                                            int k,
-                                            int nnz,
-                                            const double *alpha,
-                                            const cusparseMatDescr_t descrA,
-                                            const double *csrSortedValA,
-                                            const int *csrSortedRowPtrA,
-                                            const int *csrSortedColIndA,
-                                            const double *B,
-                                            int ldb,
-                                            const double *beta,
-                                            double *C,
-                                            int ldc) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, const double *, int, const double *, double *, int);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrmm(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int k,
+    int nnz, const double *alpha, const cusparseMatDescr_t descrA,
+    const double *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, const double *B, int ldb, const double *beta,
+    double *C, int ldc) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, int, int, const double *,
+      const cusparseMatDescr_t, const double *, const int *, const int *,
+      const double *, int, const double *, double *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrmm");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, k, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, beta, C, ldc);
+  return func_ptr(handle, transA, m, n, k, nnz, alpha, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, B, ldb, beta, C, ldc);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrmm(cusparseHandle_t handle,
-                                            cusparseOperation_t transA,
-                                            int m,
-                                            int n,
-                                            int k,
-                                            int nnz,
-                                            const cuComplex *alpha,
-                                            const cusparseMatDescr_t descrA,
-                                            const cuComplex  *csrSortedValA,
-                                            const int *csrSortedRowPtrA,
-                                            const int *csrSortedColIndA,
-                                            const cuComplex *B,
-                                            int ldb,
-                                            const cuComplex *beta,
-                                            cuComplex *C,
-                                            int ldc) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, int, const cuComplex *, const cusparseMatDescr_t, const cuComplex  *, const int *, const int *, const cuComplex *, int, const cuComplex *, cuComplex *, int);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrmm(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int k,
+    int nnz, const cuComplex *alpha, const cusparseMatDescr_t descrA,
+    const cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, const cuComplex *B, int ldb,
+    const cuComplex *beta, cuComplex *C, int ldc) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, int, int,
+      const cuComplex *, const cusparseMatDescr_t, const cuComplex *,
+      const int *, const int *, const cuComplex *, int, const cuComplex *,
+      cuComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrmm");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, k, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, beta, C, ldc);
+  return func_ptr(handle, transA, m, n, k, nnz, alpha, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, B, ldb, beta, C, ldc);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrmm(cusparseHandle_t handle,
-                                            cusparseOperation_t transA,
-                                            int m,
-                                            int n,
-                                            int k,
-                                            int nnz,
-                                            const cuDoubleComplex *alpha,
-                                            const cusparseMatDescr_t descrA,
-                                            const cuDoubleComplex  *csrSortedValA,
-                                            const int *csrSortedRowPtrA,
-                                            const int *csrSortedColIndA,
-                                            const cuDoubleComplex *B,
-                                            int ldb,
-                                            const cuDoubleComplex *beta,
-                                            cuDoubleComplex *C,
-                                            int ldc) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, const cuDoubleComplex  *, const int *, const int *, const cuDoubleComplex *, int, const cuDoubleComplex *, cuDoubleComplex *, int);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrmm(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int n, int k,
+    int nnz, const cuDoubleComplex *alpha, const cusparseMatDescr_t descrA,
+    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, const cuDoubleComplex *B, int ldb,
+    const cuDoubleComplex *beta, cuDoubleComplex *C, int ldc) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, int, int,
+      const cuDoubleComplex *, const cusparseMatDescr_t,
+      const cuDoubleComplex *, const int *, const int *,
+      const cuDoubleComplex *, int, const cuDoubleComplex *, cuDoubleComplex *,
+      int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrmm");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, k, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, beta, C, ldc);
+  return func_ptr(handle, transA, m, n, k, nnz, alpha, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, B, ldb, beta, C, ldc);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrmm2(cusparseHandle_t handle,
-                                             cusparseOperation_t transA,
-                                             cusparseOperation_t transB,
-                                             int m,
-                                             int n,
-                                             int k,
-                                             int nnz,
-                                             const float *alpha,
-                                             const cusparseMatDescr_t descrA,
-                                             const float *csrSortedValA,
-                                             const int *csrSortedRowPtrA,
-                                             const int *csrSortedColIndA,
-                                             const float *B,
-                                             int ldb,
-                                             const float *beta,
-                                             float *C,
-                                             int ldc) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int, int, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, const float *, int, const float *, float *, int);
+cusparseStatus_t CUSPARSEAPI
+cusparseScsrmm2(cusparseHandle_t handle, cusparseOperation_t transA,
+                cusparseOperation_t transB, int m, int n, int k, int nnz,
+                const float *alpha, const cusparseMatDescr_t descrA,
+                const float *csrSortedValA, const int *csrSortedRowPtrA,
+                const int *csrSortedColIndA, const float *B, int ldb,
+                const float *beta, float *C, int ldc) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int,
+      int, const float *, const cusparseMatDescr_t, const float *, const int *,
+      const int *, const float *, int, const float *, float *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrmm2");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, transB, m, n, k, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, beta, C, ldc);
+  return func_ptr(handle, transA, transB, m, n, k, nnz, alpha, descrA,
+                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
+                  beta, C, ldc);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrmm2(cusparseHandle_t handle,
-                                             cusparseOperation_t transA,
-                                             cusparseOperation_t transB,
-                                             int m,
-                                             int n,
-                                             int k,
-                                             int nnz,
-                                             const double *alpha,
-                                             const cusparseMatDescr_t descrA,
-                                             const double *csrSortedValA,
-                                             const int *csrSortedRowPtrA,
-                                             const int *csrSortedColIndA,
-                                             const double *B,
-                                             int ldb,
-                                             const double *beta,
-                                             double *C,
-                                             int ldc) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, const double *, int, const double *, double *, int);
+cusparseStatus_t CUSPARSEAPI
+cusparseDcsrmm2(cusparseHandle_t handle, cusparseOperation_t transA,
+                cusparseOperation_t transB, int m, int n, int k, int nnz,
+                const double *alpha, const cusparseMatDescr_t descrA,
+                const double *csrSortedValA, const int *csrSortedRowPtrA,
+                const int *csrSortedColIndA, const double *B, int ldb,
+                const double *beta, double *C, int ldc) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int,
+      int, const double *, const cusparseMatDescr_t, const double *,
+      const int *, const int *, const double *, int, const double *, double *,
+      int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrmm2");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, transB, m, n, k, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, beta, C, ldc);
+  return func_ptr(handle, transA, transB, m, n, k, nnz, alpha, descrA,
+                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
+                  beta, C, ldc);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrmm2(cusparseHandle_t handle,
-                                             cusparseOperation_t transA,
-                                             cusparseOperation_t transB,
-                                             int m,
-                                             int n,
-                                             int k,
-                                             int nnz,
-                                             const cuComplex *alpha,
-                                             const cusparseMatDescr_t descrA,
-                                             const cuComplex *csrSortedValA,
-                                             const int *csrSortedRowPtrA,
-                                             const int *csrSortedColIndA,
-                                             const cuComplex *B,
-                                             int ldb,
-                                             const cuComplex *beta,
-                                             cuComplex *C,
-                                             int ldc) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int, int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, const cuComplex *, int, const cuComplex *, cuComplex *, int);
+cusparseStatus_t CUSPARSEAPI
+cusparseCcsrmm2(cusparseHandle_t handle, cusparseOperation_t transA,
+                cusparseOperation_t transB, int m, int n, int k, int nnz,
+                const cuComplex *alpha, const cusparseMatDescr_t descrA,
+                const cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
+                const int *csrSortedColIndA, const cuComplex *B, int ldb,
+                const cuComplex *beta, cuComplex *C, int ldc) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int,
+      int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *,
+      const int *, const int *, const cuComplex *, int, const cuComplex *,
+      cuComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrmm2");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, transB, m, n, k, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, beta, C, ldc);
+  return func_ptr(handle, transA, transB, m, n, k, nnz, alpha, descrA,
+                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
+                  beta, C, ldc);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrmm2(cusparseHandle_t handle,
-                                             cusparseOperation_t transA,
-                                             cusparseOperation_t transB,
-                                             int m,
-                                             int n,
-                                             int k,
-                                             int nnz,
-                                             const cuDoubleComplex *alpha,
-                                             const cusparseMatDescr_t descrA,
-                                             const cuDoubleComplex *csrSortedValA,
-                                             const int *csrSortedRowPtrA,
-                                             const int *csrSortedColIndA,
-                                             const cuDoubleComplex *B,
-                                             int ldb,
-                                             const cuDoubleComplex *beta,
-                                             cuDoubleComplex *C,
-                                             int ldc) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, const cuDoubleComplex *, int, const cuDoubleComplex *, cuDoubleComplex *, int);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrmm2(
+    cusparseHandle_t handle, cusparseOperation_t transA,
+    cusparseOperation_t transB, int m, int n, int k, int nnz,
+    const cuDoubleComplex *alpha, const cusparseMatDescr_t descrA,
+    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, const cuDoubleComplex *B, int ldb,
+    const cuDoubleComplex *beta, cuDoubleComplex *C, int ldc) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int,
+      int, const cuDoubleComplex *, const cusparseMatDescr_t,
+      const cuDoubleComplex *, const int *, const int *,
+      const cuDoubleComplex *, int, const cuDoubleComplex *, cuDoubleComplex *,
+      int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrmm2");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, transB, m, n, k, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, beta, C, ldc);
+  return func_ptr(handle, transA, transB, m, n, k, nnz, alpha, descrA,
+                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
+                  beta, C, ldc);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsrmm(cusparseHandle_t handle,
-                                            cusparseDirection_t dirA,
-                                            cusparseOperation_t transA,
-                                            cusparseOperation_t transB,
-                                            int mb,
-                                            int n,
-                                            int kb,
-                                            int nnzb,
-                                            const float *alpha,
-                                            const cusparseMatDescr_t descrA,
-                                            const float *bsrSortedValA,
-                                            const int *bsrSortedRowPtrA,
-                                            const int *bsrSortedColIndA,
-                                            const int  blockSize,
-                                            const float *B,
-                                            const int ldb,
-                                            const float *beta,
-                                            float *C,
-                                            int ldc) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, int, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, const int, const float *, const int, const float *, float *, int);
+cusparseStatus_t CUSPARSEAPI cusparseSbsrmm(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, cusparseOperation_t transB, int mb, int n,
+    int kb, int nnzb, const float *alpha, const cusparseMatDescr_t descrA,
+    const float *bsrSortedValA, const int *bsrSortedRowPtrA,
+    const int *bsrSortedColIndA, const int blockSize, const float *B,
+    const int ldb, const float *beta, float *C, int ldc) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
+      cusparseOperation_t, int, int, int, int, const float *,
+      const cusparseMatDescr_t, const float *, const int *, const int *,
+      const int, const float *, const int, const float *, float *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrmm");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transB, mb, n, kb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockSize, B, ldb, beta, C, ldc);
+  return func_ptr(handle, dirA, transA, transB, mb, n, kb, nnzb, alpha, descrA,
+                  bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockSize,
+                  B, ldb, beta, C, ldc);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsrmm(cusparseHandle_t handle,
-                                            cusparseDirection_t dirA,
-                                            cusparseOperation_t transA,
-                                            cusparseOperation_t transB,
-                                            int mb,
-                                            int n,
-                                            int kb,
-                                            int nnzb,
-                                            const double *alpha,
-                                            const cusparseMatDescr_t descrA,
-                                            const double *bsrSortedValA,
-                                            const int *bsrSortedRowPtrA,
-                                            const int *bsrSortedColIndA,
-                                            const int  blockSize,
-                                            const double *B,
-                                            const int ldb,
-                                            const double *beta,
-                                            double *C,
-                                            int ldc) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, const int, const double *, const int, const double *, double *, int);
+cusparseStatus_t CUSPARSEAPI cusparseDbsrmm(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, cusparseOperation_t transB, int mb, int n,
+    int kb, int nnzb, const double *alpha, const cusparseMatDescr_t descrA,
+    const double *bsrSortedValA, const int *bsrSortedRowPtrA,
+    const int *bsrSortedColIndA, const int blockSize, const double *B,
+    const int ldb, const double *beta, double *C, int ldc) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
+      cusparseOperation_t, int, int, int, int, const double *,
+      const cusparseMatDescr_t, const double *, const int *, const int *,
+      const int, const double *, const int, const double *, double *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrmm");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transB, mb, n, kb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockSize, B, ldb, beta, C, ldc);
+  return func_ptr(handle, dirA, transA, transB, mb, n, kb, nnzb, alpha, descrA,
+                  bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockSize,
+                  B, ldb, beta, C, ldc);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsrmm(cusparseHandle_t handle,
-                                            cusparseDirection_t dirA,
-                                            cusparseOperation_t transA,
-                                            cusparseOperation_t transB,
-                                            int mb,
-                                            int n,
-                                            int kb,
-                                            int nnzb,
-                                            const cuComplex *alpha,
-                                            const cusparseMatDescr_t descrA,
-                                            const cuComplex *bsrSortedValA,
-                                            const int *bsrSortedRowPtrA,
-                                            const int *bsrSortedColIndA,
-                                            const int  blockSize,
-                                            const cuComplex *B,
-                                            const int ldb,
-                                            const cuComplex *beta,
-                                            cuComplex *C,
-                                            int ldc) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, const int, const cuComplex *, const int, const cuComplex *, cuComplex *, int);
+cusparseStatus_t CUSPARSEAPI cusparseCbsrmm(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, cusparseOperation_t transB, int mb, int n,
+    int kb, int nnzb, const cuComplex *alpha, const cusparseMatDescr_t descrA,
+    const cuComplex *bsrSortedValA, const int *bsrSortedRowPtrA,
+    const int *bsrSortedColIndA, const int blockSize, const cuComplex *B,
+    const int ldb, const cuComplex *beta, cuComplex *C, int ldc) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
+      cusparseOperation_t, int, int, int, int, const cuComplex *,
+      const cusparseMatDescr_t, const cuComplex *, const int *, const int *,
+      const int, const cuComplex *, const int, const cuComplex *, cuComplex *,
+      int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrmm");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transB, mb, n, kb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockSize, B, ldb, beta, C, ldc);
+  return func_ptr(handle, dirA, transA, transB, mb, n, kb, nnzb, alpha, descrA,
+                  bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockSize,
+                  B, ldb, beta, C, ldc);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrmm(cusparseHandle_t handle,
-                                            cusparseDirection_t dirA,
-                                            cusparseOperation_t transA,
-                                            cusparseOperation_t transB,
-                                            int mb,
-                                            int n,
-                                            int kb,
-                                            int nnzb,
-                                            const cuDoubleComplex *alpha,
-                                            const cusparseMatDescr_t descrA,
-                                            const cuDoubleComplex *bsrSortedValA,
-                                            const int *bsrSortedRowPtrA,
-                                            const int *bsrSortedColIndA,
-                                            const int  blockSize,
-                                            const cuDoubleComplex *B,
-                                            const int ldb,
-                                            const cuDoubleComplex *beta,
-                                            cuDoubleComplex *C,
-                                            int ldc) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, const int, const cuDoubleComplex *, const int, const cuDoubleComplex *, cuDoubleComplex *, int);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrmm(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, cusparseOperation_t transB, int mb, int n,
+    int kb, int nnzb, const cuDoubleComplex *alpha,
+    const cusparseMatDescr_t descrA, const cuDoubleComplex *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA,
+    const int blockSize, const cuDoubleComplex *B, const int ldb,
+    const cuDoubleComplex *beta, cuDoubleComplex *C, int ldc) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
+      cusparseOperation_t, int, int, int, int, const cuDoubleComplex *,
+      const cusparseMatDescr_t, const cuDoubleComplex *, const int *,
+      const int *, const int, const cuDoubleComplex *, const int,
+      const cuDoubleComplex *, cuDoubleComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrmm");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transB, mb, n, kb, nnzb, alpha, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockSize, B, ldb, beta, C, ldc);
+  return func_ptr(handle, dirA, transA, transB, mb, n, kb, nnzb, alpha, descrA,
+                  bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockSize,
+                  B, ldb, beta, C, ldc);
 }
 
-cusparseStatus_t  CUSPARSEAPI cusparseSgemmi(cusparseHandle_t handle,
-                                             int m,
-                                             int n,
-					     int k,
-					     int nnz,
-                                             const float *alpha, /* host or device pointer */
-                                             const float *A,
-                                             int lda,
-                                             const float *cscValB,
-					     const int *cscColPtrB,
-					     const int *cscRowIndB,
-                                             const float *beta, /* host or device pointer */
-                                             float *C,
-                                             int ldc) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, int, const float *, const float *, int, const float *, const int *, const int *, const float *, float *, int);
+cusparseStatus_t CUSPARSEAPI cusparseSgemmi(
+    cusparseHandle_t handle, int m, int n, int k, int nnz, const float *alpha,
+    const float *A, int lda, const float *cscValB, const int *cscColPtrB,
+    const int *cscRowIndB, const float *beta, float *C, int ldc) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, int, const float *, const float *, int,
+      const float *, const int *, const int *, const float *, float *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgemmi");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, k, nnz, alpha, A, lda, cscValB, cscColPtrB, cscRowIndB, beta, C, ldc);
+  return func_ptr(handle, m, n, k, nnz, alpha, A, lda, cscValB, cscColPtrB,
+                  cscRowIndB, beta, C, ldc);
 }
 
-cusparseStatus_t  CUSPARSEAPI cusparseDgemmi(cusparseHandle_t handle,
-                                             int m,
-                                             int n,
-					     int k,
-					     int nnz,
-                                             const double *alpha, /* host or device pointer */
-                                             const double *A,
-                                             int lda,
-                                             const double *cscValB,
-					     const int *cscColPtrB,
-					     const int *cscRowIndB,
-                                             const double *beta, /* host or device pointer */
-                                             double *C,
-                                             int ldc) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, int, const double *, const double *, int, const double *, const int *, const int *, const double *, double *, int);
+cusparseStatus_t CUSPARSEAPI cusparseDgemmi(
+    cusparseHandle_t handle, int m, int n, int k, int nnz, const double *alpha,
+    const double *A, int lda, const double *cscValB, const int *cscColPtrB,
+    const int *cscRowIndB, const double *beta, double *C, int ldc) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, int, const double *, const double *, int,
+      const double *, const int *, const int *, const double *, double *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgemmi");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, k, nnz, alpha, A, lda, cscValB, cscColPtrB, cscRowIndB, beta, C, ldc);
+  return func_ptr(handle, m, n, k, nnz, alpha, A, lda, cscValB, cscColPtrB,
+                  cscRowIndB, beta, C, ldc);
 }
 
-cusparseStatus_t  CUSPARSEAPI cusparseCgemmi(cusparseHandle_t handle,
-                                             int m,
-                                             int n,
-					     int k,
-					     int nnz,
-                                             const cuComplex *alpha, /* host or device pointer */
-                                             const cuComplex *A,
-                                             int lda,
-                                             const cuComplex *cscValB,
-					     const int *cscColPtrB,
-					     const int *cscRowIndB,
-                                             const cuComplex *beta, /* host or device pointer */
-                                             cuComplex *C,
-                                             int ldc) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, int, const cuComplex *, const cuComplex *, int, const cuComplex *, const int *, const int *, const cuComplex *, cuComplex *, int);
+cusparseStatus_t CUSPARSEAPI cusparseCgemmi(
+    cusparseHandle_t handle, int m, int n, int k, int nnz,
+    const cuComplex *alpha, const cuComplex *A, int lda,
+    const cuComplex *cscValB, const int *cscColPtrB, const int *cscRowIndB,
+    const cuComplex *beta, cuComplex *C, int ldc) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, int, const cuComplex *,
+      const cuComplex *, int, const cuComplex *, const int *, const int *,
+      const cuComplex *, cuComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgemmi");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, k, nnz, alpha, A, lda, cscValB, cscColPtrB, cscRowIndB, beta, C, ldc);
+  return func_ptr(handle, m, n, k, nnz, alpha, A, lda, cscValB, cscColPtrB,
+                  cscRowIndB, beta, C, ldc);
 }
 
-cusparseStatus_t  CUSPARSEAPI cusparseZgemmi(cusparseHandle_t handle,
-                                             int m,
-                                             int n,
-					     int k,
-					     int nnz,
-                                             const cuDoubleComplex *alpha, /* host or device pointer */
-                                             const cuDoubleComplex *A,
-                                             int lda,
-                                             const cuDoubleComplex *cscValB,
-					     const int *cscColPtrB,
-					     const int *cscRowIndB,
-                                             const cuDoubleComplex *beta, /* host or device pointer */
-                                             cuDoubleComplex *C,
-                                             int ldc) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, int, const cuDoubleComplex *, const cuDoubleComplex *, int, const cuDoubleComplex *, const int *, const int *, const cuDoubleComplex *, cuDoubleComplex *, int);
+cusparseStatus_t CUSPARSEAPI
+cusparseZgemmi(cusparseHandle_t handle, int m, int n, int k, int nnz,
+               const cuDoubleComplex *alpha, const cuDoubleComplex *A, int lda,
+               const cuDoubleComplex *cscValB, const int *cscColPtrB,
+               const int *cscRowIndB, const cuDoubleComplex *beta,
+               cuDoubleComplex *C, int ldc) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, int, const cuDoubleComplex *,
+      const cuDoubleComplex *, int, const cuDoubleComplex *, const int *,
+      const int *, const cuDoubleComplex *, cuDoubleComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgemmi");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, k, nnz, alpha, A, lda, cscValB, cscColPtrB, cscRowIndB, beta, C, ldc);
+  return func_ptr(handle, m, n, k, nnz, alpha, A, lda, cscValB, cscColPtrB,
+                  cscRowIndB, beta, C, ldc);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrsm_analysis(cusparseHandle_t handle,
-                                                     cusparseOperation_t transA,
-                                                     int m,
-                                                     int nnz,
-                                                     const cusparseMatDescr_t descrA,
-                                                     const float *csrSortedValA,
-                                                     const int *csrSortedRowPtrA,
-                                                     const int *csrSortedColIndA,
-                                                     cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseScsrsm_analysis(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
+    const cusparseMatDescr_t descrA, const float *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
+      const float *, const int *, const int *, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrsm_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrsm_analysis(cusparseHandle_t handle,
-                                                     cusparseOperation_t transA,
-                                                     int m,
-                                                     int nnz,
-                                                     const cusparseMatDescr_t descrA,
-                                                     const double *csrSortedValA,
-                                                     const int *csrSortedRowPtrA,
-                                                     const int *csrSortedColIndA,
-                                                     cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrsm_analysis(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
+    const cusparseMatDescr_t descrA, const double *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
+      const double *, const int *, const int *, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrsm_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrsm_analysis(cusparseHandle_t handle,
-                                                     cusparseOperation_t transA,
-                                                     int m,
-                                                     int nnz,
-                                                     const cusparseMatDescr_t descrA,
-                                                     const cuComplex *csrSortedValA,
-                                                     const int *csrSortedRowPtrA,
-                                                     const int *csrSortedColIndA,
-                                                     cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrsm_analysis(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
+    const cusparseMatDescr_t descrA, const cuComplex *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
+      const cuComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrsm_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrsm_analysis(cusparseHandle_t handle,
-                                                     cusparseOperation_t transA,
-                                                     int m,
-                                                     int nnz,
-                                                     const cusparseMatDescr_t descrA,
-                                                     const cuDoubleComplex *csrSortedValA,
-                                                     const int *csrSortedRowPtrA,
-                                                     const int *csrSortedColIndA,
-                                                     cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrsm_analysis(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int nnz,
+    const cusparseMatDescr_t descrA, const cuDoubleComplex *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const cusparseMatDescr_t,
+      const cuDoubleComplex *, const int *, const int *,
+      cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrsm_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, transA, m, nnz, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrsm_solve(cusparseHandle_t handle,
-                                                  cusparseOperation_t transA,
-                                                  int m,
-                                                  int n,
-                                                  const float *alpha,
-                                                  const cusparseMatDescr_t descrA,
-                                                  const float *csrSortedValA,
-                                                  const int *csrSortedRowPtrA,
-                                                  const int *csrSortedColIndA,
-                                                  cusparseSolveAnalysisInfo_t info,
-                                                  const float *B,
-                                                  int ldb,
-                                                  float *X,
-                                                  int ldx) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, cusparseSolveAnalysisInfo_t, const float *, int, float *, int);
+cusparseStatus_t CUSPARSEAPI cusparseScsrsm_solve(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int n,
+    const float *alpha, const cusparseMatDescr_t descrA,
+    const float *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, cusparseSolveAnalysisInfo_t info,
+    const float *B, int ldb, float *X, int ldx) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const float *,
+      const cusparseMatDescr_t, const float *, const int *, const int *,
+      cusparseSolveAnalysisInfo_t, const float *, int, float *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrsm_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, B, ldb, X, ldx);
+  return func_ptr(handle, transA, m, n, alpha, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info, B, ldb, X, ldx);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrsm_solve(cusparseHandle_t handle,
-                                                  cusparseOperation_t transA,
-                                                  int m,
-                                                  int n,
-                                                  const double *alpha,
-                                                  const cusparseMatDescr_t descrA,
-                                                  const double *csrSortedValA,
-                                                  const int *csrSortedRowPtrA,
-                                                  const int *csrSortedColIndA,
-                                                  cusparseSolveAnalysisInfo_t info,
-                                                  const double *B,
-                                                  int ldb,
-                                                  double *X,
-                                                  int ldx) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, cusparseSolveAnalysisInfo_t, const double *, int, double *, int);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrsm_solve(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int n,
+    const double *alpha, const cusparseMatDescr_t descrA,
+    const double *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, cusparseSolveAnalysisInfo_t info,
+    const double *B, int ldb, double *X, int ldx) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const double *,
+      const cusparseMatDescr_t, const double *, const int *, const int *,
+      cusparseSolveAnalysisInfo_t, const double *, int, double *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrsm_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, B, ldb, X, ldx);
+  return func_ptr(handle, transA, m, n, alpha, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info, B, ldb, X, ldx);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrsm_solve(cusparseHandle_t handle,
-                                                  cusparseOperation_t transA,
-                                                  int m,
-                                                  int n,
-                                                  const cuComplex *alpha,
-                                                  const cusparseMatDescr_t descrA,
-                                                  const cuComplex *csrSortedValA,
-                                                  const int *csrSortedRowPtrA,
-                                                  const int *csrSortedColIndA,
-                                                  cusparseSolveAnalysisInfo_t info,
-                                                  const cuComplex *B,
-                                                  int ldb,
-                                                  cuComplex *X,
-                                                  int ldx) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t, const cuComplex *, int, cuComplex *, int);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrsm_solve(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int n,
+    const cuComplex *alpha, const cusparseMatDescr_t descrA,
+    const cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, cusparseSolveAnalysisInfo_t info,
+    const cuComplex *B, int ldb, cuComplex *X, int ldx) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const cuComplex *,
+      const cusparseMatDescr_t, const cuComplex *, const int *, const int *,
+      cusparseSolveAnalysisInfo_t, const cuComplex *, int, cuComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrsm_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, B, ldb, X, ldx);
+  return func_ptr(handle, transA, m, n, alpha, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info, B, ldb, X, ldx);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrsm_solve(cusparseHandle_t handle,
-                                                  cusparseOperation_t transA,
-                                                  int m,
-                                                  int n,
-                                                  const cuDoubleComplex *alpha,
-                                                  const cusparseMatDescr_t descrA,
-                                                  const cuDoubleComplex *csrSortedValA,
-                                                  const int *csrSortedRowPtrA,
-                                                  const int *csrSortedColIndA,
-                                                  cusparseSolveAnalysisInfo_t info,
-                                                  const cuDoubleComplex *B,
-                                                  int ldb,
-                                                  cuDoubleComplex *X,
-                                                  int ldx) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t, const cuDoubleComplex *, int, cuDoubleComplex *, int);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrsm_solve(
+    cusparseHandle_t handle, cusparseOperation_t transA, int m, int n,
+    const cuDoubleComplex *alpha, const cusparseMatDescr_t descrA,
+    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, cusparseSolveAnalysisInfo_t info,
+    const cuDoubleComplex *B, int ldb, cuDoubleComplex *X, int ldx) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, int, const cuDoubleComplex *,
+      const cusparseMatDescr_t, const cuDoubleComplex *, const int *,
+      const int *, cusparseSolveAnalysisInfo_t, const cuDoubleComplex *, int,
+      cuDoubleComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrsm_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, m, n, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, B, ldb, X, ldx);
+  return func_ptr(handle, transA, m, n, alpha, descrA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, info, B, ldb, X, ldx);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCreateCsrsm2Info(
-    csrsm2Info_t *info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(csrsm2Info_t *);
+cusparseStatus_t CUSPARSEAPI cusparseCreateCsrsm2Info(csrsm2Info_t *info) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(csrsm2Info_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateCsrsm2Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDestroyCsrsm2Info(
-    csrsm2Info_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(csrsm2Info_t);
+cusparseStatus_t CUSPARSEAPI cusparseDestroyCsrsm2Info(csrsm2Info_t info) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(csrsm2Info_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyCsrsm2Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseXcsrsm2_zeroPivot(
-    cusparseHandle_t handle,
-    csrsm2Info_t info,
-    int *position) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, csrsm2Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseXcsrsm2_zeroPivot(cusparseHandle_t handle,
+                                                       csrsm2Info_t info,
+                                                       int *position) {
+  using FuncPtr =
+      cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, csrsm2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcsrsm2_zeroPivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, position);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseScsrsm2_bufferSizeExt(
-    cusparseHandle_t handle,
-    int algo, /* algo = 0, 1 */
-    cusparseOperation_t transA,
-    cusparseOperation_t transB,
-    int m,
-    int nrhs,
-    int nnz,
-    const float *alpha,
-    const cusparseMatDescr_t descrA,
-    const float *csrSortedValA,
-    const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA,
-    const float *B,
-    int ldb,
-    csrsm2Info_t info,
-    cusparseSolvePolicy_t policy,
+    cusparseHandle_t handle, int algo, cusparseOperation_t transA,
+    cusparseOperation_t transB, int m, int nrhs, int nnz, const float *alpha,
+    const cusparseMatDescr_t descrA, const float *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, const float *B,
+    int ldb, csrsm2Info_t info, cusparseSolvePolicy_t policy,
     size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int, int, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, const float *, int, csrsm2Info_t, cusparseSolvePolicy_t, size_t *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int,
+      int, const float *, const cusparseMatDescr_t, const float *, const int *,
+      const int *, const float *, int, csrsm2Info_t, cusparseSolvePolicy_t,
+      size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrsm2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, info, policy, pBufferSize);
+  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA,
+                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
+                  info, policy, pBufferSize);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDcsrsm2_bufferSizeExt(
-    cusparseHandle_t handle,
-    int algo, /* algo = 0, 1 */
-    cusparseOperation_t transA,
-    cusparseOperation_t transB,
-    int m,
-    int nrhs,
-    int nnz,
-    const double *alpha,
-    const cusparseMatDescr_t descrA,
-    const double *csrSortedValA,
-    const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA,
-    const double *B,
-    int ldb,
-    csrsm2Info_t info,
-    cusparseSolvePolicy_t policy,
+    cusparseHandle_t handle, int algo, cusparseOperation_t transA,
+    cusparseOperation_t transB, int m, int nrhs, int nnz, const double *alpha,
+    const cusparseMatDescr_t descrA, const double *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, const double *B,
+    int ldb, csrsm2Info_t info, cusparseSolvePolicy_t policy,
     size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, const double *, int, csrsm2Info_t, cusparseSolvePolicy_t, size_t *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int,
+      int, const double *, const cusparseMatDescr_t, const double *,
+      const int *, const int *, const double *, int, csrsm2Info_t,
+      cusparseSolvePolicy_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrsm2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, info, policy, pBufferSize);
+  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA,
+                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
+                  info, policy, pBufferSize);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCcsrsm2_bufferSizeExt(
-    cusparseHandle_t handle,
-    int algo, /* algo = 0, 1 */
-    cusparseOperation_t transA,
-    cusparseOperation_t transB,
-    int m,
-    int nrhs,
-    int nnz,
-    const cuComplex *alpha,
-    const cusparseMatDescr_t descrA,
-    const cuComplex *csrSortedValA,
-    const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA,
-    const cuComplex *B,
-    int ldb,
-    csrsm2Info_t info,
-    cusparseSolvePolicy_t policy,
-    size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int, int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, const cuComplex *, int, csrsm2Info_t, cusparseSolvePolicy_t, size_t *);
+    cusparseHandle_t handle, int algo, cusparseOperation_t transA,
+    cusparseOperation_t transB, int m, int nrhs, int nnz,
+    const cuComplex *alpha, const cusparseMatDescr_t descrA,
+    const cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, const cuComplex *B, int ldb, csrsm2Info_t info,
+    cusparseSolvePolicy_t policy, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int,
+      int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *,
+      const int *, const int *, const cuComplex *, int, csrsm2Info_t,
+      cusparseSolvePolicy_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrsm2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, info, policy, pBufferSize);
+  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA,
+                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
+                  info, policy, pBufferSize);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseZcsrsm2_bufferSizeExt(
-    cusparseHandle_t handle,
-    int algo, /* algo = 0, 1 */
-    cusparseOperation_t transA,
-    cusparseOperation_t transB,
-    int m,
-    int nrhs,
-    int nnz,
-    const cuDoubleComplex *alpha,
-    const cusparseMatDescr_t descrA,
-    const cuDoubleComplex *csrSortedValA,
-    const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA,
-    const cuDoubleComplex *B,
-    int ldb,
-    csrsm2Info_t info,
-    cusparseSolvePolicy_t policy,
-    size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, const cuDoubleComplex *, int, csrsm2Info_t, cusparseSolvePolicy_t, size_t *);
+    cusparseHandle_t handle, int algo, cusparseOperation_t transA,
+    cusparseOperation_t transB, int m, int nrhs, int nnz,
+    const cuDoubleComplex *alpha, const cusparseMatDescr_t descrA,
+    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, const cuDoubleComplex *B, int ldb,
+    csrsm2Info_t info, cusparseSolvePolicy_t policy, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int,
+      int, const cuDoubleComplex *, const cusparseMatDescr_t,
+      const cuDoubleComplex *, const int *, const int *,
+      const cuDoubleComplex *, int, csrsm2Info_t, cusparseSolvePolicy_t,
+      size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrsm2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, info, policy, pBufferSize);
+  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA,
+                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
+                  info, policy, pBufferSize);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseScsrsm2_analysis(
-    cusparseHandle_t handle,
-    int algo, /* algo = 0, 1 */
-    cusparseOperation_t transA,
-    cusparseOperation_t transB,
-    int m,
-    int nrhs,
-    int nnz,
-    const float *alpha,
-    const cusparseMatDescr_t descrA,
-    const float *csrSortedValA,
-    const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA,
-    const float *B,
-    int ldb,
-    csrsm2Info_t info,
-    cusparseSolvePolicy_t policy,
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int, int, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, const float *, int, csrsm2Info_t, cusparseSolvePolicy_t, void *);
+    cusparseHandle_t handle, int algo, cusparseOperation_t transA,
+    cusparseOperation_t transB, int m, int nrhs, int nnz, const float *alpha,
+    const cusparseMatDescr_t descrA, const float *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, const float *B,
+    int ldb, csrsm2Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int,
+      int, const float *, const cusparseMatDescr_t, const float *, const int *,
+      const int *, const float *, int, csrsm2Info_t, cusparseSolvePolicy_t,
+      void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrsm2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, info, policy, pBuffer);
+  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA,
+                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
+                  info, policy, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDcsrsm2_analysis(
-    cusparseHandle_t handle,
-    int algo, /* algo = 0, 1 */
-    cusparseOperation_t transA,
-    cusparseOperation_t transB,
-    int m,
-    int nrhs,
-    int nnz,
-    const double *alpha,
-    const cusparseMatDescr_t descrA,
-    const double *csrSortedValA,
-    const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA,
-    const double *B,
-    int ldb,
-    csrsm2Info_t info,
-    cusparseSolvePolicy_t policy,
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, const double *, int, csrsm2Info_t, cusparseSolvePolicy_t, void *);
+    cusparseHandle_t handle, int algo, cusparseOperation_t transA,
+    cusparseOperation_t transB, int m, int nrhs, int nnz, const double *alpha,
+    const cusparseMatDescr_t descrA, const double *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, const double *B,
+    int ldb, csrsm2Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int,
+      int, const double *, const cusparseMatDescr_t, const double *,
+      const int *, const int *, const double *, int, csrsm2Info_t,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrsm2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, info, policy, pBuffer);
+  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA,
+                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
+                  info, policy, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCcsrsm2_analysis(
-    cusparseHandle_t handle,
-    int algo, /* algo = 0, 1 */
-    cusparseOperation_t transA,
-    cusparseOperation_t transB,
-    int m,
-    int nrhs,
-    int nnz,
-    const cuComplex *alpha,
-    const cusparseMatDescr_t descrA,
-    const cuComplex *csrSortedValA,
-    const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA,
-    const cuComplex *B,
-    int ldb,
-    csrsm2Info_t info,
-    cusparseSolvePolicy_t policy,
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int, int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, const cuComplex *, int, csrsm2Info_t, cusparseSolvePolicy_t, void *);
+    cusparseHandle_t handle, int algo, cusparseOperation_t transA,
+    cusparseOperation_t transB, int m, int nrhs, int nnz,
+    const cuComplex *alpha, const cusparseMatDescr_t descrA,
+    const cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, const cuComplex *B, int ldb, csrsm2Info_t info,
+    cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int,
+      int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *,
+      const int *, const int *, const cuComplex *, int, csrsm2Info_t,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrsm2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, info, policy, pBuffer);
+  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA,
+                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
+                  info, policy, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseZcsrsm2_analysis(
-    cusparseHandle_t handle,
-    int algo, /* algo = 0, 1 */
-    cusparseOperation_t transA,
-    cusparseOperation_t transB,
-    int m,
-    int nrhs,
-    int nnz,
-    const cuDoubleComplex *alpha,
-    const cusparseMatDescr_t descrA,
-    const cuDoubleComplex *csrSortedValA,
-    const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA,
-    const cuDoubleComplex *B,
-    int ldb,
-    csrsm2Info_t info,
-    cusparseSolvePolicy_t policy,
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, const cuDoubleComplex *, int, csrsm2Info_t, cusparseSolvePolicy_t, void *);
+    cusparseHandle_t handle, int algo, cusparseOperation_t transA,
+    cusparseOperation_t transB, int m, int nrhs, int nnz,
+    const cuDoubleComplex *alpha, const cusparseMatDescr_t descrA,
+    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, const cuDoubleComplex *B, int ldb,
+    csrsm2Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int,
+      int, const cuDoubleComplex *, const cusparseMatDescr_t,
+      const cuDoubleComplex *, const int *, const int *,
+      const cuDoubleComplex *, int, csrsm2Info_t, cusparseSolvePolicy_t,
+      void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrsm2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, info, policy, pBuffer);
+  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA,
+                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
+                  info, policy, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseScsrsm2_solve(
-    cusparseHandle_t handle,
-    int algo, /* algo = 0, 1 */
-    cusparseOperation_t transA,
-    cusparseOperation_t transB,
-    int m,
-    int nrhs,
-    int nnz,
-    const float *alpha,
-    const cusparseMatDescr_t descrA,
-    const float *csrSortedValA,
-    const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA,
-    float *B,
-    int ldb,
-    csrsm2Info_t info,
-    cusparseSolvePolicy_t policy,
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int, int, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, float *, int, csrsm2Info_t, cusparseSolvePolicy_t, void *);
+    cusparseHandle_t handle, int algo, cusparseOperation_t transA,
+    cusparseOperation_t transB, int m, int nrhs, int nnz, const float *alpha,
+    const cusparseMatDescr_t descrA, const float *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, float *B, int ldb,
+    csrsm2Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int,
+      int, const float *, const cusparseMatDescr_t, const float *, const int *,
+      const int *, float *, int, csrsm2Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrsm2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, info, policy, pBuffer);
+  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA,
+                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
+                  info, policy, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDcsrsm2_solve(
-    cusparseHandle_t handle,
-    int algo, /* algo = 0, 1 */
-    cusparseOperation_t transA,
-    cusparseOperation_t transB,
-    int m,
-    int nrhs,
-    int nnz,
-    const double *alpha,
-    const cusparseMatDescr_t descrA,
-    const double *csrSortedValA,
-    const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA,
-    double *B,
-    int ldb,
-    csrsm2Info_t info,
-    cusparseSolvePolicy_t policy,
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, double *, int, csrsm2Info_t, cusparseSolvePolicy_t, void *);
+    cusparseHandle_t handle, int algo, cusparseOperation_t transA,
+    cusparseOperation_t transB, int m, int nrhs, int nnz, const double *alpha,
+    const cusparseMatDescr_t descrA, const double *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, double *B,
+    int ldb, csrsm2Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int,
+      int, const double *, const cusparseMatDescr_t, const double *,
+      const int *, const int *, double *, int, csrsm2Info_t,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrsm2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, info, policy, pBuffer);
+  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA,
+                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
+                  info, policy, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCcsrsm2_solve(
-    cusparseHandle_t handle,
-    int algo, /* algo = 0, 1 */
-    cusparseOperation_t transA,
-    cusparseOperation_t transB,
-    int m,
-    int nrhs,
-    int nnz,
-    const cuComplex *alpha,
-    const cusparseMatDescr_t descrA,
-    const cuComplex *csrSortedValA,
-    const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA,
-    cuComplex *B,
-    int ldb,
-    csrsm2Info_t info,
-    cusparseSolvePolicy_t policy,
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int, int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, cuComplex *, int, csrsm2Info_t, cusparseSolvePolicy_t, void *);
+    cusparseHandle_t handle, int algo, cusparseOperation_t transA,
+    cusparseOperation_t transB, int m, int nrhs, int nnz,
+    const cuComplex *alpha, const cusparseMatDescr_t descrA,
+    const cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, cuComplex *B, int ldb, csrsm2Info_t info,
+    cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int,
+      int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *,
+      const int *, const int *, cuComplex *, int, csrsm2Info_t,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrsm2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, info, policy, pBuffer);
+  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA,
+                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
+                  info, policy, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseZcsrsm2_solve(
-    cusparseHandle_t handle,
-    int algo, /* algo = 0, 1 */
-    cusparseOperation_t transA,
-    cusparseOperation_t transB,
-    int m,
-    int nrhs,
-    int nnz,
-    const cuDoubleComplex *alpha,
-    const cusparseMatDescr_t descrA,
-    const cuDoubleComplex *csrSortedValA,
-    const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA,
-    cuDoubleComplex *B,
-    int ldb,
-    csrsm2Info_t info,
-    cusparseSolvePolicy_t policy,
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, cuDoubleComplex *, int, csrsm2Info_t, cusparseSolvePolicy_t, void *);
+    cusparseHandle_t handle, int algo, cusparseOperation_t transA,
+    cusparseOperation_t transB, int m, int nrhs, int nnz,
+    const cuDoubleComplex *alpha, const cusparseMatDescr_t descrA,
+    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, cuDoubleComplex *B, int ldb, csrsm2Info_t info,
+    cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, cusparseOperation_t, cusparseOperation_t, int, int,
+      int, const cuDoubleComplex *, const cusparseMatDescr_t,
+      const cuDoubleComplex *, const int *, const int *, cuDoubleComplex *, int,
+      csrsm2Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrsm2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb, info, policy, pBuffer);
+  return func_ptr(handle, algo, transA, transB, m, nrhs, nnz, alpha, descrA,
+                  csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, B, ldb,
+                  info, policy, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseXbsrsm2_zeroPivot(cusparseHandle_t handle,
                                                        bsrsm2Info_t info,
                                                        int *position) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, bsrsm2Info_t, int *);
+  using FuncPtr =
+      cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, bsrsm2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXbsrsm2_zeroPivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, position);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsrsm2_bufferSize(cusparseHandle_t handle,
-                                                        cusparseDirection_t dirA,
-                                                        cusparseOperation_t transA,
-                                                        cusparseOperation_t transXY,
-                                                        int mb,
-                                                        int n,
-                                                        int nnzb,
-                                                        const cusparseMatDescr_t descrA,
-                                                        float *bsrSortedVal,
-                                                        const int *bsrSortedRowPtr,
-                                                        const int *bsrSortedColInd,
-                                                        int blockSize,
-                                                        bsrsm2Info_t info,
-                                                        int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, float *, const int *, const int *, int, bsrsm2Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsrsm2_bufferSize(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, cusparseOperation_t transXY, int mb, int n,
+    int nnzb, const cusparseMatDescr_t descrA, float *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
+    bsrsm2Info_t info, int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
+      cusparseOperation_t, int, int, int, const cusparseMatDescr_t, float *,
+      const int *, const int *, int, bsrsm2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrsm2_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA,
+                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
+                  info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsrsm2_bufferSize(cusparseHandle_t handle,
-                                                        cusparseDirection_t dirA,
-                                                        cusparseOperation_t transA,
-                                                        cusparseOperation_t transXY,
-                                                        int mb,
-                                                        int n,
-                                                        int nnzb,
-                                                        const cusparseMatDescr_t descrA,
-                                                        double *bsrSortedVal,
-                                                        const int *bsrSortedRowPtr,
-                                                        const int *bsrSortedColInd,
-                                                        int blockSize,
-                                                        bsrsm2Info_t info,
-                                                        int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, double *, const int *, const int *, int, bsrsm2Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsrsm2_bufferSize(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, cusparseOperation_t transXY, int mb, int n,
+    int nnzb, const cusparseMatDescr_t descrA, double *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
+    bsrsm2Info_t info, int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
+      cusparseOperation_t, int, int, int, const cusparseMatDescr_t, double *,
+      const int *, const int *, int, bsrsm2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrsm2_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA,
+                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
+                  info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsrsm2_bufferSize(cusparseHandle_t handle,
-                                                        cusparseDirection_t dirA,
-                                                        cusparseOperation_t transA,
-                                                        cusparseOperation_t transXY,
-                                                        int mb,
-                                                        int n,
-                                                        int nnzb,
-                                                        const cusparseMatDescr_t descrA,
-                                                        cuComplex *bsrSortedVal,
-                                                        const int *bsrSortedRowPtr,
-                                                        const int *bsrSortedColInd,
-                                                        int blockSize,
-                                                        bsrsm2Info_t info,
-                                                        int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, int, bsrsm2Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsrsm2_bufferSize(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, cusparseOperation_t transXY, int mb, int n,
+    int nnzb, const cusparseMatDescr_t descrA, cuComplex *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
+    bsrsm2Info_t info, int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
+      cusparseOperation_t, int, int, int, const cusparseMatDescr_t, cuComplex *,
+      const int *, const int *, int, bsrsm2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrsm2_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA,
+                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
+                  info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrsm2_bufferSize(cusparseHandle_t handle,
-                                                        cusparseDirection_t dirA,
-                                                        cusparseOperation_t transA,
-                                                        cusparseOperation_t transXY,
-                                                        int mb,
-                                                        int n,
-                                                        int nnzb,
-                                                        const cusparseMatDescr_t descrA,
-                                                        cuDoubleComplex *bsrSortedVal,
-                                                        const int *bsrSortedRowPtr,
-                                                        const int *bsrSortedColInd,
-                                                        int blockSize,
-                                                        bsrsm2Info_t info,
-                                                        int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, int, bsrsm2Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrsm2_bufferSize(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, cusparseOperation_t transXY, int mb, int n,
+    int nnzb, const cusparseMatDescr_t descrA, cuDoubleComplex *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
+    bsrsm2Info_t info, int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
+      cusparseOperation_t, int, int, int, const cusparseMatDescr_t,
+      cuDoubleComplex *, const int *, const int *, int, bsrsm2Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrsm2_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA,
+                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
+                  info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsrsm2_bufferSizeExt(cusparseHandle_t handle,
-                                                           cusparseDirection_t dirA,
-                                                           cusparseOperation_t transA,
-                                                           cusparseOperation_t transB,
-                                                           int mb,
-                                                           int n,
-                                                           int nnzb,
-                                                           const cusparseMatDescr_t descrA,
-                                                           float *bsrSortedVal,
-                                                           const int *bsrSortedRowPtr,
-                                                           const int *bsrSortedColInd,
-                                                           int blockSize,
-                                                           bsrsm2Info_t info,
-                                                           size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, float *, const int *, const int *, int, bsrsm2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsrsm2_bufferSizeExt(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, cusparseOperation_t transB, int mb, int n,
+    int nnzb, const cusparseMatDescr_t descrA, float *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
+    bsrsm2Info_t info, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
+      cusparseOperation_t, int, int, int, const cusparseMatDescr_t, float *,
+      const int *, const int *, int, bsrsm2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrsm2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transB, mb, n, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSize);
+  return func_ptr(handle, dirA, transA, transB, mb, n, nnzb, descrA,
+                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
+                  info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsrsm2_bufferSizeExt(cusparseHandle_t handle,
-                                                           cusparseDirection_t dirA,
-                                                           cusparseOperation_t transA,
-                                                           cusparseOperation_t transB,
-                                                           int mb,
-                                                           int n,
-                                                           int nnzb,
-                                                           const cusparseMatDescr_t descrA,
-                                                           double *bsrSortedVal,
-                                                           const int *bsrSortedRowPtr,
-                                                           const int *bsrSortedColInd,
-                                                           int blockSize,
-                                                           bsrsm2Info_t info,
-                                                           size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, double *, const int *, const int *, int, bsrsm2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsrsm2_bufferSizeExt(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, cusparseOperation_t transB, int mb, int n,
+    int nnzb, const cusparseMatDescr_t descrA, double *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
+    bsrsm2Info_t info, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
+      cusparseOperation_t, int, int, int, const cusparseMatDescr_t, double *,
+      const int *, const int *, int, bsrsm2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrsm2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transB, mb, n, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSize);
+  return func_ptr(handle, dirA, transA, transB, mb, n, nnzb, descrA,
+                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
+                  info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsrsm2_bufferSizeExt(cusparseHandle_t handle,
-                                                           cusparseDirection_t dirA,
-                                                           cusparseOperation_t transA,
-                                                           cusparseOperation_t transB,
-                                                           int mb,
-                                                           int n,
-                                                           int nnzb,
-                                                           const cusparseMatDescr_t descrA,
-                                                           cuComplex *bsrSortedVal,
-                                                           const int *bsrSortedRowPtr,
-                                                           const int *bsrSortedColInd,
-                                                           int blockSize,
-                                                           bsrsm2Info_t info,
-                                                           size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, int, bsrsm2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsrsm2_bufferSizeExt(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, cusparseOperation_t transB, int mb, int n,
+    int nnzb, const cusparseMatDescr_t descrA, cuComplex *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
+    bsrsm2Info_t info, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
+      cusparseOperation_t, int, int, int, const cusparseMatDescr_t, cuComplex *,
+      const int *, const int *, int, bsrsm2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrsm2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transB, mb, n, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSize);
+  return func_ptr(handle, dirA, transA, transB, mb, n, nnzb, descrA,
+                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
+                  info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrsm2_bufferSizeExt(cusparseHandle_t handle,
-                                                           cusparseDirection_t dirA,
-                                                           cusparseOperation_t transA,
-                                                           cusparseOperation_t transB,
-                                                           int mb,
-                                                           int n,
-                                                           int nnzb,
-                                                           const cusparseMatDescr_t descrA,
-                                                           cuDoubleComplex *bsrSortedVal,
-                                                           const int *bsrSortedRowPtr,
-                                                           const int *bsrSortedColInd,
-                                                           int blockSize,
-                                                           bsrsm2Info_t info,
-                                                           size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, int, bsrsm2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrsm2_bufferSizeExt(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, cusparseOperation_t transB, int mb, int n,
+    int nnzb, const cusparseMatDescr_t descrA, cuDoubleComplex *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
+    bsrsm2Info_t info, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
+      cusparseOperation_t, int, int, int, const cusparseMatDescr_t,
+      cuDoubleComplex *, const int *, const int *, int, bsrsm2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrsm2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transB, mb, n, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSize);
+  return func_ptr(handle, dirA, transA, transB, mb, n, nnzb, descrA,
+                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
+                  info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsrsm2_analysis(cusparseHandle_t handle,
-                                                      cusparseDirection_t dirA,
-                                                      cusparseOperation_t transA,
-                                                      cusparseOperation_t transXY,
-                                                      int mb,
-                                                      int n,
-                                                      int nnzb,
-                                                      const cusparseMatDescr_t descrA,
-                                                      const float *bsrSortedVal,
-                                                      const int *bsrSortedRowPtr,
-                                                      const int *bsrSortedColInd,
-                                                      int blockSize,
-                                                      bsrsm2Info_t info,
-                                                      cusparseSolvePolicy_t policy,
-                                                      void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, int, bsrsm2Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsrsm2_analysis(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, cusparseOperation_t transXY, int mb, int n,
+    int nnzb, const cusparseMatDescr_t descrA, const float *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
+    bsrsm2Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
+      cusparseOperation_t, int, int, int, const cusparseMatDescr_t,
+      const float *, const int *, const int *, int, bsrsm2Info_t,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrsm2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, policy, pBuffer);
+  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA,
+                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
+                  info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsrsm2_analysis(cusparseHandle_t handle,
-                                                      cusparseDirection_t dirA,
-                                                      cusparseOperation_t transA,
-                                                      cusparseOperation_t transXY,
-                                                      int mb,
-                                                      int n,
-                                                      int nnzb,
-                                                      const cusparseMatDescr_t descrA,
-                                                      const double *bsrSortedVal,
-                                                      const int *bsrSortedRowPtr,
-                                                      const int *bsrSortedColInd,
-                                                      int blockSize,
-                                                      bsrsm2Info_t info,
-                                                      cusparseSolvePolicy_t policy,
-                                                      void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, int, bsrsm2Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsrsm2_analysis(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, cusparseOperation_t transXY, int mb, int n,
+    int nnzb, const cusparseMatDescr_t descrA, const double *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
+    bsrsm2Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
+      cusparseOperation_t, int, int, int, const cusparseMatDescr_t,
+      const double *, const int *, const int *, int, bsrsm2Info_t,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrsm2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, policy, pBuffer);
+  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA,
+                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
+                  info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsrsm2_analysis(cusparseHandle_t handle,
-                                                      cusparseDirection_t dirA,
-                                                      cusparseOperation_t transA,
-                                                      cusparseOperation_t transXY,
-                                                      int mb,
-                                                      int n,
-                                                      int nnzb,
-                                                      const cusparseMatDescr_t descrA,
-                                                      const cuComplex *bsrSortedVal,
-                                                      const int *bsrSortedRowPtr,
-                                                      const int *bsrSortedColInd,
-                                                      int blockSize,
-                                                      bsrsm2Info_t info,
-                                                      cusparseSolvePolicy_t policy,
-                                                      void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, int, bsrsm2Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsrsm2_analysis(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, cusparseOperation_t transXY, int mb, int n,
+    int nnzb, const cusparseMatDescr_t descrA, const cuComplex *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
+    bsrsm2Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
+      cusparseOperation_t, int, int, int, const cusparseMatDescr_t,
+      const cuComplex *, const int *, const int *, int, bsrsm2Info_t,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrsm2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, policy, pBuffer);
+  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA,
+                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
+                  info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrsm2_analysis(cusparseHandle_t handle,
-                                                      cusparseDirection_t dirA,
-                                                      cusparseOperation_t transA,
-                                                      cusparseOperation_t transXY,
-                                                      int mb,
-                                                      int n,
-                                                      int nnzb,
-                                                      const cusparseMatDescr_t descrA,
-                                                      const cuDoubleComplex *bsrSortedVal,
-                                                      const int *bsrSortedRowPtr,
-                                                      const int *bsrSortedColInd,
-                                                      int blockSize,
-                                                      bsrsm2Info_t info,
-                                                      cusparseSolvePolicy_t policy,
-                                                      void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, int, bsrsm2Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrsm2_analysis(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, cusparseOperation_t transXY, int mb, int n,
+    int nnzb, const cusparseMatDescr_t descrA,
+    const cuDoubleComplex *bsrSortedVal, const int *bsrSortedRowPtr,
+    const int *bsrSortedColInd, int blockSize, bsrsm2Info_t info,
+    cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
+      cusparseOperation_t, int, int, int, const cusparseMatDescr_t,
+      const cuDoubleComplex *, const int *, const int *, int, bsrsm2Info_t,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrsm2_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, policy, pBuffer);
+  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, descrA,
+                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
+                  info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsrsm2_solve(cusparseHandle_t handle,
-                                                   cusparseDirection_t dirA,
-                                                   cusparseOperation_t transA,
-                                                   cusparseOperation_t transXY,
-                                                   int mb,
-                                                   int n,
-                                                   int nnzb,
-                                                   const float *alpha,
-                                                   const cusparseMatDescr_t descrA,
-                                                   const float *bsrSortedVal,
-                                                   const int *bsrSortedRowPtr,
-                                                   const int *bsrSortedColInd,
-                                                   int blockSize,
-                                                   bsrsm2Info_t info,
-                                                   const float *B,
-                                                   int ldb,
-                                                   float *X,
-                                                   int ldx,
-                                                   cusparseSolvePolicy_t policy,
-                                                   void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, int, bsrsm2Info_t, const float *, int, float *, int, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsrsm2_solve(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, cusparseOperation_t transXY, int mb, int n,
+    int nnzb, const float *alpha, const cusparseMatDescr_t descrA,
+    const float *bsrSortedVal, const int *bsrSortedRowPtr,
+    const int *bsrSortedColInd, int blockSize, bsrsm2Info_t info,
+    const float *B, int ldb, float *X, int ldx, cusparseSolvePolicy_t policy,
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
+      cusparseOperation_t, int, int, int, const float *,
+      const cusparseMatDescr_t, const float *, const int *, const int *, int,
+      bsrsm2Info_t, const float *, int, float *, int, cusparseSolvePolicy_t,
+      void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrsm2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, alpha, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, B, ldb, X, ldx, policy, pBuffer);
+  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, alpha, descrA,
+                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
+                  info, B, ldb, X, ldx, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsrsm2_solve(cusparseHandle_t handle,
-                                                   cusparseDirection_t dirA,
-                                                   cusparseOperation_t transA,
-                                                   cusparseOperation_t transXY,
-                                                   int mb,
-                                                   int n,
-                                                   int nnzb,
-                                                   const double *alpha,
-                                                   const cusparseMatDescr_t descrA,
-                                                   const double *bsrSortedVal,
-                                                   const int *bsrSortedRowPtr,
-                                                   const int *bsrSortedColInd,
-                                                   int blockSize,
-                                                   bsrsm2Info_t info,
-                                                   const double *B,
-                                                   int ldb,
-                                                   double *X,
-                                                   int ldx,
-                                                   cusparseSolvePolicy_t policy,
-                                                   void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, int, bsrsm2Info_t, const double *, int, double *, int, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsrsm2_solve(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, cusparseOperation_t transXY, int mb, int n,
+    int nnzb, const double *alpha, const cusparseMatDescr_t descrA,
+    const double *bsrSortedVal, const int *bsrSortedRowPtr,
+    const int *bsrSortedColInd, int blockSize, bsrsm2Info_t info,
+    const double *B, int ldb, double *X, int ldx, cusparseSolvePolicy_t policy,
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
+      cusparseOperation_t, int, int, int, const double *,
+      const cusparseMatDescr_t, const double *, const int *, const int *, int,
+      bsrsm2Info_t, const double *, int, double *, int, cusparseSolvePolicy_t,
+      void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrsm2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, alpha, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, B, ldb, X, ldx, policy, pBuffer);
+  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, alpha, descrA,
+                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
+                  info, B, ldb, X, ldx, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsrsm2_solve(cusparseHandle_t handle,
-                                                   cusparseDirection_t dirA,
-                                                   cusparseOperation_t transA,
-                                                   cusparseOperation_t transXY,
-                                                   int mb,
-                                                   int n,
-                                                   int nnzb,
-                                                   const cuComplex *alpha,
-                                                   const cusparseMatDescr_t descrA,
-                                                   const cuComplex *bsrSortedVal,
-                                                   const int *bsrSortedRowPtr,
-                                                   const int *bsrSortedColInd,
-                                                   int blockSize,
-                                                   bsrsm2Info_t info,
-                                                   const cuComplex *B,
-                                                   int ldb,
-                                                   cuComplex *X,
-                                                   int ldx,
-                                                   cusparseSolvePolicy_t policy,
-                                                   void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cuComplex *, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, int, bsrsm2Info_t, const cuComplex *, int, cuComplex *, int, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsrsm2_solve(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, cusparseOperation_t transXY, int mb, int n,
+    int nnzb, const cuComplex *alpha, const cusparseMatDescr_t descrA,
+    const cuComplex *bsrSortedVal, const int *bsrSortedRowPtr,
+    const int *bsrSortedColInd, int blockSize, bsrsm2Info_t info,
+    const cuComplex *B, int ldb, cuComplex *X, int ldx,
+    cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
+      cusparseOperation_t, int, int, int, const cuComplex *,
+      const cusparseMatDescr_t, const cuComplex *, const int *, const int *,
+      int, bsrsm2Info_t, const cuComplex *, int, cuComplex *, int,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrsm2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, alpha, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, B, ldb, X, ldx, policy, pBuffer);
+  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, alpha, descrA,
+                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
+                  info, B, ldb, X, ldx, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrsm2_solve(cusparseHandle_t handle,
-                                                   cusparseDirection_t dirA,
-                                                   cusparseOperation_t transA,
-                                                   cusparseOperation_t transXY,
-                                                   int mb,
-                                                   int n,
-                                                   int nnzb,
-                                                   const cuDoubleComplex *alpha,
-                                                   const cusparseMatDescr_t descrA,
-                                                   const cuDoubleComplex *bsrSortedVal,
-                                                   const int *bsrSortedRowPtr,
-                                                   const int *bsrSortedColInd,
-                                                   int blockSize,
-                                                   bsrsm2Info_t info,
-                                                   const cuDoubleComplex *B,
-                                                   int ldb,
-                                                   cuDoubleComplex *X,
-                                                   int ldx,
-                                                   cusparseSolvePolicy_t policy,
-                                                   void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, int, bsrsm2Info_t, const cuDoubleComplex *, int, cuDoubleComplex *, int, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrsm2_solve(
+    cusparseHandle_t handle, cusparseDirection_t dirA,
+    cusparseOperation_t transA, cusparseOperation_t transXY, int mb, int n,
+    int nnzb, const cuDoubleComplex *alpha, const cusparseMatDescr_t descrA,
+    const cuDoubleComplex *bsrSortedVal, const int *bsrSortedRowPtr,
+    const int *bsrSortedColInd, int blockSize, bsrsm2Info_t info,
+    const cuDoubleComplex *B, int ldb, cuDoubleComplex *X, int ldx,
+    cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, cusparseOperation_t,
+      cusparseOperation_t, int, int, int, const cuDoubleComplex *,
+      const cusparseMatDescr_t, const cuDoubleComplex *, const int *,
+      const int *, int, bsrsm2Info_t, const cuDoubleComplex *, int,
+      cuDoubleComplex *, int, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrsm2_solve");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, alpha, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, B, ldb, X, ldx, policy, pBuffer);
+  return func_ptr(handle, dirA, transA, transXY, mb, n, nnzb, alpha, descrA,
+                  bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize,
+                  info, B, ldb, X, ldx, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCsrilu0Ex(cusparseHandle_t handle,
-                                              cusparseOperation_t trans,
-                                              int m,
-                                              const cusparseMatDescr_t descrA,
-                                              void *csrSortedValA_ValM,
-                                              cudaDataType csrSortedValA_ValMtype,
-                                              /* matrix A values are updated inplace
-                                                 to be the preconditioner M values */
-                                              const int *csrSortedRowPtrA,
-                                              const int *csrSortedColIndA,
-                                              cusparseSolveAnalysisInfo_t info,
-                                              cudaDataType executiontype) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t, void *, cudaDataType, const int *, const int *, cusparseSolveAnalysisInfo_t, cudaDataType);
+cusparseStatus_t CUSPARSEAPI cusparseCsrilu0Ex(
+    cusparseHandle_t handle, cusparseOperation_t trans, int m,
+    const cusparseMatDescr_t descrA, void *csrSortedValA_ValM,
+    cudaDataType csrSortedValA_ValMtype, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, cusparseSolveAnalysisInfo_t info,
+    cudaDataType executiontype) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t,
+      void *, cudaDataType, const int *, const int *,
+      cusparseSolveAnalysisInfo_t, cudaDataType);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCsrilu0Ex");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM, csrSortedValA_ValMtype, csrSortedRowPtrA, csrSortedColIndA, info, executiontype);
+  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM,
+                  csrSortedValA_ValMtype, csrSortedRowPtrA, csrSortedColIndA,
+                  info, executiontype);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrilu0(cusparseHandle_t handle,
-                                              cusparseOperation_t trans,
-                                              int m,
-                                              const cusparseMatDescr_t descrA,
-                                              float *csrSortedValA_ValM,
-                                              /* matrix A values are updated inplace
-                                                 to be the preconditioner M values */
-                                              const int *csrSortedRowPtrA,
-                                              const int *csrSortedColIndA,
-                                              cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t, float *, const int *, const int *, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI
+cusparseScsrilu0(cusparseHandle_t handle, cusparseOperation_t trans, int m,
+                 const cusparseMatDescr_t descrA, float *csrSortedValA_ValM,
+                 const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+                 cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t,
+      float *, const int *, const int *, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrilu0");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM, csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM,
+                  csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrilu0(cusparseHandle_t handle,
-                                              cusparseOperation_t trans,
-                                              int m,
-                                              const cusparseMatDescr_t descrA,
-                                              double *csrSortedValA_ValM,
-                                              /* matrix A values are updated inplace
-                                                 to be the preconditioner M values */
-                                              const int *csrSortedRowPtrA,
-                                              const int *csrSortedColIndA,
-                                              cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t, double *, const int *, const int *, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI
+cusparseDcsrilu0(cusparseHandle_t handle, cusparseOperation_t trans, int m,
+                 const cusparseMatDescr_t descrA, double *csrSortedValA_ValM,
+                 const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+                 cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t,
+      double *, const int *, const int *, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrilu0");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM, csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM,
+                  csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrilu0(cusparseHandle_t handle,
-                                              cusparseOperation_t trans,
-                                              int m,
-                                              const cusparseMatDescr_t descrA,
-                                              cuComplex *csrSortedValA_ValM,
-                                              /* matrix A values are updated inplace
-                                                 to be the preconditioner M values */
-                                              const int *csrSortedRowPtrA,
-                                              const int *csrSortedColIndA,
-                                              cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI
+cusparseCcsrilu0(cusparseHandle_t handle, cusparseOperation_t trans, int m,
+                 const cusparseMatDescr_t descrA, cuComplex *csrSortedValA_ValM,
+                 const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+                 cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t,
+      cuComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrilu0");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM, csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM,
+                  csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrilu0(cusparseHandle_t handle,
-                                              cusparseOperation_t trans,
-                                              int m,
-                                              const cusparseMatDescr_t descrA,
-                                              cuDoubleComplex *csrSortedValA_ValM,
-                                              /* matrix A values are updated inplace
-                                                 to be the preconditioner M values */
-                                              const int *csrSortedRowPtrA,
-                                              const int *csrSortedColIndA,
-                                              cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrilu0(
+    cusparseHandle_t handle, cusparseOperation_t trans, int m,
+    const cusparseMatDescr_t descrA, cuDoubleComplex *csrSortedValA_ValM,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t,
+      cuDoubleComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrilu0");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM, csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM,
+                  csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrilu02_numericBoost(cusparseHandle_t handle,
-                                                            csrilu02Info_t info,
-                                                            int enable_boost,
-                                                            double *tol,
-                                                            float *boost_val) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, csrilu02Info_t, int, double *, float *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrilu02_numericBoost(
+    cusparseHandle_t handle, csrilu02Info_t info, int enable_boost, double *tol,
+    float *boost_val) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, csrilu02Info_t, int, double *, float *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrilu02_numericBoost");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, enable_boost, tol, boost_val);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrilu02_numericBoost(cusparseHandle_t handle,
-                                                            csrilu02Info_t info,
-                                                            int enable_boost,
-                                                            double *tol,
-                                                            double *boost_val) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, csrilu02Info_t, int, double *, double *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrilu02_numericBoost(
+    cusparseHandle_t handle, csrilu02Info_t info, int enable_boost, double *tol,
+    double *boost_val) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, csrilu02Info_t, int, double *, double *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrilu02_numericBoost");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, enable_boost, tol, boost_val);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrilu02_numericBoost(cusparseHandle_t handle,
-                                                            csrilu02Info_t info,
-                                                            int enable_boost,
-                                                            double *tol,
-                                                            cuComplex *boost_val) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, csrilu02Info_t, int, double *, cuComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrilu02_numericBoost(
+    cusparseHandle_t handle, csrilu02Info_t info, int enable_boost, double *tol,
+    cuComplex *boost_val) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, csrilu02Info_t, int, double *, cuComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrilu02_numericBoost");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, enable_boost, tol, boost_val);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrilu02_numericBoost(cusparseHandle_t handle,
-                                                            csrilu02Info_t info,
-                                                            int enable_boost,
-                                                            double *tol,
-                                                            cuDoubleComplex *boost_val) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, csrilu02Info_t, int, double *, cuDoubleComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrilu02_numericBoost(
+    cusparseHandle_t handle, csrilu02Info_t info, int enable_boost, double *tol,
+    cuDoubleComplex *boost_val) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, csrilu02Info_t, int, double *, cuDoubleComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrilu02_numericBoost");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, enable_boost, tol, boost_val);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseXcsrilu02_zeroPivot(cusparseHandle_t handle,
-                                                         csrilu02Info_t info,
-                                                         int *position) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, csrilu02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseXcsrilu02_zeroPivot(
+    cusparseHandle_t handle, csrilu02Info_t info, int *position) {
+  using FuncPtr =
+      cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, csrilu02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcsrilu02_zeroPivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, position);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrilu02_bufferSize(cusparseHandle_t handle,
-                                                          int m,
-                                                          int nnz,
-                                                          const cusparseMatDescr_t descrA,
-                                                          float *csrSortedValA,
-                                                          const int *csrSortedRowPtrA,
-                                                          const int *csrSortedColIndA,
-                                                          csrilu02Info_t info,
-                                                          int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, csrilu02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrilu02_bufferSize(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    float *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, csrilu02Info_t info, int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, float *,
+      const int *, const int *, csrilu02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrilu02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrilu02_bufferSize(cusparseHandle_t handle,
-                                                          int m,
-                                                          int nnz,
-                                                          const cusparseMatDescr_t descrA,
-                                                          double *csrSortedValA,
-                                                          const int *csrSortedRowPtrA,
-                                                          const int *csrSortedColIndA,
-                                                          csrilu02Info_t info,
-                                                          int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, csrilu02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrilu02_bufferSize(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    double *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, csrilu02Info_t info, int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, double *,
+      const int *, const int *, csrilu02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrilu02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrilu02_bufferSize(cusparseHandle_t handle,
-                                                          int m,
-                                                          int nnz,
-                                                          const cusparseMatDescr_t descrA,
-                                                          cuComplex *csrSortedValA,
-                                                          const int *csrSortedRowPtrA,
-                                                          const int *csrSortedColIndA,
-                                                          csrilu02Info_t info,
-                                                          int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, csrilu02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrilu02_bufferSize(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, csrilu02Info_t info, int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, cuComplex *,
+      const int *, const int *, csrilu02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrilu02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrilu02_bufferSize(cusparseHandle_t handle,
-                                                          int m,
-                                                          int nnz,
-                                                          const cusparseMatDescr_t descrA,
-                                                          cuDoubleComplex *csrSortedValA,
-                                                          const int *csrSortedRowPtrA,
-                                                          const int *csrSortedColIndA,
-                                                          csrilu02Info_t info,
-                                                          int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, csrilu02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrilu02_bufferSize(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, csrilu02Info_t info, int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *,
+      const int *, const int *, csrilu02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrilu02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrilu02_bufferSizeExt(cusparseHandle_t handle,
-                                                             int m,
-                                                             int nnz,
-                                                             const cusparseMatDescr_t descrA,
-                                                             float *csrSortedVal,
-                                                             const int *csrSortedRowPtr,
-                                                             const int *csrSortedColInd,
-                                                             csrilu02Info_t info,
-                                                             size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, csrilu02Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrilu02_bufferSizeExt(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    float *csrSortedVal, const int *csrSortedRowPtr, const int *csrSortedColInd,
+    csrilu02Info_t info, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, float *,
+      const int *, const int *, csrilu02Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrilu02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr, csrSortedColInd, info, pBufferSize);
+  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr,
+                  csrSortedColInd, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrilu02_bufferSizeExt(cusparseHandle_t handle,
-                                                             int m,
-                                                             int nnz,
-                                                             const cusparseMatDescr_t descrA,
-                                                             double *csrSortedVal,
-                                                             const int *csrSortedRowPtr,
-                                                             const int *csrSortedColInd,
-                                                             csrilu02Info_t info,
-                                                             size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, csrilu02Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrilu02_bufferSizeExt(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    double *csrSortedVal, const int *csrSortedRowPtr,
+    const int *csrSortedColInd, csrilu02Info_t info, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, double *,
+      const int *, const int *, csrilu02Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrilu02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr, csrSortedColInd, info, pBufferSize);
+  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr,
+                  csrSortedColInd, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrilu02_bufferSizeExt(cusparseHandle_t handle,
-                                                             int m,
-                                                             int nnz,
-                                                             const cusparseMatDescr_t descrA,
-                                                             cuComplex *csrSortedVal,
-                                                             const int *csrSortedRowPtr,
-                                                             const int *csrSortedColInd,
-                                                             csrilu02Info_t info,
-                                                             size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, csrilu02Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrilu02_bufferSizeExt(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    cuComplex *csrSortedVal, const int *csrSortedRowPtr,
+    const int *csrSortedColInd, csrilu02Info_t info, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, cuComplex *,
+      const int *, const int *, csrilu02Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrilu02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr, csrSortedColInd, info, pBufferSize);
+  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr,
+                  csrSortedColInd, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrilu02_bufferSizeExt(cusparseHandle_t handle,
-                                                             int m,
-                                                             int nnz,
-                                                             const cusparseMatDescr_t descrA,
-                                                             cuDoubleComplex *csrSortedVal,
-                                                             const int *csrSortedRowPtr,
-                                                             const int *csrSortedColInd,
-                                                             csrilu02Info_t info,
-                                                             size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, csrilu02Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrilu02_bufferSizeExt(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    cuDoubleComplex *csrSortedVal, const int *csrSortedRowPtr,
+    const int *csrSortedColInd, csrilu02Info_t info, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *,
+      const int *, const int *, csrilu02Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrilu02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr, csrSortedColInd, info, pBufferSize);
+  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr,
+                  csrSortedColInd, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrilu02_analysis(cusparseHandle_t handle,
-                                                        int m,
-                                                        int nnz,
-                                                        const cusparseMatDescr_t descrA,
-                                                        const float *csrSortedValA,
-                                                        const int *csrSortedRowPtrA,
-                                                        const int *csrSortedColIndA,
-                                                        csrilu02Info_t info,
-                                                        cusparseSolvePolicy_t policy,
-                                                        void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, csrilu02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrilu02_analysis(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    const float *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, csrilu02Info_t info,
+    cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *,
+      const int *, const int *, csrilu02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrilu02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrilu02_analysis(cusparseHandle_t handle,
-                                                        int m,
-                                                        int nnz,
-                                                        const cusparseMatDescr_t descrA,
-                                                        const double *csrSortedValA,
-                                                        const int *csrSortedRowPtrA,
-                                                        const int *csrSortedColIndA,
-                                                        csrilu02Info_t info,
-                                                        cusparseSolvePolicy_t policy,
-                                                        void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, csrilu02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrilu02_analysis(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    const double *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, csrilu02Info_t info,
+    cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *,
+      const int *, const int *, csrilu02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrilu02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrilu02_analysis(cusparseHandle_t handle,
-                                                        int m,
-                                                        int nnz,
-                                                        const cusparseMatDescr_t descrA,
-                                                        const cuComplex *csrSortedValA,
-                                                        const int *csrSortedRowPtrA,
-                                                        const int *csrSortedColIndA,
-                                                        csrilu02Info_t info,
-                                                        cusparseSolvePolicy_t policy,
-                                                        void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, csrilu02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrilu02_analysis(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    const cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, csrilu02Info_t info,
+    cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *,
+      const int *, const int *, csrilu02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrilu02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrilu02_analysis(cusparseHandle_t handle,
-                                                        int m,
-                                                        int nnz,
-                                                        const cusparseMatDescr_t descrA,
-                                                        const cuDoubleComplex *csrSortedValA,
-                                                        const int *csrSortedRowPtrA,
-                                                        const int *csrSortedColIndA,
-                                                        csrilu02Info_t info,
-                                                        cusparseSolvePolicy_t policy,
-                                                        void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, csrilu02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrilu02_analysis(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, csrilu02Info_t info,
+    cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t,
+      const cuDoubleComplex *, const int *, const int *, csrilu02Info_t,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrilu02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrilu02(cusparseHandle_t handle,
-                                               int m,
-                                               int nnz,
-                                               const cusparseMatDescr_t descrA,
-                                               float *csrSortedValA_valM,
-                                               /* matrix A values are updated inplace
-                                                  to be the preconditioner M values */
-                                               const int *csrSortedRowPtrA,
-                                               const int *csrSortedColIndA,
-                                               csrilu02Info_t info,
-                                               cusparseSolvePolicy_t policy,
-                                               void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, csrilu02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrilu02(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    float *csrSortedValA_valM, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, csrilu02Info_t info,
+    cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, float *,
+      const int *, const int *, csrilu02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrilu02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA,
+                  csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrilu02(cusparseHandle_t handle,
-                                               int m,
-                                               int nnz,
-                                               const cusparseMatDescr_t descrA,
-                                               double *csrSortedValA_valM,
-                                               /* matrix A values are updated inplace
-                                                  to be the preconditioner M values */
-                                               const int *csrSortedRowPtrA,
-                                               const int *csrSortedColIndA,
-                                               csrilu02Info_t info,
-                                               cusparseSolvePolicy_t policy,
-                                               void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, csrilu02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrilu02(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    double *csrSortedValA_valM, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, csrilu02Info_t info,
+    cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, double *,
+      const int *, const int *, csrilu02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrilu02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA,
+                  csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrilu02(cusparseHandle_t handle,
-                                               int m,
-                                               int nnz,
-                                               const cusparseMatDescr_t descrA,
-                                               cuComplex *csrSortedValA_valM,
-                                               /* matrix A values are updated inplace
-                                                  to be the preconditioner M values */
-                                               const int *csrSortedRowPtrA,
-                                               const int *csrSortedColIndA,
-                                               csrilu02Info_t info,
-                                               cusparseSolvePolicy_t policy,
-                                               void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, csrilu02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrilu02(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    cuComplex *csrSortedValA_valM, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, csrilu02Info_t info,
+    cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, cuComplex *,
+      const int *, const int *, csrilu02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrilu02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA,
+                  csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrilu02(cusparseHandle_t handle,
-                                               int m,
-                                               int nnz,
-                                               const cusparseMatDescr_t descrA,
-                                               cuDoubleComplex *csrSortedValA_valM,
-                                               /* matrix A values are updated inplace
-                                                  to be the preconditioner M values */
-                                               const int *csrSortedRowPtrA,
-                                               const int *csrSortedColIndA,
-                                               csrilu02Info_t info,
-                                               cusparseSolvePolicy_t policy,
-                                               void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, csrilu02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrilu02(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    cuDoubleComplex *csrSortedValA_valM, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, csrilu02Info_t info,
+    cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *,
+      const int *, const int *, csrilu02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrilu02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA,
+                  csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsrilu02_numericBoost(cusparseHandle_t handle,
-                                                            bsrilu02Info_t info,
-                                                            int enable_boost,
-                                                            double *tol,
-                                                            float *boost_val) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, bsrilu02Info_t, int, double *, float *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsrilu02_numericBoost(
+    cusparseHandle_t handle, bsrilu02Info_t info, int enable_boost, double *tol,
+    float *boost_val) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, bsrilu02Info_t, int, double *, float *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrilu02_numericBoost");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, enable_boost, tol, boost_val);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsrilu02_numericBoost(cusparseHandle_t handle,
-                                                            bsrilu02Info_t info,
-                                                            int enable_boost,
-                                                            double *tol,
-                                                            double *boost_val) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, bsrilu02Info_t, int, double *, double *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsrilu02_numericBoost(
+    cusparseHandle_t handle, bsrilu02Info_t info, int enable_boost, double *tol,
+    double *boost_val) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, bsrilu02Info_t, int, double *, double *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrilu02_numericBoost");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, enable_boost, tol, boost_val);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsrilu02_numericBoost(cusparseHandle_t handle,
-                                                            bsrilu02Info_t info,
-                                                            int enable_boost,
-                                                            double *tol,
-                                                            cuComplex *boost_val) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, bsrilu02Info_t, int, double *, cuComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsrilu02_numericBoost(
+    cusparseHandle_t handle, bsrilu02Info_t info, int enable_boost, double *tol,
+    cuComplex *boost_val) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, bsrilu02Info_t, int, double *, cuComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrilu02_numericBoost");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, enable_boost, tol, boost_val);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrilu02_numericBoost(cusparseHandle_t handle,
-                                                            bsrilu02Info_t info,
-                                                            int enable_boost,
-                                                            double *tol,
-                                                            cuDoubleComplex *boost_val) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, bsrilu02Info_t, int, double *, cuDoubleComplex *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrilu02_numericBoost(
+    cusparseHandle_t handle, bsrilu02Info_t info, int enable_boost, double *tol,
+    cuDoubleComplex *boost_val) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, bsrilu02Info_t, int, double *, cuDoubleComplex *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrilu02_numericBoost");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, enable_boost, tol, boost_val);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseXbsrilu02_zeroPivot(cusparseHandle_t handle,
-                                                         bsrilu02Info_t info,
-                                                         int *position) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, bsrilu02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseXbsrilu02_zeroPivot(
+    cusparseHandle_t handle, bsrilu02Info_t info, int *position) {
+  using FuncPtr =
+      cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, bsrilu02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXbsrilu02_zeroPivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, position);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsrilu02_bufferSize(cusparseHandle_t handle,
-                                                          cusparseDirection_t dirA,
-                                                          int mb,
-                                                          int nnzb,
-                                                          const cusparseMatDescr_t descrA,
-                                                          float *bsrSortedVal,
-                                                          const int *bsrSortedRowPtr,
-                                                          const int *bsrSortedColInd,
-                                                          int blockDim,
-                                                          bsrilu02Info_t info,
-                                                          int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, int, bsrilu02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsrilu02_bufferSize(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, float *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+    bsrilu02Info_t info, int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      float *, const int *, const int *, int, bsrilu02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrilu02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsrilu02_bufferSize(cusparseHandle_t handle,
-                                                          cusparseDirection_t dirA,
-                                                          int mb,
-                                                          int nnzb,
-                                                          const cusparseMatDescr_t descrA,
-                                                          double *bsrSortedVal,
-                                                          const int *bsrSortedRowPtr,
-                                                          const int *bsrSortedColInd,
-                                                          int blockDim,
-                                                          bsrilu02Info_t info,
-                                                          int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, int, bsrilu02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsrilu02_bufferSize(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, double *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+    bsrilu02Info_t info, int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      double *, const int *, const int *, int, bsrilu02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrilu02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsrilu02_bufferSize(cusparseHandle_t handle,
-                                                          cusparseDirection_t dirA,
-                                                          int mb,
-                                                          int nnzb,
-                                                          const cusparseMatDescr_t descrA,
-                                                          cuComplex *bsrSortedVal,
-                                                          const int *bsrSortedRowPtr,
-                                                          const int *bsrSortedColInd,
-                                                          int blockDim,
-                                                          bsrilu02Info_t info,
-                                                          int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, int, bsrilu02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsrilu02_bufferSize(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, cuComplex *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+    bsrilu02Info_t info, int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      cuComplex *, const int *, const int *, int, bsrilu02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrilu02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrilu02_bufferSize(cusparseHandle_t handle,
-                                                          cusparseDirection_t dirA,
-                                                          int mb,
-                                                          int nnzb,
-                                                          const cusparseMatDescr_t descrA,
-                                                          cuDoubleComplex *bsrSortedVal,
-                                                          const int *bsrSortedRowPtr,
-                                                          const int *bsrSortedColInd,
-                                                          int blockDim,
-                                                          bsrilu02Info_t info,
-                                                          int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, int, bsrilu02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrilu02_bufferSize(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, cuDoubleComplex *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+    bsrilu02Info_t info, int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      cuDoubleComplex *, const int *, const int *, int, bsrilu02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrilu02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsrilu02_bufferSizeExt(cusparseHandle_t handle,
-                                                          cusparseDirection_t dirA,
-                                                          int mb,
-                                                          int nnzb,
-                                                          const cusparseMatDescr_t descrA,
-                                                          float *bsrSortedVal,
-                                                          const int *bsrSortedRowPtr,
-                                                          const int *bsrSortedColInd,
-                                                          int blockSize,
-                                                          bsrilu02Info_t info,
-                                                          size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, int, bsrilu02Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsrilu02_bufferSizeExt(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, float *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
+    bsrilu02Info_t info, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      float *, const int *, const int *, int, bsrilu02Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrilu02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSize);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockSize, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsrilu02_bufferSizeExt(cusparseHandle_t handle,
-                                                          cusparseDirection_t dirA,
-                                                          int mb,
-                                                          int nnzb,
-                                                          const cusparseMatDescr_t descrA,
-                                                          double *bsrSortedVal,
-                                                          const int *bsrSortedRowPtr,
-                                                          const int *bsrSortedColInd,
-                                                          int blockSize,
-                                                          bsrilu02Info_t info,
-                                                          size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, int, bsrilu02Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsrilu02_bufferSizeExt(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, double *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
+    bsrilu02Info_t info, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      double *, const int *, const int *, int, bsrilu02Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrilu02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSize);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockSize, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsrilu02_bufferSizeExt(cusparseHandle_t handle,
-                                                          cusparseDirection_t dirA,
-                                                          int mb,
-                                                          int nnzb,
-                                                          const cusparseMatDescr_t descrA,
-                                                          cuComplex *bsrSortedVal,
-                                                          const int *bsrSortedRowPtr,
-                                                          const int *bsrSortedColInd,
-                                                          int blockSize,
-                                                          bsrilu02Info_t info,
-                                                          size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, int, bsrilu02Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsrilu02_bufferSizeExt(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, cuComplex *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
+    bsrilu02Info_t info, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      cuComplex *, const int *, const int *, int, bsrilu02Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrilu02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSize);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockSize, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrilu02_bufferSizeExt(cusparseHandle_t handle,
-                                                          cusparseDirection_t dirA,
-                                                          int mb,
-                                                          int nnzb,
-                                                          const cusparseMatDescr_t descrA,
-                                                          cuDoubleComplex *bsrSortedVal,
-                                                          const int *bsrSortedRowPtr,
-                                                          const int *bsrSortedColInd,
-                                                          int blockSize,
-                                                          bsrilu02Info_t info,
-                                                          size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, int, bsrilu02Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrilu02_bufferSizeExt(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, cuDoubleComplex *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
+    bsrilu02Info_t info, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      cuDoubleComplex *, const int *, const int *, int, bsrilu02Info_t,
+      size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrilu02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSize);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockSize, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsrilu02_analysis(cusparseHandle_t handle,
-                                                        cusparseDirection_t dirA,
-                                                        int mb,
-                                                        int nnzb,
-                                                        const cusparseMatDescr_t descrA,
-                                                        float *bsrSortedVal,
-                                                        const int *bsrSortedRowPtr,
-                                                        const int *bsrSortedColInd,
-                                                        int blockDim,
-                                                        bsrilu02Info_t info,
-                                                        cusparseSolvePolicy_t policy,
-                                                        void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, int, bsrilu02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsrilu02_analysis(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, float *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+    bsrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      float *, const int *, const int *, int, bsrilu02Info_t,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrilu02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockDim, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsrilu02_analysis(cusparseHandle_t handle,
-                                                        cusparseDirection_t dirA,
-                                                        int mb,
-                                                        int nnzb,
-                                                        const cusparseMatDescr_t descrA,
-                                                        double *bsrSortedVal,
-                                                        const int *bsrSortedRowPtr,
-                                                        const int *bsrSortedColInd,
-                                                        int blockDim,
-                                                        bsrilu02Info_t info,
-                                                        cusparseSolvePolicy_t policy,
-                                                        void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, int, bsrilu02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsrilu02_analysis(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, double *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+    bsrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      double *, const int *, const int *, int, bsrilu02Info_t,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrilu02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockDim, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsrilu02_analysis(cusparseHandle_t handle,
-                                                        cusparseDirection_t dirA,
-                                                        int mb,
-                                                        int nnzb,
-                                                        const cusparseMatDescr_t descrA,
-                                                        cuComplex *bsrSortedVal,
-                                                        const int *bsrSortedRowPtr,
-                                                        const int *bsrSortedColInd,
-                                                        int blockDim,
-                                                        bsrilu02Info_t info,
-                                                        cusparseSolvePolicy_t policy,
-                                                        void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, int, bsrilu02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsrilu02_analysis(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, cuComplex *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+    bsrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      cuComplex *, const int *, const int *, int, bsrilu02Info_t,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrilu02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockDim, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrilu02_analysis(cusparseHandle_t handle,
-                                                        cusparseDirection_t dirA,
-                                                        int mb,
-                                                        int nnzb,
-                                                        const cusparseMatDescr_t descrA,
-                                                        cuDoubleComplex *bsrSortedVal,
-                                                        const int *bsrSortedRowPtr,
-                                                        const int *bsrSortedColInd,
-                                                        int blockDim,
-                                                        bsrilu02Info_t info,
-                                                        cusparseSolvePolicy_t policy,
-                                                        void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, int, bsrilu02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrilu02_analysis(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, cuDoubleComplex *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+    bsrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      cuDoubleComplex *, const int *, const int *, int, bsrilu02Info_t,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrilu02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockDim, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsrilu02(cusparseHandle_t handle,
-                                               cusparseDirection_t dirA,
-                                               int mb,
-                                               int nnzb,
-                                               const cusparseMatDescr_t descrA,
-                                               float *bsrSortedVal,
-                                               const int *bsrSortedRowPtr,
-                                               const int *bsrSortedColInd,
-                                               int blockDim,
-                                               bsrilu02Info_t info,
-                                               cusparseSolvePolicy_t policy,
-                                               void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, int, bsrilu02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsrilu02(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, float *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+    bsrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      float *, const int *, const int *, int, bsrilu02Info_t,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsrilu02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockDim, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsrilu02(cusparseHandle_t handle,
-                                               cusparseDirection_t dirA,
-                                               int mb,
-                                               int nnzb,
-                                               const cusparseMatDescr_t descrA,
-                                               double *bsrSortedVal,
-                                               const int *bsrSortedRowPtr,
-                                               const int *bsrSortedColInd,
-                                               int blockDim,
-                                               bsrilu02Info_t info,
-                                               cusparseSolvePolicy_t policy,
-                                               void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, int, bsrilu02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsrilu02(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, double *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+    bsrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      double *, const int *, const int *, int, bsrilu02Info_t,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsrilu02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockDim, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsrilu02(cusparseHandle_t handle,
-                                               cusparseDirection_t dirA,
-                                               int mb,
-                                               int nnzb,
-                                               const cusparseMatDescr_t descrA,
-                                               cuComplex *bsrSortedVal,
-                                               const int *bsrSortedRowPtr,
-                                               const int *bsrSortedColInd,
-                                               int blockDim,
-                                               bsrilu02Info_t info,
-                                               cusparseSolvePolicy_t policy,
-                                               void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, int, bsrilu02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsrilu02(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, cuComplex *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+    bsrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      cuComplex *, const int *, const int *, int, bsrilu02Info_t,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsrilu02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockDim, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsrilu02(cusparseHandle_t handle,
-                                               cusparseDirection_t dirA,
-                                               int mb,
-                                               int nnzb,
-                                               const cusparseMatDescr_t descrA,
-                                               cuDoubleComplex *bsrSortedVal,
-                                               const int *bsrSortedRowPtr,
-                                               const int *bsrSortedColInd,
-                                               int blockDim,
-                                               bsrilu02Info_t info,
-                                               cusparseSolvePolicy_t policy,
-                                               void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, int, bsrilu02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsrilu02(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, cuDoubleComplex *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+    bsrilu02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      cuDoubleComplex *, const int *, const int *, int, bsrilu02Info_t,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsrilu02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockDim, info, policy, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseScsric0(cusparseHandle_t handle,
-                                              cusparseOperation_t trans,
-                                              int m,
-                                              const cusparseMatDescr_t descrA,
-                                              float *csrSortedValA_ValM,
-                                              /* matrix A values are updated inplace
-                                                 to be the preconditioner M values */
-                                              const int *csrSortedRowPtrA,
-                                              const int *csrSortedColIndA,
-                                              cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t, float *, const int *, const int *, cusparseSolveAnalysisInfo_t);
+                                             cusparseOperation_t trans, int m,
+                                             const cusparseMatDescr_t descrA,
+                                             float *csrSortedValA_ValM,
+                                             const int *csrSortedRowPtrA,
+                                             const int *csrSortedColIndA,
+                                             cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t,
+      float *, const int *, const int *, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsric0");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM, csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM,
+                  csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDcsric0(cusparseHandle_t handle,
-                                              cusparseOperation_t trans,
-                                              int m,
-                                              const cusparseMatDescr_t descrA,
-                                              double *csrSortedValA_ValM,
-                                              /* matrix A values are updated inplace
-                                                 to be the preconditioner M values */
-                                              const int *csrSortedRowPtrA,
-                                              const int *csrSortedColIndA,
-                                              cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t, double *, const int *, const int *, cusparseSolveAnalysisInfo_t);
+                                             cusparseOperation_t trans, int m,
+                                             const cusparseMatDescr_t descrA,
+                                             double *csrSortedValA_ValM,
+                                             const int *csrSortedRowPtrA,
+                                             const int *csrSortedColIndA,
+                                             cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t,
+      double *, const int *, const int *, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsric0");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM, csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM,
+                  csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCcsric0(cusparseHandle_t handle,
-                                              cusparseOperation_t trans,
-                                              int m,
-                                              const cusparseMatDescr_t descrA,
-                                              cuComplex *csrSortedValA_ValM,
-                                              /* matrix A values are updated inplace
-                                                 to be the preconditioner M values */
-                                              const int *csrSortedRowPtrA,
-                                              const int *csrSortedColIndA,
-                                              cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t);
+                                             cusparseOperation_t trans, int m,
+                                             const cusparseMatDescr_t descrA,
+                                             cuComplex *csrSortedValA_ValM,
+                                             const int *csrSortedRowPtrA,
+                                             const int *csrSortedColIndA,
+                                             cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t,
+      cuComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsric0");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM, csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM,
+                  csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsric0(cusparseHandle_t handle,
-                                              cusparseOperation_t trans,
-                                              int m,
-                                              const cusparseMatDescr_t descrA,
-                                              cuDoubleComplex *csrSortedValA_ValM,
-                                              /* matrix A values are updated inplace
-                                                 to be the preconditioner M values */
-                                              const int *csrSortedRowPtrA,
-                                              const int *csrSortedColIndA,
-                                              cusparseSolveAnalysisInfo_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseZcsric0(
+    cusparseHandle_t handle, cusparseOperation_t trans, int m,
+    const cusparseMatDescr_t descrA, cuDoubleComplex *csrSortedValA_ValM,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    cusparseSolveAnalysisInfo_t info) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, int, const cusparseMatDescr_t,
+      cuDoubleComplex *, const int *, const int *, cusparseSolveAnalysisInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsric0");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM, csrSortedRowPtrA, csrSortedColIndA, info);
+  return func_ptr(handle, trans, m, descrA, csrSortedValA_ValM,
+                  csrSortedRowPtrA, csrSortedColIndA, info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseXcsric02_zeroPivot(cusparseHandle_t handle,
                                                         csric02Info_t info,
                                                         int *position) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, csric02Info_t, int *);
+  using FuncPtr =
+      cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, csric02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcsric02_zeroPivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, position);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsric02_bufferSize(cusparseHandle_t handle,
-                                                         int m,
-                                                         int nnz,
-                                                         const cusparseMatDescr_t descrA,
-                                                         float *csrSortedValA,
-                                                         const int *csrSortedRowPtrA,
-                                                         const int *csrSortedColIndA,
-                                                         csric02Info_t info,
-                                                         int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, csric02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseScsric02_bufferSize(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    float *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, csric02Info_t info, int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, float *,
+      const int *, const int *, csric02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsric02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsric02_bufferSize(cusparseHandle_t handle,
-                                                         int m,
-                                                         int nnz,
-                                                         const cusparseMatDescr_t descrA,
-                                                         double *csrSortedValA,
-                                                         const int *csrSortedRowPtrA,
-                                                         const int *csrSortedColIndA,
-                                                         csric02Info_t info,
-                                                         int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, csric02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsric02_bufferSize(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    double *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, csric02Info_t info, int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, double *,
+      const int *, const int *, csric02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsric02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsric02_bufferSize(cusparseHandle_t handle,
-                                                         int m,
-                                                         int nnz,
-                                                         const cusparseMatDescr_t descrA,
-                                                         cuComplex *csrSortedValA,
-                                                         const int *csrSortedRowPtrA,
-                                                         const int *csrSortedColIndA,
-                                                         csric02Info_t info,
-                                                         int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, csric02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsric02_bufferSize(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, csric02Info_t info, int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, cuComplex *,
+      const int *, const int *, csric02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsric02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsric02_bufferSize(cusparseHandle_t handle,
-                                                         int m,
-                                                         int nnz,
-                                                         const cusparseMatDescr_t descrA,
-                                                         cuDoubleComplex *csrSortedValA,
-                                                         const int *csrSortedRowPtrA,
-                                                         const int *csrSortedColIndA,
-                                                         csric02Info_t info,
-                                                         int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, csric02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsric02_bufferSize(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, csric02Info_t info, int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *,
+      const int *, const int *, csric02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsric02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsric02_bufferSizeExt(cusparseHandle_t handle,
-                                                            int m,
-                                                            int nnz,
-                                                            const cusparseMatDescr_t descrA,
-                                                            float *csrSortedVal,
-                                                            const int *csrSortedRowPtr,
-                                                            const int *csrSortedColInd,
-                                                            csric02Info_t info,
-                                                            size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, csric02Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseScsric02_bufferSizeExt(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    float *csrSortedVal, const int *csrSortedRowPtr, const int *csrSortedColInd,
+    csric02Info_t info, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, float *,
+      const int *, const int *, csric02Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsric02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr, csrSortedColInd, info, pBufferSize);
+  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr,
+                  csrSortedColInd, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsric02_bufferSizeExt(cusparseHandle_t handle,
-                                                            int m,
-                                                            int nnz,
-                                                            const cusparseMatDescr_t descrA,
-                                                            double *csrSortedVal,
-                                                            const int *csrSortedRowPtr,
-                                                            const int *csrSortedColInd,
-                                                            csric02Info_t info,
-                                                            size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, csric02Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsric02_bufferSizeExt(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    double *csrSortedVal, const int *csrSortedRowPtr,
+    const int *csrSortedColInd, csric02Info_t info, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, double *,
+      const int *, const int *, csric02Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsric02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr, csrSortedColInd, info, pBufferSize);
+  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr,
+                  csrSortedColInd, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsric02_bufferSizeExt(cusparseHandle_t handle,
-                                                            int m,
-                                                            int nnz,
-                                                            const cusparseMatDescr_t descrA,
-                                                            cuComplex *csrSortedVal,
-                                                            const int *csrSortedRowPtr,
-                                                            const int *csrSortedColInd,
-                                                            csric02Info_t info,
-                                                            size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, csric02Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsric02_bufferSizeExt(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    cuComplex *csrSortedVal, const int *csrSortedRowPtr,
+    const int *csrSortedColInd, csric02Info_t info, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, cuComplex *,
+      const int *, const int *, csric02Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsric02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr, csrSortedColInd, info, pBufferSize);
+  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr,
+                  csrSortedColInd, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsric02_bufferSizeExt(cusparseHandle_t handle,
-                                                            int m,
-                                                            int nnz,
-                                                            const cusparseMatDescr_t descrA,
-                                                            cuDoubleComplex *csrSortedVal,
-                                                            const int *csrSortedRowPtr,
-                                                            const int *csrSortedColInd,
-                                                            csric02Info_t info,
-                                                            size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, csric02Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsric02_bufferSizeExt(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    cuDoubleComplex *csrSortedVal, const int *csrSortedRowPtr,
+    const int *csrSortedColInd, csric02Info_t info, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *,
+      const int *, const int *, csric02Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsric02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr, csrSortedColInd, info, pBufferSize);
+  return func_ptr(handle, m, nnz, descrA, csrSortedVal, csrSortedRowPtr,
+                  csrSortedColInd, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsric02_analysis(cusparseHandle_t handle,
-                                                       int m,
-                                                       int nnz,
-                                                       const cusparseMatDescr_t descrA,
-                                                       const float *csrSortedValA,
-                                                       const int *csrSortedRowPtrA,
-                                                       const int *csrSortedColIndA,
-                                                       csric02Info_t info,
-                                                       cusparseSolvePolicy_t policy,
-                                                       void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, csric02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseScsric02_analysis(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    const float *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, csric02Info_t info,
+    cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *,
+      const int *, const int *, csric02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsric02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsric02_analysis(cusparseHandle_t handle,
-                                                       int m,
-                                                       int nnz,
-                                                       const cusparseMatDescr_t descrA,
-                                                       const double *csrSortedValA,
-                                                       const int *csrSortedRowPtrA,
-                                                       const int *csrSortedColIndA,
-                                                       csric02Info_t info,
-                                                       cusparseSolvePolicy_t policy,
-                                                       void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, csric02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsric02_analysis(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    const double *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, csric02Info_t info,
+    cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *,
+      const int *, const int *, csric02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsric02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsric02_analysis(cusparseHandle_t handle,
-                                                       int m,
-                                                       int nnz,
-                                                       const cusparseMatDescr_t descrA,
-                                                       const cuComplex *csrSortedValA,
-                                                       const int *csrSortedRowPtrA,
-                                                       const int *csrSortedColIndA,
-                                                       csric02Info_t info,
-                                                       cusparseSolvePolicy_t policy,
-                                                       void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, csric02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsric02_analysis(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    const cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, csric02Info_t info,
+    cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *,
+      const int *, const int *, csric02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsric02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsric02_analysis(cusparseHandle_t handle,
-                                                       int m,
-                                                       int nnz,
-                                                       const cusparseMatDescr_t descrA,
-                                                       const cuDoubleComplex *csrSortedValA,
-                                                       const int *csrSortedRowPtrA,
-                                                       const int *csrSortedColIndA,
-                                                       csric02Info_t info,
-                                                       cusparseSolvePolicy_t policy,
-                                                       void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, csric02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsric02_analysis(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, csric02Info_t info,
+    cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t,
+      const cuDoubleComplex *, const int *, const int *, csric02Info_t,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsric02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsric02(cusparseHandle_t handle,
-                                              int m,
-                                              int nnz,
-                                              const cusparseMatDescr_t descrA,
-                                              float *csrSortedValA_valM,
-                                              /* matrix A values are updated inplace
-                                                 to be the preconditioner M values */
-                                              const int *csrSortedRowPtrA,
-                                              const int *csrSortedColIndA,
-                                              csric02Info_t info,
-                                              cusparseSolvePolicy_t policy,
-                                              void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, csric02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseScsric02(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    float *csrSortedValA_valM, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, csric02Info_t info,
+    cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, float *,
+      const int *, const int *, csric02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsric02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA,
+                  csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsric02(cusparseHandle_t handle,
-                                              int m,
-                                              int nnz,
-                                              const cusparseMatDescr_t descrA,
-                                              double *csrSortedValA_valM,
-                                              /* matrix A values are updated inplace
-                                                 to be the preconditioner M values */
-                                              const int *csrSortedRowPtrA,
-                                              const int *csrSortedColIndA,
-                                              csric02Info_t info,
-                                              cusparseSolvePolicy_t policy,
-                                              void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, csric02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsric02(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    double *csrSortedValA_valM, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, csric02Info_t info,
+    cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, double *,
+      const int *, const int *, csric02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsric02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA,
+                  csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsric02(cusparseHandle_t handle,
-                                              int m,
-                                              int nnz,
-                                              const cusparseMatDescr_t descrA,
-                                              cuComplex *csrSortedValA_valM,
-                                              /* matrix A values are updated inplace
-                                                 to be the preconditioner M values */
-                                              const int *csrSortedRowPtrA,
-                                              const int *csrSortedColIndA,
-                                              csric02Info_t info,
-                                              cusparseSolvePolicy_t policy,
-                                              void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, csric02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsric02(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    cuComplex *csrSortedValA_valM, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, csric02Info_t info,
+    cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, cuComplex *,
+      const int *, const int *, csric02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsric02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA,
+                  csrSortedColIndA, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsric02(cusparseHandle_t handle,
-                                              int m,
-                                              int nnz,
-                                              const cusparseMatDescr_t descrA,
-                                              cuDoubleComplex *csrSortedValA_valM,
-                                              /* matrix A values are updated inplace
-                                                 to be the preconditioner M values */
-                                              const int *csrSortedRowPtrA,
-                                              const int *csrSortedColIndA,
-                                              csric02Info_t info,
-                                              cusparseSolvePolicy_t policy,
-                                              void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, csric02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsric02(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    cuDoubleComplex *csrSortedValA_valM, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, csric02Info_t info,
+    cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *,
+      const int *, const int *, csric02Info_t, cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsric02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA, csrSortedColIndA, info, policy, pBuffer);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA_valM, csrSortedRowPtrA,
+                  csrSortedColIndA, info, policy, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseXbsric02_zeroPivot(cusparseHandle_t handle,
                                                         bsric02Info_t info,
                                                         int *position) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, bsric02Info_t, int *);
+  using FuncPtr =
+      cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, bsric02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXbsric02_zeroPivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, info, position);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsric02_bufferSize(cusparseHandle_t handle,
-                                                         cusparseDirection_t dirA,
-                                                         int mb,
-                                                         int nnzb,
-                                                         const cusparseMatDescr_t descrA,
-                                                         float *bsrSortedVal,
-                                                         const int *bsrSortedRowPtr,
-                                                         const int *bsrSortedColInd,
-                                                         int blockDim,
-                                                         bsric02Info_t info,
-                                                         int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, int, bsric02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsric02_bufferSize(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, float *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+    bsric02Info_t info, int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      float *, const int *, const int *, int, bsric02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsric02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsric02_bufferSize(cusparseHandle_t handle,
-                                                         cusparseDirection_t dirA,
-                                                         int mb,
-                                                         int nnzb,
-                                                         const cusparseMatDescr_t descrA,
-                                                         double *bsrSortedVal,
-                                                         const int *bsrSortedRowPtr,
-                                                         const int *bsrSortedColInd,
-                                                         int blockDim,
-                                                         bsric02Info_t info,
-                                                         int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, int, bsric02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsric02_bufferSize(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, double *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+    bsric02Info_t info, int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      double *, const int *, const int *, int, bsric02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsric02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsric02_bufferSize(cusparseHandle_t handle,
-                                                         cusparseDirection_t dirA,
-                                                         int mb,
-                                                         int nnzb,
-                                                         const cusparseMatDescr_t descrA,
-                                                         cuComplex *bsrSortedVal,
-                                                         const int *bsrSortedRowPtr,
-                                                         const int *bsrSortedColInd,
-                                                         int blockDim,
-                                                         bsric02Info_t info,
-                                                         int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, int, bsric02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsric02_bufferSize(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, cuComplex *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+    bsric02Info_t info, int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      cuComplex *, const int *, const int *, int, bsric02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsric02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsric02_bufferSize(cusparseHandle_t handle,
-                                                         cusparseDirection_t dirA,
-                                                         int mb,
-                                                         int nnzb,
-                                                         const cusparseMatDescr_t descrA,
-                                                         cuDoubleComplex *bsrSortedVal,
-                                                         const int *bsrSortedRowPtr,
-                                                         const int *bsrSortedColInd,
-                                                         int blockDim,
-                                                         bsric02Info_t info,
-                                                         int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, int, bsric02Info_t, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsric02_bufferSize(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, cuDoubleComplex *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+    bsric02Info_t info, int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      cuDoubleComplex *, const int *, const int *, int, bsric02Info_t, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsric02_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockDim, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsric02_bufferSizeExt(cusparseHandle_t handle,
-                                                         cusparseDirection_t dirA,
-                                                         int mb,
-                                                         int nnzb,
-                                                         const cusparseMatDescr_t descrA,
-                                                         float *bsrSortedVal,
-                                                         const int *bsrSortedRowPtr,
-                                                         const int *bsrSortedColInd,
-                                                         int blockSize,
-                                                         bsric02Info_t info,
-                                                         size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, int, bsric02Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsric02_bufferSizeExt(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, float *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
+    bsric02Info_t info, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      float *, const int *, const int *, int, bsric02Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsric02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSize);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockSize, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsric02_bufferSizeExt(cusparseHandle_t handle,
-                                                         cusparseDirection_t dirA,
-                                                         int mb,
-                                                         int nnzb,
-                                                         const cusparseMatDescr_t descrA,
-                                                         double *bsrSortedVal,
-                                                         const int *bsrSortedRowPtr,
-                                                         const int *bsrSortedColInd,
-                                                         int blockSize,
-                                                         bsric02Info_t info,
-                                                         size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, int, bsric02Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsric02_bufferSizeExt(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, double *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
+    bsric02Info_t info, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      double *, const int *, const int *, int, bsric02Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsric02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSize);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockSize, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsric02_bufferSizeExt(cusparseHandle_t handle,
-                                                         cusparseDirection_t dirA,
-                                                         int mb,
-                                                         int nnzb,
-                                                         const cusparseMatDescr_t descrA,
-                                                         cuComplex *bsrSortedVal,
-                                                         const int *bsrSortedRowPtr,
-                                                         const int *bsrSortedColInd,
-                                                         int blockSize,
-                                                         bsric02Info_t info,
-                                                         size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, int, bsric02Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsric02_bufferSizeExt(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, cuComplex *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
+    bsric02Info_t info, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      cuComplex *, const int *, const int *, int, bsric02Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsric02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSize);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockSize, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsric02_bufferSizeExt(cusparseHandle_t handle,
-                                                         cusparseDirection_t dirA,
-                                                         int mb,
-                                                         int nnzb,
-                                                         const cusparseMatDescr_t descrA,
-                                                         cuDoubleComplex *bsrSortedVal,
-                                                         const int *bsrSortedRowPtr,
-                                                         const int *bsrSortedColInd,
-                                                         int blockSize,
-                                                         bsric02Info_t info,
-                                                         size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, int, bsric02Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsric02_bufferSizeExt(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, cuDoubleComplex *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockSize,
+    bsric02Info_t info, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      cuDoubleComplex *, const int *, const int *, int, bsric02Info_t,
+      size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsric02_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockSize, info, pBufferSize);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockSize, info, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsric02_analysis(cusparseHandle_t handle,
-                                                       cusparseDirection_t dirA,
-                                                       int mb,
-                                                       int nnzb,
-                                                       const cusparseMatDescr_t descrA,
-                                                       const float *bsrSortedVal,
-                                                       const int *bsrSortedRowPtr,
-                                                       const int *bsrSortedColInd,
-                                                       int blockDim,
-                                                       bsric02Info_t info,
-                                                       cusparseSolvePolicy_t policy,
-                                                       void *pInputBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, int, bsric02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsric02_analysis(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, const float *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+    bsric02Info_t info, cusparseSolvePolicy_t policy, void *pInputBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const float *, const int *, const int *, int, bsric02Info_t,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsric02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pInputBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockDim, info, policy, pInputBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsric02_analysis(cusparseHandle_t handle,
-                                                       cusparseDirection_t dirA,
-                                                       int mb,
-                                                       int nnzb,
-                                                       const cusparseMatDescr_t descrA,
-                                                       const double *bsrSortedVal,
-                                                       const int *bsrSortedRowPtr,
-                                                       const int *bsrSortedColInd,
-                                                       int blockDim,
-                                                       bsric02Info_t info,
-                                                       cusparseSolvePolicy_t policy,
-                                                       void *pInputBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, int, bsric02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsric02_analysis(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, const double *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+    bsric02Info_t info, cusparseSolvePolicy_t policy, void *pInputBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const double *, const int *, const int *, int, bsric02Info_t,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsric02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pInputBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockDim, info, policy, pInputBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsric02_analysis(cusparseHandle_t handle,
-                                                       cusparseDirection_t dirA,
-                                                       int mb,
-                                                       int nnzb,
-                                                       const cusparseMatDescr_t descrA,
-                                                       const cuComplex *bsrSortedVal,
-                                                       const int *bsrSortedRowPtr,
-                                                       const int *bsrSortedColInd,
-                                                       int blockDim,
-                                                       bsric02Info_t info,
-                                                       cusparseSolvePolicy_t policy,
-                                                       void *pInputBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, int, bsric02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsric02_analysis(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, const cuComplex *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+    bsric02Info_t info, cusparseSolvePolicy_t policy, void *pInputBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const cuComplex *, const int *, const int *, int, bsric02Info_t,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsric02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pInputBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockDim, info, policy, pInputBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsric02_analysis(cusparseHandle_t handle,
-                                                       cusparseDirection_t dirA,
-                                                       int mb,
-                                                       int nnzb,
-                                                       const cusparseMatDescr_t descrA,
-                                                       const cuDoubleComplex *bsrSortedVal,
-                                                       const int *bsrSortedRowPtr,
-                                                       const int *bsrSortedColInd,
-                                                       int blockDim,
-                                                       bsric02Info_t info,
-                                                       cusparseSolvePolicy_t policy,
-                                                       void *pInputBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, int, bsric02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsric02_analysis(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, const cuDoubleComplex *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+    bsric02Info_t info, cusparseSolvePolicy_t policy, void *pInputBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const cuDoubleComplex *, const int *, const int *, int, bsric02Info_t,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsric02_analysis");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pInputBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockDim, info, policy, pInputBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsric02(cusparseHandle_t handle,
-                                              cusparseDirection_t dirA,
-                                              int mb,
-                                              int nnzb,
-                                              const cusparseMatDescr_t descrA,
-                                              float *bsrSortedVal,
-                                              const int *bsrSortedRowPtr,
-                                              const int *bsrSortedColInd,
-                                              int blockDim,
-                                              bsric02Info_t info,
-                                              cusparseSolvePolicy_t policy,
-                                              void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, float *, const int *, const int *, int, bsric02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsric02(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, float *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+    bsric02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      float *, const int *, const int *, int, bsric02Info_t,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsric02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockDim, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsric02(cusparseHandle_t handle,
-                                              cusparseDirection_t dirA,
-                                              int mb,
-                                              int nnzb,
-                                              const cusparseMatDescr_t descrA,
-                                              double *bsrSortedVal,
-                                              const int *bsrSortedRowPtr,
-                                              const int *bsrSortedColInd,
-                                              int blockDim,
-                                              bsric02Info_t info,
-                                              cusparseSolvePolicy_t policy,
-                                              void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, double *, const int *, const int *, int, bsric02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsric02(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, double *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+    bsric02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      double *, const int *, const int *, int, bsric02Info_t,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsric02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockDim, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsric02(cusparseHandle_t handle,
-                                              cusparseDirection_t dirA,
-                                              int mb,
-                                              int nnzb,
-                                              const cusparseMatDescr_t descrA,
-                                              cuComplex *bsrSortedVal,
-                                              const int *bsrSortedRowPtr,
-                                              const int *bsrSortedColInd,
-                                              int blockDim,
-                                              bsric02Info_t info,
-                                              cusparseSolvePolicy_t policy,
-                                              void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, cuComplex *, const int *, const int *, int, bsric02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsric02(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, cuComplex *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+    bsric02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      cuComplex *, const int *, const int *, int, bsric02Info_t,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsric02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockDim, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsric02(cusparseHandle_t handle,
-                                              cusparseDirection_t dirA,
-                                              int mb,
-                                              int nnzb,
-                                              const cusparseMatDescr_t descrA,
-                                              cuDoubleComplex *bsrSortedVal,
-                                              const int *bsrSortedRowPtr,
-                                              const int *bsrSortedColInd,
-                                              int blockDim,
-                                              bsric02Info_t info,
-                                              cusparseSolvePolicy_t policy,
-                                              void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, const int *, int, bsric02Info_t, cusparseSolvePolicy_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsric02(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nnzb,
+    const cusparseMatDescr_t descrA, cuDoubleComplex *bsrSortedVal,
+    const int *bsrSortedRowPtr, const int *bsrSortedColInd, int blockDim,
+    bsric02Info_t info, cusparseSolvePolicy_t policy, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      cuDoubleComplex *, const int *, const int *, int, bsric02Info_t,
+      cusparseSolvePolicy_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsric02");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, blockDim, info, policy, pBuffer);
+  return func_ptr(handle, dirA, mb, nnzb, descrA, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, blockDim, info, policy, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSgtsv(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const float *dl,
-    const float  *d,
-    const float *du,
-    float *B,
-    int ldb) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, const float  *, const float *, float *, int);
+cusparseStatus_t CUSPARSEAPI cusparseSgtsv(cusparseHandle_t handle, int m,
+                                           int n, const float *dl,
+                                           const float *d, const float *du,
+                                           float *B, int ldb) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, int, int,
+                                                  const float *, const float *,
+                                                  const float *, float *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgtsv");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDgtsv(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const double *dl,
-    const double  *d,
-    const double *du,
-    double *B,
-    int ldb) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, const double  *, const double *, double *, int);
+cusparseStatus_t CUSPARSEAPI cusparseDgtsv(cusparseHandle_t handle, int m,
+                                           int n, const double *dl,
+                                           const double *d, const double *du,
+                                           double *B, int ldb) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const double *, const double *,
+      const double *, double *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgtsv");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCgtsv(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const cuComplex *dl,
-    const cuComplex  *d,
-    const cuComplex *du,
-    cuComplex *B,
-    int ldb) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuComplex *, const cuComplex  *, const cuComplex *, cuComplex *, int);
+cusparseStatus_t CUSPARSEAPI cusparseCgtsv(cusparseHandle_t handle, int m,
+                                           int n, const cuComplex *dl,
+                                           const cuComplex *d,
+                                           const cuComplex *du, cuComplex *B,
+                                           int ldb) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cuComplex *, const cuComplex *,
+      const cuComplex *, cuComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgtsv");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZgtsv(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const cuDoubleComplex *dl,
-    const cuDoubleComplex  *d,
-    const cuDoubleComplex *du,
-    cuDoubleComplex *B,
-    int ldb) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuDoubleComplex *, const cuDoubleComplex  *, const cuDoubleComplex *, cuDoubleComplex *, int);
+cusparseStatus_t CUSPARSEAPI cusparseZgtsv(cusparseHandle_t handle, int m,
+                                           int n, const cuDoubleComplex *dl,
+                                           const cuDoubleComplex *d,
+                                           const cuDoubleComplex *du,
+                                           cuDoubleComplex *B, int ldb) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cuDoubleComplex *,
+      const cuDoubleComplex *, const cuDoubleComplex *, cuDoubleComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgtsv");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSgtsv2_bufferSizeExt(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const float *dl,
-    const float  *d,
-    const float *du,
-    const float *B,
-    int ldb,
-    size_t *bufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, const float  *, const float *, const float *, int, size_t *);
+    cusparseHandle_t handle, int m, int n, const float *dl, const float *d,
+    const float *du, const float *B, int ldb, size_t *bufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const float *, const float *, const float *,
+      const float *, int, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgtsv2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, bufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDgtsv2_bufferSizeExt(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const double *dl,
-    const double  *d,
-    const double *du,
-    const double *B,
-    int ldb,
-    size_t *bufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, const double  *, const double *, const double *, int, size_t *);
+    cusparseHandle_t handle, int m, int n, const double *dl, const double *d,
+    const double *du, const double *B, int ldb, size_t *bufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const double *, const double *,
+      const double *, const double *, int, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgtsv2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, bufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCgtsv2_bufferSizeExt(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const cuComplex *dl,
-    const cuComplex  *d,
-    const cuComplex *du,
-    const cuComplex *B,
-    int ldb,
+    cusparseHandle_t handle, int m, int n, const cuComplex *dl,
+    const cuComplex *d, const cuComplex *du, const cuComplex *B, int ldb,
     size_t *bufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuComplex *, const cuComplex  *, const cuComplex *, const cuComplex *, int, size_t *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cuComplex *, const cuComplex *,
+      const cuComplex *, const cuComplex *, int, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgtsv2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, bufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseZgtsv2_bufferSizeExt(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const cuDoubleComplex *dl,
-    const cuDoubleComplex  *d,
-    const cuDoubleComplex *du,
-    const cuDoubleComplex *B,
-    int ldb,
-    size_t *bufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuDoubleComplex *, const cuDoubleComplex  *, const cuDoubleComplex *, const cuDoubleComplex *, int, size_t *);
+    cusparseHandle_t handle, int m, int n, const cuDoubleComplex *dl,
+    const cuDoubleComplex *d, const cuDoubleComplex *du,
+    const cuDoubleComplex *B, int ldb, size_t *bufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cuDoubleComplex *,
+      const cuDoubleComplex *, const cuDoubleComplex *, const cuDoubleComplex *,
+      int, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgtsv2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, bufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSgtsv2(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const float *dl,
-    const float  *d,
-    const float *du,
-    float *B,
-    int ldb,
-    void* pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, const float  *, const float *, float *, int, void *);
+cusparseStatus_t CUSPARSEAPI cusparseSgtsv2(cusparseHandle_t handle, int m,
+                                            int n, const float *dl,
+                                            const float *d, const float *du,
+                                            float *B, int ldb, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const float *, const float *, const float *,
+      float *, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgtsv2");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDgtsv2(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const double *dl,
-    const double  *d,
-    const double *du,
-    double *B,
-    int ldb,
-    void* pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, const double  *, const double *, double *, int, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDgtsv2(cusparseHandle_t handle, int m,
+                                            int n, const double *dl,
+                                            const double *d, const double *du,
+                                            double *B, int ldb, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const double *, const double *,
+      const double *, double *, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgtsv2");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCgtsv2(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const cuComplex *dl,
-    const cuComplex  *d,
-    const cuComplex *du,
-    cuComplex *B,
-    int ldb,
-    void* pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuComplex *, const cuComplex  *, const cuComplex *, cuComplex *, int, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCgtsv2(cusparseHandle_t handle, int m,
+                                            int n, const cuComplex *dl,
+                                            const cuComplex *d,
+                                            const cuComplex *du, cuComplex *B,
+                                            int ldb, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cuComplex *, const cuComplex *,
+      const cuComplex *, cuComplex *, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgtsv2");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZgtsv2(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const cuDoubleComplex *dl,
-    const cuDoubleComplex  *d,
-    const cuDoubleComplex *du,
-    cuDoubleComplex *B,
-    int ldb,
-    void* pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuDoubleComplex *, const cuDoubleComplex  *, const cuDoubleComplex *, cuDoubleComplex *, int, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZgtsv2(cusparseHandle_t handle, int m,
+                                            int n, const cuDoubleComplex *dl,
+                                            const cuDoubleComplex *d,
+                                            const cuDoubleComplex *du,
+                                            cuDoubleComplex *B, int ldb,
+                                            void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cuDoubleComplex *,
+      const cuDoubleComplex *, const cuDoubleComplex *, cuDoubleComplex *, int,
+      void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgtsv2");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSgtsv_nopivot(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const float *dl,
-    const float  *d,
-    const float *du,
-    float *B,
-    int ldb) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, const float  *, const float *, float *, int);
+cusparseStatus_t CUSPARSEAPI
+cusparseSgtsv_nopivot(cusparseHandle_t handle, int m, int n, const float *dl,
+                      const float *d, const float *du, float *B, int ldb) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, int, int,
+                                                  const float *, const float *,
+                                                  const float *, float *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgtsv_nopivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDgtsv_nopivot(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const double *dl,
-    const double  *d,
-    const double *du,
-    double *B,
-    int ldb) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, const double  *, const double *, double *, int);
+cusparseStatus_t CUSPARSEAPI
+cusparseDgtsv_nopivot(cusparseHandle_t handle, int m, int n, const double *dl,
+                      const double *d, const double *du, double *B, int ldb) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const double *, const double *,
+      const double *, double *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgtsv_nopivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCgtsv_nopivot(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const cuComplex *dl,
-    const cuComplex  *d,
-    const cuComplex *du,
-    cuComplex *B,
-    int ldb) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuComplex *, const cuComplex  *, const cuComplex *, cuComplex *, int);
+    cusparseHandle_t handle, int m, int n, const cuComplex *dl,
+    const cuComplex *d, const cuComplex *du, cuComplex *B, int ldb) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cuComplex *, const cuComplex *,
+      const cuComplex *, cuComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgtsv_nopivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZgtsv_nopivot(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const cuDoubleComplex *dl,
-    const cuDoubleComplex  *d,
-    const cuDoubleComplex *du,
-    cuDoubleComplex *B,
-    int ldb) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuDoubleComplex *, const cuDoubleComplex  *, const cuDoubleComplex *, cuDoubleComplex *, int);
+cusparseStatus_t CUSPARSEAPI
+cusparseZgtsv_nopivot(cusparseHandle_t handle, int m, int n,
+                      const cuDoubleComplex *dl, const cuDoubleComplex *d,
+                      const cuDoubleComplex *du, cuDoubleComplex *B, int ldb) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cuDoubleComplex *,
+      const cuDoubleComplex *, const cuDoubleComplex *, cuDoubleComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgtsv_nopivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSgtsv2_nopivot_bufferSizeExt(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const float *dl,
-    const float  *d,
-    const float *du,
-    const float *B,
-    int ldb,
-    size_t *bufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, const float  *, const float *, const float *, int, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgtsv2_nopivot_bufferSizeExt");
+    cusparseHandle_t handle, int m, int n, const float *dl, const float *d,
+    const float *du, const float *B, int ldb, size_t *bufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const float *, const float *, const float *,
+      const float *, int, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseSgtsv2_nopivot_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, bufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDgtsv2_nopivot_bufferSizeExt(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const double *dl,
-    const double  *d,
-    const double *du,
-    const double *B,
-    int ldb,
-    size_t *bufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, const double  *, const double *, const double *, int, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgtsv2_nopivot_bufferSizeExt");
+    cusparseHandle_t handle, int m, int n, const double *dl, const double *d,
+    const double *du, const double *B, int ldb, size_t *bufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const double *, const double *,
+      const double *, const double *, int, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseDgtsv2_nopivot_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, bufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCgtsv2_nopivot_bufferSizeExt(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const cuComplex *dl,
-    const cuComplex  *d,
-    const cuComplex *du,
-    const cuComplex *B,
-    int ldb,
+    cusparseHandle_t handle, int m, int n, const cuComplex *dl,
+    const cuComplex *d, const cuComplex *du, const cuComplex *B, int ldb,
     size_t *bufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuComplex *, const cuComplex  *, const cuComplex *, const cuComplex *, int, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgtsv2_nopivot_bufferSizeExt");
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cuComplex *, const cuComplex *,
+      const cuComplex *, const cuComplex *, int, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseCgtsv2_nopivot_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, bufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseZgtsv2_nopivot_bufferSizeExt(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const cuDoubleComplex *dl,
-    const cuDoubleComplex  *d,
-    const cuDoubleComplex *du,
-    const cuDoubleComplex *B,
-    int ldb,
-    size_t *bufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuDoubleComplex *, const cuDoubleComplex  *, const cuDoubleComplex *, const cuDoubleComplex *, int, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgtsv2_nopivot_bufferSizeExt");
+    cusparseHandle_t handle, int m, int n, const cuDoubleComplex *dl,
+    const cuDoubleComplex *d, const cuDoubleComplex *du,
+    const cuDoubleComplex *B, int ldb, size_t *bufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cuDoubleComplex *,
+      const cuDoubleComplex *, const cuDoubleComplex *, const cuDoubleComplex *,
+      int, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseZgtsv2_nopivot_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, bufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSgtsv2_nopivot(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const float *dl,
-    const float  *d,
-    const float *du,
-    float *B,
-    int ldb,
-    void* pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, const float  *, const float *, float *, int, void *);
+    cusparseHandle_t handle, int m, int n, const float *dl, const float *d,
+    const float *du, float *B, int ldb, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const float *, const float *, const float *,
+      float *, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgtsv2_nopivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDgtsv2_nopivot(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const double *dl,
-    const double  *d,
-    const double *du,
-    double *B,
-    int ldb,
-    void* pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, const double  *, const double *, double *, int, void *);
+    cusparseHandle_t handle, int m, int n, const double *dl, const double *d,
+    const double *du, double *B, int ldb, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const double *, const double *,
+      const double *, double *, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgtsv2_nopivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCgtsv2_nopivot(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const cuComplex *dl,
-    const cuComplex  *d,
-    const cuComplex *du,
-    cuComplex *B,
-    int ldb,
-    void* pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuComplex *, const cuComplex  *, const cuComplex *, cuComplex *, int, void *);
+    cusparseHandle_t handle, int m, int n, const cuComplex *dl,
+    const cuComplex *d, const cuComplex *du, cuComplex *B, int ldb,
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cuComplex *, const cuComplex *,
+      const cuComplex *, cuComplex *, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgtsv2_nopivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseZgtsv2_nopivot(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const cuDoubleComplex *dl,
-    const cuDoubleComplex  *d,
-    const cuDoubleComplex *du,
-    cuDoubleComplex *B,
-    int ldb,
-    void* pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuDoubleComplex *, const cuDoubleComplex  *, const cuDoubleComplex *, cuDoubleComplex *, int, void *);
+    cusparseHandle_t handle, int m, int n, const cuDoubleComplex *dl,
+    const cuDoubleComplex *d, const cuDoubleComplex *du, cuDoubleComplex *B,
+    int ldb, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cuDoubleComplex *,
+      const cuDoubleComplex *, const cuDoubleComplex *, cuDoubleComplex *, int,
+      void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgtsv2_nopivot");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, dl, d, du, B, ldb, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSgtsvStridedBatch(
-    cusparseHandle_t handle,
-    int m,
-    const float *dl,
-    const float  *d,
-    const float *du,
-    float *x,
-    int batchCount,
-    int batchStride) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const float *, const float  *, const float *, float *, int, int);
+    cusparseHandle_t handle, int m, const float *dl, const float *d,
+    const float *du, float *x, int batchCount, int batchStride) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const float *, const float *, const float *,
+      float *, int, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgtsvStridedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDgtsvStridedBatch(
-    cusparseHandle_t handle,
-    int m,
-    const double *dl,
-    const double  *d,
-    const double *du,
-    double *x,
-    int batchCount,
-    int batchStride) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const double *, const double  *, const double *, double *, int, int);
+    cusparseHandle_t handle, int m, const double *dl, const double *d,
+    const double *du, double *x, int batchCount, int batchStride) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const double *, const double *, const double *,
+      double *, int, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgtsvStridedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCgtsvStridedBatch(
-    cusparseHandle_t handle,
-    int m,
-    const cuComplex *dl,
-    const cuComplex  *d,
-    const cuComplex *du,
-    cuComplex *x,
-    int batchCount,
-    int batchStride) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuComplex *, const cuComplex  *, const cuComplex *, cuComplex *, int, int);
+    cusparseHandle_t handle, int m, const cuComplex *dl, const cuComplex *d,
+    const cuComplex *du, cuComplex *x, int batchCount, int batchStride) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const cuComplex *, const cuComplex *,
+      const cuComplex *, cuComplex *, int, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgtsvStridedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseZgtsvStridedBatch(
-    cusparseHandle_t handle,
-    int m,
-    const cuDoubleComplex *dl,
-    const cuDoubleComplex  *d,
-    const cuDoubleComplex *du,
-    cuDoubleComplex *x,
-    int batchCount,
-    int batchStride) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuDoubleComplex *, const cuDoubleComplex  *, const cuDoubleComplex *, cuDoubleComplex *, int, int);
+    cusparseHandle_t handle, int m, const cuDoubleComplex *dl,
+    const cuDoubleComplex *d, const cuDoubleComplex *du, cuDoubleComplex *x,
+    int batchCount, int batchStride) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const cuDoubleComplex *, const cuDoubleComplex *,
+      const cuDoubleComplex *, cuDoubleComplex *, int, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgtsvStridedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSgtsv2StridedBatch_bufferSizeExt(
-    cusparseHandle_t handle,
-    int m,
-    const float *dl,
-    const float  *d,
-    const float *du,
-    const float *x,
-    int batchCount,
-    int batchStride,
+    cusparseHandle_t handle, int m, const float *dl, const float *d,
+    const float *du, const float *x, int batchCount, int batchStride,
     size_t *bufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const float *, const float  *, const float *, const float *, int, int, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgtsv2StridedBatch_bufferSizeExt");
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const float *, const float *, const float *,
+      const float *, int, int, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseSgtsv2StridedBatch_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride, bufferSizeInBytes);
+  return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride,
+                  bufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDgtsv2StridedBatch_bufferSizeExt(
-    cusparseHandle_t handle,
-    int m,
-    const double *dl,
-    const double  *d,
-    const double *du,
-    const double *x,
-    int batchCount,
-    int batchStride,
+    cusparseHandle_t handle, int m, const double *dl, const double *d,
+    const double *du, const double *x, int batchCount, int batchStride,
     size_t *bufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const double *, const double  *, const double *, const double *, int, int, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgtsv2StridedBatch_bufferSizeExt");
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const double *, const double *, const double *,
+      const double *, int, int, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseDgtsv2StridedBatch_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride, bufferSizeInBytes);
+  return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride,
+                  bufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCgtsv2StridedBatch_bufferSizeExt(
-    cusparseHandle_t handle,
-    int m,
-    const cuComplex *dl,
-    const cuComplex  *d,
-    const cuComplex *du,
-    const cuComplex *x,
-    int batchCount,
-    int batchStride,
+    cusparseHandle_t handle, int m, const cuComplex *dl, const cuComplex *d,
+    const cuComplex *du, const cuComplex *x, int batchCount, int batchStride,
     size_t *bufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuComplex *, const cuComplex  *, const cuComplex *, const cuComplex *, int, int, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgtsv2StridedBatch_bufferSizeExt");
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const cuComplex *, const cuComplex *,
+      const cuComplex *, const cuComplex *, int, int, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseCgtsv2StridedBatch_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride, bufferSizeInBytes);
+  return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride,
+                  bufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseZgtsv2StridedBatch_bufferSizeExt(
-    cusparseHandle_t handle,
-    int m,
-    const cuDoubleComplex *dl,
-    const cuDoubleComplex  *d,
-    const cuDoubleComplex *du,
-    const cuDoubleComplex *x,
-    int batchCount,
-    int batchStride,
+    cusparseHandle_t handle, int m, const cuDoubleComplex *dl,
+    const cuDoubleComplex *d, const cuDoubleComplex *du,
+    const cuDoubleComplex *x, int batchCount, int batchStride,
     size_t *bufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuDoubleComplex *, const cuDoubleComplex  *, const cuDoubleComplex *, const cuDoubleComplex *, int, int, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgtsv2StridedBatch_bufferSizeExt");
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const cuDoubleComplex *, const cuDoubleComplex *,
+      const cuDoubleComplex *, const cuDoubleComplex *, int, int, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseZgtsv2StridedBatch_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride, bufferSizeInBytes);
+  return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride,
+                  bufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSgtsv2StridedBatch(
-    cusparseHandle_t handle,
-    int m,
-    const float *dl,
-    const float  *d,
-    const float *du,
-    float *x,
-    int batchCount,
-    int batchStride,
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const float *, const float  *, const float *, float *, int, int, void *);
+    cusparseHandle_t handle, int m, const float *dl, const float *d,
+    const float *du, float *x, int batchCount, int batchStride, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const float *, const float *, const float *,
+      float *, int, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgtsv2StridedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDgtsv2StridedBatch(
-    cusparseHandle_t handle,
-    int m,
-    const double *dl,
-    const double  *d,
-    const double *du,
-    double *x,
-    int batchCount,
-    int batchStride,
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const double *, const double  *, const double *, double *, int, int, void *);
+cusparseStatus_t CUSPARSEAPI
+cusparseDgtsv2StridedBatch(cusparseHandle_t handle, int m, const double *dl,
+                           const double *d, const double *du, double *x,
+                           int batchCount, int batchStride, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const double *, const double *, const double *,
+      double *, int, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgtsv2StridedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCgtsv2StridedBatch(
-    cusparseHandle_t handle,
-    int m,
-    const cuComplex *dl,
-    const cuComplex  *d,
-    const cuComplex *du,
-    cuComplex *x,
-    int batchCount,
-    int batchStride,
+    cusparseHandle_t handle, int m, const cuComplex *dl, const cuComplex *d,
+    const cuComplex *du, cuComplex *x, int batchCount, int batchStride,
     void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuComplex *, const cuComplex  *, const cuComplex *, cuComplex *, int, int, void *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const cuComplex *, const cuComplex *,
+      const cuComplex *, cuComplex *, int, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgtsv2StridedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseZgtsv2StridedBatch(
-    cusparseHandle_t handle,
-    int m,
-    const cuDoubleComplex *dl,
-    const cuDoubleComplex  *d,
-    const cuDoubleComplex *du,
-    cuDoubleComplex *x,
-    int batchCount,
-    int batchStride,
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cuDoubleComplex *, const cuDoubleComplex  *, const cuDoubleComplex *, cuDoubleComplex *, int, int, void *);
+    cusparseHandle_t handle, int m, const cuDoubleComplex *dl,
+    const cuDoubleComplex *d, const cuDoubleComplex *du, cuDoubleComplex *x,
+    int batchCount, int batchStride, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const cuDoubleComplex *, const cuDoubleComplex *,
+      const cuDoubleComplex *, cuDoubleComplex *, int, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgtsv2StridedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, dl, d, du, x, batchCount, batchStride, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSgtsvInterleavedBatch_bufferSizeExt(
-    cusparseHandle_t handle,
-    int algo,
-    int m,
-    const float *dl,
-    const float  *d,
-    const float *du,
-    const float *x,
-    int batchCount,
+    cusparseHandle_t handle, int algo, int m, const float *dl, const float *d,
+    const float *du, const float *x, int batchCount,
     size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, const float  *, const float *, const float *, int, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgtsvInterleavedBatch_bufferSizeExt");
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const float *, const float *, const float *,
+      const float *, int, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseSgtsvInterleavedBatch_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, m, dl, d, du, x, batchCount, pBufferSizeInBytes);
+  return func_ptr(handle, algo, m, dl, d, du, x, batchCount,
+                  pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDgtsvInterleavedBatch_bufferSizeExt(
-    cusparseHandle_t handle,
-    int algo,
-    int m,
-    const double *dl,
-    const double  *d,
-    const double *du,
-    const double *x,
-    int batchCount,
+    cusparseHandle_t handle, int algo, int m, const double *dl, const double *d,
+    const double *du, const double *x, int batchCount,
     size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, const double  *, const double *, const double *, int, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgtsvInterleavedBatch_bufferSizeExt");
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const double *, const double *,
+      const double *, const double *, int, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseDgtsvInterleavedBatch_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, m, dl, d, du, x, batchCount, pBufferSizeInBytes);
+  return func_ptr(handle, algo, m, dl, d, du, x, batchCount,
+                  pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCgtsvInterleavedBatch_bufferSizeExt(
-    cusparseHandle_t handle,
-    int algo,
-    int m,
-    const cuComplex *dl,
-    const cuComplex  *d,
-    const cuComplex *du,
-    const cuComplex *x,
-    int batchCount,
+    cusparseHandle_t handle, int algo, int m, const cuComplex *dl,
+    const cuComplex *d, const cuComplex *du, const cuComplex *x, int batchCount,
     size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuComplex *, const cuComplex  *, const cuComplex *, const cuComplex *, int, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgtsvInterleavedBatch_bufferSizeExt");
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cuComplex *, const cuComplex *,
+      const cuComplex *, const cuComplex *, int, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseCgtsvInterleavedBatch_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, m, dl, d, du, x, batchCount, pBufferSizeInBytes);
+  return func_ptr(handle, algo, m, dl, d, du, x, batchCount,
+                  pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseZgtsvInterleavedBatch_bufferSizeExt(
-    cusparseHandle_t handle,
-    int algo,
-    int m,
-    const cuDoubleComplex *dl,
-    const cuDoubleComplex  *d,
-    const cuDoubleComplex *du,
-    const cuDoubleComplex *x,
-    int batchCount,
-    size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuDoubleComplex *, const cuDoubleComplex  *, const cuDoubleComplex *, const cuDoubleComplex *, int, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgtsvInterleavedBatch_bufferSizeExt");
+    cusparseHandle_t handle, int algo, int m, const cuDoubleComplex *dl,
+    const cuDoubleComplex *d, const cuDoubleComplex *du,
+    const cuDoubleComplex *x, int batchCount, size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cuDoubleComplex *,
+      const cuDoubleComplex *, const cuDoubleComplex *, const cuDoubleComplex *,
+      int, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseZgtsvInterleavedBatch_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, m, dl, d, du, x, batchCount, pBufferSizeInBytes);
+  return func_ptr(handle, algo, m, dl, d, du, x, batchCount,
+                  pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSgtsvInterleavedBatch(
-    cusparseHandle_t handle,
-    int algo,
-    int m,
-    float *dl,
-    float  *d,
-    float *du,
-    float *x,
-    int batchCount,
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, float *, float  *, float *, float *, int, void *);
+    cusparseHandle_t handle, int algo, int m, float *dl, float *d, float *du,
+    float *x, int batchCount, void *pBuffer) {
+  using FuncPtr =
+      cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, int, int, float *,
+                                      float *, float *, float *, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgtsvInterleavedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, algo, m, dl, d, du, x, batchCount, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDgtsvInterleavedBatch(
-    cusparseHandle_t handle,
-    int algo,
-    int m,
-    double *dl,
-    double  *d,
-    double *du,
-    double *x,
-    int batchCount,
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, double *, double  *, double *, double *, int, void *);
+    cusparseHandle_t handle, int algo, int m, double *dl, double *d, double *du,
+    double *x, int batchCount, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, int, int,
+                                                  double *, double *, double *,
+                                                  double *, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgtsvInterleavedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, algo, m, dl, d, du, x, batchCount, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCgtsvInterleavedBatch(
-    cusparseHandle_t handle,
-    int algo,
-    int m,
-    cuComplex *dl,
-    cuComplex  *d,
-    cuComplex *du,
-    cuComplex *x,
-    int batchCount,
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, cuComplex *, cuComplex  *, cuComplex *, cuComplex *, int, void *);
+    cusparseHandle_t handle, int algo, int m, cuComplex *dl, cuComplex *d,
+    cuComplex *du, cuComplex *x, int batchCount, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, cuComplex *, cuComplex *, cuComplex *,
+      cuComplex *, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgtsvInterleavedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, algo, m, dl, d, du, x, batchCount, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseZgtsvInterleavedBatch(
-    cusparseHandle_t handle,
-    int algo,
-    int m,
-    cuDoubleComplex *dl,
-    cuDoubleComplex  *d,
-    cuDoubleComplex *du,
-    cuDoubleComplex *x,
-    int batchCount,
+    cusparseHandle_t handle, int algo, int m, cuDoubleComplex *dl,
+    cuDoubleComplex *d, cuDoubleComplex *du, cuDoubleComplex *x, int batchCount,
     void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, cuDoubleComplex *, cuDoubleComplex  *, cuDoubleComplex *, cuDoubleComplex *, int, void *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, cuDoubleComplex *, cuDoubleComplex *,
+      cuDoubleComplex *, cuDoubleComplex *, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgtsvInterleavedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, algo, m, dl, d, du, x, batchCount, pBuffer);
 }
 
-cusparseStatus_t  CUSPARSEAPI cusparseSgpsvInterleavedBatch_bufferSizeExt(
-    cusparseHandle_t handle,
-    int algo,
-    int m,
-    const float *ds,
-    const float *dl,
-    const float  *d,
-    const float *du,
-    const float *dw,
-    const float *x,
-    int batchCount,
-    size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, const float *, const float  *, const float *, const float *, const float *, int, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgpsvInterleavedBatch_bufferSizeExt");
+cusparseStatus_t CUSPARSEAPI cusparseSgpsvInterleavedBatch_bufferSizeExt(
+    cusparseHandle_t handle, int algo, int m, const float *ds, const float *dl,
+    const float *d, const float *du, const float *dw, const float *x,
+    int batchCount, size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const float *, const float *, const float *,
+      const float *, const float *, const float *, int, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseSgpsvInterleavedBatch_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, m, ds, dl, d, du, dw, x, batchCount, pBufferSizeInBytes);
+  return func_ptr(handle, algo, m, ds, dl, d, du, dw, x, batchCount,
+                  pBufferSizeInBytes);
 }
 
-cusparseStatus_t  CUSPARSEAPI cusparseDgpsvInterleavedBatch_bufferSizeExt(
-    cusparseHandle_t handle,
-    int algo,
-    int m,
-    const double *ds,
-    const double *dl,
-    const double  *d,
-    const double *du,
-    const double *dw,
-    const double *x,
-    int batchCount,
-    size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, const double *, const double  *, const double *, const double *, const double *, int, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgpsvInterleavedBatch_bufferSizeExt");
+cusparseStatus_t CUSPARSEAPI cusparseDgpsvInterleavedBatch_bufferSizeExt(
+    cusparseHandle_t handle, int algo, int m, const double *ds,
+    const double *dl, const double *d, const double *du, const double *dw,
+    const double *x, int batchCount, size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const double *, const double *,
+      const double *, const double *, const double *, const double *, int,
+      size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseDgpsvInterleavedBatch_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, m, ds, dl, d, du, dw, x, batchCount, pBufferSizeInBytes);
+  return func_ptr(handle, algo, m, ds, dl, d, du, dw, x, batchCount,
+                  pBufferSizeInBytes);
 }
 
-cusparseStatus_t  CUSPARSEAPI cusparseCgpsvInterleavedBatch_bufferSizeExt(
-    cusparseHandle_t handle,
-    int algo,
-    int m,
-    const cuComplex *ds,
-    const cuComplex *dl,
-    const cuComplex  *d,
-    const cuComplex *du,
-    const cuComplex *dw,
-    const cuComplex *x,
-    int batchCount,
+cusparseStatus_t CUSPARSEAPI cusparseCgpsvInterleavedBatch_bufferSizeExt(
+    cusparseHandle_t handle, int algo, int m, const cuComplex *ds,
+    const cuComplex *dl, const cuComplex *d, const cuComplex *du,
+    const cuComplex *dw, const cuComplex *x, int batchCount,
     size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuComplex *, const cuComplex *, const cuComplex  *, const cuComplex *, const cuComplex *, const cuComplex *, int, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgpsvInterleavedBatch_bufferSizeExt");
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cuComplex *, const cuComplex *,
+      const cuComplex *, const cuComplex *, const cuComplex *,
+      const cuComplex *, int, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseCgpsvInterleavedBatch_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, m, ds, dl, d, du, dw, x, batchCount, pBufferSizeInBytes);
+  return func_ptr(handle, algo, m, ds, dl, d, du, dw, x, batchCount,
+                  pBufferSizeInBytes);
 }
 
-cusparseStatus_t  CUSPARSEAPI cusparseZgpsvInterleavedBatch_bufferSizeExt(
-    cusparseHandle_t handle,
-    int algo,
-    int m,
-    const cuDoubleComplex *ds,
-    const cuDoubleComplex *dl,
-    const cuDoubleComplex  *d,
-    const cuDoubleComplex *du,
-    const cuDoubleComplex *dw,
-    const cuDoubleComplex *x,
-    int batchCount,
-    size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuDoubleComplex *, const cuDoubleComplex *, const cuDoubleComplex  *, const cuDoubleComplex *, const cuDoubleComplex *, const cuDoubleComplex *, int, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgpsvInterleavedBatch_bufferSizeExt");
+cusparseStatus_t CUSPARSEAPI cusparseZgpsvInterleavedBatch_bufferSizeExt(
+    cusparseHandle_t handle, int algo, int m, const cuDoubleComplex *ds,
+    const cuDoubleComplex *dl, const cuDoubleComplex *d,
+    const cuDoubleComplex *du, const cuDoubleComplex *dw,
+    const cuDoubleComplex *x, int batchCount, size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cuDoubleComplex *,
+      const cuDoubleComplex *, const cuDoubleComplex *, const cuDoubleComplex *,
+      const cuDoubleComplex *, const cuDoubleComplex *, int, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseZgpsvInterleavedBatch_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, algo, m, ds, dl, d, du, dw, x, batchCount, pBufferSizeInBytes);
+  return func_ptr(handle, algo, m, ds, dl, d, du, dw, x, batchCount,
+                  pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSgpsvInterleavedBatch(
-    cusparseHandle_t handle,
-    int algo,
-    int m,
-    float *ds,
-    float *dl,
-    float  *d,
-    float *du,
-    float *dw,
-    float *x,
-    int batchCount,
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, float *, float *, float  *, float *, float *, float *, int, void *);
+    cusparseHandle_t handle, int algo, int m, float *ds, float *dl, float *d,
+    float *du, float *dw, float *x, int batchCount, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, float *, float *, float *, float *, float *,
+      float *, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgpsvInterleavedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, algo, m, ds, dl, d, du, dw, x, batchCount, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDgpsvInterleavedBatch(
-    cusparseHandle_t handle,
-    int algo,
-    int m,
-    double *ds,
-    double *dl,
-    double  *d,
-    double *du,
-    double *dw,
-    double *x,
-    int batchCount,
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, double *, double *, double  *, double *, double *, double *, int, void *);
+    cusparseHandle_t handle, int algo, int m, double *ds, double *dl, double *d,
+    double *du, double *dw, double *x, int batchCount, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, double *, double *, double *, double *,
+      double *, double *, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgpsvInterleavedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, algo, m, ds, dl, d, du, dw, x, batchCount, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCgpsvInterleavedBatch(
-    cusparseHandle_t handle,
-    int algo,
-    int m,
-    cuComplex *ds,
-    cuComplex *dl,
-    cuComplex  *d,
-    cuComplex *du,
-    cuComplex *dw,
-    cuComplex *x,
-    int batchCount,
+    cusparseHandle_t handle, int algo, int m, cuComplex *ds, cuComplex *dl,
+    cuComplex *d, cuComplex *du, cuComplex *dw, cuComplex *x, int batchCount,
     void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, cuComplex *, cuComplex *, cuComplex  *, cuComplex *, cuComplex *, cuComplex *, int, void *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, cuComplex *, cuComplex *, cuComplex *,
+      cuComplex *, cuComplex *, cuComplex *, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgpsvInterleavedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, algo, m, ds, dl, d, du, dw, x, batchCount, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseZgpsvInterleavedBatch(
-    cusparseHandle_t handle,
-    int algo,
-    int m,
-    cuDoubleComplex *ds,
-    cuDoubleComplex *dl,
-    cuDoubleComplex  *d,
-    cuDoubleComplex *du,
-    cuDoubleComplex *dw,
-    cuDoubleComplex *x,
-    int batchCount,
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, cuDoubleComplex *, cuDoubleComplex *, cuDoubleComplex  *, cuDoubleComplex *, cuDoubleComplex *, cuDoubleComplex *, int, void *);
+    cusparseHandle_t handle, int algo, int m, cuDoubleComplex *ds,
+    cuDoubleComplex *dl, cuDoubleComplex *d, cuDoubleComplex *du,
+    cuDoubleComplex *dw, cuDoubleComplex *x, int batchCount, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, cuDoubleComplex *, cuDoubleComplex *,
+      cuDoubleComplex *, cuDoubleComplex *, cuDoubleComplex *,
+      cuDoubleComplex *, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgpsvInterleavedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, algo, m, ds, dl, d, du, dw, x, batchCount, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseXcsrgemmNnz(cusparseHandle_t handle,
-                                                 cusparseOperation_t transA,
-                                                 cusparseOperation_t transB,
-                                                 int m,
-                                                 int n,
-                                                 int k,
-                                                 const cusparseMatDescr_t descrA,
-                                                 const int nnzA,
-                                                 const int *csrSortedRowPtrA,
-                                                 const int *csrSortedColIndA,
-                                                 const cusparseMatDescr_t descrB,
-                                                 const int nnzB,
-                                                 const int *csrSortedRowPtrB,
-                                                 const int *csrSortedColIndB,
-                                                 const cusparseMatDescr_t descrC,
-                                                 int *csrSortedRowPtrC,
-                                                 int *nnzTotalDevHostPtr) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, const int, const int *, const int *, const cusparseMatDescr_t, const int, const int *, const int *, const cusparseMatDescr_t, int *, int *);
+cusparseStatus_t CUSPARSEAPI
+cusparseXcsrgemmNnz(cusparseHandle_t handle, cusparseOperation_t transA,
+                    cusparseOperation_t transB, int m, int n, int k,
+                    const cusparseMatDescr_t descrA, const int nnzA,
+                    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+                    const cusparseMatDescr_t descrB, const int nnzB,
+                    const int *csrSortedRowPtrB, const int *csrSortedColIndB,
+                    const cusparseMatDescr_t descrC, int *csrSortedRowPtrC,
+                    int *nnzTotalDevHostPtr) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int,
+      const cusparseMatDescr_t, const int, const int *, const int *,
+      const cusparseMatDescr_t, const int, const int *, const int *,
+      const cusparseMatDescr_t, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcsrgemmNnz");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, transB, m, n, k, descrA, nnzA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedRowPtrC, nnzTotalDevHostPtr);
+  return func_ptr(handle, transA, transB, m, n, k, descrA, nnzA,
+                  csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB,
+                  csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedRowPtrC,
+                  nnzTotalDevHostPtr);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrgemm(cusparseHandle_t handle,
-                                              cusparseOperation_t transA,
-                                              cusparseOperation_t transB,
-                                              int m,
-                                              int n,
-                                              int k,
-                                              const cusparseMatDescr_t descrA,
-                                              const int nnzA,
-                                              const float *csrSortedValA,
-                                              const int *csrSortedRowPtrA,
-                                              const int *csrSortedColIndA,
-                                              const cusparseMatDescr_t descrB,
-                                              const int nnzB,
-                                              const float *csrSortedValB,
-                                              const int *csrSortedRowPtrB,
-                                              const int *csrSortedColIndB,
-                                              const cusparseMatDescr_t descrC,
-                                              float *csrSortedValC,
-                                              const int *csrSortedRowPtrC,
-                                              int *csrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, const int, const float *, const int *, const int *, const cusparseMatDescr_t, const int, const float *, const int *, const int *, const cusparseMatDescr_t, float *, const int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrgemm(
+    cusparseHandle_t handle, cusparseOperation_t transA,
+    cusparseOperation_t transB, int m, int n, int k,
+    const cusparseMatDescr_t descrA, const int nnzA, const float *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    const cusparseMatDescr_t descrB, const int nnzB, const float *csrSortedValB,
+    const int *csrSortedRowPtrB, const int *csrSortedColIndB,
+    const cusparseMatDescr_t descrC, float *csrSortedValC,
+    const int *csrSortedRowPtrC, int *csrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int,
+      const cusparseMatDescr_t, const int, const float *, const int *,
+      const int *, const cusparseMatDescr_t, const int, const float *,
+      const int *, const int *, const cusparseMatDescr_t, float *, const int *,
+      int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrgemm");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, transB, m, n, k, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, transA, transB, m, n, k, descrA, nnzA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB,
+                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
+                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrgemm(cusparseHandle_t handle,
-                                              cusparseOperation_t transA,
-                                              cusparseOperation_t transB,
-                                              int m,
-                                              int n,
-                                              int k,
-                                              const cusparseMatDescr_t descrA,
-                                              int nnzA,
-                                              const double *csrSortedValA,
-                                              const int *csrSortedRowPtrA,
-                                              const int *csrSortedColIndA,
-                                              const cusparseMatDescr_t descrB,
-                                              int nnzB,
-                                              const double *csrSortedValB,
-                                              const int *csrSortedRowPtrB,
-                                              const int *csrSortedColIndB,
-                                              const cusparseMatDescr_t descrC,
-                                              double *csrSortedValC,
-                                              const int *csrSortedRowPtrC,
-                                              int *csrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, int, const double *, const int *, const int *, const cusparseMatDescr_t, int, const double *, const int *, const int *, const cusparseMatDescr_t, double *, const int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrgemm(
+    cusparseHandle_t handle, cusparseOperation_t transA,
+    cusparseOperation_t transB, int m, int n, int k,
+    const cusparseMatDescr_t descrA, int nnzA, const double *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    const cusparseMatDescr_t descrB, int nnzB, const double *csrSortedValB,
+    const int *csrSortedRowPtrB, const int *csrSortedColIndB,
+    const cusparseMatDescr_t descrC, double *csrSortedValC,
+    const int *csrSortedRowPtrC, int *csrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int,
+      const cusparseMatDescr_t, int, const double *, const int *, const int *,
+      const cusparseMatDescr_t, int, const double *, const int *, const int *,
+      const cusparseMatDescr_t, double *, const int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrgemm");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, transB, m, n, k, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, transA, transB, m, n, k, descrA, nnzA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB,
+                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
+                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrgemm(cusparseHandle_t handle,
-                                              cusparseOperation_t transA,
-                                              cusparseOperation_t transB,
-                                              int m,
-                                              int n,
-                                              int k,
-                                              const cusparseMatDescr_t descrA,
-                                              int nnzA,
-                                              const cuComplex *csrSortedValA,
-                                              const int *csrSortedRowPtrA,
-                                              const int *csrSortedColIndA,
-                                              const cusparseMatDescr_t descrB,
-                                              int nnzB,
-                                              const cuComplex *csrSortedValB,
-                                              const int *csrSortedRowPtrB,
-                                              const int *csrSortedColIndB,
-                                              const cusparseMatDescr_t descrC,
-                                              cuComplex *csrSortedValC,
-                                              const int *csrSortedRowPtrC,
-                                              int *csrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, int, const cuComplex *, const int *, const int *, const cusparseMatDescr_t, int, const cuComplex *, const int *, const int *, const cusparseMatDescr_t, cuComplex *, const int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrgemm(
+    cusparseHandle_t handle, cusparseOperation_t transA,
+    cusparseOperation_t transB, int m, int n, int k,
+    const cusparseMatDescr_t descrA, int nnzA, const cuComplex *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    const cusparseMatDescr_t descrB, int nnzB, const cuComplex *csrSortedValB,
+    const int *csrSortedRowPtrB, const int *csrSortedColIndB,
+    const cusparseMatDescr_t descrC, cuComplex *csrSortedValC,
+    const int *csrSortedRowPtrC, int *csrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int,
+      const cusparseMatDescr_t, int, const cuComplex *, const int *,
+      const int *, const cusparseMatDescr_t, int, const cuComplex *,
+      const int *, const int *, const cusparseMatDescr_t, cuComplex *,
+      const int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrgemm");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, transB, m, n, k, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, transA, transB, m, n, k, descrA, nnzA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB,
+                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
+                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrgemm(cusparseHandle_t handle,
-                                              cusparseOperation_t transA,
-                                              cusparseOperation_t transB,
-                                              int m,
-                                              int n,
-                                              int k,
-                                              const cusparseMatDescr_t descrA,
-                                              int nnzA,
-                                              const cuDoubleComplex *csrSortedValA,
-                                              const int *csrSortedRowPtrA,
-                                              const int *csrSortedColIndA,
-                                              const cusparseMatDescr_t descrB,
-                                              int nnzB,
-                                              const cuDoubleComplex *csrSortedValB,
-                                              const int *csrSortedRowPtrB,
-                                              const int *csrSortedColIndB,
-                                              const cusparseMatDescr_t descrC,
-                                              cuDoubleComplex *csrSortedValC,
-                                              const int *csrSortedRowPtrC,
-                                              int *csrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int, const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *, const int *, const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *, const int *, const cusparseMatDescr_t, cuDoubleComplex *, const int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrgemm(
+    cusparseHandle_t handle, cusparseOperation_t transA,
+    cusparseOperation_t transB, int m, int n, int k,
+    const cusparseMatDescr_t descrA, int nnzA,
+    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, const cusparseMatDescr_t descrB, int nnzB,
+    const cuDoubleComplex *csrSortedValB, const int *csrSortedRowPtrB,
+    const int *csrSortedColIndB, const cusparseMatDescr_t descrC,
+    cuDoubleComplex *csrSortedValC, const int *csrSortedRowPtrC,
+    int *csrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, int, int, int,
+      const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *,
+      const int *, const cusparseMatDescr_t, int, const cuDoubleComplex *,
+      const int *, const int *, const cusparseMatDescr_t, cuDoubleComplex *,
+      const int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrgemm");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, transB, m, n, k, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, transA, transB, m, n, k, descrA, nnzA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB,
+                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
+                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCreateCsrgemm2Info(csrgemm2Info_t *info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(csrgemm2Info_t *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(csrgemm2Info_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateCsrgemm2Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDestroyCsrgemm2Info(csrgemm2Info_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(csrgemm2Info_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(csrgemm2Info_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyCsrgemm2Info");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrgemm2_bufferSizeExt(cusparseHandle_t handle,
-                                                             int m,
-                                                             int n,
-                                                             int k,
-                                                             const float *alpha,
-                                                             const cusparseMatDescr_t descrA,
-                                                             int nnzA,
-                                                             const int *csrSortedRowPtrA,
-                                                             const int *csrSortedColIndA,
-                                                             const cusparseMatDescr_t descrB,
-                                                             int nnzB,
-                                                             const int *csrSortedRowPtrB,
-                                                             const int *csrSortedColIndB,
-                                                             const float *beta,
-                                                             const cusparseMatDescr_t descrD,
-                                                             int nnzD,
-                                                             const int *csrSortedRowPtrD,
-                                                             const int *csrSortedColIndD,
-                                                             csrgemm2Info_t info,
-                                                             size_t *pBufferSizeInBytes ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const float *, const cusparseMatDescr_t, int, const int *, const int *, const cusparseMatDescr_t, int, const int *, const int *, const float *, const cusparseMatDescr_t, int, const int *, const int *, csrgemm2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrgemm2_bufferSizeExt(
+    cusparseHandle_t handle, int m, int n, int k, const float *alpha,
+    const cusparseMatDescr_t descrA, int nnzA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, const cusparseMatDescr_t descrB, int nnzB,
+    const int *csrSortedRowPtrB, const int *csrSortedColIndB, const float *beta,
+    const cusparseMatDescr_t descrD, int nnzD, const int *csrSortedRowPtrD,
+    const int *csrSortedColIndD, csrgemm2Info_t info,
+    size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const float *, const cusparseMatDescr_t,
+      int, const int *, const int *, const cusparseMatDescr_t, int, const int *,
+      const int *, const float *, const cusparseMatDescr_t, int, const int *,
+      const int *, csrgemm2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrgemm2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB, csrSortedColIndB, beta, descrD, nnzD, csrSortedRowPtrD, csrSortedColIndD, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedRowPtrA,
+                  csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB,
+                  csrSortedColIndB, beta, descrD, nnzD, csrSortedRowPtrD,
+                  csrSortedColIndD, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrgemm2_bufferSizeExt(cusparseHandle_t handle,
-                                                             int m,
-                                                             int n,
-                                                             int k,
-                                                             const double *alpha,
-                                                             const cusparseMatDescr_t descrA,
-                                                             int nnzA,
-                                                             const int *csrSortedRowPtrA,
-                                                             const int *csrSortedColIndA,
-                                                             const cusparseMatDescr_t descrB,
-                                                             int nnzB,
-                                                             const int *csrSortedRowPtrB,
-                                                             const int *csrSortedColIndB,
-                                                             const double *beta,
-                                                             const cusparseMatDescr_t descrD,
-                                                             int nnzD,
-                                                             const int *csrSortedRowPtrD,
-                                                             const int *csrSortedColIndD,
-                                                             csrgemm2Info_t info,
-                                                             size_t *pBufferSizeInBytes ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const double *, const cusparseMatDescr_t, int, const int *, const int *, const cusparseMatDescr_t, int, const int *, const int *, const double *, const cusparseMatDescr_t, int, const int *, const int *, csrgemm2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrgemm2_bufferSizeExt(
+    cusparseHandle_t handle, int m, int n, int k, const double *alpha,
+    const cusparseMatDescr_t descrA, int nnzA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, const cusparseMatDescr_t descrB, int nnzB,
+    const int *csrSortedRowPtrB, const int *csrSortedColIndB,
+    const double *beta, const cusparseMatDescr_t descrD, int nnzD,
+    const int *csrSortedRowPtrD, const int *csrSortedColIndD,
+    csrgemm2Info_t info, size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const double *, const cusparseMatDescr_t,
+      int, const int *, const int *, const cusparseMatDescr_t, int, const int *,
+      const int *, const double *, const cusparseMatDescr_t, int, const int *,
+      const int *, csrgemm2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrgemm2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB, csrSortedColIndB, beta, descrD, nnzD, csrSortedRowPtrD, csrSortedColIndD, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedRowPtrA,
+                  csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB,
+                  csrSortedColIndB, beta, descrD, nnzD, csrSortedRowPtrD,
+                  csrSortedColIndD, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrgemm2_bufferSizeExt(cusparseHandle_t handle,
-                                                             int m,
-                                                             int n,
-                                                             int k,
-                                                             const cuComplex *alpha,
-                                                             const cusparseMatDescr_t descrA,
-                                                             int nnzA,
-                                                             const int *csrSortedRowPtrA,
-                                                             const int *csrSortedColIndA,
-                                                             const cusparseMatDescr_t descrB,
-                                                             int nnzB,
-                                                             const int *csrSortedRowPtrB,
-                                                             const int *csrSortedColIndB,
-                                                             const cuComplex *beta,
-                                                             const cusparseMatDescr_t descrD,
-                                                             int nnzD,
-                                                             const int *csrSortedRowPtrD,
-                                                             const int *csrSortedColIndD,
-                                                             csrgemm2Info_t info,
-                                                             size_t *pBufferSizeInBytes ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cuComplex *, const cusparseMatDescr_t, int, const int *, const int *, const cusparseMatDescr_t, int, const int *, const int *, const cuComplex *, const cusparseMatDescr_t, int, const int *, const int *, csrgemm2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrgemm2_bufferSizeExt(
+    cusparseHandle_t handle, int m, int n, int k, const cuComplex *alpha,
+    const cusparseMatDescr_t descrA, int nnzA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, const cusparseMatDescr_t descrB, int nnzB,
+    const int *csrSortedRowPtrB, const int *csrSortedColIndB,
+    const cuComplex *beta, const cusparseMatDescr_t descrD, int nnzD,
+    const int *csrSortedRowPtrD, const int *csrSortedColIndD,
+    csrgemm2Info_t info, size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cuComplex *,
+      const cusparseMatDescr_t, int, const int *, const int *,
+      const cusparseMatDescr_t, int, const int *, const int *,
+      const cuComplex *, const cusparseMatDescr_t, int, const int *,
+      const int *, csrgemm2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrgemm2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB, csrSortedColIndB, beta, descrD, nnzD, csrSortedRowPtrD, csrSortedColIndD, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedRowPtrA,
+                  csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB,
+                  csrSortedColIndB, beta, descrD, nnzD, csrSortedRowPtrD,
+                  csrSortedColIndD, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrgemm2_bufferSizeExt(cusparseHandle_t handle,
-                                                             int m,
-                                                             int n,
-                                                             int k,
-                                                             const cuDoubleComplex *alpha,
-                                                             const cusparseMatDescr_t descrA,
-                                                             int nnzA,
-                                                             const int *csrSortedRowPtrA,
-                                                             const int *csrSortedColIndA,
-                                                             const cusparseMatDescr_t descrB,
-                                                             int nnzB,
-                                                             const int *csrSortedRowPtrB,
-                                                             const int *csrSortedColIndB,
-                                                             const cuDoubleComplex *beta,
-                                                             const cusparseMatDescr_t descrD,
-                                                             int nnzD,
-                                                             const int *csrSortedRowPtrD,
-                                                             const int *csrSortedColIndD,
-                                                             csrgemm2Info_t info,
-                                                             size_t *pBufferSizeInBytes ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, int, const int *, const int *, const cusparseMatDescr_t, int, const int *, const int *, const cuDoubleComplex *, const cusparseMatDescr_t, int, const int *, const int *, csrgemm2Info_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrgemm2_bufferSizeExt(
+    cusparseHandle_t handle, int m, int n, int k, const cuDoubleComplex *alpha,
+    const cusparseMatDescr_t descrA, int nnzA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, const cusparseMatDescr_t descrB, int nnzB,
+    const int *csrSortedRowPtrB, const int *csrSortedColIndB,
+    const cuDoubleComplex *beta, const cusparseMatDescr_t descrD, int nnzD,
+    const int *csrSortedRowPtrD, const int *csrSortedColIndD,
+    csrgemm2Info_t info, size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cuDoubleComplex *,
+      const cusparseMatDescr_t, int, const int *, const int *,
+      const cusparseMatDescr_t, int, const int *, const int *,
+      const cuDoubleComplex *, const cusparseMatDescr_t, int, const int *,
+      const int *, csrgemm2Info_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrgemm2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB, csrSortedColIndB, beta, descrD, nnzD, csrSortedRowPtrD, csrSortedColIndD, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedRowPtrA,
+                  csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB,
+                  csrSortedColIndB, beta, descrD, nnzD, csrSortedRowPtrD,
+                  csrSortedColIndD, info, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseXcsrgemm2Nnz(cusparseHandle_t handle,
-                                                  int m,
-                                                  int n,
-                                                  int k,
-                                                  const cusparseMatDescr_t descrA,
-                                                  int nnzA,
-                                                  const int *csrSortedRowPtrA,
-                                                  const int *csrSortedColIndA,
-                                                  const cusparseMatDescr_t descrB,
-                                                  int nnzB,
-                                                  const int *csrSortedRowPtrB,
-                                                  const int *csrSortedColIndB,
-                                                  const cusparseMatDescr_t descrD,
-                                                  int nnzD,
-                                                  const int *csrSortedRowPtrD,
-                                                  const int *csrSortedColIndD,
-                                                  const cusparseMatDescr_t descrC,
-                                                  int *csrSortedRowPtrC,
-                                                  int *nnzTotalDevHostPtr,
-                                                  const csrgemm2Info_t info,
-                                                  void *pBuffer ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, int, const int *, const int *, const cusparseMatDescr_t, int, const int *, const int *, const cusparseMatDescr_t, int, const int *, const int *, const cusparseMatDescr_t, int *, int *, const csrgemm2Info_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseXcsrgemm2Nnz(
+    cusparseHandle_t handle, int m, int n, int k,
+    const cusparseMatDescr_t descrA, int nnzA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, const cusparseMatDescr_t descrB, int nnzB,
+    const int *csrSortedRowPtrB, const int *csrSortedColIndB,
+    const cusparseMatDescr_t descrD, int nnzD, const int *csrSortedRowPtrD,
+    const int *csrSortedColIndD, const cusparseMatDescr_t descrC,
+    int *csrSortedRowPtrC, int *nnzTotalDevHostPtr, const csrgemm2Info_t info,
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, int,
+      const int *, const int *, const cusparseMatDescr_t, int, const int *,
+      const int *, const cusparseMatDescr_t, int, const int *, const int *,
+      const cusparseMatDescr_t, int *, int *, const csrgemm2Info_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcsrgemm2Nnz");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, k, descrA, nnzA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB, csrSortedColIndB, descrD, nnzD, csrSortedRowPtrD, csrSortedColIndD, descrC, csrSortedRowPtrC, nnzTotalDevHostPtr, info, pBuffer);
+  return func_ptr(handle, m, n, k, descrA, nnzA, csrSortedRowPtrA,
+                  csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB,
+                  csrSortedColIndB, descrD, nnzD, csrSortedRowPtrD,
+                  csrSortedColIndD, descrC, csrSortedRowPtrC,
+                  nnzTotalDevHostPtr, info, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrgemm2(cusparseHandle_t handle,
-                                               int m,
-                                               int n,
-                                               int k,
-                                               const float *alpha,
-                                               const cusparseMatDescr_t descrA,
-                                               int nnzA,
-                                               const float *csrSortedValA,
-                                               const int *csrSortedRowPtrA,
-                                               const int *csrSortedColIndA,
-                                               const cusparseMatDescr_t descrB,
-                                               int nnzB,
-                                               const float *csrSortedValB,
-                                               const int *csrSortedRowPtrB,
-                                               const int *csrSortedColIndB,
-                                               const float *beta,
-                                               const cusparseMatDescr_t descrD,
-                                               int nnzD,
-                                               const float *csrSortedValD,
-                                               const int *csrSortedRowPtrD,
-                                               const int *csrSortedColIndD,
-                                               const cusparseMatDescr_t descrC,
-                                               float *csrSortedValC,
-                                               const int *csrSortedRowPtrC,
-                                               int *csrSortedColIndC,
-                                               const csrgemm2Info_t info,
-                                               void *pBuffer ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const float *, const cusparseMatDescr_t, int, const float *, const int *, const int *, const cusparseMatDescr_t, int, const float *, const int *, const int *, const float *, const cusparseMatDescr_t, int, const float *, const int *, const int *, const cusparseMatDescr_t, float *, const int *, int *, const csrgemm2Info_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrgemm2(
+    cusparseHandle_t handle, int m, int n, int k, const float *alpha,
+    const cusparseMatDescr_t descrA, int nnzA, const float *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    const cusparseMatDescr_t descrB, int nnzB, const float *csrSortedValB,
+    const int *csrSortedRowPtrB, const int *csrSortedColIndB, const float *beta,
+    const cusparseMatDescr_t descrD, int nnzD, const float *csrSortedValD,
+    const int *csrSortedRowPtrD, const int *csrSortedColIndD,
+    const cusparseMatDescr_t descrC, float *csrSortedValC,
+    const int *csrSortedRowPtrC, int *csrSortedColIndC,
+    const csrgemm2Info_t info, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const float *, const cusparseMatDescr_t,
+      int, const float *, const int *, const int *, const cusparseMatDescr_t,
+      int, const float *, const int *, const int *, const float *,
+      const cusparseMatDescr_t, int, const float *, const int *, const int *,
+      const cusparseMatDescr_t, float *, const int *, int *,
+      const csrgemm2Info_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrgemm2");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, beta, descrD, nnzD, csrSortedValD, csrSortedRowPtrD, csrSortedColIndD, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, info, pBuffer);
+  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB,
+                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, beta,
+                  descrD, nnzD, csrSortedValD, csrSortedRowPtrD,
+                  csrSortedColIndD, descrC, csrSortedValC, csrSortedRowPtrC,
+                  csrSortedColIndC, info, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrgemm2(cusparseHandle_t handle,
-                                               int m,
-                                               int n,
-                                               int k,
-                                               const double *alpha,
-                                               const cusparseMatDescr_t descrA,
-                                               int nnzA,
-                                               const double *csrSortedValA,
-                                               const int *csrSortedRowPtrA,
-                                               const int *csrSortedColIndA,
-                                               const cusparseMatDescr_t descrB,
-                                               int nnzB,
-                                               const double *csrSortedValB,
-                                               const int *csrSortedRowPtrB,
-                                               const int *csrSortedColIndB,
-                                               const double *beta,
-                                               const cusparseMatDescr_t descrD,
-                                               int nnzD,
-                                               const double *csrSortedValD,
-                                               const int *csrSortedRowPtrD,
-                                               const int *csrSortedColIndD,
-                                               const cusparseMatDescr_t descrC,
-                                               double *csrSortedValC,
-                                               const int *csrSortedRowPtrC,
-                                               int *csrSortedColIndC,
-                                               const csrgemm2Info_t info,
-                                               void *pBuffer ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const double *, const cusparseMatDescr_t, int, const double *, const int *, const int *, const cusparseMatDescr_t, int, const double *, const int *, const int *, const double *, const cusparseMatDescr_t, int, const double *, const int *, const int *, const cusparseMatDescr_t, double *, const int *, int *, const csrgemm2Info_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrgemm2(
+    cusparseHandle_t handle, int m, int n, int k, const double *alpha,
+    const cusparseMatDescr_t descrA, int nnzA, const double *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    const cusparseMatDescr_t descrB, int nnzB, const double *csrSortedValB,
+    const int *csrSortedRowPtrB, const int *csrSortedColIndB,
+    const double *beta, const cusparseMatDescr_t descrD, int nnzD,
+    const double *csrSortedValD, const int *csrSortedRowPtrD,
+    const int *csrSortedColIndD, const cusparseMatDescr_t descrC,
+    double *csrSortedValC, const int *csrSortedRowPtrC, int *csrSortedColIndC,
+    const csrgemm2Info_t info, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const double *, const cusparseMatDescr_t,
+      int, const double *, const int *, const int *, const cusparseMatDescr_t,
+      int, const double *, const int *, const int *, const double *,
+      const cusparseMatDescr_t, int, const double *, const int *, const int *,
+      const cusparseMatDescr_t, double *, const int *, int *,
+      const csrgemm2Info_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrgemm2");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, beta, descrD, nnzD, csrSortedValD, csrSortedRowPtrD, csrSortedColIndD, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, info, pBuffer);
+  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB,
+                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, beta,
+                  descrD, nnzD, csrSortedValD, csrSortedRowPtrD,
+                  csrSortedColIndD, descrC, csrSortedValC, csrSortedRowPtrC,
+                  csrSortedColIndC, info, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrgemm2(cusparseHandle_t handle,
-                                               int m,
-                                               int n,
-                                               int k,
-                                               const cuComplex *alpha,
-                                               const cusparseMatDescr_t descrA,
-                                               int nnzA,
-                                               const cuComplex *csrSortedValA,
-                                               const int *csrSortedRowPtrA,
-                                               const int *csrSortedColIndA,
-                                               const cusparseMatDescr_t descrB,
-                                               int nnzB,
-                                               const cuComplex *csrSortedValB,
-                                               const int *csrSortedRowPtrB,
-                                               const int *csrSortedColIndB,
-                                               const cuComplex *beta,
-                                               const cusparseMatDescr_t descrD,
-                                               int nnzD,
-                                               const cuComplex *csrSortedValD,
-                                               const int *csrSortedRowPtrD,
-                                               const int *csrSortedColIndD,
-                                               const cusparseMatDescr_t descrC,
-                                               cuComplex *csrSortedValC,
-                                               const int *csrSortedRowPtrC,
-                                               int *csrSortedColIndC,
-                                               const csrgemm2Info_t info,
-                                               void *pBuffer ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cuComplex *, const cusparseMatDescr_t, int, const cuComplex *, const int *, const int *, const cusparseMatDescr_t, int, const cuComplex *, const int *, const int *, const cuComplex *, const cusparseMatDescr_t, int, const cuComplex *, const int *, const int *, const cusparseMatDescr_t, cuComplex *, const int *, int *, const csrgemm2Info_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrgemm2(
+    cusparseHandle_t handle, int m, int n, int k, const cuComplex *alpha,
+    const cusparseMatDescr_t descrA, int nnzA, const cuComplex *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    const cusparseMatDescr_t descrB, int nnzB, const cuComplex *csrSortedValB,
+    const int *csrSortedRowPtrB, const int *csrSortedColIndB,
+    const cuComplex *beta, const cusparseMatDescr_t descrD, int nnzD,
+    const cuComplex *csrSortedValD, const int *csrSortedRowPtrD,
+    const int *csrSortedColIndD, const cusparseMatDescr_t descrC,
+    cuComplex *csrSortedValC, const int *csrSortedRowPtrC,
+    int *csrSortedColIndC, const csrgemm2Info_t info, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cuComplex *,
+      const cusparseMatDescr_t, int, const cuComplex *, const int *,
+      const int *, const cusparseMatDescr_t, int, const cuComplex *,
+      const int *, const int *, const cuComplex *, const cusparseMatDescr_t,
+      int, const cuComplex *, const int *, const int *,
+      const cusparseMatDescr_t, cuComplex *, const int *, int *,
+      const csrgemm2Info_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrgemm2");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, beta, descrD, nnzD, csrSortedValD, csrSortedRowPtrD, csrSortedColIndD, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, info, pBuffer);
+  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB,
+                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, beta,
+                  descrD, nnzD, csrSortedValD, csrSortedRowPtrD,
+                  csrSortedColIndD, descrC, csrSortedValC, csrSortedRowPtrC,
+                  csrSortedColIndC, info, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrgemm2(cusparseHandle_t handle,
-                                               int m,
-                                               int n,
-                                               int k,
-                                               const cuDoubleComplex *alpha,
-                                               const cusparseMatDescr_t descrA,
-                                               int nnzA,
-                                               const cuDoubleComplex *csrSortedValA,
-                                               const int *csrSortedRowPtrA,
-                                               const int *csrSortedColIndA,
-                                               const cusparseMatDescr_t descrB,
-                                               int nnzB,
-                                               const cuDoubleComplex *csrSortedValB,
-                                               const int *csrSortedRowPtrB,
-                                               const int *csrSortedColIndB,
-                                               const cuDoubleComplex *beta,
-                                               const cusparseMatDescr_t descrD,
-                                               int nnzD,
-                                               const cuDoubleComplex *csrSortedValD,
-                                               const int *csrSortedRowPtrD,
-                                               const int *csrSortedColIndD,
-                                               const cusparseMatDescr_t descrC,
-                                               cuDoubleComplex *csrSortedValC,
-                                               const int *csrSortedRowPtrC,
-                                               int *csrSortedColIndC,
-                                               const csrgemm2Info_t info,
-                                               void *pBuffer ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *, const int *, const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *, const int *, const cuDoubleComplex *, const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *, const int *, const cusparseMatDescr_t, cuDoubleComplex *, const int *, int *, const csrgemm2Info_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrgemm2(
+    cusparseHandle_t handle, int m, int n, int k, const cuDoubleComplex *alpha,
+    const cusparseMatDescr_t descrA, int nnzA,
+    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, const cusparseMatDescr_t descrB, int nnzB,
+    const cuDoubleComplex *csrSortedValB, const int *csrSortedRowPtrB,
+    const int *csrSortedColIndB, const cuDoubleComplex *beta,
+    const cusparseMatDescr_t descrD, int nnzD,
+    const cuDoubleComplex *csrSortedValD, const int *csrSortedRowPtrD,
+    const int *csrSortedColIndD, const cusparseMatDescr_t descrC,
+    cuDoubleComplex *csrSortedValC, const int *csrSortedRowPtrC,
+    int *csrSortedColIndC, const csrgemm2Info_t info, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cuDoubleComplex *,
+      const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *,
+      const int *, const cusparseMatDescr_t, int, const cuDoubleComplex *,
+      const int *, const int *, const cuDoubleComplex *,
+      const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *,
+      const int *, const cusparseMatDescr_t, cuDoubleComplex *, const int *,
+      int *, const csrgemm2Info_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrgemm2");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, beta, descrD, nnzD, csrSortedValD, csrSortedRowPtrD, csrSortedColIndD, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, info, pBuffer);
+  return func_ptr(handle, m, n, k, alpha, descrA, nnzA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB,
+                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, beta,
+                  descrD, nnzD, csrSortedValD, csrSortedRowPtrD,
+                  csrSortedColIndD, descrC, csrSortedValC, csrSortedRowPtrC,
+                  csrSortedColIndC, info, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseXcsrgeamNnz(cusparseHandle_t handle,
-                                                 int m,
-                                                 int n,
-                                                 const cusparseMatDescr_t descrA,
-                                                 int nnzA,
-                                                 const int *csrSortedRowPtrA,
-                                                 const int *csrSortedColIndA,
-                                                 const cusparseMatDescr_t descrB,
-                                                 int nnzB,
-                                                 const int *csrSortedRowPtrB,
-                                                 const int *csrSortedColIndB,
-                                                 const cusparseMatDescr_t descrC,
-                                                 int *csrSortedRowPtrC,
-                                                 int *nnzTotalDevHostPtr) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, int, const int *, const int *, const cusparseMatDescr_t, int, const int *, const int *, const cusparseMatDescr_t, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseXcsrgeamNnz(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    int nnzA, const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    const cusparseMatDescr_t descrB, int nnzB, const int *csrSortedRowPtrB,
+    const int *csrSortedColIndB, const cusparseMatDescr_t descrC,
+    int *csrSortedRowPtrC, int *nnzTotalDevHostPtr) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, int, const int *,
+      const int *, const cusparseMatDescr_t, int, const int *, const int *,
+      const cusparseMatDescr_t, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcsrgeamNnz");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, nnzA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedRowPtrC, nnzTotalDevHostPtr);
+  return func_ptr(handle, m, n, descrA, nnzA, csrSortedRowPtrA,
+                  csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB,
+                  csrSortedColIndB, descrC, csrSortedRowPtrC,
+                  nnzTotalDevHostPtr);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrgeam(cusparseHandle_t handle,
-                                              int m,
-                                              int n,
-                                              const float *alpha,
-                                              const cusparseMatDescr_t descrA,
-                                              int nnzA,
-                                              const float *csrSortedValA,
-                                              const int *csrSortedRowPtrA,
-                                              const int *csrSortedColIndA,
-                                              const float *beta,
-                                              const cusparseMatDescr_t descrB,
-                                              int nnzB,
-                                              const float *csrSortedValB,
-                                              const int *csrSortedRowPtrB,
-                                              const int *csrSortedColIndB,
-                                              const cusparseMatDescr_t descrC,
-                                              float *csrSortedValC,
-                                              int *csrSortedRowPtrC,
-                                              int *csrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, const cusparseMatDescr_t, int, const float *, const int *, const int *, const float *, const cusparseMatDescr_t, int, const float *, const int *, const int *, const cusparseMatDescr_t, float *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseScsrgeam(
+    cusparseHandle_t handle, int m, int n, const float *alpha,
+    const cusparseMatDescr_t descrA, int nnzA, const float *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, const float *beta,
+    const cusparseMatDescr_t descrB, int nnzB, const float *csrSortedValB,
+    const int *csrSortedRowPtrB, const int *csrSortedColIndB,
+    const cusparseMatDescr_t descrC, float *csrSortedValC,
+    int *csrSortedRowPtrC, int *csrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const float *, const cusparseMatDescr_t, int,
+      const float *, const int *, const int *, const float *,
+      const cusparseMatDescr_t, int, const float *, const int *, const int *,
+      const cusparseMatDescr_t, float *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrgeam");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB,
+                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
+                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrgeam(cusparseHandle_t handle,
-                                              int m,
-                                              int n,
-                                              const double *alpha,
-                                              const cusparseMatDescr_t descrA,
-                                              int nnzA,
-                                              const double *csrSortedValA,
-                                              const int *csrSortedRowPtrA,
-                                              const int *csrSortedColIndA,
-                                              const double *beta,
-                                              const cusparseMatDescr_t descrB,
-                                              int nnzB,
-                                              const double *csrSortedValB,
-                                              const int *csrSortedRowPtrB,
-                                              const int *csrSortedColIndB,
-                                              const cusparseMatDescr_t descrC,
-                                              double *csrSortedValC,
-                                              int *csrSortedRowPtrC,
-                                              int *csrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, const cusparseMatDescr_t, int, const double *, const int *, const int *, const double *, const cusparseMatDescr_t, int, const double *, const int *, const int *, const cusparseMatDescr_t, double *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrgeam(
+    cusparseHandle_t handle, int m, int n, const double *alpha,
+    const cusparseMatDescr_t descrA, int nnzA, const double *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    const double *beta, const cusparseMatDescr_t descrB, int nnzB,
+    const double *csrSortedValB, const int *csrSortedRowPtrB,
+    const int *csrSortedColIndB, const cusparseMatDescr_t descrC,
+    double *csrSortedValC, int *csrSortedRowPtrC, int *csrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const double *, const cusparseMatDescr_t, int,
+      const double *, const int *, const int *, const double *,
+      const cusparseMatDescr_t, int, const double *, const int *, const int *,
+      const cusparseMatDescr_t, double *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrgeam");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB,
+                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
+                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrgeam(cusparseHandle_t handle,
-                                              int m,
-                                              int n,
-                                              const cuComplex *alpha,
-                                              const cusparseMatDescr_t descrA,
-                                              int nnzA,
-                                              const cuComplex *csrSortedValA,
-                                              const int *csrSortedRowPtrA,
-                                              const int *csrSortedColIndA,
-                                              const cuComplex *beta,
-                                              const cusparseMatDescr_t descrB,
-                                              int nnzB,
-                                              const cuComplex *csrSortedValB,
-                                              const int *csrSortedRowPtrB,
-                                              const int *csrSortedColIndB,
-                                              const cusparseMatDescr_t descrC,
-                                              cuComplex *csrSortedValC,
-                                              int *csrSortedRowPtrC,
-                                              int *csrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuComplex *, const cusparseMatDescr_t, int, const cuComplex *, const int *, const int *, const cuComplex *, const cusparseMatDescr_t, int, const cuComplex *, const int *, const int *, const cusparseMatDescr_t, cuComplex *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrgeam(
+    cusparseHandle_t handle, int m, int n, const cuComplex *alpha,
+    const cusparseMatDescr_t descrA, int nnzA, const cuComplex *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    const cuComplex *beta, const cusparseMatDescr_t descrB, int nnzB,
+    const cuComplex *csrSortedValB, const int *csrSortedRowPtrB,
+    const int *csrSortedColIndB, const cusparseMatDescr_t descrC,
+    cuComplex *csrSortedValC, int *csrSortedRowPtrC, int *csrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cuComplex *, const cusparseMatDescr_t,
+      int, const cuComplex *, const int *, const int *, const cuComplex *,
+      const cusparseMatDescr_t, int, const cuComplex *, const int *,
+      const int *, const cusparseMatDescr_t, cuComplex *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrgeam");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB,
+                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
+                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrgeam(cusparseHandle_t handle,
-                                              int m,
-                                              int n,
-                                              const cuDoubleComplex *alpha,
-                                              const cusparseMatDescr_t descrA,
-                                              int nnzA,
-                                              const cuDoubleComplex *csrSortedValA,
-                                              const int *csrSortedRowPtrA,
-                                              const int *csrSortedColIndA,
-                                              const cuDoubleComplex *beta,
-                                              const cusparseMatDescr_t descrB,
-                                              int nnzB,
-                                              const cuDoubleComplex *csrSortedValB,
-                                              const int *csrSortedRowPtrB,
-                                              const int *csrSortedColIndB,
-                                              const cusparseMatDescr_t descrC,
-                                              cuDoubleComplex *csrSortedValC,
-                                              int *csrSortedRowPtrC,
-                                              int *csrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *, const int *, const cuDoubleComplex *, const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *, const int *, const cusparseMatDescr_t, cuDoubleComplex *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrgeam(
+    cusparseHandle_t handle, int m, int n, const cuDoubleComplex *alpha,
+    const cusparseMatDescr_t descrA, int nnzA,
+    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, const cuDoubleComplex *beta,
+    const cusparseMatDescr_t descrB, int nnzB,
+    const cuDoubleComplex *csrSortedValB, const int *csrSortedRowPtrB,
+    const int *csrSortedColIndB, const cusparseMatDescr_t descrC,
+    cuDoubleComplex *csrSortedValC, int *csrSortedRowPtrC,
+    int *csrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cuDoubleComplex *,
+      const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *,
+      const int *, const cuDoubleComplex *, const cusparseMatDescr_t, int,
+      const cuDoubleComplex *, const int *, const int *,
+      const cusparseMatDescr_t, cuDoubleComplex *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrgeam");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB,
+                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
+                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseScsrgeam2_bufferSizeExt(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const float *alpha,
-    const cusparseMatDescr_t descrA,
-    int nnzA,
-    const float *csrSortedValA,
-    const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA,
-    const float *beta,
-    const cusparseMatDescr_t descrB,
-    int nnzB,
-    const float *csrSortedValB,
-    const int *csrSortedRowPtrB,
-    const int *csrSortedColIndB,
-    const cusparseMatDescr_t descrC,
-    const float *csrSortedValC,
-    const int *csrSortedRowPtrC,
-    const int *csrSortedColIndC,
-    size_t *pBufferSizeInBytes ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, const cusparseMatDescr_t, int, const float *, const int *, const int *, const float *, const cusparseMatDescr_t, int, const float *, const int *, const int *, const cusparseMatDescr_t, const float *, const int *, const int *, size_t *);
+    cusparseHandle_t handle, int m, int n, const float *alpha,
+    const cusparseMatDescr_t descrA, int nnzA, const float *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, const float *beta,
+    const cusparseMatDescr_t descrB, int nnzB, const float *csrSortedValB,
+    const int *csrSortedRowPtrB, const int *csrSortedColIndB,
+    const cusparseMatDescr_t descrC, const float *csrSortedValC,
+    const int *csrSortedRowPtrC, const int *csrSortedColIndC,
+    size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const float *, const cusparseMatDescr_t, int,
+      const float *, const int *, const int *, const float *,
+      const cusparseMatDescr_t, int, const float *, const int *, const int *,
+      const cusparseMatDescr_t, const float *, const int *, const int *,
+      size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrgeam2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB,
+                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
+                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC,
+                  pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDcsrgeam2_bufferSizeExt(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const double *alpha,
-    const cusparseMatDescr_t descrA,
-    int nnzA,
-    const double *csrSortedValA,
-    const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA,
-    const double *beta,
-    const cusparseMatDescr_t descrB,
-    int nnzB,
-    const double *csrSortedValB,
-    const int *csrSortedRowPtrB,
-    const int *csrSortedColIndB,
-    const cusparseMatDescr_t descrC,
-    const double *csrSortedValC,
-    const int *csrSortedRowPtrC,
-    const int *csrSortedColIndC,
-    size_t *pBufferSizeInBytes ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, const cusparseMatDescr_t, int, const double *, const int *, const int *, const double *, const cusparseMatDescr_t, int, const double *, const int *, const int *, const cusparseMatDescr_t, const double *, const int *, const int *, size_t *);
+    cusparseHandle_t handle, int m, int n, const double *alpha,
+    const cusparseMatDescr_t descrA, int nnzA, const double *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    const double *beta, const cusparseMatDescr_t descrB, int nnzB,
+    const double *csrSortedValB, const int *csrSortedRowPtrB,
+    const int *csrSortedColIndB, const cusparseMatDescr_t descrC,
+    const double *csrSortedValC, const int *csrSortedRowPtrC,
+    const int *csrSortedColIndC, size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const double *, const cusparseMatDescr_t, int,
+      const double *, const int *, const int *, const double *,
+      const cusparseMatDescr_t, int, const double *, const int *, const int *,
+      const cusparseMatDescr_t, const double *, const int *, const int *,
+      size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrgeam2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB,
+                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
+                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC,
+                  pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCcsrgeam2_bufferSizeExt(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const cuComplex *alpha,
-    const cusparseMatDescr_t descrA,
-    int nnzA,
-    const cuComplex *csrSortedValA,
-    const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA,
-    const cuComplex *beta,
-    const cusparseMatDescr_t descrB,
-    int nnzB,
-    const cuComplex *csrSortedValB,
-    const int *csrSortedRowPtrB,
-    const int *csrSortedColIndB,
-    const cusparseMatDescr_t descrC,
-    const cuComplex *csrSortedValC,
-    const int *csrSortedRowPtrC,
-    const int *csrSortedColIndC,
-    size_t *pBufferSizeInBytes ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuComplex *, const cusparseMatDescr_t, int, const cuComplex *, const int *, const int *, const cuComplex *, const cusparseMatDescr_t, int, const cuComplex *, const int *, const int *, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, size_t *);
+    cusparseHandle_t handle, int m, int n, const cuComplex *alpha,
+    const cusparseMatDescr_t descrA, int nnzA, const cuComplex *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    const cuComplex *beta, const cusparseMatDescr_t descrB, int nnzB,
+    const cuComplex *csrSortedValB, const int *csrSortedRowPtrB,
+    const int *csrSortedColIndB, const cusparseMatDescr_t descrC,
+    const cuComplex *csrSortedValC, const int *csrSortedRowPtrC,
+    const int *csrSortedColIndC, size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cuComplex *, const cusparseMatDescr_t,
+      int, const cuComplex *, const int *, const int *, const cuComplex *,
+      const cusparseMatDescr_t, int, const cuComplex *, const int *,
+      const int *, const cusparseMatDescr_t, const cuComplex *, const int *,
+      const int *, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrgeam2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB,
+                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
+                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC,
+                  pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseZcsrgeam2_bufferSizeExt(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const cuDoubleComplex *alpha,
-    const cusparseMatDescr_t descrA,
-    int nnzA,
-    const cuDoubleComplex *csrSortedValA,
-    const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA,
-    const cuDoubleComplex *beta,
-    const cusparseMatDescr_t descrB,
-    int nnzB,
-    const cuDoubleComplex *csrSortedValB,
-    const int *csrSortedRowPtrB,
-    const int *csrSortedColIndB,
-    const cusparseMatDescr_t descrC,
-    const cuDoubleComplex *csrSortedValC,
-    const int *csrSortedRowPtrC,
-    const int *csrSortedColIndC,
-    size_t *pBufferSizeInBytes ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *, const int *, const cuDoubleComplex *, const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *, const int *, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, size_t *);
+    cusparseHandle_t handle, int m, int n, const cuDoubleComplex *alpha,
+    const cusparseMatDescr_t descrA, int nnzA,
+    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, const cuDoubleComplex *beta,
+    const cusparseMatDescr_t descrB, int nnzB,
+    const cuDoubleComplex *csrSortedValB, const int *csrSortedRowPtrB,
+    const int *csrSortedColIndB, const cusparseMatDescr_t descrC,
+    const cuDoubleComplex *csrSortedValC, const int *csrSortedRowPtrC,
+    const int *csrSortedColIndC, size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cuDoubleComplex *,
+      const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *,
+      const int *, const cuDoubleComplex *, const cusparseMatDescr_t, int,
+      const cuDoubleComplex *, const int *, const int *,
+      const cusparseMatDescr_t, const cuDoubleComplex *, const int *,
+      const int *, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrgeam2_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB,
+                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
+                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC,
+                  pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseXcsrgeam2Nnz(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const cusparseMatDescr_t descrA,
-    int nnzA,
-    const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA,
-    const cusparseMatDescr_t descrB,
-    int nnzB,
-    const int *csrSortedRowPtrB,
-    const int *csrSortedColIndB,
-    const cusparseMatDescr_t descrC,
-    int *csrSortedRowPtrC,
-    int *nnzTotalDevHostPtr,
-    void *workspace ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, int, const int *, const int *, const cusparseMatDescr_t, int, const int *, const int *, const cusparseMatDescr_t, int *, int *, void *);
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    int nnzA, const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    const cusparseMatDescr_t descrB, int nnzB, const int *csrSortedRowPtrB,
+    const int *csrSortedColIndB, const cusparseMatDescr_t descrC,
+    int *csrSortedRowPtrC, int *nnzTotalDevHostPtr, void *workspace) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, int, const int *,
+      const int *, const cusparseMatDescr_t, int, const int *, const int *,
+      const cusparseMatDescr_t, int *, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcsrgeam2Nnz");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, nnzA, csrSortedRowPtrA, csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedRowPtrC, nnzTotalDevHostPtr, workspace);
+  return func_ptr(handle, m, n, descrA, nnzA, csrSortedRowPtrA,
+                  csrSortedColIndA, descrB, nnzB, csrSortedRowPtrB,
+                  csrSortedColIndB, descrC, csrSortedRowPtrC,
+                  nnzTotalDevHostPtr, workspace);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseScsrgeam2(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const float *alpha,
-    const cusparseMatDescr_t descrA,
-    int nnzA,
-    const float *csrSortedValA,
-    const int   *csrSortedRowPtrA,
-    const int   *csrSortedColIndA,
-    const float *beta,
-    const cusparseMatDescr_t descrB,
-    int nnzB,
-    const float *csrSortedValB,
-    const int   *csrSortedRowPtrB,
-    const int   *csrSortedColIndB,
-    const cusparseMatDescr_t descrC,
-    float       *csrSortedValC,
-    int         *csrSortedRowPtrC,
-    int         *csrSortedColIndC,
-    void *pBuffer ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, const cusparseMatDescr_t, int, const float *, const int   *, const int   *, const float *, const cusparseMatDescr_t, int, const float *, const int   *, const int   *, const cusparseMatDescr_t, float       *, int         *, int         *, void *);
+    cusparseHandle_t handle, int m, int n, const float *alpha,
+    const cusparseMatDescr_t descrA, int nnzA, const float *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, const float *beta,
+    const cusparseMatDescr_t descrB, int nnzB, const float *csrSortedValB,
+    const int *csrSortedRowPtrB, const int *csrSortedColIndB,
+    const cusparseMatDescr_t descrC, float *csrSortedValC,
+    int *csrSortedRowPtrC, int *csrSortedColIndC, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const float *, const cusparseMatDescr_t, int,
+      const float *, const int *, const int *, const float *,
+      const cusparseMatDescr_t, int, const float *, const int *, const int *,
+      const cusparseMatDescr_t, float *, int *, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrgeam2");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBuffer);
+  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB,
+                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
+                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBuffer);
 }
 
-cusparseStatus_t  CUSPARSEAPI cusparseDcsrgeam2(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const double *alpha,
-    const cusparseMatDescr_t descrA,
-    int nnzA,
-    const double *csrSortedValA,
-    const int    *csrSortedRowPtrA,
-    const int    *csrSortedColIndA,
-    const double *beta,
-    const cusparseMatDescr_t descrB,
-    int nnzB,
-    const double *csrSortedValB,
-    const int    *csrSortedRowPtrB,
-    const int    *csrSortedColIndB,
-    const cusparseMatDescr_t descrC,
-    double *csrSortedValC,
-    int    *csrSortedRowPtrC,
-    int    *csrSortedColIndC,
-    void *pBuffer ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, const cusparseMatDescr_t, int, const double *, const int    *, const int    *, const double *, const cusparseMatDescr_t, int, const double *, const int    *, const int    *, const cusparseMatDescr_t, double *, int    *, int    *, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrgeam2(
+    cusparseHandle_t handle, int m, int n, const double *alpha,
+    const cusparseMatDescr_t descrA, int nnzA, const double *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    const double *beta, const cusparseMatDescr_t descrB, int nnzB,
+    const double *csrSortedValB, const int *csrSortedRowPtrB,
+    const int *csrSortedColIndB, const cusparseMatDescr_t descrC,
+    double *csrSortedValC, int *csrSortedRowPtrC, int *csrSortedColIndC,
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const double *, const cusparseMatDescr_t, int,
+      const double *, const int *, const int *, const double *,
+      const cusparseMatDescr_t, int, const double *, const int *, const int *,
+      const cusparseMatDescr_t, double *, int *, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrgeam2");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBuffer);
+  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB,
+                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
+                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseCcsrgeam2(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const cuComplex *alpha,
-    const cusparseMatDescr_t descrA,
-    int nnzA,
-    const cuComplex *csrSortedValA,
-    const int       *csrSortedRowPtrA,
-    const int       *csrSortedColIndA,
-    const cuComplex *beta,
-    const cusparseMatDescr_t descrB,
-    int nnzB,
-    const cuComplex *csrSortedValB,
-    const int       *csrSortedRowPtrB,
-    const int       *csrSortedColIndB,
-    const cusparseMatDescr_t descrC,
-    cuComplex *csrSortedValC,
-    int       *csrSortedRowPtrC,
-    int       *csrSortedColIndC,
-    void *pBuffer ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuComplex *, const cusparseMatDescr_t, int, const cuComplex *, const int       *, const int       *, const cuComplex *, const cusparseMatDescr_t, int, const cuComplex *, const int       *, const int       *, const cusparseMatDescr_t, cuComplex *, int       *, int       *, void *);
+    cusparseHandle_t handle, int m, int n, const cuComplex *alpha,
+    const cusparseMatDescr_t descrA, int nnzA, const cuComplex *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    const cuComplex *beta, const cusparseMatDescr_t descrB, int nnzB,
+    const cuComplex *csrSortedValB, const int *csrSortedRowPtrB,
+    const int *csrSortedColIndB, const cusparseMatDescr_t descrC,
+    cuComplex *csrSortedValC, int *csrSortedRowPtrC, int *csrSortedColIndC,
+    void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cuComplex *, const cusparseMatDescr_t,
+      int, const cuComplex *, const int *, const int *, const cuComplex *,
+      const cusparseMatDescr_t, int, const cuComplex *, const int *,
+      const int *, const cusparseMatDescr_t, cuComplex *, int *, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrgeam2");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBuffer);
+  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB,
+                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
+                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBuffer);
 }
 
-cusparseStatus_t  CUSPARSEAPI cusparseZcsrgeam2(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const cuDoubleComplex *alpha,
-    const cusparseMatDescr_t descrA,
-    int nnzA,
-    const cuDoubleComplex *csrSortedValA,
-    const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA,
-    const cuDoubleComplex *beta,
-    const cusparseMatDescr_t descrB,
-    int nnzB,
-    const cuDoubleComplex *csrSortedValB,
-    const int *csrSortedRowPtrB,
-    const int *csrSortedColIndB,
-    const cusparseMatDescr_t descrC,
-    cuDoubleComplex *csrSortedValC,
-    int *csrSortedRowPtrC,
-    int *csrSortedColIndC,
-    void *pBuffer ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cuDoubleComplex *, const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *, const int *, const cuDoubleComplex *, const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *, const int *, const cusparseMatDescr_t, cuDoubleComplex *, int *, int *, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrgeam2(
+    cusparseHandle_t handle, int m, int n, const cuDoubleComplex *alpha,
+    const cusparseMatDescr_t descrA, int nnzA,
+    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, const cuDoubleComplex *beta,
+    const cusparseMatDescr_t descrB, int nnzB,
+    const cuDoubleComplex *csrSortedValB, const int *csrSortedRowPtrB,
+    const int *csrSortedColIndB, const cusparseMatDescr_t descrC,
+    cuDoubleComplex *csrSortedValC, int *csrSortedRowPtrC,
+    int *csrSortedColIndC, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cuDoubleComplex *,
+      const cusparseMatDescr_t, int, const cuDoubleComplex *, const int *,
+      const int *, const cuDoubleComplex *, const cusparseMatDescr_t, int,
+      const cuDoubleComplex *, const int *, const int *,
+      const cusparseMatDescr_t, cuDoubleComplex *, int *, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrgeam2");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB, csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBuffer);
+  return func_ptr(handle, m, n, alpha, descrA, nnzA, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA, beta, descrB, nnzB,
+                  csrSortedValB, csrSortedRowPtrB, csrSortedColIndB, descrC,
+                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsrcolor(cusparseHandle_t handle,
-                                               int m,
-                                               int nnz,
-                                               const cusparseMatDescr_t descrA,
-                                               const float *csrSortedValA,
-                                               const int *csrSortedRowPtrA,
-                                               const int *csrSortedColIndA,
-                                               const float *fractionToColor,
-                                               int *ncolors,
-                                               int *coloring,
-                                               int *reordering,
-                                               const cusparseColorInfo_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, const float *, int *, int *, int *, const cusparseColorInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseScsrcolor(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    const float *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, const float *fractionToColor, int *ncolors,
+    int *coloring, int *reordering, const cusparseColorInfo_t info) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *,
+      const int *, const int *, const float *, int *, int *, int *,
+      const cusparseColorInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsrcolor");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, fractionToColor, ncolors, coloring, reordering, info);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, fractionToColor, ncolors, coloring,
+                  reordering, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsrcolor(cusparseHandle_t handle,
-                                               int m,
-                                               int nnz,
-                                               const cusparseMatDescr_t descrA,
-                                               const double *csrSortedValA,
-                                               const int *csrSortedRowPtrA,
-                                               const int *csrSortedColIndA,
-                                               const double *fractionToColor,
-                                               int *ncolors,
-                                               int *coloring,
-                                               int *reordering,
-                                               const cusparseColorInfo_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, const double *, int *, int *, int *, const cusparseColorInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseDcsrcolor(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    const double *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, const double *fractionToColor, int *ncolors,
+    int *coloring, int *reordering, const cusparseColorInfo_t info) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *,
+      const int *, const int *, const double *, int *, int *, int *,
+      const cusparseColorInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsrcolor");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, fractionToColor, ncolors, coloring, reordering, info);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, fractionToColor, ncolors, coloring,
+                  reordering, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsrcolor(cusparseHandle_t handle,
-                                               int m,
-                                               int nnz,
-                                               const cusparseMatDescr_t descrA,
-                                               const cuComplex *csrSortedValA,
-                                               const int *csrSortedRowPtrA,
-                                               const int *csrSortedColIndA,
-                                               const float *fractionToColor,
-                                               int *ncolors,
-                                               int *coloring,
-                                               int *reordering,
-                                               const cusparseColorInfo_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, const float *, int *, int *, int *, const cusparseColorInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseCcsrcolor(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    const cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, const float *fractionToColor, int *ncolors,
+    int *coloring, int *reordering, const cusparseColorInfo_t info) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *,
+      const int *, const int *, const float *, int *, int *, int *,
+      const cusparseColorInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsrcolor");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, fractionToColor, ncolors, coloring, reordering, info);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, fractionToColor, ncolors, coloring,
+                  reordering, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsrcolor(cusparseHandle_t handle,
-                                               int m,
-                                               int nnz,
-                                               const cusparseMatDescr_t descrA,
-                                               const cuDoubleComplex *csrSortedValA,
-                                               const int *csrSortedRowPtrA,
-                                               const int *csrSortedColIndA,
-                                               const double *fractionToColor,
-                                               int *ncolors,
-                                               int *coloring,
-                                               int *reordering,
-                                               const cusparseColorInfo_t info) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, const double *, int *, int *, int *, const cusparseColorInfo_t);
+cusparseStatus_t CUSPARSEAPI cusparseZcsrcolor(
+    cusparseHandle_t handle, int m, int nnz, const cusparseMatDescr_t descrA,
+    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, const double *fractionToColor, int *ncolors,
+    int *coloring, int *reordering, const cusparseColorInfo_t info) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t,
+      const cuDoubleComplex *, const int *, const int *, const double *, int *,
+      int *, int *, const cusparseColorInfo_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsrcolor");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, fractionToColor, ncolors, coloring, reordering, info);
+  return func_ptr(handle, m, nnz, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, fractionToColor, ncolors, coloring,
+                  reordering, info);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSnnz(cusparseHandle_t handle,
-                                          cusparseDirection_t dirA,
-                                          int m,
-                                          int n,
-                                          const cusparseMatDescr_t  descrA,
-                                          const float *A,
-                                          int lda,
-                                          int *nnzPerRowCol,
-                                          int *nnzTotalDevHostPtr) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const float *, int, int *, int *);
+cusparseStatus_t CUSPARSEAPI
+cusparseSnnz(cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
+             const cusparseMatDescr_t descrA, const float *A, int lda,
+             int *nnzPerRowCol, int *nnzTotalDevHostPtr) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const float *, int, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSnnz");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, A, lda, nnzPerRowCol, nnzTotalDevHostPtr);
+  return func_ptr(handle, dirA, m, n, descrA, A, lda, nnzPerRowCol,
+                  nnzTotalDevHostPtr);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDnnz(cusparseHandle_t handle,
-                                          cusparseDirection_t dirA,
-                                          int m,
-                                          int n,
-                                          const cusparseMatDescr_t  descrA,
-                                          const double *A,
-                                          int lda,
-                                          int *nnzPerRowCol,
-                                          int *nnzTotalDevHostPtr) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const double *, int, int *, int *);
+cusparseStatus_t CUSPARSEAPI
+cusparseDnnz(cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
+             const cusparseMatDescr_t descrA, const double *A, int lda,
+             int *nnzPerRowCol, int *nnzTotalDevHostPtr) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const double *, int, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDnnz");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, A, lda, nnzPerRowCol, nnzTotalDevHostPtr);
+  return func_ptr(handle, dirA, m, n, descrA, A, lda, nnzPerRowCol,
+                  nnzTotalDevHostPtr);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCnnz(cusparseHandle_t handle,
-                                          cusparseDirection_t dirA,
-                                          int m,
-                                          int n,
-                                          const cusparseMatDescr_t  descrA,
-                                          const cuComplex *A,
-                                          int lda,
-                                          int *nnzPerRowCol,
-                                          int *nnzTotalDevHostPtr) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuComplex *, int, int *, int *);
+cusparseStatus_t CUSPARSEAPI
+cusparseCnnz(cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
+             const cusparseMatDescr_t descrA, const cuComplex *A, int lda,
+             int *nnzPerRowCol, int *nnzTotalDevHostPtr) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const cuComplex *, int, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCnnz");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, A, lda, nnzPerRowCol, nnzTotalDevHostPtr);
+  return func_ptr(handle, dirA, m, n, descrA, A, lda, nnzPerRowCol,
+                  nnzTotalDevHostPtr);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZnnz(cusparseHandle_t handle,
-                                          cusparseDirection_t dirA,
-                                          int m,
-                                          int n,
-                                          const cusparseMatDescr_t  descrA,
-                                          const cuDoubleComplex *A,
-                                          int lda,
-                                          int *nnzPerRowCol,
-                                          int *nnzTotalDevHostPtr) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, int, int *, int *);
+cusparseStatus_t CUSPARSEAPI
+cusparseZnnz(cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
+             const cusparseMatDescr_t descrA, const cuDoubleComplex *A, int lda,
+             int *nnzPerRowCol, int *nnzTotalDevHostPtr) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const cuDoubleComplex *, int, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZnnz");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, A, lda, nnzPerRowCol, nnzTotalDevHostPtr);
+  return func_ptr(handle, dirA, m, n, descrA, A, lda, nnzPerRowCol,
+                  nnzTotalDevHostPtr);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSnnz_compress(cusparseHandle_t handle,
-                                          int m,
-                                          const cusparseMatDescr_t descr,
-                                          const float *csrSortedValA,
-                                          const int *csrSortedRowPtrA,
-                                          int *nnzPerRow,
-                                          int *nnzC,
-                                          float tol) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cusparseMatDescr_t, const float *, const int *, int *, int *, float);
+cusparseStatus_t CUSPARSEAPI cusparseSnnz_compress(
+    cusparseHandle_t handle, int m, const cusparseMatDescr_t descr,
+    const float *csrSortedValA, const int *csrSortedRowPtrA, int *nnzPerRow,
+    int *nnzC, float tol) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const cusparseMatDescr_t, const float *,
+      const int *, int *, int *, float);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSnnz_compress");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, descr, csrSortedValA, csrSortedRowPtrA, nnzPerRow, nnzC, tol);
+  return func_ptr(handle, m, descr, csrSortedValA, csrSortedRowPtrA, nnzPerRow,
+                  nnzC, tol);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDnnz_compress(cusparseHandle_t handle,
-                                          int m,
-                                          const cusparseMatDescr_t descr,
-                                          const double *csrSortedValA,
-                                          const int *csrSortedRowPtrA,
-                                          int *nnzPerRow,
-                                          int *nnzC,
-                                          double tol) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cusparseMatDescr_t, const double *, const int *, int *, int *, double);
+cusparseStatus_t CUSPARSEAPI cusparseDnnz_compress(
+    cusparseHandle_t handle, int m, const cusparseMatDescr_t descr,
+    const double *csrSortedValA, const int *csrSortedRowPtrA, int *nnzPerRow,
+    int *nnzC, double tol) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const cusparseMatDescr_t, const double *,
+      const int *, int *, int *, double);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDnnz_compress");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, descr, csrSortedValA, csrSortedRowPtrA, nnzPerRow, nnzC, tol);
+  return func_ptr(handle, m, descr, csrSortedValA, csrSortedRowPtrA, nnzPerRow,
+                  nnzC, tol);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCnnz_compress(cusparseHandle_t handle,
-                                          int m,
-                                          const cusparseMatDescr_t descr,
-                                          const cuComplex *csrSortedValA,
-                                          const int *csrSortedRowPtrA,
-                                          int *nnzPerRow,
-                                          int *nnzC,
-                                          cuComplex tol) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cusparseMatDescr_t, const cuComplex *, const int *, int *, int *, cuComplex);
+cusparseStatus_t CUSPARSEAPI cusparseCnnz_compress(
+    cusparseHandle_t handle, int m, const cusparseMatDescr_t descr,
+    const cuComplex *csrSortedValA, const int *csrSortedRowPtrA, int *nnzPerRow,
+    int *nnzC, cuComplex tol) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const cusparseMatDescr_t, const cuComplex *,
+      const int *, int *, int *, cuComplex);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCnnz_compress");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, descr, csrSortedValA, csrSortedRowPtrA, nnzPerRow, nnzC, tol);
+  return func_ptr(handle, m, descr, csrSortedValA, csrSortedRowPtrA, nnzPerRow,
+                  nnzC, tol);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZnnz_compress(cusparseHandle_t handle,
-                                          int m,
-                                          const cusparseMatDescr_t descr,
-                                          const cuDoubleComplex *csrSortedValA,
-                                          const int *csrSortedRowPtrA,
-                                          int *nnzPerRow,
-                                          int *nnzC,
-                                          cuDoubleComplex tol) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, int *, int *, cuDoubleComplex);
+cusparseStatus_t CUSPARSEAPI cusparseZnnz_compress(
+    cusparseHandle_t handle, int m, const cusparseMatDescr_t descr,
+    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    int *nnzPerRow, int *nnzC, cuDoubleComplex tol) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, const cusparseMatDescr_t, const cuDoubleComplex *,
+      const int *, int *, int *, cuDoubleComplex);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZnnz_compress");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, descr, csrSortedValA, csrSortedRowPtrA, nnzPerRow, nnzC, tol);
+  return func_ptr(handle, m, descr, csrSortedValA, csrSortedRowPtrA, nnzPerRow,
+                  nnzC, tol);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsr2csr_compress(cusparseHandle_t handle,
-                                                      int m,
-                                                      int n,
-                                                      const cusparseMatDescr_t descrA,
-                                                      const float *csrSortedValA,
-                                                      const int *csrSortedColIndA,
-                                                      const int *csrSortedRowPtrA,
-                                                      int nnzA,
-                                                      const int *nnzPerRow,
-                                                      float *csrSortedValC,
-                                                      int *csrSortedColIndC,
-                                                      int *csrSortedRowPtrC,
-                                                      float tol) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, int, const int *, float *, int *, int *, float);
+cusparseStatus_t CUSPARSEAPI cusparseScsr2csr_compress(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    const float *csrSortedValA, const int *csrSortedColIndA,
+    const int *csrSortedRowPtrA, int nnzA, const int *nnzPerRow,
+    float *csrSortedValC, int *csrSortedColIndC, int *csrSortedRowPtrC,
+    float tol) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *,
+      const int *, const int *, int, const int *, float *, int *, int *, float);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsr2csr_compress");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedColIndA, csrSortedRowPtrA, nnzA, nnzPerRow, csrSortedValC, csrSortedColIndC, csrSortedRowPtrC, tol);
+  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedColIndA,
+                  csrSortedRowPtrA, nnzA, nnzPerRow, csrSortedValC,
+                  csrSortedColIndC, csrSortedRowPtrC, tol);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsr2csr_compress(cusparseHandle_t handle,
-                                                      int m,
-                                                      int n,
-                                                      const cusparseMatDescr_t descrA,
-                                                      const double *csrSortedValA,
-                                                      const int *csrSortedColIndA,
-                                                      const int * csrSortedRowPtrA,
-                                                      int  nnzA,
-                                                      const int *nnzPerRow,
-                                                      double *csrSortedValC,
-                                                      int *csrSortedColIndC,
-                                                      int *csrSortedRowPtrC,
-                                                      double tol) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, int, const int *, double *, int *, int *, double);
+cusparseStatus_t CUSPARSEAPI cusparseDcsr2csr_compress(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    const double *csrSortedValA, const int *csrSortedColIndA,
+    const int *csrSortedRowPtrA, int nnzA, const int *nnzPerRow,
+    double *csrSortedValC, int *csrSortedColIndC, int *csrSortedRowPtrC,
+    double tol) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *,
+      const int *, const int *, int, const int *, double *, int *, int *,
+      double);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsr2csr_compress");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedColIndA, csrSortedRowPtrA, nnzA, nnzPerRow, csrSortedValC, csrSortedColIndC, csrSortedRowPtrC, tol);
+  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedColIndA,
+                  csrSortedRowPtrA, nnzA, nnzPerRow, csrSortedValC,
+                  csrSortedColIndC, csrSortedRowPtrC, tol);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsr2csr_compress(cusparseHandle_t handle,
-                                                        int m,
-                                                        int n,
-                                                        const cusparseMatDescr_t descrA,
-                                                        const cuComplex *csrSortedValA,
-                                                        const int *csrSortedColIndA,
-                                                        const int * csrSortedRowPtrA,
-                                                        int nnzA,
-                                                        const int *nnzPerRow,
-                                                        cuComplex *csrSortedValC,
-                                                        int *csrSortedColIndC,
-                                                        int *csrSortedRowPtrC,
-                                                        cuComplex tol) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, int, const int *, cuComplex *, int *, int *, cuComplex);
+cusparseStatus_t CUSPARSEAPI cusparseCcsr2csr_compress(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    const cuComplex *csrSortedValA, const int *csrSortedColIndA,
+    const int *csrSortedRowPtrA, int nnzA, const int *nnzPerRow,
+    cuComplex *csrSortedValC, int *csrSortedColIndC, int *csrSortedRowPtrC,
+    cuComplex tol) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *,
+      const int *, const int *, int, const int *, cuComplex *, int *, int *,
+      cuComplex);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsr2csr_compress");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedColIndA, csrSortedRowPtrA, nnzA, nnzPerRow, csrSortedValC, csrSortedColIndC, csrSortedRowPtrC, tol);
+  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedColIndA,
+                  csrSortedRowPtrA, nnzA, nnzPerRow, csrSortedValC,
+                  csrSortedColIndC, csrSortedRowPtrC, tol);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsr2csr_compress(cusparseHandle_t handle,
-                                                      int m,
-                                                      int n,
-                                                      const cusparseMatDescr_t descrA,
-                                                      const cuDoubleComplex *csrSortedValA,
-                                                      const int *csrSortedColIndA,
-                                                      const int * csrSortedRowPtrA,
-                                                      int  nnzA,
-                                                      const int *nnzPerRow,
-                                                      cuDoubleComplex *csrSortedValC,
-                                                      int *csrSortedColIndC,
-                                                      int *csrSortedRowPtrC,
-                                                      cuDoubleComplex tol) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, int, const int *, cuDoubleComplex *, int *, int *, cuDoubleComplex);
+cusparseStatus_t CUSPARSEAPI cusparseZcsr2csr_compress(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    const cuDoubleComplex *csrSortedValA, const int *csrSortedColIndA,
+    const int *csrSortedRowPtrA, int nnzA, const int *nnzPerRow,
+    cuDoubleComplex *csrSortedValC, int *csrSortedColIndC,
+    int *csrSortedRowPtrC, cuDoubleComplex tol) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t,
+      const cuDoubleComplex *, const int *, const int *, int, const int *,
+      cuDoubleComplex *, int *, int *, cuDoubleComplex);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsr2csr_compress");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedColIndA, csrSortedRowPtrA, nnzA, nnzPerRow, csrSortedValC, csrSortedColIndC, csrSortedRowPtrC, tol);
+  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedColIndA,
+                  csrSortedRowPtrA, nnzA, nnzPerRow, csrSortedValC,
+                  csrSortedColIndC, csrSortedRowPtrC, tol);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSdense2csr(cusparseHandle_t handle,
-                                                int m,
-                                                int n,
-                                                const cusparseMatDescr_t descrA,
-                                                const float *A,
-                                                int lda,
-                                                const int *nnzPerRow,
-                                                float *csrSortedValA,
-                                                int *csrSortedRowPtrA,
-                                                int *csrSortedColIndA) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *, int, const int *, float *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseSdense2csr(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    const float *A, int lda, const int *nnzPerRow, float *csrSortedValA,
+    int *csrSortedRowPtrA, int *csrSortedColIndA) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *, int,
+      const int *, float *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSdense2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA);
+  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDdense2csr(cusparseHandle_t handle,
-                                                int m,
-                                                int n,
-                                                const cusparseMatDescr_t descrA,
-                                                const double *A,
-                                                int lda,
-                                                const int *nnzPerRow,
-                                                double *csrSortedValA,
-                                                int *csrSortedRowPtrA,
-                                                int *csrSortedColIndA) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *, int, const int *, double *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDdense2csr(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    const double *A, int lda, const int *nnzPerRow, double *csrSortedValA,
+    int *csrSortedRowPtrA, int *csrSortedColIndA) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *, int,
+      const int *, double *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDdense2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA);
+  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCdense2csr(cusparseHandle_t handle,
-                                                int m,
-                                                int n,
-                                                const cusparseMatDescr_t descrA,
-                                                const cuComplex *A,
-                                                int lda,
-                                                const int *nnzPerRow,
-                                                cuComplex *csrSortedValA,
-                                                int *csrSortedRowPtrA,
-                                                int *csrSortedColIndA) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *, int, const int *, cuComplex *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCdense2csr(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    const cuComplex *A, int lda, const int *nnzPerRow, cuComplex *csrSortedValA,
+    int *csrSortedRowPtrA, int *csrSortedColIndA) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *,
+      int, const int *, cuComplex *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCdense2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA);
+  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZdense2csr(cusparseHandle_t handle,
-                                                int m,
-                                                int n,
-                                                const cusparseMatDescr_t descrA,
-                                                const cuDoubleComplex *A,
-                                                int lda,
-                                                const int *nnzPerRow,
-                                                cuDoubleComplex *csrSortedValA,
-                                                int *csrSortedRowPtrA,
-                                                int *csrSortedColIndA) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, int, const int *, cuDoubleComplex *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZdense2csr(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    const cuDoubleComplex *A, int lda, const int *nnzPerRow,
+    cuDoubleComplex *csrSortedValA, int *csrSortedRowPtrA,
+    int *csrSortedColIndA) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t,
+      const cuDoubleComplex *, int, const int *, cuDoubleComplex *, int *,
+      int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZdense2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA);
+  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, csrSortedValA,
+                  csrSortedRowPtrA, csrSortedColIndA);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsr2dense(cusparseHandle_t handle,
-                                                int m,
-                                                int n,
-                                                const cusparseMatDescr_t descrA,
-                                                const float *csrSortedValA,
-                                                const int *csrSortedRowPtrA,
-                                                const int *csrSortedColIndA,
-                                                float *A,
-                                                int lda) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, float *, int);
+cusparseStatus_t CUSPARSEAPI cusparseScsr2dense(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    const float *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, float *A, int lda) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *,
+      const int *, const int *, float *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsr2dense");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, A, lda);
+  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, A, lda);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsr2dense(cusparseHandle_t handle,
-                                                int m,
-                                                int n,
-                                                const cusparseMatDescr_t descrA,
-                                                const double *csrSortedValA,
-                                                const int *csrSortedRowPtrA,
-                                                const int *csrSortedColIndA,
-                                                double *A,
-                                                int lda) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, double *, int);
+cusparseStatus_t CUSPARSEAPI cusparseDcsr2dense(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    const double *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, double *A, int lda) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *,
+      const int *, const int *, double *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsr2dense");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, A, lda);
+  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, A, lda);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsr2dense(cusparseHandle_t handle,
-                                                int m,
-                                                int n,
-                                                const cusparseMatDescr_t descrA,
-                                                const cuComplex *csrSortedValA,
-                                                const int *csrSortedRowPtrA,
-                                                const int *csrSortedColIndA,
-                                                cuComplex *A,
-                                                int lda) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, cuComplex *, int);
+cusparseStatus_t CUSPARSEAPI cusparseCcsr2dense(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    const cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, cuComplex *A, int lda) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *,
+      const int *, const int *, cuComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsr2dense");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, A, lda);
+  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, A, lda);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsr2dense(cusparseHandle_t handle,
-                                                int m,
-                                                int n,
-                                                const cusparseMatDescr_t descrA,
-                                                const cuDoubleComplex *csrSortedValA,
-                                                const int *csrSortedRowPtrA,
-                                                const int *csrSortedColIndA,
-                                                cuDoubleComplex *A,
-                                                int lda) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, cuDoubleComplex *, int);
+cusparseStatus_t CUSPARSEAPI cusparseZcsr2dense(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, cuDoubleComplex *A, int lda) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t,
+      const cuDoubleComplex *, const int *, const int *, cuDoubleComplex *,
+      int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsr2dense");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, A, lda);
+  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, A, lda);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSdense2csc(cusparseHandle_t handle,
-                                                int m,
-                                                int n,
-                                                const cusparseMatDescr_t descrA,
-                                                const float *A,
-                                                int lda,
-                                                const int *nnzPerCol,
-                                                float *cscSortedValA,
-                                                int *cscSortedRowIndA,
-                                                int *cscSortedColPtrA) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *, int, const int *, float *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseSdense2csc(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    const float *A, int lda, const int *nnzPerCol, float *cscSortedValA,
+    int *cscSortedRowIndA, int *cscSortedColPtrA) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *, int,
+      const int *, float *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSdense2csc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, A, lda, nnzPerCol, cscSortedValA, cscSortedRowIndA, cscSortedColPtrA);
+  return func_ptr(handle, m, n, descrA, A, lda, nnzPerCol, cscSortedValA,
+                  cscSortedRowIndA, cscSortedColPtrA);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDdense2csc(cusparseHandle_t handle,
-                                                int m,
-                                                int n,
-                                                const cusparseMatDescr_t descrA,
-                                                const double *A,
-                                                int lda,
-                                                const int *nnzPerCol,
-                                                double *cscSortedValA,
-                                                int *cscSortedRowIndA,
-                                                int *cscSortedColPtrA) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *, int, const int *, double *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDdense2csc(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    const double *A, int lda, const int *nnzPerCol, double *cscSortedValA,
+    int *cscSortedRowIndA, int *cscSortedColPtrA) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *, int,
+      const int *, double *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDdense2csc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, A, lda, nnzPerCol, cscSortedValA, cscSortedRowIndA, cscSortedColPtrA);
+  return func_ptr(handle, m, n, descrA, A, lda, nnzPerCol, cscSortedValA,
+                  cscSortedRowIndA, cscSortedColPtrA);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCdense2csc(cusparseHandle_t handle,
-                                                int m,
-                                                int n,
-                                                const cusparseMatDescr_t descrA,
-                                                const cuComplex *A,
-                                                int lda,
-                                                const int *nnzPerCol,
-                                                cuComplex *cscSortedValA,
-                                                int *cscSortedRowIndA,
-                                                int *cscSortedColPtrA) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *, int, const int *, cuComplex *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCdense2csc(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    const cuComplex *A, int lda, const int *nnzPerCol, cuComplex *cscSortedValA,
+    int *cscSortedRowIndA, int *cscSortedColPtrA) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *,
+      int, const int *, cuComplex *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCdense2csc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, A, lda, nnzPerCol, cscSortedValA, cscSortedRowIndA, cscSortedColPtrA);
+  return func_ptr(handle, m, n, descrA, A, lda, nnzPerCol, cscSortedValA,
+                  cscSortedRowIndA, cscSortedColPtrA);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZdense2csc(cusparseHandle_t handle,
-                                                int m,
-                                                int n,
-                                                const cusparseMatDescr_t descrA,
-                                                const cuDoubleComplex *A,
-                                                int lda,
-                                                const int *nnzPerCol,
-                                                cuDoubleComplex *cscSortedValA,
-                                                int *cscSortedRowIndA,
-                                                int *cscSortedColPtrA) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, int, const int *, cuDoubleComplex *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZdense2csc(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    const cuDoubleComplex *A, int lda, const int *nnzPerCol,
+    cuDoubleComplex *cscSortedValA, int *cscSortedRowIndA,
+    int *cscSortedColPtrA) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t,
+      const cuDoubleComplex *, int, const int *, cuDoubleComplex *, int *,
+      int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZdense2csc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, A, lda, nnzPerCol, cscSortedValA, cscSortedRowIndA, cscSortedColPtrA);
+  return func_ptr(handle, m, n, descrA, A, lda, nnzPerCol, cscSortedValA,
+                  cscSortedRowIndA, cscSortedColPtrA);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsc2dense(cusparseHandle_t handle,
-                                                int m,
-                                                int n,
-                                                const cusparseMatDescr_t descrA,
-                                                const float *cscSortedValA,
-                                                const int *cscSortedRowIndA,
-                                                const int *cscSortedColPtrA,
-                                                float *A,
-                                                int lda) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, float *, int);
+cusparseStatus_t CUSPARSEAPI cusparseScsc2dense(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    const float *cscSortedValA, const int *cscSortedRowIndA,
+    const int *cscSortedColPtrA, float *A, int lda) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *,
+      const int *, const int *, float *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsc2dense");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA, cscSortedColPtrA, A, lda);
+  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA,
+                  cscSortedColPtrA, A, lda);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsc2dense(cusparseHandle_t handle,
-                                                int m,
-                                                int n,
-                                                const cusparseMatDescr_t descrA,
-                                                const double *cscSortedValA,
-                                                const int *cscSortedRowIndA,
-                                                const int *cscSortedColPtrA,
-                                                double *A,
-                                                int lda) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, double *, int);
+cusparseStatus_t CUSPARSEAPI cusparseDcsc2dense(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    const double *cscSortedValA, const int *cscSortedRowIndA,
+    const int *cscSortedColPtrA, double *A, int lda) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *,
+      const int *, const int *, double *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsc2dense");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA, cscSortedColPtrA, A, lda);
+  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA,
+                  cscSortedColPtrA, A, lda);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsc2dense(cusparseHandle_t handle,
-                                                int m,
-                                                int n,
-                                                const cusparseMatDescr_t descrA,
-                                                const cuComplex *cscSortedValA,
-                                                const int *cscSortedRowIndA,
-                                                const int *cscSortedColPtrA,
-                                                cuComplex *A,
-                                                int lda) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, cuComplex *, int);
+cusparseStatus_t CUSPARSEAPI cusparseCcsc2dense(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    const cuComplex *cscSortedValA, const int *cscSortedRowIndA,
+    const int *cscSortedColPtrA, cuComplex *A, int lda) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *,
+      const int *, const int *, cuComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsc2dense");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA, cscSortedColPtrA, A, lda);
+  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA,
+                  cscSortedColPtrA, A, lda);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsc2dense(cusparseHandle_t handle,
-                                                int m,
-                                                int n,
-                                                const cusparseMatDescr_t descrA,
-                                                const cuDoubleComplex *cscSortedValA,
-                                                const int *cscSortedRowIndA,
-                                                const int *cscSortedColPtrA,
-                                                cuDoubleComplex *A,
-                                                int lda) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, cuDoubleComplex *, int);
+cusparseStatus_t CUSPARSEAPI cusparseZcsc2dense(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    const cuDoubleComplex *cscSortedValA, const int *cscSortedRowIndA,
+    const int *cscSortedColPtrA, cuDoubleComplex *A, int lda) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t,
+      const cuDoubleComplex *, const int *, const int *, cuDoubleComplex *,
+      int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsc2dense");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA, cscSortedColPtrA, A, lda);
+  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA,
+                  cscSortedColPtrA, A, lda);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseXcoo2csr(cusparseHandle_t handle,
-                                              const int *cooRowInd,
-                                              int nnz,
-                                              int m,
-                                              int *csrSortedRowPtr,
+                                              const int *cooRowInd, int nnz,
+                                              int m, int *csrSortedRowPtr,
                                               cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, const int *, int, int, int *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, const int *, int, int, int *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcoo2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, cooRowInd, nnz, m, csrSortedRowPtr, idxBase);
@@ -6677,179 +5805,159 @@ cusparseStatus_t CUSPARSEAPI cusparseXcoo2csr(cusparseHandle_t handle,
 
 cusparseStatus_t CUSPARSEAPI cusparseXcsr2coo(cusparseHandle_t handle,
                                               const int *csrSortedRowPtr,
-                                              int nnz,
-                                              int m,
-                                              int *cooRowInd,
+                                              int nnz, int m, int *cooRowInd,
                                               cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, const int *, int, int, int *, cusparseIndexBase_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, const int *, int, int, int *, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcsr2coo");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, csrSortedRowPtr, nnz, m, cooRowInd, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCsr2cscEx(cusparseHandle_t handle,
-                                              int m,
-                                              int n,
-                                              int nnz,
-                                              const void  *csrSortedVal,
-                                              cudaDataType csrSortedValtype,
-                                              const int *csrSortedRowPtr,
-                                              const int *csrSortedColInd,
-                                              void *cscSortedVal,
-                                              cudaDataType cscSortedValtype,
-                                              int *cscSortedRowInd,
-                                              int *cscSortedColPtr,
-                                              cusparseAction_t copyValues,
-                                              cusparseIndexBase_t idxBase,
-                                              cudaDataType executiontype) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const void  *, cudaDataType, const int *, const int *, void *, cudaDataType, int *, int *, cusparseAction_t, cusparseIndexBase_t, cudaDataType);
+cusparseStatus_t CUSPARSEAPI cusparseCsr2cscEx(
+    cusparseHandle_t handle, int m, int n, int nnz, const void *csrSortedVal,
+    cudaDataType csrSortedValtype, const int *csrSortedRowPtr,
+    const int *csrSortedColInd, void *cscSortedVal,
+    cudaDataType cscSortedValtype, int *cscSortedRowInd, int *cscSortedColPtr,
+    cusparseAction_t copyValues, cusparseIndexBase_t idxBase,
+    cudaDataType executiontype) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const void *, cudaDataType, const int *,
+      const int *, void *, cudaDataType, int *, int *, cusparseAction_t,
+      cusparseIndexBase_t, cudaDataType);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCsr2cscEx");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, csrSortedVal, csrSortedValtype, csrSortedRowPtr, csrSortedColInd, cscSortedVal, cscSortedValtype, cscSortedRowInd, cscSortedColPtr, copyValues, idxBase, executiontype);
+  return func_ptr(handle, m, n, nnz, csrSortedVal, csrSortedValtype,
+                  csrSortedRowPtr, csrSortedColInd, cscSortedVal,
+                  cscSortedValtype, cscSortedRowInd, cscSortedColPtr,
+                  copyValues, idxBase, executiontype);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsr2csc(cusparseHandle_t handle,
-                                              int m,
-                                              int n,
-                                              int nnz,
-                                              const float  *csrSortedVal,
-                                              const int *csrSortedRowPtr,
-                                              const int *csrSortedColInd,
-                                              float *cscSortedVal,
-                                              int *cscSortedRowInd,
-                                              int *cscSortedColPtr,
-                                              cusparseAction_t copyValues,
-                                              cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const float  *, const int *, const int *, float *, int *, int *, cusparseAction_t, cusparseIndexBase_t);
+cusparseStatus_t CUSPARSEAPI cusparseScsr2csc(
+    cusparseHandle_t handle, int m, int n, int nnz, const float *csrSortedVal,
+    const int *csrSortedRowPtr, const int *csrSortedColInd, float *cscSortedVal,
+    int *cscSortedRowInd, int *cscSortedColPtr, cusparseAction_t copyValues,
+    cusparseIndexBase_t idxBase) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const float *, const int *, const int *,
+      float *, int *, int *, cusparseAction_t, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsr2csc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, csrSortedVal, csrSortedRowPtr, csrSortedColInd, cscSortedVal, cscSortedRowInd, cscSortedColPtr, copyValues, idxBase);
+  return func_ptr(handle, m, n, nnz, csrSortedVal, csrSortedRowPtr,
+                  csrSortedColInd, cscSortedVal, cscSortedRowInd,
+                  cscSortedColPtr, copyValues, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsr2csc(cusparseHandle_t handle,
-                                              int m,
-                                              int n,
-                                              int nnz,
-                                              const double  *csrSortedVal,
-                                              const int *csrSortedRowPtr,
-                                              const int *csrSortedColInd,
-                                              double *cscSortedVal,
-                                              int *cscSortedRowInd,
-                                              int *cscSortedColPtr,
-                                              cusparseAction_t copyValues,
-                                              cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const double  *, const int *, const int *, double *, int *, int *, cusparseAction_t, cusparseIndexBase_t);
+cusparseStatus_t CUSPARSEAPI cusparseDcsr2csc(
+    cusparseHandle_t handle, int m, int n, int nnz, const double *csrSortedVal,
+    const int *csrSortedRowPtr, const int *csrSortedColInd,
+    double *cscSortedVal, int *cscSortedRowInd, int *cscSortedColPtr,
+    cusparseAction_t copyValues, cusparseIndexBase_t idxBase) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const double *, const int *, const int *,
+      double *, int *, int *, cusparseAction_t, cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsr2csc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, csrSortedVal, csrSortedRowPtr, csrSortedColInd, cscSortedVal, cscSortedRowInd, cscSortedColPtr, copyValues, idxBase);
+  return func_ptr(handle, m, n, nnz, csrSortedVal, csrSortedRowPtr,
+                  csrSortedColInd, cscSortedVal, cscSortedRowInd,
+                  cscSortedColPtr, copyValues, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsr2csc(cusparseHandle_t handle,
-                                              int m,
-                                              int n,
-                                              int nnz,
-                                              const cuComplex  *csrSortedVal,
-                                              const int *csrSortedRowPtr,
-                                              const int *csrSortedColInd,
-                                              cuComplex *cscSortedVal,
-                                              int *cscSortedRowInd,
-                                              int *cscSortedColPtr,
-                                              cusparseAction_t copyValues,
-                                              cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cuComplex  *, const int *, const int *, cuComplex *, int *, int *, cusparseAction_t, cusparseIndexBase_t);
+cusparseStatus_t CUSPARSEAPI
+cusparseCcsr2csc(cusparseHandle_t handle, int m, int n, int nnz,
+                 const cuComplex *csrSortedVal, const int *csrSortedRowPtr,
+                 const int *csrSortedColInd, cuComplex *cscSortedVal,
+                 int *cscSortedRowInd, int *cscSortedColPtr,
+                 cusparseAction_t copyValues, cusparseIndexBase_t idxBase) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cuComplex *, const int *,
+      const int *, cuComplex *, int *, int *, cusparseAction_t,
+      cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsr2csc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, csrSortedVal, csrSortedRowPtr, csrSortedColInd, cscSortedVal, cscSortedRowInd, cscSortedColPtr, copyValues, idxBase);
+  return func_ptr(handle, m, n, nnz, csrSortedVal, csrSortedRowPtr,
+                  csrSortedColInd, cscSortedVal, cscSortedRowInd,
+                  cscSortedColPtr, copyValues, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsr2csc(cusparseHandle_t handle,
-                                              int m,
-                                              int n,
-                                              int nnz,
-                                              const cuDoubleComplex *csrSortedVal,
-                                              const int *csrSortedRowPtr,
-                                              const int *csrSortedColInd,
-                                              cuDoubleComplex *cscSortedVal,
-                                              int *cscSortedRowInd,
-                                              int *cscSortedColPtr,
-                                              cusparseAction_t copyValues,
-                                              cusparseIndexBase_t idxBase) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cuDoubleComplex *, const int *, const int *, cuDoubleComplex *, int *, int *, cusparseAction_t, cusparseIndexBase_t);
+cusparseStatus_t CUSPARSEAPI cusparseZcsr2csc(
+    cusparseHandle_t handle, int m, int n, int nnz,
+    const cuDoubleComplex *csrSortedVal, const int *csrSortedRowPtr,
+    const int *csrSortedColInd, cuDoubleComplex *cscSortedVal,
+    int *cscSortedRowInd, int *cscSortedColPtr, cusparseAction_t copyValues,
+    cusparseIndexBase_t idxBase) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cuDoubleComplex *, const int *,
+      const int *, cuDoubleComplex *, int *, int *, cusparseAction_t,
+      cusparseIndexBase_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsr2csc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, csrSortedVal, csrSortedRowPtr, csrSortedColInd, cscSortedVal, cscSortedRowInd, cscSortedColPtr, copyValues, idxBase);
+  return func_ptr(handle, m, n, nnz, csrSortedVal, csrSortedRowPtr,
+                  csrSortedColInd, cscSortedVal, cscSortedRowInd,
+                  cscSortedColPtr, copyValues, idxBase);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSdense2hyb(cusparseHandle_t handle,
-                                                int m,
-                                                int n,
-                                                const cusparseMatDescr_t descrA,
-                                                const float *A,
-                                                int lda,
-                                                const int *nnzPerRow,
-                                                cusparseHybMat_t hybA,
-                                                int userEllWidth,
-                                                cusparseHybPartition_t partitionType) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *, int, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
+cusparseStatus_t CUSPARSEAPI cusparseSdense2hyb(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    const float *A, int lda, const int *nnzPerRow, cusparseHybMat_t hybA,
+    int userEllWidth, cusparseHybPartition_t partitionType) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *, int,
+      const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSdense2hyb");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, hybA, userEllWidth, partitionType);
+  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, hybA, userEllWidth,
+                  partitionType);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDdense2hyb(cusparseHandle_t handle,
-                                                int m,
-                                                int n,
-                                                const cusparseMatDescr_t descrA,
-                                                const double *A,
-                                                int lda,
-                                                const int *nnzPerRow,
-                                                cusparseHybMat_t hybA,
-                                                int userEllWidth,
-                                                cusparseHybPartition_t partitionType) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *, int, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
+cusparseStatus_t CUSPARSEAPI cusparseDdense2hyb(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    const double *A, int lda, const int *nnzPerRow, cusparseHybMat_t hybA,
+    int userEllWidth, cusparseHybPartition_t partitionType) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *, int,
+      const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDdense2hyb");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, hybA, userEllWidth, partitionType);
+  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, hybA, userEllWidth,
+                  partitionType);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCdense2hyb(cusparseHandle_t handle,
-                                                int m,
-                                                int n,
-                                                const cusparseMatDescr_t descrA,
-                                                const cuComplex *A,
-                                                int lda,
-                                                const int *nnzPerRow,
-                                                cusparseHybMat_t hybA,
-                                                int userEllWidth,
-                                                cusparseHybPartition_t partitionType) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *, int, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
+cusparseStatus_t CUSPARSEAPI cusparseCdense2hyb(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    const cuComplex *A, int lda, const int *nnzPerRow, cusparseHybMat_t hybA,
+    int userEllWidth, cusparseHybPartition_t partitionType) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *,
+      int, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCdense2hyb");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, hybA, userEllWidth, partitionType);
+  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, hybA, userEllWidth,
+                  partitionType);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZdense2hyb(cusparseHandle_t handle,
-                                                int m,
-                                                int n,
-                                                const cusparseMatDescr_t descrA,
-                                                const cuDoubleComplex *A,
-                                                int lda,
-                                                const int *nnzPerRow,
-                                                cusparseHybMat_t hybA,
-                                                int userEllWidth,
-                                                cusparseHybPartition_t partitionType) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, int, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
+cusparseStatus_t CUSPARSEAPI
+cusparseZdense2hyb(cusparseHandle_t handle, int m, int n,
+                   const cusparseMatDescr_t descrA, const cuDoubleComplex *A,
+                   int lda, const int *nnzPerRow, cusparseHybMat_t hybA,
+                   int userEllWidth, cusparseHybPartition_t partitionType) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t,
+      const cuDoubleComplex *, int, const int *, cusparseHybMat_t, int,
+      cusparseHybPartition_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZdense2hyb");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, hybA, userEllWidth, partitionType);
+  return func_ptr(handle, m, n, descrA, A, lda, nnzPerRow, hybA, userEllWidth,
+                  partitionType);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseShyb2dense(cusparseHandle_t handle,
                                                 const cusparseMatDescr_t descrA,
                                                 const cusparseHybMat_t hybA,
-                                                float *A,
-                                                int lda) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t, float *, int);
+                                                float *A, int lda) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t,
+      float *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseShyb2dense");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, descrA, hybA, A, lda);
@@ -6858,9 +5966,10 @@ cusparseStatus_t CUSPARSEAPI cusparseShyb2dense(cusparseHandle_t handle,
 cusparseStatus_t CUSPARSEAPI cusparseDhyb2dense(cusparseHandle_t handle,
                                                 const cusparseMatDescr_t descrA,
                                                 const cusparseHybMat_t hybA,
-                                                double *A,
-                                                int lda) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t, double *, int);
+                                                double *A, int lda) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t,
+      double *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDhyb2dense");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, descrA, hybA, A, lda);
@@ -6869,9 +5978,10 @@ cusparseStatus_t CUSPARSEAPI cusparseDhyb2dense(cusparseHandle_t handle,
 cusparseStatus_t CUSPARSEAPI cusparseChyb2dense(cusparseHandle_t handle,
                                                 const cusparseMatDescr_t descrA,
                                                 const cusparseHybMat_t hybA,
-                                                cuComplex *A,
-                                                int lda) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t, cuComplex *, int);
+                                                cuComplex *A, int lda) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t,
+      cuComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseChyb2dense");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, descrA, hybA, A, lda);
@@ -6880,76 +5990,70 @@ cusparseStatus_t CUSPARSEAPI cusparseChyb2dense(cusparseHandle_t handle,
 cusparseStatus_t CUSPARSEAPI cusparseZhyb2dense(cusparseHandle_t handle,
                                                 const cusparseMatDescr_t descrA,
                                                 const cusparseHybMat_t hybA,
-                                                cuDoubleComplex *A,
-                                                int lda) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t, cuDoubleComplex *, int);
+                                                cuDoubleComplex *A, int lda) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t,
+      cuDoubleComplex *, int);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZhyb2dense");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, descrA, hybA, A, lda);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsr2hyb(cusparseHandle_t handle,
-                                              int m,
-                                              int n,
-                                              const cusparseMatDescr_t descrA,
-                                              const float *csrSortedValA,
-                                              const int *csrSortedRowPtrA,
-                                              const int *csrSortedColIndA,
-                                              cusparseHybMat_t hybA,
-                                              int userEllWidth,
-                                              cusparseHybPartition_t partitionType) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
+cusparseStatus_t CUSPARSEAPI cusparseScsr2hyb(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    const float *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, cusparseHybMat_t hybA, int userEllWidth,
+    cusparseHybPartition_t partitionType) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *,
+      const int *, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsr2hyb");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, hybA, userEllWidth, partitionType);
+  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, hybA, userEllWidth, partitionType);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsr2hyb(cusparseHandle_t handle,
-                                              int m,
-                                              int n,
-                                              const cusparseMatDescr_t descrA,
-                                              const double *csrSortedValA,
-                                              const int *csrSortedRowPtrA,
-                                              const int *csrSortedColIndA,
-                                              cusparseHybMat_t hybA,
-                                              int userEllWidth,
-                                              cusparseHybPartition_t partitionType) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
+cusparseStatus_t CUSPARSEAPI cusparseDcsr2hyb(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    const double *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, cusparseHybMat_t hybA, int userEllWidth,
+    cusparseHybPartition_t partitionType) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *,
+      const int *, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsr2hyb");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, hybA, userEllWidth, partitionType);
+  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, hybA, userEllWidth, partitionType);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsr2hyb(cusparseHandle_t handle,
-                                              int m,
-                                              int n,
-                                              const cusparseMatDescr_t descrA,
-                                              const cuComplex *csrSortedValA,
-                                              const int *csrSortedRowPtrA,
-                                              const int *csrSortedColIndA,
-                                              cusparseHybMat_t hybA,
-                                              int userEllWidth,
-                                              cusparseHybPartition_t partitionType) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
+cusparseStatus_t CUSPARSEAPI cusparseCcsr2hyb(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    const cuComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, cusparseHybMat_t hybA, int userEllWidth,
+    cusparseHybPartition_t partitionType) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *,
+      const int *, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsr2hyb");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, hybA, userEllWidth, partitionType);
+  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, hybA, userEllWidth, partitionType);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsr2hyb(cusparseHandle_t handle,
-                                              int m,
-                                              int n,
-                                              const cusparseMatDescr_t descrA,
-                                              const cuDoubleComplex *csrSortedValA,
-                                              const int *csrSortedRowPtrA,
-                                              const int *csrSortedColIndA,
-                                              cusparseHybMat_t hybA,
-                                              int userEllWidth,
-                                              cusparseHybPartition_t partitionType) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
+cusparseStatus_t CUSPARSEAPI cusparseZcsr2hyb(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    const cuDoubleComplex *csrSortedValA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, cusparseHybMat_t hybA, int userEllWidth,
+    cusparseHybPartition_t partitionType) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t,
+      const cuDoubleComplex *, const int *, const int *, cusparseHybMat_t, int,
+      cusparseHybPartition_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsr2hyb");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, hybA, userEllWidth, partitionType);
+  return func_ptr(handle, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, hybA, userEllWidth, partitionType);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseShyb2csr(cusparseHandle_t handle,
@@ -6958,10 +6062,13 @@ cusparseStatus_t CUSPARSEAPI cusparseShyb2csr(cusparseHandle_t handle,
                                               float *csrSortedValA,
                                               int *csrSortedRowPtrA,
                                               int *csrSortedColIndA) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t, float *, int *, int *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t,
+      float *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseShyb2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, descrA, hybA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA);
+  return func_ptr(handle, descrA, hybA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDhyb2csr(cusparseHandle_t handle,
@@ -6970,10 +6077,13 @@ cusparseStatus_t CUSPARSEAPI cusparseDhyb2csr(cusparseHandle_t handle,
                                               double *csrSortedValA,
                                               int *csrSortedRowPtrA,
                                               int *csrSortedColIndA) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t, double *, int *, int *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t,
+      double *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDhyb2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, descrA, hybA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA);
+  return func_ptr(handle, descrA, hybA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseChyb2csr(cusparseHandle_t handle,
@@ -6982,10 +6092,13 @@ cusparseStatus_t CUSPARSEAPI cusparseChyb2csr(cusparseHandle_t handle,
                                               cuComplex *csrSortedValA,
                                               int *csrSortedRowPtrA,
                                               int *csrSortedColIndA) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t, cuComplex *, int *, int *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t,
+      cuComplex *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseChyb2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, descrA, hybA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA);
+  return func_ptr(handle, descrA, hybA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseZhyb2csr(cusparseHandle_t handle,
@@ -6994,74 +6107,70 @@ cusparseStatus_t CUSPARSEAPI cusparseZhyb2csr(cusparseHandle_t handle,
                                               cuDoubleComplex *csrSortedValA,
                                               int *csrSortedRowPtrA,
                                               int *csrSortedColIndA) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t, cuDoubleComplex *, int *, int *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t,
+      cuDoubleComplex *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZhyb2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, descrA, hybA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA);
+  return func_ptr(handle, descrA, hybA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsc2hyb(cusparseHandle_t handle,
-                                              int m,
-                                              int n,
-                                              const cusparseMatDescr_t descrA,
-                                              const float *cscSortedValA,
-                                              const int *cscSortedRowIndA,
-                                              const int *cscSortedColPtrA,
-                                              cusparseHybMat_t hybA,
-                                              int userEllWidth,
-                                              cusparseHybPartition_t partitionType) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
+cusparseStatus_t CUSPARSEAPI cusparseScsc2hyb(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    const float *cscSortedValA, const int *cscSortedRowIndA,
+    const int *cscSortedColPtrA, cusparseHybMat_t hybA, int userEllWidth,
+    cusparseHybPartition_t partitionType) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const float *,
+      const int *, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsc2hyb");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA, cscSortedColPtrA, hybA, userEllWidth, partitionType);
+  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA,
+                  cscSortedColPtrA, hybA, userEllWidth, partitionType);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsc2hyb(cusparseHandle_t handle,
-                                              int m,
-                                              int n,
-                                              const cusparseMatDescr_t descrA,
-                                              const double *cscSortedValA,
-                                              const int *cscSortedRowIndA,
-                                              const int *cscSortedColPtrA,
-                                              cusparseHybMat_t hybA,
-                                              int userEllWidth,
-                                              cusparseHybPartition_t partitionType) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
+cusparseStatus_t CUSPARSEAPI cusparseDcsc2hyb(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    const double *cscSortedValA, const int *cscSortedRowIndA,
+    const int *cscSortedColPtrA, cusparseHybMat_t hybA, int userEllWidth,
+    cusparseHybPartition_t partitionType) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const double *,
+      const int *, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsc2hyb");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA, cscSortedColPtrA, hybA, userEllWidth, partitionType);
+  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA,
+                  cscSortedColPtrA, hybA, userEllWidth, partitionType);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsc2hyb(cusparseHandle_t handle,
-                                              int m,
-                                              int n,
-                                              const cusparseMatDescr_t descrA,
-                                              const cuComplex *cscSortedValA,
-                                              const int *cscSortedRowIndA,
-                                              const int *cscSortedColPtrA,
-                                              cusparseHybMat_t hybA,
-                                              int userEllWidth,
-                                              cusparseHybPartition_t partitionType) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
+cusparseStatus_t CUSPARSEAPI cusparseCcsc2hyb(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    const cuComplex *cscSortedValA, const int *cscSortedRowIndA,
+    const int *cscSortedColPtrA, cusparseHybMat_t hybA, int userEllWidth,
+    cusparseHybPartition_t partitionType) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuComplex *,
+      const int *, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsc2hyb");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA, cscSortedColPtrA, hybA, userEllWidth, partitionType);
+  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA,
+                  cscSortedColPtrA, hybA, userEllWidth, partitionType);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsc2hyb(cusparseHandle_t handle,
-                                              int m,
-                                              int n,
-                                              const cusparseMatDescr_t descrA,
-                                              const cuDoubleComplex *cscSortedValA,
-                                              const int *cscSortedRowIndA,
-                                              const int *cscSortedColPtrA,
-                                              cusparseHybMat_t hybA,
-                                              int userEllWidth,
-                                              cusparseHybPartition_t partitionType) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, cusparseHybMat_t, int, cusparseHybPartition_t);
+cusparseStatus_t CUSPARSEAPI cusparseZcsc2hyb(
+    cusparseHandle_t handle, int m, int n, const cusparseMatDescr_t descrA,
+    const cuDoubleComplex *cscSortedValA, const int *cscSortedRowIndA,
+    const int *cscSortedColPtrA, cusparseHybMat_t hybA, int userEllWidth,
+    cusparseHybPartition_t partitionType) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const cusparseMatDescr_t,
+      const cuDoubleComplex *, const int *, const int *, cusparseHybMat_t, int,
+      cusparseHybPartition_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsc2hyb");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA, cscSortedColPtrA, hybA, userEllWidth, partitionType);
+  return func_ptr(handle, m, n, descrA, cscSortedValA, cscSortedRowIndA,
+                  cscSortedColPtrA, hybA, userEllWidth, partitionType);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseShyb2csc(cusparseHandle_t handle,
@@ -7070,10 +6179,13 @@ cusparseStatus_t CUSPARSEAPI cusparseShyb2csc(cusparseHandle_t handle,
                                               float *cscSortedVal,
                                               int *cscSortedRowInd,
                                               int *cscSortedColPtr) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t, float *, int *, int *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t,
+      float *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseShyb2csc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, descrA, hybA, cscSortedVal, cscSortedRowInd, cscSortedColPtr);
+  return func_ptr(handle, descrA, hybA, cscSortedVal, cscSortedRowInd,
+                  cscSortedColPtr);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDhyb2csc(cusparseHandle_t handle,
@@ -7082,10 +6194,13 @@ cusparseStatus_t CUSPARSEAPI cusparseDhyb2csc(cusparseHandle_t handle,
                                               double *cscSortedVal,
                                               int *cscSortedRowInd,
                                               int *cscSortedColPtr) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t, double *, int *, int *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t,
+      double *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDhyb2csc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, descrA, hybA, cscSortedVal, cscSortedRowInd, cscSortedColPtr);
+  return func_ptr(handle, descrA, hybA, cscSortedVal, cscSortedRowInd,
+                  cscSortedColPtr);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseChyb2csc(cusparseHandle_t handle,
@@ -7094,10 +6209,13 @@ cusparseStatus_t CUSPARSEAPI cusparseChyb2csc(cusparseHandle_t handle,
                                               cuComplex *cscSortedVal,
                                               int *cscSortedRowInd,
                                               int *cscSortedColPtr) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t, cuComplex *, int *, int *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t,
+      cuComplex *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseChyb2csc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, descrA, hybA, cscSortedVal, cscSortedRowInd, cscSortedColPtr);
+  return func_ptr(handle, descrA, hybA, cscSortedVal, cscSortedRowInd,
+                  cscSortedColPtr);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseZhyb2csc(cusparseHandle_t handle,
@@ -7106,1943 +6224,1875 @@ cusparseStatus_t CUSPARSEAPI cusparseZhyb2csc(cusparseHandle_t handle,
                                               cuDoubleComplex *cscSortedVal,
                                               int *cscSortedRowInd,
                                               int *cscSortedColPtr) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t, cuDoubleComplex *, int *, int *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, const cusparseMatDescr_t, const cusparseHybMat_t,
+      cuDoubleComplex *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZhyb2csc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, descrA, hybA, cscSortedVal, cscSortedRowInd, cscSortedColPtr);
+  return func_ptr(handle, descrA, hybA, cscSortedVal, cscSortedRowInd,
+                  cscSortedColPtr);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseXcsr2bsrNnz(cusparseHandle_t handle,
-                                                 cusparseDirection_t dirA,
-                                                 int m,
-                                                 int n,
-                                                 const cusparseMatDescr_t descrA,
-                                                 const int *csrSortedRowPtrA,
-                                                 const int *csrSortedColIndA,
-                                                 int blockDim,
-                                                 const cusparseMatDescr_t descrC,
-                                                 int *bsrSortedRowPtrC,
-                                                 int *nnzTotalDevHostPtr) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const int *, const int *, int, const cusparseMatDescr_t, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseXcsr2bsrNnz(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
+    const cusparseMatDescr_t descrA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, int blockDim, const cusparseMatDescr_t descrC,
+    int *bsrSortedRowPtrC, int *nnzTotalDevHostPtr) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const int *, const int *, int, const cusparseMatDescr_t, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcsr2bsrNnz");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedRowPtrA, csrSortedColIndA, blockDim, descrC, bsrSortedRowPtrC, nnzTotalDevHostPtr);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedRowPtrA,
+                  csrSortedColIndA, blockDim, descrC, bsrSortedRowPtrC,
+                  nnzTotalDevHostPtr);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsr2bsr(cusparseHandle_t handle,
-                                              cusparseDirection_t dirA,
-                                              int m,
-                                              int n,
-                                              const cusparseMatDescr_t descrA,
-                                              const float *csrSortedValA,
-                                              const int *csrSortedRowPtrA,
-                                              const int *csrSortedColIndA,
-                                              int blockDim,
-                                              const cusparseMatDescr_t descrC,
-                                              float *bsrSortedValC,
-                                              int *bsrSortedRowPtrC,
-                                              int *bsrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, int, const cusparseMatDescr_t, float *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseScsr2bsr(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
+    const cusparseMatDescr_t descrA, const float *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, int blockDim,
+    const cusparseMatDescr_t descrC, float *bsrSortedValC,
+    int *bsrSortedRowPtrC, int *bsrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const float *, const int *, const int *, int, const cusparseMatDescr_t,
+      float *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsr2bsr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, blockDim, descrC, bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, blockDim, descrC, bsrSortedValC,
+                  bsrSortedRowPtrC, bsrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsr2bsr(cusparseHandle_t handle,
-                                              cusparseDirection_t dirA,
-                                              int m,
-                                              int n,
-                                              const cusparseMatDescr_t descrA,
-                                              const double *csrSortedValA,
-                                              const int *csrSortedRowPtrA,
-                                              const int *csrSortedColIndA,
-                                              int blockDim,
-                                              const cusparseMatDescr_t descrC,
-                                              double *bsrSortedValC,
-                                              int *bsrSortedRowPtrC,
-                                              int *bsrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, int, const cusparseMatDescr_t, double *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsr2bsr(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
+    const cusparseMatDescr_t descrA, const double *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, int blockDim,
+    const cusparseMatDescr_t descrC, double *bsrSortedValC,
+    int *bsrSortedRowPtrC, int *bsrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const double *, const int *, const int *, int, const cusparseMatDescr_t,
+      double *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsr2bsr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, blockDim, descrC, bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, blockDim, descrC, bsrSortedValC,
+                  bsrSortedRowPtrC, bsrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsr2bsr(cusparseHandle_t handle,
-                                              cusparseDirection_t dirA,
-                                              int m,
-                                              int n,
-                                              const cusparseMatDescr_t descrA,
-                                              const cuComplex *csrSortedValA,
-                                              const int *csrSortedRowPtrA,
-                                              const int *csrSortedColIndA,
-                                              int blockDim,
-                                              const cusparseMatDescr_t descrC,
-                                              cuComplex *bsrSortedValC,
-                                              int *bsrSortedRowPtrC,
-                                              int *bsrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, int, const cusparseMatDescr_t, cuComplex *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsr2bsr(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
+    const cusparseMatDescr_t descrA, const cuComplex *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, int blockDim,
+    const cusparseMatDescr_t descrC, cuComplex *bsrSortedValC,
+    int *bsrSortedRowPtrC, int *bsrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const cuComplex *, const int *, const int *, int,
+      const cusparseMatDescr_t, cuComplex *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsr2bsr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, blockDim, descrC, bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, blockDim, descrC, bsrSortedValC,
+                  bsrSortedRowPtrC, bsrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsr2bsr(cusparseHandle_t handle,
-                                              cusparseDirection_t dirA,
-                                              int m,
-                                              int n,
-                                              const cusparseMatDescr_t descrA,
-                                              const cuDoubleComplex *csrSortedValA,
-                                              const int *csrSortedRowPtrA,
-                                              const int *csrSortedColIndA,
-                                              int blockDim,
-                                              const cusparseMatDescr_t descrC,
-                                              cuDoubleComplex *bsrSortedValC,
-                                              int *bsrSortedRowPtrC,
-                                              int *bsrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, int, const cusparseMatDescr_t, cuDoubleComplex *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsr2bsr(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
+    const cusparseMatDescr_t descrA, const cuDoubleComplex *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, int blockDim,
+    const cusparseMatDescr_t descrC, cuDoubleComplex *bsrSortedValC,
+    int *bsrSortedRowPtrC, int *bsrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const cuDoubleComplex *, const int *, const int *, int,
+      const cusparseMatDescr_t, cuDoubleComplex *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsr2bsr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, blockDim, descrC, bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, blockDim, descrC, bsrSortedValC,
+                  bsrSortedRowPtrC, bsrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSbsr2csr(cusparseHandle_t handle,
-                                              cusparseDirection_t dirA,
-                                              int mb,
-                                              int nb,
-                                              const cusparseMatDescr_t descrA,
-                                              const float *bsrSortedValA,
-                                              const int *bsrSortedRowPtrA,
-                                              const int *bsrSortedColIndA,
-                                              int blockDim,
-                                              const cusparseMatDescr_t descrC,
-                                              float *csrSortedValC,
-                                              int *csrSortedRowPtrC,
-                                              int *csrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, int, const cusparseMatDescr_t, float *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseSbsr2csr(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb,
+    const cusparseMatDescr_t descrA, const float *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
+    const cusparseMatDescr_t descrC, float *csrSortedValC,
+    int *csrSortedRowPtrC, int *csrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const float *, const int *, const int *, int, const cusparseMatDescr_t,
+      float *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSbsr2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA,
+                  bsrSortedColIndA, blockDim, descrC, csrSortedValC,
+                  csrSortedRowPtrC, csrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDbsr2csr(cusparseHandle_t handle,
-                                              cusparseDirection_t dirA,
-                                              int mb,
-                                              int nb,
-                                              const cusparseMatDescr_t descrA,
-                                              const double *bsrSortedValA,
-                                              const int *bsrSortedRowPtrA,
-                                              const int *bsrSortedColIndA,
-                                              int   blockDim,
-                                              const cusparseMatDescr_t descrC,
-                                              double *csrSortedValC,
-                                              int *csrSortedRowPtrC,
-                                              int *csrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, int, const cusparseMatDescr_t, double *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDbsr2csr(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb,
+    const cusparseMatDescr_t descrA, const double *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
+    const cusparseMatDescr_t descrC, double *csrSortedValC,
+    int *csrSortedRowPtrC, int *csrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const double *, const int *, const int *, int, const cusparseMatDescr_t,
+      double *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDbsr2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA,
+                  bsrSortedColIndA, blockDim, descrC, csrSortedValC,
+                  csrSortedRowPtrC, csrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCbsr2csr(cusparseHandle_t handle,
-                                              cusparseDirection_t dirA,
-                                              int mb,
-                                              int nb,
-                                              const cusparseMatDescr_t descrA,
-                                              const cuComplex *bsrSortedValA,
-                                              const int *bsrSortedRowPtrA,
-                                              const int *bsrSortedColIndA,
-                                              int blockDim,
-                                              const cusparseMatDescr_t descrC,
-                                              cuComplex *csrSortedValC,
-                                              int *csrSortedRowPtrC,
-                                              int *csrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, int, const cusparseMatDescr_t, cuComplex *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCbsr2csr(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb,
+    const cusparseMatDescr_t descrA, const cuComplex *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
+    const cusparseMatDescr_t descrC, cuComplex *csrSortedValC,
+    int *csrSortedRowPtrC, int *csrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const cuComplex *, const int *, const int *, int,
+      const cusparseMatDescr_t, cuComplex *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCbsr2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA,
+                  bsrSortedColIndA, blockDim, descrC, csrSortedValC,
+                  csrSortedRowPtrC, csrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZbsr2csr(cusparseHandle_t handle,
-                                              cusparseDirection_t dirA,
-                                              int mb,
-                                              int nb,
-                                              const cusparseMatDescr_t descrA,
-                                              const cuDoubleComplex *bsrSortedValA,
-                                              const int *bsrSortedRowPtrA,
-                                              const int *bsrSortedColIndA,
-                                              int blockDim,
-                                              const cusparseMatDescr_t descrC,
-                                              cuDoubleComplex *csrSortedValC,
-                                              int *csrSortedRowPtrC,
-                                              int *csrSortedColIndC) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, int, const cusparseMatDescr_t, cuDoubleComplex *, int *, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZbsr2csr(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb,
+    const cusparseMatDescr_t descrA, const cuDoubleComplex *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int blockDim,
+    const cusparseMatDescr_t descrC, cuDoubleComplex *csrSortedValC,
+    int *csrSortedRowPtrC, int *csrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const cuDoubleComplex *, const int *, const int *, int,
+      const cusparseMatDescr_t, cuDoubleComplex *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZbsr2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, blockDim, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA,
+                  bsrSortedColIndA, blockDim, descrC, csrSortedValC,
+                  csrSortedRowPtrC, csrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSgebsr2gebsc_bufferSize(cusparseHandle_t handle,
-                                                             int mb,
-                                                             int nb,
-                                                             int nnzb,
-                                                             const float *bsrSortedVal,
-                                                             const int *bsrSortedRowPtr,
-                                                             const int *bsrSortedColInd,
-                                                             int rowBlockDim,
-                                                             int colBlockDim,
-                                                             int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const float *, const int *, const int *, int, int, int *);
+cusparseStatus_t CUSPARSEAPI cusparseSgebsr2gebsc_bufferSize(
+    cusparseHandle_t handle, int mb, int nb, int nnzb,
+    const float *bsrSortedVal, const int *bsrSortedRowPtr,
+    const int *bsrSortedColInd, int rowBlockDim, int colBlockDim,
+    int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const float *, const int *, const int *,
+      int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgebsr2gebsc_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, rowBlockDim, colBlockDim, pBufferSizeInBytes);
+  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, rowBlockDim, colBlockDim,
+                  pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDgebsr2gebsc_bufferSize(cusparseHandle_t handle,
-                                                             int mb,
-                                                             int nb,
-                                                             int nnzb,
-                                                             const double *bsrSortedVal,
-                                                             const int *bsrSortedRowPtr,
-                                                             const int *bsrSortedColInd,
-                                                             int rowBlockDim,
-                                                             int colBlockDim,
-                                                             int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const double *, const int *, const int *, int, int, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDgebsr2gebsc_bufferSize(
+    cusparseHandle_t handle, int mb, int nb, int nnzb,
+    const double *bsrSortedVal, const int *bsrSortedRowPtr,
+    const int *bsrSortedColInd, int rowBlockDim, int colBlockDim,
+    int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const double *, const int *, const int *,
+      int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgebsr2gebsc_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, rowBlockDim, colBlockDim, pBufferSizeInBytes);
+  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, rowBlockDim, colBlockDim,
+                  pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCgebsr2gebsc_bufferSize(cusparseHandle_t handle,
-                                                             int mb,
-                                                             int nb,
-                                                             int nnzb,
-                                                             const cuComplex *bsrSortedVal,
-                                                             const int *bsrSortedRowPtr,
-                                                             const int *bsrSortedColInd,
-                                                             int rowBlockDim,
-                                                             int colBlockDim,
-                                                             int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cuComplex *, const int *, const int *, int, int, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCgebsr2gebsc_bufferSize(
+    cusparseHandle_t handle, int mb, int nb, int nnzb,
+    const cuComplex *bsrSortedVal, const int *bsrSortedRowPtr,
+    const int *bsrSortedColInd, int rowBlockDim, int colBlockDim,
+    int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cuComplex *, const int *,
+      const int *, int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgebsr2gebsc_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, rowBlockDim, colBlockDim, pBufferSizeInBytes);
+  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, rowBlockDim, colBlockDim,
+                  pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZgebsr2gebsc_bufferSize(cusparseHandle_t handle,
-                                                             int mb,
-                                                             int nb,
-                                                             int nnzb,
-                                                             const cuDoubleComplex *bsrSortedVal,
-                                                             const int *bsrSortedRowPtr,
-                                                             const int *bsrSortedColInd,
-                                                             int rowBlockDim,
-                                                             int colBlockDim,
-                                                             int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cuDoubleComplex *, const int *, const int *, int, int, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZgebsr2gebsc_bufferSize(
+    cusparseHandle_t handle, int mb, int nb, int nnzb,
+    const cuDoubleComplex *bsrSortedVal, const int *bsrSortedRowPtr,
+    const int *bsrSortedColInd, int rowBlockDim, int colBlockDim,
+    int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cuDoubleComplex *, const int *,
+      const int *, int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgebsr2gebsc_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, rowBlockDim, colBlockDim, pBufferSizeInBytes);
+  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, rowBlockDim, colBlockDim,
+                  pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSgebsr2gebsc_bufferSizeExt(cusparseHandle_t handle,
-                                                                int mb,
-                                                                int nb,
-                                                                int nnzb,
-                                                                const float *bsrSortedVal,
-                                                                const int *bsrSortedRowPtr,
-                                                                const int *bsrSortedColInd,
-                                                                int rowBlockDim,
-                                                                int colBlockDim,
-                                                                size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const float *, const int *, const int *, int, int, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgebsr2gebsc_bufferSizeExt");
+cusparseStatus_t CUSPARSEAPI cusparseSgebsr2gebsc_bufferSizeExt(
+    cusparseHandle_t handle, int mb, int nb, int nnzb,
+    const float *bsrSortedVal, const int *bsrSortedRowPtr,
+    const int *bsrSortedColInd, int rowBlockDim, int colBlockDim,
+    size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const float *, const int *, const int *,
+      int, int, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseSgebsr2gebsc_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, rowBlockDim, colBlockDim, pBufferSize);
+  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, rowBlockDim, colBlockDim, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDgebsr2gebsc_bufferSizeExt(cusparseHandle_t handle,
-                                                                int mb,
-                                                                int nb,
-                                                                int nnzb,
-                                                                const double *bsrSortedVal,
-                                                                const int *bsrSortedRowPtr,
-                                                                const int *bsrSortedColInd,
-                                                                int rowBlockDim,
-                                                                int colBlockDim,
-                                                                size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const double *, const int *, const int *, int, int, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgebsr2gebsc_bufferSizeExt");
+cusparseStatus_t CUSPARSEAPI cusparseDgebsr2gebsc_bufferSizeExt(
+    cusparseHandle_t handle, int mb, int nb, int nnzb,
+    const double *bsrSortedVal, const int *bsrSortedRowPtr,
+    const int *bsrSortedColInd, int rowBlockDim, int colBlockDim,
+    size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const double *, const int *, const int *,
+      int, int, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseDgebsr2gebsc_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, rowBlockDim, colBlockDim, pBufferSize);
+  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, rowBlockDim, colBlockDim, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCgebsr2gebsc_bufferSizeExt(cusparseHandle_t handle,
-                                                                int mb,
-                                                                int nb,
-                                                                int nnzb,
-                                                                const cuComplex *bsrSortedVal,
-                                                                const int *bsrSortedRowPtr,
-                                                                const int *bsrSortedColInd,
-                                                                int rowBlockDim,
-                                                                int colBlockDim,
-                                                                size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cuComplex *, const int *, const int *, int, int, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgebsr2gebsc_bufferSizeExt");
+cusparseStatus_t CUSPARSEAPI cusparseCgebsr2gebsc_bufferSizeExt(
+    cusparseHandle_t handle, int mb, int nb, int nnzb,
+    const cuComplex *bsrSortedVal, const int *bsrSortedRowPtr,
+    const int *bsrSortedColInd, int rowBlockDim, int colBlockDim,
+    size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cuComplex *, const int *,
+      const int *, int, int, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseCgebsr2gebsc_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, rowBlockDim, colBlockDim, pBufferSize);
+  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, rowBlockDim, colBlockDim, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZgebsr2gebsc_bufferSizeExt(cusparseHandle_t handle,
-                                                                int mb,
-                                                                int nb,
-                                                                int nnzb,
-                                                                const cuDoubleComplex *bsrSortedVal,
-                                                                const int *bsrSortedRowPtr,
-                                                                const int *bsrSortedColInd,
-                                                                int rowBlockDim,
-                                                                int colBlockDim,
-                                                                size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cuDoubleComplex *, const int *, const int *, int, int, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgebsr2gebsc_bufferSizeExt");
+cusparseStatus_t CUSPARSEAPI cusparseZgebsr2gebsc_bufferSizeExt(
+    cusparseHandle_t handle, int mb, int nb, int nnzb,
+    const cuDoubleComplex *bsrSortedVal, const int *bsrSortedRowPtr,
+    const int *bsrSortedColInd, int rowBlockDim, int colBlockDim,
+    size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cuDoubleComplex *, const int *,
+      const int *, int, int, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseZgebsr2gebsc_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, rowBlockDim, colBlockDim, pBufferSize);
+  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, rowBlockDim, colBlockDim, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSgebsr2gebsc(cusparseHandle_t handle,
-                                                  int mb,
-                                                  int nb,
-                                                  int nnzb,
-                                                  const float *bsrSortedVal,
-                                                  const int *bsrSortedRowPtr,
-                                                  const int *bsrSortedColInd,
-                                                  int rowBlockDim,
-                                                  int colBlockDim,
-                                                  float *bscVal,
-                                                  int *bscRowInd,
-                                                  int *bscColPtr,
-                                                  cusparseAction_t copyValues,
-                                                  cusparseIndexBase_t idxBase,
-                                                  void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const float *, const int *, const int *, int, int, float *, int *, int *, cusparseAction_t, cusparseIndexBase_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseSgebsr2gebsc(
+    cusparseHandle_t handle, int mb, int nb, int nnzb,
+    const float *bsrSortedVal, const int *bsrSortedRowPtr,
+    const int *bsrSortedColInd, int rowBlockDim, int colBlockDim, float *bscVal,
+    int *bscRowInd, int *bscColPtr, cusparseAction_t copyValues,
+    cusparseIndexBase_t idxBase, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const float *, const int *, const int *,
+      int, int, float *, int *, int *, cusparseAction_t, cusparseIndexBase_t,
+      void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgebsr2gebsc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, rowBlockDim, colBlockDim, bscVal, bscRowInd, bscColPtr, copyValues, idxBase, pBuffer);
+  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, rowBlockDim, colBlockDim, bscVal, bscRowInd,
+                  bscColPtr, copyValues, idxBase, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDgebsr2gebsc(cusparseHandle_t handle,
-                                                  int mb,
-                                                  int nb,
-                                                  int nnzb,
-                                                  const double *bsrSortedVal,
-                                                  const int *bsrSortedRowPtr,
-                                                  const int *bsrSortedColInd,
-                                                  int rowBlockDim,
-                                                  int colBlockDim,
-                                                  double *bscVal,
-                                                  int *bscRowInd,
-                                                  int *bscColPtr,
-                                                  cusparseAction_t copyValues,
-                                                  cusparseIndexBase_t idxBase,
-                                                  void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const double *, const int *, const int *, int, int, double *, int *, int *, cusparseAction_t, cusparseIndexBase_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDgebsr2gebsc(
+    cusparseHandle_t handle, int mb, int nb, int nnzb,
+    const double *bsrSortedVal, const int *bsrSortedRowPtr,
+    const int *bsrSortedColInd, int rowBlockDim, int colBlockDim,
+    double *bscVal, int *bscRowInd, int *bscColPtr, cusparseAction_t copyValues,
+    cusparseIndexBase_t idxBase, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const double *, const int *, const int *,
+      int, int, double *, int *, int *, cusparseAction_t, cusparseIndexBase_t,
+      void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgebsr2gebsc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, rowBlockDim, colBlockDim, bscVal, bscRowInd, bscColPtr, copyValues, idxBase, pBuffer);
+  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, rowBlockDim, colBlockDim, bscVal, bscRowInd,
+                  bscColPtr, copyValues, idxBase, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCgebsr2gebsc(cusparseHandle_t handle,
-                                                  int mb,
-                                                  int nb,
-                                                  int nnzb,
-                                                  const cuComplex *bsrSortedVal,
-                                                  const int *bsrSortedRowPtr,
-                                                  const int *bsrSortedColInd,
-                                                  int rowBlockDim,
-                                                  int colBlockDim,
-                                                  cuComplex *bscVal,
-                                                  int *bscRowInd,
-                                                  int *bscColPtr,
-                                                  cusparseAction_t copyValues,
-                                                  cusparseIndexBase_t idxBase,
-                                                  void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cuComplex *, const int *, const int *, int, int, cuComplex *, int *, int *, cusparseAction_t, cusparseIndexBase_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCgebsr2gebsc(
+    cusparseHandle_t handle, int mb, int nb, int nnzb,
+    const cuComplex *bsrSortedVal, const int *bsrSortedRowPtr,
+    const int *bsrSortedColInd, int rowBlockDim, int colBlockDim,
+    cuComplex *bscVal, int *bscRowInd, int *bscColPtr,
+    cusparseAction_t copyValues, cusparseIndexBase_t idxBase, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cuComplex *, const int *,
+      const int *, int, int, cuComplex *, int *, int *, cusparseAction_t,
+      cusparseIndexBase_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgebsr2gebsc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, rowBlockDim, colBlockDim, bscVal, bscRowInd, bscColPtr, copyValues, idxBase, pBuffer);
+  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, rowBlockDim, colBlockDim, bscVal, bscRowInd,
+                  bscColPtr, copyValues, idxBase, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZgebsr2gebsc(cusparseHandle_t handle,
-                                                  int mb,
-                                                  int nb,
-                                                  int nnzb,
-                                                  const cuDoubleComplex *bsrSortedVal,
-                                                  const int *bsrSortedRowPtr,
-                                                  const int *bsrSortedColInd,
-                                                  int rowBlockDim,
-                                                  int colBlockDim,
-                                                  cuDoubleComplex *bscVal,
-                                                  int *bscRowInd,
-                                                  int *bscColPtr,
-                                                  cusparseAction_t copyValues,
-                                                  cusparseIndexBase_t idxBase,
-                                                  void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cuDoubleComplex *, const int *, const int *, int, int, cuDoubleComplex *, int *, int *, cusparseAction_t, cusparseIndexBase_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZgebsr2gebsc(
+    cusparseHandle_t handle, int mb, int nb, int nnzb,
+    const cuDoubleComplex *bsrSortedVal, const int *bsrSortedRowPtr,
+    const int *bsrSortedColInd, int rowBlockDim, int colBlockDim,
+    cuDoubleComplex *bscVal, int *bscRowInd, int *bscColPtr,
+    cusparseAction_t copyValues, cusparseIndexBase_t idxBase, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cuDoubleComplex *, const int *,
+      const int *, int, int, cuDoubleComplex *, int *, int *, cusparseAction_t,
+      cusparseIndexBase_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgebsr2gebsc");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr, bsrSortedColInd, rowBlockDim, colBlockDim, bscVal, bscRowInd, bscColPtr, copyValues, idxBase, pBuffer);
+  return func_ptr(handle, mb, nb, nnzb, bsrSortedVal, bsrSortedRowPtr,
+                  bsrSortedColInd, rowBlockDim, colBlockDim, bscVal, bscRowInd,
+                  bscColPtr, copyValues, idxBase, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseXgebsr2csr(cusparseHandle_t handle,
-                                                cusparseDirection_t dirA,
-                                                int mb,
-                                                int nb,
-                                                const cusparseMatDescr_t descrA,
-                                                const int    *bsrSortedRowPtrA,
-                                                const int    *bsrSortedColIndA,
-                                                int   rowBlockDim,
-                                                int   colBlockDim,
-                                                const cusparseMatDescr_t descrC,
-                                                int    *csrSortedRowPtrC,
-                                                int    *csrSortedColIndC ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const int    *, const int    *, int, int, const cusparseMatDescr_t, int    *, int    *);
+cusparseStatus_t CUSPARSEAPI cusparseXgebsr2csr(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb,
+    const cusparseMatDescr_t descrA, const int *bsrSortedRowPtrA,
+    const int *bsrSortedColIndA, int rowBlockDim, int colBlockDim,
+    const cusparseMatDescr_t descrC, int *csrSortedRowPtrC,
+    int *csrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const int *, const int *, int, int, const cusparseMatDescr_t, int *,
+      int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXgebsr2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDim, colBlockDim, descrC, csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedRowPtrA,
+                  bsrSortedColIndA, rowBlockDim, colBlockDim, descrC,
+                  csrSortedRowPtrC, csrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSgebsr2csr(cusparseHandle_t handle,
-                                                cusparseDirection_t dirA,
-                                                int mb,
-                                                int nb,
-                                                const cusparseMatDescr_t descrA,
-                                                const float *bsrSortedValA,
-                                                const int    *bsrSortedRowPtrA,
-                                                const int    *bsrSortedColIndA,
-                                                int   rowBlockDim,
-                                                int   colBlockDim,
-                                                const cusparseMatDescr_t descrC,
-                                                float  *csrSortedValC,
-                                                int    *csrSortedRowPtrC,
-                                                int    *csrSortedColIndC ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const float *, const int    *, const int    *, int, int, const cusparseMatDescr_t, float  *, int    *, int    *);
+cusparseStatus_t CUSPARSEAPI cusparseSgebsr2csr(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb,
+    const cusparseMatDescr_t descrA, const float *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDim,
+    int colBlockDim, const cusparseMatDescr_t descrC, float *csrSortedValC,
+    int *csrSortedRowPtrC, int *csrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const float *, const int *, const int *, int, int,
+      const cusparseMatDescr_t, float *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgebsr2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDim, colBlockDim, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA,
+                  bsrSortedColIndA, rowBlockDim, colBlockDim, descrC,
+                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDgebsr2csr(cusparseHandle_t handle,
-                                                cusparseDirection_t dirA,
-                                                int mb,
-                                                int nb,
-                                                const cusparseMatDescr_t descrA,
-                                                const double *bsrSortedValA,
-                                                const int    *bsrSortedRowPtrA,
-                                                const int    *bsrSortedColIndA,
-                                                int   rowBlockDim,
-                                                int   colBlockDim,
-                                                const cusparseMatDescr_t descrC,
-                                                double  *csrSortedValC,
-                                                int    *csrSortedRowPtrC,
-                                                int    *csrSortedColIndC ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const double *, const int    *, const int    *, int, int, const cusparseMatDescr_t, double  *, int    *, int    *);
+cusparseStatus_t CUSPARSEAPI cusparseDgebsr2csr(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb,
+    const cusparseMatDescr_t descrA, const double *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDim,
+    int colBlockDim, const cusparseMatDescr_t descrC, double *csrSortedValC,
+    int *csrSortedRowPtrC, int *csrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const double *, const int *, const int *, int, int,
+      const cusparseMatDescr_t, double *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgebsr2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDim, colBlockDim, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA,
+                  bsrSortedColIndA, rowBlockDim, colBlockDim, descrC,
+                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCgebsr2csr(cusparseHandle_t handle,
-                                                cusparseDirection_t dirA,
-                                                int mb,
-                                                int nb,
-                                                const cusparseMatDescr_t descrA,
-                                                const cuComplex *bsrSortedValA,
-                                                const int    *bsrSortedRowPtrA,
-                                                const int    *bsrSortedColIndA,
-                                                int   rowBlockDim,
-                                                int   colBlockDim,
-                                                const cusparseMatDescr_t descrC,
-                                                cuComplex  *csrSortedValC,
-                                                int    *csrSortedRowPtrC,
-                                                int    *csrSortedColIndC ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int    *, const int    *, int, int, const cusparseMatDescr_t, cuComplex  *, int    *, int    *);
+cusparseStatus_t CUSPARSEAPI cusparseCgebsr2csr(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb,
+    const cusparseMatDescr_t descrA, const cuComplex *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDim,
+    int colBlockDim, const cusparseMatDescr_t descrC, cuComplex *csrSortedValC,
+    int *csrSortedRowPtrC, int *csrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const cuComplex *, const int *, const int *, int, int,
+      const cusparseMatDescr_t, cuComplex *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgebsr2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDim, colBlockDim, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA,
+                  bsrSortedColIndA, rowBlockDim, colBlockDim, descrC,
+                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZgebsr2csr(cusparseHandle_t handle,
-                                                cusparseDirection_t dirA,
-                                                int mb,
-                                                int nb,
-                                                const cusparseMatDescr_t descrA,
-                                                const cuDoubleComplex *bsrSortedValA,
-                                                const int    *bsrSortedRowPtrA,
-                                                const int    *bsrSortedColIndA,
-                                                int   rowBlockDim,
-                                                int   colBlockDim,
-                                                const cusparseMatDescr_t descrC,
-                                                cuDoubleComplex  *csrSortedValC,
-                                                int    *csrSortedRowPtrC,
-                                                int    *csrSortedColIndC ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int    *, const int    *, int, int, const cusparseMatDescr_t, cuDoubleComplex  *, int    *, int    *);
+cusparseStatus_t CUSPARSEAPI cusparseZgebsr2csr(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb,
+    const cusparseMatDescr_t descrA, const cuDoubleComplex *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDim,
+    int colBlockDim, const cusparseMatDescr_t descrC,
+    cuDoubleComplex *csrSortedValC, int *csrSortedRowPtrC,
+    int *csrSortedColIndC) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const cuDoubleComplex *, const int *, const int *, int, int,
+      const cusparseMatDescr_t, cuDoubleComplex *, int *, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgebsr2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDim, colBlockDim, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
+  return func_ptr(handle, dirA, mb, nb, descrA, bsrSortedValA, bsrSortedRowPtrA,
+                  bsrSortedColIndA, rowBlockDim, colBlockDim, descrC,
+                  csrSortedValC, csrSortedRowPtrC, csrSortedColIndC);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsr2gebsr_bufferSize(cusparseHandle_t handle,
-                                                           cusparseDirection_t dirA,
-                                                           int m,
-                                                           int n,
-                                                           const cusparseMatDescr_t descrA,
-                                                           const float *csrSortedValA,
-                                                           const int *csrSortedRowPtrA,
-                                                           const int *csrSortedColIndA,
-                                                           int rowBlockDim,
-                                                           int colBlockDim,
-                                                           int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, int, int, int *);
+cusparseStatus_t CUSPARSEAPI cusparseScsr2gebsr_bufferSize(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
+    const cusparseMatDescr_t descrA, const float *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, int rowBlockDim,
+    int colBlockDim, int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const float *, const int *, const int *, int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsr2gebsr_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, rowBlockDim, colBlockDim, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, rowBlockDim, colBlockDim,
+                  pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsr2gebsr_bufferSize(cusparseHandle_t handle,
-                                                           cusparseDirection_t dirA,
-                                                           int m,
-                                                           int n,
-                                                           const cusparseMatDescr_t descrA,
-                                                           const double *csrSortedValA,
-                                                           const int *csrSortedRowPtrA,
-                                                           const int *csrSortedColIndA,
-                                                           int rowBlockDim,
-                                                           int colBlockDim,
-                                                           int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, int, int, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsr2gebsr_bufferSize(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
+    const cusparseMatDescr_t descrA, const double *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, int rowBlockDim,
+    int colBlockDim, int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const double *, const int *, const int *, int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsr2gebsr_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, rowBlockDim, colBlockDim, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, rowBlockDim, colBlockDim,
+                  pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsr2gebsr_bufferSize(cusparseHandle_t handle,
-                                                           cusparseDirection_t dirA,
-                                                           int m,
-                                                           int n,
-                                                           const cusparseMatDescr_t descrA,
-                                                           const cuComplex *csrSortedValA,
-                                                           const int *csrSortedRowPtrA,
-                                                           const int *csrSortedColIndA,
-                                                           int rowBlockDim,
-                                                           int colBlockDim,
-                                                           int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, int, int, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsr2gebsr_bufferSize(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
+    const cusparseMatDescr_t descrA, const cuComplex *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, int rowBlockDim,
+    int colBlockDim, int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const cuComplex *, const int *, const int *, int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsr2gebsr_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, rowBlockDim, colBlockDim, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, rowBlockDim, colBlockDim,
+                  pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsr2gebsr_bufferSize(cusparseHandle_t handle,
-                                                           cusparseDirection_t dirA,
-                                                           int m,
-                                                           int n,
-                                                           const cusparseMatDescr_t descrA,
-                                                           const cuDoubleComplex *csrSortedValA,
-                                                           const int *csrSortedRowPtrA,
-                                                           const int *csrSortedColIndA,
-                                                           int rowBlockDim,
-                                                           int colBlockDim,
-                                                           int *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, int, int, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsr2gebsr_bufferSize(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
+    const cusparseMatDescr_t descrA, const cuDoubleComplex *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, int rowBlockDim,
+    int colBlockDim, int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const cuDoubleComplex *, const int *, const int *, int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsr2gebsr_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, rowBlockDim, colBlockDim, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, rowBlockDim, colBlockDim,
+                  pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsr2gebsr_bufferSizeExt(cusparseHandle_t handle,
-                                                              cusparseDirection_t dirA,
-                                                              int m,
-                                                              int n,
-                                                              const cusparseMatDescr_t descrA,
-                                                              const float *csrSortedValA,
-                                                              const int *csrSortedRowPtrA,
-                                                              const int *csrSortedColIndA,
-                                                              int rowBlockDim,
-                                                              int colBlockDim,
-                                                              size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, int, int, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsr2gebsr_bufferSizeExt");
+cusparseStatus_t CUSPARSEAPI cusparseScsr2gebsr_bufferSizeExt(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
+    const cusparseMatDescr_t descrA, const float *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, int rowBlockDim,
+    int colBlockDim, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const float *, const int *, const int *, int, int, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseScsr2gebsr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, rowBlockDim, colBlockDim, pBufferSize);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, rowBlockDim, colBlockDim, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsr2gebsr_bufferSizeExt(cusparseHandle_t handle,
-                                                              cusparseDirection_t dirA,
-                                                              int m,
-                                                              int n,
-                                                              const cusparseMatDescr_t descrA,
-                                                              const double *csrSortedValA,
-                                                              const int *csrSortedRowPtrA,
-                                                              const int *csrSortedColIndA,
-                                                              int rowBlockDim,
-                                                              int colBlockDim,
-                                                              size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, int, int, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsr2gebsr_bufferSizeExt");
+cusparseStatus_t CUSPARSEAPI cusparseDcsr2gebsr_bufferSizeExt(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
+    const cusparseMatDescr_t descrA, const double *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, int rowBlockDim,
+    int colBlockDim, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const double *, const int *, const int *, int, int, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseDcsr2gebsr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, rowBlockDim, colBlockDim, pBufferSize);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, rowBlockDim, colBlockDim, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsr2gebsr_bufferSizeExt(cusparseHandle_t handle,
-                                                              cusparseDirection_t dirA,
-                                                              int m,
-                                                              int n,
-                                                              const cusparseMatDescr_t descrA,
-                                                              const cuComplex *csrSortedValA,
-                                                              const int *csrSortedRowPtrA,
-                                                              const int *csrSortedColIndA,
-                                                              int rowBlockDim,
-                                                              int colBlockDim,
-                                                              size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, int, int, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsr2gebsr_bufferSizeExt");
+cusparseStatus_t CUSPARSEAPI cusparseCcsr2gebsr_bufferSizeExt(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
+    const cusparseMatDescr_t descrA, const cuComplex *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, int rowBlockDim,
+    int colBlockDim, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const cuComplex *, const int *, const int *, int, int, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseCcsr2gebsr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, rowBlockDim, colBlockDim, pBufferSize);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, rowBlockDim, colBlockDim, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsr2gebsr_bufferSizeExt(cusparseHandle_t handle,
-                                                              cusparseDirection_t dirA,
-                                                              int m,
-                                                              int n,
-                                                              const cusparseMatDescr_t descrA,
-                                                              const cuDoubleComplex *csrSortedValA,
-                                                              const int *csrSortedRowPtrA,
-                                                              const int *csrSortedColIndA,
-                                                              int rowBlockDim,
-                                                              int colBlockDim,
-                                                              size_t *pBufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, int, int, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsr2gebsr_bufferSizeExt");
+cusparseStatus_t CUSPARSEAPI cusparseZcsr2gebsr_bufferSizeExt(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
+    const cusparseMatDescr_t descrA, const cuDoubleComplex *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, int rowBlockDim,
+    int colBlockDim, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const cuDoubleComplex *, const int *, const int *, int, int, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseZcsr2gebsr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, rowBlockDim, colBlockDim, pBufferSize);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, rowBlockDim, colBlockDim, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseXcsr2gebsrNnz(cusparseHandle_t handle,
-                                                   cusparseDirection_t dirA,
-                                                   int m,
-                                                   int n,
-                                                   const cusparseMatDescr_t descrA,
-                                                   const int *csrSortedRowPtrA,
-                                                   const int *csrSortedColIndA,
-                                                   const cusparseMatDescr_t descrC,
-                                                   int *bsrSortedRowPtrC,
-                                                   int rowBlockDim,
-                                                   int colBlockDim,
-                                                   int *nnzTotalDevHostPtr,
-                                                   void *pBuffer ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const int *, const int *, const cusparseMatDescr_t, int *, int, int, int *, void *);
+cusparseStatus_t CUSPARSEAPI cusparseXcsr2gebsrNnz(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
+    const cusparseMatDescr_t descrA, const int *csrSortedRowPtrA,
+    const int *csrSortedColIndA, const cusparseMatDescr_t descrC,
+    int *bsrSortedRowPtrC, int rowBlockDim, int colBlockDim,
+    int *nnzTotalDevHostPtr, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const int *, const int *, const cusparseMatDescr_t, int *, int, int,
+      int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcsr2gebsrNnz");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedRowPtrA, csrSortedColIndA, descrC, bsrSortedRowPtrC, rowBlockDim, colBlockDim, nnzTotalDevHostPtr, pBuffer);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedRowPtrA,
+                  csrSortedColIndA, descrC, bsrSortedRowPtrC, rowBlockDim,
+                  colBlockDim, nnzTotalDevHostPtr, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsr2gebsr(cusparseHandle_t handle,
-                                                cusparseDirection_t dirA,
-                                                int m,
-                                                int n,
-                                                const cusparseMatDescr_t descrA,
-                                                const float *csrSortedValA,
-                                                const int *csrSortedRowPtrA,
-                                                const int *csrSortedColIndA,
-                                                const cusparseMatDescr_t descrC,
-                                                float *bsrSortedValC,
-                                                int *bsrSortedRowPtrC,
-                                                int *bsrSortedColIndC,
-                                                int rowBlockDim,
-                                                int colBlockDim,
-                                                void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, const cusparseMatDescr_t, float *, int *, int *, int, int, void *);
+cusparseStatus_t CUSPARSEAPI cusparseScsr2gebsr(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
+    const cusparseMatDescr_t descrA, const float *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    const cusparseMatDescr_t descrC, float *bsrSortedValC,
+    int *bsrSortedRowPtrC, int *bsrSortedColIndC, int rowBlockDim,
+    int colBlockDim, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const float *, const int *, const int *, const cusparseMatDescr_t,
+      float *, int *, int *, int, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsr2gebsr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, descrC, bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC, rowBlockDim, colBlockDim, pBuffer);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, descrC, bsrSortedValC, bsrSortedRowPtrC,
+                  bsrSortedColIndC, rowBlockDim, colBlockDim, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsr2gebsr(cusparseHandle_t handle,
-                                                cusparseDirection_t dirA,
-                                                int m,
-                                                int n,
-                                                const cusparseMatDescr_t descrA,
-                                                const double *csrSortedValA,
-                                                const int *csrSortedRowPtrA,
-                                                const int *csrSortedColIndA,
-                                                const cusparseMatDescr_t descrC,
-                                                double *bsrSortedValC,
-                                                int *bsrSortedRowPtrC,
-                                                int *bsrSortedColIndC,
-                                                int rowBlockDim,
-                                                int colBlockDim,
-                                                void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, const cusparseMatDescr_t, double *, int *, int *, int, int, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsr2gebsr(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
+    const cusparseMatDescr_t descrA, const double *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    const cusparseMatDescr_t descrC, double *bsrSortedValC,
+    int *bsrSortedRowPtrC, int *bsrSortedColIndC, int rowBlockDim,
+    int colBlockDim, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const double *, const int *, const int *, const cusparseMatDescr_t,
+      double *, int *, int *, int, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsr2gebsr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, descrC, bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC, rowBlockDim, colBlockDim, pBuffer);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, descrC, bsrSortedValC, bsrSortedRowPtrC,
+                  bsrSortedColIndC, rowBlockDim, colBlockDim, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsr2gebsr(cusparseHandle_t handle,
-                                                cusparseDirection_t dirA,
-                                                int m,
-                                                int n,
-                                                const cusparseMatDescr_t descrA,
-                                                const cuComplex *csrSortedValA,
-                                                const int *csrSortedRowPtrA,
-                                                const int *csrSortedColIndA,
-                                                const cusparseMatDescr_t descrC,
-                                                cuComplex *bsrSortedValC,
-                                                int *bsrSortedRowPtrC,
-                                                int *bsrSortedColIndC,
-                                                int rowBlockDim,
-                                                int colBlockDim,
-                                                void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, const cusparseMatDescr_t, cuComplex *, int *, int *, int, int, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsr2gebsr(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
+    const cusparseMatDescr_t descrA, const cuComplex *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    const cusparseMatDescr_t descrC, cuComplex *bsrSortedValC,
+    int *bsrSortedRowPtrC, int *bsrSortedColIndC, int rowBlockDim,
+    int colBlockDim, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const cuComplex *, const int *, const int *, const cusparseMatDescr_t,
+      cuComplex *, int *, int *, int, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsr2gebsr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, descrC, bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC, rowBlockDim, colBlockDim, pBuffer);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, descrC, bsrSortedValC, bsrSortedRowPtrC,
+                  bsrSortedColIndC, rowBlockDim, colBlockDim, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsr2gebsr(cusparseHandle_t handle,
-                                                cusparseDirection_t dirA,
-                                                int m,
-                                                int n,
-                                                const cusparseMatDescr_t descrA,
-                                                const cuDoubleComplex *csrSortedValA,
-                                                const int *csrSortedRowPtrA,
-                                                const int *csrSortedColIndA,
-                                                const cusparseMatDescr_t descrC,
-                                                cuDoubleComplex *bsrSortedValC,
-                                                int *bsrSortedRowPtrC,
-                                                int *bsrSortedColIndC,
-                                                int rowBlockDim,
-                                                int colBlockDim,
-                                                void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, const cusparseMatDescr_t, cuDoubleComplex *, int *, int *, int, int, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsr2gebsr(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int m, int n,
+    const cusparseMatDescr_t descrA, const cuDoubleComplex *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    const cusparseMatDescr_t descrC, cuDoubleComplex *bsrSortedValC,
+    int *bsrSortedRowPtrC, int *bsrSortedColIndC, int rowBlockDim,
+    int colBlockDim, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, const cusparseMatDescr_t,
+      const cuDoubleComplex *, const int *, const int *,
+      const cusparseMatDescr_t, cuDoubleComplex *, int *, int *, int, int,
+      void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsr2gebsr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, descrC, bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC, rowBlockDim, colBlockDim, pBuffer);
+  return func_ptr(handle, dirA, m, n, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, descrC, bsrSortedValC, bsrSortedRowPtrC,
+                  bsrSortedColIndC, rowBlockDim, colBlockDim, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSgebsr2gebsr_bufferSize(cusparseHandle_t handle,
-                                                             cusparseDirection_t dirA,
-                                                             int mb,
-                                                             int nb,
-                                                             int nnzb,
-                                                             const cusparseMatDescr_t descrA,
-                                                             const float *bsrSortedValA,
-                                                             const int *bsrSortedRowPtrA,
-                                                             const int *bsrSortedColIndA,
-                                                             int rowBlockDimA,
-                                                             int colBlockDimA,
-                                                             int rowBlockDimC,
-                                                             int colBlockDimC,
-                                                             int *pBufferSizeInBytes ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, int, int, int, int, int *);
+cusparseStatus_t CUSPARSEAPI cusparseSgebsr2gebsr_bufferSize(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb, int nnzb,
+    const cusparseMatDescr_t descrA, const float *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDimA,
+    int colBlockDimA, int rowBlockDimC, int colBlockDimC,
+    int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, int,
+      const cusparseMatDescr_t, const float *, const int *, const int *, int,
+      int, int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgebsr2gebsr_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA, colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA,
+                  bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA,
+                  colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDgebsr2gebsr_bufferSize(cusparseHandle_t handle,
-                                                             cusparseDirection_t dirA,
-                                                             int mb,
-                                                             int nb,
-                                                             int nnzb,
-                                                             const cusparseMatDescr_t descrA,
-                                                             const double *bsrSortedValA,
-                                                             const int *bsrSortedRowPtrA,
-                                                             const int *bsrSortedColIndA,
-                                                             int rowBlockDimA,
-                                                             int colBlockDimA,
-                                                             int rowBlockDimC,
-                                                             int colBlockDimC,
-                                                             int *pBufferSizeInBytes ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, int, int, int, int, int *);
+cusparseStatus_t CUSPARSEAPI cusparseDgebsr2gebsr_bufferSize(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb, int nnzb,
+    const cusparseMatDescr_t descrA, const double *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDimA,
+    int colBlockDimA, int rowBlockDimC, int colBlockDimC,
+    int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, int,
+      const cusparseMatDescr_t, const double *, const int *, const int *, int,
+      int, int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgebsr2gebsr_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA, colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA,
+                  bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA,
+                  colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCgebsr2gebsr_bufferSize(cusparseHandle_t handle,
-                                                             cusparseDirection_t dirA,
-                                                             int mb,
-                                                             int nb,
-                                                             int nnzb,
-                                                             const cusparseMatDescr_t descrA,
-                                                             const cuComplex *bsrSortedValA,
-                                                             const int *bsrSortedRowPtrA,
-                                                             const int *bsrSortedColIndA,
-                                                             int rowBlockDimA,
-                                                             int colBlockDimA,
-                                                             int rowBlockDimC,
-                                                             int colBlockDimC,
-                                                             int *pBufferSizeInBytes ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, int, int, int, int, int *);
+cusparseStatus_t CUSPARSEAPI cusparseCgebsr2gebsr_bufferSize(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb, int nnzb,
+    const cusparseMatDescr_t descrA, const cuComplex *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDimA,
+    int colBlockDimA, int rowBlockDimC, int colBlockDimC,
+    int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, int,
+      const cusparseMatDescr_t, const cuComplex *, const int *, const int *,
+      int, int, int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgebsr2gebsr_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA, colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA,
+                  bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA,
+                  colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZgebsr2gebsr_bufferSize(cusparseHandle_t handle,
-                                                             cusparseDirection_t dirA,
-                                                             int mb,
-                                                             int nb,
-                                                             int nnzb,
-                                                             const cusparseMatDescr_t descrA,
-                                                             const cuDoubleComplex *bsrSortedValA,
-                                                             const int *bsrSortedRowPtrA,
-                                                             const int *bsrSortedColIndA,
-                                                             int rowBlockDimA,
-                                                             int colBlockDimA,
-                                                             int rowBlockDimC,
-                                                             int colBlockDimC,
-                                                             int *pBufferSizeInBytes ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, int, int, int, int, int *);
+cusparseStatus_t CUSPARSEAPI cusparseZgebsr2gebsr_bufferSize(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb, int nnzb,
+    const cusparseMatDescr_t descrA, const cuDoubleComplex *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDimA,
+    int colBlockDimA, int rowBlockDimC, int colBlockDimC,
+    int *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, int,
+      const cusparseMatDescr_t, const cuDoubleComplex *, const int *,
+      const int *, int, int, int, int, int *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgebsr2gebsr_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA, colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSizeInBytes);
+  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA,
+                  bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA,
+                  colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSgebsr2gebsr_bufferSizeExt(cusparseHandle_t handle,
-                                                                cusparseDirection_t dirA,
-                                                                int mb,
-                                                                int nb,
-                                                                int nnzb,
-                                                                const cusparseMatDescr_t descrA,
-                                                                const float *bsrSortedValA,
-                                                                const int    *bsrSortedRowPtrA,
-                                                                const int    *bsrSortedColIndA,
-                                                                int   rowBlockDimA,
-                                                                int   colBlockDimA,
-                                                                int   rowBlockDimC,
-                                                                int   colBlockDimC,
-                                                                size_t  *pBufferSize ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, int, const cusparseMatDescr_t, const float *, const int    *, const int    *, int, int, int, int, size_t  *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgebsr2gebsr_bufferSizeExt");
+cusparseStatus_t CUSPARSEAPI cusparseSgebsr2gebsr_bufferSizeExt(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb, int nnzb,
+    const cusparseMatDescr_t descrA, const float *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDimA,
+    int colBlockDimA, int rowBlockDimC, int colBlockDimC, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, int,
+      const cusparseMatDescr_t, const float *, const int *, const int *, int,
+      int, int, int, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseSgebsr2gebsr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA, colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSize);
+  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA,
+                  bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA,
+                  colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDgebsr2gebsr_bufferSizeExt(cusparseHandle_t handle,
-                                                                cusparseDirection_t dirA,
-                                                                int mb,
-                                                                int nb,
-                                                                int nnzb,
-                                                                const cusparseMatDescr_t descrA,
-                                                                const double *bsrSortedValA,
-                                                                const int    *bsrSortedRowPtrA,
-                                                                const int    *bsrSortedColIndA,
-                                                                int   rowBlockDimA,
-                                                                int   colBlockDimA,
-                                                                int   rowBlockDimC,
-                                                                int   colBlockDimC,
-                                                                size_t  *pBufferSize ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, int, const cusparseMatDescr_t, const double *, const int    *, const int    *, int, int, int, int, size_t  *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgebsr2gebsr_bufferSizeExt");
+cusparseStatus_t CUSPARSEAPI cusparseDgebsr2gebsr_bufferSizeExt(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb, int nnzb,
+    const cusparseMatDescr_t descrA, const double *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDimA,
+    int colBlockDimA, int rowBlockDimC, int colBlockDimC, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, int,
+      const cusparseMatDescr_t, const double *, const int *, const int *, int,
+      int, int, int, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseDgebsr2gebsr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA, colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSize);
+  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA,
+                  bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA,
+                  colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCgebsr2gebsr_bufferSizeExt(cusparseHandle_t handle,
-                                                                cusparseDirection_t dirA,
-                                                                int mb,
-                                                                int nb,
-                                                                int nnzb,
-                                                                const cusparseMatDescr_t descrA,
-                                                                const cuComplex *bsrSortedValA,
-                                                                const int    *bsrSortedRowPtrA,
-                                                                const int    *bsrSortedColIndA,
-                                                                int   rowBlockDimA,
-                                                                int   colBlockDimA,
-                                                                int   rowBlockDimC,
-                                                                int   colBlockDimC,
-                                                                size_t  *pBufferSize ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, int, const cusparseMatDescr_t, const cuComplex *, const int    *, const int    *, int, int, int, int, size_t  *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgebsr2gebsr_bufferSizeExt");
+cusparseStatus_t CUSPARSEAPI cusparseCgebsr2gebsr_bufferSizeExt(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb, int nnzb,
+    const cusparseMatDescr_t descrA, const cuComplex *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDimA,
+    int colBlockDimA, int rowBlockDimC, int colBlockDimC, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, int,
+      const cusparseMatDescr_t, const cuComplex *, const int *, const int *,
+      int, int, int, int, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseCgebsr2gebsr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA, colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSize);
+  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA,
+                  bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA,
+                  colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZgebsr2gebsr_bufferSizeExt(cusparseHandle_t handle,
-                                                                cusparseDirection_t dirA,
-                                                                int mb,
-                                                                int nb,
-                                                                int nnzb,
-                                                                const cusparseMatDescr_t descrA,
-                                                                const cuDoubleComplex *bsrSortedValA,
-                                                                const int    *bsrSortedRowPtrA,
-                                                                const int    *bsrSortedColIndA,
-                                                                int   rowBlockDimA,
-                                                                int   colBlockDimA,
-                                                                int   rowBlockDimC,
-                                                                int   colBlockDimC,
-                                                                size_t  *pBufferSize ) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int    *, const int    *, int, int, int, int, size_t  *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgebsr2gebsr_bufferSizeExt");
+cusparseStatus_t CUSPARSEAPI cusparseZgebsr2gebsr_bufferSizeExt(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb, int nnzb,
+    const cusparseMatDescr_t descrA, const cuDoubleComplex *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDimA,
+    int colBlockDimA, int rowBlockDimC, int colBlockDimC, size_t *pBufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, int,
+      const cusparseMatDescr_t, const cuDoubleComplex *, const int *,
+      const int *, int, int, int, int, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseZgebsr2gebsr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA, colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSize);
+  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA,
+                  bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA,
+                  colBlockDimA, rowBlockDimC, colBlockDimC, pBufferSize);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseXgebsr2gebsrNnz(cusparseHandle_t handle,
-                                                     cusparseDirection_t dirA,
-                                                     int mb,
-                                                     int nb,
-                                                     int nnzb,
-                                                     const cusparseMatDescr_t descrA,
-                                                     const int *bsrSortedRowPtrA,
-                                                     const int *bsrSortedColIndA,
-                                                     int rowBlockDimA,
-                                                     int colBlockDimA,
-                                                     const cusparseMatDescr_t descrC,
-                                                     int *bsrSortedRowPtrC,
-                                                     int rowBlockDimC,
-                                                     int colBlockDimC,
-                                                     int *nnzTotalDevHostPtr,
-                                                     void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, int, const cusparseMatDescr_t, const int *, const int *, int, int, const cusparseMatDescr_t, int *, int, int, int *, void *);
+cusparseStatus_t CUSPARSEAPI cusparseXgebsr2gebsrNnz(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb, int nnzb,
+    const cusparseMatDescr_t descrA, const int *bsrSortedRowPtrA,
+    const int *bsrSortedColIndA, int rowBlockDimA, int colBlockDimA,
+    const cusparseMatDescr_t descrC, int *bsrSortedRowPtrC, int rowBlockDimC,
+    int colBlockDimC, int *nnzTotalDevHostPtr, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, int,
+      const cusparseMatDescr_t, const int *, const int *, int, int,
+      const cusparseMatDescr_t, int *, int, int, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXgebsr2gebsrNnz");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA, colBlockDimA, descrC, bsrSortedRowPtrC, rowBlockDimC, colBlockDimC, nnzTotalDevHostPtr, pBuffer);
+  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedRowPtrA,
+                  bsrSortedColIndA, rowBlockDimA, colBlockDimA, descrC,
+                  bsrSortedRowPtrC, rowBlockDimC, colBlockDimC,
+                  nnzTotalDevHostPtr, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseSgebsr2gebsr(cusparseHandle_t handle,
-                                                  cusparseDirection_t dirA,
-                                                  int mb,
-                                                  int nb,
-                                                  int nnzb,
-                                                  const cusparseMatDescr_t descrA,
-                                                  const float *bsrSortedValA,
-                                                  const int *bsrSortedRowPtrA,
-                                                  const int *bsrSortedColIndA,
-                                                  int rowBlockDimA,
-                                                  int colBlockDimA,
-                                                  const cusparseMatDescr_t descrC,
-                                                  float *bsrSortedValC,
-                                                  int *bsrSortedRowPtrC,
-                                                  int *bsrSortedColIndC,
-                                                  int rowBlockDimC,
-                                                  int colBlockDimC,
-                                                  void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, int, int, const cusparseMatDescr_t, float *, int *, int *, int, int, void *);
+cusparseStatus_t CUSPARSEAPI cusparseSgebsr2gebsr(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb, int nnzb,
+    const cusparseMatDescr_t descrA, const float *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDimA,
+    int colBlockDimA, const cusparseMatDescr_t descrC, float *bsrSortedValC,
+    int *bsrSortedRowPtrC, int *bsrSortedColIndC, int rowBlockDimC,
+    int colBlockDimC, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, int,
+      const cusparseMatDescr_t, const float *, const int *, const int *, int,
+      int, const cusparseMatDescr_t, float *, int *, int *, int, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSgebsr2gebsr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA, colBlockDimA, descrC, bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC, rowBlockDimC, colBlockDimC, pBuffer);
+  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA,
+                  bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA,
+                  colBlockDimA, descrC, bsrSortedValC, bsrSortedRowPtrC,
+                  bsrSortedColIndC, rowBlockDimC, colBlockDimC, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDgebsr2gebsr(cusparseHandle_t handle,
-                                                  cusparseDirection_t dirA,
-                                                  int mb,
-                                                  int nb,
-                                                  int nnzb,
-                                                  const cusparseMatDescr_t descrA,
-                                                  const double *bsrSortedValA,
-                                                  const int *bsrSortedRowPtrA,
-                                                  const int *bsrSortedColIndA,
-                                                  int rowBlockDimA,
-                                                  int colBlockDimA,
-                                                  const cusparseMatDescr_t descrC,
-                                                  double *bsrSortedValC,
-                                                  int *bsrSortedRowPtrC,
-                                                  int *bsrSortedColIndC,
-                                                  int rowBlockDimC,
-                                                  int colBlockDimC,
-                                                  void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, int, int, const cusparseMatDescr_t, double *, int *, int *, int, int, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDgebsr2gebsr(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb, int nnzb,
+    const cusparseMatDescr_t descrA, const double *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDimA,
+    int colBlockDimA, const cusparseMatDescr_t descrC, double *bsrSortedValC,
+    int *bsrSortedRowPtrC, int *bsrSortedColIndC, int rowBlockDimC,
+    int colBlockDimC, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, int,
+      const cusparseMatDescr_t, const double *, const int *, const int *, int,
+      int, const cusparseMatDescr_t, double *, int *, int *, int, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDgebsr2gebsr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA, colBlockDimA, descrC, bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC, rowBlockDimC, colBlockDimC, pBuffer);
+  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA,
+                  bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA,
+                  colBlockDimA, descrC, bsrSortedValC, bsrSortedRowPtrC,
+                  bsrSortedColIndC, rowBlockDimC, colBlockDimC, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCgebsr2gebsr(cusparseHandle_t handle,
-                                                  cusparseDirection_t dirA,
-                                                  int mb,
-                                                  int nb,
-                                                  int nnzb,
-                                                  const cusparseMatDescr_t descrA,
-                                                  const cuComplex *bsrSortedValA,
-                                                  const int *bsrSortedRowPtrA,
-                                                  const int *bsrSortedColIndA,
-                                                  int rowBlockDimA,
-                                                  int colBlockDimA,
-                                                  const cusparseMatDescr_t descrC,
-                                                  cuComplex *bsrSortedValC,
-                                                  int *bsrSortedRowPtrC,
-                                                  int *bsrSortedColIndC,
-                                                  int rowBlockDimC,
-                                                  int colBlockDimC,
-                                                  void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, int, const cusparseMatDescr_t, const cuComplex *, const int *, const int *, int, int, const cusparseMatDescr_t, cuComplex *, int *, int *, int, int, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCgebsr2gebsr(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb, int nnzb,
+    const cusparseMatDescr_t descrA, const cuComplex *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDimA,
+    int colBlockDimA, const cusparseMatDescr_t descrC, cuComplex *bsrSortedValC,
+    int *bsrSortedRowPtrC, int *bsrSortedColIndC, int rowBlockDimC,
+    int colBlockDimC, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, int,
+      const cusparseMatDescr_t, const cuComplex *, const int *, const int *,
+      int, int, const cusparseMatDescr_t, cuComplex *, int *, int *, int, int,
+      void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCgebsr2gebsr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA, colBlockDimA, descrC, bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC, rowBlockDimC, colBlockDimC, pBuffer);
+  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA,
+                  bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA,
+                  colBlockDimA, descrC, bsrSortedValC, bsrSortedRowPtrC,
+                  bsrSortedColIndC, rowBlockDimC, colBlockDimC, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZgebsr2gebsr(cusparseHandle_t handle,
-                                                  cusparseDirection_t dirA,
-                                                  int mb,
-                                                  int nb,
-                                                  int nnzb,
-                                                  const cusparseMatDescr_t descrA,
-                                                  const cuDoubleComplex *bsrSortedValA,
-                                                  const int *bsrSortedRowPtrA,
-                                                  const int *bsrSortedColIndA,
-                                                  int rowBlockDimA,
-                                                  int colBlockDimA,
-                                                  const cusparseMatDescr_t descrC,
-                                                  cuDoubleComplex *bsrSortedValC,
-                                                  int *bsrSortedRowPtrC,
-                                                  int *bsrSortedColIndC,
-                                                  int rowBlockDimC,
-                                                  int colBlockDimC,
-                                                  void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseDirection_t, int, int, int, const cusparseMatDescr_t, const cuDoubleComplex *, const int *, const int *, int, int, const cusparseMatDescr_t, cuDoubleComplex *, int *, int *, int, int, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZgebsr2gebsr(
+    cusparseHandle_t handle, cusparseDirection_t dirA, int mb, int nb, int nnzb,
+    const cusparseMatDescr_t descrA, const cuDoubleComplex *bsrSortedValA,
+    const int *bsrSortedRowPtrA, const int *bsrSortedColIndA, int rowBlockDimA,
+    int colBlockDimA, const cusparseMatDescr_t descrC,
+    cuDoubleComplex *bsrSortedValC, int *bsrSortedRowPtrC,
+    int *bsrSortedColIndC, int rowBlockDimC, int colBlockDimC, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseDirection_t, int, int, int,
+      const cusparseMatDescr_t, const cuDoubleComplex *, const int *,
+      const int *, int, int, const cusparseMatDescr_t, cuDoubleComplex *, int *,
+      int *, int, int, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZgebsr2gebsr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA, bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA, colBlockDimA, descrC, bsrSortedValC, bsrSortedRowPtrC, bsrSortedColIndC, rowBlockDimC, colBlockDimC, pBuffer);
+  return func_ptr(handle, dirA, mb, nb, nnzb, descrA, bsrSortedValA,
+                  bsrSortedRowPtrA, bsrSortedColIndA, rowBlockDimA,
+                  colBlockDimA, descrC, bsrSortedValC, bsrSortedRowPtrC,
+                  bsrSortedColIndC, rowBlockDimC, colBlockDimC, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCreateIdentityPermutation(cusparseHandle_t handle,
-                                                               int n,
-                                                               int *p) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateIdentityPermutation");
+cusparseStatus_t CUSPARSEAPI
+cusparseCreateIdentityPermutation(cusparseHandle_t handle, int n, int *p) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseHandle_t, int, int *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseCreateIdentityPermutation");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, n, p);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseXcoosort_bufferSizeExt(cusparseHandle_t handle,
-                                                            int m,
-                                                            int n,
-                                                            int nnz,
-                                                            const int *cooRowsA,
-                                                            const int *cooColsA,
-                                                            size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const int *, const int *, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseXcoosort_bufferSizeExt(
+    cusparseHandle_t handle, int m, int n, int nnz, const int *cooRowsA,
+    const int *cooColsA, size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const int *, const int *, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcoosort_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, nnz, cooRowsA, cooColsA, pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseXcoosortByRow(cusparseHandle_t handle,
-                                                   int m,
-                                                   int n,
-                                                   int nnz,
-                                                   int *cooRowsA,
-                                                   int *cooColsA,
-                                                   int *P,
-                                                   void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, int *, int *, int *, void *);
+                                                   int m, int n, int nnz,
+                                                   int *cooRowsA, int *cooColsA,
+                                                   int *P, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, int *, int *, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcoosortByRow");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, nnz, cooRowsA, cooColsA, P, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseXcoosortByColumn(cusparseHandle_t handle,
-                                                      int m,
-                                                      int n,
-                                                      int nnz,
+                                                      int m, int n, int nnz,
                                                       int *cooRowsA,
-                                                      int *cooColsA,
-                                                      int *P,
+                                                      int *cooColsA, int *P,
                                                       void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, int *, int *, int *, void *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, int *, int *, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcoosortByColumn");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(handle, m, n, nnz, cooRowsA, cooColsA, P, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseXcsrsort_bufferSizeExt(cusparseHandle_t handle,
-                                                            int m,
-                                                            int n,
-                                                            int nnz,
-                                                            const int *csrRowPtrA,
-                                                            const int *csrColIndA,
-                                                            size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const int *, const int *, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseXcsrsort_bufferSizeExt(
+    cusparseHandle_t handle, int m, int n, int nnz, const int *csrRowPtrA,
+    const int *csrColIndA, size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const int *, const int *, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcsrsort_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, csrRowPtrA, csrColIndA, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, nnz, csrRowPtrA, csrColIndA,
+                  pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseXcsrsort(cusparseHandle_t handle,
-                                              int m,
-                                              int n,
-                                              int nnz,
+cusparseStatus_t CUSPARSEAPI cusparseXcsrsort(cusparseHandle_t handle, int m,
+                                              int n, int nnz,
                                               const cusparseMatDescr_t descrA,
                                               const int *csrRowPtrA,
-                                              int *csrColIndA,
-                                              int *P,
+                                              int *csrColIndA, int *P,
                                               void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const int *, int *, int *, void *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const int *,
+      int *, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcsrsort");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, descrA, csrRowPtrA, csrColIndA, P, pBuffer);
+  return func_ptr(handle, m, n, nnz, descrA, csrRowPtrA, csrColIndA, P,
+                  pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseXcscsort_bufferSizeExt(cusparseHandle_t handle,
-                                                            int m,
-                                                            int n,
-                                                            int nnz,
-                                                            const int *cscColPtrA,
-                                                            const int *cscRowIndA,
-                                                            size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const int *, const int *, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseXcscsort_bufferSizeExt(
+    cusparseHandle_t handle, int m, int n, int nnz, const int *cscColPtrA,
+    const int *cscRowIndA, size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const int *, const int *, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcscsort_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, cscColPtrA, cscRowIndA, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, nnz, cscColPtrA, cscRowIndA,
+                  pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseXcscsort(cusparseHandle_t handle,
-                                              int m,
-                                              int n,
-                                              int nnz,
+cusparseStatus_t CUSPARSEAPI cusparseXcscsort(cusparseHandle_t handle, int m,
+                                              int n, int nnz,
                                               const cusparseMatDescr_t descrA,
                                               const int *cscColPtrA,
-                                              int *cscRowIndA,
-                                              int *P,
+                                              int *cscRowIndA, int *P,
                                               void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const int *, int *, int *, void *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const int *,
+      int *, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseXcscsort");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, descrA, cscColPtrA, cscRowIndA, P, pBuffer);
+  return func_ptr(handle, m, n, nnz, descrA, cscColPtrA, cscRowIndA, P,
+                  pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsru2csr_bufferSizeExt(cusparseHandle_t handle,
-                                                             int m,
-                                                             int n,
-                                                             int nnz,
-                                                             float *csrVal,
-                                                             const int *csrRowPtr,
-                                                             int *csrColInd,
-                                                             csru2csrInfo_t  info,
-                                                             size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, float *, const int *, int *, csru2csrInfo_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseScsru2csr_bufferSizeExt(
+    cusparseHandle_t handle, int m, int n, int nnz, float *csrVal,
+    const int *csrRowPtr, int *csrColInd, csru2csrInfo_t info,
+    size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, float *, const int *, int *,
+      csru2csrInfo_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsru2csr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, csrVal, csrRowPtr, csrColInd, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, nnz, csrVal, csrRowPtr, csrColInd, info,
+                  pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsru2csr_bufferSizeExt(cusparseHandle_t handle,
-                                                             int m,
-                                                             int n,
-                                                             int nnz,
-                                                             double *csrVal,
-                                                             const int *csrRowPtr,
-                                                             int *csrColInd,
-                                                             csru2csrInfo_t  info,
-                                                             size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, double *, const int *, int *, csru2csrInfo_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsru2csr_bufferSizeExt(
+    cusparseHandle_t handle, int m, int n, int nnz, double *csrVal,
+    const int *csrRowPtr, int *csrColInd, csru2csrInfo_t info,
+    size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, double *, const int *, int *,
+      csru2csrInfo_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsru2csr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, csrVal, csrRowPtr, csrColInd, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, nnz, csrVal, csrRowPtr, csrColInd, info,
+                  pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsru2csr_bufferSizeExt(cusparseHandle_t handle,
-                                                             int m,
-                                                             int n,
-                                                             int nnz,
-                                                             cuComplex *csrVal,
-                                                             const int *csrRowPtr,
-                                                             int *csrColInd,
-                                                             csru2csrInfo_t  info,
-                                                             size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, cuComplex *, const int *, int *, csru2csrInfo_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsru2csr_bufferSizeExt(
+    cusparseHandle_t handle, int m, int n, int nnz, cuComplex *csrVal,
+    const int *csrRowPtr, int *csrColInd, csru2csrInfo_t info,
+    size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, cuComplex *, const int *, int *,
+      csru2csrInfo_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsru2csr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, csrVal, csrRowPtr, csrColInd, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, nnz, csrVal, csrRowPtr, csrColInd, info,
+                  pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsru2csr_bufferSizeExt(cusparseHandle_t handle,
-                                                             int m,
-                                                             int n,
-                                                             int nnz,
-                                                             cuDoubleComplex *csrVal,
-                                                             const int *csrRowPtr,
-                                                             int *csrColInd,
-                                                             csru2csrInfo_t  info,
-                                                             size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, cuDoubleComplex *, const int *, int *, csru2csrInfo_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsru2csr_bufferSizeExt(
+    cusparseHandle_t handle, int m, int n, int nnz, cuDoubleComplex *csrVal,
+    const int *csrRowPtr, int *csrColInd, csru2csrInfo_t info,
+    size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, cuDoubleComplex *, const int *, int *,
+      csru2csrInfo_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsru2csr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, csrVal, csrRowPtr, csrColInd, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, nnz, csrVal, csrRowPtr, csrColInd, info,
+                  pBufferSizeInBytes);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsru2csr(cusparseHandle_t handle,
-                                               int m,
-                                               int n,
-                                               int nnz,
-                                               const cusparseMatDescr_t descrA,
-                                               float *csrVal,
-                                               const int *csrRowPtr,
-                                               int *csrColInd,
-                                               csru2csrInfo_t  info,
-                                               void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, float *, const int *, int *, csru2csrInfo_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseScsru2csr(
+    cusparseHandle_t handle, int m, int n, int nnz,
+    const cusparseMatDescr_t descrA, float *csrVal, const int *csrRowPtr,
+    int *csrColInd, csru2csrInfo_t info, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, float *,
+      const int *, int *, csru2csrInfo_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsru2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info, pBuffer);
+  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info,
+                  pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsru2csr(cusparseHandle_t handle,
-                                               int m,
-                                               int n,
-                                               int nnz,
-                                               const cusparseMatDescr_t descrA,
-                                               double *csrVal,
-                                               const int *csrRowPtr,
-                                               int *csrColInd,
-                                               csru2csrInfo_t  info,
-                                               void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, double *, const int *, int *, csru2csrInfo_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsru2csr(
+    cusparseHandle_t handle, int m, int n, int nnz,
+    const cusparseMatDescr_t descrA, double *csrVal, const int *csrRowPtr,
+    int *csrColInd, csru2csrInfo_t info, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, double *,
+      const int *, int *, csru2csrInfo_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsru2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info, pBuffer);
+  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info,
+                  pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsru2csr(cusparseHandle_t handle,
-                                               int m,
-                                               int n,
-                                               int nnz,
-                                               const cusparseMatDescr_t descrA,
-                                               cuComplex *csrVal,
-                                               const int *csrRowPtr,
-                                               int *csrColInd,
-                                               csru2csrInfo_t  info,
-                                               void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, cuComplex *, const int *, int *, csru2csrInfo_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsru2csr(
+    cusparseHandle_t handle, int m, int n, int nnz,
+    const cusparseMatDescr_t descrA, cuComplex *csrVal, const int *csrRowPtr,
+    int *csrColInd, csru2csrInfo_t info, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, cuComplex *,
+      const int *, int *, csru2csrInfo_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsru2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info, pBuffer);
+  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info,
+                  pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsru2csr(cusparseHandle_t handle,
-                                               int m,
-                                               int n,
-                                               int nnz,
-                                               const cusparseMatDescr_t descrA,
-                                               cuDoubleComplex *csrVal,
-                                               const int *csrRowPtr,
-                                               int *csrColInd,
-                                               csru2csrInfo_t  info,
-                                               void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, int *, csru2csrInfo_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsru2csr(
+    cusparseHandle_t handle, int m, int n, int nnz,
+    const cusparseMatDescr_t descrA, cuDoubleComplex *csrVal,
+    const int *csrRowPtr, int *csrColInd, csru2csrInfo_t info, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cusparseMatDescr_t,
+      cuDoubleComplex *, const int *, int *, csru2csrInfo_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsru2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info, pBuffer);
+  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info,
+                  pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseScsr2csru(cusparseHandle_t handle,
-                                               int m,
-                                               int n,
-                                               int nnz,
-                                               const cusparseMatDescr_t descrA,
-                                               float *csrVal,
-                                               const int *csrRowPtr,
-                                               int *csrColInd,
-                                               csru2csrInfo_t  info,
-                                               void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, float *, const int *, int *, csru2csrInfo_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseScsr2csru(
+    cusparseHandle_t handle, int m, int n, int nnz,
+    const cusparseMatDescr_t descrA, float *csrVal, const int *csrRowPtr,
+    int *csrColInd, csru2csrInfo_t info, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, float *,
+      const int *, int *, csru2csrInfo_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseScsr2csru");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info, pBuffer);
+  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info,
+                  pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseDcsr2csru(cusparseHandle_t handle,
-                                               int m,
-                                               int n,
-                                               int nnz,
-                                               const cusparseMatDescr_t descrA,
-                                               double *csrVal,
-                                               const int *csrRowPtr,
-                                               int *csrColInd,
-                                               csru2csrInfo_t  info,
-                                               void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, double *, const int *, int *, csru2csrInfo_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseDcsr2csru(
+    cusparseHandle_t handle, int m, int n, int nnz,
+    const cusparseMatDescr_t descrA, double *csrVal, const int *csrRowPtr,
+    int *csrColInd, csru2csrInfo_t info, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, double *,
+      const int *, int *, csru2csrInfo_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDcsr2csru");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info, pBuffer);
+  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info,
+                  pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseCcsr2csru(cusparseHandle_t handle,
-                                               int m,
-                                               int n,
-                                               int nnz,
-                                               const cusparseMatDescr_t descrA,
-                                               cuComplex *csrVal,
-                                               const int *csrRowPtr,
-                                               int *csrColInd,
-                                               csru2csrInfo_t  info,
-                                               void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, cuComplex *, const int *, int *, csru2csrInfo_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCcsr2csru(
+    cusparseHandle_t handle, int m, int n, int nnz,
+    const cusparseMatDescr_t descrA, cuComplex *csrVal, const int *csrRowPtr,
+    int *csrColInd, csru2csrInfo_t info, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, cuComplex *,
+      const int *, int *, csru2csrInfo_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCcsr2csru");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info, pBuffer);
+  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info,
+                  pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI cusparseZcsr2csru(cusparseHandle_t handle,
-                                               int m,
-                                               int n,
-                                               int nnz,
-                                               const cusparseMatDescr_t descrA,
-                                               cuDoubleComplex *csrVal,
-                                               const int *csrRowPtr,
-                                               int *csrColInd,
-                                               csru2csrInfo_t  info,
-                                               void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, cuDoubleComplex *, const int *, int *, csru2csrInfo_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseZcsr2csru(
+    cusparseHandle_t handle, int m, int n, int nnz,
+    const cusparseMatDescr_t descrA, cuDoubleComplex *csrVal,
+    const int *csrRowPtr, int *csrColInd, csru2csrInfo_t info, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cusparseMatDescr_t,
+      cuDoubleComplex *, const int *, int *, csru2csrInfo_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseZcsr2csru");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info, pBuffer);
+  return func_ptr(handle, m, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, info,
+                  pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSpruneDense2csr_bufferSizeExt(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const float *A,
-    int lda,
-    const float *threshold,
-    const cusparseMatDescr_t descrC,
-    const float *csrSortedValC,
-    const int *csrSortedRowPtrC,
-    const int *csrSortedColIndC,
-    size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, int, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpruneDense2csr_bufferSizeExt");
+    cusparseHandle_t handle, int m, int n, const float *A, int lda,
+    const float *threshold, const cusparseMatDescr_t descrC,
+    const float *csrSortedValC, const int *csrSortedRowPtrC,
+    const int *csrSortedColIndC, size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const float *, int, const float *,
+      const cusparseMatDescr_t, const float *, const int *, const int *,
+      size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseSpruneDense2csr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, A, lda, threshold, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, A, lda, threshold, descrC, csrSortedValC,
+                  csrSortedRowPtrC, csrSortedColIndC, pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDpruneDense2csr_bufferSizeExt(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const double *A,
-    int lda,
-    const double *threshold,
-    const cusparseMatDescr_t descrC,
-    const double *csrSortedValC,
-    const int *csrSortedRowPtrC,
-    const int *csrSortedColIndC,
-    size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, int, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDpruneDense2csr_bufferSizeExt");
+    cusparseHandle_t handle, int m, int n, const double *A, int lda,
+    const double *threshold, const cusparseMatDescr_t descrC,
+    const double *csrSortedValC, const int *csrSortedRowPtrC,
+    const int *csrSortedColIndC, size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const double *, int, const double *,
+      const cusparseMatDescr_t, const double *, const int *, const int *,
+      size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseDpruneDense2csr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, A, lda, threshold, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, A, lda, threshold, descrC, csrSortedValC,
+                  csrSortedRowPtrC, csrSortedColIndC, pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSpruneDense2csrNnz(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const float *A,
-    int lda,
-    const float *threshold,
-    const cusparseMatDescr_t descrC,
-    int *csrRowPtrC,
-    int *nnzTotalDevHostPtr,
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, int, const float *, const cusparseMatDescr_t, int *, int *, void *);
+    cusparseHandle_t handle, int m, int n, const float *A, int lda,
+    const float *threshold, const cusparseMatDescr_t descrC, int *csrRowPtrC,
+    int *nnzTotalDevHostPtr, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const float *, int, const float *,
+      const cusparseMatDescr_t, int *, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpruneDense2csrNnz");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, A, lda, threshold, descrC, csrRowPtrC, nnzTotalDevHostPtr, pBuffer);
+  return func_ptr(handle, m, n, A, lda, threshold, descrC, csrRowPtrC,
+                  nnzTotalDevHostPtr, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDpruneDense2csrNnz(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const double *A,
-    int lda,
-    const double *threshold,
-    const cusparseMatDescr_t descrC,
-    int *csrSortedRowPtrC,
-    int *nnzTotalDevHostPtr,
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, int, const double *, const cusparseMatDescr_t, int *, int *, void *);
+    cusparseHandle_t handle, int m, int n, const double *A, int lda,
+    const double *threshold, const cusparseMatDescr_t descrC,
+    int *csrSortedRowPtrC, int *nnzTotalDevHostPtr, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const double *, int, const double *,
+      const cusparseMatDescr_t, int *, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDpruneDense2csrNnz");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, A, lda, threshold, descrC, csrSortedRowPtrC, nnzTotalDevHostPtr, pBuffer);
+  return func_ptr(handle, m, n, A, lda, threshold, descrC, csrSortedRowPtrC,
+                  nnzTotalDevHostPtr, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSpruneDense2csr(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const float *A,
-    int lda,
-    const float *threshold,
-    const cusparseMatDescr_t descrC,
-    float *csrSortedValC,
-    const int *csrSortedRowPtrC,
-    int *csrSortedColIndC,
+    cusparseHandle_t handle, int m, int n, const float *A, int lda,
+    const float *threshold, const cusparseMatDescr_t descrC,
+    float *csrSortedValC, const int *csrSortedRowPtrC, int *csrSortedColIndC,
     void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, int, const float *, const cusparseMatDescr_t, float *, const int *, int *, void *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const float *, int, const float *,
+      const cusparseMatDescr_t, float *, const int *, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpruneDense2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, A, lda, threshold, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBuffer);
+  return func_ptr(handle, m, n, A, lda, threshold, descrC, csrSortedValC,
+                  csrSortedRowPtrC, csrSortedColIndC, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDpruneDense2csr(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const double *A,
-    int lda,
-    const double *threshold,
-    const cusparseMatDescr_t descrC,
-    double *csrSortedValC,
-    const int *csrSortedRowPtrC,
-    int *csrSortedColIndC,
+    cusparseHandle_t handle, int m, int n, const double *A, int lda,
+    const double *threshold, const cusparseMatDescr_t descrC,
+    double *csrSortedValC, const int *csrSortedRowPtrC, int *csrSortedColIndC,
     void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, int, const double *, const cusparseMatDescr_t, double *, const int *, int *, void *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const double *, int, const double *,
+      const cusparseMatDescr_t, double *, const int *, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDpruneDense2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, A, lda, threshold, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBuffer);
+  return func_ptr(handle, m, n, A, lda, threshold, descrC, csrSortedValC,
+                  csrSortedRowPtrC, csrSortedColIndC, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSpruneCsr2csr_bufferSizeExt(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    int nnzA,
-    const cusparseMatDescr_t descrA,
-    const float *csrSortedValA,
-    const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA,
-    const float *threshold,
-    const cusparseMatDescr_t descrC,
-    const float *csrSortedValC,
-    const int *csrSortedRowPtrC,
-    const int *csrSortedColIndC,
-    size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, const float *, const cusparseMatDescr_t, const float *, const int *, const int *, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpruneCsr2csr_bufferSizeExt");
+    cusparseHandle_t handle, int m, int n, int nnzA,
+    const cusparseMatDescr_t descrA, const float *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    const float *threshold, const cusparseMatDescr_t descrC,
+    const float *csrSortedValC, const int *csrSortedRowPtrC,
+    const int *csrSortedColIndC, size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const float *,
+      const int *, const int *, const float *, const cusparseMatDescr_t,
+      const float *, const int *, const int *, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseSpruneCsr2csr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, threshold, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, threshold, descrC, csrSortedValC,
+                  csrSortedRowPtrC, csrSortedColIndC, pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDpruneCsr2csr_bufferSizeExt(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    int nnzA,
-    const cusparseMatDescr_t descrA,
-    const double *csrSortedValA,
-    const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA,
-    const double *threshold,
-    const cusparseMatDescr_t descrC,
-    const double *csrSortedValC,
-    const int *csrSortedRowPtrC,
-    const int *csrSortedColIndC,
-    size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, const double *, const cusparseMatDescr_t, const double *, const int *, const int *, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDpruneCsr2csr_bufferSizeExt");
+    cusparseHandle_t handle, int m, int n, int nnzA,
+    const cusparseMatDescr_t descrA, const double *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    const double *threshold, const cusparseMatDescr_t descrC,
+    const double *csrSortedValC, const int *csrSortedRowPtrC,
+    const int *csrSortedColIndC, size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const double *,
+      const int *, const int *, const double *, const cusparseMatDescr_t,
+      const double *, const int *, const int *, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseDpruneCsr2csr_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, threshold, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, threshold, descrC, csrSortedValC,
+                  csrSortedRowPtrC, csrSortedColIndC, pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSpruneCsr2csrNnz(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    int nnzA,
-    const cusparseMatDescr_t descrA,
-    const float *csrSortedValA,
-    const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA,
-    const float *threshold,
-    const cusparseMatDescr_t descrC,
-    int *csrSortedRowPtrC,
-    int *nnzTotalDevHostPtr, /* can be on host or device */
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, const float *, const cusparseMatDescr_t, int *, int *, void *);
+    cusparseHandle_t handle, int m, int n, int nnzA,
+    const cusparseMatDescr_t descrA, const float *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    const float *threshold, const cusparseMatDescr_t descrC,
+    int *csrSortedRowPtrC, int *nnzTotalDevHostPtr, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const float *,
+      const int *, const int *, const float *, const cusparseMatDescr_t, int *,
+      int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpruneCsr2csrNnz");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, threshold, descrC, csrSortedRowPtrC, nnzTotalDevHostPtr, pBuffer);
+  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, threshold, descrC, csrSortedRowPtrC,
+                  nnzTotalDevHostPtr, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDpruneCsr2csrNnz(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    int nnzA,
-    const cusparseMatDescr_t descrA,
-    const double *csrSortedValA,
-    const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA,
-    const double *threshold,
-    const cusparseMatDescr_t descrC,
-    int *csrSortedRowPtrC,
-    int *nnzTotalDevHostPtr, /* can be on host or device */
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, const double *, const cusparseMatDescr_t, int *, int *, void *);
+    cusparseHandle_t handle, int m, int n, int nnzA,
+    const cusparseMatDescr_t descrA, const double *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    const double *threshold, const cusparseMatDescr_t descrC,
+    int *csrSortedRowPtrC, int *nnzTotalDevHostPtr, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const double *,
+      const int *, const int *, const double *, const cusparseMatDescr_t, int *,
+      int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDpruneCsr2csrNnz");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, threshold, descrC, csrSortedRowPtrC, nnzTotalDevHostPtr, pBuffer);
+  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, threshold, descrC, csrSortedRowPtrC,
+                  nnzTotalDevHostPtr, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSpruneCsr2csr(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    int nnzA,
-    const cusparseMatDescr_t descrA,
-    const float *csrSortedValA,
-    const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA,
-    const float *threshold,
-    const cusparseMatDescr_t descrC,
-    float *csrSortedValC,
-    const int *csrSortedRowPtrC,
-    int *csrSortedColIndC,
+    cusparseHandle_t handle, int m, int n, int nnzA,
+    const cusparseMatDescr_t descrA, const float *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    const float *threshold, const cusparseMatDescr_t descrC,
+    float *csrSortedValC, const int *csrSortedRowPtrC, int *csrSortedColIndC,
     void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, const float *, const cusparseMatDescr_t, float *, const int *, int *, void *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const float *,
+      const int *, const int *, const float *, const cusparseMatDescr_t,
+      float *, const int *, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpruneCsr2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, threshold, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBuffer);
+  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, threshold, descrC, csrSortedValC,
+                  csrSortedRowPtrC, csrSortedColIndC, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDpruneCsr2csr(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    int nnzA,
-    const cusparseMatDescr_t descrA,
-    const double *csrSortedValA,
-    const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA,
-    const double *threshold,
-    const cusparseMatDescr_t descrC,
-    double *csrSortedValC,
-    const int *csrSortedRowPtrC,
-    int *csrSortedColIndC,
+    cusparseHandle_t handle, int m, int n, int nnzA,
+    const cusparseMatDescr_t descrA, const double *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA,
+    const double *threshold, const cusparseMatDescr_t descrC,
+    double *csrSortedValC, const int *csrSortedRowPtrC, int *csrSortedColIndC,
     void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, const double *, const cusparseMatDescr_t, double *, const int *, int *, void *);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const double *,
+      const int *, const int *, const double *, const cusparseMatDescr_t,
+      double *, const int *, int *, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDpruneCsr2csr");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, threshold, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, pBuffer);
+  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, threshold, descrC, csrSortedValC,
+                  csrSortedRowPtrC, csrSortedColIndC, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSpruneDense2csrByPercentage_bufferSizeExt(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const float *A,
-    int lda,
-    float percentage, /* between 0 to 100 */
-    const cusparseMatDescr_t descrC,
-    const float *csrSortedValC,
-    const int *csrSortedRowPtrC,
-    const int *csrSortedColIndC,
-    pruneInfo_t info,
-    size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, int, float, const cusparseMatDescr_t, const float *, const int *, const int *, pruneInfo_t, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpruneDense2csrByPercentage_bufferSizeExt");
+    cusparseHandle_t handle, int m, int n, const float *A, int lda,
+    float percentage, const cusparseMatDescr_t descrC,
+    const float *csrSortedValC, const int *csrSortedRowPtrC,
+    const int *csrSortedColIndC, pruneInfo_t info, size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const float *, int, float,
+      const cusparseMatDescr_t, const float *, const int *, const int *,
+      pruneInfo_t, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseSpruneDense2csrByPercentage_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, A, lda, percentage, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, A, lda, percentage, descrC, csrSortedValC,
+                  csrSortedRowPtrC, csrSortedColIndC, info, pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDpruneDense2csrByPercentage_bufferSizeExt(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const double *A,
-    int lda,
-    float percentage, /* between 0 to 100 */
-    const cusparseMatDescr_t descrC,
-    const double *csrSortedValC,
-    const int *csrSortedRowPtrC,
-    const int *csrSortedColIndC,
-    pruneInfo_t info,
-    size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, int, float, const cusparseMatDescr_t, const double *, const int *, const int *, pruneInfo_t, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDpruneDense2csrByPercentage_bufferSizeExt");
+    cusparseHandle_t handle, int m, int n, const double *A, int lda,
+    float percentage, const cusparseMatDescr_t descrC,
+    const double *csrSortedValC, const int *csrSortedRowPtrC,
+    const int *csrSortedColIndC, pruneInfo_t info, size_t *pBufferSizeInBytes) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const double *, int, float,
+      const cusparseMatDescr_t, const double *, const int *, const int *,
+      pruneInfo_t, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseDpruneDense2csrByPercentage_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, A, lda, percentage, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, A, lda, percentage, descrC, csrSortedValC,
+                  csrSortedRowPtrC, csrSortedColIndC, info, pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSpruneDense2csrNnzByPercentage(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const float *A,
-    int lda,
-    float percentage, /* between 0 to 100 */
-    const cusparseMatDescr_t descrC,
-    int *csrRowPtrC,
-    int *nnzTotalDevHostPtr, /* can be on host or device */
-    pruneInfo_t info,
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, int, float, const cusparseMatDescr_t, int *, int *, pruneInfo_t, void *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpruneDense2csrNnzByPercentage");
+    cusparseHandle_t handle, int m, int n, const float *A, int lda,
+    float percentage, const cusparseMatDescr_t descrC, int *csrRowPtrC,
+    int *nnzTotalDevHostPtr, pruneInfo_t info, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const float *, int, float,
+      const cusparseMatDescr_t, int *, int *, pruneInfo_t, void *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseSpruneDense2csrNnzByPercentage");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, A, lda, percentage, descrC, csrRowPtrC, nnzTotalDevHostPtr, info, pBuffer);
+  return func_ptr(handle, m, n, A, lda, percentage, descrC, csrRowPtrC,
+                  nnzTotalDevHostPtr, info, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDpruneDense2csrNnzByPercentage(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const double *A,
-    int lda,
-    float percentage, /* between 0 to 100 */
-    const cusparseMatDescr_t descrC,
-    int *csrRowPtrC,
-    int *nnzTotalDevHostPtr, /* can be on host or device */
-    pruneInfo_t info,
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, int, float, const cusparseMatDescr_t, int *, int *, pruneInfo_t, void *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDpruneDense2csrNnzByPercentage");
+    cusparseHandle_t handle, int m, int n, const double *A, int lda,
+    float percentage, const cusparseMatDescr_t descrC, int *csrRowPtrC,
+    int *nnzTotalDevHostPtr, pruneInfo_t info, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const double *, int, float,
+      const cusparseMatDescr_t, int *, int *, pruneInfo_t, void *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseDpruneDense2csrNnzByPercentage");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, A, lda, percentage, descrC, csrRowPtrC, nnzTotalDevHostPtr, info, pBuffer);
+  return func_ptr(handle, m, n, A, lda, percentage, descrC, csrRowPtrC,
+                  nnzTotalDevHostPtr, info, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSpruneDense2csrByPercentage(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const float *A,
-    int lda,
-    float percentage, /* between 0 to 100 */
-    const cusparseMatDescr_t descrC,
-    float *csrSortedValC,
-    const int *csrSortedRowPtrC,
-    int *csrSortedColIndC,
-    pruneInfo_t info,
+    cusparseHandle_t handle, int m, int n, const float *A, int lda,
+    float percentage, const cusparseMatDescr_t descrC, float *csrSortedValC,
+    const int *csrSortedRowPtrC, int *csrSortedColIndC, pruneInfo_t info,
     void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const float *, int, float, const cusparseMatDescr_t, float *, const int *, int *, pruneInfo_t, void *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpruneDense2csrByPercentage");
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const float *, int, float,
+      const cusparseMatDescr_t, float *, const int *, int *, pruneInfo_t,
+      void *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseSpruneDense2csrByPercentage");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, A, lda, percentage, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, info, pBuffer);
+  return func_ptr(handle, m, n, A, lda, percentage, descrC, csrSortedValC,
+                  csrSortedRowPtrC, csrSortedColIndC, info, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDpruneDense2csrByPercentage(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    const double *A,
-    int lda,
-    float percentage, /* between 0 to 100 */
-    const cusparseMatDescr_t descrC,
-    double *csrSortedValC,
-    const int *csrSortedRowPtrC,
-    int *csrSortedColIndC,
-    pruneInfo_t info,
+    cusparseHandle_t handle, int m, int n, const double *A, int lda,
+    float percentage, const cusparseMatDescr_t descrC, double *csrSortedValC,
+    const int *csrSortedRowPtrC, int *csrSortedColIndC, pruneInfo_t info,
     void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, const double *, int, float, const cusparseMatDescr_t, double *, const int *, int *, pruneInfo_t, void *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDpruneDense2csrByPercentage");
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, const double *, int, float,
+      const cusparseMatDescr_t, double *, const int *, int *, pruneInfo_t,
+      void *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseDpruneDense2csrByPercentage");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, A, lda, percentage, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, info, pBuffer);
+  return func_ptr(handle, m, n, A, lda, percentage, descrC, csrSortedValC,
+                  csrSortedRowPtrC, csrSortedColIndC, info, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSpruneCsr2csrByPercentage_bufferSizeExt(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    int nnzA,
-    const cusparseMatDescr_t descrA,
-    const float *csrSortedValA,
-    const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA,
-    float percentage, /* between 0 to 100 */
-    const cusparseMatDescr_t descrC,
-    const float *csrSortedValC,
-    const int *csrSortedRowPtrC,
-    const int *csrSortedColIndC,
-    pruneInfo_t info,
+    cusparseHandle_t handle, int m, int n, int nnzA,
+    const cusparseMatDescr_t descrA, const float *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, float percentage,
+    const cusparseMatDescr_t descrC, const float *csrSortedValC,
+    const int *csrSortedRowPtrC, const int *csrSortedColIndC, pruneInfo_t info,
     size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, float, const cusparseMatDescr_t, const float *, const int *, const int *, pruneInfo_t, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpruneCsr2csrByPercentage_bufferSizeExt");
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const float *,
+      const int *, const int *, float, const cusparseMatDescr_t, const float *,
+      const int *, const int *, pruneInfo_t, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseSpruneCsr2csrByPercentage_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, percentage, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, percentage, descrC, csrSortedValC,
+                  csrSortedRowPtrC, csrSortedColIndC, info, pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDpruneCsr2csrByPercentage_bufferSizeExt(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    int nnzA,
-    const cusparseMatDescr_t descrA,
-    const double *csrSortedValA,
-    const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA,
-    float percentage, /* between 0 to 100 */
-    const cusparseMatDescr_t descrC,
-    const double *csrSortedValC,
-    const int *csrSortedRowPtrC,
-    const int *csrSortedColIndC,
-    pruneInfo_t info,
+    cusparseHandle_t handle, int m, int n, int nnzA,
+    const cusparseMatDescr_t descrA, const double *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, float percentage,
+    const cusparseMatDescr_t descrC, const double *csrSortedValC,
+    const int *csrSortedRowPtrC, const int *csrSortedColIndC, pruneInfo_t info,
     size_t *pBufferSizeInBytes) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, float, const cusparseMatDescr_t, const double *, const int *, const int *, pruneInfo_t, size_t *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDpruneCsr2csrByPercentage_bufferSizeExt");
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const double *,
+      const int *, const int *, float, const cusparseMatDescr_t, const double *,
+      const int *, const int *, pruneInfo_t, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseDpruneCsr2csrByPercentage_bufferSizeExt");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, percentage, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, info, pBufferSizeInBytes);
+  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, percentage, descrC, csrSortedValC,
+                  csrSortedRowPtrC, csrSortedColIndC, info, pBufferSizeInBytes);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSpruneCsr2csrNnzByPercentage(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    int nnzA,
-    const cusparseMatDescr_t descrA,
-    const float *csrSortedValA,
-    const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA,
-    float percentage, /* between 0 to 100 */
-    const cusparseMatDescr_t descrC,
-    int *csrSortedRowPtrC,
-    int *nnzTotalDevHostPtr, /* can be on host or device */
-    pruneInfo_t info,
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, float, const cusparseMatDescr_t, int *, int *, pruneInfo_t, void *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpruneCsr2csrNnzByPercentage");
+    cusparseHandle_t handle, int m, int n, int nnzA,
+    const cusparseMatDescr_t descrA, const float *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, float percentage,
+    const cusparseMatDescr_t descrC, int *csrSortedRowPtrC,
+    int *nnzTotalDevHostPtr, pruneInfo_t info, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const float *,
+      const int *, const int *, float, const cusparseMatDescr_t, int *, int *,
+      pruneInfo_t, void *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseSpruneCsr2csrNnzByPercentage");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, percentage, descrC, csrSortedRowPtrC, nnzTotalDevHostPtr, info, pBuffer);
+  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, percentage, descrC, csrSortedRowPtrC,
+                  nnzTotalDevHostPtr, info, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDpruneCsr2csrNnzByPercentage(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    int nnzA,
-    const cusparseMatDescr_t descrA,
-    const double *csrSortedValA,
-    const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA,
-    float percentage, /* between 0 to 100 */
-    const cusparseMatDescr_t descrC,
-    int *csrSortedRowPtrC,
-    int *nnzTotalDevHostPtr, /* can be on host or device */
-    pruneInfo_t info,
-    void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, float, const cusparseMatDescr_t, int *, int *, pruneInfo_t, void *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDpruneCsr2csrNnzByPercentage");
+    cusparseHandle_t handle, int m, int n, int nnzA,
+    const cusparseMatDescr_t descrA, const double *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, float percentage,
+    const cusparseMatDescr_t descrC, int *csrSortedRowPtrC,
+    int *nnzTotalDevHostPtr, pruneInfo_t info, void *pBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const double *,
+      const int *, const int *, float, const cusparseMatDescr_t, int *, int *,
+      pruneInfo_t, void *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseDpruneCsr2csrNnzByPercentage");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, percentage, descrC, csrSortedRowPtrC, nnzTotalDevHostPtr, info, pBuffer);
+  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, percentage, descrC, csrSortedRowPtrC,
+                  nnzTotalDevHostPtr, info, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseSpruneCsr2csrByPercentage(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    int nnzA,
-    const cusparseMatDescr_t descrA,
-    const float *csrSortedValA,
-    const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA,
-    float percentage, /* between 0 to 100 */
-    const cusparseMatDescr_t descrC,
-    float *csrSortedValC,
-    const int *csrSortedRowPtrC,
-    int *csrSortedColIndC,
-    pruneInfo_t info,
+    cusparseHandle_t handle, int m, int n, int nnzA,
+    const cusparseMatDescr_t descrA, const float *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, float percentage,
+    const cusparseMatDescr_t descrC, float *csrSortedValC,
+    const int *csrSortedRowPtrC, int *csrSortedColIndC, pruneInfo_t info,
     void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const float *, const int *, const int *, float, const cusparseMatDescr_t, float *, const int *, int *, pruneInfo_t, void *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpruneCsr2csrByPercentage");
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const float *,
+      const int *, const int *, float, const cusparseMatDescr_t, float *,
+      const int *, int *, pruneInfo_t, void *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseSpruneCsr2csrByPercentage");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, percentage, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, info, pBuffer);
+  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, percentage, descrC, csrSortedValC,
+                  csrSortedRowPtrC, csrSortedColIndC, info, pBuffer);
 }
 
 cusparseStatus_t CUSPARSEAPI cusparseDpruneCsr2csrByPercentage(
-    cusparseHandle_t handle,
-    int m,
-    int n,
-    int nnzA,
-    const cusparseMatDescr_t descrA,
-    const double *csrSortedValA,
-    const int *csrSortedRowPtrA,
-    const int *csrSortedColIndA,
-    float percentage, /* between 0 to 100 */
-    const cusparseMatDescr_t descrC,
-    double *csrSortedValC,
-    const int *csrSortedRowPtrC,
-    int *csrSortedColIndC,
-    pruneInfo_t info,
+    cusparseHandle_t handle, int m, int n, int nnzA,
+    const cusparseMatDescr_t descrA, const double *csrSortedValA,
+    const int *csrSortedRowPtrA, const int *csrSortedColIndA, float percentage,
+    const cusparseMatDescr_t descrC, double *csrSortedValC,
+    const int *csrSortedRowPtrC, int *csrSortedColIndC, pruneInfo_t info,
     void *pBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const double *, const int *, const int *, float, const cusparseMatDescr_t, double *, const int *, int *, pruneInfo_t, void *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDpruneCsr2csrByPercentage");
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const cusparseMatDescr_t, const double *,
+      const int *, const int *, float, const cusparseMatDescr_t, double *,
+      const int *, int *, pruneInfo_t, void *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseDpruneCsr2csrByPercentage");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA, csrSortedColIndA, percentage, descrC, csrSortedValC, csrSortedRowPtrC, csrSortedColIndC, info, pBuffer);
+  return func_ptr(handle, m, n, nnzA, descrA, csrSortedValA, csrSortedRowPtrA,
+                  csrSortedColIndA, percentage, descrC, csrSortedValC,
+                  csrSortedRowPtrC, csrSortedColIndC, info, pBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseCsr2cscEx2(cusparseHandle_t     handle,
-                   int                  m,
-                   int                  n,
-                   int                  nnz,
-                   const void*          csrVal,
-                   const int*           csrRowPtr,
-                   const int*           csrColInd,
-                   void*                cscVal,
-                   int*                 cscColPtr,
-                   int*                 cscRowInd,
-                   cudaDataType         valType,
-                   cusparseAction_t     copyValues,
-                   cusparseIndexBase_t  idxBase,
-                   cusparseCsr2CscAlg_t alg,
-                   void*                buffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const void *, const int *, const int *, void *, int *, int *, cudaDataType, cusparseAction_t, cusparseIndexBase_t, cusparseCsr2CscAlg_t, void *);
+cusparseStatus_t CUSPARSEAPI cusparseCsr2cscEx2(
+    cusparseHandle_t handle, int m, int n, int nnz, const void *csrVal,
+    const int *csrRowPtr, const int *csrColInd, void *cscVal, int *cscColPtr,
+    int *cscRowInd, cudaDataType valType, cusparseAction_t copyValues,
+    cusparseIndexBase_t idxBase, cusparseCsr2CscAlg_t alg, void *buffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const void *, const int *, const int *,
+      void *, int *, int *, cudaDataType, cusparseAction_t, cusparseIndexBase_t,
+      cusparseCsr2CscAlg_t, void *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCsr2cscEx2");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, csrVal, csrRowPtr, csrColInd, cscVal, cscColPtr, cscRowInd, valType, copyValues, idxBase, alg, buffer);
+  return func_ptr(handle, m, n, nnz, csrVal, csrRowPtr, csrColInd, cscVal,
+                  cscColPtr, cscRowInd, valType, copyValues, idxBase, alg,
+                  buffer);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseCsr2cscEx2_bufferSize(cusparseHandle_t     handle,
-                              int                  m,
-                              int                  n,
-                              int                  nnz,
-                              const void*          csrVal,
-                              const int*           csrRowPtr,
-                              const int*           csrColInd,
-                              void*                cscVal,
-                              int*                 cscColPtr,
-                              int*                 cscRowInd,
-                              cudaDataType         valType,
-                              cusparseAction_t     copyValues,
-                              cusparseIndexBase_t  idxBase,
-                              cusparseCsr2CscAlg_t alg,
-                              size_t*              bufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, int, int, int, const void *, const int *, const int *, void *, int *, int *, cudaDataType, cusparseAction_t, cusparseIndexBase_t, cusparseCsr2CscAlg_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseCsr2cscEx2_bufferSize(
+    cusparseHandle_t handle, int m, int n, int nnz, const void *csrVal,
+    const int *csrRowPtr, const int *csrColInd, void *cscVal, int *cscColPtr,
+    int *cscRowInd, cudaDataType valType, cusparseAction_t copyValues,
+    cusparseIndexBase_t idxBase, cusparseCsr2CscAlg_t alg, size_t *bufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, int, int, int, const void *, const int *, const int *,
+      void *, int *, int *, cudaDataType, cusparseAction_t, cusparseIndexBase_t,
+      cusparseCsr2CscAlg_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCsr2cscEx2_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, m, n, nnz, csrVal, csrRowPtr, csrColInd, cscVal, cscColPtr, cscRowInd, valType, copyValues, idxBase, alg, bufferSize);
+  return func_ptr(handle, m, n, nnz, csrVal, csrRowPtr, csrColInd, cscVal,
+                  cscColPtr, cscRowInd, valType, copyValues, idxBase, alg,
+                  bufferSize);
+}
+
+#if !defined(_WIN32)
+
+cusparseStatus_t CUSPARSEAPI
+cusparseCreateSpVec(cusparseSpVecDescr_t *spVecDescr, int64_t size, int64_t nnz,
+                    void *indices, void *values, cusparseIndexType_t idxType,
+                    cusparseIndexBase_t idxBase, cudaDataType valueType) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseSpVecDescr_t *, int64_t, int64_t, void *, void *,
+      cusparseIndexType_t, cusparseIndexBase_t, cudaDataType);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateSpVec");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(spVecDescr, size, nnz, indices, values, idxType, idxBase,
+                  valueType);
 }
 
 cusparseStatus_t CUSPARSEAPI
-cusparseCreateCoo(cusparseSpMatDescr_t* spMatDescr,
-                  int                   rows,
-                  int                   cols,
-                  int                   nnz,
-                  void*                 cooRowInd,  // COO row indices
-                  void*                 cooColInd,  // COO column indices
-                  void*                 cooValues,  // COO values
-                  cusparseIndexType_t   cooIdxType,
-                  cusparseIndexBase_t   idxBase,
-                  cudaDataType          valueType) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseSpMatDescr_t *, int, int, int, void *, // COO row indices
-                  void *, // COO column indices
-                  void *, // COO values
-                  cusparseIndexType_t, cusparseIndexBase_t, cudaDataType);
+cusparseDestroySpVec(cusparseSpVecDescr_t spVecDescr) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseSpVecDescr_t);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroySpVec");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(spVecDescr);
+}
+
+cusparseStatus_t CUSPARSEAPI cusparseSpVecGet(
+    const cusparseSpVecDescr_t spVecDescr, int64_t *size, int64_t *nnz,
+    void **indices, void **values, cusparseIndexType_t *idxType,
+    cusparseIndexBase_t *idxBase, cudaDataType *valueType) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      const cusparseSpVecDescr_t, int64_t *, int64_t *, void **, void **,
+      cusparseIndexType_t *, cusparseIndexBase_t *, cudaDataType *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpVecGet");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(spVecDescr, size, nnz, indices, values, idxType, idxBase,
+                  valueType);
+}
+
+cusparseStatus_t CUSPARSEAPI cusparseSpVecGetIndexBase(
+    const cusparseSpVecDescr_t spVecDescr, cusparseIndexBase_t *idxBase) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(const cusparseSpVecDescr_t,
+                                                  cusparseIndexBase_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpVecGetIndexBase");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(spVecDescr, idxBase);
+}
+
+cusparseStatus_t CUSPARSEAPI
+cusparseSpVecGetValues(const cusparseSpVecDescr_t spVecDescr, void **values) {
+  using FuncPtr =
+      cusparseStatus_t(CUSPARSEAPI *)(const cusparseSpVecDescr_t, void **);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpVecGetValues");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(spVecDescr, values);
+}
+
+cusparseStatus_t CUSPARSEAPI
+cusparseSpVecSetValues(cusparseSpVecDescr_t spVecDescr, void *values) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseSpVecDescr_t, void *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpVecSetValues");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(spVecDescr, values);
+}
+
+cusparseStatus_t CUSPARSEAPI
+cusparseCreateDnVec(cusparseDnVecDescr_t *dnVecDescr, int64_t size,
+                    void *values, cudaDataType valueType) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseDnVecDescr_t *, int64_t, void *, cudaDataType);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateDnVec");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(dnVecDescr, size, values, valueType);
+}
+
+cusparseStatus_t CUSPARSEAPI
+cusparseDestroyDnVec(cusparseDnVecDescr_t dnVecDescr) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseDnVecDescr_t);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyDnVec");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(dnVecDescr);
+}
+
+cusparseStatus_t CUSPARSEAPI
+cusparseDnVecGet(const cusparseDnVecDescr_t dnVecDescr, int64_t *size,
+                 void **values, cudaDataType *valueType) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      const cusparseDnVecDescr_t, int64_t *, void **, cudaDataType *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDnVecGet");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(dnVecDescr, size, values, valueType);
+}
+
+cusparseStatus_t CUSPARSEAPI
+cusparseDnVecGetValues(const cusparseDnVecDescr_t dnVecDescr, void **values) {
+  using FuncPtr =
+      cusparseStatus_t(CUSPARSEAPI *)(const cusparseDnVecDescr_t, void **);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDnVecGetValues");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(dnVecDescr, values);
+}
+
+cusparseStatus_t CUSPARSEAPI
+cusparseDnVecSetValues(cusparseDnVecDescr_t dnVecDescr, void *values) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseDnVecDescr_t, void *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDnVecSetValues");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(dnVecDescr, values);
+}
+
+cusparseStatus_t CUSPARSEAPI cusparseCreateCoo(cusparseSpMatDescr_t *spMatDescr,
+                                               int64_t rows, int64_t cols,
+                                               int64_t nnz, void *cooRowInd,
+                                               void *cooColInd, void *cooValues,
+                                               cusparseIndexType_t cooIdxType,
+                                               cusparseIndexBase_t idxBase,
+                                               cudaDataType valueType) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseSpMatDescr_t *, int64_t, int64_t, int64_t, void *, void *, void *,
+      cusparseIndexType_t, cusparseIndexBase_t, cudaDataType);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateCoo");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(spMatDescr, rows, cols, nnz, cooRowInd, cooColInd, cooValues, cooIdxType, idxBase, valueType);
+  return func_ptr(spMatDescr, rows, cols, nnz, cooRowInd, cooColInd, cooValues,
+                  cooIdxType, idxBase, valueType);
+}
+
+cusparseStatus_t CUSPARSEAPI cusparseCreateCsr(
+    cusparseSpMatDescr_t *spMatDescr, int64_t rows, int64_t cols, int64_t nnz,
+    void *csrRowOffsets, void *csrColInd, void *csrValues,
+    cusparseIndexType_t csrRowOffsetsType, cusparseIndexType_t csrColIndType,
+    cusparseIndexBase_t idxBase, cudaDataType valueType) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseSpMatDescr_t *, int64_t, int64_t, int64_t, void *, void *, void *,
+      cusparseIndexType_t, cusparseIndexType_t, cusparseIndexBase_t,
+      cudaDataType);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateCsr");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(spMatDescr, rows, cols, nnz, csrRowOffsets, csrColInd,
+                  csrValues, csrRowOffsetsType, csrColIndType, idxBase,
+                  valueType);
+}
+
+cusparseStatus_t CUSPARSEAPI cusparseCreateCooAoS(
+    cusparseSpMatDescr_t *spMatDescr, int64_t rows, int64_t cols, int64_t nnz,
+    void *cooInd, void *cooValues, cusparseIndexType_t cooIdxType,
+    cusparseIndexBase_t idxBase, cudaDataType valueType) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseSpMatDescr_t *, int64_t, int64_t, int64_t, void *, void *,
+      cusparseIndexType_t, cusparseIndexBase_t, cudaDataType);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateCooAoS");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(spMatDescr, rows, cols, nnz, cooInd, cooValues, cooIdxType,
+                  idxBase, valueType);
 }
 
 cusparseStatus_t CUSPARSEAPI
 cusparseDestroySpMat(cusparseSpMatDescr_t spMatDescr) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseSpMatDescr_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseSpMatDescr_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroySpMat");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(spMatDescr);
 }
 
 cusparseStatus_t CUSPARSEAPI
-cusparseCooGet(const cusparseSpMatDescr_t spMatDescr,
-               int*                       rows,
-               int*                       cols,
-               int*                       nnz,
-               void**                     cooRowInd,  // COO row indices
-               void**                     cooColInd,  // COO column indices
-               void**                     cooValues,  // COO values
-               cusparseIndexType_t*       idxType,
-               cusparseIndexBase_t*       idxBase,
-               cudaDataType*              valueType) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(const cusparseSpMatDescr_t, int *, int *, int *, void **, // COO row indices
-               void **, // COO column indices
-               void **, // COO values
-               cusparseIndexType_t *, cusparseIndexBase_t *, cudaDataType *);
+cusparseCooGet(const cusparseSpMatDescr_t spMatDescr, int64_t *rows,
+               int64_t *cols, int64_t *nnz,
+               void **cooRowInd,  // COO row indices
+               void **cooColInd,  // COO column indices
+               void **cooValues,  // COO values
+               cusparseIndexType_t *idxType, cusparseIndexBase_t *idxBase,
+               cudaDataType *valueType) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      const cusparseSpMatDescr_t, int64_t *, int64_t *, int64_t *, void **,
+      void **, void **, cusparseIndexType_t *, cusparseIndexBase_t *,
+      cudaDataType *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCooGet");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(spMatDescr, rows, cols, nnz, cooRowInd, cooColInd, cooValues, idxType, idxBase, valueType);
+  return func_ptr(spMatDescr, rows, cols, nnz, cooRowInd, cooColInd, cooValues,
+                  idxType, idxBase, valueType);
 }
 
 cusparseStatus_t CUSPARSEAPI
-cusparseSpMatGetFormat(const cusparseSpMatDescr_t spMatDescr,
-                       cusparseFormat_t*          format) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(const cusparseSpMatDescr_t, cusparseFormat_t *);
+cusparseCooAoSGet(const cusparseSpMatDescr_t spMatDescr, int64_t *rows,
+                  int64_t *cols, int64_t *nnz,
+                  void **cooInd,     // COO indices
+                  void **cooValues,  // COO values
+                  cusparseIndexType_t *idxType, cusparseIndexBase_t *idxBase,
+                  cudaDataType *valueType) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      const cusparseSpMatDescr_t, int64_t *, int64_t *, int64_t *, void **,
+      void **, cusparseIndexType_t *, cusparseIndexBase_t *, cudaDataType *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCooAoSGet");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(spMatDescr, rows, cols, nnz, cooInd, cooValues, idxType,
+                  idxBase, valueType);
+}
+
+cusparseStatus_t CUSPARSEAPI cusparseCsrGet(
+    const cusparseSpMatDescr_t spMatDescr, int64_t *rows, int64_t *cols,
+    int64_t *nnz, void **csrRowOffsets, void **csrColInd, void **csrValues,
+    cusparseIndexType_t *csrRowOffsetsType, cusparseIndexType_t *csrColIndType,
+    cusparseIndexBase_t *idxBase, cudaDataType *valueType) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      const cusparseSpMatDescr_t, int64_t *, int64_t *, int64_t *, void **,
+      void **, void **, cusparseIndexType_t *, cusparseIndexType_t *,
+      cusparseIndexBase_t *, cudaDataType *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCsrGet");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(spMatDescr, rows, cols, nnz, csrRowOffsets, csrColInd,
+                  csrValues, csrRowOffsetsType, csrColIndType, idxBase,
+                  valueType);
+}
+
+cusparseStatus_t CUSPARSEAPI cusparseSpMatGetFormat(
+    const cusparseSpMatDescr_t spMatDescr, cusparseFormat_t *format) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(const cusparseSpMatDescr_t,
+                                                  cusparseFormat_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpMatGetFormat");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(spMatDescr, format);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseSpMatGetIndexBase(const cusparseSpMatDescr_t spMatDescr,
-                          cusparseIndexBase_t*       idxBase) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(const cusparseSpMatDescr_t, cusparseIndexBase_t *);
+cusparseStatus_t CUSPARSEAPI cusparseSpMatGetIndexBase(
+    const cusparseSpMatDescr_t spMatDescr, cusparseIndexBase_t *idxBase) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(const cusparseSpMatDescr_t,
+                                                  cusparseIndexBase_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpMatGetIndexBase");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(spMatDescr, idxBase);
 }
 
 cusparseStatus_t CUSPARSEAPI
-cusparseSpMatSetNumBatches(cusparseSpMatDescr_t spMatDescr,
-                           int                  batchCount) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseSpMatDescr_t, int);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpMatSetNumBatches");
+cusparseSpMatGetValues(const cusparseSpMatDescr_t spMatDescr, void **values) {
+  using FuncPtr =
+      cusparseStatus_t(CUSPARSEAPI *)(const cusparseSpMatDescr_t, void **);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpMatGetValues");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(spMatDescr, values);
+}
+
+cusparseStatus_t CUSPARSEAPI
+cusparseSpMatSetValues(cusparseSpMatDescr_t spMatDescr, void *values) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseSpMatDescr_t, void *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpMatSetValues");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(spMatDescr, values);
+}
+
+cusparseStatus_t CUSPARSEAPI
+cusparseSpMatSetStridedBatch(cusparseSpMatDescr_t spMatDescr, int batchCount) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseSpMatDescr_t, int);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpMatSetStridedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(spMatDescr, batchCount);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseSpMatGetNumBatches(const cusparseSpMatDescr_t spMatDescr,
-                           int*                       batchCount) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(const cusparseSpMatDescr_t, int *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpMatGetNumBatches");
+cusparseStatus_t CUSPARSEAPI cusparseSpMatGetStridedBatch(
+    const cusparseSpMatDescr_t spMatDescr, int *batchCount) {
+  using FuncPtr =
+      cusparseStatus_t(CUSPARSEAPI *)(const cusparseSpMatDescr_t, int *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpMatGetStridedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(spMatDescr, batchCount);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseCreateDnMat(cusparseDnMatDescr_t* dnMatDescr,
-                    size_t                rows,
-                    size_t                cols,
-                    int64_t               ld,
-                    void*                 valuesPtr,
-                    cudaDataType          type,
-                    cusparseOrder_t       order) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseDnMatDescr_t *, size_t, size_t, int64_t, void *, cudaDataType, cusparseOrder_t);
+cusparseStatus_t CUSPARSEAPI cusparseCreateDnMat(
+    cusparseDnMatDescr_t *dnMatDescr, int64_t rows, int64_t cols, int64_t ld,
+    void *values, cudaDataType valueType, cusparseOrder_t order) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseDnMatDescr_t *, int64_t, int64_t, int64_t, void *, cudaDataType,
+      cusparseOrder_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseCreateDnMat");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(dnMatDescr, rows, cols, ld, valuesPtr, type, order);
+  return func_ptr(dnMatDescr, rows, cols, ld, values, valueType, order);
 }
 
 cusparseStatus_t CUSPARSEAPI
 cusparseDestroyDnMat(cusparseDnMatDescr_t dnMatDescr) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseDnMatDescr_t);
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseDnMatDescr_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDestroyDnMat");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(dnMatDescr);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseDnMatGet(const cusparseDnMatDescr_t dnMatDescr,
-                 size_t*                    rows,
-                 size_t*                    cols,
-                 int64_t*                   ld,
-                 void**                     valuesPtr,
-                 cudaDataType*              type,
-                 cusparseOrder_t*           order) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(const cusparseDnMatDescr_t, size_t *, size_t *, int64_t *, void **, cudaDataType *, cusparseOrder_t *);
+cusparseStatus_t CUSPARSEAPI cusparseDnMatGet(
+    const cusparseDnMatDescr_t dnMatDescr, int64_t *rows, int64_t *cols,
+    int64_t *ld, void **values, cudaDataType *type, cusparseOrder_t *order) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      const cusparseDnMatDescr_t, int64_t *, int64_t *, int64_t *, void **,
+      cudaDataType *, cusparseOrder_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDnMatGet");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(dnMatDescr, rows, cols, ld, valuesPtr, type, order);
+  return func_ptr(dnMatDescr, rows, cols, ld, values, type, order);
 }
 
 cusparseStatus_t CUSPARSEAPI
-cusparseDnMatSetStridedBatch(cusparseDnMatDescr_t dnMatDescr,
-                             int                  batchCount,
-                             size_t               batchStride) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseDnMatDescr_t, int, size_t);
+cusparseDnMatGetValues(const cusparseDnMatDescr_t dnMatDescr, void **values) {
+  using FuncPtr =
+      cusparseStatus_t(CUSPARSEAPI *)(const cusparseDnMatDescr_t, void **);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDnMatGetValues");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(dnMatDescr, values);
+}
+
+cusparseStatus_t CUSPARSEAPI
+cusparseDnMatSetValues(cusparseDnMatDescr_t dnMatDescr, void *values) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(cusparseDnMatDescr_t, void *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDnMatSetValues");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(dnMatDescr, values);
+}
+
+cusparseStatus_t CUSPARSEAPI cusparseDnMatSetStridedBatch(
+    cusparseDnMatDescr_t dnMatDescr, int batchCount, int64_t batchStride) {
+  using FuncPtr =
+      cusparseStatus_t(CUSPARSEAPI *)(cusparseDnMatDescr_t, int, int64_t);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDnMatSetStridedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(dnMatDescr, batchCount, batchStride);
@@ -9050,48 +8100,131 @@ cusparseDnMatSetStridedBatch(cusparseDnMatDescr_t dnMatDescr,
 
 cusparseStatus_t CUSPARSEAPI
 cusparseDnMatGetStridedBatch(const cusparseDnMatDescr_t dnMatDescr,
-                             int*                       batchCount,
-                             size_t*                    batchStride) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(const cusparseDnMatDescr_t, int *, size_t *);
+                             int *batchCount, int64_t *batchStride) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(const cusparseDnMatDescr_t,
+                                                  int *, int64_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseDnMatGetStridedBatch");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(dnMatDescr, batchCount, batchStride);
 }
 
 cusparseStatus_t CUSPARSEAPI
-cusparseSpMM(cusparseHandle_t           handle,
-             cusparseOperation_t        transA,
-             cusparseOperation_t        transB,
-             const void*                alpha,
-             const cusparseSpMatDescr_t matA,
-             const cusparseDnMatDescr_t matB,
-             const void*                beta,
-             cusparseDnMatDescr_t       matC,
-             cudaDataType               computeType,
-             cusparseSpMMAlg_t          alg,
-             void*                      externalBuffer) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, const void *, const cusparseSpMatDescr_t, const cusparseDnMatDescr_t, const void *, cusparseDnMatDescr_t, cudaDataType, cusparseSpMMAlg_t, void *);
-  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpMM");
+cusparseSpVV(cusparseHandle_t handle, cusparseOperation_t opX,
+             const cusparseSpVecDescr_t vecX, const cusparseDnVecDescr_t vecY,
+             void *result, cudaDataType computeType, void *externalBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, const cusparseSpVecDescr_t,
+      const cusparseDnVecDescr_t, void *, cudaDataType, void *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpVV");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, transB, alpha, matA, matB, beta, matC, computeType, alg, externalBuffer);
+  return func_ptr(handle, opX, vecX, vecY, result, computeType, externalBuffer);
 }
 
-cusparseStatus_t CUSPARSEAPI
-cusparseSpMM_bufferSize(cusparseHandle_t           handle,
-                        cusparseOperation_t        transA,
-                        cusparseOperation_t        transB,
-                        const void*                alpha,
-                        const cusparseSpMatDescr_t matA,
-                        const cusparseDnMatDescr_t matB,
-                        const void*                beta,
-                        cusparseDnMatDescr_t       matC,
-                        cudaDataType               computeType,
-                        cusparseSpMMAlg_t          alg,
-                        size_t*                    bufferSize) {
-  using FuncPtr = cusparseStatus_t (CUSPARSEAPI *)(cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, const void *, const cusparseSpMatDescr_t, const cusparseDnMatDescr_t, const void *, cusparseDnMatDescr_t, cudaDataType, cusparseSpMMAlg_t, size_t *);
+cusparseStatus_t CUSPARSEAPI cusparseSpVV_bufferSize(
+    cusparseHandle_t handle, cusparseOperation_t opX,
+    const cusparseSpVecDescr_t vecX, const cusparseDnVecDescr_t vecY,
+    const void *result, cudaDataType computeType, size_t *bufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, const cusparseSpVecDescr_t,
+      const cusparseDnVecDescr_t, const void *, cudaDataType, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpVV_bufferSize");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(handle, opX, vecX, vecY, result, computeType, bufferSize);
+}
+
+cusparseStatus_t CUSPARSEAPI cusparseSpMV(
+    cusparseHandle_t handle, cusparseOperation_t opA, const void *alpha,
+    const cusparseSpMatDescr_t matA, const cusparseDnVecDescr_t vecX,
+    const void *beta, const cusparseDnVecDescr_t vecY, cudaDataType computeType,
+    cusparseSpMVAlg_t alg, void *externalBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, const void *,
+      const cusparseSpMatDescr_t, const cusparseDnVecDescr_t, const void *,
+      const cusparseDnVecDescr_t, cudaDataType, cusparseSpMVAlg_t, void *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpMV");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(handle, opA, alpha, matA, vecX, beta, vecY, computeType, alg,
+                  externalBuffer);
+}
+
+cusparseStatus_t CUSPARSEAPI cusparseSpMV_bufferSize(
+    cusparseHandle_t handle, cusparseOperation_t opA, const void *alpha,
+    const cusparseSpMatDescr_t matA, const cusparseDnVecDescr_t vecX,
+    const void *beta, const cusparseDnVecDescr_t vecY, cudaDataType computeType,
+    cusparseSpMVAlg_t alg, size_t *bufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, const void *,
+      const cusparseSpMatDescr_t, const cusparseDnVecDescr_t, const void *,
+      const cusparseDnVecDescr_t, cudaDataType, cusparseSpMVAlg_t, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpMV_bufferSize");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(handle, opA, alpha, matA, vecX, beta, vecY, computeType, alg,
+                  bufferSize);
+}
+
+cusparseStatus_t CUSPARSEAPI cusparseSpMM(
+    cusparseHandle_t handle, cusparseOperation_t opA, cusparseOperation_t opB,
+    const void *alpha, const cusparseSpMatDescr_t matA,
+    const cusparseDnMatDescr_t matB, const void *beta,
+    cusparseDnMatDescr_t matC, cudaDataType computeType, cusparseSpMMAlg_t alg,
+    void *externalBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, const void *,
+      const cusparseSpMatDescr_t, const cusparseDnMatDescr_t, const void *,
+      cusparseDnMatDescr_t, cudaDataType, cusparseSpMMAlg_t, void *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpMM");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(handle, opA, opB, alpha, matA, matB, beta, matC, computeType,
+                  alg, externalBuffer);
+}
+
+cusparseStatus_t CUSPARSEAPI cusparseSpMM_bufferSize(
+    cusparseHandle_t handle, cusparseOperation_t opA, cusparseOperation_t opB,
+    const void *alpha, const cusparseSpMatDescr_t matA,
+    const cusparseDnMatDescr_t matB, const void *beta,
+    cusparseDnMatDescr_t matC, cudaDataType computeType, cusparseSpMMAlg_t alg,
+    size_t *bufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, const void *,
+      const cusparseSpMatDescr_t, const cusparseDnMatDescr_t, const void *,
+      cusparseDnMatDescr_t, cudaDataType, cusparseSpMMAlg_t, size_t *);
   static auto func_ptr = LoadSymbol<FuncPtr>("cusparseSpMM_bufferSize");
   if (!func_ptr) return GetSymbolNotFoundError();
-  return func_ptr(handle, transA, transB, alpha, matA, matB, beta, matC, computeType, alg, bufferSize);
+  return func_ptr(handle, opA, opB, alpha, matA, matB, beta, matC, computeType,
+                  alg, bufferSize);
 }
+
+cusparseStatus_t CUSPARSEAPI cusparseConstrainedGeMM(
+    cusparseHandle_t handle, cusparseOperation_t opA, cusparseOperation_t opB,
+    const void *alpha, const cusparseDnMatDescr_t matA,
+    const cusparseDnMatDescr_t matB, const void *beta,
+    cusparseSpMatDescr_t matC, cudaDataType computeType, void *externalBuffer) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, const void *,
+      const cusparseDnMatDescr_t, const cusparseDnMatDescr_t, const void *,
+      cusparseSpMatDescr_t, cudaDataType, void *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cusparseConstrainedGeMM");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(handle, opA, opB, alpha, matA, matB, beta, matC, computeType,
+                  externalBuffer);
+}
+
+cusparseStatus_t CUSPARSEAPI cusparseConstrainedGeMM_bufferSize(
+    cusparseHandle_t handle, cusparseOperation_t opA, cusparseOperation_t opB,
+    const void *alpha, const cusparseDnMatDescr_t matA,
+    const cusparseDnMatDescr_t matB, const void *beta,
+    cusparseSpMatDescr_t matC, cudaDataType computeType, size_t *bufferSize) {
+  using FuncPtr = cusparseStatus_t(CUSPARSEAPI *)(
+      cusparseHandle_t, cusparseOperation_t, cusparseOperation_t, const void *,
+      const cusparseDnMatDescr_t, const cusparseDnMatDescr_t, const void *,
+      cusparseSpMatDescr_t, cudaDataType, size_t *);
+  static auto func_ptr =
+      LoadSymbol<FuncPtr>("cusparseConstrainedGeMM_bufferSize");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(handle, opA, opB, alpha, matA, matB, beta, matC, computeType,
+                  bufferSize);
+}
+
+#endif // _WIN32
 
 }  // extern "C"


### PR DESCRIPTION
This PR replaces calls to cusparse calls that are deprecated in CUDA 10.2.

CC @pankajkgupta and @sanjoy 