### PR TITLE
Reform the benchmark rules.

### DIFF
--- a/tensorflow/python/keras/benchmarks/keras_examples_benchmarks/antirectifier_benchmark_test.py
+++ b/tensorflow/python/keras/benchmarks/keras_examples_benchmarks/antirectifier_benchmark_test.py
@@ -54,69 +54,61 @@ class AntirectifierBenchmark(tf.test.Benchmark):
   #   Check more details in `measure_performance()` method of
   #   benchmark_util.
   def benchmark_antirectifier_bs_128(self):
-    """Measure performance with batch_size=128 and run_iters=2."""
+    """Measure performance with batch_size=128."""
     batch_size = 128
-    run_iters = 2
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.x_train,
         y=self.y_train,
         batch_size=batch_size,
-        run_iters=run_iters,
         optimizer="rmsprop",
         loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),
         metrics=["sparse_categorical_accuracy"])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
   def benchmark_antirectifier_bs_256(self):
-    """Measure performance with batch_size=256 and run_iters=3."""
+    """Measure performance with batch_size=256."""
     batch_size = 256
-    run_iters = 3
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.x_train,
         y=self.y_train,
         batch_size=batch_size,
-        run_iters=run_iters,
         optimizer="rmsprop",
         loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),
         metrics=["sparse_categorical_accuracy"])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
   def benchmark_antirectifier_bs_512(self):
-    """Measure performance with batch_size=512 and run_iters=4."""
+    """Measure performance with batch_size=512."""
     batch_size = 512
-    run_iters = 4
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.x_train,
         y=self.y_train,
         batch_size=batch_size,
-        run_iters=run_iters,
         optimizer="rmsprop",
         loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),
         metrics=["sparse_categorical_accuracy"])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
   def benchmark_antirectifier_bs_512_gpu_2(self):
-    """Measure performance with batch_size=512, run_iters=4, gpu=2 and
+    """Measure performance with batch_size=512, gpu=2 and
 
     distribution_strategy=`mirrored`.
     """
     batch_size = 512
-    run_iters = 4
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.x_train,
         y=self.y_train,
         batch_size=batch_size,
-        run_iters=run_iters,
         num_gpus=2,
         distribution_strategy="mirrored",
         optimizer="rmsprop",
@@ -124,7 +116,7 @@ class AntirectifierBenchmark(tf.test.Benchmark):
         metrics=["sparse_categorical_accuracy"])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
 
 class Antirectifier(tf.keras.layers.Layer):

--- a/tensorflow/python/keras/benchmarks/keras_examples_benchmarks/bidirectional_lstm_benchmark_test.py
+++ b/tensorflow/python/keras/benchmarks/keras_examples_benchmarks/bidirectional_lstm_benchmark_test.py
@@ -56,69 +56,61 @@ class BidirectionalLSTMBenchmark(tf.test.Benchmark):
   #   Check more details in `measure_performance()` method of
   #   benchmark_util.
   def benchmark_bidirect_lstm_imdb_bs_128(self):
-    """Measure performance with batch_size=128 and run_iters=3."""
+    """Measure performance with batch_size=128."""
     batch_size = 128
-    run_iters = 3
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.imdb_x,
         y=self.imdb_y,
         batch_size=batch_size,
-        run_iters=run_iters,
         optimizer='adam',
         loss='binary_crossentropy',
         metrics=['accuracy'])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
   def benchmark_bidirect_lstm_imdb_bs_256(self):
-    """Measure performance with batch_size=256 and run_iters=2."""
+    """Measure performance with batch_size=256."""
     batch_size = 256
-    run_iters = 2
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.imdb_x,
         y=self.imdb_y,
         batch_size=batch_size,
-        run_iters=run_iters,
         optimizer='adam',
         loss='binary_crossentropy',
         metrics=['accuracy'])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
   def benchmark_bidirect_lstm_imdb_bs_512(self):
-    """Measure performance with batch_size=512 and run_iters=4."""
+    """Measure performance with batch_size=512."""
     batch_size = 512
-    run_iters = 4
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.imdb_x,
         y=self.imdb_y,
         batch_size=batch_size,
-        run_iters=run_iters,
         optimizer='adam',
         loss='binary_crossentropy',
         metrics=['accuracy'])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
   def benchmark_bidirect_lstm_imdb_bs_512_gpu_2(self):
-    """Measure performance with batch_size=512, run_iters=4, gpu=2 and
+    """Measure performance with batch_size=512, gpu=2 and
 
     distribution_strategy=`mirrored`.
     """
     batch_size = 512
