### PR TITLE
add cuda compute capability 8 to profiler hardware type utils

### DIFF
--- a/tensorflow/core/profiler/utils/hardware_type_utils.cc
+++ b/tensorflow/core/profiler/utils/hardware_type_utils.cc
@@ -57,6 +57,18 @@ uint32 GetFmaMaxThroughputPerSMPerCycle(const DeviceCapabilities& device_cap) {
       n_fp32_cores = 64;
       n_tc_cores = 8;
       break;
+    case 8:
+      // Ampere
+      if (device_cap.compute_capability().minor() >= 6) {
+        // Ampere SM86
+        n_fp32_cores = 128;
+      }
+      else {
+        // Ampere SM80
+        n_fp32_cores = 64;
+      }
+      n_tc_cores = 4;
+      break;
     default:
       LOG(ERROR) << "Invalid GPU compute capability.";
       break;


### PR DESCRIPTION
- Add case for CUDA compute capability 8.0 and 8.6 