### PR TITLE
C get temp file name

### DIFF
--- a/tensorflow/c/env.cc
+++ b/tensorflow/c/env.cc
@@ -146,6 +146,16 @@ TF_StringStream* TF_GetLocalTempDirectories() {
   return list;
 }
 
+void TF_GetTempFileName(const char* extension, std::string* name,
+                        TF_Status* status) {
+  *name = ::tensorflow::Env::Default()->GetTempFilename(extension);
+  if (*name.length() == 0) {
+    TF_SetStatus(status, TF_INTERNAL, "Can not create temp file name");
+  } else {
+    TF_SetStatus(status, TF_OK, "");
+  }
+}
+
 TF_CAPI_EXPORT extern uint64_t TF_NowNanos(void) {
   return ::tensorflow::Env::Default()->NowNanos();
 }

--- a/tensorflow/c/env.cc
+++ b/tensorflow/c/env.cc
@@ -147,14 +147,8 @@ TF_StringStream* TF_GetLocalTempDirectories() {
   return list;
 }
 
-void TF_GetTempFileName(const char* extension, std::string* name,
-                        TF_Status* status) {
-  *name = ::tensorflow::io::GetTempFilename(extension);
-  if (name->length() == 0) {
-    TF_SetStatus(status, TF_INTERNAL, "Can not get temp file name");
-  } else {
-    TF_SetStatus(status, TF_OK, "");
-  }
+void TF_GetTempFileName(const char* extension, char** name) {
+  *name = strdup(::tensorflow::io::GetTempFilename(extension).c_str());
 }
 
 TF_CAPI_EXPORT extern uint64_t TF_NowNanos(void) {

--- a/tensorflow/c/env.cc
+++ b/tensorflow/c/env.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include "tensorflow/c/c_api_internal.h"
 #include "tensorflow/c/tf_status_helper.h"
 #include "tensorflow/core/platform/env.h"
+#include "tensorflow/core/platform/path.h"
 #include "tensorflow/core/platform/types.h"
 
 struct TF_StringStream {
@@ -148,9 +149,9 @@ TF_StringStream* TF_GetLocalTempDirectories() {
 
 void TF_GetTempFileName(const char* extension, std::string* name,
                         TF_Status* status) {
-  *name = ::tensorflow::Env::Default()->GetTempFilename(extension);
-  if (*name.length() == 0) {
-    TF_SetStatus(status, TF_INTERNAL, "Can not create temp file name");
+  *name = ::tensorflow::io::GetTempFilename(extension);
+  if (name->length() == 0) {
+    TF_SetStatus(status, TF_INTERNAL, "Can not get temp file name");
   } else {
     TF_SetStatus(status, TF_OK, "");
   }

--- a/tensorflow/c/env.cc
+++ b/tensorflow/c/env.cc
@@ -147,8 +147,8 @@ TF_StringStream* TF_GetLocalTempDirectories() {
   return list;
 }
 
-void TF_GetTempFileName(const char* extension, char** name) {
-  *name = strdup(::tensorflow::io::GetTempFilename(extension).c_str());
+char* TF_GetTempFileName(const char* extension) {
+  return strdup(::tensorflow::io::GetTempFilename(extension).c_str());
 }
 
 TF_CAPI_EXPORT extern uint64_t TF_NowNanos(void) {

--- a/tensorflow/c/env.h
+++ b/tensorflow/c/env.h
@@ -20,8 +20,6 @@ limitations under the License.
 #include <stddef.h>
 #include <stdint.h>
 
-#include <string>
-
 #include "tensorflow/c/c_api.h"
 #include "tensorflow/c/tf_file_statistics.h"
 
@@ -157,8 +155,7 @@ TF_CAPI_EXPORT extern TF_StringStream* TF_GetLocalTempDirectories(void);
 // Creates a temporary file name with an extension.
 // The caller is responsible for freeing the returned pointer.
 TF_CAPI_EXPORT extern void TF_GetTempFileName(const char* extension,
-                                              std::string* name,
-                                              TF_Status* status);
+                                              char** name);
 
 // Returns the number of nanoseconds since the Unix epoch.
 TF_CAPI_EXPORT extern uint64_t TF_NowNanos(void);

--- a/tensorflow/c/env.h
+++ b/tensorflow/c/env.h
@@ -154,8 +154,7 @@ TF_CAPI_EXPORT extern TF_StringStream* TF_GetLocalTempDirectories(void);
 
 // Creates a temporary file name with an extension.
 // The caller is responsible for freeing the returned pointer.
-TF_CAPI_EXPORT extern void TF_GetTempFileName(const char* extension,
-                                              char** name);
+TF_CAPI_EXPORT extern char* TF_GetTempFileName(const char* extension);
 
 // Returns the number of nanoseconds since the Unix epoch.
 TF_CAPI_EXPORT extern uint64_t TF_NowNanos(void);

--- a/tensorflow/c/env.h
+++ b/tensorflow/c/env.h
@@ -20,6 +20,8 @@ limitations under the License.
 #include <stddef.h>
 #include <stdint.h>
 
+#include <string>
+
 #include "tensorflow/c/c_api.h"
 #include "tensorflow/c/tf_file_statistics.h"
 

--- a/tensorflow/c/env.h
+++ b/tensorflow/c/env.h
@@ -152,6 +152,12 @@ TF_CAPI_EXPORT extern TF_StringStream* TF_GetChildren(const char* filename,
 // The caller is responsible for freeing the list (see TF_StringStreamDone).
 TF_CAPI_EXPORT extern TF_StringStream* TF_GetLocalTempDirectories(void);
 
+// Creates a temporary file name with an extension.
+// The caller is responsible for freeing the returned pointer.
+TF_CAPI_EXPORT extern void TF_GetTempFileName(const char* extension,
+                                              std::string* name,
+                                              TF_Status* status);
+
 // Returns the number of nanoseconds since the Unix epoch.
 TF_CAPI_EXPORT extern uint64_t TF_NowNanos(void);
 

--- a/tensorflow/core/platform/path.cc
+++ b/tensorflow/core/platform/path.cc
@@ -327,8 +327,6 @@ string GetTempFilename(const string& extension) {
   }
   LOG(FATAL) << "No temp directory found.";
 #endif
-  // Return an empty string to indicate that we can not create temp file name.
-  return "";
 }
 
 bool GetTestUndeclaredOutputsDir(string* dir) {

--- a/tensorflow/core/platform/path.cc
+++ b/tensorflow/core/platform/path.cc
@@ -327,6 +327,8 @@ string GetTempFilename(const string& extension) {
   }
   LOG(FATAL) << "No temp directory found.";
 #endif
+  // Return an empty string to indicate that we can not create temp file name.
+  return "";
 }
 
 bool GetTestUndeclaredOutputsDir(string* dir) {


### PR DESCRIPTION
@mihaimaruseac 
This PR add a function to getTempFileName for C API.
I have to use `std::string` here since there is not effective way to store the result. Since we don't know we should use `new` or `malloc` to allocate a `const char*` the result