### PR TITLE
[Intel MKL] Vectorize FP32/BF16 RandomUniform process

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -2411,6 +2411,7 @@ tf_kernel_library(
     prefix = "candidate_sampler_ops",
     deps = [
         ":range_sampler",
+        "//tensorflow/core:framework",
         "//tensorflow/core:lib",
     ],
 )
@@ -2421,9 +2422,9 @@ cc_library(
     hdrs = ["range_sampler.h"],
     visibility = ["//visibility:private"],
     deps = [
-        "//tensorflow/core:framework",
         "//tensorflow/core:lib",
         "//tensorflow/core:lib_internal",
+        "//tensorflow/core/framework:numeric_types",
     ],
 )
 
@@ -2433,6 +2434,7 @@ tf_cc_test(
     srcs = ["range_sampler_test.cc"],
     deps = [
         ":range_sampler",
+        "//tensorflow/core:framework",
         "//tensorflow/core:lib",
         "//tensorflow/core:test",
         "//tensorflow/core:test_main",

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -2424,6 +2424,7 @@ cc_library(
     deps = [
         "//tensorflow/core:lib",
         "//tensorflow/core:lib_internal",
+        "//tensorflow/core:framework",
     ],
 )
 

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -2411,7 +2411,6 @@ tf_kernel_library(
     prefix = "candidate_sampler_ops",
     deps = [
         ":range_sampler",
-        "//tensorflow/core:framework",
         "//tensorflow/core:lib",
     ],
 )
@@ -2422,9 +2421,9 @@ cc_library(
     hdrs = ["range_sampler.h"],
     visibility = ["//visibility:private"],
     deps = [
+        "//tensorflow/core:framework",
         "//tensorflow/core:lib",
         "//tensorflow/core:lib_internal",
-        "//tensorflow/core:framework",
     ],
 )
 
@@ -2434,7 +2433,6 @@ tf_cc_test(
     srcs = ["range_sampler_test.cc"],
     deps = [
         ":range_sampler",
-        "//tensorflow/core:framework",
         "//tensorflow/core:lib",
         "//tensorflow/core:test",
         "//tensorflow/core:test_main",

--- a/tensorflow/core/kernels/parameterized_truncated_normal_op.cc
+++ b/tensorflow/core/kernels/parameterized_truncated_normal_op.cc
@@ -190,8 +190,11 @@ struct TruncatedNormalFunctor<CPUDevice, T> {
             // sampling.
             // Simply allocate Uniform::kResultElementCount for the two arrays
             // since they are only used by UniformDistribution.
-            Eigen::array<T, size> z;
-            Eigen::array<T, size> g;
+            OP_REQUIRES(ctx, size == Uniform::kResultElementCount,
+                        errors::InvalidArgument(
+                            "Incompatible UniformDistribution size."));
+            Eigen::array<T, Uniform::kResultElementCount> z;
+            Eigen::array<T, Uniform::kResultElementCount> g;
 
             // NOTE(ringwalt): These loops seem to only generate packed AVX
             // instructions for float32.

--- a/tensorflow/core/kernels/parameterized_truncated_normal_op.cc
+++ b/tensorflow/core/kernels/parameterized_truncated_normal_op.cc
@@ -87,9 +87,10 @@ struct TruncatedNormalFunctor<CPUDevice, T> {
       Normal normal_dist;
 
       // Vectorized intermediate calculations for uniform rejection sampling.
-      // We always generate at most 4 samples.
-      Eigen::array<T, 4> z;
-      Eigen::array<T, 4> g;
+      const int length =
+          std::max(Uniform::kResultElementCount, Normal::kResultElementCount);
+      Eigen::array<T, length> z;
+      Eigen::array<T, length> g;
 
       for (int64 b = start_batch; b < limit_batch; ++b) {
         // We are passed a flat array for each of the parameter tensors.

--- a/tensorflow/core/kernels/parameterized_truncated_normal_op.cc
+++ b/tensorflow/core/kernels/parameterized_truncated_normal_op.cc
@@ -190,8 +190,8 @@ struct TruncatedNormalFunctor<CPUDevice, T> {
             // sampling.
             // Simply allocate Uniform::kResultElementCount for the two arrays
             // since they are only used by UniformDistribution.
-            Eigen::array<T, Uniform::kResultElementCount> z;
-            Eigen::array<T, Uniform::kResultElementCount> g;
+            Eigen::array<T, size> z;
+            Eigen::array<T, size> g;
 
             // NOTE(ringwalt): These loops seem to only generate packed AVX
             // instructions for float32.

--- a/tensorflow/core/kernels/random_binomial_op.cc
+++ b/tensorflow/core/kernels/random_binomial_op.cc
@@ -183,10 +183,6 @@ struct RandomBinomialFunctor<CPUDevice, T, U> {
     // We have B1 * ... * Bk samples per batch member we need.
     auto DoWork = [num_batches, samples_per_batch, &bcast, &counts, &probs,
                    &gen, &output](int start_output, int limit_output) {
-      // Vectorized intermediate calculations for uniform rejection sampling.
-      // We always generate at most 4 samples.
-      Eigen::array<T, 4> z;
-      Eigen::array<T, 4> g;
       const bool should_bcast = bcast.IsBroadcastingRequired();
       const auto& counts_batch_indices = bcast.x_batch_indices();
       const auto& probs_batch_indices = bcast.y_batch_indices();

--- a/tensorflow/core/kernels/random_op.cc
+++ b/tensorflow/core/kernels/random_op.cc
@@ -344,7 +344,7 @@ class RandomGammaOp : public OpKernel {
           .HostMemory("shape")                                                 \
           .TypeConstraint<TYPE>("dtype"),                                      \
       PhiloxRandomOp<CPUDevice, random::UniformDistribution<                   \
-                                    random::PhiloxRandom, TYPE>>);             \
+                                    random::PhiloxRandom, TYPE, true>>);       \
   REGISTER_KERNEL_BUILDER(                                                     \
       Name("RandomStandardNormal")                                             \
           .Device(DEVICE_CPU)                                                  \

--- a/tensorflow/core/kernels/random_op_cpu.h
+++ b/tensorflow/core/kernels/random_op_cpu.h
@@ -86,7 +86,7 @@ struct FillPhiloxRandomTask<Distribution, false> {
                   int64 start_group, int64 limit_group, Distribution dist) {
     const int kGroupSize = Distribution::kResultElementCount;
 
-    gen.Skip(start_group);
+    gen.Skip(start_group * kGroupSize / gen.kResultElementCount);
     int64 offset = start_group * kGroupSize;
 
     // First fill all the full-size groups
@@ -166,9 +166,8 @@ void FillPhiloxRandom<CPUDevice, Distribution>::operator()(
 
   int64 total_group_count = (size + kGroupSize - 1) / kGroupSize;
 
-  const int kGroupCost = random::PhiloxRandom::kResultElementCount *
-                             random::PhiloxRandom::kElementCost +
-                         kGroupSize * Distribution::kElementCost;
+  const int kGroupCost = kGroupSize * (random::PhiloxRandom::kElementCost +
+                                       Distribution::kElementCost);
   Shard(worker_threads.num_threads, worker_threads.workers, total_group_count,
         kGroupCost,
         [&gen, data, size, dist](int64 start_group, int64 limit_group) {

--- a/tensorflow/core/kernels/random_op_cpu.h
+++ b/tensorflow/core/kernels/random_op_cpu.h
@@ -166,9 +166,9 @@ void FillPhiloxRandom<CPUDevice, Distribution>::operator()(
 
   int64 total_group_count = (size + kGroupSize - 1) / kGroupSize;
 
-  const int kGroupCost =
-      random::PhiloxRandom::kResultElementCount *
-      (random::PhiloxRandom::kElementCost + Distribution::kElementCost);
+  const int kGroupCost = random::PhiloxRandom::kResultElementCount *
+                             random::PhiloxRandom::kElementCost +
+                         kGroupSize * Distribution::kElementCost;
   Shard(worker_threads.num_threads, worker_threads.workers, total_group_count,
         kGroupCost,
         [&gen, data, size, dist](int64 start_group, int64 limit_group) {

--- a/tensorflow/core/kernels/random_op_cpu.h
+++ b/tensorflow/core/kernels/random_op_cpu.h
@@ -86,7 +86,13 @@ struct FillPhiloxRandomTask<Distribution, false> {
                   int64 start_group, int64 limit_group, Distribution dist) {
     const int kGroupSize = Distribution::kResultElementCount;
 
-    gen.Skip(start_group * kGroupSize / gen.kResultElementCount);
+    // Decide skip strides according to different kResultElementCount:
+    // * `1 = (4 + 3) / 4` for normal Distribution.
+    // * `1 = (2 + 3) / 4` for double/int64 Distribution.
+    // * `4 = (16 + 3) / 4` for vecotorized float/bfloat16 Distribution.
+    const int skip_strides =
+        (kGroupSize + gen.kResultElementCount - 1) / gen.kResultElementCount;
+    gen.Skip(start_group * skip_strides);
     int64 offset = start_group * kGroupSize;
 
     // First fill all the full-size groups

--- a/tensorflow/core/kernels/random_op_cpu.h
+++ b/tensorflow/core/kernels/random_op_cpu.h
@@ -89,7 +89,7 @@ struct FillPhiloxRandomTask<Distribution, false> {
     // Decide skip strides according to different kResultElementCount:
     // * `1 = (4 + 3) / 4` for normal Distribution.
     // * `1 = (2 + 3) / 4` for double/int64 Distribution.
-    // * `4 = (16 + 3) / 4` for vecotorized float/bfloat16 Distribution.
+    // * `4 = (16 + 3) / 4` for vectorized float/bfloat16 Distribution.
     const int skip_strides =
         (kGroupSize + gen.kResultElementCount - 1) / gen.kResultElementCount;
     gen.Skip(start_group * skip_strides);

--- a/tensorflow/core/kernels/random_op_test.cc
+++ b/tensorflow/core/kernels/random_op_test.cc
@@ -37,41 +37,41 @@ Tensor VecShape(int64 v) {
   }
 }
 
-Graph* RandomUniform(int64 n) {
+Graph* RandomUniform(int64 n, DataType dtype) {
   Graph* g = new Graph(OpRegistry::Global());
-  test::graph::RandomUniform(g, test::graph::Constant(g, VecShape(n)),
-                             DT_FLOAT);
+  test::graph::RandomUniform(g, test::graph::Constant(g, VecShape(n)), dtype);
   return g;
 }
 
-Graph* RandomNormal(int64 n) {
+Graph* RandomNormal(int64 n, DataType dtype) {
   Graph* g = new Graph(OpRegistry::Global());
-  test::graph::RandomGaussian(g, test::graph::Constant(g, VecShape(n)),
-                              DT_FLOAT);
+  test::graph::RandomGaussian(g, test::graph::Constant(g, VecShape(n)), dtype);
   return g;
 }
 
-Graph* TruncatedNormal(int64 n) {
+Graph* TruncatedNormal(int64 n, DataType dtype) {
   Graph* g = new Graph(OpRegistry::Global());
-  test::graph::TruncatedNormal(g, test::graph::Constant(g, VecShape(n)),
-                               DT_FLOAT);
+  test::graph::TruncatedNormal(g, test::graph::Constant(g, VecShape(n)), dtype);
   return g;
 }
 
-#define BM_RNG(DEVICE, RNG)                                   \
-  void BM_##DEVICE##_##RNG(int iters, int arg) {              \
+#define BM_RNG(DEVICE, RNG, DTYPE)                            \
+  void BM_##DEVICE##_##RNG##_##DTYPE(int iters, int arg) {    \
     testing::ItemsProcessed(static_cast<int64>(iters) * arg); \
-    test::Benchmark(#DEVICE, RNG(arg)).Run(iters);            \
+    test::Benchmark(#DEVICE, RNG(arg, DTYPE)).Run(iters);     \
   }                                                           \
-  BENCHMARK(BM_##DEVICE##_##RNG)->Range(1 << 20, 8 << 20);
+  BENCHMARK(BM_##DEVICE##_##RNG##_##DTYPE)->Range(1 << 20, 8 << 20);
 
-BM_RNG(cpu, RandomUniform);
-BM_RNG(cpu, RandomNormal);
-BM_RNG(cpu, TruncatedNormal);
+BM_RNG(cpu, RandomUniform, DT_FLOAT);
+BM_RNG(cpu, RandomUniform, DT_BFLOAT16);
+BM_RNG(cpu, RandomNormal, DT_FLOAT);
+BM_RNG(cpu, TruncatedNormal, DT_FLOAT);
 
-BM_RNG(gpu, RandomUniform);
-BM_RNG(gpu, RandomNormal);
-BM_RNG(gpu, TruncatedNormal);
+#ifdef GOOGLE_CUDA
+BM_RNG(gpu, RandomUniform, DT_FLOAT);
+BM_RNG(gpu, RandomNormal, DT_FLOAT);
+BM_RNG(gpu, TruncatedNormal, DT_FLOAT);
+#endif
 
 Tensor VecAlphas(int64 n) {
   Tensor alphas(DT_DOUBLE, TensorShape({n}));

--- a/tensorflow/core/lib/random/BUILD
+++ b/tensorflow/core/lib/random/BUILD
@@ -40,7 +40,7 @@ cc_library(
     deps = [
         ":exact_uniform_int",
         ":philox_random",
-        "//tensorflow/core:framework",
+        "//tensorflow/core/framework:numeric_types",
         "//tensorflow/core/lib/bfloat16",
         "//tensorflow/core/lib/gtl:array_slice",
         "//tensorflow/core/platform:logging",

--- a/tensorflow/core/lib/random/BUILD
+++ b/tensorflow/core/lib/random/BUILD
@@ -40,12 +40,12 @@ cc_library(
     deps = [
         ":exact_uniform_int",
         ":philox_random",
+        "//tensorflow/core:framework",
         "//tensorflow/core/lib/bfloat16",
         "//tensorflow/core/lib/gtl:array_slice",
         "//tensorflow/core/platform:logging",
         "//tensorflow/core/platform:macros",
         "//tensorflow/core/platform:types",
-        "//tensorflow/core:framework",
         "//third_party/eigen3",
     ],
     alwayslink = 1,

--- a/tensorflow/core/lib/random/BUILD
+++ b/tensorflow/core/lib/random/BUILD
@@ -45,6 +45,7 @@ cc_library(
         "//tensorflow/core/platform:logging",
         "//tensorflow/core/platform:macros",
         "//tensorflow/core/platform:types",
+        "//tensorflow/core:framework",
         "//third_party/eigen3",
     ],
     alwayslink = 1,

--- a/tensorflow/core/lib/random/random_distributions.h
+++ b/tensorflow/core/lib/random/random_distributions.h
@@ -63,6 +63,8 @@ typename Distribution::ResultType VectorizedFormat(
     }
   }
   // Tail processing if any.
+  // Put the tail condition out of above loop to improve performance:
+  // it will be executed only once and save time on CPU.
   if (offset < kResultElementCount) {
     sample = (*gen)();
     for (int i = 0; offset < kResultElementCount; i++, offset++) {

--- a/tensorflow/core/lib/random/random_distributions.h
+++ b/tensorflow/core/lib/random/random_distributions.h
@@ -23,7 +23,7 @@ limitations under the License.
 #include <algorithm>
 #include <type_traits>
 
-#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/numeric_types.h"
 #include "tensorflow/core/lib/bfloat16/bfloat16.h"
 #include "tensorflow/core/lib/random/philox_random.h"
 #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
@@ -72,9 +72,12 @@ typename Distribution::ResultType VectorizedFormat(
     }
   }
 
-  auto tensor_result =
-      typename TTypes<typename Distribution::ResultElementType>::Tensor(
-          &result[0], kResultElementCount);
+  typedef Eigen::TensorMap<
+      Eigen::Tensor<typename Distribution::ResultElementType, 1,
+                    Eigen::RowMajor, Eigen::DenseIndex>,
+      Eigen::Aligned>
+      Tensor;
+  auto tensor_result = Tensor(&result[0], kResultElementCount);
   tensor_result = tensor_result - typename Distribution::ResultElementType(1.0);
   return result;
 }

--- a/tensorflow/core/lib/random/random_distributions.h
+++ b/tensorflow/core/lib/random/random_distributions.h
@@ -133,14 +133,12 @@ template <class Generator>
 class UniformDistribution<Generator, bfloat16> {
  public:
   // The number of elements that will be returned.
-  // Set the number to be greater equal to Eigen packet size of type,
+  // Set the number to be Eigen packet size of type at least,
   // so computations can be vectorized using SIMD.
   static constexpr int kVectorLength =
       Eigen::internal::packet_traits<bfloat16>::size;
   static constexpr int kResultElementCount =
-      (kVectorLength > Generator::kResultElementCount)
-          ? kVectorLength
-          : Generator::kResultElementCount;
+      std::max(kVectorLength, Generator::kResultElementCount);
   // Cost of generation of a single element (in cycles).
   static constexpr int kElementCost = 3;
   // Indicate that this distribution may take variable number of samples
@@ -148,7 +146,7 @@ class UniformDistribution<Generator, bfloat16> {
   static constexpr bool kVariableSamplesPerOutput = false;
   typedef Array<bfloat16, kResultElementCount> ResultType;
   typedef bfloat16 ResultElementType;
-  // Helper definiation for the format function.
+  // Helper definition for the format function.
   typedef bfloat16 (*FormatFunc)(uint16);
 
   PHILOX_DEVICE_INLINE
@@ -162,14 +160,12 @@ template <class Generator>
 class UniformDistribution<Generator, float> {
  public:
   // The number of elements that will be returned.
-  // Set the number to be greater equal to Eigen packet size of type,
+  // Set the number to be Eigen packet size of type at least,
   // so computations can be vectorized using SIMD.
   static constexpr int kVectorLength =
       Eigen::internal::packet_traits<float>::size;
   static constexpr int kResultElementCount =
-      (kVectorLength > Generator::kResultElementCount)
-          ? kVectorLength
-          : Generator::kResultElementCount;
+      std::max(kVectorLength, Generator::kResultElementCount);
   // Cost of generation of a single element (in cycles).
   static constexpr int kElementCost = 3;
   // Indicate that this distribution may take variable number of samples
@@ -177,7 +173,7 @@ class UniformDistribution<Generator, float> {
   static constexpr bool kVariableSamplesPerOutput = false;
   typedef Array<float, kResultElementCount> ResultType;
   typedef float ResultElementType;
-  // Helper definiation for the format function.
+  // Helper definition for the format function.
   typedef float (*FormatFunc)(uint32);
 
   PHILOX_DEVICE_INLINE

--- a/tensorflow/python/kernel_tests/random/random_ops_test.py
+++ b/tensorflow/python/kernel_tests/random/random_ops_test.py
@@ -276,8 +276,9 @@ class RandomUniformTest(RandomOpTestCommon):
 
   def testRange(self):
     for dt in (dtypes.float16, dtypes.float32, dtypes.float64, dtypes.int32,
-               dtypes.int64):
-      sampler = self._Sampler(1000, minv=-2, maxv=8, dtype=dt, use_gpu=True)
+               dtypes.int64, dtypes.bfloat16):
+      use_gpu = (dt != dtypes.bfloat16)
+      sampler = self._Sampler(1000, minv=-2, maxv=8, dtype=dt, use_gpu=use_gpu)
       x = sampler()
       self.assertTrue(-2 <= np.min(x))
       self.assertTrue(np.max(x) < 8)
@@ -363,10 +364,11 @@ class RandomUniformTest(RandomOpTestCommon):
   @test_util.run_deprecated_v1
   def testSeed(self):
     for dt in (dtypes.float16, dtypes.float32, dtypes.float64, dtypes.int32,
-               dtypes.int64):
+               dtypes.int64, dtypes.bfloat16):
       for seed in [345, 2**100, -2**100]:
-        sx = self._Sampler(1000, 0, 17, dtype=dt, use_gpu=True, seed=seed)
-        sy = self._Sampler(1000, 0, 17, dtype=dt, use_gpu=True, seed=seed)
+        use_gpu = (dt != dtypes.bfloat16)
+        sx = self._Sampler(1000, 0, 17, dtype=dt, use_gpu=use_gpu, seed=seed)
+        sy = self._Sampler(1000, 0, 17, dtype=dt, use_gpu=use_gpu, seed=seed)
         self.assertAllEqual(sx(), sy())
 
   @test_util.run_deprecated_v1


### PR DESCRIPTION
Change the `Distribution` result length from fixed length `4` to `Eigen::internal::packet_traits<T>::size` and do computation with `Eigen::Tensor` to use Eigen packet feature for vectoring.

Functionality of this PR is independent, but its performance is depended on another public Eigen PR for BF16: https://gitlab.com/libeigen/eigen/-/merge_requests/84. So, currently this PR will only improve FP32 performance.

Signed-off-by: Lu Teng teng.lu@intel.com