### PR TITLE
[TF 2.3.0] [Intel MKL]  Make bf16 default with mkl + non AVX512 system error handling

### DIFF
--- a/tensorflow/core/graph/mkl_graph_util.h
+++ b/tensorflow/core/graph/mkl_graph_util.h
@@ -216,8 +216,7 @@ static inline bool IsMklNameChangeOp(const string& op_name, DataType T) {
     isTypeAllowed = (T == DT_COMPLEX128 || T == DT_COMPLEX64 ||
                      T == DT_DOUBLE || T == DT_FLOAT);
 #ifdef ENABLE_INTEL_MKL_BFLOAT16
-    isTypeAllowed =
-        (isTypeAllowed || CheckBfloat16Support(T));
+    isTypeAllowed = (isTypeAllowed || CheckBfloat16Support(T));
 #endif
     return isTypeAllowed;
   }

--- a/tensorflow/core/graph/mkl_graph_util.h
+++ b/tensorflow/core/graph/mkl_graph_util.h
@@ -126,7 +126,7 @@ inline string GetMklEagerOpName(const string& name) {
 }
 
 #ifdef ENABLE_INTEL_MKL_BFLOAT16
-static inline bool HasBfloat16Support(DataType T) {
+static inline bool CheckBfloat16Support(DataType T) {
   static absl::once_flag cpu_bfloat16_warn_once_flag;
   // Restrict bfloat16 ops to platforms with at least AVX512 support, fall back
   // to Eigen implementation otherwise.
@@ -159,7 +159,7 @@ static inline bool IsMklLayoutDependentOp(const string& op_name, DataType T) {
 #ifdef ENABLE_INTEL_MKL_BFLOAT16
   // Restrict regular ops to FLOAT and BFLOAT16
   if (kernel.find(kMklLayoutDependentOpLabelPattern) != string::npos) {
-    return (T == DT_FLOAT || (T == DT_BFLOAT16 && HasBfloat16Support(T)));
+    return (T == DT_FLOAT || CheckBfloat16Support(T));
   }
 #else
   // Restrict regular ops to FLOAT
@@ -217,7 +217,7 @@ static inline bool IsMklNameChangeOp(const string& op_name, DataType T) {
                      T == DT_DOUBLE || T == DT_FLOAT);
 #ifdef ENABLE_INTEL_MKL_BFLOAT16
     isTypeAllowed =
-        isTypeAllowed || (T == DT_BFLOAT16 && HasBfloat16Support(T));
+        (isTypeAllowed || CheckBfloat16Support(T));
 #endif
     return isTypeAllowed;
   }

--- a/tensorflow/core/graph/mkl_graph_util.h
+++ b/tensorflow/core/graph/mkl_graph_util.h
@@ -126,10 +126,10 @@ inline string GetMklEagerOpName(const string& name) {
 }
 
 #ifdef ENABLE_INTEL_MKL_BFLOAT16
-static inline bool CheckBfloat16Support(DataType T) {
+static inline bool HasBfloat16Support(DataType T) {
   static absl::once_flag cpu_bfloat16_warn_once_flag;
   // Restrict bfloat16 ops to platforms with at least AVX512 support, fall back
-  // to Eigen implementation.
+  // to Eigen implementation otherwise.
   if (!(port::TestCPUFeature(port::CPUFeature::AVX512F)) && T == DT_BFLOAT16) {
     absl::call_once(cpu_bfloat16_warn_once_flag, [] {
       LOG(ERROR)
@@ -159,7 +159,7 @@ static inline bool IsMklLayoutDependentOp(const string& op_name, DataType T) {
 #ifdef ENABLE_INTEL_MKL_BFLOAT16
   // Restrict regular ops to FLOAT and BFLOAT16
   if (kernel.find(kMklLayoutDependentOpLabelPattern) != string::npos) {
-    return (T == DT_FLOAT || (T == DT_BFLOAT16 && CheckBfloat16Support(T)));
+    return (T == DT_FLOAT || (T == DT_BFLOAT16 && HasBfloat16Support(T)));
   }
 #else
   // Restrict regular ops to FLOAT
@@ -217,7 +217,7 @@ static inline bool IsMklNameChangeOp(const string& op_name, DataType T) {
                      T == DT_DOUBLE || T == DT_FLOAT);
 #ifdef ENABLE_INTEL_MKL_BFLOAT16
     isTypeAllowed =
-        isTypeAllowed || (T == DT_BFLOAT16 && CheckBfloat16Support(T));
+        isTypeAllowed || (T == DT_BFLOAT16 && HasBfloat16Support(T));
 #endif
     return isTypeAllowed;
   }

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -327,7 +327,7 @@ def tf_copts(
         if_tensorrt(["-DGOOGLE_TENSORRT=1"]) +
         if_mkl(["-DINTEL_MKL=1", "-DEIGEN_USE_VML"]) +
         if_mkl_open_source_only(["-DINTEL_MKL_DNN_ONLY"]) +
-        if_mkl_v1_open_source_only(["-DENABLE_MKLDNN_V1"]) +
+        if_mkl_v1_open_source_only(["-DENABLE_MKLDNN_V1", "-DENABLE_INTEL_MKL_BFLOAT16"]) +
         if_mkldnn_threadpool([
             "-DENABLE_MKLDNN_THREADPOOL",
             "-DENABLE_MKLDNN_V1",


### PR DESCRIPTION
1. Make bf16 default with mkl build
2. Log appropriate message to user with legacy systems without AVX512 such as AVX and AVX2 (example broadwell) and fall back to eigen kernels when available.