### PR TITLE
Fix error in deleting servers because module may be garbage collected ahead

### DIFF
--- a/tensorflow/python/training/server_lib.py
+++ b/tensorflow/python/training/server_lib.py
@@ -150,16 +150,21 @@ class Server(object):
       self.start()
 
   def __del__(self):
+    # At shutdown, `errors` may have been garbage collected.
+    if errors is not None:
+      exception = errors.UnimplementedError
+    else:
+      exception = Exception
     try:
       c_api.TF_ServerStop(self._server)
       # Clean shutdown of servers is not yet implemented, so
       # we leak instead of calling c_api.TF_DeleteServer here.
       # See:
       # https://github.com/tensorflow/tensorflow/blob/0495317a6e9dd4cac577b9d5cf9525e62b571018/tensorflow/core/distributed_runtime/rpc/grpc_server_lib.h#L73
-    except errors.UnimplementedError:
-      pass
     except AttributeError:
       # At shutdown, `c_api` may have been garbage collected.
+      pass
+    except exception:
       pass
     self._server = None
 


### PR DESCRIPTION
When deleting grpc server at the end of the program, the `errors` module may already be garbage collected and trigger:
```python
Exception ignored in: <bound method Server.__del__ of <tensorflow.python.training.server_lib.Server object at 0x7f61a00e4668>>
Traceback (most recent call last):
  File "/usr/local/lib64/python3.6/site-packages/tensorflow/python/training/server_lib.py", line 161, in __del__
AttributeError: 'NoneType' object has no attribute 'UnimplementedError'
```
This pr will just check if `errors` is none ahead.

Thank you for your time on this review.