### PR TITLE
[ROCm] Adding bsdmainutils to the install list for ROCm docker containers.

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -25,6 +25,7 @@ RUN bin/bash -c 'if [[ $ROCM_DEB_REPO == http://repo.radeon.com/rocm/*  ]] ; the
 # Install misc pkgs
 RUN apt-get update --allow-insecure-repositories && DEBIAN_FRONTEND=noninteractive apt-get install -y \
   build-essential \
+  bsdmainutils \
   clang-6.0 \
   clang-format-6.0 \
   clang-tidy-6.0 \


### PR DESCRIPTION
For the ROCm TensorFlow build, the "hexdump" utility is required for the tool flow used by MLIR generated GPU kernels. 

The "hexdump" utility is part of the "bsdmainutils" package and that package is currently not installed in the ROCm docker container. This change simply adds the "bsdmainutils" package to the install list

------------------------------------------

/cc @cheshire @chsigg @nvining-work 