### PR TITLE
ensure model initialized on ANY trackable attr set

### DIFF
--- a/tensorflow/python/keras/engine/training.py
+++ b/tensorflow/python/keras/engine/training.py
@@ -319,7 +319,7 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
       super(Model, self).__setattr__(name, value)
       return
 
-    if all(
+    if any(
         isinstance(v, (base_layer.Layer,
                        data_structures.TrackableDataStructure)) or
         trackable_layer_utils.has_weights(v) for v in nest.flatten(value)):

--- a/tensorflow/python/keras/engine/training_test.py
+++ b/tensorflow/python/keras/engine/training_test.py
@@ -3328,6 +3328,16 @@ class TestTrainingWithMetrics(keras_parameterized.TestCase):
     outer_model.fit(np.ones((10, 1)), np.ones((10, 1)), batch_size=10)
     self.assertEqual([m.name for m in outer_model.metrics],
                      ['loss', 'acc2', 'mean', 'mean1', 'mean2'])
+  
+  def test_subclassed_model_with_empty_list_attr(self):
+    class ModelSubclass(training_module.Model):
+      def __init__(self):
+        self.empty_list = []
+        inputs = layers_module.Input(shape=())
+        outputs = inputs + 1
+        super(ModelSubclass, self).__init__(inputs, outputs)
+    
+    ModelSubclass()  # empty_list attr assignment should not raise
 
 
 class BareUpdateLayer(layers_module.Layer):


### PR DESCRIPTION
In particular, empty tuples should not trigger this.