-    run_iters = 4
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.imdb_x,
         y=self.imdb_y,
         batch_size=batch_size,
-        run_iters=run_iters,
         num_gpus=2,
         distribution_strategy='mirrored',
         optimizer='adam',
@@ -126,7 +118,7 @@ class BidirectionalLSTMBenchmark(tf.test.Benchmark):
         metrics=['accuracy'])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
 
 if __name__ == '__main__':

--- a/tensorflow/python/keras/benchmarks/keras_examples_benchmarks/cifar10_cnn_benchmark_test.py
+++ b/tensorflow/python/keras/benchmarks/keras_examples_benchmarks/cifar10_cnn_benchmark_test.py
@@ -70,72 +70,64 @@ class Cifar10CNNBenchmark(tf.test.Benchmark):
   #   Check more details in `measure_performance()` method of
   #   benchmark_util.
   def benchmark_cnn_cifar10_bs_256(self):
-    """Measure performance with batch_size=256 and run_iters=3."""
+    """Measure performance with batch_size=256."""
     batch_size = 256
-    run_iters = 3
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.x_train,
         y=self.y_train,
         batch_size=batch_size,
-        run_iters=run_iters,
         epochs=self.epochs,
         optimizer=tf.keras.optimizers.RMSprop(learning_rate=0.0001, decay=1e-6),
         loss='categorical_crossentropy',
         metrics=['accuracy'])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
   def benchmark_cnn_cifar10_bs_512(self):
-    """Measure performance with batch_size=512 and run_iters=3."""
+    """Measure performance with batch_size=512."""
     batch_size = 512
-    run_iters = 3
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.x_train,
         y=self.y_train,
         batch_size=batch_size,
-        run_iters=run_iters,
         epochs=self.epochs,
         optimizer=tf.keras.optimizers.RMSprop(learning_rate=0.0001, decay=1e-6),
         loss='categorical_crossentropy',
         metrics=['accuracy'])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
   def benchmark_cnn_cifar10_bs_1024(self):
-    """Measure performance with batch_size=1024 and run_iters=2."""
+    """Measure performance with batch_size=1024."""
     batch_size = 1024
-    run_iters = 2
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.x_train,
         y=self.y_train,
         batch_size=batch_size,
-        run_iters=run_iters,
         epochs=self.epochs,
         optimizer=tf.keras.optimizers.RMSprop(learning_rate=0.0001, decay=1e-6),
         loss='categorical_crossentropy',
         metrics=['accuracy'])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
   def benchmark_cnn_cifar10_bs_1024_gpu_2(self):
-    """Measure performance with batch_size=1024, run_iters=2, gpu=2 and
+    """Measure performance with batch_size=1024, gpu=2 and
 
     distribution_strategy=`mirrored`.
     """
     batch_size = 1024
-    run_iters = 2
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.x_train,
         y=self.y_train,
         batch_size=batch_size,
-        run_iters=run_iters,
         num_gpus=2,
         distribution_strategy='mirrored',
         epochs=self.epochs,
@@ -144,7 +136,7 @@ class Cifar10CNNBenchmark(tf.test.Benchmark):
         metrics=['accuracy'])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
 
 if __name__ == '__main__':

--- a/tensorflow/python/keras/benchmarks/keras_examples_benchmarks/cifar10_cnn_benchmark_test.py
+++ b/tensorflow/python/keras/benchmarks/keras_examples_benchmarks/cifar10_cnn_benchmark_test.py
@@ -31,7 +31,7 @@ class Cifar10CNNBenchmark(tf.test.Benchmark):
     (self.x_train, self.y_train), _ = tf.keras.datasets.cifar10.load_data()
     self.x_train = self.x_train.astype('float32') / 255
     self.y_train = tf.keras.utils.to_categorical(self.y_train, self.num_classes)
-    self.epochs = 25
+    self.epochs = 5
 
   def _build_model(self):
     """Model from https://github.com/keras-team/keras/blob/master/examples/cifar10_cnn.py."""

