### PR TITLE
Keras: Allow setting constant initializers using Python literals

### DIFF
--- a/tensorflow/python/keras/initializers/__init__.py
+++ b/tensorflow/python/keras/initializers/__init__.py
@@ -157,6 +157,8 @@ def get(identifier):
     return deserialize(identifier)
   elif callable(identifier):
     return identifier
+  elif isinstance(identifier, (int, float)):
+    return initializers_v2.Constant(identifier)
   else:
     raise ValueError('Could not interpret initializer identifier: ' +
                      str(identifier))

--- a/tensorflow/python/keras/initializers_test.py
+++ b/tensorflow/python/keras/initializers_test.py
@@ -201,6 +201,16 @@ class KerasInitializersTest(test.TestCase):
     self.assertEqual(tn.mean, 0.0)
     self.assertEqual(tn.stddev, 0.05)
 
+  def test_constant_int(self):
+    cst = initializers.get(3)
+    self.assertIsInstance(cst, initializers.ConstantV2)
+    self.assertEqual(cst.value, 3.0)
+
+  def test_constant_float(self):
+    cst = initializers.get(6.0)
+    self.assertIsInstance(cst, initializers.ConstantV2)
+    self.assertEqual(cst.value, 6.0)
+
   def test_custom_initializer_saving(self):
 
     def my_initializer(shape, dtype=None):


### PR DESCRIPTION
This PR adds support for setting Keras constant initializers using Python literals.

## Motivation
When implementing custom layers that use some variant of scaling factors that should be initialized with a non-zero and non-unit constants I often find myself needing to write some avoidable boilerplate since using a mutable `tf.keras.initializers.Constant` as a [default argument can lead to unexpected behaviour in Python](https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments).

For implementing such a custom layer I would usually do something like
```python
class CustomLayer(tf.keras.layers.Layer):
    def __init__(self, scale_initializer=None, **kwargs):
        if scale_initializer is None:
            self.scale_initializer = tf.keras.initializers.Constant(0.5)
        else:
            self.scale_initializer = tf.keras.initializers.get(scale_initializer)
        super().__init__(**kwargs)
```
which in my opinion is not optimial because the default value won't be obvious from the signature unless documented explicitely.

The second option would be to pass an initial value directly which breaks with the Keras naming convention of `{variable_name}_initializer`.
```python
class CustomLayer(tf.keras.layers.Layer):
    def __init__(self, scale_initial_value=0.5, **kwargs):
        self.scale_initializer = tf.keras.initializers.Constant(scale_initial_value)
        super().__init__(**kwargs)
```

This PR allows to set constant initializers directly via Python literals without needing to overwrite `tf.keras.initializers.get`:
```python
class CustomLayer(tf.keras.layers.Layer):
    def __init__(self, scale_initializer=0.5, **kwargs):
        self.scale_initializer = tf.keras.initializers.get(scale_initializer)
        super().__init__(**kwargs)
```
Furthermore this simplifies the use of `Layer.add_weight` when initializing it with plain Python constants that might be computed from the `input_shape` inside `Layer.build`.