### PR TITLE
[ROCm] Prepare for switch to ROCm 3.5

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
+++ b/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
@@ -630,8 +630,10 @@ StatusOr<std::vector<uint8>> EmitModuleToHsaco(
   // Locate lld.
   // TODO(whchung@gmail.com): change to tensorflow::ROCmRoot() after
   // ROCm-Device-Libs PR.
-  std::string lld_path = tensorflow::io::JoinPath("/opt/rocm", "hcc/bin");
-  auto lld_program = llvm::sys::findProgramByName("ld.lld", {lld_path});
+  std::string lld_path_1 = tensorflow::io::JoinPath("/opt/rocm", "hcc/bin");
+  std::string lld_path_2 = tensorflow::io::JoinPath("/opt/rocm", "llvm/bin");
+  auto lld_program =
+      llvm::sys::findProgramByName("ld.lld", {lld_path_1, lld_path_2});
   if (!lld_program) {
     return xla::InternalError("unable to find ld.lld in PATH: %s",
                               lld_program.getError().message());

--- a/tensorflow/core/kernels/reduction_gpu_kernels.cu.h
+++ b/tensorflow/core/kernels/reduction_gpu_kernels.cu.h
@@ -147,7 +147,7 @@ struct Or {
 // each block does a grid strided loop and reduces its values locally
 // the case of one block is used for low latency small reductions to scalars
 template <typename T, typename OUT_T, int num_threads, typename Op>
-__global__ void BlockReduceKernel(
+__global__ __launch_bounds__(1024) void BlockReduceKernel(
     T in, OUT_T out, int num_elems, Op op,
     typename std::iterator_traits<T>::value_type initVal) {
   const int bid = blockIdx.x;
@@ -184,7 +184,7 @@ __global__ void BlockReduceKernel(
 
 // maps a warp to each row
 template <typename T, typename OUT_T, typename Op>
-__global__ void RowReduceKernel(
+__global__ __launch_bounds__(1024) void RowReduceKernel(
     T in, OUT_T out, int num_rows, int num_cols, Op op,
     typename std::iterator_traits<T>::value_type initVal) {
   typedef typename std::iterator_traits<T>::value_type value_type;
@@ -252,7 +252,7 @@ struct storage_type<std::complex<T2>> {
 // Works only if there are <= 16 columns
 // each warps sums over multiple rows at once
 template <typename T, typename OUT_T, typename Op>
-__global__ void ColumnReduceMax16ColumnsKernel(
+__global__ __launch_bounds__(1024) void ColumnReduceMax16ColumnsKernel(
     T in, OUT_T out, int num_rows, int num_cols, Op op,
     typename std::iterator_traits<T>::value_type initVal) {
   typedef typename std::iterator_traits<T>::value_type value_type;
@@ -322,7 +322,7 @@ __global__ void ColumnReduceMax16ColumnsKernel(
 
 // Maps each block to a column range TF_RED_WARPSIZE wide
 template <typename T, typename OUT_T, typename Op>
-__global__ void ColumnReduceKernel(
+__global__ __launch_bounds__(1024) void ColumnReduceKernel(
     T in, OUT_T out, int num_rows, int num_cols, Op op,
     typename std::iterator_traits<T>::value_type initVal) {
   typedef typename std::iterator_traits<T>::value_type value_type;
@@ -388,7 +388,7 @@ __global__ void ColumnReduceKernel(
 // segments cannot cross warp boundaries (mainly used for reducing the segments
 // that come from the Max16Columns column reduction kernel)
 template <typename T, typename OUT_T, typename Op>
-__global__ void CleanupSegments(
+__global__ __launch_bounds__(1024) void CleanupSegments(
     T partial_sums, OUT_T out, int num_rows, int num_cols, int segment_size,
     Op op, typename std::iterator_traits<T>::value_type initVal) {
   typedef typename std::iterator_traits<T>::value_type value_type;
@@ -412,8 +412,8 @@ __global__ void CleanupSegments(
 
 // assigns one thread to a column
 template <typename T, typename OUT_T, typename Op>
-__global__ void ColumnReduceSimpleKernel(T in, OUT_T out, int num_planes,
-                                         int num_rows, int num_cols, Op op) {
+__global__ __launch_bounds__(1024) void ColumnReduceSimpleKernel(
+    T in, OUT_T out, int num_planes, int num_rows, int num_cols, Op op) {
   typedef typename std::iterator_traits<T>::value_type value_type;
   const int gid = threadIdx.x + blockIdx.x * blockDim.x;
   const int elems_per_plane = num_rows * num_cols;
@@ -479,11 +479,9 @@ __device__ __inline__ T ComputeSum(IN_T in_, const int plane,
 }
 
 template <typename IN_T, typename Op>
-__global__ void ColumnReduceInToTempKernel(void* __restrict__ temp,
-                                           int temp_in_offset,
-                                           int temp_out_offset, IN_T in,
-                                           int num_planes, int num_rows,
-                                           int num_cols, Op op) {
+__global__ __launch_bounds__(1024) void ColumnReduceInToTempKernel(
+    void* __restrict__ temp, int temp_in_offset, int temp_out_offset, IN_T in,
+    int num_planes, int num_rows, int num_cols, Op op) {
   typedef typename std::iterator_traits<IN_T>::value_type value_type;
 
   value_type* t = (value_type*)temp;
@@ -510,10 +508,9 @@ __global__ void ColumnReduceInToTempKernel(void* __restrict__ temp,
 }
 
 template <typename T, typename OUT_T, typename Op>
-__global__ void ColumnReduceTempToOutKernel(void* __restrict__ temp,
-                                            int temp_in_offset, T in, OUT_T out,
-                                            int num_planes, int num_rows,
-                                            int num_cols, Op op) {
+__global__ __launch_bounds__(1024) void ColumnReduceTempToOutKernel(
+    void* __restrict__ temp, int temp_in_offset, T in, OUT_T out,
+    int num_planes, int num_rows, int num_cols, Op op) {
   typedef typename std::iterator_traits<T>::value_type value_type;
   value_type* t = (value_type*)temp;
   const int tid = threadIdx.x;

--- a/tensorflow/core/kernels/scan_ops_gpu.h
+++ b/tensorflow/core/kernels/scan_ops_gpu.h
@@ -248,6 +248,10 @@ void LaunchScan(const GPUDevice& d, typename TTypes<T, 3>::ConstTensor in,
   int num_blocks = dimx * dimz;
 
   int ideal_block_size = dimy / items_per_thread;
+#if TENSORFLOW_COMPILER_IS_HIP_CLANG
+  const int rocm_threads_per_warp = 64;
+  ideal_block_size = std::max(ideal_block_size, rocm_threads_per_warp);
+#endif
 
   // There seems to be a bug when the type is not float and block_size 1024.
   // Launch on the smallest power of 2 block size that we can.

--- a/tensorflow/core/kernels/training_ops_gpu.cu.cc
+++ b/tensorflow/core/kernels/training_ops_gpu.cu.cc
@@ -28,12 +28,11 @@ typedef Eigen::GpuDevice GPUDevice;
 namespace functor {
 
 template <typename T>
-__global__ void ApplyAdamKernel(int32 data_dim, T* var, T* m, T* v,
-                                const T* const beta1_power_,
-                                const T* const beta2_power_, const T* const lr_,
-                                const T* const beta1_, const T* const beta2_,
-                                const T* const epsilon_, const T* grad,
-                                bool use_nesterov) {
+__global__ __launch_bounds__(1024) void ApplyAdamKernel(
+    int32 data_dim, T* var, T* m, T* v, const T* const beta1_power_,
+    const T* const beta2_power_, const T* const lr_, const T* const beta1_,
+    const T* const beta2_, const T* const epsilon_, const T* grad,
+    bool use_nesterov) {
   eigen_assert(blockDim.y == 1);
   eigen_assert(blockDim.z == 1);
   eigen_assert(gridDim.y == 1);
@@ -68,7 +67,7 @@ __global__ void ApplyAdamKernel(int32 data_dim, T* var, T* m, T* v,
 }
 
 template <typename T, typename Tindex>
-__global__ void SparseApplyKerasMomentumKernel(
+__global__ __launch_bounds__(1024) void SparseApplyKerasMomentumKernel(
     T* var, T* accum, const T* lr, const T* grad, const Tindex* indices,
     const T* momentum, bool use_nesterov, Tindex param_rows,
     Tindex updates_size, Tindex indices_size) {
@@ -186,9 +185,11 @@ __device__ std::complex<T> impl_rsqrt(std::complex<T> x) {
 }
 
 template <typename T>
-__global__ void ApplyAdagradKernel(GpuLaunchConfig cfg, T* var, T* accum,
-                                   const T* lr, const T* grad,
-                                   bool update_slots) {
+__global__ __launch_bounds__(1024) void ApplyAdagradKernel(GpuLaunchConfig cfg,
+                                                           T* var, T* accum,
+                                                           const T* lr,
+                                                           const T* grad,
+                                                           bool update_slots) {
   GPU_1D_KERNEL_LOOP(i, cfg.virtual_thread_count) {
     if (update_slots) accum[i] += grad[i] * grad[i];
     var[i] -= lr[0] * grad[i] * impl_rsqrt(accum[i]);
@@ -196,9 +197,9 @@ __global__ void ApplyAdagradKernel(GpuLaunchConfig cfg, T* var, T* accum,
 }
 
 template <typename T>
-__global__ void ApplyAdagradV2Kernel(GpuLaunchConfig cfg, T* var, T* accum,
-                                     const T* lr, const T* epsilon,
-                                     const T* grad, bool update_slots) {
+__global__ __launch_bounds__(1024) void ApplyAdagradV2Kernel(
+    GpuLaunchConfig cfg, T* var, T* accum, const T* lr, const T* epsilon,
+    const T* grad, bool update_slots) {
   GPU_1D_KERNEL_LOOP(i, cfg.virtual_thread_count) {
     if (update_slots) accum[i] += grad[i] * grad[i];
     T update = grad[i] / (impl_sqrt(accum[i]) + epsilon[0]);
@@ -207,10 +208,9 @@ __global__ void ApplyAdagradV2Kernel(GpuLaunchConfig cfg, T* var, T* accum,
 }
 
 template <typename T>
-__global__ void ApplyAdadeltaKernel(GpuLaunchConfig cfg, T* var, T* accum,
-                                    T* accum_update, const T* plr,
-                                    const T* prho, const T* peps,
-                                    const T* grad) {
+__global__ __launch_bounds__(1024) void ApplyAdadeltaKernel(
+    GpuLaunchConfig cfg, T* var, T* accum, T* accum_update, const T* plr,
+    const T* prho, const T* peps, const T* grad) {
   T rho = prho[0];
   T eps = peps[0];
   T lr = plr[0];
@@ -224,10 +224,9 @@ __global__ void ApplyAdadeltaKernel(GpuLaunchConfig cfg, T* var, T* accum,
 }
 
 template <typename T>
-__global__ void ApplyRMSPropKernel(GpuLaunchConfig cfg, T* var, T* ms, T* mom,
-                                   const T* plr, const T* prho,
-                                   const T* pmomentum, const T* peps,
-                                   const T* grad) {
+__global__ __launch_bounds__(1024) void ApplyRMSPropKernel(
+    GpuLaunchConfig cfg, T* var, T* ms, T* mom, const T* plr, const T* prho,
+    const T* pmomentum, const T* peps, const T* grad) {
   T rho = prho[0];
   T eps = peps[0];
   T lr = plr[0];
@@ -240,10 +239,9 @@ __global__ void ApplyRMSPropKernel(GpuLaunchConfig cfg, T* var, T* ms, T* mom,
 }
 
 template <typename T>
-__global__ void ApplyCenteredRMSPropKernel(GpuLaunchConfig cfg, T* var, T* mg,
-                                           T* ms, T* mom, const T* plr,
-                                           const T* prho, const T* pmomentum,
-                                           const T* peps, const T* grad) {
+__global__ __launch_bounds__(1024) void ApplyCenteredRMSPropKernel(
+    GpuLaunchConfig cfg, T* var, T* mg, T* ms, T* mom, const T* plr,
+    const T* prho, const T* pmomentum, const T* peps, const T* grad) {
   T rho = prho[0];
   T eps = peps[0];
   T lr = plr[0];

--- a/tensorflow/core/platform/default/rocm_rocdl_path.cc
+++ b/tensorflow/core/platform/default/rocm_rocdl_path.cc
@@ -36,7 +36,11 @@ string RocmRoot() {
 }
 
 string RocdlRoot() {
+#if TENSORFLOW_COMPILER_IS_HIP_CLANG
+  return tensorflow::io::JoinPath(tensorflow::RocmRoot(), "lib");
+#else
   return tensorflow::io::JoinPath(tensorflow::RocmRoot(), "hcc/lib");
+#endif
 }
 
 }  // namespace tensorflow


### PR DESCRIPTION
This PR is collection of commits required to prepare for the switch to ROCm 3.5 (or higher, from the current ROCm 3.3 being used by the `master` branch). 

Starting with ROCm 3.5 the underlying compiler used by hipcc will change from HCC to hip-clang. There will be a corresponding change in the HIP Runtime as well. The idea behind this PR is to make the transition to ROCm 3.5+ seamless.

/cc @cheshire @chsigg @nvining-work 