### PR TITLE
Added useful C++ symbols missing from the tensorflow DLL on windows

### DIFF
--- a/tensorflow/tools/def_file_filter/def_file_filter.py.tpl
+++ b/tensorflow/tools/def_file_filter/def_file_filter.py.tpl
@@ -268,6 +268,14 @@ def main():
       def_fp.write("LIBRARY " + args.target + "\n")
     def_fp.write("EXPORTS\n")
     def_fp.write("\t ??1OpDef@tensorflow@@UEAA@XZ\n")
+    # Write additional symbols:
+    def_fp.write("\t ??0SessionOptions@tensorflow@@QEAA@XZ\n")
+    def_fp.write("\t ?NewSession@tensorflow@@YAPEAVSession@1@AEBUSessionOptions@1@@Z\n")
+    def_fp.write("\t ??1SavedModelBundleInterface@tensorflow@@UEAA@XZ\n")
+    def_fp.write("\t ?LoadSavedModel@tensorflow@@YA?AVStatus@1@AEBUSessionOptions@1@AEBVRunOptions@1@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@AEBV?$unordered_set@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@U?$hash@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@2@U?$equal_to@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@2@V?$allocator@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@2@@6@QEAUSavedModelBundle@1@@Z\n")
+    def_fp.write("\t ?MaybeSavedModelDirectory@tensorflow@@YA_NAEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z\n")
+    def_fp.write("\t ?_TensorShapeProto_default_instance_@tensorflow@@3VTensorShapeProtoDefaultTypeInternal@1@A\n")
+    def_fp.write("\t ?_GraphDef_default_instance_@tensorflow@@3VGraphDefDefaultTypeInternal@1@A\n")
 
     # Each symbols returned by undname matches the same position in candidates.
     # We compare on undname but use the decorated name from candidates.


### PR DESCRIPTION
On Windows, there is tool for selecting which symbols get exported to the tensorflow DLL.
However, this filter does not include the symbols needed to use SessionOptions and SavedModel. It is also missing symbols for accessing shapes of a given node in the graph and creating a default instance of GraphDef.

This fix adds these symbols manually, thus not an elegant fix, and there are most likely several other symbols that should be included, but these are symbols which I find essential to: load a SavedModel, determine shapes and run inference with specific SessionOptions in C++.