### PR TITLE
[CherryPick:r2.4] Expose Logging C API in pip package

### DIFF
--- a/tensorflow/c/BUILD
+++ b/tensorflow/c/BUILD
@@ -199,6 +199,7 @@ tf_cuda_library(
             "//tensorflow/core:portable_tensorflow_lib_lite",
         ],
         "//conditions:default": [
+            ":logging",
             ":tf_status",
             ":tf_tensor",
             "@com_google_absl//absl/strings",


### PR DESCRIPTION
**Note: this is an r2.4 PR** /cc @mihaimaruseac It might make sense to apply a82cdca (PR #44690) to 2.4. Though I am not sure if branch 2.4 still accept cherry-picks, so please feel free to close the PR if not appropriate.

While working on modular file systems, noticed that the logging
C API headers are not included in tensorflow pip packages.

This limit the ability for plugins to add logging in the file system.

This PR adds logging C API header in pip package.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>