### PR TITLE
Expose modular file system header in pip install package

### DIFF
--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -36,6 +36,7 @@ transitive_hdrs(
         "//tensorflow/cc/saved_model:loader",
         "//tensorflow/cc/saved_model:reader",
         "//tensorflow/cc/saved_model:bundle_v2",
+        "//tensorflow/c/experimental/filesystem:modular_filesystem",
         # WARNING: None of the C/C++ code under python/ has any API guarantees, and TF team
         # reserves the right to change APIs and other header-level interfaces.  If your custom
         # op uses these headers, it may break when users upgrade their version of tensorflow.


### PR DESCRIPTION
This PR tries to expose modular file system header in pip install package
so that downstream packages could use the header files with pip install

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>