### PR TITLE
removed unreachable original_index

### DIFF
--- a/tensorflow/lite/python/op_hint.py
+++ b/tensorflow/lite/python/op_hint.py
@@ -1168,7 +1168,6 @@ def _get_correct_mapping(original_index, nodes):
     return node_indices[-1]
   else:
     return original_index
-  return original_index
 
 
 def _convert_op_hints_to_stubs_helper(


### PR DESCRIPTION
the last `return original_index` cannot be reached -> removed
```python
def _get_correct_mapping(original_index, nodes):
  # Special handle for the index is -1 case.
  # If it is -1, return the last index.
  if original_index == -1:
    node_indices = nodes.keys()
    node_indices = sorted(node_indices)
    return node_indices[-1]
  else:
    return original_index
  return original_index
```