### PR TITLE
Add GPU implementation for tf.segment_* (prod&max&min)

### DIFF
--- a/tensorflow/core/kernels/segment_reduction_ops.h
+++ b/tensorflow/core/kernels/segment_reduction_ops.h
@@ -47,7 +47,7 @@ typedef Eigen::GpuDevice GPUDevice;
 // data: input data tensor.
 // output: output reshaped to {output_rows, output.size/output_rows}
 template <typename T, typename Index, typename InitialValueF,
-          typename SegmentReductionF, typename SegmentAtomicReductionF>
+          typename ReductionF, typename AtomicReductionF>
 struct SegmentReductionFunctor {
   void operator()(OpKernelContext* ctx, const GPUDevice& d,
                   const Index output_rows, const TensorShape& segment_ids_shape,
@@ -71,7 +71,7 @@ struct UnsortedSegmentFunctor {
 
 // Atomic reduction functors for the gpu.
 template <typename T>
-struct SumAtomicOpGpu {
+struct AtomicSumOpGpu {
   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void operator()(T* dest,
                                                         const T& value) {
     GpuAtomicAdd(dest, value);
@@ -79,7 +79,7 @@ struct SumAtomicOpGpu {
 };
 
 template <typename T>
-struct ProdAtomicOpGpu {
+struct AtomicProdOpGpu {
   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void operator()(T* dest,
                                                         const T& value) {
     GpuAtomicMul(dest, value);
@@ -87,7 +87,7 @@ struct ProdAtomicOpGpu {
 };
 
 template <typename T>
-struct MaxAtomicOpGpu {
+struct AtomicMaxOpGpu {
   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void operator()(T* dest,
                                                         const T& value) {
     GpuAtomicMax(dest, value);
@@ -95,16 +95,16 @@ struct MaxAtomicOpGpu {
 };
 
 template <typename T>
-struct MinAtomicOpGpu {
+struct AtomicMinOpGpu {
   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void operator()(T* dest,
                                                         const T& value) {
     GpuAtomicMin(dest, value);
   }
 };
 
-// Reduction functors for the gpu.
+// Non-atomic reduction functors for the gpu.
 template <typename T>
-struct SumOpGpu {
+struct NonAtomicSumOpGpu {
   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void operator()(T* dest,
                                                         const T& value) {
     *dest += value;
@@ -112,7 +112,7 @@ struct SumOpGpu {
 };
 
 template <typename T>
-struct ProdOpGpu {
+struct NonAtomicProdOpGpu {
   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void operator()(T* dest,
                                                         const T& value) {
     *dest *= value;
@@ -120,7 +120,7 @@ struct ProdOpGpu {
 };
 
 template <typename T>
-struct MaxOpGpu {
+struct NonAtomicMaxOpGpu {
   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void operator()(T* dest,
                                                         const T& value) {
     *dest = max(*dest, value);
@@ -128,7 +128,7 @@ struct MaxOpGpu {
 };
 
 template <typename T>
-struct MinOpGpu {
+struct NonAtomicMinOpGpu {
   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void operator()(T* dest,
                                                         const T& value) {
     *dest = min(*dest, value);

--- a/tensorflow/core/kernels/segment_reduction_ops.h
+++ b/tensorflow/core/kernels/segment_reduction_ops.h
@@ -87,7 +87,7 @@ struct UnsortedSegmentFunctor {
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
-// atomic reduction functors for the gpu
+// Atomic reduction functors for the gpu.
 template <typename T>
 struct SumAtomicOpGpu {
   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void operator()(T* dest,
@@ -120,7 +120,7 @@ struct MinAtomicOpGpu {
   }
 };
 
-// reduction functors for the gpu
+// Reduction functors for the gpu.
 template <typename T>
 struct SumOpGpu {
   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void operator()(T* dest,
@@ -155,7 +155,7 @@ struct MinOpGpu {
 
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
-// initial value functors
+// Initial value functors.
 template <typename T>
 struct Zero {
   EIGEN_STRONG_INLINE T operator()() const { return T(0); }

--- a/tensorflow/core/kernels/segment_reduction_ops.h
+++ b/tensorflow/core/kernels/segment_reduction_ops.h
@@ -56,24 +56,6 @@ struct SegmentReductionFunctor {
                   typename TTypes<T, 2>::Tensor output);
 };
 
-// Functor for SegmentMeanGPUOp.
-// output_rows: the number of output segments (unique segment ids in
-//                'segment_ids').
-// segment_ids_shape: shape of 'segment_ids' tensor.
-// segment_ids: unsorted map from input to output segment ids at which to
-//                perform segment sum operation.
-// data_size: size of input data tensor.
-// data: input data tensor.
-// output: output reshaped to {output_rows, output.size/output_rows}
-template <typename T, typename Index>
-struct SegmentMeanFunctor {
-  void operator()(OpKernelContext* ctx, const GPUDevice& d,
-                  const Index output_rows, const TensorShape& segment_ids_shape,
-                  typename TTypes<Index>::ConstFlat segment_ids,
-                  const Index data_size, const T* data,
-                  typename TTypes<T, 2>::Tensor output);
-};
-
 #endif
 
 template <typename Device, typename T, typename Index, typename InitialValueF,

--- a/tensorflow/core/kernels/segment_reduction_ops_gpu.cu.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops_gpu.cu.cc
@@ -74,13 +74,13 @@ __global__ void SortedSegmentReductionCustomKernel(
       Index current_output_segment_id =
           segment_ids[input_outer_dim_index_base + j];
       // Decide whether to write result to global memory. Result is only written
-      // to global memory if we move to another segment. Otherwise we can keep 
+      // to global memory if we move to another segment. Otherwise we can keep
       // accumulating locally.
       if (current_output_segment_id > last_output_segment_id) {
         const Index output_index =
             last_output_segment_id * inner_dim_size + segment_offset;
-        // decide whether to write result to global memory using atomic
-        // operations
+        // Decide whether to write result to global memory using atomic
+        // operations.
         if (last_output_segment_id == first_segment_id) {
           SegmentAtomicReductionF()(output + output_index, reduce_res);
         } else {
@@ -99,90 +99,6 @@ __global__ void SortedSegmentReductionCustomKernel(
     const Index output_index =
         last_output_segment_id * inner_dim_size + segment_offset;
     SegmentAtomicReductionF()(output + output_index, reduce_res);
-  }
-}
-
-template <typename T, typename Index, int OuterDimTileSize>
-__global__ void SortedSegmentMeanCustomKernel(
-    const Index input_outer_dim_size, const Index inner_dim_size,
-    const Index output_outer_dim_size, const Index* __restrict__ segment_ids,
-    const T* __restrict__ input, T* __restrict__ output,
-    const Index total_stripe_count) {
-  for (int stripe_index : GpuGridRangeX(total_stripe_count)) {
-    const Index segment_offset = stripe_index % inner_dim_size;
-    const Index input_outer_dim_index_base =
-        stripe_index / inner_dim_size * Index(OuterDimTileSize);
-
-    T sum = T(0);
-    Index first_segment_id = segment_ids[input_outer_dim_index_base];
-    Index last_output_segment_id = output_outer_dim_size;
-    bool is_first_update_racy = input_outer_dim_index_base > 0
-        && first_segment_id == segment_ids[input_outer_dim_index_base - 1]
-        ? true : false;
-
-    const Index actual_stripe_height =
-        min(Index(OuterDimTileSize),
-            input_outer_dim_size - input_outer_dim_index_base);
-    Index cur_segment_num = 0;
-    for (Index j = 0; j < actual_stripe_height; j++) {
-      Index current_output_segment_id =
-          segment_ids[input_outer_dim_index_base + j];
-      // Decide whether to write result to global memory.
-      // Result is only written to global memory if we move
-      // to another segment. Otherwise we can keep accumulating
-      // locally.
-      if (current_output_segment_id > last_output_segment_id) {
-        const Index output_index =
-            last_output_segment_id * inner_dim_size + segment_offset;
-        // decide whether to write result to global memory using atomic
-        // operations
-        if (last_output_segment_id == first_segment_id 
-            && is_first_update_racy) {
-          Index previous_segment_num = 0;
-          for (Index k = 1; input_outer_dim_index_base - k >= 0; k++) {
-            if (segment_ids[input_outer_dim_index_base]
-                  != segment_ids[input_outer_dim_index_base - k])
-              break;
-            previous_segment_num++;
-          }
-          cur_segment_num += previous_segment_num;
-          GpuAtomicAdd(output + output_index, sum / T(cur_segment_num));
-        } else {
-          *(output + output_index) = sum / T(cur_segment_num);
-        }
-        sum = T(0);
-        cur_segment_num = 0;
-      }
-      sum += ldg(input + (input_outer_dim_index_base + j) * inner_dim_size +
-                 segment_offset);
-      last_output_segment_id = current_output_segment_id;
-      cur_segment_num++;
-    }
-
-    Index last_input_outer_dim_index =
-        input_outer_dim_index_base + actual_stripe_height - 1;
-    bool is_last_update_racy =
-        last_input_outer_dim_index < input_outer_dim_size - 1
-          && segment_ids[last_input_outer_dim_index] ==
-             segment_ids[last_input_outer_dim_index + 1]
-          ? true : false;
-    const Index output_index =
-        last_output_segment_id * inner_dim_size + segment_offset;
-    if (is_last_update_racy) {
-      Index after_segment_num = 0;
-      for (Index j = 1;
-           last_input_outer_dim_index + j < input_outer_dim_size;
-           j++) {
-        if (segment_ids[last_input_outer_dim_index]
-              != segment_ids[last_input_outer_dim_index + j])
-          break;
-        after_segment_num++;
-      }
-      cur_segment_num += after_segment_num;
-      CudaAtomicAdd(output + output_index, sum / T(cur_segment_num));
-    } else {
-      *(output + output_index) = sum / T(cur_segment_num);
-    }
   }
 }
 
@@ -210,49 +126,6 @@ __global__ void UnsortedSegmentCustomKernel(
 }
 
 namespace functor {
-
-template <typename T, typename Index>
-void SegmentMeanFunctor<T, Index>::operator()(
-    OpKernelContext* ctx, const GPUDevice& d, const Index output_rows,
-    const TensorShape& segment_ids_shape,
-    typename TTypes<Index>::ConstFlat segment_ids, const Index data_size,
-    const T* data, typename TTypes<T, 2>::Tensor output) {
-  if (output.size() == 0) {
-    return;
-  }
-  // Set 'output' to zeros.
-  GpuLaunchConfig config = GetGpuLaunchConfig(output.size(), d);
-  TF_CHECK_OK(GpuLaunchKernel(SetZero<T>, config.block_count,
-                              config.thread_per_block, 0, d.stream(),
-                              output.size(), output.data()));
-  if (data_size == 0 || segment_ids_shape.num_elements() == 0) {
-    return;
-  }
-
-  // Launch kernel to compute sorted segment mean.
-  // Notes:
-  // *) 'input_total_size' is the total number of elements to process.
-  // *) 'segment_ids.shape' is a prefix of data's shape.
-  // *) 'input_outer_dim_size' is the total number of segments to process.
-  const Index input_total_size = data_size;
-  const Index input_outer_dim_size = segment_ids.dimension(0);
-  const Index input_inner_dim_size = input_total_size / input_outer_dim_size;
-
-  const int OuterDimTileSize = 8;
-
-  const Index input_outer_dim_num_stripe =
-      Eigen::divup(input_outer_dim_size, Index(OuterDimTileSize));
-
-  const Index total_stripe_count =
-      input_inner_dim_size * input_outer_dim_num_stripe;
-
-  config = GetGpuLaunchConfig(total_stripe_count, d);
-  TF_CHECK_OK(GpuLaunchKernel(
-      SortedSegmentMeanCustomKernel<T, Index, OuterDimTileSize>,
-      config.block_count, config.thread_per_block, 0, d.stream(),
-      input_outer_dim_size, input_inner_dim_size, output_rows,
-      segment_ids.data(), data, output.data(), total_stripe_count));
-}
 
 template <typename T, typename Index, typename InitialValueF,
           typename SegmentReductionF, typename SegmentAtomicReductionF>
@@ -342,7 +215,6 @@ struct UnsortedSegmentFunctor<GPUDevice, T, Index, InitialValueF, ReductionF> {
 };
 
 #define DEFINE_SORTED_GPU_SPECS_INDEX(T, Index)                                \
-  template struct SegmentMeanFunctor<T, Index>;                                \
   template struct SegmentReductionFunctor<T, Index, functor::Zero<T>,          \
       functor::SumOpGpu<T>, functor::SumAtomicOpGpu<T>>;                       \
   template struct SegmentReductionFunctor<T, Index, functor::One<T>,           \
@@ -366,7 +238,7 @@ TF_CALL_GPU_NUMBER_TYPES(DEFINE_SORTED_GPU_SPECS);
   template struct UnsortedSegmentFunctor<GPUDevice, T, Index, functor::One<T>, \
                                          functor::ProdAtomicOpGpu<T>>;
 
-// sum is the only op that supports all input types currently
+// Sum is the only op that supports all input types currently.
 #define DEFINE_SUM_UNSORTED_GPU_SPECS_INDEX(T, Index) \
   template struct UnsortedSegmentFunctor<             \
       GPUDevice, T, Index, functor::Zero<T>, functor::SumAtomicOpGpu<T>>;

--- a/tensorflow/core/kernels/segment_reduction_ops_gpu.cu.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops_gpu.cu.cc
@@ -31,14 +31,14 @@ namespace tensorflow {
 
 using GPUDevice = Eigen::GpuDevice;
 
-// SortedSegmentSumFunctor kernel reduces input data just as
-// UnsortedSegmentSumCustomKernel does except that input data
+// SortedSegmentReductionFunctor kernel reduces input data just as
+// UnsortedSegmentReductionCustomKernel does except that input data
 // is partitioned along the outer reduction dimension. This is
 // because consecutive rows (elements in a row share the same
 // outer dimension index) in the flattened 2D input data likely
 // belong to the same segment in sorted segment sum operation.
 // Therefore such partitioning strategy has two advantages over
-// the UnsortedSegmentSumFunctor kernel:
+// the UnsortedSegmentReductionFunctor kernel:
 // 1. Each thread reduces across multiple rows before writing
 // answers to the global memory, we can therefore
 // write reduction results to global memory less often.
@@ -51,20 +51,24 @@ using GPUDevice = Eigen::GpuDevice;
 // size OuterDimTileSize x 1. This strip runs across multiple
 // rows of input data and all reduction elements share one inner
 // dimension index.
-template <typename T, typename Index, int OuterDimTileSize>
-__global__ void SortedSegmentSumCustomKernel(
+template <typename T, typename Index, int OuterDimTileSize,
+          typename SegmentReductionF, typename SegmentAtomicReductionF>
+__global__ void SortedSegmentReductionCustomKernel(
     const Index input_outer_dim_size, const Index inner_dim_size,
     const Index output_outer_dim_size, const Index* __restrict__ segment_ids,
     const T* __restrict__ input, T* __restrict__ output,
-    const Index total_stripe_count) {
+    const Index total_stripe_count，const T initial_value) {
   for (int stripe_index : GpuGridRangeX(total_stripe_count)) {
     const Index segment_offset = stripe_index % inner_dim_size;
     const Index input_outer_dim_index_base =
         stripe_index / inner_dim_size * Index(OuterDimTileSize);
 
-    T sum = T(0);
+    T reduce_res = initial_value;
     Index first_segment_id = segment_ids[input_outer_dim_index_base];
     Index last_output_segment_id = output_outer_dim_size;
+    bool is_first_has_race = input_outer_dim_index_base > 0 \
+        && first_segment_id == segment_ids[input_outer_dim_index_base - 1] \
+        ? true : false;
 
     const Index actual_stripe_height =
         min(Index(OuterDimTileSize),
@@ -81,23 +85,118 @@ __global__ void SortedSegmentSumCustomKernel(
             last_output_segment_id * inner_dim_size + segment_offset;
         // decide whether to write result to global memory using atomic
         // operations
-        if (last_output_segment_id == first_segment_id) {
-          GpuAtomicAdd(output + output_index, sum);
+        if (last_output_segment_id == first_segment_id && is_first_has_race) {
+          SegmentAtomicReductionF()(output + output_index, reduce_res);
         } else {
-          *(output + output_index) = sum;
+          SegmentReductionF()(output + output_index, reduce_res);
         }
-        sum = T(0);
+        reduce_res = initial_value;
       }
-      sum += ldg(input + (input_outer_dim_index_base + j) * inner_dim_size +
-                 segment_offset);
+      SegmentReductionF()(&reduce_res,
+                          ldg(input + (input_outer_dim_index_base + j) \
+                              * inner_dim_size + segment_offset));
       last_output_segment_id = current_output_segment_id;
     }
     // For the last result in a strip, always write using atomic operations
     // due to possible race conditions with threads computing
     // the following strip.
+    Index last_input_outer_dim_index =
+        input_outer_dim_index_base + actual_stripe_height - 1;
+    bool is_last_has_race =
+        last_input_outer_dim_index < input_outer_dim_size - 1 \
+          && segment_ids[last_input_outer_dim_index] == \
+             segment_ids[last_input_outer_dim_index + 1] \
+          ? true : false;
     const Index output_index =
         last_output_segment_id * inner_dim_size + segment_offset;
-    GpuAtomicAdd(output + output_index, sum);
+    if (is_last_has_race) {
+      SegmentAtomicReductionF()(output + output_index, reduce_res);
+    } else {
+      SegmentReductionF()(output + output_index, reduce_res);
+    }
+  }
+}
+
+template <typename T, typename Index, int OuterDimTileSize>
+__global__ void SortedSegmentMeanCustomKernel(
+    const Index input_outer_dim_size, const Index inner_dim_size,
+    const Index output_outer_dim_size, const Index* __restrict__ segment_ids,
+    const T* __restrict__ input, T* __restrict__ output,
+    const Index total_stripe_count) {
+  for (int stripe_index : GpuGridRangeX(total_stripe_count)) {
+    const Index segment_offset = stripe_index % inner_dim_size;
+    const Index input_outer_dim_index_base =
+        stripe_index / inner_dim_size * Index(OuterDimTileSize);
+
+    T sum = T(0);
+    Index first_segment_id = segment_ids[input_outer_dim_index_base];
+    Index last_output_segment_id = output_outer_dim_size;
+    bool is_first_has_race = input_outer_dim_index_base > 0 \
+        && first_segment_id == segment_ids[input_outer_dim_index_base - 1] \
+        ? true : false;
+
+    const Index actual_stripe_height =
+        min(Index(OuterDimTileSize),
+            input_outer_dim_size - input_outer_dim_index_base);
+    Index cur_segment_num = 0;
+    for (Index j = 0; j < actual_stripe_height; j++) {
+      Index current_output_segment_id =
+          segment_ids[input_outer_dim_index_base + j];
+      // Decide whether to write result to global memory.
+      // Result is only written to global memory if we move
+      // to another segment. Otherwise we can keep accumulating
+      // locally.
+      if (current_output_segment_id > last_output_segment_id) {
+        const Index output_index =
+            last_output_segment_id * inner_dim_size + segment_offset;
+        // decide whether to write result to global memory using atomic
+        // operations
+        if (last_output_segment_id == first_segment_id && is_first_has_race) {
+          Index previous_segment_num = 0;
+          for (Index k = 1; input_outer_dim_index_base - k >= 0; k++) {
+            if (segment_ids[input_outer_dim_index_base] \
+                  != segment_ids[input_outer_dim_index_base - k])
+              break;
+            previous_segment_num++;
+          }
+          cur_segment_num += previous_segment_num;
+          GpuAtomicAdd(output + output_index, sum / T(cur_segment_num));
+        } else {
+          *(output + output_index) = sum / T(cur_segment_num);
+        }
+        sum = T(0);
+        cur_segment_num = 0;
+      }
+      sum += ldg(input + (input_outer_dim_index_base + j) * inner_dim_size +
+                 segment_offset);
+      last_output_segment_id = current_output_segment_id;
+      cur_segment_num++;
+    }
+
+    Index last_input_outer_dim_index =
+        input_outer_dim_index_base + actual_stripe_height - 1;
+    bool is_last_has_race =
+        last_input_outer_dim_index < input_outer_dim_size - 1 \
+          && segment_ids[last_input_outer_dim_index] == \
+             segment_ids[last_input_outer_dim_index + 1] \
+          ? true : false;
+    const Index output_index =
+        last_output_segment_id * inner_dim_size + segment_offset;
+    if (is_last_has_race) {
+      Index after_segment_num = 0;
+      for (Index j = 1;
+           last_input_outer_dim_index + j < input_outer_dim_size;
+           j++) {
+        if (segment_ids[last_input_outer_dim_index] \
+              != segment_ids[last_input_outer_dim_index + j])
+          break;
+        after_segment_num++;
+      }
+      cur_segment_num += after_segment_num;
+      CudaAtomicAdd(output + output_index, sum / T(cur_segment_num));
+    } else {
+      *(output + output_index) = sum / T(cur_segment_num);
+    }
   }
 }
 
@@ -127,7 +226,7 @@ __global__ void UnsortedSegmentCustomKernel(
 namespace functor {
 
 template <typename T, typename Index>
-void SegmentSumFunctor<T, Index>::operator()(
+void SegmentMeanFunctor<T, Index>::operator()(
     OpKernelContext* ctx, const GPUDevice& d, const Index output_rows,
     const TensorShape& segment_ids_shape,
     typename TTypes<Index>::ConstFlat segment_ids, const Index data_size,
@@ -163,10 +262,59 @@ void SegmentSumFunctor<T, Index>::operator()(
 
   config = GetGpuLaunchConfig(total_stripe_count, d);
   TF_CHECK_OK(GpuLaunchKernel(
-      SortedSegmentSumCustomKernel<T, Index, OuterDimTileSize>,
+      SortedSegmentMeanCustomKernel<T, Index, OuterDimTileSize>,
       config.block_count, config.thread_per_block, 0, d.stream(),
       input_outer_dim_size, input_inner_dim_size, output_rows,
       segment_ids.data(), data, output.data(), total_stripe_count));
+}
+
+template <typename T, typename Index, typename InitialValueF,
+          typename SegmentReductionF, typename SegmentAtomicReductionF>
+void SegmentReductionFunctor<T, Index, InitialValueF, SegmentReductionF,
+                             SegmentAtomicReductionF>::operator()(
+    OpKernelContext* ctx, const GPUDevice& d, const Index output_rows,
+    const TensorShape& segment_ids_shape,
+    typename TTypes<Index>::ConstFlat segment_ids, const Index data_size,
+    const T* data, typename TTypes<T, 2>::Tensor output) {
+  if (output.size() == 0) {
+    return;
+  }
+  // Set 'output' to initial value.
+  GpuLaunchConfig config = GetGpuLaunchConfig(output.size(), d);
+  const T InitialValue = InitialValueF()();
+  TF_CHECK_OK(GpuLaunchKernel(SetToValue<T>, config.block_count,
+                              config.thread_per_block, 0, d.stream(),
+                              output.size(), output.data(), InitialValue));
+  if (data_size == 0 || segment_ids_shape.num_elements() == 0) {
+    return;
+  }
+
+  // Launch kernel to compute sorted segment sum.
+  // Notes:
+  // *) 'input_total_size' is the total number of elements to process.
+  // *) 'segment_ids.shape' is a prefix of data's shape.
+  // *) 'input_outer_dim_size' is the total number of segments to process.
+  const Index input_total_size = data_size;
+  const Index input_outer_dim_size = segment_ids.dimension(0);
+  const Index input_inner_dim_size = input_total_size / input_outer_dim_size;
+
+  const int OuterDimTileSize = 8;
+
+  const Index input_outer_dim_num_stripe =
+      Eigen::divup(input_outer_dim_size, Index(OuterDimTileSize));
+
+  const Index total_stripe_count =
+      input_inner_dim_size * input_outer_dim_num_stripe;
+
+  config = GetGpuLaunchConfig(total_stripe_count, d);
+  TF_CHECK_OK(GpuLaunchKernel(
+      SortedSegmentReductionCustomKernel<T, Index, OuterDimTileSize,
+                                         SegmentReductionF,
+                                         SegmentAtomicReductionF>,
+      config.block_count, config.thread_per_block, 0, d.stream(),
+      input_outer_dim_size, input_inner_dim_size, output_rows,
+      segment_ids.data(), data, output.data(), total_stripe_count,
+      InitialValue));
 }
 
 template <typename T, typename Index, typename InitialValueF,
@@ -207,8 +355,16 @@ struct UnsortedSegmentFunctor<GPUDevice, T, Index, InitialValueF, ReductionF> {
   }
 };
 
-#define DEFINE_SORTED_GPU_SPECS_INDEX(T, Index) \
-  template struct SegmentSumFunctor<T, Index>
+#define DEFINE_SORTED_GPU_SPECS_INDEX(T, Index)                                \
+  template struct SegmentMeanFunctor<T, Index>;                                \
+  template struct SegmentReductionFunctor<T, Index, functor::Zero<T>,          \
+      functor::SumOpGpu<T>, functor::SumAtomicOpGpu<T>>;                       \
+  template struct SegmentReductionFunctor<T, Index, functor::One<T>,           \
+      functor::ProdOpGpu<T>, functor::ProdAtomicOpGpu<T>>;                     \
+  template struct SegmentReductionFunctor<T, Index, functor::Highest<T>,       \
+      functor::MinOpGpu<T>, functor::MinAtomicOpGpu<T>>;                       \
+  template struct SegmentReductionFunctor<T, Index, functor::Lowest<T>,        \
+      functor::MaxOpGpu<T>, functor::MaxAtomicOpGpu<T>>;
 
 #define DEFINE_SORTED_GPU_SPECS(T)         \
   DEFINE_SORTED_GPU_SPECS_INDEX(T, int32); \
@@ -218,16 +374,16 @@ TF_CALL_GPU_NUMBER_TYPES(DEFINE_SORTED_GPU_SPECS);
 
 #define DEFINE_REAL_UNSORTED_GPU_SPECS_INDEX(T, Index)                         \
   template struct UnsortedSegmentFunctor<                                      \
-      GPUDevice, T, Index, functor::Lowest<T>, functor::MaxOpGpu<T>>;          \
+      GPUDevice, T, Index, functor::Lowest<T>, functor::MaxAtomicOpGpu<T>>;    \
   template struct UnsortedSegmentFunctor<                                      \
-      GPUDevice, T, Index, functor::Highest<T>, functor::MinOpGpu<T>>;         \
+      GPUDevice, T, Index, functor::Highest<T>, functor::MinAtomicOpGpu<T>>;   \
   template struct UnsortedSegmentFunctor<GPUDevice, T, Index, functor::One<T>, \
-                                         functor::ProdOpGpu<T>>;
+                                         functor::ProdAtomicOpGpu<T>>;
 
 // sum is the only op that supports all input types currently
 #define DEFINE_SUM_UNSORTED_GPU_SPECS_INDEX(T, Index) \
   template struct UnsortedSegmentFunctor<             \
-      GPUDevice, T, Index, functor::Zero<T>, functor::SumOpGpu<T>>;
+      GPUDevice, T, Index, functor::Zero<T>, functor::SumAtomicOpGpu<T>>;
 
 #define DEFINE_REAL_GPU_SPECS(T)                  \
   DEFINE_REAL_UNSORTED_GPU_SPECS_INDEX(T, int32); \

--- a/tensorflow/core/kernels/segment_reduction_ops_gpu.cu.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops_gpu.cu.cc
@@ -73,10 +73,9 @@ __global__ void SortedSegmentReductionCustomKernel(
     for (Index j = 0; j < actual_stripe_height; j++) {
       Index current_output_segment_id =
           segment_ids[input_outer_dim_index_base + j];
-      // Decide whether to write result to global memory.
-      // Result is only written to global memory if we move
-      // to another segment. Otherwise we can keep accumulating
-      // locally.
+      // Decide whether to write result to global memory. Result is only written
+      // to global memory if we move to another segment. Otherwise we can keep 
+      // accumulating locally.
       if (current_output_segment_id > last_output_segment_id) {
         const Index output_index =
             last_output_segment_id * inner_dim_size + segment_offset;
@@ -90,7 +89,7 @@ __global__ void SortedSegmentReductionCustomKernel(
         reduce_res = initial_value;
       }
       SegmentReductionF()(&reduce_res,
-                          ldg(input + (input_outer_dim_index_base + j) \
+                          ldg(input + (input_outer_dim_index_base + j)
                               * inner_dim_size + segment_offset));
       last_output_segment_id = current_output_segment_id;
     }
@@ -117,8 +116,8 @@ __global__ void SortedSegmentMeanCustomKernel(
     T sum = T(0);
     Index first_segment_id = segment_ids[input_outer_dim_index_base];
     Index last_output_segment_id = output_outer_dim_size;
-    bool is_first_has_race = input_outer_dim_index_base > 0 \
-        && first_segment_id == segment_ids[input_outer_dim_index_base - 1] \
+    bool is_first_has_race = input_outer_dim_index_base > 0
+        && first_segment_id == segment_ids[input_outer_dim_index_base - 1]
         ? true : false;
 
     const Index actual_stripe_height =
@@ -140,7 +139,7 @@ __global__ void SortedSegmentMeanCustomKernel(
         if (last_output_segment_id == first_segment_id && is_first_has_race) {
           Index previous_segment_num = 0;
           for (Index k = 1; input_outer_dim_index_base - k >= 0; k++) {
-            if (segment_ids[input_outer_dim_index_base] \
+            if (segment_ids[input_outer_dim_index_base]
                   != segment_ids[input_outer_dim_index_base - k])
               break;
             previous_segment_num++;
@@ -162,9 +161,9 @@ __global__ void SortedSegmentMeanCustomKernel(
     Index last_input_outer_dim_index =
         input_outer_dim_index_base + actual_stripe_height - 1;
     bool is_last_has_race =
-        last_input_outer_dim_index < input_outer_dim_size - 1 \
-          && segment_ids[last_input_outer_dim_index] == \
-             segment_ids[last_input_outer_dim_index + 1] \
+        last_input_outer_dim_index < input_outer_dim_size - 1
+          && segment_ids[last_input_outer_dim_index] ==
+             segment_ids[last_input_outer_dim_index + 1]
           ? true : false;
     const Index output_index =
         last_output_segment_id * inner_dim_size + segment_offset;
@@ -173,7 +172,7 @@ __global__ void SortedSegmentMeanCustomKernel(
       for (Index j = 1;
            last_input_outer_dim_index + j < input_outer_dim_size;
            j++) {
-        if (segment_ids[last_input_outer_dim_index] \
+        if (segment_ids[last_input_outer_dim_index]
               != segment_ids[last_input_outer_dim_index + j])
           break;
         after_segment_num++;
@@ -229,7 +228,7 @@ void SegmentMeanFunctor<T, Index>::operator()(
     return;
   }
 
-  // Launch kernel to compute sorted segment sum.
+  // Launch kernel to compute sorted segment mean.
   // Notes:
   // *) 'input_total_size' is the total number of elements to process.
   // *) 'segment_ids.shape' is a prefix of data's shape.
@@ -275,7 +274,7 @@ void SegmentReductionFunctor<T, Index, InitialValueF, SegmentReductionF,
     return;
   }
 
-  // Launch kernel to compute sorted segment sum.
+  // Launch kernel to compute sorted segment reduction.
   // Notes:
   // *) 'input_total_size' is the total number of elements to process.
   // *) 'segment_ids.shape' is a prefix of data's shape.

--- a/tensorflow/core/kernels/segment_reduction_ops_impl.h
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl.h
@@ -206,20 +206,22 @@ class SegmentReductionOp : public OpKernel {
 };
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
-//  SegmentReductionGPUOp is a segment reduction operator implemented for GPU only.
+//  SegmentReductionGPUOp is a segment reduction operator implemented for GPU
+//  only.
 //  TODO: This implementation of SegmentReductionGPUOp is sometimes slower than
 //  its unsorted counterpart (mostly when problem size is small).
 //  This is due to the following two main reasons and a cost-effective way
 //  to resolve these problems is desirable.
-//  1. Sorted segment reduction requires a memory transfer from device to host in
-//     order to know the size of the output dimension whereas unsorted segment
-//     reduction receives the size of the output dimension as an input parameter.
-//  2. Sorted segment reduction is essentially a tiled version of unsorted segment
-//     reduction and therefore such optimization comes at an inherent cost. However
-//     such cost may not be justified when the problem size is small. When to
-//     use the tiled version or the untiled version depends on many factors
-//     including data alignments, ratio of calculation to memory traffic and
-//     obviously, the problem sizes.
+//  1. Sorted segment reduction requires a memory transfer from device to host
+//     in order to know the size of the output dimension whereas unsorted
+//     segment reduction receives the size of the output dimension as an input
+//     parameter.
+//  2. Sorted segment reduction is essentially a tiled version of unsorted
+//     segment reduction and therefore such optimization comes at an inherent
+//     cost. However such cost may not be justified when the problem size is
+//     small. When to use the tiled version or the untiled version depends on
+//     many factors including data alignments, ratio of calculation to memory
+//     traffic and obviously, the problem sizes.
 template <class T, class Index, class SegmentReductionFunctor>
 class SegmentReductionGPUOp : public AsyncOpKernel {
  public:

--- a/tensorflow/core/kernels/segment_reduction_ops_impl.h
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl.h
@@ -268,8 +268,7 @@ class SegmentReductionGPUOp : public AsyncOpKernel {
                          sizeof(Index))
             .ok(),
         errors::Internal(
-            this->type_string() + ": failed to copy output_rows from device"),
-        done);
+            type_string() + ": failed to copy output_rows from device"), done);
 
     SegmentReductionFunctor functor_;
     auto create_and_check_output = [context, output_rows_host, &input,

--- a/tensorflow/core/kernels/segment_reduction_ops_impl.h
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl.h
@@ -266,7 +266,7 @@ class SegmentReductionGPUOp : public AsyncOpKernel {
                          sizeof(Index))
             .ok(),
         errors::Internal(
-            "SegmentReductionGPUOp: failed to copy output_rows from device"),
+            this->type_string() + ": failed to copy output_rows from device"),
         done);
 
     SegmentReductionFunctor functor_;

--- a/tensorflow/core/kernels/segment_reduction_ops_impl.h
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl.h
@@ -206,24 +206,24 @@ class SegmentReductionOp : public OpKernel {
 };
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
-//  SegmentSumGPUOp is a segment sum operator implemented for GPU only.
-//  TODO: This implementation of SegmentSumGPUOp is sometimes slower than
+//  SegmentReductionGPUOp is a segment reduction operator implemented for GPU only.
+//  TODO: This implementation of SegmentReductionGPUOp is sometimes slower than
 //  its unsorted counterpart (mostly when problem size is small).
 //  This is due to the following two main reasons and a cost-effective way
 //  to resolve these problems is desirable.
-//  1. Sorted segment sum requires a memory transfer from device to host in
+//  1. Sorted segment reduction requires a memory transfer from device to host in
 //     order to know the size of the output dimension whereas unsorted segment
-//     sum receives the size of the output dimension as an input parameter.
-//  2. Sorted segment sum is essentially a tiled version of unsorted segment
-//     sum and therefore such optimization comes at an inherent cost. However
+//     reduction receives the size of the output dimension as an input parameter.
+//  2. Sorted segment reduction is essentially a tiled version of unsorted segment
+//     reduction and therefore such optimization comes at an inherent cost. However
 //     such cost may not be justified when the problem size is small. When to
 //     use the tiled version or the untiled version depends on many factors
 //     including data alignments, ratio of calculation to memory traffic and
 //     obviously, the problem sizes.
-template <class T, class Index>
-class SegmentSumGPUOp : public AsyncOpKernel {
+template <class T, class Index, class SegmentReductionFunctor>
+class SegmentReductionGPUOp : public AsyncOpKernel {
  public:
-  explicit SegmentSumGPUOp(OpKernelConstruction* context)
+  explicit SegmentReductionGPUOp(OpKernelConstruction* context)
       : AsyncOpKernel(context) {}
 
   void ComputeAsync(OpKernelContext* context, DoneCallback done) override {
@@ -266,10 +266,10 @@ class SegmentSumGPUOp : public AsyncOpKernel {
                          sizeof(Index))
             .ok(),
         errors::Internal(
-            "SegmentSumGPUOp: failed to copy output_rows from device"),
+            "SegmentReductionGPUOp: failed to copy output_rows from device"),
         done);
 
-    functor::SegmentSumFunctor<T, Index> functor_;
+    SegmentReductionFunctor functor_;
     auto create_and_check_output = [context, output_rows_host, &input,
                                     &segment_ids, &functor_, done]() {
       // Ensure that within the callback, the proper GPU settings are

--- a/tensorflow/core/kernels/segment_reduction_ops_impl_1.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl_1.cc
@@ -113,17 +113,44 @@ REGISTER_COMPLEX_CPU_KERNELS_ALL(complex128);
 #undef REGISTER_COMPLEX_CPU_KERNELS_ALL
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
-#define REGISTER_GPU_SORTED_KERNELS(type, index_type)                  \
-  REGISTER_KERNEL_BUILDER(Name("SegmentSum")                           \
-                              .Device(DEVICE_GPU)                      \
-                              .TypeConstraint<type>("T")               \
-                              .TypeConstraint<index_type>("Tindices"), \
-                          SegmentSumGPUOp<type, index_type>)
+#define REGISTER_GPU_KERNEL_SORTEDSEGMENT(                                   \
+    name, type, index_type, initial_value_functor,                           \
+    reduction_kernel_functor, atomic_reduction_kernel_functor)               \
+  REGISTER_KERNEL_BUILDER(                                                   \
+      Name(name)                                                             \
+          .Device(DEVICE_GPU)                                                \
+          .TypeConstraint<type>("T")                                         \
+          .TypeConstraint<index_type>("Tindices"),                           \
+      SegmentReductionGPUOp<                                                 \
+          type, index_type,                                                  \
+          functor::SegmentReductionFunctor<type, index_type,                 \
+                                          initial_value_functor,             \
+                                          reduction_kernel_functor,          \
+                                          atomic_reduction_kernel_functor> >)
+
+#define REGISTER_GPU_SORTED_KERNELS(type, index_type)                        \
+  REGISTER_GPU_KERNEL_SORTEDSEGMENT("SegmentSum", type, index_type,          \
+                                    functor::Zero<type>,                     \
+                                    functor::NonAtomicSumOpGpu<type>,        \
+                                    functor::AtomicSumOpGpu<type>);          \
+  REGISTER_GPU_KERNEL_SORTEDSEGMENT("SegmentProd", type, index_type,         \
+                                    functor::One<type>,                      \
+                                    functor::NonAtomicProdOpGpu<type>,       \
+                                    functor::AtomicProdOpGpu<type>);         \
+  REGISTER_GPU_KERNEL_SORTEDSEGMENT("SegmentMin", type, index_type,          \
+                                    functor::Highest<type>,                  \
+                                    functor::NonAtomicMinOpGpu<type>,        \
+                                    functor::AtomicMinOpGpu<type>);          \
+  REGISTER_GPU_KERNEL_SORTEDSEGMENT("SegmentMax", type, index_type,          \
+                                    functor::Lowest<type>,                   \
+                                    functor::NonAtomicMaxOpGpu<type>,        \
+                                    functor::AtomicMaxOpGpu<type>);
 
 #define REGISTER_GPU_SORTED_KERNELS_ALL(type) \
   REGISTER_GPU_SORTED_KERNELS(type, int32)
 
 TF_CALL_GPU_NUMBER_TYPES(REGISTER_GPU_SORTED_KERNELS_ALL);
+#undef REGISTER_GPU_KERNEL_SORTEDSEGMENT
 #undef REGISTER_GPU_SORTED_KERNELS
 #undef REGISTER_GPU_SORTED_KERNELS_ALL
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/core/kernels/segment_reduction_ops_impl_2.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl_2.cc
@@ -63,17 +63,51 @@ REGISTER_COMPLEX_CPU_KERNELS_ALL(complex128);
 #undef REGISTER_COMPLEX_CPU_KERNELS_ALL
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
-#define REGISTER_GPU_SORTED_KERNELS(type, index_type)                  \
-  REGISTER_KERNEL_BUILDER(Name("SegmentSum")                           \
-                              .Device(DEVICE_GPU)                      \
-                              .TypeConstraint<type>("T")               \
-                              .TypeConstraint<index_type>("Tindices"), \
-                          SegmentSumGPUOp<type, index_type>)
+#define REGISTER_GPU_KERNEL_SORTEDSEGMENT(                                   \
+    name, type, index_type, initial_value_functor,                           \
+    reduction_kernel_functor, atomic_reduction_kernel_functor)               \
+  REGISTER_KERNEL_BUILDER(                                                   \
+      Name(name)                                                             \
+          .Device(DEVICE_GPU)                                                \
+          .TypeConstraint<type>("T")                                         \
+          .TypeConstraint<index_type>("Tindices"),                           \
+      SegmentReductionGPUOp<                                                 \
+          type, index_type,                                                  \
+          functor::SegmentReductionFunctor<type, index_type,                 \
+                                          initial_value_functor,             \
+                                          reduction_kernel_functor,          \
+                                          atomic_reduction_kernel_functor> >)
+
+#define REGISTER_GPU_SORTED_KERNELS(type, index_type)                        \
+  REGISTER_KERNEL_BUILDER(                                                   \
+    Name("SegmentMean")                                                      \
+        .Device(DEVICE_GPU)                                                  \
+        .TypeConstraint<type>("T")                                           \
+        .TypeConstraint<index_type>("Tindices"),                             \
+    SegmentReductionGPUOp<type, index_type,                                  \
+      functor::SegmentMeanFunctor<type, index_type>>);                       \
+  REGISTER_GPU_KERNEL_SORTEDSEGMENT("SegmentSum", type, index_type,          \
+                                    functor::Zero<type>,                     \
+                                    functor::SumOpGpu<type>,                 \
+                                    functor::SumAtomicOpGpu<type>);          \
+  REGISTER_GPU_KERNEL_SORTEDSEGMENT("SegmentProd", type, index_type,         \
+                                    functor::One<type>,                      \
+                                    functor::ProdOpGpu<type>,                \
+                                    functor::ProdAtomicOpGpu<type>);         \
+  REGISTER_GPU_KERNEL_SORTEDSEGMENT("SegmentMin", type, index_type,          \
+                                    functor::Highest<type>,                  \
+                                    functor::MinOpGpu<type>,                 \
+                                    functor::MinAtomicOpGpu<type>);          \
+  REGISTER_GPU_KERNEL_SORTEDSEGMENT("SegmentMax", type, index_type,          \
+                                    functor::Lowest<type>,                   \
+                                    functor::MaxOpGpu<type>,                 \
+                                    functor::MaxAtomicOpGpu<type>);
 
 #define REGISTER_GPU_SORTED_KERNELS_ALL(type) \
   REGISTER_GPU_SORTED_KERNELS(type, int64);
 
 TF_CALL_GPU_NUMBER_TYPES(REGISTER_GPU_SORTED_KERNELS_ALL);
+#undef REGISTER_GPU_KERNEL_SORTEDSEGMENT
 #undef REGISTER_GPU_SORTED_KERNELS
 #undef REGISTER_GPU_SORTED_KERNELS_ALL
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/core/kernels/segment_reduction_ops_impl_2.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl_2.cc
@@ -81,20 +81,20 @@ REGISTER_COMPLEX_CPU_KERNELS_ALL(complex128);
 #define REGISTER_GPU_SORTED_KERNELS(type, index_type)                        \
   REGISTER_GPU_KERNEL_SORTEDSEGMENT("SegmentSum", type, index_type,          \
                                     functor::Zero<type>,                     \
-                                    functor::SumOpGpu<type>,                 \
-                                    functor::SumAtomicOpGpu<type>);          \
+                                    functor::NonAtomicSumOpGpu<type>,        \
+                                    functor::AtomicSumOpGpu<type>);          \
   REGISTER_GPU_KERNEL_SORTEDSEGMENT("SegmentProd", type, index_type,         \
                                     functor::One<type>,                      \
-                                    functor::ProdOpGpu<type>,                \
-                                    functor::ProdAtomicOpGpu<type>);         \
+                                    functor::NonAtomicProdOpGpu<type>,       \
+                                    functor::AtomicProdOpGpu<type>);         \
   REGISTER_GPU_KERNEL_SORTEDSEGMENT("SegmentMin", type, index_type,          \
                                     functor::Highest<type>,                  \
-                                    functor::MinOpGpu<type>,                 \
-                                    functor::MinAtomicOpGpu<type>);          \
+                                    functor::NonAtomicMinOpGpu<type>,        \
+                                    functor::AtomicMinOpGpu<type>);          \
   REGISTER_GPU_KERNEL_SORTEDSEGMENT("SegmentMax", type, index_type,          \
                                     functor::Lowest<type>,                   \
-                                    functor::MaxOpGpu<type>,                 \
-                                    functor::MaxAtomicOpGpu<type>);
+                                    functor::NonAtomicMaxOpGpu<type>,        \
+                                    functor::AtomicMaxOpGpu<type>);
 
 #define REGISTER_GPU_SORTED_KERNELS_ALL(type) \
   REGISTER_GPU_SORTED_KERNELS(type, int64);

--- a/tensorflow/core/kernels/segment_reduction_ops_impl_2.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl_2.cc
@@ -79,13 +79,6 @@ REGISTER_COMPLEX_CPU_KERNELS_ALL(complex128);
                                           atomic_reduction_kernel_functor> >)
 
 #define REGISTER_GPU_SORTED_KERNELS(type, index_type)                        \
-  REGISTER_KERNEL_BUILDER(                                                   \
-    Name("SegmentMean")                                                      \
-        .Device(DEVICE_GPU)                                                  \
-        .TypeConstraint<type>("T")                                           \
-        .TypeConstraint<index_type>("Tindices"),                             \
-    SegmentReductionGPUOp<type, index_type,                                  \
-      functor::SegmentMeanFunctor<type, index_type>>);                       \
   REGISTER_GPU_KERNEL_SORTEDSEGMENT("SegmentSum", type, index_type,          \
                                     functor::Zero<type>,                     \
                                     functor::SumOpGpu<type>,                 \

--- a/tensorflow/core/kernels/segment_reduction_ops_impl_3.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl_3.cc
@@ -88,18 +88,18 @@ REGISTER_COMPLEX_CPU_UNSORTED_KERNELS_ALL(complex128);
 #define REGISTER_REAL_GPU_UNSORTED_KERNELS(type, index_type)                   \
   REGISTER_GPU_KERNEL_UNSORTEDSEGMENT("UnsortedSegmentMax", type, index_type,  \
                                       functor::Lowest<type>,                   \
-                                      functor::MaxOpGpu<type>);                \
+                                      functor::MaxAtomicOpGpu<type>);          \
   REGISTER_GPU_KERNEL_UNSORTEDSEGMENT("UnsortedSegmentMin", type, index_type,  \
                                       functor::Highest<type>,                  \
-                                      functor::MinOpGpu<type>);                \
+                                      functor::MinAtomicOpGpu<type>);          \
   REGISTER_GPU_KERNEL_UNSORTEDSEGMENT("UnsortedSegmentProd", type, index_type, \
                                       functor::One<type>,                      \
-                                      functor::ProdOpGpu<type>);
+                                      functor::ProdAtomicOpGpu<type>);
 
 #define REGISTER_SUM_GPU_UNSORTED_KERNELS(type, index_type)                   \
   REGISTER_GPU_KERNEL_UNSORTEDSEGMENT("UnsortedSegmentSum", type, index_type, \
                                       functor::Zero<type>,                    \
-                                      functor::SumOpGpu<type>);
+                                      functor::SumAtomicOpGpu<type>);
 
 #define REGISTER_REAL_GPU_UNSORTED_KERNELS_ALL(type) \
   REGISTER_REAL_GPU_UNSORTED_KERNELS(type, int32)

--- a/tensorflow/core/kernels/segment_reduction_ops_impl_3.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl_3.cc
@@ -88,18 +88,18 @@ REGISTER_COMPLEX_CPU_UNSORTED_KERNELS_ALL(complex128);
 #define REGISTER_REAL_GPU_UNSORTED_KERNELS(type, index_type)                   \
   REGISTER_GPU_KERNEL_UNSORTEDSEGMENT("UnsortedSegmentMax", type, index_type,  \
                                       functor::Lowest<type>,                   \
-                                      functor::MaxAtomicOpGpu<type>);          \
+                                      functor::AtomicMaxOpGpu<type>);          \
   REGISTER_GPU_KERNEL_UNSORTEDSEGMENT("UnsortedSegmentMin", type, index_type,  \
                                       functor::Highest<type>,                  \
-                                      functor::MinAtomicOpGpu<type>);          \
+                                      functor::AtomicMinOpGpu<type>);          \
   REGISTER_GPU_KERNEL_UNSORTEDSEGMENT("UnsortedSegmentProd", type, index_type, \
                                       functor::One<type>,                      \
-                                      functor::ProdAtomicOpGpu<type>);
+                                      functor::AtomicProdOpGpu<type>);
 
 #define REGISTER_SUM_GPU_UNSORTED_KERNELS(type, index_type)                   \
   REGISTER_GPU_KERNEL_UNSORTEDSEGMENT("UnsortedSegmentSum", type, index_type, \
                                       functor::Zero<type>,                    \
-                                      functor::SumAtomicOpGpu<type>);
+                                      functor::AtomicSumOpGpu<type>);
 
 #define REGISTER_REAL_GPU_UNSORTED_KERNELS_ALL(type) \
   REGISTER_REAL_GPU_UNSORTED_KERNELS(type, int32)

--- a/tensorflow/core/kernels/segment_reduction_ops_impl_4.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl_4.cc
@@ -88,18 +88,18 @@ REGISTER_COMPLEX_CPU_UNSORTED_KERNELS_ALL(complex128);
 #define REGISTER_REAL_GPU_UNSORTED_KERNELS(type, index_type)                   \
   REGISTER_GPU_KERNEL_UNSORTEDSEGMENT("UnsortedSegmentMax", type, index_type,  \
                                       functor::Lowest<type>,                   \
-                                      functor::MaxAtomicOpGpu<type>);          \
+                                      functor::AtomicMaxOpGpu<type>);          \
   REGISTER_GPU_KERNEL_UNSORTEDSEGMENT("UnsortedSegmentMin", type, index_type,  \
                                       functor::Highest<type>,                  \
-                                      functor::MinAtomicOpGpu<type>);          \
+                                      functor::AtomicMinOpGpu<type>);          \
   REGISTER_GPU_KERNEL_UNSORTEDSEGMENT("UnsortedSegmentProd", type, index_type, \
                                       functor::One<type>,                      \
-                                      functor::ProdAtomicOpGpu<type>);
+                                      functor::AtomicProdOpGpu<type>);
 
 #define REGISTER_SUM_GPU_UNSORTED_KERNELS(type, index_type)                   \
   REGISTER_GPU_KERNEL_UNSORTEDSEGMENT("UnsortedSegmentSum", type, index_type, \
                                       functor::Zero<type>,                    \
-                                      functor::SumAtomicOpGpu<type>);
+                                      functor::AtomicSumOpGpu<type>);
 
 #define REGISTER_REAL_GPU_UNSORTED_KERNELS_ALL(type) \
   REGISTER_REAL_GPU_UNSORTED_KERNELS(type, int64)

--- a/tensorflow/core/kernels/segment_reduction_ops_impl_4.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl_4.cc
@@ -88,18 +88,18 @@ REGISTER_COMPLEX_CPU_UNSORTED_KERNELS_ALL(complex128);
 #define REGISTER_REAL_GPU_UNSORTED_KERNELS(type, index_type)                   \
   REGISTER_GPU_KERNEL_UNSORTEDSEGMENT("UnsortedSegmentMax", type, index_type,  \
                                       functor::Lowest<type>,                   \
-                                      functor::MaxOpGpu<type>);                \
+                                      functor::MaxAtomicOpGpu<type>);          \
   REGISTER_GPU_KERNEL_UNSORTEDSEGMENT("UnsortedSegmentMin", type, index_type,  \
                                       functor::Highest<type>,                  \
-                                      functor::MinOpGpu<type>);                \
+                                      functor::MinAtomicOpGpu<type>);          \
   REGISTER_GPU_KERNEL_UNSORTEDSEGMENT("UnsortedSegmentProd", type, index_type, \
                                       functor::One<type>,                      \
-                                      functor::ProdOpGpu<type>);
+                                      functor::ProdAtomicOpGpu<type>);
 
 #define REGISTER_SUM_GPU_UNSORTED_KERNELS(type, index_type)                   \
   REGISTER_GPU_KERNEL_UNSORTEDSEGMENT("UnsortedSegmentSum", type, index_type, \
                                       functor::Zero<type>,                    \
-                                      functor::SumOpGpu<type>);
+                                      functor::SumAtomicOpGpu<type>);
 
 #define REGISTER_REAL_GPU_UNSORTED_KERNELS_ALL(type) \
   REGISTER_REAL_GPU_UNSORTED_KERNELS(type, int64)

--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -987,7 +987,7 @@ tf_py_test(
     ],
 )
 
-tf_py_test(
+cuda_py_test(
     name = "segment_reduction_ops_test",
     size = "medium",
     srcs = ["segment_reduction_ops_test.py"],


### PR DESCRIPTION
This is a PR from JIZHI Team & TaiJi AI platform in Tencent.

The GPU kernel implements of a series of sorted segment reduction ops have been created, i.e. 
- `tf.segment_prod`
- `tf.segment_max`
- `tf.segment_min`


Since `segment_mean` is not a direct binary reduction operation, different from `segment_prod` & `segment_min` & `segment_max`. Therefore, in the actual implementation, I temporarily implemented it separately as `SortedSegmentMeanCustomKernel`, which may cause some inelegance codes. According to @sanjoy 's suggestion, I will proposal its implementation through another pr.

