### PR TITLE
Remove patching of the downloaded CMSIS code.

### DIFF
--- a/tensorflow/lite/micro/tools/make/ext_libs/cmsis_nn.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/cmsis_nn.inc
@@ -6,7 +6,7 @@ ifneq ($(filter cmsis-nn,$(ALL_TAGS)),)
 
     # Setup CMSIS-NN lib and add required header files to microlite lib INCLUDE
     THIRD_PARTY_DOWNLOADS += \
-      $(eval $(call add_third_party_download,$(CMSIS_URL),$(CMSIS_MD5),cmsis,patch_cmsis))
+      $(eval $(call add_third_party_download,$(CMSIS_URL),$(CMSIS_MD5),cmsis,))
 
     CMSIS_PATH := $(MAKEFILE_DIR)/downloads/cmsis/
 
@@ -89,9 +89,7 @@ ifneq ($(filter cmsis-nn,$(ALL_TAGS)),)
 
     # Cherry-picked list of headers that are needed to compile the CMSIS-NN
     # optimized kernels. We don't include all the possible CMSIS headers because
-    # of their large number. See the RFC document for more details:
-    # https://docs.google.com/document/d/14GRxeVEgSKgKBKAijO7oxnI49nLoTYBFQmPok-rG0cw
-    # Note: If you add a .h here, you must update patch_cmsis() in download_and_extract.sh as well.
+    # of their large number.
     THIRD_PARTY_CC_HDRS += \
       $(CMSIS_PATH)CMSIS/Core/Include/cmsis_compiler.h \
       $(CMSIS_PATH)CMSIS/DSP/Include/arm_common_tables.h \

--- a/tensorflow/lite/micro/tools/make/ext_libs/ethosu.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/ethosu.inc
@@ -28,7 +28,7 @@ ifneq ($(filter ethos-u,$(ALL_TAGS)),)
 
     # Currently there is a dependency to CMSIS-NN
     THIRD_PARTY_DOWNLOADS += \
-        $(eval $(call add_third_party_download,$(CMSIS_URL),$(CMSIS_MD5),cmsis,patch_cmsis))
+        $(eval $(call add_third_party_download,$(CMSIS_URL),$(CMSIS_MD5),cmsis,))
     ifeq ($(CMSIS_PATH),)
       CMSIS_PATH = $(MAKEFILE_DIR)/downloads/cmsis/
     endif

--- a/tensorflow/lite/micro/tools/make/targets/apollo3evb_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/apollo3evb_makefile.inc
@@ -10,7 +10,7 @@ APOLLO3_SDK := $(MAKEFILE_DIR)/downloads/$(AM_SDK_DEST)
 GCC_ARM := $(MAKEFILE_DIR)/downloads/gcc_embedded/
 
 $(eval $(call add_third_party_download,$(GCC_EMBEDDED_URL),$(GCC_EMBEDDED_MD5),gcc_embedded,))
-$(eval $(call add_third_party_download,$(CMSIS_URL),$(CMSIS_MD5),cmsis,patch_cmsis))
+$(eval $(call add_third_party_download,$(CMSIS_URL),$(CMSIS_MD5),cmsis,))
 $(eval $(call add_third_party_download,$(AM_SDK_URL),$(AM_SDK_MD5),$(AM_SDK_DEST),patch_am_sdk))
 
 ifeq ($(findstring sparkfun,$(TARGET)), sparkfun)

--- a/tensorflow/lite/micro/tools/make/targets/bluepill_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/bluepill_makefile.inc
@@ -3,7 +3,7 @@ TARGET_ARCH := cortex-m3
 TARGET_TOOLCHAIN_PREFIX := arm-none-eabi-
 
 $(eval $(call add_third_party_download,$(GCC_EMBEDDED_URL),$(GCC_EMBEDDED_MD5),gcc_embedded,))
-$(eval $(call add_third_party_download,$(CMSIS_URL),$(CMSIS_MD5),cmsis,patch_cmsis))
+$(eval $(call add_third_party_download,$(CMSIS_URL),$(CMSIS_MD5),cmsis,))
 $(eval $(call add_third_party_download,$(STM32_BARE_LIB_URL),$(STM32_BARE_LIB_MD5),stm32_bare_lib,))
 
 PLATFORM_FLAGS = \

