### PR TITLE
Prefer Tensor._shape_tuple over Tensor._shape_as_list 

### DIFF
--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -513,16 +513,16 @@ class Tensor(internal.NativeObject, core_tf_types.Tensor):
     return _TensorIterator(self, shape[0])
 
   def _shape_as_list(self):
-    if self.shape.ndims is not None:
-      return [dim.value for dim in self.shape.dims]
-    else:
-      return None
-
-  def _shape_tuple(self):
-    shape = self._shape_as_list()
+    shape = self._shape_tuple()
     if shape is None:
       return None
-    return tuple(shape)
+    return list(shape)
+
+  def _shape_tuple(self):
+    try:
+      return tuple(dim.value for dim in self.shape.dims)
+    except TypeError:
+      return None
 
   def _rank(self):
     """Integer rank of this Tensor, if known, else None.

--- a/tensorflow/python/kernel_tests/lookup_ops_test.py
+++ b/tensorflow/python/kernel_tests/lookup_ops_test.py
@@ -1060,7 +1060,7 @@ class StaticVocabularyTableTest(BaseLookupTableTest):
 
     sp_ids = table.lookup(sp_features)
 
-    self.assertAllEqual([5], sp_ids.values._shape_as_list())
+    self.assertAllEqual((5,), sp_ids.values._shape_tuple())
 
     sp_ids_ind, sp_ids_val, sp_ids_shape = self.evaluate(
         [sp_ids.indices, sp_ids.values, sp_ids.dense_shape])
@@ -1086,7 +1086,7 @@ class StaticVocabularyTableTest(BaseLookupTableTest):
 
     sp_ids = table.lookup(sp_features)
 
-    self.assertAllEqual([5], sp_ids.values._shape_as_list())
+    self.assertAllEqual((5,), sp_ids.values._shape_tuple())
 
     sp_ids_ind, sp_ids_val, sp_ids_shape = self.evaluate(
         [sp_ids.indices, sp_ids.values, sp_ids.dense_shape])
@@ -1109,7 +1109,7 @@ class StaticVocabularyTableTest(BaseLookupTableTest):
 
     sp_ids = table.lookup(sp_features)
 
-    self.assertAllEqual([5], sp_ids.values._shape_as_list())
+    self.assertAllEqual((5,), sp_ids.values._shape_tuple())
 
     sp_ids_ind, sp_ids_val, sp_ids_shape = self.evaluate(
         [sp_ids.indices, sp_ids.values, sp_ids.dense_shape])
@@ -2681,7 +2681,7 @@ class IdTableWithHashBucketsTest(test.TestCase):
 
       sp_ids = table.lookup(sp_features)
 
-      self.assertAllEqual([5], sp_ids.values._shape_as_list())
+      self.assertAllEqual((5,), sp_ids.values._shape_tuple())
 
       sp_ids_ind, sp_ids_val, sp_ids_shape = sess.run(
           [sp_ids.indices, sp_ids.values, sp_ids.dense_shape])
@@ -2710,7 +2710,7 @@ class IdTableWithHashBucketsTest(test.TestCase):
 
       sp_ids = table.lookup(sp_features)
 
-      self.assertAllEqual([5], sp_ids.values._shape_as_list())
+      self.assertAllEqual((5,), sp_ids.values._shape_tuple())
 
       sp_ids_ind, sp_ids_val, sp_ids_shape = sess.run(
           [sp_ids.indices, sp_ids.values, sp_ids.dense_shape])
@@ -2739,7 +2739,7 @@ class IdTableWithHashBucketsTest(test.TestCase):
 
       sp_ids = table.lookup(sp_features)
 
-      self.assertAllEqual([5], sp_ids.values._shape_as_list())
+      self.assertAllEqual((5,), sp_ids.values._shape_tuple())
 
       sp_ids_ind, sp_ids_val, sp_ids_shape = sess.run(
           [sp_ids.indices, sp_ids.values, sp_ids.dense_shape])

--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -676,7 +676,7 @@ def real(val):
 @np_utils.np_doc('repeat')
 def repeat(a, repeats, axis=None):  # pylint: disable=missing-docstring
   a = asarray(a).data
-  original_shape = a._shape_as_list()  # pylint: disable=protected-access
+  original_shape = a._shape_tuple()  # pylint: disable=protected-access
   # Best effort recovery of the shape.
   known_shape = original_shape is not None and None not in original_shape
   if known_shape:

--- a/tensorflow/python/ops/resource_variable_ops.py
+++ b/tensorflow/python/ops/resource_variable_ops.py
@@ -441,7 +441,6 @@ class BaseResourceVariable(variables.VariableV1, core.Tensor):
         handle_deleter = EagerResourceDeleter(
             handle=self._handle, handle_device=self._handle.device)
     self._handle_deleter = handle_deleter
-    self._cached_shape_as_list = None
 
   def __repr__(self):
     if context.executing_eagerly() and not self._in_graph_mode:
@@ -524,15 +523,16 @@ class BaseResourceVariable(variables.VariableV1, core.Tensor):
     self._shape = self._shape.merge_with(shape)
 
   def _shape_as_list(self):
-    if self.shape.ndims is None:
-      return None
-    return [dim.value for dim in self.shape.dims]
-
-  def _shape_tuple(self):
-    shape = self._shape_as_list()
+    shape = self._shape_tuple()
     if shape is None:
       return None
-    return tuple(shape)
+    return list(shape)
+
+  def _shape_tuple(self):
+    try:
+      return tuple(dim.value for dim in self.shape.dims)
+    except TypeError:
+      return None
 
   @property
   def create(self):


### PR DESCRIPTION
This PR removes the `Tensor._shape_as_list()` method. `Tensor._shape_tuple()` provides the same functionality and its use is more prevelent throughout the codebase. Since it is a private method this removal should not be a breaking change.

This change also improves performance of `Tensor._shape_tuple()` and `ResourceVariable._shape_tuple()` by about 20-25% as it avoids one list creation.