### PR TITLE
2.4.0 cherry-pick request: update tensorboard dependency to 2.4.x

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -96,7 +96,7 @@ REQUIRED_PACKAGES = [
     # These need to be in sync with the existing TF version
     # They are updated during the release process
     # When updating these, please also update the nightly versions below
-    'tensorboard ~= 2.3',
+    'tensorboard ~= 2.4',
     'tensorflow_estimator >= 2.4.0rc0 , < 2.5.0',
 ]
 


### PR DESCRIPTION
Consequences of not including this cherry-pick in TF 2.4.0:
users who pip install tensorflow will be left with an outdated
tensorboard version.

TensorBoard release: https://pypi.org/project/tensorboard/2.4.0/

PiperOrigin-RevId: 342150986
Change-Id: I6f3945a744a9de482b72342cb1ed770d0fe6bf36