### PR TITLE
Specialize sources for target and optimized kernels independently.

### DIFF
--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -42,6 +42,16 @@ CXX_TOOL := g++
 CC_TOOL := gcc
 AR_TOOL := ar
 
+# Specify which specialized kernel implementation should be pulled in. This was
+# previously supported via TAGS, but that is soon going to be removed. The
+# reason for removing TAGS is that we no longer support more than a single
+# specialized implementation and we also want to be explicit about what
+# makefiles get included for a given command line invocation.
+#
+# Currently, we are keeping the support for optimized kernels via TAGS for
+# backwards compatibility, but will be removing that in the near future.
+OPTIMIZED_KERNEL_DIR :=
+
 # Specify TAGS on the command line to add a particular set of specialized
 # implementations, for example TAGS="CMSIS disco_f746ng" to target a Discovery
 # STM32F746NG board, using the CMSIS library's implementations where possible.
@@ -74,7 +84,6 @@ TEST_SCRIPT := tensorflow/lite/micro/testing/test_linux_binary.sh
 
 MICROLITE_LIBS := -lm
 
-
 # For each tag specified on the command line we add -D<tag> to the cflags to
 # allow for #idefs in the code.
 #
@@ -87,6 +96,17 @@ MICROLITE_LIBS := -lm
 # TODO(b/168824958): remove dash->underscore transformation once the cmsis-nn
 # and ethos-u directories have been renamed.
 TAG_DEFINES := $(foreach TAG,$(TAGS),-D$(shell echo $(TAG) | tr [a-z] [A-Z] | tr - _))
+
+OPTIMIZED_KERNEL_DEFINES :=
+ifneq ($(OPTIMIZED_KERNEL_DIR),)
+  # For backwards compatibility, we are using an empty OPTIMIZED_KERNEL_DIR to
+  # impy that we want to fall-back to TAGS. So, we are additionally using
+  # OPTIMIZED_KERNEL_DIR==none to signify that we do not want any optimized
+  # implementations.
+  ifneq ($(OPTIMIZED_KERNEL_DIR), none)
+    OPTIMIZED_KERNEL_DEFINES := -D$(shell echo $(OPTIMIZED_KERNEL_DIR) | tr [a-z] [A-Z] | tr - _)
+  endif
+endif
 
 OPTIMIZATION_LEVEL := -O3
 
@@ -114,6 +134,7 @@ COMMON_FLAGS := \
   -DTF_LITE_DISABLE_X86_NEON \
   $(OPTIMIZATION_LEVEL) \
   $(CC_WARNINGS) \
+  $(OPTIMIZED_KERNEL_DEFINES) \
   $(TAG_DEFINES)
 
 CXXFLAGS := \
