### PR TITLE
Adopt existing cpu frequency implementation over abseil one

### DIFF
--- a/tensorflow/core/platform/default/BUILD
+++ b/tensorflow/core/platform/default/BUILD
@@ -269,6 +269,8 @@ cc_library(
         "//tensorflow/core/platform:mem.h",
         "//tensorflow/core/platform:numa.h",
         "//tensorflow/core/platform:snappy.h",
+        "//tensorflow/core/platform:profile_utils/cpu_utils.h",
+        "//tensorflow/core/platform:profile_utils/i_cpu_utils_helper.h",
     ],
     copts = tf_copts(),
     defines = ["TF_USE_SNAPPY"] + select({

--- a/tensorflow/core/platform/default/BUILD
+++ b/tensorflow/core/platform/default/BUILD
@@ -268,9 +268,9 @@ cc_library(
         "//tensorflow/core/platform:init_main.h",
         "//tensorflow/core/platform:mem.h",
         "//tensorflow/core/platform:numa.h",
-        "//tensorflow/core/platform:snappy.h",
         "//tensorflow/core/platform:profile_utils/cpu_utils.h",
         "//tensorflow/core/platform:profile_utils/i_cpu_utils_helper.h",
+        "//tensorflow/core/platform:snappy.h",
     ],
     copts = tf_copts(),
     defines = ["TF_USE_SNAPPY"] + select({

--- a/tensorflow/core/platform/default/port.cc
+++ b/tensorflow/core/platform/default/port.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include "tensorflow/core/platform/numa.h"
 #include "tensorflow/core/platform/snappy.h"
 #include "tensorflow/core/platform/types.h"
+#include "tensorflow/core/platform/profile_utils/cpu_utils.h"
 
 #if defined(__linux__) && !defined(__ANDROID__)
 #include <sched.h>
@@ -345,7 +346,7 @@ bool Snappy_UncompressToIOVec(const char* compressed, size_t compressed_length,
 string Demangle(const char* mangled) { return mangled; }
 
 double NominalCPUFrequency() {
-  return absl::base_internal::NominalCPUFrequency();
+  return tensorflow::profile_utils::CpuUtils::GetCycleCounterFrequency();
 }
 
 MemoryInfo GetMemoryInfo() {


### PR DESCRIPTION
Solving issue https://github.com/tensorflow/tensorflow/issues/41033
Remove the abseil internal method of retrieving cpu frequency, and use a Tensorflow native one instead.