### PR TITLE
Fix exception handling of tf.histogram_fixed_width_bins

### DIFF
--- a/tensorflow/python/ops/histogram_ops.py
+++ b/tensorflow/python/ops/histogram_ops.py
@@ -24,7 +24,9 @@ from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import clip_ops
+from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import gen_math_ops
+from tensorflow.python.ops import gen_string_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.util.tf_export import tf_export
 
@@ -81,6 +83,14 @@ def histogram_fixed_width_bins(values,
 
     values = array_ops.reshape(values, [-1])
     value_range = ops.convert_to_tensor(value_range, name='value_range')
+    msg = gen_string_ops.string_join([
+        "value_range should satisfy value_range[0] < value_range[1], but got '[",
+        gen_string_ops.as_string(value_range[0]),
+        ", ",
+        gen_string_ops.as_string(value_range[1]), "]'"])
+    with ops.control_dependencies([control_flow_ops.Assert(math_ops.less(value_range[0], value_range[1]), [msg])]):
+        value_range = array_ops.identity(value_range)
+
     nbins = ops.convert_to_tensor(nbins, dtype=dtypes.int32, name='nbins')
     nbins_float = math_ops.cast(nbins, values.dtype)
 

--- a/tensorflow/python/ops/histogram_ops.py
+++ b/tensorflow/python/ops/histogram_ops.py
@@ -84,12 +84,15 @@ def histogram_fixed_width_bins(values,
     values = array_ops.reshape(values, [-1])
     value_range = ops.convert_to_tensor(value_range, name='value_range')
     msg = gen_string_ops.string_join([
-        "value_range should satisfy value_range[0] < value_range[1], but got '[",
+        "value_range should satisfy value_range[0] < value_range[1], ",
+        "but got '[",
         gen_string_ops.as_string(value_range[0]),
         ", ",
         gen_string_ops.as_string(value_range[1]), "]'"])
-    with ops.control_dependencies([control_flow_ops.Assert(math_ops.less(value_range[0], value_range[1]), [msg])]):
-        value_range = array_ops.identity(value_range)
+    with ops.control_dependencies(
+        [control_flow_ops.Assert(math_ops.less(
+            value_range[0], value_range[1]), [msg])]):
+      value_range = array_ops.identity(value_range)
 
     nbins = ops.convert_to_tensor(nbins, dtype=dtypes.int32, name='nbins')
     nbins_float = math_ops.cast(nbins, values.dtype)

--- a/tensorflow/python/ops/histogram_ops_test.py
+++ b/tensorflow/python/ops/histogram_ops_test.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 import numpy as np
 
 from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import errors_impl
 from tensorflow.python.framework import test_util
 from tensorflow.python.framework import constant_op
 from tensorflow.python.ops import array_ops
@@ -78,6 +79,16 @@ class BinValuesFixedWidth(test.TestCase):
           values, value_range, nbins=5)
       self.assertEqual(dtypes.int32, bins.dtype)
       self.assertAllClose(expected_bins, self.evaluate(bins))
+
+  def test_range_overlap(self):
+    # GitHub issue 29661
+    value_range = np.float32([0.0, 0.0])
+    values = np.float32([-1.0, 0.0, 1.5, 2.0, 5.0, 15])
+    expected_bins = [0, 0, 4, 4, 4, 4]
+    with self.assertRaises(errors_impl.InvalidArgumentError):
+      with self.cached_session():
+        _ = histogram_ops.histogram_fixed_width_bins(
+            values, value_range, nbins=5)
 
 
 class HistogramFixedWidthTest(test.TestCase):

--- a/tensorflow/python/ops/histogram_ops_test.py
+++ b/tensorflow/python/ops/histogram_ops_test.py
@@ -21,7 +21,6 @@ from __future__ import print_function
 import numpy as np
 
 from tensorflow.python.framework import dtypes
-from tensorflow.python.framework import errors_impl
 from tensorflow.python.framework import test_util
 from tensorflow.python.framework import constant_op
 from tensorflow.python.ops import array_ops

--- a/tensorflow/python/ops/histogram_ops_test.py
+++ b/tensorflow/python/ops/histogram_ops_test.py
@@ -85,7 +85,7 @@ class BinValuesFixedWidth(test.TestCase):
     value_range = np.float32([0.0, 0.0])
     values = np.float32([-1.0, 0.0, 1.5, 2.0, 5.0, 15])
     expected_bins = [0, 0, 4, 4, 4, 4]
-    with self.assertRaises(errors_impl.InvalidArgumentError):
+    with self.assertRaises(ValueError):
       with self.cached_session():
         _ = histogram_ops.histogram_fixed_width_bins(
             values, value_range, nbins=5)


### PR DESCRIPTION

This PR tries to address the issue in #29661 where
tf.histogram_fixed_width_bins does not throw out an exception
when (value_range[0] < value_range[1]) is not satified.
This is dfferent from the documentation specified in the docstring.

This is different from a similiar API `tf.histogram_fixed_width`
where exception is thrown out correctly. The reason is that
`tf.histogram_fixed_width_bins` is handled in python while
`tf.histogram_fixed_width` has a C++ kernel.

This PR uses tf.Assert to make sure `(value_range[0] < value_range[1])`
satisty.

This PR fixes #29661.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>