### PR TITLE
Add EuclideanNorm XLA kernel

### DIFF
--- a/tensorflow/compiler/jit/mark_for_compilation_pass.cc
+++ b/tensorflow/compiler/jit/mark_for_compilation_pass.cc
@@ -1892,6 +1892,7 @@ absl::flat_hash_set<string> GetKnownXLAAllowlistOp() {
                                      "Einsum",
                                      "EmptyTensorList",
                                      "EnsureShape",
+                                     "EuclideanNorm",
                                      "ExtractImagePatches",
                                      "Igamma",
                                      "IgammaGradA",

--- a/tensorflow/compiler/tests/reduce_ops_test.py
+++ b/tensorflow/compiler/tests/reduce_ops_test.py
@@ -25,6 +25,7 @@ from absl.testing import parameterized
 import numpy as np
 
 from tensorflow.compiler.tests import xla_test
+from tensorflow.python.eager import def_function
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors_impl
 from tensorflow.python.ops import array_ops
@@ -50,7 +51,8 @@ class ReduceOpsTest(xla_test.XLATestCase, parameterized.TestCase):
         with self.test_scope():
           a = array_ops.placeholder(dtype)
           index = array_ops.placeholder(index_dtype)
-          out = tf_reduce_fn(a, index)
+          out = def_function.function(experimental_compile=True)(
+              tf_reduce_fn)(a, index)
         result = sess.run(out, {a: test_input, index: [0]})
         self.assertAllClose(
             result, np_reduce_fn(test_input, axis=0), rtol=rtol, atol=atol)
@@ -178,6 +180,44 @@ class ReduceOpsTest(xla_test.XLATestCase, parameterized.TestCase):
           errors_impl.InvalidArgumentError,
           'Axes contains duplicate dimension'):
         sess.run(out, {a: [10, 20, 30], index: [0, 0]})
+
+  def testReduceEuclideanNorm(self, index_dtype):
+    def reference_euclidean_norm(dtype, inp, axis):
+      inp = inp.astype(dtype)
+      return np.sqrt(np.sum(inp * np.conj(inp), axis)).astype(dtype)
+
+    for real_dtype in [np.int32, np.int64, np.float16,
+                       np.float32, np.float64]:
+      self._testReduction(math_ops.reduce_euclidean_norm,
+                          functools.partial(
+                              reference_euclidean_norm, real_dtype),
+                          real_dtype,
+                          self.REAL_DATA, index_dtype)
+
+    for complex_dtype in [np.complex64, np.complex128]:
+      self._testReduction(math_ops.reduce_euclidean_norm,
+                          functools.partial(
+                              reference_euclidean_norm, complex_dtype),
+                          complex_dtype,
+                          self.COMPLEX_DATA, index_dtype)
+
+  def testReduceEuclideanNormEmptyAxis(self, index_dtype):
+    # special case for euclidean norm because sqrt(a * a) != a
+    # when a is negative real number or complex number.
+    fn = def_function.function(experimental_compile=True)(
+        math_ops.reduce_euclidean_norm)
+
+    for real_dtype in [np.int32, np.int64, np.float16,
+                       np.float32, np.float64]:
+      x = (np.arange(12).reshape(3, 4) - 6).astype(real_dtype)
+      expected_result = np.abs(x)
+      self.assertAllCloseAccordingToType(fn(x, axis=[]), expected_result)
+
+    for complex_dtype in [np.complex64, np.complex128]:
+      x = np.arange(12).reshape(3, 4).astype(np.float32)
+      x = (x + x * 1j).astype(complex_dtype)
+      expected_result = np.sqrt(x * np.conj(x))
+      self.assertAllCloseAccordingToType(fn(x, axis=[]), expected_result)
 
 
 class ReduceOpPrecisionTest(xla_test.XLATestCase):

--- a/tensorflow/compiler/tf2xla/kernels/reduction_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/reduction_ops.cc
@@ -20,8 +20,10 @@ limitations under the License.
 #include "tensorflow/compiler/tf2xla/xla_helpers.h"
 #include "tensorflow/compiler/tf2xla/xla_op_registry.h"
 #include "tensorflow/compiler/xla/client/lib/constants.h"
