### PR TITLE
[INTEL MKL] fix a missing build dependency.

### DIFF
--- a/tensorflow/core/common_runtime/BUILD
+++ b/tensorflow/core/common_runtime/BUILD
@@ -1038,7 +1038,7 @@ cc_library(
         "//tensorflow/core:lib",
         "//tensorflow/core:lib_internal",
         "//tensorflow/core:protos_all_cc",
-    ],
+    ] + if_mkl([":mkl_cpu_allocator"]),
 )
 
 cc_library(


### PR DESCRIPTION
Commit a9c4cbb4244733e3c4451e12a41ab513b9ee5d3b did some refactoring of the common_runtime build file which also includes some mkl components. However, there was a dependency that was missed which resulted in build failures under --config=mkl. This PR adds the dependency.