### PR TITLE
[TFLu] Update initialization of 'input_dims' in EvalQuantizedInt8() method of Fully Connected kernel (CMSIS-NN)

### DIFF
--- a/tensorflow/lite/micro/kernels/cmsis-nn/fully_connected.cc
+++ b/tensorflow/lite/micro/kernels/cmsis-nn/fully_connected.cc
@@ -142,7 +142,7 @@ TfLiteStatus EvalQuantizedInt8(TfLiteContext* context, TfLiteNode* node,
   // The 'if' condition can be removed when null handling of bias is added to
   // arm_fully_connected_s8
   if (nullptr != tflite::micro::GetTensorData<int32_t>(bias)) {
-    RuntimeShape output_shape = tflite::micro::GetTensorShape(output);
+    const RuntimeShape output_shape = tflite::micro::GetTensorShape(output);
     TFLITE_DCHECK_EQ(output_shape.DimensionsCount(), 2);
     const int batches = output_shape.Dims(0);
     const int output_depth = output_shape.Dims(1);
@@ -164,9 +164,9 @@ TfLiteStatus EvalQuantizedInt8(TfLiteContext* context, TfLiteNode* node,
 
     cmsis_nn_dims input_dims;
     input_dims.n = batches;
-    input_dims.h = input_shape.Dims(1);
-    input_dims.w = input_shape.Dims(2);
-    input_dims.c = input_shape.Dims(3);
+    input_dims.h = 1;
+    input_dims.w = 1;
+    input_dims.c = accum_depth;
 
     cmsis_nn_dims filter_dims;
     filter_dims.n = accum_depth;


### PR DESCRIPTION
This is a new pull request based on the comments of #41285, which aims to fix initialization of `cmsis_nn_dims input_dims`.

Fixes #41816
