### PR TITLE
Add Log1p and DivNoNan gradients

### DIFF
--- a/tensorflow/c/eager/gradients_test.cc
+++ b/tensorflow/c/eager/gradients_test.cc
@@ -65,6 +65,8 @@ Status RegisterGradients(GradientRegistry* registry) {
   TF_RETURN_IF_ERROR(registry->Register("Neg", NegRegisterer));
   TF_RETURN_IF_ERROR(registry->Register("Sub", SubRegisterer));
   TF_RETURN_IF_ERROR(registry->Register("Mul", MulRegisterer));
+  TF_RETURN_IF_ERROR(registry->Register("Log1p", Log1pRegisterer));
+  TF_RETURN_IF_ERROR(registry->Register("DivNoNan", DivNoNanRegisterer));
   return Status::OK();
 }
 
@@ -290,6 +292,73 @@ Status MulGradModel(AbstractContext* ctx,
       /*build_default_zeros_grads=*/false));
   for (auto mul_output : mul_outputs) {
     mul_output->Unref();
+  }
+  outputs[0] = out_grads[0];
+  outputs[1] = out_grads[1];
+  delete tape;
+  return Status::OK();
+}
+
+// Computes
+// y = log(1 + inputs[0])
+// return grad(y, {inputs[0]})
+Status Log1pGradModel(AbstractContext* ctx,
+                      absl::Span<AbstractTensorHandle* const> inputs,
+                      absl::Span<AbstractTensorHandle*> outputs,
+                      const GradientRegistry& registry) {
+  TapeVSpace vspace(ctx);
+  auto tape = new Tape(/*persistent=*/false);
+  tape->Watch(ToId(inputs[0]));  // Watch x.
+  std::vector<AbstractTensorHandle*> log1p_outputs(1);
+  AbstractContextPtr tape_ctx(new TapeContext(ctx, tape, registry));
+  TF_RETURN_IF_ERROR(ops::Log1p(tape_ctx.get(), inputs,
+                                absl::MakeSpan(log1p_outputs),
+                                "Log1p"));  // Compute log(1 + x).
+  std::unordered_map<tensorflow::int64, TapeTensor>
+      source_tensors_that_are_targets;
+
+  std::vector<AbstractTensorHandle*> out_grads;
+  TF_RETURN_IF_ERROR(tape->ComputeGradient(
+      vspace, /*target_tensor_ids=*/{ToId(log1p_outputs[0])},
+      /*source_tensor_ids=*/{ToId(inputs[0])}, source_tensors_that_are_targets,
+      /*output_gradients=*/{}, &out_grads,
+      /*build_default_zeros_grads=*/false));
+  for (auto log1p_output : log1p_outputs) {
+    log1p_output->Unref();
+  }
+  outputs[0] = out_grads[0];
+  delete tape;
+  return Status::OK();
+}
+
+// Computes
+// y = inputs[0] / inputs[1]
+// return grad(y, {inputs[0], inputs[1]})
+Status DivNoNanGradModel(AbstractContext* ctx,
+                         absl::Span<AbstractTensorHandle* const> inputs,
+                         absl::Span<AbstractTensorHandle*> outputs,
+                         const GradientRegistry& registry) {
+  TapeVSpace vspace(ctx);
+  auto tape = new Tape(/*persistent=*/false);
+  tape->Watch(ToId(inputs[0]));  // Watch x.
+  tape->Watch(ToId(inputs[1]));  // Watch y.
+  std::vector<AbstractTensorHandle*> div_outputs(1);
+  AbstractContextPtr tape_ctx(new TapeContext(ctx, tape, registry));
+  TF_RETURN_IF_ERROR(ops::DivNoNan(tape_ctx.get(), inputs,
+                                   absl::MakeSpan(div_outputs),
+                                   "DivNoNan"));  // Compute x / y.
+  std::unordered_map<tensorflow::int64, TapeTensor>
+      source_tensors_that_are_targets;
+
+  std::vector<AbstractTensorHandle*> out_grads;
+  TF_RETURN_IF_ERROR(tape->ComputeGradient(
+      vspace, /*target_tensor_ids=*/{ToId(div_outputs[0])},
+      /*source_tensor_ids=*/{ToId(inputs[0]), ToId(inputs[1])},
+      source_tensors_that_are_targets,
+      /*output_gradients=*/{}, &out_grads,
+      /*build_default_zeros_grads=*/false));
+  for (auto div_output : div_outputs) {
+    div_output->Unref();
   }
   outputs[0] = out_grads[0];
   outputs[1] = out_grads[1];
@@ -796,6 +865,111 @@ TEST_P(CppGradients, TestMulGrad) {
   ASSERT_EQ(errors::OK, s.code()) << s.error_message();
   result_value = static_cast<float*>(TF_TensorData(result_tensor));
   EXPECT_EQ(*result_value, 1.0);
+  outputs[1]->Unref();
+  TF_DeleteTensor(result_tensor);
+}
+
+TEST_P(CppGradients, TestLog1pGrad) {
+  std::unique_ptr<TF_Status, decltype(&TF_DeleteStatus)> status(
+      TF_NewStatus(), TF_DeleteStatus);
+  AbstractContextPtr ctx;
+  {
+    AbstractContext* ctx_raw = nullptr;
+    Status s =
+        BuildImmediateExecutionContext(std::get<1>(GetParam()), &ctx_raw);
+    ASSERT_EQ(errors::OK, s.code()) << s.error_message();
+    ctx.reset(ctx_raw);
+  }
+
+  AbstractTensorHandlePtr x;
+  {
+    AbstractTensorHandle* x_raw = nullptr;
+    Status s = TestScalarTensorHandle(ctx.get(), 1.0f, &x_raw);
+    ASSERT_EQ(errors::OK, s.code()) << s.error_message();
+    x.reset(x_raw);
+  }
+
+  GradientRegistry registry;
+  Status s = RegisterGradients(&registry);
+  ASSERT_EQ(errors::OK, s.code()) << s.error_message();
+
+  // Pseudo-code:
+  //
+  // tape.watch(x)
+  // y = log(1 + x)
+  // outputs = tape.gradient(y, x)
+  std::vector<AbstractTensorHandle*> outputs(1);
+  s = RunModel(Log1pGradModel, ctx.get(), {x.get()}, absl::MakeSpan(outputs),
+               /*use_function=*/!std::get<2>(GetParam()), registry);
+  ASSERT_EQ(errors::OK, s.code()) << s.error_message();
+
+  TF_Tensor* result_tensor;
+  s = getValue(outputs[0], &result_tensor);
+  ASSERT_EQ(errors::OK, s.code()) << s.error_message();
+  auto result_value = static_cast<float*>(TF_TensorData(result_tensor));
+  EXPECT_NEAR(*result_value, 0.5, 0.001);
+  outputs[0]->Unref();
+  TF_DeleteTensor(result_tensor);
+  result_tensor = nullptr;
+}
+
+TEST_P(CppGradients, TestDivNoNanGrad) {
+  std::unique_ptr<TF_Status, decltype(&TF_DeleteStatus)> status(
+      TF_NewStatus(), TF_DeleteStatus);
+  AbstractContextPtr ctx;
+  {
+    AbstractContext* ctx_raw = nullptr;
+    Status s =
+        BuildImmediateExecutionContext(std::get<1>(GetParam()), &ctx_raw);
+    ASSERT_EQ(errors::OK, s.code()) << s.error_message();
+    ctx.reset(ctx_raw);
+  }
+
+  AbstractTensorHandlePtr x;
+  {
+    AbstractTensorHandle* x_raw = nullptr;
+    Status s = TestScalarTensorHandle(ctx.get(), 1.0f, &x_raw);
+    ASSERT_EQ(errors::OK, s.code()) << s.error_message();
+    x.reset(x_raw);
+  }
+
+  AbstractTensorHandlePtr y;
+  {
+    AbstractTensorHandle* y_raw = nullptr;
+    Status s = TestScalarTensorHandle(ctx.get(), 2.0f, &y_raw);
+    ASSERT_EQ(errors::OK, s.code()) << s.error_message();
+    y.reset(y_raw);
+  }
+
+  GradientRegistry registry;
+  Status s = RegisterGradients(&registry);
+  ASSERT_EQ(errors::OK, s.code()) << s.error_message();
+
+  // Pseudo-code:
+  //
+  // tape.watch(x)
+  // tape.watch(y)
+  // y = x / y
+  // outputs = tape.gradient(y, [x, y])
+  std::vector<AbstractTensorHandle*> outputs(2);
+  s = RunModel(DivNoNanGradModel, ctx.get(), {x.get(), y.get()},
+               absl::MakeSpan(outputs),
+               /*use_function=*/!std::get<2>(GetParam()), registry);
+  ASSERT_EQ(errors::OK, s.code()) << s.error_message();
+
+  TF_Tensor* result_tensor;
+  s = getValue(outputs[0], &result_tensor);
+  ASSERT_EQ(errors::OK, s.code()) << s.error_message();
+  auto result_value = static_cast<float*>(TF_TensorData(result_tensor));
+  EXPECT_NEAR(*result_value, 0.5, 0.001);
+  outputs[0]->Unref();
+  TF_DeleteTensor(result_tensor);
+  result_tensor = nullptr;
+
+  s = getValue(outputs[1], &result_tensor);
+  ASSERT_EQ(errors::OK, s.code()) << s.error_message();
+  result_value = static_cast<float*>(TF_TensorData(result_tensor));
+  EXPECT_NEAR(*result_value, -0.25, 0.001);
   outputs[1]->Unref();
   TF_DeleteTensor(result_tensor);
 }

--- a/tensorflow/c/experimental/gradients/math_grad.cc
+++ b/tensorflow/c/experimental/gradients/math_grad.cc
@@ -366,7 +366,6 @@ class DivNoNanGradientFunction : public GradientFunction {
      */
 
     AbstractTensorHandle* upstream_grad = grad_inputs[0];
-    AbstractTensorHandle* X = forward_inputs[0];
     AbstractTensorHandle* Y = forward_inputs[1];
     AbstractTensorHandle* Z = forward_outputs[0];
 

--- a/tensorflow/c/experimental/gradients/math_grad.cc
+++ b/tensorflow/c/experimental/gradients/math_grad.cc
@@ -23,6 +23,7 @@ limitations under the License.
 using std::vector;
 using tensorflow::ops::Add;
 using tensorflow::ops::Conj;
+using tensorflow::ops::Div;
 using tensorflow::ops::DivNoNan;
 using tensorflow::ops::MatMul;
 using tensorflow::ops::Mul;
@@ -333,10 +334,10 @@ class Log1pGradientFunction : public GradientFunction {
 
     AbstractTensorHandle* Conj_XP1 = temp_outputs[0];
 
-    name = "DivNoNan_Log1p_Grad_X";
+    name = "Div_Log1p_Grad_X";
     // Calculate U / (1 + Conj(X))
-    TF_RETURN_IF_ERROR(DivNoNan(ctx->ctx, {upstream_grad, Conj_XP1},
-                                absl::MakeSpan(temp_outputs), name.c_str()));
+    TF_RETURN_IF_ERROR(Div(ctx->ctx, {upstream_grad, Conj_XP1},
+                           absl::MakeSpan(temp_outputs), name.c_str()));
 
     (*grad_outputs)[0] = temp_outputs[0];
 

--- a/tensorflow/c/experimental/gradients/math_grad.cc
+++ b/tensorflow/c/experimental/gradients/math_grad.cc
@@ -21,10 +21,13 @@ limitations under the License.
 #include "tensorflow/c/experimental/ops/nn_ops.h"
 
 using std::vector;
+using tensorflow::ops::Add;
 using tensorflow::ops::Conj;
+using tensorflow::ops::DivNoNan;
 using tensorflow::ops::MatMul;
 using tensorflow::ops::Mul;
 using tensorflow::ops::Neg;
+using tensorflow::ops::OnesLike;
 using tensorflow::ops::SqrtGrad;
 
 namespace tensorflow {
@@ -289,6 +292,107 @@ class MulGradientFunction : public GradientFunction {
   vector<AbstractTensorHandle*> forward_inputs;
 };
 
+class Log1pGradientFunction : public GradientFunction {
+ public:
+  explicit Log1pGradientFunction(vector<AbstractTensorHandle*> f_inputs)
+      : forward_inputs(f_inputs) {}
+
+  Status Compute(Context* ctx, const IncomingGradients& grad_inputs,
+                 vector<AbstractTensorHandle*>* grad_outputs) override {
+    /* Given upstream grad U and a Log1p op: Y = log(1 + X), the gradients are:
+     *
+     *    dX = U / (1 + X)
+     *
+     */
+
+    AbstractTensorHandle* upstream_grad = grad_inputs[0];
+    AbstractTensorHandle* X = forward_inputs[0];
+
+    grad_outputs->resize(1);
+    vector<AbstractTensorHandle*> temp_outputs(1);
+
+    // Creates Ones
+    std::string name = "OnesLike_Log1p_Grad_X";
+    TF_RETURN_IF_ERROR(
+        OnesLike(ctx->ctx, {X}, absl::MakeSpan(temp_outputs), name.c_str()));
+
+    AbstractTensorHandle* Ones_X = temp_outputs[0];
+
+    // Calculate 1 + X
+    TF_RETURN_IF_ERROR(
+        Add(ctx->ctx, {Ones_X, X}, absl::MakeSpan(temp_outputs), name.c_str()));
+
+    AbstractTensorHandle* XP1 = temp_outputs[0];
+
+    // Calculate U / (1 + X)
+    TF_RETURN_IF_ERROR(DivNoNan(ctx->ctx, {upstream_grad, XP1},
+                                absl::MakeSpan(temp_outputs), name.c_str()));
+
+    (*grad_outputs)[0] = temp_outputs[0];
+
+    return Status::OK();
+  }
+  ~Log1pGradientFunction() override {}
+
+ private:
+  vector<AbstractTensorHandle*> forward_inputs;
+};
+
+class DivNoNanGradientFunction : public GradientFunction {
+ public:
+  explicit DivNoNanGradientFunction(vector<AbstractTensorHandle*> f_inputs,
+                                    vector<AbstractTensorHandle*> f_outputs)
+      : forward_inputs(f_inputs), forward_outputs(f_outputs) {}
+
+  Status Compute(Context* ctx, const IncomingGradients& grad_inputs,
+                 vector<AbstractTensorHandle*>* grad_outputs) override {
+    /* Given upstream grad U and a Div op: Z = X/Y, the gradients are:
+     *
+     *    dX = U / Y
+     *    dY = -U*X / Y^2 = (X/Y) * -U / Y = -U*Z / Y
+     *
+     */
+
+    AbstractTensorHandle* upstream_grad = grad_inputs[0];
+    AbstractTensorHandle* X = forward_inputs[0];
+    AbstractTensorHandle* Y = forward_inputs[1];
+    AbstractTensorHandle* Z = forward_outputs[0];
+
+    grad_outputs->resize(2);
+    vector<AbstractTensorHandle*> temp_outputs(1);
+
+    // Calculate dX =  U / Y
+    std::string name = "Div_Grad_X";
+    TF_RETURN_IF_ERROR(DivNoNan(ctx->ctx, {upstream_grad, Y},
+                                absl::MakeSpan(temp_outputs), name.c_str()));
+
+    (*grad_outputs)[0] = temp_outputs[0];
+
+    // Calculate dY = -U*Z / Y
+    name = "Neg_Div_Grad_Y";
+    TF_RETURN_IF_ERROR(Neg(ctx->ctx, {upstream_grad},
+                           absl::MakeSpan(temp_outputs), name.c_str()));  // -U
+    AbstractTensorHandle* MinusU = temp_outputs[0];
+
+    name = "Mul_Div_Grad_Y";
+    TF_RETURN_IF_ERROR(Mul(ctx->ctx, {MinusU, Z}, absl::MakeSpan(temp_outputs),
+                           name.c_str()));  // -U*Z
+    AbstractTensorHandle* UZ = temp_outputs[0];
+
+    name = "Div_Grad_Y";
+    TF_RETURN_IF_ERROR(DivNoNan(ctx->ctx, {UZ, Y}, absl::MakeSpan(temp_outputs),
+                                name.c_str()));  // -U*Z / Y
+
+    (*grad_outputs)[1] = temp_outputs[0];
+    return Status::OK();
+  }
+  ~DivNoNanGradientFunction() override {}
+
+ private:
+  vector<AbstractTensorHandle*> forward_inputs;
+  vector<AbstractTensorHandle*> forward_outputs;
+};
+
 }  // namespace
 
 BackwardFunction* AddRegisterer(const ForwardOperation& op) {
@@ -350,6 +454,24 @@ BackwardFunction* MulRegisterer(const ForwardOperation& op) {
   // is no incoming gradient. So we do not need to worry about creating zeros
   // grads in this case.
   auto gradient_function = new MulGradientFunction(op.inputs);
+  auto default_gradients = new PassThroughDefaultGradients(op);
+  return new BackwardFunction(gradient_function, default_gradients);
+}
+
+BackwardFunction* Log1pRegisterer(const ForwardOperation& op) {
+  // For ops with a single output, the gradient function is not called if there
+  // is no incoming gradient. So we do not need to worry about creating zeros
+  // grads in this case.
+  auto gradient_function = new Log1pGradientFunction(op.inputs);
+  auto default_gradients = new PassThroughDefaultGradients(op);
+  return new BackwardFunction(gradient_function, default_gradients);
+}
+
+BackwardFunction* DivNoNanRegisterer(const ForwardOperation& op) {
+  // For ops with a single output, the gradient function is not called if there
+  // is no incoming gradient. So we do not need to worry about creating zeros
+  // grads in this case.
+  auto gradient_function = new DivNoNanGradientFunction(op.inputs, op.outputs);
   auto default_gradients = new PassThroughDefaultGradients(op);
   return new BackwardFunction(gradient_function, default_gradients);
 }

--- a/tensorflow/c/experimental/gradients/math_grad.h
+++ b/tensorflow/c/experimental/gradients/math_grad.h
@@ -27,6 +27,8 @@ BackwardFunction* SqrtRegisterer(const ForwardOperation& op);
 BackwardFunction* NegRegisterer(const ForwardOperation& op);
 BackwardFunction* SubRegisterer(const ForwardOperation& op);
 BackwardFunction* MulRegisterer(const ForwardOperation& op);
+BackwardFunction* Log1pRegisterer(const ForwardOperation& op);
+BackwardFunction* DivNoNanRegisterer(const ForwardOperation& op);
 
 }  // namespace gradients
 }  // namespace tensorflow

--- a/tensorflow/c/experimental/ops/array_ops.cc
+++ b/tensorflow/c/experimental/ops/array_ops.cc
@@ -81,5 +81,17 @@ Status ExpandDims(AbstractContext* ctx,
   return op->Execute(outputs, &num_retvals);
 }
 
+Status OnesLike(AbstractContext* ctx,
+                absl::Span<AbstractTensorHandle* const> inputs,
+                absl::Span<AbstractTensorHandle*> outputs, const char* name) {
+  AbstractOperationPtr op(ctx->CreateOperation());
+  TF_RETURN_IF_ERROR(op->Reset("OnesLike", /*raw_device_name=*/nullptr));
+  TF_RETURN_IF_ERROR(MaybeSetOpName(op.get(), name));
+  TF_RETURN_IF_ERROR(op->AddInput(inputs[0]));
+
+  int num_retvals = 1;
+  return op->Execute(outputs, &num_retvals);
+}
+
 }  // namespace ops
 }  // namespace tensorflow

