### PR TITLE
Add gpu implementation of ResourceSparseApplyAdadelta Op for issue #2…

### DIFF
--- a/tensorflow/core/kernels/training_ops.h
+++ b/tensorflow/core/kernels/training_ops.h
@@ -46,6 +46,18 @@ struct ApplyAdadelta {
                   typename TTypes<T>::ConstFlat grad);
 };
 
+template <typename Device, typename T, typename Tindex>
+struct ResourceSparseApplyAdadelta {
+  Tindex operator()(const Device& d, typename TTypes<T>::Matrix var,
+                  typename TTypes<T>::Matrix accum,
+                  typename TTypes<T>::Matrix accum_update,
+                  typename TTypes<T>::ConstScalar lr,
+                  typename TTypes<T>::ConstScalar rho,
+                  typename TTypes<T>::ConstScalar epsilon,
+                  typename TTypes<T>::ConstMatrix grad,
+                  typename TTypes<Tindex>::ConstFlat indices);
+};
+
 template <typename Device, typename T>
 struct FobosElasticNet {
   void operator()(const Device& d, typename TTypes<T>::Flat var,


### PR DESCRIPTION
# This commit is related to issue #2314 and #30537.
## When I want to use Adadelta Optimizer in GPU, I encounted the following error：
Error environment info:
- Ubuntu 16
- Python 3.6
- Tensorflow 2.3
- CUDA 10.1
- GPU Tesla V100
- GPU Driver 396.37

```
File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/eager/execute.py", line 60, in quick_execute  
inputs, attrs, num_outputs)  
tensorflow.python.framework.errors\_impl.InvalidArgumentError: Cannot assign a device for operation Adadelta/Adadelta/update/Unique: Could not satisfy explicit device specification '' because the node {{colocation\_node Adadelta/Adadelta/update/Unique}} was colocated with a group of nodes that required incompatible device '/job:localhost/replica:0/task:0/device:GPU:0'. All available devices \[/job:localhost/replica:0/task:0/device:CPU:0, /job:localhost/replica:0/task:0/device:XLA\_CPU:0, /job:localhost/replica:0/task:0/device:XLA\_GPU:0, /job:localhost/replica:0/task:0/device:GPU:0\].  
Colocation Debug Info:  
Colocation group had the following types and supported devices:  
Root Member(assigned\_device\_name\_index\_=2 requested\_device\_name_='/job:localhost/replica:0/task:0/device:GPU:0' assigned\_device\_name_='/job:localhost/replica:0/task:0/device:GPU:0' resource\_device\_name_='/job:localhost/replica:0/task:0/device:GPU:0' supported\_device\_types_=\[CPU\] possible\_devices\_=\[\]  
Identity: GPU CPU XLA\_CPU XLA\_GPU  
ReadVariableOp: GPU CPU XLA\_CPU XLA\_GPU  
ResourceSparseApplyAdadelta: CPU  
Unique: GPU CPU  
Shape: GPU CPU XLA\_CPU XLA\_GPU  
\_Arg: GPU CPU XLA\_CPU XLA_GPU  
Const: GPU CPU XLA\_CPU XLA\_GPU  
StridedSlice: GPU CPU XLA\_CPU XLA\_GPU  
UnsortedSegmentSum: GPU CPU XLA\_CPU XLA\_GPU

Colocation members, user-requested devices, and framework assigned devices, if any:  
wide\_deep\_8564 (_Arg) framework assigned device=/job:localhost/replica:0/task:0/device:GPU:0  
adadelta\_adadelta\_update\_resourcesparseapplyadadelta\_accum (_Arg) framework assigned device=/job:localhost/replica:0/task:0/device:GPU:0  
adadelta\_adadelta\_update\_resourcesparseapplyadadelta\_accum\_update (\_Arg) framework assigned device=/job:localhost/replica:0/task:0/device:GPU:0  
Adadelta/Adadelta/update/Unique (Unique)  
Adadelta/Adadelta/update/Shape (Shape)  
Adadelta/Adadelta/update/strided_slice/stack (Const)  
Adadelta/Adadelta/update/strided\_slice/stack\_1 (Const)  
Adadelta/Adadelta/update/strided\_slice/stack\_2 (Const)  
Adadelta/Adadelta/update/strided_slice (StridedSlice)  
Adadelta/Adadelta/update/UnsortedSegmentSum (UnsortedSegmentSum)  
Adadelta/Adadelta/update/ResourceSparseApplyAdadelta (ResourceSparseApplyAdadelta)  
wide\_deep/StatefulPartitionedCall/embedding\_lookup\_sparse\_30/embedding\_lookup\_sparse/embedding_lookup/ReadVariableOp (ReadVariableOp)  
Func/wide\_deep/StatefulPartitionedCall/input/\_148 (Identity) /job:localhost/replica:0/task:0/device:GPU:0

     [[{{node Adadelta/Adadelta/update/Unique}}]] [Op:__inference_train_step_9850]
```

To fix this, I wrote the GPU implementation for ResourceSparseApplyAdadelta Op and tested in r2.3 branch.
Test Environment info:
- Docker Image: tensorflow/tensorflow:nightly-custom-op-gpu-ubuntu16
- Ubuntu 16
- Python 3.6
- Tensorflow r2.3
- CUDA 10.1
- cuDNN 7
- Cuda Compute Capabilities 7.0 (Tesla V100 Driver 396.37)
- GCC 7
- bazel 3.1.0
