### PR TITLE
Add expiring_lru_cache

### DIFF
--- a/tensorflow/c/experimental/filesystem/plugins/gcs/BUILD
+++ b/tensorflow/c/experimental/filesystem/plugins/gcs/BUILD
@@ -69,3 +69,29 @@ tf_cc_test(
         "@com_google_absl//absl/strings",
     ],
 )
+
+cc_library(
+    name = "expiring_lru_cache",
+    hdrs = ["expiring_lru_cache.h"],
+    deps = [
+         "//tensorflow/c:tf_status",
+         "//tensorflow/c:env",
+         "@com_google_absl//absl/base",
+         "@com_google_absl//absl/synchronization",
+    ],
+)
+
+tf_cc_test(
+    name = "expiring_lru_cache_test",
+    size = "small",
+    srcs = ["expiring_lru_cache_test.cc"],
+    deps = [
+        ":expiring_lru_cache",
+        "//tensorflow/c:tf_status_helper",
+        "//tensorflow/c:tf_status_internal",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
+        "//tensorflow/core/platform/cloud:now_seconds_env",
+    ],
+)

--- a/tensorflow/c/experimental/filesystem/plugins/gcs/expiring_lru_cache.h
+++ b/tensorflow/c/experimental/filesystem/plugins/gcs/expiring_lru_cache.h
@@ -1,0 +1,189 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_PLUGINS_GCS_EXPIRING_LRU_CACHE_H_
+#define TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_PLUGINS_GCS_EXPIRING_LRU_CACHE_H_
+
+#include <functional>
+#include <list>
+#include <map>
+#include <memory>
+#include <string>
+
+#include "absl/base/thread_annotations.h"
+#include "absl/synchronization/mutex.h"
+#include "tensorflow/c/env.h"
+#include "tensorflow/c/tf_status.h"
+
+namespace tf_gcs_filesystem {
+
+/// \brief An LRU cache of string keys and arbitrary values, with configurable
+/// max item age (in seconds) and max entries.
+///
+/// This class is thread safe.
+template <typename T>
+class ExpiringLRUCache {
+ public:
+  /// A `max_age` of 0 means that nothing is cached. A `max_entries` of 0 means
+  /// that there is no limit on the number of entries in the cache (however, if
+  /// `max_age` is also 0, the cache will not be populated).
+  ExpiringLRUCache(uint64_t max_age, size_t max_entries,
+                   std::function<uint64_t()> timer_seconds = TF_NowSeconds)
+      : max_age_(max_age), max_entries_(max_entries), timer_seconds_(timer_seconds) {}
+
+  /// Insert `value` with key `key`. This will replace any previous entry with
+  /// the same key.
+  void Insert(const std::string& key, const T& value) {
+    if (max_age_ == 0) {
+      return;
+    }
+    absl::MutexLock lock(&mu_);
+    InsertLocked(key, value);
+  }
+
+  // Delete the entry with key `key`. Return true if the entry was found for
+  // `key`, false if the entry was not found. In both cases, there is no entry
+  // with key `key` existed after the call.
+  bool Delete(const std::string& key) {
+    absl::MutexLock lock(&mu_);
+    return DeleteLocked(key);
+  }
+
+  /// Look up the entry with key `key` and copy it to `value` if found. Returns
+  /// true if an entry was found for `key`, and its timestamp is not more than
+  /// max_age_ seconds in the past.
+  bool Lookup(const std::string& key, T* value) {
+    if (max_age_ == 0) {
+      return false;
+    }
+    absl::MutexLock lock(&mu_);
+    return LookupLocked(key, value);
+  }
+
+  typedef std::function<void(const std::string&, T*, TF_Status*)> ComputeFunc;
+
+  /// Look up the entry with key `key` and copy it to `value` if found. If not
+  /// found, call `compute_func`. If `compute_func` set `status` to `TF_OK`, store
+  /// a copy of the output parameter in the cache, and another copy in `value`.
+  void LookupOrCompute(const std::string& key, T* value,
+                         const ComputeFunc& compute_func, TF_Status* status) {
+    if (max_age_ == 0) {
+      return compute_func(key, value, status);
+    }
+
+    // Note: we hold onto mu_ for the rest of this function. In practice, this
+    // is okay, as stat requests are typically fast, and concurrent requests are
+    // often for the same file. Future work can split this up into one lock per
+    // key if this proves to be a significant performance bottleneck.
+    absl::MutexLock lock(&mu_);
+    if (LookupLocked(key, value)) {
+      return TF_SetStatus(status, TF_OK, "");
+    }
+    compute_func(key, value, status);
+    if (TF_GetCode(status) == TF_OK) {
+      InsertLocked(key, *value);
+    }
+    return;
+  }
+
+  /// Clear the cache.
+  void Clear() {
+    absl::MutexLock lock(&mu_);
+    cache_.clear();
+    lru_list_.clear();
+  }
+
+  /// Accessors for cache parameters.
+  uint64_t max_age() const { return max_age_; }
+  size_t max_entries() const { return max_entries_; }
+
+ private:
+  struct Entry {
+    /// The timestamp (seconds) at which the entry was added to the cache.
+    uint64_t timestamp;
+
+    /// The entry's value.
+    T value;
+
+    /// A list iterator pointing to the entry's position in the LRU list.
+    std::list<std::string>::iterator lru_iterator;
+  };
+
+  bool LookupLocked(const std::string& key, T* value)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_) {
+    auto it = cache_.find(key);
+    if (it == cache_.end()) {
+      return false;
+    }
+    lru_list_.erase(it->second.lru_iterator);
+    if (timer_seconds_() - it->second.timestamp > max_age_) {
+      cache_.erase(it);
+      return false;
+    }
+    *value = it->second.value;
+    lru_list_.push_front(it->first);
+    it->second.lru_iterator = lru_list_.begin();
+    return true;
+  }
+
+  void InsertLocked(const std::string& key, const T& value)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_) {
+    lru_list_.push_front(key);
+    Entry entry{timer_seconds_(), value, lru_list_.begin()};
+    auto insert = cache_.insert(std::make_pair(key, entry));
+    if (!insert.second) {
+      lru_list_.erase(insert.first->second.lru_iterator);
+      insert.first->second = entry;
+    } else if (max_entries_ > 0 && cache_.size() > max_entries_) {
+      cache_.erase(lru_list_.back());
+      lru_list_.pop_back();
+    }
+  }
+
+  bool DeleteLocked(const std::string& key) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_) {
+    auto it = cache_.find(key);
+    if (it == cache_.end()) {
+      return false;
+    }
+    lru_list_.erase(it->second.lru_iterator);
+    cache_.erase(it);
+    return true;
+  }
+
+  /// The maximum age of entries in the cache, in seconds. A value of 0 means
+  /// that no entry is ever placed in the cache.
+  const uint64_t max_age_;
+
+  /// The maximum number of entries in the cache. A value of 0 means there is no
+  /// limit on entry count.
+  const size_t max_entries_;
+
+  /// The callback to read timestamps.
+  std::function<uint64_t()> timer_seconds_;
+
+  /// Guards access to the cache and the LRU list.
+  absl::Mutex mu_;
+
+  /// The cache (a map from string key to Entry).
+  std::map<std::string, Entry> cache_ ABSL_GUARDED_BY(mu_);
+
+  /// The LRU list of entries. The front of the list identifies the most
+  /// recently accessed entry.
+  std::list<std::string> lru_list_ ABSL_GUARDED_BY(mu_);
+};
+
+}  // namespace tf_gcs_filesystem
+
+#endif  // TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_PLUGINS_GCS_EXPIRING_LRU_CACHE_H_

