### PR TITLE
Add gpu implementation of ResourceSparseApplyAdadelta Op for issue #2314 

### DIFF
--- a/tensorflow/core/kernels/training_ops.cc
+++ b/tensorflow/core/kernels/training_ops.cc
@@ -768,7 +768,6 @@ struct ResourceSparseApplyAdadelta<CPUDevice, T, Tindex> {
       a_update = a_update * a_update.constant(rho()) +
                  update.square() * update.constant(static_cast<T>(1) - rho());
     }
-    return -1;
   }
 };
 
@@ -1271,12 +1270,10 @@ class SparseApplyAdadeltaOp : public OpKernel {
       auto indices_vec = indices.vec<Tindex>();
 
       const Device& device = ctx->template eigen_device<Device>();
-      const Tindex bad_i =
-          functor::ResourceSparseApplyAdadelta<Device, T, Tindex>()(
-              device, var.flat_outer_dims<T>(), accum_grad.flat_outer_dims<T>(),
-              accum_update.flat_outer_dims<T>(), lr.scalar<T>(),
-              rho.scalar<T>(), epsilon.scalar<T>(), grad.flat_outer_dims<T>(),
-              indices_vec);
+      functor::ResourceSparseApplyAdadelta<Device, T, Tindex>()(
+          device, var.flat_outer_dims<T>(), accum_grad.flat_outer_dims<T>(),
+          accum_update.flat_outer_dims<T>(), lr.scalar<T>(), rho.scalar<T>(),
+          epsilon.scalar<T>(), grad.flat_outer_dims<T>(), indices_vec);
     }
 
     MaybeForwardRefInputToRefOutput(ctx, 0, 0);

--- a/tensorflow/core/kernels/training_ops.cc
+++ b/tensorflow/core/kernels/training_ops.cc
@@ -1192,7 +1192,7 @@ class SparseApplyAdadeltaOp : public OpKernel {
     OP_REQUIRES_OK(ctx, ctx->GetAttr("use_locking", &use_exclusive_lock_));
   }
 
