### PR TITLE
micro: fix build warning due to example person_detection

### DIFF
--- a/tensorflow/lite/micro/examples/person_detection/Makefile.inc
+++ b/tensorflow/lite/micro/examples/person_detection/Makefile.inc
@@ -1,5 +1,3 @@
-$(eval $(call add_third_party_download,$(PERSON_MODEL_INT8_URL),$(PERSON_MODEL_INT8_MD5),person_model_int8,))
-
 person_detection_MODEL_SRCS := \
 tensorflow/lite/micro/examples/person_detection/model_settings.cc \
 $(MAKEFILE_DIR)/downloads/person_model_int8/person_detect_model_data.cc


### PR DESCRIPTION
`make` was warning because the recipe for target person_model_int8
was being defined twice, once in the main Makefile at the
location given in the warning:

    tensorflow/lite/micro/tools/make/Makefile:583:
      warning: overriding recipe for target
      'tensorflow/lite/micro/tools/make/downloads/person_model_int8'
    tensorflow/lite/micro/tools/make/Makefile:583:
      warning: ignoring old recipe for target
      'tensorflow/lite/micro/tools/make/downloads/person_model_int8'

and once in the person_detection example's include Makefile, which is
included by the main Makefile.

These warnings were causing annoying, false-positives while
browsing complier errors via my editor following a build.

To fix, remove the re-definition in the example's include Makefile.

This fixes #45665.