### PR TITLE
Removed the no longer necessary if statements in ARC makefiles. Minor fixes in generation flow.

### DIFF
--- a/tensorflow/lite/micro/tools/make/targets/arc/README.md
+++ b/tensorflow/lite/micro/tools/make/targets/arc/README.md
@@ -269,8 +269,10 @@ comments about make versions.
 Before building the application itself, you need to generate the project for
 this application from TensorFlow sources and external dependencies. To generate
 it for a custom TCF you need to set the following variables in the make command
-line: * TARGET_ARCH=arc * TCF_FILE=<path to TCF file> * (optional)
-LCF_FILE=<path to LCF file>
+line:
+* TARGET=arc_custom 
+* TCF_FILE=<path to TCF file> 
+* (optional) LCF_FILE=<path to LCF file>
 
 If you don’t supply an external LCF, the one embedded in the TCF will be used
 instead
@@ -279,7 +281,7 @@ For instance, to build **Person Detection** test application, use the following
 command from the root directory of the TensorFlow repo:
 
 ```
-make -f tensorflow/lite/micro/tools/make/Makefile generate_person_detection_test_int8_make_project TARGET_ARCH=arc TCF_FILE=<path_to_tcf_file> LCF_FILE=<path_to_lcf_file>
+make -f tensorflow/lite/micro/tools/make/Makefile generate_person_detection_test_int8_make_project TARGET=arc_custom TCF_FILE=<path_to_tcf_file> LCF_FILE=<path_to_lcf_file>
 ```
 
 The application project will be generated into

--- a/tensorflow/lite/micro/tools/make/targets/arc/arc_common.inc
+++ b/tensorflow/lite/micro/tools/make/targets/arc/arc_common.inc
@@ -133,9 +133,9 @@ endif
   CCFLAGS += $(PLATFORM_FLAGS)
   LDFLAGS += $(PLATFORM_LDFLAGS)
 
-
-
-
 endif # ARC_TOOLCHAIN
-endif  # TARGET_ARCH
 
+else
+  $(error "Only ARC target architecture supported (TARGET_ARCH=arc)")
+
+endif  # TARGET_ARCH

--- a/tensorflow/lite/micro/tools/make/targets/arc_custom_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/arc_custom_makefile.inc
@@ -15,26 +15,22 @@
 # Settings for not pre-defined ARC processors. 
 # User need to specify ARC target with Tool Configuration File (*.tcf). 
 # Path to this file must be passed through TCF_FILE variable.
-# Otherwise, default em7d_voice_audio configuration is used 
-ifeq ($(TARGET_ARCH), arc)
+# Otherwise, default em7d_voice_audio configuration is used
 
-# Known target are specified with their own make configurations. 
-ifeq ($(filter $(TARGET), arc_emsdp),)
-
+TARGET_ARCH := arc
 ARC_TOOLCHAIN := mwdt
 
+# Overriding TARGET variable to change name of project folder according
+# to specified Tool Configuration File (*.tcf) passed through TCF_FILE variable
+# or default em7d_voice_audio configuration.
 ifneq ($(TCF_FILE), )
-  TARGET = $(basename $(notdir $(TCF_FILE)))
+  override TARGET = $(basename $(notdir $(TCF_FILE)))
 else
   $(warning TCF_FILE variable is not specified. Use default em7d_voice_audio configuration)
-  TARGET = em7d_voice_audio
+  override TARGET = em7d_voice_audio
   TCF_FILE = em7d_voice_audio
 endif
 
 include $(MAKEFILE_DIR)/targets/arc/arc_common.inc
 
 MAKE_PROJECT_FILES := $(filter-out README_MAKE.md, $(MAKE_PROJECT_FILES)) README_ARC.md
-
-endif  # $(TARGET)
-endif  # $(TARGET_ARCH)...
-

--- a/tensorflow/lite/micro/tools/make/targets/arc_emsdp_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/arc_emsdp_makefile.inc
@@ -13,14 +13,13 @@
 # limitations under the License.
 
 # Settings for EMSDP target (ARC processor)
