### PR TITLE
2.3.0-rc2 cherry-pick request: Cherry pick library threadsafestatus 

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -672,6 +672,10 @@ cc_library(
         "//tensorflow/core:protos_all_cc",
         "//tensorflow/core/kernels/batching_util:periodic_function_dynamic",
         "//tensorflow/core/kernels/batching_util:shared_batch_scheduler_hdrs",
+        "//tensorflow/core/kernels/batching_util:threadsafe_status",
+        "//tensorflow/core/util:incremental_barrier",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/strings",
     ],
     alwayslink = 1,
 )

--- a/tensorflow/core/kernels/batch_kernels.cc
+++ b/tensorflow/core/kernels/batch_kernels.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "tensorflow/core/framework/types.h"
 #include "tensorflow/core/kernels/batching_util/periodic_function.h"
 #include "tensorflow/core/kernels/batching_util/shared_batch_scheduler.h"
+#include "tensorflow/core/kernels/batching_util/threadsafe_status.h"
 #include "tensorflow/core/kernels/concat_lib.h"
 #include "tensorflow/core/kernels/ops_util.h"
 #include "tensorflow/core/kernels/split_lib.h"

--- a/tensorflow/core/kernels/batching_util/BUILD
+++ b/tensorflow/core/kernels/batching_util/BUILD
@@ -52,6 +52,18 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "threadsafe_status",
+    srcs = ["threadsafe_status.cc"],
+    hdrs = ["threadsafe_status.h"],
+    deps = [
+        "//tensorflow/core:lib",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/synchronization",
+    ],
+)
+
 tf_cc_test(
     name = "batch_scheduler_test",
     srcs = ["batch_scheduler_test.cc"],
@@ -183,6 +195,18 @@ tf_cc_test(
         "//tensorflow/core:lib",
         "//tensorflow/core:tensorflow",
         "//tensorflow/core:test",
+    ],
+)
+
+tf_cc_test(
+    name = "threadsafe_status_test",
+    srcs = ["threadsafe_status_test.cc"],
+    deps = [
+        ":threadsafe_status",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:protos_all_cc",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
     ],
 )
 

--- a/tensorflow/core/kernels/batching_util/BUILD
+++ b/tensorflow/core/kernels/batching_util/BUILD
@@ -64,6 +64,18 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "threadsafe_status",
+    srcs = ["threadsafe_status.cc"],
+    hdrs = ["threadsafe_status.h"],
+    deps = [
+        "//tensorflow/core:lib",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/synchronization",
+    ],
+)
+
 tf_cc_test(
     name = "batch_scheduler_test",
     srcs = ["batch_scheduler_test.cc"],

--- a/tensorflow/core/kernels/batching_util/threadsafe_status.cc
+++ b/tensorflow/core/kernels/batching_util/threadsafe_status.cc
@@ -1,0 +1,51 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/kernels/batching_util/threadsafe_status.h"
+
+#include "absl/base/thread_annotations.h"
+#include "absl/status/status.h"
+#include "absl/synchronization/mutex.h"
+#include "tensorflow/core/platform/mutex.h"
+
+namespace tensorflow {
+const Status& ThreadSafeStatus::status() const& {
+  tf_shared_lock lock(mutex_);
+  return status_;
+}
+
+Status ThreadSafeStatus::status() && {
+  tf_shared_lock lock(mutex_);
+  return std::move(status_);
+}
+
+void ThreadSafeStatus::Update(const Status& new_status) {
+  if (new_status.ok()) {
+    return;
+  }
+
+  mutex_lock lock(mutex_);
+  status_.Update(new_status);
+}
+
+void ThreadSafeStatus::Update(Status&& new_status) {
+  if (new_status.ok()) {
+    return;
+  }
+
+  mutex_lock lock(mutex_);
+  status_.Update(std::forward<Status>(new_status));
+}
+}  // namespace tensorflow

--- a/tensorflow/core/kernels/batching_util/threadsafe_status.h
+++ b/tensorflow/core/kernels/batching_util/threadsafe_status.h
@@ -1,0 +1,57 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORE_KERNELS_BATCHING_UTIL_THREADSAFE_STATUS_H_
+#define TENSORFLOW_CORE_KERNELS_BATCHING_UTIL_THREADSAFE_STATUS_H_
+
+#include "tensorflow/core/platform/mutex.h"
+#include "tensorflow/core/platform/status.h"
+#include "tensorflow/core/platform/thread_annotations.h"
+
+namespace tensorflow {
+// Wrapper class to allow both lock-free construction and concurrent updates on
+// a 'status'.
+//
+// Example Usage:
+//   std::thread threads[2];
+//   ThreadSafeStatus thread_safe_status;
+//   threads[0] = std::thread([&]() {
+//     status.Update(errors::Internal("internal error"));
+//   });
+//   threads[1] = std::thread([&]() {
+//     status.Update(errors::InvalidArgument("invalid argument"));
+//   });
+//   threads[0].Join();
+//   threads[1].Join();
+//
+//   NOTE:
+//   When updated in a multi-threading setup, only the first error is retained.
+class ThreadSafeStatus {
+ public:
+  const Status& status() const& TF_LOCKS_EXCLUDED(mutex_);
+  Status status() && TF_LOCKS_EXCLUDED(mutex_);
+
+  // Retains the first error status: replaces the current status with
+  // `new_status` if `new_status` is not OK and the previous status is OK.
+  void Update(const Status& new_status) TF_LOCKS_EXCLUDED(mutex_);
+  void Update(Status&& new_status) TF_LOCKS_EXCLUDED(mutex_);
+
+ private:
+  mutable mutex mutex_;
+  Status status_ TF_GUARDED_BY(mutex_);
+};
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_CORE_KERNELS_BATCHING_UTIL_THREADSAFE_STATUS_H_

--- a/tensorflow/core/kernels/batching_util/threadsafe_status_test.cc
+++ b/tensorflow/core/kernels/batching_util/threadsafe_status_test.cc
@@ -1,0 +1,51 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/kernels/batching_util/threadsafe_status.h"
+
+#include "tensorflow/core/lib/core/status_test_util.h"
+#include "tensorflow/core/platform/errors.h"
+#include "tensorflow/core/platform/test.h"
+#include "tensorflow/core/protobuf/error_codes.pb.h"
+
+namespace tensorflow {
+namespace {
+
+TEST(ThreadSafeStatus, DefaultOk) {
+  ThreadSafeStatus status;
+  TF_EXPECT_OK(status.status());
+}
+
+TEST(ThreadSafeStatus, Update) {
+  ThreadSafeStatus status;
+  TF_EXPECT_OK(status.status());
+
+  status.Update(errors::FailedPrecondition("original error"));
+  EXPECT_EQ(status.status().code(), error::FAILED_PRECONDITION);
+
+  status.Update(Status::OK());
+  EXPECT_EQ(status.status().code(), error::FAILED_PRECONDITION);
+
+  status.Update(errors::Internal("new error"));
+  EXPECT_EQ(status.status().code(), error::FAILED_PRECONDITION);
+}
+
+TEST(ThreadSafeStatus, Move) {
+  ThreadSafeStatus status;
+  TF_EXPECT_OK(std::move(status).status());
+}
+
+}  // namespace
+}  // namespace tensorflow


### PR DESCRIPTION
TF serving is releasing 2.3.0-rc0 on top of TF 2.3.0-rc2. This library is needed to compile TF serving 2.3.0-rc0 (namely this cherry pick is a release blocker for TF serving)