### PR TITLE
micro: copy operator FILL kernel from lite

### DIFF
--- a/tensorflow/lite/micro/kernels/fill.cc
+++ b/tensorflow/lite/micro/kernels/fill.cc
@@ -41,7 +41,8 @@ TfLiteStatus ResizeOutputImpl(TfLiteContext* context, const TfLiteTensor* dims,
     T data = GetTensorData<T>(dims)[i];
     if (data < 0) {
       TfLiteIntArrayFree(output_shape);
-      context->ReportError(context, "Fill dimensions must be >= 0", dims->type);
+      TF_LITE_KERNEL_LOG(context, "Fill dimensions must be >= 0",
+                         TfLiteTypeGetName(dims->type));
       return kTfLiteError;
     }
     output_shape->data[i] = data;
@@ -57,11 +58,10 @@ TfLiteStatus ResizeOutput(TfLiteContext* context, const TfLiteTensor* dims,
     case kTfLiteInt64:
       return ResizeOutputImpl<int64_t>(context, dims, output);
     default:
-      context->ReportError(
+      TF_LITE_KERNEL_LOG(
           context,
-          "Fill only currently supports int32, int64 for input 0, "
-          "got %d.",
-          dims->type);
+          "Fill only currently supports int32, int64 for input 0, got %s.",
+          TfLiteTypeGetName(dims->type));
       return kTfLiteError;
   }
 }
@@ -148,11 +148,11 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       FillString(value, output);
       break;
     default:
-      context->ReportError(
+      TF_LITE_KERNEL_LOG(
           context,
           "Fill only currently supports int32, int64, float32, bool, string "
           "for input 1, got %d.",
-          value->type);
+          TfLiteTypeGetName(value->type));
       return kTfLiteError;
   }
 #undef TF_LITE_FILL

