### PR TITLE
Adding HDFS connection cache on tensorflow side can improve performance by 20+ times #43187

### DIFF
--- a/tensorflow/core/platform/hadoop/hadoop_file_system.cc
+++ b/tensorflow/core/platform/hadoop/hadoop_file_system.cc
@@ -154,9 +154,8 @@ Status SplitArchiveNameAndPath(StringPiece& path, string& nn) {
   return Status::OK();
 }
 
-// We rely on HDFS connection caching here. The HDFS client calls
-// org.apache.hadoop.fs.FileSystem.get(), which caches the connection
-// internally.
+// We implement connection caching in Tensorflow, which can significantly
+// improve performance. Fixes #43187
 Status HadoopFileSystem::Connect(StringPiece fname, hdfsFS* fs) {
   TF_RETURN_IF_ERROR(libhdfs()->status());
 
@@ -164,6 +163,7 @@ Status HadoopFileSystem::Connect(StringPiece fname, hdfsFS* fs) {
   io::ParseURI(fname, &scheme, &namenode, &path);
   string nn(namenode);
 
+  string cacheKey(scheme.data(), scheme.size());
   hdfsBuilder* builder = libhdfs()->hdfsNewBuilder();
   if (scheme == "file") {
     libhdfs()->hdfsBuilderSetNameNode(builder, nullptr);
@@ -185,11 +185,16 @@ Status HadoopFileSystem::Connect(StringPiece fname, hdfsFS* fs) {
   } else if (scheme == "har") {
     TF_RETURN_IF_ERROR(SplitArchiveNameAndPath(path, nn));
     libhdfs()->hdfsBuilderSetNameNode(builder, nn.c_str());
+    cacheKey += nn;
   } else {
     libhdfs()->hdfsBuilderSetNameNode(builder,
                                       nn.empty() ? "default" : nn.c_str());
+    cacheKey += nn;
   }
-  *fs = libhdfs()->hdfsBuilderConnect(builder);
+  if (connectionCache_.find(cacheKey) == connectionCache_.end()) {
+    connectionCache_[cacheKey] = libhdfs()->hdfsBuilderConnect(builder);
+  }
+  *fs = connectionCache_[cacheKey];
   if (*fs == nullptr) {
     return errors::NotFound(strerror(errno));
   }

--- a/tensorflow/core/platform/hadoop/hadoop_file_system.h
+++ b/tensorflow/core/platform/hadoop/hadoop_file_system.h
@@ -16,7 +16,10 @@ limitations under the License.
 #ifndef TENSORFLOW_CORE_PLATFORM_HADOOP_HADOOP_FILE_SYSTEM_H_
 #define TENSORFLOW_CORE_PLATFORM_HADOOP_HADOOP_FILE_SYSTEM_H_
 
+#include <map>
+
 #include "tensorflow/core/platform/env.h"
+#include "third_party/hadoop/hdfs.h"
 
 extern "C" {
 struct hdfs_internal;
@@ -74,6 +77,7 @@ class HadoopFileSystem : public FileSystem {
   string TranslateName(const string& name) const override;
 
  private:
+  std::map<std::string, hdfsFS> connectionCache_;
   Status Connect(StringPiece fname, hdfsFS* fs);
 };
 


### PR DESCRIPTION
This is a PR from TaiJi AI platform in Tencent.

Adding HDFS connection cache on tensorflow side can improve performance by 20+ times #43187.