### PR TITLE
Improve documentation for tf.linalg.qr

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_Qr.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_Qr.pbtxt
@@ -34,6 +34,10 @@ END
 Computes the QR decomposition of each inner matrix in `tensor` such that
 `tensor[..., :, :] = q[..., :, :] * r[..., :,:])`
 
+Currently, the gradient for the QR decomposition is well-defined only when
+the first `P` columns of the inner matrix are linearly independent, where
+`P` is the minimum of `M` and `N`, the 2 inner-most dimmensions of `tensor`.
+
 ```python
 # a is a tensor.
 # q is a tensor of orthonormal matrices.

--- a/tensorflow/python/ops/linalg_grad.py
+++ b/tensorflow/python/ops/linalg_grad.py
@@ -524,6 +524,7 @@ def _QrGrad(op, dq, dr):
     return _QrGradSquareAndDeepMatrices(q, r, dq, dr)
 
   # Partition a = [x, y], r = [u, v] and reduce to the square case
+  # The methodology is explained in detail in https://arxiv.org/abs/2009.10071
   a = op.inputs[0]
   y = a[..., :, num_rows:]
   u = r[..., :, :num_rows]


### PR DESCRIPTION
Currently, there is no user documentation for the backward method in tf.linalg.qr.

The user can backpropagate through the qr factorization and they should know what assumptions (limitations) are being made by the autodiff methodology, as detailed in the reference document:

[QR and LQ Decomposition Matrix Backpropagation Algorithms for Square, Wide, and Deep Matrices and Their Software Implementation](https://arxiv.org/abs/2009.10071)