### PR TITLE
Don’t try to build compiled metrics, when loading the model

### DIFF
--- a/tensorflow/python/keras/saving/hdf5_format.py
+++ b/tensorflow/python/keras/saving/hdf5_format.py
@@ -198,7 +198,6 @@ def load_model_from_hdf5(filepath, custom_objects=None, compile=True):  # pylint
       # Compile model.
       model.compile(**saving_utils.compile_args_from_training_config(
           training_config, custom_objects))
-      saving_utils.try_build_compiled_arguments(model)
 
       # Set optimizer weights.
       if 'optimizer_weights' in f:

--- a/tensorflow/python/keras/saving/saved_model/load.py
+++ b/tensorflow/python/keras/saving/saved_model/load.py
@@ -169,7 +169,6 @@ def load(path, compile=True, options=None):  # pylint: disable=redefined-builtin
     if training_config is not None:
       model.compile(**saving_utils.compile_args_from_training_config(
           training_config))
-      saving_utils.try_build_compiled_arguments(model)
     else:
       logging.warning('No training configuration found in save file, so the '
                       'model was *not* compiled. Compile it manually.')

--- a/tensorflow/python/keras/saving/saving_utils.py
+++ b/tensorflow/python/keras/saving/saving_utils.py
@@ -308,16 +308,3 @@ def _enforce_names_consistency(specs):
   if name_inconsistency:
     specs = nest.map_structure(_clear_name, specs)
   return specs
-
-
-def try_build_compiled_arguments(model):
-  if (not version_utils.is_v1_layer_or_model(model) and
-      model.outputs is not None):
-    try:
-      model.compiled_loss.build(model.outputs)
-      model.compiled_metrics.build(model.outputs, model.outputs)
-    except:  # pylint: disable=bare-except
-      logging.warning(
-          'Compiled the loaded model, but the compiled metrics have yet to '
-          'be built. `model.compile_metrics` will be empty until you train '
-          'or evaluate the model.')


### PR DESCRIPTION
Currently, the user can pass the strings to the metrics argument in `Model.compile` function, and convert it to one of `tf.keras.metrics` classes based on y_true shape and y_pred shape(In function `MetricsContainer._get_metric_object`). 

This feature brings us convenience, but when the user saves the model and loads it, the model is compiled by default, and at the same time, it tries to build the compiled metrics. But when the compiled metrics are built, only the output shape of the model is used to guess which metric class the user wants to use, which brings surprises. The current examples are sparse categorical accuracy and sparse categorical cross-entropy. 

Here is the small demo to reproduce the problem. I have encountered this problem. I always thought that the performance of the model was not good, but I did not expect the metric class to be wrong.

```python
# TensorFlow and tf.keras
import tensorflow as tf

# Helper libraries
import numpy as np

print(tf.__version__)

fashion_mnist = tf.keras.datasets.fashion_mnist

(train_images, train_labels), (test_images, test_labels) = fashion_mnist.load_data()

model = tf.keras.Sequential([
    tf.keras.layers.Flatten(input_shape=(28, 28)),
    tf.keras.layers.Dense(128, activation='relu'),
    tf.keras.layers.Dense(10)
])

model.compile(optimizer='adam',
              loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),
              metrics=['accuracy'])

model.fit(train_images, train_labels, epochs=1)

test_loss, test_acc = model.evaluate(test_images,  test_labels, verbose=2)

model.save('model.h5')

model = tf.keras.models.load_model('model.h5')

test_loss, test_acc = model.evaluate(test_images,  test_labels, verbose=2)

model = tf.keras.models.load_model('model.h5', compile=False)

model.compile(optimizer='adam',
              loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),
              metrics=['accuracy'])

test_loss, test_acc = model.evaluate(test_images,  test_labels, verbose=2)
```
```
1875/1875 [==============================] - 2s 1ms/step - loss: 3.1409 - accuracy: 0.6773
313/313 - 0s - loss: 0.8313 - accuracy: 0.7169
313/313 - 0s - loss: 0.8313 - accuracy: 0.1098
313/313 - 0s - loss: 0.8313 - accuracy: 0.7169
```

I also found that some users have encountered this "surprise" #43230