### PR TITLE
r2.4: Update CMake build rules of TFLite

### DIFF
--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -27,6 +27,12 @@
 # - Host Tools (i.e conversion / analysis tools etc.)
 
 cmake_minimum_required(VERSION 3.16)
+if(NOT CMAKE_BUILD_TYPE)
+  message(STATUS "Setting build type to Release, for debug builds use"
+    "'-DCMAKE_BUILD_TYPE=Debug'.")
+  set(CMAKE_BUILD_TYPE "Release")
+endif()
+
 # Double colon in target name means ALIAS or IMPORTED target.
 cmake_policy(SET CMP0028 NEW)
 # Enable MACOSX_RPATH (@rpath) for built dynamic libraries.

--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -449,3 +449,13 @@ target_compile_options(benchmark_model
 target_link_libraries(benchmark_model
     ${TFLITE_BENCHMARK_LIBS}
 )
+
+# TFLite minimal example
+add_executable(minimal
+  EXCLUDE_FROM_ALL
+    ${TFLITE_SOURCE_DIR}/examples/minimal/minimal.cc
+)
+target_link_libraries(minimal
+  tensorflow-lite
+  ${CMAKE_DL_LIBS}
+)

--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -450,12 +450,3 @@ target_link_libraries(benchmark_model
     ${TFLITE_BENCHMARK_LIBS}
 )
 
-# TFLite minimal example
-add_executable(minimal
-  EXCLUDE_FROM_ALL
-    ${TFLITE_SOURCE_DIR}/examples/minimal/minimal.cc
-)
-target_link_libraries(minimal
-  tensorflow-lite
-  ${CMAKE_DL_LIBS}
-)

--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -319,6 +319,12 @@ populate_tflite_source_vars("kernels/internal/reference/integer_ops"
 populate_tflite_source_vars("kernels/internal/reference/sparse_ops"
   TFLITE_KERNEL_INTERNAL_REF_SPARSE_OPS_SRCS
 )
+set(TFLITE_PROFILER_SRCS ${TFLITE_SOURCE_DIR}/profiling/platform_profiler.cc)
+if(CMAKE_SYSTEM_NAME MATCHES "Android")
+  list(APPEND TFLITE_PROFILER_SRCS
+    ${TFLITE_SOURCE_DIR}/profiling/atrace_profiler.cc
+  )
+endif()
 
 # Common include directories
 set(TFLITE_INCLUDE_DIRS
@@ -353,7 +359,7 @@ add_library(tensorflow-lite
   ${TFLITE_KERNEL_SRCS}
   ${TFLITE_NNAPI_SRCS}
   ${TFLITE_SRCS}
-  ${TFLITE_SOURCE_DIR}/profiling/platform_profiler.cc
+  ${TFLITE_PROFILER_SRCS}
   ${TFLITE_SOURCE_DIR}/schema/schema_utils.cc
   ${TFLITE_SOURCE_DIR}/tools/optimize/sparsity/format_converter.cc
 )
@@ -392,7 +398,6 @@ populate_source_vars("${TFLITE_SOURCE_DIR}/tools/benchmark"
 list(APPEND TFLITE_BENCHMARK_SRCS
   ${TF_SOURCE_DIR}/core/util/stats_calculator.cc
   ${TFLITE_SOURCE_DIR}/profiling/memory_info.cc
-  ${TFLITE_SOURCE_DIR}/profiling/platform_profiler.cc
   ${TFLITE_SOURCE_DIR}/profiling/profile_summarizer.cc
   ${TFLITE_SOURCE_DIR}/profiling/profile_summary_formatter.cc
   ${TFLITE_SOURCE_DIR}/profiling/time.cc
@@ -424,9 +429,6 @@ else()
 endif()  # TFLITE_ENABLE_XNNPACK
 
 if(CMAKE_SYSTEM_NAME MATCHES "Android")
-  list(APPEND TFLITE_BENCHMARK_SRCS
-    ${TFLITE_SOURCE_DIR}/profiling/atrace_profiler.cc
-  )
   if(_TFLITE_ENABLE_NNAPI)
     list(APPEND TFLITE_BENCHMARK_SRCS
       ${TFLITE_SOURCE_DIR}/tools/delegates/nnapi_delegate_provider.cc

--- a/tensorflow/lite/examples/minimal/CMakeLists.txt
+++ b/tensorflow/lite/examples/minimal/CMakeLists.txt
@@ -1,0 +1,44 @@
+#
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Builds the minimal Tensorflow Lite example.
+
+cmake_minimum_required(VERSION 3.16)
+project(minimal C CXX)
+
+set(TENSORFLOW_SOURCE_DIR "" CACHE PATH
+  "Directory that contains the TensorFlow project"
+)
+if(NOT TENSORFLOW_SOURCE_DIR)
+  get_filename_component(TENSORFLOW_SOURCE_DIR
+    "${CMAKE_CURRENT_LIST_DIR}/../../../../"
+    ABSOLUTE
+  )
+endif()
+
+add_subdirectory(
+  "${TENSORFLOW_SOURCE_DIR}/tensorflow/lite"
+  "${CMAKE_CURRENT_BINARY_DIR}/tensorflow-lite"
+  EXCLUDE_FROM_ALL
+)
+
+add_executable(minimal
+  minimal.cc
+)
+target_link_libraries(minimal
+  tensorflow-lite
+  ${CMAKE_DL_LIBS}
+)

--- a/tensorflow/lite/examples/minimal/README.md
+++ b/tensorflow/lite/examples/minimal/README.md
@@ -1,0 +1,37 @@
+# TensorFlow Lite C++ minimal example
+
+This example shows how you can build a simple TensorFlow Lite application.
+
+#### Step 1. Install CMake tool
+
+It requires CMake 3.16 or higher. On Ubuntu, you can simply run the following
+command.
+
+```sh
+sudo apt-get install cmake
+```
+
+Or you can follow
+[the official cmake installation guide](https://cmake.org/install/)
+
+#### Step 2. Clone TensorFlow repository
+
+```sh
+git clone https://github.com/tensorflow/tensorflow.git tensorflow_src
+```
+
+#### Step 3. Create CMake build directory and run CMake tool
+
+```sh
+mkdir minimal_build
+cd minimal_build
+cmake ../tensorflow_src/tensorflow/lite/examples/minimal
+```
+
+#### Step 4. Build TensorFlow Lite
+
+In the minimal_build directory,
+
+```sh
+cmake --build . -j
+```

--- a/tensorflow/lite/tools/cmake/README.md
+++ b/tensorflow/lite/tools/cmake/README.md
@@ -40,6 +40,13 @@ cd tflite_build
 cmake ../tensorflow_src/tensorflow/lite
 ```
 
+It generates release binary by default. If you need to produce debug builds, you
+need to provide '-DCMAKE_BUILD_TYPE=Debug' option.
+
+```sh
+cmake ../tensorflow_src/tensorflow/lite -DCMAKE_BUILD_TYPE=Debug
+```
+
 If you want to configure Android build with GPU delegate support,
 
 ```sh


### PR DESCRIPTION
These are cherry-picks of master branch to make CMake build more stable on 2.4 branch.

Changes are mostly on tensorflow/lite/CMakeLists.txt.