--- a/tensorflow/lite/micro/tools/make/targets/mbed_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/mbed_makefile.inc
@@ -1,7 +1,7 @@
 # Settings for mbed platforms.
 ifeq ($(TARGET), mbed)
   TARGET_ARCH := cortex-m4
-  $(eval $(call add_third_party_download,$(CMSIS_URL),$(CMSIS_MD5),cmsis,patch_cmsis))
+  $(eval $(call add_third_party_download,$(CMSIS_URL),$(CMSIS_MD5),cmsis,))
   $(eval $(call add_third_party_download,$(CUST_CMSIS_URL),$(CUST_CMSIS_MD5),CMSIS_ext,))
   $(eval $(call add_third_party_download,$(GCC_EMBEDDED_URL),$(GCC_EMBEDDED_MD5),gcc_embedded,))
 endif

--- a/tensorflow/lite/micro/tools/make/targets/stm32f4_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/stm32f4_makefile.inc
@@ -6,7 +6,7 @@ TARGET_TOOLCHAIN_PREFIX := arm-none-eabi-
 TARGET_TOOLCHAIN_ROOT := $(TENSORFLOW_ROOT)$(MAKEFILE_DIR)/downloads/gcc_embedded/bin/
 
 $(eval $(call add_third_party_download,$(GCC_EMBEDDED_URL),$(GCC_EMBEDDED_MD5),gcc_embedded,))
-$(eval $(call add_third_party_download,$(CMSIS_URL),$(CMSIS_MD5),cmsis,patch_cmsis))
+$(eval $(call add_third_party_download,$(CMSIS_URL),$(CMSIS_MD5),cmsis,))
 $(eval $(call add_third_party_download,$(STM32_BARE_LIB_URL),$(STM32_BARE_LIB_MD5),stm32_bare_lib,))
 
 # TODO(b/161478030) : change - Wno - vla to - Wvla and remove - Wno-shadow once


### PR DESCRIPTION
Patching was added to support the need for full include paths for the Arduino build (and presumably other IDEs).

However, it turns out there is a second find and replace of the include paths that happens somewhere in the project generation makefile magic via the `transform_source.py` script:
https://github.com/tensorflow/tensorflow/blob/f9818f12c332e8a35dbc9042af55649be64f30c4/tensorflow/lite/micro/tools/make/helper_functions.inc#L223-L317

As a result, we do not need to patch the downloaded CMSIS directory and still support at least the Arduino. This allows us to avoid some of the challenges described in https://github.com/tensorflow/tensorflow/issues/44013 and https://github.com/tensorflow/tensorflow/issues/44261


Since exactly how the paths are updated during the Arduino project generation is a bit of a mystery, here are some quick steps to confirm that the Arduino projects continue to have full include paths:

Generate the hello_world project:
```
make -f tensorflow/lite/micro/tools/make/Makefile clean clean_downloads
make -f tensorflow/lite/micro/tools/make/Makefile generate_hello_world_arduino_project TARGET=arduino TAGS=cmsis-nn
```

Confirm that the downloaded CMSIS does not have any modifications to the include paths:
```
cd tensorflow/lite/micro/tools/make/
head -n 35 downloads/cmsis/CMSIS/NN/Source/ActivationFunctions/arm_nn_activations_q7.c
```

Output:
```cc
#include "arm_math.h"
#include "arm_common_tables.h"
#include "arm_nnfunctions.h"
```

Confirm that the cmsis code within the Arduino tree has full paths:

```
cd tensorflow/lite/micro/tools/make/
head -n 35 gen/arduino_x86_64/prj/hello_world/arduino/src/tensorflow/lite/micro/tools/make/downloads/cmsis/CMSIS/NN/Source/ActivationFunctions/arm_nn_activations_q7.c
```

Output:
```cc
#include "tensorflow/lite/micro/tools/make/downloads/cmsis/CMSIS/DSP/Include/arm_math.h"
#include "tensorflow/lite/micro/tools/make/downloads/cmsis/CMSIS/DSP/Include/arm_common_tables.h"
#include "tensorflow/lite/micro/tools/make/downloads/cmsis/CMSIS/NN/Include/arm_nnfunctions.h"
```

