### PR TITLE
Fix _EagerTensorCache.flush

### DIFF
--- a/tensorflow/python/eager/context.py
+++ b/tensorflow/python/eager/context.py
@@ -98,7 +98,7 @@ class _EagerTensorCache(object):
     return self._data.get(key, None)
 
   def flush(self):
-    self._data = {}
+    self._data.clear()
 
 
 class FunctionCallOptions(object):


### PR DESCRIPTION
`_EagerTensorCache._data` is initialized with an `OrderedDict`:
https://github.com/tensorflow/tensorflow/blob/7113c0b029ad067bf9b5e633082434bb4a4aba62/tensorflow/python/eager/context.py#L84

However, `_EagerTensorCache.flush` resets the cache by assigning a `dict` instead of an `OrderedDict`. This can lead to different behaviour on older versions of Python where dictionary ordering wasn't preserved. This PR switches to using `.clear()` to flush the cache which won't change the data structure.