### PR TITLE
Typing mistake in the documentation of momentum optimization

### DIFF
--- a/tensorflow/python/keras/optimizer_v2/gradient_descent.py
+++ b/tensorflow/python/keras/optimizer_v2/gradient_descent.py
@@ -40,7 +40,7 @@ class SGD(optimizer_v2.OptimizerV2):
 
   ```python
   velocity = momentum * velocity - learning_rate * g
-  w = w * velocity
+  w = w + velocity
   ```
 
   When `nesterov=False`, this rule becomes:


### PR DESCRIPTION
In the documentation of momentum optimization, I noticed that it should '+' instead of '*'. This is definitely a typing mistake.