### PR TITLE
Requantize: Return when we have traced opt path

### DIFF
--- a/tensorflow/lite/kernels/internal/reference/requantize.h
+++ b/tensorflow/lite/kernels/internal/reference/requantize.h
@@ -45,6 +45,7 @@ inline void Requantize(const input_type* input_data, int32_t size,
       for (int i = 0; i < size; ++i) {
         output_data[i] = input_data[i] ^ 0x80;
       }
+      return;
     }
   }
   static constexpr int32_t kMinOutput = std::numeric_limits<output_type>::min();


### PR DESCRIPTION
We do not need to do whole operation again once we have used optimized path.

Returned from the function if we trace optimized path.