-ifeq ($(TARGET), arc_emsdp)
 
-  TARGET_ARCH := arc
-  ARC_TOOLCHAIN := mwdt
+TARGET_ARCH := arc
+ARC_TOOLCHAIN := mwdt
 
 
-  BUILD_ARC_MLI := false
-  ARC_MLI_PRE_COMPILED_TARGET := emsdp_em11d_em9d_dfss
+BUILD_ARC_MLI := false
+ARC_MLI_PRE_COMPILED_TARGET := emsdp_em11d_em9d_dfss
 
 ifneq ($(filter no_arc_mli,$(ALL_TAGS)),)
   MLI_LIB_DIR = arc_mli_package
@@ -29,37 +28,35 @@ else ifeq ($(BUILD_ARC_MLI), true)
   MLI_LIB_DIR = arc_mli_$(ARC_MLI_PRE_COMPILED_TARGET)
 endif
 
-  TCF_FILE = $(PWD)/$(MAKEFILE_DIR)/downloads/$(MLI_LIB_DIR)/hw/emsdp_em11d_em9d_dfss.tcf
-  LCF_FILE = $(PWD)/$(MAKEFILE_DIR)/targets/arc/emsdp/emsdp.lcf
+TCF_FILE = $(PWD)/$(MAKEFILE_DIR)/downloads/$(MLI_LIB_DIR)/hw/emsdp_em11d_em9d_dfss.tcf
+LCF_FILE = $(PWD)/$(MAKEFILE_DIR)/targets/arc/emsdp/emsdp.lcf
 
 
 include $(MAKEFILE_DIR)/targets/arc/arc_common.inc
   
-   ARC_EXTRA_APP_SETTINGS = \
-      BIN_DIR = .$(DLR)\(PS\)bin\n\
-      BIN_FILE = $(DLR)\(BIN_DIR\)$(DLR)\(PS\)app.elf\n
+  ARC_EXTRA_APP_SETTINGS = \
+    BIN_DIR = .$(DLR)\(PS\)bin\n\
+    BIN_FILE = $(DLR)\(BIN_DIR\)$(DLR)\(PS\)app.elf\n
 
-   ARC_EXTRA_APP_RULES = \
-     $(DLR)\(BIN_FILE\): $(DLR)\(BIN_DIR\) $(DLR)\(OUT_NAME\)\
-     \n\t\@$(DLR)\(CP\) $(DLR)\(OUT_NAME\) $(DLR)\(BIN_FILE\)\
-     \n \
-     \n$(DLR)\(BIN_DIR\):\
-     \n\t\@$(DLR)\(MKDIR\) $(DLR)\(BIN_DIR\)\
+  ARC_EXTRA_APP_RULES = \
+    $(DLR)\(BIN_FILE\): $(DLR)\(BIN_DIR\) $(DLR)\(OUT_NAME\)\
+    \n\t\@$(DLR)\(CP\) $(DLR)\(OUT_NAME\) $(DLR)\(BIN_FILE\)\
+    \n \
+    \n$(DLR)\(BIN_DIR\):\
+    \n\t\@$(DLR)\(MKDIR\) $(DLR)\(BIN_DIR\)\
 
-   ARC_EXTRA_RM_TARGETS = $(DLR)\(BIN_DIR\)
+  ARC_EXTRA_RM_TARGETS = $(DLR)\(BIN_DIR\)
 
