### PR TITLE
go: Add input mapping option when importing Graph

### DIFF
--- a/tensorflow/go/graph.go
+++ b/tensorflow/go/graph.go
@@ -61,6 +61,11 @@ type GraphImportOptions struct {
 	// Execution device
 	Device string
 
+	InputMapping map[struct {
+		Name  string
+		Index int
+	}]*Operation
+
 	// TODO: extend this structure to support more options from TF_ImportGraphDefOptions
 }
 
@@ -120,6 +125,12 @@ func (g *Graph) ImportWithOptions(def []byte, options GraphImportOptions) error 
 		cdev := C.CString(options.Device)
 		defer C.free(unsafe.Pointer(cdev))
 		C.TF_ImportGraphDefOptionsSetDefaultDevice(opts, cdev)
+	}
+
+	for src, dst := range options.InputMapping {
+		cSrcName := C.CString(src.Name)
+		defer C.free(unsafe.Pointer(cSrcName))
+		C.TF_ImportGraphDefOptionsAddInputMapping(opts, cSrcName, C.int(src.Index), dst.c())
 	}
 
 	buf := C.TF_NewBuffer()

--- a/tensorflow/go/graph_test.go
+++ b/tensorflow/go/graph_test.go
@@ -82,6 +82,74 @@ func TestGraphWriteToAndImport(t *testing.T) {
 	}
 }
 
+func TestGraphInputMapping(t *testing.T) {
+	// Construct a graph
+	g := NewGraph()
+	v, err := NewTensor(int64(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	input, err := Placeholder(g, "input", v.DataType())
+	if err != nil {
+		t.Fatal(err)
+	}
+	neg, err := Neg(g, "neg", input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Serialize the graph
+	buf := new(bytes.Buffer)
+	if _, err := g.WriteTo(buf); err != nil {
+		t.Fatal(err)
+	}
+
+	g = NewGraph()
+	v, err := NewTensor(int64(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	replacement, err := Placeholder(g, "replacement", v.DataType())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	options := GraphImportOptions{
+		Prefix: "imported",
+		InputMapping: map[struct {
+			Name  string
+			Index int
+		}]*Operation{{"input", 0}: replacement},
+	}
+	// Import it into the same graph, with a prefix and replacement
+	if err := g.ImportWithOptions(buf.Bytes(), options); err != nil {
+		t.Error(err)
+	}
+	if err := hasOperations(g, "replacement", "imported/neg"); err != nil {
+		t.Error(err)
+	}
+
+	sess, err := NewSession(g, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	outputs, err := sess.Run(
+		map[Output]*Tensor{replacement: v},
+		[]Output{neg},
+		nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(outputs) != 1 {
+		t.Fatal(len(outputs))
+	}
+	if outputs[0].Value().(float32) != -1 {
+		t.Fatalf("Got %v, wanted float -1", outputs[0].Value())
+	}
+}
+
 func TestGraphAddGradients(t *testing.T) {
 	g := NewGraph()
 	x1, err := Placeholder(g, "x1", Float)


### PR DESCRIPTION
I can't actually run the test because it's missing some imports, but I don't understand why the imports are missing.