### PR TITLE
[TFLite] Error reporting message does not include name of the operator.

### DIFF
--- a/tensorflow/lite/tools/optimize/quantize_model.cc
+++ b/tensorflow/lite/tools/optimize/quantize_model.cc
@@ -950,12 +950,12 @@ TfLiteStatus QuantizeWeightsInputOutput(
           !allow_float) {
         TF_LITE_REPORT_ERROR(
             error_reporter,
-            "Quantization to 16x8-bit not yet supported for op: %",
+            "Quantization to 16x8-bit not yet supported for op: '%s'.\n",
             EnumNameBuiltinOperator(op_code));
         return kTfLiteError;
       } else if (!property.quantizable && !allow_float) {
         TF_LITE_REPORT_ERROR(error_reporter,
-                             "Quantization not yet supported for op: %",
+                             "Quantization not yet supported for op: '%s'.\n",
                              EnumNameBuiltinOperator(op_code));
         return kTfLiteError;
       }


### PR DESCRIPTION
This is a small fix for the regression in the error reporting in the quantize model function:
the name of the operator was not included.