### PR TITLE
Add parallel matching for `tf.gfile.Glob`

### DIFF
--- a/tensorflow/core/platform/file_system_helper.cc
+++ b/tensorflow/core/platform/file_system_helper.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include <string>
 #include <vector>
 
+#include "tensorflow/core/platform/cpu_info.h"
 #include "tensorflow/core/platform/env.h"
 #include "tensorflow/core/platform/file_system.h"
 #include "tensorflow/core/platform/path.h"
@@ -32,7 +33,7 @@ namespace internal {
 
 namespace {
 
-constexpr int kNumThreads = 8;
+const int kNumThreads = port::NumSchedulableCPUs();
 
 // Run a function in parallel using a ThreadPool, but skip the ThreadPool
 // on the iOS platform due to its problems with more than a few threads.

--- a/tensorflow/python/lib/io/file_io.py
+++ b/tensorflow/python/lib/io/file_io.py
@@ -18,7 +18,6 @@ from __future__ import division
 from __future__ import print_function
 
 import binascii
-import copy
 import functools
 import operator
 import os
@@ -446,7 +445,7 @@ def get_matching_files_v2(pattern, num_threads=1):
     ]
     return partial_files
 
-  patterns = list(copy.deepcopy(pattern))
+  patterns = list(pattern)
   pool = Pool(processes=min(num_threads, len(patterns)))
   all_files = pool.map(handle_single_pattern, patterns)
   pool.close()

--- a/tensorflow/python/lib/io/file_io.py
+++ b/tensorflow/python/lib/io/file_io.py
@@ -427,7 +427,7 @@ def get_matching_files_v2(pattern, num_threads=1):
     ]
 
   if not isinstance(num_threads, int):
