### PR TITLE
[TFLite] Added op tests for conv_activations

### DIFF
--- a/tensorflow/lite/testing/op_tests/conv_activation.py
+++ b/tensorflow/lite/testing/op_tests/conv_activation.py
@@ -40,6 +40,7 @@ def make_conv_activation_tests(activation_op):
             "constant_filter": [True, False],
             "channel_multiplier": [1, 2],
             "fully_quantize": [False],
+            "quant_16x8": [False],
             "dynamic_range_quantize": [False],
         },
         # TODO(b/134702301): The fully_quantize param is just ignored by the
@@ -55,6 +56,7 @@ def make_conv_activation_tests(activation_op):
             "constant_filter": [True],
             "channel_multiplier": [1, 2],
             "fully_quantize": [True],
+            "quant_16x8": [False, True],
             "dynamic_range_quantize": [False],
         },
         {
@@ -67,6 +69,7 @@ def make_conv_activation_tests(activation_op):
             "constant_filter": [True],
             "channel_multiplier": [1, 2],
             "fully_quantize": [False],
+            "quant_16x8": [False],
             "dynamic_range_quantize": [True],
         },
     ]

--- a/tensorflow/lite/testing/op_tests/conv_activation.py
+++ b/tensorflow/lite/testing/op_tests/conv_activation.py
@@ -56,7 +56,20 @@ def make_conv_activation_tests(activation_op):
             "constant_filter": [True],
             "channel_multiplier": [1, 2],
             "fully_quantize": [True],
-            "quant_16x8": [False, True],
+            "quant_16x8": [False],
+            "dynamic_range_quantize": [False],
+        },
+        {
+            "input_shape": [[4, 6, 6, 1]],
+            "filter_shape": [[1, 1], [2, 3]],
+            "strides": [[1, 1, 1, 1], [1, 2, 3, 1]],
+            "dilations": [[1, 1, 1, 1], [1, 3, 2, 1]],
+            "padding": ["SAME", "VALID"],
+            "data_format": ["NHWC"],  # TODO(aselle): NCHW  would be good
+            "constant_filter": [True],
+            "channel_multiplier": [1, 2],
+            "fully_quantize": [True],
+            "quant_16x8": [True],
             "dynamic_range_quantize": [False],
         },
         {

--- a/tensorflow/lite/testing/op_tests/conv_activation.py
+++ b/tensorflow/lite/testing/op_tests/conv_activation.py
@@ -65,7 +65,7 @@ def make_conv_activation_tests(activation_op):
             "strides": [[1, 1, 1, 1], [1, 2, 3, 1]],
             "dilations": [[1, 1, 1, 1], [1, 3, 2, 1]],
             "padding": ["SAME", "VALID"],
-            "data_format": ["NHWC"],  # TODO(aselle): NCHW  would be good
+            "data_format": ["NHWC"],
             "constant_filter": [True],
             "channel_multiplier": [1, 2],
             "fully_quantize": [True],


### PR DESCRIPTION
Op tests for conv operator with activation for 16x8 quantization mode.

Command to run them:
bazel run //tensorflow/lite/testing:generate_examples -- /tmp --zip_to_output=conv_activation --toco=$(pwd)/bazel-bin/tensorflow/lite/toco/toco

Follow up of #39543