### PR TITLE
[DOC] Removed extraneous period in TFLite code example

### DIFF
--- a/tensorflow/lite/g3doc/convert/index.md
+++ b/tensorflow/lite/g3doc/convert/index.md
@@ -74,7 +74,7 @@ import tensorflow as tf
 
 # Convert the model
 converter = tf.lite.TFLiteConverter.from_saved_model(saved_model_dir) # path to the SavedModel directory
-tflite_model = converter.convert().
+tflite_model = converter.convert()
 
 # Save the model.
 with open('model.tflite', 'wb') as f:


### PR DESCRIPTION
This code example in the TFLite documentation [found here](https://www.tensorflow.org/lite/convert/index#convert_a_savedmodel_recommended_) has an extraneous period, likely a typo. 

This results in a syntax error if the reader copies and pastes the code.