### PR TITLE
Fix messy rendering of docs for tf.image.extract_patches

### DIFF
--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -5519,9 +5519,9 @@ def extract_image_patches_v2(images, sizes, strides, rates, padding, name=None):
   ```
 
   Args:
-    images: A 4-D Tensor with shape `[batch, in_rows, in_cols, depth]
-    sizes: The size of the extracted patches. Must be [1, size_rows, size_cols,
-      1].
+    images: A 4-D Tensor with shape `[batch, in_rows, in_cols, depth]`.
+    sizes: The size of the extracted patches. Must be
+      `[1, size_rows, size_cols, 1]`.
     strides: A 1-D Tensor of length 4. How far the centers of two consecutive
       patches are in the images. Must be: `[1, stride_rows, stride_cols, 1]`.
     rates: A 1-D Tensor of length 4. Must be: `[1, rate_rows, rate_cols, 1]`.


### PR DESCRIPTION
While working on using tf.image.extract_patches, noticed
that the docs rendering of tf.image.extract_patches was messed.
The issue was the missing backtick ("`") at the first line of args section.

See  https://www.tensorflow.org/api_docs/python/tf/image/extract_patches

<img width="888" alt="Screen Shot 2020-08-24 at 11 42 10 AM" src="https://user-images.githubusercontent.com/6932348/91083330-f9958100-e5fe-11ea-95cd-617d7c1fabeb.png">


This PR fixes the docs rendering issue.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>