### PR TITLE
Added EEMBC benchmark test harness + two targets.

### DIFF
--- a/tensorflow/lite/micro/benchmarks/Makefile.inc
+++ b/tensorflow/lite/micro/benchmarks/Makefile.inc
@@ -1,6 +1,4 @@
 $(eval $(call add_third_party_download,$(PERSON_MODEL_URL),$(PERSON_MODEL_MD5),person_model_grayscale,))
-$(eval $(call add_third_party_download,$(PERSON_MODEL_INT8_URL),$(PERSON_MODEL_INT8_MD5),person_model_int8,))
-
 
 KEYWORD_BENCHMARK_SRCS := \
 tensorflow/lite/micro/benchmarks/keyword_benchmark.cc \
@@ -18,15 +16,6 @@ $(MAKEFILE_DIR)/downloads/person_model_grayscale/person_image_data.cc
 PERSON_DETECTION_BENCHMARK_HDRS := \
 tensorflow/lite/micro/examples/person_detection/person_detect_model_data.h
 
-PERSON_DETECTION_EXPERIMENTAL_BENCHMARK_SRCS := \
-tensorflow/lite/micro/benchmarks/person_detection_experimental_benchmark.cc \
-$(MAKEFILE_DIR)/downloads/person_model_int8/no_person_image_data.cc \
-$(MAKEFILE_DIR)/downloads/person_model_int8/person_detect_model_data.cc \
-$(MAKEFILE_DIR)/downloads/person_model_int8/person_image_data.cc
-
-PERSON_DETECTION_EXPERIMENTAL_BENCHMARK_HDRS := \
-tensorflow/lite/micro/examples/person_detection_experimental/person_detect_model_data.h
-
 # Builds a standalone binary.
 $(eval $(call microlite_test,keyword_benchmark,\
 $(KEYWORD_BENCHMARK_SRCS),$(KEYWORD_BENCHMARK_HDRS)))
@@ -34,5 +23,70 @@ $(KEYWORD_BENCHMARK_SRCS),$(KEYWORD_BENCHMARK_HDRS)))
 $(eval $(call microlite_test,person_detection_benchmark,\
 $(PERSON_DETECTION_BENCHMARK_SRCS),$(PERSON_DETECTION_BENCHMARK_HDRS)))
 
-$(eval $(call microlite_test,person_detection_experimental_benchmark,\
-$(PERSON_DETECTION_EXPERIMENTAL_BENCHMARK_SRCS),$(PERSON_DETECTION_EXPERIMENTAL_BENCHMARK_HDRS)))
+
+#
+# EEMBC Harness
+#
+
+EEMBC_TH_SRCS := \
+tensorflow/lite/micro/benchmarks/eembc/monitor/ee_main.cc \
+tensorflow/lite/micro/$(TARGET)/eembc/monitor/th_api/th_lib.cc \
+tensorflow/lite/micro/$(TARGET)/eembc/monitor/th_api/th_libc.cc \
+tensorflow/lite/micro/benchmarks/eembc/profile/ee_profile.cc \
+tensorflow/lite/micro/benchmarks/eembc/profile/ee_buffer.cc \
+tensorflow/lite/micro/benchmarks/eembc/profile/ee_util.cc \
+
+#
+# person_detection for EEMBC, override GetImage and RespondToDetection
+#
+# The default model is person_image_data.cc.
+#
+
+PERSON_DETECTION_EEMBC_TH_SRCS := \
+$(EEMBC_TH_SRCS) \
+tensorflow/lite/micro/examples/person_detection/main_functions.cc \
+$(MAKEFILE_DIR)/downloads/person_model_grayscale/person_image_data.cc \
+tensorflow/lite/micro/benchmarks/eembc/profile/ee_person_detection.cc \
+$(person_detection_MODEL_SRCS)
+ 
+PERSON_DETECTION_EEMBC_TH_HDRS := \
+tensorflow/lite/micro/examples/person_detection/main_functions.h \
+tensorflow/lite/micro/examples/person_detection/no_person_image_data.h \
+tensorflow/lite/micro/examples/person_detection/person_image_data.h \
+$(person_detection_MODEL_HDRS)
+
+$(eval $(call microlite_test,person_detection_eembc_th,\
+$(PERSON_DETECTION_EEMBC_TH_SRCS),$(PERSON_DETECTION_EEMBC_TH_HDRS)))
+
+
+#
+# micro_speech for EEMBC, override GetAudioSamples and RespondToCommand
+#
+
+MICRO_SPEECH_EEMBC_TH_SRCS := \
+$(EEMBC_TH_SRCS) \
+tensorflow/lite/micro/examples/micro_speech/yes_1000ms_sample_data.cc \
+tensorflow/lite/micro/examples/micro_speech/micro_features/model.cc \
+tensorflow/lite/micro/examples/micro_speech/micro_features/micro_model_settings.cc \
+tensorflow/lite/micro/examples/micro_speech/micro_features/micro_features_generator.cc \
+tensorflow/lite/micro/examples/micro_speech/feature_provider.cc \
+tensorflow/lite/micro/examples/micro_speech/recognize_commands.cc \
+tensorflow/lite/micro/examples/micro_speech/main_functions.cc \
+tensorflow/lite/micro/benchmarks/eembc/profile/ee_micro_speech.cc \
+$(MICRO_FEATURES_LIB_SRCS) \
+$(micro_speech_MODEL_SRCS)
+ 
+MICRO_SPEECH_EEMBC_TH_HDRS := \
+tensorflow/lite/micro/examples/micro_speech/yes_1000ms_sample_data.h \
+tensorflow/lite/micro/examples/micro_speech/micro_features/model.h \
+tensorflow/lite/micro/examples/micro_speech/micro_features/micro_model_settings.h \
+tensorflow/lite/micro/examples/micro_speech/micro_features/micro_features_generator.h \
+tensorflow/lite/micro/examples/micro_speech/feature_provider.h \
+tensorflow/lite/micro/examples/micro_speech/recognize_commands.h \
+tensorflow/lite/micro/examples/micro_speech/main_functions.h \
+$(MICRO_FEATURES_LIB_HDRS) \
+$(micro_speech_MODEL_HDRS)
+
+$(eval $(call microlite_test,micro_speech_eembc_th,\
+$(MICRO_SPEECH_EEMBC_TH_SRCS),$(MICRO_SPEECH_EEMBC_TH_HDRS)))
+

