### PR TITLE
Try RecursivelyCreateDir Except os.makedirs solution to Create Missing Path

### DIFF
--- a/tensorflow/python/lib/io/file_io.py
+++ b/tensorflow/python/lib/io/file_io.py
@@ -471,6 +471,7 @@ def recursive_create_dir_v2(path):
   """Creates a directory and all parent/intermediate directories.
 
   It succeeds if path already exists and is writable.
+  If RecursivelyCreateDir method does not work it tries os method.
 
   Args:
     path: string, name of the directory to be created
@@ -478,7 +479,11 @@ def recursive_create_dir_v2(path):
   Raises:
     errors.OpError: If the operation fails.
   """
-  _pywrap_file_io.RecursivelyCreateDir(compat.path_to_bytes(path))
+  try:
+    pywrap_tensorflow.RecursivelyCreateDir(compat.as_bytes(path))
+  except:
+    if not os.path.exists(path):
+      os.makedirs(path)
 
 
 @tf_export(v1=["gfile.Copy"])

--- a/tensorflow/python/lib/io/file_io.py
+++ b/tensorflow/python/lib/io/file_io.py
@@ -480,7 +480,7 @@ def recursive_create_dir_v2(path):
     errors.OpError: If the operation fails.
   """
   try:
-    pywrap_tensorflow.RecursivelyCreateDir(compat.as_bytes(path))
+    _pywrap_file_io.RecursivelyCreateDir(compat.path_to_bytes(path))
   except:
     if not os.path.exists(path):
       os.makedirs(path)


### PR DESCRIPTION
Previous version hits a bug when trying to run tensorflow wrapped in other scripts. 
E.g. while replicating [UberAI Plato](https://github.com/uber-research/plato-research-dialogue-system#running-plato) project, will hit the following error:

`tensorflow.python.framework.errors_impl.NotFoundError: Failed to create a directory: models/camrest_nlu/sys\experiment_run_0\model\log\train; No such file or directory`

With os method, it quickly resolves the issue.