### PR TITLE
Extend documentation for the minimal tflite example. 

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,6 +5,7 @@
 # Android options:
 #    android:
 #    android_arm:
+#    android_arm64:
 #    android_x86:
 #    android_x86_64:
 #

--- a/tensorflow/lite/examples/minimal/minimal.cc
+++ b/tensorflow/lite/examples/minimal/minimal.cc
@@ -28,8 +28,6 @@ limitations under the License.
 //
 // Usage: minimal <tflite model>
 
-using namespace tflite;
-
 #define TFLITE_MINIMAL_CHECK(x)                              \
   if (!(x)) {                                                \
     fprintf(stderr, "Error at %s:%d\n", __FILE__, __LINE__); \
@@ -53,8 +51,8 @@ int main(int argc, char* argv[]) {
   // which allocates memory for the Intrepter and does various set up
   // tasks so that the Interpreter can read the provided model.
   tflite::ops::builtin::BuiltinOpResolver resolver;
-  InterpreterBuilder builder(*model, resolver);
-  std::unique_ptr<Interpreter> interpreter;
+  tflite::InterpreterBuilder builder(*model, resolver);
+  std::unique_ptr<tflite::Interpreter> interpreter;
   builder(&interpreter);
   TFLITE_MINIMAL_CHECK(interpreter != nullptr);
 
@@ -64,7 +62,9 @@ int main(int argc, char* argv[]) {
   tflite::PrintInterpreterState(interpreter.get());
 
   // Fill input buffers
-  // TODO(user): Insert code to fill input tensors
+  // TODO(user): Insert code to fill input tensors.
+  // Note: The buffer of the input tensor with index `i` of type T can
+  // be accessed with `T* input = interpreter->typed_input_tensor<T>(i);`
 
   // Run inference
   TFLITE_MINIMAL_CHECK(interpreter->Invoke() == kTfLiteOk);
@@ -73,6 +73,8 @@ int main(int argc, char* argv[]) {
 
   // Read output buffers
   // TODO(user): Insert getting data out code.
+  // Note: The buffer of the output tensor with index `i` of type T can
+  // be accessed with `T* output = interpreter->typed_output_tensor<T>(i);`
 
   return 0;
 }


### PR DESCRIPTION
* Add `tflite::` prefix for all tflite types for consistency.
* Extend documentation of how to read the input/output buffers of the interpreter.

Bonus:
* Adds missing entry for `android_arm64` in `.baselrc`. 