### PR TITLE
[INTEL MKL] Bug-fix to in-place computation with tensor forwarding.

### DIFF
--- a/tensorflow/core/util/mkl_util.h
+++ b/tensorflow/core/util/mkl_util.h
@@ -894,7 +894,7 @@ inline void SetDummyMklDnnShapeOutput(OpKernelContext* context,
 }
 
 // If the input tensor has ref count as 1, it is forwarded to the desired
-// output port and the function reutrns true. In that case, it also allocates
+// output port and the function returns true. In that case, it also allocates
 // the serialized MklDnnShape object. Otherwise, the function returns false.
 inline bool ForwardMklTensorInToOutWithMklShape(OpKernelContext* context,
                                                 int idx_in, int idx_out,
@@ -921,9 +921,8 @@ inline bool ForwardMklTensorInToOutWithMklShape(OpKernelContext* context,
   if (is_forwarded || always_forward) {
     AllocateOutputSetMklShape(context, idx_out, mkl_shape);
     return true;
-  } else {
-    return false;
   }
+  return false;
 }
 
 // Forward the MKL shape ONLY (used in elementwise and other ops where

--- a/tensorflow/python/kernel_tests/conv_ops_test.py
+++ b/tensorflow/python/kernel_tests/conv_ops_test.py
@@ -39,6 +39,7 @@ from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import gradient_checker
 from tensorflow.python.ops import gradients_impl
+from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import nn_impl
 from tensorflow.python.ops import nn_ops
 from tensorflow.python.ops import random_ops
@@ -3265,6 +3266,164 @@ def GetInceptionBackFilterTest(input_size, filter_size, output_size, strides,
 
   return Test
 
+
+class FusedConv2DTest(test.TestCase):
+
+  def _CreateNumpyTensor(self, shape):
+    total_size = 1
+    for s in shape:
+      total_size *= s
+    return np.arange(1, total_size + 1, dtype=np.float32).reshape(shape)
+
+  def _CreateConv2D(self, input_values, filters,
+                    strides=[1, 1], padding="SAME"):
+    return nn_ops.convolution(
+              input_values,
+              filters,
+              strides=strides,
+              padding=padding)
+
+  @test_util.deprecated_graph_mode_only
+  def testAddWithRefCountOne(self):
+    expected_output = [
+        113377, 125570, 77305, 86738, 19433, 22226, 60681,
+        70722, 36291, 43718, 7143, 9206, 9785, 12098,
+        4783, 6366, 779, 1134]
+    tensor_in_sizes = [1, 3, 3, 2]
+    filter_in_sizes = [2, 2, 2, 2]
+    bias_in_sizes = [2]
+
+    x = self._CreateNumpyTensor(tensor_in_sizes)
+    filter_in = self._CreateNumpyTensor(filter_in_sizes)
+    bias_in = self._CreateNumpyTensor(bias_in_sizes)
+    # To get different weights for filter
+    ofs = 1
+
+    conv1 = self._CreateConv2D(x, filter_in)
+    conv2 = self._CreateConv2D(conv1, filter_in + ofs)
+
+    conv = self._CreateConv2D(conv1, filter_in - ofs)
+    bias_add = nn_ops.bias_add(conv, bias_in)
+    add = math_ops.add_n([bias_add, conv2])
+
+    self.assertAllEqual(
+        np.rint(expected_output),
+        self.evaluate(add).reshape(-1))
+
+  @test_util.deprecated_graph_mode_only
+  def testAddWithRefCountTwoAndRunAddLast(self):
+    expected_output = [
+        1.907175e+06, 2.253505e+06, 7.809210e+05, 9.537180e+05,
+        1.184170e+05, 1.523070e+05, 5.367010e+05, 6.803700e+05,
+        1.867090e+05, 2.529460e+05, 2.362300e+04, 3.522600e+04,
+        5.121700e+04, 7.168300e+04, 1.494300e+04, 2.347400e+04,
+        1.558000e+03, 2.903000e+03]
+    tensor_in_sizes = [1, 3, 3, 2]
+    filter_in_sizes = [2, 2, 2, 2]
+    bias_in_sizes = [2]
+
+    x = self._CreateNumpyTensor(tensor_in_sizes)
+    filter_in = self._CreateNumpyTensor(filter_in_sizes)
+    bias_in = self._CreateNumpyTensor(bias_in_sizes)
+    # To get different weights for filter
+    ofs = 1
+
+    conv1 = self._CreateConv2D(x, filter_in)
+    conv2 = self._CreateConv2D(conv1, filter_in + ofs)
+
+    conv = self._CreateConv2D(conv2, filter_in - ofs)
+    bias_add = nn_ops.bias_add(conv, bias_in)
+    add = math_ops.add_n([bias_add, conv1])
+
+    self.assertAllEqual(
+        np.rint(expected_output),
+        self.evaluate(add).reshape(-1))
+
+  @test_util.deprecated_graph_mode_only
+  def testAddWithRefCountTwoAndRunAddFirst(self):
+    expected_output = [
+        176161, 194450, 120673, 134822, 30545, 34734, 96041,
+        111102, 58149, 69289, 11745, 14839, 15833, 19302,
+        7965, 10339, 1345, 1877]
+    tensor_in_sizes = [1, 3, 3, 2]
+    filter_in_sizes = [2, 2, 2, 2]
+    bias_in_sizes = [2]
+
+    x = self._CreateNumpyTensor(tensor_in_sizes)
+    filter_in = self._CreateNumpyTensor(filter_in_sizes)
+    bias_in = self._CreateNumpyTensor(bias_in_sizes)
+    # To get different weights for filter
+    ofs = 1
+
+    conv1 = self._CreateConv2D(x, filter_in)
+    conv2 = self._CreateConv2D(conv1, filter_in + ofs)
+
+    conv = self._CreateConv2D(conv1, filter_in - ofs)
+    bias_add = nn_ops.bias_add(conv, bias_in)
+    add = math_ops.add_n([bias_add, conv2])
+
+    relu = nn_ops.relu(add)
+    output = math_ops.add_n([relu, conv2])
+
+    self.assertAllEqual(
+        np.rint(expected_output),
+        self.evaluate(output).reshape(-1))
+
+  @test_util.deprecated_graph_mode_only
+  def testAddWithRefCountTwoAndNoDependence(self):
+    expected_output = [
+        176161, 194450, 120673, 134822, 30545, 34734, 96041,
+        111102, 58149, 69289, 11745, 14839, 15833, 19302,
+        7965, 10339, 1345, 1877]
+    tensor_in_sizes = [1, 3, 3, 2]
+    filter_in_sizes = [2, 2, 2, 2]
+    bias_in_sizes = [2]
+
+    x = self._CreateNumpyTensor(tensor_in_sizes)
+    filter_in = self._CreateNumpyTensor(filter_in_sizes)
+    bias_in = self._CreateNumpyTensor(bias_in_sizes)
+    # To get different weights for filter
+    ofs = 1
+
+    conv1 = self._CreateConv2D(x, filter_in)
+    conv2 = self._CreateConv2D(conv1, filter_in + ofs)
+
+    conv = self._CreateConv2D(conv1, filter_in - ofs)
+    bias_add = nn_ops.bias_add(conv, bias_in)
+    add = math_ops.add_n([bias_add, conv2])
+
+    relu1 = nn_ops.relu(add)
+    relu2 = nn_ops.relu(conv2)
+    output = math_ops.add_n([relu1, relu2])
+
+    self.assertAllEqual(
+        np.rint(expected_output),
+        self.evaluate(output).reshape(-1))
+
+
+  @test_util.deprecated_graph_mode_only
+  def testAddWithSameSrcAndAddTensorBuffer(self):
+    expected_output = [
+        57157, 63298, 39249, 44026, 9971, 11402, 31193, 36306,
+        19126, 22948, 3970, 5060, 5135, 6350, 2666, 3524,
+        461, 674]
+    tensor_in_sizes = [1, 3, 3, 2]
+    filter_in_sizes = [2, 2, 2, 2]
+    bias_in_sizes = [2]
+
+    x = self._CreateNumpyTensor(tensor_in_sizes)
+    filter_in = self._CreateNumpyTensor(filter_in_sizes)
+    bias_in = self._CreateNumpyTensor(bias_in_sizes)
+
+    conv1 = self._CreateConv2D(x, filter_in)
+
+    conv = self._CreateConv2D(conv1, filter_in)
+    bias_add = nn_ops.bias_add(conv, bias_in)
+    add = math_ops.add_n([bias_add, conv1])
+
+    self.assertAllEqual(
+        np.rint(expected_output),
+        self.evaluate(add).reshape(-1))
 
 if __name__ == "__main__":
   for index, (input_size_, filter_size_, output_size_, stride_,


### PR DESCRIPTION
This PR fixes a bug in a fused operator (`conv2d` + `bias_add` + `add` + `relu`), wherein one of the inputs to `add` is used as in-place buffer for output result. Previous code was forcefully forwarding the input to the output, although the input could have more than one fan-outs.