### PR TITLE
Fix unknown output shape issue in autograph for tf.equal

### DIFF
--- a/tensorflow/core/framework/common_shape_fns.cc
+++ b/tensorflow/core/framework/common_shape_fns.cc
@@ -1936,6 +1936,7 @@ Status BroadcastBinaryOpOutputShapeFnHelper(InferenceContext* c,
       // in C++ op code, we must still assert that the unknown dim is either 1
       // or the same as the known dim.
       // - If either dimension is 1, the other dimension is the output.
+      // - If both are unknown then dimension is unknown
       if (c->Value(dim_x) > 1) {
         if (!incompatible_shape_error) {
           *out = c->UnknownShape();
@@ -1954,6 +1955,8 @@ Status BroadcastBinaryOpOutputShapeFnHelper(InferenceContext* c,
         dims.push_back(dim_x);
       } else if (dim_y.SameHandle(dim_x)) {
         dims.push_back(dim_x);
+      } else if (!c->ValueKnown(dim_x) && !c->ValueKnown(dim_y)) {
+        dims.push_back(c->UnknownDim());
       } else {
         if (!incompatible_shape_error) {
           *out = c->UnknownShape();

--- a/tensorflow/core/ops/math_ops_test.cc
+++ b/tensorflow/core/ops/math_ops_test.cc
@@ -604,4 +604,22 @@ TEST(MathOpsTest, SobolSample) {
 
   INFER_OK(op, "[];[];[]", "[?,?]");
 }
+
+TEST(MathOpsTest, EqualOp) {
+  ShapeInferenceTestOp op("Equal");
+  AddNodeAttr("incompatible_shape_error", true, &op.node_def);
+
+  INFER_OK(op, "?;?", "?");
+  INFER_OK(op, "[1,2];?", "?");
+  INFER_OK(op, "?;[1,2]", "?");
+
+  INFER_OK(op, "[1,2,3];[1]", "[d0_0,d0_1,d0_2]");
+  INFER_OK(op, "[?,2,1];[1,3]", "[d0_0,d0_1,d1_1]");
+  INFER_OK(op, "[1,?,3];[3,1]", "[d0_0,d1_0,d0_2]");
+  INFER_OK(op, "[1,2,3];[2,1,3]", "[d1_0,d0_1,d0_2]");
+
+  // Note: Test case for GitHub issue 40471
+  INFER_OK(op, "[?,10,1];[?,1,4]", "[?,d0_1,d1_2]");
+  INFER_OK(op, "[10,?,1];[1,?,4]", "[d0_0,?,d1_2]");
+}
 }  // end namespace tensorflow

--- a/tensorflow/core/ops/math_ops_test.cc
+++ b/tensorflow/core/ops/math_ops_test.cc
@@ -120,7 +120,7 @@ TEST(MathOpsTest, BroadcastBinaryOps_ShapeFn) {
     INFER_OK(op, "[1];[?]", "[d1_0]");
     INFER_OK(op, "[?];[2]", incompatible_shape_error ? "[d1_0]" : "?");
     INFER_OK(op, "[2];[?]", incompatible_shape_error ? "[d0_0]" : "?");
-    INFER_OK(op, "[?];[?]", incompatible_shape_error ? "[?]" : "?");
+    INFER_OK(op, "[?];[?]", "[?]");
     INFER_OK(op, "[];[?]", "[d1_0]");
     INFER_OK(op, "[?];[]", "[d0_0]");
 

--- a/tensorflow/python/autograph/operators/logical_test.py
+++ b/tensorflow/python/autograph/operators/logical_test.py
@@ -19,9 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 from tensorflow.python.autograph.operators import logical
-from tensorflow.python.eager import def_function
 from tensorflow.python.framework import constant_op
-from tensorflow.python.framework import tensor_spec
 from tensorflow.python.framework import test_util
 from tensorflow.python.platform import test
 
@@ -84,18 +82,6 @@ class LogicalOperatorsTest(test.TestCase):
     with self.cached_session() as sess:
       t = logical.not_(self._tf_false())
       self.assertEqual(self.evaluate(t), True)
-
-  # Test case for GitHub issue 40471
-  def test_equal_output_shapes(self):
-
-    @def_function.function(input_signature=[
-        tensor_spec.TensorSpec([None, 10, 1]),
-        tensor_spec.TensorSpec([None, 1, 4])])
-    def f(x, y):
-      z = x == y
-      return z
-
-    self.assertAllEqual(f.get_concrete_function().output_shapes, [None, 10, 4])
 
 
 if __name__ == '__main__':

--- a/tensorflow/python/autograph/operators/logical_test.py
+++ b/tensorflow/python/autograph/operators/logical_test.py
@@ -19,7 +19,9 @@ from __future__ import division
 from __future__ import print_function
 
 from tensorflow.python.autograph.operators import logical
+from tensorflow.python.eager import def_function
 from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import tensor_spec
 from tensorflow.python.framework import test_util
 from tensorflow.python.platform import test
 
@@ -82,6 +84,18 @@ class LogicalOperatorsTest(test.TestCase):
     with self.cached_session() as sess:
       t = logical.not_(self._tf_false())
       self.assertEqual(self.evaluate(t), True)
+
+  # Test case for GitHub issue 40471
+  def test_equal_output_shapes(self):
+
+    @def_function.function(input_signature=[
+        tensor_spec.TensorSpec([None, 10, 1]),
+        tensor_spec.TensorSpec([None, 1, 4])])
+    def f(x, y):
+      z = x == y
+      return z
+
+    self.assertAllEqual(f.get_concrete_function().output_shapes, [None, 10, 4])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR tries to address the issue raised in #40471 where
the output shape of an autograph consists of tf.equal
could not inference correctly. Specifically
`x.shape == [None, 10, 1]` and `y.shape == [None, 1, 4]`
only yield `shape == None` (should be `shape == [None, 10, 4]`).

The reason was that the shape inbference function for equal
didn't capture the cases where both x and y's dim are None.

This PR fixes the issue.

This PR fixes #40471.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>