### PR TITLE
Don't call Graph.control_dependencies() when inside v2 tf.functions

### DIFF
--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -5352,7 +5352,7 @@ def control_dependencies(control_inputs):
    A context manager that specifies control dependencies for all
    operations constructed within the context.
   """
-  if context.executing_eagerly():
+  if executing_eagerly_outside_functions():
     if control_inputs:
       # Execute any pending callables.
       for control in control_inputs:


### PR DESCRIPTION
As discussed in https://github.com/tensorflow/tensorflow/pull/40564#issuecomment-652060166 `control_dependencies` should not be necessary when using `tf.function` in eager mode.

/cc @alextp 