### PR TITLE
Resolved an execution error when the path contains space

### DIFF
--- a/configure.cmd
+++ b/configure.cmd
@@ -16,5 +16,5 @@
 
 set configure_dir=%~dp0
 set configure_dir=%configure_dir:~0,-1%
-python %configure_dir%\configure.py %* || ( exit /b )
+python "%configure_dir%\configure.py" %* || ( exit /b )
 echo Configuration finished


### PR DESCRIPTION
The python file configure.py does not execute if the env %configure_dir% contains spaces.
The error resolved with double quotes.