### PR TITLE
Fixing bug where undocumented FileNotFound error is thrown when trying to use tf.io.gfile.glob()

### DIFF
--- a/tensorflow/python/lib/io/file_io.py
+++ b/tensorflow/python/lib/io/file_io.py
@@ -347,6 +347,7 @@ def get_matching_files(filename):
 
   Raises:
   *  errors.OpError: If there are filesystem / directory listing errors.
+  *  errors.NotFoundError: If pattern to be matched is an invalid directory.
   """
   return get_matching_files_v2(filename)
 
@@ -401,6 +402,7 @@ def get_matching_files_v2(pattern):
 
   Raises:
     errors.OpError: If there are filesystem / directory listing errors.
+    errors.NotFoundError: If pattern to be matched is an invalid directory.
   """
   if isinstance(pattern, six.string_types):
     return [


### PR DESCRIPTION
PR to fix issues presented in Issue [#43319](https://github.com/tensorflow/tensorflow/issues/43319). Currently, a undocumented FileNotFound error is raised when trying to match a non-existent directory and/or the files inside of it. This PR adds logic to catch that error and instead return a empty list corresponding to that pattern.