### PR TITLE
Move some filesystems to new api

### DIFF
--- a/tensorflow/c/experimental/filesystem/modular_filesystem.cc
+++ b/tensorflow/c/experimental/filesystem/modular_filesystem.cc
@@ -35,7 +35,7 @@ using UniquePtrTo_TF_Status =
     ::std::unique_ptr<TF_Status, decltype(&TF_DeleteStatus)>;
 
 Status ModularFileSystem::NewRandomAccessFile(
-    const std::string& fname, std::unique_ptr<RandomAccessFile>* result) {
+    const std::string& fname, std::unique_ptr<RandomAccessFile>* result/*, TransactionToken* token */) {
   if (ops_->new_random_access_file == nullptr)
     return errors::Unimplemented(tensorflow::strings::StrCat(
         "Filesystem for ", fname, " does not support NewRandomAccessFile()"));
@@ -54,7 +54,7 @@ Status ModularFileSystem::NewRandomAccessFile(
 }
 
 Status ModularFileSystem::NewWritableFile(
-    const std::string& fname, std::unique_ptr<WritableFile>* result) {
+    const std::string& fname, std::unique_ptr<WritableFile>* result/*, TransactionToken* token */) {
   if (ops_->new_writable_file == nullptr)
     return errors::Unimplemented(tensorflow::strings::StrCat(
         "Filesystem for ", fname, " does not support NewWritableFile()"));
@@ -73,7 +73,7 @@ Status ModularFileSystem::NewWritableFile(
 }
 
 Status ModularFileSystem::NewAppendableFile(
-    const std::string& fname, std::unique_ptr<WritableFile>* result) {
+    const std::string& fname, std::unique_ptr<WritableFile>* result/*, TransactionToken* token */) {
   if (ops_->new_appendable_file == nullptr)
     return errors::Unimplemented(tensorflow::strings::StrCat(
         "Filesystem for ", fname, " does not support NewAppendableFile()"));
@@ -92,7 +92,7 @@ Status ModularFileSystem::NewAppendableFile(
 }
 
 Status ModularFileSystem::NewReadOnlyMemoryRegionFromFile(
-    const std::string& fname, std::unique_ptr<ReadOnlyMemoryRegion>* result) {
+    const std::string& fname, std::unique_ptr<ReadOnlyMemoryRegion>* result/*, TransactionToken* token */) {
   if (ops_->new_read_only_memory_region_from_file == nullptr)
     return errors::Unimplemented(tensorflow::strings::StrCat(
         "Filesystem for ", fname,
@@ -112,7 +112,7 @@ Status ModularFileSystem::NewReadOnlyMemoryRegionFromFile(
   return StatusFromTF_Status(plugin_status.get());
 }
 
-Status ModularFileSystem::FileExists(const std::string& fname) {
+Status ModularFileSystem::FileExists(const std::string& fname/*, TransactionToken* token */) {
   if (ops_->path_exists == nullptr)
     return errors::Unimplemented(tensorflow::strings::StrCat(
         "Filesystem for ", fname, " does not support FileExists()"));
@@ -125,7 +125,7 @@ Status ModularFileSystem::FileExists(const std::string& fname) {
 }
 
 bool ModularFileSystem::FilesExist(const std::vector<std::string>& files,
-                                   std::vector<Status>* status) {
+                                   std::vector<Status>* status/*, TransactionToken* token */) {
   if (ops_->paths_exist == nullptr)
     return FileSystem::FilesExist(files, status);
 
@@ -157,7 +157,7 @@ bool ModularFileSystem::FilesExist(const std::vector<std::string>& files,
 }
 
 Status ModularFileSystem::GetChildren(const std::string& dir,
-                                      std::vector<std::string>* result) {
+                                      std::vector<std::string>* result/*, TransactionToken* token */) {
   if (ops_->get_children == nullptr)
     return errors::Unimplemented(tensorflow::strings::StrCat(
         "Filesystem for ", dir, " does not support GetChildren()"));
@@ -182,7 +182,7 @@ Status ModularFileSystem::GetChildren(const std::string& dir,
 }
 
 Status ModularFileSystem::GetMatchingPaths(const std::string& pattern,
-                                           std::vector<std::string>* result) {
+                                           std::vector<std::string>* result/*, TransactionToken* token */) {
   if (ops_->get_matching_paths == nullptr)
     return internal::GetMatchingPaths(this, Env::Default(), pattern, result);
 
@@ -203,7 +203,7 @@ Status ModularFileSystem::GetMatchingPaths(const std::string& pattern,
   return StatusFromTF_Status(plugin_status.get());
 }
 
-Status ModularFileSystem::DeleteFile(const std::string& fname) {
+Status ModularFileSystem::DeleteFile(const std::string& fname/*, TransactionToken* token */) {
   if (ops_->delete_file == nullptr)
     return errors::Unimplemented(tensorflow::strings::StrCat(
         "Filesystem for ", fname, " does not support DeleteFile()"));
@@ -217,7 +217,7 @@ Status ModularFileSystem::DeleteFile(const std::string& fname) {
 
 Status ModularFileSystem::DeleteRecursively(const std::string& dirname,
                                             int64* undeleted_files,
-                                            int64* undeleted_dirs) {
+                                            int64* undeleted_dirs/*, TransactionToken* token */) {
   if (undeleted_files == nullptr || undeleted_dirs == nullptr)
     return errors::FailedPrecondition(
         "DeleteRecursively must not be called with `undeleted_files` or "
@@ -238,7 +238,7 @@ Status ModularFileSystem::DeleteRecursively(const std::string& dirname,
   return StatusFromTF_Status(plugin_status.get());
 }
 
-Status ModularFileSystem::DeleteDir(const std::string& dirname) {
+Status ModularFileSystem::DeleteDir(const std::string& dirname/*, TransactionToken* token */) {
   if (ops_->delete_dir == nullptr)
     return errors::Unimplemented(tensorflow::strings::StrCat(
         "Filesystem for ", dirname, " does not support DeleteDir()"));
@@ -250,7 +250,7 @@ Status ModularFileSystem::DeleteDir(const std::string& dirname) {
   return StatusFromTF_Status(plugin_status.get());
 }
 
-Status ModularFileSystem::RecursivelyCreateDir(const std::string& dirname) {
+Status ModularFileSystem::RecursivelyCreateDir(const std::string& dirname/*, TransactionToken* token */) {
   if (ops_->recursively_create_dir == nullptr)
     return FileSystem::RecursivelyCreateDir(dirname);
 
@@ -261,7 +261,7 @@ Status ModularFileSystem::RecursivelyCreateDir(const std::string& dirname) {
   return StatusFromTF_Status(plugin_status.get());
 }
 
-Status ModularFileSystem::CreateDir(const std::string& dirname) {
+Status ModularFileSystem::CreateDir(const std::string& dirname/*, TransactionToken* token */) {
   if (ops_->create_dir == nullptr)
     return errors::Unimplemented(tensorflow::strings::StrCat(
         "Filesystem for ", dirname, " does not support CreateDir()"));
@@ -273,7 +273,7 @@ Status ModularFileSystem::CreateDir(const std::string& dirname) {
   return StatusFromTF_Status(plugin_status.get());
 }
 
-Status ModularFileSystem::Stat(const std::string& fname, FileStatistics* stat) {
+Status ModularFileSystem::Stat(const std::string& fname, FileStatistics* stat/*, TransactionToken* token */) {
   if (ops_->stat == nullptr)
     return errors::Unimplemented(tensorflow::strings::StrCat(
         "Filesystem for ", fname, " does not support Stat()"));
@@ -296,7 +296,7 @@ Status ModularFileSystem::Stat(const std::string& fname, FileStatistics* stat) {
   return StatusFromTF_Status(plugin_status.get());
 }
 
-Status ModularFileSystem::IsDirectory(const std::string& name) {
+Status ModularFileSystem::IsDirectory(const std::string& name/*, TransactionToken* token */) {
   if (ops_->is_directory == nullptr) return FileSystem::IsDirectory(name);
 
   UniquePtrTo_TF_Status plugin_status(TF_NewStatus(), TF_DeleteStatus);
@@ -307,7 +307,7 @@ Status ModularFileSystem::IsDirectory(const std::string& name) {
 }
 
 Status ModularFileSystem::GetFileSize(const std::string& fname,
-                                      uint64* file_size) {
+                                      uint64* file_size/*, TransactionToken* token */) {
   if (ops_->get_file_size == nullptr) {
     FileStatistics stat;
     Status status = Stat(fname, &stat);
@@ -327,7 +327,7 @@ Status ModularFileSystem::GetFileSize(const std::string& fname,
 }
 
 Status ModularFileSystem::RenameFile(const std::string& src,
-                                     const std::string& target) {
+                                     const std::string& target/*, TransactionToken* token */) {
   if (ops_->rename_file == nullptr) {
     Status status = CopyFile(src, target);
     if (status.ok()) status = DeleteFile(src);
@@ -343,7 +343,7 @@ Status ModularFileSystem::RenameFile(const std::string& src,
 }
 
 Status ModularFileSystem::CopyFile(const std::string& src,
-                                   const std::string& target) {
+                                   const std::string& target/*, TransactionToken* token */) {
   if (ops_->copy_file == nullptr) return FileSystem::CopyFile(src, target);
 
   UniquePtrTo_TF_Status plugin_status(TF_NewStatus(), TF_DeleteStatus);
@@ -354,7 +354,7 @@ Status ModularFileSystem::CopyFile(const std::string& src,
   return StatusFromTF_Status(plugin_status.get());
 }
 
-std::string ModularFileSystem::TranslateName(const std::string& name) const {
+std::string ModularFileSystem::TranslateName(const std::string& name/*, TransactionToken* token */) const {
   if (ops_->translate_name == nullptr) return FileSystem::TranslateName(name);
 
   char* p = ops_->translate_name(filesystem_.get(), name.c_str());
@@ -366,7 +366,7 @@ std::string ModularFileSystem::TranslateName(const std::string& name) const {
   return ret;
 }
 
-void ModularFileSystem::FlushCaches() {
+void ModularFileSystem::FlushCaches(TransactionToken* token=nullptr) {
   if (ops_->flush_caches != nullptr) ops_->flush_caches(filesystem_.get());
 }
 

--- a/tensorflow/c/experimental/filesystem/modular_filesystem.h
+++ b/tensorflow/c/experimental/filesystem/modular_filesystem.h
@@ -61,34 +61,34 @@ class ModularFileSystem final : public FileSystem {
 
   Status NewRandomAccessFile(
       const std::string& fname,
-      std::unique_ptr<RandomAccessFile>* result) override;
+      std::unique_ptr<RandomAccessFile>* result/*, TransactionToken* token = nullptr */) override;
   Status NewWritableFile(const std::string& fname,
-                         std::unique_ptr<WritableFile>* result) override;
+                         std::unique_ptr<WritableFile>* result/*, TransactionToken* token = nullptr */) override;
   Status NewAppendableFile(const std::string& fname,
-                           std::unique_ptr<WritableFile>* result) override;
+                           std::unique_ptr<WritableFile>* result/*, TransactionToken* token = nullptr */) override;
   Status NewReadOnlyMemoryRegionFromFile(
       const std::string& fname,
-      std::unique_ptr<ReadOnlyMemoryRegion>* result) override;
-  Status FileExists(const std::string& fname) override;
+      std::unique_ptr<ReadOnlyMemoryRegion>* result/*, TransactionToken* token = nullptr */) override;
+  Status FileExists(const std::string& fname/*, TransactionToken* token = nullptr */) override;
   bool FilesExist(const std::vector<std::string>& files,
-                  std::vector<Status>* status) override;
+                  std::vector<Status>* status/*, TransactionToken* token = nullptr */) override;
   Status GetChildren(const std::string& dir,
-                     std::vector<std::string>* result) override;
+                     std::vector<std::string>* result/*, TransactionToken* token = nullptr */) override;
   Status GetMatchingPaths(const std::string& pattern,
-                          std::vector<std::string>* results) override;
-  Status DeleteFile(const std::string& fname) override;
+                          std::vector<std::string>* results/*, TransactionToken* token = nullptr */) override;
+  Status DeleteFile(const std::string& fname/*, TransactionToken* token = nullptr */) override;
   Status DeleteRecursively(const std::string& dirname, int64* undeleted_files,
-                           int64* undeleted_dirs) override;
-  Status DeleteDir(const std::string& dirname) override;
-  Status RecursivelyCreateDir(const std::string& dirname) override;
-  Status CreateDir(const std::string& dirname) override;
-  Status Stat(const std::string& fname, FileStatistics* stat) override;
-  Status IsDirectory(const std::string& fname) override;
-  Status GetFileSize(const std::string& fname, uint64* file_size) override;
-  Status RenameFile(const std::string& src, const std::string& target) override;
-  Status CopyFile(const std::string& src, const std::string& target) override;
-  std::string TranslateName(const std::string& name) const override;
-  void FlushCaches() override;
+                           int64* undeleted_dirs/*, TransactionToken* token = nullptr */) override;
+  Status DeleteDir(const std::string& dirname/*, TransactionToken* token = nullptr */) override;
+  Status RecursivelyCreateDir(const std::string& dirname/*, TransactionToken* token = nullptr */) override;
+  Status CreateDir(const std::string& dirname/*, TransactionToken* token = nullptr */) override;
+  Status Stat(const std::string& fname, FileStatistics* stat/*, TransactionToken* token = nullptr */) override;
+  Status IsDirectory(const std::string& fname/*, TransactionToken* token = nullptr */) override;
+  Status GetFileSize(const std::string& fname, uint64* file_size/*, TransactionToken* token = nullptr */) override;
+  Status RenameFile(const std::string& src, const std::string& target/*, TransactionToken* token = nullptr */) override;
+  Status CopyFile(const std::string& src, const std::string& target/*, TransactionToken* token = nullptr */) override;
+  std::string TranslateName(const std::string& name/*, TransactionToken* token = nullptr */) const override;
+  void FlushCaches(/* TransactionToken* token=nullptr */) override;
 
  private:
   std::unique_ptr<TF_Filesystem> filesystem_;

--- a/tensorflow/core/platform/null_file_system.h
+++ b/tensorflow/core/platform/null_file_system.h
@@ -37,61 +37,61 @@ class NullFileSystem : public FileSystem {
   ~NullFileSystem() override = default;
 
   Status NewRandomAccessFile(
-      const string& fname, std::unique_ptr<RandomAccessFile>* result) override {
+      const string& fname, std::unique_ptr<RandomAccessFile>* result/*, TransactionToken* token = nullptr */) override {
     return errors::Unimplemented("NewRandomAccessFile unimplemented");
   }
 
   Status NewWritableFile(const string& fname,
-                         std::unique_ptr<WritableFile>* result) override {
+                         std::unique_ptr<WritableFile>* result/*, TransactionToken* token = nullptr */) override {
     return errors::Unimplemented("NewWritableFile unimplemented");
   }
 
   Status NewAppendableFile(const string& fname,
-                           std::unique_ptr<WritableFile>* result) override {
+                           std::unique_ptr<WritableFile>* result/*, TransactionToken* token = nullptr */) override {
     return errors::Unimplemented("NewAppendableFile unimplemented");
   }
 
   Status NewReadOnlyMemoryRegionFromFile(
       const string& fname,
-      std::unique_ptr<ReadOnlyMemoryRegion>* result) override {
+      std::unique_ptr<ReadOnlyMemoryRegion>* result/*, TransactionToken* token = nullptr */) override {
     return errors::Unimplemented(
         "NewReadOnlyMemoryRegionFromFile unimplemented");
   }
 
-  Status FileExists(const string& fname) override {
+  Status FileExists(const string& fname/*, TransactionToken* token = nullptr */) override {
     return errors::Unimplemented("FileExists unimplemented");
   }
 
-  Status GetChildren(const string& dir, std::vector<string>* result) override {
+  Status GetChildren(const string& dir, std::vector<string>* result/*, TransactionToken* token = nullptr */) override {
     return errors::Unimplemented("GetChildren unimplemented");
   }
 
   Status GetMatchingPaths(const string& pattern,
-                          std::vector<string>* results) override {
+                          std::vector<string>* results/*, TransactionToken* token = nullptr */) override {
     return internal::GetMatchingPaths(this, Env::Default(), pattern, results);
   }
 
-  Status DeleteFile(const string& fname) override {
+  Status DeleteFile(const string& fname/*, TransactionToken* token = nullptr */) override {
     return errors::Unimplemented("DeleteFile unimplemented");
   }
 
-  Status CreateDir(const string& dirname) override {
+  Status CreateDir(const string& dirname/*, TransactionToken* token = nullptr */) override {
     return errors::Unimplemented("CreateDir unimplemented");
   }
 
-  Status DeleteDir(const string& dirname) override {
+  Status DeleteDir(const string& dirname/*, TransactionToken* token = nullptr */) override {
     return errors::Unimplemented("DeleteDir unimplemented");
   }
 
-  Status GetFileSize(const string& fname, uint64* file_size) override {
+  Status GetFileSize(const string& fname, uint64* file_size/*, TransactionToken* token = nullptr */) override {
     return errors::Unimplemented("GetFileSize unimplemented");
   }
 
-  Status RenameFile(const string& src, const string& target) override {
+  Status RenameFile(const string& src, const string& target/*, TransactionToken* token = nullptr */) override {
     return errors::Unimplemented("RenameFile unimplemented");
   }
 
-  Status Stat(const string& fname, FileStatistics* stat) override {
+  Status Stat(const string& fname, FileStatistics* stat/*, TransactionToken* token = nullptr */) override {
     return errors::Unimplemented("Stat unimplemented");
   }
 };

--- a/tensorflow/core/platform/ram_file_system.h
+++ b/tensorflow/core/platform/ram_file_system.h
@@ -104,7 +104,7 @@ class RamRandomAccessFile : public RandomAccessFile, public WritableFile {
 class RamFileSystem : public FileSystem {
  public:
   Status NewRandomAccessFile(
-      const string& fname, std::unique_ptr<RandomAccessFile>* result) override {
+      const string& fname, std::unique_ptr<RandomAccessFile>* result/*, TransactionToken* token = nullptr */) override {
     mutex_lock m(mu_);
     if (fs_.find(fname) == fs_.end()) {
       return errors::NotFound("");
@@ -115,7 +115,7 @@ class RamFileSystem : public FileSystem {
   }
 
   Status NewWritableFile(const string& fname,
-                         std::unique_ptr<WritableFile>* result) override {
+                         std::unique_ptr<WritableFile>* result/*, TransactionToken* token = nullptr */) override {
     mutex_lock m(mu_);
     if (fs_.find(fname) == fs_.end()) {
       fs_[fname] = std::make_shared<std::string>();
@@ -125,7 +125,7 @@ class RamFileSystem : public FileSystem {
     return Status::OK();
   }
   Status NewAppendableFile(const string& fname,
-                           std::unique_ptr<WritableFile>* result) override {
+                           std::unique_ptr<WritableFile>* result/*, TransactionToken* token = nullptr */) override {
     mutex_lock m(mu_);
     if (fs_.find(fname) == fs_.end()) {
       fs_[fname] = std::make_shared<std::string>();
@@ -137,16 +137,16 @@ class RamFileSystem : public FileSystem {
 
   Status NewReadOnlyMemoryRegionFromFile(
       const string& fname,
-      std::unique_ptr<ReadOnlyMemoryRegion>* result) override {
+      std::unique_ptr<ReadOnlyMemoryRegion>* result/*, TransactionToken* token = nullptr */) override {
     return errors::Unimplemented("");
   }
 
-  Status FileExists(const string& fname) override {
+  Status FileExists(const string& fname/*, TransactionToken* token = nullptr */) override {
     FileStatistics stat;
     return Stat(fname, &stat);
   }
 
-  Status GetChildren(const string& dir, std::vector<string>* result) override {
+  Status GetChildren(const string& dir, std::vector<string>* result/*, TransactionToken* token = nullptr */) override {
     mutex_lock m(mu_);
     auto it = fs_.lower_bound(dir);
     while (it != fs_.end() && absl::StartsWith(it->first, dir)) {
@@ -158,7 +158,7 @@ class RamFileSystem : public FileSystem {
   }
 
   Status GetMatchingPaths(const string& pattern,
-                          std::vector<string>* results) override {
+                          std::vector<string>* results/*, TransactionToken* token = nullptr */) override {
     mutex_lock m(mu_);
     Env* env = Env::Default();
     for (auto it = fs_.begin(); it != fs_.end(); ++it) {
@@ -169,7 +169,7 @@ class RamFileSystem : public FileSystem {
     return Status::OK();
   }
 
-  Status Stat(const string& fname, FileStatistics* stat) override {
+  Status Stat(const string& fname, FileStatistics* stat/*, TransactionToken* token = nullptr */) override {
     mutex_lock m(mu_);
     auto it = fs_.lower_bound(fname);
     if (it == fs_.end()) {
@@ -189,7 +189,7 @@ class RamFileSystem : public FileSystem {
     return Status::OK();
   }
 
-  Status DeleteFile(const string& fname) override {
+  Status DeleteFile(const string& fname/*, TransactionToken* token = nullptr */) override {
     mutex_lock m(mu_);
     if (fs_.find(fname) != fs_.end()) {
       fs_.erase(fname);
@@ -199,15 +199,15 @@ class RamFileSystem : public FileSystem {
     return errors::NotFound("");
   }
 
-  Status CreateDir(const string& dirname) override { return Status::OK(); }
+  Status CreateDir(const string& dirname/*, TransactionToken* token = nullptr */) override { return Status::OK(); }
 
-  Status RecursivelyCreateDir(const string& dirname) override {
+  Status RecursivelyCreateDir(const string& dirname/*, TransactionToken* token = nullptr */) override {
     return Status::OK();
   }
 
-  Status DeleteDir(const string& dirname) override { return Status::OK(); }
+  Status DeleteDir(const string& dirname/*, TransactionToken* token = nullptr */) override { return Status::OK(); }
 
-  Status GetFileSize(const string& fname, uint64* file_size) override {
+  Status GetFileSize(const string& fname, uint64* file_size/*, TransactionToken* token = nullptr */) override {
     mutex_lock m(mu_);
     if (fs_.find(fname) != fs_.end()) {
       *file_size = fs_[fname]->size();
@@ -216,7 +216,7 @@ class RamFileSystem : public FileSystem {
     return errors::NotFound("");
   }
 
-  Status RenameFile(const string& src, const string& target) override {
+  Status RenameFile(const string& src, const string& target/*, TransactionToken* token = nullptr */) override {
     mutex_lock m(mu_);
     if (fs_.find(src) != fs_.end()) {
       fs_[target] = fs_[src];

--- a/tensorflow/core/platform/retrying_file_system.h
+++ b/tensorflow/core/platform/retrying_file_system.h
@@ -40,25 +40,25 @@ class RetryingFileSystem : public FileSystem {
 
   Status NewRandomAccessFile(
       const string& filename,
-      std::unique_ptr<RandomAccessFile>* result) override;
+      std::unique_ptr<RandomAccessFile>* result/*, TransactionToken* token = nullptr */) override;
 
   Status NewWritableFile(const string& fname,
-                         std::unique_ptr<WritableFile>* result) override;
+                         std::unique_ptr<WritableFile>* result/*, TransactionToken* token = nullptr */) override;
 
   Status NewAppendableFile(const string& fname,
-                           std::unique_ptr<WritableFile>* result) override;
+                           std::unique_ptr<WritableFile>* result/*, TransactionToken* token = nullptr */) override;
 
   Status NewReadOnlyMemoryRegionFromFile(
       const string& filename,
-      std::unique_ptr<ReadOnlyMemoryRegion>* result) override;
+      std::unique_ptr<ReadOnlyMemoryRegion>* result/*, TransactionToken* token = nullptr */) override;
 
-  Status FileExists(const string& fname) override {
+  Status FileExists(const string& fname/*, TransactionToken* token = nullptr */) override {
     return RetryingUtils::CallWithRetries(
         [this, &fname]() { return base_file_system_->FileExists(fname); },
         retry_config_);
   }
 
-  Status GetChildren(const string& dir, std::vector<string>* result) override {
+  Status GetChildren(const string& dir, std::vector<string>* result/*, TransactionToken* token = nullptr */) override {
     return RetryingUtils::CallWithRetries(
         [this, &dir, result]() {
           return base_file_system_->GetChildren(dir, result);
@@ -67,7 +67,7 @@ class RetryingFileSystem : public FileSystem {
   }
 
   Status GetMatchingPaths(const string& pattern,
-                          std::vector<string>* result) override {
+                          std::vector<string>* result/*, TransactionToken* token = nullptr */) override {
     return RetryingUtils::CallWithRetries(
         [this, &pattern, result]() {
           return base_file_system_->GetMatchingPaths(pattern, result);
@@ -75,31 +75,31 @@ class RetryingFileSystem : public FileSystem {
         retry_config_);
   }
 
-  Status Stat(const string& fname, FileStatistics* stat) override {
+  Status Stat(const string& fname, FileStatistics* stat/*, TransactionToken* token = nullptr */) override {
     return RetryingUtils::CallWithRetries(
         [this, &fname, stat]() { return base_file_system_->Stat(fname, stat); },
         retry_config_);
   }
 
-  Status DeleteFile(const string& fname) override {
+  Status DeleteFile(const string& fname/*, TransactionToken* token = nullptr */) override {
     return RetryingUtils::DeleteWithRetries(
         [this, &fname]() { return base_file_system_->DeleteFile(fname); },
         retry_config_);
   }
 
-  Status CreateDir(const string& dirname) override {
+  Status CreateDir(const string& dirname/*, TransactionToken* token = nullptr */) override {
     return RetryingUtils::CallWithRetries(
         [this, &dirname]() { return base_file_system_->CreateDir(dirname); },
         retry_config_);
   }
 
-  Status DeleteDir(const string& dirname) override {
+  Status DeleteDir(const string& dirname/*, TransactionToken* token = nullptr */) override {
     return RetryingUtils::DeleteWithRetries(
         [this, &dirname]() { return base_file_system_->DeleteDir(dirname); },
         retry_config_);
   }
 
-  Status GetFileSize(const string& fname, uint64* file_size) override {
+  Status GetFileSize(const string& fname, uint64* file_size/*, TransactionToken* token = nullptr */) override {
     return RetryingUtils::CallWithRetries(
         [this, &fname, file_size]() {
           return base_file_system_->GetFileSize(fname, file_size);
@@ -107,7 +107,7 @@ class RetryingFileSystem : public FileSystem {
         retry_config_);
   }
 
-  Status RenameFile(const string& src, const string& target) override {
+  Status RenameFile(const string& src, const string& target/*, TransactionToken* token = nullptr */) override {
     return RetryingUtils::CallWithRetries(
         [this, &src, &target]() {
           return base_file_system_->RenameFile(src, target);
@@ -115,7 +115,7 @@ class RetryingFileSystem : public FileSystem {
         retry_config_);
   }
 
-  Status IsDirectory(const string& dirname) override {
+  Status IsDirectory(const string& dirname/*, TransactionToken* token = nullptr */) override {
     return RetryingUtils::CallWithRetries(
         [this, &dirname]() { return base_file_system_->IsDirectory(dirname); },
         retry_config_);
@@ -127,7 +127,7 @@ class RetryingFileSystem : public FileSystem {
   }
 
   Status DeleteRecursively(const string& dirname, int64* undeleted_files,
-                           int64* undeleted_dirs) override {
+                           int64* undeleted_dirs/*, TransactionToken* token = nullptr */) override {
     return RetryingUtils::DeleteWithRetries(
         [this, &dirname, undeleted_files, undeleted_dirs]() {
           return base_file_system_->DeleteRecursively(dirname, undeleted_files,
@@ -136,7 +136,7 @@ class RetryingFileSystem : public FileSystem {
         retry_config_);
   }
 
-  void FlushCaches() override { base_file_system_->FlushCaches(); }
+  void FlushCaches(/* TransactionToken* token=nullptr */) override { base_file_system_->FlushCaches(); }
 
   Underlying* underlying() const { return base_file_system_.get(); }
 
@@ -218,7 +218,7 @@ class RetryingWritableFile : public WritableFile {
 
 template <typename Underlying>
 Status RetryingFileSystem<Underlying>::NewRandomAccessFile(
-    const string& filename, std::unique_ptr<RandomAccessFile>* result) {
+    const string& filename, std::unique_ptr<RandomAccessFile>* result/*, TransactionToken* token */) {
   std::unique_ptr<RandomAccessFile> base_file;
   TF_RETURN_IF_ERROR(RetryingUtils::CallWithRetries(
       [this, &filename, &base_file]() {
@@ -232,7 +232,7 @@ Status RetryingFileSystem<Underlying>::NewRandomAccessFile(
 
 template <typename Underlying>
 Status RetryingFileSystem<Underlying>::NewWritableFile(
-    const string& filename, std::unique_ptr<WritableFile>* result) {
+    const string& filename, std::unique_ptr<WritableFile>* result/*, TransactionToken* token */) {
   std::unique_ptr<WritableFile> base_file;
   TF_RETURN_IF_ERROR(RetryingUtils::CallWithRetries(
       [this, &filename, &base_file]() {
@@ -246,7 +246,7 @@ Status RetryingFileSystem<Underlying>::NewWritableFile(
 
 template <typename Underlying>
 Status RetryingFileSystem<Underlying>::NewAppendableFile(
-    const string& filename, std::unique_ptr<WritableFile>* result) {
+    const string& filename, std::unique_ptr<WritableFile>* result/*, TransactionToken* token */) {
   std::unique_ptr<WritableFile> base_file;
   TF_RETURN_IF_ERROR(RetryingUtils::CallWithRetries(
       [this, &filename, &base_file]() {
@@ -260,7 +260,7 @@ Status RetryingFileSystem<Underlying>::NewAppendableFile(
 
 template <typename Underlying>
 Status RetryingFileSystem<Underlying>::NewReadOnlyMemoryRegionFromFile(
-    const string& filename, std::unique_ptr<ReadOnlyMemoryRegion>* result) {
+    const string& filename, std::unique_ptr<ReadOnlyMemoryRegion>* result/*, TransactionToken* token */) {
   return RetryingUtils::CallWithRetries(
       [this, &filename, result]() {
         return base_file_system_->NewReadOnlyMemoryRegionFromFile(filename,

--- a/tensorflow/core/platform/retrying_file_system_test.cc
+++ b/tensorflow/core/platform/retrying_file_system_test.cc
@@ -100,76 +100,76 @@ class MockFileSystem : public FileSystem {
       : calls_(calls), flushed_(flushed) {}
 
   Status NewRandomAccessFile(
-      const string& fname, std::unique_ptr<RandomAccessFile>* result) override {
+      const string& fname, std::unique_ptr<RandomAccessFile>* result/*, TransactionToken* token = nullptr */) override {
     *result = std::move(random_access_file_to_return);
     return calls_.ConsumeNextCall("NewRandomAccessFile");
   }
 
   Status NewWritableFile(const string& fname,
-                         std::unique_ptr<WritableFile>* result) override {
+                         std::unique_ptr<WritableFile>* result/*, TransactionToken* token = nullptr */) override {
     *result = std::move(writable_file_to_return);
     return calls_.ConsumeNextCall("NewWritableFile");
   }
 
   Status NewAppendableFile(const string& fname,
-                           std::unique_ptr<WritableFile>* result) override {
+                           std::unique_ptr<WritableFile>* result/*, TransactionToken* token = nullptr */) override {
     *result = std::move(writable_file_to_return);
     return calls_.ConsumeNextCall("NewAppendableFile");
   }
 
   Status NewReadOnlyMemoryRegionFromFile(
       const string& fname,
-      std::unique_ptr<ReadOnlyMemoryRegion>* result) override {
+      std::unique_ptr<ReadOnlyMemoryRegion>* result/*, TransactionToken* token = nullptr */) override {
     return calls_.ConsumeNextCall("NewReadOnlyMemoryRegionFromFile");
   }
 
-  Status FileExists(const string& fname) override {
+  Status FileExists(const string& fname/*, TransactionToken* token = nullptr */) override {
     return calls_.ConsumeNextCall("FileExists");
   }
 
-  Status GetChildren(const string& dir, std::vector<string>* result) override {
+  Status GetChildren(const string& dir, std::vector<string>* result/*, TransactionToken* token = nullptr */) override {
     return calls_.ConsumeNextCall("GetChildren");
   }
 
   Status GetMatchingPaths(const string& dir,
-                          std::vector<string>* result) override {
+                          std::vector<string>* result/*, TransactionToken* token = nullptr */) override {
     return calls_.ConsumeNextCall("GetMatchingPaths");
   }
 
-  Status Stat(const string& fname, FileStatistics* stat) override {
+  Status Stat(const string& fname, FileStatistics* stat/*, TransactionToken* token = nullptr */) override {
     return calls_.ConsumeNextCall("Stat");
   }
 
-  Status DeleteFile(const string& fname) override {
+  Status DeleteFile(const string& fname/*, TransactionToken* token = nullptr */) override {
     return calls_.ConsumeNextCall("DeleteFile");
   }
 
-  Status CreateDir(const string& dirname) override {
+  Status CreateDir(const string& dirname/*, TransactionToken* token = nullptr */) override {
     return calls_.ConsumeNextCall("CreateDir");
   }
 
-  Status DeleteDir(const string& dirname) override {
+  Status DeleteDir(const string& dirname/*, TransactionToken* token = nullptr */) override {
     return calls_.ConsumeNextCall("DeleteDir");
   }
 
-  Status GetFileSize(const string& fname, uint64* file_size) override {
+  Status GetFileSize(const string& fname, uint64* file_size/*, TransactionToken* token = nullptr */) override {
     return calls_.ConsumeNextCall("GetFileSize");
   }
 
-  Status RenameFile(const string& src, const string& target) override {
+  Status RenameFile(const string& src, const string& target/*, TransactionToken* token = nullptr */) override {
     return calls_.ConsumeNextCall("RenameFile");
   }
 
-  Status IsDirectory(const string& dirname) override {
+  Status IsDirectory(const string& dirname/*, TransactionToken* token = nullptr */) override {
     return calls_.ConsumeNextCall("IsDirectory");
   }
 
   Status DeleteRecursively(const string& dirname, int64* undeleted_files,
-                           int64* undeleted_dirs) override {
+                           int64* undeleted_dirs/*, TransactionToken* token = nullptr */) override {
     return calls_.ConsumeNextCall("DeleteRecursively");
   }
 
-  void FlushCaches() override {
+  void FlushCaches(/* TransactionToken* token=nullptr */) override {
     if (flushed_) {
       *flushed_ = true;
     }


### PR DESCRIPTION
This PR is part of introducing the C++ api layer changes for Transactional FileSystem support. It requires PR #41433 to be merged before being merged. There will be follow up PRs to add other filesystems and re-enable override keywords once base class FileSystem method signature is changed.