### PR TITLE
Const-qulify PyUFuncGenericFunction's arguments

### DIFF
--- a/tensorflow/compiler/xla/python/bfloat16.cc
+++ b/tensorflow/compiler/xla/python/bfloat16.cc
@@ -708,8 +708,8 @@ struct UnaryUFunc {
   static std::vector<int> Types() {
     return {TypeDescriptor<InType>::Dtype(), TypeDescriptor<OutType>::Dtype()};
   }
-  static void Call(char** args, npy_intp* dimensions, npy_intp* steps,
-                   void* data) {
+  static void Call(char** args, const npy_intp* dimensions,
+                   const npy_intp* steps, void* data) {
     const char* i0 = args[0];
     char* o = args[1];
     for (npy_intp k = 0; k < *dimensions; k++) {
@@ -728,8 +728,8 @@ struct UnaryUFunc2 {
     return {TypeDescriptor<InType>::Dtype(), TypeDescriptor<OutType>::Dtype(),
             TypeDescriptor<OutType2>::Dtype()};
   }
-  static void Call(char** args, npy_intp* dimensions, npy_intp* steps,
-                   void* data) {
+  static void Call(char** args, const npy_intp* dimensions,
+                   const npy_intp* steps, void* data) {
     const char* i0 = args[0];
     char* o0 = args[1];
     char* o1 = args[2];
@@ -751,8 +751,8 @@ struct BinaryUFunc {
     return {TypeDescriptor<InType>::Dtype(), TypeDescriptor<InType>::Dtype(),
             TypeDescriptor<OutType>::Dtype()};
   }
-  static void Call(char** args, npy_intp* dimensions, npy_intp* steps,
-                   void* data) {
+  static void Call(char** args, const npy_intp* dimensions,
+                   const npy_intp* steps, void* data) {
     const char* i0 = args[0];
     const char* i1 = args[1];
     char* o = args[2];
@@ -774,8 +774,8 @@ struct BinaryUFunc2 {
     return {TypeDescriptor<InType>::Dtype(), TypeDescriptor<InType2>::Dtype(),
             TypeDescriptor<OutType>::Dtype()};
   }
-  static void Call(char** args, npy_intp* dimensions, npy_intp* steps,
-                   void* data) {
+  static void Call(char** args, const npy_intp* dimensions,
+                   const npy_intp* steps, void* data) {
     const char* i0 = args[0];
     const char* i1 = args[1];
     char* o = args[2];
@@ -873,8 +873,8 @@ struct DivmodUFunc {
   static std::vector<int> Types() {
     return {npy_bfloat16, npy_bfloat16, npy_bfloat16, npy_bfloat16};
   }
-  static void Call(char** args, npy_intp* dimensions, npy_intp* steps,
-                   void* data) {
+  static void Call(char** args, const npy_intp* dimensions,
+                   const npy_intp* steps, void* data) {
     const char* i0 = args[0];
     const char* i1 = args[1];
     char* o0 = args[2];

--- a/tensorflow/python/lib/core/bfloat16.cc
+++ b/tensorflow/python/lib/core/bfloat16.cc
@@ -517,7 +517,7 @@ bool RegisterBfloat16Cast(int numpy_type, bool cast_is_safe) {
 }
 
 template <typename InType, typename OutType, typename Functor>
-void BinaryUFunc(char** args, npy_intp* dimensions, npy_intp* steps,
+void BinaryUFunc(char** args, const npy_intp* dimensions, const npy_intp* steps,
                  void* data) {
   const char* i0 = args[0];
   const char* i1 = args[1];
@@ -533,8 +533,8 @@ void BinaryUFunc(char** args, npy_intp* dimensions, npy_intp* steps,
 }
 
 template <typename Functor>
-void CompareUFunc(char** args, npy_intp* dimensions, npy_intp* steps,
-                  void* data) {
+void CompareUFunc(char** args, const npy_intp* dimensions,
+                  const npy_intp* steps, void* data) {
   BinaryUFunc<bfloat16, npy_bool, Functor>(args, dimensions, steps, data);
 }
 

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -58,9 +58,7 @@ REQUIRED_PACKAGES = [
     'google_pasta >= 0.1.8',
     'h5py >= 2.10.0, < 2.11.0',
     'keras_preprocessing >= 1.1.1, < 1.2',
-    # TODO(mihaimaruseac): numpy 1.19.0 has ABI breakage
-    # https://github.com/numpy/numpy/pull/15355
-    'numpy >= 1.16.0, < 1.19.0',
+    'numpy >= 1.16.0, < 2.0',
     'opt_einsum >= 2.3.2',
     'protobuf >= 3.9.2',
     'tensorboard >= 2.2.0, < 2.3.0',


### PR DESCRIPTION
Due to recent changes in Numpy [1], PyUFuncGenericFunction's argument should be const-qualified.
This change is non-breaking (i.e. it will work for both numpy 1.18 and 1.19).


[1] https://github.com/numpy/numpy/pull/15355