-   ARC_BIN_DEPEND = $(DLR)\(BIN_DIR\) $(DLR)\(BIN_FILE\)
-   ARC_BIN_RULE = \t@echo Copy content of $(DLR)\(BIN_DIR\) into the root of SD card and follow instructions
-   
-   ARC_APP_RUN_CMD = mdb -run -digilent -nooptions $(DLR)\(DBG_ARGS\)
-   ARC_APP_DEBUG_CMD = mdb -OK -digilent -nooptions $(DLR)\(DBG_ARGS\)
-   ARC_EXTRA_EXECUTE_RULES = 
+  ARC_BIN_DEPEND = $(DLR)\(BIN_DIR\) $(DLR)\(BIN_FILE\)
+  ARC_BIN_RULE = \t@echo Copy content of $(DLR)\(BIN_DIR\) into the root of SD card and follow instructions
+  
+  ARC_APP_RUN_CMD = mdb -run -digilent -nooptions $(DLR)\(DBG_ARGS\)
+  ARC_APP_DEBUG_CMD = mdb -OK -digilent -nooptions $(DLR)\(DBG_ARGS\)
+  ARC_EXTRA_EXECUTE_RULES = 
 
-  MAKE_PROJECT_FILES := $(filter-out README_MAKE.md, $(MAKE_PROJECT_FILES)) README_ARC_EMSDP.md
+MAKE_PROJECT_FILES := $(filter-out README_MAKE.md, $(MAKE_PROJECT_FILES)) README_ARC_EMSDP.md
 
-  # for default EMSDP configuration we can use em9d_va rt libs
-  # for better performance runtime should be built for emsdp configuration
-  # No hostlink library for smaller codesize purpose
-  PLATFORM_LDFLAGS += -Hlib=em9d_voice_audio -Hhostlib=
-
-endif
+# for default EMSDP configuration we can use em9d_va rt libs
+# for better performance runtime should be built for emsdp configuration
+# No hostlink library for smaller codesize purpose
+PLATFORM_LDFLAGS += -Hlib=em9d_voice_audio -Hhostlib=

--- a/tensorflow/lite/micro/tools/make/targets/himax_we1_evb_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/himax_we1_evb_makefile.inc
@@ -1,96 +1,93 @@
 # Settings for himax WE_1 evb.
-ifeq ($(TARGET), himax_we1_evb)
+
+CC_TOOL = ccac
+AR_TOOL = arac
+CXX_TOOL = ccac
+LD_TOOL := ccac
+TARGET_ARCH := arc
+#ARC_TOOLCHAIN := mwdt 
+
+BUILD_ARC_MLI := false
+ARC_MLI_PRE_COMPILED_TARGET := himax_arcem9d_r16
+
+include $(MAKEFILE_DIR)/targets/arc/arc_common.inc
+
+#download SDK & MLI
+HIMAX_WE1_SDK_NAME := himax_we1_sdk
+$(eval $(call add_third_party_download,$(HIMAX_WE1_SDK_URL),$(HIMAX_WE1_SDK_MD5),$(HIMAX_WE1_SDK_NAME),))
+
+#export path of toolchain
+#export PATH := $(MAKEFILE_DIR)/downloads/$(HIMAX_WE1_SDK_NAME)/image_gen_linux_v3/:$(PATH)
+
+TCF_FILE := $(PWD)/$(MAKEFILE_DIR)/downloads/$(HIMAX_WE1_SDK_NAME)/arcem9d_wei_r16.tcf
+LCF_FILE := $(PWD)/$(MAKEFILE_DIR)/downloads/$(HIMAX_WE1_SDK_NAME)/memory.lcf
+ARCLIB_FILE :=  $(PWD)/$(MAKEFILE_DIR)/downloads/$(HIMAX_WE1_SDK_NAME)/libembarc.a
+LIB_HEADER_FILE :=  $(PWD)/$(MAKEFILE_DIR)/downloads/$(HIMAX_WE1_SDK_NAME)/hx_drv_tflm.h
+
+
+DEFAULT_HEAPSZ := 8192
+DEFAULT_STACKSZ := 8192
+
+TCF_FILE_NAME = $(notdir $(TCF_FILE))
+ARC_TARGET_COPY_FILES += $(notdir $(TCF_FILE))!$(TCF_FILE)
+MAKE_PROJECT_FILES += $(TCF_FILE_NAME)
+
+
   
