### PR TITLE
[Intel MKL] Enabling few optimizations with native format

### DIFF
--- a/tensorflow/core/framework/common_shape_fns.cc
+++ b/tensorflow/core/framework/common_shape_fns.cc
@@ -918,6 +918,25 @@ Status Conv2DBackpropInputShape(shape_inference::InferenceContext* c) {
   return Status::OK();
 }
 
+Status Conv2DBackpropFilterWithBiasShape(shape_inference::InferenceContext* c) {
+  ShapeHandle input_shape;
+  // Fetch the data_format attribute, which may not exist.
+  string data_format;
+  Status s = c->GetAttr("data_format", &data_format);
+
+  TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 4, &input_shape));
+  if (s.ok() && data_format == "NCHW") {
+    c->set_output(1, c->Vector(c->Dim(input_shape, -3)));
+  } else {
+    c->set_output(1, c->Vector(c->Dim(input_shape, -1)));
+  }
+  ShapeHandle sh;
+  TF_RETURN_IF_ERROR(c->MakeShapeFromShapeTensor(1, &sh));
+  TF_RETURN_IF_ERROR(c->WithRank(sh, 4, &sh));
+  c->set_output(0, sh);
+  return Status::OK();
+}
+
 namespace {
 
 Status DepthwiseConv2DNativeShapeImpl(shape_inference::InferenceContext* c,

--- a/tensorflow/core/framework/common_shape_fns.h
+++ b/tensorflow/core/framework/common_shape_fns.h
@@ -144,6 +144,9 @@ Status DepthwiseConv2DNativeShape(shape_inference::InferenceContext* c);
 // Shape function for Conv2DBackpropInput.
 Status Conv2DBackpropInputShape(shape_inference::InferenceContext* c);
 
+// Shape function for Conv2DBackpropFilterWithBias.
+Status Conv2DBackpropFilterWithBiasShape(shape_inference::InferenceContext* c);
+
 // Shape function for AvgPool-like operations.
 Status AvgPoolShape(shape_inference::InferenceContext* c);
 

--- a/tensorflow/core/kernels/mkl/mkl_conv_grad_filter_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_grad_filter_ops.cc
@@ -453,7 +453,7 @@ class MklConvCustomBackpropFilterOp
       memory::dims diff_bias_dims = {};
       int64 depth = 0;
       if (bias_enabled) {
-        TensorShape obp_tf_shape = GetTfShape(context, 2);
+        TensorShape obp_tf_shape = GetTfShape(context, 2, native_format);
         depth = (this->data_format_ == FORMAT_NCHW)
                     ? obp_tf_shape.dim_size(1)
                     : obp_tf_shape.dim_size(is_conv2d ? 3 : 4);
@@ -702,7 +702,7 @@ class MklConvCustomBackpropFilterOp
     MklDnnShape bias_grad_mkl_shape;
     bias_grad_mkl_shape.SetMklTensor(false);
     AllocateOutputSetMklShape(context, 1, bias_grad_tensor, bias_grad_shape,
-                              bias_grad_mkl_shape);
+                              bias_grad_mkl_shape, native_format);
   }
 };
 
@@ -754,7 +754,13 @@ class MklConvCustomBackpropFilterOp
           .Device(DEVICE_CPU)                                            \
           .TypeConstraint<T>("T")                                        \
           .Label(mkl_op_registry::kMklNameChangeOpLabel),                \
-      MklConvCustomBackpropFilterOp<CPUDevice, T, false, false, true>);
+      MklConvCustomBackpropFilterOp<CPUDevice, T, false, false, true>);  \
+  REGISTER_KERNEL_BUILDER(                                               \
+      Name("_MklNativeConv2DBackpropFilterWithBias")                     \
+          .Device(DEVICE_CPU)                                            \
+          .TypeConstraint<T>("T")                                        \
+          .Label(mkl_op_registry::kMklNameChangeOpLabel),                \
+      MklConvCustomBackpropFilterOp<CPUDevice, T, true, false, true>);
 
 TF_CALL_float(REGISTER_MKL_FILTER_KERNELS);
 TF_CALL_bfloat16(REGISTER_MKL_FILTER_KERNELS);

--- a/tensorflow/core/ops/mkl_nn_ops.cc
+++ b/tensorflow/core/ops/mkl_nn_ops.cc
@@ -232,6 +232,27 @@ MKL version of Conv2D and BiasAdd operator. Uses oneDNN APIs to perform
 expected to invoke this operator.
 )doc");
 
+REGISTER_OP("_MklNativeConv2DBackpropFilterWithBias")
+    .Input("input: T")
+    .Input("filter_sizes: int32")
+    .Input("out_backprop: T")
+    .Output("output: T")
+    .Output("bias_grad: T")
+    .Attr("T: {bfloat16, float}")
+    .Attr("strides: list(int)")
+    .Attr("use_cudnn_on_gpu: bool = true")
+    .Attr(GetPaddingAttrString())
+    .Attr(GetConvnetDataFormatAttrString())
+    .Attr("dilations: list(int) = [1, 1, 1, 1]")
+    .SetShapeFn(shape_inference::Conv2DBackpropFilterWithBiasShape)
+    .Doc(R"doc(
+oneDNN version of Conv2DBackpropFilterWithBias. Uses oneDNN APIs to compute the
+fusion of Conv2DBackpropFilter and BiasAddGrad.
+
+*NOTE*: Do not invoke this operator directly in Python. Graph rewrite pass is
+expected to invoke this one.
+)doc");
+
 REGISTER_OP("_MklFusedDepthwiseConv2dNative")
     .Input("input: T")
     .Input("filter: T")

--- a/tensorflow/core/ops/nn_ops.cc
+++ b/tensorflow/core/ops/nn_ops.cc
@@ -1922,25 +1922,7 @@ REGISTER_OP("_MklConv2DBackpropFilterWithBias")
     .Attr(GetPaddingAttrString())
     .Attr(GetConvnetDataFormatAttrString())
     .Attr("dilations: list(int) = [1, 1, 1, 1]")
-    .SetShapeFn([](InferenceContext* c) {
-      ShapeHandle input_shape;
-      // Fetch the data_format attribute, which may not exist.
-      string data_format;
-      Status s = c->GetAttr("data_format", &data_format);
-
-      if (s.ok() && data_format == "NCHW") {
-        TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 4, &input_shape));
-        c->set_output(1, c->Vector(c->Dim(input_shape, -3)));
-      } else {
-        TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 4, &input_shape));
-        c->set_output(1, c->Vector(c->Dim(input_shape, -1)));
-      }
-      ShapeHandle sh;
-      TF_RETURN_IF_ERROR(c->MakeShapeFromShapeTensor(1, &sh));
-      TF_RETURN_IF_ERROR(c->WithRank(sh, 4, &sh));
-      c->set_output(0, sh);
-      return Status::OK();
-    })
+    .SetShapeFn(shape_inference::Conv2DBackpropFilterWithBiasShape)
     .Doc(R"doc(
 MKL version of Conv2DBackpropFilterWithBias. Uses MKL DNN APIs to compute the
 gradients of convolution with respect to the filter.


### PR DESCRIPTION
This PR enables couple of optimizations that were exist with internal format but not available with native format:
Conv2DBackpropFilterWithBias Fusion.
Removal of redundant Transpose op.