### PR TITLE
Remove scipy dependency.

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -69,8 +69,6 @@ REQUIRED_PACKAGES = [
     'wrapt >= 1.11.1',
     'wheel >= 0.26',
     'six >= 1.12.0',
-    # scipy < 1.4.1 causes segfaults due to pybind11
-    'scipy == 1.4.1',
 ]
 
 if sys.byteorder == 'little':


### PR DESCRIPTION
See #40884, #35709, #40789.

Keeping here in case of a patch release.