### PR TITLE
Update protobuf-java to 3.9.2

### DIFF
--- a/tensorflow/java/maven/proto/pom.xml
+++ b/tensorflow/java/maven/proto/pom.xml
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.5.1</version>
+      <version>3.9.2</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
This PR updates protobuf-java to 3.9.2, to match C++ version
in tensorflow/workspace.bzl (3.9.2), and to fix the issue raised
in #39381 about Java9+ specific warning messages (related https://github.com/protocolbuffers/protobuf/issues/3781)

This PR fixes #39381.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>