### PR TITLE
Fix Windows platform file stat length out of range error

### DIFF
--- a/tensorflow/core/platform/windows/windows_file_system.cc
+++ b/tensorflow/core/platform/windows/windows_file_system.cc
@@ -570,9 +570,9 @@ bool WindowsFileSystem::Match(const string& filename, const string& pattern) {
 Status WindowsFileSystem::Stat(const string& fname, TransactionToken* token,
                                FileStatistics* stat) {
   Status result;
-  struct _stat sbuf;
+  struct _stat64 sbuf;
   std::wstring ws_translated_fname = Utf8ToWideChar(TranslateName(fname));
-  if (_wstat(ws_translated_fname.c_str(), &sbuf) != 0) {
+  if (_wstat64(ws_translated_fname.c_str(), &sbuf) != 0) {
     result = IOError(fname, errno);
   } else {
     stat->mtime_nsec = sbuf.st_mtime * 1e9;


### PR DESCRIPTION
Tensorflow Windows version's file stat function by default use **_wstat** which represents the file size as 32-bit integer, once load large than 4GB file will meet **outOfRange** error. So I change the default to use **_wstat64** which represents the file size as 64-bit integer to fix the issue.