### PR TITLE
Fix the absl module not found error

### DIFF
--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -52,7 +52,7 @@ set(CMAKE_PREFIX_PATH
   ${CMAKE_PREFIX_PATH}
 )
 # b/168750039: To workaround absl module not found error on Android build.
-set(absl_DIR ${CMAKE_MODULE_PATH})
+set(absl_DIR "${TFLITE_SOURCE_DIR}/tools/cmake/modules")
 
 option(TFLITE_ENABLE_RUY "Enable experimental RUY integration" OFF)
 option(TFLITE_ENABLE_RESOURCE "Enable experimental support for resources" ON)


### PR DESCRIPTION
ToT workarounds the absl module not found error by using $CMAKE_MODULE_PATH,
but this is still likely to fail due to the fact that $CMAKE_MODULE_PATH is
a semicolon-separated list of directories specifying a search path for CMake
modules. In fact, if we set more than one path to $CMAKE_MODULE_PATH, the absl
module not found error occurs. This patch solves the problem by give |absl_DIR|
the unique CMake module path in the source tree.