### PR TITLE
[INTEL MKL] Bug fix to duplicate kernel registration of BatchMatMulV2.

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_tmp_bf16_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_tmp_bf16_ops.cc
@@ -56,9 +56,7 @@ namespace tensorflow {
                               .TypeConstraint<float>("U"),                    \
                           NoOp);                                              \
   REGISTER_KERNEL_BUILDER(                                                    \
-      Name("_FusedMatMul").Device(DEVICE_CPU).TypeConstraint<T>("T"), NoOp);  \
-  REGISTER_KERNEL_BUILDER(                                                    \
-      Name("BatchMatMulV2").Device(DEVICE_CPU).TypeConstraint<T>("T"), NoOp);
+      Name("_FusedMatMul").Device(DEVICE_CPU).TypeConstraint<T>("T"), NoOp);
 
 TF_CALL_bfloat16(REGISTER_CPU);
 #undef REGISTER_CPU


### PR DESCRIPTION
The PR fixes duplicate kernel registration of BatchMatMulV2 on CPU device with bfloat16 data type.