### PR TITLE
[ROCm] Fix for XLA "scatter" op related unit test failures.

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/hlo_to_ir_bindings.cc
+++ b/tensorflow/compiler/xla/service/gpu/hlo_to_ir_bindings.cc
@@ -119,7 +119,9 @@ void HloToIrBindings::EmitBasePointersForHlos(
           if (slice.allocation()->is_thread_local()) {
             llvm::Type* pointee_type =
                 llvm_ir::ShapeToIrType(non_io_hlo->shape(), module_);
-            BindHloToIrValue(*non_io_hlo, b_->CreateAlloca(pointee_type),
+            BindHloToIrValue(*non_io_hlo,
+                             llvm_ir::EmitAllocaAtFunctionEntry(
+                                 pointee_type, /*name=*/"", b_),
                              index);
           } else if (slice.allocation()->is_constant()) {
             llvm::Value* global_for_constant = module_->getGlobalVariable(


### PR DESCRIPTION
After the upstream commit 4de4c60972da38d09662842614ad4dcfd019a6be, the following unit-tests started failing on the ROCm platform

```
//tensorflow/python/keras/optimizer_v2:adam_test_gpu
//tensorflow/compiler/xla/tests:scatter_test_gpu
//tensorflow/compiler/tests:scatter_nd_op_test_gpu
```

The cause seems to be a change in the commit above that updates the LLVM version in use.

The LLVM version change (more specifically some AMDGPU backend change contained within the LLVM version change) either introduces an issue or lets manifest an existing issue, w.r.t alloca instructions outside of the entry basic block of a function. The AMDGPU backend seems to expect all alloca instructions to be inside the entry basic block. Having this assumption broken, leads to the regression failures we see above.

This PR/commit changes IR generation for "scatter" op to ensure that the alloca instruction gets emitted in the entry basic block of the function. This changesmakes the above unit tests pass again. This commit also updates other instances in XLA code where alloca instructions were getting added outside of the entry basic block of a function.

-----------------------------

/cc @whchung @ekuznetsov139 @cheshire @chsigg @nvining-work 