### PR TITLE
enlarge the format data width

### DIFF
--- a/tensorflow/core/platform/default/test_benchmark.cc
+++ b/tensorflow/core/platform/default/test_benchmark.cc
@@ -166,12 +166,12 @@ void Benchmark::Run(const char* pattern) {
       char buf[100];
       std::string full_label = label;
       if (bytes_processed > 0) {
-        snprintf(buf, sizeof(buf), " %.1fMB/s",
+        snprintf(buf, sizeof(buf), " %.5fMB/s",
                  (bytes_processed * 1e-6) / seconds);
         full_label += buf;
       }
       if (items_processed > 0) {
-        snprintf(buf, sizeof(buf), " %.1fM items/s",
+        snprintf(buf, sizeof(buf), " %.5fM items/s",
                  (items_processed * 1e-6) / seconds);
         full_label += buf;
       }


### PR DESCRIPTION
When run this _//tensorflow/core/kernels/image:non_max_suppression_op_benchmark_test_, since this op is time consumption, and the origin format only keep 1 digits after the decimal point. the output items_processed per second is always zero. Enlarge the digits number to run the benchmark.