### PR TITLE
[Grappler] Fix bug in UpdateSqueezeDims

### DIFF
--- a/tensorflow/core/grappler/optimizers/generic_layout_optimizer_transposer.cc
+++ b/tensorflow/core/grappler/optimizers/generic_layout_optimizer_transposer.cc
@@ -1493,21 +1493,21 @@ Status SqueezeTransposer::UpdateSqueezeDims(TransposeContext* context,
   if (squeeze_dims_attr == nullptr) {
     return errors::InvalidArgument("Missing attribute ", kAttrSqueezeDims);
   }
-  const int max_num_squeeze_dim = context->src_format.length() - 1;
-  const int min_squeeze_dim = -(max_num_squeeze_dim + 1);
+  const int num_input_dims = context->src_format.length();
+  const int min_squeeze_dim = -num_input_dims;
   std::vector<int> squeeze_dims_mapped;
   const int squeeze_dims_size = squeeze_dims_attr->list().i_size();
   squeeze_dims_mapped.reserve(squeeze_dims_size);
   for (int i = 0; i < squeeze_dims_size; ++i) {
     int dim = squeeze_dims_attr->list().i(i);
-    if (dim < min_squeeze_dim || dim >= max_num_squeeze_dim) {
+    if (dim < min_squeeze_dim || dim >= num_input_dims) {
       return errors::InvalidArgument(
           "Attribute '", kAttrSqueezeDims, "' contains out of range index '",
           dim, "', index must be between [", min_squeeze_dim, ", ",
-          max_num_squeeze_dim, ")");
+          num_input_dims, ")");
     }
     if (dim < 0) {
-      dim += max_num_squeeze_dim;
+      dim += num_input_dims;
     }
     squeeze_dims_mapped.push_back(context->dst_to_src[dim]);
   }

--- a/tensorflow/core/grappler/optimizers/generic_layout_optimizer_transposer_test.cc
+++ b/tensorflow/core/grappler/optimizers/generic_layout_optimizer_transposer_test.cc
@@ -2137,6 +2137,133 @@ TEST_F(TransposerTest, SqueezeTransposerTestSqueezeDimsUpdated) {
   VerifyRegularFaninMatch(z_output_node, 0, squeeze_node->GetName(), 0);
 }
 
+// Same as SqueezeTransposerTestSqueezeDimsUpdated but with squeeze dims
+// specified with negative values.
+TEST_F(TransposerTest, SqueezeTransposerTestNegativeSqueezeDimsUpdated) {
+#if !(GOOGLE_CUDA || TENSORFLOW_USE_ROCM)
+  GTEST_SKIP() << "Neither CUDA nor ROCm is enabled";
+#endif  // !(GOOGLE_CUDA || TENSORFLOW_USE_ROCM)
+  GrapplerItem item;
+  Scope scope = Scope::NewRootScope();
+  auto input =
+      ops::RandomUniform(scope.WithOpName("input"), {1, 1, 1, 8}, DT_FLOAT);
+  auto filter =
+      ops::RandomUniform(scope.WithOpName("filter"), {1, 1, 8, 1}, DT_FLOAT);
+  auto conv2d = ops::Conv2D(
+      scope.WithOpName("conv2d").WithDevice("/device:GPU:0"), input, filter,
+      {1, 1, 1, 1}, "SAME", ops::Conv2D::DataFormat(kSrcFormat));
+
+  auto squeeze_op =
+      ops::Squeeze(scope.WithOpName("squeeze").WithDevice("/device:GPU:0"),
+                   conv2d, ops::Squeeze::Attrs().Axis({-3, -2}));
+  auto z = ops::Identity(scope.WithOpName("z"), squeeze_op);
+  TF_ASSERT_OK(scope.ToGraphDef(&item.graph));
+  TransposeContext context;
+  TF_ASSERT_OK(TransposeContext::InitializeTransposeContext(
+      item, virtual_cluster_.get(), &context));
+  context.AssignDeviceAndDataFormats(kGPU, kSrcFormat, kDstFormat);
+
+  DefaultLayoutSensitiveOpTransposer conv2d_transposer;
+  auto* c2d = context.graph_view->GetNode("conv2d");
+  ASSERT_NE(c2d, nullptr);
+  TF_ASSERT_OK(conv2d_transposer.TransposeNode(&context, c2d));
+
+  SqueezeTransposer squeeze_transposer;
+  auto* squeeze = context.graph_view->GetNode("squeeze");
+  ASSERT_NE(squeeze, nullptr);
+  TF_ASSERT_OK(squeeze_transposer.TransposeNode(&context, squeeze));
+
+  auto* input_transpose_node1 = context.graph_view->GetNode(
+      "squeeze-0-TransposeNHWCToNCHW-LayoutOptimizer");
+  ASSERT_NE(input_transpose_node1, nullptr);
+  ASSERT_EQ(input_transpose_node1->NumRegularFanins(), 2);
+  VerifyRegularFaninMatch(input_transpose_node1, 0,
+                          "conv2d-0-0-TransposeNCHWToNHWC-LayoutOptimizer", 0);
+
+  auto* squeeze_node = context.graph_view->GetNode("squeeze");
+  ASSERT_NE(squeeze_node, nullptr);
+  ASSERT_EQ(squeeze_node->NumRegularFanins(), 1);
+  VerifyRegularFaninMatch(squeeze_node, 0, input_transpose_node1->GetName(), 0);
+  const auto* squeeze_dims_attr = squeeze_node->GetAttr("squeeze_dims");
+  const auto& list = squeeze_dims_attr->list();
+  ASSERT_EQ(list.i_size(), 2);
+  EXPECT_EQ(list.i(0), 2);
+  EXPECT_EQ(list.i(1), 3);
+
+  auto* output_transpose_node = context.graph_view->GetNode(
+      "squeeze-0-0-TransposeNCHWToNHWC-LayoutOptimizer");
+  EXPECT_EQ(output_transpose_node, nullptr);
+
+  auto* z_output_node = context.graph_view->GetNode("z");
+  ASSERT_NE(z_output_node, nullptr);
+  ASSERT_EQ(z_output_node->NumRegularFanins(), 1);
+  VerifyRegularFaninMatch(z_output_node, 0, squeeze_node->GetName(), 0);
+}
+
+// Same as SqueezeTransposerTestSqueezeDimsUpdated but with the source and
+// destination formats swapped (as is used in some cases when the data type is
+// DT_HALF).
+TEST_F(TransposerTest, SqueezeTransposerTestNCHWToNHWCSqueezeDimsUpdated) {
+#if !(GOOGLE_CUDA || TENSORFLOW_USE_ROCM)
+  GTEST_SKIP() << "Neither CUDA nor ROCm is enabled";
+#endif  // !(GOOGLE_CUDA || TENSORFLOW_USE_ROCM)
+  GrapplerItem item;
+  Scope scope = Scope::NewRootScope();
+  auto input =
+      ops::RandomUniform(scope.WithOpName("input"), {1, 8, 1, 1}, DT_FLOAT);
+  auto filter =
+      ops::RandomUniform(scope.WithOpName("filter"), {1, 1, 8, 1}, DT_FLOAT);
+  auto conv2d = ops::Conv2D(
+      scope.WithOpName("conv2d").WithDevice("/device:GPU:0"), input, filter,
+      {1, 1, 1, 1}, "SAME", ops::Conv2D::DataFormat(kDstFormat));
+
+  auto squeeze_op =
+      ops::Squeeze(scope.WithOpName("squeeze").WithDevice("/device:GPU:0"),
+                   conv2d, ops::Squeeze::Attrs().Axis({2, 3}));
+  auto z = ops::Identity(scope.WithOpName("z"), squeeze_op);
+  TF_ASSERT_OK(scope.ToGraphDef(&item.graph));
+  TransposeContext context;
+  TF_ASSERT_OK(TransposeContext::InitializeTransposeContext(
+      item, virtual_cluster_.get(), &context));
+  context.AssignDeviceAndDataFormats(kGPU, kDstFormat, kSrcFormat);
+
+  DefaultLayoutSensitiveOpTransposer conv2d_transposer;
+  auto* c2d = context.graph_view->GetNode("conv2d");
+  ASSERT_NE(c2d, nullptr);
+  TF_ASSERT_OK(conv2d_transposer.TransposeNode(&context, c2d));
+
+  SqueezeTransposer squeeze_transposer;
+  auto* squeeze = context.graph_view->GetNode("squeeze");
+  ASSERT_NE(squeeze, nullptr);
+  TF_ASSERT_OK(squeeze_transposer.TransposeNode(&context, squeeze));
+
+  auto* input_transpose_node1 = context.graph_view->GetNode(
+      "squeeze-0-TransposeNCHWToNHWC-LayoutOptimizer");
+  ASSERT_NE(input_transpose_node1, nullptr);
+  ASSERT_EQ(input_transpose_node1->NumRegularFanins(), 2);
+  VerifyRegularFaninMatch(input_transpose_node1, 0,
+                          "conv2d-0-0-TransposeNHWCToNCHW-LayoutOptimizer", 0);
+
+  auto* squeeze_node = context.graph_view->GetNode("squeeze");
+  ASSERT_NE(squeeze_node, nullptr);
+  ASSERT_EQ(squeeze_node->NumRegularFanins(), 1);
+  VerifyRegularFaninMatch(squeeze_node, 0, input_transpose_node1->GetName(), 0);
+  const auto* squeeze_dims_attr = squeeze_node->GetAttr("squeeze_dims");
+  const auto& list = squeeze_dims_attr->list();
+  ASSERT_EQ(list.i_size(), 2);
+  EXPECT_EQ(list.i(0), 1);
+  EXPECT_EQ(list.i(1), 2);
+
+  auto* output_transpose_node = context.graph_view->GetNode(
+      "squeeze-0-0-TransposeNHWCToNCHW-LayoutOptimizer");
+  EXPECT_EQ(output_transpose_node, nullptr);
+
+  auto* z_output_node = context.graph_view->GetNode("z");
+  ASSERT_NE(z_output_node, nullptr);
+  ASSERT_EQ(z_output_node->NumRegularFanins(), 1);
+  VerifyRegularFaninMatch(z_output_node, 0, squeeze_node->GetName(), 0);
+}
+
 TEST_F(TransposerTest, MaxPoolV2Transposer) {
 #if !(GOOGLE_CUDA || TENSORFLOW_USE_ROCM)
   GTEST_SKIP() << "Neither CUDA nor ROCm is enabled";


### PR DESCRIPTION
The dim logic in generic_layout_transposer's SqueezeTransposer was incorrect, which caused two problems:
- Negative dims were transformed incorrectly.
- The dim check incorrectly failed when dim = rank - 1 (which can occur when transforming NCHW to NHWC).

This PR fixes the dim logic and adds tests to check these cases.

cc @nluehr 