### PR TITLE
Split env library so that there is only one instance of `Env::Default()`

### DIFF
--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -712,7 +712,6 @@ tf_cc_shared_object(
         "//tensorflow/core/common_runtime/gpu:gpu_runtime_impl",
         "//tensorflow/core/grappler/optimizers:custom_graph_optimizer_registry_impl",
         "//tensorflow/core:lib_internal_impl",
-        "//tensorflow/core/platform:env_impl",
         "//tensorflow/core/profiler:profiler_impl",
         "//tensorflow/stream_executor:stream_executor_impl",
         "//tensorflow:tf_framework_version_script.lds",

--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -712,6 +712,7 @@ tf_cc_shared_object(
         "//tensorflow/core/common_runtime/gpu:gpu_runtime_impl",
         "//tensorflow/core/grappler/optimizers:custom_graph_optimizer_registry_impl",
         "//tensorflow/core:lib_internal_impl",
+        "//tensorflow/core/platform:env_impl",
         "//tensorflow/core/profiler:profiler_impl",
         "//tensorflow/stream_executor:stream_executor_impl",
         "//tensorflow:tf_framework_version_script.lds",

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -2080,6 +2080,7 @@ tf_cuda_library(
         "//tensorflow/core/framework:tensor",
         "//tensorflow/core/framework:tensor_shape",
         "//tensorflow/core/kernels:bounds_check",
+        "//tensorflow/core/platform:env_impl",
         "//tensorflow/core/platform/default/build_config:platformlib",
         "//tensorflow/core/profiler/lib:annotated_traceme",
         "//tensorflow/core/profiler/lib:traceme",

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -1740,6 +1740,7 @@ cc_library(
         "//tensorflow/core/platform:denormal",
         "//tensorflow/core/platform:dynamic_annotations",
         "//tensorflow/core/platform:env",
+        "//tensorflow/core/platform:env_impl",
         "//tensorflow/core/platform:error",
         "//tensorflow/core/platform:errors",
         "//tensorflow/core/platform:file_statistics",

--- a/tensorflow/core/platform/BUILD
+++ b/tensorflow/core/platform/BUILD
@@ -251,6 +251,11 @@ cc_library(
 )
 
 cc_library(
+    name = "env_impl",
+    deps = tf_windows_aware_platform_deps("env_impl"),
+)
+
+cc_library(
     name = "env_time",
     textual_hdrs = ["env_time.h"],
     deps = tf_windows_aware_platform_deps("env_time"),

--- a/tensorflow/core/platform/default/BUILD
+++ b/tensorflow/core/platform/default/BUILD
@@ -74,7 +74,6 @@ cc_library(
 cc_library(
     name = "env",
     srcs = [
-        "env.cc",
         "posix_file_system.cc",
         "posix_file_system.h",
         "//tensorflow/core/platform:env.cc",
@@ -126,6 +125,21 @@ cc_library(
         "//third_party/eigen3",
         "@com_google_absl//absl/time",
         "@com_google_absl//absl/types:optional",
+    ],
+)
+
+cc_library(
+    name = "env_impl",
+    srcs = [
+        "env.cc",
+    ],
+    tags = [
+        "manual",
+        "no_oss",
+        "nobuilder",
+    ],
+    deps = [
+        ":env",
     ],
 )
 

--- a/tensorflow/core/platform/windows/BUILD
+++ b/tensorflow/core/platform/windows/BUILD
@@ -20,7 +20,6 @@ package(
 cc_library(
     name = "env",
     srcs = [
-        "env.cc",
         "windows_file_system.cc",
         "windows_file_system.h",
         "//tensorflow/core/platform:env.cc",
@@ -74,6 +73,21 @@ cc_library(
         "//third_party/eigen3",
         "@com_google_absl//absl/time",
         "@com_google_absl//absl/types:optional",
+    ],
+)
+
+cc_library(
+    name = "env_impl",
+    srcs = [
+        "env.cc",
+    ],
+    tags = [
+        "manual",
+        "no_oss",
+        "nobuilder",
+    ],
+    deps = [
+        ":env",
     ],
 )
 


### PR DESCRIPTION
While working on modular file systems, noticed that tensorflow's pip package
includes two copies of `Env::Default()` in two shared objects libraries.
One is in `libtensorflow_framework.so`, another is in `_pywrap_tensorflow_internal.so`.

Because of that, `Env::Default()` could return different instance depending on when
a modular file system is called. The Lookup vs. Register discrepancy may confuse the file
system to believe the scheme (e.g., `s3`/`gcs`) is not registered (actually registered
by another `Env::Default()`).

The duplication of `Env::Default()` is caused by the fact that `tensorflow/core/platform:env`
dependency is included in both `libtensorflow_framework.so` and `_pywrap_tensorflow_internal.so`.
in bazel indirectly.

There are two many dpendency graph component in between `tensorflow/core/platform:env`
and `libtensorflow_framework.so`/`_pywrap_tensorflow_internal.so` in bazel.
As a result this PR tries to address the issue by split out the `Env::Default()` implementation
out and only link it with `libtensorflow_framework.so` to guarantee `libtensorflow_framework.so`
is the only place to include `Env::Default()`.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>