### PR TITLE
Change accumulator count dtype to int64 in tf.keras.layers.experimental.preprocessing.Normalization

### DIFF
--- a/tensorflow/python/keras/layers/preprocessing/normalization.py
+++ b/tensorflow/python/keras/layers/preprocessing/normalization.py
@@ -177,7 +177,7 @@ class _NormalizingCombiner(Combiner):
       reduction_counts = np.delete(values.shape, self.axis)
     # We get the number of elements that will be reduced by multiplying all
     # values of 'shape' corresponding to the reduced axes.
-    count = np.prod(reduction_counts, dtype=np.int32)
+    count = np.prod(reduction_counts, dtype=np.int64)
 
     # We want to reduce across dimensions except those specified in 'axis'
     # when using np.mean or np.variance; create the tuple of axes to reduce


### PR DESCRIPTION
This fixes #40016. The dtype for the [outward-facing count](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/layers/preprocessing/normalization.py#L116) is already int64.