### PR TITLE
Include .h.inc file into the header files of the wheel package

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -252,6 +252,7 @@ headers = (
     list(find_files('*.h', 'tensorflow/c')) +
     list(find_files('*.h', 'tensorflow/cc')) +
     list(find_files('*.h', 'tensorflow/compiler')) +
+    list(find_files('*.h.inc', 'tensorflow/compiler')) +
     list(find_files('*.h', 'tensorflow/core')) +
     list(find_files('*.h', 'tensorflow/python')) +
     list(find_files('*.h', 'tensorflow/stream_executor')) +


### PR DESCRIPTION
While working on inlcuding some header files in compiler directory
from a installed tf-nightly wheel package, we noticed that the
generated header files from llvm (*.h.inc) in `tensorflow/compiler`
directories are not packaged into the wheel package.

As a result, it is not possible to include the header files in `tensorflow/compiler`
because they include `*.h.inc` as well.

For example, `mlir/tensorflow/ir/tf_ops.h` needs both `mlir/tensorflow/ir/tf_interfaces.h.inc`
and `mlir/tensorflow/ir/tf_ops.h.inc"

This PR add `.h.inc` into the packaged wheel file so that it is possible to use
header files in a locall install.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>