### PR TITLE
Fix SyntaxWarnings on Python >= 3.8

### DIFF
--- a/tensorflow/python/kernel_tests/matrix_band_part_op_test.py
+++ b/tensorflow/python/kernel_tests/matrix_band_part_op_test.py
@@ -56,7 +56,7 @@ def _GetMatrixBandPartTest(dtype_, batch_shape_, shape_):
           band_np = np.triu(band_np, -lower)
         if upper >= 0:
           band_np = np.tril(band_np, upper)
-        if batch_shape_ is not ():
+        if batch_shape_ != ():
           band_np = np.tile(band_np, batch_shape_ + (1, 1))
         for index_dtype in [dtypes_lib.int32, dtypes_lib.int64]:
           with self.cached_session(use_gpu=False):

--- a/tensorflow/python/kernel_tests/matrix_solve_ls_op_test.py
+++ b/tensorflow/python/kernel_tests/matrix_solve_ls_op_test.py
@@ -107,7 +107,7 @@ class MatrixSolveLsOpTest(test_lib.TestCase):
       np_ans = _SolveWithNumpy(x, y, l2_regularizer=l2_regularizer)
       np_r = np.dot(np.conj(a.T), b - np.dot(a, np_ans))
       np_r_norm = np.sqrt(np.sum(np.conj(np_r) * np_r))
-      if batch_shape is not ():
+      if batch_shape != ():
         a = np.tile(a, batch_shape + (1, 1))
         b = np.tile(b, batch_shape + (1, 1))
         np_ans = np.tile(np_ans, batch_shape + (1, 1))

--- a/tensorflow/python/ops/ragged/ragged_batch_gather_with_default_op.py
+++ b/tensorflow/python/ops/ragged/ragged_batch_gather_with_default_op.py
@@ -81,8 +81,7 @@ def batch_gather_with_default(params,
                                               return_dtype=True))
     # TODO(hterry): lift this restriction and support default_values of
     #               of rank > 1
-    if (default_value.shape.ndims is not 0
-        and default_value.shape.ndims is not 1):
+    if default_value.shape.ndims not in (0, 1):
       raise ValueError('"default_value" must be a scalar or vector')
     upper_bounds = None
     if indices.shape.ndims is None:

--- a/tensorflow/python/ops/random_ops.py
+++ b/tensorflow/python/ops/random_ops.py
@@ -288,8 +288,8 @@ def random_uniform(shape,
     shape = tensor_util.shape_tensor(shape)
     # In case of [0,1) floating results, minval and maxval is unused. We do an
     # `is` comparison here since this is cheaper than isinstance or  __eq__.
-    minval_is_zero = minval is 0  # pylint: disable=literal-comparison
-    maxval_is_one = maxval is 1  # pylint: disable=literal-comparison
+    minval_is_zero = minval == 0
+    maxval_is_one = maxval == 1
     if not minval_is_zero or not maxval_is_one or dtype.is_integer:
       minval = ops.convert_to_tensor(minval, dtype=dtype, name="min")
       maxval = ops.convert_to_tensor(maxval, dtype=dtype, name="max")

--- a/tensorflow/python/ops/random_ops.py
+++ b/tensorflow/python/ops/random_ops.py
@@ -288,8 +288,8 @@ def random_uniform(shape,
     shape = tensor_util.shape_tensor(shape)
     # In case of [0,1) floating results, minval and maxval is unused. We do an
     # `is` comparison here since this is cheaper than isinstance or  __eq__.
-    minval_is_zero = minval == 0
-    maxval_is_one = maxval == 1
+    minval_is_zero = minval is 0  # pylint: disable=literal-comparison
+    maxval_is_one = maxval is 1  # pylint: disable=literal-comparison
     if not minval_is_zero or not maxval_is_one or dtype.is_integer:
       minval = ops.convert_to_tensor(minval, dtype=dtype, name="min")
       maxval = ops.convert_to_tensor(maxval, dtype=dtype, name="max")

--- a/tensorflow/tools/docs/doc_generator_visitor.py
+++ b/tensorflow/tools/docs/doc_generator_visitor.py
@@ -240,10 +240,9 @@ class DocGeneratorVisitor(object):
       # We cannot use the duplicate mechanism for some constants, since e.g.,
       # id(c1) == id(c2) with c1=1, c2=1. This is unproblematic since constants
       # have no usable docstring and won't be documented automatically.
-      if (py_object is not None and
+      if (py_object not in (None, ())
           not isinstance(py_object, six.integer_types + six.string_types +
-                         (six.binary_type, six.text_type, float, complex, bool))
-          and py_object is not ()):  # pylint: disable=literal-comparison
+                         (six.binary_type, six.text_type, float, complex, bool))):
         object_id = id(py_object)
         if object_id in reverse_index:
           master_name = reverse_index[object_id]

--- a/tensorflow/tools/docs/doc_generator_visitor.py
+++ b/tensorflow/tools/docs/doc_generator_visitor.py
@@ -241,7 +241,7 @@ class DocGeneratorVisitor(object):
       # id(c1) == id(c2) with c1=1, c2=1. This is unproblematic since constants
       # have no usable docstring and won't be documented automatically.
       if (py_object not in (None, ())
-          not isinstance(py_object, six.integer_types + six.string_types +
+          and not isinstance(py_object, six.integer_types + six.string_types +
                          (six.binary_type, six.text_type, float, complex, bool))):
         object_id = id(py_object)
         if object_id in reverse_index:


### PR DESCRIPTION
Avoid [SyntaxWarnings on Python >= 3.8](https://docs.python.org/3/whatsnew/3.8.html#porting-to-python-3-8).

% `python3.8`
```
>>> 0 is 0
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
>>> () is ()
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
```