### PR TITLE
make debug build on Windows MSVC compile

### DIFF
--- a/tensorflow/core/distributed_runtime/remote_device.cc
+++ b/tensorflow/core/distributed_runtime/remote_device.cc
@@ -45,6 +45,7 @@ class RemoteDevice : public Device {
   ResourceMgr* resource_manager() override {
     LOG(FATAL) << "Accessing the resource manager of a remote device is not "
                << "supported.";
+    return nullptr;
   }
 
   bool IsLocal() const override { return false; }

--- a/tensorflow/core/distributed_runtime/remote_device.cc
+++ b/tensorflow/core/distributed_runtime/remote_device.cc
@@ -45,7 +45,7 @@ class RemoteDevice : public Device {
   ResourceMgr* resource_manager() override {
     LOG(FATAL) << "Accessing the resource manager of a remote device is not "
                << "supported.";
-    return nullptr;
+    std::abort();
   }
 
   bool IsLocal() const override { return false; }

--- a/tensorflow/core/framework/device_base.cc
+++ b/tensorflow/core/framework/device_base.cc
@@ -70,7 +70,7 @@ const DeviceAttributes& DeviceBase::attributes() const {
 
 const string& DeviceBase::name() const {
   LOG(FATAL) << "Device does not implement name()";
-  return "";
+  std::abort();
 }
 
 void DeviceBase::set_eigen_cpu_device(Eigen::ThreadPoolDevice* d) {

--- a/tensorflow/core/framework/device_base.cc
+++ b/tensorflow/core/framework/device_base.cc
@@ -65,10 +65,12 @@ Status DeviceContext::CopyCPUTensorToDeviceSync(const Tensor* cpu_tensor,
 
 const DeviceAttributes& DeviceBase::attributes() const {
   LOG(FATAL) << "Device does not implement attributes()";
+  std::abort();
 }
 
 const string& DeviceBase::name() const {
   LOG(FATAL) << "Device does not implement name()";
+  return "";
 }
 
 void DeviceBase::set_eigen_cpu_device(Eigen::ThreadPoolDevice* d) {

--- a/tensorflow/core/kernels/depthtospace_op.cc
+++ b/tensorflow/core/kernels/depthtospace_op.cc
@@ -178,7 +178,7 @@ template <typename T>
 struct DepthToSpaceOpFunctor<CPUDevice, T, FORMAT_NCHW> {
   void operator()(const CPUDevice& d, typename TTypes<T, 4>::ConstTensor input,
                   int block_size, typename TTypes<T, 4>::Tensor output) {
-    LOG(FATAL) << "dummy implementation to make debug build compile";
+    LOG(FATAL) << "Trivial implementation to make debug build compile.";
   }
 };
 #endif

--- a/tensorflow/core/kernels/depthtospace_op.cc
+++ b/tensorflow/core/kernels/depthtospace_op.cc
@@ -172,6 +172,16 @@ struct DepthToSpaceOpFunctor<CPUDevice, T, FORMAT_NHWC> {
     }
   }
 };
+
+#ifdef WIN32
+template <typename T>
+struct DepthToSpaceOpFunctor<CPUDevice, T, FORMAT_NCHW> {
+  void operator()(const CPUDevice& d, typename TTypes<T, 4>::ConstTensor input,
+                  int block_size, typename TTypes<T, 4>::Tensor output) {
+    LOG(FATAL) << "dummy implementation to make debug build compile";
+  }
+};
+#endif
 }  // namespace functor
 
 #define REGISTER(type)                                                \

--- a/tensorflow/core/kernels/spacetodepth_op.cc
+++ b/tensorflow/core/kernels/spacetodepth_op.cc
@@ -188,6 +188,16 @@ struct SpaceToDepthOpFunctor<CPUDevice, T, FORMAT_NHWC> {
     }
   }
 };
+
+#ifdef WIN32
+template <typename T>
+struct SpaceToDepthOpFunctor<CPUDevice, T, FORMAT_NCHW> {
+  void operator()(const CPUDevice& d, typename TTypes<T, 4>::ConstTensor input,
+                  int block_size, typename TTypes<T, 4>::Tensor output) {
+    LOG(FATAL) << "dummy implementation to make debug build compile";
+  }
+};
+#endif
 }  // namespace functor
 
 #define REGISTER(type)                                                \

--- a/tensorflow/core/kernels/spacetodepth_op.cc
+++ b/tensorflow/core/kernels/spacetodepth_op.cc
@@ -194,7 +194,7 @@ template <typename T>
 struct SpaceToDepthOpFunctor<CPUDevice, T, FORMAT_NCHW> {
   void operator()(const CPUDevice& d, typename TTypes<T, 4>::ConstTensor input,
                   int block_size, typename TTypes<T, 4>::Tensor output) {
-    LOG(FATAL) << "dummy implementation to make debug build compile";
+    LOG(FATAL) << "Trivial implementation to make debug build compile.";
   }
 };
 #endif

--- a/tensorflow/core/platform/path.cc
+++ b/tensorflow/core/platform/path.cc
@@ -328,7 +328,7 @@ string GetTempFilename(const string& extension) {
     }
   }
   LOG(FATAL) << "No temp directory found.";
-  return "";
+  std::abort();
 #endif
 }
 

--- a/tensorflow/core/platform/path.cc
+++ b/tensorflow/core/platform/path.cc
@@ -328,6 +328,7 @@ string GetTempFilename(const string& extension) {
     }
   }
   LOG(FATAL) << "No temp directory found.";
+  return "";
 #endif
 }
 


### PR DESCRIPTION
- fix missing-return-statement errors
- add partial dummy template specializations (which are not needed but without optimization the compiler doesn't find out about it)

The second part is a supplement to PR #42307.