### PR TITLE
WorkerTrainingState Test and Bugfix

### DIFF
--- a/tensorflow/python/keras/distribute/worker_training_state.py
+++ b/tensorflow/python/keras/distribute/worker_training_state.py
@@ -21,7 +21,6 @@ import os
 
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
-from tensorflow.python.framework.errors_impl import NotFoundError as _NotFoundError
 from tensorflow.python.keras import backend as K
 from tensorflow.python.keras.distribute import distributed_file_utils
 from tensorflow.python.keras.utils import mode_keys

--- a/tensorflow/python/keras/distribute/worker_training_state.py
+++ b/tensorflow/python/keras/distribute/worker_training_state.py
@@ -43,14 +43,15 @@ class WorkerTrainingState(object):
   This allows model and epoch information to be saved periodically and restore
   for fault-tolerance, also known as preemption-recovery purpose.
   """
+
   def __init__(self, model, checkpoint_dir):
     self._model = model
 
     # The epoch at which the checkpoint is saved. Used for fault-tolerance.
     # GPU device only has int64 dtype registered VarHandleOp.
     self._ckpt_saved_epoch = variables.Variable(
-        initial_value=constant_op.constant(CKPT_SAVED_EPOCH_UNUSED_VALUE,
-                                           dtype=dtypes.int64),
+        initial_value=constant_op.constant(
+            CKPT_SAVED_EPOCH_UNUSED_VALUE, dtype=dtypes.int64),
         name='ckpt_saved_epoch')
 
     # Variable initialization.

--- a/tensorflow/python/keras/distribute/worker_training_state.py
+++ b/tensorflow/python/keras/distribute/worker_training_state.py
@@ -21,6 +21,7 @@ import os
 
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
+from tensorflow.python.framework.errors_impl import NotFoundError as _NotFoundError
 from tensorflow.python.keras import backend as K
 from tensorflow.python.keras.distribute import distributed_file_utils
 from tensorflow.python.keras.utils import mode_keys
@@ -43,15 +44,14 @@ class WorkerTrainingState(object):
   This allows model and epoch information to be saved periodically and restore
   for fault-tolerance, also known as preemption-recovery purpose.
   """
-
   def __init__(self, model, checkpoint_dir):
     self._model = model
 
     # The epoch at which the checkpoint is saved. Used for fault-tolerance.
     # GPU device only has int64 dtype registered VarHandleOp.
     self._ckpt_saved_epoch = variables.Variable(
-        initial_value=constant_op.constant(
-            CKPT_SAVED_EPOCH_UNUSED_VALUE, dtype=dtypes.int64),
+        initial_value=constant_op.constant(CKPT_SAVED_EPOCH_UNUSED_VALUE,
+                                           dtype=dtypes.int64),
         name='ckpt_saved_epoch')
 
     # Variable initialization.

--- a/tensorflow/python/keras/distribute/worker_training_state_test.py
+++ b/tensorflow/python/keras/distribute/worker_training_state_test.py
@@ -17,16 +17,23 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+
+import json
+import multiprocessing as mp
 import os
 import sys
+import tempfile
 
 from absl.testing import parameterized
+from tensorflow.python.distribute import collective_all_reduce_strategy
 from tensorflow.python.distribute import combinations as ds_combinations
 from tensorflow.python.distribute import multi_worker_test_base as test_base
 from tensorflow.python.framework import test_combinations as combinations
 from tensorflow.python.keras import callbacks
 from tensorflow.python.keras.distribute import multi_worker_testing_utils
+from tensorflow.python.keras.distribute import worker_training_state
 from tensorflow.python.lib.io import file_io
+from tensorflow.python.platform import googletest
 from tensorflow.python.platform import test
 
 
@@ -34,11 +41,10 @@ class ModelCheckpointTest(test_base.IndependentWorkerTestBase,
                           parameterized.TestCase):
 
   @ds_combinations.generate(
-      combinations.combine(
-          mode=['graph'],
-          required_gpus=[0, 1],
-          file_format=['h5', 'tf'],
-          save_weights_only=[True, False]))
+      combinations.combine(mode=['graph'],
+                           required_gpus=[0, 1],
+                           file_format=['h5', 'tf'],
+                           save_weights_only=[True, False]))
   def testCheckpointExists(self, file_format, save_weights_only):
     with self.cached_session():
       train_ds, _ = multi_worker_testing_utils.mnist_synthetic_dataset(64, 2)
