### PR TITLE
[EXT-SYSLIB] Add absl_py logging submodule to build flow.

### DIFF
--- a/tensorflow/opensource_only.files
+++ b/tensorflow/opensource_only.files
@@ -170,6 +170,7 @@ tensorflow/third_party/systemlibs/BUILD.tpl
 tensorflow/third_party/systemlibs/absl_py.BUILD
 tensorflow/third_party/systemlibs/absl_py.absl.flags.BUILD
 tensorflow/third_party/systemlibs/absl_py.absl.testing.BUILD
+tensorflow/third_party/systemlibs/absl_py.absl.logging.BUILD
 tensorflow/third_party/systemlibs/astor.BUILD
 tensorflow/third_party/systemlibs/boringssl.BUILD
 tensorflow/third_party/systemlibs/build_defs.bzl.tpl

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -535,6 +535,7 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
             "//third_party/systemlibs:absl_py.absl.BUILD": "absl/BUILD",
             "//third_party/systemlibs:absl_py.absl.flags.BUILD": "absl/flags/BUILD",
             "//third_party/systemlibs:absl_py.absl.testing.BUILD": "absl/testing/BUILD",
+            "//third_party/systemlibs:absl_py.absl.logging.BUILD": "absl/logging/BUILD",
         },
         urls = [
             "https://storage.googleapis.com/mirror.tensorflow.org/github.com/abseil/abseil-py/archive/pypi-v0.9.0.tar.gz",

--- a/third_party/systemlibs/absl_py.absl.logging.BUILD
+++ b/third_party/systemlibs/absl_py.absl.logging.BUILD
@@ -1,0 +1,11 @@
+licenses(["notice"])  # Apache 2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "LICENSE",
+)
+
+py_library(
+    name = "logging",
+)


### PR DESCRIPTION
Enable proper build when ```absl_py``` is external ```LOCAL_LIBS```.

```
ERROR: /home/cbalint/rpmbuild/BUILD/tensorflow/tensorflow/tensorflow/python/distribute/BUILD:1733:11: no such package '@absl_py//absl/logging': BUILD file not found in directory 'absl/logging' of external repository @absl_py. Add a BUILD file to a directory to mark it as a package. and referenced by '//tensorflow/python/distribute:multi_process_runner'
```

Cc @perfinion 

Thank You !
