### PR TITLE
CMSIS-NN conv, depthwise conv kernels: allocate per channel memory dynamically (#42748)

### DIFF
--- a/tensorflow/lite/micro/kernels/cmsis-nn/conv.cc
+++ b/tensorflow/lite/micro/kernels/cmsis-nn/conv.cc
@@ -36,6 +36,7 @@ constexpr int kInputTensor = 0;
 constexpr int kFilterTensor = 1;
 constexpr int kBiasTensor = 2;
 constexpr int kOutputTensor = 0;
+constexpr int kMaxChannels = 256;
 
 // Conv is quantized along dimension 0:
 // https://www.tensorflow.org/lite/performance/quantization_spec
@@ -55,8 +56,9 @@ struct OpData {
   int output_shift;
 
   // Per channel output multiplier and shift.
-  int32_t* per_channel_output_multiplier;
-  int32_t* per_channel_output_shift;
+  // TODO(b/141139247): Allocate these dynamically when possible.
+  int32_t per_channel_output_multiplier[kMaxChannels];
+  int32_t per_channel_output_shift[kMaxChannels];
 
   // The range of the fused activation layer. For example for kNone and
   // uint8_t these would be 0 and 255.
@@ -156,18 +158,6 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   output_dims.h = output->dims->data[1];
   output_dims.w = output->dims->data[2];
   output_dims.c = output_shape.Dims(3);
-
-  // Dynamically allocate per-channel quantization parameters.
-  const int num_channels = filter->dims->data[kConvQuantizedDimension];
-
-  data->per_channel_output_multiplier =
-    reinterpret_cast<int32_t*>(
-      context->AllocatePersistentBuffer(
-        context, num_channels * sizeof(int32_t)));
-  data->per_channel_output_shift =
-    reinterpret_cast<int32_t*>(
-      context->AllocatePersistentBuffer(
-        context, num_channels * sizeof(int32_t)));
 
   TF_LITE_ENSURE_STATUS(CalculateOpData(
       context, node, params, input_dims.w, input_dims.h, filter_dims.w,

--- a/tensorflow/lite/micro/kernels/cmsis-nn/depthwise_conv.cc
+++ b/tensorflow/lite/micro/kernels/cmsis-nn/depthwise_conv.cc
@@ -130,10 +130,6 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   int filter_height = SizeOfDimension(filter, 1);
 
   if (input->type == kTfLiteInt8) {
-    // Allocate memory for per-channel quantization parameters
-    const int num_channels =
-        filter->dims->data[kDepthwiseConvQuantizedDimension];
-
     TF_LITE_ENSURE_EQ(context, filter->quantization.type,
                       kTfLiteAffineQuantization);
 
@@ -152,8 +148,9 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
                       affine_quantization->zero_point->size);
   }
 
-  // Dynamically allocate per-channel quantization parameters.
-  const int num_channels = filter->dims->data[kDepthwiseConvQuantizedDimension];
+  // Allocate memory for per-channel quantization parameters
+  const int num_channels =
+      filter->dims->data[kDepthwiseConvQuantizedDimension];
 
   data->per_channel_output_multiplier =
     reinterpret_cast<int32_t*>(


### PR DESCRIPTION
See #42748 

The CMSIS-NN convolutional and depthwise convolutional kernels write in uninitialized memory when num_channels is higher than 256. This is because the OpData struct allocates memory statically, rather than request memory from the arena, like the non-CMSIS-NN kernels. As there is no boundary checking in this function this leads to errors when dealing with any network that contains more channels in a layer (this has shown for us in e.g. MobileNet v2 0.05). This patch brings the behavior of the kernel in line with the normal TFLM conv and depthwise_conv kernels, by allocating the memory from the arena.

Additionally I've (in the second commit) changed the way that kernels allocate memory from using the scratch buffer to allocating persistent memory. As far as I can see this should be the case anyway, this memory is required permanently for the kernel.

I've [backported](https://github.com/edgeimpulse/tensorflow/tree/fix-42748-v2.3.0) this fix to the TensorFlow v2.3.0 release and verified that it works on Mbed OS 6.2 on the ST IoT Discovery Kit using CMSIS-NN (compiled with GCC ARM 9), but current master hardfaults on a nullptr reference both with and without CMSIS-NN.

/cc @kwagyeman @dansitu 