### PR TITLE
Add complex64 and complex128 gpu support for tensor_scatter_nd_add

### DIFF
--- a/tensorflow/core/kernels/inplace_ops_functor_gpu.cu.cc
+++ b/tensorflow/core/kernels/inplace_ops_functor_gpu.cu.cc
@@ -197,6 +197,8 @@ Status DoCopy(const Device& d, const Tensor& x, Tensor* y) {
     CASE(float)
     CASE(double)
     CASE(Eigen::half)
+    CASE(complex64)
+    CASE(complex128)
     CASE(int64)
 #undef CASE
     default:


### PR DESCRIPTION
This PR adds complex64 and complex128 gpu support for tensor_scatter_nd_add,
as was raised in #40577.

This PR fixes #40577.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>