### PR TITLE
[Intel Mkl]  Fixed auto mixed precision bug ,Ops  have more than one attr_type(like FusedBatchNorm )

### DIFF
--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision.cc
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision.cc
@@ -965,6 +965,7 @@ class AutoMixedPrecisionImpl {
   bool NodeImplicitlyReadsNonResourceVariable(const NodeDef& node) const;
   void ConvertBatchNormOpsToV2();
   bool SupportsF16(const NodeTypeId& node_type) const;
+  bool SupportsF16DataType(const NodeTypeId& node_type) const;
   const NodeTypeId* GetTensorListFloat32NodeTypeId(const NodeDef& node) const;
   bool IsSourceOrSinkOp(const string& op) const;
   void FindFloat32TensorListOpClustersAndDenylistUnsafe(
@@ -974,6 +975,7 @@ class AutoMixedPrecisionImpl {
       const absl::flat_hash_set<const NodeDef*>& tensor_list_nodes,
       std::vector<NodeTypeIdEdge>* implicit_data_edges) const;
   void AddAllowlistOps(absl::flat_hash_set<int>* allow_set) const;
+  void RemoveAllowsetWithFp32(absl::flat_hash_set<int>* allow_set) const;
   void PropagateDenyFwdThroughClearAndInfer(
       absl::flat_hash_set<int>* deny_set) const;
   void ForceColorMatchBetweenTensorListOps(
@@ -1200,6 +1202,14 @@ bool AutoMixedPrecisionImpl::SupportsF16(const NodeTypeId& node_type) const {
          NodeHasF16KernelForTypeAttr(*node_type.node, node_type.type_attr);
 }
 
+bool AutoMixedPrecisionImpl::SupportsF16DataType(const NodeTypeId& node_type) const {
+  const OpDef* op_def;
+  Status status =
+      OpRegistry::Global()->LookUpOpDef(node_type.node->op(), &op_def);
+  if (!status.ok()) return false;
+  return AllowedDataTypes(*op_def, node_type.type_attr).Contains(target_dtype_);
+}
+
 // TODO(mconley): Make this change the node's name (to aid debugging). Need to
 // make sure that doing this won't break anything.
 void AutoMixedPrecisionImpl::ConvertBatchNormOpsToV2() {
@@ -1365,6 +1375,11 @@ Status AutoMixedPrecisionImpl::Optimize() {
              "clearlist ops";
   PropagateAllowThroughClear(deny_set, &allow_set);
   VLOG(2) << "Finished pass 4";
+
+  VLOG(2) << "Beginning pass 5 to remove some nodes which could not be changed to F16"
+             "from allow set";
+  RemoveAllowsetWithFp32(&allow_set);
+  VLOG(2) << "Finished pass 5";
 
   VLOG(2) << "Forcing color match between data structure ops";
   for (const auto& cluster : tensor_list_clusters) {
@@ -1681,6 +1696,25 @@ void AutoMixedPrecisionImpl::PropagateAllowThroughClear(
                     << item.node->name() << " ALLOW";
           }
         }));
+  }
+}
+
+// If ops have one or more type_attr, But this type_attr could not be converted to F16.
+// Such as FusedBatchNormV2/FusedBatchNormV3, its type_attr 'U' only support float.
+// So we will remove this node from allow_set.
+void AutoMixedPrecisionImpl::RemoveAllowsetWithFp32(
+    absl::flat_hash_set<int>* allow_set) const {
+  for (int root_idx = 0; root_idx < graph_type_view_.num_nodes(); ++root_idx) {
+  const NodeTypeId& root = *graph_type_view_.GetNode(root_idx);
+    if (f16_allowlist_.count(root.node->op()) && allow_set->count(root_idx) &&
+        !SupportsF16DataType(root)) {
+      auto erased = allow_set->erase(root_idx);
+      if (VLOG_IS_ON(2) && erased) {
+        VLOG(2) << "UnPainting type " << root.type_attr.DebugString()
+                << " of node " << root.node->name() << " ALLOW because its op "
+                << root.node->op() << " is not support F16 DataType";
+        }
+    }
   }
 }
 


### PR DESCRIPTION
 
**this pr aim to fixed bf16 op have more than one attr_type problems, like FusedBatchNormV2 and FusedBatchNormV3, it has type attr "U", "U" only  support float32, but if we add this op to allow_list, it will add the idnex of attr_type "U"  to allow_set, this will encount an error.**

Using bfloat16 of FusedBatchNormV2 will encount below problems:
- FusedBatchNorm's input with "U" type only support float32, but not support bf16.
- After using bf16 for Resnet V2 101 and Resnet V2 50/101 , if add FusedBatchNormV2 into ALLOWLIST,  it will add more Cast op, this can greatly affect performance.

this pr is to fix FusedBatchNormV2/FusedBatchNormV3  with bf16 BUG,

Below table is model's **throughput** data(BatchSize = 128, Intel CPU）

the throughput  compares with FP32 model.
| model / fps |  Fp32 |  BF16(origin)| BF16 (fix FusedBatchNormV2 bug)|
|---|---|---| --- |
| Resnet v2 50 | 1| 0.77|  1.58|
|Resnet v2 101 | 1 | 0.81 | 1.773|

After fix this bug, the thoughput speed up **~1.6x** than float32.

Below is Resnet **acccuracy **in imagenet dataset:

| model / (top1/top5)|  Fp32 |  BF16(origin)| BF16 (fix FusedBatchNormV2 bug)|
|---|---|---| --- |
| Resnet v2 50 | 0.6964/0.8948| 0.6988/0.8953|  0.6985/0.8953|
|Resnet v2 101 | 0.7187/0.9059 | 0.7207/0.9068| 0.7205/0.9068|


Why need I add a new pass?:
- if customer add FusedBatchNormV2/FusedBatchNormV3 in allow_list, attr_type 'U' only support float, it maybe add cast in their type U node(like mean, offset, variance and scale). 


I run a little case to show the result:  

 I run a test for conv_bn. used default set for ALLOWLIST. the below picture is bf16 pb。
![image](https://user-images.githubusercontent.com/35016185/94387011-7a561880-017b-11eb-8c5b-0ac31fadde52.png)



after I add FusedBatchNormV3 to ALLOWLIST, it will add more redundant Cast for FusedBatchnormV3(This cast will be added in FusedBatchNormV3  input of  type "U" ,  as same as FusedBatchNormV2)

![image](https://user-images.githubusercontent.com/35016185/94387196-010af580-017c-11eb-90ce-653d35644f78.png)


After I fixed this bug, and add FusedBatchNormV3 to ALLOWLIST, the result is;
![Screenshot 2020-09-28 123759](https://user-images.githubusercontent.com/35016185/94391385-e2aaf700-0187-11eb-8e7d-781e44ae8ca9.png)

The difference with default set( not add FusedBatchNormV3 into ALLOWLIST, see the first picture) is **between Conv2D 
 and FusedBatchNormV3 have no `cast`, but have `cast` in  FusedBatchNormV3  and Identity,  in first picture, it will add `cast`    between Conv2D  and FusedBatchNormV3** 
