### PR TITLE
[40171] Add VarHandleOp to set of kernels not to cache

### DIFF
--- a/tensorflow/core/common_runtime/eager/execute.cc
+++ b/tensorflow/core/common_runtime/eager/execute.cc
@@ -92,6 +92,10 @@ const string& DeviceNameOrUnspecified(VariantDevice device) {
 bool KernelCacheEnabled(const OpDef& op_def) {
   if (data::DatasetOpKernel::IsDatasetOp(&op_def)) {
     return false;
+  } else if (op_def.name() == "VarHandleOp") {
+    // [40171] Don't cache kernels for VarHandleOp because `saved_model.load()`
+    // rewrites these ops to be globally-unique on every load operation.
+    return false;
   }
   // TODO(b/162540360): Revisit a way to mark kernels as uncachable once we have
   // 5+ kernels to exclude.


### PR DESCRIPTION
Following the discussion with @jaingaurav on pull request #42337 , I have reimplemented the patch for the fourth memory leak from issue #40171 . This new version of the patch filters out `VarHandleOp` operations from the set of operations whose kernels are cached inside `EagerExecutor`. Excluding `VarHandleOp` from caching prevents `saved_model.load()` from leaking kernels when loading variable values. This change reduces the amount of memory leakage on my test script (which repeatedly loads a toy Keras model) substantially:

![cache_vs_no_cache](https://user-images.githubusercontent.com/12436991/90295190-1b437b00-de3d-11ea-870d-57d53534ee8b.png)

Not caching these kernels should have minimal negative impact on performance as far as I'm aware.  `VarHandleOp::Compute()` is a relatively lightweight operation that usually runs right before a more expensive operation.