### PR TITLE
Integrate cuBLASLt API into backend

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -3334,6 +3334,9 @@ tf_kernel_library(
     prefix = "batch_matmul_op",
     deps = MATH_DEPS + [":eigen_contraction_kernel"] + if_mkl_ml([
         "//third_party/mkl:intel_binary_blob",
+    ]) + if_cuda([
+        "//tensorflow/core/kernels:gpu_utils",
+        "//tensorflow/core/platform:tensor_float_32_utils",
     ]),
 )
 
@@ -3392,6 +3395,7 @@ tf_kernel_library(
     prefix = "fft_ops",
     deps = MATH_DEPS + [
     ] + if_cuda([
+        "//tensorflow/core/kernels:gpu_utils",
         "//tensorflow/core/platform/default/build_config:cufft_plugin",
     ]),
 )

--- a/tensorflow/core/kernels/batch_matmul_op_impl.h
+++ b/tensorflow/core/kernels/batch_matmul_op_impl.h
@@ -558,8 +558,8 @@ struct LaunchBatchMatMul<GPUDevice, Scalar> {
             stream->parent()->CreateBlasLtMatmulPlanStridedBatched(
                 /*ab_type=*/blas_dtype,
                 /*cd_type=*/blas_dtype, computation_type,
-                se::blas::PointerMode::kHost, blas_transpose_b,
-                blas_transpose_a, n, m, k, batch_size,
+                se::blas::PointerMode::kHost, se::blas::Epilogue::kDefault,
+                blas_transpose_b, blas_transpose_a, n, m, k, batch_size,
                 /*lda=*/in_y.dim_size(2), b_stride,
                 /*ldb=*/in_x.dim_size(2), a_stride, /*ldc=*/n, c_stride);
         OP_REQUIRES(
@@ -621,7 +621,8 @@ struct LaunchBatchMatMul<GPUDevice, Scalar> {
               stream
                   ->ThenBlasLtMatmul(plan.get(), alpha, *b_ptrs[0], *a_ptrs[0],
                                      beta, c_ptrs[0], &scratch_allocator,
-                                     profile_algorithm.get(), &profile_result)
+                                     profile_algorithm.get(), {},
+                                     &profile_result)
                   .ok();
 
           VLOG(4) << "  Autotune algorithm " << i

--- a/tensorflow/core/kernels/batch_matmul_op_impl.h
+++ b/tensorflow/core/kernels/batch_matmul_op_impl.h
@@ -555,23 +555,23 @@ struct LaunchBatchMatMul<GPUDevice, Scalar> {
             GetBlasComputationType(dtype, allow_tf32, &computation_type),
             errors::Internal("Unsupported dtype for batched matmul"));
         std::unique_ptr<se::blas::IBlasLtMatmulPlan> plan =
-            stream->parent()->CreateBlasLtMatmulPlanStridedBatched(
-                /*ab_type=*/blas_dtype,
-                /*cd_type=*/blas_dtype, computation_type,
-                se::blas::PointerMode::kHost, se::blas::Epilogue::kDefault,
-                blas_transpose_b, blas_transpose_a, n, m, k, batch_size,
-                /*lda=*/in_y.dim_size(2), b_stride,
-                /*ldb=*/in_x.dim_size(2), a_stride, /*ldc=*/n, c_stride);
+            stream->parent()->CreateBlasLtMatmulPlan(
+                {/*ab_type=*/blas_dtype,
+                 /*c_type=*/blas_dtype, computation_type,
+                 se::blas::PointerMode::kHost, se::blas::Epilogue::kDefault,
+                 blas_transpose_b, blas_transpose_a, n, m, k,
+                 /*lda=*/in_y.dim_size(2), /*ldb=*/in_x.dim_size(2), /*ldc=*/n,
+                 batch_size, b_stride, a_stride, c_stride});
         OP_REQUIRES(
             context, plan,
-            errors::Internal(
-                "CreateBlasLtMatmulPlanStridedBatched failed : a.shape=(",
-                in_x.dim_size(0), ", ", in_x.dim_size(1), ", ",
-                in_x.dim_size(2), "), b.shape=(", in_y.dim_size(0), ", ",
-                in_y.dim_size(1), ", ", in_y.dim_size(2), "), m=", m, ", n=", n,
-                ", k=", k, ", batch_size=", batch_size, ", adjoint_a=", adj_x,
-                ", adjoint_b=", adj_x, ", dtype=", dtype,
-                ", computation_type=", computation_type));
+            errors::Internal("CreateBlasLtMatmulPlan failed : a.shape=(",
+                             in_x.dim_size(0), ", ", in_x.dim_size(1), ", ",
+                             in_x.dim_size(2), "), b.shape=(", in_y.dim_size(0),
+                             ", ", in_y.dim_size(1), ", ", in_y.dim_size(2),
+                             "), m=", m, ", n=", n, ", k=", k,
+                             ", batch_size=", batch_size, ", adjoint_a=", adj_x,
+                             ", adjoint_b=", adj_x, ", dtype=", dtype,
+                             ", computation_type=", computation_type));
         std::vector<std::unique_ptr<se::blas::IBlasLtMatmulAlgorithm>>
             algorithms;
         OP_REQUIRES(

--- a/tensorflow/core/kernels/batch_matmul_op_impl.h
+++ b/tensorflow/core/kernels/batch_matmul_op_impl.h
@@ -22,7 +22,6 @@ limitations under the License.
 
 #include <vector>
 
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/op.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"
@@ -34,17 +33,24 @@ limitations under the License.
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/lib/gtl/inlined_vector.h"
 #include "tensorflow/core/platform/logging.h"
+#include "tensorflow/core/platform/tensor_float_32_utils.h"
 #include "tensorflow/core/platform/types.h"
+#include "tensorflow/core/util/matmul_autotune.h"
 #include "tensorflow/core/util/matmul_bcast.h"
 #include "tensorflow/core/util/work_sharder.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 #if defined(TENSORFLOW_USE_CUSTOM_CONTRACTION_KERNEL)
 #include "tensorflow/core/kernels/eigen_contraction_kernel.h"
 #endif
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+#include "tensorflow/core/kernels/gpu_utils.h"
 #include "tensorflow/core/platform/stream_executor.h"
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+#if GOOGLE_CUDA
+#include "third_party/gpus/cuda/include/cuda.h"  // For CUDA_VERSION
+#endif
 
 namespace tensorflow {
 
@@ -219,7 +225,8 @@ template <typename Scalar>
 struct LaunchBatchMatMul<CPUDevice, Scalar> {
   static void Launch(OpKernelContext* context, const Tensor& in_x,
                      const Tensor& in_y, bool adj_x, bool adj_y, bool trans_x,
-                     bool trans_y, const MatMulBCast& bcast, Tensor* out) {
+                     bool trans_y, const MatMulBCast& bcast, bool use_autotune,
+                     Tensor* out) {
     typedef ParallelMatMulKernel<Scalar, Eigen::NumTraits<Scalar>::IsComplex>
         ParallelMatMulKernel;
     bool conjugate_result = false;
@@ -275,45 +282,201 @@ se::DeviceMemory<T> AsDeviceMemory(const T* gpu_memory) {
   return typed;
 }
 
-class BlasScratchAllocator : public se::ScratchAllocator {
+using BlasScratchAllocator = GpuScratchAllocator;
+
+int64 GetBlasWorkspaceLimit(const string& envvar_in_mb,
+                            int64 default_value_in_bytes) {
+  return GetWorkspaceLimit(envvar_in_mb, default_value_in_bytes);
+}
+
+// Encapsulate all of the shape, dtype etc. information that defines a unique
+// batched matmul operation.
+class BatchMatmulParameters {
  public:
-  using Stream = se::Stream;
-  using DeviceMemoryBytes = se::DeviceMemory<uint8>;
+  BatchMatmulParameters(bool trans_a, bool trans_b, bool adj_a, bool adj_b,
+                        uint64 m, uint64 n, uint64 k, uint64 batch_count,
+                        bool broadcast_a, bool broadcast_b, DataType dtype_ab,
+                        DataType dtype_cd, bool allow_tf32, int device_id)
+      : trans_a_(trans_a),
+        trans_b_(trans_b),
+        adj_a_(adj_a),
+        adj_b_(adj_b),
+        m_(m),
+        n_(n),
+        k_(k),
+        batch_count_(batch_count),
+        broadcast_a_(broadcast_a),
+        broadcast_b_(broadcast_b),
+        dtype_ab_(dtype_ab),
+        dtype_cd_(dtype_cd),
+        allow_tf32_(allow_tf32),
+        device_id_(device_id) {
+    hash_code_ = trans_a;
+    hash_code_ = Hash64Combine(hash_code_, trans_b);
+    hash_code_ = Hash64Combine(hash_code_, adj_a);
+    hash_code_ = Hash64Combine(hash_code_, adj_b);
+    hash_code_ = Hash64Combine(hash_code_, m);
+    hash_code_ = Hash64Combine(hash_code_, n);
+    hash_code_ = Hash64Combine(hash_code_, k);
+    hash_code_ = Hash64Combine(hash_code_, batch_count);
+    hash_code_ = Hash64Combine(hash_code_, broadcast_a);
+    hash_code_ = Hash64Combine(hash_code_, broadcast_b);
+    hash_code_ = Hash64Combine(hash_code_, dtype_ab);
+    hash_code_ = Hash64Combine(hash_code_, dtype_cd);
+    hash_code_ = Hash64Combine(hash_code_, allow_tf32);
+    hash_code_ = Hash64Combine(hash_code_, device_id);
+  }
+  bool operator==(const BatchMatmulParameters& other) const {
+    return this->get_data_as_tuple() == other.get_data_as_tuple();
+  }
 
-  BlasScratchAllocator(OpKernelContext* context) : context_(context) {}
+  bool operator!=(const BatchMatmulParameters& other) const {
+    return !(*this == other);
+  }
+  uint64 hash() const { return hash_code_; }
 
-  int64 GetMemoryLimitInBytes() override { return -1; }
-
-  se::port::StatusOr<DeviceMemoryBytes> AllocateBytes(
-      int64 byte_size) override {
-    Tensor temporary_memory;
-
-    Status allocation_status(context_->allocate_temp(
-        DT_UINT8, TensorShape({byte_size}), &temporary_memory));
-    if (!allocation_status.ok()) {
-      return se::port::StatusOr<DeviceMemoryBytes>(
-          DeviceMemoryBytes::MakeFromByteSize(nullptr, 0));
-    }
-    // Hold the reference of the allocated tensors until the end of the
-    // allocator.
-    allocated_tensors_.push_back(temporary_memory);
-    return se::port::StatusOr<DeviceMemoryBytes>(
-        DeviceMemoryBytes::MakeFromByteSize(
-            temporary_memory.flat<uint8>().data(),
-            temporary_memory.flat<uint8>().size()));
+  string ToString() const {
+    // clang-format off
+    return strings::StrCat(
+        trans_a_, ", ", trans_b_, ", ", adj_a_, ", ", adj_b_, ", ",
+        m_, ", ", n_, ", ", k_, ", ", batch_count_, ", ",
+        broadcast_a_, ", ", broadcast_b_, ", ",
+        dtype_ab_, ", ", dtype_cd_, ", ", allow_tf32_, ", ", device_id_);
+    // clang-format on
   }
 
  private:
-  OpKernelContext* context_;
-  std::vector<Tensor> allocated_tensors_;
+  typedef std::tuple<bool, bool, bool, bool, int64, int64, int64, int64, bool,
+                     bool, DataType, DataType, bool, int>
+      ParameterDataType;
+
+  ParameterDataType get_data_as_tuple() const {
+    return std::make_tuple(trans_a_, trans_b_, adj_a_, adj_b_, m_, n_, k_,
+                           batch_count_, broadcast_a_, broadcast_b_, dtype_ab_,
+                           dtype_cd_, allow_tf32_, device_id_);
+  }
+
+  bool trans_a_;
+  bool trans_b_;
+  bool adj_a_;
+  bool adj_b_;
+  uint64 m_;
+  uint64 n_;
+  uint64 k_;
+  uint64 batch_count_;
+  bool broadcast_a_;
+  bool broadcast_b_;
+  DataType dtype_ab_;
+  DataType dtype_cd_;
+  bool allow_tf32_;
+  int device_id_;
+  uint64 hash_code_;
 };
+
+bool GetBlasComputationType(const DataType& dtype, bool allow_tf32,
+                            se::blas::ComputationType* compute_type) {
+  using se::blas::ComputationType;
+  static bool use_f32_for_f16_computation = MatmulDoFP32ComputationFP16Input();
+  ComputationType f32_type =
+      allow_tf32 ? ComputationType::kF32FastTF32 : ComputationType::kF32;
+  switch (dtype) {
+    case DT_HALF:
+    case DT_BFLOAT16:
+      *compute_type =
+          use_f32_for_f16_computation ? f32_type : ComputationType::kF16;
+      return true;
+    case DT_FLOAT:
+      *compute_type = f32_type;
+      return true;
+    case DT_DOUBLE:
+      *compute_type = ComputationType::kF64;
+      return true;
+    case DT_COMPLEX64:
+      *compute_type = f32_type;
+      return true;
+    case DT_COMPLEX128:
+      *compute_type = ComputationType::kComplexF64;
+      return true;
+    default:
+      // Unsupported compute_type, return false.
+      return false;
+  }
+}
+
+// Thread-safe map from matmul parameters to their corresponding plan and
+// algorithms.
+template <typename Parameters>
+class BlasLtMatmulPlanMap {
+ public:
+  struct PlanAndAlgorithms {
+    std::unique_ptr<se::blas::IBlasLtMatmulPlan> plan;
+    std::vector<std::unique_ptr<se::blas::IBlasLtMatmulAlgorithm>> algorithms;
+  };
+
+  const PlanAndAlgorithms* Find(const Parameters& params) {
+    mutex_lock lock(mu_);
+    auto iter = params_plan_map_.find(params);
+    if (iter == params_plan_map_.end()) {
+      return nullptr;
+    }
+    return &iter->second;
+  }
+  const PlanAndAlgorithms* Insert(const Parameters& params,
+                                  PlanAndAlgorithms value) {
+    mutex_lock lock(mu_);
+    return &params_plan_map_.emplace(params, std::move(value)).first->second;
+  }
+
+ private:
+  struct Hasher {
+    std::size_t operator()(const Parameters& parameter) const {
+      return parameter.hash();
+    }
+  };
+
+  mutable mutex mu_;
+  std::unordered_map<Parameters, PlanAndAlgorithms, Hasher> params_plan_map_
+      GUARDED_BY(mu_);
+};
+
+template <typename Parameters>
+struct BlasLtPlanMapSingleton {
+  typedef BlasLtMatmulPlanMap<Parameters> PlanMapType;
+  static PlanMapType* GetInstance() {
+    static PlanMapType* instance = new PlanMapType();
+    return instance;
+  }
+};
+
+typedef BlasLtPlanMapSingleton<BatchMatmulParameters>
+    BatchMatmulPlanMapSingleton;
+
+// A dummy type to group matmul autotune results together.
+struct BatchMatmulAutoTuneGroup {
+  static string name() { return "MatmulLt"; }
+};
+
+typedef AutoTuneSingleton<BatchMatmulAutoTuneGroup, BatchMatmulParameters,
+                          se::blas::AlgorithmConfig>
+    AutoTuneBatchMatmul;
+
+template <typename Scalar>
+struct CoefficientType {
+  typedef Scalar type;
+};
+template <>
+struct CoefficientType<Eigen::half> {
+  typedef float type;
+};
+
 }  // namespace
 
 template <typename Scalar>
 struct LaunchBatchMatMul<GPUDevice, Scalar> {
   static void Launch(OpKernelContext* context, const Tensor& in_x,
                      const Tensor& in_y, bool adj_x, bool adj_y, bool trans_x,
-                     bool trans_y, const MatMulBCast& bcast, Tensor* out) {
+                     bool trans_y, const MatMulBCast& bcast, bool use_autotune,
+                     Tensor* out) {
     se::blas::Transpose trans[] = {se::blas::Transpose::kNoTranspose,
                                    se::blas::Transpose::kTranspose,
                                    se::blas::Transpose::kConjugateTranspose};
@@ -347,6 +510,198 @@ struct LaunchBatchMatMul<GPUDevice, Scalar> {
     uint64 b_stride;
     uint64 c_stride;
 
+    typedef typename CoefficientType<Scalar>::type Coefficient;
+
+    static const int64 max_scratch_size = GetBlasWorkspaceLimit(
+        "TF_CUBLAS_WORKSPACE_LIMIT_IN_MB", 1LL << 32);  // 4GB by default
+
+    // The BlasLtMatmul routines are only supported from CUDA 11.0 onward.
+#if GOOGLE_CUDA && CUDA_VERSION >= 11000
+    bool is_full_broadcast =
+        std::min(bcast.x_batch_size(), bcast.y_batch_size()) == 1;
+    bool requires_mixed_broadcasting =
+        bcast.IsBroadcastingRequired() && !is_full_broadcast;
+    if (!requires_mixed_broadcasting) {
+      bool broadcast_a = bcast.x_batch_size() == 1;
+      bool broadcast_b = bcast.y_batch_size() == 1;
+      a_stride = broadcast_a ? 0 : m * k;
+      b_stride = broadcast_b ? 0 : k * n;
+      c_stride = m * n;
+      a_device_memory.push_back(AsDeviceMemory(a_base_ptr));
+      b_device_memory.push_back(AsDeviceMemory(b_base_ptr));
+      c_device_memory.push_back(AsDeviceMemory(c_base_ptr));
+      a_ptrs.push_back(&a_device_memory.back());
+      b_ptrs.push_back(&b_device_memory.back());
+      c_ptrs.push_back(&c_device_memory.back());
+
+      DataType dtype = DataTypeToEnum<Scalar>::value;
+      bool allow_tf32 = tensor_float_32_execution_enabled();
+      int device_id = stream->parent()->device_ordinal();
+      BatchMatmulParameters matmul_parameters(
+          trans_x, trans_y, adj_x, adj_y, m, n, k, batch_size, broadcast_a,
+          broadcast_b, dtype, dtype, allow_tf32, device_id);
+
+      static const bool max_autotune_algorithm_count =
+          MatmulMaxAutotuneAlgorithmCount();
+      int max_algorithm_count = use_autotune ? max_autotune_algorithm_count : 1;
+
+      const auto* plan_and_algorithms =
+          BatchMatmulPlanMapSingleton::GetInstance()->Find(matmul_parameters);
+      if (!plan_and_algorithms) {
+        se::blas::DataType blas_dtype = se::blas::ToDataType<Scalar>::value;
+        se::blas::ComputationType computation_type;
+        OP_REQUIRES(
+            context,
+            GetBlasComputationType(dtype, allow_tf32, &computation_type),
+            errors::Internal("Unsupported dtype for batched matmul"));
+        std::unique_ptr<se::blas::IBlasLtMatmulPlan> plan =
+            stream->parent()->CreateBlasLtMatmulPlanStridedBatched(
+                /*ab_type=*/blas_dtype,
+                /*cd_type=*/blas_dtype, computation_type,
+                se::blas::PointerMode::kHost, blas_transpose_b,
+                blas_transpose_a, n, m, k, batch_size,
+                /*lda=*/in_y.dim_size(2), b_stride,
+                /*ldb=*/in_x.dim_size(2), a_stride, /*ldc=*/n, c_stride);
+        OP_REQUIRES(
+            context, plan,
+            errors::Internal(
+                "CreateBlasLtMatmulPlanStridedBatched failed : a.shape=(",
+                in_x.dim_size(0), ", ", in_x.dim_size(1), ", ",
+                in_x.dim_size(2), "), b.shape=(", in_y.dim_size(0), ", ",
+                in_y.dim_size(1), ", ", in_y.dim_size(2), "), m=", m, ", n=", n,
+                ", k=", k, ", batch_size=", batch_size, ", adjoint_a=", adj_x,
+                ", adjoint_b=", adj_x, ", dtype=", dtype,
+                ", computation_type=", computation_type));
+        std::vector<std::unique_ptr<se::blas::IBlasLtMatmulAlgorithm>>
+            algorithms;
+        OP_REQUIRES(
+            context,
+            stream->parent()->GetBlasLtMatmulAlgorithms(
+                plan.get(), max_scratch_size, max_algorithm_count, &algorithms),
+            errors::Internal("GetBlasLtMatmulAlgorithms failed: a.shape=(",
+                             in_x.dim_size(0), ", ", in_x.dim_size(1), ", ",
+                             in_x.dim_size(2), "), b.shape=(", in_y.dim_size(0),
+                             ", ", in_y.dim_size(1), ", ", in_y.dim_size(2),
+                             "), m=", m, ", n=", n, ", k=", k,
+                             ", batch_size=", batch_size, ", adjoint_a=", adj_x,
+                             ", adjoint_b=", adj_x, ", dtype=", dtype,
+                             ", computation_type=", computation_type));
+        plan_and_algorithms =
+            BatchMatmulPlanMapSingleton::GetInstance()->Insert(
+                matmul_parameters, {std::move(plan), std::move(algorithms)});
+      }
+      const auto& plan = plan_and_algorithms->plan;
+      const auto& algorithms = plan_and_algorithms->algorithms;
+
+      // The BlasLtMatmul routines (unlike BlasGemm, BlasGemmBatched etc.) take
+      // alpha and beta with the same type as the matrices.
+      Scalar alpha(1.0);
+      Scalar beta(0.0);
+
+      // Note that algorithm_config.algorithm() here is used to refer
+      // to the index within the algorithms vector, not the algorithm
+      // itself.
+      se::blas::AlgorithmConfig algorithm_config(se::blas::kNoAlgorithm);
+      if (max_algorithm_count == 1) {
+        algorithm_config.set_algorithm(0);
+      } else if (!AutoTuneBatchMatmul::GetInstance()->Find(matmul_parameters,
+                                                           &algorithm_config)) {
+        VLOG(4) << "Autotuning BlasLtMatmul over " << algorithms.size()
+                << " algorithms.";
+        se::blas::ProfileResult best_result;
+        se::blas::ProfileResult profile_result;
+        //for (const auto& profile_algorithm : plan_and_algorithms->algorithms) {
+        for (size_t i = 0; i != algorithms.size(); ++i) {
+          const auto& profile_algorithm = algorithms[i];
+          // Create a new scratch allocator with every autotuning run so that
+          // scratch space is deallocated between runs.
+          BlasScratchAllocator scratch_allocator(max_scratch_size, context);
+
+          bool cublas_launch_status =
+              stream
+                  ->ThenBlasLtMatmul(plan.get(), alpha, *b_ptrs[0], *a_ptrs[0],
+                                     beta, c_ptrs[0], &scratch_allocator,
+                                     profile_algorithm.get(), &profile_result)
+                  .ok();
+
+          VLOG(4) << "  Autotune algorithm " << i
+                  << " result: " << profile_result.elapsed_time_in_ms()
+                  << " ms, valid=" << profile_result.is_valid()
+                  << ", workspace_size="
+                  << profile_algorithm->workspace_size();
+
+          if (cublas_launch_status && profile_result.is_valid() &&
+              profile_result.elapsed_time_in_ms() <
+                  best_result.elapsed_time_in_ms()) {
+            best_result = profile_result;
+          }
+        }
+
+        if (best_result.is_valid()) {
+          algorithm_config.set_algorithm(best_result.algorithm());
+        }
+        // We make sure that each matmul parameter set only gets one pass of
+        // autotune. If no algorithms works, we add kNoAlgorithm to the autotune
+        // map.
+        AutoTuneBatchMatmul::GetInstance()->Insert(matmul_parameters,
+                                                   algorithm_config);
+      }
+      se::blas::AlgorithmType algorithm_idx = algorithm_config.algorithm();
+      OP_REQUIRES(context,
+                  0 <= algorithm_idx && algorithm_idx < algorithms.size(),
+                  errors::Internal("Missing/invalid BatchMatmul algorithm"));
+      const auto& algorithm = algorithms[algorithm_idx];
+      BlasScratchAllocator scratch_allocator(max_scratch_size, context);
+      bool cublas_launch_status =
+          stream
+              ->ThenBlasLtMatmul(plan.get(), alpha, *b_ptrs[0], *a_ptrs[0],
+                                 beta, c_ptrs[0], &scratch_allocator,
+                                 algorithm.get())
+              .ok();
+      if (!cublas_launch_status) {
+        context->SetStatus(errors::Internal(
+            "Blas batched matmul launch failed : a.shape=(",
+            bcast.x_batch_size(), ", ", in_x.dim_size(0), ", ",
+            in_x.dim_size(1), "), b.shape=(", bcast.y_batch_size(), ", ",
+            in_y.dim_size(0), ", ", in_y.dim_size(1), "), m=", m, ", n=", n,
+            ", k=", k, ", batch_size=", batch_size));
+      }
+    } else {  // requires mixed broadcasting
+      const std::vector<int64>& a_batch_indices = bcast.x_batch_indices();
+      const std::vector<int64>& b_batch_indices = bcast.y_batch_indices();
+      for (int64 i = 0; i < bcast.x_batch_size(); ++i) {
+        a_device_memory.push_back(AsDeviceMemory(a_base_ptr + i * m * k));
+      }
+      for (int64 i = 0; i < bcast.y_batch_size(); ++i) {
+        b_device_memory.push_back(AsDeviceMemory(b_base_ptr + i * k * n));
+      }
+      for (int64 i = 0; i < batch_size; ++i) {
+        c_device_memory.push_back(AsDeviceMemory(c_base_ptr + i * m * n));
+        a_ptrs.push_back(&a_device_memory[a_batch_indices[i]]);
+        b_ptrs.push_back(&b_device_memory[b_batch_indices[i]]);
+        c_ptrs.push_back(&c_device_memory.back());
+      }
+
+      BlasScratchAllocator scratch_allocator(max_scratch_size, context);
+      bool blas_launch_status =
+          stream
+              ->ThenBlasGemmBatchedWithScratch(
+                  blas_transpose_b, blas_transpose_a, n, m, k,
+                  static_cast<Coefficient>(1.0), b_ptrs,
+                  adj_y || trans_y ? k : n, a_ptrs, adj_x || trans_x ? m : k,
+                  static_cast<Coefficient>(0.0), c_ptrs, n, batch_size,
+                  &scratch_allocator)
+              .ok();
+      if (!blas_launch_status) {
+        context->SetStatus(errors::Internal(
+            "Blas xGEMMBatched launch failed : a.shape=",
+            in_x.shape().DebugString(),
+            ", b.shape=", in_y.shape().DebugString(), ", m=", m, ", n=", n,
+            ", k=", k, ", batch_size=", batch_size));
+      }
+    }
+    return;
+#else  // if not GOOGLE_CUDA or CUDA_VERSION < 11000
     bool is_full_broadcast =
         std::min(bcast.x_batch_size(), bcast.y_batch_size()) == 1;
     bool use_strided_batched =
@@ -388,8 +743,6 @@ struct LaunchBatchMatMul<GPUDevice, Scalar> {
       }
     }
 
-    typedef Scalar Coefficient;
-
     // Blas does
     // C = A x B
     // where A, B and C are assumed to be in column major.
@@ -399,7 +752,10 @@ struct LaunchBatchMatMul<GPUDevice, Scalar> {
     if (batch_size == 1) {
       // This is a regular matrix*matrix or matrix*vector multiply. Avoid the
       // overhead of the scratch allocator and the batch interface.
-      if (n == 1 &&
+      // Note that the GEMV call here does not support Eigen::half, so we do not
+      // use this path in that case. A workaround is applied to the pointers
+      // passed to the call itself to avoid compilation errors.
+      if (!std::is_same<Scalar, Eigen::half>::value && n == 1 &&
           blas_transpose_b != se::blas::Transpose::kConjugateTranspose &&
           blas_transpose_a != se::blas::Transpose::kConjugateTranspose) {
         // This is a matrix*vector multiply so use GEMV to compute A * b.
@@ -410,13 +766,19 @@ struct LaunchBatchMatMul<GPUDevice, Scalar> {
         auto gemv_trans_a = blas_transpose_a == se::blas::Transpose::kTranspose
                                 ? se::blas::Transpose::kNoTranspose
                                 : se::blas::Transpose::kTranspose;
+        // Cast pointers as a workaround for GEMV not supporting Eigen::half
+        // (this will never actually be executed for Eigen::half).
+        typedef se::DeviceMemory<Coefficient> NonHalfDeviceMemoryType;
+        NonHalfDeviceMemoryType a_ptr(*(a_ptrs[0]));
+        NonHalfDeviceMemoryType b_ptr(*(b_ptrs[0]));
+        NonHalfDeviceMemoryType c_ptr(*(c_ptrs[0]));
         bool blas_launch_status =
             stream
                 ->ThenBlasGemv(gemv_trans_a, adj_x || trans_x ? m : k,
                                adj_x || trans_x ? k : m,
-                               static_cast<Coefficient>(1.0), *(a_ptrs[0]),
-                               adj_x || trans_x ? m : k, *(b_ptrs[0]), 1,
-                               static_cast<Coefficient>(0.0), c_ptrs[0], 1)
+                               static_cast<Coefficient>(1.0), a_ptr,
+                               adj_x || trans_x ? m : k, b_ptr, 1,
+                               static_cast<Coefficient>(0.0), &c_ptr, 1)
                 .ok();
         if (!blas_launch_status) {
           context->SetStatus(errors::Internal(
@@ -459,7 +821,7 @@ struct LaunchBatchMatMul<GPUDevice, Scalar> {
             ", k=", k, ", batch_size=", batch_size));
       }
     } else {
-      BlasScratchAllocator scratch_allocator(context);
+      BlasScratchAllocator scratch_allocator(max_scratch_size, context);
       bool blas_launch_status =
           stream
               ->ThenBlasGemmBatchedWithScratch(
@@ -477,153 +839,7 @@ struct LaunchBatchMatMul<GPUDevice, Scalar> {
             ", k=", k, ", batch_size=", batch_size));
       }
     }
-  }
-};
-
-template <>
-struct LaunchBatchMatMul<GPUDevice, Eigen::half> {
-  static void Launch(OpKernelContext* context, const Tensor& in_x,
-                     const Tensor& in_y, bool adj_x, bool adj_y, bool trans_x,
-                     bool trans_y, const MatMulBCast& bcast, Tensor* out) {
-    typedef Eigen::half Scalar;
-    se::blas::Transpose trans[] = {se::blas::Transpose::kNoTranspose,
-                                   se::blas::Transpose::kTranspose,
-                                   se::blas::Transpose::kConjugateTranspose};
-    const uint64 m = in_x.dim_size(adj_x || trans_x ? 2 : 1);
-    const uint64 k = in_x.dim_size(adj_x || trans_x ? 1 : 2);
-    const uint64 n = in_y.dim_size(adj_y || trans_y ? 1 : 2);
-    const uint64 batch_size = bcast.output_batch_size();
-    auto blas_transpose_a = trans[adj_x ? 2 : (trans_x ? 1 : 0)];
-    auto blas_transpose_b = trans[adj_y ? 2 : (trans_y ? 1 : 0)];
-
-    auto* stream = context->op_device_context()->stream();
-    OP_REQUIRES(context, stream, errors::Internal("No GPU stream available."));
-
-    typedef perftools::gputools::DeviceMemory<Scalar> DeviceMemoryType;
-    std::vector<DeviceMemoryType> a_device_memory;
-    std::vector<DeviceMemoryType> b_device_memory;
-    std::vector<DeviceMemoryType> c_device_memory;
-    std::vector<DeviceMemoryType*> a_ptrs;
-    std::vector<DeviceMemoryType*> b_ptrs;
-    std::vector<DeviceMemoryType*> c_ptrs;
-    a_device_memory.reserve(bcast.x_batch_size());
-    b_device_memory.reserve(bcast.y_batch_size());
-    c_device_memory.reserve(batch_size);
-    a_ptrs.reserve(batch_size);
-    b_ptrs.reserve(batch_size);
-    c_ptrs.reserve(batch_size);
-    auto* a_base_ptr = in_x.template flat<Scalar>().data();
-    auto* b_base_ptr = in_y.template flat<Scalar>().data();
-    auto* c_base_ptr = out->template flat<Scalar>().data();
-
-    uint64 a_stride;
-    uint64 b_stride;
-    uint64 c_stride;
-
-    bool is_full_broadcast =
-        std::min(bcast.x_batch_size(), bcast.y_batch_size()) == 1;
-    bool use_strided_batched =
-        (!bcast.IsBroadcastingRequired() || is_full_broadcast) &&
-        batch_size > 1;
-    if (use_strided_batched) {
-      a_stride = bcast.x_batch_size() != 1 ? m * k : 0;
-      b_stride = bcast.y_batch_size() != 1 ? k * n : 0;
-      c_stride = m * n;
-      a_device_memory.push_back(AsDeviceMemory(a_base_ptr));
-      b_device_memory.push_back(AsDeviceMemory(b_base_ptr));
-      c_device_memory.push_back(AsDeviceMemory(c_base_ptr));
-      a_ptrs.push_back(&a_device_memory.back());
-      b_ptrs.push_back(&b_device_memory.back());
-      c_ptrs.push_back(&c_device_memory.back());
-    } else if (!bcast.IsBroadcastingRequired()) {
-      for (int64 i = 0; i < batch_size; ++i) {
-        a_device_memory.push_back(AsDeviceMemory(a_base_ptr + i * m * k));
-        b_device_memory.push_back(AsDeviceMemory(b_base_ptr + i * k * n));
-        c_device_memory.push_back(AsDeviceMemory(c_base_ptr + i * m * n));
-        a_ptrs.push_back(&a_device_memory.back());
-        b_ptrs.push_back(&b_device_memory.back());
-        c_ptrs.push_back(&c_device_memory.back());
-      }
-    } else {
-      const std::vector<int64>& a_batch_indices = bcast.x_batch_indices();
-      const std::vector<int64>& b_batch_indices = bcast.y_batch_indices();
-      for (int64 i = 0; i < bcast.x_batch_size(); ++i) {
-        a_device_memory.push_back(AsDeviceMemory(a_base_ptr + i * m * k));
-      }
-      for (int64 i = 0; i < bcast.y_batch_size(); ++i) {
-        b_device_memory.push_back(AsDeviceMemory(b_base_ptr + i * k * n));
-      }
-      for (int64 i = 0; i < batch_size; ++i) {
-        c_device_memory.push_back(AsDeviceMemory(c_base_ptr + i * m * n));
-        a_ptrs.push_back(&a_device_memory[a_batch_indices[i]]);
-        b_ptrs.push_back(&b_device_memory[b_batch_indices[i]]);
-        c_ptrs.push_back(&c_device_memory.back());
-      }
-    }
-
-    typedef float Coefficient;
-
-    // Blas does
-    // C = A x B
-    // where A, B and C are assumed to be in column major.
-    // We want the output to be in row-major, so we can compute
-    // C' = B' x A', where ' stands for transpose (not adjoint).
-    // TODO(yangzihao): Choose the best of the three strategies using autotune.
-    if (batch_size == 1) {
-      // This is a regular matrix*matrix or matrix*vector multiply. Avoid the
-      // overhead of the scratch allocator and the batch interface.
-      // TODO(benbarsdell): Use fp16 Gemv if it becomes supported by CUBLAS
-      bool blas_launch_status =
-          stream
-              ->ThenBlasGemm(blas_transpose_b, blas_transpose_a, n, m, k,
-                             static_cast<Coefficient>(1.0), *(b_ptrs[0]),
-                             adj_y || trans_y ? k : n, *(a_ptrs[0]),
-                             adj_x || trans_x ? m : k,
-                             static_cast<Coefficient>(0.0), c_ptrs[0], n)
-              .ok();
-      if (!blas_launch_status) {
-        context->SetStatus(errors::Internal(
-            "Blas xGEMM launch failed : a.shape=", in_x.shape().DebugString(),
-            ", b.shape=", in_y.shape().DebugString(), ", m=", m, ", n=", n,
-            ", k=", k));
-      }
-    } else if (use_strided_batched) {
-      bool blas_launch_status =
-          stream
-              ->ThenBlasGemmStridedBatched(
-                  blas_transpose_b, blas_transpose_a, n, m, k,
-                  static_cast<Coefficient>(1.0), *b_ptrs[0],
-                  adj_y || trans_y ? k : n, b_stride, *a_ptrs[0],
-                  adj_x || trans_x ? m : k, a_stride,
-                  static_cast<Coefficient>(0.0), c_ptrs[0], n, c_stride,
-                  batch_size)
-              .ok();
-      if (!blas_launch_status) {
-        context->SetStatus(errors::Internal(
-            "Blas xGEMMStridedBatched launch failed : a.shape=",
-            in_x.shape().DebugString(),
-            ", b.shape=", in_y.shape().DebugString(), ", m=", m, ", n=", n,
-            ", k=", k, ", batch_size=", batch_size));
-      }
-    } else {
-      BlasScratchAllocator scratch_allocator(context);
-      bool blas_launch_status =
-          stream
-              ->ThenBlasGemmBatchedWithScratch(
-                  blas_transpose_b, blas_transpose_a, n, m, k,
-                  static_cast<Coefficient>(1.0), b_ptrs,
-                  adj_y || trans_y ? k : n, a_ptrs, adj_x || trans_x ? m : k,
-                  static_cast<Coefficient>(0.0), c_ptrs, n, batch_size,
-                  &scratch_allocator)
-              .ok();
-      if (!blas_launch_status) {
-        context->SetStatus(errors::Internal(
-            "Blas xGEMMBatched launch failed : a.shape=",
-            in_x.shape().DebugString(),
-            ", b.shape=", in_y.shape().DebugString(), ", m=", m, ", n=", n,
-            ", k=", k, ", batch_size=", batch_size));
-      }
-    }
+#endif  // not GOOGLE_CUDA or CUDA_VERSION < 11000
   }
 };
 
@@ -637,6 +853,7 @@ class BaseBatchMatMulOp : public OpKernel {
       : OpKernel(context) {
     OP_REQUIRES_OK(context, context->GetAttr("adj_x", &adj_x_));
     OP_REQUIRES_OK(context, context->GetAttr("adj_y", &adj_y_));
+    use_autotune_ = MatmulAutotuneEnable();
   }
 
   ~BaseBatchMatMulOp() override {}
@@ -698,7 +915,7 @@ class BaseBatchMatMulOp : public OpKernel {
                                  out->shape().DebugString()));
     LaunchBatchMatMul<Device, Scalar>::Launch(
         ctx, in0_reshaped, in1_reshaped, adj_x_, adj_y_, /*trans_x=*/false,
-        /*trans_y=*/false, bcast, &out_reshaped);
+        /*trans_y=*/false, bcast, use_autotune_, &out_reshaped);
   }
 
  protected:
@@ -708,6 +925,7 @@ class BaseBatchMatMulOp : public OpKernel {
  private:
   bool adj_x_;
   bool adj_y_;
+  bool use_autotune_;
 };
 
 // BatchMatMul Op implementation which disallows broadcasting.

--- a/tensorflow/core/kernels/batch_matmul_op_impl.h
+++ b/tensorflow/core/kernels/batch_matmul_op_impl.h
@@ -378,7 +378,7 @@ bool GetBlasComputationType(const DataType& dtype, bool allow_tf32,
   using se::blas::ComputationType;
   static bool use_f32_for_f16_computation = MatmulDoFP32ComputationFP16Input();
   ComputationType f32_type =
-      allow_tf32 ? ComputationType::kF32FastTF32 : ComputationType::kF32;
+      allow_tf32 ? ComputationType::kTF32AsF32 : ComputationType::kF32;
   switch (dtype) {
     case DT_HALF:
     case DT_BFLOAT16:

--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -619,19 +619,7 @@ template struct LaunchConv2DOp<CPUDevice, double>;
 
 int64 GetDnnWorkspaceLimit(const string& envvar_in_mb,
                            int64 default_value_in_bytes) {
-  const char* workspace_limit_in_mb_str = getenv(envvar_in_mb.c_str());
-  if (workspace_limit_in_mb_str != nullptr &&
-      strcmp(workspace_limit_in_mb_str, "") != 0) {
-    int64 scratch_limit_in_mb = -1;
-    if (strings::safe_strto64(workspace_limit_in_mb_str,
-                              &scratch_limit_in_mb)) {
-      return scratch_limit_in_mb * (1 << 20);
-    } else {
-      LOG(WARNING) << "Invalid value for env-var " << envvar_in_mb << ": "
-                   << workspace_limit_in_mb_str;
-    }
-  }
-  return default_value_in_bytes;
+  return GetWorkspaceLimit(envvar_in_mb, default_value_in_bytes);
 }
 
 // A dummy type to group forward convolution autotune results together.

--- a/tensorflow/core/kernels/fft_ops.cc
+++ b/tensorflow/core/kernels/fft_ops.cc
@@ -31,6 +31,7 @@ limitations under the License.
 
 #if (defined(GOOGLE_CUDA) && GOOGLE_CUDA) || \
     (defined(TENSORFLOW_USE_ROCM) && TENSORFLOW_USE_ROCM)
+#include "tensorflow/core/kernels/gpu_utils.h"
 #include "tensorflow/core/platform/stream_executor.h"
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
@@ -400,20 +401,7 @@ class CufftScratchAllocator : public se::ScratchAllocator {
 
 int64 GetCufftWorkspaceLimit(const string& envvar_in_mb,
                              int64 default_value_in_bytes) {
-  const char* workspace_limit_in_mb_str = getenv(envvar_in_mb.c_str());
-  if (workspace_limit_in_mb_str != nullptr &&
-      strcmp(workspace_limit_in_mb_str, "") != 0) {
-    int64 scratch_limit_in_mb = -1;
-    Status status = ReadInt64FromEnvVar(envvar_in_mb, default_value_in_bytes,
-                                        &scratch_limit_in_mb);
-    if (!status.ok()) {
-      LOG(WARNING) << "Invalid value for env-var " << envvar_in_mb << ": "
-                   << workspace_limit_in_mb_str;
-    } else {
-      return scratch_limit_in_mb * (1 << 20);
-    }
-  }
-  return default_value_in_bytes;
+  return GetWorkspaceLimit(envvar_in_mb, default_value_in_bytes);
 }
 
 class FFTGPUBase : public FFTBase {

--- a/tensorflow/core/util/matmul_autotune.cc
+++ b/tensorflow/core/util/matmul_autotune.cc
@@ -48,4 +48,22 @@ bool MatmulDoFP32ComputationFP16Input() {
   return value;
 }
 
+int MatmulMaxAutotuneAlgorithmCount() {
+  int64 value;
+  // In CUDA 11, cublasLtMatmulAlgoGetHeuristic typically returns <= 4
+  // algorithms for a given configuration, so 10 seems like a reasonable default
+  // here.
+  Status status =
+      ReadInt64FromEnvVar("TF_MATMUL_AUTOTUNE_MAX_ALGORITHMS", 10, &value);
+  if (!status.ok()) {
+    LOG(ERROR) << status.error_message();
+  }
+  static constexpr const int kMaxValue = std::numeric_limits<int>::max();
+  if (value < 1 || value > kMaxValue) {
+    LOG(ERROR) << "Invalid value for TF_MATMUL_AUTOTUNE_MAX_ALGORITHMS: "
+               << value << " is not in range [1, " << kMaxValue << "]";
+  }
+  return value;
+}
+
 }  // namespace tensorflow

--- a/tensorflow/core/util/matmul_autotune.h
+++ b/tensorflow/core/util/matmul_autotune.h
@@ -22,6 +22,7 @@ namespace tensorflow {
 
 bool MatmulAutotuneEnable();
 bool MatmulDoFP32ComputationFP16Input();
+int MatmulMaxAutotuneAlgorithmCount();
 
 }  // namespace tensorflow
 

--- a/tensorflow/stream_executor/blas.cc
+++ b/tensorflow/stream_executor/blas.cc
@@ -97,19 +97,19 @@ std::ostream& operator<<(std::ostream& os, ComputationType ty) {
 
 string DataTypeString(DataType ty) {
   switch (ty) {
-    case DataType::kF16:
+    case DataType::kHalf:
       return "f16";
-    case DataType::kF32:
+    case DataType::kFloat:
       return "f32";
-    case DataType::kF64:
+    case DataType::kDouble:
       return "f64";
-    case DataType::kI8:
+    case DataType::kInt8:
       return "i8";
-    case DataType::kI32:
+    case DataType::kInt32:
       return "i32";
-    case DataType::kComplexF32:
+    case DataType::kComplexFloat:
       return "complex f32";
-    case DataType::kComplexF64:
+    case DataType::kComplexDouble:
       return "complex f64";
     default:
       LOG(FATAL) << "Unknown DataType " << static_cast<int32>(ty);

--- a/tensorflow/stream_executor/blas.cc
+++ b/tensorflow/stream_executor/blas.cc
@@ -95,5 +95,30 @@ std::ostream& operator<<(std::ostream& os, ComputationType ty) {
   return os << ComputationTypeString(ty);
 }
 
+string DataTypeString(DataType ty) {
+  switch (ty) {
+    case DataType::kF16:
+      return "f16";
+    case DataType::kF32:
+      return "f32";
+    case DataType::kF64:
+      return "f64";
+    case DataType::kI8:
+      return "i8";
+    case DataType::kI32:
+      return "i32";
+    case DataType::kComplexF32:
+      return "complex f32";
+    case DataType::kComplexF64:
+      return "complex f64";
+    default:
+      LOG(FATAL) << "Unknown DataType " << static_cast<int32>(ty);
+  }
+}
+
+std::ostream& operator<<(std::ostream& os, DataType ty) {
+  return os << DataTypeString(ty);
+}
+
 }  // namespace blas
 }  // namespace stream_executor

--- a/tensorflow/stream_executor/blas.h
+++ b/tensorflow/stream_executor/blas.h
@@ -107,8 +107,8 @@ enum class ComputationType {
   // The below values are only supported for BlasLt routines (both real and
   // complex). They use float32 for accumulation but round the input mantissas
   // to a smaller number of bits.
-  kF32FastTF32, // 32-bit floating-point with reduced (>=10-bit) mantissa
-  kF32FastBF16, // 32-bit floating-point with reduced (7-bit) mantissa
+  kTF32AsF32,  // 32-bit floating-point with reduced (>=10-bit) mantissa
+  kBF16AsF32,  // 32-bit floating-point with reduced (7-bit) mantissa
 };
 
 enum class Epilogue {

--- a/tensorflow/stream_executor/blas.h
+++ b/tensorflow/stream_executor/blas.h
@@ -1454,19 +1454,18 @@ class BlasSupport {
   // Creates a backend-specific plan object for a blaslt matmul operation, which
   // can then be passed to DoBlasLtMatmul(). When possible, plans should be
   // created once and reused for multiple calls to DoBlasLtMatmul().
-  // Returns a null pointer on failure.
-  virtual std::unique_ptr<blas::IBlasLtMatmulPlan> CreateBlasLtMatmulPlan(
-      const blas::BlasLtMatmulPlanParams& params) = 0;
+  virtual port::StatusOr<std::unique_ptr<blas::IBlasLtMatmulPlan>>
+  CreateBlasLtMatmulPlan(const blas::BlasLtMatmulPlanParams& params) = 0;
 
   // Gets a list of supported algorithms for DoBlasLtMatmul. The algorithms are
   // returned in the order of increasing estimated compute time according to an
   // internal heuristic. The first returned algorithm can be used as the default
   // algorithm if no autotuning is to be performed.
-  virtual bool GetBlasLtMatmulAlgorithms(
-      const blas::IBlasLtMatmulPlan* plan, size_t max_workspace_size,
-      int max_algorithm_count,
-      std::vector<std::unique_ptr<blas::IBlasLtMatmulAlgorithm>>*
-          out_algorithms) = 0;
+  virtual port::StatusOr<
+      std::vector<std::unique_ptr<blas::IBlasLtMatmulAlgorithm>>>
+  GetBlasLtMatmulAlgorithms(const blas::IBlasLtMatmulPlan* plan,
+                            size_t max_workspace_size,
+                            int max_algorithm_count) = 0;
 
   // Executes a blaslt matmul operation on the stream. If output_profile_result
   // is not nullptr, the operation is profiled, error messages are
@@ -2330,13 +2329,12 @@ class BlasSupport {
                   uint64 n, std::complex<double> alpha,                        \
                   const DeviceMemory<std::complex<double>> &a, int lda,        \
                   DeviceMemory<std::complex<double>> *b, int ldb) override;    \
-  std::unique_ptr<blas::IBlasLtMatmulPlan> CreateBlasLtMatmulPlan(             \
-      const blas::BlasLtMatmulPlanParams& params) override;                    \
-  bool GetBlasLtMatmulAlgorithms(                                              \
-      const blas::IBlasLtMatmulPlan* plan, size_t max_workspace_size,          \
-      int max_algorithm_count,                                                 \
-      std::vector<std::unique_ptr<blas::IBlasLtMatmulAlgorithm>>*              \
-          out_algorithms) override;                                            \
+  port::StatusOr<std::unique_ptr<blas::IBlasLtMatmulPlan>>                     \
+  CreateBlasLtMatmulPlan(const blas::BlasLtMatmulPlanParams& params) override; \
+  port::StatusOr<std::vector<std::unique_ptr<blas::IBlasLtMatmulAlgorithm>>>   \
+  GetBlasLtMatmulAlgorithms(const blas::IBlasLtMatmulPlan* plan,               \
+                            size_t max_workspace_size,                         \
+                            int max_algorithm_count) override;                 \
   bool DoBlasLtMatmul(                                                         \
       Stream* stream, const blas::IBlasLtMatmulPlan* plan,                     \
       const HostOrDeviceScalar<void>& alpha, DeviceMemoryBase a,               \

--- a/tensorflow/stream_executor/blas.h
+++ b/tensorflow/stream_executor/blas.h
@@ -105,7 +105,8 @@ enum class ComputationType {
   kComplexF32,  // Complex number comprised of two f32s.
   kComplexF64,  // Complex number comprised of two f64s.
   // The below values are only supported for BlasLt routines (both real and
-  // complex).
+  // complex). They use float32 for accumulation but round the input mantissas
+  // to a smaller number of bits.
   kF32FastTF32, // 32-bit floating-point with reduced (>=10-bit) mantissa
   kF32FastBF16, // 32-bit floating-point with reduced (7-bit) mantissa
 };

--- a/tensorflow/stream_executor/blas.h
+++ b/tensorflow/stream_executor/blas.h
@@ -44,6 +44,7 @@ limitations under the License.
 #include <vector>
 
 #include "tensorflow/stream_executor/host_or_device_scalar.h"
+#include "tensorflow/stream_executor/dnn.h"  // For DataType, ToDataType
 #include "tensorflow/stream_executor/lib/array_slice.h"
 #include "tensorflow/stream_executor/lib/statusor.h"
 #include "tensorflow/stream_executor/platform/port.h"
@@ -119,16 +120,8 @@ std::string ComputationTypeString(ComputationType ty);
 
 std::ostream &operator<<(std::ostream &os, ComputationType ty);
 
-// Type with which inputs and outputs of a blaslt routine are performed.
-enum class DataType {
-  kF16,         // 16-bit floating-point
-  kF32,         // 32-bit floating-point
-  kF64,         // 64-bit floating-point
-  kI8,          // 8-bit integer
-  kI32,         // 32-bit integer
-  kComplexF32,  // Complex number comprised of two f32s
-  kComplexF64,  // Complex number comprised of two f64s
-};
+using dnn::DataType;
+using dnn::ToDataType;
 
 // Describes the type of pointers for the scaling factors alpha and beta in
 // blaslt routines.
@@ -141,38 +134,6 @@ enum class PointerMode {
 string DataTypeString(DataType ty);
 
 std::ostream &operator<<(std::ostream &os, DataType ty);
-
-// Converts a compile-time type to a DataType value.
-template <typename T>
-struct ToDataType {};
-template <>
-struct ToDataType<Eigen::half> {
-  static constexpr const DataType value = DataType::kF16;
-};
-template <>
-struct ToDataType<float> {
-  static constexpr const DataType value = DataType::kF32;
-};
-template <>
-struct ToDataType<double> {
-  static constexpr const DataType value = DataType::kF64;
-};
-template <>
-struct ToDataType<int8> {
-  static constexpr const DataType value = DataType::kI8;
-};
-template <>
-struct ToDataType<int32> {
-  static constexpr const DataType value = DataType::kI32;
-};
-template <>
-struct ToDataType<std::complex<float>> {
-  static constexpr const DataType value = DataType::kComplexF32;
-};
-template <>
-struct ToDataType<std::complex<double>> {
-  static constexpr const DataType value = DataType::kComplexF64;
-};
 
 // Opaque identifier for an "algorithm" used by a blas routine.  This functions
 // as a hint to the blas library.

--- a/tensorflow/stream_executor/cuda/BUILD
+++ b/tensorflow/stream_executor/cuda/BUILD
@@ -243,12 +243,36 @@ alias(
 )
 
 cc_library(
+    name = "cublasLt_stub",
+    srcs = if_cuda_is_configured(["cublasLt_stub.cc"]),
+    textual_hdrs = glob(["cublasLt_*.inc"]),
+    deps = if_cuda_is_configured([
+        # LINT.IfChange
+        "@local_config_cuda//cuda:cublas_headers",
+        # LINT.ThenChange(//tensorflow/copy.bara.sky:cublasLt_headers)
+        "@local_config_cuda//cuda:cuda_headers",
+        "//tensorflow/stream_executor/lib",
+        "//tensorflow/stream_executor/platform:dso_loader",
+    ]),
+)
+
+alias(
+    name = "cublasLt_lib",
+    actual = select({
+        "//tensorflow:oss": ":cublasLt_stub",
+        "//conditions:default": "@local_config_cuda//cuda:cublasLt",
+    }),
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
     name = "cublas_plugin",
     srcs = if_cuda_is_configured(["cuda_blas.cc"]),
     hdrs = if_cuda_is_configured(["cuda_blas.h"]),
     visibility = ["//visibility:public"],
     deps = if_cuda_is_configured([
         ":cublas_lib",
+        ":cublasLt_lib",
         ":cuda_activation",
         ":cuda_gpu_executor",
         ":cuda_platform_id",

--- a/tensorflow/stream_executor/cuda/cublasLt_11_0.inc
+++ b/tensorflow/stream_executor/cuda/cublasLt_11_0.inc
@@ -1,0 +1,415 @@
+// Auto-generated, do not edit.
+
+extern "C" {
+
+cublasStatus_t CUBLASWINAPI
+cublasLtCreate(cublasLtHandle_t *lightHandle) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(cublasLtHandle_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtCreate");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(lightHandle);
+}
+
+cublasStatus_t CUBLASWINAPI
+cublasLtDestroy(cublasLtHandle_t lightHandle) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(cublasLtHandle_t);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtDestroy");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(lightHandle);
+}
+
+size_t CUBLASWINAPI
+cublasLtGetVersion(void) {
+  using FuncPtr = size_t (CUBLASWINAPI *)();
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtGetVersion");
+  if (!func_ptr) return 0;
+  return func_ptr();
+}
+
+size_t CUBLASWINAPI
+cublasLtGetCudartVersion(void) {
+  using FuncPtr = size_t (CUBLASWINAPI *)();
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtGetCudartVersion");
+  if (!func_ptr) return 0;
+  return func_ptr();
+}
+
+cublasStatus_t CUBLASWINAPI
+cublasLtGetProperty(libraryPropertyType type, int *value) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(libraryPropertyType, int *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtGetProperty");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(type, value);
+}
+
+cublasStatus_t CUBLASWINAPI
+cublasLtMatmul(cublasLtHandle_t lightHandle,
+               cublasLtMatmulDesc_t computeDesc,
+               const void *alpha, /* host or device pointer */
+               const void *A,
+               cublasLtMatrixLayout_t Adesc,
+               const void *B,
+               cublasLtMatrixLayout_t Bdesc,
+               const void *beta, /* host or device pointer */
+               const void *C,
+               cublasLtMatrixLayout_t Cdesc,
+               void *D,
+               cublasLtMatrixLayout_t Ddesc,
+               const cublasLtMatmulAlgo_t *algo,
+               void *workspace,
+               size_t workspaceSizeInBytes,
+               cudaStream_t stream) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(cublasLtHandle_t, cublasLtMatmulDesc_t, const void *, const void *, cublasLtMatrixLayout_t, const void *, cublasLtMatrixLayout_t, const void *, const void *, cublasLtMatrixLayout_t, void *, cublasLtMatrixLayout_t, const cublasLtMatmulAlgo_t *, void *, size_t, cudaStream_t);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtMatmul");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(lightHandle, computeDesc, alpha, A, Adesc, B, Bdesc, beta, C, Cdesc, D, Ddesc, algo, workspace, workspaceSizeInBytes, stream);
+}
+
+cublasStatus_t CUBLASWINAPI
+cublasLtMatrixTransform(cublasLtHandle_t lightHandle,
+                        cublasLtMatrixTransformDesc_t transformDesc,
+                        const void *alpha, /* host or device pointer */
+                        const void *A,
+                        cublasLtMatrixLayout_t Adesc,
+                        const void *beta, /* host or device pointer */
+                        const void *B,
+                        cublasLtMatrixLayout_t Bdesc,
+                        void *C,
+                        cublasLtMatrixLayout_t Cdesc,
+                        cudaStream_t stream) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(cublasLtHandle_t, cublasLtMatrixTransformDesc_t, const void *, const void *, cublasLtMatrixLayout_t, const void *, const void *, cublasLtMatrixLayout_t, void *, cublasLtMatrixLayout_t, cudaStream_t);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtMatrixTransform");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(lightHandle, transformDesc, alpha, A, Adesc, beta, B, Bdesc, C, Cdesc, stream);
+}
+
+cublasStatus_t CUBLASWINAPI
+cublasLtMatrixLayoutInit_internal(  //
+    cublasLtMatrixLayout_t matLayout,
+    size_t size,
+    cudaDataType type,
+    uint64_t rows,
+    uint64_t cols,
+    int64_t ld) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(//
+    cublasLtMatrixLayout_t, size_t, cudaDataType, uint64_t, uint64_t, int64_t);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtMatrixLayoutInit_internal");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(matLayout, size, type, rows, cols, ld);
+}
+
+cublasStatus_t CUBLASWINAPI
+cublasLtMatrixLayoutCreate(  //
+    cublasLtMatrixLayout_t *matLayout,
+    cudaDataType type,
+    uint64_t rows,
+    uint64_t cols,
+    int64_t ld) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(//
+    cublasLtMatrixLayout_t *, cudaDataType, uint64_t, uint64_t, int64_t);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtMatrixLayoutCreate");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(matLayout, type, rows, cols, ld);
+}
+
+cublasStatus_t CUBLASWINAPI
+cublasLtMatrixLayoutDestroy(cublasLtMatrixLayout_t matLayout) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(cublasLtMatrixLayout_t);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtMatrixLayoutDestroy");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(matLayout);
+}
+
+cublasStatus_t CUBLASWINAPI
+cublasLtMatrixLayoutSetAttribute(  //
+    cublasLtMatrixLayout_t matLayout,
+    cublasLtMatrixLayoutAttribute_t attr,
+    const void *buf,
+    size_t sizeInBytes) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(//
+    cublasLtMatrixLayout_t, cublasLtMatrixLayoutAttribute_t, const void *, size_t);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtMatrixLayoutSetAttribute");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(matLayout, attr, buf, sizeInBytes);
+}
+
+cublasStatus_t CUBLASWINAPI
+cublasLtMatrixLayoutGetAttribute(  //
+    cublasLtMatrixLayout_t matLayout,
+    cublasLtMatrixLayoutAttribute_t attr,
+    void *buf,
+    size_t sizeInBytes,
+    size_t *sizeWritten) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(//
+    cublasLtMatrixLayout_t, cublasLtMatrixLayoutAttribute_t, void *, size_t, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtMatrixLayoutGetAttribute");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(matLayout, attr, buf, sizeInBytes, sizeWritten);
+}
+
+cublasStatus_t CUBLASWINAPI cublasLtMatmulDescInit_internal(  //
+    cublasLtMatmulDesc_t matmulDesc,
+    size_t size,
+    cublasComputeType_t computeType,
+    cudaDataType_t scaleType) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(//
+    cublasLtMatmulDesc_t, size_t, cublasComputeType_t, cudaDataType_t);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtMatmulDescInit_internal");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(matmulDesc, size, computeType, scaleType);
+}
+
+cublasStatus_t CUBLASWINAPI
+cublasLtMatmulDescCreate(cublasLtMatmulDesc_t *matmulDesc, cublasComputeType_t computeType, cudaDataType_t scaleType) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(cublasLtMatmulDesc_t *, cublasComputeType_t, cudaDataType_t);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtMatmulDescCreate");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(matmulDesc, computeType, scaleType);
+}
+
+cublasStatus_t CUBLASWINAPI
+cublasLtMatmulDescDestroy(cublasLtMatmulDesc_t matmulDesc) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(cublasLtMatmulDesc_t);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtMatmulDescDestroy");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(matmulDesc);
+}
+
+cublasStatus_t CUBLASWINAPI
+cublasLtMatmulDescSetAttribute(  //
+    cublasLtMatmulDesc_t matmulDesc,
+    cublasLtMatmulDescAttributes_t attr,
+    const void *buf,
+    size_t sizeInBytes) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(//
+    cublasLtMatmulDesc_t, cublasLtMatmulDescAttributes_t, const void *, size_t);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtMatmulDescSetAttribute");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(matmulDesc, attr, buf, sizeInBytes);
+}
+
+cublasStatus_t CUBLASWINAPI
+cublasLtMatmulDescGetAttribute(  //
+    cublasLtMatmulDesc_t matmulDesc,
+    cublasLtMatmulDescAttributes_t attr,
+    void *buf,
+    size_t sizeInBytes,
+    size_t *sizeWritten) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(//
+    cublasLtMatmulDesc_t, cublasLtMatmulDescAttributes_t, void *, size_t, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtMatmulDescGetAttribute");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(matmulDesc, attr, buf, sizeInBytes, sizeWritten);
+}
+
+cublasStatus_t CUBLASWINAPI
+cublasLtMatrixTransformDescInit_internal(cublasLtMatrixTransformDesc_t transformDesc, size_t size, cudaDataType scaleType) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(cublasLtMatrixTransformDesc_t, size_t, cudaDataType);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtMatrixTransformDescInit_internal");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(transformDesc, size, scaleType);
+}
+
+cublasStatus_t CUBLASWINAPI
+cublasLtMatrixTransformDescCreate(cublasLtMatrixTransformDesc_t *transformDesc, cudaDataType scaleType) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(cublasLtMatrixTransformDesc_t *, cudaDataType);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtMatrixTransformDescCreate");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(transformDesc, scaleType);
+}
+
+cublasStatus_t CUBLASWINAPI
+cublasLtMatrixTransformDescDestroy(cublasLtMatrixTransformDesc_t transformDesc) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(cublasLtMatrixTransformDesc_t);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtMatrixTransformDescDestroy");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(transformDesc);
+}
+
+cublasStatus_t CUBLASWINAPI
+cublasLtMatrixTransformDescSetAttribute(  //
+    cublasLtMatrixTransformDesc_t transformDesc,
+    cublasLtMatrixTransformDescAttributes_t attr,
+    const void *buf,
+    size_t sizeInBytes) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(//
+    cublasLtMatrixTransformDesc_t, cublasLtMatrixTransformDescAttributes_t, const void *, size_t);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtMatrixTransformDescSetAttribute");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(transformDesc, attr, buf, sizeInBytes);
+}
+
+cublasStatus_t CUBLASWINAPI
+cublasLtMatrixTransformDescGetAttribute(  //
+    cublasLtMatrixTransformDesc_t transformDesc,
+    cublasLtMatrixTransformDescAttributes_t attr,
+    void *buf,
+    size_t sizeInBytes,
+    size_t *sizeWritten) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(//
+    cublasLtMatrixTransformDesc_t, cublasLtMatrixTransformDescAttributes_t, void *, size_t, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtMatrixTransformDescGetAttribute");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(transformDesc, attr, buf, sizeInBytes, sizeWritten);
+}
+
+cublasStatus_t CUBLASWINAPI
+cublasLtMatmulPreferenceInit_internal(cublasLtMatmulPreference_t pref, size_t size) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(cublasLtMatmulPreference_t, size_t);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtMatmulPreferenceInit_internal");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(pref, size);
+}
+
+cublasStatus_t CUBLASWINAPI
+cublasLtMatmulPreferenceCreate(cublasLtMatmulPreference_t *pref) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(cublasLtMatmulPreference_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtMatmulPreferenceCreate");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(pref);
+}
+
+cublasStatus_t CUBLASWINAPI
+cublasLtMatmulPreferenceDestroy(cublasLtMatmulPreference_t pref) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(cublasLtMatmulPreference_t);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtMatmulPreferenceDestroy");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(pref);
+}
+
+cublasStatus_t CUBLASWINAPI
+cublasLtMatmulPreferenceSetAttribute(  //
+    cublasLtMatmulPreference_t pref,
+    cublasLtMatmulPreferenceAttributes_t attr,
+    const void *buf,
+    size_t sizeInBytes) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(//
+    cublasLtMatmulPreference_t, cublasLtMatmulPreferenceAttributes_t, const void *, size_t);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtMatmulPreferenceSetAttribute");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(pref, attr, buf, sizeInBytes);
+}
+
+cublasStatus_t CUBLASWINAPI
+cublasLtMatmulPreferenceGetAttribute(  //
+    cublasLtMatmulPreference_t pref,
+    cublasLtMatmulPreferenceAttributes_t attr,
+    void *buf,
+    size_t sizeInBytes,
+    size_t *sizeWritten) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(//
+    cublasLtMatmulPreference_t, cublasLtMatmulPreferenceAttributes_t, void *, size_t, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtMatmulPreferenceGetAttribute");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(pref, attr, buf, sizeInBytes, sizeWritten);
+}
+
+cublasStatus_t CUBLASWINAPI
+cublasLtMatmulAlgoGetHeuristic(
+    cublasLtHandle_t lightHandle,
+    cublasLtMatmulDesc_t operationDesc,
+    cublasLtMatrixLayout_t Adesc,
+    cublasLtMatrixLayout_t Bdesc,
+    cublasLtMatrixLayout_t Cdesc,
+    cublasLtMatrixLayout_t Ddesc,
+    cublasLtMatmulPreference_t preference,
+    int requestedAlgoCount,
+    cublasLtMatmulHeuristicResult_t heuristicResultsArray[],
+    int *returnAlgoCount) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(cublasLtHandle_t, cublasLtMatmulDesc_t, cublasLtMatrixLayout_t, cublasLtMatrixLayout_t, cublasLtMatrixLayout_t, cublasLtMatrixLayout_t, cublasLtMatmulPreference_t, int, cublasLtMatmulHeuristicResult_t [], int *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtMatmulAlgoGetHeuristic");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(lightHandle, operationDesc, Adesc, Bdesc, Cdesc, Ddesc, preference, requestedAlgoCount, heuristicResultsArray, returnAlgoCount);
+}
+
+cublasStatus_t CUBLASWINAPI
+cublasLtMatmulAlgoGetIds(
+    cublasLtHandle_t lightHandle,
+    cublasComputeType_t computeType,
+    cudaDataType_t scaleType,
+    cudaDataType_t Atype,
+    cudaDataType_t Btype,
+    cudaDataType_t Ctype,
+    cudaDataType_t Dtype,
+    int requestedAlgoCount,
+    int algoIdsArray[],
+    int *returnAlgoCount) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(cublasLtHandle_t, cublasComputeType_t, cudaDataType_t, cudaDataType_t, cudaDataType_t, cudaDataType_t, cudaDataType_t, int, int [], int *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtMatmulAlgoGetIds");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(lightHandle, computeType, scaleType, Atype, Btype, Ctype, Dtype, requestedAlgoCount, algoIdsArray, returnAlgoCount);
+}
+
+cublasStatus_t CUBLASWINAPI
+cublasLtMatmulAlgoInit ( cublasLtHandle_t lightHandle,
+                         cublasComputeType_t computeType,
+                         cudaDataType_t scaleType,
+                         cudaDataType_t Atype,
+                         cudaDataType_t Btype,
+                         cudaDataType_t Ctype,
+                         cudaDataType_t Dtype,
+                         int algoId,
+                         cublasLtMatmulAlgo_t *algo) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(cublasLtHandle_t, cublasComputeType_t, cudaDataType_t, cudaDataType_t, cudaDataType_t, cudaDataType_t, cudaDataType_t, int, cublasLtMatmulAlgo_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtMatmulAlgoInit");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(lightHandle, computeType, scaleType, Atype, Btype, Ctype, Dtype, algoId, algo);
+}
+
+cublasStatus_t CUBLASWINAPI
+cublasLtMatmulAlgoCheck(  //
+    cublasLtHandle_t lightHandle,
+    cublasLtMatmulDesc_t operationDesc,
+    cublasLtMatrixLayout_t Adesc,
+    cublasLtMatrixLayout_t Bdesc,
+    cublasLtMatrixLayout_t Cdesc,
+    cublasLtMatrixLayout_t Ddesc,
+    const cublasLtMatmulAlgo_t *algo, ///< may point to result->algo
+    cublasLtMatmulHeuristicResult_t *result) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(//
+    cublasLtHandle_t, cublasLtMatmulDesc_t, cublasLtMatrixLayout_t, cublasLtMatrixLayout_t, cublasLtMatrixLayout_t, cublasLtMatrixLayout_t, const cublasLtMatmulAlgo_t *, ///< may point to result->algo
+    cublasLtMatmulHeuristicResult_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtMatmulAlgoCheck");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(lightHandle, operationDesc, Adesc, Bdesc, Cdesc, Ddesc, algo, result);
+}
+
+cublasStatus_t CUBLASWINAPI
+cublasLtMatmulAlgoCapGetAttribute(
+    const cublasLtMatmulAlgo_t *algo,
+    cublasLtMatmulAlgoCapAttributes_t attr,
+    void *buf,
+    size_t sizeInBytes,
+    size_t *sizeWritten) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(const cublasLtMatmulAlgo_t *, cublasLtMatmulAlgoCapAttributes_t, void *, size_t, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtMatmulAlgoCapGetAttribute");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(algo, attr, buf, sizeInBytes, sizeWritten);
+}
+
+cublasStatus_t CUBLASWINAPI
+cublasLtMatmulAlgoConfigSetAttribute(
+    cublasLtMatmulAlgo_t *algo,
+    cublasLtMatmulAlgoConfigAttributes_t attr,
+    const void *buf,
+    size_t sizeInBytes) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(cublasLtMatmulAlgo_t *, cublasLtMatmulAlgoConfigAttributes_t, const void *, size_t);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtMatmulAlgoConfigSetAttribute");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(algo, attr, buf, sizeInBytes);
+}
+
+cublasStatus_t CUBLASWINAPI
+cublasLtMatmulAlgoConfigGetAttribute(
+        const cublasLtMatmulAlgo_t *algo,
+        cublasLtMatmulAlgoConfigAttributes_t attr,
+        void *buf,
+        size_t sizeInBytes,
+        size_t *sizeWritten) {
+  using FuncPtr = cublasStatus_t (CUBLASWINAPI *)(const cublasLtMatmulAlgo_t *, cublasLtMatmulAlgoConfigAttributes_t, void *, size_t, size_t *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("cublasLtMatmulAlgoConfigGetAttribute");
+  if (!func_ptr) return GetSymbolNotFoundError();
+  return func_ptr(algo, attr, buf, sizeInBytes, sizeWritten);
+}
+
+}  // extern "C"

