### PR TITLE
activation, kernel, bias are all attributes in Dense

### DIFF
--- a/tensorflow/python/keras/layers/core.py
+++ b/tensorflow/python/keras/layers/core.py
@@ -1085,7 +1085,7 @@ class Dense(Layer):
   where `activation` is the element-wise activation function
   passed as the `activation` argument, `kernel` is a weights matrix
   created by the layer, and `bias` is a bias vector created by the layer
-  (only applicable if `use_bias` is `True`). These are all attributes in 
+  (only applicable if `use_bias` is `True`). These are all attributes of 
   `Dense`.
 
   Note: If the input to the layer has a rank greater than 2, then `Dense`

--- a/tensorflow/python/keras/layers/core.py
+++ b/tensorflow/python/keras/layers/core.py
@@ -1085,7 +1085,8 @@ class Dense(Layer):
   where `activation` is the element-wise activation function
   passed as the `activation` argument, `kernel` is a weights matrix
   created by the layer, and `bias` is a bias vector created by the layer
-  (only applicable if `use_bias` is `True`).
+  (only applicable if `use_bias` is `True`). These are all attributes in 
+  `Dense`.
 
   Note: If the input to the layer has a rank greater than 2, then `Dense`
   computes the dot product between the `inputs` and the `kernel` along the


### PR DESCRIPTION
Current documentation only says Dense implements such math operation. It's unclear to user how to access `kernel` and `bias`.

It turns out, through reading the code, these are all attributes added in this layer.

`kernel` and `bias` are added in `build()`, while `activation` is added in the constructor.

