### PR TITLE
Fix flexible members crash in clang 7.1 (Fixes #42468)

### DIFF
--- a/tensorflow/lite/c/common.h
+++ b/tensorflow/lite/c/common.h
@@ -88,7 +88,8 @@ typedef struct TfLiteIntArray {
 // https://github.com/google/re2/commit/b94b7cd42e9f02673cd748c1ac1d16db4052514c
 #if (!defined(__clang__) && defined(__GNUC__) && __GNUC__ == 6 && \
      __GNUC_MINOR__ >= 1) ||                                      \
-    defined(HEXAGON)
+    defined(HEXAGON) || \
+	(__clang_major__ == 7 && __clang_minor__ ==1)
   int data[0];
 #else
   int data[];


### PR DESCRIPTION
Fix flexible members crash in clang 7.1

Fixes #42468 

Defining data as data[] causes compiler crash in clang 7.1 when defining
const TfLiteIntArray kZeroLengthIntArray = {0, {}};
in micro_allocator.cc
