### PR TITLE
[tflite] Make --nnapi_accelerator_name work in kernel tests

### DIFF
--- a/tensorflow/lite/kernels/test_main.cc
+++ b/tensorflow/lite/kernels/test_main.cc
@@ -31,8 +31,12 @@ void InitKernelTest(int* argc, char** argv) {
     // In Android Q, the NNAPI delegate avoids delegation if the only device
     // is the reference CPU. However, for testing purposes, we still want
     // delegation coverage, so force use of this reference path.
+    const auto opt_name = "nnapi_accelerator_name";
+    std::string accelerator_name =
+        delegate_providers->ConstParams().Get<std::string>(opt_name);
     delegate_providers->MutableParams()->Set<std::string>(
-        "nnapi_accelerator_name", "nnapi-reference");
+        opt_name, accelerator_name.empty() ? "nnapi-reference"
+                                           : accelerator_name.c_str());
   }
 }
 

--- a/tensorflow/lite/kernels/test_main.cc
+++ b/tensorflow/lite/kernels/test_main.cc
@@ -31,12 +31,10 @@ void InitKernelTest(int* argc, char** argv) {
     // In Android Q, the NNAPI delegate avoids delegation if the only device
     // is the reference CPU. However, for testing purposes, we still want
     // delegation coverage, so force use of this reference path.
-    const auto opt_name = "nnapi_accelerator_name";
-    std::string accelerator_name =
-        delegate_providers->ConstParams().Get<std::string>(opt_name);
-    delegate_providers->MutableParams()->Set<std::string>(
-        opt_name, accelerator_name.empty() ? "nnapi-reference"
-                                           : accelerator_name.c_str());
+    auto* params = delegate_providers->MutableParams();
+    if (!params->HasValueSet<std::string>("nnapi_accelerator_name")) {
+      params->Set<std::string>("nnapi_accelerator_name", "nnapi-reference");
+    }
   }
 }
 


### PR DESCRIPTION
Originally, when `--nnapi=true`, always test `nnapi-reference`, the NNAPI CPU reference implementation. Now when `--nnapi_accelerator_name` is specified, set it as is.

@multiverse-tf: my colleagues and me want to use these kernel tests to test NNAPI drivers other than `nnapi-reference`.