### PR TITLE
Add cardinality calculation for Dataset.unbatch() when possible

### DIFF
--- a/tensorflow/python/data/experimental/kernel_tests/cardinality_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/cardinality_test.py
@@ -143,6 +143,12 @@ def _test_combinations():
        cardinality.UNKNOWN),
       ("Unbatch4", lambda: dataset_ops.Dataset.range(5).batch(2, drop_remainder=True).repeat().unbatch(),
        cardinality.INFINITE),
+      ("Unbatch5",
+       lambda: dataset_ops.Dataset.zip((
+           dataset_ops.Dataset.range(4).batch(2, drop_remainder=False),
+           dataset_ops.Dataset.range(5).batch(2, drop_remainder=True),
+       )).unbatch(),
+       4),
       ("Window1", lambda: dataset_ops.Dataset.range(5).window(
           size=2, shift=2, drop_remainder=True), 2),
       ("Window2", lambda: dataset_ops.Dataset.range(5).window(

--- a/tensorflow/python/data/experimental/kernel_tests/cardinality_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/cardinality_test.py
@@ -134,6 +134,15 @@ def _test_combinations():
        lambda: dataset_ops.Dataset.range(5).filter(lambda _: True).take(2),
        cardinality.UNKNOWN),
       ("Take4", lambda: dataset_ops.Dataset.range(5).repeat().take(2), 2),
+      ("Unbatch1",
+       lambda: dataset_ops.Dataset.range(5).batch(2, drop_remainder=True).unbatch(), 4),
+      ("Unbatch2",
+       lambda: dataset_ops.Dataset.range(5).batch(2, drop_remainder=False).unbatch(), cardinality.UNKNOWN),
+      ("Unbatch3",
+       lambda: dataset_ops.Dataset.range(5).batch(2, drop_remainder=True).filter(lambda _: True).unbatch(),
+       cardinality.UNKNOWN),
+      ("Unbatch4", lambda: dataset_ops.Dataset.range(5).batch(2, drop_remainder=True).repeat().unbatch(),
+       cardinality.INFINITE),
       ("Window1", lambda: dataset_ops.Dataset.range(5).window(
           size=2, shift=2, drop_remainder=True), 2),
       ("Window2", lambda: dataset_ops.Dataset.range(5).window(


### PR DESCRIPTION
This PR tries to address the issue raised in #39136 where cardinality
of Dataset.unbatch() was always UNKNOWN, even if it might be known
in certain situations.

This PR add the cardinality calculation in case the input cardinality
is known and the leading dim of the output shape is known.

This PR fixes #39136.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>