### PR TITLE
Make http://metadata.google.internal configurable

### DIFF
--- a/tensorflow/python/tpu/client/client.py
+++ b/tensorflow/python/tpu/client/client.py
@@ -38,7 +38,7 @@ _GKE_ENV_VARIABLE = 'KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS'
 _ENDPOINTS_SEPARATOR = ','
 _DEFAULT_ENV_VARIABLE = 'TPU_NAME'
 _DISCOVERY_SERVICE_URL_ENV_VARIABLE = 'TPU_API_DISCOVERY_URL'
-_GCE_METADATA_ENDPOINT = 'http://metadata.google.internal'
+_GCE_METADATA_URL_ENV_VARIABLE = 'GCE_METADATA_IP'
 _DEFAULT_ENDPOINT_PORT = '8470'
 
 
@@ -46,9 +46,15 @@ def _environment_discovery_url():
   return os.environ.get(_DISCOVERY_SERVICE_URL_ENV_VARIABLE)
 
 
+def _gce_metadata_endpoint():
+  return 'http://' + os.environ.get(
+    _GCE_METADATA_URL_ENV_VARIABLE,
+    'metadata.google.internal')
+
+
 def _request_compute_metadata(path):
   req = request.Request(
-      '%s/computeMetadata/v1/%s' % (_GCE_METADATA_ENDPOINT, path),
+      '%s/computeMetadata/v1/%s' % (_gce_metadata_endpoint(), path),
       headers={'Metadata-Flavor': 'Google'})
   resp = request.urlopen(req)
   return _as_text(resp.read())

--- a/tensorflow/python/tpu/client/client.py
+++ b/tensorflow/python/tpu/client/client.py
@@ -48,8 +48,8 @@ def _environment_discovery_url():
 
 def _gce_metadata_endpoint():
   return 'http://' + os.environ.get(
-    _GCE_METADATA_URL_ENV_VARIABLE,
-    'metadata.google.internal')
+      _GCE_METADATA_URL_ENV_VARIABLE,
+      'metadata.google.internal')
 
 
 def _request_compute_metadata(path):


### PR DESCRIPTION
The TPU client library has a hardcoded dependency on `http://metadata.google.internal`. We happen to need to redirect this URL to a different VM. Since the URL is hardcoded, we're forced to use a fragile code patch against our version of Tensorflow, which isn't ideal, or rely on `/etc/hosts` to forward `metadata.google.internal`, which causes unexpected global side effects to the user's VM. (For example, GCE uses `metadata.google.internal` to distribute SSH keys to GCE VMs, which breaks when we reroute `metadata.google.internal` using `/etc/hosts`.)

oauth2client solves this by making `http://metadata.google.internal` configurable via the `GCE_METADATA_IP` environment variable. The final url becomes `'http://' + os.getenv('GCE_METADATA_IP', '169.254.169.254')`:

https://github.com/googleapis/oauth2client/blob/50d20532a748f18e53f7d24ccbe6647132c979a9/oauth2client/client.py#L111

Following oauth2client's lead, this PR makes `http://metadata.google.internal` configurable for Tensorflow users via `GCE_METADATA_IP`:

```py
_GCE_METADATA_URL_ENV_VARIABLE = 'GCE_METADATA_IP'

# ...

def _gce_metadata_endpoint():
  return 'http://' + os.environ.get(
    _GCE_METADATA_URL_ENV_VARIABLE,
    'metadata.google.internal')
```

`GCE_METADATA_IP` might seem like an awkward name. After all, `metadata.google.internal` is a URL, not an IP address. But it's probably best to match oauth2client's naming convention. That way users won't need to worry about setting two slightly-different variable names to configure both oauth2client and Tensorflow.