### PR TITLE
Add gcc specific linker flag only when building with gcc.

### DIFF
--- a/tensorflow/lite/micro/cortex_m_generic/README.md
+++ b/tensorflow/lite/micro/cortex_m_generic/README.md
@@ -22,7 +22,7 @@ Required parameters:
 
 Optional parameters:
 
-  - TOOLCHAIN: armgcc (default) or armmclang
+  - TOOLCHAIN: gcc (default) or armmclang
   - For Cortex-M55, ARM Compiler 6.14 or later is required.
 
 Some examples:

--- a/tensorflow/lite/micro/tools/ci_build/test_cortex_m_generic.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_cortex_m_generic.sh
@@ -25,22 +25,23 @@ cd "${ROOT_DIR}"
 source tensorflow/lite/micro/tools/ci_build/helper_functions.sh
 
 TARGET=cortex_m_generic
+TAGS=cmsis-nn
 
 # TODO(b/143715361): downloading first to allow for parallel builds.
-readable_run make -f tensorflow/lite/micro/tools/make/Makefile TOOLCHAIN=armgcc TAGS="cmsis-nn armgcc" TARGET=${TARGET} TARGET_ARCH=cortex-m4 third_party_downloads
+readable_run make -f tensorflow/lite/micro/tools/make/Makefile TAGS=${TAGS} TARGET=${TARGET} TARGET_ARCH=cortex-m4 third_party_downloads
 
 # Build for Cortex-M4 (no FPU) without CMSIS
 readable_run make -f tensorflow/lite/micro/tools/make/Makefile clean
-readable_run make -j$(nproc) -f tensorflow/lite/micro/tools/make/Makefile TOOLCHAIN=armgcc TARGET=${TARGET} TARGET_ARCH=cortex-m4 microlite
+readable_run make -j$(nproc) -f tensorflow/lite/micro/tools/make/Makefile TARGET=${TARGET} TARGET_ARCH=cortex-m4 microlite
 
 # Build for Cortex-M4F (FPU present) without CMSIS
 readable_run make -f tensorflow/lite/micro/tools/make/Makefile clean
-readable_run make -j$(nproc) -f tensorflow/lite/micro/tools/make/Makefile TOOLCHAIN=armgcc TARGET=${TARGET} TARGET_ARCH=cortex-m4+fp microlite
+readable_run make -j$(nproc) -f tensorflow/lite/micro/tools/make/Makefile TARGET=${TARGET} TARGET_ARCH=cortex-m4+fp microlite
 
 # Build for Cortex-M4 (no FPU) with CMSIS
 readable_run make -f tensorflow/lite/micro/tools/make/Makefile clean
-readable_run make -j$(nproc) -f tensorflow/lite/micro/tools/make/Makefile TOOLCHAIN=armgcc TAGS=cmsis-nn TARGET=${TARGET} TARGET_ARCH=cortex-m4 microlite
+readable_run make -j$(nproc) -f tensorflow/lite/micro/tools/make/Makefile TAGS=${TAGS} TARGET=${TARGET} TARGET_ARCH=cortex-m4 microlite
 
 # Build for Cortex-M4 (FPU present) with CMSIS
 readable_run make -f tensorflow/lite/micro/tools/make/Makefile clean
-readable_run make -j$(nproc) -f tensorflow/lite/micro/tools/make/Makefile TOOLCHAIN=armgcc TAGS=cmsis-nn TARGET=${TARGET} TARGET_ARCH=cortex-m4+fp microlite
+readable_run make -j$(nproc) -f tensorflow/lite/micro/tools/make/Makefile TAGS=${TAGS} TARGET=${TARGET} TARGET_ARCH=cortex-m4+fp microlite

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -37,6 +37,7 @@ TARGET := $(HOST_OS)
 TARGET_ARCH := $(HOST_ARCH)
 
 # Default compiler and tool names:
+TOOLCHAIN:=gcc
 CXX_TOOL := g++
 CC_TOOL := gcc
 AR_TOOL := ar
@@ -123,16 +124,20 @@ CXXFLAGS := \
   -fno-threadsafe-statics \
   $(COMMON_FLAGS)
 
-CCFLAGS  := \
-	-std=c11 \
-	$(COMMON_FLAGS)
+CCFLAGS := \
+  -std=c11 \
+  $(COMMON_FLAGS)
 
 ARFLAGS := -r
 
-ifeq ($(filter armclang,$(ALL_TAGS)),)
-LDFLAGS += \
-  -Wl,--fatal-warnings \
-  -Wl,--gc-sections
+ifeq ($(TOOLCHAIN), gcc)
+  ifneq ($(TARGET), osx)
+    # GCC on MacOS uses an LLVM backend so we avoid the additional linker flags
+    # that are unsupported with LLVM.
+    LDFLAGS += \
+      -Wl,--fatal-warnings \
+      -Wl,--gc-sections
+  endif
 endif
 
 # override these in the makefile.inc for specific compiler targets

--- a/tensorflow/lite/micro/tools/make/targets/cortex_m_generic_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/cortex_m_generic_makefile.inc
@@ -1,7 +1,6 @@
 # Generic Makefile target for ARM Cortex M builds.
 # For more info see: tensorflow/lite/micro/cortex_m_generic/README.md
 
-TOOLCHAIN:=armgcc
 FLOAT := soft
 GCC_TARGET_ARCH := $(TARGET_ARCH)
 
@@ -64,7 +63,7 @@ else
 endif
 
 ifneq ($(filter cortex-m55%,$(TARGET_ARCH)),)
-  ifeq ($(TOOLCHAIN), armgcc)
+  ifeq ($(TOOLCHAIN), gcc)
     $(error "Micro architecure support is not available for arm-gcc for TARGET_ARCH=$(TARGET_ARCH)")
   endif
 
@@ -97,7 +96,7 @@ ifeq ($(TOOLCHAIN), armclang)
   # https://developer.arm.com/documentation/100891/0611/troubleshooting/general-troubleshooting-advice
   MICROLITE_LIBS := $(filter-out -lm,$(MICROLITE_LIBS))
 
-else ifeq ($(TOOLCHAIN), armgcc)
+else ifeq ($(TOOLCHAIN), gcc)
   export PATH := $(MAKEFILE_DIR)/downloads/gcc_embedded/bin/:$(PATH)
   $(eval $(call add_third_party_download,$(GCC_EMBEDDED_URL),$(GCC_EMBEDDED_MD5),gcc_embedded,))
 


### PR DESCRIPTION
The additional linker flag for fatal-warnings should not be used whe
cross compiling with armclang, or on MacOS.

Fixes #43885 #44181 #43887 #43865
