### PR TITLE
xrange() was removed from Python on 1/1/2020

### DIFF
--- a/tensorflow/python/training/tracking/benchmarks_test.py
+++ b/tensorflow/python/training/tracking/benchmarks_test.py
@@ -77,7 +77,7 @@ class SavingBenchmarks(test.Benchmark):
   def _run(self, func, num_iters, execution_mode=None):
     func()
     start = time.time()
-    for _ in xrange(num_iters):
+    for _ in range(num_iters):
       func()
     end = time.time()
     mean_us = (end - start) * 1e6 / num_iters


### PR DESCRIPTION
Like #40241