### PR TITLE
fix tflite python whl package pybind11 build fail

### DIFF
--- a/tensorflow/lite/tools/pip_package/README.md
+++ b/tensorflow/lite/tools/pip_package/README.md
@@ -9,6 +9,7 @@ To build a binary wheel run this script:
 
 ```sh
 sudo apt install swig libjpeg-dev zlib1g-dev python3-dev python3-numpy
+pip install numpy pybind11
 sh tensorflow/lite/tools/make/download_dependencies.sh
 sh tensorflow/lite/tools/pip_package/build_pip_package.sh
 ```

--- a/tensorflow/lite/tools/pip_package/setup.py
+++ b/tensorflow/lite/tools/pip_package/setup.py
@@ -33,6 +33,7 @@ import sysconfig
 
 from distutils.command.build_ext import build_ext
 import numpy
+import pybind11
 
 from setuptools import Extension
 from setuptools import find_packages
@@ -178,8 +179,9 @@ ext = Extension(
                      'pip_package'),
         numpy.get_include(),
         os.path.join(DOWNLOADS_DIR, 'flatbuffers', 'include'),
-        os.path.join(DOWNLOADS_DIR, 'absl')
-    ] + get_pybind_include(),
+        os.path.join(DOWNLOADS_DIR, 'absl'),
+        pybind11.get_include()
+    ],
     libraries=[LIB_TFLITE],
     library_dirs=[LIB_TFLITE_DIR])
 


### PR DESCRIPTION
Get the correct pybind11.h include path when build the tflite run time whl package.
As reported in this issue: https://github.com/tensorflow/tensorflow/issues/38903