### PR TITLE
[TF 2.3.0] [Intel MKL] remove duplicate registration for softmax bf16 op

### DIFF
--- a/tensorflow/core/kernels/mkl_tmp_bf16_ops.cc
+++ b/tensorflow/core/kernels/mkl_tmp_bf16_ops.cc
@@ -58,9 +58,7 @@ namespace tensorflow {
   REGISTER_KERNEL_BUILDER(                                                    \
       Name("_FusedMatMul").Device(DEVICE_CPU).TypeConstraint<T>("T"), NoOp);  \
   REGISTER_KERNEL_BUILDER(                                                    \
-      Name("BatchMatMulV2").Device(DEVICE_CPU).TypeConstraint<T>("T"), NoOp); \
-  REGISTER_KERNEL_BUILDER(                                                    \
-      Name("Softmax").Device(DEVICE_CPU).TypeConstraint<T>("T"), NoOp);
+      Name("BatchMatMulV2").Device(DEVICE_CPU).TypeConstraint<T>("T"), NoOp);
 
 TF_CALL_bfloat16(REGISTER_CPU);
 #undef REGISTER_CPU


### PR DESCRIPTION
Removing the duplicate registration of the softmax kernel from mkl_tmp_bf16_op.cc.

Google added the op registration here already
https://github.com/tensorflow/tensorflow/commit/cbac31d59ded64caa23a00481bb33d1104ab8822#diff-d960722b1c03feab5e375c2bfe409747R85