### PR TITLE
Fix [SplitV CPU Kernel] condition error for parallelism output judgement.

### DIFF
--- a/tensorflow/core/kernels/split_v_op.cc
+++ b/tensorflow/core/kernels/split_v_op.cc
@@ -206,7 +206,7 @@ class SplitVOpCPUImpl {
     const int num_split = split_start_points.size();
     const bool use_parallelism_between_outputs =
         (num_split >= 4 &&
-         input_element_count >= std::max(num_threads, num_split) * 4096 &&
+         input_element_count >= std::min(num_threads, num_split) * 4096 &&
          input_element_count < num_split * 180 * 1024);
 
     auto range_output_func = [&indices, context, &input_shape, split_dim,


### PR DESCRIPTION
The condition wants to make sure each intra-thread has enough work.
The detail requirement should be:
if num_splits < num_threads, then we just use **num_splits** intra-threads to work, each intra-thread should handle at least 4096 elements.
if num_splits >= num_threads, then we use **num_threads** intra-threads to work, each intra-thread should handle multi-splits, avg sigma( elements of num_spilits / num_threads) > 4096.

So the condition should be **min**(num_splits, num_threads), not **max**.