### PR TITLE
RFC: use atomic instructions for propagating simple node outputs

### DIFF
--- a/tensorflow/core/common_runtime/pending_counts_test.cc
+++ b/tensorflow/core/common_runtime/pending_counts_test.cc
@@ -13,10 +13,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include <memory>
-#include <unordered_map>
-
 #include "tensorflow/core/common_runtime/pending_counts.h"
+
+#include <memory>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
 #include "tensorflow/core/platform/test.h"
 
 namespace tensorflow {
@@ -163,6 +166,37 @@ TEST(PendingCounts, AdjustForActivation) {
     EXPECT_EQ(c.dead_count(h), 1);
     EXPECT_TRUE(result.any_dead);
   }
+}
+
+TEST(PendingCounts, AdjustForActivationAtomic) {
+  PendingCounts::Layout layout;
+  PendingCounts::Handle handles[2];
+  const int kInitialCounts[2] = {6, 16};
+  handles[0] = layout.CreateHandle(kInitialCounts[0], 0);
+  handles[1] = layout.CreateHandle(kInitialCounts[1], 0);
+  PendingCounts c(layout);
+  c.set_initial_count(handles[0], kInitialCounts[0]);
+  c.set_initial_count(handles[1], kInitialCounts[1]);
+
+  std::atomic<bool> start{false};
+  std::vector<std::thread> threads;
+  for (int t = 0; t < 2; t++) {
+    threads.emplace_back([&]() {
+      while (!start) {
+      }
+      for (int i = 0; i < kInitialCounts[0] / 2; i++) {
+        c.adjust_for_activation_atomic(handles[0], false);
+      }
+      for (int i = 0; i < kInitialCounts[1] / 2; i++) {
+        c.adjust_for_activation_atomic(handles[1], false);
+      }
+    });
+  }
+  start = true;
+  for (auto& t : threads) t.join();
+
+  EXPECT_EQ(c.pending(handles[0]), 0);
+  EXPECT_EQ(c.pending(handles[1]), 0);
 }
 
 }  // namespace tensorflow