--- a/tensorflow/c/experimental/ops/array_ops.h
+++ b/tensorflow/c/experimental/ops/array_ops.h
@@ -42,6 +42,10 @@ Status ExpandDims(AbstractContext* ctx,
                   absl::Span<AbstractTensorHandle* const> inputs,
                   absl::Span<AbstractTensorHandle*> outputs, const char* name);
 
+Status OnesLike(AbstractContext* ctx,
+                absl::Span<AbstractTensorHandle* const> inputs,
+                absl::Span<AbstractTensorHandle*> outputs, const char* name);
+
 }  // namespace ops
 }  // namespace tensorflow
 

--- a/tensorflow/c/experimental/ops/math_ops.cc
+++ b/tensorflow/c/experimental/ops/math_ops.cc
@@ -124,6 +124,19 @@ Status Sum(AbstractContext* ctx, absl::Span<AbstractTensorHandle* const> inputs,
   return Status::OK();
 }
 
+Status Div(AbstractContext* ctx, absl::Span<AbstractTensorHandle* const> inputs,
+           absl::Span<AbstractTensorHandle*> outputs, const char* name) {
+  AbstractOperationPtr div_op(ctx->CreateOperation());
+  TF_RETURN_IF_ERROR(div_op->Reset("Div", /*raw_device_name=*/nullptr));
+  TF_RETURN_IF_ERROR(MaybeSetOpName(div_op.get(), name));
+  TF_RETURN_IF_ERROR(div_op->AddInput(inputs[0]));  // x
+  TF_RETURN_IF_ERROR(div_op->AddInput(inputs[1]));  // y
+
+  int num_retvals = 1;
+  TF_RETURN_IF_ERROR(div_op->Execute(outputs, &num_retvals));  // z = x / y
+  return Status::OK();
+}
+
 Status DivNoNan(AbstractContext* ctx,
                 absl::Span<AbstractTensorHandle* const> inputs,
                 absl::Span<AbstractTensorHandle*> outputs, const char* name) {

--- a/tensorflow/c/experimental/ops/math_ops.cc
+++ b/tensorflow/c/experimental/ops/math_ops.cc
@@ -40,14 +40,14 @@ Status Mul(AbstractContext* ctx, absl::Span<AbstractTensorHandle* const> inputs,
 Status Conj(AbstractContext* ctx,
             absl::Span<AbstractTensorHandle* const> inputs,
             absl::Span<AbstractTensorHandle*> outputs, const char* name) {
-  auto dtype = inputs[0]->DataType();
-  if (DataTypeIsFloating(BaseType(dtype)) ||
-      DataTypeIsInteger(BaseType(dtype))) {
-    TF_RETURN_IF_ERROR(Identity(ctx, inputs, outputs, name));
-  } else {
-    return errors::Unimplemented("Conj does not support complex types yet.");
-  }
-  return Status::OK();
+  AbstractOperationPtr conj_op(ctx->CreateOperation());
+  TF_RETURN_IF_ERROR(conj_op->Reset("Conj", /*raw_device_name=*/nullptr));
+  TF_RETURN_IF_ERROR(MaybeSetOpName(conj_op.get(), name));
+  TF_RETURN_IF_ERROR(conj_op->AddInput(inputs[0]));
+
+  int num_retvals = 1;
+  Status s = conj_op->Execute(outputs, &num_retvals);
+  return s;
 }
 
 Status Add(AbstractContext* ctx, absl::Span<AbstractTensorHandle* const> inputs,
@@ -182,19 +182,6 @@ Status Log1p(AbstractContext* ctx,
 
   int num_retvals = 1;
   Status s = log1p_op->Execute(outputs, &num_retvals);
-  return s;
-}
-
-Status Conj(AbstractContext* ctx,
-            absl::Span<AbstractTensorHandle* const> inputs,
-            absl::Span<AbstractTensorHandle*> outputs, const char* name) {
-  AbstractOperationPtr conj_op(ctx->CreateOperation());
-  TF_RETURN_IF_ERROR(conj_op->Reset("Conj", /*raw_device_name=*/nullptr));
-  TF_RETURN_IF_ERROR(MaybeSetOpName(conj_op.get(), name));
-  TF_RETURN_IF_ERROR(conj_op->AddInput(inputs[0]));
-
-  int num_retvals = 1;
-  Status s = conj_op->Execute(outputs, &num_retvals);
   return s;
 }
 

--- a/tensorflow/c/experimental/ops/math_ops.cc
+++ b/tensorflow/c/experimental/ops/math_ops.cc
@@ -172,5 +172,18 @@ Status SqrtGrad(AbstractContext* ctx,
   return s;
 }
 
+Status Log1p(AbstractContext* ctx,
+             absl::Span<AbstractTensorHandle* const> inputs,
+             absl::Span<AbstractTensorHandle*> outputs, const char* name) {
+  AbstractOperationPtr log1p_op(ctx->CreateOperation());
+  TF_RETURN_IF_ERROR(log1p_op->Reset("Log1p", /*raw_device_name=*/nullptr));
+  TF_RETURN_IF_ERROR(MaybeSetOpName(log1p_op.get(), name));
+  TF_RETURN_IF_ERROR(log1p_op->AddInput(inputs[0]));
+
+  int num_retvals = 1;
+  Status s = log1p_op->Execute(outputs, &num_retvals);
+  return s;
+}
+
 }  // namespace ops
 }  // namespace tensorflow

--- a/tensorflow/c/experimental/ops/math_ops.cc
+++ b/tensorflow/c/experimental/ops/math_ops.cc
@@ -185,5 +185,18 @@ Status Log1p(AbstractContext* ctx,
   return s;
 }
 
+Status Conj(AbstractContext* ctx,
+            absl::Span<AbstractTensorHandle* const> inputs,
+            absl::Span<AbstractTensorHandle*> outputs, const char* name) {
+  AbstractOperationPtr conj_op(ctx->CreateOperation());
+  TF_RETURN_IF_ERROR(conj_op->Reset("Conj", /*raw_device_name=*/nullptr));
+  TF_RETURN_IF_ERROR(MaybeSetOpName(conj_op.get(), name));
+  TF_RETURN_IF_ERROR(conj_op->AddInput(inputs[0]));
+
+  int num_retvals = 1;
+  Status s = conj_op->Execute(outputs, &num_retvals);
+  return s;
+}
+
 }  // namespace ops
 }  // namespace tensorflow

