### PR TITLE
Adding README.md to TFLite evaluation/tasks

### DIFF
--- a/tensorflow/lite/tools/evaluation/tasks/README.md
+++ b/tensorflow/lite/tools/evaluation/tasks/README.md
@@ -2,13 +2,16 @@
 
 This page describes how you can check the accuracy of quantized models to verify that any degradation in accuracy is within acceptable limits.
 
+## Accuracy & correctness
+TensorFlow Lite has two types of tooling to measure how accurately a delegate behaves for a given model: Task-Based and Task-Agnostic. 
+
+For more information visit the [Tools for Evaluation](https://www.tensorflow.org/lite/performance/delegates#tools_for_evaluation) page.
+
 ## Tools
 There are three different binaries which are supported. A brief description of each is provided below.
 
 ### [Inference Diff Tool](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/tools/evaluation/tasks/inference_diff#inference-diff-tool)
 This binary compares TensorFlow Lite execution in single-threaded CPU inference and user-defined inference.
-
-
 
 ### [Image Classification Evaluation](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/tools/evaluation/tasks/imagenet_image_classification#image-classification-evaluation-based-on-ilsvrc-2012-task)
 This binary evaluates TensorFlow Lite models trained for the [ILSVRC 2012 image classification task.](http://www.image-net.org/challenges/LSVRC/2012/)

--- a/tensorflow/lite/tools/evaluation/tasks/README.md
+++ b/tensorflow/lite/tools/evaluation/tasks/README.md
@@ -5,17 +5,13 @@ This page describes how you can check the accuracy of quantized models to verify
 ## Tools
 There are three different binaries which are supported. A brief description of each is provided below.
 
-### Inference Diff Tool
+### [Inference Diff Tool](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/tools/evaluation/tasks/inference_diff#inference-diff-tool)
 This binary compares TensorFlow Lite execution in single-threaded CPU inference and user-defined inference.
 
-### Image Classification Evaluation
+
+
+### [Image Classification Evaluation](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/tools/evaluation/tasks/imagenet_image_classification#image-classification-evaluation-based-on-ilsvrc-2012-task)
 This binary evaluates TensorFlow Lite models trained for the [ILSVRC 2012 image classification task.](http://www.image-net.org/challenges/LSVRC/2012/)
 
-### Object Detection Evaluation
+### [Object Detection Evaluation](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/tools/evaluation/tasks/coco_object_detection#object-detection-evaluation-using-the-2014-coco-minival-dataset)
 This binary evaluates TensorFlow Lite models trained for the bounding box-based [COCO Object Detection](https://cocodataset.org/#detection-eval) task.
-
-For a more detailed specification of each tool refer to:
-
-- [Inference Diff tool](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/tools/evaluation/tasks/inference_diff#inference-diff-tool)
-- [Image Classification evaluation based on ILSVRC 2012 task](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/tools/evaluation/tasks/imagenet_image_classification#image-classification-evaluation-based-on-ilsvrc-2012-task)
-- [Object Detection evaluation using the 2014 COCO minival dataset](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/tools/evaluation/tasks/coco_object_detection#object-detection-evaluation-using-the-2014-coco-minival-dataset)

--- a/tensorflow/lite/tools/evaluation/tasks/README.md
+++ b/tensorflow/lite/tools/evaluation/tasks/README.md
@@ -27,4 +27,4 @@ This binary evaluates TensorFlow Lite models trained for the bounding box-based 
 
 ***
 
-For more information visit the TensorFlow Lite guide on [Tools for Evaluation](https://www.tensorflow.org/lite/performance/delegates#tools_for_evaluation) page.
+For more information visit the TensorFlow Lite guide on [Accuracy & correctness](https://www.tensorflow.org/lite/performance/delegates#accuracy_correctness) page.

--- a/tensorflow/lite/tools/evaluation/tasks/README.md
+++ b/tensorflow/lite/tools/evaluation/tasks/README.md
@@ -1,0 +1,21 @@
+# TFLite Model Task Evaluation
+
+This page describes how you can check the accuracy of quantized models to verify that any degradation in accuracy is within acceptable limits.
+
+## Tools
+There are three different binaries which are supported. A breif description of each is provided below.
+
+### Inference Diff Tool
+This binary compares TensorFlow Lite execution in single-threaded CPU inference and user-defined infrence.
+
+### Image Classification Evaluation
+This binary evaluates TensorFlow Lite models trained for the [ILSVRC 2012 image classification task.](http://www.image-net.org/challenges/LSVRC/2012/)
+
+### Object Detection Evaluation
+This binary evaluates TensorFlow Lite models trained for the bounding box-based [COCO Object Detection](https://cocodataset.org/#detection-eval) task.
+
+For a more detailed specification of each tool refer to:
+
+- [Inference Diff tool](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/tools/evaluation/tasks/inference_diff#inference-diff-tool)
+- [Image Classification evaluation based on ILSVRC 2012 task](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/tools/evaluation/tasks/imagenet_image_classification#image-classification-evaluation-based-on-ilsvrc-2012-task)
+- [Object Detection evaluation using the 2014 COCO minival dataset](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/tools/evaluation/tasks/coco_object_detection#object-detection-evaluation-using-the-2014-coco-minival-dataset)

--- a/tensorflow/lite/tools/evaluation/tasks/README.md
+++ b/tensorflow/lite/tools/evaluation/tasks/README.md
@@ -3,10 +3,10 @@
 This page describes how you can check the accuracy of quantized models to verify that any degradation in accuracy is within acceptable limits.
 
 ## Tools
-There are three different binaries which are supported. A breif description of each is provided below.
+There are three different binaries which are supported. A brief description of each is provided below.
 
 ### Inference Diff Tool
-This binary compares TensorFlow Lite execution in single-threaded CPU inference and user-defined infrence.
+This binary compares TensorFlow Lite execution in single-threaded CPU inference and user-defined inference.
 
 ### Image Classification Evaluation
 This binary evaluates TensorFlow Lite models trained for the [ILSVRC 2012 image classification task.](http://www.image-net.org/challenges/LSVRC/2012/)

--- a/tensorflow/lite/tools/evaluation/tasks/README.md
+++ b/tensorflow/lite/tools/evaluation/tasks/README.md
@@ -5,7 +5,13 @@ This page describes how you can check the accuracy of quantized models to verify
 ## Accuracy & correctness
 TensorFlow Lite has two types of tooling to measure how accurately a delegate behaves for a given model: Task-Based and Task-Agnostic. 
 
-For more information visit the [Tools for Evaluation](https://www.tensorflow.org/lite/performance/delegates#tools_for_evaluation) page.
+**Task-Based Evaluation**
+TFLite has two tools to evaluate correctness on two image-based tasks:
+- [ILSVRC 2012](http://image-net.org/challenges/LSVRC/2012/) (Image Classification) with top-K accuracy
+- [COCO Object Detection](https://cocodataset.org/#detection-2020) (w/ bounding boxes) with mean Average Precision (mAP)
+
+**Task-Agnostic Evaluation**
+For tasks where there isn't an established on-device evaluation tool, or if you are experimenting with custom models, TensorFlow Lite has the Inference Diff tool.
 
 ## Tools
 There are three different binaries which are supported. A brief description of each is provided below.
@@ -18,3 +24,7 @@ This binary evaluates TensorFlow Lite models trained for the [ILSVRC 2012 image 
 
 ### [Object Detection Evaluation](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/tools/evaluation/tasks/coco_object_detection#object-detection-evaluation-using-the-2014-coco-minival-dataset)
 This binary evaluates TensorFlow Lite models trained for the bounding box-based [COCO Object Detection](https://cocodataset.org/#detection-eval) task.
+
+***
+
+For more information visit the TensorFlow Lite guide on [Tools for Evaluation](https://www.tensorflow.org/lite/performance/delegates#tools_for_evaluation) page.


### PR DESCRIPTION
PR related to #43294. 

Adding documentation under `evaluation/tasks` to guide users who are directed from the [TFLite documentation guide](https://www.tensorflow.org/lite/performance/post_training_quantization#model_accuracy).