### PR TITLE
Move -no-as-needed to the top of the linking command line in the cuda toolchain

### DIFF
--- a/third_party/nccl/archive.BUILD
+++ b/third_party/nccl/archive.BUILD
@@ -90,6 +90,7 @@ cc_library(
     include_prefix = "third_party/nccl",
     strip_include_prefix = "src",
     visibility = ["//visibility:public"],
+    linkopts = ["-lrt"],
     deps = [
         ":device",
         ":include_hdrs",


### PR DESCRIPTION
`-no-as-needed` linker flag is position sensitive (it's only effecting
following -l flags), therefore we need to move it before libraries to
link.

This change uncovered that nccl doesn't properly declare it's dependency
on `-lrt`, which is fixed. I suspect this started to be a problem in
https://github.com/tensorflow/tensorflow/commit/f819114a2d9d393a60e954d3a3e42d8700ff3b19.

This change also uncovered that some tests don't need to depend on nccl.
While `-no-as-needed` wasn't taking effect, nccl was just left out as
not needed.

https://github.com/tensorflow/tensorflow/issues/38205