### PR TITLE
[ROCm] Fix ROCm CSB build failure - 200618

### DIFF
--- a/tensorflow/core/util/gpu_device_functions.h
+++ b/tensorflow/core/util/gpu_device_functions.h
@@ -789,11 +789,6 @@ __device__ inline double GpuAtomicMax(double* ptr, double value) {
       ptr, [value](double a) { return fmax(a, value); });
 }
 
-__device__ inline long long GpuAtomicMax(long long* ptr, long long value) {
-  return detail::GpuAtomicCasHelper(
-      ptr, [value](long long a) { return max(a, value); });
-}
-
 #else
 
 __device__ inline float GpuAtomicMax(float* ptr, float value) {
@@ -814,7 +809,7 @@ __device__ inline Eigen::half GpuAtomicMax(Eigen::half* ptr,
       ptr, [value](Eigen::half a) { return max(a, value); });
 }
 
-#if __CUDA_ARCH__ < 320
+#if TENSORFLOW_USE_ROCM || (__CUDA_ARCH__ < 320)
 __device__ inline tensorflow::uint64 GpuAtomicMax(tensorflow::uint64* ptr,
                                                   tensorflow::uint64 value) {
   return detail::GpuAtomicCasHelper(
@@ -859,11 +854,6 @@ __device__ inline double GpuAtomicMin(double* ptr, double value) {
       ptr, [value](double a) { return fmin(a, value); });
 }
 
-__device__ inline long long GpuAtomicMin(long long* ptr, long long value) {
-  return detail::GpuAtomicCasHelper(
-      ptr, [value](long long a) { return min(a, value); });
-}
-
 #else
 
 __device__ inline float GpuAtomicMin(float* ptr, float value) {
@@ -884,7 +874,7 @@ __device__ inline Eigen::half GpuAtomicMin(Eigen::half* ptr,
       ptr, [value](Eigen::half a) { return min(a, value); });
 }
 
-#if __CUDA_ARCH__ < 320
+#if TENSORFLOW_USE_ROCM || (__CUDA_ARCH__ < 320)
 __device__ inline tensorflow::uint64 GpuAtomicMin(tensorflow::uint64* ptr,
                                                   tensorflow::uint64 value) {
   return detail::GpuAtomicCasHelper(


### PR DESCRIPTION
The folllowing commit introduces build error on the ROCm platform

https://github.com/tensorflow/tensorflow/commit/b6ff68822a59578f942e4fb8076757da8db278ae

build error

```
In file included from tensorflow/core/kernels/split_lib_gpu.cu.cc:27:
In file included from ./tensorflow/core/util/gpu_kernel_helper.h:25:
./tensorflow/core/util/gpu_device_functions.h:824:25: error: redefinition of 'GpuAtomicMax'
__device__ inline int64 GpuAtomicMax(int64* ptr, int64 value) {
                        ^
./tensorflow/core/util/gpu_device_functions.h:792:29: note: previous definition is here
__device__ inline long long GpuAtomicMax(long long* ptr, long long value) {
                            ^
./tensorflow/core/util/gpu_device_functions.h:894:25: error: redefinition of 'GpuAtomicMin'
__device__ inline int64 GpuAtomicMin(int64* ptr, int64 value) {
                        ^
./tensorflow/core/util/gpu_device_functions.h:862:29: note: previous definition is here
__device__ inline long long GpuAtomicMin(long long* ptr, long long value) {
                            ^
2 errors generated.
...
...
```

The cause is a combination of two things
* The condition `#if __CUDA_ARCH__ < 320` will hold true for ROCm too!
* The issue being addressed by (the build breaking commit, for CUDA) was already fixed by this commit (https://github.com/tensorflow/tensorflow/commit/307485737f46a76c97aefb51b0fc3cd264c2bb94) within a `#if TENSORFLOW_USE_ROCM` block

The fix being submitted in this PR, is to undo some of the changes introduced by the earlier ROCm commit, and combine that change with the change in the breaking commit.


-----------------------------------

/cc @chsigg @cheshire @nvining-work 