### PR TITLE
[GPU delegate] Fix cannot locate symbol error

### DIFF
--- a/tensorflow/lite/delegates/gpu/cl/arguments.cc
+++ b/tensorflow/lite/delegates/gpu/cl/arguments.cc
@@ -130,6 +130,8 @@ std::string GetImageModifier(AccessType access) {
 
 }  // namespace
 
+constexpr char Arguments::kArgsPrefix[];
+
 Arguments::Arguments(Arguments&& args)
     : int_values_(std::move(args.int_values_)),
       shared_int4s_data_(std::move(args.shared_int4s_data_)),


### PR DESCRIPTION
Fix cannot locate symbol "_ZN6tflite3gpu2cl9Arguments11kArgsPrefixE" error by defining Arguments::kArgsPrefix storage