### PR TITLE
Fixes added to remove CorrectTensorEndianness in AllocateTensors

### DIFF
--- a/tensorflow/lite/micro/micro_interpreter.cc
+++ b/tensorflow/lite/micro/micro_interpreter.cc
@@ -237,28 +237,6 @@ TfLiteStatus MicroInterpreter::AllocateTensors() {
   context_helper_.SetTfLiteEvalTensors(eval_tensors_);
   context_.tensors_size = subgraph_->tensors()->size();
 
-  // If the system is big endian then convert weights from the flatbuffer from
-  // little to big endian on startup so that it does not need to be done during
-  // inference.
-  // NOTE: This requires that the flatbuffer is held in memory which can be
-  // modified by this process.
-  if (!FLATBUFFERS_LITTLEENDIAN) {
-    for (size_t t = 0; t < subgraph_->tensors()->size(); ++t) {
-      if (auto* buffer =
-              (*model_->buffers())[subgraph_->tensors()->Get(t)->buffer()]) {
-        // If we've found a buffer, does it have any data?
-        if (auto* array = buffer->data()) {
-          // If it has any data, is the data size larger than zero?
-          if (array->size()) {
-            // Update the endianness of the corresponding eval tensor since that
-            // struct holds the buffer used at inference time.
-            CorrectTensorEndianness(&eval_tensors_[t]);
-          }
-        }
-      }
-    }
-  }
-
   // Only allow AllocatePersistentBuffer in Init stage.
   context_.AllocatePersistentBuffer = context_helper_.AllocatePersistentBuffer;
   context_.RequestScratchBufferInArena = nullptr;

--- a/tensorflow/lite/micro/micro_interpreter.cc
+++ b/tensorflow/lite/micro/micro_interpreter.cc
@@ -177,49 +177,6 @@ void MicroInterpreter::Init(tflite::Profiler* profiler) {
   initialization_status_ = kTfLiteOk;
 }
 
-void MicroInterpreter::CorrectTensorEndianness(TfLiteEvalTensor* tensorCorr) {
-  int32_t tensorSize = 1;
-  for (int d = 0; d < tensorCorr->dims->size; ++d)
-    tensorSize *= reinterpret_cast<const int32_t*>(tensorCorr->dims->data)[d];
-
-  switch (tensorCorr->type) {
-    case TfLiteType::kTfLiteFloat32:
-      CorrectTensorDataEndianness(tensorCorr->data.f, tensorSize);
-      break;
-    case TfLiteType::kTfLiteFloat16:
-      CorrectTensorDataEndianness(tensorCorr->data.f16, tensorSize);
-      break;
-    case TfLiteType::kTfLiteInt64:
-      CorrectTensorDataEndianness(tensorCorr->data.i64, tensorSize);
-      break;
-    case TfLiteType::kTfLiteUInt64:
-      CorrectTensorDataEndianness(tensorCorr->data.u64, tensorSize);
-      break;
-    case TfLiteType::kTfLiteInt32:
-      CorrectTensorDataEndianness(tensorCorr->data.i32, tensorSize);
-      break;
-    case TfLiteType::kTfLiteInt16:
-      CorrectTensorDataEndianness(tensorCorr->data.i16, tensorSize);
-      break;
-    case TfLiteType::kTfLiteComplex64:
-      CorrectTensorDataEndianness(tensorCorr->data.c64, tensorSize);
-      break;
-    case TfLiteType::kTfLiteComplex128:
-      CorrectTensorDataEndianness(tensorCorr->data.c128, tensorSize);
-      break;
-    default:
-      // Do nothing for other data types.
-      break;
-  }
-}
-
-template <class T>
-void MicroInterpreter::CorrectTensorDataEndianness(T* data, int32_t size) {
-  for (int32_t i = 0; i < size; ++i) {
-    data[i] = flatbuffers::EndianScalar(data[i]);
-  }
-}
-
 TfLiteStatus MicroInterpreter::AllocateTensors() {
   if (allocator_.StartModelAllocation(model_, op_resolver_,
                                       &node_and_registrations_,

--- a/tensorflow/lite/micro/micro_interpreter.h
+++ b/tensorflow/lite/micro/micro_interpreter.h
@@ -177,11 +177,6 @@ class MicroInterpreter {
   // error reporting during initialization.
   void Init(tflite::Profiler* profiler);
 
-  void CorrectTensorEndianness(TfLiteEvalTensor* tensorCorr);
-
-  template <class T>
-  void CorrectTensorDataEndianness(T* data, int32_t size);
-
   NodeAndRegistration* node_and_registrations_ = nullptr;
 
   const Model* model_;


### PR DESCRIPTION
This PR request is raised with respect to bug #45858 .
A previous discussion was done on a PR #45790 where it was suggested to raise a separate PR with only this fix.

Changes done:
Calling of CorrectTensorEndianness function is removed as the FlatBufferVectorToTfLiteTypeArray already converts flatbuffer tensor data from little endian to big endian during StartModelAllocation function call within AllocateTensors function.