### PR TITLE
fix the pylint hang issue while performing sanity checks

### DIFF
--- a/tensorflow/tools/ci_build/ci_build.sh
+++ b/tensorflow/tools/ci_build/ci_build.sh
@@ -162,7 +162,7 @@ mkdir -p ${WORKSPACE}/bazel-ci_build-cache
 # By default we cleanup - remove the container once it finish running (--rm)
 # and share the PID namespace (--pid=host) so the process inside does not have
 # pid 1 and SIGKILL is propagated to the process inside (jenkins can kill it).
-${DOCKER_BINARY} run --rm --pid=host \
+${DOCKER_BINARY} run --rm --name ${DOCKER_IMG_NAME} --pid=host \
     -v ${WORKSPACE}/bazel-ci_build-cache:${WORKSPACE}/bazel-ci_build-cache \
     -e "CI_BUILD_HOME=${WORKSPACE}/bazel-ci_build-cache" \
     -e "CI_BUILD_USER=$(id -u -n)" \

--- a/tensorflow/tools/ci_build/ci_sanity.sh
+++ b/tensorflow/tools/ci_build/ci_sanity.sh
@@ -130,7 +130,7 @@ do_pylint() {
   echo "check whether pylint is available or not."
   echo ""
   ${PYLINT_BIN} --version
-  if [ $? -eq 0 ]
+  if [[ $? -eq 0 ]]
   then
     echo ""
     echo "pylint available, proceeding with pylint sanity check."

--- a/tensorflow/tools/ci_build/ci_sanity.sh
+++ b/tensorflow/tools/ci_build/ci_sanity.sh
@@ -126,6 +126,22 @@ do_pylint() {
 
   PYLINT_BIN="python3 -m pylint"
 
+  echo ""
+  echo "check whether pylint is available or not."
+  echo ""
+  ${PYLINT_BIN} --version
+  if [ $? -eq 0 ]
+  then
+    echo ""
+    echo "pylint available, proceeding with pylint sanity check."
+    echo ""
+  else
+    echo ""
+    echo "pylint not available." >&2
+    echo ""
+    return 1
+  fi
+
   if [[ "$1" == "--incremental" ]]; then
     PYTHON_SRC_FILES=$(get_py_files_to_check --incremental)
 

--- a/tensorflow/tools/ci_build/install/install_pip_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_pip_packages.sh
@@ -96,13 +96,17 @@ pip3 install py-cpuinfo
 
 # pylint==1.6.4 requires python-astroid (>= 1.4.5) requires lazy-object-proxy
 # Latest version of lazy-object-proxy (1.4.2) fails to install from source
-# when using setuptools 39.1.0
+# when using setuptools 39.1.0.
+# NOTE: Using the updated version of pylint for python3 as python2 is EOL,
+# thus using the updated version of lazy-object-proxy==1.4.3
 pip2 install lazy-object-proxy==1.4.1
-pip3 install lazy-object-proxy==1.4.1
+pip3 install lazy-object-proxy==1.4.3
 
-# pylint tests require the following:
+# pylint tests require the following version. pylint==1.6.4 hangs erratically,
+# thus using the updated version of 2.5.3 only for python3 as python2 is EOL
+# and this version is not available.
 pip2 install pylint==1.6.4
-pip3 install pylint==1.6.4
+pip3 install pylint==2.5.3
 
 # pycodestyle tests require the following:
 pip2 install pycodestyle


### PR DESCRIPTION
This PR addresses the issue: https://github.com/tensorflow/tensorflow/issues/41600 by updating the following:
- pylint version update for python3 while performing sanity checks resolves the issue where pylint hangs indefinitely during step 2 of the checklist in `tensorflow/tools/ci_build/ci_sanity.sh`.
- Provides a verbose message if pylint is not installed, so that we fail the step immediately.
-  Name the docker container in `tensorflow/tools/ci_build/ci_build.sh` for clarity purposes.