### PR TITLE
[TF-TRT] Adding mixed precision support for non converted OPs & native segments

### DIFF
--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision.h
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision.h
@@ -24,6 +24,10 @@ namespace grappler {
 
 enum class AutoMixedPrecisionMode { CUDA, MKL };
 
+// Note: This is primarily used by the tf.experimental.tensorrt. Converter class
+// to use mixed precision on ops not converted by TensorRT. It is also used for
+// the soon-to-be-deprecated enable_mixed_precision_graph_rewrite API.
+//
 // Convert data types to float16 or bfloat16 where appropriate to improve
 // performance on GPUs or CPUs.
 class AutoMixedPrecision : public GraphOptimizer {

--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -119,7 +119,7 @@ class TrtConversionParams(
         "rewriter_config_template", "max_workspace_size_bytes",
         "precision_mode", "minimum_segment_size", "is_dynamic_op",
         "maximum_cached_engines", "use_calibration", "max_batch_size",
-        "allow_build_at_runtime"
+        "allow_build_at_runtime", "allow_mixed_precision_on_unconverted_ops"
     ])):
   """Parameters that are used for TF-TRT conversion.
 
@@ -160,6 +160,10 @@ class TrtConversionParams(
       inputs during runtime, then a new TensorRT engine is built at runtime if
       allow_build_at_runtime=True, and otherwise native TF is used. This
       argument is only effective if is_dynamic_op=True.
+    allow_mixed_precision_on_unconverted_ops: whether to allow TensorFlow to
+      use mixed precision on the operations which are not converted to inside
+      a TensorRT engine. This argument has a default value of True, and is
+      only effective if the requested `precision_mode` is lower than FP32.
   """
 
   def __new__(cls,
@@ -171,13 +175,15 @@ class TrtConversionParams(
               maximum_cached_engines=1,
               use_calibration=True,
               max_batch_size=1,
-              allow_build_at_runtime=True):
+              allow_build_at_runtime=True,
+              allow_mixed_precision_on_unconverted_ops=True):
     return super(TrtConversionParams,
                  cls).__new__(cls, rewriter_config_template,
                               max_workspace_size_bytes, precision_mode,
                               minimum_segment_size, is_dynamic_op,
                               maximum_cached_engines, use_calibration,
-                              max_batch_size, allow_build_at_runtime)
+                              max_batch_size, allow_build_at_runtime,
+                              allow_mixed_precision_on_unconverted_ops)
 
 
 DEFAULT_TRT_CONVERSION_PARAMS = TrtConversionParams()
@@ -247,6 +253,13 @@ def _check_conversion_params(conversion_params, is_v2=False):
          "if is_dynamic_op=False, therefore assuming "
          "allow_build_at_runtime=False. If building TensorRT engines "
          "at runtime is desired, set is_dynamic_op=True."))
+
+  if not conversion_params.allow_mixed_precision_on_unconverted_ops:
+      tf_logging.warn("Mixed precision on OPs not converted by TF-TRT has been "
+                      "deactivated. We recommend setting: "
+                      "`allow_mixed_precision_on_unconverted_ops=True` for "
+                      "performance reasons."
+      )
 
 
 def _check_trt_version_compatibility():
@@ -347,6 +360,14 @@ def get_tensorrt_rewriter_config(conversion_params,
     rewriter_config_with_trt.CopyFrom(
         conversion_params.rewriter_config_template)
 
+  if (conversion_params.allow_mixed_precision_on_unconverted_ops and
+      conversion_params.precision_mode != TrtPrecisionMode.FP32):
+      rewriter_config_with_trt.auto_mixed_precision = \
+          rewriter_config_pb2.RewriterConfig.ON
+  else:
+      rewriter_config_with_trt.auto_mixed_precision = \
+          rewriter_config_pb2.RewriterConfig.OFF
+
   # Disabling optimizers should happen after CopyFrom the template
   # otherwise the template can overwrite the disablement.
   if disable_non_trt_optimizers:
@@ -366,6 +387,7 @@ def get_tensorrt_rewriter_config(conversion_params,
         rewriter_config_pb2.RewriterConfig.NO_MEM_OPT)
     rewriter_config_with_trt.pin_to_host_optimization = off
     rewriter_config_with_trt.auto_parallel.enable = False
+    rewriter_config_with_trt.auto_mixed_precision = off
 
   return rewriter_config_with_trt
 
@@ -439,7 +461,8 @@ class TrtGraphConverter(object):
                minimum_segment_size=3,
                is_dynamic_op=False,
                maximum_cached_engines=1,
-               use_calibration=True):
+               use_calibration=True,
+               allow_mixed_precision_on_unconverted_ops=True):
     """Initialize the converter.
 
     Args:
@@ -478,6 +501,10 @@ class TrtGraphConverter(object):
         will occur. Please note that accuracy may be negatively affected if
         there is a mismatch between which tensors TRT quantizes and which
         tensors were trained with fake quantization.
+      allow_mixed_precision_on_unconverted_ops: whether to allow TensorFlow to
+        use mixed precision on the operations which are not converted to inside
+        a TensorRT engine. This argument has a default value of True, and is
+        only effective if the requested `precision_mode` is lower than FP32.
 
     Raises:
       ValueError: if the combination of the parameters is invalid.
@@ -537,7 +564,8 @@ class TrtGraphConverter(object):
         maximum_cached_engines=maximum_cached_engines,
         use_calibration=use_calibration,
         max_batch_size=max_batch_size,
-        allow_build_at_runtime=True)
+        allow_build_at_runtime=True,
+        allow_mixed_precision_on_unconverted_ops=allow_mixed_precision_on_unconverted_ops)
     _check_conversion_params(self._conversion_params)
 
   def _run_conversion(self):

--- a/tensorflow/tools/api/golden/v2/tensorflow.experimental.tensorrt.-conversion-params.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.experimental.tensorrt.-conversion-params.pbtxt
@@ -8,6 +8,10 @@ tf_class {
     mtype: "<type \'property\'>"
   }
   member {
+    name: "allow_mixed_precision_on_unconverted_ops"
+    mtype: "<type \'property\'>"
+  }
+  member {
     name: "is_dynamic_op"
     mtype: "<type \'property\'>"
   }


### PR DESCRIPTION
This PR adds support for TF-TRT mixed precision on the Tensorflow OPs that are not converted by TF-TRT and the fallback native segments.

**Changes in the API:**
- `TrtConversionParams` obtains a new parameter: `allow_mixed_precision_on_unconverted_ops`, True by default. Can be turned off manually.
- This behavior is **only active** if `TrtConversionParams.precision_mode < FP32` (in other words if user request FP16 or INT8)
