### PR TITLE
Fix compiling against system protobuf

### DIFF
--- a/third_party/systemlibs/protobuf.BUILD
+++ b/third_party/systemlibs/protobuf.BUILD
@@ -15,8 +15,13 @@ filegroup(
 HEADERS = [
     "google/protobuf/any.pb.h",
     "google/protobuf/any.proto",
+    "google/protobuf/api.pb.h",
+    "google/protobuf/api.proto",
     "google/protobuf/arena.h",
     "google/protobuf/compiler/importer.h",
+    "google/protobuf/compiler/plugin.h",
+    "google/protobuf/compiler/plugin.pb.h",
+    "google/protobuf/compiler/plugin.proto",
     "google/protobuf/descriptor.h",
     "google/protobuf/descriptor.pb.h",
     "google/protobuf/descriptor.proto",
@@ -32,9 +37,15 @@ HEADERS = [
     "google/protobuf/io/zero_copy_stream_impl_lite.h",
     "google/protobuf/map.h",
     "google/protobuf/repeated_field.h",
+    "google/protobuf/source_context.pb.h",
+    "google/protobuf/source_context.proto",
+    "google/protobuf/struct.pb.h",
+    "google/protobuf/struct.proto",
     "google/protobuf/text_format.h",
     "google/protobuf/timestamp.pb.h",
     "google/protobuf/timestamp.proto",
+    "google/protobuf/type.pb.h",
+    "google/protobuf/type.proto",
     "google/protobuf/util/json_util.h",
     "google/protobuf/util/type_resolver_util.h",
     "google/protobuf/wrappers.pb.h",
@@ -100,5 +111,77 @@ py_library(
     name = "protobuf_python",
     data = [":link_headers"],
     srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "any_proto",
+    srcs = ["google/protobuf/any.proto"],
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "api_proto",
+    srcs = ["google/protobuf/api.proto"],
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "compiler_plugin_proto",
+    srcs = ["google/protobuf/compiler/plugin.proto"],
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "descriptor_proto",
+    srcs = ["google/protobuf/descriptor.proto"],
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "duration_proto",
+    srcs = ["google/protobuf/duration.proto"],
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "empty_proto",
+    srcs = ["google/protobuf/empty.proto"],
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "field_mask_proto",
+    srcs = ["google/protobuf/field_mask.proto"],
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "source_context_proto",
+    srcs = ["google/protobuf/source_context.proto"],
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "struct_proto",
+    srcs = ["google/protobuf/struct.proto"],
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "timestamp_proto",
+    srcs = ["google/protobuf/timestamp.proto"],
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "type_proto",
+    srcs = ["google/protobuf/type.proto"],
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "wrappers_proto",
+    srcs = ["google/protobuf/wrappers.proto"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
When trying to compile with the bazel configuration `build --action_env TF_SYSTEM_LIBS="com_google_protobuf"`, the following errors occur.

```
ERROR: /home/sclarkson/tensorflow-master/tensorflow/core/data/service/BUILD:31:17: no such target '@com_google_protobuf//:any_proto': target 'any_proto' not declared in package '' defined by /home/sclarkson/.cache/bazel/_bazel_sclarkson/fffe72c6b1157d70fb0a456ab7b675c2/external/com_google_protobuf/BUILD.bazel and referenced by '//tensorflow/core/data/service:dispatcher_proto'
```

This PR adds the missing protobuf library definitions to successfully compile against the system protobuf.