### PR TITLE
[ROCm] MLIR-unranked kernels with ROCm

### DIFF
--- a/tensorflow/compiler/mlir/tools/kernel_gen/BUILD
+++ b/tensorflow/compiler/mlir/tools/kernel_gen/BUILD
@@ -167,6 +167,15 @@ cc_library(
 )
 
 cc_library(
+    name = "tf_gpu_runtime_wrappers",
+    deps = if_cuda_is_configured([
+        ":tf_cuda_runtime_wrappers",
+    ]) + if_rocm_is_configured([
+        ":tf_rocm_runtime_wrappers",
+    ]),
+)
+
+cc_library(
     name = "tf_cuda_runtime_wrappers",
     srcs = ["tf_cuda_runtime_wrappers.cc"],
     compatible_with = get_compatible_with_cloud(),
@@ -176,5 +185,18 @@ cc_library(
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:mlir_c_runner_utils",
         "@local_config_cuda//cuda:cuda_headers",
+    ],
+)
+
+cc_library(
+    name = "tf_rocm_runtime_wrappers",
+    srcs = ["tf_rocm_runtime_wrappers.cc"],
+    compatible_with = get_compatible_with_cloud(),
+    copts = if_rocm_is_configured(["-DTENSORFLOW_USE_ROCM=1"]),
+    deps = [
+        "//tensorflow/core/platform/default/build_config:stream_executor_rocm",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:mlir_c_runner_utils",
+        "@local_config_rocm//rocm:rocm_headers",
     ],
 )

