### PR TITLE
Type annotations to improve the tracing process of tf.function

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -30,7 +30,8 @@
 *   `tf.keras`:
     * <ADD RELEASE NOTES HERE>
 *   `tf.function`/AutoGraph:
-    * <ADD RELEASE NOTES HERE>
+    * Added `experimental_follow_type_hints` argument. When True, the function may use type
+      annotations to optimize the tracing performance.
 *   `tf.lite`:
     * <ADD RELEASE NOTES HERE>
 *   `tf.random`:

--- a/tensorflow/python/eager/def_function.py
+++ b/tensorflow/python/eager/def_function.py
@@ -1414,9 +1414,10 @@ def function(func=None,
     experimental_compile: If True, the function is always compiled by
       [XLA](https://www.tensorflow.org/xla). XLA may be more efficient in some
       cases (e.g. TPU, XLA_GPU, dense tensor computations).
-    experimental_follow_type_hints: When True, the function may use type annotations
-      to optimize the tracing performance. For example, arguments annotated with
-      `tf.Tensor` will automatically be converted to a Tensor.
+    experimental_follow_type_hints: When True, the function may use type
+      annotations to optimize the tracing performance. For example,
+      arguments annotated with tf.Tensor` will automatically be converted
+      to a Tensor.
 
   Returns:
      If `func` is not None, returns a callable that will execute the compiled

--- a/tensorflow/python/eager/def_function.py
+++ b/tensorflow/python/eager/def_function.py
@@ -1416,7 +1416,7 @@ def function(func=None,
       cases (e.g. TPU, XLA_GPU, dense tensor computations).
     experimental_follow_type_hints: When True, the function may use type
       annotations to optimize the tracing performance. For example,
-      arguments annotated with tf.Tensor` will automatically be converted
+      arguments annotated with `tf.Tensor` will automatically be converted
       to a Tensor.
 
   Returns:

--- a/tensorflow/python/eager/def_function.py
+++ b/tensorflow/python/eager/def_function.py
@@ -456,7 +456,8 @@ class Function(object):
                experimental_implements=None,
                experimental_autograph_options=None,
                experimental_relax_shapes=False,
-               experimental_compile=None):
+               experimental_compile=None,
+               experimental_type_tracing=False):
     """Initializes a `Function`.
 
     Args:
@@ -512,6 +513,9 @@ class Function(object):
         executor). Set this value to `False` when directly running a
         multi-device function on TPUs (e.g. two TPU cores, one TPU core and its
         host CPU).
+      experimental_type_tracing: When true, arguments type annotated with
+        tf.TensorLike will be treated as if they were a tensor.
+
     Raises:
       ValueError: if `input_signature` is not None and the `python_function`'s
         argspec has keyword arguments.
@@ -519,7 +523,8 @@ class Function(object):
     self._lock = threading.Lock()
     self._python_function = python_function
     self._function_spec = function_lib.FunctionSpec.from_function_and_signature(
-        python_function, input_signature)
+        python_function, input_signature,
+        experimental_type_tracing=experimental_type_tracing)
     self._implements = experimental_implements
     # If `True`, the function uses the rendezvous of the parent. This is only
     # needed to support code where raw send/recv operations are inserted and
@@ -529,6 +534,7 @@ class Function(object):
     self._experimental_autograph_options = experimental_autograph_options
     self._experimental_relax_shapes = experimental_relax_shapes
     self._experimental_compile = experimental_compile
+    self._experimental_type_tracing = experimental_type_tracing
     self._created_variables = None  # GUARDED_BY(self._lock)
     self._stateful_fn = None  # GUARDED_BY(self._lock)
     self._stateless_fn = None  # GUARDED_BY(self._lock)
@@ -658,6 +664,7 @@ class Function(object):
         autograph=self._autograph,
         experimental_autograph_options=self._experimental_autograph_options,
         experimental_compile=self._experimental_compile,
+        experimental_type_tracing=self._experimental_type_tracing,
         experimental_relax_shapes=self._experimental_relax_shapes)
 
   def _initialize(self, args, kwds, add_initializers_to=None):
@@ -716,7 +723,8 @@ class Function(object):
         experimental_implements=self._implements,
         experimental_autograph_options=self._experimental_autograph_options,
         experimental_relax_shapes=self._experimental_relax_shapes,
-        experimental_compile=self._experimental_compile)
+        experimental_compile=self._experimental_compile,
+        experimental_type_tracing=self._experimental_type_tracing)
 
     if self._shared_rendezvous:
       f._shared_rendezvous = self._shared_rendezvous  # pylint: disable=protected-access
@@ -1203,7 +1211,8 @@ def function(func=None,
              experimental_implements=None,
              experimental_autograph_options=None,
              experimental_relax_shapes=False,
-             experimental_compile=None):
+             experimental_compile=None,
+             experimental_type_tracing=False):
   """Compiles a function into a callable TensorFlow graph.
 
   `tf.function` constructs a callable that executes a TensorFlow graph
