### PR TITLE
Make ProgBarLogger, ModelCheckpoint and TensorBoard callbacks not use batch hooks when possible

### DIFF
--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -1235,6 +1235,10 @@ class ModelCheckpoint(Callback):
           raise ValueError('Error loading file from {}. Reason: {}'.format(
               filepath_to_load, e))
 
+  def _implements_train_batch_hooks(self):
+    # Only call batch hooks when saving on batch
+    return self.save_freq != 'epoch'
+
   def on_train_batch_end(self, batch, logs=None):
     if self._should_save_on_batch(batch):
       self._save_model(epoch=self._current_epoch, logs=logs)
@@ -2154,6 +2158,9 @@ class TensorBoard(Callback, version_utils.TensorBoardVersionSelector):
 
   def on_test_end(self, logs=None):
     self._pop_writer()
+
+  def _implements_train_batch_hooks(self):
+    return self._should_trace  # Only call batch hooks when tracing is enabled
 
   def on_train_batch_begin(self, batch, logs=None):
     self._global_train_batch += 1

--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -959,12 +959,15 @@ class ProgbarLogger(Callback):
   def on_test_begin(self, logs=None):
     if not self._called_in_fit:
       self._reset_progbar()
+      self._maybe_init_progbar()
 
   def on_predict_begin(self, logs=None):
     self._reset_progbar()
+    self._maybe_init_progbar()
 
   def on_epoch_begin(self, epoch, logs=None):
     self._reset_progbar()
+    self._maybe_init_progbar()
     if self.verbose and self.epochs > 1:
       print('Epoch %d/%d' % (epoch + 1, self.epochs))
 
@@ -1044,7 +1047,7 @@ class ProgbarLogger(Callback):
         if not self.use_steps:
           counter *= logs.get('size', 1)
       self.target = counter or self.seen
-    self._maybe_init_progbar()
+      self.progbar.target = self.target
     self.progbar.update(self.target, list(logs.items()), finalize=True)
 
 

--- a/tensorflow/python/keras/callbacks_test.py
+++ b/tensorflow/python/keras/callbacks_test.py
@@ -1704,6 +1704,19 @@ class KerasCallbacksTest(keras_parameterized.TestCase):
     self.assertEqual(my_cb.test_batches, 0)
     self.assertEqual(my_cb.predict_batches, 0)
 
+  @keras_parameterized.run_all_keras_modes(always_skip_v1=True)
+  def test_default_callbacks_do_not_call_batch_hooks(self):
+    model = keras.Sequential([keras.layers.Dense(1)])
+    log_dir = self.get_temp_dir()
+    cb_list = keras.callbacks.CallbackList([
+        keras.callbacks.TensorBoard(log_dir, profile_batch=0),
+        keras.callbacks.ModelCheckpoint(log_dir),
+        ], add_progbar=True, model=model, verbose=2, epochs=3)
+    self.assertLen(cb_list.callbacks, 3)
+    self.assertFalse(cb_list._should_call_train_batch_hooks)
+    self.assertFalse(cb_list._should_call_test_batch_hooks)
+    self.assertFalse(cb_list._should_call_predict_batch_hooks)
+
 
 # A summary that was emitted during a test. Fields:
 #   logdir: str. The logdir of the FileWriter to which the summary was

--- a/tensorflow/python/keras/callbacks_test.py
+++ b/tensorflow/python/keras/callbacks_test.py
@@ -2203,7 +2203,7 @@ class TestTensorBoardV2NonParameterizedTest(keras_parameterized.TestCase):
     model.compile('sgd', 'mse', run_eagerly=False)
     self.fitModelAndAssertKerasModelWritten(model)
 
-  def test_TensoriBoard_writeModel(self):
+  def test_TensorBoard_writeModel(self):
     inputs = keras.layers.Input([10, 10, 1])
     x = keras.layers.Conv2D(8, (3, 3), activation='relu')(inputs)
     x = keras.layers.Flatten()(x)


### PR DESCRIPTION
This PR changes the `ProgBarLogger`, `ModelCheckpoint` and `TensorBoard` callbacks to not use batch hooks when possible.

`ProgBarLogger` will now only require batch hooks if `verbose == 1` or the cardinality of the dataset cannot be determined in v1 execution. `ModelCheckpoint` will require batch hooks only if `save_freq != "epoch"` and `TensorBoard` only when profiling is enabled.

These changes may enable future optimizations where the entire epoch iteration in the training loop could be wrapped in a `tf.function` if no batch hooks need to be called:
https://github.com/tensorflow/tensorflow/blob/9b13f1b47fc97cb8b167d7fe5f1dc2277c85698d/tensorflow/python/keras/engine/training.py#L1089-L1103

The 2.3.0-rc0 release notes mention that `experimental_steps_per_execution` can result in up to 3x preformance improvements on TPUs. Unfortunately in my opinions the usablility of `experimental_steps_per_execution` is not really optimal since exposes too many implementation details to the user. I think it would be a lot nicer if performance optimizations like this could be done automatically for common use cases where only epoch level logging is required so users only need to care about `experimental_steps_per_execution` when requiring more customizability.
This PR is intended as a first step to explore if we can wrap the entire epoch iterations into a `tf.function` if no batch hooks need to be called, I am happy to explore this in a future PR.

This fixed `b/150629188`