### PR TITLE
Fix tpu_executor_dlsym_initializer windows build error

### DIFF
--- a/tensorflow/core/tpu/BUILD
+++ b/tensorflow/core/tpu/BUILD
@@ -162,7 +162,10 @@ cc_library(
 # not link in both this and "tpu_api_dlsym_initializer".
 cc_library(
     name = "tpu_executor_dlsym_initializer",
-    srcs = ["tpu_executor_dlsym_initializer.cc"],
+    srcs = if_windows(
+        ["tpu_executor_dlsym_initializer_windows.cc"],
+        otherwise = ["tpu_executor_dlsym_initializer.cc"],
+    ),
     visibility = ["//visibility:public"],
     deps = [
         ":tpu_api_dlsym_set_fn",

--- a/tensorflow/core/tpu/tpu_executor_dlsym_initializer_windows.cc
+++ b/tensorflow/core/tpu/tpu_executor_dlsym_initializer_windows.cc
@@ -1,0 +1,33 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// TODO(skye): this is largely a copy of tpu_api_dlsym_initializer.cc. Figure
+// out how to deduplicate these files a little.
+
+
+#include "tensorflow/core/platform/errors.h"
+#include "tensorflow/core/platform/status.h"
+#include "tensorflow/core/tpu/tpu_api_dlsym_set_fn.h"
+
+namespace tensorflow {
+namespace tpu {
+
+Status InitializeTpuLibrary(void* library_handle) {
+  return errors::Unimplemented(
+      "Loading TPU library is not supported on Windows.");
+}
+
+}  // namespace tpu
+}  // namespace tensorflow


### PR DESCRIPTION
This PR enables me build jax natively on windows, https://github.com/google/jax/pull/4843