### PR TITLE
Dispatch reverse_sequence

### DIFF
--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -4759,6 +4759,7 @@ def reverse_sequence(input,
 
 
 @tf_export("reverse_sequence", v1=[])
+@dispatch.add_dispatch_support
 def reverse_sequence_v2(input,
                         seq_lengths,
                         seq_axis=None,


### PR DESCRIPTION
The code snippet
```python
tf.reverse_sequence(x, seq_len, seq_axis=-1)
```
will fail when inputs are keras symbolic tensor. Originated from addons when trying to test against TF2.4.

https://github.com/tensorflow/addons/pull/2250

https://colab.research.google.com/drive/1lGXNR5nm6FS-F_gzx-GretLJCrljU96t?usp=sharing