### PR TITLE
Fix imports of generated go proto bindings

### DIFF
--- a/tensorflow/go/saved_model.go
+++ b/tensorflow/go/saved_model.go
@@ -22,7 +22,7 @@ import (
 	"unsafe"
 
 	"github.com/golang/protobuf/proto"
-	corepb "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf/for_core_protos_go_proto"
+	corepb "github.com/tensorflow/tensorflow/tensorflow/go/core/core_protos_go_proto"
 )
 
 // #include <stdlib.h>

--- a/tensorflow/go/signature.go
+++ b/tensorflow/go/signature.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package tensorflow
 
-import corepb "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf/for_core_protos_go_proto"
+import corepb "github.com/tensorflow/tensorflow/tensorflow/go/core/core_protos_go_proto"
 
 // #include "tensorflow/c/c_api.h"
 import "C"

--- a/tensorflow/go/signature_test.go
+++ b/tensorflow/go/signature_test.go
@@ -22,7 +22,7 @@ import (
 
 	tspb "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/tensor_shape_go_proto"
 	typb "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/types_go_proto"
-	corepb "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf/for_core_protos_go_proto"
+	corepb "github.com/tensorflow/tensorflow/tensorflow/go/core/core_protos_go_proto"
 )
 
 func TestSignatureFromProto(t *testing.T) {


### PR DESCRIPTION
### Fixes
[#39744](https://github.com/tensorflow/tensorflow/issues/39744) 

### Summary

After running the following in accordance with the [installation instructions](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/go/README.md) for go:
```
$ go get -d github.com/tensorflow/tensorflow/tensorflow/go
$ go generate github.com/tensorflow/tensorflow/tensorflow/go/op
$ go test github.com/tensorflow/tensorflow/tensorflow/go
```

The first command generates error message unrelated to this PR, a [fix for which](https://github.com/tensorflow/tensorflow/pull/36523) is ready to pull. That error message is relatively low impact and should not impact the functionality of the library after the `go generate` command is run. However, the third command generates the following error:

```
$ go test github.com/tensorflow/tensorflow/tensorflow/go
../../../go/src/github.com/tensorflow/tensorflow/tensorflow/go/saved_model.go:25:2: cannot find package "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf/for_core_protos_go_proto" in any of:
	/home/abls/go/src/github.com/tensorflow/tensorflow/tensorflow/go/vendor/github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf/for_core_protos_go_proto (vendor tree)
	/usr/local/go/src/github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf/for_core_protos_go_proto (from $GOROOT)
	/home/abls/go/src/github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf/for_core_protos_go_proto (from $GOPATH)
```

This is caused by a bad import that seemed to be from an accident during a [refactor](https://github.com/tensorflow/tensorflow/commit/fd895bf2b98250929a442e5cf689f6bb272ac52c). The problematic import that occurs in several files is:
```
import corepb "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf/for_core_protos_go_proto"
```

This line is supposed to point to the generated files, however the generated files are actually placed in `github.com/tensorflow/tensorflow/tensorflow/go/core/core_protos_go_proto` due to the following line in several proto files in `tensorflow/core/protobuf` read by protoc during generation:
```
option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/core_protos_go_proto";
```

The fix is simply to correct the import lines to point to the actual location of the files.