### PR TITLE
label_image linker fix

### DIFF
--- a/tensorflow/lite/tools/make/Makefile
+++ b/tensorflow/lite/tools/make/Makefile
@@ -111,7 +111,9 @@ MINIMAL_SRCS := \
 LABEL_IMAGE_SRCS := \
 	tensorflow/lite/examples/label_image/bitmap_helpers.cc \
 	tensorflow/lite/examples/label_image/label_image.cc \
-	tensorflow/lite/tools/evaluation/utils.cc
+	tensorflow/lite/tools/evaluation/utils.cc \
+	tensorflow/lite/tools/command_line_flags.cc \
+	tensorflow/lite/tools/tool_params.cc
 
 # What sources we want to compile, must be kept in sync with the main Bazel
 # build files.


### PR DESCRIPTION
While building label_image using makefile we get linker error. So to solve this, tensorflow/lite/tools/command_line_flags.cc and tensorflow/lite/tools/tool_params.cc are added to LABEL_IMAGE_SRCS