### PR TITLE
Make Tensor a generic class

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,9 @@
 # Release 2.4.0
 
-<INSERT SMALL BLURB ABOUT RELEASE FOCUS AREA AND POTENTIAL TOOLCHAIN CHANGES>
+* `tf.Tensor` is now a subclass of `typing.Generic`, allowing type
+  annotations to be parameterized by dtype: `tf.Tensor[tf.Int32]`.
+  This requires Python 3, and will become fully compatible with
+  static type checkers in the future.
 
 ## Breaking Changes
 

--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -254,24 +254,18 @@ def disable_tensor_equality():
   Tensor._USE_EQUALITY = False  # pylint: disable=protected-access
 
 
-DataType = TypeVar("DataType",
-                   dtypes.Float16, dtypes.Float32, dtypes.Float64,
-                   dtypes.BFloat16, dtypes.Complex64, dtypes.Complex128,
-                   dtypes.Int8, dtypes.UInt8, dtypes.UInt16,
-                   dtypes.UInt32, dtypes.UInt64, dtypes.Int16,
-                   dtypes.Int32, dtypes.Int64, dtypes.Bool,
-                   dtypes.String, dtypes.QInt8, dtypes.QUInt8,
-                   dtypes.QInt16, dtypes.QUInt16, dtypes.QInt32,
-                   dtypes.Resource, dtypes.Variant)
+DataType = TypeVar("DataType", bound=dtypes.DType)
 
+# TODO(rahulkamat): Remove this and make Tensor a generic class
+# once compatibility with Python 2 is dropped.
 if sys.version_info[0] >= 3:
-  GenericTensor = Generic[DataType]
+  TensorTypeBase = Generic[DataType]
 else:
-  GenericTensor = object
+  TensorTypeBase = object
 
 # TODO(mdan): This object should subclass Symbol, not just Tensor.
 @tf_export("Tensor")
-class Tensor(internal.NativeObject, core_tf_types.Tensor, GenericTensor):
+class Tensor(internal.NativeObject, core_tf_types.Tensor, TensorTypeBase):
   """A tensor is a multidimensional array of elements represented by a
 
   `tf.Tensor` object.  All elements are of a single known data type.

--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -24,6 +24,7 @@ import sys
 import threading
 import types
 
+from typing import Generic, TypeVar
 import numpy as np
 import six
 from six.moves import map  # pylint: disable=redefined-builtin
@@ -253,9 +254,24 @@ def disable_tensor_equality():
   Tensor._USE_EQUALITY = False  # pylint: disable=protected-access
 
 
+DataType = TypeVar("DataType",
+                   dtypes.Float16, dtypes.Float32, dtypes.Float64,
+                   dtypes.BFloat16, dtypes.Complex64, dtypes.Complex128,
+                   dtypes.Int8, dtypes.UInt8, dtypes.UInt16,
+                   dtypes.UInt32, dtypes.UInt64, dtypes.Int16,
+                   dtypes.Int32, dtypes.Int64, dtypes.Bool,
+                   dtypes.String, dtypes.QInt8, dtypes.QUInt8,
+                   dtypes.QInt16, dtypes.QUInt16, dtypes.QInt32,
+                   dtypes.Resource, dtypes.Variant)
+
+if sys.version_info[0] >= 3:
+  GenericTensor = Generic[DataType]
+else:
+  GenericTensor = object
+
 # TODO(mdan): This object should subclass Symbol, not just Tensor.
 @tf_export("Tensor")
-class Tensor(internal.NativeObject, core_tf_types.Tensor):
+class Tensor(internal.NativeObject, core_tf_types.Tensor, GenericTensor):
   """A tensor is a multidimensional array of elements represented by a
 
   `tf.Tensor` object.  All elements are of a single known data type.

--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -263,6 +263,7 @@ if sys.version_info[0] >= 3:
 else:
   TensorTypeBase = object
 
+
 # TODO(mdan): This object should subclass Symbol, not just Tensor.
 @tf_export("Tensor")
 class Tensor(internal.NativeObject, core_tf_types.Tensor, TensorTypeBase):

--- a/tensorflow/tools/api/golden/v1/tensorflow.-tensor.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.-tensor.pbtxt
@@ -3,7 +3,7 @@ tf_class {
   is_instance: "<class \'tensorflow.python.framework.ops.Tensor\'>"
   is_instance: "<class \'tensorflow.python.types.internal.NativeObject\'>"
   is_instance: "<class \'tensorflow.python.types.core.Tensor\'>"
-  is_instance: "<type \'object\'>"
+  is_instance: "<class \'typing.Generic\'>"
   member {
     name: "OVERLOADABLE_OPERATORS"
     mtype: "<type \'set\'>"

--- a/tensorflow/tools/api/golden/v2/tensorflow.-tensor.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.-tensor.pbtxt
@@ -3,7 +3,7 @@ tf_class {
   is_instance: "<class \'tensorflow.python.framework.ops.Tensor\'>"
   is_instance: "<class \'tensorflow.python.types.internal.NativeObject\'>"
   is_instance: "<class \'tensorflow.python.types.core.Tensor\'>"
-  is_instance: "<type \'object\'>"
+  is_instance: "<class \'typing.Generic\'>"
   member {
     name: "OVERLOADABLE_OPERATORS"
     mtype: "<type \'set\'>"


### PR DESCRIPTION
Define a version-specific base class which allows `Tensor` type annotations to be parameterized by `DType` in Python 3.

#### Examples

Valid in Python 3 only:
```python
def foo(t: tf.Tensor[tf.Float32]):
  return t
```

Valid in Python 2 (if parser allows type annotations):
```python
def foo(t: tf.Tensor):
  return t
```
