### PR TITLE
fix ops.Tensor initializer in keras.initializers.get

### DIFF
--- a/tensorflow/python/keras/initializers/__init__.py
+++ b/tensorflow/python/keras/initializers/__init__.py
@@ -22,6 +22,7 @@ import threading
 import six
 
 from tensorflow.python import tf2
+from tensorflow.python.framework import ops
 from tensorflow.python.keras.initializers import initializers_v1
 from tensorflow.python.keras.initializers import initializers_v2
 from tensorflow.python.keras.utils import generic_utils
@@ -156,6 +157,8 @@ def get(identifier):
     identifier = str(identifier)
     return deserialize(identifier)
   elif callable(identifier):
+    return identifier
+  elif isinstance(identifier, ops.Tensor):
     return identifier
   else:
     raise ValueError('Could not interpret initializer identifier: ' +


### PR DESCRIPTION
This PR allows keras.initializers.get method deal with ops.Tensor initializer correctly, and fixes the following issue.

In partitioned variable cases, like distributed training, `constant_initializer` do not parse partitioned_info in call stage, where an ops.Tensor initializer will lead expected results (see line 746 in tensorflow/tensorflow/python/ops/variable_scope.py for more details). But the following code leads a ValueError.

```python
>>> import tensorflow as tf
>>> x = tf.constant([[1], [2]])
>>> layer = tf.keras.layers.Dense(3, kernel_initializer=tf.constant([[1]]))
>>> y = layer(x)
ValueError: Could not interpret initializer identifier: tf.Tensor([[1]], shape=(1, 1), dtype=int32)
```