### PR TITLE
[ROCm] Fix for ROCm CSB breakage - 200608

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
@@ -159,7 +159,7 @@ class MathTest(test.TestCase, parameterized.TestCase):
         actual.shape, expected.shape,
         'Shape mismatch.\nActual: {}\nExpected: {}\n{}'.format(
             actual.shape, expected.shape, msg))
-    np.testing.assert_almost_equal(actual.tolist(), expected.tolist())
+    np.testing.assert_allclose(actual.tolist(), expected.tolist(), rtol=1e-6)
 
   def testArgsort(self):
     self._testUnaryOp(np_math_ops.argsort, np.argsort, 'argsort')


### PR DESCRIPTION
The test `//tensorflow/python/ops/numpy_ops:np_math_ops_test_gpu` started failing on Friday (200605), with the following error

```
=====================================================================
FAIL: testExp (__main__.MathTest)
testExp (__main__.MathTest)
----------------------------------------------------------------------
Traceback (most recent call last):
...
...
AssertionError:
Arrays are not almost equal to 7 decimals

Mismatched elements: 1 / 2 (50%)
Max absolute difference: 4.76837158e-07
Max relative difference: 6.45328909e-08
 x: array([ 7.3890557, 20.085537 ])
 y: array([ 7.3890562, 20.085537 ])

----------------------------------------------------------------------
Ran 19 tests in 24.663s

FAILED (failures=1, skipped=1)
================================================================================

```

This is a new unit test introduced by the commit 84c796966b0b75a3561d4b076a8388f2091ff57d

The fix is to drop the relative tolerance down to 1e-6 (from the default of 1e-7). This should be okay since numerous other TF unit tests also use the same value for relative tolerance.

Note that this commit also changes the check call from `assert_almost_equal` to `assert_allclose`, to be able to specifyt eh relative tolerance



-------------------------------------

cc @whchung @chsigg @cheshire @nvining-work 