### PR TITLE
Only use site.USER_SITE if site.ENABLE_USER_SITE is set

### DIFF
--- a/tensorflow/api_template.__init__.py
+++ b/tensorflow/api_template.__init__.py
@@ -116,7 +116,8 @@ from tensorflow.python.lib.io import file_io as _fi
 
 # Get sitepackages directories for the python installation.
 _site_packages_dirs = []
-_site_packages_dirs += [] if _site.USER_SITE is None else [_site.USER_SITE]
+if _site.ENABLE_USER_SITE and _site.USER_SITE is not None:
+  _site_packages_dirs += [_site.USER_SITE]
 _site_packages_dirs += [_p for _p in _sys.path if 'site-packages' in _p]
 if 'getsitepackages' in dir(_site):
   _site_packages_dirs += _site.getsitepackages()


### PR DESCRIPTION
Currently, TensorFlow does not respect the virtual environment borders, loading dynamic kernels from the user site even in a virtual environment, causing a hard crash during start when for example TF 2.3 is installed in a user site and TF 2.4 in a virtual environment.

This pull request is a cherry pick of a commit from `master` which adds the `site.USER_SITE` to the list of paths to be loaded from only if `site.ENABLE_USER_SITE` is set, which fixes the issue.

The pull request on master is #45399, the original issue #42978.