### PR TITLE
xrt ops use bfc_allocator instead

### DIFF
--- a/tensorflow/compiler/xrt/kernels/xrt_compile_ops.cc
+++ b/tensorflow/compiler/xrt/kernels/xrt_compile_ops.cc
@@ -161,7 +161,7 @@ Status XRTCompileOp::Compile(OpKernelContext* ctx,
   build_options.set_device_ordinal(device_ref.device_ordinal());
   build_options.set_num_replicas(num_replicas);
   build_options.set_result_layout(xla::Shape(config.program_shape().result()));
-  build_options.set_device_allocator(device_ref.backend()->memory_allocator());
+  build_options.set_device_allocator(device_ref.GetMemoryAllocator(ctx));
   if (config.has_debug_options()) {
     *build_options.mutable_debug_options() =
         BuildXlaDebugOptions(config.debug_options());

--- a/tensorflow/compiler/xrt/kernels/xrt_state_ops.h
+++ b/tensorflow/compiler/xrt/kernels/xrt_state_ops.h
@@ -201,7 +201,8 @@ class XRTAllocateOp : public OpKernel {
     XRTTupleAllocation* allocation;
     OP_REQUIRES_OK(ctx, XRTTupleAllocation::CreateAndTransfer(
                             literal, memory_manager.get(), device_ref.backend(),
-                            device_ref.device_ordinal(), &allocation));
+                            device_ref.device_ordinal(), &allocation,
+                            device_ref.GetMemoryAllocator()));
 
     Tensor output(DT_INT64, TensorShape({}));
     output.scalar<int64>()() = memory_manager->Register(allocation);
@@ -239,10 +240,10 @@ class XRTAllocateUninitializedOp : public OpKernel {
 
     RefPtr<XRTMemoryManager> memory_manager = XRTMemoryManager::Get(rm);
     XRTTupleAllocation* allocation;
-    OP_REQUIRES_OK(ctx,
-                   XRTTupleAllocation::CreateUninitialized(
-                       xla_shape_, memory_manager.get(), device_ref.backend(),
-                       device_ref.device_ordinal(), &allocation));
+    OP_REQUIRES_OK(ctx, XRTTupleAllocation::CreateUninitialized(
+                            xla_shape_, memory_manager.get(),
+                            device_ref.backend(), device_ref.device_ordinal(),
+                            &allocation, device_ref.GetMemoryAllocator()));
 
     Tensor output(DT_INT64, TensorShape({}));
     output.scalar<int64>()() = memory_manager->Register(allocation);
@@ -345,7 +346,8 @@ class XRTAllocateFromTensorOp : public OpKernel {
     XRTTupleAllocation* allocation;
     OP_REQUIRES_OK(ctx, XRTTupleAllocation::CreateAndTransfer(
                             literal, memory_manager.get(), device_ref.backend(),
-                            device_ref.device_ordinal(), &allocation));
+                            device_ref.device_ordinal(), &allocation,
+                            device_ref.GetMemoryAllocator()));
 
     Tensor output(DT_INT64, TensorShape({}));
     output.scalar<int64>()() = memory_manager->Register(allocation);
@@ -462,10 +464,11 @@ class XRTMakeTupleOp : public OpKernel {
 
     RefPtr<XRTMemoryManager> memory_manager = XRTMemoryManager::Get(rm);
     XRTTupleAllocation* output_allocation;
-    OP_REQUIRES_OK(ctx, XRTTupleAllocation::MakeTuple(
-                            memory_manager.get(), device_ref.backend(),
-                            device_ref.device_ordinal(), tuple_shape_tree,
-                            &output_allocation));
+    OP_REQUIRES_OK(ctx,
+                   XRTTupleAllocation::MakeTuple(
+                       memory_manager.get(), device_ref.backend(),
+                       device_ref.device_ordinal(), tuple_shape_tree,
+                       &output_allocation, device_ref.GetMemoryAllocator()));
     RefPtr<XRTTupleAllocation> output_ptr(output_allocation);
     for (int i = 0; i < input_vector.size(); ++i) {
       if (input_vector[i].release_allocation_after_use) {
@@ -735,7 +738,8 @@ class XRTCompactAllocationsOp : public OpKernel {
     class DeviceAccessor::ScopedRef device_ref;
     OP_REQUIRES_OK(ctx, DeviceAccessor::InitScopedRef(ctx, &device_ref));
     OP_REQUIRES_OK(ctx, memory_manager->CompactAllocations(
-                            device_ref.backend(), device_ref.device_ordinal()));
+                            device_ref.backend(), device_ref.device_ordinal(),
+                            device_ref.GetMemoryAllocator()));
   }
 };
 

--- a/tensorflow/compiler/xrt/xrt_device.cc
+++ b/tensorflow/compiler/xrt/xrt_device.cc
@@ -20,10 +20,10 @@ limitations under the License.
 #include <map>
 
 #include "tensorflow/compiler/jit/xla_device.h"
+#include "tensorflow/core/common_runtime/gpu/gpu_process_state.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/resource_mgr.h"
 #include "tensorflow/core/lib/core/status.h"
-#include "tensorflow/core/platform/mutex.h"
 
 namespace tensorflow {
 namespace {
@@ -76,7 +76,8 @@ XRTGenericDeviceAccessor::GetOrCreateCompilationCache(
                             " on device with ordinal ",
                             metadata->device_ordinal());
   }
-  scoped_ref->Acquire(metadata->client(), device_ordinal);
+  scoped_ref->Acquire(metadata->client(), device_ordinal,
+                      metadata->platform()->Name());
   return Status::OK();
 }
 
@@ -84,8 +85,56 @@ XRTGenericDeviceAccessor::GetOrCreateCompilationCache(
     OpKernelContext* ctx, ScopedRef* scoped_ref) {
   const XlaDevice::Metadata* metadata;
   TF_RETURN_IF_ERROR(XlaDevice::GetMetadata(ctx, &metadata));
-  scoped_ref->Acquire(metadata->client(), metadata->device_ordinal());
+  scoped_ref->Acquire(metadata->client(), metadata->device_ordinal(),
+                      metadata->platform()->Name());
   return Status::OK();
 }
 
+mutex XRTGenericDeviceAccessor::ScopedRef::mutex_;
+std::map<void*, std::unique_ptr<se::TfAllocatorAdapter>>
+    XRTGenericDeviceAccessor::ScopedRef::compile_cuda_allocators_;
+std::map<std::string, std::unique_ptr<se::TfAllocatorAdapter>>
+    XRTGenericDeviceAccessor::ScopedRef::other_cuda_allocators_;
+
+se::DeviceMemoryAllocator*
+XRTGenericDeviceAccessor::ScopedRef::GetMemoryAllocator() {
+  if (platform_name_ != "CUDA") {
+    return client_->mutable_backend()->memory_allocator();
+  }
+  if (!other_cuda_allocators_.count(platform_name_)) {
+    mutex_lock lock(mutex_);
+    if (!other_cuda_allocators_.count(platform_name_)) {
+      se::Platform* platform =
+          se::MultiPlatformManager::PlatformWithName(platform_name_)
+              .ValueOrDie();
+      GPUOptions gpu_options;
+      Allocator* raw_allocator =
+          GPUProcessState::singleton()->GetGPUAllocator(TfGpuId(ordinal_));
+      other_cuda_allocators_[platform_name_] =
+          std::make_unique<se::TfAllocatorAdapter>(raw_allocator, platform,
+                                                   false);
+    }
+  }
+  return other_cuda_allocators_[platform_name_].get();
+}
+
+se::DeviceMemoryAllocator*
+XRTGenericDeviceAccessor::ScopedRef::GetMemoryAllocator(OpKernelContext* ctx) {
+  if (platform_name_ != "CUDA") {
+    return client_->mutable_backend()->memory_allocator();
+  }
+  auto stream = ctx->op_device_context()->stream();
+  if (!compile_cuda_allocators_.count(stream)) {
+    mutex_lock lock(mutex_);
+    if (!compile_cuda_allocators_.count(stream)) {
+      GPUOptions gpu_options;
+      Allocator* raw_allocator =
+          GPUProcessState::singleton()->GetGPUAllocator(TfGpuId(ordinal_));
+      compile_cuda_allocators_[stream] =
+          std::make_unique<se::TfAllocatorAdapter>(raw_allocator, stream,
+                                                   false);
+    }
+  }
+  return compile_cuda_allocators_[stream].get();
+}
 }  // namespace tensorflow

