### PR TITLE
[XLA/GPU] Size-constrained buffer allocation.

### DIFF
--- a/tensorflow/compiler/xla/debug_options_flags.cc
+++ b/tensorflow/compiler/xla/debug_options_flags.cc
@@ -73,6 +73,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_deterministic_reductions(false);
   opts.set_xla_cpu_enable_xprof_traceme(false);
   opts.set_xla_gpu_unsafe_fallback_to_driver_on_ptxas_not_found(false);
+  opts.set_xla_multiheap_size_constraint_per_heap(-1);
 
   return opts;
 }
@@ -571,6 +572,16 @@ static void AllocateFlags() {
       "that falling back to the driver can have drawbacks like using more "
       "memory and/or other bugs during compilation, so we recommend setting "
       "this flag to false."));
+  flag_objects->push_back(tensorflow::Flag(
+      "xla_multiheap_size_constraint_per_heap",
+      int32_setter_for(
+          &DebugOptions::set_xla_multiheap_size_constraint_per_heap),
+      flag_values->xla_multiheap_size_constraint_per_heap(),
+      "Generates multiple heaps (i.e., temp buffers) with a size "
+      "constraint on each heap to avoid Out-of-Memory due to memory "
+      "fragmentation. The constraint is soft, so it works with tensors "
+      "larger than the given constraint size."));
+
   ParseFlagsFromEnvAndDieIfUnknown("XLA_FLAGS", *flag_objects);
 }
 

--- a/tensorflow/compiler/xla/debug_options_flags.cc
+++ b/tensorflow/compiler/xla/debug_options_flags.cc
@@ -580,7 +580,8 @@ static void AllocateFlags() {
       "Generates multiple heaps (i.e., temp buffers) with a size "
       "constraint on each heap to avoid Out-of-Memory due to memory "
       "fragmentation. The constraint is soft, so it works with tensors "
-      "larger than the given constraint size."));
+      "larger than the given constraint size. -1 corresponds to no "
+      "constraints."));
 
   ParseFlagsFromEnvAndDieIfUnknown("XLA_FLAGS", *flag_objects);
 }

--- a/tensorflow/compiler/xla/service/buffer_assignment.cc
+++ b/tensorflow/compiler/xla/service/buffer_assignment.cc
@@ -1542,10 +1542,8 @@ void BufferAssigner::AssignBuffersFromHeapSimulator(
     }
     // Compute peak_buffers only when the multiheap mode is off. Simply return
     // an empty vector in the multiheap mode.
-    if (assignment->multiheap_size_constraint_per_heap() == -1) {
-      allocation->peak_buffers_ =
-          ComputePeakMemoryLogicalBuffers(*allocation, result.debug_trace);
-    }
+    allocation->peak_buffers_ =
+        ComputePeakMemoryLogicalBuffers(*allocation, result.debug_trace);
 
     XLA_VLOG_LINES(2, allocation->ToString());
 

