### PR TITLE
TF-TRT ConvertTranspose in dynamic shape mode

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -1488,7 +1488,8 @@ class OpConverterTest : public ::testing::Test {
   // Adds ITensor for both validation and conversion. The difference compared to
   // AddTestTensorWithExplicitBatchDim is in the meaning of the dims parameter.
   // To define a tensor with NCHW shape, here we set dims = {C,H,W} and
-  // batch_size = N.
+  // batch_size = N. TODO(tfeher) remove this once all test specify batch dim
+  // explicitly. 
   void AddTestTensor(
       const string& name, const std::vector<int32>& dims, int batch_size = 1,
       nvinfer1::DataType trt_dtype = nvinfer1::DataType::kFLOAT) {

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -1489,7 +1489,7 @@ class OpConverterTest : public ::testing::Test {
   // AddTestTensorWithExplicitBatchDim is in the meaning of the dims parameter.
   // To define a tensor with NCHW shape, here we set dims = {C,H,W} and
   // batch_size = N. TODO(tfeher) remove this once all test specify batch dim
-  // explicitly. 
+  // explicitly.
   void AddTestTensor(
       const string& name, const std::vector<int32>& dims, int batch_size = 1,
       nvinfer1::DataType trt_dtype = nvinfer1::DataType::kFLOAT) {
@@ -1699,7 +1699,7 @@ template <DataType dtype>
 void BuildAndRunConvertedNetwork(
     const string& name, OpConverterTest* test, const TestParamBase& p,
     const std::vector<float>& input_vec,
-    const Matcher<const std::vector<float>&>& matcher) {
+    const Matcher<std::vector<float>>& matcher) {
   if (!p.status.ok()) {
     // conversion was not successful, we cannot run the network
     return;
@@ -1735,7 +1735,7 @@ void BuildAndRunConvertedNetwork(
 void InstantiateBuildAndRun(DataType tf_dtype, const string& name,
                             OpConverterTest* test, const TestParamBase& p,
                             const std::vector<float>& input_vec,
-                            const Matcher<const std::vector<float>&>& matcher) {
+                            const Matcher<std::vector<float>>& matcher) {
   if (tf_dtype == DT_FLOAT) {
     BuildAndRunConvertedNetwork<DT_FLOAT>(name, test, p, input_vec, matcher);
   } else if (tf_dtype == DT_HALF) {

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -1664,10 +1664,12 @@ std::ostream& operator<<(std::ostream& os, const TestParamBase& p) {
   return os;
 }
 
-// Parameterized version of OpConverterTest. Parameters are:
-// 1. TrtTestMode (implicit batch / explicit batch / dynamic shape)
-// 2. DataType of the input TF tensors
-// 3. TrtPrecisionMode argument for the Converter (FP32, FP16, INT8)
+// Parameterized version of OpConverterTest. This class will be instantiated
+// to test all the TrtTestModes but only in FP32 precision. This means that we
+// will use the following combinations of test parameters:
+// 1. TrtTestMode: implicit batch, explicit batch, dynamic shape modes
+// 2. DataType of the input TF tensors: DT_FLOAT
+// 3. TrtPrecisionMode argument for the Converter: FP32
 class ParameterizedOpConverterTest
     : public OpConverterTest,
       public ::testing::WithParamInterface<

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -1356,10 +1356,8 @@ class OpConverterTest : public ::testing::Test {
     }
   }
 
-  // TODO(laigd): test fp16 and int8 support for more converters.
   void BuildAndRun(const DataVec& input_data, DataVec* output_data,
                    const int batch_size = 1) {
-    // TODO(tamas) the precision_mode arg is not used anymore, remove it
     // Mark the output tensor as TRT engine output.
     std::vector<Converter::EngineOutputInfo> output_info;
     for (const auto& data : *output_data) {
@@ -1693,8 +1691,8 @@ INSTANTIATE_TEST_CASE_P(
                        ::testing::Values(DT_FLOAT),
                        ::testing::Values(TrtPrecisionMode::FP32)));
 
-// Build and the converted network. Check output tensor shape. Test output
-// values using matcher.
+// Builds and runs the converted network. Checks output tensor shape. Tests
+// output values using a matcher.
 template <DataType dtype>
 void BuildAndRunConvertedNetwork(
     const string& name, OpConverterTest* test, const TestParamBase& p,


### PR DESCRIPTION
This PR enables conversion of the Transpose op in dynamic shape mode and tests it. 
 
Additionally the ConvertSqueeze test is simplified: the test params are now built in a way that they do not contain invalid combinations. E.g. if trt_mode==kImplicitBatch we do not add dynamic input shapes, only static shapes. This way we can remove the skip_test arg of AddTestTensor.

Tagging @bixia1 for review.