-  void Compute(OpKernelContext* ctx) override TF_NO_THREAD_SAFETY_ANALYSIS {
+  void Compute(OpKernelContext* ctx) {
     const bool sparse = true;
     auto locks = MaybeLockVariableInputMutexesInOrder<Device, T>(
         ctx, use_exclusive_lock_, sparse, {0, 1, 2});

--- a/tensorflow/core/kernels/training_ops.cc
+++ b/tensorflow/core/kernels/training_ops.cc
@@ -743,6 +743,40 @@ struct SparseApplyKerasMomentum<CPUDevice, T, Tindex> {
   }
 };
 
+
+template <typename T, typename Tindex>
+struct ResourceSparseApplyAdadelta<CPUDevice, T, Tindex> {
+  Tindex operator()(const CPUDevice& d, typename TTypes<T>::Matrix var,
+                  typename TTypes<T>::Matrix accum,
+                  typename TTypes<T>::Matrix accum_update,
+                  typename TTypes<T>::ConstScalar lr,
+                  typename TTypes<T>::ConstScalar rho,
+                  typename TTypes<T>::ConstScalar epsilon,
+                  typename TTypes<T>::ConstMatrix grad,
+                  typename TTypes<Tindex>::ConstFlat indices){
+    const Tindex N = static_cast<Tindex>(indices.size());
+    for (Tindex i = 0; i < N; i++) {
+      const Tindex index = indices(i);
+      auto accum_ = accum.template chip<0>(index);
+      auto accum_update_ = accum_update.template chip<0>(index);
+      auto grad_ = grad.template chip<0>(i);
+
+      accum_ = accum_ * accum_.constant(rho()) +
+                grad_.square() * grad_.constant(T(1) - rho());
+      const auto update =
+          (accum_update_ + accum_update_.constant(epsilon())).sqrt() *
+          (accum_ + accum_.constant(epsilon())).rsqrt() * grad_;
+      auto v = var.template chip<0>(index);
+      v -= update * update.constant(lr());
+      accum_update_ =
+          accum_update_ * accum_update_.constant(rho()) +
+          update.square() * update.constant(static_cast<T>(1) - rho());
+    }
+    return -1;
+  }
+};
+
+
 template <typename Device, typename T>
 struct ApplyAdamNonCuda {
   void operator()(const Device& d, typename TTypes<T>::Flat var,
@@ -1157,8 +1191,7 @@ REGISTER_KERNELS(GPU, complex128);
 #undef REGISTER_CPU_KERNELS
 #undef REGISTER_KERNELS
 
-// Note, this op works on cpu only.
-template <typename T, typename Tindex>
+template <typename T, typename Device, typename Tindex>
 class SparseApplyAdadeltaOp : public OpKernel {
  public:
   explicit SparseApplyAdadeltaOp(OpKernelConstruction* ctx) : OpKernel(ctx) {
@@ -1166,23 +1199,33 @@ class SparseApplyAdadeltaOp : public OpKernel {
   }
 
   void Compute(OpKernelContext* ctx) override {
+    Var* var;
     const bool sparse = true;
-    auto locks = MaybeLockVariableInputMutexesInOrder<CPUDevice, T>(
-        ctx, use_exclusive_lock_, sparse, {0, 1, 2});
-    DoCompute(ctx);
+    mutex* mu = GetTrainingVariableMutex<Device, T>(ctx, 0, sparse, &var);
+    core::ScopedUnref scoped_unref(var);
+    // mu_accum is actually the same mutex as mu_var since currently we use a
+    // global mutex.
+    //
+    // mutex* mu_accum = ctx->input_ref_mutex(1);
+    if (use_exclusive_lock_ && mu != nullptr) {
+      mutex_lock ml(*mu);
+      DoCompute(ctx);
+    } else {
+      DoCompute(ctx);
+    }
   }
 
   void DoCompute(OpKernelContext* ctx) {
     Tensor var;
     const bool sparse = true;
-    OP_REQUIRES_OK(ctx, GetInputTensorFromVariable<CPUDevice, T>(
+    OP_REQUIRES_OK(ctx, GetInputTensorFromVariable<Device, T>(
                             ctx, 0, use_exclusive_lock_, sparse, &var));
     Tensor accum_grad;
-    OP_REQUIRES_OK(ctx, GetInputTensorFromVariable<CPUDevice, T>(
+    OP_REQUIRES_OK(ctx, GetInputTensorFromVariable<Device, T>(
                             ctx, 1, use_exclusive_lock_, sparse, &accum_grad));
     Tensor accum_update;
     OP_REQUIRES_OK(ctx,
-                   GetInputTensorFromVariable<CPUDevice, T>(
+                   GetInputTensorFromVariable<Device, T>(
                        ctx, 2, use_exclusive_lock_, sparse, &accum_update));
     OP_REQUIRES(
         ctx, var.IsInitialized(),
@@ -1241,39 +1284,12 @@ class SparseApplyAdadeltaOp : public OpKernel {
       const Tindex first_dim_size = var.dim_size(0);
       // Validate all the indices are in range
       auto indices_vec = indices.vec<Tindex>();
-      for (Tindex i = 0; i < N; i++) {
-        const Tindex index = indices_vec(i);
-        OP_REQUIRES(ctx, index >= 0 && index < first_dim_size,
-                    errors::InvalidArgument(
-                        strings::StrCat("Index ", index, " at offset ", i,
-                                        " in indices is out of range")));
-      }
 
-      auto var_flat = var.flat_outer_dims<T>();
-      auto accum_grad_flat = accum_grad.flat_outer_dims<T>();
-      auto accum_update_flat = accum_update.flat_outer_dims<T>();
-      auto grad_flat = grad.flat_outer_dims<T>();
-      const T lr_scalar = lr.scalar<T>()();
-      const T rho_scalar = rho.scalar<T>()();
-      const T epsilon_scalar = epsilon.scalar<T>()();
-
-      for (Tindex i = 0; i < N; i++) {
-        const Tindex index = indices_vec(i);
-        auto accum_ = accum_grad_flat.template chip<0>(index);
-        auto accum_update_ = accum_update_flat.template chip<0>(index);
-        auto grad_ = grad_flat.template chip<0>(i);
-
-        accum_ = accum_ * accum_.constant(rho_scalar) +
-                 grad_.square() * grad_.constant(T(1) - rho_scalar);
-        const auto update =
-            (accum_update_ + accum_update_.constant(epsilon_scalar)).sqrt() *
-            (accum_ + accum_.constant(epsilon_scalar)).rsqrt() * grad_;
-        auto v = var_flat.template chip<0>(index);
-        v -= update * update.constant(lr_scalar);
-        accum_update_ =
-            accum_update_ * accum_update_.constant(rho_scalar) +
-            update.square() * update.constant(static_cast<T>(1) - rho_scalar);
-      }
+    const Device& device = ctx->template eigen_device<Device>();
+    const Tindex bad_i = functor::ResourceSparseApplyAdadelta<Device, T, Tindex>()(
+        device, var.flat_outer_dims<T>(), accum_grad.flat_outer_dims<T>(),
+        accum_update.flat_outer_dims<T>(), lr.scalar<T>(), rho.scalar<T>(),
+        epsilon.scalar<T>(), grad.flat_outer_dims<T>(), indices_vec);
     }
 
     MaybeForwardRefInputToRefOutput(ctx, 0, 0);
@@ -1283,25 +1299,74 @@ class SparseApplyAdadeltaOp : public OpKernel {
   bool use_exclusive_lock_;
 };
 
-#define REGISTER_KERNELS(T, Tindices)                                \
+
+#define REGISTER_KERNELS(T, D, Tindices)                             \
   REGISTER_KERNEL_BUILDER(Name("SparseApplyAdadelta")                \
-                              .Device(DEVICE_CPU)                    \
+                              .Device(DEVICE_##D)                    \
                               .TypeConstraint<T>("T")                \
                               .TypeConstraint<Tindices>("Tindices"), \
-                          SparseApplyAdadeltaOp<T, Tindices>);       \
+                      SparseApplyAdadeltaOp<T, D##Device, Tindices>);\
   REGISTER_KERNEL_BUILDER(Name("ResourceSparseApplyAdadelta")        \
-                              .Device(DEVICE_CPU)                    \
+                              .Device(DEVICE_##D)                    \
                               .TypeConstraint<T>("T")                \
                               .TypeConstraint<Tindices>("Tindices"), \
-                          SparseApplyAdadeltaOp<T, Tindices>);
-#define REGISTER_CPU_KERNELS(T) \
-  REGISTER_KERNELS(T, int32);   \
-  REGISTER_KERNELS(T, int64);
+                      SparseApplyAdadeltaOp<T, D##Device, Tindices>);
+#define REGISTER_CPU_KERNELS(T)      \
+  REGISTER_KERNELS(T, CPU, int32);   \
+  REGISTER_KERNELS(T, CPU, int64);
 
 TF_CALL_FLOAT_TYPES(REGISTER_CPU_KERNELS);
 TF_CALL_COMPLEX_TYPES(REGISTER_CPU_KERNELS);
 
 #undef REGISTER_CPU_KERNELS
+
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+// Forward declarations of the functor specializations for GPU.
+namespace functor {
+#define DECLARE_GPU_SPEC(T, Tindex)                                         \
+  template <>                                                               \
+  Tindex ResourceSparseApplyAdadelta<GPUDevice, T, Tindex>::operator()(     \
+      const GPUDevice& d, typename TTypes<T>::Matrix var,                   \
+      typename TTypes<T>::Matrix accum,                                     \
+      typename TTypes<T>::Matrix accum_update,                              \
+      typename TTypes<T>::ConstScalar lr,                                   \
+      typename TTypes<T>::ConstScalar rho,                                  \
+      typename TTypes<T>::ConstScalar epsilon,                              \
+      typename TTypes<T>::ConstMatrix grad,                                 \
+      typename TTypes<Tindex>::ConstFlat indices);                          \
+  extern template struct ResourceSparseApplyAdadelta<GPUDevice, T, Tindex>;
+DECLARE_GPU_SPEC(Eigen::half, int32);
+DECLARE_GPU_SPEC(Eigen::half, int64);
+DECLARE_GPU_SPEC(float, int32);
+DECLARE_GPU_SPEC(float, int64);
+DECLARE_GPU_SPEC(double, int32);
+DECLARE_GPU_SPEC(double, int64);
+#if !defined(TENSORFLOW_USE_NVCC) && \
+    !defined(TENSORFLOW_USE_ROCM)  // TODO(b/143684500): Eigen to support
+                                   // complex sqrt
+DECLARE_GPU_SPEC(complex64, int32);
+DECLARE_GPU_SPEC(complex64, int64);
+DECLARE_GPU_SPEC(complex128, int32);
+DECLARE_GPU_SPEC(complex128, int64);
+#endif
+#undef DECLARE_GPU_SPEC
+}  // namespace functor
+
+#define REGISTER_GPU_KERNELS(T)    \
+  REGISTER_KERNELS(T, GPU, int32); \
+  REGISTER_KERNELS(T, GPU, int64);
+
+REGISTER_GPU_KERNELS(Eigen::half);
+REGISTER_GPU_KERNELS(float);
+REGISTER_GPU_KERNELS(double);
+#if !defined(TENSORFLOW_USE_NVCC) && \
+    !defined(TENSORFLOW_USE_ROCM)  // TODO(b/143684500): Eigen to support
+                                   // complex sqrt
+REGISTER_GPU_KERNELS(complex64);
+REGISTER_GPU_KERNELS(complex128);
+#endif
+#undef REGISTER_GPU_KERNELS
+#endif
 #undef REGISTER_KERNELS
 
 // Note, this op works on cpu only.

--- a/tensorflow/core/kernels/training_ops.h
+++ b/tensorflow/core/kernels/training_ops.h
@@ -47,7 +47,7 @@ struct ApplyAdadelta {
 };
 
 template <typename Device, typename T, typename Tindex>
-struct ResourceSparseApplyAdadelta {
+struct SparseApplyAdadelta {
   void operator()(const Device& d, typename TTypes<T>::Matrix var,
                     typename TTypes<T>::Matrix accum,
                     typename TTypes<T>::Matrix accum_update,

--- a/tensorflow/core/kernels/training_ops.h
+++ b/tensorflow/core/kernels/training_ops.h
@@ -46,6 +46,18 @@ struct ApplyAdadelta {
                   typename TTypes<T>::ConstFlat grad);
 };
 
+template <typename Device, typename T, typename Tindex>
+struct ResourceSparseApplyAdadelta {
+  Tindex operator()(const Device& d, typename TTypes<T>::Matrix var,
+                  typename TTypes<T>::Matrix accum,
+                  typename TTypes<T>::Matrix accum_update,
+                  typename TTypes<T>::ConstScalar lr,
+                  typename TTypes<T>::ConstScalar rho,
+                  typename TTypes<T>::ConstScalar epsilon,
+                  typename TTypes<T>::ConstMatrix grad,
+                  typename TTypes<Tindex>::ConstFlat indices);
+};
+
 template <typename Device, typename T>
 struct FobosElasticNet {
   void operator()(const Device& d, typename TTypes<T>::Flat var,

--- a/tensorflow/core/kernels/training_ops.h
+++ b/tensorflow/core/kernels/training_ops.h
@@ -48,7 +48,7 @@ struct ApplyAdadelta {
 
 template <typename Device, typename T, typename Tindex>
 struct ResourceSparseApplyAdadelta {
-  Tindex operator()(const Device& d, typename TTypes<T>::Matrix var,
+  void operator()(const Device& d, typename TTypes<T>::Matrix var,
                     typename TTypes<T>::Matrix accum,
                     typename TTypes<T>::Matrix accum_update,
                     typename TTypes<T>::ConstScalar lr,

--- a/tensorflow/core/kernels/training_ops.h
+++ b/tensorflow/core/kernels/training_ops.h
@@ -16,10 +16,10 @@ limitations under the License.
 #ifndef TENSORFLOW_CORE_KERNELS_TRAINING_OPS_H_
 #define TENSORFLOW_CORE_KERNELS_TRAINING_OPS_H_
 
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/tensor_types.h"
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/platform/types.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 namespace tensorflow {
 namespace functor {
@@ -49,13 +49,13 @@ struct ApplyAdadelta {
 template <typename Device, typename T, typename Tindex>
 struct ResourceSparseApplyAdadelta {
   Tindex operator()(const Device& d, typename TTypes<T>::Matrix var,
-                  typename TTypes<T>::Matrix accum,
-                  typename TTypes<T>::Matrix accum_update,
-                  typename TTypes<T>::ConstScalar lr,
-                  typename TTypes<T>::ConstScalar rho,
-                  typename TTypes<T>::ConstScalar epsilon,
-                  typename TTypes<T>::ConstMatrix grad,
-                  typename TTypes<Tindex>::ConstFlat indices);
+                    typename TTypes<T>::Matrix accum,
+                    typename TTypes<T>::Matrix accum_update,
+                    typename TTypes<T>::ConstScalar lr,
+                    typename TTypes<T>::ConstScalar rho,
+                    typename TTypes<T>::ConstScalar epsilon,
+                    typename TTypes<T>::ConstMatrix grad,
+                    typename TTypes<Tindex>::ConstFlat indices);
 };
 
 template <typename Device, typename T>

--- a/tensorflow/core/kernels/training_ops_gpu.cu.cc
+++ b/tensorflow/core/kernels/training_ops_gpu.cu.cc
@@ -799,7 +799,7 @@ struct SparseApplyKerasMomentum<GPUDevice, T, Tindex> {
 };
 
 template <typename T, typename Tindex>
-__global__ __launch_bounds__(1024) void ResourceSparseApplyAdadeltaKernel(
+__global__ __launch_bounds__(1024) void SparseApplyAdadeltaKernel(
     T* var, T* accum, T* accum_update, const T* lr, const T* rho,
     const T* epsilon, const T* grad, const Tindex* indices, Tindex param_rows,
     Tindex updates_size, Tindex indices_size) {
@@ -840,8 +840,8 @@ __global__ __launch_bounds__(1024) void ResourceSparseApplyAdadeltaKernel(
 }
 
 template <typename T, typename Tindex>
-struct ResourceSparseApplyAdadelta<GPUDevice, T, Tindex> {
-  Tindex operator()(const GPUDevice& d, typename TTypes<T>::Matrix var,
+struct SparseApplyAdadelta<GPUDevice, T, Tindex> {
+  void operator()(const GPUDevice& d, typename TTypes<T>::Matrix var,
                     typename TTypes<T>::Matrix accum,
                     typename TTypes<T>::Matrix accum_update,
                     typename TTypes<T>::ConstScalar lr,
@@ -854,7 +854,7 @@ struct ResourceSparseApplyAdadelta<GPUDevice, T, Tindex> {
     const Tindex indices_size = indices.size();
     GpuLaunchConfig config = GetGpuLaunchConfig(grad_size, d);
     TF_CHECK_OK(GpuLaunchKernel(
-        ResourceSparseApplyAdadeltaKernel<T, Tindex>, config.block_count,
+        SparseApplyAdadeltaKernel<T, Tindex>, config.block_count,
         config.thread_per_block, 0, d.stream(), var.data(), accum.data(),
         accum_update.data(), lr.data(), rho.data(), epsilon.data(), grad.data(),
         indices.data(), first_dim_size, grad_size, indices_size));
@@ -1179,24 +1179,24 @@ template struct functor::SparseApplyKerasMomentum<GPUDevice, complex64, int64>;
 template struct functor::SparseApplyKerasMomentum<GPUDevice, complex128, int32>;
 template struct functor::SparseApplyKerasMomentum<GPUDevice, complex128, int64>;
 
-template struct functor::ResourceSparseApplyAdadelta<GPUDevice, Eigen::half,
+template struct functor::SparseApplyAdadelta<GPUDevice, Eigen::half,
                                                      int32>;
-template struct functor::ResourceSparseApplyAdadelta<GPUDevice, Eigen::half,
+template struct functor::SparseApplyAdadelta<GPUDevice, Eigen::half,
                                                      int64>;
-template struct functor::ResourceSparseApplyAdadelta<GPUDevice, float, int32>;
-template struct functor::ResourceSparseApplyAdadelta<GPUDevice, float, int64>;
-template struct functor::ResourceSparseApplyAdadelta<GPUDevice, double, int32>;
-template struct functor::ResourceSparseApplyAdadelta<GPUDevice, double, int64>;
+template struct functor::SparseApplyAdadelta<GPUDevice, float, int32>;
+template struct functor::SparseApplyAdadelta<GPUDevice, float, int64>;
+template struct functor::SparseApplyAdadelta<GPUDevice, double, int32>;
+template struct functor::SparseApplyAdadelta<GPUDevice, double, int64>;
 #if !defined(TENSORFLOW_USE_NVCC) && \
     !defined(TENSORFLOW_USE_ROCM)  // TODO(b/143684500): Eigen to support
                                    // complex sqrt
-template struct functor::ResourceSparseApplyAdadelta<GPUDevice, complex64,
+template struct functor::SparseApplyAdadelta<GPUDevice, complex64,
                                                      int32>;
-template struct functor::ResourceSparseApplyAdadelta<GPUDevice, complex64,
+template struct functor::SparseApplyAdadelta<GPUDevice, complex64,
                                                      int64>;
-template struct functor::ResourceSparseApplyAdadelta<GPUDevice, complex128,
+template struct functor::SparseApplyAdadelta<GPUDevice, complex128,
                                                      int32>;
-template struct functor::ResourceSparseApplyAdadelta<GPUDevice, complex128,
+template struct functor::SparseApplyAdadelta<GPUDevice, complex128,
                                                      int64>;
 #endif
 

--- a/tensorflow/core/kernels/training_ops_gpu.cu.cc
+++ b/tensorflow/core/kernels/training_ops_gpu.cu.cc
@@ -826,9 +826,9 @@ __global__ __launch_bounds__(1024) void SparseApplyAdadeltaKernel(
 
     // Variable update computation.
     accum_i = accum_i * rho_t + grad_i * grad_i * (T(1.0) - rho_t);
-    T update =
-        sqrt(accum_update_i + epsilon_t) * grad_i / sqrt(accum_i + epsilon_t);
-    var_i -= update * lr_t;
+    T update = Eigen::numext::sqrt(accum_update_i + epsilon_t) * grad_i /
+               Eigen::numext::sqrt(accum_i + epsilon_t);
+    var_i = var_i - update * lr_t;
     accum_update_i =
         accum_update_i * rho_t + update * update * (T(1.0) - rho_t);
 
@@ -842,13 +842,13 @@ __global__ __launch_bounds__(1024) void SparseApplyAdadeltaKernel(
 template <typename T, typename Tindex>
 struct SparseApplyAdadelta<GPUDevice, T, Tindex> {
   void operator()(const GPUDevice& d, typename TTypes<T>::Matrix var,
-                    typename TTypes<T>::Matrix accum,
-                    typename TTypes<T>::Matrix accum_update,
-                    typename TTypes<T>::ConstScalar lr,
-                    typename TTypes<T>::ConstScalar rho,
-                    typename TTypes<T>::ConstScalar epsilon,
-                    typename TTypes<T>::ConstMatrix grad,
-                    typename TTypes<Tindex>::ConstFlat indices) {
+                  typename TTypes<T>::Matrix accum,
+                  typename TTypes<T>::Matrix accum_update,
+                  typename TTypes<T>::ConstScalar lr,
+                  typename TTypes<T>::ConstScalar rho,
+                  typename TTypes<T>::ConstScalar epsilon,
+                  typename TTypes<T>::ConstMatrix grad,
+                  typename TTypes<Tindex>::ConstFlat indices) {
     const Tindex first_dim_size = var.dimension(0);
     const Tindex grad_size = grad.size();
     const Tindex indices_size = indices.size();
@@ -1179,26 +1179,16 @@ template struct functor::SparseApplyKerasMomentum<GPUDevice, complex64, int64>;
 template struct functor::SparseApplyKerasMomentum<GPUDevice, complex128, int32>;
 template struct functor::SparseApplyKerasMomentum<GPUDevice, complex128, int64>;
 
-template struct functor::SparseApplyAdadelta<GPUDevice, Eigen::half,
-                                                     int32>;
-template struct functor::SparseApplyAdadelta<GPUDevice, Eigen::half,
-                                                     int64>;
+template struct functor::SparseApplyAdadelta<GPUDevice, Eigen::half, int32>;
+template struct functor::SparseApplyAdadelta<GPUDevice, Eigen::half, int64>;
 template struct functor::SparseApplyAdadelta<GPUDevice, float, int32>;
 template struct functor::SparseApplyAdadelta<GPUDevice, float, int64>;
 template struct functor::SparseApplyAdadelta<GPUDevice, double, int32>;
 template struct functor::SparseApplyAdadelta<GPUDevice, double, int64>;
-#if !defined(TENSORFLOW_USE_NVCC) && \
-    !defined(TENSORFLOW_USE_ROCM)  // TODO(b/143684500): Eigen to support
-                                   // complex sqrt
-template struct functor::SparseApplyAdadelta<GPUDevice, complex64,
-                                                     int32>;
-template struct functor::SparseApplyAdadelta<GPUDevice, complex64,
-                                                     int64>;
-template struct functor::SparseApplyAdadelta<GPUDevice, complex128,
-                                                     int32>;
-template struct functor::SparseApplyAdadelta<GPUDevice, complex128,
-                                                     int64>;
-#endif
+template struct functor::SparseApplyAdadelta<GPUDevice, complex64, int32>;
+template struct functor::SparseApplyAdadelta<GPUDevice, complex64, int64>;
+template struct functor::SparseApplyAdadelta<GPUDevice, complex128, int32>;
+template struct functor::SparseApplyAdadelta<GPUDevice, complex128, int64>;
 
 template struct functor::ApplyAdam<GPUDevice, Eigen::half>;
 template struct functor::ApplyAdam<GPUDevice, float>;

--- a/tensorflow/core/kernels/training_ops_gpu.cu.cc
+++ b/tensorflow/core/kernels/training_ops_gpu.cu.cc
@@ -858,7 +858,6 @@ struct ResourceSparseApplyAdadelta<GPUDevice, T, Tindex> {
         config.thread_per_block, 0, d.stream(), var.data(), accum.data(),
         accum_update.data(), lr.data(), rho.data(), epsilon.data(), grad.data(),
         indices.data(), first_dim_size, grad_size, indices_size));
-    return static_cast<Tindex>(-1);
   }
 };
 

--- a/tensorflow/core/kernels/training_ops_gpu.cu.cc
+++ b/tensorflow/core/kernels/training_ops_gpu.cu.cc
@@ -800,7 +800,7 @@ struct SparseApplyKerasMomentum<GPUDevice, T, Tindex> {
 
 
 template <typename T, typename Tindex>
-__global__ __launch_bounds__(1024) ResourceSparseApplyAdadeltaKernel(
+__global__ __launch_bounds__(1024) void ResourceSparseApplyAdadeltaKernel(
     T* var, T* accum, T* accum_update, const T* lr, const T* rho, const T* epsilon,
     const T* grad, const Tindex* indices, Tindex param_rows, Tindex updates_size, 
     Tindex indices_size) {

--- a/tensorflow/core/kernels/training_ops_gpu.cu.cc
+++ b/tensorflow/core/kernels/training_ops_gpu.cu.cc
@@ -798,12 +798,11 @@ struct SparseApplyKerasMomentum<GPUDevice, T, Tindex> {
   }
 };
 
-
 template <typename T, typename Tindex>
 __global__ __launch_bounds__(1024) void ResourceSparseApplyAdadeltaKernel(
-    T* var, T* accum, T* accum_update, const T* lr, const T* rho, const T* epsilon,
-    const T* grad, const Tindex* indices, Tindex param_rows, Tindex updates_size, 
-    Tindex indices_size) {
+    T* var, T* accum, T* accum_update, const T* lr, const T* rho,
+    const T* epsilon, const T* grad, const Tindex* indices, Tindex param_rows,
+    Tindex updates_size, Tindex indices_size) {
   Tindex col_size = updates_size / indices_size;
   GPU_1D_KERNEL_LOOP(grad_index, updates_size) {
     Tindex indices_row = grad_index / col_size;
@@ -827,9 +826,11 @@ __global__ __launch_bounds__(1024) void ResourceSparseApplyAdadeltaKernel(
 
     // Variable update computation.
     accum_i = accum_i * rho_t + grad_i * grad_i * (T(1.0) - rho_t);
-    T update = sqrt(accum_update_i + epsilon_t) * grad_i / sqrt(accum_i + epsilon_t);
+    T update =
+        sqrt(accum_update_i + epsilon_t) * grad_i / sqrt(accum_i + epsilon_t);
     var_i -= update * lr_t;
-    accum_update_i = accum_update_i * rho_t + update * update * (T(1.0) - rho_t);
+    accum_update_i =
+        accum_update_i * rho_t + update * update * (T(1.0) - rho_t);
 
     // Write update back to variables.
     var[param_index] = var_i;
@@ -860,7 +861,6 @@ struct ResourceSparseApplyAdadelta<GPUDevice, T, Tindex> {
     return static_cast<Tindex>(-1);
   }
 };
-
 
 template <typename T>
 struct ApplyAdam<GPUDevice, T> {
@@ -1181,9 +1181,9 @@ template struct functor::SparseApplyKerasMomentum<GPUDevice, complex128, int32>;
 template struct functor::SparseApplyKerasMomentum<GPUDevice, complex128, int64>;
 
 template struct functor::ResourceSparseApplyAdadelta<GPUDevice, Eigen::half,
-                                                  int32>;
+                                                     int32>;
 template struct functor::ResourceSparseApplyAdadelta<GPUDevice, Eigen::half,
-                                                  int64>;
+                                                     int64>;
 template struct functor::ResourceSparseApplyAdadelta<GPUDevice, float, int32>;
 template struct functor::ResourceSparseApplyAdadelta<GPUDevice, float, int64>;
 template struct functor::ResourceSparseApplyAdadelta<GPUDevice, double, int32>;
@@ -1191,12 +1191,15 @@ template struct functor::ResourceSparseApplyAdadelta<GPUDevice, double, int64>;
 #if !defined(TENSORFLOW_USE_NVCC) && \
     !defined(TENSORFLOW_USE_ROCM)  // TODO(b/143684500): Eigen to support
                                    // complex sqrt
-template struct functor::ResourceSparseApplyAdadelta<GPUDevice, complex64, int32>;
-template struct functor::ResourceSparseApplyAdadelta<GPUDevice, complex64, int64>;
-template struct functor::ResourceSparseApplyAdadelta<GPUDevice, complex128, int32>;
-template struct functor::ResourceSparseApplyAdadelta<GPUDevice, complex128, int64>;
+template struct functor::ResourceSparseApplyAdadelta<GPUDevice, complex64,
+                                                     int32>;
+template struct functor::ResourceSparseApplyAdadelta<GPUDevice, complex64,
+                                                     int64>;
+template struct functor::ResourceSparseApplyAdadelta<GPUDevice, complex128,
+                                                     int32>;
+template struct functor::ResourceSparseApplyAdadelta<GPUDevice, complex128,
+                                                     int64>;
 #endif
-
 
 template struct functor::ApplyAdam<GPUDevice, Eigen::half>;
 template struct functor::ApplyAdam<GPUDevice, float>;

--- a/tensorflow/core/kernels/training_ops_gpu.cu.cc
+++ b/tensorflow/core/kernels/training_ops_gpu.cu.cc
@@ -798,6 +798,70 @@ struct SparseApplyKerasMomentum<GPUDevice, T, Tindex> {
   }
 };
 
+
+template <typename T, typename Tindex>
+__global__ __launch_bounds__(1024) ResourceSparseApplyAdadeltaKernel(
+    T* var, T* accum, T* accum_update, const T* lr, const T* rho, const T* epsilon,
+    const T* grad, const Tindex* indices, Tindex param_rows, Tindex updates_size, 
+    Tindex indices_size) {
+  Tindex col_size = updates_size / indices_size;
+  GPU_1D_KERNEL_LOOP(grad_index, updates_size) {
+    Tindex indices_row = grad_index / col_size;
+    Tindex param_row = indices[indices_row];
+    if (param_row < 0 || param_row >= param_rows) {
+      // Ignore indices that are out of range.
+      continue;
+    }
+
+    // Compute the index of var and accum.
+    Tindex param_index = param_row * col_size + (grad_index % col_size);
+
+    // Read variables.
+    T var_i = var[param_index];
+    T accum_i = accum[param_index];
+    T accum_update_i = accum_update[param_index];
+    T grad_i = grad[grad_index];
+    const T lr_t = *lr;
+    const T rho_t = *rho;
+    const T epsilon_t = *epsilon;
+
+    // Variable update computation.
+    accum_i = accum_i * rho_t + grad_i * grad_i * (T(1.0) - rho_t);
+    T update = sqrt(accum_update_i + epsilon_t) * grad_i / sqrt(accum_i + epsilon_t);
+    var_i -= update * lr_t;
+    accum_update_i = accum_update_i * rho_t + update * update * (T(1.0) - rho_t);
+
+    // Write update back to variables.
+    var[param_index] = var_i;
+    accum[param_index] = accum_i;
+    accum_update[param_index] = accum_update_i;
+  }
+}
+
+template <typename T, typename Tindex>
+struct ResourceSparseApplyAdadelta<GPUDevice, T, Tindex> {
+  Tindex operator()(const GPUDevice& d, typename TTypes<T>::Matrix var,
+                    typename TTypes<T>::Matrix accum,
+                    typename TTypes<T>::Matrix accum_update,
+                    typename TTypes<T>::ConstScalar lr,
+                    typename TTypes<T>::ConstScalar rho,
+                    typename TTypes<T>::ConstScalar epsilon,
+                    typename TTypes<T>::ConstMatrix grad,
+                    typename TTypes<Tindex>::ConstFlat indices) {
+    const Tindex first_dim_size = var.dimension(0);
+    const Tindex grad_size = grad.size();
+    const Tindex indices_size = indices.size();
+    GpuLaunchConfig config = GetGpuLaunchConfig(grad_size, d);
+    TF_CHECK_OK(GpuLaunchKernel(
+        ResourceSparseApplyAdadeltaKernel<T, Tindex>, config.block_count,
+        config.thread_per_block, 0, d.stream(), var.data(), accum.data(),
+        accum_update.data(), lr.data(), rho.data(), epsilon.data(), grad.data(),
+        indices.data(), first_dim_size, grad_size, indices_size));
+    return static_cast<Tindex>(-1);
+  }
+};
+
+
 template <typename T>
 struct ApplyAdam<GPUDevice, T> {
   void operator()(const GPUDevice& d, typename TTypes<T>::Flat var,
@@ -1115,6 +1179,24 @@ template struct functor::SparseApplyKerasMomentum<GPUDevice, complex64, int32>;
 template struct functor::SparseApplyKerasMomentum<GPUDevice, complex64, int64>;
 template struct functor::SparseApplyKerasMomentum<GPUDevice, complex128, int32>;
 template struct functor::SparseApplyKerasMomentum<GPUDevice, complex128, int64>;
+
+template struct functor::ResourceSparseApplyAdadelta<GPUDevice, Eigen::half,
+                                                  int32>;
+template struct functor::ResourceSparseApplyAdadelta<GPUDevice, Eigen::half,
+                                                  int64>;
+template struct functor::ResourceSparseApplyAdadelta<GPUDevice, float, int32>;
+template struct functor::ResourceSparseApplyAdadelta<GPUDevice, float, int64>;
+template struct functor::ResourceSparseApplyAdadelta<GPUDevice, double, int32>;
+template struct functor::ResourceSparseApplyAdadelta<GPUDevice, double, int64>;
+#if !defined(TENSORFLOW_USE_NVCC) && \
+    !defined(TENSORFLOW_USE_ROCM)  // TODO(b/143684500): Eigen to support
+                                   // complex sqrt
+template struct functor::ResourceSparseApplyAdadelta<GPUDevice, complex64, int32>;
+template struct functor::ResourceSparseApplyAdadelta<GPUDevice, complex64, int64>;
+template struct functor::ResourceSparseApplyAdadelta<GPUDevice, complex128, int32>;
+template struct functor::ResourceSparseApplyAdadelta<GPUDevice, complex128, int64>;
+#endif
+
 
 template struct functor::ApplyAdam<GPUDevice, Eigen::half>;
 template struct functor::ApplyAdam<GPUDevice, float>;


### PR DESCRIPTION
# This commit is related to issue #2314 and #30537.
### When I want to use Adadelta Optimizer in GPU, I encounted the following error：
Error environment info:
- Ubuntu 16
- Python 3.6
- Tensorflow 2.3
- CUDA 10.1
- GPU Tesla V100
- GPU Driver 396.37

```
File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/eager/execute.py", line 60, in quick_execute  
inputs, attrs, num_outputs)  
tensorflow.python.framework.errors\_impl.InvalidArgumentError: Cannot assign a device for operation Adadelta/Adadelta/update/Unique: Could not satisfy explicit device specification '' because the node {{colocation\_node Adadelta/Adadelta/update/Unique}} was colocated with a group of nodes that required incompatible device '/job:localhost/replica:0/task:0/device:GPU:0'. All available devices \[/job:localhost/replica:0/task:0/device:CPU:0, /job:localhost/replica:0/task:0/device:XLA\_CPU:0, /job:localhost/replica:0/task:0/device:XLA\_GPU:0, /job:localhost/replica:0/task:0/device:GPU:0\].  
Colocation Debug Info:  
Colocation group had the following types and supported devices:  
Root Member(assigned\_device\_name\_index\_=2 requested\_device\_name_='/job:localhost/replica:0/task:0/device:GPU:0' assigned\_device\_name_='/job:localhost/replica:0/task:0/device:GPU:0' resource\_device\_name_='/job:localhost/replica:0/task:0/device:GPU:0' supported\_device\_types_=\[CPU\] possible\_devices\_=\[\]  
Identity: GPU CPU XLA\_CPU XLA\_GPU  
ReadVariableOp: GPU CPU XLA\_CPU XLA\_GPU  
ResourceSparseApplyAdadelta: CPU  
Unique: GPU CPU  
Shape: GPU CPU XLA\_CPU XLA\_GPU  
\_Arg: GPU CPU XLA\_CPU XLA_GPU  
Const: GPU CPU XLA\_CPU XLA\_GPU  
StridedSlice: GPU CPU XLA\_CPU XLA\_GPU  
UnsortedSegmentSum: GPU CPU XLA\_CPU XLA\_GPU

Colocation members, user-requested devices, and framework assigned devices, if any:  
wide\_deep\_8564 (_Arg) framework assigned device=/job:localhost/replica:0/task:0/device:GPU:0  
adadelta\_adadelta\_update\_resourcesparseapplyadadelta\_accum (_Arg) framework assigned device=/job:localhost/replica:0/task:0/device:GPU:0  
adadelta\_adadelta\_update\_resourcesparseapplyadadelta\_accum\_update (\_Arg) framework assigned device=/job:localhost/replica:0/task:0/device:GPU:0  
Adadelta/Adadelta/update/Unique (Unique)  
Adadelta/Adadelta/update/Shape (Shape)  
Adadelta/Adadelta/update/strided_slice/stack (Const)  
Adadelta/Adadelta/update/strided\_slice/stack\_1 (Const)  
Adadelta/Adadelta/update/strided\_slice/stack\_2 (Const)  
Adadelta/Adadelta/update/strided_slice (StridedSlice)  
Adadelta/Adadelta/update/UnsortedSegmentSum (UnsortedSegmentSum)  
Adadelta/Adadelta/update/ResourceSparseApplyAdadelta (ResourceSparseApplyAdadelta)  
wide\_deep/StatefulPartitionedCall/embedding\_lookup\_sparse\_30/embedding\_lookup\_sparse/embedding_lookup/ReadVariableOp (ReadVariableOp)  
Func/wide\_deep/StatefulPartitionedCall/input/\_148 (Identity) /job:localhost/replica:0/task:0/device:GPU:0

     [[{{node Adadelta/Adadelta/update/Unique}}]] [Op:__inference_train_step_9850]
```

To fix this, I wrote the GPU implementation for ResourceSparseApplyAdadelta Op and tested in r2.3 branch.
Test Environment info:
- Docker Image: tensorflow/tensorflow:nightly-custom-op-gpu-ubuntu16
- Ubuntu 16
- Python 3.6
- Tensorflow r2.3
- CUDA 10.1
- cuDNN 7
- Cuda Compute Capabilities 7.0 (Tesla V100 Driver 396.37)
- GCC 7
- bazel 3.1.0