### PR TITLE
tensor_diag_part doc fix

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_DiagPart.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_DiagPart.pbtxt
@@ -22,15 +22,22 @@ tensor of rank `k` with dimensions `[D1,..., Dk]` where:
 
 `diagonal[i1,..., ik] = input[i1, ..., ik, i1,..., ik]`.
 
-For example:
+For a rank 2 tensor, `diag_part` and `tensor_diag_part`
+produce the same result. An example where they differ
+is given below.
 
 ```
-# 'input' is [[1, 0, 0, 0]
-              [0, 2, 0, 0]
-              [0, 0, 3, 0]
-              [0, 0, 0, 4]]
+# 'input' is [[[[1111,1112],[1121,1122]],
+               [[1211,1212],[1221,1222]]],
+              [[[2111, 2112], [2121, 2122]],
+               [[2211, 2212], [2221, 2222]]]
+             ]
 
-tf.diag_part(input) ==> [1, 2, 3, 4]
+tf.tensor_diag_part(input) ==> [[1111, 1212], [2121, 2222]]
+tf.diag_part(input) ==> [[[1111, 1122],
+                          [1211, 1222]],
+                         [[2111, 2122],
+                          [2211, 2222]]]
 ```
 END
 }

--- a/tensorflow/core/api_def/python_api/api_def_DiagPart.pbtxt
+++ b/tensorflow/core/api_def/python_api/api_def_DiagPart.pbtxt
@@ -1,10 +1,4 @@
 op {
   graph_op_name: "DiagPart"
-  endpoint {
-    name: "linalg.tensor_diag_part"
-  }
-  endpoint {
-    name: "diag_part"
-    deprecation_version: 2
-  }
+  visibility: HIDDEN
 }

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -2610,7 +2610,8 @@ def matrix_diag_part(
       input=input, k=k, padding_value=padding_value, align=align, name=name)
 
 
-@tf_export("linalg.tensor_diag_part", v1=["linalg.tensor_diag_part", "diag_part"])
+@tf_export("linalg.tensor_diag_part",
+           v1=["linalg.tensor_diag_part", "diag_part"])
 @dispatch.add_dispatch_support
 @deprecation.deprecated_endpoints("diag_part")
 @dispatch.add_dispatch_support

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -2610,6 +2610,50 @@ def matrix_diag_part(
       input=input, k=k, padding_value=padding_value, align=align, name=name)
 
 
+@tf_export("linalg.tensor_diag_part", v1=["linalg.tensor_diag_part", "diag_part"])
+@dispatch.add_dispatch_support
+@deprecation.deprecated_endpoints("diag_part")
+@dispatch.add_dispatch_support
+def tensor_diag_part(
+    input,  # pylint:disable=redefined-builtin
+    name="tensor_diag_part"):
+  """Returns the diagonal part of the tensor.
+
+  This operation returns a tensor with the `diagonal` part
+  of the `input`. The `diagonal` part is computed as follows:
+
+  Assume `input` has dimensions `[D1,..., Dk, D1,..., Dk]`, then the output is a
+  tensor of rank `k` with dimensions `[D1,..., Dk]` where:
+
+  `diagonal[i1,..., ik] = input[i1, ..., ik, i1,..., ik]`.
+
+  For a rank 2 tensor, `diag_part` and `tensor_diag_part`
+  produce the same result. An example where they differ
+  is given below.
+
+  >>> x = [[[[1111,1112],[1121,1122]],
+  ...       [[1211,1212],[1221,1222]]],
+  ...      [[[2111, 2112], [2121, 2122]],
+  ...       [[2211, 2212], [2221, 2222]]]
+  ...      ]
+  >>> tf.linalg.tensor_diag_part(x)
+  <tf.Tensor: shape=(2, 2), dtype=int32, numpy=
+  array([[1111, 1212],
+         [2121, 2222]], dtype=int32)>
+  >>> tf.linalg.diag_part(x).shape
+  TensorShape([2, 2, 2])
+
+  Args:
+    input: A `Tensor` with rank `2k`.
+    name: A name for the operation (optional).
+
+  Returns:
+    A Tensor containing diagonals of `input`. Has the same type as `input`, and
+    rank `k`.
+  """
+  return gen_array_ops.diag_part(input=input, name=name)
+
+
 @tf_export("linalg.set_diag", v1=["linalg.set_diag", "matrix_set_diag"])
 @dispatch.add_dispatch_support
 @deprecation.deprecated_endpoints("matrix_set_diag")

--- a/tensorflow/tools/api/golden/v1/tensorflow.linalg.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.linalg.pbtxt
@@ -238,7 +238,7 @@ tf_module {
   }
   member_method {
     name: "tensor_diag_part"
-    argspec: "args=[\'input\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+    argspec: "args=[\'input\', \'name\'], varargs=None, keywords=None, defaults=[\'tensor_diag_part\'], "
   }
   member_method {
     name: "tensordot"

--- a/tensorflow/tools/api/golden/v1/tensorflow.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.pbtxt
@@ -1126,7 +1126,7 @@ tf_module {
   }
   member_method {
     name: "diag_part"
-    argspec: "args=[\'input\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+    argspec: "args=[\'input\', \'name\'], varargs=None, keywords=None, defaults=[\'tensor_diag_part\'], "
   }
   member_method {
     name: "digamma"

--- a/tensorflow/tools/api/golden/v2/tensorflow.linalg.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.linalg.pbtxt
@@ -250,7 +250,7 @@ tf_module {
   }
   member_method {
     name: "tensor_diag_part"
-    argspec: "args=[\'input\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+    argspec: "args=[\'input\', \'name\'], varargs=None, keywords=None, defaults=[\'tensor_diag_part\'], "
   }
   member_method {
     name: "tensordot"


### PR DESCRIPTION
A documentation fix for #38564 which has been closed but not been fixed. 
To restate the problem, there are two shortcoming in the current documentation:
1) The example (https://www.tensorflow.org/api_docs/python/tf/linalg/tensor_diag_part) for the **tensor_diag_part** shows in the code a call to the **diag_part** function, not to `tensor_diag_part`.
2) The numeric example is chosen such that `diag_part` and `tensor_diag_part` would give the same result. This is not really helpful for somebody looking to see what differentiates these two functions.