### PR TITLE
[TFLite] Added op tests for leaky_relu

### DIFF
--- a/tensorflow/lite/testing/op_tests/leaky_relu.py
+++ b/tensorflow/lite/testing/op_tests/leaky_relu.py
@@ -32,15 +32,11 @@ def make_leaky_relu_tests(options):
       {
           "input_shape": [[], [1], [5], [1, 10, 10, 3], [3, 3, 3, 3]],
           "alpha": [0.1, 1.0, 2.0, -0.1, -1.0, -2.0],
-          "fully_quantize": [False],
-          "quant_16x8": [False],
-      },
-      {
-          "input_shape": [[1, 10, 10, 3]],
-          "alpha": [0.1],
-          "fully_quantize": [True],
-          "quant_16x8": [True, False],
-      }]
+          "fully_quantize": [False, True],
+          "input_range": [(-3, 10)],
+          "quant_16x8": [False, True],
+      }
+  ]
 
   def build_graph(parameters):
     """Build the graph for the test case."""

--- a/tensorflow/lite/testing/op_tests/leaky_relu.py
+++ b/tensorflow/lite/testing/op_tests/leaky_relu.py
@@ -32,8 +32,21 @@ def make_leaky_relu_tests(options):
       {
           "input_shape": [[], [1], [5], [1, 10, 10, 3], [3, 3, 3, 3]],
           "alpha": [0.1, 1.0, 2.0, -0.1, -1.0, -2.0],
+          "fully_quantize": [False],
+          "quant_16x8": [False],
       },
-  ]
+      {
+          "input_shape": [[1, 10, 10, 3]],
+          "alpha": [0.1],
+          "fully_quantize": [True],
+          "quant_16x8": [True],
+      },
+      {
+          "input_shape": [[1, 10, 10, 3]],
+          "alpha": [0.1],
+          "fully_quantize": [True],
+          "quant_16x8": [False]
+      }]
 
   def build_graph(parameters):
     """Build the graph for the test case."""

--- a/tensorflow/lite/testing/op_tests/leaky_relu.py
+++ b/tensorflow/lite/testing/op_tests/leaky_relu.py
@@ -39,13 +39,7 @@ def make_leaky_relu_tests(options):
           "input_shape": [[1, 10, 10, 3]],
           "alpha": [0.1],
           "fully_quantize": [True],
-          "quant_16x8": [True],
-      },
-      {
-          "input_shape": [[1, 10, 10, 3]],
-          "alpha": [0.1],
-          "fully_quantize": [True],
-          "quant_16x8": [False]
+          "quant_16x8": [True, False],
       }]
 
   def build_graph(parameters):


### PR DESCRIPTION
Op tests for leaky_relu operator for 16x8 quantization mode.

Command to run them:
bazel run //tensorflow/lite/testing:generate_examples -- /tmp --zip_to_output=leaky_relu --toco=$(pwd)/bazel-bin/tensorflow/lite/toco/toco

Follow up of https://github.com/tensorflow/tensorflow/pull/39543
