### PR TITLE
Bump libjpeg-turbo from 2.0.4 to 2.0.5

### DIFF
--- a/third_party/jpeg/workspace.bzl
+++ b/third_party/jpeg/workspace.bzl
@@ -6,11 +6,11 @@ def repo():
     third_party_http_archive(
         name = "libjpeg_turbo",
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/libjpeg-turbo/libjpeg-turbo/archive/2.0.4.tar.gz",
-            "https://github.com/libjpeg-turbo/libjpeg-turbo/archive/2.0.4.tar.gz",
+            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/libjpeg-turbo/libjpeg-turbo/archive/2.0.5.tar.gz",
+            "https://github.com/libjpeg-turbo/libjpeg-turbo/archive/2.0.5.tar.gz",
         ],
-        sha256 = "7777c3c19762940cff42b3ba4d7cd5c52d1671b39a79532050c85efb99079064",
-        strip_prefix = "libjpeg-turbo-2.0.4",
+        sha256 = "b3090cd37b5a8b3e4dbd30a1311b3989a894e5d3c668f14cbc6739d77c9402b7",
+        strip_prefix = "libjpeg-turbo-2.0.5",
         build_file = "//third_party/jpeg:BUILD.bazel",
         system_build_file = "//third_party/jpeg:BUILD.system",
     )


### PR DESCRIPTION
It looks like the latest libjpeg-turbo is 2.0.5 so this PR
bumps the version (currently on 2.0.4).

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>