### PR TITLE
use string instead of const char* gcs

### DIFF
--- a/tensorflow/c/experimental/filesystem/plugins/gcs/BUILD
+++ b/tensorflow/c/experimental/filesystem/plugins/gcs/BUILD
@@ -30,7 +30,6 @@ cc_library(
         "//tensorflow/c:tf_status",
         "//tensorflow/c/experimental/filesystem:filesystem_interface",
         "@com_github_googlecloudplatform_google_cloud_cpp//:storage_client",
-        "@com_google_absl//absl/strings",
     ],
 )
 
@@ -50,7 +49,6 @@ tf_cc_test(
         "gcs_filesystem.cc",
         "gcs_filesystem_test.cc",
     ],
-    local_defines = ["TF_GCS_FILESYSTEM_TEST"],
     tags = [
         "manual",
         "notap",

--- a/tensorflow/c/experimental/filesystem/plugins/gcs/gcs_filesystem.h
+++ b/tensorflow/c/experimental/filesystem/plugins/gcs/gcs_filesystem.h
@@ -20,7 +20,7 @@
 #include "tensorflow/c/tf_status.h"
 
 void ParseGCSPath(const std::string& fname, bool object_empty_ok,
-                  std::string& bucket, std::string& object, TF_Status* status);
+                  std::string* bucket, std::string* object, TF_Status* status);
 
 namespace tf_gcs_filesystem {
 void Init(TF_Filesystem* filesystem, TF_Status* status);

--- a/tensorflow/c/experimental/filesystem/plugins/gcs/gcs_filesystem.h
+++ b/tensorflow/c/experimental/filesystem/plugins/gcs/gcs_filesystem.h
@@ -15,13 +15,12 @@
 #ifndef TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_PLUGINS_GCS_GCS_FILESYSTEM_H_
 #define TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_PLUGINS_GCS_GCS_FILESYSTEM_H_
 
-#include "absl/strings/string_view.h"
 #include "google/cloud/storage/client.h"
 #include "tensorflow/c/experimental/filesystem/filesystem_interface.h"
 #include "tensorflow/c/tf_status.h"
 
-void ParseGCSPath(absl::string_view fname, bool object_empty_ok, char** bucket,
-                  char** object, TF_Status* status);
+void ParseGCSPath(const std::string& fname, bool object_empty_ok,
+                  std::string& bucket, std::string& object, TF_Status* status);
 
 namespace tf_gcs_filesystem {
 void Init(TF_Filesystem* filesystem, TF_Status* status);

--- a/tensorflow/c/experimental/filesystem/plugins/gcs/gcs_filesystem_test.cc
+++ b/tensorflow/c/experimental/filesystem/plugins/gcs/gcs_filesystem_test.cc
@@ -43,9 +43,27 @@ class GCSFilesystemTest : public ::testing::Test {
   TF_Status* status_;
 };
 
-// We have to add this test here because there must be at least one test.
-// This test will be removed in the future.
-TEST_F(GCSFilesystemTest, TestInit) { ASSERT_TF_OK(status_); }
+TEST_F(GCSFilesystemTest, ParseGCSPath) {
+  std::string bucket, object;
+  ParseGCSPath("gs://bucket/path/to/object", false, bucket, object, status_);
+  ASSERT_TF_OK(status_);
+  ASSERT_EQ(bucket, "bucket");
+  ASSERT_EQ(object, "path/to/object");
+
+  ParseGCSPath("gs://bucket/", true, bucket, object, status_);
+  ASSERT_TF_OK(status_);
+  ASSERT_EQ(bucket, "bucket");
+
+  ParseGCSPath("bucket/path/to/object", false, bucket, object, status_);
+  ASSERT_EQ(TF_GetCode(status_), TF_INVALID_ARGUMENT);
+
+  // bucket name must end with "/"
+  ParseGCSPath("gs://bucket", true, bucket, object, status_);
+  ASSERT_EQ(TF_GetCode(status_), TF_INVALID_ARGUMENT);
+
+  ParseGCSPath("gs://bucket/", false, bucket, object, status_);
+  ASSERT_EQ(TF_GetCode(status_), TF_INVALID_ARGUMENT);
+}
 
 }  // namespace
 }  // namespace tensorflow

--- a/tensorflow/c/experimental/filesystem/plugins/gcs/gcs_filesystem_test.cc
+++ b/tensorflow/c/experimental/filesystem/plugins/gcs/gcs_filesystem_test.cc
@@ -45,23 +45,23 @@ class GCSFilesystemTest : public ::testing::Test {
 
 TEST_F(GCSFilesystemTest, ParseGCSPath) {
   std::string bucket, object;
-  ParseGCSPath("gs://bucket/path/to/object", false, bucket, object, status_);
+  ParseGCSPath("gs://bucket/path/to/object", false, &bucket, &object, status_);
   ASSERT_TF_OK(status_);
   ASSERT_EQ(bucket, "bucket");
   ASSERT_EQ(object, "path/to/object");
 
-  ParseGCSPath("gs://bucket/", true, bucket, object, status_);
+  ParseGCSPath("gs://bucket/", true, &bucket, &object, status_);
   ASSERT_TF_OK(status_);
   ASSERT_EQ(bucket, "bucket");
 
-  ParseGCSPath("bucket/path/to/object", false, bucket, object, status_);
+  ParseGCSPath("bucket/path/to/object", false, &bucket, &object, status_);
   ASSERT_EQ(TF_GetCode(status_), TF_INVALID_ARGUMENT);
 
   // bucket name must end with "/"
-  ParseGCSPath("gs://bucket", true, bucket, object, status_);
+  ParseGCSPath("gs://bucket", true, &bucket, &object, status_);
   ASSERT_EQ(TF_GetCode(status_), TF_INVALID_ARGUMENT);
 
-  ParseGCSPath("gs://bucket/", false, bucket, object, status_);
+  ParseGCSPath("gs://bucket/", false, &bucket, &object, status_);
   ASSERT_EQ(TF_GetCode(status_), TF_INVALID_ARGUMENT);
 }
 


### PR DESCRIPTION
@mihaimaruseac 
This PR use `std::string` instead of `char*` for `ParseGCSPath` and `tf_writable_file`