### PR TITLE
Fix doc layout error for regularizer

### DIFF
--- a/tensorflow/python/keras/regularizers.py
+++ b/tensorflow/python/keras/regularizers.py
@@ -104,6 +104,7 @@ class Regularizer(object):
   as if it is a one-argument function.
 
   E.g.
+  
   >>> regularizer = tf.keras.regularizers.L2(2.)
   >>> tensor = tf.ones(shape=(5, 5))
   >>> regularizer(tensor)


### PR DESCRIPTION
Without the additional blank line, the doc shows as follows
![image](https://user-images.githubusercontent.com/5104719/90545959-46301680-e13e-11ea-93e7-a39e8224af55.png)