+#include "tensorflow/compiler/xla/client/lib/math.h"
 #include "tensorflow/compiler/xla/client/xla_builder.h"
 #include "tensorflow/compiler/xla/literal.h"
+#include "tensorflow/compiler/xla/primitive_util.h"
 #include "tensorflow/core/framework/kernel_def_builder.h"
 
 namespace tensorflow {
@@ -183,6 +185,54 @@ class AnyOp : public XlaReductionOp {
 
 REGISTER_XLA_OP(Name("Any").CompileTimeConstantInput("reduction_indices"),
                 AnyOp);
+
+class EuclideanNormOp : public XlaReductionOp {
+ public:
+  explicit EuclideanNormOp(OpKernelConstruction* ctx)
+      : XlaReductionOp(ctx,
+                       XlaHelpers::SumAccumulationType(ctx->input_type(0))) {}
+  xla::XlaOp InitialValue(xla::XlaBuilder* builder) override {
+    return xla::Zero(builder, xla_reduction_type_);
+  }
+
+  xla::XlaOp PreprocessInput(xla::XlaBuilder* /*builder*/,
+                             const xla::XlaOp& data) override {
+    return xla::Mul(data, MaybeConjugate(data, true));
+  }
+
+  xla::XlaOp ComputeWhenEmptyAxis(xla::XlaBuilder* builder,
+                                  const xla::XlaOp& input) override {
+    // For real numbers, sqrt(x * x) = abs(x).
+    if (!xla::primitive_util::IsComplexType(xla_reduction_type_)) {
+      return xla::Abs(input);
+    }
+    return xla::Sqrt(PreprocessInput(builder, input));
+  }
+
+  void BuildReducer(xla::XlaBuilder* builder, const xla::XlaOp& scalar_lhs,
+                    const xla::XlaOp& scalar_rhs) override {
+    xla::Add(scalar_lhs, scalar_rhs);
+  }
+
+  xla::XlaOp BuildFinalizer(
+      xla::XlaBuilder* /*builder*/, const xla::XlaOp& input,
+      const xla::XlaOp& reduce_output,
+      const std::vector<int64>& /*dimensions_to_reduce*/) override {
+    if (xla::primitive_util::IsIntegralType(xla_reduction_type_)) {
+      // XLA only supports float and complex sqrt.
+      // Thus, cast integral type to F32 for computation.
+      return XlaHelpers::ConvertElementType(
+          xla::Sqrt(xla::ConvertElementType(reduce_output, xla::F32)),
+          input_type(0));
+    }
+    return XlaHelpers::ConvertElementType(xla::Sqrt(reduce_output),
+                                          input_type(0));
+  }
+};
+
+REGISTER_XLA_OP(
+    Name("EuclideanNorm").CompileTimeConstantInput("reduction_indices"),
+    EuclideanNormOp);
 
 }  // namespace
 }  // namespace tensorflow

--- a/tensorflow/compiler/tf2xla/kernels/reduction_ops.h
+++ b/tensorflow/compiler/tf2xla/kernels/reduction_ops.h
@@ -39,6 +39,16 @@ class XlaReductionOp : public XlaOpKernel {
   // Return the base case for the reduction.
   virtual xla::XlaOp InitialValue(xla::XlaBuilder* builder) = 0;
 
+  // Preprocesses input before reduction.
+  virtual xla::XlaOp PreprocessInput(xla::XlaBuilder* builder,
+                                     const xla::XlaOp& data);
+
+  // Return the output when axis is empty.
+  // Defaults to returning input directly, which is correct for common
+  // reduction ops, such as sum, mean and prod.
+  virtual xla::XlaOp ComputeWhenEmptyAxis(xla::XlaBuilder* builder,
+                                          const xla::XlaOp& input);
+
   // Implement the (scalar,scalar)->scalar lambda that should be
   // applied to each pair of elements to be reduced. The desired
   // computation should be added to 'builder' and


### PR DESCRIPTION
Per discussion https://github.com/tensorflow/tensorflow/pull/41916#issuecomment-673641088. In order not to have additional works for common reduction ops, it calls another virtual function, which defaults to returning input directly when axis is empty. I have no better engineering way to approach this, so it's more than welcome to have some feedback. Thanks!

/cc @cheshire.