--- a/tensorflow/python/keras/benchmarks/keras_examples_benchmarks/mnist_conv_benchmark_test.py
+++ b/tensorflow/python/keras/benchmarks/keras_examples_benchmarks/mnist_conv_benchmark_test.py
@@ -96,29 +96,6 @@ class ConvMnistBenchmark(tf.test.Benchmark):
     self.report_benchmark(
         iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
 
-  def benchmark_conv_mnist_bs_256_gpu_2(self):
-    """Measure performance with batch_size=256, run_iters=3, gpu=2 and
-
-    distribution_strategy='mirrored'
-    """
-    batch_size = 256
-    run_iters = 3
-    metrics, wall_time, extras = benchmark_util.measure_performance(
-        self._build_model,
-        x=self.x_train,
-        y=self.y_train,
-        batch_size=batch_size,
-        run_iters=run_iters,
-        num_gpus=2,
-        distribution_strategy='mirrored',
-        epochs=self.epochs,
-        optimizer='adam',
-        loss='categorical_crossentropy',
-        metrics=['accuracy'])
-
-    self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
-
   def benchmark_conv_mnist_bs_512(self):
     """Measure performance with batch_size=512 and run_iters=3."""
     batch_size = 512
@@ -129,6 +106,29 @@ class ConvMnistBenchmark(tf.test.Benchmark):
         y=self.y_train,
         batch_size=batch_size,
         run_iters=run_iters,
+        epochs=self.epochs,
+        optimizer='adam',
+        loss='categorical_crossentropy',
+        metrics=['accuracy'])
+
+    self.report_benchmark(
+        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+
+  def benchmark_conv_mnist_bs_512_gpu_2(self):
+    """Measure performance with batch_size=512, run_iters=3, gpu=2 and
+
+    distribution_strategy='mirrored'
+    """
+    batch_size = 512
+    run_iters = 3
+    metrics, wall_time, extras = benchmark_util.measure_performance(
+        self._build_model,
+        x=self.x_train,
+        y=self.y_train,
+        batch_size=batch_size,
+        run_iters=run_iters,
+        num_gpus=2,
+        distribution_strategy='mirrored',
         epochs=self.epochs,
         optimizer='adam',
         loss='categorical_crossentropy',

--- a/tensorflow/python/keras/benchmarks/keras_examples_benchmarks/mnist_conv_benchmark_test.py
+++ b/tensorflow/python/keras/benchmarks/keras_examples_benchmarks/mnist_conv_benchmark_test.py
@@ -61,72 +61,64 @@ class ConvMnistBenchmark(tf.test.Benchmark):
   #   Check more details in `measure_performance()` method of
   #   benchmark_util.
   def benchmark_conv_mnist_bs_128(self):
-    """Measure performance with batch_size=128 and run_iters=2."""
+    """Measure performance with batch_size=128."""
     batch_size = 128
-    run_iters = 2
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.x_train,
         y=self.y_train,
         batch_size=batch_size,
-        run_iters=run_iters,
         epochs=self.epochs,
         optimizer='adam',
         loss='categorical_crossentropy',
         metrics=['accuracy'])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
   def benchmark_conv_mnist_bs_256(self):
-    """Measure performance with batch_size=256 and run_iters=3."""
+    """Measure performance with batch_size=256."""
     batch_size = 256
-    run_iters = 3
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.x_train,
         y=self.y_train,
         batch_size=batch_size,
-        run_iters=run_iters,
         epochs=self.epochs,
         optimizer='adam',
         loss='categorical_crossentropy',
         metrics=['accuracy'])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
   def benchmark_conv_mnist_bs_512(self):
-    """Measure performance with batch_size=512 and run_iters=3."""
+    """Measure performance with batch_size=512."""
     batch_size = 512
-    run_iters = 3
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.x_train,
         y=self.y_train,
         batch_size=batch_size,
-        run_iters=run_iters,
         epochs=self.epochs,
         optimizer='adam',
         loss='categorical_crossentropy',
         metrics=['accuracy'])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
   def benchmark_conv_mnist_bs_512_gpu_2(self):
