### PR TITLE
Fix audio bugs in the Arduino micro_speech example

### DIFF
--- a/tensorflow/lite/micro/examples/micro_speech/arduino/audio_provider.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/arduino/audio_provider.cc
@@ -62,7 +62,7 @@ void CaptureSamples() {
   const int32_t start_sample_offset =
       g_latest_audio_timestamp * (kAudioSampleFrequency / 1000);
   // Determine the index of this sample in our ring buffer
-  const int capture_index = (start_sample_offset * sizeof(int16_t)) % kAudioCaptureBufferSize;
+  const int capture_index = start_sample_offset % kAudioCaptureBufferSize;
   // Read the data to the correct place in our buffer
   PDM.read(g_audio_capture_buffer + capture_index, DEFAULT_PDM_BUFFER_SIZE);
   // This is how we let the outside world know that new audio data has arrived.

--- a/tensorflow/lite/micro/examples/micro_speech/arduino/audio_provider.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/arduino/audio_provider.cc
@@ -53,7 +53,7 @@ volatile int32_t g_latest_audio_timestamp = 0;
 
 void CaptureSamples() {
   // This is how many bytes of new data we have each time this is called
-  const int number_of_samples = DEFAULT_PDM_BUFFER_SIZE;
+  const int number_of_samples = DEFAULT_PDM_BUFFER_SIZE / sizeof(int16_t);
   // Calculate what timestamp the last audio sample represents
   const int32_t time_in_ms =
       g_latest_audio_timestamp +
@@ -62,7 +62,7 @@ void CaptureSamples() {
   const int32_t start_sample_offset =
       g_latest_audio_timestamp * (kAudioSampleFrequency / 1000);
   // Determine the index of this sample in our ring buffer
-  const int capture_index = start_sample_offset % kAudioCaptureBufferSize;
+  const int capture_index = (start_sample_offset * sizeof(int16_t)) % kAudioCaptureBufferSize;
   // Read the data to the correct place in our buffer
   PDM.read(g_audio_capture_buffer + capture_index, DEFAULT_PDM_BUFFER_SIZE);
   // This is how we let the outside world know that new audio data has arrived.

--- a/tensorflow/lite/micro/examples/micro_speech/feature_provider.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/feature_provider.cc
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include <algorithm>
+
 #include "tensorflow/lite/micro/examples/micro_speech/feature_provider.h"
 
 #include "tensorflow/lite/micro/examples/micro_speech/audio_provider.h"
@@ -92,12 +94,11 @@ TfLiteStatus FeatureProvider::PopulateFeatureData(
   if (slices_needed > 0) {
     for (int new_slice = slices_to_keep; new_slice < kFeatureSliceCount;
          ++new_slice) {
-      const int new_step = (current_step - kFeatureSliceCount + 1) + new_slice;
+      const int new_step = std::max(0, (current_step - kFeatureSliceCount + 1) + new_slice);
       const int32_t slice_start_ms = (new_step * kFeatureSliceStrideMs);
       int16_t* audio_samples = nullptr;
       int audio_samples_size = 0;
-      // TODO(petewarden): Fix bug that leads to non-zero slice_start_ms
-      GetAudioSamples(error_reporter, (slice_start_ms > 0 ? slice_start_ms : 0),
+      GetAudioSamples(error_reporter, slice_start_ms,
                       kFeatureSliceDurationMs, &audio_samples_size,
                       &audio_samples);
       if (audio_samples_size < kMaxAudioSampleSize) {

--- a/tensorflow/lite/micro/examples/micro_speech/feature_provider.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/feature_provider.cc
@@ -43,8 +43,8 @@ TfLiteStatus FeatureProvider::PopulateFeatureData(
 
   // Quantize the time into steps as long as each window stride, so we can
   // figure out which audio data we need to fetch.
-  const int last_step = (last_time_in_ms / kFeatureSliceStrideMs);
-  const int current_step = (time_in_ms / kFeatureSliceStrideMs);
+  const int last_step = (last_time_in_ms - kFeatureSliceDurationMs) / kFeatureSliceStrideMs;
+  const int current_step = (time_in_ms - kFeatureSliceDurationMs) / kFeatureSliceStrideMs;
 
   int slices_needed = current_step - last_step;
   // If this is the first call, make sure we don't use any cached information.


### PR DESCRIPTION
In the Arduino audio_provider, the LatestAudioTimestamp increments twice as fast as real-time because the audio code confuses bytes and samples (one sample is two bytes).

Related to this, the feature_provider sometimes attempts to read too far ahead from the audio capture buffer.
