### PR TITLE
Fix TFLite quantization example

### DIFF
--- a/tensorflow/lite/g3doc/guide/get_started.md
+++ b/tensorflow/lite/g3doc/guide/get_started.md
@@ -274,7 +274,7 @@ import tensorflow as tf
 
 converter = tf.lite.TFLiteConverter.from_saved_model(saved_model_dir)
 converter.optimizations = [tf.lite.Optimize.DEFAULT]
-tflite_quant_model = converter.convert()
+tflite_quantized_model = converter.convert()
 open("converted_model.tflite", "wb").write(tflite_quantized_model)
 ```
 


### PR DESCRIPTION
The TFLite documentation at https://www.tensorflow.org/lite/guide/get_started#quantization contained a slight error. The name of the quantized model variable was `tflite_quant_model`, but on the line below it was used as `tflite_quantized_model`.

Also I think that the example could use the proper `with open(...)` pattern? I'll add it to this PR if you agree.