-    raise TypeError("`max_parallel_num` must be a integer.")
+    raise TypeError("`num_threads` must be a integer.")
 
   if num_threads <= 1:
     return [

--- a/tensorflow/python/lib/io/file_io.py
+++ b/tensorflow/python/lib/io/file_io.py
@@ -340,15 +340,15 @@ def write_string_to_file(filename, file_content):
 
 
 @tf_export(v1=["gfile.Glob"])
-def get_matching_files(filename, max_parallel_num=1):
+def get_matching_files(filename, num_threads=1):
   """Returns a list of files that match the given pattern(s).
 
   Args:
     filename: string or iterable of strings. The glob pattern(s).
-    max_parallel_num: int. If `filename` is iterable of strings and
-      `max_parallel_num` is greater than one, it will create a threadpool to
+    num_threads: int. If `filename` is iterable of strings and
+      `num_threads` is greater than one, it will create a threadpool to
       match all strings parallelly. The size of threadpool is
-      `min(max_parallel_num, len(list(filename)))`.
+      `min(num_threads, len(list(filename)))`.
 
   Returns:
     A list of strings containing filenames that match the given pattern(s).
@@ -358,11 +358,11 @@ def get_matching_files(filename, max_parallel_num=1):
   *  errors.NotFoundError: If pattern to be matched is an invalid directory.
   *  TypeError: If any argument does not have the expected type.
   """
-  return get_matching_files_v2(filename, max_parallel_num)
+  return get_matching_files_v2(filename, num_threads)
 
 
 @tf_export("io.gfile.glob")
-def get_matching_files_v2(pattern, max_parallel_num=1):
+def get_matching_files_v2(pattern, num_threads=1):
   r"""Returns a list of files that match the given pattern(s).
 
   The patterns are defined as strings. Supported patterns are defined
@@ -405,10 +405,10 @@ def get_matching_files_v2(pattern, max_parallel_num=1):
 
   Args:
     pattern: string or iterable of strings. The glob pattern(s).
-    max_parallel_num: int. If `pattern` is iterable of strings and
-      `max_parallel_num` is greater than one, it will create a threadpool to
+    num_threads: int. If `pattern` is iterable of strings and
+      `num_threads` is greater than one, it will create a threadpool to
       match all strings parallelly. The size of threadpool is
-      `min(max_parallel_num, len(list(pattern)))`.
+      `min(num_threads, len(list(pattern)))`.
 
   Returns:
     A list of strings containing filenames that match the given pattern(s).
@@ -426,10 +426,10 @@ def get_matching_files_v2(pattern, max_parallel_num=1):
             compat.as_bytes(pattern))
     ]
 
-  if not isinstance(max_parallel_num, int):
+  if not isinstance(num_threads, int):
     raise TypeError("`max_parallel_num` must be a integer.")
 
-  if max_parallel_num <= 1:
+  if num_threads <= 1:
     return [
         # Convert the filenames to string from bytes.
         compat.as_str_any(matching_filename)  # pylint: disable=g-complex-comprehension
@@ -447,8 +447,7 @@ def get_matching_files_v2(pattern, max_parallel_num=1):
     return partial_files
 
   patterns = list(copy.deepcopy(pattern))
-  pool = Pool(processes=min(max_parallel_num, 
-                            len(patterns)))
+  pool = Pool(processes=min(num_threads, len(patterns)))
   all_files = pool.map(handle_single_pattern, patterns)
   pool.close()
   pool.join()

--- a/tensorflow/python/lib/io/file_io.py
+++ b/tensorflow/python/lib/io/file_io.py
@@ -428,10 +428,14 @@ def get_matching_files_v2(pattern, num_threads=1):
   if isinstance(pattern, six.string_types):
     return handle_single_pattern(pattern)
 
-  if not isinstance(num_threads, int) or num_threads < 1:
-    raise TypeError("`num_threads` must be a integer and not less than 1.")
-
   patterns = list(pattern)
+  if num_threads is None:
+    # If user didn't supply any, use the length of pattern list
+    num_threads = len(patterns)
+  else:
+    if not isinstance(num_threads, int) or num_threads < 1:
+      raise TypeError("`num_threads` must be a integer and not less than 1.")
+  
   pool = Pool(processes=min(num_threads, len(patterns)))
   all_files = pool.map(handle_single_pattern, patterns)
   pool.close()

--- a/tensorflow/python/lib/io/file_io.py
+++ b/tensorflow/python/lib/io/file_io.py
@@ -429,12 +429,12 @@ def get_matching_files_v2(pattern, num_threads=None):
     return handle_single_pattern(pattern)
 
   patterns = list(pattern)
-  if num_threads is None:
-    # If user didn't supply any, use the length of pattern list
-    num_threads = len(patterns)
-  else:
-    if not isinstance(num_threads, int) or num_threads < 1:
-      raise TypeError("`num_threads` must be a integer and not less than 1.")
+  if not patterns:
+    return []
+  # If user didn't supply any, use the length of pattern list
+  num_threads = num_threads or len(patterns)
+  if not isinstance(num_threads, int) or num_threads < 1:
+    raise TypeError("`num_threads` must be a integer and not less than 1.")
   
   pool = Pool(processes=min(num_threads, len(patterns)))
   all_files = pool.map(handle_single_pattern, patterns)

--- a/tensorflow/python/lib/io/file_io.py
+++ b/tensorflow/python/lib/io/file_io.py
@@ -344,10 +344,10 @@ def get_matching_files(filename, num_threads=None):
 
   Args:
     filename: string or iterable of strings. The glob pattern(s).
-    num_threads: int. If `filename` is iterable of strings and
-      `num_threads` is greater than one, it will create a threadpool to
-      match all strings parallelly. The size of threadpool is
-      `min(num_threads, len(list(filename)))`.
+    num_threads: int. If `filename` is iterable of strings, it will create 
+      a threadpool of size `min(num_threads, len(list(filename)))` to match all 
+      strings parallelly. Default `num_threads` is None, which will use the 
+      length of `filename` directly.
 
   Returns:
     A list of strings containing filenames that match the given pattern(s).
@@ -404,10 +404,10 @@ def get_matching_files_v2(pattern, num_threads=None):
 
   Args:
     pattern: string or iterable of strings. The glob pattern(s).
-    num_threads: int. If `pattern` is iterable of strings and
-      `num_threads` is greater than one, it will create a threadpool to
-      match all strings parallelly. The size of threadpool is
-      `min(num_threads, len(list(pattern)))`.
+    num_threads: int. If `pattern` is iterable of strings, it will create 
+      a threadpool of size `min(num_threads, len(list(pattern)))` to match all 
+      strings parallelly. Default `num_threads` is None, which will use the 
+      length of `pattern` directly.
 
   Returns:
     A list of strings containing filenames that match the given pattern(s).

--- a/tensorflow/python/lib/io/file_io.py
+++ b/tensorflow/python/lib/io/file_io.py
@@ -346,8 +346,8 @@ def get_matching_files(filename, num_threads=None):
     filename: string or iterable of strings. The glob pattern(s).
     num_threads: int. If `filename` is iterable of strings, it will create 
       a threadpool of size `min(num_threads, len(list(filename)))` to match all 
-      strings parallelly. Default `num_threads` is None, which will use the 
-      length of `filename` directly.
+      strings parallelly. Default `num_threads` is None, which will execute 
+      serially.
 
   Returns:
     A list of strings containing filenames that match the given pattern(s).
@@ -406,8 +406,8 @@ def get_matching_files_v2(pattern, num_threads=None):
     pattern: string or iterable of strings. The glob pattern(s).
     num_threads: int. If `pattern` is iterable of strings, it will create 
       a threadpool of size `min(num_threads, len(list(pattern)))` to match all 
-      strings parallelly. Default `num_threads` is None, which will use the 
-      length of `pattern` directly.
+      strings parallelly. Default `num_threads` is None, which will execute 
+      serially.
 
   Returns:
     A list of strings containing filenames that match the given pattern(s).
@@ -431,8 +431,8 @@ def get_matching_files_v2(pattern, num_threads=None):
   patterns = list(pattern)
   if not patterns:
     return []
-  # If user didn't supply any, use the length of pattern list
-  num_threads = num_threads or len(patterns)
+  # If user didn't give anything or give None, use one thread. 
+  num_threads = num_threads or 1
   if not isinstance(num_threads, int) or num_threads < 1:
     raise TypeError("`num_threads` must be a integer and not less than 1.")
   

--- a/tensorflow/python/lib/io/file_io.py
+++ b/tensorflow/python/lib/io/file_io.py
@@ -339,7 +339,7 @@ def write_string_to_file(filename, file_content):
 
 
 @tf_export(v1=["gfile.Glob"])
-def get_matching_files(filename, num_threads=1):
+def get_matching_files(filename, num_threads=None):
   """Returns a list of files that match the given pattern(s).
 
   Args:
@@ -361,7 +361,7 @@ def get_matching_files(filename, num_threads=1):
 
 
 @tf_export("io.gfile.glob")
-def get_matching_files_v2(pattern, num_threads=1):
+def get_matching_files_v2(pattern, num_threads=None):
   r"""Returns a list of files that match the given pattern(s).
 
   The patterns are defined as strings. Supported patterns are defined

--- a/tensorflow/python/lib/io/file_io.py
+++ b/tensorflow/python/lib/io/file_io.py
@@ -417,13 +417,16 @@ def get_matching_files_v2(pattern, num_threads=1):
     errors.NotFoundError: If pattern to be matched is an invalid directory.
     TypeError: If any argument does not have the expected type.
   """
-  if isinstance(pattern, six.string_types):
+  def handle_single_pattern(single_pattern):
     return [
-        # Convert the filenames to string from bytes.
-        compat.as_str_any(matching_filename)
-        for matching_filename in _pywrap_file_io.GetMatchingFiles(
-            compat.as_bytes(pattern))
+      # Convert the filenames to string from bytes.
+      compat.as_str_any(matching_filename)
+      for matching_filename in _pywrap_file_io.GetMatchingFiles(
+          compat.as_bytes(single_pattern))
     ]
+
+  if isinstance(pattern, six.string_types):
+    return handle_single_pattern(pattern)
 
   if not isinstance(num_threads, int):
     raise TypeError("`num_threads` must be a integer.")
@@ -436,14 +439,6 @@ def get_matching_files_v2(pattern, num_threads=1):
         for matching_filename in _pywrap_file_io.GetMatchingFiles(
             compat.as_bytes(single_filename))
     ]
