### PR TITLE
Replaced the batch sizes with 'None' instead '?'

### DIFF
--- a/tensorflow/python/keras/utils/vis_utils.py
+++ b/tensorflow/python/keras/utils/vis_utils.py
@@ -206,7 +206,7 @@ def model_to_dot(model,
     if show_shapes:
 
       def format_shape(shape):
-        return str(shape).replace(str(None), '?')
+        return str(shape).replace(str(None), 'None')
 
       try:
         outputlabels = format_shape(layer.output_shape)


### PR DESCRIPTION
I have replaced the default text to be shown if batch sizes are not present as 'None' instead of '?' because it is more readable and understandable during the plotting of the model. Furthermore, it avoids the confusion of any error in the model and signifies that the programmer voluntarily hasn't given any batch sizes