### PR TITLE
Add GPU kernels for ApplyProximalAdagrad and SparseApplyFtrl

### DIFF
--- a/tensorflow/core/kernels/training_ops.cc
+++ b/tensorflow/core/kernels/training_ops.cc
@@ -391,6 +391,7 @@ struct SparseApplyFtrl<CPUDevice, T, Tindex, has_l2_shrinkage> {
           auto g = grad.template chip<0>(i);
           auto v = var.template chip<0>(index);
 
+// TODO(sanjoy): Remove this macro.
 // Use a macro to implement the computation here due to the templating of the
 // eigen tensor library.
 #define COMPUTE_FTRL(g, g_maybe_with_shrinkage)                         \

--- a/tensorflow/core/kernels/training_ops.h
+++ b/tensorflow/core/kernels/training_ops.h
@@ -151,6 +151,20 @@ struct ApplyFtrlV2MultiplyLinearByLr {
                   typename TTypes<T>::ConstScalar lr_power);
 };
 
+template <typename Device, typename T, typename Tindex, bool has_l2_shrinkage>
+struct SparseApplyFtrl {
+  Tindex operator()(const Device& d, typename TTypes<T>::Matrix var,
+                    typename TTypes<T>::Matrix accum,
+                    typename TTypes<T>::Matrix linear,
+                    typename TTypes<T>::ConstScalar lr,
+                    typename TTypes<T>::ConstScalar l1,
+                    typename TTypes<T>::ConstScalar l2,
+                    typename TTypes<T>::ConstScalar l2_shrinkage,
+                    typename TTypes<T>::ConstScalar lr_power,
+                    typename TTypes<T>::ConstMatrix grad,
+                    typename TTypes<Tindex>::ConstVec indices, int64 inner_dim);
+};
+
 template <typename Device, typename T>
 struct ApplyMomentum {
   void operator()(const Device& d, typename TTypes<T>::Flat var,

--- a/tensorflow/core/kernels/training_ops_gpu.cu.cc
+++ b/tensorflow/core/kernels/training_ops_gpu.cu.cc
@@ -208,6 +208,19 @@ __global__ __launch_bounds__(1024) void ApplyAdagradV2Kernel(
 }
 
 template <typename T>
+__global__ __launch_bounds__(1024) void ApplyProximalAdagradKernel(
+    GpuLaunchConfig cfg, T* var, T* accum, const T* lr, const T* l1,
+    const T* l2, const T* grad) {
+  GPU_1D_KERNEL_LOOP(i, cfg.virtual_thread_count) {
+    accum[i] += grad[i] * grad[i];
+    T prox_var = var[i] - grad[i] * lr[0];
+    var[i] -= (prox_var < T(0.f) ? -T(1.f) : T(1.f)) *
+              max(fabs(prox_var) - lr[0] * max(l1[0], T(0.f)), T(0.f)) /
+              (T(1.f) + l2[0] * lr[0]);
+  }
+}
+
+template <typename T>
 __global__ __launch_bounds__(1024) void ApplyAdadeltaKernel(
     GpuLaunchConfig cfg, T* var, T* accum, T* accum_update, const T* plr,
     const T* prho, const T* peps, const T* grad) {
@@ -326,6 +339,43 @@ struct ApplyAdagradV2<GPUDevice, T> {
 #endif
   }
 };
+
+template <typename T>
+struct ApplyProximalAdagrad<GPUDevice, T> {
+  void operator()(const GPUDevice& d, typename TTypes<T>::Flat var,
+                  typename TTypes<T>::Flat accum,
+                  typename TTypes<T>::ConstScalar lr,
+                  typename TTypes<T>::ConstScalar l1,
+                  typename TTypes<T>::ConstScalar l2,
+                  typename TTypes<T>::ConstFlat grad) {
+#if TENSORFLOW_USE_ROCM
+    wrap_kernel_call(ApplyProximalAdagradKernel<T>, d, var, accum, lr, l1, l2,
+                     grad);
+#else
+    Eigen::array<typename TTypes<T>::Tensor::Index, 1> bcast;
+    bcast[0] = grad.dimension(0);
+    Eigen::Sizes<1> single;
+    // Fobos update per paper with Adagrad learning rate.
+    accum.device(d) += grad.square();
+    // Adagrad learning rate.
+    // The following is the GPU equivalent of the CPU version:
+    // auto learning_rate = accum.constant(lr()) * accum.rsqrt();
+    auto lr_bcast = lr.reshape(single).broadcast(bcast);
+    auto l1_bcast = l1.reshape(single).broadcast(bcast);
+    auto l2_bcast = l2.reshape(single).broadcast(bcast);
+    auto learning_rate = lr_bcast * accum.rsqrt();
+    auto prox_var = var;
+    // compute v = w - lr * grad.
+    prox_var.device(d) -= grad * learning_rate;
+    // compute sign(v) * max(|v| - lr * max(l1, 0), 0)
+    var.device(d) = prox_var.sign() *
+                    (prox_var.abs() - learning_rate * l1_bcast.cwiseMax(T(0.f)))
+                        .cwiseMax(T(0.f)) /
+                    (var.constant(T(1.f)) + l2_bcast * learning_rate);
+#endif
+  }
+};
+
 template <typename T>
 struct ApplyAdadelta<GPUDevice, T> {
   void operator()(const GPUDevice& d, typename TTypes<T>::Flat var,
@@ -810,6 +860,10 @@ template struct functor::ApplyAdagradV2<GPUDevice, double>;
 template struct functor::ApplyAdagradV2<GPUDevice, complex64>;
 template struct functor::ApplyAdagradV2<GPUDevice, complex128>;
 #endif
+
+template struct functor::ApplyProximalAdagrad<GPUDevice, Eigen::half>;
+template struct functor::ApplyProximalAdagrad<GPUDevice, float>;
+template struct functor::ApplyProximalAdagrad<GPUDevice, double>;
 
 template struct functor::ApplyAdadelta<GPUDevice, Eigen::half>;
 template struct functor::ApplyAdadelta<GPUDevice, float>;


### PR DESCRIPTION
These were observed to improve performance in some models when run on the GPU. Kernels for additional ops will be added in subsequent PRs.

I'm not sure how to make the relevant tests run on both the CPU and GPU (currently they only seem to run on the CPU and I had to manually force them with `use_gpu=True` during development). Let me know if there's an easy way to do that.

cc @nluehr @reedwm 