### PR TITLE
Fix MirroredStrategy cannot output RunMetadata

### DIFF
--- a/tensorflow/python/keras/backend.py
+++ b/tensorflow/python/keras/backend.py
@@ -3538,13 +3538,13 @@ class GraphExecutionFunction(object):
       self.updates_op = control_flow_ops.group(*updates_ops)
     self.name = name
     # additional tensor substitutions
-    self.feed_dict = session_kwargs.pop('feed_dict', None)
+    self.feed_dict = session_kwargs.get('feed_dict', None)
     # additional operations
-    self.fetches = session_kwargs.pop('fetches', [])
+    self.fetches = session_kwargs.get('fetches', [])
     if not isinstance(self.fetches, list):
       self.fetches = [self.fetches]
-    self.run_options = session_kwargs.pop('options', None)
-    self.run_metadata = session_kwargs.pop('run_metadata', None)
+    self.run_options = session_kwargs.get('options', None)
+    self.run_metadata = session_kwargs.get('run_metadata', None)
     # The main use case of `fetches` being passed to a model is the ability
     # to run custom updates
     # This requires us to wrap fetches in `identity` ops.
@@ -3556,9 +3556,11 @@ class GraphExecutionFunction(object):
     # output values for a fetch it added.
     self.fetch_callbacks = {}
 
-    if session_kwargs:
+    allowed_kwargs = {'feed_dict', 'fetches', 'options', 'run_metadata'}
+    unknown_kwargs = set(session_kwargs.keys()) - allowed_kwargs
+    if unknown_kwargs:
       raise ValueError('Some keys in session_kwargs are not supported at this '
-                       'time: %s' % (session_kwargs.keys(),))
+                       'time: %s' % (unknown_kwargs,))
 
     self._callable_fn = None
     self._feed_arrays = None

--- a/tensorflow/python/keras/distribute/distributed_training_utils.py
+++ b/tensorflow/python/keras/distribute/distributed_training_utils.py
@@ -133,6 +133,14 @@ def unwrap_values(distribution_strategy, grouped_inputs, grouped_outputs,
       all_session_args['fetches'] = flatten_per_replica_values(
           distribution_strategy, grouped_fetches)
 
+    grouped_run_metadata = grouped_session_args.get("run_metadata")
+    if grouped_run_metadata:
+      all_session_args['run_metadata'] = grouped_run_metadata
+
+    grouped_run_options = grouped_session_args.get("options")
+    if grouped_run_options:
+      all_session_args['options'] = grouped_run_options
+
   # TODO(priyag): Return only non empty/None values
   return all_inputs, all_outputs, all_updates, all_session_args
 
@@ -769,7 +777,8 @@ def _build_network_on_replica(model, mode, inputs=None, targets=None):
         sample_weight_mode=model.sample_weight_mode,
         weighted_metrics=metrics_module.clone_metrics(
             model._compile_weighted_metrics),
-        target_tensors=targets)
+        target_tensors=targets,
+        **model._function_kwargs)
   return updated_model
 
 


### PR DESCRIPTION
This is a PR from JIZHI, the AI platform in Tencent.

Currently, we cannot get `run_metadata` (or timeline) in graph mode when using `MirroredStrategy` and keras together. The reason is that the current implementation failed to pass `run_options` and `run_metadata` to the distributed model. This pr is trying to fix it.

The main changed we did are:
- Retain the kwargs in `self.session_kwargs` in `GraphExecutionFunction`, because it is used as the input of  the distributed `K.function` in `_make_graph_execution_function`.
- Update the unwrapping of grouped kwargs to make them support `run_metadata` and `run_options`.

Thank you for your time on reviewing this pr.