### PR TITLE
Add test ReadWhileOverwriting

### DIFF
--- a/tensorflow/core/platform/hadoop/hadoop_file_system_test.cc
+++ b/tensorflow/core/platform/hadoop/hadoop_file_system_test.cc
@@ -236,6 +236,40 @@ TEST_F(HadoopFileSystemTest, WriteWhileReading) {
   TF_EXPECT_OK(writer->Close());
 }
 
+TEST_F(HadoopFileSystemTest, ReadWhileOverwriting) {
+  static char set_disable_var[] = "HDFS_DISABLE_READ_EOF_RETRIED=1";
+  putenv(set_disable_var);
+  const string fname = TmpDir("ReadWhileOverwriting");
+
+  if (!str_util::StartsWith(fname, "hdfs://")) {
+    return;
+  }
+
+  const string content1 = "content1";
+  TF_ASSERT_OK(WriteString(fname, content1));
+
+  std::unique_ptr<RandomAccessFile> reader;
+  TF_EXPECT_OK(hdfs.NewRandomAccessFile(fname, &reader));
+
+  string got;
+  got.resize(content1.size());
+  StringPiece result;
+  TF_EXPECT_OK(reader->Read(0, content1.size(), &result, &*got.begin()));
+  EXPECT_EQ(content1, result);
+
+  TF_EXPECT_OK(hdfs.DeleteFile(fname));
+
+  string content2 = "overwrite";
+  TF_ASSERT_OK(WriteString(fname, content1 + content2));
+
+  got.resize(content2.size());
+  reader->Read(content1.size(), content2.size(), &result, &*got.begin());
+  EXPECT_EQ(0, result.size());
+
+  static char set_enable_var[] = "HDFS_DISABLE_READ_EOF_RETRIED=0";
+  putenv(set_enable_var);
+}
+
 TEST_F(HadoopFileSystemTest, HarSplit) {
   string har_path =
       "har://hdfs-root/user/j.doe/my_archive.har/dir0/dir1/file.txt";


### PR DESCRIPTION
This is a PR from TaiJi AI platform in Tencent.

- The file copied by TF from HDFS to local may be wrong, when HDFS file is being overwritten [#42597](https://github.com/tensorflow/tensorflow/issues/42597)