### PR TITLE
XLA: Print nicer message when trying to traverse HLO computation

### DIFF
--- a/tensorflow/compiler/xla/service/hlo_computation.cc
+++ b/tensorflow/compiler/xla/service/hlo_computation.cc
@@ -380,6 +380,9 @@ void HloComputation::ComputeInstructionPostOrder(
   dfs_stack.push_back(root);
   while (!dfs_stack.empty()) {
     const auto current = dfs_stack.back();
+    CHECK_EQ(current->parent(), this)
+        << "Instruction " << current->name()
+        << " is not in the current computation (" << name() << ").";
     auto it = visited->find(current);
     if (it != visited->end()) {
       if (it->second == kVisited) {


### PR DESCRIPTION
Sometimes when developing a new pass/optimization with a new computation being built some instructions from other computations might incorrectly end up in the graph traversal.
Print a nicer error message when that happens.