### PR TITLE
Fix a conv3d dgrad type issue

### DIFF
--- a/tensorflow/core/kernels/conv_grad_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_grad_ops_3d.cc
@@ -1394,7 +1394,9 @@ class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
         "TF_CUDNN_WORKSPACE_LIMIT_IN_MB", 1LL << 32);  // 4GB by default
 
     const int device_id = stream->parent()->device_ordinal();
-    DataType dtype = context->input(0).dtype();
+    // To make sure the Conv3DBackpropInputV2 get the correct dtype, we infer
+    // the dtype from 2nd input, i.e., out_backprop.
+    DataType dtype = context->input(2).dtype();
     const ConvParameters conv_parameters = {
         dims.batch_size,
         dims.in_depth,


### PR DESCRIPTION
This PR is to fix a conv3d dgrad type issue.

Before this PR, we use the `context->input(0).dtype()` to infer the dtype of the dgrad conv (mainly for creating the param key for autotuning). This is fine for the Conv3DBackpropInput, which has `Input("input: T")` as input(0). However, for the Conv3DBackpropInputV2, the input(0) turns to be `Input("input_sizes: Tshape")`. So, to fix this, we use `context->input(2).dtype()`, which is `Input("out_backprop: T")` and is shared by Conv3DBackpropInput and Conv3DBackpropInputV2.

fyi @nluehr 