### PR TITLE
[ROCm] Fix for ROCm CSB breakage - 200529

### DIFF
--- a/tensorflow/python/keras/integration_test/BUILD
+++ b/tensorflow/python/keras/integration_test/BUILD
@@ -75,6 +75,7 @@ cuda_py_test(
     name = "gradient_checkpoint_test",
     srcs = ["gradient_checkpoint_test.py"],
     python_version = "PY3",
+    tags = ["no_rocm"],
     deps = [
         "//tensorflow:tensorflow_py",
         "//tensorflow/python:extra_py_tests_deps",

--- a/tensorflow/python/keras/integration_test/gradient_checkpoint_test.py
+++ b/tensorflow/python/keras/integration_test/gradient_checkpoint_test.py
@@ -75,7 +75,7 @@ def _limit_gpu_memory():
   if gpus:
     tf.config.experimental.set_virtual_device_configuration(
         gpus[0],
-        [tf.config.experimental.VirtualDeviceConfiguration(memory_limit=1152)])
+        [tf.config.experimental.VirtualDeviceConfiguration(memory_limit=1024)])
     return True
   return False
 

--- a/tensorflow/python/keras/optimizer_v2/BUILD
+++ b/tensorflow/python/keras/optimizer_v2/BUILD
@@ -105,6 +105,7 @@ cuda_py_test(
     size = "medium",
     srcs = ["adam_test.py"],
     shard_count = 4,
+    tags = ["no_rocm"],
     deps = [
         ":optimizer_v2",
         "//tensorflow/python:client_testlib",


### PR DESCRIPTION
This PR 
* adds no_rocm tag to one unit-test that recently regressed on the ROCm platform and 
* reverts PR #39914, and instead adds a no_rocm tag to the unit-test regression that was being addressed by that PR

See individual commit messages for details.

---------------------

/cc @chsigg @cheshire @nvining-work 
