### PR TITLE
Per-op tf32 plumbing for GPUs (Stage1: API change)

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/gemm_thunk.cc
+++ b/tensorflow/compiler/xla/service/gpu/gemm_thunk.cc
@@ -129,7 +129,7 @@ static bool DoGemmWithAlgorithm(
             /*leading dim of RHS=*/rhs_matrix.num_rows,
             /*beta=*/static_cast<Element>(beta), &output_data,
             /*leading dim of output=*/output_matrix.num_rows, computation_type,
-            *algorithm, output_profile_result)
+            *algorithm, /*allow_fast_math=*/-1, output_profile_result)
         .ok();
   }
 
@@ -146,7 +146,7 @@ static bool DoGemmWithAlgorithm(
             /*leading dim of RHS=*/rhs_matrix.num_rows, rhs_stride,
             /*beta=*/beta, &output_data,
             /*leading dim of output=*/output_matrix.num_rows, output_stride,
-            batch_size)
+            batch_size, /*allow_fast_math=*/-1)
         .ok();
   }
 
@@ -156,7 +156,8 @@ static bool DoGemmWithAlgorithm(
           output_matrix.num_cols, /*size of reduce dim=*/k, /*alpha=*/alpha,
           lhs_data, /*leading dim of LHS=*/lhs_matrix.num_rows, rhs_data,
           /*leading dim of RHS=*/rhs_matrix.num_rows, /*beta=*/beta,
-          &output_data, /*leading dim of output=*/output_matrix.num_rows)
+          &output_data, /*leading dim of output=*/output_matrix.num_rows,
+          /*allow_fast_math=*/-1)
       .ok();
 }
 

