### PR TITLE
Make tf.errors subclasses of relevant Python builtin exceptions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,6 +12,8 @@
   `TF_StringEncodedSize` are no longer relevant and have been removed; see
   core/platform/ctstring.h for string access/modification in C.
 * Removed `tf.distribute.Strategy.experimental_run_v2` method, which was deprecated in TF 2.2.
+* `PermissionDeniedError` and `UnimplementedError` now subclass Python's builtin
+  `PermissionError` and `NotImplementedError`.
 
 ## Known Caveats
 
@@ -431,7 +433,7 @@ This release contains contributions from many people at Google, as well as:
 8bitmp3, Aaron Ma, AbdüLhamit Yilmaz, Abhai Kollara, aflc, Ag Ramesh, Albert Z. Guo, Alex Torres, amoitra, Andrii Prymostka, angeliand, Anshuman Tripathy, Anthony Barbier, Anton Kachatkou, Anubh-V, Anuja Jakhade, Artem Ryabov, autoih, Bairen Yi, Bas Aarts, Basit Ayantunde, Ben Barsdell, Bhavani Subramanian, Brett Koonce, candy.dc, Captain-Pool, caster, cathy, Chong Yan, Choong Yin Thong, Clayne Robison, Colle, Dan Ganea, David Norman, David Refaeli, dengziming, Diego Caballero, Divyanshu, djshen, Douman, Duncan Riach, EFanZh, Elena Zhelezina, Eric Schweitz, Evgenii Zheltonozhskii, Fei Hu, fo40225, Fred Reiss, Frederic Bastien, Fredrik Knutsson, fsx950223, fwcore, George Grzegorz Pawelczak, George Sterpu, Gian Marco Iodice, Giorgio Arena, giuros01, Gomathi Ramamurthy, Guozhong Zhuang, Haifeng Jin, Haoyu Wu, HarikrishnanBalagopal, HJYOO, Huang Chen-Yi, Ilham Firdausi Putra, Imran Salam, Jared Nielsen, Jason Zaman, Jasper Vicenti, Jeff Daily, Jeff Poznanovic, Jens Elofsson, Jerry Shih, jerryyin, Jesper Dramsch, jim.meyer, Jongwon Lee, Jun Wan, Junyuan Xie, Kaixi Hou, kamalkraj, Kan Chen, Karthik Muthuraman, Keiji Ariyama, Kevin Rose, Kevin Wang, Koan-Sin Tan, kstuedem, Kwabena W. Agyeman, Lakshay Tokas, latyas, Leslie-Fang-Intel, Li, Guizi, Luciano Resende, Lukas Folle, Lukas Geiger, Mahmoud Abuzaina, Manuel Freiberger, Mark Ryan, Martin Mlostek, Masaki Kozuki, Matthew Bentham, Matthew Denton, mbhuiyan, mdfaijul, Muhwan Kim, Nagy Mostafa, nammbash, Nathan Luehr, Nathan Wells, Niranjan Hasabnis, Oleksii Volkovskyi, Olivier Moindrot, olramde, Ouyang Jin, OverLordGoldDragon, Pallavi G, Paul Andrey, Paul Wais, pkanwar23, Pooya Davoodi, Prabindh Sundareson, Rajeshwar Reddy T, Ralovich, Kristof, Refraction-Ray, Richard Barnes, richardbrks, Robert Herbig, Romeo Kienzler, Ryan Mccormick, saishruthi, Saket Khandelwal, Sami Kama, Sana Damani, Satoshi Tanaka, Sergey Mironov, Sergii Khomenko, Shahid, Shawn Presser, ShengYang1, Siddhartha Bagaria, Simon Plovyt, skeydan, srinivasan.narayanamoorthy, Stephen Mugisha, sunway513, Takeshi Watanabe, Taylor Jakobson, TengLu, TheMindVirus, ThisIsIsaac, Tim Gates, Timothy Liu, Tomer Gafner, Trent Lo, Trevor Hickey, Trevor Morris, vcarpani, Wei Wang, Wen-Heng (Jack) Chung, wenshuai, Wenshuai-Xiaomi, wenxizhu, william, William D. Irons, Xinan Jiang, Yannic, Yasir Modak, Yasuhiro Matsumoto, Yong Tang, Yongfeng Gu, Youwei Song, Zaccharie Ramzi, Zhang, Zhenyu Guo, 王振华 (Zhenhua Wang), 韩董, 이중건 Isaac Lee
 
 # Release 1.15.0
