### PR TITLE
Fix dynamic display for PyCharm (r1.15)

### DIFF
--- a/tensorflow/python/keras/utils/generic_utils.py
+++ b/tensorflow/python/keras/utils/generic_utils.py
@@ -338,7 +338,8 @@ class Progbar(object):
     self._dynamic_display = ((hasattr(sys.stdout, 'isatty') and
                               sys.stdout.isatty()) or
                              'ipykernel' in sys.modules or
-                             'posix' in sys.modules)
+                             'posix' in sys.modules or
+                             'PYCHARM_HOSTED' in os.environ)
     self._total_width = 0
     self._seen_so_far = 0
     # We use a dict + list to avoid garbage collection


### PR DESCRIPTION
### Summary
Fixes `self._dynamic_display` not being set to true for printing out the verbose training updates. Previously in PyCharm, it would print a new line every update to the progress bar and with this change it works as expected, clearing each previous update to the line and removing the annoying bug of many, many fast printing lines to the console.

*This is a cherry-pick of https://github.com/tensorflow/tensorflow/pull/34911, relating to issue #38883*