### PR TITLE
[TFTRT] Disable non TRT optimization fix

### DIFF
--- a/tensorflow/python/compiler/tensorrt/BUILD
+++ b/tensorflow/python/compiler/tensorrt/BUILD
@@ -36,7 +36,10 @@ py_library(
 
 py_library(
     name = "trt_convert_py",
-    srcs = ["trt_convert.py"],
+    srcs = [
+        "trt_convert.py",
+        "utils.py"
+    ],
     srcs_version = "PY2AND3",
     deps = [
         "//tensorflow/compiler/tf2tensorrt:_pywrap_py_utils",

--- a/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
+++ b/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
@@ -35,7 +35,9 @@ from tensorflow.compiler.tf2tensorrt._pywrap_py_utils import get_linked_tensorrt
 from tensorflow.compiler.tf2tensorrt._pywrap_py_utils import is_tensorrt_enabled
 from tensorflow.core.framework import graph_pb2
 from tensorflow.core.protobuf import config_pb2
+from tensorflow.core.protobuf import rewriter_config_pb2
 from tensorflow.python.compiler.tensorrt import trt_convert
+from tensorflow.python.compiler.tensorrt import utils as trt_utils
 from tensorflow.python.eager import def_function
 from tensorflow.python.framework import graph_io
 from tensorflow.python.framework import ops
@@ -331,17 +333,24 @@ class TfTrtIntegrationTestBase(test_util.TensorFlowTestCase):
     """Get config proto based on specific settings."""
     conversion_params = self.GetConversionParams(run_params)
     max_batch_size = self.GetMaxBatchSize(run_params)
+
     if graph_state == GraphState.INFERENCE and run_params.convert_online:
       rewriter_cfg = trt_convert.get_tensorrt_rewriter_config(
           conversion_params,
           is_dynamic_op=run_params.dynamic_engine,
-          max_batch_size=max_batch_size)
-      graph_options = config_pb2.GraphOptions(rewrite_options=rewriter_cfg)
+          max_batch_size=max_batch_size,
+          disable_non_trt_optimizers=self._disable_non_trt_optimizers)
     else:
-      graph_options = config_pb2.GraphOptions()
+      rewriter_cfg = rewriter_config_pb2.RewriterConfig()
+      if self._disable_non_trt_optimizers:
+          rewriter_cfg = \
+              trt_utils.disable_non_trt_optimizers_in_rewriter_config(
+              rewriter_cfg
+          )
 
     config = config_pb2.ConfigProto(
-        gpu_options=self._GetGPUOptions(), graph_options=graph_options)
+        gpu_options=self._GetGPUOptions(),
+        graph_options=config_pb2.GraphOptions(rewrite_options=rewriter_cfg))
     return config
 
   def _GetFeedNames(self):

--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -30,6 +30,7 @@ from tensorflow.core.protobuf import config_pb2
 from tensorflow.core.protobuf import meta_graph_pb2
 from tensorflow.core.protobuf import rewriter_config_pb2
 from tensorflow.python.client import session
+from tensorflow.python.compiler.tensorrt import utils as trt_utils
 from tensorflow.python.eager import context
 from tensorflow.python.eager import wrap_function
 from tensorflow.python.framework import convert_to_constants
@@ -227,7 +228,6 @@ def _check_trt_version_compatibility():
         "This is supported because TensorRT " +
         " minor/patch upgrades are backward compatible")
 
