### PR TITLE
Fix a flaky test when pretty print function keyword arguments in Python 3.5

### DIFF
--- a/tensorflow/python/eager/function.py
+++ b/tensorflow/python/eager/function.py
@@ -2234,7 +2234,7 @@ class ConcreteFunction(object):
     arg_specs, kwarg_specs = self.structured_input_signature
     names = list(self._function_spec.arg_names)
     names.extend(sorted(kwarg_specs))
-    specs = list(arg_specs) + list(kwarg_specs.values())
+    specs = list(arg_specs) + list(_deterministic_dict_values(kwarg_specs))
     # note: we can skip bound args, since we already displayed thier bound
     # value in the signature summary.
     arg_details = []


### PR DESCRIPTION
I observed the following error with Python 3.5 on `//tensorflow/python/eager:function_test`:

```
FAIL: testPrettyPrintedSignature (__main__.FunctionTest)
testPrettyPrintedSignature (__main__.FunctionTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/bazel-buildfarm/default/operations/83398799-fc19-4863-a3e0-99fb3531f4ad/bazel-out/k8-opt/bin/tensorflow/python/eager/function_test.runfiles/org_tensorflow/tensorflow/python/eager/function_test.py", line 3625, in testPrettyPrintedSignature
    c3_summary + '\n' + c3_details)
AssertionError: Regex didn't match: "func\\(x, kangaroo=None, octopus=7\\)\n  Args:\\n    x: {'a': <1>, 'b': \\[<2>, <3>\\]}\\n      <1>: int32 Tensor, shape=\\(\\)\\n      <2>: RaggedTensorSpec\\(.*\\)\\n      <3>: RaggedTensorSpec\\(.*\\)\\n  Returns:\\n    {'a': <1>, 'b': \\[<2>, <3>\\]}\\n      <1>: int32 Tensor, shape=\\(\\)\\n      <2>: RaggedTensorSpec\\(.*\\)\\n      <3>: RaggedTensorSpec\\(.*\\)" not found in "func(x, kangaroo=None, octopus=7)\n  Args:\n    x: {'b': [<2>, <3>], 'a': <1>}\n      <1>: int32 Tensor, shape=()\n      <2>: RaggedTensorSpec(TensorShape([2, None]), tf.int32, 1, tf.int64)\n      <3>: RaggedTensorSpec(TensorShape([2, None]), tf.int32, 1, tf.int64)\n  Returns:\n    {'b': [<2>, <3>], 'a': <1>}\n      <1>: int32 Tensor, shape=()\n      <2>: RaggedTensorSpec(TensorShape([2, None]), tf.int32, 1, tf.int64)\n      <3>: RaggedTensorSpec(TensorShape([2, None]), tf.int32, 1, tf.int64)"
```

It appears that when enumerating the `kwargs` dictionary, the order is only deterministic for Python >=3.6 (so the pre-submit didn't catch it). See https://mail.python.org/pipermail/python-dev/2017-December/151263.html

cc @edloper 