### PR TITLE
Fixed recompute grad issue - no memory savings

### DIFF
--- a/tensorflow/python/eager/forwardprop_test.py
+++ b/tensorflow/python/eager/forwardprop_test.py
@@ -177,8 +177,7 @@ def _test_gradients(testcase,
                     order,
                     delta=1e-3,
                     rtol=1e-2,
-                    atol=1e-6,
-                    recompute=False):
+                    atol=1e-6):
   """Tests forward/backward jacobians of `f`'s [0, `order`)-order gradients."""
   if order < 1:
     raise ValueError(
@@ -191,21 +190,14 @@ def _test_gradients(testcase,
         order=order - 1,
         delta=delta,
         rtol=rtol,
-        atol=atol,
-        recompute=recompute)
+        atol=atol)
   sym_jac_back, num_jac = gradient_checker_v2.compute_gradient(
       f, primals, delta=delta)
   testcase.assertAllClose(num_jac, sym_jac_back, rtol=rtol, atol=atol)
-  if not recompute:
-    sym_jac_fwd = _jacfwd(f, primals)
-    testcase.assertAllClose(num_jac, sym_jac_fwd, rtol=rtol, atol=atol)
-    # And the symbolic computations should be much closer.
-    testcase.assertAllClose(sym_jac_back, sym_jac_fwd)
-  else:
-    with testcase.assertRaisesRegexp(ValueError,
-                                     "recompute_grad tried to transpose"):
-      sym_jac_fwd = _jacfwd(f, primals)
-
+  sym_jac_fwd = _jacfwd(f, primals)
+  testcase.assertAllClose(num_jac, sym_jac_fwd, rtol=rtol, atol=atol)
+  # And the symbolic computations should be much closer.
+  testcase.assertAllClose(sym_jac_back, sym_jac_fwd)
 
 class ForwardpropTest(test.TestCase, parameterized.TestCase):
 
@@ -364,10 +356,9 @@ class ForwardpropTest(test.TestCase, parameterized.TestCase):
     def f(x):
       return math_ops.reduce_prod(math_ops.tanh(x)**2)
 
-    _test_gradients(self,
-                    f, [constant_op.constant([1.])],
-                    order=3,
-                    recompute=True)
+    with self.assertRaisesRegexp(NotImplementedError,
+                                 "recompute_grad tried to transpose"):
+      _test_gradients(self, f, [constant_op.constant([1.])], order=3)
 
   def testExceptionInCustomGradientNotSwallowed(self):
 

--- a/tensorflow/python/eager/forwardprop_test.py
+++ b/tensorflow/python/eager/forwardprop_test.py
@@ -350,7 +350,7 @@ class ForwardpropTest(test.TestCase, parameterized.TestCase):
     _test_gradients(self, f, [constant_op.constant([1., 2.])], order=3)
 
   # TODO(allenl): investigate why assert_no_new_pyobjects_executing_eagerly fails around this test?
-  def testCustomGradientRecomputeGrad(self):
+  def testExceptionCustomGradientRecomputeGradForward(self):
 
     @custom_gradient.recompute_grad
     def f(x):
@@ -358,7 +358,8 @@ class ForwardpropTest(test.TestCase, parameterized.TestCase):
 
     with self.assertRaisesRegexp(NotImplementedError,
                                  "recompute_grad tried to transpose"):
-      _test_gradients(self, f, [constant_op.constant([1.])], order=3)
+      primals = [constant_op.constant([1.])]
+      sym_jac_fwd = _jacfwd(f, primals)
 
   def testExceptionInCustomGradientNotSwallowed(self):
 

--- a/tensorflow/python/eager/forwardprop_test.py
+++ b/tensorflow/python/eager/forwardprop_test.py
@@ -349,7 +349,7 @@ class ForwardpropTest(test.TestCase, parameterized.TestCase):
 
     _test_gradients(self, f, [constant_op.constant([1., 2.])], order=3)
 
-  @test_util.assert_no_new_pyobjects_executing_eagerly
+  # TODO(allenl): investigate why assert_no_new_pyobjects_executing_eagerly fails around this test?
   def testCustomGradientRecomputeGrad(self):
 
     @custom_gradient.recompute_grad

--- a/tensorflow/python/keras/integration_test/BUILD
+++ b/tensorflow/python/keras/integration_test/BUILD
@@ -1,7 +1,7 @@
 # Description:
 #   Contains Keras integration tests that verify with other TF high level APIs.
 
