### PR TITLE
In case hdfsBuilderConnect returns nullptr

### DIFF
--- a/tensorflow/c/experimental/filesystem/plugins/hadoop/hadoop_filesystem.cc
+++ b/tensorflow/c/experimental/filesystem/plugins/hadoop/hadoop_filesystem.cc
@@ -209,14 +209,15 @@ hdfsFS Connect(tf_hadoop_filesystem::HadoopFile* hadoop_file,
   }
   if (hadoop_file->connection_cache.find(cacheKey) ==
       hadoop_file->connection_cache.end()) {
-    hadoop_file->connection_cache[cacheKey] =
-        libhdfs->hdfsBuilderConnect(builder);
+    auto cacheFs = libhdfs->hdfsBuilderConnect(builder);
+    if (cacheFs == nullptr) {
+      TF_SetStatusFromIOError(status, TF_NOT_FOUND, strerror(errno));
+      return cacheFs;
+    }
+    hadoop_file->connection_cache[cacheKey] = cacheFs;
   }
   auto fs = hadoop_file->connection_cache[cacheKey];
-  if (fs == nullptr)
-    TF_SetStatusFromIOError(status, TF_NOT_FOUND, strerror(errno));
-  else
-    TF_SetStatus(status, TF_OK, "");
+  TF_SetStatus(status, TF_OK, "");
   return fs;
 }
 

--- a/tensorflow/core/platform/hadoop/hadoop_file_system.cc
+++ b/tensorflow/core/platform/hadoop/hadoop_file_system.cc
@@ -191,6 +191,7 @@ Status HadoopFileSystem::Connect(StringPiece fname, hdfsFS* fs) {
                                       nn.empty() ? "default" : nn.c_str());
     cacheKey += nn;
   }
+  mtx_.lock();
   if (connectionCache_.find(cacheKey) == connectionCache_.end()) {
     hdfsFS cacheFs = libhdfs()->hdfsBuilderConnect(builder);
     if (cacheFs == nullptr) {
@@ -199,6 +200,7 @@ Status HadoopFileSystem::Connect(StringPiece fname, hdfsFS* fs) {
     connectionCache_[cacheKey] = cacheFs;
   }
   *fs = connectionCache_[cacheKey];
+  mtx_.unlock();
   return Status::OK();
 }
 

--- a/tensorflow/core/platform/hadoop/hadoop_file_system.cc
+++ b/tensorflow/core/platform/hadoop/hadoop_file_system.cc
@@ -192,12 +192,13 @@ Status HadoopFileSystem::Connect(StringPiece fname, hdfsFS* fs) {
     cacheKey += nn;
   }
   if (connectionCache_.find(cacheKey) == connectionCache_.end()) {
-    connectionCache_[cacheKey] = libhdfs()->hdfsBuilderConnect(builder);
+    hdfsFS cacheFs = libhdfs()->hdfsBuilderConnect(builder);
+    if (cacheFs == nullptr) {
+      return errors::NotFound(strerror(errno));
+    }
+    connectionCache_[cacheKey] = cacheFs;
   }
   *fs = connectionCache_[cacheKey];
-  if (*fs == nullptr) {
-    return errors::NotFound(strerror(errno));
-  }
   return Status::OK();
 }
 

--- a/tensorflow/core/platform/hadoop/hadoop_file_system.h
+++ b/tensorflow/core/platform/hadoop/hadoop_file_system.h
@@ -78,6 +78,7 @@ class HadoopFileSystem : public FileSystem {
 
  private:
   std::map<std::string, hdfsFS> connectionCache_;
+  std::mutex mtx_;
   Status Connect(StringPiece fname, hdfsFS* fs);
 };
 

--- a/tensorflow/core/platform/hadoop/hadoop_file_system.h
+++ b/tensorflow/core/platform/hadoop/hadoop_file_system.h
@@ -77,8 +77,8 @@ class HadoopFileSystem : public FileSystem {
   string TranslateName(const string& name) const override;
 
  private:
-  std::map<std::string, hdfsFS> connectionCache_;
-  std::mutex mtx_;
+  mutable mutex mu_;
+  std::map<std::string, hdfsFS> connectionCache_ TF_GUARDED_BY(mu_);
   Status Connect(StringPiece fname, hdfsFS* fs);
 };
 

--- a/tensorflow/core/platform/hadoop/hadoop_file_system.h
+++ b/tensorflow/core/platform/hadoop/hadoop_file_system.h
@@ -77,7 +77,7 @@ class HadoopFileSystem : public FileSystem {
   string TranslateName(const string& name) const override;
 
  private:
-  mutable mutex mu_;
+  mutex mu_;
   std::map<std::string, hdfsFS> connectionCache_ TF_GUARDED_BY(mu_);
   Status Connect(StringPiece fname, hdfsFS* fs);
 };


### PR DESCRIPTION
In case [hdfsBuilderConnect returns nullptr](https://github.com/apache/hadoop/blob/release-3.3.0-RC0/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/include/hdfs/hdfs.h#L261)

```c
    /** 
     * Connect to HDFS using the parameters defined by the builder.
     *
     * The HDFS builder will be freed, whether or not the connection was
     * successful.
     *
     * Every successful call to hdfsBuilderConnect should be matched with a call
     * to hdfsDisconnect, when the hdfsFS is no longer needed.
     *
     * @param bld    The HDFS builder
     * @return       Returns a handle to the filesystem, or NULL on error.
     */
     LIBHDFS_EXTERNAL
     hdfsFS hdfsBuilderConnect(struct hdfsBuilder *bld);
```