### PR TITLE
Ifx/pr back to back fq

### DIFF
--- a/tensorflow/compiler/mlir/lite/tests/end2end/back2back_fake_quant.pbtxt
+++ b/tensorflow/compiler/mlir/lite/tests/end2end/back2back_fake_quant.pbtxt
@@ -1,0 +1,1185 @@
+# RUN: tf_tfl_translate --mlir-elide-elementsattrs-if-larger=10 --emit-builtin-tflite-ops \
+# RUN: --emit-select-tf-ops --tf-inference-type=DT_QUINT8 --tf-input-min-values=0.0 \
+# RUN: --tf-input-max-values=6.283185307179586 --tf-input-arrays=quant_dense_input --tf-input-shapes=1,1  \
+# RUN: --tf-output-arrays=Identity -o %t.tflite  %s 2>&1 | FileCheck %s
+# RUN: flatbuffer_to_string %t.tflite | FileCheck --check-prefix=RESULT1 %s
+
+node {
+  name: "quant_dense_input"
+  op: "Placeholder"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: -1
+        }
+        dim {
+          size: 1
+        }
+      }
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense/MatMul/ReadVariableOp/resource"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+          dim {
+            size: 1
+          }
+          dim {
+            size: 16
+          }
+        }
+        tensor_content: "n\267\313\276@W\337>\227o9>PF\237\275|%}\276\333n\005>\371\005\031?\230\355\235\275\344\211_>\034\222\264=\254\003\345=Q\027*>\225\304\373>Qm6>\270\025\022;N/\020\277"
+      }
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense/MatMul/ReadVariableOp"
+  op: "Identity"
+  input: "sequential/quant_dense/MatMul/ReadVariableOp/resource"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense/MatMul/kquant/FakeQuantWithMinMaxVars/ReadVariableOp/resource"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: -0.5634322166442871
+      }
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense/MatMul/kquant/FakeQuantWithMinMaxVars/ReadVariableOp"
+  op: "Identity"
+  input: "sequential/quant_dense/MatMul/kquant/FakeQuantWithMinMaxVars/ReadVariableOp/resource"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense/MatMul/kquant/FakeQuantWithMinMaxVars/ReadVariableOp_1/resource"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.5968852043151855
+      }
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense/MatMul/kquant/FakeQuantWithMinMaxVars/ReadVariableOp_1"
+  op: "Identity"
+  input: "sequential/quant_dense/MatMul/kquant/FakeQuantWithMinMaxVars/ReadVariableOp_1/resource"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense/MatMul/kquant/FakeQuantWithMinMaxVars"
+  op: "FakeQuantWithMinMaxVars"
+  input: "sequential/quant_dense/MatMul/ReadVariableOp"
+  input: "sequential/quant_dense/MatMul/kquant/FakeQuantWithMinMaxVars/ReadVariableOp"
+  input: "sequential/quant_dense/MatMul/kquant/FakeQuantWithMinMaxVars/ReadVariableOp_1"
+  attr {
+    key: "narrow_range"
+    value {
+      b: false
+    }
+  }
+  attr {
+    key: "num_bits"
+    value {
+      i: 8
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense/MatMul/kquant/IdentityN"
+  op: "IdentityN"
+  input: "sequential/quant_dense/MatMul/kquant/FakeQuantWithMinMaxVars"
+  input: "sequential/quant_dense/MatMul/ReadVariableOp"
+  attr {
+    key: "T"
+    value {
+      list {
+        type: DT_FLOAT
+        type: DT_FLOAT
+      }
+    }
+  }
+  attr {
+    key: "_gradient_op_type"
+    value {
+      s: "CustomGradient-10455"
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense/MatMul"
+  op: "MatMul"
+  input: "quant_dense_input"
+  input: "sequential/quant_dense/MatMul/kquant/IdentityN"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "transpose_a"
+    value {
+      b: false
+    }
+  }
+  attr {
+    key: "transpose_b"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense/BiasAdd/ReadVariableOp/resource"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+          dim {
+            size: 16
+          }
+        }
+        tensor_content: "\000\000\000\000L\020\341=\355\223\242\276\000\000\000\000\000\000\000\000\223&<>\206\234d\276\000\000\000\000\323%\241\276\331\305\234>\004\341\216>\3545e\276\032\363O\276\257:u\276\313\223\r>\000\000\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense/BiasAdd/ReadVariableOp"
+  op: "Identity"
+  input: "sequential/quant_dense/BiasAdd/ReadVariableOp/resource"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense/BiasAdd"
+  op: "BiasAdd"
+  input: "sequential/quant_dense/MatMul"
+  input: "sequential/quant_dense/BiasAdd/ReadVariableOp"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "data_format"
+    value {
+      s: "NHWC"
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense/Relu"
+  op: "Relu"
+  input: "sequential/quant_dense/BiasAdd"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense/oquant/FakeQuantWithMinMaxVars/ReadVariableOp/resource"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: -0.0019266719464212656
+      }
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense/oquant/FakeQuantWithMinMaxVars/ReadVariableOp"
+  op: "Identity"
+  input: "sequential/quant_dense/oquant/FakeQuantWithMinMaxVars/ReadVariableOp/resource"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense/oquant/FakeQuantWithMinMaxVars/ReadVariableOp_1/resource"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 3.249699354171753
+      }
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense/oquant/FakeQuantWithMinMaxVars/ReadVariableOp_1"
+  op: "Identity"
+  input: "sequential/quant_dense/oquant/FakeQuantWithMinMaxVars/ReadVariableOp_1/resource"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense/oquant/FakeQuantWithMinMaxVars"
+  op: "FakeQuantWithMinMaxVars"
+  input: "sequential/quant_dense/Relu"
+  input: "sequential/quant_dense/oquant/FakeQuantWithMinMaxVars/ReadVariableOp"
+  input: "sequential/quant_dense/oquant/FakeQuantWithMinMaxVars/ReadVariableOp_1"
+  attr {
+    key: "narrow_range"
+    value {
+      b: false
+    }
+  }
+  attr {
+    key: "num_bits"
+    value {
+      i: 8
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense/oquant/IdentityN"
+  op: "IdentityN"
+  input: "sequential/quant_dense/oquant/FakeQuantWithMinMaxVars"
+  input: "sequential/quant_dense/Relu"
+  attr {
+    key: "T"
+    value {
+      list {
+        type: DT_FLOAT
+        type: DT_FLOAT
+      }
+    }
+  }
+  attr {
+    key: "_gradient_op_type"
+    value {
+      s: "CustomGradient-10477"
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_1/iquant/FakeQuantWithMinMaxVars/ReadVariableOp/resource"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: -0.0019266719464212656
+      }
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_1/iquant/FakeQuantWithMinMaxVars/ReadVariableOp"
+  op: "Identity"
+  input: "sequential/quant_dense_1/iquant/FakeQuantWithMinMaxVars/ReadVariableOp/resource"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_1/iquant/FakeQuantWithMinMaxVars/ReadVariableOp_1/resource"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 3.1626083850860596
+      }
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_1/iquant/FakeQuantWithMinMaxVars/ReadVariableOp_1"
+  op: "Identity"
+  input: "sequential/quant_dense_1/iquant/FakeQuantWithMinMaxVars/ReadVariableOp_1/resource"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_1/iquant/FakeQuantWithMinMaxVars"
+  op: "FakeQuantWithMinMaxVars"
+  input: "sequential/quant_dense/oquant/IdentityN"
+  input: "sequential/quant_dense_1/iquant/FakeQuantWithMinMaxVars/ReadVariableOp"
+  input: "sequential/quant_dense_1/iquant/FakeQuantWithMinMaxVars/ReadVariableOp_1"
+  attr {
+    key: "narrow_range"
+    value {
+      b: false
+    }
+  }
+  attr {
+    key: "num_bits"
+    value {
+      i: 8
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_1/iquant/IdentityN"
+  op: "IdentityN"
+  input: "sequential/quant_dense_1/iquant/FakeQuantWithMinMaxVars"
+  input: "sequential/quant_dense/oquant/IdentityN"
+  attr {
+    key: "T"
+    value {
+      list {
+        type: DT_FLOAT
+        type: DT_FLOAT
+      }
+    }
+  }
+  attr {
+    key: "_gradient_op_type"
+    value {
+      s: "CustomGradient-10494"
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_1/MatMul/ReadVariableOp/resource"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+          dim {
+            size: 16
+          }
+          dim {
+            size: 16
+          }
+        }
+        tensor_content: "\356x\007<\273\351H\275\2506\242\275\261t\332>\"O\'>m\"\010\276(\311b\275\301\233\262=d\327\031\275V\030`>1U\212\276\325\353,=\321\375+=\305\016-=IQC\276\272N\255\276\342\\\241=\253K\230>\221\247\220\274\026[\220=\301W9\276\3041\311>\200\013\255\276@\331\307>\250\246\320=e\305A\276\312\211\200>\252\220x\276?\306\305>jC\221>_h\304>\350\2701>\213&\014\277\327a\251>\010\321\365=\022\346\357>_P\326>\024@\260\276\010\002\203\275%\013;\276\300\270s\2762~\206\2769\341\356<;\364\023\276\'=\225\276\347\327\247\275\037\317\326\276\2379\243>\241+\306\276\252\226\007\276\232\273\010= \001s>h.\010=x\rK=\231\255\315\276\001\244>>_\227\304\276\030\255\255\276\t\013\014>\263\031i\276\312\312\204>\262\331\244=\367\331R\276\020h\005>\361\260\322<n\273\274>a?\323>\t\236\304\275\240\215\240\275Y\034V>\200\236=<\232\336Y\276\274_\263\276\240\004\334\276\232\003\252>\264\243\273>\254Q\201>_\271\263\276a1\305>\237?\331>\244\031\275>\365K\351\276\212\302\234>\276{\217\275{\211{\276.\016\271\276\337\344\255\276\230\2347\2757O(>puO=\024\177\207\276v:\255>%.\230>\237\211\341=\327\316\037\274\302\205I>\020\234\201\276\027\356(\276J\320*\277\014\226\240=\222\312\323\276J\235\253=\263\201\221>\030\220\027\276\375g\"\277\227E\326\276\206\267{>\253\271\374\276!\235\203>\264\215\342=g\235\267\2767\211\306>x\323i>\244TJ>\306\216]\275\310\230\004\276\340\000B\274\351\324a>$[\266=\267\220\256\275\241n >\003s\235>\340\251\225\276\335jX=N\"@\276N;\271\276Sl6=\234S\007>~\345\025\277\013\020\362\275\377\333 \276@\227\325=\177\375\215=\335\357\332=t\217\027\276D\337\326=}\211\363\276\227\"\322>r\245\267=]\007x=4\372e>\252\235\373\276\030\276\221\275\2763\000\276\202\007\301>H\037Y>\307;\006?QT\241=NY\\<\014\254@>P\031\217<l\023\340>\010\327+\276\212\240\305\276\371x7>$\350\037?I\332\262\276\361\307\031\276\275o\206>\355\217\016\276 \036\007>yQ\221=\372\204\207>#\301\214>\344\376\302\275y\024\261\2768\304+\276\260\n \276(\026\254>\300*\034=j\2142=[\023\233>\301\370\304\2766<0=\321\025\237>\264C\220\2765\301\330\276\274\027\252\276\n\331U\276\355\363\302>\214i\305\276\367`\273>\244\352\241\276c\030C\276u\033\251\275r\314\036>\033\352h\275\361\372\374\276\370\356\242\274O\305\030\277\360\264\221>\244 \'\276\223j\006>\334\320E>\274\223\031\277\275\210\326>\330\301o=9\273>>\324\003\314\275\234\204\215\276\321\253|\276\313v\275\276d\256\270>r,\013\27765J=\313s\'\276\035\363{\276\"3\251\275\007\267d<\266\261\256\2766\205g\276~\275\331>\272\317\242>\237\305\034>\312\1770\2769\356\024\277\255|Y\276\374V\271=\320b\177\276\014\023\345\2766\353\226\273\333\033\373\275.[\264\276\tx@\276Dx\273>Q\327\233>\246\265\353>\021\214\315\276\000K\356\272d\207\037\276\331Z\321\276\\>\001?\202\343\031?\000>^\2727\375V\276\266\006[=\367\377\313>;vB\275F\212\022?D\253\246\276\314\207\210>\255\222\211\276\230V\223\273z,\316\276\325D\206\276CR\260> \260-\275\273-*\276i\032d>\266\316\003>\300\322\205\276\232\205\322\276\036\267\205>\372Y\342=r\221k\276(\003k>"
+      }
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_1/MatMul/ReadVariableOp"
+  op: "Identity"
+  input: "sequential/quant_dense_1/MatMul/ReadVariableOp/resource"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_1/MatMul/kquant/FakeQuantWithMinMaxVars/ReadVariableOp/resource"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: -0.6485296487808228
+      }
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_1/MatMul/kquant/FakeQuantWithMinMaxVars/ReadVariableOp"
+  op: "Identity"
+  input: "sequential/quant_dense_1/MatMul/kquant/FakeQuantWithMinMaxVars/ReadVariableOp/resource"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_1/MatMul/kquant/FakeQuantWithMinMaxVars/ReadVariableOp_1/resource"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.6135242581367493
+      }
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_1/MatMul/kquant/FakeQuantWithMinMaxVars/ReadVariableOp_1"
+  op: "Identity"
+  input: "sequential/quant_dense_1/MatMul/kquant/FakeQuantWithMinMaxVars/ReadVariableOp_1/resource"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_1/MatMul/kquant/FakeQuantWithMinMaxVars"
+  op: "FakeQuantWithMinMaxVars"
+  input: "sequential/quant_dense_1/MatMul/ReadVariableOp"
+  input: "sequential/quant_dense_1/MatMul/kquant/FakeQuantWithMinMaxVars/ReadVariableOp"
+  input: "sequential/quant_dense_1/MatMul/kquant/FakeQuantWithMinMaxVars/ReadVariableOp_1"
+  attr {
+    key: "narrow_range"
+    value {
+      b: false
+    }
+  }
+  attr {
+    key: "num_bits"
+    value {
+      i: 8
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_1/MatMul/kquant/IdentityN"
+  op: "IdentityN"
+  input: "sequential/quant_dense_1/MatMul/kquant/FakeQuantWithMinMaxVars"
+  input: "sequential/quant_dense_1/MatMul/ReadVariableOp"
+  attr {
+    key: "T"
+    value {
+      list {
+        type: DT_FLOAT
+        type: DT_FLOAT
+      }
+    }
+  }
+  attr {
+    key: "_gradient_op_type"
+    value {
+      s: "CustomGradient-10513"
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_1/MatMul"
+  op: "MatMul"
+  input: "sequential/quant_dense_1/iquant/IdentityN"
+  input: "sequential/quant_dense_1/MatMul/kquant/IdentityN"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "transpose_a"
+    value {
+      b: false
+    }
+  }
+  attr {
+    key: "transpose_b"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_1/BiasAdd/ReadVariableOp/resource"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+          dim {
+            size: 16
+          }
+        }
+        tensor_content: "Y\226;>\002#==\315\253\207>\032t\021\276\2510O\273\354\026\001\276\000\000\000\000\227\021M>\275D\213>\000\000\000\000\231\354)\276]@\237>\026\327E=p\007\003>\007\340c>\\\241\336\275"
+      }
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_1/BiasAdd/ReadVariableOp"
+  op: "Identity"
+  input: "sequential/quant_dense_1/BiasAdd/ReadVariableOp/resource"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_1/BiasAdd"
+  op: "BiasAdd"
+  input: "sequential/quant_dense_1/MatMul"
+  input: "sequential/quant_dense_1/BiasAdd/ReadVariableOp"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "data_format"
+    value {
+      s: "NHWC"
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_1/Relu"
+  op: "Relu"
+  input: "sequential/quant_dense_1/BiasAdd"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_1/oquant/FakeQuantWithMinMaxVars/ReadVariableOp/resource"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: -0.0019266719464212656
+      }
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_1/oquant/FakeQuantWithMinMaxVars/ReadVariableOp"
+  op: "Identity"
+  input: "sequential/quant_dense_1/oquant/FakeQuantWithMinMaxVars/ReadVariableOp/resource"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_1/oquant/FakeQuantWithMinMaxVars/ReadVariableOp_1/resource"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 2.7181646823883057
+      }
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_1/oquant/FakeQuantWithMinMaxVars/ReadVariableOp_1"
+  op: "Identity"
+  input: "sequential/quant_dense_1/oquant/FakeQuantWithMinMaxVars/ReadVariableOp_1/resource"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_1/oquant/FakeQuantWithMinMaxVars"
+  op: "FakeQuantWithMinMaxVars"
+  input: "sequential/quant_dense_1/Relu"
+  input: "sequential/quant_dense_1/oquant/FakeQuantWithMinMaxVars/ReadVariableOp"
+  input: "sequential/quant_dense_1/oquant/FakeQuantWithMinMaxVars/ReadVariableOp_1"
+  attr {
+    key: "narrow_range"
+    value {
+      b: false
+    }
+  }
+  attr {
+    key: "num_bits"
+    value {
+      i: 8
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_1/oquant/IdentityN"
+  op: "IdentityN"
+  input: "sequential/quant_dense_1/oquant/FakeQuantWithMinMaxVars"
+  input: "sequential/quant_dense_1/Relu"
+  attr {
+    key: "T"
+    value {
+      list {
+        type: DT_FLOAT
+        type: DT_FLOAT
+      }
+    }
+  }
+  attr {
+    key: "_gradient_op_type"
+    value {
+      s: "CustomGradient-10535"
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_2/MatMul/ReadVariableOp/resource"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+          dim {
+            size: 16
+          }
+          dim {
+            size: 1
+          }
+        }
+        tensor_content: "\217\017J?$\023*>\352\265\272\276\304|;\276\2178\277=\275\031\026\277J\017\304\276Iu!?h]\314\276A7;\276\204\221\031\275\323\2259\277\341K\304>Uzs?@)\337>\"\300n\276"
+      }
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_2/MatMul/ReadVariableOp"
+  op: "Identity"
+  input: "sequential/quant_dense_2/MatMul/ReadVariableOp/resource"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_2/MatMul/kquant/FakeQuantWithMinMaxVars/ReadVariableOp/resource"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: -0.7017847895622253
+      }
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_2/MatMul/kquant/FakeQuantWithMinMaxVars/ReadVariableOp"
+  op: "Identity"
+  input: "sequential/quant_dense_2/MatMul/kquant/FakeQuantWithMinMaxVars/ReadVariableOp/resource"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_2/MatMul/kquant/FakeQuantWithMinMaxVars/ReadVariableOp_1/resource"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.9041997790336609
+      }
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_2/MatMul/kquant/FakeQuantWithMinMaxVars/ReadVariableOp_1"
+  op: "Identity"
+  input: "sequential/quant_dense_2/MatMul/kquant/FakeQuantWithMinMaxVars/ReadVariableOp_1/resource"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_2/MatMul/kquant/FakeQuantWithMinMaxVars"
+  op: "FakeQuantWithMinMaxVars"
+  input: "sequential/quant_dense_2/MatMul/ReadVariableOp"
+  input: "sequential/quant_dense_2/MatMul/kquant/FakeQuantWithMinMaxVars/ReadVariableOp"
+  input: "sequential/quant_dense_2/MatMul/kquant/FakeQuantWithMinMaxVars/ReadVariableOp_1"
+  attr {
+    key: "narrow_range"
+    value {
+      b: false
+    }
+  }
+  attr {
+    key: "num_bits"
+    value {
+      i: 8
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_2/MatMul/kquant/IdentityN"
+  op: "IdentityN"
+  input: "sequential/quant_dense_2/MatMul/kquant/FakeQuantWithMinMaxVars"
+  input: "sequential/quant_dense_2/MatMul/ReadVariableOp"
+  attr {
+    key: "T"
+    value {
+      list {
+        type: DT_FLOAT
+        type: DT_FLOAT
+      }
+    }
+  }
+  attr {
+    key: "_gradient_op_type"
+    value {
+      s: "CustomGradient-10554"
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_2/MatMul"
+  op: "MatMul"
+  input: "sequential/quant_dense_1/oquant/IdentityN"
+  input: "sequential/quant_dense_2/MatMul/kquant/IdentityN"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "transpose_a"
+    value {
+      b: false
+    }
+  }
+  attr {
+    key: "transpose_b"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_2/BiasAdd/ReadVariableOp/resource"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+          dim {
+            size: 1
+          }
+        }
+        float_val: 0.04556306451559067
+      }
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_2/BiasAdd/ReadVariableOp"
+  op: "Identity"
+  input: "sequential/quant_dense_2/BiasAdd/ReadVariableOp/resource"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_2/BiasAdd"
+  op: "BiasAdd"
+  input: "sequential/quant_dense_2/MatMul"
+  input: "sequential/quant_dense_2/BiasAdd/ReadVariableOp"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "data_format"
+    value {
+      s: "NHWC"
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_2/oquant/FakeQuantWithMinMaxVars/ReadVariableOp/resource"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: -0.8735198974609375
+      }
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_2/oquant/FakeQuantWithMinMaxVars/ReadVariableOp"
+  op: "Identity"
+  input: "sequential/quant_dense_2/oquant/FakeQuantWithMinMaxVars/ReadVariableOp/resource"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_2/oquant/FakeQuantWithMinMaxVars/ReadVariableOp_1/resource"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 1.0447778701782227
+      }
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_2/oquant/FakeQuantWithMinMaxVars/ReadVariableOp_1"
+  op: "Identity"
+  input: "sequential/quant_dense_2/oquant/FakeQuantWithMinMaxVars/ReadVariableOp_1/resource"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_2/oquant/FakeQuantWithMinMaxVars"
+  op: "FakeQuantWithMinMaxVars"
+  input: "sequential/quant_dense_2/BiasAdd"
+  input: "sequential/quant_dense_2/oquant/FakeQuantWithMinMaxVars/ReadVariableOp"
+  input: "sequential/quant_dense_2/oquant/FakeQuantWithMinMaxVars/ReadVariableOp_1"
+  attr {
+    key: "narrow_range"
+    value {
+      b: false
+    }
+  }
+  attr {
+    key: "num_bits"
+    value {
+      i: 8
+    }
+  }
+}
+node {
+  name: "sequential/quant_dense_2/oquant/IdentityN"
+  op: "IdentityN"
+  input: "sequential/quant_dense_2/oquant/FakeQuantWithMinMaxVars"
+  input: "sequential/quant_dense_2/BiasAdd"
+  attr {
+    key: "T"
+    value {
+      list {
+        type: DT_FLOAT
+        type: DT_FLOAT
+      }
+    }
+  }
+  attr {
+    key: "_gradient_op_type"
+    value {
+      s: "CustomGradient-10575"
+    }
+  }
+}
+node {
+  name: "sequential/output/FakeQuantWithMinMaxArgs"
+  op: "FakeQuantWithMinMaxArgs"
+  input: "sequential/quant_dense_2/oquant/IdentityN"
+  attr {
+    key: "max"
+    value {
+      f: 0.9921875
+    }
+  }
+  attr {
+    key: "min"
+    value {
+      f: -1.0
+    }
+  }
+  attr {
+    key: "narrow_range"
+    value {
+      b: false
+    }
+  }
+  attr {
+    key: "num_bits"
+    value {
+      i: 8
+    }
+  }
+}
+node {
+  name: "Identity"
+  op: "Identity"
+  input: "sequential/output/FakeQuantWithMinMaxArgs"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+versions {
+  producer: 175
+}
+
+# CHECK: {{.*: warning:}} loc(fused["sequential/quant_dense/oquant/FakeQuantWithMinMaxVars"{{.*\): }}quantizer's output has another quantizer
+# CHECK-NEXT: {{.*: warning:}} loc(fused["sequential/quant_dense_2/oquant/FakeQuantWithMinMaxVars"{{.*\): }}quantizer's output has another quantizer
+
+# RESULT1: name: "Identity"
+# RESULT1-NEXT: quantization:
+# RESULT1-NEXT: scale: [ 0.007523 ],
+# RESULT1-NEXT: zero_point: [ 116 ]
+
+# TODO  Actually RESULT1 represents in incomplete implementation answer.  Currently all but the first fake_quant in 
+# sequence are dropped.  A correct transalation would retain the second as a requantization
+# op.
+
+# CORRECT1:name: "Identity"
+# CORRECT1-NEXT: quantization:
+# CORRECT1-NEXT: scale: [ 0.007813 ],
+# CORRECT1-NEXT: zero_point: [ 128 ]
+

--- a/tensorflow/compiler/mlir/lite/tests/end2end/back2back_fake_quant.pbtxt
+++ b/tensorflow/compiler/mlir/lite/tests/end2end/back2back_fake_quant.pbtxt
@@ -1174,7 +1174,8 @@ versions {
 # RESULT1-NEXT: scale: [ 0.007523 ],
 # RESULT1-NEXT: zero_point: [ 116 ]
 
-# TODO  Actually RESULT1 represents in incomplete implementation answer.  Currently all but the first fake_quant in 
+# TODO  Actually RESULT1 represents in incomplete implementation
+# Currently TF2.2.0-rc3 all but the first fake_quant in 
 # sequence are dropped.  A correct transalation would retain the second as a requantization
 # op.
 

--- a/tensorflow/compiler/mlir/lite/tf_tfl_translate.cc
+++ b/tensorflow/compiler/mlir/lite/tf_tfl_translate.cc
@@ -126,6 +126,7 @@ int main(int argc, char **argv) {
   // We need to disable duplicated ones to provide a cleaner command-line option
   // interface. That also means we need to relay the value set in one option to
   // all its aliases.
+  mlir::registerPassManagerCLOptions();
   llvm::cl::ParseCommandLineOptions(
       argc, argv, "TF GraphDef to TFLite FlatBuffer converter\n");
 
@@ -157,6 +158,8 @@ int main(int argc, char **argv) {
   if (!module.ok()) return kTrFailure;
 
   mlir::PassManager pm(&context);
+
+  mlir::applyPassManagerCLOptions(pm);
 
   // Set the quantization specifications from the command line flags.
   mlir::TFL::QuantizationSpecs quant_specs;

--- a/tensorflow/compiler/mlir/lite/transforms/optimize.cc
+++ b/tensorflow/compiler/mlir/lite/transforms/optimize.cc
@@ -193,6 +193,15 @@ DenseElementsAttr GetShape(Value output_val) {
       llvm::makeArrayRef(shape));
 }
 
+bool notFromQuantOpDifferentQuanteUse( Value val, TypeAttr qtype) {
+  auto val_defn_op = val.getDefiningOp();
+  TFL::QuantizeOp q_op = llvm::dyn_cast_or_null<TFL::QuantizeOp>(val_defn_op);
+  if( !q_op)
+    return true;
+
+  return q_op.qtype() == qtype.getValue();
+}
+
 #include "tensorflow/compiler/mlir/lite/transforms/generated_optimize.inc"
 
 // Fuse Add with proceeding FullyConnected.

--- a/tensorflow/compiler/mlir/lite/transforms/optimize_patterns.td
+++ b/tensorflow/compiler/mlir/lite/transforms/optimize_patterns.td
@@ -29,6 +29,11 @@ def ExtractSingleElementAsFloat : NativeCodeCall<
 // Checks if the value has only one user.
 def HasOneUse : Constraint<CPred<"$0.hasOneUse()">>;
 
+
+// Checks value is not produce by a TLF_QUant with
+// different quantization attribute
+
+def NotFromQuantOpDifferentQuant : Constraint<CPred<"notFromQuantOpDifferentQuanteUse($0,$1)">>;
 //===----------------------------------------------------------------------===//
 // Ternary ops patterns.
 //===----------------------------------------------------------------------===//
@@ -160,7 +165,7 @@ foreach BinaryOp = [TFL_DivOp, TFL_MulOp] in
 // This pattern applies when the same quantize/dequantize have been used twice
 // with the same scale. We want to remove the redundancy.
 // TODO(fengliuai): move this to the sanity check of pre-quantize pass.
-def : Pat<(TFL_QuantizeOp (TFL_DequantizeOp $in), $qt), (replaceWithValue $in)>;
+def eliminate_dq_q_pairs : Pat<(TFL_QuantizeOp (TFL_DequantizeOp $in), $qt), (replaceWithValue $in), [(NotFromQuantOpDifferentQuant $in, $qt)]>;
 
 
 // Constraint that makes sure both operands are the same operands.

--- a/tensorflow/compiler/mlir/lite/transforms/prepare_quantize.cc
+++ b/tensorflow/compiler/mlir/lite/transforms/prepare_quantize.cc
@@ -263,15 +263,17 @@ void PrepareQuantizePass::SanityCheckAndAdjustment(FuncOp func) {
     }
 
     // Invariant: 
-    // isa<quant::QuantizeCastOp>(dq_arg.getDefiningOp()) &&
+    // isa<quant::QuantizeCastOp>(dq_arg.getDefiningOp()) -->
     // getdq_arg.getType() != q_op.getResult().getType() 
     //
     // as otherwise qdq pair would have been optimized away.
 
     auto qd_arg_def_q_op = 
       dyn_cast_or_null<quant::QuantizeCastOp>(dq_arg.getDefiningOp());
-    assert(qd_arg_def_q_op);
-    
+    if(!qd_arg_def_q_op) {
+      return;
+    }
+
     qd_arg_def_q_op.emitWarning() << " quantizer's output has another quantizer ("
         << q_op.getLoc()
         << ") as consumer - intentional?";

--- a/tensorflow/compiler/mlir/lite/transforms/prepare_quantize.cc
+++ b/tensorflow/compiler/mlir/lite/transforms/prepare_quantize.cc
@@ -204,6 +204,7 @@ void PrepareQuantizePass::SanityCheckAndAdjustment(FuncOp func) {
   // one is returned directly, we decide to return the quantized result instead,
   // so this op can be quantized. This is only applied on the returned result
   // because the error will not be accumulated.
+
   func.walk([&](ReturnOp ret) {
     int i = 0;
     for (Value returned : ret.operands()) {
@@ -225,11 +226,55 @@ void PrepareQuantizePass::SanityCheckAndAdjustment(FuncOp func) {
   func.walk([&](ConcatenationOp concat) {
     if (concat.output().hasOneUse() &&
         Quantized(*concat.output().user_begin())) {
-      return;
+        return;
     }
     concat.emitWarning(
-        "Missing quantization parameter on the output might introduce "
-        "quantization error!");
+            "Missing quantization parameter on the output might introduce "
+            "quantization error!");
+  });
+
+  // Check for  (Quant (Dequant $in), $qA) "qdq" pairs that couldn't be eliminated at this
+  // point.  This only occurs for the pattern 
+  //      (Quant (Dequant (Quant $in, $qB)), $qA)   $qB != $qA
+  // where the  qdq pair denotes a non-trivial requantiziion of an alreadyquantized value.
+  // Since this makes little sense (directly quantizing (Quant $in, $qA) would introduce
+  // less quantization noise) the likley cause is an minor error in constructing
+  // the original network model that introduced back-to-back Fake Quantization operations.
+  // Hence: emit a warning.
+  // N.b. at this point weŕe (teporarility) in the quantization dialect (presuambly
+  // enalbe re-use in xla etc) quant::*QuantizeCastOp weŕe matching here.
+  //
+  func.walk([&](quant::QuantizeCastOp q_op) {
+
+    // If up with end up with
+    auto dq_op = 
+      dyn_cast_or_null<quant::DequantizeCastOp>(q_op.getOperand().getDefiningOp());
+    if (!dq_op) {
+      return;
+    }
+    auto dq_arg = dq_op.getOperand();
+
+    if (!dq_arg.hasOneUse()  ) {
+      // The initial quanization is used sompleace else ... so it might be
+      // reasonable for it to requantized for another purpose.
+      // TODO: ideally would want to still check whether requanization narrows 
+      // rather than widens the representation
+      return;
+    }
+
+    // Invariant: 
+    // isa<quant::QuantizeCastOp>(dq_arg.getDefiningOp()) &&
+    // getdq_arg.getType() != q_op.getResult().getType() 
+    //
+    // as otherwise qdq pair would have been optimized away.
+
+    auto qd_arg_def_q_op = 
+      dyn_cast_or_null<quant::QuantizeCastOp>(dq_arg.getDefiningOp());
+    assert(qd_arg_def_q_op);
+    
+    qd_arg_def_q_op.emitWarning() << " quantizer's output has another quantizer ("
+        << q_op.getLoc()
+        << ") as consumer - intentional?";
   });
 }
 


### PR DESCRIPTION
Improvements to QAT support in TFLite conversion.

- Adds a warning if redundant back-to-back fake quantization ops are detected + associated imrpovements - typically as sign of an error in construction of a quantization-aware-traininable model construction is detect. 

- mlir::TFL::Optimize: suppress premature elimination of Dequant ; Quant pairs that are not no-ops (i.e. applied to value of differing quantization).

- Handling of FakeQuantWithMinMaxArgsOp in mlir::TFL::PrepareTFPass is now consistent with that of constant min/max input FakeQuantWithMinMaxVarsPerChannelOp and FakeQuantWithMinMaxVarsOp.

- tf_tfl_translate test application enhanced  to expose command-line options controlling MLIR::PassManager logging.

Implementation follows guidance by Feng Liu <fengliuai@google.com>.