### PR TITLE
Set the "nightly" branch to master HEAD every day

### DIFF
--- a/.github/workflows/update-nightly.yml
+++ b/.github/workflows/update-nightly.yml
@@ -1,0 +1,13 @@
+on:
+  workflow_dispatch:  # Allow manual triggers
+  schedule:
+    - cron: 0 4 * * *  # 4am UTC is 9pm PDT and 8pm PST
+name: Set nightly branch to master HEAD
+jobs:
+  master-to-nightly:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: zofrex/mirror-branch@v1
+      name: Set nightly branch to master HEAD
+      with:
+        target-branch: 'nightly'


### PR DESCRIPTION
This GitHub Actions workflow runs every night at 8pm PDT / 9pm PST, and
sets the "nightly" branch to whatever master HEAD is at that time. The
TensorFlow team uses this branch for our suite of nightly tests, NOT for
the "tf-nightly" releases.