### PR TITLE
TF-TRT Expose TRTEngineInstance class

### DIFF
--- a/tensorflow/python/compiler/tensorrt/BUILD
+++ b/tensorflow/python/compiler/tensorrt/BUILD
@@ -37,6 +37,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         "//tensorflow/compiler/tf2tensorrt:_pywrap_py_utils",
+        "//tensorflow/compiler/tf2tensorrt:trt_engine_instance_proto_py",
         "//tensorflow/compiler/tf2tensorrt:trt_ops_loader",
         "//tensorflow/python:convert_to_constants",
         "//tensorflow/python:func_graph",
@@ -100,6 +101,7 @@ cuda_py_test(
     xla_enable_strict_auto_jit = False,
     deps = [
         ":trt_convert_py",
+        "//tensorflow/compiler/tf2tensorrt:trt_engine_instance_proto_py",
         "//tensorflow/python:client_testlib",
         "//tensorflow/python:framework_test_lib",
         "//tensorflow/python:graph_util",

--- a/tensorflow/python/compiler/tensorrt/trt_convert_test.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert_test.py
@@ -74,6 +74,12 @@ class TrtConvertTest(test_util.TensorFlowTestCase, parameterized.TestCase):
   def mkdtemp(self):
     return tempfile.mkdtemp(dir=self.get_temp_dir())
 
+  def testTRTEngineInstanceAvailable(self):
+    # test if we can access the TRTEngineInstance protobuf
+    from tensorflow.compiler.tf2tensorrt.utils.trt_engine_instance_pb2 \
+        import TRTEngineInstance
+    assert hasattr(TRTEngineInstance(), 'serialized_engine')
+
   def testGetTensorrtRewriterConfig(self):
     """Test case for TrtGraphConverter.get_tensorrt_rewriter_config()."""
     if not is_tensorrt_enabled():


### PR DESCRIPTION
Add `trt_engine_instance_proto_py` as a dependency of `trt_convert.py` to ensure that TF will install the `TRTEngineInstance` python class. Modify an existing test for this.

The `TRTEngineInstance` protobuf class is needed to retrieve serialized TensorRT inference engines from an asset file using Python, to support use cases similar to https://docs.nvidia.com/deeplearning/frameworks/tf-trt-user-guide/index.html#tensorrt-plan.

Here is an example how to load a TensorRT engine from the asset file:

```python
import numpy as np
import tensorflow as tf

from tensorflow.compiler.tf2tensorrt.utils.trt_engine_instance_pb2 import TRTEngineInstance

def get_first_serialized_engine_from_asset(asset_file):
    """ Read the serialized TRT engine from an asset file, and return the buffer that contains the first engine.
    Arguments: asset_file -- path to the file
    """
    raw_dataset = tf.data.TFRecordDataset([asset_file])

    # Note that the asset file could contain multiple engines, one for each input shape that the
    # corresponding TRTEngineOp handles. Here we only return the buffer that contains the first engine.
    for raw_record in raw_dataset.take(1):
        engine_instance = TRTEngineInstance()
        engine_instance.ParseFromString(raw_record.numpy())
        #print("Loaded engine for shape", engine_instance.input_shapes)
        #print(repr(raw_record))
        
    return engine_instance.serialized_engine

asset_file = '/tmp/models/trt_model/assets/trt-serialized-engine.TRTEngineOp_0_0'
engine_string = get_first_serialized_engine_from_asset(asset_file)
```

Tagging @bixia1 for review.