--- a/tensorflow/lite/micro/benchmarks/eembc/README.md
+++ b/tensorflow/lite/micro/benchmarks/eembc/README.md
@@ -1,0 +1,96 @@
+This document describes the EEMBC test-harness extension for TFLite Micro.
+
+# What is a "Test Harness"
+
+A test harness is a thin wrapper of _instrumentation code_ into which is placed _test code_ to be isolated and analyzed. It is a "petri dish" of sorts for algorithms: it provides a way for an external observer to control the stimulus and measure the response in order to characterize the device across many different metrics. Generally, the test harness connects to an external host system which coordinates the testing and measurement, but it may be self-hosted (i.e., not requiring external apparatus).
+
+The thin wrapper defines the _test-harness API_, which has a few common characteristics for each benchmark (such as initialization), but often the API is tied to the behavior of the benchmark itself. In the case of the test harness by EEMBC, you will see a `monitor` code that provides the most basic functionality, and the `profile` code which is specific to the behavior.
+
+## Repeatability
+
+Benchmarks that aren't repeatable are useless. One way a test harness helps with this is by providing strict control over the inputs and state of the device. The inputs must be identical for every _device under test_ (a.k.a., DUT), otherwise one platform may perform more work than another, which may skew results. The test harness must also provide a means to configure the DUT so that each platform starts from the same state.
+
+## Connectivity
+
+The test harness provides a means to send and receive data to and from the DUT, often through an external serial port. Furthermore, if the code under test is sensitive to (in this case) the UART, the test harness provides hooks to enable and disable test functionality before entering, and after exiting, critical code (in this harness: `th_pre()` and `th_post()`. Why? If the benchmark is measuring a low-power state, it would not make sense to have the GPIO clocks and UART running during the measured portion of the test, consuming lots of energy!
+
+## Precision Measurement
+
+Benchmarks aren't just about speed: sometimes something other than milliseconds needs to be measured, such as power or energy. Often the test harness is just a component in a much larger framework, which they capability perform high-speed timing, or triggering logic- or real-time-spectrum analyzers, or energy monitors. Typically, a test harness that requires external components will require at least one GPIO API call that can be used in the benchmark. This test harness is designed to work with the IoTConnect Framework by EEMBC, which has a host UI application for each benchmark. However, at this time (Summer 2020) the host UI is still under development.
+
+## Trust
+
+The test harness also provides a means to verify the results of the DUT. This provides a first-order verification of results without a 3rd party.
+
+Simply measuring the amount of time it takes to run an algorithm might be suitable for individual analysis, but when comparing results from competitors, there needs to be a mechanism to establish trust. Sometimes the mechanism is a simple honor system, other times measurements are performed by a 3rd-part test lab, such as Underwriter's Labs, Consumer Reports, or the EEMBC certification program.
+
+The test harness attempts to provide a way for the host UI application to perform much self-checking and verification as possible to defeat cheating without 3rd party certification.
+
+# The EEMBC Test Harness for TFLite Micro
+
+The test harness provided here by EEMBC utilizes just the most basic components for external communication: UART Tx, Rx, and a GPIO. This allows control over execution and input data. Currently, this is all that the EEMBC IoTConnect framework has required. However, the benchmark is still under development, and may require a more sophisticated API going forward. This has not yet been decided on by the consortium's tinyML working group.
+
+A set of monitor commands allow control over loop execution and input dataset. Each command ends with a '%'.
+
+For example, when connecting to a terminal application and booting the device, one would see:
+~~~
+m-timestamp-mode-energy
+m-init-done
+m-ready
+~~~
+
+And issueing `help%` would print this, list of commands.
+
+~~~
+ULPMark-ML Firmware V0.0.1
+
+help         : Print this information
+loop         : first-stab at measurement
+buff SUBCMD  : Input buffer functions
+  on         : Infer from buffer data
+  off        : Infer from default data
+  load N     : Allocate N bytes and set load counter
+  i16 N [N]+ : Load 16-bit signed decimal integer(s)
+  x8 N [N]+  : Load 8-bit hex byte(s)
+  print i16  : Print buffer as 16-bit signed decimal
+  print x8   : Print buffer as 8-bit hex
+m-ready
+~~~
+
+## Implementation
+
+The basic harness is found under `tensorflow/lite/micro/benchmarks/eembc`. Files and functions that begin with `ee_` may not be altered under any circumstances. Files and functions that begin with `th_` must be implemented, as they often require calls to hardware-specific SDK, such as configuring a UART to receive bytes.
+
+Two profiles have been implemented using the `benchmarks/Makefile.inc` rules:
+
+### Person Detection (target `person_detection_eembc_th`)
+
+Building this target installs the harness, replacing `main()` with a UART parser, and overrides the functions `GetImage` and `RespondToDetection`. This allows the host framework to download new test data on-the-fly during benchmarking.
+
+### Micro Speech (target `micro_speech_eembc_th`)
+
+Building this target installs the harness, replacing `main()` with a UART parser, and overrides the functions `GetAudioSamples`, `LatestAudioTimestamp`, and `RespondToCommand`. This allows the host framework to download new test data on-the-fly during benchmarking.
+
+## Porting
+
+The porting process for this benchmark on TFLite Micro is not particularly complex. Simply provide the file `tensorflow/lite/micro/<TARGET>/eembc/monitor/th_api/th_lib.cc` and `th_libc.cc`. The bare-bones file is included in `tensorflow/lite/micro/benchmarks/eembc/monitor/th_api`. The three key functions that need to be implemented are:
+
+1. `th_printf` - often this can be implemented with vsprintf (or even #defined as printf) since retargeting STDIO is very common these days. Otherwise you will need to provide your own per-character UART function and initialize it during `th_monitor_initialize`.
+
+2. `th_check_serial` - this responds to a new character(s) in the UART rx buffer and feeds it to `ee_serial_callback` one character at a time.
+
+3. `th_timestamp` - this must generate an open-drain falling edge with 1us hold time
+
+Lastly, `th_serialport_initialize` may need to be modified to make sure transmission is done at 9600 baud 8N1. This is a requirement of the EEMBC IoTConnect framework.
+
+An example port is provided in `tensorflow/lite/micro/ecm3532`.
+
+# Changes from Standard EEMBC Harness and TODOs
+
+1. To avoid C-to-C++ linkage hassles, all harness files end with ".cc"
+
+2. Full paths to include files are used due to the way the TFLite Micro makefiles build targets.
+
+# What is EEMBC?
+
+Founded in 1997, EEMBC is US non-profit which develops  benchmarks for the hardware and software used in autonomous driving, mobile imaging, the Internet of Things, mobile devices, and many other applications. The EEMBC community includes member companies, commercial licensees, and academic licensees at institutions of higher learning around the world. Visit our [website](https://www.eembc.org).

--- a/tensorflow/lite/micro/benchmarks/eembc/eembc.mk
+++ b/tensorflow/lite/micro/benchmarks/eembc/eembc.mk
@@ -1,0 +1,17 @@
+NAME := eembc
+
+#$(NAME)_GLOBAL_INCLUDES := inc
+
+#$(NAME)_CFLAGS := -Wimplicit-fallthrough=0
+
+$(NAME)_GLOBAL_INCLUDES := \
+	monitor/ \
+	monitor/th_api \
+	profile/
+
+$(NAME)_SOURCES := \
+	monitor/ee_main.c \
+	monitor/th_api/th_lib.c \
+	monitor/th_api/th_libc.c \
+	profile/ee_util.c \
+	profile/ee_profile.c

--- a/tensorflow/lite/micro/benchmarks/eembc/monitor/ee_main.cc
+++ b/tensorflow/lite/micro/benchmarks/eembc/monitor/ee_main.cc
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) EEMBC(R). All Rights Reserved
+ *
+ * All EEMBC Benchmark Software are products of EEMBC and are provided under the
+ * terms of the EEMBC Benchmark License Agreements. The EEMBC Benchmark Software
+ * are proprietary intellectual properties of EEMBC and its Members and is
+ * protected under all applicable laws, including all applicable copyright laws.
+ *
+ * If you received this EEMBC Benchmark Software without having a currently
+ * effective EEMBC Benchmark License Agreement, you must discontinue use.
+ */
+
+#include "tensorflow/lite/micro/benchmarks/eembc/monitor/ee_main.h"
+
+#if EE_CFG_SELFHOSTED != 1
+
+// Command buffer (incoming commands from host)
+static char volatile g_cmd_buf[EE_CMD_SIZE + 1];
+static unsigned int volatile  g_cmd_pos = 0u;
+/**
+ * Since the serial port ISR may be connected before the loop is ready, this
+ * flag turns off the parser until the main routine is ready.
+ */
+static bool g_parser_enabled = false;
+
+/**
+ * This function assembles a command string from the UART. It should be called
+ * from the UART ISR for each new character received. When the parser sees the
+ * termination character, the user-defined th_command_ready() command is called.
+ * It is up to the application to then dispatch this command outside the ISR
+ * as soon as possible by calling ee_serial_command_parser_callback(), below.
+ */
+void
+ee_serial_callback(char c)
+{
+    if (c == EE_CMD_TERMINATOR)
+    {
+        g_cmd_buf[g_cmd_pos] = (char)0;
+        th_command_ready(g_cmd_buf);
+        g_cmd_pos = 0;
+    }
+    else
+    {
+        g_cmd_buf[g_cmd_pos] = c;
+        g_cmd_pos = g_cmd_pos >= EE_CMD_SIZE ? EE_CMD_SIZE : g_cmd_pos + 1;
+    }
+}
+
+/**
+ * This is the minimal parser required to test the monitor; profile-specific
+ * commands are handled by whatever profile is compiled into the firmware.
+ *
+ * The most basic commands are:
+ *
+ * name             Print m-name-NAME, where NAME defines the intent of the f/w
+ * timestamp        Generate a signal used for timestamping by the framework
+ */
+/*@-mustfreefresh*/
+/*@-nullpass*/
+void
+ee_serial_command_parser_callback(char *p_command)
+{
+    char *tok;
+
+    if (g_parser_enabled != true)
+    {
+        return;
+    }
+
+    tok = th_strtok(p_command, EE_CMD_DELIMITER);
+
+    if (th_strncmp(tok, EE_CMD_NAME, EE_CMD_SIZE) == 0)
+    {
+        th_printf(EE_MSG_NAME, EE_DEVICE_NAME, TH_VENDOR_NAME_STRING);
+    }
+    else if (th_strncmp(tok, EE_CMD_TIMESTAMP, EE_CMD_SIZE) == 0)
+    {
+        th_timestamp();
+    }
+    else if (ee_profile_parse(tok) == EE_ARG_CLAIMED)
+    {
+    }
+    else
+    {
+        th_printf(EE_ERR_CMD, tok);
+    }
+
+    th_printf(EE_MSG_READY);
+}
+
+/**
+ * Perform the basic setup.
+ */
+void
+ee_main(void)
+{
+    th_serialport_initialize();
+    th_printf("\r\n");
+    th_timestamp_initialize();
+    th_monitor_initialize();
+    th_printf(EE_MSG_INIT_DONE);
+    // Enable the command parser here (the callback is connected)
+    g_parser_enabled = true;
+    // At this point, the serial monitor should be up and running,
+    th_printf(EE_MSG_READY);
+}
+
+#endif // EE_CFG_SELFHOSTED

--- a/tensorflow/lite/micro/benchmarks/eembc/monitor/ee_main.h
+++ b/tensorflow/lite/micro/benchmarks/eembc/monitor/ee_main.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) EEMBC(R). All Rights Reserved
+ *
+ * All EEMBC Benchmark Software are products of EEMBC and are provided under the
+ * terms of the EEMBC Benchmark License Agreements. The EEMBC Benchmark Software
+ * are proprietary intellectual properties of EEMBC and its Members and is
+ * protected under all applicable laws, including all applicable copyright laws.
+ *
+ * If you received this EEMBC Benchmark Software without having a currently
+ * effective EEMBC Benchmark License Agreement, you must discontinue use.
+ */
+
+#ifndef __EE_MAIN_H
+#define __EE_MAIN_H
+
+#include <stdbool.h>
+#include "tensorflow/lite/micro/benchmarks/eembc/monitor/th_api/th_lib.h"
+#include "tensorflow/lite/micro/benchmarks/eembc/monitor/th_api/th_libc.h"
+
+#define EE_MONITOR_VERSION "2.1.0"
+
+typedef enum { EE_ARG_CLAIMED, EE_ARG_UNCLAIMED } arg_claimed_t;
+typedef enum { EE_STATUS_OK = 0, EE_STATUS_ERROR } ee_status_t;
+
+#define EE_DEVICE_NAME    "dut"
+
+#define EE_CMD_SIZE       80u
+#define EE_CMD_DELIMITER  " "
+#define EE_CMD_TERMINATOR '%'
+
+#define EE_CMD_NAME       "name"
+#define EE_CMD_TIMESTAMP  "timestamp"
+
+#define EE_MSG_READY      "m-ready\r\n"
+#define EE_MSG_INIT_DONE  "m-init-done\r\n"
+#define EE_MSG_NAME       "m-name-%s-[%s]\r\n"
+
+#define EE_ERR_CMD        "e-[Unknown command: %s]\r\n"
+
+void ee_serial_callback(char);
+void ee_serial_command_parser_callback(char *);
+void ee_main(void);
+
+// From ../profile/ee_profile.c
+arg_claimed_t ee_profile_parse(char *);
+void          ee_profile_initialize(void);
+
+#endif // __EE_MAIN_H

--- a/tensorflow/lite/micro/benchmarks/eembc/monitor/th_api/th_lib.cc
+++ b/tensorflow/lite/micro/benchmarks/eembc/monitor/th_api/th_lib.cc
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) EEMBC(R). All Rights Reserved
+ *
+ * All EEMBC Benchmark Software are products of EEMBC and are provided under the
+ * terms of the EEMBC Benchmark License Agreements. The EEMBC Benchmark Software
+ * are proprietary intellectual properties of EEMBC and its Members and is
+ * protected under all applicable laws, including all applicable copyright laws.
+ *
+ * If you received this EEMBC Benchmark Software without having a currently
+ * effective EEMBC Benchmark License Agreement, you must discontinue use.
+ */
+
+#include "tensorflow/lite/micro/benchmarks/eembc/monitor/th_api/th_lib.h"
+
+#if EE_CFG_SELFHOSTED != 1
+
+/**
+ * PORTME: If there's anything else that needs to be done on init, do it here,
+ * othewise OK to leave it alone.
+ */
+void
+th_monitor_initialize(void)
+{
+}
+
+/**
+ * PORTME: Set up an OPEN-DRAIN GPIO if it hasn't already been done,
+ * otherwise it is OK to leave this alone.
+ */
+void
+th_timestamp_initialize(void)
+{
+    // USER CODE 1 BEGIN
+    // USER CODE 1 END
+    // Always print this message
+    th_printf(EE_MSG_TIMESTAMP_MODE);
+    /* Always call the timestamp on initialize so that the open-drain output
+       is set to "1" (so that we catch a falling edge) */
+    th_timestamp();
+}
+
+/**
+ * PORTME: Generate a falling edge. Since GPIO pin is OPEN-DRAIN it is OK to
+ * float and let the pullup resistor drive.
+ *
+ * NOTE: The hold time is 62.5ns.
+ */
+void
+th_timestamp(void)
+{
+    int i;
+    #if EE_CFG_ENERGY_MODE==1
+    // 1. pull pin low
+    // 2. wait at least 1us
+    // 3. set pin high
+    #warning "th_timestamp() energy not implemented"
+    #else
+    #warning "th_timestamp() performance not implemented"
+    uint32_t elapsedMicroSeconds = 0;
+    // Print out the timestamp in this exact format:
+    th_printf(EE_MSG_TIMESTAMP, elapsedMicroSeconds);
+    #endif
+}
+
+/**
+ * PORTME: Set up a serialport at 9600 baud to use for communication to the
+ * host system if it hasn't already been done, otherwise it is OK to leave this
+ * blank.
+ * 
+ * Repeat: for connections through the IO Manager, baud rate is 9600! 
+ * For connections directly to the Host UI, baud must be 115200.
+ */
+void
+th_serialport_initialize(void)
+{
+}
+
+/**
+ * PORTME: Modify this function to call the proper printf and send to the
+ * serial port.
+ *
+ * It may only be necessary to comment out this function and define
+ * th_printf as printf and just rerout fputc();
+ */
+void
+th_printf(const char *p_fmt, ...)
+{
+    va_list args;
+    va_start(args, p_fmt);
+    (void)th_vprintf(p_fmt, args); // ignore return
+    va_end(args);
+}
+
+void
+th_check_serial(void)
+{
+    // Check for UART Rx and call ee_serial_callback() per character
+    #warning "th_check_serial() not implemented"
+}
+
+/**
+ * PORTME: This function is called with a pointer to the command built from the
+ * ee_serial_callback() function during the ISR. It is up to the developer
+ * to call ee_serial_command_parser_callback() at the next available non-ISR
+ * clock with this command string.
+ */
+// PORT:ECM3532: no need to use this since we have a local buff in ee_main.c
+void
+th_command_ready(volatile char *p_command)
+{
+    /**
+     * Example of how this might be implemented if there's no need to store
+     * the command string locally:
+     *
+     * ee_serial_command_parser_callback(command);
+     *
+     * Or, depending on the baremetal/RTOS, it might be necessary to create a 
+     * static char array in this file, store the command, and then call
+     * ee_serial_command_parser_callback() when the system is ready to do
+     * work.
+     */
+    // Since we aren't in an interrupt, it is OK to just call this here
+    ee_serial_command_parser_callback((char *)p_command);
+}
+
+#endif // EE_CFG_SELFHOSTED

