### PR TITLE
[compiler] Fix segmentation fault in segment graph

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/segment/segment.cc
+++ b/tensorflow/compiler/tf2tensorrt/segment/segment.cc
@@ -721,6 +721,10 @@ Status SegmentGraph(const Graph* tf_graph,
   std::vector<UnionFind<SimpleNode*>> node_segments;
   for (int i = 0; i < graph->num_node_ids(); ++i) {
     SimpleNode* node = graph->FindNodeId(i);
+	if (!node) {
+		VLOG(1) << "Node " << i << " doesn't exist in the graph";
+		continue;
+	}
     auto exclude_node = [&](absl::string_view reason) {
       VLOG(1) << "Not a TF-TRT candidate, "
               << "(Op type: " << node->tf_node()->type_string() << "), "


### PR DESCRIPTION
Signed-off-by: Gaurav Singh <gaurav1086@gmail.com>

The function: graph->FindNodeId(i) can return a nullptr for invalid i (node_id)
```
  SimpleNode* FindNodeId(int node_id) {
    if (node_id < 0 || node_id > static_cast<int>(nodes_.size())) {
      return nullptr;
    }    
    return nodes_[node_id];
  }
```
The returned node is dereferenced multiple times in the caller thereby causing segmentation fault. To fix this, add the null check and if null/invalid, continue/skip the node right away