### PR TITLE
add test case to keras model save with pathlike dir 

### DIFF
--- a/tensorflow/python/keras/saving/save_test.py
+++ b/tensorflow/python/keras/saving/save_test.py
@@ -72,6 +72,13 @@ class TestSaveModel(test.TestCase, parameterized.TestCase):
     self.assert_saved_model(path)
 
   @test_util.run_v2_only
+  def test_save_format_defaults_pathlib(self):
+    if sys.version_info >= (3, 6):
+      path = pathlib.Path(self.get_temp_dir()) / 'model_path'
+      save.save_model(self.model, path)
+      self.assert_saved_model(path)
+
+  @test_util.run_v2_only
   def test_save_hdf5(self):
     path = os.path.join(self.get_temp_dir(), 'model')
     save.save_model(self.model, path, save_format='h5')
@@ -80,6 +87,13 @@ class TestSaveModel(test.TestCase, parameterized.TestCase):
         NotImplementedError,
         'requires the model to be a Functional model or a Sequential model.'):
       save.save_model(self.subclassed_model, path, save_format='h5')
+
+  @test_util.run_v2_only
+  def test_save_load_hdf5_pathlib(self):
+    if sys.version_info >= (3, 6):
+      path = pathlib.Path(self.get_temp_dir()) / 'model'
+      save.save_model(self.model, path, save_format='h5')
+      save.load_model(path)
 
   @test_util.run_v2_only
   def test_save_tf(self):
@@ -104,6 +118,20 @@ class TestSaveModel(test.TestCase, parameterized.TestCase):
       path = pathlib.Path(self.get_temp_dir()) / 'model'
       save.save_model(self.model, path, save_format='tf')
       save.load_model(path)
+
+  @test_util.run_v2_only
+  def test_save_load_weights_tf_pathlib(self):
+    if sys.version_info >= (3, 6):
+      path = pathlib.Path(self.get_temp_dir()) / 'model'
+      self.model.save_weights(path, save_format='tf')
+      self.model.load_weights(path)
+
+  @test_util.run_v2_only
+  def test_save_load_weights_hdf5_pathlib(self):
+    if sys.version_info >= (3, 6):
+      path = pathlib.Path(self.get_temp_dir()) / 'model'
+      self.model.save_weights(path, save_format='h5')
+      self.model.load_weights(path)
 
   @combinations.generate(combinations.combine(mode=['graph', 'eager']))
   def test_saving_with_dense_features(self):

--- a/tensorflow/python/keras/saving/save_test.py
+++ b/tensorflow/python/keras/saving/save_test.py
@@ -73,10 +73,11 @@ class TestSaveModel(test.TestCase, parameterized.TestCase):
 
   @test_util.run_v2_only
   def test_save_format_defaults_pathlib(self):
-    if sys.version_info >= (3, 6):
-      path = pathlib.Path(self.get_temp_dir()) / 'model_path'
-      save.save_model(self.model, path)
-      self.assert_saved_model(path)
+    if sys.version_info < (3, 6):
+      self.skipTest('pathlib is only available for python version >= 3.6')
+    path = pathlib.Path(self.get_temp_dir()) / 'model_path'
+    save.save_model(self.model, path)
+    self.assert_saved_model(path)
 
   @test_util.run_v2_only
   def test_save_hdf5(self):
@@ -90,10 +91,11 @@ class TestSaveModel(test.TestCase, parameterized.TestCase):
 
   @test_util.run_v2_only
   def test_save_load_hdf5_pathlib(self):
-    if sys.version_info >= (3, 6):
-      path = pathlib.Path(self.get_temp_dir()) / 'model'
-      save.save_model(self.model, path, save_format='h5')
-      save.load_model(path)
+    if sys.version_info < (3, 6):
+      self.skipTest('pathlib is only available for python version >= 3.6')
+    path = pathlib.Path(self.get_temp_dir()) / 'model'
+    save.save_model(self.model, path, save_format='h5')
+    save.load_model(path)
 
   @test_util.run_v2_only
   def test_save_tf(self):
