### PR TITLE
DOC Add None as possible in input_shape

### DIFF
--- a/tensorflow/python/keras/layers/convolutional.py
+++ b/tensorflow/python/keras/layers/convolutional.py
@@ -524,7 +524,7 @@ class Conv2D(Conv):
 
   When using this layer as the first layer in a model,
   provide the keyword argument `input_shape`
-  (tuple of integers, does not include the sample axis),
+  (tuple of integers or `None`, does not include the sample axis),
   e.g. `input_shape=(128, 128, 3)` for 128x128 RGB pictures
   in `data_format="channels_last"`.
 
@@ -683,7 +683,7 @@ class Conv3D(Conv):
 
   When using this layer as the first layer in a model,
   provide the keyword argument `input_shape`
-  (tuple of integers, does not include the sample axis),
+  (tuple of integers or `None`, does not include the sample axis),
   e.g. `input_shape=(128, 128, 128, 1)` for 128x128x128 volumes
   with a single channel,
   in `data_format="channels_last"`.
@@ -832,7 +832,7 @@ class Conv1DTranspose(Conv1D):
 
   When using this layer as the first layer in a model,
   provide the keyword argument `input_shape`
-  (tuple of integers, does not include the sample axis),
+  (tuple of integers or `None`, does not include the sample axis),
   e.g. `input_shape=(128, 3)` for data with 128 time steps and 3 channels.
 
   Arguments:
@@ -1079,7 +1079,7 @@ class Conv2DTranspose(Conv2D):
 
   When using this layer as the first layer in a model,
   provide the keyword argument `input_shape`
-  (tuple of integers, does not include the sample axis),
+  (tuple of integers or `None`, does not include the sample axis),
   e.g. `input_shape=(128, 128, 3)` for 128x128 RGB pictures
   in `data_format="channels_last"`.
 
@@ -1382,7 +1382,7 @@ class Conv3DTranspose(Conv3D):
 
   When using this layer as the first layer in a model,
   provide the keyword argument `input_shape`
-  (tuple of integers, does not include the sample axis),
+  (tuple of integers or `None`, does not include the sample axis),
   e.g. `input_shape=(128, 128, 128, 3)` for a 128x128x128 volume with 3 channels
   if `data_format="channels_last"`.
 


### PR DESCRIPTION
Update docs to explicitly mention that `None` can be passed in `input_shape`.