### PR TITLE
Fix docstring error of MlirPassthroughOp

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_MlirPassthroughOp.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_MlirPassthroughOp.pbtxt
@@ -27,7 +27,7 @@ func @main(%arg0 : tensor<10xf32>, %arg1 : tensor<10xf32>) -> tensor<10x10xf32> 
 
 @tf.function
 def foo(x, y):
-  return = mlir_passthrough_op([x, y], mlir_module, Toutputs=[tf.float32])
+  return mlir_passthrough_op([x, y], mlir_module, Toutputs=[tf.float32])
 
 graph_def = foo.get_concrete_function(tf.TensorSpec([10], tf.float32), tf.TensorSpec([10], tf.float32)).graph.as_graph_def()
 ```


### PR DESCRIPTION
In api_def_MlirPassthroughOp.pbtxt, the docstring of MlirPassthroughOp has
a typo (extra `=`) which needs to be removed:

```diff
 @tf.function
 def foo(x, y):
-  return = mlir_passthrough_op([x, y], mlir_module, Toutputs=[tf.float32])
+  return mlir_passthrough_op([x, y], mlir_module, Toutputs=[tf.float32])

```

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>