### PR TITLE
changed EarlyStopping so best weights are also loaded at the end of training

### DIFF
--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -1337,6 +1337,11 @@ class EarlyStopping(Callback):
   def on_train_end(self, logs=None):
     if self.stopped_epoch > 0 and self.verbose > 0:
       print('Epoch %05d: early stopping' % (self.stopped_epoch + 1))
+    if self.restore_best_weights:
+      if self.verbose > 0:
+        print('Restoring model weights from the end of the best epoch.')
+      self.model.set_weights(self.best_weights)
+
 
   def get_monitor_value(self, logs):
     logs = logs or {}

--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -1342,7 +1342,6 @@ class EarlyStopping(Callback):
         print('Restoring model weights from the end of the best epoch.')
       self.model.set_weights(self.best_weights)
 
-
   def get_monitor_value(self, logs):
     logs = logs or {}
     monitor_value = logs.get(self.monitor)


### PR DESCRIPTION
Hi,

I love using tf.keras.callbacks.EarlyStopping. But I also want the best weights to be loaded automatically at the end of the training, in addition to during training if `restore_best_weights=True`. Checking out the semantics from the documentation:

restore_best_weights | Whether to restore model weights from the epoch with the best value of the monitored quantity. If False, the model weights obtained at the last step of training are used.
-- | --

I think this PR more closely aligns with expected behavior vs. the current version. It's easy enough to make a version of EarlyStopping with this behavior, but I was pretty surprised that this wasn't the default so figured I'd make a PR.