### PR TITLE
[ROCm] AMDGPU XLA compiler bugfixes, HLO slice sorting

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/gpu_executable.h
+++ b/tensorflow/compiler/xla/service/gpu/gpu_executable.h
@@ -138,7 +138,7 @@ class GpuExecutable : public Executable {
   // compute_capability_.
   //
   // May be empty, in which case we leave compilation up to the GPU driver.
-  const std::vector<uint8> binary_;
+  std::vector<uint8> binary_;
 
   // The GPU version for compute compatibility check.
   GpuVersion gpu_version_;


### PR DESCRIPTION
This PR:
Implements HSACO cache, to avoid rerunning (expensive) AMDGPU compilation for identical modules
Makes sure that AMDGPU backend deletes temporary files after compilation
Implements deterministic sorting of HLO slices (without it, identical HLOs may result in different IRs)
Supplies workarounds for two bugs in the ROCm backend