### PR TITLE
Do not create unnecessary intermediate lists in tf.nest

### DIFF
--- a/tensorflow/python/data/util/nest.py
+++ b/tensorflow/python/data/util/nest.py
@@ -238,7 +238,7 @@ def map_structure(func, *structure, **check_types_dict):
   for other in structure[1:]:
     assert_same_structure(structure[0], other, check_types=check_types)
 
-  flat_structure = [flatten(s) for s in structure]
+  flat_structure = (flatten(s) for s in structure)
   entries = zip(*flat_structure)
 
   return pack_sequence_as(
@@ -316,8 +316,8 @@ def assert_shallow_structure(shallow_tree, input_tree, check_types=True):
             "The two structures don't have the same keys. Input "
             "structure has keys %s, while shallow structure has keys %s." %
             (list(input_tree), list(shallow_tree)))
-      input_tree = list(sorted(_six.iteritems(input_tree)))
-      shallow_tree = list(sorted(_six.iteritems(shallow_tree)))
+      input_tree = sorted(_six.iteritems(input_tree))
+      shallow_tree = sorted(_six.iteritems(shallow_tree))
 
     for shallow_branch, input_branch in zip(shallow_tree, input_tree):
       assert_shallow_structure(shallow_branch, input_branch,
@@ -465,8 +465,8 @@ def map_structure_up_to(shallow_tree, func, *inputs):
 
   # Flatten each input separately, apply the function to corresponding elements,
   # then repack based on the structure of the first input.
-  all_flattened_up_to = [flatten_up_to(shallow_tree, input_tree)
-                         for input_tree in inputs]
+  all_flattened_up_to = (flatten_up_to(shallow_tree, input_tree)
+                         for input_tree in inputs)
 
   results = [func(*tensors) for tensors in zip(*all_flattened_up_to)]
   return pack_sequence_as(structure=shallow_tree, flat_sequence=results)

--- a/tensorflow/python/util/nest.py
+++ b/tensorflow/python/util/nest.py
@@ -89,7 +89,7 @@ def _get_attrs_items(obj):
     A list of (attr_name, attr_value) pairs, sorted by attr_name.
   """
   attrs = getattr(obj.__class__, "__attrs_attrs__")
-  attr_names = [a.name for a in attrs]
+  attr_names = (a.name for a in attrs)
   return [(attr_name, getattr(obj, attr_name)) for attr_name in attr_names]
 
 
@@ -637,7 +637,7 @@ def map_structure(func, *structure, **kwargs):
     assert_same_structure(structure[0], other, check_types=check_types,
                           expand_composites=expand_composites)
 
-  flat_structure = [flatten(s, expand_composites) for s in structure]
+  flat_structure = (flatten(s, expand_composites) for s in structure)
   entries = zip(*flat_structure)
 
   return pack_sequence_as(
@@ -960,7 +960,7 @@ def flatten_up_to(shallow_tree, input_tree, check_types=True,
                            check_types=check_types,
                            expand_composites=expand_composites)
   # Discard paths returned by _yield_flat_up_to.
-  return list(v for _, v in _yield_flat_up_to(shallow_tree, input_tree, is_seq))
+  return [v for _, v in _yield_flat_up_to(shallow_tree, input_tree, is_seq)]
 
 
 def flatten_with_tuple_paths_up_to(shallow_tree,
@@ -1231,17 +1231,17 @@ def map_structure_with_tuple_paths_up_to(shallow_tree, func, *inputs, **kwargs):
 
   # Flatten each input separately, apply the function to corresponding elements,
   # then repack based on the structure of the first input.
-  flat_value_lists = [
+  flat_value_gen = (
       flatten_up_to(  # pylint: disable=g-complex-comprehension
           shallow_tree,
           input_tree,
           check_types,
           expand_composites=expand_composites) for input_tree in inputs
-  ]
-  flat_path_list = [path for path, _
-                    in _yield_flat_up_to(shallow_tree, inputs[0], is_seq)]
-  results = [func(*args, **kwargs) for args in zip(flat_path_list,
-                                                   *flat_value_lists)]
+  )
+  flat_path_gen = (path for path, _
+                   in _yield_flat_up_to(shallow_tree, inputs[0], is_seq))
+  results = [func(*args, **kwargs) for args in zip(flat_path_gen,
+                                                   *flat_value_gen)]
   return pack_sequence_as(structure=shallow_tree, flat_sequence=results,
                           expand_composites=expand_composites)
 
@@ -1380,7 +1380,7 @@ def flatten_with_joined_string_paths(structure, separator="/",
   flat_paths = yield_flat_paths(structure, expand_composites=expand_composites)
   def stringify_and_join(path_elements):
     return separator.join(str(path_element) for path_element in path_elements)
-  flat_string_paths = [stringify_and_join(path) for path in flat_paths]
+  flat_string_paths = (stringify_and_join(path) for path in flat_paths)
   return list(zip(flat_string_paths,
                   flatten(structure, expand_composites=expand_composites)))
 


### PR DESCRIPTION
`tf.nest` creates intermediate lists for iterating over elements. This PR changes the list comprehensions to generator expresions in places where they are only used to iterate over once inside the same function. This makes the iteration lazy and removes the need for creation of intermediate lists.