### PR TITLE
Allow dict input_spec for keras.Model

### DIFF
--- a/tensorflow/python/keras/engine/training.py
+++ b/tensorflow/python/keras/engine/training.py
@@ -350,11 +350,11 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
     if input_shape is None:
       raise ValueError('Input shape must be defined when calling build on a '
                        'model subclass network.')
-    valid_types = (tuple, list, tensor_shape.TensorShape)
+    valid_types = (tuple, list, dict, tensor_shape.TensorShape)
     if not isinstance(input_shape, valid_types):
       raise ValueError('Specified input shape is not one of the valid types. '
-                       'Please specify a batch input shape of type tuple or '
-                       'list of input shapes. User provided '
+                       'Please specify a batch input shape of type tuple, '
+                       'dict, or list of input shapes. User provided '
                        'input type: {}'.format(type(input_shape)))
 
     if input_shape and not self.inputs:


### PR DESCRIPTION
This PR tries to address the issue raised in #42691 where
usage of dict will cause ValueError in keras.Model.

This PR fixes #42691.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>