--- a/tensorflow/lite/micro/benchmarks/eembc/monitor/th_api/th_lib.h
+++ b/tensorflow/lite/micro/benchmarks/eembc/monitor/th_api/th_lib.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) EEMBC(R). All Rights Reserved
+ *
+ * All EEMBC Benchmark Software are products of EEMBC and are provided under the
+ * terms of the EEMBC Benchmark License Agreements. The EEMBC Benchmark Software
+ * are proprietary intellectual properties of EEMBC and its Members and is
+ * protected under all applicable laws, including all applicable copyright laws.
+ *
+ * If you received this EEMBC Benchmark Software without having a currently
+ * effective EEMBC Benchmark License Agreement, you must discontinue use.
+ */
+
+#ifndef __TH_LIB_H
+#define __TH_LIB_H
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include "tensorflow/lite/micro/benchmarks/eembc/monitor/th_api/th_libc.h"
+#include "tensorflow/lite/micro/benchmarks/eembc/monitor/ee_main.h"
+
+// For printf_ redefine
+#include "tensorflow/lite/micro/tools/make/downloads/TensaiSDK/3rd_party/tiny_printf/printf.h"
+// For UART baud definitions
+#include "tensorflow/lite/micro/tools/make/downloads/TensaiSDK/soc/ecm3532/m3/csp/inc/eta_csp_uart.h"
+
+// It is crucial to follow EEMBC message syntax for key messages
+#define EE_MSG_TIMESTAMP "m-lap-us-%lu\r\n"
+
+#ifndef EE_CFG_ENERGY_MODE
+#define EE_CFG_ENERGY_MODE 1
+#endif
+
+#if EE_CFG_ENERGY_MODE==1
+#   define EE_MSG_TIMESTAMP_MODE "m-timestamp-mode-energy\r\n"
+#else
+#   define EE_MSG_TIMESTAMP_MODE "m-timestamp-mode-performance\r\n"
+#endif
+
+/** 
+ * This string is used in the "name%" command. When the host UI starts a test,
+ * it calles the "name%" command, and the result is captured in the log file.
+ * It can be quite useful to have the device's name in the log file for future
+ * reference or debug.
+ */
+#define TH_VENDOR_NAME_STRING "unspecified"
+
+void th_monitor_initialize(void);
+void th_timestamp_initialize(void);
+void th_timestamp(void);
+void th_serialport_initialize(void);
+/* PORT:ECM3532
+void th_printf(const char * fmt, ...);
+*/
+#define th_printf printf_
+void th_command_ready(volatile char *);
+/* PORT:ECM3532
+// Yay, we have getchar
+*/
+void th_check_serial(void);
+
+#endif // __TH_LIB_H

