### PR TITLE
Update README.md resources roadmap link

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Build Type                                                                      
 *   [Learn ML with TensorFlow](https://www.tensorflow.org/resources/learn-ml)
 *   [TensorFlow Twitter](https://twitter.com/tensorflow)
 *   [TensorFlow YouTube](https://www.youtube.com/channel/UC0rqucBdTuFTjJiefW5t-IQ)
-*   [TensorFlow Roadmap](https://www.tensorflow.org/community/roadmap)
+*   [TensorFlow Roadmap](https://www.tensorflow.org/model_optimization/guide/roadmap)
 *   [TensorFlow White Papers](https://www.tensorflow.org/about/bib)
 *   [TensorBoard Visualization Toolkit](https://github.com/tensorflow/tensorboard)
 


### PR DESCRIPTION
Link to TensorFlow Roadmap https://www.tensorflow.org/community/roadmap is not working. 
Therefore, it was changed to the right webpage https://www.tensorflow.org/model_optimization/guide/roadmap.