### PR TITLE
Prevent Aborted (core dumped) in tf.nest.assert_same_structure for type mismatch in passed args

### DIFF
--- a/tensorflow/python/util/nest.py
+++ b/tensorflow/python/util/nest.py
@@ -392,6 +392,9 @@ def assert_same_structure(nest1, nest2, check_types=True,
     TypeError: If the two structures differ in the type of sequence in any of
       their substructures. Only possible if `check_types` is `True`.
   """
+  # Convert to bool explicitly as otherwise pybind will not be able# to handle
+  # type mismatch message correctly. See GitHub issue 42329 for details.
+  check_types = bool(check_types)
   try:
     _pywrap_utils.AssertSameStructure(nest1, nest2, check_types,
                                       expand_composites)

--- a/tensorflow/python/util/nest.py
+++ b/tensorflow/python/util/nest.py
@@ -395,6 +395,7 @@ def assert_same_structure(nest1, nest2, check_types=True,
   # Convert to bool explicitly as otherwise pybind will not be able# to handle
   # type mismatch message correctly. See GitHub issue 42329 for details.
   check_types = bool(check_types)
+  expand_composites = bool(expand_composites)
   try:
     _pywrap_utils.AssertSameStructure(nest1, nest2, check_types,
                                       expand_composites)

--- a/tensorflow/python/util/nest_test.py
+++ b/tensorflow/python/util/nest_test.py
@@ -1221,8 +1221,12 @@ class NestTest(parameterized.TestCase, test.TestCase):
   def testInvalidCheckTypes(self):
     with self.assertRaises(ValueError):
       nest.assert_same_structure(
-          nest1=array_ops.zeros((1)), nest2=array_ops.ones((1,1,1)),
+          nest1=array_ops.zeros((1)), nest2=array_ops.ones((1, 1, 1)),
           check_types=array_ops.ones((2)))
+    with self.assertRaises(ValueError):
+      nest.assert_same_structure(
+          nest1=array_ops.zeros((1)), nest2=array_ops.ones((1, 1, 1)),
+          expand_composites=array_ops.ones((2)))
 
 
 class NestBenchmark(test.Benchmark):

--- a/tensorflow/python/util/nest_test.py
+++ b/tensorflow/python/util/nest_test.py
@@ -1219,11 +1219,11 @@ class NestTest(parameterized.TestCase, test.TestCase):
     )
 
   def testInvalidCheckTypes(self):
-    with self.assertRaises(ValueError):
+    with self.assertRaises((ValueError, TypeError)):
       nest.assert_same_structure(
           nest1=array_ops.zeros((1)), nest2=array_ops.ones((1, 1, 1)),
           check_types=array_ops.ones((2)))
-    with self.assertRaises(ValueError):
+    with self.assertRaises((ValueError, TypeError)):
       nest.assert_same_structure(
           nest1=array_ops.zeros((1)), nest2=array_ops.ones((1, 1, 1)),
           expand_composites=array_ops.ones((2)))

--- a/tensorflow/python/util/nest_test.py
+++ b/tensorflow/python/util/nest_test.py
@@ -1218,6 +1218,12 @@ class NestTest(parameterized.TestCase, test.TestCase):
         expected,
     )
 
+  def testInvalidCheckTypes(self):
+    with self.assertRaises(ValueError):
+      nest.assert_same_structure(
+          nest1=array_ops.zeros((1)), nest2=array_ops.ones((1,1,1)),
+          check_types=array_ops.ones((2)))
+
 
 class NestBenchmark(test.Benchmark):
 


### PR DESCRIPTION


This PR tries to address the issue raised in #42329 where
tf.nest.assert_same_structure will abort with core dump when
check_types is passed with a non-bool value.

The issue is related to pybind where type mismatch will
throw out an error and further cause 'pybind11::error_already_set' error.

This PR explicitly convert check_types to bool before passing to pybind,
and, in case check_types is not bool, an ValueError will be thrown out
gracefully by python itself.

This will be better than process abort (core dump).

This PR fixes #42329.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>