### PR TITLE
[tflite] make `//tensorflow/lite/kernels:all` build

### DIFF
--- a/tensorflow/lite/kernels/BUILD
+++ b/tensorflow/lite/kernels/BUILD
@@ -1,5 +1,4 @@
-load("//tensorflow/lite:build_def.bzl", "tflite_copts")
-load("//tensorflow/lite:build_def.bzl", "tflite_linkopts")
+load("//tensorflow/lite:build_def.bzl", "tflite_copts", "tflite_linkopts")
 load("//tensorflow/lite/micro:build_def.bzl", "micro_copts")
 load("//tensorflow/lite:special_rules.bzl", "tflite_portable_test_suite_combined")
 load("//tensorflow:tensorflow.bzl", "tf_opts_nortti_if_android")

--- a/tensorflow/lite/kernels/BUILD
+++ b/tensorflow/lite/kernels/BUILD
@@ -146,15 +146,15 @@ cc_library(
         "acceleration_test_util_internal.cc",
     ],
     hdrs = ["acceleration_test_util_internal.h"],
+    linkopts = select({
+        "//tensorflow:windows": [],
+        "//conditions:default": ["-lm"],
+    }),
     deps = [
         "//tensorflow/lite:minimal_logging",
         "@com_google_absl//absl/types:optional",
         "@com_googlesource_code_re2//:re2",
     ],
-    linkopts = select({
-        "//tensorflow:windows": [],
-        "//conditions:default": ["-lm"],
-    }),
 )
 
 cc_test(
@@ -275,6 +275,10 @@ cc_test(
     name = "eigen_support_test",
     size = "small",
     srcs = ["eigen_support_test.cc"],
+    linkopts = select({
+        "//tensorflow:windows": [],
+        "//conditions:default": ["-lm"],
+    }),
     deps = [
         ":eigen_support",
         "//tensorflow/lite/c:common",
@@ -282,10 +286,6 @@ cc_test(
         "//third_party/eigen3",
         "@com_google_googletest//:gtest",
     ],
-    linkopts = select({
-        "//tensorflow:windows": [],
-        "//conditions:default": ["-lm"],
-    }),
 )
 
 cc_library(
@@ -463,16 +463,16 @@ cc_test(
     name = "kernel_util_test",
     size = "small",
     srcs = ["kernel_util_test.cc"],
+    linkopts = select({
+        "//tensorflow:windows": [],
+        "//conditions:default": ["-lm"],
+    }),
     deps = [
         ":kernel_util",
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/testing:util",
         "@com_google_googletest//:gtest",
     ],
-    linkopts = select({
-        "//tensorflow:windows": [],
-        "//conditions:default": ["-lm"],
-    }),
 )
 
 cc_test(

--- a/tensorflow/lite/kernels/BUILD
+++ b/tensorflow/lite/kernels/BUILD
@@ -151,11 +151,9 @@ cc_library(
         "@com_google_absl//absl/types:optional",
         "@com_googlesource_code_re2//:re2",
     ],
-    linkopts = tflite_linkopts() + select({
-        "//tensorflow:android": [
-            "-lm",
-        ],
-        "//conditions:default": [],
+    linkopts = select({
+        "//tensorflow:windows": [],
+        "//conditions:default": ["-lm"],
     }),
 )
 
@@ -284,11 +282,9 @@ cc_test(
         "//third_party/eigen3",
         "@com_google_googletest//:gtest",
     ],
-    linkopts = tflite_linkopts() + select({
-        "//tensorflow:android": [
-            "-lm",
-        ],
-        "//conditions:default": [],
+    linkopts = select({
+        "//tensorflow:windows": [],
+        "//conditions:default": ["-lm"],
     }),
 )
 
@@ -473,11 +469,9 @@ cc_test(
         "//tensorflow/lite/testing:util",
         "@com_google_googletest//:gtest",
     ],
-    linkopts = tflite_linkopts() + select({
-        "//tensorflow:android": [
-            "-lm"
-        ],
-        "//conditions:default": [],
+    linkopts = select({
+        "//tensorflow:windows": [],
+        "//conditions:default": ["-lm"],
     }),
 )
 

--- a/tensorflow/lite/kernels/BUILD
+++ b/tensorflow/lite/kernels/BUILD
@@ -1,4 +1,5 @@
 load("//tensorflow/lite:build_def.bzl", "tflite_copts")
+load("//tensorflow/lite:build_def.bzl", "tflite_linkopts")
 load("//tensorflow/lite/micro:build_def.bzl", "micro_copts")
 load("//tensorflow/lite:special_rules.bzl", "tflite_portable_test_suite_combined")
 load("//tensorflow:tensorflow.bzl", "tf_opts_nortti_if_android")
@@ -150,6 +151,12 @@ cc_library(
         "@com_google_absl//absl/types:optional",
         "@com_googlesource_code_re2//:re2",
     ],
+    linkopts = tflite_linkopts() + select({
+        "//tensorflow:android": [
+            "-lm",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 cc_test(
@@ -277,6 +284,12 @@ cc_test(
         "//third_party/eigen3",
         "@com_google_googletest//:gtest",
     ],
+    linkopts = tflite_linkopts() + select({
+        "//tensorflow:android": [
+            "-lm",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 cc_library(
@@ -460,6 +473,12 @@ cc_test(
         "//tensorflow/lite/testing:util",
         "@com_google_googletest//:gtest",
     ],
+    linkopts = tflite_linkopts() + select({
+        "//tensorflow:android": [
+            "-lm"
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 cc_test(

--- a/tensorflow/lite/kernels/BUILD
+++ b/tensorflow/lite/kernels/BUILD
@@ -1,4 +1,4 @@
-load("//tensorflow/lite:build_def.bzl", "tflite_copts", "tflite_linkopts")
+load("//tensorflow/lite:build_def.bzl", "tflite_copts")
 load("//tensorflow/lite/micro:build_def.bzl", "micro_copts")
 load("//tensorflow/lite:special_rules.bzl", "tflite_portable_test_suite_combined")
 load("//tensorflow:tensorflow.bzl", "tf_opts_nortti_if_android")

--- a/tensorflow/lite/kernels/kernel_util_test.cc
+++ b/tensorflow/lite/kernels/kernel_util_test.cc
@@ -14,11 +14,11 @@ limitations under the License.
 ==============================================================================*/
 #include "tensorflow/lite/kernels/kernel_util.h"
 
+#include <math.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include <cmath>
 #include <initializer_list>
 #include <vector>
 

--- a/tensorflow/lite/kernels/kernel_util_test.cc
+++ b/tensorflow/lite/kernels/kernel_util_test.cc
@@ -14,11 +14,11 @@ limitations under the License.
 ==============================================================================*/
 #include "tensorflow/lite/kernels/kernel_util.h"
 
-#include <math.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
+#include <cmath>
 #include <initializer_list>
 #include <vector>
 


### PR DESCRIPTION
make
```
bazel build --config android_arm64 //tensorflow/lite/kernels:all
```
work.

I want to run all test cases on an Android devices, but  there are some problems why trying to build `//tensorflow/lite/kernels:all`. All of them are libm related problems.