### PR TITLE
Change tf_upgrade_v2 to be compatible with tf1 and tf2 for tf.nn.dropout

### DIFF
--- a/tensorflow/tools/compatibility/tf_upgrade_v2.py
+++ b/tensorflow/tools/compatibility/tf_upgrade_v2.py
@@ -1845,7 +1845,10 @@ def _dropout_transformer(parent, node, full_name, name, logs):
                  "automatic fix was disabled. tf.nn.dropout has changed "
                  "the semantics of the second argument."))
   else:
-    _replace_keep_prob_node(node, node.args[1])
+    rate_arg = ast.keyword(arg="rate", value=node.args[1])
+    _replace_keep_prob_node(rate_arg, rate_arg.value)
+    node.keywords.append(rate_arg)
+    del node.args[1]
     logs.append((ast_edits.INFO, node.lineno, node.col_offset,
                  "Changing keep_prob arg of tf.nn.dropout to rate, and "
                  "recomputing value.\n"))

--- a/tensorflow/tools/compatibility/tf_upgrade_v2_test.py
+++ b/tensorflow/tools/compatibility/tf_upgrade_v2_test.py
@@ -901,7 +901,7 @@ bazel-bin/tensorflow/tools/compatibility/update/generate_v2_reorders_map
     _, unused_report, unused_errors, new_text = self._upgrade(text)
     self.assertEqual(
         new_text,
-        "tf.nn.dropout(x, 1 - (keep_prob), name=\"foo\")\n",
+        "tf.nn.dropout(x, rate=1 - (keep_prob), name=\"foo\")\n",
     )
 
     text = "tf.nn.dropout(x, keep_prob=.4, name=\"foo\")\n"
@@ -934,7 +934,7 @@ bazel-bin/tensorflow/tools/compatibility/update/generate_v2_reorders_map
     _, unused_report, unused_errors, new_text = self._upgrade(text)
     self.assertEqual(
         new_text,
-        "tf.nn.dropout(x, 1 - (1 - func(3 + 4.)), name=\"foo\")\n",
+        "tf.nn.dropout(x, rate=1 - (1 - func(3 + 4.)), name=\"foo\")\n",
     )
 
   def testContribL1(self):


### PR DESCRIPTION
According to [the recommended upgrade process](https://www.tensorflow.org/guide/upgrade#recommended_upgrade_process), even after converting,
We can run and pass the test with tensorflow 1.14 as well.

I found that If we run tf_upgrade_v2 on tf.nn.dropout, tf1 and tf2 are incompatible.
In the case of `tf.nn.dropout(x, keep_prob)`, if you don't specify it
with a keyword, such as, tf_upgrade_v2 converts to `tf.nn.dropout(x, 1-keep_prob)`.

In tf2, it is compatible with tf1 since the second argument is rate and rate=1-keep_prob.
In 1.14, on the other hand, the result is not the same because the second argument is keep_probe.

For compatibility, it should be `tf.nn.dropout(x, rate=1-keep_prob)`.

