### PR TITLE
TFLite: reduced duplicated calculation of exp in softmax.h (float)

### DIFF
--- a/tensorflow/lite/kernels/internal/reference/softmax.h
+++ b/tensorflow/lite/kernels/internal/reference/softmax.h
@@ -49,15 +49,15 @@ inline void Softmax(const SoftmaxParams& params,
     // Compute sum.
     float sum = 0.f;
     for (int c = 0; c < depth; ++c) {
-      sum += std::exp((input_data[i * depth + c] - max) *
-                      static_cast<float>(params.beta));
+      const float exp_c = std::exp((input_data[i * depth + c] - max) *
+                                   static_cast<float>(params.beta));
+      output_data[i * depth + c] = exp_c;
+      sum += exp_c;
     }
 
     // Compute result.
     for (int c = 0; c < depth; ++c) {
-      output_data[i * depth + c] = std::exp((input_data[i * depth + c] - max) *
-                                            static_cast<float>(params.beta)) /
-                                   sum;
+      output_data[i * depth + c] = output_data[i * depth + c] / sum;
     }
   }
 }


### PR DESCRIPTION
This PR improves floating point softmax kernel (similar to the implementation on [GPU version](https://github.com/tensorflow/tensorflow/blob/84d053187cb80d975ef2b9684d4b61981bca0c41/tensorflow/core/kernels/sparse/kernels_gpu.cu.cc#L345)). The original implementation calculates the sum of exponential terms in the first pass and then in the second pass, the exponential terms are recalculated and divided by the sum in the first pass to get the final results.

The change reduces duplicated calculations of exponential terms, to be more specific, exponential terms are calculated and stored in the output tensor and accumulate the value to sum in the first pass; on the second pass, the only thing need to be done is to load the value at the output and divided by the sum.

Experiments on zephyr_riscv platforms (I use Arty A7 running RISC-V soft-CPU) gives great performance improvements in the Softmax alone. The runtime is measured in number of CPU cycles (clock speed is fixed in this platform) not actual time, but improvements are expected to be similar on other devices as well.

| Input size |    # cycles (k) [Before]    |    # cycles (k) [After]    | Speedup (%) |
|:----------:|:------------:|:------------:|:-----------:|
|      2     |      16      |      5.8     |    75.47%   |
|      5     |      53      |      13      |    75.25%   |
|     10     |      101     |      25      |    50.62%   |
|     16     |      81      |      40      |    50.62%   |
|     32     |      162     |      81      |    50.00%   |
|     64     |      225     |      161     |    28.44%   |
|     128    |      452     |      321     |    28.98%   |
|     256    |      902     |      640     |    29.05%   |
|     512    |     1812     |     1285     |    29.08%   |
|    1024    |     3628     |     2584     |    28.78%   |

* *Input size* is the dimension of the row vector passed into softmax layer