### PR TITLE
in resolution of [Wsign-compare] warning id 10

### DIFF
--- a/tensorflow/core/framework/allocator_registry.cc
+++ b/tensorflow/core/framework/allocator_registry.cc
@@ -113,7 +113,7 @@ SubAllocator* AllocatorFactoryRegistry::GetSubAllocator(int numa_node) {
       CHECK_LE(numa_node, port::NUMANumNodes());
       index = 1 + numa_node;
     }
-    if (best_entry->sub_allocators.size() < (index + 1)) {
+    if (best_entry->sub_allocators.size() < static_cast<size_t>(index + 1)) {
       best_entry->sub_allocators.resize(index + 1);
     }
     if (!best_entry->sub_allocators[index].get()) {


### PR DESCRIPTION
Static cast  `int index` for the sake of the single `size_t` to `int` comparison on line 116.

@mihaimaruseac 