### PR TITLE
Add the `size` API for TensorFlow NumPy operations.

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -560,9 +560,13 @@ def _reduce(tf_fn,
       tf_fn(input_tensor=a.data, axis=axis, keepdims=keepdims))
 
 
+# TODO (DarrenZhang01): Add `axis` support to the `size` API.
 @utils.np_doc('size')
-def size(x):
-  x = x.numpy() if isinstance(x, tf.Tensor) else x
+def size(x, axis=None):
+  if axis is not None:
+    raise NotImplementedError("axis argument is not supported in the current `np.size` "
+                     "implementation")
+  x = asarray(x).data
   if isinstance(x, (int, float, onp.int32, onp.int64,
                     onp.float32, onp.float64)):
     return 1

--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -563,7 +563,8 @@ def _reduce(tf_fn,
 @utils.np_doc('size')
 def size(x):
   x = x.numpy() if isinstance(x, tf.Tensor) else x
-  if isinstance(x, (int, float, onp.int32, onp.int64, onp.float32, onp.float64)):
+  if isinstance(x, (int, float, onp.int32, onp.int64,
+                    onp.float32, onp.float64)):
     return 1
   elif isinstance(x, (np.ndarray, onp.ndarray)):
     return np.prod(x.shape)

--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -560,6 +560,18 @@ def _reduce(tf_fn,
       tf_fn(input_tensor=a.data, axis=axis, keepdims=keepdims))
 
 
+@utils.np_doc('size')
+def size(x):
+  x = x.numpy() if isinstance(x, tf.Tensor) else x
+  if isinstance(x, (int, float, onp.int32, onp.int64, onp.float32, onp.float64)):
+    return 1
+  elif isinstance(x, (np.ndarray, onp.ndarray)):
+    return np.prod(x.shape)
+  else:
+    raise TypeError("The inputs must be one of types {int, float, numpy array"
+                    ", TensorFlow Tensor, TensorFlow ndarray} object.")
+
+
 @np_utils.np_doc('sum')
 def sum(a, axis=None, dtype=None, keepdims=None):  # pylint: disable=redefined-builtin
   return _reduce(

--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -564,15 +564,15 @@ def _reduce(tf_fn,
 # TODO (DarrenZhang01): Add `axis` support to the `size` API.
 @np_utils.np_doc('size')
 def size(x, axis=None):   # pylint: disable=missing-docstring
-  x = np.asarray(x) if isinstance(x, tf.Tensor) else x
+  x = asarray(x).data
   if axis is not None:
     raise NotImplementedError("axis argument is not supported in the current "
                               "`np.size` implementation")
   if isinstance(x, (int, float, np.int32, np.int64,
                     np.float32, np.float64)):
     return 1
-  elif isinstance(x, (np_arrays.ndarray, np.ndarray)):
-    return prod(x.shape)
+  elif isinstance(x, (np_arrays.ndarray, np.ndarray)) or tf.is_tensor(x):
+    return prod(tuple(x.shape))
   else:
     raise TypeError("The inputs must be one of types {int, float, numpy array"
                     ", TensorFlow Tensor, TensorFlow ndarray} object.")

--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -570,16 +570,11 @@ def size(x, axis=None):   # pylint: disable=missing-docstring
   if isinstance(x, (int, float, np.int32, np.int64,
                     np.float32, np.float64)):
     return 1
-  # Turn possible graph tensors into non-graph tensors.
   x = asarray(x).data
-  if isinstance(x, (np_arrays.ndarray, np.ndarray)) or tensor_util.is_tensor(x):
-    if x.shape.is_fully_defined():
-      return prod(tuple(x.shape))
-    else:
-      return array_ops.size_v2(x)
+  if x.shape.is_fully_defined():
+    return prod(tuple(x.shape))
   else:
-    raise TypeError("The inputs must be one of types {int, float, numpy array"
-                    ", TensorFlow Tensor, TensorFlow ndarray} object.")
+    return np_utils.tensor_to_ndarray(array_ops.size_v2(x))
 
 
 @np_utils.np_doc('sum')

--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -28,7 +28,6 @@ from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import tensor_shape
-from tensorflow.python.framework import tensor_util
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import clip_ops
 from tensorflow.python.ops import control_flow_ops

--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -24,6 +24,7 @@ import numbers
 import numpy as np
 import six
 
+import tensorflow as tf
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
@@ -563,10 +564,10 @@ def _reduce(tf_fn,
 # TODO (DarrenZhang01): Add `axis` support to the `size` API.
 @np_utils.np_doc('size')
 def size(x, axis=None):   # pylint: disable=missing-docstring
+  x = np.asarray(x) if isinstance(x, tf.Tensor) else x
   if axis is not None:
     raise NotImplementedError("axis argument is not supported in the current "
                               "`np.size` implementation")
-  x = asarray(x).data
   if isinstance(x, (int, float, np.int32, np.int64,
                     np.float32, np.float64)):
     return 1

--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -562,16 +562,16 @@ def _reduce(tf_fn,
 
 # TODO (DarrenZhang01): Add `axis` support to the `size` API.
 @utils.np_doc('size')
-def size(x, axis=None):
+def size(x, axis=None):   # pylint: disable=missing-docstring
   if axis is not None:
-    raise NotImplementedError("axis argument is not supported in the current `np.size` "
-                     "implementation")
+    raise NotImplementedError("axis argument is not supported in the current "
+                              "`np.size` implementation")
   x = asarray(x).data
-  if isinstance(x, (int, float, onp.int32, onp.int64,
-                    onp.float32, onp.float64)):
+  if isinstance(x, (int, float, np.int32, np.int64,
+                    np.float32, np.float64)):
     return 1
-  elif isinstance(x, (np.ndarray, onp.ndarray)):
-    return np.prod(x.shape)
+  elif isinstance(x, (np_arrays.ndarray, np.ndarray)):
+    return prod(x.shape)
   else:
     raise TypeError("The inputs must be one of types {int, float, numpy array"
                     ", TensorFlow Tensor, TensorFlow ndarray} object.")

--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -561,7 +561,7 @@ def _reduce(tf_fn,
 
 
 # TODO (DarrenZhang01): Add `axis` support to the `size` API.
-@utils.np_doc('size')
+@np_utils.np_doc('size')
 def size(x, axis=None):   # pylint: disable=missing-docstring
   if axis is not None:
     raise NotImplementedError("axis argument is not supported in the current "

--- a/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
@@ -829,7 +829,7 @@ class ArrayMethodsTest(test.TestCase):
       arr = np_array_ops.asarray(arr)
       return np_array_ops.size(arr)
 
-    self.assertEqual(f(np_array_ops.ones((3, 2))).numpy(), 6)
+    self.assertEqual(f(np_array_ops.ones((3, 2))).data.numpy(), 6)
 
   def testRavel(self):
 

--- a/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
@@ -19,8 +19,8 @@ from __future__ import division
 from __future__ import print_function
 
 import itertools
-import numpy as np
 import sys
+import numpy as np
 from six.moves import range
 from six.moves import zip
 

--- a/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
@@ -807,7 +807,7 @@ class ArrayMethodsTest(test.TestCase):
   def testSize(self):
 
     def run_test(arr, axis=None):
-      onp_arr = arr.numpy() if isinstance(arr, tf.Tensor) else arr
+      onp_arr = np.array(arr).data
       self.assertEqual(np_array_ops.size(arr, axis), onp.size(onp_arr, axis))
 
     run_test(np.array([1]))

--- a/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
@@ -19,7 +19,6 @@ from __future__ import division
 from __future__ import print_function
 
 import itertools
-import sys
 import numpy as np
 from six.moves import range
 from six.moves import zip
@@ -808,7 +807,7 @@ class ArrayMethodsTest(test.TestCase):
   def testSize(self):
 
     def run_test(arr, axis=None):
-      onp_arr = np.array(arr) if isinstance(arr, tf.Tensor) else arr
+      onp_arr = np.array(arr)
       self.assertEqual(np_array_ops.size(arr, axis), np.size(onp_arr, axis))
 
     run_test(np_array_ops.array([1]))
@@ -820,7 +819,8 @@ class ArrayMethodsTest(test.TestCase):
     run_test(np_array_ops.ones((3, 2, 1)))
     run_test(tf.constant(5))
     run_test(tf.constant([1, 1, 1]))
-    self.assertRaises(NotImplementedError, size, np.ones((2, 2)), 1)
+    self.assertRaises(NotImplementedError, np_array_ops.size,
+                      np.ones((2, 2)), 1)
 
   def testRavel(self):
 

--- a/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
@@ -806,9 +806,9 @@ class ArrayMethodsTest(test.TestCase):
 
   def testSize(self):
 
-    def run_test(arr):
+    def run_test(arr, axis=None):
       onp_arr = arr.numpy() if isinstance(arr, tf.Tensor) else arr
-      self.assertEqual(np_size(arr), onp.size(onp_arr))
+      self.assertEqual(np_array_ops.size(arr, axis), onp.size(onp_arr, axis))
 
     run_test(np.array([1]))
     run_test(np.array([1, 2, 3, 4, 5]))
@@ -819,6 +819,7 @@ class ArrayMethodsTest(test.TestCase):
     run_test(onp.ones((3, 2, 1)))
     run_test(tf.constant(5))
     run_test(tf.constant([1, 1, 1]))
+    self.assertRaises(ValueError, run_test, np.ones((2, 2)), 1)
 
   def testRavel(self):
 

--- a/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
@@ -808,7 +808,6 @@ class ArrayMethodsTest(test.TestCase):
 
     def run_test(arr):
       onp_arr = arr.numpy() if isinstance(arr, tf.Tensor) else arr
-      print(onp_arr)
       self.assertEqual(np_size(arr), onp.size(onp_arr))
 
     run_test(np.array([1]))

--- a/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
@@ -20,10 +20,10 @@ from __future__ import print_function
 
 import itertools
 import numpy as np
+import sys
 from six.moves import range
 from six.moves import zip
 
-import tensorflow as tf
 from tensorflow.python.eager import context
 from tensorflow.python.framework import config
 from tensorflow.python.framework import constant_op
@@ -817,8 +817,8 @@ class ArrayMethodsTest(test.TestCase):
     run_test(np_array_ops.zeros((5, 6, 7)))
     run_test(1)
     run_test(np_array_ops.ones((3, 2, 1)))
-    run_test(tf.constant(5))
-    run_test(tf.constant([1, 1, 1]))
+    run_test(constant_op.constant(5))
+    run_test(constant_op.constant([1, 1, 1]))
     self.assertRaises(NotImplementedError, np_array_ops.size,
                       np.ones((2, 2)), 1)
 

--- a/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
@@ -25,12 +25,14 @@ from six.moves import range
 from six.moves import zip
 
 from tensorflow.python.eager import context
+from tensorflow.python.eager import def_function
 from tensorflow.python.framework import config
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import indexed_slices
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import tensor_shape
+from tensorflow.python.framework import tensor_spec
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops.numpy_ops import np_array_ops
 from tensorflow.python.ops.numpy_ops import np_arrays
@@ -821,6 +823,13 @@ class ArrayMethodsTest(test.TestCase):
     run_test(constant_op.constant([1, 1, 1]))
     self.assertRaises(NotImplementedError, np_array_ops.size,
                       np.ones((2, 2)), 1)
+
+    @def_function.function(input_signature=[tensor_spec.TensorSpec(shape=None)])
+    def f(arr):
+      arr = np_array_ops.asarray(arr)
+      return np_array_ops.size(arr)
+
+    self.assertEqual(f(np_array_ops.ones((3, 2))).numpy(), 6)
 
   def testRavel(self):
 

--- a/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
@@ -24,6 +24,7 @@ import numpy as np
 from six.moves import range
 from six.moves import zip
 
+import tensorflow as tf
 from tensorflow.python.eager import context
 from tensorflow.python.framework import config
 from tensorflow.python.framework import constant_op
@@ -807,19 +808,19 @@ class ArrayMethodsTest(test.TestCase):
   def testSize(self):
 
     def run_test(arr, axis=None):
-      onp_arr = np.array(arr).data
-      self.assertEqual(np_array_ops.size(arr, axis), onp.size(onp_arr, axis))
+      onp_arr = np.array(arr) if isinstance(arr, tf.Tensor) else arr
+      self.assertEqual(np_array_ops.size(arr, axis), np.size(onp_arr, axis))
 
-    run_test(np.array([1]))
-    run_test(np.array([1, 2, 3, 4, 5]))
-    run_test(np.ones((2, 3, 2)))
-    run_test(np.ones((3, 2)))
-    run_test(np.zeros((5, 6, 7)))
+    run_test(np_array_ops.array([1]))
+    run_test(np_array_ops.array([1, 2, 3, 4, 5]))
+    run_test(np_array_ops.ones((2, 3, 2)))
+    run_test(np_array_ops.ones((3, 2)))
+    run_test(np_array_ops.zeros((5, 6, 7)))
     run_test(1)
-    run_test(onp.ones((3, 2, 1)))
+    run_test(np_array_ops.ones((3, 2, 1)))
     run_test(tf.constant(5))
     run_test(tf.constant([1, 1, 1]))
-    self.assertRaises(ValueError, run_test, np.ones((2, 2)), 1)
+    self.assertRaises(NotImplementedError, size, np.ones((2, 2)), 1)
 
   def testRavel(self):
 

--- a/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
@@ -804,6 +804,23 @@ class ArrayMethodsTest(test.TestCase):
   def testAmax(self):
     self._testReduce(np_array_ops.amax, np.amax, 'amax')
 
+  def testSize(self):
+
+    def run_test(arr):
+      onp_arr = arr.numpy() if isinstance(arr, tf.Tensor) else arr
+      print(onp_arr)
+      self.assertEqual(np_size(arr), onp.size(onp_arr))
+
+    run_test(np.array([1]))
+    run_test(np.array([1, 2, 3, 4, 5]))
+    run_test(np.ones((2, 3, 2)))
+    run_test(np.ones((3, 2)))
+    run_test(np.zeros((5, 6, 7)))
+    run_test(1)
+    run_test(onp.ones((3, 2, 1)))
+    run_test(tf.constant(5))
+    run_test(tf.constant([1, 1, 1]))
+
   def testRavel(self):
 
     def run_test(arr, *args, **kwargs):

--- a/third_party/py/numpy/tf_numpy_api/tensorflow.experimental.numpy.pbtxt
+++ b/third_party/py/numpy/tf_numpy_api/tensorflow.experimental.numpy.pbtxt
@@ -785,6 +785,10 @@ tf_module {
     argspec: "args=[\'x\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "size"
+    argspec: "args=[\'x\', \'axis\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
     name: "sort"
     argspec: "args=[\'a\', \'axis\', \'kind\', \'order\'], varargs=None, keywords=None, defaults=[\'-1\', \'quicksort\', \'None\'], "
   }


### PR DESCRIPTION
The equivalent vanilla NumPy operation: https://numpy.org/doc/stable/reference/generated/numpy.ndarray.size.html