### PR TITLE
Add arm source file into aws-checksums

### DIFF
--- a/third_party/aws/aws-checksums.bazel
+++ b/third_party/aws/aws-checksums.bazel
@@ -16,6 +16,7 @@ cc_library(
         "//conditions:default": [],
     }) + glob([
         "source/intel/*.c",
+        "source/arm/*.c",
         "source/*.c",
     ]),
     hdrs = glob([


### PR DESCRIPTION
According to https://github.com/tensorflow/tensorflow/issues/40463#issuecomment-647640030 , seem the aws libs need to add the arm related libs during build tensorflow package.