--- a/tensorflow/lite/micro/benchmarks/eembc/monitor/th_api/th_libc.cc
+++ b/tensorflow/lite/micro/benchmarks/eembc/monitor/th_api/th_libc.cc
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) EEMBC(R). All Rights Reserved
+ *
+ * All EEMBC Benchmark Software are products of EEMBC and are provided under the
+ * terms of the EEMBC Benchmark License Agreements. The EEMBC Benchmark Software
+ * are proprietary intellectual properties of EEMBC and its Members and is
+ * protected under all applicable laws, including all applicable copyright laws.
+ *
+ * If you received this EEMBC Benchmark Software without having a currently
+ * effective EEMBC Benchmark License Agreement, you must discontinue use.
+ */
+
+/**
+ * These functions are needed by the main framework. If no LIBC
+ * is provided, please implmenent these.
+ */
+
+#include "tensorflow/lite/micro/benchmarks/eembc/monitor/th_api/th_libc.h"
+
+int
+th_strncmp(const char *str1, const char *str2, size_t n)
+{
+    return strncmp(str1, str2, n);
+}
+
+size_t
+th_strlen(const char * str)
+{
+    return strlen(str);
+}
+
+/*@-mayaliasunique*/
+/*@-temptrans*/
+char *
+th_strcat(char *dest, const char *src)
+{
+    return strcat(dest, src);
+}
+
+char *
+th_strstr(const char *str1, const char *str2)
+{
+    return strstr(str1, str2);
+}
+
+char *
+th_strtok(char *str1, const char *sep)
+{
+    return strtok(str1, sep);
+}
+
+int
+th_atoi(const char *str)
+{
+    return atoi(str);
+}
+
+void *
+th_memset(void *b, int c, size_t len)
+{
+    return memset(b, c, len);
+}
+
+void *
+th_memcpy(void *dst, const void *src, size_t n)
+{
+    return memcpy(dst, src, n);
+}
+
+void *
+th_malloc(size_t size)
+{
+    return malloc(size);
+}
+
+void *
+th_calloc(size_t count, size_t size)
+{
+    return calloc(count, size);
+}
+
+void
+th_free(void *ptr)
+{
+    free(ptr);
+}
+
+int
+th_vprintf(const char *format, va_list ap)
+{
+    return vprintf(format, ap);
+}

