### PR TITLE
Fix floating point exception with tf.unravel_index

### DIFF
--- a/tensorflow/python/kernel_tests/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops_test.py
@@ -1384,6 +1384,16 @@ class UnravelIndexTest(test_util.TensorFlowTestCase):
         out_3 = array_ops.unravel_index(indices_3, dims_3)
         self.assertAllEqual(out_3.eval(), [[3, 6, 6], [4, 5, 1]])
 
+  # Test case for GitHub issue 40204.
+  def testUnravelIndexZeroDim(self):
+    with self.cached_session():
+      for dtype in [dtypes.int32, dtypes.int64]:
+        with self.assertRaisesRegexp(
+            errors.InvalidArgumentError, "index is out of bound as with dims"):
+          indices = constant_op.constant([2, 5, 7], dtype=dtype)
+          dims = constant_op.constant([3, 0], dtype=dtype)
+          self.evaluate(array_ops.unravel_index(indices=indices, dims=dims))
+
 
 class GuaranteeConstOpTest(test_util.TensorFlowTestCase):
 


### PR DESCRIPTION
This PR tries to address the issue raised in #40204 where
`tf.unravel_index` caused floating point exception when any one
element is 0 in `dims`.

The issue is that `indices` in `tf.unravel_index` should make sure
it is not out of boundary compared to `dims`.

This PR fixes the issue by adding a check before hand, though Eigen.

This PR fixes #40204.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>