### PR TITLE
Change snappy_buffers_test record size for s390x

### DIFF
--- a/tensorflow/core/lib/io/snappy/snappy_test.cc
+++ b/tensorflow/core/lib/io/snappy/snappy_test.cc
@@ -25,7 +25,11 @@ namespace tensorflow {
 // The current implementation of snappy compresses the below block to 619 bytes.
 // We use this to validate the error messages. Please change this number if
 // a new snappy implementation compresses to a different size.
+#if defined(__s390x__)
+const int COMPRESSED_RECORD_SIZE = 620;
+#else 
 const int COMPRESSED_RECORD_SIZE = 619;
+#endif
 
 static string GetRecord() {
   static const string lorem_ipsum =


### PR DESCRIPTION
On s390x the record size for snappy_buffers_test should be 620 bytes.