### PR TITLE
Fix GCC 10.1 compile error.

### DIFF
--- a/tensorflow/python/lib/core/bfloat16.cc
+++ b/tensorflow/python/lib/core/bfloat16.cc
@@ -660,26 +660,26 @@ bool Initialize() {
   const std::array<int, 3> compare_types = {
       {npy_bfloat16_, npy_bfloat16_, NPY_BOOL}};
 
-  if (!register_ufunc("equal", CompareUFunc<Bfloat16EqFunctor>,
+  if (!register_ufunc("equal", (PyUFuncGenericFunction) CompareUFunc<Bfloat16EqFunctor>,
                       compare_types)) {
     return false;
   }
-  if (!register_ufunc("not_equal", CompareUFunc<Bfloat16NeFunctor>,
+  if (!register_ufunc("not_equal", (PyUFuncGenericFunction) CompareUFunc<Bfloat16NeFunctor>,
                       compare_types)) {
     return false;
   }
-  if (!register_ufunc("less", CompareUFunc<Bfloat16LtFunctor>, compare_types)) {
+  if (!register_ufunc("less", (PyUFuncGenericFunction) CompareUFunc<Bfloat16LtFunctor>, compare_types)) {
     return false;
   }
-  if (!register_ufunc("greater", CompareUFunc<Bfloat16GtFunctor>,
+  if (!register_ufunc("greater", (PyUFuncGenericFunction) CompareUFunc<Bfloat16GtFunctor>,
                       compare_types)) {
     return false;
   }
-  if (!register_ufunc("less_equal", CompareUFunc<Bfloat16LeFunctor>,
+  if (!register_ufunc("less_equal", (PyUFuncGenericFunction) CompareUFunc<Bfloat16LeFunctor>,
                       compare_types)) {
     return false;
   }
-  if (!register_ufunc("greater_equal", CompareUFunc<Bfloat16GeFunctor>,
+  if (!register_ufunc("greater_equal", (PyUFuncGenericFunction) CompareUFunc<Bfloat16GeFunctor>,
                       compare_types)) {
     return false;
   }


### PR DESCRIPTION
This PR fix compile error using gcc 10.1

**Description**

There is an ```auto``` inference failure error fixed by this PR:

```
~/rpmbuild/BUILD/tensorflow/_bazel_cbalint/4c79ce0d14678d18eb8640cac68aaf03/execroot/org_tensorflow ~/rpmbuild/BUILD/tensorflow/tensorflow
tensorflow/python/lib/core/bfloat16.cc: In function ‘bool tensorflow::{anonymous}::Initialize()’:
tensorflow/python/lib/core/bfloat16.cc:664:36: error: no match for call to ‘(tensorflow::{anonymous}::Initialize()::<lambda(const char*, PyUFuncGenericFunction, const std::array<int, 3>&)>) (const char [6], <unresolved overloaded function type>, const std::array<int, 3>&)’
  664 |                       compare_types)) {
      |                                    ^
tensorflow/python/lib/core/bfloat16.cc:637:25: note: candidate: ‘tensorflow::{anonymous}::Initialize()::<lambda(const char*, PyUFuncGenericFunction, const std::array<int, 3>&)>’
  637 |   auto register_ufunc = [&](const char* name, PyUFuncGenericFunction fn,
      |                         ^
tensorflow/python/lib/core/bfloat16.cc:637:25: note:   no known conversion for argument 2 from ‘<unresolved overloaded function type>’ to ‘PyUFuncGenericFunction’ {aka ‘void (*)(char**, const long int*, const long int*, void*)’}
tensorflow/python/lib/core/bfloat16.cc:668:36: error: no match for call to ‘(tensorflow::{anonymous}::Initialize()::<lambda(const char*, PyUFuncGenericFunction, const std::array<int, 3>&)>) (const char [10], <unresolved overloaded function type>, const std::array<int, 3>&)’
  668 |                       compare_types)) {
      |                                    ^
tensorflow/python/lib/core/bfloat16.cc:637:25: note: candidate: ‘tensorflow::{anonymous}::Initialize()::<lambda(const char*, PyUFuncGenericFunction, const std::array<int, 3>&)>’
  637 |   auto register_ufunc = [&](const char* name, PyUFuncGenericFunction fn,
      |                         ^
tensorflow/python/lib/core/bfloat16.cc:637:25: note:   no known conversion for argument 2 from ‘<unresolved overloaded function type>’ to ‘PyUFuncGenericFunction’ {aka ‘void (*)(char**, const long int*, const long int*, void*)’}
tensorflow/python/lib/core/bfloat16.cc:671:77: error: no match for call to ‘(tensorflow::{anonymous}::Initialize()::<lambda(const char*, PyUFuncGenericFunction, const std::array<int, 3>&)>) (const char [5], <unresolved overloaded function type>, const std::array<int, 3>&)’
  671 |   if (!register_ufunc("less", CompareUFunc<Bfloat16LtFunctor>, compare_types)) {
      |                                                                             ^
tensorflow/python/lib/core/bfloat16.cc:637:25: note: candidate: ‘tensorflow::{anonymous}::Initialize()::<lambda(const char*, PyUFuncGenericFunction, const std::array<int, 3>&)>’
  637 |   auto register_ufunc = [&](const char* name, PyUFuncGenericFunction fn,
      |                         ^
tensorflow/python/lib/core/bfloat16.cc:637:25: note:   no known conversion for argument 2 from ‘<unresolved overloaded function type>’ to ‘PyUFuncGenericFunction’ {aka ‘void (*)(char**, const long int*, const long int*, void*)’}
tensorflow/python/lib/core/bfloat16.cc:675:36: error: no match for call to ‘(tensorflow::{anonymous}::Initialize()::<lambda(const char*, PyUFuncGenericFunction, const std::array<int, 3>&)>) (const char [8], <unresolved overloaded function type>, const std::array<int, 3>&)’
  675 |                       compare_types)) {
      |                                    ^
tensorflow/python/lib/core/bfloat16.cc:637:25: note: candidate: ‘tensorflow::{anonymous}::Initialize()::<lambda(const char*, PyUFuncGenericFunction, const std::array<int, 3>&)>’
  637 |   auto register_ufunc = [&](const char* name, PyUFuncGenericFunction fn,
      |                         ^
tensorflow/python/lib/core/bfloat16.cc:637:25: note:   no known conversion for argument 2 from ‘<unresolved overloaded function type>’ to ‘PyUFuncGenericFunction’ {aka ‘void (*)(char**, const long int*, const long int*, void*)’}
tensorflow/python/lib/core/bfloat16.cc:679:36: error: no match for call to ‘(tensorflow::{anonymous}::Initialize()::<lambda(const char*, PyUFuncGenericFunction, const std::array<int, 3>&)>) (const char [11], <unresolved overloaded function type>, const std::array<int, 3>&)’
  679 |                       compare_types)) {
      |                                    ^
tensorflow/python/lib/core/bfloat16.cc:637:25: note: candidate: ‘tensorflow::{anonymous}::Initialize()::<lambda(const char*, PyUFuncGenericFunction, const std::array<int, 3>&)>’
  637 |   auto register_ufunc = [&](const char* name, PyUFuncGenericFunction fn,
      |                         ^
tensorflow/python/lib/core/bfloat16.cc:637:25: note:   no known conversion for argument 2 from ‘<unresolved overloaded function type>’ to ‘PyUFuncGenericFunction’ {aka ‘void (*)(char**, const long int*, const long int*, void*)’}
tensorflow/python/lib/core/bfloat16.cc:683:36: error: no match for call to ‘(tensorflow::{anonymous}::Initialize()::<lambda(const char*, PyUFuncGenericFunction, const std::array<int, 3>&)>) (const char [14], <unresolved overloaded function type>, const std::array<int, 3>&)’
  683 |                       compare_types)) {
      |                                    ^
tensorflow/python/lib/core/bfloat16.cc:637:25: note: candidate: ‘tensorflow::{anonymous}::Initialize()::<lambda(const char*, PyUFuncGenericFunction, const std::array<int, 3>&)>’
  637 |   auto register_ufunc = [&](const char* name, PyUFuncGenericFunction fn,
      |                         ^
tensorflow/python/lib/core/bfloat16.cc:637:25: note:   no known conversion for argument 2 from ‘<unresolved overloaded function type>’ to ‘PyUFuncGenericFunction’ {aka ‘void (*)(char**, const long int*, const long int*, void*)’}
```

* Relevant toolchain versions:

```
$ gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/libexec/gcc/x86_64-redhat-linux/10/lto-wrapper
OFFLOAD_TARGET_NAMES=nvptx-none
OFFLOAD_TARGET_DEFAULT=1
Target: x86_64-redhat-linux
Configured with: ../configure --enable-bootstrap --enable-languages=c,c++,fortran,objc,obj-c++,ada,go,d,lto --prefix=/usr --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=http://bugzilla.redhat.com/bugzilla --enable-shared --enable-threads=posix --enable-checking=release --enable-multilib --with-system-zlib --enable-__cxa_atexit --disable-libunwind-exceptions --enable-gnu-unique-object --enable-linker-build-id --with-gcc-major-version-only --with-linker-hash-style=gnu --enable-plugin --enable-initfini-array --with-isl --enable-offload-targets=nvptx-none --without-cuda-driver --enable-gnu-indirect-function --enable-cet --with-tune=generic --with-arch_32=i686 --build=x86_64-redhat-linux
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 10.1.1 20200618 (Red Hat 10.1.1-2) (GCC) 
```
```
$ python --version
Python 3.9.0b3+
```
