### PR TITLE
Go: make ReadTensor return error for shapes with negative dimention

### DIFF
--- a/tensorflow/go/tensor.go
+++ b/tensorflow/go/tensor.go
@@ -168,11 +168,18 @@ func ReadTensor(dataType DataType, shape []int64, r io.Reader) (*Tensor, error) 
 	if err := isTensorSerializable(dataType); err != nil {
 		return nil, err
 	}
-	nbytes := TypeOf(dataType, nil).Size() * uintptr(numElements(shape))
+
 	var shapePtr *C.int64_t
 	if len(shape) > 0 {
+		for _, dim := range shape {
+			if dim < 0 {
+				return nil, fmt.Errorf("all shape dimentions should be non-negative: %v", shape)
+			}
+		}
 		shapePtr = (*C.int64_t)(unsafe.Pointer(&shape[0]))
 	}
+
+	nbytes := TypeOf(dataType, nil).Size() * uintptr(numElements(shape))
 	t := &Tensor{
 		c:     C.TF_AllocateTensor(C.TF_DataType(dataType), shapePtr, C.int(len(shape)), C.size_t(nbytes)),
 		shape: shape,

--- a/tensorflow/go/tensor_test.go
+++ b/tensorflow/go/tensor_test.go
@@ -276,6 +276,14 @@ func TestReadTensorReadAll(t *testing.T) {
 	}
 }
 
+func TestReadTensorNegativeDimention(t *testing.T) {
+	buf := new(bytes.Buffer)
+	_, err := ReadTensor(Int32, []int64{-1, 1}, buf)
+	if err == nil {
+		t.Fatal("ReadTensor should failed if shape contains negative dimention")
+	}
+}
+
 func benchmarkNewTensor(b *testing.B, v interface{}) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
This PR fixes `SIGABRT: abort` when shape with negative dimension is passed to `ReadTensor` function
