### PR TITLE
Check libraries linked into mlir-hlo-opt

### DIFF
--- a/tensorflow/compiler/mlir/hlo/tools/mlir-hlo-opt/CMakeLists.txt
+++ b/tensorflow/compiler/mlir/hlo/tools/mlir-hlo-opt/CMakeLists.txt
@@ -30,3 +30,5 @@ add_llvm_executable(mlir-hlo-opt mlir-hlo-opt.cpp
 )
 llvm_update_compile_flags(mlir-hlo-opt)
 target_link_libraries(mlir-hlo-opt PRIVATE ${LIBS})
+
+mlir_check_all_link_libraries(mlir-hlo-opt)


### PR DESCRIPTION
Adds a call to mlir_check_all_link_libraries() to check all libraries
linked into mlir-hlo-opt.