-    """Measure performance with batch_size=512, run_iters=3, gpu=2 and
+    """Measure performance with batch_size=512, gpu=2 and
 
     distribution_strategy='mirrored'
     """
     batch_size = 512
-    run_iters = 3
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.x_train,
         y=self.y_train,
         batch_size=batch_size,
-        run_iters=run_iters,
         num_gpus=2,
         distribution_strategy='mirrored',
         epochs=self.epochs,
@@ -135,7 +127,7 @@ class ConvMnistBenchmark(tf.test.Benchmark):
         metrics=['accuracy'])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
 
 if __name__ == '__main__':

--- a/tensorflow/python/keras/benchmarks/keras_examples_benchmarks/mnist_hierarchical_rnn_benchmark_test.py
+++ b/tensorflow/python/keras/benchmarks/keras_examples_benchmarks/mnist_hierarchical_rnn_benchmark_test.py
@@ -78,28 +78,6 @@ class HierarchicalRNNBenchmark(tf.test.Benchmark):
     self.report_benchmark(
         iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
 
-  def benchmark_hrnn_mnist_bs_256_gpu_2(self):
-    """Measure performance with batch_size=256, run_iters=4, gpu=2 and
-
-    distribution_strategy='mirrored'
-    """
-    batch_size = 256
-    run_iters = 4
-    metrics, wall_time, extras = benchmark_util.measure_performance(
-        self._build_model,
-        x=self.x_train,
-        y=self.y_train,
-        batch_size=batch_size,
-        run_iters=run_iters,
-        num_gpus=2,
-        distribution_strategy='mirrored',
-        optimizer='rmsprop',
-        loss='categorical_crossentropy',
-        metrics=['accuracy'])
-
-    self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
-
   def benchmark_hrnn_mnist_bs_512(self):
     """Measure performance with batch_size=512 and run_iters=5."""
     batch_size = 512
@@ -127,6 +105,28 @@ class HierarchicalRNNBenchmark(tf.test.Benchmark):
         y=self.y_train,
         batch_size=batch_size,
         run_iters=run_iters,
+        optimizer='rmsprop',
+        loss='categorical_crossentropy',
+        metrics=['accuracy'])
+
+    self.report_benchmark(
+        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+
+  def benchmark_hrnn_mnist_bs_1024_gpu_2(self):
+    """Measure performance with batch_size=1024, run_iters=4, gpu=2 and
+
+    distribution_strategy='mirrored'
+    """
+    batch_size = 1024
+    run_iters = 4
+    metrics, wall_time, extras = benchmark_util.measure_performance(
+        self._build_model,
+        x=self.x_train,
+        y=self.y_train,
+        batch_size=batch_size,
+        run_iters=run_iters,
+        num_gpus=2,
+        distribution_strategy='mirrored',
         optimizer='rmsprop',
         loss='categorical_crossentropy',
         metrics=['accuracy'])

--- a/tensorflow/python/keras/benchmarks/keras_examples_benchmarks/mnist_hierarchical_rnn_benchmark_test.py
+++ b/tensorflow/python/keras/benchmarks/keras_examples_benchmarks/mnist_hierarchical_rnn_benchmark_test.py
@@ -62,69 +62,61 @@ class HierarchicalRNNBenchmark(tf.test.Benchmark):
   #   Check more details in `measure_performance()` method of
   #   benchmark_util.
   def benchmark_hrnn_mnist_bs_256(self):
-    """Measure performance with batch_size=256 and run_iters=4."""
+    """Measure performance with batch_size=256."""
     batch_size = 256
-    run_iters = 4
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.x_train,
         y=self.y_train,
         batch_size=batch_size,
-        run_iters=run_iters,
         optimizer='rmsprop',
         loss='categorical_crossentropy',
         metrics=['accuracy'])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
   def benchmark_hrnn_mnist_bs_512(self):
-    """Measure performance with batch_size=512 and run_iters=5."""
+    """Measure performance with batch_size=512."""
     batch_size = 512
-    run_iters = 5
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.x_train,
         y=self.y_train,
         batch_size=batch_size,
-        run_iters=run_iters,
         optimizer='rmsprop',
         loss='categorical_crossentropy',
         metrics=['accuracy'])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
   def benchmark_hrnn_mnist_bs_1024(self):
-    """Measure performance with batch_size=1024 and run_iters=3."""
+    """Measure performance with batch_size=1024."""
     batch_size = 1024
-    run_iters = 3
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.x_train,
         y=self.y_train,
         batch_size=batch_size,
-        run_iters=run_iters,
         optimizer='rmsprop',
         loss='categorical_crossentropy',
         metrics=['accuracy'])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
   def benchmark_hrnn_mnist_bs_1024_gpu_2(self):
-    """Measure performance with batch_size=1024, run_iters=4, gpu=2 and
+    """Measure performance with batch_size=1024, gpu=2 and
 
     distribution_strategy='mirrored'
     """
     batch_size = 1024
