### PR TITLE
Account for possibility of pyc extension in TFLite check.

### DIFF
--- a/tensorflow/lite/python/interpreter.py
+++ b/tensorflow/lite/python/interpreter.py
@@ -21,11 +21,12 @@ from __future__ import print_function
 import ctypes
 import platform
 import sys
+import os
 
 import numpy as np
 
 # pylint: disable=g-import-not-at-top
-if not __file__.endswith('tflite_runtime/interpreter.py'):
+if not os.path.splitext(__file__)[0].endswith('tflite_runtime/interpreter'):
   # This file is part of tensorflow package.
   from tensorflow.lite.python.interpreter_wrapper import _pywrap_tensorflow_interpreter_wrapper as _interpreter_wrapper
   from tensorflow.python.util.tf_export import tf_export as _tf_export


### PR DESCRIPTION
Closes https://github.com/tensorflow/tensorflow/issues/41352

This PR fixes the runtime check for whether TFLite is running as a separate library or as a part of the full TensorFlow package.