### PR TITLE
[TF-numpy] `np.size` always returns `int`

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -572,7 +572,7 @@ def size(x, axis=None):  # pylint: disable=missing-docstring
     return 1
   x = asarray(x).data
   if x.shape.is_fully_defined():
-    return np.prod(x.shape.as_list())
+    return np.prod(x.shape.as_list(), dtype=int)
   else:
     return np_utils.tensor_to_ndarray(array_ops.size_v2(x))
 


### PR DESCRIPTION
`np.size` of original numpy always returns `int`. But, Sometimes `np.size` of tensorflow returns 'float'

**before**
```python
np.size(np.array(5))
# output -> 1.0
```

**after**
```python
np.size(np.array(5))
# output -> 1
```