--- a/tensorflow/lite/micro/kernels/fill.cc
+++ b/tensorflow/lite/micro/kernels/fill.cc
@@ -1,0 +1,172 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <stdint.h>
+
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/reference/reference_ops.h"
+#include "tensorflow/lite/kernels/internal/tensor.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/string_util.h"
+
+namespace tflite {
+namespace ops {
+namespace builtin {
+namespace fill {
+
+namespace {
+
+constexpr int kDimsTensor = 0;
+constexpr int kValueTensor = 1;
+constexpr int kOutputTensor = 0;
+
+template <typename T>
+TfLiteStatus ResizeOutputImpl(TfLiteContext* context, const TfLiteTensor* dims,
+                              TfLiteTensor* output) {
+  TfLiteIntArray* output_shape = TfLiteIntArrayCreate(dims->dims->data[0]);
+  for (int i = 0; i < output_shape->size; ++i) {
+    T data = GetTensorData<T>(dims)[i];
+    if (data < 0) {
+      TfLiteIntArrayFree(output_shape);
+      context->ReportError(context, "Fill dimensions must be >= 0", dims->type);
+      return kTfLiteError;
+    }
+    output_shape->data[i] = data;
+  }
+  return context->ResizeTensor(context, output, output_shape);
+}
+
+TfLiteStatus ResizeOutput(TfLiteContext* context, const TfLiteTensor* dims,
+                          TfLiteTensor* output) {
+  switch (dims->type) {
+    case kTfLiteInt32:
+      return ResizeOutputImpl<int32_t>(context, dims, output);
+    case kTfLiteInt64:
+      return ResizeOutputImpl<int64_t>(context, dims, output);
+    default:
+      context->ReportError(
+          context,
+          "Fill only currently supports int32, int64 for input 0, "
+          "got %d.",
+          dims->type);
+      return kTfLiteError;
+  }
+}
+
+}  // namespace
+
+TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+  TF_LITE_ENSURE_EQ(context, NumInputs(node), 2);
+  TF_LITE_ENSURE_EQ(context, NumOutputs(node), 1);
+
+  const TfLiteTensor* dims;
+  TF_LITE_ENSURE_OK(context, GetInputSafe(context, node, kDimsTensor, &dims));
+  const TfLiteTensor* value;
+  TF_LITE_ENSURE_OK(context, GetInputSafe(context, node, kValueTensor, &value));
+
+  // Make sure the 1st input tensor is 1-D.
+  TF_LITE_ENSURE_EQ(context, NumDimensions(dims), 1);
+
+  // Make sure the 1st input tensor is int32 or int64.
+  const auto dtype = dims->type;
+  TF_LITE_ENSURE(context, dtype == kTfLiteInt32 || dtype == kTfLiteInt64);
+
+  // Make sure the 2nd input tensor is a scalar.
+  TF_LITE_ENSURE_EQ(context, NumDimensions(value), 0);
+
+  TfLiteTensor* output;
+  TF_LITE_ENSURE_OK(context,
+                    GetOutputSafe(context, node, kOutputTensor, &output));
+  output->type = value->type;
+
+  if (IsConstantTensor(dims)) {
+    TF_LITE_ENSURE_OK(context, ResizeOutput(context, dims, output));
+  } else {
+    SetTensorToDynamic(output);
+  }
+  return kTfLiteOk;
+}
+
+TfLiteStatus FillString(const TfLiteTensor* value, TfLiteTensor* output) {
+  DynamicBuffer buffer;
+  const auto string_ref = GetString(value, 0);
+  int n = 1;
+  for (int i = 0; i < output->dims->size; ++i) {
+    n *= output->dims->data[i];
+  }
+  for (int i = 0; i < n; ++i) {
+    buffer.AddString(string_ref.str, string_ref.len);
+  }
+  buffer.WriteToTensor(output, /*new_shape=*/nullptr);
+  return kTfLiteOk;
+}
+
+TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
+  const TfLiteTensor* value;
+  TF_LITE_ENSURE_OK(context, GetInputSafe(context, node, kValueTensor, &value));
+
+  TfLiteTensor* output;
+  TF_LITE_ENSURE_OK(context,
+                    GetOutputSafe(context, node, kOutputTensor, &output));
+
+  if (IsDynamicTensor(output)) {
+    const TfLiteTensor* dims;
+    TF_LITE_ENSURE_OK(context, GetInputSafe(context, node, kDimsTensor, &dims));
+    TF_LITE_ENSURE_OK(context, ResizeOutput(context, dims, output));
+  }
+#define TF_LITE_FILL(data_type)                                               \
+  reference_ops::Fill(GetTensorShape(value), GetTensorData<data_type>(value), \
+                      GetTensorShape(output),                                 \
+                      GetTensorData<data_type>(output))
+  switch (output->type) {
+    case kTfLiteInt32:
+      TF_LITE_FILL(int32_t);
+      break;
+    case kTfLiteInt64:
+      TF_LITE_FILL(int64_t);
+      break;
+    case kTfLiteFloat32:
+      TF_LITE_FILL(float);
+      break;
+    case kTfLiteBool:
+      TF_LITE_FILL(bool);
+      break;
+    case kTfLiteString:
+      FillString(value, output);
+      break;
+    default:
+      context->ReportError(
+          context,
+          "Fill only currently supports int32, int64, float32, bool, string "
+          "for input 1, got %d.",
+          value->type);
+      return kTfLiteError;
+  }
+#undef TF_LITE_FILL
+  return kTfLiteOk;
+}
+
+}  // namespace fill
+
+TfLiteRegistration* Register_FILL() {
+  static TfLiteRegistration r = {/*init=*/nullptr, /*free=*/nullptr,
+                                 fill::Prepare, fill::Eval};
+  return &r;
+}
+
+}  // namespace builtin
+}  // namespace ops
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/fill_test.cc
+++ b/tensorflow/lite/micro/kernels/fill_test.cc
@@ -1,0 +1,144 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include <stdint.h>
+
+#include <initializer_list>
+#include <string>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "tensorflow/lite/kernels/test_util.h"
+#include "tensorflow/lite/schema/schema_generated.h"
+#include "tensorflow/lite/string_type.h"
+
+namespace tflite {
+namespace {
+
+using ::testing::ElementsAreArray;
+using ::testing::IsEmpty;
+
+enum class TestType {
+  kConst = 0,
+  kDynamic = 1,
+};
+
+template <typename dims_type, typename value_type>
+class FillOpModel : public SingleOpModel {
+ public:
+  explicit FillOpModel(TensorType dims_tensor_type,
+                       std::initializer_list<int> dims_shape,
+                       std::initializer_list<dims_type> dims_data,
+                       value_type value, TestType input_tensor_types) {
+    if (input_tensor_types == TestType::kDynamic) {
+      dims_ = AddInput(dims_tensor_type);
+      value_ = AddInput(GetTensorType<value_type>());
+    } else {
+      dims_ = AddConstInput(dims_tensor_type, dims_data, dims_shape);
+      value_ = AddConstInput(GetTensorType<value_type>(), {value}, {});
+    }
+    output_ = AddOutput(GetTensorType<value_type>());
+    SetBuiltinOp(BuiltinOperator_FILL, BuiltinOptions_FillOptions,
+                 CreateFillOptions(builder_).Union());
+    BuildInterpreter({dims_shape, {}});
+
+    if (input_tensor_types == TestType::kDynamic) {
+      if (dims_data.size() > 0) {
+        PopulateTensor<dims_type>(dims_, dims_data);
+      }
+      PopulateTensor<value_type>(value_, {value});
+    }
+  }
+
+  std::vector<value_type> GetOutput() {
+    return ExtractVector<value_type>(output_);
+  }
+  std::vector<int> GetOutputShape() { return GetTensorShape(output_); }
+
+ protected:
+  int dims_;
+  int value_;
+  int output_;
+};
+
+class FillOpTest : public ::testing::TestWithParam<TestType> {};
+
+TEST_P(FillOpTest, FillInt32) {
+  FillOpModel<int32_t, int32_t> m(TensorType_INT32, {2}, {2, 3}, -11,
+                                  GetParam());
+  m.Invoke();
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray({-11, -11, -11, -11, -11, -11}));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 3}));
+}
+
+TEST_P(FillOpTest, FillInt64) {
+  FillOpModel<int64_t, int64_t> m(TensorType_INT64, {2}, {2, 4}, 1LL << 45,
+                                  GetParam());
+  m.Invoke();
+  EXPECT_THAT(m.GetOutput(),
+              ElementsAreArray({1LL << 45, 1LL << 45, 1LL << 45, 1LL << 45,
+                                1LL << 45, 1LL << 45, 1LL << 45, 1LL << 45}));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 4}));
+}
+
+TEST_P(FillOpTest, FillFloat) {
+  FillOpModel<int64_t, float> m(TensorType_INT64, {3}, {2, 2, 2}, 4.0,
+                                GetParam());
+  m.Invoke();
+  EXPECT_THAT(m.GetOutput(),
+              ElementsAreArray({4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0}));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 2, 2}));
+}
+
+TEST_P(FillOpTest, FillFloatInt32Dims) {
+  FillOpModel<int32_t, float> m(TensorType_INT32, {3}, {2, 2, 2}, 4.0,
+                                GetParam());
+  m.Invoke();
+  EXPECT_THAT(m.GetOutput(),
+              ElementsAreArray({4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0}));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 2, 2}));
+}
+
+TEST_P(FillOpTest, FillOutputScalar) {
+  FillOpModel<int64_t, float> m(TensorType_INT64, {0}, {}, 4.0, GetParam());
+  m.Invoke();
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray({4.0}));
+  EXPECT_THAT(m.GetOutputShape(), IsEmpty());
+}
+
+TEST_P(FillOpTest, FillBool) {
+  FillOpModel<int64_t, bool> m(TensorType_INT64, {3}, {2, 2, 2}, true,
+                               GetParam());
+  m.Invoke();
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray({true, true, true, true, true,
+                                               true, true, true}));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 2, 2}));
+}
+
+TEST(FillOpTest, FillString) {
+  FillOpModel<int64_t, std::string> m(TensorType_INT64, {3}, {2, 2, 2}, "AB",
+                                      TestType::kDynamic);
+  m.Invoke();
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray({"AB", "AB", "AB", "AB", "AB",
+                                               "AB", "AB", "AB"}));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 2, 2}));
+}
+
+INSTANTIATE_TEST_SUITE_P(FillOpTest, FillOpTest,
+                         ::testing::Values(TestType::kConst,
+                                           TestType::kDynamic));
+
+}  // namespace
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/fill_test.cc
+++ b/tensorflow/lite/micro/kernels/fill_test.cc
@@ -12,8 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <initializer_list>

--- a/tensorflow/lite/micro/kernels/fill_test.cc
+++ b/tensorflow/lite/micro/kernels/fill_test.cc
@@ -12,14 +12,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <initializer_list>
 #include <string>
 #include <vector>
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
 #include "tensorflow/lite/kernels/test_util.h"
 #include "tensorflow/lite/schema/schema_generated.h"
 #include "tensorflow/lite/string_type.h"


### PR DESCRIPTION
This is a copy without modification of the kernel and test for
operator FILL from tensorflow/lite/kernels at 67993f46cb9.
Adaptations to micro and addition to the micro build to follow.

This is part of the work to port operator FILL as tracked in #45306.