### PR TITLE
[tflite] enable passing int32 elementray arith to NNAPI

### DIFF
--- a/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
+++ b/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
@@ -2040,16 +2040,9 @@ bool NNAPIDelegateKernel::Validate(
       ExpectOpVersion(version, 1, &val_ctx);
       ExpectMinAndroidSdkVersion(android_sdk_version, kMinSdkVersionForNNAPI11,
                                  &val_ctx);
-      const TfLiteType input_type =
-          context->tensors[node->inputs->data[0]].type;
-
-      if (android_sdk_version >= kMinSdkVersionForNNAPI13) {
-        ExpectIsFloatOrInt32Operator(context, node, &val_ctx);
-      } else {
-        Expect(IsFloat(input_type),
-               NNAPIValidationFailureType::kUnsupportedInputType,
-               "NNAPI only support float div.", &val_ctx);
-      }
+      Expect(context->tensors[node->inputs->data[0]].type == kTfLiteFloat32,
+             NNAPIValidationFailureType::kUnsupportedInputType,
+             "NNAPI only support float div.", &val_ctx);
     } break;
     case kTfLiteBuiltinPad:
     case kTfLiteBuiltinPadv2: {


### PR DESCRIPTION
NNAPI 1.3 (Android API level 30) [1] supports int32 add, sub, mul, and div. This patch enables passing +-*/ with int32 tensors to NNAPI. With that, we can do something like
```
./mul_test   --gtest_filter=IntegerMulOpTest.NoActivation --use_nnapi=1
```
on Android R devices, such as Pixel 4 running Android R beta.

[1] https://developer.android.com/ndk/reference/group/neural-networks