### PR TITLE
Remove deprecated calls to iterator_ops.get_next_as_optional

### DIFF
--- a/tensorflow/python/autograph/operators/control_flow.py
+++ b/tensorflow/python/autograph/operators/control_flow.py
@@ -571,7 +571,7 @@ def _tf_iterator_for_stmt(
 
   def aug_body():
     """Main body passed to _tf_while_stmt."""
-    opt_iterate = iterator_ops.get_next_as_optional(iter_)
+    opt_iterate = iter_.get_next_as_optional()
     has_next.value = opt_iterate.has_value()
     loop_vars = aug_get_state()  # updated by set_state() in _tf_while_loop.
 

--- a/tensorflow/python/autograph/operators/control_flow_deprecated_py2.py
+++ b/tensorflow/python/autograph/operators/control_flow_deprecated_py2.py
@@ -590,7 +590,7 @@ def _tf_iterator_for_stmt(itr, extra_test, body, get_state, set_state,
 
   def while_body(has_next, *loop_vars):
     """Main loop body."""
-    opt_iterate = iterator_ops.get_next_as_optional(itr)
+    opt_iterate = itr.get_next_as_optional()
     has_next = opt_iterate.has_value()
 
     if not init_vars:

--- a/tensorflow/python/autograph/operators/py_builtins.py
+++ b/tensorflow/python/autograph/operators/py_builtins.py
@@ -511,7 +511,7 @@ def next_tf_iterator(iterator, default=UNSPECIFIED):
     # Without a default, fall back to the "normal" behavior which raises
     # a runtime exception.
     return next(iterator)
-  opt_iterate = iterator_ops.get_next_as_optional(iterator)
+  opt_iterate = iterator.get_next_as_optional()
   _verify_structure_compatible(
       'the default argument', 'the iterate', default, iterator.element_spec)
   return control_flow_ops.cond(


### PR DESCRIPTION
This PR replaces a few deprecated calls to `iterator_ops.get_next_as_optional(...)` with `iterator_ops.OwnedIterator.get_next_as_optional()`. There are still some deprecated calls left in the source code, but there it looks like a simple replacement isn't possible yet.