-This is the last 1.x release for TensorFlow. We do not expect to update the 1.x branch with features, although we will issue patch releases to fix vulnerabilities for at least one year. 
+This is the last 1.x release for TensorFlow. We do not expect to update the 1.x branch with features, although we will issue patch releases to fix vulnerabilities for at least one year.
 
 ## Major Features and Improvements
 * As [announced](https://groups.google.com/a/tensorflow.org/forum/#!topic/developers/iRCt5m4qUz0), `tensorflow` pip package will by default include GPU support (same as `tensorflow-gpu` now) for the platforms we currently have GPU support (Linux and Windows). It will work on machines with and without Nvidia GPUs. `tensorflow-gpu` will still be available, and CPU-only packages can be downloaded at `tensorflow-cpu` for users who are concerned about package size.
@@ -441,7 +443,7 @@ This enables writing forward compatible code: by explicitly importing either `te
 * Add toggles `tf.enable_control_flow_v2()` and `tf.disable_control_flow_v2()` for enabling/disabling v2 control flow.
 * Enable v2 control flow as part of `tf.enable_v2_behavior()` and `TF2_BEHAVIOR=1`.
 * AutoGraph translates Python control flow into TensorFlow expressions, allowing users to write regular Python inside `tf.function`-decorated functions. AutoGraph is also applied in functions used with `tf.data`, `tf.distribute` and `tf.keras` APIS.
-* Adds `enable_tensor_equality()`, which switches the behavior such that: 
+* Adds `enable_tensor_equality()`, which switches the behavior such that:
   * Tensors are no longer hashable.
   * Tensors can be compared with `==` and `!=`, yielding a Boolean Tensor with element-wise comparison results. This will be the default behavior in 2.0.
 
@@ -597,12 +599,12 @@ For information on upgrading your existing TensorFlow 1.x models, please refer t
   * TensorFlow 2.0.0 is built using devtoolset7 (GCC7) on Ubuntu 16. This may lead to ABI incompatibilities with extensions built against earlier versions of TensorFlow.
   * Tensorflow code now produces 2 different pip packages: tensorflow_core containing all the code (in the future it will contain only the private implementation) and tensorflow which is a virtual pip package doing forwarding to tensorflow_core (and in the future will contain only the public API of tensorflow). We don't expect this to be breaking, unless you were importing directly from the implementation.
   Removed the `freeze_graph` command line tool; `SavedModel` should be used in place of frozen graphs.
-  
+
 * `tf.contrib`:
   * `tf.contrib` has been deprecated, and functionality has been either migrated to the core TensorFlow API, to an ecosystem project such as [tensorflow/addons](https://www.github.com/tensorflow/addons) or [tensorflow/io](https://www.github.com/tensorflow/io), or removed entirely.
   * Remove `tf.contrib.timeseries` dependency on TF distributions.
   * Replace contrib references with `tf.estimator.experimental.*` for apis in `early_stopping.py`.
-  
+
 * `tf.estimator`:
   * Premade estimators in the tf.estimator.DNN/Linear/DNNLinearCombined family have been updated to use `tf.keras.optimizers` instead of the `tf.compat.v1.train.Optimizer`s. If you do not pass in an `optimizer=` arg or if you use a string, the premade estimator will use the Keras optimizer. This is checkpoint breaking, as the optimizers have separate variables. A checkpoint converter tool for converting optimizers is included with the release,  but if you want to avoid any change, switch to the v1 version of the estimator:  `tf.compat.v1.estimator.DNN/Linear/DNNLinearCombined*`.
   * Default aggregation for canned Estimators is now `SUM_OVER_BATCH_SIZE`. To maintain previous default behavior, please pass `SUM` as the loss aggregation method.
@@ -610,13 +612,13 @@ For information on upgrading your existing TensorFlow 1.x models, please refer t
   * `Estimator.export_savedmodel` has been renamed to `export_saved_model`.
   * When saving to SavedModel, Estimators will strip default op attributes. This is almost always the correct behavior, as it is more forwards compatible, but if you require that default attributes to be saved with the model, please use `tf.compat.v1.Estimator`.
   * Feature Columns have been upgraded to be more Eager-friendly and to work with Keras. As a result, `tf.feature_column.input_layer` has been deprecated in favor of `tf.keras.layers.DenseFeatures`. v1 feature columns have direct analogues in v2 except for `shared_embedding_columns`, which are not cross-compatible with v1 and v2. Use `tf.feature_column.shared_embeddings` instead.
-  
+
 * `tf.keras`:
   * `OMP_NUM_THREADS` is no longer used by the default Keras config.  To configure the number of threads, use `tf.config.threading` APIs.
   * `tf.keras.model.save_model` and `model.save` now defaults to saving a TensorFlow SavedModel. HDF5 files are still supported.
   * Deprecated `tf.keras.experimental.export_saved_model` and `tf.keras.experimental.function`. Please use `tf.keras.models.save_model(..., save_format='tf')` and `tf.keras.models.load_model` instead.
   * Layers now default to float32, and automatically cast their inputs to the layer's dtype. If you had a model that used float64, it will probably silently use float32 in TensorFlow 2, and a warning will be issued that starts with `Layer <layer-name>` is casting an input tensor from dtype float64 to the layer's dtype of float32. To fix, either set the default dtype to float64 with `tf.keras.backend.set_floatx('float64')`, or pass `dtype='float64'` to each of the Layer constructors. See `tf.keras.layers.Layer` for more information.
- 
+
 * `tf.lite`:
   * Removed `lite.OpHint`, `lite.experimental`, and `lite.constant` from 2.0 API.
 * Tensors are no longer hashable, but instead compare element-wise with `==` and `!=`. Use `tf.compat.v1.disable_tensor_equality()` to return to the previous behavior.
@@ -1861,7 +1863,7 @@ Ag Ramesh, Alex Wiltschko, Alexander Pantyukhin, Amogh Mannekote, An Jiaoyang, A
   * [`tf.contrib.estimator.RNNEstimator`](https://www.tensorflow.org/versions/r1.9/api_docs/python/tf/contrib/estimator/RNNClassifier)
 * The [distributions.Bijector](https://www.tensorflow.org/versions/r1.9/api_docs/python/tf/contrib/distributions/bijectors/Bijector)
   API supports broadcasting for Bijectors with new API changes.
-  
+
 ## Breaking Changes
   * If you're opening empty variable scopes; replace `variable_scope('', ...)` by
     `variable_scope(tf.get_variable_scope(), ...)`.
@@ -2340,7 +2342,7 @@ Samuel He, Sandeep Dcunha, sandipmgiri, Sang Han, scott, Scott Mudge, Se-Won Kim
 Simone Cirillo, Steffen Schmitz, Suvojit Manna, Sylvus, Taehoon Lee, Ted Chang, Thomas Deegan,
 Till Hoffmann, Tim, Toni Kunic, Toon Verstraelen, Tristan Rice, Urs KöSter, Utkarsh Upadhyay,
 Vish (Ishaya) Abrams, Winnie Tsang, Yan Chen, Yan Facai (颜发才), Yi Yang, Yong Tang,
-Youssef Hesham, Yuan (Terry) Tang, Zhengsheng Wei, zxcqwe4906, 张志豪, 田传武 
+Youssef Hesham, Yuan (Terry) Tang, Zhengsheng Wei, zxcqwe4906, 张志豪, 田传武
 
 We are also grateful to all who filed issues or helped resolve them, asked and
 answered questions, and were part of inspiring discussions.

--- a/tensorflow/python/framework/errors_impl.py
+++ b/tensorflow/python/framework/errors_impl.py
@@ -318,7 +318,7 @@ class AlreadyExistsError(OpError):
 
 
 @tf_export("errors.PermissionDeniedError")
-class PermissionDeniedError(OpError):
+class PermissionDeniedError(OpError, PermissionError):
   """Raised when the caller does not have permission to run an operation.
 
   For example, running the
@@ -421,7 +421,7 @@ class OutOfRangeError(OpError):
 
 
 @tf_export("errors.UnimplementedError")
-class UnimplementedError(OpError):
+class UnimplementedError(OpError, NotImplementedError):
   """Raised when an operation has not been implemented.
 
   Some operations may raise this error when passed otherwise-valid

--- a/tensorflow/tools/api/golden/v1/tensorflow.errors.-permission-denied-error.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.errors.-permission-denied-error.pbtxt
@@ -2,14 +2,30 @@ path: "tensorflow.errors.PermissionDeniedError"
 tf_class {
   is_instance: "<class \'tensorflow.python.framework.errors_impl.PermissionDeniedError\'>"
   is_instance: "<class \'tensorflow.python.framework.errors_impl.OpError\'>"
-  is_instance: "<type \'exceptions.Exception\'>"
+  is_instance: "<class \'PermissionError\'>"
   member {
     name: "args"
     mtype: "<type \'getset_descriptor\'>"
   }
   member {
+    name: "characters_written"
+    mtype: "<type \'getset_descriptor\'>"
+  }
+  member {
+    name: "errno"
+    mtype: "<type \'member_descriptor\'>"
+  }
+  member {
     name: "error_code"
     mtype: "<type \'property\'>"
+  }
+  member {
+    name: "filename"
+    mtype: "<type \'member_descriptor\'>"
+  }
+  member {
+    name: "filename2"
+    mtype: "<type \'member_descriptor\'>"
   }
   member {
     name: "message"
@@ -22,6 +38,10 @@ tf_class {
   member {
     name: "op"
     mtype: "<type \'property\'>"
+  }
+  member {
+    name: "strerror"
+    mtype: "<type \'member_descriptor\'>"
   }
   member_method {
     name: "__init__"

--- a/tensorflow/tools/api/golden/v1/tensorflow.errors.-unimplemented-error.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.errors.-unimplemented-error.pbtxt
@@ -2,7 +2,7 @@ path: "tensorflow.errors.UnimplementedError"
 tf_class {
   is_instance: "<class \'tensorflow.python.framework.errors_impl.UnimplementedError\'>"
   is_instance: "<class \'tensorflow.python.framework.errors_impl.OpError\'>"
-  is_instance: "<type \'exceptions.Exception\'>"
+  is_instance: "<class \'NotImplementedError\'>"
   member {
     name: "args"
     mtype: "<type \'getset_descriptor\'>"

--- a/tensorflow/tools/api/golden/v2/tensorflow.errors.-permission-denied-error.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.errors.-permission-denied-error.pbtxt
@@ -2,14 +2,30 @@ path: "tensorflow.errors.PermissionDeniedError"
 tf_class {
   is_instance: "<class \'tensorflow.python.framework.errors_impl.PermissionDeniedError\'>"
   is_instance: "<class \'tensorflow.python.framework.errors_impl.OpError\'>"
-  is_instance: "<type \'exceptions.Exception\'>"
+  is_instance: "<class \'PermissionError\'>"
   member {
     name: "args"
     mtype: "<type \'getset_descriptor\'>"
   }
   member {
+    name: "characters_written"
+    mtype: "<type \'getset_descriptor\'>"
+  }
+  member {
+    name: "errno"
+    mtype: "<type \'member_descriptor\'>"
+  }
+  member {
     name: "error_code"
     mtype: "<type \'property\'>"
+  }
+  member {
+    name: "filename"
+    mtype: "<type \'member_descriptor\'>"
+  }
+  member {
+    name: "filename2"
+    mtype: "<type \'member_descriptor\'>"
   }
   member {
     name: "message"
@@ -22,6 +38,10 @@ tf_class {
   member {
     name: "op"
     mtype: "<type \'property\'>"
+  }
+  member {
+    name: "strerror"
+    mtype: "<type \'member_descriptor\'>"
   }
   member_method {
     name: "__init__"

--- a/tensorflow/tools/api/golden/v2/tensorflow.errors.-unimplemented-error.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.errors.-unimplemented-error.pbtxt
@@ -2,7 +2,7 @@ path: "tensorflow.errors.UnimplementedError"
 tf_class {
   is_instance: "<class \'tensorflow.python.framework.errors_impl.UnimplementedError\'>"
   is_instance: "<class \'tensorflow.python.framework.errors_impl.OpError\'>"
-  is_instance: "<type \'exceptions.Exception\'>"
+  is_instance: "<class \'NotImplementedError\'>"
   member {
     name: "args"
     mtype: "<type \'getset_descriptor\'>"


### PR DESCRIPTION
Whe porting some code from Python's builtin file I/O to `tf.io.gfile` I had to adapt a lot of error handling which was checking against the [builtin Python exceptions](https://docs.python.org/3.8/library/exceptions.html#exception-hierarchy).

This PR makes the following `tf.errors` subclasses of their respective builtin Python analogue so that users don't need to modify `isinstance` checks during error handling when switching between Python's file I/O and `tf.io.gfile`:
- `tf.errors.NotFoundError` subclasses [`FileNotFoundError`](https://docs.python.org/3.8/library/exceptions.html#FileNotFoundError)
- `tf.errors.AlreadyExistsError` subclasses [`FileExistsError`](https://docs.python.org/3.8/library/exceptions.html#FileExistsError)
- `tf.errors.PermissionDeniedError` subclasses [`PermissionError`](https://docs.python.org/3.8/library/exceptions.html#PermissionError)
- `tf.errors.UnimplementedError` subclasses [`NotImplementedError`](https://docs.python.org/3.8/library/exceptions.html#NotImplementedError)

Together with #41173 this should improve the usability of `tf.io.gfile` as a replacement for Python's file I/O.

One could also think of making [`tf.errors.OutOfRangeError`](https://www.tensorflow.org/api_docs/python/tf/errors/OutOfRangeError) a subclass of [`StopIteration`](https://docs.python.org/3.8/library/exceptions.html#StopIteration) but I am not sure if there are some subtle differences between the meaning of those two errors.