### PR TITLE
make xtensa downloader generic to support variants

### DIFF
--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
@@ -1,11 +1,15 @@
 ifeq ($(TARGET_ARCH), hifi4)
 
-  DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/ext_libs/xtensa_download.sh ${MAKEFILE_DIR}/downloads)
+  LIBRARY_URL := "http://mirror.tensorflow.org/github.com/foss-xtensa/nnlib-hifi4/raw/master/archive/xa_nnlib_06_27.zip"
+  LIBRARY_DIRNAME := "xa_nnlib_hifi4"
+  LIBRARY_MD5 := "45fdc1209a8da62ab568aa6040f7eabf"
+
+  DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/ext_libs/xtensa_download.sh ${MAKEFILE_DIR}/downloads $(LIBRARY_URL) $(LIBRARY_DIRNAME) $(LIBRARY_MD5))
   ifneq ($(DOWNLOAD_RESULT), SUCCESS)
     $(error Something went wrong with the xtensa download: $(DOWNLOAD_RESULT))
   endif
 
-  NNLIB_PATH := $(MAKEFILE_DIR)/downloads/xa_nnlib_hifi4
+  NNLIB_PATH := $(MAKEFILE_DIR)/downloads/$(LIBRARY_DIRNAME)
 
   THIRD_PARTY_CC_SRCS += \
     $(shell find $(NNLIB_PATH) -name "*.c")

--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
@@ -1,15 +1,11 @@
 ifeq ($(TARGET_ARCH), hifi4)
 
-  LIBRARY_URL := "http://mirror.tensorflow.org/github.com/foss-xtensa/nnlib-hifi4/raw/master/archive/xa_nnlib_06_27.zip"
-  LIBRARY_DIRNAME := "xa_nnlib_hifi4"
-  LIBRARY_MD5 := "45fdc1209a8da62ab568aa6040f7eabf"
-
-  DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/ext_libs/xtensa_download.sh ${MAKEFILE_DIR}/downloads $(LIBRARY_URL) $(LIBRARY_DIRNAME) $(LIBRARY_MD5))
+  DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/ext_libs/xtensa_download.sh ${MAKEFILE_DIR}/downloads hifi4)
   ifneq ($(DOWNLOAD_RESULT), SUCCESS)
     $(error Something went wrong with the xtensa download: $(DOWNLOAD_RESULT))
   endif
 
-  NNLIB_PATH := $(MAKEFILE_DIR)/downloads/$(LIBRARY_DIRNAME)
+  NNLIB_PATH := $(MAKEFILE_DIR)/downloads/xa_nnlib_hifi4
 
   THIRD_PARTY_CC_SRCS += \
     $(shell find $(NNLIB_PATH) -name "*.c")

--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa_download.sh
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa_download.sh
@@ -19,6 +19,9 @@
 # Called with four arguments:
 # 1 - Path to the downloads folder which is typically
 #     tensorflow/lite/micro/tools/make/downloads
+# 2 - URL to downoad external library
+# 3 - Name of the library directory once it is unzipped.
+# 4 - MD5 checksum for library
 #
 # This script is called from the Makefile and uses the following convention to
 # enable determination of sucess/failure:
@@ -39,28 +42,28 @@ if [ ! -d ${DOWNLOADS_DIR} ]; then
   exit 1
 fi
 
-# Name of the xa_nnlib directory once it is unzipped.
-HIFI4_XA_NNLIB_DIRNAME="xa_nnlib_hifi4"
+# URL to downoad external library
+LIBRARY_URL=${2}
+# Name of the library directory once it is unzipped.
+LIBRARY_DIRNAME=${3}
+# MD5 checksum
+LIBRARY_MD5=${4}
 
-HIFI4_PATH=${DOWNLOADS_DIR}/${HIFI4_XA_NNLIB_DIRNAME}
-if [ -d ${HIFI4_PATH} ]; then
-  echo >&2 "${HIFI4_PATH} already exists, skipping the download."
+LIBRARY_INSTALL_PATH=${DOWNLOADS_DIR}/${LIBRARY_DIRNAME}
+if [ -d ${LIBRARY_INSTALL_PATH} ]; then
+  echo >&2 "${LIBRARY_INSTALL_PATH} already exists, skipping the download."
 else
+  TMP_ZIP_ARCHIVE_NAME="xtensa_library.zip"
+  wget ${LIBRARY_URL} -O /tmp/${TMP_ZIP_ARCHIVE_NAME} >&2
+  MD5=`md5sum /tmp/${TMP_ZIP_ARCHIVE_NAME} | awk '{print $1}'`
 
