### PR TITLE
Define __slots__ for object wrappers

### DIFF
--- a/tensorflow/python/util/object_identity.py
+++ b/tensorflow/python/util/object_identity.py
@@ -30,7 +30,7 @@ class _ObjectIdentityWrapper(object):
   _ListWrapper objects to object-identity collections.
   """
 
-  __slots__ = ["_wrapped"]
+  __slots__ = ["_wrapped", "__weakref__"]
 
   def __init__(self, wrapped):
     self._wrapped = wrapped
@@ -72,6 +72,8 @@ class _ObjectIdentityWrapper(object):
 
 class _WeakObjectIdentityWrapper(_ObjectIdentityWrapper):
 
+  __slots__ = ()
+
   def __init__(self, wrapped):
     super(_WeakObjectIdentityWrapper, self).__init__(weakref.ref(wrapped))
 
@@ -98,6 +100,8 @@ class Reference(_ObjectIdentityWrapper):
   ==> False
   ```
   """
+
+  __slots__ = ()
 
   # Disabling super class' unwrapped field.
   unwrapped = property()
@@ -153,6 +157,8 @@ class ObjectIdentityDictionary(collections_abc.MutableMapping):
 class ObjectIdentityWeakKeyDictionary(ObjectIdentityDictionary):
   """Like weakref.WeakKeyDictionary, but compares objects with "is"."""
 
+  __slots__ = ["__weakref__"]
+
   def _wrap_key(self, key):
     return _WeakObjectIdentityWrapper(key)
 
@@ -173,7 +179,7 @@ class ObjectIdentityWeakKeyDictionary(ObjectIdentityDictionary):
 class ObjectIdentitySet(collections_abc.MutableSet):
   """Like the built-in set, but compares objects with "is"."""
 
-  __slots__ = ["_storage"]
+  __slots__ = ["_storage", "__weakref__"]
 
   def __init__(self, *args):
     self._storage = set(self._wrap_key(obj) for obj in list(*args))
@@ -220,6 +226,8 @@ class ObjectIdentitySet(collections_abc.MutableSet):
 
 class ObjectIdentityWeakSet(ObjectIdentitySet):
   """Like weakref.WeakSet, but compares objects with "is"."""
+
+  __slots__ = ()
 
   def _wrap_key(self, key):
     return _WeakObjectIdentityWrapper(key)


### PR DESCRIPTION
This PR defines [`__slots__`](https://docs.python.org/3/reference/datamodel.html#slots) for the small classes which prevents the creation of an unnecessary `__dict__`  per class which can save a bit of memory since TensorFlow uses these wrappers in many places internally.