### PR TITLE
Refactor gcs part 1 random access file

### DIFF
--- a/tensorflow/c/experimental/filesystem/plugins/gcs/BUILD
+++ b/tensorflow/c/experimental/filesystem/plugins/gcs/BUILD
@@ -25,7 +25,9 @@ cc_library(
         "//tensorflow:windows": get_win_copts(),
     }),
     deps = [
+        ":expiring_lru_cache",
         ":gcs_helper",
+        ":ram_file_block_cache",
         "//tensorflow/c:env",
         "//tensorflow/c:tf_status",
         "//tensorflow/c/experimental/filesystem:filesystem_interface",

--- a/tensorflow/c/experimental/filesystem/plugins/gcs/gcs_filesystem.cc
+++ b/tensorflow/c/experimental/filesystem/plugins/gcs/gcs_filesystem.cc
@@ -142,6 +142,7 @@ typedef struct GCSFile {
   uint64_t buffer_start ABSL_GUARDED_BY(buffer_mutex);
   bool buffer_end_is_past_eof ABSL_GUARDED_BY(buffer_mutex);
   std::string buffer ABSL_GUARDED_BY(buffer_mutex);
+
   GCSFile(std::string path, bool is_cache_enable, uint64_t buffer_size,
           ReadFn read_fn)
       : path(path),

--- a/tensorflow/c/experimental/filesystem/plugins/gcs/gcs_filesystem.cc
+++ b/tensorflow/c/experimental/filesystem/plugins/gcs/gcs_filesystem.cc
@@ -161,7 +161,7 @@ void Cleanup(TF_RandomAccessFile* file) {
 }
 
 static void FillBuffer(uint64_t start, GCSFile* gcs_file, TF_Status* status) {
-  ABSL_EXCLUSIVE_LOCKS_REQUIRED(gcs_file->buffer_mutex)
+  ABSL_EXCLUSIVE_LOCKS_REQUIRED(gcs_file->buffer_mutex);
   gcs_file->buffer_start = start;
   gcs_file->buffer.resize(gcs_file->buffer_size);
   auto read =

--- a/tensorflow/c/experimental/filesystem/plugins/gcs/gcs_filesystem.cc
+++ b/tensorflow/c/experimental/filesystem/plugins/gcs/gcs_filesystem.cc
@@ -148,11 +148,11 @@ typedef struct GCSFile {
       : path(path),
         is_cache_enable(is_cache_enable),
         buffer_size(buffer_size),
+        read_fn(std::move(read_fn)),
         buffer_mutex(),
         buffer_start(0),
         buffer_end_is_past_eof(false),
-        buffer(),
-        read_fn(std::move(read_fn)) {}
+        buffer() {}
 } GCSFile;
 
 void Cleanup(TF_RandomAccessFile* file) {


### PR DESCRIPTION
@mihaimaruseac 
This PR refactors `gcs` to use the `core` implementation. The change is:
- Get various envs
- Use `ram_file_block_cache` https://github.com/tensorflow/tensorflow/blob/2629e4f9a4d982448494c880402f603cf559c488/tensorflow/core/platform/cloud/gcs_file_system.cc#L826
- This variable can be controlled by env so I drop it https://github.com/tensorflow/tensorflow/blob/2629e4f9a4d982448494c880402f603cf559c488/tensorflow/core/platform/cloud/gcs_file_system.cc#L788
- Merge 2 `RandomAccessFile` into one. https://github.com/tensorflow/tensorflow/blob/2629e4f9a4d982448494c880402f603cf559c488/tensorflow/core/platform/cloud/gcs_file_system.cc#L261 and https://github.com/tensorflow/tensorflow/blob/2629e4f9a4d982448494c880402f603cf559c488/tensorflow/core/platform/cloud/gcs_file_system.cc#L289
- I am missing this part https://github.com/tensorflow/tensorflow/blob/2629e4f9a4d982448494c880402f603cf559c488/tensorflow/core/platform/cloud/gcs_file_system.cc#L991-L1003 will be added in later PR.