### PR TITLE
Revert "[Cherrypick r2.4] Save response on the client side for better backward compatibility."

### DIFF
--- a/tensorflow/core/profiler/rpc/client/capture_profile.cc
+++ b/tensorflow/core/profiler/rpc/client/capture_profile.cc
@@ -134,12 +134,6 @@ Status Profile(const std::string& repository_root,
                    << client_response.service_address;
     } else {
       has_trace_data = true;
-      // If server side returns tool data in the response, saves that into the
-      // repository. This improves backward compatibility by reducing assumption
-      // of what server side does.
-      TF_RETURN_IF_ERROR(SaveProfile(repository_root, session_id,
-                                     client_response.service_address, response,
-                                     &std::cout));
     }
     if (!client_response.status.ok()) {
       LOG(WARNING) << client_response.service_address << " returned "

--- a/tensorflow/core/profiler/rpc/client/save_profile.cc
+++ b/tensorflow/core/profiler/rpc/client/save_profile.cc
@@ -22,7 +22,6 @@ limitations under the License.
 
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
-#include "absl/strings/str_replace.h"
 #include "absl/strings/string_view.h"
 #include "absl/strings/strip.h"
 #include "absl/time/clock.h"
@@ -116,13 +115,10 @@ Status MaybeCreateEmptyEventFile(const std::string& logdir) {
 Status SaveProfile(const std::string& repository_root, const std::string& run,
                    const std::string& host, const ProfileResponse& response,
                    std::ostream* os) {
-  if (response.tool_data().empty()) return Status::OK();
   std::string run_dir;
   TF_RETURN_IF_ERROR(GetOrCreateRunDir(repository_root, run, &run_dir, os));
-  // Windows file names do not support colons.
-  std::string hostname = absl::StrReplaceAll(host, {{":", "_"}});
   for (const auto& tool_data : response.tool_data()) {
-    TF_RETURN_IF_ERROR(DumpToolData(run_dir, hostname, tool_data, os));
+    TF_RETURN_IF_ERROR(DumpToolData(run_dir, host, tool_data, os));
   }
   return Status::OK();
 }


### PR DESCRIPTION
Reverts tensorflow/tensorflow#44365

Temporarily rolling back as it seems to be culprit for memory issues