### PR TITLE
in resolution of [Wsign-compare] warning id 3

### DIFF
--- a/tensorflow/core/platform/default/logging.cc
+++ b/tensorflow/core/platform/default/logging.cc
@@ -366,7 +366,7 @@ bool LogEveryNState::ShouldLog(int n) {
 
 bool LogFirstNState::ShouldLog(int n) {
   const uint32 counter_value = counter_.load(std::memory_order_relaxed);
-  if (counter_value < n) {
+  if (counter_value < (size_t)n) {
     counter_.store(counter_value + 1, std::memory_order_relaxed);
     return true;
   }

--- a/tensorflow/core/platform/default/logging.cc
+++ b/tensorflow/core/platform/default/logging.cc
@@ -365,8 +365,8 @@ bool LogEveryNState::ShouldLog(int n) {
 }
 
 bool LogFirstNState::ShouldLog(int n) {
-  const uint32 counter_value = counter_.load(std::memory_order_relaxed);
-  if (counter_value < (size_t)n) {
+  const int counter_value = static_cast<int>( counter_.load(std::memory_order_relaxed) );
+  if (counter_value < n) {
     counter_.store(counter_value + 1, std::memory_order_relaxed);
     return true;
   }


### PR DESCRIPTION
It is explicit that 'counter_value' is of unsigned type. It is implied that 'n' is a quantity/count. Given that 'n' is a signed int however, the apparent intended behavior of logging the first N state transistions is not ensured.

In resolution of the warning I cast 'n' to size_t. 
It is suggested however that the type n be changed from an int to an appropriate unsigned type in order to disqualify the possibility of the passed 'n' being negative; unintentional behavior.