### PR TITLE
Added missing docstrings in dataset_utils.py module

### DIFF
--- a/tensorflow/python/keras/preprocessing/dataset_utils.py
+++ b/tensorflow/python/keras/preprocessing/dataset_utils.py
@@ -215,8 +215,7 @@ def check_validation_split_arg(validation_split, subset, shuffle, seed):
   """Raise errors in case of invalid argument values.
 
   Args:
-    shuffle: Whether to shuffle the data. Default: True.
-        If set to False, sorts the data in alphanumeric order.
+    shuffle: Whether to shuffle the data. Either True or False.
     seed: Optional random seed for shuffling and transformations.
     validation_split: Optional float between 0 and 1,
         fraction of data to reserve for validation.

--- a/tensorflow/python/keras/preprocessing/dataset_utils.py
+++ b/tensorflow/python/keras/preprocessing/dataset_utils.py
@@ -216,9 +216,9 @@ def check_validation_split_arg(validation_split, subset, shuffle, seed):
 
   Args:
     shuffle: Whether to shuffle the data. Either True or False.
-    seed: Optional random seed for shuffling and transformations.
-    validation_split: Optional float between 0 and 1,
-        fraction of data to reserve for validation.
+    seed: random seed for shuffling and transformations.
+    validation_split: float between 0 and 1,
+      fraction of data to reserve for validation.
     subset: One of "training" or "validation".
         Only used if `validation_split` is set.
   """

--- a/tensorflow/python/keras/preprocessing/dataset_utils.py
+++ b/tensorflow/python/keras/preprocessing/dataset_utils.py
@@ -189,6 +189,19 @@ def get_training_or_validation_split(samples, labels, validation_split, subset):
 
 
 def labels_to_dataset(labels, label_mode, num_classes):
+  """Create a tf.data.Dataset from the list/tuple of labels.
+
+  Args:
+    labels: list/tuple of labels to be converted into a tf.data.Dataset.
+    label_mode:
+      - 'binary' indicates that the labels (there can be only 2)
+        are encoded as `float32` scalars with values 0 or 1
+        (e.g. for `binary_crossentropy`).
+      - 'categorical' means that the labels are
+        mapped into a categorical vector.
+        (e.g. for `categorical_crossentropy` loss).
+    num_classes: number of classes of labels.
+  """
   label_ds = dataset_ops.Dataset.from_tensor_slices(labels)
   if label_mode == 'binary':
     label_ds = label_ds.map(
@@ -199,7 +212,17 @@ def labels_to_dataset(labels, label_mode, num_classes):
 
 
 def check_validation_split_arg(validation_split, subset, shuffle, seed):
-  """Raise errors in case of invalid argument values."""
+  """Raise errors in case of invalid argument values.
+
+  Args:
+    shuffle: Whether to shuffle the data. Default: True.
+        If set to False, sorts the data in alphanumeric order.
+    seed: Optional random seed for shuffling and transformations.
+    validation_split: Optional float between 0 and 1,
+        fraction of data to reserve for validation.
+    subset: One of "training" or "validation".
+        Only used if `validation_split` is set.
+  """
   if validation_split and not 0 < validation_split < 1:
     raise ValueError(
         '`validation_split` must be between 0 and 1, received: %s' %


### PR DESCRIPTION
This PR adds the missing docstrings to the following functions in `tensorflow/python/keras/preprocessing/dataset_utils.py` module:

1. labels_to_dataset
2. check_validation_split_arg