### PR TITLE
[TF-TRT] TRTEngineOp Unknown Inference Fix

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/ops/trt_engine_op.cc
+++ b/tensorflow/compiler/tf2tensorrt/ops/trt_engine_op.cc
@@ -36,6 +36,7 @@ REGISTER_OP("TRTEngineOp")
     .Attr("InT: list({int8,float16,float32,int32})")
     .Attr("OutT: list({int8,float16,float32,int32})")
     .Attr("input_shapes: list(shape) = []")
+    .Attr("output_shapes: list(shape) = []")
     .Attr("max_cached_engines_count: int = 1")
     .Attr("workspace_size_bytes: int")
     .Attr("precision_mode: {'FP32', 'FP16', 'INT8'}")
@@ -43,18 +44,24 @@ REGISTER_OP("TRTEngineOp")
     .Attr("use_calibration: bool = true")
     .Input("in_tensor: InT")
     .Output("out_tensor: OutT")
-    // TODO(jie): TF requires concrete output shape for concrete input shapes.
-    // This is tricky for batch dimension, since we cannot ensure which input
-    // would carry the correct batch dimension (for the current stage of the
-    // implementation, we do require all input tensor to carry the same batch
-    // size, but this could change in the future). Hence we disable shape
-    // inference function as a workaround.
-    .SetShapeFn(shape_inference::UnknownShape)
+    .SetShapeFn([](::tensorflow::shape_inference::InferenceContext* c) {
+      std::vector<tensorflow::PartialTensorShape> output_shapes;
+      TF_RETURN_IF_ERROR(c->GetAttr("output_shapes", &output_shapes));
+
+      for(int i=0; i<output_shapes.size(); i++) {
+        ::tensorflow::shape_inference::ShapeHandle shape;
+        shape_inference::ShapeHandle output_shape_handle;
+        TF_RETURN_IF_ERROR(c->MakeShapeFromPartialTensorShape(
+            output_shapes[i], &output_shape_handle));
+        c->set_output(i, output_shape_handle);
+      }
+
+      return Status::OK();
+    })
     // Deprecated attributes.
     .Attr("segment_funcdef_name: string = ''")
     .Attr("cached_engine_batches: list(int) >= 0 = []")
     .Attr("fixed_input_size: bool = true")
-    .Attr("output_shapes: list(shape) = []")
     .Attr("static_engine: bool = true");
 }  // namespace tensorflow
 

