### PR TITLE
Make effective scale in quantize kernel consistent b/w Lite and Micro.

### DIFF
--- a/tensorflow/lite/micro/kernels/quantize.cc
+++ b/tensorflow/lite/micro/kernels/quantize.cc
@@ -72,8 +72,8 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   if (((input->type == kTfLiteInt16 || input->type == kTfLiteInt8) &&
        output->type == kTfLiteInt8) ||
       (input->type == kTfLiteInt16 && output->type == kTfLiteInt16)) {
-    double effective_scale =
-        static_cast<double>(input->params.scale / output->params.scale);
+    double effective_scale = static_cast<double>(input->params.scale) /
+                             static_cast<double>(output->params.scale);
 
     QuantizeMultiplier(effective_scale, &data->output_multiplier,
                        &data->output_shift);


### PR DESCRIPTION
There is no reason for the Micro implementation to do a division in single precision.

Fixes #42648