### PR TITLE
 [INTEL MKL] Enable DNNL cpu dispatch control

### DIFF
--- a/third_party/mkl_dnn/mkldnn_v1.BUILD
+++ b/third_party/mkl_dnn/mkldnn_v1.BUILD
@@ -83,7 +83,7 @@ cc_library(
     }) + [
         "-UUSE_MKL",
         "-UUSE_CBLAS",
-        "-DNNL_ENABLE_MAX_CPU_ISA",
+        "-DDNNL_ENABLE_MAX_CPU_ISA",
     ] + tf_openmp_copts(),
     includes = [
         "include",

--- a/third_party/mkl_dnn/mkldnn_v1.BUILD
+++ b/third_party/mkl_dnn/mkldnn_v1.BUILD
@@ -83,6 +83,7 @@ cc_library(
     }) + [
         "-UUSE_MKL",
         "-UUSE_CBLAS",
+        "-DNNL_ENABLE_MAX_CPU_ISA",
     ] + tf_openmp_copts(),
     includes = [
         "include",


### PR DESCRIPTION
Define DNNL_ENABLE_MAX_CPU_ISA when building oneDNN to allow TF env variable to pass through to OneDNN in order to select the desired ISA. Once this is enabled during build time then DNNL_MAX_CPU_ISA environment variable can be set to desired ISA such as AMX, VNNI etc, during runtime and will override ISA automatically detected by oneDNN. This is useful for debugging.