### PR TITLE
Fix issue in tf.string.format wheree unicode is not rendered correctly

### DIFF
--- a/tensorflow/core/framework/tensor.cc
+++ b/tensorflow/core/framework/tensor.cc
@@ -1007,9 +1007,9 @@ inline const strings::AlphaNum& PrintOneElement(const strings::AlphaNum& a,
 }
 inline string PrintOneElement(const tstring& a, bool print_v2) {
   if (print_v2) {
-    return "\"" + absl::CEscape(a) + "\"";
+    return "\"" + absl::Utf8SafeCEscape(a) + "\"";
   } else {
-    return absl::CEscape(a);
+    return absl::Utf8SafeCEscape(a);
   }
 }
 inline float PrintOneElement(const Eigen::half& h, bool print_v2) {

--- a/tensorflow/python/kernel_tests/string_format_op_test.py
+++ b/tensorflow/python/kernel_tests/string_format_op_test.py
@@ -379,6 +379,15 @@ class StringFormatOpTest(test.TestCase):
         format_output = string_ops.string_format("{}", (tensor, tensor))
         self.evaluate(format_output)
 
+  @test_util.run_in_graph_and_eager_modes()
+  def testTensorAndFormatUnicode(self):
+    with self.cached_session():
+      tensor = constant_op.constant('😊')
+      format_output = string_ops.string_format("😊:{}", tensor)
+      out = self.evaluate(format_output)
+      expected = '😊:"😊"'
+      self.assertEqual(compat.as_text(out), expected)
+
 
 if __name__ == "__main__":
   test.main()


### PR DESCRIPTION
This PR tries to address the issue raised in #42001 where
unicode tensor is not rendered correctly in tf.string.format.

The issue was that tf.string.format incorrectly escape the tensor.

This PR address the issue by adding escape option in tensor print
function to selectively control the escape.

This PR fixes #42001.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>