### PR TITLE
Fix 1.15 build and run issues on iOS

### DIFF
--- a/tensorflow/contrib/makefile/download_dependencies.sh
+++ b/tensorflow/contrib/makefile/download_dependencies.sh
@@ -26,7 +26,7 @@ if [ ! -f $BZL_FILE_PATH ]; then
   exit 1;
 fi
 
-EIGEN_URL="$(grep -o 'https://bitbucket.org/eigen/eigen/get/.*tar\.gz' "${BZL_FILE_PATH}" | grep -v mirror.bazel | head -n1)"
+EIGEN_URL="$(grep -o 'https://storage.googleapis.com/mirror.tensorflow.org/bitbucket.org/eigen/eigen/get/.*tar.gz' "${BZL_FILE_PATH}")"
 GEMMLOWP_URL="$(grep -o 'https://storage.googleapis.com/mirror.tensorflow.org/github.com/google/gemmlowp/.*zip' "${BZL_FILE_PATH}" | head -n1)"
 GOOGLETEST_URL="https://github.com/google/googletest/archive/release-1.8.0.tar.gz"
 NSYNC_URL="$(grep -o 'https://storage.googleapis.com/mirror.tensorflow.org/github.com/google/nsync/.*tar\.gz' "${BZL_FILE_PATH}" | head -n1)"

--- a/tensorflow/core/platform/profile_utils/cpu_utils.h
+++ b/tensorflow/core/platform/profile_utils/cpu_utils.h
@@ -67,6 +67,10 @@ class CpuUtils {
     __asm__ volatile("rdtsc" : "=a"(low), "=d"(high));
     return (high << 32) | low;
 // ----------------------------------------------------------------
+#elif defined(__aarch64__) && defined(TARGET_OS_IOS)
+    // On iOS, we are not able to access the cntvct_el0 register.
+    // As a temporary build fix, we will just return the dummy cycle clock.
+    return DUMMY_CYCLE_CLOCK
 #elif defined(__aarch64__)
     // System timer of ARMv8 runs at a different frequency than the CPU's.
     // The frequency is fixed, typically in the range 1-50MHz.  It can because


### PR DESCRIPTION
- Fix `download_dependencies.sh` to use Google archive mirror for the Eigen library (The bitbucket archive link was dead because Eigen had moved to Gitlab)

- Temporarily fix crash issue on iOS runs (#29627) caused by the fact that `CPU_utils.h` tries to access a [prohibited register on iOS](https://github.com/xianyi/OpenBLAS/issues/2281#issuecomment-541154490). (It may actually be the case that we just need a [register permission set](https://android.googlesource.com/kernel/bcm/+/android-wear-5.0.2_r0.5/arch/arm64/include/asm/arch_timer.h#110), but I will leave that to the experts).

@mihaimaruseac 