### PR TITLE
Remove unnecessary assignment in BaseResourceVariable

### DIFF
--- a/tensorflow/python/ops/resource_variable_ops.py
+++ b/tensorflow/python/ops/resource_variable_ops.py
@@ -431,7 +431,6 @@ class BaseResourceVariable(variables.VariableV1, core.Tensor):
     self._shape = tensor_shape.as_shape(shape)
     self._dtype = dtypes.as_dtype(dtype)
     self._handle = handle
-    self._graph_element = graph_element
     self._unique_id = unique_id
     self._handle_name = handle_name + ":0"
     self._constraint = constraint


### PR DESCRIPTION
This PR removes an unnecessary attribute assignment as it already happens a few lines earlier:
https://github.com/tensorflow/tensorflow/blob/c257a5d21025e32ac6f954e50c51d8657ee62fb3/tensorflow/python/ops/resource_variable_ops.py#L424