### PR TITLE
supporting x dtype instead of only float 32 in K.relu

### DIFF
--- a/tensorflow/python/keras/backend.py
+++ b/tensorflow/python/keras/backend.py
@@ -4541,8 +4541,10 @@ def relu(x, alpha=0., max_value=None, threshold=0):
   Returns:
       A tensor.
   """
-
-  if isinstance(x, tf.Tensor) or isinstance(x, np.ndarray):
+  if isinstance(x, (ops.Tensor,
+                    variables_module.Variable,
+                    sparse_tensor.SparseTensor,
+                    np.ndarray)):
     dtype = x.dtype
   else:
     dtype = floatx()

--- a/tensorflow/python/keras/backend.py
+++ b/tensorflow/python/keras/backend.py
@@ -3452,7 +3452,7 @@ _VALUE_SET_CODE_STRING = """
   >>> print(K.get_value(v))
   3.0
 
-  Variable semantics in TensorFlow 2 are eager execution friendly. The above 
+  Variable semantics in TensorFlow 2 are eager execution friendly. The above
   code is roughly equivalent to:
 
   >>> v = tf.Variable(1.)
@@ -4555,7 +4555,7 @@ def relu(x, alpha=0., max_value=None, threshold=0):
 
   if threshold != 0:
     # computes x for x > threshold else 0
-    x = x * math_ops.cast(math_ops.greater(x, threshold), floatx())
+    x = x * math_ops.cast(math_ops.greater(x, threshold), x.dtype)
   elif max_value == 6:
     # if no threshold, then can use nn.relu6 native TF op for performance
     x = nn.relu6(x)

--- a/tensorflow/python/keras/backend.py
+++ b/tensorflow/python/keras/backend.py
@@ -4541,6 +4541,7 @@ def relu(x, alpha=0., max_value=None, threshold=0):
   Returns:
       A tensor.
   """
+
   if isinstance(x, tf.Tensor) or isinstance(x, np.ndarray):
     dtype = x.dtype
   else:

--- a/tensorflow/python/keras/backend.py
+++ b/tensorflow/python/keras/backend.py
@@ -4541,10 +4541,10 @@ def relu(x, alpha=0., max_value=None, threshold=0):
   Returns:
       A tensor.
   """
-  if hasattr(x, "dtype"):
-    dtype = x.dtype
-  else:
-    dtype = floatx()
+  # While x can be a tensor or variable, we also see cases where 
+  # numpy arrays, lists, tuples are passed as well.
+  # lists, tuples do not have 'dtype' attribute.
+  dtype = getattr(x, 'dtype', floatx())
   if alpha != 0.:
     if max_value is None and threshold == 0:
       return nn.leaky_relu(x, alpha=alpha)

--- a/tensorflow/python/keras/backend.py
+++ b/tensorflow/python/keras/backend.py
@@ -4541,10 +4541,7 @@ def relu(x, alpha=0., max_value=None, threshold=0):
   Returns:
       A tensor.
   """
-  if isinstance(x, (ops.Tensor,
-                    variables_module.Variable,
-                    sparse_tensor.SparseTensor,
-                    np.ndarray)):
+  if hasattr(x, "dtype"):
     dtype = x.dtype
   else:
     dtype = floatx()

--- a/tensorflow/python/keras/backend.py
+++ b/tensorflow/python/keras/backend.py
@@ -4541,7 +4541,10 @@ def relu(x, alpha=0., max_value=None, threshold=0):
   Returns:
       A tensor.
   """
-
+  if isinstance(x, tf.Tensor) or isinstance(x, np.ndarray):
+    dtype = x.dtype
+  else:
+    dtype = floatx()
   if alpha != 0.:
     if max_value is None and threshold == 0:
       return nn.leaky_relu(x, alpha=alpha)
@@ -4555,7 +4558,7 @@ def relu(x, alpha=0., max_value=None, threshold=0):
 
   if threshold != 0:
     # computes x for x > threshold else 0
-    x = x * math_ops.cast(math_ops.greater(x, threshold), x.dtype)
+    x = x * math_ops.cast(math_ops.greater(x, threshold), dtype=dtype)
   elif max_value == 6:
     # if no threshold, then can use nn.relu6 native TF op for performance
     x = nn.relu6(x)


### PR DESCRIPTION
K.relu casts to floatx() by default when threshold is greater than 0. This fails when one sets mixed precision through `tf.keras.mixed_precision.experimental.set_policy` to `mixed_float16` or just pass an input of dtype float16

Changing it to follow the documentation to use the inputs dtype instead.

#40687
 cc @Saduf2019