### PR TITLE
[tf.data] Add SkipNext interface to iterator

### DIFF
--- a/tensorflow/core/framework/dataset.cc
+++ b/tensorflow/core/framework/dataset.cc
@@ -501,9 +501,24 @@ Status DatasetBaseIterator::Skip(IteratorContext* ctx, int num_to_skip,
   profiler::TraceMe activity([&] { return BuildTraceMeName(); },
                              profiler::TraceMeLevel::kInfo);
   DVLOG(3) << prefix() << " Skip enter";
-  RecordStart(ctx, /*stop_output=*/true);
+  auto model = ctx->model();
+  if (model && model->collect_resource_usage() && node_) {
+    int64 now_nanos = EnvTime::NowNanos();
+    auto output = node_->output();
+    if (output) {
+      output->record_stop(now_nanos);
+    }
+    node_->record_start(now_nanos);
+  }
   Status s = SkipInternal(ctx, num_to_skip, end_of_sequence, num_skipped);
-  RecordStop(ctx, /*start_output=*/true);
+  if (model && model->collect_resource_usage() && node_) {
+    int64 now_nanos = EnvTime::NowNanos();
+    node_->record_stop(now_nanos);
+    auto output = node_->output();
+    if (output) {
+      output->record_start(now_nanos);
+    }
+  }
   if (TF_PREDICT_FALSE(errors::IsOutOfRange(s))) {
     s = errors::Internal("Iterator \"", params_.prefix,
                          "\" returned `OutOfRange`. This indicates an "

--- a/tensorflow/core/framework/dataset.h
+++ b/tensorflow/core/framework/dataset.h
@@ -592,6 +592,8 @@ class IteratorBase {
     return GetNext(&ctx, out_tensors, end_of_sequence);
   }
 
+  virtual Status SkipNext(IteratorContext* ctx, bool* end_of_sequence) = 0;
+
   // Returns a vector of DataType values, representing the respective
   // element types of each tuple component in the outputs of this
   // iterator.
@@ -895,6 +897,8 @@ class DatasetBaseIterator : public IteratorBase {
     return GetNext(&ctx, out_tensors, end_of_sequence);
   }
 
+  Status SkipNext(IteratorContext* ctx, bool* end_of_sequence) final;
+
   Status Save(SerializationContext* ctx, IteratorStateWriter* writer) final {
     return IteratorBase::Save(ctx, writer);
   }
@@ -904,6 +908,8 @@ class DatasetBaseIterator : public IteratorBase {
   virtual Status GetNextInternal(IteratorContext* ctx,
                                  std::vector<Tensor>* out_tensors,
                                  bool* end_of_sequence) = 0;
+
+  virtual Status SkipNextInternal(IteratorContext* ctx, bool* end_of_sequence);
 
   string full_name(const string& name) const {
     if (str_util::StrContains(name, kColon)) {

--- a/tensorflow/core/kernels/data/shard_dataset_op.cc
+++ b/tensorflow/core/kernels/data/shard_dataset_op.cc
@@ -123,6 +123,7 @@ class ShardDatasetOp::Dataset : public DatasetBase {
                            bool* end_of_sequence) override {
       mutex_lock l(mu_);
 
+      *end_of_sequence = false;
       if (!input_impl_) {
         *end_of_sequence = true;
         return Status::OK();

--- a/tensorflow/core/kernels/data/skip_dataset_op.cc
+++ b/tensorflow/core/kernels/data/skip_dataset_op.cc
@@ -140,14 +140,8 @@ class SkipDatasetOp::Dataset : public DatasetBase {
         return Status::OK();
       }
 
-      // Keep calling GetNext().  TODO(vrv): Figure out a way to
-      // skip records without reading, perhaps by adding an
-      // interface to iterator.
       while (i_ < dataset()->count_) {
-        // Fetch and throw away Tensors.
-        std::vector<Tensor> dummy_out_tensors;
-        TF_RETURN_IF_ERROR(
-            input_impl_->GetNext(ctx, &dummy_out_tensors, end_of_sequence));
+        TF_RETURN_IF_ERROR(input_impl_->SkipNext(ctx, end_of_sequence));
         if (*end_of_sequence) {
           // We reached the end before the count was reached.
           input_impl_.reset();

--- a/tensorflow/core/kernels/data/skip_dataset_op.cc
+++ b/tensorflow/core/kernels/data/skip_dataset_op.cc
@@ -140,15 +140,17 @@ class SkipDatasetOp::Dataset : public DatasetBase {
         return Status::OK();
       }
 
-      while (i_ < dataset()->count_) {
-        TF_RETURN_IF_ERROR(input_impl_->SkipNext(ctx, end_of_sequence));
+      if (i_ < dataset()->count_) {
+        int num_skipped;
+        TF_RETURN_IF_ERROR(
+            input_impl_->Skip(ctx, dataset()->count_ - i_, end_of_sequence,
+                              &num_skipped));
+        i_ += num_skipped;
         if (*end_of_sequence) {
           // We reached the end before the count was reached.
           input_impl_.reset();
           return Status::OK();
         }
-
-        ++i_;
       }
 
       // Return GetNext() on the underlying iterator.


### PR DESCRIPTION
This is a PR from JIZHI, the AI platform in Tencent.

This pr adds a `SkipNext` interface to `IteratorBase` and use this method in `SkipDatasetOp` and `ShardDatasetOp`.

If this interface is added, we can gradually implement it for all dataset ops so that some unnecesscary calculation can be avoided.

Thank you for your time on reviewing this pr.