### PR TITLE
TFLu: Fix Ethos-U build issue

### DIFF
--- a/tensorflow/lite/micro/tools/make/download_and_extract.sh
+++ b/tensorflow/lite/micro/tools/make/download_and_extract.sh
@@ -223,6 +223,7 @@ download_and_extract() {
     fi
   else
     echo "Error unsupported archive type. Failed to extract tool after download."
+    exit 1
   fi
   rm -rf ${tempdir2} ${tempdir}
 

--- a/tensorflow/lite/micro/tools/make/ext_libs/ethosu.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/ethosu.inc
@@ -1,5 +1,10 @@
 ifneq ($(filter ethos-u,$(ALL_TAGS)),)
-    # Do not link Math library
+    # Arm Compiler will not link the Math library (see below), therefore we're filtering it out.
+    # See Fatal error: L6450U: Cannot find library m:
+    # "Arm Compiler is designed to run in a bare metal environment,
+    # and automatically includes implementations of these functions,
+    # and so no such flag is necessary."
+    # https://developer.arm.com/documentation/100891/0611/troubleshooting/general-troubleshooting-advice
     MICROLITE_LIBS := $(filter-out -lm,$(MICROLITE_LIBS))
 
     ifneq (,$(filter $(TARGET_ARCH), x86_64))

--- a/tensorflow/lite/micro/tools/make/ext_libs/ethosu.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/ethosu.inc
@@ -1,19 +1,31 @@
 ifneq ($(filter ethos-u,$(ALL_TAGS)),)
-    # Don't want -lm flag
-    MICROLITE_LIBS :=
+    MICROLITE_LIBS := $(filter-out -lm,$(MICROLITE_LIBS))
 
     ifneq (,$(filter $(TARGET_ARCH), x86_64))
         $(error target architecture x86_64 not supported)
     endif
 
-    THIRD_PARTY_DOWNLOADS += \
-      $(eval $(call add_third_party_download,$(ETHOSU_URL),$(ETHOSU_MD5),ethosu,))
     ETHOSU_DRIVER_PATH = $(MAKEFILE_DIR)/downloads/ethosu
+
+    # The driver need to be downloaded before the recursive_find below.
+    # That won't happen with the standard way of downloading by generating a
+    # target(call add_third_party_download), so instead use the shell function.
+    NEED_DOWNLOAD := YES
+    ifeq ($(NEED_DOWNLOAD),$(shell test -d $(ETHOSU_DRIVER_PATH) || echo $(NEED_DOWNLOAD)))
+        DOWNLOAD_SCRIPT := ./tensorflow/lite/micro/tools/make/download_and_extract.sh
+        DOWNLOAD_OK := OK
+        DOWNLOAD_STATUS := $(shell $(DOWNLOAD_SCRIPT) $(ETHOSU_URL) $(ETHOSU_MD5) $(ETHOSU_DRIVER_PATH) >&2 && echo $(DOWNLOAD_OK))
+        ifneq ($(DOWNLOAD_OK),$(DOWNLOAD_STATUS))
+            $(error $(DOWNLOAD_SCRIPT) failed)
+        endif
+    endif
 
     # Currently there is a dependency to CMSIS-NN
     THIRD_PARTY_DOWNLOADS += \
         $(eval $(call add_third_party_download,$(CMSIS_URL),$(CMSIS_MD5),cmsis,patch_cmsis))
-    CMSIS_PATH = $(MAKEFILE_DIR)/downloads/cmsis/
+    ifeq ($(CMSIS_PATH),)
+      CMSIS_PATH = $(MAKEFILE_DIR)/downloads/cmsis/
+    endif
     THIRD_PARTY_CC_HDRS += $(call recursive_find,$(CMSIS_PATH)/CMSIS/Core/Include,*.h)
 
     THIRD_PARTY_CC_HDRS += $(call recursive_find,$(ETHOSU_DRIVER_PATH)/include,*.h)

--- a/tensorflow/lite/micro/tools/make/ext_libs/ethosu.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/ethosu.inc
@@ -1,4 +1,5 @@
 ifneq ($(filter ethos-u,$(ALL_TAGS)),)
+    # Do not link Math library
     MICROLITE_LIBS := $(filter-out -lm,$(MICROLITE_LIBS))
 
     ifneq (,$(filter $(TARGET_ARCH), x86_64))


### PR DESCRIPTION
The issue is that a binary need to be built twice, since it
depends on recursive_find. The driver is not fully downloaded when
recursive_find is called. 
The solution proposal is to call the download script
immediately via the make's shell function.

Also add missing exit to error case in download script.