### PR TITLE
micro: list test and kernel files explicitly in Makefile

### DIFF
--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -233,14 +233,14 @@ MICRO_LITE_EXAMPLE_TESTS := $(shell find tensorflow/lite/micro/examples/ -maxdep
 MICRO_LITE_EXAMPLE_TESTS += $(shell find tensorflow/lite/micro/examples/ -name Makefile_internal.inc)
 MICRO_LITE_BENCHMARKS := $(wildcard tensorflow/lite/micro/benchmarks/Makefile.inc)
 
+# TODO(b/152645559): move all benchmarks to benchmarks directory.
+MICROLITE_BENCHMARK_SRCS := \
+$(wildcard tensorflow/lite/micro/benchmarks/*benchmark.cc)
+
 MICROLITE_TEST_SRCS := \
 $(wildcard tensorflow/lite/micro/*test.cc) \
 $(wildcard tensorflow/lite/micro/kernels/*test.cc) \
 $(wildcard tensorflow/lite/micro/memory_planner/*test.cc)
-
-# TODO(b/152645559): move all benchmarks to benchmarks directory.
-MICROLITE_BENCHMARK_SRCS := \
-$(wildcard tensorflow/lite/micro/benchmarks/*benchmark.cc)
 
 MICROLITE_CC_KERNEL_SRCS := \
 $(wildcard tensorflow/lite/micro/kernels/*.cc)

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -238,13 +238,106 @@ MICROLITE_BENCHMARK_SRCS := \
 $(wildcard tensorflow/lite/micro/benchmarks/*benchmark.cc)
 
 MICROLITE_TEST_SRCS := \
-$(wildcard tensorflow/lite/micro/*test.cc) \
-$(wildcard tensorflow/lite/micro/kernels/*test.cc) \
-$(wildcard tensorflow/lite/micro/memory_planner/*test.cc)
+tensorflow/lite/micro/memory_arena_threshold_test.cc \
+tensorflow/lite/micro/memory_helpers_test.cc \
+tensorflow/lite/micro/micro_allocator_test.cc \
+tensorflow/lite/micro/micro_error_reporter_test.cc \
+tensorflow/lite/micro/micro_interpreter_test.cc \
+tensorflow/lite/micro/micro_mutable_op_resolver_test.cc \
+tensorflow/lite/micro/micro_string_test.cc \
+tensorflow/lite/micro/micro_time_test.cc \
+tensorflow/lite/micro/micro_utils_test.cc \
+tensorflow/lite/micro/recording_micro_allocator_test.cc \
+tensorflow/lite/micro/recording_simple_memory_allocator_test.cc \
+tensorflow/lite/micro/simple_memory_allocator_test.cc \
+tensorflow/lite/micro/testing_helpers_test.cc \
+tensorflow/lite/micro/kernels/activations_test.cc \
+tensorflow/lite/micro/kernels/add_test.cc \
+tensorflow/lite/micro/kernels/arg_min_max_test.cc \
+tensorflow/lite/micro/kernels/ceil_test.cc \
+tensorflow/lite/micro/kernels/circular_buffer_test.cc \
+tensorflow/lite/micro/kernels/comparisons_test.cc \
+tensorflow/lite/micro/kernels/concatenation_test.cc \
+tensorflow/lite/micro/kernels/conv_test.cc \
+tensorflow/lite/micro/kernels/depthwise_conv_test.cc \
+tensorflow/lite/micro/kernels/dequantize_test.cc \
+tensorflow/lite/micro/kernels/detection_postprocess_test.cc \
+tensorflow/lite/micro/kernels/elementwise_test.cc \
+tensorflow/lite/micro/kernels/floor_test.cc \
+tensorflow/lite/micro/kernels/fully_connected_test.cc \
+tensorflow/lite/micro/kernels/hard_swish_test.cc \
+tensorflow/lite/micro/kernels/l2norm_test.cc \
+tensorflow/lite/micro/kernels/logical_test.cc \
+tensorflow/lite/micro/kernels/logistic_test.cc \
+tensorflow/lite/micro/kernels/maximum_minimum_test.cc \
+tensorflow/lite/micro/kernels/mul_test.cc \
+tensorflow/lite/micro/kernels/neg_test.cc \
+tensorflow/lite/micro/kernels/pack_test.cc \
+tensorflow/lite/micro/kernels/pad_test.cc \
+tensorflow/lite/micro/kernels/pooling_test.cc \
+tensorflow/lite/micro/kernels/prelu_test.cc \
+tensorflow/lite/micro/kernels/quantization_util_test.cc \
+tensorflow/lite/micro/kernels/quantize_test.cc \
+tensorflow/lite/micro/kernels/reduce_test.cc \
+tensorflow/lite/micro/kernels/reshape_test.cc \
+tensorflow/lite/micro/kernels/resize_nearest_neighbor_test.cc \
+tensorflow/lite/micro/kernels/round_test.cc \
+tensorflow/lite/micro/kernels/shape_test.cc \
+tensorflow/lite/micro/kernels/softmax_test.cc \
+tensorflow/lite/micro/kernels/split_test.cc \
+tensorflow/lite/micro/kernels/split_v_test.cc \
+tensorflow/lite/micro/kernels/strided_slice_test.cc \
+tensorflow/lite/micro/kernels/sub_test.cc \
+tensorflow/lite/micro/kernels/svdf_test.cc \
+tensorflow/lite/micro/kernels/tanh_test.cc \
+tensorflow/lite/micro/kernels/unpack_test.cc \
+tensorflow/lite/micro/memory_planner/greedy_memory_planner_test.cc \
+tensorflow/lite/micro/memory_planner/linear_memory_planner_test.cc
 
 MICROLITE_CC_KERNEL_SRCS := \
-$(wildcard tensorflow/lite/micro/kernels/*.cc)
-MICROLITE_CC_KERNEL_SRCS := $(filter-out $(MICROLITE_TEST_SRCS), $(MICROLITE_CC_KERNEL_SRCS))
+tensorflow/lite/micro/kernels/activations.cc \
+tensorflow/lite/micro/kernels/add.cc \
+tensorflow/lite/micro/kernels/arg_min_max.cc \
+tensorflow/lite/micro/kernels/ceil.cc \
+tensorflow/lite/micro/kernels/circular_buffer.cc \
+tensorflow/lite/micro/kernels/comparisons.cc \
+tensorflow/lite/micro/kernels/concatenation.cc \
+tensorflow/lite/micro/kernels/conv.cc \
+tensorflow/lite/micro/kernels/depthwise_conv.cc \
+tensorflow/lite/micro/kernels/dequantize.cc \
+tensorflow/lite/micro/kernels/detection_postprocess.cc \
+tensorflow/lite/micro/kernels/elementwise.cc \
+tensorflow/lite/micro/kernels/ethosu.cc \
+tensorflow/lite/micro/kernels/flexbuffers_generated_data.cc \
+tensorflow/lite/micro/kernels/floor.cc \
+tensorflow/lite/micro/kernels/fully_connected.cc \
+tensorflow/lite/micro/kernels/hard_swish.cc \
+tensorflow/lite/micro/kernels/kernel_runner.cc \
+tensorflow/lite/micro/kernels/kernel_util.cc \
+tensorflow/lite/micro/kernels/l2norm.cc \
+tensorflow/lite/micro/kernels/logical.cc \
+tensorflow/lite/micro/kernels/logistic.cc \
+tensorflow/lite/micro/kernels/maximum_minimum.cc \
+tensorflow/lite/micro/kernels/mul.cc \
+tensorflow/lite/micro/kernels/neg.cc \
+tensorflow/lite/micro/kernels/pack.cc \
+tensorflow/lite/micro/kernels/pad.cc \
+tensorflow/lite/micro/kernels/pooling.cc \
+tensorflow/lite/micro/kernels/prelu.cc \
+tensorflow/lite/micro/kernels/quantize.cc \
+tensorflow/lite/micro/kernels/reduce.cc \
+tensorflow/lite/micro/kernels/reshape.cc \
+tensorflow/lite/micro/kernels/resize_nearest_neighbor.cc \
+tensorflow/lite/micro/kernels/round.cc \
+tensorflow/lite/micro/kernels/shape.cc \
+tensorflow/lite/micro/kernels/softmax.cc \
+tensorflow/lite/micro/kernels/split.cc \
+tensorflow/lite/micro/kernels/split_v.cc \
+tensorflow/lite/micro/kernels/strided_slice.cc \
+tensorflow/lite/micro/kernels/sub.cc \
+tensorflow/lite/micro/kernels/svdf.cc \
+tensorflow/lite/micro/kernels/tanh.cc \
+tensorflow/lite/micro/kernels/unpack.cc
 
 MICROLITE_TEST_HDRS := \
 $(wildcard tensorflow/lite/micro/testing/*.h)


### PR DESCRIPTION
See issue #45387. We occasionally want to exclude, from the build, test and kernel files that would otherwise match wildcards.

Listing files explicitly, as done in this PR, is one method of achieving the goal. There is an alternative PR #45388 which keeps the wildcards and adds exclusion lists instead. This PR's scheme may be a little cleaner and less prone to merge conflicts when multiple PRs with exclusions are in-flight at the same time. Of course, the tradeoff is a long list of files; however, that's a common trend in build system configuration files these days.