### PR TITLE
Return ValueError in case of empty list input for tf.map_fn

### DIFF
--- a/tensorflow/python/kernel_tests/map_fn_test.py
+++ b/tensorflow/python/kernel_tests/map_fn_test.py
@@ -217,6 +217,12 @@ class MapFnTest(test.TestCase):
       self.assertAllEqual([0, 3, 2], map_return.get_shape().dims)
       self.assertAllEqual([0, 3, 2], self.evaluate(map_return).shape)
 
+  @test_util.run_in_graph_and_eager_modes
+  def testMapEmptyList(self):
+    x = []
+    with self.assertRaisesRegexp(
+        ValueError, r"elems must be a Tensor or"):
+      _ = map_fn.map_fn(lambda e: e, x)
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/ops/map_fn.py
+++ b/tensorflow/python/ops/map_fn.py
@@ -267,7 +267,7 @@ def map_fn(fn,
     elems: A tensor or (possibly nested) sequence of tensors, each of which will
       be unstacked along their first dimension.  `fn` will be applied to the
       nested sequence of the resulting slices.  `elems` may include ragged and
-      sparse tensors.
+      sparse tensors. `elems` must consist of at least one tensor.
     dtype: Deprecated: Equivalent to `fn_output_signature`.
     parallel_iterations: (optional) The number of iterations allowed to run in
       parallel. When graph building, the default value is 10. While executing
@@ -296,7 +296,7 @@ def map_fn(fn,
     TypeError: if `fn` is not callable or the structure of the output of
       `fn` and `fn_output_signature` do not match.
     ValueError: if the lengths of the output of `fn` and `fn_output_signature`
-      do not match.
+      do not match, or if the `elems` does not contain any tensor.
 
   Examples:
 

--- a/tensorflow/python/ops/map_fn.py
+++ b/tensorflow/python/ops/map_fn.py
@@ -375,6 +375,13 @@ def map_fn(fn,
 
   # Flatten the input tensors, and get the TypeSpec for each one.
   elems_flat = nest.flatten(elems)
+
+  # Check in case this is an empty list
+  if len(elems_flat) == 0:
+    raise ValueError(
+        "elems must be a Tensor or (possibly nested) sequence of Tensors. "
+        "Got {}, which does not contain any Tensors.".format(elems))
+
   elems_flat_signature = [type_spec.type_spec_from_value(e) for e in elems_flat]
   elems_unflatten = lambda x: nest.pack_sequence_as(elems, x)
 


### PR DESCRIPTION
This PR tries to address the issue raised in #39229 where
empty lists input was not checked and throw out a non-obvious error:
```python
>>> import numpy as np
>>> import tensorflow as tf
>>> fn = lambda x: x
>>> tf.map_fn(fn, [])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Library/Python/3.7/site-packages/tensorflow/python/util/deprecation.py", line 574, in new_func
    return func(*args, **kwargs)
  File "/Library/Python/3.7/site-packages/tensorflow/python/ops/map_fn.py", line 425, in map_fn_v2
    name=name)
  File "/Library/Python/3.7/site-packages/tensorflow/python/ops/map_fn.py", line 213, in map_fn
    static_shape = elems_flat[0].shape
IndexError: list index out of range
>>>
```


This PR update to perform a check and thrown out
`ValueError("elems must not be empty")` to help clarify.

This PR fixes #39229.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>