### PR TITLE
Update _inferred_steps when recreating iterator.

### DIFF
--- a/tensorflow/python/keras/engine/data_adapter.py
+++ b/tensorflow/python/keras/engine/data_adapter.py
@@ -1141,6 +1141,8 @@ class DataHandler(object):
     self._insufficient_data = False
     self._model = model
 
+    self._steps_per_epoch = steps_per_epoch
+
     # `steps_per_execution_value` is the cached initial value.
     # `steps_per_execution` is mutable and may be changed by the DataAdapter
     # to handle partial executions.
@@ -1204,6 +1206,7 @@ class DataHandler(object):
           break
         if self._adapter.should_recreate_iterator():
           data_iterator = iter(self._dataset)
+          self._inferred_steps = self._infer_steps(self._steps_per_epoch, self._dataset)
         yield epoch, data_iterator
         self._adapter.on_epoch_end()
 

--- a/tensorflow/python/keras/engine/data_adapter.py
+++ b/tensorflow/python/keras/engine/data_adapter.py
@@ -967,7 +967,7 @@ class KerasSequenceAdapter(GeneratorDataAdapter):
     return generator_fn
 
   def get_size(self):
-    return self._size
+    return len(self._keras_sequence)
 
   def should_recreate_iterator(self):
     return True


### PR DESCRIPTION
closes https://github.com/tensorflow/tensorflow/issues/41019

In case your data generator returns different number of batches per epoch, we need to update the `inferred_steps` after recreating the iterator over the dataset. This allows users to create data generators that modify the datasets and update the batch size every epoch, for example, using an increasing batch size.