### PR TITLE
Fix doc rendering error in tf.ragged.constant

### DIFF
--- a/tensorflow/python/ops/ragged/ragged_factory_ops.py
+++ b/tensorflow/python/ops/ragged/ragged_factory_ops.py
@@ -59,8 +59,8 @@ def constant(pylist, dtype=None, ragged_rank=None, inner_shape=None,
       `pylist`.
     ragged_rank: An integer specifying the ragged rank of the returned
       `RaggedTensor`.  Must be nonnegative and less than `K`. Defaults to
-      `max(0, K - 1)` if `inner_shape` is not specified.  Defaults to `max(0, K
-      - 1 - len(inner_shape))` if `inner_shape` is specified.
+      `max(0, K - 1)` if `inner_shape` is not specified.  Defaults to
+      `max(0, K - 1 - len(inner_shape))` if `inner_shape` is specified.
     inner_shape: A tuple of integers specifying the shape for individual inner
       values in the returned `RaggedTensor`.  Defaults to `()` if `ragged_rank`
       is not specified.  If `ragged_rank` is specified, then a default is chosen


### PR DESCRIPTION
This PR tries to address the issue raised in #40052 where
the doc rendering of `ragged_rank` in `tf.ragged.constant`
caused invalid alignment.

The issue was because `max(0, K - 1 - len(inner_shape))` crossed
two lines and messed up the doc rendering.

This PR fixes #40052.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>