### PR TITLE
Fix environment for protobuf compilation

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -688,6 +688,7 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
         sha256 = "b956598d8cbe168b5ee717b5dafa56563eb5201a947856a6688bbeac9cac4e1f",
         strip_prefix = "grpc-b54a5b338637f92bfcf4b0bc05e0f57a5fd8fadd",
         system_build_file = clean_dep("//third_party/systemlibs:grpc.BUILD"),
+        patch_file = clean_dep("//third_party/grpc:generate_cc_env_fix.patch"),
         system_link_files = {
             "//third_party/systemlibs:BUILD": "bazel/BUILD",
             "//third_party/systemlibs:grpc.BUILD": "src/compiler/BUILD",

--- a/third_party/grpc/generate_cc_env_fix.patch
+++ b/third_party/grpc/generate_cc_env_fix.patch
@@ -1,0 +1,10 @@
+--- a/bazel/generate_cc.bzl
++++ b/bazel/generate_cc.bzl
+@@ -141,6 +141,7 @@ def generate_cc_impl(ctx):
+         outputs = out_files,
+         executable = ctx.executable._protoc,
+         arguments = arguments,
++        use_default_shell_env = True,
+     )
+
+     return struct(files = depset(out_files))


### PR DESCRIPTION
The invocation environment for protobuf compilation is ignoring environment variables like LD_LIBRARY_PATH which were used when building `protoc`. This leads to failures due to e.g. mismatches in the `libstdc++.so` versions.


This fixes #41857 by using the patch from upstream https://github.com/grpc/grpc/pull/23664