### PR TITLE
Let Attention layer accept a layer mask of list of length 3, namely [query_mask, value_mask, key_mask] #41294

### DIFF
--- a/tensorflow/python/keras/layers/dense_attention.py
+++ b/tensorflow/python/keras/layers/dense_attention.py
@@ -192,7 +192,7 @@ class BaseDenseAttention(Layer):
         raise ValueError(
             '{} layer mask must be a list, '
             'namely [query_mask, value_mask].'.format(class_name))
-      if len(mask) < 2 or len(mask) > 3:
+      if len(mask) < 2 or len(mask) > len(inputs):
         raise ValueError(
             '{} layer mask must be a list of length 2, namely [query_mask, '
             'value_mask]. Given length: {}'.format(class_name, len(mask)))

--- a/tensorflow/python/keras/layers/dense_attention.py
+++ b/tensorflow/python/keras/layers/dense_attention.py
@@ -192,10 +192,10 @@ class BaseDenseAttention(Layer):
         raise ValueError(
             '{} layer mask must be a list, '
             'namely [query_mask, value_mask].'.format(class_name))
-      if len(mask) != 2:
+      if len(mask) < 2 or len(mask) > 3:
         raise ValueError(
-            '{} layer mask must be a list of length 2, namely [query_mask, '
-            'value_mask]. Given length: {}'.format(class_name, len(mask)))
+            '{} layer mask must be a list of length 2 or 3, namely [query_mask, '
+            'value_mask] or [query_mask, value_mask, key_mask]. Given length: {}'.format(class_name, len(mask)))
 
   def get_config(self):
     config = {

--- a/tensorflow/python/keras/layers/dense_attention.py
+++ b/tensorflow/python/keras/layers/dense_attention.py
@@ -194,8 +194,8 @@ class BaseDenseAttention(Layer):
             'namely [query_mask, value_mask].'.format(class_name))
       if len(mask) < 2 or len(mask) > 3:
         raise ValueError(
-            '{} layer mask must be a list of length 2 or 3, namely [query_mask, '
-            'value_mask] or [query_mask, value_mask, key_mask]. Given length: {}'.format(class_name, len(mask)))
+            '{} layer mask must be a list of length 2, namely [query_mask, '
+            'value_mask]. Given length: {}'.format(class_name, len(mask)))
 
   def get_config(self):
     config = {


### PR DESCRIPTION
#41294 

First pull request feel free to let me know if I am doing anything wrong. Thanks

for tf.keras.layers.Attention currently the layer mask must be a list of length 2, namely [query_mask, value_mask]
change it to also accept a layer mask of list of length 3, namely [query_mask, value_mask, key_mask]

currently def compute_mask() returns the query_mask and ignores the value_mask. If passed a key_mask it could also just be ignored
