### PR TITLE
Extended test cases and added eager mode tests for compression ops

### DIFF
--- a/tensorflow/python/data/experimental/kernel_tests/compression_ops_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/compression_ops_test.py
@@ -28,6 +28,7 @@ from tensorflow.python.framework import combinations
 from tensorflow.python.framework import sparse_tensor
 from tensorflow.python.ops.ragged import ragged_factory_ops
 from tensorflow.python.platform import test
+from tensorflow.python.framework import test_util
 
 
 def _test_objects():
@@ -60,15 +61,15 @@ def _test_objects():
   ]
 
 
-def _test_eager_only_objects():
+def _test_ragged_based_objects():
   return [
-      combinations.NamedObject(
-          "ragged",
-          ragged_factory_ops.constant([[0, 1, 2, 3], [4, 5], [6, 7, 8], [9]])
+      dict(
+          test_name="ragged",
+          test_input=ragged_factory_ops.constant([[0, 1, 2, 3], [4, 5], [9]])
       ),
-      combinations.NamedObject(
-          "sparse_ragged_structured",
-          {
+      dict(
+          test_name="sparse_ragged_structured",
+          test_input={
               "sparse": sparse_tensor.SparseTensorValue(
                   indices=[[0, 0], [1, 2]], values=[1, 2], dense_shape=[3, 4]),
               "ragged": ragged_factory_ops.constant([[0, 1, 2, 3], [9]])
@@ -81,10 +82,7 @@ class CompressionOpsTest(test_base.DatasetTestBase, parameterized.TestCase):
   @combinations.generate(
       combinations.times(
           test_base.default_test_combinations(),
-          combinations.combine(element=_test_objects())) +
-      combinations.times(
-          test_base.eager_only_combinations(),
-          combinations.combine(element=_test_eager_only_objects())))
+          combinations.combine(element=_test_objects())))
   def testCompression(self, element):
     element = element._obj
 
@@ -96,10 +94,7 @@ class CompressionOpsTest(test_base.DatasetTestBase, parameterized.TestCase):
   @combinations.generate(
       combinations.times(
           test_base.default_test_combinations(),
-          combinations.combine(element=_test_objects())) +
-      combinations.times(
-          test_base.eager_only_combinations(),
-          combinations.combine(element=_test_eager_only_objects())))
+          combinations.combine(element=_test_objects())))
   def testDatasetCompression(self, element):
     element = element._obj
 
@@ -109,6 +104,27 @@ class CompressionOpsTest(test_base.DatasetTestBase, parameterized.TestCase):
     dataset = dataset.map(lambda *x: compression_ops.compress(x))
     dataset = dataset.map(lambda x: compression_ops.uncompress(x, element_spec))
     self.assertDatasetProduces(dataset, [element])
+
+
+class RaggedCompressionOpsTest(test_base.DatasetTestBase, parameterized.TestCase):
+
+  def testCompression(self):
+    for test_case in _test_ragged_based_objects():
+      element = test_case["test_input"]
+      compressed = compression_ops.compress(element)
+      uncompressed = compression_ops.uncompress(
+          compressed, structure.type_spec_from_value(element))
+      self.assertValuesEqual(element, self.evaluate(uncompressed))
+
+  def testDatasetCompression(self):
+    for test_case in _test_ragged_based_objects():
+      element = test_case["test_input"]
+      dataset = dataset_ops.Dataset.from_tensors(element)
+      element_spec = dataset.element_spec
+
+      dataset = dataset.map(lambda *x: compression_ops.compress(x))
+      dataset = dataset.map(lambda x: compression_ops.uncompress(x, element_spec))
+      self.assertDatasetProduces(dataset, [element])
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/data/experimental/kernel_tests/compression_ops_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/compression_ops_test.py
@@ -105,10 +105,7 @@ class CompressionOpsTest(test_base.DatasetTestBase, parameterized.TestCase):
     dataset = dataset.map(lambda x: compression_ops.uncompress(x, element_spec))
     self.assertDatasetProduces(dataset, [element])
 
-
-class RaggedCompressionOpsTest(test_base.DatasetTestBase, parameterized.TestCase):
-
-  def testCompression(self):
+  def testRaggedCompression(self):
     for test_case in _test_ragged_based_objects():
       element = test_case["test_input"]
       compressed = compression_ops.compress(element)
@@ -116,7 +113,7 @@ class RaggedCompressionOpsTest(test_base.DatasetTestBase, parameterized.TestCase
           compressed, structure.type_spec_from_value(element))
       self.assertValuesEqual(element, self.evaluate(uncompressed))
 
-  def testDatasetCompression(self):
+  def testRaggedDatasetCompression(self):
     for test_case in _test_ragged_based_objects():
       element = test_case["test_input"]
       dataset = dataset_ops.Dataset.from_tensors(element)

--- a/tensorflow/python/data/experimental/kernel_tests/compression_ops_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/compression_ops_test.py
@@ -28,7 +28,6 @@ from tensorflow.python.framework import combinations
 from tensorflow.python.framework import sparse_tensor
 from tensorflow.python.ops.ragged import ragged_factory_ops
 from tensorflow.python.platform import test
-from tensorflow.python.framework import test_util
 
 
 def _test_objects():

--- a/tensorflow/python/data/experimental/kernel_tests/compression_ops_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/compression_ops_test.py
@@ -83,7 +83,7 @@ class CompressionOpsTest(test_base.DatasetTestBase, parameterized.TestCase):
           test_base.default_test_combinations(),
           combinations.combine(element=_test_objects())) +
       combinations.times(
-          test_base.eager_only_combinations(),
+          test_base.v2_eager_only_combinations(),
           combinations.combine(element=_test_eager_only_objects())))
   def testCompression(self, element):
     element = element._obj
