### PR TITLE
[AMP] Add `disable_amp_scope` to disable auto mixed precision cast

### DIFF
--- a/tensorflow/python/framework/function.py
+++ b/tensorflow/python/framework/function.py
@@ -1229,6 +1229,10 @@ def _parse_kwargs_as_attrs(func_name, **kwargs):
   if noinline is not None:
     attrs["_noinline"] = attr_value_pb2.AttrValue(b=bool(noinline))
 
+  disableamp = kwargs.pop("disableamp", None)
+  if disableamp is not None:
+    attrs["_DisableAmp"] = attr_value_pb2.AttrValue(b=bool(disableamp))
+
   # For compatibility with previous behavior, Defun does not perform shape
   # inference through its function call operations.
   attrs["_disable_call_shape_inference"] = attr_value_pb2.AttrValue(b=True)


### PR DESCRIPTION
This is a PR from JIZHI, the AI platform in Tencent.
This allows disabling AMP autocast in the scope if someone want to force to run in a particular dtype, which has been supported in [PyTorch](https://pytorch.org/docs/master/amp.html).