### PR TITLE
Fix DynamicPartitionOpGPU when running on multiple GPUs

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -2514,7 +2514,6 @@ tf_kernel_library(
         ":gather_functor",
         ":gpu_prim_hdrs",
         "//tensorflow/core:framework_internal",
-        "//tensorflow/core:gpu_runtime",
     ],
 )
 

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -2514,6 +2514,7 @@ tf_kernel_library(
         ":gather_functor",
         ":gpu_prim_hdrs",
         "//tensorflow/core:framework_internal",
+        "//tensorflow/core:gpu_runtime",
     ],
 )
 

--- a/tensorflow/core/kernels/dynamic_partition_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/dynamic_partition_op_gpu.cu.cc
@@ -36,6 +36,7 @@ limitations under the License.
 #define EIGEN_USE_GPU
 
 #include "tensorflow/core/common_runtime/gpu/gpu_event_mgr.h"
+#include "tensorflow/core/common_runtime/gpu_device_context.h"
 #include "tensorflow/core/framework/bounds_check.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"
@@ -47,6 +48,9 @@ limitations under the License.
 #include "tensorflow/core/kernels/gpu_prim.h"
 #include "tensorflow/core/util/gpu_kernel_helper.h"
 #include "tensorflow/core/util/transform_output_iterator.h"
+#if GOOGLE_CUDA
+#include "tensorflow/stream_executor/cuda/cuda_activation.h"
+#endif
 
 namespace tensorflow {
 
@@ -302,6 +306,13 @@ class DynamicPartitionOpGPU : public AsyncOpKernel {
     TensorReference partition_ref(partition_count);
     auto wrapped_callback = [this, c, &data, &partitions, indices_out,
                              partition_ref, cpu_tensor, done]() {
+      GPUDeviceContext* gpu_device_context = static_cast<GPUDeviceContext*>(
+          c->op_device_context());
+      auto* stream = gpu_device_context->stream();
+      stream_executor::gpu::ScopedActivateExecutorContext scoped_activation {
+          stream->parent()
+      };
+
       OpOutputList outputs;
       this->AllocateOutputs(c, &data, &partitions, &cpu_tensor, &outputs, done);
       if (!c->status().ok()) {

--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -2048,10 +2048,10 @@ cuda_py_test(
     name = "dynamic_partition_op_test",
     size = "medium",
     srcs = ["dynamic_partition_op_test.py"],
-    tfrt_enabled = True,
     tags = [
         "multi_and_single_gpu",
     ],
+    tfrt_enabled = True,
     deps = [
         "//tensorflow/python:array_ops",
         "//tensorflow/python:client_testlib",

--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -2049,6 +2049,9 @@ cuda_py_test(
     size = "medium",
     srcs = ["dynamic_partition_op_test.py"],
     tfrt_enabled = True,
+    tags = [
+        "multi_and_single_gpu",
+    ],
     deps = [
         "//tensorflow/python:array_ops",
         "//tensorflow/python:client_testlib",

--- a/tensorflow/python/kernel_tests/dynamic_partition_op_test.py
+++ b/tensorflow/python/kernel_tests/dynamic_partition_op_test.py
@@ -358,7 +358,8 @@ class DynamicPartitionTest(test.TestCase):
         partitions = constant_op.constant(np.arange(1000, dtype=np.int32) % 10)
         result = data_flow_ops.dynamic_partition(data, partitions, 10)
         results.append(self.evaluate(result))
-    self.assertAllEqual(results, np.zeros((len(device_list), 10, 100)))
+    if device_list:
+      self.assertAllEqual(results, np.zeros((len(device_list), 10, 100)))
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/kernel_tests/dynamic_partition_op_test.py
+++ b/tensorflow/python/kernel_tests/dynamic_partition_op_test.py
@@ -23,8 +23,10 @@ import unittest
 import numpy as np
 from six.moves import xrange  # pylint: disable=redefined-builtin
 
+from tensorflow.python.framework import config
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import ops
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import data_flow_ops
@@ -345,6 +347,18 @@ class DynamicPartitionTest(test.TestCase):
     with self.cached_session() as sess:
       res = self.evaluate(partitioned)
     self.assertEqual(res[-1].shape[0], 192)
+
+  #  see https://github.com/tensorflow/tensorflow/issues/42500
+  def testMultiGPU(self):
+    device_list = config.list_logical_devices("GPU")
+    results = []
+    for device in device_list:
+      with ops.device(device.name):
+        data = constant_op.constant(np.zeros((1000, )))
+        partitions = constant_op.constant(np.arange(1000, dtype=np.int32) % 10)
+        result = data_flow_ops.dynamic_partition(data, partitions, 10)
+        results.append(self.evaluate(result))
+    self.assertAllEqual(results, np.zeros((len(device_list), 10, 100)))
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/kernel_tests/dynamic_partition_op_test.py
+++ b/tensorflow/python/kernel_tests/dynamic_partition_op_test.py
@@ -354,7 +354,7 @@ class DynamicPartitionTest(test.TestCase):
     results = []
     for device in device_list:
       with ops.device(device.name):
-        data = constant_op.constant(np.zeros((1000, )))
+        data = constant_op.constant(np.zeros((1000,)))
         partitions = constant_op.constant(np.arange(1000, dtype=np.int32) % 10)
         result = data_flow_ops.dynamic_partition(data, partitions, 10)
         results.append(self.evaluate(result))


### PR DESCRIPTION
Previously, a callback in DynamicPartitionOpGPU was running outside the correct GPU context and crashed when using a non-default GPU device. This adds a reactivation of the correct context when the callback runs.

Fixes #42500