### PR TITLE
TFLite: Improved memory access pattern in integer_ops depthwise_conv.h

### DIFF
--- a/tensorflow/lite/kernels/internal/reference/integer_ops/depthwise_conv.h
+++ b/tensorflow/lite/kernels/internal/reference/integer_ops/depthwise_conv.h
@@ -58,25 +58,42 @@ inline void DepthwiseConvPerChannel(
   TFLITE_DCHECK_EQ(output_depth, input_depth * depth_multiplier);
   TFLITE_DCHECK_EQ(bias_shape.FlatSize(), output_depth);
 
+  const int channel_step = 32;
+
   for (int batch = 0; batch < batches; ++batch) {
     for (int out_y = 0; out_y < output_height; ++out_y) {
       for (int out_x = 0; out_x < output_width; ++out_x) {
-        for (int in_channel = 0; in_channel < input_depth; ++in_channel) {
-          for (int m = 0; m < depth_multiplier; ++m) {
-            const int output_channel = m + in_channel * depth_multiplier;
-            const int in_x_origin = (out_x * stride_width) - pad_width;
-            const int in_y_origin = (out_y * stride_height) - pad_height;
-            int32_t acc = 0;
+        for (int m = 0; m < depth_multiplier; ++m) {
+          const int in_x_origin = (out_x * stride_width) - pad_width;
+          const int in_y_origin = (out_y * stride_height) - pad_height;
+          // Divide channels to chunks of size channel_step
+          for (int begin_ch = 0; begin_ch < input_depth;
+               begin_ch += channel_step) {
+            // Allocate a partial result accumulator for each channel
+            // in current chunks
+            int32_t acc[channel_step] = {0};
+            // Calculate the last channel for current chunk
+            const int steps =
+                std::min(input_depth, begin_ch + channel_step) - begin_ch;
+
+            // Accumulate partial results to acc for a small chunk of channels
             for (int filter_y = 0; filter_y < filter_height; ++filter_y) {
+              const int in_y = in_y_origin + dilation_height_factor * filter_y;
               for (int filter_x = 0; filter_x < filter_width; ++filter_x) {
                 const int in_x = in_x_origin + dilation_width_factor * filter_x;
-                const int in_y =
-                    in_y_origin + dilation_height_factor * filter_y;
                 // Zero padding by omitting the areas outside the image.
                 const bool is_point_inside_image =
                     (in_x >= 0) && (in_x < input_width) && (in_y >= 0) &&
                     (in_y < input_height);
-                if (is_point_inside_image) {
+
+                if (!is_point_inside_image) {
+                  continue;
+                }
+
+                for (int offset_ch = 0; offset_ch < steps; ++offset_ch) {
+                  const int in_channel = begin_ch + offset_ch;
+                  const int output_channel = m + in_channel * depth_multiplier;
+
                   int32_t input_val = input_data[Offset(
                       input_shape, batch, in_y, in_x, in_channel)];
                   int32_t filter_val = filter_data[Offset(
@@ -97,21 +114,31 @@ inline void DepthwiseConvPerChannel(
                   // we have seen so far.
                   // TODO(jianlijianli): Add a check to make sure the
                   // accumulator depth is smaller than 2^16.
-                  acc += filter_val * (input_val + input_offset);
+                  acc[offset_ch] += filter_val * (input_val + input_offset);
                 }
               }
             }
-            if (bias_data) {
-              acc += bias_data[output_channel];
+
+            // Add bias / activations for current chunk of channels
+            for (int offset_ch = 0; offset_ch < steps; ++offset_ch) {
+              const int in_channel = begin_ch + offset_ch;
+              const int output_channel = m + in_channel * depth_multiplier;
+
+              int32_t value = acc[offset_ch];
+              if (bias_data) {
+                value += bias_data[output_channel];
+              }
+
+              value = MultiplyByQuantizedMultiplier(
+                  value, output_multiplier[output_channel],
+                  output_shift[output_channel]);
+              value += output_offset;
+              value = std::max(value, output_activation_min);
+              value = std::min(value, output_activation_max);
+
+              output_data[Offset(output_shape, batch, out_y, out_x,
+                                 output_channel)] = static_cast<int8_t>(value);
             }
-            acc = MultiplyByQuantizedMultiplier(
-                acc, output_multiplier[output_channel],
-                output_shift[output_channel]);
-            acc += output_offset;
-            acc = std::max(acc, output_activation_min);
-            acc = std::min(acc, output_activation_max);
-            output_data[Offset(output_shape, batch, out_y, out_x,
-                               output_channel)] = static_cast<int8_t>(acc);
           }
         }
       }


### PR DESCRIPTION
This PR improves the memory access pattern of the int8 version of `DepthwiseConvPerChannel` in `tensorflow/lite/kernels/internal/reference/integer_ops/depthwise_conv.h`. The implementation iterates input/filter data in a sequential manner (for each (x, y), access the data in each channel from 0, 1, ..., C - 1) which becomes consistent with the flattened memory layout (NHWC) in TFLite tensors. This design involves a small fixed size accumulator to store intermediate values in order to sequentially access the memory and utilizes memory hierarchy to reduce the latency caused by cache miss.

[Updated] August 19: Added uint8 version of the same implementation.

The change results in a 5.03% (uint8) / 5.05% (int8) of speedup during inference (or a total of 18.25% speedup if combined with the changes in #41947 ) when running person_detection_experimental (MobileNetV1) on Arty A7 using the soft CPU provided by Antmicro, see antmicro/litex-vexriscv-tensorflow-lite-demo for more info.