### PR TITLE
fix windows 10 build dependency error

### DIFF
--- a/tensorflow/stream_executor/cuda/BUILD
+++ b/tensorflow/stream_executor/cuda/BUILD
@@ -324,6 +324,7 @@ cc_library(
         "@local_config_cuda//cuda:cudnn_header",
         "//tensorflow/stream_executor/lib",
         "//tensorflow/stream_executor/platform:dso_loader",
+        ":cudnn_version",
     ]),
 )
 


### PR DESCRIPTION
fix for windows 10 with CUDA 11.0 build

#41446 