### PR TITLE
Adding log_warning option in tf.data.experimental.ignore_errors

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_IgnoreErrorsDatasetV2.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_IgnoreErrorsDatasetV2.pbtxt
@@ -1,7 +1,0 @@
-op {
-  graph_op_name: "IgnoreErrorsDatasetV2"
-  summary: <<END
-Creates a dataset that contains the elements of `input_dataset` ignoring errors.
-END
-  visibility: HIDDEN
-}

--- a/tensorflow/core/api_def/base_api/api_def_IgnoreErrorsDatasetV2.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_IgnoreErrorsDatasetV2.pbtxt
@@ -1,0 +1,7 @@
+op {
+  graph_op_name: "IgnoreErrorsDatasetV2"
+  summary: <<END
+Creates a dataset that contains the elements of `input_dataset` ignoring errors.
+END
+  visibility: HIDDEN
+}

--- a/tensorflow/core/kernels/data/experimental/BUILD
+++ b/tensorflow/core/kernels/data/experimental/BUILD
@@ -248,6 +248,7 @@ tf_kernel_library(
     deps = [
         "//tensorflow/core:experimental_dataset_ops_op_lib",
         "//tensorflow/core:framework",
+	"//tensorflow/core/platform:logging",
         "//third_party/eigen3",
     ],
 )

--- a/tensorflow/core/kernels/data/experimental/BUILD
+++ b/tensorflow/core/kernels/data/experimental/BUILD
@@ -248,7 +248,7 @@ tf_kernel_library(
     deps = [
         "//tensorflow/core:experimental_dataset_ops_op_lib",
         "//tensorflow/core:framework",
-	"//tensorflow/core/platform:logging",
+        "//tensorflow/core/platform:logging",
         "//third_party/eigen3",
     ],
 )

--- a/tensorflow/core/ops/experimental_dataset_ops.cc
+++ b/tensorflow/core/ops/experimental_dataset_ops.cc
@@ -432,6 +432,7 @@ REGISTER_OP("IgnoreErrorsDataset")
     .Output("handle: variant")
     .Attr("output_types: list(type) >= 1")
     .Attr("output_shapes: list(shape) >= 1")
+    .Attr("log_warning: bool = false")
     .SetShapeFn(shape_inference::ScalarShape);
 
 REGISTER_OP("ExperimentalIgnoreErrorsDataset")
@@ -439,14 +440,7 @@ REGISTER_OP("ExperimentalIgnoreErrorsDataset")
     .Output("handle: variant")
     .Attr("output_types: list(type) >= 1")
     .Attr("output_shapes: list(shape) >= 1")
-    .SetShapeFn(shape_inference::ScalarShape);
-
-REGISTER_OP("IgnoreErrorsDatasetV2")
-    .Input("input_dataset: variant")
-    .Input("log_warning : bool")
-    .Output("handle: variant")
-    .Attr("output_types: list(type) >= 1")
-    .Attr("output_shapes: list(shape) >= 1")
+    .Attr("log_warning: bool = false")
     .SetShapeFn(shape_inference::ScalarShape);
 
 REGISTER_OP("IteratorGetDevice")

--- a/tensorflow/core/ops/experimental_dataset_ops.cc
+++ b/tensorflow/core/ops/experimental_dataset_ops.cc
@@ -441,6 +441,14 @@ REGISTER_OP("ExperimentalIgnoreErrorsDataset")
     .Attr("output_shapes: list(shape) >= 1")
     .SetShapeFn(shape_inference::ScalarShape);
 
+REGISTER_OP("IgnoreErrorsDatasetV2")
+    .Input("input_dataset: variant")
+    .Input("log_warning : bool")
+    .Output("handle: variant")
+    .Attr("output_types: list(type) >= 1")
+    .Attr("output_shapes: list(shape) >= 1")
+    .SetShapeFn(shape_inference::ScalarShape);
+
 REGISTER_OP("IteratorGetDevice")
     .Input("resource: resource")
     .Output("device: string")

