### PR TITLE
Change code examples in tf.strings.format to use TF 2.x

### DIFF
--- a/tensorflow/python/ops/string_ops.py
+++ b/tensorflow/python/ops/string_ops.py
@@ -123,35 +123,29 @@ def string_format(template, inputs, placeholder="{}", summarize=3, name=None):
   Example:
     Formatting a single-tensor template:
     ```python
-    sess = tf.compat.v1.Session()
-    with sess.as_default():
-        tensor = tf.range(10)
-        formatted = tf.strings.format("tensor: {}, suffix", tensor)
-        out = sess.run(formatted)
-        expected = "tensor: [0 1 2 ... 7 8 9], suffix"
+    tensor = tf.range(10)
+    formatted = tf.strings.format("tensor: {}, suffix", tensor)
+    expected = "tensor: [0 1 2 ... 7 8 9], suffix"
 
-        assert(out.decode() == expected)
+    assert(formatted == expected)
     ```
 
     Formatting a multi-tensor template:
     ```python
-    sess = tf.compat.v1.Session()
-    with sess.as_default():
-        tensor_one = tf.reshape(tf.range(100), [10, 10])
-        tensor_two = tf.range(10)
-        formatted = tf.strings.format("first: {}, second: {}, suffix",
-          (tensor_one, tensor_two))
+    tensor_one = tf.reshape(tf.range(100), [10, 10])
+    tensor_two = tf.range(10)
+    formatted = tf.strings.format("first: {}, second: {}, suffix",
+      (tensor_one, tensor_two))
 
-        out = sess.run(formatted)
-        expected = ("first: [[0 1 2 ... 7 8 9]\n"
-              " [10 11 12 ... 17 18 19]\n"
-              " [20 21 22 ... 27 28 29]\n"
-              " ...\n"
-              " [70 71 72 ... 77 78 79]\n"
-              " [80 81 82 ... 87 88 89]\n"
-              " [90 91 92 ... 97 98 99]], second: [0 1 2 ... 7 8 9], suffix")
+    expected = ("first: [[0 1 2 ... 7 8 9]\n"
+          " [10 11 12 ... 17 18 19]\n"
+          " [20 21 22 ... 27 28 29]\n"
+          " ...\n"
+          " [70 71 72 ... 77 78 79]\n"
+          " [80 81 82 ... 87 88 89]\n"
+          " [90 91 92 ... 97 98 99]], second: [0 1 2 ... 7 8 9], suffix")
 
-        assert(out.decode() == expected)
+    assert(formatted == expected)
     ```
 
   Args:

--- a/tensorflow/python/ops/string_ops.py
+++ b/tensorflow/python/ops/string_ops.py
@@ -125,7 +125,7 @@ def string_format(template, inputs, placeholder="{}", summarize=3, name=None):
     ```python
     >>> tensor = tf.range(10)
     >>> tf.strings.format("tensor: {}, suffix", tensor)
-    tf.Tensor(b'tensor: [0 1 2 ... 7 8 9], suffix', shape=(), dtype=string)
+    <tf.Tensor: shape=(), dtype=string, numpy=b'tensor: [0 1 2 ... 7 8 9], suffix'>
     ```
 
     Formatting a multi-tensor template:
@@ -134,7 +134,7 @@ def string_format(template, inputs, placeholder="{}", summarize=3, name=None):
     >>> tensor_two = tf.range(10)
     >>> tf.strings.format("first: {}, second: {}, suffix",
     ...                               (tensor_one, tensor_two))
-    tf.Tensor(b'first: [[0 1 2 ... 7 8 9]\n [10 11 12 ... 17 18 19]\n [20 21 22 ... 27 28 29]\n ...\n [70 71 72 ... 77 78 79]\n [80 81 82 ... 87 88 89]\n [90 91 92 ... 97 98 99]], second: [0 1 2 ... 7 8 9], suffix', shape=(), dtype=string)
+    <tf.Tensor: shape=(), dtype=string, numpy=b'first: [[0 1 2 ... 7 8 9]\n [10 11 12 ... 17 18 19]\n [20 21 22 ... 27 28 29]\n ...\n [70 71 72 ... 77 78 79]\n [80 81 82 ... 87 88 89]\n [90 91 92 ... 97 98 99]], second: [0 1 2 ... 7 8 9], suffix'>
     ```
 
   Args:

--- a/tensorflow/python/ops/string_ops.py
+++ b/tensorflow/python/ops/string_ops.py
@@ -123,29 +123,26 @@ def string_format(template, inputs, placeholder="{}", summarize=3, name=None):
   Example:
     Formatting a single-tensor template:
     ```python
