### PR TITLE
Allow single element padding_values to be broadcasted to a structure for tf.data.Dataset.padded_batch

### DIFF
--- a/tensorflow/python/data/kernel_tests/padded_batch_test.py
+++ b/tensorflow/python/data/kernel_tests/padded_batch_test.py
@@ -306,6 +306,22 @@ class PaddedBatchTest(test_base.DatasetTestBase, parameterized.TestCase):
     self.assertDatasetProduces(
         ds, expected_output=[[0.0, 1.0, 2.0, 3.0, 4.0]])
 
+  @combinations.generate(test_base.default_test_combinations())
+  def testDefaultPaddedValueShapes(self):
+
+    def fill(x):
+      return array_ops.fill([x], x)
+
+    dataset = dataset_ops.Dataset.zip((
+        dataset_ops.Dataset.from_tensor_slices([1, 2, 3, 4]).map(fill),
+        dataset_ops.Dataset.from_tensor_slices([1, 2, 3, 4]).map(fill)))
+    dataset = dataset.padded_batch(batch_size=2, padding_values=-1)
+    self.assertDatasetProduces(
+        dataset,
+        expected_output=[
+            ([[1, -1], [2, 2]], [[1, -1], [2, 2]]),
+            ([[3, 3, 3, -1], [4, 4, 4, 4]], [[3, 3, 3, -1], [4, 4, 4, 4]])])
+
 
 if __name__ == '__main__':
   test.main()

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -4027,6 +4027,12 @@ class PaddedBatchDataset(UnaryDataset):
     self._padded_shapes = nest.pack_sequence_as(input_shapes,
                                                 flat_padded_shapes_as_tensors)
 
+    # If padding_values is a single element and input_shapes is a structure,
+    # "broadcast" padding_values to the same structure as input_shapes.
+    if nest.is_sequence(input_shapes) and not nest.is_sequence(padding_values):
+      padding_values = nest.map_structure(
+          lambda _: padding_values, input_shapes)
+
     self._padding_values = nest.map_structure_up_to(
         input_shapes, _padding_value_to_tensor, padding_values,
         get_legacy_output_types(input_dataset))

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -1461,6 +1461,16 @@ class DatasetV2(tracking_base.Trackable, composite_tensor.CompositeTensor):
     >>> list(dataset.as_numpy_iterator())
     [(array([[ 1,  2,  3, -1], [ 4,  5, -1, -1]], dtype=int32),
       array([[ 10, 100], [ 11,  12]], dtype=int32))]
+    >>> # Pad with a single value and multiple components.
+    >>> E = tf.data.Dataset.zip((A, A)).padded_batch(2, padding_values=-1)
+    >>> for element in E.as_numpy_iterator():
+    ...   print(element)
+    (array([[ 1, -1],
+           [ 2,  2]], dtype=int32), array([[ 1, -1],
+           [ 2,  2]], dtype=int32))
+    (array([[ 3,  3,  3, -1],
+           [ 4,  4,  4,  4]], dtype=int32), array([[ 3,  3,  3, -1],
+           [ 4,  4,  4,  4]], dtype=int32))
 
     See also `tf.data.experimental.dense_to_sparse_batch`, which combines
     elements that may have different shapes into a `tf.sparse.SparseTensor`.
@@ -1479,7 +1489,12 @@ class DatasetV2(tracking_base.Trackable, composite_tensor.CompositeTensor):
         `tf.Tensor`, representing the padding values to use for the respective
         components. None represents that the nested structure should be padded
         with default values.  Defaults are `0` for numeric types and the empty
-        string for string types.
+        string for string types. The `padding_values` should have the
+        same structure as the input dataset. If `padding_values` is a single
+        element and the input dataset has multiple components, then the same
+        `padding_values` will be used to pad every component of the dataset.
+        If `padding_values` is a scalar, then its value will be broadcasted
+        to match the shape of each component.
       drop_remainder: (Optional.) A `tf.bool` scalar `tf.Tensor`, representing
         whether the last batch should be dropped in the case it has fewer than
         `batch_size` elements; the default behavior is not to drop the smaller


### PR DESCRIPTION
This PR is a follow up based on comment in https://github.com/tensorflow/tensorflow/issues/35900#issuecomment-576969545

In #35900, the issue was raised where if padding_values is a single elment
and the dataset has a structured shape, then tf.data.Dataset.padded_batch
will return and error.

This PR adds the support to "broadcast" padding_values to match the same
structure as the dataset, which could be convenient in many cases (avoid
repeat the padding_values into the stucture manually).

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
