### PR TITLE
Fix bug: "Unsupported activation type for quantize-activation: 0"

### DIFF
--- a/tensorflow/lite/tools/optimize/quantize_model_test.cc
+++ b/tensorflow/lite/tools/optimize/quantize_model_test.cc
@@ -1001,6 +1001,7 @@ TEST_F(QuantizeMultiInputAddWithReshapeTest, VerifyAddQuantization) {
 class QuantizeConstInputTest : public QuantizeModelTest {
  protected:
   QuantizeConstInputTest() {
+    tensor_type_ = GetParam();
     input_model_ = ReadModel(internal::kConstInputAddModel);
     readonly_model_ = input_model_->GetModel();
     readonly_model_->UnPackTo(&model_);


### PR DESCRIPTION
When running unit tests from custom-op docker image, we got the following errors:
```
12:17:10  //tensorflow/lite/tools/optimize:quantize_model_test                     FAILED in 3 out of 3 in 0.3s
12:17:10    Stats over 3 runs: max = 0.3s, min = 0.2s, avg = 0.3s, dev = 0.1s
12:17:10      FAILED  QuantizeConstInputTestInst/QuantizeConstInputTest.VerifyConstOpInput/0 (0.0s)
12:17:10      FAILED  QuantizeConstInputTestInst/QuantizeConstInputTest.VerifyConstOpInput/1 (0.0s)
12:17:10  Test cases: finished with 118 passing and 2 failing out of 120 test cases
```

After investigating it, we have found that the fail can be fixed by properly accessing the parametrized test's parameter with the GetParam() method.