### PR TITLE
Update contribution guidlines with developer workflow.

### DIFF
--- a/tensorflow/lite/micro/CONTRIBUTING.md
+++ b/tensorflow/lite/micro/CONTRIBUTING.md
@@ -297,5 +297,10 @@ Most PRs for TensorFlow Lite Micro will be C++ only. Adding some notes on Python
 that can be expanded and improved as necessary.
 
  * [TensorFlow guide](https://www.tensorflow.org/community/contribute/code_style#python_style) for Python development
+
  * [yapf](https://github.com/google/yapf/) should be used for formatting.
+
+   ```
+   yapf log_parser.py -i --style='{based_on_style: pep8, indent_width: 2}'
+   ```
 

--- a/tensorflow/lite/micro/CONTRIBUTING.md
+++ b/tensorflow/lite/micro/CONTRIBUTING.md
@@ -1,3 +1,30 @@
+
+<!--
+Semi-automated TOC generation with instructions from
+https://github.com/ekalinin/github-markdown-toc#auto-insert-and-update-toc
+-->
+
+<!--ts-->
+   * [Resources](#resources)
+   * [Contributing Guidelines](#contributing-guidelines)
+      * [General Pull Request Guidelines](#general-pull-request-guidelines)
+      * [Guidelines for Specific Contribution Categories](#guidelines-for-specific-contribution-categories)
+         * [Bug Fixes](#bug-fixes)
+         * [Reference Kernel Implementations](#reference-kernel-implementations)
+         * [Optimized Kernel Implementations](#optimized-kernel-implementations)
+         * [New Target / Platform / IDE / Examples](#new-target--platform--ide--examples)
+         * [New Features](#new-features)
+   * [Development Workflow](#development-workflow)
+      * [Before Creating a Pull Request](#before-creating-a-pull-request)
+      * [Making Changes During the Pull Request Review Process](#making-changes-during-the-pull-request-review-process)
+      * [Reviewer Notes](#reviewer-notes)
+      * [Python Notes](#python-notes)
+
+<!-- Added by: advaitjain, at: Wed 02 Sep 2020 02:59:14 PM PDT -->
+
+<!--te-->
+
+
 # Resources
 
 A
@@ -167,9 +194,9 @@ Having said that, we still invite feature requests via
 [TF Lite Micro Github issues](https://github.com/tensorflow/tensorflow/issues/new?labels=comp%3Amicro&template=70-tflite-micro-issue.md)
 to determine if the requested feature aligns with the TFLM roadmap.
 
-# Development Workflow Notes
+# Development Workflow
 
-## Before submitting your PR
+## Before Creating a Pull Request
 
  1. Run in-place clang-format on all the files that are modified in your git
     tree with
@@ -179,10 +206,7 @@ to determine if the requested feature aligns with the TFLM roadmap.
 
  1. Make sure your code is lint-free.
 
-    Get a copy of cpplint
-    ```
-    git@github.com:google/styleguide.git
-    ```
+    Get a copy of [cpplint](https://github.com/google/styleguide/tree/gh-pages/cpplint)
 
     Run cpplint.py on all modified files in your git tree:
     ```
@@ -202,12 +226,12 @@ to determine if the requested feature aligns with the TFLM roadmap.
     following command (replace `micro_interpreter_test` with the target that you
     want to test:
     ```
-    CC=clang BAZEL_COMPILER=llvm bazel run --copt=-DADDRESS_SANITIZER    
-    --copt=-fsanitize=address --linkopt=-fsanitize=address
+    CC=clang BAZEL_COMPILER=llvm bazel run --copt=-DADDRESS_SANITIZER \
+    --copt=-fsanitize=address --linkopt=-fsanitize=address \
     tensorflow/lite/micro:micro_interpreter_test
     ```
 
-## During the PR review
+## Making Changes During the Pull Request Review Process
 
  1. Do not change the git version history. Always merge upstream/master, and no
     force-pushes please.
@@ -246,7 +270,7 @@ to determine if the requested feature aligns with the TFLM roadmap.
     force-push may be unavoidable.
 
 
-## Reviewer notes
+## Reviewer Notes
 
  * [GIthub CLI](cli.github.com) can be useful to quickly checkout a PR to test
    locally.
@@ -276,7 +300,7 @@ to determine if the requested feature aligns with the TFLM roadmap.
    git remote rm <remote_name>
    ```
 
-## Python notes
+## Python Notes
 
 Most PRs for TensorFlow Lite Micro will be C++ only. Adding some notes on Python
 that can be expanded and improved as necessary.

--- a/tensorflow/lite/micro/CONTRIBUTING.md
+++ b/tensorflow/lite/micro/CONTRIBUTING.md
@@ -1,3 +1,29 @@
+
+<!--
+Semi-automated TOC generation with instructions from
+https://github.com/ekalinin/github-markdown-toc#auto-insert-and-update-toc
+-->
+<!--ts-->
+   * [Resources](#resources)
+   * [Contributing Guidelines](#contributing-guidelines)
+      * [General Pull Request Guidelines](#general-pull-request-guidelines)
+      * [Guidelines for Specific Contribution Categories](#guidelines-for-specific-contribution-categories)
+         * [Bug Fixes](#bug-fixes)
+         * [Reference Kernel Implementations](#reference-kernel-implementations)
+         * [Optimized Kernel Implementations](#optimized-kernel-implementations)
+         * [New Target / Platform / IDE / Examples](#new-target--platform--ide--examples)
+         * [New Features](#new-features)
+   * [Development Workflow Notes](#development-workflow-notes)
+      * [Before submitting your PR](#before-submitting-your-pr)
+      * [During the PR review](#during-the-pr-review)
+      * [Reviewer notes](#reviewer-notes)
+      * [Python notes](#python-notes)
+
+<!-- Added by: advaitjain, at: Wed 02 Sep 2020 02:55:16 PM PDT -->
+
+<!--te-->
+
+
 # Resources
 
 A
@@ -179,10 +205,7 @@ to determine if the requested feature aligns with the TFLM roadmap.
 
  1. Make sure your code is lint-free.
 
-    Get a copy of cpplint
-    ```
-    git@github.com:google/styleguide.git
-    ```
+    Get a copy of [cpplint](https://github.com/google/styleguide/tree/gh-pages/cpplint)
 
     Run cpplint.py on all modified files in your git tree:
     ```
@@ -202,8 +225,8 @@ to determine if the requested feature aligns with the TFLM roadmap.
     following command (replace `micro_interpreter_test` with the target that you
     want to test:
     ```
-    CC=clang BAZEL_COMPILER=llvm bazel run --copt=-DADDRESS_SANITIZER    
-    --copt=-fsanitize=address --linkopt=-fsanitize=address
+    CC=clang BAZEL_COMPILER=llvm bazel run --copt=-DADDRESS_SANITIZER \
+    --copt=-fsanitize=address --linkopt=-fsanitize=address \
     tensorflow/lite/micro:micro_interpreter_test
     ```
 

--- a/tensorflow/lite/micro/CONTRIBUTING.md
+++ b/tensorflow/lite/micro/CONTRIBUTING.md
@@ -206,19 +206,16 @@ to determine if the requested feature aligns with the TFLM roadmap.
 
  1. Make sure your code is lint-free.
 
-    Get a copy of cpplint
-    ```
-    git@github.com:google/styleguide.git
-    ```
+    Get a copy of [cpplint](https://github.com/google/styleguide/tree/gh-pages/cpplint)
 
     Run cpplint.py on all modified files in your git tree:
     ```
     cpplint.py `git ls-files -m`
     ```
+
  1. Run all the tests for x86, and any other platform that you are modifying.
     ```
     make -f tensorflow/lite/micro/tools/make/Makefile test
-
     ```
 
     Please check the READMEs in the optimized kernel directories for specific

--- a/tensorflow/lite/micro/CONTRIBUTING.md
+++ b/tensorflow/lite/micro/CONTRIBUTING.md
@@ -253,16 +253,7 @@ to determine if the requested feature aligns with the TFLM roadmap.
     # Use your favorite diff tools (e.g. meld) to resolve the conflicts.
     git add <files that were manually resolved>
     git commit
-    # Update the commit message to call out which files were manually resolved for a
-    # conflict. See [this commit](https://github.com/tensorflow/tensorflow/pull/42571/commits/303e22d09a175fdc1093d57fa09b44367851628b) as an example.
     ```
-
-   The benefit of `git merge` and resolving the conflicts is that the github review
-   tool can easily show the reviewer ecatly what part of the merge commit was a
-   manual change, and which parts were files that were automatically merged.
-
-   Additionally, the commit message shows which branch was merged (i.e.
-   upstream/master was merged into your feature branch)
 
  1. If a force push seems to be the only path forward, please stop and let your
     PR reviewer know ***before*** force pushing. We will attempt to do the merge


### PR DESCRIPTION
Making progress towards making the contribution guidelines have more detail (per
issue #42569)

Specifically, this PR:

 * Adds some workflows before creating a PR and during the PR review process.

 * Add some tips that I have found useful as a PR reviewer to keep things moving
   along (especially since not all the checks in Google's internal CI system have
   a counterpart that is visible to external developers.

I'm also trying out a semi-automated way to generate a table of content for our
markdown files using [this tool](https://github.com/ekalinin/github-markdown-toc#auto-insert-and-update-toc).

