### PR TITLE
Prevent crash of tensorflow if shape is too large for tf.sparse.reorder

### DIFF
--- a/tensorflow/core/kernels/sparse_reorder_op.cc
+++ b/tensorflow/core/kernels/sparse_reorder_op.cc
@@ -27,6 +27,7 @@ limitations under the License.
 #include "tensorflow/core/framework/types.h"
 #include "tensorflow/core/lib/gtl/inlined_vector.h"
 #include "tensorflow/core/util/sparse/sparse_tensor.h"
+#include "tensorflow/core/util/overflow.h"
 
 namespace tensorflow {
 
@@ -53,6 +54,18 @@ class SparseReorderOp : public OpKernel {
                 errors::InvalidArgument(
                     "Input shape should be a vector but received shape ",
                     input_shape_in.shape().DebugString()));
+
+    // Check if the sparse tensor input shape is valid
+    int64 total = 1;
+    for (int64 i = 0; i < input_shape_in.NumElements(); ++i) {
+      int dim = input_shape_in.vec<int64>()(i);
+      OP_REQUIRES(context, (dim >= 0),
+                  errors::InvalidArgument("Dimension ", dim, " must be >= 0"));
+      total = MultiplyWithoutOverflow(total, dim);
+      OP_REQUIRES(context, (total > 0),
+                  errors::InvalidArgument(
+                      "Shape would have more than 2**63 - 1 elements"));
+    }
 
     const TensorShape input_shape(input_shape_in.vec<int64>());
 

--- a/tensorflow/python/kernel_tests/sparse_reorder_op_test.py
+++ b/tensorflow/python/kernel_tests/sparse_reorder_op_test.py
@@ -21,7 +21,6 @@ from __future__ import print_function
 import numpy as np
 
 from tensorflow.python.framework import dtypes
-from tensorflow.python.framework import errors_impl
 from tensorflow.python.framework import sparse_tensor
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
@@ -132,9 +131,9 @@ class SparseReorderTest(test.TestCase):
         dense_shape=[4096, 4096, 4096, 4096, 4096, 4096])
     self.assertAllEqual(
         (4096, 4096, 4096, 4096, 4096, 4096), sp_input.get_shape())
-    with self.assertRaisesRegex(errors_impl.InvalidArgumentError,
-                                "Shape would have more than"):
-        sp_output = sparse_ops.sparse_reorder(sp_input)
+    sp_output = sparse_ops.sparse_reorder(sp_input)
+    self.assertAllEqual(
+        (4096, 4096, 4096, 4096, 4096, 4096), sp_output.get_shape())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR tries to address the issue raised in #45392 where tensorflow crashes if shape of sparse tensor is too large for tf.sparse.reorder

This PR adds additional checks and exit gracefully if the shape is too large.

This PR fixes #45392.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>