### PR TITLE
[tflite] make evaluation tasks build

### DIFF
--- a/tensorflow/lite/tools/evaluation/tasks/coco_object_detection/BUILD
+++ b/tensorflow/lite/tools/evaluation/tasks/coco_object_detection/BUILD
@@ -43,7 +43,7 @@ cc_binary(
     copts = tflite_copts(),
     linkopts = task_linkopts(),
     deps = [
-        ":run_eval_lib",
         "//tensorflow/lite/tools/evaluation/tasks:task_executor_main",
+        ":run_eval_lib",
     ],
 )

--- a/tensorflow/lite/tools/evaluation/tasks/imagenet_image_classification/BUILD
+++ b/tensorflow/lite/tools/evaluation/tasks/imagenet_image_classification/BUILD
@@ -33,7 +33,7 @@ cc_binary(
     copts = tflite_copts(),
     linkopts = task_linkopts(),
     deps = [
-        ":run_eval_lib",
         "//tensorflow/lite/tools/evaluation/tasks:task_executor_main",
+        ":run_eval_lib",
     ],
 )

--- a/tensorflow/lite/tools/evaluation/tasks/inference_diff/BUILD
+++ b/tensorflow/lite/tools/evaluation/tasks/inference_diff/BUILD
@@ -32,7 +32,7 @@ cc_binary(
     copts = tflite_copts(),
     linkopts = task_linkopts(),
     deps = [
-        ":run_eval_lib",
         "//tensorflow/lite/tools/evaluation/tasks:task_executor_main",
+        ":run_eval_lib",
     ],
 )


### PR DESCRIPTION
Fix dependency problem. Not all linkers can check functions in previous libraries. The `//tensorflow/lite/tools/evaluation/tasks:task_executor_main` needs `tflite::evaluation::CreateTaskExecutor(int*, char**)` which is in `:run_eval_lib`. We need `:run_eval_lib` after `task_exceutor_main`. Otherwise we'll see error like

```
ERROR: /Volumes/Seagate5T/tf-clean/tensorflow/lite/tools/evaluation/tasks/coco_object_detection/BUILD:41:1: Linking of rule '//tensorflow/lite/tools/evaluation/tasks/coco_object_detection:run_eval' failed (Exit 1)
bazel-out/arm64-v8a-opt/bin/tensorflow/lite/tools/evaluation/tasks/libtask_executor_main.a(task_executor_main.o): In function `main':
/private/var/tmp/_bazel_freedom/adcaa36b2ac85ab2f5a2434777d27f58/execroot/org_tensorflow/tensorflow/lite/tools/evaluation/tasks/task_executor_main.cc:21: undefined reference to `tflite::evaluation::CreateTaskExecutor(int*, char**)'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
Target //tensorflow/lite/tools/evaluation/tasks/coco_object_detection:run_eval failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 1.753s, Critical Path: 1.15s
INFO: 3 processes: 3 local.
FAILED: Build did NOT complete successfully
```
when building with something like
```
build --config android_arm64 \
  tensorflow/lite/tools/evaluation/tasks/coco_object_detection:run_eval
```