### PR TITLE
Expose Logging C API in pip package

### DIFF
--- a/tensorflow/c/BUILD
+++ b/tensorflow/c/BUILD
@@ -199,6 +199,7 @@ tf_cuda_library(
             "//tensorflow/core:portable_tensorflow_lib_lite",
         ],
         "//conditions:default": [
+            ":logging",
             ":tf_status",
             ":tf_tensor",
             "@com_google_absl//absl/strings",


### PR DESCRIPTION
While working on modular file systems, noticed that the logging
C API headers are not included in tensorflow pip packages.

This limit the ability for plugins to add logging in the file system.

This PR adds logging C API header in pip package.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>