### PR TITLE
in resolution of [Wsign-compare] warning id 9

### DIFF
--- a/tensorflow/core/framework/cpu_allocator_impl.cc
+++ b/tensorflow/core/framework/cpu_allocator_impl.cc
@@ -75,7 +75,7 @@ class CPUAllocator : public Allocator {
   string Name() override { return "cpu"; }
 
   void* AllocateRaw(size_t alignment, size_t num_bytes) override {
-    if (num_bytes > LargeAllocationWarningBytes() &&
+    if (num_bytes > static_cast<size_t>(LargeAllocationWarningBytes()) &&
         single_allocation_warning_count_ < kMaxSingleAllocationWarnings) {
       ++single_allocation_warning_count_;
       LOG(WARNING) << "Allocation of " << num_bytes << " exceeds "


### PR DESCRIPTION
LargeAllocationWarningBytes() is implied to be a quantity ( it calls AvailableRam(), which unless improperly named, is a quantity/ i.e. non-negative ). 

Given LargeAllocationWarningBytes() is a quantity, it can be cast to size_t with behavior constrained to be as-intend.

@mihaimaruseac 