### PR TITLE
[XLA/GPU] clear operands for removed HLOs.

### DIFF
--- a/tensorflow/compiler/xla/service/hlo_computation.cc
+++ b/tensorflow/compiler/xla/service/hlo_computation.cc
@@ -315,6 +315,8 @@ Status HloComputation::RemoveInstructionImpl(HloInstruction* instruction,
   (*inst_it->second)->set_parent(nullptr);
   to_be_deleted_.emplace_back(inst_it->second->release());
   to_be_deleted_.back()->DetachFromOperandsAndUsers();
+  // Clear all operands to avoid Null operands.
+  to_be_deleted_.back()->RemoveAllOperands();
   to_be_deleted_.back()->MarkAsDead();
   instructions_.erase(inst_it->second);
   instruction_iterators_.erase(inst_it);

--- a/tensorflow/compiler/xla/service/hlo_instruction.h
+++ b/tensorflow/compiler/xla/service/hlo_instruction.h
@@ -1911,6 +1911,10 @@ class HloInstruction {
   // by factory methods.
   HloInstruction(HloOpcode opcode, const Shape& shape);
 
+  void RemoveAllOperands() {
+    operands_.clear();
+  }
+
   void RemoveOperandAt(int index) {
     operands_.erase(operands_.begin() + index);
   }


### PR DESCRIPTION
This avoids possible accesses to the Null operands.

Operands of a removed instruction is not cleared but only set to NULL. A more sound behavior should be to also clear the operands for the removed instructions, so that we avoid potential accesses to the NULL operands.

This fixed a crash case encountered by https://github.com/tensorflow/tensorflow/pull/43051.
