### PR TITLE
Fix the build for benchmarks for bluepill and STM32F4.

### DIFF
--- a/tensorflow/lite/micro/benchmarks/keyword_benchmark.cc
+++ b/tensorflow/lite/micro/benchmarks/keyword_benchmark.cc
@@ -38,25 +38,18 @@ alignas(16) uint8_t tensor_arena[tensor_arena_size];
 // A random number generator seed to generate input values.
 constexpr int kRandomSeed = 42;
 
-MicroBenchmarkRunner<int16_t>* benchmark_runner = nullptr;
-
-void InitializeBenchmarkRunner() {
-  // NOLINTNEXTLINE
-  static MicroBenchmarkRunner<int16_t> runner(g_keyword_scrambled_model_data,
-                                              tensor_arena, tensor_arena_size);
-  benchmark_runner = &runner;
-}
+static MicroBenchmarkRunner<int16_t> benchmark_runner(
+    g_keyword_scrambled_model_data, tensor_arena, tensor_arena_size);
 
 // Initializes keyword runner and sets random inputs.
 void InitializeKeywordRunner() {
-  InitializeBenchmarkRunner();
-  benchmark_runner->SetRandomInput(kRandomSeed);
+  benchmark_runner.SetRandomInput(kRandomSeed);
 }
 
 // This method assumes InitializeKeywordRunner has already been run.
 void KeywordRunNIerations(int iterations) {
   for (int i = 0; i < iterations; i++) {
-    benchmark_runner->RunSingleIteration();
+    benchmark_runner.RunSingleIteration();
   }
 }
 

--- a/tensorflow/lite/micro/benchmarks/person_detection_benchmark.cc
+++ b/tensorflow/lite/micro/benchmarks/person_detection_benchmark.cc
@@ -40,35 +40,29 @@ constexpr int kTensorArenaSize = 95 * 1024;
 constexpr int kRandomSeed = 42;
 alignas(16) uint8_t tensor_arena[kTensorArenaSize];
 
-MicroBenchmarkRunner<uint8_t>* benchmark_runner = nullptr;
-
-void InitializeBenchmarkRunner() {
-  // NOLINTNEXTLINE
-  static MicroBenchmarkRunner<uint8_t> runner(g_person_detect_model_data,
-                                              tensor_arena, kTensorArenaSize);
-  benchmark_runner = &runner;
-}
+static MicroBenchmarkRunner<uint8_t> benchmark_runner(
+    g_person_detect_model_data, tensor_arena, kTensorArenaSize);
 
 void PersonDetectionTenIterationsWithRandomInput() {
-  benchmark_runner->SetRandomInput(kRandomSeed);
+  benchmark_runner.SetRandomInput(kRandomSeed);
   for (int i = 0; i < 10; i++) {
-    benchmark_runner->RunSingleIteration();
+    benchmark_runner.RunSingleIteration();
   }
 }
 
 void PersonDetectionTenIerationsWithPerson() {
   // TODO(b/152644476): Add a way to run more than a single deterministic input.
-  benchmark_runner->SetInput(g_person_data);
+  benchmark_runner.SetInput(g_person_data);
   for (int i = 0; i < 10; i++) {
-    benchmark_runner->RunSingleIteration();
+    benchmark_runner.RunSingleIteration();
   }
 }
 
 void PersonDetectionTenIerationsWithoutPerson() {
   // TODO(b/152644476): Add a way to run more than a single deterministic input.
-  benchmark_runner->SetInput(g_no_person_data);
+  benchmark_runner.SetInput(g_no_person_data);
   for (int i = 0; i < 10; i++) {
-    benchmark_runner->RunSingleIteration();
+    benchmark_runner.RunSingleIteration();
   }
 }
 
