### PR TITLE
Fix distributed autocast variable assignment

### DIFF
--- a/tensorflow/python/framework/func_graph.py
+++ b/tensorflow/python/framework/func_graph.py
@@ -187,7 +187,7 @@ class FuncGraph(ops.Graph):
     self.inputs = []
     self.outputs = []
     self.control_outputs = []
-    self.control_captures = set()
+    self.control_captures = object_identity.ObjectIdentitySet()
     self.structured_input_signature = None
     self.structured_outputs = None
     self._weak_variables = []

--- a/tensorflow/python/keras/mixed_precision/experimental/autocast_variable.py
+++ b/tensorflow/python/keras/mixed_precision/experimental/autocast_variable.py
@@ -188,61 +188,88 @@ class AutoCastVariable(variables.Variable, core.Tensor):
   def constraint(self):
     return self._variable.constraint
 
+  def _apply_assign_update(
+      self, update_fn, value, use_locking=None, name=None, read_value=True):
+    if not read_value:
+      return update_fn(value, use_locking, name, read_value)
+
+    if context.executing_eagerly() or ops.inside_function():
+      assign_op = update_fn(value, use_locking, name, False)
+      with ops.control_dependencies([assign_op]):
+        return self
+
+    # Fallback to wrapping the returned variable in graph mode if possible
+    assign_var = update_fn(value, use_locking, name, read_value)
+    if resource_variable_ops.is_resource_variable(assign_var):
+      return create_autocast_variable(assign_var)
+    return assign_var
+
+  def _apply_update(self, update_fn, *args, **kwargs):
+    update_var = update_fn(*args, **kwargs)
+    if context.executing_eagerly() or ops.inside_function():
+      with ops.control_dependencies([update_var]):
+        return self
+
+    # Fallback to wrapping the returned variable in graph mode if possible
+    if resource_variable_ops.is_resource_variable(update_var):
+      return create_autocast_variable(update_var)
+    return update_var
+
   def assign(self, value, use_locking=None, name=None, read_value=True):
-    assign_op = self._variable.assign(value, use_locking, name, read_value)
-    return _maybe_wrap(assign_op, wrap=read_value)
+    return self._apply_assign_update(
+        self._variable.assign, value, use_locking, name, read_value)
 
   def assign_add(self, delta, use_locking=None, name=None, read_value=True):
-    assign_op = self._variable.assign_add(delta, use_locking, name, read_value)
-    return _maybe_wrap(assign_op, wrap=read_value)
+    return self._apply_assign_update(
+        self._variable.assign_add, delta, use_locking, name, read_value)
 
   def assign_sub(self, delta, use_locking=None, name=None, read_value=True):
-    assign_op = self._variable.assign_sub(delta, use_locking, name, read_value)
-    return _maybe_wrap(assign_op, wrap=read_value)
+    return self._apply_assign_update(
+        self._variable.assign_sub, delta, use_locking, name, read_value)
 
   def scatter_sub(self, sparse_delta, use_locking=False, name=None):
-    var = self._variable.scatter_sub(sparse_delta, use_locking, name)
-    return _maybe_wrap(var)
+    return self._apply_update(
+        self._variable.scatter_sub, sparse_delta, use_locking, name)
 
   def scatter_add(self, sparse_delta, use_locking=False, name=None):
-    var = self._variable.scatter_add(sparse_delta, use_locking, name)
-    return _maybe_wrap(var)
+    return self._apply_update(
+        self._variable.scatter_add, sparse_delta, use_locking, name)
 
   def scatter_max(self, sparse_delta, use_locking=False, name=None):
-    var = self._variable.scatter_max(sparse_delta, use_locking, name)
-    return _maybe_wrap(var)
+    return self._apply_update(
+        self._variable.scatter_max, sparse_delta, use_locking, name)
 
   def scatter_min(self, sparse_delta, use_locking=False, name=None):
-    var = self._variable.scatter_min(sparse_delta, use_locking, name)
-    return _maybe_wrap(var)
+    return self._apply_update(
+        self._variable.scatter_min, sparse_delta, use_locking, name)
 
   def scatter_mul(self, sparse_delta, use_locking=False, name=None):
-    var = self._variable.scatter_mul(sparse_delta, use_locking, name)
-    return _maybe_wrap(var)
+    return self._apply_update(
+        self._variable.scatter_mul, sparse_delta, use_locking, name)
 
   def scatter_div(self, sparse_delta, use_locking=False, name=None):
-    var = self._variable.scatter_div(sparse_delta, use_locking, name)
-    return _maybe_wrap(var)
+    return self._apply_update(
+        self._variable.scatter_div, sparse_delta, use_locking, name)
 
   def scatter_update(self, sparse_delta, use_locking=False, name=None):
-    var = self._variable.scatter_update(sparse_delta, use_locking, name)
-    return _maybe_wrap(var)
+    return self._apply_update(
+        self._variable.scatter_update, sparse_delta, use_locking, name)
 
   def batch_scatter_update(self, sparse_delta, use_locking=False, name=None):
-    var = self._variable.batch_scatter_update(sparse_delta, use_locking, name)
-    return _maybe_wrap(var)
+    return self._apply_update(
+        self._variable.batch_scatter_update, sparse_delta, use_locking, name)
 
   def scatter_nd_sub(self, indices, updates, name=None):
-    var = self._variable.scatter_nd_sub(indices, updates, name)
-    return _maybe_wrap(var)
+    return self._apply_update(
+        self._variable.scatter_nd_sub, indices, updates, name)
 
   def scatter_nd_add(self, indices, updates, name=None):
