### PR TITLE
Fix TypeError when sparse.from_dense is called with tf.string

### DIFF
--- a/tensorflow/python/ops/sparse_ops.py
+++ b/tensorflow/python/ops/sparse_ops.py
@@ -120,7 +120,7 @@ def from_dense(tensor, name=None):
   with ops.name_scope(name, "dense_to_sparse"):
     tensor = ops.convert_to_tensor(tensor)
     indices = array_ops.where_v2(
-        math_ops.not_equal(tensor, array_ops.constant(0, tensor.dtype)))
+        math_ops.not_equal(tensor, array_ops.zeros_like(tensor)))
     values = array_ops.gather_nd(tensor, indices)
     shape = array_ops.shape(tensor, out_type=dtypes.int64)
     return sparse_tensor.SparseTensor(indices, values, shape)

--- a/tensorflow/python/ops/sparse_ops_test.py
+++ b/tensorflow/python/ops/sparse_ops_test.py
@@ -180,6 +180,15 @@ class SparseOpsTest(test_util.TensorFlowTestCase, parameterized.TestCase):
         array_ops.transpose(dense_of_sparse))
     self.assertAllEqual(expected, result)
 
+  def testConstantStringToSparse(self):
+    # Test case for GitHub issue 40633.
+    tensor = constant_op.constant(list("ababa"))
+    sparse = sparse_ops.from_dense(tensor)
+    result = self.evaluate(sparse)
+    self.assertAllEqual([[0], [1], [2], [3], [4]], result.indices)
+    self.assertAllEqual([b'a', b'b', b'a', b'b', b'a'], result.values)
+    self.assertAllEqual([5], result.dense_shape)
+
 
 if __name__ == '__main__':
   googletest.main()


### PR DESCRIPTION
This PR tries to fix the issue raised in #40633 where
sparse.from_dense throws out TypeError with tf.string as input.

The issue was that from_dense uses `tf.constant(0, dtype)` to get
the zero value which fails on tf.string. This PR changes to `zeros_like`
to work with tf.string.

This PR fixes #40633.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>