### PR TITLE
Provide NVIDIA CUDA build data in metadata and API

### DIFF
--- a/tensorflow/python/framework/config.py
+++ b/tensorflow/python/framework/config.py
@@ -19,6 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 from tensorflow.python.eager import context
+from tensorflow.python.platform import build_info
 from tensorflow.python.util import deprecation
 from tensorflow.python.util.tf_export import tf_export
 
@@ -653,3 +654,25 @@ def disable_mlir_bridge():
 def disable_mlir_graph_optimization():
   """Disables experimental MLIR-Based TensorFlow Compiler Optimizations."""
   context.context().enable_mlir_graph_optimization = False
+
+
+@tf_export('config.get_cuda_version_used_to_compile_tf')
+def get_cuda_version_used_to_compile_tf():
+  """Get the version of NVIDIA CUDA used to compile this TensorFlow release.
+
+  Returns:
+    String representation of CUDA version number (Major.Minor) if CUDA support
+    is included, otherwise None.
+  """
+  return build_info.cuda_build_info.get('cuda_version', None)
+
+
+@tf_export('config.get_cudnn_version_used_to_compile_tf')
+def get_cudnn_version_used_to_compile_tf():
+  """Get the version of NVIDIA cuDNN used to compile this TensorFlow release.
+
+  Returns:
+    String representation of cuDNN version number (Major only) if cuDNN support
+    is included, otherwise None.
+  """
+  return build_info.cuda_build_info.get('cudnn_version', None)

--- a/tensorflow/python/framework/config.py
+++ b/tensorflow/python/framework/config.py
@@ -656,7 +656,7 @@ def disable_mlir_graph_optimization():
   context.context().enable_mlir_graph_optimization = False
 
 
-@tf_export('config.get_build_info()')
+@tf_export('config.get_build_info')
 def get_build_info():
   """Get a dictionary describing TensorFlow's build environment.
 

--- a/tensorflow/python/framework/config.py
+++ b/tensorflow/python/framework/config.py
@@ -656,23 +656,26 @@ def disable_mlir_graph_optimization():
   context.context().enable_mlir_graph_optimization = False
 
 
-@tf_export('config.get_cuda_version_used_to_compile_tf')
-def get_cuda_version_used_to_compile_tf():
-  """Get the version of NVIDIA CUDA used to compile this TensorFlow release.
+@tf_export('config.get_build_info()')
+def get_build_info():
+  """Get a dictionary describing TensorFlow's build environment.
+
+  Values are generated when TensorFlow is compiled, and are static for each
+  TensorFlow package. This information is limited to a subset of the following
+  keys based on the platforms targeted by the package:
+
+    - cuda_version
+    - cudnn_version
+    - tensorrt_version
+    - nccl_version
+    - is_cuda_build
+    - is_rocm_build
+    - msvcp_dll_names
+    - nvcuda_dll_name
+    - cudart_dll_name
+    - cudnn_dll_name
 
   Returns:
-    String representation of CUDA version number (Major.Minor) if CUDA support
-    is included, otherwise None.
+    A Dictionary describing TensorFlow's build environment.
   """
   return build_info.cuda_build_info.get('cuda_version', None)
-
-
-@tf_export('config.get_cudnn_version_used_to_compile_tf')
-def get_cudnn_version_used_to_compile_tf():
-  """Get the version of NVIDIA cuDNN used to compile this TensorFlow release.
-
-  Returns:
-    String representation of cuDNN version number (Major only) if cuDNN support
-    is included, otherwise None.
-  """
-  return build_info.cuda_build_info.get('cudnn_version', None)

