### PR TITLE
Remove Python 2 instructions from TF Lite demo README

### DIFF
--- a/tensorflow/lite/examples/python/README.md
+++ b/tensorflow/lite/examples/python/README.md
@@ -31,8 +31,6 @@ mv /tmp/mobilenet_v1_1.0_224/labels.txt /tmp/
 
 ## Run the sample
 
-Note: Instead use `python` if you're using Python 2.x.
-
 ```sh
 python3 label_image.py \
   --model_file /tmp/mobilenet_v1_1.0_224.tflite \


### PR DESCRIPTION
Python 2 is not supported in TensorFlow after TF 2.1, so having Python 2 instructions in a demo's README in 2.4.0 is misleading.