### PR TITLE
Enable Transactions API

### DIFF
--- a/tensorflow/c/experimental/filesystem/modular_filesystem.cc
+++ b/tensorflow/c/experimental/filesystem/modular_filesystem.cc
@@ -35,8 +35,8 @@ using UniquePtrTo_TF_Status =
     ::std::unique_ptr<TF_Status, decltype(&TF_DeleteStatus)>;
 
 Status ModularFileSystem::NewRandomAccessFile(
-    const std::string& fname,
-    std::unique_ptr<RandomAccessFile>* result /*, TransactionToken* token */) {
+    const std::string& fname, std::unique_ptr<RandomAccessFile>* result,
+    TransactionToken* token) {
   if (ops_->new_random_access_file == nullptr)
     return errors::Unimplemented(tensorflow::strings::StrCat(
         "Filesystem for ", fname, " does not support NewRandomAccessFile()"));
@@ -54,9 +54,9 @@ Status ModularFileSystem::NewRandomAccessFile(
   return StatusFromTF_Status(plugin_status.get());
 }
 
-Status ModularFileSystem::NewWritableFile(
-    const std::string& fname,
-    std::unique_ptr<WritableFile>* result /*, TransactionToken* token */) {
+Status ModularFileSystem::NewWritableFile(const std::string& fname,
+                                          std::unique_ptr<WritableFile>* result,
+                                          TransactionToken* token) {
   if (ops_->new_writable_file == nullptr)
     return errors::Unimplemented(tensorflow::strings::StrCat(
         "Filesystem for ", fname, " does not support NewWritableFile()"));
@@ -75,8 +75,8 @@ Status ModularFileSystem::NewWritableFile(
 }
 
 Status ModularFileSystem::NewAppendableFile(
-    const std::string& fname,
-    std::unique_ptr<WritableFile>* result /*, TransactionToken* token */) {
+    const std::string& fname, std::unique_ptr<WritableFile>* result,
+    TransactionToken* token) {
   if (ops_->new_appendable_file == nullptr)
     return errors::Unimplemented(tensorflow::strings::StrCat(
         "Filesystem for ", fname, " does not support NewAppendableFile()"));
@@ -95,8 +95,8 @@ Status ModularFileSystem::NewAppendableFile(
 }
 
 Status ModularFileSystem::NewReadOnlyMemoryRegionFromFile(
-    const std::string& fname, std::unique_ptr<ReadOnlyMemoryRegion>*
-                                  result /*, TransactionToken* token */) {
+    const std::string& fname, std::unique_ptr<ReadOnlyMemoryRegion>* result,
+    TransactionToken* token) {
   if (ops_->new_read_only_memory_region_from_file == nullptr)
     return errors::Unimplemented(tensorflow::strings::StrCat(
         "Filesystem for ", fname,
@@ -116,8 +116,8 @@ Status ModularFileSystem::NewReadOnlyMemoryRegionFromFile(
   return StatusFromTF_Status(plugin_status.get());
 }
 
-Status ModularFileSystem::FileExists(
-    const std::string& fname /*, TransactionToken* token */) {
+Status ModularFileSystem::FileExists(const std::string& fname,
+                                     TransactionToken* token) {
   if (ops_->path_exists == nullptr)
     return errors::Unimplemented(tensorflow::strings::StrCat(
         "Filesystem for ", fname, " does not support FileExists()"));
@@ -129,9 +129,9 @@ Status ModularFileSystem::FileExists(
   return StatusFromTF_Status(plugin_status.get());
 }
 
-bool ModularFileSystem::FilesExist(
-    const std::vector<std::string>& files,
-    std::vector<Status>* status /*, TransactionToken* token */) {
+bool ModularFileSystem::FilesExist(const std::vector<std::string>& files,
+                                   std::vector<Status>* status,
+                                   TransactionToken* token) {
   if (ops_->paths_exist == nullptr)
     return FileSystem::FilesExist(files, status);
 
@@ -162,9 +162,9 @@ bool ModularFileSystem::FilesExist(
   return result;
 }
 
-Status ModularFileSystem::GetChildren(
-    const std::string& dir,
-    std::vector<std::string>* result /*, TransactionToken* token */) {
+Status ModularFileSystem::GetChildren(const std::string& dir,
+                                      std::vector<std::string>* result,
+                                      TransactionToken* token) {
   if (ops_->get_children == nullptr)
     return errors::Unimplemented(tensorflow::strings::StrCat(
         "Filesystem for ", dir, " does not support GetChildren()"));
@@ -188,9 +188,9 @@ Status ModularFileSystem::GetChildren(
   return StatusFromTF_Status(plugin_status.get());
 }
 
-Status ModularFileSystem::GetMatchingPaths(
-    const std::string& pattern,
-    std::vector<std::string>* result /*, TransactionToken* token */) {
+Status ModularFileSystem::GetMatchingPaths(const std::string& pattern,
+                                           std::vector<std::string>* result,
+                                           TransactionToken* token) {
   if (ops_->get_matching_paths == nullptr)
     return internal::GetMatchingPaths(this, Env::Default(), pattern, result);
 
@@ -211,8 +211,8 @@ Status ModularFileSystem::GetMatchingPaths(
   return StatusFromTF_Status(plugin_status.get());
 }
 
-Status ModularFileSystem::DeleteFile(
-    const std::string& fname /*, TransactionToken* token */) {
+Status ModularFileSystem::DeleteFile(const std::string& fname,
+                                     TransactionToken* token) {
   if (ops_->delete_file == nullptr)
     return errors::Unimplemented(tensorflow::strings::StrCat(
         "Filesystem for ", fname, " does not support DeleteFile()"));
@@ -224,9 +224,10 @@ Status ModularFileSystem::DeleteFile(
   return StatusFromTF_Status(plugin_status.get());
 }
 
-Status ModularFileSystem::DeleteRecursively(
-    const std::string& dirname, int64* undeleted_files,
-    int64* undeleted_dirs /*, TransactionToken* token */) {
+Status ModularFileSystem::DeleteRecursively(const std::string& dirname,
+                                            int64* undeleted_files,
+                                            int64* undeleted_dirs,
+                                            TransactionToken* token) {
   if (undeleted_files == nullptr || undeleted_dirs == nullptr)
     return errors::FailedPrecondition(
         "DeleteRecursively must not be called with `undeleted_files` or "
@@ -247,8 +248,8 @@ Status ModularFileSystem::DeleteRecursively(
   return StatusFromTF_Status(plugin_status.get());
 }
 
-Status ModularFileSystem::DeleteDir(
-    const std::string& dirname /*, TransactionToken* token */) {
+Status ModularFileSystem::DeleteDir(const std::string& dirname,
+                                    TransactionToken* token) {
   if (ops_->delete_dir == nullptr)
     return errors::Unimplemented(tensorflow::strings::StrCat(
         "Filesystem for ", dirname, " does not support DeleteDir()"));
@@ -260,8 +261,8 @@ Status ModularFileSystem::DeleteDir(
   return StatusFromTF_Status(plugin_status.get());
 }
 
-Status ModularFileSystem::RecursivelyCreateDir(
-    const std::string& dirname /*, TransactionToken* token */) {
+Status ModularFileSystem::RecursivelyCreateDir(const std::string& dirname,
+                                               TransactionToken* token) {
   if (ops_->recursively_create_dir == nullptr)
     return FileSystem::RecursivelyCreateDir(dirname);
 
@@ -272,8 +273,8 @@ Status ModularFileSystem::RecursivelyCreateDir(
   return StatusFromTF_Status(plugin_status.get());
 }
 
-Status ModularFileSystem::CreateDir(
-    const std::string& dirname /*, TransactionToken* token */) {
+Status ModularFileSystem::CreateDir(const std::string& dirname,
+                                    TransactionToken* token) {
   if (ops_->create_dir == nullptr)
     return errors::Unimplemented(tensorflow::strings::StrCat(
         "Filesystem for ", dirname, " does not support CreateDir()"));
@@ -285,9 +286,8 @@ Status ModularFileSystem::CreateDir(
   return StatusFromTF_Status(plugin_status.get());
 }
 
-Status ModularFileSystem::Stat(
-    const std::string& fname,
-    FileStatistics* stat /*, TransactionToken* token */) {
+Status ModularFileSystem::Stat(const std::string& fname, FileStatistics* stat,
+                               TransactionToken* token) {
   if (ops_->stat == nullptr)
     return errors::Unimplemented(tensorflow::strings::StrCat(
         "Filesystem for ", fname, " does not support Stat()"));
@@ -310,8 +310,8 @@ Status ModularFileSystem::Stat(
   return StatusFromTF_Status(plugin_status.get());
 }
 
-Status ModularFileSystem::IsDirectory(
-    const std::string& name /*, TransactionToken* token */) {
+Status ModularFileSystem::IsDirectory(const std::string& name,
+                                      TransactionToken* token) {
   if (ops_->is_directory == nullptr) return FileSystem::IsDirectory(name);
 
   UniquePtrTo_TF_Status plugin_status(TF_NewStatus(), TF_DeleteStatus);
@@ -321,9 +321,9 @@ Status ModularFileSystem::IsDirectory(
   return StatusFromTF_Status(plugin_status.get());
 }
 
-Status ModularFileSystem::GetFileSize(
-    const std::string& fname,
-    uint64* file_size /*, TransactionToken* token */) {
+Status ModularFileSystem::GetFileSize(const std::string& fname,
+                                      uint64* file_size,
+                                      TransactionToken* token) {
   if (ops_->get_file_size == nullptr) {
     FileStatistics stat;
     Status status = Stat(fname, &stat);
@@ -342,9 +342,9 @@ Status ModularFileSystem::GetFileSize(
   return StatusFromTF_Status(plugin_status.get());
 }
 
-Status ModularFileSystem::RenameFile(
-    const std::string& src,
-    const std::string& target /*, TransactionToken* token */) {
+Status ModularFileSystem::RenameFile(const std::string& src,
+                                     const std::string& target,
+                                     TransactionToken* token) {
   if (ops_->rename_file == nullptr) {
     Status status = CopyFile(src, target);
     if (status.ok()) status = DeleteFile(src);
@@ -359,9 +359,9 @@ Status ModularFileSystem::RenameFile(
   return StatusFromTF_Status(plugin_status.get());
 }
 
-Status ModularFileSystem::CopyFile(
-    const std::string& src,
-    const std::string& target /*, TransactionToken* token */) {
+Status ModularFileSystem::CopyFile(const std::string& src,
+                                   const std::string& target,
+                                   TransactionToken* token) {
   if (ops_->copy_file == nullptr) return FileSystem::CopyFile(src, target);
 
   UniquePtrTo_TF_Status plugin_status(TF_NewStatus(), TF_DeleteStatus);
@@ -372,8 +372,7 @@ Status ModularFileSystem::CopyFile(
   return StatusFromTF_Status(plugin_status.get());
 }
 
-std::string ModularFileSystem::TranslateName(
-    const std::string& name /*, TransactionToken* token */) const {
+std::string ModularFileSystem::TranslateName(const std::string& name) const {
   if (ops_->translate_name == nullptr) return FileSystem::TranslateName(name);
 
   char* p = ops_->translate_name(filesystem_.get(), name.c_str());
@@ -385,7 +384,7 @@ std::string ModularFileSystem::TranslateName(
   return ret;
 }
 
-void ModularFileSystem::FlushCaches(/*TransactionToken* token*/) {
+void ModularFileSystem::FlushCaches(TransactionToken* token) {
   if (ops_->flush_caches != nullptr) ops_->flush_caches(filesystem_.get());
 }
 

--- a/tensorflow/c/experimental/filesystem/modular_filesystem.h
+++ b/tensorflow/c/experimental/filesystem/modular_filesystem.h
@@ -59,71 +59,51 @@ class ModularFileSystem final : public FileSystem {
 
   ~ModularFileSystem() override { ops_->cleanup(filesystem_.get()); }
 
-  Status NewRandomAccessFile(
-      const std::string& fname,
-      std::unique_ptr<RandomAccessFile>*
-          result /*, TransactionToken* token = nullptr */) override;
-  Status NewWritableFile(
-      const std::string& fname,
-      std::unique_ptr<WritableFile>*
-          result /*, TransactionToken* token = nullptr */) override;
-  Status NewAppendableFile(
-      const std::string& fname,
-      std::unique_ptr<WritableFile>*
-          result /*, TransactionToken* token = nullptr */) override;
+  Status NewRandomAccessFile(const std::string& fname,
+                             std::unique_ptr<RandomAccessFile>* result,
+                             TransactionToken* token = nullptr) override;
+  Status NewWritableFile(const std::string& fname,
+                         std::unique_ptr<WritableFile>* result,
+                         TransactionToken* token = nullptr) override;
+  Status NewAppendableFile(const std::string& fname,
+                           std::unique_ptr<WritableFile>* result,
+                           TransactionToken* token = nullptr) override;
   Status NewReadOnlyMemoryRegionFromFile(
-      const std::string& fname,
-      std::unique_ptr<ReadOnlyMemoryRegion>*
-          result /*, TransactionToken* token = nullptr */) override;
-  Status FileExists(
-      const std::string& fname /*, TransactionToken* token = nullptr */)
-      override;
+      const std::string& fname, std::unique_ptr<ReadOnlyMemoryRegion>* result,
+      TransactionToken* token = nullptr) override;
+  Status FileExists(const std::string& fname,
+                    TransactionToken* token = nullptr) override;
   bool FilesExist(const std::vector<std::string>& files,
-                  std::vector<Status>*
-                      status /*, TransactionToken* token = nullptr */) override;
-  Status GetChildren(
-      const std::string& dir,
-      std::vector<std::string>* result /*, TransactionToken* token = nullptr */)
-      override;
-  Status GetMatchingPaths(
-      const std::string& pattern,
-      std::vector<std::string>*
-          results /*, TransactionToken* token = nullptr */) override;
-  Status DeleteFile(
-      const std::string& fname /*, TransactionToken* token = nullptr */)
-      override;
-  Status DeleteRecursively(
-      const std::string& dirname, int64* undeleted_files,
-      int64* undeleted_dirs /*, TransactionToken* token = nullptr */) override;
-  Status DeleteDir(
-      const std::string& dirname /*, TransactionToken* token = nullptr */)
-      override;
-  Status RecursivelyCreateDir(
-      const std::string& dirname /*, TransactionToken* token = nullptr */)
-      override;
-  Status CreateDir(
-      const std::string& dirname /*, TransactionToken* token = nullptr */)
-      override;
-  Status Stat(
-      const std::string& fname,
-      FileStatistics* stat /*, TransactionToken* token = nullptr */) override;
-  Status IsDirectory(
-      const std::string& fname /*, TransactionToken* token = nullptr */)
-      override;
-  Status GetFileSize(
-      const std::string& fname,
-      uint64* file_size /*, TransactionToken* token = nullptr */) override;
-  Status RenameFile(
-      const std::string& src,
-      const std::string& target /*, TransactionToken* token = nullptr */)
-      override;
-  Status CopyFile(const std::string& src,
-                  const std::string&
-                      target /*, TransactionToken* token = nullptr */) override;
-  std::string TranslateName(
-      const std::string& name /*, TransactionToken* token = nullptr */)
-      const override;
-  void FlushCaches(/* TransactionToken* token=nullptr */) override;
+                  std::vector<Status>* status,
+                  TransactionToken* token = nullptr) override;
+  Status GetChildren(const std::string& dir, std::vector<std::string>* result,
+                     TransactionToken* token = nullptr) override;
+  Status GetMatchingPaths(const std::string& pattern,
+                          std::vector<std::string>* results,
+                          TransactionToken* token = nullptr) override;
+  Status DeleteFile(const std::string& fname,
+                    TransactionToken* token = nullptr) override;
+  Status DeleteRecursively(const std::string& dirname, int64* undeleted_files,
+                           int64* undeleted_dirs,
+                           TransactionToken* token = nullptr) override;
+  Status DeleteDir(const std::string& dirname,
+                   TransactionToken* token = nullptr) override;
+  Status RecursivelyCreateDir(const std::string& dirname,
+                              TransactionToken* token = nullptr) override;
+  Status CreateDir(const std::string& dirname,
+                   TransactionToken* token = nullptr) override;
+  Status Stat(const std::string& fname, FileStatistics* stat,
+              TransactionToken* token = nullptr) override;
+  Status IsDirectory(const std::string& fname,
+                     TransactionToken* token = nullptr) override;
+  Status GetFileSize(const std::string& fname, uint64* file_size,
+                     TransactionToken* token = nullptr) override;
+  Status RenameFile(const std::string& src, const std::string& target,
+                    TransactionToken* token = nullptr) override;
+  Status CopyFile(const std::string& src, const std::string& target,
+                  TransactionToken* token = nullptr) override;
+  std::string TranslateName(const std::string& name) const override;
+  void FlushCaches(TransactionToken* token = nullptr) override;
 
  private:
   std::unique_ptr<TF_Filesystem> filesystem_;

--- a/tensorflow/core/common_runtime/constant_folding_test.cc
+++ b/tensorflow/core/common_runtime/constant_folding_test.cc
@@ -13,15 +13,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include "tensorflow/core/common_runtime/constant_folding.h"
+
 #include <map>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
-#include "tensorflow/cc/ops/nn_ops.h"
-#include "tensorflow/core/common_runtime/constant_folding.h"
-
 #include "tensorflow/cc/ops/array_ops_internal.h"
+#include "tensorflow/cc/ops/nn_ops.h"
 #include "tensorflow/cc/ops/sendrecv_ops.h"
 #include "tensorflow/cc/ops/standard_ops.h"
 #include "tensorflow/core/common_runtime/device.h"
@@ -689,7 +689,8 @@ class TestTFFileSystem : public ::tensorflow::NullFileSystem {
 
   ::tensorflow::Status NewReadOnlyMemoryRegionFromFile(
       const string& fname,
-      std::unique_ptr<::tensorflow::ReadOnlyMemoryRegion>* result) override {
+      std::unique_ptr<::tensorflow::ReadOnlyMemoryRegion>* result,
+      TransactionToken* token = nullptr) override {
     if (fname != kTestMemRegionName) {
       return ::tensorflow::errors::Unimplemented(
           "NewReadOnlyMemoryRegionFromFile unimplemented");

--- a/tensorflow/core/kernels/immutable_constant_op_test.cc
+++ b/tensorflow/core/kernels/immutable_constant_op_test.cc
@@ -61,8 +61,8 @@ class TestFileSystem : public NullFileSystem {
  public:
   ~TestFileSystem() override = default;
   Status NewReadOnlyMemoryRegionFromFile(
-      const string& fname,
-      std::unique_ptr<ReadOnlyMemoryRegion>* result) override {
+      const string& fname, std::unique_ptr<ReadOnlyMemoryRegion>* result,
+      TransactionToken* token = nullptr) override {
     float val = 0;
     StringPiece scheme, host, path;
     io::ParseURI(fname, &scheme, &host, &path);

--- a/tensorflow/core/platform/cloud/gcs_file_system.h
+++ b/tensorflow/core/platform/cloud/gcs_file_system.h
@@ -125,68 +125,57 @@ class GcsFileSystem : public FileSystem {
                 std::pair<const string, const string>* additional_header,
                 bool compose_append);
 
-  Status NewRandomAccessFile(
-      const string& fname,
-      std::unique_ptr<RandomAccessFile>*
-          result /*, TransactionToken* token = nullptr */) override;
+  Status NewRandomAccessFile(const string& fname,
+                             std::unique_ptr<RandomAccessFile>* result,
+                             TransactionToken* token = nullptr) override;
 
-  Status NewWritableFile(
-      const string& fname,
-      std::unique_ptr<WritableFile>*
-          result) /*, TransactionToken* token = nullptr */ override;
+  Status NewWritableFile(const string& fname,
+                         std::unique_ptr<WritableFile>* result,
+                         TransactionToken* token = nullptr) override;
 
-  Status NewAppendableFile(
-      const string& fname,
-      std::unique_ptr<WritableFile>*
-          result /*, TransactionToken* token = nullptr */) override;
+  Status NewAppendableFile(const string& fname,
+                           std::unique_ptr<WritableFile>* result,
+                           TransactionToken* token = nullptr) override;
 
   Status NewReadOnlyMemoryRegionFromFile(
-      const string& fname,
-      std::unique_ptr<ReadOnlyMemoryRegion>*
-          result /*, TransactionToken* token = nullptr */) override;
+      const string& fname, std::unique_ptr<ReadOnlyMemoryRegion>* result,
+      TransactionToken* token = nullptr) override;
 
-  Status FileExists(
-      const string& fname /*, TransactionToken* token = nullptr */) override;
+  Status FileExists(const string& fname,
+                    TransactionToken* token = nullptr) override;
 
-  Status Stat(
-      const string& fname,
-      FileStatistics* stat /*, TransactionToken* token = nullptr */) override;
+  Status Stat(const string& fname, FileStatistics* stat,
+              TransactionToken* token = nullptr) override;
 
-  Status GetChildren(
-      const string& dir,
-      std::vector<string>* result /*, TransactionToken* token = nullptr */)
-      override;
+  Status GetChildren(const string& dir, std::vector<string>* result,
+                     TransactionToken* token = nullptr) override;
 
-  Status GetMatchingPaths(
-      const string& pattern,
-      std::vector<string>* results /*, TransactionToken* token = nullptr */)
-      override;
+  Status GetMatchingPaths(const string& pattern, std::vector<string>* results,
+                          TransactionToken* token = nullptr) override;
 
-  Status DeleteFile(
-      const string& fname /*, TransactionToken* token = nullptr */) override;
+  Status DeleteFile(const string& fname,
+                    TransactionToken* token = nullptr) override;
 
-  Status CreateDir(
-      const string& dirname /*, TransactionToken* token = nullptr */) override;
+  Status CreateDir(const string& dirname,
+                   TransactionToken* token = nullptr) override;
 
-  Status DeleteDir(
-      const string& dirname /*, TransactionToken* token = nullptr */) override;
+  Status DeleteDir(const string& dirname,
+                   TransactionToken* token = nullptr) override;
 
-  Status GetFileSize(
-      const string& fname,
-      uint64* file_size /*, TransactionToken* token = nullptr */) override;
+  Status GetFileSize(const string& fname, uint64* file_size,
+                     TransactionToken* token = nullptr) override;
 
-  Status RenameFile(
-      const string& src,
-      const string& target /*, TransactionToken* token = nullptr */) override;
+  Status RenameFile(const string& src, const string& target,
+                    TransactionToken* token = nullptr) override;
 
-  Status IsDirectory(
-      const string& fname /*, TransactionToken* token = nullptr */) override;
+  Status IsDirectory(const string& fname,
+                     TransactionToken* token = nullptr) override;
 
-  Status DeleteRecursively(
-      const string& dirname, int64* undeleted_files,
-      int64* undeleted_dirs /*, TransactionToken* token = nullptr */) override;
+  Status DeleteRecursively(const string& dirname, int64* undeleted_files,
+                           int64* undeleted_dirs,
+                           TransactionToken* token = nullptr) override;
 
-  void FlushCaches(/* TransactionToken* token = nullptr */) override;
+  void FlushCaches(TransactionToken* token = nullptr) override;
 
   /// Set an object to collect runtime statistics from the GcsFilesystem.
   void SetStats(GcsStatsInterface* stats);

--- a/tensorflow/core/platform/default/posix_file_system.cc
+++ b/tensorflow/core/platform/default/posix_file_system.cc
@@ -178,8 +178,8 @@ class PosixReadOnlyMemoryRegion : public ReadOnlyMemoryRegion {
 };
 
 Status PosixFileSystem::NewRandomAccessFile(
-    const string& fname,
-    std::unique_ptr<RandomAccessFile>* result /*, TransactionToken* token */) {
+    const string& fname, std::unique_ptr<RandomAccessFile>* result,
+    TransactionToken* token) {
   string translated_fname = TranslateName(fname);
   Status s;
   int fd = open(translated_fname.c_str(), O_RDONLY);
@@ -191,9 +191,9 @@ Status PosixFileSystem::NewRandomAccessFile(
   return s;
 }
 
-Status PosixFileSystem::NewWritableFile(
-    const string& fname,
-    std::unique_ptr<WritableFile>* result /*, TransactionToken* token */) {
+Status PosixFileSystem::NewWritableFile(const string& fname,
+                                        std::unique_ptr<WritableFile>* result,
+                                        TransactionToken* token) {
   string translated_fname = TranslateName(fname);
   Status s;
   FILE* f = fopen(translated_fname.c_str(), "w");
@@ -205,9 +205,9 @@ Status PosixFileSystem::NewWritableFile(
   return s;
 }
 
-Status PosixFileSystem::NewAppendableFile(
-    const string& fname,
-    std::unique_ptr<WritableFile>* result /*, TransactionToken* token */) {
+Status PosixFileSystem::NewAppendableFile(const string& fname,
+                                          std::unique_ptr<WritableFile>* result,
+                                          TransactionToken* token) {
   string translated_fname = TranslateName(fname);
   Status s;
   FILE* f = fopen(translated_fname.c_str(), "a");
@@ -220,8 +220,8 @@ Status PosixFileSystem::NewAppendableFile(
 }
 
 Status PosixFileSystem::NewReadOnlyMemoryRegionFromFile(
-    const string& fname, std::unique_ptr<ReadOnlyMemoryRegion>*
-                             result /*, TransactionToken* token */) {
+    const string& fname, std::unique_ptr<ReadOnlyMemoryRegion>* result,
+    TransactionToken* token) {
   string translated_fname = TranslateName(fname);
   Status s = Status::OK();
   int fd = open(translated_fname.c_str(), O_RDONLY);
@@ -244,17 +244,17 @@ Status PosixFileSystem::NewReadOnlyMemoryRegionFromFile(
   return s;
 }
 
-Status PosixFileSystem::FileExists(
-    const string& fname /*, TransactionToken* token */) {
+Status PosixFileSystem::FileExists(const string& fname,
+                                   TransactionToken* token) {
   if (access(TranslateName(fname).c_str(), F_OK) == 0) {
     return Status::OK();
   }
   return errors::NotFound(fname, " not found");
 }
 
-Status PosixFileSystem::GetChildren(
-    const string& dir,
-    std::vector<string>* result /*, TransactionToken* token */) {
+Status PosixFileSystem::GetChildren(const string& dir,
+                                    std::vector<string>* result,
+                                    TransactionToken* token) {
   string translated_dir = TranslateName(dir);
   result->clear();
   DIR* d = opendir(translated_dir.c_str());
@@ -274,14 +274,14 @@ Status PosixFileSystem::GetChildren(
   return Status::OK();
 }
 
-Status PosixFileSystem::GetMatchingPaths(
-    const string& pattern,
-    std::vector<string>* results /*, TransactionToken* token */) {
+Status PosixFileSystem::GetMatchingPaths(const string& pattern,
+                                         std::vector<string>* results,
+                                         TransactionToken* token) {
   return internal::GetMatchingPaths(this, Env::Default(), pattern, results);
 }
 
-Status PosixFileSystem::DeleteFile(
-    const string& fname /*, TransactionToken* token */) {
+Status PosixFileSystem::DeleteFile(const string& fname,
+                                   TransactionToken* token) {
   Status result;
   if (unlink(TranslateName(fname).c_str()) != 0) {
     result = IOError(fname, errno);
@@ -289,8 +289,7 @@ Status PosixFileSystem::DeleteFile(
   return result;
 }
 
-Status PosixFileSystem::CreateDir(
-    const string& name /*, TransactionToken* token */) {
+Status PosixFileSystem::CreateDir(const string& name, TransactionToken* token) {
   string translated = TranslateName(name);
   if (translated.empty()) {
     return errors::AlreadyExists(name);
@@ -301,8 +300,7 @@ Status PosixFileSystem::CreateDir(
   return Status::OK();
 }
 
-Status PosixFileSystem::DeleteDir(
-    const string& name /*, TransactionToken* token */) {
+Status PosixFileSystem::DeleteDir(const string& name, TransactionToken* token) {
   Status result;
   if (rmdir(TranslateName(name).c_str()) != 0) {
     result = IOError(name, errno);
@@ -310,8 +308,8 @@ Status PosixFileSystem::DeleteDir(
   return result;
 }
 
-Status PosixFileSystem::GetFileSize(
-    const string& fname, uint64* size /*, TransactionToken* token */) {
+Status PosixFileSystem::GetFileSize(const string& fname, uint64* size,
+                                    TransactionToken* token) {
   Status s;
   struct stat sbuf;
   if (stat(TranslateName(fname).c_str(), &sbuf) != 0) {
@@ -323,8 +321,8 @@ Status PosixFileSystem::GetFileSize(
   return s;
 }
 
-Status PosixFileSystem::Stat(
-    const string& fname, FileStatistics* stats /*, TransactionToken* token */) {
+Status PosixFileSystem::Stat(const string& fname, FileStatistics* stats,
+                             TransactionToken* token) {
   Status s;
   struct stat sbuf;
   if (stat(TranslateName(fname).c_str(), &sbuf) != 0) {
@@ -337,8 +335,8 @@ Status PosixFileSystem::Stat(
   return s;
 }
 
-Status PosixFileSystem::RenameFile(
-    const string& src, const string& target /*, TransactionToken* token */) {
+Status PosixFileSystem::RenameFile(const string& src, const string& target,
+                                   TransactionToken* token) {
   Status result;
   if (rename(TranslateName(src).c_str(), TranslateName(target).c_str()) != 0) {
     result = IOError(src, errno);
@@ -346,8 +344,8 @@ Status PosixFileSystem::RenameFile(
   return result;
 }
 
-Status PosixFileSystem::CopyFile(
-    const string& src, const string& target /*, TransactionToken* token */) {
+Status PosixFileSystem::CopyFile(const string& src, const string& target,
+                                 TransactionToken* token) {
   string translated_src = TranslateName(src);
   struct stat sbuf;
   if (stat(translated_src.c_str(), &sbuf) != 0) {

--- a/tensorflow/core/platform/default/posix_file_system.h
+++ b/tensorflow/core/platform/default/posix_file_system.h
@@ -27,63 +27,51 @@ class PosixFileSystem : public FileSystem {
 
   ~PosixFileSystem() {}
 
-  Status NewRandomAccessFile(
-      const string& filename,
-      std::unique_ptr<RandomAccessFile>*
-          result /*, TransactionToken* token = nullptr */) override;
+  Status NewRandomAccessFile(const string& filename,
+                             std::unique_ptr<RandomAccessFile>* result,
+                             TransactionToken* token = nullptr) override;
 
-  Status NewWritableFile(
-      const string& fname,
-      std::unique_ptr<WritableFile>*
-          result /*, TransactionToken* token = nullptr */) override;
+  Status NewWritableFile(const string& fname,
+                         std::unique_ptr<WritableFile>* result,
+                         TransactionToken* token = nullptr) override;
 
-  Status NewAppendableFile(
-      const string& fname,
-      std::unique_ptr<WritableFile>*
-          result /*, TransactionToken* token = nullptr */) override;
+  Status NewAppendableFile(const string& fname,
+                           std::unique_ptr<WritableFile>* result,
+                           TransactionToken* token = nullptr) override;
 
   Status NewReadOnlyMemoryRegionFromFile(
-      const string& filename,
-      std::unique_ptr<ReadOnlyMemoryRegion>*
-          result /*, TransactionToken* token = nullptr */) override;
+      const string& filename, std::unique_ptr<ReadOnlyMemoryRegion>* result,
+      TransactionToken* token = nullptr) override;
 
-  Status FileExists(
-      const string& fname /*, TransactionToken* token = nullptr */) override;
+  Status FileExists(const string& fname,
+                    TransactionToken* token = nullptr) override;
 
-  Status GetChildren(
-      const string& dir,
-      std::vector<string>* result /*, TransactionToken* token = nullptr */)
-      override;
+  Status GetChildren(const string& dir, std::vector<string>* result,
+                     TransactionToken* token = nullptr) override;
 
-  Status Stat(
-      const string& fname,
-      FileStatistics* stats /*, TransactionToken* token = nullptr */) override;
+  Status Stat(const string& fname, FileStatistics* stats,
+              TransactionToken* token = nullptr) override;
 
-  Status GetMatchingPaths(
-      const string& pattern,
-      std::vector<string>* results /*, TransactionToken* token = nullptr */)
-      override;
+  Status GetMatchingPaths(const string& pattern, std::vector<string>* results,
+                          TransactionToken* token = nullptr) override;
 
-  Status DeleteFile(
-      const string& fname /*, TransactionToken* token = nullptr */) override;
+  Status DeleteFile(const string& fname,
+                    TransactionToken* token = nullptr) override;
 
-  Status CreateDir(
-      const string& name /*, TransactionToken* token = nullptr */) override;
+  Status CreateDir(const string& name,
+                   TransactionToken* token = nullptr) override;
 
-  Status DeleteDir(
-      const string& name /*, TransactionToken* token = nullptr */) override;
+  Status DeleteDir(const string& name,
+                   TransactionToken* token = nullptr) override;
 
-  Status GetFileSize(
-      const string& fname,
-      uint64* size /*, TransactionToken* token = nullptr */) override;
+  Status GetFileSize(const string& fname, uint64* size,
+                     TransactionToken* token = nullptr) override;
 
-  Status RenameFile(
-      const string& src,
-      const string& target /*, TransactionToken* token = nullptr */) override;
+  Status RenameFile(const string& src, const string& target,
+                    TransactionToken* token = nullptr) override;
 
-  Status CopyFile(
-      const string& src,
-      const string& target /*, TransactionToken* token = nullptr */) override;
+  Status CopyFile(const string& src, const string& target,
+                  TransactionToken* token = nullptr) override;
 };
 
 Status IOError(const string& context, int err_number);

--- a/tensorflow/core/platform/env_test.cc
+++ b/tensorflow/core/platform/env_test.cc
@@ -295,7 +295,8 @@ TEST_F(DefaultEnvTest, SleepForMicroseconds) {
 
 class TmpDirFileSystem : public NullFileSystem {
  public:
-  Status FileExists(const string& dir) override {
+  Status FileExists(const string& dir,
+                    TransactionToken* token = nullptr) override {
     StringPiece scheme, host, path;
     io::ParseURI(dir, &scheme, &host, &path);
     if (path.empty()) return errors::NotFound(dir, " not found");
@@ -311,7 +312,8 @@ class TmpDirFileSystem : public NullFileSystem {
     return Env::Default()->FileExists(io::JoinPath(BaseDir(), path));
   }
 
-  Status CreateDir(const string& dir) override {
+  Status CreateDir(const string& dir,
+                   TransactionToken* token = nullptr) override {
     StringPiece scheme, host, path;
     io::ParseURI(dir, &scheme, &host, &path);
     if (scheme != "tmpdirfs") {
@@ -328,7 +330,8 @@ class TmpDirFileSystem : public NullFileSystem {
     return status;
   }
 
-  Status IsDirectory(const string& dir) override {
+  Status IsDirectory(const string& dir,
+                     TransactionToken* token = nullptr) override {
     StringPiece scheme, host, path;
     io::ParseURI(dir, &scheme, &host, &path);
     for (const auto& existing_dir : created_directories_)
@@ -336,7 +339,9 @@ class TmpDirFileSystem : public NullFileSystem {
     return errors::NotFound(dir, " not found");
   }
 
-  void FlushCaches() override { flushed_ = true; }
+  void FlushCaches(TransactionToken* token = nullptr) override {
+    flushed_ = true;
+  }
 
  private:
   bool flushed_ = false;

--- a/tensorflow/core/platform/file_system.cc
+++ b/tensorflow/core/platform/file_system.cc
@@ -70,8 +70,7 @@ string FileSystem::TranslateName(const string& name) const {
   return this->CleanPath(path);
 }
 
-Status FileSystem::IsDirectory(
-    const string& name /*, TransactionToken *token */) {
+Status FileSystem::IsDirectory(const string& name, TransactionToken* token) {
   // Check if path exists.
   TF_RETURN_IF_ERROR(FileExists(name));
   FileStatistics stat;
@@ -87,11 +86,11 @@ Status FileSystem::HasAtomicMove(const string& path, bool* has_atomic_move) {
   return Status::OK();
 }
 
-void FileSystem::FlushCaches(/* TransactionToken *token */) {}
+void FileSystem::FlushCaches(TransactionToken* token) {}
 
-bool FileSystem::FilesExist(
-    const std::vector<string>& files,
-    std::vector<Status>* status /*, TransactionToken *token */) {
+bool FileSystem::FilesExist(const std::vector<string>& files,
+                            std::vector<Status>* status,
+                            TransactionToken* token) {
   bool result = true;
   for (const auto& file : files) {
     Status s = FileExists(file);
@@ -106,9 +105,10 @@ bool FileSystem::FilesExist(
   return result;
 }
 
-Status FileSystem::DeleteRecursively(
-    const string& dirname, int64* undeleted_files,
-    int64* undeleted_dirs /*, TransactionToken *token */) {
+Status FileSystem::DeleteRecursively(const string& dirname,
+                                     int64* undeleted_files,
+                                     int64* undeleted_dirs,
+                                     TransactionToken* token) {
   CHECK_NOTNULL(undeleted_files);
   CHECK_NOTNULL(undeleted_dirs);
 
@@ -178,8 +178,8 @@ Status FileSystem::DeleteRecursively(
   return ret;
 }
 
-Status FileSystem::RecursivelyCreateDir(
-    const string& dirname /*, TransactionToken *token */) {
+Status FileSystem::RecursivelyCreateDir(const string& dirname,
+                                        TransactionToken* token) {
   StringPiece scheme, host, remaining_dir;
   this->ParseURI(dirname, &scheme, &host, &remaining_dir);
   std::vector<StringPiece> sub_dirs;
@@ -224,8 +224,8 @@ Status FileSystem::RecursivelyCreateDir(
   return Status::OK();
 }
 
-Status FileSystem::CopyFile(
-    const string& src, const string& target /*, TransactionToken *token */) {
+Status FileSystem::CopyFile(const string& src, const string& target,
+                            TransactionToken* token) {
   return FileSystemCopyFile(this, src, this, target);
 }
 

--- a/tensorflow/core/platform/file_system.h
+++ b/tensorflow/core/platform/file_system.h
@@ -68,9 +68,8 @@ class FileSystem {
   /// The ownership of the returned RandomAccessFile is passed to the caller
   /// and the object should be deleted when is not used.
   virtual tensorflow::Status NewRandomAccessFile(
-      const string& fname,
-      std::unique_ptr<RandomAccessFile>*
-          result /*, TransactionToken* token = nullptr */) = 0;
+      const string& fname, std::unique_ptr<RandomAccessFile>* result,
+      TransactionToken* token = nullptr) = 0;
 
   /// \brief Creates an object that writes to a new file with the specified
   /// name.
@@ -85,9 +84,8 @@ class FileSystem {
   /// The ownership of the returned WritableFile is passed to the caller
   /// and the object should be deleted when is not used.
   virtual tensorflow::Status NewWritableFile(
-      const string& fname,
-      std::unique_ptr<WritableFile>*
-          result /*, TransactionToken* token = nullptr */) = 0;
+      const string& fname, std::unique_ptr<WritableFile>* result,
+      TransactionToken* token = nullptr) = 0;
 
   /// \brief Creates an object that either appends to an existing file, or
   /// writes to a new file (if the file does not exist to begin with).
@@ -101,9 +99,8 @@ class FileSystem {
   /// The ownership of the returned WritableFile is passed to the caller
   /// and the object should be deleted when is not used.
   virtual tensorflow::Status NewAppendableFile(
-      const string& fname,
-      std::unique_ptr<WritableFile>*
-          result /*, TransactionToken* token = nullptr */) = 0;
+      const string& fname, std::unique_ptr<WritableFile>* result,
+      TransactionToken* token = nullptr) = 0;
 
   /// \brief Creates a readonly region of memory with the file context.
   ///
@@ -116,26 +113,26 @@ class FileSystem {
   /// The ownership of the returned ReadOnlyMemoryRegion is passed to the caller
   /// and the object should be deleted when is not used.
   virtual tensorflow::Status NewReadOnlyMemoryRegionFromFile(
-      const string& fname,
-      std::unique_ptr<ReadOnlyMemoryRegion>*
-          result /*, TransactionToken* token = nullptr */) = 0;
+      const string& fname, std::unique_ptr<ReadOnlyMemoryRegion>* result,
+      TransactionToken* token = nullptr) = 0;
 
   /// Returns OK if the named path exists and NOT_FOUND otherwise.
-  virtual tensorflow::Status FileExists(const string& fname) = 0;
+  virtual tensorflow::Status FileExists(const string& fname,
+                                        TransactionToken* token = nullptr) = 0;
 
   /// Returns true if all the listed files exist, false otherwise.
   /// if status is not null, populate the vector with a detailed status
   /// for each file.
-  virtual bool FilesExist(
-      const std::vector<string>& files,
-      std::vector<Status>* status /*, TransactionToken* token = nullptr */);
+  virtual bool FilesExist(const std::vector<string>& files,
+                          std::vector<Status>* status,
+                          TransactionToken* token = nullptr);
 
   /// \brief Returns the immediate children in the given directory.
   ///
   /// The returned paths are relative to 'dir'.
-  virtual tensorflow::Status GetChildren(
-      const string& dir,
-      std::vector<string>* result /*, TransactionToken* token = nullptr */) = 0;
+  virtual tensorflow::Status GetChildren(const string& dir,
+                                         std::vector<string>* result,
+                                         TransactionToken* token = nullptr) = 0;
 
   /// \brief Given a pattern, stores in *results the set of paths that matches
   /// that pattern. *results is cleared.
@@ -160,9 +157,8 @@ class FileSystem {
   ///  * UNIMPLEMENTED - Some underlying functions (like GetChildren) are not
   ///                    implemented
   virtual tensorflow::Status GetMatchingPaths(
-      const string& pattern,
-      std::vector<string>*
-          results /*, TransactionToken* token = nullptr */) = 0;
+      const string& pattern, std::vector<string>* results,
+      TransactionToken* token = nullptr) = 0;
 
   /// \brief Checks if the given filename matches the pattern.
   ///
@@ -172,21 +168,20 @@ class FileSystem {
   virtual bool Match(const std::string& filename, const std::string& pattern);
 
   /// \brief Obtains statistics for the given path.
-  virtual tensorflow::Status Stat(
-      const string& fname,
-      FileStatistics* stat /*, TransactionToken* token = nullptr */) = 0;
+  virtual tensorflow::Status Stat(const string& fname, FileStatistics* stat,
+                                  TransactionToken* token = nullptr) = 0;
 
   /// \brief Deletes the named file.
-  virtual tensorflow::Status DeleteFile(
-      const string& fname /*, TransactionToken* token = nullptr */) = 0;
+  virtual tensorflow::Status DeleteFile(const string& fname,
+                                        TransactionToken* token = nullptr) = 0;
 
   /// \brief Creates the specified directory.
   /// Typical return codes:
   ///  * OK - successfully created the directory.
   ///  * ALREADY_EXISTS - directory with name dirname already exists.
   ///  * PERMISSION_DENIED - dirname is not writable.
-  virtual tensorflow::Status CreateDir(
-      const string& dirname /*, TransactionToken* token = nullptr */) = 0;
+  virtual tensorflow::Status CreateDir(const string& dirname,
+                                       TransactionToken* token = nullptr) = 0;
 
   /// \brief Creates the specified directory and all the necessary
   /// subdirectories.
@@ -195,11 +190,11 @@ class FileSystem {
   ///         they were already created.
   ///  * PERMISSION_DENIED - dirname or some subdirectory is not writable.
   virtual tensorflow::Status RecursivelyCreateDir(
-      const string& dirname /*, TransactionToken* token = nullptr */);
+      const string& dirname, TransactionToken* token = nullptr);
 
   /// \brief Deletes the specified directory.
-  virtual tensorflow::Status DeleteDir(
-      const string& dirname /*, TransactionToken* token = nullptr */) = 0;
+  virtual tensorflow::Status DeleteDir(const string& dirname,
+                                       TransactionToken* token = nullptr) = 0;
 
   /// \brief Deletes the specified directory and all subdirectories and files
   /// underneath it. This is accomplished by traversing the directory tree
@@ -226,23 +221,20 @@ class FileSystem {
   ///  * UNIMPLEMENTED - Some underlying functions (like Delete) are not
   ///                    implemented
   virtual tensorflow::Status DeleteRecursively(
-      const string& dirname, int64* undeleted_files,
-      int64* undeleted_dirs /*, TransactionToken* token = nullptr */);
+      const string& dirname, int64* undeleted_files, int64* undeleted_dirs,
+      TransactionToken* token = nullptr);
 
   /// \brief Stores the size of `fname` in `*file_size`.
-  virtual tensorflow::Status GetFileSize(
-      const string& fname,
-      uint64* file_size /*, TransactionToken* token = nullptr */) = 0;
+  virtual tensorflow::Status GetFileSize(const string& fname, uint64* file_size,
+                                         TransactionToken* token = nullptr) = 0;
 
   /// \brief Overwrites the target if it exists.
-  virtual tensorflow::Status RenameFile(
-      const string& src,
-      const string& target /*, TransactionToken* token = nullptr */) = 0;
+  virtual tensorflow::Status RenameFile(const string& src, const string& target,
+                                        TransactionToken* token = nullptr) = 0;
 
   /// \brief Copy the src to target.
-  virtual tensorflow::Status CopyFile(
-      const string& src,
-      const string& target /*, TransactionToken* token = nullptr */);
+  virtual tensorflow::Status CopyFile(const string& src, const string& target,
+                                      TransactionToken* token = nullptr);
 
   /// \brief Translate an URI to a filename for the FileSystem implementation.
   ///
@@ -262,8 +254,8 @@ class FileSystem {
   ///  * NOT_FOUND - The path entry does not exist.
   ///  * PERMISSION_DENIED - Insufficient permissions.
   ///  * UNIMPLEMENTED - The file factory doesn't support directories.
-  virtual tensorflow::Status IsDirectory(
-      const string& fname /*, TransactionToken* token = nullptr */);
+  virtual tensorflow::Status IsDirectory(const string& fname,
+                                         TransactionToken* token = nullptr);
 
   /// \brief Returns whether the given path is on a file system
   /// that has atomic move capabilities. This can be used
@@ -278,7 +270,7 @@ class FileSystem {
   virtual Status HasAtomicMove(const string& path, bool* has_atomic_move);
 
   /// \brief Flushes any cached filesystem objects from memory.
-  virtual void FlushCaches(/* TransactionToken* token = nullptr */);
+  virtual void FlushCaches(TransactionToken* token = nullptr);
 
   /// \brief The separator this filesystem uses.
   ///
@@ -372,7 +364,7 @@ class FileSystem {
 
   /// \brief Starts a new transaction
   virtual tensorflow::Status StartTransaction(TransactionToken** token) {
-    token = nullptr;
+    *token = nullptr;
     return Status::OK();
   };
 
@@ -391,15 +383,15 @@ class FileSystem {
   /// it.
   virtual tensorflow::Status GetTokenOrStartTransaction(
       const string& path, TransactionToken** token) {
-    token = nullptr;
+    *token = nullptr;
     return Status::OK();
   };
 
   /// \brief Return transaction for `path` or nullptr in `token`
   virtual tensorflow::Status GetTransactionForPath(const string& path,
                                                    TransactionToken** token) {
+    *token = nullptr;
     return Status::OK();
-    token = nullptr;
   };
 
   /// \brief Decode transaction to human readable string.
@@ -423,179 +415,158 @@ class FileSystem {
 class WrappedFileSystem : public FileSystem {
  public:
   virtual tensorflow::Status NewRandomAccessFile(
-      const string& fname, std::unique_ptr<RandomAccessFile>* result
-      /*, TransactionToken* token = nullptr */) /* override */ {
-    return fs_->NewRandomAccessFile(fname,
-                                    result /* , (token ? token : token_) */);
+      const string& fname, std::unique_ptr<RandomAccessFile>* result,
+      TransactionToken* token = nullptr) override {
+    return fs_->NewRandomAccessFile(fname, result, (token ? token : token_));
   }
 
   virtual tensorflow::Status NewWritableFile(
-      const string& fname, std::unique_ptr<WritableFile>* result
-      /*, TransactionToken* token = nullptr */) /* override */ {
-    return fs_->NewWritableFile(fname, result /* , (token ? token : token_) */);
+      const string& fname, std::unique_ptr<WritableFile>* result,
+      TransactionToken* token = nullptr) override {
+    return fs_->NewWritableFile(fname, result, (token ? token : token_));
   }
 
   virtual tensorflow::Status NewAppendableFile(
-      const string& fname, std::unique_ptr<WritableFile>* result
-      /*, TransactionToken* token = nullptr */) /* override */ {
-    return fs_->NewAppendableFile(fname,
-                                  result /* , (token ? token : token_) */);
+      const string& fname, std::unique_ptr<WritableFile>* result,
+      TransactionToken* token = nullptr) override {
+    return fs_->NewAppendableFile(fname, result, (token ? token : token_));
   }
 
   virtual tensorflow::Status NewReadOnlyMemoryRegionFromFile(
-      const string& fname, std::unique_ptr<ReadOnlyMemoryRegion>* result
-      /*, TransactionToken* token = nullptr */) /* override */ {
-    return fs_->NewReadOnlyMemoryRegionFromFile(
-        fname, result /* , (token ? token : token_) */);
+      const string& fname, std::unique_ptr<ReadOnlyMemoryRegion>* result,
+      TransactionToken* token = nullptr) override {
+    return fs_->NewReadOnlyMemoryRegionFromFile(fname, result,
+                                                (token ? token : token_));
   }
 
   virtual tensorflow::Status FileExists(
-      const string&
-          fname /*, TransactionToken* token = nullptr */) /* override */ {
-    return fs_->FileExists(fname /* , (token ? token : token_) */);
+      const string& fname, TransactionToken* token = nullptr) override {
+    return fs_->FileExists(fname, (token ? token : token_));
   }
 
-  virtual bool FilesExist(
-      const std::vector<string>& files, std::vector<Status>* status
-      /*, TransactionToken* token = nullptr */) /* override */ {
-    return fs_->FilesExist(files, status /* , (token ? token : token_) */);
+  virtual bool FilesExist(const std::vector<string>& files,
+                          std::vector<Status>* status,
+                          TransactionToken* token = nullptr) override {
+    return fs_->FilesExist(files, status, (token ? token : token_));
   }
 
   virtual tensorflow::Status GetChildren(
-      const string& dir, std::vector<string>* result
-      /*, TransactionToken* token = nullptr */) /* override */ {
-    return fs_->GetChildren(dir, result /* , (token ? token : token_) */);
+      const string& dir, std::vector<string>* result,
+      TransactionToken* token = nullptr) override {
+    return fs_->GetChildren(dir, result, (token ? token : token_));
   }
 
   virtual tensorflow::Status GetMatchingPaths(
-      const string& pattern, std::vector<string>* results
-      /*, TransactionToken* token = nullptr */) /* override */ {
-    return fs_->GetMatchingPaths(pattern,
-                                 results /* , (token ? token : token_) */);
+      const string& pattern, std::vector<string>* results,
+      TransactionToken* token = nullptr) override {
+    return fs_->GetMatchingPaths(pattern, results, (token ? token : token_));
   }
 
-  virtual bool Match(const std::string& filename, const std::string& pattern
-                     /*, TransactionToken* token = nullptr */) /* override */ {
-    return fs_->Match(filename, pattern /* , (token ? token : token_) */);
+  virtual bool Match(const std::string& filename,
+                     const std::string& pattern) override {
+    return fs_->Match(filename, pattern);
   }
 
-  virtual tensorflow::Status Stat(
-      const string& fname, FileStatistics* stat
-      /*, TransactionToken* token = nullptr */) /* override */ {
-    return fs_->Stat(fname, stat /* , (token ? token : token_) */);
+  virtual tensorflow::Status Stat(const string& fname, FileStatistics* stat,
+                                  TransactionToken* token = nullptr) override {
+    return fs_->Stat(fname, stat, (token ? token : token_));
   }
 
   virtual tensorflow::Status DeleteFile(
-      const string&
-          fname /*, TransactionToken* token = nullptr */) /* override */ {
-    return fs_->DeleteFile(fname /* , (token ? token : token_) */);
+      const string& fname, TransactionToken* token = nullptr) override {
+    return fs_->DeleteFile(fname, (token ? token : token_));
   }
 
   virtual tensorflow::Status CreateDir(
-      const string&
-          dirname /*, TransactionToken* token = nullptr */) /* override */ {
-    return fs_->CreateDir(dirname /* , (token ? token : token_) */);
+      const string& dirname, TransactionToken* token = nullptr) override {
+    return fs_->CreateDir(dirname, (token ? token : token_));
   }
 
   virtual tensorflow::Status RecursivelyCreateDir(
-      const string&
-          dirname /*, TransactionToken* token = nullptr */) /* override */ {
-    return fs_->RecursivelyCreateDir(dirname /* , (token ? token : token_) */);
+      const string& dirname, TransactionToken* token = nullptr) override {
+    return fs_->RecursivelyCreateDir(dirname, (token ? token : token_));
   }
 
   virtual tensorflow::Status DeleteDir(
-      const string&
-          dirname /*, TransactionToken* token = nullptr */) /* override */ {
-    return fs_->DeleteDir(dirname /* , (token ? token : token_) */);
+      const string& dirname, TransactionToken* token = nullptr) override {
+    return fs_->DeleteDir(dirname, (token ? token : token_));
   }
 
   virtual tensorflow::Status DeleteRecursively(
-      const string& dirname, int64* undeleted_files, int64* undeleted_dirs
-      /*, TransactionToken* token = nullptr */) /* override */ {
-    return fs_->DeleteRecursively(
-        dirname, undeleted_files,
-        undeleted_dirs /*, (token ? token : token_) */);
+      const string& dirname, int64* undeleted_files, int64* undeleted_dirs,
+      TransactionToken* token = nullptr) override {
+    return fs_->DeleteRecursively(dirname, undeleted_files, undeleted_dirs,
+                                  (token ? token : token_));
   }
 
   virtual tensorflow::Status GetFileSize(
-      const string& fname, uint64* file_size
-      /*, TransactionToken* token = nullptr */) /* override */ {
-    return fs_->GetFileSize(fname, file_size /* , (token ? token : token_) */);
+      const string& fname, uint64* file_size,
+      TransactionToken* token = nullptr) override {
+    return fs_->GetFileSize(fname, file_size, (token ? token : token_));
   }
 
   virtual tensorflow::Status RenameFile(
-      const string& src, const string& target
-      /*, TransactionToken* token = nullptr */) /* override */ {
-    return fs_->RenameFile(src, target /* , (token ? token : token_) */);
+      const string& src, const string& target,
+      TransactionToken* token = nullptr) override {
+    return fs_->RenameFile(src, target, (token ? token : token_));
   }
 
   virtual tensorflow::Status CopyFile(
-      const string& src, const string& target
-      /*, TransactionToken* token = nullptr */) /* override */ {
-    return fs_->CopyFile(src, target /* , (token ? token : token_) */);
+      const string& src, const string& target,
+      TransactionToken* token = nullptr) override {
+    return fs_->CopyFile(src, target, (token ? token : token_));
   }
 
-  virtual std::string TranslateName(const std::string& name) const
-  /* override */ {
+  virtual std::string TranslateName(const std::string& name) const override {
     return fs_->TranslateName(name);
   }
 
   virtual tensorflow::Status IsDirectory(
-      const string&
-          fname /*, TransactionToken* token = nullptr */) /* override */ {
-    return fs_->IsDirectory(fname /* , (token ? token : token_) */);
+      const string& fname, TransactionToken* token = nullptr) override {
+    return fs_->IsDirectory(fname, (token ? token : token_));
   }
 
   virtual Status HasAtomicMove(const string& path,
-                               bool* has_atomic_move) /* override */ {
+                               bool* has_atomic_move) override {
     return fs_->HasAtomicMove(path, has_atomic_move);
   }
 
-  virtual void FlushCaches(
-      /*TransactionToken* token = nullptr */) /* override */ {
-    return fs_->FlushCaches(/* (token ? token : token_) */);
+  virtual void FlushCaches(TransactionToken* token = nullptr) override {
+    return fs_->FlushCaches((token ? token : token_));
   }
 
-  virtual char Separator() const /* override */ { return fs_->Separator(); }
+  virtual char Separator() const override { return fs_->Separator(); }
 
-  virtual StringPiece Basename(StringPiece path) const /* override */ {
+  virtual StringPiece Basename(StringPiece path) const override {
     return fs_->Basename(path);
   }
 
   virtual tensorflow::Status StartTransaction(
-      TransactionToken** token) /* override */ {
-    /* return fs_->StartTransaction(token); */
-    return Status::OK();
+      TransactionToken** token) override {
+    return fs_->StartTransaction(token);
   }
 
   virtual tensorflow::Status AddToTransaction(
-      const string& path, TransactionToken* token) /* override */ {
-    /* return fs_->AddToTransaction(path, (token ? token : token_) ); */
-    return Status::OK();
+      const string& path, TransactionToken* token) override {
+    return fs_->AddToTransaction(path, (token ? token : token_));
   }
 
-  virtual tensorflow::Status EndTransaction(
-      TransactionToken* token) /* override */ {
-    /* return fs_->EndTransaction(token); */
-    return Status::OK();
+  virtual tensorflow::Status EndTransaction(TransactionToken* token) override {
+    return fs_->EndTransaction(token);
   }
 
   virtual tensorflow::Status GetTransactionForPath(
-      const string& path, TransactionToken** token) /* override */ {
-    /* return fs_->GetTransactionForPath(path, token); */
-    return Status::OK();
+      const string& path, TransactionToken** token) override {
+    return fs_->GetTransactionForPath(path, token);
   }
 
   virtual tensorflow::Status GetTokenOrStartTransaction(
-      const string& path, TransactionToken** token) /* override */ {
-    /* return fs_->GetTokenOrStartTransaction(path, token); */
-    return Status::OK();
+      const string& path, TransactionToken** token) override {
+    return fs_->GetTokenOrStartTransaction(path, token);
   }
 
-  virtual string DecodeTransaction(
-      const TransactionToken* token) /* override */ {
-    return "";
-    /*return fs_->DecodeTransaction((token ? token : token_)); */
+  virtual string DecodeTransaction(const TransactionToken* token) override {
+    return fs_->DecodeTransaction((token ? token : token_));
   }
 
   WrappedFileSystem(FileSystem* file_system, TransactionToken* token)

--- a/tensorflow/core/platform/file_system_test.cc
+++ b/tensorflow/core/platform/file_system_test.cc
@@ -32,7 +32,8 @@ static const char* const kPrefix = "ipfs://solarsystem";
 // cannot have children further.
 class InterPlanetaryFileSystem : public NullFileSystem {
  public:
-  Status FileExists(const string& fname) override {
+  Status FileExists(const string& fname,
+                    TransactionToken* token = nullptr) override {
     string parsed_path;
     ParsePath(fname, &parsed_path);
     if (BodyExists(parsed_path)) {
@@ -42,7 +43,8 @@ class InterPlanetaryFileSystem : public NullFileSystem {
   }
 
   // Adds the dir to the parent's children list and creates an entry for itself.
-  Status CreateDir(const string& dirname) override {
+  Status CreateDir(const string& dirname,
+                   TransactionToken* token = nullptr) override {
     string parsed_path;
     ParsePath(dirname, &parsed_path);
     // If the directory already exists, throw an error.
@@ -88,7 +90,8 @@ class InterPlanetaryFileSystem : public NullFileSystem {
     return Status(tensorflow::error::FAILED_PRECONDITION, "Failed to create");
   }
 
-  Status IsDirectory(const string& dirname) override {
+  Status IsDirectory(const string& dirname,
+                     TransactionToken* token = nullptr) override {
     string parsed_path;
     ParsePath(dirname, &parsed_path);
     // Simulate evil_directory has bad permissions by throwing a LOG(FATAL)
@@ -105,7 +108,8 @@ class InterPlanetaryFileSystem : public NullFileSystem {
     return Status(tensorflow::error::FAILED_PRECONDITION, "Not a dir");
   }
 
-  Status GetChildren(const string& dir, std::vector<string>* result) override {
+  Status GetChildren(const string& dir, std::vector<string>* result,
+                     TransactionToken* token = nullptr) override {
     TF_RETURN_IF_ERROR(IsDirectory(dir));
     string parsed_path;
     ParsePath(dir, &parsed_path);
@@ -273,7 +277,8 @@ TEST(InterPlanetaryFileSystemTest, HasAtomicMove) {
 class TestFileSystem : public NullFileSystem {
  public:
   // Only allow for a single root directory.
-  Status IsDirectory(const string& dirname) override {
+  Status IsDirectory(const string& dirname,
+                     TransactionToken* token = nullptr) override {
     if (dirname == "." || dirname.empty()) {
       return Status::OK();
     }
@@ -281,7 +286,8 @@ class TestFileSystem : public NullFileSystem {
   }
 
   // Simulating a FS with a root dir and a single file underneath it.
-  Status GetChildren(const string& dir, std::vector<string>* result) override {
+  Status GetChildren(const string& dir, std::vector<string>* result,
+                     TransactionToken* token = nullptr) override {
     if (dir == "." || dir.empty()) {
       result->push_back("test");
     }

--- a/tensorflow/core/platform/hadoop/hadoop_file_system.cc
+++ b/tensorflow/core/platform/hadoop/hadoop_file_system.cc
@@ -280,8 +280,8 @@ class HDFSRandomAccessFile : public RandomAccessFile {
 };
 
 Status HadoopFileSystem::NewRandomAccessFile(
-    const string& fname,
-    std::unique_ptr<RandomAccessFile>* result /*, TransactionToken* token */) {
+    const string& fname, std::unique_ptr<RandomAccessFile>* result,
+    TransactionToken* token) {
   hdfsFS fs = nullptr;
   TF_RETURN_IF_ERROR(Connect(fname, &fs));
 
@@ -372,9 +372,9 @@ class HDFSWritableFile : public WritableFile {
   hdfsFile file_;
 };
 
-Status HadoopFileSystem::NewWritableFile(
-    const string& fname,
-    std::unique_ptr<WritableFile>* result /*, TransactionToken* token */) {
+Status HadoopFileSystem::NewWritableFile(const string& fname,
+                                         std::unique_ptr<WritableFile>* result,
+                                         TransactionToken* token) {
   hdfsFS fs = nullptr;
   TF_RETURN_IF_ERROR(Connect(fname, &fs));
 
@@ -388,8 +388,8 @@ Status HadoopFileSystem::NewWritableFile(
 }
 
 Status HadoopFileSystem::NewAppendableFile(
-    const string& fname,
-    std::unique_ptr<WritableFile>* result /*, TransactionToken* token */) {
+    const string& fname, std::unique_ptr<WritableFile>* result,
+    TransactionToken* token) {
   hdfsFS fs = nullptr;
   TF_RETURN_IF_ERROR(Connect(fname, &fs));
 
@@ -403,8 +403,8 @@ Status HadoopFileSystem::NewAppendableFile(
 }
 
 Status HadoopFileSystem::NewReadOnlyMemoryRegionFromFile(
-    const string& fname, std::unique_ptr<ReadOnlyMemoryRegion>*
-                             result /*, TransactionToken* token */) {
+    const string& fname, std::unique_ptr<ReadOnlyMemoryRegion>* result,
+    TransactionToken* token) {
   // hadoopReadZero() technically supports this call with the following
   // caveats:
   // - It only works up to 2 GB. We'd have to Stat() the file to ensure that
@@ -414,8 +414,8 @@ Status HadoopFileSystem::NewReadOnlyMemoryRegionFromFile(
   return errors::Unimplemented("HDFS does not support ReadOnlyMemoryRegion");
 }
 
-Status HadoopFileSystem::FileExists(
-    const string& fname /*, TransactionToken* token */) {
+Status HadoopFileSystem::FileExists(const string& fname,
+                                    TransactionToken* token) {
   hdfsFS fs = nullptr;
   TF_RETURN_IF_ERROR(Connect(fname, &fs));
   if (libhdfs()->hdfsExists(fs, TranslateName(fname).c_str()) == 0) {
@@ -424,9 +424,9 @@ Status HadoopFileSystem::FileExists(
   return errors::NotFound(fname, " not found.");
 }
 
-Status HadoopFileSystem::GetChildren(
-    const string& dir,
-    std::vector<string>* result /*, TransactionToken* token */) {
+Status HadoopFileSystem::GetChildren(const string& dir,
+                                     std::vector<string>* result,
+                                     TransactionToken* token) {
   result->clear();
   hdfsFS fs = nullptr;
   TF_RETURN_IF_ERROR(Connect(dir, &fs));
@@ -453,14 +453,14 @@ Status HadoopFileSystem::GetChildren(
   return Status::OK();
 }
 
-Status HadoopFileSystem::GetMatchingPaths(
-    const string& pattern,
-    std::vector<string>* results /*, TransactionToken* token */) {
+Status HadoopFileSystem::GetMatchingPaths(const string& pattern,
+                                          std::vector<string>* results,
+                                          TransactionToken* token) {
   return internal::GetMatchingPaths(this, Env::Default(), pattern, results);
 }
 
-Status HadoopFileSystem::DeleteFile(
-    const string& fname /*, TransactionToken* token */) {
+Status HadoopFileSystem::DeleteFile(const string& fname,
+                                    TransactionToken* token) {
   hdfsFS fs = nullptr;
   TF_RETURN_IF_ERROR(Connect(fname, &fs));
 
@@ -471,8 +471,7 @@ Status HadoopFileSystem::DeleteFile(
   return Status::OK();
 }
 
-Status HadoopFileSystem::CreateDir(
-    const string& dir /*, TransactionToken* token */) {
+Status HadoopFileSystem::CreateDir(const string& dir, TransactionToken* token) {
   hdfsFS fs = nullptr;
   TF_RETURN_IF_ERROR(Connect(dir, &fs));
 
@@ -482,8 +481,7 @@ Status HadoopFileSystem::CreateDir(
   return Status::OK();
 }
 
-Status HadoopFileSystem::DeleteDir(
-    const string& dir /*, TransactionToken* token */) {
+Status HadoopFileSystem::DeleteDir(const string& dir, TransactionToken* token) {
   hdfsFS fs = nullptr;
   TF_RETURN_IF_ERROR(Connect(dir, &fs));
 
@@ -515,8 +513,8 @@ Status HadoopFileSystem::DeleteDir(
   return Status::OK();
 }
 
-Status HadoopFileSystem::GetFileSize(
-    const string& fname, uint64* size /*, TransactionToken* token */) {
+Status HadoopFileSystem::GetFileSize(const string& fname, uint64* size,
+                                     TransactionToken* token) {
   hdfsFS fs = nullptr;
   TF_RETURN_IF_ERROR(Connect(fname, &fs));
 
@@ -530,8 +528,8 @@ Status HadoopFileSystem::GetFileSize(
   return Status::OK();
 }
 
-Status HadoopFileSystem::RenameFile(
-    const string& src, const string& target /*, TransactionToken* token */) {
+Status HadoopFileSystem::RenameFile(const string& src, const string& target,
+                                    TransactionToken* token) {
   hdfsFS fs = nullptr;
   TF_RETURN_IF_ERROR(Connect(src, &fs));
 
@@ -548,8 +546,8 @@ Status HadoopFileSystem::RenameFile(
   return Status::OK();
 }
 
-Status HadoopFileSystem::Stat(
-    const string& fname, FileStatistics* stats /*, TransactionToken* token */) {
+Status HadoopFileSystem::Stat(const string& fname, FileStatistics* stats,
+                              TransactionToken* token) {
   hdfsFS fs = nullptr;
   TF_RETURN_IF_ERROR(Connect(fname, &fs));
 

--- a/tensorflow/core/platform/hadoop/hadoop_file_system.h
+++ b/tensorflow/core/platform/hadoop/hadoop_file_system.h
@@ -32,63 +32,50 @@ class HadoopFileSystem : public FileSystem {
   HadoopFileSystem();
   ~HadoopFileSystem();
 
-  Status NewRandomAccessFile(
-      const string& fname,
-      std::unique_ptr<RandomAccessFile>*
-          result /*, TransactionToken* token = nullptr*/) override;
+  Status NewRandomAccessFile(const string& fname,
+                             std::unique_ptr<RandomAccessFile>* result,
+                             TransactionToken* token = nullptr) override;
 
-  Status NewWritableFile(
-      const string& fname,
-      std::unique_ptr<WritableFile>*
-          result /*, TransactionToken* token = nullptr*/) override;
+  Status NewWritableFile(const string& fname,
+                         std::unique_ptr<WritableFile>* result,
+                         TransactionToken* token = nullptr) override;
 
-  Status NewAppendableFile(
-      const string& fname,
-      std::unique_ptr<WritableFile>*
-          result /*, TransactionToken* token = nullptr*/) override;
+  Status NewAppendableFile(const string& fname,
+                           std::unique_ptr<WritableFile>* result,
+                           TransactionToken* token = nullptr) override;
 
   Status NewReadOnlyMemoryRegionFromFile(
-      const string& fname,
-      std::unique_ptr<ReadOnlyMemoryRegion>*
-          result /*, TransactionToken* token = nullptr*/) override;
+      const string& fname, std::unique_ptr<ReadOnlyMemoryRegion>* result,
+      TransactionToken* token = nullptr) override;
 
-  Status FileExists(
-      const string& fname /*, TransactionToken* token = nullptr*/) override;
+  Status FileExists(const string& fname,
+                    TransactionToken* token = nullptr) override;
 
-  Status GetChildren(
-      const string& dir,
-      std::vector<string>* result /*, TransactionToken* token = nullptr*/)
-      override;
+  Status GetChildren(const string& dir, std::vector<string>* result,
+                     TransactionToken* token = nullptr) override;
 
-  Status GetMatchingPaths(
-      const string& pattern,
-      std::vector<string>* results /*, TransactionToken* token = nullptr*/)
-      override;
+  Status GetMatchingPaths(const string& pattern, std::vector<string>* results,
+                          TransactionToken* token = nullptr) override;
 
-  Status DeleteFile(
-      const string& fname /*, TransactionToken* token = nullptr*/) override;
+  Status DeleteFile(const string& fname,
+                    TransactionToken* token = nullptr) override;
 
-  Status CreateDir(
-      const string& name /*, TransactionToken* token = nullptr*/) override;
+  Status CreateDir(const string& name,
+                   TransactionToken* token = nullptr) override;
 
-  Status DeleteDir(
-      const string& name /*, TransactionToken* token = nullptr*/) override;
+  Status DeleteDir(const string& name,
+                   TransactionToken* token = nullptr) override;
 
-  Status GetFileSize(
-      const string& fname,
-      uint64* size /*, TransactionToken* token = nullptr*/) override;
+  Status GetFileSize(const string& fname, uint64* size,
+                     TransactionToken* token = nullptr) override;
 
-  Status RenameFile(
-      const string& src,
-      const string& target /*, TransactionToken* token = nullptr*/) override;
+  Status RenameFile(const string& src, const string& target,
+                    TransactionToken* token = nullptr) override;
 
-  Status Stat(
-      const string& fname,
-      FileStatistics* stat /*, TransactionToken* token = nullptr*/) override;
+  Status Stat(const string& fname, FileStatistics* stat,
+              TransactionToken* token = nullptr) override;
 
-  string TranslateName(
-      const string& name /*, TransactionToken* token = nullptr*/)
-      const override;
+  string TranslateName(const string& name) const override;
 
  private:
   Status Connect(StringPiece fname, hdfsFS* fs);

--- a/tensorflow/core/platform/null_file_system.h
+++ b/tensorflow/core/platform/null_file_system.h
@@ -36,84 +36,73 @@ class NullFileSystem : public FileSystem {
 
   ~NullFileSystem() override = default;
 
-  Status NewRandomAccessFile(
-      const string& fname,
-      std::unique_ptr<RandomAccessFile>*
-          result /*, TransactionToken* token = nullptr */) override {
+  Status NewRandomAccessFile(const string& fname,
+                             std::unique_ptr<RandomAccessFile>* result,
+                             TransactionToken* token = nullptr) override {
     return errors::Unimplemented("NewRandomAccessFile unimplemented");
   }
 
-  Status NewWritableFile(
-      const string& fname,
-      std::unique_ptr<WritableFile>*
-          result /*, TransactionToken* token = nullptr */) override {
+  Status NewWritableFile(const string& fname,
+                         std::unique_ptr<WritableFile>* result,
+                         TransactionToken* token = nullptr) override {
     return errors::Unimplemented("NewWritableFile unimplemented");
   }
 
-  Status NewAppendableFile(
-      const string& fname,
-      std::unique_ptr<WritableFile>*
-          result /*, TransactionToken* token = nullptr */) override {
+  Status NewAppendableFile(const string& fname,
+                           std::unique_ptr<WritableFile>* result,
+                           TransactionToken* token = nullptr) override {
     return errors::Unimplemented("NewAppendableFile unimplemented");
   }
 
   Status NewReadOnlyMemoryRegionFromFile(
-      const string& fname,
-      std::unique_ptr<ReadOnlyMemoryRegion>*
-          result /*, TransactionToken* token = nullptr */) override {
+      const string& fname, std::unique_ptr<ReadOnlyMemoryRegion>* result,
+      TransactionToken* token = nullptr) override {
     return errors::Unimplemented(
         "NewReadOnlyMemoryRegionFromFile unimplemented");
   }
 
-  Status FileExists(
-      const string& fname /*, TransactionToken* token = nullptr */) override {
+  Status FileExists(const string& fname,
+                    TransactionToken* token = nullptr) override {
     return errors::Unimplemented("FileExists unimplemented");
   }
 
-  Status GetChildren(
-      const string& dir,
-      std::vector<string>* result /*, TransactionToken* token = nullptr */)
-      override {
+  Status GetChildren(const string& dir, std::vector<string>* result,
+                     TransactionToken* token = nullptr) override {
     return errors::Unimplemented("GetChildren unimplemented");
   }
 
-  Status GetMatchingPaths(
-      const string& pattern,
-      std::vector<string>* results /*, TransactionToken* token = nullptr */)
-      override {
+  Status GetMatchingPaths(const string& pattern, std::vector<string>* results,
+                          TransactionToken* token = nullptr) override {
     return internal::GetMatchingPaths(this, Env::Default(), pattern, results);
   }
 
-  Status DeleteFile(
-      const string& fname /*, TransactionToken* token = nullptr */) override {
+  Status DeleteFile(const string& fname,
+                    TransactionToken* token = nullptr) override {
     return errors::Unimplemented("DeleteFile unimplemented");
   }
 
-  Status CreateDir(
-      const string& dirname /*, TransactionToken* token = nullptr */) override {
+  Status CreateDir(const string& dirname,
+                   TransactionToken* token = nullptr) override {
     return errors::Unimplemented("CreateDir unimplemented");
   }
 
-  Status DeleteDir(
-      const string& dirname /*, TransactionToken* token = nullptr */) override {
+  Status DeleteDir(const string& dirname,
+                   TransactionToken* token = nullptr) override {
     return errors::Unimplemented("DeleteDir unimplemented");
   }
 
-  Status GetFileSize(
-      const string& fname,
-      uint64* file_size /*, TransactionToken* token = nullptr */) override {
+  Status GetFileSize(const string& fname, uint64* file_size,
+                     TransactionToken* token = nullptr) override {
     return errors::Unimplemented("GetFileSize unimplemented");
   }
 
-  Status RenameFile(
-      const string& src,
-      const string& target /*, TransactionToken* token = nullptr */) override {
+  Status RenameFile(const string& src, const string& target,
+                    TransactionToken* token = nullptr) override {
     return errors::Unimplemented("RenameFile unimplemented");
   }
 
-  Status Stat(
-      const string& fname,
-      FileStatistics* stat /*, TransactionToken* token = nullptr */) override {
+  Status Stat(const string& fname, FileStatistics* stat,
+              TransactionToken* token = nullptr) override {
     return errors::Unimplemented("Stat unimplemented");
   }
 };

--- a/tensorflow/core/platform/ram_file_system.h
+++ b/tensorflow/core/platform/ram_file_system.h
@@ -103,10 +103,9 @@ class RamRandomAccessFile : public RandomAccessFile, public WritableFile {
 
 class RamFileSystem : public FileSystem {
  public:
-  Status NewRandomAccessFile(
-      const string& fname,
-      std::unique_ptr<RandomAccessFile>*
-          result /*, TransactionToken* token = nullptr */) override {
+  Status NewRandomAccessFile(const string& fname,
+                             std::unique_ptr<RandomAccessFile>* result,
+                             TransactionToken* token = nullptr) override {
     mutex_lock m(mu_);
     if (fs_.find(fname) == fs_.end()) {
       return errors::NotFound("");
@@ -116,10 +115,9 @@ class RamFileSystem : public FileSystem {
     return Status::OK();
   }
 
-  Status NewWritableFile(
-      const string& fname,
-      std::unique_ptr<WritableFile>*
-          result /*, TransactionToken* token = nullptr */) override {
+  Status NewWritableFile(const string& fname,
+                         std::unique_ptr<WritableFile>* result,
+                         TransactionToken* token = nullptr) override {
     mutex_lock m(mu_);
     if (fs_.find(fname) == fs_.end()) {
       fs_[fname] = std::make_shared<std::string>();
@@ -128,10 +126,9 @@ class RamFileSystem : public FileSystem {
         new RamRandomAccessFile(fname, fs_[fname]));
     return Status::OK();
   }
-  Status NewAppendableFile(
-      const string& fname,
-      std::unique_ptr<WritableFile>*
-          result /*, TransactionToken* token = nullptr */) override {
+  Status NewAppendableFile(const string& fname,
+                           std::unique_ptr<WritableFile>* result,
+                           TransactionToken* token = nullptr) override {
     mutex_lock m(mu_);
     if (fs_.find(fname) == fs_.end()) {
       fs_[fname] = std::make_shared<std::string>();
@@ -142,22 +139,19 @@ class RamFileSystem : public FileSystem {
   }
 
   Status NewReadOnlyMemoryRegionFromFile(
-      const string& fname,
-      std::unique_ptr<ReadOnlyMemoryRegion>*
-          result /*, TransactionToken* token = nullptr */) override {
+      const string& fname, std::unique_ptr<ReadOnlyMemoryRegion>* result,
+      TransactionToken* token = nullptr) override {
     return errors::Unimplemented("");
   }
 
-  Status FileExists(
-      const string& fname /*, TransactionToken* token = nullptr */) override {
+  Status FileExists(const string& fname,
+                    TransactionToken* token = nullptr) override {
     FileStatistics stat;
     return Stat(fname, &stat);
   }
 
-  Status GetChildren(
-      const string& dir,
-      std::vector<string>* result /*, TransactionToken* token = nullptr */)
-      override {
+  Status GetChildren(const string& dir, std::vector<string>* result,
+                     TransactionToken* token = nullptr) override {
     mutex_lock m(mu_);
     auto it = fs_.lower_bound(dir);
     while (it != fs_.end() && absl::StartsWith(it->first, dir)) {
@@ -168,10 +162,8 @@ class RamFileSystem : public FileSystem {
     return Status::OK();
   }
 
-  Status GetMatchingPaths(
-      const string& pattern,
-      std::vector<string>* results /*, TransactionToken* token = nullptr */)
-      override {
+  Status GetMatchingPaths(const string& pattern, std::vector<string>* results,
+                          TransactionToken* token = nullptr) override {
     mutex_lock m(mu_);
     Env* env = Env::Default();
     for (auto it = fs_.begin(); it != fs_.end(); ++it) {
@@ -182,9 +174,8 @@ class RamFileSystem : public FileSystem {
     return Status::OK();
   }
 
-  Status Stat(
-      const string& fname,
-      FileStatistics* stat /*, TransactionToken* token = nullptr */) override {
+  Status Stat(const string& fname, FileStatistics* stat,
+              TransactionToken* token = nullptr) override {
     mutex_lock m(mu_);
     auto it = fs_.lower_bound(fname);
     if (it == fs_.end()) {
@@ -204,8 +195,8 @@ class RamFileSystem : public FileSystem {
     return Status::OK();
   }
 
-  Status DeleteFile(
-      const string& fname /*, TransactionToken* token = nullptr */) override {
+  Status DeleteFile(const string& fname,
+                    TransactionToken* token = nullptr) override {
     mutex_lock m(mu_);
     if (fs_.find(fname) != fs_.end()) {
       fs_.erase(fname);
@@ -215,24 +206,23 @@ class RamFileSystem : public FileSystem {
     return errors::NotFound("");
   }
 
-  Status CreateDir(
-      const string& dirname /*, TransactionToken* token = nullptr */) override {
+  Status CreateDir(const string& dirname,
+                   TransactionToken* token = nullptr) override {
     return Status::OK();
   }
 
-  Status RecursivelyCreateDir(
-      const string& dirname /*, TransactionToken* token = nullptr */) override {
+  Status RecursivelyCreateDir(const string& dirname,
+                              TransactionToken* token = nullptr) override {
     return Status::OK();
   }
 
-  Status DeleteDir(
-      const string& dirname /*, TransactionToken* token = nullptr */) override {
+  Status DeleteDir(const string& dirname,
+                   TransactionToken* token = nullptr) override {
     return Status::OK();
   }
 
-  Status GetFileSize(
-      const string& fname,
-      uint64* file_size /*, TransactionToken* token = nullptr */) override {
+  Status GetFileSize(const string& fname, uint64* file_size,
+                     TransactionToken* token = nullptr) override {
     mutex_lock m(mu_);
     if (fs_.find(fname) != fs_.end()) {
       *file_size = fs_[fname]->size();
@@ -241,9 +231,8 @@ class RamFileSystem : public FileSystem {
     return errors::NotFound("");
   }
 
-  Status RenameFile(
-      const string& src,
-      const string& target /*, TransactionToken* token = nullptr */) override {
+  Status RenameFile(const string& src, const string& target,
+                    TransactionToken* token = nullptr) override {
     mutex_lock m(mu_);
     if (fs_.find(src) != fs_.end()) {
       fs_[target] = fs_[src];

--- a/tensorflow/core/platform/retrying_file_system.h
+++ b/tensorflow/core/platform/retrying_file_system.h
@@ -38,37 +38,31 @@ class RetryingFileSystem : public FileSystem {
       : base_file_system_(std::move(base_file_system)),
         retry_config_(retry_config) {}
 
-  Status NewRandomAccessFile(
-      const string& filename,
-      std::unique_ptr<RandomAccessFile>*
-          result /*, TransactionToken* token = nullptr */) override;
+  Status NewRandomAccessFile(const string& filename,
+                             std::unique_ptr<RandomAccessFile>* result,
+                             TransactionToken* token = nullptr) override;
 
-  Status NewWritableFile(
-      const string& filename,
-      std::unique_ptr<WritableFile>*
-          result /*, TransactionToken* token = nullptr */) override;
+  Status NewWritableFile(const string& filename,
+                         std::unique_ptr<WritableFile>* result,
+                         TransactionToken* token = nullptr) override;
 
-  Status NewAppendableFile(
-      const string& filename,
-      std::unique_ptr<WritableFile>*
-          result /*, TransactionToken* token = nullptr */) override;
+  Status NewAppendableFile(const string& filename,
+                           std::unique_ptr<WritableFile>* result,
+                           TransactionToken* token = nullptr) override;
 
   Status NewReadOnlyMemoryRegionFromFile(
-      const string& filename,
-      std::unique_ptr<ReadOnlyMemoryRegion>*
-          result /*, TransactionToken* token = nullptr */) override;
+      const string& filename, std::unique_ptr<ReadOnlyMemoryRegion>* result,
+      TransactionToken* token = nullptr) override;
 
-  Status FileExists(
-      const string& fname /*, TransactionToken* token = nullptr */) override {
+  Status FileExists(const string& fname,
+                    TransactionToken* token = nullptr) override {
     return RetryingUtils::CallWithRetries(
         [this, &fname]() { return base_file_system_->FileExists(fname); },
         retry_config_);
   }
 
-  Status GetChildren(
-      const string& dir,
-      std::vector<string>* result /*, TransactionToken* token = nullptr */)
-      override {
+  Status GetChildren(const string& dir, std::vector<string>* result,
+                     TransactionToken* token = nullptr) override {
     return RetryingUtils::CallWithRetries(
         [this, &dir, result]() {
           return base_file_system_->GetChildren(dir, result);
@@ -76,10 +70,8 @@ class RetryingFileSystem : public FileSystem {
         retry_config_);
   }
 
-  Status GetMatchingPaths(
-      const string& pattern,
-      std::vector<string>* result /*, TransactionToken* token = nullptr */)
-      override {
+  Status GetMatchingPaths(const string& pattern, std::vector<string>* result,
+                          TransactionToken* token = nullptr) override {
     return RetryingUtils::CallWithRetries(
         [this, &pattern, result]() {
           return base_file_system_->GetMatchingPaths(pattern, result);
@@ -87,38 +79,36 @@ class RetryingFileSystem : public FileSystem {
         retry_config_);
   }
 
-  Status Stat(
-      const string& fname,
-      FileStatistics* stat /*, TransactionToken* token = nullptr */) override {
+  Status Stat(const string& fname, FileStatistics* stat,
+              TransactionToken* token = nullptr) override {
     return RetryingUtils::CallWithRetries(
         [this, &fname, stat]() { return base_file_system_->Stat(fname, stat); },
         retry_config_);
   }
 
-  Status DeleteFile(
-      const string& fname /*, TransactionToken* token = nullptr */) override {
+  Status DeleteFile(const string& fname,
+                    TransactionToken* token = nullptr) override {
     return RetryingUtils::DeleteWithRetries(
         [this, &fname]() { return base_file_system_->DeleteFile(fname); },
         retry_config_);
   }
 
-  Status CreateDir(
-      const string& dirname /*, TransactionToken* token = nullptr */) override {
+  Status CreateDir(const string& dirname,
+                   TransactionToken* token = nullptr) override {
     return RetryingUtils::CallWithRetries(
         [this, &dirname]() { return base_file_system_->CreateDir(dirname); },
         retry_config_);
   }
 
-  Status DeleteDir(
-      const string& dirname /*, TransactionToken* token = nullptr */) override {
+  Status DeleteDir(const string& dirname,
+                   TransactionToken* token = nullptr) override {
     return RetryingUtils::DeleteWithRetries(
         [this, &dirname]() { return base_file_system_->DeleteDir(dirname); },
         retry_config_);
   }
 
-  Status GetFileSize(
-      const string& fname,
-      uint64* file_size /*, TransactionToken* token = nullptr */) override {
+  Status GetFileSize(const string& fname, uint64* file_size,
+                     TransactionToken* token = nullptr) override {
     return RetryingUtils::CallWithRetries(
         [this, &fname, file_size]() {
           return base_file_system_->GetFileSize(fname, file_size);
@@ -126,9 +116,8 @@ class RetryingFileSystem : public FileSystem {
         retry_config_);
   }
 
-  Status RenameFile(
-      const string& src,
-      const string& target /*, TransactionToken* token = nullptr */) override {
+  Status RenameFile(const string& src, const string& target,
+                    TransactionToken* token = nullptr) override {
     return RetryingUtils::CallWithRetries(
         [this, &src, &target]() {
           return base_file_system_->RenameFile(src, target);
@@ -136,8 +125,8 @@ class RetryingFileSystem : public FileSystem {
         retry_config_);
   }
 
-  Status IsDirectory(
-      const string& dirname /*, TransactionToken* token = nullptr */) override {
+  Status IsDirectory(const string& dirname,
+                     TransactionToken* token = nullptr) override {
     return RetryingUtils::CallWithRetries(
         [this, &dirname]() { return base_file_system_->IsDirectory(dirname); },
         retry_config_);
@@ -148,9 +137,9 @@ class RetryingFileSystem : public FileSystem {
     return base_file_system_->HasAtomicMove(path, has_atomic_move);
   }
 
-  Status DeleteRecursively(
-      const string& dirname, int64* undeleted_files,
-      int64* undeleted_dirs /*, TransactionToken* token = nullptr */) override {
+  Status DeleteRecursively(const string& dirname, int64* undeleted_files,
+                           int64* undeleted_dirs,
+                           TransactionToken* token = nullptr) override {
     return RetryingUtils::DeleteWithRetries(
         [this, &dirname, undeleted_files, undeleted_dirs]() {
           return base_file_system_->DeleteRecursively(dirname, undeleted_files,
@@ -159,7 +148,7 @@ class RetryingFileSystem : public FileSystem {
         retry_config_);
   }
 
-  void FlushCaches(/* TransactionToken* token=nullptr */) override {
+  void FlushCaches(TransactionToken* token=nullptr) override {
     base_file_system_->FlushCaches();
   }
 
@@ -243,8 +232,8 @@ class RetryingWritableFile : public WritableFile {
 
 template <typename Underlying>
 Status RetryingFileSystem<Underlying>::NewRandomAccessFile(
-    const string& filename,
-    std::unique_ptr<RandomAccessFile>* result /*, TransactionToken* token */) {
+    const string& filename, std::unique_ptr<RandomAccessFile>* result,
+    TransactionToken* token) {
   std::unique_ptr<RandomAccessFile> base_file;
   TF_RETURN_IF_ERROR(RetryingUtils::CallWithRetries(
       [this, &filename, &base_file]() {
@@ -258,8 +247,8 @@ Status RetryingFileSystem<Underlying>::NewRandomAccessFile(
 
 template <typename Underlying>
 Status RetryingFileSystem<Underlying>::NewWritableFile(
-    const string& filename,
-    std::unique_ptr<WritableFile>* result /*, TransactionToken* token */) {
+    const string& filename, std::unique_ptr<WritableFile>* result,
+    TransactionToken* token) {
   std::unique_ptr<WritableFile> base_file;
   TF_RETURN_IF_ERROR(RetryingUtils::CallWithRetries(
       [this, &filename, &base_file]() {
@@ -273,8 +262,8 @@ Status RetryingFileSystem<Underlying>::NewWritableFile(
 
 template <typename Underlying>
 Status RetryingFileSystem<Underlying>::NewAppendableFile(
-    const string& filename,
-    std::unique_ptr<WritableFile>* result /*, TransactionToken* token */) {
+    const string& filename, std::unique_ptr<WritableFile>* result,
+    TransactionToken* token) {
   std::unique_ptr<WritableFile> base_file;
   TF_RETURN_IF_ERROR(RetryingUtils::CallWithRetries(
       [this, &filename, &base_file]() {
@@ -288,8 +277,8 @@ Status RetryingFileSystem<Underlying>::NewAppendableFile(
 
 template <typename Underlying>
 Status RetryingFileSystem<Underlying>::NewReadOnlyMemoryRegionFromFile(
-    const string& filename, std::unique_ptr<ReadOnlyMemoryRegion>*
-                                result /*, TransactionToken* token */) {
+    const string& filename, std::unique_ptr<ReadOnlyMemoryRegion>* result,
+    TransactionToken* token) {
   return RetryingUtils::CallWithRetries(
       [this, &filename, result]() {
         return base_file_system_->NewReadOnlyMemoryRegionFromFile(filename,

--- a/tensorflow/core/platform/retrying_file_system_test.cc
+++ b/tensorflow/core/platform/retrying_file_system_test.cc
@@ -102,7 +102,7 @@ class MockFileSystem : public FileSystem {
   Status NewRandomAccessFile(
       const string& fname,
       std::unique_ptr<RandomAccessFile>*
-          result /*, TransactionToken* token = nullptr */) override {
+          result , TransactionToken* token = nullptr ) override {
     *result = std::move(random_access_file_to_return);
     return calls_.ConsumeNextCall("NewRandomAccessFile");
   }
@@ -110,7 +110,7 @@ class MockFileSystem : public FileSystem {
   Status NewWritableFile(
       const string& fname,
       std::unique_ptr<WritableFile>*
-          result /*, TransactionToken* token = nullptr */) override {
+          result , TransactionToken* token = nullptr ) override {
     *result = std::move(writable_file_to_return);
     return calls_.ConsumeNextCall("NewWritableFile");
   }
@@ -118,7 +118,7 @@ class MockFileSystem : public FileSystem {
   Status NewAppendableFile(
       const string& fname,
       std::unique_ptr<WritableFile>*
-          result /*, TransactionToken* token = nullptr */) override {
+          result , TransactionToken* token = nullptr ) override {
     *result = std::move(writable_file_to_return);
     return calls_.ConsumeNextCall("NewAppendableFile");
   }
@@ -126,74 +126,74 @@ class MockFileSystem : public FileSystem {
   Status NewReadOnlyMemoryRegionFromFile(
       const string& fname,
       std::unique_ptr<ReadOnlyMemoryRegion>*
-          result /*, TransactionToken* token = nullptr */) override {
+          result , TransactionToken* token = nullptr ) override {
     return calls_.ConsumeNextCall("NewReadOnlyMemoryRegionFromFile");
   }
 
   Status FileExists(
-      const string& fname /*, TransactionToken* token = nullptr */) override {
+      const string& fname , TransactionToken* token = nullptr ) override {
     return calls_.ConsumeNextCall("FileExists");
   }
 
   Status GetChildren(
       const string& dir,
-      std::vector<string>* result /*, TransactionToken* token = nullptr */)
+      std::vector<string>* result , TransactionToken* token = nullptr )
       override {
     return calls_.ConsumeNextCall("GetChildren");
   }
 
   Status GetMatchingPaths(
       const string& dir,
-      std::vector<string>* result /*, TransactionToken* token = nullptr */)
+      std::vector<string>* result , TransactionToken* token = nullptr )
       override {
     return calls_.ConsumeNextCall("GetMatchingPaths");
   }
 
   Status Stat(
       const string& fname,
-      FileStatistics* stat /*, TransactionToken* token = nullptr */) override {
+      FileStatistics* stat , TransactionToken* token = nullptr ) override {
     return calls_.ConsumeNextCall("Stat");
   }
 
   Status DeleteFile(
-      const string& fname /*, TransactionToken* token = nullptr */) override {
+      const string& fname , TransactionToken* token = nullptr ) override {
     return calls_.ConsumeNextCall("DeleteFile");
   }
 
   Status CreateDir(
-      const string& dirname /*, TransactionToken* token = nullptr */) override {
+      const string& dirname , TransactionToken* token = nullptr ) override {
     return calls_.ConsumeNextCall("CreateDir");
   }
 
   Status DeleteDir(
-      const string& dirname /*, TransactionToken* token = nullptr */) override {
+      const string& dirname , TransactionToken* token = nullptr ) override {
     return calls_.ConsumeNextCall("DeleteDir");
   }
 
   Status GetFileSize(
       const string& fname,
-      uint64* file_size /*, TransactionToken* token = nullptr */) override {
+      uint64* file_size , TransactionToken* token = nullptr ) override {
     return calls_.ConsumeNextCall("GetFileSize");
   }
 
   Status RenameFile(
       const string& src,
-      const string& target /*, TransactionToken* token = nullptr */) override {
+      const string& target , TransactionToken* token = nullptr ) override {
     return calls_.ConsumeNextCall("RenameFile");
   }
 
   Status IsDirectory(
-      const string& dirname /*, TransactionToken* token = nullptr */) override {
+      const string& dirname , TransactionToken* token = nullptr ) override {
     return calls_.ConsumeNextCall("IsDirectory");
   }
 
   Status DeleteRecursively(
       const string& dirname, int64* undeleted_files,
-      int64* undeleted_dirs /*, TransactionToken* token = nullptr */) override {
+      int64* undeleted_dirs , TransactionToken* token = nullptr ) override {
     return calls_.ConsumeNextCall("DeleteRecursively");
   }
 
-  void FlushCaches(/* TransactionToken* token=nullptr */) override {
+  void FlushCaches(TransactionToken* token=nullptr) override {
     if (flushed_) {
       *flushed_ = true;
     }

--- a/tensorflow/core/platform/s3/s3_file_system.cc
+++ b/tensorflow/core/platform/s3/s3_file_system.cc
@@ -58,7 +58,7 @@ static const char* kS3TempFileTemplate = "/tmp/s3_filesystem_XXXXXX";
 #endif
 static const char* kS3FileSystemAllocationTag = "S3FileSystemAllocation";
 static const size_t kS3ReadAppendableFileBufferSize = 1024 * 1024;
-static const int64 kS3TimeoutMsec = 300000;                       // 5 min
+static const int64 kS3TimeoutMsec = 300000;                           // 5 min
 static const uint64 kS3MultiPartUploadChunkSize = 50 * 1024 * 1024;   // 50 MB
 static const uint64 kS3MultiPartDownloadChunkSize = 2 * 1024 * 1024;  // 50 MB
 static const int kS3GetChildrenMaxKeys = 100;
@@ -568,14 +568,14 @@ S3FileSystem::GetExecutor() {
 }
 
 Status S3FileSystem::NewRandomAccessFile(
-    const string& fname,
-    std::unique_ptr<RandomAccessFile>* result /*, TransactionToken* token */) {
+    const string& fname, std::unique_ptr<RandomAccessFile>* result,
+    TransactionToken* token) {
   return NewRandomAccessFile(fname, result, true);
 }
 
 Status S3FileSystem::NewRandomAccessFile(
     const string& fname, std::unique_ptr<RandomAccessFile>* result,
-    bool use_multi_part_download /*, TransactionToken* token */) {
+    bool use_multi_part_download, TransactionToken* token) {
   string bucket, object;
   TF_RETURN_IF_ERROR(ParseS3Path(fname, false, &bucket, &object));
 
@@ -588,9 +588,9 @@ Status S3FileSystem::NewRandomAccessFile(
   return Status::OK();
 }
 
-Status S3FileSystem::NewWritableFile(
-    const string& fname,
-    std::unique_ptr<WritableFile>* result /*, TransactionToken* token */) {
+Status S3FileSystem::NewWritableFile(const string& fname,
+                                     std::unique_ptr<WritableFile>* result,
+                                     TransactionToken* token) {
   string bucket, object;
   TF_RETURN_IF_ERROR(ParseS3Path(fname, false, &bucket, &object));
   result->reset(new S3WritableFile(
@@ -601,9 +601,9 @@ Status S3FileSystem::NewWritableFile(
   return Status::OK();
 }
 
-Status S3FileSystem::NewAppendableFile(
-    const string& fname,
-    std::unique_ptr<WritableFile>* result /*, TransactionToken* token */) {
+Status S3FileSystem::NewAppendableFile(const string& fname,
+                                       std::unique_ptr<WritableFile>* result,
+                                       TransactionToken* token) {
   std::unique_ptr<RandomAccessFile> reader;
   TF_RETURN_IF_ERROR(NewRandomAccessFile(fname, &reader));
   std::unique_ptr<char[]> buffer(new char[kS3ReadAppendableFileBufferSize]);
@@ -637,8 +637,8 @@ Status S3FileSystem::NewAppendableFile(
 }
 
 Status S3FileSystem::NewReadOnlyMemoryRegionFromFile(
-    const string& fname, std::unique_ptr<ReadOnlyMemoryRegion>*
-                             result /*, TransactionToken* token */) {
+    const string& fname, std::unique_ptr<ReadOnlyMemoryRegion>* result,
+    TransactionToken* token) {
   uint64 size;
   TF_RETURN_IF_ERROR(GetFileSize(fname, &size));
   std::unique_ptr<char[]> data(new char[size]);
@@ -653,16 +653,14 @@ Status S3FileSystem::NewReadOnlyMemoryRegionFromFile(
   return Status::OK();
 }
 
-Status S3FileSystem::FileExists(
-    const string& fname /*, TransactionToken* token */) {
+Status S3FileSystem::FileExists(const string& fname, TransactionToken* token) {
   FileStatistics stats;
   TF_RETURN_IF_ERROR(this->Stat(fname, &stats));
   return Status::OK();
 }
 
-Status S3FileSystem::GetChildren(
-    const string& dir,
-    std::vector<string>* result /*, TransactionToken* token */) {
+Status S3FileSystem::GetChildren(const string& dir, std::vector<string>* result,
+                                 TransactionToken* token) {
   VLOG(1) << "GetChildren for path: " << dir;
   string bucket, prefix;
   TF_RETURN_IF_ERROR(ParseS3Path(dir, true, &bucket, &prefix));
@@ -709,8 +707,8 @@ Status S3FileSystem::GetChildren(
   return Status::OK();
 }
 
-Status S3FileSystem::Stat(
-    const string& fname, FileStatistics* stats /*, TransactionToken* token */) {
+Status S3FileSystem::Stat(const string& fname, FileStatistics* stats,
+                          TransactionToken* token) {
   VLOG(1) << "Stat on path: " << fname;
   string bucket, object;
   TF_RETURN_IF_ERROR(ParseS3Path(fname, true, &bucket, &object));
@@ -772,14 +770,13 @@ Status S3FileSystem::Stat(
   return Status::OK();
 }
 
-Status S3FileSystem::GetMatchingPaths(
-    const string& pattern,
-    std::vector<string>* results /*, TransactionToken* token */) {
+Status S3FileSystem::GetMatchingPaths(const string& pattern,
+                                      std::vector<string>* results,
+                                      TransactionToken* token) {
   return internal::GetMatchingPaths(this, Env::Default(), pattern, results);
 }
 
-Status S3FileSystem::DeleteFile(
-    const string& fname /*, TransactionToken* token */) {
+Status S3FileSystem::DeleteFile(const string& fname, TransactionToken* token) {
   VLOG(1) << "DeleteFile: " << fname;
   string bucket, object;
   TF_RETURN_IF_ERROR(ParseS3Path(fname, false, &bucket, &object));
@@ -795,8 +792,7 @@ Status S3FileSystem::DeleteFile(
   return Status::OK();
 }
 
-Status S3FileSystem::CreateDir(
-    const string& dirname /*, TransactionToken* token */) {
+Status S3FileSystem::CreateDir(const string& dirname, TransactionToken* token) {
   VLOG(1) << "CreateDir: " << dirname;
   string bucket, object;
   TF_RETURN_IF_ERROR(ParseS3Path(dirname, true, &bucket, &object));
@@ -823,8 +819,7 @@ Status S3FileSystem::CreateDir(
   return Status::OK();
 }
 
-Status S3FileSystem::DeleteDir(
-    const string& dirname /*, TransactionToken* token */) {
+Status S3FileSystem::DeleteDir(const string& dirname, TransactionToken* token) {
   VLOG(1) << "DeleteDir: " << dirname;
   string bucket, object;
   TF_RETURN_IF_ERROR(ParseS3Path(dirname, false, &bucket, &object));
@@ -863,8 +858,8 @@ Status S3FileSystem::DeleteDir(
   return Status::OK();
 }
 
-Status S3FileSystem::GetFileSize(
-    const string& fname, uint64* file_size /*, TransactionToken* token */) {
+Status S3FileSystem::GetFileSize(const string& fname, uint64* file_size,
+                                 TransactionToken* token) {
   FileStatistics stats;
   TF_RETURN_IF_ERROR(this->Stat(fname, &stats));
   *file_size = stats.length;
@@ -1135,8 +1130,8 @@ Status S3FileSystem::CompleteMultiPartCopy(
   return Status::OK();
 }
 
-Status S3FileSystem::RenameFile(
-    const string& src, const string& target /*, TransactionToken* token */) {
+Status S3FileSystem::RenameFile(const string& src, const string& target,
+                                TransactionToken* token) {
   VLOG(1) << "RenameFile from: " << src << " to: " << target;
   string src_bucket, src_object, target_bucket, target_object;
   TF_RETURN_IF_ERROR(ParseS3Path(src, false, &src_bucket, &src_object));

--- a/tensorflow/core/platform/s3/s3_file_system.h
+++ b/tensorflow/core/platform/s3/s3_file_system.h
@@ -49,67 +49,55 @@ class S3FileSystem : public FileSystem {
   S3FileSystem();
   ~S3FileSystem();
 
-  Status NewRandomAccessFile(
-      const string& fname,
-      std::unique_ptr<RandomAccessFile>*
-          result /*, TransactionToken* token = nullptr */) override;
+  Status NewRandomAccessFile(const string& fname,
+                             std::unique_ptr<RandomAccessFile>* result,
+                             TransactionToken* token = nullptr) override;
 
-  Status NewRandomAccessFile(
-      const string& fname, std::unique_ptr<RandomAccessFile>* result,
-      bool use_multi_part_download /*, TransactionToken* token = nullptr */);
+  Status NewRandomAccessFile(const string& fname,
+                             std::unique_ptr<RandomAccessFile>* result,
+                             bool use_multi_part_download,
+                             TransactionToken* token = nullptr);
 
-  Status NewWritableFile(
-      const string& fname,
-      std::unique_ptr<WritableFile>*
-          result /*, TransactionToken* token = nullptr */) override;
+  Status NewWritableFile(const string& fname,
+                         std::unique_ptr<WritableFile>* result,
+                         TransactionToken* token = nullptr) override;
 
-  Status NewAppendableFile(
-      const string& fname,
-      std::unique_ptr<WritableFile>*
-          result /*, TransactionToken* token = nullptr */) override;
+  Status NewAppendableFile(const string& fname,
+                           std::unique_ptr<WritableFile>* result,
+                           TransactionToken* token = nullptr) override;
 
   Status NewReadOnlyMemoryRegionFromFile(
-      const string& fname,
-      std::unique_ptr<ReadOnlyMemoryRegion>*
-          result /*, TransactionToken* token = nullptr */) override;
+      const string& fname, std::unique_ptr<ReadOnlyMemoryRegion>* result,
+      TransactionToken* token = nullptr) override;
 
-  Status FileExists(
-      const string& fname /*, TransactionToken* token = nullptr */) override;
+  Status FileExists(const string& fname,
+                    TransactionToken* token = nullptr) override;
 
-  Status GetChildren(
-      const string& dir,
-      std::vector<string>* result /*, TransactionToken* token = nullptr */)
-      override;
+  Status GetChildren(const string& dir, std::vector<string>* result,
+                     TransactionToken* token = nullptr) override;
 
-  Status Stat(
-      const string& fname,
-      FileStatistics* stat /*, TransactionToken* token = nullptr */) override;
+  Status Stat(const string& fname, FileStatistics* stat,
+              TransactionToken* token = nullptr) override;
 
-  Status GetMatchingPaths(
-      const string& pattern,
-      std::vector<string>* results /*, TransactionToken* token = nullptr */)
-      override;
+  Status GetMatchingPaths(const string& pattern, std::vector<string>* results,
+                          TransactionToken* token = nullptr) override;
 
-  Status DeleteFile(
-      const string& fname /*, TransactionToken* token = nullptr */) override;
+  Status DeleteFile(const string& fname,
+                    TransactionToken* token = nullptr) override;
 
-  Status CreateDir(
-      const string& name /*, TransactionToken* token = nullptr */) override;
+  Status CreateDir(const string& name,
+                   TransactionToken* token = nullptr) override;
 
-  Status DeleteDir(
-      const string& name /*, TransactionToken* token = nullptr */) override;
+  Status DeleteDir(const string& name,
+                   TransactionToken* token = nullptr) override;
 
-  Status GetFileSize(
-      const string& fname,
-      uint64* size /*, TransactionToken* token = nullptr */) override;
+  Status GetFileSize(const string& fname, uint64* size,
+                     TransactionToken* token = nullptr) override;
 
-  Status RenameFile(
-      const string& src,
-      const string& target /*, TransactionToken* token = nullptr */) override;
+  Status RenameFile(const string& src, const string& target,
+                    TransactionToken* token = nullptr) override;
 
-  Status HasAtomicMove(
-      const string& path,
-      bool* has_atomic_move /*, TransactionToken* token = nullptr */) override;
+  Status HasAtomicMove(const string& path, bool* has_atomic_move) override;
 
  private:
   // Returns the member S3 client, initializing as-needed.

--- a/tensorflow/core/platform/windows/windows_file_system.cc
+++ b/tensorflow/core/platform/windows/windows_file_system.cc
@@ -261,8 +261,8 @@ class WinReadOnlyMemoryRegion : public ReadOnlyMemoryRegion {
 }  // namespace
 
 Status WindowsFileSystem::NewRandomAccessFile(
-    const string& fname,
-    std::unique_ptr<RandomAccessFile>* result /*, TransactionToken* token */) {
+    const string& fname, std::unique_ptr<RandomAccessFile>* result,
+    TransactionToken* token) {
   string translated_fname = TranslateName(fname);
   std::wstring ws_translated_fname = Utf8ToWideChar(translated_fname);
   result->reset();
@@ -288,9 +288,9 @@ Status WindowsFileSystem::NewRandomAccessFile(
   return Status::OK();
 }
 
-Status WindowsFileSystem::NewWritableFile(
-    const string& fname,
-    std::unique_ptr<WritableFile>* result /*, TransactionToken* token */) {
+Status WindowsFileSystem::NewWritableFile(const string& fname,
+                                          std::unique_ptr<WritableFile>* result,
+                                          TransactionToken* token) {
   string translated_fname = TranslateName(fname);
   std::wstring ws_translated_fname = Utf8ToWideChar(translated_fname);
   result->reset();
@@ -310,8 +310,8 @@ Status WindowsFileSystem::NewWritableFile(
 }
 
 Status WindowsFileSystem::NewAppendableFile(
-    const string& fname,
-    std::unique_ptr<WritableFile>* result /*, TransactionToken* token */) {
+    const string& fname, std::unique_ptr<WritableFile>* result,
+    TransactionToken* token) {
   string translated_fname = TranslateName(fname);
   std::wstring ws_translated_fname = Utf8ToWideChar(translated_fname);
   result->reset();
@@ -341,8 +341,8 @@ Status WindowsFileSystem::NewAppendableFile(
 }
 
 Status WindowsFileSystem::NewReadOnlyMemoryRegionFromFile(
-    const string& fname, std::unique_ptr<ReadOnlyMemoryRegion>*
-                             result /*, TransactionToken* token */) {
+    const string& fname, std::unique_ptr<ReadOnlyMemoryRegion>* result,
+    TransactionToken* token) {
   string translated_fname = TranslateName(fname);
   std::wstring ws_translated_fname = Utf8ToWideChar(translated_fname);
   result->reset();
@@ -418,8 +418,8 @@ Status WindowsFileSystem::NewReadOnlyMemoryRegionFromFile(
   return s;
 }
 
-Status WindowsFileSystem::FileExists(
-    const string& fname /*, TransactionToken* token */) {
+Status WindowsFileSystem::FileExists(const string& fname,
+                                     TransactionToken* token) {
   constexpr int kOk = 0;
   std::wstring ws_translated_fname = Utf8ToWideChar(TranslateName(fname));
   if (_waccess(ws_translated_fname.c_str(), kOk) == 0) {
@@ -428,9 +428,9 @@ Status WindowsFileSystem::FileExists(
   return errors::NotFound(fname, " not found");
 }
 
-Status WindowsFileSystem::GetChildren(
-    const string& dir,
-    std::vector<string>* result /*, TransactionToken* token */) {
+Status WindowsFileSystem::GetChildren(const string& dir,
+                                      std::vector<string>* result,
+                                      TransactionToken* token) {
   string translated_dir = TranslateName(dir);
   std::wstring ws_translated_dir = Utf8ToWideChar(translated_dir);
   result->clear();
@@ -465,8 +465,8 @@ Status WindowsFileSystem::GetChildren(
   return Status::OK();
 }
 
-Status WindowsFileSystem::DeleteFile(
-    const string& fname /*, TransactionToken* token */) {
+Status WindowsFileSystem::DeleteFile(const string& fname,
+                                     TransactionToken* token) {
   Status result;
   std::wstring file_name = Utf8ToWideChar(fname);
   if (_wunlink(file_name.c_str()) != 0) {
@@ -475,8 +475,8 @@ Status WindowsFileSystem::DeleteFile(
   return result;
 }
 
-Status WindowsFileSystem::CreateDir(
-    const string& name /*, TransactionToken* token */) {
+Status WindowsFileSystem::CreateDir(const string& name,
+                                    TransactionToken* token) {
   Status result;
   std::wstring ws_name = Utf8ToWideChar(name);
   if (ws_name.empty()) {
@@ -488,8 +488,8 @@ Status WindowsFileSystem::CreateDir(
   return result;
 }
 
-Status WindowsFileSystem::DeleteDir(
-    const string& name /*, TransactionToken* token */) {
+Status WindowsFileSystem::DeleteDir(const string& name,
+                                    TransactionToken* token) {
   Status result;
   std::wstring ws_name = Utf8ToWideChar(name);
   if (_wrmdir(ws_name.c_str()) != 0) {
@@ -498,8 +498,8 @@ Status WindowsFileSystem::DeleteDir(
   return result;
 }
 
-Status WindowsFileSystem::GetFileSize(
-    const string& fname, uint64* size /*, TransactionToken* token */) {
+Status WindowsFileSystem::GetFileSize(const string& fname, uint64* size,
+                                      TransactionToken* token) {
   string translated_fname = TranslateName(fname);
   std::wstring ws_translated_dir = Utf8ToWideChar(translated_fname);
   Status result;
@@ -517,8 +517,8 @@ Status WindowsFileSystem::GetFileSize(
   return result;
 }
 
-Status WindowsFileSystem::IsDirectory(
-    const string& fname /*, TransactionToken* token */) {
+Status WindowsFileSystem::IsDirectory(const string& fname,
+                                      TransactionToken* token) {
   TF_RETURN_IF_ERROR(FileExists(fname));
   std::wstring ws_translated_fname = Utf8ToWideChar(TranslateName(fname));
   if (PathIsDirectoryW(ws_translated_fname.c_str())) {
@@ -527,8 +527,8 @@ Status WindowsFileSystem::IsDirectory(
   return Status(tensorflow::error::FAILED_PRECONDITION, "Not a directory");
 }
 
-Status WindowsFileSystem::RenameFile(
-    const string& src, const string& target /*, TransactionToken* token */) {
+Status WindowsFileSystem::RenameFile(const string& src, const string& target,
+                                     TransactionToken* token) {
   Status result;
   // rename() is not capable of replacing the existing file as on Linux
   // so use OS API directly
@@ -542,9 +542,9 @@ Status WindowsFileSystem::RenameFile(
   return result;
 }
 
-Status WindowsFileSystem::GetMatchingPaths(
-    const string& pattern,
-    std::vector<string>* results /*, TransactionToken* token */) {
+Status WindowsFileSystem::GetMatchingPaths(const string& pattern,
+                                           std::vector<string>* results,
+                                           TransactionToken* token) {
   // NOTE(mrry): The existing implementation of FileSystem::GetMatchingPaths()
   // does not handle Windows paths containing backslashes correctly. Since
   // Windows APIs will accept forward and backslashes equivalently, we
@@ -567,8 +567,8 @@ bool WindowsFileSystem::Match(const string& filename, const string& pattern) {
   return PathMatchSpecW(ws_path.c_str(), ws_pattern.c_str()) == TRUE;
 }
 
-Status WindowsFileSystem::Stat(
-    const string& fname, FileStatistics* stat /*, TransactionToken* token */) {
+Status WindowsFileSystem::Stat(const string& fname, FileStatistics* stat,
+                               TransactionToken* token) {
   Status result;
   struct _stat sbuf;
   std::wstring ws_translated_fname = Utf8ToWideChar(TranslateName(fname));

--- a/tensorflow/core/platform/windows/windows_file_system.h
+++ b/tensorflow/core/platform/windows/windows_file_system.h
@@ -32,70 +32,55 @@ class WindowsFileSystem : public FileSystem {
 
   ~WindowsFileSystem() {}
 
-  Status NewRandomAccessFile(
-      const string& fname,
-      std::unique_ptr<RandomAccessFile>*
-          result /*, TransactionToken* token = nullptr */) override;
+  Status NewRandomAccessFile(const string& fname,
+                             std::unique_ptr<RandomAccessFile>* result,
+                             TransactionToken* token = nullptr) override;
 
-  Status NewWritableFile(
-      const string& fname,
-      std::unique_ptr<WritableFile>*
-          result /*, TransactionToken* token = nullptr */) override;
+  Status NewWritableFile(const string& fname,
+                         std::unique_ptr<WritableFile>* result,
+                         TransactionToken* token = nullptr) override;
 
-  Status NewAppendableFile(
-      const string& fname,
-      std::unique_ptr<WritableFile>*
-          result /*, TransactionToken* token = nullptr */) override;
+  Status NewAppendableFile(const string& fname,
+                           std::unique_ptr<WritableFile>* result,
+                           TransactionToken* token = nullptr) override;
 
   Status NewReadOnlyMemoryRegionFromFile(
-      const string& fname,
-      std::unique_ptr<ReadOnlyMemoryRegion>*
-          result /*, TransactionToken* token = nullptr */) override;
+      const string& fname, std::unique_ptr<ReadOnlyMemoryRegion>* result,
+      TransactionToken* token = nullptr) override;
 
-  Status FileExists(
-      const string& fname /*, TransactionToken* token = nullptr */) override;
+  Status FileExists(const string& fname,
+                    TransactionToken* token = nullptr) override;
 
-  Status GetChildren(
-      const string& dir,
-      std::vector<string>* result /*, TransactionToken* token = nullptr */)
-      override;
+  Status GetChildren(const string& dir, std::vector<string>* result,
+                     TransactionToken* token = nullptr) override;
 
-  Status GetMatchingPaths(
-      const string& pattern,
-      std::vector<string>* result /*, TransactionToken* token = nullptr */)
-      override;
+  Status GetMatchingPaths(const string& pattern, std::vector<string>* result,
+                          TransactionToken* token = nullptr) override;
 
-  bool Match(
-      const string& filename,
-      const string& pattern /*, TransactionToken* token = nullptr */) override;
+  bool Match(const string& filename, const string& pattern) override;
 
-  Status Stat(
-      const string& fname,
-      FileStatistics* stat /*, TransactionToken* token = nullptr */) override;
+  Status Stat(const string& fname, FileStatistics* stat,
+              TransactionToken* token = nullptr) override;
 
-  Status DeleteFile(
-      const string& fname /*, TransactionToken* token = nullptr */) override;
+  Status DeleteFile(const string& fname,
+                    TransactionToken* token = nullptr) override;
 
-  Status CreateDir(
-      const string& name /*, TransactionToken* token = nullptr */) override;
+  Status CreateDir(const string& name,
+                   TransactionToken* token = nullptr) override;
 
-  Status DeleteDir(
-      const string& name /*, TransactionToken* token = nullptr */) override;
+  Status DeleteDir(const string& name,
+                   TransactionToken* token = nullptr) override;
 
-  Status GetFileSize(
-      const string& fname,
-      uint64* size /*, TransactionToken* token = nullptr */) override;
+  Status GetFileSize(const string& fname, uint64* size,
+                     TransactionToken* token = nullptr) override;
 
-  Status IsDirectory(
-      const string& fname /*, TransactionToken* token = nullptr */) override;
+  Status IsDirectory(const string& fname,
+                     TransactionToken* token = nullptr) override;
 
-  Status RenameFile(
-      const string& src,
-      const string& target /*, TransactionToken* token = nullptr */) override;
+  Status RenameFile(const string& src, const string& target,
+                    TransactionToken* token = nullptr) override;
 
-  string TranslateName(
-      const string& name /*, TransactionToken* token = nullptr */)
-      const override {
+  string TranslateName(const string& name) const override {
     return name;
   }
 

--- a/tensorflow/core/util/memmapped_file_system.cc
+++ b/tensorflow/core/util/memmapped_file_system.cc
@@ -87,7 +87,7 @@ class RandomAccessFileFromMemmapped : public RandomAccessFile {
 MemmappedFileSystem::MemmappedFileSystem() {}
 
 Status MemmappedFileSystem::FileExists(
-    const string& fname /*, TransactionToken* token */) {
+    const string& fname , TransactionToken* token) {
   if (!mapped_memory_) {
     return errors::FailedPrecondition("MemmappedEnv is not initialized");
   }
@@ -100,7 +100,7 @@ Status MemmappedFileSystem::FileExists(
 
 Status MemmappedFileSystem::NewRandomAccessFile(
     const string& filename,
-    std::unique_ptr<RandomAccessFile>* result /*, TransactionToken* token */) {
+    std::unique_ptr<RandomAccessFile>* result , TransactionToken* token) {
   if (!mapped_memory_) {
     return errors::FailedPrecondition("MemmappedEnv is not initialized");
   }
@@ -116,7 +116,7 @@ Status MemmappedFileSystem::NewRandomAccessFile(
 
 Status MemmappedFileSystem::NewReadOnlyMemoryRegionFromFile(
     const string& filename, std::unique_ptr<ReadOnlyMemoryRegion>*
-                                result /*, TransactionToken* token */) {
+                                result , TransactionToken* token) {
   if (!mapped_memory_) {
     return errors::FailedPrecondition("MemmappedEnv is not initialized");
   }
@@ -131,7 +131,7 @@ Status MemmappedFileSystem::NewReadOnlyMemoryRegionFromFile(
 }
 
 Status MemmappedFileSystem::GetFileSize(
-    const string& filename, uint64* size /*, TransactionToken* token */) {
+    const string& filename, uint64* size , TransactionToken* token) {
   if (!mapped_memory_) {
     return errors::FailedPrecondition("MemmappedEnv is not initialized");
   }
@@ -144,7 +144,7 @@ Status MemmappedFileSystem::GetFileSize(
 }
 
 Status MemmappedFileSystem::Stat(
-    const string& fname, FileStatistics* stat /*, TransactionToken* token */) {
+    const string& fname, FileStatistics* stat , TransactionToken* token) {
   uint64 size;
   auto status = GetFileSize(fname, &size);
   if (status.ok()) {
@@ -155,47 +155,47 @@ Status MemmappedFileSystem::Stat(
 
 Status MemmappedFileSystem::NewWritableFile(
     const string& filename,
-    std::unique_ptr<WritableFile>* wf /*, TransactionToken* token */) {
+    std::unique_ptr<WritableFile>* wf , TransactionToken* token) {
   return errors::Unimplemented("memmapped format doesn't support writing");
 }
 
 Status MemmappedFileSystem::NewAppendableFile(
     const string& filename,
-    std::unique_ptr<WritableFile>* result /*, TransactionToken* token */) {
+    std::unique_ptr<WritableFile>* result , TransactionToken* token) {
   return errors::Unimplemented("memmapped format doesn't support writing");
 }
 
 Status MemmappedFileSystem::GetChildren(
     const string& filename,
-    std::vector<string>* strings /*, TransactionToken* token */) {
+    std::vector<string>* strings , TransactionToken* token) {
   return errors::Unimplemented("memmapped format doesn't support GetChildren");
 }
 
 Status MemmappedFileSystem::GetMatchingPaths(
     const string& pattern,
-    std::vector<string>* results /*, TransactionToken* token */) {
+    std::vector<string>* results , TransactionToken* token) {
   return errors::Unimplemented(
       "memmapped format doesn't support GetMatchingPaths");
 }
 
 Status MemmappedFileSystem::DeleteFile(
-    const string& filename /*, TransactionToken* token */) {
+    const string& filename , TransactionToken* token) {
   return errors::Unimplemented("memmapped format doesn't support DeleteFile");
 }
 
 Status MemmappedFileSystem::CreateDir(
-    const string& dirname /*, TransactionToken* token */) {
+    const string& dirname , TransactionToken* token) {
   return errors::Unimplemented("memmapped format doesn't support CreateDir");
 }
 
 Status MemmappedFileSystem::DeleteDir(
-    const string& dirname /*, TransactionToken* token */) {
+    const string& dirname , TransactionToken* token) {
   return errors::Unimplemented("memmapped format doesn't support DeleteDir");
 }
 
 Status MemmappedFileSystem::RenameFile(
     const string& filename_from,
-    const string& filename_to /*, TransactionToken* token */) {
+    const string& filename_to , TransactionToken* token) {
   return errors::Unimplemented("memmapped format doesn't support RenameFile");
 }
 

--- a/tensorflow/core/util/memmapped_file_system.h
+++ b/tensorflow/core/util/memmapped_file_system.h
@@ -60,52 +60,40 @@ class MemmappedFileSystem : public FileSystem {
 
   MemmappedFileSystem();
   ~MemmappedFileSystem() override = default;
-  Status FileExists(
-      const string& fname /*, TransactionToken* token =  nullptr */) override;
-  Status NewRandomAccessFile(
-      const string& filename,
-      std::unique_ptr<RandomAccessFile>*
-          result /*, TransactionToken* token =  nullptr */) override;
+  Status FileExists(const string& fname,
+                    TransactionToken* token = nullptr) override;
+  Status NewRandomAccessFile(const string& filename,
+                             std::unique_ptr<RandomAccessFile>* result,
+                             TransactionToken* token = nullptr) override;
   Status NewReadOnlyMemoryRegionFromFile(
-      const string& filename,
-      std::unique_ptr<ReadOnlyMemoryRegion>*
-          result /*, TransactionToken* token =  nullptr */) override;
+      const string& filename, std::unique_ptr<ReadOnlyMemoryRegion>* result,
+      TransactionToken* token = nullptr) override;
 
   // All these functions return Unimplemented error, the memmapped storage is
   // read only.
-  Status NewWritableFile(
-      const string& fname,
-      std::unique_ptr<WritableFile>*
-          result /*, TransactionToken* token =  nullptr */) override;
-  Status NewAppendableFile(
-      const string& fname,
-      std::unique_ptr<WritableFile>*
-          result /*, TransactionToken* token =  nullptr */) override;
-  Status GetChildren(const string& dir,
-                     std::vector<string>*
-                         r /*, TransactionToken* token =  nullptr */) override;
-  Status GetMatchingPaths(
-      const string& pattern,
-      std::vector<string>* results /*, TransactionToken* token =  nullptr */)
-      override;
-  Status DeleteFile(
-      const string& f /*, TransactionToken* token =  nullptr */) override;
-  Status CreateDir(
-      const string& d /*, TransactionToken* token =  nullptr */) override;
-  Status DeleteDir(
-      const string& d /*, TransactionToken* token =  nullptr */) override;
-  Status RenameFile(
-      const string& s,
-      const string& t /*, TransactionToken* token =  nullptr */) override;
+  Status NewWritableFile(const string& fname,
+                         std::unique_ptr<WritableFile>* result,
+                         TransactionToken* token = nullptr) override;
+  Status NewAppendableFile(const string& fname,
+                           std::unique_ptr<WritableFile>* result,
+                           TransactionToken* token = nullptr) override;
+  Status GetChildren(const string& dir, std::vector<string>* r,
+                     TransactionToken* token = nullptr) override;
+  Status GetMatchingPaths(const string& pattern, std::vector<string>* results,
+                          TransactionToken* token = nullptr) override;
+  Status DeleteFile(const string& f,
+                    TransactionToken* token = nullptr) override;
+  Status CreateDir(const string& d, TransactionToken* token = nullptr) override;
+  Status DeleteDir(const string& d, TransactionToken* token = nullptr) override;
+  Status RenameFile(const string& s, const string& t,
+                    TransactionToken* token = nullptr) override;
 
   // These functions are implemented.
-  Status GetFileSize(
-      const string& f,
-      uint64* s /*, TransactionToken* token =  nullptr */) override;
+  Status GetFileSize(const string& f, uint64* s,
+                     TransactionToken* token = nullptr) override;
   // Currently just returns size.
-  Status Stat(
-      const string& fname,
-      FileStatistics* stat /*, TransactionToken* token =  nullptr */) override;
+  Status Stat(const string& fname, FileStatistics* stat,
+              TransactionToken* token = nullptr) override;
 
   // Initializes filesystem from a file in memmapped format.
   Status InitializeFromFile(Env* env, const string& filename);

--- a/tensorflow/python/framework/test_file_system.cc
+++ b/tensorflow/python/framework/test_file_system.cc
@@ -39,12 +39,12 @@ class TestRandomAccessFile : public RandomAccessFile {
 class TestFileSystem : public NullFileSystem {
  public:
   Status NewRandomAccessFile(
-      const string& fname, std::unique_ptr<RandomAccessFile>* result) override {
+      const string& fname, std::unique_ptr<RandomAccessFile>* result, TransactionToken *token = nullptr) override {
     result->reset(new TestRandomAccessFile);
     return Status::OK();
   }
   // Always return size of 10
-  Status GetFileSize(const string& fname, uint64* file_size) override {
+  Status GetFileSize(const string& fname, uint64* file_size, TransactionToken *token = nullptr) override {
     *file_size = 10;
     return Status::OK();
   }

--- a/tensorflow/tools/android/inference_interface/asset_manager_filesystem.cc
+++ b/tensorflow/tools/android/inference_interface/asset_manager_filesystem.cc
@@ -125,7 +125,7 @@ AssetManagerFileSystem::AssetManagerFileSystem(AAssetManager* asset_manager,
     : asset_manager_(asset_manager), prefix_(prefix) {}
 
 Status AssetManagerFileSystem::FileExists(
-    const string& fname /*, TransactionToken* token */) {
+    const string& fname , TransactionToken* token) {
   string path = RemoveAssetPrefix(fname);
   auto asset = ScopedAsset(
       AAssetManager_open(asset_manager_, path.c_str(), AASSET_MODE_RANDOM));
@@ -137,7 +137,7 @@ Status AssetManagerFileSystem::FileExists(
 
 Status AssetManagerFileSystem::NewRandomAccessFile(
     const string& fname,
-    std::unique_ptr<RandomAccessFile>* result /*, TransactionToken* token */) {
+    std::unique_ptr<RandomAccessFile>* result , TransactionToken* token) {
   string path = RemoveAssetPrefix(fname);
   auto asset = ScopedAsset(
       AAssetManager_open(asset_manager_, path.c_str(), AASSET_MODE_RANDOM));
@@ -150,7 +150,7 @@ Status AssetManagerFileSystem::NewRandomAccessFile(
 
 Status AssetManagerFileSystem::NewReadOnlyMemoryRegionFromFile(
     const string& fname, std::unique_ptr<ReadOnlyMemoryRegion>*
-                             result /*, TransactionToken* token */) {
+                             result , TransactionToken* token) {
   string path = RemoveAssetPrefix(fname);
   auto asset = ScopedAsset(
       AAssetManager_open(asset_manager_, path.c_str(), AASSET_MODE_STREAMING));
@@ -188,7 +188,7 @@ Status AssetManagerFileSystem::NewReadOnlyMemoryRegionFromFile(
 
 Status AssetManagerFileSystem::GetChildren(
     const string& prefixed_dir,
-    std::vector<string>* r /*, TransactionToken* token */) {
+    std::vector<string>* r , TransactionToken* token) {
   std::string path = NormalizeDirectoryPath(prefixed_dir);
   auto dir =
       ScopedAssetDir(AAssetManager_openDir(asset_manager_, path.c_str()));
@@ -204,7 +204,7 @@ Status AssetManagerFileSystem::GetChildren(
 }
 
 Status AssetManagerFileSystem::GetFileSize(
-    const string& fname, uint64* s /*, TransactionToken* token */) {
+    const string& fname, uint64* s , TransactionToken* token) {
   // If fname corresponds to a directory, return early. It doesn't map to an
   // AAsset, and would otherwise return NotFound.
   if (DirectoryExists(fname)) {
@@ -222,7 +222,7 @@ Status AssetManagerFileSystem::GetFileSize(
 }
 
 Status AssetManagerFileSystem::Stat(
-    const string& fname, FileStatistics* stat /*, TransactionToken* token */) {
+    const string& fname, FileStatistics* stat , TransactionToken* token) {
   uint64 size;
   stat->is_directory = DirectoryExists(fname);
   TF_RETURN_IF_ERROR(GetFileSize(fname, &size));
@@ -241,7 +241,7 @@ string AssetManagerFileSystem::RemoveAssetPrefix(const string& name) {
 }
 
 bool AssetManagerFileSystem::DirectoryExists(
-    const std::string& fname /*, TransactionToken* token */) {
+    const std::string& fname , TransactionToken* token) {
   std::string path = NormalizeDirectoryPath(fname);
   auto dir =
       ScopedAssetDir(AAssetManager_openDir(asset_manager_, path.c_str()));
@@ -252,34 +252,34 @@ bool AssetManagerFileSystem::DirectoryExists(
 
 Status AssetManagerFileSystem::GetMatchingPaths(
     const string& pattern,
-    std::vector<string>* results /*, TransactionToken* token */) {
+    std::vector<string>* results , TransactionToken* token) {
   return internal::GetMatchingPaths(this, Env::Default(), pattern, results);
 }
 
 Status AssetManagerFileSystem::NewWritableFile(
     const string& fname,
-    std::unique_ptr<WritableFile>* result /*, TransactionToken* token */) {
+    std::unique_ptr<WritableFile>* result , TransactionToken* token) {
   return errors::Unimplemented("Asset storage is read only.");
 }
 Status AssetManagerFileSystem::NewAppendableFile(
     const string& fname,
-    std::unique_ptr<WritableFile>* result /*, TransactionToken* token */) {
+    std::unique_ptr<WritableFile>* result , TransactionToken* token) {
   return errors::Unimplemented("Asset storage is read only.");
 }
 Status AssetManagerFileSystem::DeleteFile(
-    const string& f /*, TransactionToken* token */) {
+    const string& f , TransactionToken* token) {
   return errors::Unimplemented("Asset storage is read only.");
 }
 Status AssetManagerFileSystem::CreateDir(
-    const string& d /*, TransactionToken* token */) {
+    const string& d , TransactionToken* token) {
   return errors::Unimplemented("Asset storage is read only.");
 }
 Status AssetManagerFileSystem::DeleteDir(
-    const string& d /*, TransactionToken* token */) {
+    const string& d , TransactionToken* token) {
   return errors::Unimplemented("Asset storage is read only.");
 }
 Status AssetManagerFileSystem::RenameFile(
-    const string& s, const string& t /*, TransactionToken* token */) {
+    const string& s, const string& t , TransactionToken* token) {
   return errors::Unimplemented("Asset storage is read only.");
 }
 

--- a/tensorflow/tools/android/inference_interface/asset_manager_filesystem.h
+++ b/tensorflow/tools/android/inference_interface/asset_manager_filesystem.h
@@ -42,52 +42,40 @@ class AssetManagerFileSystem : public FileSystem {
   AssetManagerFileSystem(AAssetManager* asset_manager, const string& prefix);
   ~AssetManagerFileSystem() override = default;
 
-  Status FileExists(
-      const string& fname /*, TransactionToken* token = nullptr*/) override;
-  Status NewRandomAccessFile(
-      const string& filename,
-      std::unique_ptr<RandomAccessFile>*
-          result /*, TransactionToken* token = nullptr*/) override;
+  Status FileExists(const string& fname,
+                    TransactionToken* token = nullptr) override;
+  Status NewRandomAccessFile(const string& filename,
+                             std::unique_ptr<RandomAccessFile>* result,
+                             TransactionToken* token = nullptr) override;
   Status NewReadOnlyMemoryRegionFromFile(
-      const string& filename,
-      std::unique_ptr<ReadOnlyMemoryRegion>*
-          result /*, TransactionToken* token = nullptr*/) override;
+      const string& filename, std::unique_ptr<ReadOnlyMemoryRegion>* result,
+      TransactionToken* token = nullptr) override;
 
-  Status GetFileSize(
-      const string& f,
-      uint64* s /*, TransactionToken* token = nullptr*/) override;
+  Status GetFileSize(const string& f, uint64* s,
+                     TransactionToken* token = nullptr) override;
   // Currently just returns size.
-  Status Stat(
-      const string& fname,
-      FileStatistics* stat /*, TransactionToken* token = nullptr*/) override;
-  Status GetChildren(
-      const string& dir,
-      std::vector<string>* r /*, TransactionToken* token = nullptr*/) override;
+  Status Stat(const string& fname, FileStatistics* stat,
+              TransactionToken* token = nullptr) override;
+  Status GetChildren(const string& dir, std::vector<string>* r,
+                     TransactionToken* token = nullptr) override;
 
   // All these functions return Unimplemented error. Asset storage is
   // read only.
-  Status NewWritableFile(
-      const string& fname,
-      std::unique_ptr<WritableFile>*
-          result /*, TransactionToken* token = nullptr*/) override;
-  Status NewAppendableFile(
-      const string& fname,
-      std::unique_ptr<WritableFile>*
-          result /*, TransactionToken* token = nullptr*/) override;
-  Status DeleteFile(
-      const string& f /*, TransactionToken* token = nullptr*/) override;
-  Status CreateDir(
-      const string& d /*, TransactionToken* token = nullptr*/) override;
-  Status DeleteDir(
-      const string& d /*, TransactionToken* token = nullptr*/) override;
-  Status RenameFile(
-      const string& s,
-      const string& t /*, TransactionToken* token = nullptr*/) override;
+  Status NewWritableFile(const string& fname,
+                         std::unique_ptr<WritableFile>* result,
+                         TransactionToken* token = nullptr) override;
+  Status NewAppendableFile(const string& fname,
+                           std::unique_ptr<WritableFile>* result,
+                           TransactionToken* token = nullptr) override;
+  Status DeleteFile(const string& f,
+                    TransactionToken* token = nullptr) override;
+  Status CreateDir(const string& d, TransactionToken* token = nullptr) override;
+  Status DeleteDir(const string& d, TransactionToken* token = nullptr) override;
+  Status RenameFile(const string& s, const string& t,
+                    TransactionToken* token = nullptr) override;
 
-  Status GetMatchingPaths(
-      const string& pattern,
-      std::vector<string>* results /*, TransactionToken* token = nullptr*/)
-      override;
+  Status GetMatchingPaths(const string& pattern, std::vector<string>* results,
+                          TransactionToken* token = nullptr) override;
 
  private:
   string RemoveAssetPrefix(const string& name);


### PR DESCRIPTION
This PR enables Transactional FileSystem API C++ layer, added in previous PRs (#41431, #41433, #41434, #41434, #41462, #41463 and #41516)  by uncommenting extra arguments and running clang-format on modified files. Follow-up PRs will expose the API to python layers.