### PR TITLE
Fix typo in optimizer_v2.py

### DIFF
--- a/tensorflow/python/keras/optimizer_v2/optimizer_v2.py
+++ b/tensorflow/python/keras/optimizer_v2/optimizer_v2.py
@@ -282,7 +282,7 @@ class OptimizerV2(trackable.Trackable):
     you should be able to use the _set_hyper()/state.get_hyper()
     facility instead.
 
-    This class in stateful and thread-compatible.
+    This class is stateful and thread-compatible.
 
     Args:
       name: A non-empty string.  The name to use for accumulators created


### PR DESCRIPTION
Issue opened by FirefoxMetzger 3 hours ago: typo in optimizer_v2.py #41658

Fixed line in:
tensorflow/tensorflow/python/keras/optimizer_v2/optimizer_v2.py
Line 285 in bd6b557

