### PR TITLE
tf.function ensures type annotations and input_signature match

### DIFF
--- a/tensorflow/python/eager/def_function.py
+++ b/tensorflow/python/eager/def_function.py
@@ -22,7 +22,6 @@ from __future__ import print_function
 import functools
 import threading
 import weakref
-import typing
 import six
 
 from google.protobuf import text_format as _text_format
@@ -1192,7 +1191,8 @@ class Function(object):
     arg_to_dtype = dict(arg_dtype_list)
     type_annotations = self.function_spec.fullargspec.annotations
     for arg, annot in type_annotations.items():
-      if not hasattr(annot, '__args__'):
+      # Only verify annotations that are perameterized
+      if not hasattr(annot, '__args__') or len(annot.__args__) != 1:
         return
       annotation_dtype = annot.__args__[0]
       input_signature_dtype = arg_to_dtype.get(arg)
@@ -1202,7 +1202,7 @@ class Function(object):
       if annotation_dtype != input_signature_dtype.__class__:
         raise ValueError(
             "type mismatch for argument '%s': type annotation "\
-            "is %s, but input_signature is %s" %
+            "specifies %s, but input_signature specifies %s" %
             (arg, annotation_dtype.__name__,
              input_signature_dtype.__class__.__name__))
 

--- a/tensorflow/python/eager/def_function_test.py
+++ b/tensorflow/python/eager/def_function_test.py
@@ -922,11 +922,11 @@ class DefFunctionTest(test.TestCase, parameterized.TestCase):
       return x
     signature = [tensor_spec.TensorSpec(None, dtypes.int32),
                  tensor_spec.TensorSpec(None, dtypes.float32)]
-    def_function.function(f, input_signature=signature) # No error to be raised
+    def_function.function(f, input_signature=signature)  # No error to be raised
 
   def test_signature_validation_mismatched_type_annotation(self):
-    msg = "type mismatch for argument \'y\': type annotation is String, "\
-          "but input_signature is Float32"
+    msg = "type mismatch for argument \'y\': type annotation specifies "\
+          "String, but input_signature specifies Float32"
     with self.assertRaisesRegex(ValueError, msg):
       def f(x: ops.Tensor[dtypes.Int32], y: ops.Tensor[dtypes.String]):
         return x
@@ -940,8 +940,8 @@ class DefFunctionTest(test.TestCase, parameterized.TestCase):
     signature = [tensor_spec.TensorSpec(None, dtypes.int32)]
     def_function.function(f, input_signature=signature)
 
-    msg = "type mismatch for argument \'x\': type annotation is int, "\
-          "but input_signature is Int32"
+    msg = "type mismatch for argument \'x\': type annotation specifies "\
+          "int, but input_signature specifies Int32"
     with self.assertRaisesRegex(ValueError, msg):
       def g(x: ops.Tensor[int]):
         return x
@@ -956,8 +956,8 @@ class DefFunctionTest(test.TestCase, parameterized.TestCase):
     signature = [tensor_spec.TensorSpec(None, dtypes.float32)]
     def_function.function(f, input_signature=signature)
 
-    msg = "type mismatch for argument \'x\': type annotation is Float32, "\
-          "but input_signature is Int32"
+    msg = "type mismatch for argument \'x\': type annotation specifies "\
+          "Float32, but input_signature specifies Int32"
     with self.assertRaisesRegex(ValueError, msg):
       def g(x: type_annotation):
         return x

--- a/tensorflow/python/eager/def_function_test.py
+++ b/tensorflow/python/eager/def_function_test.py
@@ -917,36 +917,38 @@ class DefFunctionTest(test.TestCase, parameterized.TestCase):
     self.assertLen(logs.output, 1)
     self.assertIn('Tracing is expensive', logs.output[0])
 
-  def test_type_annotation_basic(self):
+  def test_signature_validation_basic(self):
     def f(x: ops.Tensor[dtypes.Int32], y: ops.Tensor[dtypes.Float32]):
       return x
     signature = [tensor_spec.TensorSpec(None, dtypes.int32),
                  tensor_spec.TensorSpec(None, dtypes.float32)]
-    def_function.function(f, input_signature=signature)
+    def_function.function(f, input_signature=signature) # No error to be raised
 
-  def test_mismatch_type_annotation(self):
-    msg = 'Type annotation does not match input_signature'
-    with self.assertRaisesRegexp(ValueError, msg):
+  def test_signature_validation_mismatched_type_annotation(self):
+    msg = "type mismatch for argument \'y\': type annotation is String, "\
+          "but input_signature is Float32"
+    with self.assertRaisesRegex(ValueError, msg):
       def f(x: ops.Tensor[dtypes.Int32], y: ops.Tensor[dtypes.String]):
         return x
       signature = [tensor_spec.TensorSpec(None, dtypes.int32),
                    tensor_spec.TensorSpec(None, dtypes.float32)]
       def_function.function(f, input_signature=signature)
 
-  def test_non_tensor_type_annotation(self):
+  def test_signature_validation_non_tensor_type_annotation(self):
     def f(x: int):
       return x
     signature = [tensor_spec.TensorSpec(None, dtypes.int32)]
     def_function.function(f, input_signature=signature)
 
-    msg = 'Type annotation does not match input_signature'
-    with self.assertRaisesRegexp(ValueError, msg):
+    msg = "type mismatch for argument \'x\': type annotation is int, "\
+          "but input_signature is Int32"
+    with self.assertRaisesRegex(ValueError, msg):
       def g(x: ops.Tensor[int]):
         return x
       signature = [tensor_spec.TensorSpec(None, dtypes.int32)]
       def_function.function(g, input_signature=signature)
 
-  def test_alias_type_annotation(self):
+  def test_signature_validation_alias_type_annotation(self):
     type_annotation = ops.Tensor[dtypes.Float32]
 
     def f(x: type_annotation):
@@ -954,8 +956,9 @@ class DefFunctionTest(test.TestCase, parameterized.TestCase):
     signature = [tensor_spec.TensorSpec(None, dtypes.float32)]
     def_function.function(f, input_signature=signature)
 
-    msg = 'Type annotation does not match input_signature'
-    with self.assertRaisesRegexp(ValueError, msg):
+    msg = "type mismatch for argument \'x\': type annotation is Float32, "\
+          "but input_signature is Int32"
+    with self.assertRaisesRegex(ValueError, msg):
       def g(x: type_annotation):
         return x
       signature = [tensor_spec.TensorSpec(None, dtypes.int32)]


### PR DESCRIPTION
The `input_signature` argument of `tf.function` allows users to specify the input dtypes of function arguments. 
Python type annotations for Tensors will contain the dtype of the Tensor.

These changes will allow `tf.function` to ensure that type annotations and `input_signature` match. When there is a mismatch, an error will be thrown. 

This is of particular importance to ensure forward compatibility, so that in the future we can switch from `input_signature` to type annotations without breaking existing code.

### Example
```python
@tf.function(input_signature=[tf.TensorSpec(None, dtype=tf.int32)])
def f(x: tf.Tensor[dtypes.Int32]):
  return x

@tf.function(input_signature=[tf.TensorSpec(None, dtype=tf.int32)])
def f(x: tf.Tensor[dtypes.String]): # Error! Type annotation does not match input_signature.
  return x

```