### PR TITLE
Improve grappler layout optimizer to support 5D tensors

### DIFF
--- a/tensorflow/compiler/tf2xla/kernels/data_format_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/data_format_ops.cc
@@ -91,15 +91,15 @@ class DataFormatVecPermuteOp : public XlaOpKernel {
       : XlaOpKernel(ctx) {
     OP_REQUIRES_OK(ctx, ctx->GetAttr("src_format", &src_format_));
     OP_REQUIRES(
-        ctx, src_format_.size() == 4,
-        errors::InvalidArgument("Data format should have 4 characters"));
+        ctx, src_format_.size() == 4 || src_format_.size() == 5,
+        errors::InvalidArgument("Data format should have 4 or 5 characters"));
     TensorFormat data_format;
     OP_REQUIRES(ctx, FormatFromString(src_format_, &data_format),
                 errors::InvalidArgument("Invalid data format"));
     OP_REQUIRES_OK(ctx, ctx->GetAttr("dst_format", &dst_format_));
     OP_REQUIRES(
-        ctx, dst_format_.size() == 4,
-        errors::InvalidArgument("Data format should have 4 characters"));
+        ctx, dst_format_.size() == 4 || dst_format_.size() == 5,
+        errors::InvalidArgument("Data format should have 4 or 5 characters"));
     OP_REQUIRES(ctx, FormatFromString(dst_format_, &data_format),
                 errors::InvalidArgument("Invalid data format"));
   }
