### PR TITLE
Fix TFRecord uncompressed test cases

### DIFF
--- a/tensorflow/core/kernels/data/tf_record_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/tf_record_dataset_op_test.cc
@@ -126,7 +126,7 @@ TFRecordDatasetParams TFRecordDatasetParams3() {
       absl::StrCat(testing::TmpDir(), "/tf_record_UNCOMPRESSED_2")};
   std::vector<std::vector<string>> contents = {{"1", "22", "333"},
                                                {"a", "bb", "ccc"}};
-  CompressionType compression_type = CompressionType::GZIP;
+  CompressionType compression_type = CompressionType::UNCOMPRESSED;
   if (!CreateTestFiles(filenames, contents, compression_type).ok()) {
     VLOG(WARNING) << "Failed to create the test files: "
                   << absl::StrJoin(filenames, ", ");


### PR DESCRIPTION
Two of the test cases were testing the same code path. A TFRecord test case was testing the GZIP (compressed) path twice (case 2 and 3) rather than using one test case (case 3) to test the uncompressed path. This PR changes the latter test to test the uncompressed code path, as was intended.