### PR TITLE
[keras/optimizer_v2/ftrl.py] Reflect defaults in docstring

### DIFF
--- a/tensorflow/python/keras/optimizer_v2/ftrl.py
+++ b/tensorflow/python/keras/optimizer_v2/ftrl.py
@@ -64,16 +64,16 @@ class Ftrl(optimizer_v2.OptimizerV2):
     initial_accumulator_value: The starting value for accumulators.
       Only zero or positive values are allowed.
     l1_regularization_strength: A float value, must be greater than or
-      equal to zero.
+      equal to zero. Defaults to 0.0.
     l2_regularization_strength: A float value, must be greater than or
-      equal to zero.
+      equal to zero. Defaults to 0.0.
     name: Optional name prefix for the operations created when applying
       gradients.  Defaults to `"Ftrl"`.
     l2_shrinkage_regularization_strength: A float value, must be greater than
       or equal to zero. This differs from L2 above in that the L2 above is a
       stabilization penalty, whereas this L2 shrinkage is a magnitude penalty.
       When input is sparse shrinkage will only happen on the active weights.
-    beta: A float value, representing the beta value from the paper.
+    beta: A float value, representing the beta value from the paper. Defaults to 0.0.
     **kwargs: Keyword arguments. Allowed to be one of
       `"clipnorm"` or `"clipvalue"`.
       `"clipnorm"` (float) clips gradients by norm; `"clipvalue"` (float) clips

--- a/tensorflow/python/keras/optimizer_v2/ftrl.py
+++ b/tensorflow/python/keras/optimizer_v2/ftrl.py
@@ -73,7 +73,8 @@ class Ftrl(optimizer_v2.OptimizerV2):
       or equal to zero. This differs from L2 above in that the L2 above is a
       stabilization penalty, whereas this L2 shrinkage is a magnitude penalty.
       When input is sparse shrinkage will only happen on the active weights.
-    beta: A float value, representing the beta value from the paper. Defaults to 0.0.
+    beta: A float value, representing the beta value from the paper.
+      Defaults to 0.0.
     **kwargs: Keyword arguments. Allowed to be one of
       `"clipnorm"` or `"clipvalue"`.
       `"clipnorm"` (float) clips gradients by norm; `"clipvalue"` (float) clips


### PR DESCRIPTION
I'm writing an open-source typed wrapped for TensorFlow [and other ML frameworks], to enable good errors; parameter optimisation and analysis; over other interfaces like CLI, GUIs and decoupled frontends, databases, RPC, and REST.

The docstrings must reflect the defaults in the `__init__` function, otherwise I'll need to extend my side to parse & merge the defaults—e.g., from [`inspect.Signature`](https://docs.python.org/3/library/inspect.html#inspect.signature) or from [`ast`](https://docs.python.org/3/library/ast.html)—with the `class`'s docstring.

So this'll probably be the first of many trivial change PRs I'll be sending over :+1: 