### PR TITLE
Add several fixes for s390x architecture and other Big-Endian systems

### DIFF
--- a/tensorflow/compiler/xla/literal.cc
+++ b/tensorflow/compiler/xla/literal.cc
@@ -57,14 +57,14 @@ constexpr int kMinimumAlignment = 64;
 //
 // Precondition: size % 2 == 0 (elements in the array are 16 bits long)
 void ConvertEndianShort(string* bytes) {
-  CHECK_EQ(bytes->size() / 2, 0);
+  CHECK_EQ(bytes->size() % 2, 0);
   for (int64 i = 0, end = bytes->size(); i < end; i += 2) {
     std::swap((*bytes)[i], (*bytes)[i + 1]);
   }
 }
 
 void ConvertEndianShort(char* bytes, int64 size) {
-  CHECK_EQ(size / 2, 0);
+  CHECK_EQ(size % 2, 0);
   for (int64 i = 0; i < size; i += 2) {
     std::swap(bytes[i], bytes[i + 1]);
   }

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -773,6 +773,7 @@ cc_library(
         "//tensorflow:arm_any": [],
         "//tensorflow:ios": [],
         "//tensorflow:linux_ppc64le": [],
+        "//tensorflow:linux_s390x": [],
         "//conditions:default": [
             "TENSORFLOW_USE_CUSTOM_CONTRACTION_KERNEL",
             "TENSORFLOW_USE_MKLDNN_CONTRACTION_KERNEL",
@@ -787,6 +788,7 @@ cc_library(
         "//tensorflow:arm_any": [],
         "//tensorflow:ios": [],
         "//tensorflow:linux_ppc64le": [],
+        "//tensorflow:linux_s390x": [],
         "//conditions:default": ["@mkl_dnn//:mkldnn_single_threaded"],
     }),
 )
@@ -2901,6 +2903,7 @@ tf_cc_test(
         "//tensorflow:arm_any": [],
         "//tensorflow:ios": [],
         "//tensorflow:linux_ppc64le": [],
+        "//tensorflow:linux_s390x": [],
         ":no_mkldnn_contraction_kernel": [],
         "//conditions:default": ["eigen_mkldnn_contraction_kernel_test.cc"],
     }),

--- a/tensorflow/core/kernels/data/experimental/lmdb_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/experimental/lmdb_dataset_op_test.cc
@@ -23,7 +23,11 @@ namespace {
 
 constexpr char kNodeName[] = "lmdb_dataset";
 constexpr char kIteratorPrefix[] = "Iterator";
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+constexpr char kDataFileName[] = "data_bigendian.mdb";
+#else
 constexpr char kDataFileName[] = "data.mdb";
+#endif
 constexpr char kDataFileLoc[] = "core/lib/lmdb/testdata";
 
 class LMDBDatasetParams : public DatasetParams {

--- a/third_party/cpuinfo/BUILD.bazel
+++ b/third_party/cpuinfo/BUILD.bazel
@@ -103,6 +103,7 @@ cc_library(
         ":linux_armeabi": COMMON_SRCS + ARM_SRCS + LINUX_SRCS + LINUX_ARM32_SRCS,
         ":linux_aarch64": COMMON_SRCS + ARM_SRCS + LINUX_SRCS + LINUX_ARM64_SRCS,
         ":linux_mips64": COMMON_SRCS + LINUX_SRCS,
+        ":linux_s390x": COMMON_SRCS + LINUX_SRCS,
         ":macos_x86_64": COMMON_SRCS + X86_SRCS + MACH_SRCS + MACH_X86_SRCS,
         ":windows_x86_64": COMMON_SRCS + X86_SRCS + WINDOWS_X86_SRCS,
         ":android_armv7": COMMON_SRCS + ARM_SRCS + LINUX_SRCS + LINUX_ARM32_SRCS + ANDROID_ARM_SRCS,
@@ -212,6 +213,11 @@ config_setting(
 config_setting(
     name = "linux_mips64",
     values = {"cpu": "mips64"},
+)
+
+config_setting(
+    name = "linux_s390x",
+    values = {"cpu": "s390x"},
 )
 
 config_setting(


### PR DESCRIPTION
The patch contains the following changes:
1. Fix a typo in `tensorflow/compiler/xla/literal.cc`, as the annotation suggests, it should be modulo not division.
2. Disable `MKLDNN_CONTRACTION_KERNEL` build for s390x, as it is not supported on s390x.
3. Select the test file with correct endianness for `tensorflow/core/kernels/data/experimental/lmdb_dataset_op_test.cc`, since the big endian version test file is already available in the repo.
4. Add support for s390x with cpuinfo package. s390x is not officially supported by cpuinfo, so only include the common sources.