### PR TITLE
Adding an option to tf.compat.v1.lite.TFLiteConverter.from_frozen_graph()

### DIFF
--- a/tensorflow/lite/g3doc/convert/index.md
+++ b/tensorflow/lite/g3doc/convert/index.md
@@ -50,6 +50,7 @@ In case you encounter any issues:
     (from the [tflite_convert](https://www.tensorflow.org/lite/convert/cmdline)
     command line tool) or `converter.experimental_new_converter=False` (from the
     [Python API](https://www.tensorflow.org/api_docs/python/tf/lite/TFLiteConverter))
+*   If you want to convert a Frozen Graph you can use the `from_frozen_graph()` method from `tf.compat.v1.lite.TFLiteConverter.from_frozen_graph()`. One advantage of using it is it allows us to specify `input_arrays` and `output_arrays` that would go into the converted TensorFlow Lite model.   
 
 ## Device deployment
 


### PR DESCRIPTION
This PR adds a note on using the `tf.compat.v1.lite.TFLiteConverter.from_frozen_graph()` method and also briefly specify where it might be useful. An end-to-end workflow is demonstrated here in [this Colab Notebook](https://colab.research.google.com/github/sayakpaul/Adventures-in-TensorFlow-Lite/blob/master/DeepLabV3/DeepLab_TFLite_COCO.ipynb). 

Cc: @khanhlvg 