### PR TITLE
Module of the same name was imported twice.

### DIFF
--- a/tensorflow/python/keras/engine/training_dataset_test.py
+++ b/tensorflow/python/keras/engine/training_dataset_test.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import logging
 import sys
 
 import numpy as np

--- a/tensorflow/python/util/module_wrapper_test.py
+++ b/tensorflow/python/util/module_wrapper_test.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import logging
 import pickle
 import types
 


### PR DESCRIPTION
Imported python `logging` module was redefined several lines afterwards as `from tensorflow.python.platform import tf_logging`.
The module `loggin` is also used extensively by itself `tf_logging`.