### PR TITLE
TFLu: Support operator only input tensors.

### DIFF
--- a/tensorflow/lite/micro/micro_allocator.cc
+++ b/tensorflow/lite/micro/micro_allocator.cc
@@ -242,6 +242,18 @@ TfLiteStatus AllocationInfoBuilder::AddTensors(const SubGraph* subgraph,
     for (size_t n = 0; n < op->inputs()->size(); ++n) {
       const int tensor_index = op->inputs()->Get(n);
       AllocationInfo* current = &info_[tensor_index];
+
+      // In case operator input are not in subgraph inputs initialize them.
+      if (current->first_created == 0) {
+        for (size_t op_input = 0; op_input < op->inputs()->size(); ++op_input) {
+          const int op_tensor_index = op->inputs()->Get(op_input);
+          AllocationInfo* op_current = &info_[op_tensor_index];
+          if (op_current->needs_allocating && op_current->first_created == -1) {
+            op_current->first_created = i;
+          }
+        }
+      }
+
       if (((current->last_used == -1) || (current->last_used < i))) {
         current->last_used = i;
       }

--- a/tensorflow/lite/micro/micro_allocator.cc
+++ b/tensorflow/lite/micro/micro_allocator.cc
@@ -243,7 +243,10 @@ TfLiteStatus AllocationInfoBuilder::AddTensors(const SubGraph* subgraph,
       const int tensor_index = op->inputs()->Get(n);
       AllocationInfo* current = &info_[tensor_index];
 
-      // In case operator input are not in subgraph inputs initialize them.
+      // TODO(b/166484865): Figure out a more general solution.
+      // This workaround is needed to handle situations where subgraph input !=
+      // operator input.
+      // In case operator input(s) are not in subgraph inputs initialize them.
       if (current->first_created == 0) {
         for (size_t op_input = 0; op_input < op->inputs()->size(); ++op_input) {
           const int op_tensor_index = op->inputs()->Get(op_input);

--- a/tensorflow/lite/micro/micro_allocator_test.cc
+++ b/tensorflow/lite/micro/micro_allocator_test.cc
@@ -735,4 +735,64 @@ TF_LITE_MICRO_TEST(TestAllocateTfLiteTensorWithReset) {
   TF_LITE_MICRO_EXPECT(tensor2 == tensor1);
 }
 
+TF_LITE_MICRO_TEST(TestOperatorInputsNotInSubgraphInputs) {
+  constexpr int nbr_tensors = 5;
+  tflite::AllOpsResolver op_resolver = tflite::testing::GetOpResolver();
+  tflite::NodeAndRegistration* node_and_registration;
+  const int32_t metadata_buffer[tflite::testing::kOfflinePlannerHeaderSize +
+                                nbr_tensors] = {
+      1, 0, nbr_tensors,  // header: version, subgraph, nbr tensors
+      // memory offsets:
+      0,    // t0
+      0,    // t1
+      0,    // t2
+      48,   // t3
+      -1};  // t4
+
+  int t0 = 0;
+  int t1 = 1;
+  int t2 = 2;
+  int t3 = 3;
+  int t4 = 4;
+
+  int num_conns = 2;
+  tflite::testing::NodeConnection node_list[2] = {
+      {
+        {t0, t1, t2},  // t0: input (actual input part of subgraph inputs as well as
+                       // operator inputs)
+                       // t1: scratch1 (only in operator inputs)
+                       // t2: scratch2 (only in operator inputs)
+        {t3}           // output
+      },
+      {
+        {t3},  // input
+        {t4}   // output
+      },
+  };
+
+  const tflite::Model* model = tflite::testing::GetModelWithOfflinePlanning(
+      nbr_tensors, metadata_buffer, node_list, num_conns,
+      1/* only first tensor (t0) is in subgraph input list*/);
+
+  TfLiteEvalTensor* eval_tensors = nullptr;
+  constexpr size_t arena_size = 4096;
+  uint8_t arena[arena_size];
+  tflite::MicroAllocator* allocator =
+      tflite::MicroAllocator::Create(arena, arena_size, micro_test::reporter);
+
+  TF_LITE_MICRO_EXPECT_EQ(
+      kTfLiteOk,
+      allocator->StartModelAllocation(model, op_resolver,
+                                      &node_and_registration, &eval_tensors));
+  TF_LITE_MICRO_EXPECT_EQ(
+      kTfLiteOk, allocator->FinishModelAllocation(model, eval_tensors));
+
+  uint8_t* start = eval_tensors[0].data.uint8;
+  TF_LITE_MICRO_EXPECT_EQ(0, eval_tensors[0].data.uint8 - start);
+  TF_LITE_MICRO_EXPECT_EQ(0, eval_tensors[1].data.uint8 - start);
+  TF_LITE_MICRO_EXPECT_EQ(0, eval_tensors[2].data.uint8 - start);
+  TF_LITE_MICRO_EXPECT_EQ(48, eval_tensors[3].data.uint8 - start);
+  TF_LITE_MICRO_EXPECT_EQ(0, eval_tensors[4].data.uint8 - start);
+}
+
 TF_LITE_MICRO_TESTS_END

--- a/tensorflow/lite/micro/micro_allocator_test.cc
+++ b/tensorflow/lite/micro/micro_allocator_test.cc
@@ -758,8 +758,8 @@ TF_LITE_MICRO_TEST(TestOperatorInputsNotInSubgraphInputs) {
   int num_conns = 2;
   tflite::testing::NodeConnection node_list[2] = {
       {
-        {t0, t1, t2},  // t0: input (actual input part of subgraph inputs as well as
-                       // operator inputs)
+        {t0, t1, t2},  // t0: input (actual input part of subgraph inputs as
+                       // well as operator inputs)
                        // t1: scratch1 (only in operator inputs)
                        // t2: scratch2 (only in operator inputs)
         {t3}           // output

--- a/tensorflow/lite/micro/test_helpers.h
+++ b/tensorflow/lite/micro/test_helpers.h
@@ -91,7 +91,8 @@ const Model* GetSimpleModelWithBranch();
 const Model* GetModelWithOfflinePlanning(int num_tensors,
                                          const int32_t* metadata_buffer,
                                          NodeConnection* node_conn,
-                                         int num_conns);
+                                         int num_conns,
+                                         int num_subgraph_inputs = 0/*0 means all*/);
 
 // Returns a flatbuffer model with `simple_stateful_op`
 const Model* GetSimpleStatefulModel();

--- a/tensorflow/lite/micro/test_helpers.h
+++ b/tensorflow/lite/micro/test_helpers.h
@@ -88,11 +88,22 @@ const Model* GetComplexMockModel();
 const Model* GetSimpleModelWithBranch();
 
 // Returns a simple flatbuffer model with offline planned tensors
+// @param[in]       num_tensors           Number of tensors in the model.
+// @param[in]       metadata_buffer       Metadata for offline planner.
+// @param[in]       node_con              List of connections, i.e. operators
+//                                        in the model.
+// @param[in]       num_conns             Number of connections.
+// @param[in]       num_subgraph_inputs   How many of the input tensors are in
+//                                        the subgraph inputs. The default value
+//                                        of 0 means all of the input tensors
+//                                        are in the subgraph input list. There
+//                                        must be at least 1 input tensor in the
+//                                        subgraph input list.
 const Model* GetModelWithOfflinePlanning(int num_tensors,
                                          const int32_t* metadata_buffer,
                                          NodeConnection* node_conn,
                                          int num_conns,
-                                         int num_subgraph_inputs = 0/*0 means all*/);
+                                         int num_subgraph_inputs = 0);
 
 // Returns a flatbuffer model with `simple_stateful_op`
 const Model* GetSimpleStatefulModel();


### PR DESCRIPTION
Ethos-u relies on differentiating between having operator input tensors
as subgraph inputs or not.