### PR TITLE
Add ESP32 examples build test

### DIFF
--- a/tensorflow/lite/micro/tools/ci_build/test_all.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_all.sh
@@ -55,7 +55,4 @@ tensorflow/lite/micro/tools/ci_build/test_arduino.sh
 echo "Running cortex_m_generic tests at `date`"
 tensorflow/lite/micro/tools/ci_build/test_cortex_m_generic.sh
 
-echo "Running ESP32 tests at `date`"
-tensorflow/lite/micro/tools/ci_build/test_esp32.sh
-
 echo "Finished all micro tests at `date`"

--- a/tensorflow/lite/micro/tools/ci_build/test_all.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_all.sh
@@ -55,4 +55,7 @@ tensorflow/lite/micro/tools/ci_build/test_arduino.sh
 echo "Running cortex_m_generic tests at `date`"
 tensorflow/lite/micro/tools/ci_build/test_cortex_m_generic.sh
 
+echo "Running ESP32 tests at `date`"
+tensorflow/lite/micro/tools/ci_build/test_esp32.sh
+
 echo "Finished all micro tests at `date`"

--- a/tensorflow/lite/micro/tools/ci_build/test_esp32.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_esp32.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# Tests the microcontroller code for esp32 platform
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR=${SCRIPT_DIR}/../../../../..
+cd "${ROOT_DIR}"
+pwd
+
+source tensorflow/lite/micro/tools/ci_build/helper_functions.sh
+
+TARGET=esp
+
+# setup esp-idf and toolchains
+readable_run git clone --recursive --single-branch --branch release/v4.2 https://github.com/espressif/esp-idf.git
+readable_run export IDF_PATH="${ROOT_DIR}"/esp-idf
+cd $IDF_PATH
+readable_run ./install.sh
+readable_run . ./export.sh
+cd "${ROOT_DIR}"
+
+# clean all
+readable_run make -f tensorflow/lite/micro/tools/make/Makefile clean
+
+# generate examples
+readable_run make -j8 -f tensorflow/lite/micro/tools/make/Makefile TARGET=${TARGET} generate_hello_world_esp_project
+readable_run make -j8 -f tensorflow/lite/micro/tools/make/Makefile TARGET=${TARGET} generate_person_detection_esp_project
+readable_run make -j8 -f tensorflow/lite/micro/tools/make/Makefile TARGET=${TARGET} generate_micro_speech_esp_project
+
+# build examples
+cd "${ROOT_DIR}"/tensorflow/lite/micro/tools/make/gen/esp_xtensa-esp32/prj/hello_world/esp-idf
+readable_run idf.py build
+
+cd "${ROOT_DIR}"/tensorflow/lite/micro/tools/make/gen/esp_xtensa-esp32/prj/person_detection/esp-idf
+readable_run git clone https://github.com/espressif/esp32-camera.git components/esp32-camera
+cd components/esp32-camera/
+readable_run git checkout eacd640b8d379883bff1251a1005ebf3cf1ed95c
+cd ../../
+readable_run idf.py build
+
+cd "${ROOT_DIR}"/tensorflow/lite/micro/tools/make/gen/esp_xtensa-esp32/prj/micro_speech/esp-idf
+readable_run idf.py build


### PR DESCRIPTION
Following examples will be generated and built for ESP32 platform
1. hello_world
2. person_detection
3. micro_speech

Just the builds are tested for now

Addresses https://github.com/tensorflow/tensorflow/issues/43450

This change adds a script for ESP32 but does not enable it as part of the Tensorflow CI. Enabling a continuous build and a build badge will be a separate change.