--- a/tensorflow/c/experimental/ops/math_ops.cc
+++ b/tensorflow/c/experimental/ops/math_ops.cc
@@ -44,7 +44,8 @@ Status Conj(AbstractContext* ctx,
   if (DataTypeIsFloating(BaseType(dtype)) ||
       DataTypeIsInteger(BaseType(dtype))) {
     TF_RETURN_IF_ERROR(Identity(ctx, inputs, outputs, name));
-  } else {
+  } else if (DataTypeIsComplex(BaseType(dtype)) ||
+             BaseType(dtype) == DT_VARIANT) {
     AbstractOperationPtr conj_op(ctx->CreateOperation());
     TF_RETURN_IF_ERROR(conj_op->Reset("Conj", /*raw_device_name=*/nullptr));
     TF_RETURN_IF_ERROR(MaybeSetOpName(conj_op.get(), name));
@@ -52,6 +53,9 @@ Status Conj(AbstractContext* ctx,
 
     int num_retvals = 1;
     TF_RETURN_IF_ERROR(conj_op->Execute(outputs, &num_retvals));
+  } else {
+    return errors::InvalidArgument(
+        "Expected numeric or variant tensor, got dtype ", dtype);
   }
   return Status::OK();
 }

--- a/tensorflow/c/experimental/ops/math_ops.h
+++ b/tensorflow/c/experimental/ops/math_ops.h
@@ -63,6 +63,10 @@ Status Log1p(AbstractContext* ctx,
              absl::Span<AbstractTensorHandle* const> inputs,
              absl::Span<AbstractTensorHandle*> outputs, const char* name);
 
+Status Conj(AbstractContext* ctx,
+            absl::Span<AbstractTensorHandle* const> inputs,
+            absl::Span<AbstractTensorHandle*> outputs, const char* name);
+
 }  // namespace ops
 }  // namespace tensorflow
 

