### PR TITLE
CMSIS-NN: Partial fix for failing conv unit test cases

### DIFF
--- a/tensorflow/lite/micro/kernels/cmsis-nn/conv.cc
+++ b/tensorflow/lite/micro/kernels/cmsis-nn/conv.cc
@@ -339,6 +339,8 @@ TfLiteStatus EvalQuantizedPerChannel(
     "CMSIS-NN optimization for conv not available for this target. Using reference kernel.")
 
   ConvParams op_params;
+  op_params.input_offset = -data.input_zero_point;
+  op_params.output_offset = data.output_zero_point;
   op_params.stride_height = params->stride_height;
   op_params.stride_width = params->stride_width;
   op_params.dilation_height_factor = params->dilation_height_factor;


### PR DESCRIPTION
Fixes #43475 when combined with PR that fixes #42951

Fix #42951 ensures that the reference implementation is invoked
when dilation is not equal to 1 as that case does not have an
optimized implementation.

This PR addresses the issue that zero point arguments are
uninitialized when invoking the reference implementation of
convolution resulting in failing test cases.