### PR TITLE
Add gcs_file_system to be part of the pip wheel build

### DIFF
--- a/tensorflow/core/platform/default/build_config.bzl
+++ b/tensorflow/core/platform/default/build_config.bzl
@@ -638,7 +638,9 @@ def tf_additional_core_deps():
         clean_dep("//tensorflow:android"): [],
         clean_dep("//tensorflow:ios"): [],
         clean_dep("//tensorflow:linux_s390x"): [],
-        clean_dep("//tensorflow:windows"): [],
+        clean_dep("//tensorflow:windows"): [
+            "//tensorflow/core/platform/cloud:gcs_file_system",
+        ],
         clean_dep("//tensorflow:no_gcp_support"): [],
         "//conditions:default": [
             "//tensorflow/core/platform/cloud:gcs_file_system",


### PR DESCRIPTION
This PR is related to https://github.com/tensorflow/io/pull/919, while trying to include
'tensorflow/core/platform/cloud/gcs_file_system.h' with installed tf-nightly,
the Windows wheel is missing this file while Linux and macOS works file.

It seems that gcs_file_system was not included in windows tf-nightly build

This PR adds gcs_file_system to tf-niglty windows build.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>