### PR TITLE
update python_api.md

### DIFF
--- a/tensorflow/lite/g3doc/convert/python_api.md
+++ b/tensorflow/lite/g3doc/convert/python_api.md
@@ -93,7 +93,7 @@ converter = tf.lite.TFLiteConverter.from_keras_model(model)
 tflite_model = converter.convert()
 
 # Save the TF Lite model.
-with tf.gfile.GFile('model.tflite', 'wb') as f:
+with tf.io.gfile.GFile('model.tflite', 'wb') as f:
   f.write(tflite_model)
 ```
 


### PR DESCRIPTION
This fixes #39962
Changed `tf.gfile.GFile` with `tf.io.gfile.GFile` for the code to work in TF 2.2
The former is an alias declared in TF 1.X and fails in TF 2 due to absence.