### PR TITLE
Remove link to inactive chat room on StackOverflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,8 +159,6 @@ Container Type                                                    | Status | Art
 *   [Introduction to TensorFlow Lite from Udacity](https://www.udacity.com/course/intro-to-tensorflow-lite--ud190)
 *   [Machine Learning with TensorFlow on GCP](https://www.coursera.org/specializations/machine-learning-tensorflow-gcp)
 *   [TensorFlow Codelabs](https://codelabs.developers.google.com/?cat=TensorFlow)
-*   [TensorFlow Chat Room on StackOverflow (not actively monitored by the
-    TensorFlow team)](https://chat.stackoverflow.com/rooms/216694/tensorflow)
 *   [TensorFlow Blog](https://blog.tensorflow.org)
 *   [Learn ML with TensorFlow](https://www.tensorflow.org/resources/learn-ml)
 *   [TensorFlow Twitter](https://twitter.com/tensorflow)


### PR DESCRIPTION
This room no longer exists.

Fixes #44525.