### PR TITLE
Fix issue in boolean_mask when axis is passed as a tensor

### DIFF
--- a/tensorflow/python/kernel_tests/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops_test.py
@@ -281,6 +281,15 @@ class BooleanMaskTest(test_util.TensorFlowTestCase):
         result = sess.run(masked_tensor, feed_dict={tile_placeholder: [2, 2]})
         self.assertAllEqual([b"hello", b"hello", b"hello", b"hello"], result)
 
+  def testMaskWithAxisTensor(self):
+    @def_function.function(autograph=False)
+    def f():
+      return array_ops.boolean_mask(
+          [1, 2, 3], [True, False, True],
+          axis=constant_op.constant(0, dtype=dtypes.int32))
+
+    self.assertAllEqual(self.evaluate(f()), [1, 3])
+
 
 @test_util.run_all_in_graph_and_eager_modes
 class OperatorShapeTest(test_util.TensorFlowTestCase):

--- a/tensorflow/python/kernel_tests/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops_test.py
@@ -290,6 +290,19 @@ class BooleanMaskTest(test_util.TensorFlowTestCase):
 
     self.assertAllEqual(self.evaluate(f()), [1, 3])
 
+  def testMaskWithAxisNonConstTensor(self):
+    @def_function.function(
+        autograph=False,
+        input_signature=[
+            tensor_spec.TensorSpec(shape=None, dtype=dtypes.int32)])
+    def f(axis):
+      return array_ops.boolean_mask(
+          [1, 2, 3], [True, False, True],
+          axis=axis)
+
+    self.assertAllEqual(
+        self.evaluate(f(constant_op.constant(0, dtype=dtypes.int32))), [1, 3])
+
 
 @test_util.run_all_in_graph_and_eager_modes
 class OperatorShapeTest(test_util.TensorFlowTestCase):

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -1702,7 +1702,7 @@ def boolean_mask(tensor, mask, name="boolean_mask", axis=None):
     axis_value = tensor_util.constant_value(axis)
     if axis_value is not None:
       axis = axis_value
-    shape_tensor[axis:axis + ndims_mask].assert_is_compatible_with(shape_mask)
+      shape_tensor[axis:axis + ndims_mask].assert_is_compatible_with(shape_mask)
 
     leading_size = gen_math_ops.prod(shape(tensor)[axis:axis + ndims_mask], [0])
     tensor = reshape(
@@ -1711,10 +1711,15 @@ def boolean_mask(tensor, mask, name="boolean_mask", axis=None):
             shape(tensor)[:axis], [leading_size],
             shape(tensor)[axis + ndims_mask:]
         ], 0))
-    first_dim = shape_tensor[axis:axis + ndims_mask].num_elements()
-    tensor.set_shape(
-        tensor_shape.as_shape(shape_tensor[:axis]).concatenate(
-            [first_dim]).concatenate(shape_tensor[axis + ndims_mask:]))
+    # TODO(yongtang): tf.reshape in C++ kernel might have set the shape
+    # correctly, so the following may not be needed? It still might ben
+    # possible that there are some edge case where tensor_util.constant_value
+    # resolves more case than ShapeInference of tf.reshape in C++ kernel.
+    if axis_value is not None:
+      first_dim = shape_tensor[axis:axis + ndims_mask].num_elements()
+      tensor.set_shape(
+          tensor_shape.as_shape(shape_tensor[:axis]).concatenate(
+              [first_dim]).concatenate(shape_tensor[axis + ndims_mask:]))
 
     mask = reshape(mask, [-1])
     return _apply_mask_1d(tensor, mask, axis)

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -1699,6 +1699,9 @@ def boolean_mask(tensor, mask, name="boolean_mask", axis=None):
           "Number of mask dimensions must be specified, even if some dimensions"
           " are None.  E.g. shape=[None] is ok, but shape=None is not.")
     axis = 0 if axis is None else axis
+    axis_value = tensor_util.constant_value(axis)
+    if axis_value is not None:
+      axis = axis_value
     shape_tensor[axis:axis + ndims_mask].assert_is_compatible_with(shape_mask)
 
     leading_size = gen_math_ops.prod(shape(tensor)[axis:axis + ndims_mask], [0])


### PR DESCRIPTION

This PR tries to address the issue raised in #32236 where
a TypeError was thrown out when axis is passed as a tensor.
In the docstring axis has been specified as accepting a 1-D tensor.

This PR fixes the issue.

This PR fixes #32236.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>