### PR TITLE
with_values for SparseTensor

### DIFF
--- a/tensorflow/python/framework/sparse_tensor.py
+++ b/tensorflow/python/framework/sparse_tensor.py
@@ -178,6 +178,21 @@ class SparseTensor(internal.NativeObject, composite_tensor.CompositeTensor):
     """
     return self._values
 
+  def with_values(self, new_values):
+    """Returns a copy of `self` with `values` replaced by `new_values`.
+
+    This method produces a new `SparseTensor` that has the same nonzero
+    indices, but updated values.
+
+    Args:
+      new_values: The values of the new `SparseTensor. Needs to have the same
+        shape as the current `.values` `Tensor`.
+
+    Returns:
+      A `SparseTensor` with identical indices but updated values.
+    """
+    return SparseTensor(self._indices, new_values, self._dense_shape)
+
   @property
   def op(self):
     """The `Operation` that produces `values` as an output."""

--- a/tensorflow/python/framework/sparse_tensor.py
+++ b/tensorflow/python/framework/sparse_tensor.py
@@ -182,14 +182,15 @@ class SparseTensor(internal.NativeObject, composite_tensor.CompositeTensor):
     """Returns a copy of `self` with `values` replaced by `new_values`.
 
     This method produces a new `SparseTensor` that has the same nonzero
-    indices, but updated values.
+    `indices` and same `dense_shape`, but updated values.
 
     Args:
-      new_values: The values of the new `SparseTensor. Needs to have the same
-        shape as the current `.values` `Tensor`.
+      new_values: The values of the new `SparseTensor`. Needs to have the same
+        shape as the current `.values` `Tensor`. May have a different type
+        than the current `values`.
 
     Returns:
