### PR TITLE
Adding TF_UNUSED_VARIABLE

### DIFF
--- a/tensorflow/core/platform/macros.h
+++ b/tensorflow/core/platform/macros.h
@@ -120,5 +120,13 @@ limitations under the License.
   do {                          \
   } while (0)
 #endif
+namespace tensorflow {
+namespace internal {
+template <typename T>
+void remove_unused_variable_compiler_warning(const T&){};
+}
+}  // namespace tensorflow
+#define TF_UNUSED_VARIABLE(x) \
+  tensorflow::internal::remove_unused_variable_compiler_warning(x)
 
 #endif  // TENSORFLOW_CORE_PLATFORM_MACROS_H_

--- a/tensorflow/core/platform/macros.h
+++ b/tensorflow/core/platform/macros.h
@@ -120,6 +120,7 @@ limitations under the License.
   do {                          \
   } while (0)
 #endif
+
 namespace tensorflow {
 namespace internal {
 template <typename T>


### PR DESCRIPTION
This PR adds a new macro for compiler warnings in case of unused variables. Similar to EIGEN_UNUSED_VARIABLE, it creates a void function that will be optimized away by the compiler. This comes in handy to reduce the warning messages while building and allows user to explicitly mark unused variable so that real warnings can be investigated.