--- a/tensorflow/c/experimental/ops/math_ops.h
+++ b/tensorflow/c/experimental/ops/math_ops.h
@@ -63,10 +63,6 @@ Status Log1p(AbstractContext* ctx,
              absl::Span<AbstractTensorHandle* const> inputs,
              absl::Span<AbstractTensorHandle*> outputs, const char* name);
 
-Status Conj(AbstractContext* ctx,
-            absl::Span<AbstractTensorHandle* const> inputs,
-            absl::Span<AbstractTensorHandle*> outputs, const char* name);
-
 }  // namespace ops
 }  // namespace tensorflow
 

--- a/tensorflow/c/experimental/ops/math_ops.h
+++ b/tensorflow/c/experimental/ops/math_ops.h
@@ -59,6 +59,10 @@ Status SqrtGrad(AbstractContext* ctx,
                 absl::Span<AbstractTensorHandle* const> inputs,
                 absl::Span<AbstractTensorHandle*> outputs, const char* name);
 
+Status Log1p(AbstractContext* ctx,
+             absl::Span<AbstractTensorHandle* const> inputs,
+             absl::Span<AbstractTensorHandle*> outputs, const char* name);
+
 }  // namespace ops
 }  // namespace tensorflow
 

--- a/tensorflow/c/experimental/ops/math_ops.h
+++ b/tensorflow/c/experimental/ops/math_ops.h
@@ -44,6 +44,9 @@ Status Sum(AbstractContext* ctx, absl::Span<AbstractTensorHandle* const> inputs,
 Status Sub(AbstractContext* ctx, absl::Span<AbstractTensorHandle* const> inputs,
            absl::Span<AbstractTensorHandle*> outputs, const char* name);
 
+Status Div(AbstractContext* ctx, absl::Span<AbstractTensorHandle* const> inputs,
+           absl::Span<AbstractTensorHandle*> outputs, const char* name);
+
 Status DivNoNan(AbstractContext* ctx,
                 absl::Span<AbstractTensorHandle* const> inputs,
                 absl::Span<AbstractTensorHandle*> outputs, const char* name);

--- a/tensorflow/python/framework/experimental/math_ops.cc
+++ b/tensorflow/python/framework/experimental/math_ops.cc
@@ -86,5 +86,27 @@ PYBIND11_MODULE(_math_ops, m) {
         ops::Mul(ctx, {a, b}, absl::MakeSpan(outputs), name));
     return outputs[0];
   });
