### PR TITLE
Fix the issue of tf.divide's return value is not a tensor

### DIFF
--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -72,6 +72,7 @@ from __future__ import print_function
 
 import numpy as np
 import six
+import sys
 from six.moves import builtins
 from six.moves import xrange  # pylint: disable=redefined-builtin
 
@@ -438,8 +439,12 @@ def divide(x, y, name=None):
     # override names. Use a dummy class to track the runtime division behavior
     return DivideDelegateWithName(x, name) / y
   else:
+    if not (isinstance(x, ops.Tensor)  or isinstance(y, ops.Tensor)):
+      if sys.version_info.major < 3:
+        return _truediv_python2(x, y)
+      else:
+        return _truediv_python3(x, y)
     return x / y
-
 
 @tf_export("math.multiply", "multiply")
 @dispatch.add_dispatch_support

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -439,8 +439,8 @@ def divide(x, y, name=None):
     # override names. Use a dummy class to track the runtime division behavior
     return DivideDelegateWithName(x, name) / y
   else:
-    # We do conversion here to make sure at least either x or y is a tensor.
-    if not (tensor_util.is_tensor(x) or tensor_util.is_tensor(y)):
+    # We do conversion here to make sure at least x is a tensor.
+    if not tensor_util.is_tensor(x):
       x = ops.convert_to_tensor(x)
     return x / y
 

--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -498,9 +498,8 @@ class DivAndModTest(test_util.TensorFlowTestCase):
   def testWithPythonValue(self):
     # Test case for GitHub issue 39475:
     # https://github.com/tensorflow/tensorflow/issues/39475
-    x = math_ops.divide(5,  2)
+    x = math_ops.divide(5, 2)
     self.assertTrue(isinstance(x, ops.Tensor))
-
 
 @test_util.run_all_in_graph_and_eager_modes
 class DivNoNanTest(test_util.TensorFlowTestCase):

--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -495,6 +495,12 @@ class DivAndModTest(test_util.TensorFlowTestCase):
     # Consistent with desire to get numerator
     self.assertAllEqual(tf_result, expanded_nums)
 
+  def testWithPythonValue(self):
+    # Test case for GitHub issue 39475:
+    # https://github.com/tensorflow/tensorflow/issues/39475
+    x = math_ops.divide(5,  2)
+    self.assertTrue(isinstance(x, ops.Tensor))
+
 
 @test_util.run_all_in_graph_and_eager_modes
 class DivNoNanTest(test_util.TensorFlowTestCase):


### PR DESCRIPTION
This PR fixes the issue of #39475 where tf.divide's return value
is not a tensor in case x, y in divide(x, y) are both primitive python
types.

The reason was that tf.divide relies on implict `x / y`. However,
if both x and y are not tensor, the return value will fall through
python and will not be a tensor.

This PR fixes the issue.

This PR fixes #39475.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>