### PR TITLE
[Intel MKL] Update legacy APIs and reenable mkl_dequantize_op_test

### DIFF
--- a/tensorflow/core/kernels/mkl/BUILD
+++ b/tensorflow/core/kernels/mkl/BUILD
@@ -274,6 +274,7 @@ tf_cc_test_mkl(
     name = "mkl_dequantize_op_test",
     size = "small",
     srcs = ["mkl_dequantize_op_test.cc"],
+    linkstatic = 1,  # Fixes dyld error on MacOS.
     deps = [
         ":mkl_dequantize_op",
         ":mkl_tfconv_op",

--- a/tensorflow/core/kernels/mkl/BUILD
+++ b/tensorflow/core/kernels/mkl/BUILD
@@ -274,11 +274,6 @@ tf_cc_test_mkl(
     name = "mkl_dequantize_op_test",
     size = "small",
     srcs = ["mkl_dequantize_op_test.cc"],
-    # TODO(b/149940073): Re-enable.
-    tags = [
-        "no_oss",
-        "notap",
-    ],
     deps = [
         ":mkl_dequantize_op",
         ":mkl_tfconv_op",

--- a/tensorflow/core/kernels/mkl/mkl_dequantize_op_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_dequantize_op_test.cc
@@ -62,6 +62,23 @@ TEST_F(MklDequantizeOpTest, small) {
   test::ExpectTensorNear<float>(expected, output, 0.1);
 }
 
+Tensor CreateMklInput() {
+  MklDnnShape mkl_shape;
+  memory::desc md =
+      memory::desc({1, 2, 2, 2}, MklDnnType<uint8>(), memory::format_tag::nhwc);
+  mkl_shape.SetMklTensor(true);
+  mkl_shape.SetMklLayout(&md);
+  mkl_shape.SetElemType(MklDnnType<uint8>());
+  mkl_shape.SetTfLayout(4, {1, 2, 2, 2}, MKL_TENSOR_FORMAT_NHWC);
+
+  DataType dtype = DataTypeToEnum<uint8>::v();
+  Tensor mkl_tensor(dtype, {mkl_shape.GetSerializeBufferSize()});
+  mkl_shape.SerializeMklDnnShape(
+      mkl_tensor.flat<uint8>().data(),
+      mkl_tensor.flat<uint8>().size() * sizeof(uint8));
+  return mkl_tensor;
+}
+
 template <typename T>
 class CommonTestUtilities : public OpsTestBase {
  public:
@@ -112,7 +129,8 @@ TEST_F(MklDequantizeOpTest, MKLInput) {
   AddInputFromArray<float>(TensorShape({1}), {0});
   // max_range = 200
   AddInputFromArray<float>(TensorShape({1}), {200.0f});
-  AddInputFromArray<uint8>(dummy_shape, dummy_tensor);
+  auto mkl_tensor = CreateMklInput();
+  AddInputFromArray<uint8>(mkl_tensor.shape(), mkl_tensor.flat<uint8>());
   AddInputFromArray<uint8>(dummy_shape, dummy_tensor);
   AddInputFromArray<uint8>(dummy_shape, dummy_tensor);
   TF_ASSERT_OK(RunOpKernel());


### PR DESCRIPTION
Small fix to update legacy API in `mkl_dequantize_op_test.cc` and reenable it.

Signed-off-by: Lu Teng teng.lu@intel.com