### PR TITLE
fixing problem with patching CMSIS lib when installing under msys64.

### DIFF
--- a/tensorflow/lite/micro/tools/make/download_and_extract.sh
+++ b/tensorflow/lite/micro/tools/make/download_and_extract.sh
@@ -104,86 +104,86 @@ patch_cmsis() {
     sed -i -E $'s@#include "arm_nn_types.h"@#include "cmsis/CMSIS/NN/Include/arm_nn_types.h"@g' {} \;
 
   find tensorflow/lite/micro/tools/make/downloads/cmsis \
-    -iname '*.*' -exec \
+    \( -iname '*.c' -o -iname '*.cpp' -o -iname '*.h' -o -iname '*.py' \) -exec \
     sed -i -E $'s@#include "arm_math.h"@#include "cmsis/CMSIS/DSP/Include/arm_math.h"@g' {} \;
 
   find tensorflow/lite/micro/tools/make/downloads/cmsis \
-    -iname '*.*' -exec \
+    \( -iname '*.c' -o -iname '*.cpp' -o -iname '*.h' -o -iname '*.py' \) -exec \
     sed -i -E $'s@#include "arm_common_tables.h"@#include "cmsis/CMSIS/DSP/Include/arm_common_tables.h"@g' {} \;
 
   find tensorflow/lite/micro/tools/make/downloads/cmsis \
-    -iname '*.*' -exec \
+    \( -iname '*.c' -o -iname '*.cpp' -o -iname '*.h' -o -iname '*.py' \) -exec \
     sed -i -E $'s@#include "arm_nn_tables.h"@#include "cmsis/CMSIS/NN/Include/arm_nn_tables.h"@g' {} \;
 
   find tensorflow/lite/micro/tools/make/downloads/cmsis \
-    -iname '*.*' -exec \
+    \( -iname '*.c' -o -iname '*.cpp' -o -iname '*.h' -o -iname '*.py' \) -exec \
     sed -i -E $'s@#include "arm_math_types.h"@#include "cmsis/CMSIS/DSP/Include/arm_math_types.h"@g' {} \;
 
   find tensorflow/lite/micro/tools/make/downloads/cmsis \
-    -iname '*.*' -exec \
+    \( -iname '*.c' -o -iname '*.cpp' -o -iname '*.h' -o -iname '*.py' \) -exec \
     sed -i -E $'s@#include "arm_math_memory.h"@#include "cmsis/CMSIS/DSP/Include/arm_math_memory.h"@g' {} \;
 
   find tensorflow/lite/micro/tools/make/downloads/cmsis \
-    -iname '*.*' -exec \
+    \( -iname '*.c' -o -iname '*.cpp' -o -iname '*.h' -o -iname '*.py' \) -exec \
     sed -i -E $'s@#include "dsp/none.h"@#include "cmsis/CMSIS/DSP/Include/dsp/none.h"@g' {} \;
 
   find tensorflow/lite/micro/tools/make/downloads/cmsis \
-    -iname '*.*' -exec \
+    \( -iname '*.c' -o -iname '*.cpp' -o -iname '*.h' -o -iname '*.py' \) -exec \
     sed -i -E $'s@#include "dsp/utils.h"@#include "cmsis/CMSIS/DSP/Include/dsp/utils.h"@g' {} \;
 
   find tensorflow/lite/micro/tools/make/downloads/cmsis \
-    -iname '*.*' -exec \
+    \( -iname '*.c' -o -iname '*.cpp' -o -iname '*.h' -o -iname '*.py' \) -exec \
     sed -i -E $'s@#include "dsp/basic_math_functions.h"@#include "cmsis/CMSIS/DSP/Include/dsp/basic_math_functions.h"@g' {} \;
   find tensorflow/lite/micro/tools/make/downloads/cmsis \
-    -iname '*.*' -exec \
+    \( -iname '*.c' -o -iname '*.cpp' -o -iname '*.h' -o -iname '*.py' \) -exec \
     sed -i -E $'s@#include "dsp/statistics_functions.h"@#include "cmsis/CMSIS/DSP/Include/dsp/statistics_functions.h"@g' {} \;
 
   find tensorflow/lite/micro/tools/make/downloads/cmsis \
-    -iname '*.*' -exec \
+    \( -iname '*.c' -o -iname '*.cpp' -o -iname '*.h' -o -iname '*.py' \) -exec \
     sed -i -E $'s@#include "dsp/svm_defines.h"@#include "cmsis/CMSIS/DSP/Include/dsp/svm_defines.h"@g' {} \;
 
   find tensorflow/lite/micro/tools/make/downloads/cmsis \
-    -iname '*.*' -exec \
+    \( -iname '*.c' -o -iname '*.cpp' -o -iname '*.h' -o -iname '*.py' \) -exec \
     sed -i -E $'s@#include "dsp/svm_functions.h"@#include "cmsis/CMSIS/DSP/Include/dsp/svm_functions.h"@g' {} \;
 
   find tensorflow/lite/micro/tools/make/downloads/cmsis \
-    -iname '*.*' -exec \
+    \( -iname '*.c' -o -iname '*.cpp' -o -iname '*.h' -o -iname '*.py' \) -exec \
     sed -i -E $'s@#include "dsp/support_functions.h"@#include "cmsis/CMSIS/DSP/Include/dsp/support_functions.h"@g' {} \;
 
   find tensorflow/lite/micro/tools/make/downloads/cmsis \
-    -iname '*.*' -exec \
+    \( -iname '*.c' -o -iname '*.cpp' -o -iname '*.h' -o -iname '*.py' \) -exec \
     sed -i -E $'s@#include "dsp/transform_functions.h"@#include "cmsis/CMSIS/DSP/Include/dsp/transform_functions.h"@g' {} \;
 
   find tensorflow/lite/micro/tools/make/downloads/cmsis \
-    -iname '*.*' -exec \
+    \( -iname '*.c' -o -iname '*.cpp' -o -iname '*.h' -o -iname '*.py' \) -exec \
     sed -i -E $'s@#include "dsp/bayes_functions.h"@#include "cmsis/CMSIS/DSP/Include/dsp/bayes_functions.h"@g' {} \;
 
   find tensorflow/lite/micro/tools/make/downloads/cmsis \
-    -iname '*.*' -exec \
+    \( -iname '*.c' -o -iname '*.cpp' -o -iname '*.h' -o -iname '*.py' \) -exec \
     sed -i -E $'s@#include "dsp/complex_math_functions.h"@#include "cmsis/CMSIS/DSP/Include/dsp/complex_math_functions.h"@g' {} \;
 
   find tensorflow/lite/micro/tools/make/downloads/cmsis \
-    -iname '*.*' -exec \
+    \( -iname '*.c' -o -iname '*.cpp' -o -iname '*.h' -o -iname '*.py' \) -exec \
     sed -i -E $'s@#include "dsp/controller_functions.h"@#include "cmsis/CMSIS/DSP/Include/dsp/controller_functions.h"@g' {} \;
 
   find tensorflow/lite/micro/tools/make/downloads/cmsis \
-    -iname '*.*' -exec \
+    \( -iname '*.c' -o -iname '*.cpp' -o -iname '*.h' -o -iname '*.py' \) -exec \
     sed -i -E $'s@#include "dsp/distance_functions.h"@#include "cmsis/CMSIS/DSP/Include/dsp/distance_functions.h"@g' {} \;
 
   find tensorflow/lite/micro/tools/make/downloads/cmsis \
-    -iname '*.*' -exec \
+    \( -iname '*.c' -o -iname '*.cpp' -o -iname '*.h' -o -iname '*.py' \) -exec \
     sed -i -E $'s@#include "dsp/fast_math_functions.h"@#include "cmsis/CMSIS/DSP/Include/dsp/fast_math_functions.h"@g' {} \;
 
   find tensorflow/lite/micro/tools/make/downloads/cmsis \
-    -iname '*.*' -exec \
+    \( -iname '*.c' -o -iname '*.cpp' -o -iname '*.h' -o -iname '*.py' \) -exec \
     sed -i -E $'s@#include "dsp/filtering_functions.h"@#include "cmsis/CMSIS/DSP/Include/dsp/filtering_functions.h"@g' {} \;
 
   find tensorflow/lite/micro/tools/make/downloads/cmsis \
-    -iname '*.*' -exec \
+    \( -iname '*.c' -o -iname '*.cpp' -o -iname '*.h' -o -iname '*.py' \) -exec \
     sed -i -E $'s@#include "dsp/interpolation_functions.h"@#include "cmsis/CMSIS/DSP/Include/dsp/interpolation_functions.h"@g' {} \;
 
   find tensorflow/lite/micro/tools/make/downloads/cmsis \
-    -iname '*.*' -exec \
+    \( -iname '*.c' -o -iname '*.cpp' -o -iname '*.h' -o -iname '*.py' \) -exec \
     sed -i -E $'s@#include "dsp/matrix_functions.h"@#include "cmsis/CMSIS/DSP/Include/dsp/matrix_functions.h"@g' {} \;
 
   # Until the fix for https://github.com/ARMmbed/mbed-os/issues/12568 is


### PR DESCRIPTION
When patching CMSIS under Win10/msys64 the command

`find tensorflow/lite/micro/tools/make/downloads/cmsis -iname '*.*'`

matches on the directory name '.settings' and sends it to the 'sed' command which then results in an error

`sed: couldn't edit tensorflow/lite/micro/tools/make/downloads/cmsis/CMSIS/DSP/DSP_Lib_TestSuite/DspLibTest_FVP_A5/.settings: not a regular file`

This terminates patching and leaves a partially patched CMSIS package behind. To improve this, 'find' should pass only files that match certain pattern to 'sed'.
