### PR TITLE
[XLA] Fix a dangling reference bug that is triggered in Ubuntu 20.04 with GCC 9.3

### DIFF
--- a/tensorflow/compiler/tf2xla/kernels/conv_op_helpers.cc
+++ b/tensorflow/compiler/tf2xla/kernels/conv_op_helpers.cc
@@ -179,7 +179,7 @@ Status ConvBackpropComputeDimensionsV2XlaShapes(
 
 }  // anonymous namespace
 
-absl::Span<const DataType> GetXlaConvTypes() {
+std::vector<DataType> GetXlaConvTypes() {
   return {DT_FLOAT, DT_BFLOAT16, DT_HALF, DT_DOUBLE};
 }
 

--- a/tensorflow/compiler/tf2xla/kernels/conv_op_helpers.h
+++ b/tensorflow/compiler/tf2xla/kernels/conv_op_helpers.h
@@ -37,7 +37,7 @@ namespace tensorflow {
 
 // We don't support integers for convolutions, so we list the supported types
 // here.
-absl::Span<const DataType> GetXlaConvTypes();
+std::vector<DataType> GetXlaConvTypes();
 
 // ConvOpAttrs contains all of the metadata necessary to specify a TF or XLA
 // convolution.


### PR DESCRIPTION
The Span returned point to an initializer list that is removed. This isn't allowed.

This is triggered in Ubuntu 20.03 that have GCC 9.3. If I install and use gcc 8 in the same container, the error doesn't show up.

@sanjoy @nluehr 