### PR TITLE
[TFLite, 16x8] Quantization 16x8, fix for inference_input(output)_type

### DIFF
--- a/tensorflow/lite/python/lite.py
+++ b/tensorflow/lite/python/lite.py
@@ -202,7 +202,9 @@ class QuantizationMode(object):
   def is_post_training_integer_quantize(self):
     """Post training integer quantization."""
     return (self.post_training_int8_no_float() or
-            self.post_training_int8_allow_float())
+            self.post_training_int8_allow_float() or
+            self.post_training_int16x8_no_float() or
+            self.post_training_int16x8_allow_float())
 
   def training_time_int8_allow_float(self):
     """Training-time int8 quantize, allow float fallback."""
@@ -556,7 +558,7 @@ class TFLiteConverterBaseV2(TFLiteConverterBase):
     # We only support integer types for post training integer quantization
     # as we have statistical information to quantize the input and output.
     if quant_mode.is_post_training_integer_quantize():
-      all_types = default_types + [constants.INT8, constants.QUANTIZED_UINT8]
+      all_types = default_types + [constants.INT8, constants.INT16, constants.QUANTIZED_UINT8]
       if self.inference_input_type not in all_types or \
           self.inference_output_type not in all_types:
         all_types_names = ["tf." + t.name for t in all_types]

--- a/tensorflow/lite/python/lite.py
+++ b/tensorflow/lite/python/lite.py
@@ -558,7 +558,7 @@ class TFLiteConverterBaseV2(TFLiteConverterBase):
     # We only support integer types for post training integer quantization
     # as we have statistical information to quantize the input and output.
     if quant_mode.is_post_training_integer_quantize():
-      all_types = default_types + [constants.INT8, constants.INT16, constants.QUANTIZED_UINT8]
+      all_types = default_types + [constants.INT8, constants.QUANTIZED_UINT8, constants.INT16]
       if self.inference_input_type not in all_types or \
           self.inference_output_type not in all_types:
         all_types_names = ["tf." + t.name for t in all_types]

--- a/tensorflow/lite/python/lite.py
+++ b/tensorflow/lite/python/lite.py
@@ -569,10 +569,12 @@ class TFLiteConverterBaseV2(TFLiteConverterBase):
         raise ValueError("The inference_input_type and inference_output_type "
                          "must be in {}.".format(all_types_names))
     elif quant_mode.is_post_training_integer_quantize_16x8():
-      if self.inference_input_type != constants.INT16 or \
-          self.inference_output_type != constants.INT16:
+      all_types = default_types + [constants.INT16]
+      if self.inference_input_type not in all_types or \
+          self.inference_output_type not in all_types:
+        all_types_names = ["tf." + t.name for t in all_types]
         raise ValueError("The inference_input_type and inference_output_type "
-                         "must be constants.INT16.")
+                         "must be in {}.".format(all_types_names))
     elif self.inference_input_type not in default_types or \
         self.inference_output_type not in default_types:
       raise ValueError("The inference_input_type and inference_output_type "

--- a/tensorflow/lite/python/lite.py
+++ b/tensorflow/lite/python/lite.py
@@ -558,7 +558,8 @@ class TFLiteConverterBaseV2(TFLiteConverterBase):
     # We only support integer types for post training integer quantization
     # as we have statistical information to quantize the input and output.
     if quant_mode.is_post_training_integer_quantize():
-      all_types = default_types + [constants.INT8, constants.QUANTIZED_UINT8, constants.INT16]
+      all_types = default_types + [constants.INT8, constants.QUANTIZED_UINT8,\
+        constants.INT16]
       if self.inference_input_type not in all_types or \
           self.inference_output_type not in all_types:
         all_types_names = ["tf." + t.name for t in all_types]

--- a/tensorflow/lite/python/lite_v2_test.py
+++ b/tensorflow/lite/python/lite_v2_test.py
@@ -73,7 +73,8 @@ class FromConcreteFunctionTest(lite_v2_test_util.ModelTest):
 
   @parameterized.named_parameters(
       ('_INT8InputOutput', lite.constants.INT8),
-      ('_UINT8InputOutput', lite.constants.QUANTIZED_UINT8))
+      ('_UINT8InputOutput', lite.constants.QUANTIZED_UINT8),
+      ('_INT16InputOutput', lite.constants.INT16))
   @test_util.run_v2_only
   def testInvalidFloat(self, inference_input_output_type):
     root = self._getSimpleVariableModel()
@@ -194,7 +195,8 @@ class FromConcreteFunctionTest(lite_v2_test_util.ModelTest):
 
   @parameterized.named_parameters(
       ('_INT8InputOutput', lite.constants.INT8),
-      ('_UINT8InputOutput', lite.constants.QUANTIZED_UINT8))
+      ('_UINT8InputOutput', lite.constants.QUANTIZED_UINT8),
+      ('_INT16InputOutput', lite.constants.INT16))
   @test_util.run_v2_only
   def testInvalidPostTrainingDynamicRangeQuantization(
       self, inference_input_output_type):


### PR DESCRIPTION
This is a small fix for the new options in TFLite converter to make them work with int16 activations:

`converter.inference_input_type = tf.int16`
`converter.inference_output_type = tf.int16`