### PR TITLE
Revert "[CherryPick r2.4]Disable test for macos."

### DIFF
--- a/tensorflow/core/distributed_runtime/rpc/BUILD
+++ b/tensorflow/core/distributed_runtime/rpc/BUILD
@@ -496,7 +496,6 @@ tf_cc_test(
     size = "small",
     srcs = ["grpc_tensor_coding_test.cc"],
     tags = [
-        "no_mac",
         "no_windows",
     ],
     deps = [
@@ -519,9 +518,6 @@ tf_cc_test(
     name = "grpc_util_test",
     size = "small",
     srcs = ["grpc_util_test.cc"],
-    tags = [
-        "no_mac",
-    ],
     deps = [
         ":grpc_util",
         "//tensorflow/core:test",


### PR DESCRIPTION
Reverts tensorflow/tensorflow#44398

Testing if this causes the memory issue (very unliekly)