### PR TITLE
[Intel-MKL] Supporting quantized pooling op for signed 8 bit

### DIFF
--- a/tensorflow/core/kernels/quantized_pooling_ops.cc
+++ b/tensorflow/core/kernels/quantized_pooling_ops.cc
@@ -137,4 +137,14 @@ REGISTER_KERNEL_BUILDER(
     Name("QuantizedMaxPool").Device(DEVICE_CPU).TypeConstraint<quint8>("T"),
     QuantizedMaxPoolingOp<CPUDevice, quint8>);
 
+#ifdef INTEL_MKL
+REGISTER_KERNEL_BUILDER(
+    Name("QuantizedAvgPool").Device(DEVICE_CPU).TypeConstraint<qint8>("T"),
+    QuantizedAvgPoolingOp<CPUDevice, qint8>);
+
+REGISTER_KERNEL_BUILDER(
+    Name("QuantizedMaxPool").Device(DEVICE_CPU).TypeConstraint<qint8>("T"),
+    QuantizedMaxPoolingOp<CPUDevice, qint8>);
+#endif
+
 }  // namespace tensorflow


### PR DESCRIPTION
Maxpool and average pool supports unsigned 8 bit quantization. But, for some models using Intel MKL quantization, we need to use signed 8 bit. Here, we are supporting signed 8 bit quantization. 