### PR TITLE
add tf.mask_fill()

### DIFF
--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -5908,22 +5908,16 @@ def mask_fill(tensor, mask, name="mask_fill", value=0):
   def mask__fill_1d(tensor, mask, value):
     """Mask tensor along dimension 0 with a 1-D mask."""
     return tensor * (1 - mask) + (value * mask)
+  if(tensor.ndim != 1):
+    raise ValueError("tensor should be 1-D array")
+  if(mask.ndim != 1):
+    raise ValueError("mask should be 1-D array")
   for i in mask:
     if(i!= 1 and i!= 0):
       raise ValueError("mask should have only boolean values")
   with ops.name_scope(name, values=[tensor, mask]):
     tensor = ops.convert_to_tensor(tensor, name="tensor")
     mask = ops.convert_to_tensor(mask, name="mask")
-
-    shape_mask = mask.get_shape()
-    ndims_mask = shape_mask.ndims
-    shape_tensor = tensor.get_shape()
-    if ndims_mask == 0:
-      raise ValueError("mask cannot be scalar.")
-    if ndims_mask is None:
-      raise ValueError(
-          "Number of mask dimensions must be specified, even if some dimensions"
-          " are None.  E.g. shape=[None] is ok, but shape=None is not.")
-    for i in mask
+    
     return mask_fill_1d(tensor, mask, value)
 

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -5883,10 +5883,11 @@ def mask_fill(tensor, mask, name="mask_fill", value=0):
   Examples:
 
   ```python
-  >>>tensor = [0, 1, 2, 3]
+  >>>tensor = tf.constant([0, 1, 2, 3])
   >>>mask = np.array([True, False, True, False])
   >>>value = 5
-  >>>tf.mask_fill(tensor, mask, value)  # [5, 1, 5, 3]
+  >>>tf.mask_fill(tensor, mask, value)
+  <tf.Tensor: shape=(4,), dtype=int32, numpy=array([5, 1, 5, 3], dtype=int32)>
   ```
 
   Args:
@@ -5906,7 +5907,7 @@ def mask_fill(tensor, mask, name="mask_fill", value=0):
 
   def mask__fill_1d(tensor, mask, value):
     """Mask tensor along dimension 0 with a 1-D mask."""
-    return tensor * (1 - tf.cast(mask, tf.int32)) + value * tf.cast(mask, tf.int32)
+    return tensor * (1 - mask) + (value * mask)
 
   with ops.name_scope(name, values=[tensor, mask]):
     tensor = ops.convert_to_tensor(tensor, name="tensor")

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -5908,7 +5908,10 @@ def mask_fill(tensor, mask, name="mask_fill", value=0):
   def mask__fill_1d(tensor, mask, value):
     """Mask tensor along dimension 0 with a 1-D mask."""
     return tensor * (1 - mask) + (value * mask)
-
+  for i in mask:
+  if(i!= 1 and i!= 0):
+    raise ValueError(
+          "mask should have only boolean values")
   with ops.name_scope(name, values=[tensor, mask]):
     tensor = ops.convert_to_tensor(tensor, name="tensor")
     mask = ops.convert_to_tensor(mask, name="mask")
@@ -5922,5 +5925,6 @@ def mask_fill(tensor, mask, name="mask_fill", value=0):
       raise ValueError(
           "Number of mask dimensions must be specified, even if some dimensions"
           " are None.  E.g. shape=[None] is ok, but shape=None is not.")
+    for i in mask
     return mask_fill_1d(tensor, mask, value)
 

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -5872,7 +5872,7 @@ def repeat(input, repeats, axis=None, name=None):  # pylint: disable=redefined-b
     axis = 0
   return repeat_with_axis(input, repeats, axis, name)
 
-@tf_export(v1=["mask_fill"])
+@tf_export("mask_fill")
 @dispatch.add_dispatch_support
 def mask_fill(tensor, mask, name="mask_fill", value=0):
   """Apply boolean mask fill to tensor.

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -5883,10 +5883,10 @@ def mask_fill(tensor, mask, name="mask_fill", value=0):
   Examples:
 
   ```python
-  tensor = [0, 1, 2, 3]
-  mask = np.array([True, False, True, False])
-  value = 5
-  tf.mask_fill(tensor, mask, value)  # [5, 1, 5, 3]
+  >>>tensor = [0, 1, 2, 3]
+  >>>mask = np.array([True, False, True, False])
+  >>>value = 5
+  >>>tf.mask_fill(tensor, mask, value)  # [5, 1, 5, 3]
   ```
 
   Args:

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -5909,9 +5909,8 @@ def mask_fill(tensor, mask, name="mask_fill", value=0):
     """Mask tensor along dimension 0 with a 1-D mask."""
     return tensor * (1 - mask) + (value * mask)
   for i in mask:
-  if(i!= 1 and i!= 0):
-    raise ValueError(
-          "mask should have only boolean values")
+    if(i!= 1 and i!= 0):
+      raise ValueError("mask should have only boolean values")
   with ops.name_scope(name, values=[tensor, mask]):
     tensor = ops.convert_to_tensor(tensor, name="tensor")
     mask = ops.convert_to_tensor(mask, name="mask")


### PR DESCRIPTION
## Added new api  `tf.mask_fill()` according to issue #41617 

> This api will work similar to [Pytorch's masked_fill_](https://pytorch.org/docs/stable/tensors.html#torch.Tensor.masked_fill_)

### Example:
`>>>tensor = tf.constant([1, 2, 3])`
`>>>mask = tf.constant([True, False, True])`
`>>>value = 5`
`>>>tf.mask_fill(tensor, mask, value)`
`<tf.Tensor: shape=(3,), dtype=int32, numpy=array([5, 2, 5], dtype=int32)>`