### PR TITLE
Directly call sample_distorted_bounding_box_v2 to prevent deprecation warnings

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -2931,10 +2931,18 @@ def sample_distorted_bounding_box_v2(image_size,
     Provide as input to `tf.image.draw_bounding_boxes`.
   """
   seed1, seed2 = random_seed.get_seed(seed) if seed else (0, 0)
-  return sample_distorted_bounding_box(image_size, bounding_boxes, seed1, seed2,
-                                       min_object_covered, aspect_ratio_range,
-                                       area_range, max_attempts,
-                                       use_image_if_no_bounding_boxes, name)
+  with ops.name_scope(name, 'sample_distorted_bounding_box'):
+    return gen_image_ops.sample_distorted_bounding_box_v2(
+        image_size,
+        bounding_boxes,
+        seed=seed1,
+        seed2=seed2,
+        min_object_covered=min_object_covered,
+        aspect_ratio_range=aspect_ratio_range,
+        area_range=area_range,
+        max_attempts=max_attempts,
+        use_image_if_no_bounding_boxes=use_image_if_no_bounding_boxes,
+        name=name)
 
 
 @tf_export(v1=['image.sample_distorted_bounding_box'])


### PR DESCRIPTION
`sample_distorted_bounding_box` is deprected and the warning recommends using `sample_distorted_bounding_box_v2` instead:
https://github.com/tensorflow/tensorflow/blob/055c5e107db5a3b7b0899d8974e14ab6ce772fc0/tensorflow/python/ops/image_ops_impl.py#L2942-L2946

However, `sample_distorted_bounding_box_v2` internally calls `sample_distorted_bounding_box` so users will see deprecation warnings in both cases.

This PR changes `sample_distorted_bounding_box_v2` to directly call the underlying C++ op to prevent deprecation warnings from being raised.