### PR TITLE
Remove requirement that first dimensions of inputs are equal when using train_on_batch and test_on_batch

### DIFF
--- a/tensorflow/python/keras/engine/data_adapter.py
+++ b/tensorflow/python/keras/engine/data_adapter.py
@@ -1510,7 +1510,6 @@ def single_batch_iterator(strategy,
   else:
     data = (x, y, sample_weight)
 
-  _check_data_cardinality(data)
   dataset = dataset_ops.DatasetV2.from_tensors(data)
   if class_weight:
     dataset = dataset.map(_make_class_weight_map_fn(class_weight))

--- a/tensorflow/python/keras/engine/training_test.py
+++ b/tensorflow/python/keras/engine/training_test.py
@@ -1742,26 +1742,6 @@ class TestExceptionsAndWarnings(keras_parameterized.TestCase):
                                 'Expect x to be a non-empty array or dataset.'):
       model.predict(np.array([]))
 
-  @keras_parameterized.run_all_keras_modes(always_skip_v1=True)
-  def test_on_batch_error_inconsistent_batch_size(self):
-    input_node1 = layers_module.Input(shape=(5,))
-    input_node2 = layers_module.Input(shape=(5,))
-    output_node = layers_module.Concatenate()([input_node1, input_node2])
-    output_node = layers_module.Dense(4)(output_node)
-    model = training_module.Model([input_node1, input_node2], output_node)
-    model.compile(loss='mse')
-
-    with self.assertRaisesRegex(ValueError, 'Data cardinality is ambiguous'):
-      model.train_on_batch([np.ones((10, 5)), np.ones((10, 5))],
-                           np.ones((11, 4)))
-
-    with self.assertRaisesRegex(ValueError, 'Data cardinality is ambiguous'):
-      model.test_on_batch([np.ones((10, 5)), np.ones((10, 5))],
-                          np.ones((11, 4)))
-
-    with self.assertRaisesRegex(ValueError, 'Data cardinality is ambiguous'):
-      model.predict_on_batch([np.ones((10, 5)), np.ones((11, 5))])
-
 
 class LossWeightingTest(keras_parameterized.TestCase):
 


### PR DESCRIPTION
This PR reverts part of commit 56a0ce87911236765633d2a873e706ebc6401ef9 that introduced the requirement that all input tensors have equal first dimensions when using `model.train_on_batch` and `model.test_on_batch`. 

Checking that all inputs have the same first dimensions introduces a pointless constraint, which makes it impossible to deal with dynamic data such as graphs in Graph Neural Networks (see [here](https://github.com/danielegrattarola/spektral/blob/master/examples/graph_prediction/general_gnn.py) for an example of code that relied on `train_on_batch` that stopped working in TF 2.4).

Note that this constraint is also implemented in `model.fit`. However, `train_on_batch` and `test_on_batch` are to be intended as somewhat lower-level than the full training loop, and so it makes sense to allow more flexibility in their usage. 

By introducing this additional constraint, users can only use the Keras API if their data conforms to the classic `[batch, ...]` format. This feels like a very limiting perspective going forward, since it imposes a strong constraint on data (a constraint which is not even required by the rest of the Keras API, since layers allow for any tensor manipulation).