### PR TITLE
Add an additional arg to tf.experimental.register_filesystem_plugin to take plugin function name

### DIFF
--- a/tensorflow/c/c_api.cc
+++ b/tensorflow/c/c_api.cc
@@ -2608,12 +2608,14 @@ void TF_RegisterLogListener(void (*listener)(const char*)) {
 }
 
 void TF_RegisterFilesystemPlugin(const char* plugin_filename,
+                                 const char* plugin_function,
                                  TF_Status* status) {
 #if defined(IS_MOBILE_PLATFORM) || defined(IS_SLIM_BUILD)
   status->status = tensorflow::errors::Unimplemented(
       "FileSystem plugin functionality is not supported on mobile");
 #else
-  status->status = tensorflow::RegisterFilesystemPlugin(plugin_filename);
+  status->status = tensorflow::RegisterFilesystemPlugin(
+      plugin_filename, plugin_function);
 #endif  // defined(IS_MOBILE_PLATFORM) || defined(IS_SLIM_BUILD)
 }
 

--- a/tensorflow/c/c_api.h
+++ b/tensorflow/c/c_api.h
@@ -1582,7 +1582,7 @@ TF_CAPI_EXPORT extern void TF_RegisterLogListener(
 // On success, place OK in status.
 // On failure, place an error status in status.
 TF_CAPI_EXPORT extern void TF_RegisterFilesystemPlugin(
-    const char* plugin_filename, TF_Status* status);
+    const char* plugin_filename, const char* plugin_function, TF_Status* status);
 
 #ifdef __cplusplus
 } /* end extern "C" */

--- a/tensorflow/c/experimental/filesystem/modular_filesystem.cc
+++ b/tensorflow/c/experimental/filesystem/modular_filesystem.cc
@@ -457,16 +457,19 @@ Status ModularWritableFile::Tell(int64* position) {
   return StatusFromTF_Status(plugin_status.get());
 }
 
-Status RegisterFilesystemPlugin(const std::string& dso_path) {
+Status RegisterFilesystemPlugin(const std::string& dso_path,
+                                const std::string& func_name) {
   // Step 1: Load plugin
   Env* env = Env::Default();
   void* dso_handle;
   TF_RETURN_IF_ERROR(env->LoadDynamicLibrary(dso_path.c_str(), &dso_handle));
 
-  // Step 2: Load symbol for `TF_InitPlugin`
+  // Step 2: Load symbol for function,
+  // if function is not specified, use `TF_InitPlugin` as default.
+  const char* func = (func_name == "") ? "TF_InitPlugin" : func_name.c_str();
   void* dso_symbol;
   TF_RETURN_IF_ERROR(
-      env->GetSymbolFromLibrary(dso_handle, "TF_InitPlugin", &dso_symbol));
+      env->GetSymbolFromLibrary(dso_handle, func, &dso_symbol));
 
   // Step 3: Call `TF_InitPlugin`
   TF_FilesystemPluginInfo info;

--- a/tensorflow/c/experimental/filesystem/modular_filesystem.h
+++ b/tensorflow/c/experimental/filesystem/modular_filesystem.h
@@ -175,7 +175,8 @@ class ModularReadOnlyMemoryRegion final : public ReadOnlyMemoryRegion {
 };
 
 // Registers a filesystem plugin so that core TensorFlow can use it.
-Status RegisterFilesystemPlugin(const std::string& dso_path);
+Status RegisterFilesystemPlugin(const std::string& dso_path,
+                                const std::string& func_name);
 
 }  // namespace tensorflow
 

--- a/tensorflow/python/client/tf_session_wrapper.cc
+++ b/tensorflow/python/client/tf_session_wrapper.cc
@@ -1155,10 +1155,10 @@ PYBIND11_MODULE(_pywrap_tf_session, m) {
     return "TensorHandle";
   });
 
-  m.def("TF_RegisterFilesystemPlugin", [](const char* plugin_filename) {
+  m.def("TF_RegisterFilesystemPlugin", [](const char* plugin_filename, const char* plugin_function) {
     tensorflow::Safe_TF_StatusPtr status =
         tensorflow::make_safe(TF_NewStatus());
-    TF_RegisterFilesystemPlugin(plugin_filename, status.get());
+    TF_RegisterFilesystemPlugin(plugin_filename, plugin_function, status.get());
     tensorflow::MaybeRaiseRegisteredFromTFStatus(status.get());
   });
 

--- a/tensorflow/python/framework/load_library.py
+++ b/tensorflow/python/framework/load_library.py
@@ -160,12 +160,14 @@ def load_library(library_location):
 
 
 @tf_export('experimental.register_filesystem_plugin')
-def register_filesystem_plugin(plugin_location):
+def register_filesystem_plugin(plugin_location, plugin_function=None):
   """Loads a TensorFlow FileSystem plugin.
 
   Args:
     plugin_location: Path to the plugin. Relative or absolute filesystem plugin
       path to a dynamic library file.
+    plugin_function: Name of the function in the plugin to be loaded. Default
+      to `TF_InitPlugin`.
 
   Returns:
     None
@@ -175,7 +177,7 @@ def register_filesystem_plugin(plugin_location):
     RuntimeError: when unable to load the library.
   """
   if os.path.exists(plugin_location):
-    py_tf.TF_RegisterFilesystemPlugin(plugin_location)
+    py_tf.TF_RegisterFilesystemPlugin(plugin_location, plugin_function)
 
   else:
     raise OSError(errno.ENOENT,

--- a/tensorflow/tools/api/golden/v1/tensorflow.experimental.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.experimental.pbtxt
@@ -22,6 +22,6 @@ tf_module {
   }
   member_method {
     name: "register_filesystem_plugin"
-    argspec: "args=[\'plugin_location\'], varargs=None, keywords=None, defaults=None"
+    argspec: "args=[\'plugin_location\', \'plugin_function\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
 }

--- a/tensorflow/tools/api/golden/v2/tensorflow.experimental.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.experimental.pbtxt
@@ -30,6 +30,6 @@ tf_module {
   }
   member_method {
     name: "register_filesystem_plugin"
-    argspec: "args=[\'plugin_location\'], varargs=None, keywords=None, defaults=None"
+    argspec: "args=[\'plugin_location\', \'plugin_function\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
 }


### PR DESCRIPTION
This PR proposes to add an additional arg `plugin_function` to
tf.experimental.register_filesystem_plugin so that it is possible to load
a file system plugin with a different function name, i.e., a name other than
default `TF_InitPlugin` (e.g., `TF_InitPlugin_AzureFileSystem`, `TF_InitPlugin_HTTPFileSystem`, etc).

There are several reasons for a need to have the flexibility of using a different function name.
But the biggest reason is that, by allowing passing function name as the parameter, it is possible
to bundle several file systems into one shared object library and reduce the total size of the
package (e.g., one `.so` file with multiple file system support for Azure FS, HTTP FS, etc).

Since thie PR will only add an optional args, users may still pass the `library_pathname`
only (and `TF_InitPlugin` function name will automatically be used).

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>