### PR TITLE
Attempt to fix the pip wheel rename on Windows.

### DIFF
--- a/tensorflow/tools/ci_build/release/common.sh
+++ b/tensorflow/tools/ci_build/release/common.sh
@@ -223,6 +223,10 @@ function maybe_skip_v1 {
 function copy_to_new_project_name {
   WHL_PATH="$1"
   NEW_PROJECT_NAME="$2"
+  PYTHON_CMD="$3"
+
+  # Debugging only, could be removed after we know it works
+  echo "copy_to_new_project_name PATH is ${PATH}"
 
   ORIGINAL_WHL_NAME=$(basename "${WHL_PATH}")
   ORIGINAL_WHL_DIR=$(realpath "$(dirname "${WHL_PATH}")")
@@ -232,7 +236,7 @@ function copy_to_new_project_name {
   VERSION="$(echo "${FULL_TAG}" | cut -d '-' -f 1)"
 
   TMP_DIR="$(mktemp -d)"
-  wheel unpack "${WHL_PATH}" -d "${TMP_DIR}"
+  ${PYTHON_CMD} -m wheel unpack "${WHL_PATH}" -d "${TMP_DIR}"
   TMP_UNPACKED_DIR="$(ls -d "${TMP_DIR}"/* | head -n 1)"
   pushd "${TMP_UNPACKED_DIR}"
 
@@ -247,7 +251,7 @@ function copy_to_new_project_name {
   NEW_PROJECT_NAME_DASH="${NEW_PROJECT_NAME//_/-}"
   sed -i.bak "s/${ORIGINAL_PROJECT_NAME_DASH}/${NEW_PROJECT_NAME_DASH}/g" "${NEW_WHL_DIR_PREFIX}.dist-info/METADATA"
 
-  wheel pack "${TMP_UNPACKED_DIR}" -d "${ORIGINAL_WHL_DIR}"
+  ${PYTHON_CMD} -m wheel pack "${TMP_UNPACKED_DIR}" -d "${ORIGINAL_WHL_DIR}"
   popd
   rm -rf "${TMP_DIR}"
 }

--- a/tensorflow/tools/ci_build/release/windows/gpu_py36_full/release_pip_rename.sh
+++ b/tensorflow/tools/ci_build/release/windows/gpu_py36_full/release_pip_rename.sh
@@ -20,5 +20,5 @@ source tensorflow/tools/ci_build/release/common.sh
 
 # Copy and rename to tensorflow
 for f in $(ls py_test_dir/tensorflow-*cp3*-cp3*m-win_amd64.whl); do
-  copy_to_new_project_name "${f}" tensorflow_gpu
+  copy_to_new_project_name "${f}" tensorflow_gpu python3.6
 done

--- a/tensorflow/tools/ci_build/release/windows/gpu_py37_full/release_pip_rename.sh
+++ b/tensorflow/tools/ci_build/release/windows/gpu_py37_full/release_pip_rename.sh
@@ -20,5 +20,5 @@ source tensorflow/tools/ci_build/release/common.sh
 
 # Copy and rename to tensorflow
 for f in $(ls py_test_dir/tensorflow-*cp3*-cp3*m-win_amd64.whl); do
-  copy_to_new_project_name "${f}" tensorflow_gpu
+  copy_to_new_project_name "${f}" tensorflow_gpu /c/Python37/python
 done

--- a/tensorflow/tools/ci_build/release/windows/gpu_py38_full/release_pip_rename.sh
+++ b/tensorflow/tools/ci_build/release/windows/gpu_py38_full/release_pip_rename.sh
@@ -20,5 +20,5 @@ source tensorflow/tools/ci_build/release/common.sh
 
 # Copy and rename to tensorflow
 for f in $(ls py_test_dir/tensorflow-*cp3*-cp3*-win_amd64.whl); do
-  copy_to_new_project_name "${f}" tensorflow_gpu
+  copy_to_new_project_name "${f}" tensorflow_gpu python
 done


### PR DESCRIPTION
There are different builds with 3 different solutions. Don't know yet
which one works, by reading code all 3 should work but Windows paths are
dubious since we call to bash during the release script.

That's why I'm also adding a debug line to display the contents of
`PATH`.