### PR TITLE
Fix expensive decompression in JPEG GetImageInfo

### DIFF
--- a/tensorflow/core/lib/jpeg/jpeg_mem.cc
+++ b/tensorflow/core/lib/jpeg/jpeg_mem.cc
@@ -164,7 +164,7 @@ uint8* UncompressLow(const void* srcdata, FewerArgsForCompiler* argball) {
   cinfo.dct_method = flags.dct_method;
 
   // Determine the output image size before attempting decompress to prevent
-  // OOM'ing doing the decompress
+  // OOM'ing during the decompress
   jpeg_calc_output_dimensions(&cinfo);
 
   int64 total_size = static_cast<int64>(cinfo.output_height) *

--- a/tensorflow/core/lib/jpeg/jpeg_mem.cc
+++ b/tensorflow/core/lib/jpeg/jpeg_mem.cc
@@ -577,7 +577,7 @@ bool GetImageInfo(const void* srcdata, int datasize, int* width, int* height,
   SetSrc(&cinfo, srcdata, datasize, false);
 
   jpeg_read_header(&cinfo, TRUE);
-  jpeg_start_decompress(&cinfo);  // required to transfer image size to cinfo
+  jpeg_calc_output_dimensions(&cinfo);
   if (width) *width = cinfo.output_width;
   if (height) *height = cinfo.output_height;
   if (components) *components = cinfo.output_components;


### PR DESCRIPTION
The current implementation of GetImageInfo starts a libjpeg decompression pass over input images. Certain images (e.g., progressive JPEG) trigger a full image decompression, resulting in a performance degradation. This commit switches to an equivalent but cheaper libjpeg call for evaluating image dimensions.

The end result is performance is currently slowed down on these images by over **50x** when using ExtractJpegShape.

To reproduce, download input image as 'test_img.jpg':
![test_img](https://user-images.githubusercontent.com/12423239/96190717-ac53d280-0f10-11eb-9bb9-ee1c3301c49e.jpg)

Convert it to progressive jpeg:
`jpegtran -progressive test_img.jpg > test_img_progressive.jpg`

And benchmark using test_img_progressive.jpg with `use_shape=False` and `use_shape=True`. On my machine, the first finishes in 0.12 seconds and the second in 8.85 seconds (roughly 70x performance degradation).

```python3
import tensorflow as tf
import numpy as np

import timeit

# Inputs
#filenames = ["test_img.jpg"]
filenames = ["test_img_progressive.jpg"]
#use_shape = False
use_shape = True
# End Inputs

def read_path(file_path):
    img = tf.io.read_file(file_path)
    return img

def jpeg_to_shape(image_buffer):
  shape = tf.image.extract_jpeg_shape(image_buffer)
  return shape

def fake_jpeg_to_shape(image_buffer):
  """Pretend we read shape using extract jpeg shape"""
  shape = np.array([1920, 1080, 3], dtype=np.int32)
  return shape

def create_dataset():
    dataset = tf.data.Dataset.from_tensor_slices(filenames)
    dataset = dataset.map(read_path)
    dataset = dataset.cache()
    if use_shape:
        dataset = dataset.map(jpeg_to_shape)
    else:
        dataset = dataset.map(fake_jpeg_to_shape)
    return dataset

def noop():
    return None

def run_loop(dataset):
    for x in dataset:
        noop()

def main():
    dataset = create_dataset()
    dataset = dataset.repeat(1000) # run 1e3 times
    timeit_results = timeit.timeit(lambda: run_loop(dataset),
                                   number=1
                                   )
    print("Elapsed time:\n{}".format(timeit_results))

if __name__ == "__main__":
    main()
```

Inspecting profiling results, the _data decoding_ part of the decompression pass is being performed on the JPEG. In other words, the JPEG is being decompressed at near the full cost of decompression rather than simply extracting the shape (a _metadata_ operation).
![get_shape_profiler](https://user-images.githubusercontent.com/12423239/96191390-fc7f6480-0f11-11eb-9943-4fd9d7fe70a0.png)

This PR replaces the `jpeg_start_decompress` call with a call to `jpeg_calc_output_dimensions`, which fills out the required `cinfo` fields without decompressing the data.
