### PR TITLE
Enable unit testing with Renode for the Bluepill target as part of CI.

### DIFF
--- a/tensorflow/lite/micro/tools/ci_build/test_all.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_all.sh
@@ -38,7 +38,7 @@ echo "Running x86 tests at `date`"
 tensorflow/lite/micro/tools/ci_build/test_x86.sh PRESUBMIT
 
 echo "Running bluepill tests at `date`"
-tensorflow/lite/micro/tools/ci_build/test_bluepill.sh PRESUBMIT
+tensorflow/lite/micro/tools/ci_build/test_bluepill.sh
 
 echo "Running mbed tests at `date`"
 tensorflow/lite/micro/tools/ci_build/test_mbed.sh PRESUBMIT

--- a/tensorflow/lite/micro/tools/ci_build/test_all.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_all.sh
@@ -27,6 +27,14 @@ pwd
 make -f tensorflow/lite/micro/tools/make/Makefile \
   clean clean_downloads
 
+# We are moving away from having the downloads and installations be part of the
+# Makefile. As a result, we need to manually add the downloads in this script.
+# Once we move more than the renode downloads out of the Makefile, we should
+# have common way to perform the downloads for a given target, tags ...
+echo "Starting renode download at `date`"
+tensorflow/lite/micro/testing/download_renode.sh tensorflow/lite/micro/tools/make/downloads/renode
+pip3 install -r tensorflow/lite/micro/tools/make/downloads/renode/tests/requirements.txt
+
 # Add all the test scripts for the various supported platforms here. This
 # enables running all the tests together has part of the continuous integration
 # pipeline and reduces duplication associated with setting up the docker

--- a/tensorflow/lite/micro/tools/ci_build/test_bluepill.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_bluepill.sh
@@ -41,10 +41,7 @@ readable_run make -j8 -f tensorflow/lite/micro/tools/make/Makefile TARGET=${TARG
 readable_run make -f tensorflow/lite/micro/tools/make/Makefile clean
 readable_run make -j8 -f tensorflow/lite/micro/tools/make/Makefile TARGET=${TARGET} build
 
-# TODO(b/149597202): Running tests via renode are disabled as part of the
-# continuous integration until we can get Docker running inside Docker. However,
-# if this script is run locally, the tests will still be run.
-if [[ ${1} != "PRESUBMIT" ]]; then
-readable_run make -f tensorflow/lite/micro/tools/make/Makefile TARGET=${TARGET} test
-fi
-
+# TODO(b/172939049): Using renode to run the tests is not currently integrated
+# with the Makefile.  So, we manually run the test script with the correct path
+# to the bluepill generated files.
+tensorflow/lite/micro/testing/test_bluepill_binary.sh tensorflow/lite/micro/tools/make/gen/bluepill_cortex-m3/bin/


### PR DESCRIPTION
With the addition of running all the unit tests on a software emulated bluepill target with Renode, we add an additional 25s (on my i7-7820HQ) to the running time for test_bluepill.sh

Addresses http://b/146226672
