### PR TITLE
[ROCm] Fix for ROCm CSB Breakage - 200827

### DIFF
--- a/tensorflow/core/kernels/avgpooling_op.cc
+++ b/tensorflow/core/kernels/avgpooling_op.cc
@@ -600,7 +600,8 @@ class AvgPoolingGradOpCustomGPUKernel : public OpKernel {
                                 context->eigen_gpu_device());   // d
     } else {
       DnnPoolingGradOp<T>::Compute(context, se::dnn::PoolingMode::kAverage,
-                                   ksize_, stride_, padding_, data_format_,
+                                   ksize_, stride_, padding_,
+                                   /*explicit_paddings=*/{}, data_format_,
                                    nullptr, nullptr, out_backprop, output_shape,
                                    /*propagate_nans=*/false);
     }


### PR DESCRIPTION
The following commit breaks the ROCm TF build

https://github.com/tensorflow/tensorflow/commit/188db19ebf9a645b90ad6ee6e6e127be28e68224

The commit adds an extra argument to the `DnnPoolingGradOp<T>::Compute` routine, and updates all (but one) of the call-sites accordingly. The one call-site that was not updated is the one used in the ROCm build, which leads to the folowing compile errror

```
tensorflow/core/kernels/avgpooling_op.cc: In instantiation of 'void tensorflow::AvgPoolingGradOpCustomGPUKernel<T>::Compute(tensorflow::OpKernelContext*) [with T = Eigen::half]':
tensorflow/core/kernels/avgpooling_op.cc:635:1:   required from here
tensorflow/core/kernels/avgpooling_op.cc:602:35: error: no matching function for call to 'tensorflow::DnnPoolingGradOp<Eigen::half>::Compute(tensorflow::OpKernelContext*&, stream_executor::dnn::PoolingMode, std::vector<int>&, std::vector<int>&, tensorflow::Padding&, tensorflow::TensorFormat&, std::nullptr_t, std::nullptr_t, const tensorflow::Tensor&, tensorflow::TensorShape&, bool)'
       DnnPoolingGradOp<T>::Compute(context, se::dnn::PoolingMode::kAverage,
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                    ksize_, stride_, padding_, data_format_,
                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                    nullptr, nullptr, out_backprop, output_shape,
                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                    /*propagate_nans=*/false);
                                    ~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from tensorflow/core/kernels/avgpooling_op.cc:47:0:
./tensorflow/core/kernels/pooling_ops_common_gpu.h:58:15: note: candidate: static void tensorflow::DnnPoolingGradOp<T>::Compute(tensorflow::OpKernelContext*, stream_executor::dnn::PoolingMode, const std::vector<int>&, const std::vector<int>&, tensorflow::Padding, std::vector<long long int>, tensorflow::TensorFormat, const tensorflow::Tensor*, const tensorflow::Tensor*, const tensorflow::Tensor&, const tensorflow::TensorShape&, bool) [with T = Eigen::half]
   static void Compute(OpKernelContext* context,
               ^~~~~~~
./tensorflow/core/kernels/pooling_ops_common_gpu.h:58:15: note:   candidate expects 12 arguments, 11 provided
```

The fix is trivial, which is to add the missing argument.


-----------------------------------------


/cc @cheshire @chsigg @nvining-work 







