### PR TITLE
Keras SavedModel: Ignore custom metrics failure when compile=False

### DIFF
--- a/tensorflow/python/keras/saving/saved_model/saved_model_test.py
+++ b/tensorflow/python/keras/saving/saved_model/saved_model_test.py
@@ -1159,6 +1159,26 @@ class MetricTest(test.TestCase, parameterized.TestCase):
       self._test_metric_save_and_load(
           metric, self._save_model_dir(), 1, test_sample_weight=False)
 
+  @keras_parameterized.run_with_all_model_types
+  def test_custom_metric_model(self):
+
+    class CustomMetric(keras.metrics.MeanSquaredError):
+      pass
+
+    model = testing_utils.get_small_mlp(1, 4, input_dim=3)
+    model.compile(
+        loss='mse',
+        optimizer='rmsprop',
+        metrics=[CustomMetric()])
+
+    saved_model_dir = self._save_model_dir()
+    tf_save.save(model, saved_model_dir)
+    with self.assertRaisesRegex(ValueError, 'custom_objects'):
+      keras_load.load(saved_model_dir)
+
+    keras_load.load(saved_model_dir, compile=False)
+
+
 
 if __name__ == '__main__':
   test.main()


### PR DESCRIPTION
Keras currently doesn't support serialising and loading custom metrics in the saved model format.

However, when loading models with `compile=False` these metrics are not needed but still prevent the model from being loaded correctly.
This PR will ignore such errors when used with `tf.keras.models.load_model(path, compile=False)` allowing to reload models without code even if they have been saved with custom metrics. This is important since ["SavedModels are [supposed to be] able to save custom objects like subclassed models and custom layers without requiring the original code"](https://www.tensorflow.org/tutorials/keras/save_and_load#saving_custom_objects).

This PR fixes #43478 which was introduced in TensorFlow 2.2. It is a workaround until [proper support for serialising and deserialising custom metrics](https://github.com/tensorflow/tensorflow/blob/107b96da1ca5f0db752a11c4fae85ef1272ee175/tensorflow/python/keras/saving/saved_model/metric_serialization.py#L43-L46) is implemented. /cc @k-w-w, @yhliang2018, @qlzh727

@mihaimaruseac Would you still accept a cherry-pick of this PR onto the 2.4 release branch, since it fixes a bug that prevents loading of saved models with custom metrics that have been saved with TensorFlow 2.2 or newer? To me it looks like the risk of this PR breaking any current users is pretty low, but I might be missing something here.