### PR TITLE
Fixed SeparableConv1D self._compute_causal_padding missing inputs arg

### DIFF
--- a/tensorflow/python/keras/layers/convolutional.py
+++ b/tensorflow/python/keras/layers/convolutional.py
@@ -2029,7 +2029,7 @@ class SeparableConv1D(SeparableConv):
 
   def call(self, inputs):
     if self.padding == 'causal':
-      inputs = array_ops.pad(inputs, self._compute_causal_padding())
+      inputs = array_ops.pad(inputs, self._compute_causal_padding(inputs))
     if self.data_format == 'channels_last':
       strides = (1,) + self.strides * 2 + (1,)
       spatial_start_dim = 1


### PR DESCRIPTION
inputs argument is missing in a call of self._compute_causal_padding in SeparableConv1D. If you attempt to create a SeparableConv1D with causal padding, the following error message will appear:

    /usr/local/lib/python3.6/dist-packages/tensorflow/python/keras/engine/base_layer.py:985 __call__  **
        outputs = call_fn(inputs, *args, **kwargs)
    /usr/local/lib/python3.6/dist-packages/tensorflow/python/keras/engine/sequential.py:386 call
        outputs = layer(inputs, **kwargs)
    /usr/local/lib/python3.6/dist-packages/tensorflow/python/keras/engine/base_layer.py:985 __call__
        outputs = call_fn(inputs, *args, **kwargs)
    /usr/local/lib/python3.6/dist-packages/tensorflow/python/keras/layers/convolutional.py:2002 call
        inputs = array_ops.pad(inputs, self._compute_causal_padding())

    TypeError: _compute_causal_padding() missing 1 required positional argument: 'inputs'

This PR fixes it.