### PR TITLE
Tweaks to build tensorflow-lite-select-tf-ops

### DIFF
--- a/tensorflow/lite/delegates/flex/build_def.bzl
+++ b/tensorflow/lite/delegates/flex/build_def.bzl
@@ -141,6 +141,7 @@ def tflite_flex_cc_library(
                 clean_dep("//tensorflow/core:portable_tensorflow_lib_lite"),
                 clean_dep("//tensorflow/core/platform:strong_hash"),
                 clean_dep("//tensorflow/lite/delegates/flex:portable_images_lib"),
+                clean_dep("@com_google_protobuf//:protobuf"),
             ],
             alwayslink = 1,
         )

--- a/tensorflow/lite/delegates/flex/delegate.cc
+++ b/tensorflow/lite/delegates/flex/delegate.cc
@@ -149,7 +149,7 @@ extern "C" {
 #if defined(_WIN32)
 __declspec(dllexport)
 #endif
-    tflite::TfLiteDelegateUniquePtr TF_AcquireFlexDelegate() {
-  return tflite::FlexDelegate::Create();
-}
+//    tflite::TfLiteDelegateUniquePtr TF_AcquireFlexDelegate() {
+//  return tflite::FlexDelegate::Create();
+//}
 }  // extern "C"

--- a/tensorflow/lite/delegates/flex/delegate.cc
+++ b/tensorflow/lite/delegates/flex/delegate.cc
@@ -149,7 +149,7 @@ extern "C" {
 #if defined(_WIN32)
 __declspec(dllexport)
 #endif
-//    tflite::TfLiteDelegateUniquePtr TF_AcquireFlexDelegate() {
-//  return tflite::FlexDelegate::Create();
-//}
+    tflite::TfLiteDelegateUniquePtr TF_AcquireFlexDelegate() {
+  return tflite::FlexDelegate::Create();
+}
 }  // extern "C"

--- a/tensorflow/lite/tools/build_aar.sh
+++ b/tensorflow/lite/tools/build_aar.sh
@@ -41,7 +41,7 @@ function generate_list_field {
   local list_string="$2"
   local list=(${list_string//,/ })
 
-  local message+=("$name=[")
+  local message=("$name=[")
   for item in "${list[@]}"
   do
     message+=("\"$item\",")


### PR DESCRIPTION
These were the minor updates I needed in order to successfully build the tensorflow-lite-select-tf-ops.aar dependency with a tflite input model.

Without the protobuf dependency, I could build my app but always got a runtime error when loading the tflite model:

`java.lang.UnsatisfiedLinkError: dlopen failed: cannot locate symbol "_ZNK6google8protobuf7Message11GetTypeNameEv" referenced by "/data/app/org.auderenow.openrdt.reader-2/lib/arm64/libtensorflowlite_flex_jni.so".`

The update to `delegate.cc` is taken directly from the quick fix described here: https://github.com/tensorflow/tensorflow/issues/42744. I'm sure there must be some other fix that would maintain functionality on Windows, but I have no idea what that would be.