### PR TITLE
[MLIR] Add conversions dot op from LHLO to Affine

### DIFF
--- a/tensorflow/compiler/mlir/xla/tests/lhlo-legalize-to-affine.mlir
+++ b/tensorflow/compiler/mlir/xla/tests/lhlo-legalize-to-affine.mlir
@@ -143,3 +143,23 @@ func @int_sub_op(%lhs: memref<7xi32>, %rhs: memref<7xi32>,
       : (memref<7xi32>, memref<7xi32>, memref<7xi32>) -> ()
   return
 }
+
+// Dot tests.
+// CHECK-LABEL: func @float_dot_op
+func @float_dot_op(%lhs: <memref<7x3xf32>, %rhs: 
+                  memref<3x4xf32>, %result: memref<7x4xf32> ) -> () {
+    // CHECK-NEXT: affine.for %[[I:.*]] = 0 to 7 {
+    // CHECK-NEXT:  affine.for %[[J:.*]] = 0 to 4 {
+    // CHECK-NEXT:    affine.for %[[K:.*]] = 0 to 3 {
+    // CHECK-NEXT:      %[[LHS:.*]] = affine.load %{{.*}}[%[[I]], %[[K]]] : memref<7x3xf32>
+    // CHECK-NEXT:      %[[RHS:.*]] = affine.load %{{.*}}[%[[K]], %[[J]]] : memref<3x4xf32>
+    // CHECK-NEXT:      %[[RESULT:.*]] = affine.load %{{.*}}[%[[I]], %[[J]]] : memref<7x4xf32>
+    // CHECK-NEXT:      %[[MULT:.*]] = mulf %[[LHS]], %[[RHS]] : f32
+    // CHECK-NEXT:      %[[ADD:.*]] =  addf %[[MULT]], %[[RESULT]] : f32
+    // CHECK-NEXT:      affine.store %[[ADD]], %{{.*}}[%[[I]], %[[J]]] : memref<7x4xf32> 
+    // CHECK: return          
+  "xla_lhlo.dot"(%lhs, %rhs, %result) : 
+    (memref<7x3xf32>, memref<3x4xf32>, memref<7x4xf32>) -> ()
+  return
+}
+

--- a/tensorflow/compiler/mlir/xla/transforms/map_xla_to_scalar_op.h
+++ b/tensorflow/compiler/mlir/xla/transforms/map_xla_to_scalar_op.h
@@ -287,6 +287,29 @@ inline Value MapLhloOpToStdScalarOp<xla_lhlo::ConvertOp>(
   return nullptr;
 }
 
+template<>
+inline Value MapLhloOpToStdScalarOp<xla_lhlo::DotOp>(Location loc, ArrayRef<Type> result_types,
+                                    ArrayRef<Value> args, OpBuilder* b) {
+  // Dot Op converter from lhlo to affine only accepts float and integer types.
+  const auto& lhs = args[0];
+  const auto& rhs = args[1];                                      
+  const auto& result = args[2];
+  Type element_type = lhs.getType();   
+  if (element_type.isa<FloatType>()) {   
+    Value float_mul = MapLhloOpToStdScalarOpImpl<FloatType, ::mlir::MulFOp>{}(
+        loc, result_types, {lhs, rhs}, b);
+    return MapLhloOpToStdScalarOpImpl<FloatType, ::mlir::AddFOp>{}(
+        loc, result_types, {float_mul, result}, b);
+  }
+  if (element_type.isa<IntegerType>()){	
+    Value int_mul = MapLhloOpToStdScalarOpImpl<IntegerType, ::mlir::MulIOp>{}(
+      loc, result_types, {lhs, rhs}, b);    
+    return MapLhloOpToStdScalarOpImpl<IntegerType, ::mlir::AddIOp>{}(
+      loc, result_types, {int_mul, result}, b);
+  }
+  return nullptr;
+}
+
 template <>
 inline Value MapLhloOpToStdScalarOp<xla_lhlo::CosOp>(
     Location loc, ArrayRef<Type> result_types, ArrayRef<Value> args,


### PR DESCRIPTION
Add conversion from MLIR lhlo dot op to affine loops. These conversions are
run as part of -lhlo-legalize-to-affine passes.

Signed-off-by: Prashant Kumar <prashantk@polymagelabs.com>