### PR TITLE
Update mobilenet_v3 performance table to correct markdown format

### DIFF
--- a/tensorflow/python/keras/applications/mobilenet_v3.py
+++ b/tensorflow/python/keras/applications/mobilenet_v3.py
@@ -61,14 +61,15 @@ BASE_DOCSTRING = """Instantiates the {name} architecture.
   The following table describes the performance of MobileNets:
   ------------------------------------------------------------------------
   MACs stands for Multiply Adds
-
-  |Classification Checkpoint|MACs(M)|Parameters(M)|Top1 Accuracy|Pixel1|CPU(ms)|
-  | [mobilenet_v3_large_1.0_224]              | 217 | 5.4 |   75.6   |   51.2  |
-  | [mobilenet_v3_large_0.75_224]             | 155 | 4.0 |   73.3   |   39.8  |
-  | [mobilenet_v3_large_minimalistic_1.0_224] | 209 | 3.9 |   72.3   |   44.1  |
-  | [mobilenet_v3_small_1.0_224]              | 66  | 2.9 |   68.1   |   15.8  |
-  | [mobilenet_v3_small_0.75_224]             | 44  | 2.4 |   65.4   |   12.8  |
-  | [mobilenet_v3_small_minimalistic_1.0_224] | 65  | 2.0 |   61.9   |   12.2  |
+  
+  |Classification Checkpoint|MACs(M)|Parameters(M)|Top1 Accuracy|Pixel1 CPU(ms)|
+  |---|---|---|---|---|
+  | mobilenet_v3_large_1.0_224              | 217 | 5.4 |   75.6   |   51.2  |
+  | mobilenet_v3_large_0.75_224             | 155 | 4.0 |   73.3   |   39.8  |
+  | mobilenet_v3_large_minimalistic_1.0_224 | 209 | 3.9 |   72.3   |   44.1  |
+  | mobilenet_v3_small_1.0_224              | 66  | 2.9 |   68.1   |   15.8  |
+  | mobilenet_v3_small_0.75_224             | 44  | 2.4 |   65.4   |   12.8  |
+  | mobilenet_v3_small_minimalistic_1.0_224 | 65  | 2.0 |   61.9   |   12.2  |
 
   The weights for all 6 models are obtained and translated from the Tensorflow
   checkpoints from TensorFlow checkpoints found [here]


### PR DESCRIPTION
Updated mobilenet_v3 performance table to correct markdown format which is shown at the official tensorflow api documents
https://www.tensorflow.org/api_docs/python/tf/keras/applications/MobileNetV3Large

This is current documentation
![image](https://user-images.githubusercontent.com/21135812/95040390-7b082500-070e-11eb-82d8-c7362289d0d1.png)

And this is expected table form written in correct markdown format
![image](https://user-images.githubusercontent.com/21135812/95040423-94a96c80-070e-11eb-83fb-f24d19876165.png)
