### PR TITLE
TFLu: Suppress compiler error for generated segfault

### DIFF
--- a/tensorflow/lite/micro/tools/make/flatbuffers_download.sh
+++ b/tensorflow/lite/micro/tools/make/flatbuffers_download.sh
@@ -54,7 +54,9 @@ function patch_to_avoid_strtod() {
   echo "#if 1" >> ${temp_flexbuffers_path}
   echo "          // TODO(b/173239141): Patched via micro/tools/make/flexbuffers_download.sh" >> ${temp_flexbuffers_path}
   echo "          // Introduce a segfault for an unsupported code path for TFLM." >> ${temp_flexbuffers_path}
+  echo "#pragma GCC diagnostic ignored \"-Wnull-dereference\"" >> ${temp_flexbuffers_path}
   echo "          return *(static_cast<double*>(nullptr));" >> ${temp_flexbuffers_path}
+  echo "#pragma GCC diagnostic error \"-Wnull-dereference\"" >> ${temp_flexbuffers_path}
   echo "#else" >> ${temp_flexbuffers_path}
   echo "          // This is the original code" >> ${temp_flexbuffers_path}
   sed -n -e $((${string_to_num_line} -  1)),$((${string_to_num_line} + 1))p ${input_flexbuffers_path} >> ${temp_flexbuffers_path}


### PR DESCRIPTION
Suppress -Wnull-dereference for both Armclang and GCC, when
intentionally generating a segfault in patched code.

Fix for: https://github.com/tensorflow/tensorflow/issues/44971
