### PR TITLE
mis-indent in conv_ops_test python scripts

### DIFF
--- a/tensorflow/python/kernel_tests/conv_ops_test.py
+++ b/tensorflow/python/kernel_tests/conv_ops_test.py
@@ -310,14 +310,14 @@ class Conv2DTest(test.TestCase):
           data_format, use_gpu)
       expected_results.append(expected)
       computed_results.append(computed)
-      tolerance = 1e-2 if use_gpu else 1e-5
-      expected_values = self.evaluate(expected_results)
-      computed_values = self.evaluate(computed_results)
-      for e_value, c_value in zip(expected_values, computed_values):
-        tf_logging.debug("expected = %s", e_value)
-        tf_logging.debug("actual = %s", c_value)
-        self.assertAllClose(
-            e_value.flatten(), c_value.flatten(), atol=tolerance, rtol=rtol)
+    tolerance = 1e-2 if use_gpu else 1e-5
+    expected_values = self.evaluate(expected_results)
+    computed_values = self.evaluate(computed_results)
+    for e_value, c_value in zip(expected_values, computed_values):
+      tf_logging.debug("expected = %s", e_value)
+      tf_logging.debug("actual = %s", c_value)
+      self.assertAllClose(
+          e_value.flatten(), c_value.flatten(), atol=tolerance, rtol=rtol)
 
   def _VerifyValues(self,
                     tensor_in_sizes,


### PR DESCRIPTION
The changed code block was inside the for loop iterating over values from GetTestConfigs().
It make more sense to me to move these line out from the loop, so instead evaluating the unfinished expected_results & computed_values lists for multiple times, only a one time evaluation will be performed on them.

I am not quite sure whats the original purpose how it was writing this way, from my view, I would like to move them out, please correct me if I am wrong. 

And a question, could there be a problem to evaluate these tensors over and over again?