### PR TITLE
Create directory if not exist when saving keras model in h5

### DIFF
--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -1358,6 +1358,8 @@ class ModelCheckpoint(Callback):
           raise IOError('Please specify a non-directory filepath for '
                         'ModelCheckpoint. Filepath used is an existing '
                         'directory: {}'.format(filepath))
+        # Re-throw the error for any other causes.
+        raise e
 
   def _get_file_path(self, epoch, logs):
     """Returns the file path for checkpoint."""

--- a/tensorflow/python/keras/engine/training.py
+++ b/tensorflow/python/keras/engine/training.py
@@ -69,6 +69,7 @@ from tensorflow.python.ops import variables
 from tensorflow.python.ops.ragged import ragged_concat_ops
 from tensorflow.python.ops.ragged import ragged_tensor
 from tensorflow.python.platform import tf_logging as logging
+from tensorflow.python.platform import gfile
 from tensorflow.python.profiler import trace
 from tensorflow.python.training import checkpoint_management
 from tensorflow.python.training import py_checkpoint_reader
@@ -2094,6 +2095,8 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
       if not proceed:
         return
     if save_format == 'h5':
+      dirpath = os.path.dirname(filepath)
+      gfile.MakeDirs(dirpath)
       with h5py.File(filepath, 'w') as f:
         hdf5_format.save_weights_to_hdf5_group(f, self.layers)
     else:

--- a/tensorflow/python/keras/engine/training.py
+++ b/tensorflow/python/keras/engine/training.py
@@ -69,7 +69,6 @@ from tensorflow.python.ops import variables
 from tensorflow.python.ops.ragged import ragged_concat_ops
 from tensorflow.python.ops.ragged import ragged_tensor
 from tensorflow.python.platform import tf_logging as logging
-from tensorflow.python.platform import gfile
 from tensorflow.python.profiler import trace
 from tensorflow.python.training import checkpoint_management
 from tensorflow.python.training import py_checkpoint_reader
@@ -2095,8 +2094,6 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
       if not proceed:
         return
     if save_format == 'h5':
-      dirpath = os.path.dirname(filepath)
-      gfile.MakeDirs(dirpath)
       with h5py.File(filepath, 'w') as f:
         hdf5_format.save_weights_to_hdf5_group(f, self.layers)
     else:

--- a/tensorflow/python/keras/saving/hdf5_format.py
+++ b/tensorflow/python/keras/saving/hdf5_format.py
@@ -35,6 +35,7 @@ from tensorflow.python.keras.utils.generic_utils import LazyLoader
 from tensorflow.python.keras.utils.io_utils import ask_to_proceed_with_overwrite
 from tensorflow.python.ops import variables as variables_module
 from tensorflow.python.platform import tf_logging as logging
+from tensorflow.python.platform import gfile
 
 # pylint: disable=g-import-not-at-top
 try:
@@ -98,6 +99,10 @@ def save_model_to_hdf5(model, filepath, overwrite=True, include_optimizer=True):
       proceed = ask_to_proceed_with_overwrite(filepath)
       if not proceed:
         return
+
+    # Try creating dir if not exist
+    dirpath = os.path.dirname(filepath)
+    gfile.MakeDirs(dirpath)
 
     f = h5py.File(filepath, mode='w')
     opened_new_file = True

--- a/tensorflow/python/keras/saving/hdf5_format_test.py
+++ b/tensorflow/python/keras/saving/hdf5_format_test.py
@@ -731,9 +731,9 @@ class TestWholeModelSaving(keras_parameterized.TestCase):
       os.remove(fname)
 
   def test_model_saving_to_new_dir_path(self):
-    saved_model_dir = self._save_model_dir()
-    saved_model_dir = os.path.join(saved_model_dir, 'newdir')
-    saved_model_dir = os.path.join(saved_model_dir, 'saved_model')
+    saved_model_dir = os.path.join(self._save_model_dir(),
+                                   'newdir',
+                                   'saved_model')
     save_format = testing_utils.get_save_format()
 
     with self.cached_session():
@@ -766,9 +766,8 @@ class TestWholeModelSaving(keras_parameterized.TestCase):
       model.add(keras.layers.RepeatVector(3))
       model.add(keras.layers.TimeDistributed(keras.layers.Dense(3)))
 
-      x = np.random.random((1, 3))
-      with self.assertRaises(OSError):
-        with h5py.File(saved_model_path, 'w') as f:
+      with self.assertRaisesRegex(OSError, 'Unable to create file'):
+        with h5py.File(saved_model_path, 'w'):
           keras.models.save_model(model, saved_model_path)
 
 


### PR DESCRIPTION
Fixes #41874: raise error when h5 save fail; create directory if not already exist, so that it does not fail when saving to new directory.
