### PR TITLE
Use proper mmap_allocator for TFLite

### DIFF
--- a/tensorflow/lite/tools/make/Makefile
+++ b/tensorflow/lite/tools/make/Makefile
@@ -177,9 +177,9 @@ ifeq ($(BUILD_TYPE),windows)
 	BUILD_WITH_MMAP=false
 endif
 ifeq ($(BUILD_WITH_MMAP),true)
-	CORE_CC_EXCLUDE_SRCS += tensorflow/lite/mmap_allocation.cc
-else
 	CORE_CC_EXCLUDE_SRCS += tensorflow/lite/mmap_allocation_disabled.cc
+else
+	CORE_CC_EXCLUDE_SRCS += tensorflow/lite/mmap_allocation.cc
 endif
 
 BUILD_WITH_RUY ?= false


### PR DESCRIPTION
When BUILD_WITH_MMAP is true,
mmap_allocator_disabled.cc should be excluded

Change-Id: I2014e79de12512f77c8d3f7a91258dfeef33fb7a
Signed-off-by: Semun Lee <semun.lee@samsung.com>