### PR TITLE
Add to release notes: deterministic tf.image.resize (bilinear)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -216,6 +216,9 @@
         these stateless functions/ops produce the same results independent of
         how many times the function is called, and independent of global seed
         settings.
+    *   Added deterministic `tf.image.resize` backprop CUDA kernels for
+        `method=ResizeMethod.BILINEAR` (the default method). Enable by setting
+        the environment variable `TF_DETERMINISTIC_OPS` to `"true"` or `"1"`.
 *   `tf.distribute`:
     *   (Experimental) Parameter server training:
         *   Replaced the existing


### PR DESCRIPTION
This current pull request (into the r2.4 branch) adds information to the version 2.4.0 release notes about the changes made by pull request [39243](https://github.com/tensorflow/tensorflow/pull/39243), which was merged into the master branch on 2020-09-22.