### PR TITLE
Fix Const op tensor_content on s390x during save/load

### DIFF
--- a/tensorflow/cc/saved_model/BUILD
+++ b/tensorflow/cc/saved_model/BUILD
@@ -45,7 +45,7 @@ cc_library(
     deps = [
         ":constants",
         "//tensorflow/core:protos_all_cc",
-       "//tensorflow/core/util/tensor_bundle",
+        "//tensorflow/core/util/tensor_bundle",
     ] + if_not_mobile([
         # TODO(b/111634734): :lib and :protos_all contain dependencies that
         # cannot be built on mobile platforms. Instead, include the appropriate

--- a/tensorflow/cc/saved_model/BUILD
+++ b/tensorflow/cc/saved_model/BUILD
@@ -45,6 +45,7 @@ cc_library(
     deps = [
         ":constants",
         "//tensorflow/core:protos_all_cc",
+       "//tensorflow/core/util/tensor_bundle",
     ] + if_not_mobile([
         # TODO(b/111634734): :lib and :protos_all contain dependencies that
         # cannot be built on mobile platforms. Instead, include the appropriate

--- a/tensorflow/python/saved_model/load.py
+++ b/tensorflow/python/saved_model/load.py
@@ -878,7 +878,8 @@ def load_internal(export_dir, tags=None, options=None, loader_cls=Loader,
     # tensor_content field contains raw bytes in litle endian format which causes problems
     # when loaded on big-endian systems requiring byteswap
     if sys.byteorder == 'big':
-      saved_model_utils.swap_function_tensor_content(meta_graph_def, "little", "big")
+      saved_model_utils.swap_function_tensor_content(
+              meta_graph_def, "little", "big")
     if (tags is not None
         and set(tags) != set(meta_graph_def.meta_info_def.tags)):
       raise ValueError(

--- a/tensorflow/python/saved_model/save.py
+++ b/tensorflow/python/saved_model/save.py
@@ -22,6 +22,7 @@ import collections
 import functools
 import gc
 import os
+import sys
 
 from absl import logging
 from tensorflow.core.framework import versions_pb2
@@ -719,6 +720,9 @@ def _fill_meta_graph_def(meta_graph_def, saveable_view, signature_functions,
   for signature_key, signature in signatures.items():
     meta_graph_def.signature_def[signature_key].CopyFrom(signature)
   meta_graph.strip_graph_default_valued_attrs(meta_graph_def)
+  # store tensor_content in litle endian format
+  if sys.byteorder == 'big':
+    utils_impl.swap_function_tensor_content(meta_graph_def, "big", "little")
   return asset_info, exported_graph
 
 

--- a/tensorflow/python/saved_model/utils_impl.py
+++ b/tensorflow/python/saved_model/utils_impl.py
@@ -318,6 +318,9 @@ def byte_swap_tensor_content(tensor, from_endiness, to_endiness):
         tensor_size = tensor_size*sz.size
       chunksize = int(len(tensor_bytes)/tensor_size)
       #split tensor_data into chunks for byte swapping
-      to_swap = [tensor_bytes[i:i+chunksize] for i in range(0, len(tensor_bytes), chunksize)]
+      to_swap = [tensor_bytes[i:i+chunksize] for i in range(
+          0, len(tensor_bytes), chunksize)]
       #swap and replace tensor_content
-      tensor.tensor_content = b''.join([int.from_bytes(byteswap, from_endiness).to_bytes(chunksize, to_endiness) for byteswap in to_swap])
+      tensor.tensor_content = b''.join([int.from_bytes(
+          byteswap, from_endiness).to_bytes(
+              chunksize, to_endiness) for byteswap in to_swap])


### PR DESCRIPTION
This PR addresses swapping of  tensor_content data when Tensorflow models are saved across LE/BE systems.

Few [testcases](https://github.com/tensorflow/serving/blob/42666a18c050c47753449726f65cccc0937b75e0/tensorflow_serving/model_servers/tensorflow_model_server_test.py#L768) in Tensorflow Serving fail because they try to serve TF models that were saved on x86.  In particular, `tensor_content` field of `Const op` tensor has data stored in the native endiness format.  However, `tensor_content` field does not have a way to indicate endiness of the raw bytes that go in the `tensor_content` field.

Load and store mechanism of `saved_model` code has been modified to account for endiness when these operations are performed on LE/BE machines.  This is achieved by traversing through `meta_graph_def` proto and modifying the `tensor_content` of `Const op` tensor.

Specifically:

- In `tensorflow/python/saved_model/save.py` a function to swap `tensor_content`  is called on big-endian machine to store the bytes in little-endian format
- In `tensorflow/python/saved_model/load.py`, a reverse operation is performed to get `tensor_content` in big-endian format
- Similar changes are implemented in `tensorflow/cc/saved_model/reader.cc` to byte swap `tensor_content` 

This implementation is broadly based on the ideas from [this](https://github.com/tensorflow/tensorflow/pull/28490) PR.

