### PR TITLE
Support TF logs in TerminateOnNaN callback

### DIFF
--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -884,10 +884,15 @@ class TerminateOnNaN(Callback):
   """Callback that terminates training when a NaN loss is encountered.
   """
 
+  def __init__(self):
+    super(TerminateOnNaN, self).__init__()
+    self._supports_tf_logs = True
+
   def on_batch_end(self, batch, logs=None):
     logs = logs or {}
     loss = logs.get('loss')
     if loss is not None:
+      loss = tf_utils.to_numpy_or_python_type(loss)
       if np.isnan(loss) or np.isinf(loss):
         print('Batch %d: Invalid loss, terminating training' % (batch))
         self.model.stop_training = True


### PR DESCRIPTION
This PR adds support for TF logs in the `TerminateOnNaN` callback. This callback is the only one that implements batch hooks and doesn't yet support TF logs by default. With this change only the `loss` needs to be converted to numpy instead of the entire `logs` dictionary.

This change is covered by the existing unittests so I didn't adapt them.