### PR TITLE
Fix linking failure of Flex delegate in Archive mode

### DIFF
--- a/tensorflow/lite/experimental/ios/allowlist_TensorFlowLiteC.txt
+++ b/tensorflow/lite/experimental/ios/allowlist_TensorFlowLiteC.txt
@@ -1,1 +1,2 @@
 _TfLite*
+*AcquireFlexDelegate*


### PR DESCRIPTION
Without this change, users will not be able to push the app with Flex delegate to App store.
Please see https://github.com/tensorflow/tensorflow/issues/44879 for more context.

PiperOrigin-RevId: 344578122
Change-Id: Ibce63196691dcec2f958064e72f6ffec5f9a617a