### PR TITLE
[ROCm] Removing TPU tests from the ROCm CSB + CI scripts.

### DIFF
--- a/tensorflow/tools/ci_build/linux/rocm/run_cc_core.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_cc_core.sh
@@ -53,6 +53,8 @@ bazel test \
       //tensorflow/... \
       -//tensorflow/compiler/... \
       -//tensorflow/lite/... \
+      -//tensorflow/python/integration_testing/... \
+      -//tensorflow/core/tpu/... \
 && bazel test \
       --config=rocm \
       -k \

--- a/tensorflow/tools/ci_build/linux/rocm/run_csb_tests.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_csb_tests.sh
@@ -52,6 +52,8 @@ bazel test \
       -//tensorflow/compiler/... \
       -//tensorflow/lite/... \
       -//tensorflow/python/compiler/tensorrt/... \
+      -//tensorflow/python/integration_testing/... \
+      -//tensorflow/core/tpu/... \
 && bazel test \
       --config=rocm \
       -k \

--- a/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
@@ -52,4 +52,6 @@ bazel test \
       -- \
       //tensorflow/... \
       -//tensorflow/compiler/... \
+      -//tensorflow/python/integration_testing/... \
+      -//tensorflow/core/tpu/... \
       -//tensorflow/lite/...


### PR DESCRIPTION
The ROCm CSB + CI scripts were not skipping the tests within `//tensorflow/core/tpu`.
Some of the targets within `//tensorflow/core/tpu` have had build errors creep into them over the last week, resulting in the ROCm CSB and CI scripts failing due to those build errors.

This commit simply updates the ROCm CSB + CI scripts to skip the tests within `//tensorflow/core/tpu`.

-------------------------------------------

/cc @chsigg @cheshire @nvining-work 

