### PR TITLE
include tf_types.def as part of the tf-nightly pip install

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -240,6 +240,7 @@ headers = (
     list(find_files('*.proto', 'tensorflow/compiler')) +
     list(find_files('*.proto', 'tensorflow/core')) +
     list(find_files('*.proto', 'tensorflow/python')) +
+    list(find_files('*.def', 'tensorflow/compiler')) +
     list(find_files('*.h', 'tensorflow/c')) +
     list(find_files('*.h', 'tensorflow/cc')) +
     list(find_files('*.h', 'tensorflow/compiler')) +


### PR DESCRIPTION
While trying to build mlir with tf-nightly, there are situations

`tensorflow/compiler/mlir/tensorflow/ir/tf_types.h`

needs to be included. However, this file implicitly includes
`tensorflow/compiler/mlir/tensorflow/ir/tf_types.def` which is not included.

The follow error thrown out:
```
In file included from bazel-out/darwin-fastbuild/bin/external/local_config_tf/include/tensorflow/compiler/mlir/tensorflow/ir/tf_ops.h:37:
In file included from bazel-out/darwin-fastbuild/bin/external/local_config_tf/include/tensorflow/compiler/mlir/tensorflow/ir/tf_traits.h:25:
bazel-out/darwin-fastbuild/bin/external/local_config_tf/include/tensorflow/compiler/mlir/tensorflow/ir/tf_types.h:74:10: fatal error: 'tensorflow/compiler/mlir/tensorflow/ir/tf_types.def' file not found
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

This PR add `.def` file under `tensorflow/compiler` to be part of the pip install, so that
`tf_types.h` could be used.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>