### PR TITLE
Add TF-TRT optimization profiles for testing

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -1470,13 +1470,17 @@ class OpConverterTest : public ::testing::Test {
     if (engine_.get() != nullptr) {
       return errors::Internal("Engine already exists");
     }
-    TrtShapeOptimizationProfile profiles;
+    TrtShapeOptimizationProfile profiles(
+        ProfileStrategy::kImplicitBatchModeCompatible);
     if (!converter_->use_implicit_batch()) {
       // Create a single optimization profile for explicit batch mode
       std::vector<TensorShape> input_shapes;
       TF_RETURN_IF_ERROR(GetShapeFromDataVec(input_data, &input_shapes));
       profiles.AddShape(input_shapes);
-      profiles.InitProfiles();
+      std::vector<PartialTensorShape> input_partial_shapes;
+      TF_RETURN_IF_ERROR(
+          GetNetworkInputShapes(converter_->network(), &input_partial_shapes));
+      profiles.InitProfiles(input_partial_shapes);
     }
     TF_RETURN_IF_ERROR(
         converter_->BuildCudaEngine(&engine_,

--- a/tensorflow/compiler/tf2tensorrt/convert/utils.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/utils.cc
@@ -181,25 +181,24 @@ bool AreShapesCompatible(const std::vector<TensorShape>& actual_shapes,
   }
   return true;
 }
-
-Status TrtDimsToTensorShape(const std::vector<int>& trt_dims,
-                            bool use_implicit_batch, int batch_size,
-                            TensorShape& shape) {
-  TF_RETURN_IF_ERROR(
-      TensorShapeUtils::MakeShape(trt_dims.data(), trt_dims.size(), &shape));
-  if (use_implicit_batch) {
-    shape.InsertDim(0, batch_size);
+Status GetNetworkInputShapes(const nvinfer1::INetworkDefinition* network,
+                             std::vector<PartialTensorShape>* input_shapes) {
+  const int n_inputs = network->getNbInputs();
+  input_shapes->resize(n_inputs);
+  for (int i = 0; i < n_inputs; i++) {
+    const nvinfer1::ITensor* input = network->getInput(i);
+    const nvinfer1::Dims input_dim = input->getDimensions();
+    TF_RETURN_IF_ERROR(TrtDimsToTensorShape(input_dim, &input_shapes->at(i)));
   }
   return Status::OK();
 }
-
-Status TrtDimsToTensorShape(const nvinfer1::Dims trt_dims,
-                            bool use_implicit_batch, int batch_size,
-                            TensorShape& shape) {
+Status TrtDimsToTensorShape(const std::vector<int>& trt_dims,
+                            TensorShape* shape,
+                            absl::optional<int> batch_size) {
   TF_RETURN_IF_ERROR(
-      TensorShapeUtils::MakeShape(trt_dims.d, trt_dims.nbDims, &shape));
-  if (use_implicit_batch) {
-    shape.InsertDim(0, batch_size);
+      TensorShapeUtils::MakeShape(trt_dims.data(), trt_dims.size(), shape));
+  if (batch_size) {
+    shape->InsertDim(0, batch_size.value());
   }
   return Status::OK();
 }

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
@@ -178,6 +178,9 @@ class TRTEngineOp : public AsyncOpKernel {
   // use_implicit_batch_=false.
   bool profile_generation_mode_;
 
+  // Whether the TRTEngineOp has any input with unknown dimensions.
+  bool has_dynamic_shape_input_;
+
   // Whether to build TensorRT engines at runtime.
   bool allow_build_at_runtime_;
 
@@ -432,6 +435,11 @@ TRTEngineOp::TRTEngineOp(OpKernelConstruction* context)
                 errors::InvalidArgument(
                     "Explicit batch mode does not support calibration"));
   }
+  has_dynamic_shape_input_ = absl::c_any_of(
+      input_partial_shapes_,
+      [](PartialTensorShape shape) { return !shape.IsFullyDefined(); });
+  VLOG(2) << "TRTEngineOp has_dynamic_shape_input_: "
+          << has_dynamic_shape_input_;
 }
 
 void TRTEngineOp::ExecuteNativeSegment(OpKernelContext* ctx,
@@ -663,7 +671,7 @@ void TRTEngineOp::ComputeAsync(OpKernelContext* ctx,
     return;
   }
 
-  if (!use_implicit_batch_) {
+  if (!use_implicit_batch_ && has_dynamic_shape_input_) {
     if (profile_generation_mode_) {
       // Collecting new shapes for profiles can be only done once. After the
       // shapes are converted to TRT profiles, no shapes can be collected
@@ -678,8 +686,12 @@ void TRTEngineOp::ComputeAsync(OpKernelContext* ctx,
       ExecuteNativeSegment(ctx, helper);
       return;
     } else if (cache_res->profiles_.GetNumProfiles() == 0) {
+      // Add current shape if we did not collect any shapes so far.
+      if (!cache_res->profiles_.HasShape()) {
+        cache_res->profiles_.AddShape(input_concrete_shapes);
+      }
       // Create profiles out of collected shapes during profile generation.
-      cache_res->profiles_.InitProfiles();
+      cache_res->profiles_.InitProfiles(input_partial_shapes_);
     }
   }
   StatusOr<std::pair<EngineContext*, int>> status =
@@ -763,6 +775,9 @@ Status TRTEngineOp::ExecuteTrtEngine(OpKernelContext* ctx,
   TF_RETURN_IF_ERROR(
       engine_context->GetExecutionContext(trt_context_idx, &execution_context));
 
+  if (VLOG_IS_ON(2)) {
+    VLOG(2) << "Selected execution context: " << trt_context_idx;
+  }
   const int num_batch =
       use_implicit_batch_ ? ctx->input(0).shape().dim_size(0) : 0;
 
@@ -990,6 +1005,8 @@ StatusOr<std::pair<EngineContext*, int>> TRTEngineOp::GetEngine(
     VLOG(1) << "Added new engine to cache of " << name()
             << ". Cache size: " << cache.size();
     engine_contexts = cache.at(input_concrete_shapes).get();
+    // Query which profile of the new engine matches the actual input.
+    profile_id = cache_res->profiles_.GetProfileNumber(input_concrete_shapes);
   }
   return std::pair<EngineContext*, int>(engine_contexts,
                                         use_implicit_batch_ ? 0 : profile_id);

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op_test.cc
@@ -245,16 +245,11 @@ TEST_F(TRTEngineOpTestBase, ExplicitBatch) {
       device_->resource_manager()->Lookup("TF-TRT", "myop", &cache_resource));
   core::ScopedUnref sc(cache_resource);
 
-  // Due to the way the engine lookup is implemented, explicit batch mode
-  // requires profile generation. Currently profile generaton is not enabled in
-  // this test therfore engine creation fails.
-  //
-  // TODO(Tamas) find a way to enable profile generation mode and test it
   auto cache = &cache_resource->cache_;
-  EXPECT_EQ(0, cache->size());
-  // ASSERT_EQ(1, cache->count({input_shape}));
-  // EngineContext* ectx = cache->at({input_shape}).get();
-  // EXPECT_NE(ectx->cuda_engine, nullptr);
+  EXPECT_EQ(1, cache->size());
+  ASSERT_EQ(1, cache->count({input_shape}));
+  EngineContext* ectx = cache->at({input_shape}).get();
+  EXPECT_NE(ectx->cuda_engine, nullptr);
 }
 
 TEST_F(TRTEngineOpTestBase, DynamicShapes) {
@@ -278,13 +273,11 @@ TEST_F(TRTEngineOpTestBase, DynamicShapes) {
       device_->resource_manager()->Lookup("TF-TRT", "myop", &cache_resource));
   core::ScopedUnref sc(cache_resource);
 
-  // We did not have profile generation mode therfore engine creation failed.
-  // TODO(Tamas) find a way to enable profile generation mode and test it
   auto cache = &cache_resource->cache_;
-  EXPECT_EQ(0, cache->size());
-  // ASSERT_EQ(1, cache->count({input_shape}));
-  // EngineContext* ectx = cache->at({input_shape}).get();
-  // EXPECT_NE(ectx->cuda_engine, nullptr);
+  EXPECT_EQ(1, cache->size());
+  ASSERT_EQ(1, cache->count({input_shape}));
+  EngineContext* ectx = cache->at({input_shape}).get();
+  EXPECT_NE(ectx->cuda_engine, nullptr);
 }
 
 template <typename T>

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_lru_cache.cc
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_lru_cache.cc
@@ -120,7 +120,7 @@ EngineContext* TRTEngineCacheResource::GetEngineContext(
 }
 
 EngineContext* TRTEngineCacheResource::GetEngineContext(const int profile_id) {
-  if (profile_id >= profiles_.GetNumProfiles()) {
+  if (profiles_.NeedProfiles() && profile_id >= profiles_.GetNumProfiles()) {
     LOG(ERROR) << "Out of range: profile_id " << profile_id
                << " is larger than number of profiles "
                << profiles_.GetNumProfiles();

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.cc
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.cc
@@ -25,26 +25,109 @@ limitations under the License.
 namespace tensorflow {
 namespace tensorrt {
 
-// Creates optimization profiles for a list of input shapes. The list of input
-// shapes are stored in shapes_.
-void TrtShapeOptimizationProfile::InitProfiles() {
+// Returns a vector of nvinfer1::Dims for a vector of TensorShapes.
+template <typename TensorShapeType>
+std::vector<nvinfer1::Dims> GetDimVec(std::vector<TensorShapeType> shape_vec) {
+  std::vector<nvinfer1::Dims> dimvec(shape_vec.size());
+  absl::c_transform(shape_vec, dimvec.begin(), [](TensorShapeType shape) {
+    return TensorShapeToTrtDims(shape, false);
+  });
+  return dimvec;
+}
+
+// In dynamic shape mode the optimization profile dims are only allowed to
+// differ from the network input dims where the network input dims have -1
+// values. We enforce this condition by changing prof_dims if necessary.
+void EnforceCompatibility(nvinfer1::Dims* prof_dims,
+                          const PartialTensorShape& input_shape) {
+  for (int i = 0; i < input_shape.dims(); i++) {
+    if (input_shape.dim_size(i) != -1) {
+      prof_dims->d[i] = input_shape.dim_size(i);
+    }
+  }
+}
+
+void SetImplicitBatchModeCompatibleProfile(
+    const std::vector<nvinfer1::Dims>& dimvec, std::vector<nvinfer1::Dims>* min,
+    std::vector<nvinfer1::Dims>* opt, std::vector<nvinfer1::Dims>* max) {
+  *min = dimvec;
+  for (auto& dim : *min) {
+    dim.d[0] = 1;  // Set min batch size to 1.
+  }
+  *opt = dimvec;
+  *max = dimvec;
+}
+
+void TrtShapeOptimizationProfile::ImplicitBatchModeCompatibleStrategy() {
+  for (auto& shape_vec : input_shapes_) {
+    if (!shape_vec.empty()) {
+      std::vector<nvinfer1::Dims> dimvec = GetDimVec(shape_vec);
+      std::vector<nvinfer1::Dims> min, opt, max;
+      SetImplicitBatchModeCompatibleProfile(dimvec, &min, &opt, &max);
+      OptimizationProfileConfig profConfig{min, opt, max};
+      profiles_.push_back(std::move(profConfig));
+    }
+  }
+}
+
+void TrtShapeOptimizationProfile::OptimalStrategy() {
+  for (auto& shape_vec : input_shapes_) {
+    if (!shape_vec.empty()) {
+      std::vector<nvinfer1::Dims> min = GetDimVec(shape_vec);
+      std::vector<nvinfer1::Dims> opt = min;
+      std::vector<nvinfer1::Dims> max = min;
+      OptimizationProfileConfig profConfig{min, opt, max};
+      profiles_.push_back(std::move(profConfig));
+    }
+  }
+}
+
+// Adjust shape value profile to prevent TRT from removing shape value input
+// bindings whose value is redundant (only a single value matches the profile).
+// This should be removed once the NVIDIA bug 3153064 is fixed.
+void FixShapeValueProfile(OptimizationProfileConfig* prof,
+                          const std::vector<bool>& is_shape_tensor) {
+  for (int i = 0; i < prof->min.size(); i++) {
+    if (is_shape_tensor[i] &&
+        std::equal(prof->min[i].d, prof->min[i].d + prof->min[i].nbDims,
+                   prof->max[i].d)) {
+      VLOG(2) << "Adjust profile for shape value tensor " << i;
+      prof->max[i].d[0]++;
+    }
+  }
+}
+
+void TrtShapeOptimizationProfile::InitProfiles(
+    const std::vector<PartialTensorShape>& input_partial_shapes) {
   if (input_shapes_.size() == 0) {
     VLOG(1) << "Not creating profiles without input_shapes. "
                "You have to enable profile generation mode first (build).";
-  } else {
-    VLOG(1) << "Creating profiles with startegy of one profile "
-            << "for each input (min=opt=max).";
+    return;
   }
-  for (auto& shape_vec : input_shapes_) {
-    if (!shape_vec.empty()) {
-      std::vector<nvinfer1::Dims> dimvec(shape_vec.size());
-      absl::c_transform(shape_vec, dimvec.begin(), [](TensorShape shape) {
-        return TensorShapeToTrtDims(shape, false);
-      });
-      // Set min=opt=max.
-      OptimizationProfileConfig profConfig{dimvec, dimvec, dimvec};
-      profiles_.push_back(std::move(profConfig));
-      VLOG(1) << "Created profile " << profiles_.back().DebugString();
+  switch (strategy_) {
+    case ProfileStrategy::kImplicitBatchModeCompatible:
+      VLOG(1) << "Creating profiles with ImplicitBatchModeCompatible strategy";
+      ImplicitBatchModeCompatibleStrategy();
+      break;
+    case ProfileStrategy::kOptimal:
+      VLOG(1) << "Creating profiles with Optimal strategy";
+      OptimalStrategy();
+      break;
+  }
+  // Define a mask that describe which input could be a shape tensor. Note that
+  // here we can have false positives. The shape tensor mask will be updated
+  // once the network is constructed.
+  SetShapeTensorMask(input_partial_shapes);
+  if (input_partial_shapes.size() > 0) {
+    for (OptimizationProfileConfig& prof : profiles_) {
+      // TODO(NVIDIA bug 3153064): Remove this when the bug is fixed.
+      FixShapeValueProfile(&prof, is_shape_tensor_);
+      for (int i = 0; i < input_partial_shapes.size(); i++) {
+        auto network_input = input_partial_shapes[i];
+        EnforceCompatibility(&prof.min[i], network_input);
+        EnforceCompatibility(&prof.opt[i], network_input);
+        EnforceCompatibility(&prof.max[i], network_input);
+      }
     }
   }
 }
@@ -53,7 +136,7 @@ void TrtShapeOptimizationProfile::InitProfiles() {
 Status TrtShapeOptimizationProfile::AddProfiles(
     nvinfer1::IBuilder* builder, nvinfer1::IBuilderConfig* config,
     const nvinfer1::INetworkDefinition* network) {
-  // Create a vector of optimization profiles
+  // Create a vector of optimization profiles.
   for (int i = 0; i < profiles_.size(); i++) {
     auto* optProfile = builder->createOptimizationProfile();
     Status status = profiles_[i].SetDimensions(network, optProfile);
@@ -82,7 +165,11 @@ Status TrtShapeOptimizationProfile::AddProfiles(
   if (!profiles_.empty() && config->getNbOptimizationProfiles() == 0) {
     return errors::Internal("Failure in adding an optimization profile.");
   }
-  // if TRT_VERSION < 6, then we do not need to add
+  need_profiles_ = config->getNbOptimizationProfiles() > 0;
+  // Update the the mask that flag shape tensors. The network is known now,
+  // the mask will be correct.
+  SetShapeTensorMask(network);
+  // if TRT_VERSION < 6, then we do not need to add.
   return Status::OK();
 }
 #endif
@@ -96,8 +183,43 @@ Status TrtShapeOptimizationProfile::ConfigureBuilder(
 }
 #endif
 
+// Sets the shape tensor mask using the network definition.
+void TrtShapeOptimizationProfile::SetShapeTensorMask(
+    const nvinfer1::INetworkDefinition* network) {
+  int n_inputs = network->getNbInputs();
+  is_shape_tensor_.resize(n_inputs, false);
+#if IS_TRT_VERSION_GE(6, 0, 0, 0)
+  for (int i = 0; i < n_inputs; i++) {
+    const nvinfer1::ITensor* input = network->getInput(i);
+    is_shape_tensor_[i] = input->isShapeTensor();
+    if (is_shape_tensor_[i]) {
+      VLOG(2) << "Found shape tensor " << input->getName() << ' at ' << i;
+    }
+  }
+#endif
+  has_shape_tensor_ =
+      absl::c_any_of(is_shape_tensor_, [](bool b) { return b; });
+}
+
+// Sets the shape tensor mask using the input partial shapes. This only tells
+// whether the tensors are shape value compatible, only the final network
+// definition or the engine would give concrete answers.
+void TrtShapeOptimizationProfile::SetShapeTensorMask(
+    const std::vector<PartialTensorShape>& input_partial_shapes) {
+  is_shape_tensor_.resize(input_partial_shapes.size(), false);
+  for (int i = 0; i < input_partial_shapes.size(); i++) {
+    is_shape_tensor_[i] = IsTrtShapeTensorCompatible(input_partial_shapes[i]);
+    if (is_shape_tensor_[i]) {
+      VLOG(2) << "Found shape compatible tensor at " << i;
+    }
+  }
+  has_shape_tensor_ =
+      absl::c_any_of(is_shape_tensor_, [](bool b) { return b; });
+}
+
 int TrtShapeOptimizationProfile::GetProfileNumber(
-    std::vector<TensorShape> shapes) {
+    const std::vector<TensorShape>& shapes) {
+  if (!need_profiles_) return 0;
   for (int i = 0; i < profiles_.size(); i++) {
     if (profiles_[i].IncludesShapes(shapes)) {
       return i;
@@ -146,18 +268,20 @@ Status TrtShapeOptimizationProfile::CreateExecutionContexts(
 
 Status TrtShapeOptimizationProfile::RestoreProfiles(
     const nvinfer1::ICudaEngine* engine) {
+  need_profiles_ = false;
 #if IS_TRT_VERSION_GE(6, 0, 0, 0)
   if (!engine) {
-    // We do not need to restore profiles for an empty engine
+    // We do not need to restore profiles for an empty engine.
     return Status::OK();
   }
 #if IS_TRT_VERSION_GE(7, 0, 0, 0)
   if (engine->hasImplicitBatchDimension()) {
-    // Nothing to do, we cannot have profiles in implicit batch mode
+    // Nothing to do, we cannot have profiles in implicit batch mode.
     return Status::OK();
   }
 #endif
   int n_profiles = engine->getNbOptimizationProfiles();
+  need_profiles_ = n_profiles > 0;
   int n_inputs = GetNumberOfEngineInputs(engine);
   VLOG(2) << "Attempting to restore " << n_profiles << " profiles, each with "
           << n_inputs << " inputs";


### PR DESCRIPTION
TF-TRT dynamic shape feature requires the creation of optimization profiles. Currently just a basic optimization profile is created where we set min = opt = max = input_shape. Let's call this `optimal` profile.

This PR implements an additional optimization profile generation strategies:
- kImplicitBatchLike: the batch dimension has min = 1, opt = max = input_batch_size, other dims agree with the input dim

For any shape tensor compatible input the profile is adjusted to have max > min. The goal here is to enable unit testing of converters that have shape input. This requires optimization profile where max != min. Otherwise the shape input tensor is known at build time (equals with min=opt=max), and TRT7 drops it from the list of input bindings. (This problem will probably be corrected in an upcoming version of TRT).

Additionally, profile handling improved in dynamic shape mode. Previously it required to run `profile_generation_mode`, otherwise engine creation failed. This condition was relaxed: if profile generation mode was not used, then we create a single implicit batch like profile using the current input shape. This improves testing of the trt_engine_op, additionally this will provide an implicit batch mode compatible fall-back for users that do not wish to build the engine in advance.

A follow up PR shall implement additional optimization profile strategies.

Additionally, two bugs are fixed:
- The profile index in case of newly created engine was not set,
- Error was not handled while setting the input binding size.
- 
Tagging @bixia1 for review and @DEKHTIARJonathan for visibility.
