### PR TITLE
[EXT-SYSLIB] Add runtime_py for external flatbuffer.

### DIFF
--- a/third_party/flatbuffers/BUILD.system
+++ b/third_party/flatbuffers/BUILD.system
@@ -36,3 +36,8 @@ cc_library(
     name = "runtime_cc",
     visibility = ["//visibility:public"],
 )
+
+py_library(
+    name = "runtime_py",
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Fix proper build when ```flatbuffer``` is external ```LOCAL_LIBS```.

```
ERROR: /home/cbalint/rpmbuild/BUILD/tensorflow/tensorflow/tensorflow/lite/python/BUILD:206:11: no such target '@flatbuffers//:runtime_py': target 'runtime_py' not declared in package '' (did you mean 'runtime_cc'?) defined by /home/cbalint/rpmbuild/BUILD/tensorflow/_bazel_cbalint/4c79ce0d14678d18eb8640cac68aaf03/external/flatbuffers/BUILD.bazel and referenced by '//tensorflow/lite/python:util'
```

Cc @perfinion, @mihaimaruseac 

Thank You !