### PR TITLE
Update Eigen to 8719b9c5bc1a97e62d675c02495ed72dda6fae73 to fix compiling error

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -237,11 +237,11 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
         name = "eigen_archive",
         build_file = clean_dep("//third_party:eigen.BUILD"),
         patch_file = clean_dep("//third_party/eigen3:gpu_packet_math.patch"),
-        sha256 = "854eabe6817e38d7738fde6ec39c3dfc55fd5e68b2523de8cae936f391a38a69",  # SHARED_EIGEN_SHA
-        strip_prefix = "eigen-cc86a31e20b48b0f03d714b4d1b1f50d52848d36",
+        sha256 = "615be1295290c13039b0c980a4a55933be26b1e06194d86c6014876fa85c7c6b",  # SHARED_EIGEN_SHA
+        strip_prefix = "eigen-8719b9c5bc1a97e62d675c02495ed72dda6fae73",
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/gitlab.com/libeigen/eigen/-/archive/cc86a31e20b48b0f03d714b4d1b1f50d52848d36/eigen-cc86a31e20b48b0f03d714b4d1b1f50d52848d36.tar.gz",
-            "https://gitlab.com/libeigen/eigen/-/archive/cc86a31e20b48b0f03d714b4d1b1f50d52848d36/eigen-cc86a31e20b48b0f03d714b4d1b1f50d52848d36.tar.gz",
+            "https://storage.googleapis.com/mirror.tensorflow.org/gitlab.com/libeigen/eigen/-/archive/8719b9c5bc1a97e62d675c02495ed72dda6fae73/eigen-8719b9c5bc1a97e62d675c02495ed72dda6fae73.tar.gz",
+            "https://gitlab.com/libeigen/eigen/-/archive/8719b9c5bc1a97e62d675c02495ed72dda6fae73/eigen-8719b9c5bc1a97e62d675c02495ed72dda6fae73.tar.gz",
         ],
     )
 


### PR DESCRIPTION
This PR tries to update Eigen to 8719b9c5bc1a97e62d675c02495ed72dda6fae73.
The reason to update Eigen is to fix the build error for custom ops (See error below).
The issue is that in Eigen there was a bug that uses `if defined(EIGEN_ARCH_PPC)` incorrectly (should be `if EIGEN_ARCH_PPC`).

I have created a PR in Eigen https://gitlab.com/libeigen/eigen/-/merge_requests/131 and the PR has already been merged.

This PR is a follow up in tensorflow repo to bump the Eigen to the latest version.

The error before this PR, when building a custom ops:
```
Execution platform: @local_config_platform//:host

Use --sandbox_debug to see verbose messages from the sandbox
In file included from tensorflow_io/core/kernels/io_optimization.cc:22:
In file included from bazel-out/darwin-fastbuild/bin/external/local_config_tf/include/tensorflow/compiler/mlir/mlir_graph_optimization_pass.h:20:
In file included from bazel-out/darwin-fastbuild/bin/external/local_config_tf/include/tensorflow/core/common_runtime/function_optimization_registry.h:23:
In file included from bazel-out/darwin-fastbuild/bin/external/local_config_tf/include/tensorflow/core/common_runtime/device_set.h:23:
In file included from bazel-out/darwin-fastbuild/bin/external/local_config_tf/include/tensorflow/core/common_runtime/device.h:35:
In file included from bazel-out/darwin-fastbuild/bin/external/local_config_tf/include/tensorflow/core/framework/allocator.h:26:
In file included from bazel-out/darwin-fastbuild/bin/external/local_config_tf/include/tensorflow/core/framework/numeric_types.h:20:
In file included from bazel-out/darwin-fastbuild/bin/external/local_config_tf/include/third_party/eigen3/unsupported/Eigen/CXX11/Tensor:1:
In file included from bazel-out/darwin-fastbuild/bin/external/local_config_tf/include/unsupported/Eigen/CXX11/Tensor:14:
bazel-out/darwin-fastbuild/bin/external/local_config_tf/include/unsupported/Eigen/CXX11/../../../Eigen/Core:334:10: fatal error: 'src/Core/arch/AltiVec/MatrixProduct.h' file not found
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
Target //tensorflow_io/core:optimization failed to build
INFO: Elapsed time: 4.778s, Critical Path: 4.54s
```

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>