### PR TITLE
TFLite Conv.h inner loop optimizations

### DIFF
--- a/tensorflow/lite/kernels/internal/reference/integer_ops/conv.h
+++ b/tensorflow/lite/kernels/internal/reference/integer_ops/conv.h
@@ -82,11 +82,15 @@ inline void ConvPerChannel(
                 continue;
               }
 
+              int8 *pFilter, *pInput;
+              pFilter = (int8 *)&filter_data[Offset(filter_shape, out_channel, filter_y,
+                                filter_x, 0)];
+              pInput = (int8 *)&input_data[Offset(input_shape, batch, in_y,
+                                in_x, 0)];
+
               for (int in_channel = 0; in_channel < input_depth; ++in_channel) {
-                int32_t input_val = input_data[Offset(input_shape, batch, in_y,
-                                                      in_x, in_channel)];
-                int32_t filter_val = filter_data[Offset(
-                    filter_shape, out_channel, filter_y, filter_x, in_channel)];
+                int32_t input_val = *pInput++;
+                int32_t filter_val = *pFilter++;
                 // Accumulate with 32 bits accumulator.
                 // In the nudging process during model quantization, we force
                 // real value of 0.0 be represented by a quantized value. This
@@ -185,10 +189,15 @@ inline void ConvPerChannel(
                 continue;
               }
 
+              int8 *pFilter, *pInput;
+              pFilter = (int8 *)&filter_data[Offset(filter_shape, out_channel, filter_y,
+                                filter_x, 0)];
+              pInput = (int8 *)&input_data[Offset(input_shape, batch, in_y,
+                                in_x, 0)];
+
               for (int in_channel = 0; in_channel < input_depth; ++in_channel) {
-                int32_t input_val = input_data[Offset(input_shape, batch, in_y,
-                                                      in_x, in_channel)];
-                int32_t filter_val = filter_data[Offset(
+                int32_t input_val = = *pInput++;
+                int32_t filter_val = *pFilter++;
                     filter_shape, out_channel, filter_y, filter_x, in_channel)];
                 // Accumulate with 64 bits accumulator.
                 // int64_t += int8_t * int16_t so the highest value we can


### PR DESCRIPTION
This PR contains a number of inner loop optimizations for TFLite's conv.h kernel, to avoid calling `Offset()` multiple times in the loop, and to do boundary checking once when possible. For a typical image model on TensorFlow Lite Micro running on a Cortex-M4F MCU (without CMSIS-NN kernels) we see a decrease in inferencing time from 388ms. to 302ms. 

I see that there are plenty of regression tests for this kernel, so I hope that CI runs them on this PR, as I have no idea how to do so :-) It has passed our internal regression suite, but we have only a small variety of models and we are branched off of TF 2.3 tag.

This work was done by @bitbank2 but sponsored by Edge Impulse - which is why I'm opening the PR.