### PR TITLE
Make the XLA_FLAGS=--xla_gpu_asm_extra_flags works with replay_computation

### DIFF
--- a/tensorflow/compiler/xla/tools/replay_computation.cc
+++ b/tensorflow/compiler/xla/tools/replay_computation.cc
@@ -234,7 +234,13 @@ StatusOr<Literal> ReplayComputation(const HloSnapshot& module,
     // Run fake computations with debug options ignoring XLA_FLAGS.  Users very
     // likely want XLA_FLAGS only to apply to the "real" computation being run,
     // not to the fake computations we use for generating arguments.
+    auto debug_opts_flags = GetDebugOptionsFromFlags();
     auto debug_opts = DefaultDebugOptionsIgnoringFlags();
+
+    // ptxas can be called during the generation of fake data.
+    // As it is cached, we want it to not ignore this flag.
+    debug_opts.set_xla_gpu_asm_extra_flags(debug_opts_flags.xla_gpu_asm_extra_flags());
+
     global_data_arguments =
         MakeFakeArgumentsOrDie(computation, client, &debug_opts);
     for (const auto& data : global_data_arguments) {

--- a/tensorflow/compiler/xla/tools/replay_computation.cc
+++ b/tensorflow/compiler/xla/tools/replay_computation.cc
@@ -233,12 +233,12 @@ StatusOr<Literal> ReplayComputation(const HloSnapshot& module,
   if (opts.use_fake_data) {
     // Run fake computations with debug options ignoring XLA_FLAGS.  Users very
     // likely want XLA_FLAGS only to apply to the "real" computation being run,
-    // not to the fake computations we use for generating arguments.
+    // not to the fake computations we use for generating arguments. There is
+    // an exception. ptxas can be called during the generation of fake
+    // data. As it is cached in the process memory, the flag affecting this call
+    // should not be ignored.
     auto debug_opts_flags = GetDebugOptionsFromFlags();
     auto debug_opts = DefaultDebugOptionsIgnoringFlags();
-
-    // ptxas can be called during the generation of fake data.
-    // As it is cached, we want it to not ignore this flag.
     debug_opts.set_xla_gpu_asm_extra_flags(debug_opts_flags.xla_gpu_asm_extra_flags());
 
     global_data_arguments =


### PR DESCRIPTION
Mostly, replay_computation have call to ptxas during the generation of the fake input. But it doesn't use the XLA_FLAGS. So this patch this specific case.

This is a follow up from #39734
@timshen91  that reviewed it.