### PR TITLE
Fix bazel build with -DTF_LITE_STATIC_MEMORY.

### DIFF
--- a/tensorflow/lite/micro/micro_mutable_op_resolver.h
+++ b/tensorflow/lite/micro/micro_mutable_op_resolver.h
@@ -36,6 +36,8 @@ TfLiteRegistration* Register_DETECTION_POSTPROCESS();
 template <unsigned int tOpCount>
 class MicroMutableOpResolver : public MicroOpResolver {
  public:
+  TF_LITE_REMOVE_VIRTUAL_DELETE
+
   explicit MicroMutableOpResolver(ErrorReporter* error_reporter = nullptr)
       : error_reporter_(error_reporter) {}
 
@@ -421,8 +423,6 @@ class MicroMutableOpResolver : public MicroOpResolver {
   unsigned int GetRegistrationLength() { return registrations_len_; }
 
  private:
-  TF_LITE_REMOVE_VIRTUAL_DELETE
-
   TfLiteStatus AddBuiltin(tflite::BuiltinOperator op,
                           const TfLiteRegistration& registration,
                           MicroOpResolver::BuiltinParseFunction parser) {


### PR DESCRIPTION
Tested that the following command passes:
```
bazel test tensorflow/lite/micro/...  --test_tag_filters=-no_oss --build_tag_filters=-no_oss --copt=-DTF_LITE_STATIC_MEMORY
```

This PR was created to address http://b/175642155 and https://github.com/tensorflow/tensorflow/pull/45535#issuecomment-744901727

In reality, while there is a mismatch between the internal and external CI (which should indeed be addressed), that wasn't the source of the problem. See https://github.com/tensorflow/tensorflow/pull/45535#issuecomment-745057559 for more information.