--- a/tensorflow/python/compiler/tensorrt/BUILD
+++ b/tensorflow/python/compiler/tensorrt/BUILD
@@ -138,6 +138,7 @@ cuda_py_tests(
         "test/rank_two_test.py",
         "test/reshape_transpose_test.py",
         "test/topk_test.py",
+        "test/trt_engine_op_shape_test.py",
         "test/trt_mode_test.py",
         "test/unary_test.py",
         "test/vgg_block_nchw_test.py",

--- a/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
+++ b/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
@@ -187,9 +187,8 @@ class TfTrtIntegrationTestBase(test_util.TensorFlowTestCase):
     """
 
     input_mask = [[False] + [True] * (len(shape) - 1) for shape in input_shapes]
-    output_mask = [
-        [False] + [True] * (len(shape) - 1) for shape in output_shapes
-    ]
+    output_mask = [[False] + [True] * (len(shape) - 1) if shape else []
+                   for shape in output_shapes]
 
     return self.BuildParamsWithMask(graph_fn, dtype, input_shapes,
                                     output_shapes, input_mask, output_mask, [],

--- a/tensorflow/python/compiler/tensorrt/test/trt_engine_op_shape_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/trt_engine_op_shape_test.py
@@ -20,10 +20,10 @@ from __future__ import print_function
 
 from tensorflow.python.compiler.tensorrt.test import tf_trt_integration_test_base as trt_test
 from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import tensor_shape
 from tensorflow.python.platform import test
 
-import numpy as np
-import tensorflow as tf
+from tensorflow.python import saved_model
 from tensorflow.python.saved_model import signature_constants
 from tensorflow.python.saved_model import tag_constants
 
@@ -36,7 +36,6 @@ class TRTEngineOpInputOutputShapeTest(trt_test.TfTrtIntegrationTestBase):
   """Testing conversion of Conv2D (data_format=NCHW) in TF-TRT conversion."""
 
   def GraphFn(self, inp):
-    np.random.seed(1234)
     b = array_ops.squeeze(inp, axis=[2])
     c = nn.relu(b)
     d1 = c + c
@@ -57,7 +56,7 @@ class TRTEngineOpInputOutputShapeTest(trt_test.TfTrtIntegrationTestBase):
       )._GetInferGraph(*args, **kwargs)
 
       def get_func_from_saved_model(saved_model_dir):
-          saved_model_loaded = tf.saved_model.load(
+          saved_model_loaded = saved_model.load.load(
               saved_model_dir, tags=[tag_constants.SERVING])
           graph_func = saved_model_loaded.signatures[
               signature_constants.DEFAULT_SERVING_SIGNATURE_DEF_KEY]
@@ -66,19 +65,19 @@ class TRTEngineOpInputOutputShapeTest(trt_test.TfTrtIntegrationTestBase):
       func, loaded_model = get_func_from_saved_model(trt_saved_model_dir)
 
       input_shape = func.inputs[0].shape
-      if isinstance(input_shape, tf.TensorShape):
+      if isinstance(input_shape, tensor_shape.TensorShape):
           input_shape = input_shape.as_list()
 
       output_shapes = [
           out_shape.shape.as_list()
-          if isinstance(out_shape.shape, tf.TensorShape) else
+          if isinstance(out_shape.shape, tensor_shape.TensorShape) else
           out_shape.shape
           for out_shape in func.outputs
       ]
 
-      assert (func.inputs[0].dtype == tf.float32)
-      assert (func.outputs[0].dtype == tf.float32)
-      assert (func.outputs[1].dtype == tf.float32)
+      assert (func.inputs[0].dtype == dtypes.float32)
+      assert (func.outputs[0].dtype == dtypes.float32)
+      assert (func.outputs[1].dtype == dtypes.float32)
 
       assert (input_shape == [None, 2, 1, 4])
       assert (output_shapes[0] == [None, 2, 4])

--- a/tensorflow/python/compiler/tensorrt/test/trt_engine_op_shape_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/trt_engine_op_shape_test.py
@@ -1,0 +1,96 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""This script test input and output shapes and dtype of the TRTEngineOp."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.python.compiler.tensorrt.test import tf_trt_integration_test_base as trt_test
+from tensorflow.python.framework import dtypes
+from tensorflow.python.platform import test
+
+import numpy as np
+import tensorflow as tf
+from tensorflow.python.saved_model import signature_constants
+from tensorflow.python.saved_model import tag_constants
+
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import nn
+
+
+class TRTEngineOpInputOutputShapeTest(trt_test.TfTrtIntegrationTestBase):
+  """Testing conversion of Conv2D (data_format=NCHW) in TF-TRT conversion."""
+
+  def GraphFn(self, inp):
+    np.random.seed(1234)
+    b = array_ops.squeeze(inp, axis=[2])
+    c = nn.relu(b)
+    d1 = c + c
+    d2 = math_ops.reduce_sum(d1)
+
+    d1 = array_ops.identity(d1, name="output_0")
+    d2 = array_ops.identity(d2, name="output_1")
+    return d1, d2
+
+  def GetParams(self):
+    # TODO(aaroey): test graph with different dtypes.
+    return self.BuildParams(self.GraphFn, dtypes.float32, [[1, 2, 1, 4]],
+                            [[1, 2, 4], []])
+
+  def _GetInferGraph(self, *args, **kwargs):
+      trt_saved_model_dir = super(
+          TRTEngineOpInputOutputShapeTest, self
+      )._GetInferGraph(*args, **kwargs)
+
+      def get_func_from_saved_model(saved_model_dir):
+          saved_model_loaded = tf.saved_model.load(
+              saved_model_dir, tags=[tag_constants.SERVING])
+          graph_func = saved_model_loaded.signatures[
+              signature_constants.DEFAULT_SERVING_SIGNATURE_DEF_KEY]
+          return graph_func, saved_model_loaded
+
+      func, loaded_model = get_func_from_saved_model(trt_saved_model_dir)
+
+      input_shape = func.inputs[0].shape
+      if isinstance(input_shape, tf.TensorShape):
+          input_shape = input_shape.as_list()
+
+      output_shapes = [
+          out_shape.shape.as_list()
+          if isinstance(out_shape.shape, tf.TensorShape) else
+          out_shape.shape
+          for out_shape in func.outputs
+      ]
+
+      assert (func.inputs[0].dtype == tf.float32)
+      assert (func.outputs[0].dtype == tf.float32)
+      assert (func.outputs[1].dtype == tf.float32)
+
+      assert (input_shape == [None, 2, 1, 4])
+      assert (output_shapes[0] == [None, 2, 4])
+      assert (output_shapes[1] == [])
+
+      return trt_saved_model_dir
+
+  def ExpectedEnginesToBuild(self, run_params):
+    """Return the expected engines to build."""
+    return ["TRTEngineOp_0"]
+
+
+if __name__ == "__main__":
+  test.main()
+


### PR DESCRIPTION
@bixia1 : for review

You can reproduce the bug with the following code:

```python
#!/usr/bin/env python
# coding: utf-8

import numpy as np
import tensorflow as tf
from tensorflow.python.compiler.tensorrt import trt_convert as trt
from tensorflow.python.saved_model import signature_constants
from tensorflow.python.saved_model import tag_constants

from tensorflow.python.ops import array_ops
from tensorflow.python.ops import math_ops
from tensorflow.python.ops import nn


# ## Define TF2 model
# The data type of A will define the input type of the network

a = np.arange(-4, 4, dtype=np.float32).reshape((1,2,1,4))

@tf.function
def my_network(x):
    b = array_ops.squeeze(x, axis=[2])
    c = nn.relu(b)
    d1 = c + c
    d2 = math_ops.reduce_sum(d1)
    return d1, d2


output = my_network(tf.convert_to_tensor(a))
print('Output:', output)

cfunc = my_network.get_concrete_function(
    tf.TensorSpec(a.shape, tf.dtypes.as_dtype(a.dtype))
)

# we can save a function just by making it a field of a module
module = tf.Module()
module.myfunc = my_network

tf.saved_model.save(module,'/tmp/models/my_function', signatures=cfunc)


# ## Convert model to TF-TRT
converter = trt.TrtGraphConverterV2(input_saved_model_dir="/tmp/models/my_function")
converter.convert()


def input_fn():
    input_shapes = [[a.shape], ]
    for shapes in input_shapes:
        # return a list of input tensors
        yield [np.ones(shape=x).astype(a.dtype) for x in shapes]


converter.build(input_fn)

converter.save("/tmp/models/trt_model")

print("Model exported to TRT")


def get_func_from_saved_model(saved_model_dir):
    saved_model_loaded = tf.saved_model.load(
        saved_model_dir, tags=[tag_constants.SERVING])
    graph_func = saved_model_loaded.signatures[
        signature_constants.DEFAULT_SERVING_SIGNATURE_DEF_KEY]
    return graph_func, saved_model_loaded


func, loaded_model = get_func_from_saved_model("/tmp/models/trt_model")


print("Input tensor", func.inputs)
assert(func.inputs[0].shape == tf.TensorShape((1, 2, 1, 4)))

print("Output tensor", func.outputs)

assert(func.outputs[0].shape == tf.TensorShape(dims=(1, 2, 4)))
assert(func.outputs[1].shape == tf.TensorShape(dims=()))
```

With upstream tensorflow, this piece of code will fail. 

With this PR you should obtain this result:
```
Input tensor [<tf.Tensor 'x:0' shape=(1, 2, 1, 4) dtype=float32>]
Output tensor [<tf.Tensor 'Identity:0' shape=(1, 2, 4) dtype=float32>, <tf.Tensor 'Identity_1:0' shape=() dtype=float32>]
```

**My next step:** using the script above as a unittest