### PR TITLE
Keras TB callback: Fix write_steps_per_second when profile_batch=0

### DIFF
--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -2363,7 +2363,8 @@ class TensorBoard(Callback, version_utils.TensorBoardVersionSelector):
     self._pop_writer()
 
   def _implements_train_batch_hooks(self):
-    return self._should_trace  # Only call batch hooks when tracing is enabled
+    # Only call batch hooks when tracing or write_steps_per_second are enabled
+    return self._should_trace or self.write_steps_per_second
 
   def on_train_batch_begin(self, batch, logs=None):
     self._global_train_batch += 1

--- a/tensorflow/python/keras/callbacks_test.py
+++ b/tensorflow/python/keras/callbacks_test.py
@@ -2041,9 +2041,11 @@ class TestTensorBoardV2(keras_parameterized.TestCase):
         y,
         batch_size=2,
         epochs=2,
+        verbose=0,
         callbacks=[
             keras.callbacks.TensorBoard(
-                self.logdir, update_freq=1, write_steps_per_second=True)
+                self.logdir, update_freq=1, profile_batch=0,
+                write_steps_per_second=True)
         ])
 
     summary_file = list_summaries(self.logdir)


### PR DESCRIPTION
cef7da10e1e944e11961f4d18978f611358023b2 introduced a bug where setting `write_steps_per_second` had no effect in cases where `profile_batch=0`.
This is due to an optimisation in the TensorBoard callback that disables calling batch hooks when not necessary.

This PR fixes it by making sure that batch level hooks are always called when `write_steps_per_second` is `True`.