-    tensor = tf.range(10)
-    formatted = tf.strings.format("tensor: {}, suffix", tensor)
-    expected = "tensor: [0 1 2 ... 7 8 9], suffix"
-
-    assert(formatted == expected)
+    >>> tensor = tf.range(10)
+    >>> formatted = tf.strings.format("tensor: {}, suffix", tensor)
+    >>> expected = "tensor: [0 1 2 ... 7 8 9], suffix"
+    >>> assert(formatted == expected)
     ```
 
     Formatting a multi-tensor template:
     ```python
-    tensor_one = tf.reshape(tf.range(100), [10, 10])
-    tensor_two = tf.range(10)
-    formatted = tf.strings.format("first: {}, second: {}, suffix",
-      (tensor_one, tensor_two))
-
-    expected = ("first: [[0 1 2 ... 7 8 9]\n"
-          " [10 11 12 ... 17 18 19]\n"
-          " [20 21 22 ... 27 28 29]\n"
-          " ...\n"
-          " [70 71 72 ... 77 78 79]\n"
-          " [80 81 82 ... 87 88 89]\n"
-          " [90 91 92 ... 97 98 99]], second: [0 1 2 ... 7 8 9], suffix")
-
-    assert(formatted == expected)
+    >>> tensor_one = tf.reshape(tf.range(100), [10, 10])
+    >>> tensor_two = tf.range(10)
+    >>> formatted = tf.strings.format("first: {}, second: {}, suffix",
+    ...                               (tensor_one, tensor_two))
+    >>> expected = ("first: [[0 1 2 ... 7 8 9]\n"
+    ...             " [10 11 12 ... 17 18 19]\n"
+    ...             " [20 21 22 ... 27 28 29]\n"
+    ...             " ...\n"
+    ...             " [70 71 72 ... 77 78 79]\n"
+    ...             " [80 81 82 ... 87 88 89]\n"
+    ...             " [90 91 92 ... 97 98 99]], second: [0 1 2 ... 7 8 9], suffix")
+    >>> assert(formatted == expected)
     ```
 
   Args:

--- a/tensorflow/python/ops/string_ops.py
+++ b/tensorflow/python/ops/string_ops.py
@@ -133,9 +133,8 @@ def string_format(template, inputs, placeholder="{}", summarize=3, name=None):
     ```python
     >>> tensor_one = tf.reshape(tf.range(100), [10, 10])
     >>> tensor_two = tf.range(10)
