### PR TITLE
Fix incorrect usage of tf.broadcast_weights in docstring

### DIFF
--- a/tensorflow/python/keras/metrics.py
+++ b/tensorflow/python/keras/metrics.py
@@ -138,7 +138,6 @@ class Metric(base_layer.Layer):
       values = tf.cast(values, self.dtype)
       if sample_weight is not None:
         sample_weight = tf.cast(sample_weight, self.dtype)
-        sample_weight = tf.broadcast_weights(sample_weight, values)
         values = tf.multiply(values, sample_weight)
       self.true_positives.assign_add(tf.reduce_sum(values))
 


### PR DESCRIPTION
This PR tries to address the issue raised in #33526 where
`tf.broadcast_weights` was used incorrectly in docstring
(`broadcast_weights` is not public).

Since the docstring uses `broadcast_weights` in a example,
and `broadcast_weights` by itself is just to make sure
it follow a subset of broadcast rules than `tf.multiply`,
it actually makes sense to remove this line as it does not
add much to be an example in docs:

```diff
         sample_weight = tf.cast(sample_weight, self.dtype)
-        sample_weight = tf.broadcast_weights(sample_weight, values)
         values = tf.multiply(values, sample_weight)
```

This PR fixes #33526

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>