-
 def _get_tensorrt_rewriter_config(conversion_params,
                                   is_dynamic_op=None,
                                   max_batch_size=None,
@@ -271,11 +271,14 @@ def _get_tensorrt_rewriter_config(conversion_params,
     # need to run constant folding again.
     rewriter_config_with_trt.optimizers.extend(
         ["constfold", "layout", "constfold"])
+
   rewriter_config_with_trt.meta_optimizer_iterations = (
       rewriter_config_pb2.RewriterConfig.ONE)
   optimizer = rewriter_config_with_trt.custom_optimizers.add()
-  # Add a constfold optimizer to cleanup the unused Const nodes.
-  rewriter_config_with_trt.custom_optimizers.add().name = "constfold"
+
+  if not disable_non_trt_optimizers:
+    # Add a constfold optimizer to cleanup the unused Const nodes.
+    rewriter_config_with_trt.custom_optimizers.add().name = "constfold"
 
   optimizer.name = "TensorRTOptimizer"
   optimizer.parameter_map[
@@ -295,25 +298,13 @@ def _get_tensorrt_rewriter_config(conversion_params,
     optimizer.parameter_map["max_batch_size"].i = max_batch_size
   optimizer.parameter_map["use_implicit_batch"].b = use_implicit_batch
 
-  # Disabling optimizers should happen after CopyFrom the template
+  # Disabling optimizers should happen after defining the TF-TRT grappler pass
   # otherwise the template can overwrite the disablement.
   if disable_non_trt_optimizers:
-    off = rewriter_config_pb2.RewriterConfig.OFF
-    rewriter_config_with_trt.layout_optimizer = off
-    rewriter_config_with_trt.constant_folding = off
-    rewriter_config_with_trt.shape_optimization = off
-    rewriter_config_with_trt.remapping = off
-    rewriter_config_with_trt.arithmetic_optimization = off
-    rewriter_config_with_trt.dependency_optimization = off
-    rewriter_config_with_trt.loop_optimization = off
-    rewriter_config_with_trt.function_optimization = off
-    rewriter_config_with_trt.debug_stripper = off
-    rewriter_config_with_trt.disable_model_pruning = True
-    rewriter_config_with_trt.scoped_allocator_optimization = off
-    rewriter_config_with_trt.memory_optimization = (
-        rewriter_config_pb2.RewriterConfig.NO_MEM_OPT)
-    rewriter_config_with_trt.pin_to_host_optimization = off
-    rewriter_config_with_trt.auto_parallel.enable = False
+    rewriter_config_with_trt = \
+        trt_utils.disable_non_trt_optimizers_in_rewriter_config(
+            rewriter_config_with_trt
+        )
 
   return rewriter_config_with_trt
 
@@ -652,10 +643,23 @@ class TrtGraphConverter(object):
           return_elements=fetch_names,
           name="")
 
+    calibrate_rewriter_cfg = rewriter_config_pb2.RewriterConfig()
+    if self._test_only_disable_non_trt_optimizers:
+        calibrate_rewriter_cfg = \
+            trt_utils.disable_non_trt_optimizers_in_rewriter_config(
+                calibrate_rewriter_cfg
+            )
+
     # Set allow_soft_placement=True to run the graph for calibration so that
     # OPs supported by TensorRT but don't have a GPU implementation are allowed
     # to execute on CPU.
-    calibrate_config = config_pb2.ConfigProto(allow_soft_placement=True)
+    calibrate_config = config_pb2.ConfigProto(
+        allow_soft_placement=True,
+        graph_options=config_pb2.GraphOptions(
+            rewrite_options=calibrate_rewriter_cfg
+        )
+    )
+
     with session.Session(
         graph=self._calibration_graph,
         config=calibrate_config) as calibration_sess:

--- a/tensorflow/python/compiler/tensorrt/utils.py
+++ b/tensorflow/python/compiler/tensorrt/utils.py
@@ -1,0 +1,51 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+"""Exposes the Python wrapper conversion to trt_graph."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.core.protobuf import rewriter_config_pb2
+
+
+def disable_non_trt_optimizers_in_rewriter_config(rewriter_config):
+    """Returns a RewriterConfig proto with all non-TRT optimizations disabled.
+    """
+    off = rewriter_config_pb2.RewriterConfig.OFF
+
+    rewriter_config.arithmetic_optimization = off
+    rewriter_config.auto_mixed_precision = off
+    rewriter_config.auto_parallel.enable = False
+    rewriter_config.constant_folding = off
+    rewriter_config.debug_stripper = off
+    rewriter_config.dependency_optimization = off
+    # This one needs to be ON to allow TF-TRT
+    rewriter_config.disable_meta_optimizer = False
+    rewriter_config.disable_model_pruning = True
+    rewriter_config.function_optimization= off
+    rewriter_config.implementation_selector = off
+    rewriter_config.layout_optimizer = off
+    rewriter_config.loop_optimization = off
+    rewriter_config.memory_optimization= (
+        rewriter_config_pb2.RewriterConfig.NO_MEM_OPT
+    )
+    rewriter_config.min_graph_nodes = -1
+    rewriter_config.pin_to_host_optimization = off
+    rewriter_config.remapping = off
+    rewriter_config.scoped_allocator_optimization = off
+    rewriter_config.shape_optimization = off
+
+    return rewriter_config


### PR DESCRIPTION
This PR fixes OfflineConversion not respecting properly: `DisableNonTrtOptimizers()`.
In addition it provides some cleanup, and a "private" function to get a rewriter_config with all non-TRT grappler opt disabled.