### PR TITLE
Fix convert_variables_to_constants_v2 for scalar valued captures

### DIFF
--- a/tensorflow/python/framework/convert_to_constants.py
+++ b/tensorflow/python/framework/convert_to_constants.py
@@ -823,7 +823,7 @@ class _FunctionConverterData(_ConverterData):
       if idx in map_index_to_variable:
         data = map_index_to_variable[idx].numpy()
       else:
-        data = val_tensor.numpy()
+        data = np.array(val_tensor.numpy())
       self._tensor_data[tensor_name] = _TensorData(
           numpy=data,
           dtype=dtypes.as_dtype(data.dtype).as_datatype_enum,


### PR DESCRIPTION
tensor.numpy() can return a scalar, not a numpy array.