### PR TITLE
Error refactoring for keyword arguments in graphing function in eager mode.

### DIFF
--- a/tensorflow/python/keras/backend.py
+++ b/tensorflow/python/keras/backend.py
@@ -3817,7 +3817,7 @@ def function(inputs, outputs, updates=None, name=None, **kwargs):
   """
   if ops.executing_eagerly_outside_functions():
     if kwargs:
-      raise ValueError('Session keyword arguments are not support during '
+      raise ValueError('Session keyword arguments are not supported during '
                        'eager execution. You passed: %s' % (kwargs,))
     if updates:
       raise ValueError('`updates` argument is not support during '

--- a/tensorflow/python/keras/backend.py
+++ b/tensorflow/python/keras/backend.py
@@ -3820,7 +3820,7 @@ def function(inputs, outputs, updates=None, name=None, **kwargs):
       raise ValueError('Session keyword arguments are not supported during '
                        'eager execution. You passed: %s' % (kwargs,))
     if updates:
-      raise ValueError('`updates` argument is not support during '
+      raise ValueError('`updates` argument is not supported during '
                        'eager execution. You passed: %s' % (updates,))
     from tensorflow.python.keras import models  # pylint: disable=g-import-not-at-top
     from tensorflow.python.keras.utils import tf_utils  # pylint: disable=g-import-not-at-top


### PR DESCRIPTION
Grammatical error corrected in keras/backend.py
Instead of this, 
Session keyword arguments are not support during 'eager execution.'
Correcting the grammatical error,
Session keyword arguments are not supported during 'eager execution.'