### PR TITLE
Introduce MHLO_BUILD_EMBEDDED build option

### DIFF
--- a/tensorflow/compiler/mlir/hlo/CMakeLists.txt
+++ b/tensorflow/compiler/mlir/hlo/CMakeLists.txt
@@ -59,9 +59,9 @@ endif()
 # MLIR/LLVM Configuration
 #-------------------------------------------------------------------------------
 
-# Skip to find MLIR, which allows to build MHLO as part of another project.
-# This is necessary if the project which embeds MHLO uses a bundled version of
-# MLIR and does not use an installed version of MLIR.
+# Find MLIR to install if we are building standalone. If building as part of
+# another project, let it handle the MLIR dependency. The dependent project
+# might use a bundled version of MLIR instead of installing, for instance.
 if(NOT MHLO_BUILD_EMBEDDED)
   find_package(MLIR REQUIRED CONFIG)
   message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")

--- a/tensorflow/compiler/mlir/hlo/CMakeLists.txt
+++ b/tensorflow/compiler/mlir/hlo/CMakeLists.txt
@@ -41,6 +41,8 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 # Options and settings
 #-------------------------------------------------------------------------------
 
+option(MHLO_BUILD_EMBEDDED "Build MHLO as part of another project" OFF)
+
 #-------------------------------------------------------------------------------
 # MSVC defaults
 #-------------------------------------------------------------------------------
@@ -57,11 +59,16 @@ endif()
 # MLIR/LLVM Configuration
 #-------------------------------------------------------------------------------
 
-find_package(MLIR REQUIRED CONFIG)
-message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
-message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
-list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
-list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
+# Skip to find MLIR, which allows to build MHLO as part of another project.
+# This is necessary if the project which embeds MHLO uses a bundled version of
+# MLIR and does not use an installed version of MLIR.
+if(NOT MHLO_BUILD_EMBEDDED)
+  find_package(MLIR REQUIRED CONFIG)
+  message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
+  message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+  list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
+  list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
+endif()
 
 if(LLVM_ENABLE_ZLIB)
   find_package(ZLIB)


### PR DESCRIPTION
This option allows to skip calling `find_package(MLIR)`, enabling to
embed MHLO into other project, e.g. IREE.