### PR TITLE
[TF:MLIR] Legalize tf.diag with tf2xla

### DIFF
--- a/tensorflow/compiler/mlir/tensorflow/ir/tf_generated_ops.td
+++ b/tensorflow/compiler/mlir/tensorflow/ir/tf_generated_ops.td
@@ -2487,6 +2487,40 @@ this op runs. The length of the list is returned in two cases:
   );
 }
 
+def TF_DiagOp : TF_Op<"Diag", [NoSideEffect]> {
+  let summary = "Returns a diagonal tensor with a given diagonal values.";
+
+  let description = [{
+Given a `diagonal`, this operation returns a tensor with the `diagonal`
+and everything else padded with zeros. The diagonal is computed as follows:
+
+Assume `diagonal` has dimensions `[D1, ..., Dk]`, then the output is
+a tensor of rank `2k` with dimensions `[D1, ..., Dk, D1, ..., Dk]` where:
+
+`output[i1,..., ik, i1,..., ik] = diagonal[i1, ..., ik]` and 0 everywhere else.
+
+For example:
+
+```
+# 'diagonal' is [1, 2, 3, 4]
+tf.diag(diagonal) ==> [[1, 0, 0, 0]
+                       [0, 2, 0, 0]
+                       [0, 0, 3, 0]
+                       [0, 0, 0, 4]]
+```
+  }];
+
+  let arguments = (ins
+    TensorOf<[BF16, F16, F32, F64, I32, I64, TF_Complex128, TF_Complex64]>:$diagonal
+  );
+
+  let results = (outs
+    TensorOf<[BF16, F16, F32, F64, I32, I64, TF_Complex128, TF_Complex64]>:$output
+  );
+
+  TF_DerivedOperandTypeAttr T = TF_DerivedOperandTypeAttr<0>;
+}
+
 def TF_DiagPartOp : TF_Op<"DiagPart", [NoSideEffect]> {
   let summary = "Returns the diagonal part of the tensor.";
 

--- a/tensorflow/compiler/mlir/tensorflow/ir/tf_generated_ops.td
+++ b/tensorflow/compiler/mlir/tensorflow/ir/tf_generated_ops.td
@@ -2487,7 +2487,7 @@ this op runs. The length of the list is returned in two cases:
   );
 }
 
