### PR TITLE
Increase Apache Spark version to 2.4.5 to handle GitHub Security Alert

### DIFF
--- a/tensorflow/java/maven/spark-tensorflow-connector/pom.xml
+++ b/tensorflow/java/maven/spark-tensorflow-connector/pom.xml
@@ -33,7 +33,7 @@
         <scala.test.version>2.2.6</scala.test.version>
         <maven.compiler.version>3.0</maven.compiler.version>
         <java.version>1.8</java.version>
-        <spark.version>2.3.1</spark.version>
+        <spark.version>2.4.5</spark.version>
         <yarn.api.version>2.7.3</yarn.api.version>
         <junit.version>4.11</junit.version>
     </properties>


### PR DESCRIPTION
Handles CVE-2019-10099, CVE-2018-17190, CVE-2018-11770.

To be cherrypicked on r1.15, r2.0, r2.1 and r2.2 branches

PiperOrigin-RevId: 309955549
Change-Id: I5ee68fdd3270534066487be67232c1abc687f968