### PR TITLE
micro: fix null-dereference build warning/error on g++ 10.2

### DIFF
--- a/tensorflow/lite/micro/kernels/detection_postprocess.cc
+++ b/tensorflow/lite/micro/kernels/detection_postprocess.cc
@@ -587,6 +587,8 @@ TfLiteStatus NonMaxSuppressionMultiClassRegularHelper(TfLiteContext* context,
           0.0f;
     }
   }
+
+  TF_LITE_ENSURE(context, num_detections != nullptr);
   tflite::micro::GetTensorData<float>(num_detections)[0] =
       size_of_sorted_indices;
 
@@ -683,6 +685,7 @@ TfLiteStatus NonMaxSuppressionMultiClassFastHelper(TfLiteContext* context,
     }
   }
 
+  TF_LITE_ENSURE(context, num_detections != nullptr);
   tflite::micro::GetTensorData<float>(num_detections)[0] = output_box_index;
   return kTfLiteOk;
 }


### PR DESCRIPTION
Without the added ENSURE, g++ flags an:

    error: potential null pointer dereference [-Werror=null-dereference]

in both of these locations while building from the Makefile a la:

    % g++ --version
    g++ (Debian 10.2.0-19) 10.2.0

    % make -f tensorflow/lite/micro/tools/make/Makefile test

which breaks the build.

Fixes #45381.

----
Not sure if this is the best way to fix this. The warning-as-error is annoying considering this is a pretty straightforward uses of GetEvalOutput and GetTensorData. Not certain why it isn't triggered on other uses of the return from GetTensorData, perhaps being within control-flow constructs causes g++ to assume the nullptr case is already handled.