### PR TITLE
Declare member functions on TensorShapeIter const.

### DIFF
--- a/tensorflow/core/framework/op_kernel.h
+++ b/tensorflow/core/framework/op_kernel.h
@@ -405,12 +405,12 @@ class OpArgIterator {
 
   OpArgIterator(const ListType* list, int i) : list_(list), i_(i) {}
 
-  bool operator==(const OpArgIterator& rhs) {
+  bool operator==(const OpArgIterator& rhs) const {
     DCHECK(list_ == rhs.list_);
     return i_ == rhs.i_;
   }
 
-  bool operator!=(const OpArgIterator& rhs) {
+  bool operator!=(const OpArgIterator& rhs) const {
     DCHECK(list_ == rhs.list_);
     return i_ != rhs.i_;
   }

--- a/tensorflow/core/framework/tensor_shape.h
+++ b/tensorflow/core/framework/tensor_shape.h
@@ -345,16 +345,16 @@ template <class Shape>
 class TensorShapeIter {
  public:
   TensorShapeIter(const Shape* shape, int d) : shape_(shape), d_(d) {}
-  bool operator==(const TensorShapeIter& rhs) {
+  bool operator==(const TensorShapeIter& rhs) const {
     DCHECK(shape_ == rhs.shape_);
     return d_ == rhs.d_;
   }
-  bool operator!=(const TensorShapeIter& rhs) {
+  bool operator!=(const TensorShapeIter& rhs) const {
     DCHECK(shape_ == rhs.shape_);
     return d_ != rhs.d_;
   }
   void operator++() { ++d_; }
-  TensorShapeDim operator*() { return TensorShapeDim(shape_->dim_size(d_)); }
+  TensorShapeDim operator*() const { return TensorShapeDim(shape_->dim_size(d_)); }
 
  private:
   const Shape* shape_;


### PR DESCRIPTION
This fixes a compiler error in C++20 mode caused by ambiguities between reversed and negated comparison candidates.