--- a/tensorflow/compiler/mlir/tools/kernel_gen/tf_rocm_runtime_wrappers.cc
+++ b/tensorflow/compiler/mlir/tools/kernel_gen/tf_rocm_runtime_wrappers.cc
@@ -1,0 +1,114 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Implements C wrappers around the ROCm library for easy linking in ORC jit.
+// Also adds some debugging helpers that are helpful when writing MLIR code to
+// run on GPUs.
+
+#include <cassert>
+#include <numeric>
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/raw_ostream.h"
+#include "mlir/ExecutionEngine/CRunnerUtils.h"  // from @llvm-project
+
+#if TENSORFLOW_USE_ROCM
+#include "rocm/include/hip/hip_runtime.h"
+
+#define HIP_REPORT_IF_ERROR(expr)                                       \
+  [](hipError_t result) {                                               \
+    if (!result) return;                                                \
+    const char* name = hipGetErrorName(result);                         \
+    if (!name) name = "<unknown>";                                      \
+    llvm::errs() << "'" << #expr << "' failed with '" << name << "'\n"; \
+  }(expr)
+
+extern "C" hipModule_t mgpuModuleLoad(void* data) {
+  hipModule_t module = nullptr;
+  HIP_REPORT_IF_ERROR(hipModuleLoadData(&module, data));
+  return module;
+}
+
+extern "C" void mgpuModuleUnload(hipModule_t module) {
+  HIP_REPORT_IF_ERROR(hipModuleUnload(module));
+}
+
+extern "C" hipFunction_t mgpuModuleGetFunction(hipModule_t module,
+                                               const char* name) {
+  hipFunction_t function = nullptr;
+  HIP_REPORT_IF_ERROR(hipModuleGetFunction(&function, module, name));
+  return function;
+}
+
+// The wrapper uses intptr_t instead of CUDA's unsigned int to match
+// the type of MLIR's index type. This avoids the need for casts in the
+// generated MLIR code.
+extern "C" void mgpuLaunchKernel(hipFunction_t function, intptr_t gridX,
+                                 intptr_t gridY, intptr_t gridZ,
+                                 intptr_t blockX, intptr_t blockY,
+                                 intptr_t blockZ, int32_t smem,
+                                 hipStream_t stream, void** params,
+                                 void** extra) {
+  HIP_REPORT_IF_ERROR(hipModuleLaunchKernel(function, gridX, gridY, gridZ,
+                                            blockX, blockY, blockZ, smem,
+                                            stream, params, extra));
+}
+
+extern "C" hipStream_t mgpuStreamCreate() {
+  hipStream_t stream = nullptr;
+  HIP_REPORT_IF_ERROR(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
+  return stream;
+}
+
+extern "C" void mgpuStreamDestroy(hipStream_t stream) {
+  HIP_REPORT_IF_ERROR(hipStreamDestroy(stream));
+}
+
+extern "C" void mgpuStreamSynchronize(hipStream_t stream) {
+  HIP_REPORT_IF_ERROR(hipStreamSynchronize(stream));
+}
+
+/// Helper functions for writing mlir example code
+
+// Allows to register byte array with the CUDA runtime. Helpful until we have
+// transfer functions implemented.
+extern "C" void mgpuMemHostRegister(void* ptr, uint64_t sizeBytes) {
+  HIP_REPORT_IF_ERROR(hipHostRegister(ptr, sizeBytes, /*flags=*/0));
+}
+
+// Allows to register a MemRef with the ROCm runtime. Helpful until we have
+// transfer functions implemented.
+extern "C" void mgpuMemHostRegisterMemRef(
+    int64_t rank, StridedMemRefType<char, 1>* descriptor,
+    int64_t elementSizeBytes) {
+  llvm::SmallVector<int64_t, 4> denseStrides(rank);
+  llvm::ArrayRef<int64_t> sizes(descriptor->sizes, rank);
+  llvm::ArrayRef<int64_t> strides(sizes.end(), rank);
+
+  std::partial_sum(sizes.rbegin(), sizes.rend(), denseStrides.rbegin(),
+                   std::multiplies<int64_t>());
+  auto sizeBytes = denseStrides.front() * elementSizeBytes;
+
+  // Only densely packed tensors are currently supported.
+  std::rotate(denseStrides.begin(), denseStrides.begin() + 1,
+              denseStrides.end());
+  denseStrides.back() = 1;
+  assert(strides == llvm::makeArrayRef(denseStrides));
+
+  auto ptr = descriptor->data + descriptor->offset * elementSizeBytes;
+  mgpuMemHostRegister(ptr, sizeBytes);
+}
+
+#endif  // TENSORFLOW_USE_ROCM

--- a/tensorflow/compiler/mlir/tools/kernel_gen/transforms/BUILD
+++ b/tensorflow/compiler/mlir/tools/kernel_gen/transforms/BUILD
@@ -131,6 +131,7 @@ cc_library(
     ] + if_cuda_is_configured([
         "//tensorflow/stream_executor/gpu:asm_compiler",
     ]) + if_rocm_is_configured([
+        "//tensorflow/stream_executor/gpu:asm_compiler",
         "//tensorflow/core/platform:rocm_rocdl_path",
     ]),
 )

--- a/tensorflow/compiler/mlir/tools/kernel_gen/transforms/gpu_kernel_to_blob_pass.cc
+++ b/tensorflow/compiler/mlir/tools/kernel_gen/transforms/gpu_kernel_to_blob_pass.cc
@@ -35,6 +35,7 @@ limitations under the License.
 #include "tensorflow/stream_executor/gpu/asm_compiler.h"
 #elif TENSORFLOW_USE_ROCM
 #include "tensorflow/core/platform/rocm_rocdl_path.h"