-  CC_TOOL = ccac
-  AR_TOOL = arac
-  CXX_TOOL = ccac
-  LD_TOOL := ccac
-  TARGET_ARCH := arc
-  #ARC_TOOLCHAIN := mwdt 
+LCF_FILE_NAME = $(notdir $(LCF_FILE))
+ARC_TARGET_COPY_FILES += $(notdir $(LCF_FILE))!$(LCF_FILE)
+MAKE_PROJECT_FILES += $(LCF_FILE_NAME)
 
-  BUILD_ARC_MLI := false
-  ARC_MLI_PRE_COMPILED_TARGET := himax_arcem9d_r16
-  
-  include $(MAKEFILE_DIR)/targets/arc/arc_common.inc
+ARCLIB_FILE_NAME = $(notdir $(ARCLIB_FILE))
+ARC_TARGET_COPY_FILES += $(notdir $(ARCLIB_FILE))!$(ARCLIB_FILE)
+MAKE_PROJECT_FILES += $(ARCLIB_FILE_NAME)
 
-  #download SDK & MLI
-  HIMAX_WE1_SDK_NAME := himax_we1_sdk
-  $(eval $(call add_third_party_download,$(HIMAX_WE1_SDK_URL),$(HIMAX_WE1_SDK_MD5),$(HIMAX_WE1_SDK_NAME),))
-
-  #export path of toolchain
-  #export PATH := $(MAKEFILE_DIR)/downloads/$(HIMAX_WE1_SDK_NAME)/image_gen_linux_v3/:$(PATH)
-  
-  TCF_FILE := $(PWD)/$(MAKEFILE_DIR)/downloads/$(HIMAX_WE1_SDK_NAME)/arcem9d_wei_r16.tcf
-  LCF_FILE := $(PWD)/$(MAKEFILE_DIR)/downloads/$(HIMAX_WE1_SDK_NAME)/memory.lcf
-  ARCLIB_FILE :=  $(PWD)/$(MAKEFILE_DIR)/downloads/$(HIMAX_WE1_SDK_NAME)/libembarc.a
-  LIB_HEADER_FILE :=  $(PWD)/$(MAKEFILE_DIR)/downloads/$(HIMAX_WE1_SDK_NAME)/hx_drv_tflm.h
-  
-
-  DEFAULT_HEAPSZ := 8192
-  DEFAULT_STACKSZ := 8192
-
-  TCF_FILE_NAME = $(notdir $(TCF_FILE))
-  ARC_TARGET_COPY_FILES += $(notdir $(TCF_FILE))!$(TCF_FILE)
-  MAKE_PROJECT_FILES += $(TCF_FILE_NAME)
+LIB_HEADER_FILE_NAME = $(notdir $(LIB_HEADER_FILE))
+ARC_TARGET_COPY_FILES += $(notdir $(LIB_HEADER_FILE))!$(LIB_HEADER_FILE)
+MAKE_PROJECT_FILES += $(LIB_HEADER_FILE_NAME)
 
 
-    
-  LCF_FILE_NAME = $(notdir $(LCF_FILE))
-  ARC_TARGET_COPY_FILES += $(notdir $(LCF_FILE))!$(LCF_FILE)
-  MAKE_PROJECT_FILES += $(LCF_FILE_NAME)
-  
-  ARCLIB_FILE_NAME = $(notdir $(ARCLIB_FILE))
-  ARC_TARGET_COPY_FILES += $(notdir $(ARCLIB_FILE))!$(ARCLIB_FILE)
-  MAKE_PROJECT_FILES += $(ARCLIB_FILE_NAME)
-  
-  LIB_HEADER_FILE_NAME = $(notdir $(LIB_HEADER_FILE))
-  ARC_TARGET_COPY_FILES += $(notdir $(LIB_HEADER_FILE))!$(LIB_HEADER_FILE)
-  MAKE_PROJECT_FILES += $(LIB_HEADER_FILE_NAME)
-  
-  
-  # Need a pointer to the TCF and lcf file
+# Need a pointer to the TCF and lcf file
 
