### PR TITLE
TFLu: Fix Ethos-U build errors

### DIFF
--- a/tensorflow/lite/micro/kernels/conv_test.cc
+++ b/tensorflow/lite/micro/kernels/conv_test.cc
@@ -436,12 +436,17 @@ TF_LITE_MICRO_TEST(Kernel1x1QuantizedPerChannel) {
   const int input_zero_point = 0;
   const int output_zero_point = 0;
 
-  int8_t input_quantized[kInputElements];
-  int8_t filter_quantized[kFilterElements];
-  int32_t bias_quantized[kBiasElements];
-  int8_t golden_quantized[kOutputElements];
-  int zero_points[kBiasElements + 1];
-  float scales[kBiasElements + 1];
+  // Avoid variable length array error for Arm Compiler armclang.
+  TF_LITE_MICRO_EXPECT_EQ(tflite::testing::kInputElements, kInputElements);
+  TF_LITE_MICRO_EXPECT_EQ(tflite::testing::kFilterElements, kFilterElements);
+  TF_LITE_MICRO_EXPECT_EQ(tflite::testing::kBiasElements, kBiasElements);
+  TF_LITE_MICRO_EXPECT_EQ(tflite::testing::kOutputElements, kOutputElements);
+  int8_t input_quantized[tflite::testing::kInputElements];
+  int8_t filter_quantized[tflite::testing::kFilterElements];
+  int32_t bias_quantized[tflite::testing::kBiasElements];
+  int8_t golden_quantized[tflite::testing::kOutputElements];
+  int zero_points[tflite::testing::kBiasElements + 1];
+  float scales[tflite::testing::kBiasElements + 1];
 
   tflite::testing::TestConvQuantizedPerChannel(
       kInputShape, kInputData, input_quantized, input_scale, input_zero_point,
@@ -480,12 +485,17 @@ TF_LITE_MICRO_TEST(Kernel1x1QuantizedPerChannelRelu6) {
   const int input_zero_point = -128;
   const int output_zero_point = -128;
 
-  int8_t input_quantized[kInputElements];
-  int8_t filter_quantized[kFilterElements];
-  int32_t bias_quantized[kBiasElements];
-  int8_t golden_quantized[kOutputElements];
-  int zero_points[kBiasElements + 1];
-  float scales[kBiasElements + 1];
+  // Avoid variable length array error for Arm Compiler armclang.
+  TF_LITE_MICRO_EXPECT_EQ(tflite::testing::kInputElements, kInputElements);
+  TF_LITE_MICRO_EXPECT_EQ(tflite::testing::kFilterElements, kFilterElements);
+  TF_LITE_MICRO_EXPECT_EQ(tflite::testing::kBiasElements, kBiasElements);
+  TF_LITE_MICRO_EXPECT_EQ(tflite::testing::kOutputElements, kOutputElements);
+  int8_t input_quantized[tflite::testing::kInputElements];
+  int8_t filter_quantized[tflite::testing::kFilterElements];
+  int32_t bias_quantized[tflite::testing::kBiasElements];
+  int8_t golden_quantized[tflite::testing::kOutputElements];
+  int zero_points[tflite::testing::kBiasElements + 1];
+  float scales[tflite::testing::kBiasElements + 1];
 
   tflite::testing::TestConvQuantizedPerChannel(
       kInputShape, kInputData, input_quantized, input_scale, input_zero_point,

--- a/tensorflow/lite/micro/kernels/ethos-u/ethosu.cc
+++ b/tensorflow/lite/micro/kernels/ethos-u/ethosu.cc
@@ -17,7 +17,15 @@ limitations under the License.
 
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
-#include "tensorflow/lite/micro/tools/make/downloads/flatbuffers/include/flatbuffers/flexbuffers.h"
+#if !defined(__GNUC__) || defined(__CC_ARM) || defined(__clang__)
+// TODO remove this once error is fixed in Flatbuffers.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdouble-promotion"
+#include "flatbuffers/flexbuffers.h"
+#pragma clang diagnostic pop
+#else
+#include "flatbuffers/flexbuffers.h"
+#endif
 
 namespace tflite {
 namespace ops {

--- a/tensorflow/lite/micro/kernels/ethos-u/ethosu.cc
+++ b/tensorflow/lite/micro/kernels/ethos-u/ethosu.cc
@@ -17,15 +17,7 @@ limitations under the License.
 
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
-#if !defined(__GNUC__) || defined(__CC_ARM) || defined(__clang__)
-// TODO remove this once error is fixed in Flatbuffers.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdouble-promotion"
 #include "flatbuffers/flexbuffers.h"
-#pragma clang diagnostic pop
-#else
-#include "flatbuffers/flexbuffers.h"
-#endif
 
 namespace tflite {
 namespace ops {

--- a/tensorflow/lite/micro/tools/make/third_party_downloads.inc
+++ b/tensorflow/lite/micro/tools/make/third_party_downloads.inc
@@ -8,13 +8,8 @@
 GEMMLOWP_URL := "https://github.com/google/gemmlowp/archive/719139ce755a0f31cbf1c37f7f98adcc7fc9f425.zip"
 GEMMLOWP_MD5 := "7e8191b24853d75de2af87622ad293ba"
 
-ifeq ($(HOST_OS),windows)
-  FLATBUFFERS_URL := "http://mirror.tensorflow.org/github.com/google/flatbuffers/archive/v1.12.0.zip"
-  FLATBUFFERS_MD5 := "a1afdbf114dec01a861c1b8c917d0fc7"
-else
-  FLATBUFFERS_URL := "http://mirror.tensorflow.org/github.com/google/flatbuffers/archive/v1.12.0.tar.gz"
-  FLATBUFFERS_MD5 := "c62ffefb3d4548b127cca14ce047f16c"
-endif
+FLATBUFFERS_URL := "https://github.com/google/flatbuffers/archive/dca12522a9f9e37f126ab925fd385c807ab4f84e.zip"
+FLATBUFFERS_MD5 := aa9adc93eb9b33fa1a2a90969e48baee
 
 ifeq ($(HOST_OS),osx)
   GCC_EMBEDDED_URL := "http://mirror.tensorflow.org/developer.arm.com/-/media/Files/downloads/gnu-rm/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-mac.tar.bz2"


### PR DESCRIPTION
-Fix variable length array error in conv_test.
-As for now, suppress -Wdouble-promotion in Ethos-U operator until it is
 resolved in Flatbuffers.