### PR TITLE
TF-Lite Micro: port Silicon Labs STK3701A to Micro Speech example

### DIFF
--- a/tensorflow/lite/micro/examples/micro_speech/README.md
+++ b/tensorflow/lite/micro/examples/micro_speech/README.md
@@ -19,6 +19,7 @@ kilobytes of Flash.
 -   [Deploy to ARC EM SDP](#deploy-to-arc-em-sdp)
 -   [Deploy to Arduino](#deploy-to-arduino)
 -   [Deploy to ESP32](#deploy-to-esp32)
+-   [Deploy to Silicon Labs STK3701A](#deploy-to-silicon-labs-stk3701a)
 -   [Deploy to SparkFun Edge](#deploy-to-sparkfun-edge)
 -   [Deploy to STM32F746](#deploy-to-STM32F746)
 -   [Deploy to NXP FRDM K66F](#deploy-to-nxp-frdm-k66f)
@@ -227,6 +228,74 @@ Use `Ctrl+]` to exit.
 
 The previous two commands can be combined: `idf.py --port /dev/ttyUSB0 flash
 monitor`
+
+
+
+## Deploy to Silicon Labs STK3701A
+
+The following describes how to deploy to the Silicon Labs [SLSTK3701A](https://www.silabs.com/products/development-tools/mcu/32-bit/efm32-giant-gecko-gg11-starter-kit) development board:
+- 2MB flash
+- 512kB RAM
+- 72MHz clock
+
+
+### Initial Setup
+
+While Linux and MacOS may also work, the [Ubuntu Subsystem](https://docs.microsoft.com/en-us/windows/wsl/install-win10) for Windows 10 is the recommended development environment.  
+(Hint: Follow these [instructions](https://superuser.com/a/1134645/864689) to set the Ubuntu home directory to your Windows home directory).
+
+1 ) Install [Simplicity Studio](https://www.silabs.com/products/development-tools/software/simplicity-studio). Note, registration is not required. This step just ensures you have the [Segger JLink drivers](https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack) installed.  
+2 ) Open a terminal and navigate to the root of the cloned Tensorflow repository directory  
+3 ) Ensure GNU `make` is found on PATH. On Ubuntu, issue this command to install `make`:
+
+```
+sudo apt-get install build-essential
+```
+
+4 ) Additional third-party software needs to be downloaded before building the example.  
+    From the Tensorflow repo root, issue the following command:
+
+```
+make -j4 -f tensorflow/lite/micro/tools/make/Makefile TARGET=stk3701a third_party_downloads
+```
+
+5 ) Plug the STK3701A development board in via USB. Ensure the board switch on the bottom-left is set to `AEM`.  
+    Issue the following command to ensure the build scripts are able to communicate with the board:  
+
+```
+cd <Tensorflow repo root directory>
+make -f tensorflow/lite/micro/tools/make/Makefile TARGET=stk3701a reset
+```
+
+You should see something like the following on the command output:
+
+```
+Resetting chip...
+DONE
+```
+
+If this doesn't work, ensure you have correctly installed the J-Link driver. Note that the build scripts
+are using the [Standalone Simplicity Commander](https://www.silabs.com/mcu/programming-options). Refer to the [Reference Guide](https://www.silabs.com/documents/public/user-guides/ug162-simplicity-commander-reference-guide.pdf) for more details.
+
+
+
+### Build & Download
+
+To build and download the Micro Speech example to the STK3701A, issue the following commands:
+
+```
+cd <Tensorflow repo root directory>
+make -j4 -f tensorflow/lite/micro/tools/make/Makefile TARGET=stk3701a micro_speech download
+```
+
+This will build the example executable and download it to the development board.  
+Once the firmware is downloaded:
+- Saying `Yes` will turn LED1 on
+- Saying `No` will turn LED2 on
+
+
+
+
 
 ## Deploy to SparkFun Edge
 

--- a/tensorflow/lite/micro/examples/micro_speech/silabs/audio_provider.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/silabs/audio_provider.cc
@@ -1,0 +1,135 @@
+/***************************************************************************//**
+ * # License
+ * <b>Copyright 2020 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+#include <cstring>
+#include <cassert>
+#include <stdio.h>
+
+#include "tensorflow/lite/micro/examples/micro_speech/audio_provider.h"
+#include "tensorflow/lite/micro/examples/micro_speech/micro_features/micro_model_settings.h"
+
+
+#include "microphone.h"
+
+
+
+#define AlignUp(m, n) ((((m) + (n) - 1) / (n)) * (n))
+
+
+
+static void init_microphone(tflite::ErrorReporter* error_reporter);
+static void microphone_buffer_callback(const void* buf, uint32_t buffer_length_bytes, void *arg);
+
+
+// Buffers up to 2s of audio (aligned to kMaxAudioSampleSize)
+constexpr int kAudioBufferSize = AlignUp(kAudioSampleFrequency * 2, kMaxAudioSampleSize);
+
+
+static struct
+{
+    bool initialized;
+    volatile int32_t latest_audio_timestamp_ms;
+    int16_t audio_buffer[kAudioBufferSize];
+    int16_t sample_buffer[kMaxAudioSampleSize];
+} g_context;
+
+
+
+
+/*************************************************************************************************/
+TfLiteStatus GetAudioSamples(tflite::ErrorReporter* error_reporter,
+                             int start_ms, int duration_ms,
+                             int* audio_samples_size, int16_t** audio_samples)
+{
+    constexpr int kSamplePerMs = kAudioSampleFrequency / 1000;
+    const int start_index = (start_ms * kSamplePerMs) % kAudioBufferSize;
+    const int end_index = ((start_ms + duration_ms) * kSamplePerMs) % kAudioBufferSize;
+
+
+    init_microphone(error_reporter);
+
+
+    if(start_index < end_index)
+    {
+        const int length = (end_index - start_index);
+        memcpy(g_context.sample_buffer, &g_context.audio_buffer[start_index], length * sizeof(int16_t));
+    }
+    else
+    {
+        const int length_to_end = (kAudioBufferSize - start_index);
+        memcpy(g_context.sample_buffer, &g_context.audio_buffer[start_index], length_to_end * sizeof(int16_t));
+        memcpy(&g_context.sample_buffer[length_to_end], g_context.audio_buffer, end_index * sizeof(int16_t));
+    }
+
+    *audio_samples_size = kMaxAudioSampleSize;
+    *audio_samples = g_context.sample_buffer;
+
+    return kTfLiteOk;
+}
+
+/*************************************************************************************************/
+int32_t LatestAudioTimestamp()
+{
+    return g_context.latest_audio_timestamp_ms;
+}
+
+
+/*************************************************************************************************/
+static void init_microphone(tflite::ErrorReporter* error_reporter)
+{
+    if(!g_context.initialized)
+    {
+        microphone_config_t config;
+        config.sample_rate = kAudioSampleFrequency;
+        config.sample_size = kMaxAudioSampleSize;
+        config.resolution = MICROPHONE_RESOLUTION_16BITS;
+        config.flags = MICROPHONE_FLAG_MONO_DROP_OTHER_CHANNEL;
+        config.buffer_callback = microphone_buffer_callback;
+        config.buffer = g_context.audio_buffer;
+        config.buffer_length_bytes = kAudioBufferSize * sizeof(int16_t);
+
+        if(microphone_init(&config) != 0)
+        {
+            error_reporter->Report("Failed to initialize microphone");
+            return;
+        }
+        else if(microphone_start() != 0)
+        {
+            error_reporter->Report("Failed to start microphone");
+            return;
+        }
+
+        g_context.initialized = true;
+
+        error_reporter->Report("Microphone initialized");
+    }
+}
+
+/*************************************************************************************************/
+static void microphone_buffer_callback(const void* buf, uint32_t buffer_length_bytes, void *arg)
+{
+    g_context.latest_audio_timestamp_ms += (kMaxAudioSampleSize * 1000) / kAudioSampleFrequency;
+}

--- a/tensorflow/lite/micro/examples/micro_speech/silabs/command_responder.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/silabs/command_responder.cc
@@ -1,0 +1,70 @@
+/***************************************************************************//**
+ * # License
+ * <b>Copyright 2020 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+#include <string.h>
+
+#include "tensorflow/lite/micro/examples/micro_speech/command_responder.h"
+
+
+#include "bsp.h"
+
+
+
+
+
+// The default implementation writes out the name of the recognized command
+// to the error console. Real applications will want to take some custom
+// action instead, and should implement their own versions of this function.
+void RespondToCommand(tflite::ErrorReporter* error_reporter,
+                      int32_t current_time, const char* found_command,
+                      uint8_t score, bool is_new_command) {
+    static bool initialized = false;
+
+    if(!initialized)
+    {
+        initialized = true;
+        BSP_LedsInit();
+    }
+
+   //error_reporter->Report("%s %d", found_command, score);
+
+    if (is_new_command) {
+    TF_LITE_REPORT_ERROR(error_reporter, "Heard %s (%d) @%dms", found_command,
+                         score, current_time);
+
+
+        if(strcmp(found_command, "no") == 0)
+        {
+            BSP_LedSet(0);
+            BSP_LedClear(1);
+        }
+        else if(strcmp(found_command, "yes") == 0)
+        {
+            BSP_LedClear(0);
+            BSP_LedSet(1);
+        }
+  }
+}

--- a/tensorflow/lite/micro/silabs/debug_log.cc
+++ b/tensorflow/lite/micro/silabs/debug_log.cc
@@ -1,0 +1,26 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+
+#include "retargetserial.h"
+
+#include "tensorflow/lite/micro/debug_log.h"
+
+
+extern "C" void DebugLog(const char* s) {
+  while(*s != 0) {
+      RETARGET_WriteChar(*s++);
+  }
+}

--- a/tensorflow/lite/micro/tools/ci_build/test_all.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_all.sh
@@ -48,8 +48,10 @@ tensorflow/lite/micro/tools/ci_build/test_sparkfun.sh
 
 echo "Running stm32f4 tests at `date`"
 tensorflow/lite/micro/tools/ci_build/test_stm32f4.sh
-
 echo "Running Arduino tests at `date`"
 tensorflow/lite/micro/tools/ci_build/test_arduino.sh
+
+echo "Running silabs tests at `date`"
+tensorflow/lite/micro/tools/ci_build/test_silabs.sh
 
 echo "Finished all micro tests at `date`"

--- a/tensorflow/lite/micro/tools/ci_build/test_silabs.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_silabs.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# Tests the microcontroller code using native x86 execution.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR=${SCRIPT_DIR}/../../../../..
+cd "${ROOT_DIR}"
+
+source tensorflow/lite/micro/tools/ci_build/helper_functions.sh
+
+readable_run make -f tensorflow/lite/micro/tools/make/Makefile clean
+
+TARGET=stk3701a
+
+# TODO(b/143715361): downloading first to allow for parallel builds.
+readable_run make -f tensorflow/lite/micro/tools/make/Makefile TARGET=${TARGET} third_party_downloads
+readable_run make -j8 -f tensorflow/lite/micro/tools/make/Makefile TARGET=${TARGET} micro_speech_bin
+

--- a/tensorflow/lite/micro/tools/make/targets/efx32_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/efx32_makefile.inc
@@ -1,0 +1,169 @@
+# Settings for Silicon Labs EFM32/EFX32 platforms
+ifneq ($(filter $(TARGET),stk3701a),)
+ 
+  GCC_ARM := $(MAKEFILE_DIR)/downloads/gcc_embedded/
+
+  export PATH := $(GCC_ARM):$(PATH)
+  TARGET_ARCH := cortex-m4
+  TARGET_TOOLCHAIN_PREFIX := arm-none-eabi-
+  # Download the EFx32 TF-Lite Micro library and set this variable to find the header
+  # files:
+  SILABS_EFX32_LIB := $(MAKEFILE_DIR)/downloads/$(SILABS_EFX32_LIB_DEST)
+  GECKO_SDK_DIR := $(SILABS_EFX32_LIB)/components/gecko_sdk_suite/v27/
+  BINDIR := $(MAKEFILE_DIR)/gen/$(TARGET)_$(TARGET_ARCH)/bin
+  APP_NAME := $(subst _bin,,$(firstword $(MAKECMDGOALS)))
+
+  $(eval $(call add_third_party_download,$(GCC_EMBEDDED_URL),$(GCC_EMBEDDED_MD5),gcc_embedded,))
+  $(eval $(call add_third_party_download,$(SILABS_EFX32_LIB_URL),$(SILABS_EFX32_LIB_MD5),$(SILABS_EFX32_LIB_DEST),))
+
+  # Use the CMSIS-NN optimized kernels
+  ALL_TAGS += silabs efx32 cmsis-nn
+
+  COMMON_FLAGS := \
+    -mthumb -mno-thumb-interwork \
+     --specs $(GCC_ARM)/arm-none-eabi/lib/thumb/v7e-m/fpv5/hard/nano.specs \
+     --specs $(GCC_ARM)/arm-none-eabi/lib/thumb/v7e-m/fpv5/hard/nosys.specs \
+    -nostartfiles -ffunction-sections -fdata-sections -ggdb -ffreestanding \
+    -Wall -Wextra -fno-common -fno-delete-null-pointer-checks \
+    -Wno-unused-parameter \
+    -D__PROGRAM_START -D__STARTUP_CLEAR_BSS \
+    -D__STACK_SIZE=10240 -D__HEAP_SIZE=262144
+    
+  # Cortex-CM4 common flags
+  ifneq ($(filter $(TARGET), stk3701a),)
+    PLATFORM_FLAGS += \
+      -mfloat-abi=hard -mfpu=fpv4-sp-d16 -mcpu=cortex-m4 \
+      -D__ARM_FEATURE_DSP=1  -DARM_MATH_CM4
+    PLATFORM_LDFLAGS += -mfloat-abi=hard -mfpu=fpv4-sp-d16 -mcpu=cortex-m4
+  endif
+    
+
+  # STK3701A config
+  ifeq ($(TARGET), stk3701a)
+    PLATFORM_FLAGS += \
+      -DEFM32GG11B820F2048GM64 -DEFM32GG11BxxxF2048 \
+      -DEFM32GG11B -D_SILICON_LABS_32B_SERIES_1_CONFIG=1 \
+      -DRETARGET_VCOM
+    PLATFORM_LDFLAGS += -Wl,-T$(GECKO_SDK_DIR)platform/Device/SiliconLabs/EFM32GG11B/Source/GCC/efm32gg11b.ld 
+    PLATFORM_INCLUDES += \
+      -I$(GECKO_SDK_DIR)platform/Device/SiliconLabs/EFM32GG11B/Include \
+      -I$(GECKO_SDK_DIR)hardware/kit/SLSTK3701A_EFM32GG11/config
+      
+    PLATFORM_CC_SRCS += $(addprefix $(GECKO_SDK_DIR)platform/Device/SiliconLabs/EFM32GG11B/,\
+      Source/system_efm32gg11b.c \
+      Source/GCC/startup_efm32gg11b.c)
+  endif
+
+  CXXFLAGS += \
+    $(COMMON_FLAGS) $(PLATFORM_FLAGS) -fno-threadsafe-statics \
+     -Wno-sign-compare -Wno-unused-but-set-variable -Wno-comment -Wno-type-limits -Wno-strict-aliasing \
+     -Wno-missing-field-initializers -Wno-deprecated-declarations \
+     -Wno-maybe-uninitialized -Wno-unused-variable -Wno-unused-value
+  CCFLAGS += $(COMMON_FLAGS) $(PLATFORM_FLAGS)
+  LDFLAGS += $(PLATFORM_LDFLAGS) \
+    -Wl,--cref -mthumb -Wl,--no-wchar-size-warning \
+     -ffunction-sections -fdata-sections -ggdb \
+    -u _sbrk \
+    -ffreestanding -nodefaultlibs -flto -Wl,--gc-sections \
+    -Wl,-Map=$(BINDIR)/$(APP_NAME).map,--cref
+  
+  
+  BUILD_TYPE := micro
+
+
+  MICROLITE_LIBS := -lstdc++ -lm -lc -lgcc
+  INCLUDES += \
+    -isystem$(MAKEFILE_DIR)/downloads/cmsis/CMSIS/Core/Include/ \
+    -isystem$(MAKEFILE_DIR)/downloads/cmsis/CMSIS/DSP/Include/ \
+    $(PLATFORM_INCLUDES) \
+    -I$(GECKO_SDK_DIR)platform/emlib/inc \
+    -I$(GECKO_SDK_DIR)hardware/kit/common/bsp \
+    -I$(GECKO_SDK_DIR)hardware/kit/common/drivers
+
+  # emlib
+  PLATFORM_CC_SRCS += $(addprefix $(GECKO_SDK_DIR)platform/emlib/,\
+     src/em_assert.c \
+     src/em_core.c \
+     src/em_cmu.c \
+     src/em_emu.c \
+     src/em_gpio.c \
+     src/em_ldma.c \
+     src/em_system.c \
+     src/em_usart.c)
+     
+   # Microphone
+   PLATFORM_CC_SRCS += $(addprefix $(SILABS_EFX32_LIB)/components/microphone/,\
+     microphone.c platform_dma.c)
+   INCLUDES += \
+     -I$(SILABS_EFX32_LIB)/components/microphone \
+     -I$(SILABS_EFX32_LIB)/components/microphone/config 
+
+     
+   # BSP
+   PLATFORM_CC_SRCS += $(addprefix $(GECKO_SDK_DIR)hardware/kit/common/bsp/,\
+     bsp_bcc.c bsp_stk_leds.c bsp_stk.c bsp_trace.c)
+   PLATFORM_CC_SRCS += $(addprefix $(GECKO_SDK_DIR)hardware/kit/common/drivers/,\
+     retargetio.c retargetserial.c)
+
+  # Newlib Nano overrides
+  MICROLITE_CC_SRCS +=\
+    $(PLATFORM_CC_SRCS) \
+    $(SILABS_EFX32_LIB)/tools/toolchains/gcc/arm/newlib_nano_cpp.cc \
+    $(SILABS_EFX32_LIB)/tools/toolchains/gcc/arm/newlib_nano.c
+  
+  # Currently only the micro_speech example is supported
+  MICRO_LITE_EXAMPLE_TESTS := tensorflow/lite/micro/examples/micro_speech/Makefile.inc
+
+
+
+
+
+
+
+
+
+OBJCOPY := ${TARGET_TOOLCHAIN_ROOT}$(TARGET_TOOLCHAIN_PREFIX)objcopy
+ELFSIZE := ${TARGET_TOOLCHAIN_ROOT}$(TARGET_TOOLCHAIN_PREFIX)size
+
+
+print_size: $(BINDIR)/$(APP_NAME)
+	$(ELFSIZE) $< 
+
+$(BINDIR)/$(APP_NAME).bin: $(BINDIR)/$(APP_NAME) print_size
+	@mkdir -p $(dir $@)
+	$(OBJCOPY) $< $@ -O binary
+	
+$(BINDIR)/$(APP_NAME).s37: $(BINDIR)/$(APP_NAME)
+	@mkdir -p $(dir $@)
+	$(OBJCOPY) $< $@ -O srec
+
+
+ifeq ($(HOST_OS),windows)
+COMMANDER := $(SILABS_EFX32_LIB)/tools/commander/windows/commander.exe
+endif
+ifeq ($(HOST_OS),osx)
+COMMANDER := $(SILABS_EFX32_LIB)/tools/commander/osx/MacOS/commander
+endif
+ifeq ($(HOST_OS),linux)
+COMMANDER := $(SILABS_EFX32_LIB)/tools/commander/linux/commander/commander
+endif
+
+download_commander:
+	$(eval IS_WINDOWS_UBUNTU=$(shell $(SILABS_EFX32_LIB)/tools/check_if_windows_ubuntu.sh))
+	$(if $(filter $(IS_WINDOWS_UBUNTU),true),\
+	  $(eval COMMANDER=$(SILABS_EFX32_LIB)/tools/commander/windows/commander.exe)\
+	  $(eval CMDER_HOST_OS=windows))
+	@python --version >/dev/null || echo "'python' not found in environment PATH"
+	@python $(SILABS_EFX32_LIB)/tools/python/download_commander.py \
+	        --host_os $(if $(CMDER_HOST_OS),$(CMDER_HOST_OS),$(HOST_OS))\
+	        --output $(dir $(COMMANDER))/download_details.txt
+
+download: $(BINDIR)/$(APP_NAME).s37 download_commander
+	$(info Downloading $< ...)
+	$(COMMANDER) flash --device EFM32 --force $<
+
+
+reset: download_commander
+	$(COMMANDER) device reset --device EFM32
+
+endif

--- a/tensorflow/lite/micro/tools/make/third_party_downloads.inc
+++ b/tensorflow/lite/micro/tools/make/third_party_downloads.inc
@@ -93,3 +93,6 @@ ETHOSU_MD5 := "d2073c8d88fc167fd5c46b5dcda58ea1"
 
 HIMAX_WE1_SDK_URL ="https://www.himax.com.tw/we-i/himax_we1_sdk_v03.zip"
 HIMAX_WE1_SDK_MD5 ="1cd9b17f3fdb3e9a1dfd1cc356694325"
+SILABS_EFX32_LIB_URL := "https://www.dropbox.com/s/g3lxy03br939opl/efx32_tflite_micro-1.0.tar.gz?dl=1"
+SILABS_EFX32_LIB_MD5 := "85b62ae1d3761a4437d2ea61063cc431"
+SILABS_EFX32_LIB_DEST := efx32_tflite_micro-1.0


### PR DESCRIPTION
This ports the Micro Speech example to the Silicon Labs STK3701A development board:
https://www.silabs.com/development-tools/mcu/32-bit/efm32gg11-starter-kit
