### PR TITLE
Include C logging API into part of the libtensorflow_framework.so

### DIFF
--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -730,6 +730,7 @@ tf_cc_shared_object(
         "//tensorflow/c/experimental/filesystem:filesystem_interface",
         "//tensorflow/c/experimental/stream_executor:stream_executor_hdrs",
         "//tensorflow/c:kernels_hdrs",
+        "//tensorflow/c:logging",
         "//tensorflow/c:ops_hdrs",
         "//tensorflow/cc/saved_model:loader_lite_impl",
         "//tensorflow/core/common_runtime:core_cpu_impl",


### PR DESCRIPTION
This PR includes C logging API into part of the libtensorflow_framework.so
as otherwise the file system plugins will not be able to link to TF_Log
to send logs to tensorflow logging system.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>