### PR TITLE
Fix nasnet.py default weights

### DIFF
--- a/tensorflow/python/keras/applications/nasnet.py
+++ b/tensorflow/python/keras/applications/nasnet.py
@@ -70,7 +70,7 @@ def NASNet(
     skip_reduction=True,
     filter_multiplier=2,
     include_top=True,
-    weights=None,
+    weights='imagenet',
     input_tensor=None,
     pooling=None,
     classes=1000,


### PR DESCRIPTION
Default `weights` of `nasnet.py` should be `'imagenet'` instead of `None`