### PR TITLE
[tflite] fix missing labels.txt in model maker tutorial

### DIFF
--- a/tensorflow/lite/g3doc/tutorials/model_maker_image_classification.ipynb
+++ b/tensorflow/lite/g3doc/tutorials/model_maker_image_classification.ipynb
@@ -805,7 +805,7 @@
         "colab": {}
       },
       "source": [
-        "model.export(export_dir='.')"
+        "model.export(export_dir='.', metadata=False)"
       ],
       "execution_count": null,
       "outputs": []


### PR DESCRIPTION
fix the problem of missing `labels.txt` in #43463 and #41470