### PR TITLE
Removed softmax Int16 dependency on std::vector

### DIFF
--- a/tensorflow/lite/kernels/internal/reference/softmax.h
+++ b/tensorflow/lite/kernels/internal/reference/softmax.h
@@ -144,7 +144,7 @@ inline void Softmax(const SoftmaxParams& params,
   }
 }
 
-int16_t CalculateExp(const SoftmaxParams& params, const int16_t* input_data,
+inline int16_t SoftMaxCalculateExp(const SoftmaxParams& params, const int16_t* input_data,
                      const int depth, int16_t max_in_row, int i, int c) {
   int32_t input_diff = input_data[i * depth + c] - max_in_row;
   // scale the input_diff such that [-65535, 0] correspond to [-10.0, 0.0]
@@ -181,7 +181,7 @@ inline void SoftmaxInt16(const SoftmaxParams& params,
     // sum_of_exps is a Q16.15 fixed point format.
     int32_t sum_of_exps = 0;
     for (int c = 0; c < depth; ++c) {
-      sum_of_exps += CalculateExp(params, input_data, depth, max_in_row, i, c);
+      sum_of_exps += SoftMaxCalculateExp(params, input_data, depth, max_in_row, i, c);
     }
 
     // Compute the reciprocal 1/sum_of_exps
@@ -208,7 +208,7 @@ inline void SoftmaxInt16(const SoftmaxParams& params,
       uint8_t right_shift = 31 - headroom_plus_one;
       int64_t round = 1 << (right_shift - 1);
       int16_t exp_result_Q015 =
-          CalculateExp(params, input_data, depth, max_in_row, i, c);
+          SoftMaxCalculateExp(params, input_data, depth, max_in_row, i, c);
       int32_t result = (static_cast<int64_t>(exp_result_Q015) *
                             static_cast<int64_t>(reciprocal_scale_Q015) +
                         round) >>

--- a/tensorflow/lite/kernels/internal/reference/softmax.h
+++ b/tensorflow/lite/kernels/internal/reference/softmax.h
@@ -180,6 +180,7 @@ inline void SoftmaxInt16(const SoftmaxParams& params,
 
     // Compute exp(input - max_input)
     // sum_of_exps is a Q16.15 fixed point format.
+	//the output buffer is used as scratch memory and overwritten when the results are written.
     int32_t sum_of_exps = 0;
     int16_t* exp_results_Q015 = output_data + i * depth;
     for (int c = 0; c < depth; ++c) {


### PR DESCRIPTION
This addresses the issue raised in https://github.com/tensorflow/tensorflow/issues/43126

The reference implementation of int16 softmax uses std::vector, this PR removes that dependency. 
The approach I took was rewriting the loop to in order to calculate the exponent twice instead of saving it after the first calculation - essentially paying with CPU time for memory. Slightly less efficient but embedded friendly, especially considering that most embedded platforms will just use it as reference and probably use an optimized implementation.  
