### PR TITLE
Fix: tf.contrib.distribute.CollectiveAllReduceStrategy can't load model from checkpoint #45839

### DIFF
--- a/tensorflow/python/distribute/collective_all_reduce_strategy.py
+++ b/tensorflow/python/distribute/collective_all_reduce_strategy.py
@@ -228,8 +228,8 @@ class CollectiveAllReduceExtended(mirrored_strategy.MirroredExtended):
       raise ValueError("No `worker`, `chief` or `evaluator` tasks can be found "
                        "in `cluster_spec`.")
 
-    self._is_chief = multi_worker_util.is_chief(cluster_spec, task_type,
-                                                task_id)
+    self._is_chief = multi_worker_util.is_chief_for_collective_all_reduce_strategy(
+        cluster_spec, task_type, task_id)
 
     self._worker_device = "/job:%s/task:%d" % (task_type, task_id)
     self._host_input_device = numpy_dataset.SingleDevice(self._worker_device)


### PR DESCRIPTION
About [issue 45839](https://github.com/tensorflow/tensorflow/issues/45839)

I analyzed and debug the source code and found the following problems:

1.  The value of `worker_context.should_checkpoint` will change the basic path of checkpoint. But the restore action is related to

 the base path of the checkpoint.
```
venv/lib/python3.6/site-packages/tensorflow_core/python/training/monitored_session.py line: 341
def _create_monitored_session_with_worker_context(...)
  ...
  if (((save_checkpoint_secs and save_checkpoint_secs > 0) or
       (save_checkpoint_steps and save_checkpoint_steps > 0)) and
      checkpoint_dir):
    if worker_context.should_checkpoint:
      all_hooks.append(
          basic_session_run_hooks.CheckpointSaverHook(
              checkpoint_dir,
              save_steps=save_checkpoint_steps,
              save_secs=save_checkpoint_secs,
              scaffold=scaffold))
    elif tmpdir:
      all_hooks.append(
          basic_session_run_hooks.CheckpointSaverHook(
              os.path.join(checkpoint_dir, tmpdir),
              save_steps=save_checkpoint_steps,
              save_secs=save_checkpoint_secs,
              scaffold=scaffold))
  ...
```

2. The value of `worker_context.should_checkpoint` depends on the _is_chief attribute of Class `Collective AllReduce Extended`
```
venv/lib/python3.6/sitepackages/tensorflow_core/python/distribute/collective_all_reduce_strategy.py line 231

def _initialize_multi_worker(self, cluster_resolver):
    """Initializes the object for multi-worker training."""
    ....
    self._is_chief = multi_worker_util.is_chief(
        cluster_spec, task_type,task_id)
```
3. `multi_worker_util.py is_chief()` is the key to the problem 
```
/venv/lib/python3.6/site-packages/tensorflow_core/python/distribute/multi_worker_util.py
line 93: is_chief
def is_chief(cluster_spec=None, task_type=None, task_id=None):
  ...
  if task_type == "chief" or task_type == "evaluator":
    return True

  if ("chief" not in cluster_spec and task_type == "worker" and task_id == 0):
    return True
  return False
  ...
```

My sulotion as follow:
```
def is_chief_for_collective_all_reduce_strategy(cluster_spec=None, task_type=None, task_id=None):
  # Fix the bug that the model fails to load from checkpoint when using collective_all_reduce_strategy
  # if task_type == "chief" or task_type == "worker" or task_type == "evaluator":
  if task_type == "chief" or task_type == "evaluator":
    return True
  return False
```

I will use this solution in kubeflow in production environment.  Is there any risk in this?


Hope the PR can pass, if any questions, please give me some advice.

Thanks a lot!!!