-
-  def handle_single_pattern(single_pattern):
-    partial_files = [
-      compat.as_str_any(matching_filename)
-      for matching_filename in _pywrap_file_io.GetMatchingFiles(
-          compat.as_bytes(single_pattern))
-    ]
-    return partial_files
 
   patterns = list(pattern)
   pool = Pool(processes=min(num_threads, len(patterns)))

--- a/tensorflow/python/lib/io/file_io.py
+++ b/tensorflow/python/lib/io/file_io.py
@@ -428,17 +428,8 @@ def get_matching_files_v2(pattern, num_threads=1):
   if isinstance(pattern, six.string_types):
     return handle_single_pattern(pattern)
 
-  if not isinstance(num_threads, int):
-    raise TypeError("`num_threads` must be a integer.")
-
-  if num_threads <= 1:
-    return [
-        # Convert the filenames to string from bytes.
-        compat.as_str_any(matching_filename)  # pylint: disable=g-complex-comprehension
-        for single_filename in pattern
-        for matching_filename in _pywrap_file_io.GetMatchingFiles(
-            compat.as_bytes(single_filename))
-    ]
+  if not isinstance(num_threads, int) or num_threads < 1:
+    raise TypeError("`num_threads` must be a integer and not less than 1.")
 
   patterns = list(pattern)
   pool = Pool(processes=min(num_threads, len(patterns)))

--- a/tensorflow/tools/api/golden/v1/tensorflow.gfile.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.gfile.pbtxt
@@ -26,7 +26,7 @@ tf_module {
   }
   member_method {
     name: "Glob"
-    argspec: "args=[\'filename\'], varargs=None, keywords=None, defaults=None"
+    argspec: "args=[\'filename\', \'num_threads\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
     name: "IsDirectory"

--- a/tensorflow/tools/api/golden/v1/tensorflow.io.gfile.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.io.gfile.pbtxt
@@ -14,7 +14,7 @@ tf_module {
   }
   member_method {
     name: "glob"
-    argspec: "args=[\'pattern\'], varargs=None, keywords=None, defaults=None"
+    argspec: "args=[\'pattern\', \'num_threads\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
     name: "isdir"

--- a/tensorflow/tools/api/golden/v2/tensorflow.io.gfile.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.io.gfile.pbtxt
@@ -14,7 +14,7 @@ tf_module {
   }
   member_method {
     name: "glob"
-    argspec: "args=[\'pattern\'], varargs=None, keywords=None, defaults=None"
+    argspec: "args=[\'pattern\', \'num_threads\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
     name: "isdir"


### PR DESCRIPTION
This is a PR from JIZHI Team & TaiJi AI platform in Tencent.

Add a argument `max_parallel_num` for  `tf.gfile.Glob`, which will setup a threadpool to parallelize the matching for mulitple pattern strings. It can bring nice performance improvement if `max_parallel_num` is set appropriately.

Thanks for your review.