### PR TITLE
Fix that when hdfsBuilderConnect returns NULL, HadoopFileSystem::FileExists returns errors::NotFound exception

### DIFF
--- a/tensorflow/c/experimental/filesystem/plugins/hadoop/hadoop_filesystem.cc
+++ b/tensorflow/c/experimental/filesystem/plugins/hadoop/hadoop_filesystem.cc
@@ -217,7 +217,7 @@ hdfsFS Connect(tf_hadoop_filesystem::HadoopFile* hadoop_file,
       hadoop_file->connection_cache.end()) {
     auto cacheFs = libhdfs->hdfsBuilderConnect(builder);
     if (cacheFs == nullptr) {
-      TF_SetStatusFromIOError(status, TF_NOT_FOUND, strerror(errno));
+      TF_SetStatusFromIOError(status, TF_ABORTED, strerror(errno));
       return cacheFs;
     }
     hadoop_file->connection_cache[cacheKey] = cacheFs;

--- a/tensorflow/core/platform/hadoop/hadoop_file_system.cc
+++ b/tensorflow/core/platform/hadoop/hadoop_file_system.cc
@@ -196,7 +196,7 @@ Status HadoopFileSystem::Connect(StringPiece fname, hdfsFS* fs) {
     if (connectionCache_.find(cacheKey) == connectionCache_.end()) {
       hdfsFS cacheFs = libhdfs()->hdfsBuilderConnect(builder);
       if (cacheFs == nullptr) {
-        return errors::NotFound(strerror(errno));
+        return errors::Aborted(strerror(errno));
       }
       connectionCache_[cacheKey] = cacheFs;
     }


### PR DESCRIPTION
Fix that when `hdfsBuilderConnect` returns NULL, `HadoopFileSystem::Connect` returns `errors::NotFound`, which conflicts with `errors::NotFound` in `HadoopFileSystem::FileExists`. `errors::NotFound` means that [the file does not exist](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/framework/errors_impl.py#L297)