--- a/tensorflow/lite/micro/benchmarks/eembc/monitor/th_api/th_libc.h
+++ b/tensorflow/lite/micro/benchmarks/eembc/monitor/th_api/th_libc.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) EEMBC(R). All Rights Reserved
+ *
+ * All EEMBC Benchmark Software are products of EEMBC and are provided under the
+ * terms of the EEMBC Benchmark License Agreements. The EEMBC Benchmark Software
+ * are proprietary intellectual properties of EEMBC and its Members and is
+ * protected under all applicable laws, including all applicable copyright laws.
+ *
+ * If you received this EEMBC Benchmark Software without having a currently
+ * effective EEMBC Benchmark License Agreement, you must discontinue use.
+ */
+
+#ifndef __TH_LIBC_H
+#define __TH_LIBC_H
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+int     th_strncmp(const char *str1, const char *str2, size_t n);
+size_t  th_strlen(const char *str);
+char*   th_strcat(char *dest, const char *src);
+/*@null@*/
+char*   th_strstr(const char *str1, const char *str2);
+/*@null@*/
+char*   th_strtok(/*@null@*/ char *str1, const char *sep);
+int     th_atoi(const char *str);
+void*   th_memset(void *b, int c, size_t len);
+void*   th_memcpy(void* dst, const void* src, size_t n);
+/*@null@*//*@out@*/
+void*   th_malloc(size_t size);
+/*@null@*//*@out@*/
+void*   th_calloc(size_t count, size_t size);
+void    th_free(void* ptr);
+int     th_vprintf(const char *format, va_list ap);
+
+#endif // __TH_LIBC_H

