### PR TITLE
Add use_default_shell_env = True to all ctx.actions.run_shell rules

### DIFF
--- a/tensorflow/core/kernels/mlir_generated/build_defs.bzl
+++ b/tensorflow/core/kernels/mlir_generated/build_defs.bzl
@@ -71,6 +71,7 @@ def _gen_mlir_op_impl(ctx):
                 ctx.outputs.out.path,
             )
         ),
+        use_default_shell_env = True,
     )
 
 _gen_mlir_op_rule = rule(

--- a/tensorflow/core/kernels/mlir_generated/build_defs.bzl
+++ b/tensorflow/core/kernels/mlir_generated/build_defs.bzl
@@ -164,6 +164,7 @@ def _gen_kernel_bin_impl(ctx):
             "--cpu_codegen=%s" % ctx.attr.cpu_codegen,
             "--jit=%s" % ctx.attr.jit,
         ],
+        use_default_shell_env = True,
         mnemonic = "compile",
         progress_message = "Generating kernel '%{label}'",
     )

--- a/third_party/flatbuffers/build_defs.bzl
+++ b/third_party/flatbuffers/build_defs.bzl
@@ -394,6 +394,7 @@ def _concat_flatbuffer_py_srcs_impl(ctx):
             ctx.attr.deps[0].files.to_list()[0].path,
             ctx.outputs.out.path,
         ),
+        use_default_shell_env = True,
     )
 
 _concat_flatbuffer_py_srcs = rule(

--- a/third_party/nccl/build_defs.bzl.tpl
+++ b/third_party/nccl/build_defs.bzl.tpl
@@ -236,6 +236,7 @@ def _merge_archive_impl(ctx):
         inputs = ctx.files.srcs,  # + ctx.files._crosstool,
         outputs = [ctx.outputs.out],
         command = "echo -e \"%s\" | %s -M" % (mri_script, cc_toolchain.ar_executable),
+        use_default_shell_env = True,
     )
 
 _merge_archive = rule(

--- a/third_party/nccl/build_defs.bzl.tpl
+++ b/third_party/nccl/build_defs.bzl.tpl
@@ -100,6 +100,7 @@ def _device_link_impl(ctx):
                 "--output-file=%s" % cubin.path,
             ] + [file.path for file in inputs],
             mnemonic = "nvlink",
+            use_default_shell_env = True,
         )
         cubins.append(cubin)
         images.append("--image=profile=%s,file=%s" % (arch, cubin.path))
@@ -125,6 +126,7 @@ def _device_link_impl(ctx):
         arguments = arguments_list + images,
         tools = [bin2c],
         mnemonic = "fatbinary",
+        use_default_shell_env = True,
     )
 
     # Generate the source file #including the headers generated above.
@@ -203,6 +205,7 @@ def _prune_relocatable_code_impl(ctx):
             executable = ctx.file._nvprune,
             arguments = arguments,
             mnemonic = "nvprune",
+            use_default_shell_env = True,
         )
         outputs.append(output)
 

--- a/third_party/systemlibs/grpc.bazel.generate_cc.bzl
+++ b/third_party/systemlibs/grpc.bazel.generate_cc.bzl
@@ -140,6 +140,7 @@ def generate_cc_impl(ctx):
         outputs = out_files,
         executable = ctx.executable._protoc,
         arguments = arguments,
+        use_default_shell_env = True,
     )
 
     return struct(files = depset(out_files))


### PR DESCRIPTION
To start subprograms, even simple bash snippets, Bazel uses an
executable `process-wrapper` which is potentially built using a custom
toolchain and hence requires a set up LD_LIBRARY_PATH.
Ommitting the `use_default_shell_env` (defaulting to false) clears the
whole environment and the binary may try to use older system libs such
as /lib64/libstdc++.so causing it to fail in case it is (much) older
than the used libstdc++ from the custom toolchain which is very common
in HPC environments.
Hence I added `use_default_shell_env = True` as already done in e.g.
`_local_genrule_impl`.