### PR TITLE
[MLIR] NFC remove dangling braces in comments

### DIFF
--- a/tensorflow/compiler/mlir/xla/transforms/hlo_legalize_to_lhlo.cc
+++ b/tensorflow/compiler/mlir/xla/transforms/hlo_legalize_to_lhlo.cc
@@ -281,7 +281,6 @@ class HloToLhloTensorStoreOpConverter
 //     "xla_lhlo.terminator"() : () -> ()
 //   }) : () -> ()
 //   return
-//  }
 // }
 //
 // FuncOp signature conversion example:

--- a/tensorflow/compiler/mlir/xla/transforms/xla_legalize_to_linalg.cc
+++ b/tensorflow/compiler/mlir/xla/transforms/xla_legalize_to_linalg.cc
@@ -690,13 +690,12 @@ void populateLHLOToLinalgConversionPattern(MLIRContext* context,
 //   ^bb0(%arg4: f32, %arg5: f32):
 //     %0 = addf %arg4, %arg5 : f32
 //     "linalg.yield"(%0) : (f32) -> ()
-//   }) {
+// }) {
 //     args_in = 2,
 //     args_out = 1,
 //     indexing_maps = [#map0, #map0, #map0],
 //     iterator_types = ["parallel", "parallel"],
-//   } : (memref<2x2xf32>, memref<2x2xf32>, memref<2x2xf32>) -> ()
-// }
+// } : (memref<2x2xf32>, memref<2x2xf32>, memref<2x2xf32>) -> ()
 struct LhloLegalizeToLinalg
     : public PassWrapper<LhloLegalizeToLinalg, FunctionPass> {
   void runOnFunction() override {


### PR DESCRIPTION
Remove incorrect braces in example comments in hlo/lhlo/linalg
conversion passes - these mess up brace matching.