### PR TITLE
[ROCm] Explicitly specifying dtype=np.float32 for *ExpandedBatch subtests in conv_ops_3d_test

### DIFF
--- a/tensorflow/python/kernel_tests/conv_ops_3d_test.py
+++ b/tensorflow/python/kernel_tests/conv_ops_3d_test.py
@@ -189,9 +189,8 @@ class Conv3DTest(test.TestCase):
                 e_value.flatten(), c_value.flatten(), atol=tolerance, rtol=1e-6)
 
   def _CreateNumpyTensor(self, sizes):
-    return np.asarray([f * 1.0
-                       for f in range(1,
-                                      np.prod(sizes) + 1)]).reshape(sizes)
+    return np.asarray([f * 1.0 for f in range(1, np.prod(sizes) + 1)],
+                      dtype=np.float32).reshape(sizes)
 
   @test_util.run_in_graph_and_eager_modes
   def testConv3DExpandedBatch(self):


### PR DESCRIPTION
The following commit adds the *ExpandedBatch subtests in the unit test `conv_ops_3d_test`

https://github.com/tensorflow/tensorflow/commit/549e69ca1316cd6bc54cbbe28dd9340fdd7b8e76

Those unit tests currently fail on the ROCm platform, because the dtype is not explicitly specified in the capp to `np.asarray` within the `_CreateNumpyTensor`. This defaults the datatype for the data/filter tensors to `double/float64` and ROCm does not have support for it, wich leads to those subtests failing.

This PR/commit adds an explicit `dtype=np.float32` argument to above mentioned call to `np.asarray`, thus making the data/filter tensors to be of `float32` type, which makes those subtests pass on the ROCm platform.

Changing the dtype from `float64` to `float32` does change what the subtests are testing, so this change should be ok.

----------------------

/cc @cheshire @chsigg @nvining-work 