### PR TITLE
[CherryPick:r2.4]Fix single pip package renaming bug

### DIFF
--- a/tensorflow/tools/ci_build/release/common.sh
+++ b/tensorflow/tools/ci_build/release/common.sh
@@ -256,7 +256,14 @@ function copy_to_new_project_name {
 
   ORIGINAL_PROJECT_NAME_DASH="${ORIGINAL_PROJECT_NAME//_/-}"
   NEW_PROJECT_NAME_DASH="${NEW_PROJECT_NAME//_/-}"
-  sed -i.bak "s/${ORIGINAL_PROJECT_NAME_DASH}/${NEW_PROJECT_NAME_DASH}/g" "${NEW_WHL_DIR_PREFIX}.dist-info/METADATA"
+
+  # We need to change the name in the METADATA file, but we need to ensure that
+  # all other occurences of the name stay the same, otherwise things such as
+  # URLs and depedencies might be broken (for example, replacing without care
+  # might transform a `tensorflow_estimator` dependency into
+  # `tensorflow_gpu_estimator`, which of course does not exist -- except by
+  # manual upload of a manually altered `tensorflow_estimator` package)
+  sed -i.bak "s/Name: ${ORIGINAL_PROJECT_NAME_DASH}/Name: ${NEW_PROJECT_NAME_DASH}/g" "${NEW_WHL_DIR_PREFIX}.dist-info/METADATA"
 
   ${PYTHON_CMD} -m wheel pack .
   # Debug


### PR DESCRIPTION
There is a bug in the single pip package renaming code: we do a replacement over the entire contents of `METADATA` and this causes the `tensorflow_estimator` dependency to be replaced with `tensorflow_gpu_estimator` (on 1.15 it was `tensorflow_cpu_estimator`). These packages don't exist by themseleves, Estimator has no CPU/GPU split. Previously this required a manual alteration of the Estimator package to fake it being the CPU/GPU version and a manual upload for that, but we should move away from this manual step as it always causes issues with new releases.

See for example #44775 (there are a few more similar issues, both internally and externally, but this is the most recent one).

We should build each pip package instead of doing the renaming. We do that on Linux/Mac already but Windows builds take too long so rather than rebuilding we just fake the new package via this renaming function. Future work in this area is needed to get rid of the renaming function, eventually removing it completely from both TF and TF ecosystem packages.

PiperOrigin-RevId: 341915841
Change-Id: I2bd4c3621e581ccf31e7bdd52958937b93971b90