### PR TITLE
Rename Raspbian to Raspberry Pi OS

### DIFF
--- a/tensorflow/lite/g3doc/guide/build_rpi.md
+++ b/tensorflow/lite/g3doc/guide/build_rpi.md
@@ -81,8 +81,8 @@ PATH=../rpi_tools/arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf/bin:$PATH \
 
 ## Compile natively on Raspberry Pi
 
-The following instructions have been tested on Raspberry Pi Zero, Raspbian
-GNU/Linux 10 (buster), gcc version 8.3.0 (Raspbian 8.3.0-6+rpi1):
+The following instructions have been tested on Raspberry Pi Zero, Raspberry Pi OS (previously called Raspbian)
+GNU/Linux 10 (Buster), gcc version 8.3.0 (Raspbian 8.3.0-6+rpi1):
 
 To natively compile TensorFlow Lite follow the steps:
 

--- a/tensorflow/lite/g3doc/guide/build_rpi.md
+++ b/tensorflow/lite/g3doc/guide/build_rpi.md
@@ -81,8 +81,9 @@ PATH=../rpi_tools/arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf/bin:$PATH \
 
 ## Compile natively on Raspberry Pi
 
-The following instructions have been tested on Raspberry Pi Zero, Raspberry Pi OS (previously called Raspbian)
-GNU/Linux 10 (Buster), gcc version 8.3.0 (Raspbian 8.3.0-6+rpi1):
+The following instructions have been tested on Raspberry Pi Zero, Raspberry Pi OS 
+(previously called Raspbian) GNU/Linux 10 (Buster), gcc version 8.3.0 
+(Raspbian 8.3.0-6+rpi1):
 
 To natively compile TensorFlow Lite follow the steps:
 

--- a/tensorflow/lite/g3doc/guide/build_rpi.md
+++ b/tensorflow/lite/g3doc/guide/build_rpi.md
@@ -82,8 +82,7 @@ PATH=../rpi_tools/arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf/bin:$PATH \
 ## Compile natively on Raspberry Pi
 
 The following instructions have been tested on Raspberry Pi Zero, Raspberry Pi OS 
-(previously called Raspbian) GNU/Linux 10 (Buster), gcc version 8.3.0 
-(Raspbian 8.3.0-6+rpi1):
+GNU/Linux 10 (Buster), gcc version 8.3.0 (Raspbian 8.3.0-6+rpi1):
 
 To natively compile TensorFlow Lite follow the steps:
 

--- a/tensorflow/lite/g3doc/guide/python.md
+++ b/tensorflow/lite/g3doc/guide/python.md
@@ -29,8 +29,9 @@ package](https://www.tensorflow.org/install/).
 To install, run `pip3 install` and pass it the appropriate Python wheel URL from
 the following table.
 
-For example, if you have Raspberry Pi that's running Raspberry Pi OS 10 (previously called Raspbian Buster) (which has
-Python 3.7), install the Python wheel as follows:
+For example, if you have Raspberry Pi that's running Raspberry Pi OS 10 
+(previously called Raspbian Buster) (which has Python 3.7), install the 
+Python wheel as follows:
 
 <pre class="devsite-terminal devsite-click-to-copy">
 pip3 install https://dl.google.com/coral/python/tflite_runtime-2.1.0.post1-cp37-cp37m-linux_armv7l.whl

--- a/tensorflow/lite/g3doc/guide/python.md
+++ b/tensorflow/lite/g3doc/guide/python.md
@@ -29,7 +29,7 @@ package](https://www.tensorflow.org/install/).
 To install, run `pip3 install` and pass it the appropriate Python wheel URL from
 the following table.
 
-For example, if you have Raspberry Pi that's running Raspbian Buster (which has
+For example, if you have Raspberry Pi that's running Raspberry Pi OS 10 (previously called Raspbian Buster) (which has
 Python 3.7), install the Python wheel as follows:
 
 <pre class="devsite-terminal devsite-click-to-copy">

--- a/tensorflow/lite/g3doc/guide/python.md
+++ b/tensorflow/lite/g3doc/guide/python.md
@@ -29,9 +29,8 @@ package](https://www.tensorflow.org/install/).
 To install, run `pip3 install` and pass it the appropriate Python wheel URL from
 the following table.
 
-For example, if you have Raspberry Pi that's running Raspberry Pi OS 10 
-(previously called Raspbian Buster) (which has Python 3.7), install the 
-Python wheel as follows:
+For example, if you have a Raspberry Pi that's running Raspberry Pi OS 10 
+(which has Python 3.7), install the Python wheel as follows:
 
 <pre class="devsite-terminal devsite-click-to-copy">
 pip3 install https://dl.google.com/coral/python/tflite_runtime-2.1.0.post1-cp37-cp37m-linux_armv7l.whl


### PR DESCRIPTION
This May, Raspbian was renamed to Raspberry Pi OS, as visible on the [official Raspberry Pi downloads page](https://www.raspberrypi.org/downloads/raspberry-pi-os/). In order to maintain consistency and reduce confusion for new users, we should replace `Raspbian` with `Raspberry Pi OS` in our docs wherever it makes sense.