### PR TITLE
Enable resize_images_with_crop_or_pad to pad with normal tensorflow.pad calls (mode, name, and constant_values)

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -882,17 +882,20 @@ def pad_to_bounding_box(image, offset_height, offset_width, target_height,
   offset_height = tf.constant(1), 
   offset_width = tf.constant(1)
   target_height = tf.constant(4)
-  target-width = tf.constant(7)
+  target_width = tf.constant(7)
   #constant_values = 0
-  tf.pad(t, paddings, "CONSTANT")  # [[0, 0, 0, 0, 0, 0, 0],
+  tf.image.pad_to_bounding_box(t, offset_height=offset_height, offset_width=offset_width, target_height=target_height, target_width=target_width, mode="CONSTANT")  
+                                   # [[0, 0, 0, 0, 0, 0, 0],
                                    #  [0, 0, 1, 2, 3, 0, 0],
                                    #  [0, 0, 4, 5, 6, 0, 0],
                                    #  [0, 0, 0, 0, 0, 0, 0]]
-  tf.pad(t, paddings, "REFLECT")  # [[6, 5, 4, 5, 6, 5, 4],
+  tf.image.pad_to_bounding_box(t, offset_height=offset_height, offset_width=offset_width, target_height=target_height, target_width=target_width, mode="REFLECT")  
+                                  # [[6, 5, 4, 5, 6, 5, 4],
                                   #  [3, 2, 1, 2, 3, 2, 1],
                                   #  [6, 5, 4, 5, 6, 5, 4],
                                   #  [3, 2, 1, 2, 3, 2, 1]]
-  tf.pad(t, paddings, "SYMMETRIC")  # [[2, 1, 1, 2, 3, 3, 2],
+  tf.image.pad_to_bounding_box(t, offset_height=offset_height, offset_width=offset_width, target_height=target_height, target_width=target_width, mode="SYMETRIC")  
+                                    # [[2, 1, 1, 2, 3, 3, 2],
                                     #  [2, 1, 1, 2, 3, 3, 2],
                                     #  [5, 4, 4, 5, 6, 6, 5],
                                     #  [5, 4, 4, 5, 6, 6, 5]]

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1079,12 +1079,12 @@ def resize_image_with_crop_or_pad(image, target_height, target_width, mode="CONS
   """Crops and/or pads an image to a target width and height.
 
   Resizes an image to a target width and height by either centrally
-  cropping the image or padding it evenly with zeros.
+  cropping the image or padding it evenly with 'constant_values'.
 
   If `width` or `height` is greater than the specified `target_width` or
   `target_height` respectively, this op centrally crops along that dimension.
   If `width` or `height` is smaller than the specified `target_width` or
-  `target_height` respectively, this op centrally pads with 0 along that
+  `target_height` respectively, this op centrally pads with 'constant_values' along that
   dimension.
 
   Args:

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -879,27 +879,38 @@ def pad_to_bounding_box(image, offset_height, offset_width, target_height,
   `target_height` by `target_width`.
 
   Usage Example:
-  t = tf.constant([[1, 2, 3], [4, 5, 6]])
-  offset_height = tf.constant(1), 
-  offset_width = tf.constant(1)
-  target_height = tf.constant(4)
-  target_width = tf.constant(7)
-  #constant_values = 0
-  tf.image.pad_to_bounding_box(t, offset_height=offset_height, offset_width=offset_width, target_height=target_height, target_width=target_width, mode="CONSTANT")  
-                                   # [[0, 0, 0, 0, 0, 0, 0],
-                                   #  [0, 0, 1, 2, 3, 0, 0],
-                                   #  [0, 0, 4, 5, 6, 0, 0],
-                                   #  [0, 0, 0, 0, 0, 0, 0]]
-  tf.image.pad_to_bounding_box(t, offset_height=offset_height, offset_width=offset_width, target_height=target_height, target_width=target_width, mode="REFLECT")  
-                                  # [[6, 5, 4, 5, 6, 5, 4],
-                                  #  [3, 2, 1, 2, 3, 2, 1],
-                                  #  [6, 5, 4, 5, 6, 5, 4],
-                                  #  [3, 2, 1, 2, 3, 2, 1]]
-  tf.image.pad_to_bounding_box(t, offset_height=offset_height, offset_width=offset_width, target_height=target_height, target_width=target_width, mode="SYMMETRIC")  
-                                    # [[2, 1, 1, 2, 3, 3, 2],
-                                    #  [2, 1, 1, 2, 3, 3, 2],
-                                    #  [5, 4, 4, 5, 6, 6, 5],
-                                    #  [5, 4, 4, 5, 6, 6, 5]]
+>>> x = [[[1., 2., 3.], [4., 5., 6.]],
+         [[7., 8., 9.], [10., 11., 12.]]]
+>>> padded_image_constant = tf.image.pad_to_bounding_box(x, 1, 1, 4, 4,
+                                                         mode="CONSTANT", constant_values=0)
+                                                         
+>>> padded_image_constant
+tf.Tensor(
+[[[ 0.  0.  0.], [ 0.  0.  0.], [ 0.  0.  0.], [ 0.  0.  0.]],
+ [[ 0.  0.  0.], [ 1.  2.  3.], [ 4.  5.  6.], [ 0.  0.  0.]],
+ [[ 0.  0.  0.], [ 7.  8.  9.], [10. 11. 12.], [ 0.  0.  0.]],
+ [[ 0.  0.  0.], [ 0.  0.  0.], [ 0.  0.  0.], [ 0.  0.  0.]]],
+ shape=(4, 4, 3), dtype=float32)
+ 
+>>> padded_image_reflect = tf.image.pad_to_bounding_box(x, 1, 1, 4, 4,
+                                                       mode="REFLECT")
+>>> padded_image_reflect
+tf.Tensor(
+[[[10. 11. 12.], [ 7.  8.  9.], [10. 11. 12.], [ 7.  8.  9.]],
+ [[ 4.  5.  6.], [ 1.  2.  3.], [ 4.  5.  6.], [ 1.  2.  3.]],
+ [[10. 11. 12.], [ 7.  8.  9.], [10. 11. 12.], [ 7.  8.  9.]],
+ [[ 4.  5.  6.], [ 1.  2.  3.], [ 4.  5.  6.], [ 1.  2.  3.]]],
+ shape=(4, 4, 3), dtype=float32)
+ 
+>>> padded_image_symmetric = tf.image.pad_to_bounding_box(x, 1, 1, 4, 4,
+                                                          mode="SYMMETRIC")
+>>> padded_image_symmetric
+tf.Tensor(
+[[[ 1.  2.  3.], [ 1.  2.  3.], [ 4.  5.  6.], [ 4.  5.  6.]],
+ [[ 1.  2.  3.], [ 1.  2.  3.], [ 4.  5.  6.], [ 4.  5.  6.]],
+ [[ 7.  8.  9.], [ 7.  8.  9.], [10. 11. 12.], [10. 11. 12.]],
+ [[ 7.  8.  9.], [ 7.  8.  9.], [10. 11. 12.], [10. 11. 12.]]],
+ shape=(4, 4, 3), dtype=float32)
   Args:
     image: 4-D Tensor of shape `[batch, height, width, channels]` or 3-D Tensor
       of shape `[height, width, channels]`.

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -910,6 +910,10 @@ def pad_to_bounding_box(image, offset_height, offset_width, target_height,
     offset_width: Number of columns of zeros to add on the left.
     target_height: Height of output image.
     target_width: Width of output image.
+    mode: One of "CONSTANT", "REFLECT", or "SYMMETRIC" (case-insensitive)
+    name: A name for the operation (optional).
+    constant_values: In "CONSTANT" mode, the scalar pad value to use. Must be
+      same type as `tensor`.
 
   Returns:
     If `image` was 4-D, a 4-D float Tensor of shape
@@ -1063,7 +1067,7 @@ def crop_to_bounding_box(image, offset_height, offset_width, target_height,
     'image.resize_with_crop_or_pad',
     v1=['image.resize_with_crop_or_pad', 'image.resize_image_with_crop_or_pad'])
 @dispatch.add_dispatch_support
-def resize_image_with_crop_or_pad(image, target_height, target_width):
+def resize_image_with_crop_or_pad(image, target_height, target_width, mode="CONSTANT", name=None, constant_values=0):
   """Crops and/or pads an image to a target width and height.
 
   Resizes an image to a target width and height by either centrally
@@ -1080,6 +1084,10 @@ def resize_image_with_crop_or_pad(image, target_height, target_width):
       of shape `[height, width, channels]`.
     target_height: Target height.
     target_width: Target width.
+    mode: One of "CONSTANT", "REFLECT", or "SYMMETRIC" (case-insensitive)
+    name: A name for the operation (optional).
+    constant_values: In "CONSTANT" mode, the scalar pad value to use. Must be
+      same type as `tensor`.
 
   Raises:
     ValueError: if `target_height` or `target_width` are zero or negative.
@@ -1157,7 +1165,7 @@ def resize_image_with_crop_or_pad(image, target_height, target_width):
 
     # Maybe pad if needed.
     resized = pad_to_bounding_box(cropped, offset_pad_height, offset_pad_width,
-                                  target_height, target_width)
+                                  target_height, target_width, mode=mode, name=name, constant_values=constant_values)
 
     # In theory all the checks below are redundant.
     if resized.get_shape().ndims is None:

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -894,7 +894,7 @@ def pad_to_bounding_box(image, offset_height, offset_width, target_height,
                                   #  [3, 2, 1, 2, 3, 2, 1],
                                   #  [6, 5, 4, 5, 6, 5, 4],
                                   #  [3, 2, 1, 2, 3, 2, 1]]
-  tf.image.pad_to_bounding_box(t, offset_height=offset_height, offset_width=offset_width, target_height=target_height, target_width=target_width, mode="SYMETRIC")  
+  tf.image.pad_to_bounding_box(t, offset_height=offset_height, offset_width=offset_width, target_height=target_height, target_width=target_width, mode="SYMMETRIC")  
                                     # [[2, 1, 1, 2, 3, 3, 2],
                                     #  [2, 1, 1, 2, 3, 3, 2],
                                     #  [5, 4, 4, 5, 6, 6, 5],

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -867,7 +867,7 @@ def central_crop(image, central_fraction):
 @tf_export('image.pad_to_bounding_box')
 @dispatch.add_dispatch_support
 def pad_to_bounding_box(image, offset_height, offset_width, target_height,
-                        target_width):
+                        target_width, mode="CONSTANT", name=None, constant_values=0):
   """Pad `image` with zeros to the specified `height` and `width`.
 
   Adds `offset_height` rows of zeros on top, `offset_width` columns of
@@ -962,7 +962,7 @@ def pad_to_bounding_box(image, offset_height, offset_width, target_height,
             0, 0, offset_height, after_padding_height, offset_width,
             after_padding_width, 0, 0
         ]), [4, 2])
-    padded = array_ops.pad(image, paddings)
+    padded = array_ops.pad(image, paddings, mode=mode, name=name, constant_values=constant_values)
 
     padded_shape = [
         None if _is_tensor(i) else i

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1092,7 +1092,8 @@ def resize_image_with_crop_or_pad(image, target_height, target_width, mode="CONS
       of shape `[height, width, channels]`.
     target_height: Target height.
     target_width: Target width.
-    mode: One of "CONSTANT", "REFLECT", or "SYMMETRIC" (case-insensitive)
+    mode: One of "CONSTANT", "REFLECT", or "SYMMETRIC" (case-insensitive),
+    refer to description of 'mode' in 'pad_to_bounding_box' for example cases
     name: A name for the operation (optional).
     constant_values: In "CONSTANT" mode, the scalar pad value to use. Must be
       same type as `tensor`.

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -878,31 +878,24 @@ def pad_to_bounding_box(image, offset_height, offset_width, target_height,
   `target_height` by `target_width`.
 
   Usage Example:
-
-  >>> x = [[[1., 2., 3.],
-  ...       [4., 5., 6.]],
-  ...       [[7., 8., 9.],
-  ...       [10., 11., 12.]]]
-  >>> padded_image = tf.image.pad_to_bounding_box(x, 1, 1, 4, 4)
-  >>> padded_image
-  <tf.Tensor: shape=(4, 4, 3), dtype=float32, numpy=
-  array([[[ 0.,  0.,  0.],
-  [ 0.,  0.,  0.],
-  [ 0.,  0.,  0.],
-  [ 0.,  0.,  0.]],
-  [[ 0.,  0.,  0.],
-  [ 1.,  2.,  3.],
-  [ 4.,  5.,  6.],
-  [ 0.,  0.,  0.]],
-  [[ 0.,  0.,  0.],
-  [ 7.,  8.,  9.],
-  [10., 11., 12.],
-  [ 0.,  0.,  0.]],
-  [[ 0.,  0.,  0.],
-  [ 0.,  0.,  0.],
-  [ 0.,  0.,  0.],
-  [ 0.,  0.,  0.]]], dtype=float32)>
-
+  t = tf.constant([[1, 2, 3], [4, 5, 6]])
+  offset_height = tf.constant(1), 
+  offset_width = tf.constant(1)
+  target_height = tf.constant(4)
+  target-width = tf.constant(7)
+  #constant_values = 0
+  tf.pad(t, paddings, "CONSTANT")  # [[0, 0, 0, 0, 0, 0, 0],
+                                   #  [0, 0, 1, 2, 3, 0, 0],
+                                   #  [0, 0, 4, 5, 6, 0, 0],
+                                   #  [0, 0, 0, 0, 0, 0, 0]]
+  tf.pad(t, paddings, "REFLECT")  # [[6, 5, 4, 5, 6, 5, 4],
+                                  #  [3, 2, 1, 2, 3, 2, 1],
+                                  #  [6, 5, 4, 5, 6, 5, 4],
+                                  #  [3, 2, 1, 2, 3, 2, 1]]
+  tf.pad(t, paddings, "SYMMETRIC")  # [[2, 1, 1, 2, 3, 3, 2],
+                                    #  [2, 1, 1, 2, 3, 3, 2],
+                                    #  [5, 4, 4, 5, 6, 6, 5],
+                                    #  [5, 4, 4, 5, 6, 6, 5]]
   Args:
     image: 4-D Tensor of shape `[batch, height, width, channels]` or 3-D Tensor
       of shape `[height, width, channels]`.

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -868,11 +868,12 @@ def central_crop(image, central_fraction):
 @dispatch.add_dispatch_support
 def pad_to_bounding_box(image, offset_height, offset_width, target_height,
                         target_width, mode="CONSTANT", name=None, constant_values=0):
-  """Pad `image` with zeros to the specified `height` and `width`.
+  """Pads an image according to the 'mode' which you specify. 
+  Pads with 'constant_values' to the specified `height` and `width`, default is 0.
 
-  Adds `offset_height` rows of zeros on top, `offset_width` columns of
-  zeros on the left, and then pads the image on the bottom and right
-  with zeros until it has dimensions `target_height`, `target_width`.
+  Adds `offset_height` rows of 'constant_values' on top, `offset_width` columns of
+  'constant_values' on the left, and then pads the image on the bottom and right
+  with 'constant_values' until it has dimensions `target_height`, `target_width`.
 
   This op does nothing if `offset_*` is zero and the image already has size
   `target_height` by `target_width`.

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1174,14 +1174,17 @@ def resize_image_with_crop_or_pad(image, target_height, target_width,
     offset_pad_height = max_(height_diff // 2, 0)
 
     # Maybe crop if needed.
-    cropped = crop_to_bounding_box(image, offset_crop_height, offset_crop_width,
+    cropped = crop_to_bounding_box(image, offset_crop_height,
+                                   offset_crop_width,
                                    min_(target_height, height),
                                    min_(target_width, width))
 
     # Maybe pad if needed.
-    resized = pad_to_bounding_box(cropped, offset_pad_height, offset_pad_width,
-                                  target_height, target_width, mode=mode,
-                                  name=name, constant_values=constant_values)
+    resized = pad_to_bounding_box(cropped, offset_pad_height,
+                                  offset_pad_width,
+                                  target_height, target_width,
+                                  mode=mode, name=name,
+                                  constant_values=constant_values)
 
     # In theory all the checks below are redundant.
     if resized.get_shape().ndims is None:

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -867,22 +867,26 @@ def central_crop(image, central_fraction):
 @tf_export('image.pad_to_bounding_box')
 @dispatch.add_dispatch_support
 def pad_to_bounding_box(image, offset_height, offset_width, target_height,
-                        target_width, mode="CONSTANT", name=None, constant_values=0):
+                        target_width, mode="CONSTANT", name=None,
+                        constant_values=0):
   """Pads an image according to the 'mode' which you specify. 
-  Pads with 'constant_values' to the specified `height` and `width`, default is 0.
+  Pads with 'constant_values' to the specified `height` and `width`,
+  default is 0.
 
-  Adds `offset_height` rows of 'constant_values' on top, `offset_width` columns of
-  'constant_values' on the left, and then pads the image on the bottom and right
-  with 'constant_values' until it has dimensions `target_height`, `target_width`.
+  Adds `offset_height` rows of 'constant_values' on top, `offset_width`
+  columns of 'constant_values' on the left, and then pads the image on 
+  the bottom and right with 'constant_values' until it has dimensions
+  `target_height`, `target_width`.
 
-  This op does nothing if `offset_*` is zero and the image already has size
-  `target_height` by `target_width`.
+  This op does nothing if `offset_*` is zero and the image already has
+  size `target_height` by `target_width`.
 
   Usage Example:
 >>> x = [[[1., 2., 3.], [4., 5., 6.]],
          [[7., 8., 9.], [10., 11., 12.]]]
 >>> padded_image_constant = tf.image.pad_to_bounding_box(x, 1, 1, 4, 4,
-                                                         mode="CONSTANT", constant_values=0)
+                                                         mode="CONSTANT",
+                                                         constant_values=0)
                                                          
 >>> padded_image_constant
 tf.Tensor(
@@ -974,7 +978,8 @@ tf.Tensor(
             0, 0, offset_height, after_padding_height, offset_width,
             after_padding_width, 0, 0
         ]), [4, 2])
