### PR TITLE
[ROCm] Updates for XLA unit-tests on the ROCm platform

### DIFF
--- a/tensorflow/compiler/xla/service/mlir_gpu/tests/BUILD
+++ b/tensorflow/compiler/xla/service/mlir_gpu/tests/BUILD
@@ -22,6 +22,7 @@ glob_lit_tests(
     default_tags = tf_cuda_tests_tags() + [
         "no_pip",
         "config-cuda-only",
+        "no_rocm",
     ],
     driver = "@llvm-project//mlir:run_lit.sh",
     exclude = [


### PR DESCRIPTION
This PR 
* adds no_rocm tag to tests within the `//tensforlow/compiler/xla/service/mlir_gpu` dir
 These tests need to be disabled on the ROCm platform, until we add ROCm support for them
* fixes a bug that was causing some test failures
 @ekuznetsov139 originally applied the fix on the ROCm fork. this PR upstreams it.


-------------------------------------

/cc @cheshire @chsigg @nvining-work @ekuznetsov139 