### PR TITLE
Fix a TF Lite issue when loading a saved TF Lite model on platforms with different endianness

### DIFF
--- a/tensorflow/compiler/mlir/lite/flatbuffer_export.cc
+++ b/tensorflow/compiler/mlir/lite/flatbuffer_export.cc
@@ -69,6 +69,7 @@ limitations under the License.
 #include "tensorflow/compiler/xla/statusor.h"
 #include "tensorflow/core/framework/attr_value.pb.h"
 #include "tensorflow/core/framework/node_def.pb.h"
+#include "tensorflow/core/platform/byte_order.h"
 #include "tensorflow/core/platform/errors.h"
 #include "tensorflow/core/platform/logging.h"
 #include "tensorflow/core/platform/status.h"
@@ -1283,6 +1284,10 @@ Translator::CreateMetadataVector() {
   // cause any waste of space if the actual string is shorter than 16 bytes.
   metadata.push_back(
       BuildMetadata("min_runtime_version", std::string(16, '\0')));
+  // Export a string buffer that contains the model's endianness information.
+  std::string endianness = (tensorflow::port::kLittleEndian) ? "little" : "big";
+  metadata.push_back(
+      BuildMetadata("model_endianness", endianness));
   return builder_.CreateVector(metadata);
 }
 

--- a/tensorflow/lite/BUILD
+++ b/tensorflow/lite/BUILD
@@ -292,6 +292,7 @@ cc_library(
         ":type_to_tflitetype",
         ":util",
         ":version",
+        "//tensorflow/core/platform:byte_order",
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/core/api",
         "//tensorflow/lite/delegates/nnapi:nnapi_delegate",

--- a/tensorflow/lite/BUILD
+++ b/tensorflow/lite/BUILD
@@ -257,6 +257,7 @@ cc_library(
         ":type_to_tflitetype",
         ":util",
         ":version",
+        "//tensorflow/core/platform:byte_order",
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/core/api",
         "//tensorflow/lite/delegates:status",

--- a/tensorflow/lite/interpreter_builder.h
+++ b/tensorflow/lite/interpreter_builder.h
@@ -92,6 +92,7 @@ class InterpreterBuilder {
 
   bool has_flex_op_ = false;
   int num_fp32_tensors_ = 0;
+  bool need_to_swap_bytes_ = false;
 };
 
 }  // namespace tflite

--- a/tensorflow/lite/model_builder.h
+++ b/tensorflow/lite/model_builder.h
@@ -148,6 +148,11 @@ class FlatBufferModel {
   // reported minimum.
   std::string GetMinimumRuntime() const;
 
+  // Return the endianness of the serialized flatbuffer. If the endianness is
+  // different from the host machine endianness, the tensors need to be
+  // byte-swapped during interpreter initialization.
+  string GetModelEndianness() const;
+
   /// Returns true if the model identifier is correct (otherwise false and
   /// reports an error).
   bool CheckModelIdentifier() const;

--- a/tensorflow/lite/toco/tflite/export_test.cc
+++ b/tensorflow/lite/toco/tflite/export_test.cc
@@ -264,7 +264,7 @@ TEST_F(ExportTest, ExportMinRuntime) {
   std::string output;
   auto status = Export(input_model_, &output, params);
   auto* model = ::tflite::GetModel(output.data());
-  EXPECT_EQ(model->metadata()->size(), 1);
+  EXPECT_EQ(model->metadata()->size(), 2);
   EXPECT_EQ(model->metadata()->Get(0)->name()->str(), "min_runtime_version");
   auto buf = model->metadata()->Get(0)->buffer();
   auto* buffer = (*model->buffers())[buf];
@@ -283,7 +283,7 @@ TEST_F(ExportTest, ExportEmptyMinRuntime) {
   std::string output;
   auto status = Export(input_model_, &output, params);
   auto* model = ::tflite::GetModel(output.data());
-  EXPECT_EQ(model->metadata()->size(), 1);
+  EXPECT_EQ(model->metadata()->size(), 2);
   EXPECT_EQ(model->metadata()->Get(0)->name()->str(), "min_runtime_version");
   auto buf = model->metadata()->Get(0)->buffer();
   auto* buffer = (*model->buffers())[buf];

--- a/third_party/aws/BUILD.bazel
+++ b/third_party/aws/BUILD.bazel
@@ -24,6 +24,9 @@ cc_library(
         "@org_tensorflow//tensorflow:linux_ppc64le": glob([
             "aws-cpp-sdk-core/source/platform/linux-shared/*.cpp",
         ]),
+        "@org_tensorflow//tensorflow:linux_s390x": glob([
+            "aws-cpp-sdk-core/source/platform/linux-shared/*.cpp",
+        ]),
         "@org_tensorflow//tensorflow:raspberry_pi_armeabi": glob([
             "aws-cpp-sdk-core/source/platform/linux-shared/*.cpp",
         ]),


### PR DESCRIPTION
In the current TensorFlow Lite mechanism, the saved `.tflite` model will not have any information indicating the endianness of the serialized model, which might cause some op tensors not being read correctly if loading the model on a machine with different endianness. Here is a related [issue](https://github.com/tensorflow/tensorflow/issues/28807).

The issue is also causing two test cases failure for TensorFlow Serving: `//tensorflow_serving/servables/tensorflow:saved_model_bundle_factory_test` and `//tensorflow_serving/servables/tensorflow:tflite_session_test`. Because these two test cases will load a pre-generated `model.tflite` file (generated on little endian), so they fail when testing on big endian machines.

A similar issue is resolved for a regular TensorFlow model, as the endianness information is written alongside the model itself, see [here](https://github.com/tensorflow/tensorflow/blob/1492da4bae85410a9ce5b896b871de2fb930ba06/tensorflow/core/util/tensor_bundle/tensor_bundle.cc#L546). And such endianness info will be read on loading, and byte-swapping will be conducted if the endianness of the model is different from the endianness of the host, see [here](https://github.com/tensorflow/tensorflow/blob/1492da4bae85410a9ce5b896b871de2fb930ba06/tensorflow/core/util/tensor_bundle/tensor_bundle.cc#L793).

Consequently, I am using a similar approach to saved `.tflite` models. I make use of the `Metadata` field in the [schema](https://github.com/tensorflow/tensorflow/blob/1492da4bae85410a9ce5b896b871de2fb930ba06/tensorflow/lite/schema/schema.fbs#L1073) of saved TF Lite Model, saving a string type metadata indicating `little` or `big` of the machine endianness where the model is saved.

This piece of metadata will be read when the `FlatBufferModel` is passed into an `InterpreterBuilder`, and the byte-swapping will be conducted during `ParseTensors`. Right now I am only supporting the byte-swap of float type tensors, as they are the most common ones. It is also possible to add support for more data types if needed.

Please also note that this PR will not cause any test cases regression for TensorFlow, and it is also compatible with TF Lite models generated before because if the `Metadata` field is not found in the saved model, the loader will assume the model is generated with the same host endianness (which is basically what is happening without the changes). And after the changes, even the `model.tflite` file generated on a little-endian machine will make the TensorFlow Serving test case pass on a big-endian machine (vice versa).

This PR is also including a small fix for aws building target on s390x arch.