### PR TITLE
Fixes #42872: map_to_outputs_names always returns a copy

### DIFF
--- a/tensorflow/python/keras/engine/compile_utils.py
+++ b/tensorflow/python/keras/engine/compile_utils.py
@@ -593,10 +593,9 @@ def map_to_output_names(y_pred, output_names, struct):
   outputs_are_flat_list = (not single_output and
                            isinstance(y_pred, (list, tuple)) and
                            not any(nest.is_nested(y_p) for y_p in y_pred))
-
+  struct = copy.copy(struct)
   if (single_output or outputs_are_flat_list) and isinstance(struct, dict):
     output_names = output_names or create_pseudo_output_names(y_pred)
-    struct = copy.copy(struct)
     new_struct = [struct.pop(name, None) for name in output_names]
     if struct:
       raise ValueError('Found unexpected keys that do not correspond '


### PR DESCRIPTION
This PR always returns a copy to ensure that any change made to `struct` after calling this function does not propagate to the original `struct` which leads to undesired behavior.
The PR fixes #42872 (code snipped to reproduce the bug also present there)