### PR TITLE
Specify -mfpu for TARGET_ARCH=cortex-m4+fpu

### DIFF
--- a/tensorflow/lite/micro/tools/make/targets/cortex_m_generic_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/cortex_m_generic_makefile.inc
@@ -8,12 +8,10 @@ GCC_TARGET_ARCH := $(TARGET_ARCH)
 ifeq ($(TARGET_ARCH), cortex-m0)
   CORE=M0
   ARM_LDFLAGS := -Wl,--cpu=Cortex-M0
-  TARGET_SPECIFIC_FLAGS +=
 
 else ifeq ($(TARGET_ARCH), cortex-m3)
   CORE=M3
   ARM_LDFLAGS := -Wl,--cpu=Cortex-M3
-  TARGET_SPECIFIC_FLAGS +=
 
 else ifeq ($(TARGET_ARCH), cortex-m33)
   CORE=M33
@@ -24,7 +22,6 @@ else ifeq ($(TARGET_ARCH), cortex-m33)
 else ifeq ($(TARGET_ARCH), cortex-m33+nodsp)
   CORE=M33
   ARM_LDFLAGS := -Wl,--cpu=Cortex-M33.no_dsp.no_fp
-  TARGET_SPECIFIC_FLAGS +=
 
 else ifeq ($(TARGET_ARCH), cortex-m4)
   CORE=M4
@@ -33,6 +30,7 @@ else ifeq ($(TARGET_ARCH), cortex-m4)
 else ifeq ($(TARGET_ARCH), cortex-m4+fp)
   CORE=M4
   ARM_LDFLAGS := -Wl,--cpu=Cortex-M4
+  TARGET_SPECIFIC_FLAGS += -D__FPU_PRESENT=1 -mfpu=fpv4-sp-d16
   FLOAT=hard
   GCC_TARGET_ARCH := cortex-m4
 
@@ -45,7 +43,6 @@ else ifeq ($(TARGET_ARCH), cortex-m55)
 else ifeq ($(TARGET_ARCH), cortex-m55+nodsp+nofp)
   CORE=M55
   ARM_LDFLAGS := -Wl,--cpu=8.1-M.Main.mve.no_dsp.no_fp
-  TARGET_SPECIFIC_FLAGS +=
 
 else ifeq ($(TARGET_ARCH), cortex-m55+nofp)
   CORE=M55


### PR DESCRIPTION
The steps to reproduce are comlicated and rely on internal systems but
this can likely be reproduced on a sparkfun edge as well. See #44170 for
more details.
