### PR TITLE
[XLA] Remove cross device nodes from clusters

### DIFF
--- a/tensorflow/compiler/jit/mark_for_compilation_pass.cc
+++ b/tensorflow/compiler/jit/mark_for_compilation_pass.cc
@@ -1179,7 +1179,11 @@ Status MarkForCompilationPassImpl::FindCompilationCandidates() {
     // skip nodes that have cross device edges.
     auto is_cross_device_edge = [](const Edge* e) {
       auto src = e->src();
+      if (src->IsSource())
+        return false;
       auto dst = e->dst();
+      if (dst->IsSink())
+        return false;
       return !src->assigned_device_name().empty() &&
              !dst->assigned_device_name().empty() &&
              src->assigned_device_name() != dst->assigned_device_name();

--- a/tensorflow/compiler/jit/mark_for_compilation_pass.cc
+++ b/tensorflow/compiler/jit/mark_for_compilation_pass.cc
@@ -1176,6 +1176,31 @@ Status MarkForCompilationPassImpl::FindCompilationCandidates() {
       break;
     }
 
+    // skip nodes that have cross device edges.
+    bool cross_device = false;
+    for (const Edge* e : node->out_edges()) {
+      auto dst = e->dst();
+      if (!node->assigned_device_name().empty() &&
+          !dst->assigned_device_name().empty() &&
+          node->assigned_device_name() != dst->assigned_device_name()) {
+        cross_device = true;
+        break;
+      }
+    }
+    if (!cross_device) {
+      for (const Edge* e : node->in_edges()) {
+        auto src = e->src();
+        if (!node->assigned_device_name().empty() &&
+            !src->assigned_device_name().empty() &&
+            node->assigned_device_name() != src->assigned_device_name()) {
+          cross_device = true;
+          break;
+        }
+      }
+    }
+    if (cross_device)
+      continue;
+
     TF_ASSIGN_OR_RETURN(
         const DeviceType& device_type,
         device_info_cache_.GetDeviceTypeFor(node->assigned_device_name()));


### PR DESCRIPTION
This is a PR from JIZHI, the AI platform in Tencent.

This pr removes the the cross device nodes (nodes that have input or output from
other device) from the compilation candidates in `MarkForCompilation`. The reason for this change is that if the cross device nodes are introduced into clusters, the following 2 situation may happen and largely harm the performance.
```
  device0:  op1 ---    op2        cluster(op1, op2) ---
                  |          ===>                     |
  device1:        ---> op3                            ---> op3

  or

  device0:  op1   ---> op2              ---> cluster(op1, op2)
                  |          ===>       |
  device1:  op3 ---               op3 ---
```
XLA will delay the execution of an op when one of its predecessors is merged in the middle of a cluster. This delay will be ok when the op and the cluster are on the same device, because their kernels are executed sequentially. But when using multiple devices, this delay will make one device wait. For example, this is the timeline of a transformer model:
- Before removing cross device nodes:
![image](https://user-images.githubusercontent.com/10428324/80304808-105fce80-87eb-11ea-845d-473d9397c421.png)
- After removing cross device nodes:
![image](https://user-images.githubusercontent.com/10428324/80304824-29687f80-87eb-11ea-8712-bca355333d52.png)

The alternative way to solve this problem is to add more condition in `TryToContract`. However,  that will result in larger modification because we need to save the device information of all nodes in a cluster. If you prefer this way, we are also glad to help.

Thank you for your time on reviewing this pr.