### PR TITLE
Remove unnecessary check for TARGET in the xtensa_hifimini makefile.

### DIFF
--- a/tensorflow/lite/micro/tools/make/targets/xtensa_hifimini_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/xtensa_hifimini_makefile.inc
@@ -8,52 +8,50 @@
 #   - XTENSA_CORE: The name of the Xtensa core to use
 #      For example: hifimini
 
-ifeq ($(TARGET), xtensa_hifimini)
-  TARGET_ARCH := xtensa_hifimini
+TARGET_ARCH := xtensa_hifimini
 
-  ifndef XTENSA_BASE
-    $(error XTENSA_BASE is undefined)
-  endif
-
-  ifndef XTENSA_TOOLS_VERSION
-    $(error XTENSA_TOOLS_VERSION is undefined)
-  endif
-
-  ifndef XTENSA_CORE
-    $(error XTENSA_CORE is undefined)
-  endif
-
-  PLATFORM_FLAGS = \
-    -DTF_LITE_MCU_DEBUG_LOG \
-    --xtensa-core=$(XTENSA_CORE) \
-    -mcoproc \
-    -DXTENSA \
-    -DMAX_RFFT_PWR=9 \
-    -DMIN_RFFT_PWR=MAX_RFFT_PWR
-
-
-  export PATH := $(XTENSA_BASE)/tools/$(XTENSA_TOOLS_VERSION)/XtensaTools/bin:$(PATH)
-  TARGET_TOOLCHAIN_PREFIX := xt-
-  CXX_TOOL := clang++
-  CC_TOOL := clang
-
-  CXXFLAGS += $(PLATFORM_FLAGS)
-  CCFLAGS += $(PLATFORM_FLAGS)
-
-  # TODO(b/150240249): Do not remove -fno-rtti once that works for the Xtensa toolchain.
-  CXXFLAGS := $(filter-out -fno-rtti, $(CXXFLAGS))
-
-  TEST_SCRIPT := tensorflow/lite/micro/testing/test_xtensa_hifimini_binary.sh
-
-  # TODO(b/156962140): This manually maintained list of excluded examples is
-  # quite error prone.
-  EXCLUDED_EXAMPLE_TESTS := \
-    tensorflow/lite/micro/examples/image_recognition_experimental/Makefile.inc \
-    tensorflow/lite/micro/examples/magic_wand/Makefile.inc \
-    tensorflow/lite/micro/examples/micro_speech/Makefile.inc \
-    tensorflow/lite/micro/examples/network_tester/Makefile.inc \
-    tensorflow/lite/micro/examples/person_detection/Makefile.inc \
-    tensorflow/lite/micro/examples/person_detection_experimental/Makefile.inc
-  MICRO_LITE_EXAMPLE_TESTS := $(filter-out $(EXCLUDED_EXAMPLE_TESTS), $(MICRO_LITE_EXAMPLE_TESTS))
-
+ifndef XTENSA_BASE
+  $(error XTENSA_BASE is undefined)
 endif
+
+ifndef XTENSA_TOOLS_VERSION
+  $(error XTENSA_TOOLS_VERSION is undefined)
+endif
+
+ifndef XTENSA_CORE
+  $(error XTENSA_CORE is undefined)
+endif
+
+PLATFORM_FLAGS = \
+  -DTF_LITE_MCU_DEBUG_LOG \
+  --xtensa-core=$(XTENSA_CORE) \
+  -mcoproc \
+  -DXTENSA \
+  -DMAX_RFFT_PWR=9 \
+  -DMIN_RFFT_PWR=MAX_RFFT_PWR
+
+
+export PATH := $(XTENSA_BASE)/tools/$(XTENSA_TOOLS_VERSION)/XtensaTools/bin:$(PATH)
+TARGET_TOOLCHAIN_PREFIX := xt-
+CXX_TOOL := clang++
+CC_TOOL := clang
+
+CXXFLAGS += $(PLATFORM_FLAGS)
+CCFLAGS += $(PLATFORM_FLAGS)
+
+# TODO(b/150240249): Do not remove -fno-rtti once that works for the Xtensa toolchain.
+CXXFLAGS := $(filter-out -fno-rtti, $(CXXFLAGS))
+
+TEST_SCRIPT := tensorflow/lite/micro/testing/test_xtensa_hifimini_binary.sh
+
+# TODO(b/156962140): This manually maintained list of excluded examples is
+# quite error prone.
+EXCLUDED_EXAMPLE_TESTS := \
+  tensorflow/lite/micro/examples/image_recognition_experimental/Makefile.inc \
+  tensorflow/lite/micro/examples/magic_wand/Makefile.inc \
+  tensorflow/lite/micro/examples/micro_speech/Makefile.inc \
+  tensorflow/lite/micro/examples/network_tester/Makefile.inc \
+  tensorflow/lite/micro/examples/person_detection/Makefile.inc \
+  tensorflow/lite/micro/examples/person_detection_experimental/Makefile.inc
+MICRO_LITE_EXAMPLE_TESTS := $(filter-out $(EXCLUDED_EXAMPLE_TESTS), $(MICRO_LITE_EXAMPLE_TESTS))
+


### PR DESCRIPTION
Manually confirmed that:

```
make -f tensorflow/lite/micro/tools/make/Makefile -j8 TARGET=xtensa_hifimini XTENSA_CORE=<core> test_keyword_benchmark
```

Gives the following output:
```
tensorflow/lite/micro/testing/test_xtensa_hifimini_binary.sh tensorflow/lite/micro/tools/make/gen/xtensa_hifimini_xtensa_hifimini/bin/keyword_benchmark '~~~ALL TESTS PASSED~~~'
InitializeKeywordRunner() took 1389000 ticks (1389 ms)
KeywordRunNIerations(1) took 89318 ticks (89 ms)
KeywordRunNIerations(10) took 892739 ticks (892 ms)
tensorflow/lite/micro/tools/make/gen/xtensa_hifimini_xtensa_hifimini/bin/keyword_benchmark: FAIL - '~~~ALL TESTS PASSED~~~' not found in logs.
```

Fixes #43898