--- a/tensorflow/python/data/experimental/kernel_tests/ignore_errors_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/ignore_errors_test.py
@@ -18,6 +18,7 @@ from __future__ import division
 from __future__ import print_function
 
 import os
+import sys
 
 from absl.testing import parameterized
 import numpy as np
@@ -51,6 +52,23 @@ class IgnoreErrorsTest(test_base.DatasetTestBase, parameterized.TestCase):
 
     for x in [1., 2., 3., 5.]:
       self.assertEqual(x, self.evaluate(get_next()))
+    with self.assertRaises(errors.OutOfRangeError):
+      self.evaluate(get_next())
+
+  @combinations.generate(test_base.default_test_combinations())
+  def testIgnoreError_withLogWarning(self):
+    components = np.array([1., 2., 3., np.nan, 5.]).astype(np.float32)
+    dataset = (
+        dataset_ops.Dataset.from_tensor_slices(components)
+        .map(lambda x: array_ops.check_numerics(x, "message")).apply(
+            error_ops.ignore_errors(log_warning=True)))
+    get_next = self.getNext(dataset)
+    for x in [1., 2., 3.]:
+      self.assertEqual(x, self.evaluate(get_next()))
+    with self.captureWritesToStream(sys.stderr) as logged:
+      self.assertEqual(5., self.evaluate(get_next()))
+    expected = "Tensor had NaN values"
+    self.assertIn((expected), logged.contents())
     with self.assertRaises(errors.OutOfRangeError):
       self.evaluate(get_next())
 

--- a/tensorflow/python/data/experimental/ops/error_ops.py
+++ b/tensorflow/python/data/experimental/ops/error_ops.py
@@ -20,7 +20,6 @@ from __future__ import print_function
 from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.ops import gen_experimental_dataset_ops
 from tensorflow.python.util.tf_export import tf_export
-from tensorflow.python.compat import compat
 
 @tf_export("data.experimental.ignore_errors")
 def ignore_errors(log_warning=False):
@@ -62,15 +61,9 @@ class _IgnoreErrorsDataset(dataset_ops.UnaryUnchangedStructureDataset):
   def __init__(self, input_dataset, log_warning):
     """See `Dataset.ignore_errors()` for details."""
     self._input_dataset = input_dataset
-    if compat.forward_compatible(2020, 7, 26) or log_warning:
-      variant_tensor = (
-          gen_experimental_dataset_ops.ignore_errors_dataset_v2(
-              self._input_dataset._variant_tensor,  # pylint: disable=protected-access
-              log_warning,
-              **self._flat_structure))
-    else:
-      variant_tensor = (
-          gen_experimental_dataset_ops.ignore_errors_dataset(
-              self._input_dataset._variant_tensor,  # pylint: disable=protected-access
-              **self._flat_structure))
+    variant_tensor = (
+        gen_experimental_dataset_ops.ignore_errors_dataset(
+            self._input_dataset._variant_tensor,  # pylint: disable=protected-access
+            log_warning=log_warning,
+            **self._flat_structure))
     super(_IgnoreErrorsDataset, self).__init__(input_dataset, variant_tensor)

--- a/tensorflow/python/data/experimental/ops/error_ops.py
+++ b/tensorflow/python/data/experimental/ops/error_ops.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.ops import gen_experimental_dataset_ops
 from tensorflow.python.util.tf_export import tf_export
+from tensorflow.python.compat import compat
 
 @tf_export("data.experimental.ignore_errors")
 def ignore_errors(log_warning=False):
@@ -61,9 +62,15 @@ class _IgnoreErrorsDataset(dataset_ops.UnaryUnchangedStructureDataset):
   def __init__(self, input_dataset, log_warning):
     """See `Dataset.ignore_errors()` for details."""
     self._input_dataset = input_dataset
