### PR TITLE
[Draft] Adding Multi device iterator Serialization and De-serialization

### DIFF
--- a/tensorflow/core/ops/dataset_ops.cc
+++ b/tensorflow/core/ops/dataset_ops.cc
@@ -1001,4 +1001,18 @@ REGISTER_OP("MultiDeviceIteratorFromStringHandle")
     .Attr("output_shapes: list(shape) >= 0 = []")
     .SetShapeFn(shape_inference::ScalarShape);
 
+REGISTER_OP("SerializeMultiDeviceIterator")
+    .Input("resource_handle: resource")
+    .Attr("external_state_policy: int = 0")
+    .Output("serialized: variant")
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      c->set_output(0, c->Vector(c->UnknownDim()));
+      return Status::OK();
+    });
+
+REGISTER_OP("DeserializeMultiDeviceIterator")
+    .Input("resource_handle: resource")
+    .Input("serialized: variant")
+    .SetShapeFn(shape_inference::NoOutputs);
+
 }  // namespace tensorflow

--- a/tensorflow/python/data/kernel_tests/BUILD
+++ b/tensorflow/python/data/kernel_tests/BUILD
@@ -448,7 +448,7 @@ cuda_py_test(
     srcs = ["multi_device_iterator_test.py"],
     tags = [
         "no_gpu",  #TODO(b/141255188): Enable test after bug is resolved.
-        "no_oss",
+        #"no_oss",
         "no_windows_gpu",
     ],
     deps = [


### PR DESCRIPTION
Context: 
The idea is to be able to save and restore iterators (The iterators that can be saved) for multi worker training. This will allow for training to be resumed mid-epoch instead. This reduces wasted compute cycles when restarting training jobs.
With this change the Backup and restore keras callback can include the iterator (if supported), and actually restore the keras model to a state mid epoch also.

Description:
Adding a serialization and de-serialization to multi device iterator.
Added Save and Restore in both the Multi Device Resource and the Multi Device Buffer.

Design.
New operators added for Multi Device Iterators to serialize and de-serialize
Multi device buffer will save its buffer and host_iterator.
Multi device Resource will restore by creating a new buffer because the host iterator is const.
It will then call the multi device buffer to restore its own buffer.

Test.
Using a Range Dataset(10)
Save after 0-5, then restore in a new session, and verify 6-9
