### PR TITLE
Disable `control_flow_ops_test` test

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -4031,6 +4031,7 @@ cuda_py_test(
         ":while_v2",
         "//tensorflow/python/eager:def_function",
     ],
+    tags = ["no_pip"],
     shard_count = 2,
     xla_enable_strict_auto_jit = True,
 )


### PR DESCRIPTION
Since `absl_py` update to 0.10.0 on Aug 19th, this test would break. We disable the test instead of upper bounding the dependency since the failure is only in test code