### PR TITLE
Adding Configurable Filesystem API part 1

### DIFF
--- a/tensorflow/c/experimental/filesystem/filesystem_interface.h
+++ b/tensorflow/c/experimental/filesystem/filesystem_interface.h
@@ -902,7 +902,7 @@ typedef struct TF_FilesystemOps {
   ///
   /// Plugins:
   ///   * Must set `status` to `TF_OK` on success. If there are no configurable
-  ///   keys, `num_keys` should be set to 0
+  ///     keys, `num_keys` should be set to 0
   ///   * Might use any other error value for `status` to signal other errors.
   ///
   /// DEFAULT IMPLEMENTATION: return `TF_OK` and `num_keys`=0.

--- a/tensorflow/c/experimental/filesystem/filesystem_interface.h
+++ b/tensorflow/c/experimental/filesystem/filesystem_interface.h
@@ -836,27 +836,38 @@ typedef struct TF_FilesystemOps {
   /// `num_options`. Ownership of the array is transferred to caller and the
   /// caller is responsible of freeing the buffers using respective file systems
   /// allocation API.
+  /// Plugins:
+  ///   * Must set `status` to `TF_OK` if `options` and `num_options` set.
+  ///     If there is no configurable option, `num_options` should be 0.
+  ///   * Might use any other error value for `status` to signal other errors.
+  /// DEFAULT IMPLEMENTATION: return 0 options and `TF_OK`.
   void (*get_filesystem_configuration)(const TF_Filesystem* filesystem,
                                        TF_Filesystem_Option** options,
                                        int* num_options, TF_Status* status);
 
   /// Updates filesystem configuration with options passed in `options`. It can
   /// contain full set of options supported by the filesystem or just a subset
-  /// of them. Ownership of options and buffers therein belongs to the caller and
-  /// any buffers need to be allocated through filesystem allocation API. On
-  /// success should return TF_OK in `status`. On failure, it should return a relevant error
-  /// code. Filesystems may choose to ignore configuration errors but should at
-  /// least display a warning or error message to warn the users.
+  /// of them. Ownership of options and buffers therein belongs to the caller
+  /// and any buffers need to be allocated through filesystem allocation API.
+  /// Filesystems may choose to ignore configuration errors but should at least
+  /// display a warning or error message to warn the users. Plugins:
+  ///   * Must set `status` to `TF_OK` if options are updated.
+  ///   * Might use any other error value for `status` to signal other errors.
+  /// DEFAULT IMPLEMENTATION: return `TF_NOT_FOUND`.
   void (*set_filesystem_configuration)(const TF_Filesystem* filesystem,
                                        const TF_Filesystem_Option** options,
                                        int num_options, TF_Status* status);
 
   /// Returns the value of the filesystem option given in `key` in `option`.
   /// Valid values of the `key` are returned by
-  /// `get_file_system_configuration_keys` call. This method should return TF_OK
-  /// on success, TF_NOT_FOUND if the key does not exist. Ownership of the
+  /// `get_file_system_configuration_keys` call. Ownership of the
   /// `option` is transferred to caller. Buffers therein should be allocated and
   /// freed by the relevant filesystems allocation API.
+  /// Plugins:
+  ///   * Must set `status` to `TF_OK` if `option` is set
+  ///   * Must set `status` to `TF_NOT_FOUND` if the key is invalid
+  ///   * Might use any other error value for `status` to signal other errors.
+  /// DEFAULT IMPLEMENTATION: return `TF_NOT_FOUND`.
   void (*get_filesystem_configuration_option)(const TF_Filesystem* filesystem,
                                               const char* key,
                                               TF_Filesystem_Option** option,
@@ -864,10 +875,13 @@ typedef struct TF_FilesystemOps {
 
   /// Sets the value of the filesystem option given in `key` to value in
   /// `option`. Valid values of the `key` are returned by
-  /// `get_file_system_configuration_keys` call. This method should return TF_OK
-  /// on success, TF_NOT_FOUND if the key does not exist or other relevant error
-  /// codes. `option` and the `key` are owned by the caller. Buffers therein
-  /// should be allocated and freed by the filesystems allocation API.
+  /// `get_file_system_configuration_keys` call. Ownership of the `option` and
+  /// the `key` belogs to the caller. Buffers therein should be allocated and
+  /// freed by the filesystems allocation API. Plugins:
+  ///   * Must set `status` to `TF_OK` if `option` is set/updated
+  ///   * Must set `status` to `TF_NOT_FOUND` if the key is invalid
+  ///   * Might use any other error value for `status` to signal other errors.
+  /// DEFAULT IMPLEMENTATION: return `TF_NOT_FOUND`.
   void (*set_filesystem_configuration_option)(
       const TF_Filesystem* filesystem, const TF_Filesystem_Option* option,
       TF_Status* status);
@@ -875,6 +889,11 @@ typedef struct TF_FilesystemOps {
   /// Returns a list of valid configuration keys in `keys` array and number of
   /// keys in `num_keys`. Ownership of the buffers in `keys` are transferred to
   /// caller and needs to be freed using relevant filesystem allocation API.
+  /// Plugins:
+  ///   * Must set `status` to `TF_OK` on success. If there are no configurable
+  ///   keys, `num_keys` should be set to 0
+  ///   * Might use any other error value for `status` to signal other errors.
+  /// DEFAULT IMPLEMENTATION: return `TF_OK` and `num_keys`=0.
   void (*get_filesystem_configuration_keys)(const TF_Filesystem* filesystem,
                                             char** keys, int* num_keys,
                                             TF_Status* status);

--- a/tensorflow/c/experimental/filesystem/filesystem_interface.h
+++ b/tensorflow/c/experimental/filesystem/filesystem_interface.h
@@ -840,6 +840,7 @@ typedef struct TF_FilesystemOps {
   ///   * Must set `status` to `TF_OK` if `options` and `num_options` set.
   ///     If there is no configurable option, `num_options` should be 0.
   ///   * Might use any other error value for `status` to signal other errors.
+
   /// DEFAULT IMPLEMENTATION: return 0 options and `TF_OK`.
   void (*get_filesystem_configuration)(const TF_Filesystem* filesystem,
                                        TF_Filesystem_Option** options,

--- a/tensorflow/c/experimental/filesystem/filesystem_interface.h
+++ b/tensorflow/c/experimental/filesystem/filesystem_interface.h
@@ -898,6 +898,7 @@ typedef struct TF_FilesystemOps {
   ///   * Must set `status` to `TF_OK` on success. If there are no configurable
   ///   keys, `num_keys` should be set to 0
   ///   * Might use any other error value for `status` to signal other errors.
+  ///
   /// DEFAULT IMPLEMENTATION: return `TF_OK` and `num_keys`=0.
   void (*get_filesystem_configuration_keys)(const TF_Filesystem* filesystem,
                                             char** keys, int* num_keys,

--- a/tensorflow/c/experimental/filesystem/filesystem_interface.h
+++ b/tensorflow/c/experimental/filesystem/filesystem_interface.h
@@ -885,6 +885,7 @@ typedef struct TF_FilesystemOps {
   ///   * Must set `status` to `TF_OK` if `option` is set/updated
   ///   * Must set `status` to `TF_NOT_FOUND` if the key is invalid
   ///   * Might use any other error value for `status` to signal other errors.
+  ///
   /// DEFAULT IMPLEMENTATION: return `TF_NOT_FOUND`.
   void (*set_filesystem_configuration_option)(
       const TF_Filesystem* filesystem, const TF_Filesystem_Option* option,

--- a/tensorflow/c/experimental/filesystem/filesystem_interface.h
+++ b/tensorflow/c/experimental/filesystem/filesystem_interface.h
@@ -894,6 +894,7 @@ typedef struct TF_FilesystemOps {
   /// Returns a list of valid configuration keys in `keys` array and number of
   /// keys in `num_keys`. Ownership of the buffers in `keys` are transferred to
   /// caller and needs to be freed using relevant filesystem allocation API.
+  ///
   /// Plugins:
   ///   * Must set `status` to `TF_OK` on success. If there are no configurable
   ///   keys, `num_keys` should be set to 0

--- a/tensorflow/c/experimental/filesystem/filesystem_interface.h
+++ b/tensorflow/c/experimental/filesystem/filesystem_interface.h
@@ -836,12 +836,12 @@ typedef struct TF_FilesystemOps {
   /// `num_options`. Ownership of the array is transferred to caller and the
   /// caller is responsible of freeing the buffers using respective file systems
   /// allocation API.
-
+  ///
   /// Plugins:
   ///   * Must set `status` to `TF_OK` if `options` and `num_options` set.
   ///     If there is no configurable option, `num_options` should be 0.
   ///   * Might use any other error value for `status` to signal other errors.
-
+  ///
   /// DEFAULT IMPLEMENTATION: return 0 options and `TF_OK`.
   void (*get_filesystem_configuration)(const TF_Filesystem* filesystem,
                                        TF_Filesystem_Option** options,
@@ -852,7 +852,9 @@ typedef struct TF_FilesystemOps {
   /// of them. Ownership of options and buffers therein belongs to the caller
   /// and any buffers need to be allocated through filesystem allocation API.
   /// Filesystems may choose to ignore configuration errors but should at least
-  /// display a warning or error message to warn the users. Plugins:
+  /// display a warning or error message to warn the users. 
+  ///
+  /// Plugins:
   ///   * Must set `status` to `TF_OK` if options are updated.
   ///   * Might use any other error value for `status` to signal other errors.
   ///
@@ -866,6 +868,7 @@ typedef struct TF_FilesystemOps {
   /// `get_file_system_configuration_keys` call. Ownership of the
   /// `option` is transferred to caller. Buffers therein should be allocated and
   /// freed by the relevant filesystems allocation API.
+  ///
   /// Plugins:
   ///   * Must set `status` to `TF_OK` if `option` is set
   ///   * Must set `status` to `TF_NOT_FOUND` if the key is invalid
@@ -881,7 +884,9 @@ typedef struct TF_FilesystemOps {
   /// `option`. Valid values of the `key` are returned by
   /// `get_file_system_configuration_keys` call. Ownership of the `option` and
   /// the `key` belogs to the caller. Buffers therein should be allocated and
-  /// freed by the filesystems allocation API. Plugins:
+  /// freed by the filesystems allocation API.
+  ///
+  /// Plugins:
   ///   * Must set `status` to `TF_OK` if `option` is set/updated
   ///   * Must set `status` to `TF_NOT_FOUND` if the key is invalid
   ///   * Might use any other error value for `status` to signal other errors.

--- a/tensorflow/c/experimental/filesystem/filesystem_interface.h
+++ b/tensorflow/c/experimental/filesystem/filesystem_interface.h
@@ -836,6 +836,7 @@ typedef struct TF_FilesystemOps {
   /// `num_options`. Ownership of the array is transferred to caller and the
   /// caller is responsible of freeing the buffers using respective file systems
   /// allocation API.
+
   /// Plugins:
   ///   * Must set `status` to `TF_OK` if `options` and `num_options` set.
   ///     If there is no configurable option, `num_options` should be 0.

--- a/tensorflow/c/experimental/filesystem/filesystem_interface.h
+++ b/tensorflow/c/experimental/filesystem/filesystem_interface.h
@@ -870,6 +870,7 @@ typedef struct TF_FilesystemOps {
   ///   * Must set `status` to `TF_OK` if `option` is set
   ///   * Must set `status` to `TF_NOT_FOUND` if the key is invalid
   ///   * Might use any other error value for `status` to signal other errors.
+  ///
   /// DEFAULT IMPLEMENTATION: return `TF_NOT_FOUND`.
   void (*get_filesystem_configuration_option)(const TF_Filesystem* filesystem,
                                               const char* key,

--- a/tensorflow/c/experimental/filesystem/filesystem_interface.h
+++ b/tensorflow/c/experimental/filesystem/filesystem_interface.h
@@ -94,10 +94,6 @@ typedef struct TF_Filesystem_Option_Value {
       int buf_length;
     } buffer_val;
   } * values;  // owned
-  // A pointer to filesystem is needed in case options are passed around
-  // different modules to free the memory or allocate a new buffer for
-  // modification.
-  TF_Filesystem* file_system;
 } TF_Filesystem_Option_Value;
 
 typedef struct TF_Filesystem_Option {
@@ -105,7 +101,6 @@ typedef struct TF_Filesystem_Option {
   char* description;                  // null terminated, owned
   int per_file;                       // bool actually, but bool is not a C type
   TF_Filesystem_Option_Value* value;  // owned
-  TF_Filesystem* file_system;         // pointer to owning file system
 } TF_Filesystem_Option;
 
 /// SECTION 2. Function tables for functionality provided by plugins
@@ -838,26 +833,23 @@ typedef struct TF_FilesystemOps {
 
   /// Returns pointer to an array of available configuration options and their
   /// current/default values in `options` and number of options in array in
-  /// num_options. Ownership of the array is transferred to caller and the
+  /// `num_options`. Ownership of the array is transferred to caller and the
   /// caller is responsible of freeing the buffers using respective file systems
   /// allocation API.
-  ///
   void (*get_filesystem_configuration)(const TF_Filesystem* filesystem,
-                                             TF_Filesystem_Option** options,
-                                             int* num_options,
-                                             TF_Status* status);
+                                       TF_Filesystem_Option** options,
+                                       int* num_options, TF_Status* status);
 
   /// Updates filesystem configuration with options passed in `options`. It can
   /// contain full set of options supported by the filesystem or just a subset
-  /// of it. Ownership of options and buffers therein belongs to the caller and
+  /// of them. Ownership of options and buffers therein belongs to the caller and
   /// any buffers need to be allocated through filesystem allocation API. On
-  /// success should return TF_OK. On failure should return relevan error code.
-  /// Filesystems may choose to ignore configuration errors but should at least
-  /// display a warning or error message to warn the users.
-  ///
-  void (*set_filesystem_configuration)(
-      const TF_Filesystem* filesystem, const TF_Filesystem_Option** options,
-      int num_options, TF_Status* status);
+  /// success should return TF_OK in `status`. On failure, it should return a relevant error
+  /// code. Filesystems may choose to ignore configuration errors but should at
+  /// least display a warning or error message to warn the users.
+  void (*set_filesystem_configuration)(const TF_Filesystem* filesystem,
+                                       const TF_Filesystem_Option** options,
+                                       int num_options, TF_Status* status);
 
   /// Returns the value of the filesystem option given in `key` in `option`.
   /// Valid values of the `key` are returned by
@@ -865,9 +857,10 @@ typedef struct TF_FilesystemOps {
   /// on success, TF_NOT_FOUND if the key does not exist. Ownership of the
   /// `option` is transferred to caller. Buffers therein should be allocated and
   /// freed by the relevant filesystems allocation API.
-  void (*get_filesystem_configuration_option)(
-      const TF_Filesystem* filesystem, const char* key,
-      TF_Filesystem_Option** option, TF_Status* status);
+  void (*get_filesystem_configuration_option)(const TF_Filesystem* filesystem,
+                                              const char* key,
+                                              TF_Filesystem_Option** option,
+                                              TF_Status* status);
 
   /// Sets the value of the filesystem option given in `key` to value in
   /// `option`. Valid values of the `key` are returned by
@@ -880,11 +873,11 @@ typedef struct TF_FilesystemOps {
       TF_Status* status);
 
   /// Returns a list of valid configuration keys in `keys` array and number of
-  /// keys in `num_keys`. Ownership of the buffers in `keys` are transferred to caller
-  /// and needs to be freed using relevant filesystem allocation API.
-  void (*get_filesystem_configuration_keys)(
-      const TF_Filesystem* filesystem, char** keys, int* num_keys,
-      TF_Status* status);
+  /// keys in `num_keys`. Ownership of the buffers in `keys` are transferred to
+  /// caller and needs to be freed using relevant filesystem allocation API.
+  void (*get_filesystem_configuration_keys)(const TF_Filesystem* filesystem,
+                                            char** keys, int* num_keys,
+                                            TF_Status* status);
 
 } TF_FilesystemOps;
 // LINT.ThenChange(:filesystem_ops_version)

--- a/tensorflow/c/experimental/filesystem/filesystem_interface.h
+++ b/tensorflow/c/experimental/filesystem/filesystem_interface.h
@@ -855,6 +855,7 @@ typedef struct TF_FilesystemOps {
   /// display a warning or error message to warn the users. Plugins:
   ///   * Must set `status` to `TF_OK` if options are updated.
   ///   * Might use any other error value for `status` to signal other errors.
+  ///
   /// DEFAULT IMPLEMENTATION: return `TF_NOT_FOUND`.
   void (*set_filesystem_configuration)(const TF_Filesystem* filesystem,
                                        const TF_Filesystem_Option** options,


### PR DESCRIPTION
This PR introduces necessary API changes needed for Configurable Filesystems as described in https://github.com/tensorflow/community/pull/277. This is the first part of a series of PRs to implement these changes.