-    variant_tensor = (
-        gen_experimental_dataset_ops.ignore_errors_dataset(
-            self._input_dataset._variant_tensor,  # pylint: disable=protected-access
-            log_warning=log_warning,
-            **self._flat_structure))
+    if compat.forward_compatible(2020, 8, 26) or log_warning:
+      variant_tensor = (
+          gen_experimental_dataset_ops.ignore_errors_dataset(
+              self._input_dataset._variant_tensor,  # pylint: disable=protected-access
+              log_warning=log_warning,
+              **self._flat_structure))
+    else:
+      variant_tensor = (
+          gen_experimental_dataset_ops.ignore_errors_dataset(
+              self._input_dataset._variant_tensor,  # pylint: disable=protected-access
+              **self._flat_structure))
     super(_IgnoreErrorsDataset, self).__init__(input_dataset, variant_tensor)

--- a/tensorflow/python/data/experimental/ops/error_ops.py
+++ b/tensorflow/python/data/experimental/ops/error_ops.py
@@ -20,10 +20,10 @@ from __future__ import print_function
 from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.ops import gen_experimental_dataset_ops
 from tensorflow.python.util.tf_export import tf_export
-
+from tensorflow.python.compat import compat
 
 @tf_export("data.experimental.ignore_errors")
-def ignore_errors():
+def ignore_errors(log_warning=False):
   """Creates a `Dataset` from another `Dataset` and silently ignores any errors.
 
   Use this transformation to produce a dataset that contains the same elements
@@ -48,7 +48,7 @@ def ignore_errors():
   """
 
   def _apply_fn(dataset):
-    return _IgnoreErrorsDataset(dataset)
+    return _IgnoreErrorsDataset(dataset, log_warning)
 
   return _apply_fn
 
@@ -56,11 +56,18 @@ def ignore_errors():
 class _IgnoreErrorsDataset(dataset_ops.UnaryUnchangedStructureDataset):
   """A `Dataset` that silently ignores errors when computing its input."""
 
-  def __init__(self, input_dataset):
+  def __init__(self, input_dataset, log_warning):
     """See `Dataset.ignore_errors()` for details."""
     self._input_dataset = input_dataset
-    variant_tensor = (
-        gen_experimental_dataset_ops.ignore_errors_dataset(
-            self._input_dataset._variant_tensor,  # pylint: disable=protected-access
-            **self._flat_structure))
+    if compat.forward_compatible(2020, 7, 26) or log_warning:
+      variant_tensor = (
+          gen_experimental_dataset_ops.ignore_errors_dataset_v2(
+              self._input_dataset._variant_tensor,  # pylint: disable=protected-access
+              log_warning,
+              **self._flat_structure))
+    else:
+      variant_tensor = (
+          gen_experimental_dataset_ops.ignore_errors_dataset(
+              self._input_dataset._variant_tensor,  # pylint: disable=protected-access
+              **self._flat_structure))
     super(_IgnoreErrorsDataset, self).__init__(input_dataset, variant_tensor)