@@ -98,7 +98,7 @@ class CompressionOpsTest(test_base.DatasetTestBase, parameterized.TestCase):
           test_base.default_test_combinations(),
           combinations.combine(element=_test_objects())) +
       combinations.times(
-          test_base.eager_only_combinations(),
+          test_base.v2_eager_only_combinations(),
           combinations.combine(element=_test_eager_only_objects())))
   def testDatasetCompression(self, element):
     element = element._obj

--- a/tensorflow/python/data/experimental/kernel_tests/compression_ops_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/compression_ops_test.py
@@ -60,7 +60,7 @@ def _test_objects():
   ]
 
 
-def _test_eager_only_objects():
+def _test_v2_eager_only_objects():
   return [
       combinations.NamedObject(
           "ragged",
@@ -84,7 +84,7 @@ class CompressionOpsTest(test_base.DatasetTestBase, parameterized.TestCase):
           combinations.combine(element=_test_objects())) +
       combinations.times(
           test_base.v2_eager_only_combinations(),
-          combinations.combine(element=_test_eager_only_objects())))
+          combinations.combine(element=_test_v2_eager_only_objects())))
   def testCompression(self, element):
     element = element._obj
 
@@ -99,7 +99,7 @@ class CompressionOpsTest(test_base.DatasetTestBase, parameterized.TestCase):
           combinations.combine(element=_test_objects())) +
       combinations.times(
           test_base.v2_eager_only_combinations(),
-          combinations.combine(element=_test_eager_only_objects())))
+          combinations.combine(element=_test_v2_eager_only_objects())))
   def testDatasetCompression(self, element):
     element = element._obj
 

--- a/tensorflow/python/data/experimental/kernel_tests/compression_ops_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/compression_ops_test.py
@@ -79,10 +79,12 @@ def _test_eager_only_objects():
 class CompressionOpsTest(test_base.DatasetTestBase, parameterized.TestCase):
 
   @combinations.generate(
-      combinations.times(test_base.default_test_combinations(),
-                         combinations.combine(element=_test_objects())) +
-      combinations.times(test_base.eager_only_combinations(),
-                         combinations.combine(element=_test_eager_only_objects())))
+      combinations.times(
+          test_base.default_test_combinations(),
+          combinations.combine(element=_test_objects())) +
+      combinations.times(
+          test_base.eager_only_combinations(),
+          combinations.combine(element=_test_eager_only_objects())))
   def testCompression(self, element):
     element = element._obj
 
@@ -92,10 +94,12 @@ class CompressionOpsTest(test_base.DatasetTestBase, parameterized.TestCase):
     self.assertValuesEqual(element, self.evaluate(uncompressed))
 
   @combinations.generate(
-      combinations.times(test_base.default_test_combinations(),
-                         combinations.combine(element=_test_objects())) +
-      combinations.times(test_base.eager_only_combinations(),
-                         combinations.combine(element=_test_eager_only_objects())))
+      combinations.times(
+          test_base.default_test_combinations(),
+          combinations.combine(element=_test_objects())) +
+      combinations.times(
+          test_base.eager_only_combinations(),
+          combinations.combine(element=_test_eager_only_objects())))
   def testDatasetCompression(self, element):
     element = element._obj
 