@@ -76,7 +70,6 @@ void PersonDetectionTenIerationsWithoutPerson() {
 
 TF_LITE_MICRO_BENCHMARKS_BEGIN
 
-TF_LITE_MICRO_BENCHMARK(InitializeBenchmarkRunner());
 TF_LITE_MICRO_BENCHMARK(PersonDetectionTenIterationsWithRandomInput());
 TF_LITE_MICRO_BENCHMARK(PersonDetectionTenIerationsWithPerson());
 TF_LITE_MICRO_BENCHMARK(PersonDetectionTenIerationsWithoutPerson());

--- a/tensorflow/lite/micro/benchmarks/person_detection_experimental_benchmark.cc
+++ b/tensorflow/lite/micro/benchmarks/person_detection_experimental_benchmark.cc
@@ -39,27 +39,25 @@ namespace {
 constexpr int tensor_arena_size = 135 * 1024;
 alignas(16) uint8_t tensor_arena[tensor_arena_size];
 
-MicroBenchmarkRunner<int8_t>* runner;
+static MicroBenchmarkRunner<int8_t> benchmark_runner(g_person_detect_model_data,
+                                                     tensor_arena,
+                                                     tensor_arena_size);
 
 void InitializeBenchmarkRunner() {
-  // NOLINTNEXTLINE
-  static MicroBenchmarkRunner<int8_t> benchmark_runner(
-      g_person_detect_model_data, tensor_arena, tensor_arena_size);
-  runner = &benchmark_runner;
-  runner->SetInput(reinterpret_cast<const int8_t*>(g_person_data));
+  benchmark_runner.SetInput(reinterpret_cast<const int8_t*>(g_person_data));
 }
 
 void PersonDetectionTenIerationsWithPerson() {
-  runner->SetInput(reinterpret_cast<const int8_t*>(g_person_data));
+  benchmark_runner.SetInput(reinterpret_cast<const int8_t*>(g_person_data));
   for (int i = 0; i < 10; i++) {
-    runner->RunSingleIteration();
+    benchmark_runner.RunSingleIteration();
   }
 }
 
 void PersonDetectionTenIerationsWithoutPerson() {
-  runner->SetInput(reinterpret_cast<const int8_t*>(g_no_person_data));
+  benchmark_runner.SetInput(reinterpret_cast<const int8_t*>(g_no_person_data));
   for (int i = 0; i < 10; i++) {
-    runner->RunSingleIteration();
+    benchmark_runner.RunSingleIteration();
   }
 }
 
@@ -68,7 +66,7 @@ void PersonDetectionTenIerationsWithoutPerson() {
 TF_LITE_MICRO_BENCHMARKS_BEGIN
 
 TF_LITE_MICRO_BENCHMARK(InitializeBenchmarkRunner());
-TF_LITE_MICRO_BENCHMARK(runner->RunSingleIteration());
+TF_LITE_MICRO_BENCHMARK(benchmark_runner.RunSingleIteration());
 TF_LITE_MICRO_BENCHMARK(PersonDetectionTenIerationsWithPerson());
 TF_LITE_MICRO_BENCHMARK(PersonDetectionTenIerationsWithoutPerson());
 

--- a/tensorflow/lite/micro/tools/make/targets/bluepill/bluepill.lds
+++ b/tensorflow/lite/micro/tools/make/targets/bluepill/bluepill.lds
@@ -20,7 +20,7 @@ limitations under the License.
 
 /*
  * 0x00000000 - 0x07ffffff - aliased to flash or sys memory depending on BOOT jumpers.
- * 0x08000000 - 0x0807ffff - Flash.
+ * 0x08000000 - 0x080fffff - Flash.
  * 0x1ffff000 - 0x1ffff7ff - Boot firmware in system memory.
  * 0x1ffff800 - 0x1fffffff - Option bytes.
  * 0x20000000 - 0x2003ffff - SRAM.
@@ -32,7 +32,7 @@ ENTRY(_main)
 
 MEMORY {
 RAM (xrw) : ORIGIN = 0x20000000, LENGTH = 256K
-FLASH (rx) : ORIGIN = 0x8000000, LENGTH = 512K
+FLASH (rx) : ORIGIN = 0x8000000, LENGTH = 1024K
 }
 
 /* Compute where the stack ends rather than hard coding it */


### PR DESCRIPTION
The root cause here is that a static inside a function still has locks
around it, but a global static does not. This is the behavior if we use
no-threadsafe-statics.

Also note that while this change fixes the build, the current HEAD is broken for `TARGET=bluepill` and `TAGS=cmsis-nn`. See issue #43510 for more details and PR #43509 improves the coverage for the CI system.

Manually tested with the following commands:
```
make -f tensorflow/lite/micro/tools/make/Makefile -j8 TARGET=stm32f4 TAGS=cmsis-nn keyword_benchmark person_detection_benchmark person_detection_experimental_benchmark
make -f tensorflow/lite/micro/tools/make/Makefile -j8 TARGET=bluepill keyword_benchmark person_detection_benchmark person_detection_experimental_benchmark
```