### PR TITLE
TFLu: Don't construct PoolParams if not needed in CMSIS int8 kernel

### DIFF
--- a/tensorflow/lite/micro/kernels/cmsis-nn/pooling.cc
+++ b/tensorflow/lite/micro/kernels/cmsis-nn/pooling.cc
@@ -99,17 +99,17 @@ void AverageEvalQuantized(TfLiteContext* context, const TfLiteNode* node,
                           TfLiteEvalTensor* output) {
   TFLITE_DCHECK(input->type == kTfLiteUInt8 || input->type == kTfLiteInt8);
 
-  PoolParams op_params;
-  op_params.stride_height = params->stride_height;
-  op_params.stride_width = params->stride_width;
-  op_params.filter_height = params->filter_height;
-  op_params.filter_width = params->filter_width;
-  op_params.padding_values.height = data.padding.height;
-  op_params.padding_values.width = data.padding.width;
-  op_params.quantized_activation_min = data.activation_min;
-  op_params.quantized_activation_max = data.activation_max;
-
   if (input->type == kTfLiteUInt8) {
+    PoolParams op_params;
+    op_params.stride_height = params->stride_height;
+    op_params.stride_width = params->stride_width;
+    op_params.filter_height = params->filter_height;
+    op_params.filter_width = params->filter_width;
+    op_params.padding_values.height = data.padding.height;
+    op_params.padding_values.width = data.padding.width;
+    op_params.quantized_activation_min = data.activation_min;
+    op_params.quantized_activation_max = data.activation_max;
+
     reference_ops::AveragePool(op_params, tflite::micro::GetTensorShape(input),
                                tflite::micro::GetTensorData<uint8_t>(input),
                                tflite::micro::GetTensorShape(output),


### PR DESCRIPTION
`PoolParams` are not needed for optimized CMSIS int8 average pool kernels, so this PR moves the creation inside the if statement.

/cc @freddan80