### PR TITLE
fix DEBUG_BUILD option on linux not getting passed into third_party/aws-checksums

### DIFF
--- a/third_party/aws/aws-checksums.bazel
+++ b/third_party/aws/aws-checksums.bazel
@@ -7,6 +7,13 @@ licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])
 
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+selects.config_setting_group(
+    name = "is_linux_debug",
+    match_all = ["@org_tensorflow//tensorflow:linux_x86_64", "@org_tensorflow//tensorflow:debug"],
+)
+
 cc_library(
     name = "aws-checksums",
     srcs = select({
@@ -28,4 +35,10 @@ cc_library(
     deps = [
         "@aws-c-common",
     ],
+    defines = select({
+        ":is_linux_debug": [
+            "DEBUG_BUILD"
+        ],
+        "//conditions:default": [],
+    }),
 )


### PR DESCRIPTION
- fixes #37498
- probably obsoletes #39239 (already merged) which doesn't work (in at least one case)