### PR TITLE
updated documentation for tensorflow lite micro-speech example on NXP…

### DIFF
--- a/tensorflow/lite/micro/examples/micro_speech/README.md
+++ b/tensorflow/lite/micro/examples/micro_speech/README.md
@@ -492,43 +492,29 @@ followed by the `K` key, then hit the `Y` key.
 
 ## Deploy to NXP FRDM K66F
 
-The following instructions will help you build and deploy the example to the
-[NXP FRDM K66F](https://www.nxp.com/design/development-boards/freedom-development-boards/mcu-boards/freedom-development-platform-for-kinetis-k66-k65-and-k26-mcus:FRDM-K66F)
-using [ARM Mbed](https://github.com/ARMmbed/mbed-cli).
+The following instructions will help you build and deploy the example to the [NXP FRDM K66F](https://www.nxp.com/design/development-boards/freedom-development-boards/mcu-boards/freedom-development-platform-for-kinetis-k66-k65-and-k26-mcus:FRDM-K66F) using [ARM Mbed](https://github.com/ARMmbed/mbed-cli).
 
-1.  Download
-    [the TensorFlow source code](https://github.com/tensorflow/tensorflow).
-2.  Follow instructions from
-    [mbed website](https://os.mbed.com/docs/mbed-os/v5.13/tools/installation-and-setup.html)
-    to setup and install mbed CLI.
+1.  Download [the TensorFlow source code](https://github.com/tensorflow/tensorflow).
+2.  Follow instructions from [mbed website](https://os.mbed.com/docs/mbed-os/v5.13/tools/installation-and-setup.html) to setup and install mbed CLI.
 3.  Compile TensorFlow with the following command to generate mbed project:
 
     ```
     make -f tensorflow/lite/micro/tools/make/Makefile TARGET=mbed TAGS="nxp_k66f" generate_micro_speech_mbed_project
     ```
 
-4.  Go to the location of the generated project. The generated project is
-    usually in
+4.  Change into the following directory that has been generated:
     `tensorflow/lite/micro/tools/make/gen/mbed_cortex-m4/prj/micro_speech/mbed`
 
-5.  Create a mbed project using the generated files: `mbed new .`
+5.  Create an Mbed project using the generated files, run ensuring your environment is using Python 2.7: 
+     `mbed config root .`
 
-6.  Change the project setting to use C++ 11 rather than C++ 14 using:
+6. Next, tell Mbed to download the dependencies and prepare to build:
+    ` mbed deploy`
 
-    ```
-    python -c 'import fileinput, glob;
-    for filename in glob.glob("mbed-os/tools/profiles/*.json"):
-      for line in fileinput.input(filename, inplace=True):
-        print line.replace("\"-std=gnu++14\"","\"-std=c++11\", \"-fpermissive\"")'
-    ```
+7. Finally, we can run the following command to compile the code:
+   `mbed compile -m K66F -t GCC_ARM` 
 
-7.  To compile project, use the following command:
-
-    ```
-    mbed compile --target K66F --toolchain GCC_ARM --profile release
-    ```
-
-8.  For some mbed compilers, you may get compile error in mbed_rtc_time.cpp. Go
+8.  For some Mbed compilers (such as GCC), you may get compile error in mbed_rtc_time.cpp. Go
     to `mbed-os/platform/mbed_rtc_time.h` and comment line 32 and line 37:
 
     ```
@@ -539,12 +525,7 @@ using [ARM Mbed](https://github.com/ARMmbed/mbed-cli).
     };
     //#endif
     ```
-
-9.  Look at helpful resources from NXP website such as
-    [NXP FRDM-K66F User guide](https://www.nxp.com/docs/en/user-guide/FRDMK66FUG.pdf)
-    and
-    [NXP FRDM-K66F Getting Started](https://www.nxp.com/document/guide/get-started-with-the-frdm-k66f:NGS-FRDM-K66F)
-    to understand information about the board.
+9. If your system does not recognize the board with the `mbed detect` command. Follow the instructions for setting up [DAPLink](https://armmbed.github.io/DAPLink/?board=FRDM-K66F) for the [K66F](https://os.mbed.com/platforms/FRDM-K66F/).
 
 10. Connect the USB cable to the micro USB port. When the Ethernet port is
     facing towards you, the micro USB port is left of the Ethernet port.
@@ -552,7 +533,7 @@ using [ARM Mbed](https://github.com/ARMmbed/mbed-cli).
 11. To compile and flash in a single step, add the `--flash` option:
 
     ```
-    mbed compile --target K66F --toolchain GCC_ARM --profile release --flash
+    mbed compile -m K66F -t GCC_ARM --flash
     ```
 
 12. Disconnect USB cable from the device to power down the device and connect


### PR DESCRIPTION
…-k66f board. Documentation now explains which versions of Python to use with mbed-cli (step 5). It omits an erroneous step that would cause the compilation stage to fail (previously step 6) by changing compiler flags from c++14 to c++11 for Mbed OS code which resulted in issues that prevented the example from running as code uses things like std::enable_if_t which is a c++14 feature used by Mbed OS. Also, added an extra step explaining DPALink if not already enabled on board. Fixes #43001