### PR TITLE
Fix broken compilation

### DIFF
--- a/tensorflow/lite/micro/tools/make/targets/esp32_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/esp32_makefile.inc
@@ -2,4 +2,6 @@
 
 ifeq ($(TARGET), esp)
   TARGET_ARCH := xtensa-esp32
+  CCFLAGS := $(filter-out -std=c11,$(CCFLAGS))
+  CFLAGS += -std=c11
 endif


### PR DESCRIPTION
On ESP32, the -std=c11 flags are also passed to .cc files for some reason, causing the compiler to throw an error.
I am not quite sure if the `CFLAGS` there are required though.