### PR TITLE
Fixed the Windows build for TF Scala.

### DIFF
--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -882,7 +882,7 @@ genrule(
     visibility = ["//visibility:public"],
 )
 
-# The interface library (tensorflow_framework.dll.if.lib) for linking tensorflow DLL 
+# The interface library (tensorflow_framework.dll.if.lib) for linking tensorflow DLL
 # library (tensorflow_framework.dll) on Windows.
 # To learn more about import library (called interface library in Bazel):
 #     https://docs.microsoft.com/en-us/cpp/build/linking-an-executable-to-a-dll?view=vs-2017#linking-implicitly
@@ -893,7 +893,7 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-# Rename the import library for tensorflow_framework.dll from 
+# Rename the import library for tensorflow_framework.dll from
 # tensorflow_framework.dll.if.lib to tensorflow_framework.lib
 genrule(
     name = "tensorflow_framework_dll_import_lib",

--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -882,8 +882,8 @@ genrule(
     visibility = ["//visibility:public"],
 )
 
-# The interface library (tensorflow_framework.dll.if.lib) for linking tensorflow DLL library 
-# (tensorflow_framework.dll) on Windows.
+# The interface library (tensorflow_framework.dll.if.lib) for linking tensorflow DLL 
+# library (tensorflow_framework.dll) on Windows.
 # To learn more about import library (called interface library in Bazel):
 #     https://docs.microsoft.com/en-us/cpp/build/linking-an-executable-to-a-dll?view=vs-2017#linking-implicitly
 filegroup(
@@ -893,8 +893,8 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-# Rename the import library for tensorflow_framework.dll from tensorflow_framework.dll.if.lib to 
-# tensorflow_framework.lib
+# Rename the import library for tensorflow_framework.dll from 
+# tensorflow_framework.dll.if.lib to tensorflow_framework.lib
 genrule(
     name = "tensorflow_framework_dll_import_lib",
     srcs = [":get_tensorflow_framework_dll_import_lib"],

--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -882,6 +882,30 @@ genrule(
     visibility = ["//visibility:public"],
 )
 
+# The interface library (tensorflow_framework.dll.if.lib) for linking tensorflow DLL library 
+# (tensorflow_framework.dll) on Windows.
+# To learn more about import library (called interface library in Bazel):
+#     https://docs.microsoft.com/en-us/cpp/build/linking-an-executable-to-a-dll?view=vs-2017#linking-implicitly
+filegroup(
+    name = "get_tensorflow_framework_dll_import_lib",
+    srcs = ["//tensorflow:tensorflow_framework.dll"],
+    output_group = "interface_library",
+    visibility = ["//visibility:public"],
+)
+
+# Rename the import library for tensorflow_framework.dll from tensorflow_framework.dll.if.lib to 
+# tensorflow_framework.lib
+genrule(
+    name = "tensorflow_framework_dll_import_lib",
+    srcs = [":get_tensorflow_framework_dll_import_lib"],
+    outs = ["tensorflow_framework.lib"],
+    cmd = select({
+        "//tensorflow:windows": "cp -f $< $@",
+        "//conditions:default": "touch $@",  # Just a placeholder for Unix platforms
+    }),
+    visibility = ["//visibility:public"],
+)
+
 # The interface library (tensorflow_cc.dll.if.lib) for linking tensorflow DLL library (tensorflow_cc.dll) on Windows.
 # To learn more about import library (called interface library in Bazel):
 #     https://docs.microsoft.com/en-us/cpp/build/linking-an-executable-to-a-dll?view=vs-2017#linking-implicitly

--- a/tensorflow/core/framework/tensor_shape.h
+++ b/tensorflow/core/framework/tensor_shape.h
@@ -297,7 +297,10 @@ std::ostream& operator<<(std::ostream& os, const TensorShapeBase<Shape>& tsb) {
 /// zero dimensions and one element, and call AddDim() to add dimensions later.
 class TensorShape : public TensorShapeBase<TensorShape> {
  public:
-  using TensorShapeBase<TensorShape>::TensorShapeBase;
+  TF_EXPORT TensorShape(gtl::ArraySlice<int64> dim_sizes)
+      : TensorShapeBase<TensorShape>(dim_sizes) {};
+  TF_EXPORT TensorShape(std::initializer_list<int64> dim_sizes)
+      : TensorShapeBase<TensorShape>(dim_sizes) {};
 
   TF_EXPORT TensorShape(): TensorShapeBase<TensorShape>() {};
   TF_EXPORT TensorShape(const TensorShapeProto& proto): TensorShapeBase<TensorShape>(proto) {};
@@ -323,6 +326,9 @@ class TensorShape : public TensorShapeBase<TensorShape> {
   /// significantly improve performance on GPU.
   template <int NDIMS, typename IndexType = Eigen::DenseIndex>
   Eigen::DSizes<IndexType, NDIMS> AsEigenDSizesWithPadding() const;
+
+ protected:
+  explicit TensorShape(DataType dt): TensorShapeBase<TensorShape>(dt) {};
 
  private:
   // These CHECK fail to ease debugging.

--- a/tensorflow/core/framework/tensor_shape.h
+++ b/tensorflow/core/framework/tensor_shape.h
@@ -297,13 +297,7 @@ std::ostream& operator<<(std::ostream& os, const TensorShapeBase<Shape>& tsb) {
 /// zero dimensions and one element, and call AddDim() to add dimensions later.
 class TensorShape : public TensorShapeBase<TensorShape> {
  public:
-  TF_EXPORT TensorShape(gtl::ArraySlice<int64> dim_sizes)
-      : TensorShapeBase<TensorShape>(dim_sizes) {};
-  TF_EXPORT TensorShape(std::initializer_list<int64> dim_sizes)
-      : TensorShapeBase<TensorShape>(dim_sizes) {};
-
-  TF_EXPORT TensorShape(): TensorShapeBase<TensorShape>() {};
-  TF_EXPORT TensorShape(const TensorShapeProto& proto): TensorShapeBase<TensorShape>(proto) {};
+  using TensorShapeBase<TensorShape>::TensorShapeBase;
 
   /// Allow a TensorShape to be used as a PartialTensorShape without copying
   operator const PartialTensorShape&() const;  // NOLINT(runtime/explicit)
@@ -326,9 +320,6 @@ class TensorShape : public TensorShapeBase<TensorShape> {
   /// significantly improve performance on GPU.
   template <int NDIMS, typename IndexType = Eigen::DenseIndex>
   Eigen::DSizes<IndexType, NDIMS> AsEigenDSizesWithPadding() const;
-
- protected:
-  explicit TensorShape(DataType dt): TensorShapeBase<TensorShape>(dt) {};
 
  private:
   // These CHECK fail to ease debugging.

--- a/tensorflow/core/framework/tensor_shape.h
+++ b/tensorflow/core/framework/tensor_shape.h
@@ -299,6 +299,9 @@ class TensorShape : public TensorShapeBase<TensorShape> {
  public:
   using TensorShapeBase<TensorShape>::TensorShapeBase;
 
+  TF_EXPORT TensorShape(): TensorShapeBase<TensorShape>() {};
+  TF_EXPORT TensorShape(const TensorShapeProto& proto): TensorShapeBase<TensorShape>(proto) {};
+
   /// Allow a TensorShape to be used as a PartialTensorShape without copying
   operator const PartialTensorShape&() const;  // NOLINT(runtime/explicit)
 

--- a/tensorflow/core/util/tensor_bundle/tensor_bundle.cc
+++ b/tensorflow/core/util/tensor_bundle/tensor_bundle.cc
@@ -741,7 +741,7 @@ Status MergeBundles(Env* env, gtl::ArraySlice<tstring> prefixes,
 
 // Interface for reading a tensor bundle.
 
-BundleReader::BundleReader(Env* env, StringPiece prefix)
+TF_EXPORT BundleReader::BundleReader(Env* env, StringPiece prefix)
     : env_(env),
       prefix_(prefix),
       metadata_(nullptr),
@@ -796,7 +796,7 @@ BundleReader::BundleReader(Env* env, StringPiece prefix)
                           kTensorBundleMinProducer, "Checkpoint", "checkpoint");
 }
 
-BundleReader::~BundleReader() {
+TF_EXPORT BundleReader::~BundleReader() {
   delete metadata_;
   delete iter_;
   delete table_;
@@ -936,7 +936,7 @@ Status BundleReader::GetValue(const BundleEntryProto& entry, Tensor* val) {
   return Status::OK();
 }
 
-Status BundleReader::Lookup(StringPiece key, Tensor* val) {
+TF_EXPORT Status BundleReader::Lookup(StringPiece key, Tensor* val) {
   CHECK(val != nullptr);
   BundleEntryProto entry;
   TF_RETURN_IF_ERROR(GetBundleEntryProto(key, &entry));
@@ -950,7 +950,7 @@ Status BundleReader::Lookup(StringPiece key, Tensor* val) {
   }
 }
 
-Status BundleReader::ReadCurrent(Tensor* val) {
+TF_EXPORT Status BundleReader::ReadCurrent(Tensor* val) {
   CHECK(val != nullptr);
   BundleEntryProto entry;
   TF_RETURN_IF_ERROR(ParseEntryProto(iter_->key(), iter_->value(), &entry));
@@ -968,8 +968,8 @@ Status BundleReader::ReadCurrent(Tensor* val) {
   }
 }
 
-Status BundleReader::LookupTensorSlices(StringPiece key,
-                                        std::vector<TensorSlice>* slices) {
+TF_EXPORT Status BundleReader::LookupTensorSlices(StringPiece key,
+                                                  std::vector<TensorSlice>* slices) {
   slices->clear();
   BundleEntryProto entry;
   TF_RETURN_IF_ERROR(GetBundleEntryProto(key, &entry));
@@ -980,8 +980,8 @@ Status BundleReader::LookupTensorSlices(StringPiece key,
   return Status::OK();
 }
 
-Status BundleReader::LookupSlice(StringPiece full_tensor_key,
-                                 const TensorSlice& slice_spec, Tensor* val) {
+TF_EXPORT Status BundleReader::LookupSlice(StringPiece full_tensor_key,
+                                           const TensorSlice& slice_spec, Tensor* val) {
   CHECK(val != nullptr);
   BundleEntryProto entry;
   TF_RETURN_IF_ERROR(GetBundleEntryProto(full_tensor_key, &entry));
@@ -1103,13 +1103,13 @@ Status BundleReader::GetSliceValue(StringPiece full_tensor_key,
   return Status::OK();
 }
 
-bool BundleReader::Contains(StringPiece key) {
+TF_EXPORT bool BundleReader::Contains(StringPiece key) {
   Seek(key);
   return Valid() && (this->key() == key);
 }
 
-Status BundleReader::LookupDtypeAndShape(StringPiece key, DataType* dtype,
-                                         TensorShape* shape) {
+TF_EXPORT Status BundleReader::LookupDtypeAndShape(StringPiece key, DataType* dtype,
+                                                   TensorShape* shape) {
   BundleEntryProto entry;
   TF_RETURN_IF_ERROR(GetBundleEntryProto(key, &entry));
   *dtype = entry.dtype();
@@ -1117,12 +1117,12 @@ Status BundleReader::LookupDtypeAndShape(StringPiece key, DataType* dtype,
   return Status::OK();
 }
 
-Status BundleReader::LookupTensorShape(StringPiece key, TensorShape* shape) {
+TF_EXPORT Status BundleReader::LookupTensorShape(StringPiece key, TensorShape* shape) {
   DataType ignored;
   return LookupDtypeAndShape(key, &ignored, shape);
 }
 
-string BundleReader::DebugString() {
+TF_EXPORT string BundleReader::DebugString() {
   // Format used below emulates that of TensorSliceReader::DebugString().
   string shape_str;
   BundleEntryProto entry;

--- a/tensorflow/core/util/tensor_bundle/tensor_bundle.h
+++ b/tensorflow/core/util/tensor_bundle/tensor_bundle.h
@@ -182,28 +182,28 @@ Status MergeBundles(Env* env, gtl::ArraySlice<tstring> prefixes,
 // All threads accessing the same BundleReader must synchronize.
 class BundleReader {
  public:
-  BundleReader(Env* const env, StringPiece prefix);
-  ~BundleReader();
+  TF_EXPORT BundleReader(Env* const env, StringPiece prefix);
+  TF_EXPORT ~BundleReader();
 
   // Is ok() iff the reader construction is successful (completed the read of
   // the metadata).
-  Status status() const { return status_; }
+  TF_EXPORT Status status() const { return status_; }
 
   // Queries whether the bundle contains an entry keyed by "key".  Calls Seek()
   // internally, so this call invalidates the reader's current position.
   // REQUIRES: status().ok()
-  bool Contains(StringPiece key);
+  TF_EXPORT bool Contains(StringPiece key);
 
   // Looks up the dtype and the shape of the tensor keyed by "key".
   // REQUIRES: status().ok()
-  Status LookupDtypeAndShape(StringPiece key, DataType* dtype,
-                             TensorShape* shape) TF_MUST_USE_RESULT;
+  TF_EXPORT Status LookupDtypeAndShape(StringPiece key, DataType* dtype,
+                                       TensorShape* shape) TF_MUST_USE_RESULT;
 
   // Looks up the shape of the tensor keyed by "key".
   // Clears "shape" if not found.
   // REQUIRES: status().ok()
-  Status LookupTensorShape(StringPiece key,
-                           TensorShape* shape) TF_MUST_USE_RESULT;
+  TF_EXPORT Status LookupTensorShape(StringPiece key,
+                                     TensorShape* shape) TF_MUST_USE_RESULT;
 
   // Looks up the tensor keyed by "key".  If "key" refers to a partitioned
   // tensor, attempts to look up the full contents using all stored slices.
@@ -217,7 +217,7 @@ class BundleReader {
   //
   // Validates the stored crc32c checksum against the restored bytes.
   // REQUIRES: status().ok()
-  Status Lookup(StringPiece key, Tensor* val) TF_MUST_USE_RESULT;
+  TF_EXPORT Status Lookup(StringPiece key, Tensor* val) TF_MUST_USE_RESULT;
 
   // Looks up the tensor pointed to by the internal iterator.
   //
@@ -225,7 +225,7 @@ class BundleReader {
   //
   // Validates the stored crc32c checksum against the restored bytes.
   // REQUIRES: status().ok() && Valid()
-  Status ReadCurrent(Tensor* val) TF_MUST_USE_RESULT;
+  TF_EXPORT Status ReadCurrent(Tensor* val) TF_MUST_USE_RESULT;
 
   // Looks up the slices of the tensor keyed by "key".  On OK, "slices"
   // is non-empty if and only if the tensor is a partitioned tensor.
@@ -234,34 +234,34 @@ class BundleReader {
   // a slice with a larger start index in some dimension could come before
   // another slice with a smaller start index in the same dimension.
   // REQUIRES: status().ok()
-  Status LookupTensorSlices(StringPiece key, std::vector<TensorSlice>* slices)
+  TF_EXPORT Status LookupTensorSlices(StringPiece key, std::vector<TensorSlice>* slices)
       TF_MUST_USE_RESULT;
 
   // Looks up a specific slice of a partitioned tensor.
   // It is only required that the stored slices cover the requested slice,
   // namely "slice_spec" is a subset of the union of the stored slices.
   // REQUIRES: status().ok()
-  Status LookupSlice(StringPiece full_tensor_key, const TensorSlice& slice_spec,
-                     Tensor* val) TF_MUST_USE_RESULT;
+  TF_EXPORT Status LookupSlice(StringPiece full_tensor_key, const TensorSlice& slice_spec,
+                               Tensor* val) TF_MUST_USE_RESULT;
 
   // Seeks to the first position in the bundle whose key is no less than "key".
   // REQUIRES: status().ok()
-  void Seek(StringPiece key) { return iter_->Seek(key); }
+  TF_EXPORT void Seek(StringPiece key) { return iter_->Seek(key); }
   // Moves to the next position in the bundle.
   // REQUIRES: status().ok()
-  void Next() const { iter_->Next(); }
+  TF_EXPORT void Next() const { iter_->Next(); }
   // Returns true iff the reader is positioned to a key/val pair.
   // REQUIRES: status().ok()
-  bool Valid() const { return iter_->Valid(); }
+  TF_EXPORT bool Valid() const { return iter_->Valid(); }
 
   // Returns the key at the current position.
   // REQUIRES: status().ok() && Valid()
-  StringPiece key() const { return iter_->key(); }
+  TF_EXPORT StringPiece key() const { return iter_->key(); }
   // Returns the raw value at the current position.
   // REQUIRES: status().ok() && Valid()
-  StringPiece value() const { return iter_->value(); }
+  TF_EXPORT StringPiece value() const { return iter_->value(); }
 
-  string DebugString();
+  TF_EXPORT string DebugString();
 
  private:
   // Seeks for "key" and reads the metadata proto.

--- a/tensorflow/tools/def_file_filter/def_file_filter.py.tpl
+++ b/tensorflow/tools/def_file_filter/def_file_filter.py.tpl
@@ -51,8 +51,11 @@ INCLUDEPRE_RE = re.compile(r"google::protobuf::internal::ExplicitlyConstructed|"
                            r"google::protobuf::internal::ArenaImpl::AddCleanup|" # for contrib/data/_prefetching_ops
                            r"google::protobuf::internal::LogMessage|" # for contrib/data/_prefetching_ops
                            r"google::protobuf::Arena::OnArenaAllocation|" # for contrib/data/_prefetching_ops
+                           r"google::protobuf::Message::InitializationErrorString|"
+                           r"google::protobuf::MessageLite::ParseFromArray|"
                            r"absl::Mutex::ReaderLock|" # for //tensorflow/contrib/rnn:python/ops/_gru_ops.so and more ops
                            r"absl::Mutex::ReaderUnlock|" # for //tensorflow/contrib/rnn:python/ops/_gru_ops.so and more ops
+                           r"tensorflow::TensorShape|"
                            r"tensorflow::internal::LogMessage|"
                            r"tensorflow::internal::LogString|"
                            r"tensorflow::internal::CheckOpMessageBuilder|"


### PR DESCRIPTION
This PR introduces some changes that I found necessary when trying to support a windows build for TF Scala. Specifically, I added a build target for building `tensorflow_framework.lib` and made some changes to export some missing symbols that are used in the TF Scala checkpoint reader.

I also had a question: is there currently a single bazel build target that can be used for building `tensorflow.dll`, `tensorflow.lib`, `tensorflow_framework.dll`, and `tensorflow_framework.lib`, all at once? Thanks!

cc @alextp 