### PR TITLE
micro: RFC: port op FILL to micro

### DIFF
--- a/tensorflow/lite/micro/all_ops_resolver.cc
+++ b/tensorflow/lite/micro/all_ops_resolver.cc
@@ -32,6 +32,7 @@ AllOpsResolver::AllOpsResolver() {
   AddDetectionPostprocess();
   AddEqual();
   AddEthosU();
+  AddFill();
   AddFloor();
   AddFullyConnected();
   AddGreater();

--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -106,6 +106,7 @@ cc_library(
         "dequantize.cc",
         "detection_postprocess.cc",
         "elementwise.cc",
+        "fill.cc",
         "floor.cc",
         "l2norm.cc",
         "logical.cc",
@@ -329,6 +330,20 @@ tflite_micro_cc_test(
     deps = [
         ":kernel_runner",
         "//tensorflow/lite/c:common",
+        "//tensorflow/lite/micro:test_helpers",
+        "//tensorflow/lite/micro/testing:micro_test",
+    ],
+)
+
+tflite_micro_cc_test(
+    name = "fill_test",
+    srcs = [
+        "fill_test.cc",
+    ],
+    deps = [
+        ":kernel_runner",
+        "//tensorflow/lite/c:common",
+        "//tensorflow/lite/micro:op_resolvers",
         "//tensorflow/lite/micro:test_helpers",
         "//tensorflow/lite/micro/testing:micro_test",
     ],

--- a/tensorflow/lite/micro/kernels/fill.cc
+++ b/tensorflow/lite/micro/kernels/fill.cc
@@ -1,0 +1,172 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <stdint.h>
+
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/reference/reference_ops.h"
+#include "tensorflow/lite/kernels/internal/tensor.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/string_util.h"
+
+namespace tflite {
+namespace ops {
+namespace builtin {
+namespace fill {
+
+namespace {
+
+constexpr int kDimsTensor = 0;
+constexpr int kValueTensor = 1;
+constexpr int kOutputTensor = 0;
+
+template <typename T>
+TfLiteStatus ResizeOutputImpl(TfLiteContext* context, const TfLiteTensor* dims,
+                              TfLiteTensor* output) {
+  TfLiteIntArray* output_shape = TfLiteIntArrayCreate(dims->dims->data[0]);
+  for (int i = 0; i < output_shape->size; ++i) {
+    T data = GetTensorData<T>(dims)[i];
+    if (data < 0) {
+      TfLiteIntArrayFree(output_shape);
+      context->ReportError(context, "Fill dimensions must be >= 0", dims->type);
+      return kTfLiteError;
+    }
+    output_shape->data[i] = data;
+  }
+  return context->ResizeTensor(context, output, output_shape);
+}
+
+TfLiteStatus ResizeOutput(TfLiteContext* context, const TfLiteTensor* dims,
+                          TfLiteTensor* output) {
+  switch (dims->type) {
+    case kTfLiteInt32:
+      return ResizeOutputImpl<int32_t>(context, dims, output);
+    case kTfLiteInt64:
+      return ResizeOutputImpl<int64_t>(context, dims, output);
+    default:
+      context->ReportError(
+          context,
+          "Fill only currently supports int32, int64 for input 0, "
+          "got %d.",
+          dims->type);
+      return kTfLiteError;
+  }
+}
+
+}  // namespace
+
+TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+  TF_LITE_ENSURE_EQ(context, NumInputs(node), 2);
+  TF_LITE_ENSURE_EQ(context, NumOutputs(node), 1);
+
+  const TfLiteTensor* dims;
+  TF_LITE_ENSURE_OK(context, GetInputSafe(context, node, kDimsTensor, &dims));
+  const TfLiteTensor* value;
+  TF_LITE_ENSURE_OK(context, GetInputSafe(context, node, kValueTensor, &value));
+
+  // Make sure the 1st input tensor is 1-D.
+  TF_LITE_ENSURE_EQ(context, NumDimensions(dims), 1);
+
+  // Make sure the 1st input tensor is int32 or int64.
+  const auto dtype = dims->type;
+  TF_LITE_ENSURE(context, dtype == kTfLiteInt32 || dtype == kTfLiteInt64);
+
+  // Make sure the 2nd input tensor is a scalar.
+  TF_LITE_ENSURE_EQ(context, NumDimensions(value), 0);
+
+  TfLiteTensor* output;
+  TF_LITE_ENSURE_OK(context,
+                    GetOutputSafe(context, node, kOutputTensor, &output));
+  output->type = value->type;
+
+  if (IsConstantTensor(dims)) {
+    TF_LITE_ENSURE_OK(context, ResizeOutput(context, dims, output));
+  } else {
+    SetTensorToDynamic(output);
+  }
+  return kTfLiteOk;
+}
+
+TfLiteStatus FillString(const TfLiteTensor* value, TfLiteTensor* output) {
+  DynamicBuffer buffer;
+  const auto string_ref = GetString(value, 0);
+  int n = 1;
+  for (int i = 0; i < output->dims->size; ++i) {
+    n *= output->dims->data[i];
+  }
+  for (int i = 0; i < n; ++i) {
+    buffer.AddString(string_ref.str, string_ref.len);
+  }
+  buffer.WriteToTensor(output, /*new_shape=*/nullptr);
+  return kTfLiteOk;
+}
+
+TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
+  const TfLiteTensor* value;
+  TF_LITE_ENSURE_OK(context, GetInputSafe(context, node, kValueTensor, &value));
+
+  TfLiteTensor* output;
+  TF_LITE_ENSURE_OK(context,
+                    GetOutputSafe(context, node, kOutputTensor, &output));
+
+  if (IsDynamicTensor(output)) {
+    const TfLiteTensor* dims;
+    TF_LITE_ENSURE_OK(context, GetInputSafe(context, node, kDimsTensor, &dims));
+    TF_LITE_ENSURE_OK(context, ResizeOutput(context, dims, output));
+  }
+#define TF_LITE_FILL(data_type)                                               \
+  reference_ops::Fill(GetTensorShape(value), GetTensorData<data_type>(value), \
+                      GetTensorShape(output),                                 \
+                      GetTensorData<data_type>(output))
+  switch (output->type) {
+    case kTfLiteInt32:
+      TF_LITE_FILL(int32_t);
+      break;
+    case kTfLiteInt64:
+      TF_LITE_FILL(int64_t);
+      break;
+    case kTfLiteFloat32:
+      TF_LITE_FILL(float);
+      break;
+    case kTfLiteBool:
+      TF_LITE_FILL(bool);
+      break;
+    case kTfLiteString:
+      FillString(value, output);
+      break;
+    default:
+      context->ReportError(
+          context,
+          "Fill only currently supports int32, int64, float32, bool, string "
+          "for input 1, got %d.",
+          value->type);
+      return kTfLiteError;
+  }
+#undef TF_LITE_FILL
+  return kTfLiteOk;
+}
+
+}  // namespace fill
+
+TfLiteRegistration* Register_FILL() {
+  static TfLiteRegistration r = {/*init=*/nullptr, /*free=*/nullptr,
+                                 fill::Prepare, fill::Eval};
+  return &r;
+}
+
+}  // namespace builtin
+}  // namespace ops
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/fill.cc
+++ b/tensorflow/lite/micro/kernels/fill.cc
@@ -101,6 +101,12 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   TfLiteEvalTensor* output = GetEvalOutput(context, node, kOutputTensor);
 
   switch (output->type) {
+    case kTfLiteInt8:
+      FillImpl<int8_t>(value, output);
+      break;
+    case kTfLiteInt16:
+      FillImpl<int16_t>(value, output);
+      break;
     case kTfLiteInt32:
       FillImpl<int32_t>(value, output);
       break;

--- a/tensorflow/lite/micro/kernels/fill_test.cc
+++ b/tensorflow/lite/micro/kernels/fill_test.cc
@@ -1,0 +1,144 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include <stdint.h>
+
+#include <initializer_list>
+#include <string>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "tensorflow/lite/kernels/test_util.h"
+#include "tensorflow/lite/schema/schema_generated.h"
+#include "tensorflow/lite/string_type.h"
+
+namespace tflite {
+namespace {
+
+using ::testing::ElementsAreArray;
+using ::testing::IsEmpty;
+
+enum class TestType {
+  kConst = 0,
+  kDynamic = 1,
+};
+
+template <typename dims_type, typename value_type>
+class FillOpModel : public SingleOpModel {
+ public:
+  explicit FillOpModel(TensorType dims_tensor_type,
+                       std::initializer_list<int> dims_shape,
+                       std::initializer_list<dims_type> dims_data,
+                       value_type value, TestType input_tensor_types) {
+    if (input_tensor_types == TestType::kDynamic) {
+      dims_ = AddInput(dims_tensor_type);
+      value_ = AddInput(GetTensorType<value_type>());
+    } else {
+      dims_ = AddConstInput(dims_tensor_type, dims_data, dims_shape);
+      value_ = AddConstInput(GetTensorType<value_type>(), {value}, {});
+    }
+    output_ = AddOutput(GetTensorType<value_type>());
+    SetBuiltinOp(BuiltinOperator_FILL, BuiltinOptions_FillOptions,
+                 CreateFillOptions(builder_).Union());
+    BuildInterpreter({dims_shape, {}});
+
+    if (input_tensor_types == TestType::kDynamic) {
+      if (dims_data.size() > 0) {
+        PopulateTensor<dims_type>(dims_, dims_data);
+      }
+      PopulateTensor<value_type>(value_, {value});
+    }
+  }
+
+  std::vector<value_type> GetOutput() {
+    return ExtractVector<value_type>(output_);
+  }
+  std::vector<int> GetOutputShape() { return GetTensorShape(output_); }
+
+ protected:
+  int dims_;
+  int value_;
+  int output_;
+};
+
+class FillOpTest : public ::testing::TestWithParam<TestType> {};
+
+TEST_P(FillOpTest, FillInt32) {
+  FillOpModel<int32_t, int32_t> m(TensorType_INT32, {2}, {2, 3}, -11,
+                                  GetParam());
+  m.Invoke();
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray({-11, -11, -11, -11, -11, -11}));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 3}));
+}
+
+TEST_P(FillOpTest, FillInt64) {
+  FillOpModel<int64_t, int64_t> m(TensorType_INT64, {2}, {2, 4}, 1LL << 45,
+                                  GetParam());
+  m.Invoke();
+  EXPECT_THAT(m.GetOutput(),
+              ElementsAreArray({1LL << 45, 1LL << 45, 1LL << 45, 1LL << 45,
+                                1LL << 45, 1LL << 45, 1LL << 45, 1LL << 45}));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 4}));
+}
+
+TEST_P(FillOpTest, FillFloat) {
+  FillOpModel<int64_t, float> m(TensorType_INT64, {3}, {2, 2, 2}, 4.0,
+                                GetParam());
+  m.Invoke();
+  EXPECT_THAT(m.GetOutput(),
+              ElementsAreArray({4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0}));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 2, 2}));
+}
+
+TEST_P(FillOpTest, FillFloatInt32Dims) {
+  FillOpModel<int32_t, float> m(TensorType_INT32, {3}, {2, 2, 2}, 4.0,
+                                GetParam());
+  m.Invoke();
+  EXPECT_THAT(m.GetOutput(),
+              ElementsAreArray({4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0}));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 2, 2}));
+}
+
+TEST_P(FillOpTest, FillOutputScalar) {
+  FillOpModel<int64_t, float> m(TensorType_INT64, {0}, {}, 4.0, GetParam());
+  m.Invoke();
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray({4.0}));
+  EXPECT_THAT(m.GetOutputShape(), IsEmpty());
+}
+
+TEST_P(FillOpTest, FillBool) {
+  FillOpModel<int64_t, bool> m(TensorType_INT64, {3}, {2, 2, 2}, true,
+                               GetParam());
+  m.Invoke();
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray({true, true, true, true, true,
+                                               true, true, true}));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 2, 2}));
+}
+
+TEST(FillOpTest, FillString) {
+  FillOpModel<int64_t, std::string> m(TensorType_INT64, {3}, {2, 2, 2}, "AB",
+                                      TestType::kDynamic);
+  m.Invoke();
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray({"AB", "AB", "AB", "AB", "AB",
+                                               "AB", "AB", "AB"}));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 2, 2}));
+}
+
+INSTANTIATE_TEST_SUITE_P(FillOpTest, FillOpTest,
+                         ::testing::Values(TestType::kConst,
+                                           TestType::kDynamic));
+
+}  // namespace
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/fill_test.cc
+++ b/tensorflow/lite/micro/kernels/fill_test.cc
@@ -74,6 +74,42 @@ void TestFill(int* dims_shape, DimsType* dims_data,
 
 TF_LITE_MICRO_TESTS_BEGIN
 
+TF_LITE_MICRO_TEST(FillInt8) {
+  constexpr int dim1 = 3;
+  constexpr int dim2 = 8;
+
+  int dims_shape[] = {1, 2};
+  int32_t dims_data[] = {dim1, dim2};
+
+  int value_shape[] = {0};
+  int8_t value_data[] = {-42};
+ 
+  int output_shape[] = {2, dim1, dim2};
+  int8_t output_data[dim1 * dim2];
+
+  TestFill(dims_shape, dims_data,
+           value_shape, value_data,
+           output_shape, output_data);
+}
+
+TF_LITE_MICRO_TEST(FillInt16) {
+  constexpr int dim1 = 2;
+  constexpr int dim2 = 4;
+
+  int dims_shape[] = {1, 2};
+  int32_t dims_data[] = {dim1, dim2};
+
+  int value_shape[] = {0};
+  int16_t value_data[] = {1024};
+ 
+  int output_shape[] = {2, dim1, dim2};
+  int16_t output_data[dim1 * dim2];
+
+  TestFill(dims_shape, dims_data,
+           value_shape, value_data,
+           output_shape, output_data);
+}
+
 TF_LITE_MICRO_TEST(FillInt32) {
   constexpr int dim1 = 2;
   constexpr int dim2 = 3;

--- a/tensorflow/lite/micro/kernels/fill_test.cc
+++ b/tensorflow/lite/micro/kernels/fill_test.cc
@@ -12,68 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-#include <stdint.h>
 
-#include <initializer_list>
-#include <string>
-#include <vector>
-
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
-#include "tensorflow/lite/kernels/test_util.h"
-#include "tensorflow/lite/schema/schema_generated.h"
-#include "tensorflow/lite/string_type.h"
-
-namespace tflite {
 namespace {
-
-using ::testing::ElementsAreArray;
-using ::testing::IsEmpty;
-
-enum class TestType {
-  kConst = 0,
-  kDynamic = 1,
-};
-
-template <typename dims_type, typename value_type>
-class FillOpModel : public SingleOpModel {
- public:
-  explicit FillOpModel(TensorType dims_tensor_type,
-                       std::initializer_list<int> dims_shape,
-                       std::initializer_list<dims_type> dims_data,
-                       value_type value, TestType input_tensor_types) {
-    if (input_tensor_types == TestType::kDynamic) {
-      dims_ = AddInput(dims_tensor_type);
-      value_ = AddInput(GetTensorType<value_type>());
-    } else {
-      dims_ = AddConstInput(dims_tensor_type, dims_data, dims_shape);
-      value_ = AddConstInput(GetTensorType<value_type>(), {value}, {});
-    }
-    output_ = AddOutput(GetTensorType<value_type>());
-    SetBuiltinOp(BuiltinOperator_FILL, BuiltinOptions_FillOptions,
-                 CreateFillOptions(builder_).Union());
-    BuildInterpreter({dims_shape, {}});
-
-    if (input_tensor_types == TestType::kDynamic) {
-      if (dims_data.size() > 0) {
-        PopulateTensor<dims_type>(dims_, dims_data);
-      }
-      PopulateTensor<value_type>(value_, {value});
-    }
-  }
-
-  std::vector<value_type> GetOutput() {
-    return ExtractVector<value_type>(output_);
-  }
-  std::vector<int> GetOutputShape() { return GetTensorShape(output_); }
-
- protected:
-  int dims_;
-  int value_;
-  int output_;
-};
-
-class FillOpTest : public ::testing::TestWithParam<TestType> {};
 
 TEST_P(FillOpTest, FillInt32) {
   FillOpModel<int32_t, int32_t> m(TensorType_INT32, {2}, {2, 3}, -11,
@@ -118,27 +58,4 @@ TEST_P(FillOpTest, FillOutputScalar) {
   EXPECT_THAT(m.GetOutputShape(), IsEmpty());
 }
 
-TEST_P(FillOpTest, FillBool) {
-  FillOpModel<int64_t, bool> m(TensorType_INT64, {3}, {2, 2, 2}, true,
-                               GetParam());
-  m.Invoke();
-  EXPECT_THAT(m.GetOutput(), ElementsAreArray({true, true, true, true, true,
-                                               true, true, true}));
-  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 2, 2}));
-}
-
-TEST(FillOpTest, FillString) {
-  FillOpModel<int64_t, std::string> m(TensorType_INT64, {3}, {2, 2, 2}, "AB",
-                                      TestType::kDynamic);
-  m.Invoke();
-  EXPECT_THAT(m.GetOutput(), ElementsAreArray({"AB", "AB", "AB", "AB", "AB",
-                                               "AB", "AB", "AB"}));
-  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 2, 2}));
-}
-
-INSTANTIATE_TEST_SUITE_P(FillOpTest, FillOpTest,
-                         ::testing::Values(TestType::kConst,
-                                           TestType::kDynamic));
-
 }  // namespace
