### PR TITLE
[INTEL MKL] Fix MKlMaxPoolGrad

### DIFF
--- a/tensorflow/core/kernels/mkl_avgpooling_op.cc
+++ b/tensorflow/core/kernels/mkl_avgpooling_op.cc
@@ -249,8 +249,7 @@ class MklAvgPoolingGradOp : public MklPoolingBackwardOpBase<T> {
           orig_input_dims_mkl_order, output_dims_mkl_order, filter_dims,
           strides, padding_left, padding_right,
           ALGORITHM::pooling_avg_exclude_padding, prop_kind::forward_training,
-          static_cast<MEMORY_FORMAT>(this->data_format_mkldnn_), src_md,
-          diff_dst_md);
+          static_cast<MEMORY_FORMAT>(this->data_format_mkldnn_), src_md);
 #else
       MklPoolingParams bwdParams(
           orig_input_dims_mkl_order, output_dims_mkl_order, filter_dims,

--- a/tensorflow/core/kernels/mkl_maxpooling_op.cc
+++ b/tensorflow/core/kernels/mkl_maxpooling_op.cc
@@ -312,8 +312,7 @@ class MklMaxPoolingGradOp : public MklPoolingBackwardOpBase<T> {
           orig_input_dims_mkl_order, output_dims_mkl_order, filter_dims,
           strides, padding_left, padding_right, ALGORITHM::pooling_max,
           prop_kind::forward_training,
-          static_cast<MEMORY_FORMAT>(this->data_format_mkldnn_), src_md,
-          diff_dst_md);
+          static_cast<MEMORY_FORMAT>(this->data_format_mkldnn_), src_md);
 #else
       MklPoolingParams bwdParams(
           orig_input_dims_mkl_order, output_dims_mkl_order, filter_dims,

--- a/tensorflow/core/kernels/mkl_pooling_ops_common.h
+++ b/tensorflow/core/kernels/mkl_pooling_ops_common.h
@@ -280,6 +280,8 @@ class MklPoolingBwdPrimitive : public MklPrimitive {
     std::shared_ptr<mkldnn::memory> diff_dst_mem;
 
     // Memory descriptors.
+    std::shared_ptr<mkldnn::memory::desc> src_md;
+    std::shared_ptr<mkldnn::memory::desc> dst_md;
     std::shared_ptr<mkldnn::memory::desc> diff_src_md;
     std::shared_ptr<mkldnn::memory::desc> diff_dst_md;
 
@@ -306,6 +308,8 @@ class MklPoolingBwdPrimitive : public MklPrimitive {
           ws_mem(nullptr),
           diff_src_mem(nullptr),
           diff_dst_mem(nullptr),
+          src_md(nullptr),
+          dst_md(nullptr),
           diff_src_md(nullptr),
           diff_dst_md(nullptr),
           fwd_desc(nullptr),

--- a/tensorflow/core/kernels/mkl_pooling_ops_common.h
+++ b/tensorflow/core/kernels/mkl_pooling_ops_common.h
@@ -49,20 +49,12 @@ struct MklPoolingParams {
   mkldnn::prop_kind prop_kind;
   MEMORY_FORMAT src_format;
   memory::desc src_md;
-#ifdef ENABLE_MKLDNN_V1
-  memory::desc diff_dst_md;
-#endif  // ENABLE_MKLDNN_V1
 
   MklPoolingParams(memory::dims src_dims, memory::dims dst_dims,
                    memory::dims filter_dims, memory::dims strides,
                    memory::dims padding_left, memory::dims padding_right,
                    mkldnn::algorithm alg_kind, mkldnn::prop_kind prop_kind,
-#ifdef ENABLE_MKLDNN_V1
-                   MEMORY_FORMAT src_format, memory::desc src_md,
-                   memory::desc diff_dst_md = memory::desc())
-#else
                    MEMORY_FORMAT src_format, memory::desc src_md)
-#endif  // ENABLE_MKLDNN_V1
       : src_dims(src_dims),
         dst_dims(dst_dims),
         filter_dims(filter_dims),
@@ -72,14 +64,7 @@ struct MklPoolingParams {
         alg_kind(alg_kind),
         prop_kind(prop_kind),
         src_format(src_format),
-#ifdef ENABLE_MKLDNN_V1
-        src_md(src_md),
-        diff_dst_md(diff_dst_md) {
-  }
-#else
-        src_md(src_md) {
-  }
-#endif  // ENABLE_MKLDNN_V1
+        src_md(src_md) {}
 };
 
 template <typename T>
@@ -282,8 +267,10 @@ class MklPoolingBwdPrimitive : public MklPrimitive {
     // Memory descriptors.
     std::shared_ptr<mkldnn::memory::desc> src_md;
     std::shared_ptr<mkldnn::memory::desc> dst_md;
+#ifndef ENABLE_MKLDNN_V1
     std::shared_ptr<mkldnn::memory::desc> diff_src_md;
     std::shared_ptr<mkldnn::memory::desc> diff_dst_md;
+#endif
 
     // Forward and backward pooling descriptors and primitive descriptors.
     std::shared_ptr<mkldnn::pooling_forward::desc> fwd_desc;
@@ -310,13 +297,16 @@ class MklPoolingBwdPrimitive : public MklPrimitive {
           diff_dst_mem(nullptr),
           src_md(nullptr),
           dst_md(nullptr),
+#ifndef ENABLE_MKLDNN_V1
           diff_src_md(nullptr),
           diff_dst_md(nullptr),
+#endif
           fwd_desc(nullptr),
           bwd_desc(nullptr),
           fwd_pd(nullptr),
           bwd_pd(nullptr),
-          bwd(nullptr) {}
+          bwd(nullptr) {
+    }
   };
 
   struct PoolingBwdContext context_;


### PR DESCRIPTION
This PR fixes a bug in MklMaxPoolGrad.

The original implementation will generate error results if fwd and bwd have different memory formats, in which case bwd cannot recognize workspace with correct format. So in this PR we directly use src_md/dst_md to initiate bwd primitive.