### PR TITLE
add file_paths attr to image dataset

### DIFF
--- a/tensorflow/python/keras/preprocessing/image_dataset.py
+++ b/tensorflow/python/keras/preprocessing/image_dataset.py
@@ -203,6 +203,8 @@ def image_dataset_from_directory(directory,
   dataset = dataset.batch(batch_size)
   # Users may need to reference `class_names`.
   dataset.class_names = class_names
+  # Include file paths for images as attribute.
+  dataset.file_paths = image_paths
   return dataset
 
 


### PR DESCRIPTION
Adding an attribute (file_paths) to the dataset returned from image_dataset_from_directory to enable access to the image filepaths.
Resolves tensorflow/tensorflow/#40203