### PR TITLE
[TFLite] Fix uint8 MUL operator with broadcast when the scaling factor is >= 1

### DIFF
--- a/tensorflow/lite/kernels/internal/optimized/optimized_ops.h
+++ b/tensorflow/lite/kernels/internal/optimized/optimized_ops.h
@@ -2536,9 +2536,9 @@ inline void MulSimpleBroadcast(int size, const ArithmeticParams& params,
     const int32 input2_val = params.input2_offset + input2_data[i];
     const int32 unclamped_result =
         params.output_offset +
-        MultiplyByQuantizedMultiplierSmallerThanOneExp(input1_val * input2_val,
-                                                       params.output_multiplier,
-                                                       params.output_shift);
+        MultiplyByQuantizedMultiplier(input1_val * input2_val,
+                                      params.output_multiplier,
+                                      params.output_shift);
     const int32 clamped_output =
         std::min(params.quantized_activation_max,
                  std::max(params.quantized_activation_min, unclamped_result));

--- a/tensorflow/lite/kernels/mul_test.cc
+++ b/tensorflow/lite/kernels/mul_test.cc
@@ -113,7 +113,7 @@ TEST(FloatMulOpTest, ActivationRELU_N1_TO_1) {
 }
 
 TEST(FloatMulOpTest, VariousInputShapes) {
-  std::vector<std::vector<int>> test_shapes = {
+  const std::vector<std::vector<int>> test_shapes = {
       {6}, {2, 3}, {2, 1, 3}, {1, 3, 1, 2}};
   for (int i = 0; i < test_shapes.size(); ++i) {
     FloatMulOpModel m({TensorType_FLOAT32, test_shapes[i]},
@@ -130,7 +130,7 @@ TEST(FloatMulOpTest, VariousInputShapes) {
 }
 
 TEST(FloatMulOpTest, WithScalarBroadcast) {
-  std::vector<std::vector<int>> test_shapes = {
+  const std::vector<std::vector<int>> test_shapes = {
       {6}, {2, 3}, {2, 1, 3}, {1, 3, 1, 2}};
   for (int i = 0; i < test_shapes.size(); ++i) {
     FloatMulOpModel m({TensorType_FLOAT32, test_shapes[i]},
@@ -147,7 +147,7 @@ TEST(FloatMulOpTest, WithScalarBroadcast) {
 }
 
 TEST(FloatMulOpTest, WithBroadcast) {
-  std::vector<std::vector<int>> test_shapes = {
+  const std::vector<std::vector<int>> test_shapes = {
       {2, 4}, {2, 1, 4}, {1, 2, 4}, {1, 2, 1, 4}};
   for (int i = 0; i < test_shapes.size(); ++i) {
     FloatMulOpModel m({TensorType_FLOAT32, test_shapes[i]},
@@ -166,9 +166,9 @@ TEST(FloatMulOpTest, WithBroadcast) {
 
 TEST(FloatMulOpTest, MixedBroadcast) {
   const std::vector<int> base_shape = {2, 3, 1, 2};
-  std::vector<std::vector<int>> test_shapes = {
+  const std::vector<std::vector<int>> test_shapes = {
       {1, 1, 3, 2}, {1, 3, 1, 2}, {2, 1, 3, 1}, {2, 3, 1, 1}};
-  std::vector<std::vector<float>> test_outputs = {
+  const std::vector<std::vector<float>> test_outputs = {
       {-0.06f, 0.69f,  0.12f,  1.15f, -0.30f, 2.07f,  0.18f,  0.15f, -0.36f,
        0.25f,  0.90f,  0.45f,  0.16f, -0.33f, -0.32f, -0.55f, 0.80f, -0.99f,
        0.24f,  0.84f,  -0.48f, 1.40f, 1.20f,  2.52f,  -0.32f, 0.00f, 0.64f,
@@ -214,7 +214,7 @@ TEST(FloatMulOpTest, MixedBroadcast) {
 }
 
 TEST(FloatMulOpTest, WithBroadcast2Elements) {
-  std::vector<std::vector<int>> test_shapes = {
+  const std::vector<std::vector<int>> test_shapes = {
       {2, 2}, {2, 1, 2}, {1, 2, 2}, {1, 2, 1, 2}};
   for (int i = 0; i < test_shapes.size(); ++i) {
     FloatMulOpModel m({TensorType_FLOAT32, test_shapes[i]},
@@ -250,7 +250,7 @@ TEST(IntegerMulOpTest, ActivationRELU_N1_TO_1) {
 }
 
 TEST(IntegerMulOpTest, VariousInputShapes) {
-  std::vector<std::vector<int>> test_shapes = {
+  const std::vector<std::vector<int>> test_shapes = {
       {6}, {2, 3}, {2, 1, 3}, {1, 3, 1, 2}};
   for (int i = 0; i < test_shapes.size(); ++i) {
     IntegerMulOpModel m({TensorType_INT32, test_shapes[i]},
@@ -265,7 +265,7 @@ TEST(IntegerMulOpTest, VariousInputShapes) {
 }
 
 TEST(IntegerMulOpTest, WithBroadcast) {
-  std::vector<std::vector<int>> test_shapes = {
+  const std::vector<std::vector<int>> test_shapes = {
       {6}, {2, 3}, {2, 1, 3}, {1, 3, 1, 2}};
   for (int i = 0; i < test_shapes.size(); ++i) {
     IntegerMulOpModel m({TensorType_INT32, test_shapes[i]},
@@ -392,12 +392,12 @@ float GetTolerance(int min, int max) {
 
 template <TensorType tensor_type, typename integer_dtype>
 void WithBroadcast() {
-  float kQuantizedTolerance = GetTolerance(-3.0, 3.0);
-  std::vector<std::vector<int>> test_shapes = {
+  const float kQuantizedTolerance = GetTolerance(-3.0, 3.0);
+  const std::vector<std::vector<int>> test_shapes = {
       {6}, {2, 3}, {2, 1, 3}, {1, 3, 1, 2}};
   // Test with a smaller than 1 and greater than 1 quantization multiplier
-  std::vector<std::pair<float, float>> test_input_range = {{-3.0, 3.0},
-                                                           {-6.0, 6.0}};
+  const std::vector<std::pair<float, float>> test_input_range = {{-3.0, 3.0},
+                                                                 {-6.0, 6.0}};
   for (int i = 0; i < test_shapes.size(); ++i) {
     for (int j = 0; j < test_input_range.size(); ++j) {
       const std::pair<float, float>& input_range = test_input_range[j];
@@ -420,11 +420,11 @@ void WithBroadcast() {
 
 template <enum TensorType tensor_type, typename integer_dtype>
 void QuantizedWithMixedBroadcast() {
-  float kQuantizedTolerance = GetTolerance(-3.f, 3.f);
+  const float kQuantizedTolerance = GetTolerance(-3.f, 3.f);
   const std::vector<int> base_shape = {2, 3, 1, 2};
-  std::vector<std::vector<int>> test_shapes = {
+  const std::vector<std::vector<int>> test_shapes = {
       {1, 1, 3, 2}, {1, 3, 1, 2}, {2, 1, 3, 1}, {2, 3, 1, 1}};
-  std::vector<std::vector<float>> test_outputs = {
+  const std::vector<std::vector<float>> test_outputs = {
       {-0.06f, 0.69f,  0.12f,  1.15f, -0.30f, 2.07f,  0.18f,  0.15f, -0.36f,
        0.25f,  0.90f,  0.45f,  0.16f, -0.33f, -0.32f, -0.55f, 0.80f, -0.99f,
        0.24f,  0.84f,  -0.48f, 1.40f, 1.20f,  2.52f,  -0.32f, 0.00f, 0.64f,


### PR DESCRIPTION
Hi,

The uint8 `MUL` operator with broadcast uses `MulSimpleBroadcast` to do the multiplication which in turn uses `MultiplyByQuantizedMultiplierSmallerThanOneExp` for the scaling. The problem is that in the `Prepare` method of `MUL` there is no guarantee that the scaling factor is smaller than one (it's simply quantized with `QuantizeMultiplier` without any check) .

I changed the `MulSimpleBroadcast` to use `MultiplyByQuantizedMultiplier` instead and adapted the multiplication with broadcast test to also test the case where the scaling factor is greater or equal to one.

The following script can be used to reproduce the bug.

```python
import numpy as np
import tensorflow as tf

input1_shape = (2,)
# Doesn't work (broadcasting)
input2_shape = (1,)
# Works (no broadcasting)
# input2_shape = (2,)

def get_dequantized_value(quantized_val, params):
    quant_params = params["quantization_parameters"]
    scale = quant_params["scales"]
    zero_point = quant_params["zero_points"]

    return (quantized_val - zero_point) * scale

# Model
input1 = tf.keras.Input(shape=input1_shape)
input2 = tf.keras.Input(shape=input2_shape)
output = tf.keras.layers.Multiply()([input1, input2])
model = tf.keras.Model(inputs=[input1, input2], outputs=output)
model.save("model.h5")

# Convert to TFLite
converter = tf.compat.v1.lite.TFLiteConverter.from_keras_model_file("model.h5")
converter.inference_type = tf.compat.v1.lite.constants.QUANTIZED_UINT8
input_arrays = converter.get_input_arrays()
converter.quantized_input_stats = {input_arrays[0]: (0.0, 3.0),
                                   input_arrays[1]: (0.0, 3.0)}
converter.default_ranges_stats = (0, 9.0)
tflite_model = converter.convert()

# Test TFLite
interpreter = tf.lite.Interpreter(model_content=tflite_model)
interpreter.allocate_tensors()

input1 = np.full(shape=(1, *input1_shape), fill_value=1, dtype=np.uint8)
interpreter.set_tensor(interpreter.get_input_details()[0]["index"], input1)
print("input1: ", get_dequantized_value(input1, interpreter.get_input_details()[0]))

input2 = np.full(shape=(1, *input2_shape), fill_value=1, dtype=np.uint8)
interpreter.set_tensor(interpreter.get_input_details()[1]["index"], input2)
print("input2: ", get_dequantized_value(input2, interpreter.get_input_details()[1]))

interpreter.invoke()

output = interpreter.get_tensor(interpreter.get_output_details()[0]["index"])
print("output: ", get_dequantized_value(output, interpreter.get_output_details()[0]))
```