### PR TITLE
Rename exec_tools to tools

### DIFF
--- a/tensorflow/compiler/aot/tests/BUILD
+++ b/tensorflow/compiler/aot/tests/BUILD
@@ -115,8 +115,8 @@ genrule(
     # have control of the full GPU.
     cmd = "CUDA_VISIBLE_DEVICES='' " +
           "$(location :make_test_graphs) --out_dir $(@D)",
-    tools = [":make_test_graphs"],
     tags = ["manual"],
+    tools = [":make_test_graphs"],
 )
 
 tf_library(

--- a/tensorflow/compiler/aot/tests/BUILD
+++ b/tensorflow/compiler/aot/tests/BUILD
@@ -115,7 +115,7 @@ genrule(
     # have control of the full GPU.
     cmd = "CUDA_VISIBLE_DEVICES='' " +
           "$(location :make_test_graphs) --out_dir $(@D)",
-    exec_tools = [":make_test_graphs"],
+    tools = [":make_test_graphs"],
     tags = ["manual"],
 )
 

--- a/tensorflow/compiler/aot/tfcompile.bzl
+++ b/tensorflow/compiler/aot/tfcompile.bzl
@@ -127,7 +127,7 @@ def tf_library(
                    "$(location " + tfcompile_tool + ")" +
                    " --config=$(location " + config + ")" +
                    " --dump_fetch_nodes > $@"),
-            exec_tools = [tfcompile_tool],
+            tools = [tfcompile_tool],
             # Run tfcompile on the build host, rather than forge, since it's
             # typically way faster on the local machine.
             local = 1,
@@ -162,7 +162,7 @@ def tf_library(
                 "//tensorflow/python/tools:freeze_graph)" +
                 freeze_args
             ),
-            exec_tools = ["//tensorflow/python/tools:freeze_graph"],
+            tools = ["//tensorflow/python/tools:freeze_graph"],
             tags = tags,
         )
         tfcompile_graph = freeze_file
@@ -242,7 +242,7 @@ def tf_library(
             " --out_function_object=$(@D)/" + function_object_file +
             " " + flags + " " + profiling_flag + " " + mlir_flag + " " + traceme_flag
         ),
-        exec_tools = [tfcompile_tool],
+        tools = [tfcompile_tool],
         visibility = visibility,
         testonly = testonly,
         # Run tfcompile on the build host since it's typically faster on the
@@ -281,7 +281,7 @@ def tf_library(
             " --out_session_module=$(@D)/" + session_module_pb +
             " " + flags
         ),
-        exec_tools = [tfcompile_tool],
+        tools = [tfcompile_tool],
         visibility = visibility,
         testonly = testonly,
         local = 1,

--- a/tensorflow/compiler/mlir/tfr/build_defs.bzl
+++ b/tensorflow/compiler/mlir/tfr/build_defs.bzl
@@ -40,7 +40,7 @@ def gen_op_libraries(
         srcs = [],
         outs = [name + ".inc.cc"],
         cmd = "$(location %s) --output=$@ --gen_register_op=true" % gen_op_lib_exec,
-        exec_tools = [":" + gen_op_lib_exec],
+        tools = [":" + gen_op_lib_exec],
         tags = tags,
     )
 
@@ -100,7 +100,7 @@ def gen_op_libraries(
         srcs = [],
         outs = [name + ".mlir"],
         cmd = "$(location %s) --output=$@ --gen_register_op=false" % gen_tfr_lib_exec,
-        exec_tools = [":" + gen_tfr_lib_exec],
+        tools = [":" + gen_tfr_lib_exec],
         tags = tags,
     )
 

--- a/tensorflow/lite/build_def.bzl
+++ b/tensorflow/lite/build_def.bzl
@@ -674,8 +674,7 @@ def gen_zipped_test_file(name, file, toco, flags):
         cmd = (("$(locations :generate_examples) --toco $(locations {0}) " +
                 " --zip_to_output {1} {2} $(@D)").format(toco, file, flags)),
         outs = [file],
