### PR TITLE
added subprocess.Popen to view pdf extension file

### DIFF
--- a/tensorflow/python/keras/utils/vis_utils.py
+++ b/tensorflow/python/keras/utils/vis_utils.py
@@ -206,7 +206,7 @@ def model_to_dot(model,
     if show_shapes:
 
       def format_shape(shape):
-        return str(shape).replace(str(None), '?')
+        return str(shape).replace(str(None), 'None')
 
       try:
         outputlabels = format_shape(layer.output_shape)

--- a/tensorflow/python/keras/utils/vis_utils.py
+++ b/tensorflow/python/keras/utils/vis_utils.py
@@ -348,3 +348,9 @@ def plot_model(model,
       return display.Image(filename=to_file)
     except ImportError:
       pass
+  else:
+    try:
+      import subprocess
+      return subprocess.Popen([to_file], shell=True)
+    except ImportError:
+      pass


### PR DESCRIPTION
plot_model saves image as pdf extension as well but there is no option to directly open it as soon as the file is created to check the file as IPython only supports image format types.
So I have added subprocess library to open the pdf extension files as well so that they are opened as soon as it is created by the function plot_model.