### PR TITLE
ellaborated docs on determinism in dataset ops

### DIFF
--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -1774,11 +1774,6 @@ name=None))
     in general precludes the possibility of executing user-defined
     transformations in parallel (because of Python GIL).
 
-    The order of elements yielded by this transformation is
-    deterministic, as long as `map_func` is a pure function and
-    `deterministic=True`. If `map_func` contains any stateful operations, the
-    order in which that state is accessed is undefined.
-
     Performance can often be improved by setting `num_parallel_calls` so that
     `map` will use multiple threads to process elements. If deterministic order
     isn't required, it can also improve performance to set
@@ -1788,6 +1783,12 @@ name=None))
     >>> dataset = dataset.map(lambda x: x + 1,
     ...     num_parallel_calls=tf.data.AUTOTUNE,
     ...     deterministic=False)
+
+    If `num_parallel_calls > 1`, the order of elements yielded by this
+    transformation is deterministic if `deterministic=True`. If `map_func`
+    contains stateful operations and `num_parallel_calls > 1`, the order in
+    which that state is accessed is undefined, so the values of output elements
+    may not be deterministic regardless of the `deterministic` flag value.
 
     Args:
       map_func: A function mapping a dataset element to another dataset element.

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -1784,11 +1784,11 @@ name=None))
     ...     num_parallel_calls=tf.data.AUTOTUNE,
     ...     deterministic=False)
 
-    If `num_parallel_calls > 1`, the order of elements yielded by this
-    transformation is deterministic if `deterministic=True`. If `map_func`
-    contains stateful operations and `num_parallel_calls > 1`, the order in
-    which that state is accessed is undefined, so the values of output elements
-    may not be deterministic regardless of the `deterministic` flag value.
+    The order of elements yielded by this transformation is deterministic if
+    `deterministic=True`. If `map_func` contains stateful operations and
+    `num_parallel_calls > 1`, the order in which that state is accessed is
+    undefined, so the values of output elements may not be deterministic
+    regardless of the `deterministic` flag value.
 
     Args:
       map_func: A function mapping a dataset element to another dataset element.

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -1774,6 +1774,11 @@ name=None))
     in general precludes the possibility of executing user-defined
     transformations in parallel (because of Python GIL).
 
+    The order of elements yielded by this transformation is
+    deterministic, as long as `map_func` is a pure function and
+    `deterministic=True`. If `map_func` contains any stateful operations, the
+    order in which that state is accessed is undefined.
+
     Performance can often be improved by setting `num_parallel_calls` so that
     `map` will use multiple threads to process elements. If deterministic order
     isn't required, it can also improve performance to set
@@ -1792,11 +1797,10 @@ name=None))
         `tf.data.AUTOTUNE` is used, then the number of parallel
         calls is set dynamically based on available CPU.
       deterministic: (Optional.) A boolean controlling whether determinism
-        should be traded for performance by allowing elements to be produced out
+        should be traded for performance by allowing elements to be yielded out
         of order.  If `deterministic` is `None`, the
         `tf.data.Options.experimental_deterministic` dataset option (`True` by
-        default) is used to decide whether to produce elements
-        deterministically.
+        default) is used to decide whether to run deterministically.
 
     Returns:
       Dataset: A `Dataset`.
@@ -1925,8 +1929,7 @@ name=None))
         should be traded for performance by allowing elements to be produced out
         of order.  If `deterministic` is `None`, the
         `tf.data.Options.experimental_deterministic` dataset option (`True` by
-        default) is used to decide whether to produce elements
-        deterministically.
+        default) is used to decide whether to run deterministically.
 
     Returns:
       Dataset: A `Dataset`.


### PR DESCRIPTION
Following on from [this discussion](https://github.com/tensorflow/tensorflow/issues/44491), `Dataset.map` docs imply setting `determinism=True` in `Dataset.map` will make the returned dataset deterministic (assuming the original is). This clarifies the behaviour is undefined if `map_func` is not pure (doc addition similar to that used in `interleave`).