--- a/tensorflow/stream_executor/cuda/cublasLt_stub.cc
+++ b/tensorflow/stream_executor/cuda/cublasLt_stub.cc
@@ -1,0 +1,59 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "third_party/gpus/cuda/include/cublasLt.h"
+#include "third_party/gpus/cuda/include/cuda.h"
+#include "tensorflow/stream_executor/lib/env.h"
+#include "tensorflow/stream_executor/platform/dso_loader.h"
+
+// Implements the cuBLASLt API by forwarding to cuBLASLt loaded from the DSO.
+
+namespace {
+// Returns DSO handle or null if loading the DSO fails.
+void* GetDsoHandle() {
+#ifdef PLATFORM_GOOGLE
+  return nullptr;
+#else
+  static auto handle = []() -> void* {
+    auto handle_or =
+        stream_executor::internal::DsoLoader::GetCublasLtDsoHandle();
+    if (!handle_or.ok()) return nullptr;
+    return handle_or.ValueOrDie();
+  }();
+  return handle;
+#endif
+}
+
+template <typename T>
+T LoadSymbol(const char* symbol_name) {
+  void* symbol = nullptr;
+  if (auto handle = GetDsoHandle()) {
+    stream_executor::port::Env::Default()
+        ->GetSymbolFromLibrary(handle, symbol_name, &symbol)
+        .IgnoreError();
+  }
+  return reinterpret_cast<T>(symbol);
+}
+
+void LogFatalSymbolNotFound(const char* symbol_name) {
+  LOG(FATAL) << symbol_name << " symbol not found.";
+}
+
+cublasStatus_t GetSymbolNotFoundError() { return CUBLAS_STATUS_INTERNAL_ERROR; }
+}  // namespace
+
+// We only use cublasLt from CUDA 11.0 onward.
+#if CUDA_VERSION >= 11000
+#include "tensorflow/stream_executor/cuda/cublasLt_11_0.inc"
+#endif