-        # `exec_tools` is required for PY3 compatibility in place of `tools`.
-        exec_tools = [
+        tools = [
             ":generate_examples",
             toco,
         ],

--- a/tensorflow/lite/delegates/flex/build_def.bzl
+++ b/tensorflow/lite/delegates/flex/build_def.bzl
@@ -73,7 +73,7 @@ def generate_flex_kernel_header(
         name = "%s_kernel_registration" % name,
         srcs = [list_ops_output],
         outs = [header],
-        exec_tools = [tool],
+        tools = [tool],
         message = "Processing %s..." % list_ops_output,
         cmd = ("$(location " + tool + ")" +
                " --default_ops=\"\"" +

--- a/tensorflow/lite/experimental/acceleration/compatibility/BUILD
+++ b/tensorflow/lite/experimental/acceleration/compatibility/BUILD
@@ -99,7 +99,7 @@ genrule(
         --output_source_file $(location :devicedb-sample.cc) \
         --array_variable_name g_tflite_acceleration_devicedb_sample_binary
     """,
-    exec_tools = [":convert_binary_to_cc_source"],
+    tools = [":convert_binary_to_cc_source"],
 )
 
 cc_library(
@@ -142,7 +142,7 @@ genrule(
         --output_source_file $(location :gpu_compatibility_binary.cc) \
         --array_variable_name g_tflite_acceleration_gpu_compatibility_binary
     """,
-    exec_tools = [":convert_binary_to_cc_source"],
+    tools = [":convert_binary_to_cc_source"],
 )
 
 cc_library(

--- a/tensorflow/python/tools/BUILD
+++ b/tensorflow/python/tools/BUILD
@@ -399,8 +399,8 @@ genrule(
     cmd = (
         "$(location :make_aot_compile_models) --out_dir $(@D)"
     ),
-    tools = [":make_aot_compile_models"],
     tags = ["no_rocm"],
+    tools = [":make_aot_compile_models"],
 )
 
 filegroup(

--- a/tensorflow/python/tools/BUILD
+++ b/tensorflow/python/tools/BUILD
@@ -399,7 +399,7 @@ genrule(
     cmd = (
         "$(location :make_aot_compile_models) --out_dir $(@D)"
     ),
-    exec_tools = [":make_aot_compile_models"],
+    tools = [":make_aot_compile_models"],
     tags = ["no_rocm"],
 )
 

--- a/tensorflow/python/tools/api/generator/api_gen.bzl
+++ b/tensorflow/python/tools/api/generator/api_gen.bzl
@@ -139,7 +139,7 @@ def gen_api_init_files(
             " --use_relative_imports=True $(OUTS)"
         ),
         srcs = srcs,
-        exec_tools = [":" + api_gen_binary_target],
+        tools = [":" + api_gen_binary_target],
         visibility = [
             "//tensorflow:__pkg__",
             "//tensorflow/tools/api/tests:__pkg__",

--- a/tensorflow/tools/compatibility/BUILD
+++ b/tensorflow/tools/compatibility/BUILD
@@ -219,7 +219,7 @@ genrule(
            " --infile $(location testdata/test_file_v0_11.py)" +
            " --outfile $(location test_file_v1_0.py)" +
            " --reportfile $(location report.txt)"),
-    exec_tools = [":tf_upgrade"],
+    tools = [":tf_upgrade"],
 )
 
 py_test(
@@ -246,7 +246,7 @@ genrule(
            " --outfile $(location test_file_v2_0.py)" +
            " --reportfile $(location report_v2.txt) && " +
            "sed -i'.original' 's/_TEST_VERSION = 1/_TEST_VERSION = 2/g' $(location test_file_v2_0.py)"),
-    exec_tools = [":tf_upgrade_v2"],
+    tools = [":tf_upgrade_v2"],
 )
 
 py_test(


### PR DESCRIPTION
Follow up to #43156
Based on https://github.com/bazelbuild/bazel/issues/12059#issuecomment-725641997 exec_tools might no longer be needed and hence can be replaced by tools.
This fixes various build failures caused by missing environment variables in environments where they are required, e.g. using custom compilers.