### PR TITLE
TFLite: add EXTRA_CFLAGS variable

### DIFF
--- a/tensorflow/lite/tools/make/Makefile
+++ b/tensorflow/lite/tools/make/Makefile
@@ -58,7 +58,7 @@ LIBS := \
 # There are no rules for compiling objects for the host system (since we don't
 # generate things like the protobuf compiler that require that), so all of
 # these settings are for the target compiler.
-CFLAGS := -O3 -DNDEBUG -fPIC
+CFLAGS := -O3 -DNDEBUG -fPIC $(EXTRA_CFLAGS)
 CXXFLAGS := $(CFLAGS) --std=c++11 $(EXTRA_CXXFLAGS)
 LDOPTS := -L/usr/local/lib
 ARFLAGS := -r

--- a/tensorflow/lite/tools/pip_package/setup.py
+++ b/tensorflow/lite/tools/pip_package/setup.py
@@ -58,7 +58,8 @@ elif TARGET == 'aarch64':
   os.environ['CC'] = 'aarch64-linux-gnu-gcc'
 
 MAKE_CROSS_OPTIONS = []
-for name in ['TARGET', 'TARGET_ARCH', 'CC_PREFIX', 'EXTRA_CXXFLAGS']:
+for name in ['TARGET', 'TARGET_ARCH', 'CC_PREFIX', 'EXTRA_CXXFLAGS',
+             'EXTRA_CFLAGS']:
   value = os.environ.get('TENSORFLOW_%s' % name)
   if value:
     MAKE_CROSS_OPTIONS.append('%s=%s' % (name, value))


### PR DESCRIPTION
Since commit SHA1: d28cf21aa51d12ce9c526f7baf5137bc2e2b7f7d
Cross compilation of TFLite is failing.
Add an EXTRA_CFLAGS varibale to allow cross compilation environment to
define extra CFLAGS when needed.

Signed-off-by: Vincent ABRIOU <vincent.abriou@st.com>