### PR TITLE
MeanIoU: Support y_pred passed as a logits tensor or probability tensor

### DIFF
--- a/tensorflow/python/keras/metrics.py
+++ b/tensorflow/python/keras/metrics.py
@@ -2802,6 +2802,7 @@ class MeanIoU(Metric):
       This value must be provided, since a confusion matrix of dimension =
       [num_classes, num_classes] will be allocated.
     name: (Optional) string name of the metric instance.
+    from_logits: (Optional) Whether `y_pred` is expected to be a logits tensor.
     dtype: (Optional) data type of the metric result.
 
   Standalone usage:
@@ -2832,9 +2833,10 @@ class MeanIoU(Metric):
   ```
   """
 
-  def __init__(self, num_classes, name=None, dtype=None):
+  def __init__(self, num_classes, name=None, from_logits=False, dtype=None):
     super(MeanIoU, self).__init__(name=name, dtype=dtype)
     self.num_classes = num_classes
+    self.from_logits = from_logits
 
     # Variable to accumulate the predictions in the confusion matrix.
     self.total_cm = self.add_weight(
@@ -2855,6 +2857,8 @@ class MeanIoU(Metric):
     Returns:
       Update op.
     """
+    if self.from_logits:
+      y_pred = math_ops.argmax(y_pred, axis=-1)
 
     y_true = math_ops.cast(y_true, self._dtype)
     y_pred = math_ops.cast(y_pred, self._dtype)

--- a/tensorflow/python/keras/metrics.py
+++ b/tensorflow/python/keras/metrics.py
@@ -2823,6 +2823,15 @@ class MeanIoU(Metric):
   >>> m.result().numpy()
   0.23809525
 
+  When passing `y_pred` as a logits tensor:
+
+  >>> m = tf.keras.metrics.MeanIoU(num_classes=3, from_logits=True)
+  >>> y_true = [2, 0, 1, 1]
+  >>> y_pred = [[2.5, 0.2, 2.7], [-1.4, 0.7, 1.2], [2., 3., 1.4], [2.2, 2.4, 1.5]]
+  >>> m.update_state(y_true, y_pred)
+  >>> m.result().numpy()
+  0.5
+
   Usage with `compile()` API:
 
   ```python

--- a/tensorflow/python/keras/metrics.py
+++ b/tensorflow/python/keras/metrics.py
@@ -2875,7 +2875,7 @@ class MeanIoU(Metric):
     y_pred = math_ops.cast(y_pred, self._dtype)
 
     # If y_pred is passed as a logits tensor, or a probability tensor
-    if len(K.int_shape(y_true)) == len(K.int_shape(y_pred)) - 1:
+    if len(backend.int_shape(y_true)) == len(backend.int_shape(y_pred)) - 1:
       y_pred = math_ops.argmax(y_pred, axis=-1)
 
     # Flatten the input if its rank > 1.

--- a/tensorflow/python/keras/metrics.py
+++ b/tensorflow/python/keras/metrics.py
@@ -2832,7 +2832,10 @@ class MeanIoU(Metric):
   >>> # expected_result = (0 / (1 + 0 - 0) + 2 / (2 + 2 - 2) + 1 / (1 + 2 - 1)) / 3
   >>> m = tf.keras.metrics.MeanIoU(num_classes=3)
   >>> y_true = [2, 0, 1, 1]
-  >>> y_pred = [[2.5, 0.2, 2.7], [-1.4, 0.7, 1.2], [2., 3., 1.4], [2.2, 2.4, 1.5]]
+  >>> y_pred = [[2.5,  0.2, 2.7],
+  ...           [-1.4, 0.7, 1.2],
+  ...           [2.0, 3.0, 1.4],
+  ...           [2.2, 2.4, 1.5]]
   >>> m.update_state(y_true, y_pred)
   >>> m.result().numpy()
   0.5

--- a/tensorflow/python/keras/metrics.py
+++ b/tensorflow/python/keras/metrics.py
@@ -2824,6 +2824,12 @@ class MeanIoU(Metric):
 
   When passing `y_pred` as a logits tensor:
 
+  >>> # cm = [[0., 0., 1.],
+  >>> #       [0., 2., 0.],
+  >>> #       [0., 0., 1.]]
+  >>> # sum_row = [1, 2, 1], sum_col = [0, 2, 2], true_positives = [0, 2, 1]
+  >>> # iou = true_positives / (sum_row + sum_col - true_positives))
+  >>> # expected_result = (0 / (1 + 0 - 0) + 2 / (2 + 2 - 2) + 1 / (1 + 2 - 1)) / 3
   >>> m = tf.keras.metrics.MeanIoU(num_classes=3)
   >>> y_true = [2, 0, 1, 1]
   >>> y_pred = [[2.5, 0.2, 2.7], [-1.4, 0.7, 1.2], [2., 3., 1.4], [2.2, 2.4, 1.5]]

--- a/tensorflow/python/keras/metrics_test.py
+++ b/tensorflow/python/keras/metrics_test.py
@@ -1396,6 +1396,7 @@ class MeanIoUTest(test.TestCase):
     expected_result = (0 / (1 + 0 - 0) + 2 / (2 + 2 - 2) + 1 / (1 + 2 - 1)) / 3
     self.assertAllClose(self.evaluate(result), expected_result, atol=1e-3)
 
+
 class MeanTensorTest(test.TestCase, parameterized.TestCase):
 
   @combinations.generate(combinations.combine(mode=['graph', 'eager']))

