### PR TITLE
Do not call tf.shape on a ragged tensor when computing losses.

### DIFF
--- a/tensorflow/python/keras/engine/compile_utils.py
+++ b/tensorflow/python/keras/engine/compile_utils.py
@@ -26,6 +26,7 @@ from tensorflow.python.keras import losses as losses_mod
 from tensorflow.python.keras import metrics as metrics_mod
 from tensorflow.python.keras.utils import generic_utils
 from tensorflow.python.keras.utils import losses_utils
+from tensorflow.python.keras.utils import tf_utils
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.util import nest
@@ -209,7 +210,11 @@ class LossesContainer(Container):
         loss_metric_value *= ds_context.get_strategy().num_replicas_in_sync
 
       if batch_dim is None:
-        batch_dim = array_ops.shape(y_t)[0]
+        if tf_utils.is_ragged(y_t):
+          batch_dim = y_t.nrows()
+        else:
+          batch_dim = array_ops.shape(y_t)[0]
+
       if metric_obj is not None:
         metric_obj.update_state(loss_metric_value, sample_weight=batch_dim)
 

--- a/tensorflow/python/keras/engine/compile_utils_test.py
+++ b/tensorflow/python/keras/engine/compile_utils_test.py
@@ -29,6 +29,8 @@ from tensorflow.python.keras import metrics as metrics_mod
 from tensorflow.python.keras.engine import compile_utils
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import math_ops
+from tensorflow.python.ops.ragged import ragged_functional_ops
+from tensorflow.python.ops.ragged import ragged_tensor
 from tensorflow.python.platform import test
 
 
@@ -356,6 +358,34 @@ class LossesContainerTest(keras_parameterized.TestCase):
     self.assertEqual(loss_container._losses[0].name, 'custom_loss_fn')
     self.assertEqual(loss_container._losses[1].name, 'custom_loss_class')
 
+  def test_ragged_tensor_output(self):
+    """ Ensure that ragged tensors can be passed as targets and predictions.
+    """
+    def custom_loss_fn(y_true, y_pred):
+      losses = ragged_functional_ops.map_flat_values(
+        losses_mod.mse, y_true, y_pred)
+      return math_ops.reduce_mean(losses)
+
+    class CustomLossClass(object):
+
+      def __call__(self, y_true, y_pred):
+        losses = ragged_functional_ops.map_flat_values(
+          losses_mod.mse, y_true, y_pred)
+        return math_ops.reduce_mean(losses)
+
+    loss_container = compile_utils.LossesContainer(
+        [custom_loss_fn, CustomLossClass()])
+
+    v_t = constant_op.constant([[3., 4.], [1., 2.], [3., 5.]])
+    v_p = constant_op.constant([[3.1, 4.], [1., 2.], [3., 5.]])
+
+    y_t = array_ops.expand_dims(
+      ragged_tensor.RaggedTensor.from_row_splits(v_t, [0, 2, 3]), 0)
+    y_p = array_ops.expand_dims(
+      ragged_tensor.RaggedTensor.from_row_splits(v_p, [0, 2, 3]), 0)
+    loss_container(y_t, y_p)
+
+    self.assertEqual(loss_container._losses[0].name, 'custom_loss_fn')
 
 class MetricsContainerTest(keras_parameterized.TestCase):
 

--- a/tensorflow/python/keras/utils/losses_utils.py
+++ b/tensorflow/python/keras/utils/losses_utils.py
@@ -26,6 +26,7 @@ from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops.losses import loss_reduction
+from tensorflow.python.ops.ragged import ragged_tensor
 from tensorflow.python.util.tf_export import keras_export
 
 
@@ -62,11 +63,13 @@ def remove_squeezable_dimensions(
     Tuple of `labels` and `predictions`, possibly with last dim squeezed.
   """
   with K.name_scope(name or 'remove_squeezable_dimensions'):
-    predictions = ops.convert_to_tensor_v2_with_dispatch(predictions)
-    labels = ops.convert_to_tensor_v2_with_dispatch(labels)
-    predictions_shape = predictions.get_shape()
+    if not isinstance(predictions, ragged_tensor.RaggedTensor):
+      predictions = ops.convert_to_tensor_v2_with_dispatch(predictions)
+    if not isinstance(labels, ragged_tensor.RaggedTensor):
+      labels = ops.convert_to_tensor_v2_with_dispatch(labels)
+    predictions_shape = predictions.shape
     predictions_rank = predictions_shape.ndims
-    labels_shape = labels.get_shape()
+    labels_shape = labels.shape
     labels_rank = labels_shape.ndims
     if (labels_rank is not None) and (predictions_rank is not None):
       # Use static rank.


### PR DESCRIPTION
For a ragged tensor use bounding_shape(). In losses_utils do not attempt
to convert a tensor before determining that the dimensions needs to be
squeezed. Conversion does not work for ragged tensors.

Fixes issue #44988 