### PR TITLE
Parallelize each level of BFS in `GetMatchingPaths`

### DIFF
--- a/tensorflow/core/platform/file_system_helper.cc
+++ b/tensorflow/core/platform/file_system_helper.cc
@@ -15,10 +15,13 @@ limitations under the License.
 
 #include "tensorflow/core/platform/file_system_helper.h"
 
+#include <condition_variable>
 #include <deque>
+#include <mutex>
 #include <string>
 #include <vector>
 
+#include "tensorflow/core/platform/cpu_info.h"
 #include "tensorflow/core/platform/env.h"
 #include "tensorflow/core/platform/file_system.h"
 #include "tensorflow/core/platform/path.h"
@@ -32,7 +35,7 @@ namespace internal {
 
 namespace {
 
-constexpr int kNumThreads = 8;
+const int kNumThreads = port::NumSchedulableCPUs();
 
 // Run a function in parallel using a ThreadPool, but skip the ThreadPool
 // on the iOS platform due to its problems with more than a few threads.
@@ -75,67 +78,89 @@ Status GetMatchingPaths(FileSystem* fs, Env* env, const string& pattern,
 #endif
   std::vector<string> dirs;
   if (!is_directory) {
-    dirs.push_back(eval_pattern);
+    dirs.emplace_back(eval_pattern);
   }
   StringPiece tmp_dir(io::Dirname(eval_pattern));
   while (tmp_dir.size() > dir.size()) {
-    dirs.push_back(string(tmp_dir));
+    dirs.emplace_back(string(tmp_dir));
     tmp_dir = io::Dirname(tmp_dir);
   }
-  dirs.push_back(dir);
+  dirs.emplace_back(dir);
   std::reverse(dirs.begin(), dirs.end());
-  // Setup a BFS to explore everything under dir.
+  // Setup a parallel BFS to explore everything under dir.
   std::deque<std::pair<string, int>> dir_q;
-  dir_q.push_back({dirs[0], 0});
+  std::deque<std::pair<string, int>> next_dir_q;
+  dir_q.emplace_back({dirs[0], 0});
   Status ret;  // Status to return.
-  // children_dir_status holds is_dir status for children. It can have three
-  // possible values: OK for true; FAILED_PRECONDITION for false; CANCELLED
-  // if we don't calculate IsDirectory (we might do that because there isn't
-  // any point in exploring that child path).
-  std::vector<Status> children_dir_status;
+  std::mutex results_mutex;
+  std::condition_variable results_cond;
+  std::mutex next_que_mutex;
+  std::condition_variable next_que_cond;
   while (!dir_q.empty()) {
-    string current_dir = dir_q.front().first;
-    int dir_index = dir_q.front().second;
-    dir_index++;
-    dir_q.pop_front();
-    std::vector<string> children;
-    Status s = fs->GetChildren(current_dir, &children);
-    // In case PERMISSION_DENIED is encountered, we bail here.
-    if (s.code() == tensorflow::error::PERMISSION_DENIED) {
-      continue;
-    }
-    ret.Update(s);
-    if (children.empty()) continue;
-    // This IsDirectory call can be expensive for some FS. Parallelizing it.
-    children_dir_status.resize(children.size());
-    ForEach(0, children.size(),
-            [fs, &current_dir, &children, &dirs, dir_index, is_directory,
-             &children_dir_status](int i) {
-              const string child_path = io::JoinPath(current_dir, children[i]);
-              if (!fs->Match(child_path, dirs[dir_index])) {
-                children_dir_status[i] = Status(tensorflow::error::CANCELLED,
-                                                "Operation not needed");
-              } else if (dir_index != dirs.size() - 1) {
-                children_dir_status[i] = fs->IsDirectory(child_path);
-              } else {
-                children_dir_status[i] =
-                    is_directory ? fs->IsDirectory(child_path) : Status::OK();
-              }
-            });
-    for (size_t i = 0; i < children.size(); ++i) {
-      const string child_path = io::JoinPath(current_dir, children[i]);
-      // If the IsDirectory call was cancelled we bail.
-      if (children_dir_status[i].code() == tensorflow::error::CANCELLED) {
-        continue;
+    next_dir_q.clear();
+    std::vector<Status> new_rets(dir_q.size());
+    auto handle_level = [fs, &results, &dir_q, &next_dir_q, &new_rets,
+      &results_mutex, &results_cond, &next_que_mutex, &next_que_cond](int i) {
+
+      string current_dir = dir_q.at(i).first;
+      int dir_index = dir_q.at(i).second;
+      dir_index++;
+      std::vector<string> children;
+      Status s = fs->GetChildren(current_dir, &children);
+      // In case PERMISSION_DENIED is encountered, we bail here.
+      if (s.code() == tensorflow::error::PERMISSION_DENIED) {
+        return;
       }
-      if (children_dir_status[i].ok()) {
-        if (dir_index != dirs.size() - 1) {
-          dir_q.push_back({child_path, dir_index});
+      new_rets[i] = s;
+      if (children.empty()) return;
+
+      // children_dir_status holds is_dir status for children. It can have three
+      // possible values: OK for true; FAILED_PRECONDITION for false; CANCELLED
+      // if we don't calculate IsDirectory (we might do that because there isn't
+      // any point in exploring that child path).
+      std::vector<Status> children_dir_status;
+
+      // This IsDirectory call can be expensive for some FS. Parallelizing it.
+      children_dir_status.resize(children.size());
+      auto handle_children = [fs, &current_dir, &children, &dirs, dir_index,
+                              is_directory, &children_dir_status](int j) {
+        const string child_path = io::JoinPath(current_dir, children[j]);
+        if (!fs->Match(child_path, dirs[dir_index])) {
+          children_dir_status[j] = Status(tensorflow::error::CANCELLED,
+                                          "Operation not needed");
+        } else if (dir_index != dirs.size() - 1) {
+          children_dir_status[j] = fs->IsDirectory(child_path);
         } else {
-          results->push_back(child_path);
+          children_dir_status[j] =
+              is_directory ? fs->IsDirectory(child_path) : Status::OK();
+        }
+      };
+      ForEach(0, children.size(), handle_children);
+
+      for (size_t j = 0; j < children.size(); ++j) {
+        const string child_path = io::JoinPath(current_dir, children[j]);
+        // If the IsDirectory call was cancelled we bail.
+        if (children_dir_status[j].code() == tensorflow::error::CANCELLED) {
+          continue;
+        }
+        if (children_dir_status[j].ok()) {
+          if (dir_index != dirs.size() - 1) {
+            std::lock_guard<std::mutex> lk(next_que_mutex);
+            next_dir_q.emplace_back(child_path);
+            next_que_cond.notify_one();
+          } else {
+            std::lock_guard<std::mutex> lk(results_mutex);
+            results->emplace_back(child_path);
+            results_cond.notify_one();
+          }
         }
       }
-    }
+    };
+    ForEach(0, dir_q.size(), handle_level);
+
+    ret.Update(new_rets[dir_q.size() - 1]);
+    std::swap(dir_q, next_dir_q);
+
   }
   return ret;
 }


### PR DESCRIPTION
This is a PR from JIZHI Team & TaiJi AI platform in Tencent.

I have tried to submit a PR #44269 which parallelize the `tf.gfile.Glob` in Python, by multi-threaeds against multiple path patterns. This PR is going to optimize the `GetMatchingPaths` in C++, which brings PBFS into the progress, parallelizes every level of tree by a additional queue. The optimizion can bring considerable performance improvement when the number of files to match reaches a certain level.

Since the content of the change is different, I put this in another PR.  @mihaimaruseac  Could you please task a look at this? Thanks for your review!