### PR TITLE
[TF-TRT] - Bazel Test does not use allow_growth in TF2

### DIFF
--- a/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
+++ b/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
@@ -376,7 +376,6 @@ class TfTrtIntegrationTestBase(test_util.TensorFlowTestCase):
 
   def _RunGraphV2(self, saved_model_dir, inputs_data, graph_state, num_runs=2):
     """Run given graphdef multiple times using TF 2.0 runtime."""
-
     params = self._GetParamsCached()
     root = load.load(saved_model_dir)
     func = root.signatures[
@@ -431,7 +430,6 @@ class TfTrtIntegrationTestBase(test_util.TensorFlowTestCase):
                        conversion_params):
     """Return a TrtGraphConverter."""
     if run_params.is_v2:
-
       return trt_convert.TrtGraphConverterV2(
           input_saved_model_dir=saved_model_dir,
           conversion_params=conversion_params)

--- a/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
+++ b/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
@@ -36,6 +36,7 @@ from tensorflow.core.framework import graph_pb2
 from tensorflow.core.protobuf import config_pb2
 from tensorflow.python.compiler.tensorrt import trt_convert
 from tensorflow.python.eager import def_function
+from tensorflow.python.framework import config
 from tensorflow.python.framework import graph_io
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import tensor_spec
@@ -375,6 +376,13 @@ class TfTrtIntegrationTestBase(test_util.TensorFlowTestCase):
 
   def _RunGraphV2(self, saved_model_dir, inputs_data, graph_state, num_runs=2):
     """Run given graphdef multiple times using TF 2.0 runtime."""
+
+    gpus = config.list_physical_devices('GPU')
+
+    # Modifying the GPU configuration is not supported
+    for gpu in gpus:
+        config.set_memory_growth(gpu, True)
+
     params = self._GetParamsCached()
     root = load.load(saved_model_dir)
     func = root.signatures[
@@ -429,6 +437,13 @@ class TfTrtIntegrationTestBase(test_util.TensorFlowTestCase):
                        conversion_params):
     """Return a TrtGraphConverter."""
     if run_params.is_v2:
+
+      gpus = config.list_physical_devices('GPU')
+
+      # Modifying the GPU configuration is not supported
+      for gpu in gpus:
+        config.set_memory_growth(gpu, True)
+
       return trt_convert.TrtGraphConverterV2(
           input_saved_model_dir=saved_model_dir,
           conversion_params=conversion_params)
@@ -803,6 +818,13 @@ class TfTrtIntegrationTestBase(test_util.TensorFlowTestCase):
 
   def _MakeSavedModel(self, run_params):
     if run_params.is_v2:
+
+      gpus = config.list_physical_devices('GPU')
+
+      # Modifying the GPU configuration is not supported
+      for gpu in gpus:
+        config.set_memory_growth(gpu, True)
+
       return self._MakeSavedModelV2(run_params)
     return self._MakeSavedModelV1(run_params)
 

--- a/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
+++ b/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
@@ -377,12 +377,6 @@ class TfTrtIntegrationTestBase(test_util.TensorFlowTestCase):
   def _RunGraphV2(self, saved_model_dir, inputs_data, graph_state, num_runs=2):
     """Run given graphdef multiple times using TF 2.0 runtime."""
 
-    gpus = config.list_physical_devices('GPU')
-
-    # Modifying the GPU configuration is not supported
-    for gpu in gpus:
-        config.set_memory_growth(gpu, True)
-
     params = self._GetParamsCached()
     root = load.load(saved_model_dir)
     func = root.signatures[
@@ -437,12 +431,6 @@ class TfTrtIntegrationTestBase(test_util.TensorFlowTestCase):
                        conversion_params):
     """Return a TrtGraphConverter."""
     if run_params.is_v2:
-
-      gpus = config.list_physical_devices('GPU')
-
-      # Modifying the GPU configuration is not supported
-      for gpu in gpus:
-        config.set_memory_growth(gpu, True)
 
       return trt_convert.TrtGraphConverterV2(
           input_saved_model_dir=saved_model_dir,
@@ -818,13 +806,6 @@ class TfTrtIntegrationTestBase(test_util.TensorFlowTestCase):
 
   def _MakeSavedModel(self, run_params):
     if run_params.is_v2:
-
-      gpus = config.list_physical_devices('GPU')
-
-      # Modifying the GPU configuration is not supported
-      for gpu in gpus:
-        config.set_memory_growth(gpu, True)
-
       return self._MakeSavedModelV2(run_params)
     return self._MakeSavedModelV1(run_params)
 
@@ -832,6 +813,11 @@ class TfTrtIntegrationTestBase(test_util.TensorFlowTestCase):
     should_run, reason_for_skipping = self.ShouldRunTest(run_params)
     if not should_run:
       return self.skipTest(reason_for_skipping)
+
+    if run_params.is_v2:
+      gpus = config.list_physical_devices('GPU')
+      for gpu in gpus:
+        config.set_memory_growth(gpu, True)
 
     saved_model_dir = self._MakeSavedModel(run_params)
 


### PR DESCRIPTION
CC: @bixia1 I recently saw numerous of OOM when running python bazel tests:

```bash
bazel test --verbose_failures --cache_test_results=no --runs_per_test=10 //tensorflow/python/compiler/tensorrt/...
```

This tends to generate OOM issues for the TF2 unittests. This PR fixes this. 

In TF1 the configuration is applied properly, in TF2 mode this is skipped: https://github.com/tensorflow/tensorflow/blob/e5648ef49daa9500ebdebca603f3b5cc42c76a99/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py#L317-L320