### PR TITLE
Add commented arguments and new methods to FileSystem for Transactions

### DIFF
--- a/tensorflow/core/platform/file_system.cc
+++ b/tensorflow/core/platform/file_system.cc
@@ -436,7 +436,9 @@ string FileSystem::CreateURI(StringPiece scheme, StringPiece host,
   return strings::StrCat(scheme, "://", host, path);
 }
 
-string FileSystem::DecodeTransaction(const TransactionToken* token){
+std::string FileSystem::DecodeTransaction(const TransactionToken* token){
+
+// TODO(sami): Switch using StrCat when void* is supported
   if(token){
     std::stringstream oss;
     oss<<"Token= "<<token->token<<", Owner="<<token->owner;

--- a/tensorflow/core/platform/file_system.cc
+++ b/tensorflow/core/platform/file_system.cc
@@ -441,7 +441,7 @@ std::string FileSystem::DecodeTransaction(const TransactionToken* token){
 // TODO(sami): Switch using StrCat when void* is supported
   if(token){
     std::stringstream oss;
-    oss<<"Token= "<<token->token<<", Owner="<<token->owner;
+    oss << "Token= " << token->token << ", Owner=" << token->owner;
     return oss.str();
   }
   return "No Transaction";

--- a/tensorflow/core/platform/file_system.cc
+++ b/tensorflow/core/platform/file_system.cc
@@ -70,7 +70,7 @@ string FileSystem::TranslateName(const string& name) const {
   return this->CleanPath(path);
 }
 
-Status FileSystem::IsDirectory(const string& name) {
+Status FileSystem::IsDirectory(const string& name/*, TransactionToken *token */) {
   // Check if path exists.
   TF_RETURN_IF_ERROR(FileExists(name));
   FileStatistics stat;
@@ -86,10 +86,10 @@ Status FileSystem::HasAtomicMove(const string& path, bool* has_atomic_move) {
   return Status::OK();
 }
 
-void FileSystem::FlushCaches() {}
+void FileSystem::FlushCaches(/* TransactionToken *token */) {}
 
 bool FileSystem::FilesExist(const std::vector<string>& files,
-                            std::vector<Status>* status) {
+                            std::vector<Status>* status/*, TransactionToken *token */) {
   bool result = true;
   for (const auto& file : files) {
     Status s = FileExists(file);
@@ -106,7 +106,7 @@ bool FileSystem::FilesExist(const std::vector<string>& files,
 
 Status FileSystem::DeleteRecursively(const string& dirname,
                                      int64* undeleted_files,
-                                     int64* undeleted_dirs) {
+                                     int64* undeleted_dirs/*, TransactionToken *token */) {
   CHECK_NOTNULL(undeleted_files);
   CHECK_NOTNULL(undeleted_dirs);
 
@@ -176,7 +176,7 @@ Status FileSystem::DeleteRecursively(const string& dirname,
   return ret;
 }
 
-Status FileSystem::RecursivelyCreateDir(const string& dirname) {
+Status FileSystem::RecursivelyCreateDir(const string& dirname/*, TransactionToken *token */) {
   StringPiece scheme, host, remaining_dir;
   this->ParseURI(dirname, &scheme, &host, &remaining_dir);
   std::vector<StringPiece> sub_dirs;
@@ -221,7 +221,7 @@ Status FileSystem::RecursivelyCreateDir(const string& dirname) {
   return Status::OK();
 }
 
-Status FileSystem::CopyFile(const string& src, const string& target) {
+Status FileSystem::CopyFile(const string& src, const string& target/*, TransactionToken *token */) {
   return FileSystemCopyFile(this, src, this, target);
 }
 
@@ -434,6 +434,15 @@ string FileSystem::CreateURI(StringPiece scheme, StringPiece host,
     return string(path);
   }
   return strings::StrCat(scheme, "://", host, path);
+}
+
+string FileSystem::DecodeTransaction(const TransactionToken* token){
+  if(token){
+    std::stringstream oss;
+    oss<<"Token= "<<token->token<<", Owner="<<token->owner;
+    return oss.str();
+  }
+  return "No Transaction";
 }
 
 }  // namespace tensorflow

--- a/tensorflow/core/platform/file_system.h
+++ b/tensorflow/core/platform/file_system.h
@@ -68,7 +68,7 @@ class FileSystem {
   /// The ownership of the returned RandomAccessFile is passed to the caller
   /// and the object should be deleted when is not used.
   virtual tensorflow::Status NewRandomAccessFile(
-      const string& fname, std::unique_ptr<RandomAccessFile>* result) = 0;
+      const string& fname, std::unique_ptr<RandomAccessFile>* result/*, TransactionToken* token = nullptr */) = 0;
 
   /// \brief Creates an object that writes to a new file with the specified
   /// name.
@@ -83,7 +83,7 @@ class FileSystem {
   /// The ownership of the returned WritableFile is passed to the caller
   /// and the object should be deleted when is not used.
   virtual tensorflow::Status NewWritableFile(
-      const string& fname, std::unique_ptr<WritableFile>* result) = 0;
+      const string& fname, std::unique_ptr<WritableFile>* result/*, TransactionToken* token = nullptr */) = 0;
 
   /// \brief Creates an object that either appends to an existing file, or
   /// writes to a new file (if the file does not exist to begin with).
@@ -97,7 +97,7 @@ class FileSystem {
   /// The ownership of the returned WritableFile is passed to the caller
   /// and the object should be deleted when is not used.
   virtual tensorflow::Status NewAppendableFile(
-      const string& fname, std::unique_ptr<WritableFile>* result) = 0;
+      const string& fname, std::unique_ptr<WritableFile>* result/*, TransactionToken* token = nullptr */) = 0;
 
   /// \brief Creates a readonly region of memory with the file context.
   ///
@@ -110,7 +110,7 @@ class FileSystem {
   /// The ownership of the returned ReadOnlyMemoryRegion is passed to the caller
   /// and the object should be deleted when is not used.
   virtual tensorflow::Status NewReadOnlyMemoryRegionFromFile(
-      const string& fname, std::unique_ptr<ReadOnlyMemoryRegion>* result) = 0;
+      const string& fname, std::unique_ptr<ReadOnlyMemoryRegion>* result/*, TransactionToken* token = nullptr */) = 0;
 
   /// Returns OK if the named path exists and NOT_FOUND otherwise.
   virtual tensorflow::Status FileExists(const string& fname) = 0;
@@ -119,13 +119,13 @@ class FileSystem {
   /// if status is not null, populate the vector with a detailed status
   /// for each file.
   virtual bool FilesExist(const std::vector<string>& files,
-                          std::vector<Status>* status);
+                          std::vector<Status>* status/*, TransactionToken* token = nullptr */);
 
   /// \brief Returns the immediate children in the given directory.
   ///
   /// The returned paths are relative to 'dir'.
   virtual tensorflow::Status GetChildren(const string& dir,
-                                         std::vector<string>* result) = 0;
+                                         std::vector<string>* result/*, TransactionToken* token = nullptr */) = 0;
 
   /// \brief Given a pattern, stores in *results the set of paths that matches
   /// that pattern. *results is cleared.
@@ -150,7 +150,7 @@ class FileSystem {
   ///  * UNIMPLEMENTED - Some underlying functions (like GetChildren) are not
   ///                    implemented
   virtual tensorflow::Status GetMatchingPaths(const string& pattern,
-                                              std::vector<string>* results) = 0;
+                                              std::vector<string>* results/*, TransactionToken* token = nullptr */) = 0;
 
   /// \brief Checks if the given filename matches the pattern.
   ///
@@ -161,17 +161,17 @@ class FileSystem {
 
   /// \brief Obtains statistics for the given path.
   virtual tensorflow::Status Stat(const string& fname,
-                                  FileStatistics* stat) = 0;
+                                  FileStatistics* stat/*, TransactionToken* token = nullptr */) = 0;
 
   /// \brief Deletes the named file.
-  virtual tensorflow::Status DeleteFile(const string& fname) = 0;
+  virtual tensorflow::Status DeleteFile(const string& fname/*, TransactionToken* token = nullptr */) = 0;
 
   /// \brief Creates the specified directory.
   /// Typical return codes:
   ///  * OK - successfully created the directory.
   ///  * ALREADY_EXISTS - directory with name dirname already exists.
   ///  * PERMISSION_DENIED - dirname is not writable.
-  virtual tensorflow::Status CreateDir(const string& dirname) = 0;
+  virtual tensorflow::Status CreateDir(const string& dirname/*, TransactionToken* token = nullptr */) = 0;
 
   /// \brief Creates the specified directory and all the necessary
   /// subdirectories.
@@ -179,10 +179,10 @@ class FileSystem {
   ///  * OK - successfully created the directory and sub directories, even if
   ///         they were already created.
   ///  * PERMISSION_DENIED - dirname or some subdirectory is not writable.
-  virtual tensorflow::Status RecursivelyCreateDir(const string& dirname);
+  virtual tensorflow::Status RecursivelyCreateDir(const string& dirname/*, TransactionToken* token = nullptr */);
 
   /// \brief Deletes the specified directory.
-  virtual tensorflow::Status DeleteDir(const string& dirname) = 0;
+  virtual tensorflow::Status DeleteDir(const string& dirname/*, TransactionToken* token = nullptr */) = 0;
 
   /// \brief Deletes the specified directory and all subdirectories and files
   /// underneath it. This is accomplished by traversing the directory tree
@@ -210,18 +210,18 @@ class FileSystem {
   ///                    implemented
   virtual tensorflow::Status DeleteRecursively(const string& dirname,
                                                int64* undeleted_files,
-                                               int64* undeleted_dirs);
+                                               int64* undeleted_dirs/*, TransactionToken* token = nullptr */);
 
   /// \brief Stores the size of `fname` in `*file_size`.
   virtual tensorflow::Status GetFileSize(const string& fname,
-                                         uint64* file_size) = 0;
+                                         uint64* file_size/*, TransactionToken* token = nullptr */) = 0;
 
   /// \brief Overwrites the target if it exists.
   virtual tensorflow::Status RenameFile(const string& src,
-                                        const string& target) = 0;
+                                        const string& target/*, TransactionToken* token = nullptr */) = 0;
 
   /// \brief Copy the src to target.
-  virtual tensorflow::Status CopyFile(const string& src, const string& target);
+  virtual tensorflow::Status CopyFile(const string& src, const string& target/*, TransactionToken* token = nullptr */);
 
   /// \brief Translate an URI to a filename for the FileSystem implementation.
   ///
@@ -241,7 +241,7 @@ class FileSystem {
   ///  * NOT_FOUND - The path entry does not exist.
   ///  * PERMISSION_DENIED - Insufficient permissions.
   ///  * UNIMPLEMENTED - The file factory doesn't support directories.
-  virtual tensorflow::Status IsDirectory(const string& fname);
+  virtual tensorflow::Status IsDirectory(const string& fname/*, TransactionToken* token = nullptr */);
 
   /// \brief Returns whether the given path is on a file system
   /// that has atomic move capabilities. This can be used
@@ -256,7 +256,7 @@ class FileSystem {
   virtual Status HasAtomicMove(const string& path, bool* has_atomic_move);
 
   /// \brief Flushes any cached filesystem objects from memory.
-  virtual void FlushCaches();
+  virtual void FlushCaches(/* TransactionToken* token = nullptr */);
 
   /// \brief The separator this filesystem uses.
   ///
@@ -345,6 +345,43 @@ class FileSystem {
   /// empty.
   void ParseURI(StringPiece remaining, StringPiece* scheme, StringPiece* host,
                 StringPiece* path) const;
+
+  // Transaction related API
+
+  /// \brief Starts a new transaction
+  virtual tensorflow::Status StartTransaction(TransactionToken** token) {
+    token = nullptr;
+    return Status::OK();
+  };
+
+  /// \brief Adds `path` to transaction in `token`
+  virtual tensorflow::Status AddToTransaction(const string& path,
+                                              TransactionToken* token) {
+    return Status::OK();
+  };
+
+  /// \brief Ends transaction
+  virtual tensorflow::Status EndTransaction(TransactionToken* token) {
+    return Status::OK();
+  };
+
+  /// \brief Get token for `path` or start a new transaction and add `path` to
+  /// it.
+  virtual tensorflow::Status GetTokenOrStartTransaction(
+      const string& path, TransactionToken** token) {
+    token = nullptr;
+    return Status::OK();
+  };
+
+  /// \brief Return transaction for `path` or nullptr in `token`
+  virtual tensorflow::Status GetTransactionForPath(const string& path,
+                                                   TransactionToken** token) {
+    return Status::OK();
+    token = nullptr;
+  };
+
+  /// \brief Decode transaction to human readable string.
+  virtual string DecodeTransaction(const TransactionToken* token);
 
   FileSystem() {}
 

--- a/tensorflow/core/platform/file_system.h
+++ b/tensorflow/core/platform/file_system.h
@@ -381,7 +381,7 @@ class FileSystem {
   };
 
   /// \brief Decode transaction to human readable string.
-  virtual string DecodeTransaction(const TransactionToken* token);
+  virtual std::string DecodeTransaction(const TransactionToken* token);
 
   FileSystem() {}
 


### PR DESCRIPTION
This PR is a continuation of series of PRs introducing Transactions API to FileSystems. In this PR new Transaction API methods have been added to FileSystem base class and existing method signatures are changed to add Transaction Token arguments in commented form. Previous PRs, #41431, #41433, #41434, #41462 and #41463 and this PR merged, I will open another PR to uncomment the extra arguments and enable new API. 