### PR TITLE
XLA Asynchronous compilation

### DIFF
--- a/tensorflow/compiler/jit/flags.cc
+++ b/tensorflow/compiler/jit/flags.cc
@@ -219,8 +219,8 @@ void AllocateAndParseFlags() {
             &ops_flags->tf_xla_always_defer_compilation, ""),
        Flag("tf_xla_async_compilation",
             &ops_flags->tf_xla_async_compilation,
-            "When lazy compilation is enabled, asynchronous compilation starts"
-            "the cluster compilation in the background, and the fallback path"
+            "When lazy compilation is enabled, asynchronous compilation starts "
+            "the cluster compilation in the background, and the fallback path "
             "is executed until the compilation has finished."),
 
        Flag("tf_introduce_floating_point_jitter_to_tensors",

--- a/tensorflow/compiler/jit/flags.cc
+++ b/tensorflow/compiler/jit/flags.cc
@@ -163,6 +163,7 @@ void AllocateAndParseFlags() {
 
   ops_flags = new XlaOpsCommonFlags;
   ops_flags->tf_xla_always_defer_compilation = false;
+  ops_flags->tf_xla_async_compilation = false;
 
   jitter_flags = new IntroduceFloatingPointJitterPassFlags;
   jitter_flags->jitter_amount = 1e-5;
@@ -216,6 +217,11 @@ void AllocateAndParseFlags() {
 
        Flag("tf_xla_always_defer_compilation",
             &ops_flags->tf_xla_always_defer_compilation, ""),
+       Flag("tf_xla_async_compilation",
+            &ops_flags->tf_xla_async_compilation,
+            "When lazy compilation is enabled, asynchronous compilation starts"
+            "the cluster compilation in the background, and the fallback path"
+            "is executed until the compilation has finished."),
 
        Flag("tf_introduce_floating_point_jitter_to_tensors",
             setter_for_jitter_tensor_names, "",

--- a/tensorflow/compiler/jit/flags.h
+++ b/tensorflow/compiler/jit/flags.h
@@ -99,7 +99,7 @@ struct XlaOpsCommonFlags {
   // XLA clusters always run in the TF executor.  Defaults to false.
   bool tf_xla_always_defer_compilation;
   // If true, _XlaCompile compiles the cluster asynchronously with respect to
-  // the main execution. The fall back path is taken while compilation happens.
+  // the main execution. The fallback path is taken while compilation happens.
   bool tf_xla_async_compilation;
 };
 

--- a/tensorflow/compiler/jit/flags.h
+++ b/tensorflow/compiler/jit/flags.h
@@ -98,6 +98,9 @@ struct XlaOpsCommonFlags {
   // If true, _XlaCompile always refuses to compile the cluster, which means the
   // XLA clusters always run in the TF executor.  Defaults to false.
   bool tf_xla_always_defer_compilation;
+  // If true, _XlaCompile compiles the cluster asynchronously with respect to
+  // the main execution. The fall back path is taken while compilation happens.
+  bool tf_xla_async_compilation;
 };
 
 // Flags for the build_xla_ops pass.

--- a/tensorflow/compiler/jit/get_compiler_ir.cc
+++ b/tensorflow/compiler/jit/get_compiler_ir.cc
@@ -37,7 +37,8 @@ static xla::StatusOr<xla::LocalExecutable*> GetLocalExecutable(
     const XlaCompiler::Options& options,
     const XlaCompiler::CompileOptions& compile_options,
     const NameAttrList& function, XlaCompilationCache* cache,
-    std::vector<XlaCompiler::Argument>& args, const XlaCompiler& compiler) {
+    const std::vector<XlaCompiler::Argument>& args,
+    const XlaCompiler& compiler) {
   const XlaCompiler::CompilationResult* compilation_result = nullptr;
   xla::LocalExecutable* executable = nullptr;
   TF_RETURN_IF_ERROR(cache->Compile(options, function, args, compile_options,

--- a/tensorflow/compiler/jit/get_compiler_ir.cc
+++ b/tensorflow/compiler/jit/get_compiler_ir.cc
@@ -37,7 +37,7 @@ static xla::StatusOr<xla::LocalExecutable*> GetLocalExecutable(
     const XlaCompiler::Options& options,
     const XlaCompiler::CompileOptions& compile_options,
     const NameAttrList& function, XlaCompilationCache* cache,
-    absl::Span<XlaCompiler::Argument const> args, const XlaCompiler& compiler) {
+    std::vector<XlaCompiler::Argument>& args, const XlaCompiler& compiler) {
   const XlaCompiler::CompilationResult* compilation_result = nullptr;
   xla::LocalExecutable* executable = nullptr;
   TF_RETURN_IF_ERROR(cache->Compile(options, function, args, compile_options,
@@ -100,12 +100,10 @@ xla::StatusOr<std::string> GetCompilerIr(
       }));
   core::ScopedUnref cache_ref(cache);
 
-  absl::optional<se::TfAllocatorAdapter> tf_allocator_adapter;
-
   XlaCompiler::Options options =
       GenerateCompilerOptions(*cache, *flr, dev,
                               /*stream=*/nullptr, platform_info,
-                              /*has_ref_vars=*/false, &tf_allocator_adapter);
+                              /*has_ref_vars=*/false);
 
   XlaCompiler::CompileOptions compile_options;
   compile_options.always_return_tuple = false;

--- a/tensorflow/compiler/jit/kernels/xla_ops.cc
+++ b/tensorflow/compiler/jit/kernels/xla_ops.cc
@@ -245,7 +245,6 @@ void XlaLocalLaunchBase::Compute(OpKernelContext* ctx) {
   se::Stream* stream =
       ctx->op_device_context() ? ctx->op_device_context()->stream() : nullptr;
 
-  absl::optional<se::TfAllocatorAdapter> tf_allocator_adapter;
   se::DeviceMemoryAllocator* allocator =
       GetAllocator(ctx->device(), stream, platform_info_).get();
   int device_ordinal = stream ? stream->parent()->device_ordinal()

--- a/tensorflow/compiler/jit/kernels/xla_ops.cc
+++ b/tensorflow/compiler/jit/kernels/xla_ops.cc
@@ -244,9 +244,9 @@ void XlaLocalLaunchBase::Compute(OpKernelContext* ctx) {
 
   se::Stream* stream =
       ctx->op_device_context() ? ctx->op_device_context()->stream() : nullptr;
-
-  se::DeviceMemoryAllocator* allocator =
-      GetAllocator(ctx->device(), stream, platform_info_).get();
+  std::shared_ptr<se::DeviceMemoryAllocator> allocator_ptr =
+      GetAllocator(ctx->device(), stream, platform_info_);
+  se::DeviceMemoryAllocator* allocator = allocator_ptr.get();
   int device_ordinal = stream ? stream->parent()->device_ordinal()
                               : client->default_device_ordinal();
   XlaComputationLaunchContext launch_context(
@@ -467,8 +467,9 @@ void XlaRunOp::Compute(OpKernelContext* ctx) {
 
   se::Stream* stream =
       ctx->op_device_context() ? ctx->op_device_context()->stream() : nullptr;
-  se::DeviceMemoryAllocator* allocator =
-      GetAllocator(ctx->device(), stream, platform_info_).get();
+  std::shared_ptr<se::DeviceMemoryAllocator> allocator_ptr =
+      GetAllocator(ctx->device(), stream, platform_info_);
+  se::DeviceMemoryAllocator* allocator = allocator_ptr.get();
   int device_ordinal = stream ? stream->parent()->device_ordinal()
                               : closure.client()->default_device_ordinal();
   XlaComputationLaunchContext launch_context(

--- a/tensorflow/compiler/jit/xla_compilation_cache.cc
+++ b/tensorflow/compiler/jit/xla_compilation_cache.cc
@@ -387,7 +387,7 @@ Status XlaCompilationCache::CompileAsynchronous(
     const std::function<Status(XlaCompiler* compiler,
                                const std::vector<XlaCompiler::Argument>& args,
                                XlaCompiler::CompilationResult*)>& compile_fn) {
-  entry->compile_state = CompileState::kCompiling; // Still under caller's lock.
+  entry->compile_state = CompileState::kCompiling;
   {
     mutex_lock lock(async_compilation_.async_compilation_mu_);
     async_compilation_.num_ongoing_compilations++;
@@ -539,14 +539,12 @@ Status XlaCompilationCache::CompileImpl(
 
       if (compile_mode == CompileMode::kAsync) {
         // asynchronous compilation is enabled.
-        {
-          mutex_lock lock(async_compilation_.async_compilation_mu_);
-          if (async_compilation_.num_ongoing_compilations >=
-                async_compilation_.kMaxNumOngoingCompilations) {
-            VLOG(2) << "Not asynchronously compiling cluster " << function.name()
-                    << " because of too many ongoing compilations.";
-            return false;
-          }
+        mutex_lock lock(async_compilation_.async_compilation_mu_);
+        if (async_compilation_.num_ongoing_compilations >=
+              async_compilation_.kMaxNumOngoingCompilations) {
+          VLOG(2) << "Not asynchronously compiling cluster " << function.name()
+                  << " because of too many ongoing compilations.";
+          return false;
         }
       }
 

--- a/tensorflow/compiler/jit/xla_compilation_cache.cc
+++ b/tensorflow/compiler/jit/xla_compilation_cache.cc
@@ -387,7 +387,7 @@ Status XlaCompilationCache::CompileAsynchronous(
     const std::function<Status(XlaCompiler* compiler,
                                const std::vector<XlaCompiler::Argument>& args,
                                XlaCompiler::CompilationResult*)>& compile_fn) {
-  entry->compile_state = CompileState::kCompiling; // still under caller's lock.
+  entry->compile_state = CompileState::kCompiling; // Still under caller's lock.
   {
     mutex_lock lock(async_compilation_.async_compilation_mu_);
     async_compilation_.num_ongoing_compilations++;

--- a/tensorflow/compiler/jit/xla_compilation_cache.cc
+++ b/tensorflow/compiler/jit/xla_compilation_cache.cc
@@ -56,7 +56,7 @@ constexpr int64 XlaCompilationCache::kDefaultCompilationThreshold;
 
 XlaCompilationCache::XlaCompilationCache(xla::LocalClient* client,
                                          DeviceType device_type)
-    : client_(client), device_type_(std::move(device_type)) {}
+    : client_(client), device_type_(std::move(device_type)), async_compilation_() {}
 
 XlaCompilationCache::~XlaCompilationCache() {
   // Ensure any use of our programs have completed by waiting for all stream
@@ -170,7 +170,7 @@ Status XlaCompilationCache::BuildExecutable(
                                        ? options.device_ordinal
                                        : client_->default_device_ordinal());
   build_options.set_result_layout(result.xla_output_shape);
-  build_options.set_device_allocator(options.device_allocator);
+  build_options.set_device_allocator(options.device_allocator.get());
   build_options.set_alias_passthrough_params(options.alias_passthrough_params);
   build_options.mutable_debug_options()->set_xla_detailed_logging(
       options.detailed_logging);
@@ -184,21 +184,20 @@ Status XlaCompilationCache::BuildExecutable(
 
 Status XlaCompilationCache::Compile(
     const XlaCompiler::Options& options, const NameAttrList& function,
-    absl::Span<const XlaCompiler::Argument> args,
+    const std::vector<XlaCompiler::Argument>& args,
     const XlaCompiler::CompileOptions& compile_options,
     CompileMode compile_mode,
     const XlaCompiler::CompilationResult** out_compilation_result,
     xla::LocalExecutable** out_executable) {
-  absl::optional<int64> compile_threshold;
-  if (compile_mode == CompileMode::kLazy) {
-    compile_threshold = kDefaultCompilationThreshold;
-  }
-  auto compile_fn = [&](XlaCompiler* compiler,
+  // compile_fn can be called asynchronously. Make sure all required arguments
+  // are passed by value.
+  auto compile_fn = [&, compile_options, function](
+                        XlaCompiler* compiler,
+                        const std::vector<XlaCompiler::Argument>& args,
                         XlaCompiler::CompilationResult* result) {
     return compiler->CompileFunction(compile_options, function, args, result);
   };
-  return CompileImpl(options, function, args, compile_fn,
-                     /*compile_threshold=*/compile_threshold,
+  return CompileImpl(options, function, args, compile_fn, compile_mode,
                      out_compilation_result, out_executable);
 }
 
@@ -261,7 +260,7 @@ static xla::StatusOr<std::unique_ptr<Graph>> CreateGraph(
 
 Status XlaCompilationCache::CompileSingleOp(
     const XlaCompiler::Options& options,
-    absl::Span<const XlaCompiler::Argument> args, OpKernelContext* ctx,
+    const std::vector<XlaCompiler::Argument>& args, OpKernelContext* ctx,
     const XlaCompiler::CompileOptions& compile_options,
     const XlaCompiler::CompilationResult** out_compilation_result,
     xla::LocalExecutable** out_executable) {
@@ -274,6 +273,7 @@ Status XlaCompilationCache::CompileSingleOp(
   // and causes false uniqueness between nodes.
   name.mutable_attr()->erase("_class");
   auto compile_op = [&](XlaCompiler* compiler,
+                        const std::vector<XlaCompiler::Argument>& args,
                         XlaCompiler::CompilationResult* result) {
     std::vector<DataType> result_dtypes(ctx->num_outputs());
     for (int i = 0, end = result_dtypes.size(); i < end; ++i) {
@@ -307,8 +307,7 @@ Status XlaCompilationCache::CompileSingleOp(
         options.device_type.type_string(), compile_options.use_tuple_arg,
         *options.flib_def, debug_info, options.shape_representation_fn, result);
   };
-  return CompileImpl(options, name, args, compile_op,
-                     /*compile_threshold=*/absl::nullopt,
+  return CompileImpl(options, name, args, compile_op, CompileMode::kStrict,
                      out_compilation_result, out_executable);
 }
 
@@ -326,12 +325,110 @@ void LogOnceXlaCompiledFirstCluster() {
 }
 }  // namespace
 
+Status XlaCompilationCache::CompileStrict(
+    Entry* entry, const XlaCompiler::Options& options,
+    const std::vector<XlaCompiler::Argument>& args,
+    const string &function_name,
+    const std::function<Status(XlaCompiler* compiler,
+                               const std::vector<XlaCompiler::Argument>& args,
+                               XlaCompiler::CompilationResult*)>& compile_fn) {
+  tensorflow::Env* env = tensorflow::Env::Default();
+  const uint64 compile_start_us = env->NowMicros();
+
+  XlaCompiler compiler(options);
+  entry->compile_state = CompileState::kCompiled;
+
+  entry->compilation_status =
+      compile_fn(&compiler, args, &entry->compilation_result);
+  TF_RETURN_IF_ERROR(entry->compilation_status);
+  CHECK_EQ(entry->executable.get(), nullptr);
+  entry->compilation_status =
+      BuildExecutable(options, entry->compilation_result, &entry->executable);
+
+  const uint64 compile_end_us = env->NowMicros();
+  const uint64 compile_time_us = compile_end_us - compile_start_us;
+  metrics::UpdateXlaCompilationTime(compile_time_us);
+  {
+    mutex_lock lock(cluster_compile_stats_mu_);
+    auto it = cluster_compile_stats_.find(function_name);
+    const uint64 compile_time_s = compile_time_us / 1.0e6;
+    it->second.compile_count++;
+    it->second.cumulative_compile_time_us += compile_time_us;
+
+    LogOnceXlaCompiledFirstCluster();
+    VLOG(1) << "compiled " << function_name << " "
+            << it->second.compile_count
+            << " times, compile time: " << compile_time_us
+            << " us, cumulative: " << it->second.cumulative_compile_time_us
+            << " us ("
+            << tensorflow::strings::HumanReadableElapsedTime(compile_time_s)
+            << " / "
+            << tensorflow::strings::HumanReadableElapsedTime(
+                   it->second.cumulative_compile_time_us / 1.0e6)
+            << ")";
+
+    XlaJitCompilationActivity jit_compilation_activity;
+    jit_compilation_activity.set_cluster_name(function_name);
+    jit_compilation_activity.set_compile_count(it->second.compile_count);
+    jit_compilation_activity.set_compile_time_us(compile_time_us);
+    jit_compilation_activity.set_cumulative_compile_time_us(
+        it->second.cumulative_compile_time_us);
+    TF_RETURN_IF_ERROR(
+        BroadcastXlaActivity(std::move(jit_compilation_activity)));
+  }
+
+  return Status::OK();
+}
+
+Status XlaCompilationCache::CompileAsynchronous(
+    Entry* entry, const XlaCompiler::Options& options,
+    const std::vector<XlaCompiler::Argument>& args,
+    const string &function_name,
+    const std::function<Status(XlaCompiler* compiler,
+                               const std::vector<XlaCompiler::Argument>& args,
+                               XlaCompiler::CompilationResult*)>& compile_fn) {
+  entry->compile_state = CompileState::kCompiling; // still under caller's lock.
+  {
+    mutex_lock lock(async_compilation_.async_compilation_mu_);
+    async_compilation_.num_ongoing_compilations++;
+  }
+  // Don't move the above code into the thread function!!!
+
+  // Passing everything by value to make sure nothing is deleted while the
+  // compilation is still ongoing. In particular, this increases the refcount on
+  // options.device_allocator, keeping it alive for the duration of the
+  // compilation.
+  async_compilation_.compiler_threads.Schedule([=] {
+      Entry local_entry;
+      VLOG(2) << "Starting asynchronous compilation of cluster "
+              << function_name << '.';
+      (void)CompileStrict(&local_entry, options, args, function_name,
+                          compile_fn);
+      VLOG(2) << "Finished asynchronous compililation of cluster "
+              << function_name << '.';
+      {
+        mutex_lock lock(async_compilation_.async_compilation_mu_);
+        async_compilation_.num_ongoing_compilations--;
+      }
+      { // Populate original entry with compilation result.
+        mutex_lock entry_lock(entry->mu);
+        entry->compilation_result = local_entry.compilation_result;
+        entry->compile_state = local_entry.compile_state;
+        entry->compilation_status = local_entry.compilation_status;
+        entry->executable = std::move(local_entry.executable);
+      }
+    }
+  );
+  return Status::OK();
+}
+
 Status XlaCompilationCache::CompileImpl(
     const XlaCompiler::Options& options, const NameAttrList& function,
-    absl::Span<const XlaCompiler::Argument> args,
+    const std::vector<XlaCompiler::Argument>& args,
     const std::function<Status(XlaCompiler* compiler,
+                               const std::vector<XlaCompiler::Argument>& args,
                                XlaCompiler::CompilationResult*)>& compile_fn,
-    absl::optional<int64> compile_threshold,
+    CompileMode compile_mode,
     const XlaCompiler::CompilationResult** out_compilation_result,
     xla::LocalExecutable** out_executable) {
   if (FailOnXlaCompilation()) {
@@ -347,9 +444,20 @@ Status XlaCompilationCache::CompileImpl(
       VLOG(3) << i << ": " << args[i].HumanString();
     }
   }
+  absl::optional<int64> compile_threshold;
+  if (compile_mode == CompileMode::kLazy) {
+    compile_threshold = kDefaultCompilationThreshold;
+  } else if (compile_mode == CompileMode::kAsync) {
+    compile_threshold = 0; // for now, always compile right away
+  }
 
   TF_ASSIGN_OR_RETURN(Signature signature, BuildSignature(function, args));
-  VLOG(2) << "Signature: " << signature.HumanString();
+
+  string human_signature;
+  if (VLOG_IS_ON(2)) {
+    human_signature = VLOG_IS_ON(3) ? signature.HumanString() : function.name();
+    VLOG(2) << "Signature: " << human_signature;
+  }
 
   // The outer lock protects the existence of the cache entry. It does not
   // protect the contents of the cache entry.
@@ -401,14 +509,17 @@ Status XlaCompilationCache::CompileImpl(
   // cache eviction.
   mutex_lock entry_lock(entry->mu);
   int64 current_request_count = ++entry->request_count;
-  VLOG(2) << "Compilation cache entry hit: " << entry->compiled
-          << " signature: " << signature.HumanString() << " with request count "
+  VLOG(2) << "Compilation cache entry hit: "
+          << static_cast<int>(entry->compile_state)
+          << " signature: " << human_signature << " with request count "
           << current_request_count << " and compile threshold "
           << compile_threshold.value_or(0);
-  if (!entry->compiled) {
+  bool return_null = false;
+  CompileState state = entry->compile_state;
+  if (state == CompileState::kUncompiled) {
     XLA_SCOPED_LOGGING_TIMER("Compilation of XLA executable");
     const bool should_compile = [&] {
-      if (!compile_threshold.has_value()) {
+      if (compile_mode == CompileMode::kStrict) {
         // Lazy compilation is disabled.
         return true;
       }
@@ -417,7 +528,7 @@ Status XlaCompilationCache::CompileImpl(
         BroadcastOptimizationRemark(XlaOptimizationRemark::MEGAMORPHIC_FUNCTION,
                                     function.name())
             .IgnoreError();
-        VLOG(3) << "Not compiling cluster " << function.name()
+        VLOG(2) << "Not compiling cluster " << function.name()
                 << " because it is megamorphic.";
         return false;
       }
@@ -426,10 +537,23 @@ Status XlaCompilationCache::CompileImpl(
         return true;
       }
 
+      if (compile_mode == CompileMode::kAsync) {
+        // asynchronous compilation is enabled.
+        {
+          mutex_lock lock(async_compilation_.async_compilation_mu_);
+          if (async_compilation_.num_ongoing_compilations >=
+                async_compilation_.kMaxNumOngoingCompilations) {
+            VLOG(2) << "Not asynchronously compiling cluster " << function.name()
+                    << " because of too many ongoing compilations.";
+            return false;
+          }
+        }
+      }
+
       bool reached_compile_threshold =
           current_request_count >= *compile_threshold;
       if (!reached_compile_threshold) {
-        VLOG(3)
+        VLOG(2)
             << "Not compiling cluster " << function.name()
             << " because it has not reached compile threshold; threshold is "
             << *compile_threshold << " execution count "
@@ -439,62 +563,32 @@ Status XlaCompilationCache::CompileImpl(
     }();
 
     if (!should_compile) {
-      VLOG(2) << "Not compiling for signature: " << signature.HumanString();
-      *out_compilation_result = nullptr;
-      *out_executable = nullptr;
-      return Status::OK();
-    }
-
-    tensorflow::Env* env = tensorflow::Env::Default();
-    const uint64 compile_start_us = env->NowMicros();
-    // Do the actual JIT compilation without holding the lock (it can take
-    // a long time.)
-
-    XlaCompiler compiler(options);
-    entry->compiled = true;
-
-    entry->compilation_status =
-        compile_fn(&compiler, &entry->compilation_result);
-    TF_RETURN_IF_ERROR(entry->compilation_status);
-    CHECK_EQ(entry->executable.get(), nullptr);
-    entry->compilation_status =
-        BuildExecutable(options, entry->compilation_result, &entry->executable);
-
-    const uint64 compile_end_us = env->NowMicros();
-    const uint64 compile_time_us = compile_end_us - compile_start_us;
-    metrics::UpdateXlaCompilationTime(compile_time_us);
-    {
-      mutex_lock lock(cluster_compile_stats_mu_);
-      auto it = cluster_compile_stats_.find(function.name());
-      it->second.compile_count++;
-      it->second.cumulative_compile_time_us += compile_time_us;
-      LogOnceXlaCompiledFirstCluster();
-      VLOG(1) << "compiled " << function.name() << " "
-              << it->second.compile_count
-              << " times, compile time: " << compile_time_us
-              << " us, cumulative: " << it->second.cumulative_compile_time_us
-              << " us ("
-              << tensorflow::strings::HumanReadableElapsedTime(compile_time_us /
-                                                               1.0e6)
-              << " / "
-              << tensorflow::strings::HumanReadableElapsedTime(
-                     it->second.cumulative_compile_time_us / 1.0e6)
-              << ")";
-
-      XlaJitCompilationActivity jit_compilation_activity;
-      jit_compilation_activity.set_cluster_name(function.name());
-      jit_compilation_activity.set_compile_count(it->second.compile_count);
-      jit_compilation_activity.set_compile_time_us(compile_time_us);
-      jit_compilation_activity.set_cumulative_compile_time_us(
-          it->second.cumulative_compile_time_us);
-
+      VLOG(2) << "Not compiling for signature: " << human_signature;
+      return_null = true;
+    } else if (compile_mode == CompileMode::kAsync) {
+      VLOG(2) << "Queueing asynchronous compilation for signature: " << human_signature;
       TF_RETURN_IF_ERROR(
-          BroadcastXlaActivity(std::move(jit_compilation_activity)));
+        CompileAsynchronous(entry, options, args, function.name(), compile_fn));
+      return_null = true;
+    } else {
+      VLOG(2) << "Instantly compiling for signature: " << human_signature;
+      TF_RETURN_IF_ERROR(
+        CompileStrict(entry, options, args, function.name(), compile_fn));
     }
+  } else if (state == CompileState::kCompiling) {
+      VLOG(2) << "Ongoing asynchronous compilation for signature: " << human_signature;
+      return_null = true;
+  } else if (state == CompileState::kCompiled) {
+      VLOG(2) << "Already Compiled for signature: " << human_signature;
   }
-  TF_RETURN_IF_ERROR(entry->compilation_status);
-  *out_compilation_result = &entry->compilation_result;
-  *out_executable = entry->executable.get();
+  if (return_null) {
+    *out_compilation_result = nullptr;
+    *out_executable = nullptr;
+  } else {
+    TF_RETURN_IF_ERROR(entry->compilation_status);
+    *out_compilation_result = &entry->compilation_result;
+    *out_executable = entry->executable.get();
+  }
   return Status::OK();
 }
 

--- a/tensorflow/compiler/jit/xla_compilation_cache.cc
+++ b/tensorflow/compiler/jit/xla_compilation_cache.cc
@@ -56,7 +56,7 @@ constexpr int64 XlaCompilationCache::kDefaultCompilationThreshold;
 
 XlaCompilationCache::XlaCompilationCache(xla::LocalClient* client,
                                          DeviceType device_type)
-    : client_(client), device_type_(std::move(device_type)), async_compilation_() {}
+    : client_(client), device_type_(std::move(device_type)) {}
 
 XlaCompilationCache::~XlaCompilationCache() {
   // Ensure any use of our programs have completed by waiting for all stream

--- a/tensorflow/compiler/jit/xla_compilation_cache.cc
+++ b/tensorflow/compiler/jit/xla_compilation_cache.cc
@@ -53,6 +53,8 @@ limitations under the License.
 namespace tensorflow {
 
 constexpr int64 XlaCompilationCache::kDefaultCompilationThreshold;
+constexpr int64 XlaCompilationCache::AsyncCompilationState::kNumCompilerThreads;
+constexpr int64 XlaCompilationCache::AsyncCompilationState::kMaxNumOngoingCompilations;
 
 XlaCompilationCache::XlaCompilationCache(xla::LocalClient* client,
                                          DeviceType device_type)

--- a/tensorflow/compiler/jit/xla_compilation_cache.h
+++ b/tensorflow/compiler/jit/xla_compilation_cache.h
@@ -214,8 +214,8 @@ class XlaCompilationCache : public ResourceBase {
   absl::flat_hash_map<string, ClusterCompileStats> cluster_compile_stats_
       TF_GUARDED_BY(cluster_compile_stats_mu_);
 
-  struct AsyncCompilation {
-    mutex async_compilation_mu_;
+  struct AsyncCompilationState {
+    mutex async_compilation_state_mu_;
 
     // Number of threads for asynchronous compilations.
     static constexpr int64 kNumCompilerThreads = 10;
@@ -224,19 +224,19 @@ class XlaCompilationCache : public ResourceBase {
     static constexpr int64 kMaxNumOngoingCompilations = kNumCompilerThreads;
 
     // Number of ongoing compilations.
-    int64 num_ongoing_compilations GUARDED_BY(async_compilation_mu_) = 0;
+    int64 num_ongoing_compilations GUARDED_BY(async_compilation_state_mu_) = 0;
 
     // Pool of threads for asynchronous compilations.
     std::unique_ptr<thread::ThreadPool> compiler_threads;
 
-    AsyncCompilation()
+    AsyncCompilationState()
     {
        compiler_threads = absl::make_unique<tensorflow::thread::ThreadPool>(
          tensorflow::Env::Default(), "aync_compiler_threads",
          kNumCompilerThreads);
     }
 
-  } async_compilation_;
+  } async_compilation_state_;
 
   // The number of times a lazy compilation must be requested for a specific
   // signature before  we attempt to compile it.

--- a/tensorflow/compiler/jit/xla_compilation_cache.h
+++ b/tensorflow/compiler/jit/xla_compilation_cache.h
@@ -50,6 +50,13 @@ class XlaCompilationCache : public ResourceBase {
   enum class CompileMode {
     kLazy,
     kStrict,
+    kAsync,
+  };
+
+  enum class CompileState {
+    kUncompiled,
+    kCompiling,
+    kCompiled,
   };
 
   // Compiles a function into a XlaCompiler::CompilationResult that can be used
@@ -62,7 +69,9 @@ class XlaCompilationCache : public ResourceBase {
   // heuristics, the compilation cache may decide not to compile the cluster at
   // this time.  In this case it returns null into both `out_compilation_result`
   // and `out_executable`.  If `compile_mode` is `kStrict` then the compilation
-  // cache always attempts the compilation on a cache miss.
+  // cache always attempts the compilation on a cache miss. If compilation mode
+  // is 'kAsync' compilation of the cluster happens in the background while the
+  // fallback path executes.
   //
   // The result of compilation is written to `*out_compilation_result`, which
   // must be non-null. If `out_executable` is non-null, also builds an
@@ -71,7 +80,7 @@ class XlaCompilationCache : public ResourceBase {
   // non-constant outputs.
   Status Compile(const XlaCompiler::Options& options,
                  const NameAttrList& function,
-                 absl::Span<const XlaCompiler::Argument> args,
+                 const std::vector<XlaCompiler::Argument>& args,
                  const XlaCompiler::CompileOptions& compile_options,
                  CompileMode compile_mode,
                  const XlaCompiler::CompilationResult** out_compilation_result,
@@ -83,7 +92,7 @@ class XlaCompilationCache : public ResourceBase {
   // XlaCompiler, if possible.
   Status CompileSingleOp(
       const XlaCompiler::Options& options,
-      absl::Span<const XlaCompiler::Argument> args, OpKernelContext* ctx,
+      const std::vector<XlaCompiler::Argument>& args, OpKernelContext* ctx,
       const XlaCompiler::CompileOptions& compile_options,
       const XlaCompiler::CompilationResult** out_compilation_result,
       xla::LocalExecutable** out_executable);
@@ -126,10 +135,11 @@ class XlaCompilationCache : public ResourceBase {
   // Common implementation of Compile and CompileSingleOp.
   Status CompileImpl(
       const XlaCompiler::Options& options, const NameAttrList& function,
-      absl::Span<const XlaCompiler::Argument> args,
+      const std::vector<XlaCompiler::Argument>& args,
       const std::function<Status(XlaCompiler* compiler,
+                                 const std::vector<XlaCompiler::Argument>& args,
                                  XlaCompiler::CompilationResult*)>& compile_fn,
-      absl::optional<int64> compile_threshold,
+      CompileMode compile_mode,
       const XlaCompiler::CompilationResult** out_compilation_result,
       xla::LocalExecutable** out_executable);
 
@@ -147,7 +157,7 @@ class XlaCompilationCache : public ResourceBase {
     mutex mu;
 
     // Have we tried compiling this entry?
-    bool compiled = false;
+    CompileState compile_state = CompileState::kUncompiled;
 
     // The number of times a compilation with this signature has been requested.
     int64 request_count = 0;
@@ -162,6 +172,21 @@ class XlaCompilationCache : public ResourceBase {
     // executable has been built.
     std::unique_ptr<xla::LocalExecutable> executable TF_GUARDED_BY(mu);
   };
+
+  Status CompileStrict(
+    Entry* entry, const XlaCompiler::Options& options,
+    const std::vector<XlaCompiler::Argument>& args,
+    const string &function_name,
+    const std::function<Status(XlaCompiler* compiler,
+                               const std::vector<XlaCompiler::Argument>& args,
+                               XlaCompiler::CompilationResult*)>& compile_fn);
+  Status CompileAsynchronous(
+    Entry* entry, const XlaCompiler::Options& options,
+    const std::vector<XlaCompiler::Argument>& args,
+    const string &function_name,
+    const std::function<Status(XlaCompiler* compiler,
+                               const std::vector<XlaCompiler::Argument>& args,
+                               XlaCompiler::CompilationResult*)>& compile_fn);
 
   mutex compile_cache_mu_;
   absl::flat_hash_map<Signature, std::unique_ptr<Entry>, Signature::Hash> cache_
@@ -188,6 +213,27 @@ class XlaCompilationCache : public ResourceBase {
   // Maps cluster names to compilation statistics for said cluster.
   absl::flat_hash_map<string, ClusterCompileStats> cluster_compile_stats_
       TF_GUARDED_BY(cluster_compile_stats_mu_);
+
+  struct AsyncCompilation {
+    mutex async_compilation_mu_;
+
+    // Number of threads for asynchronous compilations.
+    static constexpr int64 kNumCompilerThreads = 10;
+
+    // Maximum number of ongoing compilations.
+    static constexpr int64 kMaxNumOngoingCompilations = kNumCompilerThreads;
+
+    // Pool of threads for asynchronous compilations.
+    thread::ThreadPool compiler_threads;
+
+    // Number of ongoing compilations.
+    int64 num_ongoing_compilations GUARDED_BY(async_compilation_mu_) = 0;
+
+    AsyncCompilation()
+      : compiler_threads(tensorflow::Env::Default(), "aync_compiler_threads",
+                         kNumCompilerThreads) {}
+
+  } async_compilation_;
 
   // The number of times a lazy compilation must be requested for a specific
   // signature before  we attempt to compile it.

--- a/tensorflow/compiler/jit/xla_compile_on_demand_op.cc
+++ b/tensorflow/compiler/jit/xla_compile_on_demand_op.cc
@@ -48,11 +48,10 @@ Status XlaCompileOnDemandOp::Run(OpKernelContext* ctx,
                                  const ResourceVarsSnapshot& variable_args) {
   xla::LocalClient* client = static_cast<xla::LocalClient*>(cache->client());
 
-  absl::optional<se::TfAllocatorAdapter> tf_allocator_adapter;
   se::DeviceMemoryAllocator* allocator = GetAllocator(
-      &tf_allocator_adapter, ctx->device(),
+      ctx->device(),
       ctx->op_device_context() ? ctx->op_device_context()->stream() : nullptr,
-      platform_info_);
+      platform_info_).get();
   XlaComputationLaunchContext launch_context(
       client, allocator, client->default_device_ordinal(),
       /*allocate_xla_tensors=*/platform_info_.xla_device_metadata() != nullptr,
@@ -126,12 +125,10 @@ Status XlaCompileOnDemandOp::Compile(
                                         write_into_cache);
       }));
 
-  absl::optional<se::TfAllocatorAdapter> tf_allocator_adapter;
   XlaCompiler::Options options = GenerateCompilerOptions(
       **cache, *ctx->function_library(), ctx->device(),
       ctx->op_device_context() ? ctx->op_device_context()->stream() : nullptr,
-      platform_info_,
-      /*has_ref_vars=*/true, &tf_allocator_adapter);
+      platform_info_, /*has_ref_vars=*/true);
   // No detailed logging from on demand op.
   options.detailed_logging = false;
   XlaCompiler::CompileOptions compile_options;

--- a/tensorflow/compiler/jit/xla_compile_on_demand_op.cc
+++ b/tensorflow/compiler/jit/xla_compile_on_demand_op.cc
@@ -48,10 +48,11 @@ Status XlaCompileOnDemandOp::Run(OpKernelContext* ctx,
                                  const ResourceVarsSnapshot& variable_args) {
   xla::LocalClient* client = static_cast<xla::LocalClient*>(cache->client());
 
-  se::DeviceMemoryAllocator* allocator = GetAllocator(
-      ctx->device(),
-      ctx->op_device_context() ? ctx->op_device_context()->stream() : nullptr,
-      platform_info_).get();
+  se::Stream* stream =
+      ctx->op_device_context() ? ctx->op_device_context()->stream() : nullptr;
+  std::shared_ptr<se::DeviceMemoryAllocator> allocator_ptr =
+      GetAllocator(ctx->device(), stream, platform_info_);
+  se::DeviceMemoryAllocator* allocator = allocator_ptr.get();
   XlaComputationLaunchContext launch_context(
       client, allocator, client->default_device_ordinal(),
       /*allocate_xla_tensors=*/platform_info_.xla_device_metadata() != nullptr,
@@ -72,9 +73,6 @@ Status XlaCompileOnDemandOp::Run(OpKernelContext* ctx,
                                     /*missing_ctx_input_prefix=*/0,
                                     input_output_alias);
   TF_RETURN_IF_ERROR(execution_inputs.status());
-
-  se::Stream* stream =
-      ctx->op_device_context() ? ctx->op_device_context()->stream() : nullptr;
 
   VLOG(2) << "Executing computation: " << name();
   xla::ExecutableRunOptions run_options;

--- a/tensorflow/compiler/jit/xla_platform_info.cc
+++ b/tensorflow/compiler/jit/xla_platform_info.cc
@@ -79,7 +79,7 @@ XlaPlatformInfo XlaPlatformInfoFromDevice(DeviceBase* device_base) {
   auto device = static_cast<Device*>(device_base);
   se::Platform::Id platform_id = nullptr;
   const XlaDevice::Metadata* xla_device_metadata = nullptr;
-  se::DeviceMemoryAllocator* custom_allocator = nullptr;
+  std::shared_ptr<se::DeviceMemoryAllocator> custom_allocator;
 
   if (device->device_type() == DEVICE_CPU) {
     platform_id = se::host::kHostPlatformId;
@@ -101,37 +101,34 @@ XlaPlatformInfo XlaPlatformInfoFromDevice(DeviceBase* device_base) {
     // allocator to allocate real buffers.
     platform_id = xla_device_metadata->platform()->id();
     custom_allocator =
-        xla_device_metadata->client()->backend().memory_allocator();
+        xla_device_metadata->client()->backend().shared_memory_allocator();
   }
 
   return XlaPlatformInfo(DeviceType(device->device_type()), platform_id,
                          xla_device_metadata, custom_allocator);
 }
 
-se::DeviceMemoryAllocator* GetAllocator(
-    absl::optional<se::TfAllocatorAdapter>* tf_allocator_adapter,
+std::shared_ptr<se::DeviceMemoryAllocator> GetAllocator(
     DeviceBase* device, se::Stream* stream,
     const XlaPlatformInfo& platform_info) {
   if (platform_info.custom_allocator()) {
     return platform_info.custom_allocator();
   }
+  auto *alloc = device->GetAllocator({});
   if (!stream) {
     // Stream is not set for the host platform.
     se::Platform* platform =
         se::MultiPlatformManager::PlatformWithId(platform_info.platform_id())
             .ValueOrDie();
-    tf_allocator_adapter->emplace(device->GetAllocator({}), platform);
-    return &tf_allocator_adapter->value();
+    return std::make_shared<se::TfAllocatorAdapter>(alloc, platform);
   }
-  tf_allocator_adapter->emplace(device->GetAllocator({}), stream);
-  return &tf_allocator_adapter->value();
+  return std::make_shared<se::TfAllocatorAdapter>(alloc, stream);
 }
 
 XlaCompiler::Options GenerateCompilerOptions(
     const XlaCompilationCache& cache,
     const FunctionLibraryRuntime& function_library, DeviceBase* device,
-    se::Stream* stream, const XlaPlatformInfo& platform_info, bool has_ref_vars,
-    absl::optional<se::TfAllocatorAdapter>* tf_allocator_adapter) {
+    se::Stream* stream, const XlaPlatformInfo& platform_info, bool has_ref_vars) {
   XlaCompiler::Options options;
   options.client = static_cast<xla::LocalClient*>(cache.client());
   if (stream != nullptr) {
@@ -143,7 +140,7 @@ XlaCompiler::Options GenerateCompilerOptions(
   options.allow_cpu_custom_calls =
       (platform_info.platform_id() == se::host::kHostPlatformId);
   options.device_allocator =
-      GetAllocator(tf_allocator_adapter, device, stream, platform_info);
+      GetAllocator(device, stream, platform_info);
   if (platform_info.xla_device_metadata()) {
     options.shape_representation_fn =
         platform_info.xla_device_metadata()->shape_representation_fn();

--- a/tensorflow/compiler/jit/xla_platform_info.h
+++ b/tensorflow/compiler/jit/xla_platform_info.h
@@ -32,7 +32,7 @@ class XlaPlatformInfo {
   explicit XlaPlatformInfo(const DeviceType device_type,
                            se::Platform::Id platform_id,
                            const XlaDevice::Metadata* xla_device_metadata,
-                           se::DeviceMemoryAllocator* device_allocator)
+                           std::shared_ptr<se::DeviceMemoryAllocator> device_allocator)
       : device_type_(device_type),
         platform_id_(platform_id),
         xla_device_metadata_(xla_device_metadata),
@@ -45,7 +45,7 @@ class XlaPlatformInfo {
   }
 
   // Non-null only when run on an XLA device.
-  se::DeviceMemoryAllocator* custom_allocator() const {
+  std::shared_ptr<se::DeviceMemoryAllocator> custom_allocator() const {
     return device_allocator_;
   }
 
@@ -74,7 +74,9 @@ class XlaPlatformInfo {
   // If the op associated with this XlaPlatformInfo is placed on an XLA device
   // then device_allocator_ is the xla::Backend's memory allocator.  If the op
   // is placed on a regular CPU or GPU device then device_allocator_ is null.
-  se::DeviceMemoryAllocator* device_allocator_;
+  // The allocator is of unknown provenance; keep it in a shared pointer to
+  // set an artificial refcount of one.
+  std::shared_ptr<se::DeviceMemoryAllocator> device_allocator_;
 
   TF_DISALLOW_COPY_AND_ASSIGN(XlaPlatformInfo);
 };
@@ -94,8 +96,7 @@ XlaPlatformInfo XlaPlatformInfoFromDevice(DeviceBase* device);
 // dummy tensors.
 //
 // `stream` parameter is nullable when running on host.
-se::DeviceMemoryAllocator* GetAllocator(
-    absl::optional<se::TfAllocatorAdapter>* tf_allocator_adapter,
+std::shared_ptr<se::DeviceMemoryAllocator> GetAllocator(
     DeviceBase* device, se::Stream* stream,
     const XlaPlatformInfo& platform_info);
 
@@ -104,8 +105,7 @@ se::DeviceMemoryAllocator* GetAllocator(
 XlaCompiler::Options GenerateCompilerOptions(
     const XlaCompilationCache& cache,
     const FunctionLibraryRuntime& function_library, DeviceBase* device,
-    se::Stream* stream, const XlaPlatformInfo& platform_info, bool has_ref_vars,
-    absl::optional<se::TfAllocatorAdapter>* tf_allocator_adapter);
+    se::Stream* stream, const XlaPlatformInfo& platform_info, bool has_ref_vars);
 
 }  // namespace tensorflow
 

--- a/tensorflow/compiler/tests/BUILD
+++ b/tensorflow/compiler/tests/BUILD
@@ -1662,11 +1662,8 @@ cuda_py_test(
         "//tensorflow/python:array_ops",
         "//tensorflow/python:client",
         "//tensorflow/python:client_testlib",
-        "//tensorflow/python:control_flow_ops",
         "//tensorflow/python:framework",
-        "//tensorflow/python:gradients",
         "//tensorflow/python:math_ops",
-        "//tensorflow/python:nn_ops",
         "//tensorflow/python/compiler/xla:compiler_py",
     ],
 )

--- a/tensorflow/compiler/tests/BUILD
+++ b/tensorflow/compiler/tests/BUILD
@@ -1625,6 +1625,31 @@ cuda_py_test(
     name = "jit_test",
     size = "medium",
     srcs = ["jit_test.py"],
+    #shard_count = 5,
+    tags = [
+        "no_pip",  # TODO(b/149738646): fix pip install so these tests run on kokoro pip
+    ],
+    xla_enable_strict_auto_jit = False,
+    xla_enabled = True,
+    deps = [
+        ":test_utils",
+        "//tensorflow/core:protos_all_py",
+        "//tensorflow/python:array_ops",
+        "//tensorflow/python:client",
+        "//tensorflow/python:client_testlib",
+        "//tensorflow/python:control_flow_ops",
+        "//tensorflow/python:framework",
+        "//tensorflow/python:gradients",
+        "//tensorflow/python:math_ops",
+        "//tensorflow/python:nn_ops",
+        "//tensorflow/python/compiler/xla:compiler_py",
+    ],
+)
+
+cuda_py_test(
+    name = "async_comp_test",
+    size = "medium",
+    srcs = ["async_comp_test.py"],
     shard_count = 5,
     tags = [
         "no_pip",  # TODO(b/149738646): fix pip install so these tests run on kokoro pip

--- a/tensorflow/compiler/tests/async_comp_test.py
+++ b/tensorflow/compiler/tests/async_comp_test.py
@@ -20,22 +20,13 @@ from __future__ import print_function
 
 import os
 
-import numpy as np
-
-from tensorflow.compiler.tests import test_utils
 from tensorflow.core.protobuf import config_pb2
-from tensorflow.core.protobuf import rewriter_config_pb2
 from tensorflow.python.client import session as session_lib
-from tensorflow.python.compiler.xla import jit
-from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import function
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
-from tensorflow.python.ops import control_flow_ops
-from tensorflow.python.ops import gradients_impl
 from tensorflow.python.ops import math_ops
-from tensorflow.python.ops import nn_ops
 from tensorflow.python.platform import test
 
 def RunMetadataLabels(run_metadata):
@@ -85,14 +76,15 @@ class AsyncCompilationTest(test.TestCase):
 
       # Execute the session until after asynchronous compilation is finished
       # and the compiled cluster has been executed once.
-      while (not hasXlaRunOp) :
-          sess.run(
-              y,
-              feed_dict={x: [0.] * 60},
-              run_metadata=run_metadata,
-              options=config_pb2.RunOptions(
-                  trace_level=config_pb2.RunOptions.FULL_TRACE))
-          hasXlaRunOp = MetadataHasXlaRunOp(run_metadata)
+      while (not hasXlaRunOp):
+        run_metadata = config_pb2.RunMetadata()
+        sess.run(
+            y,
+            feed_dict={x: [0.] * 60},
+            run_metadata=run_metadata,
+            options=config_pb2.RunOptions(
+                trace_level=config_pb2.RunOptions.FULL_TRACE))
+        hasXlaRunOp = MetadataHasXlaRunOp(run_metadata)
 
 if __name__ == "__main__":
   os.environ["TF_XLA_FLAGS"] = ("--tf_xla_async_compilation=true " +

--- a/tensorflow/compiler/tests/async_comp_test.py
+++ b/tensorflow/compiler/tests/async_comp_test.py
@@ -1,0 +1,104 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for asynchronous compilation on the CPU and GPU devices."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+
+import numpy as np
+
+from tensorflow.compiler.tests import test_utils
+from tensorflow.core.protobuf import config_pb2
+from tensorflow.core.protobuf import rewriter_config_pb2
+from tensorflow.python.client import session as session_lib
+from tensorflow.python.compiler.xla import jit
+from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import function
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import control_flow_ops
+from tensorflow.python.ops import gradients_impl
+from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import nn_ops
+from tensorflow.python.platform import test
+
+def RunMetadataLabels(run_metadata):
+  """Returns all labels in run_metadata."""
+  labels = []
+  for dev_stats in run_metadata.step_stats.dev_stats:
+    for node_stats in dev_stats.node_stats:
+      labels.append(node_stats.timeline_label)
+  return labels
+
+
+def InLabels(labels, substr):
+  """Returns true iff one of the labels contains substr."""
+  return any(substr in x for x in labels)
+
+
+def MetadataHasXlaRunOp(run_metadata):
+  """Returns true if there are XlaRun kernels in run_metadata's timeline."""
+
+  # TODO(phawkins): find a less hacky way to test whether a kernel ran.
+  return InLabels(RunMetadataLabels(run_metadata), "_XlaRun")
+
+class AsyncCompilationTest(test.TestCase):
+
+  # Asynchrobnous compilation uses the existing fallback path and existing
+  # compiler. This test only tests that asynchronus compilation is performed.
+  def testAsyncCompilationJit(self):
+
+    @function.Defun(compiled=True)
+    def CompiledFunction(x):
+      return math_ops.log(x)
+
+    with session_lib.Session() as sess:
+      x = array_ops.placeholder(dtypes.float32)
+      y = CompiledFunction(x)
+
+      run_metadata = config_pb2.RunMetadata()
+      sess.run(
+          y,
+          feed_dict={x: [0.] * 60},
+          run_metadata=run_metadata,
+          options=config_pb2.RunOptions(
+              trace_level=config_pb2.RunOptions.FULL_TRACE))
+      # For The first iteration, the fall back path is chosen.
+      hasXlaRunOp = MetadataHasXlaRunOp(run_metadata)
+      self.assert_(not hasXlaRunOp)
+
+      # Execute the session until after asynchronous compilation is finished
+      # and the compiled cluster has been executed once.
+      while (not hasXlaRunOp) :
+          sess.run(
+              y,
+              feed_dict={x: [0.] * 60},
+              run_metadata=run_metadata,
+              options=config_pb2.RunOptions(
+                  trace_level=config_pb2.RunOptions.FULL_TRACE))
+          hasXlaRunOp = MetadataHasXlaRunOp(run_metadata)
+
+if __name__ == "__main__":
+  os.environ["TF_XLA_FLAGS"] = ("--tf_xla_async_compilation=true " +
+                                "--tf_xla_enable_lazy_compilation=true " +
+                                os.environ.get("TF_XLA_FLAGS", ""))
+  # This test is using Tensorflow sessions which are not compatible with eager
+  # mode.
+  ops.disable_eager_execution()
+  test.main()

--- a/tensorflow/compiler/tests/jit_test.py
+++ b/tensorflow/compiler/tests/jit_test.py
@@ -18,8 +18,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import unittest
-
 import os
 
 import numpy as np

--- a/tensorflow/compiler/tests/jit_test.py
+++ b/tensorflow/compiler/tests/jit_test.py
@@ -18,6 +18,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import unittest
+
 import os
 
 import numpy as np

--- a/tensorflow/compiler/tf2xla/xla_compiler.h
+++ b/tensorflow/compiler/tf2xla/xla_compiler.h
@@ -194,7 +194,7 @@ class XlaCompiler {
     // compiler to access, unless it can use TensorFlow's allocator.
     // This must be a shared_ptr, as this is passed all the way down to the
     // cluster compilation. This allows asynchronous compilation to hold a
-    // referecence until the compilation is finished. 
+    // reference until the compilation is finished. 
     std::shared_ptr<se::DeviceMemoryAllocator> device_allocator;
 
     // Alias input and output buffers for parameters that are passed-through XLA

--- a/tensorflow/compiler/tf2xla/xla_compiler.h
+++ b/tensorflow/compiler/tf2xla/xla_compiler.h
@@ -192,7 +192,10 @@ class XlaCompiler {
     // here, but on some devices (notably, GPUs), TensorFlow tends to eagerly
     // allocate most or all available memory on the device, leaving none for the
     // compiler to access, unless it can use TensorFlow's allocator.
-    se::DeviceMemoryAllocator* device_allocator = nullptr;
+    // This must be a shared_ptr, as this is passed all the way down to the
+    // cluster compilation. This allows asynchronous compilation to hold a
+    // referecence until the compilation is finished. 
+    std::shared_ptr<se::DeviceMemoryAllocator> device_allocator;
 
     // Alias input and output buffers for parameters that are passed-through XLA
     // modules without being changed.

--- a/tensorflow/compiler/xla/service/backend.cc
+++ b/tensorflow/compiler/xla/service/backend.cc
@@ -142,9 +142,7 @@ Backend::Backend(se::Platform* platform, Compiler* compiler,
   }
 }
 
-Backend::~Backend() {
-    CHECK_EQ(memory_allocator_.use_count(), 1);
-}
+Backend::~Backend() {}
 
 int Backend::default_device_ordinal() const {
   return default_stream_executor()->device_ordinal();

--- a/tensorflow/compiler/xla/service/backend.cc
+++ b/tensorflow/compiler/xla/service/backend.cc
@@ -129,7 +129,7 @@ Backend::Backend(se::Platform* platform, Compiler* compiler,
       computation_placer_(computation_placer),
       stream_executors_(stream_executors.begin(), stream_executors.end()) {
   // Create a memory allocator for the valid stream executors.
-  memory_allocator_ = absl::make_unique<se::StreamExecutorMemoryAllocator>(
+  memory_allocator_ = std::make_shared<se::StreamExecutorMemoryAllocator>(
       platform, stream_executors_);
   CHECK(!stream_executors_.empty())
       << "Service found no devices for backend " << platform_->Name() << '.';
@@ -142,7 +142,9 @@ Backend::Backend(se::Platform* platform, Compiler* compiler,
   }
 }
 
-Backend::~Backend() {}
+Backend::~Backend() {
+    CHECK_EQ(memory_allocator_.use_count(), 1);
+}
 
 int Backend::default_device_ordinal() const {
   return default_stream_executor()->device_ordinal();

--- a/tensorflow/compiler/xla/service/backend.h
+++ b/tensorflow/compiler/xla/service/backend.h
@@ -91,6 +91,9 @@ class Backend {
   se::DeviceMemoryAllocator* memory_allocator() const {
     return memory_allocator_.get();
   }
+  std::shared_ptr<se::DeviceMemoryAllocator> shared_memory_allocator() const {
+    return memory_allocator_;
+  }
   TransferManager* transfer_manager() const { return transfer_manager_; }
   ComputationPlacer* computation_placer() const { return computation_placer_; }
 
@@ -179,7 +182,10 @@ class Backend {
       stream_pools_ TF_GUARDED_BY(mu_);
 
   // The default memory allocator to use.
-  std::unique_ptr<se::StreamExecutorMemoryAllocator> memory_allocator_;
+  // This must be a shared_ptr, as this is passed all the way down to the
+  // cluster compilation. This allows asynchronous compilation to hold a
+  // referecence until the compilation is finished. 
+  std::shared_ptr<se::StreamExecutorMemoryAllocator> memory_allocator_;
 
   // For the CPU backend, an Eigen threadpool device for use by Eigen code.
   struct IntraOpThreadPool;


### PR DESCRIPTION
XLA Asynchronous compilation
    1) add option to opt into asynchronous compilation
    2) asynchronous compilation uses a dedicated number of threads
    to start a cluster instance compilation while the fallback path
    is executed
    3) limit number of ongoing compilations to a fixed threshold

change some VLOG levels to make level 2 less verbose