### PR TITLE
Use copy instead of deepcopy for sklearn wrapper

### DIFF
--- a/tensorflow/python/keras/wrappers/scikit_learn.py
+++ b/tensorflow/python/keras/wrappers/scikit_learn.py
@@ -114,7 +114,7 @@ class BaseWrapper(object):
     Returns:
         Dictionary of parameter names mapped to their values.
     """
-    res = copy.deepcopy(self.sk_params)
+    res = self.sk_params.copy()
     res.update({'build_fn': self.build_fn})
     return res
 


### PR DESCRIPTION
# Summary
**Submitted on behalf of a third-party:** @mcarbajo. This PR is a copy of @mcarbajo's PR to the main keras repo: https://github.com/keras-team/keras/pull/13598

For compatibility with the scikit-learn clone function get_params has to return the same parameters as given in the init function.

Note that we want this function to return a *reference*, not a *copy*.  Original issue here: https://github.com/keras-team/keras/issues/13586

# Related Issues:
https://github.com/keras-team/keras/issues/13586
https://github.com/scikit-learn/scikit-learn/issues/17022
https://github.com/scikit-learn/scikit-learn/issues/15722

