### PR TITLE
fix memory_space_assignment_best_fit_repacker_test

### DIFF
--- a/tensorflow/compiler/xla/service/memory_space_assignment_best_fit_repacker.cc
+++ b/tensorflow/compiler/xla/service/memory_space_assignment_best_fit_repacker.cc
@@ -57,12 +57,14 @@ class BestFitRepacker
   }
 
   bool Repack() {
-    Finish();
-    bool success = result_.heap_size <= max_size_;
+    const HeapSimulator::Result<AllocationBlock>& results = Finish();
+    const HeapSimulator::HeapResult<AllocationBlock>& result =
+      results.heap_results.at(0);
+    bool success = result.heap_size <= max_size_;
     if (success) {
       for (AllocationBlock* block : allocation_blocks_) {
-        auto chunk_it = result_.chunk_map.find(block);
-        if (chunk_it != result_.chunk_map.end()) {
+        auto chunk_it = result.chunk_map.find(block);
+        if (chunk_it != result.chunk_map.end()) {
           block->offset = chunk_it->second.offset;
         }
       }


### PR DESCRIPTION
in BestFitRepacker::Repack, the call to Finish moves the 'result_'
data to the values returned. This means that result_ is empty
for the remainder of the code in Repack.
Use the result returned form Finish instead.