### PR TITLE
Correctly handle resource variables in control_dependencies

### DIFF
--- a/tensorflow/python/framework/func_graph.py
+++ b/tensorflow/python/framework/func_graph.py
@@ -187,7 +187,7 @@ class FuncGraph(ops.Graph):
     self.inputs = []
     self.outputs = []
     self.control_outputs = []
-    self.control_captures = set()
+    self.control_captures = object_identity.ObjectIdentitySet()
     self.structured_input_signature = None
     self.structured_outputs = None
     self._weak_variables = []
@@ -347,7 +347,7 @@ class FuncGraph(ops.Graph):
     for c in control_inputs:
       # Check for _UnreadVariable
       if (isinstance(c, ops.IndexedSlices) or
-          (hasattr(c, "_handle") and hasattr(c, "op"))):
+          (resource_variable_ops.is_resource_variable(c) and hasattr(c, "op"))):
         c = c.op
       graph_element = ops._as_graph_element(c)  # pylint: disable=protected-access
       if graph_element is None:

--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -4737,6 +4737,10 @@ class Graph(object):
     """
     if control_inputs is None:
       return self._ControlDependenciesController(self, None)
+
+    # Imported here to avoid circular dependency.
+    from tensorflow.python.ops import resource_variable_ops  # pylint: disable=g-import-not-at-top
+
     # First convert the inputs to ops, and deduplicate them.
     # NOTE(mrry): Other than deduplication, we do not currently track direct
     #   or indirect dependencies between control_inputs, which may result in
@@ -4748,7 +4752,7 @@ class Graph(object):
       # control dependencies on a variable or on an unread variable don't
       # trigger reads.
       if (isinstance(c, IndexedSlices) or
-          (hasattr(c, "_handle") and hasattr(c, "op"))):
+          (resource_variable_ops.is_resource_variable(c) and hasattr(c, "op"))):
         c = c.op
       c = self.as_graph_element(c)
       if isinstance(c, Tensor):


### PR DESCRIPTION
This PR includes the `FuncGraph` changes required to rollforward #40564 and fixes handling of resource variables as input to control dependencies.

/cc @alextp @crccw