-    var = self._variable.scatter_nd_add(indices, updates, name)
-    return _maybe_wrap(var)
+    return self._apply_update(
+        self._variable.scatter_nd_add, indices, updates, name)
 
   def scatter_nd_update(self, indices, updates, name=None):
-    var = self._variable.scatter_nd_update(indices, updates, name)
-    return _maybe_wrap(var)
+    return self._apply_update(
+        self._variable.scatter_nd_update, indices, updates, name)
 
   def load(self, value, session=None):
     return self._variable.load(value, session)
@@ -462,24 +489,3 @@ def create_autocast_variable(variable):
       # pylint: enable=missing-format-attribute
 
   return AutoCastDistributedVariable(variable)
-
-
-def _maybe_wrap(variable, wrap=True):
-  """Creates an AutoCastVariable that wraps another variable if applicable.
-
-  This function is used to wrap the return value of AutoCastVariable.assign.
-  Unfortunately MirroredVariable.assign will (incorrectly) return a Mirrored
-  value instead of a MirroredVariable. So we cannot properly wrap it in an
-  AutoCastVariable. We return the original variable in that case.
-
-  Args:
-    variable: A tf.Variable or op.
-    wrap: A boolean to define whether to wrap the variable in an
-      AutoCastVariable or not.
-
-  Returns:
-    An AutoCastVariable if wrap is True and variable is a resource variable.
-  """
-  if wrap and resource_variable_ops.is_resource_variable(variable):
-    return create_autocast_variable(variable)
-  return variable

--- a/tensorflow/python/keras/mixed_precision/experimental/autocast_variable.py
+++ b/tensorflow/python/keras/mixed_precision/experimental/autocast_variable.py
@@ -190,7 +190,7 @@ class AutoCastVariable(variables.Variable, core.Tensor):
 
   def _apply_assign_update(
       self, update_fn, value, use_locking=None, name=None, read_value=True):
-    if context.executing_eagerly() or ops.inside_function():
+    if ops.executing_eagerly_outside_functions():
       assign_op = update_fn(value, use_locking, name, False)
       return self if read_value else assign_op
 
@@ -202,7 +202,7 @@ class AutoCastVariable(variables.Variable, core.Tensor):
 
   def _apply_update(self, update_fn, *args, **kwargs):
     update_var = update_fn(*args, **kwargs)
-    if context.executing_eagerly() or ops.inside_function():
+    if ops.executing_eagerly_outside_functions():
       return self
 
     # Fallback to wrapping the returned variable in graph mode if possible

--- a/tensorflow/python/keras/mixed_precision/experimental/autocast_variable_test.py
+++ b/tensorflow/python/keras/mixed_precision/experimental/autocast_variable_test.py
@@ -372,7 +372,6 @@ class AutoCastVariableTest(test.TestCase, parameterized.TestCase):
         # Variable should be increased, despite it appearing to be the same
         # float16 value.
         self.evaluate(x.assign(1. + small_tensor))
-        self.assertEqual(1. + small_val, self.evaluate(x._variable))
         self.assertEqual(1., self.evaluate(x.value()))
       self.assertEqual(1. + small_val, self.evaluate(x))
 
@@ -380,7 +379,6 @@ class AutoCastVariableTest(test.TestCase, parameterized.TestCase):
       with ops.get_default_graph()._enable_auto_casting_variables(
           dtypes.float16):
         self.evaluate(x.assign_add(small_tensor))
-        self.assertEqual(1. + small_val, self.evaluate(x._variable))
         self.assertEqual(1., self.evaluate(x.value()))
       self.assertEqual(1. + small_val, self.evaluate(x))
 

--- a/tensorflow/python/keras/mixed_precision/experimental/autocast_variable_test.py
+++ b/tensorflow/python/keras/mixed_precision/experimental/autocast_variable_test.py
@@ -345,6 +345,9 @@ class AutoCastVariableTest(test.TestCase, parameterized.TestCase):
 
   @combinations.generate(maybe_distribute)
   def test_assign_tf_function(self, distribution):
+    if not context.executing_eagerly():
+      self.skipTest("Test is not compatible with graph mode")
+
     with distribution.scope():
       x = get_var(0., dtypes.float32)
       x = autocast_variable.create_autocast_variable(x)

--- a/tensorflow/python/keras/mixed_precision/experimental/autocast_variable_test.py
+++ b/tensorflow/python/keras/mixed_precision/experimental/autocast_variable_test.py
@@ -304,8 +304,8 @@ class AutoCastVariableTest(test.TestCase, parameterized.TestCase):
         self.assertAllClose(3., self.evaluate(x.assign_sub(3.)))
 
         # Assign multiple times
-        # This currently doesn't work in graph mode
-        if context.executing_eagerly() or ops.inside_function():
+        # This currently doesn't work in graph mode if a strategy is used
+        if not ds_context.has_strategy() or context.executing_eagerly():
           assign = x.assign(1.)
           self.assertAllClose(1., self.evaluate(assign))
           self.assertAllClose(0., self.evaluate(assign.assign(0.)))


### PR DESCRIPTION
This PR fixes assignment and variable updates of `AutoCastVariable` inside distribution strategies as mentioned in https://github.com/tensorflow/tensorflow/pull/40493#discussion_r440508322.
This makes `AutoCastVariable` work as expected in eager execution and inside TF functions. Distribution strategies in graph mode now remain the only case where `AutoCastVariable` doesn't fully follow the spec due to https://github.com/tensorflow/tensorflow/pull/40493#discussion_r440523571.
This PR should also remove the overhead of creating new `AutoCastVariable` instances on variable assignment in eager execution, though I haven't benchmarked this since this doesn't seem like a very hot code path during normal usage.

@reedwm Would be great if you could take a look at this.