### PR TITLE
Add SelectV2 to list of format agnostic ops

### DIFF
--- a/tensorflow/core/grappler/optimizers/layout_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/layout_optimizer.cc
@@ -181,6 +181,7 @@ std::set<string> GetOpsFormatAgnostic() {
                                           "ReluGrad",
                                           "Rint",
                                           "Select",
+                                          "SelectV2",
                                           "Selu",
                                           "SeluGrad",
                                           "Shape",


### PR DESCRIPTION
Since 7ea9c329266e365f667cfb75965543c08bac7476 grappler treats `Select` and `SelectV2` the same.
This PR adds `SelectV2` to `GetOpsFormatAgnostic` in order to also support [layout optimizations](https://github.com/tensorflow/tensorflow/blob/dc843fad65fb4eb1b173a7577d0d932b2af94951/tensorflow/core/grappler/optimizers/layout_optimizer.cc#L2142-L2143) . I can't think of a reason why this pass shouldn't be  enabled for `SelectV2`, but let me know if I am missing something here.