### PR TITLE
Fix regex for scope name specification

### DIFF
--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -1748,8 +1748,8 @@ def _NodeDef(op_type, name, attrs=None):
 
 # Copied from core/framework/node_def_util.cc
 # TODO(mrry,josh11b): Consolidate this validation in C++ code.
-_VALID_OP_NAME_REGEX = re.compile("^[A-Za-z0-9.][A-Za-z0-9_.\\-/>]*$")
-_VALID_SCOPE_NAME_REGEX = re.compile("^[A-Za-z0-9_.\\-/>]*$")
+_VALID_OP_NAME_REGEX = re.compile(r"^[A-Za-z0-9.][A-Za-z0-9_.\\/>-]*$")
+_VALID_SCOPE_NAME_REGEX = re.compile(r"^[A-Za-z0-9_.\\/>-]*$")
 
 
 def _create_c_op(graph, node_def, inputs, control_inputs, op_def=None):

--- a/tensorflow/python/framework/ops_test.py
+++ b/tensorflow/python/framework/ops_test.py
@@ -1308,15 +1308,15 @@ class NameStackTest(test_util.TensorFlowTestCase):
     self.assertEqual("bar_2", g.unique_name("bar", mark_as_used=False))
     self.assertEqual("bar_2", g.unique_name("bar"))
 
-  def testBackslashRegex(self):
+  def testBackslashAndDashRegex(self):
     # GitHub issue 39019, all should pass
     g = ops.Graph()
-    with g.name_scope("n_CatCntc_campaign\c_campaign"):
+    with g.name_scope("n_CatCntc-campaign\\c_campaign"):
       pass
     with g.name_scope("foo"):
-      with g.name_scope("n_CatCntc_campaign\c_campaign"):
+      with g.name_scope("n_CatCntc-campaign\\c_campaign"):
         pass
-    with g.name_scope("n_CatCntc_campaign\c_campaign"):
+    with g.name_scope("n_CatCntc-campaign\\c_campaign"):
       with g.name_scope("foo"):
         pass
 

--- a/tensorflow/python/framework/ops_test.py
+++ b/tensorflow/python/framework/ops_test.py
@@ -1308,6 +1308,18 @@ class NameStackTest(test_util.TensorFlowTestCase):
     self.assertEqual("bar_2", g.unique_name("bar", mark_as_used=False))
     self.assertEqual("bar_2", g.unique_name("bar"))
 
+  def testBackslashRegex(self):
+    # GitHub issue 39019, all should pass
+    g = ops.Graph()
+    with g.name_scope("n_CatCntc_campaign\c_campaign"):
+      pass
+    with g.name_scope("foo"):
+      with g.name_scope("n_CatCntc_campaign\c_campaign"):
+        pass
+    with g.name_scope("n_CatCntc_campaign\c_campaign"):
+      with g.name_scope("foo"):
+        pass
+
   @test_util.run_deprecated_v1
   def testNameAndVariableScope(self):
     with self.cached_session() as sess:


### PR DESCRIPTION
This PR tries to address the issue raised in #39019 where
regex for scope name does not capture `\` symbol.
```
VALID_OP_NAME_REGEX = re.compile("^[A-Za-z0-9.][A-Za-z0-9_.\\-/>]*$")
_VALID_SCOPE_NAME_REGEX = re.compile("^[A-Za-z0-9_.\\-/>]*$")
```
The reason was:
1. `-` was placed in the middle and was incorrectly considered by python as a range.
2. `\\` was considered as escape by python, so only one `\` when `re` starts processing.

This PR moves `-` to the end, and prefix with `r` for the string:
```
VALID_OP_NAME_REGEX = re.compile(r"^[A-Za-z0-9.][A-Za-z0-9_.\\/>-]*$")
_VALID_SCOPE_NAME_REGEX = re.compile(r"^[A-Za-z0-9_.\\/>-]*$")
```

This PR fixes #39019.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>