### PR TITLE
Extended the http response codes to be handled

### DIFF
--- a/tensorflow/core/platform/cloud/curl_http_request.cc
+++ b/tensorflow/core/platform/cloud/curl_http_request.cc
@@ -494,13 +494,16 @@ Status CurlHttpRequest::Send() {
 
     // INVALID_ARGUMENT indicates a problem with how the request is constructed.
     case 400:  // Bad Request
+    case 406:  // Not Acceptable
     case 411:  // Length Required
+    case 414:  // URI Too Long
       result = errors::InvalidArgument(get_error_message());
       break;
 
     // PERMISSION_DENIED indicates an authentication or an authorization issue.
     case 401:  // Unauthorized
     case 403:  // Forbidden
+    case 407:  // Proxy Authorization Required
       result = errors::PermissionDenied(get_error_message());
       break;
 


### PR DESCRIPTION
This PR extends the switch cases of response codes to be handled by the `CurlHttpRequest` class. The codes were observed while working on https://github.com/tensorflow/io/pull/1099 and the error handling seemed to be missing in the `CurlHttpRequest` class.