--- a/tensorflow/core/api_def/base_api/api_def_BatchMatMulV3.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_BatchMatMulV3.pbtxt
@@ -1,0 +1,65 @@
+op {
+  graph_op_name: "BatchMatMulV3"
+  in_arg {
+    name: "x"
+    description: <<END
+2-D or higher with shape `[..., r_x, c_x]`.
+END
+  }
+  in_arg {
+    name: "y"
+    description: <<END
+2-D or higher with shape `[..., r_y, c_y]`.
+END
+  }
+  out_arg {
+    name: "output"
+    description: <<END
+3-D or higher with shape `[..., r_o, c_o]`
+END
+  }
+  attr {
+    name: "adj_x"
+    description: <<END
+If `True`, adjoint the slices of `x`. Defaults to `False`.
+END
+  }
+  attr {
+    name: "adj_y"
+    description: <<END
+If `True`, adjoint the slices of `y`. Defaults to `False`.
+END
+  }
+  attr {
+    name: "allow_fast_math"
+    description: <<END
+If true, fast TensorFloat32 math will be used when possible.
+END
+  }
+  summary: "Multiplies slices of two tensors in batches."
+  description: <<END
+Multiplies all slices of `Tensor` `x` and `y` (each slice can be
+viewed as an element of a batch), and arranges the individual results
+in a single output tensor of the same batch size. Each of the
+individual slices can optionally be adjointed (to adjoint a matrix
+means to transpose and conjugate it) before multiplication by setting
+the `adj_x` or `adj_y` flag to `True`, which are by default `False`.
+
+The input tensors `x` and `y` are 2-D or higher with shape `[..., r_x, c_x]`
+and `[..., r_y, c_y]`.
+
+The output tensor is 2-D or higher with shape `[..., r_o, c_o]`, where:
+
+    r_o = c_x if adj_x else r_x
+    c_o = r_y if adj_y else c_y
+
+It is computed as:
+
+    output[..., :, :] = matrix(x[..., :, :]) * matrix(y[..., :, :])
+
+*NOTE*: `BatchMatMulV2` supports broadcasting in the batch dimensions. More
+about broadcasting
+[here](http://docs.scipy.org/doc/numpy/user/basics.broadcasting.html).
+
+END
+}

--- a/tensorflow/core/api_def/base_api/api_def_MatMulV2.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_MatMulV2.pbtxt
@@ -1,0 +1,31 @@
+op {
+  graph_op_name: "MatMulV2"
+  attr {
+    name: "transpose_a"
+    description: <<END
+If true, "a" is transposed before multiplication.
+END
+  }
+  attr {
+    name: "transpose_b"
+    description: <<END
+If true, "b" is transposed before multiplication.
+END
+  }
+  attr {
+    name: "allow_fast_math"
+    description: <<END
+If true, fast TensorFloat32 math will be used when possible.
+END
+  }
+  summary: "Multiply the matrix \"a\" by the matrix \"b\"."
+  description: <<END
+The inputs must be two-dimensional matrices and the inner dimension of
+"a" (after being transposed if transpose_a is true) must match the
+outer dimension of "b" (after being transposed if transposed_b is
+true).
+
+*Note*: The default kernel implementation for MatMul on GPUs uses
+cublas.
+END
+}

--- a/tensorflow/core/kernels/conv_grad_filter_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_filter_ops.cc
@@ -744,7 +744,8 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
         stream
             ->ThenBlasGemm(se::blas::Transpose::kNoTranspose,
                            se::blas::Transpose::kTranspose, n, m, k, 1.0f,
-                           a_ptr, n, b_ptr, m, 0.0f, &c_ptr, n)
+                           a_ptr, n, b_ptr, m, 0.0f, &c_ptr, n,
+                           /*allow_fast_math=*/-1)
             .ok();
     if (!blas_launch_status) {
       ctx->SetStatus(errors::Internal("Blas SGEMM launch failed : m=", m,
@@ -775,7 +776,8 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
         stream
             ->ThenBlasGemm(se::blas::Transpose::kNoTranspose,
                            se::blas::Transpose::kTranspose, n, m, k, 1.0f,
-                           b_ptr, n, a_ptr, m, 0.0f, &c_ptr, n)
+                           b_ptr, n, a_ptr, m, 0.0f, &c_ptr, n,
+                           /*allow_fast_math=*/-1)
             .ok();
     if (!blas_launch_status) {
       ctx->SetStatus(errors::Internal("Blas SGEMM launch failed : m=", m,

--- a/tensorflow/core/kernels/conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_input_ops.cc
@@ -920,7 +920,7 @@ void LaunchConv2DBackpropInputOp<GPUDevice, T>::operator()(
     bool blas_launch_status =
         stream
             ->ThenBlasGemm(transpose, no_transpose, n, m, k, 1.0f, b_ptr, k,
-                           a_ptr, k, 0.0f, &c_ptr, n)
+                           a_ptr, k, 0.0f, &c_ptr, n, /*allow_fast_math=*/-1)
             .ok();
     if (!blas_launch_status) {
       ctx->SetStatus(errors::Internal("Blas SGEMM launch failed : m=", m,
@@ -953,7 +953,7 @@ void LaunchConv2DBackpropInputOp<GPUDevice, T>::operator()(
     bool blas_launch_status =
         stream
             ->ThenBlasGemm(transpose, no_transpose, n, m, k, 1.0f, b_ptr, k,
-                           a_ptr, k, 0.0f, &c_ptr, n)
+                           a_ptr, k, 0.0f, &c_ptr, n, /*allow_fast_math=*/-1)
             .ok();
     if (!blas_launch_status) {
       ctx->SetStatus(errors::Internal("Blas SGEMM launch failed : m=", m,

--- a/tensorflow/core/kernels/conv_grad_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_grad_ops_3d.cc
@@ -1200,7 +1200,7 @@ class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
       bool blas_launch_status =
           stream
               ->ThenBlasGemm(transpose, no_transpose, n, m, k, 1.0f, b_ptr, k,
-                             a_ptr, k, 0.0f, &c_ptr, n)
+                             a_ptr, k, 0.0f, &c_ptr, n, /*allow_fast_math=*/-1)
               .ok();
       if (!blas_launch_status) {
         context->SetStatus(errors::Internal("Blas SGEMM launch failed : m=", m,
@@ -1230,7 +1230,7 @@ class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
       bool blas_launch_status =
           stream
               ->ThenBlasGemm(transpose, no_transpose, n, m, k, 1.0f, b_ptr, k,
-                             a_ptr, k, 0.0f, &c_ptr, n)
+                             a_ptr, k, 0.0f, &c_ptr, n, /*allow_fast_math=*/-1)
               .ok();
       if (!blas_launch_status) {
         context->SetStatus(errors::Internal("Blas SGEMM launch failed : m=", m,
@@ -1703,7 +1703,8 @@ class Conv3DBackpropFilterOp<GPUDevice, T> : public OpKernel {
           stream
               ->ThenBlasGemm(se::blas::Transpose::kNoTranspose,
                              se::blas::Transpose::kTranspose, n, m, k, 1.0f,
-                             a_ptr, n, b_ptr, m, 0.0f, &c_ptr, n)
+                             a_ptr, n, b_ptr, m, 0.0f, &c_ptr, n,
+                             /*allow_fast_math=*/-1)
               .ok();
       if (!blas_launch_status) {
         context->SetStatus(errors::Internal("Blas SGEMM launch failed : m=", m,
@@ -1731,7 +1732,8 @@ class Conv3DBackpropFilterOp<GPUDevice, T> : public OpKernel {
           stream
               ->ThenBlasGemm(se::blas::Transpose::kNoTranspose,
                              se::blas::Transpose::kTranspose, n, m, k, 1.0f,
-                             b_ptr, n, a_ptr, m, 0.0f, &c_ptr, n)
+                             b_ptr, n, a_ptr, m, 0.0f, &c_ptr, n,
+                             /*allow_fast_math=*/-1)
               .ok();
       if (!blas_launch_status) {
         context->SetStatus(errors::Internal("Blas SGEMM launch failed : m=", m,

--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -696,7 +696,7 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
     bool blas_launch_status =
         stream
             ->ThenBlasGemm(no_transpose, no_transpose, n, m, k, 1.0f, b_ptr, n,
-                           a_ptr, k, 0.0f, &c_ptr, n)
+                           a_ptr, k, 0.0f, &c_ptr, n, /*allow_fast_math=*/-1)
             .ok();
     if (!blas_launch_status) {
       ctx->SetStatus(errors::Internal("Blas SGEMM launch failed : m=", m,
@@ -724,7 +724,7 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
     bool blas_launch_status =
         stream
             ->ThenBlasGemm(no_transpose, no_transpose, n, m, k, 1.0f, b_ptr, n,
-                           a_ptr, k, 0.0f, &c_ptr, n)
+                           a_ptr, k, 0.0f, &c_ptr, n, /*allow_fast_math=*/-1)
             .ok();
     if (!blas_launch_status) {
       ctx->SetStatus(errors::Internal("Blas SGEMM launch failed : m=", m,

--- a/tensorflow/core/kernels/conv_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_ops_3d.cc
@@ -133,7 +133,8 @@ struct LaunchConvOp<GPUDevice, T, OpKernelContext> {
       bool blas_launch_status =
           stream
               ->ThenBlasGemm(no_transpose, no_transpose, n, m, k, 1.0f, b_ptr,
-                             n, a_ptr, k, 0.0f, &c_ptr, n)
+                             n, a_ptr, k, 0.0f, &c_ptr, n,
+                             /*allow_fast_math=*/-1)
               .ok();
       if (!blas_launch_status) {
         ctx->SetStatus(errors::Internal("Blas SGEMM launch failed : m=", m,
@@ -160,7 +161,8 @@ struct LaunchConvOp<GPUDevice, T, OpKernelContext> {
       bool blas_launch_status =
           stream
               ->ThenBlasGemm(no_transpose, no_transpose, n, m, k, 1.0f, b_ptr,
-                             n, a_ptr, k, 0.0f, &c_ptr, n)
+                             n, a_ptr, k, 0.0f, &c_ptr, n,
+                             /*allow_fast_math=*/-1)
               .ok();
       if (!blas_launch_status) {
         ctx->SetStatus(errors::Internal("Blas SGEMM launch failed : m=", m,

--- a/tensorflow/core/kernels/einsum_op_impl.h
+++ b/tensorflow/core/kernels/einsum_op_impl.h
@@ -580,9 +580,11 @@ struct EinsumHelper {
     Tensor output_reshaped;
     TF_RETURN_IF_ERROR(
         ReshapeToRank3(*output, bcast.output_batch_size(), &output_reshaped));
+    // By default, we disable the TF32 math mode on GPU for this operation.
     LaunchBatchMatMul<Device, T>::Launch(ctx, lhs, rhs, /*adj_x=*/false,
                                          /*adj_y=*/false, trans_x, trans_y,
-                                         bcast, &output_reshaped);
+                                         bcast, &output_reshaped,
+                                         /*allow_fast_math=*/0);
     return Status::OK();
   }
 };

--- a/tensorflow/core/kernels/rnn/blas_gemm.cc
+++ b/tensorflow/core/kernels/rnn/blas_gemm.cc
@@ -53,7 +53,8 @@ void TensorCuBlasGemm<T>::operator()(OpKernelContext* ctx, bool transa,
       ctx->op_device_context()
           ->stream()
           ->ThenBlasGemm(trans[transa], trans[transb], m, n, k, alpha, a_ptr,
-                         lda, b_ptr, ldb, beta, &c_ptr, ldc)
+                         lda, b_ptr, ldb, beta, &c_ptr, ldc,
+                         /*allow_fast_math=*/-1)
           .ok();
   OP_REQUIRES(ctx, blas_launch_status, errors::Aborted("CuBlasGemm failed!"));
 #else

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -137,6 +137,18 @@ REGISTER_OP("BatchMatMulV2")
     .Attr("adj_y: bool = false")
     .SetShapeFn(shape_inference::BatchMatMulV2Shape);
 
+REGISTER_OP("BatchMatMulV3")
+    .Input("x: T")
+    .Input("y: T")
+    .Output("output: T")
+    .Attr(
+        "T: {bfloat16, half, float, double, int32, int64, complex64, "
+        "complex128}")
+    .Attr("adj_x: bool = false")
+    .Attr("adj_y: bool = false")
+    .Attr("allow_fast_math: int = -1")
+    .SetShapeFn(shape_inference::BatchMatMulV2Shape);
+
 #ifdef INTEL_MKL
 REGISTER_OP("_MklBatchMatMul")
     .Input("x: T")
@@ -919,6 +931,18 @@ REGISTER_OP("MatMul")
     .Attr(
         "T: {bfloat16, half, float, double, int32, int64, complex64, "
         "complex128}")
+    .SetShapeFn(shape_inference::MatMulShape);
+
+REGISTER_OP("MatMulV2")
+    .Input("a: T")
+    .Input("b: T")
+    .Output("product: T")
+    .Attr("transpose_a: bool = false")
+    .Attr("transpose_b: bool = false")
+    .Attr(
+        "T: {bfloat16, half, float, double, int32, int64, complex64, "
+        "complex128}")
+    .Attr("allow_fast_math: int = -1")
     .SetShapeFn(shape_inference::MatMulShape);
 
 #ifdef INTEL_MKL

--- a/tensorflow/python/ops/linalg/linear_operator.py
+++ b/tensorflow/python/ops/linalg/linear_operator.py
@@ -1186,11 +1186,14 @@ def _matmul(  # pylint:disable=missing-docstring
     adjoint_b=False,
     a_is_sparse=False,
     b_is_sparse=False,
+    allow_fast_math=None,
     name=None):
   if transpose_a or transpose_b:
     raise ValueError("Transposing not supported at this time.")
   if a_is_sparse or b_is_sparse:
     raise ValueError("Sparse methods not supported at this time.")
+  if allow_fast_math != None:
+    raise ValueError("allow_fast_math is not supported at this time.")
   if not isinstance(a, LinearOperator):
     # We use the identity (B^HA^H)^H =  AB
     adjoint_matmul = b.matmul(

--- a/tensorflow/stream_executor/blas.h
+++ b/tensorflow/stream_executor/blas.h
@@ -957,48 +957,52 @@ class BlasSupport {
                           float alpha, const DeviceMemory<Eigen::half> &a,
                           int lda, const DeviceMemory<Eigen::half> &b, int ldb,
                           float beta, DeviceMemory<Eigen::half> *c,
-                          int ldc) = 0;
+                          int ldc, int allow_fast_math) = 0;
   virtual bool DoBlasGemm(Stream *stream, blas::Transpose transa,
                           blas::Transpose transb, uint64 m, uint64 n, uint64 k,
                           float alpha, const DeviceMemory<float> &a, int lda,
                           const DeviceMemory<float> &b, int ldb, float beta,
-                          DeviceMemory<float> *c, int ldc) = 0;
+                          DeviceMemory<float> *c, int ldc,
+                          int allow_fast_math) = 0;
   virtual bool DoBlasGemm(Stream *stream, blas::Transpose transa,
                           blas::Transpose transb, uint64 m, uint64 n, uint64 k,
                           double alpha, const DeviceMemory<double> &a, int lda,
                           const DeviceMemory<double> &b, int ldb, double beta,
-                          DeviceMemory<double> *c, int ldc) = 0;
+                          DeviceMemory<double> *c, int ldc,
+                          int allow_fast_math) = 0;
   virtual bool DoBlasGemm(Stream *stream, blas::Transpose transa,
                           blas::Transpose transb, uint64 m, uint64 n, uint64 k,
                           std::complex<float> alpha,
                           const DeviceMemory<std::complex<float>> &a, int lda,
                           const DeviceMemory<std::complex<float>> &b, int ldb,
                           std::complex<float> beta,
-                          DeviceMemory<std::complex<float>> *c, int ldc) = 0;
+                          DeviceMemory<std::complex<float>> *c, int ldc,
+                          int allow_fast_math) = 0;
   virtual bool DoBlasGemm(Stream *stream, blas::Transpose transa,
                           blas::Transpose transb, uint64 m, uint64 n, uint64 k,
                           std::complex<double> alpha,
                           const DeviceMemory<std::complex<double>> &a, int lda,
                           const DeviceMemory<std::complex<double>> &b, int ldb,
                           std::complex<double> beta,
-                          DeviceMemory<std::complex<double>> *c, int ldc) = 0;
+                          DeviceMemory<std::complex<double>> *c, int ldc,
+                          int allow_fast_math) = 0;
 
   virtual bool DoBlasGemmWithProfiling(
       Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
       uint64 n, uint64 k, float alpha, const DeviceMemory<Eigen::half> &a,
       int lda, const DeviceMemory<Eigen::half> &b, int ldb, float beta,
-      DeviceMemory<Eigen::half> *c, int ldc,
+      DeviceMemory<Eigen::half> *c, int ldc, int allow_fast_math,
       ProfileResult *output_profile_result) = 0;
   virtual bool DoBlasGemmWithProfiling(
       Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
       uint64 n, uint64 k, float alpha, const DeviceMemory<float> &a, int lda,
       const DeviceMemory<float> &b, int ldb, float beta, DeviceMemory<float> *c,
-      int ldc, ProfileResult *output_profile_result) = 0;
+      int ldc, int allow_fast_math, ProfileResult *output_profile_result) = 0;
   virtual bool DoBlasGemmWithProfiling(
       Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
       uint64 n, uint64 k, double alpha, const DeviceMemory<double> &a, int lda,
       const DeviceMemory<double> &b, int ldb, double beta,
-      DeviceMemory<double> *c, int ldc,
+      DeviceMemory<double> *c, int ldc, int allow_fast_math,
       ProfileResult *output_profile_result) = 0;
   virtual bool DoBlasGemmWithProfiling(
       Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
@@ -1006,14 +1010,14 @@ class BlasSupport {
       const DeviceMemory<std::complex<float>> &a, int lda,
       const DeviceMemory<std::complex<float>> &b, int ldb,
       std::complex<float> beta, DeviceMemory<std::complex<float>> *c, int ldc,
-      ProfileResult *output_profile_result) = 0;
+      int allow_fast_math, ProfileResult *output_profile_result) = 0;
   virtual bool DoBlasGemmWithProfiling(
       Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
       uint64 n, uint64 k, std::complex<double> alpha,
       const DeviceMemory<std::complex<double>> &a, int lda,
       const DeviceMemory<std::complex<double>> &b, int ldb,
       std::complex<double> beta, DeviceMemory<std::complex<double>> *c, int ldc,
-      ProfileResult *output_profile_result) = 0;
+      int allow_fast_math, ProfileResult *output_profile_result) = 0;
 
   // Gets a list of supported algorithms for DoBlasGemmWithAlgorithm.
   virtual bool GetBlasGemmAlgorithms(
@@ -1039,7 +1043,7 @@ class BlasSupport {
       const DeviceMemory<int8> &a, int lda, const DeviceMemory<int8> &b,
       int ldb, const HostOrDeviceScalar<int> &beta, DeviceMemory<int32> *c,
       int ldc, ComputationType computation_type, AlgorithmType algorithm,
-      ProfileResult *output_profile_result) = 0;
+      int allow_fast_math, ProfileResult *output_profile_result) = 0;
   virtual bool DoBlasGemmWithAlgorithm(
       Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
       uint64 n, uint64 k, const HostOrDeviceScalar<Eigen::half> &alpha,
@@ -1047,21 +1051,21 @@ class BlasSupport {
       const DeviceMemory<Eigen::half> &b, int ldb,
       const HostOrDeviceScalar<Eigen::half> &beta, DeviceMemory<Eigen::half> *c,
       int ldc, ComputationType computation_type, AlgorithmType algorithm,
-      ProfileResult *output_profile_result) = 0;
+      int allow_fast_math, ProfileResult *output_profile_result) = 0;
   virtual bool DoBlasGemmWithAlgorithm(
       Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
       uint64 n, uint64 k, const HostOrDeviceScalar<float> &alpha,
       const DeviceMemory<float> &a, int lda, const DeviceMemory<float> &b,
       int ldb, const HostOrDeviceScalar<float> &beta, DeviceMemory<float> *c,
       int ldc, ComputationType computation_type, AlgorithmType algorithm,
-      ProfileResult *output_profile_result) = 0;
+      int allow_fast_math, ProfileResult *output_profile_result) = 0;
   virtual bool DoBlasGemmWithAlgorithm(
       Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
       uint64 n, uint64 k, const HostOrDeviceScalar<double> &alpha,
       const DeviceMemory<double> &a, int lda, const DeviceMemory<double> &b,
       int ldb, const HostOrDeviceScalar<double> &beta, DeviceMemory<double> *c,
       int ldc, ComputationType computation_type, AlgorithmType algorithm,
-      ProfileResult *output_profile_result) = 0;
+      int allow_fast_math, ProfileResult *output_profile_result) = 0;
   virtual bool DoBlasGemmWithAlgorithm(
       Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
       uint64 n, uint64 k, const HostOrDeviceScalar<std::complex<float>> &alpha,
@@ -1070,7 +1074,7 @@ class BlasSupport {
       const HostOrDeviceScalar<std::complex<float>> &beta,
       DeviceMemory<std::complex<float>> *c, int ldc,
       ComputationType computation_type, AlgorithmType algorithm,
-      ProfileResult *output_profile_result) = 0;
+      int allow_fast_math, ProfileResult *output_profile_result) = 0;
   virtual bool DoBlasGemmWithAlgorithm(
       Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
       uint64 n, uint64 k, const HostOrDeviceScalar<std::complex<double>> &alpha,
@@ -1079,7 +1083,7 @@ class BlasSupport {
       const HostOrDeviceScalar<std::complex<double>> &beta,
       DeviceMemory<std::complex<double>> *c, int ldc,
       ComputationType computation_type, AlgorithmType algorithm,
-      ProfileResult *output_profile_result) = 0;
+      int allow_fast_math, ProfileResult *output_profile_result) = 0;
 
   // Computes a batch of matrix-matrix product with general matrices.
   // This is a batched version of DoBlasGemm.
@@ -1091,21 +1095,24 @@ class BlasSupport {
       const port::ArraySlice<DeviceMemory<Eigen::half> *> &a, int lda,
       const port::ArraySlice<DeviceMemory<Eigen::half> *> &b, int ldb,
       float beta, const port::ArraySlice<DeviceMemory<Eigen::half> *> &c,
-      int ldc, int batch_count, ScratchAllocator *scratch_allocator) = 0;
+      int ldc, int batch_count, ScratchAllocator *scratch_allocator,
+      int allow_fast_math) = 0;
   virtual bool DoBlasGemmBatched(
       Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
       uint64 n, uint64 k, float alpha,
       const port::ArraySlice<DeviceMemory<float> *> &a, int lda,
       const port::ArraySlice<DeviceMemory<float> *> &b, int ldb, float beta,
       const port::ArraySlice<DeviceMemory<float> *> &c, int ldc,
-      int batch_count, ScratchAllocator *scratch_allocator) = 0;
+      int batch_count, ScratchAllocator *scratch_allocator,
+      int allow_fast_math) = 0;
   virtual bool DoBlasGemmBatched(
       Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
       uint64 n, uint64 k, double alpha,
       const port::ArraySlice<DeviceMemory<double> *> &a, int lda,
       const port::ArraySlice<DeviceMemory<double> *> &b, int ldb, double beta,
       const port::ArraySlice<DeviceMemory<double> *> &c, int ldc,
-      int batch_count, ScratchAllocator *scratch_allocator) = 0;
+      int batch_count, ScratchAllocator *scratch_allocator,
+      int allow_fast_math) = 0;
   virtual bool DoBlasGemmBatched(
       Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
       uint64 n, uint64 k, std::complex<float> alpha,
@@ -1113,7 +1120,8 @@ class BlasSupport {
       const port::ArraySlice<DeviceMemory<std::complex<float>> *> &b, int ldb,
       std::complex<float> beta,
       const port::ArraySlice<DeviceMemory<std::complex<float>> *> &c, int ldc,
-      int batch_count, ScratchAllocator *scratch_allocator) = 0;
+      int batch_count, ScratchAllocator *scratch_allocator,
+      int allow_fast_math) = 0;
   virtual bool DoBlasGemmBatched(
       Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
       uint64 n, uint64 k, std::complex<double> alpha,
@@ -1121,7 +1129,8 @@ class BlasSupport {
       const port::ArraySlice<DeviceMemory<std::complex<double>> *> &b, int ldb,
       std::complex<double> beta,
       const port::ArraySlice<DeviceMemory<std::complex<double>> *> &c, int ldc,
-      int batch_count, ScratchAllocator *scratch_allocator) = 0;
+      int batch_count, ScratchAllocator *scratch_allocator,
+      int allow_fast_math) = 0;
 
   // Batched gemm with strides instead of pointer arrays.
   virtual bool DoBlasGemmStridedBatched(
@@ -1129,33 +1138,33 @@ class BlasSupport {
       uint64 n, uint64 k, float alpha, const DeviceMemory<Eigen::half> &a,
       int lda, int64 stride_a, const DeviceMemory<Eigen::half> &b, int ldb,
       int64 stride_b, float beta, DeviceMemory<Eigen::half> *c, int ldc,
-      int64 stride_c, int batch_count) = 0;
+      int64 stride_c, int batch_count, int allow_fast_math) = 0;
   virtual bool DoBlasGemmStridedBatched(
       Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
       uint64 n, uint64 k, float alpha, const DeviceMemory<float> &a, int lda,
       int64 stride_a, const DeviceMemory<float> &b, int ldb, int64 stride_b,
       float beta, DeviceMemory<float> *c, int ldc, int64 stride_c,
-      int batch_count) = 0;
+      int batch_count, int allow_fast_math) = 0;
   virtual bool DoBlasGemmStridedBatched(
       Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
       uint64 n, uint64 k, double alpha, const DeviceMemory<double> &a, int lda,
       int64 stride_a, const DeviceMemory<double> &b, int ldb, int64 stride_b,
       double beta, DeviceMemory<double> *c, int ldc, int64 stride_c,
-      int batch_count) = 0;
+      int batch_count, int allow_fast_math) = 0;
   virtual bool DoBlasGemmStridedBatched(
       Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
       uint64 n, uint64 k, std::complex<float> alpha,
       const DeviceMemory<std::complex<float>> &a, int lda, int64 stride_a,
       const DeviceMemory<std::complex<float>> &b, int ldb, int64 stride_b,
       std::complex<float> beta, DeviceMemory<std::complex<float>> *c, int ldc,
-      int64 stride_c, int batch_count) = 0;
+      int64 stride_c, int batch_count, int allow_fast_math) = 0;
   virtual bool DoBlasGemmStridedBatched(
       Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
       uint64 n, uint64 k, std::complex<double> alpha,
       const DeviceMemory<std::complex<double>> &a, int lda, int64 stride_a,
       const DeviceMemory<std::complex<double>> &b, int ldb, int64 stride_b,
       std::complex<double> beta, DeviceMemory<std::complex<double>> *c, int ldc,
-      int64 stride_c, int batch_count) = 0;
+      int64 stride_c, int batch_count, int allow_fast_math) = 0;
 
   // Computes a matrix-matrix product where one input matrix is Hermitian:
   //
@@ -1876,49 +1885,55 @@ class BlasSupport {
                   blas::Transpose transb, uint64 m, uint64 n, uint64 k,        \
                   float alpha, const DeviceMemory<Eigen::half> &a, int lda,    \
                   const DeviceMemory<Eigen::half> &b, int ldb, float beta,     \
-                  DeviceMemory<Eigen::half> *c, int ldc) override;             \
+                  DeviceMemory<Eigen::half> *c, int ldc,                       \
+                  int allow_fast_math) override;                               \
   bool DoBlasGemm(Stream *stream, blas::Transpose transa,                      \
                   blas::Transpose transb, uint64 m, uint64 n, uint64 k,        \
                   float alpha, const DeviceMemory<float> &a, int lda,          \
                   const DeviceMemory<float> &b, int ldb, float beta,           \
-                  DeviceMemory<float> *c, int ldc) override;                   \
+                  DeviceMemory<float> *c, int ldc,                             \
+                  int allow_fast_math) override;                               \
   bool DoBlasGemm(Stream *stream, blas::Transpose transa,                      \
                   blas::Transpose transb, uint64 m, uint64 n, uint64 k,        \
                   double alpha, const DeviceMemory<double> &a, int lda,        \
                   const DeviceMemory<double> &b, int ldb, double beta,         \
-                  DeviceMemory<double> *c, int ldc) override;                  \
+                  DeviceMemory<double> *c, int ldc,                            \
+                  int allow_fast_math) override;                               \
   bool DoBlasGemm(Stream *stream, blas::Transpose transa,                      \
                   blas::Transpose transb, uint64 m, uint64 n, uint64 k,        \
                   std::complex<float> alpha,                                   \
                   const DeviceMemory<std::complex<float>> &a, int lda,         \
                   const DeviceMemory<std::complex<float>> &b, int ldb,         \
                   std::complex<float> beta,                                    \
-                  DeviceMemory<std::complex<float>> *c, int ldc) override;     \
+                  DeviceMemory<std::complex<float>> *c, int ldc,               \
+                  int allow_fast_math) override;                               \
   bool DoBlasGemm(Stream *stream, blas::Transpose transa,                      \
                   blas::Transpose transb, uint64 m, uint64 n, uint64 k,        \
                   std::complex<double> alpha,                                  \
                   const DeviceMemory<std::complex<double>> &a, int lda,        \
                   const DeviceMemory<std::complex<double>> &b, int ldb,        \
                   std::complex<double> beta,                                   \
-                  DeviceMemory<std::complex<double>> *c, int ldc) override;    \
+                  DeviceMemory<std::complex<double>> *c, int ldc,              \
+                  int allow_fast_math) override;                               \
   bool DoBlasGemmWithProfiling(                                                \
       Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
       uint64 m, uint64 n, uint64 k, float alpha,                               \
       const DeviceMemory<Eigen::half> &a, int lda,                             \
       const DeviceMemory<Eigen::half> &b, int ldb, float beta,                 \
-      DeviceMemory<Eigen::half> *c, int ldc,                                   \
+      DeviceMemory<Eigen::half> *c, int ldc, int allow_fast_math,              \
       blas::ProfileResult *output_profile_result) override;                    \
   bool DoBlasGemmWithProfiling(                                                \
       Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
       uint64 m, uint64 n, uint64 k, float alpha, const DeviceMemory<float> &a, \
       int lda, const DeviceMemory<float> &b, int ldb, float beta,              \
-      DeviceMemory<float> *c, int ldc,                                         \
+      DeviceMemory<float> *c, int ldc, int allow_fast_math,                    \
       blas::ProfileResult *output_profile_result) override;                    \
   bool DoBlasGemmWithProfiling(                                                \
       Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
       uint64 m, uint64 n, uint64 k, double alpha,                              \
       const DeviceMemory<double> &a, int lda, const DeviceMemory<double> &b,   \
       int ldb, double beta, DeviceMemory<double> *c, int ldc,                  \
+      int allow_fast_math,                                                     \
       blas::ProfileResult *output_profile_result) override;                    \
   bool DoBlasGemmWithProfiling(                                                \
       Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
@@ -1926,6 +1941,7 @@ class BlasSupport {
       const DeviceMemory<std::complex<float>> &a, int lda,                     \
       const DeviceMemory<std::complex<float>> &b, int ldb,                     \
       std::complex<float> beta, DeviceMemory<std::complex<float>> *c, int ldc, \
+      int allow_fast_math,                                                     \
       blas::ProfileResult *output_profile_result) override;                    \
   bool DoBlasGemmWithProfiling(                                                \
       Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
@@ -1933,7 +1949,8 @@ class BlasSupport {
       const DeviceMemory<std::complex<double>> &a, int lda,                    \
       const DeviceMemory<std::complex<double>> &b, int ldb,                    \
       std::complex<double> beta, DeviceMemory<std::complex<double>> *c,        \
-      int ldc, blas::ProfileResult *output_profile_result) override;           \
+      int ldc, int allow_fast_math,                                            \
+      blas::ProfileResult *output_profile_result) override;                    \
   bool GetBlasGemmAlgorithms(std::vector<blas::AlgorithmType> *out_algorithms) \
       override;                                                                \
   bool DoBlasGemmWithAlgorithm(                                                \
@@ -1942,7 +1959,7 @@ class BlasSupport {
       const DeviceMemory<int8> &a, int lda, const DeviceMemory<int8> &b,       \
       int ldb, const HostOrDeviceScalar<int> &beta, DeviceMemory<int> *c,      \
       int ldc, blas::ComputationType computation_type,                         \
-      blas::AlgorithmType algorithm,                                           \
+      blas::AlgorithmType algorithm, int allow_fast_math,                      \
       blas::ProfileResult *output_profile_result) override;                    \
   bool DoBlasGemmWithAlgorithm(                                                \
       Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
@@ -1953,6 +1970,7 @@ class BlasSupport {
       const HostOrDeviceScalar<Eigen::half> &beta,                             \
       DeviceMemory<Eigen::half> *c, int ldc,                                   \
       blas::ComputationType computation_type, blas::AlgorithmType algorithm,   \
+      int allow_fast_math,                                                     \
       blas::ProfileResult *output_profile_result) override;                    \
   bool DoBlasGemmWithAlgorithm(                                                \
       Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
@@ -1961,6 +1979,7 @@ class BlasSupport {
       int ldb, const HostOrDeviceScalar<float> &beta, DeviceMemory<float> *c,  \
       int ldc, blas::ComputationType computation_type,                         \
       blas::AlgorithmType algorithm,                                           \
+      int allow_fast_math,                                                     \
       blas::ProfileResult *output_profile_result) override;                    \
   bool DoBlasGemmWithAlgorithm(                                                \
       Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
@@ -1969,6 +1988,7 @@ class BlasSupport {
       int ldb, const HostOrDeviceScalar<double> &beta,                         \
       DeviceMemory<double> *c, int ldc,                                        \
       blas::ComputationType computation_type, blas::AlgorithmType algorithm,   \
+      int allow_fast_math,                                                     \
       blas::ProfileResult *output_profile_result) override;                    \
   bool DoBlasGemmWithAlgorithm(                                                \
       Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
@@ -1979,6 +1999,7 @@ class BlasSupport {
       const HostOrDeviceScalar<std::complex<float>> &beta,                     \
       DeviceMemory<std::complex<float>> *c, int ldc,                           \
       blas::ComputationType computation_type, blas::AlgorithmType algorithm,   \
+      int allow_fast_math,                                                     \
       blas::ProfileResult *output_profile_result) override;                    \
   bool DoBlasGemmWithAlgorithm(                                                \
       Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
@@ -1989,6 +2010,7 @@ class BlasSupport {
       const HostOrDeviceScalar<std::complex<double>> &beta,                    \
       DeviceMemory<std::complex<double>> *c, int ldc,                          \
       blas::ComputationType computation_type, blas::AlgorithmType algorithm,   \
+      int allow_fast_math,                                                     \
       blas::ProfileResult *output_profile_result) override;                    \
   bool DoBlasGemmBatched(                                                      \
       Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
@@ -1996,21 +2018,24 @@ class BlasSupport {
       const port::ArraySlice<DeviceMemory<Eigen::half> *> &a, int lda,         \
       const port::ArraySlice<DeviceMemory<Eigen::half> *> &b, int ldb,         \
       float beta, const port::ArraySlice<DeviceMemory<Eigen::half> *> &c,      \
-      int ldc, int batch_count, ScratchAllocator *scratch_allocator) override; \
+      int ldc, int batch_count, ScratchAllocator *scratch_allocator,           \
+      int allow_fast_math) override;                                           \
   bool DoBlasGemmBatched(                                                      \
       Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
       uint64 m, uint64 n, uint64 k, float alpha,                               \
       const port::ArraySlice<DeviceMemory<float> *> &a, int lda,               \
       const port::ArraySlice<DeviceMemory<float> *> &b, int ldb, float beta,   \
       const port::ArraySlice<DeviceMemory<float> *> &c, int ldc,               \
-      int batch_count, ScratchAllocator *scratch_allocator) override;          \
+      int batch_count, ScratchAllocator *scratch_allocator,                    \
+      int allow_fast_math) override;                                           \
   bool DoBlasGemmBatched(                                                      \
       Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
       uint64 m, uint64 n, uint64 k, double alpha,                              \
       const port::ArraySlice<DeviceMemory<double> *> &a, int lda,              \
       const port::ArraySlice<DeviceMemory<double> *> &b, int ldb, double beta, \
       const port::ArraySlice<DeviceMemory<double> *> &c, int ldc,              \
-      int batch_count, ScratchAllocator *scratch_allocator) override;          \
+      int batch_count, ScratchAllocator *scratch_allocator,                    \
+      int allow_fast_math) override;                                           \
   bool DoBlasGemmBatched(                                                      \
       Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
       uint64 m, uint64 n, uint64 k, std::complex<float> alpha,                 \
@@ -2018,7 +2043,8 @@ class BlasSupport {
       const port::ArraySlice<DeviceMemory<std::complex<float>> *> &b, int ldb, \
       std::complex<float> beta,                                                \
       const port::ArraySlice<DeviceMemory<std::complex<float>> *> &c, int ldc, \
-      int batch_count, ScratchAllocator *scratch_allocator) override;          \
+      int batch_count, ScratchAllocator *scratch_allocator,                    \
+      int allow_fast_math) override;                                           \
   bool DoBlasGemmBatched(                                                      \
       Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
       uint64 m, uint64 n, uint64 k, std::complex<double> alpha,                \
@@ -2027,39 +2053,42 @@ class BlasSupport {
       const port::ArraySlice<DeviceMemory<std::complex<double>> *> &b,         \
       int ldb, std::complex<double> beta,                                      \
       const port::ArraySlice<DeviceMemory<std::complex<double>> *> &c,         \
-      int ldc, int batch_count, ScratchAllocator *scratch_allocator) override; \
+      int ldc, int batch_count, ScratchAllocator *scratch_allocator,           \
+      int allow_fast_math) override;                                           \
   bool DoBlasGemmStridedBatched(                                               \
       Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
       uint64 m, uint64 n, uint64 k, float alpha,                               \
       const DeviceMemory<Eigen::half> &a, int lda, int64 stride_a,             \
       const DeviceMemory<Eigen::half> &b, int ldb, int64 stride_b, float beta, \
-      DeviceMemory<Eigen::half> *c, int ldc, int64 stride_c, int batch_count); \
+      DeviceMemory<Eigen::half> *c, int ldc, int64 stride_c, int batch_count,  \
+      int allow_fast_math);                                                    \
   bool DoBlasGemmStridedBatched(                                               \
       Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
       uint64 m, uint64 n, uint64 k, float alpha, const DeviceMemory<float> &a, \
       int lda, int64 stride_a, const DeviceMemory<float> &b, int ldb,          \
       int64 stride_b, float beta, DeviceMemory<float> *c, int ldc,             \
-      int64 stride_c, int batch_count);                                        \
+      int64 stride_c, int batch_count, int allow_fast_math);                   \
   bool DoBlasGemmStridedBatched(                                               \
       Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
       uint64 m, uint64 n, uint64 k, double alpha,                              \
       const DeviceMemory<double> &a, int lda, int64 stride_a,                  \
       const DeviceMemory<double> &b, int ldb, int64 stride_b, double beta,     \
-      DeviceMemory<double> *c, int ldc, int64 stride_c, int batch_count);      \
+      DeviceMemory<double> *c, int ldc, int64 stride_c, int batch_count,       \
+      int allow_fast_math);                                                    \
   bool DoBlasGemmStridedBatched(                                               \
       Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
       uint64 m, uint64 n, uint64 k, std::complex<float> alpha,                 \
       const DeviceMemory<std::complex<float>> &a, int lda, int64 stride_a,     \
       const DeviceMemory<std::complex<float>> &b, int ldb, int64 stride_b,     \
       std::complex<float> beta, DeviceMemory<std::complex<float>> *c, int ldc, \
-      int64 stride_c, int batch_count);                                        \
+      int64 stride_c, int batch_count, int allow_fast_math);                   \
   bool DoBlasGemmStridedBatched(                                               \
       Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
       uint64 m, uint64 n, uint64 k, std::complex<double> alpha,                \
       const DeviceMemory<std::complex<double>> &a, int lda, int64 stride_a,    \
       const DeviceMemory<std::complex<double>> &b, int ldb, int64 stride_b,    \
       std::complex<double> beta, DeviceMemory<std::complex<double>> *c,        \
-      int ldc, int64 stride_c, int batch_count);                               \
+      int ldc, int64 stride_c, int batch_count, int allow_fast_math);          \
   bool DoBlasHemm(Stream *stream, blas::Side side, blas::UpperLower uplo,      \
                   uint64 m, uint64 n, std::complex<float> alpha,               \
                   const DeviceMemory<std::complex<float>> &a, int lda,         \

--- a/tensorflow/stream_executor/cuda/cuda_blas.h
+++ b/tensorflow/stream_executor/cuda/cuda_blas.h
@@ -84,7 +84,8 @@ class CUDABlas : public blas::BlasSupport {
   template <typename FuncT, typename... Args>
   bool DoBlasInternalImpl(FuncT cublas_func, Stream *stream,
                           bool pointer_mode_host, bool err_on_failure,
-                          cublasMath_t math_type, Args... args);
+                          cublasMath_t math_type, int allow_fast_math,
+                          Args... args);
 
   // Convenience functions that call DoBlasInternalImpl with err_on_failure=true
   // and math_type=CUBLAS_DEFAULT_MATH.
@@ -93,7 +94,7 @@ class CUDABlas : public blas::BlasSupport {
                       Args... args) {
     return DoBlasInternalImpl(cublas_func, stream, pointer_mode_host,
                               /*err_on_failure=*/true, CUBLAS_DEFAULT_MATH,
-                              args...);
+                              /*allow_fast_math=*/-1, args...);
   }
 
   // A helper function to implement DoBlasGemmBatched interfaces for generic
@@ -105,7 +106,8 @@ class CUDABlas : public blas::BlasSupport {
       const port::ArraySlice<DeviceMemory<T> *> &a_array, int lda,
       const port::ArraySlice<DeviceMemory<T> *> &b_array, int ldb, Scalar beta,
       const port::ArraySlice<DeviceMemory<T> *> &c_array, int ldc,
-      int batch_count, ScratchAllocator *scratch_allocator);
+      int batch_count, ScratchAllocator *scratch_allocator,
+      int allow_fast_math);
 
   // Helper function for implementing DoBlasGemmWithAlgorithm.
   template <typename InT, typename OutT, typename CompT>
@@ -115,7 +117,7 @@ class CUDABlas : public blas::BlasSupport {
       const DeviceMemory<InT> &a, int lda, const DeviceMemory<InT> &b, int ldb,
       const HostOrDeviceScalar<CompT> &beta, DeviceMemory<OutT> *c, int ldc,
       blas::ComputationType computation_type, blas::AlgorithmType algorithm,
-      blas::ProfileResult *output_profile_result);
+      int allow_fast_math, blas::ProfileResult *output_profile_result);
 
   // Helper function for implementing DoBlasGemmWithProfiling.
   template <typename T, typename ParamType>
@@ -123,7 +125,8 @@ class CUDABlas : public blas::BlasSupport {
       Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
       uint64 n, uint64 k, const ParamType &alpha, const DeviceMemory<T> &a,
       int lda, const DeviceMemory<T> &b, int ldb, const ParamType &beta,
-      DeviceMemory<T> *c, int ldc, blas::ProfileResult *output_profile_result);
+      DeviceMemory<T> *c, int ldc, int allow_fast_math,
+      blas::ProfileResult *output_profile_result);
 
   // Helper function for implementing DoBlasGemvWithProfiling.
   template <typename T>

--- a/tensorflow/stream_executor/cuda/cuda_dnn.cc
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.cc
@@ -4064,7 +4064,8 @@ bool CudnnSupport::DoMatMul(Stream* stream,
     const int64 k = input_dimensions.NodesAcrossFeatureMaps();
     stream->ThenBlasGemm(blas::Transpose::kNoTranspose,
                          blas::Transpose::kNoTranspose, m, n, k, alpha, weights,
-                         m, input_data, k, beta, output_data, m);
+                         m, input_data, k, beta, output_data, m,
+                         /*allow_fast_math=*/-1);
   } else {
     // This is a slower and more complex path that supports output
     // width() * height() > 1, though it only supports the
@@ -4144,7 +4145,7 @@ bool CudnnSupport::DoMatMul(Stream* stream,
     stream->ThenBlasGemmBatched(blas::Transpose::kNoTranspose,
                                 blas::Transpose::kNoTranspose, m, n, k, alpha,
                                 toPtrs(a), lda, toPtrs(b), ldb, beta, toPtrs(c),
-                                ldc, batch_count);
+                                ldc, batch_count, /*allow_fast_math=*/-1);
   }
 
   return stream->ok();

--- a/tensorflow/stream_executor/rocm/rocm_blas.cc
+++ b/tensorflow/stream_executor/rocm/rocm_blas.cc
@@ -1516,7 +1516,8 @@ bool ROCMBlas::DoBlasGemm(Stream *stream, blas::Transpose transa,
                           blas::Transpose transb, uint64 m, uint64 n, uint64 k,
                           float alpha, const DeviceMemory<Eigen::half> &a,
                           int lda, const DeviceMemory<Eigen::half> &b, int ldb,
-                          float beta, DeviceMemory<Eigen::half> *c, int ldc) {
+                          float beta, DeviceMemory<Eigen::half> *c, int ldc,
+                          int allow_fast_math) {
   blas_log("DoBlasGemm");
   VLOG(1) << absl::StreamFormat(
       "doing rocBLAS SGEMM<half>: at=%d bt=%d m=%u n=%u "
@@ -1562,7 +1563,8 @@ bool ROCMBlas::DoBlasGemm(Stream *stream, blas::Transpose transa,
                           blas::Transpose transb, uint64 m, uint64 n, uint64 k,
                           float alpha, const DeviceMemory<float> &a, int lda,
                           const DeviceMemory<float> &b, int ldb, float beta,
-                          DeviceMemory<float> *c, int ldc) {
+                          DeviceMemory<float> *c, int ldc,
+                          int allow_fast_math) {
   blas_log("DoBlasGemm");
   VLOG(1) << absl::StreamFormat(
       "doing rocBLAS SGEMM<float>: at=%d bt=%d m=%u n=%u "
@@ -1602,7 +1604,8 @@ bool ROCMBlas::DoBlasGemm(Stream *stream, blas::Transpose transa,
                           blas::Transpose transb, uint64 m, uint64 n, uint64 k,
                           double alpha, const DeviceMemory<double> &a, int lda,
                           const DeviceMemory<double> &b, int ldb, double beta,
-                          DeviceMemory<double> *c, int ldc) {
+                          DeviceMemory<double> *c, int ldc,
+                          int allow_fast_math) {
   blas_log("DoBlasGemm");
   return DoBlasInternal(
       wrap::rocblas_dgemm, stream, true /* = pointer_mode_host */,
@@ -1616,7 +1619,8 @@ bool ROCMBlas::DoBlasGemm(Stream *stream, blas::Transpose transa,
                           const DeviceMemory<std::complex<float>> &a, int lda,
                           const DeviceMemory<std::complex<float>> &b, int ldb,
                           std::complex<float> beta,
-                          DeviceMemory<std::complex<float>> *c, int ldc) {
+                          DeviceMemory<std::complex<float>> *c, int ldc,
+                          int allow_fast_math) {
   blas_log("DoBlasGemm");
   return DoBlasInternal(
       wrap::rocblas_cgemm, stream, true /* = pointer_mode_host */,
@@ -1631,7 +1635,8 @@ bool ROCMBlas::DoBlasGemm(Stream *stream, blas::Transpose transa,
                           const DeviceMemory<std::complex<double>> &a, int lda,
                           const DeviceMemory<std::complex<double>> &b, int ldb,
                           std::complex<double> beta,
-                          DeviceMemory<std::complex<double>> *c, int ldc) {
+                          DeviceMemory<std::complex<double>> *c, int ldc,
+                          int allow_fast_math) {
   blas_log("DoBlasGemm");
   return DoBlasInternal(
       wrap::rocblas_zgemm, stream, true /* = pointer_mode_host */,
@@ -1686,7 +1691,7 @@ bool ROCMBlas::DoBlasGemmWithProfiling(
     Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
     uint64 n, uint64 k, float alpha, const DeviceMemory<Eigen::half> &a,
     int lda, const DeviceMemory<Eigen::half> &b, int ldb, float beta,
-    DeviceMemory<Eigen::half> *c, int ldc,
+    DeviceMemory<Eigen::half> *c, int ldc, int allow_fast_math,
     blas::ProfileResult *output_profile_result) {
   return DoBlasGemmWithProfilingImpl(stream, transa, transb, m, n, k, alpha, a,
                                      lda, b, ldb, beta, c, ldc,
@@ -1697,7 +1702,7 @@ bool ROCMBlas::DoBlasGemmWithProfiling(
     Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
     uint64 n, uint64 k, float alpha, const DeviceMemory<float> &a, int lda,
     const DeviceMemory<float> &b, int ldb, float beta, DeviceMemory<float> *c,
-    int ldc, blas::ProfileResult *output_profile_result) {
+    int ldc, int allow_fast_math, blas::ProfileResult *output_profile_result) {
   return DoBlasGemmWithProfilingImpl(stream, transa, transb, m, n, k, alpha, a,
                                      lda, b, ldb, beta, c, ldc,
                                      output_profile_result);
@@ -1707,7 +1712,7 @@ bool ROCMBlas::DoBlasGemmWithProfiling(
     Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
     uint64 n, uint64 k, double alpha, const DeviceMemory<double> &a, int lda,
     const DeviceMemory<double> &b, int ldb, double beta,
-    DeviceMemory<double> *c, int ldc,
+    DeviceMemory<double> *c, int ldc, int allow_fast_math,
     blas::ProfileResult *output_profile_result) {
   return DoBlasGemmWithProfilingImpl(stream, transa, transb, m, n, k, alpha, a,
                                      lda, b, ldb, beta, c, ldc,
@@ -1720,7 +1725,7 @@ bool ROCMBlas::DoBlasGemmWithProfiling(
     const DeviceMemory<std::complex<float>> &a, int lda,
     const DeviceMemory<std::complex<float>> &b, int ldb,
     std::complex<float> beta, DeviceMemory<std::complex<float>> *c, int ldc,
-    blas::ProfileResult *output_profile_result) {
+    int allow_fast_math, blas::ProfileResult *output_profile_result) {
   return DoBlasGemmWithProfilingImpl(stream, transa, transb, m, n, k, alpha, a,
                                      lda, b, ldb, beta, c, ldc,
                                      output_profile_result);
@@ -1732,7 +1737,7 @@ bool ROCMBlas::DoBlasGemmWithProfiling(
     const DeviceMemory<std::complex<double>> &a, int lda,
     const DeviceMemory<std::complex<double>> &b, int ldb,
     std::complex<double> beta, DeviceMemory<std::complex<double>> *c, int ldc,
-    blas::ProfileResult *output_profile_result) {
+    int allow_fast_math, blas::ProfileResult *output_profile_result) {
   return DoBlasGemmWithProfilingImpl(stream, transa, transb, m, n, k, alpha, a,
                                      lda, b, ldb, beta, c, ldc,
                                      output_profile_result);
@@ -1781,7 +1786,7 @@ bool ROCMBlas::DoBlasGemmWithAlgorithm(
     const DeviceMemory<int8> &a, int lda, const DeviceMemory<int8> &b, int ldb,
     const HostOrDeviceScalar<int> &beta, DeviceMemory<int32> *c, int ldc,
     blas::ComputationType computation_type, blas::AlgorithmType algorithm,
-    blas::ProfileResult *output_profile_result) {
+    int allow_fast_math, blas::ProfileResult *output_profile_result) {
   LOG(ERROR)
       << "rocBLAS does not currently support the GEMMwithAlgorithm operation "
       << "for the \"int8\" datatype";
@@ -1795,7 +1800,8 @@ bool ROCMBlas::DoBlasGemmWithAlgorithm(
     const DeviceMemory<Eigen::half> &b, int ldb,
     const HostOrDeviceScalar<Eigen::half> &beta, DeviceMemory<Eigen::half> *c,
     int ldc, blas::ComputationType computation_type,
-    blas::AlgorithmType algorithm, blas::ProfileResult *output_profile_result) {
+    blas::AlgorithmType algorithm, int allow_fast_math,
+    blas::ProfileResult *output_profile_result) {
   LOG(ERROR)
       << "rocBLAS does not currently support the GEMMwithAlgorithm operation "
       << "for the \"half\" datatype";
@@ -1808,7 +1814,8 @@ bool ROCMBlas::DoBlasGemmWithAlgorithm(
     const DeviceMemory<float> &a, int lda, const DeviceMemory<float> &b,
     int ldb, const HostOrDeviceScalar<float> &beta, DeviceMemory<float> *c,
     int ldc, blas::ComputationType computation_type,
-    blas::AlgorithmType algorithm, blas::ProfileResult *output_profile_result) {
+    blas::AlgorithmType algorithm, int allow_fast_math,
+    blas::ProfileResult *output_profile_result) {
   LOG(ERROR)
       << "rocBLAS does not currently support the GEMMwithAlgorithm operation "
       << "for the \"float\" datatype";
@@ -1821,7 +1828,8 @@ bool ROCMBlas::DoBlasGemmWithAlgorithm(
     const DeviceMemory<double> &a, int lda, const DeviceMemory<double> &b,
     int ldb, const HostOrDeviceScalar<double> &beta, DeviceMemory<double> *c,
     int ldc, blas::ComputationType computation_type,
-    blas::AlgorithmType algorithm, blas::ProfileResult *output_profile_result) {
+    blas::AlgorithmType algorithm, int allow_fast_math,
+    blas::ProfileResult *output_profile_result) {
   LOG(ERROR)
       << "rocBLAS does not currently support the GEMMwithAlgorithm operation "
       << "for the \"double\" datatype";
@@ -1836,7 +1844,7 @@ bool ROCMBlas::DoBlasGemmWithAlgorithm(
     const HostOrDeviceScalar<std::complex<float>> &beta,
     DeviceMemory<std::complex<float>> *c, int ldc,
     blas::ComputationType computation_type, blas::AlgorithmType algorithm,
-    blas::ProfileResult *output_profile_result) {
+    int allow_fast_math, blas::ProfileResult *output_profile_result) {
   LOG(ERROR)
       << "rocBLAS does not currently support the GEMMwithAlgorithm operation "
       << "for the \"complex<float>\" datatype";
@@ -1851,7 +1859,7 @@ bool ROCMBlas::DoBlasGemmWithAlgorithm(
     const HostOrDeviceScalar<std::complex<double>> &beta,
     DeviceMemory<std::complex<double>> *c, int ldc,
     blas::ComputationType computation_type, blas::AlgorithmType algorithm,
-    blas::ProfileResult *output_profile_result) {
+    int allow_fast_math, blas::ProfileResult *output_profile_result) {
   LOG(ERROR)
       << "rocBLAS does not currently support the GEMMwithAlgorithm operation "
       << "for the \"complex<double>\" datatype";
@@ -2065,7 +2073,7 @@ bool ROCMBlas::DoBlasGemmBatched(
     const port::ArraySlice<DeviceMemory<Eigen::half> *> &a, int lda,
     const port::ArraySlice<DeviceMemory<Eigen::half> *> &b, int ldb, float beta,
     const port::ArraySlice<DeviceMemory<Eigen::half> *> &c, int ldc,
-    int batch_count, ScratchAllocator *scratch_allocator) {
+    int batch_count, ScratchAllocator *scratch_allocator, int allow_fast_math) {
   blas_log("DoBlasGemmBatched");
   const Eigen::half alpha_half(alpha);
   const Eigen::half beta_half(beta);
@@ -2087,7 +2095,7 @@ bool ROCMBlas::DoBlasGemmBatched(
     const port::ArraySlice<DeviceMemory<float> *> &a_array, int lda,
     const port::ArraySlice<DeviceMemory<float> *> &b_array, int ldb, float beta,
     const port::ArraySlice<DeviceMemory<float> *> &c_array, int ldc,
-    int batch_count, ScratchAllocator *scratch_allocator) {
+    int batch_count, ScratchAllocator *scratch_allocator, int allow_fast_math) {
   blas_log("DoBlasGemmBatched");
   port::Status status = DoBlasGemmBatchedInternal(
       wrap::rocblas_sgemm_strided_batched, stream, transa, transb, m, n, k,
@@ -2105,7 +2113,8 @@ bool ROCMBlas::DoBlasGemmBatched(
     const port::ArraySlice<DeviceMemory<double> *> &a_array, int lda,
     const port::ArraySlice<DeviceMemory<double> *> &b_array, int ldb,
     double beta, const port::ArraySlice<DeviceMemory<double> *> &c_array,
-    int ldc, int batch_count, ScratchAllocator *scratch_allocator) {
+    int ldc, int batch_count, ScratchAllocator *scratch_allocator,
+    int allow_fast_math) {
   blas_log("DoBlasGemmBatched");
   port::Status status = DoBlasGemmBatchedInternal(
       wrap::rocblas_dgemm_strided_batched, stream, transa, transb, m, n, k,
@@ -2125,7 +2134,8 @@ bool ROCMBlas::DoBlasGemmBatched(
     const port::ArraySlice<DeviceMemory<std::complex<float>> *> &b_array,
     int ldb, std::complex<float> beta,
     const port::ArraySlice<DeviceMemory<std::complex<float>> *> &c_array,
-    int ldc, int batch_count, ScratchAllocator *scratch_allocator) {
+    int ldc, int batch_count, ScratchAllocator *scratch_allocator,
+    int allow_fast_math) {
   blas_log("DoBlasGemmBatched");
   port::Status status = DoBlasGemmBatchedInternal(
       wrap::rocblas_cgemm_strided_batched, stream, transa, transb, m, n, k,
@@ -2145,7 +2155,8 @@ bool ROCMBlas::DoBlasGemmBatched(
     const port::ArraySlice<DeviceMemory<std::complex<double>> *> &b_array,
     int ldb, std::complex<double> beta,
     const port::ArraySlice<DeviceMemory<std::complex<double>> *> &c_array,
-    int ldc, int batch_count, ScratchAllocator *scratch_allocator) {
+    int ldc, int batch_count, ScratchAllocator *scratch_allocator,
+    int allow_fast_math) {
   blas_log("DoBlasGemmBatched");
   port::Status status = DoBlasGemmBatchedInternal(
       wrap::rocblas_zgemm_strided_batched, stream, transa, transb, m, n, k,
@@ -2450,7 +2461,7 @@ bool ROCMBlas::DoBlasGemmStridedBatched(
     uint64 n, uint64 k, float alpha, const DeviceMemory<Eigen::half> &a,
     int lda, int64 stride_a, const DeviceMemory<Eigen::half> &b, int ldb,
     int64 stride_b, float beta, DeviceMemory<Eigen::half> *c, int ldc,
-    int64 stride_c, int batch_count) {
+    int64 stride_c, int batch_count, int allow_fast_math) {
   blas_log("DoBlasGemmStridedBatched");
   const Eigen::half alpha_half(alpha);
   const Eigen::half beta_half(beta);
@@ -2472,7 +2483,7 @@ bool ROCMBlas::DoBlasGemmStridedBatched(
     uint64 n, uint64 k, float alpha, const DeviceMemory<float> &a, int lda,
     int64 stride_a, const DeviceMemory<float> &b, int ldb, int64 stride_b,
     float beta, DeviceMemory<float> *c, int ldc, int64 stride_c,
-    int batch_count) {
+    int batch_count, int allow_fast_math) {
   VLOG(1) << absl::StreamFormat(
       "doing rocBLAS SGEMM Strided Batched<float>: at=%d bt=%d m=%u n=%u "
       "k=%llu alpha=%f a=%p lda=%d b=%p ldb=%d beta=%f "
@@ -2491,7 +2502,7 @@ bool ROCMBlas::DoBlasGemmStridedBatched(
     uint64 n, uint64 k, double alpha, const DeviceMemory<double> &a, int lda,
     int64 stride_a, const DeviceMemory<double> &b, int ldb, int64 stride_b,
     double beta, DeviceMemory<double> *c, int ldc, int64 stride_c,
-    int batch_count) {
+    int batch_count, int allow_fast_math) {
   VLOG(1) << absl::StreamFormat(
       "doing rocBLAS SGEMM Strided Batched<double>: at=%d bt=%d m=%u n=%u "
       "k=%llu alpha=%f a=%p lda=%d b=%p ldb=%d beta=%f "
@@ -2511,7 +2522,7 @@ bool ROCMBlas::DoBlasGemmStridedBatched(
     const DeviceMemory<std::complex<float>> &a, int lda, int64 stride_a,
     const DeviceMemory<std::complex<float>> &b, int ldb, int64 stride_b,
     std::complex<float> beta, DeviceMemory<std::complex<float>> *c, int ldc,
-    int64 stride_c, int batch_count) {
+    int64 stride_c, int batch_count, int allow_fast_math) {
   return DoBlasInternal(wrap::rocblas_cgemm_strided_batched, stream,
                         false, /* pointer_mode_host */
                         ROCMBlasTranspose(transa), ROCMBlasTranspose(transb), m,
@@ -2526,7 +2537,7 @@ bool ROCMBlas::DoBlasGemmStridedBatched(
     const DeviceMemory<std::complex<double>> &a, int lda, int64 stride_a,
     const DeviceMemory<std::complex<double>> &b, int ldb, int64 stride_b,
     std::complex<double> beta, DeviceMemory<std::complex<double>> *c, int ldc,
-    int64 stride_c, int batch_count) {
+    int64 stride_c, int batch_count, int allow_fast_math) {
   return DoBlasInternal(wrap::rocblas_zgemm_strided_batched, stream,
                         false, /* pointer_mode_host */
                         ROCMBlasTranspose(transa), ROCMBlasTranspose(transb), m,

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -3869,7 +3869,8 @@ bool MIOpenSupport::DoMatMul(Stream* stream,
     const int64 k = input_dimensions.NodesAcrossFeatureMaps();
     stream->ThenBlasGemm(blas::Transpose::kNoTranspose,
                          blas::Transpose::kNoTranspose, m, n, k, alpha, weights,
-                         m, input_data, k, beta, output_data, m);
+                         m, input_data, k, beta, output_data, m,
+                         /*allow_fast_math=*/-1);
   } else {
     // This is a slower and more complex path that supports output
     // width() * height() > 1, though it only supports the
@@ -3949,7 +3950,7 @@ bool MIOpenSupport::DoMatMul(Stream* stream,
     stream->ThenBlasGemmBatched(blas::Transpose::kNoTranspose,
                                 blas::Transpose::kNoTranspose, m, n, k, alpha,
                                 toPtrs(a), lda, toPtrs(b), ldb, beta, toPtrs(c),
-                                ldc, batch_count);
+                                ldc, batch_count, /*allow_fast_math=*/-1);
   }
 
   return stream->ok();

--- a/tensorflow/stream_executor/stream.cc
+++ b/tensorflow/stream_executor/stream.cc
@@ -3652,49 +3652,52 @@ Stream &Stream::ThenBlasGemm(blas::Transpose transa, blas::Transpose transb,
                              const DeviceMemory<Eigen::half> &a, int lda,
                              const DeviceMemory<Eigen::half> &b, int ldb,
                              float beta,
-                             DeviceMemory<Eigen::half> *c, int ldc) {
+                             DeviceMemory<Eigen::half> *c, int ldc,
+                             int allow_fast_math) {
   VLOG_CALL(PARAM(transa), PARAM(transb), PARAM(m), PARAM(n), PARAM(k),
             PARAM(alpha), PARAM(a), PARAM(lda), PARAM(b), PARAM(ldb),
-            PARAM(beta), PARAM(c), PARAM(ldc));
+            PARAM(beta), PARAM(c), PARAM(ldc), PARAM(allow_fast_math));
 
   ThenBlasImpl<blas::Transpose, blas::Transpose, uint64, uint64, uint64, float,
                const DeviceMemory<Eigen::half> &, int,
                const DeviceMemory<Eigen::half> &, int,
-               float, DeviceMemory<Eigen::half> *, int> impl;
+               float, DeviceMemory<Eigen::half> *, int, int> impl;
   return impl(this, &blas::BlasSupport::DoBlasGemm, transa, transb, m, n, k,
-              alpha, a, lda, b, ldb, beta, c, ldc);
+              alpha, a, lda, b, ldb, beta, c, ldc, allow_fast_math);
 }
 
 Stream &Stream::ThenBlasGemm(blas::Transpose transa, blas::Transpose transb,
                              uint64 m, uint64 n, uint64 k, float alpha,
                              const DeviceMemory<float> &a, int lda,
                              const DeviceMemory<float> &b, int ldb, float beta,
-                             DeviceMemory<float> *c, int ldc) {
+                             DeviceMemory<float> *c, int ldc,
+                             int allow_fast_math) {
   VLOG_CALL(PARAM(transa), PARAM(transb), PARAM(m), PARAM(n), PARAM(k),
             PARAM(alpha), PARAM(a), PARAM(lda), PARAM(b), PARAM(ldb),
-            PARAM(beta), PARAM(c), PARAM(ldc));
+            PARAM(beta), PARAM(c), PARAM(ldc), PARAM(allow_fast_math));
 
   ThenBlasImpl<blas::Transpose, blas::Transpose, uint64, uint64, uint64, float,
                const DeviceMemory<float> &, int, const DeviceMemory<float> &,
-               int, float, DeviceMemory<float> *, int> impl;
+               int, float, DeviceMemory<float> *, int, int> impl;
   return impl(this, &blas::BlasSupport::DoBlasGemm, transa, transb, m, n, k,
-              alpha, a, lda, b, ldb, beta, c, ldc);
+              alpha, a, lda, b, ldb, beta, c, ldc, allow_fast_math);
 }
 
 Stream &Stream::ThenBlasGemm(blas::Transpose transa, blas::Transpose transb,
                              uint64 m, uint64 n, uint64 k, double alpha,
                              const DeviceMemory<double> &a, int lda,
                              const DeviceMemory<double> &b, int ldb,
-                             double beta, DeviceMemory<double> *c, int ldc) {
+                             double beta, DeviceMemory<double> *c, int ldc,
+                             int allow_fast_math) {
   VLOG_CALL(PARAM(transa), PARAM(transb), PARAM(m), PARAM(n), PARAM(k),
             PARAM(alpha), PARAM(a), PARAM(lda), PARAM(b), PARAM(ldb),
-            PARAM(beta), PARAM(c), PARAM(ldc));
+            PARAM(beta), PARAM(c), PARAM(ldc), PARAM(allow_fast_math));
 
   ThenBlasImpl<blas::Transpose, blas::Transpose, uint64, uint64, uint64, double,
                const DeviceMemory<double> &, int, const DeviceMemory<double> &,
-               int, double, DeviceMemory<double> *, int> impl;
+               int, double, DeviceMemory<double> *, int, int> impl;
   return impl(this, &blas::BlasSupport::DoBlasGemm, transa, transb, m, n, k,
-              alpha, a, lda, b, ldb, beta, c, ldc);
+              alpha, a, lda, b, ldb, beta, c, ldc, allow_fast_math);
 }
 
 Stream &Stream::ThenBlasGemm(blas::Transpose transa, blas::Transpose transb,
@@ -3704,18 +3707,19 @@ Stream &Stream::ThenBlasGemm(blas::Transpose transa, blas::Transpose transb,
                              int lda,
                              const DeviceMemory<std::complex<float>> &b,
                              int ldb, std::complex<float> beta,
-                             DeviceMemory<std::complex<float>> *c, int ldc) {
+                             DeviceMemory<std::complex<float>> *c, int ldc,
+                             int allow_fast_math) {
   VLOG_CALL(PARAM(transa), PARAM(transb), PARAM(m), PARAM(n), PARAM(k),
             PARAM(alpha), PARAM(a), PARAM(lda), PARAM(b), PARAM(ldb),
-            PARAM(beta), PARAM(c), PARAM(ldc));
+            PARAM(beta), PARAM(c), PARAM(ldc), PARAM(allow_fast_math));
 
   ThenBlasImpl<blas::Transpose, blas::Transpose, uint64, uint64, uint64,
                std::complex<float>, const DeviceMemory<std::complex<float>> &,
                int, const DeviceMemory<std::complex<float>> &, int,
                std::complex<float>, DeviceMemory<std::complex<float>> *,
-               int> impl;
+               int, int> impl;
   return impl(this, &blas::BlasSupport::DoBlasGemm, transa, transb, m, n, k,
-              alpha, a, lda, b, ldb, beta, c, ldc);
+              alpha, a, lda, b, ldb, beta, c, ldc, allow_fast_math);
 }
 
 Stream &Stream::ThenBlasGemm(blas::Transpose transa, blas::Transpose transb,
@@ -3725,18 +3729,19 @@ Stream &Stream::ThenBlasGemm(blas::Transpose transa, blas::Transpose transb,
                              int lda,
                              const DeviceMemory<std::complex<double>> &b,
                              int ldb, std::complex<double> beta,
-                             DeviceMemory<std::complex<double>> *c, int ldc) {
+                             DeviceMemory<std::complex<double>> *c, int ldc,
+                             int allow_fast_math) {
   VLOG_CALL(PARAM(transa), PARAM(transb), PARAM(m), PARAM(n), PARAM(k),
             PARAM(alpha), PARAM(a), PARAM(lda), PARAM(b), PARAM(ldb),
-            PARAM(beta), PARAM(c), PARAM(ldc));
+            PARAM(beta), PARAM(c), PARAM(ldc), PARAM(allow_fast_math));
 
   ThenBlasImpl<blas::Transpose, blas::Transpose, uint64, uint64, uint64,
                std::complex<double>, const DeviceMemory<std::complex<double>> &,
                int, const DeviceMemory<std::complex<double>> &, int,
                std::complex<double>, DeviceMemory<std::complex<double>> *,
-               int> impl;
+               int, int> impl;
   return impl(this, &blas::BlasSupport::DoBlasGemm, transa, transb, m, n, k,
-              alpha, a, lda, b, ldb, beta, c, ldc);
+              alpha, a, lda, b, ldb, beta, c, ldc, allow_fast_math);
 }
 
 namespace {
@@ -3836,19 +3841,19 @@ Stream &Stream::ThenBlasGemmWithProfiling(
     blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
     uint64 k, float alpha, const DeviceMemory<Eigen::half> &a, int lda,
     const DeviceMemory<Eigen::half> &b, int ldb, float beta,
-    DeviceMemory<Eigen::half> *c, int ldc,
+    DeviceMemory<Eigen::half> *c, int ldc, int allow_fast_math, 
     blas::ProfileResult *output_profile_result) {
   VLOG_CALL(PARAM(transa), PARAM(transb), PARAM(m), PARAM(n), PARAM(k),
             PARAM(alpha), PARAM(a), PARAM(lda), PARAM(b), PARAM(ldb),
-            PARAM(beta), PARAM(c), PARAM(ldc));
+            PARAM(beta), PARAM(c), PARAM(ldc), PARAM(allow_fast_math));
 
   ThenBlasWithProfileImpl<blas::Transpose, blas::Transpose, uint64, uint64,
                           uint64, float, const DeviceMemory<Eigen::half> &, int,
                           const DeviceMemory<Eigen::half> &, int, float,
-                          DeviceMemory<Eigen::half> *, int>
+                          DeviceMemory<Eigen::half> *, int, int>
       impl;
   return impl(this, &blas::BlasSupport::DoBlasGemmWithProfiling, transa, transb,
-              m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
+              m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, allow_fast_math,
               output_profile_result);
 }
 
@@ -3856,18 +3861,18 @@ Stream &Stream::ThenBlasGemmWithProfiling(
     blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
     uint64 k, float alpha, const DeviceMemory<float> &a, int lda,
     const DeviceMemory<float> &b, int ldb, float beta, DeviceMemory<float> *c,
-    int ldc, blas::ProfileResult *output_profile_result) {
+    int ldc, int allow_fast_math, blas::ProfileResult *output_profile_result) {
   VLOG_CALL(PARAM(transa), PARAM(transb), PARAM(m), PARAM(n), PARAM(k),
             PARAM(alpha), PARAM(a), PARAM(lda), PARAM(b), PARAM(ldb),
-            PARAM(beta), PARAM(c), PARAM(ldc));
+            PARAM(beta), PARAM(c), PARAM(ldc), PARAM(allow_fast_math));
 
   ThenBlasWithProfileImpl<blas::Transpose, blas::Transpose, uint64, uint64,
                           uint64, float, const DeviceMemory<float> &, int,
                           const DeviceMemory<float> &, int, float,
-                          DeviceMemory<float> *, int>
+                          DeviceMemory<float> *, int, int>
       impl;
   return impl(this, &blas::BlasSupport::DoBlasGemmWithProfiling, transa, transb,
-              m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
+              m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, allow_fast_math,
               output_profile_result);
 }
 
@@ -3875,19 +3880,19 @@ Stream &Stream::ThenBlasGemmWithProfiling(
     blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
     uint64 k, double alpha, const DeviceMemory<double> &a, int lda,
     const DeviceMemory<double> &b, int ldb, double beta,
-    DeviceMemory<double> *c, int ldc,
+    DeviceMemory<double> *c, int ldc, int allow_fast_math,
     blas::ProfileResult *output_profile_result) {
   VLOG_CALL(PARAM(transa), PARAM(transb), PARAM(m), PARAM(n), PARAM(k),
             PARAM(alpha), PARAM(a), PARAM(lda), PARAM(b), PARAM(ldb),
-            PARAM(beta), PARAM(c), PARAM(ldc));
+            PARAM(beta), PARAM(c), PARAM(ldc), PARAM(allow_fast_math));
 
   ThenBlasWithProfileImpl<blas::Transpose, blas::Transpose, uint64, uint64,
                           uint64, double, const DeviceMemory<double> &, int,
                           const DeviceMemory<double> &, int, double,
-                          DeviceMemory<double> *, int>
+                          DeviceMemory<double> *, int, int>
       impl;
   return impl(this, &blas::BlasSupport::DoBlasGemmWithProfiling, transa, transb,
-              m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
+              m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, allow_fast_math,
               output_profile_result);
 }
 
@@ -3897,19 +3902,19 @@ Stream &Stream::ThenBlasGemmWithProfiling(
     const DeviceMemory<std::complex<float>> &a, int lda,
     const DeviceMemory<std::complex<float>> &b, int ldb,
     std::complex<float> beta, DeviceMemory<std::complex<float>> *c, int ldc,
-    blas::ProfileResult *output_profile_result) {
+    int allow_fast_math, blas::ProfileResult *output_profile_result) {
   VLOG_CALL(PARAM(transa), PARAM(transb), PARAM(m), PARAM(n), PARAM(k),
             PARAM(alpha), PARAM(a), PARAM(lda), PARAM(b), PARAM(ldb),
-            PARAM(beta), PARAM(c), PARAM(ldc));
+            PARAM(beta), PARAM(c), PARAM(ldc), PARAM(allow_fast_math));
 
   ThenBlasWithProfileImpl<
       blas::Transpose, blas::Transpose, uint64, uint64, uint64,
       std::complex<float>, const DeviceMemory<std::complex<float>> &, int,
       const DeviceMemory<std::complex<float>> &, int, std::complex<float>,
-      DeviceMemory<std::complex<float>> *, int>
+      DeviceMemory<std::complex<float>> *, int, int>
       impl;
   return impl(this, &blas::BlasSupport::DoBlasGemmWithProfiling, transa, transb,
-              m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
+              m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, allow_fast_math,
               output_profile_result);
 }
 
@@ -3919,19 +3924,19 @@ Stream &Stream::ThenBlasGemmWithProfiling(
     const DeviceMemory<std::complex<double>> &a, int lda,
     const DeviceMemory<std::complex<double>> &b, int ldb,
     std::complex<double> beta, DeviceMemory<std::complex<double>> *c, int ldc,
-    blas::ProfileResult *output_profile_result) {
+    int allow_fast_math, blas::ProfileResult *output_profile_result) {
   VLOG_CALL(PARAM(transa), PARAM(transb), PARAM(m), PARAM(n), PARAM(k),
             PARAM(alpha), PARAM(a), PARAM(lda), PARAM(b), PARAM(ldb),
-            PARAM(beta), PARAM(c), PARAM(ldc));
+            PARAM(beta), PARAM(c), PARAM(ldc), PARAM(allow_fast_math));
 
   ThenBlasWithProfileImpl<
       blas::Transpose, blas::Transpose, uint64, uint64, uint64,
       std::complex<double>, const DeviceMemory<std::complex<double>> &, int,
       const DeviceMemory<std::complex<double>> &, int, std::complex<double>,
-      DeviceMemory<std::complex<double>> *, int>
+      DeviceMemory<std::complex<double>> *, int, int>
       impl;
   return impl(this, &blas::BlasSupport::DoBlasGemmWithProfiling, transa, transb,
-              m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
+              m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, allow_fast_math,
               output_profile_result);
 }
 
@@ -3942,22 +3947,23 @@ Stream &Stream::ThenBlasGemmWithAlgorithm(
     const DeviceMemory<Eigen::half> &b, int ldb,
     const HostOrDeviceScalar<Eigen::half> &beta, DeviceMemory<Eigen::half> *c,
     int ldc, blas::ComputationType computation_type,
-    blas::AlgorithmType algorithm, blas::ProfileResult *output_profile_result) {
+    blas::AlgorithmType algorithm, int allow_fast_math,
+    blas::ProfileResult *output_profile_result) {
   VLOG_CALL(PARAM(transa), PARAM(transb), PARAM(m), PARAM(n), PARAM(k),
             PARAM(alpha), PARAM(a), PARAM(lda), PARAM(b), PARAM(ldb),
             PARAM(beta), PARAM(c), PARAM(ldc), PARAM(computation_type),
-            PARAM(algorithm));
+            PARAM(algorithm), PARAM(allow_fast_math));
 
   ThenBlasWithProfileImpl<
       blas::Transpose, blas::Transpose, uint64, uint64, uint64,
       const HostOrDeviceScalar<Eigen::half> &,
       const DeviceMemory<Eigen::half> &, int, const DeviceMemory<Eigen::half> &,
       int, const HostOrDeviceScalar<Eigen::half> &, DeviceMemory<Eigen::half> *,
-      int, blas::ComputationType, blas::AlgorithmType>
+      int, blas::ComputationType, blas::AlgorithmType, int>
       impl;
   return impl(this, &blas::BlasSupport::DoBlasGemmWithAlgorithm, transa, transb,
               m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, computation_type,
-              algorithm, output_profile_result);
+              algorithm, allow_fast_math, output_profile_result);
 }
 
 Stream &Stream::ThenBlasGemmWithAlgorithm(
@@ -3966,21 +3972,21 @@ Stream &Stream::ThenBlasGemmWithAlgorithm(
     int lda, const DeviceMemory<int8> &b, int ldb,
     const HostOrDeviceScalar<int> &beta, DeviceMemory<int> *c, int ldc,
     blas::ComputationType computation_type, blas::AlgorithmType algorithm,
-    blas::ProfileResult *output_profile_result) {
+    int allow_fast_math, blas::ProfileResult *output_profile_result) {
   VLOG_CALL(PARAM(transa), PARAM(transb), PARAM(m), PARAM(n), PARAM(k),
             PARAM(alpha), PARAM(a), PARAM(lda), PARAM(b), PARAM(ldb),
             PARAM(beta), PARAM(c), PARAM(ldc), PARAM(computation_type),
-            PARAM(algorithm));
+            PARAM(algorithm), PARAM(allow_fast_math));
 
   ThenBlasWithProfileImpl<
       blas::Transpose, blas::Transpose, uint64, uint64, uint64,
       const HostOrDeviceScalar<int> &, const DeviceMemory<int8> &, int,
       const DeviceMemory<int8> &, int, const HostOrDeviceScalar<int> &,
-      DeviceMemory<int> *, int, blas::ComputationType, blas::AlgorithmType>
+      DeviceMemory<int> *, int, blas::ComputationType, blas::AlgorithmType, int>
       impl;
   return impl(this, &blas::BlasSupport::DoBlasGemmWithAlgorithm, transa, transb,
               m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, computation_type,
-              algorithm, output_profile_result);
+              algorithm, allow_fast_math, output_profile_result);
 }
 
 Stream &Stream::ThenBlasGemmWithAlgorithm(
@@ -3989,21 +3995,23 @@ Stream &Stream::ThenBlasGemmWithAlgorithm(
     const DeviceMemory<float> &a, int lda, const DeviceMemory<float> &b,
     int ldb, const HostOrDeviceScalar<float> &beta, DeviceMemory<float> *c,
     int ldc, blas::ComputationType computation_type,
-    blas::AlgorithmType algorithm, blas::ProfileResult *output_profile_result) {
+    blas::AlgorithmType algorithm, int allow_fast_math,
+    blas::ProfileResult *output_profile_result) {
   VLOG_CALL(PARAM(transa), PARAM(transb), PARAM(m), PARAM(n), PARAM(k),
             PARAM(alpha), PARAM(a), PARAM(lda), PARAM(b), PARAM(ldb),
             PARAM(beta), PARAM(c), PARAM(ldc), PARAM(computation_type),
-            PARAM(algorithm));
+            PARAM(algorithm), PARAM(allow_fast_math));
 
   ThenBlasWithProfileImpl<
       blas::Transpose, blas::Transpose, uint64, uint64, uint64,
       const HostOrDeviceScalar<float> &, const DeviceMemory<float> &, int,
       const DeviceMemory<float> &, int, const HostOrDeviceScalar<float> &,
-      DeviceMemory<float> *, int, blas::ComputationType, blas::AlgorithmType>
+      DeviceMemory<float> *, int, blas::ComputationType, blas::AlgorithmType,
+      int>
       impl;
   return impl(this, &blas::BlasSupport::DoBlasGemmWithAlgorithm, transa, transb,
               m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, computation_type,
-              algorithm, output_profile_result);
+              algorithm, allow_fast_math, output_profile_result);
 }
 
 Stream &Stream::ThenBlasGemmWithAlgorithm(
@@ -4012,22 +4020,24 @@ Stream &Stream::ThenBlasGemmWithAlgorithm(
     const DeviceMemory<double> &a, int lda, const DeviceMemory<double> &b,
     int ldb, const HostOrDeviceScalar<double> &beta, DeviceMemory<double> *c,
     int ldc, blas::ComputationType computation_type,
-    blas::AlgorithmType algorithm, blas::ProfileResult *output_profile_result) {
+    blas::AlgorithmType algorithm, int allow_fast_math,
+    blas::ProfileResult *output_profile_result) {
   VLOG_CALL(PARAM(transa), PARAM(transb), PARAM(m), PARAM(n), PARAM(k),
             PARAM(alpha), PARAM(a), PARAM(lda), PARAM(b), PARAM(ldb),
             PARAM(beta), PARAM(c), PARAM(ldc), PARAM(computation_type),
-            PARAM(algorithm));
+            PARAM(algorithm), PARAM(allow_fast_math));
 
   ThenBlasWithProfileImpl<
       blas::Transpose, blas::Transpose, uint64, uint64, uint64,
       const HostOrDeviceScalar<double> &, const DeviceMemory<double> &, int,
       const DeviceMemory<double> &, int, const HostOrDeviceScalar<double> &,
-      DeviceMemory<double> *, int, blas::ComputationType, blas::AlgorithmType>
+      DeviceMemory<double> *, int, blas::ComputationType, blas::AlgorithmType,
+      int>
       impl;
   return impl(this, &blas::BlasSupport::DoBlasGemmWithAlgorithm, transa, transb,
               m, n, k, HostOrDeviceScalar<double>(alpha), a, lda, b, ldb,
               HostOrDeviceScalar<double>(beta), c, ldc, computation_type,
-              algorithm, output_profile_result);
+              algorithm, allow_fast_math, output_profile_result);
 }
 
 Stream &Stream::ThenBlasGemmWithAlgorithm(
@@ -4038,11 +4048,11 @@ Stream &Stream::ThenBlasGemmWithAlgorithm(
     const HostOrDeviceScalar<std::complex<float>> &beta,
     DeviceMemory<std::complex<float>> *c, int ldc,
     blas::ComputationType computation_type, blas::AlgorithmType algorithm,
-    blas::ProfileResult *output_profile_result) {
+    int allow_fast_math, blas::ProfileResult *output_profile_result) {
   VLOG_CALL(PARAM(transa), PARAM(transb), PARAM(m), PARAM(n), PARAM(k),
             PARAM(alpha), PARAM(a), PARAM(lda), PARAM(b), PARAM(ldb),
             PARAM(beta), PARAM(c), PARAM(ldc), PARAM(computation_type),
-            PARAM(algorithm));
+            PARAM(algorithm), PARAM(allow_fast_math));
 
   ThenBlasWithProfileImpl<blas::Transpose, blas::Transpose, uint64, uint64,
                           uint64,
@@ -4051,11 +4061,11 @@ Stream &Stream::ThenBlasGemmWithAlgorithm(
                           const DeviceMemory<std::complex<float>> &, int,
                           const HostOrDeviceScalar<std::complex<float>> &,
                           DeviceMemory<std::complex<float>> *, int,
-                          blas::ComputationType, blas::AlgorithmType>
+                          blas::ComputationType, blas::AlgorithmType, int>
       impl;
   return impl(this, &blas::BlasSupport::DoBlasGemmWithAlgorithm, transa, transb,
               m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, computation_type,
-              algorithm, output_profile_result);
+              algorithm, allow_fast_math, output_profile_result);
 }
 
 Stream &Stream::ThenBlasGemmWithAlgorithm(
@@ -4066,11 +4076,11 @@ Stream &Stream::ThenBlasGemmWithAlgorithm(
     const HostOrDeviceScalar<std::complex<double>> &beta,
     DeviceMemory<std::complex<double>> *c, int ldc,
     blas::ComputationType computation_type, blas::AlgorithmType algorithm,
-    blas::ProfileResult *output_profile_result) {
+    int allow_fast_math, blas::ProfileResult *output_profile_result) {
   VLOG_CALL(PARAM(transa), PARAM(transb), PARAM(m), PARAM(n), PARAM(k),
             PARAM(alpha), PARAM(a), PARAM(lda), PARAM(b), PARAM(ldb),
             PARAM(beta), PARAM(c), PARAM(ldc), PARAM(computation_type),
-            PARAM(algorithm));
+            PARAM(algorithm), PARAM(allow_fast_math));
 
   ThenBlasWithProfileImpl<blas::Transpose, blas::Transpose, uint64, uint64,
                           uint64,
@@ -4079,11 +4089,11 @@ Stream &Stream::ThenBlasGemmWithAlgorithm(
                           const DeviceMemory<std::complex<double>> &, int,
                           const HostOrDeviceScalar<std::complex<double>> &,
                           DeviceMemory<std::complex<double>> *, int,
-                          blas::ComputationType, blas::AlgorithmType>
+                          blas::ComputationType, blas::AlgorithmType, int>
       impl;
   return impl(this, &blas::BlasSupport::DoBlasGemmWithAlgorithm, transa, transb,
               m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, computation_type,
-              algorithm, output_profile_result);
+              algorithm, allow_fast_math, output_profile_result);
 }
 
 Stream &Stream::ThenBlasHemm(blas::Side side, blas::UpperLower uplo, uint64 m,
@@ -4532,10 +4542,11 @@ Stream &Stream::ThenBlasGemmBatched(
     const port::ArraySlice<DeviceMemory<Eigen::half> *> &a, int lda,
     const port::ArraySlice<DeviceMemory<Eigen::half> *> &b, int ldb, float beta,
     const port::ArraySlice<DeviceMemory<Eigen::half> *> &c, int ldc,
-    int batch_count) {
+    int batch_count, int allow_fast_math) {
   return ThenBlasGemmBatchedWithScratch(transa, transb, m, n, k, alpha, a, lda,
                                         b, ldb, beta, c, ldc, batch_count,
-                                        /*scratch_allocator=*/nullptr);
+                                        /*scratch_allocator=*/nullptr,
+                                        allow_fast_math);
 }
 
 Stream &Stream::ThenBlasGemmBatchedWithScratch(
@@ -4544,20 +4555,21 @@ Stream &Stream::ThenBlasGemmBatchedWithScratch(
     const port::ArraySlice<DeviceMemory<Eigen::half> *> &a, int lda,
     const port::ArraySlice<DeviceMemory<Eigen::half> *> &b, int ldb, float beta,
     const port::ArraySlice<DeviceMemory<Eigen::half> *> &c, int ldc,
-    int batch_count, ScratchAllocator *scratch_allocator) {
+    int batch_count, ScratchAllocator *scratch_allocator, int allow_fast_math) {
   VLOG_CALL(PARAM(transa), PARAM(transb), PARAM(m), PARAM(n), PARAM(k),
             PARAM(alpha), PARAM(a), PARAM(lda), PARAM(b), PARAM(ldb),
-            PARAM(beta), PARAM(c), PARAM(ldc), PARAM(batch_count));
+            PARAM(beta), PARAM(c), PARAM(ldc), PARAM(batch_count),
+            PARAM(allow_fast_math));
 
   ThenBlasImpl<blas::Transpose, blas::Transpose, uint64, uint64, uint64, float,
                const port::ArraySlice<DeviceMemory<Eigen::half> *> &, int,
                const port::ArraySlice<DeviceMemory<Eigen::half> *> &, int,
                float, const port::ArraySlice<DeviceMemory<Eigen::half> *> &,
-               int, int, ScratchAllocator *>
+               int, int, ScratchAllocator *, int>
       impl;
   return impl(this, &blas::BlasSupport::DoBlasGemmBatched, transa, transb, m, n,
               k, alpha, a, lda, b, ldb, beta, c, ldc, batch_count,
-              scratch_allocator);
+              scratch_allocator, allow_fast_math);
 }
 
 Stream &Stream::ThenBlasGemmBatched(
@@ -4565,10 +4577,11 @@ Stream &Stream::ThenBlasGemmBatched(
     uint64 k, float alpha, const port::ArraySlice<DeviceMemory<float> *> &a,
     int lda, const port::ArraySlice<DeviceMemory<float> *> &b, int ldb,
     float beta, const port::ArraySlice<DeviceMemory<float> *> &c, int ldc,
-    int batch_count) {
+    int batch_count, int allow_fast_math) {
   return ThenBlasGemmBatchedWithScratch(transa, transb, m, n, k, alpha, a, lda,
                                         b, ldb, beta, c, ldc, batch_count,
-                                        /*scratch_allocator=*/nullptr);
+                                        /*scratch_allocator=*/nullptr,
+                                        allow_fast_math);
 }
 
 Stream &Stream::ThenBlasGemmBatchedWithScratch(
@@ -4576,20 +4589,21 @@ Stream &Stream::ThenBlasGemmBatchedWithScratch(
     uint64 k, float alpha, const port::ArraySlice<DeviceMemory<float> *> &a,
     int lda, const port::ArraySlice<DeviceMemory<float> *> &b, int ldb,
     float beta, const port::ArraySlice<DeviceMemory<float> *> &c, int ldc,
-    int batch_count, ScratchAllocator *scratch_allocator) {
+    int batch_count, ScratchAllocator *scratch_allocator, int allow_fast_math) {
   VLOG_CALL(PARAM(transa), PARAM(transb), PARAM(m), PARAM(n), PARAM(k),
             PARAM(alpha), PARAM(a), PARAM(lda), PARAM(b), PARAM(ldb),
-            PARAM(beta), PARAM(c), PARAM(ldc), PARAM(batch_count));
+            PARAM(beta), PARAM(c), PARAM(ldc), PARAM(batch_count),
+            PARAM(allow_fast_math));
 
   ThenBlasImpl<blas::Transpose, blas::Transpose, uint64, uint64, uint64, float,
                const port::ArraySlice<DeviceMemory<float> *> &, int,
                const port::ArraySlice<DeviceMemory<float> *> &, int, float,
                const port::ArraySlice<DeviceMemory<float> *> &, int, int,
-               ScratchAllocator *>
+               ScratchAllocator *, int>
       impl;
   return impl(this, &blas::BlasSupport::DoBlasGemmBatched, transa, transb, m, n,
               k, alpha, a, lda, b, ldb, beta, c, ldc, batch_count,
-              scratch_allocator);
+              scratch_allocator, allow_fast_math);
 }
 
 Stream &Stream::ThenBlasGemmBatched(
@@ -4597,10 +4611,11 @@ Stream &Stream::ThenBlasGemmBatched(
     uint64 k, double alpha, const port::ArraySlice<DeviceMemory<double> *> &a,
     int lda, const port::ArraySlice<DeviceMemory<double> *> &b, int ldb,
     double beta, const port::ArraySlice<DeviceMemory<double> *> &c, int ldc,
-    int batch_count) {
+    int batch_count, int allow_fast_math) {
   return ThenBlasGemmBatchedWithScratch(transa, transb, m, n, k, alpha, a, lda,
                                         b, ldb, beta, c, ldc, batch_count,
-                                        /*scratch_allocator=*/nullptr);
+                                        /*scratch_allocator=*/nullptr,
+                                        allow_fast_math);
 }
 
 Stream &Stream::ThenBlasGemmBatchedWithScratch(
@@ -4608,20 +4623,21 @@ Stream &Stream::ThenBlasGemmBatchedWithScratch(
     uint64 k, double alpha, const port::ArraySlice<DeviceMemory<double> *> &a,
     int lda, const port::ArraySlice<DeviceMemory<double> *> &b, int ldb,
     double beta, const port::ArraySlice<DeviceMemory<double> *> &c, int ldc,
-    int batch_count, ScratchAllocator *scratch_allocator) {
+    int batch_count, ScratchAllocator *scratch_allocator, int allow_fast_math) {
   VLOG_CALL(PARAM(transa), PARAM(transb), PARAM(m), PARAM(n), PARAM(k),
             PARAM(alpha), PARAM(a), PARAM(lda), PARAM(b), PARAM(ldb),
-            PARAM(beta), PARAM(c), PARAM(ldc), PARAM(batch_count));
+            PARAM(beta), PARAM(c), PARAM(ldc), PARAM(batch_count),
+            PARAM(allow_fast_math));
 
   ThenBlasImpl<blas::Transpose, blas::Transpose, uint64, uint64, uint64, double,
                const port::ArraySlice<DeviceMemory<double> *> &, int,
                const port::ArraySlice<DeviceMemory<double> *> &, int, double,
                const port::ArraySlice<DeviceMemory<double> *> &, int, int,
-               ScratchAllocator *>
+               ScratchAllocator *, int>
       impl;
   return impl(this, &blas::BlasSupport::DoBlasGemmBatched, transa, transb, m, n,
               k, alpha, a, lda, b, ldb, beta, c, ldc, batch_count,
-              scratch_allocator);
+              scratch_allocator, allow_fast_math);
 }
 
 Stream &Stream::ThenBlasGemmBatched(
@@ -4631,10 +4647,11 @@ Stream &Stream::ThenBlasGemmBatched(
     const port::ArraySlice<DeviceMemory<std::complex<float>> *> &b, int ldb,
     std::complex<float> beta,
     const port::ArraySlice<DeviceMemory<std::complex<float>> *> &c, int ldc,
-    int batch_count) {
+    int batch_count, int allow_fast_math) {
   return ThenBlasGemmBatchedWithScratch(transa, transb, m, n, k, alpha, a, lda,
                                         b, ldb, beta, c, ldc, batch_count,
-                                        /*scratch_allocator=*/nullptr);
+                                        /*scratch_allocator=*/nullptr,
+                                        allow_fast_math);
 }
 
 Stream &Stream::ThenBlasGemmBatchedWithScratch(
@@ -4644,10 +4661,11 @@ Stream &Stream::ThenBlasGemmBatchedWithScratch(
     const port::ArraySlice<DeviceMemory<std::complex<float>> *> &b, int ldb,
     std::complex<float> beta,
     const port::ArraySlice<DeviceMemory<std::complex<float>> *> &c, int ldc,
-    int batch_count, ScratchAllocator *scratch_allocator) {
+    int batch_count, ScratchAllocator *scratch_allocator, int allow_fast_math) {
   VLOG_CALL(PARAM(transa), PARAM(transb), PARAM(m), PARAM(n), PARAM(k),
             PARAM(alpha), PARAM(a), PARAM(lda), PARAM(b), PARAM(ldb),
-            PARAM(beta), PARAM(c), PARAM(ldc), PARAM(batch_count));
+            PARAM(beta), PARAM(c), PARAM(ldc), PARAM(batch_count),
+            PARAM(allow_fast_math));
 
   ThenBlasImpl<blas::Transpose, blas::Transpose, uint64, uint64, uint64,
                std::complex<float>,
@@ -4656,11 +4674,11 @@ Stream &Stream::ThenBlasGemmBatchedWithScratch(
                const port::ArraySlice<DeviceMemory<std::complex<float>> *> &,
                int, std::complex<float>,
                const port::ArraySlice<DeviceMemory<std::complex<float>> *> &,
-               int, int, ScratchAllocator *>
+               int, int, ScratchAllocator *, int>
       impl;
   return impl(this, &blas::BlasSupport::DoBlasGemmBatched, transa, transb, m, n,
               k, alpha, a, lda, b, ldb, beta, c, ldc, batch_count,
-              scratch_allocator);
+              scratch_allocator, allow_fast_math);
 }
 
 Stream &Stream::ThenBlasGemmBatched(
@@ -4670,10 +4688,11 @@ Stream &Stream::ThenBlasGemmBatched(
     const port::ArraySlice<DeviceMemory<std::complex<double>> *> &b, int ldb,
     std::complex<double> beta,
     const port::ArraySlice<DeviceMemory<std::complex<double>> *> &c, int ldc,
-    int batch_count) {
+    int batch_count, int allow_fast_math) {
   return ThenBlasGemmBatchedWithScratch(transa, transb, m, n, k, alpha, a, lda,
                                         b, ldb, beta, c, ldc, batch_count,
-                                        /*scratch_allocator=*/nullptr);
+                                        /*scratch_allocator=*/nullptr,
+                                        allow_fast_math);
 }
 
 Stream &Stream::ThenBlasGemmBatchedWithScratch(
@@ -4683,10 +4702,11 @@ Stream &Stream::ThenBlasGemmBatchedWithScratch(
     const port::ArraySlice<DeviceMemory<std::complex<double>> *> &b, int ldb,
     std::complex<double> beta,
     const port::ArraySlice<DeviceMemory<std::complex<double>> *> &c, int ldc,
-    int batch_count, ScratchAllocator *scratch_allocator) {
+    int batch_count, ScratchAllocator *scratch_allocator, int allow_fast_math) {
   VLOG_CALL(PARAM(transa), PARAM(transb), PARAM(m), PARAM(n), PARAM(k),
             PARAM(alpha), PARAM(a), PARAM(lda), PARAM(b), PARAM(ldb),
-            PARAM(beta), PARAM(c), PARAM(ldc), PARAM(batch_count));
+            PARAM(beta), PARAM(c), PARAM(ldc), PARAM(batch_count),
+            PARAM(allow_fast_math));
 
   ThenBlasImpl<blas::Transpose, blas::Transpose, uint64, uint64, uint64,
                std::complex<double>,
@@ -4695,11 +4715,11 @@ Stream &Stream::ThenBlasGemmBatchedWithScratch(
                const port::ArraySlice<DeviceMemory<std::complex<double>> *> &,
                int, std::complex<double>,
                const port::ArraySlice<DeviceMemory<std::complex<double>> *> &,
-               int, int, ScratchAllocator *>
+               int, int, ScratchAllocator *, int>
       impl;
   return impl(this, &blas::BlasSupport::DoBlasGemmBatched, transa, transb, m, n,
               k, alpha, a, lda, b, ldb, beta, c, ldc, batch_count,
-              scratch_allocator);
+              scratch_allocator, allow_fast_math);
 }
 
 Stream &Stream::ThenBlasGemmStridedBatched(
@@ -4707,20 +4727,20 @@ Stream &Stream::ThenBlasGemmStridedBatched(
     uint64 k, float alpha, const DeviceMemory<Eigen::half> &a, int lda,
     int64 stride_a, const DeviceMemory<Eigen::half> &b, int ldb, int64 stride_b,
     float beta, DeviceMemory<Eigen::half> *c, int ldc, int64 stride_c,
-    int batch_count) {
+    int batch_count, int allow_fast_math) {
   VLOG_CALL(PARAM(transa), PARAM(transb), PARAM(m), PARAM(n), PARAM(k),
             PARAM(alpha), PARAM(a), PARAM(lda), PARAM(stride_a), PARAM(b),
             PARAM(ldb), PARAM(stride_b), PARAM(beta), PARAM(c), PARAM(ldc),
-            PARAM(stride_c), PARAM(batch_count));
+            PARAM(stride_c), PARAM(batch_count), PARAM(allow_fast_math));
 
   ThenBlasImpl<blas::Transpose, blas::Transpose, uint64, uint64, uint64, float,
                const DeviceMemory<Eigen::half> &, int, int64,
                const DeviceMemory<Eigen::half> &, int, int64, float,
-               DeviceMemory<Eigen::half> *, int, int64, int>
+               DeviceMemory<Eigen::half> *, int, int64, int, int>
       impl;
   return impl(this, &blas::BlasSupport::DoBlasGemmStridedBatched, transa,
               transb, m, n, k, alpha, a, lda, stride_a, b, ldb, stride_b, beta,
-              c, ldc, stride_c, batch_count);
+              c, ldc, stride_c, batch_count, allow_fast_math);
 }
 
 Stream &Stream::ThenBlasGemmStridedBatched(
@@ -4728,20 +4748,20 @@ Stream &Stream::ThenBlasGemmStridedBatched(
     uint64 k, float alpha, const DeviceMemory<float> &a, int lda,
     int64 stride_a, const DeviceMemory<float> &b, int ldb, int64 stride_b,
     float beta, DeviceMemory<float> *c, int ldc, int64 stride_c,
-    int batch_count) {
+    int batch_count, int allow_fast_math) {
   VLOG_CALL(PARAM(transa), PARAM(transb), PARAM(m), PARAM(n), PARAM(k),
             PARAM(alpha), PARAM(a), PARAM(lda), PARAM(stride_a), PARAM(b),
             PARAM(ldb), PARAM(stride_b), PARAM(beta), PARAM(c), PARAM(ldc),
-            PARAM(stride_c), PARAM(batch_count));
+            PARAM(stride_c), PARAM(batch_count), PARAM(allow_fast_math));
 
   ThenBlasImpl<blas::Transpose, blas::Transpose, uint64, uint64, uint64, float,
                const DeviceMemory<float> &, int, int64,
                const DeviceMemory<float> &, int, int64, float,
-               DeviceMemory<float> *, int, int64, int>
+               DeviceMemory<float> *, int, int64, int, int>
       impl;
   return impl(this, &blas::BlasSupport::DoBlasGemmStridedBatched, transa,
               transb, m, n, k, alpha, a, lda, stride_a, b, ldb, stride_b, beta,
-              c, ldc, stride_c, batch_count);
+              c, ldc, stride_c, batch_count, allow_fast_math);
 }
 
 Stream &Stream::ThenBlasGemmStridedBatched(
@@ -4749,20 +4769,20 @@ Stream &Stream::ThenBlasGemmStridedBatched(
     uint64 k, double alpha, const DeviceMemory<double> &a, int lda,
     int64 stride_a, const DeviceMemory<double> &b, int ldb, int64 stride_b,
     double beta, DeviceMemory<double> *c, int ldc, int64 stride_c,
-    int batch_count) {
+    int batch_count, int allow_fast_math) {
   VLOG_CALL(PARAM(transa), PARAM(transb), PARAM(m), PARAM(n), PARAM(k),
             PARAM(alpha), PARAM(a), PARAM(lda), PARAM(stride_a), PARAM(b),
             PARAM(ldb), PARAM(stride_b), PARAM(beta), PARAM(c), PARAM(ldc),
-            PARAM(stride_c), PARAM(batch_count));
+            PARAM(stride_c), PARAM(batch_count), PARAM(allow_fast_math));
 
   ThenBlasImpl<blas::Transpose, blas::Transpose, uint64, uint64, uint64, double,
                const DeviceMemory<double> &, int, int64,
                const DeviceMemory<double> &, int, int64, double,
-               DeviceMemory<double> *, int, int64, int>
+               DeviceMemory<double> *, int, int64, int, int>
       impl;
   return impl(this, &blas::BlasSupport::DoBlasGemmStridedBatched, transa,
               transb, m, n, k, alpha, a, lda, stride_a, b, ldb, stride_b, beta,
-              c, ldc, stride_c, batch_count);
+              c, ldc, stride_c, batch_count, allow_fast_math);
 }
 
 Stream &Stream::ThenBlasGemmStridedBatched(
@@ -4771,21 +4791,21 @@ Stream &Stream::ThenBlasGemmStridedBatched(
     const DeviceMemory<std::complex<float>> &a, int lda, int64 stride_a,
     const DeviceMemory<std::complex<float>> &b, int ldb, int64 stride_b,
     std::complex<float> beta, DeviceMemory<std::complex<float>> *c, int ldc,
-    int64 stride_c, int batch_count) {
+    int64 stride_c, int batch_count, int allow_fast_math) {
   VLOG_CALL(PARAM(transa), PARAM(transb), PARAM(m), PARAM(n), PARAM(k),
             PARAM(alpha), PARAM(a), PARAM(lda), PARAM(stride_a), PARAM(b),
             PARAM(ldb), PARAM(stride_b), PARAM(beta), PARAM(c), PARAM(ldc),
-            PARAM(stride_c), PARAM(batch_count));
+            PARAM(stride_c), PARAM(batch_count), PARAM(allow_fast_math));
 
   ThenBlasImpl<blas::Transpose, blas::Transpose, uint64, uint64, uint64,
                std::complex<float>, const DeviceMemory<std::complex<float>> &,
                int, int64, const DeviceMemory<std::complex<float>> &, int,
                int64, std::complex<float>, DeviceMemory<std::complex<float>> *,
-               int, int64, int>
+               int, int64, int, int>
       impl;
   return impl(this, &blas::BlasSupport::DoBlasGemmStridedBatched, transa,
               transb, m, n, k, alpha, a, lda, stride_a, b, ldb, stride_b, beta,
-              c, ldc, stride_c, batch_count);
+              c, ldc, stride_c, batch_count, allow_fast_math);
 }
 
 Stream &Stream::ThenBlasGemmStridedBatched(
@@ -4794,21 +4814,21 @@ Stream &Stream::ThenBlasGemmStridedBatched(
     const DeviceMemory<std::complex<double>> &a, int lda, int64 stride_a,
     const DeviceMemory<std::complex<double>> &b, int ldb, int64 stride_b,
     std::complex<double> beta, DeviceMemory<std::complex<double>> *c, int ldc,
-    int64 stride_c, int batch_count) {
+    int64 stride_c, int batch_count, int allow_fast_math) {
   VLOG_CALL(PARAM(transa), PARAM(transb), PARAM(m), PARAM(n), PARAM(k),
             PARAM(alpha), PARAM(a), PARAM(lda), PARAM(stride_a), PARAM(b),
             PARAM(ldb), PARAM(stride_b), PARAM(beta), PARAM(c), PARAM(ldc),
-            PARAM(stride_c), PARAM(batch_count));
+            PARAM(stride_c), PARAM(batch_count), PARAM(allow_fast_math));
 
   ThenBlasImpl<blas::Transpose, blas::Transpose, uint64, uint64, uint64,
                std::complex<double>, const DeviceMemory<std::complex<double>> &,
                int, int64, const DeviceMemory<std::complex<double>> &, int,
                int64, std::complex<double>,
-               DeviceMemory<std::complex<double>> *, int, int64, int>
+               DeviceMemory<std::complex<double>> *, int, int64, int, int>
       impl;
   return impl(this, &blas::BlasSupport::DoBlasGemmStridedBatched, transa,
               transb, m, n, k, alpha, a, lda, stride_a, b, ldb, stride_b, beta,
-              c, ldc, stride_c, batch_count);
+              c, ldc, stride_c, batch_count, allow_fast_math);
 }
 
 Stream &Stream::ThenSetRngSeed(const uint8 *seed, uint64 seed_bytes) {

--- a/tensorflow/stream_executor/stream.h
+++ b/tensorflow/stream_executor/stream.h
@@ -1295,17 +1295,19 @@ class Stream {
                                  const DeviceMemory<Eigen::half> &a, int lda,
                                  const DeviceMemory<Eigen::half> &b, int ldb,
                                  float beta, DeviceMemory<Eigen::half> *c,
-                                 int ldc);
+                                 int ldc, int allow_fast_math);
   TF_EXPORT Stream &ThenBlasGemm(blas::Transpose transa, blas::Transpose transb,
                                  uint64 m, uint64 n, uint64 k, float alpha,
                                  const DeviceMemory<float> &a, int lda,
                                  const DeviceMemory<float> &b, int ldb,
-                                 float beta, DeviceMemory<float> *c, int ldc);
+                                 float beta, DeviceMemory<float> *c, int ldc,
+                                 int allow_fast_math);
   TF_EXPORT Stream &ThenBlasGemm(blas::Transpose transa, blas::Transpose transb,
                                  uint64 m, uint64 n, uint64 k, double alpha,
                                  const DeviceMemory<double> &a, int lda,
                                  const DeviceMemory<double> &b, int ldb,
-                                 double beta, DeviceMemory<double> *c, int ldc);
+                                 double beta, DeviceMemory<double> *c, int ldc,
+                                 int allow_fast_math);
   TF_EXPORT Stream &ThenBlasGemm(blas::Transpose transa, blas::Transpose transb,
                                  uint64 m, uint64 n, uint64 k,
                                  std::complex<float> alpha,
@@ -1313,7 +1315,8 @@ class Stream {
                                  int lda,
                                  const DeviceMemory<std::complex<float>> &b,
                                  int ldb, std::complex<float> beta,
-                                 DeviceMemory<std::complex<float>> *c, int ldc);
+                                 DeviceMemory<std::complex<float>> *c, int ldc,
+                                 int allow_fast_math);
   TF_EXPORT Stream &ThenBlasGemm(blas::Transpose transa, blas::Transpose transb,
                                  uint64 m, uint64 n, uint64 k,
                                  std::complex<double> alpha,
@@ -1322,7 +1325,7 @@ class Stream {
                                  const DeviceMemory<std::complex<double>> &b,
                                  int ldb, std::complex<double> beta,
                                  DeviceMemory<std::complex<double>> *c,
-                                 int ldc);
+                                 int ldc, int allow_fast_math);
 
   Stream &ThenBlasGemmWithProfiling(blas::Transpose transa,
                                     blas::Transpose transb, uint64 m, uint64 n,
@@ -1330,7 +1333,7 @@ class Stream {
                                     const DeviceMemory<Eigen::half> &a, int lda,
                                     const DeviceMemory<Eigen::half> &b, int ldb,
                                     float beta, DeviceMemory<Eigen::half> *c,
-                                    int ldc,
+                                    int ldc, int allow_fast_math,
                                     blas::ProfileResult *output_profile_result);
   Stream &ThenBlasGemmWithProfiling(blas::Transpose transa,
                                     blas::Transpose transb, uint64 m, uint64 n,
@@ -1338,6 +1341,7 @@ class Stream {
                                     const DeviceMemory<float> &a, int lda,
                                     const DeviceMemory<float> &b, int ldb,
                                     float beta, DeviceMemory<float> *c, int ldc,
+                                    int allow_fast_math,
                                     blas::ProfileResult *output_profile_result);
   Stream &ThenBlasGemmWithProfiling(blas::Transpose transa,
                                     blas::Transpose transb, uint64 m, uint64 n,
@@ -1345,7 +1349,7 @@ class Stream {
                                     const DeviceMemory<double> &a, int lda,
                                     const DeviceMemory<double> &b, int ldb,
                                     double beta, DeviceMemory<double> *c,
-                                    int ldc,
+                                    int ldc, int allow_fast_math,
                                     blas::ProfileResult *output_profile_result);
   Stream &ThenBlasGemmWithProfiling(
       blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
@@ -1353,14 +1357,14 @@ class Stream {
       const DeviceMemory<std::complex<float>> &a, int lda,
       const DeviceMemory<std::complex<float>> &b, int ldb,
       std::complex<float> beta, DeviceMemory<std::complex<float>> *c, int ldc,
-      blas::ProfileResult *output_profile_result);
+      int allow_fast_math, blas::ProfileResult *output_profile_result);
   Stream &ThenBlasGemmWithProfiling(
       blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
       uint64 k, std::complex<double> alpha,
       const DeviceMemory<std::complex<double>> &a, int lda,
       const DeviceMemory<std::complex<double>> &b, int ldb,
       std::complex<double> beta, DeviceMemory<std::complex<double>> *c, int ldc,
-      blas::ProfileResult *output_profile_result);
+      int allow_fast_math, blas::ProfileResult *output_profile_result);
 
   // See BlasSupport::DoBlasGemmWithAlgorithm.
   Stream &ThenBlasGemmWithAlgorithm(
@@ -1370,7 +1374,7 @@ class Stream {
       const DeviceMemory<Eigen::half> &b, int ldb,
       const HostOrDeviceScalar<Eigen::half> &beta, DeviceMemory<Eigen::half> *c,
       int ldc, blas::ComputationType computation_type,
-      blas::AlgorithmType algorithm,
+      blas::AlgorithmType algorithm, int allow_fast_math,
       blas::ProfileResult *output_profile_result);
   Stream &ThenBlasGemmWithAlgorithm(
       blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
@@ -1378,7 +1382,7 @@ class Stream {
       const DeviceMemory<int8> &a, int lda, const DeviceMemory<int8> &b,
       int ldb, const HostOrDeviceScalar<int> &beta, DeviceMemory<int> *c,
       int ldc, blas::ComputationType computation_type,
-      blas::AlgorithmType algorithm,
+      blas::AlgorithmType algorithm, int allow_fast_math,
       blas::ProfileResult *output_profile_result);
   Stream &ThenBlasGemmWithAlgorithm(
       blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
@@ -1386,7 +1390,7 @@ class Stream {
       const DeviceMemory<float> &a, int lda, const DeviceMemory<float> &b,
       int ldb, const HostOrDeviceScalar<float> &beta, DeviceMemory<float> *c,
       int ldc, blas::ComputationType computation_type,
-      blas::AlgorithmType algorithm,
+      blas::AlgorithmType algorithm, int allow_fast_math,
       blas::ProfileResult *output_profile_result);
   Stream &ThenBlasGemmWithAlgorithm(
       blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
@@ -1394,7 +1398,7 @@ class Stream {
       const DeviceMemory<double> &a, int lda, const DeviceMemory<double> &b,
       int ldb, const HostOrDeviceScalar<double> &beta, DeviceMemory<double> *c,
       int ldc, blas::ComputationType computation_type,
-      blas::AlgorithmType algorithm,
+      blas::AlgorithmType algorithm, int allow_fast_math,
       blas::ProfileResult *output_profile_result);
   Stream &ThenBlasGemmWithAlgorithm(
       blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
@@ -1404,7 +1408,7 @@ class Stream {
       const HostOrDeviceScalar<std::complex<float>> &beta,
       DeviceMemory<std::complex<float>> *c, int ldc,
       blas::ComputationType computation_type, blas::AlgorithmType algorithm,
-      blas::ProfileResult *output_profile_result);
+      int allow_fast_math, blas::ProfileResult *output_profile_result);
   Stream &ThenBlasGemmWithAlgorithm(
       blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
       uint64 k, const HostOrDeviceScalar<std::complex<double>> &alpha,
@@ -1413,7 +1417,7 @@ class Stream {
       const HostOrDeviceScalar<std::complex<double>> &beta,
       DeviceMemory<std::complex<double>> *c, int ldc,
       blas::ComputationType computation_type, blas::AlgorithmType algorithm,
-      blas::ProfileResult *output_profile_result);
+      int allow_fast_math, blas::ProfileResult *output_profile_result);
 
   // See BlasSupport::DoBlasGemmBatched.
   Stream &ThenBlasGemmBatched(
@@ -1422,7 +1426,7 @@ class Stream {
       const port::ArraySlice<DeviceMemory<Eigen::half> *> &a, int lda,
       const port::ArraySlice<DeviceMemory<Eigen::half> *> &b, int ldb,
       float beta, const port::ArraySlice<DeviceMemory<Eigen::half> *> &c,
-      int ldc, int batch_count);
+      int ldc, int batch_count, int allow_fast_math);
   Stream &ThenBlasGemmBatched(blas::Transpose transa, blas::Transpose transb,
                               uint64 m, uint64 n, uint64 k, float alpha,
                               const port::ArraySlice<DeviceMemory<float> *> &a,
@@ -1430,7 +1434,7 @@ class Stream {
                               const port::ArraySlice<DeviceMemory<float> *> &b,
                               int ldb, float beta,
                               const port::ArraySlice<DeviceMemory<float> *> &c,
-                              int ldc, int batch_count);
+                              int ldc, int batch_count, int allow_fast_math);
   Stream &ThenBlasGemmBatched(blas::Transpose transa, blas::Transpose transb,
                               uint64 m, uint64 n, uint64 k, double alpha,
                               const port::ArraySlice<DeviceMemory<double> *> &a,
@@ -1438,7 +1442,7 @@ class Stream {
                               const port::ArraySlice<DeviceMemory<double> *> &b,
                               int ldb, double beta,
                               const port::ArraySlice<DeviceMemory<double> *> &c,
-                              int ldc, int batch_count);
+                              int ldc, int batch_count, int allow_fast_math);
   Stream &ThenBlasGemmBatched(
       blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
       uint64 k, std::complex<float> alpha,
@@ -1446,7 +1450,7 @@ class Stream {
       const port::ArraySlice<DeviceMemory<std::complex<float>> *> &b, int ldb,
       std::complex<float> beta,
       const port::ArraySlice<DeviceMemory<std::complex<float>> *> &c, int ldc,
-      int batch_count);
+      int batch_count, int allow_fast_math);
   Stream &ThenBlasGemmBatched(
       blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
       uint64 k, std::complex<double> alpha,
@@ -1454,26 +1458,29 @@ class Stream {
       const port::ArraySlice<DeviceMemory<std::complex<double>> *> &b, int ldb,
       std::complex<double> beta,
       const port::ArraySlice<DeviceMemory<std::complex<double>> *> &c, int ldc,
-      int batch_count);
+      int batch_count, int allow_fast_math);
   Stream &ThenBlasGemmBatchedWithScratch(
       blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
       uint64 k, float alpha,
       const port::ArraySlice<DeviceMemory<Eigen::half> *> &a, int lda,
       const port::ArraySlice<DeviceMemory<Eigen::half> *> &b, int ldb,
       float beta, const port::ArraySlice<DeviceMemory<Eigen::half> *> &c,
-      int ldc, int batch_count, ScratchAllocator *scratch_allocator);
+      int ldc, int batch_count, ScratchAllocator *scratch_allocator,
+      int allow_fast_math);
   Stream &ThenBlasGemmBatchedWithScratch(
       blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
       uint64 k, float alpha, const port::ArraySlice<DeviceMemory<float> *> &a,
       int lda, const port::ArraySlice<DeviceMemory<float> *> &b, int ldb,
       float beta, const port::ArraySlice<DeviceMemory<float> *> &c, int ldc,
-      int batch_count, ScratchAllocator *scratch_allocator);
+      int batch_count, ScratchAllocator *scratch_allocator,
+      int allow_fast_math);
   Stream &ThenBlasGemmBatchedWithScratch(
       blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
       uint64 k, double alpha, const port::ArraySlice<DeviceMemory<double> *> &a,
       int lda, const port::ArraySlice<DeviceMemory<double> *> &b, int ldb,
       double beta, const port::ArraySlice<DeviceMemory<double> *> &c, int ldc,
-      int batch_count, ScratchAllocator *scratch_allocator);
+      int batch_count, ScratchAllocator *scratch_allocator,
+      int allow_fast_math);
   Stream &ThenBlasGemmBatchedWithScratch(
       blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
       uint64 k, std::complex<float> alpha,
@@ -1481,7 +1488,8 @@ class Stream {
       const port::ArraySlice<DeviceMemory<std::complex<float>> *> &b, int ldb,
       std::complex<float> beta,
       const port::ArraySlice<DeviceMemory<std::complex<float>> *> &c, int ldc,
-      int batch_count, ScratchAllocator *scratch_allocator);
+      int batch_count, ScratchAllocator *scratch_allocator,
+      int allow_fast_math);
   Stream &ThenBlasGemmBatchedWithScratch(
       blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
       uint64 k, std::complex<double> alpha,
@@ -1489,39 +1497,40 @@ class Stream {
       const port::ArraySlice<DeviceMemory<std::complex<double>> *> &b, int ldb,
       std::complex<double> beta,
       const port::ArraySlice<DeviceMemory<std::complex<double>> *> &c, int ldc,
-      int batch_count, ScratchAllocator *scratch_allocator);
+      int batch_count, ScratchAllocator *scratch_allocator,
+      int allow_fast_math);
   Stream &ThenBlasGemmStridedBatched(
       blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
       uint64 k, float alpha, const DeviceMemory<Eigen::half> &a, int lda,
       int64 stride_a, const DeviceMemory<Eigen::half> &b, int ldb,
       int64 stride_b, float beta, DeviceMemory<Eigen::half> *c, int ldc,
-      int64 stride_c, int batch_count);
+      int64 stride_c, int batch_count, int allow_fast_math);
   Stream &ThenBlasGemmStridedBatched(
       blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
       uint64 k, float alpha, const DeviceMemory<float> &a, int lda,
       int64 stride_a, const DeviceMemory<float> &b, int ldb, int64 stride_b,
       float beta, DeviceMemory<float> *c, int ldc, int64 stride_c,
-      int batch_count);
+      int batch_count, int allow_fast_math);
   Stream &ThenBlasGemmStridedBatched(
       blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
       uint64 k, double alpha, const DeviceMemory<double> &a, int lda,
       int64 stride_a, const DeviceMemory<double> &b, int ldb, int64 stride_b,
       double beta, DeviceMemory<double> *c, int ldc, int64 stride_c,
-      int batch_count);
+      int batch_count, int allow_fast_math);
   Stream &ThenBlasGemmStridedBatched(
       blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
       uint64 k, std::complex<float> alpha,
       const DeviceMemory<std::complex<float>> &a, int lda, int64 stride_a,
       const DeviceMemory<std::complex<float>> &b, int ldb, int64 stride_b,
       std::complex<float> beta, DeviceMemory<std::complex<float>> *c, int ldc,
-      int64 stride_c, int batch_count);
+      int64 stride_c, int batch_count, int allow_fast_math);
   Stream &ThenBlasGemmStridedBatched(
       blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
       uint64 k, std::complex<double> alpha,
       const DeviceMemory<std::complex<double>> &a, int lda, int64 stride_a,
       const DeviceMemory<std::complex<double>> &b, int ldb, int64 stride_b,
       std::complex<double> beta, DeviceMemory<std::complex<double>> *c, int ldc,
-      int64 stride_c, int batch_count);
+      int64 stride_c, int batch_count, int allow_fast_math);
 
   // See BlasSupport::DoBlasHemm.
   Stream &ThenBlasHemm(blas::Side side, blas::UpperLower uplo, uint64 m,

--- a/tensorflow/tools/api/golden/v1/tensorflow.linalg.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.linalg.pbtxt
@@ -182,7 +182,7 @@ tf_module {
   }
   member_method {
     name: "matmul"
-    argspec: "args=[\'a\', \'b\', \'transpose_a\', \'transpose_b\', \'adjoint_a\', \'adjoint_b\', \'a_is_sparse\', \'b_is_sparse\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'False\', \'False\', \'False\', \'False\', \'False\', \'None\'], "
+    argspec: "args=[\'a\', \'b\', \'transpose_a\', \'transpose_b\', \'adjoint_a\', \'adjoint_b\', \'a_is_sparse\', \'b_is_sparse\', \'allow_fast_math\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'False\', \'False\', \'False\', \'False\', \'False\', \'None\', \'None\'], "
   }
   member_method {
     name: "matrix_rank"

--- a/tensorflow/tools/api/golden/v1/tensorflow.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.pbtxt
@@ -913,6 +913,10 @@ tf_module {
     argspec: "args=[\'params\', \'indices\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "batch_mat_mul_v3"
+    argspec: "args=[\'x\', \'y\', \'adj_x\', \'adj_y\', \'allow_fast_math\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'False\', \'-1\', \'None\'], "
+  }
+  member_method {
     name: "batch_scatter_update"
     argspec: "args=[\'ref\', \'indices\', \'updates\', \'use_locking\', \'name\'], varargs=None, keywords=None, defaults=[\'True\', \'None\'], "
   }
@@ -1629,12 +1633,16 @@ tf_module {
     argspec: "args=[\'fn\', \'elems\', \'dtype\', \'parallel_iterations\', \'back_prop\', \'swap_memory\', \'infer_shape\', \'name\', \'fn_output_signature\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'True\', \'False\', \'True\', \'None\', \'None\'], "
   }
   member_method {
+    name: "mat_mul_v2"
+    argspec: "args=[\'a\', \'b\', \'transpose_a\', \'transpose_b\', \'allow_fast_math\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'False\', \'-1\', \'None\'], "
+  }
+  member_method {
     name: "matching_files"
     argspec: "args=[\'pattern\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
     name: "matmul"
-    argspec: "args=[\'a\', \'b\', \'transpose_a\', \'transpose_b\', \'adjoint_a\', \'adjoint_b\', \'a_is_sparse\', \'b_is_sparse\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'False\', \'False\', \'False\', \'False\', \'False\', \'None\'], "
+    argspec: "args=[\'a\', \'b\', \'transpose_a\', \'transpose_b\', \'adjoint_a\', \'adjoint_b\', \'a_is_sparse\', \'b_is_sparse\', \'allow_fast_math\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'False\', \'False\', \'False\', \'False\', \'False\', \'None\', \'None\'], "
   }
   member_method {
     name: "matrix_band_part"

--- a/tensorflow/tools/api/golden/v1/tensorflow.raw_ops.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.raw_ops.pbtxt
@@ -369,6 +369,10 @@ tf_module {
     argspec: "args=[\'x\', \'y\', \'adj_x\', \'adj_y\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'False\', \'None\'], "
   }
   member_method {
+    name: "BatchMatMulV3"
+    argspec: "args=[\'x\', \'y\', \'adj_x\', \'adj_y\', \'allow_fast_math\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'False\', \'-1\', \'None\'], "
+  }
+  member_method {
     name: "BatchMatrixBandPart"
     argspec: "args=[\'input\', \'num_lower\', \'num_upper\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
@@ -2323,6 +2327,10 @@ tf_module {
   member_method {
     name: "MatMul"
     argspec: "args=[\'a\', \'b\', \'transpose_a\', \'transpose_b\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'False\', \'None\'], "
+  }
+  member_method {
+    name: "MatMulV2"
+    argspec: "args=[\'a\', \'b\', \'transpose_a\', \'transpose_b\', \'allow_fast_math\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'False\', \'-1\', \'None\'], "
   }
   member_method {
     name: "MatchingFiles"

--- a/tensorflow/tools/api/golden/v2/tensorflow.linalg.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.linalg.pbtxt
@@ -194,7 +194,7 @@ tf_module {
   }
   member_method {
     name: "matmul"
-    argspec: "args=[\'a\', \'b\', \'transpose_a\', \'transpose_b\', \'adjoint_a\', \'adjoint_b\', \'a_is_sparse\', \'b_is_sparse\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'False\', \'False\', \'False\', \'False\', \'False\', \'None\'], "
+    argspec: "args=[\'a\', \'b\', \'transpose_a\', \'transpose_b\', \'adjoint_a\', \'adjoint_b\', \'a_is_sparse\', \'b_is_sparse\', \'allow_fast_math\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'False\', \'False\', \'False\', \'False\', \'False\', \'None\', \'None\'], "
   }
   member_method {
     name: "matrix_rank"

--- a/tensorflow/tools/api/golden/v2/tensorflow.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.pbtxt
@@ -509,6 +509,10 @@ tf_module {
     argspec: "args=[\'x\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "batch_mat_mul_v3"
+    argspec: "args=[\'x\', \'y\', \'adj_x\', \'adj_y\', \'allow_fast_math\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'False\', \'-1\', \'None\'], "
+  }
+  member_method {
     name: "batch_to_space"
     argspec: "args=[\'input\', \'block_shape\', \'crops\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
@@ -793,8 +797,12 @@ tf_module {
     argspec: "args=[\'fn\', \'elems\', \'dtype\', \'parallel_iterations\', \'back_prop\', \'swap_memory\', \'infer_shape\', \'name\', \'fn_output_signature\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'True\', \'False\', \'True\', \'None\', \'None\'], "
   }
   member_method {
+    name: "mat_mul_v2"
+    argspec: "args=[\'a\', \'b\', \'transpose_a\', \'transpose_b\', \'allow_fast_math\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'False\', \'-1\', \'None\'], "
+  }
+  member_method {
     name: "matmul"
-    argspec: "args=[\'a\', \'b\', \'transpose_a\', \'transpose_b\', \'adjoint_a\', \'adjoint_b\', \'a_is_sparse\', \'b_is_sparse\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'False\', \'False\', \'False\', \'False\', \'False\', \'None\'], "
+    argspec: "args=[\'a\', \'b\', \'transpose_a\', \'transpose_b\', \'adjoint_a\', \'adjoint_b\', \'a_is_sparse\', \'b_is_sparse\', \'allow_fast_math\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'False\', \'False\', \'False\', \'False\', \'False\', \'None\', \'None\'], "
   }
   member_method {
     name: "matrix_square_root"

--- a/tensorflow/tools/api/golden/v2/tensorflow.raw_ops.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.raw_ops.pbtxt
@@ -369,6 +369,10 @@ tf_module {
     argspec: "args=[\'x\', \'y\', \'adj_x\', \'adj_y\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'False\', \'None\'], "
   }
   member_method {
+    name: "BatchMatMulV3"
+    argspec: "args=[\'x\', \'y\', \'adj_x\', \'adj_y\', \'allow_fast_math\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'False\', \'-1\', \'None\'], "
+  }
+  member_method {
     name: "BatchMatrixBandPart"
     argspec: "args=[\'input\', \'num_lower\', \'num_upper\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
@@ -2323,6 +2327,10 @@ tf_module {
   member_method {
     name: "MatMul"
     argspec: "args=[\'a\', \'b\', \'transpose_a\', \'transpose_b\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'False\', \'None\'], "
+  }
+  member_method {
+    name: "MatMulV2"
+    argspec: "args=[\'a\', \'b\', \'transpose_a\', \'transpose_b\', \'allow_fast_math\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'False\', \'-1\', \'None\'], "
   }
   member_method {
     name: "MatchingFiles"


### PR DESCRIPTION
This PR is related to the global setting of TensorFloat32 (TF32) for GPUs. Though TF32 can provide significant performance benefits, TensorFlow uses matmul operations in some contexts where full fp32 precision needs to be maintained. For these, we need an easy way to control precision in a per op basis. This PR adds an attribute "allow_fast_math" to the matmul/batchedmatmul op to control TF32/fp32. Correspondingly, the python APIs are also changed.

With that, we have three options for "allow_fast_math":
- -1(None for python API): use global setting.
- 0  (False): use fp32.
- 1  (True): use TF32.

Note: For now, this PR shouldn't affect the unit tests, since TF32 is not enabled globally by default and in the PR this attribute is set to -1 (following the global setting). When it is enabled in the future, we have another PR to fix those affected unit tests (which might fail due to reduced precision issues) based on this PR.
 
@nluehr 
