### PR TITLE
Implementation of relational operator for complex numbers in XLA

### DIFF
--- a/tensorflow/compiler/xla/service/elemental_ir_emitter.cc
+++ b/tensorflow/compiler/xla/service/elemental_ir_emitter.cc
@@ -1292,6 +1292,16 @@ StatusOr<llvm::Value*> ElementalIrEmitter::EmitComplexBinaryOp(
                     llvm_ir::EmitComparison(llvm::CmpInst::FCMP_UNE,
                                             EmitExtractImag(lhs_value),
                                             EmitExtractImag(rhs_value), b_));
+	case ComparisonDirection::kGt:
+          return Or(llvm_ir::EmitComparison(llvm::CmpInst::FCMP_OGT,
+				            EmitExtractReal(lhs_value),
+					    EmitExtractReal(rhs_value), b_),
+                    And(llvm_ir::EmitComparison(llvm::CmpInst::FCMP_OEQ,
+				                EmitExtractReal(lhs_value),
+						EmitExtractReal(rhs_value), b_),
+                        llvm_ir::EmitComparison(llvm::CmpInst::FCMP_OGT,
+                                 EmitExtractImag(lhs_value),
+				 EmitExtractImag(rhs_value), b_)));
         default:
           return Unimplemented(
               "complex comparison '%s'",


### PR DESCRIPTION
This is the suggestion to implement relational operators for complex numbers (<, <=, >, >=) as in numpy, i.e., the lexicographical order. In this PR only the ">" relation was implemented as feedback from the community is important to evaluate if this functionality is wished for and makes sense.

This could be leveraged for the implementation of [np.unique in JAX](https://github.com/google/jax/pull/2760) as comparison and sorting of complex arrays is not supported by XLA but possible with numpy. Another usage could be an implementation of [complex QR decomposition in JAX](https://github.com/google/jax/issues/1274).

The remaining comparisons for complex numbers and tests for it, will be added if this functionality makes sense.