### PR TITLE
TFLite library fix for r2.1 branch

### DIFF
--- a/tensorflow/lite/tools/make/Makefile
+++ b/tensorflow/lite/tools/make/Makefile
@@ -112,6 +112,7 @@ $(wildcard tensorflow/lite/kernels/internal/reference/*.cc) \
 $(PROFILER_SRCS) \
 tensorflow/lite/tools/make/downloads/farmhash/src/farmhash.cc \
 tensorflow/lite/tools/make/downloads/fft2d/fftsg.c \
+tensorflow/lite/tools/make/downloads/fft2d/fftsg2d.c \
 tensorflow/lite/tools/make/downloads/flatbuffers/src/util.cpp
 CORE_CC_ALL_SRCS += \
 	$(shell find tensorflow/lite/tools/make/downloads/absl/absl/ \

--- a/tensorflow/lite/tools/make/Makefile
+++ b/tensorflow/lite/tools/make/Makefile
@@ -129,6 +129,8 @@ $(wildcard tensorflow/lite/*/*/*test.cc) \
 $(wildcard tensorflow/lite/*/*/*/*test.cc) \
 $(wildcard tensorflow/lite/kernels/*test_main.cc) \
 $(wildcard tensorflow/lite/kernels/*test_util*.cc) \
+tensorflow/lite/experimental/ruy/tune_tool.cc \
+tensorflow/lite/tools/make/downloads/absl/absl/hash/internal/print_hash_of.cc \
 $(MINIMAL_SRCS)
 
 BUILD_WITH_MMAP ?= true

--- a/tensorflow/lite/tools/make/Makefile
+++ b/tensorflow/lite/tools/make/Makefile
@@ -115,7 +115,7 @@ tensorflow/lite/tools/make/downloads/fft2d/fftsg.c \
 tensorflow/lite/tools/make/downloads/flatbuffers/src/util.cpp
 CORE_CC_ALL_SRCS += \
 	$(shell find tensorflow/lite/tools/make/downloads/absl/absl/ \
-	             -type f -name \*.cc | grep -v test | grep -v benchmark | grep -v synchronization | grep -v debugging)
+	             -type f -name \*.cc | grep -v test | grep -v benchmark | grep -v synchronization | grep -v debugging | grep -v hash | grep -v flags)
 endif
 # Remove any duplicates.
 CORE_CC_ALL_SRCS := $(sort $(CORE_CC_ALL_SRCS))
@@ -130,7 +130,6 @@ $(wildcard tensorflow/lite/*/*/*/*test.cc) \
 $(wildcard tensorflow/lite/kernels/*test_main.cc) \
 $(wildcard tensorflow/lite/kernels/*test_util*.cc) \
 tensorflow/lite/experimental/ruy/tune_tool.cc \
-tensorflow/lite/tools/make/downloads/absl/absl/hash/internal/print_hash_of.cc \
 $(MINIMAL_SRCS)
 
 BUILD_WITH_MMAP ?= true


### PR DESCRIPTION
This PR contains the following cherry-picks to fix a link failure with TFLite library.

5b1fbe0268 TFLite: tools: make: add fftsg2d.c file in the build resources for libtensorflow-lite.a
7f190ecb9f TFLite: tools: make: remove hash and flags files from the build sources for libtensorflow-lite.a
dcb6a33c40 Update Makefile of TFLite not to include main() function
