### PR TITLE
[ROCm] Fix for ROCm CSB Breakage - 201017

### DIFF
--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -33,6 +33,7 @@ from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import resource_variable_ops
 from tensorflow.python.ops import variables
 from tensorflow.python.platform import googletest
+from tensorflow.python.platform import test
 
 
 @test_util.run_all_in_graph_and_eager_modes
@@ -886,6 +887,12 @@ class RangeTest(test_util.TensorFlowTestCase):
 class ErfcinvTest(test_util.TensorFlowTestCase):
 
   def testErfcinv(self):
+    if test.is_built_with_rocm():
+      # The implementation of erfcinv calls ndtri op,
+      # and the ROCm implementaion for ndtri op has a known bug in it
+      # whose fix will be in a forthcoming ROCm release (4.0 ?).
+      # Need to skip this unit-test until that ROCm release is out
+      self.skipTest("ndtri op implementation is buggy on ROCm")
     values = np.random.uniform(0.1, 1.9, size=int(1e4)).astype(np.float32)
     approx_id = math_ops.erfc(math_ops.erfcinv(values))
     self.assertAllClose(values, self.evaluate(approx_id))


### PR DESCRIPTION
The following commit introduces a new subtest that fails on the ROCM platform.

https://github.com/tensorflow/tensorflow/commit/e31505fdee68ca72885cc60b170939bb8efcce0d

The subtest is for the `tf.math.efrcinv` op uses the `ndtri` op. The (Eigen) implementation for the `ndtri` op on the ROCM platform has a known bug in it. That bug has been fixed (for reference - internal JIRA ticket 236756), and will be available in a forthcoming ROCm release.

For the time being (i.e. until that ROCm release is out) we need to skip this subtest on the ROCm platform, and hence this commit.


--------------------------------

/cc @cheshire @chsigg @nvining-work 