### PR TITLE
Fix a logic issue of layout optimizer

### DIFF
--- a/tensorflow/core/grappler/optimizers/generic_layout_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/generic_layout_optimizer.cc
@@ -77,7 +77,7 @@ inline bool NumConvOnDeviceWithDataTypeOverThreshold(
 
   for (const auto& node : context.graph_view->GetNodes()) {
     const auto* node_def = node.node();
-    if (!IsConv2D(*node_def) or !IsConv3D(*node_def)) {
+    if (!IsConv2D(*node_def) and !IsConv3D(*node_def)) {
       continue;
     }
     const string& device_name =


### PR DESCRIPTION
The previous PR https://github.com/tensorflow/tensorflow/pull/40961 added the conv3d support. However, we noticed that the logic of this `!conv2d or !conv3d` should be `!(conv2d or conv3d)` or `!conv2d and !conv3d`. 

fyi @nluehr @ezhulenev 