### PR TITLE
[Do not submit/review] Python stack trace pipelining sketch

### DIFF
--- a/tensorflow/c/eager/context_interface.h
+++ b/tensorflow/c/eager/context_interface.h
@@ -27,6 +27,7 @@ limitations under the License.
 #include "tensorflow/core/framework/types.pb.h"
 #include "tensorflow/core/platform/status.h"
 #include "tensorflow/core/platform/tstring.h"
+#include "tensorflow/core/util/stack_trace_base.h"
 
 namespace tensorflow {
 
@@ -100,6 +101,10 @@ class AbstractContextInterface {
   virtual void StartStep() = 0;
   // Destroy the step resource container for a training step.
   virtual void EndStep() = 0;
+
+  virtual void SetStackTrace(std::unique_ptr<StackTraceBase> stack_trace) = 0;
+
+  virtual std::unique_ptr<StackTraceBase> GetStackTrace() = 0;
 
  protected:
   virtual ~AbstractContextInterface() {}

--- a/tensorflow/core/common_runtime/eager/context.h
+++ b/tensorflow/core/common_runtime/eager/context.h
@@ -46,6 +46,7 @@ limitations under the License.
 #include "tensorflow/core/framework/function.h"
 #include "tensorflow/core/platform/env.h"
 #include "tensorflow/core/util/device_name_utils.h"
+#include "tensorflow/core/util/stack_trace_base.h"
 #if !defined(IS_MOBILE_PLATFORM)
 #include "tensorflow/core/distributed_runtime/eager/eager_client.h"
 #include "tensorflow/core/distributed_runtime/rendezvous_mgr_interface.h"
@@ -208,6 +209,14 @@ class EagerContext : public AbstractContextInterface, public core::RefCounted {
 
   // Specify a executor for this thread.
   void SetExecutorForThread(EagerExecutor* executor);
+
+  void SetStackTrace(std::unique_ptr<StackTraceBase> stack_trace) override {
+    stack_trace_ = std::move(stack_trace);
+  }
+
+  std::unique_ptr<StackTraceBase> GetStackTrace() override {
+    return std::move(stack_trace_);
+  }
 
   const std::shared_ptr<std::vector<DeviceType>> prioritized_device_type_list()
       const {
@@ -713,6 +722,9 @@ class EagerContext : public AbstractContextInterface, public core::RefCounted {
   // Function that will be invoked in destructor to deallocate resources related
   // to this context.
   std::function<void()> resource_deallocator_ = nullptr;
+
+  std::unique_ptr<StackTraceBase> stack_trace_;
+  OpaquePythonStackTrace* python_stack_trace_ = nullptr;
 };
 
 inline EagerContext* ContextFromInterface(AbstractContextInterface* context) {

--- a/tensorflow/core/common_runtime/eager/execute.cc
+++ b/tensorflow/core/common_runtime/eager/execute.cc
@@ -70,6 +70,8 @@ limitations under the License.
 #include "tensorflow/core/platform/mutex.h"
 #include "tensorflow/core/util/ptr_util.h"
 #include "tensorflow/core/common_runtime/eager/eager_op_rewrite_registry.h"
+#include "
+tensorflow/python/util/stack_trace.h"
 
 namespace tensorflow {
 
@@ -1171,7 +1173,8 @@ Status EagerKernelExecute(
   // acquires a lock) and we can't recover from errors anyway.
   ScopedStepContainer* container = ctx->StepContainer();
   TF_RETURN_IF_ERROR(kernel->Run(container, inputs, &outputs,
-                                 cancellation_manager, remote_func_params));
+                                 cancellation_manager, remote_func_params,
+                                 ctx->GetStackTrace()));
   if (graph_collector != nullptr) {
     CollectGraphs(ctx);
   }
@@ -1394,7 +1397,8 @@ void EagerKernelExecuteAsync(
         DCHECK_EQ(num_outputs, outputs->size());
         wrapped_done(GetKernelOutputs(outputs.get(), num_outputs, retvals, ctx,
                                       kernel_raw));
-      });
+      },
+      ctx->GetStackTrace());
 }
 }  // namespace
 

--- a/tensorflow/core/distributed_runtime/eager/remote_copy_node.cc
+++ b/tensorflow/core/distributed_runtime/eager/remote_copy_node.cc
@@ -109,7 +109,7 @@ Status RemoteCopyNode::RunLocalSend(EagerOperation* op) {
 
   return kernel->Run(/*step_container=*/nullptr, args, /*outputs=*/nullptr,
                      /*cancellation_manager=*/nullptr,
-                     /*remote_func_params=*/absl::nullopt);
+                     /*remote_func_params=*/absl::nullopt, nullptr);
 }
 
 void RemoteCopyNode::StartSend() {
@@ -193,7 +193,7 @@ Status RemoteCopyNode::RunLocalRecv(EagerOperation* op,
   EagerKernelArgs args;
   return kernel->Run(/*step_container*/ nullptr, args, outputs,
                      captured_state_->recv_cancellation(),
-                     /*remote_func_params=*/absl::nullopt);
+                     /*remote_func_params=*/absl::nullopt, nullptr);
 }
 
 void RemoteCopyNode::RunRemoteRecv(EagerOperation* op, StatusCallback done) {

--- a/tensorflow/core/framework/op_kernel.h
+++ b/tensorflow/core/framework/op_kernel.h
@@ -54,6 +54,9 @@ limitations under the License.
 #include "tensorflow/core/platform/thread_annotations.h"
 #include "tensorflow/core/platform/types.h"
 #include "tensorflow/core/protobuf/config.pb.h"
+#include "tensorflow/core/util/stack_trace_base.h"
+
+class OpaquePythonStackTrace;
 
 namespace Eigen {
 struct ThreadPoolDevice;
@@ -592,6 +595,12 @@ class OpKernelContext {
   // The Params struct is passed in to initialize an OpKernelContext,
   // and must outlive the OpKernelContext.
   struct Params {
+    Params() {}
+
+    // TODO(kkb@): There is a place that copies Params.  But not possible with
+    // std::unique_ptr member.  Figure out what to do there.
+    Params(const Params& p) {}
+
     ~Params() { delete eigen_gpu_device; }
 
     // The step being executed.
@@ -707,6 +716,8 @@ class OpKernelContext {
     // For implementing `OpKernelContext::output_required()`. If null, all
     // outputs are required.
     bool* outputs_required_array = nullptr;
+
+    std::unique_ptr<StackTraceBase> stack_trace = nullptr;
   };
 
   // params must outlive the OpKernelContext.


### PR DESCRIPTION
This is a very rough sketch of Python stack trace eager pipelining.  It's not compilable.

Remaining work for eager:
1. Our fast Python stack trace class was landed https://github.com/tensorflow/tensorflow/commit/0e517a6fc0dc40926f68f4b7bf9c0337e3bc55a9 but reverted https://github.com/tensorflow/tensorflow/commit/9ab73c7bd10158e9ba4570ad331497254b05aa75 due to a linking issue.  Need to debug and land.
2. Need to clean up this CL and land.  Also, in this CL the stack trace is saved at `AbstractContextInterface` class but a better place is `AbstractOperationInterface`.  

Remaining work for graph:
1. Expand ExperimentalDebugInfo proto https://github.com/tensorflow/tensorflow/blob/b1e813e2ec9634ec0e6562b836e372e393f3de43/tensorflow/core/framework/node_def.proto#L66 to support saving Python stack trace.
2. Populate those fields when we construct NodeDef during graph building