### PR TITLE
Fix build on r2.1 branch

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -4412,6 +4412,7 @@ cuda_py_test(
         "//tensorflow/python/eager:def_function",
     ],
     shard_count = 2,
+    tags = ["no_pip"],
 )
 
 cuda_py_test(


### PR DESCRIPTION
Disable test that fails with newer absl_py syntax