### PR TITLE
[Intel MKL] Enable MklConv/MklFusedConv with explicit padding

### DIFF
--- a/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite.cc
+++ b/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite.cc
@@ -93,17 +93,17 @@ MklEagerOpRewrite::MklEagerOpRewrite(string name, string file, string line)
   InsertMKLEagerOps({"AvgPool3DGrad", AlwaysRewrite, CreateGenericMklOp});
   InsertMKLEagerOps({"BatchMatMul", AlwaysRewrite, CreateGenericMklOp});
   InsertMKLEagerOps({"BatchMatMulV2", AlwaysRewrite, CreateGenericMklOp});
-  InsertMKLEagerOps({"Conv2D", RewriteConv2D, CreateGenericMklOp});
+  InsertMKLEagerOps({"Conv2D", AlwaysRewrite, CreateGenericMklOp});
   InsertMKLEagerOps(
       {"Conv2DBackpropFilter", RewriteConv2D, CreateGenericMklOp});
   InsertMKLEagerOps({"Conv2DBackpropInput", RewriteConv2D, CreateGenericMklOp});
-  InsertMKLEagerOps({"Conv3D", RewriteConv2D, CreateGenericMklOp});
+  InsertMKLEagerOps({"Conv3D", AlwaysRewrite, CreateGenericMklOp});
   InsertMKLEagerOps(
       {"Conv3DBackpropFilterV2", RewriteConv2D, CreateGenericMklOp});
   InsertMKLEagerOps(
       {"Conv3DBackpropInputV2", RewriteConv2D, CreateGenericMklOp});
   InsertMKLEagerOps(
-      {"DepthwiseConv2dNative", RewriteConv2D, CreateGenericMklOp});
+      {"DepthwiseConv2dNative", AlwaysRewrite, CreateGenericMklOp});
   InsertMKLEagerOps({"DepthwiseConv2dNativeBackpropFilter", RewriteConv2D,
                      CreateGenericMklOp});
   InsertMKLEagerOps({"DepthwiseConv2dNativeBackpropInput", RewriteConv2D,

--- a/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite_test.cc
+++ b/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite_test.cc
@@ -107,7 +107,7 @@ REGISTER_TEST_ALL_TYPES(ConvOps_Positive);
                    mkl_op_registry::GetMklNativeOpName(conv_ops[i])); \
     }                                                                 \
   }
-REGISTER_TEST_ALL_TYPES(ConvOpsExplicitPadding_Postive);
+REGISTER_TEST_ALL_TYPES(ConvOpsExplicitPadding_Positive);
 #undef REGISTER_TEST
 
 #define REGISTER_TEST(NAME, T, INPUT)                      \

--- a/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite_test.cc
+++ b/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite_test.cc
@@ -73,11 +73,14 @@ class EagerOpRewriteTest : public ::testing::Test {
   tensorflow::EagerContext* eager_ctx_;
 };
 
-#define CONV_OPS                                                      \
-  "Conv2D", "Conv2DBackpropInput", "Conv2DBackpropFilter", "Conv3D",  \
-      "Conv3DBackpropFilterV2", "Conv3DBackpropInputV2",              \
-      "DepthwiseConv2dNative", "DepthwiseConv2dNativeBackpropFilter", \
+#define CONV_FORWARD_OPS "Conv2D", "Conv3D", "DepthwiseConv2dNative"
+
+#define CONV_BACKWARD_OPS                                                  \
+  "Conv2DBackpropInput", "Conv2DBackpropFilter", "Conv3DBackpropFilterV2", \
+      "Conv3DBackpropInputV2", "DepthwiseConv2dNativeBackpropFilter",      \
       "DepthwiseConv2dNativeBackpropInput"
