### PR TITLE
[r1.15-CherryPick] Add __reduce__ method in virtual pip root due to lazy loading

### DIFF
--- a/tensorflow/virtual_root_template_v1.__init__.py
+++ b/tensorflow/virtual_root_template_v1.__init__.py
@@ -54,6 +54,9 @@ class _LazyLoader(_types.ModuleType):
     module = self._load()
     return dir(module)
 
+  def __reduce__(self):
+    return __import__, (self.__name__,)
+
 
 # Forwarding a module is as simple as lazy loading the module from the new path
 # and then registering it to sys.modules using the old path

--- a/tensorflow/virtual_root_template_v2.__init__.py
+++ b/tensorflow/virtual_root_template_v2.__init__.py
@@ -54,6 +54,9 @@ class _LazyLoader(_types.ModuleType):
     module = self._load()
     return dir(module)
 
+  def __reduce__(self):
+    return __import__, (self.__name__,)
+
 
 # Forwarding a module is as simple as lazy loading the module from the new path
 # and then registering it to sys.modules using the old path


### PR DESCRIPTION
Fixes pickling issue #32159

Tested manually: just applied patch to tensorflow nightly and checked required imports.

PiperOrigin-RevId: 276301497
Change-Id: I6b3b6ae8b1218b43c31403ea7cc595ed11136ff9
(cherry picked from commit 353b8a1adcb471a48ef9b1c5cbfc6097d036473e)

Intended for a possible future r1.15 patch.