### PR TITLE
Fix messy formating in tf.linalg.inv's docstring

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_MatrixInverse.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_MatrixInverse.pbtxt
@@ -16,9 +16,8 @@ Equivalent to np.linalg.inv
 @end_compatibility
 END
   }
-  summary: "Computes the inverse of one or more square invertible matrices or their"
+  summary: "Computes the inverse of one or more square invertible matrices or their adjoints (conjugate transposes)."
   description: <<END
-adjoints (conjugate transposes).
 
 The input is a tensor of shape `[..., M, M]` whose inner-most 2 dimensions
 form square matrices. The output is a tensor of the same shape as the input


### PR DESCRIPTION
This PR fixes the incorrect formating of tf.linalg.inv's docstring
where the summary span into description.

This PR fixes #41656.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>