### PR TITLE
Add s390x support for compiler related TCs

### DIFF
--- a/tensorflow/compiler/xla/service/cpu/test_target_triple_helper.h
+++ b/tensorflow/compiler/xla/service/cpu/test_target_triple_helper.h
@@ -21,8 +21,13 @@ limitations under the License.
 static const char kTargetCpuForHost[] = "ppc";
 static const char kTargetTripleForHost[] = "ppc64le-ibm-linux-gnu";
 #else
+#if defined(__s390x__)
+static const char kTargetCpuForHost[] = "s390x";
+static const char kTargetTripleForHost[] = "systemz-none-linux-gnu";
+#else
 static const char kTargetCpuForHost[] = "";
 static const char kTargetTripleForHost[] = "x86_64-pc-linux";
+#endif
 #endif
 
 #endif

--- a/tensorflow/compiler/xla/tests/local_client_aot_test_helper.cc
+++ b/tensorflow/compiler/xla/tests/local_client_aot_test_helper.cc
@@ -73,6 +73,8 @@ int main(int argc, char** argv) {
     triple_string = "x86_64-pc-windows-msvc19";
   } else if (target_cpu == "ppc") {
     triple_string = "ppc64le-ibm-linux-gnu";
+  } else if (target_cpu == "s390x") {
+    triple_string = "systemz-none-linux-gnu";
   } else if (target_cpu == "local") {
     triple_string = llvm::sys::getDefaultTargetTriple();
   } else {


### PR DESCRIPTION
Multiple compiler related test cases were failing with this error:
`Internal: TargetRegistry::lookupTarget failed: No available targets are compatible with triple "x86_64-pc-linux"`
The test cases were retrieving default value, "x86_64-pc-linux" as target architecture.

This PR adds support for s390x as target architecture and fixes 15 compiler related TCs on s390x.
 