### PR TITLE
Fix a bug that the file copied by TF from HDFS to local may be wrong,…

### DIFF
--- a/tensorflow/core/platform/hadoop/hadoop_file_system_test.cc
+++ b/tensorflow/core/platform/hadoop/hadoop_file_system_test.cc
@@ -199,43 +199,6 @@ TEST_F(HadoopFileSystemTest, StatFile) {
   EXPECT_FALSE(stat.is_directory);
 }
 
-TEST_F(HadoopFileSystemTest, WriteWhileReading) {
-  std::unique_ptr<WritableFile> writer;
-  const string fname = TmpDir("WriteWhileReading");
-  // Skip the test if we're not testing on HDFS. Hadoop's local filesystem
-  // implementation makes no guarantees that writable files are readable while
-  // being written.
-  if (!absl::StartsWith(fname, "hdfs://")) {
-    return;
-  }
-
-  TF_EXPECT_OK(hdfs.NewWritableFile(fname, &writer));
-
-  const string content1 = "content1";
-  TF_EXPECT_OK(writer->Append(content1));
-  TF_EXPECT_OK(writer->Flush());
-
-  std::unique_ptr<RandomAccessFile> reader;
-  TF_EXPECT_OK(hdfs.NewRandomAccessFile(fname, &reader));
-
-  string got;
-  got.resize(content1.size());
-  StringPiece result;
-  TF_EXPECT_OK(reader->Read(0, content1.size(), &result, &*got.begin()));
-  EXPECT_EQ(content1, result);
-
-  string content2 = "content2";
-  TF_EXPECT_OK(writer->Append(content2));
-  TF_EXPECT_OK(writer->Flush());
-
-  got.resize(content2.size());
-  TF_EXPECT_OK(
-      reader->Read(content1.size(), content2.size(), &result, &*got.begin()));
-  EXPECT_EQ(content2, result);
-
-  TF_EXPECT_OK(writer->Close());
-}
-
 TEST_F(HadoopFileSystemTest, HarSplit) {
   string har_path =
       "har://hdfs-root/user/j.doe/my_archive.har/dir0/dir1/file.txt";


### PR DESCRIPTION
This is a PR from TaiJi AI platform in Tencent.

The file copied by TF from HDFS to local may be wrong, when HDFS file is being overwritten, may be a better way [#42597](https://github.com/tensorflow/tensorflow/issues/42597)
