### PR TITLE
Don't try to link JSON headers to fix JSON in TF_SYSTEM_LIBS

### DIFF
--- a/third_party/systemlibs/jsoncpp.BUILD
+++ b/third_party/systemlibs/jsoncpp.BUILD
@@ -5,35 +5,8 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-HEADERS = [
-    "include/json/allocator.h",
-    "include/json/assertions.h",
-    "include/json/autolink.h",
-    "include/json/config.h",
-    "include/json/features.h",
-    "include/json/forwards.h",
-    "include/json/json.h",
-    "include/json/reader.h",
-    "include/json/value.h",
-    "include/json/version.h",
-    "include/json/writer.h",
-]
-
-genrule(
-    name = "link_headers",
-    outs = HEADERS,
-    cmd = """
-      for i in $(OUTS); do
-        i=$${i##*/}
-        ln -sf $(INCLUDEDIR)/jsoncpp/json/$$i $(@D)/include/json/$$i
-      done
-    """,
-)
-
 cc_library(
     name = "jsoncpp",
-    hdrs = HEADERS,
-    includes = ["."],
     linkopts = ["-ljsoncpp"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This is not required and now avoids conflicting settings of INCLUDEPATH when protobuf and JSONCpp is installed into different prefixes

We have used this patch successfully in compiling TF 2.0, 2.1 and 2.2 on our system, so I'd say it works.

CCing @cbalint13 and @perfinion to maybe verify on their builds.