### PR TITLE
in resolution of [Wsign-compare] warning id 0

### DIFF
--- a/tensorflow/lite/arena_planner.cc
+++ b/tensorflow/lite/arena_planner.cc
@@ -197,7 +197,7 @@ TfLiteStatus ArenaPlanner::ExecuteAllocations(int first_node, int last_node) {
   dealloc_node_.resize(graph_info_->num_tensors(), kNodeNotAssigned);
   allocs_.resize(graph_info_->num_tensors());
   // Set allocation and deallocation for temporary tensors.
-  for (size_t i = first_node; i <= (size_t)last_node && i < graph_info_->num_nodes();
+  for (size_t i = first_node; i <= static_cast<size_t>(last_node) && i < graph_info_->num_nodes();
        ++i) {
     const TfLiteNode& node = graph_info_->node(i);
     TfLiteIntArray* node_temporaries = node.temporaries;

--- a/tensorflow/lite/arena_planner.cc
+++ b/tensorflow/lite/arena_planner.cc
@@ -197,7 +197,7 @@ TfLiteStatus ArenaPlanner::ExecuteAllocations(int first_node, int last_node) {
   dealloc_node_.resize(graph_info_->num_tensors(), kNodeNotAssigned);
   allocs_.resize(graph_info_->num_tensors());
   // Set allocation and deallocation for temporary tensors.
-  for (size_t i = first_node; i <= last_node && i < graph_info_->num_nodes();
+  for (size_t i = first_node; i <= (size_t)last_node && i < (size_t)(graph_info_->num_nodes());
        ++i) {
     const TfLiteNode& node = graph_info_->node(i);
     TfLiteIntArray* node_temporaries = node.temporaries;

--- a/tensorflow/lite/arena_planner.cc
+++ b/tensorflow/lite/arena_planner.cc
@@ -197,7 +197,7 @@ TfLiteStatus ArenaPlanner::ExecuteAllocations(int first_node, int last_node) {
   dealloc_node_.resize(graph_info_->num_tensors(), kNodeNotAssigned);
   allocs_.resize(graph_info_->num_tensors());
   // Set allocation and deallocation for temporary tensors.
-  for (size_t i = first_node; i <= (size_t)last_node && i < (size_t)(graph_info_->num_nodes());
+  for (size_t i = first_node; i <= (size_t)last_node && i < graph_info_->num_nodes();
        ++i) {
     const TfLiteNode& node = graph_info_->node(i);
     TfLiteIntArray* node_temporaries = node.temporaries;


### PR DESCRIPTION
I looked a little into the context of how the variables 'last_node' and 'graph_info_->num_nodes()' are used. num_nodes() implies that the quantity returned is unsigned/non-negative, although the same assumption cannot be clearly made about last_node. 

I cast last_node to size_t under the assumption that it is being utilized as a size/non-negative quantity.