### PR TITLE
Minor change to fix #39462

### DIFF
--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -2261,7 +2261,7 @@ class ReduceLROnPlateau(Callback):
       elif not self.in_cooldown():
         self.wait += 1
         if self.wait >= self.patience:
-          old_lr = float(K.get_value(self.model.optimizer.lr))
+          old_lr = K.get_value(self.model.optimizer.lr)
           if old_lr > self.min_lr:
             new_lr = old_lr * self.factor
             new_lr = max(new_lr, self.min_lr)


### PR DESCRIPTION
#39462

Casting to float here adds significant digits to the end of the value so that when compared to our supplied min_lr, the two will never be equal. Internally the LR exists in it's proper form without the trailing sig digits, only after casting is the value altered. Removing this casting here ensures this does not happen and now we can properly see if min_lr has been reached.