### PR TITLE
Fix for concat v2 unit test failure in [INTEL MKL] enabled Tensorflow

### DIFF
--- a/tensorflow/core/common_runtime/mkl_layout_pass.cc
+++ b/tensorflow/core/common_runtime/mkl_layout_pass.cc
@@ -1496,14 +1496,11 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
     }
     return false;
   }
-  // For NKL-DNN only int32 supported for axis data type
+  // For oneDNN, only int32 is supported for axis data type
   static bool ConcatV2Rewrite(const Node *n) {
     DataType T;
     GetNodeAttr(n->def(),"Tidx", &T);
-    if (T != DT_INT32) {
-      return false;
-    }
-    return true;
+    return (T == DT_INT32);
   }
 
   static bool DequantizeRewrite(const Node* n) {

--- a/tensorflow/core/common_runtime/mkl_layout_pass.cc
+++ b/tensorflow/core/common_runtime/mkl_layout_pass.cc
@@ -407,7 +407,7 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
                       CopyAttrsAll, AlwaysRewrite, GetRewriteCause()});
     rinfo_.push_back({csinfo_.concatv2,
                       mkl_op_registry::GetMklOpName(csinfo_.concatv2),
-                      CopyAttrsAll, AlwaysRewrite, GetRewriteCause()});
+                      CopyAttrsAll, ConcatV2Rewrite, GetRewriteCause()});
     rinfo_.push_back(
         {csinfo_.conjugate_transpose,
          mkl_op_registry::GetMklOpName(csinfo_.conjugate_transpose),
@@ -549,7 +549,7 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
                       CopyAttrsAll, AlwaysRewrite, GetRewriteCause()});
     rinfo_.push_back({csinfo_.quantized_concatv2,
                       mkl_op_registry::GetMklOpName(csinfo_.quantized_concatv2),
-                      CopyAttrsAll, AlwaysRewrite, GetRewriteCause()});
+                      CopyAttrsAll, ConcatV2Rewrite, GetRewriteCause()});
     rinfo_.push_back({csinfo_.quantized_conv2d,
                       mkl_op_registry::GetMklOpName(csinfo_.quantized_conv2d),
                       CopyAttrsQuantizedConv2D, AlwaysRewrite,
@@ -1495,6 +1495,15 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
       return true;
     }
     return false;
+  }
+  // For NKL-DNN only int32 supported for axis data type
+  static bool ConcatV2Rewrite(const Node *n) {
+    DataType T;
+    GetNodeAttr(n->def(),"Tidx", &T);
+    if (T != DT_INT32) {
+      return false;
+    }
+    return true;
   }
 
   static bool DequantizeRewrite(const Node* n) {

--- a/tensorflow/core/common_runtime/mkl_layout_pass_test.cc
+++ b/tensorflow/core/common_runtime/mkl_layout_pass_test.cc
@@ -4258,6 +4258,29 @@ TEST_F(MklLayoutPassTest, NodeRewrite_ConcatV2_DeviceTest) {
             "A->D:2;B->D;B:1->D:1;C->E;D->E:1");
 }
 
+
+TEST_F(MklLayoutPassTest, NodeRewrite_ConcatV2_idxtest) {
+  InitGraph(
+      "node { name: 'A' op: 'Const' "
+      " attr { key: 'dtype' value { type: DT_INT64 } }"
+      " attr { key: 'value' value { "
+      "    tensor { dtype: DT_INT32 tensor_shape { dim { size: 1 } } "
+      "    int_val: 0 } } } }"
+      "node { name: 'B' op: 'InputList'"
+      " attr { key: 'N'                value { i: 2 } }}"
+      "node { name: 'C' op: 'Input'}"
+      "node { name: 'D' op: 'ConcatV2'"
+      " attr { key: 'T'                value { type: DT_FLOAT } }"
+      " attr { key: 'Tidx'             value { type: DT_INT64 } }"
+      " attr { key: 'N'                value { i: 2 } }"
+      " input: ['B:0', 'B:1', 'A']}"
+      "node { name: 'E' op: 'Zeta' attr { key: 'T' value { type: DT_FLOAT } }"
+      " input: ['C', 'D'] }");
+  EXPECT_EQ(DoMklLayoutOptimizationPass(),
+            "A(Const);B(InputList);C(Input);D(ConcatV2);E(Zeta)|"
+            "A->D:2;B->D;B:1->D:1;C->E;D->E:1");
+}
+
 TEST_F(MklLayoutPassTest, NodeRewrite_FusedBatchNorm_DeviceTest) {
   InitGraph(
       "node { name: 'A' op: 'Input'}"

--- a/tensorflow/core/common_runtime/mkl_layout_pass_test.cc
+++ b/tensorflow/core/common_runtime/mkl_layout_pass_test.cc
@@ -4259,7 +4259,7 @@ TEST_F(MklLayoutPassTest, NodeRewrite_ConcatV2_DeviceTest) {
 }
 
 
-TEST_F(MklLayoutPassTest, NodeRewrite_ConcatV2_idxtest) {
+TEST_F(MklLayoutPassTest, NodeRewrite_ConcatV2_IndexTest) {
   InitGraph(
       "node { name: 'A' op: 'Const' "
       " attr { key: 'dtype' value { type: DT_INT64 } }"


### PR DESCRIPTION
Fix for unit test failure in [INTEL MKL] Tensorflow
    //tensorflow/python/ops/parallel_for:array_test (concat_v2) 
The unit test has axis type : INT64 i not supported by MKLDNN.
The fix disallows the mapping to MKLDNN ops when any type other than INT32 is used for axis.