### PR TITLE
Disabled performance killing ASSERTS

### DIFF
--- a/tensorflow/lite/kernels/internal/types.h
+++ b/tensorflow/lite/kernels/internal/types.h
@@ -383,20 +383,20 @@ inline size_t ReducedOutputOffset(const int num_dims, const int* dims,
 }
 
 inline int Offset(const RuntimeShape& shape, int i0, int i1, int i2, int i3) {
-  TFLITE_DCHECK_EQ(shape.DimensionsCount(), 4);
+//  TFLITE_DCHECK_EQ(shape.DimensionsCount(), 4);
   const int* dims_data = reinterpret_cast<const int*>(shape.DimsDataUpTo5D());
-  TFLITE_DCHECK(i0 >= 0 && i0 < dims_data[0]);
-  TFLITE_DCHECK(i1 >= 0 && i1 < dims_data[1]);
-  TFLITE_DCHECK(i2 >= 0 && i2 < dims_data[2]);
-  TFLITE_DCHECK(i3 >= 0 && i3 < dims_data[3]);
+//  TFLITE_DCHECK(i0 >= 0 && i0 < dims_data[0]);
+//  TFLITE_DCHECK(i1 >= 0 && i1 < dims_data[1]);
+//  TFLITE_DCHECK(i2 >= 0 && i2 < dims_data[2]);
+//  TFLITE_DCHECK(i3 >= 0 && i3 < dims_data[3]);
   return ((i0 * dims_data[1] + i1) * dims_data[2] + i2) * dims_data[3] + i3;
 }
 
 inline int Offset(const Dims<4>& dims, int i0, int i1, int i2, int i3) {
-  TFLITE_DCHECK(i0 >= 0 && i0 < dims.sizes[0]);
-  TFLITE_DCHECK(i1 >= 0 && i1 < dims.sizes[1]);
-  TFLITE_DCHECK(i2 >= 0 && i2 < dims.sizes[2]);
-  TFLITE_DCHECK(i3 >= 0 && i3 < dims.sizes[3]);
+//  TFLITE_DCHECK(i0 >= 0 && i0 < dims.sizes[0]);
+//  TFLITE_DCHECK(i1 >= 0 && i1 < dims.sizes[1]);
+//  TFLITE_DCHECK(i2 >= 0 && i2 < dims.sizes[2]);
+//  TFLITE_DCHECK(i3 >= 0 && i3 < dims.sizes[3]);
   return i0 * dims.strides[0] + i1 * dims.strides[1] + i2 * dims.strides[2] +
          i3 * dims.strides[3];
 }


### PR DESCRIPTION
On embedded targets, the Offset() function is called quite frequently, Within it, these ASSERTS generate compare/branch code which dramatically reduces the performance. By removing them, the inference pipeline on target CPUs like the Cortex-M run nearly 2x faster.