### PR TITLE
tf.TensorLike

### DIFF
--- a/tensorflow/python/types/core.py
+++ b/tensorflow/python/types/core.py
@@ -64,5 +64,6 @@ class Value(Tensor):
     pass
 
 
-TensorLike = Union[Tensor, int, float, bool, str, complex, tuple, list, np.ndarray]
+TensorLike = Union[Tensor, int, float, bool, str, complex, tuple, list,
+                   np.ndarray]
 tf_export("experimental.TensorLike").export_constant(__name__, "TensorLike")

--- a/tensorflow/python/types/core.py
+++ b/tensorflow/python/types/core.py
@@ -64,5 +64,5 @@ class Value(Tensor):
     pass
 
 
-TensorLike = Union[Tensor, int, float, bool, str, tuple, list, np.ndarray]
-tf_export("TensorLike").export_constant(__name__, "TensorLike")
+TensorLike = Union[Tensor, int, float, bool, str, complex, tuple, list, np.ndarray]
+tf_export("experimental.TensorLike").export_constant(__name__, "TensorLike")

--- a/tensorflow/python/types/core.py
+++ b/tensorflow/python/types/core.py
@@ -64,6 +64,7 @@ class Value(Tensor):
     pass
 
 
+# TODO(rahulkamat): Add missing types that are convertible to tensor
 TensorLike = Union[Tensor, int, float, bool, str, complex, tuple, list,
                    np.ndarray]
 tf_export("experimental.TensorLike").export_constant(__name__, "TensorLike")

--- a/tensorflow/python/types/core.py
+++ b/tensorflow/python/types/core.py
@@ -18,6 +18,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from typing import Union
+import numpy as np
+
+from tensorflow.python.util.tf_export import tf_export
 
 # TODO(mdan): Consider adding ABC once the dependence on isinstance is reduced.
 # TODO(mdan): Add type annotations.
@@ -58,3 +62,7 @@ class Value(Tensor):
 
   def numpy(self):
     pass
+
+
+TensorLike = Union[Tensor, int, float, bool, str, tuple, list, np.ndarray]
+tf_export("TensorLike").export_constant(__name__, "TensorLike")

--- a/tensorflow/tools/api/golden/v1/tensorflow.experimental.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.experimental.pbtxt
@@ -4,6 +4,10 @@ tf_module {
     name: "Optional"
     mtype: "<type \'type\'>"
   }
+  member {
+    name: "TensorLike"
+    mtype: "<class \'typing._GenericAlias\'>"
+  }
   member_method {
     name: "async_clear_error"
     argspec: "args=[], varargs=None, keywords=None, defaults=None"

--- a/tensorflow/tools/api/golden/v2/tensorflow.experimental.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.experimental.pbtxt
@@ -5,6 +5,10 @@ tf_module {
     mtype: "<type \'type\'>"
   }
   member {
+    name: "TensorLike"
+    mtype: "<class \'typing._GenericAlias\'>"
+  }
+  member {
     name: "dlpack"
     mtype: "<type \'module\'>"
   }


### PR DESCRIPTION
Define `tf.TensorLike` to be a Union of all types which have a registered Tensor conversion function.

Use tf.TensorLike to annotate function arguments and treat them as if they were a tensor.

### Examples
Using `tf.TensorLike` to annotate function arguments:
```python
def foo(t: tf.TensorLike):
  return t

x = foo(1) # x = tf.Tensor(1, shape=(), dtype=int32)
```

Without `tf.TensorLike` annotation:
```python
def foo(t):
  return t

x = foo(1) # x = 1
```

Note: The input will not actually be converted to a Tensor, but using `tf.TensorLike` will allow input to be defined as a Tensor.