-  PLATFORM_FLAGS = \
-    -DNDEBUG \
-    -g \
-    -DCPU_ARC \
-    -Hnosdata \
-    -DTF_LITE_STATIC_MEMORY \
-    -tcf=$(TCF_FILE_NAME) \
-    -Hnocopyr \
-    -Hpurge \
-    -Hcl \
-    -fslp-vectorize-aggressive \
-    -ffunction-sections \
-    -fdata-sections \
-    -tcf_core_config \
+PLATFORM_FLAGS = \
+  -DNDEBUG \
+  -g \
+  -DCPU_ARC \
+  -Hnosdata \
+  -DTF_LITE_STATIC_MEMORY \
+  -tcf=$(TCF_FILE_NAME) \
+  -Hnocopyr \
+  -Hpurge \
+  -Hcl \
+  -fslp-vectorize-aggressive \
+  -ffunction-sections \
+  -fdata-sections \
+  -tcf_core_config \
 
-  CXXFLAGS += -fno-rtti -DSCRATCH_MEM_Z_SIZE=0x10000 $(PLATFORM_FLAGS)
-  CCFLAGS += $(PLATFORM_FLAGS)
+CXXFLAGS += -fno-rtti -DSCRATCH_MEM_Z_SIZE=0x10000 $(PLATFORM_FLAGS)
+CCFLAGS += $(PLATFORM_FLAGS)
 
-  INCLUDES+= \
-    -I $(MAKEFILE_DIR)/downloads/$(WEI_SDK_NAME) \
-    -I $(MAKEFILE_DIR)/downloads/kissfft
+INCLUDES+= \
+  -I $(MAKEFILE_DIR)/downloads/$(WEI_SDK_NAME) \
+  -I $(MAKEFILE_DIR)/downloads/kissfft
 
-  GENERATED_PROJECT_INCLUDES += \
-    -I. \
-    -I./third_party/kissfft
+GENERATED_PROJECT_INCLUDES += \
+  -I. \
+  -I./third_party/kissfft
 
-  LDFLAGS += \
-    -Hheap=8192 \
-    -tcf=$(TCF_FILE_NAME) \
-    -Hnocopyr \
-    -m \
-    -Hldopt=-Coutput=$(TARGET).map \
-    $(LCF_FILE_NAME) \
-    -Hldopt=-Bgrouplib $(ARCLIB_FILE_NAME)
+LDFLAGS += \
+  -Hheap=8192 \
+  -tcf=$(TCF_FILE_NAME) \
+  -Hnocopyr \
+  -m \
+  -Hldopt=-Coutput=$(TARGET).map \
+  $(LCF_FILE_NAME) \
+  -Hldopt=-Bgrouplib $(ARCLIB_FILE_NAME)
 
-  CXXFLAGS := $(filter-out -std=c++11,$(CXXFLAGS))
-  CCFLAGS := $(filter-out -std=c11,$(CCFLAGS))
+CXXFLAGS := $(filter-out -std=c++11,$(CXXFLAGS))
+CCFLAGS := $(filter-out -std=c11,$(CCFLAGS))
 
-  ldflags_to_remove = -Wl,--fatal-warnings -Wl,--gc-sections
-  LDFLAGS := $(filter-out $(ldflags_to_remove),$(LDFLAGS))
+ldflags_to_remove = -Wl,--fatal-warnings -Wl,--gc-sections
+LDFLAGS := $(filter-out $(ldflags_to_remove),$(LDFLAGS))
 
-  MICROLITE_LIBS := $(filter-out -lm,$(MICROLITE_LIBS))
-
-endif
+MICROLITE_LIBS := $(filter-out -lm,$(MICROLITE_LIBS))


### PR DESCRIPTION
This pull request removes unnecessary TARGET checks in ARC makefiles as far as target-specific makefiles now used automaticly.
Also, TARGET_ARCH is no longer required for custom ARC build and corresponding changes have been made in code and README.

@bigcat-himax Hi, can you please check out changes I applied in the himax_we1_evb_makefile.inc file? I added/removed some code that was preventing build for himax platform target. Thank you.

Fixes #43898