### PR TITLE
Use a ternary if for checking main_op is None in Saved Model Builder

### DIFF
--- a/tensorflow/python/saved_model/builder_impl.py
+++ b/tensorflow/python/saved_model/builder_impl.py
@@ -534,7 +534,7 @@ class SavedModelBuilder(_SavedModelBuilder):
 
     # legacy_init_op is deprecated, and going away in TF 2.0.
     # Re-mapping to main_op, as treatment is identical regardless.
-    main_op = main_op or legacy_init_op
+    main_op = main_op if main_op is not None else legacy_init_op
 
     # Add assets and ops
     self._add_collections(assets_collection, main_op, None)


### PR DESCRIPTION
Fixes a minor bug in saved_model which raises an
exception since evaluating ops as booleans are
forbidden in TF 2.x

Fixes #38041 

I haven't added a test case yet, but the fix is quite simple.