### PR TITLE
[TFLite] Quantization of PAD operator for 16x8 quantization scheme.

### DIFF
--- a/tensorflow/lite/testing/op_tests/pad.py
+++ b/tensorflow/lite/testing/op_tests/pad.py
@@ -67,17 +67,7 @@ def make_pad_tests(options):
                        [[0, 0], [0, 0], [0, 0], [0, 0]]],
           "constant_paddings": [True],
           "fully_quantize": [True],
-          "quant_16x8": [False]
-      },
-      {
-          "dtype": [tf.float32],
-          "input_shape": [[1, 1, 2, 1], [2, 1, 1, 1]],
-          "paddings": [[[0, 0], [0, 1], [2, 3], [0, 0]],
-                       [[0, 1], [0, 0], [0, 0], [2, 3]],
-                       [[0, 0], [0, 0], [0, 0], [0, 0]]],
-          "constant_paddings": [True],
-          "fully_quantize": [True],
-          "quant_16x8": [True]
+          "quant_16x8": [False, True]
       },
       # 2D:
       {
@@ -86,15 +76,7 @@ def make_pad_tests(options):
           "paddings": [[[0, 1], [2, 3]]],
           "constant_paddings": [True],
           "fully_quantize": [True],
-          "quant_16x8": [False],
-      },
-      {
-          "dtype": [tf.float32],
-          "input_shape": [[1, 2]],
-          "paddings": [[[0, 1], [2, 3]]],
-          "constant_paddings": [True],
-          "fully_quantize": [True],
-          "quant_16x8": [True],
+          "quant_16x8": [False, True],
       },
       # 1D:
       {
@@ -103,15 +85,7 @@ def make_pad_tests(options):
           "paddings": [[[1, 2]]],
           "constant_paddings": [True],
           "fully_quantize": [True],
-          "quant_16x8": [False],
-      },
-      {
-          "dtype": [tf.float32],
-          "input_shape": [[1]],
-          "paddings": [[[1, 2]]],
-          "constant_paddings": [True],
-          "fully_quantize": [True],
-          "quant_16x8": [True],
+          "quant_16x8": [False, True],
       },
   ]
 

--- a/tensorflow/lite/testing/op_tests/pad.py
+++ b/tensorflow/lite/testing/op_tests/pad.py
@@ -37,7 +37,8 @@ def make_pad_tests(options):
           "paddings": [[[0, 0], [0, 1], [2, 3], [0, 0]],
                        [[0, 1], [0, 0], [0, 0], [2, 3]]],
           "constant_paddings": [True, False],
-          "fully_quantize": [False]
+          "fully_quantize": [False],
+          "quantize_mode_16x8": [False]
       },
       # 2D:
       {
@@ -45,7 +46,8 @@ def make_pad_tests(options):
           "input_shape": [[1, 2]],
           "paddings": [[[0, 1], [2, 3]]],
           "constant_paddings": [True, False],
-          "fully_quantize": [False]
+          "fully_quantize": [False],
+          "quantize_mode_16x8": [False]
       },
       # 1D:
       {
@@ -53,7 +55,8 @@ def make_pad_tests(options):
           "input_shape": [[1]],
           "paddings": [[[1, 2]]],
           "constant_paddings": [False],
-          "fully_quantize": [False]
+          "fully_quantize": [False],
+          "quantize_mode_16x8": [False]
       },
       # 4D:
       {
@@ -63,7 +66,18 @@ def make_pad_tests(options):
                        [[0, 1], [0, 0], [0, 0], [2, 3]],
                        [[0, 0], [0, 0], [0, 0], [0, 0]]],
           "constant_paddings": [True],
-          "fully_quantize": [True]
+          "fully_quantize": [True],
+          "quantize_mode_16x8": [False]
+      },
+      {
+          "dtype": [tf.float32],
+          "input_shape": [[1, 1, 2, 1], [2, 1, 1, 1]],
+          "paddings": [[[0, 0], [0, 1], [2, 3], [0, 0]],
+                       [[0, 1], [0, 0], [0, 0], [2, 3]],
+                       [[0, 0], [0, 0], [0, 0], [0, 0]]],
+          "constant_paddings": [True],
+          "fully_quantize": [True],
+          "quantize_mode_16x8": [True]
       },
       # 2D:
       {
@@ -71,7 +85,16 @@ def make_pad_tests(options):
           "input_shape": [[1, 2]],
           "paddings": [[[0, 1], [2, 3]]],
           "constant_paddings": [True],
-          "fully_quantize": [True]
+          "fully_quantize": [True],
+          "quantize_mode_16x8": [False],
+      },
+      {
+          "dtype": [tf.float32],
+          "input_shape": [[1, 2]],
+          "paddings": [[[0, 1], [2, 3]]],
+          "constant_paddings": [True],
+          "fully_quantize": [True],
+          "quantize_mode_16x8": [True],
       },
       # 1D:
       {
@@ -79,7 +102,16 @@ def make_pad_tests(options):
           "input_shape": [[1]],
           "paddings": [[[1, 2]]],
           "constant_paddings": [True],
-          "fully_quantize": [True]
+          "fully_quantize": [True],
+          "quantize_mode_16x8": [False],
+      },
+      {
+          "dtype": [tf.float32],
+          "input_shape": [[1]],
+          "paddings": [[[1, 2]]],
+          "constant_paddings": [True],
+          "fully_quantize": [True],
+          "quantize_mode_16x8": [True],
       },
   ]
 

