### PR TITLE
RGB to YUV: Conflicting information between example and description

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -3314,7 +3314,7 @@ def rgb_to_yuv(images):
 
   Outputs a tensor of the same shape as the `images` tensor, containing the YUV
   value of the pixels.
-  The output is only well defined if the value in images are greater than 1.
+  The output is only well defined if the value in images are greater or equal to 1.
 
   Args:
     images: 2-D or higher rank. Image data to convert. Last dimension must be

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -3314,7 +3314,10 @@ def rgb_to_yuv(images):
 
   Outputs a tensor of the same shape as the `images` tensor, containing the YUV
   value of the pixels.
-  The output is only well defined if the value in images are greater or equal to 1.
+  The output is only well defined if the value in images are in [0, 1].
+  There are two ways of representing an image: [0, 255] pixel values range or 
+  [0, 1] (as float) pixel values range. Users need to convert the input image 
+  into a float [0, 1] range.
 
   Args:
     images: 2-D or higher rank. Image data to convert. Last dimension must be

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -3314,7 +3314,7 @@ def rgb_to_yuv(images):
 
   Outputs a tensor of the same shape as the `images` tensor, containing the YUV
   value of the pixels.
-  The output is only well defined if the value in images are in [0,1].
+  The output is only well defined if the value in images are greater than 1.
 
   Args:
     images: 2-D or higher rank. Image data to convert. Last dimension must be


### PR DESCRIPTION
https://www.tensorflow.org/api_docs/python/tf/image/rgb_to_yuv 

Fix the documentation explainations. [0, 1] input range was misleading.

Issue is tracked here https://github.com/tensorflow/tensorflow/issues/41496 and https://github.com/tensorflow/tensorflow/issues/41300