### PR TITLE
Fix casting condition in Embedding layer

### DIFF
--- a/tensorflow/python/keras/layers/embeddings.py
+++ b/tensorflow/python/keras/layers/embeddings.py
@@ -188,7 +188,7 @@ class Embedding(Layer):
 
   def call(self, inputs):
     dtype = K.dtype(inputs)
-    if dtype != 'int32' and dtype != 'int64':
+    if dtype != 'int32' or dtype != 'int64':
       inputs = math_ops.cast(inputs, 'int32')
     if isinstance(self.embeddings, sharded_variable.ShardedVariable):
       out = embedding_ops.embedding_lookup_v2(self.embeddings.variables, inputs)


### PR DESCRIPTION
As it appears, the current condition for casting is flawed due to using `and` operator, i.e. the `inputs` cannot have both `int32` and `int64` data-type at the same time hence making the condition always evaluating to `True` and doing unnecessary work when the `inputs` is already of type integer.