### PR TITLE
remove large loop warning

### DIFF
--- a/tensorflow/python/eager/def_function.py
+++ b/tensorflow/python/eager/def_function.py
@@ -952,8 +952,8 @@ class Function(object):
     canon_args, canon_kwds, _, filtered_flat_args = \
         self._stateful_fn._function_spec.canonicalize_function_inputs(  # pylint: disable=protected-access
             *args, **kwds)
-    return function_lib.defun(fn_with_cond)(canon_args, canon_kwds,
-                                            filtered_flat_args)
+    return function_lib.defun(fn_with_cond, autograph=False)(
+        canon_args, canon_kwds, filtered_flat_args)
 
   def experimental_get_compiler_ir(self, *args, **kwargs):
     """Returns compiler IR for the compiled function.


### PR DESCRIPTION
The sentence throws a large unrolled loop warning which is produced by autograph when there are 3000+ ```self._created_variables```, disable autograph to fix it.
```
WARNING: Large unrolled loop detected. Did you mean to use a TF loop? The following ops were created after iteration 3002: (<tf.Operation 'VarIsInitializedOp_3000/resource' type=Placeholder>, <tf.Operation 'VarIsInitializedOp_3000' type=VarIsInitializedOp>, <tf.Operation 'LogicalAnd_3000' type=LogicalAnd>)
See https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/autograph/g3doc/reference/common_errors.md#warning-large-unrolled-loop-detected
Location:
  File "keras/train.py", line 215, in <module>
    app.run(main)

  File "/usr/local/lib/python3.6/dist-packages/absl/app.py", line 299, in run
    _run_main(main, args)

  File "/usr/local/lib/python3.6/dist-packages/absl/app.py", line 250, in _run_main
    sys.exit(main(argv))

  File "keras/train.py", line 209, in main
    validation_steps=(FLAGS.eval_samples // FLAGS.batch_size))

  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/keras/engine/training.py", line 108, in _method_wrapper
    return method(self, *args, **kwargs)

  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/keras/engine/training.py", line 1098, in fit
    tmp_logs = train_function(iterator)

  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/eager/def_function.py", line 780, in __call__
    result = self._call(*args, **kwds)

  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/eager/def_function.py", line 904, in _call
    return function_lib.defun(fn_with_cond)(*canon_args, **canon_kwds)

  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/eager/function.py", line 2828, in __call__
    graph_function, args, kwargs = self._maybe_define_function(args, kwargs)

  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/eager/function.py", line 3213, in _maybe_define_function
    graph_function = self._create_graph_function(args, kwargs)

  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/eager/function.py", line 3075, in _create_graph_function
    capture_by_value=self._capture_by_value),

  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/framework/func_graph.py", line 986, in func_graph_from_py_func
    func_outputs = python_func(*func_args, **func_kwargs)

  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/framework/func_graph.py", line 969, in wrapper
    user_requested=True,

  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/autograph/impl/api.py", line 596, in converted_call
    result = converted_f(*effective_args, **kwargs)

  File "/tmp/tmpyw1arwrw.py", line 42, in tf__fn_with_cond
    ag__.for_stmt(ag__.ld(self)._created_variables, None, loop_body, get_state_1, set_state_1, ('condition',), {'iterate_names': 'wr'})

  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/autograph/operators/control_flow.py", line 368, in for_stmt
    _py_for_stmt(iter_, extra_test, body, None, None)

  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/autograph/operators/control_flow.py", line 397, in _py_for_stmt
    body(target)

  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/autograph/operators/control_flow.py", line 384, in protected_body
    after_iteration()

  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/autograph/operators/control_flow.py", line 834, in after_iteration
    did_warn = self._verify_inefficient_unroll()

  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/autograph/operators/control_flow.py", line 817, in _verify_inefficient_unroll
    '', self.iterations, new_ops, '\n'.join(traceback.format_stack()))
```