### PR TITLE
Added an example to Arguments in function on_epoch_end.

### DIFF
--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -665,7 +665,8 @@ class Callback(object):
         epoch: Integer, index of epoch.
         logs: Dict, metric results for this training epoch, and for the
           validation epoch if validation is performed. Validation result keys
-          are prefixed with `val_`.
+          are prefixed with `val_`. For training epoch, the values of the  
+         `Model`'s metrics are returned. Example : `{'loss': 0.2, 'acc': 0.7}`.
     """
 
   @doc_controls.for_subclass_implementers


### PR DESCRIPTION
Described the dictionary that will be returned as metric results at the end of the training of each epoch. The example clearly shows that the accuracy and the loss at the end of each epoch can be accessed by the get method as - 
1. `logs.get('loss')`
2. `logs.get('acc')`