### PR TITLE
Added support for noisy dense layer

### DIFF
--- a/tensorflow/python/keras/layers/__init__.py
+++ b/tensorflow/python/keras/layers/__init__.py
@@ -131,6 +131,7 @@ from tensorflow.python.keras.layers.core import Flatten
 from tensorflow.python.keras.layers.core import RepeatVector
 from tensorflow.python.keras.layers.core import Lambda
 from tensorflow.python.keras.layers.core import Dense
+from tensorflow.python.keras.layers.core import NoisyDense
 from tensorflow.python.keras.layers.core import ActivityRegularization
 
 # Dense Attention layers.

--- a/tensorflow/python/keras/layers/core.py
+++ b/tensorflow/python/keras/layers/core.py
@@ -1259,7 +1259,7 @@ class NoisyDense(Layer):
   >>> # and output arrays of shape (None, 32).
   >>> # Note that after the first layer, you don't need to specify
   >>> # the size of the input anymore:
-  >>> model.add(tf.keras.layers.Dense(32))
+  >>> model.add(tf.keras.layers.NoisyDense(32))
   >>> model.output_shape
   (None, 32)
 

--- a/tensorflow/python/keras/layers/core.py
+++ b/tensorflow/python/keras/layers/core.py
@@ -1380,7 +1380,7 @@ class NoisyDense(Layer):
     if inputs.dtype.base_dtype != dtype.base_dtype:
       inputs = math_ops.cast(inputs, dtype=dtype)
 
-    # Unlearnable parameters added as the noise
+    # Fixed parameters added as the noise
     ε_i = tf.random.normal([self.last_dim, self.units])
     ε_j = tf.random.normal([self.units,])
 
@@ -1388,8 +1388,8 @@ class NoisyDense(Layer):
     ε_kernel = f(ε_i) * f(ε_j)
     ε_bias = f(ε_j)
 
-    # Code adapted from: https://github.com/tensorflow/tensorflow/blob/v2.3.0/tensorflow/python/keras/layers/ops/core.py
-    # Optimally performs: y = (µw + σw · εw)x + µb + σb · εb
+    # Performs: y = (µw + σw · εw)x + µb + σb · εb
+    # to calculate the output
     rank = inputs.shape.rank
     if rank == 2 or rank is None:
       if isinstance(inputs, sparse_tensor.SparseTensor):

--- a/tensorflow/python/keras/layers/core.py
+++ b/tensorflow/python/keras/layers/core.py
@@ -1372,7 +1372,7 @@ class NoisyDense(Layer):
     self.built = True
 
   @staticmethod
-  def f(x):
+  def _scale_noise(x):
     return tf.sign(x)*tf.sqrt(tf.abs(x))
 
   def call(self, inputs):
@@ -1384,7 +1384,8 @@ class NoisyDense(Layer):
     ε_i = tf.random.normal([self.last_dim, self.units])
     ε_j = tf.random.normal([self.units,])
 
-    f = NoisyDense.f
+    # Creates the factorised Gaussian noise
+    f = NoisyDense._scale_noise
     ε_kernel = f(ε_i) * f(ε_j)
     ε_bias = f(ε_j)
 

--- a/tensorflow/python/keras/layers/core_test.py
+++ b/tensorflow/python/keras/layers/core_test.py
@@ -541,6 +541,57 @@ class CoreLayersTest(keras_parameterized.TestCase):
     self.assertEqual(layer.kernel.constraint, k_constraint)
     self.assertEqual(layer.bias.constraint, b_constraint)
 
+  def test_noisy_dense(self):
+    testing_utils.layer_test(
+        keras.layers.NoisyDense, kwargs={'units': 3}, input_shape=(3, 2))
+
+    testing_utils.layer_test(
+        keras.layers.NoisyDense, kwargs={'units': 3}, input_shape=(3, 4, 2))
+
+    testing_utils.layer_test(
+        keras.layers.NoisyDense, kwargs={'units': 3}, input_shape=(None, None, 2))
+
+    testing_utils.layer_test(
+        keras.layers.NoisyDense, kwargs={'units': 3}, input_shape=(3, 4, 5, 2))
+
+  def test_noisy_dense_dtype(self):
+    inputs = ops.convert_to_tensor_v2(
+        np.random.randint(low=0, high=7, size=(2, 2)))
+    layer = keras.layers.NoisyDense(5, dtype='float32')
+    outputs = layer(inputs)
+    self.assertEqual(outputs.dtype, 'float32')
+
+  def test_noisy_dense_with_policy(self):
+    inputs = ops.convert_to_tensor_v2(
+        np.random.randint(low=0, high=7, size=(2, 2)))
+    layer = keras.layers.NoisyDense(5, dtype=policy.Policy('mixed_float16'))
+    outputs = layer(inputs)
+    output_signature = layer.compute_output_signature(
+        tensor_spec.TensorSpec(dtype='float16', shape=(2, 2)))
+    self.assertEqual(output_signature.dtype, dtypes.float16)
+    self.assertEqual(output_signature.shape, (2, 5))
+    self.assertEqual(outputs.dtype, 'float16')
+    self.assertEqual(layer.kernel.dtype, 'float32')
+
+  def test_noisy_dense_regularization(self):
+    layer = keras.layers.NoisyDense(
+        3,
+        kernel_regularizer=keras.regularizers.l1(0.01),
+        bias_regularizer='l1',
+        activity_regularizer='l2',
+        name='noisy_dense_reg')
+    layer(keras.backend.variable(np.ones((2, 4))))
+    self.assertEqual(3, len(layer.losses))
+
+  def test_noisy_dense_constraints(self):
+    k_constraint = keras.constraints.max_norm(0.01)
+    b_constraint = keras.constraints.max_norm(0.01)
+    layer = keras.layers.NoisyDense(
+        3, kernel_constraint=k_constraint, bias_constraint=b_constraint)
+    layer(keras.backend.variable(np.ones((2, 4))))
+    self.assertEqual(layer.kernel.constraint, k_constraint)
+    self.assertEqual(layer.bias.constraint, b_constraint)
+
   def test_activity_regularization(self):
     layer = keras.layers.ActivityRegularization(l1=0.1)
     layer(keras.backend.variable(np.ones((2, 4))))


### PR DESCRIPTION
Added support for noisy dense layers which are just dense layers with some random noise (decayed through gradient descent) added to the weights matrix to help with exploration in reinforcement learning environments.

Paper on noisy nets: https://arxiv.org/pdf/1706.10295.pdf