### PR TITLE
Fix for TF Lite verifier, arg_min_max op and lsh_projection_test on Big Endian machine

### DIFF
--- a/tensorflow/lite/delegates/nnapi/nnapi_delegate_test.cc
+++ b/tensorflow/lite/delegates/nnapi/nnapi_delegate_test.cc
@@ -2040,7 +2040,13 @@ TEST(NNAPIDelegate, LSHProjectionDense1DInputs) {
 
   m.Invoke();
 
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && \
+    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  // Hash returns differently on machines with different endianness
+  EXPECT_THAT(m.GetOutput(), ElementsAre(0, 0, 1, 1, 1, 0));
+#else
   EXPECT_THAT(m.GetOutput(), ElementsAre(0, 0, 0, 1, 0, 0));
+#endif
 }
 
 TEST(NNAPIDelegate, LSHProjectionSparse1DInputs) {
@@ -2051,7 +2057,13 @@ TEST(NNAPIDelegate, LSHProjectionSparse1DInputs) {
 
   m.Invoke();
 
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && \
+    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  // Hash returns differently on machines with different endianness
+  EXPECT_THAT(m.GetOutput(), ElementsAre(0 + 0, 4 + 3, 8 + 2));
+#else
   EXPECT_THAT(m.GetOutput(), ElementsAre(0 + 0, 4 + 1, 8 + 0));
+#endif
 }
 
 TEST(NNAPIDelegate, LSHProjectionSparse3DInputs) {
@@ -2064,7 +2076,13 @@ TEST(NNAPIDelegate, LSHProjectionSparse3DInputs) {
 
   m.Invoke();
 
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && \
+    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  // Hash returns differently on machines with different endianness
+  EXPECT_THAT(m.GetOutput(), ElementsAre(0 + 0, 4 + 3, 8 + 2));
+#else
   EXPECT_THAT(m.GetOutput(), ElementsAre(0 + 2, 4 + 1, 8 + 1));
+#endif
 }
 
 class BaseActivationsOpModel : public SingleOpModelWithNNAPI {

--- a/tensorflow/lite/kernels/arg_min_max.cc
+++ b/tensorflow/lite/kernels/arg_min_max.cc
@@ -38,8 +38,9 @@ constexpr int kOutputTensor = 0;
 TfLiteStatus ResizeOutput(TfLiteContext* context, const TfLiteTensor* input,
                           const TfLiteTensor* axis, TfLiteTensor* output) {
   int axis_value;
+  // Retrive all 8 bytes when axis type is kTfLiteInt64 to avoid data loss.
   if (axis->type == kTfLiteInt64) {
-    axis_value = *GetTensorData<int64_t>(axis);
+    axis_value = static_cast<int>(*GetTensorData<int64_t>(axis));
   } else {
     axis_value = *GetTensorData<int>(axis);
   }

--- a/tensorflow/lite/kernels/arg_min_max.cc
+++ b/tensorflow/lite/kernels/arg_min_max.cc
@@ -37,7 +37,12 @@ constexpr int kOutputTensor = 0;
 
 TfLiteStatus ResizeOutput(TfLiteContext* context, const TfLiteTensor* input,
                           const TfLiteTensor* axis, TfLiteTensor* output) {
-  int axis_value = *GetTensorData<int>(axis);
+  int axis_value;
+  if (axis->type == kTfLiteInt64) {
+    axis_value = *GetTensorData<int64_t>(axis);
+  } else {
+    axis_value = *GetTensorData<int>(axis);
+  }
   if (axis_value < 0) {
     axis_value += NumDimensions(input);
   }

--- a/tensorflow/lite/kernels/lsh_projection_test.cc
+++ b/tensorflow/lite/kernels/lsh_projection_test.cc
@@ -87,7 +87,12 @@ TEST(LSHProjectionOpTest2, Dense1DInputs) {
 
   m.Invoke();
 
+#if defined(__s390x__)
+  // Hash returns differently on machines with different endianness
+  EXPECT_THAT(m.GetOutput(), ElementsAre(0, 0, 1, 1, 1, 0));
+#else
   EXPECT_THAT(m.GetOutput(), ElementsAre(0, 0, 0, 1, 0, 0));
+#endif
 }
 
 TEST(LSHProjectionOpTest2, Sparse1DInputs) {
@@ -98,7 +103,12 @@ TEST(LSHProjectionOpTest2, Sparse1DInputs) {
 
   m.Invoke();
 
+#if defined(__s390x__)
+  // Hash returns differently on machines with different endianness
+  EXPECT_THAT(m.GetOutput(), ElementsAre(0 + 0, 4 + 3, 8 + 2));
+#else
   EXPECT_THAT(m.GetOutput(), ElementsAre(0 + 0, 4 + 1, 8 + 0));
+#endif
 }
 
 TEST(LSHProjectionOpTest2, Sparse3DInputs) {
@@ -111,7 +121,12 @@ TEST(LSHProjectionOpTest2, Sparse3DInputs) {
 
   m.Invoke();
 
+#if defined(__s390x__)
+  // Hash returns differently on machines with different endianness
+  EXPECT_THAT(m.GetOutput(), ElementsAre(0 + 0, 4 + 3, 8 + 2));
+#else
   EXPECT_THAT(m.GetOutput(), ElementsAre(0 + 2, 4 + 1, 8 + 1));
+#endif
 }
 
 }  // namespace

--- a/tensorflow/lite/kernels/lsh_projection_test.cc
+++ b/tensorflow/lite/kernels/lsh_projection_test.cc
@@ -87,7 +87,8 @@ TEST(LSHProjectionOpTest2, Dense1DInputs) {
 
   m.Invoke();
 
-#if defined(__s390x__)
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && \
+    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
   // Hash returns differently on machines with different endianness
   EXPECT_THAT(m.GetOutput(), ElementsAre(0, 0, 1, 1, 1, 0));
 #else
@@ -103,7 +104,8 @@ TEST(LSHProjectionOpTest2, Sparse1DInputs) {
 
   m.Invoke();
 
-#if defined(__s390x__)
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && \
+    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
   // Hash returns differently on machines with different endianness
   EXPECT_THAT(m.GetOutput(), ElementsAre(0 + 0, 4 + 3, 8 + 2));
 #else
@@ -121,7 +123,8 @@ TEST(LSHProjectionOpTest2, Sparse3DInputs) {
 
   m.Invoke();
 
-#if defined(__s390x__)
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && \
+    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
   // Hash returns differently on machines with different endianness
   EXPECT_THAT(m.GetOutput(), ElementsAre(0 + 0, 4 + 3, 8 + 2));
 #else

--- a/tensorflow/lite/tools/verifier.cc
+++ b/tensorflow/lite/tools/verifier.cc
@@ -52,7 +52,7 @@ void ReportError(ErrorReporter* error_reporter, const char* format, ...) {
 // Returns the int32_t value pointed by ptr.
 const uint32_t GetIntPtr(const char* ptr) {
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-  return return flatbuffers::EndianScalar(*reinterpret_cast<const uint32_t*>(ptr));
+  return flatbuffers::EndianScalar(*reinterpret_cast<const uint32_t*>(ptr));
 #else
   return *reinterpret_cast<const uint32_t*>(ptr);
 #endif

--- a/tensorflow/lite/tools/verifier.cc
+++ b/tensorflow/lite/tools/verifier.cc
@@ -51,7 +51,8 @@ void ReportError(ErrorReporter* error_reporter, const char* format, ...) {
 }
 // Returns the int32_t value pointed by ptr.
 const uint32_t GetIntPtr(const char* ptr) {
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && \
+    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
   return flatbuffers::EndianScalar(*reinterpret_cast<const uint32_t*>(ptr));
 #else
   return *reinterpret_cast<const uint32_t*>(ptr);

--- a/tensorflow/lite/tools/verifier.cc
+++ b/tensorflow/lite/tools/verifier.cc
@@ -50,8 +50,12 @@ void ReportError(ErrorReporter* error_reporter, const char* format, ...) {
   }
 }
 // Returns the int32_t value pointed by ptr.
-const uint32_t* GetIntPtr(const char* ptr) {
-  return reinterpret_cast<const uint32_t*>(ptr);
+const uint32_t GetIntPtr(const char* ptr) {
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  return return flatbuffers::EndianScalar(*reinterpret_cast<const uint32_t*>(ptr));
+#else
+  return *reinterpret_cast<const uint32_t*>(ptr);
+#endif
 }
 
 // Verifies flatbuffer format of the model contents and returns the in-memory
@@ -79,7 +83,7 @@ bool VerifyStringTensorBuffer(const Tensor& tensor, const Buffer& buffer,
   }
   const char* buffer_ptr = reinterpret_cast<const char*>(buffer.data()->data());
 
-  uint32_t num_strings = *GetIntPtr(buffer_ptr);
+  uint32_t num_strings = GetIntPtr(buffer_ptr);
   if (num_strings > kMaxNumString) {
     ReportError(error_reporter,
                 "String tensor %s has invalid num of string set: %d",
@@ -100,7 +104,7 @@ bool VerifyStringTensorBuffer(const Tensor& tensor, const Buffer& buffer,
   uint32_t prev_ptr = header_offsets;
   uint32_t offset = sizeof(int32_t);
 
-  if (*GetIntPtr(buffer_ptr + offset) != header_offsets) {
+  if (GetIntPtr(buffer_ptr + offset) != header_offsets) {
     ReportError(error_reporter,
                 "String tensor %s buffer initial offset must be: %d",
                 NameOrEmptyString(tensor.name()), header_offsets);
@@ -108,7 +112,7 @@ bool VerifyStringTensorBuffer(const Tensor& tensor, const Buffer& buffer,
   }
   offset += sizeof(int32_t);
   for (int i = 1, end = num_strings; i <= end; i++, offset += sizeof(int32_t)) {
-    int string_offset = *GetIntPtr(buffer_ptr + offset);
+    int string_offset = GetIntPtr(buffer_ptr + offset);
     if (string_offset < static_cast<int>(prev_ptr) ||
         string_offset > static_cast<int>(buffer_size)) {
       ReportError(error_reporter,
@@ -117,7 +121,7 @@ bool VerifyStringTensorBuffer(const Tensor& tensor, const Buffer& buffer,
       return false;
     }
   }
-  if (*GetIntPtr(buffer_ptr + offset - sizeof(int32_t)) != buffer_size) {
+  if (GetIntPtr(buffer_ptr + offset - sizeof(int32_t)) != buffer_size) {
     ReportError(error_reporter,
                 "String tensor %s buffer last offset must be %d",
                 NameOrEmptyString(tensor.name()), buffer_size);


### PR DESCRIPTION
This PR consists of 2 fixes.
The first fix is in `verifier.cc`, as discussed in https://github.com/tensorflow/tensorflow/issues/44852.
The second fix is for retrieving `axis_value` data in `arg_min_max.cc`. Since the `axis` could be of type `int64`, it will cause an issue when retrieving it as int32 on Big Endian machines - It only retrieves the first 4 bytes which are the most significant bytes on Big Endian machines. Retrieve it as int64 at first and then convert it to int32 will be safer and more consistent.

Edit:
Push another fix for `lsh_projection_test`, as discussed in https://github.com/tensorflow/tensorflow/issues/44982.