### PR TITLE
Replace list concatenation with generators for auto control deps

### DIFF
--- a/tensorflow/python/framework/auto_control_deps.py
+++ b/tensorflow/python/framework/auto_control_deps.py
@@ -535,8 +535,10 @@ def _get_resource_inputs(op):
 
   # Note: A resource handle that is not written to is treated as read-only. We
   # don't have a special way of denoting an unused resource.
-  return ([(t, ResourceType.READ_ONLY) for t in reads] +
-          [(t, ResourceType.READ_WRITE) for t in writes])
+  for t in reads:
+    yield (t, ResourceType.READ_ONLY)
+  for t in writes:
+    yield (t, ResourceType.READ_WRITE)
 
 
 def automatic_control_dependencies(f):


### PR DESCRIPTION
For processing `switch` ops, `AutomaticControlDependencies` iterates over `_get_resource_inputs(op)` at
https://github.com/tensorflow/tensorflow/blob/1a93f37e2614b38b3a12f82c9bc25aea9eda3953/tensorflow/python/framework/auto_control_deps.py#L398

This allows to make `_get_resource_inputs` a generator which removes the need to create and concatenate two lists as a return value of the function.