### PR TITLE
r2.4-rc1 cherry-pick request: [Intel MKL] Prevent unnecessary copies of oneDNN in .so files.

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -129,7 +129,6 @@ load("@local_config_tensorrt//:build_defs.bzl", "if_tensorrt")
 load(
     "//third_party/mkl:build_defs.bzl",
     "if_mkl",
-    "mkl_deps",
 )
 
 package(
@@ -1722,7 +1721,7 @@ tf_cuda_library(
     ] + if_static(
         extra_deps = ["@com_google_protobuf//:protobuf"],
         otherwise = ["@com_google_protobuf//:protobuf_headers"],
-    ) + mkl_deps(),
+    ),
     alwayslink = 1,
 )
 

--- a/tensorflow/core/grappler/optimizers/BUILD
+++ b/tensorflow/core/grappler/optimizers/BUILD
@@ -12,10 +12,6 @@ load(
     "//tensorflow/core/platform:build_config_root.bzl",
     "if_static",
 )
-load(
-    "//third_party/mkl:build_defs.bzl",
-    "mkl_deps",
-)
 
 package(
     licenses = ["notice"],  # Apache 2.0
@@ -638,7 +634,7 @@ cc_library(
         "//tensorflow/core/grappler/costs:virtual_placer",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
-    ] + mkl_deps(),
+    ],
 )
 
 tf_cuda_cc_test(

--- a/tensorflow/core/util/BUILD
+++ b/tensorflow/core/util/BUILD
@@ -26,10 +26,6 @@ load("//tensorflow:tensorflow.bzl", "get_compatible_with_portable")
 # buildifier: disable=same-origin-load
 load("//tensorflow:tensorflow.bzl", "tf_version_info_genrule")
 load(
-    "//third_party/mkl:build_defs.bzl",
-    "mkl_deps",
-)
-load(
     "//tensorflow/core/platform:build_config_root.bzl",
     "if_static",
 )
@@ -707,7 +703,7 @@ tf_cuda_only_cc_test(
         "//tensorflow/core:test",
         "//tensorflow/core:test_main",
         "//third_party/eigen3",
-    ] + mkl_deps(),
+    ],
 )
 
 tf_cc_tests(

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -39,7 +39,6 @@ load(
     "if_enable_mkl",
     "if_mkl",
     "if_mkl_ml",
-    "mkl_deps",
 )
 load(
     "//third_party/mkl_dnn:build_defs.bzl",
@@ -1270,7 +1269,7 @@ def tf_cc_test_mkl(
                     "-lm",
                 ],
             }) + _rpath_linkopts(src_to_test_name(src)),
-            deps = deps + tf_binary_dynamic_kernel_deps(kernels) + mkl_deps(),
+            deps = deps + tf_binary_dynamic_kernel_deps(kernels) + if_mkl_ml(["//third_party/mkl:intel_binary_blob"]),
             data = data + tf_binary_dynamic_kernel_dsos(),
             exec_properties = tf_exec_properties({"tags": tags}),
             linkstatic = linkstatic,
@@ -2677,7 +2676,7 @@ def tf_python_pybind_extension(
         features = features,
         copts = copts,
         hdrs = hdrs,
-        deps = deps + tf_binary_pybind_deps() + mkl_deps(),
+        deps = deps + tf_binary_pybind_deps() + if_mkl_ml(["//third_party/mkl:intel_binary_blob"]),
         defines = defines,
         visibility = visibility,
         link_in_framework = True,


### PR DESCRIPTION
Original PR: #44629 

oneDNN was getting statically linked to all the .so created by TF, thereby increasing the installation significantly. Removed redundant dependencies of oneDNN. Also, in a few places the dependency was only with libiomp.so and not oneDNN, made appropriate changes to address it.