### PR TITLE
Prefer generator expressions over list comprehensions

### DIFF
--- a/tensorflow/python/eager/function.py
+++ b/tensorflow/python/eager/function.py
@@ -1192,7 +1192,7 @@ class _TapeGradientFunctions(object):
   def _wrap_backward_function(self, forward_graph, backward, outputs):
     """Create a backward function given `outputs` from the forward function."""
     capture_mapping = dict(
-        zip([ops.tensor_id(t) for t in forward_graph.outputs], outputs))
+        zip((ops.tensor_id(t) for t in forward_graph.outputs), outputs))
     remapped_captures = [
         capture_mapping.get(ops.tensor_id(capture), capture)
         for capture in backward.captured_inputs
@@ -1491,7 +1491,7 @@ class ConcreteFunction(object):
     self._ndarrays_list = (
         isinstance(structured_outputs, (list, tuple)) and
         structured_outputs and
-        all([isinstance(o, np_arrays.ndarray) for o in structured_outputs]))
+        all(isinstance(o, np_arrays.ndarray) for o in structured_outputs))
     self._ndarray_singleton = isinstance(structured_outputs, np_arrays.ndarray)
 
     # function_spec defines the structured signature.

--- a/tensorflow/python/keras/engine/training_v1.py
+++ b/tensorflow/python/keras/engine/training_v1.py
@@ -1492,8 +1492,8 @@ class Model(training_lib.Model):
   def _recompile_weights_loss_and_weighted_metrics(self):
     if not self._is_compiled:
       return False
-    recompile = any([e.sample_weights_mismatch()
-                     for e in self._training_endpoints])
+    recompile = any(e.sample_weights_mismatch()
+                    for e in self._training_endpoints)
 
     if recompile:
       self._compile_weights_loss_and_weighted_metrics()

--- a/tensorflow/python/keras/layers/preprocessing/category_crossing.py
+++ b/tensorflow/python/keras/layers/preprocessing/category_crossing.py
@@ -188,15 +188,15 @@ class CategoryCrossing(Layer):
   def compute_output_signature(self, input_spec):
     input_shapes = [x.shape for x in input_spec]
     output_shape = self.compute_output_shape(input_shapes)
-    if any([
+    if any(
         isinstance(inp_spec, ragged_tensor.RaggedTensorSpec)
         for inp_spec in input_spec
-    ]):
+    ):
       return tensor_spec.TensorSpec(shape=output_shape, dtype=dtypes.string)
-    elif any([
+    elif any(
         isinstance(inp_spec, sparse_tensor.SparseTensorSpec)
         for inp_spec in input_spec
-    ]):
+    ):
       return sparse_tensor.SparseTensorSpec(
           shape=output_shape, dtype=dtypes.string)
     return tensor_spec.TensorSpec(shape=output_shape, dtype=dtypes.string)

--- a/tensorflow/python/keras/layers/preprocessing/hashing.py
+++ b/tensorflow/python/keras/layers/preprocessing/hashing.py
@@ -158,10 +158,10 @@ class Hashing(Layer):
   def _preprocess_inputs(self, inputs):
     if isinstance(inputs, (tuple, list)):
       # If any of them is tensor or ndarray, then treat as list
-      if any([
+      if any(
           tensor_util.is_tensor(inp) or isinstance(inp, np.ndarray)
           for inp in inputs
-      ]):
+      ):
         return [self._preprocess_single_input(inp) for inp in inputs]
     return self._preprocess_single_input(inputs)
 
@@ -261,15 +261,15 @@ class Hashing(Layer):
         return tensor_spec.TensorSpec(shape=output_shape, dtype=output_dtype)
     input_shapes = [x.shape for x in input_spec]
     output_shape = self.compute_output_shape(input_shapes)
-    if any([
+    if any(
         isinstance(inp_spec, ragged_tensor.RaggedTensorSpec)
         for inp_spec in input_spec
-    ]):
+    ):
       return tensor_spec.TensorSpec(shape=output_shape, dtype=dtypes.int64)
-    elif any([
+    elif any(
         isinstance(inp_spec, sparse_tensor.SparseTensorSpec)
         for inp_spec in input_spec
-    ]):
+    ):
       return sparse_tensor.SparseTensorSpec(
           shape=output_shape, dtype=dtypes.int64)
     return tensor_spec.TensorSpec(shape=output_shape, dtype=dtypes.int64)


### PR DESCRIPTION
Same as #39887

This PR replaces list comprehensions that are only used as input to `any()`, `all()` or `zip()` with generator expressions. This removes the need to instantiate unnecessary lists if the expresion is only consumed as an iterator and in the case of any/all allows the loop to potentially exit early which can improve performance for long iterations.

Most of the changes are not in a hot code path so this won't noticably improve performance but since the change don't hurt readability I think they are still useful to include.