### PR TITLE
Removes `SetIsStateful` from op StatelessRandomGetKeyCounterAlg

### DIFF
--- a/tensorflow/core/ops/stateless_random_ops_v2.cc
+++ b/tensorflow/core/ops/stateless_random_ops_v2.cc
@@ -101,7 +101,6 @@ REGISTER_OP("StatelessRandomGetKeyCounterAlg")
     .Output("counter: uint64")
     .Output("alg: int32")
     .Attr("Tseed: {int32, int64} = DT_INT64")
-    .SetIsStateful()  // because outputs depend on device
     .SetShapeFn([](InferenceContext* c) {
       // Check seed shape
       ShapeHandle seed;


### PR DESCRIPTION
PiperOrigin-RevId: 339147256
Change-Id: I4444b47e9d974bd5bb643b80ae55fcbc347653df