### PR TITLE
TF-TRT Improve reshape op converter

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -82,9 +82,13 @@ tf_cuda_cc_test(
 cc_library(
     name = "common_utils",
     srcs = ["common/utils.cc"],
-    hdrs = ["common/utils.h"],
+    hdrs = [
+        "common/datavec.h",
+        "common/utils.h",
+    ],
     copts = tf_copts(),
     deps = [
+        "//tensorflow/core:framework",
         "//tensorflow/core/platform:logging",
     ] + if_tensorrt([":tensorrt_lib"]),
 )
@@ -234,18 +238,22 @@ cc_library(
 
 tf_cuda_library(
     name = "trt_engine_utils",
-    srcs = ["utils/trt_engine_utils.cc"],
-    hdrs = ["utils/trt_engine_utils.h"],
+    srcs = ["utils/trt_engine_utils.cc",
+            "utils/trt_shape_optimization_profiles.cc",],
+    hdrs = ["utils/trt_engine_utils.h",
+            "utils/trt_shape_optimization_profiles.h",
+            "utils/trt_execution_context.h",],
     deps = [
+        ":common_utils",
         ":trt_logging",
         ":utils",
         ":trt_allocator",
-        ":common_utils",
         "@com_google_absl//absl/strings",
         "//tensorflow/core:framework",
+        "//tensorflow/core:framework_headers_lib",
         "//tensorflow/core:lib",
         "//tensorflow/core/platform:status",
-        "//tensorflow/stream_executor/lib",
+        "//tensorflow/core:stream_executor_headers_lib",
     ] + if_tensorrt([":tensorrt_lib"]),
 )
 
@@ -287,7 +295,6 @@ tf_cuda_library(
     srcs = [
         "utils/trt_int8_calibrator.cc",
         "utils/trt_lru_cache.cc",
-        "utils/trt_shape_optimization_profiles.cc",
     ],
     hdrs = [
         "utils/trt_int8_calibrator.h",
@@ -295,6 +302,7 @@ tf_cuda_library(
         "utils/trt_shape_optimization_profiles.h",
     ],
     deps = [
+        ":common_utils",
         ":trt_allocator",
         ":trt_engine_utils",
         ":trt_logging",

--- a/tensorflow/compiler/tf2tensorrt/common/datavec.h
+++ b/tensorflow/compiler/tf2tensorrt/common/datavec.h
@@ -1,0 +1,42 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_COMPILER_TF2TENSORRT_COMMON_DATAVEC_H_
+#define TENSORFLOW_COMPILER_TF2TENSORRT_COMMON_DATAVEC_H_
+
+#include <vector>
+
+#include "tensorflow/core/framework/tensor.h"
+
+namespace tensorflow {
+namespace tensorrt {
+
+// Input/output data format for OpConverterTest::BuildAndRun().
+struct InputOutputData {
+  void* Buffer() const {
+    return const_cast<char*>(tensor.tensor_data().data());
+  }
+
+  size_t TotalBytes() const { return tensor.TotalBytes(); }
+
+  string name;
+  Tensor tensor;
+};
+
+using DataVec = std::vector<InputOutputData>;
+
+}  // namespace tensorrt
+}  // namespace tensorflow
+#endif

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h
@@ -163,7 +163,6 @@ class OutputEdgeValidator {
   bool operator()(const Edge* out_edge) const;
 };
 
-int64_t TrtWeightDimsNumElements(const nvinfer1::Dims& dims);
 int64_t TrtTensorDimsNumElements(const nvinfer1::Dims& dims);
 
 // Class to convert TF compile-time constants (e.g. Const nodes) to TRT weight.
@@ -194,7 +193,13 @@ class TRT_ShapedWeights {
 
   Status SetShape(nvinfer1::Dims dims);
 
-  int64_t count() const;
+  // Returns total number of elements. Returning 0 means either some dim is 0
+  // or the number of dims is 0. Note that a TF scalar constant is marked as
+  // Dims{0, {1}}, and has a count() == 1.
+  int64_t count() const { return count(shape_); }
+
+  // Returns the total number of elements in a weight with shape dims.
+  static int64_t count(nvinfer1::Dims dims);
 
   size_t size_bytes() const;
 
@@ -214,6 +219,11 @@ class TRT_ShapedWeights {
   nvinfer1::DataType TrtDType() const { return type_; }
 
   // TODO(aaroey): make these private.
+  // Before TRT 6, scalar weights are not supported. In that case a TF scalar
+  // constant tensor is represented via TRT_ShapedWeights::shape_ = {1,{1}}.
+  //
+  // Starting TRT 6, scalar weights are supported, a scalar constant tensor is
+  // represented via TRT_ShapedWeights::shape_ = {0, {1}}.
   nvinfer1::Dims shape_;  // Note: shape.type[] is not used.
 
  private:

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
@@ -119,7 +119,8 @@ class TRTEngineOp : public AsyncOpKernel {
   // Executes the tensorrt engine. Returns whether we need to retry by running
   // the native segment.
   Status ExecuteTrtEngine(OpKernelContext* ctx, EngineContext* engine_context,
-                          int trt_context_idx);
+                          int trt_context_idx,
+                          const TrtShapeOptimizationProfile& profiles);
 
   // Allocates necessary resources for calibration.
   Status AllocateCalibrationResources(OpKernelContext* ctx,
@@ -671,14 +672,18 @@ void TRTEngineOp::ComputeAsync(OpKernelContext* ctx,
     return;
   }
 
-  if (!use_implicit_batch_ && has_dynamic_shape_input_) {
+  if (!use_implicit_batch_ &&
+      (has_dynamic_shape_input_ || cache_res->profiles_.HasShapeTensor())) {
+    OP_REQUIRES_OK_ASYNC(ctx, cache_res->profiles_.CollectShapeValues(ctx),
+                         *helper);
     if (profile_generation_mode_) {
       // Collecting new shapes for profiles can be only done once. After the
       // shapes are converted to TRT profiles, no shapes can be collected
       // anymore.
-      OP_REQUIRES(ctx, cache_res->profiles_.GetNumProfiles() == 0,
-                  errors::Unimplemented("Cannot collect new shapes when "
-                                        "profiles are already created."));
+      OP_REQUIRES_ASYNC(ctx, cache_res->profiles_.GetNumProfiles() == 0,
+                        errors::Unimplemented("Cannot collect new shapes when "
+                                              "profiles are already created."),
+                        *helper);
       // Just collect the input shape info and return. The shapes are used to
       // generate optimization profiles during engine creation.
       cache_res->profiles_.AddShape(input_concrete_shapes);
@@ -718,7 +723,8 @@ void TRTEngineOp::ComputeAsync(OpKernelContext* ctx,
     }
     return;
   }
-  Status stat = ExecuteTrtEngine(ctx, engine_context, trt_context_idx);
+  Status stat = ExecuteTrtEngine(ctx, engine_context, trt_context_idx,
+                                 cache_res->profiles_);
   if (!stat.ok()) {
     LOG_FIRST_FEW_WARNING_WITH_PREFIX << "Failed to execute engine: " << stat
                                       << " Retrying with native segment for "
@@ -738,9 +744,9 @@ void TRTEngineOp::ComputeAsync(OpKernelContext* ctx,
   }
 }
 
-Status TRTEngineOp::ExecuteTrtEngine(OpKernelContext* ctx,
-                                     EngineContext* engine_context,
-                                     int trt_context_idx) {
+Status TRTEngineOp::ExecuteTrtEngine(
+    OpKernelContext* ctx, EngineContext* engine_context, int trt_context_idx,
+    const TrtShapeOptimizationProfile& profiles) {
   tensorflow::profiler::TraceMe activity(
       "TRTEngineOp::ExecuteTrtEngine",
       tensorflow::profiler::TraceMeLevel::kInfo);
@@ -781,9 +787,9 @@ Status TRTEngineOp::ExecuteTrtEngine(OpKernelContext* ctx,
   const int num_batch =
       use_implicit_batch_ ? ctx->input(0).shape().dim_size(0) : 0;
 
-  TF_RETURN_IF_ERROR(SetTrtEngineInputs(cuda_engine.get(), execution_context,
-                                        trt_context_idx, buffers,
-                                        use_implicit_batch_, num_batch, ctx));
+  TF_RETURN_IF_ERROR(SetTrtEngineInputs(
+      cuda_engine.get(), execution_context, trt_context_idx, buffers,
+      use_implicit_batch_, num_batch, profiles, ctx));
 
   TF_RETURN_IF_ERROR(SetTrtEngineOutputs(cuda_engine.get(), execution_context,
                                          trt_context_idx, buffers,

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_resource_ops_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_resource_ops_test.cc
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include "absl/container/inlined_vector.h"
 #include "absl/memory/memory.h"
+#include "tensorflow/compiler/tf2tensorrt/common/datavec.h"
 #include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
 #include "tensorflow/compiler/tf2tensorrt/utils/trt_engine_instance.pb.h"  // NOLINT
 #include "tensorflow/compiler/tf2tensorrt/utils/trt_logger.h"
@@ -53,7 +54,18 @@ limitations under the License.
 namespace tensorflow {
 namespace tensorrt {
 
-class TRTEngineResourceOpsTest : public OpsTestBase {
+struct TestParam {
+  nvinfer1::Dims dims;
+  bool dynamic_shape;
+  int n_inputs;
+};
+
+class TRTEngineResourceOpsTest
+    : public OpsTestBase,
+      public ::testing::WithParamInterface<TestParam> {
+ public:
+  TRTEngineResourceOpsTest() : param_(GetParam()) {}
+
  protected:
   void Reset() {
     for (auto& temp : tensors_) {
@@ -67,47 +79,171 @@ class TRTEngineResourceOpsTest : public OpsTestBase {
     inputs_.clear();
   }
 
-  TrtUniquePtrType<nvinfer1::ICudaEngine> CreateTRTEngine() {
-    TrtUniquePtrType<nvinfer1::IBuilder> builder(
-        nvinfer1::createInferBuilder(logger_));
-    TrtUniquePtrType<nvinfer1::INetworkDefinition> network(
-        builder->createNetwork());
-
-    // Add the input.
-    nvinfer1::Dims dims;
-    dims.nbDims = 1;
-    dims.d[0] = 1;
-    nvinfer1::ITensor* input =
-        network->addInput("input", nvinfer1::DataType::kFLOAT, dims);
-    EXPECT_NE(nullptr, input);
-
+  nvinfer1::ITensor* NetworkWith1Input(nvinfer1::INetworkDefinition* network,
+                                       nvinfer1::ITensor* input) {
     // Add a unary layer.
     nvinfer1::IUnaryLayer* layer =
         network->addUnary(*input, nvinfer1::UnaryOperation::kEXP);
     EXPECT_NE(nullptr, layer);
+    return layer->getOutput(0);
+  }
 
+  // Constructs a network with two inputs, where the second input is a shape
+  // tensor. We take a slice of the first input with the size of the slice
+  // specified by the second input, assuming the first input is a 2D tensor.
+  // We then add the slice to itself to produce the output of the network.
+  nvinfer1::ITensor* NetworkWith2Inputs(nvinfer1::INetworkDefinition* network,
+                                        nvinfer1::ITensor* input) {
+    nvinfer1::Dims dims2{1, {2}};
+    nvinfer1::ITensor* input2 =
+        network->addInput("input2", nvinfer1::DataType::kINT32, dims2);
+    EXPECT_NE(nullptr, input2);
+
+    nvinfer1::Dims start{2, {0, 0}};
+    nvinfer1::Dims stride{2, {1, 1}};
+    auto slice_layer = network->addSlice(*input, start, stride, stride);
+    EXPECT_NE(nullptr, slice_layer);
+
+    slice_layer->setInput(2, *input2);
+    nvinfer1::ITensor* sliced_input = slice_layer->getOutput(0);
+    EXPECT_NE(nullptr, sliced_input);
+
+    auto layer = network->addElementWise(*sliced_input, *sliced_input,
+                                         nvinfer1::ElementWiseOperation::kSUM);
+    EXPECT_NE(nullptr, layer);
+    return layer->getOutput(0);
+  }
+
+  TrtUniquePtrType<nvinfer1::ICudaEngine> CreateTRTEngine() {
+    TrtUniquePtrType<nvinfer1::IBuilder> builder(
+        nvinfer1::createInferBuilder(logger_));
+    TrtUniquePtrType<nvinfer1::INetworkDefinition> network;
+    if (!this->param_.dynamic_shape || !IS_TRT_VERSION_GE(6, 0, 0, 0)) {
+      network = TrtUniquePtrType<nvinfer1::INetworkDefinition>(
+          builder->createNetwork());
+    } else {
+#if IS_TRT_VERSION_GE(6, 0, 0, 0)
+      network = TrtUniquePtrType<nvinfer1::INetworkDefinition>(
+          builder->createNetworkV2(
+              1U << static_cast<int>(
+                  nvinfer1::NetworkDefinitionCreationFlag::kEXPLICIT_BATCH)));
+#endif
+    }
+
+    // Add the input.
+    nvinfer1::Dims dims = this->param_.dims;
+    if (this->param_.dynamic_shape) {
+      std::fill(dims.d, dims.d + dims.nbDims, -1);
+    }
+    const char* in_name = "input";
+    nvinfer1::ITensor* input =
+        network->addInput(in_name, nvinfer1::DataType::kFLOAT, dims);
+    EXPECT_NE(nullptr, input);
     // Mark the output.
-    nvinfer1::ITensor* output = layer->getOutput(0);
+    nvinfer1::ITensor* output =
+        this->param_.n_inputs == 1
+            ? this->NetworkWith1Input(network.get(), input)
+            : this->NetworkWith2Inputs(network.get(), input);
     output->setName("output");
     network->markOutput(*output);
 
     // Build the engine
-    builder->setMaxBatchSize(1);
+#if IS_TRT_VERSION_GE(6, 0, 0, 0)
+    TrtUniquePtrType<nvinfer1::IBuilderConfig> builder_config(
+        builder->createBuilderConfig());
+    builder_config->setMaxWorkspaceSize(1 << 10);
+#else
     builder->setMaxWorkspaceSize(1 << 10);
+#endif
+    builder->setMaxBatchSize(1);
+
+    if (this->param_.dynamic_shape) {
+      TrtShapeOptimizationProfile profile;
+      profile.SetShapeTensorMask(network.get());
+      // The for loop defines three optimization profiles for the network.
+      for (int i = 1; i <= 3; i++) {
+        const int n_input = param_.n_inputs;
+        std::vector<TensorShape> shape_vec(n_input);
+        // Define a shape with all dimensions set to 3*i.
+        std::vector<int> dimvec(this->param_.dims.nbDims, 3 * i);
+        TensorShape shape;
+        TF_CHECK_OK(
+            TensorShapeUtils::MakeShape(dimvec.data(), dimvec.size(), &shape));
+
+        const nvinfer1::ITensor* input = network->getInput(0);
+        const char* name = input->getName();
+        VLOG(2) << "Defining profile for input " << name;
+        shape_vec[0] = shape;
+        if (this->param_.n_inputs == 2) {
+          // The shape of the shape tensor.
+          TF_CHECK_OK(TensorShapeUtils::MakeShape(
+              std::vector<int32>{param_.dims.nbDims}, &shape));
+          shape_vec[1] = shape;
+          // Values of the shape tensor
+          Tensor shape_tensor(DT_INT32, shape);
+          // Define shape values {1, i}, where 1 is the value of the first dim,
+          // and i is the value of the second dimension.
+          std::vector<int32> vals{1, i};
+          std::copy_n(vals.data(), vals.size(),
+                      shape_tensor.flat<int32_t>().data());
+          DataVec shape_values{{"one", {}}, {"two", shape_tensor}};
+          TF_CHECK_OK(profile.CollectShapeValues(shape_values));
+        } else {
+          TF_CHECK_OK(profile.CollectShapeValues({{"one", {}}}));
+        }
+        profile.AddShape(shape_vec);
+      }
+      std::vector<PartialTensorShape> input_partial_shapes;
+      TF_CHECK_OK(GetNetworkInputShapes(network.get(), &input_partial_shapes));
+      profile.InitProfiles(input_partial_shapes);
+      // Configure and build engine
+#if IS_TRT_VERSION_GE(6, 0, 0, 0)
+      TF_CHECK_OK(profile.ConfigureBuilder(builder.get(), builder_config.get(),
+                                           network.get()));
+#endif
+    }
+    VLOG(2) << "ConfigureBuilder Finished";
+#if IS_TRT_VERSION_GE(6, 0, 0, 0)
+    TrtUniquePtrType<nvinfer1::ICudaEngine> engine(
+        builder->buildEngineWithConfig(*network, *builder_config));
+#else
     TrtUniquePtrType<nvinfer1::ICudaEngine> engine(
         builder->buildCudaEngine(*network));
+#endif
+    VLOG(2) << "Engine constructed";
     EXPECT_NE(nullptr, engine);
     return engine;
   }
   Logger logger_;
+  TestParam param_;
 };
 
-TEST_F(TRTEngineResourceOpsTest, Basic) {
+#if IS_TRT_VERSION_GE(7, 1, 3, 0)
+constexpr std::array<TestParam, 3> TestParameters = {
+    TestParam{nvinfer1::Dims{1, {1}}, false, 1},
+    TestParam{nvinfer1::Dims{1, {1}}, true, 1},
+    TestParam{nvinfer1::Dims{2, {3, 3}}, true, 2}};
+#elif IS_TRT_VERSION_GE(6, 0, 0, 0)
+constexpr std::array<TestParam, 2> TestParameters = {
+    TestParam{nvinfer1::Dims{1, {1}}, false, 1},
+    TestParam{nvinfer1::Dims{1, {1}}, true, 1}};
+#else
+constexpr std::array<TestParam, 1> TestParameters = {
+    TestParam{nvinfer1::Dims{1, {1}}, false, 1}};
+#endif
+
+INSTANTIATE_TEST_CASE_P(EngineResourceOpsTestInstantiation,
+                        TRTEngineResourceOpsTest,
+                        ::testing::ValuesIn(TestParameters));
+
+TEST_P(TRTEngineResourceOpsTest, Basic) {
   // Create the GPU device.
   std::unique_ptr<Device> device(
       DeviceFactory::NewDevice("GPU", {}, "/job:worker/replica:0/task:0"));
   ResourceMgr* rm = device->resource_manager();
   SetDevice(DEVICE_GPU, std::move(device));
+
+  VLOG(2) << "Is TRT64 ? " << IS_TRT_VERSION_GE(6, 0, 0, 0);
 
   // Create a resource handle.
   const string container(kTfTrtContainerName);
@@ -180,8 +316,8 @@ TEST_F(TRTEngineResourceOpsTest, Basic) {
   EXPECT_TRUE(resource->RefCountIsOne());
   resource->Unref();
 
-  // Check that unregistering the resource from the resource manager returns an
-  // error as the resource has already been unregistered.
+  // Check that unregistering the resource from the resource manager returns
+  // an error as the resource has already been unregistered.
   Reset();
   TF_ASSERT_OK(NodeDefBuilder("op", "DestroyResourceOp")
                    .Attr("ignore_lookup_error", false)
@@ -223,6 +359,36 @@ TEST_F(TRTEngineResourceOpsTest, Basic) {
   // the cache of the resource is not empty.
   EXPECT_TRUE(rm->Lookup(container, resource_name, &resource).ok());
   EXPECT_EQ(1, resource->cache_.size());
+  if (this->param_.dynamic_shape) {
+    EXPECT_EQ(3, resource->profiles_.GetNumProfiles());
+    EXPECT_EQ(3, resource->cache_.begin()->second->GetNumContexts());
+
+    if (this->param_.n_inputs == 1) {
+      // Check if profiles are restored correctly.
+      std::vector<TensorShape> shapes(1);
+      // We create a shape vector that matches only profile 1.
+      TF_CHECK_OK(
+          TensorShapeUtils::MakeShape(std::vector<int32>{6}, &shapes[0]));
+      EXPECT_EQ(1, resource->profiles_.GetProfileNumber(shapes));
+    } else {
+      // Check if shape values are restored corretly.
+      std::vector<TensorShape> shapes(2);
+      // We create a shape vector that matches only profile 2.
+      TF_CHECK_OK(
+          TensorShapeUtils::MakeShape(std::vector<int32>{9, 9}, &shapes[0]));
+      TF_CHECK_OK(
+          TensorShapeUtils::MakeShape(std::vector<int32>{2}, &shapes[1]));
+      Tensor shape_tensor(DT_INT32, shapes[1]);
+      std::vector<int32> vals{1, 3};
+      std::copy_n(vals.data(), vals.size(),
+                  shape_tensor.flat<int32_t>().data());
+      // DataVec names are not in used CollectShapeValues, only the order
+      // matters.
+      DataVec shape_values{{"one", {}}, {"two", shape_tensor}};
+      TF_CHECK_OK(resource->profiles_.CollectShapeValues(shape_values));
+      EXPECT_EQ(2, resource->profiles_.GetProfileNumber(shapes));
+    }
+  }
   // Check that the resource has multiple references before it is unregistered
   // from the resource manager.
   EXPECT_FALSE(resource->RefCountIsOne());

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_engine_utils.h
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_engine_utils.h
@@ -19,6 +19,9 @@ limitations under the License.
 #include <string>
 #include <vector>
 
+#include "tensorflow/compiler/tf2tensorrt/common/datavec.h"
+#include "tensorflow/compiler/tf2tensorrt/utils/trt_execution_context.h"
+#include "tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/framework/tensor_shape.h"
@@ -32,83 +35,6 @@ namespace tensorflow {
 namespace tensorrt {
 using ::stream_executor::port::StatusOr;
 
-// Input/output data format for OpConverterTest::BuildAndRun().
-struct InputOutputData {
-  void* Buffer() const {
-    return const_cast<char*>(tensor.tensor_data().data());
-  }
-
-  size_t TotalBytes() const { return tensor.TotalBytes(); }
-
-  string name;
-  Tensor tensor;
-};
-
-class TRTBaseAllocator;
-
-// Keeps track of the TensorRT execution context and the device memory owned by
-// the context, if any. An execution context owns the device memory that TF-TRT
-// allocates for the context. In this case, the allocator is not null and is
-// used to free the device memory. An execution context doesn't own a device
-// memory (1) if the device memory is allocated through TensorRT, or (2) the
-// device memory is allocated by TF-TRT for another execution context but
-// shared with this context. If this case, the device memory is null.
-//
-// Currently, the main reason we want to allocate the device memory for an
-// execution context in TF-TRT is because the TensorRT API to create an
-// execution context with device memory doesn't handle out of memory properly.
-//
-// To support dynamic shapes, we create multiple execution contexts for an
-// engine and may want to support multiple execution contexts sharing the same
-// device memory.
-class ExecutionContext {
- private:
-  // Records the TensorRT execution context `context`, the device memory
-  // `device_memory` TF-TRT allocates for the context and the device memory
-  // allocator `allocator` used to allocate the memory. If TF-TRT doesn't
-  // allocate any device memory for the context, then `device_memory` is null.
-  // otherwise, allocator should not be null.
-  ExecutionContext(TRTBaseAllocator* allocator, void* device_memory,
-                   nvinfer1::IExecutionContext* context)
-      : memory_allocator_(allocator),
-        device_memory_(device_memory),
-        execution_context_(context) {}
-
- public:
-  // Disables copy constructors as the object owns the device memory and the
-  // execution context.
-  ExecutionContext(const ExecutionContext&) = delete;
-  ExecutionContext& operator=(const ExecutionContext&) = delete;
-
-  ExecutionContext(ExecutionContext&& other)
-      : memory_allocator_(other.memory_allocator_),
-        device_memory_(other.device_memory_),
-        execution_context_(other.execution_context_) {
-    other.memory_allocator_ = nullptr;
-    other.device_memory_ = nullptr;
-    other.execution_context_ = nullptr;
-  }
-
-  ~ExecutionContext();
-
-  operator nvinfer1::IExecutionContext*() const { return execution_context_; }
-  nvinfer1::IExecutionContext* GetIExecutionContext() const {
-    return execution_context_;
-  }
-
-  static StatusOr<ExecutionContext> Create(nvinfer1::ICudaEngine* cuda_engine,
-                                           TRTBaseAllocator* allocator);
-
- private:
-  // The allocator used to allocate and free the device memory owned by the
-  // execution context.
-  TRTBaseAllocator* memory_allocator_;
-  // The device memory owned by the execution context.
-  void* device_memory_;
-  // The TensorRT execution context.
-  nvinfer1::IExecutionContext* execution_context_;
-};
-
 // Creates a TensorRT execution context. If an allocator is not given, then the
 // execution context is created with device memory allocated by TensorRT.
 // Otherwise, uses the allocator to allocate the needed device memory for the
@@ -118,8 +44,6 @@ class ExecutionContext {
 // device memory happens, returns an error status instead.
 StatusOr<ExecutionContext> CreateExecutionContext(
     nvinfer1::ICudaEngine* cuda_engine, TRTBaseAllocator* allocator);
-
-using DataVec = std::vector<InputOutputData>;
 
 // Gets the binding index of a tensor in an engine.
 //
@@ -135,7 +59,9 @@ Status SetTrtEngineInputs(nvinfer1::ICudaEngine* cuda_engine,
                           nvinfer1::IExecutionContext* execution_context,
                           const int trt_profile_idx,
                           std::vector<void*>& buffers, bool use_implicit_batch,
-                          int num_batch, OpKernelContext* ctx = nullptr,
+                          int num_batch,
+                          const TrtShapeOptimizationProfile& profiles,
+                          OpKernelContext* ctx = nullptr,
                           const DataVec* input_vec = nullptr);
 
 // Returns the shape of a binding from TensorRT.

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_execution_context.h
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_execution_context.h
@@ -1,0 +1,96 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_COMPILER_TF2TENSORRT_UTILS_TRT_EXECUTION_CONTEXT_H_
+#define TENSORFLOW_COMPILER_TF2TENSORRT_UTILS_TRT_EXECUTION_CONTEXT_H_
+
+#include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/stream_executor/lib/statusor.h"
+
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+#include "third_party/tensorrt/NvInfer.h"
+
+namespace tensorflow {
+namespace tensorrt {
+using ::stream_executor::port::StatusOr;
+
+class TRTBaseAllocator;
+
+// Keeps track of the TensorRT execution context and the device memory owned by
+// the context, if any. An execution context owns the device memory that TF-TRT
+// allocates for the context. In this case, the allocator is not null and is
+// used to free the device memory. An execution context doesn't own a device
+// memory (1) if the device memory is allocated through TensorRT, or (2) the
+// device memory is allocated by TF-TRT for another execution context but
+// shared with this context. If this case, the device memory is null.
+//
+// Currently, the main reason we want to allocate the device memory for an
+// execution context in TF-TRT is because the TensorRT API to create an
+// execution context with device memory doesn't handle out of memory properly.
+//
+// To support dynamic shapes, we create multiple execution contexts for an
+// engine and may want to support multiple execution contexts sharing the same
+// device memory.
+class ExecutionContext {
+ private:
+  // Records the TensorRT execution context `context`, the device memory
+  // `device_memory` TF-TRT allocates for the context and the device memory
+  // allocator `allocator` used to allocate the memory. If TF-TRT doesn't
+  // allocate any device memory for the context, then `device_memory` is null.
+  // otherwise, allocator should not be null.
+  ExecutionContext(TRTBaseAllocator* allocator, void* device_memory,
+                   nvinfer1::IExecutionContext* context)
+      : memory_allocator_(allocator),
+        device_memory_(device_memory),
+        execution_context_(context) {}
+
+ public:
+  // Disables copy constructors as the object owns the device memory and the
+  // execution context.
+  ExecutionContext(const ExecutionContext&) = delete;
+  ExecutionContext& operator=(const ExecutionContext&) = delete;
+
+  ExecutionContext(ExecutionContext&& other)
+      : memory_allocator_(other.memory_allocator_),
+        device_memory_(other.device_memory_),
+        execution_context_(other.execution_context_) {
+    other.memory_allocator_ = nullptr;
+    other.device_memory_ = nullptr;
+    other.execution_context_ = nullptr;
+  }
+
+  ~ExecutionContext();
+
+  operator nvinfer1::IExecutionContext*() const { return execution_context_; }
+  nvinfer1::IExecutionContext* GetIExecutionContext() const {
+    return execution_context_;
+  }
+
+  static StatusOr<ExecutionContext> Create(nvinfer1::ICudaEngine* cuda_engine,
+                                           TRTBaseAllocator* allocator);
+
+ private:
+  // The allocator used to allocate and free the device memory owned by the
+  // execution context.
+  TRTBaseAllocator* memory_allocator_;
+  // The device memory owned by the execution context.
+  void* device_memory_;
+  // The TensorRT execution context.
+  nvinfer1::IExecutionContext* execution_context_;
+};
+};  // namespace tensorrt
+};  // namespace tensorflow
+#endif
+#endif

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_lru_cache.h
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_lru_cache.h
@@ -144,6 +144,11 @@ struct EngineContext {
     return Status::OK();
   }
 
+  int GetNumContexts() {
+    mutex_lock lock(mu);
+    return execution_context.size();
+  }
+
   // In explicit batch mode, we maintain a vector of contexts for each engine,
   // where each context is created for a specific profile. This is because it is
   // either not possible or non-trivial to change the profile of a context for

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.cc
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.cc
@@ -20,8 +20,12 @@ limitations under the License.
 
 #include "absl/algorithm/container.h"
 #include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
+#include "tensorflow/core/platform/stream_executor.h"
 
 #if GOOGLE_CUDA && GOOGLE_TENSORRT
+
+#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
+
 namespace tensorflow {
 namespace tensorrt {
 
@@ -30,7 +34,9 @@ template <typename TensorShapeType>
 std::vector<nvinfer1::Dims> GetDimVec(std::vector<TensorShapeType> shape_vec) {
   std::vector<nvinfer1::Dims> dimvec(shape_vec.size());
   absl::c_transform(shape_vec, dimvec.begin(), [](TensorShapeType shape) {
-    return TensorShapeToTrtDims(shape, false);
+    nvinfer1::Dims dims;
+    TF_CHECK_OK(TensorShapeToTrtDims(shape, false, &dims));
+    return dims;
   });
   return dimvec;
 }
@@ -52,49 +58,143 @@ void SetImplicitBatchModeCompatibleProfile(
     std::vector<nvinfer1::Dims>* opt, std::vector<nvinfer1::Dims>* max) {
   *min = dimvec;
   for (auto& dim : *min) {
-    dim.d[0] = 1;  // Set min batch size to 1.
+    // Shape value tensors can have -1 value as a wildcard. We do not change
+    // in that case.
+    if (dim.d[0] != -1) dim.d[0] = 1;  // Set min batch size to 1.
   }
   *opt = dimvec;
   *max = dimvec;
 }
 
-void TrtShapeOptimizationProfile::ImplicitBatchModeCompatibleStrategy() {
-  for (auto& shape_vec : input_shapes_) {
-    if (!shape_vec.empty()) {
-      std::vector<nvinfer1::Dims> dimvec = GetDimVec(shape_vec);
-      std::vector<nvinfer1::Dims> min, opt, max;
-      SetImplicitBatchModeCompatibleProfile(dimvec, &min, &opt, &max);
-      OptimizationProfileConfig profConfig{min, opt, max};
-      profiles_.push_back(std::move(profConfig));
-    }
+void TrtShapeOptimizationProfile::ImplicitBatchModeCompatibleStrategy(
+    const std::vector<std::vector<nvinfer1::Dims>>& collected_shapes) {
+  for (auto& shape_vec : collected_shapes) {
+    std::vector<nvinfer1::Dims> min, opt, max;
+    SetImplicitBatchModeCompatibleProfile(shape_vec, &min, &opt, &max);
+    VLOG(2) << "Initializing optimization profile config with min="
+            << DebugString(min) << ", opt=max=" << DebugString(max);
+    OptimizationProfileConfig profConfig{min, opt, max};
+    profiles_.push_back(std::move(profConfig));
   }
 }
 
-void TrtShapeOptimizationProfile::OptimalStrategy() {
-  for (auto& shape_vec : input_shapes_) {
-    if (!shape_vec.empty()) {
-      std::vector<nvinfer1::Dims> min = GetDimVec(shape_vec);
-      std::vector<nvinfer1::Dims> opt = min;
-      std::vector<nvinfer1::Dims> max = min;
-      OptimizationProfileConfig profConfig{min, opt, max};
-      profiles_.push_back(std::move(profConfig));
-    }
+void TrtShapeOptimizationProfile::OptimalStrategy(
+    const std::vector<std::vector<nvinfer1::Dims>>& collected_shapes) {
+  for (auto& shape_vec : collected_shapes) {
+    std::vector<nvinfer1::Dims> min = shape_vec;
+    std::vector<nvinfer1::Dims> opt = min;
+    std::vector<nvinfer1::Dims> max = min;
+    VLOG(2) << "Initializing optimization profile config with min=opt=max="
+            << DebugString(min);
+    OptimizationProfileConfig profConfig{min, opt, max};
+    profiles_.push_back(std::move(profConfig));
   }
 }
 
-// Adjust shape value profile to prevent TRT from removing shape value input
+// Collects the values of tensors that are ShapeTensorCompatible to. The values
+// are stored in the actual_shape_values_ member variable.
+Status TrtShapeOptimizationProfile::CollectShapeValues(OpKernelContext* ctx) {
+  const cudaStream_t* stream = CHECK_NOTNULL(
+      reinterpret_cast<const cudaStream_t*>(ctx->op_device_context()
+                                                ->stream()
+                                                ->implementation()
+                                                ->GpuStreamMemberHack()));
+  actual_shape_values_.resize(ctx->num_inputs());
+  if (is_shape_tensor_.empty()) {
+    is_shape_tensor_.resize(ctx->num_inputs());
+    for (int i = 0; i < ctx->num_inputs(); i++) {
+      is_shape_tensor_[i] = IsTrtShapeTensorCompatible(ctx->input(i));
+    }
+  }
+  int n_shape_val = 0;
+  // First copy all the shape value candidates into actual_shape_values_ vector.
+  for (int i = 0; i < ctx->num_inputs(); i++) {
+    if (is_shape_tensor_[i]) {
+      // We have to copy the shape values to the host, because TRT's
+      // ExecutionContext::setInputShapeBinding expects a host pointer.
+      n_shape_val++;
+      const Tensor& input = ctx->input(i);
+      actual_shape_values_[i].nbDims = input.NumElements();
+      auto ret = cudaMemcpyAsync(
+          actual_shape_values_[i].d, input.flat<int32>().data(),
+          input.NumElements() * sizeof(int32), cudaMemcpyDeviceToHost, *stream);
+      if (ret != 0) {
+        return errors::Internal("Could not copy shape tensor values");
+      }
+      VLOG(2) << "Input " << i << " is (probably) a shape tensor, n_values="
+              << input.NumElements();
+    } else {
+      actual_shape_values_[i] = {0, {}};
+    }
+  }
+  if (n_shape_val > 0) {
+    // If we have any shape values candidates, then wait until data is copied
+    // to host.
+    cudaStreamSynchronize(*stream);
+  }
+  return Status::OK();
+}
+
+// Collects the values of tensors that are ShapeTensorCompatible to. To be used
+// for unit tests.
+Status TrtShapeOptimizationProfile::CollectShapeValues(const DataVec& input) {
+  actual_shape_values_.resize(input.size());
+  for (int i = 0; i < input.size(); i++) {
+    if (is_shape_tensor_[i]) {
+      if (!IsTrtShapeTensorCompatible(input[i].tensor)) {
+        return errors::Internal("Inconsistent shape tensor ", input[i].name,
+                                ", ", i);
+      }
+      int n_elements = input[i].tensor.NumElements();
+      actual_shape_values_[i].nbDims = n_elements;
+      // During unit tests, the data is in unified memory
+      std::copy(input[i].tensor.flat<int32>().data(),
+                input[i].tensor.flat<int32>().data() + n_elements,
+                actual_shape_values_[i].d);
+      VLOG(2) << "Collected tensor shape values "
+              << DebugString(actual_shape_values_[i]);
+    } else {
+      actual_shape_values_[i] = {0, {}};
+    }
+  }
+  return Status::OK();
+}
+
+// Adjusts shape value profile to prevent TRT from removing shape value input
 // bindings whose value is redundant (only a single value matches the profile).
 // This should be removed once the NVIDIA bug 3153064 is fixed.
 void FixShapeValueProfile(OptimizationProfileConfig* prof,
                           const std::vector<bool>& is_shape_tensor) {
-  for (int i = 0; i < prof->min.size(); i++) {
+  int shape_value_offset = is_shape_tensor.size();
+  for (int i = 0; i < is_shape_tensor.size(); i++) {
     if (is_shape_tensor[i] &&
-        std::equal(prof->min[i].d, prof->min[i].d + prof->min[i].nbDims,
-                   prof->max[i].d)) {
-      VLOG(2) << "Adjust profile for shape value tensor " << i;
-      prof->max[i].d[0]++;
+        std::equal(prof->min[shape_value_offset + i].d,
+                   prof->min[shape_value_offset + i].d +
+                       prof->min[shape_value_offset + i].nbDims,
+                   prof->max[shape_value_offset + i].d)) {
+      prof->max[shape_value_offset + i].d[0]++;
+      VLOG(2) << "Adjusted profile for shape value tensor " << i << " "
+              << DebugString(prof->max[shape_value_offset + i]);
+    } else {
+      VLOG(2) << i << " is not a shape tensor." << is_shape_tensor[i];
     }
   }
+}
+
+// Checks whether rhs is already contained in values.
+bool AlreadyCollected(const std::vector<std::vector<nvinfer1::Dims>>& values,
+                      const std::vector<nvinfer1::Dims>& rhs) {
+  for (auto& lhs : values) {
+    bool ret = lhs.size() == rhs.size();
+    for (int i = 0; ret && i < lhs.size(); i++) {
+      ret &= lhs[i].nbDims == rhs[i].nbDims;
+      for (int j = 0; ret && j < lhs[i].nbDims; j++) {
+        ret &= (lhs[i].d[j] == rhs[i].d[j]);
+      }
+    }
+    if (ret) return true;
+  }
+  return false;
 }
 
 void TrtShapeOptimizationProfile::InitProfiles(
@@ -104,10 +204,32 @@ void TrtShapeOptimizationProfile::InitProfiles(
                "You have to enable profile generation mode first (build).";
     return;
   }
+  // Preprocess the vector of input shapes and shape values:
+  // - Converts TensorShape -> nvinfer::Dims.
+  // - Concatenates the shape values after the input shapes:
+  //   dimvec = [dim0, dim1,..., shapeval0, shapval1, ...]
+  // - Ensures that the list is unique.
+  std::vector<std::vector<nvinfer1::Dims>> collected_shapes;
+  for (int i = 0; i < input_shapes_.size(); i++) {
+    auto shape_vec = input_shapes_[i];
+    VLOG(2) << "Initprofiles, processing shape " << i;
+    if (!shape_vec.empty()) {
+      std::vector<nvinfer1::Dims> dimvec = GetDimVec(shape_vec);
+      dimvec.insert(dimvec.end(), input_shape_values_[i].begin(),
+                    input_shape_values_[i].end());
+      // TODO(tfeher): This condition should not apply for explicit profile. In
+      // that case consicutive elements in collected_shapes contain the user
+      // defined values of min, opt and max, and it is valid the have min = opt
+      // and opt = max.
+      if (!AlreadyCollected(collected_shapes, dimvec)) {
+        collected_shapes.push_back(dimvec);
+      }
+    }
+  }
   switch (strategy_) {
     case ProfileStrategy::kImplicitBatchModeCompatible:
       VLOG(1) << "Creating profiles with ImplicitBatchModeCompatible strategy";
-      ImplicitBatchModeCompatibleStrategy();
+      ImplicitBatchModeCompatibleStrategy(collected_shapes);
       break;
     // Treat all other strategies the same as kOptimal for now. Implementing
     // those is outlined in the dynamic shape support implementation plan.
@@ -115,12 +237,12 @@ void TrtShapeOptimizationProfile::InitProfiles(
     case ProfileStrategy::kRangeOptimal:
     case ProfileStrategy::kOptimal:
       VLOG(1) << "Creating profiles with Optimal strategy";
-      OptimalStrategy();
+      OptimalStrategy(collected_shapes);
       break;
   }
-  // Define a mask that describe which input could be a shape tensor. Note that
-  // here we can have false positives. The shape tensor mask will be updated
-  // once the network is constructed.
+  // Define a mask that describe which input could be a shape tensor. Note
+  // that here we can have false positives. The shape tensor mask will be
+  // updated once the network is constructed.
   SetShapeTensorMask(input_partial_shapes);
   if (input_partial_shapes.size() > 0) {
     for (OptimizationProfileConfig& prof : profiles_) {
@@ -154,12 +276,12 @@ Status TrtShapeOptimizationProfile::AddProfiles(
     if (idx >= 0) {
       if (i != idx) {
         return errors::Internal(
-            "Profile index of engine config is different from resource profile "
+            "Profile index of engine config is different from source profile "
             "index: ",
             i, " != ", idx);
       }
       VLOG(1) << "Added optimization profile " << profiles_[i].DebugString()
-              << " to builder config.";
+              << " with idx " << idx << " to builder config.";
     } else {
       LOG(ERROR) << "Failed to add optimization profile "
                  << profiles_[i].DebugString()
@@ -186,6 +308,22 @@ Status TrtShapeOptimizationProfile::ConfigureBuilder(
   return Status::OK();
 }
 #endif
+
+// Sets the shape tensor mask from the TRT engine definition.
+void TrtShapeOptimizationProfile::SetShapeTensorMask(
+    const nvinfer1::ICudaEngine* engine, int n_inputs) {
+  is_shape_tensor_.resize(n_inputs, false);
+#if IS_TRT_VERSION_GE(6, 0, 0, 0)
+  for (int i = 0; i < n_inputs; i++) {
+    is_shape_tensor_[i] = engine->isShapeBinding(i);
+    if (is_shape_tensor_[i]) {
+      VLOG(2) << "Found shape tensor at " << i;
+    }
+  }
+#endif
+  has_shape_tensor_ =
+      absl::c_any_of(is_shape_tensor_, [](bool b) { return b; });
+}
 
 // Sets the shape tensor mask using the network definition.
 void TrtShapeOptimizationProfile::SetShapeTensorMask(
@@ -224,8 +362,10 @@ void TrtShapeOptimizationProfile::SetShapeTensorMask(
 int TrtShapeOptimizationProfile::GetProfileNumber(
     const std::vector<TensorShape>& shapes) {
   if (!need_profiles_) return 0;
+  // TODO(tfeher): Return the best profile not just the first compatible.
   for (int i = 0; i < profiles_.size(); i++) {
-    if (profiles_[i].IncludesShapes(shapes)) {
+    if (profiles_[i].IncludesShapes(shapes, HasShapeTensor(),
+                                    actual_shape_values_)) {
       return i;
     }
   }
@@ -270,6 +410,55 @@ Status TrtShapeOptimizationProfile::CreateExecutionContexts(
   return Status::OK();
 }
 
+Status TrtShapeOptimizationProfile::SetInputShapeBinding(
+    int input_index, int binding_index, nvinfer1::ICudaEngine* cuda_engine,
+    nvinfer1::IExecutionContext* exec_context) const {
+#if IS_TRT_VERSION_GE(6, 0, 0, 0)
+  if (cuda_engine->isShapeBinding(binding_index)) {
+    // Input shape binding data has to be in host memory. That is the reason
+    // we can't use input_tensor.flat().data(). which contains the same
+    // values in device memory. Instead, we use data that was copied to host
+    // by CollectShapeValues.
+    VLOG(2) << "Setting input shape binding for idx " << binding_index
+            << ", with values "
+            << DebugString(actual_shape_values_.at(input_index));
+    bool ret = exec_context->setInputShapeBinding(
+        binding_index, actual_shape_values_.at(input_index).d);
+    if (!ret) {
+      return errors::Internal("Could not set input shape binding for idx ",
+                              binding_index);
+    }
+  }
+#endif
+  return Status::OK();
+}
+
+// If binding_idx is a shape tensor, then returns the associated min/max/opt
+// shape values from prof_idx.
+#if IS_TRT_VERSION_GE(6, 0, 0, 0)
+nvinfer1::Dims GetDimsFromShapeVal(int prof_idx, int binding_idx,
+                                   nvinfer1::OptProfileSelector selector,
+                                   const nvinfer1::ICudaEngine* engine) {
+  if (engine->isShapeBinding(binding_idx)) {
+    const int32* shape_val_ptr =
+        engine->getProfileShapeValues(binding_idx, prof_idx, selector);
+    if (shape_val_ptr) {
+      VLOG(2) << "Found shape value in prof " << prof_idx << ", binding "
+              << binding_idx;
+      nvinfer1::Dims dims = engine->getBindingDimensions(binding_idx);
+      // nbDims == 0 represent scalar, -1 represents invalid dim
+      int n_values = (dims.nbDims == 0) ? 1 : dims.d[0];
+      if (n_values > 0) {
+        dims.nbDims = n_values;
+        std::copy(shape_val_ptr, shape_val_ptr + n_values, dims.d);
+      }
+      return dims;
+    }
+  }
+  return {0, {0}};
+}
+#endif
+
 Status TrtShapeOptimizationProfile::RestoreProfiles(
     const nvinfer1::ICudaEngine* engine) {
   need_profiles_ = false;
@@ -286,21 +475,44 @@ Status TrtShapeOptimizationProfile::RestoreProfiles(
 #endif
   int n_profiles = engine->getNbOptimizationProfiles();
   need_profiles_ = n_profiles > 0;
+  int n_bindings = engine->getNbBindings();
+  int K = n_bindings / n_profiles;
   int n_inputs = GetNumberOfEngineInputs(engine);
   VLOG(2) << "Attempting to restore " << n_profiles << " profiles, each with "
           << n_inputs << " inputs";
+  SetShapeTensorMask(engine, n_inputs);
   for (int prof_idx = 0; prof_idx < n_profiles; prof_idx++) {
     OptimizationProfileConfig cfg;
+
+    cfg.min.resize(n_inputs * 2);
+    cfg.max.resize(n_inputs * 2);
+    cfg.opt.resize(n_inputs * 2);
+    // restore shape values
     for (int j = 0; j < n_inputs; j++) {
+#if IS_TRT_VERSION_GE(7, 1, 3, 0)
+      // TODO(tfeher): consider getting the binding idx from
+      // GetTrtBindingIndex. To make that work we need to construct the input
+      // name similarily as it is done in SetTrtEngineInputs.
+      int binding_idx = prof_idx * K + j;
+#else
+      int binding_idx = j;
+#endif
       nvinfer1::Dims min = engine->getProfileDimensions(
-          j, prof_idx, nvinfer1::OptProfileSelector::kMIN);
+          binding_idx, prof_idx, nvinfer1::OptProfileSelector::kMIN);
       nvinfer1::Dims max = engine->getProfileDimensions(
-          j, prof_idx, nvinfer1::OptProfileSelector::kMAX);
+          binding_idx, prof_idx, nvinfer1::OptProfileSelector::kMAX);
       nvinfer1::Dims opt = engine->getProfileDimensions(
-          j, prof_idx, nvinfer1::OptProfileSelector::kOPT);
-      cfg.min.push_back(min);
-      cfg.max.push_back(max);
-      cfg.opt.push_back(opt);
+          binding_idx, prof_idx, nvinfer1::OptProfileSelector::kOPT);
+      cfg.min[j] = min;
+      cfg.max[j] = max;
+      cfg.opt[j] = opt;
+
+      cfg.min[j + n_inputs] = GetDimsFromShapeVal(
+          prof_idx, binding_idx, nvinfer1::OptProfileSelector::kMIN, engine);
+      cfg.max[j + n_inputs] = GetDimsFromShapeVal(
+          prof_idx, binding_idx, nvinfer1::OptProfileSelector::kMAX, engine);
+      cfg.opt[j + n_inputs] = GetDimsFromShapeVal(
+          prof_idx, binding_idx, nvinfer1::OptProfileSelector::kOPT, engine);
     }
     VLOG(2) << "Restored profile " << cfg.DebugString();
     profiles_.push_back(std::move(cfg));


### PR DESCRIPTION
This PR improves the Reshape op converter to handle explicit batch and dynamic shape input data.

Since TRT6, IShuffleLayer has an option to accept the shape parameter as an [input tensor](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_shuffle_layer.html#a0ab2ab37e4377c9c317c1d869908efbc). If the shape input tensor corresponds to an input tensor of  the TRTEngineOp, then we need to [specify the input shape values](https://github.com/tfeher/tensorflow/blob/318b5c416db756432125af9d25446bdc3db5ee1f/tensorflow/compiler/tf2tensorrt/utils/trt_engine_utils.cc#L127-L134) for the engine. Additionally we need to specify optimization profile parameters for the shape values. The necessary changes were implemented in TrtShapeOptimizationProfile, TRTEngineOp, trt_engine_utils.

The unit tests have only a single op, and therefore handling shape input values are required to test
reshape with tensor input shape. In normal network it is less likely to have shape input tensors. 

Additionally the handling of scalar input/output shapes are improved.

C++ test for serialization / deserialization of input shapes and shape values added.

Note: TensorRT has a function  [INetworkDefinition::markOutputForShapes](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_network_definition.html#a1f0fff6e9c2469e31ac3be82dd3f0f28) which could enable the output tensor's value to be computed by IExecutionContext::getShapeBinding. This is not used in this PR, but it might be useful for shape inference.

