### PR TITLE
Fixed wrong cast which caused problems with build for ARC targets.

### DIFF
--- a/tensorflow/lite/micro/kernels/arc_mli/mli_tf_utils.h
+++ b/tensorflow/lite/micro/kernels/arc_mli/mli_tf_utils.h
@@ -96,7 +96,11 @@ inline void ConvertToMliQuantParamsPerChannel(const TfLiteTensor* tfT,
 template <typename datatype>
 inline void MliTensorAttachBuffer(const TfLiteEvalTensor* tfT,
                                   mli_tensor* mliT) {
-  mliT->data = static_cast<void*>(tflite::micro::GetTensorData<datatype>(tfT));
+  // "const_cast" here used to attach const data buffer to the initially
+  // non-const mli_tensor. This is required by current implementation of MLI
+  // backend and planned for redesign due to this and some other aspects.
+  mliT->data = const_cast<void*>(
+      static_cast<const void*>(tflite::micro::GetTensorData<datatype>(tfT)));
 }
 
 inline void ConvertToMliTensor(const TfLiteTensor* tfT, mli_tensor* mliT) {


### PR DESCRIPTION
This PR fixes the build problem. It does it using const_cast which is necessary measure at the moment, since we have no choice with the current state of ARC backend interface. But it will be replaced in future update of our backend (with update to MLI 2.0) and our team already has plans how to deal with this mismatch.

Fixes #45106