### PR TITLE
TFLM: Added VexRISCV optimized DepthwiseConv2d kernel (int8/uint8)

### DIFF
--- a/tensorflow/lite/micro/kernels/vexriscv/depthwise_conv.cc
+++ b/tensorflow/lite/micro/kernels/vexriscv/depthwise_conv.cc
@@ -1,0 +1,531 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/common.h"
+#include "tensorflow/lite/kernels/internal/quantization_util.h"
+#include "tensorflow/lite/kernels/internal/reference/depthwiseconv_float.h"
+#include "tensorflow/lite/kernels/internal/reference/depthwiseconv_uint8.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/kernels/padding.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+
+namespace tflite {
+namespace ops {
+namespace micro {
+namespace depthwise_conv {
+namespace vexriscv {
+
+constexpr int kChannelStep = 32;
+
+inline void DepthwiseConvPerChannel(
+    const DepthwiseParams& params, const int32_t* output_multiplier,
+    const int32_t* output_shift, const RuntimeShape& input_shape,
+    const int8_t* input_data, const RuntimeShape& filter_shape,
+    const int8_t* filter_data, const RuntimeShape& bias_shape,
+    const int32_t* bias_data, const RuntimeShape& output_shape,
+    int8_t* output_data) {
+  // Get parameters.
+  // TODO(b/141565753): Re-introduce ScopedProfilingLabel on Micro.
+  const int stride_width = params.stride_width;
+  const int stride_height = params.stride_height;
+  const int dilation_width_factor = params.dilation_width_factor;
+  const int dilation_height_factor = params.dilation_height_factor;
+  const int pad_width = params.padding_values.width;
+  const int pad_height = params.padding_values.height;
+  const int depth_multiplier = params.depth_multiplier;
+  const int32_t input_offset = params.input_offset;
+  const int32_t output_offset = params.output_offset;
+  const int32_t output_activation_min = params.quantized_activation_min;
+  const int32_t output_activation_max = params.quantized_activation_max;
+
+  // Check dimensions of the tensors.
+  TFLITE_DCHECK_EQ(input_shape.DimensionsCount(), 4);
+  TFLITE_DCHECK_EQ(filter_shape.DimensionsCount(), 4);
+  TFLITE_DCHECK_EQ(output_shape.DimensionsCount(), 4);
+
+  TFLITE_DCHECK_LE(output_activation_min, output_activation_max);
+  const int batches = MatchingDim(input_shape, 0, output_shape, 0);
+  const int output_depth = MatchingDim(filter_shape, 3, output_shape, 3);
+  const int input_height = input_shape.Dims(1);
+  const int input_width = input_shape.Dims(2);
+  const int input_depth = input_shape.Dims(3);
+  const int filter_height = filter_shape.Dims(1);
+  const int filter_width = filter_shape.Dims(2);
+  const int output_height = output_shape.Dims(1);
+  const int output_width = output_shape.Dims(2);
+  TFLITE_DCHECK_EQ(output_depth, input_depth * depth_multiplier);
+  TFLITE_DCHECK_EQ(bias_shape.FlatSize(), output_depth);
+
+  for (int batch = 0; batch < batches; ++batch) {
+    for (int out_y = 0; out_y < output_height; ++out_y) {
+      for (int out_x = 0; out_x < output_width; ++out_x) {
+        for (int m = 0; m < depth_multiplier; ++m) {
+          const int in_x_origin = (out_x * stride_width) - pad_width;
+          const int in_y_origin = (out_y * stride_height) - pad_height;
+          // Divide channels to chunks of size kChannelStep
+          for (int begin_ch = 0; begin_ch < input_depth;
+               begin_ch += kChannelStep) {
+            // Allocate a partial result accumulator for each channel
+            // in current chunks
+            int32_t acc[kChannelStep] = {0};
+            // Calculate the last channel for current chunk
+            const int steps =
+                std::min(input_depth, begin_ch + kChannelStep) - begin_ch;
+
+            // Accumulate partial results to acc for a small chunk of channels
+            for (int filter_y = 0; filter_y < filter_height; ++filter_y) {
+              const int in_y = in_y_origin + dilation_height_factor * filter_y;
+              for (int filter_x = 0; filter_x < filter_width; ++filter_x) {
+                const int in_x = in_x_origin + dilation_width_factor * filter_x;
+                // Zero padding by omitting the areas outside the image.
+                const bool is_point_inside_image =
+                    (in_x >= 0) && (in_x < input_width) && (in_y >= 0) &&
+                    (in_y < input_height);
+
+                if (!is_point_inside_image) {
+                  continue;
+                }
+
+                for (int offset_ch = 0; offset_ch < steps; ++offset_ch) {
+                  const int in_channel = begin_ch + offset_ch;
+                  const int output_channel = m + in_channel * depth_multiplier;
+
+                  int32_t input_val = input_data[Offset(
+                      input_shape, batch, in_y, in_x, in_channel)];
+                  int32_t filter_val = filter_data[Offset(
+                      filter_shape, 0, filter_y, filter_x, output_channel)];
+                  // Accumulate with 32 bits accumulator.
+                  // In the nudging process during model quantization, we force
+                  // real value of 0.0 be represented by a quantized value. This
+                  // guarantees that the input_offset is a int8_t, even though
+                  // it is represented using int32_t. int32_t += int8_t *
+                  // (int8_t - int8_t) so the highest value we can get from each
+                  // accumulation is [-127, 127] * ([-128, 127] -
+                  // [-128, 127]), which is [-32512, 32512]. log2(32512)
+                  // = 14.98, which means we can accumulate at least 2^16
+                  // multiplications without overflow. The accumulator is
+                  // applied to a filter so the accumulation logic will hold as
+                  // long as the filter size (filter_y * filter_x * in_channel)
+                  // does not exceed 2^16, which is the case in all the models
+                  // we have seen so far.
+                  // TODO(jianlijianli): Add a check to make sure the
+                  // accumulator depth is smaller than 2^16.
+                  acc[offset_ch] += filter_val * (input_val + input_offset);
+                }
+              }
+            }
+
+            // Add bias / activations for current chunk of channels
+            for (int offset_ch = 0; offset_ch < steps; ++offset_ch) {
+              const int in_channel = begin_ch + offset_ch;
+              const int output_channel = m + in_channel * depth_multiplier;
+
+              int32_t value = acc[offset_ch];
+              if (bias_data) {
+                value += bias_data[output_channel];
+              }
+
+              value = MultiplyByQuantizedMultiplier(
+                  value, output_multiplier[output_channel],
+                  output_shift[output_channel]);
+              value += output_offset;
+              value = std::max(value, output_activation_min);
+              value = std::min(value, output_activation_max);
+
+              output_data[Offset(output_shape, batch, out_y, out_x,
+                                 output_channel)] = static_cast<int8_t>(value);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+inline void DepthwiseConv(
+    const DepthwiseParams& params, const RuntimeShape& input_shape,
+    const uint8_t* input_data, const RuntimeShape& filter_shape,
+    const uint8_t* filter_data, const RuntimeShape& bias_shape,
+    const int32_t* bias_data, const RuntimeShape& output_shape,
+    uint8_t* output_data) {
+  const int stride_width = params.stride_width;
+  const int stride_height = params.stride_height;
+  const int dilation_width_factor = params.dilation_width_factor;
+  const int dilation_height_factor = params.dilation_height_factor;
+  const int pad_width = params.padding_values.width;
+  const int pad_height = params.padding_values.height;
+  const int depth_multiplier = params.depth_multiplier;
+  const int32_t output_activation_min = params.quantized_activation_min;
+  const int32_t output_activation_max = params.quantized_activation_max;
+  const int32_t input_offset = params.input_offset;
+  const int32_t filter_offset = params.weights_offset;
+  const int32_t output_offset = params.output_offset;
+  const int32_t output_multiplier = params.output_multiplier;
+  const int output_shift = params.output_shift;
+  TFLITE_DCHECK_EQ(input_shape.DimensionsCount(), 4);
+  TFLITE_DCHECK_EQ(filter_shape.DimensionsCount(), 4);
+  TFLITE_DCHECK_EQ(output_shape.DimensionsCount(), 4);
+
+  TFLITE_DCHECK_LE(output_activation_min, output_activation_max);
+  const int batches = MatchingDim(input_shape, 0, output_shape, 0);
+  const int output_depth = MatchingDim(filter_shape, 3, output_shape, 3);
+  const int input_height = input_shape.Dims(1);
+  const int input_width = input_shape.Dims(2);
+  const int input_depth = input_shape.Dims(3);
+  const int filter_height = filter_shape.Dims(1);
+  const int filter_width = filter_shape.Dims(2);
+  const int output_height = output_shape.Dims(1);
+  const int output_width = output_shape.Dims(2);
+  TFLITE_DCHECK_EQ(output_depth, input_depth * depth_multiplier);
+  TFLITE_DCHECK_EQ(bias_shape.FlatSize(), output_depth);
+
+  for (int batch = 0; batch < batches; ++batch) {
+    for (int out_y = 0; out_y < output_height; ++out_y) {
+      for (int out_x = 0; out_x < output_width; ++out_x) {
+        for (int m = 0; m < depth_multiplier; m++) {
+          const int in_x_origin = (out_x * stride_width) - pad_width;
+          const int in_y_origin = (out_y * stride_height) - pad_height;
+          // Divide channels to chunks of size kChannelStep
+          for (int begin_ch = 0; begin_ch < input_depth;
+               begin_ch += kChannelStep) {
+            // Allocate a partial result accumulator for each channel
+            // in current chunks
+            int32_t acc[kChannelStep] = {0};
+            // Calculate the last channel for current chunk
+            const int steps =
+                std::min(input_depth, begin_ch + kChannelStep) - begin_ch;
+
+            // Accumulate partial results to acc for a small chunk of channels
+            for (int filter_y = 0; filter_y < filter_height; ++filter_y) {
+              const int in_y =
+                  in_y_origin + dilation_height_factor * filter_y;
+              for (int filter_x = 0; filter_x < filter_width; ++filter_x) {
+                const int in_x =
+                    in_x_origin + dilation_width_factor * filter_x;
+                // Zero padding by omitting the areas outside the image.
+                const bool is_point_inside_image =
+                    (in_x >= 0) && (in_x < input_width) && (in_y >= 0) &&
+                    (in_y < input_height);
+
+                if (!is_point_inside_image) {
+                  continue;
+                }
+
+                for (int offset_ch = 0; offset_ch < steps; ++offset_ch) {
+                  const int in_channel = begin_ch + offset_ch;
+                  const int output_channel =
+                      m + in_channel * depth_multiplier;
+
+                  int32_t input_val = input_data[Offset(
+                      input_shape, batch, in_y, in_x, in_channel)];
+                  int32_t filter_val = filter_data[Offset(
+                      filter_shape, 0, filter_y, filter_x, output_channel)];
+                  acc[offset_ch] += (filter_val + filter_offset) *
+                                    (input_val + input_offset);
+                }
+              }
+            }
+
+            // Add bias / activations for current chunk of channels
+            for (int offset_ch = 0; offset_ch < steps; ++offset_ch) {
+              const int in_channel = begin_ch + offset_ch;
+              const int output_channel = m + in_channel * depth_multiplier;
+
+              int32_t value = acc[offset_ch];
+              if (bias_data) {
+                value += bias_data[output_channel];
+              }
+
+              value = MultiplyByQuantizedMultiplier(
+                  value, output_multiplier, output_shift);
+              value += output_offset;
+              value = std::max(value, output_activation_min);
+              value = std::min(value, output_activation_max);
+
+              output_data[Offset(output_shape, batch, out_y, out_x,
+                                 output_channel)] = static_cast<uint8_t>(value);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+}  // namespace vexriscv
+
+namespace {
+
+constexpr int kInputTensor = 0;
+constexpr int kFilterTensor = 1;
+constexpr int kBiasTensor = 2;
+constexpr int kOutputTensor = 0;
+
+// Depthwise conv is quantized along dimension 3:
+// https://www.tensorflow.org/lite/performance/quantization_spec
+constexpr int kDepthwiseConvQuantizedDimension = 3;
+
+struct OpData {
+  TfLitePaddingValues padding;
+
+  // Cached tensor zero point values for quantized operations.
+  int32_t input_zero_point;
+  int32_t filter_zero_point; //***
+  int32_t output_zero_point;
+
+  // The scaling factor from input to output (aka the 'real multiplier') can
+  // be represented as a fixed point multiplier plus a left shift.
+  int32_t output_multiplier;
+  int output_shift;
+
+  // Per channel output multiplier and shift.
+  int32_t* per_channel_output_multiplier;
+  int32_t* per_channel_output_shift;
+  // The range of the fused activation layer. For example for kNone and
+  // uint8_t these would be 0 and 255.
+  int32_t output_activation_min;
+  int32_t output_activation_max;
+};
+
+TfLiteStatus CalculateOpData(TfLiteContext* context, TfLiteNode* node,
+                             TfLiteDepthwiseConvParams* params, int width,
+                             int height, int filter_width, int filter_height,
+                             const TfLiteType data_type, OpData* data) {
+  bool has_bias = node->inputs->size == 3;
+  // Check number of inputs/outputs
+  TF_LITE_ENSURE(context, has_bias || node->inputs->size == 2);
+  TF_LITE_ENSURE_EQ(context, node->outputs->size, 1);
+
+  int unused_output_height, unused_output_width;
+  data->padding = ComputePaddingHeightWidth(
+      params->stride_height, params->stride_width, 1, 1, height, width,
+      filter_height, filter_width, params->padding, &unused_output_height,
+      &unused_output_width);
+
+  // Note that quantized inference requires that all tensors have their
+  // parameters set. This is usually done during quantized training.
+  if (data_type != kTfLiteFloat32) {
+    const TfLiteTensor* input = GetInput(context, node, kInputTensor);
+    const TfLiteTensor* filter = GetInput(context, node, kFilterTensor);
+    const TfLiteTensor* bias =
+        GetOptionalInputTensor(context, node, kBiasTensor);
+    TfLiteTensor* output = GetOutput(context, node, kOutputTensor);
+    int num_channels = filter->dims->data[kDepthwiseConvQuantizedDimension];
+
+    return tflite::PopulateConvolutionQuantizationParams(
+        context, input, filter, bias, output, params->activation,
+        &data->output_multiplier, &data->output_shift,
+        &data->output_activation_min, &data->output_activation_max,
+        data->per_channel_output_multiplier,
+        reinterpret_cast<int*>(data->per_channel_output_shift), num_channels);
+  }
+  return kTfLiteOk;
+}
+
+}  // namespace
+
+void* Init(TfLiteContext* context, const char* buffer, size_t length) {
+  TFLITE_DCHECK(context->AllocatePersistentBuffer != nullptr);
+  return context->AllocatePersistentBuffer(context, sizeof(OpData));
+}
+
+TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+  TFLITE_DCHECK(node->user_data != nullptr);
+  TFLITE_DCHECK(node->builtin_data != nullptr);
+
+  auto* params =
+      reinterpret_cast<TfLiteDepthwiseConvParams*>(node->builtin_data);
+  OpData* data = static_cast<OpData*>(node->user_data);
+
+  TfLiteTensor* output = GetOutput(context, node, kOutputTensor);
+  const TfLiteTensor* input = GetInput(context, node, kInputTensor);
+  const TfLiteTensor* filter = GetInput(context, node, kFilterTensor);
+
+  const TfLiteType data_type = input->type;
+  int width = SizeOfDimension(input, 2);
+  int height = SizeOfDimension(input, 1);
+  int filter_width = SizeOfDimension(filter, 2);
+  int filter_height = SizeOfDimension(filter, 1);
+
+  // Per channel quantization is only needed for int8_t inference. For other
+  // quantized types, only a single scale and zero point is needed.
+  const int num_channels = filter->dims->data[kDepthwiseConvQuantizedDimension];
+  // Dynimically allocate per-channel quantization parameters.
+  data->per_channel_output_multiplier =
+      reinterpret_cast<int32_t*>(context->AllocatePersistentBuffer(
+          context, num_channels * sizeof(int32_t)));
+  data->per_channel_output_shift =
+      reinterpret_cast<int32_t*>(context->AllocatePersistentBuffer(
+          context, num_channels * sizeof(int32_t)));
+
+  // All per-channel quantized tensors need valid zero point and scale arrays.
+  if (input->type == kTfLiteInt8) {
+    TF_LITE_ENSURE_EQ(context, filter->quantization.type,
+                      kTfLiteAffineQuantization);
+
+    const auto* affine_quantization =
+        reinterpret_cast<TfLiteAffineQuantization*>(
+            filter->quantization.params);
+    TF_LITE_ENSURE(context, affine_quantization);
+    TF_LITE_ENSURE(context, affine_quantization->scale);
+    TF_LITE_ENSURE(context, affine_quantization->zero_point);
+    TF_LITE_ENSURE(
+        context, affine_quantization->scale->size == 1 ||
+                     affine_quantization->scale->size ==
+                         filter->dims->data[kDepthwiseConvQuantizedDimension]);
+    TF_LITE_ENSURE_EQ(context, affine_quantization->scale->size,
+                      affine_quantization->zero_point->size);
+  }
+
+  TF_LITE_ENSURE_STATUS(CalculateOpData(context, node, params, width, height,
+                                        filter_width, filter_height, data_type,
+                                        data));
+
+  data->input_zero_point = input->params.zero_point;
+  data->filter_zero_point = filter->params.zero_point;
+  data->output_zero_point = output->params.zero_point;
+
+  return kTfLiteOk;
+}
+
+void EvalQuantizedPerChannel(TfLiteContext* context, TfLiteNode* node,
+                             TfLiteDepthwiseConvParams* params,
+                             const OpData& data, const TfLiteEvalTensor* input,
+                             const TfLiteEvalTensor* filter,
+                             const TfLiteEvalTensor* bias,
+                             TfLiteEvalTensor* output) {
+  DepthwiseParams op_params;
+  op_params.padding_type = PaddingType::kSame;
+  op_params.padding_values.width = data.padding.width;
+  op_params.padding_values.height = data.padding.height;
+  op_params.stride_width = params->stride_width;
+  op_params.stride_height = params->stride_height;
+  op_params.dilation_width_factor = params->dilation_width_factor;
+  op_params.dilation_height_factor = params->dilation_height_factor;
+  op_params.depth_multiplier = params->depth_multiplier;
+  op_params.input_offset = -data.input_zero_point;
+  op_params.weights_offset = 0;
+  op_params.output_offset = data.output_zero_point;
+  // TODO(b/130439627): Use calculated value for clamping.
+  op_params.quantized_activation_min = std::numeric_limits<int8_t>::min();
+  op_params.quantized_activation_max = std::numeric_limits<int8_t>::max();
+
+  vexriscv::DepthwiseConvPerChannel(
+      op_params, data.per_channel_output_multiplier,
+      data.per_channel_output_shift, tflite::micro::GetTensorShape(input),
+      tflite::micro::GetTensorData<int8_t>(input),
+      tflite::micro::GetTensorShape(filter),
+      tflite::micro::GetTensorData<int8_t>(filter),
+      tflite::micro::GetTensorShape(bias),
+      tflite::micro::GetTensorData<int32_t>(bias),
+      tflite::micro::GetTensorShape(output),
+      tflite::micro::GetTensorData<int8_t>(output));
+}
+
+void EvalQuantized(TfLiteContext* context, TfLiteNode* node,
+                   TfLiteDepthwiseConvParams* params, const OpData& data,
+                   const TfLiteEvalTensor* input,
+                   const TfLiteEvalTensor* filter, const TfLiteEvalTensor* bias,
+                   TfLiteEvalTensor* output) {
+  const int32_t input_offset = -data.input_zero_point;
+  const int32_t filter_offset = -data.filter_zero_point;
+  const int32_t output_offset = data.output_zero_point;
+
+  tflite::DepthwiseParams op_params;
+  // Padding type is ignored, but still set.
+  op_params.padding_type = PaddingType::kSame;
+  op_params.padding_values.width = data.padding.width;
+  op_params.padding_values.height = data.padding.height;
+  op_params.stride_width = params->stride_width;
+  op_params.stride_height = params->stride_height;
+  op_params.dilation_width_factor = params->dilation_width_factor;
+  op_params.dilation_height_factor = params->dilation_height_factor;
+  op_params.depth_multiplier = params->depth_multiplier;
+  op_params.quantized_activation_min = data.output_activation_min;
+  op_params.quantized_activation_max = data.output_activation_max;
+  op_params.input_offset = input_offset;
+  op_params.weights_offset = filter_offset;
+  op_params.output_offset = output_offset;
+  op_params.output_multiplier = data.output_multiplier;
+  // Legacy ops used mixed left and right shifts. Now all are +ve-means-left.
+  op_params.output_shift = -data.output_shift;
+
+  vexriscv::DepthwiseConv(
+      op_params, tflite::micro::GetTensorShape(input),
+      tflite::micro::GetTensorData<uint8_t>(input),
+      tflite::micro::GetTensorShape(filter),
+      tflite::micro::GetTensorData<uint8_t>(filter),
+      tflite::micro::GetTensorShape(bias),
+      tflite::micro::GetTensorData<int32_t>(bias),
+      tflite::micro::GetTensorShape(output),
+      tflite::micro::GetTensorData<uint8_t>(output));
+}
+
+TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
+  TFLITE_DCHECK(node->user_data != nullptr);
+  TFLITE_DCHECK(node->builtin_data != nullptr);
+
+  auto* params =
+      reinterpret_cast<TfLiteDepthwiseConvParams*>(node->builtin_data);
+  const OpData& data = *(static_cast<const OpData*>(node->user_data));
+
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kOutputTensor);
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kInputTensor);
+  const TfLiteEvalTensor* filter =
+      tflite::micro::GetEvalInput(context, node, kFilterTensor);
+  const TfLiteEvalTensor* bias =
+      (NumInputs(node) == 3)
+          ? tflite::micro::GetEvalInput(context, node, kBiasTensor)
+          : nullptr;
+
+  // TODO(aselle): Consider whether float conv and quantized conv should be
+  // separate ops to avoid dispatch overhead here.
+  switch (input->type) {  // Already know in/out types are same.
+    case kTfLiteInt8:
+      EvalQuantizedPerChannel(context, node, params, data, input, filter, bias,
+                              output);
+      break;
+    case kTfLiteUInt8:
+      EvalQuantized(context, node, params, data, input, filter, bias, output);
+      break;
+    default:
+      TF_LITE_KERNEL_LOG(context, "Type %s (%d) not supported.",
+                         TfLiteTypeGetName(input->type), input->type);
+      return kTfLiteError;
+  }
+  return kTfLiteOk;
+}
+
+}  // namespace depthwise_conv
+
+TfLiteRegistration Register_DEPTHWISE_CONV_2D() {
+  return {/*init=*/depthwise_conv::Init,
+          /*free=*/nullptr,
+          /*prepare=*/depthwise_conv::Prepare,
+          /*invoke=*/depthwise_conv::Eval,
+          /*profiling_string=*/nullptr,
+          /*builtin_code=*/0,
+          /*custom_name=*/nullptr,
+          /*version=*/0};
+}
+
+}  // namespace micro
+}  // namespace ops
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/vexriscv/depthwise_conv.cc
+++ b/tensorflow/lite/micro/kernels/vexriscv/depthwise_conv.cc
@@ -212,11 +212,9 @@ inline void DepthwiseConv(
 
             // Accumulate partial results to acc for a small chunk of channels
             for (int filter_y = 0; filter_y < filter_height; ++filter_y) {
-              const int in_y =
-                  in_y_origin + dilation_height_factor * filter_y;
+              const int in_y = in_y_origin + dilation_height_factor * filter_y;
               for (int filter_x = 0; filter_x < filter_width; ++filter_x) {
-                const int in_x =
-                    in_x_origin + dilation_width_factor * filter_x;
+                const int in_x = in_x_origin + dilation_width_factor * filter_x;
                 // Zero padding by omitting the areas outside the image.
                 const bool is_point_inside_image =
                     (in_x >= 0) && (in_x < input_width) && (in_y >= 0) &&
@@ -228,15 +226,14 @@ inline void DepthwiseConv(
 
                 for (int offset_ch = 0; offset_ch < steps; ++offset_ch) {
                   const int in_channel = begin_ch + offset_ch;
-                  const int output_channel =
-                      m + in_channel * depth_multiplier;
+                  const int output_channel = m + in_channel * depth_multiplier;
 
                   int32_t input_val = input_data[Offset(
                       input_shape, batch, in_y, in_x, in_channel)];
                   int32_t filter_val = filter_data[Offset(
                       filter_shape, 0, filter_y, filter_x, output_channel)];
-                  acc[offset_ch] += (filter_val + filter_offset) *
-                                    (input_val + input_offset);
+                  acc[offset_ch] +=
+                      (filter_val + filter_offset) * (input_val + input_offset);
                 }
               }
             }
@@ -251,8 +248,8 @@ inline void DepthwiseConv(
                 value += bias_data[output_channel];
               }
 
-              value = MultiplyByQuantizedMultiplier(
-                  value, output_multiplier, output_shift);
+              value = MultiplyByQuantizedMultiplier(value, output_multiplier,
+                                                    output_shift);
               value += output_offset;
               value = std::max(value, output_activation_min);
               value = std::min(value, output_activation_max);
@@ -285,7 +282,7 @@ struct OpData {
 
   // Cached tensor zero point values for quantized operations.
   int32_t input_zero_point;
-  int32_t filter_zero_point; //***
+  int32_t filter_zero_point;
   int32_t output_zero_point;
 
   // The scaling factor from input to output (aka the 'real multiplier') can
@@ -465,15 +462,14 @@ void EvalQuantized(TfLiteContext* context, TfLiteNode* node,
   // Legacy ops used mixed left and right shifts. Now all are +ve-means-left.
   op_params.output_shift = -data.output_shift;
 
-  vexriscv::DepthwiseConv(
-      op_params, tflite::micro::GetTensorShape(input),
-      tflite::micro::GetTensorData<uint8_t>(input),
-      tflite::micro::GetTensorShape(filter),
-      tflite::micro::GetTensorData<uint8_t>(filter),
-      tflite::micro::GetTensorShape(bias),
-      tflite::micro::GetTensorData<int32_t>(bias),
-      tflite::micro::GetTensorShape(output),
-      tflite::micro::GetTensorData<uint8_t>(output));
+  vexriscv::DepthwiseConv(op_params, tflite::micro::GetTensorShape(input),
+                          tflite::micro::GetTensorData<uint8_t>(input),
+                          tflite::micro::GetTensorShape(filter),
+                          tflite::micro::GetTensorData<uint8_t>(filter),
+                          tflite::micro::GetTensorShape(bias),
+                          tflite::micro::GetTensorData<int32_t>(bias),
+                          tflite::micro::GetTensorShape(output),
+                          tflite::micro::GetTensorData<uint8_t>(output));
 }
 
 TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {

--- a/tensorflow/lite/micro/kernels/vexriscv/doc/DepthwiseConv2D_int8.md
+++ b/tensorflow/lite/micro/kernels/vexriscv/doc/DepthwiseConv2D_int8.md
@@ -1,0 +1,136 @@
+# Design of DepthwiseConv2D for VexRISCV
+* Author: Daniel You (Google SWE intern, Summer 2020)
+* Github Profile: [danielyou0230](https://github.com/danielyou0230)
+* Last Update: August 28, 2020
+* [PR#42715](https://github.com/tensorflow/tensorflow/pull/42715) (see experiment results in the PR message)
+
+## Overview
+The kernel is optimized based on the reference kernel in Tensorflow Lite. Different from the straightforward implementation, this implementation takes memory layout in TF Lite (`NHWC`) into account, which leverages memory hierarchy to reduce memory miss count, to be more specific, it performs depthwise convolution for every channel in a fixed spatial position (iterate `C`-axis first, then `W`-axis, `H`-axis, and `N`-axis).
+
+
+## Objective
+With the debut of Artificial Intelligence (AI) products and services, our lives have been changed ever since. While much of those applications are cloud-based implementations, there are still many cases where AI algorithms have to be run on resource constrained devices. Current machine learning frameworks are still not well optimized for those platforms, thereby preventing more complicated applications running on them with acceptable performance.
+
+This design focuses on improving the performance of kernels in TensorFlow Lite Micro, to be more specific, this design involves one of the most popular kernels among the models deployed on edge devices: DepthwiseConv2D (see [TensorFlow Python API](https://www.tensorflow.org/api_docs/python/tf/keras/layers/DepthwiseConv2D); [discussion on MobileNetV1](https://groups.google.com/g/keras-users/c/sec8pYjJwwE) on Google groups.) The goal is to reduce the inference time on those devices which can in turn save more energy on them or more importantly, enable more complex applications running on them.
+
+## Background
+Existing works aim to optimize on-CPU performance focus on leveraging CPU specific instruction like SIMD instructions in RISC-V Vector and other counterparts like AVX and SSE intrinsics. An implementation released by Facebook ([pytorch/FBGEMM](https://github.com/pytorch/FBGEMM/tree/master/src)) demonstrated the potential that can be achieved with the aforementioned vector instructions.
+
+The alternative approach is to optimize on GPUs. Modern GPUs are well-known for having great performance in matrix multiplication and parallel computation (e.g. CUDA from Nvidia). Those powerful GPUs enable machine learning researchers to explore a wide variety of models and solve complicated problems. For resource constrained embedded processors, however, incorporating a GPU may not fit the limited hardware and power budget for their applications. Unlike running TensorFlow Python APIs on desktop or servers, TensorFlow Lite and TensorFlow Lite Micro are made to efficiently run inference on those devices, which enables the possibilities to make machine learning applications ubiquitous in our life.
+
+## Requirements and scale
+After detailed analysis on memory access patterns in existing implementations, I found existing code under-utilizes the memory hierarchy, specifically, the SRAM cache, to reduce excessive memory access time, which would be approximately 100 times slower if memory access were optimized ([Latency Numbers Every Programmer Should Know](https://gist.github.com/jboner/2841832), [The Effect Of CPU Caches And Memory Access Patterns](http://kejser.org/the-effect-of-cpu-caches-and-memory-access-patterns/).) Therefore, this design aims to improve the memory access pattern to better fit the memory layout of the TensorFlow Lite C++ library. Any integer-based models with DepthwiseConv2D layers using TensorFlow Lite Micro will benefit from this change.
+
+To begin with, the memory layout of tensors in TensorFlow Lite C++ library uses `NHWC` format `(n, height, width, channel)` and flattened to an 1-d tensor, the index of `(n, h, w, c)` in the tensor can then be calculated with `((n * H + h) * W + w) * C + c`. The reference implementation is depicted as follows:
+
+```
+for i-th input among N inputs
+  for c-th input channel
+    for (y, x) in input that are convolving with the filter
+      access element (i, y, x, c) in the input
+```
+
+Thus, if the current element is `(i, y, x, c)` at index  `((i * H + y) * W + x) * C + c`, next element will be `(i, y, x + 1, c)` at index `((i * H + y) * W + (x + 1)) * C + c`, the difference of indices between two consecutive accesses is `C` (illustrated below,) which is apparently not a sequential access.
+
+![dconv_arr_index](https://user-images.githubusercontent.com/21079720/91612344-0f25e600-e932-11ea-9278-7c8161748711.png)
+
+In response to the poor memory access pattern in the reference, it would be beneficial to implement DepthwiseConv2D in a depth-centric manner, namely, accessing elements at a fixed spatial location `(y, x)` for each channel. The access order then becomes sequential on the 1-d tensor because the layout of tensors are in the format of `NHWC`.
+
+## Design ideas
+Instead of accessing the memory in a non-sequential manner, this design proposes to change the access pattern to be consistent with the memory layout in the current TensorFlow Lite C++ library. The idea can be broken down into two major parts:
+
+* Relating sequential memory access to DepthwiseConv2D
+* Depthwise convolution with sequential memory access scheme
+
+### Relating sequential memory access to DepthwiseConv2D
+Contrary to the reference implementation, the proposed solution re-orders the calculation to access the elements sequentially in the tensor, namely, `(0, 1, 2, ..., H * W * C - 1)`. This can be done by interchanging the order of two inner loops:
+```
+for i-th input
+  for (y, x) in input that are convolving with the filter
+    for c-th input channel
+      access element (i, y, x, c) in the input
+```
+
+In this case, if the current element is `(i, y, x, c)` at index `((i * H + y) * W + x) * C + c`, the next element will be `((i * H + y) * W + x) * C + (c + 1)`, the difference of between two consecutive access becomes `1`, thereby fully re-using the data in a cache block.
+
+### Depthwise convolution with sequential memory access scheme
+In the existing TF Lite reference implementation, each element in the output is calculated by performing `(filter_h * filter_w)` multiplications and additions in a row. With the proposed design, memory access patterns can be greatly improved by re-ordering the calculations.
+
+Rather than calculating the results in a row, this design rearranges the operations. To calculate the output at a specific spatial location for all channels (see the colored cells in the output tensor in the figure below) the resulting order of calculations is illustrated below, the involving input/filter locations are represented as `(spatial index, channel)`
+
+![dconv_org_vis](https://user-images.githubusercontent.com/21079720/91612427-409eb180-e932-11ea-9c30-a205c8f3e461.png)
+
+|     Original    |    Optimized    |
+|:---------------:|:---------------:|
+|     (#1, 0)     |     (#1, 0)     |
+|     (#2, 0)     |     (#1, 1)     |
+|       ...       |       ...       |
+|   **(#9, 0)**   |   (#1, C - 1)   |
+|     (#1, 1)     |     (#2, 0)     |
+|      ...        |       ...       |
+|   **(#9, 1)**   |   **(#9, 0)**   |
+|      ...        |       ...       |
+| **(#9, C - 1)** | **(#9, C - 1)** |
+
+The calculation for each element at the output is completed when it reaches the bold coordinates in the table. From the table, this scheme only gets partial results until it reaches the last location (i.e., `(#9, 0)` to `(#9, C-1)`). Ideally, we can use the output tensor directly as an accumulator, no extra space is needed at runtime. Yet, since the output tensor is limited (8 bits) in an integer model, accumulating intermediate values at the output tensor will cause overflow: the product of two `int8` values is in the range of `int16` and there are `H * W` values to be accumulated, the range of the value before quantization is `H * W * MAX_INT16`. Therefore, an `int32` accumulator is adequate as long as the number of accumulations `(H*W*C)` does not exceed `2^16`. To address overflow when accumulating at output tensor and provide better memory access pattern, an `int32` array of size equals to number of channels (`C`) as accumulators is enough, since those `C` calculations are done once a set of spatial locations (`#1` to `#9`) are convolved, we don't have to allocate an array with size equals to the output tensor to accumulate the values.
+
+If we implement this idea, i.e. allocating a temporary array with size equals to `C`, we can follow the loop structure shown below, this would work just fine, but as we can see in the routine, it involves allocating an `int32` array of **size in proportional to the input channel**, which is not preferable in those resource limited devices because we cannot assure there will always be enough memory given any application or model.
+
+```
+for i-th input among N inputs
+  for each (out_y, out_x)
+    for m < depth_multiplier; step_size = 1
+      calculate origin (in_y_origin, in_x_origin) to perform convolution
+      
+      // Accumulate partial results in buffer given a origin
+      create an int32 buffer of size output_channel as accumulators
+      
+      for each (filter_y, filter_x)
+        calculate (in_y, in_x) to perform convolution
+        for in_ch < in_channel; step_size = 1
+          calculate out_ch
+          // accumulate partial results
+          buffer[ch_offset] += input[indexOf(i, y, x, in_ch)] *
+                               filter[indexOf(0, f_y, f_x, out_ch)]
+                               
+      for in_ch < in_channel; step_size = 1
+        calculate out_ch
+        // Add bias / activation / requantize
+        value = postAccumulation(buffer[out_ch])
+        output[indexOf(i, out_y, out_x, out_ch)] = value
+
+```
+
+Instead, we can further breakdown the structure into chunks, namely, we can add an additional nested loop inside to iterate `K` channels a time until all channels are processed, the modified loop structure is depicted below and the visualization is shown in the figure below the loop.
+
+```
+for i-th input among N inputs
+  for each (out_y, out_x)
+    for m < depth_multiplier; step_size = 1
+      calculate origin (in_y_origin, in_x_origin) to perform convolution
+      
+      // Accumulate partial results in buffer for K channels given a origin
+      for ch < input_ch; step_size = K
+        create an int32 buffer of size K as accumulator for current chunk
+        
+        for each (filter_y, filter_x)
+          calculate (in_y, in_x) to perform convolution
+          for ch_offset < channel_step; step_size = 1
+            calculate in_ch and out_ch
+            // accumulate partial results
+            buffer[ch_offset] += input[indexOf(i, y, x, in_ch)] *
+                                 filter[indexOf(0, f_y, f_x, out_ch)]
+
+        for ch_offset < channel_step; step_size = 1
+          // Add bias / activation / requantize
+          value = postAccumulation(buffer[ch_offset])
+          output[indexOf(i, out_y, out_x, out_ch)] = value
+
+```
+
+![dconv_design_vis](https://user-images.githubusercontent.com/21079720/91612374-2369e300-e932-11ea-90eb-898c0270794e.png)
+
+The final problem is how the choice of `K`, according to the soft-CPU configuration,  we have a cache size of 4KB and each memory block is 32 bytes. Combined with the input format we use (`int8`) whenever the OS fetches a block of input tensor, it loads 32 `int8` to the cache. To fully utilize that block, we can choose the size of the buffer to accommodate 32 partial results (128 byte, or 4 blocks,) most applications keep the number of channels to be power of 2s (except for the input,) 32 is a reasonable value to perform depthwise convolution for both small and large numbers of channels in the model.
+
+## Alternatives considered
+An alternative design is to dynamically allocate a buffer for each channel (an `int32` array of size equals to number of output channels.) This approach is easier to implement since after `H * W * C` calculations, we can requantize those `C` values and store them into the output tensor. However, we are running on memory constrained devices, dynamic allocation is not encouraged by the upstream developers.


### PR DESCRIPTION
This PR adds an optimized DepthwiseConv2D `int8`/`uint8` kernel for VexRISCV as discussed with @advaitjain earlier, see below for details. 

## TL;DR
The optimization
1. Reduces the penalty introduces by excessive memory misses compared to the straightforward implementation
2. No regression on model precision
3. Speedup person_detection (`int8`/`uint8`) by ~5% during inference
4. Requires no special hardware intrinsic instructions or compiler support, just pure C++

## Overview
The kernel is optimized based on the reference kernel in Tensorflow Lite: different from the straightforward implementation, this implementation takes memory layout in TF Lite (`NHWC`) into account, which leverages memory hierarchy to reduce memory miss count, to be more specific, it performs depthwise convolution for every channel in a fixed spatial position (iterate `C`-axis first, then `W`-axis, `H`-axis, and `N`-axis).

This design re-uses memory blocks that have already been cached in faster memory (e.g. L1 cache or L2 cache) and uses a small fixed size buffer of size `k` to store the intermediate values (`int32`) to perform the exact same operation (in this kernel: 2-D depthwise convolution,) thus, **this design has no regression in terms of model precision**.

## Cost of the design
The cost consists of two parts:
1. Uses a small fixed size buffer: memory usage will increase in this layer compared to the original implementation, but this probably will not be an issue (see below for details of how to determine the buffer size `k`)
2. Potentially more memory load when the accumulation is completed: bring buffer for quantization, activation, etc.

## Results
The following results are measured with Digilent Arty A7 with VexRISCV soft-CPU running two versions of person_detection available in the repo, this is not officially supported but basically the same makefile from zephyr_riscv in magic_wand.

### Memory load-refill count
#### Original
|       | cycles (M) | Load (M) | Refill (k) |
|-------|:----------:|:--------:|:----------:|
| uint8 |   557.46   |   93.34  |   715.39   |
|  int8 |   503.81   |   87.03  |   561.78   |

#### Optimized
|       | cycles (M) | Load (M) | Refill (k) | 
|:----------:|:--------:|:----------:|:--------:|
|  uint8 |   532.77   |   94.11  |   558.29   |   0.83   |   -21.96   | 157.15 |
|  int8 |   478.38   |   87.62  |   494.90   |   0.67   |   -11.90   | 380.27 |

#### Comparison (delta)
|       | Load | Refill | Miss Penalty (cycles/refill) |
|:----------:|:--------:|:----------:|:--------:|
|  uint8 |  +0.83%   |   -21.96%   | 157.15 |
|  int8 |   +0.67%   |   -11.90%   | 380.27 |

As showed above, with a very marginal amount (< 1%) increment of memory load introduced by the buffer, the optimized kernel reduces the overall memory refill count by at least 10%, which also leads to a speedup (see next section.) Although the measurements are not completely accurate because memory caching is very complicated and it involves a lot of other data in the memory/cache, but the results provide a strong evidence on how improving the memory access pattern impacts the performance on edge devices.

### Inference
|                          |   Original   | Optimized | Speedup |
|--------------------------|:------------:|:---------------:|:----------:|
|                          | # cycles (M) |   # cycles (M)  | (%) |
| person_detection (uint8) |    557.46    |      532.77     |    4.43%   |
| person_detection (int8)  |    503.81    |      478.38     |    5.05%   |

## Details about choice of the buffer size `k`:
The platform I'm mainly testing is Digilent Arty A7 with VexRISC-V soft-CPU. According to the hardware spec specified in [SpinalHDL/VexRiscv](https://github.com/SpinalHDL/VexRiscv), the cache size is 4 KB and the cache block (cache line) size is 32 bytes (search `bytePerLine` in the repo), so there will be 1K blocks available.

In this kernel, the input and output are both `int8` (8 bits, or 1 byte) which means that the system brings 32 `int8` data to the cache each time. To fully utilize the data in this block, we will need 32 accumulator (of type `int32`) for these 32 `int8` data. Thus, a reasonable choice of `k` is 32 and this will take an additional `32 * sizeof(int32) = 128 bytes`, or 4 blocks, this will occupy 4 out of those 1K blocks, which is comparably a small and tolerable overhead.