### PR TITLE
Disable _FusedConv2D generation in grappler if XLA is on (GPU only).

### DIFF
--- a/tensorflow/core/grappler/optimizers/meta_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/meta_optimizer.cc
@@ -149,16 +149,14 @@ bool IsXlaGlobalJitOn(
 
 // A helper function to decide whether to enable the memory optimizer.
 bool MemoryOptimizerEnabled(
-    RewriterConfig::MemOptType mem_opt_type,
-    OptimizerOptions::GlobalJitLevel jit_level_in_session_opts) {
+    RewriterConfig::MemOptType mem_opt_type, bool xla_on) {
   // Disable the default memory optimizer when XLA JIT is ON as it hurts the
   // XLA JIT performance. The (current) XLA clustering can result in loss of
   // concurrency between kernel compute and memory copies. As such, it usually
   // loses the concurrency needed to hide the latencies of the inserted swap-ins
   // and swap-outs and incurs great performance overhead. Remove this check when
   // the XLA JIT can better deal with the concurrency.
-  if (mem_opt_type == RewriterConfig::DEFAULT_MEM_OPT &&
-      IsXlaGlobalJitOn(jit_level_in_session_opts)) {
+  if (mem_opt_type == RewriterConfig::DEFAULT_MEM_OPT && xla_on) {
     return false;
   }
 
@@ -192,7 +190,7 @@ std::unique_ptr<GraphOptimizer> MetaOptimizer::MakeNewOptimizer(
              cfg_.experimental_disable_compressed_tensor_optimization(),
              !cfg_.experimental_disable_folding_quantization_emulation()));
   MK_OPT("shape", new ShapeOptimizer());
-  MK_OPT("remap", new Remapper(cfg_.remapping()));
+  MK_OPT("remap", new Remapper(cfg_.remapping(), xla_on_));
   MK_OPT("layout", new GenericLayoutOptimizer(
                        /*optimization level*/ cfg_.layout_optimizer(),
                        /*CPU layout conversion*/ cfg_.cpu_layout_conversion()));
@@ -225,6 +223,9 @@ MetaOptimizer::MetaOptimizer(DeviceBase* cpu_device, const ConfigProto& cfg)
       cfg_(*config_proto_.mutable_graph_options()->mutable_rewrite_options()) {
   DCHECK(cpu_device_ == nullptr ||
          cpu_device_->attributes().device_type() == "CPU");
+  auto global_jit_level =
+      cfg.graph_options().optimizer_options().global_jit_level();
+  xla_on_ = IsXlaGlobalJitOn(global_jit_level); 
 }
 
 Status MetaOptimizer::InitializeOptimizers(
@@ -281,7 +282,7 @@ Status MetaOptimizer::InitializeOptimizers(
         /*CPU layout conversion*/ cfg_.cpu_layout_conversion()));
   }
   if (cfg_.remapping() != RewriterConfig::OFF) {
-    optimizers->push_back(MakeUnique<Remapper>(cfg_.remapping()));
+    optimizers->push_back(MakeUnique<Remapper>(cfg_.remapping(), xla_on_));
   }
   if (cfg_.loop_optimization() != RewriterConfig::OFF) {
     optimizers->push_back(
@@ -291,9 +292,7 @@ Status MetaOptimizer::InitializeOptimizers(
     optimizers->push_back(
         MakeUnique<DependencyOptimizer>(cfg_.dependency_optimization()));
   }
-  auto global_jit_level =
-      config_proto_.graph_options().optimizer_options().global_jit_level();
-  if (MemoryOptimizerEnabled(cfg_.memory_optimization(), global_jit_level)) {
+  if (MemoryOptimizerEnabled(cfg_.memory_optimization(), xla_on_)) {
     if (cfg_.memory_optimizer_target_node_name_scope().empty()) {
       optimizers->push_back(
           // Use the default target node name prefix "gradients/"

--- a/tensorflow/core/grappler/optimizers/meta_optimizer.h
+++ b/tensorflow/core/grappler/optimizers/meta_optimizer.h
@@ -92,6 +92,7 @@ class MetaOptimizer : public GraphOptimizer {
   DeviceBase* const cpu_device_;  // may be NULL
   ConfigProto config_proto_;
   RewriterConfig& cfg_;
+  bool xla_on_;
 
   struct OptimizerResult {
     string optimizer_name;

--- a/tensorflow/core/grappler/optimizers/meta_optimizer.h
+++ b/tensorflow/core/grappler/optimizers/meta_optimizer.h
@@ -92,7 +92,7 @@ class MetaOptimizer : public GraphOptimizer {
   DeviceBase* const cpu_device_;  // may be NULL
   ConfigProto config_proto_;
   RewriterConfig& cfg_;
-  bool xla_on_;
+  bool xla_auto_clustering_on_;
 
   struct OptimizerResult {
     string optimizer_name;

--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -76,16 +76,18 @@ constexpr char kIsTraining[] = "is_training";
 constexpr int kMissingIndex = -1;
 
 struct RemapperContext {
-  explicit RemapperContext(GrapplerItem* item, Status* status)
+  explicit RemapperContext(GrapplerItem* item, Status* status, bool xla_on)
       : nodes_to_preserve(item->NodesToPreserve()),
         graph_view(&item->graph, status),
         graph_properties(*item),
-        inferred_graph_properties(false) {}
+        inferred_graph_properties(false),
+        xla_on_(xla_on) {}
 
   std::unordered_set<string> nodes_to_preserve;
   utils::MutableGraphView graph_view;
   GraphProperties graph_properties;
   bool inferred_graph_properties;
+  bool xla_on_;
 };
 
 // FusedBatchNorm that can be replaced with a cheaper set of primitives.
@@ -328,6 +330,9 @@ bool IsGpuCompatible(const RemapperContext& ctx,
   // ROCm does not support _FusedConv2D
   return false;
 #endif
+  // xla does not cluster _FusedConv2D, and knows how to do this optimization
+  if (ctx.xla_on_) return false;
+
   const GraphDef* graph = ctx.graph_view.graph();
   const NodeDef& contraction_node = graph->node(matched.contraction);
   if (!IsConv2D(contraction_node)) return false;
@@ -1774,7 +1779,7 @@ Status Remapper::Optimize(Cluster* cluster, const GrapplerItem& item,
                           GraphDef* optimized_graph) {
   GrapplerItem mutable_item = item;
   Status status;
-  RemapperContext ctx(&mutable_item, &status);
+  RemapperContext ctx(&mutable_item, &status, xla_on_);
   TF_RETURN_IF_ERROR(status);
   // Processing graph in reverse-topological sorted order allows to remap
   // longer chains of dependent ops in one pass.

--- a/tensorflow/core/grappler/optimizers/remapper.h
+++ b/tensorflow/core/grappler/optimizers/remapper.h
@@ -26,7 +26,8 @@ namespace grappler {
 // nodes to decrease the amount of operations needed to perform a computation.
 class Remapper : public GraphOptimizer {
  public:
-  explicit Remapper(RewriterConfig::Toggle opt_level) : opt_level_(opt_level) {}
+  explicit Remapper(RewriterConfig::Toggle opt_level, bool xla_on) :
+    opt_level_(opt_level), xla_on_(xla_on)  {}
 
   ~Remapper() override {}
 
@@ -42,6 +43,7 @@ class Remapper : public GraphOptimizer {
 
  private:
   RewriterConfig::Toggle opt_level_;
+  bool xla_on_;
 };
 
 }  // end namespace grappler

--- a/tensorflow/core/grappler/optimizers/remapper.h
+++ b/tensorflow/core/grappler/optimizers/remapper.h
@@ -27,7 +27,7 @@ namespace grappler {
 class Remapper : public GraphOptimizer {
  public:
   explicit Remapper(RewriterConfig::Toggle opt_level,
-                    bool xla_auto_clustering_on) :
+                    bool xla_auto_clustering_on = false) :
     opt_level_(opt_level), xla_auto_clustering_on_(xla_auto_clustering_on)  {}
 
   ~Remapper() override {}

--- a/tensorflow/core/grappler/optimizers/remapper.h
+++ b/tensorflow/core/grappler/optimizers/remapper.h
@@ -26,8 +26,9 @@ namespace grappler {
 // nodes to decrease the amount of operations needed to perform a computation.
 class Remapper : public GraphOptimizer {
  public:
-  explicit Remapper(RewriterConfig::Toggle opt_level, bool xla_on) :
-    opt_level_(opt_level), xla_on_(xla_on)  {}
+  explicit Remapper(RewriterConfig::Toggle opt_level,
+                    bool xla_auto_clustering_on) :
+    opt_level_(opt_level), xla_auto_clustering_on_(xla_auto_clustering_on)  {}
 
   ~Remapper() override {}
 
@@ -43,7 +44,7 @@ class Remapper : public GraphOptimizer {
 
  private:
   RewriterConfig::Toggle opt_level_;
-  bool xla_on_;
+  bool xla_auto_clustering_on_;
 };
 
 }  // end namespace grappler


### PR DESCRIPTION
XLA does not recognize the _FusedConv2D node, resulting in multiple
clusters during auto clustering. Furthermore, XLA performs this
particular optimization as part of the fused convolution rewriter