### PR TITLE
Fix zephyr_riscv build process

### DIFF
--- a/tensorflow/lite/micro/tools/make/templates/zephyr_cmake_project.cmake.tpl
+++ b/tensorflow/lite/micro/tools/make/templates/zephyr_cmake_project.cmake.tpl
@@ -2,12 +2,10 @@ cmake_minimum_required(VERSION 3.13.1)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(tf_lite_magic_wand)
 
-set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} %{CXX_FLAGS}%")
+# -fno-threadsafe-statics -- disables the mutex around initialization of local static variables
+set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} %{CXX_FLAGS}% -fno-threadsafe-statics -Wno-sign-compare -Wno-narrowing")
 set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} %{CC_FLAGS}%")
 set(CMAKE_EXE_LINKER_FLAGS "%{LINKER_FLAGS}%")
-
-# -fno-threadsafe-statics -- disables the mutex around initialization of local static variables
-target_compile_options(app PRIVATE "-fno-threadsafe-statics")
 
 target_sources(app PRIVATE
 		%{SRCS}%


### PR DESCRIPTION
This adds additional compiler flags for Zephyr applications
in order to eliminate compilation warnings that are treated as errors.

Additionally, the `-fno-threadsafe-statics` switch can be applied to C++ files only.