-load("//tensorflow:tensorflow.bzl", "tf_py_test", "cuda_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test", "tf_py_test")
 
 package(
     default_visibility = [

--- a/tensorflow/python/keras/integration_test/BUILD
+++ b/tensorflow/python/keras/integration_test/BUILD
@@ -1,8 +1,7 @@
 # Description:
 #   Contains Keras integration tests that verify with other TF high level APIs.
 
-load("//tensorflow:tensorflow.bzl", "tf_py_test")
-load("//tensorflow:tensorflow.bzl", "cuda_py_test")
+load("//tensorflow:tensorflow.bzl", "tf_py_test", "cuda_py_test")
 
 package(
     default_visibility = [

--- a/tensorflow/python/keras/integration_test/BUILD
+++ b/tensorflow/python/keras/integration_test/BUILD
@@ -2,6 +2,7 @@
 #   Contains Keras integration tests that verify with other TF high level APIs.
 
 load("//tensorflow:tensorflow.bzl", "tf_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 
 package(
     default_visibility = [
@@ -71,7 +72,7 @@ tf_py_test(
     ],
 )
 
-tf_py_test(
+cuda_py_test(
     name = "gradient_checkpoint_test",
     srcs = ["gradient_checkpoint_test.py"],
     python_version = "PY3",

--- a/tensorflow/python/keras/integration_test/BUILD
+++ b/tensorflow/python/keras/integration_test/BUILD
@@ -70,3 +70,13 @@ tf_py_test(
         "//tensorflow/python:extra_py_tests_deps",
     ],
 )
+
+tf_py_test(
+    name = "gradient_checkpoint_test",
+    srcs = ["gradient_checkpoint_test.py"],
+    python_version = "PY3",
+    deps = [
+        "//tensorflow:tensorflow_py",
+        "//tensorflow/python:extra_py_tests_deps",
+    ],
+)

--- a/tensorflow/python/keras/integration_test/gradient_checkpoint_test.py
+++ b/tensorflow/python/keras/integration_test/gradient_checkpoint_test.py
@@ -70,14 +70,11 @@ def _limit_gpu_memory():
   """Helper function to limit GPU memory for testing  """
   gpus = tf.config.experimental.list_physical_devices('GPU')
   if gpus:
-    try:
-      tf.config.experimental.set_virtual_device_configuration(
-          gpus[0], [
-              tf.config.experimental.VirtualDeviceConfiguration(
-                  memory_limit=1024)
-          ])
-    except RuntimeError as e:
-      print(e)
+    tf.config.experimental.set_virtual_device_configuration(
+        gpus[0], [
+            tf.config.experimental.VirtualDeviceConfiguration(
+                memory_limit=1024)
+        ])
     return True
   return False
 

--- a/tensorflow/python/keras/integration_test/gradient_checkpoint_test.py
+++ b/tensorflow/python/keras/integration_test/gradient_checkpoint_test.py
@@ -127,7 +127,8 @@ def _train_with_recompute(n_steps):
   model2_re = tf.recompute_grad(model2)
   model3_re = tf.recompute_grad(model3)
   optimizer = optimizers.SGD()
-  tr_vars = model1.trainable_variables + model2.trainable_variables + model3.trainable_variables
+  tr_vars = (model1.trainable_variables + model2.trainable_variables +
+             model3.trainable_variables)
   losses = []
   for _ in range(n_steps):
     with tf.GradientTape() as tape:

--- a/tensorflow/python/keras/integration_test/gradient_checkpoint_test.py
+++ b/tensorflow/python/keras/integration_test/gradient_checkpoint_test.py
@@ -17,7 +17,8 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow as tf
-from tensorflow.keras import layers, optimizers
+layers = tf.keras.layers
+optimizers = tf.keras.optimizers
 
 def _get_big_cnn_model(img_dim, n_channels, num_partitions,
                        blocks_per_partition):

--- a/tensorflow/python/keras/integration_test/gradient_checkpoint_test.py
+++ b/tensorflow/python/keras/integration_test/gradient_checkpoint_test.py
@@ -1,0 +1,160 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+from tensorflow.keras import layers, optimizers
+
+
+def _get_big_cnn_model(img_dim, n_channels, num_partitions,
+                       blocks_per_partition):
+  """Creates a test model whose activations are significantly larger than model size."""
+  model = tf.keras.Sequential()
+  model.add(layers.Input(shape=(img_dim, img_dim, n_channels)))
+  for _ in range(num_partitions):
+    for _ in range(blocks_per_partition):
+      model.add(layers.Conv2D(10, 5, padding='same', activation=tf.nn.relu))
+      model.add(layers.MaxPooling2D((1, 1), padding='same'))
+      model.add(layers.Conv2D(40, 5, padding='same', activation=tf.nn.relu))
+      model.add(layers.MaxPooling2D((1, 1), padding='same'))
+      model.add(layers.Conv2D(20, 5, padding='same', activation=tf.nn.relu))
+      model.add(layers.MaxPooling2D((1, 1), padding='same'))
+  model.add(layers.Flatten())
+  model.add(layers.Dense(32, activation=tf.nn.relu))
+  model.add(layers.Dense(10))
+  return model
+
+
+def _get_split_cnn_model(img_dim, n_channels, num_partitions,
+                         blocks_per_partition):
+  """Creates a test model that is split into `num_partitions` smaller models"""
+  models = [tf.keras.Sequential() for _ in range(num_partitions)]
+  models[0].add(layers.Input(shape=(img_dim, img_dim, n_channels)))
+  for i in range(num_partitions):
+    model = models[i]
+    if i > 0:
+      last_shape = models[i - 1].layers[-1].output_shape
+      model.add(layers.Input(shape=last_shape[1:]))
+    for _ in range(blocks_per_partition):
+      model.add(layers.Conv2D(10, 5, padding='same', activation=tf.nn.relu))
+      model.add(layers.MaxPooling2D((1, 1), padding='same'))
+      model.add(layers.Conv2D(40, 5, padding='same', activation=tf.nn.relu))
+      model.add(layers.MaxPooling2D((1, 1), padding='same'))
+      model.add(layers.Conv2D(20, 5, padding='same', activation=tf.nn.relu))
+      model.add(layers.MaxPooling2D((1, 1), padding='same'))
+  models[-1].add(layers.Flatten())
+  models[-1].add(layers.Dense(32, activation=tf.nn.relu))
+  models[-1].add(layers.Dense(10))
+  return models
+
+
+def _compute_loss(logits, labels):
+  return tf.reduce_mean(
+      tf.nn.sparse_softmax_cross_entropy_with_logits(logits=logits,
+                                                     labels=labels))
+
+
+def _limit_gpu_memory():
+  """Helper function to limit GPU memory for testing  """
+  gpus = tf.config.experimental.list_physical_devices('GPU')
+  if gpus:
+    try:
+      tf.config.experimental.set_virtual_device_configuration(
+          gpus[0], [
+              tf.config.experimental.VirtualDeviceConfiguration(
+                  memory_limit=1024)
+          ])
+    except RuntimeError as e:
+      print(e)
+
+
+def _get_dummy_data(img_dim, n_channels, batch_size):
+  inputs = tf.ones([batch_size, img_dim, img_dim, n_channels])
+  labels = tf.ones([batch_size], dtype=tf.int64)
+  return inputs, labels
+
+
+def _train_no_recompute(n_steps):
+  """Trains a single large model without gradient checkpointing."""
+  _limit_gpu_memory()
+  img_dim, n_channels, batch_size = 256, 1, 4
+  x, y = _get_dummy_data(img_dim, n_channels, batch_size)
+  model = _get_big_cnn_model(img_dim,
+                             n_channels,
+                             num_partitions=3,
+                             blocks_per_partition=2)
+  optimizer = optimizers.SGD()
+  losses = []
+  tr_vars = model.trainable_variables
+  for _ in range(n_steps):
+    with tf.GradientTape() as tape:
+      logits = model(x)
+      loss = _compute_loss(logits, y)
+      losses.append(loss)
+    grads = tape.gradient(loss, tr_vars)  # tr_vars
+    optimizer.apply_gradients(zip(grads, tr_vars))
+    del grads
+  return losses
+
+
+def _train_with_recompute(n_steps):
+  """Trains a single large model with gradient checkpointing using tf.recompute_grad."""
+  _limit_gpu_memory()
+  img_dim, n_channels, batch_size = 256, 1, 4
+  x, y = _get_dummy_data(img_dim, n_channels, batch_size)
+  # This model is the same model as _get_big_cnn_model but split into 3 parts.
+  models = _get_split_cnn_model(img_dim,
+                                n_channels,
+                                num_partitions=3,
+                                blocks_per_partition=2)
+  model1, model2, model3 = models
+  # Apply gradient checkpointing to the submodels using tf.recompute_grad.
+  model1_re = tf.recompute_grad(model1)
+  model2_re = tf.recompute_grad(model2)
+  model3_re = tf.recompute_grad(model3)
+  optimizer = optimizers.SGD()
+  tr_vars = model1.trainable_variables + model2.trainable_variables + model3.trainable_variables
+  losses = []
+  for _ in range(n_steps):
+    with tf.GradientTape() as tape:
+      logits1 = model1_re(x)
+      logits2 = model2_re(logits1)
+      logits3 = model3_re(logits2)
+      loss = _compute_loss(logits3, y)
+      losses.append(loss)
+      grads = tape.gradient(loss, tr_vars)  # tr_vars
+      optimizer.apply_gradients(zip(grads, tr_vars))
+      del grads
+  return losses
+
+
+class GradientCheckpointTest(tf.test.TestCase):
+
+  def test_raises_oom_exception(self):
+    with self.assertRaises(Exception) as context:
+      _train_no_recompute(1)
+    self.assertTrue(
+        context.exception.__class__.__name__ == 'ResourceExhaustedError')
+
+  def test_does_not_raise_oom_exception(self):
+    n_step = 2
+    losses = _train_with_recompute(n_step)
+    self.assertTrue(len(losses) == n_step)
+
+
+if __name__ == "__main__":
+  tf.test.main()

--- a/tensorflow/python/ops/custom_gradient.py
+++ b/tensorflow/python/ops/custom_gradient.py
@@ -33,6 +33,7 @@ from tensorflow.python.util import nest
 from tensorflow.python.util import tf_decorator
 from tensorflow.python.util import tf_inspect
 from tensorflow.python.util.tf_export import tf_export
+from tensorflow.python.ops.unconnected_gradients import UnconnectedGradients
 
 
 VAR_OP_TYPES = [
@@ -503,7 +504,8 @@ def recompute_grad(f):
         kw_vars = list(variables)
       grads = t.gradient(result,
                          list(id_args) + kw_vars,
-                         output_gradients=dresult)
+                         output_gradients=dresult,
+                         unconnected_gradients=UnconnectedGradients.ZERO)
 
       def transpose(*t_args, **t_kwargs):
         """Gradient function calculation for forward mode autodiff."""
@@ -513,8 +515,6 @@ def recompute_grad(f):
             "Consider not using recompute_grad in forward mode autodiff".format(
                 f.__name__))
 
-      if len(grads) == 1 and None in grads:
-        return 0, transpose
       return (grads[:len(id_args)], grads[len(id_args):]), transpose
 
     return result, grad

--- a/tensorflow/python/ops/custom_gradient.py
+++ b/tensorflow/python/ops/custom_gradient.py
@@ -512,8 +512,8 @@ def recompute_grad(f):
       def transpose(*t_args, **t_kwargs):
         """Gradient function calculation for forward mode autodiff."""
         # Just throw an error since gradients / activations are not stored on tape for recompute.
-        raise ValueError(
-            "recompute_grad tried to transpose {}."
+        raise NotImplementedError(
+            "recompute_grad tried to transpose grad of {}. "
             "Consider not using recompute_grad in forward mode autodiff".format(
                 f.__name__))
 

--- a/tensorflow/python/ops/custom_gradient.py
+++ b/tensorflow/python/ops/custom_gradient.py
@@ -28,12 +28,12 @@ from tensorflow.python.ops import gen_array_ops
 from tensorflow.python.ops import op_selector
 from tensorflow.python.ops import resource_variable_ops
 from tensorflow.python.ops import variable_scope
+from tensorflow.python.ops.unconnected_gradients import UnconnectedGradients
 from tensorflow.python.platform import tf_logging as logging
 from tensorflow.python.util import nest
 from tensorflow.python.util import tf_decorator
 from tensorflow.python.util import tf_inspect
 from tensorflow.python.util.tf_export import tf_export
-from tensorflow.python.ops.unconnected_gradients import UnconnectedGradients
 
 
 VAR_OP_TYPES = [
@@ -487,7 +487,7 @@ def recompute_grad(f):
       result = f(*args, **kwargs)
 
     @custom_gradient
-    def grad(*dresult, **grad_kwargs):
+    def inner_recompute_grad(*dresult, **grad_kwargs):
       """Nested custom gradient function for computing grads in reverse and forward mode autodiff."""
       # Gradient calculation for reverse mode autodiff.
       variables = grad_kwargs.get("variables")
@@ -517,7 +517,7 @@ def recompute_grad(f):
 
       return (grads[:len(id_args)], grads[len(id_args):]), transpose
 
-    return result, grad
+    return result, inner_recompute_grad
 
   return inner
 

--- a/tensorflow/python/ops/custom_gradient.py
+++ b/tensorflow/python/ops/custom_gradient.py
@@ -406,17 +406,14 @@ def _graph_mode_decorator(f, args, kwargs):
 
 def _eager_mode_decorator(f, args, kwargs):
   """Implement custom gradient decorator for eager mode."""
-
-  trainable_vars = []
-  if 'trainable_variables' in kwargs:
-    trainable_vars = kwargs.pop('trainable_variables')
-  result, grad_fn = f(*args, **kwargs)
+  with tape_lib.VariableWatcher() as variable_watcher:
+    result, grad_fn = f(*args, **kwargs)
   all_inputs = list(args) + list(kwargs.values())
   # The variables that grad_fn needs to return gradients for are the set of
   # variables used that are *not* part of the inputs.
   variables = [
       v.deref()  # pylint: disable=g-complex-comprehension
-      for v in set(v.ref() for v in trainable_vars)
+      for v in set(v.ref() for v in variable_watcher.watched_variables())
       if all(v.deref() is not i for i in all_inputs)
   ]
   grad_argspec = tf_inspect.getfullargspec(grad_fn)

--- a/tensorflow/python/ops/gradients_test.py
+++ b/tensorflow/python/ops/gradients_test.py
@@ -1371,6 +1371,7 @@ class VariablesGradientTest(test_util.TensorFlowTestCase):
                                                                  delta=delta)
     self.assertAllClose(num_jac, sym_jac_back, rtol=rtol, atol=atol)
   
+  @test_util.run_v2_only
   def testCustomGradientRecomputeGradHigherOrder(self):
 
     @custom_gradient.recompute_grad

--- a/tensorflow/python/ops/gradients_test.py
+++ b/tensorflow/python/ops/gradients_test.py
@@ -1471,7 +1471,6 @@ class VariablesGradientTest(test_util.TensorFlowTestCase):
             shape=10,
             trainable=True,
         )
-        self.evaluate(test_var.assign(np.ones([10])))
         return input_t * test_var
 
     test_input_t = constant(np.zeros((10, 10), dtype=np.float32))
@@ -1482,6 +1481,8 @@ class VariablesGradientTest(test_util.TensorFlowTestCase):
       out_re = test_fn_re(test_input_t)
       out = TestFn(test_input_t)
 
+    init = tf.compat.v1.global_variables_initializer()
+    self.evaluate(init)
     grads_re = gradients.gradients(out_re, variables.trainable_variables())
     grads = gradients.gradients(out, variables.trainable_variables())
 

--- a/tensorflow/python/ops/gradients_test.py
+++ b/tensorflow/python/ops/gradients_test.py
@@ -1481,7 +1481,7 @@ class VariablesGradientTest(test_util.TensorFlowTestCase):
       out_re = test_fn_re(test_input_t)
       out = TestFn(test_input_t)
 
-    init = tf.compat.v1.global_variables_initializer()
+    init = variables.global_variables_initializer()
     self.evaluate(init)
     grads_re = gradients.gradients(out_re, variables.trainable_variables())
     grads = gradients.gradients(out, variables.trainable_variables())


### PR DESCRIPTION
This PR addresses an issue where no memory saving was observed with gradient checkpointing in eager mode.
Results can be found here - https://github.com/pidajay/tf2_gradient_checkpointing/blob/master/Results_tf_recompute_grad_bug_fix.txt
Summary: Peak memory for a sample CNN model before fix is 3.3 GB and after fix is 704 MB.
This is the script used to generate results - https://github.com/pidajay/tf2_gradient_checkpointing/blob/master/run_recompute_grad_with_profile.py.