### PR TITLE
[TFLite] Disable the unfolding of the BatchMatMulOp for 16-bit inference

### DIFF
--- a/tensorflow/compiler/mlir/lite/python/graphdef_to_tfl_flatbuffer.cc
+++ b/tensorflow/compiler/mlir/lite/python/graphdef_to_tfl_flatbuffer.cc
@@ -89,6 +89,11 @@ Status ConvertGraphDefToTFLiteFlatBuffer(const toco::ModelFlags& model_flags,
   bool emit_builtin_tflite_ops = !toco_flags.force_select_tf_ops();
   pass_config.emit_builtin_tflite_ops = emit_builtin_tflite_ops;
   pass_config.lower_tensor_list_ops = true;
+  // Disable the unfolding of the 16x16 TF::BatchMatMulOp to avoid the
+  // conversion to an unsupported 16x16 TFL::FullyConnectedOp.
+  if (toco_flags.inference_type() == toco::IODataType::QUANTIZED_INT16) {
+    pass_config.unfold_batch_matmul = false;
+  }
 
   return internal::ConvertMLIRToTFLiteFlatBuffer(
       toco_flags, std::move(module), pass_config, /*saved_model_tags=*/{},

--- a/tensorflow/compiler/mlir/lite/python/saved_model_to_tfl_flatbuffer.cc
+++ b/tensorflow/compiler/mlir/lite/python/saved_model_to_tfl_flatbuffer.cc
@@ -174,6 +174,11 @@ Status ConvertSavedModelToTFLiteFlatBuffer(const toco::ModelFlags& model_flags,
   bool emit_builtin_tflite_ops = !toco_flags.force_select_tf_ops();
   pass_config.emit_builtin_tflite_ops = emit_builtin_tflite_ops;
   pass_config.lower_tensor_list_ops = true;
+  // Disable the unfolding of the 16x16 TF::BatchMatMulOp to avoid the
+  // conversion to an unsupported 16x16 TFL::FullyConnectedOp.
+  if (toco_flags.inference_type() == toco::IODataType::QUANTIZED_INT16) {
+    pass_config.unfold_batch_matmul = false;
+  }
 
   // TODO(b/153507667): Pass the session object when importing logic is removed.
   auto status = internal::ConvertMLIRToTFLiteFlatBuffer(


### PR DESCRIPTION
Hello,

This PR disables the unfolding of the 16x16 BatchMatMulOp into a 16x16 MatMulOp operator which in turn would be transformed into an unsupported 16x16 FullyConnectedOp. The 16-bit FullyConnectedOp only supports 16-bit inputs and 8-bit weights (16x8) but the unfolding generates a FC with 16-bit inputs and 16-bit weights which result in the following error on inference:
`RuntimeError: tensorflow/lite/kernels/fully_connected.cc:123 input->type != kTfLiteFloat32 (INT16 != FLOAT32)Node number 8 (FULLY_CONNECTED) failed to prepare.`

The PR solve part of the #44707 issue and uses the `toco_flags.inference_type()` set in [lite.py](https://github.com/tensorflow/tensorflow/blob/e9994aed883a12c5a7f77f2b3b6f59895d8faa07/tensorflow/lite/python/lite.py#L264) to check for int16 inference.

Code to reproduce the problem this PR solves:
```python
import numpy as np
import tensorflow as tf

input_shape = [4, 2]
input1 = tf.keras.Input(shape=input_shape, batch_size=1)
input2 = tf.keras.Input(shape=input_shape, batch_size=1)
output = tf.keras.layers.Lambda(lambda x: tf.linalg.matmul(
                                   x[0], x[1], transpose_b=True)
                                )([input1, input2])
model = tf.keras.Model(inputs=[input1, input2], outputs=output)


def get_rand_date():
    return np.random.rand(1, *input_shape).astype(np.float32)

def representative_data_gen():
    yield [get_rand_date(), get_rand_date()]

converter = tf.lite.TFLiteConverter.from_keras_model(model)
converter.representative_dataset = representative_data_gen
converter.optimizations = [tf.lite.Optimize.DEFAULT]
converter.target_spec.supported_ops = [
    tf.lite.OpsSet.EXPERIMENTAL_TFLITE_BUILTINS_ACTIVATIONS_INT16_WEIGHTS_INT8]

tflite_model = converter.convert()
interpreter = tf.lite.Interpreter(model_content=tflite_model)
interpreter.allocate_tensors()
interpreter.set_tensor(interpreter.get_input_details()[0]["index"],
                       get_rand_date())
interpreter.set_tensor(interpreter.get_input_details()[1]["index"],
                       get_rand_date())
interpreter.invoke()
```

Thanks,
Thibaut