### PR TITLE
micro: add mechanism for excluding sources from Makefile build

### DIFF
--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -233,14 +233,14 @@ MICRO_LITE_EXAMPLE_TESTS := $(shell find tensorflow/lite/micro/examples/ -maxdep
 MICRO_LITE_EXAMPLE_TESTS += $(shell find tensorflow/lite/micro/examples/ -name Makefile_internal.inc)
 MICRO_LITE_BENCHMARKS := $(wildcard tensorflow/lite/micro/benchmarks/Makefile.inc)
 
+# TODO(b/152645559): move all benchmarks to benchmarks directory.
+MICROLITE_BENCHMARK_SRCS := \
+$(wildcard tensorflow/lite/micro/benchmarks/*benchmark.cc)
+
 MICROLITE_TEST_SRCS := \
 $(wildcard tensorflow/lite/micro/*test.cc) \
 $(wildcard tensorflow/lite/micro/kernels/*test.cc) \
 $(wildcard tensorflow/lite/micro/memory_planner/*test.cc)
-
-# TODO(b/152645559): move all benchmarks to benchmarks directory.
-MICROLITE_BENCHMARK_SRCS := \
-$(wildcard tensorflow/lite/micro/benchmarks/*benchmark.cc)
 
 MICROLITE_CC_KERNEL_SRCS := \
 $(wildcard tensorflow/lite/micro/kernels/*.cc)

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -237,13 +237,22 @@ MICRO_LITE_BENCHMARKS := $(wildcard tensorflow/lite/micro/benchmarks/Makefile.in
 MICROLITE_BENCHMARK_SRCS := \
 $(wildcard tensorflow/lite/micro/benchmarks/*benchmark.cc)
 
+MICROLITE_EXCLUDED_TEST_SRCS := \
+end
+
 MICROLITE_TEST_SRCS := \
 $(wildcard tensorflow/lite/micro/*test.cc) \
 $(wildcard tensorflow/lite/micro/kernels/*test.cc) \
 $(wildcard tensorflow/lite/micro/memory_planner/*test.cc)
+MICROLITE_TEST_SRCS := $(filter-out $(MICROLITE_EXCLUDED_TEST_SRCS), $(MICROLITE_TEST_SRCS))
+
+MICROLITE_EXCLUDED_KERNEL_SRCS := \
+end
 
 MICROLITE_CC_KERNEL_SRCS := \
 $(wildcard tensorflow/lite/micro/kernels/*.cc)
+MICROLITE_CC_KERNEL_SRCS := $(filter-out $(MICROLITE_EXCLUDED_KERNEL_SRCS), $(MICROLITE_CC_KERNEL_SRCS))
+MICROLITE_CC_KERNEL_SRCS := $(filter-out $(MICROLITE_EXCLUDED_TEST_SRCS), $(MICROLITE_CC_KERNEL_SRCS))
 MICROLITE_CC_KERNEL_SRCS := $(filter-out $(MICROLITE_TEST_SRCS), $(MICROLITE_CC_KERNEL_SRCS))
 
 MICROLITE_TEST_HDRS := \


### PR DESCRIPTION
See issue #45387. We occasionally want to exclude, from the build, test and kernel files that would otherwise match wildcards.

Adding exclude lists, as is done in this PR, is one method of achieving the goal. It's a little messy, however, and may be prone to merge conflicts if there are multiple PRs with exclusions in-flight at the same time. There's an alternative PR coming which explicitly lists all files instead of using wildcards and exclusion lists.

@tensorflow/micro 