### PR TITLE
Avoid empty linker_bin_path breaking the build

### DIFF
--- a/third_party/gpus/crosstool/cc_toolchain_config.bzl.tpl
+++ b/third_party/gpus/crosstool/cc_toolchain_config.bzl.tpl
@@ -497,12 +497,11 @@ def _features(cpu, compiler, ctx):
                     ),
                     flag_set(
                         actions = all_link_actions(),
-                        flag_groups = [
-                            flag_group(flags = (
-                                ["-Wl,-no-as-needed"] if cpu == "local" else []
-                            ) + (
-                                ["-B" + ctx.attr.linker_bin_path] if ctx.attr.linker_bin_path else []
-                            ),
+                        flag_groups = ([
+                            flag_group(flags = ["-Wl,-no-as-needed"])
+                        ] if cpu == "local" else []) + ([
+                            flag_group(flags = ["-B" + ctx.attr.linker_bin_path])
+                        ] if ctx.attr.linker_bin_path" else []) + [
                             flag_group(
                                 flags = ["@%{linker_param_file}"],
                                 expand_if_available = "linker_param_file",

--- a/third_party/gpus/crosstool/cc_toolchain_config.bzl.tpl
+++ b/third_party/gpus/crosstool/cc_toolchain_config.bzl.tpl
@@ -501,7 +501,7 @@ def _features(cpu, compiler, ctx):
                             flag_group(flags = ["-Wl,-no-as-needed"])
                         ] if cpu == "local" else []) + ([
                             flag_group(flags = ["-B" + ctx.attr.linker_bin_path])
-                        ] if ctx.attr.linker_bin_path" else []) + [
+                        ] if ctx.attr.linker_bin_path else []) + [
                             flag_group(
                                 flags = ["@%{linker_param_file}"],
                                 expand_if_available = "linker_param_file",

--- a/third_party/gpus/crosstool/cc_toolchain_config.bzl.tpl
+++ b/third_party/gpus/crosstool/cc_toolchain_config.bzl.tpl
@@ -500,9 +500,9 @@ def _features(cpu, compiler, ctx):
                         flag_groups = [
                             flag_group(flags = (
                                 ["-Wl,-no-as-needed"] if cpu == "local" else []
-                            ) + [
-                                "-B" + ctx.attr.linker_bin_path,
-                            ]),
+                            ) + (
+                                ["-B" + ctx.attr.linker_bin_path] if ctx.attr.linker_bin_path else []
+                            ),
                             flag_group(
                                 flags = ["@%{linker_param_file}"],
                                 expand_if_available = "linker_param_file",


### PR DESCRIPTION
If ctx.attr.linker_bin_path is empty (e.g. if should_download_clang is set)
the GPU build would add a lone `-B` to the build which swallows the next
argument leading to broken builds.

Fixes #41856, fixes #42313

Example from https://github.com/tensorflow/tensorflow/issues/41856#issuecomment-665623137:

```
-Wl,-no-as-needed
-B
-o
bazel-out/k8-opt/bin/external/com_google_protobuf/protoc
bazel-out/k8-opt/bin/external/com_google_protobuf/_objs/protoc/main.o
...
```

As can be seen the lone `-B` swallows the `-o` making the compiler thing the intended output is an input.