### PR TITLE
in resolution of [Wsign-compare] warning id 5

### DIFF
--- a/tensorflow/core/lib/strings/proto_serialization.cc
+++ b/tensorflow/core/lib/strings/proto_serialization.cc
@@ -72,7 +72,7 @@ bool SerializeToBufferDeterministic(const protobuf::MessageLite& msg,
   protobuf::io::CodedOutputStream output_stream(&array_stream);
   output_stream.SetSerializationDeterministic(true);
   msg.SerializeWithCachedSizes(&output_stream);
-  return !output_stream.HadError() && size == (size_t)(output_stream.ByteCount());
+  return !output_stream.HadError() && size == static_cast<size_t>(output_stream.ByteCount());
 }
 
 bool AreSerializedProtosEqual(const protobuf::MessageLite& x,

--- a/tensorflow/core/lib/strings/proto_serialization.cc
+++ b/tensorflow/core/lib/strings/proto_serialization.cc
@@ -72,7 +72,7 @@ bool SerializeToBufferDeterministic(const protobuf::MessageLite& msg,
   protobuf::io::CodedOutputStream output_stream(&array_stream);
   output_stream.SetSerializationDeterministic(true);
   msg.SerializeWithCachedSizes(&output_stream);
-  return !output_stream.HadError() && size == output_stream.ByteCount();
+  return !output_stream.HadError() && size == (size_t)(output_stream.ByteCount());
 }
 
 bool AreSerializedProtosEqual(const protobuf::MessageLite& x,


### PR DESCRIPTION
Unsigned nature of 'output_stream.ByteCount()' implied by context ( the literal word count 😅 : )  ). 

If being more strict is prudent ( I don't think it is in this case ), the return type of 'output_stream.ByteCount()' could be explicitly set to an unsigned integer type.