--- a/tensorflow/stream_executor/cuda/cuda_blas.cc
+++ b/tensorflow/stream_executor/cuda/cuda_blas.cc
@@ -3224,7 +3224,8 @@ blas::ComputationType ToComputationType<double>() {
 template <>
 blas::ComputationType ToComputationType<std::complex<float>>() {
   return blas::ComputationType::kComplexF32;
-}template <>
+}
+template <>
 blas::ComputationType ToComputationType<std::complex<double>>() {
   return blas::ComputationType::kComplexF64;
 }

--- a/tensorflow/stream_executor/cuda/cuda_blas.cc
+++ b/tensorflow/stream_executor/cuda/cuda_blas.cc
@@ -441,21 +441,21 @@ cublasComputeType_t CUBLASComputationType(blas::ComputationType ty) {
 
 blas::DataType GetScaleType(blas::DataType data_type,
                             blas::ComputationType compute_type) {
-  bool is_complex = data_type == blas::DataType::kComplexF32 ||
-                    data_type == blas::DataType::kComplexF64;
+  bool is_complex = data_type == blas::DataType::kComplexFloat ||
+                    data_type == blas::DataType::kComplexDouble;
   switch (compute_type) {
     case blas::ComputationType::kF16:
-      return blas::DataType::kF16;
+      return blas::DataType::kHalf;
     case blas::ComputationType::kF32:          // fall-through
     case blas::ComputationType::kComplexF32:   // fall-through
     case blas::ComputationType::kF32FastTF32:  // fall-through
     case blas::ComputationType::kF32FastBF16:
-      return is_complex ? blas::DataType::kComplexF32 : blas::DataType::kF32;
+      return is_complex ? blas::DataType::kComplexFloat : blas::DataType::kFloat;
     case blas::ComputationType::kF64:  // fall-through
     case blas::ComputationType::kComplexF64:
-      return is_complex ? blas::DataType::kComplexF64 : blas::DataType::kF64;
+      return is_complex ? blas::DataType::kComplexDouble : blas::DataType::kDouble;
     case blas::ComputationType::kI32:
-      return blas::DataType::kI32;
+      return blas::DataType::kInt32;
   }
 }
 
@@ -484,38 +484,38 @@ cublasLtEpilogue_t CUBLASEpilogue(blas::Epilogue epilogue) {
 
 cudaDataType_t GetCUDADataType(blas::DataType ty) {
   switch (ty) {
-    case blas::DataType::kF16:
+    case blas::DataType::kHalf:
       return CUDA_R_16F;
-    case blas::DataType::kF32:
+    case blas::DataType::kFloat:
       return CUDA_R_32F;
-    case blas::DataType::kF64:
+    case blas::DataType::kDouble:
       return CUDA_R_64F;
-    case blas::DataType::kI8:
+    case blas::DataType::kInt8:
       return CUDA_R_8I;
-    case blas::DataType::kI32:
+    case blas::DataType::kInt32:
       return CUDA_R_32I;
-    case blas::DataType::kComplexF32:
+    case blas::DataType::kComplexFloat:
       return CUDA_C_32F;
-    case blas::DataType::kComplexF64:
+    case blas::DataType::kComplexDouble:
       return CUDA_C_64F;
   }
 }
 
 int GetDataTypeSizeBytes(blas::DataType ty) {
   switch (ty) {
-    case blas::DataType::kF16:
+    case blas::DataType::kHalf:
       return 2;
-    case blas::DataType::kF32:
+    case blas::DataType::kFloat:
       return 4;
-    case blas::DataType::kF64:
+    case blas::DataType::kDouble:
       return 8;
-    case blas::DataType::kI8:
+    case blas::DataType::kInt8:
       return 1;
-    case blas::DataType::kI32:
+    case blas::DataType::kInt32:
       return 4;
-    case blas::DataType::kComplexF32:
+    case blas::DataType::kComplexFloat:
       return 8;
-    case blas::DataType::kComplexF64:
+    case blas::DataType::kComplexDouble:
       return 16;
   }
 }
@@ -3611,7 +3611,7 @@ bool CUDABlas::DoBlasLtMatmul(Stream* stream,
                               blas::ProfileResult* output_profile_result) {
 #if CUDA_VERSION >= 11000
   const auto& cuda_plan = *static_cast<const CUDABlasLtMatmulPlan*>(plan);
-  if (cuda_plan.scale_type() == blas::DataType::kF32) {
+  if (cuda_plan.scale_type() == blas::DataType::kFloat) {
     // F32* computation types require F32 alpha/beta type, so we must cast them.
     if (alpha.is_pointer() || beta.is_pointer()) {
       // We cannot easily convert a pointer to f16 memory to a pointer to f32

--- a/tensorflow/stream_executor/cuda/cuda_blas.cc
+++ b/tensorflow/stream_executor/cuda/cuda_blas.cc
@@ -3422,7 +3422,9 @@ CUDABlas::CreateBlasLtMatmulPlan(const blas::BlasLtMatmulPlanParams& p) {
           p.pointer_mode, p.epilogue, p.batch_count, p.stride_a, p.stride_b,
           p.stride_c, p.stride_c));
 #else
-  return nullptr;
+  return port::Status(
+      port::error::UNIMPLEMENTED,
+      "CreateBlasLtMatmulPlan is not supported with this version of CUDA");
 #endif
 }
 

--- a/tensorflow/stream_executor/cuda/cuda_blas.cc
+++ b/tensorflow/stream_executor/cuda/cuda_blas.cc
@@ -3243,8 +3243,8 @@ class CUDABlasLtMatmulPlan final : public blas::IBlasLtMatmulPlan {
   cublasLtMatrixLayout_t d_desc() const { return d_desc_.get(); }
   bool ok() { return op_desc_ && a_desc_ && b_desc_ && c_desc_ && d_desc_; }
 
-  blas::DataType ab_type() const { return ab_type_; }
-  blas::DataType cd_type() const { return cd_type_; }
+  blas::DataType ab_type() const override { return ab_type_; }
+  blas::DataType c_type() const override { return c_type_; }
   blas::DataType scale_type() const { return scale_type_; }
   blas::PointerMode pointer_mode() const { return pointer_mode_; }
   blas::Epilogue epilogue() const { return epilogue_; }
@@ -3265,7 +3265,7 @@ class CUDABlasLtMatmulPlan final : public blas::IBlasLtMatmulPlan {
   UniqueLayoutDesc c_desc_;
   UniqueLayoutDesc d_desc_;
   blas::DataType ab_type_;
-  blas::DataType cd_type_;
+  blas::DataType c_type_;
   blas::DataType scale_type_;
   blas::PointerMode pointer_mode_;
   blas::Epilogue epilogue_;
@@ -3458,7 +3458,7 @@ bool CUDABlas::DoBlasLtMatmulInternal(
       beta.data_type() != cuda_plan.scale_type()) {
     VLOG(2) << "DoBlasLtMatmul returning false because alpha and beta types do "
                "not match plan: expected "
-            << cuda_plan.cd_type() << ", got alpha=" << alpha.data_type()
+            << cuda_plan.c_type() << ", got alpha=" << alpha.data_type()
             << " beta=" << beta.data_type();
     return false;
   }
@@ -3542,7 +3542,7 @@ bool CUDABlas::DoBlasLtMatmul(
   const auto& cuda_plan = *static_cast<const CUDABlasLtMatmulPlan*>(plan);
   HostOrDeviceScalar<void> alpha_cast = alpha;
   HostOrDeviceScalar<void> beta_cast = beta;
-  if (cuda_plan.cd_type() == blas::DataType::kHalf &&
+  if (cuda_plan.c_type() == blas::DataType::kHalf &&
       cuda_plan.scale_type() == blas::DataType::kFloat) {
     // The given alpha and beta types are F16 (they always match c), but F32*
     // computation type requires that they be F32, so we must cast them.

--- a/tensorflow/stream_executor/cuda/cuda_blas.cc
+++ b/tensorflow/stream_executor/cuda/cuda_blas.cc
@@ -410,8 +410,8 @@ cudaDataType_t CUDAComputationType(blas::ComputationType ty) {
       return CUDA_C_32F;
     case blas::ComputationType::kComplexF64:
       return CUDA_C_64F;
-    case blas::ComputationType::kF32FastTF32:  // fall-through
-    case blas::ComputationType::kF32FastBF16:
+    case blas::ComputationType::kTF32AsF32:  // fall-through
+    case blas::ComputationType::kBF16AsF32:
       // These cases are currently only supported in the blasLt routines, which
       // use CUBLASComputationType() instead.
       LOG(FATAL) << "Invalid value of blas::ComputationType.";
@@ -431,9 +431,9 @@ cublasComputeType_t CUBLASComputationType(blas::ComputationType ty) {
       return CUBLAS_COMPUTE_64F;
     case blas::ComputationType::kI32:
       return CUBLAS_COMPUTE_32I;
-    case blas::ComputationType::kF32FastTF32:
+    case blas::ComputationType::kTF32AsF32:
       return CUBLAS_COMPUTE_32F_FAST_TF32;
-    case blas::ComputationType::kF32FastBF16:
+    case blas::ComputationType::kBF16AsF32:
       return CUBLAS_COMPUTE_32F_FAST_16BF;
   }
 }
@@ -446,14 +446,16 @@ blas::DataType GetScaleType(blas::DataType data_type,
   switch (compute_type) {
     case blas::ComputationType::kF16:
       return blas::DataType::kHalf;
-    case blas::ComputationType::kF32:          // fall-through
-    case blas::ComputationType::kComplexF32:   // fall-through
-    case blas::ComputationType::kF32FastTF32:  // fall-through
-    case blas::ComputationType::kF32FastBF16:
-      return is_complex ? blas::DataType::kComplexFloat : blas::DataType::kFloat;
+    case blas::ComputationType::kF32:         // fall-through
+    case blas::ComputationType::kComplexF32:  // fall-through
+    case blas::ComputationType::kTF32AsF32:   // fall-through
+    case blas::ComputationType::kBF16AsF32:
+      return is_complex ? blas::DataType::kComplexFloat
+                        : blas::DataType::kFloat;
     case blas::ComputationType::kF64:  // fall-through
     case blas::ComputationType::kComplexF64:
-      return is_complex ? blas::DataType::kComplexDouble : blas::DataType::kDouble;
+      return is_complex ? blas::DataType::kComplexDouble
+                        : blas::DataType::kDouble;
     case blas::ComputationType::kI32:
       return blas::DataType::kInt32;
   }

--- a/tensorflow/stream_executor/cuda/cuda_blas.h
+++ b/tensorflow/stream_executor/cuda/cuda_blas.h
@@ -140,25 +140,15 @@ class CUDABlas : public blas::BlasSupport {
                                    blas::ProfileResult *output_profile_result);
 
   // Helper function for implementing DoBlasLtMatmul.
-  template <typename ABType, typename CDType, typename ScaleType>
-  bool DoBlasLtMatmulInternal(
-      Stream* stream, const blas::IBlasLtMatmulPlan* plan,
-      const HostOrDeviceScalar<ScaleType>& alpha, const DeviceMemory<ABType>& a,
-      const DeviceMemory<ABType>& b, const HostOrDeviceScalar<ScaleType>& beta,
-      const DeviceMemory<CDType>& c, DeviceMemory<CDType>* d,
-      ScratchAllocator* scratch_allocator,
-      const blas::IBlasLtMatmulAlgorithm* algorithm,
-      const DeviceMemory<CDType>& bias,
-      blas::ProfileResult* output_profile_result);
-
-  // Helper function for implementing DoBlasLtMatmulInternal.
-  template <typename ABType, typename CDType, typename ScaleType>
-  bool DoBlasLtMatmulInternalImpl(
-      Stream* stream, bool err_on_failure, const blas::IBlasLtMatmulPlan* plan,
-      const HostOrDeviceScalar<ScaleType>& alpha, const ABType* a,
-      const ABType* b, const HostOrDeviceScalar<ScaleType>& beta,
-      const CDType* c, CDType* d, ScratchAllocator* scratch_allocator,
-      const blas::IBlasLtMatmulAlgorithm* algorithm, const CDType* bias);
+  bool DoBlasLtMatmulInternal(Stream* stream, bool err_on_failure,
+                              const blas::IBlasLtMatmulPlan* plan,
+                              const HostOrDeviceScalar<void>& alpha,
+                              DeviceMemoryBase a, DeviceMemoryBase b,
+                              const HostOrDeviceScalar<void>& beta,
+                              DeviceMemoryBase c, DeviceMemoryBase d,
+                              ScratchAllocator* scratch_allocator,
+                              const blas::IBlasLtMatmulAlgorithm* algorithm,
+                              DeviceMemoryBase bias);
 
   // Guards the cuBLAS handle for this device.
   absl::Mutex mu_;

--- a/tensorflow/stream_executor/cuda/cuda_blas.h
+++ b/tensorflow/stream_executor/cuda/cuda_blas.h
@@ -148,6 +148,7 @@ class CUDABlas : public blas::BlasSupport {
       const DeviceMemory<CDType>& c, DeviceMemory<CDType>* d,
       ScratchAllocator* scratch_allocator,
       const blas::IBlasLtMatmulAlgorithm* algorithm,
+      const DeviceMemory<CDType>& bias,
       blas::ProfileResult* output_profile_result);
 
   // Helper function for implementing DoBlasLtMatmulInternal.
@@ -157,7 +158,7 @@ class CUDABlas : public blas::BlasSupport {
       const HostOrDeviceScalar<ScaleType>& alpha, const ABType* a,
       const ABType* b, const HostOrDeviceScalar<ScaleType>& beta,
       const CDType* c, CDType* d, ScratchAllocator* scratch_allocator,
-      const blas::IBlasLtMatmulAlgorithm* algorithm);
+      const blas::IBlasLtMatmulAlgorithm* algorithm, const CDType* bias);
 
   // Guards the cuBLAS handle for this device.
   absl::Mutex mu_;

--- a/tensorflow/stream_executor/dnn.h
+++ b/tensorflow/stream_executor/dnn.h
@@ -133,6 +133,14 @@ template <>
 struct ToDataType<int32> {
   static constexpr DataType value = DataType::kInt32;
 };
+template <>
+struct ToDataType<std::complex<float>> {
+  static constexpr DataType value = DataType::kComplexFloat;
+};
+template <>
+struct ToDataType<std::complex<double>> {
+  static constexpr DataType value = DataType::kComplexDouble;
+};
 
 // Specifies the types of a RNN model.
 enum class RnnMode {

--- a/tensorflow/stream_executor/dnn.proto
+++ b/tensorflow/stream_executor/dnn.proto
@@ -12,6 +12,8 @@ enum DataType {
   kHalf = 2;
   kInt8 = 3;
   kInt32 = 4;
+  kComplexFloat = 5;
+  kComplexDouble = 6;
 }
 
 // Describes how a convolution input or output layer's data is formatted.

--- a/tensorflow/stream_executor/host_or_device_scalar.h
+++ b/tensorflow/stream_executor/host_or_device_scalar.h
@@ -137,29 +137,6 @@ class HostOrDeviceScalar<void> {
   }
   DataType data_type() const { return dtype_; }
 
-  template <typename ResultType, typename GenericUnaryFunc>
-  ResultType CallWithValue(GenericUnaryFunc func) const {
-    CHECK(!is_pointer());
-    switch (dtype_) {
-      case DataType::kFloat:
-        return func(float_);
-      case DataType::kDouble:
-        return func(double_);
-      case DataType::kHalf:
-        return func(half_);
-      case DataType::kInt8:
-        return func(int8_);
-      case DataType::kInt32:
-        return func(int32_);
-      case DataType::kComplexFloat:
-        return func(complex_float_);
-      case DataType::kComplexDouble:
-        return func(complex_double_);
-      default:
-        return {};
-    }
-  }
-
  private:
   template <typename T>
   const T& value_impl() const;

--- a/tensorflow/stream_executor/host_or_device_scalar.h
+++ b/tensorflow/stream_executor/host_or_device_scalar.h
@@ -17,12 +17,14 @@ limitations under the License.
 #define TENSORFLOW_STREAM_EXECUTOR_HOST_OR_DEVICE_SCALAR_H_
 
 #include "tensorflow/stream_executor/device_memory.h"
+#include "tensorflow/stream_executor/dnn.h"  // For DataType, ToDataType
 #include "tensorflow/stream_executor/platform/logging.h"
 
 namespace stream_executor {
 
 // Allows to represent a value that is either a host scalar or a scalar stored
 // on the GPU device.
+// See also the specialization for ElemT=void below.
 template <typename ElemT>
 class HostOrDeviceScalar {
  public:
@@ -50,6 +52,139 @@ class HostOrDeviceScalar {
     DeviceMemory<ElemT> pointer_;
   };
   bool is_pointer_;
+};
+
+// Specialization for wrapping a dynamically-typed value (via type erasure).
+template <>
+class HostOrDeviceScalar<void> {
+ public:
+  using DataType = dnn::DataType;
+  // Not marked as explicit because when using this constructor, we usually want
+  // to set this to a compile-time constant.
+  HostOrDeviceScalar(float value)
+      : float_(value), is_pointer_(false), dtype_(DataType::kFloat) {}
+  HostOrDeviceScalar(double value)
+      : double_(value), is_pointer_(false), dtype_(DataType::kDouble) {}
+  HostOrDeviceScalar(Eigen::half value)
+      : half_(value), is_pointer_(false), dtype_(DataType::kHalf) {}
+  HostOrDeviceScalar(int8 value)
+      : int8_(value), is_pointer_(false), dtype_(DataType::kInt8) {}
+  HostOrDeviceScalar(int32 value)
+      : int32_(value), is_pointer_(false), dtype_(DataType::kInt32) {}
+  HostOrDeviceScalar(std::complex<float> value)
+      : complex_float_(value),
+        is_pointer_(false),
+        dtype_(DataType::kComplexFloat) {}
+  HostOrDeviceScalar(std::complex<double> value)
+      : complex_double_(value),
+        is_pointer_(false),
+        dtype_(DataType::kComplexDouble) {}
+  template <typename T>
+  explicit HostOrDeviceScalar(const DeviceMemory<T>& pointer)
+      : pointer_(pointer),
+        is_pointer_(true),
+        dtype_(dnn::ToDataType<T>::value) {
+    CHECK_EQ(1, pointer.ElementCount());
+  }
+  // Construct from statically-typed version.
+  template <typename T, typename std::enable_if<!std::is_same<T, void>::value,
+                                                int>::type = 0>
+  HostOrDeviceScalar(const HostOrDeviceScalar<T>& other) {
+    if (other.is_pointer()) {
+      *this = HostOrDeviceScalar(other.pointer());
+    } else {
+      *this = HostOrDeviceScalar(other.value());
+    }
+  }
+
+  bool is_pointer() const { return is_pointer_; }
+  template <typename T>
+  const DeviceMemory<T>& pointer() const {
+    CHECK(is_pointer());
+    CHECK(dtype_ == dnn::ToDataType<T>::value);
+    return pointer_;
+  }
+  template <typename T>
+  const T& value() const {
+    CHECK(!is_pointer());
+    CHECK(dtype_ == dnn::ToDataType<T>::value);
+    return value_impl<T>();
+  }
+  const DeviceMemoryBase& opaque_pointer() const {
+    CHECK(is_pointer());
+    return pointer_;
+  }
+  const void* opaque_value() const {
+    CHECK(!is_pointer());
+    switch (dtype_) {
+      case DataType::kFloat:
+        return &float_;
+      case DataType::kDouble:
+        return &double_;
+      case DataType::kHalf:
+        return &half_;
+      case DataType::kInt8:
+        return &int8_;
+      case DataType::kInt32:
+        return &int32_;
+      case DataType::kComplexFloat:
+        return &complex_float_;
+      case DataType::kComplexDouble:
+        return &complex_double_;
+      default:
+        return nullptr;
+    }
+  }
+  DataType data_type() const { return dtype_; }
+
+ private:
+  template <typename T>
+  const T& value_impl() const;
+
+  union {
+    float float_;
+    double double_;
+    Eigen::half half_;
+    int8 int8_;
+    int32 int32_;
+    std::complex<float> complex_float_;
+    std::complex<double> complex_double_;
+    DeviceMemoryBase pointer_;
+  };
+  bool is_pointer_;
+  DataType dtype_;
+};
+
+template <>
+inline const float& HostOrDeviceScalar<void>::value_impl<float>() const {
+  return float_;
+};
+template <>
+inline const double& HostOrDeviceScalar<void>::value_impl<double>() const {
+  return double_;
+};
+template <>
+inline const Eigen::half& HostOrDeviceScalar<void>::value_impl<Eigen::half>()
+    const {
+  return half_;
+};
+template <>
+inline const int8& HostOrDeviceScalar<void>::value_impl<int8>() const {
+  return int8_;
+};
+template <>
+inline const int32& HostOrDeviceScalar<void>::value_impl<int32>() const {
+  return int32_;
+};
+template <>
+inline const std::complex<float>&
+HostOrDeviceScalar<void>::value_impl<std::complex<float>>() const {
+  return complex_float_;
+};
+template <>
+inline const std::complex<double>&
+HostOrDeviceScalar<void>::value_impl<std::complex<double>>() const {
+  return complex_double_;
 };
 
 }  // namespace stream_executor

--- a/tensorflow/stream_executor/host_or_device_scalar.h
+++ b/tensorflow/stream_executor/host_or_device_scalar.h
@@ -137,6 +137,29 @@ class HostOrDeviceScalar<void> {
   }
   DataType data_type() const { return dtype_; }
 
+  template <typename ResultType, typename GenericUnaryFunc>
+  ResultType CallWithValue(GenericUnaryFunc func) const {
+    CHECK(!is_pointer());
+    switch (dtype_) {
+      case DataType::kFloat:
+        return func(float_);
+      case DataType::kDouble:
+        return func(double_);
+      case DataType::kHalf:
+        return func(half_);
+      case DataType::kInt8:
+        return func(int8_);
+      case DataType::kInt32:
+        return func(int32_);
+      case DataType::kComplexFloat:
+        return func(complex_float_);
+      case DataType::kComplexDouble:
+        return func(complex_double_);
+      default:
+        return {};
+    }
+  }
+
  private:
   template <typename T>
   const T& value_impl() const;

--- a/tensorflow/stream_executor/platform/default/dlopen_checker.cc
+++ b/tensorflow/stream_executor/platform/default/dlopen_checker.cc
@@ -23,6 +23,7 @@ namespace DsoLoader {
 port::Status TryDlopenCUDALibraries() {
   auto cudart_status = GetCudaRuntimeDsoHandle();
   auto cublas_status = GetCublasDsoHandle();
+  auto cublaslt_status = GetCublasLtDsoHandle();
   auto cufft_status = GetCufftDsoHandle();
   auto curand_status = GetCurandDsoHandle();
   auto cusolver_status = GetCusolverDsoHandle();
@@ -31,7 +32,7 @@ port::Status TryDlopenCUDALibraries() {
   if (!cudart_status.status().ok() || !cublas_status.status().ok() ||
       !cufft_status.status().ok() || !curand_status.status().ok() ||
       !cusolver_status.status().ok() || !cusparse_status.status().ok() ||
-      !cudnn_status.status().ok()) {
+      !cudnn_status.status().ok() || !cublaslt_status.status().ok()) {
     return port::Status(port::error::INTERNAL,
                         absl::StrCat("Cannot dlopen all CUDA libraries."));
   } else {

--- a/tensorflow/stream_executor/platform/default/dso_loader.cc
+++ b/tensorflow/stream_executor/platform/default/dso_loader.cc
@@ -84,6 +84,10 @@ port::StatusOr<void*> GetCublasDsoHandle() {
   return GetDsoHandle("cublas", GetCublasVersion());
 }
 
+port::StatusOr<void*> GetCublasLtDsoHandle() {
+  return GetDsoHandle("cublasLt", GetCublasVersion());
+}
+
 port::StatusOr<void*> GetCufftDsoHandle() {
   return GetDsoHandle("cufft", GetCufftVersion());
 }
@@ -157,6 +161,11 @@ port::StatusOr<void*> GetCudaRuntimeDsoHandle() {
 
 port::StatusOr<void*> GetCublasDsoHandle() {
   static auto result = new auto(DsoLoader::GetCublasDsoHandle());
+  return *result;
+}
+
+port::StatusOr<void*> GetCublasLtDsoHandle() {
+  static auto result = new auto(DsoLoader::GetCublasLtDsoHandle());
   return *result;
 }
 

--- a/tensorflow/stream_executor/platform/default/dso_loader.h
+++ b/tensorflow/stream_executor/platform/default/dso_loader.h
@@ -37,6 +37,7 @@ namespace DsoLoader {
 port::StatusOr<void*> GetCudaDriverDsoHandle();
 port::StatusOr<void*> GetCudaRuntimeDsoHandle();
 port::StatusOr<void*> GetCublasDsoHandle();
+port::StatusOr<void*> GetCublasLtDsoHandle();
 port::StatusOr<void*> GetCufftDsoHandle();
 port::StatusOr<void*> GetCurandDsoHandle();
 port::StatusOr<void*> GetCusolverDsoHandle();
@@ -72,6 +73,7 @@ namespace CachedDsoLoader {
 port::StatusOr<void*> GetCudaDriverDsoHandle();
 port::StatusOr<void*> GetCudaRuntimeDsoHandle();
 port::StatusOr<void*> GetCublasDsoHandle();
+port::StatusOr<void*> GetCublasLtDsoHandle();
 port::StatusOr<void*> GetCufftDsoHandle();
 port::StatusOr<void*> GetCurandDsoHandle();
 port::StatusOr<void*> GetCusolverDsoHandle();

--- a/tensorflow/stream_executor/stream.cc
+++ b/tensorflow/stream_executor/stream.cc
@@ -4809,27 +4809,78 @@ Stream &Stream::ThenBlasGemmStridedBatched(
               c, ldc, stride_c, batch_count);
 }
 
-Stream& Stream::ThenBlasLtMatmul(const blas::IBlasLtMatmulPlan* plan,
-                                 const HostOrDeviceScalar<void>& alpha,
-                                 DeviceMemoryBase a, DeviceMemoryBase b,
-                                 const HostOrDeviceScalar<void>& beta,
-                                 DeviceMemoryBase c,
-                                 ScratchAllocator* scratch_allocator,
-                                 const blas::IBlasLtMatmulAlgorithm* algorithm,
-                                 DeviceMemoryBase bias,
-                                 blas::ProfileResult* output_profile_result) {
+template <typename ABType, typename CType>
+Stream& Stream::ThenBlasLtMatmulImpl(
+    const blas::IBlasLtMatmulPlan* plan, const HostOrDeviceScalar<CType>& alpha,
+    const DeviceMemory<ABType>& a, const DeviceMemory<ABType>& b,
+    const HostOrDeviceScalar<CType>& beta, DeviceMemory<CType>* c,
+    ScratchAllocator* scratch_allocator,
+    const blas::IBlasLtMatmulAlgorithm* algorithm,
+    const DeviceMemory<CType>& bias,
+    blas::ProfileResult* output_profile_result) {
   VLOG_CALL(PARAM(plan), PARAM(alpha), PARAM(a), PARAM(b), PARAM(beta),
             PARAM(c), PARAM(algorithm), PARAM(bias));
 
-  ThenBlasWithProfileImpl<const blas::IBlasLtMatmulPlan*,
-                          const HostOrDeviceScalar<void>&, DeviceMemoryBase,
-                          DeviceMemoryBase, const HostOrDeviceScalar<void>&,
-                          DeviceMemoryBase, ScratchAllocator*,
-                          const blas::IBlasLtMatmulAlgorithm*, DeviceMemoryBase>
+  ThenBlasWithProfileImpl<
+      const blas::IBlasLtMatmulPlan*, const HostOrDeviceScalar<CType>&,
+      const DeviceMemory<ABType>&, const DeviceMemory<ABType>&,
+      const HostOrDeviceScalar<CType>&, DeviceMemory<CType>*, ScratchAllocator*,
+      const blas::IBlasLtMatmulAlgorithm*, const DeviceMemory<CType>&>
       impl;
   return impl(this, &blas::BlasSupport::DoBlasLtMatmul, plan, alpha, a, b, beta,
               c, scratch_allocator, algorithm, bias, output_profile_result);
 }
+
+// Explicit template instantiations for each supported type combination.
+template Stream& Stream::ThenBlasLtMatmulImpl<int8, int32>(
+    const blas::IBlasLtMatmulPlan*, const HostOrDeviceScalar<int32>&,
+    const DeviceMemory<int8>&, const DeviceMemory<int8>&,
+    const HostOrDeviceScalar<int32>&, DeviceMemory<int32>*, ScratchAllocator*,
+    const blas::IBlasLtMatmulAlgorithm*, const DeviceMemory<int32>&,
+    blas::ProfileResult*);
+
+template Stream& Stream::ThenBlasLtMatmulImpl<Eigen::half, Eigen::half>(
+    const blas::IBlasLtMatmulPlan*, const HostOrDeviceScalar<Eigen::half>&,
+    const DeviceMemory<Eigen::half>&, const DeviceMemory<Eigen::half>&,
+    const HostOrDeviceScalar<Eigen::half>&, DeviceMemory<Eigen::half>*,
+    ScratchAllocator*, const blas::IBlasLtMatmulAlgorithm*,
+    const DeviceMemory<Eigen::half>&, blas::ProfileResult*);
+
+template Stream& Stream::ThenBlasLtMatmulImpl<float, float>(
+    const blas::IBlasLtMatmulPlan*, const HostOrDeviceScalar<float>&,
+    const DeviceMemory<float>&, const DeviceMemory<float>&,
+    const HostOrDeviceScalar<float>&, DeviceMemory<float>*, ScratchAllocator*,
+    const blas::IBlasLtMatmulAlgorithm*, const DeviceMemory<float>&,
+    blas::ProfileResult*);
+
+template Stream& Stream::ThenBlasLtMatmulImpl<double, double>(
+    const blas::IBlasLtMatmulPlan*, const HostOrDeviceScalar<double>&,
+    const DeviceMemory<double>&, const DeviceMemory<double>&,
+    const HostOrDeviceScalar<double>&, DeviceMemory<double>*, ScratchAllocator*,
+    const blas::IBlasLtMatmulAlgorithm*, const DeviceMemory<double>&,
+    blas::ProfileResult*);
+
+template Stream&
+Stream::ThenBlasLtMatmulImpl<std::complex<float>, std::complex<float>>(
+    const blas::IBlasLtMatmulPlan*,
+    const HostOrDeviceScalar<std::complex<float>>&,
+    const DeviceMemory<std::complex<float>>&,
+    const DeviceMemory<std::complex<float>>&,
+    const HostOrDeviceScalar<std::complex<float>>&,
+    DeviceMemory<std::complex<float>>*, ScratchAllocator*,
+    const blas::IBlasLtMatmulAlgorithm*,
+    const DeviceMemory<std::complex<float>>&, blas::ProfileResult*);
+
+template Stream&
+Stream::ThenBlasLtMatmulImpl<std::complex<double>, std::complex<double>>(
+    const blas::IBlasLtMatmulPlan*,
+    const HostOrDeviceScalar<std::complex<double>>&,
+    const DeviceMemory<std::complex<double>>&,
+    const DeviceMemory<std::complex<double>>&,
+    const HostOrDeviceScalar<std::complex<double>>&,
+    DeviceMemory<std::complex<double>>*, ScratchAllocator*,
+    const blas::IBlasLtMatmulAlgorithm*,
+    const DeviceMemory<std::complex<double>>&, blas::ProfileResult*);
 
 Stream &Stream::ThenSetRngSeed(const uint8 *seed, uint64 seed_bytes) {
   VLOG_CALL(PARAM(seed), PARAM(seed_bytes));

--- a/tensorflow/stream_executor/stream.cc
+++ b/tensorflow/stream_executor/stream.cc
@@ -4809,18 +4809,19 @@ Stream& Stream::ThenBlasLtMatmul(const blas::IBlasLtMatmulPlan* plan,
                                  DeviceMemory<int32>* c,
                                  ScratchAllocator* scratch_allocator,
                                  const blas::IBlasLtMatmulAlgorithm* algorithm,
+                                 const DeviceMemory<int32>& bias,
                                  blas::ProfileResult* output_profile_result) {
   VLOG_CALL(PARAM(plan), PARAM(alpha), PARAM(a), PARAM(b), PARAM(beta),
-            PARAM(c), PARAM(algorithm));
+            PARAM(c), PARAM(algorithm), PARAM(bias));
 
   ThenBlasWithProfileImpl<
       const blas::IBlasLtMatmulPlan*, const HostOrDeviceScalar<int32>&,
       const DeviceMemory<int8>&, const DeviceMemory<int8>&,
       const HostOrDeviceScalar<int32>&, DeviceMemory<int32>*, ScratchAllocator*,
-      const blas::IBlasLtMatmulAlgorithm*>
+      const blas::IBlasLtMatmulAlgorithm*, const DeviceMemory<int32>&>
       impl;
   return impl(this, &blas::BlasSupport::DoBlasLtMatmul, plan, alpha, a, b, beta,
-              c, scratch_allocator, algorithm, output_profile_result);
+              c, scratch_allocator, algorithm, bias, output_profile_result);
 }
 
 Stream& Stream::ThenBlasLtMatmul(const blas::IBlasLtMatmulPlan* plan,
@@ -4831,18 +4832,20 @@ Stream& Stream::ThenBlasLtMatmul(const blas::IBlasLtMatmulPlan* plan,
                                  DeviceMemory<Eigen::half>* c,
                                  ScratchAllocator* scratch_allocator,
                                  const blas::IBlasLtMatmulAlgorithm* algorithm,
+                                 const DeviceMemory<Eigen::half>& bias,
                                  blas::ProfileResult* output_profile_result) {
   VLOG_CALL(PARAM(plan), PARAM(alpha), PARAM(a), PARAM(b), PARAM(beta),
-            PARAM(c), PARAM(algorithm));
+            PARAM(c), PARAM(algorithm), PARAM(bias));
 
   ThenBlasWithProfileImpl<
       const blas::IBlasLtMatmulPlan*, const HostOrDeviceScalar<Eigen::half>&,
       const DeviceMemory<Eigen::half>&, const DeviceMemory<Eigen::half>&,
       const HostOrDeviceScalar<Eigen::half>&, DeviceMemory<Eigen::half>*,
-      ScratchAllocator*, const blas::IBlasLtMatmulAlgorithm*>
+      ScratchAllocator*, const blas::IBlasLtMatmulAlgorithm*,
+      const DeviceMemory<Eigen::half>&>
       impl;
   return impl(this, &blas::BlasSupport::DoBlasLtMatmul, plan, alpha, a, b, beta,
-              c, scratch_allocator, algorithm, output_profile_result);
+              c, scratch_allocator, algorithm, bias, output_profile_result);
 }
 
 Stream& Stream::ThenBlasLtMatmul(const blas::IBlasLtMatmulPlan* plan,
@@ -4853,18 +4856,19 @@ Stream& Stream::ThenBlasLtMatmul(const blas::IBlasLtMatmulPlan* plan,
                                  DeviceMemory<float>* c,
                                  ScratchAllocator* scratch_allocator,
                                  const blas::IBlasLtMatmulAlgorithm* algorithm,
+                                 const DeviceMemory<float>& bias,
                                  blas::ProfileResult* output_profile_result) {
   VLOG_CALL(PARAM(plan), PARAM(alpha), PARAM(a), PARAM(b), PARAM(beta),
-            PARAM(c), PARAM(algorithm));
+            PARAM(c), PARAM(algorithm), PARAM(bias));
 
   ThenBlasWithProfileImpl<
       const blas::IBlasLtMatmulPlan*, const HostOrDeviceScalar<float>&,
       const DeviceMemory<float>&, const DeviceMemory<float>&,
       const HostOrDeviceScalar<float>&, DeviceMemory<float>*, ScratchAllocator*,
-      const blas::IBlasLtMatmulAlgorithm*>
+      const blas::IBlasLtMatmulAlgorithm*, const DeviceMemory<float>&>
       impl;
   return impl(this, &blas::BlasSupport::DoBlasLtMatmul, plan, alpha, a, b, beta,
-              c, scratch_allocator, algorithm, output_profile_result);
+              c, scratch_allocator, algorithm, bias, output_profile_result);
 }
 
 Stream& Stream::ThenBlasLtMatmul(const blas::IBlasLtMatmulPlan* plan,
@@ -4875,18 +4879,20 @@ Stream& Stream::ThenBlasLtMatmul(const blas::IBlasLtMatmulPlan* plan,
                                  DeviceMemory<double>* c,
                                  ScratchAllocator* scratch_allocator,
                                  const blas::IBlasLtMatmulAlgorithm* algorithm,
+                                 const DeviceMemory<double>& bias,
                                  blas::ProfileResult* output_profile_result) {
   VLOG_CALL(PARAM(plan), PARAM(alpha), PARAM(a), PARAM(b), PARAM(beta),
-            PARAM(c), PARAM(algorithm));
+            PARAM(c), PARAM(algorithm), PARAM(bias));
 
   ThenBlasWithProfileImpl<
       const blas::IBlasLtMatmulPlan*, const HostOrDeviceScalar<double>&,
       const DeviceMemory<double>&, const DeviceMemory<double>&,
       const HostOrDeviceScalar<double>&, DeviceMemory<double>*,
-      ScratchAllocator*, const blas::IBlasLtMatmulAlgorithm*>
+      ScratchAllocator*, const blas::IBlasLtMatmulAlgorithm*,
+      const DeviceMemory<double>&>
       impl;
   return impl(this, &blas::BlasSupport::DoBlasLtMatmul, plan, alpha, a, b, beta,
-              c, scratch_allocator, algorithm, output_profile_result);
+              c, scratch_allocator, algorithm, bias, output_profile_result);
 }
 
 Stream& Stream::ThenBlasLtMatmul(
@@ -4897,9 +4903,10 @@ Stream& Stream::ThenBlasLtMatmul(
     const HostOrDeviceScalar<std::complex<float>>& beta,
     DeviceMemory<std::complex<float>>* c, ScratchAllocator* scratch_allocator,
     const blas::IBlasLtMatmulAlgorithm* algorithm,
+    const DeviceMemory<std::complex<float>>& bias,
     blas::ProfileResult* output_profile_result) {
   VLOG_CALL(PARAM(plan), PARAM(alpha), PARAM(a), PARAM(b), PARAM(beta),
-            PARAM(c), PARAM(algorithm));
+            PARAM(c), PARAM(algorithm), PARAM(bias));
 
   ThenBlasWithProfileImpl<const blas::IBlasLtMatmulPlan*,
                           const HostOrDeviceScalar<std::complex<float>>&,
@@ -4907,10 +4914,11 @@ Stream& Stream::ThenBlasLtMatmul(
                           const DeviceMemory<std::complex<float>>&,
                           const HostOrDeviceScalar<std::complex<float>>&,
                           DeviceMemory<std::complex<float>>*, ScratchAllocator*,
-                          const blas::IBlasLtMatmulAlgorithm*>
+                          const blas::IBlasLtMatmulAlgorithm*,
+                          const DeviceMemory<std::complex<float>>&>
       impl;
   return impl(this, &blas::BlasSupport::DoBlasLtMatmul, plan, alpha, a, b, beta,
-              c, scratch_allocator, algorithm, output_profile_result);
+              c, scratch_allocator, algorithm, bias, output_profile_result);
 }
 
 Stream& Stream::ThenBlasLtMatmul(
@@ -4921,9 +4929,10 @@ Stream& Stream::ThenBlasLtMatmul(
     const HostOrDeviceScalar<std::complex<double>>& beta,
     DeviceMemory<std::complex<double>>* c, ScratchAllocator* scratch_allocator,
     const blas::IBlasLtMatmulAlgorithm* algorithm,
+    const DeviceMemory<std::complex<double>>& bias,
     blas::ProfileResult* output_profile_result) {
   VLOG_CALL(PARAM(plan), PARAM(alpha), PARAM(a), PARAM(b), PARAM(beta),
-            PARAM(c), PARAM(algorithm));
+            PARAM(c), PARAM(algorithm), PARAM(bias));
 
   ThenBlasWithProfileImpl<const blas::IBlasLtMatmulPlan*,
                           const HostOrDeviceScalar<std::complex<double>>&,
@@ -4932,10 +4941,11 @@ Stream& Stream::ThenBlasLtMatmul(
                           const HostOrDeviceScalar<std::complex<double>>&,
                           DeviceMemory<std::complex<double>>*,
                           ScratchAllocator*,
-                          const blas::IBlasLtMatmulAlgorithm*>
+                          const blas::IBlasLtMatmulAlgorithm*,
+                          const DeviceMemory<std::complex<double>>&>
       impl;
   return impl(this, &blas::BlasSupport::DoBlasLtMatmul, plan, alpha, a, b, beta,
-              c, scratch_allocator, algorithm, output_profile_result);
+              c, scratch_allocator, algorithm, bias, output_profile_result);
 }
 
 Stream &Stream::ThenSetRngSeed(const uint8 *seed, uint64 seed_bytes) {

--- a/tensorflow/stream_executor/stream.cc
+++ b/tensorflow/stream_executor/stream.cc
@@ -140,14 +140,6 @@ std::string ToVlogString(const HostOrDeviceScalar<T> &memory_or_constant) {
   return ToVlogString(memory_or_constant.value());
 }
 
-std::string ToVlogString(const HostOrDeviceScalar<void>& memory_or_constant) {
-  if (memory_or_constant.is_pointer()) {
-    return ToVlogString(memory_or_constant.opaque_pointer());
-  }
-  return memory_or_constant.CallWithValue<std::string>(
-      [](const auto& value) { return ToVlogString(value); });
-}
-
 template <class T>
 std::string ToVlogString(port::ArraySlice<T> elements) {
   std::string str = absl::StrCat(

--- a/tensorflow/stream_executor/stream.cc
+++ b/tensorflow/stream_executor/stream.cc
@@ -4801,6 +4801,143 @@ Stream &Stream::ThenBlasGemmStridedBatched(
               c, ldc, stride_c, batch_count);
 }
 
+Stream& Stream::ThenBlasLtMatmul(const blas::IBlasLtMatmulPlan* plan,
+                                 const HostOrDeviceScalar<int32>& alpha,
+                                 const DeviceMemory<int8>& a,
+                                 const DeviceMemory<int8>& b,
+                                 const HostOrDeviceScalar<int32>& beta,
+                                 DeviceMemory<int32>* c,
+                                 ScratchAllocator* scratch_allocator,
+                                 const blas::IBlasLtMatmulAlgorithm* algorithm,
+                                 blas::ProfileResult* output_profile_result) {
+  VLOG_CALL(PARAM(plan), PARAM(alpha), PARAM(a), PARAM(b), PARAM(beta),
+            PARAM(c), PARAM(algorithm));
+
+  ThenBlasWithProfileImpl<
+      const blas::IBlasLtMatmulPlan*, const HostOrDeviceScalar<int32>&,
+      const DeviceMemory<int8>&, const DeviceMemory<int8>&,
+      const HostOrDeviceScalar<int32>&, DeviceMemory<int32>*, ScratchAllocator*,
+      const blas::IBlasLtMatmulAlgorithm*>
+      impl;
+  return impl(this, &blas::BlasSupport::DoBlasLtMatmul, plan, alpha, a, b, beta,
+              c, scratch_allocator, algorithm, output_profile_result);
+}
+
+Stream& Stream::ThenBlasLtMatmul(const blas::IBlasLtMatmulPlan* plan,
+                                 const HostOrDeviceScalar<Eigen::half>& alpha,
+                                 const DeviceMemory<Eigen::half>& a,
+                                 const DeviceMemory<Eigen::half>& b,
+                                 const HostOrDeviceScalar<Eigen::half>& beta,
+                                 DeviceMemory<Eigen::half>* c,
+                                 ScratchAllocator* scratch_allocator,
+                                 const blas::IBlasLtMatmulAlgorithm* algorithm,
+                                 blas::ProfileResult* output_profile_result) {
+  VLOG_CALL(PARAM(plan), PARAM(alpha), PARAM(a), PARAM(b), PARAM(beta),
+            PARAM(c), PARAM(algorithm));
+
+  ThenBlasWithProfileImpl<
+      const blas::IBlasLtMatmulPlan*, const HostOrDeviceScalar<Eigen::half>&,
+      const DeviceMemory<Eigen::half>&, const DeviceMemory<Eigen::half>&,
+      const HostOrDeviceScalar<Eigen::half>&, DeviceMemory<Eigen::half>*,
+      ScratchAllocator*, const blas::IBlasLtMatmulAlgorithm*>
+      impl;
+  return impl(this, &blas::BlasSupport::DoBlasLtMatmul, plan, alpha, a, b, beta,
+              c, scratch_allocator, algorithm, output_profile_result);
+}
+
+Stream& Stream::ThenBlasLtMatmul(const blas::IBlasLtMatmulPlan* plan,
+                                 const HostOrDeviceScalar<float>& alpha,
+                                 const DeviceMemory<float>& a,
+                                 const DeviceMemory<float>& b,
+                                 const HostOrDeviceScalar<float>& beta,
+                                 DeviceMemory<float>* c,
+                                 ScratchAllocator* scratch_allocator,
+                                 const blas::IBlasLtMatmulAlgorithm* algorithm,
+                                 blas::ProfileResult* output_profile_result) {
+  VLOG_CALL(PARAM(plan), PARAM(alpha), PARAM(a), PARAM(b), PARAM(beta),
+            PARAM(c), PARAM(algorithm));
+
+  ThenBlasWithProfileImpl<
+      const blas::IBlasLtMatmulPlan*, const HostOrDeviceScalar<float>&,
+      const DeviceMemory<float>&, const DeviceMemory<float>&,
+      const HostOrDeviceScalar<float>&, DeviceMemory<float>*, ScratchAllocator*,
+      const blas::IBlasLtMatmulAlgorithm*>
+      impl;
+  return impl(this, &blas::BlasSupport::DoBlasLtMatmul, plan, alpha, a, b, beta,
+              c, scratch_allocator, algorithm, output_profile_result);
+}
+
+Stream& Stream::ThenBlasLtMatmul(const blas::IBlasLtMatmulPlan* plan,
+                                 const HostOrDeviceScalar<double>& alpha,
+                                 const DeviceMemory<double>& a,
+                                 const DeviceMemory<double>& b,
+                                 const HostOrDeviceScalar<double>& beta,
+                                 DeviceMemory<double>* c,
+                                 ScratchAllocator* scratch_allocator,
+                                 const blas::IBlasLtMatmulAlgorithm* algorithm,
+                                 blas::ProfileResult* output_profile_result) {
+  VLOG_CALL(PARAM(plan), PARAM(alpha), PARAM(a), PARAM(b), PARAM(beta),
+            PARAM(c), PARAM(algorithm));
+
+  ThenBlasWithProfileImpl<
+      const blas::IBlasLtMatmulPlan*, const HostOrDeviceScalar<double>&,
+      const DeviceMemory<double>&, const DeviceMemory<double>&,
+      const HostOrDeviceScalar<double>&, DeviceMemory<double>*,
+      ScratchAllocator*, const blas::IBlasLtMatmulAlgorithm*>
+      impl;
+  return impl(this, &blas::BlasSupport::DoBlasLtMatmul, plan, alpha, a, b, beta,
+              c, scratch_allocator, algorithm, output_profile_result);
+}
+
+Stream& Stream::ThenBlasLtMatmul(
+    const blas::IBlasLtMatmulPlan* plan,
+    const HostOrDeviceScalar<std::complex<float>>& alpha,
+    const DeviceMemory<std::complex<float>>& a,
+    const DeviceMemory<std::complex<float>>& b,
+    const HostOrDeviceScalar<std::complex<float>>& beta,
+    DeviceMemory<std::complex<float>>* c, ScratchAllocator* scratch_allocator,
+    const blas::IBlasLtMatmulAlgorithm* algorithm,
+    blas::ProfileResult* output_profile_result) {
+  VLOG_CALL(PARAM(plan), PARAM(alpha), PARAM(a), PARAM(b), PARAM(beta),
+            PARAM(c), PARAM(algorithm));
+
+  ThenBlasWithProfileImpl<const blas::IBlasLtMatmulPlan*,
+                          const HostOrDeviceScalar<std::complex<float>>&,
+                          const DeviceMemory<std::complex<float>>&,
+                          const DeviceMemory<std::complex<float>>&,
+                          const HostOrDeviceScalar<std::complex<float>>&,
+                          DeviceMemory<std::complex<float>>*, ScratchAllocator*,
+                          const blas::IBlasLtMatmulAlgorithm*>
+      impl;
+  return impl(this, &blas::BlasSupport::DoBlasLtMatmul, plan, alpha, a, b, beta,
+              c, scratch_allocator, algorithm, output_profile_result);
+}
+
+Stream& Stream::ThenBlasLtMatmul(
+    const blas::IBlasLtMatmulPlan* plan,
+    const HostOrDeviceScalar<std::complex<double>>& alpha,
+    const DeviceMemory<std::complex<double>>& a,
+    const DeviceMemory<std::complex<double>>& b,
+    const HostOrDeviceScalar<std::complex<double>>& beta,
+    DeviceMemory<std::complex<double>>* c, ScratchAllocator* scratch_allocator,
+    const blas::IBlasLtMatmulAlgorithm* algorithm,
+    blas::ProfileResult* output_profile_result) {
+  VLOG_CALL(PARAM(plan), PARAM(alpha), PARAM(a), PARAM(b), PARAM(beta),
+            PARAM(c), PARAM(algorithm));
+
+  ThenBlasWithProfileImpl<const blas::IBlasLtMatmulPlan*,
+                          const HostOrDeviceScalar<std::complex<double>>&,
+                          const DeviceMemory<std::complex<double>>&,
+                          const DeviceMemory<std::complex<double>>&,
+                          const HostOrDeviceScalar<std::complex<double>>&,
+                          DeviceMemory<std::complex<double>>*,
+                          ScratchAllocator*,
+                          const blas::IBlasLtMatmulAlgorithm*>
+      impl;
+  return impl(this, &blas::BlasSupport::DoBlasLtMatmul, plan, alpha, a, b, beta,
+              c, scratch_allocator, algorithm, output_profile_result);
+}
+
 Stream &Stream::ThenSetRngSeed(const uint8 *seed, uint64 seed_bytes) {
   VLOG_CALL(PARAM(seed), PARAM(seed_bytes));
 

--- a/tensorflow/stream_executor/stream.cc
+++ b/tensorflow/stream_executor/stream.cc
@@ -140,6 +140,14 @@ std::string ToVlogString(const HostOrDeviceScalar<T> &memory_or_constant) {
   return ToVlogString(memory_or_constant.value());
 }
 
+std::string ToVlogString(const HostOrDeviceScalar<void>& memory_or_constant) {
+  if (memory_or_constant.is_pointer()) {
+    return ToVlogString(memory_or_constant.opaque_pointer());
+  }
+  return memory_or_constant.CallWithValue<std::string>(
+      [](const auto& value) { return ToVlogString(value); });
+}
+
 template <class T>
 std::string ToVlogString(port::ArraySlice<T> elements) {
   std::string str = absl::StrCat(
@@ -4802,147 +4810,22 @@ Stream &Stream::ThenBlasGemmStridedBatched(
 }
 
 Stream& Stream::ThenBlasLtMatmul(const blas::IBlasLtMatmulPlan* plan,
-                                 const HostOrDeviceScalar<int32>& alpha,
-                                 const DeviceMemory<int8>& a,
-                                 const DeviceMemory<int8>& b,
-                                 const HostOrDeviceScalar<int32>& beta,
-                                 DeviceMemory<int32>* c,
+                                 const HostOrDeviceScalar<void>& alpha,
+                                 DeviceMemoryBase a, DeviceMemoryBase b,
+                                 const HostOrDeviceScalar<void>& beta,
+                                 DeviceMemoryBase c,
                                  ScratchAllocator* scratch_allocator,
                                  const blas::IBlasLtMatmulAlgorithm* algorithm,
-                                 const DeviceMemory<int32>& bias,
+                                 DeviceMemoryBase bias,
                                  blas::ProfileResult* output_profile_result) {
-  VLOG_CALL(PARAM(plan), PARAM(alpha), PARAM(a), PARAM(b), PARAM(beta),
-            PARAM(c), PARAM(algorithm), PARAM(bias));
-
-  ThenBlasWithProfileImpl<
-      const blas::IBlasLtMatmulPlan*, const HostOrDeviceScalar<int32>&,
-      const DeviceMemory<int8>&, const DeviceMemory<int8>&,
-      const HostOrDeviceScalar<int32>&, DeviceMemory<int32>*, ScratchAllocator*,
-      const blas::IBlasLtMatmulAlgorithm*, const DeviceMemory<int32>&>
-      impl;
-  return impl(this, &blas::BlasSupport::DoBlasLtMatmul, plan, alpha, a, b, beta,
-              c, scratch_allocator, algorithm, bias, output_profile_result);
-}
-
-Stream& Stream::ThenBlasLtMatmul(const blas::IBlasLtMatmulPlan* plan,
-                                 const HostOrDeviceScalar<Eigen::half>& alpha,
-                                 const DeviceMemory<Eigen::half>& a,
-                                 const DeviceMemory<Eigen::half>& b,
-                                 const HostOrDeviceScalar<Eigen::half>& beta,
-                                 DeviceMemory<Eigen::half>* c,
-                                 ScratchAllocator* scratch_allocator,
-                                 const blas::IBlasLtMatmulAlgorithm* algorithm,
-                                 const DeviceMemory<Eigen::half>& bias,
-                                 blas::ProfileResult* output_profile_result) {
-  VLOG_CALL(PARAM(plan), PARAM(alpha), PARAM(a), PARAM(b), PARAM(beta),
-            PARAM(c), PARAM(algorithm), PARAM(bias));
-
-  ThenBlasWithProfileImpl<
-      const blas::IBlasLtMatmulPlan*, const HostOrDeviceScalar<Eigen::half>&,
-      const DeviceMemory<Eigen::half>&, const DeviceMemory<Eigen::half>&,
-      const HostOrDeviceScalar<Eigen::half>&, DeviceMemory<Eigen::half>*,
-      ScratchAllocator*, const blas::IBlasLtMatmulAlgorithm*,
-      const DeviceMemory<Eigen::half>&>
-      impl;
-  return impl(this, &blas::BlasSupport::DoBlasLtMatmul, plan, alpha, a, b, beta,
-              c, scratch_allocator, algorithm, bias, output_profile_result);
-}
-
-Stream& Stream::ThenBlasLtMatmul(const blas::IBlasLtMatmulPlan* plan,
-                                 const HostOrDeviceScalar<float>& alpha,
-                                 const DeviceMemory<float>& a,
-                                 const DeviceMemory<float>& b,
-                                 const HostOrDeviceScalar<float>& beta,
-                                 DeviceMemory<float>* c,
-                                 ScratchAllocator* scratch_allocator,
-                                 const blas::IBlasLtMatmulAlgorithm* algorithm,
-                                 const DeviceMemory<float>& bias,
-                                 blas::ProfileResult* output_profile_result) {
-  VLOG_CALL(PARAM(plan), PARAM(alpha), PARAM(a), PARAM(b), PARAM(beta),
-            PARAM(c), PARAM(algorithm), PARAM(bias));
-
-  ThenBlasWithProfileImpl<
-      const blas::IBlasLtMatmulPlan*, const HostOrDeviceScalar<float>&,
-      const DeviceMemory<float>&, const DeviceMemory<float>&,
-      const HostOrDeviceScalar<float>&, DeviceMemory<float>*, ScratchAllocator*,
-      const blas::IBlasLtMatmulAlgorithm*, const DeviceMemory<float>&>
-      impl;
-  return impl(this, &blas::BlasSupport::DoBlasLtMatmul, plan, alpha, a, b, beta,
-              c, scratch_allocator, algorithm, bias, output_profile_result);
-}
-
-Stream& Stream::ThenBlasLtMatmul(const blas::IBlasLtMatmulPlan* plan,
-                                 const HostOrDeviceScalar<double>& alpha,
-                                 const DeviceMemory<double>& a,
-                                 const DeviceMemory<double>& b,
-                                 const HostOrDeviceScalar<double>& beta,
-                                 DeviceMemory<double>* c,
-                                 ScratchAllocator* scratch_allocator,
-                                 const blas::IBlasLtMatmulAlgorithm* algorithm,
-                                 const DeviceMemory<double>& bias,
-                                 blas::ProfileResult* output_profile_result) {
-  VLOG_CALL(PARAM(plan), PARAM(alpha), PARAM(a), PARAM(b), PARAM(beta),
-            PARAM(c), PARAM(algorithm), PARAM(bias));
-
-  ThenBlasWithProfileImpl<
-      const blas::IBlasLtMatmulPlan*, const HostOrDeviceScalar<double>&,
-      const DeviceMemory<double>&, const DeviceMemory<double>&,
-      const HostOrDeviceScalar<double>&, DeviceMemory<double>*,
-      ScratchAllocator*, const blas::IBlasLtMatmulAlgorithm*,
-      const DeviceMemory<double>&>
-      impl;
-  return impl(this, &blas::BlasSupport::DoBlasLtMatmul, plan, alpha, a, b, beta,
-              c, scratch_allocator, algorithm, bias, output_profile_result);
-}
-
-Stream& Stream::ThenBlasLtMatmul(
-    const blas::IBlasLtMatmulPlan* plan,
-    const HostOrDeviceScalar<std::complex<float>>& alpha,
-    const DeviceMemory<std::complex<float>>& a,
-    const DeviceMemory<std::complex<float>>& b,
-    const HostOrDeviceScalar<std::complex<float>>& beta,
-    DeviceMemory<std::complex<float>>* c, ScratchAllocator* scratch_allocator,
-    const blas::IBlasLtMatmulAlgorithm* algorithm,
-    const DeviceMemory<std::complex<float>>& bias,
-    blas::ProfileResult* output_profile_result) {
   VLOG_CALL(PARAM(plan), PARAM(alpha), PARAM(a), PARAM(b), PARAM(beta),
             PARAM(c), PARAM(algorithm), PARAM(bias));
 
   ThenBlasWithProfileImpl<const blas::IBlasLtMatmulPlan*,
-                          const HostOrDeviceScalar<std::complex<float>>&,
-                          const DeviceMemory<std::complex<float>>&,
-                          const DeviceMemory<std::complex<float>>&,
-                          const HostOrDeviceScalar<std::complex<float>>&,
-                          DeviceMemory<std::complex<float>>*, ScratchAllocator*,
-                          const blas::IBlasLtMatmulAlgorithm*,
-                          const DeviceMemory<std::complex<float>>&>
-      impl;
-  return impl(this, &blas::BlasSupport::DoBlasLtMatmul, plan, alpha, a, b, beta,
-              c, scratch_allocator, algorithm, bias, output_profile_result);
-}
-
-Stream& Stream::ThenBlasLtMatmul(
-    const blas::IBlasLtMatmulPlan* plan,
-    const HostOrDeviceScalar<std::complex<double>>& alpha,
-    const DeviceMemory<std::complex<double>>& a,
-    const DeviceMemory<std::complex<double>>& b,
-    const HostOrDeviceScalar<std::complex<double>>& beta,
-    DeviceMemory<std::complex<double>>* c, ScratchAllocator* scratch_allocator,
-    const blas::IBlasLtMatmulAlgorithm* algorithm,
-    const DeviceMemory<std::complex<double>>& bias,
-    blas::ProfileResult* output_profile_result) {
-  VLOG_CALL(PARAM(plan), PARAM(alpha), PARAM(a), PARAM(b), PARAM(beta),
-            PARAM(c), PARAM(algorithm), PARAM(bias));
-
-  ThenBlasWithProfileImpl<const blas::IBlasLtMatmulPlan*,
-                          const HostOrDeviceScalar<std::complex<double>>&,
-                          const DeviceMemory<std::complex<double>>&,
-                          const DeviceMemory<std::complex<double>>&,
-                          const HostOrDeviceScalar<std::complex<double>>&,
-                          DeviceMemory<std::complex<double>>*,
-                          ScratchAllocator*,
-                          const blas::IBlasLtMatmulAlgorithm*,
-                          const DeviceMemory<std::complex<double>>&>
+                          const HostOrDeviceScalar<void>&, DeviceMemoryBase,
+                          DeviceMemoryBase, const HostOrDeviceScalar<void>&,
+                          DeviceMemoryBase, ScratchAllocator*,
+                          const blas::IBlasLtMatmulAlgorithm*, DeviceMemoryBase>
       impl;
   return impl(this, &blas::BlasSupport::DoBlasLtMatmul, plan, alpha, a, b, beta,
               c, scratch_allocator, algorithm, bias, output_profile_result);

--- a/tensorflow/stream_executor/stream.h
+++ b/tensorflow/stream_executor/stream.h
@@ -1665,6 +1665,56 @@ class Stream {
                        const DeviceMemory<std::complex<double>> &a, int lda,
                        DeviceMemory<std::complex<double>> *b, int ldb);
 
+  // See BlasSupport::DoBlatLtMatmul.
+  Stream& ThenBlasLtMatmul(
+      const blas::IBlasLtMatmulPlan* plan,
+      const HostOrDeviceScalar<int32>& alpha, const DeviceMemory<int8>& a,
+      const DeviceMemory<int8>& b, const HostOrDeviceScalar<int32>& beta,
+      DeviceMemory<int32>* c, ScratchAllocator* scratch_allocator,
+      const blas::IBlasLtMatmulAlgorithm* algorithm,
+      blas::ProfileResult* output_profile_result = nullptr);
+  Stream& ThenBlasLtMatmul(
+      const blas::IBlasLtMatmulPlan* plan,
+      const HostOrDeviceScalar<Eigen::half>& alpha,
+      const DeviceMemory<Eigen::half>& a, const DeviceMemory<Eigen::half>& b,
+      const HostOrDeviceScalar<Eigen::half>& beta, DeviceMemory<Eigen::half>* c,
+      ScratchAllocator* scratch_allocator,
+      const blas::IBlasLtMatmulAlgorithm* algorithm,
+      blas::ProfileResult* output_profile_result = nullptr);
+  Stream& ThenBlasLtMatmul(
+      const blas::IBlasLtMatmulPlan* plan,
+      const HostOrDeviceScalar<float>& alpha, const DeviceMemory<float>& a,
+      const DeviceMemory<float>& b, const HostOrDeviceScalar<float>& beta,
+      DeviceMemory<float>* c, ScratchAllocator* scratch_allocator,
+      const blas::IBlasLtMatmulAlgorithm* algorithm,
+      blas::ProfileResult* output_profile_result = nullptr);
+  Stream& ThenBlasLtMatmul(
+      const blas::IBlasLtMatmulPlan* plan,
+      const HostOrDeviceScalar<double>& alpha, const DeviceMemory<double>& a,
+      const DeviceMemory<double>& b, const HostOrDeviceScalar<double>& beta,
+      DeviceMemory<double>* c, ScratchAllocator* scratch_allocator,
+      const blas::IBlasLtMatmulAlgorithm* algorithm,
+      blas::ProfileResult* output_profile_result = nullptr);
+  Stream& ThenBlasLtMatmul(
+      const blas::IBlasLtMatmulPlan* plan,
+      const HostOrDeviceScalar<std::complex<float>>& alpha,
+      const DeviceMemory<std::complex<float>>& a,
+      const DeviceMemory<std::complex<float>>& b,
+      const HostOrDeviceScalar<std::complex<float>>& beta,
+      DeviceMemory<std::complex<float>>* c, ScratchAllocator* scratch_allocator,
+      const blas::IBlasLtMatmulAlgorithm* algorithm,
+      blas::ProfileResult* output_profile_result = nullptr);
+  Stream& ThenBlasLtMatmul(
+      const blas::IBlasLtMatmulPlan* plan,
+      const HostOrDeviceScalar<std::complex<double>>& alpha,
+      const DeviceMemory<std::complex<double>>& a,
+      const DeviceMemory<std::complex<double>>& b,
+      const HostOrDeviceScalar<std::complex<double>>& beta,
+      DeviceMemory<std::complex<double>>* c,
+      ScratchAllocator* scratch_allocator,
+      const blas::IBlasLtMatmulAlgorithm* algorithm,
+      blas::ProfileResult* output_profile_result = nullptr);
+
   // See FftSupport::DoFft.
   Stream &ThenFft(fft::Plan *plan,
                   const DeviceMemory<std::complex<float>> &input,

--- a/tensorflow/stream_executor/stream.h
+++ b/tensorflow/stream_executor/stream.h
@@ -1679,16 +1679,6 @@ class Stream {
                        DeviceMemory<std::complex<double>> *b, int ldb);
 
   // See BlasSupport::DoBlatLtMatmul.
-  Stream& ThenBlasLtMatmul(const blas::IBlasLtMatmulPlan* plan,
-                           const HostOrDeviceScalar<void>& alpha,
-                           DeviceMemoryBase a, DeviceMemoryBase b,
-                           const HostOrDeviceScalar<void>& beta,
-                           DeviceMemoryBase c,
-                           ScratchAllocator* scratch_allocator,
-                           const blas::IBlasLtMatmulAlgorithm* algorithm,
-                           DeviceMemoryBase bias,
-                           blas::ProfileResult* output_profile_result);
-
   // Note that we prevent alpha and beta from being used to deduce CType so that
   // they can be constructed implicitly from values of type CType. Without this,
   // type deduction would fail when this function is called with a value of type
@@ -1703,8 +1693,8 @@ class Stream {
       const blas::IBlasLtMatmulAlgorithm* algorithm,
       const DeviceMemory<CType>& bias = {},
       blas::ProfileResult* output_profile_result = nullptr) {
-    return ThenBlasLtMatmul(plan, alpha, a, b, beta, *c, scratch_allocator,
-                            algorithm, bias, output_profile_result);
+    return ThenBlasLtMatmulImpl(plan, alpha, a, b, beta, c, scratch_allocator,
+                                algorithm, bias, output_profile_result);
   }
 
   // See FftSupport::DoFft.
@@ -2138,6 +2128,19 @@ class Stream {
       const DeviceMemory<T> &input_data,
       const dnn::BatchDescriptor &bias_descriptor,
       DeviceMemory<T> *backward_bias_data);
+
+  // Implementation of ThenBlasLtMatmul that is shared by all types.
+  template <typename ABType, typename CType>
+  Stream& ThenBlasLtMatmulImpl(const blas::IBlasLtMatmulPlan* plan,
+                               const HostOrDeviceScalar<CType>& alpha,
+                               const DeviceMemory<ABType>& a,
+                               const DeviceMemory<ABType>& b,
+                               const HostOrDeviceScalar<CType>& beta,
+                               DeviceMemory<CType>* c,
+                               ScratchAllocator* scratch_allocator,
+                               const blas::IBlasLtMatmulAlgorithm* algorithm,
+                               const DeviceMemory<CType>& bias,
+                               blas::ProfileResult* output_profile_result);
 
   SE_DISALLOW_COPY_AND_ASSIGN(Stream);
 };

--- a/tensorflow/stream_executor/stream.h
+++ b/tensorflow/stream_executor/stream.h
@@ -1672,6 +1672,7 @@ class Stream {
       const DeviceMemory<int8>& b, const HostOrDeviceScalar<int32>& beta,
       DeviceMemory<int32>* c, ScratchAllocator* scratch_allocator,
       const blas::IBlasLtMatmulAlgorithm* algorithm,
+      const DeviceMemory<int32>& bias = {},
       blas::ProfileResult* output_profile_result = nullptr);
   Stream& ThenBlasLtMatmul(
       const blas::IBlasLtMatmulPlan* plan,
@@ -1680,6 +1681,7 @@ class Stream {
       const HostOrDeviceScalar<Eigen::half>& beta, DeviceMemory<Eigen::half>* c,
       ScratchAllocator* scratch_allocator,
       const blas::IBlasLtMatmulAlgorithm* algorithm,
+      const DeviceMemory<Eigen::half>& bias = {},
       blas::ProfileResult* output_profile_result = nullptr);
   Stream& ThenBlasLtMatmul(
       const blas::IBlasLtMatmulPlan* plan,
@@ -1687,6 +1689,7 @@ class Stream {
       const DeviceMemory<float>& b, const HostOrDeviceScalar<float>& beta,
       DeviceMemory<float>* c, ScratchAllocator* scratch_allocator,
       const blas::IBlasLtMatmulAlgorithm* algorithm,
+      const DeviceMemory<float>& bias = {},
       blas::ProfileResult* output_profile_result = nullptr);
   Stream& ThenBlasLtMatmul(
       const blas::IBlasLtMatmulPlan* plan,
@@ -1694,6 +1697,7 @@ class Stream {
       const DeviceMemory<double>& b, const HostOrDeviceScalar<double>& beta,
       DeviceMemory<double>* c, ScratchAllocator* scratch_allocator,
       const blas::IBlasLtMatmulAlgorithm* algorithm,
+      const DeviceMemory<double>& bias = {},
       blas::ProfileResult* output_profile_result = nullptr);
   Stream& ThenBlasLtMatmul(
       const blas::IBlasLtMatmulPlan* plan,
@@ -1703,6 +1707,7 @@ class Stream {
       const HostOrDeviceScalar<std::complex<float>>& beta,
       DeviceMemory<std::complex<float>>* c, ScratchAllocator* scratch_allocator,
       const blas::IBlasLtMatmulAlgorithm* algorithm,
+      const DeviceMemory<std::complex<float>>& bias = {},
       blas::ProfileResult* output_profile_result = nullptr);
   Stream& ThenBlasLtMatmul(
       const blas::IBlasLtMatmulPlan* plan,
@@ -1713,6 +1718,7 @@ class Stream {
       DeviceMemory<std::complex<double>>* c,
       ScratchAllocator* scratch_allocator,
       const blas::IBlasLtMatmulAlgorithm* algorithm,
+      const DeviceMemory<std::complex<double>>& bias = {},
       blas::ProfileResult* output_profile_result = nullptr);
 
   // See FftSupport::DoFft.

--- a/tensorflow/stream_executor/stream_executor_pimpl.cc
+++ b/tensorflow/stream_executor/stream_executor_pimpl.cc
@@ -336,6 +336,49 @@ bool StreamExecutor::GetBlasGemmAlgorithms(
   return blas_support->GetBlasGemmAlgorithms(out_algorithms);
 }
 
+std::unique_ptr<blas::IBlasLtMatmulPlan> StreamExecutor::CreateBlasLtMatmulPlan(
+    blas::DataType ab_type, blas::DataType cd_type,
+    blas::ComputationType computation_type, blas::PointerMode pointer_mode,
+    blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
+    uint64 k, int64 lda, int64 ldb, int64 ldc) {
+  blas::BlasSupport *blas_support = AsBlas();
+  if (!blas_support) {
+    return nullptr;
+  }
+  return blas_support->CreateBlasLtMatmulPlan(
+      ab_type, cd_type, computation_type, pointer_mode, transa, transb, m, n, k,
+      lda, ldb, ldc);
+}
+
+std::unique_ptr<blas::IBlasLtMatmulPlan>
+StreamExecutor::CreateBlasLtMatmulPlanStridedBatched(
+    blas::DataType ab_type, blas::DataType cd_type,
+    blas::ComputationType computation_type, blas::PointerMode pointer_mode,
+    blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
+    uint64 k, uint64 batch_count, int64 lda, int64 stride_a, int64 ldb,
+    int64 stride_b, int64 ldc, int64 stride_c) {
+  blas::BlasSupport *blas_support = AsBlas();
+  if (!blas_support) {
+    return nullptr;
+  }
+  return blas_support->CreateBlasLtMatmulPlanStridedBatched(
+      ab_type, cd_type, computation_type, pointer_mode, transa, transb, m, n, k,
+      batch_count, lda, stride_a, ldb, stride_b, ldc, stride_c);
+}
+
+bool StreamExecutor::GetBlasLtMatmulAlgorithms(
+    const blas::IBlasLtMatmulPlan* plan, size_t max_workspace_size,
+    int max_algorithm_count,
+    std::vector<std::unique_ptr<blas::IBlasLtMatmulAlgorithm>>*
+        out_algorithms) {
+  blas::BlasSupport *blas_support = AsBlas();
+  if (!blas_support) {
+    return false;
+  }
+  return blas_support->GetBlasLtMatmulAlgorithms(
+      plan, max_workspace_size, max_algorithm_count, out_algorithms);
+}
+
 port::StatusOr<std::unique_ptr<dnn::RnnDescriptor>>
 StreamExecutor::createRnnDescriptor(
     int num_layers, int hidden_size, int input_size, int cell_size,

--- a/tensorflow/stream_executor/stream_executor_pimpl.cc
+++ b/tensorflow/stream_executor/stream_executor_pimpl.cc
@@ -336,26 +336,28 @@ bool StreamExecutor::GetBlasGemmAlgorithms(
   return blas_support->GetBlasGemmAlgorithms(out_algorithms);
 }
 
-std::unique_ptr<blas::IBlasLtMatmulPlan> StreamExecutor::CreateBlasLtMatmulPlan(
+port::StatusOr<std::unique_ptr<blas::IBlasLtMatmulPlan>>
+StreamExecutor::CreateBlasLtMatmulPlan(
     const blas::BlasLtMatmulPlanParams& params) {
-  blas::BlasSupport *blas_support = AsBlas();
+  blas::BlasSupport* blas_support = AsBlas();
   if (!blas_support) {
-    return nullptr;
+    return port::Status(port::error::UNKNOWN,
+                        "Fail to find the blas implementation.");
   }
   return blas_support->CreateBlasLtMatmulPlan(params);
 }
 
-bool StreamExecutor::GetBlasLtMatmulAlgorithms(
-    const blas::IBlasLtMatmulPlan* plan, size_t max_workspace_size,
-    int max_algorithm_count,
-    std::vector<std::unique_ptr<blas::IBlasLtMatmulAlgorithm>>*
-        out_algorithms) {
-  blas::BlasSupport *blas_support = AsBlas();
+port::StatusOr<std::vector<std::unique_ptr<blas::IBlasLtMatmulAlgorithm>>>
+StreamExecutor::GetBlasLtMatmulAlgorithms(const blas::IBlasLtMatmulPlan* plan,
+                                          size_t max_workspace_size,
+                                          int max_algorithm_count) {
+  blas::BlasSupport* blas_support = AsBlas();
   if (!blas_support) {
-    return false;
+    return port::Status(port::error::UNKNOWN,
+                        "Fail to find the blas implementation.");
   }
-  return blas_support->GetBlasLtMatmulAlgorithms(
-      plan, max_workspace_size, max_algorithm_count, out_algorithms);
+  return blas_support->GetBlasLtMatmulAlgorithms(plan, max_workspace_size,
+                                                 max_algorithm_count);
 }
 
 port::StatusOr<std::unique_ptr<dnn::RnnDescriptor>>

--- a/tensorflow/stream_executor/stream_executor_pimpl.cc
+++ b/tensorflow/stream_executor/stream_executor_pimpl.cc
@@ -339,31 +339,32 @@ bool StreamExecutor::GetBlasGemmAlgorithms(
 std::unique_ptr<blas::IBlasLtMatmulPlan> StreamExecutor::CreateBlasLtMatmulPlan(
     blas::DataType ab_type, blas::DataType cd_type,
     blas::ComputationType computation_type, blas::PointerMode pointer_mode,
-    blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
-    uint64 k, int64 lda, int64 ldb, int64 ldc) {
+    blas::Epilogue epilogue, blas::Transpose transa, blas::Transpose transb,
+    uint64 m, uint64 n, uint64 k, int64 lda, int64 ldb, int64 ldc) {
   blas::BlasSupport *blas_support = AsBlas();
   if (!blas_support) {
     return nullptr;
   }
   return blas_support->CreateBlasLtMatmulPlan(
-      ab_type, cd_type, computation_type, pointer_mode, transa, transb, m, n, k,
-      lda, ldb, ldc);
+      ab_type, cd_type, computation_type, pointer_mode, epilogue, transa,
+      transb, m, n, k, lda, ldb, ldc);
 }
 
 std::unique_ptr<blas::IBlasLtMatmulPlan>
 StreamExecutor::CreateBlasLtMatmulPlanStridedBatched(
     blas::DataType ab_type, blas::DataType cd_type,
     blas::ComputationType computation_type, blas::PointerMode pointer_mode,
-    blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
-    uint64 k, uint64 batch_count, int64 lda, int64 stride_a, int64 ldb,
-    int64 stride_b, int64 ldc, int64 stride_c) {
+    blas::Epilogue epilogue, blas::Transpose transa, blas::Transpose transb,
+    uint64 m, uint64 n, uint64 k, uint64 batch_count, int64 lda, int64 stride_a,
+    int64 ldb, int64 stride_b, int64 ldc, int64 stride_c) {
   blas::BlasSupport *blas_support = AsBlas();
   if (!blas_support) {
     return nullptr;
   }
   return blas_support->CreateBlasLtMatmulPlanStridedBatched(
-      ab_type, cd_type, computation_type, pointer_mode, transa, transb, m, n, k,
-      batch_count, lda, stride_a, ldb, stride_b, ldc, stride_c);
+      ab_type, cd_type, computation_type, pointer_mode, epilogue, transa,
+      transb, m, n, k, batch_count, lda, stride_a, ldb, stride_b, ldc,
+      stride_c);
 }
 
 bool StreamExecutor::GetBlasLtMatmulAlgorithms(

--- a/tensorflow/stream_executor/stream_executor_pimpl.cc
+++ b/tensorflow/stream_executor/stream_executor_pimpl.cc
@@ -337,34 +337,12 @@ bool StreamExecutor::GetBlasGemmAlgorithms(
 }
 
 std::unique_ptr<blas::IBlasLtMatmulPlan> StreamExecutor::CreateBlasLtMatmulPlan(
-    blas::DataType ab_type, blas::DataType cd_type,
-    blas::ComputationType computation_type, blas::PointerMode pointer_mode,
-    blas::Epilogue epilogue, blas::Transpose transa, blas::Transpose transb,
-    uint64 m, uint64 n, uint64 k, int64 lda, int64 ldb, int64 ldc) {
+    const blas::BlasLtMatmulPlanParams& params) {
   blas::BlasSupport *blas_support = AsBlas();
   if (!blas_support) {
     return nullptr;
   }
-  return blas_support->CreateBlasLtMatmulPlan(
-      ab_type, cd_type, computation_type, pointer_mode, epilogue, transa,
-      transb, m, n, k, lda, ldb, ldc);
-}
-
-std::unique_ptr<blas::IBlasLtMatmulPlan>
-StreamExecutor::CreateBlasLtMatmulPlanStridedBatched(
-    blas::DataType ab_type, blas::DataType cd_type,
-    blas::ComputationType computation_type, blas::PointerMode pointer_mode,
-    blas::Epilogue epilogue, blas::Transpose transa, blas::Transpose transb,
-    uint64 m, uint64 n, uint64 k, uint64 batch_count, int64 lda, int64 stride_a,
-    int64 ldb, int64 stride_b, int64 ldc, int64 stride_c) {
-  blas::BlasSupport *blas_support = AsBlas();
-  if (!blas_support) {
-    return nullptr;
-  }
-  return blas_support->CreateBlasLtMatmulPlanStridedBatched(
-      ab_type, cd_type, computation_type, pointer_mode, epilogue, transa,
-      transb, m, n, k, batch_count, lda, stride_a, ldb, stride_b, ldc,
-      stride_c);
+  return blas_support->CreateBlasLtMatmulPlan(params);
 }
 
 bool StreamExecutor::GetBlasLtMatmulAlgorithms(

--- a/tensorflow/stream_executor/stream_executor_pimpl.h
+++ b/tensorflow/stream_executor/stream_executor_pimpl.h
@@ -399,19 +399,7 @@ class StreamExecutor {
   // created once and reused for multiple calls to DoBlasLtMatmul().
   // Returns a null pointer on failure.
   std::unique_ptr<blas::IBlasLtMatmulPlan> CreateBlasLtMatmulPlan(
-      blas::DataType ab_type, blas::DataType cd_type,
-      blas::ComputationType computation_type, blas::PointerMode pointer_mode,
-      blas::Epilogue epilogue, blas::Transpose transa, blas::Transpose transb,
-      uint64 m, uint64 n, uint64 k, int64 lda, int64 ldb, int64 ldc);
-
-  // A more general version of CreateBlasLtMatmulPlan supporting
-  // batched operations.
-  std::unique_ptr<blas::IBlasLtMatmulPlan> CreateBlasLtMatmulPlanStridedBatched(
-      blas::DataType ab_type, blas::DataType cd_type,
-      blas::ComputationType computation_type, blas::PointerMode pointer_mode,
-      blas::Epilogue epilogue, blas::Transpose transa, blas::Transpose transb,
-      uint64 m, uint64 n, uint64 k, uint64 batch_count, int64 lda,
-      int64 stride_a, int64 ldb, int64 stride_b, int64 ldc, int64 stride_c);
+      const blas::BlasLtMatmulPlanParams& params);
 
   // Gets a list of supported algorithms for DoBlasLtMatmul. The algorithms are
   // returned in the order of increasing estimated compute time according to an

--- a/tensorflow/stream_executor/stream_executor_pimpl.h
+++ b/tensorflow/stream_executor/stream_executor_pimpl.h
@@ -398,18 +398,16 @@ class StreamExecutor {
   // can then be passed to DoBlasLtMatmul(). When possible, plans should be
   // created once and reused for multiple calls to DoBlasLtMatmul().
   // Returns a null pointer on failure.
-  std::unique_ptr<blas::IBlasLtMatmulPlan> CreateBlasLtMatmulPlan(
-      const blas::BlasLtMatmulPlanParams& params);
+  port::StatusOr<std::unique_ptr<blas::IBlasLtMatmulPlan>>
+  CreateBlasLtMatmulPlan(const blas::BlasLtMatmulPlanParams& params);
 
   // Gets a list of supported algorithms for DoBlasLtMatmul. The algorithms are
   // returned in the order of increasing estimated compute time according to an
   // internal heuristic. The first returned algorithm can be used as the default
   // algorithm if no autotuning is to be performed.
-  bool GetBlasLtMatmulAlgorithms(
-      const blas::IBlasLtMatmulPlan* plan, size_t max_workspace_size,
-      int max_algorithm_count,
-      std::vector<std::unique_ptr<blas::IBlasLtMatmulAlgorithm>>*
-          out_algorithms);
+  port::StatusOr<std::vector<std::unique_ptr<blas::IBlasLtMatmulAlgorithm>>>
+  GetBlasLtMatmulAlgorithms(const blas::IBlasLtMatmulPlan* plan,
+                            size_t max_workspace_size, int max_algorithm_count);
 
   // Create an RNN descriptor based on model shapes and configurations.
   // The caller retains the ownership of the descriptor.

--- a/tensorflow/stream_executor/stream_executor_pimpl.h
+++ b/tensorflow/stream_executor/stream_executor_pimpl.h
@@ -401,17 +401,17 @@ class StreamExecutor {
   std::unique_ptr<blas::IBlasLtMatmulPlan> CreateBlasLtMatmulPlan(
       blas::DataType ab_type, blas::DataType cd_type,
       blas::ComputationType computation_type, blas::PointerMode pointer_mode,
-      blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
-      uint64 k, int64 lda, int64 ldb, int64 ldc);
+      blas::Epilogue epilogue, blas::Transpose transa, blas::Transpose transb,
+      uint64 m, uint64 n, uint64 k, int64 lda, int64 ldb, int64 ldc);
 
   // A more general version of CreateBlasLtMatmulPlan supporting
   // batched operations.
   std::unique_ptr<blas::IBlasLtMatmulPlan> CreateBlasLtMatmulPlanStridedBatched(
       blas::DataType ab_type, blas::DataType cd_type,
       blas::ComputationType computation_type, blas::PointerMode pointer_mode,
-      blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
-      uint64 k, uint64 batch_count, int64 lda, int64 stride_a, int64 ldb,
-      int64 stride_b, int64 ldc, int64 stride_c);
+      blas::Epilogue epilogue, blas::Transpose transa, blas::Transpose transb,
+      uint64 m, uint64 n, uint64 k, uint64 batch_count, int64 lda,
+      int64 stride_a, int64 ldb, int64 stride_b, int64 ldc, int64 stride_c);
 
   // Gets a list of supported algorithms for DoBlasLtMatmul. The algorithms are
   // returned in the order of increasing estimated compute time according to an

--- a/third_party/gpus/cuda/BUILD.tpl
+++ b/third_party/gpus/cuda/BUILD.tpl
@@ -128,6 +128,13 @@ cc_library(
 )
 
 cc_library(
+    name = "cublasLt",
+    srcs = ["cuda/lib/%{cublasLt_lib}"],
+    data = ["cuda/lib/%{cublasLt_lib}"],
+    linkstatic = 1,
+)
+
+cc_library(
     name = "cusolver",
     srcs = ["cuda/lib/%{cusolver_lib}"],
     data = ["cuda/lib/%{cusolver_lib}"],
@@ -168,6 +175,7 @@ cc_library(
     name = "cuda",
     deps = [
         ":cublas",
+        ":cublasLt",
         ":cuda_headers",
         ":cudart",
         ":cudnn",

--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -551,6 +551,13 @@ def _find_libs(repository_ctx, check_cuda_libs_script, cuda_config):
             cuda_config.cublas_version,
             static = False,
         ),
+        "cublasLt": _check_cuda_lib_params(
+            "cublasLt",
+            cpu_value,
+            cuda_config.config["cublas_library_dir"],
+            cuda_config.cublas_version,
+            static = False,
+        ),
         "cusolver": _check_cuda_lib_params(
             "cusolver",
             cpu_value,
@@ -771,6 +778,7 @@ def _create_dummy_repository(repository_ctx):
             "%{cudart_static_linkopt}": _cudart_static_linkopt(cpu_value),
             "%{cudart_lib}": lib_name("cudart", cpu_value),
             "%{cublas_lib}": lib_name("cublas", cpu_value),
+            "%{cublasLt_lib}": lib_name("cublasLt", cpu_value),
             "%{cusolver_lib}": lib_name("cusolver", cpu_value),
             "%{cudnn_lib}": lib_name("cudnn", cpu_value),
             "%{cufft_lib}": lib_name("cufft", cpu_value),
@@ -802,6 +810,7 @@ filegroup(name="cudnn-include")
         "cuda/cuda/lib/%s" % lib_name("cudart_static", cpu_value),
     )
     repository_ctx.file("cuda/cuda/lib/%s" % lib_name("cublas", cpu_value))
+    repository_ctx.file("cuda/cuda/lib/%s" % lib_name("cublasLt", cpu_value))
     repository_ctx.file("cuda/cuda/lib/%s" % lib_name("cusolver", cpu_value))
     repository_ctx.file("cuda/cuda/lib/%s" % lib_name("cudnn", cpu_value))
     repository_ctx.file("cuda/cuda/lib/%s" % lib_name("curand", cpu_value))
@@ -992,11 +1001,13 @@ def _create_local_cuda_repository(repository_ctx):
             cublas_include_path + "/cublas.h",
             cublas_include_path + "/cublas_v2.h",
             cublas_include_path + "/cublas_api.h",
+            cublas_include_path + "/cublasLt.h",
         ],
         outs = [
             "cublas/include/cublas.h",
             "cublas/include/cublas_v2.h",
             "cublas/include/cublas_api.h",
+            "cublas/include/cublasLt.h",
         ],
     ))
 
@@ -1137,6 +1148,7 @@ def _create_local_cuda_repository(repository_ctx):
             "%{cudart_static_linkopt}": _cudart_static_linkopt(cuda_config.cpu_value),
             "%{cudart_lib}": _basename(repository_ctx, cuda_libs["cudart"]),
             "%{cublas_lib}": _basename(repository_ctx, cuda_libs["cublas"]),
+            "%{cublasLt_lib}": _basename(repository_ctx, cuda_libs["cublasLt"]),
             "%{cusolver_lib}": _basename(repository_ctx, cuda_libs["cusolver"]),
             "%{cudnn_lib}": _basename(repository_ctx, cuda_libs["cudnn"]),
             "%{cufft_lib}": _basename(repository_ctx, cuda_libs["cufft"]),


### PR DESCRIPTION
The cuBLASLt API provides more features and better control over the execution of GEMMs than the regular cuBLAS API.

This PR adds the following:

- Build integration and stream executor wrappers for the cublasLt API.
- Integration (with autotuning) into the batch_matmul_op_impl class (used by the BatchMatMul and Einsum ops).
- Support for bias + ReLU fusion, which is expected to be useful for XLA in the future.

(I note that this is a large PR and it may be easier to review the commits separately. Also the diff is a bit strange in places due to some minor refactoring I had to do to simplify the code).

cc @reedwm @nluehr 