### PR TITLE
Fix #39462

### DIFF
--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -2261,8 +2261,8 @@ class ReduceLROnPlateau(Callback):
       elif not self.in_cooldown():
         self.wait += 1
         if self.wait >= self.patience:
-          old_lr = float(K.get_value(self.model.optimizer.lr))
-          if old_lr > self.min_lr:
+          old_lr = K.get_value(self.model.optimizer.lr)
+          if old_lr > np.float32(self.min_lr):
             new_lr = old_lr * self.factor
             new_lr = max(new_lr, self.min_lr)
             K.set_value(self.model.optimizer.lr, new_lr)


### PR DESCRIPTION
When using `get_value` to retrieve the value for LR, we receive a np.float32. However when we cast this to a python float, there are unwanted trailing significant digits added to our value that causes old_lr to never be exactly equal to our supplied min_lr, despite it being equal internally.

By leaving old_lr as it's original np.float32, and by casting our supplied min_lr to np.float32, we are now able to properly compare the values and the block of code should not be executed again after lr has been set to min_lr.