### PR TITLE
[ROCm] Fix for ROCm Breakage - 200708

### DIFF
--- a/tensorflow/compiler/xla/service/sharding_propagation.cc
+++ b/tensorflow/compiler/xla/service/sharding_propagation.cc
@@ -1384,8 +1384,8 @@ Status CheckAndUpdateDeviceAssignmentsInWhileBody(
             [](const HloSharding& s) { return !s.HasUniqueDevice(); });
       }
       if (is_spatially_partitioned) {
-        for (HloInstruction* domain : domain.exit_domains) {
-          domain->mutable_operand(0)->set_sharding(*sharding);
+        for (HloInstruction* d : domain.exit_domains) {
+          d->mutable_operand(0)->set_sharding(*sharding);
         }
         return Status::OK();
       }


### PR DESCRIPTION
The XLA CI job for ROCm is running into the following compile failure

```
tensorflow/compiler/xla/service/sharding_propagation.cc: In static member function 'static tensorflow::Status xla::ShardingPropagation::NormalizeDomain(const xla::DomainMetadata::Domain&, const xla::DomainMetadata*)':
tensorflow/compiler/xla/service/sharding_propagation.cc:1387:46: error: request for member 'exit_domains' in 'domain', which is of pointer type 'xla::HloInstruction*' (maybe you meant to use '->' ?)
         for (HloInstruction* domain : domain.exit_domains) {
                                              ^
...
```

The failure seems to be caused by the loop variable `domain` having the same name as another variable in the enclosing scope. Renaming the loop variable to something different fixes the failure.


/cc @cheshire @chsigg @nvining-work 