### PR TITLE
Build tensorflow/lite/c/*.cc in TensorFlow Lite Makefile

### DIFF
--- a/tensorflow/lite/tools/make/Makefile
+++ b/tensorflow/lite/tools/make/Makefile
@@ -118,6 +118,7 @@ CORE_CC_ALL_SRCS := \
 $(wildcard tensorflow/lite/*.cc) \
 $(wildcard tensorflow/lite/*.c) \
 $(wildcard tensorflow/lite/c/*.c) \
+$(wildcard tensorflow/lite/c/*.cc) \
 $(wildcard tensorflow/lite/core/*.cc) \
 $(wildcard tensorflow/lite/core/api/*.cc) \
 $(wildcard tensorflow/lite/experimental/resource/*.cc) \


### PR DESCRIPTION
Hello,

I added missing `tensorflow/lite/c/*.cc` to build files of TensorFlow Lite Makefile.
This is needed to build `tensorflow/lite/c/c_api.cc`, which includes TensorFlow Lite C API implementations.
