### PR TITLE
Add bazel to the test_x86 script.

### DIFF
--- a/tensorflow/lite/micro/tools/ci_build/test_all.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_all.sh
@@ -35,7 +35,7 @@ make -f tensorflow/lite/micro/tools/make/Makefile \
 echo "Starting to run micro tests at `date`"
 
 echo "Running x86 tests at `date`"
-tensorflow/lite/micro/tools/ci_build/test_x86.sh
+tensorflow/lite/micro/tools/ci_build/test_x86.sh PRESUBMIT
 
 echo "Running bluepill tests at `date`"
 tensorflow/lite/micro/tools/ci_build/test_bluepill.sh

--- a/tensorflow/lite/micro/tools/ci_build/test_x86.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_x86.sh
@@ -44,7 +44,7 @@ readable_run make -s -j8 -f tensorflow/lite/micro/tools/make/Makefile test
 readable_run make -f tensorflow/lite/micro/tools/make/Makefile clean
 readable_run make -s -j8 -f tensorflow/lite/micro/tools/make/Makefile BUILD_TYPE=debug test
 
-# Most of TFLM external contributors only use make. So, we are building
-# with bazel as part of this script to make it easier for externally
+# Most of TFLM external contributors only use make. We are building a subset of
+# targets with bazel as part of this script to make it easier for external
 # contributors to fix these errors prior to creating a pull request.
 readable_run bazel build tensorflow/lite/micro:all

--- a/tensorflow/lite/micro/tools/ci_build/test_x86.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_x86.sh
@@ -44,6 +44,7 @@ readable_run make -s -j8 -f tensorflow/lite/micro/tools/make/Makefile test
 readable_run make -f tensorflow/lite/micro/tools/make/Makefile clean
 readable_run make -s -j8 -f tensorflow/lite/micro/tools/make/Makefile BUILD_TYPE=debug test
 
-# Most of TFLM external contributors only use make so also building with bazel
-# so that bazel errors can be reproduced externally as well.
+# Most of TFLM external contributors only use make. So, we are building
+# with bazel as part of this script to make it easier for externally
+# contributors to fix these errors prior to creating a pull request.
 readable_run bazel build tensorflow/lite/micro:all

--- a/tensorflow/lite/micro/tools/ci_build/test_x86.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_x86.sh
@@ -44,8 +44,6 @@ readable_run make -s -j8 -f tensorflow/lite/micro/tools/make/Makefile test
 readable_run make -f tensorflow/lite/micro/tools/make/Makefile clean
 readable_run make -s -j8 -f tensorflow/lite/micro/tools/make/Makefile BUILD_TYPE=debug test
 
-
-
 if [[ ${1} != "PRESUBMIT" ]]; then
   # Most of TFLM external contributors only use make. We are building a subset of
   # targets with bazel as part of this script to make it easier for external

--- a/tensorflow/lite/micro/tools/ci_build/test_x86.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_x86.sh
@@ -43,3 +43,7 @@ readable_run make -s -j8 -f tensorflow/lite/micro/tools/make/Makefile test
 # Also repeat for the debug build.
 readable_run make -f tensorflow/lite/micro/tools/make/Makefile clean
 readable_run make -s -j8 -f tensorflow/lite/micro/tools/make/Makefile BUILD_TYPE=debug test
+
+# Most of TFLM external contributors only use make so also building with bazel
+# so that bazel errors can be reproduced externally as well.
+readable_run bazel build tensorflow/lite/micro:all

--- a/tensorflow/lite/micro/tools/ci_build/test_x86.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_x86.sh
@@ -44,7 +44,15 @@ readable_run make -s -j8 -f tensorflow/lite/micro/tools/make/Makefile test
 readable_run make -f tensorflow/lite/micro/tools/make/Makefile clean
 readable_run make -s -j8 -f tensorflow/lite/micro/tools/make/Makefile BUILD_TYPE=debug test
 
-# Most of TFLM external contributors only use make. We are building a subset of
-# targets with bazel as part of this script to make it easier for external
-# contributors to fix these errors prior to creating a pull request.
-readable_run bazel build tensorflow/lite/micro:all
+
+
+if [[ ${1} != "PRESUBMIT" ]]; then
+  # Most of TFLM external contributors only use make. We are building a subset of
+  # targets with bazel as part of this script to make it easier for external
+  # contributors to fix these errors prior to creating a pull request.
+  #
+  # We only run the bazel command when this script is run locally (i.e. not via
+  # test_all.sh) to avoid duplicate work on the CI system and also avoid
+  # installing bazel on the TFLM Docker image.
+  readable_run bazel build tensorflow/lite/micro:all
+fi


### PR DESCRIPTION
This should enable external contributors to more easily test with bazel and prevent [back and forth](https://github.com/tensorflow/tensorflow/pull/42452#pullrequestreview-486197542) to try and resolve internal errors.

Note that bazel is not invoked from test_all.sh.  This is because the bazel build is already part of the presubmits and the goal here is to enable developers to catch errors sooner locally.

Also, the fact that the micro test_all.sh script runs within a docker container means that initiating a bazel build on the CI system would mean downloading bazel to the docker image.