### PR TITLE
Risc-V Linux port for TensorFlow Lite

### DIFF
--- a/tensorflow/lite/tools/make/build_riscv_lib.sh
+++ b/tensorflow/lite/tools/make/build_riscv_lib.sh
@@ -1,5 +1,5 @@
 #!/bin/bash 
-# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tensorflow/lite/tools/make/build_riscv_lib.sh
+++ b/tensorflow/lite/tools/make/build_riscv_lib.sh
@@ -1,0 +1,31 @@
+#!/bin/bash 
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+set -x
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TENSORFLOW_DIR="${SCRIPT_DIR}/../../../.."
+
+FREE_MEM="$(free -m | awk '/^Mem/ {print $2}')"
+# Use "-j 4" only memory is larger than 2GB
+if [[ "FREE_MEM" -gt "2000" ]]; then
+  NO_JOB=4
+else
+  NO_JOB=1
+fi
+
+make -j ${NO_JOB} TARGET=linux_riscv64 -C "${TENSORFLOW_DIR}" -f tensorflow/lite/tools/make/Makefile $@

--- a/tensorflow/lite/tools/make/build_riscv_lib.sh
+++ b/tensorflow/lite/tools/make/build_riscv_lib.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/bash
 # Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tensorflow/lite/tools/make/targets/riscv_makefile.inc
+++ b/tensorflow/lite/tools/make/targets/riscv_makefile.inc
@@ -8,3 +8,16 @@ ifeq ($(TARGET), riscv)
 	LIBS += -ldl
 	BUILD_TYPE := micro
 endif
+
+ifeq ($(TARGET), linux_riscv64)
+  TARGET_ARCH := riscv64
+  TARGET_TOOLCHAIN_PREFIX := riscv64-unknown-linux-gnu-
+  TARGET_OUT_DIR := linux_riscv64
+  LIBS := -lstdc++ -lpthread -lm -ldl -latomic
+  LDFLAGS := \
+        -Wl,--no-export-dynamic \
+        -Wl,--exclude-libs,ALL \
+        -Wl,--gc-sections \
+        -Wl,--as-needed \
+        -lrt
+endif


### PR DESCRIPTION
This PR has addition for riscv_makefile.inc
Pre-requistes:
- Install RISC-V GNU Toolchain for Linux. Refer https://github.com/riscv/riscv-gnu-toolchain
- Here we are using riscv64-unknown-linux-gnu- tools created for "linux" from above link.
The changes builds executables and static libs  in "linux_riscv64", in "gen" directory.
Tested on RISC-V HiFive Unleashed.
Test Results on RISC-V HiFive Unleashed:
$./label_image --tflite_model ./models/mobilenet_v1_1.0_224.tflite --labels labels.txt -i ./images/grace_hopper.bmp 
INFO: Loaded model ./models/mobilenet_v1_1.0_224.tflite
INFO: resolved reporter
INFO: invoked
INFO: average time: 1553.19 ms
INFO: 0.860174: 653 653:military uniform
INFO: 0.0481021: 907 907:Windsor tie
INFO: 0.00786705: 466 466:bulletproof vest
INFO: 0.00644936: 514 514:cornet, horn, trumpet, trump
INFO: 0.00608029: 543 543:drumstick
