### PR TITLE
Use TF_CALL_GPU_ALL_TYPES for variable ops

### DIFF
--- a/tensorflow/core/kernels/variable_ops.cc
+++ b/tensorflow/core/kernels/variable_ops.cc
@@ -230,7 +230,7 @@ TF_CALL_GPU_NUMBER_TYPES_NO_HALF(REGISTER_SYCL_KERNEL);
                               .HostMemory("is_initialized"),               \
                           IsVariableInitializedOp);
 
-TF_CALL_GPU_NUMBER_TYPES(REGISTER_GPU_KERNELS);
+TF_CALL_GPU_ALL_TYPES(REGISTER_GPU_KERNELS);
 TF_CALL_int64(REGISTER_GPU_KERNELS);
 TF_CALL_uint32(REGISTER_GPU_KERNELS);
 #undef REGISTER_GPU_KERNELS

--- a/tensorflow/python/kernel_tests/variable_ops_test.py
+++ b/tensorflow/python/kernel_tests/variable_ops_test.py
@@ -50,7 +50,7 @@ class VariableOpTest(test.TestCase):
       return self.evaluate(p)
 
   def _testTypes(self, vals):
-    for dtype in [np.float32, np.float64, np.int32, np.int64]:
+    for dtype in [np.float16, np.float32, np.float64, np.complex64, np.complex128, np.int32, np.int64]:
       self.setUp()
       x = vals.astype(dtype)
       tftype = _NP_TO_TF[dtype]

--- a/tensorflow/python/kernel_tests/variable_ops_test.py
+++ b/tensorflow/python/kernel_tests/variable_ops_test.py
@@ -33,10 +33,13 @@ from tensorflow.python.ops import variables
 from tensorflow.python.platform import test
 
 _NP_TO_TF = {
+    np.float16: dtypes.float16,
     np.float32: dtypes.float32,
     np.float64: dtypes.float64,
     np.int32: dtypes.int32,
     np.int64: dtypes.int64,
+    np.complex64: dtypes.complex64,
+    np.complex128: dtypes.complex128,
 }
 
 
@@ -50,7 +53,10 @@ class VariableOpTest(test.TestCase):
       return self.evaluate(p)
 
   def _testTypes(self, vals):
-    for dtype in [np.float16, np.float32, np.float64, np.complex64, np.complex128, np.int32, np.int64]:
+    for dtype in [
+        np.float16, np.float32, np.float64,
+        np.complex64, np.complex128,
+        np.int32, np.int64]:
       self.setUp()
       x = vals.astype(dtype)
       tftype = _NP_TO_TF[dtype]


### PR DESCRIPTION

This PR tries to expand variable ops, as was discussed in TF_CALL_GPU_ALL_TYPES

This PR fixes #35994

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>