### PR TITLE
let huber loss return the same dtype as inputs

### DIFF
--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -1443,9 +1443,9 @@ def huber(y_true, y_pred, delta=1.0):
   Returns:
     Tensor with one scalar loss entry per sample.
   """
-  y_pred = math_ops.cast(y_pred, dtype=K.floatx())
-  y_true = math_ops.cast(y_true, dtype=K.floatx())
-  delta = math_ops.cast(delta, dtype=K.floatx())
+  y_pred = ops.convert_to_tensor_v2_with_dispatch(y_pred)
+  y_true = math_ops.cast(y_true, dtype=y_pred.dtype)
+  delta = ops.convert_to_tensor_v2_with_dispatch(delta, dtype=y_pred.dtype)
   error = math_ops.subtract(y_pred, y_true)
   abs_error = math_ops.abs(error)
   half = ops.convert_to_tensor_v2_with_dispatch(0.5, dtype=abs_error.dtype)


### PR DESCRIPTION
I suggest changing https://github.com/tensorflow/tensorflow/blob/b3c4b50fa70868a2da709cb7868822e5361a50e4/tensorflow/python/keras/losses.py#L1529 to y_true.dtype too.
IMO:
1. It's annoyed when I run ```tf.keras.losses.categorical_crossentropy(tf.constant([[0, 1, 0], [0, 0, 1]], tf.float16), tf.constant([[0.05, 0.95, 0], [0.1, 0.8, 0.1]], tf.float16), label_smoothing=0.1)```, then I got dtype mismatch bug.
The result's dtype should depend on inputs.
2. Is it tf.keras.backend.set_xxx is going to be abandoned?