--- a/tensorflow/lite/micro/benchmarks/eembc/profile/ee_buffer.cc
+++ b/tensorflow/lite/micro/benchmarks/eembc/profile/ee_buffer.cc
@@ -1,0 +1,212 @@
+#include "tensorflow/lite/micro/benchmarks/eembc/profile/ee_profile.h"
+/**
+todo
+1. buff -> buff commands
+2. remove INCLUDE
+*/
+void   *gp_buff      = NULL;
+size_t  g_buff_size  = 0u;
+size_t  g_buff_pos   = 0u;
+bool    g_use_buffer = false;
+
+
+arg_claimed_t
+ee_buffer_parse(char *p_command)
+{
+    char *p_next;
+
+    if (th_strncmp(p_command, "buff", EE_CMD_SIZE) != 0)
+    {
+        return EE_ARG_UNCLAIMED;
+    }
+    
+    p_next = th_strtok(NULL, EE_CMD_DELIMITER);
+    
+    if (th_strncmp(p_next, "on", EE_CMD_SIZE) == 0)
+    {
+        if (gp_buff == NULL)
+        {
+            th_printf("e-[Buffer not populated]\r\n");
+        }
+        else
+        {
+            g_use_buffer = true;
+            th_printf("m-[Switching to buffer as input]\r\n");            
+        }
+    }
+    else if (th_strncmp(p_next, "off", EE_CMD_SIZE) == 0)
+    {
+        g_use_buffer = false;
+        th_printf("m-[Switching to default data as input]\r\n");
+    }
+    else if (th_strncmp(p_next, "load", EE_CMD_SIZE) == 0)
+    {
+        // person_detection is 96x96x1, or 9216 bytes
+        // micro_speech is 16000 bytes
+        p_next = th_strtok(NULL, EE_CMD_DELIMITER);
+
+        if (p_next == NULL)
+        {
+            th_printf("e-[Command 'buff load' requires the # of bytes]\r\n");
+        }
+        else
+        {
+            g_buff_size = (size_t)atoi(p_next);
+            if (g_buff_size == 0)
+            {
+                th_printf("e-[Command 'buff load' must be >0 bytes]\r\n");
+            }
+            else
+            {
+                g_buff_pos = 0;
+                if (gp_buff != NULL)
+                {
+                    th_free(gp_buff);
+                    gp_buff = NULL;
+                }
+                gp_buff = (void *)th_malloc(g_buff_size);
+                if (gp_buff == NULL)
+                {
+                    th_printf("e-[Unable to malloc %u bytes]\r\n", g_buff_size);
+                }
+                else
+                {
+                    th_printf("m-[Begin issuing add commands']\r\n");
+                }
+            }
+        }
+    }
+    else if (th_strncmp(p_next, "print-x8", EE_CMD_SIZE) == 0)
+    {
+        uint8_t *ptr = (uint8_t *)gp_buff;
+
+        if (ptr == NULL)
+        {
+            th_printf("e-[Buffer not allocated]\r\n");
+        }
+        else
+        {
+            size_t i = 0;
+            const size_t max = 8;
+            for (; i < g_buff_size; ++i)
+            {
+                if ((i + max) % max == 0 || i == 0)
+                {
+                    th_printf("%04xh: ", i * 2);
+                }
+                th_printf("%02x", ptr[i]);
+                if ((i + 1) % max == 0)
+                {
+                    th_printf("\r\n");
+                }
+                else
+                {
+                    th_printf(" ");
+                }
+            }
+            if (i % max != 0)
+            {
+                th_printf("\r\n");
+            }
+        }
+    }
+    else if (th_strncmp(p_next, "print-i16", EE_CMD_SIZE) == 0)
+    {
+        int16_t *ptr = (int16_t *)gp_buff;
+
+        if (ptr == NULL)
+        {
+            th_printf("e-[Buffer not allocated]\r\n");
+        }
+        else
+        {
+            size_t i = 0;
+            const size_t max = 8;
+
+            th_printf("m-[Buffer size is %d words]\r\n", g_buff_size >> 1);
+            for (; i < (g_buff_size >> 1); ++i)
+            {
+                if ((i + max) % max == 0 || i == 0)
+                {
+                    th_printf("%04xh: ", i * 2);
+                }
+                th_printf("%+6d", ptr[i]);
+                if ((i + 1) % max == 0)
+                {
+                    th_printf("\r\n");
+                }
+                else
+                {
+                    th_printf(" ");
+                }
+            }
+            if (i % max != 0)
+            {
+                th_printf("\r\n");
+            }
+        }
+    }
+    else if (th_strncmp(p_next, "i16", EE_CMD_SIZE) == 0)
+    {
+        int16_t  val;
+        int16_t *ptr = (int16_t *)gp_buff;
+        while ((p_next = th_strtok(NULL, EE_CMD_DELIMITER)) != NULL)
+        {
+            // Yes, atoi is 0 on fail. Be aware.
+            val = (int16_t)th_atoi(p_next);
+            if (g_buff_pos >= g_buff_size)
+            {
+                th_printf("e-[Buffer full, use 'buff-start' to reload]\r\n");
+                break;
+            }
+            else
+            {
+                ptr[g_buff_pos >> 1] = val;
+                g_buff_pos += 2;
+                if (g_buff_pos == g_buff_size)
+                {
+                    th_printf("m-load-done\r\n");
+                }
+            }
+        }
+    }
+    else if (th_strncmp(p_next, "x8", EE_CMD_SIZE) == 0)
+    {
+        uint8_t  val;
+        uint8_t *ptr = (uint8_t *)gp_buff;
+        long     lval;
+
+        while ((p_next = th_strtok(NULL, EE_CMD_DELIMITER)) != NULL)
+        {
+            lval = ee_hexdec(p_next);
+            if (lval < 0)
+            {
+                th_printf("e-[Bad hex value '%s']\r\n", p_next);
+                break;
+            }
+            else
+            {
+                val = (uint8_t)lval;
+                if (g_buff_pos >= g_buff_size)
+                {
+                    th_printf("e-[Buffer full, use 'buff-start' to reload]\r\n");
+                    break;
+                }
+                else
+                {
+                    ptr[g_buff_pos] = val;
+                    ++g_buff_pos;
+                    if (g_buff_pos == g_buff_size)
+                    {
+                        th_printf("m-load-done\r\n");
+                    }
+                }
+            }
+        }
+    }
+    else
+    {
+        th_printf("e-[Unknown 'buf' sub-command: %s]\r\n", p_next);
+    }
+    return EE_ARG_CLAIMED;
+}

