### PR TITLE
Use sysctl for maximum CPU frequency on MacOS

### DIFF
--- a/tensorflow/core/platform/profile_utils/cpu_utils.cc
+++ b/tensorflow/core/platform/profile_utils/cpu_utils.cc
@@ -23,6 +23,10 @@ limitations under the License.
 #include <windows.h>
 #endif
 
+#if defined(__APPLE__)
+#include <sys/sysctl.h>
+#endif
+
 #include "absl/base/call_once.h"
 #include "tensorflow/core/platform/logging.h"
 #include "tensorflow/core/platform/profile_utils/android_armv7a_cpu_utils_helper.h"
@@ -114,17 +118,11 @@ static ICpuUtilsHelper* cpu_utils_helper_instance_ = nullptr;
          "CPU frequency";
   return INVALID_FREQUENCY;
 #elif defined(__APPLE__)
-  int64 freq_hz;
-  FILE* fp =
-      popen("sysctl hw | grep hw.cpufrequency_max: | cut -d' ' -f 2", "r");
-  if (fp == nullptr) {
-    return INVALID_FREQUENCY;
-  }
-  if (fscanf(fp, "%lld", &freq_hz) != 1) {
-    return INVALID_FREQUENCY;
-  }
-  pclose(fp);
-  if (freq_hz < 1e6) {
+  int64 freq_hz = 0;
+  size_t freq_size = sizeof(freq_hz);
+  int retval =
+      sysctlbyname("hw.cpufrequency_max", &freq_hz, &freq_size, NULL, 0);
+  if (retval != 0 || freq_hz < 1e6) {
     LOG(WARNING) << "Failed to get CPU frequency: " << freq_hz << " Hz";
     return INVALID_FREQUENCY;
   }


### PR DESCRIPTION
Hello, I am one of the maintainers of the Tensorflow bindings for Elixir (https://github.com/pylon/extensor) project. We ran into a deadlock on MacOS in a recent release of the Erlang VM related to the `popen` call used to retrieve the maximum CPU frequency when a new Tensorflow session is created. The changes on this PR replace the `popen`/`fork` mechanism used to retrieve these parameters on MacOS with a `sysctl` system call that doesn't fork the process, which avoids problems with the ports mechanism in the Erlang VM.

It appears that this was the only use of the `popen` function in the Tensorflow codebase, and there is precedent for using the `sysctl` system calls elsewhere. We also believe that this method is simpler than calling out to the shell to retrieve this parameter. Because the name of the `sysctl` parameter is the same in both versions, this change should be low risk and have the same failure modes as the previous version. That said, I have only tested this change on MacOS Catalina 10.15.7.

Please let me know if there is any more information I can provide, and thank you for reviewing this PR.
