### PR TITLE
fix GetOrCreateExecutors executors_.emplace a lot of keys to executors_

### DIFF
--- a/tensorflow/core/common_runtime/direct_session.cc
+++ b/tensorflow/core/common_runtime/direct_session.cc
@@ -1517,8 +1517,6 @@ Status DirectSession::GetOrCreateExecutors(
     auto it = executors_.find(sorted_key);
     if (it != executors_.end()) {
       *executors_and_keys = it->second.get();
-      // Insert this under the original key.
-      executors_.emplace(key, it->second);
       return Status::OK();
     }
   }


### PR DESCRIPTION
The function `GetOrCreateExecutors` emplaces a lot of keys to `executors_`, which leads to memory usage a lot in TF serving.

```
  // See if we already have the executors for this run.
  {
    mutex_lock l(executor_lock_);
    auto it = executors_.find(sorted_key);
    if (it != executors_.end()) {
      *executors_and_keys = it->second.get();

      // Insert this under the original key.  
      executors_.emplace(key, it->second);  // need delete
      return Status::OK();
    }
  }
```

If number of input features is big, then `inputs` parameter `GetOrCreateExecutors` could be many kinds order.

please check attached file

[serving_nommap.0042.heap.base0007.pdf](https://github.com/tensorflow/tensorflow/files/4661274/serving_nommap.0042.heap.base0007.pdf)
