### PR TITLE
Export golang functions

### DIFF
--- a/tensorflow/go/graph.go
+++ b/tensorflow/go/graph.go
@@ -465,3 +465,33 @@ func setAttr(cdesc *C.TF_OperationDescription, status *status, name string, valu
 	}
 	return nil
 }
+
+type LibraryHandler struct {
+	cptr	*C.TF_Library
+}
+
+func LoadLibrary(path string) (*LibraryHandler, error) {
+	status := newStatus()
+
+	cpath := C.CString(path)
+	defer C.free(unsafe.Pointer(cpath))
+	cptr := C.TF_LoadLibrary(cpath, status.c)
+	if cptr == nil || status.Code() != C.TF_OK {
+		return nil, fmt.Errorf("could not load library %s: code: %d, error: %s", path, status.Code(), status.String())
+	}
+
+	lh := &LibraryHandler {
+		cptr: cptr,
+	}
+
+	runtime.SetFinalizer(h, (*LibraryHandler).free)
+	return lh, nil
+}
+
+func (lh *LibraryHandler) free() {
+	if lh == nil || lh.cptr == nil {
+		return
+	}
+
+	C.TF_DeleteLibraryHandle(lh.cptr)
+}

--- a/tensorflow/go/graph.go
+++ b/tensorflow/go/graph.go
@@ -515,7 +515,7 @@ func LoadLibrary(path string) (*LibraryHandler, error) {
 		cptr: cptr,
 	}
 
-	runtime.SetFinalizer(h, (*LibraryHandler).free)
+	runtime.SetFinalizer(lh, (*LibraryHandler).free)
 	return lh, nil
 }
 

--- a/tensorflow/go/graph.go
+++ b/tensorflow/go/graph.go
@@ -500,6 +500,7 @@ type LibraryHandler struct {
 	cptr	*C.TF_Library
 }
 
+// Load library content into current context, useful to load ops implementation into non-monolitic TF build. Returns LibraryHandler or nil and error
 func LoadLibrary(path string) (*LibraryHandler, error) {
 	status := newStatus()
 

--- a/tensorflow/go/tensor.go
+++ b/tensorflow/go/tensor.go
@@ -76,7 +76,7 @@ func NewTensor(value interface{}) (*Tensor, error) {
 		return nil, err
 	}
 	nflattened := numElements(shape)
-	nbytes := typeOf(dataType, nil).Size() * uintptr(nflattened)
+	nbytes := TypeOf(dataType, nil).Size() * uintptr(nflattened)
 	if dataType == String {
 		// TF_STRING tensors are encoded as an array of 8-byte offsets
 		// followed by string data. See c_api.h.
@@ -120,7 +120,7 @@ func ReadTensor(dataType DataType, shape []int64, r io.Reader) (*Tensor, error) 
 	if err := isTensorSerializable(dataType); err != nil {
 		return nil, err
 	}
-	nbytes := typeOf(dataType, nil).Size() * uintptr(numElements(shape))
+	nbytes := TypeOf(dataType, nil).Size() * uintptr(numElements(shape))
 	var shapePtr *C.int64_t
 	if len(shape) > 0 {
 		shapePtr = (*C.int64_t)(unsafe.Pointer(&shape[0]))
@@ -168,7 +168,7 @@ func (t *Tensor) Shape() []int64 { return t.shape }
 // Tensor(int64, 0): int64
 // Tensor(float64, 3): [][][]float64
 func (t *Tensor) Value() interface{} {
-	typ := typeOf(t.DataType(), t.Shape())
+	typ := TypeOf(t.DataType(), t.Shape())
 	val := reflect.New(typ)
 	raw := tensorData(t.c)
 	if t.DataType() != String {
@@ -261,8 +261,8 @@ func shapeAndDataTypeOf(val reflect.Value) (shape []int64, dt DataType, err erro
 	return shape, dt, fmt.Errorf("unsupported type %v", typ)
 }
 
-// typeOf converts from a DataType and Shape to the equivalent Go type.
-func typeOf(dt DataType, shape []int64) reflect.Type {
+// TypeOf converts from a DataType and Shape to the equivalent Go type.
+func TypeOf(dt DataType, shape []int64) reflect.Type {
 	var ret reflect.Type
 	for _, t := range types {
 		if dt == DataType(t.dataType) {
@@ -460,7 +460,7 @@ func (d *stringDecoder) decode(ptr reflect.Value, shape []int64) error {
 		return nil
 	}
 	val := reflect.Indirect(ptr)
-	val.Set(reflect.MakeSlice(typeOf(String, shape), int(shape[0]), int(shape[0])))
+	val.Set(reflect.MakeSlice(TypeOf(String, shape), int(shape[0]), int(shape[0])))
 	for i := 0; i < val.Len(); i++ {
 		if err := d.decode(val.Index(i).Addr(), shape[1:]); err != nil {
 			return err

--- a/tensorflow/go/tensor.go
+++ b/tensorflow/go/tensor.go
@@ -213,7 +213,7 @@ func (t *Tensor) Reshape(new_shape []int64) error {
 	new_shape_size := numElements(new_shape)
 
 	if old_shape_size != new_shape_size {
-		return bug("unable to convert shape %v (num_elements: %d) into shape %v (num_elements: %d)", t.shape, old_shape_size, new_shape, new_shape_size)
+		return fmt.Errorf("unable to convert shape %v (num_elements: %d) into shape %v (num_elements: %d)", t.shape, old_shape_size, new_shape, new_shape_size)
 	}
 
 	if len(new_shape) == 0 {

--- a/tensorflow/go/tensor.go
+++ b/tensorflow/go/tensor.go
@@ -207,7 +207,7 @@ func (t *Tensor) DataType() DataType { return DataType(C.TF_TensorType(t.c)) }
 // Shape returns the shape of the Tensor.
 func (t *Tensor) Shape() []int64 { return t.shape }
 
-// Rehape  updates tensor's shape in place if this is possible or returns an error otherwise.
+// Reshape  updates tensor's shape in place if this is possible or returns an error otherwise.
 func (t *Tensor) Reshape(new_shape []int64) error {
 	old_shape_size := numElements(t.shape)
 	new_shape_size := numElements(new_shape)

--- a/tensorflow/go/tensor.go
+++ b/tensorflow/go/tensor.go
@@ -207,7 +207,7 @@ func (t *Tensor) DataType() DataType { return DataType(C.TF_TensorType(t.c)) }
 // Shape returns the shape of the Tensor.
 func (t *Tensor) Shape() []int64 { return t.shape }
 
-// Rehape returns Tensor with the new shape or error if this conversion is not possibe.
+// Rehape  updates tensor's shape in place if this is possible or returns an error otherwise.
 func (t *Tensor) Reshape(new_shape []int64) error {
 	old_shape_size := numElements(t.shape)
 	new_shape_size := numElements(new_shape)


### PR DESCRIPTION
These functions allow to run `saved_model` models in golang when those models have external library dependencies like `tensorflow_text` normalizers in BERT tokenizers.
Also export functions to determine size of the TF type - this is used when you want to preallocate space for the tensor in advance.
And added reshape method which is self-explainatory.