-    run_iters = 4
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.x_train,
         y=self.y_train,
         batch_size=batch_size,
-        run_iters=run_iters,
         num_gpus=2,
         distribution_strategy='mirrored',
         optimizer='rmsprop',
@@ -132,7 +124,7 @@ class HierarchicalRNNBenchmark(tf.test.Benchmark):
         metrics=['accuracy'])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
 
 if __name__ == '__main__':

--- a/tensorflow/python/keras/benchmarks/keras_examples_benchmarks/mnist_irnn_benchmark_test.py
+++ b/tensorflow/python/keras/benchmarks/keras_examples_benchmarks/mnist_irnn_benchmark_test.py
@@ -62,69 +62,61 @@ class IRNNMnistBenchmark(tf.test.Benchmark):
   #   Check more details in `measure_performance()` method of
   #   benchmark_util.
   def benchmark_irnn_mnist_bs_256(self):
-    """Measure performance with batch_size=256 and run_iters=4."""
+    """Measure performance with batch_size=256."""
     batch_size = 256
-    run_iters = 4
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.x_train,
         y=self.y_train,
         batch_size=batch_size,
-        run_iters=run_iters,
         optimizer=tf.keras.optimizers.RMSprop(learning_rate=self.learning_rate),
         loss='categorical_crossentropy',
         metrics=['accuracy'])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
   def benchmark_irnn_mnist_bs_512(self):
-    """Measure performance with batch_size=512 and run_iters=3."""
+    """Measure performance with batch_size=512."""
     batch_size = 512
-    run_iters = 3
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.x_train,
         y=self.y_train,
         batch_size=batch_size,
-        run_iters=run_iters,
         optimizer=tf.keras.optimizers.RMSprop(learning_rate=self.learning_rate),
         loss='categorical_crossentropy',
         metrics=['accuracy'])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
   def benchmark_irnn_mnist_bs_1024(self):
-    """Measure performance with batch_size=1024 and run_iters=3."""
+    """Measure performance with batch_size=1024."""
     batch_size = 1024
-    run_iters = 3
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.x_train,
         y=self.y_train,
         batch_size=batch_size,
-        run_iters=run_iters,
         optimizer=tf.keras.optimizers.RMSprop(learning_rate=self.learning_rate),
         loss='categorical_crossentropy',
         metrics=['accuracy'])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
   def benchmark_irnn_mnist_bs_1024_gpu_2(self):
-    """Measure performance with batch_size=1024, run_iters=3, gpu=2 and
+    """Measure performance with batch_size=1024, gpu=2 and
 
     distribution_strategy='mirrored'
     """
     batch_size = 1024
-    run_iters = 3
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.x_train,
         y=self.y_train,
         batch_size=batch_size,
-        run_iters=run_iters,
         num_gpus=2,
         distribution_strategy='mirrored',
         optimizer=tf.keras.optimizers.RMSprop(learning_rate=self.learning_rate),
@@ -132,7 +124,7 @@ class IRNNMnistBenchmark(tf.test.Benchmark):
         metrics=['accuracy'])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
 
 if __name__ == '__main__':

--- a/tensorflow/python/keras/benchmarks/keras_examples_benchmarks/mnist_irnn_benchmark_test.py
+++ b/tensorflow/python/keras/benchmarks/keras_examples_benchmarks/mnist_irnn_benchmark_test.py
@@ -15,7 +15,7 @@
 """Benchmarks on IRNN on MNIST digits."""
 from __future__ import absolute_import
 from __future__ import division
-from __future__ import print_function
+from __future__ import print_function 
 
 import tensorflow as tf
 
@@ -112,8 +112,8 @@ class IRNNMnistBenchmark(tf.test.Benchmark):
     self.report_benchmark(
         iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
 
-  def benchmark_irnn_mnist_bs_1024_gpu_3(self):
-    """Measure performance with batch_size=1024, run_iters=3, gpu=3 and
+  def benchmark_irnn_mnist_bs_1024_gpu_2(self):
+    """Measure performance with batch_size=1024, run_iters=3, gpu=2 and
 
     distribution_strategy='mirrored'
     """
