### PR TITLE
Update google cloud cpp to 1.14.0

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -316,15 +316,15 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
 
     tf_http_archive(
         name = "com_github_googlecloudplatform_google_cloud_cpp",
-        sha256 = "d67fed328d82aa404c3ab8f52814914f419a673573e3bbd98b4e6c405ca3cd06",
-        strip_prefix = "google-cloud-cpp-0.17.0",
+        sha256 = "839b2d4dcb36a671734dac6b30ea8c298bbeaafcf7a45ee4a7d7aa5986b16569",
+        strip_prefix = "google-cloud-cpp-1.14.0",
         system_build_file = clean_dep("//third_party/systemlibs:google_cloud_cpp.BUILD"),
         system_link_files = {
             "//third_party/systemlibs:google_cloud_cpp.google.cloud.bigtable.BUILD": "google/cloud/bigtable/BUILD",
         },
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/googleapis/google-cloud-cpp/archive/v0.17.0.tar.gz",
-            "https://github.com/googleapis/google-cloud-cpp/archive/v0.17.0.tar.gz",
+            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/googleapis/google-cloud-cpp/archive/v1.14.0.tar.gz",
+            "https://github.com/googleapis/google-cloud-cpp/archive/v1.14.0.tar.gz",
         ],
     )
 


### PR DESCRIPTION
@mihaimaruseac 
The new version contains some fixes and features we need.
- Fix build on some versions of MSVC (This PR is made by me) https://github.com/googleapis/google-cloud-cpp/pull/4059
- Check if running inside Google https://github.com/googleapis/google-cloud-cpp/pull/3959
- Implement resumable parallel file uploads https://github.com/googleapis/google-cloud-cpp/pull/3389

In fact, I don't update the current version since I don't understand `system_link_files` and `system_build_file` and I think this library is used internally only in Google till now.

About the patch file, I don't add it here because it is related to GCS only. We need that patch file since `google-cloud-cpp` uses `@com_github_curl_curl` instead of `@curl` and we don't want it to download and recompile `curl`. It would be nice if Bazel has a feature that allow us to make an alias of a repository ( e.g `com_github_curl_curl` will be an alias of `curl`). That way we don't need the patch file