-def TF_DiagOp : TF_Op<"Diag", [NoSideEffect]> {
+def TF_DiagOp : TF_Op<"Diag", [NoSideEffect, SameOperandsAndResultElementType]> {
   let summary = "Returns a diagonal tensor with a given diagonal values.";
 
   let description = [{

--- a/tensorflow/compiler/mlir/xla/tests/legalize-tf-with-tf2xla.mlir
+++ b/tensorflow/compiler/mlir/xla/tests/legalize-tf-with-tf2xla.mlir
@@ -265,6 +265,7 @@ func @non_max_suppression_v4(%arg0: tensor<3x4xf32>, %arg1: tensor<3xf32>, %arg2
   return %0#0 : tensor<2xi32>
 }
 
+<<<<<<< HEAD
 // CHECK-LABEL: bessel_i0e
 func @bessel_i0e(%arg0: tensor<3xf16>, %arg1: tensor<3xf32>, %arg2: tensor<3xf64>) -> (tensor<3xf16>, tensor<3xf32>, tensor<3xf64>) {
   // CHECK-NOT: tf.BesselI0e
@@ -281,6 +282,20 @@ func @bessel_i1e(%arg0: tensor<3xf16>, %arg1: tensor<3xf32>, %arg2: tensor<3xf64
   %1 = "tf.BesselI1e"(%arg1) : (tensor<3xf32>) -> (tensor<3xf32>)
   %2 = "tf.BesselI1e"(%arg2) : (tensor<3xf64>) -> (tensor<3xf64>)
   return %0, %1, %2 : tensor<3xf16>, tensor<3xf32>, tensor<3xf64>
+=======
+// CHECK-LABEL: diag
+func @diag(%arg0: tensor<2xf32>) -> tensor<2x2xf32> {
+  // CHECK: %[[ZERO:.*]]  = mhlo.constant dense<0.000000e+00> : tensor<2x2xf32>
+  // CHECK: %[[IOTA:.*]]  = "mhlo.iota"() {iota_dimension = 0 : i64} : () -> tensor<2xi32>
+  // CHECK: %[[BROADCAST1:.*]] = "mhlo.broadcast_in_dim"(%[[IOTA]]) {broadcast_dimensions = dense<1> : tensor<1xi64>} : (tensor<2xi32>) -> tensor<2x2xi32>
+  // CHECK: %[[BROADCAST0:.*]] = "mhlo.broadcast_in_dim"(%[[IOTA]]) {broadcast_dimensions = dense<0> : tensor<1xi64>} : (tensor<2xi32>) -> tensor<2x2xi32>
+  // CHECK: %[[EQ:.*]] = "mhlo.compare"(%[[BROADCAST1]], %[[BROADCAST0]]) {comparison_direction = "EQ"} : (tensor<2x2xi32>, tensor<2x2xi32>) -> tensor<2x2xi1>
+  // CHECK: %[[BROADCAST2:.*]] = "mhlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<1> : tensor<1xi64>} : (tensor<2xf32>) -> tensor<2x2xf32>
+  // CHECK: %[[RESULT:.*]] = "mhlo.select"(%[[EQ]], %[[BROADCAST2]], %[[ZERO]]) : (tensor<2x2xi1>, tensor<2x2xf32>, tensor<2x2xf32>) -> tensor<2x2xf32>
+  %0 = "tf.Diag"(%arg0) : (tensor<2xf32>) -> tensor<2x2xf32>
+  // CHECK: return %[[RESULT]] : tensor<2x2xf32>
+  return %0 : tensor<2x2xf32>
+>>>>>>> 20e87f998e... Add test with mhlo
 }
 
 // TODO(hinsu): Add a test with a valid TF op for which tf2xla kernel is

--- a/tensorflow/compiler/mlir/xla/tests/legalize-tf-with-tf2xla.mlir
+++ b/tensorflow/compiler/mlir/xla/tests/legalize-tf-with-tf2xla.mlir
@@ -285,14 +285,7 @@ func @bessel_i1e(%arg0: tensor<3xf16>, %arg1: tensor<3xf32>, %arg2: tensor<3xf64
 
 // CHECK-LABEL: diag
 func @diag(%arg0: tensor<2xf32>) -> tensor<2x2xf32> {
-  // CHECK: %[[ZERO:.*]]  = mhlo.constant dense<0.000000e+00> : tensor<2x2xf32>
-  // CHECK: %[[IOTA:.*]]  = "mhlo.iota"() {iota_dimension = 0 : i64} : () -> tensor<2xi32>
-  // CHECK: %[[BROADCAST1:.*]] = "mhlo.broadcast_in_dim"(%[[IOTA]]) {broadcast_dimensions = dense<1> : tensor<1xi64>} : (tensor<2xi32>) -> tensor<2x2xi32>
-  // CHECK: %[[BROADCAST0:.*]] = "mhlo.broadcast_in_dim"(%[[IOTA]]) {broadcast_dimensions = dense<0> : tensor<1xi64>} : (tensor<2xi32>) -> tensor<2x2xi32>
-  // CHECK: %[[EQ:.*]] = "mhlo.compare"(%[[BROADCAST1]], %[[BROADCAST0]]) {comparison_direction = "EQ"} : (tensor<2x2xi32>, tensor<2x2xi32>) -> tensor<2x2xi1>
-  // CHECK: %[[BROADCAST2:.*]] = "mhlo.broadcast_in_dim"(%[[ARG0]]) {broadcast_dimensions = dense<1> : tensor<1xi64>} : (tensor<2xf32>) -> tensor<2x2xf32>
-  // CHECK: %[[RESULT:.*]] = "mhlo.select"(%[[EQ]], %[[BROADCAST2]], %[[ZERO]]) : (tensor<2x2xi1>, tensor<2x2xf32>, tensor<2x2xf32>) -> tensor<2x2xf32>
-  // CHECK: return %[[RESULT]] : tensor<2x2xf32>
+  // CHECK-NOT: tf.Diag
   %0 = "tf.Diag"(%arg0) : (tensor<2xf32>) -> tensor<2x2xf32>
   return %0 : tensor<2x2xf32>
 }

--- a/tensorflow/compiler/mlir/xla/tests/legalize-tf-with-tf2xla.mlir
+++ b/tensorflow/compiler/mlir/xla/tests/legalize-tf-with-tf2xla.mlir
@@ -265,7 +265,6 @@ func @non_max_suppression_v4(%arg0: tensor<3x4xf32>, %arg1: tensor<3xf32>, %arg2
   return %0#0 : tensor<2xi32>
 }
 
-<<<<<<< HEAD
 // CHECK-LABEL: bessel_i0e
 func @bessel_i0e(%arg0: tensor<3xf16>, %arg1: tensor<3xf32>, %arg2: tensor<3xf64>) -> (tensor<3xf16>, tensor<3xf32>, tensor<3xf64>) {
   // CHECK-NOT: tf.BesselI0e
@@ -282,7 +281,8 @@ func @bessel_i1e(%arg0: tensor<3xf16>, %arg1: tensor<3xf32>, %arg2: tensor<3xf64
   %1 = "tf.BesselI1e"(%arg1) : (tensor<3xf32>) -> (tensor<3xf32>)
   %2 = "tf.BesselI1e"(%arg2) : (tensor<3xf64>) -> (tensor<3xf64>)
   return %0, %1, %2 : tensor<3xf16>, tensor<3xf32>, tensor<3xf64>
-=======
+}
+
 // CHECK-LABEL: diag
 func @diag(%arg0: tensor<2xf32>) -> tensor<2x2xf32> {
   // CHECK: %[[ZERO:.*]]  = mhlo.constant dense<0.000000e+00> : tensor<2x2xf32>
@@ -290,12 +290,11 @@ func @diag(%arg0: tensor<2xf32>) -> tensor<2x2xf32> {
   // CHECK: %[[BROADCAST1:.*]] = "mhlo.broadcast_in_dim"(%[[IOTA]]) {broadcast_dimensions = dense<1> : tensor<1xi64>} : (tensor<2xi32>) -> tensor<2x2xi32>
   // CHECK: %[[BROADCAST0:.*]] = "mhlo.broadcast_in_dim"(%[[IOTA]]) {broadcast_dimensions = dense<0> : tensor<1xi64>} : (tensor<2xi32>) -> tensor<2x2xi32>
   // CHECK: %[[EQ:.*]] = "mhlo.compare"(%[[BROADCAST1]], %[[BROADCAST0]]) {comparison_direction = "EQ"} : (tensor<2x2xi32>, tensor<2x2xi32>) -> tensor<2x2xi1>
-  // CHECK: %[[BROADCAST2:.*]] = "mhlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<1> : tensor<1xi64>} : (tensor<2xf32>) -> tensor<2x2xf32>
+  // CHECK: %[[BROADCAST2:.*]] = "mhlo.broadcast_in_dim"(%[[ARG0]]) {broadcast_dimensions = dense<1> : tensor<1xi64>} : (tensor<2xf32>) -> tensor<2x2xf32>
   // CHECK: %[[RESULT:.*]] = "mhlo.select"(%[[EQ]], %[[BROADCAST2]], %[[ZERO]]) : (tensor<2x2xi1>, tensor<2x2xf32>, tensor<2x2xf32>) -> tensor<2x2xf32>
-  %0 = "tf.Diag"(%arg0) : (tensor<2xf32>) -> tensor<2x2xf32>
   // CHECK: return %[[RESULT]] : tensor<2x2xf32>
+  %0 = "tf.Diag"(%arg0) : (tensor<2xf32>) -> tensor<2x2xf32>
   return %0 : tensor<2x2xf32>
->>>>>>> 20e87f998e... Add test with mhlo
 }
 
 // TODO(hinsu): Add a test with a valid TF op for which tf2xla kernel is

--- a/tensorflow/compiler/mlir/xla/transforms/legalize_tf_with_tf2xla.cc
+++ b/tensorflow/compiler/mlir/xla/transforms/legalize_tf_with_tf2xla.cc
@@ -118,6 +118,7 @@ bool IsOpAllowedTf2XlaFallback(Operation* op) {
     TypeID::get<TF::CrossOp>(),
     TypeID::get<TF::DataFormatDimMapOp>(),
     TypeID::get<TF::DataFormatVecPermuteOp>(),
+    TypeID::get<TF::DiagOp>(),
     TypeID::get<TF::DigammaOp>(),
     TypeID::get<TF::DivNoNanOp>(),
     TypeID::get<TF::EluGradOp>(),

--- a/tensorflow/compiler/tests/unary_ops_test.py
+++ b/tensorflow/compiler/tests/unary_ops_test.py
@@ -95,8 +95,6 @@ class UnaryOpsTest(xla_test.XLATestCase):
     """Tests that result and expeted are exactly equal."""
     self.assertAllEqual(result, expected)
 
-  @test_util.disable_mlir_bridge(
-      "MlirHloBuilder::Iota missing required for xla::Diag")
   def testAllTypeOps(self):
     for dtype in self.numeric_types - {np.int8, np.uint8}:
       self._assertOpOutputMatchesExpected(

--- a/tensorflow/compiler/tests/unary_ops_test.py
+++ b/tensorflow/compiler/tests/unary_ops_test.py
@@ -95,6 +95,8 @@ class UnaryOpsTest(xla_test.XLATestCase):
     """Tests that result and expeted are exactly equal."""
     self.assertAllEqual(result, expected)
 
+  @test_util.disable_mlir_bridge(
+      "Handle complex element types in DiagPart op lowering")
   def testAllTypeOps(self):
     for dtype in self.numeric_types - {np.int8, np.uint8}:
       self._assertOpOutputMatchesExpected(


### PR DESCRIPTION
Legalize `tf.diag` with tf2xla as `MlirHloBuilder::Iota` is available.