### PR TITLE
add suport for mips64 platform

### DIFF
--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -239,6 +239,12 @@ config_setting(
 )
 
 config_setting(
+    name = "linux_mips64",
+    values = {"cpu": "mips64"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "debug",
     values = {
         "compilation_mode": "dbg",

--- a/third_party/cpuinfo/BUILD.bazel
+++ b/third_party/cpuinfo/BUILD.bazel
@@ -102,6 +102,7 @@ cc_library(
         ":linux_armv7a": COMMON_SRCS + ARM_SRCS + LINUX_SRCS + LINUX_ARM32_SRCS,
         ":linux_armeabi": COMMON_SRCS + ARM_SRCS + LINUX_SRCS + LINUX_ARM32_SRCS,
         ":linux_aarch64": COMMON_SRCS + ARM_SRCS + LINUX_SRCS + LINUX_ARM64_SRCS,
+	":linux_mips64": COMMON_SRCS + LINUX_SRCS,
         ":macos_x86_64": COMMON_SRCS + X86_SRCS + MACH_SRCS + MACH_X86_SRCS,
         ":windows_x86_64": COMMON_SRCS + X86_SRCS + WINDOWS_X86_SRCS,
         ":android_armv7": COMMON_SRCS + ARM_SRCS + LINUX_SRCS + LINUX_ARM32_SRCS + ANDROID_ARM_SRCS,
@@ -206,6 +207,11 @@ config_setting(
 config_setting(
     name = "linux_aarch64",
     values = {"cpu": "aarch64"},
+)
+
+config_setting(
+    name = "linux_mips64",
+    values = {"cpu": "mips64"},
 )
 
 config_setting(

--- a/third_party/remote_config/remote_platform_configure.bzl
+++ b/third_party/remote_config/remote_platform_configure.bzl
@@ -22,6 +22,8 @@ def _remote_platform_configure_impl(repository_ctx):
         cpu = "aarch64"
     elif machine_type.startswith("arm"):
         cpu = "arm"
+    elif machine_type.startswith("mips64"):
+	cpu = "mips64"
 
     exec_properties = repository_ctx.attr.platform_exec_properties
 


### PR DESCRIPTION
tensorflow is not supported for mips64 platform. This patch can make it supported on mips64 platform on linux OS.
configure pass, build pass!