### PR TITLE
Tangent Batching for regular ops 

### DIFF
--- a/tensorflow/python/eager/BUILD
+++ b/tensorflow/python/eager/BUILD
@@ -613,7 +613,7 @@ py_library(
         "//tensorflow/python:platform",
         "//tensorflow/python:pywrap_tfe",
         "//tensorflow/python:util",
-	"//tensorflow/python/ops/parallel_for:control_flow_ops",
+        "//tensorflow/python/ops/parallel_for:control_flow_ops",
     ],
 )
 

--- a/tensorflow/python/eager/BUILD
+++ b/tensorflow/python/eager/BUILD
@@ -613,6 +613,7 @@ py_library(
         "//tensorflow/python:platform",
         "//tensorflow/python:pywrap_tfe",
         "//tensorflow/python:util",
+	"//tensorflow/python/ops/parallel_for:control_flow_ops",
     ],
 )
 

--- a/tensorflow/python/eager/forwardprop.py
+++ b/tensorflow/python/eager/forwardprop.py
@@ -164,7 +164,7 @@ def _jvp_helper_wrapper(
   """
   if use_batch:
     for primal, tangent in zip(inputs, tangents):
-      if tangent.shape.is_compatible_with(primal.shape): 
+      if not tangent.shape.is_compatible_with([None] + primal.shape): 
         raise ValueError(
           "Tangent {} was expected to be of shape "
           "{} but is instead of shape {}".format(

--- a/tensorflow/python/eager/forwardprop.py
+++ b/tensorflow/python/eager/forwardprop.py
@@ -141,9 +141,9 @@ def _jvp_helper(op_name, attr_tuple, inputs, outputs, tangents):
 
 
 def _jvp_helper_wrapper(
-    op_name, attr_tuple, inputs, outputs, tangents, batch_size
+  op_name, attr_tuple, inputs, outputs, tangents, batch_size
 ):
-    """Computes a batch of Jacobian-vector product for an op.
+  """Computes a batch of Jacobian-vector product for an op.
 
   Args:
     op_name: A string, the type of operation being executed.
@@ -155,12 +155,10 @@ def _jvp_helper_wrapper(
   Returns:
     A flat list of tangents corresponding to `outputs`.
   """
-  use_pfor = False
-  if batch_size is not None:
-    use_pfor = True
+  if batch_size:
     for primal, tangent in zip(inputs, tangents):
       if tangent.rank == primal.rank + 1:
-        if tangent.shape != [batch_size] + primal.shape:
+        if tangent.shape != array_ops.concat([batch_size], primal.shape):
           raise ValueError(
             "Tangent {} was expected to be of shape "
             "{} but is instead of shape {}".format(
@@ -173,7 +171,7 @@ def _jvp_helper_wrapper(
             "{}, {} tangents and primals".format(tangent.rank, primal.rank)
           )
 
-  if use_pfor:
+  if batch_size:
     return control_flow_ops.vectorized_map(
       functools.partial(_jvp_helper, op_name, attr_tuple, inputs, outputs),
       tangents,

--- a/tensorflow/python/eager/forwardprop.py
+++ b/tensorflow/python/eager/forwardprop.py
@@ -157,19 +157,13 @@ def _jvp_helper_wrapper(
   """
   if batch_size:
     for primal, tangent in zip(inputs, tangents):
-      if tangent.rank == primal.rank + 1:
-        if tangent.shape != array_ops.concat([batch_size], primal.shape):
-          raise ValueError(
-            "Tangent {} was expected to be of shape "
-            "{} but is instead of shape {}".format(
-            tangent, [batch_size] + primal.shape, tangent.shape
-          )
+      if tangent.shape != array_ops.concat([batch_size], primal.shape, 0):
+        raise ValueError(
+          "Tangent {} was expected to be of shape "
+          "{} but is instead of shape {}".format(
+          tangent, [batch_size] + primal.shape, tangent.shape
         )
-        else:
-          raise ValueError(
-            "Invalid argument batch_size for rank "
-            "{}, {} tangents and primals".format(tangent.rank, primal.rank)
-          )
+      )
 
   if batch_size:
     return control_flow_ops.vectorized_map(

--- a/tensorflow/python/eager/forwardprop.py
+++ b/tensorflow/python/eager/forwardprop.py
@@ -176,6 +176,12 @@ def _jvp_dispatch(op_name, attr_tuple, inputs, outputs, tangents):
 pywrap_tfe.TFE_Py_RegisterJVPFunction(_jvp_dispatch)
 
 
+def _jvp_dispatch_batch(op_name, attr_tuple, inputs, outputs, tangents):
+  """Computes jvps of a regular op for a batch of tangents"""
+  return control_flow_ops.vectorized_map(
+      functools.partial(_jvp_dispatch, op_name, attr_tuple, inputs, outputs),
+      tangents)
+
 @tf_export("autodiff.ForwardAccumulator", v1=[])
 class ForwardAccumulator(object):
   """Computes Jacobian-vector products ("JVP"s) using forward-mode autodiff.

--- a/tensorflow/python/eager/forwardprop.py
+++ b/tensorflow/python/eager/forwardprop.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import functools
 import threading
 
 from tensorflow.python import pywrap_tfe
@@ -30,6 +31,7 @@ from tensorflow.python.eager import function
 from tensorflow.python.framework import ops
 
 from tensorflow.python.ops import array_ops
+from tensorflow.python.ops.parallel_for import control_flow_ops
 from tensorflow.python.ops.unconnected_gradients import UnconnectedGradients
 from tensorflow.python.platform import tf_logging as logging
 from tensorflow.python.util import nest
@@ -141,7 +143,7 @@ def _jvp_helper(op_name, attr_tuple, inputs, outputs, tangents):
 
 
 def _jvp_helper_wrapper(
-  op_name, attr_tuple, inputs, outputs, tangents, batch_size
+  op_name, attr_tuple, inputs, outputs, tangents, use_batch 
 ):
   """Computes a batch of Jacobian-vector product for an op.
 
@@ -150,22 +152,27 @@ def _jvp_helper_wrapper(
     attr_tuple: Attributes of the operation.
     inputs: A flat list of input Tensors to the operation.
     outputs: A flat list of output Tensors from the operation.
-    tangents: A flat list of Tensors, same shape as `[batch_size] + input_shape`.
+    tangents: A flat list of Tensors, compatible with shape `[None] + input_shape`.
+    use_batch: A bool, True to vetorize over batch of tangents 
+      of shape `[None] + input_shape`
 
   Returns:
-    A flat list of tangents corresponding to `outputs`.
+    A flat list of tangents compatible with `outputs` or `[None] + output_shape`.
+  
+  Raises:
+    ValueError: if tangent shapes are not compatible with input shapes.
+
   """
-  if batch_size:
+  if use_batch:
     for primal, tangent in zip(inputs, tangents):
-      if tangent.shape != array_ops.concat([batch_size], primal.shape, 0):
+      if tangent.shape.is_compatible_with(primal.shape): 
         raise ValueError(
           "Tangent {} was expected to be of shape "
           "{} but is instead of shape {}".format(
-          tangent, [batch_size] + primal.shape, tangent.shape
+          tangent, [None] + primal.shape, tangent.shape
         )
       )
 
-  if batch_size:
     return control_flow_ops.vectorized_map(
       functools.partial(_jvp_helper, op_name, attr_tuple, inputs, outputs),
       tangents,
@@ -196,17 +203,17 @@ _TRACE_COUNT_LIMIT = 32
 
 
 def _jvp_dispatch(
-  op_name, attr_tuple, inputs, outputs, tangents, batch_size=None
+  op_name, attr_tuple, inputs, outputs, tangents, use_batch=False
 ):
   """Determine which forwardprop function to call."""
   # Note that this _TRACE_COUNT read races with writes. That's fine, it just
   # means we may trace a few more exact shapes before moving on to relaxation.
   if _TRACE_COUNT.get(op_name, 0) < _TRACE_COUNT_LIMIT:
     return _jvp_exact_shapes(
-        op_name, attr_tuple, inputs, outputs, tangents, batch_size)
+        op_name, attr_tuple, inputs, outputs, tangents, use_batch)
   else:
     return _jvp_relaxed_shapes(
-        op_name, attr_tuple, inputs, outputs, tangents, batch_size)
+        op_name, attr_tuple, inputs, outputs, tangents, use_batch)
 
 
 pywrap_tfe.TFE_Py_RegisterJVPFunction(_jvp_dispatch)

--- a/tensorflow/python/eager/forwardprop.py
+++ b/tensorflow/python/eager/forwardprop.py
@@ -161,7 +161,6 @@ def _jvp_helper_wrapper(
   
   Raises:
     ValueError: if tangent shapes are not compatible with input shapes.
-
   """
   if use_batch:
     for primal, tangent in zip(inputs, tangents):

--- a/tensorflow/python/eager/forwardprop.py
+++ b/tensorflow/python/eager/forwardprop.py
@@ -143,7 +143,7 @@ def _jvp_helper(op_name, attr_tuple, inputs, outputs, tangents):
 
 
 def _jvp_helper_wrapper(
-  op_name, attr_tuple, inputs, outputs, tangents, use_batch 
+    op_name, attr_tuple, inputs, outputs, tangents, use_batch
 ):
   """Computes a batch of Jacobian-vector product for an op.
 
@@ -152,32 +152,33 @@ def _jvp_helper_wrapper(
     attr_tuple: Attributes of the operation.
     inputs: A flat list of input Tensors to the operation.
     outputs: A flat list of output Tensors from the operation.
-    tangents: A flat list of Tensors, compatible with shape `[None] + input_shape`.
-    use_batch: A bool, True to vetorize over batch of tangents 
-      of shape `[None] + input_shape`
+    tangents: A flat list of Tensors, compatible with
+      shape `[None] + input_shape`.
+    use_batch: A bool, True to vetorize over batch of tangents
+      of shape `[None] + input_shape`.
 
   Returns:
-    A flat list of tangents compatible with `outputs` or `[None] + output_shape`.
-  
+    A flat list of tangents compatible with `outputs`
+    or `[None] + output_shape`.
+
   Raises:
     ValueError: if tangent shapes are not compatible with input shapes.
   """
   if use_batch:
     for primal, tangent in zip(inputs, tangents):
-      if not tangent.shape.is_compatible_with([None] + primal.shape): 
+      if not tangent.shape.is_compatible_with([None] + primal.shape):
         raise ValueError(
-          "Tangent {} was expected to be of shape "
-          "{} but is instead of shape {}".format(
-          tangent, [None] + primal.shape, tangent.shape
+            "Tangent {} was expected to be of shape "
+            "{} but is instead of shape {}".format(
+                tangent, [None] + primal.shape, tangent.shape
+            )
         )
-      )
 
     return control_flow_ops.vectorized_map(
-      functools.partial(_jvp_helper, op_name, attr_tuple, inputs, outputs),
-      tangents,
+        functools.partial(_jvp_helper, op_name, attr_tuple, inputs, outputs),
+        tangents,
     )
-  else:
-    return _jvp_helper(op_name, attr_tuple, inputs, outputs, tangents)
+  return _jvp_helper(op_name, attr_tuple, inputs, outputs, tangents)
 
 
 # TODO(allenl): experimental_relax_shapes for gradients which rely on static
@@ -194,7 +195,8 @@ def _jvp_helper_wrapper(
 _jvp_relaxed_shapes = function.defun(
     _jvp_helper_wrapper, experimental_relax_shapes=True
 )
-_jvp_exact_shapes = function.defun(_jvp_helper_wrapper, experimental_relax_shapes=False)
+_jvp_exact_shapes = function.defun(
+    _jvp_helper_wrapper, experimental_relax_shapes=False)
 
 # The maximum number of exact-shape traces to perform for a single op before
 # switching to shape relaxation.
@@ -202,7 +204,7 @@ _TRACE_COUNT_LIMIT = 32
 
 
 def _jvp_dispatch(
-  op_name, attr_tuple, inputs, outputs, tangents, use_batch=False
+    op_name, attr_tuple, inputs, outputs, tangents, use_batch=False
 ):
   """Determine which forwardprop function to call."""
   # Note that this _TRACE_COUNT read races with writes. That's fine, it just
@@ -210,9 +212,8 @@ def _jvp_dispatch(
   if _TRACE_COUNT.get(op_name, 0) < _TRACE_COUNT_LIMIT:
     return _jvp_exact_shapes(
         op_name, attr_tuple, inputs, outputs, tangents, use_batch)
-  else:
-    return _jvp_relaxed_shapes(
-        op_name, attr_tuple, inputs, outputs, tangents, use_batch)
+  return _jvp_relaxed_shapes(
+      op_name, attr_tuple, inputs, outputs, tangents, use_batch)
 
 
 pywrap_tfe.TFE_Py_RegisterJVPFunction(_jvp_dispatch)
@@ -430,6 +431,7 @@ class ForwardAccumulator(object):
     unconnected_gradients = UnconnectedGradients(unconnected_gradients)
     if self._accumulator is None:
       raise ValueError("Called jvp() without first tracing anything.")
+
     def _fetch_jvp(tensor):
       if hasattr(tensor, "handle"):
         tensor = ops.convert_to_tensor(tensor.handle)

--- a/tensorflow/python/eager/forwardprop_test.py
+++ b/tensorflow/python/eager/forwardprop_test.py
@@ -27,6 +27,7 @@ import numpy as np
 from tensorflow.python import pywrap_tfe
 from tensorflow.python.distribute import mirrored_strategy
 from tensorflow.python.eager import backprop
+from tensorflow.python.eager import context
 from tensorflow.python.eager import def_function
 from tensorflow.python.eager import forwardprop
 from tensorflow.python.eager import forwardprop_util
@@ -283,9 +284,12 @@ class ForwardpropTest(test.TestCase, parameterized.TestCase):
     )
 
   def testJVPFunctionRaisesError(self):
+    context.ensure_initialized()
+    ctx = context.context()
+
     sum_outputs = (constant_op.constant(6.),)
     
-    with self.assertRaises(ValueError):
+    with self.assertRaisesRegexp(ValueError, r".*was expected to be of shape*"):
       forwardprop._jvp_dispatch(
         op_name="Add",
         attr_tuple=(),

--- a/tensorflow/python/eager/forwardprop_test.py
+++ b/tensorflow/python/eager/forwardprop_test.py
@@ -286,9 +286,6 @@ class ForwardpropTest(test.TestCase, parameterized.TestCase):
     )
 
   def testJVPFunctionRaisesError(self):
-    context.ensure_initialized()
-    ctx = context.context()
-
     sum_outputs = (constant_op.constant(6.),)
 
     with self.assertRaisesRegexp(ValueError, r".*was expected to be of shape*"):

--- a/tensorflow/python/eager/forwardprop_test.py
+++ b/tensorflow/python/eager/forwardprop_test.py
@@ -167,8 +167,8 @@ def _vectorize_parameters(f, params, use_pfor, dtype):
   if use_pfor:
     return control_flow_ops.vectorized_map(
         _wrapper, math_ops.range(total_size))
-  else:
-    return map_fn.map_fn(_wrapper, math_ops.range(total_size), dtype)
+
+  return map_fn.map_fn(_wrapper, math_ops.range(total_size), dtype)
 
 
 def _forward_over_back_hessian(f, params, use_pfor, dtype=None):
@@ -348,7 +348,7 @@ class ForwardpropTest(test.TestCase, parameterized.TestCase):
       self._execution_count = execution_count + 1
       x = array_ops.zeros([execution_count])
       with forwardprop.ForwardAccumulator(
-              x, array_ops.ones_like(x)) as acc:
+          x, array_ops.ones_like(x)) as acc:
         y = x + x
       self.assertAllClose(2. * array_ops.ones_like(x), acc.jvp(y))
 
@@ -357,10 +357,10 @@ class ForwardpropTest(test.TestCase, parameterized.TestCase):
     x = constant_op.constant(-2.)
     with self.assertRaisesRegexp(ValueError, "multiple times"):
       with forwardprop.ForwardAccumulator(
-              [x, x], [1., 2.]):
+          [x, x], [1., 2.]):
         pass
     with forwardprop.ForwardAccumulator(
-            [x], [3.]) as acc:
+        [x], [3.]) as acc:
       self.assertAllClose(3., acc.jvp(x))
       acc._watch(x, constant_op.constant(10.))
       self.assertAllClose(13., acc.jvp(x))
@@ -556,9 +556,9 @@ class ForwardpropTest(test.TestCase, parameterized.TestCase):
 
     primal = constant_op.constant(1.1)
     with forwardprop.ForwardAccumulator(
-            primal, constant_op.constant(1.)) as outer_acc:
+        primal, constant_op.constant(1.)) as outer_acc:
       with forwardprop.ForwardAccumulator(
-              primal, constant_op.constant(1.)) as acc:
+          primal, constant_op.constant(1.)) as acc:
         primal_out = f(primal)
     inner_jvp = acc.jvp(primal_out)
     outer_jvp = outer_acc.jvp(inner_jvp)
@@ -574,9 +574,9 @@ class ForwardpropTest(test.TestCase, parameterized.TestCase):
     inner_jvp = constant_op.constant(3.)
     with forwardprop.ForwardAccumulator(
         [primal_in, inner_jvp],
-            [constant_op.constant(2.), constant_op.constant(4.)]) as outer_acc:
+        [constant_op.constant(2.), constant_op.constant(4.)]) as outer_acc:
       with forwardprop.ForwardAccumulator(
-              primal_in, inner_jvp) as inner_acc:
+          primal_in, inner_jvp) as inner_acc:
         packed_input_indices, packed_input_tangents = (
             forwardprop_util.pack_tangents([primal_in]))
         self.assertAllClose([3., 2., 4.], packed_input_tangents)
@@ -606,9 +606,9 @@ class ForwardpropTest(test.TestCase, parameterized.TestCase):
 
       primal = constant_op.constant(1.1)
       with forwardprop.ForwardAccumulator(
-              primal, constant_op.constant(1.)) as outer_acc:
+          primal, constant_op.constant(1.)) as outer_acc:
         with forwardprop.ForwardAccumulator(
-                primal, constant_op.constant(1.)) as acc:
+            primal, constant_op.constant(1.)) as acc:
           primal_out = f(primal)
       inner_jvp = acc.jvp(primal_out)
       outer_jvp = outer_acc.jvp(inner_jvp)
@@ -640,7 +640,7 @@ class ForwardpropTest(test.TestCase, parameterized.TestCase):
     matmul = def_function.function(math_ops.matmul)
 
     with forwardprop.ForwardAccumulator(
-            primals=[m1, m2], tangents=[tangent1, tangent2]) as acc:
+        primals=[m1, m2], tangents=[tangent1, tangent2]) as acc:
       result1 = matmul(m1, m1, transpose_b=True)
       result2 = matmul(m2, m2, transpose_b=True)
 
@@ -851,7 +851,7 @@ class ForwardpropTest(test.TestCase, parameterized.TestCase):
   def testVariableWatched(self):
     v = variables.Variable([1., 2., 3.])
     with forwardprop.ForwardAccumulator(
-            v, constant_op.constant([.1, -.2, .3])) as acc:
+        v, constant_op.constant([.1, -.2, .3])) as acc:
       self.assertAllClose([.1, -.2, .3], acc.jvp(v))
       x = v * 2.
       self.assertAllClose([.2, -.4, .6], acc.jvp(x))
@@ -882,7 +882,7 @@ class ForwardpropTest(test.TestCase, parameterized.TestCase):
         if self._v is None:
           self._v = variables.Variable([1., 2., 3.])
         with forwardprop.ForwardAccumulator(
-                self._v, constant_op.constant([.1, -.2, .3])) as acc:
+            self._v, constant_op.constant([.1, -.2, .3])) as acc:
           x = self._v * 2.
           x2 = self._v + .1
         return acc.jvp((self._v, x, x2))

--- a/tensorflow/python/eager/forwardprop_test.py
+++ b/tensorflow/python/eager/forwardprop_test.py
@@ -27,7 +27,6 @@ import numpy as np
 from tensorflow.python import pywrap_tfe
 from tensorflow.python.distribute import mirrored_strategy
 from tensorflow.python.eager import backprop
-from tensorflow.python.eager import context
 from tensorflow.python.eager import def_function
 from tensorflow.python.eager import forwardprop
 from tensorflow.python.eager import forwardprop_util

--- a/tensorflow/python/eager/forwardprop_test.py
+++ b/tensorflow/python/eager/forwardprop_test.py
@@ -246,6 +246,42 @@ class ForwardpropTest(test.TestCase, parameterized.TestCase):
         ))
     self.assertAllClose([2. * 5. + 3. * 4.], self.evaluate(vp))
 
+  def testJVPFunctionWithBatchOfTangents(self):
+    add_outputs = (constant_op.constant(4.),)
+    jvp_flat = forwardprop._jvp_dispatch(
+        op_name="Add",
+        attr_tuple=(),
+        inputs=(constant_op.constant(1.), constant_op.constant(3.)),
+        outputs=add_outputs,
+        tangents=(
+            constant_op.constant([1., 2., 3.]),
+            constant_op.constant([4., 5., 6.]),
+        ),
+	batch_size=3)
+
+    # Using evaluate and asserting with just a list works too
+    # but the output is more explicit this way
+    self.assertAllClose(
+      [constant_op.constant([1. + 4., 2. + 5., 3. + 6.])],
+      jvp_flat
+    )
+
+    mul_outputs = (constant_op.constant([20.]),)
+    jvp_flat = forwardprop._jvp_dispatch(
+        op_name="Mul",
+        attr_tuple=(),
+        inputs=(constant_op.constant([4.]), constant_op.constant([5.])),
+        outputs=mul_outputs,
+        tangents=(
+            constant_op.constant([[1.], [0.], [1.]]),
+            constant_op.constant([[0.], [1.], [1.]]),
+        ),
+	batch_size=3)
+    self.assertAllClose(
+      [constant_op.constant([[5.], [4.], [5. + 4.]])],
+      jvp_flat
+    )
+
   def testNonDifferentiableOpWithInputTangent(self):
     x = constant_op.constant(1.)
     with forwardprop.ForwardAccumulator(x, 2.) as acc1:

--- a/tensorflow/python/eager/forwardprop_test.py
+++ b/tensorflow/python/eager/forwardprop_test.py
@@ -257,7 +257,7 @@ class ForwardpropTest(test.TestCase, parameterized.TestCase):
             constant_op.constant([1., 2., 3.]),
             constant_op.constant([4., 5., 6.]),
         ),
-	batch_size=3)
+        batch_size=3)
 
     # Using evaluate and asserting with just a list works too
     # but the output is more explicit this way
@@ -276,7 +276,7 @@ class ForwardpropTest(test.TestCase, parameterized.TestCase):
             constant_op.constant([[1.], [0.], [1.]]),
             constant_op.constant([[0.], [1.], [1.]]),
         ),
-	batch_size=3)
+        batch_size=3)
     self.assertAllClose(
       [constant_op.constant([[5.], [4.], [5. + 4.]])],
       jvp_flat

--- a/tensorflow/python/eager/forwardprop_test.py
+++ b/tensorflow/python/eager/forwardprop_test.py
@@ -27,7 +27,6 @@ import numpy as np
 from tensorflow.python import pywrap_tfe
 from tensorflow.python.distribute import mirrored_strategy
 from tensorflow.python.eager import backprop
-from tensorflow.python.eager import context
 from tensorflow.python.eager import def_function
 from tensorflow.python.eager import forwardprop
 from tensorflow.python.eager import forwardprop_util
@@ -284,9 +283,6 @@ class ForwardpropTest(test.TestCase, parameterized.TestCase):
     )
 
   def testJVPFunctionRaisesError(self):
-    context.ensure_initialized()
-    ctx = context.context()
-
     sum_outputs = (constant_op.constant(6.),)
     
     with self.assertRaises(ValueError):

--- a/tensorflow/python/eager/forwardprop_test.py
+++ b/tensorflow/python/eager/forwardprop_test.py
@@ -165,7 +165,8 @@ def _vectorize_parameters(f, params, use_pfor, dtype):
     return f(tangents)
 
   if use_pfor:
-    return control_flow_ops.vectorized_map(_wrapper, math_ops.range(total_size))
+    return control_flow_ops.vectorized_map(
+        _wrapper, math_ops.range(total_size))
   else:
     return map_fn.map_fn(_wrapper, math_ops.range(total_size), dtype)
 
@@ -220,6 +221,7 @@ def _test_gradients(testcase,
   # And the symbolic computations should be much closer.
   testcase.assertAllClose(sym_jac_back, sym_jac_fwd)
 
+
 class ForwardpropTest(test.TestCase, parameterized.TestCase):
 
   def testJVPFunction(self):
@@ -263,8 +265,8 @@ class ForwardpropTest(test.TestCase, parameterized.TestCase):
     # Using evaluate and asserting with just a list works too
     # but the output is more explicit this way
     self.assertAllClose(
-      [constant_op.constant([1. + 4., 2. + 5., 3. + 6.])],
-      jvp_flat
+        [constant_op.constant([1. + 4., 2. + 5., 3. + 6.])],
+        jvp_flat
     )
 
     mul_outputs = (constant_op.constant([20.]),)
@@ -279,8 +281,8 @@ class ForwardpropTest(test.TestCase, parameterized.TestCase):
         ),
         use_batch=True)
     self.assertAllClose(
-      [constant_op.constant([[5.], [4.], [5. + 4.]])],
-      jvp_flat
+        [constant_op.constant([[5.], [4.], [5. + 4.]])],
+        jvp_flat
     )
 
   def testJVPFunctionRaisesError(self):
@@ -288,18 +290,18 @@ class ForwardpropTest(test.TestCase, parameterized.TestCase):
     ctx = context.context()
 
     sum_outputs = (constant_op.constant(6.),)
-    
+
     with self.assertRaisesRegexp(ValueError, r".*was expected to be of shape*"):
       forwardprop._jvp_dispatch(
-        op_name="Add",
-        attr_tuple=(),
-        inputs=(constant_op.constant(2.), constant_op.constant(4.)),
-        outputs=sum_outputs,
-        tangents=(
-	  constant_op.constant([1., 2.]),
-	  constant_op.constant([[1.], [2.]])
-	),
-        use_batch=True
+          op_name="Add",
+          attr_tuple=(),
+          inputs=(constant_op.constant(2.), constant_op.constant(4.)),
+          outputs=sum_outputs,
+          tangents=(
+              constant_op.constant([1., 2.]),
+              constant_op.constant([[1.], [2.]])
+          ),
+          use_batch=True
       )
 
   def testNonDifferentiableOpWithInputTangent(self):
@@ -346,7 +348,7 @@ class ForwardpropTest(test.TestCase, parameterized.TestCase):
       self._execution_count = execution_count + 1
       x = array_ops.zeros([execution_count])
       with forwardprop.ForwardAccumulator(
-          x, array_ops.ones_like(x)) as acc:
+              x, array_ops.ones_like(x)) as acc:
         y = x + x
       self.assertAllClose(2. * array_ops.ones_like(x), acc.jvp(y))
 
@@ -355,10 +357,10 @@ class ForwardpropTest(test.TestCase, parameterized.TestCase):
     x = constant_op.constant(-2.)
     with self.assertRaisesRegexp(ValueError, "multiple times"):
       with forwardprop.ForwardAccumulator(
-          [x, x], [1., 2.]):
+              [x, x], [1., 2.]):
         pass
     with forwardprop.ForwardAccumulator(
-        [x], [3.]) as acc:
+            [x], [3.]) as acc:
       self.assertAllClose(3., acc.jvp(x))
       acc._watch(x, constant_op.constant(10.))
       self.assertAllClose(13., acc.jvp(x))
@@ -436,7 +438,8 @@ class ForwardpropTest(test.TestCase, parameterized.TestCase):
 
     _test_gradients(self, f, [constant_op.constant([1., 2.])], order=3)
 
-  # TODO(allenl): investigate why assert_no_new_pyobjects_executing_eagerly fails around this test?
+  # TODO(allenl): investigate why assert_no_new_pyobjects_executing_eagerly
+  # fails around this test?
   def testExceptionCustomGradientRecomputeGradForward(self):
 
     @custom_gradient.recompute_grad
@@ -553,9 +556,9 @@ class ForwardpropTest(test.TestCase, parameterized.TestCase):
 
     primal = constant_op.constant(1.1)
     with forwardprop.ForwardAccumulator(
-        primal, constant_op.constant(1.)) as outer_acc:
+            primal, constant_op.constant(1.)) as outer_acc:
       with forwardprop.ForwardAccumulator(
-          primal, constant_op.constant(1.)) as acc:
+              primal, constant_op.constant(1.)) as acc:
         primal_out = f(primal)
     inner_jvp = acc.jvp(primal_out)
     outer_jvp = outer_acc.jvp(inner_jvp)
@@ -571,9 +574,9 @@ class ForwardpropTest(test.TestCase, parameterized.TestCase):
     inner_jvp = constant_op.constant(3.)
     with forwardprop.ForwardAccumulator(
         [primal_in, inner_jvp],
-        [constant_op.constant(2.), constant_op.constant(4.)]) as outer_acc:
+            [constant_op.constant(2.), constant_op.constant(4.)]) as outer_acc:
       with forwardprop.ForwardAccumulator(
-          primal_in, inner_jvp) as inner_acc:
+              primal_in, inner_jvp) as inner_acc:
         packed_input_indices, packed_input_tangents = (
             forwardprop_util.pack_tangents([primal_in]))
         self.assertAllClose([3., 2., 4.], packed_input_tangents)
@@ -603,9 +606,9 @@ class ForwardpropTest(test.TestCase, parameterized.TestCase):
 
       primal = constant_op.constant(1.1)
       with forwardprop.ForwardAccumulator(
-          primal, constant_op.constant(1.)) as outer_acc:
+              primal, constant_op.constant(1.)) as outer_acc:
         with forwardprop.ForwardAccumulator(
-            primal, constant_op.constant(1.)) as acc:
+                primal, constant_op.constant(1.)) as acc:
           primal_out = f(primal)
       inner_jvp = acc.jvp(primal_out)
       outer_jvp = outer_acc.jvp(inner_jvp)
@@ -637,7 +640,7 @@ class ForwardpropTest(test.TestCase, parameterized.TestCase):
     matmul = def_function.function(math_ops.matmul)
 
     with forwardprop.ForwardAccumulator(
-        primals=[m1, m2], tangents=[tangent1, tangent2]) as acc:
+            primals=[m1, m2], tangents=[tangent1, tangent2]) as acc:
       result1 = matmul(m1, m1, transpose_b=True)
       result2 = matmul(m2, m2, transpose_b=True)
 
@@ -848,7 +851,7 @@ class ForwardpropTest(test.TestCase, parameterized.TestCase):
   def testVariableWatched(self):
     v = variables.Variable([1., 2., 3.])
     with forwardprop.ForwardAccumulator(
-        v, constant_op.constant([.1, -.2, .3])) as acc:
+            v, constant_op.constant([.1, -.2, .3])) as acc:
       self.assertAllClose([.1, -.2, .3], acc.jvp(v))
       x = v * 2.
       self.assertAllClose([.2, -.4, .6], acc.jvp(x))
@@ -864,7 +867,8 @@ class ForwardpropTest(test.TestCase, parameterized.TestCase):
       self.assertAllClose(0.0, acc.jvp(y, unconnected_gradients="zero"))
       self.assertIsNone(acc.jvp(y, unconnected_gradients="none"))
 
-  # TODO(kkb): One weakref instance is created with warmup_iters=2, investigate.
+  # TODO(kkb): One weakref instance is created with warmup_iters=2,
+  # investigate.
   @test_util.assert_no_new_pyobjects_executing_eagerly(warmup_iters=3)
   def testVariableWatchedFunction(self):
 
@@ -878,7 +882,7 @@ class ForwardpropTest(test.TestCase, parameterized.TestCase):
         if self._v is None:
           self._v = variables.Variable([1., 2., 3.])
         with forwardprop.ForwardAccumulator(
-            self._v, constant_op.constant([.1, -.2, .3])) as acc:
+                self._v, constant_op.constant([.1, -.2, .3])) as acc:
           x = self._v * 2.
           x2 = self._v + .1
         return acc.jvp((self._v, x, x2))

--- a/tensorflow/python/ops/parallel_for/BUILD
+++ b/tensorflow/python/ops/parallel_for/BUILD
@@ -89,6 +89,7 @@ py_library(
         "//tensorflow/python:util",
         "//tensorflow/python/eager:context",
         "//tensorflow/python/eager:function",
+	"//tensorflow/python/ops/signal",
     ],
 )
 

--- a/tensorflow/python/ops/parallel_for/BUILD
+++ b/tensorflow/python/ops/parallel_for/BUILD
@@ -89,7 +89,7 @@ py_library(
         "//tensorflow/python:util",
         "//tensorflow/python/eager:context",
         "//tensorflow/python/eager:function",
-	"//tensorflow/python/ops/signal",
+        "//tensorflow/python/ops/signal",
     ],
 )
 

--- a/tensorflow/python/ops/parallel_for/gradients.py
+++ b/tensorflow/python/ops/parallel_for/gradients.py
@@ -20,7 +20,7 @@ from __future__ import print_function
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import check_ops
-from tensorflow.python.ops import gradients as gradient_ops
+from tensorflow.python.ops import gradients_impl as gradient_ops
 from tensorflow.python.ops.parallel_for import control_flow_ops
 from tensorflow.python.util import nest
 


### PR DESCRIPTION
Tangent Batching for regular ops can be done by vectorizing `_jvp_dispath`.

(cc @allenlavoie)