### PR TITLE
[ROCm] hip-clang / ROCm 3.5 build fixes

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
+++ b/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
@@ -689,7 +689,7 @@ std::unique_ptr<llvm::TargetMachine> AMDGPUGetTargetMachine(
     llvm::Triple target_triple, int amdgpu_version,
     const HloModuleConfig& hlo_module_config) {
   return GetTargetMachine(target_triple, absl::StrCat("gfx", amdgpu_version),
-                          hlo_module_config, "-code-object-v3");
+                          hlo_module_config, "+code-object-v3");
 }
 
 void AMDGPUBackendInit(const HloModuleConfig& hlo_module_config) {

--- a/tensorflow/stream_executor/rocm/rocm_gpu_executor.cc
+++ b/tensorflow/stream_executor/rocm/rocm_gpu_executor.cc
@@ -133,8 +133,9 @@ bool GpuExecutor::UnloadGpuBinary(const void* gpu_binary) {
     GpuDriver::UnloadModule(context_, module);
     gpu_binary_to_module_.erase(module_it);
     const char* mem_it = nullptr;
-    for (auto x : in_memory_modules_)
+    for (auto x : in_memory_modules_) {
       if (x.second == module) mem_it = x.first;
+    }
     if (mem_it != nullptr) in_memory_modules_.erase(mem_it);
   }
   return true;

--- a/tensorflow/stream_executor/rocm/rocm_gpu_executor.cc
+++ b/tensorflow/stream_executor/rocm/rocm_gpu_executor.cc
@@ -132,6 +132,10 @@ bool GpuExecutor::UnloadGpuBinary(const void* gpu_binary) {
     VLOG(3) << "Unloading  HSACO module " << module;
     GpuDriver::UnloadModule(context_, module);
     gpu_binary_to_module_.erase(module_it);
+    const char* mem_it = nullptr;
+    for (auto x : in_memory_modules_)
+      if (x.second == module) mem_it = x.first;
+    if (mem_it != nullptr) in_memory_modules_.erase(mem_it);
   }
   return true;
 }

--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
@@ -179,7 +179,7 @@ def InvokeHipcc(argv, log=False):
   # Also we need to retain warning about uninitialised shared variable as
   # warning only, even when -Werror option is specified.
   if HIPCC_IS_HIPCLANG:
-    hipccopts += ' --include=hip/hip_runtime.h -Wno-error=cuda-shared-init '
+    hipccopts += ' --include=hip/hip_runtime.h '
   hipccopts += ' ' + hipcc_compiler_options
   # Use -fno-gpu-rdc by default for early GPU kernel finalization
   # This flag would trigger GPU kernels be generated at compile time, instead
@@ -258,6 +258,8 @@ def main():
     gpu_linker_flags.append('-L' + HIP_RUNTIME_PATH)
     gpu_linker_flags.append('-Wl,-rpath=' + HIP_RUNTIME_PATH)
     gpu_linker_flags.append('-l' + HIP_RUNTIME_LIBRARY)
+    if HIPCC_IS_HIPCLANG:
+      gpu_linker_flags.append("-lrt")
 
     if VERBOSE: print(' '.join([CPU_COMPILER] + gpu_linker_flags))
     return subprocess.call([CPU_COMPILER] + gpu_linker_flags)

--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -809,20 +809,24 @@ def make_copy_files_rule(repository_ctx, name, srcs, outs):
 )""" % (name, "\n".join(outs), " && \\\n".join(cmds))
 
 def make_copy_dir_rule(repository_ctx, name, src_dir, out_dir, exceptions=None):
-    """Returns a rule to recursively copy a directory."""
+    """Returns a rule to recursively copy a directory.
+    If exceptions is not None, it must be a list of files or directories in 
+    'src_dir'; these will be excluded from copying. 
+    """
     src_dir = _norm_path(src_dir)
     out_dir = _norm_path(out_dir)
     outs = read_dir(repository_ctx, src_dir)
     post_cmd=''
     if exceptions!=None:
-      outs = [x for x in outs if not any([x.startswith(y) for y in exceptions])]
+      outs = [x for x in outs if not any([x.startswith(src_dir+"/"+y) 
+        for y in exceptions])]
     outs = [('        "%s",' % out.replace(src_dir, out_dir)) for out in outs]
     # '@D' already contains the relative path for a single file, see
     # http://docs.bazel.build/versions/master/be/make-variables.html#predefined_genrule_variables
     out_dir = "$(@D)/%s" % out_dir if len(outs) > 1 else "$(@D)"
     if exceptions!=None:
       for x in exceptions:
-        post_cmd+=" ; rm -fR " + x.replace(src_dir, out_dir)
+        post_cmd+=" ; rm -fR " + out_dir + "/" + x
     return """genrule(
     name = "%s",
     outs = [

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -615,6 +615,8 @@ def _create_local_rocm_repository(repository_ctx):
             name = "rocm-include",
             src_dir = rocm_toolkit_path + "/include",
             out_dir = "rocm/include",
+            exceptions = [rocm_toolkit_path + "/include/gtest", 
+              rocm_toolkit_path + "/include/gmock"],
         ),
         make_copy_dir_rule(
             repository_ctx,

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -615,8 +615,7 @@ def _create_local_rocm_repository(repository_ctx):
             name = "rocm-include",
             src_dir = rocm_toolkit_path + "/include",
             out_dir = "rocm/include",
-            exceptions = [rocm_toolkit_path + "/include/gtest", 
-              rocm_toolkit_path + "/include/gmock"],
+            exceptions = ["gtest", "gmock"],
         ),
         make_copy_dir_rule(
             repository_ctx,


### PR DESCRIPTION
ROCm migrates from hcc to hip-clang in version 3.5, and these changes are needed to support the transition. 

Summary of the changes:
* ROCm 3.5 includes gtest and gmock in its install tree, and we have to delete them when copying over the headers, otherwise they take precedence over tensorflow's own gtest/gmock
* Adding rccl's dependency on librt
* The XLA compiler is switched from code object v2 to v3
* A resource handling issue is fixed (it was present all along but it got exposed by the transition)
* An unneeded command-line warning flag is removed