### PR TITLE
ValueError raised when weights is a None object

### DIFF
--- a/tensorflow/python/keras/engine/base_layer.py
+++ b/tensorflow/python/keras/engine/base_layer.py
@@ -1808,7 +1808,8 @@ class Layer(module.Module, version_utils.LayerVersionSelector):
           'You called `set_weights(weights)` on layer "%s" '
           'with a weight list of length %s, but the layer was '
           'expecting %s weights. Provided weights: %s...' %
-          (self.name, len(weights) if weights else 0, expected_num_weights, str(weights)[:50]))
+          (self.name, len(weights) if weights else 0,
+            expected_num_weights, str(weights)[:50]))
 
     weight_index = 0
     weight_value_tuples = []

--- a/tensorflow/python/keras/engine/base_layer.py
+++ b/tensorflow/python/keras/engine/base_layer.py
@@ -1803,12 +1803,12 @@ class Layer(module.Module, version_utils.LayerVersionSelector):
       else:
         expected_num_weights += 1
 
-    if expected_num_weights != len(weights):
+    if not weights or expected_num_weights != len(weights):
       raise ValueError(
           'You called `set_weights(weights)` on layer "%s" '
           'with a weight list of length %s, but the layer was '
           'expecting %s weights. Provided weights: %s...' %
-          (self.name, len(weights), expected_num_weights, str(weights)[:50]))
+          (self.name, len(weights) if weights else 0, expected_num_weights, str(weights)[:50]))
 
     weight_index = 0
     weight_value_tuples = []

--- a/tensorflow/python/keras/engine/base_layer.py
+++ b/tensorflow/python/keras/engine/base_layer.py
@@ -1803,12 +1803,12 @@ class Layer(module.Module, version_utils.LayerVersionSelector):
       else:
         expected_num_weights += 1
 
-    if not weights or expected_num_weights != len(weights):
+    if weights == None or expected_num_weights != len(weights):
       raise ValueError(
           'You called `set_weights(weights)` on layer "%s" '
           'with a weight list of length %s, but the layer was '
           'expecting %s weights. Provided weights: %s...' %
-          (self.name, len(weights) if weights else 0,
+          (self.name, len(weights) if isinstance(weights, list) else 0,
             expected_num_weights, str(weights)[:50]))
 
     weight_index = 0


### PR DESCRIPTION
Previously: raise ValueError when weights list is empty.
Now: raise ValueError when weights list does not exist or is empty.