+
+#define CONV_OPS CONV_FORWARD_OPS, CONV_BACKWARD_OPS
 
 #define REGISTER_TEST(NAME, T, INPUT)                                 \
   TEST_F(EagerOpRewriteTest, NAME##_##T) {                            \
@@ -93,9 +96,23 @@ class EagerOpRewriteTest : public ::testing::Test {
 REGISTER_TEST_ALL_TYPES(ConvOps_Positive);
 #undef REGISTER_TEST
 
+#define REGISTER_TEST(NAME, T, INPUT)                                 \
+  TEST_F(EagerOpRewriteTest, NAME##_##T) {                            \
+    std::vector<string> conv_ops = {CONV_FORWARD_OPS};                \
+    for (int i = 0; i < conv_ops.size(); ++i) {                       \
+      auto orig_op = CreateOp(conv_ops[i]);                           \
+      orig_op->MutableAttrs()->Set("T", T);                           \
+      orig_op->MutableAttrs()->Set("padding", "EXPLICIT");            \
+      CheckRewrite(orig_op.get(),                                     \
+                   mkl_op_registry::GetMklNativeOpName(conv_ops[i])); \
+    }                                                                 \
+  }
+REGISTER_TEST_ALL_TYPES(ConvOpsExplicitPadding_Postive);
+#undef REGISTER_TEST
+
 #define REGISTER_TEST(NAME, T, INPUT)                      \
   TEST_F(EagerOpRewriteTest, NAME##_##T) {                 \
-    std::vector<string> conv_ops = {CONV_OPS};             \
+    std::vector<string> conv_ops = {CONV_BACKWARD_OPS};    \
     for (int i = 0; i < conv_ops.size(); ++i) {            \
       auto orig_op = CreateOp(conv_ops[i]);                \
       orig_op->MutableAttrs()->Set("T", T);                \

--- a/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
@@ -476,7 +476,7 @@ class MklConvOp : public OpKernel {
     OP_REQUIRES_OK(context, context->GetAttr("dilations", &dilations_));
 
     // Conv and QuantizedConv ops have different padding attributes
-    // ('padding_list' versus 'explicit_paddings). But one and only one
+    // (`padding_list` versus `explicit_paddings`). But one and only one
     // attribute is expected.
     OP_REQUIRES(
         context,

--- a/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
@@ -24,8 +24,8 @@ limitations under the License.
 #include <unordered_map>
 #include <vector>
 
-#include "mkldnn.hpp"
 #include "absl/strings/str_join.h"
+#include "mkldnn.hpp"
 #include "tensorflow/core/framework/bounds_check.h"
 #include "tensorflow/core/framework/numeric_op.h"
 #include "tensorflow/core/framework/op_kernel.h"
@@ -474,9 +474,23 @@ class MklConvOp : public OpKernel {
 
   explicit MklConvOp(OpKernelConstruction* context) : OpKernel(context) {
     OP_REQUIRES_OK(context, context->GetAttr("dilations", &dilations_));
+
+    // Conv and QuantizedConv ops have different padding attributes
+    // ('padding_list' versus 'explicit_paddings). But one and only one
+    // attribute is expected.
+    OP_REQUIRES(
+        context,
+        !(context->HasAttr("padding_list") &&
+          context->HasAttr("explicit_paddings")),
+        errors::InvalidArgument("Can only have 1 `padding` list at most"));
     if (context->HasAttr("padding_list")) {
       OP_REQUIRES_OK(context, context->GetAttr("padding_list", &padding_list_));
     }
+    if (context->HasAttr("explicit_paddings")) {
+      OP_REQUIRES_OK(context,
+                     context->GetAttr("explicit_paddings", &padding_list_));
+    }
+
     OP_REQUIRES_OK(context, context->GetAttr("strides", &strides_));
     string data_format;
     OP_REQUIRES_OK(context, context->GetAttr("data_format", &data_format));
@@ -555,19 +569,20 @@ class MklConvOp : public OpKernel {
           dilations, strides;
       memory::dims dst_dims_tf_order, dst_dims_mkl_order;
 
-      // For Quantized-Conv2D and Pad fusion, we get padding from the
-      // `padding_list` attribute. Otherwise, we get it from one of the inputs.
-      bool quantized_pad_enabled = false;
+      // For any Conv with `EXPLICIT` padding, get padding from `padding_list`
+      // attribute. Otherwise, get it from one of the inputs.
+      bool pad_attr_enabled = false;
       for (auto const& padding_val : padding_list_) {
         if (padding_val) {
-          quantized_pad_enabled = true;
+          pad_attr_enabled = true;
+
           break;
         }
       }
 
-      if (fuse_pad_ || quantized_pad_enabled) {
+      if (fuse_pad_ || pad_attr_enabled) {
         PadWithConvFusion(context, padding_left, padding_right,
-                          quantized_pad_enabled);
+                          pad_attr_enabled);
       }
 
       // Get shapes of input tensors in MKL-DNN order
@@ -579,7 +594,7 @@ class MklConvOp : public OpKernel {
       conv_utl.GetConvFwdSizesInMklOrder(
           src_tf_shape, filter_tf_shape, &src_dims, &filter_dims, &strides,
           &dilations, &dst_dims_tf_order, &dst_dims_mkl_order, &padding_left,
-          &padding_right, (fuse_pad_ || quantized_pad_enabled), is_depthwise);
+          &padding_right, (fuse_pad_ || pad_attr_enabled), is_depthwise);
 
       if (!context->status().ok()) return;
 
@@ -805,13 +820,12 @@ class MklConvOp : public OpKernel {
   }
 
   void PadWithConvFusion(OpKernelContext* context, memory::dims& padding_left,
-                         memory::dims& padding_right,
-                         bool quantized_pad_enabled) {
-    const Tensor& paddings_tf = MklGetInput(context, input_index_pad_);
+                         memory::dims& padding_right, bool pad_attr_enabled) {
     Tpadding* paddings = nullptr;
-    if (quantized_pad_enabled) {
+    if (pad_attr_enabled) {
       paddings = padding_list_.data();
     } else {
+      const Tensor& paddings_tf = MklGetInput(context, input_index_pad_);
       OP_REQUIRES(context, paddings_tf.dims() == 2,
                   errors::InvalidArgument("paddings must be 2-dimensional: ",
                                           paddings_tf.shape().DebugString()));

--- a/tensorflow/core/kernels/mkl/mkl_conv_ops.h
+++ b/tensorflow/core/kernels/mkl/mkl_conv_ops.h
@@ -401,7 +401,7 @@ class MklDnnConvUtil {
     }
 
     int64 out_rows = 0, out_cols = 0, out_planes = 0;
-    int64 pad_top = 0, pad_bottom = 0, pad_left, pad_right;
+    int64 pad_top = 0, pad_bottom = 0, pad_left = 0, pad_right = 0;
     int64 pad_D1, pad_D2;
 
     if (is_conv2d) {

--- a/tensorflow/core/kernels/mkl/mkl_fused_ops_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_fused_ops_test.cc
@@ -40,9 +40,9 @@ namespace tensorflow {
 static const uint8 dummy_tensor[] = {0, 0, 0, 0, 0, 0, 0, 0};
 static const TensorShape dummy_shape({8});
 // Set the default padding value for FusedConv test.
-// Padding type will be `SAME` if padding value is INVALID_PADDING_VALUE,
-// otherwise it will be 'EXPLICIT' for Mkl ops and 'VALID' for Eigen op.
-static const int INVALID_PADDING_VALUE = -1;
+// Padding type will be `SAME` if padding value is kInvalidPaddingValue,
+// otherwise it will be `EXPLICIT` for Mkl ops and `VALID` for Eigen op.
+static const int kInvalidPaddingValue = -1;
 
 using BiasAddGraphRunner =
     std::function<void(const Tensor& input_data, const Tensor& filter_data,
@@ -147,7 +147,7 @@ class CommonTestUtilities : public OpsTestBase {
       int filter_size, int filter_count, int bias_size,
       const std::vector<string>& fused_ops, const FusedGraphRunner& run_default,
       const FusedGraphRunner& run_fused,
-      const int padding = INVALID_PADDING_VALUE) {
+      const int padding = kInvalidPaddingValue) {
     DataType dtype = DataTypeToEnum<T>::v();
 
     Tensor image(dtype, {image_batch_count, image_height, image_width, depth});
@@ -219,22 +219,21 @@ class MklFusedConv2DOpTest : public OpsTestBase {
     auto root = tensorflow::Scope::NewRootScope();
     auto input_data_op =
         ops::Const(root.WithOpName("input"), Input::Initializer(input_data));
-    Output next_op = input_data_op;
 
-    if (padding != INVALID_PADDING_VALUE) {
+    if (padding != kInvalidPaddingValue) {
       Tensor padding_data(DT_INT32, {4, 2});
       test::FillValues<int32>(&padding_data,
                               {0, 0, padding, padding, padding, padding, 0, 0});
-      next_op = ops::Pad(root.WithOpName("pad"), next_op,
-                         ops::Const(root.WithOpName("input_data"),
-                                    Input::Initializer(padding_data)));
+      input_data_op = ops::Pad(root.WithOpName("pad"), input_data_op,
+                               ops::Const(root.WithOpName("padding_data"),
+                                          Input::Initializer(padding_data)));
     }
 
-    next_op = ops::Conv2D(
-        root.WithOpName("conv"), next_op,
+    Output next_op = ops::Conv2D(
+        root.WithOpName("conv"), input_data_op,
         ops::Const(root.WithOpName("filter"), Input::Initializer(filter_data)),
         {1, stride, stride, 1},
-        padding == INVALID_PADDING_VALUE ? "SAME" : "VALID");
+        padding == kInvalidPaddingValue ? "SAME" : "VALID");
 
     string last_op = "";
     if (std::find(fused_ops.begin(), fused_ops.end(), "BiasAdd") !=
@@ -297,7 +296,7 @@ class MklFusedConv2DOpTest : public OpsTestBase {
             .Attr("num_args", num_args)
             .Attr("strides", {1, stride, stride, 1})
             .Attr("padding",
-                  padding == INVALID_PADDING_VALUE ? "SAME" : "EXPLICIT")
+                  padding == kInvalidPaddingValue ? "SAME" : "EXPLICIT")
             .Attr("fused_ops", fused_ops)
             .Attr("_kernel", NativeFormatEnabled() ? "MklNameChangeOp"
                                                    : "MklLayoutDependentOp");
@@ -307,7 +306,7 @@ class MklFusedConv2DOpTest : public OpsTestBase {
           .Input(FakeInput(DT_UINT8))
           .Input(FakeInput(num_args, DT_UINT8));
 
-    if (padding != INVALID_PADDING_VALUE)
+    if (padding != kInvalidPaddingValue)
       builder.Attr("explicit_paddings",
                    {0, 0, padding, padding, padding, padding, 0, 0});
 
@@ -343,7 +342,7 @@ class MklFusedConv2DOpTest : public OpsTestBase {
   // Verifies computing unfused ops in a graph is identical to FusedConv2D.
   void VerifyFusedConv2D(int filter_size, int filter_count,
                          const std::vector<string>& fused_ops,
-                         const int padding = INVALID_PADDING_VALUE,
+                         const int padding = kInvalidPaddingValue,
                          int depth = kDepth, int image_width = kImageWidth,
                          int image_height = kImageHeight,
                          int image_batch_count = kImageBatchCount) {

--- a/tensorflow/core/ops/mkl_nn_ops.cc
+++ b/tensorflow/core/ops/mkl_nn_ops.cc
@@ -111,11 +111,11 @@ REGISTER_OP("_MklNativeDepthwiseConv2dNative")
     .Attr("T: {half, bfloat16, float, double}")
     .Attr("strides: list(int)")
     .Attr("is_filter_const: bool = false")
-    .Attr(GetPaddingAttrString())
+    .Attr(GetPaddingAttrStringWithExplicit())
     .Attr(GetConvnetDataFormatAttrString())
     .Attr(GetExplicitPaddingsAttrString())
     .Attr("dilations: list(int) = [1, 1, 1, 1]")
-    .SetShapeFn(shape_inference::DepthwiseConv2DNativeShape);
+    .SetShapeFn(shape_inference::DepthwiseConv2DNativeShapeWithExplicitPadding);
 
 REGISTER_OP("_MklNativeDepthwiseConv2dNativeBackpropInput")
     .Input("input_sizes: int32")
@@ -170,17 +170,18 @@ REGISTER_OP("_MklFusedConv2D")
     .Attr("num_args: int >= 0")
     .Attr("strides: list(int)")
     .Attr("is_filter_const: bool = false")
-    .Attr(GetPaddingAttrString())
+    .Attr(GetPaddingAttrStringWithExplicit())
     .Attr(GetConvnetDataFormatAttrString())
     .Attr(GetExplicitPaddingsAttrString())
     .Attr("dilations: list(int) = [1, 1, 1, 1]")
+    .Attr("use_cudnn_on_gpu: bool = true")
     .Attr("fused_ops: list(string) = []")
     // Attributes for the FusedBatchNorm ------------------------------------ //
     .Attr("epsilon: float = 0.0001")
     // Attributes for the LeakyRelu ----------------------------------------- //
     .Attr("leakyrelu_alpha: float = 0.2")
     // ---------------------------------------------------------------------- //
-    .SetShapeFn(shape_inference::Conv2DShape)
+    .SetShapeFn(shape_inference::Conv2DShapeWithExplicitPadding)
     .Doc(R"doc(
 *NOTE*: Do not invoke this operator directly in Python. MKL DNN graph transformer
  is expected to create these operators.
@@ -195,10 +196,11 @@ REGISTER_OP("_MklNativeFusedConv2D")
     .Attr("num_args: int >= 0")
     .Attr("strides: list(int)")
     .Attr("is_filter_const: bool = false")
-    .Attr(GetPaddingAttrString())
+    .Attr(GetPaddingAttrStringWithExplicit())
     .Attr(GetConvnetDataFormatAttrString())
     .Attr(GetExplicitPaddingsAttrString())
     .Attr("dilations: list(int) = [1, 1, 1, 1]")
+    .Attr("use_cudnn_on_gpu: bool = true")
     .Attr("fused_ops: list(string) = []")
     // Attributes for the FusedBatchNorm ------------------------------------ //
     .Attr("epsilon: float = 0.0001")
@@ -220,10 +222,11 @@ REGISTER_OP("_MklNativeConv2DWithBias")
     .Attr("strides: list(int)")
     .Attr("use_cudnn_on_gpu: bool = true")
     .Attr("is_filter_const: bool = false")
-    .Attr(GetPaddingAttrString())
+    .Attr(GetPaddingAttrStringWithExplicit())
     .Attr(GetConvnetDataFormatAttrString())
+    .Attr(GetExplicitPaddingsAttrString())
     .Attr("dilations: list(int) = [1, 1, 1, 1]")
-    .SetShapeFn(shape_inference::Conv2DShape)
+    .SetShapeFn(shape_inference::Conv2DShapeWithExplicitPadding)
     .Doc(R"doc(
 MKL version of Conv2D and BiasAdd operator. Uses oneDNN APIs to perform
 2D convolution and add Bias to the output of convolution.

--- a/tensorflow/core/ops/nn_ops.cc
+++ b/tensorflow/core/ops/nn_ops.cc
@@ -632,10 +632,10 @@ REGISTER_OP("_FusedDepthwiseConv2dNative")
     // Attributes for the LeakyRelu ----------------------------------------- //
     .Attr("leakyrelu_alpha: float = 0.2")
     // ---------------------------------------------------------------------- //
-
     .SetShapeFn(shape_inference::DepthwiseConv2DNativeShape);
 
 // --------------------------------------------------------------------------
+
 REGISTER_OP("Conv3D")
     .Input("input: T")
     .Input("filter: T")

--- a/tensorflow/core/ops/nn_ops.cc
+++ b/tensorflow/core/ops/nn_ops.cc
@@ -632,9 +632,7 @@ REGISTER_OP("_FusedDepthwiseConv2dNative")
     // Attributes for the LeakyRelu ----------------------------------------- //
     .Attr("leakyrelu_alpha: float = 0.2")
     // ---------------------------------------------------------------------- //
-
     .SetShapeFn(shape_inference::DepthwiseConv2DNativeShape);
-
 // --------------------------------------------------------------------------
 REGISTER_OP("Conv3D")
     .Input("input: T")
@@ -1656,11 +1654,11 @@ REGISTER_OP("_MklDepthwiseConv2dNative")
     .Attr("T: {half, bfloat16, float, double}")
     .Attr("strides: list(int)")
     .Attr("is_filter_const: bool = false")
-    .Attr(GetPaddingAttrString())
+    .Attr(GetPaddingAttrStringWithExplicit())
     .Attr(GetConvnetDataFormatAttrString())
     .Attr(GetExplicitPaddingsAttrString())
     .Attr("dilations: list(int) = [1, 1, 1, 1]")
-    .SetShapeFn(shape_inference::DepthwiseConv2DNativeShape);
+    .SetShapeFn(shape_inference::DepthwiseConv2DNativeShapeWithExplicitPadding);
 
 REGISTER_OP("_MklConv2D")
     .Input("input: T")
@@ -1675,11 +1673,11 @@ REGISTER_OP("_MklConv2D")
     .Attr("strides: list(int)")
     .Attr("use_cudnn_on_gpu: bool = true")
     .Attr("is_filter_const: bool = false")
-    .Attr(GetPaddingAttrString())
+    .Attr(GetPaddingAttrStringWithExplicit())
     .Attr(GetConvnetDataFormatAttrString())
     .Attr(GetExplicitPaddingsAttrString())
     .Attr("dilations: list(int) = [1, 1, 1, 1]")
-    .SetShapeFn(shape_inference::Conv2DShape)
+    .SetShapeFn(shape_inference::Conv2DShapeWithExplicitPadding)
     .Doc(R"doc(
 MKL version of Conv2D operator. Uses MKL DNN APIs to perform 2D convolution.
 
@@ -1716,10 +1714,11 @@ REGISTER_OP("__MklDummyConv2DWithBias")
     .Attr("strides: list(int)")
     .Attr("use_cudnn_on_gpu: bool = true")
     .Attr("is_filter_const: bool = false")
-    .Attr(GetPaddingAttrString())
+    .Attr(GetPaddingAttrStringWithExplicit())
+    .Attr(GetExplicitPaddingsAttrString())
     .Attr(GetConvnetDataFormatAttrString())
     .Attr("dilations: list(int) = [1, 1, 1, 1]")
-    .SetShapeFn(shape_inference::Conv2DShape)
+    .SetShapeFn(shape_inference::Conv2DShapeWithExplicitPadding)
     .Doc(R"doc(
 Dummy node that enables fusing Conv2D and BiasAdd operator for MKL. This node
 does not perform anything. It is just created as an intermediate output of
@@ -1744,10 +1743,11 @@ REGISTER_OP("_MklConv2DWithBias")
     .Attr("strides: list(int)")
     .Attr("use_cudnn_on_gpu: bool = true")
     .Attr("is_filter_const: bool = false")
-    .Attr(GetPaddingAttrString())
+    .Attr(GetPaddingAttrStringWithExplicit())
+    .Attr(GetExplicitPaddingsAttrString())
     .Attr(GetConvnetDataFormatAttrString())
     .Attr("dilations: list(int) = [1, 1, 1, 1]")
-    .SetShapeFn(shape_inference::Conv2DShape)
+    .SetShapeFn(shape_inference::Conv2DShapeWithExplicitPadding)
     .Doc(R"doc(
 MKL version of Conv2D and BiasAdd operator. Uses MKL DNN APIs to perform
 2D convolution and add Bias to the output of convolution.
@@ -1764,7 +1764,6 @@ REGISTER_OP("__MklDummyPadWithConv2D")
     .Attr("T: {bfloat16, float}")
     .Attr("strides: list(int)")
     .Attr("use_cudnn_on_gpu: bool = true")
-    .Attr("is_filter_const: bool = false")
     .Attr(GetPaddingAttrString())
     .Attr(GetConvnetDataFormatAttrString())
     .Attr("dilations: list(int) = [1, 1, 1, 1]")

--- a/tensorflow/core/ops/nn_ops.cc
+++ b/tensorflow/core/ops/nn_ops.cc
@@ -632,7 +632,9 @@ REGISTER_OP("_FusedDepthwiseConv2dNative")
     // Attributes for the LeakyRelu ----------------------------------------- //
     .Attr("leakyrelu_alpha: float = 0.2")
     // ---------------------------------------------------------------------- //
+
     .SetShapeFn(shape_inference::DepthwiseConv2DNativeShape);
+
 // --------------------------------------------------------------------------
 REGISTER_OP("Conv3D")
     .Input("input: T")


### PR DESCRIPTION
This MR is to enable MklConv/MklFusedConv with `explicit_padding` attribute. It reused the logic of PadConv because `explicit_padding` is equal to Pad + Conv(VALID).

Changes:
* Support `explicit_padding` in MklConv/MklFuseConv definition and compute function
* Enable rewrite rule in layout pass, and use generic copy function to check whether we missed any attribute while copying from Eigen op
* Add new unit test

Note the feature can be checked by UT `//tensorflow/python/kernel_tests:conv_ops_test`, I only added new C++ case for fusion kernel.

Signed-off-by: Lu Teng teng.lu@intel.com