### PR TITLE
Fix can't get a replica variable bug when use recompute_grad

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -2696,7 +2696,6 @@ cuda_py_test(
     size = "medium",
     srcs = ["ops/gradients_test.py"],
     python_version = "PY3",
-    tags = ["no_oss"],  # b/118709825
     deps = [
         ":array_grad",
         ":array_ops",

--- a/tensorflow/python/distribute/mirrored_variable_test.py
+++ b/tensorflow/python/distribute/mirrored_variable_test.py
@@ -24,6 +24,7 @@ from tensorflow.python.distribute import distribute_utils
 from tensorflow.python.distribute import distribution_strategy_context as ds_context
 from tensorflow.python.distribute import strategy_combinations
 from tensorflow.python.distribute import values
+from tensorflow.python.eager import backprop
 from tensorflow.python.eager import context
 from tensorflow.python.eager import def_function
 from tensorflow.python.eager import test
@@ -33,6 +34,7 @@ from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import func_graph
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import custom_gradient
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import rnn
 from tensorflow.python.ops import rnn_cell_impl
@@ -611,6 +613,30 @@ class MirroredVariableCreationTest(test.TestCase):
 
       for v in ops.get_collection(ops.GraphKeys.GLOBAL_VARIABLES):
         self.assertIsNotNone(v.initializer)
+
+  def testCustomGradient(self, distribution):
+    class CustomModel:
+      def __init__(self):
+        self._v = variables.Variable(1.0)
+      
+      def __call__(self):
+        @custom_gradient.recompute_grad
+        def _call():
+          return self._v + 1
+        return _call()
+    
+    with distribution.scope():
+      model = CustomModel()
+      @def_function.function
+      def train_step():
+        def replica_step():
+          with backprop.GradientTape() as tape:
+            result = model()
+          return tape.gradient(result, [model._v])
+        return distribution.run(replica_step)
+
+    grads = distribution.experimental_local_results(train_step())
+    self.assertLen(grads, distribution.num_replicas_in_sync)
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/ops/custom_gradient.py
+++ b/tensorflow/python/ops/custom_gradient.py
@@ -311,9 +311,17 @@ class Bind(object):
 
 def get_variable_by_name(var_name):
   """Given a variable name, retrieves a handle on the tensorflow Variable."""
+  global_vars = ops.get_collection(ops.GraphKeys.GLOBAL_VARIABLES)
 
-  candidate_vars = ops.get_collection(
-      ops.GraphKeys.GLOBAL_VARIABLES, scope="{}:0".format(var_name))
+  def _filter_fn(item):
+    try:
+      return var_name == item.op.name
+    except AttributeError:
+      # Collection items without operation are ignored.
+      return False
+
+  candidate_vars = list(filter(_filter_fn, global_vars))
+
   if len(candidate_vars) >= 1:
     # Filter out non-trainable variables.
     candidate_vars = [v for v in candidate_vars if v.trainable]

--- a/tensorflow/python/ops/gradients_test.py
+++ b/tensorflow/python/ops/gradients_test.py
@@ -1028,7 +1028,10 @@ class GetDependentVariablesTest(test_util.TensorFlowTestCase):
     with context.graph_mode():
       init = constant_op.constant(100.0)
       var = variable_scope.variable(init, name='a/replica_1')
-      var._handle = array_ops.identity(var, name='a')
+      if isinstance(var, variables.RefVariable):
+        var._variable = array_ops.identity(var, name='a')
+      else:
+        var._handle = array_ops.identity(var, name='a')
       var2 = custom_gradient.get_variable_by_name('a')
       self.assertEqual(var2.name, var.name)
   

--- a/tensorflow/python/ops/gradients_test.py
+++ b/tensorflow/python/ops/gradients_test.py
@@ -1024,6 +1024,14 @@ class GetDependentVariablesTest(test_util.TensorFlowTestCase):
           [input_t], [result_t])
       self.assertEqual(dependent_vars, [])
 
+  def testGetVariableByName(self):
+    with context.graph_mode():
+      init = constant_op.constant(100.0)
+      var = variable_scope.variable(init, name='a/replica_1')
+      var._handle = array_ops.identity(var, name='a')
+      var2 = custom_gradient.get_variable_by_name('a')
+      self.assertEqual(var2.name, var.name)
+  
   def testVariablesOutsideAndNonTrainable(self):
     with ops.Graph().as_default():
       init = constant_op.constant(100.0, shape=(5,))


### PR DESCRIPTION
Fix can't get a replica variable bug when use recompute_grad in the graph mode which is reported in https://github.com/google/automl/issues/886.