### PR TITLE
Fix binary crossentropy double epsilon

### DIFF
--- a/tensorflow/python/keras/backend.py
+++ b/tensorflow/python/keras/backend.py
@@ -5046,8 +5046,8 @@ def binary_crossentropy(target, output, from_logits=False):
   output = clip_ops.clip_by_value(output, epsilon_, 1. - epsilon_)
 
   # Compute cross entropy from probabilities.
-  bce = target * math_ops.log(output + epsilon())
-  bce += (1 - target) * math_ops.log(1 - output + epsilon())
+  bce = target * math_ops.log(output)
+  bce += (1 - target) * math_ops.log(1 - output)
   return -bce
 
 

--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -1769,7 +1769,7 @@ def binary_crossentropy(y_true, y_pred, from_logits=False, label_smoothing=0):
   >>> loss = tf.keras.losses.binary_crossentropy(y_true, y_pred)
   >>> assert loss.shape == (2,)
   >>> loss.numpy()
-  array([0.916 , 0.714], dtype=float32)
+  array([0.91629076, 0.7135582], dtype=float32)
 
   Args:
     y_true: Ground truth values. shape = `[batch_size, d0, .. dN]`.

--- a/tensorflow/python/keras/losses_test.py
+++ b/tensorflow/python/keras/losses_test.py
@@ -930,7 +930,7 @@ class BinaryCrossentropyTest(test.TestCase):
     #                = [ 5.11, 0]
     # Reduced loss = 5.11 * 1.2 / 2
 
-    self.assertAlmostEqual(self.evaluate(loss), 3.0666, 3)
+    self.assertAlmostEqual(self.evaluate(loss), 3.188477, 3)
 
     # Test with logits.
     y_true = ragged_factory_ops.constant([[1, 0, 1], [0, 1]])

--- a/tensorflow/python/keras/losses_test.py
+++ b/tensorflow/python/keras/losses_test.py
@@ -167,8 +167,8 @@ class KerasLossesTest(test.TestCase, parameterized.TestCase):
         atol=1e-5)
 
   def test_binary_crossentropy_loss_with_errors_equal_to_one(self):
-    target = backend.variable(np.ones(2, 2))
-    output = backend.variable(np.zeros(2, 2))
+    target = backend.variable(np.ones((2, 2)))
+    output = backend.variable(np.zeros((2, 2)))
     loss_value = losses.binary_crossentropy(target, output)
     np.testing.assert_allclose(
         backend.eval(loss_value),

--- a/tensorflow/python/keras/losses_test.py
+++ b/tensorflow/python/keras/losses_test.py
@@ -166,6 +166,15 @@ class KerasLossesTest(test.TestCase, parameterized.TestCase):
         backend.eval(output_from_sigmoid),
         atol=1e-5)
 
+  def test_binary_crossentropy_loss_with_errors_equal_to_one(self):
+    target = backend.variable(np.ones(2, 2))
+    output = backend.variable(np.zeros(2, 2))
+    loss_value = losses.binary_crossentropy(target, output)
+    np.testing.assert_allclose(
+        backend.eval(loss_value),
+        -np.log(backend.epsilon()),
+        atol=1e-5)
+
   def test_get_bce(self):
     bce_fn = losses.get('bce')
     self.assertEqual(bce_fn, losses.binary_crossentropy)

--- a/tensorflow/python/keras/metrics_test.py
+++ b/tensorflow/python/keras/metrics_test.py
@@ -1568,7 +1568,7 @@ class BinaryCrossentropyTest(test.TestCase):
     #        = [(0 + 15.33) / 2, (0 + 0) / 2]
     # Reduced metric = 7.665 / 2
 
-    self.assertAllClose(self.evaluate(result), 3.833, atol=1e-3)
+    self.assertAllClose(self.evaluate(result), 3.9855, atol=1e-3)
 
   def test_unweighted_with_logits(self):
     bce_obj = metrics.BinaryCrossentropy(from_logits=True)
@@ -1611,7 +1611,7 @@ class BinaryCrossentropyTest(test.TestCase):
     # Weighted metric = [7.665 * 1.5, 0]
     # Reduced metric = 7.665 * 1.5 / (1.5 + 2)
 
-    self.assertAllClose(self.evaluate(result), 3.285, atol=1e-3)
+    self.assertAllClose(self.evaluate(result), 3.4162, atol=1e-3)
 
   def test_weighted_from_logits(self):
     bce_obj = metrics.BinaryCrossentropy(from_logits=True)


### PR DESCRIPTION
When I compute a binary crossentropy with Keras betweeen a target value == 1 and a prediction value == 0, the crossentropy formula contains a `log(0)` which does not exist and is avoided adding a small epsilon value. 

The epsilon has always been `1e-7` so far, and so the numerical value of the binary crossentropy in the case described above is supposed to be equal to `-log(1e-7) == 16.11809539794922 `

In previous versions of Keras this was true. However, on (at least) tensorflow 2.2, it's equal to `15.424948470398375` which is the same as `2e-7`. This is because the binary crossentropy code:

1. clips the predictions between `(epsilon, 1-epsilon)`
2. adds an epsilon when computing the log

This results in a clipping between `(2*epsilon, 1)` which I believe is not the expected behaviour. 

This pull request removes the second step.

Here is a snippet to reproduce:

```python
from tensorflow.keras.losses import BinaryCrossentropy
from tensorflow.keras import backend
import numpy as np

loss = BinaryCrossentropy()
print(backend.eval(loss(np.array([1.]), np.array([0.]))))
```

If this is indeed a bug, I can also open an issue for easier traceability.