### PR TITLE
Add idempotent based folding to TF

### DIFF
--- a/tensorflow/compiler/mlir/tensorflow/ir/tf_generated_ops.td
+++ b/tensorflow/compiler/mlir/tensorflow/ir/tf_generated_ops.td
@@ -31,7 +31,7 @@ limitations under the License.
 include "tensorflow/compiler/mlir/tensorflow/ir/tf_op_base.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 
-def TF_AbsOp : TF_Op<"Abs", [NoSideEffect, SameOperandsAndResultType]> {
+def TF_AbsOp : TF_Op<"Abs", [Idempotent, NoSideEffect, SameOperandsAndResultType]> {
   let summary = "Computes the absolute value of a tensor.";
 
   let description = [{
@@ -1462,7 +1462,7 @@ def TF_CastOp : TF_Op<"Cast", [NoSideEffect, SameOperandsAndResultShape]> {
   let hasFolder = 1;
 }
 
-def TF_CeilOp : TF_Op<"Ceil", [NoSideEffect, SameOperandsAndResultType]> {
+def TF_CeilOp : TF_Op<"Ceil", [Idempotent, NoSideEffect, SameOperandsAndResultType]> {
   let summary = "Returns element-wise smallest integer not less than x.";
 
   let arguments = (ins
@@ -3860,7 +3860,7 @@ fill([2, 3], 9) ==> [[9, 9, 9]
   ];
 }
 
-def TF_FloorOp : TF_Op<"Floor", [NoSideEffect, SameOperandsAndResultType]> {
+def TF_FloorOp : TF_Op<"Floor", [Idempotent, NoSideEffect, SameOperandsAndResultType]> {
   let summary = "Returns element-wise largest integer not greater than x.";
 
   let arguments = (ins
@@ -7717,7 +7717,7 @@ times by rerunning "MakeIterator".
   );
 }
 
-def TF_OnesLikeOp : TF_Op<"OnesLike", [NoSideEffect, SameOperandsAndResultType]> {
+def TF_OnesLikeOp : TF_Op<"OnesLike", [Idempotent, NoSideEffect, SameOperandsAndResultType]> {
   let summary = "Returns a tensor of ones with the same shape and type as x.";
 
   let arguments = (ins
@@ -8704,7 +8704,7 @@ most one RecvTPUEmbeddingActivations op in the TPU graph.
   TF_DerivedResultSizeAttr num_outputs = TF_DerivedResultSizeAttr<0>;
 }
 
-def TF_ReluOp : TF_Op<"Relu", [NoSideEffect, SameOperandsAndResultType, TF_ContractionFusableInterface, TF_LayoutAgnostic]> {
+def TF_ReluOp : TF_Op<"Relu", [Idempotent, NoSideEffect, SameOperandsAndResultType, TF_ContractionFusableInterface, TF_LayoutAgnostic]> {
   let summary = "Computes rectified linear: `max(features, 0)`.";
 
   let description = [{
@@ -8730,7 +8730,7 @@ array([ 0.,  0., -0.,  3.], dtype=float32)
   }];
 }
 
-def TF_Relu6Op : TF_Op<"Relu6", [NoSideEffect, SameOperandsAndResultType]> {
+def TF_Relu6Op : TF_Op<"Relu6", [Idempotent, NoSideEffect, SameOperandsAndResultType]> {
   let summary = "Computes rectified linear 6: `min(max(features, 0), 6)`.";
 
   let arguments = (ins
@@ -10128,7 +10128,7 @@ bitwise_ops.right_shift(lhs, rhs)
   TF_DerivedOperandTypeAttr T = TF_DerivedOperandTypeAttr<0>;
 }
 
-def TF_RintOp : TF_Op<"Rint", [NoSideEffect, SameOperandsAndResultType]> {
+def TF_RintOp : TF_Op<"Rint", [Idempotent, NoSideEffect, SameOperandsAndResultType]> {
   let summary = "Returns element-wise integer closest to x.";
 
   let description = [{
@@ -10195,7 +10195,7 @@ roll(t, shift=[2, -3], axis=[1, 1]) ==> [[1, 2, 3, 4, 0], [6, 7, 8, 9, 5]]
   TF_DerivedOperandTypeAttr Taxis = TF_DerivedOperandTypeAttr<2>;
 }
 
-def TF_RoundOp : TF_Op<"Round", [NoSideEffect, SameOperandsAndResultType]> {
+def TF_RoundOp : TF_Op<"Round", [Idempotent, NoSideEffect, SameOperandsAndResultType]> {
   let summary = [{
 Rounds the values of a tensor to the nearest integer, element-wise.
   }];
@@ -10925,7 +10925,7 @@ Specifically, `grad = dy * y * (1 - y)`, where `y = sigmoid(x)`, and
   TF_DerivedOperandTypeAttr T = TF_DerivedOperandTypeAttr<0>;
 }
 
-def TF_SignOp : TF_Op<"Sign", [NoSideEffect, SameOperandsAndResultType]> {
+def TF_SignOp : TF_Op<"Sign", [Idempotent, NoSideEffect, SameOperandsAndResultType]> {
   let summary = "Returns an element-wise indication of the sign of a number.";
 
   let description = [{
@@ -14849,7 +14849,7 @@ def TF_XlogyOp : TF_Op<"Xlogy", [NoSideEffect, ResultsBroadcastableShape, TF_Sam
   TF_DerivedOperandTypeAttr T = TF_DerivedOperandTypeAttr<0>;
 }
 
-def TF_ZerosLikeOp : TF_Op<"ZerosLike", [NoSideEffect, SameOperandsAndResultType]> {
+def TF_ZerosLikeOp : TF_Op<"ZerosLike", [Idempotent, NoSideEffect, SameOperandsAndResultType]> {
   let summary = "Returns a tensor of zeros with the same shape and type as x.";
 
   let arguments = (ins

--- a/tensorflow/compiler/mlir/tensorflow/tests/tf_trait_folds.mlir
+++ b/tensorflow/compiler/mlir/tensorflow/tests/tf_trait_folds.mlir
@@ -144,3 +144,193 @@ func @testTripleLogicalNot(%arg0: tensor<i1>) -> tensor<i1> {
   // CHECK: return [[LNOT]]
   return %2: tensor<i1>
 }
+
+// CHECK-LABEL: func @testSingleAbs
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<i8>)
+func @testSingleAbs(%arg0: tensor<i8>) -> tensor<i8> {
+  // CHECK: [[ABS:%.+]] = "tf.Abs"([[ARG0]])
+  %0 = "tf.Abs"(%arg0) : (tensor<i8>) -> tensor<i8>
+  // CHECK: return [[ABS]]
+  return %0: tensor<i8>
+}
+
+// CHECK-LABEL: func @testDoubleAbs
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<i8>)
+func @testDoubleAbs(%arg0: tensor<i8>) -> tensor<i8> {
+  // CHECK: [[ABS:%.+]] = "tf.Abs"([[ARG0]])
+  %0 = "tf.Abs"(%arg0) : (tensor<i8>) -> tensor<i8>
+  %1 = "tf.Abs"(%0) : (tensor<i8>) -> tensor<i8>
+  // CHECK: return [[ABS]]
+  return %1: tensor<i8>
+}
+
+// CHECK-LABEL: func @testSingleCeil
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<f1>)
+func @testSingleCeil(%arg0: tensor<f1>) -> tensor<f1> {
+  // CHECK: [[CEIL:%.+]] = "tf.Ceil"([[ARG0]])
+  %0 = "tf.Ceil"(%arg0) : (tensor<f1>) -> tensor<f1>
+  // CHECK: return [[CEIL]]
+  return %0: tensor<f1>
+}
+
+// CHECK-LABEL: func @testDoubleCeil
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<f1>)
+func @testDoubleCeil(%arg0: tensor<f1>) -> tensor<f1> {
+  // CHECK: [[CEIL:%.+]] = "tf.Ceil"([[ARG0]])
+  %0 = "tf.Ceil"(%arg0) : (tensor<f1>) -> tensor<f1>
+  %1 = "tf.Ceil"(%0) : (tensor<f1>) -> tensor<f1>
+  // CHECK: return [[CEIL]]
+  return %1: tensor<f1>
+}
+
+// CHECK-LABEL: func @testSingleFloor
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<f1>)
+func @testSingleFloor(%arg0: tensor<f1>) -> tensor<f1> {
+  // CHECK: [[FLOOR:%.+]] = "tf.Floor"([[ARG0]])
+  %0 = "tf.Floor"(%arg0) : (tensor<f1>) -> tensor<f1>
+  // CHECK: return [[FLOOR]]
+  return %0: tensor<f1>
+}
+
+// CHECK-LABEL: func @testDoubleFloor
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<f1>)
+func @testDoubleFloor(%arg0: tensor<f1>) -> tensor<f1> {
+  // CHECK: [[FLOOR:%.+]] = "tf.Floor"([[ARG0]])
+  %0 = "tf.Floor"(%arg0) : (tensor<f1>) -> tensor<f1>
+  %1 = "tf.Floor"(%0) : (tensor<f1>) -> tensor<f1>
+  // CHECK: return [[FLOOR]]
+  return %1: tensor<f1>
+}
+
+// CHECK-LABEL: func @testSingleOnesLike
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<i8>)
+func @testSingleOnesLike(%arg0: tensor<i8>) -> tensor<i8> {
+  // CHECK: [[ONESLIKE:%.+]] = "tf.OnesLike"([[ARG0]])
+  %0 = "tf.OnesLike"(%arg0) : (tensor<i8>) -> tensor<i8>
+  // CHECK: return [[ONESLIKE]]
+  return %0: tensor<i8>
+}
+
+// CHECK-LABEL: func @testDoubleOnesLike
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<i8>)
+func @testDoubleOnesLike(%arg0: tensor<i8>) -> tensor<i8> {
+  // CHECK: [[ONESLIKE:%.+]] = "tf.OnesLike"([[ARG0]])
+  %0 = "tf.OnesLike"(%arg0) : (tensor<i8>) -> tensor<i8>
+  %1 = "tf.OnesLike"(%0) : (tensor<i8>) -> tensor<i8>
+  // CHECK: return [[ONESLIKE]]
+  return %1: tensor<i8>
+}
+
+// CHECK-LABEL: func @testSingleRelu
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<i8>)
+func @testSingleRelu(%arg0: tensor<i8>) -> tensor<i8> {
+  // CHECK: [[RELU:%.+]] = "tf.Relu"([[ARG0]])
+  %0 = "tf.Relu"(%arg0) : (tensor<i8>) -> tensor<i8>
+  // CHECK: return [[RELU]]
+  return %0: tensor<i8>
+}
+
+// CHECK-LABEL: func @testDoubleRelu
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<i8>)
+func @testDoubleRelu(%arg0: tensor<i8>) -> tensor<i8> {
+  // CHECK: [[RELU:%.+]] = "tf.Relu"([[ARG0]])
+  %0 = "tf.Relu"(%arg0) : (tensor<i8>) -> tensor<i8>
+  %1 = "tf.Relu"(%0) : (tensor<i8>) -> tensor<i8>
+  // CHECK: return [[RELU]]
+  return %1: tensor<i8>
+}
+
+// CHECK-LABEL: func @testSingleRelu6
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<i1>)
+func @testSingleRelu6(%arg0: tensor<i1>) -> tensor<i1> {
+  // CHECK: [[RELU6:%.+]] = "tf.Relu6"([[ARG0]])
+  %0 = "tf.Relu6"(%arg0) : (tensor<i1>) -> tensor<i1>
+  // CHECK: return [[RELU6]]
+  return %0: tensor<i1>
+}
+
+// CHECK-LABEL: func @testDoubleRelu6
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<i1>)
+func @testDoubleRelu6(%arg0: tensor<i1>) -> tensor<i1> {
+  // CHECK: [[RELU6:%.+]] = "tf.Relu6"([[ARG0]])
+  %0 = "tf.Relu6"(%arg0) : (tensor<i1>) -> tensor<i1>
+  %1 = "tf.Relu6"(%0) : (tensor<i1>) -> tensor<i1>
+  // CHECK: return [[RELU6]]
+  return %1: tensor<i1>
+}
+
+// CHECK-LABEL: func @testSingleRint
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<f1>)
+func @testSingleRint(%arg0: tensor<f1>) -> tensor<f1> {
+  // CHECK: [[RINT:%.+]] = "tf.Rint"([[ARG0]])
+  %0 = "tf.Rint"(%arg0) : (tensor<f1>) -> tensor<f1>
+  // CHECK: return [[RINT]]
+  return %0: tensor<f1>
+}
+
+// CHECK-LABEL: func @testDoubleRint
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<f1>)
+func @testDoubleRint(%arg0: tensor<f1>) -> tensor<f1> {
+  // CHECK: [[RINT:%.+]] = "tf.Rint"([[ARG0]])
+  %0 = "tf.Rint"(%arg0) : (tensor<f1>) -> tensor<f1>
+  %1 = "tf.Rint"(%0) : (tensor<f1>) -> tensor<f1>
+  // CHECK: return [[RINT]]
+  return %1: tensor<f1>
+}
+
+// CHECK-LABEL: func @testSingleRound
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<i8>)
+func @testSingleRound(%arg0: tensor<i8>) -> tensor<i8> {
+  // CHECK: [[ROUND:%.+]] = "tf.Round"([[ARG0]])
+  %0 = "tf.Round"(%arg0) : (tensor<i8>) -> tensor<i8>
+  // CHECK: return [[ROUND]]
+  return %0: tensor<i8>
+}
+
+// CHECK-LABEL: func @testDoubleRound
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<i8>)
+func @testDoubleRound(%arg0: tensor<i8>) -> tensor<i8> {
+  // CHECK: [[ROUND:%.+]] = "tf.Round"([[ARG0]])
+  %0 = "tf.Round"(%arg0) : (tensor<i8>) -> tensor<i8>
+  %1 = "tf.Round"(%0) : (tensor<i8>) -> tensor<i8>
+  // CHECK: return [[ROUND]]
+  return %1: tensor<i8>
+}
+
+// CHECK-LABEL: func @testSingleSign
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<i32>)
+func @testSingleSign(%arg0: tensor<i32>) -> tensor<i32> {
+  // CHECK: [[SIGN:%.+]] = "tf.Sign"([[ARG0]])
+  %0 = "tf.Sign"(%arg0) : (tensor<i32>) -> tensor<i32>
+  // CHECK: return [[SIGN]]
+  return %0: tensor<i32>
+}
+
+// CHECK-LABEL: func @testDoubleSign
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<i32>)
+func @testDoubleSign(%arg0: tensor<i32>) -> tensor<i32> {
+  // CHECK: [[SIGN:%.+]] = "tf.Sign"([[ARG0]])
+  %0 = "tf.Sign"(%arg0) : (tensor<i32>) -> tensor<i32>
+  %1 = "tf.Sign"(%0) : (tensor<i32>) -> tensor<i32>
+  // CHECK: return [[SIGN]]
+  return %1: tensor<i32>
+}
+
+// CHECK-LABEL: func @testSingleZerosLike
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<i1>)
+func @testSingleZerosLike(%arg0: tensor<i1>) -> tensor<i1> {
+  // CHECK: [[ZEROSLIKE:%.+]] = "tf.ZerosLike"([[ARG0]])
+  %0 = "tf.ZerosLike"(%arg0) : (tensor<i1>) -> tensor<i1>
+  // CHECK: return [[ZEROSLIKE]]
+  return %0: tensor<i1>
+}
+
+// CHECK-LABEL: func @testDoubleZerosLike
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<i1>)
+func @testDoubleZerosLike(%arg0: tensor<i1>) -> tensor<i1> {
+  // CHECK: [[ZEROSLIKE:%.+]] = "tf.ZerosLike"([[ARG0]])
+  %0 = "tf.ZerosLike"(%arg0) : (tensor<i1>) -> tensor<i1>
+  %1 = "tf.ZerosLike"(%0) : (tensor<i1>) -> tensor<i1>
+  // CHECK: return [[ZEROSLIKE]]
+  return %1: tensor<i1>
+}


### PR DESCRIPTION
This trait label will allow idempotent optimizations (i.e. multiples copies of op folded to one copy) to run automatically from the MLIR side