### PR TITLE
Add support lite model conversion with zero inputs

### DIFF
--- a/tensorflow/lite/python/lite.py
+++ b/tensorflow/lite/python/lite.py
@@ -1349,7 +1349,7 @@ class TFLiteConverterBaseV1(TFLiteConverterBase):
     Returns:
       Bool.
     """
-    return self._input_tensors and self._output_tensors
+    return self._input_tensors is not None and self._output_tensors is not None
 
   def _set_batch_size(self, batch_size):
     """Sets the first dimension of the input tensor to `batch_size`.

--- a/tensorflow/lite/python/lite.py
+++ b/tensorflow/lite/python/lite.py
@@ -1349,7 +1349,7 @@ class TFLiteConverterBaseV1(TFLiteConverterBase):
     Returns:
       Bool.
     """
-    return self._input_tensors is not None and self._output_tensors is not None
+    return self._input_tensors is not None and self._output_tensors
 
   def _set_batch_size(self, batch_size):
     """Sets the first dimension of the input tensor to `batch_size`.


### PR DESCRIPTION
When I am going to convert a .pb model with no inputs to lite format, the lite converter reports an error like this:
```shell
Traceback (most recent call last):
  File "test_convert_tf.py", line 5, in <module>
    "model.pb", input_arrays=[], output_arrays=["add"], input_shapes=[])
  File "/usr/local/lib/python3.7/site-packages/tensorflow/lite/python/lite.py", line 1864, in from_frozen_graph
    return cls(sess.graph_def, input_tensors, output_tensors)
  File "/usr/local/lib/python3.7/site-packages/tensorflow/lite/python/lite.py", line 1767, in __init__
    experimental_debug_info_func)
  File "/usr/local/lib/python3.7/site-packages/tensorflow/lite/python/lite.py", line 1621, in __init__
    "If input_tensors and output_tensors are None, both "
ValueError: If input_tensors and output_tensors are None, both input_arrays_with_shape and output_arrays must be defined.
```

After this fix, the model will be successfully converted. Bellow is my codes and .pb model([model.pb.zip](https://github.com/tensorflow/tensorflow/files/5281464/model.pb.zip)) just for testing.
```python
import tensorflow as tf

# Convert the model
converter = tf.compat.v1.lite.TFLiteConverter.from_frozen_graph(
    "model.pb", input_arrays=[], output_arrays=["add"], input_shapes=[])

tflite_model = converter.convert()

# Save the model.
with open('model.tflite', 'wb') as f:
  f.write(tflite_model)
```
