### PR TITLE
Add missing initialization of filter_offset in fully connected CMSIS-NN kernel

### DIFF
--- a/tensorflow/lite/micro/kernels/cmsis-nn/fully_connected.cc
+++ b/tensorflow/lite/micro/kernels/cmsis-nn/fully_connected.cc
@@ -154,6 +154,7 @@ TfLiteStatus EvalQuantizedInt8(TfLiteContext* context, TfLiteNode* node,
     cmsis_nn_fc_params fc_params;
     fc_params.input_offset = -data.input_zero_point;
     fc_params.output_offset = data.output_zero_point;
+    fc_params.filter_offset = -data.filter_zero_point;
     fc_params.activation.min = data.output_activation_min;
     fc_params.activation.max = data.output_activation_max;
 


### PR DESCRIPTION
Fixes a bug where the filter_offset parameter is uninitialized in the CMSIS-NN kernel. Further explained in #42918 .

Fixes: #42918