### PR TITLE
Solve IndexError: list index out of range #43561

### DIFF
--- a/tensorflow/python/keras/engine/functional.py
+++ b/tensorflow/python/keras/engine/functional.py
@@ -1089,10 +1089,13 @@ def _should_skip_first_node(layer):
   # Networks that are constructed with an Input layer/shape start with a
   # pre-existing node linking their input to output. This node is excluded from
   # the network config.
-  return (isinstance(layer, Functional) and
-          # Filter out Sequential models without an input shape.
-          isinstance(layer._self_tracked_trackables[0],
-                     input_layer_module.InputLayer))
+  if layer._self_tracked_trackables:
+    return (isinstance(layer, Functional) and
+            # Filter out Sequential models without an input shape.
+            isinstance(layer._self_tracked_trackables[0],
+                       input_layer_module.InputLayer))
+  else:
+    return isinstance(layer, Functional)
 
 
 def connect_ancillary_layers(model, created_layers):


### PR DESCRIPTION
Just as I said in #43561 , when I was trying to load the sequential model [here](https://github.com/vogon101/skincancer/blob/master/models/model_6_combined_2_DA.h5) using `tf.keras.models.load_model` in **TF 2.3.1**, an error is thrown at the following location:

```bash
~/.local/lib/python3.7/site-packages/tensorflow/python/keras/engine/functional.py in _should_skip_first_node(layer)
   1031   return (isinstance(layer, Functional) and
   1032           # Filter out Sequential models without an input shape.
-> 1033           isinstance(layer._layers[0], input_layer_module.InputLayer))
   1034 
   1035 
IndexError: list index out of range
```

The model is believed to be trained using keras and under TF1.9, and the structure of the model can be found [here](https://github.com/vogon101/skincancer/blob/master/src/sandbox/ml_lib/combined_model_v2.py), and here's [the code for training](https://github.com/vogon101/skincancer/blob/master/src/sandbox/v6_combined_model_v2.py).

Here you can find the full stack trace and running code under TF 2.3.1: https://colab.research.google.com/drive/1Lfo0O7D0cM8EtR0h6noqCoWqoqf8bzAD?usp=sharing

I am able to fix this issue when replace [the code](https://github.com/tensorflow/tensorflow/blob/5d5534edf7d0b73cb23f7069135d674e1d27250b/tensorflow/python/keras/engine/functional.py#L1078-L1085) into following:
```python3
def _should_skip_first_node(layer):
  """Returns True if the first layer node should not be saved or loaded."""
  # Networks that are constructed with an Input layer/shape start with a
  # pre-existing node linking their input to output. This node is excluded from
  # the network config.
  if layer._layers:
    return (isinstance(layer, Functional) and
          # Filter out Sequential models without an input shape.
          isinstance(layer._layers[0], input_layer_module.InputLayer))
  else:
    return isinstance(layer, Functional)
```

If there's no side effects with this workaround, please merge this PR. Thanks!

Signed-off-by: Hollow Man <hollowman@hollowman.ml>