### PR TITLE
[tf.data server] prevent restart of the dispatcher server w/o fault-tolerance, in the test bed

### DIFF
--- a/tensorflow/python/data/experimental/kernel_tests/data_service_test_base.py
+++ b/tensorflow/python/data/experimental/kernel_tests/data_service_test_base.py
@@ -25,7 +25,6 @@ from tensorflow.python.data.kernel_tests import test_base
 from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.framework import combinations
 from tensorflow.python.platform import googletest
-from tensorflow.python.framework import errors
 
 # This will be resolved to a tmp directory by `start_dispatch_server`.
 TMP_WORK_DIR = "tmp_work_dir_placeholder"

--- a/tensorflow/python/data/experimental/kernel_tests/data_service_test_base.py
+++ b/tensorflow/python/data/experimental/kernel_tests/data_service_test_base.py
@@ -117,10 +117,8 @@ class TestCluster(object):
   def restart_dispatcher(self):
     """Stops `dispatcher` and creates a new dispatcher with the same port.
 
-    When the dispatcher is restarted with `fault-tolerant_mode=False`,
-    the new dispatcher is unable to find the `dataset_id` of the already
-    created dataset and thus perpetually throws a warn message until it
-    times out. Thus, the test bed prevents this scenario.
+    Restarting is supported only when the dispatcher is configured with
+    `fault_tolerant_mode=True`.
     """
     if not self.dispatcher._config.fault_tolerant_mode:
       raise ValueError(


### PR DESCRIPTION
This PR is a follow up of https://github.com/tensorflow/tensorflow/pull/43691 and prevents a restart of the dispatcher if it has been configured without fault-tolerance. Failing to do so will lead to a perpetual stream of `warn` messages on a dispatcher restart and unnecessarily extend the testing time without an immediate exit.

@aaudiber until the enhancements are implemented to handle such scenarios (as per our discussion), this will help us in handling the upcoming test cases.