--- a/tensorflow/compiler/xrt/xrt_memory_manager.cc
+++ b/tensorflow/compiler/xrt/xrt_memory_manager.cc
@@ -99,7 +99,8 @@ class XRTMemoryManager::DeviceContext {
   }
 
   Status CompactAllocations(XRTMemoryManager* memory_manager,
-                            xla::Backend* backend) {
+                            xla::Backend* backend,
+                            se::DeviceMemoryAllocator* allocator) {
     profiler::TraceMe trace_me("XRTMemoryManager::CompactAllocations",
                                /*level=*/2);
     auto timed = monitoring::MakeTimed(xrt_metrics::GetMemoryCompactCell());
@@ -131,7 +132,8 @@ class XRTMemoryManager::DeviceContext {
     // At this point we have released all the device memory we could release.
     // Load back the tuple allocations we have swapped out above.
     for (auto& it : swapped) {
-      auto swap_result_or = it->tuple->SwapIn(memory_manager, backend);
+      auto swap_result_or =
+          it->tuple->SwapIn(memory_manager, backend, allocator);
       if (!swap_result_or.ok()) {
         // If we failed to restored a pinned allocation, better to CHECK here
         // than wondering why XRTTupleAllocation calls fail with errors about
@@ -194,11 +196,11 @@ XRTMemoryManager::WorkingSet::~WorkingSet() {
   }
 }
 
-Status XRTMemoryManager::WorkingSet::LookupAndPin(xla::Backend* backend,
-                                                  int64 handle) {
+Status XRTMemoryManager::WorkingSet::LookupAndPin(
+    xla::Backend* backend, int64 handle, se::DeviceMemoryAllocator* allocator) {
   TF_ASSIGN_OR_RETURN(auto tuple, memory_manager_->Lookup(handle));
   TF_RETURN_IF_ERROR(
-      tuple->PinAndSwapIn(memory_manager_.get(), backend).status());
+      tuple->PinAndSwapIn(memory_manager_.get(), backend, allocator).status());
   pinned_tuples_.push_back(std::move(tuple));
   return Status::OK();
 }
@@ -246,12 +248,13 @@ Status XRTMemoryManager::Release(int64 handle) {
   return Status::OK();
 }
 
-Status XRTMemoryManager::CompactAllocations(xla::Backend* backend,
-                                            int device_ordinal) {
+Status XRTMemoryManager::CompactAllocations(
+    xla::Backend* backend, int device_ordinal,
+    se::DeviceMemoryAllocator* allocator) {
   DeviceContext* device_context = GetDeviceContext(device_ordinal,
                                                    /*create_if_missing=*/false);
   return device_context != nullptr
-             ? device_context->CompactAllocations(this, backend)
+             ? device_context->CompactAllocations(this, backend, allocator)
              : Status::OK();
 }
 
@@ -265,8 +268,8 @@ void XRTMemoryManager::ReleaseAllAllocations() {
 }
 
 xla::StatusOr<se::OwningDeviceMemory> XRTMemoryManager::Allocate(
-    xla::Backend* backend, int device_ordinal, size_t size) {
-  se::DeviceMemoryAllocator* allocator = backend->memory_allocator();
+    xla::Backend* backend, int device_ordinal, size_t size,
+    se::DeviceMemoryAllocator* allocator) {
   auto memory_or =
       allocator->Allocate(device_ordinal, size, /*retry_on_failure=*/false);
   if (memory_or.status().code() == error::RESOURCE_EXHAUSTED) {
@@ -318,8 +321,9 @@ XRTMemoryManager::DeviceContext* XRTMemoryManager::GetDeviceContext(
   return device_context;
 }
 
-Status XRTMemoryManager::TryFreeMemoryStep(MemoryReclaimContext* mrctx,
-                                           const Status& status) {
+Status XRTMemoryManager::TryFreeMemoryStep(
+    MemoryReclaimContext* mrctx, const Status& status,
+    se::DeviceMemoryAllocator* allocator) {
   DeviceContext* device_context = GetDeviceContext(mrctx->device_ordinal,
                                                    /*create_if_missing=*/false);
   if (device_context == nullptr) {
@@ -351,7 +355,8 @@ Status XRTMemoryManager::TryFreeMemoryStep(MemoryReclaimContext* mrctx,
   }
   if (!mrctx->done_compacting) {
     mrctx->done_compacting = true;
-    if (device_context->CompactAllocations(this, mrctx->backend).ok()) {
+    if (device_context->CompactAllocations(this, mrctx->backend, allocator)
+            .ok()) {
       return Status::OK();
     }
   }

--- a/tensorflow/compiler/xrt/xrt_state.h
+++ b/tensorflow/compiler/xrt/xrt_state.h
@@ -83,7 +83,8 @@ class XRTTupleAllocation : public core::RefCounted {
   static Status CreateAndTransfer(const xla::LiteralBase& literal,
                                   XRTMemoryManager* memory_manager,
                                   xla::Backend* backend, int device_ordinal,
-                                  XRTTupleAllocation** allocation);
+                                  XRTTupleAllocation** allocation,
+                                  se::DeviceMemoryAllocator* allocator);
 
   // Allocates new device memory buffers sufficient to store a tensor of
   // the specified shape, and returns a XRTTupleAllocation handle to the
@@ -91,12 +92,14 @@ class XRTTupleAllocation : public core::RefCounted {
   static Status CreateUninitialized(const xla::Shape& shape,
                                     XRTMemoryManager* memory_manager,
                                     xla::Backend* backend, int device_ordinal,
-                                    XRTTupleAllocation** allocation);
+                                    XRTTupleAllocation** allocation,
+                                    se::DeviceMemoryAllocator* allocator);
 
   // Wraps an existing ShapeBuffer in a new XRTTupleAllocation handle.
   static Status CreateFromBuffer(const xla::ShapedBuffer& shaped_buffer,
                                  xla::Backend* backend, int device_ordinal,
-                                 XRTTupleAllocation** allocation);
+                                 XRTTupleAllocation** allocation,
+                                 se::DeviceMemoryAllocator* allocator);
 
   // Same as the CreateFromBuffer() API above, but with the shapes being passed
   // as input. This API is used when creating tuple allocations with the output
@@ -106,7 +109,8 @@ class XRTTupleAllocation : public core::RefCounted {
                                  const xla::Shape& on_host_shape,
                                  const xla::Shape& on_device_shape,
                                  xla::Backend* backend, int device_ordinal,
-                                 XRTTupleAllocation** allocation);
+                                 XRTTupleAllocation** allocation,
+                                 se::DeviceMemoryAllocator* allocator);
 
   // Aliases a sub-shape of parent and returns a XRTTupleAllocation handle
   // to the sub-shape. If alias_base_allocation is true, the buffers in the
@@ -139,7 +143,8 @@ class XRTTupleAllocation : public core::RefCounted {
   static Status MakeTuple(XRTMemoryManager* memory_manager,
                           xla::Backend* backend, int device_ordinal,
                           const xla::ShapeTree<ExpandedTupleInput>& elements,
-                          XRTTupleAllocation** allocation);
+                          XRTTupleAllocation** allocation,
+                          se::DeviceMemoryAllocator* allocator);
 
   // Copies the allocation from device to host and returns it in literal.
   Status ToLiteral(xla::Backend* backend, xla::MutableLiteralBase* literal);
@@ -158,14 +163,16 @@ class XRTTupleAllocation : public core::RefCounted {
   // the internal literal, and transfer the literal value into the device
   // memory. Returns a boolean telling whether the allocation was swapped in.
   xla::StatusOr<bool> SwapIn(XRTMemoryManager* memory_manager,
-                             xla::Backend* backend);
+                             xla::Backend* backend,
+                             se::DeviceMemoryAllocator* allocator);
 
   // Pins the allocation first, then swap it in (if it is not already). After
   // this API returns, the allocation is pinned and its content on device
   // memory. The caller is responsible for releasing the pin-count using the
   // Unpin() API.
   xla::StatusOr<bool> PinAndSwapIn(XRTMemoryManager* memory_manager,
-                                   xla::Backend* backend);
+                                   xla::Backend* backend,
+                                   se::DeviceMemoryAllocator* allocator);
 
   // Checks whether the allocation is currently swapped out.
   bool IsSwapped() const;

--- a/tensorflow/compiler/xrt/xrt_util.h
+++ b/tensorflow/compiler/xrt/xrt_util.h
@@ -78,7 +78,8 @@ xla::StatusOr<std::vector<RefPtr<XRTTupleAllocation>>> GetInputTupleAllocations(
     const std::vector<InputCoords>& input_coords,
     XRTMemoryManager::WorkingSet* working_set, xla::Backend* backend,
     int64 num_input_shapes,
-    const std::function<xla::Shape(int64)>& shape_getter, bool release_inputs);
+    const std::function<xla::Shape(int64)>& shape_getter, bool release_inputs,
+    se::DeviceMemoryAllocator* allocator);
 
 Status RebuildOutputAliases(
     const RefPtr<XRTTupleAllocation>& output_tuple,
@@ -109,7 +110,8 @@ Status ExecuteChained(OpKernelContext* context,
                       xla::Backend* backend, int device_ordinal,
                       const xrt::XRTChainedExecutePlan& plan,
                       const xrt::XRTChainedExecuteConfig& config,
-                      const ChainedExecuteFn& execute_op);
+                      const ChainedExecuteFn& execute_op,
+                      se::DeviceMemoryAllocator* allocator);
 
 }  // namespace tensorflow
 

--- a/tensorflow/core/common_runtime/gpu/gpu_process_state.h
+++ b/tensorflow/core/common_runtime/gpu/gpu_process_state.h
@@ -84,6 +84,11 @@ class GPUProcessState {
   virtual Allocator* GetGPUAllocator(const GPUOptions& options,
                                      TfGpuId tf_gpu_id, size_t total_bytes);
 
+  virtual Allocator* GetGPUAllocator(TfGpuId tf_gpu_id) {
+    GPUOptions options;
+    return GetGPUAllocator(options, tf_gpu_id, 0);
+  }
+
   int NumGPUAllocators() {
     mutex_lock l(mu_);
     return gpu_allocators_.size();

--- a/tensorflow/stream_executor/tf_allocator_adapter.cc
+++ b/tensorflow/stream_executor/tf_allocator_adapter.cc
@@ -24,14 +24,19 @@ limitations under the License.
 namespace stream_executor {
 
 TfAllocatorAdapter::TfAllocatorAdapter(tensorflow::Allocator *wrapped,
-                                       Stream *stream)
+                                       Stream *stream, bool allow_async_dealloc)
     : DeviceMemoryAllocator(stream->parent()->platform()),
       wrapped_(wrapped),
-      stream_(stream) {}
+      stream_(stream),
+      allow_async_dealloc_(allow_async_dealloc) {}
 
 TfAllocatorAdapter::TfAllocatorAdapter(tensorflow::Allocator *wrapped,
-                                       Platform *platform)
-    : DeviceMemoryAllocator(platform), wrapped_(wrapped), stream_(nullptr) {}
+                                       Platform *platform,
+                                       bool allow_async_dealloc)
+    : DeviceMemoryAllocator(platform),
+      wrapped_(wrapped),
+      stream_(nullptr),
+      allow_async_dealloc_(allow_async_dealloc) {}
 
 TfAllocatorAdapter::~TfAllocatorAdapter() {}
 

--- a/tensorflow/stream_executor/tf_allocator_adapter.h
+++ b/tensorflow/stream_executor/tf_allocator_adapter.h
@@ -32,10 +32,12 @@ class TfAllocatorAdapter : public DeviceMemoryAllocator {
  public:
   // stream: a Stream on which the allocator can only be used. If non-null, the
   // allocator can not be used on any other stream.
-  TfAllocatorAdapter(tensorflow::Allocator *wrapped, Stream *stream);
+  TfAllocatorAdapter(tensorflow::Allocator *wrapped, Stream *stream,
+                     bool allow_async_dealloc = true);
 
   // Constructor for the cases where `stream` can not be provided.
-  TfAllocatorAdapter(tensorflow::Allocator *wrapped, Platform *platform);
+  TfAllocatorAdapter(tensorflow::Allocator *wrapped, Platform *platform,
+                     bool allow_async_dealloc = true);
 
   ~TfAllocatorAdapter() override;
 
@@ -52,13 +54,16 @@ class TfAllocatorAdapter : public DeviceMemoryAllocator {
   // support for multiple GPU streams or allocators with different ordering
   // requirements, this code may need to change.
   // (This attribute has no effect on CPU.)
-  bool AllowsAsynchronousDeallocation() const override { return true; }
+  bool AllowsAsynchronousDeallocation() const override {
+    return allow_async_dealloc_;
+  }
 
   port::StatusOr<Stream *> GetStream(int device_ordinal) override;
 
  private:
   tensorflow::Allocator *wrapped_;
   Stream *stream_;
+  bool allow_async_dealloc_;
 };
 
 // Adapter class that wraps per-device TF allocators with corresponding streams


### PR DESCRIPTION
XRT ops use `cuMemAlloc` directly, which will hurt the performance a lot.

This PR changes the cuda allocator to bfc allocator.

For Resnet-50 fp16 training with batchsize 256 in Tesla V100 GPU, the performance could increase from `730 images/s` to `1290 images/s`. Please refer to the [torch/xla issue](https://github.com/pytorch/xla/issues/2614) for more details.

