### PR TITLE
Print the version of the cuDNN library found at runtime

### DIFF
--- a/tensorflow/stream_executor/cuda/cuda_dnn.cc
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.cc
@@ -329,6 +329,8 @@ port::Status CudnnSupport::Init() {
 #endif
 
     cudnn_.reset(new CudnnAccess(cudnn_handle));
+
+    LOG(INFO) << "Loaded cuDNN version " << cudnnGetVersion();
     return port::Status::OK();
   }
 


### PR DESCRIPTION
This is especially useful if we build against X.Y.z and run with X.Y.w
where w != z.