### PR TITLE
Remove error message if >1 DataAdapter can handle data 

### DIFF
--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -264,7 +264,7 @@ class CallbackList(object):
 
     if self._progbar is None and add_progbar:
       self._progbar = ProgbarLogger(count_mode='steps')
-      self.callbacks.append(self._progbar)
+      self.callbacks.insert(0, self._progbar)
 
     if self._history is None and add_history:
       self._history = History()

--- a/tensorflow/python/keras/engine/data_adapter.py
+++ b/tensorflow/python/keras/engine/data_adapter.py
@@ -962,12 +962,6 @@ def select_data_adapter(x, y):
         "Failed to find data adapter that can handle "
         "input: {}, {}".format(
             _type_name(x), _type_name(y)))
-  elif len(adapter_cls) > 1:
-    raise RuntimeError(
-        "Data adapters should be mutually exclusive for "
-        "handling inputs. Found multiple adapters {} to handle "
-        "input: {}, {}".format(
-            adapter_cls, _type_name(x), _type_name(y)))
   return adapter_cls[0]
 
 


### PR DESCRIPTION
This issue was touched upon in [1](https://github.com/tensorflow/tensorflow/issues/41328), [2](https://github.com/tensorflow/tensorflow/issues/33811) and [3](https://github.com/tensorflow/tensorflow/issues/33734). I believe that it should be handled differently:

If there is more than single DataAdapter which can handle certain data - great, just pick the best of them and return it from the function. It should not be the user problem if developers made adapters that can handle diverse types of data.
If some DataAdapters better fit than others. they can be prioritized by changing order in `ALL_ADAPTER_CLS`. Alternatively, adapters should be selected by type of data, with 1:1 clear match of data type and adapter.

Here is an example code generating this error.
```
import tensorflow as tf

features =  tf.random.normal(shape=(100, 1, 10))
labels = tf.random.normal((100,1,1))
dataset = tf.data.Dataset.from_tensor_slices((features,labels))
ds_iter = iter(dataset) # tensorflow.python.data.ops.iterator_ops.OwnedIterator
features.shape, labels.shape

x = tf.keras.layers.Input(shape=[10])
y_pred = tf.keras.layers.Dense(1, activation='sigmoid', name="L0")(x)
model = tf.keras.Model(x, y_pred)
model.compile(optimizer='sgd', loss='mse',)
model.fit(ds_iter, epochs=1)
```

The code above triggers error `RuntimeError: Data adapters should be mutually exclusive for handling inputs`, however this is a good kind of problem to have. There are 2 adapters that claim ability to  handle such iterator: `CompositeTensorDataAdapter` and `GeneratorDataAdapter`.

I suggest not to throw `RuntimeError: Data adapters should be mutually exclusive for handling inputs ` but instead just return `adapter_cls[0]`. The change requires deleting [5 lines](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/engine/data_adapter.py#L958-L96) in `tf.python.keras.engine.data_adapter.select_data_adapter`


Later I ran tests with `tensorflow.python.data.ops.iterator_ops.OwnedIterator` forcing it to choose one of the DataAdapters:
1) `GeneratorDataAdapter` works fine with it,

2) `CompositeTensorDataAdapter` fails with error `AttributeError: 'IteratorSpec' object has no attribute '_to_batched_tensor_list'` [error stack here](https://pastebin.com/g1RxEhdc) Apparently some change is needed either in `CompositeTensorDataAdapter.can_handle()` or in the handling process itself.