--- a/tensorflow/c/experimental/filesystem/plugins/gcs/expiring_lru_cache_test.cc
+++ b/tensorflow/c/experimental/filesystem/plugins/gcs/expiring_lru_cache_test.cc
@@ -1,0 +1,215 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/c/experimental/filesystem/plugins/gcs/expiring_lru_cache.h"
+
+#include <memory>
+
+#include "tensorflow/c/tf_status.h"
+#include "tensorflow/c/tf_status_internal.h"
+#include "tensorflow/core/lib/core/status_test_util.h"
+#include "tensorflow/core/platform/cloud/now_seconds_env.h"
+#include "tensorflow/core/platform/test.h"
+
+namespace tensorflow {
+
+using namespace tf_gcs_filesystem;
+
+namespace {
+
+TEST(ExpiringLRUCacheTest, MaxAge) {
+  const string key = "a";
+  std::unique_ptr<NowSecondsEnv> env(new NowSecondsEnv);
+  ExpiringLRUCache<int> cache(1, 0, [&env]() { return env->NowSeconds(); });
+  env->SetNowSeconds(1);
+  // Verify that replacement of an existing element works, and updates the
+  // timestamp of the entry.
+  cache.Insert(key, 41);
+  env->SetNowSeconds(2);
+  cache.Insert(key, 42);
+  // 1 second after the most recent insertion, the entry is still valid.
+  env->SetNowSeconds(3);
+  int value = 0;
+  EXPECT_TRUE(cache.Lookup(key, &value));
+  EXPECT_EQ(value, 42);
+  // 2 seconds after the most recent insertion, the entry is no longer valid.
+  env->SetNowSeconds(4);
+  EXPECT_FALSE(cache.Lookup(key, &value));
+  // Re-insert the entry.
+  cache.Insert(key, 43);
+  EXPECT_TRUE(cache.Lookup(key, &value));
+  EXPECT_EQ(value, 43);
+  // The entry is valid 1 second after the insertion...
+  env->SetNowSeconds(5);
+  value = 0;
+  EXPECT_TRUE(cache.Lookup(key, &value));
+  EXPECT_EQ(value, 43);
+  // ...but is no longer valid 2 seconds after the insertion.
+  env->SetNowSeconds(6);
+  EXPECT_FALSE(cache.Lookup(key, &value));
+}
+
+TEST(ExpiringLRUCacheTest, MaxEntries) {
+  // max_age of 0 means nothing will be cached.
+  ExpiringLRUCache<int> cache1(0, 4);
+  cache1.Insert("a", 1);
+  int value = 0;
+  EXPECT_FALSE(cache1.Lookup("a", &value));
+  // Now set max_age = 1 and verify the LRU eviction logic.
+  ExpiringLRUCache<int> cache2(1, 4);
+  cache2.Insert("a", 1);
+  cache2.Insert("b", 2);
+  cache2.Insert("c", 3);
+  cache2.Insert("d", 4);
+  EXPECT_TRUE(cache2.Lookup("a", &value));
+  EXPECT_EQ(value, 1);
+  EXPECT_TRUE(cache2.Lookup("b", &value));
+  EXPECT_EQ(value, 2);
+  EXPECT_TRUE(cache2.Lookup("c", &value));
+  EXPECT_EQ(value, 3);
+  EXPECT_TRUE(cache2.Lookup("d", &value));
+  EXPECT_EQ(value, 4);
+  // Insertion of "e" causes "a" to be evicted, but the other entries are still
+  // there.
+  cache2.Insert("e", 5);
+  EXPECT_FALSE(cache2.Lookup("a", &value));
+  EXPECT_TRUE(cache2.Lookup("b", &value));
+  EXPECT_EQ(value, 2);
+  EXPECT_TRUE(cache2.Lookup("c", &value));
+  EXPECT_EQ(value, 3);
+  EXPECT_TRUE(cache2.Lookup("d", &value));
+  EXPECT_EQ(value, 4);
+  EXPECT_TRUE(cache2.Lookup("e", &value));
+  EXPECT_EQ(value, 5);
+}
+
+TEST(ExpiringLRUCacheTest, LookupOrCompute) {
+  // max_age of 0 means we should always compute.
+  uint64 num_compute_calls = 0;
+  ExpiringLRUCache<int>::ComputeFunc compute_func =
+      [&num_compute_calls](const string& key, int* value, TF_Status* status) {
+        *value = num_compute_calls;
+        num_compute_calls++;
+        return TF_SetStatus(status, TF_OK, "");
+      };
+  ExpiringLRUCache<int> cache1(0, 4);
+
+  int value = -1;
+  TF_Status status;
+  cache1.LookupOrCompute("a", &value, compute_func, &status);
+  TF_EXPECT_OK(status.status);
+  EXPECT_EQ(value, 0);
+  EXPECT_EQ(num_compute_calls, 1);
+  // re-read the same value, expect another lookup
+  cache1.LookupOrCompute("a", &value, compute_func, &status);
+  TF_EXPECT_OK(status.status);
+  EXPECT_EQ(value, 1);
+  EXPECT_EQ(num_compute_calls, 2);
+
+  // Define a new cache with max_age > 0 and verify correct behavior.
+  ExpiringLRUCache<int> cache2(2, 4);
+  num_compute_calls = 0;
+  value = -1;
+
+  // Read our first value
+  cache2.LookupOrCompute("a", &value, compute_func, &status);
+  TF_EXPECT_OK(status.status);
+  EXPECT_EQ(value, 0);
+  EXPECT_EQ(num_compute_calls, 1);
+  // Re-read, exepct no additional function compute_func calls.
+  cache2.LookupOrCompute("a", &value, compute_func, &status);
+  TF_EXPECT_OK(status.status);
+  EXPECT_EQ(value, 0);
+  EXPECT_EQ(num_compute_calls, 1);
+
+  // Read a sequence of additional values, eventually evicting "a".
+  cache2.LookupOrCompute("b", &value, compute_func, &status);
+  TF_EXPECT_OK(status.status);
+  EXPECT_EQ(value, 1);
+  EXPECT_EQ(num_compute_calls, 2);
+  cache2.LookupOrCompute("c", &value, compute_func, &status);
+  TF_EXPECT_OK(status.status);
+  EXPECT_EQ(value, 2);
+  EXPECT_EQ(num_compute_calls, 3);
+  cache2.LookupOrCompute("d", &value, compute_func, &status);
+  TF_EXPECT_OK(status.status);
+  EXPECT_EQ(value, 3);
+  EXPECT_EQ(num_compute_calls, 4);
+  cache2.LookupOrCompute("e", &value, compute_func, &status);
+  TF_EXPECT_OK(status.status);
+  EXPECT_EQ(value, 4);
+  EXPECT_EQ(num_compute_calls, 5);
+  // Verify the other values remain in the cache.
+  cache2.LookupOrCompute("b", &value, compute_func, &status);
+  TF_EXPECT_OK(status.status);
+  EXPECT_EQ(value, 1);
+  EXPECT_EQ(num_compute_calls, 5);
+  cache2.LookupOrCompute("c", &value, compute_func, &status);
+  TF_EXPECT_OK(status.status);
+  EXPECT_EQ(value, 2);
+  EXPECT_EQ(num_compute_calls, 5);
+  cache2.LookupOrCompute("d", &value, compute_func, &status);
+  TF_EXPECT_OK(status.status);
+  EXPECT_EQ(value, 3);
+  EXPECT_EQ(num_compute_calls, 5);
+
+  // Re-read "a", ensure it is re-computed.
+  cache2.LookupOrCompute("a", &value, compute_func, &status);
+  TF_EXPECT_OK(status.status);
+  EXPECT_EQ(value, 5);
+  EXPECT_EQ(num_compute_calls, 6);
+}
+
+TEST(ExpiringLRUCacheTest, Clear) {
+  ExpiringLRUCache<int> cache(1, 4);
+  cache.Insert("a", 1);
+  cache.Insert("b", 2);
+  cache.Insert("c", 3);
+  cache.Insert("d", 4);
+  int value = 0;
+  EXPECT_TRUE(cache.Lookup("a", &value));
+  EXPECT_EQ(value, 1);
+  EXPECT_TRUE(cache.Lookup("b", &value));
+  EXPECT_EQ(value, 2);
+  EXPECT_TRUE(cache.Lookup("c", &value));
+  EXPECT_EQ(value, 3);
+  EXPECT_TRUE(cache.Lookup("d", &value));
+  EXPECT_EQ(value, 4);
+  cache.Clear();
+  EXPECT_FALSE(cache.Lookup("a", &value));
+  EXPECT_FALSE(cache.Lookup("b", &value));
+  EXPECT_FALSE(cache.Lookup("c", &value));
+  EXPECT_FALSE(cache.Lookup("d", &value));
+}
+
+TEST(ExpiringLRUCacheTest, Delete) {
+  // Insert an entry.
+  ExpiringLRUCache<int> cache(1, 4);
+  cache.Insert("a", 1);
+  int value = 0;
+  EXPECT_TRUE(cache.Lookup("a", &value));
+  EXPECT_EQ(value, 1);
+
+  // Delete the entry.
+  EXPECT_TRUE(cache.Delete("a"));
+  EXPECT_FALSE(cache.Lookup("a", &value));
+
+  // Try deleting the entry again.
+  EXPECT_FALSE(cache.Delete("a"));
+  EXPECT_FALSE(cache.Lookup("a", &value));
+}
+
+}  // namespace
+}  // namespace tensorflow


### PR DESCRIPTION
@mihaimaruseac 
This PR adds `expiring_lru_cache` will be used to cache `get_matching_path`, `get_childrens`, `stat`, ...
I think this PR is good to go because I only copy the current implementation without any significant changes but only:
- `status` to `TF_Status`
- `"absl/base/thread_annotations.h"`
- `absl::Mutex`
- `absl::MutexLock`

About the test, to make sure it works, I keep almost everything, only `status` to `TF_Status`.

But this won't be used until I refactor the GCS filesystem ( PR #41192 ).