### PR TITLE
[INTEL MKL] BF16 exp

### DIFF
--- a/tensorflow/core/kernels/cwise_op_exp.cc
+++ b/tensorflow/core/kernels/cwise_op_exp.cc
@@ -16,8 +16,8 @@ limitations under the License.
 #include "tensorflow/core/kernels/cwise_ops_common.h"
 
 namespace tensorflow {
-REGISTER5(UnaryOp, CPU, "Exp", functor::exp, float, Eigen::half, double,
-          complex64, complex128);
+REGISTER6(UnaryOp, CPU, "Exp", functor::exp, float, Eigen::half, double,
+          bfloat16, complex64, complex128);
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 REGISTER5(UnaryOp, GPU, "Exp", functor::exp, float, Eigen::half, double,

--- a/tensorflow/python/kernel_tests/cwise_ops_unary_test.py
+++ b/tensorflow/python/kernel_tests/cwise_ops_unary_test.py
@@ -389,6 +389,7 @@ class UnaryOpTest(test.TestCase):
                   2).reshape(1, 3, 2).astype(dtypes_lib.bfloat16.as_numpy_dtype)
     self._compareCpu(x, np.abs, math_ops.abs)
     self._compareCpu(x, np.abs, _ABS)
+    self._compareBoth(x, np.exp, math_ops.exp)
     self._compareBoth(x, np.negative, math_ops.negative)
     self._compareBoth(x, np.negative, _NEG)
 

--- a/tensorflow/python/kernel_tests/cwise_ops_unary_test.py
+++ b/tensorflow/python/kernel_tests/cwise_ops_unary_test.py
@@ -389,7 +389,7 @@ class UnaryOpTest(test.TestCase):
                   2).reshape(1, 3, 2).astype(dtypes_lib.bfloat16.as_numpy_dtype)
     self._compareCpu(x, np.abs, math_ops.abs)
     self._compareCpu(x, np.abs, _ABS)
-    self._compareBoth(x, np.exp, math_ops.exp)
+    self._compareCpu(x, np.exp, math_ops.exp)
     self._compareBoth(x, np.negative, math_ops.negative)
     self._compareBoth(x, np.negative, _NEG)
 

--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -872,29 +872,5 @@ class RangeTest(test_util.TensorFlowTestCase):
     self.assertAllEqual(values, self.evaluate(tensor))
 
 
-@test_util.run_all_in_graph_and_eager_modes
-class ExpTest(test_util.TensorFlowTestCase):
-
-  def testExp(self):
-    x = np.random.randn(1000, 1000)
-    for dtype in [np.float32, np.float64, np.float16]:
-      x_np = np.array(x, dtype=dtype)
-      x_tf = constant_op.constant(x_np, shape=x_np.shape)
-      y_tf = math_ops.exp(x_tf)
-      y_tf_np = self.evaluate(y_tf)
-      y_np = np.exp(x_np)
-      self.assertAllClose(y_tf_np, y_np, atol=1e-5)
-
-  def testExpExtendType(self):
-    in_bf16 = np.random.randn(1000, 1000).astype(dtypes.bfloat16.as_numpy_dtype)
-    out_bf16 = self.evaluate(math_ops.exp(in_bf16))
-
-    in_f32 = math_ops.cast(in_bf16, dtypes.float32)
-    out_f32 = self.evaluate(math_ops.exp(in_f32))
-    expected = math_ops.cast(out_f32, dtypes.bfloat16)
-
-    self.assertAllClose(out_bf16, expected, rtol=1e-5)
-
-
 if __name__ == "__main__":
   googletest.main()

--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -872,5 +872,29 @@ class RangeTest(test_util.TensorFlowTestCase):
     self.assertAllEqual(values, self.evaluate(tensor))
 
 
+@test_util.run_all_in_graph_and_eager_modes
+class ExpTest(test_util.TensorFlowTestCase):
+
+  def testExp(self):
+    x = np.random.randn(1000, 1000)
+    for dtype in [np.float32, np.float64, np.float16]:
+      x_np = np.array(x, dtype=dtype)
+      x_tf = constant_op.constant(x_np, shape=x_np.shape)
+      y_tf = math_ops.exp(x_tf)
+      y_tf_np = self.evaluate(y_tf)
+      y_np = np.exp(x_np)
+      self.assertAllClose(y_tf_np, y_np, atol=1e-5)
+
+  def testExpExtendType(self):
+    in_bf16 = np.random.randn(1000, 1000).astype(dtypes.bfloat16.as_numpy_dtype)
+    out_bf16 = self.evaluate(math_ops.exp(in_bf16))
+
+    in_f32 = math_ops.cast(in_bf16, dtypes.float32)
+    out_f32 = self.evaluate(math_ops.exp(in_f32))
+    expected = math_ops.cast(out_f32, dtypes.bfloat16)
+
+    self.assertAllClose(out_bf16, expected, rtol=1e-5)
+
+
 if __name__ == "__main__":
   googletest.main()


### PR DESCRIPTION
This PR enables exp for bf16. In Eigen, exp functor will take bf16 as input, up convert to fp32, apply computation, and down convert to bf16. No reduction in it, so there should be no accuracy issue.