### PR TITLE
Simplify code for keras_cpu_benchmark_test

### DIFF
--- a/tensorflow/python/keras/benchmarks/BUILD
+++ b/tensorflow/python/keras/benchmarks/BUILD
@@ -30,8 +30,8 @@ py_test(
     python_version = "PY3",
     deps = [
         ":benchmark_util",
-        "//tensorflow/python/keras",
         "//tensorflow:tensorflow_py",
+        "//tensorflow/python/keras",
         "//third_party/py/numpy",
     ],
 )

--- a/tensorflow/python/keras/benchmarks/BUILD
+++ b/tensorflow/python/keras/benchmarks/BUILD
@@ -31,7 +31,6 @@ py_test(
     deps = [
         ":benchmark_util",
         "//tensorflow:tensorflow_py",
-        "//tensorflow/python/keras",
         "//third_party/py/numpy",
     ],
 )

--- a/tensorflow/python/keras/benchmarks/BUILD
+++ b/tensorflow/python/keras/benchmarks/BUILD
@@ -29,6 +29,8 @@ py_test(
     srcs = ["keras_cpu_benchmark_test.py"],
     python_version = "PY3",
     deps = [
+        ":benchmark_util",
+        "//tensorflow/python/keras",
         "//tensorflow:tensorflow_py",
         "//third_party/py/numpy",
     ],

--- a/tensorflow/python/keras/benchmarks/keras_cpu_benchmark_test.py
+++ b/tensorflow/python/keras/benchmarks/keras_cpu_benchmark_test.py
@@ -13,12 +13,9 @@
 # limitations under the License.
 # ==============================================================================
 """Benchmark tests for CPU performance of Keras models."""
-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
-import timeit
 
 import numpy as np
 import six
@@ -27,90 +24,38 @@ import tensorflow as tf
 
 from tensorflow.python.platform import benchmark
 from tensorflow.python.platform import test
+from tensorflow.python.keras.benchmarks import benchmark_util
 
-_NUM_EPOCHS = 4
-
-# Dataset for benchmark
-_MLP_X = np.random.random((5000, 784))
-_MLP_Y = np.random.random((5000, 10))
-
-_CONVNET_X = np.random.random((5000, 28, 28, 1))
-_CONVNET_Y = np.random.random((5000, 10))
-
-_LSTM_X = np.random.randint(0, 1999, size=(2500, 100))
-_LSTM_Y = np.random.random((2500, 1))
-
-
-class TimerCallback(tf.keras.callbacks.Callback):
-
-  def __init__(self):
-    self.times = []
-    self.timer = timeit.default_timer
-    self.startup_time = timeit.default_timer()
-    self.recorded_startup = False
-
-  def on_epoch_begin(self, e, logs):
-    self.epoch_start_time = self.timer()
-
-  def on_batch_end(self, e, logs):
-    if not self.recorded_startup:
-      self.startup_time = self.timer() - self.startup_time
-      self.recorded_startup = True
-
-  def on_epoch_end(self, e, logs):
-    self.times.append(self.timer() - self.epoch_start_time)
+# Loss function and optimizer.
+_LOSS = 'binary_crossentropy'
+_OPTIMIZER = 'rmsprop'
 
 
 class KerasModelCPUBenchmark(
     six.with_metaclass(benchmark.ParameterizedBenchmark, test.Benchmark)):
-
-  # Set parameters for paramerized benchmark.
+  """Required Arguments for measure_performance:
+      x: Input data, it could be Numpy or load from tfds.
+      y: Target data. If `x` is a dataset, generator instance,
+         `y` should not be specified.
+      loss: Loss function for model.
+      optimizer: Optimizer for model.
+      Other details can see in `measure_performance()` method of
+      benchmark_util.
+  """
+  """The parameters of each benchmark is a tuple:
+     (benchmark_name_suffix, batch_size, run_iters).
+     benchmark_name_suffix: The suffix of the benchmark test name with
+     convention `{bs}_{batch_size}`.
+     batch_size: Integer. Number of samples per gradient update.
+     run_iters: Integer. Number of iterations to run the
+         performance measurement.
+  """
   _benchmark_parameters = [
       ('bs_32', 32, 3), ('bs_64', 64, 2), ('bs_128', 128, 2),
       ('bs_256', 256, 1), ('bs_512', 512, 1)]
 
-  def _measure_performance(self, model_fn, x, y, batch_size=32,
-                           run_iters=4):
-    build_time_list, compile_time_list, startup_time_list = [], [], []
-    avg_epoch_time_list, wall_time_list, exp_per_sec_list = [], [], []
-    total_num_examples = y.shape[0] * _NUM_EPOCHS
-
-    for _ in range(run_iters):
-      timer = timeit.default_timer
-      t0 = timer()
-      model = model_fn()
-      build_time = timer() - t0
-
-      t1 = timer()
-      model.compile('rmsprop', 'binary_crossentropy')
-      compile_time = timer() - t1
-
-      cbk = TimerCallback()
-      t2 = timer()
-      model.fit(x, y, epochs=_NUM_EPOCHS, batch_size=batch_size,
-                callbacks=[cbk], verbose=0)
-      end_time = timer()
-
-      build_time_list.append(build_time)
-      compile_time_list.append(compile_time)
-      startup_time_list.append(cbk.startup_time)
-      avg_epoch_time_list.append(np.mean(cbk.times[1:]))
-      wall_time_list.append(end_time - t0)
-      exp_per_sec_list.append(total_num_examples / (end_time - t2))
-
-    results = {'build_time': np.mean(build_time_list),
-               'compile_time': np.mean(compile_time_list),
-               'startup_time': np.mean(startup_time_list),
-               'avg_epoch_time': np.mean(avg_epoch_time_list),
-               'wall_time': np.mean(wall_time_list),
-               'exp_per_sec': np.mean(exp_per_sec_list)}
-
-    self.report_benchmark(
-        iters=_NUM_EPOCHS,
-        wall_time=results['wall_time'],
-        extras=results)
-
   def _mnist_mlp(self):
+    """Simple MLP model."""
     model = tf.keras.Sequential()
     model.add(tf.keras.layers.Dense(512, activation='relu', input_shape=(784,)))
     model.add(tf.keras.layers.Dropout(0.2))
@@ -121,6 +66,7 @@ class KerasModelCPUBenchmark(
     return model
 
   def _mnist_convnet(self):
+    """Simple Convnet model."""
     model = tf.keras.Sequential()
     model.add(
         tf.keras.layers.Conv2D(
@@ -136,6 +82,7 @@ class KerasModelCPUBenchmark(
     return model
 
   def _imdb_lstm(self):
+    """Simple LSTM model."""
     model = tf.keras.Sequential()
     model.add(tf.keras.layers.Embedding(20000, 128))
     model.add(tf.keras.layers.LSTM(128, dropout=0.2, recurrent_dropout=0.2))
@@ -144,16 +91,49 @@ class KerasModelCPUBenchmark(
     return model
 
   def benchmark_mnist_mlp(self, batch_size, run_iters):
-    self._measure_performance(self._mnist_mlp, _MLP_X, _MLP_Y,
-                              batch_size=batch_size, run_iters=run_iters)
+    """Benchmark for MLP model on synthetic mnist data."""
+    mlp_x = np.random.random((5000, 784))
+    mlp_y = np.random.random((5000, 10))
+    results = benchmark_util.measure_performance(self._mnist_mlp,
+                                                 x=mlp_x,
+                                                 y=mlp_y,
+                                                 batch_size=batch_size,
+                                                 run_iters=run_iters,
+                                                 optimizer=_OPTIMIZER,
+                                                 loss=_LOSS)
+    self.report_benchmark(iters=run_iters,
+                          wall_time=results['wall_time'],
+                          extras=results)
 
   def benchmark_mnist_convnet(self, batch_size, run_iters):
-    self._measure_performance(self._mnist_convnet, _CONVNET_X, _CONVNET_Y,
-                              batch_size=batch_size, run_iters=run_iters)
+    """Benchmark for Convnet model on synthetic mnist data."""
+    convnet_x = np.random.random((5000, 28, 28, 1))
+    convnet_y = np.random.random((5000, 10))
+    results = benchmark_util.measure_performance(self._mnist_convnet,
+                                                 x=convnet_x,
+                                                 y=convnet_y,
+                                                 batch_size=batch_size,
+                                                 run_iters=run_iters,
+                                                 optimizer=_OPTIMIZER,
+                                                 loss=_LOSS)
+    self.report_benchmark(iters=run_iters,
+                          wall_time=results['wall_time'],
+                          extras=results)
 
   def benchmark_imdb_lstm(self, batch_size, run_iters):
-    self._measure_performance(self._imdb_lstm, _LSTM_X, _LSTM_Y,
-                              batch_size=batch_size, run_iters=run_iters)
+    """Benchmark for LSTM model on synthetic imdb review dataset."""
+    lstm_x = np.random.randint(0, 1999, size=(2500, 100))
+    lstm_y = np.random.random((2500, 1))
+    results = benchmark_util.measure_performance(self._imdb_lstm(),
+                                                 x=lstm_x,
+                                                 y=lstm_y,
+                                                 batch_size=batch_size,
+                                                 run_iters=run_iters,
+                                                 optimizer=_OPTIMIZER,
+                                                 loss=_LOSS)
+    self.report_benchmark(iters=run_iters,
+                          wall_time=results['wall_time'],
+                          extras=results)
 
 
 if __name__ == '__main__':

--- a/tensorflow/python/keras/benchmarks/keras_cpu_benchmark_test.py
+++ b/tensorflow/python/keras/benchmarks/keras_cpu_benchmark_test.py
@@ -123,7 +123,7 @@ class KerasModelCPUBenchmark(
     """Benchmark for LSTM model on synthetic imdb review dataset."""
     lstm_x = np.random.randint(0, 1999, size=(2500, 100))
     lstm_y = np.random.random((2500, 1))
-    results = benchmark_util.measure_performance(self._imdb_lstm(),
+    results = benchmark_util.measure_performance(self._imdb_lstm,
                                                  x=lstm_x,
                                                  y=lstm_y,
                                                  batch_size=batch_size,

--- a/tensorflow/python/keras/benchmarks/keras_cpu_benchmark_test.py
+++ b/tensorflow/python/keras/benchmarks/keras_cpu_benchmark_test.py
@@ -23,7 +23,6 @@ import six
 import tensorflow as tf
 
 from tensorflow.python.platform import benchmark
-from tensorflow.python.platform import test
 from tensorflow.python.keras.benchmarks import benchmark_util
 
 # Loss function and optimizer.
@@ -32,7 +31,7 @@ _OPTIMIZER = 'rmsprop'
 
 
 class KerasModelCPUBenchmark(
-    six.with_metaclass(benchmark.ParameterizedBenchmark, test.Benchmark)):
+    six.with_metaclass(benchmark.ParameterizedBenchmark, tf.test.Benchmark)):
   """Required Arguments for measure_performance:
       x: Input data, it could be Numpy or load from tfds.
       y: Target data. If `x` is a dataset, generator instance,
@@ -137,4 +136,4 @@ class KerasModelCPUBenchmark(
 
 
 if __name__ == '__main__':
-  test.main()
+  tf.test.main()


### PR DESCRIPTION
Since we build the `benchmark_util` to get the results of each training process and I'd like to change the `keras_cpu_benchmark_test.py` to the same format with `keras_examples_benchmark_test.py`.