+  m.def("log1p",
+        [](AbstractContext* ctx, AbstractTensorHandle* a, const char* name) {
+          int num_outputs = 1;
+          std::vector<AbstractTensorHandle*> outputs(1);
+          if (!name) {
+            name = "Log1p";
+          }
+          MaybeRaiseRegisteredFromStatus(
+              ops::Log1p(ctx, {a}, absl::MakeSpan(outputs), name));
+          return outputs[0];
+        });
+  m.def("div_no_nan", [](AbstractContext* ctx, AbstractTensorHandle* a,
+                         AbstractTensorHandle* b, const char* name) {
+    int num_outputs = 1;
+    std::vector<AbstractTensorHandle*> outputs(1);
+    if (!name) {
+      name = "DivNoNan";
+    }
+    MaybeRaiseRegisteredFromStatus(
+        ops::DivNoNan(ctx, {a, b}, absl::MakeSpan(outputs), name));
+    return outputs[0];
+  });
 }
 }  // namespace tensorflow

--- a/tensorflow/python/framework/experimental/math_ops.py
+++ b/tensorflow/python/framework/experimental/math_ops.py
@@ -45,3 +45,13 @@ def sub(a, b, name=None):
 def mul(a, b, name=None):
   ctx = context.get_default()
   return _math_ops.mul(ctx, a, b, name)