@@ -125,7 +125,7 @@ class IRNNMnistBenchmark(tf.test.Benchmark):
         y=self.y_train,
         batch_size=batch_size,
         run_iters=run_iters,
-        num_gpus=3,
+        num_gpus=2,
         distribution_strategy='mirrored',
         optimizer=tf.keras.optimizers.RMSprop(learning_rate=self.learning_rate),
         loss='categorical_crossentropy',

--- a/tensorflow/python/keras/benchmarks/keras_examples_benchmarks/reuters_mlp_benchmark_test.py
+++ b/tensorflow/python/keras/benchmarks/keras_examples_benchmarks/reuters_mlp_benchmark_test.py
@@ -61,72 +61,64 @@ class MLPReutersBenchmark(tf.test.Benchmark):
   #   Check more details in `measure_performance()` method of
   #   benchmark_util.
   def benchmark_mlp_reuters_bs_128(self):
-    """Measure performance with batch_size=128 and run_iters=2."""
+    """Measure performance with batch_size=128."""
     batch_size = 128
-    run_iters = 2
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.x_train,
         y=self.y_train,
         batch_size=batch_size,
-        run_iters=run_iters,
         epochs=self.epochs,
         optimizer='adam',
         loss='categorical_crossentropy',
         metrics=['accuracy'])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
   def benchmark_mlp_reuters_bs_256(self):
-    """Measure performance with batch_size=256 and run_iters=3."""
+    """Measure performance with batch_size=256."""
     batch_size = 256
-    run_iters = 3
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.x_train,
         y=self.y_train,
         batch_size=batch_size,
-        run_iters=run_iters,
         epochs=self.epochs,
         optimizer='adam',
         loss='categorical_crossentropy',
         metrics=['accuracy'])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
   def benchmark_mlp_reuters_bs_512(self):
-    """Measure performance with batch_size=512 and run_iters=4."""
+    """Measure performance with batch_size=512."""
     batch_size = 512
-    run_iters = 4
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.x_train,
         y=self.y_train,
         batch_size=batch_size,
-        run_iters=run_iters,
         epochs=self.epochs,
         optimizer='adam',
         loss='categorical_crossentropy',
         metrics=['accuracy'])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
   def benchmark_mlp_reuters_bs_512_gpu_2(self):