--- a/tensorflow/lite/micro/benchmarks/eembc/profile/ee_micro_speech.cc
+++ b/tensorflow/lite/micro/benchmarks/eembc/profile/ee_micro_speech.cc
@@ -1,0 +1,61 @@
+
+#include "tensorflow/lite/micro/examples/micro_speech/audio_provider.h"
+#include "tensorflow/lite/micro/examples/micro_speech/micro_features/micro_model_settings.h"
+#include "tensorflow/lite/micro/benchmarks/eembc/monitor/th_api/th_lib.h"
+
+extern const int     g_yes_1000ms_sample_data_size; //16000
+extern const int16_t g_yes_1000ms_sample_data[]; //16000
+// ee_main.c
+extern bool          g_use_buffer;
+extern void         *gp_buff;
+extern size_t        g_buff_size;
+
+int16_t g_dummy_audio_data[kMaxAudioSampleSize];
+int32_t g_latest_audio_timestamp = 0;
+
+
+TfLiteStatus
+GetAudioSamples(
+    tflite::ErrorReporter  *error_reporter,
+    int                     start_ms,
+    int                     duration_ms,
+    int                    *audio_samples_size,
+    int16_t               **audio_samples)
+{
+    static size_t wrap_at(0);
+    static size_t wrap(0);
+    int16_t *ptr;
+
+    ptr     = g_use_buffer ? (int16_t*)gp_buff : (int16_t*)g_yes_1000ms_sample_data;
+    wrap_at = g_use_buffer ? g_buff_size : g_yes_1000ms_sample_data_size;
+
+    for (int i = 0; i < kMaxAudioSampleSize; ++i, ++wrap)
+    {
+        g_dummy_audio_data[i] = ptr[i];
+        if (wrap >= wrap_at)
+        {
+            wrap = 0;
+        }
+    }
+    *audio_samples_size = kMaxAudioSampleSize;
+    *audio_samples = g_dummy_audio_data;
+    return kTfLiteOk;
+}
+
+int32_t
+LatestAudioTimestamp()
+{
+    g_latest_audio_timestamp += 100;
+    return g_latest_audio_timestamp;
+}
+
+void
+RespondToCommand(
+    tflite::ErrorReporter *error_reporter,
+    int32_t                ms,
+    const char            *found_command,
+    uint8_t                score,
+    bool                   is_new_command)
+{
+    th_printf("m-found[%s]-ms[%d]-score[%d]\r\n", found_command, ms, score);
+}

--- a/tensorflow/lite/micro/benchmarks/eembc/profile/ee_person_detection.cc
+++ b/tensorflow/lite/micro/benchmarks/eembc/profile/ee_person_detection.cc
@@ -1,0 +1,41 @@
+
+#include "tensorflow/lite/micro/examples/person_detection/image_provider.h"
+#include "tensorflow/lite/micro/examples/person_detection/model_settings.h"
+#include "tensorflow/lite/micro/examples/person_detection/detection_responder.h"
+#include "tensorflow/lite/micro/benchmarks/eembc/monitor/th_api/th_lib.h"
+
+extern const unsigned char  g_person_detect_model_data[];
+extern bool                 g_use_buffer;
+extern void                *gp_buff;
+
+TfLiteStatus
+GetImage(
+    tflite::ErrorReporter *error_reporter,
+    int                    image_width,
+    int                    image_height,
+    int                    channels,
+    uint8_t*               image_data)
+{
+    const uint8_t *ptr;
+
+    ptr = g_use_buffer ? (uint8_t *)gp_buff : g_person_detect_model_data;
+    
+    for (int i = 0; i < image_width * image_height * channels; ++i)
+    {
+        image_data[i] = ptr[i];
+    }
+    
+    return kTfLiteOk;
+}
+
+void
+RespondToDetection(
+    tflite::ErrorReporter *error_reporter,
+    uint8_t                person_score,
+    uint8_t                no_person_score)
+{
+    th_printf(
+        "m-[Person %03d, No Person %03d]\r\n",
+        person_score,
+        no_person_score);
+}

