### PR TITLE
NFC - minor spelling tweaks of documents under compiler directory

### DIFF
--- a/tensorflow/compiler/mlir/hlo/README.md
+++ b/tensorflow/compiler/mlir/hlo/README.md
@@ -22,7 +22,7 @@ upstream.
 
 ## QuickStart: building and testing
 
-These instructions work on Linux, you may have to adjust for your plaform.
+These instructions work on Linux, you may have to adjust for your platform.
 
 To build the code in this repository, you need a clone of the LLVM/MLIR git
 repository:

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/hlo_ops_base.td
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/hlo_ops_base.td
@@ -1363,7 +1363,7 @@ class BASE_HLO_BitcastOp {
 
   string description = [{
     This op changes the shape of the input in the way that the physical
-    arranggment of elements are unchanged.
+    arrangement of elements are unchanged.
 
     However, the op needs layout information to make sense of "physical
     arrangement of elements". Layout support in MHLO is currently under

--- a/tensorflow/compiler/mlir/lite/ir/tfl_ops.td
+++ b/tensorflow/compiler/mlir/lite/ir/tfl_ops.td
@@ -365,7 +365,7 @@ class TFL_TCopVTEtAreSameAt<int i, int j> : Or<[
 
 // This is a constraint for most of the binary ops, e.g., add, mul, div, etc.
 // Binary ops lhs & rhs should have the same value type, and is capable to
-// compare quantiziation types as well.
+// compare quantization types as well.
 def BinaryOpSameElementTypeConstraint :
   PredOpTrait<"operands have same element type",
     Or<[

--- a/tensorflow/compiler/mlir/lite/transforms/optimize_patterns.td
+++ b/tensorflow/compiler/mlir/lite/transforms/optimize_patterns.td
@@ -606,7 +606,7 @@ def ShapeMatchesReduceWithKeepAxes : Constraint<CPred<
   "ShapeMatchesReduceWithKeepAxes($0, $1, $2)">>;
 
 // Fold reshapes re-inserting reduced dimensions into the results of a reduction
-// with `keep_dims=false` by chaning it to one using `keep_dims=true`.
+// with `keep_dims=false` by changing it to one using `keep_dims=true`.
 foreach ReduceOp = [TFL_ReduceMaxOp, TFL_ReduceMinOp, TFL_ReduceProdOp,
                     TFL_SumOp] in {
   def FoldReshapeTo#ReduceOp : Pat<

--- a/tensorflow/compiler/mlir/tensorflow/g3doc/space_to_depth.md
+++ b/tensorflow/compiler/mlir/tensorflow/g3doc/space_to_depth.md
@@ -168,7 +168,7 @@ module {
               %filter: tensor<7x7x3x64xf32>) {
      %filter_transform = "tf.Pad/tf.Transpose/tf.Reshape"(%filter):
        tensor<7x7x3x64xf32>) -> tensor<4x4x12x64xf32>
-     %conv = "tf.Conv2D"(%input, %filter_transfrom) {strides = [1, 1, 1, 1]}:
+     %conv = "tf.Conv2D"(%input, %filter_transform) {strides = [1, 1, 1, 1]}:
        (tensor<2x112x112x12xf32>, tensor<4x4x12x64xf32>) ->
        tensor<2x112x112x64xf32>
    }

--- a/tensorflow/compiler/mlir/tfr/ir/tfr_ops.td
+++ b/tensorflow/compiler/mlir/tfr/ir/tfr_ops.td
@@ -287,8 +287,8 @@ def TFR_ConstantTensorOp : TFR_Op<"constant_tensor", [NoSideEffect]> {
     Example:
 
     ```mlir
-    %1 = tfr.contant_tensor(%0) : f32 -> tensor<f32>
-    %3 = tfr.contant_tensor(%2) : vector<1xf32> -> tensor<1xf32>
+    %1 = tfr.constant_tensor(%0) : f32 -> tensor<f32>
+    %3 = tfr.constant_tensor(%2) : vector<1xf32> -> tensor<1xf32>
     ```
   }];
 

--- a/tensorflow/compiler/xla/service/mlir_gpu/experimental/conv_emitter/g3doc/conv_emitter.md
+++ b/tensorflow/compiler/xla/service/mlir_gpu/experimental/conv_emitter/g3doc/conv_emitter.md
@@ -8,7 +8,7 @@ TODO(timshen): Change once all patches are checked in.
 The convolution emitter is a prototype with the following goals:
 
 *   The top priority is performance.
-*   It supports arbitrarily sophiscated layouts.
+*   It supports arbitrarily sophisticated layouts.
 *   It supports platform-specific high-performance instructions.
 *   It is as portable as possible.
 *   It enables fusion support in the future.


### PR DESCRIPTION
This PR addresses minor spelling tweaks of md/td files under compiler directory