### PR TITLE
[tf.data] skip concat when origin ds has infinity cardinality

### DIFF
--- a/tensorflow/core/kernels/data/concatenate_dataset_op.cc
+++ b/tensorflow/core/kernels/data/concatenate_dataset_op.cc
@@ -76,7 +76,7 @@ class ConcatenateDatasetOp::Dataset : public DatasetBase {
   int64 Cardinality() const override {
     int64 n1 = input_->Cardinality();
     int64 n2 = to_concatenate_->Cardinality();
-    if (n1 == kInfiniteCardinality || n2 == kInfiniteCardinality) {
+    if (n2 == kInfiniteCardinality) {
       return kInfiniteCardinality;
     }
     if (n1 == kUnknownCardinality || n2 == kUnknownCardinality) {
@@ -220,6 +220,10 @@ void ConcatenateDatasetOp::MakeDataset(OpKernelContext* ctx, DatasetBase* input,
                   " have different output_types %s and %s",
                   (DataTypeVectorString(input->output_dtypes()),
                    DataTypeVectorString(to_concatenate->output_dtypes()))));
+  if (input->Cardinality() == kInfiniteCardinality) {
+    output = input;
+    return;
+  }
   *output = new Dataset(ctx, input, to_concatenate);
 }
 

--- a/tensorflow/core/kernels/data/concatenate_dataset_op.cc
+++ b/tensorflow/core/kernels/data/concatenate_dataset_op.cc
@@ -221,7 +221,7 @@ void ConcatenateDatasetOp::MakeDataset(OpKernelContext* ctx, DatasetBase* input,
                   (DataTypeVectorString(input->output_dtypes()),
                    DataTypeVectorString(to_concatenate->output_dtypes()))));
   if (input->Cardinality() == kInfiniteCardinality) {
-    output = input;
+    *output = input;
     return;
   }
   *output = new Dataset(ctx, input, to_concatenate);


### PR DESCRIPTION
This pr will skip `a.concatenate(b)` when `a` already has infinity cardinality.

This may also be achieved by removing the `ConcatenateDatasetOp` from the graph when `to_concatenate` has infinity cardinality with grappler, in that way `to_concatenate` and its prior ops may be pruned in graph optimization. If you prefer this way, I'd love to contribute.

Thank you for your time on reviewing this pr.