### PR TITLE
Add c interface for `core/platform:logging`

### DIFF
--- a/tensorflow/c/BUILD
+++ b/tensorflow/c/BUILD
@@ -218,7 +218,7 @@ cc_library(
     srcs = ["logging.cc"],
     hdrs = ["logging.h"],
     deps = [
-        ":c_api",
+        ":c_api_macros",
         "//tensorflow/core/platform:logging",
         "//tensorflow/core/platform:stringprintf",
     ],

--- a/tensorflow/c/BUILD
+++ b/tensorflow/c/BUILD
@@ -213,6 +213,17 @@ tf_cuda_library(
     alwayslink = 1,
 )
 
+cc_library(
+    name = "logging",
+    srcs = ["logging.cc"],
+    hdrs = ["logging.h"],
+    deps = [
+        ":c_api",
+        "//tensorflow/core/platform:logging",
+        "//tensorflow/core/platform:stringprintf",
+    ],
+)
+
 tf_cuda_library(
     name = "tf_status_internal",
     hdrs = [

--- a/tensorflow/c/logging.cc
+++ b/tensorflow/c/logging.cc
@@ -1,0 +1,59 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/c/logging.h"
+
+#include "tensorflow/core/platform/logging.h"
+#include "tensorflow/core/platform/stringprintf.h"
+
+static ::tensorflow::string BuildMessage(const char* fmt, va_list args) {
+  ::tensorflow::string message;
+  ::tensorflow::strings::Appendv(&message, fmt, args);
+  return message;
+}
+
+void TF_Log(TF_LogLevel level, const char* fmt, ...) {
+  if (level < TF_INFO || level > TF_FATAL) return;
+  va_list args;
+  va_start(args, fmt);
+  auto message = BuildMessage(fmt, args);
+  switch (level) {
+    case TF_INFO:
+      LOG(INFO) << message;
+      break;
+    case TF_WARNING:
+      LOG(WARNING) << message;
+      break;
+    case TF_ERROR:
+      LOG(ERROR) << message;
+      break;
+    case TF_FATAL:
+      LOG(FATAL) << message;
+      break;
+  }
+}
+
+void TF_VLog(int level, const char* fmt, ...) {
+  va_list args;
+  va_start(args, fmt);
+  auto message = BuildMessage(fmt, args);
+  VLOG(level) << message;
+}
+
+void TF_DVLog(int level, const char* fmt, ...) {
+  va_list args;
+  va_start(args, fmt);
+  auto message = BuildMessage(fmt, args);
+  DVLOG(level) << message;
+}

--- a/tensorflow/c/logging.h
+++ b/tensorflow/c/logging.h
@@ -15,7 +15,7 @@ limitations under the License.
 #ifndef TENSORFLOW_C_LOGGING_H_
 #define TENSORFLOW_C_LOGGING_H_
 
-#include "tensorflow/c/c_api.h"
+#include "tensorflow/c/c_api_macros.h"
 
 // --------------------------------------------------------------------------
 // C API for tensorflow::Logging.

--- a/tensorflow/c/logging.h
+++ b/tensorflow/c/logging.h
@@ -1,0 +1,42 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_C_LOGGING_H_
+#define TENSORFLOW_C_LOGGING_H_
+
+#include "tensorflow/c/c_api.h"
+
+// --------------------------------------------------------------------------
+// C API for tensorflow::Logging.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum TF_LogLevel {
+  TF_INFO = 0,
+  TF_WARNING = 1,
+  TF_ERROR = 2,
+  TF_FATAL = 3,
+} TF_LogLevel;
+
+TF_CAPI_EXPORT extern void TF_Log(TF_LogLevel level, const char* fmt, ...);
+TF_CAPI_EXPORT extern void TF_VLog(int level, const char* fmt, ...);
+TF_CAPI_EXPORT extern void TF_DVLog(int level, const char* fmt, ...);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TENSORFLOW_C_LOGGING_H_


### PR DESCRIPTION
@mihaimaruseac 
This PR adds C API for `core/platform:logging`. 

Some observations:
- We may want to have a `macro.h` for some common macros. I have to include `:c_api` as a dependency for only one macro `TF_CAPI_EXPORT`.
- We could convert old code in `//tensorflow/c` that is using `LOG()`, `VLOG()` to C API Logging