### PR TITLE
Fix zephyr_riscv hello_world demo

### DIFF
--- a/tensorflow/lite/micro/examples/hello_world/zephyr_riscv/prj.conf
+++ b/tensorflow/lite/micro/examples/hello_world/zephyr_riscv/prj.conf
@@ -14,3 +14,4 @@
 # ==============================================================================
 CONFIG_CPLUSPLUS=y
 CONFIG_NEWLIB_LIBC=y
+CONFIG_NETWORKING=n


### PR DESCRIPTION
This disables networking in the project's configuration,
as the target platform does not support any network controller.