### PR TITLE
Initialize POD types

### DIFF
--- a/tensorflow/lite/core/api/flatbuffer_conversions.h
+++ b/tensorflow/lite/core/api/flatbuffer_conversions.h
@@ -45,7 +45,7 @@ class BuiltinDataAllocator {
     // platform targets support that properly.
     static_assert(std::is_pod<T>::value, "Builtin data structure must be POD.");
     void* allocated_memory = this->Allocate(sizeof(T), alignof(T));
-    return new (allocated_memory) T;
+    return new (allocated_memory) T();
   }
 
   virtual ~BuiltinDataAllocator() {}


### PR DESCRIPTION
Change-Id: I60cfb1744c318521ff7fb70512ebd7540a965bfc

This triggers filling fields in a POD type with the default values (0
for most parts).

Otherwise 'new' returns uninitialized memory,  and in the guts of
TFLite not all data that is obtained from AllocatePOD is initialized.

In particular this is the case for SQUEEZE:
https://github.com/tensorflow/tensorflow/blob/70b61c44ae8f60956d936fc965a1c9e46af10d55/tensorflow/lite/core/api/flatbuffer_conversions.cc#L634
If code doesn't go into the body of an 'if' statement, then params are
left with uninitialized junk from the heap. Patch resolves this by
zero filling data before when it leaves AllocatePOD.