### PR TITLE
Fix cmake build on mingw compiler

### DIFF
--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -177,7 +177,11 @@ if(CMAKE_SYSTEM_NAME MATCHES "Windows")
   list(APPEND TFLITE_TARGET_PRIVATE_OPTIONS "-DNOMINMAX" "-DNOGDI")
   # lite/kernels/conv.cc has more than 64k sections so enable /bigobj to
   # support compilation with MSVC2015.
-  list(APPEND TFLITE_TARGET_PRIVATE_OPTIONS "/bigobj")
+  if(MSVC)
+    list(APPEND TFLITE_TARGET_PRIVATE_OPTIONS "/bigobj")
+  elseif(CMAKE_COMPILER_IS_GNUCXX)
+    list(APPEND TFLITE_TARGET_PRIVATE_OPTIONS "-Wa,-mbig-obj")
+  endif()
 endif()
 # Build a list of source files to compile into the TF Lite library.
 populate_tflite_source_vars("." TFLITE_SRCS)

--- a/tensorflow/lite/shared_library.h
+++ b/tensorflow/lite/shared_library.h
@@ -33,11 +33,11 @@ class SharedLibrary {
     return ::LoadLibrary(lib);
   }
   static inline void* GetLibrarySymbol(void* handle, const char* symbol) {
-    return static_cast<void*>(
+    return reinterpret_cast<void*>(
         GetProcAddress(static_cast<HMODULE>(handle), symbol));
   }
   static inline void* GetSymbol(const char* symbol) {
-    return static_cast<void*>(GetProcAddress(nullptr, symbol));
+    return reinterpret_cast<void*>(GetProcAddress(nullptr, symbol));
   }
   static inline int UnLoadLibrary(void* handle) {
     return FreeLibrary(static_cast<HMODULE>(handle));


### PR DESCRIPTION
* `/bigobj` is a flag for MSVC compiler, use `-Wa,-mbig-obj` instead for gcc.
* use reinterpret_cast for the cast to void* from FARPROC .