### PR TITLE
TFLu: Fix bug in PPD op

### DIFF
--- a/tensorflow/lite/micro/kernels/detection_postprocess.cc
+++ b/tensorflow/lite/micro/kernels/detection_postprocess.cc
@@ -357,8 +357,9 @@ int SelectDetectionsAboveScoreThreshold(const float* values, int size,
   int counter = 0;
   for (int i = 0; i < size; i++) {
     if (values[i] >= threshold) {
-      keep_values[counter++] = values[i];
-      keep_indices[i] = i;
+      keep_values[counter] = values[i];
+      keep_indices[counter] = i;
+      counter++;
     }
   }
   return counter;


### PR DESCRIPTION
This is a fix for issue: https://github.com/tensorflow/tensorflow/issues/45473

With this fix TFL and TFLM gives the same output for SSD Mobilenet v2 (updated with fixed output dimensions).