@@ -113,10 +113,10 @@ class DataFormatVecPermuteOp : public XlaOpKernel {
                     input_tensor_shape.DebugString()));
     const int dim0 = input_tensor_shape.dim_size(0);
     OP_REQUIRES(
-        ctx, dim0 == 2 || dim0 == 4,
+        ctx, dim0 == 2 || dim0 == 4 || dim0 == 5,
         errors::InvalidArgument(
-            "First dimension of input must be of size 4, but got shape ",
-            input_tensor_shape.DebugString()));
+            "First dimension of input must be of size 2, 4 or 5, but got "
+            "shape ", input_tensor_shape.DebugString()));
     if (input_rank == 2) {
       OP_REQUIRES(
           ctx, input_tensor_shape.dim_size(1) == 2,

--- a/tensorflow/core/grappler/optimizers/generic_layout_optimizer_transposer.h
+++ b/tensorflow/core/grappler/optimizers/generic_layout_optimizer_transposer.h
@@ -210,6 +210,14 @@ class DefaultLayoutSensitiveOpTransposer : public LayoutSensitiveOpTransposer {
                        utils::MutableNodeView* node) override;
 };
 
+class BiasAddTransposer : public LayoutSensitiveOpTransposer {
+ public:
+  explicit BiasAddTransposer () : LayoutSensitiveOpTransposer() {}
+
+  Status TransposeNode(TransposeContext* context,
+                       utils::MutableNodeView* node) override;
+};
+
 class AvgPoolGradTransposer : public LayoutSensitiveOpTransposer {
  public:
   explicit AvgPoolGradTransposer() : LayoutSensitiveOpTransposer() {}
@@ -319,7 +327,7 @@ class LayoutAgnosticOpTransposer : public Transposer {
   bool IsAfterDstToSrcTransform(const TransposeContext& context,
                                 const utils::MutableNodeView& node) const;
 
-  std::vector<int> GetVariadic4DFaninPorts(
+  std::vector<int> GetVariadic4DOr5DFaninPorts(
       const TransposeContext& context,
       const utils::MutableNodeView& node) const;
 };

--- a/tensorflow/core/grappler/optimizers/generic_layout_optimizer_transposer.h
+++ b/tensorflow/core/grappler/optimizers/generic_layout_optimizer_transposer.h
@@ -327,9 +327,9 @@ class LayoutAgnosticOpTransposer : public Transposer {
   bool IsAfterDstToSrcTransform(const TransposeContext& context,
                                 const utils::MutableNodeView& node) const;
 
-  std::vector<int> GetVariadic4DOr5DFaninPorts(
-      const TransposeContext& context,
-      const utils::MutableNodeView& node) const;
+  std::vector<int> GetVariadicNDFaninPorts(
+      const TransposeContext& context, const utils::MutableNodeView& node,
+      int rank) const;
 };
 
 class DefaultLayoutAgnosticOpTransposer : public LayoutAgnosticOpTransposer {

--- a/tensorflow/core/grappler/optimizers/generic_layout_optimizer_transposer_factory.cc
+++ b/tensorflow/core/grappler/optimizers/generic_layout_optimizer_transposer_factory.cc
@@ -27,6 +27,9 @@ std::shared_ptr<Transposer> TransposerFactory::GetTransposer(
     return GetOrCreateIfNotFound<DefaultLayoutSensitiveOpTransposer>(
         "DefaultLayoutSensitiveOp");
   }
+  if (IsBiasAdd(node)) {
+    return GetOrCreateIfNotFound<BiasAddTransposer>("BiasAdd");
+  }
   if (IsAvgPoolGrad(node)) {
     return GetOrCreateIfNotFound<AvgPoolGradTransposer>("AvgPoolGrad");
   }

--- a/tensorflow/python/grappler/layout_optimizer_test.py
+++ b/tensorflow/python/grappler/layout_optimizer_test.py
@@ -1894,6 +1894,45 @@ class LayoutOptimizerTest(test.TestCase):
     self.assertAllClose(output_val_ref, output_val, atol=1e-3)
 
   @test_util.deprecated_graph_mode_only
+  def testIdentityNFor4DAnd5DTensors(self):
+    if not test.is_gpu_available(cuda_only=True):
+      self.skipTest('GPU required')
+    h = array_ops.placeholder(dtype='float32')
+    x = array_ops.reshape(h, [-1, 2, 14, 14, 1])
+    w = random_ops.truncated_normal([2, 2, 2, 1, 4], seed=0)
+    strides = [1, 1, 1, 1, 1]
+    y = gen_nn_ops.conv3d(x, w, strides, 'SAME')
+    x1 = array_ops.reshape(h, [-1, 784])
+    y1 = _two_layer_model(x1)
+    outputs = array_ops.identity_n([y1, y])
+    new_x0 = array_ops.reshape(outputs[0], [-1, 2, 14, 14, 1])
+    new_x1 = array_ops.reshape(outputs[1], [-1, 2, 14, 14, 1])
+    output = math_ops.add(new_x0, new_x1)
+
+    x_val = [1.7] * 784
+    with session.Session(config=_get_config(False)) as sess:
+      output_val_ref = sess.run(output, feed_dict={h: x_val})
+
+    with session.Session(config=_get_config()) as sess:
+      metadata = config_pb2.RunMetadata()
+      output_val = sess.run(output, run_metadata=metadata, feed_dict={h: x_val})
+
+    nodes = []
+    num_transposes = 0
+    for node in metadata.cost_graph.node:
+      if _is_transpose(node.name):
+        num_transposes += 1
+      nodes.append(node.name)
+
+    expected_num_transposes = 4
+    self.assertEqual(expected_num_transposes, num_transposes)
+    self._assert_trans_ndhwc_to_ncdhw('Conv3D-0', nodes)
+    self._assert_trans_nhwc_to_nchw('Conv2D-0', nodes)
+    self._assert_trans_ncdhw_to_ndhwc('IdentityN-1-0', nodes)
+    self._assert_trans_nchw_to_nhwc('IdentityN-0-0', nodes)
+    self.assertAllClose(output_val_ref, output_val, atol=1e-3)
+
+  @test_util.deprecated_graph_mode_only
   def testShapeNFollowedByNotConvertibleNodeReshape(self):
     if test.is_gpu_available(cuda_only=True):
       x = array_ops.placeholder(dtype='float32')

--- a/tensorflow/python/grappler/layout_optimizer_test.py
+++ b/tensorflow/python/grappler/layout_optimizer_test.py
@@ -783,6 +783,45 @@ class LayoutOptimizerTest(test.TestCase):
       self.assertAllClose(output_val_ref, output_val, atol=1e-3)
 
   @test_util.deprecated_graph_mode_only
+  def testConcatWithControlDependencyFor5DTensor(self):
+    if not test.is_gpu_available(cuda_only=True):
+      self.skipTest('GPU required')
+    random_seed.set_random_seed(0)
+    x = random_ops.truncated_normal([2, 2, 14, 14, 1], seed=0)
+    w = random_ops.truncated_normal([2, 2, 2, 1, 2], seed=0)
+    strides = [1, 1, 1, 1, 1]
+    y = gen_nn_ops.conv3d(x, w, strides, 'SAME')
+    axis = constant_op.constant(4)
+    var = variables.Variable(3)
+    assign = state_ops.assign(var, 6)
+    with ops.control_dependencies([assign]):
+      concat = array_ops.concat([y, y], axis)
+    output = array_ops.identity(concat)
+
+    with session.Session(config=_get_config(False)) as sess:
+      output_val_ref = self.evaluate(output)
+
+    with session.Session(config=_get_config()) as sess:
+      metadata = config_pb2.RunMetadata()
+      output_val = sess.run(output, run_metadata=metadata)
+
+    nodes = []
+    num_transposes = 0
+    for node in metadata.cost_graph.node:
+      if _is_transpose(node.name):
+        num_transposes += 1
+      nodes.append(node.name)
+
+    # Four transposes were initially added in the Expand phase of
+    # LayoutOptimizer; two of them are cancelled out in the Collapse phase.
+    expected_num_transposes = 2
+    self.assertEqual(expected_num_transposes, num_transposes)
+    self._assert_trans_ndhwc_to_ncdhw('Conv3D-0', nodes)
+    self._assert_trans_ncdhw_to_ndhwc('concat-0-0', nodes)
+    self._assert_map_ndhwc_to_ncdhw('concat-2', nodes)
+    self.assertAllClose(output_val_ref, output_val, atol=1e-3)
+
+  @test_util.deprecated_graph_mode_only
   def testFill(self):
     if test.is_gpu_available(cuda_only=True):
       random_seed.set_random_seed(0)
@@ -1397,107 +1436,167 @@ class LayoutOptimizerTest(test.TestCase):
 
   @test_util.deprecated_graph_mode_only
   def testConv3D(self):
-    if test.is_gpu_available(cuda_only=True):
-      random_seed.set_random_seed(0)
-      x = random_ops.truncated_normal([1, 784], seed=0)
-      conv = _two_layer_model(x)
-      filters = random_ops.truncated_normal([2, 2, 2, 1, 2], seed=0)
-      strides_val = [1, 1, 1, 1, 1]
-      x_3d = array_ops.reshape(conv, [-1, 4, 14, 14, 1])
-      conv3d = gen_nn_ops.conv3d(x_3d, filters, strides_val, 'VALID')
-      output = array_ops.identity(conv3d)
+    if not test.is_gpu_available(cuda_only=True):
+      self.skipTest('GPU required')
+    random_seed.set_random_seed(0)
+    x = random_ops.truncated_normal([2, 2, 14, 14, 1], seed=0)
+    w = random_ops.truncated_normal([2, 2, 2, 1, 2], seed=0)
+    strides = [1, 1, 1, 1, 1]
+    y = gen_nn_ops.conv3d(x, w, strides, 'SAME')
+    output = array_ops.identity(y)
 
-      with session.Session(config=_get_config(False)) as sess:
-        output_val_ref = sess.run(output)
+    with session.Session(config=_get_config(False)) as sess:
+      output_val_ref = sess.run(output)
 
-      with session.Session(config=_get_config()) as sess:
-        metadata = config_pb2.RunMetadata()
-        output_val = sess.run(output, run_metadata=metadata)
+    with session.Session(config=_get_config()) as sess:
+      metadata = config_pb2.RunMetadata()
+      output_val = sess.run(output, run_metadata=metadata)
 
-      nodes = []
-      num_transposes = 0
-      for node in metadata.cost_graph.node:
-        if _is_transpose(node.name):
-          num_transposes += 1
-        nodes.append(node.name)
+    nodes = []
+    num_transposes = 0
+    for node in metadata.cost_graph.node:
+      if _is_transpose(node.name):
+        num_transposes += 1
+      nodes.append(node.name)
 
-      expected_num_transposes = 2
-      self.assertEqual(expected_num_transposes, num_transposes)
-      self._assert_trans_nhwc_to_nchw('Conv2D-0', nodes)
-      self._assert_trans_ndhwc_to_ncdhw('Conv3D-0', nodes)
-      self._assert_trans_ncdhw_to_ndhwc('Conv3D-0-0', nodes)
-      self.assertAllClose(output_val_ref, output_val, atol=1e-3)
+    expected_num_transposes = 2
+    self.assertEqual(expected_num_transposes, num_transposes)
+    self._assert_trans_ndhwc_to_ncdhw('Conv3D-0', nodes)
+    self._assert_trans_ncdhw_to_ndhwc('Conv3D-0-0', nodes)
+    self.assertAllClose(output_val_ref, output_val, atol=1e-3)
 
   @test_util.deprecated_graph_mode_only
   def testConv3DBackpropInput(self):
-    if test.is_gpu_available(cuda_only=True):
-      random_seed.set_random_seed(0)
-      x = random_ops.truncated_normal([1, 784], seed=0)
-      conv = _two_layer_model(x)
-      x_3d = array_ops.reshape(conv, [-1, 4, 14, 14, 1])
-      filters = random_ops.truncated_normal([2, 2, 2, 1, 1], seed=0)
-      strides_val = [1, 1, 1, 1, 1]
-      shape = array_ops.shape(x_3d)
-      conv3d_grad = gen_nn_ops.conv3d_backprop_input_v2(shape, filters, x_3d,
-                                                        strides_val, 'SAME')
-      output = array_ops.identity(conv3d_grad)
+    if not test.is_gpu_available(cuda_only=True):
+      self.skipTest('GPU required')
+    random_seed.set_random_seed(0)
+    dy = random_ops.truncated_normal([2, 2, 14, 14, 1], seed=0)
+    w = random_ops.truncated_normal([2, 2, 2, 1, 1], seed=0)
+    strides = [1, 1, 1, 1, 1]
+    x_shape = array_ops.shape(dy)
+    dx = gen_nn_ops.conv3d_backprop_input_v2(x_shape, w, dy, strides, 'SAME')
+    output = array_ops.identity(dx)
 
-      with session.Session(config=_get_config(False)) as sess:
-        output_val_ref = sess.run(output)
+    with session.Session(config=_get_config(False)) as sess:
+      output_val_ref = sess.run(output)
 
-      with session.Session(config=_get_config()) as sess:
-        metadata = config_pb2.RunMetadata()
-        output_val = sess.run(output, run_metadata=metadata)
+    with session.Session(config=_get_config()) as sess:
+      metadata = config_pb2.RunMetadata()
+      output_val = sess.run(output, run_metadata=metadata)
 
-      nodes = []
-      num_transposes = 0
-      for node in metadata.cost_graph.node:
-        if _is_transpose(node.name):
-          num_transposes += 1
-        nodes.append(node.name)
+    nodes = []
+    num_transposes = 0
+    for node in metadata.cost_graph.node:
+      if _is_transpose(node.name):
+        num_transposes += 1
+      nodes.append(node.name)
 
-      expected_num_transposes = 2
-      self.assertEqual(expected_num_transposes, num_transposes)
-      self._assert_trans_nhwc_to_nchw('Conv2D-0', nodes)
-      self._assert_vec_ndhwc_to_ncdhw('Conv3DBackpropInputV2-0', nodes)
-      self._assert_trans_ndhwc_to_ncdhw('Conv3DBackpropInputV2-2', nodes)
-      self._assert_trans_ncdhw_to_ndhwc('Conv3DBackpropInputV2-0-0', nodes)
-      self.assertAllClose(output_val_ref, output_val, atol=1e-3)
+    expected_num_transposes = 2
+    self.assertEqual(expected_num_transposes, num_transposes)
+    self._assert_vec_ndhwc_to_ncdhw('Conv3DBackpropInputV2-0', nodes)
+    self._assert_trans_ndhwc_to_ncdhw('Conv3DBackpropInputV2-2', nodes)
+    self._assert_trans_ncdhw_to_ndhwc('Conv3DBackpropInputV2-0-0', nodes)
+    self.assertAllClose(output_val_ref, output_val, atol=1e-3)
 
   @test_util.deprecated_graph_mode_only
   def testConv3DBackpropFilter(self):
-    if test.is_gpu_available(cuda_only=True):
-      random_seed.set_random_seed(0)
-      x = random_ops.truncated_normal([1, 784], seed=0)
-      conv = _two_layer_model(x)
-      x_3d = array_ops.reshape(conv, [-1, 4, 14, 14, 1])
-      filters = random_ops.truncated_normal([2, 2, 2, 1, 1], seed=0)
-      strides_val = [1, 1, 1, 1, 1]
-      shape = constant_op.constant([2, 2, 2, 1, 1], shape=[5])
-      conv3d_grad = gen_nn_ops.conv3d_backprop_filter_v2(
-          x_3d, shape, x_3d, strides_val, 'SAME')
-      output = array_ops.identity(conv3d_grad)
+    if not test.is_gpu_available(cuda_only=True):
+      self.skipTest('GPU required')
+    random_seed.set_random_seed(0)
+    x = random_ops.truncated_normal([2, 2, 14, 14, 1], seed=0)
+    dy = random_ops.truncated_normal([2, 2, 14, 14, 1], seed=0)
+    strides = [1, 1, 1, 1, 1]
+    w_shape = constant_op.constant([2, 2, 2, 1, 1], shape=[5])
+    dw = gen_nn_ops.conv3d_backprop_filter_v2(x, w_shape, dy, strides, 'SAME')
+    output = array_ops.identity(dw)
 
-      with session.Session(config=_get_config(False)) as sess:
-        output_val_ref = sess.run(output)
+    with session.Session(config=_get_config(False)) as sess:
+      output_val_ref = sess.run(output)
 
-      with session.Session(config=_get_config()) as sess:
-        metadata = config_pb2.RunMetadata()
-        output_val = sess.run(output, run_metadata=metadata)
+    with session.Session(config=_get_config()) as sess:
+      metadata = config_pb2.RunMetadata()
+      output_val = sess.run(output, run_metadata=metadata)
 
-      nodes = []
-      num_transposes = 0
-      for node in metadata.cost_graph.node:
-        if _is_transpose(node.name):
-          num_transposes += 1
-        nodes.append(node.name)
+    nodes = []
+    num_transposes = 0
+    for node in metadata.cost_graph.node:
+      if _is_transpose(node.name):
+        num_transposes += 1
+      nodes.append(node.name)
 
-      expected_num_transposes = 2
-      self.assertEqual(expected_num_transposes, num_transposes)
-      self._assert_trans_nhwc_to_nchw('Conv2D-0', nodes)
-      self._assert_trans_ndhwc_to_ncdhw('Conv3DBackpropFilterV2-0', nodes)
-      self._assert_trans_ndhwc_to_ncdhw('Conv3DBackpropFilterV2-2', nodes)
-      self.assertAllClose(output_val_ref, output_val, atol=1e-3)
+    expected_num_transposes = 2
+    self.assertEqual(expected_num_transposes, num_transposes)
+    self._assert_trans_ndhwc_to_ncdhw('Conv3DBackpropFilterV2-0', nodes)
+    self._assert_trans_ndhwc_to_ncdhw('Conv3DBackpropFilterV2-2', nodes)
+    self.assertAllClose(output_val_ref, output_val, atol=1e-3)
+
+  @test_util.deprecated_graph_mode_only
+  def testBiasAddFor5DTensor(self):
+    if not test.is_gpu_available(cuda_only=True):
+      self.skipTest('GPU required')
+    random_seed.set_random_seed(0)
+    x = random_ops.truncated_normal([2, 2, 14, 14, 1], seed=0)
+    w = random_ops.truncated_normal([2, 2, 2, 1, 2], seed=0)
+    b = random_ops.truncated_normal([2], seed=0)
+    strides = [1, 1, 1, 1, 1]
+    y = gen_nn_ops.conv3d(x, w, strides, 'SAME')
+    y = gen_nn_ops.bias_add(y, b, 'NHWC')
+    output = array_ops.identity(y)
+
+    with session.Session(config=_get_config(False)) as sess:
+      output_val_ref = sess.run(output)
+
+    with session.Session(config=_get_config()) as sess:
+      metadata = config_pb2.RunMetadata()
+      output_val = sess.run(output, run_metadata=metadata)
+
+    nodes = []
+    num_transposes = 0
+    for node in metadata.cost_graph.node:
+      if _is_transpose(node.name):
+        num_transposes += 1
+      nodes.append(node.name)
+
+    expected_num_transposes = 2
+    self.assertEqual(expected_num_transposes, num_transposes)
+    self._assert_trans_ndhwc_to_ncdhw('Conv3D-0', nodes)
+    self._assert_trans_ncdhw_to_ndhwc('BiasAdd-0-0', nodes)
+    self.assertAllClose(output_val_ref, output_val, atol=1e-3)
+
+  @test_util.deprecated_graph_mode_only
+  def testBiasAddGradFor5DTensor(self):
+    if not test.is_gpu_available(cuda_only=True):
+      self.skipTest('GPU required')
+    random_seed.set_random_seed(0)
+    dy = random_ops.truncated_normal([2, 2, 14, 14, 1], seed=0)
+    w = random_ops.truncated_normal([2, 2, 2, 1, 1], seed=0)
+    strides = [1, 1, 1, 1, 1]
+    dy_shape = array_ops.shape(dy)
+    dx = gen_nn_ops.conv3d_backprop_input_v2(dy_shape, w, dy, strides, 'SAME')
+    db = gen_nn_ops.bias_add_grad(dx, 'NHWC')
+    output = array_ops.identity(db)
+
+    with session.Session(config=_get_config(False)) as sess:
+      output_val_ref = sess.run(output)
+
+    with session.Session(config=_get_config()) as sess:
+      metadata = config_pb2.RunMetadata()
+      output_val = sess.run(output, run_metadata=metadata)
+
+    nodes = []
+    num_transposes = 0
+    for node in metadata.cost_graph.node:
+      if _is_transpose(node.name):
+        num_transposes += 1
+      nodes.append(node.name)
+
+    # The output of Conv3DBackpropInputV2 won't be converted back to NDHWC
+    # because of the BiasAddGrad.
+    expected_num_transposes = 1
+    self.assertEqual(expected_num_transposes, num_transposes)
+    self._assert_vec_ndhwc_to_ncdhw('Conv3DBackpropInputV2-0', nodes)
+    self._assert_trans_ndhwc_to_ncdhw('Conv3DBackpropInputV2-2', nodes)
+    self.assertAllClose(output_val_ref, output_val, atol=1e-3)
 
   @test_util.deprecated_graph_mode_only
   def testSliceWithNonConstAxis(self):
@@ -1535,6 +1634,44 @@ class LayoutOptimizerTest(test.TestCase):
       self._assert_trans_nchw_to_nhwc('Slice-0-0', nodes)
       self._assert_vec_nhwc_to_nchw('Slice-2', nodes)
       self.assertAllClose(output_val_ref, output_val, atol=1e-3)
+
+  @test_util.deprecated_graph_mode_only
+  def testSliceWithNonConstAxisFor5DTensor(self):
+    if not test.is_gpu_available(cuda_only=True):
+      self.skipTest('GPU required')
+    random_seed.set_random_seed(0)
+    x = random_ops.truncated_normal([2, 2, 14, 14, 1], seed=0)
+    w = random_ops.truncated_normal([2, 2, 2, 1, 2], seed=0)
+    strides = [1, 1, 1, 1, 1]
+    y = gen_nn_ops.conv3d(x, w, strides, 'SAME')
+    size = array_ops.placeholder(dtype='int32')
+    s = array_ops.slice(y, [0, 0, 0, 0, 0], size)
+    output = array_ops.identity(s)
+
+    size_val = [1, 1, 2, 2, 1]
+    with session.Session(config=_get_config(False)) as sess:
+      output_val_ref = sess.run(output, feed_dict={size: size_val})
+
+    with session.Session(config=_get_config()) as sess:
+      metadata = config_pb2.RunMetadata()
+      output_val = sess.run(output, run_metadata=metadata,
+                            feed_dict={size: size_val})
+
+    nodes = []
+    num_transposes = 0
+    for node in metadata.cost_graph.node:
+      if _is_transpose(node.name):
+        num_transposes += 1
+      nodes.append(node.name)
+
+    # Four transposes were initially added in the Expand phase of
+    # LayoutOptimizer; two of them are cancelled out in the Collapse phase.
+    expected_num_transposes = 2
+    self.assertEqual(expected_num_transposes, num_transposes)
+    self._assert_trans_ndhwc_to_ncdhw('Conv3D-0', nodes)
+    self._assert_trans_ncdhw_to_ndhwc('Slice-0-0', nodes)
+    self._assert_vec_ndhwc_to_ncdhw('Slice-2', nodes)
+    self.assertAllClose(output_val_ref, output_val, atol=1e-3)
 
   @test_util.deprecated_graph_mode_only
   def testStridedSliceWithNonConstAxis(self):
@@ -1721,6 +1858,40 @@ class LayoutOptimizerTest(test.TestCase):
       self._assert_trans_nhwc_to_nchw('Conv2D-0', nodes)
       self._assert_vec_nchw_to_nhwc('ShapeN-0-0', nodes)
       self.assertAllEqual(output_val_ref, output_val)
+
+  @test_util.deprecated_graph_mode_only
+  def testShapeNFor5DTensor(self):
+    if not test.is_gpu_available(cuda_only=True):
+      self.skipTest('GPU required')
+    h = array_ops.placeholder(dtype='float32')
+    x = array_ops.reshape(h, [-1, 2, 14, 14, 1])
+    w = random_ops.truncated_normal([2, 2, 2, 1, 2], seed=0)
+    strides = [1, 1, 1, 1, 1]
+    y = gen_nn_ops.conv3d(x, w, strides, 'SAME')
+    shapen = array_ops.shape_n([y, y])
+    output = math_ops.add(shapen[0], shapen[1])
+
+    x_val = [1.7] * 784
+    with session.Session(config=_get_config(False)) as sess:
+      output_val_ref = sess.run(output, feed_dict={h: x_val})
+
+    with session.Session(config=_get_config()) as sess:
+      metadata = config_pb2.RunMetadata()
+      output_val = sess.run(output, run_metadata=metadata, feed_dict={h: x_val})
+
+    nodes = []
+    num_transposes = 0
+    for node in metadata.cost_graph.node:
+      if _is_transpose(node.name):
+        num_transposes += 1
+      nodes.append(node.name)
+
+    expected_num_transposes = 1
+    self.assertEqual(expected_num_transposes, num_transposes)
+    self._assert_trans_ndhwc_to_ncdhw('Conv3D-0', nodes)
+    self._assert_vec_ncdhw_to_ndhwc('ShapeN-0-0', nodes)
+    self._assert_vec_ncdhw_to_ndhwc('ShapeN-1-0', nodes)
+    self.assertAllClose(output_val_ref, output_val, atol=1e-3)
 
   @test_util.deprecated_graph_mode_only
   def testShapeNFollowedByNotConvertibleNodeReshape(self):


### PR DESCRIPTION
This PR further improves the grappler layout optimizer to support 5D tensors. Specifically, this PR does:

1. Fix the issue of the Conv3D/Conv3DBackpropInput/Conv3DBackpropFilter Transposers that fail to apply ScopedDataFormatUpgrader.
2. Improve the unit tests for (1).
3. Add support for 5D tensors for BiasAdd, BiasAddGrad, Shape, ShapeN, Slice, AddN, Concat.
4. Add new tests for (3).

fyi. @nluehr 