### PR TITLE
use curl instead of com_github_curl_curl

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -318,6 +318,9 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
         name = "com_github_googlecloudplatform_google_cloud_cpp",
         sha256 = "839b2d4dcb36a671734dac6b30ea8c298bbeaafcf7a45ee4a7d7aa5986b16569",
         strip_prefix = "google-cloud-cpp-1.14.0",
+        repo_mapping = {
+            "@com_github_curl_curl": "@curl",
+        },
         system_build_file = clean_dep("//third_party/systemlibs:google_cloud_cpp.BUILD"),
         system_link_files = {
             "//third_party/systemlibs:google_cloud_cpp.google.cloud.bigtable.BUILD": "google/cloud/bigtable/BUILD",


### PR DESCRIPTION
@mihaimaruseac 
This PR allow `google_cloud_cpp` use the existing `@curl` instead of download `@com_github_curl_curl` which is the same but different name because of BUILD file.
https://github.com/googleapis/google-cloud-cpp/blob/b22e726162e3d5c5f7e177a3bf26982873399018/google/cloud/storage/BUILD#L80