### PR TITLE
Add mlir_graph_optimization_pass.h header to pip wheel

### DIFF
--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -28,6 +28,7 @@ transitive_hdrs(
     deps = [
         "//tensorflow/c/experimental:network",
         "//tensorflow/compiler/tf2xla:xla_compiled_cpu_function",
+        "//tensorflow/compiler/mlir:mlir_graph_optimization_pass",
         "//tensorflow/core:core_cpu",
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",


### PR DESCRIPTION
This PR adds mlir_graph_optimization_pass.h header to tf-nightly pip wheel.

mlir_graph_optimization_pass.h is a header file that allows to register mlir based graph optimizaton (either part of the tensorflow, or externally registered).

However, it is not part of the pip install so it is not possible to register with installed version of tensorflow. This PR adds the header file to be part of the pip install.

This PR is related to #39231

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>