### PR TITLE
[TF-numpy] `imag` and `real` returns scalar when `val` is a scalar.

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -484,9 +484,9 @@ def cumsum(a, axis=None, dtype=None):  # pylint: disable=missing-docstring
 
 @np_utils.np_doc('imag')
 def imag(val):
+  if isinstance(val, (int, float, complex)):
+    return val.imag
   val = asarray(val)
-  # TODO(srbs): np.imag returns a scalar if `val` is a scalar, whereas we always
-  # return an ndarray.
   return np_utils.tensor_to_ndarray(math_ops.imag(val.data))
 
 
@@ -708,9 +708,9 @@ setattr(np_arrays.ndarray, 'ravel', ravel)
 
 @np_utils.np_doc('real')
 def real(val):
+  if isinstance(val, (int, float, complex)):
+    return val.real
   val = asarray(val)
-  # TODO(srbs): np.real returns a scalar if val is a scalar, whereas we always
-  # return an ndarray.
   return np_utils.tensor_to_ndarray(math_ops.real(val.data))
 
 

--- a/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
@@ -674,10 +674,12 @@ class ArrayMethodsTest(test.TestCase):
     def run_test(arr, *args, **kwargs):
       for fn in self.array_transforms:
         arg = fn(arr)
-        self.match(
-            np_array_ops.imag(arg, *args, **kwargs),
-            # np.imag may return a scalar so we convert to a np.ndarray.
-            np.array(np.imag(arg, *args, **kwargs)))
+        actual = np_array_ops.imag(arg, *args, **kwargs)
+        expected = np.imag(arg, *args, **kwargs)
+        if isinstance(arg, (int, float, complex)):
+          self.assertEqual(actual, expected)
+        else:
+          self.match(actual, np.array(expected))
 
     run_test(1)
     run_test(5.5)
@@ -855,9 +857,12 @@ class ArrayMethodsTest(test.TestCase):
     def run_test(arr, *args, **kwargs):
       for fn in self.array_transforms:
         arg = fn(arr)
-        self.match(
-            np_array_ops.real(arg, *args, **kwargs),
-            np.array(np.real(arg, *args, **kwargs)))
+        actual = np_array_ops.real(arg, *args, **kwargs)
+        expected = np.real(arg, *args, **kwargs)
+        if isinstance(arg, (int, float, complex)):
+          self.assertEqual(actual, expected)
+        else:
+          self.match(actual, np.array(expected))
 
     run_test(1)
     run_test(5.5)


### PR DESCRIPTION
`np.imag` and `np.real` returns scalar when `val` is a scalar.

```python
# Example
import tensorflow as tf
np = tf.experimental.numpy

np.real(5)
# output -> 5
```