### PR TITLE
[40171] Limit size of kernel cache

### DIFF
--- a/tensorflow/core/common_runtime/eager/context.h
+++ b/tensorflow/core/common_runtime/eager/context.h
@@ -518,6 +518,8 @@ class EagerContext : public ImmediateExecutionContext, public core::RefCounted {
 
   void ResetClusterFLR(DistributedFunctionLibraryRuntime* cluster_flr);
 
+  void RemoveKernelFromCacheImpl(Fprint128 cache_key);
+
   template <typename T>
   struct OwnedOrUnownedHelper {
    public:


### PR DESCRIPTION
The `EagerContext` class caches instances of kernels that have been used by the current session.  Because kernel state is opaque to `EagerContext`, the caching mechanism is very conservative about reusing kernels.  Also, there is no limit on the number of kernels cached.  As a result of these two factors, the size of the kernel cache grows in an unbounded fashion if the application calls `tf.saved_model.load()` repeatedly.  This growth is the root cause of one of the memory leaks observed in issue #40171 .

This PR puts an upper limit on the size of the kernel cache in `EagerContext`.  If the number of kernels exceeds this limit, the cache discards the least recently used kernel. I have hard-coded the capacity to a conservative number of 10000 kernels, which should be enough to prevent thrashing in normal usage while still providing protection against memory leaks.

I also added a `RemoveKernelFromCache()` method to go with the `AddKernelToCache()` method.

Here is a graph showing memory usage for a Python script that repeatedly loads and unloads a toy Keras model:
![mem_before_and_after](https://user-images.githubusercontent.com/12436991/90189530-38f7de00-dd72-11ea-99b5-27b6e6e45624.png)
The blue points show the memory footprint of that script before applying these changes; and the orange points show the memory footprint after applying these changes.

After the changes in this PR, memory usage of my test script increases until the kernel cache reaches its maximum size. After that, the memory usage increases more slowly, because there are additional memory leaks in `saved_model.load()` that are not addressed in this PR.

