### PR TITLE
Fix tf.broadcast_to abort issue when given shape value overflows int32

### DIFF
--- a/tensorflow/compiler/tf2xla/xla_op_kernel.cc
+++ b/tensorflow/compiler/tf2xla/xla_op_kernel.cc
@@ -352,6 +352,12 @@ Status XlaOpKernelContext::ConstantInputAsShape(int index, TensorShape* shape) {
   TF_RETURN_IF_ERROR(ConstantInput(index, &literal));
   std::vector<int64> dims;
   TF_RETURN_IF_ERROR(LiteralToInt64Vector(literal, &dims));
+  for (size_t i = 0; i < dims.size(); i ++) {
+    if (dims[i] < 0) {
+      return errors::InvalidArgument(
+          "Dimension[", i, "] ", dims[i], " must be >= 0");
+    }
+  }
   *shape = TensorShape(dims);
   return Status::OK();
 }

--- a/tensorflow/python/kernel_tests/broadcast_to_ops_test.py
+++ b/tensorflow/python/kernel_tests/broadcast_to_ops_test.py
@@ -200,6 +200,16 @@ class BroadcastToTest(test_util.TensorFlowTestCase):
       v = array_ops.broadcast_to(constant_op.constant(x), output_shape)
       self.evaluate(v)
 
+  # Test case for GitHub issue 40138.
+  def testBroadcastToOverflow(self):
+    for dtype in [np.uint32, np.uint64]:
+      with self.assertRaisesRegexp(errors.InvalidArgumentError,
+                                   "must be >= 0"):
+        with self.session():
+          x = np.array([1, 2], dtype=dtype)
+          shape = np.array([1e18, 2]).astype('int64')
+          self.evaluate(array_ops.broadcast_to(x, shape))
+
 
 if __name__ == "__main__":
   test_lib.main()


### PR DESCRIPTION
This PR tries to address the issue raised in #40138 where
`tf.broadcast_to(input, shape)` will cause abort core dump if `shape`
overflows and `input` is `uint32` or `uint64`.

The issue is more about xla than `broadcast_to`. Since `BroadcastTo`
does not have normal kernel for uint32 or uint64, it will fall back
to XLA. In XLA, the `shape` will result in abort as no value check (>=0).

This PR adds shape dim value check for XLA so that an error will be returned
gracefully (than a core dump).

This PR fixes #40138.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>