### PR TITLE
Finalize porting S3

### DIFF
--- a/tensorflow/c/experimental/filesystem/plugins/s3/s3_filesystem.h
+++ b/tensorflow/c/experimental/filesystem/plugins/s3/s3_filesystem.h
@@ -94,6 +94,8 @@ void DeleteDir(const TF_Filesystem* filesystem, const char* path,
                TF_Status* status);
 void CopyFile(const TF_Filesystem* filesystem, const char* src, const char* dst,
               TF_Status* status);
+void RenameFile(const TF_Filesystem* filesystem, const char* src,
+                const char* dst, TF_Status* status);
 }  // namespace tf_s3_filesystem
 
 #endif  // TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_PLUGINS_S3_S3_FILESYSTEM_H_

--- a/tensorflow/c/experimental/filesystem/plugins/s3/s3_filesystem.h
+++ b/tensorflow/c/experimental/filesystem/plugins/s3/s3_filesystem.h
@@ -92,6 +92,8 @@ void Stat(const TF_Filesystem* filesystem, const char* path,
           TF_FileStatistics* stats, TF_Status* status);
 void DeleteDir(const TF_Filesystem* filesystem, const char* path,
                TF_Status* status);
+void CopyFile(const TF_Filesystem* filesystem, const char* src, const char* dst,
+              TF_Status* status);
 }  // namespace tf_s3_filesystem
 
 #endif  // TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_PLUGINS_S3_S3_FILESYSTEM_H_

--- a/tensorflow/c/experimental/filesystem/plugins/s3/s3_filesystem_test.cc
+++ b/tensorflow/c/experimental/filesystem/plugins/s3/s3_filesystem_test.cc
@@ -452,6 +452,38 @@ TEST_F(S3FilesystemTest, SimpleCopyFile) {
   EXPECT_EQ(result, "test");
 }
 
+TEST_F(S3FilesystemTest, RenameFile) {
+  const std::string src = GetURIForPath("RenameFileSrc");
+  const std::string dst = GetURIForPath("RenameFileDst");
+  WriteString(src, "test");
+  ASSERT_TF_OK(status_);
+
+  tf_s3_filesystem::RenameFile(filesystem_, src.c_str(), dst.c_str(), status_);
+  EXPECT_TF_OK(status_);
+  auto result = ReadAll(dst);
+  EXPECT_TF_OK(status_);
+  EXPECT_EQ("test", result);
+}
+
+TEST_F(S3FilesystemTest, RenameFileOverwrite) {
+  const std::string src = GetURIForPath("RenameFileOverwriteSrc");
+  const std::string dst = GetURIForPath("RenameFileOverwriteDst");
+
+  WriteString(src, "test_old");
+  ASSERT_TF_OK(status_);
+  WriteString(dst, "test_new");
+  ASSERT_TF_OK(status_);
+
+  tf_s3_filesystem::PathExists(filesystem_, dst.c_str(), status_);
+  EXPECT_TF_OK(status_);
+  tf_s3_filesystem::RenameFile(filesystem_, src.c_str(), dst.c_str(), status_);
+  EXPECT_TF_OK(status_);
+
+  auto result = ReadAll(dst);
+  EXPECT_TF_OK(status_);
+  EXPECT_EQ("test_old", result);
+}
+
 // Test against large file.
 TEST_F(S3FilesystemTest, ReadLargeFile) {
   auto local_path = GetLocalLargeFile();


### PR DESCRIPTION
@mihaimaruseac 
This PR adds all the missing parts from `core/platform/s3`. We now finish porting s3 to `c_api`.

Actually, We are missing a logging mechanism `LOG(INFO)`, etc. Could we use `std::cout` ?