### PR TITLE
Pin keras_preprocessing to 1.1.0 instead of accidentally installing 1…

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -57,7 +57,7 @@ REQUIRED_PACKAGES = [
     'gast == 0.2.2',
     'google_pasta >= 0.1.6',
     'keras_applications >= 1.0.8',
-    'keras_preprocessing >= 1.1.0',
+    'keras_preprocessing == 1.1.0',
     'numpy >= 1.16.0, < 2.0',
     'opt_einsum >= 2.3.2',
     'protobuf >= 3.8.0',


### PR DESCRIPTION
….1.1 during test