### PR TITLE
Add ram file block cache

### DIFF
--- a/tensorflow/c/experimental/filesystem/plugins/gcs/BUILD
+++ b/tensorflow/c/experimental/filesystem/plugins/gcs/BUILD
@@ -52,6 +52,25 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "cleanup",
+    hdrs = ["cleanup.h"],
+)
+
+cc_library(
+    name = "ram_file_block_cache",
+    srcs = ["ram_file_block_cache.cc"],
+    hdrs = ["ram_file_block_cache.h"],
+    deps = [
+        ":cleanup",
+        ":file_block_cache",
+        "//tensorflow/c:env",
+        "//tensorflow/c:tf_status",
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/synchronization",
+    ],
+)
+
 tf_cc_test(
     name = "gcs_filesystem_test",
     srcs = [

--- a/tensorflow/c/experimental/filesystem/plugins/gcs/cleanup.h
+++ b/tensorflow/c/experimental/filesystem/plugins/gcs/cleanup.h
@@ -1,0 +1,111 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// MakeCleanup(f) returns an RAII cleanup object that calls 'f' in its
+// destructor. The easiest way to use MakeCleanup is with a lambda argument,
+// capturing the return value in an 'auto' local variable. Most users will not
+// need more sophisticated syntax than that.
+//
+// Example:
+//   void func() {
+//     FILE* fp = fopen("data.txt", "r");
+//     if (fp == nullptr) return;
+//     auto fp_cleaner = gtl::MakeCleanup([fp] { fclose(fp); });
+//     // No matter what, fclose(fp) will happen.
+//     DataObject d;
+//     while (ReadDataObject(fp, &d)) {
+//       if (d.IsBad()) {
+//         LOG(ERROR) << "Bad Data";
+//         return;
+//       }
+//       PushGoodData(d);
+//     }
+//   }
+//
+// You can use Cleanup<F> directly, instead of using MakeCleanup and auto,
+// but there's rarely a reason to do that.
+//
+// You can call 'release()' on a Cleanup object to cancel the cleanup.
+
+#ifndef TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_PLUGINS_GCS_CLEANUP_H_
+#define TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_PLUGINS_GCS_CLEANUP_H_
+
+#include <type_traits>
+#include <utility>
+
+#include "tensorflow/core/platform/macros.h"
+
+namespace tf_gcs_filesystem {
+
+// A move-only RAII object that calls a stored cleanup functor when
+// destroyed. Cleanup<F> is the return type of gtl::MakeCleanup(F).
+template <typename F>
+class Cleanup {
+ public:
+  Cleanup() : released_(true), f_() {}
+
+  template <typename G>
+  explicit Cleanup(G&& f)          // NOLINT
+      : f_(std::forward<G>(f)) {}  // NOLINT(build/c++11)
+
+  Cleanup(Cleanup&& src)  // NOLINT
+      : released_(src.is_released()), f_(src.release()) {}
+
+  // Implicitly move-constructible from any compatible Cleanup<G>.
+  // The source will be released as if src.release() were called.
+  // A moved-from Cleanup can be safely destroyed or reassigned.
+  template <typename G>
+  Cleanup(Cleanup<G>&& src)  // NOLINT
+      : released_(src.is_released()), f_(src.release()) {}
+
+  // Assignment to a Cleanup object behaves like destroying it
+  // and making a new one in its place, analogous to unique_ptr
+  // semantics.
+  Cleanup& operator=(Cleanup&& src) {  // NOLINT
+    if (!released_) f_();
+    released_ = src.released_;
+    f_ = src.release();
+    return *this;
+  }
+
+  ~Cleanup() {
+    if (!released_) f_();
+  }
+
+  // Releases the cleanup function instead of running it.
+  // Hint: use c.release()() to run early.
+  F release() {
+    released_ = true;
+    return std::move(f_);
+  }
+
+  bool is_released() const { return released_; }
+
+ private:
+  static_assert(!std::is_reference<F>::value, "F must not be a reference");
+
+  bool released_ = false;
+  F f_;
+};
+
+template <int&... ExplicitParameterBarrier, typename F,
+          typename DecayF = typename std::decay<F>::type>
+Cleanup<DecayF> MakeCleanup(F&& f) {
+  return Cleanup<DecayF>(std::forward<F>(f));
+}
+
+}  // namespace tf_gcs_filesystem
+
+#endif  // TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_PLUGINS_GCS_CLEANUP_H_

--- a/tensorflow/c/experimental/filesystem/plugins/gcs/file_block_cache.h
+++ b/tensorflow/c/experimental/filesystem/plugins/gcs/file_block_cache.h
@@ -1,8 +1,11 @@
 /* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/tensorflow/c/experimental/filesystem/plugins/gcs/ram_file_block_cache.cc
+++ b/tensorflow/c/experimental/filesystem/plugins/gcs/ram_file_block_cache.cc
@@ -1,0 +1,317 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/c/experimental/filesystem/plugins/gcs/ram_file_block_cache.h"
+
+#include <cstring>
+#include <memory>
+#include <sstream>
+#include <utility>
+
+#include "absl/synchronization/mutex.h"
+#include "tensorflow/c/experimental/filesystem/plugins/gcs/cleanup.h"
+
+namespace tf_gcs_filesystem {
+
+bool RamFileBlockCache::BlockNotStale(const std::shared_ptr<Block>& block) {
+  absl::MutexLock l(&block->mu);
+  if (block->state != FetchState::FINISHED) {
+    return true;  // No need to check for staleness.
+  }
+  if (max_staleness_ == 0) return true;  // Not enforcing staleness.
+  return timer_seconds_() - block->timestamp <= max_staleness_;
+}
+
+std::shared_ptr<RamFileBlockCache::Block> RamFileBlockCache::Lookup(
+    const Key& key) {
+  absl::MutexLock lock(&mu_);
+  auto entry = block_map_.find(key);
+  if (entry != block_map_.end()) {
+    if (BlockNotStale(entry->second)) {
+      if (cache_stats_ != nullptr) {
+        cache_stats_->RecordCacheHitBlockSize(entry->second->data.size());
+      }
+      return entry->second;
+    } else {
+      // Remove the stale block and continue.
+      RemoveFile_Locked(key.first);
+    }
+  }
+
+  // Insert a new empty block, setting the bookkeeping to sentinel values
+  // in order to update them as appropriate.
+  auto new_entry = std::make_shared<Block>();
+  lru_list_.push_front(key);
+  lra_list_.push_front(key);
+  new_entry->lru_iterator = lru_list_.begin();
+  new_entry->lra_iterator = lra_list_.begin();
+  new_entry->timestamp = timer_seconds_();
+  block_map_.emplace(std::make_pair(key, new_entry));
+  return new_entry;
+}
+
+// Remove blocks from the cache until we do not exceed our maximum size.
+void RamFileBlockCache::Trim() {
+  while (!lru_list_.empty() && cache_size_ > max_bytes_) {
+    RemoveBlock(block_map_.find(lru_list_.back()));
+  }
+}
+
+/// Move the block to the front of the LRU list if it isn't already there.
+void RamFileBlockCache::UpdateLRU(const Key& key,
+                                  const std::shared_ptr<Block>& block,
+                                  TF_Status* status) {
+  absl::MutexLock lock(&mu_);
+  if (block->timestamp == 0) {
+    // The block was evicted from another thread. Allow it to remain evicted.
+    return TF_SetStatus(status, TF_OK, "");
+  }
+  if (block->lru_iterator != lru_list_.begin()) {
+    lru_list_.erase(block->lru_iterator);
+    lru_list_.push_front(key);
+    block->lru_iterator = lru_list_.begin();
+  }
+
+  // Check for inconsistent state. If there is a block later in the same file
+  // in the cache, and our current block is not block size, this likely means
+  // we have inconsistent state within the cache. Note: it's possible some
+  // incomplete reads may still go undetected.
+  if (block->data.size() < block_size_) {
+    Key fmax = std::make_pair(key.first, std::numeric_limits<size_t>::max());
+    auto fcmp = block_map_.upper_bound(fmax);
+    if (fcmp != block_map_.begin() && key < (--fcmp)->first) {
+      return TF_SetStatus(status, TF_INTERNAL,
+                          "Block cache contents are inconsistent.");
+    }
+  }
+
+  Trim();
+
+  return TF_SetStatus(status, TF_OK, "");
+}
+
+void RamFileBlockCache::MaybeFetch(const Key& key,
+                                   const std::shared_ptr<Block>& block,
+                                   TF_Status* status) {
+  bool downloaded_block = false;
+  auto reconcile_state = MakeCleanup([this, &downloaded_block, &key, &block] {
+    // Perform this action in a cleanup callback to avoid locking mu_ after
+    // locking block->mu.
+    if (downloaded_block) {
+      absl::MutexLock l(&mu_);
+      // Do not update state if the block is already to be evicted.
+      if (block->timestamp != 0) {
+        // Use capacity() instead of size() to account for all  memory
+        // used by the cache.
+        cache_size_ += block->data.capacity();
+        // Put to beginning of LRA list.
+        lra_list_.erase(block->lra_iterator);
+        lra_list_.push_front(key);
+        block->lra_iterator = lra_list_.begin();
+        block->timestamp = timer_seconds_();
+      }
+    }
+  });
+  // Loop until either block content is successfully fetched, or our request
+  // encounters an error.
+  absl::MutexLock l(&block->mu);
+  TF_SetStatus(status, TF_OK, "");
+  while (true) {
+    switch (block->state) {
+      case FetchState::ERROR:
+        // TF_FALLTHROUGH_INTENDED
+      case FetchState::CREATED:
+        block->state = FetchState::FETCHING;
+        block->mu.Unlock();  // Release the lock while making the API call.
+        block->data.clear();
+        block->data.resize(block_size_, 0);
+        size_t bytes_transferred;
+        block_fetcher_(key.first, key.second, block_size_, block->data.data(),
+                       &bytes_transferred, status);
+        if (cache_stats_ != nullptr) {
+          cache_stats_->RecordCacheMissBlockSize(bytes_transferred);
+        }
+        block->mu.Lock();  // Reacquire the lock immediately afterwards
+        if (TF_GetCode(status) == TF_OK) {
+          block->data.resize(bytes_transferred, 0);
+          // Shrink the data capacity to the actual size used.
+          // NOLINTNEXTLINE: shrink_to_fit() may not shrink the capacity.
+          std::vector<char>(block->data).swap(block->data);
+          downloaded_block = true;
+          block->state = FetchState::FINISHED;
+        } else {
+          block->state = FetchState::ERROR;
+        }
+        block->cond_var.SignalAll();
+        return;
+      case FetchState::FETCHING:
+        block->cond_var.WaitWithTimeout(&block->mu, absl::Minutes(1));
+        if (block->state == FetchState::FINISHED) {
+          return TF_SetStatus(status, TF_OK, "");
+        }
+        // Re-loop in case of errors.
+        break;
+      case FetchState::FINISHED:
+        return TF_SetStatus(status, TF_OK, "");
+    }
+  }
+  return TF_SetStatus(
+      status, TF_INTERNAL,
+      "Control flow should never reach the end of RamFileBlockCache::Fetch.");
+}
+
+void RamFileBlockCache::Read(const std::string& filename, size_t offset,
+                             size_t n, char* buffer, size_t* bytes_transferred,
+                             TF_Status* status) {
+  *bytes_transferred = 0;
+  if (n == 0) {
+    return TF_SetStatus(status, TF_OK, "");
+  }
+  if (!IsCacheEnabled() || (n > max_bytes_)) {
+    // The cache is effectively disabled, so we pass the read through to the
+    // fetcher without breaking it up into blocks.
+    return block_fetcher_(filename, offset, n, buffer, bytes_transferred,
+                          status);
+  }
+  // Calculate the block-aligned start and end of the read.
+  size_t start = block_size_ * (offset / block_size_);
+  size_t finish = block_size_ * ((offset + n) / block_size_);
+  if (finish < offset + n) {
+    finish += block_size_;
+  }
+  size_t total_bytes_transferred = 0;
+  // Now iterate through the blocks, reading them one at a time.
+  for (size_t pos = start; pos < finish; pos += block_size_) {
+    Key key = std::make_pair(filename, pos);
+    // Look up the block, fetching and inserting it if necessary, and update the
+    // LRU iterator for the key and block.
+    std::shared_ptr<Block> block = Lookup(key);
+    if (!block) {
+      std::cerr << "No block for key " << key.first << "@" << key.second;
+      abort();
+    }
+    MaybeFetch(key, block, status);
+    if (TF_GetCode(status) != TF_OK) return;
+    UpdateLRU(key, block, status);
+    if (TF_GetCode(status) != TF_OK) return;
+    // Copy the relevant portion of the block into the result buffer.
+    const auto& data = block->data;
+    if (offset >= pos + data.size()) {
+      // The requested offset is at or beyond the end of the file. This can
+      // happen if `offset` is not block-aligned, and the read returns the last
+      // block in the file, which does not extend all the way out to `offset`.
+      *bytes_transferred = total_bytes_transferred;
+      std::stringstream os;
+      os << "EOF at offset " << offset << " in file " << filename
+         << " at position " << pos << " with data size " << data.size();
+      return TF_SetStatus(status, TF_OUT_OF_RANGE, std::move(os).str().c_str());
+    }
+    auto begin = data.begin();
+    if (offset > pos) {
+      // The block begins before the slice we're reading.
+      begin += offset - pos;
+    }
+    auto end = data.end();
+    if (pos + data.size() > offset + n) {
+      // The block extends past the end of the slice we're reading.
+      end -= (pos + data.size()) - (offset + n);
+    }
+    if (begin < end) {
+      size_t bytes_to_copy = end - begin;
+      memcpy(&buffer[total_bytes_transferred], &*begin, bytes_to_copy);
+      total_bytes_transferred += bytes_to_copy;
+    }
+    if (data.size() < block_size_) {
+      // The block was a partial block and thus signals EOF at its upper bound.
+      break;
+    }
+  }
+  *bytes_transferred = total_bytes_transferred;
+  return TF_SetStatus(status, TF_OK, "");
+}
+
+bool RamFileBlockCache::ValidateAndUpdateFileSignature(
+    const std::string& filename, int64_t file_signature) {
+  absl::MutexLock lock(&mu_);
+  auto it = file_signature_map_.find(filename);
+  if (it != file_signature_map_.end()) {
+    if (it->second == file_signature) {
+      return true;
+    }
+    // Remove the file from cache if the signatures don't match.
+    RemoveFile_Locked(filename);
+    it->second = file_signature;
+    return false;
+  }
+  file_signature_map_[filename] = file_signature;
+  return true;
+}
+
+size_t RamFileBlockCache::CacheSize() const {
+  absl::MutexLock lock(&mu_);
+  return cache_size_;
+}
+
+void RamFileBlockCache::Prune() {
+  while (!stop_pruning_thread_.WaitForNotificationWithTimeout(
+      absl::Microseconds(1000000))) {
+    absl::MutexLock lock(&mu_);
+    uint64_t now = timer_seconds_();
+    while (!lra_list_.empty()) {
+      auto it = block_map_.find(lra_list_.back());
+      if (now - it->second->timestamp <= max_staleness_) {
+        // The oldest block is not yet expired. Come back later.
+        break;
+      }
+      // We need to make a copy of the filename here, since it could otherwise
+      // be used within RemoveFile_Locked after `it` is deleted.
+      RemoveFile_Locked(std::string(it->first.first));
+    }
+  }
+}
+
+void RamFileBlockCache::Flush() {
+  absl::MutexLock lock(&mu_);
+  block_map_.clear();
+  lru_list_.clear();
+  lra_list_.clear();
+  cache_size_ = 0;
+}
+
+void RamFileBlockCache::RemoveFile(const std::string& filename) {
+  absl::MutexLock lock(&mu_);
+  RemoveFile_Locked(filename);
+}
+
+void RamFileBlockCache::RemoveFile_Locked(const std::string& filename) {
+  Key begin = std::make_pair(filename, 0);
+  auto it = block_map_.lower_bound(begin);
+  while (it != block_map_.end() && it->first.first == filename) {
+    auto next = std::next(it);
+    RemoveBlock(it);
+    it = next;
+  }
+}
+
+void RamFileBlockCache::RemoveBlock(BlockMap::iterator entry) {
+  // This signals that the block is removed, and should not be inadvertently
+  // reinserted into the cache in UpdateLRU.
+  entry->second->timestamp = 0;
+  lru_list_.erase(entry->second->lru_iterator);
+  lra_list_.erase(entry->second->lra_iterator);
+  cache_size_ -= entry->second->data.capacity();
+  block_map_.erase(entry);
+}
+
+}  // namespace tf_gcs_filesystem

--- a/tensorflow/c/experimental/filesystem/plugins/gcs/ram_file_block_cache.h
+++ b/tensorflow/c/experimental/filesystem/plugins/gcs/ram_file_block_cache.h
@@ -1,0 +1,266 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_PLUGINS_GCS_RAM_FILE_BLOCK_CACHE_H_
+#define TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_PLUGINS_GCS_RAM_FILE_BLOCK_CACHE_H_
+
+#include <functional>
+#include <iostream>
+#include <list>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "absl/base/thread_annotations.h"
+#include "absl/synchronization/mutex.h"
+#include "absl/synchronization/notification.h"
+#include "tensorflow/c/env.h"
+#include "tensorflow/c/experimental/filesystem/plugins/gcs/file_block_cache.h"
+#include "tensorflow/c/tf_status.h"
+
+namespace tf_gcs_filesystem {
+
+/// \brief An LRU block cache of file contents, keyed by {filename, offset}.
+///
+/// This class should be shared by read-only random access files on a remote
+/// filesystem (e.g. GCS).
+class RamFileBlockCache : public FileBlockCache {
+ public:
+  /// The callback executed when a block is not found in the cache, and needs to
+  /// be fetched from the backing filesystem. This callback is provided when the
+  /// cache is constructed. The `status` should be `TF_OK` as long as the
+  /// read from the remote filesystem succeeded (similar to the semantics of the
+  /// read(2) system call).
+  typedef std::function<void(const std::string& filename, size_t offset,
+                             size_t buffer_size, char* buffer,
+                             size_t* bytes_transferred, TF_Status* status)>
+      BlockFetcher;
+
+  RamFileBlockCache(size_t block_size, size_t max_bytes, uint64_t max_staleness,
+                    BlockFetcher block_fetcher,
+                    std::function<uint64_t()> timer_seconds)
+      : block_size_(block_size),
+        max_bytes_(max_bytes),
+        max_staleness_(max_staleness),
+        block_fetcher_(block_fetcher),
+        timer_seconds_(timer_seconds),
+        pruning_thread_(nullptr, [](TF_Thread* thread) { TF_JoinThread(thread); }) {
+    if (max_staleness_ > 0) {
+      TF_ThreadOptions thread_options;
+      TF_DefaultThreadOptions(&thread_options);
+      pruning_thread_.reset(
+          TF_StartThread(&thread_options, "TF_prune_FBC", PruneThread, this));
+    }
+    std::cout << "GCS file block cache is "
+              << (IsCacheEnabled() ? "enabled" : "disabled");
+  }
+
+  ~RamFileBlockCache() override {
+    if (pruning_thread_) {
+      stop_pruning_thread_.Notify();
+      // Destroying pruning_thread_ will block until Prune() receives the above
+      // notification and returns.
+      pruning_thread_.reset();
+    }
+  }
+
+  /// Read `n` bytes from `filename` starting at `offset` into `buffer`. This
+  /// method will set `status` to:
+  ///
+  /// 1) The error from the remote filesystem, if the read from the remote
+  ///    filesystem failed.
+  /// 2) `TF_FAILED_PRECONDITION` if the read from the remote filesystem
+  /// succeeded,
+  ///    but the read returned a partial block, and the LRU cache contained a
+  ///    block at a higher offset (indicating that the partial block should have
+  ///    been a full block).
+  /// 3) `TF_OUT_OF_RANGE` if the read from the remote filesystem succeeded, but
+  ///    the file contents do not extend past `offset` and thus nothing was
+  ///    placed in `out`.
+  /// 4) `TF_OK` otherwise (i.e. the read succeeded, and at least one byte was
+  /// placed
+  ///    in `buffer`).
+  ///
+  /// Caller is responsible for allocating memory for `buffer`.
+  /// `buffer` will be left unchanged in case of errors.
+  void Read(const std::string& filename, size_t offset, size_t n, char* buffer,
+            size_t* bytes_transferred, TF_Status* status) override;
+
+  // Validate the given file signature with the existing file signature in the
+  // cache. Returns true if the signature doesn't change or the file doesn't
+  // exist before. If the signature changes, update the existing signature with
+  // the new one and remove the file from cache.
+  bool ValidateAndUpdateFileSignature(const std::string& filename,
+                                      int64_t file_signature) override
+      ABSL_LOCKS_EXCLUDED(mu_);
+
+  /// Remove all cached blocks for `filename`.
+  void RemoveFile(const std::string& filename) override
+      ABSL_LOCKS_EXCLUDED(mu_);
+
+  /// Remove all cached data.
+  void Flush() override ABSL_LOCKS_EXCLUDED(mu_);
+
+  /// Accessors for cache parameters.
+  size_t block_size() const override { return block_size_; }
+  size_t max_bytes() const override { return max_bytes_; }
+  uint64_t max_staleness() const override { return max_staleness_; }
+
+  /// The current size (in bytes) of the cache.
+  size_t CacheSize() const override ABSL_LOCKS_EXCLUDED(mu_);
+
+  // Returns true if the cache is enabled. If false, the BlockFetcher callback
+  // is always executed during Read.
+  bool IsCacheEnabled() const override {
+    return block_size_ > 0 && max_bytes_ > 0;
+  }
+
+  // We can not pass a lambda with capture as a function pointer to
+  // `TF_StartThread`, so we have to wrap `Prune` inside a static function.
+  static void PruneThread(void* param) {
+    auto ram_file_block_cache = static_cast<RamFileBlockCache*>(param);
+    ram_file_block_cache->Prune();
+  }
+
+ private:
+  /// The size of the blocks stored in the LRU cache, as well as the size of the
+  /// reads from the underlying filesystem.
+  const size_t block_size_;
+  /// The maximum number of bytes (sum of block sizes) allowed in the LRU cache.
+  const size_t max_bytes_;
+  /// The maximum staleness of any block in the LRU cache, in seconds.
+  const uint64_t max_staleness_;
+  /// The callback to read a block from the underlying filesystem.
+  const BlockFetcher block_fetcher_;
+  /// The callback to read timestamps.
+  const std::function<uint64_t()> timer_seconds_;
+
+  /// \brief The key type for the file block cache.
+  ///
+  /// The file block cache key is a {filename, offset} pair.
+  typedef std::pair<std::string, size_t> Key;
+
+  /// \brief The state of a block.
+  ///
+  /// A block begins in the CREATED stage. The first thread will attempt to read
+  /// the block from the filesystem, transitioning the state of the block to
+  /// FETCHING. After completing, if the read was successful the state should
+  /// be FINISHED. Otherwise the state should be ERROR. A subsequent read can
+  /// re-fetch the block if the state is ERROR.
+  enum class FetchState {
+    CREATED,
+    FETCHING,
+    FINISHED,
+    ERROR,
+  };
+
+  /// \brief A block of a file.
+  ///
+  /// A file block consists of the block data, the block's current position in
+  /// the LRU cache, the timestamp (seconds since epoch) at which the block
+  /// was cached, a coordination lock, and state & condition variables.
+  ///
+  /// Thread safety:
+  /// The iterator and timestamp fields should only be accessed while holding
+  /// the block-cache-wide mu_ instance variable. The state variable should only
+  /// be accessed while holding the Block's mu lock. The data vector should only
+  /// be accessed after state == FINISHED, and it should never be modified.
+  ///
+  /// In order to prevent deadlocks, never grab the block-cache-wide mu_ lock
+  /// AFTER grabbing any block's mu lock. It is safe to grab mu without locking
+  /// mu_.
+  struct Block {
+    /// The block data.
+    std::vector<char> data;
+    /// A list iterator pointing to the block's position in the LRU list.
+    std::list<Key>::iterator lru_iterator;
+    /// A list iterator pointing to the block's position in the LRA list.
+    std::list<Key>::iterator lra_iterator;
+    /// The timestamp (seconds since epoch) at which the block was cached.
+    uint64_t timestamp;
+    /// Mutex to guard state variable
+    absl::Mutex mu;
+    /// The state of the block.
+    FetchState state ABSL_GUARDED_BY(mu) = FetchState::CREATED;
+    /// Wait on cond_var if state is FETCHING.
+    absl::CondVar cond_var;
+  };
+
+  /// \brief The block map type for the file block cache.
+  ///
+  /// The block map is an ordered map from Key to Block.
+  typedef std::map<Key, std::shared_ptr<Block>> BlockMap;
+
+  /// Prune the cache by removing files with expired blocks.
+  void Prune() ABSL_LOCKS_EXCLUDED(mu_);
+
+  bool BlockNotStale(const std::shared_ptr<Block>& block)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+
+  /// Look up a Key in the block cache.
+  std::shared_ptr<Block> Lookup(const Key& key) ABSL_LOCKS_EXCLUDED(mu_);
+
+  void MaybeFetch(const Key& key, const std::shared_ptr<Block>& block,
+                  TF_Status* status) ABSL_LOCKS_EXCLUDED(mu_);
+
+  /// Trim the block cache to make room for another entry.
+  void Trim() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+
+  /// Update the LRU iterator for the block at `key`.
+  void UpdateLRU(const Key& key, const std::shared_ptr<Block>& block,
+                 TF_Status* status) ABSL_LOCKS_EXCLUDED(mu_);
+
+  /// Remove all blocks of a file, with mu_ already held.
+  void RemoveFile_Locked(const std::string& filename)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+
+  /// Remove the block `entry` from the block map and LRU list, and update the
+  /// cache size accordingly.
+  void RemoveBlock(BlockMap::iterator entry) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+
+  /// The cache pruning thread that removes files with expired blocks.
+  std::unique_ptr<TF_Thread, std::function<void(TF_Thread*)>> pruning_thread_;
+
+  /// Notification for stopping the cache pruning thread.
+  absl::Notification stop_pruning_thread_;
+
+  /// Guards access to the block map, LRU list, and cached byte count.
+  mutable absl::Mutex mu_;
+
+  /// The block map (map from Key to Block).
+  BlockMap block_map_ ABSL_GUARDED_BY(mu_);
+
+  /// The LRU list of block keys. The front of the list identifies the most
+  /// recently accessed block.
+  std::list<Key> lru_list_ ABSL_GUARDED_BY(mu_);
+
+  /// The LRA (least recently added) list of block keys. The front of the list
+  /// identifies the most recently added block.
+  ///
+  /// Note: blocks are added to lra_list_ only after they have successfully been
+  /// fetched from the underlying block store.
+  std::list<Key> lra_list_ ABSL_GUARDED_BY(mu_);
+
+  /// The combined number of bytes in all of the cached blocks.
+  size_t cache_size_ ABSL_GUARDED_BY(mu_) = 0;
+
+  // A filename->file_signature map.
+  std::map<std::string, int64_t> file_signature_map_ ABSL_GUARDED_BY(mu_);
+};
+
+}  // namespace tf_gcs_filesystem
+
+#endif  // TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_PLUGINS_GCS_RAM_FILE_BLOCK_CACHE_H_


### PR DESCRIPTION
@mihaimaruseac 
This PR adds `ram_file_block_cache` ( implementation of the interface `file_block_cache`). Below are the changes I made compared to the current approach.
- `Status` to `TF_Status`
- `env::Thread` to `TF_Thread` ( and thread-related function )
- `mutex` to `absl::Mutex`
- `mutex_lock` to `absl::MutexLock`
- `notification` to `absl::Notification`
- `conditional_variable` to `absl::CondVar`
- `thread_annotations.h` to `"absl/base/thread_annotations.h"` (`TF_GUARDED_BY` to `ABSL_GUARDED_BY`, etc)

This PR is huge but I do not know how to break it down properly. Do you have any idea ? Thank you