-  ZIP_ARCHIVE_NAME="xa_nnlib_06_27.zip"
-  HIFI4_URL="http://mirror.tensorflow.org/github.com/foss-xtensa/nnlib-hifi4/raw/master/archive/${ZIP_ARCHIVE_NAME}"
-  HIFI4_MD5="45fdc1209a8da62ab568aa6040f7eabf"
-
-  wget ${HIFI4_URL} -O /tmp/${ZIP_ARCHIVE_NAME} >&2
-  MD5=`md5sum /tmp/${ZIP_ARCHIVE_NAME} | awk '{print $1}'`
-
-  if [[ ${MD5} != ${HIFI4_MD5} ]]
+  if [[ ${MD5} != ${LIBRARY_MD5} ]]
   then
-    echo "Bad checksum. Expected: ${HIFI4_MD5}, Got: ${MD5}"
+    echo "Bad checksum. Expected: ${LIBRARY_MD5}, Got: ${MD5}"
     exit 1
   fi
 
-  unzip -qo /tmp/${ZIP_ARCHIVE_NAME} -d ${DOWNLOADS_DIR} >&2
+  unzip -qo /tmp/${TMP_ZIP_ARCHIVE_NAME} -d ${DOWNLOADS_DIR} >&2
 fi
 
 echo "SUCCESS"

--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa_download.sh
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa_download.sh
@@ -19,9 +19,7 @@
 # Called with four arguments:
 # 1 - Path to the downloads folder which is typically
 #     tensorflow/lite/micro/tools/make/downloads
-# 2 - URL to downoad external library
-# 3 - Name of the library directory once it is unzipped.
-# 4 - MD5 checksum for library
+# 2 - Xtensa variant to download for (e.g. hifi4)
 #
 # This script is called from the Makefile and uses the following convention to
 # enable determination of sucess/failure:
@@ -42,18 +40,21 @@ if [ ! -d ${DOWNLOADS_DIR} ]; then
   exit 1
 fi
 
-# URL to downoad external library
-LIBRARY_URL=${2}
-# Name of the library directory once it is unzipped.
-LIBRARY_DIRNAME=${3}
-# MD5 checksum
-LIBRARY_MD5=${4}
+if [[ ${2} == "hifi4" ]]; then
+  LIBRARY_URL="http://mirror.tensorflow.org/github.com/foss-xtensa/nnlib-hifi4/raw/master/archive/xa_nnlib_06_27.zip"
+  LIBRARY_DIRNAME="xa_nnlib_hifi4"
+  LIBRARY_MD5="45fdc1209a8da62ab568aa6040f7eabf"
+else
+  echo "Attempting to download an unsupported xtensa variant: ${2}"
+  exit 1
+fi
 
 LIBRARY_INSTALL_PATH=${DOWNLOADS_DIR}/${LIBRARY_DIRNAME}
+
 if [ -d ${LIBRARY_INSTALL_PATH} ]; then
   echo >&2 "${LIBRARY_INSTALL_PATH} already exists, skipping the download."
 else
-  TMP_ZIP_ARCHIVE_NAME="xtensa_library.zip"
+  TMP_ZIP_ARCHIVE_NAME="${LIBRARY_DIRNAME}.zip"
   wget ${LIBRARY_URL} -O /tmp/${TMP_ZIP_ARCHIVE_NAME} >&2
   MD5=`md5sum /tmp/${TMP_ZIP_ARCHIVE_NAME} | awk '{print $1}'`
 


### PR DESCRIPTION
Change the download script so that we can support multiple xtensa target variants. The functionality is identical to https://github.com/tensorflow/tensorflow/pull/44845 but the script is ready for additional download variants.

Tested the following commands:

1. Incorrect params to the download script
    ```
    $ tensorflow/lite/micro/tools/make/ext_libs/xtensa_download.sh /tmp blah
    ```
    Gave the expected error:
    ```
    Attempting to download an unsupported xtensa variant: blah
    ```

1. Correct invocation for hifi4 
    ```
    $ tensorflow/lite/micro/tools/make/ext_libs/xtensa_download.sh /tmp hifi4
    ```
    Downloaded the library to `/tmp/xa_nnlib_hifi4`.

1. Using the makefile
    ```
    rm -rf tensorflow/lite/micro/tools/make/downloads/xa_nnlib_hifi4/
    make -f tensorflow/lite/micro/tools/make/Makefile -j8 TARGET=xtensa XTENSA_CORE=blah XTENSA_BASE=blah XTENSA_TOOLS_VERSION=blah TARGET_ARCH=hifi4 clean
    ```
    Downloaded the library and printed out the sources list.

1. Using the makefile after already downloading the library
    ```
    make -f tensorflow/lite/micro/tools/make/Makefile -j8 TARGET=xtensa XTENSA_CORE=blah XTENSA_BASE=blah XTENSA_TOOLS_VERSION=blah TARGET_ARCH=hifi4 clean
    ```
    Correctly determined that the downloaded file already exists (`tensorflow/lite/micro/tools/make/downloads/xa_nnlib_hifi4 already exists, skipping the download.`) and prints out the sources list on the terminal.
