### PR TITLE
Fix for TensorFlow Lite to parse tensor shape signature safely on big endian machines

### DIFF
--- a/tensorflow/lite/core/subgraph.h
+++ b/tensorflow/lite/core/subgraph.h
@@ -118,7 +118,8 @@ class Subgraph {
     }
     return SetTensorParametersReadWrite(tensor_index, type, name, dims.size(),
                                         dims.data(), quantization, is_variable,
-                                        dims_signature.size(), dims_signature.data());
+                                        dims_signature.size(),
+                                        dims_signature.data());
   }
   TfLiteStatus SetTensorParametersReadWrite(
       int tensor_index, TfLiteType type, const char* name, const size_t rank,

--- a/tensorflow/lite/core/subgraph.h
+++ b/tensorflow/lite/core/subgraph.h
@@ -111,11 +111,14 @@ class Subgraph {
   inline TfLiteStatus SetTensorParametersReadWrite(
       int tensor_index, TfLiteType type, const char* name,
       const std::vector<int>& dims, TfLiteQuantization quantization,
-      bool is_variable = false, const size_t rank_dims_signature = 0,
-      const int* dims_signature = nullptr) {
+      bool is_variable = false, const std::vector<int>& dims_signature = {}) {
+    if (dims_signature.empty()) {
+      return SetTensorParametersReadWrite(tensor_index, type, name, dims.size(),
+                                        dims.data(), quantization, is_variable);
+    }
     return SetTensorParametersReadWrite(tensor_index, type, name, dims.size(),
                                         dims.data(), quantization, is_variable,
-                                        rank_dims_signature, dims_signature);
+                                        dims_signature.size(), dims_signature.data());
   }
   TfLiteStatus SetTensorParametersReadWrite(
       int tensor_index, TfLiteType type, const char* name, const size_t rank,

--- a/tensorflow/lite/interpreter_builder.cc
+++ b/tensorflow/lite/interpreter_builder.cc
@@ -587,11 +587,9 @@ TfLiteStatus InterpreterBuilder::ParseTensors(
       status = kTfLiteError;
     }
 
-    size_t dims_signature_rank = 0;
-    const int* dims_signature_data = nullptr;
+    std::vector<int> dims_signature = {};
     if (tensor->shape_signature()) {
-      dims_signature_rank = tensor->shape_signature()->size();
-      dims_signature_data = tensor->shape_signature()->data();
+      dims_signature = FlatBufferIntArrayToVector(tensor->shape_signature());
     }
 
     bool is_variable = tensor->is_variable();
@@ -623,7 +621,7 @@ TfLiteStatus InterpreterBuilder::ParseTensors(
     } else {
       if (subgraph->SetTensorParametersReadWrite(
               i, type, get_name(tensor), dims, quantization, is_variable,
-              dims_signature_rank, dims_signature_data) != kTfLiteOk) {
+              dims_signature) != kTfLiteOk) {
         error_reporter_->Report("Tensor %d is invalidly specified in schema.\n",
                                 i);
         status = kTfLiteError;


### PR DESCRIPTION
Fix issue #45210.
Passing an int vector whose value has been corrected for endianness instead of passing the raw data pointer from the `shape_signature` field of a flatbuffer model. Also, check for emptiness just in case the vector is empty but the `data()` pointer points to some random places in the memory. This fix guarantees that the `dims_signature` field of tensors will be set correctly on big endian machines when a TF Lite model is interpreted.