+
+
+def log1p(a, name=None):
+  ctx = context.get_default()
+  return _math_ops.log1p(ctx, a, name)
+
+
+def div_no_nan(a, b, name=None):
+  ctx = context.get_default()
+  return _math_ops.div_no_nan(ctx, a, b, name)

--- a/tensorflow/python/framework/experimental/tape.cc
+++ b/tensorflow/python/framework/experimental/tape.cc
@@ -39,6 +39,8 @@ Status RegisterGradients(GradientRegistry* registry) {
   TF_RETURN_IF_ERROR(registry->Register("Neg", NegRegisterer));
   TF_RETURN_IF_ERROR(registry->Register("Sub", SubRegisterer));
   TF_RETURN_IF_ERROR(registry->Register("Mul", MulRegisterer));
+  TF_RETURN_IF_ERROR(registry->Register("Log1p", Log1pRegisterer));
+  TF_RETURN_IF_ERROR(registry->Register("DivNoNan", DivNoNanRegisterer));
   return Status::OK();
 }
 

--- a/tensorflow/python/framework/experimental/unified_api_test.py
+++ b/tensorflow/python/framework/experimental/unified_api_test.py
@@ -305,6 +305,99 @@ class UnifiedApiTest(test.TestCase, parameterized.TestCase):
       self.assertAllEqual(eager_outputs[0].numpy(), [3., 4.])
       self.assertAllEqual(eager_outputs[1].numpy(), [1., 2.])
 
