### PR TITLE
[INTEL MKL]Register Eigen bf16 kernels with NoOps to make bf16 kernels(which In clear and infer list) can go through auto-mixed-precision pass.

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_tmp_bf16_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_tmp_bf16_ops.cc
@@ -30,33 +30,75 @@ namespace tensorflow {
 // TensorFlow fails because Eigen CPU backend does not support these ops in
 // BFloat16 type.
 
-#define REGISTER_CPU(T)                                                       \
-  REGISTER_KERNEL_BUILDER(                                                    \
-      Name("Conv2D").Device(DEVICE_CPU).TypeConstraint<T>("T"), NoOp);        \
-  REGISTER_KERNEL_BUILDER(                                                    \
-      Name("Conv2DBackpropFilter").Device(DEVICE_CPU).TypeConstraint<T>("T"), \
-      NoOp);                                                                  \
-  REGISTER_KERNEL_BUILDER(                                                    \
-      Name("Conv2DBackpropInput").Device(DEVICE_CPU).TypeConstraint<T>("T"),  \
-      NoOp);                                                                  \
-  REGISTER_KERNEL_BUILDER(                                                    \
-      Name("_FusedConv2D").Device(DEVICE_CPU).TypeConstraint<T>("T"), NoOp);  \
-  REGISTER_KERNEL_BUILDER(                                                    \
-      Name("AvgPool").Device(DEVICE_CPU).TypeConstraint<T>("T"), NoOp);       \
-  REGISTER_KERNEL_BUILDER(                                                    \
-      Name("AvgPoolGrad").Device(DEVICE_CPU).TypeConstraint<T>("T"), NoOp);   \
-  REGISTER_KERNEL_BUILDER(Name("FusedBatchNormV3")                            \
-                              .Device(DEVICE_CPU)                             \
-                              .TypeConstraint<bfloat16>("T")                  \
-                              .TypeConstraint<float>("U"),                    \
-                          NoOp);                                              \
-  REGISTER_KERNEL_BUILDER(Name("FusedBatchNormGradV3")                        \
-                              .Device(DEVICE_CPU)                             \
-                              .TypeConstraint<bfloat16>("T")                  \
-                              .TypeConstraint<float>("U"),                    \
-                          NoOp);                                              \
-  REGISTER_KERNEL_BUILDER(                                                    \
-      Name("_FusedMatMul").Device(DEVICE_CPU).TypeConstraint<T>("T"), NoOp);
+#define REGISTER_CPU(T)                                                        \
+  REGISTER_KERNEL_BUILDER(                                                     \
+      Name("Conv2D").Device(DEVICE_CPU).TypeConstraint<T>("T"), NoOp);         \
+  REGISTER_KERNEL_BUILDER(                                                     \
+      Name("Conv2DBackpropFilter").Device(DEVICE_CPU).TypeConstraint<T>("T"),  \
+      NoOp);                                                                   \
+  REGISTER_KERNEL_BUILDER(                                                     \
+      Name("Conv2DBackpropInput").Device(DEVICE_CPU).TypeConstraint<T>("T"),   \
+      NoOp);                                                                   \
+  REGISTER_KERNEL_BUILDER(                                                     \
+      Name("Conv3D").Device(DEVICE_CPU).TypeConstraint<T>("T"), NoOp);         \
+  REGISTER_KERNEL_BUILDER(Name("Conv3DBackpropFilterV2")                       \
+                              .Device(DEVICE_CPU)                              \
+                              .TypeConstraint<T>("T"),                         \
+                          NoOp);                                               \
+  REGISTER_KERNEL_BUILDER(                                                     \
+      Name("Conv3DBackpropInputV2").Device(DEVICE_CPU).TypeConstraint<T>("T"), \
+      NoOp);                                                                   \
+  REGISTER_KERNEL_BUILDER(                                                     \
+      Name("DepthwiseConv2dNative").Device(DEVICE_CPU).TypeConstraint<T>("T"), \
+      NoOp);                                                                   \
+  REGISTER_KERNEL_BUILDER(Name("DepthwiseConv2dNativeBackpropFilter")          \
+                              .Device(DEVICE_CPU)                              \
+                              .TypeConstraint<T>("T"),                         \
+                          NoOp);                                               \
+  REGISTER_KERNEL_BUILDER(Name("DepthwiseConv2dNativeBackpropInput")           \
+                              .Device(DEVICE_CPU)                              \
+                              .TypeConstraint<T>("T"),                         \
+                          NoOp);                                               \
+  REGISTER_KERNEL_BUILDER(                                                     \
+      Name("_FusedConv2D").Device(DEVICE_CPU).TypeConstraint<T>("T"), NoOp);   \
+  REGISTER_KERNEL_BUILDER(                                                     \
+      Name("AvgPool").Device(DEVICE_CPU).TypeConstraint<T>("T"), NoOp);        \
+  REGISTER_KERNEL_BUILDER(                                                     \
+      Name("AvgPoolGrad").Device(DEVICE_CPU).TypeConstraint<T>("T"), NoOp);    \
+  REGISTER_KERNEL_BUILDER(                                                     \
+      Name("AvgPool3D").Device(DEVICE_CPU).TypeConstraint<T>("T"), NoOp);      \
+  REGISTER_KERNEL_BUILDER(                                                     \
+      Name("AvgPool3DGrad").Device(DEVICE_CPU).TypeConstraint<T>("T"), NoOp);  \
+  REGISTER_KERNEL_BUILDER(                                                     \
+      Name("MaxPool3D").Device(DEVICE_CPU).TypeConstraint<T>("T"), NoOp);      \
+  REGISTER_KERNEL_BUILDER(                                                     \
+      Name("MaxPool3DGrad").Device(DEVICE_CPU).TypeConstraint<T>("T"), NoOp);  \
+  REGISTER_KERNEL_BUILDER(Name("FusedBatchNormV2")                             \
+                              .Device(DEVICE_CPU)                              \
+                              .TypeConstraint<bfloat16>("T")                   \
+                              .TypeConstraint<float>("U"),                     \
+                          NoOp);                                               \
+  REGISTER_KERNEL_BUILDER(Name("FusedBatchNormGradV2")                         \
+                              .Device(DEVICE_CPU)                              \
+                              .TypeConstraint<bfloat16>("T")                   \
+                              .TypeConstraint<float>("U"),                     \
+                          NoOp);                                               \
+  REGISTER_KERNEL_BUILDER(Name("FusedBatchNormV3")                             \
+                              .Device(DEVICE_CPU)                              \
+                              .TypeConstraint<bfloat16>("T")                   \
+                              .TypeConstraint<float>("U"),                     \
+                          NoOp);                                               \
+  REGISTER_KERNEL_BUILDER(Name("FusedBatchNormGradV3")                         \
+                              .Device(DEVICE_CPU)                              \
+                              .TypeConstraint<bfloat16>("T")                   \
+                              .TypeConstraint<float>("U"),                     \
+                          NoOp);                                               \
+  REGISTER_KERNEL_BUILDER(                                                     \
+      Name("_FusedMatMul").Device(DEVICE_CPU).TypeConstraint<T>("T"), NoOp);   \
+  REGISTER_KERNEL_BUILDER(                                                     \
+      Name("BatchMatMul").Device(DEVICE_CPU).TypeConstraint<T>("T"), NoOp);    \
+  REGISTER_KERNEL_BUILDER(                                                     \
+      Name("BatchMatMulV2").Device(DEVICE_CPU).TypeConstraint<T>("T"), NoOp);
 
 TF_CALL_bfloat16(REGISTER_CPU);
 #undef REGISTER_CPU


### PR DESCRIPTION
This PR is to make user run bf16 models soft and easy.  
  1. target: Register Eigen bf16 kernels with NoOps,for this Ops, they have MKL bf16 kerenels but do not have Eigen bf16 kernels.
in auto-mixed-precision pass,
2.  for clear and infer nodes, if do not register bf16 Eigen kerenls, `SupportsF16` will be False, 
  so clear and infer nodes which could be added into allow_set will not be added into allow_set.   so we need to make clear and infer nodes to go through this pass.
3. if we do not register  NoOps for Eigen bf16 kernels, User must understand their Models' detailed messages.  add their ops to ALLOWLIST and remove ops FORM INFERLIST or CLEARLIST.