### PR TITLE
in resolution of [Wsign-compare] warning id 7

### DIFF
--- a/tensorflow/core/platform/default/stacktrace_handler.cc
+++ b/tensorflow/core/platform/default/stacktrace_handler.cc
@@ -99,8 +99,9 @@ static void StacktraceHandler(int sig, siginfo_t *si, void *v) {
 
 void InstallStacktraceHandler() {
   int handled_signals[] = {SIGSEGV, SIGABRT, SIGBUS, SIGILL, SIGFPE};
-
-  for (int i = 0; i < sizeof(handled_signals) / sizeof(int); i++) {
+  
+  size_t array_limit = sizeof(handled_signals) / sizeof(int);
+  for (size_t i = 0; i < array_limit; i++) {
     int sig = handled_signals[i];
     struct sigaction sa;
     struct sigaction osa;


### PR DESCRIPTION
I reexpress the array limit of `handled_signals` and the  index `i` in terms of size_t to resolve build warning: 

`tensorflow/core/platform/default/stacktrace_handler.cc:
tensorflow/core/platform/default/stacktrace_handler.cc: In function 'void tensorflow::testing::InstallStacktraceHandler()':
tensorflow/core/platform/default/stacktrace_handler.cc:103:21: warning: comparison of integer expressions of different signedness: 'int' and 'long unsigned int' [-Wsign-compare]
  103 |   for (int i = 0; i < sizeof(handled_signals) / sizeof(int); i++) {
      |                   ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`

@mihaimaruseac 