### PR TITLE
[TFLite] Fix PRELU and MIRROR_PAD operators wrongly marked as int16 quantizable

### DIFF
--- a/tensorflow/lite/tools/optimize/operator_property.cc
+++ b/tensorflow/lite/tools/optimize/operator_property.cc
@@ -850,6 +850,7 @@ OperatorProperty GetOperatorProperty(const ModelT* model, int subgraph_index,
       property.outputs = {{0, {}}};
       property.restrict_same_input_output_scale = false;
       property.version = 1;
+      property.quantizable_int16 = false;
       break;
     case BuiltinOperator_LEAKY_RELU:
       property.inputs = {{0, {}}};
@@ -987,6 +988,7 @@ OperatorProperty GetOperatorProperty(const ModelT* model, int subgraph_index,
       property.outputs = {{0, {}}};
       property.restrict_same_input_output_scale = true;
       property.version = 2;
+      property.quantizable_int16 = false;
       break;
     case BuiltinOperator_REDUCE_MAX:
     case BuiltinOperator_REDUCE_MIN:


### PR DESCRIPTION
Hi,

The `OperatorProperty::quantizable_int16` variable is (implicitly) set to true for the PRELU and MIRROR_PAD operators even though their kernels don't support int16 inputs.

This PR sets `quantizable_int16` to false for these operators to avoid an error during the inference and instead make the conversion fails with an explicit error if we try to use int16 quantization on a model with these operators.


Thibaut