### PR TITLE
Relax SciPy pip requirement to >= 1.4.1

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -70,7 +70,7 @@ REQUIRED_PACKAGES = [
     'wheel >= 0.26',
     'six >= 1.12.0',
     # scipy < 1.4.1 causes segfaults due to pybind11
-    'scipy == 1.4.1',
+    'scipy >= 1.4.1',
 ]
 
 if sys.byteorder == 'little':


### PR DESCRIPTION
SciPy 1.5.0 is out now https://docs.scipy.org/doc/scipy/reference/release.1.5.0.html and I'd like to use it. As an interim, quick to apply solution, I've relaxed the constraint. Probably a better solution would be to remove the dependency altogether and handle the version conflict some other way: https://github.com/tensorflow/tensorflow/issues/35709