### PR TITLE
[tflite] make label_image build on linux and macOS

### DIFF
--- a/tensorflow/lite/examples/label_image/BUILD
+++ b/tensorflow/lite/examples/label_image/BUILD
@@ -38,6 +38,7 @@ cc_binary(
         "//tensorflow/lite/profiling:profiler",
         "//tensorflow/lite/tools/evaluation:utils",
         "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/strings",
     ] + select({
         "//tensorflow:android": [
             "//tensorflow/lite/delegates/gpu:delegate",


### PR DESCRIPTION
label_image doesn't build on Linux and macOS platforms

```
bazel build --config opt //tensorflow/lite/examples/label_image:label_image
```
shows something like
```
ERROR: /home/freedom/work/tensorflow/tensorflow/lite/examples/label_image/BUILD:15:1: undeclared inclusion(s) in rule '//tensorflow/lite/examples/label_image:label_image':
this rule is missing dependency declarations for the following files included by 'tensorflow/lite/examples/label_image/label_image.cc':
  'external/com_google_absl/absl/strings/string_view.h'
  'external/com_google_absl/absl/base/internal/throw_delegate.h'

```

Add `"@com_google_absl//absl/strings"` to deps