### PR TITLE
Update examples in docstring to use TF 2.x code

### DIFF
--- a/tensorflow/python/ops/histogram_ops.py
+++ b/tensorflow/python/ops/histogram_ops.py
@@ -62,15 +62,14 @@ def histogram_fixed_width_bins(values,
 
   Examples:
 
-  ```python
   >>> # Bins will be:  (-inf, 1), [1, 2), [2, 3), [3, 4), [4, inf)
-  ... 
+  ...
   >>> nbins = 5
   >>> value_range = [0.0, 5.0]
   >>> new_values = [-1.0, 0.0, 1.5, 2.0, 5.0, 15]
-  >>> tf.histogram_fixed_width_bins(new_values, value_range, nbins=5)
-  <tf.Tensor: shape=(6,), dtype=int32, numpy=array([0, 0, 1, 2, 4, 4], dtype=int32)>
-  ```
+  >>> indices = tf.histogram_fixed_width_bins(new_values, value_range, nbins=5)
+  >>> indices.numpy()
+  array([0, 0, 1, 2, 4, 4], dtype=int32)
   """
   with ops.name_scope(name, 'histogram_fixed_width_bins',
                       [values, value_range, nbins]):
@@ -129,15 +128,14 @@ def histogram_fixed_width(values,
 
   Examples:
 
-  ```python
   >>> # Bins will be:  (-inf, 1), [1, 2), [2, 3), [3, 4), [4, inf)
-  ... 
+  ...
   >>> nbins = 5
   >>> value_range = [0.0, 5.0]
   >>> new_values = [-1.0, 0.0, 1.5, 2.0, 5.0, 15]
-  >>> tf.histogram_fixed_width(new_values, value_range, nbins=5)
-  <tf.Tensor: shape=(5,), dtype=int32, numpy=array([2, 1, 1, 0, 2], dtype=int32)>
-  ```
+  >>> hist = tf.histogram_fixed_width(new_values, value_range, nbins=5)
+  >>> hist.numpy()
+  array([2, 1, 1, 0, 2], dtype=int32)
   """
   with ops.name_scope(name, 'histogram_fixed_width',
                       [values, value_range, nbins]) as name:

--- a/tensorflow/python/ops/histogram_ops.py
+++ b/tensorflow/python/ops/histogram_ops.py
@@ -63,13 +63,14 @@ def histogram_fixed_width_bins(values,
   Examples:
 
   ```python
-  # Bins will be:  (-inf, 1), [1, 2), [2, 3), [3, 4), [4, inf)
-  nbins = 5
-  value_range = [0.0, 5.0]
-  new_values = [-1.0, 0.0, 1.5, 2.0, 5.0, 15]
-
-  indices = tf.histogram_fixed_width_bins(new_values, value_range, nbins=5)
-  indices # [0, 0, 1, 2, 4, 4]
+  >>> # Bins will be:  (-inf, 1), [1, 2), [2, 3), [3, 4), [4, inf)
+  ... 
+  >>> nbins = 5
+  >>> value_range = [0.0, 5.0]
+  >>> new_values = [-1.0, 0.0, 1.5, 2.0, 5.0, 15]
+  >>> indices = tf.histogram_fixed_width_bins(new_values, value_range, nbins=5)
+  >>> print(indices) 
+  tf.Tensor([0 0 1 2 4 4], shape=(6,), dtype=int32)
   ```
   """
   with ops.name_scope(name, 'histogram_fixed_width_bins',
@@ -130,13 +131,14 @@ def histogram_fixed_width(values,
   Examples:
 
   ```python
-  # Bins will be:  (-inf, 1), [1, 2), [2, 3), [3, 4), [4, inf)
-  nbins = 5
-  value_range = [0.0, 5.0]
-  new_values = [-1.0, 0.0, 1.5, 2.0, 5.0, 15]
-
-  hist = tf.histogram_fixed_width(new_values, value_range, nbins=5)
-  hist # [2, 1, 1, 0, 2]
+  >>> # Bins will be:  (-inf, 1), [1, 2), [2, 3), [3, 4), [4, inf)
+  ... 
+  >>> nbins = 5
+  >>> value_range = [0.0, 5.0]
+  >>> new_values = [-1.0, 0.0, 1.5, 2.0, 5.0, 15]
+  >>> hist = tf.histogram_fixed_width(new_values, value_range, nbins=5)
+  >>> print(hist)
+  tf.Tensor([2 1 1 0 2], shape=(5,), dtype=int32)
   ```
   """
   with ops.name_scope(name, 'histogram_fixed_width',

--- a/tensorflow/python/ops/histogram_ops.py
+++ b/tensorflow/python/ops/histogram_ops.py
@@ -68,10 +68,8 @@ def histogram_fixed_width_bins(values,
   value_range = [0.0, 5.0]
   new_values = [-1.0, 0.0, 1.5, 2.0, 5.0, 15]
 
-  with tf.compat.v1.get_default_session() as sess:
-    indices = tf.histogram_fixed_width_bins(new_values, value_range, nbins=5)
-    variables.global_variables_initializer().run()
-    sess.run(indices) # [0, 0, 1, 2, 4, 4]
+  indices = tf.histogram_fixed_width_bins(new_values, value_range, nbins=5)
+  indices # [0, 0, 1, 2, 4, 4]
   ```
   """
   with ops.name_scope(name, 'histogram_fixed_width_bins',
@@ -137,10 +135,8 @@ def histogram_fixed_width(values,
   value_range = [0.0, 5.0]
   new_values = [-1.0, 0.0, 1.5, 2.0, 5.0, 15]
 
-  with tf.compat.v1.get_default_session() as sess:
-    hist = tf.histogram_fixed_width(new_values, value_range, nbins=5)
-    variables.global_variables_initializer().run()
-    sess.run(hist) => [2, 1, 1, 0, 2]
+  hist = tf.histogram_fixed_width(new_values, value_range, nbins=5)
+  hist # [2, 1, 1, 0, 2]
   ```
   """
   with ops.name_scope(name, 'histogram_fixed_width',

--- a/tensorflow/python/ops/histogram_ops.py
+++ b/tensorflow/python/ops/histogram_ops.py
@@ -68,9 +68,8 @@ def histogram_fixed_width_bins(values,
   >>> nbins = 5
   >>> value_range = [0.0, 5.0]
   >>> new_values = [-1.0, 0.0, 1.5, 2.0, 5.0, 15]
-  >>> indices = tf.histogram_fixed_width_bins(new_values, value_range, nbins=5)
-  >>> print(indices) 
-  tf.Tensor([0 0 1 2 4 4], shape=(6,), dtype=int32)
+  >>> tf.histogram_fixed_width_bins(new_values, value_range, nbins=5)
+  <tf.Tensor: shape=(6,), dtype=int32, numpy=array([0, 0, 1, 2, 4, 4], dtype=int32)>
   ```
   """
   with ops.name_scope(name, 'histogram_fixed_width_bins',
@@ -136,9 +135,8 @@ def histogram_fixed_width(values,
   >>> nbins = 5
   >>> value_range = [0.0, 5.0]
   >>> new_values = [-1.0, 0.0, 1.5, 2.0, 5.0, 15]
-  >>> hist = tf.histogram_fixed_width(new_values, value_range, nbins=5)
-  >>> print(hist)
-  tf.Tensor([2 1 1 0 2], shape=(5,), dtype=int32)
+  >>> tf.histogram_fixed_width(new_values, value_range, nbins=5)
+  <tf.Tensor: shape=(5,), dtype=int32, numpy=array([2, 1, 1, 0, 2], dtype=int32)>
   ```
   """
   with ops.name_scope(name, 'histogram_fixed_width',


### PR DESCRIPTION
The examples in docstrings of two APIs, tf.histogram_fixed_width_bins
and tf.histogram_fixed_width still used TF 1.x code.

This PR updates the docstring to use TF 2.x code in examples.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>