### PR TITLE
make `bazel build` work on aarch64/arm linux

### DIFF
--- a/third_party/remote_config/remote_platform_configure.bzl
+++ b/third_party/remote_config/remote_platform_configure.bzl
@@ -18,6 +18,10 @@ def _remote_platform_configure_impl(repository_ctx):
         cpu = "ppc"
     elif machine_type.startswith("s390x"):
         cpu = "s390x"
+    elif machine_type.startswith("aarch64"):
+        cpu = "aarch64"
+    elif machine_type.startswith("arm"):
+        cpu = "arm"
 
     exec_properties = repository_ctx.attr.platform_exec_properties
 


### PR DESCRIPTION
make
```
bazel build //tensorflow/tools/pip_package:build_pip_package
````
work again on aarch64 (e.g., EdgeTPU Dev board and Jetson boards)
and arm (e.g, Raspberry Pi 3/4 boards) Linux platforms

without this patch, I saw

```
...
ERROR: While resolving toolchains for target //tensorflow:libtensorflow_framework.so.2.1.0: No matching toolchains found for types @bazel_tools//tools/cpp:toolchain_type. Maybe --incompatible_use_cc_configure_from_rules_cc has been flipped and there is no default C++ toolchain added in the WORKSPACE file? See https://github.com/bazelbuild/bazel/issues/10134 for details and migration instructions.
ERROR: Analysis of target '//tensorflow/tools/pip_package:build_pip_package' failed; build aborted: No matching toolchains found for types @bazel_tools//tools/cpp:toolchain_type. Maybe --incompatible_use_cc_configure_from_rules_cc has been flipped and there is no default C++ toolchain added in the WORKSPACE file? See https://github.com/bazelbuild/bazel/issues/10134 for details and migration instructions.
```