### PR TITLE
Prefer TensorShape(...) over as_shape(...) when passing lists

### DIFF
--- a/tensorflow/python/framework/tensor_util.py
+++ b/tensorflow/python/framework/tensor_util.py
@@ -865,7 +865,7 @@ def constant_value_as_shape(tensor):  # pylint: disable=invalid-name
     ValueError: If the shape is rank-0 and is not statically known to be -1.
   """
   if isinstance(tensor, ops.EagerTensor):
-    return tensor_shape.as_shape(
+    return tensor_shape.TensorShape(
         [dim if dim != -1 else None for dim in tensor.numpy()])
 
   if tensor.get_shape().ndims == 0:

--- a/tensorflow/python/tpu/tpu_sharding.py
+++ b/tensorflow/python/tpu/tpu_sharding.py
@@ -185,7 +185,7 @@ class ShardingPolicy(object):
                        (shape.as_list(), self._number_of_shards,
                         self._shard_dimension))
     dims[self._shard_dimension] //= self._number_of_shards
-    return tensor_shape.as_shape(dims)
+    return tensor_shape.TensorShape(dims)
 
   def _unshard_shape(self, shape):
     """Return the unsharded shape that would generate a given sharded shape.
@@ -213,7 +213,7 @@ class ShardingPolicy(object):
                        (shape.as_list(), self._shard_dimension))
     dims = shape.as_list()
     dims[self._shard_dimension] *= self._number_of_shards
-    return tensor_shape.as_shape(dims)
+    return tensor_shape.TensorShape(dims)
 
   def get_unsharded_shape(self, shapes):
     """Returns the shape of an unsharded Tensor given a list of shards.


### PR DESCRIPTION
Directly calling `tensor_shape.TensorShape(...)` is equivalent to `tensor_shape.as_shape(...)` when passing tuples or lists. This PR changes the usage to prefer the former.