### PR TITLE
[ROCm] Fix for ROCm CSB breakage - 201028

### DIFF
--- a/tensorflow/c/kernels/bitcast_op.cc
+++ b/tensorflow/c/kernels/bitcast_op.cc
@@ -148,7 +148,7 @@ void RegisterBitcastOpKernel() {
         << "Error while registering bitcast kernel";
   }
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
   {
     auto* builder = TF_NewKernelBuilder("Bitcast", tensorflow::DEVICE_GPU,
                                         &BitcastOp_Create, &BitcastOp_Compute,

--- a/tensorflow/c/kernels_test.cc
+++ b/tensorflow/c/kernels_test.cc
@@ -352,7 +352,7 @@ class DeviceKernelOpTest : public OpsTestBase {
     EXPECT_EQ(TF_OK, TF_GetCode(status));
     TF_DeleteStatus(status);
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
     std::unique_ptr<Device> device(
         DeviceFactory::NewDevice(device_name_, {}, "/job:a/replica:0/task:0"));
     OpsTestBase::SetDevice(DEVICE_GPU, std::move(device));
@@ -361,7 +361,7 @@ class DeviceKernelOpTest : public OpsTestBase {
     TF_ASSERT_OK(InitOp());
   }
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
   const char* device_name_ = tensorflow::DEVICE_GPU;
 #else
   const char* device_name_ = tensorflow::DEVICE_CPU;
@@ -468,7 +468,7 @@ TEST_F(DeviceKernelOpTest, TestAllocateTempSizeOne) {
     int64_t dim = 1;
     TF_AllocatorAttributes alloc_attrs;
     alloc_attrs.struct_size = TF_ALLOCATOR_ATTRIBUTES_STRUCT_SIZE;
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
     alloc_attrs.on_host = 0;
 #else
     alloc_attrs.on_host = 1;
@@ -505,7 +505,7 @@ TEST_F(DeviceKernelOpTest, TestAllocateTempEmpty) {
     int64_t dim = 0;
     TF_AllocatorAttributes alloc_attrs;
     alloc_attrs.struct_size = TF_ALLOCATOR_ATTRIBUTES_STRUCT_SIZE;
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
     alloc_attrs.on_host = 0;
 #else
     alloc_attrs.on_host = 1;
@@ -538,7 +538,7 @@ TEST_F(DeviceKernelOpTest, TestAllocateTempSize2x3) {
     int64_t dim[2] = {2, 3};
     TF_AllocatorAttributes alloc_attrs;
     alloc_attrs.struct_size = TF_ALLOCATOR_ATTRIBUTES_STRUCT_SIZE;
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
     alloc_attrs.on_host = 0;
 #else
     alloc_attrs.on_host = 1;
@@ -646,7 +646,7 @@ template <typename T>
 void set_tensor_data(TF_Tensor* tensor, T* values, size_t tensor_size_bytes,
                      TF_OpKernelContext* ctx) {
   T* data = reinterpret_cast<T*>(TF_TensorData(tensor));
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
   OpKernelContext* cc_ctx = reinterpret_cast<OpKernelContext*>(ctx);
   cc_ctx->eigen_gpu_device().memcpyHostToDevice(data, values,
                                                 tensor_size_bytes);


### PR DESCRIPTION
The following tests started failing with the weekly merge for 201026

```
//tensorflow/python:stateful_random_ops_test                             FAILED in 3 out of 3 in 6.1s
//tensorflow/python:stateful_random_ops_test_gpu                         FAILED in 3 out of 3 in 6.1s
```

The error message for those failures indicates that the failures are due to lack of support for the `Bitcast` operator on the ROCm platform, and this commit adds that missing support. The support was already available for the CUDA platform, so enabling it for ROCm is easy.

example error message

```
======================================================================
ERROR: testSameAsOldRandomOpsGPU (__main__.StatefulRandomOpsTest)
testSameAsOldRandomOpsGPU (__main__.StatefulRandomOpsTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/.cache/bazel/_bazel_root/efb88f6336d9c4a18216fb94287b8d97/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/stateful_random_ops_test_gpu.runfiles/org_tensorflow/tensorflow/python/framework/test_util.py", line 1436, in decorated
    return f(self, *args, **kwargs)
  File "/root/.cache/bazel/_bazel_root/efb88f6336d9c4a18216fb94287b8d97/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/stateful_random_ops_test_gpu.runfiles/org_tensorflow/tensorflow/python/framework/test_util.py", line 1502, in decorated
    return f(self, *args, **kwargs)
  File "/root/.cache/bazel/_bazel_root/efb88f6336d9c4a18216fb94287b8d97/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/stateful_random_ops_test_gpu.runfiles/org_tensorflow/tensorflow/python/ops/stateful_random_ops_test.py", line 451, in testSameAsOldRandomOpsGPU
    self._sameAsOldRandomOps(test_util.gpu_device_name(), GPU_FLOATS)
  File "/root/.cache/bazel/_bazel_root/efb88f6336d9c4a18216fb94287b8d97/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/stateful_random_ops_test_gpu.runfiles/org_tensorflow/tensorflow/python/ops/stateful_random_ops_test.py", line 430, in _sameAsOldRandomOps
    compare(dtype, old_normal, new_normal)
  File "/root/.cache/bazel/_bazel_root/efb88f6336d9c4a18216fb94287b8d97/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/stateful_random_ops_test_gpu.runfiles/org_tensorflow/tensorflow/python/ops/stateful_random_ops_test.py", line 398, in compare
    self.assertAllEqual(run_old(), run_new())
  File "/root/.cache/bazel/_bazel_root/efb88f6336d9c4a18216fb94287b8d97/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/stateful_random_ops_test_gpu.runfiles/org_tensorflow/tensorflow/python/ops/stateful_random_ops_test.py", line 395, in run_new
    return new(dtype, gen)
  File "/root/.cache/bazel/_bazel_root/efb88f6336d9c4a18216fb94287b8d97/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/stateful_random_ops_test_gpu.runfiles/org_tensorflow/tensorflow/python/ops/stateful_random_ops_test.py", line 410, in new_normal
    return gen._standard_normal(shape, dtype=dtype)
  File "/root/.cache/bazel/_bazel_root/efb88f6336d9c4a18216fb94287b8d97/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/stateful_random_ops_test_gpu.runfiles/org_tensorflow/tensorflow/python/ops/stateful_random_ops.py", line 576, in _standard_normal
    key, counter = self._prepare_key_counter(shape)
  File "/root/.cache/bazel/_bazel_root/efb88f6336d9c4a18216fb94287b8d97/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/stateful_random_ops_test_gpu.runfiles/org_tensorflow/tensorflow/python/ops/stateful_random_ops.py", line 630, in _prepare_key_counter
    counter = array_ops.bitcast(counter_key[:counter_size], dtypes.uint64)
  File "/root/.cache/bazel/_bazel_root/efb88f6336d9c4a18216fb94287b8d97/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/stateful_random_ops_test_gpu.runfiles/org_tensorflow/tensorflow/python/ops/gen_array_ops.py", line 598, in bitcast
    _ops.raise_from_not_ok_status(e, name)
  File "/root/.cache/bazel/_bazel_root/efb88f6336d9c4a18216fb94287b8d97/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/stateful_random_ops_test_gpu.runfiles/org_tensorflow/tensorflow/python/framework/ops.py", line 6862, in raise_from_not_ok_status
    six.raise_from(core._status_to_exception(e.code, message), None)
  File "<string>", line 3, in raise_from
tensorflow.python.framework.errors_impl.InvalidArgumentError: Could not satisfy device specification '/job:localhost/replica:0/task:0/device:GPU:0'. enable_soft_placement=0. Supported device types [CPU]. All available devices [/job:localhost/replica:0/task:0/device:GPU:0, /job:localhost/replica:0/task:0/device:CPU:0, /job:localhost/replica:0/task:0/device:CPU:1]. [Op:Bitcast]
```


--------------------------------------

/cc @cheshire @chsigg @nvining-work 