### PR TITLE
Updated documentation of TimeDistributed

### DIFF
--- a/tensorflow/python/keras/layers/wrappers.py
+++ b/tensorflow/python/keras/layers/wrappers.py
@@ -102,6 +102,9 @@ class TimeDistributed(Wrapper):
   >>> outputs.shape
   TensorShape([None, 10, 126, 126, 64])
 
+  Because `TimeDistributed` applies an instance of `Conv2D` to each of the
+  timestamps, the weights used at each timestamp are shared.
+
   Arguments:
     layer: a `tf.keras.layers.Layer` instance.
 

--- a/tensorflow/python/keras/layers/wrappers.py
+++ b/tensorflow/python/keras/layers/wrappers.py
@@ -93,8 +93,8 @@ class TimeDistributed(Wrapper):
   with `channels_last` data format, across 10 timesteps.
   The batch input shape is `(32, 10, 128, 128, 3)`.
 
-  You can then use `TimeDistributed` to apply the same `Conv2D` layer to each of the
-  10 timesteps, independently:
+  You can then use `TimeDistributed` to apply the same `Conv2D` layer to each
+  of the 10 timesteps, independently:
 
   >>> inputs = tf.keras.Input(shape=(10, 128, 128, 3))
   >>> conv_2d_layer = tf.keras.layers.Conv2D(64, (3, 3))

--- a/tensorflow/python/keras/layers/wrappers.py
+++ b/tensorflow/python/keras/layers/wrappers.py
@@ -93,7 +93,7 @@ class TimeDistributed(Wrapper):
   with `channels_last` data format, across 10 timesteps.
   The batch input shape is `(32, 10, 128, 128, 3)`.
 
-  You can then use `TimeDistributed` to apply a `Conv2D` layer to each of the
+  You can then use `TimeDistributed` to apply the same `Conv2D` layer to each of the
   10 timesteps, independently:
 
   >>> inputs = tf.keras.Input(shape=(10, 128, 128, 3))
@@ -103,7 +103,7 @@ class TimeDistributed(Wrapper):
   TensorShape([None, 10, 126, 126, 64])
 
   Because `TimeDistributed` applies an instance of `Conv2D` to each of the
-  timestamps, the weights used at each timestamp are shared.
+  timestamps, the same set of weights are used at each timestamp.
 
   Arguments:
     layer: a `tf.keras.layers.Layer` instance.

--- a/tensorflow/python/keras/layers/wrappers.py
+++ b/tensorflow/python/keras/layers/wrappers.py
@@ -102,7 +102,7 @@ class TimeDistributed(Wrapper):
   >>> outputs.shape
   TensorShape([None, 10, 126, 126, 64])
 
-  Because `TimeDistributed` applies an instance of `Conv2D` to each of the
+  Because `TimeDistributed` applies the same instance of `Conv2D` to each of the
   timestamps, the same set of weights are used at each timestamp.
 
   Arguments:


### PR DESCRIPTION
It is not clear that the weights are shared at the current documentation. I saw this question repeats at stack overflow (https://stackoverflow.com/questions/43265084/keras-timedistributed-are-weights-shared), and I thought it is worth writing that explicitly.