### PR TITLE
Add classifier_activation param to applications

### DIFF
--- a/tensorflow/python/keras/applications/applications_test.py
+++ b/tensorflow/python/keras/applications/applications_test.py
@@ -35,6 +35,7 @@ from tensorflow.python.keras.applications import vgg16
 from tensorflow.python.keras.applications import vgg19
 from tensorflow.python.keras.applications import xception
 from tensorflow.python.platform import test
+from tensorflow.python.keras.activations import linear, softmax
 
 
 MODEL_LIST_NO_NASNET = [
@@ -113,6 +114,13 @@ class ApplicationsTest(test.TestCase, parameterized.TestCase):
     output_shape = _get_output_shape(
         lambda: app(weights=None, include_top=False, pooling='avg'))
     self.assertShapeEqual(output_shape, (None, last_dim))
+
+  @parameterized.parameters(MODEL_LIST)
+  def test_application_classifier_activation(self, app, last_dim):
+      model = app(classifier_activation="softmax", weights=None)
+      self.assertTrue(model.layers[-1].activation is softmax)
+      model = app(classifier_activation="linear", weights=None)
+      self.assertTrue(model.layers[-1].activation is linear)
 
   @parameterized.parameters(*MODEL_LIST_NO_NASNET)
   def test_application_variable_input_channels(self, app, last_dim):

--- a/tensorflow/python/keras/applications/densenet.py
+++ b/tensorflow/python/keras/applications/densenet.py
@@ -325,10 +325,11 @@ def DenseNet121(include_top=True,
                 input_tensor=None,
                 input_shape=None,
                 pooling=None,
-                classes=1000):
+                classes=1000,
+                classifier_activation='softmax'):
   """Instantiates the Densenet121 architecture."""
   return DenseNet([6, 12, 24, 16], include_top, weights, input_tensor,
-                  input_shape, pooling, classes)
+                  input_shape, pooling, classes, classifier_activation)
 
 
 @keras_export('keras.applications.densenet.DenseNet169',
@@ -338,10 +339,11 @@ def DenseNet169(include_top=True,
                 input_tensor=None,
                 input_shape=None,
                 pooling=None,
-                classes=1000):
+                classes=1000,
+                classifier_activation='softmax'):
   """Instantiates the Densenet169 architecture."""
   return DenseNet([6, 12, 32, 32], include_top, weights, input_tensor,
-                  input_shape, pooling, classes)
+                  input_shape, pooling, classes, classifier_activation)
 
 
 @keras_export('keras.applications.densenet.DenseNet201',
@@ -351,10 +353,11 @@ def DenseNet201(include_top=True,
                 input_tensor=None,
                 input_shape=None,
                 pooling=None,
-                classes=1000):
+                classes=1000,
+                classifier_activation='softmax'):
   """Instantiates the Densenet201 architecture."""
   return DenseNet([6, 12, 48, 32], include_top, weights, input_tensor,
-                  input_shape, pooling, classes)
+                  input_shape, pooling, classes, classifier_activation)
 
 
 @keras_export('keras.applications.densenet.preprocess_input')

--- a/tensorflow/python/keras/applications/nasnet.py
+++ b/tensorflow/python/keras/applications/nasnet.py
@@ -325,7 +325,8 @@ def NASNetMobile(input_shape=None,
                  weights='imagenet',
                  input_tensor=None,
                  pooling=None,
-                 classes=1000):
+                 classes=1000,
+                 classifier_activation='softmax'):
   """Instantiates a Mobile NASNet model in ImageNet mode.
 
   Reference:
@@ -370,6 +371,9 @@ def NASNetMobile(input_shape=None,
       classes: Optional number of classes to classify images
           into, only to be specified if `include_top` is True, and
           if no `weights` argument is specified.
+      classifier_activation: A `str` or callable. The activation function to use
+        on the "top" layer. Ignored unless `include_top=True`. Set
+        `classifier_activation=None` to return the logits of the "top" layer.
 
   Returns:
       A Keras model instance.
@@ -392,7 +396,8 @@ def NASNetMobile(input_shape=None,
       input_tensor=input_tensor,
       pooling=pooling,
       classes=classes,
-      default_size=224)
+      default_size=224,
+      classifier_activation=classifier_activation)
 
 
 @keras_export('keras.applications.nasnet.NASNetLarge',
@@ -402,7 +407,8 @@ def NASNetLarge(input_shape=None,
                 weights='imagenet',
                 input_tensor=None,
                 pooling=None,
-                classes=1000):
+                classes=1000,
+                classifier_activation='softmax'):
   """Instantiates a NASNet model in ImageNet mode.
 
   Reference:
@@ -447,6 +453,9 @@ def NASNetLarge(input_shape=None,
       classes: Optional number of classes to classify images
           into, only to be specified if `include_top` is True, and
           if no `weights` argument is specified.
+      classifier_activation: A `str` or callable. The activation function to use
+        on the "top" layer. Ignored unless `include_top=True`. Set
+        `classifier_activation=None` to return the logits of the "top" layer.
 
   Returns:
       A Keras model instance.
@@ -469,7 +478,8 @@ def NASNetLarge(input_shape=None,
       input_tensor=input_tensor,
       pooling=pooling,
       classes=classes,
-      default_size=331)
+      default_size=331,
+      classifier_activation=classifier_activation)
 
 
 def _separable_conv_block(ip,


### PR DESCRIPTION
I have noticed that the DenseNet and NasNet models did not have the possibility to specify the `classifier_activation` parameter, when the main classes have it implemented and the other models in `tf.keras.applications` also have them available, hence I have added those parameters. I have tested the code locally.