### PR TITLE
Fix a bug that the output of `tf.sparse.fill_empty_rows` may not be ordered

### DIFF
--- a/tensorflow/core/kernels/sparse_fill_empty_rows_op.cc
+++ b/tensorflow/core/kernels/sparse_fill_empty_rows_op.cc
@@ -118,7 +118,7 @@ class SparseFillEmptyRowsOp : public OpKernel {
       return;
     }
 
-    bool indices_is_order = true;
+    bool rows_are_ordered = true;
     int64 last_indices_row = 0;
     std::vector<int64> csr_offset(dense_rows, 0);
     for (int i = 0; i < N; ++i) {
@@ -127,7 +127,7 @@ class SparseFillEmptyRowsOp : public OpKernel {
                   errors::InvalidArgument("indices(", i, ", 0) is invalid: ",
                                           row, " >= ", dense_rows));
       ++csr_offset[row];
-      indices_is_order = indices_is_order & (row >= last_indices_row);
+      rows_are_ordered = rows_are_ordered & (row >= last_indices_row);
       last_indices_row = row;
     }
     bool all_rows_full = true;
@@ -151,7 +151,7 @@ class SparseFillEmptyRowsOp : public OpKernel {
       }
     }
 
-    if (all_rows_full && indices_is_order) {
+    if (all_rows_full && rows_are_ordered) {
       context->set_output(kOutputIndicesOutput, indices_t);
       context->set_output(kOutputValuesOutput, values_t);
       if (reverse_index_map) {

--- a/tensorflow/python/kernel_tests/sparse_ops_test.py
+++ b/tensorflow/python/kernel_tests/sparse_ops_test.py
@@ -585,6 +585,22 @@ class SparseFillEmptyRowsTest(test_util.TensorFlowTestCase):
       self.assertAllEqual(output.dense_shape, [2, 6])
       self.assertAllEqual(empty_row_indicator_out, np.zeros(2).astype(np.bool))
 
+  def testNoEmptyRowsAndUnordered(self):
+    with test_util.force_cpu():
+      sp_input = sparse_tensor.SparseTensor(
+          indices=np.array([[1, 2], [1, 3], [0, 1], [0, 3]]),
+          values=np.array([1, 3, 2, 4]),
+          dense_shape=np.array([2, 5]))
+      sp_output, empty_row_indicator = (sparse_ops.sparse_fill_empty_rows(
+          sp_input, -1))
+
+      output, empty_row_indicator_out = self.evaluate(
+          [sp_output, empty_row_indicator])
+
+      self.assertAllEqual(output.indices, [[0, 1], [0, 3], [1, 2], [1, 3]])
+      self.assertAllEqual(output.values, [2, 4, 1, 3])
+      self.assertAllEqual(output.dense_shape, [2, 5])
+      self.assertAllEqual(empty_row_indicator_out, np.zeros(2).astype(np.bool))      
 
 class SparseAddTest(test_util.TensorFlowTestCase):
 


### PR DESCRIPTION
This is a PR from JIZHI Team & TaiJi AI platform in Tencent.

This pull request is for tf 2.2.0, to fix a bug that the `sp_ordered_output ` of `tf.sparse.fill_empty_rows` is not ordered when the sp_input is unordered and all rows of the sp_input are not empty.

Referring to the [docs](https://www.tensorflow.org/api_docs/python/tf/sparse/fill_empty_rows), the output of `tf.sparse.fill_empty_rows` named `sp_ordered_output` is ordered. e.g.
```python
sp_ids = tf.SparseTensor(indices=[[1, 2], [1, 3], [0, 1], [0, 3]],
                         values=[2, 1, 1, 1],
                         dense_shape=[3, 4])
sp_ids, _ = tf.sparse.fill_empty_rows(sp_ids, default_value=0)
print(sp_ids)
```
Output:
```
SparseTensor(
  indices=tf.Tensor(
  [[0 1]
   [0 3]
   [1 2]
   [1 3]
   [2 0]], shape=(5, 2), dtype=int64), 
  values=tf.Tensor([1 1 2 1 0], shape=(5,), dtype=int32), 
  dense_shape=tf.Tensor([3 4], shape=(2,), dtype=int64)
)
```

However, the `sp_ordered_output` is not ordered when the sp_input is unordered and all rows of the sp_input are not empty. e.g.
```python
sp_ids = tf.SparseTensor(indices=[[1, 2], [1, 3], [0, 1], [0, 3]],
                         values=[2, 1, 1, 1],
                         dense_shape=[2, 4])
sp_ids, _ = tf.sparse.fill_empty_rows(sp_ids, default_value=0)
print(sp_ids)
```
Output:
```
SparseTensor(
  indices=tf.Tensor(
  [[1 2]
   [1 3]
   [0 1]
   [0 3]], shape=(4, 2), dtype=int64), 
  values=tf.Tensor([2 1 1 1], shape=(4,), dtype=int32), 
  dense_shape=tf.Tensor([2 4], shape=(2,), dtype=int64)
)
```

So we add a judgment for whether the `sp_input` is ordered, and turns to make a new ordered output tensor instead of returning the original one.

Thank you for your time on reviewing this PR.