--- a/tensorflow/python/keras/metrics_test.py
+++ b/tensorflow/python/keras/metrics_test.py
@@ -1379,6 +1379,22 @@ class MeanIoUTest(test.TestCase):
     # iou = true_positives / (sum_row + sum_col - true_positives))
     expected_result = (0 + 1 / (1 + 1 - 1)) / 1
     self.assertAllClose(self.evaluate(result), expected_result, atol=1e-3)
+    
+  def test_y_pred_logits_tensor(self):
+    y_true = [2, 0, 1, 1]
+    y_pred = [[2.5, 0.2, 2.7], [-1.4, 0.7, 1.2], [2., 3., 1.4], [2.2, 2.4, 1.5]]
+    
+    m_obj = metrics.MeanIoU(num_classes=3)
+    self.evaluate(variables.variables_initializer(m_obj.variables))
+    result = m_obj(y_true, y_pred)
+
+    # cm = [[0., 0., 1.],
+    #       [0., 2., 0.],
+    #       [0., 0., 1.]]
+    # sum_row = [1, 2, 1], sum_col = [0, 2, 2], true_positives = [0, 2, 1]
+    # iou = true_positives / (sum_row + sum_col - true_positives))
+    expected_result = (0 / (1 + 0 - 0) + 2 / (2 + 2 - 2) + 1 / (1 + 2 - 1)) / 3
+    self.assertAllClose(self.evaluate(result), expected_result, atol=1e-3)
 
 
 class MeanTensorTest(test.TestCase, parameterized.TestCase):

--- a/tensorflow/python/keras/metrics_test.py
+++ b/tensorflow/python/keras/metrics_test.py
@@ -1379,22 +1379,6 @@ class MeanIoUTest(test.TestCase):
     # iou = true_positives / (sum_row + sum_col - true_positives))
     expected_result = (0 + 1 / (1 + 1 - 1)) / 1
     self.assertAllClose(self.evaluate(result), expected_result, atol=1e-3)
-    
-  def test_y_pred_logits_tensor(self):
-    y_true = [2, 0, 1, 1]
-    y_pred = [[2.5, 0.2, 2.7], [-1.4, 0.7, 1.2], [2., 3., 1.4], [2.2, 2.4, 1.5]]
-    
-    m_obj = metrics.MeanIoU(num_classes=3)
-    self.evaluate(variables.variables_initializer(m_obj.variables))
-    result = m_obj(y_true, y_pred)
-
-    # cm = [[0., 0., 1.],
-    #       [0., 2., 0.],
-    #       [0., 0., 1.]]
-    # sum_row = [1, 2, 1], sum_col = [0, 2, 2], true_positives = [0, 2, 1]
-    # iou = true_positives / (sum_row + sum_col - true_positives))
-    expected_result = (0 / (1 + 0 - 0) + 2 / (2 + 2 - 2) + 1 / (1 + 2 - 1)) / 3
-    self.assertAllClose(self.evaluate(result), expected_result, atol=1e-3)
 
 
 class MeanTensorTest(test.TestCase, parameterized.TestCase):

--- a/tensorflow/python/keras/metrics_test.py
+++ b/tensorflow/python/keras/metrics_test.py
@@ -1380,6 +1380,21 @@ class MeanIoUTest(test.TestCase):
     expected_result = (0 + 1 / (1 + 1 - 1)) / 1
     self.assertAllClose(self.evaluate(result), expected_result, atol=1e-3)
 
+  def test_y_pred_logits_tensor(self):
+    y_true = [2, 0, 1, 1]
+    y_pred = [[2.5, 0.2, 2.7], [-1.4, 0.7, 1.2], [2., 3., 1.4], [2.2, 2.4, 1.5]]
+    
+    m_obj = metrics.MeanIoU(num_classes=3, from_logits=True)
+    self.evaluate(variables.variables_initializer(m_obj.variables))
+    result = m_obj(y_true, y_pred)
+
+    # cm = [[0., 0., 1.],
+    #       [0., 2., 0.],
+    #       [0., 0., 1.]]
+    # sum_row = [1, 2, 1], sum_col = [0, 2, 2], true_positives = [0, 2, 1]
+    # iou = true_positives / (sum_row + sum_col - true_positives))
+    expected_result = (0 / (1 + 0 - 0) + 2 / (2 + 2 - 2) + 1 / (1 + 2 - 1)) / 3
+    self.assertAllClose(self.evaluate(result), expected_result, atol=1e-3)
 
 class MeanTensorTest(test.TestCase, parameterized.TestCase):
 

--- a/tensorflow/python/keras/metrics_test.py
+++ b/tensorflow/python/keras/metrics_test.py
@@ -1380,11 +1380,11 @@ class MeanIoUTest(test.TestCase):
     expected_result = (0 + 1 / (1 + 1 - 1)) / 1
     self.assertAllClose(self.evaluate(result), expected_result, atol=1e-3)
 
-  def test_y_pred_logits_tensor(self):
+  def test_y_pred_as_logits_or_probability_tensor(self):
     y_true = [2, 0, 1, 1]
     y_pred = [[2.5, 0.2, 2.7], [-1.4, 0.7, 1.2], [2., 3., 1.4], [2.2, 2.4, 1.5]]
     
-    m_obj = metrics.MeanIoU(num_classes=3, from_logits=True)
+    m_obj = metrics.MeanIoU(num_classes=3)
     self.evaluate(variables.variables_initializer(m_obj.variables))
     result = m_obj(y_true, y_pred)
 


### PR DESCRIPTION
Just like categorical_accuracy and sparse_categorical_accuracy, this change allow MeanIoU metric support y_pred to be passed as a logits tensor.