### PR TITLE
Reintroduce TF to TF lowering patterns to legalize_tf pass for TFLite 

### DIFF
--- a/tensorflow/compiler/mlir/lite/BUILD
+++ b/tensorflow/compiler/mlir/lite/BUILD
@@ -419,6 +419,7 @@ cc_library(
         "//tensorflow/compiler/mlir/lite/quantization:quantization_lib",
         "//tensorflow/compiler/mlir/tensorflow",
         "//tensorflow/compiler/mlir/tensorflow:convert_tensor",
+        "//tensorflow/compiler/mlir/tensorflow:lower_tf_lib",
         "//tensorflow/compiler/mlir/tensorflow:mangling_util",
         "//tensorflow/compiler/mlir/tensorflow:tensorflow_attributes",
         "//tensorflow/compiler/mlir/tensorflow:tensorflow_ops",

--- a/tensorflow/compiler/mlir/lite/transforms/legalize_tf.cc
+++ b/tensorflow/compiler/mlir/lite/transforms/legalize_tf.cc
@@ -50,6 +50,7 @@ limitations under the License.
 #include "tensorflow/compiler/mlir/lite/utils/validators.h"
 #include "tensorflow/compiler/mlir/tensorflow/ir/tf_ops.h"
 #include "tensorflow/compiler/mlir/tensorflow/ir/tf_ops_a_m.h"
+#include "tensorflow/compiler/mlir/tensorflow/transforms/lower_tf.h"
 #include "tensorflow/compiler/mlir/tensorflow/utils/mangling_util.h"
 #include "tensorflow/compiler/xla/status.h"
 #include "tensorflow/compiler/xla/statusor.h"
@@ -660,6 +661,9 @@ void LegalizeTF::runOnFunction() {
   OwningRewritePatternList patterns;
   auto* context = &getContext();
   auto func = getFunction();
+
+  // Add TF->TF lowering patterns.
+  TF::PopulateLoweringTFPatterns(context, &patterns);
 
   // Add the generated patterns to the list.
   populateWithGenerated(context, patterns);


### PR DESCRIPTION
The TF lowering patterns are useful across multiple different backends. This PR adds the lowering patterns from TF to TFLite so that TFLite specific code can focus on lowerings unique to it. We can also automatically benefit from any TF lowerings that get added without having to manually sync it with TFLite if TFLite didn't use the lowering patterns of TF directly.

The PR was originally reverted for an unrelated issue which was fixed in https://github.com/tensorflow/tensorflow/pull/44097. It can be reintroduced now.