### PR TITLE
use float math calls, add tanh operation, and update abs op to use fabsf

### DIFF
--- a/tensorflow/lite/micro/kernels/elementwise.cc
+++ b/tensorflow/lite/micro/kernels/elementwise.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include <cmath>
+#include <math.h>
 
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
@@ -75,27 +75,31 @@ inline TfLiteStatus EvalLogical(TfLiteContext* context, TfLiteNode* node,
 }
 
 TfLiteStatus AbsEval(TfLiteContext* context, TfLiteNode* node) {
-  return EvalNumeric(context, node, std::abs);
+  return EvalNumeric(context, node, fabsf);
 }
 
 TfLiteStatus SinEval(TfLiteContext* context, TfLiteNode* node) {
-  return EvalNumeric(context, node, std::sin);
+  return EvalNumeric(context, node, sinf);
+}
+
+TfLiteStatus TanhEval(TfLiteContext* context, TfLiteNode* node) {
+  return EvalNumeric(context, node, tanhf);
 }
 
 TfLiteStatus CosEval(TfLiteContext* context, TfLiteNode* node) {
-  return EvalNumeric(context, node, std::cos);
+  return EvalNumeric(context, node, cosf);
 }
 
 TfLiteStatus LogEval(TfLiteContext* context, TfLiteNode* node) {
-  return EvalNumeric(context, node, std::log);
+  return EvalNumeric(context, node, logf);
 }
 
 TfLiteStatus SqrtEval(TfLiteContext* context, TfLiteNode* node) {
-  return EvalNumeric(context, node, std::sqrt);
+  return EvalNumeric(context, node, sqrtf);
 }
 
 TfLiteStatus RsqrtEval(TfLiteContext* context, TfLiteNode* node) {
-  return EvalNumeric(context, node, [](float f) { return 1.f / std::sqrt(f); });
+  return EvalNumeric(context, node, [](float f) { return 1.f / sqrtf(f); });
 }
 
 TfLiteStatus SquareEval(TfLiteContext* context, TfLiteNode* node) {
@@ -131,6 +135,20 @@ TfLiteRegistration* Register_SIN() {
       /*prepare=*/
       elementwise::GenericPrepare<elementwise::IsNumericSupportedType>,
       /*invoke=*/elementwise::SinEval,
+      /*profiling_string=*/nullptr,
+      /*builtin_code=*/0,
+      /*custom_name=*/nullptr,
+      /*version=*/0};
+  return &r;
+}
+
+TfLiteRegistration* Register_TANH() {
+  static TfLiteRegistration r = {
+      /*init=*/nullptr,
+      /*free=*/nullptr,
+      /*prepare=*/
+      elementwise::GenericPrepare<elementwise::IsNumericSupportedType>,
+      /*invoke=*/elementwise::TanhEval,
       /*profiling_string=*/nullptr,
       /*builtin_code=*/0,
       /*custom_name=*/nullptr,

--- a/tensorflow/lite/micro/kernels/elementwise_test.cc
+++ b/tensorflow/lite/micro/kernels/elementwise_test.cc
@@ -188,6 +188,18 @@ TF_LITE_MICRO_TEST(Cos) {
       output_data);
 }
 
+TF_LITE_MICRO_TEST(Tanh) {
+  constexpr int output_dims_count = 4;
+  float output_data[output_dims_count];
+  tflite::testing::TestElementwiseFloat(
+      tflite::BuiltinOperator_TANH,   // TANH operator
+      {2, 2, 2},                      // Input shape
+      {0, 3.1415926, -3.1415926, 1},  // Input values
+      {2, 2, 2},                      // Output shape
+      {0, 0.99627, -0.99627, 0.76159},// Output values
+      output_data);
+}
+
 TF_LITE_MICRO_TEST(Log) {
   constexpr int output_dims_count = 4;
   float output_data[output_dims_count];

--- a/tensorflow/lite/micro/kernels/micro_ops.h
+++ b/tensorflow/lite/micro/kernels/micro_ops.h
@@ -79,6 +79,7 @@ TfLiteRegistration* Register_SQUARE();
 TfLiteRegistration* Register_STRIDED_SLICE();
 TfLiteRegistration* Register_SUB();
 TfLiteRegistration* Register_SVDF();
+TfLiteRegistration* Register_TANH();
 TfLiteRegistration* Register_UNPACK();
 TfLiteRegistration* Register_L2_NORMALIZATION();
 TfLiteRegistration* Register_TANH();

--- a/tensorflow/lite/micro/testing/micro_test.h
+++ b/tensorflow/lite/micro/testing/micro_test.h
@@ -54,6 +54,7 @@ limitations under the License.
 #ifndef TENSORFLOW_LITE_MICRO_TESTING_MICRO_TEST_H_
 #define TENSORFLOW_LITE_MICRO_TESTING_MICRO_TEST_H_
 
+#include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/micro/micro_error_reporter.h"
 
 namespace micro_test {
@@ -85,8 +86,10 @@ extern tflite::ErrorReporter* reporter;
       (micro_test::tests_failed + micro_test::tests_passed));  \
   if (micro_test::tests_failed == 0) {                         \
     micro_test::reporter->Report("~~~ALL TESTS PASSED~~~\n");  \
+    return kTfLiteOk;                                          \
   } else {                                                     \
     micro_test::reporter->Report("~~~SOME TESTS FAILED~~~\n"); \
+    return kTfLiteError;                                       \
   }                                                            \
   }
 


### PR DESCRIPTION
Updates to element-wise floating point math ops, as discussed here: https://github.com/tensorflow/tensorflow/issues/39020

Updated implementation to call float-valued math.h functions instead of double-valued, e.g. `float logf(float x)` instead of `double log(double x)`.

Changed AbsEval to reference `fabsf` instead of `std::abs`, which is integer-valued.

Changing `#include <cmath>` to `#include <math.h>` and removing `std` namespace prefix is required due to an issue with the gcc `cmath` header file (see e.g. [this discussion](https://stackoverflow.com/questions/55458487/stdexpf-and-stdlogf-not-recognized-by-gcc-7-2-0)).

This PR also adds the tanh operator, with a trivial math.h implementation.