### PR TITLE
Update tpu_strategy.py; replacing np.rank with np.ndim

### DIFF
--- a/tensorflow/python/distribute/tpu_strategy.py
+++ b/tensorflow/python/distribute/tpu_strategy.py
@@ -897,7 +897,7 @@ class TPUExtended(distribute_lib.StrategyExtendedV1):
           if tensor_util.is_tensor(input_tensor):
             rank = input_tensor.get_shape().rank
           else:
-            rank = np.rank(input_tensor)
+            rank = np.ndim(input_tensor)
           maximum_shape = tensor_shape.TensorShape([None] * rank)
           maximum_shapes.append(maximum_shape)
         maximum_shapes = nest.pack_sequence_as(replicate_inputs[0],


### PR DESCRIPTION
np.rank[DEP] -> np.ndim
**Ref**: https://numpy.org/doc/stable/release.html#rank-function

**Fixing this error:**

/usr/local/lib/python3.6/dist-packages/tensorflow/python/distribute/tpu_strategy.py:174 run  **
        return self.extended.tpu_run(fn, args, kwargs, options)
/usr/local/lib/python3.6/dist-packages/tensorflow/python/distribute/tpu_strategy.py:867 tpu_run
        return func(args, kwargs)
/usr/local/lib/python3.6/dist-packages/tensorflow/python/distribute/tpu_strategy.py:915 tpu_function
        rank = np.rank(input_tensor)

AttributeError: module 'numpy' has no attribute 'rank'