### PR TITLE
Fix incomplete description of callbacks.ModelCheckpoint

### DIFF
--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -1107,7 +1107,7 @@ class ModelCheckpoint(Callback):
         quantity monitored will not be overwritten. If `filepath` doesn't contain 
         formatting options like `{epoch}` then `filepath` will be overwritten 
         by each new better model.
-      mode: one of `{auto, min, max}`. If `save_best_only=True`, the decision to
+      mode: one of {'auto', 'min', 'max'}. If `save_best_only=True`, the decision to
         overwrite the current save file is made based on either the maximization
         or the minimization of the monitored quantity. For `val_acc`, this
         should be `max`, for `val_loss` this should be `min`, etc. In `auto`

--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -1104,15 +1104,15 @@ class ModelCheckpoint(Callback):
       verbose: verbosity mode, 0 or 1.
       save_best_only: if `save_best_only=True`, it only saves when the model 
         is considered the "best" and the latest best model according to the 
-        quantity monitored will not be overwritten. If `filepath` doesn't contain 
-        formatting options like `{epoch}` then `filepath` will be overwritten 
-        by each new better model.
-      mode: one of {'auto', 'min', 'max'}. If `save_best_only=True`, the decision to
-        overwrite the current save file is made based on either the maximization
-        or the minimization of the monitored quantity. For `val_acc`, this
-        should be `max`, for `val_loss` this should be `min`, etc. In `auto`
-        mode, the direction is automatically inferred from the name of the
-        monitored quantity.
+        quantity monitored will not be overwritten. If `filepath` doesn't 
+        contain formatting options like `{epoch}` then `filepath` will be 
+        overwritten by each new better model.
+      mode: one of {'auto', 'min', 'max'}. If `save_best_only=True`, the 
+        decision to overwrite the current save file is made based on either 
+        the maximization or the minimization of the monitored quantity. 
+        For `val_acc`, this should be `max`, for `val_loss` this should be 
+        `min`, etc. In `auto` mode, the direction is automatically inferred
+        from the name of the monitored quantity.
       save_weights_only: if True, then only the model's weights will be saved
         (`model.save_weights(filepath)`), else the full model is saved
         (`model.save(filepath)`).

--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -1102,10 +1102,9 @@ class ModelCheckpoint(Callback):
         in the filename.
       monitor: quantity to monitor.
       verbose: verbosity mode, 0 or 1.
-      save_best_only: if `save_best_only=True`, not only the "latest best model" 
-        according to the quantity monitored will not be overwritten, but also 
-        the current model will not be written at all, even if it has another 
-        filename than the "latest best model". If `filepath` doesn't contain 
+      save_best_only: if `save_best_only=True`, it only saves when the model 
+        is considered the "best" and the latest best model according to the 
+        quantity monitored will not be overwritten. If `filepath` doesn't contain 
         formatting options like `{epoch}` then `filepath` will be overwritten 
         by each new better model.
       mode: one of `{auto, min, max}`. If `save_best_only=True`, the decision to

--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -1102,11 +1102,13 @@ class ModelCheckpoint(Callback):
         in the filename.
       monitor: quantity to monitor.
       verbose: verbosity mode, 0 or 1.
-      save_best_only: if `save_best_only=True`, the latest best model according
-        to the quantity monitored will not be overwritten.
-        If `filepath` doesn't contain formatting options like `{epoch}` then
-        `filepath` will be overwritten by each new better model.
-      mode: one of {auto, min, max}. If `save_best_only=True`, the decision to
+      save_best_only: if `save_best_only=True`, not only the "latest best model" 
+        according to the quantity monitored will not be overwritten, but also 
+        the current model will not be written at all, even if it has another 
+        filename than the "latest best model". If `filepath` doesn't contain 
+        formatting options like `{epoch}` then `filepath` will be overwritten 
+        by each new better model.
+      mode: one of `{auto, min, max}`. If `save_best_only=True`, the decision to
         overwrite the current save file is made based on either the maximization
         or the minimization of the monitored quantity. For `val_acc`, this
         should be `max`, for `val_loss` this should be `min`, etc. In `auto`


### PR DESCRIPTION
Fix is based on this issue #41420
Two parts got fixed:

mode: "{auto, min, max}" should be {auto, min, max}
save_best_only: add the part that the current model will not be written