### PR TITLE
Move second half of prepare tf pass to legalize tf

### DIFF
--- a/tensorflow/compiler/mlir/lite/transforms/passes.h
+++ b/tensorflow/compiler/mlir/lite/transforms/passes.h
@@ -40,8 +40,7 @@ std::unique_ptr<OperationPass<FuncOp>> CreateLegalizeTFPass(
 std::unique_ptr<OperationPass<FuncOp>> CreateOptimizePass();
 
 // Creates an instance of the TensorFlow Lite dialect PrepareTF pass.
-std::unique_ptr<OperationPass<FuncOp>> CreatePrepareTFPass(
-    bool unfold_batch_matmul);
+std::unique_ptr<OperationPass<FuncOp>> CreatePrepareTFPass();
 
 // Creates an instance of the TensorFlow Lite dialect LowerStaticTensorList
 // pass.

--- a/tensorflow/compiler/mlir/lite/transforms/prepare_tf.h
+++ b/tensorflow/compiler/mlir/lite/transforms/prepare_tf.h
@@ -1,0 +1,18 @@
+#ifndef TENSORFLOW_COMPILER_MLIR_LITE_TRANSFORMS_PREPARE_TF_H_
+#define TENSORFLOW_COMPILER_MLIR_LITE_TRANSFORMS_PREPARE_TF_H_
+
+#include "mlir/IR/MLIRContext.h"  // from @llvm-project
+#include "mlir/IR/PatternMatch.h"  // from @llvm-project
+
+namespace mlir {
+namespace TF {
+
+// Populates TensorFlow lite prepare patterns to prepare for
+// legalization.
+void PopulatePrepareTfPatterns(MLIRContext *context,
+                               OwningRewritePatternList *patterns);
+
+}  // namespace TF
+}  // namespace mlir
+
+#endif  // TENSORFLOW_COMPILER_MLIR_LITE_TRANSFORMS_PREPARE_TF_H_


### PR DESCRIPTION
These patterns are more related to the legalization aspect rather than preparation aspect of the TFL pipeline hence they are moved

