### PR TITLE
Fix setting out_mtypes in MemoryTypesForNode

### DIFF
--- a/tensorflow/core/framework/memory_types.cc
+++ b/tensorflow/core/framework/memory_types.cc
@@ -161,6 +161,7 @@ Status MemoryTypesForNode(const OpRegistryInterface* op_registry,
       }
     }
   }
+  hostmem_attr.clear();
   if (TryGetNodeAttr(ndef, "_output_hostmem", &hostmem_attr)) {
     for (int32 i : hostmem_attr) {
       if (0 <= i && i < out_mtypes->size()) {


### PR DESCRIPTION
Clear hostmem_attr vector before populating it with indices from "_output_hostmem" attribute so that it doesn't contain indices from "_input_hostmem" attribute.