### PR TITLE
Allow custom image size for NASNet models

### DIFF
--- a/tensorflow/python/keras/applications/applications_test.py
+++ b/tensorflow/python/keras/applications/applications_test.py
@@ -134,6 +134,21 @@ class ApplicationsTest(test.TestCase, parameterized.TestCase):
     self.assertShapeEqual(output_shape, (None, None, None, last_dim))
     backend.clear_session()
 
+    @parameterized.parameters(MODEL_LIST)
+    def test_application_custom_input_shape_imagenet(self, app, _):
+      custom_input_shape = (42, 42, 3)
+      input_shape = _get_input_shape(
+           lambda: app(
+              input_shape=custom_input_shape, include_top=False, pooling="avg"
+          )
+      )
+      self.assertShapeEqual(input_shape, (None, *custom_input_shape))
+
+
+def _get_input_shape(model_fn):
+  model = model_fn()
+  return model.input_shape
+
 
 def _get_output_shape(model_fn):
   model = model_fn()

--- a/tensorflow/python/keras/applications/nasnet.py
+++ b/tensorflow/python/keras/applications/nasnet.py
@@ -174,7 +174,7 @@ def NASNet(
       default_size=default_size,
       min_size=32,
       data_format=backend.image_data_format(),
-      require_flatten=True,
+      require_flatten=include_top,
       weights=weights)
 
   if backend.image_data_format() != 'channels_last':


### PR DESCRIPTION
Running `model = NASNetMobile(input_shape=(400, 400, 3), include_top=False, weights="imagenet")` results in a ValueError: When setting `include_top=True` and loading `imagenet` weights, `input_shape` should be (224, 224, 3). This PR aims to fix the above error.