### PR TITLE
[MLIR] Add involution based folding to TF

### DIFF
--- a/tensorflow/compiler/mlir/tensorflow/ir/tf_generated_ops.td
+++ b/tensorflow/compiler/mlir/tensorflow/ir/tf_generated_ops.td
@@ -1815,8 +1815,8 @@ def TF_ConfigureTPUEmbeddingOp : TF_Op<"ConfigureTPUEmbedding", []> {
   let results = (outs);
 }
 
-def TF_ConjOp : TF_Op<"Conj", [NoSideEffect, SameOperandsAndResultType,
-                               Involution]> {
+def TF_ConjOp : TF_Op<"Conj",
+                [Involution, NoSideEffect, SameOperandsAndResultType,]> {
   let summary = "Returns the complex conjugate of a complex number.";
 
   let description = [{
@@ -4884,8 +4884,8 @@ I.e., \\(y = 1 / x\\).
   TF_DerivedOperandTypeAttr T = TF_DerivedOperandTypeAttr<0>;
 }
 
-def TF_InvertOp : TF_Op<"Invert", [NoSideEffect, SameOperandsAndResultType,
-                                   Involution]> {
+def TF_InvertOp : TF_Op<"Invert",
+                  [Involution, NoSideEffect, SameOperandsAndResultType]> {
   let summary = [{
 Invert (flip) each bit of supported types; for example, type `uint8` value 01010101 becomes 10101010.
   }];
@@ -5612,9 +5612,8 @@ def TF_LogicalAndOp : TF_Op<"LogicalAnd", [Commutative, NoSideEffect, ResultsBro
   );
 }
 
-def TF_LogicalNotOp : TF_Op<"LogicalNot", [NoSideEffect,
-                                           SameOperandsAndResultType,
-                                           Involution]> {
+def TF_LogicalNotOp : TF_Op<"LogicalNot",
+                      [Involution, NoSideEffect, SameOperandsAndResultType]> {
   let summary = "Returns the truth value of `NOT x` element-wise.";
 
   let arguments = (ins
@@ -7327,8 +7326,8 @@ def TF_NdtriOp : TF_Op<"Ndtri", [NoSideEffect]> {
   TF_DerivedOperandTypeAttr T = TF_DerivedOperandTypeAttr<0>;
 }
 
-def TF_NegOp : TF_Op<"Neg", [NoSideEffect, SameOperandsAndResultType,
-                             Involution]> {
+def TF_NegOp : TF_Op<"Neg",
+               [Involution, NoSideEffect, SameOperandsAndResultType]> {
   let summary = "Computes numerical negative value element-wise.";
 
   let description = [{
@@ -8618,9 +8617,8 @@ tf.real(input) ==> [-2.25, 3.25]
   TF_DerivedResultTypeAttr Tout = TF_DerivedResultTypeAttr<0>;
 }
 
-def TF_ReciprocalOp : TF_Op<"Reciprocal", [NoSideEffect,
-                                           SameOperandsAndResultType,
-                                           Involution]> {
+def TF_ReciprocalOp : TF_Op<"Reciprocal",
+                      [Involution, NoSideEffect, SameOperandsAndResultType]> {
   let summary = "Computes the reciprocal of x element-wise.";
 
   let description = [{

--- a/tensorflow/compiler/mlir/tensorflow/ir/tf_generated_ops.td
+++ b/tensorflow/compiler/mlir/tensorflow/ir/tf_generated_ops.td
@@ -1815,7 +1815,8 @@ def TF_ConfigureTPUEmbeddingOp : TF_Op<"ConfigureTPUEmbedding", []> {
   let results = (outs);
 }
 
-def TF_ConjOp : TF_Op<"Conj", [NoSideEffect, SameOperandsAndResultType]> {
+def TF_ConjOp : TF_Op<"Conj", [NoSideEffect, SameOperandsAndResultType,
+                               Involution]> {
   let summary = "Returns the complex conjugate of a complex number.";
 
   let description = [{
@@ -1843,8 +1844,6 @@ tf.conj(input) ==> [-2.25 - 4.75j, 3.25 - 5.75j]
   );
 
   TF_DerivedOperandTypeAttr T = TF_DerivedOperandTypeAttr<0>;
-
-  let hasCanonicalizer = 1;
 }
 
 def TF_ConjugateTransposeOp : TF_Op<"ConjugateTranspose", [NoSideEffect]> {
@@ -4885,7 +4884,8 @@ I.e., \\(y = 1 / x\\).
   TF_DerivedOperandTypeAttr T = TF_DerivedOperandTypeAttr<0>;
 }
 
-def TF_InvertOp : TF_Op<"Invert", [NoSideEffect, SameOperandsAndResultType]> {
+def TF_InvertOp : TF_Op<"Invert", [NoSideEffect, SameOperandsAndResultType,
+                                   Involution]> {
   let summary = [{
 Invert (flip) each bit of supported types; for example, type `uint8` value 01010101 becomes 10101010.
   }];
@@ -4941,8 +4941,6 @@ for dtype in dtype_list:
   );
 
   TF_DerivedOperandTypeAttr T = TF_DerivedOperandTypeAttr<0>;
-
-  let hasCanonicalizer = 1;
 }
 
 def TF_InvertPermutationOp : TF_Op<"InvertPermutation", [NoSideEffect]> {
@@ -5614,7 +5612,9 @@ def TF_LogicalAndOp : TF_Op<"LogicalAnd", [Commutative, NoSideEffect, ResultsBro
   );
 }
 
-def TF_LogicalNotOp : TF_Op<"LogicalNot", [NoSideEffect, SameOperandsAndResultType]> {
+def TF_LogicalNotOp : TF_Op<"LogicalNot", [NoSideEffect,
+                                           SameOperandsAndResultType,
+                                           Involution]> {
   let summary = "Returns the truth value of `NOT x` element-wise.";
 
   let arguments = (ins
@@ -7327,7 +7327,8 @@ def TF_NdtriOp : TF_Op<"Ndtri", [NoSideEffect]> {
   TF_DerivedOperandTypeAttr T = TF_DerivedOperandTypeAttr<0>;
 }
 
-def TF_NegOp : TF_Op<"Neg", [NoSideEffect, SameOperandsAndResultType]> {
+def TF_NegOp : TF_Op<"Neg", [NoSideEffect, SameOperandsAndResultType,
+                             Involution]> {
   let summary = "Computes numerical negative value element-wise.";
 
   let description = [{
@@ -7343,8 +7344,6 @@ I.e., \\(y = -x\\).
   );
 
   TF_DerivedOperandTypeAttr T = TF_DerivedOperandTypeAttr<0>;
-
-  let hasCanonicalizer = 1;
 }
 
 def TF_NextAfterOp : TF_Op<"NextAfter", [NoSideEffect, ResultsBroadcastableShape]>,
@@ -8619,7 +8618,9 @@ tf.real(input) ==> [-2.25, 3.25]
   TF_DerivedResultTypeAttr Tout = TF_DerivedResultTypeAttr<0>;
 }
 
-def TF_ReciprocalOp : TF_Op<"Reciprocal", [NoSideEffect, SameOperandsAndResultType]> {
+def TF_ReciprocalOp : TF_Op<"Reciprocal", [NoSideEffect,
+                                           SameOperandsAndResultType,
+                                           Involution]> {
   let summary = "Computes the reciprocal of x element-wise.";
 
   let description = [{
@@ -8635,8 +8636,6 @@ I.e., \\(y = 1 / x\\).
   );
 
   TF_DerivedOperandTypeAttr T = TF_DerivedOperandTypeAttr<0>;
-
-  let hasCanonicalizer = 1;
 }
 
 def TF_ReciprocalGradOp : TF_Op<"ReciprocalGrad", [NoSideEffect, SameOperandsAndResultType]> {

--- a/tensorflow/compiler/mlir/tensorflow/ir/tf_generated_ops.td
+++ b/tensorflow/compiler/mlir/tensorflow/ir/tf_generated_ops.td
@@ -1815,8 +1815,7 @@ def TF_ConfigureTPUEmbeddingOp : TF_Op<"ConfigureTPUEmbedding", []> {
   let results = (outs);
 }
 
-def TF_ConjOp : TF_Op<"Conj",
-                [Involution, NoSideEffect, SameOperandsAndResultType,]> {
+def TF_ConjOp : TF_Op<"Conj", [Involution, NoSideEffect, SameOperandsAndResultType]> {
   let summary = "Returns the complex conjugate of a complex number.";
 
   let description = [{
@@ -4884,8 +4883,7 @@ I.e., \\(y = 1 / x\\).
   TF_DerivedOperandTypeAttr T = TF_DerivedOperandTypeAttr<0>;
 }
 
-def TF_InvertOp : TF_Op<"Invert",
-                  [Involution, NoSideEffect, SameOperandsAndResultType]> {
+def TF_InvertOp : TF_Op<"Invert", [Involution, NoSideEffect, SameOperandsAndResultType]> {
   let summary = [{
 Invert (flip) each bit of supported types; for example, type `uint8` value 01010101 becomes 10101010.
   }];
@@ -5612,8 +5610,7 @@ def TF_LogicalAndOp : TF_Op<"LogicalAnd", [Commutative, NoSideEffect, ResultsBro
   );
 }
 
-def TF_LogicalNotOp : TF_Op<"LogicalNot",
-                      [Involution, NoSideEffect, SameOperandsAndResultType]> {
+def TF_LogicalNotOp : TF_Op<"LogicalNot", [Involution, NoSideEffect, SameOperandsAndResultType]> {
   let summary = "Returns the truth value of `NOT x` element-wise.";
 
   let arguments = (ins
@@ -7326,8 +7323,7 @@ def TF_NdtriOp : TF_Op<"Ndtri", [NoSideEffect]> {
   TF_DerivedOperandTypeAttr T = TF_DerivedOperandTypeAttr<0>;
 }
 
-def TF_NegOp : TF_Op<"Neg",
-               [Involution, NoSideEffect, SameOperandsAndResultType]> {
+def TF_NegOp : TF_Op<"Neg", [Involution, NoSideEffect, SameOperandsAndResultType]> {
   let summary = "Computes numerical negative value element-wise.";
 
   let description = [{
@@ -8617,8 +8613,7 @@ tf.real(input) ==> [-2.25, 3.25]
   TF_DerivedResultTypeAttr Tout = TF_DerivedResultTypeAttr<0>;
 }
 
-def TF_ReciprocalOp : TF_Op<"Reciprocal",
-                      [Involution, NoSideEffect, SameOperandsAndResultType]> {
+def TF_ReciprocalOp : TF_Op<"Reciprocal", [Involution, NoSideEffect, SameOperandsAndResultType]> {
   let summary = "Computes the reciprocal of x element-wise.";
 
   let description = [{

--- a/tensorflow/compiler/mlir/tensorflow/ir/tf_ops_a_m.cc
+++ b/tensorflow/compiler/mlir/tensorflow/ir/tf_ops_a_m.cc
@@ -1124,15 +1124,6 @@ LogicalResult ConcatOffsetOp::fold(ArrayRef<Attribute> operands,
 }
 
 //===----------------------------------------------------------------------===//
-// ConjOp
-//===----------------------------------------------------------------------===//
-
-void ConjOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
-                                         MLIRContext *context) {
-  results.insert<ConjNested>(context);
-}
-
-//===----------------------------------------------------------------------===//
 // ConstOp
 //===----------------------------------------------------------------------===//
 
@@ -2186,15 +2177,6 @@ void IfRegionOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
 }
 
 //===----------------------------------------------------------------------===//
-// InvertOp
-//===----------------------------------------------------------------------===//
-
-void InvertOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
-                                           MLIRContext *context) {
-  results.insert<InvertNested>(context);
-}
-
-//===----------------------------------------------------------------------===//
 // InvertPermutationOp
 //===----------------------------------------------------------------------===//
 
@@ -2257,7 +2239,7 @@ void LogOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
 
 void LogicalNotOp::getCanonicalizationPatterns(
     OwningRewritePatternList &results, MLIRContext *context) {
-  results.insert<LogicalNotNested, LogicalNotOfEqual, LogicalNotOfNotEqual,
+  results.insert<LogicalNotOfEqual, LogicalNotOfNotEqual,
                  LogicalNotOfGreater, LogicalNotOfGreaterEqual,
                  LogicalNotOfLess, LogicalNotOfLessEqual>(context);
 }

--- a/tensorflow/compiler/mlir/tensorflow/ir/tf_ops_n_z.cc
+++ b/tensorflow/compiler/mlir/tensorflow/ir/tf_ops_n_z.cc
@@ -79,15 +79,6 @@ namespace {
 }  // namespace
 
 //===----------------------------------------------------------------------===//
-// NegOp
-//===----------------------------------------------------------------------===//
-
-void NegOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
-                                        MLIRContext *context) {
-  results.insert<NegNested>(context);
-}
-
-//===----------------------------------------------------------------------===//
 // NotEqualOp
 //===----------------------------------------------------------------------===//
 
@@ -482,15 +473,6 @@ static LogicalResult Verify(QrOp op) {
 void ReadVariableOp::getCanonicalizationPatterns(
     OwningRewritePatternList &results, MLIRContext *context) {
   results.insert<ReadVariableOfCast>(context);
-}
-
-//===----------------------------------------------------------------------===//
-// ReciprocalOp
-//===----------------------------------------------------------------------===//
-
-void ReciprocalOp::getCanonicalizationPatterns(
-    OwningRewritePatternList &results, MLIRContext *context) {
-  results.insert<ReciprocalNested>(context);
 }
 
 //===----------------------------------------------------------------------===//

--- a/tensorflow/compiler/mlir/tensorflow/tests/tf_trait_folds.mlir
+++ b/tensorflow/compiler/mlir/tensorflow/tests/tf_trait_folds.mlir
@@ -14,8 +14,8 @@ func @testSingleConj(%arg0: tensor<complex<f32>>) -> tensor<complex<f32>> {
 func @testDoubleConj(%arg0: tensor<complex<f32>>) -> tensor<complex<f32>> {
   %0 = "tf.Conj"(%arg0) : (tensor<complex<f32>>) -> tensor<complex<f32>>
   %1 = "tf.Conj"(%0) : (tensor<complex<f32>>) -> tensor<complex<f32>>
-  return %1: tensor<complex<f32>>
   // CHECK: return [[ARG0]]
+  return %1: tensor<complex<f32>>
 }
 
 // CHECK-LABEL: func @testTripleConj
@@ -43,8 +43,8 @@ func @testSingleReciprocal(%arg0: tensor<i32>) -> tensor<i32> {
 func @testDoubleReciprocal(%arg0: tensor<i32>) -> tensor<i32> {
   %0 = "tf.Reciprocal"(%arg0) : (tensor<i32>) -> tensor<i32>
   %1 = "tf.Reciprocal"(%0) : (tensor<i32>) -> tensor<i32>
-  return %1: tensor<i32>
   // CHECK: return [[ARG0]]
+  return %1: tensor<i32>
 }
 
 // CHECK-LABEL: func @testTripleReciprocal
@@ -72,8 +72,8 @@ func @testSingleInvert(%arg0: tensor<i32>) -> tensor<i32> {
 func @testDoubleInvert(%arg0: tensor<i32>) -> tensor<i32> {
   %0 = "tf.Invert"(%arg0) : (tensor<i32>) -> tensor<i32>
   %1 = "tf.Invert"(%0) : (tensor<i32>) -> tensor<i32>
-  return %1: tensor<i32>
   // CHECK: return [[ARG0]]
+  return %1: tensor<i32>
 }
 
 // CHECK-LABEL: func @testTripleInvert
@@ -101,8 +101,8 @@ func @testSingleNeg(%arg0: tensor<i32>) -> tensor<i32> {
 func @testDoubleNeg(%arg0: tensor<i32>) -> tensor<i32> {
   %0 = "tf.Neg"(%arg0) : (tensor<i32>) -> tensor<i32>
   %1 = "tf.Neg"(%0) : (tensor<i32>) -> tensor<i32>
-  return %1: tensor<i32>
   // CHECK: return [[ARG0]]
+  return %1: tensor<i32>
 }
 
 // CHECK-LABEL: func @testTripleNeg
@@ -130,8 +130,8 @@ func @testSingleLogicalNot(%arg0: tensor<i1>) -> tensor<i1> {
 func @testDoubleLogicalNot(%arg0: tensor<i1>) -> tensor<i1> {
   %0 = "tf.LogicalNot"(%arg0) : (tensor<i1>) -> tensor<i1>
   %1 = "tf.LogicalNot"(%0) : (tensor<i1>) -> tensor<i1>
-  return %1: tensor<i1>
   // CHECK: return [[ARG0]]
+  return %1: tensor<i1>
 }
 
 // CHECK-LABEL: func @testTripleLogicalNot

--- a/tensorflow/compiler/mlir/tensorflow/tests/tf_trait_folds.mlir
+++ b/tensorflow/compiler/mlir/tensorflow/tests/tf_trait_folds.mlir
@@ -1,0 +1,146 @@
+// RUN: tf-opt %s -tf-standard-pipeline | FileCheck %s
+
+// CHECK-LABEL: func @testSingleConj
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<complex<f32>>)
+func @testSingleConj(%arg0: tensor<complex<f32>>) -> tensor<complex<f32>> {
+  // CHECK: [[CONJ:%.+]] = "tf.Conj"([[ARG0]])
+  %0 = "tf.Conj"(%arg0) : (tensor<complex<f32>>) -> tensor<complex<f32>>
+  // CHECK: return [[CONJ]]
+  return %0: tensor<complex<f32>>
+}
+
+// CHECK-LABEL: func @testDoubleConj
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<complex<f32>>)
+func @testDoubleConj(%arg0: tensor<complex<f32>>) -> tensor<complex<f32>> {
+  %0 = "tf.Conj"(%arg0) : (tensor<complex<f32>>) -> tensor<complex<f32>>
+  %1 = "tf.Conj"(%0) : (tensor<complex<f32>>) -> tensor<complex<f32>>
+  return %1: tensor<complex<f32>>
+  // CHECK: return [[ARG0]]
+}
+
+// CHECK-LABEL: func @testTripleConj
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<complex<f32>>)
+func @testTripleConj(%arg0: tensor<complex<f32>>) -> tensor<complex<f32>> {
+  // CHECK: [[CONJ:%.+]] = "tf.Conj"([[ARG0]])
+  %0 = "tf.Conj"(%arg0) : (tensor<complex<f32>>) -> tensor<complex<f32>>
+  %1 = "tf.Conj"(%0) : (tensor<complex<f32>>) -> tensor<complex<f32>>
+  %2 = "tf.Conj"(%1) : (tensor<complex<f32>>) -> tensor<complex<f32>>
+  // CHECK: return [[CONJ]]
+  return %2: tensor<complex<f32>>
+}
+
+// CHECK-LABEL: func @testSingleReciprocal
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<i32>)
+func @testSingleReciprocal(%arg0: tensor<i32>) -> tensor<i32> {
+  // CHECK: [[RECIPROCAL:%.+]] = "tf.Reciprocal"([[ARG0]])
+  %0 = "tf.Reciprocal"(%arg0) : (tensor<i32>) -> tensor<i32>
+  // CHECK: return [[RECIPROCAL]]
+  return %0: tensor<i32>
+}
+
+// CHECK-LABEL: func @testDoubleReciprocal
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<i32>)
+func @testDoubleReciprocal(%arg0: tensor<i32>) -> tensor<i32> {
+  %0 = "tf.Reciprocal"(%arg0) : (tensor<i32>) -> tensor<i32>
+  %1 = "tf.Reciprocal"(%0) : (tensor<i32>) -> tensor<i32>
+  return %1: tensor<i32>
+  // CHECK: return [[ARG0]]
+}
+
+// CHECK-LABEL: func @testTripleReciprocal
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<i32>)
+func @testTripleReciprocal(%arg0: tensor<i32>) -> tensor<i32> {
+  // CHECK: [[RECIPROCAL:%.+]] = "tf.Reciprocal"([[ARG0]])
+  %0 = "tf.Reciprocal"(%arg0) : (tensor<i32>) -> tensor<i32>
+  %1 = "tf.Reciprocal"(%0) : (tensor<i32>) -> tensor<i32>
+  %2 = "tf.Reciprocal"(%1) : (tensor<i32>) -> tensor<i32>
+  // CHECK: return [[RECIPROCAL]]
+  return %2: tensor<i32>
+}
+
+// CHECK-LABEL: func @testSingleInvert
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<i32>)
+func @testSingleInvert(%arg0: tensor<i32>) -> tensor<i32> {
+  // CHECK: [[INVERT:%.+]] = "tf.Invert"([[ARG0]])
+  %0 = "tf.Invert"(%arg0) : (tensor<i32>) -> tensor<i32>
+  // CHECK: return [[INVERT]]
+  return %0: tensor<i32>
+}
+
+// CHECK-LABEL: func @testDoubleInvert
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<i32>)
+func @testDoubleInvert(%arg0: tensor<i32>) -> tensor<i32> {
+  %0 = "tf.Invert"(%arg0) : (tensor<i32>) -> tensor<i32>
+  %1 = "tf.Invert"(%0) : (tensor<i32>) -> tensor<i32>
+  return %1: tensor<i32>
+  // CHECK: return [[ARG0]]
+}
+
+// CHECK-LABEL: func @testTripleInvert
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<i32>)
+func @testTripleInvert(%arg0: tensor<i32>) -> tensor<i32> {
+  // CHECK: [[INVERT:%.+]] = "tf.Invert"([[ARG0]])
+  %0 = "tf.Invert"(%arg0) : (tensor<i32>) -> tensor<i32>
+  %1 = "tf.Invert"(%0) : (tensor<i32>) -> tensor<i32>
+  %2 = "tf.Invert"(%1) : (tensor<i32>) -> tensor<i32>
+  // CHECK: return [[INVERT]]
+  return %2: tensor<i32>
+}
+
+// CHECK-LABEL: func @testSingleNeg
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<i32>)
+func @testSingleNeg(%arg0: tensor<i32>) -> tensor<i32> {
+  // CHECK: [[NEG:%.+]] = "tf.Neg"([[ARG0]])
+  %0 = "tf.Neg"(%arg0) : (tensor<i32>) -> tensor<i32>
+  // CHECK: return [[NEG]]
+  return %0: tensor<i32>
+}
+
+// CHECK-LABEL: func @testDoubleNeg
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<i32>)
+func @testDoubleNeg(%arg0: tensor<i32>) -> tensor<i32> {
+  %0 = "tf.Neg"(%arg0) : (tensor<i32>) -> tensor<i32>
+  %1 = "tf.Neg"(%0) : (tensor<i32>) -> tensor<i32>
+  return %1: tensor<i32>
+  // CHECK: return [[ARG0]]
+}
+
+// CHECK-LABEL: func @testTripleNeg
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<i32>)
+func @testTripleNeg(%arg0: tensor<i32>) -> tensor<i32> {
+  // CHECK: [[NEG:%.+]] = "tf.Neg"([[ARG0]])
+  %0 = "tf.Neg"(%arg0) : (tensor<i32>) -> tensor<i32>
+  %1 = "tf.Neg"(%0) : (tensor<i32>) -> tensor<i32>
+  %2 = "tf.Neg"(%1) : (tensor<i32>) -> tensor<i32>
+  // CHECK: return [[NEG]]
+  return %2: tensor<i32>
+}
+
+// CHECK-LABEL: func @testSingleLogicalNot
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<i1>)
+func @testSingleLogicalNot(%arg0: tensor<i1>) -> tensor<i1> {
+  // CHECK: [[LNOT:%.+]] = "tf.LogicalNot"([[ARG0]])
+  %0 = "tf.LogicalNot"(%arg0) : (tensor<i1>) -> tensor<i1>
+  // CHECK: return [[LNOT]]
+  return %0: tensor<i1>
+}
+
+// CHECK-LABEL: func @testDoubleLogicalNot
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<i1>)
+func @testDoubleLogicalNot(%arg0: tensor<i1>) -> tensor<i1> {
+  %0 = "tf.LogicalNot"(%arg0) : (tensor<i1>) -> tensor<i1>
+  %1 = "tf.LogicalNot"(%0) : (tensor<i1>) -> tensor<i1>
+  return %1: tensor<i1>
+  // CHECK: return [[ARG0]]
+}
+
+// CHECK-LABEL: func @testTripleLogicalNot
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<i1>)
+func @testTripleLogicalNot(%arg0: tensor<i1>) -> tensor<i1> {
+  // CHECK: [[LNOT:%.+]] = "tf.LogicalNot"([[ARG0]])
+  %0 = "tf.LogicalNot"(%arg0) : (tensor<i1>) -> tensor<i1>
+  %1 = "tf.LogicalNot"(%0) : (tensor<i1>) -> tensor<i1>
+  %2 = "tf.LogicalNot"(%1) : (tensor<i1>) -> tensor<i1>
+  // CHECK: return [[LNOT]]
+  return %2: tensor<i1>
+}

--- a/tensorflow/compiler/mlir/tensorflow/transforms/canonicalize.td
+++ b/tensorflow/compiler/mlir/tensorflow/transforms/canonicalize.td
@@ -108,25 +108,12 @@ def ConvertToConcatV2 : Pat<(TF_ConcatOp $axis, $inputs),
                             (TF_ConcatV2Op $inputs, $axis)>;
 
 //===----------------------------------------------------------------------===//
-// Conj op patterns.
-//===----------------------------------------------------------------------===//
-
-def ConjNested : Pat<(TF_ConjOp (TF_ConjOp $arg)), (replaceWithValue $arg)>;
-
-//===----------------------------------------------------------------------===//
 // Div op patterns.
 //===----------------------------------------------------------------------===//
 
 /// Favor Mul over Div.
 def DivWithSqrtDivisor : Pat<(TF_DivOp $arg0, (TF_SqrtOp $arg1)),
                              (TF_MulOp $arg0, (TF_RsqrtOp $arg1))>;
-
-//===----------------------------------------------------------------------===//
-// Invert op patterns.
-//===----------------------------------------------------------------------===//
-
-def InvertNested : Pat<(TF_InvertOp (TF_InvertOp $arg)),
-                       (replaceWithValue $arg)>;
 
 //===----------------------------------------------------------------------===//
 // Log op patterns.
@@ -150,10 +137,6 @@ def LogToLog1p : Pat<
 // LogicalNot op patterns.
 //===----------------------------------------------------------------------===//
 
-// TODO(ezhulenev): Generalize this pattern for all involutions.
-def LogicalNotNested : Pat<(TF_LogicalNotOp (TF_LogicalNotOp $arg)),
-                           (replaceWithValue $arg)>;
-
 def LogicalNotOfEqual : Pat<
     (TF_LogicalNotOp (TF_EqualOp $arg0, $arg1, $shape_error)),
     (TF_NotEqualOp $arg0, $arg1, $shape_error)>;
@@ -176,12 +159,6 @@ def LogicalNotOfLessEqual : Pat<(TF_LogicalNotOp (TF_LessEqualOp $arg0, $arg1)),
                                 (TF_GreaterOp $arg0, $arg1)>;
 
 //===----------------------------------------------------------------------===//
-// Neg op patterns.
-//===----------------------------------------------------------------------===//
-
-def NegNested : Pat<(TF_NegOp (TF_NegOp $arg)), (replaceWithValue $arg)>;
-
-//===----------------------------------------------------------------------===//
 // RealDiv op patterns.
 //===----------------------------------------------------------------------===//
 
@@ -194,13 +171,6 @@ def RealDivWithSqrtDivisor : Pat<(TF_RealDivOp $arg0, (TF_SqrtOp $arg1)),
 def RealDivWithConstDivisor : Pat<
   (TF_RealDivOp $arg0, (TF_ConstOp FloatElementsAttr<32>:$value)),
   (TF_MulOp $arg0, (TF_ReciprocalOp (TF_ConstOp $value)))>;
-
-//===----------------------------------------------------------------------===//
-// Reciprocal op patterns.
-//===----------------------------------------------------------------------===//
-
-def ReciprocalNested : Pat<(TF_ReciprocalOp (TF_ReciprocalOp $arg)),
-                           (replaceWithValue $arg)>;
 
 //===----------------------------------------------------------------------===//
 // Reshape op patterns.


### PR DESCRIPTION
The involution property holds in a few of the TF ops so instead of adding redundant folding operations to every single one of them, we can simply label the ops we want to support with the involution tag and MLIR automatically folds.
