### PR TITLE
Explicitly set upb repo to avoid gcc 10 build error in old version of…

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -657,6 +657,16 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
     )
 
     tf_http_archive(
+        name = "upb",
+        sha256 = "91fa3fc98538f643904b86660298a26f38259e6a51d79eb6924f8be8bdc9975e",
+        strip_prefix = "upb-a1c2caeb25b21644700b9423da573b1ccddc35a7",
+        urls = [
+            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/protocolbuffers/upb/archive/a1c2caeb25b21644700b9423da573b1ccddc35a7.tar.gz",
+            "https://github.com/protocolbuffers/upb/archive/a1c2caeb25b21644700b9423da573b1ccddc35a7.tar.gz",
+        ],
+    )
+
+    tf_http_archive(
         name = "com_github_nanopb_nanopb",
         sha256 = "18234d9f01b57248472a9bfa65c3379352b5d66c15b0ef1c2b4feece4b5670fe",
         build_file = "@com_github_grpc_grpc//third_party:nanopb.BUILD",


### PR DESCRIPTION
This PR tries to address the issue raised in #39467 where
upb library will trigger stringop-truncation error for gcc 10+

The issue comes from the protobuf/upb library which use strncpy with equal
length. 

To upgrade upb is not straightforward as upb repo was packaged as part of the
grpc. Protobuf will try to implicitly add upb repo if it is not present already:
https://github.com/grpc/grpc/blob/6640651bcff343c905d6fefa7ecab0eb1ba5f984/bazel/grpc_deps.bzl#L266

For that in order to patch upb without updating grpc, we will need to explicitly
include upb repo (so that grpc's upb repo (old version) will not be introduced instead.

This PR fixes #39467.

This PR is related to https://github.com/protocolbuffers/upb/issues/262

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>