### PR TITLE
Autotune Dataset.map when transforming builtin map with autograph

### DIFF
--- a/tensorflow/python/autograph/operators/py_builtins.py
+++ b/tensorflow/python/autograph/operators/py_builtins.py
@@ -191,8 +191,9 @@ def _tf_abs(x):
 def _tf_dataset_abs(x):
   specs = nest.flatten(x.element_spec)
   if len(specs) == 1:
-    return x.map(math_ops.abs)
-  return x.map(lambda *e: nest.map_structure(math_ops.abs, e))
+    return x.map(math_ops.abs, num_parallel_calls=dataset_ops.AUTOTUNE)
+  return x.map(lambda *e: nest.map_structure(math_ops.abs, e),
+               num_parallel_calls=dataset_ops.AUTOTUNE)
 
 
 def _py_abs(x):
@@ -427,7 +428,8 @@ def map_(fn, *iterables):
 
 
 def _tf_dataset_map(fn, *iterables):
-  return dataset_ops.DatasetV2.zip(iterables).map(fn)
+  zipped_dataset = dataset_ops.DatasetV2.zip(iterables)
+  return zipped_dataset.map(fn, num_parallel_calls=dataset_ops.AUTOTUNE)
 
 
 def _py_map(fn, *iterables):


### PR DESCRIPTION
This PR enables autotuning for `tf.data.Dataset.map()` calls that have been generated from built in `map()` via autograph. This has the potential to significantly increase performance in some cases.