### PR TITLE
Implementation of a missing hook in XlaDeviceContext

### DIFF
--- a/tensorflow/compiler/jit/xla_device_context.cc
+++ b/tensorflow/compiler/jit/xla_device_context.cc
@@ -294,4 +294,13 @@ se::Stream* XlaDeviceContext::GetDeviceToDeviceStream() {
   return device_to_device_stream(stream);
 }
 
+Status XlaDeviceContext::ThenExecute(Device* device, stream_executor::Stream* stream,
+                           std::function<void()> func) 
+{
+  VLOG(2) << "XlaDeviceContext::ThenExecute";
+  stream->ThenDoHostCallback(std::move(func));
+  return Status::OK();
+}
+
+
 }  // namespace tensorflow

--- a/tensorflow/compiler/jit/xla_device_context.h
+++ b/tensorflow/compiler/jit/xla_device_context.h
@@ -86,6 +86,9 @@ class XlaDeviceContext : public DeviceContext {
   // Returns a device-to-device stream, in round-robin fashion.
   se::Stream* GetDeviceToDeviceStream();
 
+  Status ThenExecute(Device* device, stream_executor::Stream* stream,
+                             std::function<void()> func) override;
+
  private:
   bool UseMultipleStreams() const { return stream_ != host_to_device_stream_; }
 


### PR DESCRIPTION
This supplies a default implementation of XlaDeviceContext::ThenExecute(). Without it, a host callback may fail to execute in some scenarios (because there's no one to execute it), causing a deadlock if anyone is waiting for that callback.