### PR TITLE
Convert IndexedSlices to Tensors for backward ConcreteFunction calls.

### DIFF
--- a/tensorflow/python/eager/function.py
+++ b/tensorflow/python/eager/function.py
@@ -737,7 +737,11 @@ class _DelayedRewriteGradientFunctions(object):
     cleaned_doutputs = []
     for doutput, placeholder in zip(doutputs, self._func_graph.outputs):
       if backprop_util.IsTrainable(placeholder):
-        if doutput is not None:
+        if isinstance(doutput, ops.IndexedSlices):
+          # Gradient passed to a backward ConcreteFunction must be tf.Tensor,
+          # so we convert tf.IndexedSlices to tf.Tensor.
+          cleaned_doutputs.append(ops.convert_to_tensor(doutput))
+        elif doutput is not None:
           cleaned_doutputs.append(doutput)
         else:
           cleaned_doutputs.append(default_gradient.zeros_like(placeholder))

--- a/tensorflow/python/eager/function_test.py
+++ b/tensorflow/python/eager/function_test.py
@@ -3800,6 +3800,23 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
     c5_summary = 'func2(x=8, y)'
     self.assertEqual(c5.pretty_printed_signature(verbose=False), c5_summary)
 
+  @test_util.run_in_graph_and_eager_modes
+  def testIndexedSlicesAsGradientsForConcreteFunctions(self):
+    @def_function.function
+    def summing_rnn(inputs):
+      return math_ops.reduce_sum(inputs, axis=1)
+
+    @def_function.function
+    def gradients(inputs):
+      with backprop.GradientTape() as tape:
+        tape.watch(inputs)
+        hidden = summing_rnn(inputs)
+        hidden = array_ops.gather(hidden, constant_op.constant([0]))
+        loss = math_ops.reduce_mean(hidden)
+      return tape.gradient(loss, inputs)
+
+    gradients(constant_op.constant([[[1.0], [2.0]]])) # No error is raised
+
 
 class MultiDeviceTest(test.TestCase, parameterized.TestCase):
 


### PR DESCRIPTION
Fixes #36236.

TL;DR: When a `tf.function` is used in a computation graph, during backward pass all inputs must be Tensors. If they are IndexedSlices (which can happen when for example `tf.gather` is used), an exception is raised.

The fix automatically converts IndexedSlices to Tensors during a backward pass on a ConcreteFunction.

The conversion is currently silent, i.e., no warning is produced. I could imagine a warning being emitted.