@@ -1406,6 +1415,8 @@ def function(func=None,
     experimental_compile: If True, the function is always compiled by
       [XLA](https://www.tensorflow.org/xla). XLA may be more efficient in some
       cases (e.g. TPU, XLA_GPU, dense tensor computations).
+    experimental_type_tracing: When true, arguments type annotated with
+      tf.TensorLike will be treated as if they were a tensor.
 
   Returns:
      If `func` is not None, returns a callable that will execute the compiled
@@ -1436,7 +1447,8 @@ def function(func=None,
             experimental_autograph_options=experimental_autograph_options,
             experimental_relax_shapes=experimental_relax_shapes,
             experimental_compile=experimental_compile,
-            experimental_implements=experimental_implements))
+            experimental_implements=experimental_implements,
+            experimental_type_tracing=experimental_type_tracing))
 
   # This code path is for the `foo = tf.function(foo, ...)` use case
   if func is not None:

--- a/tensorflow/python/eager/def_function.py
+++ b/tensorflow/python/eager/def_function.py
@@ -1374,6 +1374,24 @@ def function(func=None,
   In general, it is recommended to create stateful objects like `tf.Variable`
   outside of `tf.function` and passing them as arguments.
 
+  _Using type annotations to improve performance_
+
+  'experimental_follow_type_hints` can be used along with type annotations to
+  improve performance by reducing the number of expensive graph retracings.
+  For example, an argument annotated with `tf.Tensor` is converted to Tensor
+  even when the input is a non-Tensor value.
+
+  >>> @tf.function(
+  ...     experimental_follow_type_hints=True)
+  ... def f(x: tf.Tensor):
+  ...   print('Tracing!')
+  ...   tf.print('Executing')
+  >>> f(1)
+  Tracing!
+  Executing
+  >>> f(2)
+  Executing
+
   Args:
     func: the function to be compiled. If `func` is None, `tf.function` returns
       a decorator that can be invoked with a single argument - `func`. In other

--- a/tensorflow/python/eager/def_function.py
+++ b/tensorflow/python/eager/def_function.py
@@ -1414,10 +1414,9 @@ def function(func=None,
     experimental_compile: If True, the function is always compiled by
       [XLA](https://www.tensorflow.org/xla). XLA may be more efficient in some
       cases (e.g. TPU, XLA_GPU, dense tensor computations).
-    experimental_follow_type_hints: When true, arguments type annotated with
-      tf.Tensor will be treated as if they were a tensor. This will avoid
-      unnecessary retracing and give a boost to the usability and performance
-      of `tf.function`.
+    experimental_follow_type_hints: When True, the function may use type annotations
+      to optimize the tracing performance. For example, arguments annotated with
+      `tf.Tensor` will automatically be converted to a Tensor.
 
   Returns:
      If `func` is not None, returns a callable that will execute the compiled

--- a/tensorflow/python/eager/function.py
+++ b/tensorflow/python/eager/function.py
@@ -2558,8 +2558,13 @@ class FunctionSpec(object):
     if self._fullargspec.varkw is not None:
       varkw_annotation = self._fullargspec.annotations.get(
           self._fullargspec.varkw)
-      if varkw_annotation == ops.Tensor:
-        kwargs = {kw: ops.convert_to_tensor(x) for kw, x in kwargs.items()}
+      for kw, v in kwargs.items():
+        if kw in self._fullargspec.args:
+          arg_annotation = self._fullargspec.annotations.get(kw)
+          if arg_annotation == ops.Tensor:
+            kwargs[kw] = ops.convert_to_tensor(v)
+        elif varkw_annotation == ops.Tensor:
+          kwargs[kw] = ops.convert_to_tensor(v)
 
     return tuple(args), kwargs
 

--- a/tensorflow/python/eager/function.py
+++ b/tensorflow/python/eager/function.py
@@ -2400,7 +2400,8 @@ class FunctionSpec(object):
 
     return FunctionSpec(
         fullargspec, is_method, input_signature,
-        is_pure=is_pure, experimental_follow_type_hints=experimental_follow_type_hints,
+        is_pure=is_pure,
+        experimental_follow_type_hints=experimental_follow_type_hints,
         name=name)
 
   def __init__(self,
@@ -2540,6 +2541,7 @@ class FunctionSpec(object):
 
     args = list(args)
     for i, arg in enumerate(args):
+      # See https://docs.python.org/3/library/inspect.html#inspect.getfullargspec for details on fullargspec
       if i < len(self._fullargspec.args):
         arg_annotation = self._fullargspec.annotations.get(
             self._fullargspec.args[i])

--- a/tensorflow/python/eager/function.py
+++ b/tensorflow/python/eager/function.py
@@ -74,7 +74,6 @@ from tensorflow.python.util import nest
 from tensorflow.python.util import object_identity
 from tensorflow.python.util import tf_decorator
 from tensorflow.python.util import tf_inspect
-from tensorflow.python.types import core as core_tf_types
 
 # Loaded lazily due to a circular dependency (roughly
 # tf.function->autograph->->dataset->tf.function).
@@ -2544,18 +2543,20 @@ class FunctionSpec(object):
       if i < len(self._fullargspec.args):
         arg_annotation = self._fullargspec.annotations.get(
             self._fullargspec.args[i])
-        if arg_annotation == core_tf_types.TensorLike:
+        # TODO(rahulkamat): Once TensorLike is ready, change the following conditional statements
+        # to check if the input arg is annotated with TensorLike
+        if arg_annotation == ops.Tensor:
           args[i] = ops.convert_to_tensor(arg)
       else:
         varargs_annotation = self._fullargspec.annotations.get(
             self._fullargspec.varargs)
-        if varargs_annotation == core_tf_types.TensorLike:
+        if varargs_annotation == ops.Tensor:
           args[i] = ops.convert_to_tensor(arg)
 
     if self._fullargspec.varkw is not None:
       varkw_annotation = self._fullargspec.annotations.get(
           self._fullargspec.varkw)
-      if varkw_annotation == core_tf_types.TensorLike:
+      if varkw_annotation == ops.Tensor:
         kwargs = {kw: ops.convert_to_tensor(x) for kw, x in kwargs.items()}
 
     return tuple(args), kwargs

--- a/tensorflow/python/eager/function_test.py
+++ b/tensorflow/python/eager/function_test.py
@@ -4063,6 +4063,20 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
     enabled(1, 2, 3, 4, 5, 100, a=1.0, b=2.0, c=3.0) # Retrace - change in *args
     self.assertEqual(trace_count[0], 3)
 
+  def testFollowTypeHintsTraceWithKwOnlyArgs(self):
+    trace_count = [0]
+    def func(x: ops.Tensor = 0, y: int = 1, **kwargs: ops.Tensor):
+      trace_count[0] += 1
+      return x
+
+    enabled = def_function.function(func, experimental_follow_type_hints=True)
+
+    enabled(x=1, y=2, z=3)
+    enabled(x=1, y=3, z=3) # Retrace - change in args
+    enabled(x=2, y=2, z=4) # No retrace - change in args and **kwargs
+    enabled(x=2, y=2, z=4, u=5) # Retrace - change in **kwargs
+    self.assertEqual(trace_count[0], 3)
+
 class MultiDeviceTest(test.TestCase, parameterized.TestCase):
 
   @test_util.run_gpu_only

--- a/tensorflow/python/eager/function_test.py
+++ b/tensorflow/python/eager/function_test.py
@@ -4011,7 +4011,7 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
 
   def testFollowTypeHintsTraceWithOnlyArgNamed(self):
     trace_count = [0]
-    def func(t: ops.Tensor, i: int = 1, **kwargs):
+    def func(t: ops.Tensor, i: int = 1, **kwargs):  # pylint: disable=bad-whitespace
       trace_count[0] += 1
       return t
 
@@ -4064,7 +4064,8 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
 
   def testFollowTypeHintsTraceWithArgsEquals(self):
     trace_count = [0]
-    def func(x: ops.Tensor = 0, y: int = 1, **kwargs: ops.Tensor):
+    def func(x: ops.Tensor = 0, y: int = 1,  # pylint: disable=bad-whitespace
+             **kwargs: ops.Tensor):
       trace_count[0] += 1
       return x
 
@@ -4108,7 +4109,7 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
 
   def testFollowTypeHintsTraceWithKwOnlyArgsBasic(self):
     trace_count = [0]
-    def func(*, a: ops.Tensor = None, b=1):
+    def func(*, a: ops.Tensor = None, b=1):  # pylint: disable=bad-whitespace
       trace_count[0] += 1
       return a
 

--- a/tensorflow/python/eager/function_test.py
+++ b/tensorflow/python/eager/function_test.py
@@ -4018,7 +4018,6 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
 
     enabled = def_function.function(func, experimental_follow_type_hints=True)
 
-    trace_count = [0]
     enabled(1, 3, x=4.0, y="str")
     enabled(2, 4, x=4.0, y="str") # Retrace
     self.assertEqual(trace_count[0], 2)
@@ -4045,7 +4044,6 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
 
     enabled = def_function.function(func, experimental_follow_type_hints=True)
 
-    trace_count = [0]
     enabled(1, 20, 3, 4, 5, 6)
     enabled(1, 20, 3, 4, 5, 60) # No retrace - change in *args
     enabled(1, 30, 7, 8, 9, 10) # Retrace - change in args
@@ -4059,7 +4057,6 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
 
     enabled = def_function.function(func, experimental_follow_type_hints=True)
 
-    trace_count = [0]
     enabled(1, 2, 3, 4, 5, 6, a=1.0, b=2.0, c=3.0)
     enabled(1, 2, 3, 4, 5, 6, a=1.5, b=2.5, c=3.5) # No retrace - change in **kwargs
     enabled(100, 2, 3, 4, 5, 6, a=1.0, b=2.0, c=3.0) # Retrace - change in args

--- a/tensorflow/python/eager/function_test.py
+++ b/tensorflow/python/eager/function_test.py
@@ -118,6 +118,7 @@ def _spec_for_value(value):
     return value
 
 
+
 class FunctionTest(test.TestCase, parameterized.TestCase):
 
   def setUp(self):
@@ -3937,8 +3938,8 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
       trace_count[0] += 1
       return x
 
-    enabled = def_function.function(func, experimental_type_tracing=True)
-    disabled = def_function.function(func, experimental_type_tracing=False)
+    enabled = def_function.function(func, experimental_follow_type_hints=True)
+    disabled = def_function.function(func, experimental_follow_type_hints=False)
 
     enabled(1) # Initial call gets traced
     enabled(2)
@@ -3957,8 +3958,8 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
       trace_count[0] += 1
       return args
 
-    enabled = def_function.function(func, experimental_type_tracing=True)
-    disabled = def_function.function(func, experimental_type_tracing=False)
+    enabled = def_function.function(func, experimental_follow_type_hints=True)
+    disabled = def_function.function(func, experimental_follow_type_hints=False)
 
     args = ("abc", "def",) * 20
     args2 = ("def", "abc",) * 20
@@ -3978,8 +3979,8 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
       trace_count[0] += 1
       return t
 
-    enabled = def_function.function(func, experimental_type_tracing=True)
-    disabled = def_function.function(func, experimental_type_tracing=False)
+    enabled = def_function.function(func, experimental_follow_type_hints=True)
+    disabled = def_function.function(func, experimental_follow_type_hints=False)
 
     enabled(1, x=1, y=1.0, z="one")
     enabled(2, x=2, y=2.0, z="two")
@@ -3997,8 +3998,8 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
       trace_count[0] += 1
       return t
 
-    enabled = def_function.function(func, experimental_type_tracing=True)
-    disabled = def_function.function(func, experimental_type_tracing=False)
+    enabled = def_function.function(func, experimental_follow_type_hints=True)
+    disabled = def_function.function(func, experimental_follow_type_hints=False)
 
     enabled(1, constant_op.constant(1), "str", x=4.0)
     enabled(2, constant_op.constant(2), "str2", x=5.0)

--- a/tensorflow/python/eager/function_test.py
+++ b/tensorflow/python/eager/function_test.py
@@ -118,7 +118,6 @@ def _spec_for_value(value):
     return value
 
 
-
 class FunctionTest(test.TestCase, parameterized.TestCase):
 
   def setUp(self):

--- a/tensorflow/python/eager/function_test.py
+++ b/tensorflow/python/eager/function_test.py
@@ -3940,15 +3940,15 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
     enabled = def_function.function(func, experimental_follow_type_hints=True)
     disabled = def_function.function(func, experimental_follow_type_hints=False)
 
-    enabled(1) # Initial call gets traced
+    enabled(1)  # Initial call gets traced
     enabled(2)
     enabled(3)
     self.assertEqual(trace_count[0], 1)
 
     trace_count = [0]
     disabled(1)
-    disabled(2) # Retrace
-    disabled(3) # Retrace
+    disabled(2)  # Retrace
+    disabled(3)  # Retrace
     self.assertEqual(trace_count[0], 3)
 
   def testFollowTypeHintsTraceWithArgs(self):
@@ -3969,7 +3969,7 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
 
     trace_count = [0]
     disabled(args)
-    disabled(args2) # Retrace
+    disabled(args2)  # Retrace
     self.assertEqual(trace_count[0], 2)
 
   def testFollowTypeHintsTraceWithKwargs(self):
@@ -3987,7 +3987,7 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
 
     trace_count = [0]
     disabled(1, x=1, y=1.0, z="one")
-    disabled(2, x=2, y=2.0, z="two") # Retrace
+    disabled(2, x=2, y=2.0, z="two")  # Retrace
     self.assertEqual(trace_count[0], 2)
 
   def testFollowTypeHintsTraceWithMultipleInputTypes(self):
@@ -4006,8 +4006,8 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
 
     trace_count = [0]
     disabled(1, constant_op.constant(1), "str", x=4.0)
-    disabled(2, constant_op.constant(2), "str2", x=5.0) # Retrace
-    self.assertEqual(trace_count[0], 2) # pylint: disable=bad-whitespace
+    disabled(2, constant_op.constant(2), "str2", x=5.0)  # Retrace
+    self.assertEqual(trace_count[0], 2)
 
   def testFollowTypeHintsTraceWithOnlyArgNamed(self):
     trace_count = [0]
@@ -4018,7 +4018,7 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
     enabled = def_function.function(func, experimental_follow_type_hints=True)
 
     enabled(1, 3, x=4.0, y="str")
-    enabled(2, 4, x=4.0, y="str") # Retrace
+    enabled(2, 4, x=4.0, y="str")  # Retrace
     self.assertEqual(trace_count[0], 2)
 
   def testFollowTypeHintsTraceWithNotAllNamed(self):
@@ -4030,9 +4030,9 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
     enabled = def_function.function(func, experimental_follow_type_hints=True)
 
     enabled(1, 2, 3)
-    enabled(1, 20, 3) # No retrace - change in ops.Tensor typed arg
-    enabled(2, 2, 3) # Retrace - change in untyped arg
-    enabled(2, 2, 4) # Retrace - change in typed arg
+    enabled(1, 20, 3)  # No retrace - change in ops.Tensor typed arg
+    enabled(2, 2, 3)  # Retrace - change in untyped arg
+    enabled(2, 2, 4)  # Retrace - change in typed arg
     self.assertEqual(trace_count[0], 3)
 
   def testFollowTypeHintsTraceWithOnlyArgsNamed(self):
@@ -4044,8 +4044,8 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
     enabled = def_function.function(func, experimental_follow_type_hints=True)
 
     enabled(1, 20, 3, 4, 5, 6)
-    enabled(1, 20, 3, 4, 5, 60) # No retrace - change in *args
-    enabled(1, 30, 7, 8, 9, 10) # Retrace - change in args
+    enabled(1, 20, 3, 4, 5, 60)  # No retrace - change in *args
+    enabled(1, 30, 7, 8, 9, 10)  # Retrace - change in args
     self.assertEqual(trace_count[0], 2)
 
   def testFollowTypeHintsTraceWithOnlyKwargsNamed(self):
@@ -4057,9 +4057,9 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
     enabled = def_function.function(func, experimental_follow_type_hints=True)
 
     enabled(1, 2, 3, 4, 5, 6, a=1.0, b=2.0, c=3.0)
-    enabled(1, 2, 3, 4, 5, 6, a=1.5, b=2.5, c=3.5) # No retrace - change in **kwargs
-    enabled(100, 2, 3, 4, 5, 6, a=1.0, b=2.0, c=3.0) # Retrace - change in args
-    enabled(1, 2, 3, 4, 5, 100, a=1.0, b=2.0, c=3.0) # Retrace - change in *args
+    enabled(1, 2, 3, 4, 5, 6, a=1.5, b=2.5, c=3.5)  # No retrace - change in **kwargs
+    enabled(100, 2, 3, 4, 5, 6, a=1.0, b=2.0, c=3.0)  # Retrace - change in args
+    enabled(1, 2, 3, 4, 5, 100, a=1.0, b=2.0, c=3.0)  # Retrace - change in *args
     self.assertEqual(trace_count[0], 3)
 
   def testFollowTypeHintsTraceWithArgsEquals(self):
@@ -4071,9 +4071,9 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
     enabled = def_function.function(func, experimental_follow_type_hints=True)
 
     enabled(x=1, y=2, z=3)
-    enabled(x=1, y=3, z=3) # Retrace - change in args
-    enabled(x=2, y=2, z=4) # No retrace - change in args and **kwargs
-    enabled(x=2, y=2, z=4, u=5) # Retrace - change in **kwargs
+    enabled(x=1, y=3, z=3)  # Retrace - change in args
+    enabled(x=2, y=2, z=4)  # No retrace - change in args and **kwargs
+    enabled(x=2, y=2, z=4, u=5)  # Retrace - change in **kwargs
     self.assertEqual(trace_count[0], 3)
 
   def testFollowTypeHintsTraceWithArgsEqualsTypedKwargs(self):
@@ -4085,10 +4085,10 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
     enabled = def_function.function(func, experimental_follow_type_hints=True)
 
     enabled(x=1, y=2, z=3)
-    enabled(x=1, y=3, z=3) # Retrace
-    enabled(x=1, y=2, z=4) # No retrace
-    enabled(x=2, y=2, z=4) # Retrace
-    enabled(x=2, y=2, z=4, u=5) # Retrace
+    enabled(x=1, y=3, z=3)  # Retrace
+    enabled(x=1, y=2, z=4)  # No retrace
+    enabled(x=2, y=2, z=4)  # Retrace
+    enabled(x=2, y=2, z=4, u=5)  # Retrace
     self.assertEqual(trace_count[0], 4)
 
   def testFollowTypeHintsTraceWithArgsEqualsTypedArgs(self):
@@ -4100,10 +4100,10 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
     enabled = def_function.function(func, experimental_follow_type_hints=True)
 
     enabled(x=1, y=2, z=3)
-    enabled(x=1, y=3, z=3) # Retrace
-    enabled(x=1, y=2, z=4) # Retrace
-    enabled(x=2, y=2, z=3) # No retrace
-    enabled(x=2, y=2, z=4, u=5) # Retrace
+    enabled(x=1, y=3, z=3)  # Retrace
+    enabled(x=1, y=2, z=4)  # Retrace
+    enabled(x=2, y=2, z=3)  # No retrace
+    enabled(x=2, y=2, z=4, u=5)  # Retrace
     self.assertEqual(trace_count[0], 4)
 
   def testFollowTypeHintsTraceWithKwOnlyArgsBasic(self):
@@ -4115,8 +4115,8 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
     enabled = def_function.function(func, experimental_follow_type_hints=True)
 
     enabled(a=1, b=2)
-    enabled(a=2, b=2) # No retrace
-    enabled(a=1, b=1) # Retrace
+    enabled(a=2, b=2)  # No retrace
+    enabled(a=1, b=1)  # Retrace
     self.assertEqual(trace_count[0], 2)
 
   def testFollowTypeHintsTraceWithArgsKwOnlyArgsKwargsAndTypedArg(self):
@@ -4128,11 +4128,11 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
     enabled = def_function.function(func, experimental_follow_type_hints=True)
 
     enabled(1, 2, 3, 4, kwonly=5, kwarg1=6, kwarg2=7)
-    enabled(100, 2, 3, 4, kwonly=5, kwarg1=6, kwarg2=7) # No retrace
-    enabled(1000, 2, 3, 4, kwonly=5, kwarg1=6, kwarg2=7) # No retrace
-    enabled(1, 20, 30, 40, kwonly=5, kwarg1=6, kwarg2=7) # Retrace
-    enabled(1, 2, 3, 4, kwonly=50, kwarg1=6, kwarg2=7) # Retrace
-    enabled(1, 2, 3, 4, kwonly=5, kwarg1=60, kwarg2=70) # Retrace
+    enabled(100, 2, 3, 4, kwonly=5, kwarg1=6, kwarg2=7)  # No retrace
+    enabled(1000, 2, 3, 4, kwonly=5, kwarg1=6, kwarg2=7)  # No retrace
+    enabled(1, 20, 30, 40, kwonly=5, kwarg1=6, kwarg2=7)  # Retrace
+    enabled(1, 2, 3, 4, kwonly=50, kwarg1=6, kwarg2=7)  # Retrace
+    enabled(1, 2, 3, 4, kwonly=5, kwarg1=60, kwarg2=70)  # Retrace
     self.assertEqual(trace_count[0], 4)
 
   def testFollowTypeHintsTraceWithArgsKwOnlyArgsKwargsAndTypedArgs(self):
@@ -4144,11 +4144,11 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
     enabled = def_function.function(func, experimental_follow_type_hints=True)
 
     enabled(1, 2, 3, 4, kwonly=5, kwarg1=6, kwarg2=7)
-    enabled(100, 2, 3, 4, kwonly=5, kwarg1=6, kwarg2=7) # Retrace
-    enabled(1, 20, 30, 40, kwonly=5, kwarg1=6, kwarg2=7) # No retrace
-    enabled(1, 200, 300, 400, kwonly=5, kwarg1=6, kwarg2=7) # No retrace
-    enabled(1, 2, 3, 4, kwonly=50, kwarg1=6, kwarg2=7) # Retrace
-    enabled(1, 2, 3, 4, kwonly=5, kwarg1=60, kwarg2=70) # Retrace
+    enabled(100, 2, 3, 4, kwonly=5, kwarg1=6, kwarg2=7)  # Retrace
+    enabled(1, 20, 30, 40, kwonly=5, kwarg1=6, kwarg2=7)  # No retrace
+    enabled(1, 200, 300, 400, kwonly=5, kwarg1=6, kwarg2=7)  # No retrace
+    enabled(1, 2, 3, 4, kwonly=50, kwarg1=6, kwarg2=7)  # Retrace
+    enabled(1, 2, 3, 4, kwonly=5, kwarg1=60, kwarg2=70)  # Retrace
     self.assertEqual(trace_count[0], 4)
 
   def testFollowTypeHintsTraceWithArgsKwOnlyArgsKwargsAndTypedKwOnlyArg(self):
@@ -4160,11 +4160,11 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
     enabled = def_function.function(func, experimental_follow_type_hints=True)
 
     enabled(1, 2, 3, 4, kwonly=5, kwarg1=6, kwarg2=7)
-    enabled(100, 2, 3, 4, kwonly=5, kwarg1=6, kwarg2=7) # Retrace
-    enabled(1, 20, 30, 40, kwonly=5, kwarg1=6, kwarg2=7) # Retrace
-    enabled(1, 2, 3, 4, kwonly=50, kwarg1=6, kwarg2=7) # No retrace
-    enabled(1, 2, 3, 4, kwonly=500, kwarg1=6, kwarg2=7) # No retrace
-    enabled(1, 2, 3, 4, kwonly=5, kwarg1=60, kwarg2=70) # Retrace
+    enabled(100, 2, 3, 4, kwonly=5, kwarg1=6, kwarg2=7)  # Retrace
+    enabled(1, 20, 30, 40, kwonly=5, kwarg1=6, kwarg2=7)  # Retrace
+    enabled(1, 2, 3, 4, kwonly=50, kwarg1=6, kwarg2=7)  # No retrace
+    enabled(1, 2, 3, 4, kwonly=500, kwarg1=6, kwarg2=7)  # No retrace
+    enabled(1, 2, 3, 4, kwonly=5, kwarg1=60, kwarg2=70)  # Retrace
     self.assertEqual(trace_count[0], 4)
 
   def testFollowTypeHintsTraceWithArgsKwOnlyArgsKwargsAndTypedKwargs(self):
@@ -4176,11 +4176,11 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
     enabled = def_function.function(func, experimental_follow_type_hints=True)
 
     enabled(1, 2, 3, 4, kwonly=5, kwarg1=6, kwarg2=7)
-    enabled(100, 2, 3, 4, kwonly=5, kwarg1=6, kwarg2=7) # Retrace
-    enabled(1, 20, 30, 40, kwonly=5, kwarg1=6, kwarg2=7) # Retrace
-    enabled(1, 2, 3, 4, kwonly=50, kwarg1=6, kwarg2=7) # Retrace
-    enabled(1, 2, 3, 4, kwonly=5, kwarg1=60, kwarg2=70) # No retrace
-    enabled(1, 2, 3, 4, kwonly=5, kwarg1=600, kwarg2=700) # No retrace
+    enabled(100, 2, 3, 4, kwonly=5, kwarg1=6, kwarg2=7)  # Retrace
+    enabled(1, 20, 30, 40, kwonly=5, kwarg1=6, kwarg2=7)  # Retrace
+    enabled(1, 2, 3, 4, kwonly=50, kwarg1=6, kwarg2=7)  # Retrace
+    enabled(1, 2, 3, 4, kwonly=5, kwarg1=60, kwarg2=70)  # No retrace
+    enabled(1, 2, 3, 4, kwonly=5, kwarg1=600, kwarg2=700)  # No retrace
     self.assertEqual(trace_count[0], 4)
 
 class MultiDeviceTest(test.TestCase, parameterized.TestCase):

--- a/tensorflow/python/eager/function_test.py
+++ b/tensorflow/python/eager/function_test.py
@@ -4008,7 +4008,7 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
     trace_count = [0]
     disabled(1, constant_op.constant(1), "str", x=4.0)
     disabled(2, constant_op.constant(2), "str2", x=5.0) # Retrace
-    self.assertEqual(trace_count[0], 2)
+    self.assertEqual(trace_count[0], 2) # pylint: disable=bad-whitespace
 
   def testFollowTypeHintsTraceWithOnlyArgNamed(self):
     trace_count = [0]

--- a/tensorflow/python/eager/function_test.py
+++ b/tensorflow/python/eager/function_test.py
@@ -80,7 +80,6 @@ from tensorflow.python.ops.ragged import ragged_tensor
 from tensorflow.python.ops.structured import structured_tensor
 from tensorflow.python.platform import test
 from tensorflow.python.training import training_ops
-from tensorflow.python.types import core as core_tf_types
 from tensorflow.python.util import compat
 from tensorflow.python.util import nest
 from tensorflow.python.util import tf_inspect
@@ -3934,7 +3933,7 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
 
   def testTraceWithAnnotationsBasic(self):
     trace_count = [0]
-    def func(x: core_tf_types.TensorLike):
+    def func(x: ops.Tensor):
       trace_count[0] += 1
       return x
 
@@ -3954,7 +3953,7 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
 
   def testTraceWithAnnotationsWithArgs(self):
     trace_count = [0]
-    def func(*args: core_tf_types.TensorLike):
+    def func(*args: ops.Tensor):
       trace_count[0] += 1
       return args
 
@@ -3975,7 +3974,7 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
 
   def testTraceWithAnnotationsWithKwargs(self):
     trace_count = [0]
-    def func(t: core_tf_types.TensorLike, **kwargs: core_tf_types.TensorLike):
+    def func(t: ops.Tensor, **kwargs: ops.Tensor):
       trace_count[0] += 1
       return t
 
@@ -3993,8 +3992,8 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
 
   def testTraceWithAnnotationsWithMultipleInputTypes(self):
     trace_count = [0]
-    def func(t: core_tf_types.TensorLike, *args: core_tf_types.TensorLike,
-             **kwargs: core_tf_types.TensorLike):
+    def func(t: ops.Tensor, *args: ops.Tensor,
+             **kwargs: ops.Tensor):
       trace_count[0] += 1
       return t
 

--- a/tensorflow/python/types/core.py
+++ b/tensorflow/python/types/core.py
@@ -18,8 +18,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from typing import Union
-from tensorflow.python.util.tf_export import tf_export
 
 # TODO(mdan): Consider adding ABC once the dependence on isinstance is reduced.
 # TODO(mdan): Add type annotations.
@@ -60,6 +58,3 @@ class Value(Tensor):
 
   def numpy(self):
     pass
-
-# TODO(rahulkamat): add complete set of types to TensorLike and add tf.export
-TensorLike = Union[Tensor, int, float, bool, str, tuple]

--- a/tensorflow/python/types/core.py
+++ b/tensorflow/python/types/core.py
@@ -18,6 +18,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from typing import Union
+from tensorflow.python.util.tf_export import tf_export
 
 # TODO(mdan): Consider adding ABC once the dependence on isinstance is reduced.
 # TODO(mdan): Add type annotations.
@@ -58,3 +60,6 @@ class Value(Tensor):
 
   def numpy(self):
     pass
+
+# TODO(rahulkamat): add complete set of types to TensorLike and add tf.export
+TensorLike = Union[Tensor, int, float, bool, str, tuple]

--- a/tensorflow/tools/api/golden/v1/tensorflow.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.pbtxt
@@ -1338,7 +1338,7 @@ tf_module {
   }
   member_method {
     name: "function"
-    argspec: "args=[\'func\', \'input_signature\', \'autograph\', \'experimental_implements\', \'experimental_autograph_options\', \'experimental_relax_shapes\', \'experimental_compile\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'True\', \'None\', \'None\', \'False\', \'None\'], "
+    argspec: "args=[\'func\', \'input_signature\', \'autograph\', \'experimental_implements\', \'experimental_autograph_options\', \'experimental_relax_shapes\', \'experimental_compile\', \'experimental_follow_type_hints\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'True\', \'None\', \'None\', \'False\', \'None\', \'False\'], "
   }
   member_method {
     name: "gather"

--- a/tensorflow/tools/api/golden/v2/tensorflow.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.pbtxt
@@ -670,7 +670,7 @@ tf_module {
   }
   member_method {
     name: "function"
-    argspec: "args=[\'func\', \'input_signature\', \'autograph\', \'experimental_implements\', \'experimental_autograph_options\', \'experimental_relax_shapes\', \'experimental_compile\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'True\', \'None\', \'None\', \'False\', \'None\'], "
+    argspec: "args=[\'func\', \'input_signature\', \'autograph\', \'experimental_implements\', \'experimental_autograph_options\', \'experimental_relax_shapes\', \'experimental_compile\', \'experimental_follow_type_hints\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'True\', \'None\', \'None\', \'False\', \'None\', \'False\'], "
   }
   member_method {
     name: "gather"


### PR DESCRIPTION
Users can express that a function argument should be treated as a Tensor using `tf.Tensor` as the type annotation.

Specify `experimental_follow_type_hints=True` in `tf.function` to limit tracing and give a boost to the usability and performance of `tf.function`.

### Usage
With `experimental_follow_type_hints=True` 
```python
@tf.function(experimental_follow_type_hints=True)
def f(x: tf.Tensor):
 return x

f(1)
f(2) # Function is not retraced
```
With `experimental_follow_type_hints=False` which is the default.
```python
@tf.function
def f(x):
 return x

f(1)
f(2) # Function is retraced
```