### PR TITLE
Push and pop gcc diagnostic pragma's in the flexbuffer patching script. 

### DIFF
--- a/tensorflow/lite/micro/tools/make/flatbuffers_download.sh
+++ b/tensorflow/lite/micro/tools/make/flatbuffers_download.sh
@@ -52,11 +52,12 @@ function patch_to_avoid_strtod() {
   head -n ${case_string_line} ${input_flexbuffers_path} > ${temp_flexbuffers_path}
 
   echo "#if 1" >> ${temp_flexbuffers_path}
+  echo "#pragma GCC diagnostic push" >> ${temp_flexbuffers_path}
+  echo "#pragma GCC diagnostic ignored \"-Wnull-dereference\"" >> ${temp_flexbuffers_path}
   echo "          // TODO(b/173239141): Patched via micro/tools/make/flexbuffers_download.sh" >> ${temp_flexbuffers_path}
   echo "          // Introduce a segfault for an unsupported code path for TFLM." >> ${temp_flexbuffers_path}
-  echo "#pragma GCC diagnostic ignored \"-Wnull-dereference\"" >> ${temp_flexbuffers_path}
   echo "          return *(static_cast<double*>(nullptr));" >> ${temp_flexbuffers_path}
-  echo "#pragma GCC diagnostic error \"-Wnull-dereference\"" >> ${temp_flexbuffers_path}
+  echo "#pragma GCC diagnostic pop" >> ${temp_flexbuffers_path}
   echo "#else" >> ${temp_flexbuffers_path}
   echo "          // This is the original code" >> ${temp_flexbuffers_path}
   sed -n -e $((${string_to_num_line} -  1)),$((${string_to_num_line} + 1))p ${input_flexbuffers_path} >> ${temp_flexbuffers_path}


### PR DESCRIPTION
The change from PR #45040 made null-dereference an error for any code that was compiled after flexbuffers.h was included. This resulted in build errors that were hard to debug.

See [this comment](https://github.com/tensorflow/tensorflow/issues/44971#issuecomment-736130061) for additional context.

The patched lines in flexbuffers.h after this change are:
```cc
#if 1
#pragma GCC diagnostic push
#pragma GCC diagnostic ignored "-Wnull-dereference"
          // TODO(b/173239141): Patched via micro/tools/make/flexbuffers_download.sh
          // Introduce a segfault for an unsupported code path for TFLM.
          return *(static_cast<double*>(nullptr));
#pragma GCC diagnostic pop
#else
          // This is the original code
          double d;
          flatbuffers::StringToNumber(AsString().c_str(), &d);
          return d;
#endif

```