### PR TITLE
[r2.4 cherry-pick] Include C logging API into part of the libtensorflow_framework.so

### DIFF
--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -743,6 +743,7 @@ tf_cc_shared_object(
         "//tensorflow/c/experimental/filesystem:filesystem_interface",
         "//tensorflow/c/experimental/stream_executor:stream_executor_hdrs",
         "//tensorflow/c:kernels_hdrs",
+        "//tensorflow/c:logging",
         "//tensorflow/c:ops_hdrs",
         "//tensorflow/cc/saved_model:loader_lite_impl",
         "//tensorflow/core/common_runtime:core_cpu_impl",


### PR DESCRIPTION
**Note:** This PR is to **r2.4** branch and is a cherry-pick of e8c4a4d  (PR #44993) 

/cc @mihaimaruseac I think this cherry-pick makes sense to r2.4 if there is a rc3. Though I understand TF 2.4.0 release might be imminent. Feel free to close if there is no rc3.

This PR includes C logging API into part of the libtensorflow_framework.so
as otherwise the file system plugins will not be able to link to TF_Log
to send logs to tensorflow logging system.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>