### PR TITLE
Download pigweed as part of the TensorflowLite Micro makefile.

### DIFF
--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -498,6 +498,11 @@ ifneq ($(DISABLE_DOWNLOADS), true)
     $(error Something went wrong with the flatbuffers download: $(DOWNLOAD_RESULT))
   endif
 
+  DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/pigweed_download.sh ${MAKEFILE_DIR}/downloads)
+  ifneq ($(DOWNLOAD_RESULT), SUCCESS)
+    $(error Something went wrong with the pigweed download: $(DOWNLOAD_RESULT))
+  endif
+
   include $(MAKEFILE_DIR)/third_party_downloads.inc
   THIRD_PARTY_DOWNLOADS :=
   $(eval $(call add_third_party_download,$(GEMMLOWP_URL),$(GEMMLOWP_MD5),gemmlowp,))

--- a/tensorflow/lite/micro/tools/make/pigweed.patch
+++ b/tensorflow/lite/micro/tools/make/pigweed.patch
@@ -1,0 +1,103 @@
+diff --git a/pw_presubmit/py/pw_presubmit/build.py b/pw_presubmit/py/pw_presubmit/build.py
+index 4a370e33..224ad9c6 100644
+--- a/pw_presubmit/py/pw_presubmit/build.py
++++ b/pw_presubmit/py/pw_presubmit/build.py
+@@ -20,7 +20,6 @@ from pathlib import Path
+ import re
+ from typing import Container, Dict, Iterable, List, Mapping, Set, Tuple
+ 
+-from pw_package import package_manager
+ from pw_presubmit import call, log_run, plural, PresubmitFailure, tools
+ 
+ _LOG = logging.getLogger(__name__)
+diff --git a/pw_presubmit/py/pw_presubmit/pigweed_presubmit.py b/pw_presubmit/py/pw_presubmit/pigweed_presubmit.py
+index 794967db..061db7ea 100755
+--- a/pw_presubmit/py/pw_presubmit/pigweed_presubmit.py
++++ b/pw_presubmit/py/pw_presubmit/pigweed_presubmit.py
+@@ -220,8 +220,8 @@ def clang_tidy(ctx: PresubmitContext):
+ 
+ 
+ # The first line must be regex because of the '20\d\d' date
+-COPYRIGHT_FIRST_LINE = r'Copyright 20\d\d The Pigweed Authors'
+-COPYRIGHT_COMMENTS = r'(#|//| \*|REM|::)'
++COPYRIGHT_FIRST_LINE = r'Copyright 20\d\d The TensorFlow Authors. All Rights Reserved.'
++COPYRIGHT_COMMENTS = r'(#|//|\*|REM|::|/\*)'
+ COPYRIGHT_BLOCK_COMMENTS = (
+     # HTML comments
+     (r'<!--', r'-->'), )
+@@ -232,21 +232,23 @@ COPYRIGHT_FIRST_LINE_EXCEPTIONS = (
+     '@echo off',
+     '# -*-',
+     ':',
++    '# Lint as',
++    '# coding=utf-8'
+ )
+ 
+ COPYRIGHT_LINES = tuple("""\
+ 
+-Licensed under the Apache License, Version 2.0 (the "License"); you may not
+-use this file except in compliance with the License. You may obtain a copy of
+-the License at
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
+ 
+-    https://www.apache.org/licenses/LICENSE-2.0
++    http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+-distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-License for the specific language governing permissions and limitations under
+-the License.
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
+ """.splitlines())
+ 
+ _EXCLUDE_FROM_COPYRIGHT_NOTICE: Sequence[str] = (
+@@ -344,6 +346,11 @@ def copyright_notice(ctx: PresubmitContext):
+                 errors.append(path)
+                 continue
+ 
++            # Special handling for TFLM style of copyright+license in the cc
++            # files.
++            if comment == '/*':
++              comment = ''
++
+             if end_block_comment:
+                 expected_lines = COPYRIGHT_LINES + (end_block_comment, )
+             else:
+@@ -354,6 +361,10 @@ def copyright_notice(ctx: PresubmitContext):
+                     expected_line = expected + '\n'
+                 elif comment:
+                     expected_line = (comment + ' ' + expected).rstrip() + '\n'
++                else:
++                    # Special handling for TFLM style of copyright+license in
++                    # the cc files.
++                    expected_line = (expected).rstrip() + '\n'
+ 
+                 if expected_line != actual:
+                     _LOG.warning('  bad line: %r', actual)
+@@ -475,6 +486,10 @@ BROKEN = (
+     gn_nanopb_build,
+ )
+ 
++COPYRIGHT_NOTICE = (
++    copyright_notice,
++)
++
+ QUICK = (
+     commit_message_format,
+     init_cipd,
+@@ -509,7 +524,8 @@ FULL = (
+     build_env_setup,
+ )
+ 
+-PROGRAMS = Programs(broken=BROKEN, quick=QUICK, full=FULL)
++PROGRAMS = Programs(broken=BROKEN, quick=QUICK, full=FULL,
++                    copyright_notice=COPYRIGHT_NOTICE)
+ 
+ 
+ def parse_args() -> argparse.Namespace:

--- a/tensorflow/lite/micro/tools/make/pigweed_download.sh
+++ b/tensorflow/lite/micro/tools/make/pigweed_download.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# Called with following arguments:
+# 1 - Path to the downloads folder which is typically
+#     tensorflow/lite/micro/tools/make/downloads
+#
+# This script is called from the Makefile and uses the following convention to
+# enable determination of sucess/failure:
+#
+#   - If the script is successful, the only output on stdout should be SUCCESS.
+#     The makefile checks for this particular string.
+#
+#   - Any string on stdout that is not SUCCESS will be shown in the makefile as
+#     the cause for the script to have failed.
+#
+#   - Any other informational prints should be on stderr.
+
+set -e
+
+DOWNLOADS_DIR=${1}
+if [ ! -d ${DOWNLOADS_DIR} ]; then
+  echo "The top-level downloads directory: ${DOWNLOADS_DIR} does not exist."
+  exit 1
+fi
+
+# The BUILD files in the downloaded folder result in an error with:
+#  bazel build tensorflow/lite/micro/...
+#
+# Parameters:
+#   $1 - path to the downloaded flatbuffers code.
+function delete_build_files() {
+  rm -f `find ${1} -name BUILD`
+}
+
+DOWNLOADED_PIGWEED_PATH=${DOWNLOADS_DIR}/pigweed
+
+if [ -d ${DOWNLOADED_PIGWEED_PATH} ]; then
+  echo >&2 "${DOWNLOADED_PIGWEED_PATH} already exists, skipping the download."
+else
+  git clone https://pigweed.googlesource.com/pigweed/pigweed ${DOWNLOADED_PIGWEED_PATH} >&2
+  pushd ${DOWNLOADED_PIGWEED_PATH} > /dev/null
+  git checkout 47268dff45019863e20438ca3746c6c62df6ef09 >&2
+
+  # Patch for TFLM specific changes that are not currently upstreamed.
+  git apply ../../pigweed.patch
+  popd > /dev/null
+
+  delete_build_files ${DOWNLOADED_PIGWEED_PATH}
+fi
+
+echo "SUCCESS"


### PR DESCRIPTION
We will be using scripts from pigweed to add checks for licenses and
clang-formatting (follow-on changes).

Downloading and patching pigweed takes ~6 seconds on my local machine.

Addresses http://b/175315163