+  @parameterized.named_parameters([
+      ("Graph", False),
+      ("Mlir", True),
+  ])
+  def testLog1p(self, use_mlir):
+    if use_mlir:
+      SetTracingImplementation("mlir")
+
+    def model(a):
+      return unified_math_ops.log1p(a)
+
+    with context_lib.set_default(get_immediate_execution_context()):
+      a = TensorCastHelper(constant_op.constant([1.]))
+
+      func_output = def_function.function(model)(a)
+      self.assertArrayNear(func_output.numpy(), [0.69314], 0.001)
+
+      eager_output = model(a)
+      self.assertArrayNear(eager_output.numpy(), [0.69314], 0.001)
+
+  @parameterized.named_parameters([
+      ("Graph", False),
+      ("Mlir", True),
+  ])
+  def testLog1pGrad(self, use_mlir):
+    if use_mlir:
+      SetTracingImplementation("mlir")
+
+    def model(a):
+      with tape_lib.GradientTape() as tape:
+        tape.watch(a)
+        result = unified_math_ops.log1p(a)
+      grads = tape.gradient(result, a)
+      return grads
+
+    with context_lib.set_default(get_immediate_execution_context()):
+      a = TensorCastHelper(constant_op.constant([1.]))
+
+      func_outputs = def_function.function(model)(a)
+      self.assertArrayNear(func_outputs.numpy(), [0.5], 0.001)
+
+      eager_outputs = model(a)
+      self.assertArrayNear(eager_outputs.numpy(), [0.5], 0.001)
+
+  @parameterized.named_parameters([
+      ("Graph", False),
+      ("Mlir", True),
+  ])
+  def testDivNoNan(self, use_mlir):
+    if use_mlir:
+      SetTracingImplementation("mlir")
+
+    def model(a, b):
+      return unified_math_ops.div_no_nan(a, b)
+
+    with context_lib.set_default(get_immediate_execution_context()):
+      a = TensorCastHelper(constant_op.constant([2.]))
+      b = TensorCastHelper(constant_op.constant([4.]))
+
+      func_output = def_function.function(model)(a, b)
+      self.assertArrayNear(func_output.numpy(), [0.5], 0.001)
+
+      eager_output = model(a, b)
+      self.assertArrayNear(eager_output.numpy(), [0.5], 0.001)
+
+  @parameterized.named_parameters([
+      ("Graph", False),
+      ("Mlir", True),
+  ])
+  def testDivNoNanGrad(self, use_mlir):
+    if use_mlir:
+      SetTracingImplementation("mlir")
+
+    def model(a, b):
+      with tape_lib.GradientTape() as tape:
+        tape.watch(a)
+        tape.watch(b)
+        result = unified_math_ops.div_no_nan(a, b)
+      grads = tape.gradient(result, [a, b])
+      return grads
+
+    with context_lib.set_default(get_immediate_execution_context()):
+      a = TensorCastHelper(constant_op.constant([2.]))
+      b = TensorCastHelper(constant_op.constant([4.]))
+
+      func_outputs = def_function.function(model)(a, b)
+      self.assertArrayNear(func_outputs[0].numpy(), [0.25], 0.001)
+      self.assertArrayNear(func_outputs[1].numpy(), [-0.125], 0.001)
+
+      eager_outputs = model(a, b)
+      self.assertArrayNear(eager_outputs[0].numpy(), [0.25], 0.001)
+      self.assertArrayNear(eager_outputs[1].numpy(), [-0.125], 0.001)
+
 
 class UnifiedTapeBenchmark(test.Benchmark):
 


### PR DESCRIPTION
@saxenasaurabh 

Part of #42668

Now we are finishing math gradients for ResNet.

- I haven't found a way to split the test yet but I wonder if we are overtesting the code ? For example,
`ops::Add` is tested here:

https://github.com/tensorflow/tensorflow/blob/79cdd9533a3566b4b84c374645bf9ccf752cb9f4/tensorflow/python/framework/experimental/unified_api_test.py#L65-L80

But the python code is just a binding and the actual logic is already tested somewhere else.

Moreover, the gradient code is tested twice.

In `C++`:

https://github.com/tensorflow/tensorflow/blob/79cdd9533a3566b4b84c374645bf9ccf752cb9f4/tensorflow/c/eager/gradients_test.cc#L429-L488

In `Python`:

https://github.com/tensorflow/tensorflow/blob/79cdd9533a3566b4b84c374645bf9ccf752cb9f4/tensorflow/python/framework/experimental/unified_api_test.py#L86-L108

- Please tell me what need to be fixed instead of fixing internally. Because I want to avoid syncing a whole repo which will invalidate the cache and it will take my computer around 10 hours to build the new `LLVM` code. Thank you.