### PR TITLE
Fixed inputs not being cast to tuple

### DIFF
--- a/tensorflow/python/keras/layers/recurrent.py
+++ b/tensorflow/python/keras/layers/recurrent.py
@@ -2959,7 +2959,7 @@ def _standardize_args(inputs, initial_state, constants, num_constants):
     if len(inputs) > 1:
       inputs = tuple(inputs)
     else:
-      inputs = inputs[0]
+      inputs = tuple(inputs[0])
 
   def to_list_or_none(x):
     if x is None or isinstance(x, list):


### PR DESCRIPTION
Fix for #43773 

RNN's __call__  when deserialized from H5 and reconstructed from config will have the layers multiple inputs contained within a list instead of a tuple. This is due to the JSON decoder always creating lists when deserializing array. This change makes sure that its always typecast back to a tuple.