-      A `SparseTensor` with identical indices but updated values.
+      A `SparseTensor` with identical indices and shape but updated values.
     """
     return SparseTensor(self._indices, new_values, self._dense_shape)
 

--- a/tensorflow/python/framework/sparse_tensor_test.py
+++ b/tensorflow/python/framework/sparse_tensor_test.py
@@ -100,7 +100,7 @@ class SparseTensorTest(test_util.TensorFlowTestCase):
   def testWithValues(self):
       source = sparse_tensor.SparseTensor(
           indices=[[0, 0], [1, 2]], values=[1., 2], dense_shape=[3, 4])
-      new_tensor = tensor.with_values([5.0, 1.0])
+      new_tensor = source.with_values([5.0, 1.0])
       self.assertAllEqual(new_tensor.indices, source.indices)
       self.assertAllEqual(new_tensor.values, [5.0, 1.0])
       self.assertAllEqual(new_tensor.dense_shape, source.dense_shape)

--- a/tensorflow/python/framework/sparse_tensor_test.py
+++ b/tensorflow/python/framework/sparse_tensor_test.py
@@ -97,6 +97,14 @@ class SparseTensorTest(test_util.TensorFlowTestCase):
       self.assertIn(dense.op, sp.consumers())
       self.assertIn(out.op, sp.consumers())
 
+  def testWithValues(self):
+      source = sparse_tensor.SparseTensor(
+          indices=[[0, 0], [1, 2]], values=[1., 2], dense_shape=[3, 4])
+      new_tensor = tensor.with_values([5.0, 1.0])
+      self.assertAllEqual(new_tensor.indices, source.indices)
+      self.assertAllEqual(new_tensor.values, [5.0, 1.0])
+      self.assertAllEqual(new_tensor.dense_shape, source.dense_shape)
+
 
 class ConvertToTensorOrSparseTensorTest(test_util.TensorFlowTestCase):
 

--- a/tensorflow/python/framework/sparse_tensor_test.py
+++ b/tensorflow/python/framework/sparse_tensor_test.py
@@ -24,6 +24,7 @@ import numpy as np
 from tensorflow.python.eager import context
 from tensorflow.python.eager import def_function
 from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import errors
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import sparse_tensor
 from tensorflow.python.framework import tensor_shape
@@ -104,6 +105,10 @@ class SparseTensorTest(test_util.TensorFlowTestCase):
       self.assertAllEqual(new_tensor.indices, source.indices)
       self.assertAllEqual(new_tensor.values, [5.0, 1.0])
       self.assertAllEqual(new_tensor.dense_shape, source.dense_shape)
+
+      # ensure new value's shape is checked
+      with self.assertRaises((errors.InvalidArgumentError, ValueError)):
+        source.with_values([[5.0, 1.0]])
 
 
 class ConvertToTensorOrSparseTensorTest(test_util.TensorFlowTestCase):

--- a/tensorflow/python/framework/sparse_tensor_test.py
+++ b/tensorflow/python/framework/sparse_tensor_test.py
@@ -99,16 +99,16 @@ class SparseTensorTest(test_util.TensorFlowTestCase):
       self.assertIn(out.op, sp.consumers())
 
   def testWithValues(self):
-      source = sparse_tensor.SparseTensor(
-          indices=[[0, 0], [1, 2]], values=[1., 2], dense_shape=[3, 4])
-      new_tensor = source.with_values([5.0, 1.0])
-      self.assertAllEqual(new_tensor.indices, source.indices)
-      self.assertAllEqual(new_tensor.values, [5.0, 1.0])
-      self.assertAllEqual(new_tensor.dense_shape, source.dense_shape)
+    source = sparse_tensor.SparseTensor(
+        indices=[[0, 0], [1, 2]], values=[1., 2], dense_shape=[3, 4])
+    new_tensor = source.with_values([5.0, 1.0])
+    self.assertAllEqual(new_tensor.indices, source.indices)
+    self.assertAllEqual(new_tensor.values, [5.0, 1.0])
+    self.assertAllEqual(new_tensor.dense_shape, source.dense_shape)
 
-      # ensure new value's shape is checked
-      with self.assertRaises((errors.InvalidArgumentError, ValueError)):
-        source.with_values([[5.0, 1.0]])
+    # ensure new value's shape is checked
+    with self.assertRaises((errors.InvalidArgumentError, ValueError)):
+      source.with_values([[5.0, 1.0]])
 
 
 class ConvertToTensorOrSparseTensorTest(test_util.TensorFlowTestCase):

--- a/tensorflow/tools/api/golden/v1/tensorflow.-sparse-tensor.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.-sparse-tensor.pbtxt
@@ -52,4 +52,8 @@ tf_class {
     name: "get_shape"
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
+  member_method {
+    name: "with_values"
+    argspec: "args=[\'self\', \'new_values\'], varargs=None, keywords=None, defaults=None"
+  }
 }

--- a/tensorflow/tools/api/golden/v1/tensorflow.sparse.-sparse-tensor.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.sparse.-sparse-tensor.pbtxt
@@ -49,6 +49,10 @@ tf_class {
     argspec: "args=[\'cls\', \'sparse_tensor_value\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "with_values"
+    argspec: "args=[\'self\', \'new_values\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "get_shape"
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.sparse.-sparse-tensor.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.sparse.-sparse-tensor.pbtxt
@@ -49,11 +49,11 @@ tf_class {
     argspec: "args=[\'cls\', \'sparse_tensor_value\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
-    name: "with_values"
-    argspec: "args=[\'self\', \'new_values\'], varargs=None, keywords=None, defaults=None"
-  }
-  member_method {
     name: "get_shape"
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "with_values"
+    argspec: "args=[\'self\', \'new_values\'], varargs=None, keywords=None, defaults=None"
   }
 }

--- a/tensorflow/tools/api/golden/v2/tensorflow.-sparse-tensor.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.-sparse-tensor.pbtxt
@@ -52,4 +52,8 @@ tf_class {
     name: "get_shape"
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
+  member_method {
+    name: "with_values"
+    argspec: "args=[\'self\', \'new_values\'], varargs=None, keywords=None, defaults=None"
+  }
 }

--- a/tensorflow/tools/api/golden/v2/tensorflow.sparse.-sparse-tensor.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.sparse.-sparse-tensor.pbtxt
@@ -49,6 +49,10 @@ tf_class {
     argspec: "args=[\'cls\', \'sparse_tensor_value\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "with_values"
+    argspec: "args=[\'self\', \'new_values\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "get_shape"
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.sparse.-sparse-tensor.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.sparse.-sparse-tensor.pbtxt
@@ -49,11 +49,11 @@ tf_class {
     argspec: "args=[\'cls\', \'sparse_tensor_value\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
-    name: "with_values"
-    argspec: "args=[\'self\', \'new_values\'], varargs=None, keywords=None, defaults=None"
-  }
-  member_method {
     name: "get_shape"
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
+    name: "with_values"
+    argspec: "args=[\'self\', \'new_values\'], varargs=None, keywords=None, defaults=None"
   }
 }


### PR DESCRIPTION
This provides a `with_values` function for `SparseTensor` in analogy to the `with_values` function of `RaggedTensor`. See #39507