### PR TITLE
Use nasmlink genrule

### DIFF
--- a/third_party/nasm/BUILD.system
+++ b/third_party/nasm/BUILD.system
@@ -5,8 +5,14 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
+genrule(
+    name = "lnnasmlink",
+    outs = ["nasmlink"],
+    cmd = "ln -s $$(which nasm) $@",
+)
+
 sh_binary(
     name = "nasm",
-    srcs = ["nasm"],
+    srcs = ["nasmlink"],
     visibility = ["@libjpeg_turbo//:__pkg__"],
 )


### PR DESCRIPTION
Avoids cyclic dependency as the name and src must not be the same. This uses the same mechanism as done by cython

Fixes #42264 (see that for more details), TLDR is:

Currently the build file sets the name and src to "nasm" which is forbidden: https://docs.bazel.build/versions/master/be/shell.html

>    do not give the rule and the file the same name.

This PR fixes that by using an intermediate rule with a different name