### PR TITLE
Add SkipRecords to RecordReader

### DIFF
--- a/tensorflow/core/lib/io/record_reader.cc
+++ b/tensorflow/core/lib/io/record_reader.cc
@@ -208,11 +208,13 @@ Status RecordReader::ReadRecord(uint64* offset, tstring* record) {
   return Status::OK();
 }
 
-Status RecordReader::SkipRecords(uint64* offset, int num_to_skip) {
+Status RecordReader::SkipRecords(uint64* offset, int num_to_skip,
+                                 int* num_skipped) {
   TF_RETURN_IF_ERROR(PositionInputStream(*offset));
 
   Status s;
   tstring record;
+  *num_skipped = 0;
   for (int i = 0; i < num_to_skip; ++i) {
     s = ReadChecksummed(*offset, sizeof(uint64), &record);
     if (!s.ok()) {
@@ -220,10 +222,21 @@ Status RecordReader::SkipRecords(uint64* offset, int num_to_skip) {
       return s;
     }
     const uint64 length = core::DecodeFixed64(record.data());
-    input_stream_->SkipNBytes(length + kFooterSize);
+
+    // Skip data
+    s = input_stream_->SkipNBytes(length + kFooterSize);
+    if (!s.ok()) {
+      last_read_failed_ = true;
+      if (errors::IsOutOfRange(s)) {
+        s = errors::DataLoss("truncated record at ", *offset);
+      }
+      return s;
+    }
     *offset += kHeaderSize + length + kFooterSize;
     DCHECK_EQ(*offset, input_stream_->Tell());
+    (*num_skipped)++;
   }
+  return Status::OK();
 }
 
 SequentialRecordReader::SequentialRecordReader(

--- a/tensorflow/core/lib/io/record_reader.cc
+++ b/tensorflow/core/lib/io/record_reader.cc
@@ -198,7 +198,8 @@ Status RecordReader::ReadRecord(uint64* offset, tstring* record) {
   if (!s.ok()) {
     last_read_failed_ = true;
     if (errors::IsOutOfRange(s)) {
-      s = errors::DataLoss("truncated record at ", *offset);
+      s = errors::DataLoss("truncated record at ", *offset,
+                           "' failed with ", s.error_message());
     }
     return s;
   }
@@ -228,7 +229,8 @@ Status RecordReader::SkipRecords(uint64* offset, int num_to_skip,
     if (!s.ok()) {
       last_read_failed_ = true;
       if (errors::IsOutOfRange(s)) {
-        s = errors::DataLoss("truncated record at ", *offset);
+        s = errors::DataLoss("truncated record at ", *offset,
+                             "' failed with ", s.error_message());
       }
       return s;
     }

--- a/tensorflow/core/lib/io/record_reader.h
+++ b/tensorflow/core/lib/io/record_reader.h
@@ -97,6 +97,12 @@ class RecordReader {
   // OUT_OF_RANGE for end of file, or something else for an error.
   Status ReadRecord(uint64* offset, tstring* record);
 
+  // Skip num_to_skip record starting at "*offset" and update *offset
+  // to point to the offset of the next num_to_skip + 1 record.
+  // Return OK on success, OUT_OF_RANGE for end of file, or something
+  // else for an error.
+  Status SkipRecords(uint64* offset, int num_to_skip);
+
   // Return the metadata of the Record file.
   //
   // The current implementation scans the file to completion,
@@ -110,6 +116,7 @@ class RecordReader {
 
  private:
   Status ReadChecksummed(uint64 offset, size_t n, tstring* result);
+  Status PositionInputStream(uint64 offset);
 
   RecordReaderOptions options_;
   std::unique_ptr<InputStreamInterface> input_stream_;
@@ -133,13 +140,19 @@ class SequentialRecordReader {
 
   virtual ~SequentialRecordReader() = default;
 
-  // Reads the next record in the file into *record. Returns OK on success,
+  // Read the next record in the file into *record. Returns OK on success,
   // OUT_OF_RANGE for end of file, or something else for an error.
   Status ReadRecord(tstring* record) {
     return underlying_.ReadRecord(&offset_, record);
   }
 
-  // Returns the current offset in the file.
+  // Skip the next num_to_skip record in the file. Return OK on success,
+  // OUT_OF_RANGE for end of file, or something else for an error.
+  Status SkipRecords(int num_to_skip) {
+    return underlying_.SkipRecords(&offset_, num_to_skip);
+  }
+
+  // Return the current offset in the file.
   uint64 TellOffset() { return offset_; }
 
   // Seek to this offset within the file and set this offset as the current

--- a/tensorflow/core/lib/io/record_reader.h
+++ b/tensorflow/core/lib/io/record_reader.h
@@ -100,8 +100,9 @@ class RecordReader {
   // Skip num_to_skip record starting at "*offset" and update *offset
   // to point to the offset of the next num_to_skip + 1 record.
   // Return OK on success, OUT_OF_RANGE for end of file, or something
-  // else for an error.
-  Status SkipRecords(uint64* offset, int num_to_skip);
+  // else for an error. "*num_skipped" records the number of records that
+  // are actually skipped. It should be equal to num_to_skip on success.
+  Status SkipRecords(uint64* offset, int num_to_skip, int* num_skipped);
 
   // Return the metadata of the Record file.
   //
@@ -148,8 +149,10 @@ class SequentialRecordReader {
 
   // Skip the next num_to_skip record in the file. Return OK on success,
   // OUT_OF_RANGE for end of file, or something else for an error.
-  Status SkipRecords(int num_to_skip) {
-    return underlying_.SkipRecords(&offset_, num_to_skip);
+  // "*num_skipped" records the number of records that are actually skipped.
+  // It should be equal to num_to_skip on success.
+  Status SkipRecords(int num_to_skip, int* num_skipped) {
+    return underlying_.SkipRecords(&offset_, num_to_skip, num_skipped);
   }
 
   // Return the current offset in the file.

--- a/tensorflow/core/lib/io/record_reader_writer_test.cc
+++ b/tensorflow/core/lib/io/record_reader_writer_test.cc
@@ -158,9 +158,9 @@ TEST(RecordReaderWriterTest, TestBasics) {
   }
 }
 
-TEST(RecordReaderWriterTest, TestSkip) {
+TEST(RecordReaderWriterTest, TestSkipBasic) {
   Env* env = Env::Default();
-  string fname = testing::TmpDir() + "/record_reader_writer_skip_est";
+  string fname = testing::TmpDir() + "/record_reader_writer_skip_basic_test";
 
   for (auto buf_size : BufferSizes()) {
     {
@@ -184,10 +184,47 @@ TEST(RecordReaderWriterTest, TestSkip) {
       options.zlib_options.input_buffer_size = buf_size;
       io::RecordReader reader(read_file.get(), options);
       uint64 offset = 0;
+      int num_skipped;
       tstring record;
-      TF_CHECK_OK(reader.SkipRecords(&offset, 2));
+      TF_CHECK_OK(reader.SkipRecords(&offset, 2, &num_skipped));
+      EXPECT_EQ(2, num_skipped);
       TF_CHECK_OK(reader.ReadRecord(&offset, &record));
       EXPECT_EQ("hij", record);
+    }
+  }
+}
+
+TEST(RecordReaderWriterTest, TestSkipOutOfRange) {
+  Env* env = Env::Default();
+  string fname = testing::TmpDir() +
+                 "/record_reader_writer_skip_out_of_range_test";
+
+  for (auto buf_size : BufferSizes()) {
+    {
+      std::unique_ptr<WritableFile> file;
+      TF_CHECK_OK(env->NewWritableFile(fname, &file));
+
+      io::RecordWriterOptions options;
+      options.zlib_options.output_buffer_size = buf_size;
+      io::RecordWriter writer(file.get(), options);
+      TF_EXPECT_OK(writer.WriteRecord("abc"));
+      TF_EXPECT_OK(writer.WriteRecord("defg"));
+      TF_CHECK_OK(writer.Flush());
+    }
+
+    {
+      std::unique_ptr<RandomAccessFile> read_file;
+      // Read it back with the RecordReader.
+      TF_CHECK_OK(env->NewRandomAccessFile(fname, &read_file));
+      io::RecordReaderOptions options;
+      options.zlib_options.input_buffer_size = buf_size;
+      io::RecordReader reader(read_file.get(), options);
+      uint64 offset = 0;
+      int num_skipped;
+      tstring record;
+      Status s = reader.SkipRecords(&offset, 3, &num_skipped);
+      EXPECT_EQ(2, num_skipped);
+      EXPECT_EQ(error::OUT_OF_RANGE, s.code());
     }
   }
 }

--- a/tensorflow/core/lib/io/record_reader_writer_test.cc
+++ b/tensorflow/core/lib/io/record_reader_writer_test.cc
@@ -158,6 +158,40 @@ TEST(RecordReaderWriterTest, TestBasics) {
   }
 }
 
+TEST(RecordReaderWriterTest, TestSkip) {
+  Env* env = Env::Default();
+  string fname = testing::TmpDir() + "/record_reader_writer_skip_est";
+
+  for (auto buf_size : BufferSizes()) {
+    {
+      std::unique_ptr<WritableFile> file;
+      TF_CHECK_OK(env->NewWritableFile(fname, &file));
+
+      io::RecordWriterOptions options;
+      options.zlib_options.output_buffer_size = buf_size;
+      io::RecordWriter writer(file.get(), options);
+      TF_EXPECT_OK(writer.WriteRecord("abc"));
+      TF_EXPECT_OK(writer.WriteRecord("defg"));
+      TF_EXPECT_OK(writer.WriteRecord("hij"));
+      TF_CHECK_OK(writer.Flush());
+    }
+
+    {
+      std::unique_ptr<RandomAccessFile> read_file;
+      // Read it back with the RecordReader.
+      TF_CHECK_OK(env->NewRandomAccessFile(fname, &read_file));
+      io::RecordReaderOptions options;
+      options.zlib_options.input_buffer_size = buf_size;
+      io::RecordReader reader(read_file.get(), options);
+      uint64 offset = 0;
+      tstring record;
+      TF_CHECK_OK(reader.SkipRecords(&offset, 2));
+      TF_CHECK_OK(reader.ReadRecord(&offset, &record));
+      EXPECT_EQ("hij", record);
+    }
+  }
+}
+
 TEST(RecordReaderWriterTest, TestSnappy) {
   Env* env = Env::Default();
   string fname = testing::TmpDir() + "/record_reader_writer_snappy_test";


### PR DESCRIPTION
This is a PR from JIZHI Team & TaiJi AI platform in Tencent.

This pr add `SkipRecords(uint64* offset, int num_to_skip)` to `RecordReader`, which will skip `num_to_skip` number of records without reading them (using `SkipNBytes`). It will help to implement the `Skip` interface mentioned in #40963, where we are hoping to avoid unnecessary data IO and transformation in ops like `tf.data.Dataset.shard` and `tf.data.Dataset.skip`.

Thank you for your time on reviewing this pr.

FYI, @aaudiber 