-    >>> formatted = tf.strings.format("first: {}, second: {}, suffix",
+    >>> tf.strings.format("first: {}, second: {}, suffix",
     ...                               (tensor_one, tensor_two))
-    >>> print(formatted)
     tf.Tensor(b'first: [[0 1 2 ... 7 8 9]\n [10 11 12 ... 17 18 19]\n [20 21 22 ... 27 28 29]\n ...\n [70 71 72 ... 77 78 79]\n [80 81 82 ... 87 88 89]\n [90 91 92 ... 97 98 99]], second: [0 1 2 ... 7 8 9], suffix', shape=(), dtype=string)
     ```
 

--- a/tensorflow/python/ops/string_ops.py
+++ b/tensorflow/python/ops/string_ops.py
@@ -125,8 +125,8 @@ def string_format(template, inputs, placeholder="{}", summarize=3, name=None):
     ```python
     >>> tensor = tf.range(10)
     >>> formatted = tf.strings.format("tensor: {}, suffix", tensor)
-    >>> expected = "tensor: [0 1 2 ... 7 8 9], suffix"
-    >>> assert(formatted == expected)
+    >>> print(formatted)
+    tf.Tensor(b'tensor: [0 1 2 ... 7 8 9], suffix', shape=(), dtype=string)
     ```
 
     Formatting a multi-tensor template:
@@ -135,14 +135,8 @@ def string_format(template, inputs, placeholder="{}", summarize=3, name=None):
     >>> tensor_two = tf.range(10)
     >>> formatted = tf.strings.format("first: {}, second: {}, suffix",
     ...                               (tensor_one, tensor_two))
-    >>> expected = ("first: [[0 1 2 ... 7 8 9]\n"
-    ...             " [10 11 12 ... 17 18 19]\n"
-    ...             " [20 21 22 ... 27 28 29]\n"
-    ...             " ...\n"
-    ...             " [70 71 72 ... 77 78 79]\n"
-    ...             " [80 81 82 ... 87 88 89]\n"
-    ...             " [90 91 92 ... 97 98 99]], second: [0 1 2 ... 7 8 9], suffix")
-    >>> assert(formatted == expected)
+    >>> print(formatted)
+    tf.Tensor(b'first: [[0 1 2 ... 7 8 9]\n [10 11 12 ... 17 18 19]\n [20 21 22 ... 27 28 29]\n ...\n [70 71 72 ... 77 78 79]\n [80 81 82 ... 87 88 89]\n [90 91 92 ... 97 98 99]], second: [0 1 2 ... 7 8 9], suffix', shape=(), dtype=string)
     ```
 
   Args:

--- a/tensorflow/python/ops/string_ops.py
+++ b/tensorflow/python/ops/string_ops.py
@@ -124,8 +124,7 @@ def string_format(template, inputs, placeholder="{}", summarize=3, name=None):
     Formatting a single-tensor template:
     ```python
     >>> tensor = tf.range(10)
-    >>> formatted = tf.strings.format("tensor: {}, suffix", tensor)
-    >>> print(formatted)
+    >>> tf.strings.format("tensor: {}, suffix", tensor)
     tf.Tensor(b'tensor: [0 1 2 ... 7 8 9], suffix', shape=(), dtype=string)
     ```
 

--- a/tensorflow/python/ops/string_ops.py
+++ b/tensorflow/python/ops/string_ops.py
@@ -113,7 +113,6 @@ def regex_replace(input, pattern, rewrite, replace_global=True, name=None):
 
 @tf_export("strings.format")
 def string_format(template, inputs, placeholder="{}", summarize=3, name=None):
-  # pylint: disable=line-too-long
   r"""Formats a string template using a list of tensors.
 
   Formats a string template using a list of tensors, abbreviating tensors by
@@ -124,17 +123,16 @@ def string_format(template, inputs, placeholder="{}", summarize=3, name=None):
   Example:
     Formatting a single-tensor template:
 
-    >>> tensor = tf.range(10)
+    >>> tensor = tf.range(5)
     >>> tf.strings.format("tensor: {}, suffix", tensor)
-    <tf.Tensor: shape=(), dtype=string, numpy=b'tensor: [0 1 2 ... 7 8 9], suffix'>
+    <tf.Tensor: shape=(), dtype=string, numpy=b'tensor: [0 1 2 3 4], suffix'>
 
     Formatting a multi-tensor template:
 
-    >>> tensor_one = tf.reshape(tf.range(100), [10, 10])
-    >>> tensor_two = tf.range(10)
-    >>> tf.strings.format("first: {}, second: {}, suffix",
-    ...                               (tensor_one, tensor_two))
-    <tf.Tensor: shape=(), dtype=string, numpy=b'first: [[0 1 2 ... 7 8 9]\n [10 11 12 ... 17 18 19]\n [20 21 22 ... 27 28 29]\n ...\n [70 71 72 ... 77 78 79]\n [80 81 82 ... 87 88 89]\n [90 91 92 ... 97 98 99]], second: [0 1 2 ... 7 8 9], suffix'>
+    >>> tensor_a = tf.range(2)
+    >>> tensor_b = tf.range(1, 4, 2)
+    >>> tf.strings.format("a: {}, b: {}, suffix", (tensor_a, tensor_b))
+    <tf.Tensor: shape=(), dtype=string, numpy=b'a: [0 1], b: [1 3], suffix'>
 
 
   Args:

--- a/tensorflow/python/ops/string_ops.py
+++ b/tensorflow/python/ops/string_ops.py
@@ -113,6 +113,7 @@ def regex_replace(input, pattern, rewrite, replace_global=True, name=None):
 
 @tf_export("strings.format")
 def string_format(template, inputs, placeholder="{}", summarize=3, name=None):
+  # pylint: disable=line-too-long
   r"""Formats a string template using a list of tensors.
 
   Formats a string template using a list of tensors, abbreviating tensors by
@@ -122,20 +123,19 @@ def string_format(template, inputs, placeholder="{}", summarize=3, name=None):
 
   Example:
     Formatting a single-tensor template:
-    ```python
+
     >>> tensor = tf.range(10)
     >>> tf.strings.format("tensor: {}, suffix", tensor)
     <tf.Tensor: shape=(), dtype=string, numpy=b'tensor: [0 1 2 ... 7 8 9], suffix'>
-    ```
 
     Formatting a multi-tensor template:
-    ```python
+
     >>> tensor_one = tf.reshape(tf.range(100), [10, 10])
     >>> tensor_two = tf.range(10)
     >>> tf.strings.format("first: {}, second: {}, suffix",
     ...                               (tensor_one, tensor_two))
     <tf.Tensor: shape=(), dtype=string, numpy=b'first: [[0 1 2 ... 7 8 9]\n [10 11 12 ... 17 18 19]\n [20 21 22 ... 27 28 29]\n ...\n [70 71 72 ... 77 78 79]\n [80 81 82 ... 87 88 89]\n [90 91 92 ... 97 98 99]], second: [0 1 2 ... 7 8 9], suffix'>
-    ```
+
 
   Args:
     template: A string template to format tensor values into.


### PR DESCRIPTION
The code examples in tf.strings.format still uses 1.x (`tf.compat.v1`)
which is not appropriate now.

This PR changes code examples in tf.strings.format to use TF 2.x.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>