### PR TITLE
Prefer Python 3 methods over compatibility aliases

### DIFF
--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -3778,11 +3778,11 @@ class _NumpyIterator(object):
   def __iter__(self):
     return self
 
-  def next(self):
+  def __next__(self):
     return nest.map_structure(lambda x: x.numpy(), next(self._iterator))
 
-  def __next__(self):
-    return self.next()
+  def next(self):
+    return self.__next__()
 
 
 class _VariantTracker(tracking.CapturableResource):

--- a/tensorflow/python/data/ops/iterator_ops.py
+++ b/tensorflow/python/data/ops/iterator_ops.py
@@ -734,8 +734,8 @@ class OwnedIterator(IteratorBase):
   def __iter__(self):
     return self
 
-  def __next__(self):  # For Python 3 compatibility
-    return self.next()
+  def next(self):  # For Python 2 compatibility
+    return self.__next__()
 
   def _next_internal(self):
     if not context.executing_eagerly():
@@ -769,7 +769,7 @@ class OwnedIterator(IteratorBase):
   def _type_spec(self):
     return IteratorSpec(self.element_spec)
 
-  def next(self):
+  def __next__(self):
     try:
       return self._next_internal()
     except errors.OutOfRangeError:

--- a/tensorflow/python/data/ops/multi_device_iterator_ops.py
+++ b/tensorflow/python/data/ops/multi_device_iterator_ops.py
@@ -589,10 +589,10 @@ class OwnedMultiDeviceIterator(composite_tensor.CompositeTensor):
   def __iter__(self):
     return self
 
-  def __next__(self):
-    return self.next()
-
   def next(self):
+    return self.__next__()
+
+  def __next__(self):
     try:
       return self.get_next()
     except errors.OutOfRangeError:

--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -180,7 +180,7 @@ def set_callback_parameters(callback_list,
 
 def _is_generator_like(data):
   """Checks if data is a generator, Sequence, or Iterator."""
-  return (hasattr(data, 'next') or hasattr(data, '__next__') or isinstance(
+  return (hasattr(data, '__next__') or hasattr(data, 'next') or isinstance(
       data, (Sequence, iterator_ops.Iterator, iterator_ops.OwnedIterator)))
 
 

--- a/tensorflow/python/keras/utils/data_utils.py
+++ b/tensorflow/python/keras/utils/data_utils.py
@@ -384,10 +384,10 @@ class ThreadsafeIter(object):
   def __iter__(self):
     return self
 
-  def __next__(self):
-    return self.next()
-
   def next(self):
+    return self.__next__()
+
+  def __next__(self):
     with self.lock:
       if self._exception:
         raise self._exception  # pylint: disable=raising-bad-type

--- a/tensorflow/python/lib/io/file_io.py
+++ b/tensorflow/python/lib/io/file_io.py
@@ -202,14 +202,14 @@ class FileIO(object):
   def __iter__(self):
     return self
 
-  def next(self):
+  def __next__(self):
     retval = self.readline()
     if not retval:
       raise StopIteration()
     return retval
 
-  def __next__(self):
-    return self.next()
+  def next(self):
+    return self.__next__()
 
   def flush(self):
     """Flushes the Writable file.

--- a/tensorflow/python/ops/numpy_ops/np_arrays.py
+++ b/tensorflow/python/ops/numpy_ops/np_arrays.py
@@ -263,11 +263,11 @@ class ndarray(composite_tensor.CompositeTensor):
   def __float__(self):
     return float(self.data)
 
-  def __nonzero__(self):
+  def __bool__(self):
     return bool(self.data)
 
-  def __bool__(self):
-    return self.__nonzero__()
+  def __nonzero__(self):
+    return self.__bool__()
 
   def __iter__(self):
     if not isinstance(self.data, ops.EagerTensor):

--- a/tensorflow/python/training/server_lib.py
+++ b/tensorflow/python/training/server_lib.py
@@ -319,11 +319,11 @@ class ClusterSpec(object):
                       "job names to lists of network addresses, or a "
                       "`ClusterDef` protocol buffer")
 
-  def __nonzero__(self):
+  def __bool__(self):
     return bool(self._cluster_spec)
 
-  # Python 3.x
-  __bool__ = __nonzero__
+  # Python 2.x
+  __nonzero__ = __bool__
 
   def __eq__(self, other):
     return self._cluster_spec == other


### PR DESCRIPTION
This PR consolidates the implementation of magic methods like `__next__` and `__bool__` to under the Python 3 name and alias the Python 2 equivalent to be consistent accross the codebase.