--- a/tensorflow/python/keras/layers/recurrent_v2.py
+++ b/tensorflow/python/keras/layers/recurrent_v2.py
@@ -601,7 +601,7 @@ def gpu_gru(inputs, init_h, kernel, recurrent_kernel, bias, mask, time_major,
   # (6 * units)
   bias = array_ops.split(K.flatten(bias), 6)
 
-  if build_info.is_cuda_build:
+  if build_info.build_info["is_cuda_build"]:
     # Note that the gate order for CuDNN is different from the canonical format.
     # canonical format is [z, r, h], whereas CuDNN is [r, z, h]. The swap need
     # to be done for kernel, recurrent_kernel, input_bias, recurrent_bias.
@@ -1361,7 +1361,7 @@ def gpu_lstm(inputs, init_h, init_c, kernel, recurrent_kernel, bias, mask,
   # so that mathematically it is same as the canonical LSTM implementation.
   full_bias = array_ops.concat((array_ops.zeros_like(bias), bias), 0)
 
-  if build_info.is_rocm_build:
+  if build_info.build_info["is_rocm_build"]:
     # ROCm MIOpen's weight sequence for LSTM is different from both canonical
     # and Cudnn format
     # MIOpen: [i, f, o, c] Cudnn/Canonical: [i, f, c, o]

--- a/tensorflow/python/platform/build_info_test.py
+++ b/tensorflow/python/platform/build_info_test.py
@@ -25,8 +25,8 @@ from tensorflow.python.platform import test
 class BuildInfoTest(test.TestCase):
 
   def testBuildInfo(self):
-    self.assertEqual(build_info.is_rocm_build, test.is_built_with_rocm())
-    self.assertEqual(build_info.is_cuda_build, test.is_built_with_cuda())
+    self.assertEqual(build_info.build_info["is_rocm_build"], test.is_built_with_rocm())
+    self.assertEqual(build_info.build_info["is_cuda_build"], test.is_built_with_cuda())
 
 
 if __name__ == '__main__':

--- a/tensorflow/python/platform/self_check.py
+++ b/tensorflow/python/platform/self_check.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 
 import os
 
+MSVCP_DLL_NAMES = "msvcp_dll_names"
 
 try:
   from tensorflow.python.platform import build_info
@@ -42,9 +43,9 @@ def preload_check():
     # we load the Python extension, so that we can raise an actionable error
     # message if they are not found.
     import ctypes  # pylint: disable=g-import-not-at-top
-    if hasattr(build_info, "msvcp_dll_names"):
+    if MSVCP_DLL_NAMES in build_info.build_info:
       missing = []
-      for dll_name in build_info.msvcp_dll_names.split(","):
+      for dll_name in build_info.build_info[MSVCP_DLL_NAMES].split(","):
         try:
           ctypes.WinDLL(dll_name)
         except OSError:

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -2608,7 +2608,7 @@ def tf_py_build_info_genrule(name, out):
                 + " is_rocm_build=" + if_rocm("True", "False")
                 + " is_cuda_build=" + if_cuda("True", "False")
                 # TODO(angerson) Can we reliably load CUDA compute capabilities here?
-                if_windows(dict_to_kv({
+                + if_windows(dict_to_kv({
                     "msvcp_dll_names": "msvcp140.dll,msvcp140_1.dll"
                 }), "") + if_windows_cuda(dict_to_kv({
                     "nvcuda_dll_name": "nvcuda.dll",

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -2593,6 +2593,10 @@ def tf_version_info_genrule(name, out):
         arguments = "--generate \"$@\" --git_tag_override=${GIT_TAG_OVERRIDE:-}",
     )
 
+def dict_to_kv(d):
+    """Convert a dictionary to a space-joined list of key=value pairs."""
+    return " " + " ".join(["%s=%s" % (k,v) for k, v in d.items()])
+
 def tf_py_build_info_genrule(name, out):
     _local_genrule(
         name = name,
@@ -2600,16 +2604,17 @@ def tf_py_build_info_genrule(name, out):
         exec_tool = "//tensorflow/tools/build_info:gen_build_info",
         arguments =
             "--raw_generate \"$@\" " +
-            " --is_config_cuda " + if_cuda("True", "False") +
-            " --is_config_rocm " + if_rocm("True", "False") +
-            " --key_value " +
-            if_cuda(" cuda_version_number=${TF_CUDA_VERSION:-} cudnn_version_number=${TF_CUDNN_VERSION:-} ", "") +
-            if_windows(" msvcp_dll_names=msvcp140.dll,msvcp140_1.dll ", "") +
-            if_windows_cuda(" ".join([
-                "nvcuda_dll_name=nvcuda.dll",
-                "cudart_dll_name=cudart64_$(echo $${TF_CUDA_VERSION:-} | sed \"s/\\.//\").dll",
-                "cudnn_dll_name=cudnn64_${TF_CUDNN_VERSION:-}.dll",
-            ]), ""),
+            " --key_value"
+                + " is_rocm_build=" + if_rocm("True", "False")
+                + " is_cuda_build=" + if_cuda("True", "False")
+                # TODO(angerson) Can we reliably load CUDA compute capabilities here?
+                if_windows(dict_to_kv({
+                    "msvcp_dll_names": "msvcp140.dll,msvcp140_1.dll"
+                }), "") + if_windows_cuda(dict_to_kv({
+                    "nvcuda_dll_name": "nvcuda.dll",
+                    "cudart_dll_name": "cudart64_$$(echo $${TF_CUDA_VERSION:-} | sed \"s/\\.//\").dll",
+                    "cudnn_dll_name": "cudnn64_$${TF_CUDNN_VERSION:-}.dll",
+            }), ""),
     )
 
 def cc_library_with_android_deps(

--- a/tensorflow/tools/build_info/BUILD
+++ b/tensorflow/tools/build_info/BUILD
@@ -15,5 +15,6 @@ py_binary(
     tags = ["no-remote-exec"],
     deps = [
         "@six_archive//:six",
+        "//third_party/gpus:find_cuda_config",
     ],
 )

--- a/tensorflow/tools/build_info/gen_build_info.py
+++ b/tensorflow/tools/build_info/gen_build_info.py
@@ -107,7 +107,6 @@ parser.add_argument(
 args = parser.parse_args()
 
 if args.raw_generate:
-  print(args.key_value)
   write_build_info(args.raw_generate, args.key_value)
 else:
   raise RuntimeError(

--- a/tensorflow/tools/build_info/gen_build_info.py
+++ b/tensorflow/tools/build_info/gen_build_info.py
@@ -84,7 +84,7 @@ def write_build_info(filename, key_value_list):
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-\"\"\"Auto-generated module providing information about the build.\"\"\""
+\"\"\"Auto-generated module providing information about the build.\"\"\"
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/tensorflow/tools/build_info/gen_build_info.py
+++ b/tensorflow/tools/build_info/gen_build_info.py
@@ -28,48 +28,28 @@ import six
 from third_party.gpus import find_cuda_config
 
 
-def write_build_info(filename, is_config_cuda, is_config_rocm, key_value_list):
+def write_build_info(filename, key_value_list):
   """Writes a Python that describes the build.
 
   Args:
     filename: filename to write to.
-    is_config_cuda: Whether this build is using CUDA.
-    is_config_rocm: Whether this build is using ROCm.
     key_value_list: A list of "key=value" strings that will be added to the
-      module as additional fields.
-
-  Raises:
-    ValueError: If `key_value_list` includes the key "is_cuda_build", which
-      would clash with one of the default fields.
+      module's "build_info" dictionary as additional entries.
   """
-  module_docstring = "\"\"\"Generates a Python module containing information "
-  module_docstring += "about the build.\"\"\""
 
-  build_config_rocm_bool = "False"
-  build_config_cuda_bool = "False"
-
-  if is_config_rocm == "True":
-    build_config_rocm_bool = "True"
-  elif is_config_cuda == "True":
-    build_config_cuda_bool = "True"
-
-  key_value_pair_stmts = []
-  if key_value_list:
-    for arg in key_value_list:
-      key, value = six.ensure_str(arg).split("=")
-      if key == "is_cuda_build":
-        raise ValueError("The key \"is_cuda_build\" cannot be passed as one of "
-                         "the --key_value arguments.")
-      if key == "is_rocm_build":
-        raise ValueError("The key \"is_rocm_build\" cannot be passed as one of "
-                         "the --key_value arguments.")
-      key_value_pair_stmts.append("%s = %r" % (key, value))
-  key_value_pair_content = "\n".join(key_value_pair_stmts)
+  build_info = {}
+  for arg in key_value_list:
+    key, value = six.ensure_str(arg).split("=")
+    if value.lower() == "true":
+      build_info[key] = True
+    elif value.lower() == "false":
+      build_info[key] = False
+    else:
+      build_info[key] = value
 
   # Generate cuda_build_info, a dict describing the CUDA component versions
   # used to build TensorFlow.
-  cuda_build_info = "{}"
-  if is_config_cuda == "True":
+  if build_info.get("is_cuda_build", False):
     libs = ["_", "cuda", "cudnn"]
     if platform.system() == "Linux":
       if os.environ.get("TF_NEED_TENSORRT", "0") == "1":
@@ -82,16 +62,15 @@ def write_build_info(filename, is_config_cuda, is_config_rocm, key_value_list):
     backup_argv = sys.argv
     sys.argv = libs
     cuda = find_cuda_config.find_cuda_config()
-    cuda_build_info = str({
-        "cuda_version": cuda["cuda_version"],
-        "cudnn_version": cuda["cudnn_version"],
-        "tensorrt_version": cuda.get("tensorrt_version", None),
-        "nccl_version": cuda.get("nccl_version", None),
-    })
+
+    build_info["cuda_version"] = cuda["cuda_version"]
+    build_info["cudnn_version"] = cuda["cudnn_version"]
+    build_info["tensorrt_version"] = cuda.get("tensorrt_version", None)
+    build_info["nccl_version"] = cuda.get("nccl_version", None)
     sys.argv = backup_argv
 
   contents = f"""
-# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -105,31 +84,20 @@ def write_build_info(filename, is_config_cuda, is_config_rocm, key_value_list):
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-{module_docstring}
+\"\"\"Auto-generated module providing information about the build.\"\"\""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-is_rocm_build = {build_config_rocm_bool}
-is_cuda_build = {build_config_cuda_bool}
-cuda_build_info = {cuda_build_info}
+from collections import namedtuple
 
+build_info = {build_info}
 """
   open(filename, "w").write(contents)
 
 
 parser = argparse.ArgumentParser(
     description="""Build info injection into the PIP package.""")
-
-parser.add_argument(
-    "--is_config_cuda",
-    type=str,
-    help="'True' for CUDA GPU builds, 'False' otherwise.")
-
-parser.add_argument(
-    "--is_config_rocm",
-    type=str,
-    help="'True' for ROCm GPU builds, 'False' otherwise.")
 
 parser.add_argument("--raw_generate", type=str, help="Generate build_info.py")
 
@@ -138,10 +106,9 @@ parser.add_argument(
 
 args = parser.parse_args()
 
-if (args.raw_generate is not None) and (args.is_config_cuda is not None) and (
-    args.is_config_rocm is not None):
-  write_build_info(args.raw_generate, args.is_config_cuda, args.is_config_rocm,
-                   args.key_value)
+if args.raw_generate:
+  print(args.key_value)
+  write_build_info(args.raw_generate, args.key_value)
 else:
   raise RuntimeError(
-      "--raw_generate, --is_config_cuda and --is_config_rocm must be used")
+      "--raw_generate must be used.")

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -1,3 +1,4 @@
+# lint as: python3
 # Copyright 2015 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,6 +44,8 @@ from setuptools import setup
 from setuptools.command.install import install as InstallCommandBase
 from setuptools.dist import Distribution
 
+from tensorflow.python.platform import build_info
+
 DOCLINES = __doc__.split('\n')
 
 # This version string is semver compatible, but incompatible with pip.
@@ -82,6 +85,20 @@ REQUIRED_PACKAGES = [
     'scipy == 1.2.2;python_version<"3"',
 ]
 
+GPU_DESCRIPTION = ''
+if build_info.is_cuda_build:
+  gpu_header = (f'\nTensorFlow {_VERSION} for NVIDIA GPUs was built with these '
+                'platform and library versions:\n\n  - ')
+  cbi = build_info.cuda_build_info
+  trt_ver = cbi['tensorrt_version']
+  nccl_ver = cbi['nccl_version']
+  GPU_DESCRIPTION = gpu_header + '\n  - '.join([
+      'NVIDIA CUDA ' + cbi['cuda_version'],
+      'NVIDIA cuDNN ' + cbi['cudnn_version'],
+      'NVIDIA NCCL ' + 'not enabled' if not nccl_ver else nccl_ver,
+      'NVIDIA TensorRT ' + 'not enabled' if not trt_ver else trt_ver,
+  ])
+
 if sys.byteorder == 'little':
   # grpcio does not build correctly on big-endian machines due to lack of
   # BoringSSL support.
@@ -117,7 +134,8 @@ CONSOLE_SCRIPTS = [
     # even though the command is not removed, just moved to a different wheel.
     'tensorboard = tensorboard.main:run_main',
     'tf_upgrade_v2 = tensorflow.tools.compatibility.tf_upgrade_v2_main:main',
-    'estimator_ckpt_converter = tensorflow_estimator.python.estimator.tools.checkpoint_converter:main',
+    'estimator_ckpt_converter = '
+    'tensorflow_estimator.python.estimator.tools.checkpoint_converter:main',
 ]
 # pylint: enable=line-too-long
 
@@ -161,11 +179,10 @@ class InstallHeaders(Command):
   """
   description = 'install C/C++ header files'
 
-  user_options = [('install-dir=', 'd',
-                   'directory to install header files to'),
-                  ('force', 'f',
-                   'force installation (overwrite existing files)'),
-                 ]
+  user_options = [
+      ('install-dir=', 'd', 'directory to install header files to'),
+      ('force', 'f', 'force installation (overwrite existing files)'),
+  ]
 
   boolean_options = ['force']
 
@@ -175,8 +192,7 @@ class InstallHeaders(Command):
     self.outfiles = []
 
   def finalize_options(self):
-    self.set_undefined_options('install',
-                               ('install_headers', 'install_dir'),
+    self.set_undefined_options('install', ('install_headers', 'install_dir'),
                                ('force', 'force'))
 
   def mkdir_and_copy_file(self, header):
@@ -236,9 +252,7 @@ so_lib_paths = [
 
 matches = []
 for path in so_lib_paths:
-  matches.extend(
-      ['../' + x for x in find_files('*', path) if '.py' not in x]
-  )
+  matches.extend(['../' + x for x in find_files('*', path) if '.py' not in x])
 
 if os.name == 'nt':
   EXTENSION_NAME = 'python/_pywrap_tensorflow_internal.pyd'
@@ -257,17 +271,16 @@ headers = (
     list(find_files('*.h', 'tensorflow/stream_executor')) +
     list(find_files('*.h', 'google/com_google_protobuf/src')) +
     list(find_files('*.inc', 'google/com_google_protobuf/src')) +
-    list(find_files('*', 'third_party/eigen3')) + list(
-        find_files('*.h', 'tensorflow/include/external/com_google_absl')) +
-    list(
-        find_files('*.inc', 'tensorflow/include/external/com_google_absl'))
-    + list(find_files('*', 'tensorflow/include/external/eigen_archive')))
+    list(find_files('*', 'third_party/eigen3')) +
+    list(find_files('*.h', 'tensorflow/include/external/com_google_absl')) +
+    list(find_files('*.inc', 'tensorflow/include/external/com_google_absl')) +
+    list(find_files('*', 'tensorflow/include/external/eigen_archive')))
 
 setup(
     name=project_name,
     version=_VERSION.replace('-', ''),
     description=DOCLINES[0],
-    long_description='\n'.join(DOCLINES[2:]),
+    long_description='\n'.join(DOCLINES[2:]) + GPU_DESCRIPTION,
     url='https://www.tensorflow.org/',
     download_url='https://github.com/tensorflow/tensorflow/tags',
     author='Google Inc.',
@@ -288,6 +301,10 @@ setup(
         ] + matches,
     },
     zip_safe=False,
+    # Accessible with importlib.metadata.metadata('tf-pkg-name').items()
+    platforms=[
+        f'{key}:{value}' for key, value in build_info.cuda_build_info.items()
+    ],
     distclass=BinaryDistribution,
     cmdclass={
         'install_headers': InstallHeaders,

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -86,7 +86,7 @@ REQUIRED_PACKAGES = [
 ]
 
 GPU_DESCRIPTION = ''
-if build_info.is_cuda_build:
+if build_info.build_info['is_cuda_build']:
   gpu_header = (f'\nTensorFlow {_VERSION} for NVIDIA GPUs was built with these '
                 'platform and library versions:\n\n  - ')
   cbi = build_info.cuda_build_info

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -85,16 +85,18 @@ REQUIRED_PACKAGES = [
     'scipy == 1.2.2;python_version<"3"',
 ]
 
+# Generate a footer describing the CUDA technology this release was built
+# against.
 GPU_DESCRIPTION = ''
 if build_info.build_info['is_cuda_build']:
   gpu_header = (f'\nTensorFlow {_VERSION} for NVIDIA GPUs was built with these '
                 'platform and library versions:\n\n  - ')
-  cbi = build_info.cuda_build_info
-  trt_ver = cbi['tensorrt_version']
-  nccl_ver = cbi['nccl_version']
+  bi = build_info.build_info
+  trt_ver = bi['tensorrt_version']
+  nccl_ver = bi['nccl_version']
   GPU_DESCRIPTION = gpu_header + '\n  - '.join([
-      'NVIDIA CUDA ' + cbi['cuda_version'],
-      'NVIDIA cuDNN ' + cbi['cudnn_version'],
+      'NVIDIA CUDA ' + bi['cuda_version'],
+      'NVIDIA cuDNN ' + bi['cudnn_version'],
       'NVIDIA NCCL ' + 'not enabled' if not nccl_ver else nccl_ver,
       'NVIDIA TensorRT ' + 'not enabled' if not trt_ver else trt_ver,
   ])
@@ -303,7 +305,7 @@ setup(
     zip_safe=False,
     # Accessible with importlib.metadata.metadata('tf-pkg-name').items()
     platforms=[
-        f'{key}:{value}' for key, value in build_info.cuda_build_info.items()
+        f'{key}:{value}' for key, value in build_info.build_info.items()
     ],
     distclass=BinaryDistribution,
     cmdclass={

--- a/third_party/gpus/BUILD
+++ b/third_party/gpus/BUILD
@@ -1,0 +1,6 @@
+# Expose find_cuda_config.py as a library so other tools can reference it.
+py_library(
+    name = "find_cuda_config",
+    srcs = ["find_cuda_config.py"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
This change:

First exposes //third_party/gpus:find_cuda_config as a library.

Then, it extends gen_build_info.py with find_cuda_config to provide package
build information within TensorFlow's API. This is accessible as a
dictionary:

    from tensorflow.python.platform import build_info
    print(build_info.cuda_build_info)
    {'cuda_version': '10.2', 'cudnn_version': '7', 'tensorrt_version': None, 'nccl_version': None}

Finally, setup.py pulls that into package metadata (I also formatted setup.py). The same wheel's
long description ends with:

    TensorFlow 2.1.0 for NVIDIA GPUs was built with these platform
    and library versions:

      - NVIDIA CUDA 10.2
      - NVIDIA cuDNN 7
      - NVIDIA NCCL not enabled
      - NVIDIA TensorRT not enabled

In lieu of [NVIDIA CUDA classifiers][1], the same metadata is exposed in the
normally-unused "platform" tag:

    >>> import pkginfo
    >>> a = pkginfo.Wheel('./tf_nightly_gpu-2.1.0-cp36-cp36m-linux_x86_64.whl')
    >>> a.platforms
    ['cuda_version:10.2', 'cudnn_version:7', 'tensorrt_version:None', 'nccl_version:None']

I'm not 100% confident this is the best way to accomplish this. It
seems odd to import like this setup.py, even though it works, even in
an environment with TensorFlow installed.

One caveat for RBE: the contents of genrules still run on the local
system, so I had to syncronize my local environment with the RBE
environment I used to build TensorFlow. I'm not sure if this is going to
require intervention on TensorFlow's current CI.

Currently tested only on Linux GPU (Remote Build) for Python 3.6. I'd
like to see more tests before merging.

Resolves https://github.com/tensorflow/tensorflow/issues/38351.

[1]: https://github.com/pypa/trove-classifiers/issues/25