### PR TITLE
Fix issue in tf.ones where tf.quint8/quint16 does not work in graph mode

### DIFF
--- a/tensorflow/python/kernel_tests/constant_op_test.py
+++ b/tensorflow/python/kernel_tests/constant_op_test.py
@@ -24,6 +24,7 @@ from google.protobuf import text_format
 
 from tensorflow.core.framework import graph_pb2
 from tensorflow.core.framework import tensor_pb2
+from tensorflow.python.eager import def_function
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes as dtypes_lib
 from tensorflow.python.framework import errors_impl
@@ -628,6 +629,15 @@ class OnesTest(test.TestCase):
         self.assertEqual(z.dtype, dtype)
         self.assertEqual([2, 3], z.get_shape())
         self.assertAllEqual(z, np.ones([2, 3]))
+
+  def testQintDtype(self):
+    @def_function.function(autograph=False)
+    def f():
+      return math_ops.cast(
+          array_ops.ones([2, 3], dtype=dtypes_lib.quint8), dtypes_lib.int32)
+
+    value = self.evaluate(f())
+    self.assertTrue(np.all(value))
 
 
 class OnesLikeTest(test.TestCase):

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -3053,7 +3053,12 @@ def ones(shape, dtype=dtypes.float32, name=None):
   """
   dtype = dtypes.as_dtype(dtype).base_dtype
   with ops.name_scope(name, "ones", [shape]) as name:
-    one = True if dtype == dtypes.bool else 1
+    if dtype == dtypes.bool:
+      one = True
+    elif dtype.is_quantized:
+      one = np.ones([]).astype(dtype.as_numpy_dtype)
+    else:
+      one = 1
     if not isinstance(shape, ops.Tensor):
       try:
         if not context.executing_eagerly():


### PR DESCRIPTION
This PR tries to address the issue where tf.ones where tf.quint8/quint16 does not work in graph mode:
```
>>> @tf.function(autograph=False)
... def f():
...     return tf.ones([], tf.qint16)
...
>>> f()
...
...
    allow_broadcast=allow_broadcast))
  File "/Library/Python/3.7/site-packages/tensorflow/python/framework/tensor_util.py", line 456, in make_tensor_proto
    _AssertCompatible(values, dtype)
  File "/Library/Python/3.7/site-packages/tensorflow/python/framework/tensor_util.py", line 336, in _AssertCompatible
    (dtype.name, repr(mismatch), type(mismatch).__name__))
TypeError: Expected qint16, got 1 of type 'int' instead.
```

The reason is similiar to the internal error encountered in #41421.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>