--- a/tensorflow/lite/micro/benchmarks/eembc/profile/ee_profile.cc
+++ b/tensorflow/lite/micro/benchmarks/eembc/profile/ee_profile.cc
@@ -1,0 +1,88 @@
+
+#include "tensorflow/lite/micro/benchmarks/eembc/profile/ee_profile.h"
+
+// Generic TFLM main_functions
+extern "C" void setup();
+extern "C" void loop();
+
+arg_claimed_t ee_buffer_parse(char *command);
+
+arg_claimed_t
+ee_profile_parse(char *command)
+{
+    char *p_next; // strtok already primed from ee_main.c
+
+    if (th_strncmp(command, "profile", EE_CMD_SIZE) == 0)
+    {
+        th_printf("m-profile-[%s]\r\n", EE_FW_VERSION);
+    }
+    else if (th_strncmp(command, "help", EE_CMD_SIZE) == 0)
+    {
+        th_printf("%s\r\n", EE_FW_VERSION);
+        th_printf("\r\n");
+        th_printf("help         : Print this information\r\n");
+        th_printf("loop         : first-stab at measurement\r\n");
+        th_printf("buff SUBCMD  : Input buffer functions\r\n");
+        th_printf("  on         : Infer from buffer data\r\n");
+        th_printf("  off        : Infer from default data\r\n");
+        th_printf("  load N     : Allocate N bytes and set load counter\r\n");
+        th_printf("  i16 N [N]+ : Load 16-bit signed decimal integer(s)\r\n");
+        th_printf("  x8 N [N]+  : Load 8-bit hex byte(s)\r\n");
+        th_printf("  print i16  : Print buffer as 16-bit signed decimal\r\n");
+        th_printf("  print x8   : Print buffer as 8-bit hex\r\n");
+    }
+    else if (th_strncmp(command, "loop", EE_CMD_SIZE) == 0)
+    {
+        int loops;
+
+        loops = 1;
+        p_next = th_strtok(NULL, EE_CMD_DELIMITER);
+        if (NULL != p_next)
+        {
+            loops = th_atoi(p_next);
+        }
+        if (loops < 1)
+        {
+            th_printf("e-[Invalid count passed to 'loop']\r\n");
+        }
+        else
+        {
+            for (; loops > 0; --loops)
+            {
+                th_printf("m-[Running loop #%d]\r\n", loops);
+                th_timestamp();
+                //th_pre();
+                loop();
+                //th_post();
+                th_timestamp();
+            }
+        }
+    }
+    else if (ee_buffer_parse(command) == EE_ARG_CLAIMED)
+    {
+    }
+    else 
+    {
+        return EE_ARG_UNCLAIMED;
+    }
+    return EE_ARG_CLAIMED;
+}
+
+void
+ee_profile_initialize(void) {
+}
+
+/**
+ * Tensorflow Lite Micro needs a main() for the micro examples.
+ */
+
+int
+main(void)
+{
+    setup();
+    ee_main();
+    while (true) {
+        th_check_serial();
+    }
+    return 0;
+}

--- a/tensorflow/lite/micro/benchmarks/eembc/profile/ee_profile.h
+++ b/tensorflow/lite/micro/benchmarks/eembc/profile/ee_profile.h
@@ -1,0 +1,9 @@
+#ifndef __EE_PROFILE_H
+#define __EE_PROFILE_H
+
+#include "tensorflow/lite/micro/benchmarks/eembc/monitor/ee_main.h"
+#include "tensorflow/lite/micro/benchmarks/eembc/profile/ee_util.h"
+
+#define EE_FW_VERSION "ULPMark-ML Firmware V0.0.1"
+
+#endif

--- a/tensorflow/lite/micro/benchmarks/eembc/profile/ee_util.cc
+++ b/tensorflow/lite/micro/benchmarks/eembc/profile/ee_util.cc
@@ -1,0 +1,35 @@
+#include "tensorflow/lite/micro/benchmarks/eembc/profile/ee_util.h"
+
+/**
+ * @brief convert a hexidecimal string to a signed long
+ * will not produce or process negative numbers except
+ * to signal error.
+ *
+ * @param hex without decoration, case insensitive.
+ *
+ * @return -1 on error, or result (max (sizeof(long)*8)-1 bits)
+ *
+ * Provided by Steve Allen at Dialog Semiconductor
+ */
+long
+ee_hexdec(char *hex) {
+    char c;
+    long dec = 0;
+    long ret = 0;
+
+    while (*hex && ret >= 0) {
+        c = *hex++;
+        if (c >= '0' && c <= '9') {
+            dec = c - '0';
+        } else if (c >= 'a' && c <= 'f') {
+            dec = c - 'a' + 10;
+        } else if (c >= 'A' && c <= 'F') {
+            dec = c - 'A' + 10;
+        } else {
+            return -1;
+        }
+        ret = (ret << 4) + dec;
+    }
+    return ret;
+}
+

--- a/tensorflow/lite/micro/benchmarks/eembc/profile/ee_util.h
+++ b/tensorflow/lite/micro/benchmarks/eembc/profile/ee_util.h
@@ -1,0 +1,9 @@
+#ifndef __EE_UTIL_H
+#define __EE_UTIL_H
+
+#include <stdint.h>
+#include "tensorflow/lite/micro/benchmarks/eembc/monitor/ee_main.h"
+
+long ee_hexdec(char * hex);
+
+#endif


### PR DESCRIPTION
This is a pull request to enable existing targets in the TFLiteMicro repository to plug into the EEMBC ULPMark-ML low-power machine learning benchmark framework currently under development. Please see the README.md.