### PR TITLE
[doc] Fix broken figures in tiled_layout.md

### DIFF
--- a/tensorflow/compiler/xla/g3doc/tiled_layout.md
+++ b/tensorflow/compiler/xla/g3doc/tiled_layout.md
@@ -3,9 +3,10 @@
 Caution: Tiled layout is *pre-release* and this describes how it's intended to
 work. Errors may be silently ignored.
 
-<center> ![](images/xla_array_layout_figure1.png)
-
-Figure 1 </center>
+<p align="center">
+  <img src="images/xla_array_layout_figure1.png">
+  Figure 1
+</p>
 
 Figure 1 shows how an array F32[3,5] is laid out in memory with 2x2 tiling. A
 shape with this layout is written as F32[3,5]{1,0:(2,2)}, where 1,0 relates to
@@ -120,9 +121,10 @@ element follows the formula above as expected.
 
 XLA's tiling becomes even more flexible by applying it repeatedly.
 
-<center> ![](images/xla_array_layout_figure2.png)
-
-Figure 2 </center>
+<p align="center">
+  <img src="images/xla_array_layout_figure2.png">
+  Figure 2
+</p>
 
 Figure 2 shows how an array of size 4x8 is tiled by two levels of tiling (first
 2x4 then 2x1). We represent this repeated tiling as (2,4)(2,1). Each color

--- a/tensorflow/compiler/xla/xla_data.proto
+++ b/tensorflow/compiler/xla/xla_data.proto
@@ -120,7 +120,7 @@ enum Format {
 }
 
 // Describes a tile used in tiling-based layout. Refer to
-// g3doc/third_party/tensorflow/compiler/xla/g3doc/layout_with_tiling.md for
+// g3doc/third_party/tensorflow/compiler/xla/g3doc/tiled_layout.md for
 // details about tiling-based layout.
 message TileProto {
   // Number of elements in each dimension of the tile. It's ordered from the


### PR DESCRIPTION
This pr changed the figures in a style that https://stackoverflow.com/a/12118349/5163915 suggests so that  they can be shown correctly on github.

Thank you for your time on reviewing this pr.