@@ -215,13 +236,16 @@ $(wildcard tensorflow/lite/micro/memory_planner/*test.cc)
 MICROLITE_BENCHMARK_SRCS := \
 $(wildcard tensorflow/lite/micro/benchmarks/*benchmark.cc)
 
+MICROLITE_CC_KERNEL_SRCS := \
+$(wildcard tensorflow/lite/micro/kernels/*.cc)
+MICROLITE_CC_KERNEL_SRCS := $(filter-out $(MICROLITE_TEST_SRCS), $(MICROLITE_CC_KERNEL_SRCS))
+
 MICROLITE_TEST_HDRS := \
 $(wildcard tensorflow/lite/micro/testing/*.h)
 
 MICROLITE_CC_BASE_SRCS := \
 $(wildcard tensorflow/lite/micro/*.cc) \
 $(wildcard tensorflow/lite/micro/benchmarks/*model_data.cc) \
-$(wildcard tensorflow/lite/micro/kernels/*.cc) \
 $(wildcard tensorflow/lite/micro/memory_planner/*.cc) \
 $(wildcard tensorflow/lite/micro/testing/*model.cc) \
 tensorflow/lite/c/common.c \
@@ -377,11 +401,30 @@ ifeq ($(findstring $(TARGET),$(TARGETS_WITHOUT_MAKEFILES)),)
   include $(MAKEFILE_DIR)/targets/$(TARGET)_makefile.inc
 endif
 
-# Load dependencies for optimized kernel implementations.
-include $(wildcard $(MAKEFILE_DIR)/ext_libs/*.inc)
+ifneq ($(OPTIMIZED_KERNEL_DIR),)
+  # The new way of using optimized kernels enforces that only that specific
+  # makefile is included. For backwards compatibility, we are using an empty
+  # OPTIMIZED_KERNEL_DIR to impy that we want to fall-back to TAGS. So, we are
+  # additionally using OPTIMIZED_KERNEL_DIR==none to signify that we do not want
+  # any optimized implementations.
+  ifneq ($(OPTIMIZED_KERNEL_DIR), none)
+    include $(MAKEFILE_DIR)/ext_libs/$(OPTIMIZED_KERNEL_DIR).inc
+    # Specialize for the optimized kernels
+    MICROLITE_CC_KERNEL_SRCS := $(call substitute_specialized_implementations,$(MICROLITE_CC_KERNEL_SRCS),$(OPTIMIZED_KERNEL_DIR))
+  endif
 
-# Call specialize here so that platform-specific tags can be taken into account.
-MICROLITE_CC_SRCS := $(call specialize,$(MICROLITE_CC_SRCS))
+  # Specialize for debug_log. micro_time etc.
+  MICROLITE_CC_SRCS := $(call substitute_specialized_implementations,$(MICROLITE_CC_SRCS),$(TARGET))
+  MICROLITE_CC_SRCS += $(MICROLITE_CC_KERNEL_SRCS)
+else
+  # This is the deprecated way of pulling in optimized kernel implementations.
+  # Load dependencies for optimized kernel implementations.
+  include $(wildcard $(MAKEFILE_DIR)/ext_libs/*.inc)
+
+  # Call specialize here so that platform-specific tags can be taken into account.
+  MICROLITE_CC_SRCS += $(MICROLITE_CC_KERNEL_SRCS)
+  MICROLITE_CC_SRCS := $(call specialize,$(MICROLITE_CC_SRCS))
+endif
 
 ALL_TAGS += $(TARGET_ARCH)
 

--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa_hifimini.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa_hifimini.inc
@@ -1,0 +1,4 @@
+# Every optimized kernel implementation directory (i.e.
+# micro/kernels/<optimized_kernel_dir>/ must have a corresponding
+# micro/tools/make/ext_libs/<optimized_kernel_dir>.inc
+

--- a/tensorflow/lite/micro/tools/make/helper_functions.inc
+++ b/tensorflow/lite/micro/tools/make/helper_functions.inc
@@ -37,6 +37,7 @@ substitute_specialized_implementation = \
   $(if $(wildcard $(1)),$(firstword $(wildcard $(dir $(1))$(2)/$(notdir $(1))) $(wildcard $(1))),$(1))
 substitute_specialized_implementations = \
   $(foreach source,$(1),$(call substitute_specialized_implementation,$(source),$(2)))
+
 # Here we're first looking for specialized implementations in ref_dir/$(TAG1)
 # and then ref_dir/$(TAG2), etc, before falling back to ref_dir's
 # implementation.
@@ -45,6 +46,7 @@ substitute_specialized_implementations = \
 define specialize_on_tags
 $(if $(2),$(call substitute_specialized_implementations,$(call specialize_on_tags,$(1),$(wordlist 2,$(words $(2)),$(2))),$(firstword $(2))),$(1))
 endef
+
 # The entry point that most targets should use to find implementation-specific
 # versions of their source files. The only argument is a list of file paths.
 specialize = $(call specialize_on_tags,$(1),$(strip $(call reverse,$(ALL_TAGS))))


### PR DESCRIPTION
This change:
 * adds a new command line option to the makefile called OPTIMIZED_KERNEL_DIR which should be used instead of TAGS

 * TAGS is currently supported for backwards compatibility and a gradual roll-out but will be dropped (for optimized kernels) in follow-up changes.

 * Makes the necessary change to use OPTIMIZED_KERNEL_DIR for xtensa_hifimini.

First step towards #44566
Fixes internal bug: http://b/160795217
Addresses internal bug: http://b/170501366

Tested the keyword_benchmark with different combinations command line options.

We used this command
```
make -f tensorflow/lite/micro/tools/make/Makefile -j8 TARGET=xtensa_hifimini  XTENSA_CORE=<core> test_keyword_benchmark
```
along with these additional options:
|   options                | InitializeKeywordRunner | KeywordRunNIerations(1) | KeywordRunNIerations(10) |
|        ------------------ | ---------------------- | ------------------------- | ------------------------- |
(on master) <br> `TAGS=xtensa_hifimini`        | 1389000 | 89318 | 892739 |
`TAGS=xtensa_hifimini`                                    | 1389056 | 89318 | 892739 |
`OPTIMIZED_KERNEL_DIR=xtensa_hifimini` | 1389056 | 89318 | 892739 |
`OPTIMIZED_KERNEL_DIR=none`                 |  226514| 1010031 | 10088115 |

The table is showing that:
 * we support `TAGS=xtensa_hifimini` as well as `OPTIMIZED_KERNEL_DIR=xtensa_hifimini` to pull in the optimized implementations.
 * `OPTIMIZED_KERNEL_DIR=none` uses the reference kernels.
 * There is a difference of 56 cycles in the initialization with and without this change (first two lines of the table). This can be chalked up to some small difference in how a potentially difference sequence of object files is handled.

We also see a small difference in the binary size:
```
 xt-size tensorflow/lite/micro/tools/make/gen/xtensa_hifimini_xtensa_hifimini/bin/keyword_benchmark
```
On master:
```
   text	   data	    bss	    dec
  54864	  48680	  25032	 128576
```

With this change (and either `TAGS=xtensa_hifimini` or `OPTIMIZED_KERNEL_DIR=xtensa_hifimini`):
```
   text	   data	    bss	    dec
  54864	  48664	  25032	 128560	
```