### PR TITLE
Replace deprecated numpy function calls

### DIFF
--- a/tensorflow/python/framework/tensor_util.py
+++ b/tensorflow/python/framework/tensor_util.py
@@ -525,7 +525,7 @@ def make_tensor_proto(values, dtype=None, shape=None, verify_shape=False,
     if nparray.size * nparray.itemsize >= (1 << 31):
       raise ValueError(
           "Cannot create a tensor proto whose content is larger than 2GB.")
-    tensor_proto.tensor_content = nparray.tostring()
+    tensor_proto.tensor_content = nparray.tobytes()
     return tensor_proto
 
   # If we were not given values as a numpy array, compute the proto_values

--- a/tensorflow/python/kernel_tests/decode_raw_op_test.py
+++ b/tensorflow/python/kernel_tests/decode_raw_op_test.py
@@ -84,22 +84,22 @@ class DecodeRawOpTest(test.TestCase):
   def testToFloat16(self):
     result = np.matrix([[1, -2, -3, 4]], dtype="<f2")
     self.assertAllEqual(
-        result, parsing_ops.decode_raw([result.tostring()], dtypes.float16))
+        result, parsing_ops.decode_raw([result.tobytes()], dtypes.float16))
 
   def testToBool(self):
     result = np.matrix([[True, False, False, True]], dtype="<b1")
     self.assertAllEqual(
-        result, parsing_ops.decode_raw([result.tostring()], dtypes.bool))
+        result, parsing_ops.decode_raw([result.tobytes()], dtypes.bool))
 
   def testToComplex64(self):
     result = np.matrix([[1 + 1j, 2 - 2j, -3 + 3j, -4 - 4j]], dtype="<c8")
     self.assertAllEqual(
-        result, parsing_ops.decode_raw([result.tostring()], dtypes.complex64))
+        result, parsing_ops.decode_raw([result.tobytes()], dtypes.complex64))
 
   def testToComplex128(self):
     result = np.matrix([[1 + 1j, 2 - 2j, -3 + 3j, -4 - 4j]], dtype="<c16")
     self.assertAllEqual(
-        result, parsing_ops.decode_raw([result.tostring()], dtypes.complex128))
+        result, parsing_ops.decode_raw([result.tobytes()], dtypes.complex128))
 
   def testEmptyStringInput(self):
     for num_inputs in range(3):

--- a/tensorflow/python/ops/numpy_ops/np_arrays.py
+++ b/tensorflow/python/ops/numpy_ops/np_arrays.py
@@ -282,7 +282,7 @@ class ndarray(composite_tensor.CompositeTensor):  # pylint: disable=invalid-name
     # TODO(wangpeng): Handle graph mode
     if not isinstance(self.data, ops.EagerTensor):
       raise TypeError('Indexing using symbolic tensor is not allowed')
-    return np.asscalar(self.data.numpy())
+    return self.data.numpy().item()
 
   def tolist(self):
     return self.data.numpy().tolist()


### PR DESCRIPTION
This PR switches to using `numpy.ndarray.tobytes()` instead of `numpy.ndarray.tostring()` which has been deprecated in Numpy 1.19 (https://github.com/numpy/numpy/pull/15867) and replaces `numpy.asscalar` with `numpy.ndarray.item()`.

These are non-functional changes that only remove deprecation warnings in newer versions of numpy.