--- a/tensorflow/python/data/experimental/ops/error_ops.py
+++ b/tensorflow/python/data/experimental/ops/error_ops.py
@@ -41,6 +41,9 @@ def ignore_errors(log_warning=False):
   dataset =
       dataset.apply(tf.data.experimental.ignore_errors())  # ==> {1., 0.5, 0.2}
   ```
+  Args:
+     log_warning: (Optional.) A 'tf.bool' scalar indicating whether ignored
+      errors should be logged to stderr. Defaults to 'False'.
 
   Returns:
     A `Dataset` transformation function, which can be passed to

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.pbtxt
@@ -166,7 +166,7 @@ tf_module {
   }
   member_method {
     name: "ignore_errors"
-    argspec: "args=[], varargs=None, keywords=None, defaults=None"
+    argspec: "args=[\'log_warning\'], varargs=None, keywords=None, defaults=[\'False\'], "
   }
   member_method {
     name: "latency_stats"

--- a/tensorflow/tools/api/golden/v1/tensorflow.raw_ops.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.raw_ops.pbtxt
@@ -1418,7 +1418,7 @@ tf_module {
   }
   member_method {
     name: "ExperimentalIgnoreErrorsDataset"
-    argspec: "args=[\'input_dataset\', \'output_types\', \'output_shapes\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+    argspec: "args=[\'input_dataset\', \'output_types\', \'output_shapes\', \'log_warning\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'None\'], "
   }
   member_method {
     name: "ExperimentalIteratorGetDevice"
@@ -1862,11 +1862,7 @@ tf_module {
   }
   member_method {
     name: "IgnoreErrorsDataset"
-    argspec: "args=[\'input_dataset\', \'output_types\', \'output_shapes\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
-  }
-  member_method {
-    name: "IgnoreErrorsDatasetV2"
-    argspec: "args=[\'input_dataset\', \'log_warning\', \'output_types\', \'output_shapes\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+    argspec: "args=[\'input_dataset\', \'output_types\', \'output_shapes\', \'log_warning\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'None\'], "
   }
   member_method {
     name: "Imag"

--- a/tensorflow/tools/api/golden/v1/tensorflow.raw_ops.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.raw_ops.pbtxt
@@ -1865,6 +1865,10 @@ tf_module {
     argspec: "args=[\'input_dataset\', \'output_types\', \'output_shapes\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "IgnoreErrorsDatasetV2"
+    argspec: "args=[\'input_dataset\', \'log_warning\', \'output_types\', \'output_shapes\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
     name: "Imag"
     argspec: "args=[\'input\', \'Tout\', \'name\'], varargs=None, keywords=None, defaults=[\"<dtype: \'float32\'>\", \'None\'], "
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.pbtxt
@@ -138,7 +138,7 @@ tf_module {
   }
   member_method {
     name: "ignore_errors"
-    argspec: "args=[], varargs=None, keywords=None, defaults=None"
+    argspec: "args=[\'log_warning\'], varargs=None, keywords=None, defaults=[\'False\'], "
   }
   member_method {
     name: "latency_stats"

--- a/tensorflow/tools/api/golden/v2/tensorflow.raw_ops.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.raw_ops.pbtxt
@@ -1418,7 +1418,7 @@ tf_module {
   }
   member_method {
     name: "ExperimentalIgnoreErrorsDataset"
-    argspec: "args=[\'input_dataset\', \'output_types\', \'output_shapes\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+    argspec: "args=[\'input_dataset\', \'output_types\', \'output_shapes\', \'log_warning\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'None\'], "
   }
   member_method {
     name: "ExperimentalIteratorGetDevice"
@@ -1862,11 +1862,7 @@ tf_module {
   }
   member_method {
     name: "IgnoreErrorsDataset"
-    argspec: "args=[\'input_dataset\', \'output_types\', \'output_shapes\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
-  }
-  member_method {
-    name: "IgnoreErrorsDatasetV2"
-    argspec: "args=[\'input_dataset\', \'log_warning\', \'output_types\', \'output_shapes\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+    argspec: "args=[\'input_dataset\', \'output_types\', \'output_shapes\', \'log_warning\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'None\'], "
   }
   member_method {
     name: "Imag"

--- a/tensorflow/tools/api/golden/v2/tensorflow.raw_ops.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.raw_ops.pbtxt
@@ -1865,6 +1865,10 @@ tf_module {
     argspec: "args=[\'input_dataset\', \'output_types\', \'output_shapes\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "IgnoreErrorsDatasetV2"
+    argspec: "args=[\'input_dataset\', \'log_warning\', \'output_types\', \'output_shapes\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
     name: "Imag"
     argspec: "args=[\'input\', \'Tout\', \'name\'], varargs=None, keywords=None, defaults=[\"<dtype: \'float32\'>\", \'None\'], "
   }


### PR DESCRIPTION
Resolves #38078.

Adds an option log_warning for ignore_errors which can be used to control whether error is logged to stderr.