### PR TITLE
Refactor read and blockfetcher in RamFileBlockCache

### DIFF
--- a/tensorflow/c/experimental/filesystem/plugins/gcs/ram_file_block_cache.cc
+++ b/tensorflow/c/experimental/filesystem/plugins/gcs/ram_file_block_cache.cc
@@ -133,9 +133,9 @@ void RamFileBlockCache::MaybeFetch(const Key& key,
         block->mu.Unlock();  // Release the lock while making the API call.
         block->data.clear();
         block->data.resize(block_size_, 0);
-        size_t bytes_transferred;
-        block_fetcher_(key.first, key.second, block_size_, block->data.data(),
-                       &bytes_transferred, status);
+        int64_t bytes_transferred;
+        bytes_transferred = block_fetcher_(key.first, key.second, block_size_,
+                                           block->data.data(), status);
         block->mu.Lock();  // Reacquire the lock immediately afterwards
         if (TF_GetCode(status) == TF_OK) {
           block->data.resize(bytes_transferred, 0);
@@ -165,18 +165,16 @@ void RamFileBlockCache::MaybeFetch(const Key& key,
       "Control flow should never reach the end of RamFileBlockCache::Fetch.");
 }
 
-void RamFileBlockCache::Read(const std::string& filename, size_t offset,
-                             size_t n, char* buffer, size_t* bytes_transferred,
-                             TF_Status* status) {
-  *bytes_transferred = 0;
+int64_t RamFileBlockCache::Read(const std::string& filename, size_t offset,
+                                size_t n, char* buffer, TF_Status* status) {
   if (n == 0) {
-    return TF_SetStatus(status, TF_OK, "");
+    TF_SetStatus(status, TF_OK, "");
+    return 0;
   }
   if (!IsCacheEnabled() || (n > max_bytes_)) {
     // The cache is effectively disabled, so we pass the read through to the
     // fetcher without breaking it up into blocks.
-    return block_fetcher_(filename, offset, n, buffer, bytes_transferred,
-                          status);
+    return block_fetcher_(filename, offset, n, buffer, status);
   }
   // Calculate the block-aligned start and end of the read.
   size_t start = block_size_ * (offset / block_size_);
@@ -196,20 +194,20 @@ void RamFileBlockCache::Read(const std::string& filename, size_t offset,
       abort();
     }
     MaybeFetch(key, block, status);
-    if (TF_GetCode(status) != TF_OK) return;
+    if (TF_GetCode(status) != TF_OK) return -1;
     UpdateLRU(key, block, status);
-    if (TF_GetCode(status) != TF_OK) return;
+    if (TF_GetCode(status) != TF_OK) return -1;
     // Copy the relevant portion of the block into the result buffer.
     const auto& data = block->data;
     if (offset >= pos + data.size()) {
       // The requested offset is at or beyond the end of the file. This can
       // happen if `offset` is not block-aligned, and the read returns the last
       // block in the file, which does not extend all the way out to `offset`.
-      *bytes_transferred = total_bytes_transferred;
       std::stringstream os;
       os << "EOF at offset " << offset << " in file " << filename
          << " at position " << pos << " with data size " << data.size();
-      return TF_SetStatus(status, TF_OUT_OF_RANGE, std::move(os).str().c_str());
+      TF_SetStatus(status, TF_OUT_OF_RANGE, std::move(os).str().c_str());
+      return total_bytes_transferred;
     }
     auto begin = data.begin();
     if (offset > pos) {
@@ -231,8 +229,8 @@ void RamFileBlockCache::Read(const std::string& filename, size_t offset,
       break;
     }
   }
-  *bytes_transferred = total_bytes_transferred;
-  return TF_SetStatus(status, TF_OK, "");
+  TF_SetStatus(status, TF_OK, "");
+  return total_bytes_transferred;
 }
 
 bool RamFileBlockCache::ValidateAndUpdateFileSignature(


### PR DESCRIPTION
@mihaimaruseac 
I have refactored `Read` and `BlockFetcher` to make it more compatible with `C API Modular File`.  Now, `Read` and `BlockFetcher` will return total bytes read.