--- a/tensorflow/lite/testing/op_tests/pad.py
+++ b/tensorflow/lite/testing/op_tests/pad.py
@@ -38,7 +38,7 @@ def make_pad_tests(options):
                        [[0, 1], [0, 0], [0, 0], [2, 3]]],
           "constant_paddings": [True, False],
           "fully_quantize": [False],
-          "quantize_mode_16x8": [False]
+          "quant_16x8": [False]
       },
       # 2D:
       {
@@ -47,7 +47,7 @@ def make_pad_tests(options):
           "paddings": [[[0, 1], [2, 3]]],
           "constant_paddings": [True, False],
           "fully_quantize": [False],
-          "quantize_mode_16x8": [False]
+          "quant_16x8": [False]
       },
       # 1D:
       {
@@ -56,7 +56,7 @@ def make_pad_tests(options):
           "paddings": [[[1, 2]]],
           "constant_paddings": [False],
           "fully_quantize": [False],
-          "quantize_mode_16x8": [False]
+          "quant_16x8": [False]
       },
       # 4D:
       {
@@ -67,7 +67,7 @@ def make_pad_tests(options):
                        [[0, 0], [0, 0], [0, 0], [0, 0]]],
           "constant_paddings": [True],
           "fully_quantize": [True],
-          "quantize_mode_16x8": [False]
+          "quant_16x8": [False]
       },
       {
           "dtype": [tf.float32],
@@ -77,7 +77,7 @@ def make_pad_tests(options):
                        [[0, 0], [0, 0], [0, 0], [0, 0]]],
           "constant_paddings": [True],
           "fully_quantize": [True],
-          "quantize_mode_16x8": [True]
+          "quant_16x8": [True]
       },
       # 2D:
       {
@@ -86,7 +86,7 @@ def make_pad_tests(options):
           "paddings": [[[0, 1], [2, 3]]],
           "constant_paddings": [True],
           "fully_quantize": [True],
-          "quantize_mode_16x8": [False],
+          "quant_16x8": [False],
       },
       {
           "dtype": [tf.float32],
@@ -94,7 +94,7 @@ def make_pad_tests(options):
           "paddings": [[[0, 1], [2, 3]]],
           "constant_paddings": [True],
           "fully_quantize": [True],
-          "quantize_mode_16x8": [True],
+          "quant_16x8": [True],
       },
       # 1D:
       {
@@ -103,7 +103,7 @@ def make_pad_tests(options):
           "paddings": [[[1, 2]]],
           "constant_paddings": [True],
           "fully_quantize": [True],
-          "quantize_mode_16x8": [False],
+          "quant_16x8": [False],
       },
       {
           "dtype": [tf.float32],
@@ -111,7 +111,7 @@ def make_pad_tests(options):
           "paddings": [[[1, 2]]],
           "constant_paddings": [True],
           "fully_quantize": [True],
-          "quantize_mode_16x8": [True],
+          "quant_16x8": [True],
       },
   ]
 

--- a/tensorflow/lite/tools/optimize/operator_property.cc
+++ b/tensorflow/lite/tools/optimize/operator_property.cc
@@ -830,7 +830,6 @@ OperatorProperty GetOperatorProperty(const ModelT* model, int subgraph_index,
       property.outputs = {{0, {}}};
       property.restrict_same_input_output_scale = true;
       property.version = 2;
-      property.quantizable_int16 = false;
       break;
     case BuiltinOperator_QUANTIZE:
       property.inputs = {{0, {}}};


### PR DESCRIPTION
This PR enables quantization of PAD operator for 16x8 quantization scheme.
The reference kernel for 16-bit has been merged early.
This PR adds tests that need changes to the testing functions from this PR: https://github.com/tensorflow/tensorflow/pull/39543