### PR TITLE
Switch Raspberry Pi building to unofficial GCC 6.5 toolchain

### DIFF
--- a/arm_compiler.BUILD
+++ b/arm_compiler.BUILD
@@ -3,56 +3,56 @@ package(default_visibility = ["//visibility:public"])
 filegroup(
     name = "gcc",
     srcs = [
-        "bin/arm-linux-gnueabihf-gcc",
+        "bin/arm-rpi-linux-gnueabihf-gcc",
     ],
 )
 
 filegroup(
     name = "ar",
     srcs = [
-        "bin/arm-linux-gnueabihf-ar",
+        "bin/arm-rpi-linux-gnueabihf-ar",
     ],
 )
 
 filegroup(
     name = "ld",
     srcs = [
-        "bin/arm-linux-gnueabihf-ld",
+        "bin/arm-rpi-linux-gnueabihf-ld",
     ],
 )
 
 filegroup(
     name = "nm",
     srcs = [
-        "bin/arm-linux-gnueabihf-nm",
+        "bin/arm-rpi-linux-gnueabihf-nm",
     ],
 )
 
 filegroup(
     name = "objcopy",
     srcs = [
-        "bin/arm-linux-gnueabihf-objcopy",
+        "bin/arm-rpi-linux-gnueabihf-objcopy",
     ],
 )
 
 filegroup(
     name = "objdump",
     srcs = [
-        "bin/arm-linux-gnueabihf-objdump",
+        "bin/arm-rpi-linux-gnueabihf-objdump",
     ],
 )
 
 filegroup(
     name = "strip",
     srcs = [
-        "bin/arm-linux-gnueabihf-strip",
+        "bin/arm-rpi-linux-gnueabihf-strip",
     ],
 )
 
 filegroup(
     name = "as",
     srcs = [
-        "bin/arm-linux-gnueabihf-as",
+        "bin/arm-rpi-linux-gnueabihf-as",
     ],
 )
 

--- a/tensorflow/lite/tools/pip_package/setup.py
+++ b/tensorflow/lite/tools/pip_package/setup.py
@@ -43,8 +43,8 @@ TENSORFLOW_DIR = os.environ['TENSORFLOW_SRC_ROOT']
 # Setup cross compiling
 TARGET = os.environ.get('TENSORFLOW_TARGET', None)
 if TARGET == 'rpi':
-  os.environ['CXX'] = 'arm-linux-gnueabihf-g++'
-  os.environ['CC'] = 'arm-linux-gnueabihf-gcc'
+  os.environ['CXX'] = 'arm-rpi-linux-gnueabihf-g++'
+  os.environ['CC'] = 'arm-rpi-linux-gnueabihf-gcc'
 elif TARGET == 'aarch64':
   os.environ['CXX'] = 'aarch64-linux-gnu-g++'
   os.environ['CC'] = 'aarch64-linux-gnu-gcc'

--- a/tensorflow/tools/ci_build/pi/build_raspberry_pi.sh
+++ b/tensorflow/tools/ci_build/pi/build_raspberry_pi.sh
@@ -57,11 +57,11 @@ TOOLCHAIN_INSTALL_PATH=/tmp/toolchain_install/
 sudo rm -rf ${TOOLCHAIN_INSTALL_PATH}
 mkdir ${TOOLCHAIN_INSTALL_PATH}
 cd ${TOOLCHAIN_INSTALL_PATH}
-curl -L https://github.com/raspberrypi/tools/archive/0e906ebc527eab1cdbf7adabff5b474da9562e9f.tar.gz -o toolchain.tar.gz
+curl -L https://github.com/rvagg/rpi-newer-crosstools/archive/eb68350c5c8ec1663b7fe52c742ac4271e3217c5.tar.gz -o toolchain.tar.gz
 tar xzf toolchain.tar.gz
-mv tools-0e906ebc527eab1cdbf7adabff5b474da9562e9f/ tools
+mv rpi-newer-crosstools-eb68350c5c8ec1663b7fe52c742ac4271e3217c5 tools
 
