### PR TITLE
[ROCm] Fix for ROCM CSB breakage - 201007

### DIFF
--- a/tensorflow/core/nccl/nccl_manager_test.cc
+++ b/tensorflow/core/nccl/nccl_manager_test.cc
@@ -640,6 +640,10 @@ TEST(NcclManagerTest, CommunicatorKey) {
 }
 
 #if !TENSORFLOW_USE_ROCM
+// ROCm platform currently does not support simulating a mutli-node
+// environment, on a single node with multiple GPUS. So tests that rely
+// upon such simulation need to be skipped on the ROCm platform
+
 // This test creates `num_nodes` NcclManagers to simulate a multi-node
 // environment.  It works on a single node with multiple GPUs.  It enqueues NCCL
 // kernels on separate stream per rank.
@@ -661,6 +665,10 @@ TYPED_TEST(NcclManagerTest, MultiNodeSingle) {
 }
 
 #if !TENSORFLOW_USE_ROCM
+// ROCm platform currently does not support simulating a mutli-node
+// environment, on a single node with multiple GPUS. So tests that rely
+// upon such simulation need to be skipped on the ROCm platform
+
 // Multi-node broadcast.
 TYPED_TEST(NcclManagerTest, MultiNodeBroadcast) {
   int num_nodes;
@@ -850,6 +858,11 @@ TYPED_TEST(NcclManagerTest, BroadcastInconsistentSource) {
   this->VerifyError(test_case.get());
 }
 
+#if !TENSORFLOW_USE_ROCM
+// ROCm platform currently does not support simulating a mutli-node
+// environment, on a single node with multiple GPUS. So tests that rely
+// upon such simulation need to be skipped on the ROCm platform
+
 TYPED_TEST(NcclManagerTest, Abort) {
   using NodeState = typename TestFixture::NodeState;
   using TestCase = typename TestFixture::TestCase;
@@ -911,6 +924,7 @@ TYPED_TEST(NcclManagerTest, Abort) {
     }
   }
 }
+#endif
 
 }  // namespace tensorflow
 


### PR DESCRIPTION
The following commit introduces a new subtest that is failing on the ROCm platform

https://github.com/tensorflow/tensorflow/commit/f2ebefba658fb4f424842f03d15f694cb917110f

The new subtest ( `NcclManagerTest.Abort` ) requires simulating a multi-node environment on a single-node with mutliple GPUs. This functionality is currently not available on the ROCm platform, and other subtests that require this functionality have already been disabled on the ROCm platform. Doing the same for the newly added subtest as well.


------------------------------


/cc @cheshire @chsigg @nvining-work 