### PR TITLE
Fix error caused by incorrect rank assumption in tf.image.flip_left_right

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -431,7 +431,8 @@ def _random_flip(image, flip_index, seed, scope_name):
     image = ops.convert_to_tensor(image, name='image')
     image = _AssertAtLeast3DImage(image)
     shape = image.get_shape()
-    if shape.ndims == 3 or shape.ndims is None:
+
+    def f_rank3():
       uniform_random = random_ops.random_uniform([], 0, 1.0, seed=seed)
       mirror_cond = math_ops.less(uniform_random, .5)
       result = control_flow_ops.cond(
@@ -440,7 +441,8 @@ def _random_flip(image, flip_index, seed, scope_name):
           lambda: image,
           name=scope)
       return fix_image_flip_shape(image, result)
-    elif shape.ndims == 4:
+
+    def f_rank4():
       batch_size = array_ops.shape(image)[0]
       uniform_random = random_ops.random_uniform([batch_size],
                                                  0,
@@ -451,6 +453,15 @@ def _random_flip(image, flip_index, seed, scope_name):
       flips = math_ops.cast(flips, image.dtype)
       flipped_input = array_ops.reverse(image, [flip_index + 1])
       return flips * flipped_input + (1 - flips) * image
+
+    if shape.ndims is None:
+      rank = array_ops.rank(image)
+      return control_flow_ops.cond(
+          math_ops.equal(rank, 3), f_rank3, f_rank4)
+    if shape.ndims == 3:
+      return f_rank3()
+    elif shape.ndims == 4:
+      return f_rank4()
     else:
       raise ValueError(
           '\'image\' (shape %s) must have either 3 or 4 dimensions.' % shape)
@@ -549,10 +560,20 @@ def _flip(image, flip_index, scope_name):
     image = ops.convert_to_tensor(image, name='image')
     image = _AssertAtLeast3DImage(image)
     shape = image.get_shape()
-    if shape.ndims == 3 or shape.ndims is None:
+
+    def f_rank3():
       return fix_image_flip_shape(image, array_ops.reverse(image, [flip_index]))
-    elif shape.ndims == 4:
+    def f_rank4():
       return array_ops.reverse(image, [flip_index + 1])
+
+    if shape.ndims is None:
+      rank = array_ops.rank(image)
+      return control_flow_ops.cond(
+          math_ops.equal(rank, 3), f_rank3, f_rank4)
+    elif shape.ndims == 3:
+      return f_rank3()
+    elif shape.ndims == 4:
+      return f_rank4()
     else:
       raise ValueError(
           '\'image\' (shape %s)must have either 3 or 4 dimensions.' % shape)
@@ -599,7 +620,15 @@ def rot90(image, k=1, name=None):
     k = math_ops.mod(k, 4)
 
     shape = image.get_shape()
-    if shape.ndims == 3 or shape.ndims is None:
+    if shape.ndims is None:
+      rank = array_ops.rank(image)
+      def f_rank3():
+        return _rot90_3D(image, k, scope)
+      def f_rank4():
+        return _rot90_4D(image, k, scope)
+      return control_flow_ops.cond(
+          math_ops.equal(rank, 3), f_rank3, f_rank4)
+    elif shape.ndims == 3:
       return _rot90_3D(image, k, scope)
     elif shape.ndims == 4:
       return _rot90_4D(image, k, scope)
@@ -722,7 +751,15 @@ def transpose(image, name=None):
     image = ops.convert_to_tensor(image, name='image')
     image = _AssertAtLeast3DImage(image)
     shape = image.get_shape()
-    if shape.ndims == 3 or shape.ndims is None:
+    if shape.ndims is None:
+      rank = array_ops.rank(image)
+      def f_rank3():
+        return array_ops.transpose(image, [1, 0, 2], name=name)
+      def f_rank4():
+        return array_ops.transpose(image, [0, 2, 1, 3], name=name)
+      return control_flow_ops.cond(
+          math_ops.equal(rank, 3), f_rank3, f_rank4)
+    elif shape.ndims == 3:
       return array_ops.transpose(image, [1, 0, 2], name=name)
     elif shape.ndims == 4:
       return array_ops.transpose(image, [0, 2, 1, 3], name=name)

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -31,11 +31,13 @@ from six.moves import xrange  # pylint: disable=redefined-builtin
 from tensorflow.core.protobuf import config_pb2
 from tensorflow.python.client import session
 from tensorflow.python.compat import compat
+from tensorflow.python.data.experimental.ops import get_single_element
 from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors
 from tensorflow.python.framework import ops
+from tensorflow.python.framework import tensor_shape
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import control_flow_ops
@@ -1375,10 +1377,13 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
     def generator(): yield image_input
 
     dataset = dataset_ops.Dataset.from_generator(
-        generator, output_types=dtypes.int32)
+        generator,
+        output_types=dtypes.int32,
+        output_shapes=tensor_shape.TensorShape([1, 2, 2, 3]))
     dataset = dataset.map(image_ops.flip_left_right)
 
-    image_flipped_via_dataset_map = next(iter(dataset))
+    image_flipped_via_dataset_map = get_single_element.get_single_element(
+        dataset.take(1))
     self.assertAllEqual(image_flipped_via_dataset_map, expected_output)
 
 class AdjustContrastTest(test_util.TensorFlowTestCase):

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -1368,13 +1368,13 @@ class FlipTransposeRotateTest(test_util.TensorFlowTestCase):
         self.assertAllEqual(y_np, y_tf.eval({k_placeholder: k}))
 
   def testFlipImageUnknownShape(self):
-    image_input = constant_op.constant(
-        [[[[0, 1, 2], [3, 4, 5]], [[6, 7, 8], [9, 10, 11]]]])
-
     expected_output = constant_op.constant(
         [[[[3, 4, 5], [0, 1, 2]], [[9, 10, 11], [6, 7, 8]]]])
 
-    def generator(): yield image_input
+    def generator():
+      image_input = np.array(
+          [[[[0, 1, 2], [3, 4, 5]], [[6, 7, 8], [9, 10, 11]]]], np.int32)
+      yield image_input
 
     dataset = dataset_ops.Dataset.from_generator(
         generator,


### PR DESCRIPTION
This PR tries to address the issue raised in #40580 where an error
was thrown out when tf.image.flip_left_right process a tensor of unknown
rank.

The reason was that tf.image.flip_left_right assumes rank == 3 in case
of unknown rank.

This PR adjust to use array_ops.rank(image) to obtain the true rank
when unknown rank is present.

This PR fixes #40580.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>