-    padded = array_ops.pad(image, paddings, mode=mode, name=name, constant_values=constant_values)
+    padded = array_ops.pad(image, paddings, mode=mode, name=name,
+                           constant_values=constant_values)
 
     padded_shape = [
         None if _is_tensor(i) else i
@@ -1075,7 +1080,8 @@ def crop_to_bounding_box(image, offset_height, offset_width, target_height,
     'image.resize_with_crop_or_pad',
     v1=['image.resize_with_crop_or_pad', 'image.resize_image_with_crop_or_pad'])
 @dispatch.add_dispatch_support
-def resize_image_with_crop_or_pad(image, target_height, target_width, mode="CONSTANT", name=None, constant_values=0):
+def resize_image_with_crop_or_pad(image, target_height, target_width,
+                                  mode="CONSTANT", name=None, constant_values=0):
   """Crops and/or pads an image to a target width and height.
 
   Resizes an image to a target width and height by either centrally
@@ -1084,8 +1090,8 @@ def resize_image_with_crop_or_pad(image, target_height, target_width, mode="CONS
   If `width` or `height` is greater than the specified `target_width` or
   `target_height` respectively, this op centrally crops along that dimension.
   If `width` or `height` is smaller than the specified `target_width` or
-  `target_height` respectively, this op centrally pads with 'constant_values' along that
-  dimension.
+  `target_height` respectively, this op centrally pads with 'constant_values'
+  along that dimension.
 
   Args:
     image: 4-D Tensor of shape `[batch, height, width, channels]` or 3-D Tensor
@@ -1174,7 +1180,8 @@ def resize_image_with_crop_or_pad(image, target_height, target_width, mode="CONS
 
     # Maybe pad if needed.
     resized = pad_to_bounding_box(cropped, offset_pad_height, offset_pad_width,
-                                  target_height, target_width, mode=mode, name=name, constant_values=constant_values)
+                                  target_height, target_width, mode=mode,
+                                  name=name, constant_values=constant_values)
 
     # In theory all the checks below are redundant.
     if resized.get_shape().ndims is None:


### PR DESCRIPTION
I was wanting to resize_with_crop_or_pad and pad with values not equal to 0. Now you can pass the same arguments that will feed into pad into resize_with_crop_or_pad