### PR TITLE
Speedup the TFLu Renode tests

### DIFF
--- a/tensorflow/lite/micro/testing/bluepill.robot
+++ b/tensorflow/lite/micro/testing/bluepill.robot
@@ -11,6 +11,7 @@ ${UART}                       sysbus.cpu.uartSemihosting
 
 *** Keywords ***
 Prepare Tests
+    [Documentation]           Make environment variables avaiable in whole test suite and list files in ${BIN_DIR}
     Setup
     ${SCRIPT} =               Get Environment Variable    SCRIPT
     ${LOGFILE} =              Get Environment Variable    LOGFILE
@@ -21,10 +22,12 @@ Prepare Tests
     List All Test Binaries
 
 Teardown With Custom Message
+    [Documentation]           Replace robot fail message with shorter one to avoid duplicated UART output in log
     Set Test Message          ${file} - FAILED
     Test Teardown
 
 List All Test Binaries
+    [Documentation]           List all files in ${BIN_DIR} and make it available from test cases
     Setup
     ${BIN_DIR} =              Get Environment Variable    BIN_DIR
     @{binaries} =             List Files In Directory     ${BIN_DIR}   absolute=True

--- a/tensorflow/lite/micro/testing/bluepill.robot
+++ b/tensorflow/lite/micro/testing/bluepill.robot
@@ -2,10 +2,11 @@
 Suite Setup                   Prepare Tests
 Suite Teardown                Teardown
 Test Setup                    Reset Emulation
-Test Teardown                 Test Teardown
+Test Teardown                 Teardown With Custom Message
 Resource                      ${RENODEKEYWORDS}
 
 *** Variables ***
+${CREATE_SNAPSHOT_ON_FAIL}    False
 ${UART}                       sysbus.cpu.uartSemihosting
 
 *** Keywords ***
@@ -18,6 +19,10 @@ Prepare Tests
     Set Suite Variable        ${EXPECTED}
     Set Suite Variable        ${LOGFILE}
     List All Test Binaries
+
+Teardown With Custom Message
+    Set Test Message          ${file} - FAILED
+    Test Teardown
 
 List All Test Binaries
     Setup
@@ -42,6 +47,7 @@ Should Run All Bluepill Tests
     FOR  ${BIN}  IN  @{binaries}
         Execute Command       $bin = @${BIN}
         ${_}  ${file} =       Split Path  ${BIN}
+        Set Test Variable     ${file}
         Test Binary
         Execute Command       Clear
 

--- a/tensorflow/lite/micro/testing/test_bluepill_binary.sh
+++ b/tensorflow/lite/micro/testing/test_bluepill_binary.sh
@@ -46,17 +46,9 @@ then
   exit 1
 fi
 
-
-# This check ensures that we only have a single $MICRO_LOG_FILENAME. Without it,
-# renode will do a log rotation and there will be multiple files such as
-# $MICRO_LOG_FILENAME.1 $MICRO_LOG_FILENAME.2 etc.
-if [ -e $MICRO_LOG_FILENAME ]; then
-    rm $MICRO_LOG_FILENAME &> /dev/null
-fi;
-
 exit_code=0
 
-if ! BIN=${ROOT_DIR}/$1 \
+if ! BIN_DIR=${ROOT_DIR}/$1 \
   SCRIPT=${ROOT_DIR}/tensorflow/lite/micro/testing/bluepill.resc \
   LOGFILE=$MICRO_LOG_FILENAME \
   EXPECTED="$2" \

--- a/tensorflow/lite/micro/testing/test_bluepill_binary.sh
+++ b/tensorflow/lite/micro/testing/test_bluepill_binary.sh
@@ -54,18 +54,17 @@ if ! BIN_DIR=${ROOT_DIR}/$1 \
   EXPECTED="$2" \
   ${RENODE_TEST_SCRIPT} \
   ${ROOT_DIR}/tensorflow/lite/micro/testing/bluepill.robot \
-  -r $TEST_TMPDIR &> ${MICRO_LOG_PATH}robot_logs.txt
+  -r $TEST_TMPDIR
 then
   exit_code=1
 fi
 
-echo "LOGS:"
-# Extract output from renode log
-cat ${MICRO_LOG_FILENAME} |grep 'uartSemihosting' |sed 's/^.*from start] *//g'
 if [ $exit_code -eq 0 ]
 then
-  echo "$1: PASS"
+  echo "PASS"
 else
-  echo "$1: FAIL - '$2' not found in logs."
+  echo "UART LOGS:"
+  # Extract output from renode log
+  cat ${MICRO_LOG_FILENAME} |grep 'uartSemihosting' |sed 's/^.*from start] *//g'
 fi
 exit $exit_code


### PR DESCRIPTION
This is a proposed way to reduce the execution time of TFLu Renode tests by generating all tests cases in Robot.
**The changes are applied only to the Bluepill target related files and are not yet integrated with `make test`.**
Main changes:
* `test_bluepill_binary.sh` now takes directory containing test binaries as argument,
* `.robot` runs test on all files found in given directory,
* console output was changed to suit the new approach.

Running the `tensorflow/lite/micro/testing/test_bluepill_binary.sh  tensorflow/lite/micro/tools/make/gen/bluepill_cortex-m3/bin/` will ouput:
* In case of PASS:
```
Preparing suites
Started Renode instance on port 9999; pid 62470
Starting suites
Running /home/jakub/Dokumenty/renode-tensorflow/tensorflow/lite/micro/testing/bluepill.robot
+++++ Starting test 'bluepill.Should Run All Bluepill Tests'
	detection_responder_test - PASSED
	detection_responder_test_int8 - PASSED
	greedy_memory_planner_test - PASSED
	hello_world_test - PASSED
        [...]
	simple_memory_allocator_test - PASSED
	testing_helpers_test - PASSED
+++++ Finished test 'bluepill.Should Run All Bluepill Tests' in 34.06 seconds with status OK
Cleaning up suites
Closing Renode pid 62470
Aggregating all robot results
Output:  /tmp/test_bluepill_binary/robot_output.xml
Log:     /tmp/test_bluepill_binary/log.html
Report:  /tmp/test_bluepill_binary/report.html
Tests finished successfully :)
PASS
```
* In case of FAIL:
```
Preparing suites
Started Renode instance on port 9999; pid 83495
Starting suites
Running /home/jakub/Dokumenty/renode-tensorflow/tensorflow/lite/micro/testing/bluepill.robot
+++++ Starting test 'bluepill.Should Run All Bluepill Tests'
	detection_responder_test - PASSED
	detection_responder_test_int8 - PASSED
	greedy_memory_planner_test - PASSED
	hello_world_test - PASSED
        [...]
	kernel_elementwise_test - PASSED
+++++ Finished test 'bluepill.Should Run All Bluepill Tests' in 9.14 seconds with status failed
      ╔═
      ║ kernel_floor_test - FAILED
      ╚═
Cleaning up suites
Closing Renode pid 83495
Aggregating all robot results
Output:  /tmp/test_bluepill_binary/robot_output.xml
Log:     /tmp/test_bluepill_binary/log.html
Report:  /tmp/test_bluepill_binary/report.html
Some tests failed :( See logs for details!
UART LOGS:
[...]
~~~SOME TESTS FAILED~~~
```