@@ -46,8 +52,8 @@ class ModelCheckpointTest(test_base.IndependentWorkerTestBase,
       saving_dir = self.get_temp_dir()
       saving_filepath = os.path.join(saving_dir, 'checkpoint.' + file_format)
       callbacks_list = [
-          callbacks.ModelCheckpoint(
-              filepath=saving_filepath, save_weights_only=save_weights_only)
+          callbacks.ModelCheckpoint(filepath=saving_filepath,
+                                    save_weights_only=save_weights_only)
       ]
       self.assertFalse(file_io.file_exists_v2(saving_filepath))
       model.fit(
@@ -55,8 +61,58 @@ class ModelCheckpointTest(test_base.IndependentWorkerTestBase,
       tf_saved_model_exists = file_io.file_exists_v2(saving_filepath)
       tf_weights_only_checkpoint_exists = file_io.file_exists_v2(
           saving_filepath + '.index')
-      self.assertTrue(
-          tf_saved_model_exists or tf_weights_only_checkpoint_exists)
+      self.assertTrue(tf_saved_model_exists or
+                      tf_weights_only_checkpoint_exists)
+
+
+def testWorkerTrainingState(cluster_spec, task_id, backup_dir):
+  #Set TFCONFIG
+  tf_config = {
+      'cluster': cluster_spec,
+      'task': {
+          'type': "worker",
+          'index': task_id
+      }
+  }
+  os.environ["TF_CONFIG"] = json.dumps(tf_config)
+  strategy = collective_all_reduce_strategy.CollectiveAllReduceStrategy()
+  train_ds, _ = multi_worker_testing_utils.mnist_synthetic_dataset(64, 2)
+  with strategy.scope():
+    model = multi_worker_testing_utils.get_mnist_model((28, 28, 1))
+
+  model._training_state = (worker_training_state.WorkerTrainingState(
+      model, backup_dir))
+  model._training_state.back_up(0)
+
+  len_backup = len(os.listdir(backup_dir))
+  assert len_backup > 0, "%d" % (len_backup)
+
+  model._training_state.restore()
+  model._training_state.delete_backup()
+
+  len_backup = len(os.listdir(backup_dir))
+  if task_id == 0:
+    assert len_backup == 0, "%d" % (len_backup)
+
+  return
+
+
+class WorkerTrainingStateTest(test.TestCase, parameterized.TestCase):
+
+  def create_cluster_spec(self, num_workers):
+    worker_ports = [test_base.pick_unused_port() for _ in range(num_workers)]
+    cluster_dict = {}
+    if num_workers > 0:
+      cluster_dict['worker'] = ['localhost:%s' % port for port in worker_ports]
+    self._cluster_spec = cluster_dict
+
+  def testWorkerTrainingState(self):
+    num_workers = 3
+    self.create_cluster_spec(num_workers)
+    pool = mp.Pool(num_workers)
+    backup_dir = tempfile.mkdtemp(dir=googletest.GetTempDir())
+    args = [(self._cluster_spec, x, backup_dir) for x in range(num_workers)]
+    pool.starmap(testWorkerTrainingState, args)
 
 
 if __name__ == '__main__':

--- a/tensorflow/python/keras/distribute/worker_training_state_test.py
+++ b/tensorflow/python/keras/distribute/worker_training_state_test.py
@@ -100,23 +100,18 @@ def testWorkerTrainingState(cluster_spec, task_id, backup_dir, create_barrier):
 
 class WorkerTrainingStateTest(test.TestCase, parameterized.TestCase):
 
-  def create_cluster_spec(self, num_workers):
-    worker_ports = [test_base.pick_unused_port() for _ in range(num_workers)]
-    cluster_dict = {}
-    if num_workers > 0:
-      cluster_dict['worker'] = ['localhost:%s' % port for port in worker_ports]
-    self._cluster_spec = cluster_dict
-
   def testWorkerTrainingState(self):
     try:
       num_workers = 3
-      self._cluster_spec = test_base.create_cluster_spec(num_workers=num_workers)
+      self._cluster_spec = test_base.create_cluster_spec(
+          num_workers=num_workers)
       pool = mp.Pool(num_workers)
-      
+
       backup_dir = tempfile.mkdtemp(dir=googletest.GetTempDir())
       with mp.Manager() as man:
         create_barrier = man.Barrier(num_workers)
-        args = [(self._cluster_spec, x, backup_dir, create_barrier) for x in range(num_workers)]
+        args = [(self._cluster_spec, x, backup_dir, create_barrier)
+                for x in range(num_workers)]
         pool.starmap(testWorkerTrainingState, args)
     except Exception as e:
       print(e, flush=True)

--- a/tensorflow/python/keras/distribute/worker_training_state_test.py
+++ b/tensorflow/python/keras/distribute/worker_training_state_test.py
@@ -105,16 +105,16 @@ class WorkerTrainingStateTest(test.TestCase, parameterized.TestCase):
       num_workers = 3
       self._cluster_spec = test_base.create_cluster_spec(
           num_workers=num_workers)
-      pool = mp.Pool(num_workers)
+      with mp.get_context("spawn").Pool() as pool:
 
-      backup_dir = tempfile.mkdtemp(dir=googletest.GetTempDir())
-      with mp.Manager() as man:
-        create_barrier = man.Barrier(num_workers)
-        args = [(self._cluster_spec, x, backup_dir, create_barrier)
-                for x in range(num_workers)]
-        pool.starmap(testWorkerTrainingState, args)
+        backup_dir = tempfile.mkdtemp(dir=googletest.GetTempDir())
+        with mp.Manager() as man:
+          create_barrier = man.Barrier(num_workers)
+          args = [(self._cluster_spec, x, backup_dir, create_barrier)
+                  for x in range(num_workers)]
+          pool.starmap(testWorkerTrainingState, args)
     except Exception as e:
-      print(e, flush=True)
+      #propagate error
       raise e
 
 


### PR DESCRIPTION
When trying to backup and restoring from the same location on multiple workers, delete_backup has a bug where get_matching_files_v2 fails because another worker has already previously deleted the folder.

This has been fixed because of this [issue](https://github.com/tensorflow/tensorflow/issues/43789) still keeping the test there.