-}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/micro_ops.h
+++ b/tensorflow/lite/micro/kernels/micro_ops.h
@@ -33,6 +33,7 @@ namespace tflite {
 
 TfLiteRegistration Register_CONV_2D();
 TfLiteRegistration Register_DEPTHWISE_CONV_2D();
+TfLiteRegistration Register_FILL();
 TfLiteRegistration Register_QUANTIZE();
 TfLiteRegistration Register_SHAPE();
 TfLiteRegistration Register_SOFTMAX();

--- a/tensorflow/lite/micro/micro_mutable_op_resolver.h
+++ b/tensorflow/lite/micro/micro_mutable_op_resolver.h
@@ -190,6 +190,11 @@ class MicroMutableOpResolver : public MicroOpResolver {
     return kTfLiteOk;
   }
 
+  TfLiteStatus AddFill() {
+    return AddBuiltin(BuiltinOperator_FILL,
+                      tflite::Register_FILL(), ParseFill);
+  }
+
   TfLiteStatus AddFloor() {
     return AddBuiltin(BuiltinOperator_FLOOR,
                       tflite::ops::micro::Register_FLOOR(), ParseFloor);

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -263,6 +263,7 @@ tensorflow/lite/micro/kernels/depthwise_conv_test.cc \
 tensorflow/lite/micro/kernels/dequantize_test.cc \
 tensorflow/lite/micro/kernels/detection_postprocess_test.cc \
 tensorflow/lite/micro/kernels/elementwise_test.cc \
+tensorflow/lite/micro/kernels/fill_test.cc \
 tensorflow/lite/micro/kernels/floor_test.cc \
 tensorflow/lite/micro/kernels/fully_connected_test.cc \
 tensorflow/lite/micro/kernels/hard_swish_test.cc \
@@ -308,6 +309,7 @@ tensorflow/lite/micro/kernels/dequantize.cc \
 tensorflow/lite/micro/kernels/detection_postprocess.cc \
 tensorflow/lite/micro/kernels/elementwise.cc \
 tensorflow/lite/micro/kernels/ethosu.cc \
+tensorflow/lite/micro/kernels/fill.cc \
 tensorflow/lite/micro/kernels/flexbuffers_generated_data.cc \
 tensorflow/lite/micro/kernels/floor.cc \
 tensorflow/lite/micro/kernels/fully_connected.cc \


### PR DESCRIPTION
This is an RFC on how to best chunk, into reviewable PRs, the port of operator FILL from lite to micro as discussed in issue #45306. Below is the current plan from that issue and a mapping to the commits in this draft PR. Please review to ensure this is on target, creating small-enough PRs with understandable diffs.

Following the plan in issue #45306, the following PRs have already been submitted:
1. ~~**Extract the code for parsing the op from a flatbuffer**~~. Merged as #45307.
2. ~~**Extract the reference implementation into its own header**.~~ Merged as #45311.
3. **Copy operator from lite to micro without making any changes**. Open as #45457. Note I've copied both the kernel and the test.

This RFC contains the changes from plan steps PR 3 to PR 5:

4. **Delete extra code from the micro copy of the operator**: b5b6071. As I understand it, the intent is to remove some of the old code so that the diff in the following PR is more readable. The code isn't yet included in the build and doesn't function, so what is right and wrong is a little subjective. Note I've modified both the kernel and the test.
5. **Port micro copy of operator as necessary and add a corresponding test**: At the moment, this change is in three commits: 046eb2e containing the port and addition to the build, 9919a96 adding the op to the resolver (which doesn't get tested, BTW); and 6fe4e69 adding new datatypes specific to micro. Is this too large for a single PR, or do I have the right idea? It's hard to see how to get more atomic than these three commits, unless the first is broken up into small unbuilt and untested changes (like the copy PR 3 above).

Of course, the content needs reviewing too, but let's start by getting the chunking right.