### PR TITLE
Fix typos in go directory

### DIFF
--- a/tensorflow/go/README.md
+++ b/tensorflow/go/README.md
@@ -93,11 +93,11 @@ go generate github.com/tensorflow/tensorflow/tensorflow/go/op
 
 ## Support
 
-Use [stackoverflow](http://stackoverflow.com/questions/tagged/tensorflow) and/or
-[Github issues](https://github.com/tensorflow/tensorflow/issues).
+Use [Stack Overflow](http://stackoverflow.com/questions/tagged/tensorflow) and/or
+[GitHub issues](https://github.com/tensorflow/tensorflow/issues).
 
 ## Contributions
 
 Contributions are welcome. If making any signification changes, probably best to
-discuss on a [Github issue](https://github.com/tensorflow/tensorflow/issues)
-before investing too much time. Github pull requests are used for contributions.
+discuss on a [GitHub issue](https://github.com/tensorflow/tensorflow/issues)
+before investing too much time. GitHub pull requests are used for contributions.

--- a/tensorflow/go/graph.go
+++ b/tensorflow/go/graph.go
@@ -72,7 +72,7 @@ type GraphImportOptions struct {
 }
 
 // AddInputMapping adds a mapping between an Output in the imported graph
-// and an Ouput in the destination graph that it should be replaced with,
+// and an Output in the destination graph that it should be replaced with,
 // where src:srcIndex is the name of the Operation and Output index to
 // replace and dst is the output to replace it with.
 func (o *GraphImportOptions) AddInputMapping(src string, srcIndex int, dst Output) {
@@ -500,7 +500,7 @@ type LibraryHandler struct {
 	cptr *C.TF_Library
 }
 
-// Load library content into current context, useful to load ops implementation into non-monolitic TF build. Returns LibraryHandler or nil and error
+// Load library content into current context, useful to load ops implementation into non-monolithic TF build. Returns LibraryHandler or nil and error
 func LoadLibrary(path string) (*LibraryHandler, error) {
 	status := newStatus()
 

--- a/tensorflow/go/op/wrappers.go
+++ b/tensorflow/go/op/wrappers.go
@@ -12339,7 +12339,7 @@ func ExtractGlimpseV2UniformNoise(value bool) ExtractGlimpseV2Attr {
 // ExtractGlimpseV2Noise sets the optional noise attribute to value.
 //
 // value: indicates if the noise should `uniform`, `gaussian`, or
-// `zero`. The default is `uniform` which means the the noise type
+// `zero`. The default is `uniform` which means the noise type
 // will be decided by `uniform_noise`.
 // If not specified, defaults to "uniform"
 func ExtractGlimpseV2Noise(value string) ExtractGlimpseV2Attr {
@@ -12441,7 +12441,7 @@ func ExtractGlimpseUniformNoise(value bool) ExtractGlimpseAttr {
 // ExtractGlimpseNoise sets the optional noise attribute to value.
 //
 // value: indicates if the noise should `uniform`, `gaussian`, or
-// `zero`. The default is `uniform` which means the the noise type
+// `zero`. The default is `uniform` which means the noise type
 // will be decided by `uniform_noise`.
 // If not specified, defaults to "uniform"
 func ExtractGlimpseNoise(value string) ExtractGlimpseAttr {
@@ -38729,7 +38729,7 @@ func InfeedEnqueuePrelinearizedBuffer(scope *Scope, input tf.Output, optional ..
 //   is preceded by "FIRST_DIM_SIZE".
 //
 // Arguments:
-//	shape: The desired shape of the the output tensor. If left unspecified (empty),
+//	shape: The desired shape of the output tensor. If left unspecified (empty),
 // the minimal shape required to contain all the elements in the ragged tensor
 // (the natural shape) will be used. If some dimensions are left unspecified, then
 // the size of the natural shape is used in that dimension.


### PR DESCRIPTION
Splitting #43857 by top-level directories.