### PR TITLE
[ROCm] Fix for ROCm CSB breakage - 200609

### DIFF
--- a/tensorflow/python/eager/function_test.py
+++ b/tensorflow/python/eager/function_test.py
@@ -2799,8 +2799,14 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
     if not context.executing_eagerly():
       self.skipTest('eager only')
 
+    # testSharedRendezvous sets the disable_meta_optimizer flag to True
+    # if that subtest runs before this one, then having that set to True
+    # will cause this subtest to fail. To avoid that scenario, explicitly
+    # set the disable_meta_optimizer flag to false here
     context.context().set_optimizer_experimental_options(
-        {'min_graph_nodes': -1, 'implementation_selector': True})
+        {'min_graph_nodes': -1,
+         'implementation_selector': True,
+         'disable_meta_optimizer': False})
 
     @function.defun_with_attributes(
         attributes={'api_implements': 'foo',


### PR DESCRIPTION
The test `//tensorflow/python/eager:function_test_gpu` started failing today (200609), with the following error

```
======================================================================
FAIL: testSwapImplementationInEager (__main__.FunctionTest)
testSwapImplementationInEager (__main__.FunctionTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/.cache/bazel/_bazel_root/efb88f6336d9c4a18216fb94287b8d97/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/eager/function_test_gpu.runfiles/org_tensorflow/tensorflow/python/eager/function_test.py", line 2824, in testSwapImplementationInEager
    self.assertEqual(run_on_cpu(constant_op.constant(1)).numpy(), 3)
AssertionError: 5 != 3

----------------------------------------------------------------------
Ran 69 tests in 24.622s

FAILED (failures=1, skipped=1)
```

This failure seems to have been introduced by the commit b0b763203e98ea616f44678e194470791db7188d

The failing subtest is `testSwapImplementationInEager`, which I think relies on the `disable_meta_optimizer` being set to `False` (which is the default value). There is another subtest `testSharedRendezvous` within this unit-test that explicitly sets the same flag to `True`. If the `testSharedRendezvous` subtest runs before the `testSwapImplementationInEager` subtest, then the flag `disable_meta_optimizer` gets set to `True` and leads to the failure shown above (in the `testSwapImplementationInEager` subtest)

The "fix" is explicitly set the `disable_meta_optimizer` flag to `False` in the `testSwapImplementationInEager` subtest


------------------------------------------------------

cc @cheshire @chsigg @nvining-work 