--- a/tensorflow/compiler/xla/service/buffer_assignment.cc
+++ b/tensorflow/compiler/xla/service/buffer_assignment.cc
@@ -608,7 +608,7 @@ void BufferAssignment::AddAssignment(BufferAllocation* allocation,
 void BufferAssignment::CombineTempAllocations() {
   VLOG(1) << "CombineTempAllocations()";
   // Stores the combined allocations.
-  std::vector<BufferAllocation> combined_allocations;
+  std::deque<BufferAllocation> combined_allocations;
   // Holds the pointer to a combined allocation of each color, if any.
   flat_hash_map<BufferValue::Color, BufferAllocation*> combined_allocation_map;
 

--- a/tensorflow/compiler/xla/service/buffer_assignment.cc
+++ b/tensorflow/compiler/xla/service/buffer_assignment.cc
@@ -1540,8 +1540,6 @@ void BufferAssigner::AssignBuffersFromHeapSimulator(
       const HeapSimulator::Chunk& chunk = buffer_chunk.second;
       assignment->AddAssignment(allocation, value, chunk.offset, chunk.size);
     }
-    // Compute peak_buffers only when the multiheap mode is off. Simply return
-    // an empty vector in the multiheap mode.
     allocation->peak_buffers_ =
         ComputePeakMemoryLogicalBuffers(*allocation, result.debug_trace);
 

--- a/tensorflow/compiler/xla/service/buffer_assignment.cc
+++ b/tensorflow/compiler/xla/service/buffer_assignment.cc
@@ -607,7 +607,10 @@ void BufferAssignment::AddAssignment(BufferAllocation* allocation,
 // BufferAllocation.
 void BufferAssignment::CombineTempAllocations() {
   VLOG(1) << "CombineTempAllocations()";
-  flat_hash_map<BufferValue::Color, BufferAllocation> combined_allocation_map;
+  // Stores the combined allocations.
+  std::vector<BufferAllocation> combined_allocations;
+  // Holds the pointer to a combined allocation of each color, if any.
+  flat_hash_map<BufferValue::Color, BufferAllocation*> combined_allocation_map;
 
   // Move all temp allocations into a single run at the end of the allocations
   // vector.
@@ -621,19 +624,31 @@ void BufferAssignment::CombineTempAllocations() {
   // to the same color.
   if (first_temp_it != allocations_.end()) {
     for (auto it = first_temp_it; it != allocations_.end(); ++it) {
-      const BufferAllocation& temp_allocation = *it;
+      BufferAllocation& temp_allocation = *it;
       BufferValue::Color color = temp_allocation.color();
       auto combined_it = combined_allocation_map.find(color);
       if (combined_it == combined_allocation_map.end()) {
         // We have found the first temp allocation of this color. Collect
-        // the other temp allocations of the same color into it.
+        // the other temp allocations of the same color into it subject to the
+        // size constraint.
         VLOG(1) << "Combined temp allocation for color " << color
                 << " is: " << temp_allocation;
-        combined_allocation_map.emplace(color, temp_allocation);
+        combined_allocations.emplace_back(temp_allocation);
+        combined_allocation_map.emplace(color, &combined_allocations.back());
+        continue;
+      }
+      if (combined_it->second->size() + it->size() >=
+          multiheap_size_constraint_per_heap_) {
+        // We cannot put more into the current combined_it. So, appoint a new
+        // combined_it.
+        VLOG(1) << "Due to size constraint, reset temp allocation for color "
+                << color << " to: " << temp_allocation;
+        combined_allocations.emplace_back(temp_allocation);
+        combined_allocation_map.emplace(color, &combined_allocations.back());
         continue;
       }
 
-      auto* combined_allocation = &combined_it->second;
+      BufferAllocation* combined_allocation = combined_it->second;
       VLOG(1) << "Combined allocation absorbing temp allocation: "
               << temp_allocation;
 
@@ -663,9 +678,9 @@ void BufferAssignment::CombineTempAllocations() {
     // Replace all existing temporary allocations with the new combined
     // allocations.
     allocations_.erase(first_temp_it, allocations_.end());
-    for (auto& combined : combined_allocation_map) {
-      allocations_.push_back(combined.second);
-      temp_allocation_total_size_ += combined.second.size();
+    for (BufferAllocation& combined : combined_allocations) {
+      temp_allocation_total_size_ += combined.size();
+      allocations_.push_back(std::move(combined));
     }
   }
 
@@ -1330,23 +1345,14 @@ Status BufferAssigner::AssignBuffersWithSequentialOrdering(
   auto get_heap_algorithm = [&](int64 alignment) {
     auto algorithms = absl::make_unique<
         std::vector<std::unique_ptr<HeapAlgorithm<HloValue>>>>();
-    if (assignment->multiheap_size_constraint_per_heap() == -1) {
-      algorithms->push_back(
-          absl::make_unique<GlobalDecreasingSizeBestFitHeap<HloValue>>(
-              alignment, GlobalDecreasingSizeBestFitHeap<HloValue>::kSpatial));
-      algorithms->push_back(
-          absl::make_unique<GlobalDecreasingSizeBestFitHeap<HloValue>>(
-              alignment, GlobalDecreasingSizeBestFitHeap<HloValue>::kTemporal));
-    } else {
-      algorithms->push_back(
-          absl::make_unique<ConstrainedGlobalDecreasingSizeBestFitHeap>(
-              assignment->multiheap_size_constraint_per_heap(), alignment,
-              GlobalDecreasingSizeBestFitHeap<HloValue>::kSpatial));
-      algorithms->push_back(
-          absl::make_unique<ConstrainedGlobalDecreasingSizeBestFitHeap>(
-              assignment->multiheap_size_constraint_per_heap(), alignment,
-              GlobalDecreasingSizeBestFitHeap<HloValue>::kTemporal));
-    }
+    algorithms->push_back(
+        absl::make_unique<ConstrainedGlobalDecreasingSizeBestFitHeap>(
+            assignment->multiheap_size_constraint_per_heap(), alignment,
+            GlobalDecreasingSizeBestFitHeap<HloValue>::kSpatial));
+    algorithms->push_back(
+        absl::make_unique<ConstrainedGlobalDecreasingSizeBestFitHeap>(
+            assignment->multiheap_size_constraint_per_heap(), alignment,
+            GlobalDecreasingSizeBestFitHeap<HloValue>::kTemporal));
     return absl::make_unique<ChooseBestHeapAlgorithm<HloValue>>(
         std::move(algorithms));
   };
@@ -1455,6 +1461,12 @@ std::vector<const HloValue*> ComputePeakMemoryLogicalBuffers(
   int64 max_live_size = 0;
   int64 live_size = 0;
   for (const auto& event : heap_trace.events()) {
+    if (!id_to_value.contains(event.buffer_id())) {
+      // Skip as the buffer associated with this trace event is not placed into
+      // this allocation. This can happen when size constraints are given to the
+      // heap simulator.
+      continue;
+    }
     live_size += memory_delta(event);
     if (max_live_size < live_size) {
       max_live_size = live_size;
@@ -1466,6 +1478,12 @@ std::vector<const HloValue*> ComputePeakMemoryLogicalBuffers(
   absl::flat_hash_set<const HloValue*> live_values;
   live_size = 0;
   for (const auto& event : heap_trace.events()) {
+    if (!id_to_value.contains(event.buffer_id())) {
+      // Skip as the buffer associated with this trace event is not placed into
+      // this allocation. This can happen when size constraints are given to the
+      // heap simulator.
+      continue;
+    }
     const HloValue* value = id_to_value.at(event.buffer_id());
     if (event.kind() == HeapSimulatorTrace::Event::ALLOC ||
         event.kind() == HeapSimulatorTrace::Event::SHARE_WITH) {
@@ -1511,7 +1529,10 @@ void BufferAssigner::AssignBuffersFromHeapSimulator(
   }
   VLOG(1) << "Result size from heap simulator: " << result.heap_size;
 
-  for (auto& heap_result : result.heap_results) {
+  // Iterate through heap_results. For each heap_result, create a new allocation
+  // in `assignment`.
+  for (const HeapSimulator::HeapResult<HloValue>& heap_result :
+       result.heap_results) {
     BufferAllocation* allocation =
         assignment->NewEmptyAllocation(heap_result.heap_size, color);
     for (const auto& buffer_chunk : heap_result.chunk_map) {
@@ -1634,13 +1655,12 @@ StatusOr<std::unique_ptr<BufferAssignment>> BufferAssigner::CreateAssignment(
     }
   }
 
-  // Combines allocations of temporary buffers into one big BufferAllocation.
-  // This can only be performed after all buffers have been assigned, and
-  // after maybe_live_out is marked, since it is used to determine whether an
-  // allocation contains temporary buffers or not.
-  if (multiheap_size_constraint_per_heap == -1) {
-    assignment->CombineTempAllocations();
-  }
+  // Combines allocations of temporary buffers into big BufferAllocations
+  // subject to the buffer allocation size constraint. This can only be
+  // performed after all buffers have been assigned, and after maybe_live_out
+  // is marked, since it is used to determine whether an allocation contains
+  // temporary buffers or not.
+  assignment->CombineTempAllocations();
 
   XLA_VLOG_LINES(2, assignment->ToString());
   TF_RETURN_IF_ERROR(assignment->ComputeSummaryStats());

--- a/tensorflow/compiler/xla/service/buffer_assignment.cc
+++ b/tensorflow/compiler/xla/service/buffer_assignment.cc
@@ -1330,12 +1330,23 @@ Status BufferAssigner::AssignBuffersWithSequentialOrdering(
   auto get_heap_algorithm = [&](int64 alignment) {
     auto algorithms = absl::make_unique<
         std::vector<std::unique_ptr<HeapAlgorithm<HloValue>>>>();
-    algorithms->push_back(
-        absl::make_unique<GlobalDecreasingSizeBestFitHeap<HloValue>>(
-            alignment, GlobalDecreasingSizeBestFitHeap<HloValue>::kSpatial));
-    algorithms->push_back(
-        absl::make_unique<GlobalDecreasingSizeBestFitHeap<HloValue>>(
-            alignment, GlobalDecreasingSizeBestFitHeap<HloValue>::kTemporal));
+    if (assignment->multiheap_size_constraint_per_heap() == -1) {
+      algorithms->push_back(
+          absl::make_unique<GlobalDecreasingSizeBestFitHeap<HloValue>>(
+              alignment, GlobalDecreasingSizeBestFitHeap<HloValue>::kSpatial));
+      algorithms->push_back(
+          absl::make_unique<GlobalDecreasingSizeBestFitHeap<HloValue>>(
+              alignment, GlobalDecreasingSizeBestFitHeap<HloValue>::kTemporal));
+    } else {
+      algorithms->push_back(
+          absl::make_unique<ConstrainedGlobalDecreasingSizeBestFitHeap>(
+              assignment->multiheap_size_constraint_per_heap(), alignment,
+              GlobalDecreasingSizeBestFitHeap<HloValue>::kSpatial));
+      algorithms->push_back(
+          absl::make_unique<ConstrainedGlobalDecreasingSizeBestFitHeap>(
+              assignment->multiheap_size_constraint_per_heap(), alignment,
+              GlobalDecreasingSizeBestFitHeap<HloValue>::kTemporal));
+    }
     return absl::make_unique<ChooseBestHeapAlgorithm<HloValue>>(
         std::move(algorithms));
   };
@@ -1500,20 +1511,25 @@ void BufferAssigner::AssignBuffersFromHeapSimulator(
   }
   VLOG(1) << "Result size from heap simulator: " << result.heap_size;
 
-  BufferAllocation* allocation =
-      assignment->NewEmptyAllocation(result.heap_size, color);
-  for (const auto& buffer_chunk : result.chunk_map) {
-    const HloValue& value = *buffer_chunk.first;
-    const HeapSimulator::Chunk& chunk = buffer_chunk.second;
-    assignment->AddAssignment(allocation, value, chunk.offset, chunk.size);
+  for (auto& heap_result : result.heap_results) {
+    BufferAllocation* allocation =
+        assignment->NewEmptyAllocation(heap_result.heap_size, color);
+    for (const auto& buffer_chunk : heap_result.chunk_map) {
+      const HloValue& value = *buffer_chunk.first;
+      const HeapSimulator::Chunk& chunk = buffer_chunk.second;
+      assignment->AddAssignment(allocation, value, chunk.offset, chunk.size);
+    }
+    // Compute peak_buffers only when the multiheap mode is off. Simply return
+    // an empty vector in the multiheap mode.
+    if (assignment->multiheap_size_constraint_per_heap() == -1) {
+      allocation->peak_buffers_ =
+          ComputePeakMemoryLogicalBuffers(*allocation, result.debug_trace);
+    }
+
+    XLA_VLOG_LINES(2, allocation->ToString());
+
+    allocation->AddHeapTrace(result.debug_trace);
   }
-  allocation->peak_buffers_ =
-      ComputePeakMemoryLogicalBuffers(*allocation, result.debug_trace);
-
-  VLOG(1) << "Ran heap simulation for allocation: ";
-  XLA_VLOG_LINES(2, allocation->ToString());
-
-  allocation->AddHeapTrace(result.debug_trace);
 }
 
 StatusOr<std::unique_ptr<BufferAssignment>> BufferAssigner::CreateAssignment(
@@ -1580,6 +1596,10 @@ StatusOr<std::unique_ptr<BufferAssignment>> BufferAssigner::CreateAssignment(
       buffers_to_assign_sequentially.size() == global_computations.size();
   VLOG(2) << "Running whole module heap simulation: "
           << run_whole_module_heap_simulation;
+  const int32 multiheap_size_constraint_per_heap =
+      module->config().debug_options().xla_multiheap_size_constraint_per_heap();
+  VLOG(2) << "Multiheap per heap size limit: "
+          << multiheap_size_constraint_per_heap;
   TF_RETURN_IF_ERROR(AssignBuffersWithSequentialOrdering(
       buffers_to_assign_sequentially, run_whole_module_heap_simulation,
       assignment.get()));
@@ -1618,7 +1638,9 @@ StatusOr<std::unique_ptr<BufferAssignment>> BufferAssigner::CreateAssignment(
   // This can only be performed after all buffers have been assigned, and
   // after maybe_live_out is marked, since it is used to determine whether an
   // allocation contains temporary buffers or not.
-  assignment->CombineTempAllocations();
+  if (multiheap_size_constraint_per_heap == -1) {
+    assignment->CombineTempAllocations();
+  }
 
   XLA_VLOG_LINES(2, assignment->ToString());
   TF_RETURN_IF_ERROR(assignment->ComputeSummaryStats());

--- a/tensorflow/compiler/xla/service/buffer_assignment.h
+++ b/tensorflow/compiler/xla/service/buffer_assignment.h
@@ -363,6 +363,10 @@ class BufferAssignment {
     return temp_allocation_total_size_;
   }
 
+  int32 multiheap_size_constraint_per_heap() const {
+    return multiheap_size_constraint_per_heap_;
+  }
+
   // Returns whether the given buffer has been assigned an allocation.
   bool HasAllocation(const HloValue& value) const;
 
@@ -491,7 +495,11 @@ class BufferAssignment {
         buffer_size_(std::move(buffer_size)),
         color_alignment_(std::move(color_alignment)),
         alias_analysis_(std::move(alias_analysis)),
-        hlo_live_range_(std::move(hlo_live_range)) {}
+        hlo_live_range_(std::move(hlo_live_range)),
+        multiheap_size_constraint_per_heap_(
+            module->config()
+                .debug_options()
+                .xla_multiheap_size_constraint_per_heap()) {}
 
   // Creates and returns a new BufferAllocation, with no assigned
   // LogicalBuffers. Ownership is maintained internally.
@@ -534,6 +542,8 @@ class BufferAssignment {
 
   // The total size of all temporary buffers.
   int64 temp_allocation_total_size_ = 0;
+
+  int32 multiheap_size_constraint_per_heap_;
 
   // Maps Buffers to the index of the BufferAllocation which holds the buffer.
   absl::flat_hash_map<const HloValue*, BufferAllocation::Index>

--- a/tensorflow/compiler/xla/service/buffer_assignment.h
+++ b/tensorflow/compiler/xla/service/buffer_assignment.h
@@ -363,7 +363,7 @@ class BufferAssignment {
     return temp_allocation_total_size_;
   }
 
-  int32 multiheap_size_constraint_per_heap() const {
+  uint64 multiheap_size_constraint_per_heap() const {
     return multiheap_size_constraint_per_heap_;
   }
 
@@ -495,11 +495,14 @@ class BufferAssignment {
         buffer_size_(std::move(buffer_size)),
         color_alignment_(std::move(color_alignment)),
         alias_analysis_(std::move(alias_analysis)),
-        hlo_live_range_(std::move(hlo_live_range)),
-        multiheap_size_constraint_per_heap_(
-            module->config()
-                .debug_options()
-                .xla_multiheap_size_constraint_per_heap()) {}
+        hlo_live_range_(std::move(hlo_live_range)) {
+    int32 raw_value = module->config()
+                          .debug_options()
+                          .xla_multiheap_size_constraint_per_heap();
+    // -1 means no constraint.
+    multiheap_size_constraint_per_heap_ =
+        (raw_value == -1) ? UINT64_MAX : raw_value;
+  }
 
   // Creates and returns a new BufferAllocation, with no assigned
   // LogicalBuffers. Ownership is maintained internally.
@@ -543,7 +546,7 @@ class BufferAssignment {
   // The total size of all temporary buffers.
   int64 temp_allocation_total_size_ = 0;
 
-  int32 multiheap_size_constraint_per_heap_;
+  uint64 multiheap_size_constraint_per_heap_;
 
   // Maps Buffers to the index of the BufferAllocation which holds the buffer.
   absl::flat_hash_map<const HloValue*, BufferAllocation::Index>

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -1857,8 +1857,7 @@ IrEmitterUnnested::BuildKernelThunkFromBufferSlices(
     absl::string_view name, Thunk::ThunkInfo thunk_info,
     absl::Span<const BufferSlice* const> slices,
     std::function<void(const BufferSlice*, llvm::Value*)>
-        bind_slice_to_ir_value,
-    bool insist_single_temp_buffer) {
+        bind_slice_to_ir_value) {
   const auto& buffer_assn = ir_emitter_context_->buffer_assignment();
 
   // Figure out which buffer allocations need to be passed as arguments to our
@@ -1874,9 +1873,8 @@ IrEmitterUnnested::BuildKernelThunkFromBufferSlices(
   for (const BufferAllocation& alloc : buffer_assn.Allocations()) {
     if (alloc.IsPreallocatedTempBuffer()) {
       if (!temp_buffer.has_value()) {
+        // Retrieve the first seen temp buffer.
         temp_buffer = &alloc;
-      } else if (insist_single_temp_buffer) {
-        LOG(FATAL) << "Multiple temp buffers found, but only one is allowed!";
       }
     }
   }
@@ -1996,13 +1994,7 @@ std::unique_ptr<KernelThunk> IrEmitterUnnested::BuildKernelThunk(
                 << hlo_buffer_slice->gte_index.ToString();
 
         bindings_.BindHloToIrValue(*instr, value, index);
-      },
-      // Check temp buffer numbers only when the multiheap mode is off.
-      /*insist_single_temp_buffer=*/inst->parent()
-              ->parent()
-              ->config()
-              .debug_options()
-              .xla_multiheap_size_constraint_per_heap() == -1);
+      });
 }
 
 std::unique_ptr<KernelThunk> IrEmitterUnnested::BuildKernelThunkForMlir(

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.h
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.h
@@ -547,7 +547,8 @@ class IrEmitterUnnested : public IrEmitter,
       absl::string_view name, Thunk::ThunkInfo thunk_info,
       absl::Span<const BufferSlice* const> slices,
       std::function<void(const BufferSlice*, llvm::Value*)>
-          bind_slice_to_ir_value);
+          bind_slice_to_ir_value,
+      bool insist_single_temp_buffer = true);
 
   // Returns a KernelThunk that invokes the kernel emitted for `inst`. The
   // caller needs to make sure `inst` outlives the lifetime of the returned

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.h
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.h
@@ -547,8 +547,7 @@ class IrEmitterUnnested : public IrEmitter,
       absl::string_view name, Thunk::ThunkInfo thunk_info,
       absl::Span<const BufferSlice* const> slices,
       std::function<void(const BufferSlice*, llvm::Value*)>
-          bind_slice_to_ir_value,
-      bool insist_single_temp_buffer = true);
+          bind_slice_to_ir_value);
 
   // Returns a KernelThunk that invokes the kernel emitted for `inst`. The
   // caller needs to make sure `inst` outlives the lifetime of the returned

--- a/tensorflow/compiler/xla/service/heap_simulator.cc
+++ b/tensorflow/compiler/xla/service/heap_simulator.cc
@@ -409,11 +409,15 @@ HeapSimulator::Result<HloValue> HeapSimulator::Finish() {
   // Post-process the result to add chunks for shared buffers.  An empty chunk
   // map means that either no buffers were allocated, or the heap was only
   // collecting statistics, e.g. NoFragmentationStatsHeap.
-  if (!result.chunk_map.empty()) {
+  size_t total_chunk_count = 0;
+  absl::c_for_each(result.heap_results, [&](const HeapResult<HloValue>& hr) {
+    total_chunk_count += hr.chunk_map.size();
+  });
+  if (total_chunk_count != 0) {
     // If we were told to assign specific buffers, make sure we've assigned
     // exactly that many buffers.
     if (options_.buffers_to_assign != nullptr) {
-      CHECK_EQ(options_.buffers_to_assign->size(), result.chunk_map.size());
+      CHECK_EQ(options_.buffers_to_assign->size(), total_chunk_count);
     }
   }
 
@@ -825,7 +829,10 @@ GlobalDecreasingSizeBestFitHeap<BufferType>::Finish() {
     CommitChunk(buffer_interval, chunk_candidate);
   }
   VLOG(1) << "result heap_size: " << result_.heap_size;
-  return result_;
+  Result result;
+  result.heap_size = result_.heap_size;
+  result.heap_results.emplace_back(result_);
+  return result;
 }
 
 template <typename BufferType>
@@ -966,6 +973,58 @@ void GlobalDecreasingSizeBestFitHeap<BufferType>::AddToChunkMap(
     const BufferType* buffer, Chunk chunk) {
   const auto emplace_result = result_.chunk_map.emplace(buffer, chunk);
   DCHECK(emplace_result.second);
+}
+
+HeapSimulator::Result<HloValue>
+ConstrainedGlobalDecreasingSizeBestFitHeap::Finish() {
+  std::vector<BufferInterval> sorted_buffer_vec = GetSortedBufferIntervals();
+  // Convert into std::list so that erase() is O(1).
+  std::list<BufferInterval> sorted_buffer_intervals(sorted_buffer_vec.begin(),
+                                                    sorted_buffer_vec.end());
+
+  // Use do-while here, because we need to create 1 heap in `multi_heap_result`
+  // even if `sorted_buffer_intervals` is empty.
+  Result multi_heap_result;
+  do {
+    // Place buffers into the currently processed heap as many as possible.
+    for (auto it = sorted_buffer_intervals.begin();
+         it != sorted_buffer_intervals.end();) {
+      BufferInterval buffer_interval = *it;
+      if (!buffer_interval.need_allocation) {
+        it = sorted_buffer_intervals.erase(it);
+        continue;
+      }
+      if (buffer_interval.size > size_limit_per_heap_) {
+        LOG(WARNING) << "Alloc buffer size " << buffer_interval.size
+                     << " larger than the per-heap size limit "
+                     << size_limit_per_heap_;
+      }
+
+      ChunkCandidate chunk_candidate = FindChunkCandidate(buffer_interval);
+      if (chunk_candidate.heap_size <= size_limit_per_heap_ ||
+          // Commit the chunk as long as the heap is empty. We do this because
+          // we want the size constraint to be soft, meaning that results are
+          // successfully generated even if there are some buffer sizes larger
+          // than the given constraint size.
+          result_.heap_size == 0) {
+        CommitChunk(buffer_interval, chunk_candidate);
+        it = sorted_buffer_intervals.erase(it);
+        continue;
+      }
+
+      ++it;
+    }
+    // Collect the result from the currently processed heap and reset the heap
+    // states.
+    multi_heap_result.heap_size += result_.heap_size;
+    multi_heap_result.heap_results.push_back(std::move(result_));
+    result_ = {};
+    interval_tree_ = {};
+  } while (!sorted_buffer_intervals.empty());
+
+  VLOG(1) << "Number of heaps produced = "
+          << multi_heap_result.heap_results.size();
+  return multi_heap_result;
 }
 
 template <typename BufferType>

--- a/tensorflow/compiler/xla/service/heap_simulator.cc
+++ b/tensorflow/compiler/xla/service/heap_simulator.cc
@@ -409,10 +409,11 @@ HeapSimulator::Result<HloValue> HeapSimulator::Finish() {
   // Post-process the result to add chunks for shared buffers.  An empty chunk
   // map means that either no buffers were allocated, or the heap was only
   // collecting statistics, e.g. NoFragmentationStatsHeap.
-  size_t total_chunk_count = 0;
-  absl::c_for_each(result.heap_results, [&](const HeapResult<HloValue>& hr) {
-    total_chunk_count += hr.chunk_map.size();
-  });
+  size_t total_chunk_count = absl::c_accumulate(
+      result.heap_results, (size_t)0,
+      [&](size_t lhs, const HeapResult<HloValue>& rhs) -> size_t {
+        return lhs + rhs.chunk_map.size();
+      });
   if (total_chunk_count != 0) {
     // If we were told to assign specific buffers, make sure we've assigned
     // exactly that many buffers.

--- a/tensorflow/compiler/xla/service/heap_simulator.h
+++ b/tensorflow/compiler/xla/service/heap_simulator.h
@@ -456,10 +456,26 @@ class GlobalDecreasingSizeBestFitHeap : public HeapAlgorithm<BufferType> {
       const BufferInterval& interval) const;
 };
 
-// This class implements an algorithm that will output multiple heaps. Each heap
-// size is constrained by a given limit. Note that the constraint is soft,
-// meaning that valid heap results are generated even if there are some buffer
-// sizes larger than the given constraint size.
+// This class implements an algorithm that will produce multiple heaps, where
+// each heap size is constrained by a given limit. Note that the constraint is
+// soft, meaning that a valid heap result is generated even if there are some
+// buffer sizes larger than the given constraint size.
+//
+// Pseudocode:
+//   while( `buffers` is not empty ) {
+//     create a new heap `h`
+//     for (each buffer `buf` in `buffers` in the size-decreasing order) {
+//       if (buf.size() is larger than the heap size limit &&
+//           `h` is empty) {
+//         h.place(buf)
+//         buffers.remove(buf)
+//       } else if (placing `buf` into `h` does not violate size
+//           constraint) {
+//         h.place(buf)
+//         buffers.remove(buf)
+//       }
+//     }
+//   }
 class ConstrainedGlobalDecreasingSizeBestFitHeap
     : public GlobalDecreasingSizeBestFitHeap<HloValue> {
  public:

--- a/tensorflow/compiler/xla/service/heap_simulator.h
+++ b/tensorflow/compiler/xla/service/heap_simulator.h
@@ -464,7 +464,7 @@ class ConstrainedGlobalDecreasingSizeBestFitHeap
     : public GlobalDecreasingSizeBestFitHeap<HloValue> {
  public:
   explicit ConstrainedGlobalDecreasingSizeBestFitHeap(
-      size_t size_limit_per_heap, int64 alignment, Type type = kSpatial)
+      uint64 size_limit_per_heap, int64 alignment, Type type = kSpatial)
       : size_limit_per_heap_(size_limit_per_heap),
         GlobalDecreasingSizeBestFitHeap<HloValue>(alignment, type) {}
   ~ConstrainedGlobalDecreasingSizeBestFitHeap() override {}
@@ -472,7 +472,7 @@ class ConstrainedGlobalDecreasingSizeBestFitHeap
   Result Finish() override;
 
  private:
-  size_t size_limit_per_heap_;
+  uint64 size_limit_per_heap_;
 };
 
 // A heap algorithm that chooses the best results from other algorithms added to

--- a/tensorflow/compiler/xla/service/heap_simulator.h
+++ b/tensorflow/compiler/xla/service/heap_simulator.h
@@ -67,13 +67,22 @@ class HeapSimulator {
     }
   };
 
-  // Result represents the result of the heap simulation.
   template <typename BufferType>
-  struct Result {
+  struct HeapResult {
     // The assignment of buffers to chunks.
     absl::flat_hash_map<const BufferType*, Chunk> chunk_map;
 
     // The total size in bytes of the heap, containing all assigned chunks.
+    int64 heap_size = 0;
+  };
+  // Result represents the result of the heap simulation.
+  template <typename BufferType>
+  struct Result {
+    // Heap results.
+    std::vector<HeapResult<BufferType>> heap_results;
+
+    // The total size in bytes of the heaps.
+    // heap_size == sum([hr.heap_size for hr in heap_results]).
     int64 heap_size = 0;
 
     // The total size in bytes of heap fragmentation.
@@ -229,6 +238,7 @@ class HeapAlgorithm {
  public:
   using Chunk = HeapSimulator::Chunk;
   using Result = HeapSimulator::Result<BufferType>;
+  using HeapResult = HeapSimulator::HeapResult<BufferType>;
 
   virtual ~HeapAlgorithm() = default;
 
@@ -347,6 +357,7 @@ class BufferIntervalTree {
 template <typename BufferType>
 class GlobalDecreasingSizeBestFitHeap : public HeapAlgorithm<BufferType> {
  public:
+  using HeapResult = HeapSimulator::HeapResult<BufferType>;
   using Result = HeapSimulator::Result<BufferType>;
   using Chunk = HeapSimulator::Chunk;
 
@@ -415,6 +426,7 @@ class GlobalDecreasingSizeBestFitHeap : public HeapAlgorithm<BufferType> {
                                     int64 preferred_offset = -1) const;
   void CommitChunk(const BufferInterval& buffer_interval,
                    ChunkCandidate chunk_candidate);
+
   // Adds the buffer and the chunk to the result chunk map.
   virtual void AddToChunkMap(const BufferType* buffer, Chunk chunk);
 
@@ -426,7 +438,7 @@ class GlobalDecreasingSizeBestFitHeap : public HeapAlgorithm<BufferType> {
   BufferIntervalCompare GetTemporalBufferIntervalCompare() const;
 
   absl::flat_hash_map<const BufferType*, BufferInterval> buffer_intervals_;
-  Result result_;
+  HeapResult result_;
   BufferIntervalCompare buffer_interval_compare_;
   BufferIntervalTree interval_tree_;
 
@@ -442,6 +454,25 @@ class GlobalDecreasingSizeBestFitHeap : public HeapAlgorithm<BufferType> {
   // returns all three of them.
   absl::flat_hash_set<const BufferType*> GetTransitiveColocations(
       const BufferInterval& interval) const;
+};
+
+// This class implements an algorithm that will output multiple heaps. Each heap
+// size is constrained by a given limit. Note that the constraint is soft,
+// meaning that valid heap results are generated even if there are some buffer
+// sizes larger than the given constraint size.
+class ConstrainedGlobalDecreasingSizeBestFitHeap
+    : public GlobalDecreasingSizeBestFitHeap<HloValue> {
+ public:
+  explicit ConstrainedGlobalDecreasingSizeBestFitHeap(
+      size_t size_limit_per_heap, int64 alignment, Type type = kSpatial)
+      : size_limit_per_heap_(size_limit_per_heap),
+        GlobalDecreasingSizeBestFitHeap<HloValue>(alignment, type) {}
+  ~ConstrainedGlobalDecreasingSizeBestFitHeap() override {}
+
+  Result Finish() override;
+
+ private:
+  size_t size_limit_per_heap_;
 };
 
 // A heap algorithm that chooses the best results from other algorithms added to

--- a/tensorflow/compiler/xla/service/heap_simulator.h
+++ b/tensorflow/compiler/xla/service/heap_simulator.h
@@ -481,8 +481,8 @@ class ConstrainedGlobalDecreasingSizeBestFitHeap
  public:
   explicit ConstrainedGlobalDecreasingSizeBestFitHeap(
       uint64 size_limit_per_heap, int64 alignment, Type type = kSpatial)
-      : size_limit_per_heap_(size_limit_per_heap),
-        GlobalDecreasingSizeBestFitHeap<HloValue>(alignment, type) {}
+      : GlobalDecreasingSizeBestFitHeap<HloValue>(alignment, type),
+        size_limit_per_heap_(size_limit_per_heap) {}
   ~ConstrainedGlobalDecreasingSizeBestFitHeap() override {}
 
   Result Finish() override;

--- a/tensorflow/compiler/xla/service/memory_space_assignment.cc
+++ b/tensorflow/compiler/xla/service/memory_space_assignment.cc
@@ -1127,7 +1127,10 @@ HeapSimulator::Result<HloValue> AlternateMemoryBestFitHeap::Finish() {
   VLOG(3) << allocation_info_str_;
   DumpDebugStringsIfEnabled();
 
-  return result_;
+  HeapSimulator::Result<HloValue> result;
+  result.heap_size = result_.heap_size;
+  result.heap_results.emplace_back(std::move(result_));
+  return std::move(result);
 }
 
 void AlternateMemoryBestFitHeap::CreateAllocationValuesFromColocatedIntervals(

--- a/tensorflow/compiler/xla/service/memory_space_assignment.cc
+++ b/tensorflow/compiler/xla/service/memory_space_assignment.cc
@@ -1130,7 +1130,7 @@ HeapSimulator::Result<HloValue> AlternateMemoryBestFitHeap::Finish() {
   HeapSimulator::Result<HloValue> result;
   result.heap_size = result_.heap_size;
   result.heap_results.emplace_back(std::move(result_));
-  return std::move(result);
+  return result;
 }
 
 void AlternateMemoryBestFitHeap::CreateAllocationValuesFromColocatedIntervals(

--- a/tensorflow/compiler/xla/xla.proto
+++ b/tensorflow/compiler/xla/xla.proto
@@ -290,7 +290,11 @@ message DebugOptions {
   // Extra parameters to pass the GPU assembler.
   string xla_gpu_asm_extra_flags = 141;
 
-  // Next id: 142
+  // Per-heap size constraint. New heaps will be created if per-heap max size is
+  // reached.
+  int32 xla_multiheap_size_constraint_per_heap = 142;
+
+  // Next id: 143
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
This change provide the capability to XLA to generate multiple heaps
(i.e., temp buffers) with a size constraint on each heap to avoid Out-of-Memory
due to memory fragmentation. Note that larger allocations are more subject to
the effect of fragmentation.


This fixes some TF/XLA OOM issue our clients constantly reported without significant memory use size increase.

I can share some data points I have at hands:

RN50 fp16 | Baseline (no constraint) | (constraint=) 2G | 1G | 800M | 700M
-- | -- | -- | -- | -- | --
Total alloc (reported by XLA) | 10.90GiB | 10.90GiB | 10.92GiB | 10.90GiB | 10.91GiB

BERT fp16 | Baseline (no constraint) | (constraint=) 1G | 500M | 300M
-- | -- | -- | -- | --
Total alloc (reported by XLA) | 8.60GiB | 8.60GiB | 8.60GiB | 8.60GiB


UNet3d fp16 | Tensorflow(without XLA) | XLA with no size constraint on temp buffer | XLA with size-constraint=1G on temp buffer
-- | -- | -- | --
Peak Memory Use (dumped by bfc_allocator) | 10.02GiB | OOM | 10.02GiB
Total Alloc(reported by XLA) |   | 5.81GiB | 6.09GiB

