### PR TITLE
[TFLM] Fix resize_nearest_neighbor test for debug build.

### DIFF
--- a/tensorflow/lite/micro/kernels/resize_nearest_neighbor_test.cc
+++ b/tensorflow/lite/micro/kernels/resize_nearest_neighbor_test.cc
@@ -48,7 +48,7 @@ void TestResizeNearestNeighbor(const int* input_dims_data, const T* input_data,
                                const int* output_dims_data, T* output_data) {
   TfLiteIntArray* input_dims = IntArrayFromInts(input_dims_data);
 
-  int expected_size_dims_data[] = {2, 1, 2};
+  int expected_size_dims_data[] = {1, 2};
   TfLiteIntArray* expected_size_dims =
       IntArrayFromInts(expected_size_dims_data);
 
@@ -62,6 +62,8 @@ void TestResizeNearestNeighbor(const int* input_dims_data, const T* input_data,
       CreateInt32Tensor(expected_size_data, expected_size_dims),
       TestCreateTensor(output_data, output_dims),
   };
+
+  tensors[1].allocation_type = kTfLiteMmapRo;
 
   TfLiteResizeNearestNeighborParams builtin_data = {false, false};
 

--- a/tensorflow/lite/micro/tools/ci_build/test_x86.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_x86.sh
@@ -36,3 +36,7 @@ readable_run make -j8 -f tensorflow/lite/micro/tools/make/Makefile BUILD_TYPE=re
 # debugging info on failures.
 readable_run make -f tensorflow/lite/micro/tools/make/Makefile clean
 readable_run make -s -j8 -f tensorflow/lite/micro/tools/make/Makefile test
+
+# Also repeat for the debug build.
+readable_run make -f tensorflow/lite/micro/tools/make/Makefile clean
+readable_run make -s -j8 -f tensorflow/lite/micro/tools/make/Makefile BUILD_TYPE=debug test


### PR DESCRIPTION
This fixes #42832 using the patch attached to that issue by @andrewstevens-infineon 

Additionally, added the debug build to the continuous integration to prevent such issues in the future.
