### PR TITLE
Fix sha256sum issue of mkl_dnn/oneDNN

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -216,7 +216,7 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
         sha256 = "a0211aeb5e7dad50b97fa5dffc1a2fe2fe732572d4164e1ee8750a2ede43fbec",
         strip_prefix = "oneDNN-0.21.3",
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/oneapi-src/oneDNN/archive/v0.21.3.tar.gz"
+            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/oneapi-src/oneDNN/archive/v0.21.3.tar.gz",
             "https://github.com/oneapi-src/oneDNN/archive/v0.21.3.tar.gz",
         ],
     )

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -213,11 +213,11 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
     tf_http_archive(
         name = "mkl_dnn",
         build_file = clean_dep("//third_party/mkl_dnn:mkldnn.BUILD"),
-        sha256 = "31e78581e59d7e60d4becaba3834fc6a5bf2dccdae3e16b7f70d89ceab38423f",
-        strip_prefix = "mkl-dnn-0.21.3",
+        sha256 = "a0211aeb5e7dad50b97fa5dffc1a2fe2fe732572d4164e1ee8750a2ede43fbec",
+        strip_prefix = "oneDNN-0.21.3",
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/intel/mkl-dnn/archive/v0.21.3.tar.gz",
-            "https://github.com/intel/mkl-dnn/archive/v0.21.3.tar.gz",
+            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/oneapi-src/oneDNN/archive/v0.21.3.tar.gz"
+            "https://github.com/oneapi-src/oneDNN/archive/v0.21.3.tar.gz",
         ],
     )
 


### PR DESCRIPTION
This PR tries to address the issue raised in #39696 where
the sha256 of the exiting workspace.bzl archive for mkl_dnn
does not match between mirrored one and the github one.

The issue comes from the fact that mkl_dnn has been renamed
to oneDNN repo, and github repackaged the archive.
The original mkl_dnn now alias to oneDNN (with re-archive).

This PR adjust the download link to go directly to
oneDNN so that the sha256 matches.

This PR fixes #39696.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>