-CROSSTOOL_CC=${TOOLCHAIN_INSTALL_PATH}/tools/arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf/bin/arm-linux-gnueabihf-gcc
+CROSSTOOL_CC=${TOOLCHAIN_INSTALL_PATH}/tools/x64-gcc-6.5.0/arm-rpi-linux-gnueabihf/bin/arm-rpi-linux-gnueabihf-gcc
 
 OPENBLAS_SRC_PATH=/tmp/openblas_src/
 sudo rm -rf ${OPENBLAS_SRC_PATH}

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -180,11 +180,11 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
     tf_http_archive(
         name = "arm_compiler",
         build_file = clean_dep("//:arm_compiler.BUILD"),
-        sha256 = "4c622a5c7b9feb9615d4723b03a13142a7f3f813f9296861d5401282b9fbea96",
-        strip_prefix = "tools-0e906ebc527eab1cdbf7adabff5b474da9562e9f/arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf",
+        sha256 = "b9e7d50ffd9996ed18900d041d362c99473b382c0ae049b2fce3290632d2656f",
+        strip_prefix = "rpi-newer-crosstools-eb68350c5c8ec1663b7fe52c742ac4271e3217c5/x64-gcc-6.5.0/arm-rpi-linux-gnueabihf/",
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/raspberrypi/tools/archive/0e906ebc527eab1cdbf7adabff5b474da9562e9f.tar.gz",
-            "https://github.com/raspberrypi/tools/archive/0e906ebc527eab1cdbf7adabff5b474da9562e9f.tar.gz",
+            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/rvagg/rpi-newer-crosstools/archive/eb68350c5c8ec1663b7fe52c742ac4271e3217c5.tar.gz",
+            "https://github.com/rvagg/rpi-newer-crosstools/archive/eb68350c5c8ec1663b7fe52c742ac4271e3217c5.tar.gz",
         ],
     )
 

