### PR TITLE
Allow custom ops to avoid ConverterError

### DIFF
--- a/tensorflow/lite/g3doc/guide/ops_select.md
+++ b/tensorflow/lite/g3doc/guide/ops_select.md
@@ -29,6 +29,7 @@ TensorFlow ops.
 import tensorflow as tf
 
 converter = tf.lite.TFLiteConverter.from_saved_model(saved_model_dir)
+converter.allow_custom_ops = True
 converter.target_spec.supported_ops = [
   tf.lite.OpsSet.TFLITE_BUILTINS, # enable TensorFlow Lite ops.
   tf.lite.OpsSet.SELECT_TF_OPS # enable TensorFlow ops.


### PR DESCRIPTION
Enabling TensorFlow operations that are not by default supported by TensorFlow lite requires (at least in some cases) to explicitly allow custom ops. As far as I understand, the respective guide would be more useful with `converter.allow_custom_ops = True`, to avoid problems as encountered in issue #45321.