### PR TITLE
Only use site.USER_SITE if ENABLE_USER_SITE is set

### DIFF
--- a/tensorflow/api_template.__init__.py
+++ b/tensorflow/api_template.__init__.py
@@ -116,7 +116,8 @@ from tensorflow.python.lib.io import file_io as _fi
 
 # Get sitepackages directories for the python installation.
 _site_packages_dirs = []
-_site_packages_dirs += [] if _site.USER_SITE is None else [_site.USER_SITE]
+if _site.ENABLE_USER_SITE and _site.USER_SITE is not None:
+  _site_packages_dirs += [_site.USER_SITE]
 _site_packages_dirs += [_p for _p in _sys.path if 'site-packages' in _p]
 if 'getsitepackages' in dir(_site):
   _site_packages_dirs += _site.getsitepackages()


### PR DESCRIPTION
Fixes loading dynamic kernels from user site even in a virtual environment.

Currently, the `site.USER_SITE` is unconditionally added to the path used for preloading dynamic kernels. However, when running in a virtual environment, the `site.USER_SITE` should not be added, because a different TF version might be there (and as reported in #42978, it causes a crash for example when TF 2.3 is in user site and TF 2.4 in a virtual environment).

Luckily, `site.ENABLE_USER_SITE` is a flag indicating if `site.USER_SITE` was added to path, and it is set to False when running in a virtual environment. In this pull request, the `site.ENABLE_USER_SITE` is honored.

Should fix #42978.