### PR TITLE
remove $ from readme for easy compatibility with Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ To install the current release, which includes support for
 Windows)*:
 
 ```
-$ pip install tensorflow
+pip install tensorflow
 ```
 
 A smaller CPU-only package is also available:
 
 ```
-$ pip install tensorflow-cpu
+pip install tensorflow-cpu
 ```
 
 To update TensorFlow to the latest version, add `--upgrade` flag to the above
@@ -64,7 +64,7 @@ commands.
 #### *Try your first TensorFlow program*
 
 ```shell
-$ python
+python
 ```
 
 ```python


### PR DESCRIPTION
Hi! 
`` $ `` only case specific to Linux/Unix based systems only. If we use ``$``in a Windows machine we get an error as its doesn't accepts ``$`` sign in the syntax. 
So for solving that I am making this PR which will add easy compatibility to users getting started with TensorFlow on Windows.
Do suggest me if I should have made this change in some other way. 
Thanks! :) 