### PR TITLE
fix keras progbar output collision (2)

### DIFF
--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -264,7 +264,7 @@ class CallbackList(object):
 
     if self._progbar is None and add_progbar:
       self._progbar = ProgbarLogger(count_mode='steps')
-      self.callbacks.append(self._progbar)
+      self.callbacks.insert(0, self._progbar)
 
     if self._history is None and add_history:
       self._history = History()


### PR DESCRIPTION
The suggested edit ensures that `keras.model.fit()` progbar output is complete before any output from custom callbacks appears on epoch end. Basically this edit puts the standard `ProgbarLogger` first in the list of callbacks. 

**Current behavior:**
when training Model using Model.fit() with verbose=1 (for progress bar) and keras.callbacks.Callback() with on_epoch_end() function I observe that custom callback output happens BEFORE completion of the epoch progress output, like this:
```
Epoch 1/2
 63/125 [==============>...............] - ETA: 0s - loss: 43.2549 - mean_absolute_error: 4.6003
CALLBACK MESSAGE ON END EPOCH 0
125/125 [==============================] - 0s 794us/step - loss: 37.6690 - mean_absolute_error: 4.6575

```
**Expected behavior:**
custom callback output should happen AFTER completion of the epoch progress output:
```
Epoch 1/2
125/125 [==============================] - 0s 900us/step - loss: 36.9897 - mean_absolute_error: 4.8264
CALLBACK MESSAGE ON END EPOCH 0
```
Originally discussed at [tf github](https://github.com/tensorflow/tensorflow/issues/43184) with problem description and gist examples. Latest colab example is [here](https://colab.research.google.com/gist/poedator/3630b1cdec32ff6ef6ccdf6b63c4957a/custom_callback.ipynb).

This PR was attempted before(https://github.com/tensorflow/tensorflow/pull/43477) and was in process of review by @gbaned. Resubmitting separately from the other commit that caused conflict