### PR TITLE
Add mlir graph optimization to the build

### DIFF
--- a/tensorflow/compiler/mlir/python/BUILD
+++ b/tensorflow/compiler/mlir/python/BUILD
@@ -12,6 +12,22 @@ cc_library(
         "//tensorflow/c:tf_status_helper",
         "//tensorflow/compiler/mlir/tensorflow:convert_graphdef",
         "//tensorflow/compiler/mlir/tensorflow:error_util",
+        # (yongtang) The graph_optimization_pass_registration needs to be part
+        # of a shared object that will be loaded whenever `import tensorflow`
+        # is run. The natural place is libtensorflow_framework.so.
+        # While adding graph_optimization_pass_registration to
+        # libtensorflow_framework.so is possible with some modification in
+        # dependency, many tests will fail due to multiple copies of LLVM.
+        # See https://github.com/tensorflow/tensorflow/pull/39231 for details.
+        # Alternatively, we place graph_optimization_pass_registration here
+        # because:
+        # - tensorflow/python/_pywrap_mlir.so already depends on LLVM anyway
+        # - tensorflow/python/_pywrap_mlir.so always loaded as part of python
+        #   binding
+        # TODO: It might be still preferrable to place graph_optimization_pass
+        # as part of the libtensorflow_framework.so, as it is the central
+        # place for core related components.
+        "//tensorflow/compiler/mlir/tensorflow:graph_optimization_pass_registration",
         "//tensorflow/compiler/mlir/tensorflow:import_utils",
         "@llvm-project//llvm:support",
         "@llvm-project//mlir:IR",


### PR DESCRIPTION
This PR is part of the process to resolve #39135. 

As was mentioned in #39135, 248bc00 enables MLIR graph optimizations. However, it is not part of the build for pip wheel. The reason was that MLIR graph optimizations is done through a registration (mlir_graph_optimization_pass_registration.cc) but this file is not included in `libtensorflow_framerowk.so` so pip wheel package is not enabled.

This PR add the `mlir_graph_optimization_pass_registration` to be part of the `libtensorflow_framework.so`. Due to the `bazel` dependency reasons, a direct inclusion will not work as ops in core and xla will be pulled in multiple times by bazel. There will be 2 copies of xla ops, 2 copies of lite and core ops in `libtensorflow_framework.so`

So the following change has been made.  In general `import_model.[h|cc]` has been split into 3 parts:
- new `import_base.[h|cc] consists of ImporterBase class and common shared functions (by `import_model.[h|cc]` and `import_graphdef.[h|cc]`
- new `import_graphdef.[h|cc]` consists of graph only conversion to mlir
- the `import_model.[h|cc]` has also been updated to consist model only conversion to mlir

There are also some small bazel changes that removes unnecessary dependencies.

Note with the change, MLIR graph optimizations only need to depends on `import_graphdef.cc` and `export_graphdef.cc`. It will not depend on `import_model.cc` which pulled in xla and core ops multiple time by bazel.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>