### PR TITLE
Update to include filesystem:filesystem_interface in libtensorflow_framework.so

### DIFF
--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -710,6 +710,7 @@ tf_cc_shared_object(
     soversion = VERSION,
     visibility = ["//visibility:public"],
     deps = [
+        "//tensorflow/c/experimental/filesystem:filesystem_interface",
         "//tensorflow/cc/saved_model:loader_lite_impl",
         "//tensorflow/core:core_cpu_impl",
         "//tensorflow/core:framework_internal_impl",

--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -36,7 +36,7 @@ transitive_hdrs(
         "//tensorflow/cc/saved_model:loader",
         "//tensorflow/cc/saved_model:reader",
         "//tensorflow/cc/saved_model:bundle_v2",
-        "//tensorflow/c/experimental/filesystem:modular_filesystem",
+        "//tensorflow/c/experimental/filesystem:filesystem_interface",
         # WARNING: None of the C/C++ code under python/ has any API guarantees, and TF team
         # reserves the right to change APIs and other header-level interfaces.  If your custom
         # op uses these headers, it may break when users upgrade their version of tensorflow.


### PR DESCRIPTION
While trying to build a modular file system from outside of TF code tree
(with pip install tf-nightly headers), the following error happens:
```
Symbol not found: _TF_SetStatus\n  Referenced
```

The reason for the error was caused by `filesystem:filesystem_interface`
dependency in bazel is not part of the .so.

This PR add `filesystem:filesystem_interface` as part of the dependency.

Also `filesystem:filesystem_interface` replaces `filesystem:modular_filesystem`
as dependency can be reduced to just need `filesystem:filesystem_interface`.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>