### PR TITLE
[ROCm] Fix for the build error in ROCm CSB - 200604

### DIFF
--- a/tensorflow/core/util/gpu_device_functions.h
+++ b/tensorflow/core/util/gpu_device_functions.h
@@ -658,6 +658,16 @@ __device__ Eigen::half GpuAtomicCasHelper(Eigen::half* ptr, F accumulate) {
   }
 }
 
+template <typename F>
+__device__ long long GpuAtomicCasHelper(long long* ptr, F accumulate) {
+  return static_cast<long long>(
+      GpuAtomicCasHelper(reinterpret_cast<unsigned long long*>(ptr),
+                         [accumulate](unsigned long long a) {
+                           return static_cast<unsigned long long>(
+                               accumulate(static_cast<long long>(a)));
+                         }));
+}
+
 template <typename From, typename To>
 using ToTypeIfConvertible =
     typename std::enable_if<std::is_convertible<From, To>::value, To>::type;
@@ -779,6 +789,11 @@ __device__ inline double GpuAtomicMax(double* ptr, double value) {
       ptr, [value](double a) { return fmax(a, value); });
 }
 
+__device__ inline long long GpuAtomicMax(long long* ptr, long long value) {
+  return detail::GpuAtomicCasHelper(
+      ptr, [value](long long a) { return max(a, value); });
+}
+
 #else
 
 __device__ inline float GpuAtomicMax(float* ptr, float value) {
@@ -837,6 +852,11 @@ __device__ inline float GpuAtomicMin(float* ptr, float value) {
 __device__ inline double GpuAtomicMin(double* ptr, double value) {
   return detail::GpuAtomicCasHelper(
       ptr, [value](double a) { return fmin(a, value); });
+}
+
+__device__ inline long long GpuAtomicMin(long long* ptr, long long value) {
+  return detail::GpuAtomicCasHelper(
+      ptr, [value](long long a) { return min(a, value); });
 }
 
 #else


### PR DESCRIPTION
The folllowing commit introduced build errors on the ROCm platform
https://github.com/tensorflow/tensorflow/commit/cf30d41ded3b5adae5c3bf3c7e05ce8bb7066a9c

Those initial build errors are addressed by the following commit, but the build is still broken
https://github.com/tensorflow/tensorflow/commit/a1e26e4298aac041e56c856c40bcb0c29fbc3f83

Error we get after the second commit

```
In file included from tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc:24:
In file included from ./tensorflow/core/util/gpu_kernel_helper.h:25:
./tensorflow/core/util/gpu_device_functions.h:754:10: error: no matching function for call to 'atomicMax'
  return atomicMax(ptr, value);
         ^~~~~~~~~
tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc:61:5: note: in instantiation of function template specialization 'tensorflow::GpuAtomicMax<long long, long long>' requested here
    GpuAtomicMax(out, val);
    ^
tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc:118:9: note: in instantiation of member function 'tensorflow::(anonymous namespace)::LeftUpdate<long long, tensorflow::scatter_nd_op::UpdateOp::MAX>::operator()' requested here
        update(out + i + si, ldg(updates + (index * slice_size + si)));
        ^
tensorflow/core/kernels/scatter_nd_op_gpu.cu.cc:156:33: note: in instantiation of function template specialization 'tensorflow::ScatterNdOpKernel<long long, int, tensorflow::scatter_nd_op::UpdateOp::MAX, 1>' requested here
    TF_CHECK_OK(GpuLaunchKernel(ScatterNdOpKernel<T, Index, op, IXDIM>,
                                ^
/opt/rocm-3.3.0/hip/include/hip/hcc_detail/hip_atomic.h:178:5: note: candidate function not viable: no known conversion from 'long long *' to 'int *' for 1st argument
int atomicMax(int* address, int val)
    ^
/opt/rocm-3.3.0/hip/include/hip/hcc_detail/hip_atomic.h:184:14: note: candidate function not viable: no known conversion from 'long long *' to 'unsigned int *' for 1st argument
unsigned int atomicMax(unsigned int* address, unsigned int val)
             ^
/opt/rocm-3.3.0/hip/include/hip/hcc_detail/hip_atomic.h:190:20: note: candidate function not viable: no known conversion from 'long long *' to 'unsigned long long *' for 1st argument
unsigned long long atomicMax(
                   ^
```

This PR fixes the build by adding the following type specializations for the `long long` type
 * `GpuAtomicCasHelper`
 * `GpuAtomicMax`
 * `GpuAtomicMin`


------------------------

/cc @whchung @ekuznetsov139 @chsigg @cheshire @nvining-work 