### PR TITLE
[tflite] nnapi delegate max_delegated_partitions=0

### DIFF
--- a/tensorflow/lite/tools/delegates/nnapi_delegate_provider.cc
+++ b/tensorflow/lite/tools/delegates/nnapi_delegate_provider.cc
@@ -140,7 +140,7 @@ TfLiteDelegatePtr NnapiDelegateProvider::CreateTfLiteDelegate(
       options.execution_preference = execution_preference;
     }
     int max_delegated_partitions = params.Get<int>("max_delegated_partitions");
-    if (max_delegated_partitions > 0) {
+    if (max_delegated_partitions >= 0) {
       options.max_number_delegated_partitions = max_delegated_partitions;
     }
     delegate = evaluation::CreateNNAPIDelegate(options);


### PR DESCRIPTION
make it possible to specify `max_delegated_partitions=0`. In the
original code, when `--max_delegated_partitions=0` (or less than 0)
is specified, it's ignored. That is, the maximum number of
partitions is set to 3 (nnapi delegate's default number).