### PR TITLE
TFLITE_USE_DELEGATE has been changed to use GpuDelegateOptions instead of TFLGpuDelegateOptions.

### DIFF
--- a/tensorflow/lite/examples/ios/camera/CameraExampleViewController.mm
+++ b/tensorflow/lite/examples/ios/camera/CameraExampleViewController.mm
@@ -387,7 +387,7 @@ void ProcessInputWithQuantizedModel(
 - (void)dealloc {
 #if TFLITE_USE_GPU_DELEGATE
   if (delegate) {
-    TFLGpuDelegateDelete(delegate);
+    DeleteGpuDelegate(delegate);
   }
 #endif
   [self teardownAVCapture];
@@ -416,10 +416,10 @@ void ProcessInputWithQuantizedModel(
   tflite::InterpreterBuilder(*model, resolver)(&interpreter);
 
 #if TFLITE_USE_GPU_DELEGATE
-  TFLGpuDelegateOptions options;
+  GpuDelegateOptions options;
   options.allow_precision_loss = true;
-  options.wait_type = TFLGpuDelegateWaitTypeActive;
-  delegate = TFLGpuDelegateCreate(&options);
+  options.wait_type = GpuDelegateOptions::WaitType::kActive;
+  delegate = NewGpuDelegate(&options);
   interpreter->ModifyGraphWithDelegate(delegate);
 #endif
 


### PR DESCRIPTION
This PR is a modified version of the tensorflow lite sample on iOS 🙋‍♂️
Changing the value of `TFLITE_USE_GPU_DELEGATE` from 0 to 1 caused an exception in the following areas.

https://github.com/tensorflow/tensorflow/blob/36d2f532a1eade7ad8b77589c85059a9ddb2f1e1/tensorflow/lite/examples/ios/camera/CameraExampleViewController.mm#L389-L391

https://github.com/tensorflow/tensorflow/blob/36d2f532a1eade7ad8b77589c85059a9ddb2f1e1/tensorflow/lite/examples/ios/camera/CameraExampleViewController.mm#L418-L424

The exceptions that occurred are as follows 👀 
`Unknown type name 'TFLGpuDelegateOptions'; did you mean 'GpuDelegateOptions'?`
Apparently, the class name has been changed.

Using GpuDelegateOptions seemed to be the right thing to do, so I modified the code to use this one.
After changing the relevant sections, GPU-based processing now works.

I'm not sure these changes are the right ones, but it would be great to have a review!