@@ -114,24 +116,27 @@ class TestSaveModel(test.TestCase, parameterized.TestCase):
 
   @test_util.run_v2_only
   def test_save_load_tf_pathlib(self):
-    if sys.version_info >= (3, 6):
-      path = pathlib.Path(self.get_temp_dir()) / 'model'
-      save.save_model(self.model, path, save_format='tf')
-      save.load_model(path)
+    if sys.version_info < (3, 6):
+      self.skipTest('pathlib is only available for python version >= 3.6')
+    path = pathlib.Path(self.get_temp_dir()) / 'model'
+    save.save_model(self.model, path, save_format='tf')
+    save.load_model(path)
 
   @test_util.run_v2_only
   def test_save_load_weights_tf_pathlib(self):
-    if sys.version_info >= (3, 6):
-      path = pathlib.Path(self.get_temp_dir()) / 'model'
-      self.model.save_weights(path, save_format='tf')
-      self.model.load_weights(path)
+    if sys.version_info < (3, 6):
+      self.skipTest('pathlib is only available for python version >= 3.6')
+    path = pathlib.Path(self.get_temp_dir()) / 'model'
+    self.model.save_weights(path, save_format='tf')
+    self.model.load_weights(path)
 
   @test_util.run_v2_only
   def test_save_load_weights_hdf5_pathlib(self):
-    if sys.version_info >= (3, 6):
-      path = pathlib.Path(self.get_temp_dir()) / 'model'
-      self.model.save_weights(path, save_format='h5')
-      self.model.load_weights(path)
+    if sys.version_info < (3, 6):
+      self.skipTest('pathlib is only available for python version >= 3.6')
+    path = pathlib.Path(self.get_temp_dir()) / 'model'
+    self.model.save_weights(path, save_format='h5')
+    self.model.load_weights(path)
 
   @combinations.generate(combinations.combine(mode=['graph', 'eager']))
   def test_saving_with_dense_features(self):

--- a/tensorflow/python/saved_model/loader_impl.py
+++ b/tensorflow/python/saved_model/loader_impl.py
@@ -73,7 +73,7 @@ def parse_saved_model(export_dir):
   """Reads the savedmodel.pb or savedmodel.pbtxt file containing `SavedModel`.
 
   Args:
-    export_dir: Directory containing the SavedModel file.
+    export_dir: String or Pathlike, path to the directory containing the SavedModel file.
 
   Returns:
     A `SavedModel` protocol buffer.
@@ -83,11 +83,11 @@ def parse_saved_model(export_dir):
   """
   # Build the path to the SavedModel in pbtxt format.
   path_to_pbtxt = os.path.join(
-      compat.as_bytes(export_dir),
+      compat.as_bytes(compat.path_to_str(export_dir)),
       compat.as_bytes(constants.SAVED_MODEL_FILENAME_PBTXT))
   # Build the path to the SavedModel in pb format.
   path_to_pb = os.path.join(
-      compat.as_bytes(export_dir),
+      compat.as_bytes(compat.path_to_str(export_dir)),
       compat.as_bytes(constants.SAVED_MODEL_FILENAME_PB))
 
   # Parse the SavedModel protocol buffer.

--- a/tensorflow/python/saved_model/loader_impl.py
+++ b/tensorflow/python/saved_model/loader_impl.py
@@ -73,7 +73,8 @@ def parse_saved_model(export_dir):
   """Reads the savedmodel.pb or savedmodel.pbtxt file containing `SavedModel`.
 
   Args:
-    export_dir: String or Pathlike, path to the directory containing the SavedModel file.
+    export_dir: String or Pathlike, path to the directory containing the
+    SavedModel file.
 
   Returns:
     A `SavedModel` protocol buffer.


### PR DESCRIPTION
Added test case covering using pathlike objects such as pathlib.Path for path of saving model and saving weights in Keras. 
Also make `parse_saved_model` compatible with pathlike objects. 