-    """Measure performance with batch_size=512, run_iters=2, gpu=2 and
+    """Measure performance with batch_size=512, gpu=2 and
 
     distribution_strategy='mirrored'
     """
     batch_size = 512
-    run_iters = 2
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.x_train,
         y=self.y_train,
         batch_size=batch_size,
-        run_iters=run_iters,
         num_gpus=2,
         distribution_strategy='mirrored',
         epochs=self.epochs,
@@ -135,7 +127,7 @@ class MLPReutersBenchmark(tf.test.Benchmark):
         metrics=['accuracy'])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
 
 if __name__ == '__main__':

--- a/tensorflow/python/keras/benchmarks/keras_examples_benchmarks/reuters_mlp_benchmark_test.py
+++ b/tensorflow/python/keras/benchmarks/keras_examples_benchmarks/reuters_mlp_benchmark_test.py
@@ -78,29 +78,6 @@ class MLPReutersBenchmark(tf.test.Benchmark):
     self.report_benchmark(
         iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
 
-  def benchmark_mlp_reuters_bs_128_gpu_3(self):
-    """Measure performance with batch_size=128, run_iters=2, gpu=3 and
-
-    distribution_strategy='mirrored'
-    """
-    batch_size = 128
-    run_iters = 2
-    metrics, wall_time, extras = benchmark_util.measure_performance(
-        self._build_model,
-        x=self.x_train,
-        y=self.y_train,
-        batch_size=batch_size,
-        run_iters=run_iters,
-        num_gpus=3,
-        distribution_strategy='mirrored',
-        epochs=self.epochs,
-        optimizer='adam',
-        loss='categorical_crossentropy',
-        metrics=['accuracy'])
-
-    self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
-
   def benchmark_mlp_reuters_bs_256(self):
     """Measure performance with batch_size=256 and run_iters=3."""
     batch_size = 256
@@ -129,6 +106,29 @@ class MLPReutersBenchmark(tf.test.Benchmark):
         y=self.y_train,
         batch_size=batch_size,
         run_iters=run_iters,
+        epochs=self.epochs,
+        optimizer='adam',
+        loss='categorical_crossentropy',
+        metrics=['accuracy'])
+
+    self.report_benchmark(
+        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+
+  def benchmark_mlp_reuters_bs_512_gpu_2(self):
+    """Measure performance with batch_size=512, run_iters=2, gpu=2 and
+
+    distribution_strategy='mirrored'
+    """
+    batch_size = 512
+    run_iters = 2
+    metrics, wall_time, extras = benchmark_util.measure_performance(
+        self._build_model,
+        x=self.x_train,
+        y=self.y_train,
+        batch_size=batch_size,
+        run_iters=run_iters,
+        num_gpus=2,
+        distribution_strategy='mirrored',
         epochs=self.epochs,
         optimizer='adam',
         loss='categorical_crossentropy',

--- a/tensorflow/python/keras/benchmarks/keras_examples_benchmarks/text_classification_transformer_benchmark_test.py
+++ b/tensorflow/python/keras/benchmarks/keras_examples_benchmarks/text_classification_transformer_benchmark_test.py
@@ -66,69 +66,61 @@ class TextWithTransformerBenchmark(tf.test.Benchmark):
   #   Check more details in `measure_performance()` method of
   #   benchmark_util.
   def benchmark_text_classification_bs_128(self):
-    """Measure performance with batch_size=128 and run_iters=3."""
+    """Measure performance with batch_size=128."""
     batch_size = 128
-    run_iters = 3
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.imdb_x,
         y=self.imdb_y,
         batch_size=batch_size,
-        run_iters=run_iters,
         optimizer='adam',
         loss='sparse_categorical_crossentropy',
         metrics=['accuracy'])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
   def benchmark_text_classification_bs_256(self):
-    """Measure performance with batch_size=256 and run_iters=3."""
+    """Measure performance with batch_size=256."""
     batch_size = 256
-    run_iters = 3
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.imdb_x,
         y=self.imdb_y,
         batch_size=batch_size,
-        run_iters=run_iters,
         optimizer='adam',
         loss='sparse_categorical_crossentropy',
         metrics=['accuracy'])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
   def benchmark_text_classification_bs_512(self):
-    """Measure performance with batch_size=512 and run_iters=4."""
+    """Measure performance with batch_size=512."""
     batch_size = 512
-    run_iters = 4
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.imdb_x,
         y=self.imdb_y,
         batch_size=batch_size,
-        run_iters=run_iters,
         optimizer='adam',
         loss='sparse_categorical_crossentropy',
         metrics=['accuracy'])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
   def benchmark_text_classification_bs_512_gpu_2(self):
-    """Measure performance with batch_size=512, run_iters=4, gpu=1 and
+    """Measure performance with batch_size=512, gpu=1 and
 
     distribution_strategy='mirrored'
     """
     batch_size = 512
-    run_iters = 4
     metrics, wall_time, extras = benchmark_util.measure_performance(
         self._build_model,
         x=self.imdb_x,
         y=self.imdb_y,
         batch_size=batch_size,
-        run_iters=run_iters,
         num_gpus=2,
         distribution_strategy='mirrored',
         optimizer='adam',
@@ -136,7 +128,7 @@ class TextWithTransformerBenchmark(tf.test.Benchmark):
         metrics=['accuracy'])
 
     self.report_benchmark(
-        iters=run_iters, wall_time=wall_time, metrics=metrics, extras=extras)
+        wall_time=wall_time, metrics=metrics, extras=extras)
 
 
 class MultiHeadSelfAttention(tf.keras.layers.Layer):


### PR DESCRIPTION
We provide the benchmarks by sorted batch_size, and also provide GPU benchmark with maximum batch_size for current model. For `cifar10_cnn_benchmark_test`, we used the small epochs to get the results quickly.