### PR TITLE
[ROCm][mlir] Disable mlir saved model test

### DIFF
--- a/tensorflow/compiler/mlir/tensorflow/tests/tf_saved_model/build_defs.bzl
+++ b/tensorflow/compiler/mlir/tensorflow/tests/tf_saved_model/build_defs.bzl
@@ -4,8 +4,6 @@ load("//tensorflow/compiler/mlir:glob_lit_test.bzl", "lit_test")
 
 def tf_saved_model_test(name, data, tags = None):
     """Create a SavedModel test."""
-    if tags == None:
-        tags = ["no_rocm"]
     native.py_binary(
         name = name,
         testonly = 1,
@@ -26,5 +24,5 @@ def tf_saved_model_test(name, data, tags = None):
         name = name + ".py",
         data = [name] + data,
         driver = "@llvm-project//mlir:run_lit.sh",
-        tags = tags,
+        tags = tags + ["no_rocm"],
     )


### PR DESCRIPTION
Adding `no-rocm` tag to saved model test. There is flaky OOM failures yet to be investigated in the following unit tests in ROCm CI:

- basic_v1.py.test
- multi_variables_v1.py.test
- shared_variables_v1.py.test

The added tag disables those unit tests.