### PR TITLE
TFLu: update cmsis kernels

### DIFF
--- a/tensorflow/lite/micro/kernels/cmsis-nn/mul.cc
+++ b/tensorflow/lite/micro/kernels/cmsis-nn/mul.cc
@@ -62,8 +62,8 @@ TfLiteStatus CalculateOpData(TfLiteContext* context, TfLiteNode* node,
         context, params->activation, output, &data->output_activation_min,
         &data->output_activation_max));
 
-    double real_multiplier =
-        input1->params.scale * input2->params.scale / output->params.scale;
+    double real_multiplier = static_cast<double>(
+        input1->params.scale * input2->params.scale / output->params.scale);
     QuantizeMultiplier(real_multiplier, &data->output_multiplier,
                        &data->output_shift);
   }
@@ -210,7 +210,14 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
 }  // namespace mul
 
 TfLiteRegistration Register_MUL() {
-  return {mul::Init, nullptr /* Free */, mul::Prepare, mul::Eval};
+  return {/* Init=*/mul::Init,
+          /* Free=*/nullptr,
+          /* Prepare=*/mul::Prepare,
+          /*invoke=*/mul::Eval,
+          /*profiling_string=*/nullptr,
+          /*builtin_code=*/0,
+          /*custom_name=*/nullptr,
+          /*version=*/0};
 }
 
 }  // namespace micro

--- a/tensorflow/lite/micro/kernels/cmsis-nn/mul.cc
+++ b/tensorflow/lite/micro/kernels/cmsis-nn/mul.cc
@@ -62,8 +62,9 @@ TfLiteStatus CalculateOpData(TfLiteContext* context, TfLiteNode* node,
         context, params->activation, output, &data->output_activation_min,
         &data->output_activation_max));
 
-    double real_multiplier = static_cast<double>(
-        input1->params.scale * input2->params.scale / output->params.scale);
+    double real_multiplier = static_cast<double>(input1->params.scale) *
+                             static_cast<double>(input2->params.scale) /
+                             static_cast<double>(output->params.scale);
     QuantizeMultiplier(real_multiplier, &data->output_multiplier,
                        &data->output_shift);
   }


### PR DESCRIPTION
- Cast to double in mul.cc.
- Add missing initializers in Register_MUL().
- Fix compile issue in conv.cc reference (fall back) case.