### PR TITLE
Fix timeline fail to parse long kernel names when op_time is set

### DIFF
--- a/tensorflow/python/client/timeline.py
+++ b/tensorflow/python/client/timeline.py
@@ -400,9 +400,10 @@ class Timeline(object):
   def _parse_kernel_label(self, label, node_name):
     """Parses the fields in a node timeline label."""
     # Expects labels of the form: retval (arg) detail @@annotation
-    match = re.match(r'.*@@(.*)\#id.*', label)
-    if match is not None:
-      node_name = match.group(1)
+    start = label.find("@@")
+    end = label.find("#")
+    if start >= 0 and end >= 0 and start + 2 < end:
+      node_name = label[start+2:end]
     # Node names should always have the form 'name:op'.
     fields = node_name.split(':') + ['unknown']
     name, op = fields[:2]


### PR DESCRIPTION
This is a follow-up pr on #37074 .

I just found out that `re.match` is not good for multi-line text, while many XLA kernels do have a really long name or timeline_label. Therefore, this pr changed the regular expression in to manually parsing. 
Also, the format of `timeline_label` seems to be changed in the lastest version of tf, and I change a little of the parsing rule according to the new format.

Thank you for your time on reviewing this pr and I'm sorry that the origin pr on this did not resolve these problems.