### PR TITLE
Fix wrong path separator in error message when saved model does not exist

### DIFF
--- a/tensorflow/python/saved_model/loader_impl.py
+++ b/tensorflow/python/saved_model/loader_impl.py
@@ -108,8 +108,9 @@ def parse_saved_model(export_dir):
     except text_format.ParseError as e:
       raise IOError("Cannot parse file %s: %s." % (path_to_pbtxt, str(e)))
   else:
-    raise IOError("SavedModel file does not exist at: %s/{%s|%s}" %
+    raise IOError("SavedModel file does not exist at: %s%s{%s|%s}" %
                   (export_dir,
+                   os.path.sep,
                    constants.SAVED_MODEL_FILENAME_PBTXT,
                    constants.SAVED_MODEL_FILENAME_PB))
 

--- a/tensorflow/python/saved_model/loader_test.py
+++ b/tensorflow/python/saved_model/loader_test.py
@@ -290,6 +290,13 @@ class SavedModelLoaderTest(test.TestCase, parameterized.TestCase):
     with self.assertRaisesRegex(ValueError, "not found in graph"):
       loader.load_graph(graph, ["foo_graph"], return_elements=["z:0"])
 
+  def test_parse_saved_model_exception(self, builder_cls):
+    """Test that error message for not exist model have OS-depend delimiter in path"""
+    path = _get_export_dir("not_existing_dir")
+    pattern = os.path.sep + "{"
+    with self.assertRaises(IOError) as err:
+      loader_impl.parse_saved_model(path)
+    self.assertTrue(pattern in str(err.exception))
 
 if __name__ == "__main__":
   test.main()


### PR DESCRIPTION
Error message generation changed for `keras.models.load_model` (fixed bug #44739).
Path separator recived from os.path.sep, and now for Windows error message looking like
`OSError: SavedModel file does not exist at: C:\IncorrectPathToSavedModel\{saved_model.pbtxt|saved_model.pb}`
for Linux - 
`OSError: SavedModel file does not exist at: ~/IncorrectPathToSavedModel/{saved_model.pbtxt|saved_model.pb}`