### PR TITLE
[INTEL MKL] Enable NCHW to NHWC conversion for CPU - part1

### DIFF
--- a/tensorflow/core/grappler/optimizers/generic_layout_optimizer.h
+++ b/tensorflow/core/grappler/optimizers/generic_layout_optimizer.h
@@ -25,9 +25,15 @@ namespace grappler {
 // Optimize the data layout for convolutional models.
 class GenericLayoutOptimizer : public GraphOptimizer {
  public:
-  GenericLayoutOptimizer() : GenericLayoutOptimizer(RewriterConfig::DEFAULT) {}
+  GenericLayoutOptimizer()
+      : GenericLayoutOptimizer(RewriterConfig::DEFAULT,
+                               RewriterConfig::NO_CONVERSION_ON_CPU) {}
   explicit GenericLayoutOptimizer(RewriterConfig::Toggle opt_level)
-      : opt_level_(opt_level) {}
+      : GenericLayoutOptimizer(opt_level,
+                               RewriterConfig::NO_CONVERSION_ON_CPU) {}
+  explicit GenericLayoutOptimizer(RewriterConfig::Toggle opt_level,
+                                  RewriterConfig::CpuLayout layout_conversion)
+      : opt_level_(opt_level), cpu_layout_conversion_(layout_conversion) {}
   ~GenericLayoutOptimizer() override = default;
 
   string name() const override { return "layout"; };
@@ -42,6 +48,7 @@ class GenericLayoutOptimizer : public GraphOptimizer {
 
  private:
   RewriterConfig::Toggle opt_level_;
+  RewriterConfig::CpuLayout cpu_layout_conversion_;
 };
 
 }  // namespace grappler

--- a/tensorflow/core/grappler/optimizers/generic_layout_optimizer_test.cc
+++ b/tensorflow/core/grappler/optimizers/generic_layout_optimizer_test.cc
@@ -49,6 +49,38 @@ constexpr int kDepthIn = 8;
 constexpr int kKernel = 3;
 constexpr int kDepthOut = 16;
 
+// When there is a GPU, we test generic_layout_optimization for the conversion
+// from NHWC to NCHW format. When there is only CPU, we test the conversion
+// from NCHW to NHWC format. The following macros help setting tensor shapes,
+// source and destination format strings, and transpose permutation vectors
+// appropriately for NHWC -> NCHW conversion (when GPU) and NCHW -> NHWC
+// conversion (when only CPU).
+
+#if (GOOGLE_CUDA || TENSORFLOW_USE_ROCM)
+#define DIMS(n, h, w, c) \
+  { n, h, w, c }
+#define SRC_DATA_FORMAT "NHWC"
+#define DST_DATA_FORMAT "NCHW"
+#define DEVICE "GPU"
+#define REWRITER_CONFIG \
+  RewriterConfig::DEFAULT, RewriterConfig::NO_CONVERSION_ON_CPU
+#define PERMUTATION_SRC_TO_DST \
+  { 0, 3, 1, 2 }
+#define PERMUTATION_DST_TO_SRC \
+  { 0, 2, 3, 1 }
+#else
+#define DIMS(n, h, w, c) \
+  { n, c, h, w }
+#define SRC_DATA_FORMAT "NCHW"
+#define DST_DATA_FORMAT "NHWC"
+#define DEVICE "CPU"
+#define REWRITER_CONFIG RewriterConfig::DEFAULT, RewriterConfig::NCHW_TO_NHWC
+#define PERMUTATION_SRC_TO_DST \
+  { 0, 2, 3, 1 }
+#define PERMUTATION_DST_TO_SRC \
+  { 0, 3, 1, 2 }
+#endif  // (GOOGLE_CUDA || TENSORFLOW_USE_ROCM)
+
 Output SimpleConv2D(tensorflow::Scope* s, int input_size, int filter_size,
                     const string& padding, const string& device) {
   int batch_size = 8;
@@ -57,7 +89,8 @@ Output SimpleConv2D(tensorflow::Scope* s, int input_size, int filter_size,
   int input_depth = 3;
   int filter_count = 2;
   int stride = 1;
-  TensorShape input_shape({batch_size, input_height, input_width, input_depth});
+  TensorShape input_shape(
+      DIMS(batch_size, input_height, input_width, input_depth));
   Tensor input_data(DT_FLOAT, input_shape);
   test::FillIota<float>(&input_data, 1.0f);
   Output input =
@@ -71,7 +104,8 @@ Output SimpleConv2D(tensorflow::Scope* s, int input_size, int filter_size,
       ops::Const(s->WithOpName("Filter"), Input::Initializer(filter_data));
 
   Output conv = ops::Conv2D(s->WithOpName("Conv2D").WithDevice(device), input,
-                            filter, {1, stride, stride, 1}, padding);
+                            filter, DIMS(1, stride, stride, 1), padding,
+                            ops::Conv2D::Attrs().DataFormat(SRC_DATA_FORMAT));
   return conv;
 }
 
@@ -87,8 +121,8 @@ Output SimpleConv2DBackpropInput(tensorflow::Scope* s, int input_size,
   TensorShape input_sizes_shape({input_sizes_length});
   Tensor input_data(DT_INT32, input_sizes_shape);
   if (input_sizes_length == 4) {
-    test::FillValues<int>(&input_data,
-                          {batch_size, input_height, input_width, input_depth});
+    test::FillValues<int>(
+        &input_data, DIMS(batch_size, input_height, input_width, input_depth));
   } else {
     test::FillValues<int>(&input_data, {input_height, input_width});
   }
@@ -103,7 +137,7 @@ Output SimpleConv2DBackpropInput(tensorflow::Scope* s, int input_size,
   int output_height = input_height;
   int output_width = input_width;
   TensorShape output_shape(
-      {batch_size, output_height, output_width, filter_count});
+      DIMS(batch_size, output_height, output_width, filter_count));
   Tensor output_data(DT_FLOAT, output_shape);
   test::FillIota<float>(&output_data, 1.0f);
   Output output =
@@ -113,12 +147,13 @@ Output SimpleConv2DBackpropInput(tensorflow::Scope* s, int input_size,
   Output input_sizes_i =
       ops::Identity(s->WithOpName("InputSizesIdentity"), input_sizes);
   ops::Conv2DBackpropInput::Attrs attrs;
+  attrs = attrs.DataFormat(SRC_DATA_FORMAT);
   if (dilated) {
-    attrs = attrs.Dilations({1, 2, 2, 1});
+    attrs = attrs.Dilations(DIMS(1, 2, 2, 1));
   }
   conv_backprop_input = ops::Conv2DBackpropInput(
       s->WithOpName("Conv2DBackpropInput"), input_sizes_i, filter, output,
-      {1, stride, stride, 1}, padding, attrs);
+      DIMS(1, stride, stride, 1), padding, attrs);
 
   return conv_backprop_input;
 }
@@ -141,11 +176,18 @@ class GenericLayoutOptimizerTest : public GrapplerTest {
       cpu_device.set_l2_cache_size(256 * 1024);
       cpu_device.set_l3_cache_size(4 * 1024 * 1024);
       cpu_device.set_memory_size(1024 * 1024);
+#if (GOOGLE_CUDA || TENSORFLOW_USE_ROCM)
       DeviceProperties gpu_device;
       gpu_device.set_type("GPU");
       gpu_device.mutable_environment()->insert({"architecture", "6"});
-      virtual_cluster_ = absl::WrapUnique(
-          new VirtualCluster({{"/CPU:0", cpu_device}, {"/GPU:1", gpu_device}}));
+      virtual_cluster_ =
+          absl::WrapUnique(new VirtualCluster({{"/CPU:0", cpu_device},
+                                               { "/GPU:1",
+                                                 gpu_device }}));
+#else
+      virtual_cluster_ =
+          absl::WrapUnique(new VirtualCluster({{"/CPU:0", cpu_device}}));
+#endif  // (GOOGLE_CUDA || TENSORFLOW_USE_ROCM)
     }
     TF_ASSERT_OK(virtual_cluster_->Provision());
   }
@@ -183,10 +225,8 @@ void VerifyDataFormatAttributeMatch(const utils::NodeView* node,
 }
 
 TEST_F(GenericLayoutOptimizerTest, OptimizeSimpleConv2DGraph) {
-#if !(GOOGLE_CUDA || TENSORFLOW_USE_ROCM)
-  GTEST_SKIP() << "Neither CUDA nor ROCm is enabled";
-#endif  // !GOOGLE_CUDA || TENSORFLOW_USE_ROCM
-  // A simple graph contains 1 "NHWC" Conv2D node, 2 input and 1 output nodes.
+  // A simple graph contains 1 Conv2D node, 2 input and 1 output nodes.
+  // Data format is NHWC on GPU, while NCHW on CPU.
   Scope scope = Scope::NewRootScope();
 
   auto conv2d = SimpleConv2D(&scope, 4, 2, "VALID", "");
@@ -194,7 +234,7 @@ TEST_F(GenericLayoutOptimizerTest, OptimizeSimpleConv2DGraph) {
   GrapplerItem item;
   TF_ASSERT_OK(scope.ToGraphDef(&item.graph));
 
-  GenericLayoutOptimizer optimizer;
+  GenericLayoutOptimizer optimizer(REWRITER_CONFIG);
   GraphDef output;
   TF_ASSERT_OK(optimizer.Optimize(virtual_cluster_.get(), item, &output));
 
@@ -202,9 +242,11 @@ TEST_F(GenericLayoutOptimizerTest, OptimizeSimpleConv2DGraph) {
   utils::GraphView graph_view(&output, &status);
   TF_ASSERT_OK(status);
   // The expected optimized graph contains 2 extra sets of Transpose nodes and
-  // has the Conv2D's data_format set to "NCHW".
-  auto* input_transpose_node =
-      graph_view.GetNode("Conv2D-0-TransposeNHWCToNCHW-LayoutOptimizer");
+  // has the Conv2D's data_format set to "NCHW" on GPU, while "NHWC" on CPU.
+  auto* input_transpose_node = graph_view.GetNode(
+      absl::StrCat("Conv2D-0-Transpose", SRC_DATA_FORMAT, "To", DST_DATA_FORMAT,
+                   "-LayoutOptimizer"));
+
   ASSERT_NE(input_transpose_node, nullptr);
   ASSERT_EQ(input_transpose_node->NumRegularFanins(), 2);
   VerifyRegularFaninMatch(input_transpose_node, 0, "Input", 0);
@@ -214,10 +256,11 @@ TEST_F(GenericLayoutOptimizerTest, OptimizeSimpleConv2DGraph) {
   ASSERT_EQ(conv2d_node->NumRegularFanins(), 2);
   VerifyRegularFaninMatch(conv2d_node, 0, input_transpose_node->GetName(), 0);
   VerifyRegularFaninMatch(conv2d_node, 1, "Filter", 0);
-  VerifyDataFormatAttributeMatch(conv2d_node, "NCHW");
+  VerifyDataFormatAttributeMatch(conv2d_node, DST_DATA_FORMAT);
 
-  auto* output_transpose_node =
-      graph_view.GetNode("Conv2D-0-0-TransposeNCHWToNHWC-LayoutOptimizer");
+  auto* output_transpose_node = graph_view.GetNode(
+      absl::StrCat("Conv2D-0-0-Transpose", DST_DATA_FORMAT, "To",
+                   SRC_DATA_FORMAT, "-LayoutOptimizer"));
   ASSERT_NE(output_transpose_node, nullptr);
   ASSERT_EQ(output_transpose_node->NumRegularFanins(), 2);
   VerifyRegularFaninMatch(output_transpose_node, 0, conv2d_node->GetName(), 0);
@@ -236,7 +279,7 @@ TEST_F(GenericLayoutOptimizerTest, PreserveFetch) {
   item.fetch.push_back("Conv2D");
   TF_ASSERT_OK(s.ToGraphDef(&item.graph));
 
-  GenericLayoutOptimizer optimizer;
+  GenericLayoutOptimizer optimizer(REWRITER_CONFIG);
   GraphDef output;
   TF_ASSERT_OK(optimizer.Optimize(virtual_cluster_.get(), item, &output));
 
@@ -245,20 +288,17 @@ TEST_F(GenericLayoutOptimizerTest, PreserveFetch) {
   TF_ASSERT_OK(status);
   auto* conv_node = graph_view.GetNode("Conv2D");
   ASSERT_NE(conv_node, nullptr);
-  VerifyDataFormatAttributeMatch(conv_node, "NHWC");
+  VerifyDataFormatAttributeMatch(conv_node, SRC_DATA_FORMAT);
 }
 
 TEST_F(GenericLayoutOptimizerTest, EmptyDevice) {
-#if !(GOOGLE_CUDA || TENSORFLOW_USE_ROCM)
-  GTEST_SKIP() << "Neither CUDA nor ROCm is enabled";
-#endif  // !GOOGLE_CUDA || TENSORFLOW_USE_ROCM
   tensorflow::Scope s = tensorflow::Scope::NewRootScope();
   auto conv = SimpleConv2D(&s, 4, 2, "VALID", "");
   Output fetch = ops::Identity(s.WithOpName("Fetch"), {conv});
   GrapplerItem item;
   TF_ASSERT_OK(s.ToGraphDef(&item.graph));
 
-  GenericLayoutOptimizer optimizer;
+  GenericLayoutOptimizer optimizer(REWRITER_CONFIG);
   GraphDef output;
   TF_ASSERT_OK(optimizer.Optimize(virtual_cluster_.get(), item, &output));
 
@@ -267,7 +307,7 @@ TEST_F(GenericLayoutOptimizerTest, EmptyDevice) {
   TF_ASSERT_OK(status);
   auto* conv_node = graph_view.GetNode("Conv2D");
   ASSERT_NE(conv_node, nullptr);
-  VerifyDataFormatAttributeMatch(conv_node, "NCHW");
+  VerifyDataFormatAttributeMatch(conv_node, DST_DATA_FORMAT);
 }
 
 TEST_F(GenericLayoutOptimizerTest, GPUDevice) {
@@ -294,16 +334,13 @@ TEST_F(GenericLayoutOptimizerTest, GPUDevice) {
 }
 
 TEST_F(GenericLayoutOptimizerTest, CPUDevice) {
-#if !(GOOGLE_CUDA || TENSORFLOW_USE_ROCM)
-  GTEST_SKIP() << "Neither CUDA nor ROCm is enabled";
-#endif  // !(GOOGLE_CUDA || TENSORFLOW_USE_ROCM)
   tensorflow::Scope s = tensorflow::Scope::NewRootScope();
   auto conv = SimpleConv2D(&s, 4, 2, "VALID", "/CPU:0");
   Output fetch = ops::Identity(s.WithOpName("Fetch"), {conv});
   GrapplerItem item;
   TF_ASSERT_OK(s.ToGraphDef(&item.graph));
 
-  GenericLayoutOptimizer optimizer;
+  GenericLayoutOptimizer optimizer(REWRITER_CONFIG);
   GraphDef output;
   TF_ASSERT_OK(optimizer.Optimize(virtual_cluster_.get(), item, &output));
 
@@ -312,15 +349,17 @@ TEST_F(GenericLayoutOptimizerTest, CPUDevice) {
   TF_ASSERT_OK(status);
   auto* conv_node = graph_view.GetNode("Conv2D");
   ASSERT_NE(conv_node, nullptr);
+#if (GOOGLE_CUDA || TENSORFLOW_USE_ROCM)
   VerifyDataFormatAttributeMatch(conv_node, "NHWC");
+#else
+  VerifyDataFormatAttributeMatch(conv_node, DST_DATA_FORMAT);
+#endif // (GOOGLE_CUDA || TENSORFLOW_USE_ROCM)
 }
 
 TEST_F(GenericLayoutOptimizerTest, Connectivity) {
-#if !(GOOGLE_CUDA || TENSORFLOW_USE_ROCM)
-  GTEST_SKIP() << "Neither CUDA nor ROCm is enabled";
-#endif  // !(GOOGLE_CUDA || TENSORFLOW_USE_ROCM)
   Scope scope = Scope::NewRootScope();
-  auto conv = SimpleConv2D(&scope, 4, 2, "VALID", "/device:GPU:0");
+  auto conv = SimpleConv2D(&scope, 4, 2, "VALID",
+                           absl::StrCat("/device:", DEVICE, ":0"));
   auto i1 = ops::Identity(scope.WithOpName("i1"), conv);
   auto i2 = ops::Identity(scope.WithOpName("i2"), i1);
   auto i3 = ops::Identity(scope.WithOpName("i3"), i2);
@@ -337,7 +376,7 @@ TEST_F(GenericLayoutOptimizerTest, Connectivity) {
   const int i2_index = graph_view_original.GetNode("i2")->node_index();
   item.graph.mutable_node()->SwapElements(i1_index, i2_index);
 
-  GenericLayoutOptimizer optimizer;
+  GenericLayoutOptimizer optimizer(REWRITER_CONFIG);
   GraphDef output;
   TF_ASSERT_OK(optimizer.Optimize(virtual_cluster_.get(), item, &output));
 
@@ -353,9 +392,6 @@ TEST_F(GenericLayoutOptimizerTest, Connectivity) {
 }
 
 TEST_F(GenericLayoutOptimizerTest, Conv2DBackpropInputNonConstInputSizes) {
-#if !(GOOGLE_CUDA || TENSORFLOW_USE_ROCM)
-  GTEST_SKIP() << "Neither CUDA nor ROCm is enabled";
-#endif  // !(GOOGLE_CUDA || TENSORFLOW_USE_ROCM)
   for (const int input_sizes_length : {2, 4}) {
     Scope s = Scope::NewRootScope();
     auto conv = SimpleConv2DBackpropInput(&s, 7, 2, "SAME", /*dilated=*/false,
@@ -364,7 +400,7 @@ TEST_F(GenericLayoutOptimizerTest, Conv2DBackpropInputNonConstInputSizes) {
     GrapplerItem item;
     TF_ASSERT_OK(s.ToGraphDef(&item.graph));
 
-    GenericLayoutOptimizer optimizer;
+    GenericLayoutOptimizer optimizer(REWRITER_CONFIG);
     GraphDef output;
     TF_ASSERT_OK(optimizer.Optimize(virtual_cluster_.get(), item, &output));
 
@@ -376,10 +412,13 @@ TEST_F(GenericLayoutOptimizerTest, Conv2DBackpropInputNonConstInputSizes) {
     ASSERT_EQ(conv2d_backprop_node->NumRegularFanins(), 3);
     VerifyRegularFaninMatch(
         conv2d_backprop_node, 0,
-        "Conv2DBackpropInput-0-DataFormatVecPermuteNHWCToNCHW-LayoutOptimizer",
+        absl::StrCat("Conv2DBackpropInput-0-DataFormatVecPermute",
+                     SRC_DATA_FORMAT, "To", DST_DATA_FORMAT,
+                     "-LayoutOptimizer"),
         0);
-    auto* input_sizes_node = graph_view.GetNode(
-        "Conv2DBackpropInput-0-DataFormatVecPermuteNHWCToNCHW-LayoutOptimizer");
+    auto* input_sizes_node = graph_view.GetNode(absl::StrCat(
+        "Conv2DBackpropInput-0-DataFormatVecPermute", SRC_DATA_FORMAT, "To",
+        DST_DATA_FORMAT, "-LayoutOptimizer"));
     ASSERT_NE(input_sizes_node, nullptr);
     EXPECT_EQ(input_sizes_node->GetOp(), "DataFormatVecPermute");
     ASSERT_EQ(input_sizes_node->NumRegularFanins(), 1);
@@ -388,11 +427,10 @@ TEST_F(GenericLayoutOptimizerTest, Conv2DBackpropInputNonConstInputSizes) {
 }
 
 TEST_F(GenericLayoutOptimizerTest, Conv2DDataFormatVecPermuteCollapse) {
-#if !(GOOGLE_CUDA || TENSORFLOW_USE_ROCM)
-  GTEST_SKIP() << "Neither CUDA nor ROCm is enabled";
-#endif  // !(GOOGLE_CUDA || TENSORFLOW_USE_ROCM)
-  Scope scope = Scope::NewRootScope().WithDevice("/device:GPU:0");
-  auto conv = SimpleConv2D(&scope, 4, 2, "VALID", "/device:GPU:0");
+  Scope scope =
+      Scope::NewRootScope().WithDevice(absl::StrCat("/device:", DEVICE, ":0"));
+  auto conv = SimpleConv2D(&scope, 4, 2, "VALID",
+                           absl::StrCat("/device:", DEVICE, ":0"));
   auto shape = ops::Shape(scope.WithOpName("shape"), conv);
   auto value = ops::Const(scope.WithOpName("value"), 0, {});
   auto fill = ops::Fill(scope.WithOpName("fill"), shape, value);
@@ -400,7 +438,7 @@ TEST_F(GenericLayoutOptimizerTest, Conv2DDataFormatVecPermuteCollapse) {
   GrapplerItem item;
   TF_ASSERT_OK(scope.ToGraphDef(&item.graph));
 
-  GenericLayoutOptimizer optimizer;
+  GenericLayoutOptimizer optimizer(REWRITER_CONFIG);
   GraphDef output;
   TF_ASSERT_OK(optimizer.Optimize(virtual_cluster_.get(), item, &output));
 
@@ -418,8 +456,11 @@ TEST_F(GenericLayoutOptimizerTest, Conv2DDataFormatVecPermuteCollapse) {
   auto* conv2d_node = graph_view.GetNode("Conv2D");
   ASSERT_NE(conv2d_node, nullptr);
   ASSERT_EQ(conv2d_node->NumRegularFanins(), 2);
-  VerifyRegularFaninMatch(conv2d_node, 0,
-                          "Conv2D-0-TransposeNHWCToNCHW-LayoutOptimizer", 0);
+  VerifyRegularFaninMatch(
+      conv2d_node, 0,
+      absl::StrCat("Conv2D-0-Transpose", SRC_DATA_FORMAT, "To", DST_DATA_FORMAT,
+                   "-LayoutOptimizer"),
+      0);
 
   auto* shape_node = graph_view.GetNode("shape");
   ASSERT_NE(shape_node, nullptr);
@@ -430,50 +471,59 @@ TEST_F(GenericLayoutOptimizerTest, Conv2DDataFormatVecPermuteCollapse) {
   ASSERT_NE(fill_node, nullptr);
   ASSERT_EQ(fill_node->NumRegularFanins(), 2);
   VerifyRegularFaninMatch(fill_node, 0, shape_node->GetName(), 0);
-  VerifyRegularFanoutMatch(fill_node, 0,
-                           "fill-0-0-TransposeNCHWToNHWC-LayoutOptimizer", 0);
+  VerifyRegularFanoutMatch(
+      fill_node, 0,
+      absl::StrCat("fill-0-0-Transpose", DST_DATA_FORMAT, "To", SRC_DATA_FORMAT,
+                   "-LayoutOptimizer"),
+      0);
 
   auto* graph_output = graph_view.GetNode("i");
   ASSERT_NE(graph_output, nullptr);
   ASSERT_EQ(graph_output->NumRegularFanins(), 1);
-  VerifyRegularFaninMatch(graph_output, 0,
-                          "fill-0-0-TransposeNCHWToNHWC-LayoutOptimizer", 0);
+  VerifyRegularFaninMatch(
+      graph_output, 0,
+      absl::StrCat("fill-0-0-Transpose", DST_DATA_FORMAT, "To", SRC_DATA_FORMAT,
+                   "-LayoutOptimizer"),
+      0);
 }
 
 TEST_F(GenericLayoutOptimizerTest, DoNotPruneNonAddedCancellableTransposes) {
-#if !(GOOGLE_CUDA || TENSORFLOW_USE_ROCM)
-  GTEST_SKIP() << "Neither CUDA nor ROCm is enabled";
-#endif  // !(GOOGLE_CUDA || TENSORFLOW_USE_ROCM)
   GrapplerItem item;
   {
-    Scope scope = Scope::NewRootScope().WithDevice("/device:GPU:0");
-    auto input =
-        ops::RandomUniform(scope.WithOpName("input"),
-                           {kBatchSize, kHeight, kWidth, kDepthIn}, DT_FLOAT);
-    // NHWC -> NCHW: {0, 3, 1, 2}
+    Scope scope = Scope::NewRootScope().WithDevice(
+        absl::StrCat("/device:", DEVICE, ":0"));
+    auto input = ops::RandomUniform(scope.WithOpName("input"),
+                                    DIMS(kBatchSize, kHeight, kWidth, kDepthIn),
+                                    DT_FLOAT);
+    // Permuation for source to destination data format.
+    // GPU: NHWC -> NCHW: {0, 3, 1, 2}
+    // CPU: NCHW -> NHWC: {0, 2, 3, 1}
     auto input_in_transpose =
         ops::Transpose(scope.WithOpName("input_in_transpose"), input,
-                       ops::Const(scope, {0, 3, 1, 2}, {4}));
-    // NCHW -> NHWC: {0, 2, 3, 1}
+                       ops::Const(scope, PERMUTATION_SRC_TO_DST, {4}));
+    // Permuation for destination to source data format.
+    // GPU: NCHW -> NHWC: {0, 2, 3, 1}
+    // CPU: NHWC -> NCHW: {0, 3, 1, 2}
     auto input_out_transpose = ops::Transpose(
         scope.WithOpName("input_out_transpose"), input_in_transpose,
-        ops::Const(scope, {0, 2, 3, 1}, {4}));
+        ops::Const(scope, PERMUTATION_DST_TO_SRC, {4}));
     Tensor bias_data(DT_FLOAT, TensorShape({kDepthIn}));
     test::FillIota<float>(&bias_data, 1.0f);
-    auto bias_add = ops::BiasAdd(scope.WithOpName("bias_add"),
-                                 input_out_transpose, bias_data);
+    auto bias_add = ops::BiasAdd(
+        scope.WithOpName("bias_add"), input_out_transpose, bias_data,
+        ops::BiasAdd::Attrs().DataFormat(SRC_DATA_FORMAT));
     auto output_in_transpose =
         ops::Transpose(scope.WithOpName("output_in_transpose"), bias_add,
-                       ops::Const(scope, {0, 3, 1, 2}, {4}));
+                       ops::Const(scope, PERMUTATION_SRC_TO_DST, {4}));
     auto output_out_transpose = ops::Transpose(
         scope.WithOpName("output_out_transpose"), output_in_transpose,
-        ops::Const(scope, {0, 2, 3, 1}, {4}));
+        ops::Const(scope, PERMUTATION_DST_TO_SRC, {4}));
     auto output =
         ops::Identity(scope.WithOpName("output"), output_out_transpose);
     TF_ASSERT_OK(scope.ToGraphDef(&item.graph));
   }
 
-  GenericLayoutOptimizer optimizer;
+  GenericLayoutOptimizer optimizer(REWRITER_CONFIG);
   GraphDef output;
   TF_ASSERT_OK(optimizer.Optimize(virtual_cluster_.get(), item, &output));
 
@@ -495,8 +545,9 @@ TEST_F(GenericLayoutOptimizerTest, DoNotPruneNonAddedCancellableTransposes) {
   VerifyRegularFaninMatch(input_out_transpose_node, 0,
                           input_in_transpose_node->GetName(), 0);
 
-  auto* bias_add_in_transpose_node =
-      graph_view.GetNode("bias_add-0-TransposeNHWCToNCHW-LayoutOptimizer");
+  auto* bias_add_in_transpose_node = graph_view.GetNode(
+      absl::StrCat("bias_add-0-Transpose", SRC_DATA_FORMAT, "To",
+                   DST_DATA_FORMAT, "-LayoutOptimizer"));
   ASSERT_NE(bias_add_in_transpose_node, nullptr);
   ASSERT_EQ(bias_add_in_transpose_node->NumRegularFanins(), 2);
   VerifyRegularFaninMatch(bias_add_in_transpose_node, 0,
@@ -508,8 +559,9 @@ TEST_F(GenericLayoutOptimizerTest, DoNotPruneNonAddedCancellableTransposes) {
   VerifyRegularFaninMatch(bias_add_node, 0,
                           bias_add_in_transpose_node->GetName(), 0);
 
-  auto* bias_add_out_transpose_node =
-      graph_view.GetNode("bias_add-0-0-TransposeNCHWToNHWC-LayoutOptimizer");
+  auto* bias_add_out_transpose_node = graph_view.GetNode(
+      absl::StrCat("bias_add-0-0-Transpose", DST_DATA_FORMAT, "To",
+                   SRC_DATA_FORMAT, "-LayoutOptimizer"));
   ASSERT_NE(bias_add_out_transpose_node, nullptr);
   ASSERT_EQ(bias_add_out_transpose_node->NumRegularFanins(), 2);
   VerifyRegularFaninMatch(bias_add_out_transpose_node, 0,
@@ -537,7 +589,9 @@ TEST_F(GenericLayoutOptimizerTest, DoNotPruneNonAddedCancellableTransposes) {
 TEST_F(GenericLayoutOptimizerTest, CancelTransposeAroundPad) {
   using test::function::NDef;
 
-  GenericLayoutOptimizer optimizer(RewriterConfig::AGGRESSIVE);
+  GenericLayoutOptimizer optimizer(
+      RewriterConfig::AGGRESSIVE,
+      RewriterConfig::NCHW_TO_NHWC /* CPU settings*/);
 
   const Tensor kPermuteNhwcToNchw = test::AsTensor<int32>({0, 3, 1, 2});
   const Tensor kPermuteNchwToNhwc = test::AsTensor<int32>({0, 2, 3, 1});

--- a/tensorflow/core/grappler/optimizers/generic_layout_optimizer_test.cc
+++ b/tensorflow/core/grappler/optimizers/generic_layout_optimizer_test.cc
@@ -353,7 +353,7 @@ TEST_F(GenericLayoutOptimizerTest, CPUDevice) {
   VerifyDataFormatAttributeMatch(conv_node, "NHWC");
 #else
   VerifyDataFormatAttributeMatch(conv_node, DST_DATA_FORMAT);
-#endif // (GOOGLE_CUDA || TENSORFLOW_USE_ROCM)
+#endif  // (GOOGLE_CUDA || TENSORFLOW_USE_ROCM)
 }
 
 TEST_F(GenericLayoutOptimizerTest, Connectivity) {

--- a/tensorflow/core/grappler/optimizers/generic_layout_optimizer_transposer.h
+++ b/tensorflow/core/grappler/optimizers/generic_layout_optimizer_transposer.h
@@ -41,6 +41,7 @@ constexpr char kAttrSrcFormat[] = "src_format";
 constexpr char kAttrDstFormat[] = "dst_format";
 constexpr char kAttrOutputShape[] = "_output_shapes";
 constexpr char kGPU[] = "GPU";
+constexpr char kCPU[] = "CPU";
 
 // TransposeContext owns all data members. Must initialize GraphProperties,
 // FrameView, GraphDef and MutableGraphView with the same graph. NodeDef

--- a/tensorflow/core/grappler/optimizers/meta_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/meta_optimizer.cc
@@ -191,7 +191,9 @@ std::unique_ptr<GraphOptimizer> MetaOptimizer::MakeNewOptimizer(
              cfg_.experimental_disable_compressed_tensor_optimization()));
   MK_OPT("shape", new ShapeOptimizer());
   MK_OPT("remap", new Remapper(cfg_.remapping()));
-  MK_OPT("layout", new GenericLayoutOptimizer());
+  MK_OPT("layout", new GenericLayoutOptimizer(
+                       /*optimization level*/ cfg_.layout_optimizer(),
+                       /*CPU layout conversion*/ cfg_.cpu_layout_conversion()));
   MK_OPT("auto_mixed_precision",
          new AutoMixedPrecision(AutoMixedPrecisionMode::CUDA));
   MK_OPT("auto_mixed_precision_mkl",
@@ -271,7 +273,9 @@ Status MetaOptimizer::InitializeOptimizers(
         MakeUnique<ArithmeticOptimizer>(cfg_.arithmetic_optimization()));
   }
   if (cfg_.layout_optimizer() != RewriterConfig::OFF) {
-    optimizers->push_back(MakeUnique<GenericLayoutOptimizer>());
+    optimizers->push_back(MakeUnique<GenericLayoutOptimizer>(
+        /*optimization level*/ cfg_.layout_optimizer(),
+        /*CPU layout conversion*/ cfg_.cpu_layout_conversion()));
   }
   if (cfg_.remapping() != RewriterConfig::OFF) {
     optimizers->push_back(MakeUnique<Remapper>(cfg_.remapping()));

--- a/tensorflow/core/protobuf/rewriter_config.proto
+++ b/tensorflow/core/protobuf/rewriter_config.proto
@@ -39,6 +39,13 @@ message RewriterConfig {
     AGGRESSIVE = 3;
   }
 
+  // Enum for layout conversion between NCHW and NHWC on CPU. Default is OFF.
+  enum CpuLayout {
+    NO_CONVERSION_ON_CPU = 0;
+    NCHW_TO_NHWC = 1;
+    NHWC_TO_NCHW = 2;
+  }
+
   // Enum controlling the number of times to run optimizers. The default is to
   // run them twice.
   enum NumIterationsType {
@@ -46,6 +53,9 @@ message RewriterConfig {
     ONE = 1;
     TWO = 2;
   }
+
+  // CPU Conversion settings between NHCW and NCHW.
+  CpuLayout cpu_layout_conversion = 50;
 
   // Optimize tensor layouts (default is ON)
   // e.g. This will try to use NCHW layout on GPU which is faster.


### PR DESCRIPTION
This is an already reviewed PR #39760 with a fix to GPU failure.

This PR enables layout (data format) conversion from NCHW to NHWC on CPU. This is useful (1) when a model is trained on GPU and later doing inference/fine-tuning on CPU and (2) helps quantizing NCHW trained model for CPU.

To make the PR small, we have included a few unit tests in this part1. More unit tests will follow on future PRs.