### PR TITLE
Don't check for attribute `is_tensor_like` in `is_tensor`

### DIFF
--- a/tensorflow/python/framework/tensor_util.py
+++ b/tensorflow/python/framework/tensor_util.py
@@ -1016,8 +1016,7 @@ def is_tensor(x):  # pylint: disable=invalid-name
     `True` if `x` is a tensor or "tensor-like", `False` if not.
   """
   return (isinstance(x, internal.NativeObject) or
-          isinstance(x, core.Tensor) or
-          getattr(x, "is_tensor_like", False))
+          isinstance(x, core.Tensor))
 
 
 def shape_tensor(shape):  # pylint: disable=invalid-name


### PR DESCRIPTION
`is_tensor` implementation says that an object is Tensor if it matches at least one of three independent checks.

One of them is an object having attribute `is_tensor_like`.

But nobody seems to use it throughout the code anymore.

From the history we can see that this check [was added specifically to support the same name property of the `DistributedValues`](https://github.com/tensorflow/tensorflow/commit/89e06304aad35bfb019a8c10f39fc1ead83e0f99) class, but again from the history we see that the property [was later removed from `DistributedValues`](https://github.com/tensorflow/tensorflow/commit/6b68396a8279e00676c75d685ada2f74398d3c08).

Let's remove checking for `is_tensor_like` attribute from `is_tensor`.