### PR TITLE
fix nvcc compiler-options

### DIFF
--- a/third_party/gpus/crosstool/windows/msvc_wrapper_for_nvcc.py.tpl
+++ b/third_party/gpus/crosstool/windows/msvc_wrapper_for_nvcc.py.tpl
@@ -158,7 +158,7 @@ def InvokeNvcc(argv, log=False):
   nvccopts += defines
   nvccopts += m_options
   nvccopts += fatbin_options
-  nvccopts += ['--compiler-options="' + " ".join(host_compiler_options) + '"']
+  nvccopts += ['--compiler-options=' + ",".join(host_compiler_options)]
   nvccopts += ['-x', 'cu'] + opt + includes + out + ['-c'] + src_files
   # Specify a unique temp directory for nvcc to generate intermediate files,
   # then Bazel can ignore files under NVCC_TEMP_DIR during dependency check


### PR DESCRIPTION
ref. https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/#options-for-passing-specific-phase-options-compiler-options

The host compiler parameter should be separated by commas instead of spaces.