### PR TITLE
BUG: log_cosh alias missing results in round-trip serialization failure

### DIFF
--- a/tensorflow/python/keras/metrics.py
+++ b/tensorflow/python/keras/metrics.py
@@ -3402,6 +3402,7 @@ mae = MAE = mean_absolute_error
 mape = MAPE = mean_absolute_percentage_error
 msle = MSLE = mean_squared_logarithmic_error
 cosine_similarity = cosine_proximity
+log_cosh = logcosh
 
 
 def clone_metric(metric):


### PR DESCRIPTION
See https://colab.research.google.com/drive/1AfOBJTHOYngsPEn3Fo4rkeD4kUJG3eil#scrollTo=_pyJctK__Btb

```python3
from tensorflow.keras.metrics import deserialize, serialize

deserialize("mse")  # returns tensorflow.python.keras.losses.mean_squared_error
# so let's try deserialize("mean_squared_error")
deserialize("mean_squared_error") # returns tensorflow.python.keras.losses.mean_squared_error

deserialize("logcosh")  # returns tensorflow.python.keras.losses.log_cosh
# so let's try deserialize("log_cosh")
deserialize("log_cosh") # ValueError: Unknown metric function: log_cosh

deserialize(serialize(deserialize("mse")))  # roundtrip works

deserialize(serialize(deserialize("logcosh")))  # roundtrip breaks
```