### PR TITLE
Create makefile targets to expose file lists to enable separate scripting

### DIFF
--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -544,6 +544,21 @@ ARDUINO_PROJECT_TARGETS := $(foreach TARGET,$(ALL_PROJECT_TARGETS),$(if $(findst
 generate_arduino_zip: $(ARDUINO_PROJECT_TARGETS) $(ARDUINO_LIBRARY_ZIPS)
 	python tensorflow/lite/micro/tools/make/merge_arduino_zips.py $(PRJDIR)/tensorflow_lite.zip $(ARDUINO_LIBRARY_ZIPS)
 
+# API for external project generation scripts to retrieve lists of files needed
+# for particular platforms. For more details see:
+# https://docs.google.com/document/d/1gfbpBtiivYMenCDIvJb-m5RIV4rKAR5dvdAJC5LLv8o
+list_library_source_files:
+	@echo $(MICROLITE_CC_SRCS)
+
+list_library_header_files:
+	@echo $(MICROLITE_CC_HDRS)
+
+list_third_party_source_files:
+	@echo $(THIRD_PARTY_CC_SRCS)
+
+list_third_party_header_files:
+	@echo $(THIRD_PARTY_CC_HDRS)
+
 # Gets rid of all generated files.
 clean:
 	rm -rf $(MAKEFILE_DIR)/gen


### PR DESCRIPTION
As per bug #45086 and the RFC at https://docs.google.com/document/d/1gfbpBtiivYMenCDIvJb-m5RIV4rKAR5dvdAJC5LLv8o/edit?usp=sharing we want to break out the project generation process from the standard make file dependency logic. By creating these targets, external scripts can retrieve the source files needed for a particular platform.

There are no tests for this change, because it's tricky to integrate GitHub-only tests into our standard Bazel setup. The scripts that will rely on this change will have their own tests that will check this API is working, and we don't have direct tests for other makefile targets, so I hope this is reasonable.