### PR TITLE
Fix markdown bullet list in keras.models.save_model docstring

### DIFF
--- a/tensorflow/python/keras/saving/save.py
+++ b/tensorflow/python/keras/saving/save.py
@@ -66,9 +66,9 @@ def save_model(model,
 
   The saved model contains:
 
-      - the model's configuration (topology)
-      - the model's weights
-      - the model's optimizer's state (if any)
+  - the model's configuration (topology)
+  - the model's weights
+  - the model's optimizer's state (if any)
 
   Thus the saved model can be reinstantiated in
   the exact same state, without any of the code


### PR DESCRIPTION
Removes the four spaces of indent on a bullet list, which was causing it to render as a code block on [the documentation page](https://www.tensorflow.org/api_docs/python/tf/keras/models/save_model).

### Old output:

> The saved model contains:
>
>     - the model's configuration (topology)
>     - the model's weights
>     - the model's optimizer's state (if any)

### New output:

> The saved model contains:
>
> - the model's configuration (topology)
> - the model's weights
> - the model's optimizer's state (if any)