### PR TITLE
[SE] Include absl/memory/memory.h

### DIFF
--- a/tensorflow/stream_executor/cuda/BUILD
+++ b/tensorflow/stream_executor/cuda/BUILD
@@ -364,6 +364,7 @@ cc_library(
         ":cuda_timer",
         ":cudnn_version",
         ":cudnn_lib",
+        "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "//third_party/eigen3",
         "@local_config_cuda//cuda:cuda_headers",

--- a/tensorflow/stream_executor/cuda/cuda_dnn.cc
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include <memory>
 #include <utility>
 
+#include "absl/memory/memory.h"
 #include "absl/strings/str_cat.h"
 #include "third_party/eigen3/Eigen/Core"
 #include "tensorflow/core/lib/core/errors.h"


### PR DESCRIPTION
Similar to https://github.com/tensorflow/tensorflow/pull/42942

```
external/org_tensorflow/tensorflow/stream_executor/cuda/cuda_dnn.cc:184:23: error: 'make_unique' is not a member of 'absl'
     auto lock = absl::make_unique<absl::MutexLock>(&mutex_);
                       ^~~~~~~~~~~
```