### PR TITLE
[SE] Include absl/memory/memory.h

### DIFF
--- a/tensorflow/stream_executor/host/BUILD
+++ b/tensorflow/stream_executor/host/BUILD
@@ -54,6 +54,7 @@ cc_library(
         "//tensorflow/stream_executor:stream_executor_headers",
         "//tensorflow/stream_executor/lib",
         "//tensorflow/stream_executor/platform",
+        "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/synchronization",
     ],

--- a/tensorflow/stream_executor/host/host_platform.cc
+++ b/tensorflow/stream_executor/host/host_platform.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <thread>
 
+#include "absl/memory/memory.h"
 #include "absl/strings/str_format.h"
 #include "tensorflow/stream_executor/host/host_gpu_executor.h"
 #include "tensorflow/stream_executor/host/host_platform_id.h"


### PR DESCRIPTION
Otherwise our build environment fails to build it with:
```
external/org_tensorflow/tensorflow/stream_executor/host/host_platform.cc: In member function 'virtual stream_executor::port::StatusOr<std::unique_ptr<stream_executor::StreamExecutor> > stream_executor::host::HostPlatform::GetUncachedExecutor(const stream_executor::StreamExecutorConfig&)':
external/org_tensorflow/tensorflow/stream_executor/host/host_platform.cc:73:25: error: 'make_unique' is not a member of 'absl'
   auto executor = absl::make_unique<StreamExecutor>(
                         ^~~~~~~~~~~
```