### PR TITLE
Fix build failures for python 3.8

### DIFF
--- a/tensorflow/compiler/xla/python/bfloat16.cc
+++ b/tensorflow/compiler/xla/python/bfloat16.cc
@@ -343,7 +343,7 @@ PyTypeObject PyBfloat16_Type = {
     sizeof(PyBfloat16),    // tp_basicsize
     0,                     // tp_itemsize
     nullptr,               // tp_dealloc
-    0,                     // tp_print  NOLINT
+    0,                     // tp_vectorcall_offset  NOLINT
     nullptr,               // tp_getattr
     nullptr,               // tp_setattr
     nullptr,               // tp_compare / tp_reserved

--- a/tensorflow/python/eager/pywrap_tensor.cc
+++ b/tensorflow/python/eager/pywrap_tensor.cc
@@ -762,7 +762,7 @@ static PyTypeObject _EagerTensorType = {
     sizeof(EagerTensor),                /* tp_basicsize */
     0,                                  /* tp_itemsize */
     (destructor)EagerTensor_dealloc,    /* tp_dealloc */
-    nullptr,                            /* tp_print */
+    0,                                  /* tp_vectorcall_offset */
     nullptr,                            /* tp_getattr */
     nullptr,                            /* tp_setattr */
     nullptr,                            /* tp_compare */

--- a/tensorflow/python/eager/pywrap_tfe_src.cc
+++ b/tensorflow/python/eager/pywrap_tfe_src.cc
@@ -1504,7 +1504,7 @@ static PyTypeObject TFE_Py_Tape_Type = {
     sizeof(TFE_Py_Tape),                          /* tp_basicsize */
     0,                                            /* tp_itemsize */
     &TFE_Py_Tape_Delete,                          /* tp_dealloc */
-    nullptr,                                      /* tp_print */
+    0,                                            /* tp_vectorcall_offset */
     nullptr,                                      /* tp_getattr */
     nullptr,                                      /* tp_setattr */
     nullptr,                                      /* tp_reserved */
@@ -1542,7 +1542,7 @@ static PyTypeObject TFE_Py_ForwardAccumulator_Type = {
     sizeof(TFE_Py_ForwardAccumulator),                      /* tp_basicsize */
     0,                                                      /* tp_itemsize */
     &TFE_Py_ForwardAccumulatorDelete,                       /* tp_dealloc */
-    nullptr,                                                /* tp_print */
+    0,                                                      /* tp_vectorcall_offset */
     nullptr,                                                /* tp_getattr */
     nullptr,                                                /* tp_setattr */
     nullptr,                                                /* tp_reserved */
@@ -1577,7 +1577,7 @@ static PyTypeObject TFE_Py_VariableWatcher_Type = {
     sizeof(TFE_Py_VariableWatcher),                          /* tp_basicsize */
     0,                                                       /* tp_itemsize */
     &TFE_Py_VariableWatcher_Delete,                          /* tp_dealloc */
-    nullptr,                                                 /* tp_print */
+    0,                                                       /* tp_vectorcall_offset */
     nullptr,                                                 /* tp_getattr */
     nullptr,                                                 /* tp_setattr */
     nullptr,                                                 /* tp_reserved */

--- a/tensorflow/python/lib/core/bfloat16.cc
+++ b/tensorflow/python/lib/core/bfloat16.cc
@@ -317,7 +317,7 @@ PyTypeObject PyBfloat16_Type = {
     sizeof(PyBfloat16),                        // tp_basicsize
     0,                                         // tp_itemsize
     nullptr,                                   // tp_dealloc
-    0,                                         // tp_print
+    0,                                         // tp_vectorcall_offset
     nullptr,                                   // tp_getattr
     nullptr,                                   // tp_setattr
     nullptr,                                   // tp_compare / tp_reserved


### PR DESCRIPTION
According to https://bugzilla.redhat.com/show_bug.cgi?id=1718837:

> In Python 3.8, the reserved "tp_print" slot was changed from a function pointer to a number, `Py_ssize_t tp_vectorcall_offset`.

This fix our nightly Python 3.8 builds. 

cc @mihaimaruseac 