--- a/tensorflow/core/common_runtime/propagator_state.h
+++ b/tensorflow/core/common_runtime/propagator_state.h
@@ -143,7 +143,7 @@ class PropagatorState {
     Entry* input_tensors;
 
     // The number of outstanding ops for each iteration.
-    size_t outstanding_ops;
+    std::atomic<size_t> outstanding_ops;
 
     // The number of outstanding frames for each iteration.
     int outstanding_frame_count;
@@ -169,6 +169,10 @@ class PropagatorState {
     PendingCounts::AdjustResult adjust_for_activation(PendingCounts::Handle h,
                                                       bool increment_dead) {
       return counts.adjust_for_activation(h, increment_dead);
+    }
+    PendingCounts::AdjustResult adjust_for_activation_atomic(PendingCounts::Handle h,
+                                                             bool increment_dead) {
+      return counts.adjust_for_activation_atomic(h, increment_dead);
     }
 
     ~IterationState() { delete[] input_tensors; }
@@ -294,15 +298,27 @@ class PropagatorState {
 
     void SetIteration(int64 iter, IterationState* state);
 
-    // Decrement the outstanding op count and clean up the iterations in the
-    // frame. Return true iff the execution of the frame is done.
+    // Adjust the outstanding op count by 'delta' and clean up the iterations in the
+    // frame if no more ops are oustanding. Return true iff the execution of the frame is done.
+    //
+    // Avoids acquiring the lock in the common case that the frame is not done.
+    bool AdjustOutstandingOps(IterationState* iter_state,
+                              int delta,
+                              TaggedNodeSeq* ready);
+
+    bool AdjustOutstandingOpsLocked(IterationState* iter_state,
+                                    int delta,
+                                    TaggedNodeSeq* ready)
+        TF_EXCLUSIVE_LOCKS_REQUIRED(mu);
+
+    // Convenience methods for the above 'Adjust' calls where delta takes the common
+    // value of -1.
     bool DecrementOutstandingOps(IterationState* iter_state,
                                  TaggedNodeSeq* ready);
 
-    // Decrement the outstanding op count and clean up the iterations in the
-    // frame. Return true iff the execution of the frame is done.
     bool DecrementOutstandingOpsLocked(IterationState* iter_state,
                                        TaggedNodeSeq* ready);
+
 
     // Returns true if the computation in the frame is completed.
     bool IsFrameDone();
@@ -332,9 +348,19 @@ class PropagatorState {
 
     // Activate the successors of a node. Contents of *outputs are left in an
     // indeterminate state after returning from this method.
-    void ActivateNodes(const NodeItem* item, const bool is_dead,
-                       IterationState* iter_state, EntryVector* outputs,
-                       TaggedNodeSeq* ready) TF_EXCLUSIVE_LOCKS_REQUIRED(mu);
+    //
+    // In the case that 'item' is a simple node (no merge/control outputs) this will
+    // acquire a shared lock and can run concurrently with other invocations.
+    //
+    // Returns the number of newly activated nodes that have been added to '*ready'.
+    int ActivateNodes(const NodeItem* item, const bool is_dead,
+                      IterationState* iter_state, EntryVector* outputs,
+                      TaggedNodeSeq* ready);
+
+    // Same as the above, but requires 'mu' already held in exclusive mode.
+    int ActivateNodesLocked(const NodeItem* item, const bool is_dead,
+                            IterationState* iter_state, EntryVector* outputs,
+                            TaggedNodeSeq* ready) TF_EXCLUSIVE_LOCKS_REQUIRED(mu);
 
     // Cleanup iterations of this frame starting from the given iteration.
     bool CleanupIterations(IterationState* iter_state, TaggedNodeSeq* ready)
@@ -359,14 +385,32 @@ class PropagatorState {
 
    private:
     // REQUIRES: `!item->is_any_consumer_merge_or_control_trigger`.
-    void ActivateNodesFastPath(const NodeItem* item, const bool is_dead,
-                               IterationState* iter_state, EntryVector* outputs,
-                               TaggedNodeSeq* ready)
-        TF_EXCLUSIVE_LOCKS_REQUIRED(mu);
+    // This variant does not use atomic operations to modify the pending counts and thus
+    // must hold the exclusive lock.
+    int ActivateNodesFastPathLocked(const NodeItem* item, const bool is_dead,
+                                    IterationState* iter_state, EntryVector* outputs,
+                                    TaggedNodeSeq* ready)
+        TF_EXCLUSIVE_LOCKS_REQUIRED(mu) {
+      return ActivateNodesFastPathInternal<false>(item, is_dead, iter_state, outputs, ready);
+    }
 
-    void ActivateNodesSlowPath(const NodeItem* item, const bool is_dead,
-                               IterationState* iter_state, EntryVector* outputs,
-                               TaggedNodeSeq* ready)
+    // REQUIRES: `!item->is_any_consumer_merge_or_control_trigger`.
+    // This variant uses atomic operations to modify the pending counts.
+    int ActivateNodesFastPathShared(const NodeItem* item, const bool is_dead,
+                                    IterationState* iter_state, EntryVector* outputs,
+                                    TaggedNodeSeq* ready)
+        TF_SHARED_LOCKS_REQUIRED(mu) {
+      return ActivateNodesFastPathInternal<true>(item, is_dead, iter_state, outputs, ready);
+    }
+
+    template<bool atomic>
+    int ActivateNodesFastPathInternal(const NodeItem* item, const bool is_dead,
+                                      IterationState* iter_state, EntryVector* outputs,
+                                      TaggedNodeSeq* ready);
+
+    int ActivateNodesSlowPath(const NodeItem* item, const bool is_dead,
+                              IterationState* iter_state, EntryVector* outputs,
+                              TaggedNodeSeq* ready)
         TF_EXCLUSIVE_LOCKS_REQUIRED(mu);
   };
 


### PR DESCRIPTION
This follows a similar approach to the earlier work by Derek Murray
(change ID I9058c55898079cb3ab6011513b4468ddb293f59f) and allows using
atomic operations on the pending counts. It extends that work to also
apply to graphs that include control/merge nodes (eg the 'wide_deep'
model in the tf models repo)

The approach here is to note that even in a graph that has control/merge
nodes, it's likely that many nodes do not have any merge/control
outputs. There's already a fast path for this case with simpler logic,
and that simple logic has the advantage of only accessing the pending
count in one spot where it decrements the incoming pending values. Only
the last such decrementer propagates the output and activates the node.

Given this, we can use atomic operations for all such "fast path" nodes
and avoid holding an exclusive lock. We fall back to the exclusive lock
for any nodes that have slow-path outputs. As a conservative measure,
this patch acquires the shared lock for the fast path, though it may
not be necessary.

The other bit in this patch is the management of the 'outstanding_ops'
member. In order to allow concurrent completion of ops without the
exclusive lock, this also becomes atomic. Simply making it atomic is
sufficient but leaves a lot of performance on the table. This patch
batches the updates of this variable so that each op completion only
touches it at most once, and no-ops out in the case that the pending op
count doesn't need to be modified (eg when an op completion activates
exactly one downstream node).

I benchmarked this change using tensorflow-models/official/r1/wide_deep
and collecting the distribution of "steps/sec" reported using commands
like:
```
  # switch to new code
  $ python -u  census_main.py -ebe=20  -te 20 -mt wide 2>&1 | tee /tmp/before/wide.txt
  # switch to new code
  $ python -u  census_main.py -ebe=20  -te 20 -mt wide 2>&1 | tee /tmp/after/wide.txt
```
... for the 'wide', 'wide_deep', and 'deep' models. I then exported the
'steps/second' metrics to TSV with:
```
  $ grep 'tensorflow:global_step/sec' \
    /tmp/{before,after}/*.txt | perl -p  -e \
    's,/tmp/(.+)/(.+).txt:.*?([\d\.]+)$,$1 $2 $3,g' > /tmp/data.tsv
```
Mean steps/sec are as follows on my AMD Ryzen 9 3900X desktop (12
physical cores, 'performance' CPU governor enabled):
```
Before:
    model   steps/sec
----------------------
      deep  888.2449
      wide  778.8037
 wide_deep  635.0198

After:
    model   steps/sec   improvement
-----------------------------------
      deep  929.8955  (+4%)
      wide  989.9900  (+27%)
 wide_deep  780.8842  (+22%)
```
A few notes worth considering:

Using atomic operations has some fixed overhead compared to non-atomics,
and particularly when the cache line being operated on is in M
"modified" state in another core. This increased latency of operating on
a cache-line in remote M state (aka "HitM" access) is also true with
non-atomic operations, but non-atomics can potentially allow for
instruction level parallelism and pipeline multiple such accesses
together, whereas atomics do not on current x86 architectures[1]. So,
there is possibly a cross-over point on some graph shapes where the
mutex-based synchronization with non-atomic operations actually beats
the atomic-based implementation here.

That said, the current code path for the non-atomic (mutex-protected)
case is complex/branchy enough that it's not clear that any significant
pipelining of reads can actually occur without some more explicit
unrolling, etc.

It's also worth noting that, in uncontended cases, the atomics will be
slower than the non-atomics. However, this is unlikely an issue in real
workloads, considering that these code paths are only uncontended when
the actual work of op execution dominates the runtime. In other words,
this is only a perf bottleneck when it's under contention, and a small
regression for uncontended cases is likely in the noise.

[1] https://spcl.inf.ethz.ch/Publications/.pdf/atomic-bench.pdf