### PR TITLE
Run SWIG in the default environment

### DIFF
--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -1652,6 +1652,7 @@ def _py_wrap_cc_impl(ctx):
     args.append(src.path)
     outputs = [ctx.outputs.cc_out, ctx.outputs.py_out]
     ctx.actions.run(
+        use_default_shell_env = True,
         executable = ctx.executable._swig,
         arguments = args,
         inputs = inputs,


### PR DESCRIPTION
This avoids failures when swig is build in custom envs e.g. with a compiler installed into another location (e.g. /opt)
See also https://github.com/bazelbuild/bazel/issues/4053
Patch by @boegel from https://github.com/bazelbuild/bazel/issues/4053#issuecomment-343134886

Fixes #41806