### PR TITLE
Modify smart_resize in keras.preprocessing.image

### DIFF
--- a/tensorflow/python/keras/preprocessing/image.py
+++ b/tensorflow/python/keras/preprocessing/image.py
@@ -120,25 +120,26 @@ def smart_resize(x, size, interpolation='bilinear'):
   shape = array_ops.shape(img)
   height, width = shape[0], shape[1]
   target_height, target_width = size
-  target_ratio = float(target_height) / target_width
-  img_ratio = math_ops.cast(
-      height, 'float32') / math_ops.cast(width, 'float32')
-  if target_ratio < img_ratio:
-    crop_height = math_ops.cast(
-        math_ops.cast(width, 'float32') * target_height / target_width, 'int32')
-    crop_box_hstart = math_ops.cast(
-        math_ops.cast(height - crop_height, 'float32') / 2, 'int32')
-    crop_box_start = [crop_box_hstart, 0, 0]
-    crop_box_size = [crop_height, -1, -1]
-  else:
-    crop_width = math_ops.cast(
-        math_ops.cast(height * target_width, 'float32') / target_height,
-        'int32')
-    crop_box_wstart = math_ops.cast((width - crop_width) / 2, 'int32')
-    crop_box_start = [0, crop_box_wstart, 0]
-    crop_box_size = [-1, crop_width, -1]
-  crop_box_start = array_ops.stack(crop_box_start)
-  crop_box_size = array_ops.stack(crop_box_size)
+
+  crop_height = math_ops.cast(
+      math_ops.cast(width * target_height, 'float32') / target_width,
+      'int32')
+  crop_width = math_ops.cast(
+      math_ops.cast(height * target_width, 'float32') / target_height,
+      'int32')
+
+  # Set back to input height / width if crop_height / crop_width is not smaller.
+  crop_height = math_ops.minimum(height, crop_height)
+  crop_width = math_ops.minimum(width, crop_width)
+
+  crop_box_hstart = math_ops.cast(
+      math_ops.cast(height - crop_height, 'float32') / 2, 'int32')
+  crop_box_wstart = math_ops.cast(
+      math_ops.cast(width - crop_width, 'float32') / 2, 'int32')
+
+  crop_box_start = array_ops.stack([crop_box_hstart, crop_box_wstart, 0])
+  crop_box_size = array_ops.stack([crop_height, crop_width, -1])
+
   img = array_ops.slice(img, crop_box_start, crop_box_size)
   img = image_ops.resize_images_v2(
       images=img,

--- a/tensorflow/python/keras/preprocessing/image_test.py
+++ b/tensorflow/python/keras/preprocessing/image_test.py
@@ -30,6 +30,7 @@ from tensorflow.python.keras import layers
 from tensorflow.python.keras.engine import sequential
 from tensorflow.python.keras.preprocessing import image as preprocessing_image
 from tensorflow.python.platform import test
+from tensorflow.python.data import Dataset
 
 try:
   import PIL  # pylint:disable=g-import-not-at-top
@@ -69,6 +70,21 @@ class TestImage(keras_parameterized.TestCase):
     self.assertListEqual(list(output.shape), [100, 50, 3])
     output = preprocessing_image.smart_resize(test_input, size=(5, 15))
     self.assertListEqual(list(output.shape), [5, 15, 3])
+
+
+  @test_util.run_v2_only
+  def test_smart_resize_tf_dataset(self):
+    test_input_np = np.random.random((2, 20, 40, 3))
+    test_ds = Dataset.from_tensor_slices(test_input_np)
+
+    resize = lambda img: preprocessing_image.smart_resize(img, size=size)
+
+    for size in [(50, 50), (10, 10), (100, 50), (5, 15)]:
+      test_ds = test_ds.map(resize)
+      for sample in test_ds.as_numpy_iterator():
+        self.assertIsInstance(sample, np.ndarray)
+        self.assertListEqual(list(sample.shape), [size[0], size[1], 3])
+
 
   def test_smart_resize_errors(self):
     with self.assertRaisesRegex(ValueError, 'a tuple of 2 integers'):


### PR DESCRIPTION
Rewrite the crop part for `smart_resize` to avoid if-else. The target height (width) is always the smaller of original height (width) or the height (width) calculated from width (height). 
This change makes `smart_resize` compatible with `tf.data.Dataset`. 

Fixes #41501 