+#include "tensorflow/stream_executor/gpu/asm_compiler.h"
 #endif
 
 namespace mlir {
@@ -95,25 +96,42 @@ class GpuKernelToBlobPass
     xla::HloModuleConfig config;
     config.set_debug_options(xla::GetDebugOptionsFromFlags());
 
-    // TODO(b/169066682): Support fatbin on ROCm.
-    if (generate_fatbin_) {
-      return InternalError("Fatbins are not yet supported for ROCm.");
+    using AmdGpuHsaco = std::vector<tensorflow::uint8>;
+    std::vector<tensorflow::se::HsacoImage> images;
+    for (const std::string& arch_str : architectures_) {
+      // Parse ROCm architecture.
+      absl::string_view consumable_arch(arch_str);
+      if (!absl::ConsumePrefix(&consumable_arch, "gfx")) {
+        return InternalError(
+            "Could not parse ROCm architecture prefix (expected gfx)");
+      }
+      uint32_t arch;
+      if (!absl::SimpleAtoi(consumable_arch, &arch)) {
+        return InternalError("Could not parse ROCm architecture number");
+      }
+
+      std::string libdevice_dir = tensorflow::RocdlRoot();
+      auto llvm_module_copy = llvm::CloneModule(*llvmModule);
+      auto hsaco_or = xla::gpu::amdgpu::CompileToHsaco(
+          llvm_module_copy.get(), arch, config, libdevice_dir);
+      if (!hsaco_or.ok()) {
+        return InternalError("Failure when generating HSACO");
+      }
+
+      auto hsaco = hsaco_or.ValueOrDie();
+      if (!generate_fatbin_) {
+        // Skip fatbin generation and return the first and only GPU machine
+        // code. This is currently only used for `tf_to_gpu_binary` and will
+        // eventually disappear.
+        return hsaco;
+      }
+
+      images.push_back({arch_str, std::move(hsaco)});
     }
 
-    // Parse ROCm architecture.
-    absl::string_view consumable_arch(architectures_.front());
-    if (!absl::ConsumePrefix(&consumable_arch, "gfx")) {
-      return InternalError(
-          "Could not parse ROCm architecture prefix (expected gfx)");
-    }
-    uint32_t arch;
-    if (!absl::SimpleAtoi(consumable_arch, &arch)) {
-      return InternalError("Could not parse ROCm architecture number");
-    }
-
-    std::string libdevice_dir = tensorflow::RocdlRoot();
-    return xla::gpu::amdgpu::CompileToHsaco(llvmModule.get(), arch, config,
-                                            libdevice_dir);
+    // TODO(b/169870789): Revisit the use of fatbins.
+    // Bundle HSACO images into a single fatbin.
+    return tensorflow::se::BundleGpuAsm(images, tensorflow::RocmRoot());
 
 #elif GOOGLE_CUDA
     auto llvmModule = mlir::translateModuleToNVVMIR(gpu_module, llvmContext);

--- a/tensorflow/core/kernels/mlir_generated/BUILD
+++ b/tensorflow/core/kernels/mlir_generated/BUILD
@@ -61,6 +61,18 @@ filegroup(
     ),
 )
 
+filegroup(
+    name = "binary_kernel_srcs",
+    srcs = if_mlir_unranked_kernels_enabled(
+        [
+            "unranked_gpu_add.cc",
+            "unranked_op_gpu_base.h",
+            "unranked_op_gpu_base.cc",
+        ],
+        [],
+    ),
+)
+
 cc_library(
     name = "unranked_kernel_deps",
     deps =
@@ -124,11 +136,8 @@ tf_kernel_library(
     name = "cwise_binary_op",
     # Technically these source files don't need --config=cuda or --config=rocm,
     # but we want to avoid building them if they are not needed.
-    srcs = if_cuda_or_rocm(["unranked_gpu_add.cc"]),
-    tags = [
-        "manual",
-        "no_rocm",
-    ],
+    srcs = if_cuda_or_rocm([":binary_kernel_srcs"]),
+    tags = ["manual"],
     deps = if_cuda_or_rocm([
         ":unranked_kernel_deps",
         "@com_google_absl//absl/strings",

--- a/tensorflow/core/kernels/mlir_generated/BUILD
+++ b/tensorflow/core/kernels/mlir_generated/BUILD
@@ -75,8 +75,8 @@ cc_library(
             ":rsqrt_unranked_kernels",
             ":sqrt_unranked_kernels",
             ":tanh_unranked_kernels",
-            "//tensorflow/compiler/mlir/tools/kernel_gen:tf_cuda_runtime_wrappers",
             "//tensorflow/compiler/mlir/tools/kernel_gen:tf_framework_c_interface",
+            "//tensorflow/compiler/mlir/tools/kernel_gen:tf_gpu_runtime_wrappers",
         ],
 )
 
@@ -106,7 +106,6 @@ tf_kernel_library(
     # Technically these source files don't need --config=cuda or --config=rocm,
     # but we want to avoid building them if they are not needed.
     srcs = if_cuda_or_rocm([":unary_kernel_srcs"]),
-    tags = ["no_rocm"],
     deps = if_cuda_or_rocm(
         [
             ":kernel_deps",

--- a/tensorflow/core/kernels/mlir_generated/build_defs.bzl
+++ b/tensorflow/core/kernels/mlir_generated/build_defs.bzl
@@ -339,7 +339,7 @@ def gen_unranked_kernel_library(name, types, tile_size, tags = [], unroll_factor
       extra_args: Extra arguments to pass to the generator tool.
     """
 
-    if cuda_gpu_architectures():
+    if cuda_gpu_architectures() or rocm_gpu_architectures():
         for type in types:
             _gen_mlir_op(
                 name = name,
@@ -350,7 +350,7 @@ def gen_unranked_kernel_library(name, types, tile_size, tags = [], unroll_factor
                 name = "{name}_{type}_kernel_generator".format(name = name, type = type),
                 mlir_op = "{name}_{type}.mlir".format(name = name, type = type),
                 output = "{name}_{type}.a".format(name = name, type = type),
-                gpu_archs = cuda_gpu_architectures(),
+                gpu_archs = rocm_gpu_architectures() if rocm_is_configured() else cuda_gpu_architectures(),
                 tile_size = tile_size,
                 unroll_factors = unroll_factors,
                 extra_args = extra_args,
@@ -362,7 +362,7 @@ def gen_unranked_kernel_library(name, types, tile_size, tags = [], unroll_factor
 
     native.cc_library(
         name = name + "_kernels",
-        deps = if_cuda_is_configured([":{name}_{type}_kernel".format(name = name, type = type) for type in types]),
+        deps = if_gpu_is_configured([":{name}_{type}_kernel".format(name = name, type = type) for type in types]),
         linkstatic = 1,
         tags = tags,
     )

--- a/tensorflow/core/kernels/mlir_generated/unranked_op_gpu_base.h
+++ b/tensorflow/core/kernels/mlir_generated/unranked_op_gpu_base.h
@@ -16,8 +16,8 @@ limitations under the License.
 #ifndef TENSORFLOW_CORE_KERNELS_MLIR_GENERATED_UNRANKED_OP_GPU_ABS_H_
 #define TENSORFLOW_CORE_KERNELS_MLIR_GENERATED_UNRANKED_OP_GPU_ABS_H_
 
-#include "third_party/llvm/llvm-project/llvm/include/llvm/ADT/ArrayRef.h"
-#include "third_party/llvm/llvm-project/llvm/include/llvm/ADT/SmallVector.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
 #include "mlir/ExecutionEngine/CRunnerUtils.h"  // from @llvm-project
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/op_requires.h"

--- a/tensorflow/stream_executor/gpu/asm_compiler.cc
+++ b/tensorflow/stream_executor/gpu/asm_compiler.cc
@@ -331,14 +331,14 @@ port::StatusOr<std::vector<uint8>> BundleGpuAsm(
   return std::vector<uint8>(result_blob.begin(), result_blob.end());
 }
 
-static std::string findRocmExecutable(const std::string binary_relative_path,
-                                      const std::string rocm_root_dir) {
+static std::string findRocmExecutable(const std::string& binary_relative_path,
+                                      const std::string& rocm_root_dir) {
   auto env = tensorflow::Env::Default();
   std::string binary_path =
       tensorflow::io::JoinPath(rocm_root_dir, binary_relative_path);
   VLOG(2) << "Looking for " << binary_relative_path << " at " << rocm_root_dir;
   if (!env->FileExists(binary_path).ok()) {
-    binary_path = "<" + binary_path + " - NOT FOUND>";
+    binary_path = absl::StrCat("<", binary_path, " - NOT FOUND>");
   }
   return binary_path;
 }
@@ -419,7 +419,7 @@ port::StatusOr<std::vector<uint8>> BundleGpuAsm(
     VLOG(2) << stderr_output;
   }
 
-  // // Read in the result and return it as a byte vector.
+  // Read in the result and return it as a byte vector.
   std::string result_blob;
   TF_RETURN_IF_ERROR(tensorflow::ReadFileToString(tensorflow::Env::Default(),
                                                   result_path, &result_blob));

--- a/tensorflow/stream_executor/gpu/asm_compiler.cc
+++ b/tensorflow/stream_executor/gpu/asm_compiler.cc
@@ -331,4 +331,99 @@ port::StatusOr<std::vector<uint8>> BundleGpuAsm(
   return std::vector<uint8>(result_blob.begin(), result_blob.end());
 }
 
+static std::string findRocmExecutable(const std::string binary_relative_path,
+                                      const std::string rocm_root_dir) {
+  auto env = tensorflow::Env::Default();
+  std::string binary_path =
+      tensorflow::io::JoinPath(rocm_root_dir, binary_relative_path);
+  VLOG(2) << "Looking for " << binary_relative_path << " at " << rocm_root_dir;
+  if (!env->FileExists(binary_path).ok()) {
+    binary_path = "<" + binary_path + " - NOT FOUND>";
+  }
+  return binary_path;
+}
+
+port::StatusOr<std::vector<uint8>> BundleGpuAsm(
+    std::vector<HsacoImage> images, const std::string rocm_root_dir) {
+  std::string clang_offload_bundler_path =
+      findRocmExecutable("llvm/bin/clang-offload-bundler", rocm_root_dir);
+
+  // Initialise the "--inputs" / "--targets" arguments for the
+  // clang-offload-bundler with a dummy file / host target triple...
+  // clang-offload-bundler requires 1 and only 1 host target triple
+  std::ostringstream inputs_list;
+  std::ostringstream targets_list;
+
+  inputs_list << "/dev/null";
+  targets_list << "host-x86_64-unknown-linux";
+
+  // Write images to temporary files.
+  std::vector<std::string> image_paths;
+  auto env = tensorflow::Env::Default();
+  for (const HsacoImage& img : images) {
+    std::string img_path;
+    if (!env->LocalTempFilename(&img_path)) {
+      return port::InternalError(
+          "Could not get temporary filenames for images.");
+    }
+    TF_RETURN_IF_ERROR(tensorflow::WriteStringToFile(
+        env, img_path, std::string(img.bytes.begin(), img.bytes.end())));
+    VLOG(2) << "image written to " << img_path;
+    inputs_list << "," << img_path;
+    targets_list << ",hip-amdgcn-amd-amdhsa-" << img.gfx_arch;
+    image_paths.push_back(std::move(img_path));
+  }
+  auto image_files_cleaner = tensorflow::gtl::MakeCleanup([&image_paths] {
+    for (const auto& path : image_paths) {
+      TF_CHECK_OK(tensorflow::Env::Default()->DeleteFile(path));
+    }
+  });
+
+  // Prepare temorary result file.
+  std::string result_path;
+  if (!env->LocalTempFilename(&result_path)) {
+    return port::InternalError(
+        "Could not get temporary filename for fatbin result.");
+  }
+  auto result_file_cleaner = tensorflow::gtl::MakeCleanup([&result_path] {
+    // This file may never be created, so the failure to delete it should not
+    // propagate to TF.
+    tensorflow::Env::Default()->DeleteFile(result_path).IgnoreError();
+  });
+
+  // Invoke clang_offload_bundler and collect its output.
+  tensorflow::SubProcess clang_offload_bundler;
+  std::vector<std::string> clang_offload_bundler_args = {
+      clang_offload_bundler_path, absl::StrCat("--inputs=", inputs_list.str()),
+      absl::StrCat("--targets=", targets_list.str()), "--type=o",
+      absl::StrCat("--outputs=", result_path)};
+  if (VLOG_IS_ON(3)) {
+    VLOG(3) << absl::StrJoin(clang_offload_bundler_args, " ");
+  }
+  clang_offload_bundler.SetProgram(clang_offload_bundler_path,
+                                   clang_offload_bundler_args);
+  clang_offload_bundler.SetChannelAction(tensorflow::CHAN_STDERR,
+                                         tensorflow::ACTION_PIPE);
+  if (!clang_offload_bundler.Start()) {
+    return port::InternalError("Failed to launch clang_offload_bundler.");
+  }
+  std::string stderr_output;
+  int exit_status = clang_offload_bundler.Communicate(
+      /*stdin_input=*/nullptr, /*stdout_output=*/nullptr, &stderr_output);
+  if (exit_status != 0) {
+    return port::InternalError(absl::StrFormat(
+        "clang_offload_bundler exited with non-zero error code %d, output: %s",
+        exit_status, stderr_output));
+  }
+  if (!stderr_output.empty()) {
+    VLOG(2) << stderr_output;
+  }
+
+  // // Read in the result and return it as a byte vector.
+  std::string result_blob;
+  TF_RETURN_IF_ERROR(tensorflow::ReadFileToString(tensorflow::Env::Default(),
+                                                  result_path, &result_blob));
+  return std::vector<uint8>(result_blob.begin(), result_blob.end());
+}
+
 }  // namespace stream_executor

--- a/tensorflow/stream_executor/gpu/asm_compiler.h
+++ b/tensorflow/stream_executor/gpu/asm_compiler.h
@@ -67,7 +67,7 @@ struct HsacoImage {
   std::vector<uint8> bytes;
 };
 
-// Bundles the GPU machine code ()HSA Code Object) and returns the resulting
+// Bundles the GPU machine code (HSA Code Object) and returns the resulting
 // binary (i.e. a fatbin) as a byte array.
 port::StatusOr<std::vector<uint8>> BundleGpuAsm(
     std::vector<HsacoImage> images, const std::string rocm_root_dir);

--- a/tensorflow/stream_executor/gpu/asm_compiler.h
+++ b/tensorflow/stream_executor/gpu/asm_compiler.h
@@ -62,6 +62,16 @@ struct CubinOrPTXImage {
 port::StatusOr<std::vector<uint8>> BundleGpuAsm(
     std::vector<CubinOrPTXImage> images, const std::string preferred_cuda_dir);
 
+struct HsacoImage {
+  std::string gfx_arch;
+  std::vector<uint8> bytes;
+};
+
+// Bundles the GPU machine code ()HSA Code Object) and returns the resulting
+// binary (i.e. a fatbin) as a byte array.
+port::StatusOr<std::vector<uint8>> BundleGpuAsm(
+    std::vector<HsacoImage> images, const std::string rocm_root_dir);
+
 }  // namespace stream_executor
 
 #endif  // TENSORFLOW_STREAM_EXECUTOR_GPU_ASM_COMPILER_H_


### PR DESCRIPTION
Adding ROCm support for MLIR-unranked kernels with ROCm, as discussed in the email thread.

I have tested this locally with the following lines set in the `.tf_configure.bazelrc` file
```
build --config=rocm
build:rocm --define tensorflow_enable_mlir_generated_gpu_kernels=1
```
and then the commands
```bash
root@prj47-rack-15: bazel test --define enable_unranked_kernels=1 //tensorflow/core/kernels/mlir_generated/...
...
INFO: Build completed successfully, 241 total actions
//tensorflow/core/kernels/mlir_generated:gpu_abs_test                    PASSED in 3.8s
//tensorflow/core/kernels/mlir_generated:gpu_abs_test_gpu                PASSED in 3.8s
//tensorflow/core/kernels/mlir_generated:gpu_tanh_test                   PASSED in 3.8s
//tensorflow/core/kernels/mlir_generated:gpu_tanh_test_gpu               PASSED in 1.3s

INFO: Build completed successfully, 241 total actions
...
root@prj47-rack-15:/root/tensorflow# bazel test //tensorflow/core/kernels/mlir_generated/...
...
INFO: Build completed successfully, 250 total actions
//tensorflow/core/kernels/mlir_generated:gpu_abs_test                    PASSED in 1.3s
//tensorflow/core/kernels/mlir_generated:gpu_abs_test_gpu                PASSED in 1.4s
//tensorflow/core/kernels/mlir_generated:gpu_tanh_test                   PASSED in 1.5s
//tensorflow/core/kernels/mlir_generated:gpu_tanh_test_gpu               PASSED in 1.3s

INFO: Build completed successfully, 250 total actions
...
```


/cc @whchung  @pifon2a @sherhut @thomasjoerg @akuegel 