### PR TITLE
Undefined name: import sys for line 56

### DIFF
--- a/tensorflow/compiler/mlir/runlit.cfg.py
+++ b/tensorflow/compiler/mlir/runlit.cfg.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 
 import os
 import platform
+import sys
 import lit.formats
 from lit.llvm import llvm_config
 from lit.llvm.subst import ToolSubst


### PR DESCRIPTION
`sys` is neither defined nor imported which leads to an _undefined name_ which has the potential to raise NameError at runtime.