### PR TITLE
Improve error message in shape check

### DIFF
--- a/tensorflow/core/framework/tensor_shape.cc
+++ b/tensorflow/core/framework/tensor_shape.cc
@@ -593,7 +593,7 @@ Status MakeShapeHelper(const T* dims, int64 n, Shape* out) {
       if (TF_PREDICT_FALSE(new_num_elements < 0)) {
         TensorShapeProto proto;
         for (int64 j = 0; j < n; ++j) {
-          proto.add_dim()->set_size(dim);
+          proto.add_dim()->set_size(internal::SubtleMustCopy(dims[j]));
         }
         return errors::InvalidArgument(
             "Shape ", TensorShape::DebugString(proto),

--- a/tensorflow/python/kernel_tests/broadcast_to_ops_test.py
+++ b/tensorflow/python/kernel_tests/broadcast_to_ops_test.py
@@ -192,5 +192,15 @@ class BroadcastToTest(test_util.TensorFlowTestCase):
                                                     out, out.get_shape())
     self.assertLess(err, 1e-4)
 
+  def testBroadcastToInvalidShape(self):
+    with self.assertRaisesRegex(
+        (ValueError, errors.InvalidArgumentError),
+        "110,53,104,147,157,123,5,24,188,40,5,2"):
+      output_shape = [110, 53, 104, 147, 157, 123, 5, 24, 188, 40, 5, 2]
+      x = np.array([1, 2, 3], dtype=np.int32)
+      v = array_ops.broadcast_to(constant_op.constant(x), output_shape)
+      self.evaluate(v)
+
+
 if __name__ == "__main__":
   test_lib.main()


### PR DESCRIPTION
This PR tries to address the issue raised in #41504 where the
error message of:
```
InvalidArgumentError: Shape [2,2,2,2,2,2,2,2,2,2,2,2] would have more than 2**63 - 1 elements [Op:BroadcastTo]
```
is not intuitive.

The issue is that the construction of error message in tensor_shape.cc
did not copy the complete shape dims.

This PR fixes the issue.

This PR fixes #41504.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>