--- a/third_party/toolchains/cpus/arm/cc_config.bzl.tpl
+++ b/third_party/toolchains/cpus/arm/cc_config.bzl.tpl
@@ -331,17 +331,13 @@ def _impl(ctx):
                             flags = [
                                 "-std=c++11",
                                 "-isystem",
-                                "%{ARM_COMPILER_PATH}%/arm-linux-gnueabihf/include/c++/4.9.3/",
+			 	"%{ARM_COMPILER_PATH}%/lib/gcc/arm-rpi-linux-gnueabihf/6.5.0/include",
                                 "-isystem",
-                                "%{ARM_COMPILER_PATH}%/arm-linux-gnueabihf/sysroot/usr/include/",
+                                "%{ARM_COMPILER_PATH}%/lib/gcc/arm-rpi-linux-gnueabihf/6.5.0/include-fixed",
                                 "-isystem",
-                                "%{ARM_COMPILER_PATH}%/arm-linux-gnueabihf/libc/usr/include/",
+                                "%{ARM_COMPILER_PATH}%/arm-rpi-linux-gnueabihf/sysroot/usr/include/",
                                 "-isystem",
-                                "%{ARM_COMPILER_PATH}%/lib/gcc/arm-linux-gnueabihf/4.9.3/include",
-                                "-isystem",
-                                "%{ARM_COMPILER_PATH}%/lib/gcc/arm-linux-gnueabihf/4.9.3/include-fixed",
-                                "-isystem",
-                                "%{ARM_COMPILER_PATH}%/local_include",
+		                "%{ARM_COMPILER_PATH}%/arm-rpi-linux-gnueabihf/include/c++/6.5.0/",
                                 "-isystem",
                                 "%{PYTHON_INCLUDE_PATH}%",
                                 "-isystem",
@@ -563,12 +559,10 @@ def _impl(ctx):
 
     if (ctx.attr.cpu == "armeabi"):
         cxx_builtin_include_directories = [
-                "%{ARM_COMPILER_PATH}%/arm-linux-gnueabihf/include/c++/4.9.3/",
-                "%{ARM_COMPILER_PATH}%/arm-linux-gnueabihf/sysroot/usr/include/",
-                "%{ARM_COMPILER_PATH}%/arm-linux-gnueabihf/libc/usr/include/",
-                "%{ARM_COMPILER_PATH}%/lib/gcc/arm-linux-gnueabihf/4.9.3/include",
-                "%{ARM_COMPILER_PATH}%/lib/gcc/arm-linux-gnueabihf/4.9.3/include-fixed",
-                "%{ARM_COMPILER_PATH}%/local_include",
+                "%{ARM_COMPILER_PATH}%/lib/gcc/arm-rpi-linux-gnueabihf/6.5.0/include",
+                "%{ARM_COMPILER_PATH}%/lib/gcc/arm-rpi-linux-gnueabihf/6.5.0/include-fixed",
+                "%{ARM_COMPILER_PATH}%/arm-rpi-linux-gnueabihf/sysroot/usr/include/",
+		"%{ARM_COMPILER_PATH}%/arm-rpi-linux-gnueabihf/include/c++/6.5.0/",
                 "/usr/include",
                 "/tmp/openblas_install/include/",
             ]
@@ -585,44 +579,44 @@ def _impl(ctx):
         tool_paths = [
             tool_path(
                 name = "ar",
-                path = "%{ARM_COMPILER_PATH}%/bin/arm-linux-gnueabihf-ar",
+                path = "%{ARM_COMPILER_PATH}%/bin/arm-rpi-linux-gnueabihf-ar",
             ),
             tool_path(name = "compat-ld", path = "/bin/false"),
             tool_path(
                 name = "cpp",
-                path = "%{ARM_COMPILER_PATH}%/bin/arm-linux-gnueabihf-cpp",
+                path = "%{ARM_COMPILER_PATH}%/bin/arm-rpi-linux-gnueabihf-cpp",
             ),
             tool_path(
                 name = "dwp",
-                path = "%{ARM_COMPILER_PATH}%/bin/arm-linux-gnueabihf-dwp",
+                path = "%{ARM_COMPILER_PATH}%/bin/arm-rpi-linux-gnueabihf-dwp",
             ),
             tool_path(
                 name = "gcc",
-                path = "%{ARM_COMPILER_PATH}%/bin/arm-linux-gnueabihf-gcc",
+                path = "%{ARM_COMPILER_PATH}%/bin/arm-rpi-linux-gnueabihf-gcc",
             ),
             tool_path(
                 name = "gcov",
-                path = "%{ARM_COMPILER_PATH}%/bin/arm-linux-gnueabihf-gcov",
+                path = "%{ARM_COMPILER_PATH}%/bin/arm-rpi-linux-gnueabihf-gcov",
             ),
             tool_path(
                 name = "ld",
-                path = "%{ARM_COMPILER_PATH}%/bin/arm-linux-gnueabihf-ld",
+                path = "%{ARM_COMPILER_PATH}%/bin/arm-rpi-linux-gnueabihf-ld",
             ),
             tool_path(
                 name = "nm",
-                path = "%{ARM_COMPILER_PATH}%/bin/arm-linux-gnueabihf-nm",
+                path = "%{ARM_COMPILER_PATH}%/bin/arm-rpi-linux-gnueabihf-nm",
             ),
             tool_path(
                 name = "objcopy",
-                path = "%{ARM_COMPILER_PATH}%/bin/arm-linux-gnueabihf-objcopy",
+                path = "%{ARM_COMPILER_PATH}%/bin/arm-rpi-linux-gnueabihf-objcopy",
             ),
             tool_path(
                 name = "objdump",
-                path = "%{ARM_COMPILER_PATH}%/bin/arm-linux-gnueabihf-objdump",
+                path = "%{ARM_COMPILER_PATH}%/bin/arm-rpi-linux-gnueabihf-objdump",
             ),
             tool_path(
                 name = "strip",
-                path = "%{ARM_COMPILER_PATH}%/bin/arm-linux-gnueabihf-strip",
+                path = "%{ARM_COMPILER_PATH}%/bin/arm-rpi-linux-gnueabihf-strip",
             ),
         ]
     elif (ctx.attr.cpu == "local"):


### PR DESCRIPTION
PiperOrigin-RevId: 267155769

This cherry-pick is needed to fix the issue #35062.