--- a/tensorflow/python/data/experimental/kernel_tests/compression_ops_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/compression_ops_test.py
@@ -60,7 +60,7 @@ def _test_objects():
   ]
 
 
-def _test_eager_objects():
+def _test_eager_only_objects():
   return [
       combinations.NamedObject(
           "ragged",
@@ -80,7 +80,9 @@ class CompressionOpsTest(test_base.DatasetTestBase, parameterized.TestCase):
 
   @combinations.generate(
       combinations.times(test_base.default_test_combinations(),
-                         combinations.combine(element=_test_objects())))
+                         combinations.combine(element=_test_objects())) +
+      combinations.times(test_base.eager_only_combinations(),
+                         combinations.combine(element=_test_eager_only_objects())))
   def testCompression(self, element):
     element = element._obj
 
@@ -91,32 +93,10 @@ class CompressionOpsTest(test_base.DatasetTestBase, parameterized.TestCase):
 
   @combinations.generate(
       combinations.times(test_base.default_test_combinations(),
-                         combinations.combine(element=_test_objects())))
+                         combinations.combine(element=_test_objects())) +
+      combinations.times(test_base.eager_only_combinations(),
+                         combinations.combine(element=_test_eager_only_objects())))
   def testDatasetCompression(self, element):
-    element = element._obj
-
-    dataset = dataset_ops.Dataset.from_tensors(element)
-    element_spec = dataset.element_spec
-
-    dataset = dataset.map(lambda *x: compression_ops.compress(x))
-    dataset = dataset.map(lambda x: compression_ops.uncompress(x, element_spec))
-    self.assertDatasetProduces(dataset, [element])
-
-  @combinations.generate(combinations.times(
-      test_base.eager_only_combinations(),
-      combinations.combine(element=_test_objects() + _test_eager_objects())))
-  def testCompressionEager(self, element):
-    element = element._obj
-
-    compressed = compression_ops.compress(element)
-    uncompressed = compression_ops.uncompress(
-        compressed, structure.type_spec_from_value(element))
-    self.assertValuesEqual(element, self.evaluate(uncompressed))
-
-  @combinations.generate(combinations.times(
-      test_base.eager_only_combinations(),
-      combinations.combine(element=_test_objects() + _test_eager_objects())))
-  def testDatasetCompressionEager(self, element):
     element = element._obj
 
     dataset = dataset_ops.Dataset.from_tensors(element)

--- a/tensorflow/python/data/kernel_tests/test_base.py
+++ b/tensorflow/python/data/kernel_tests/test_base.py
@@ -137,7 +137,7 @@ class DatasetTestBase(test.TestCase):
     for i in range(len(result_values)):
       nest.assert_same_structure(result_values[i], expected_values[i])
       for result_value, expected_value in zip(
-              nest.flatten(result_values[i]), nest.flatten(expected_values[i])):
+          nest.flatten(result_values[i]), nest.flatten(expected_values[i])):
         self.assertValuesEqual(expected_value, result_value)
 
   def getDatasetOutput(self, dataset, requires_initialization=False):

--- a/tensorflow/python/data/kernel_tests/test_base.py
+++ b/tensorflow/python/data/kernel_tests/test_base.py
@@ -52,8 +52,13 @@ def graph_only_combinations():
 
 
 def v2_only_combinations():
-  """Returns the default test combinations for v1 only tf.data tests."""
+  """Returns the default test combinations for v2 only tf.data tests."""
   return combinations.combine(tf_api_version=2, mode=["eager", "graph"])
+
+
+def v2_eager_only_combinations():
+  """Returns the default test combinations for v2 eager only tf.data tests."""
+  return combinations.combine(tf_api_version=2, mode="eager")
 
 
 class DatasetTestBase(test.TestCase):
@@ -132,7 +137,7 @@ class DatasetTestBase(test.TestCase):
     for i in range(len(result_values)):
       nest.assert_same_structure(result_values[i], expected_values[i])
       for result_value, expected_value in zip(
-          nest.flatten(result_values[i]), nest.flatten(expected_values[i])):
+              nest.flatten(result_values[i]), nest.flatten(expected_values[i])):
         self.assertValuesEqual(expected_value, result_value)
 
   def getDatasetOutput(self, dataset, requires_initialization=False):


### PR DESCRIPTION
This PR extends the kernel testing for `tensorflow/python/data/experimental/ops/compression_ops.py` by

- [x] extending the current test inputs.
- [x] adding eager mode based tests.