### PR TITLE
Fixed build issue on windows: realpath command not found

### DIFF
--- a/third_party/remote_config/common.bzl
+++ b/third_party/remote_config/common.bzl
@@ -274,7 +274,7 @@ def realpath(repository_ctx, path, bash_bin = None):
     if bash_bin == None:
         bash_bin = get_bash_bin(repository_ctx)
 
-    return execute(repository_ctx, [bash_bin, "-c", "realpath \"%s\"" % path]).stdout.strip()
+    return execute(repository_ctx, [bash_bin, "-cl", "realpath \"%s\"" % path]).stdout.strip()
 
 def err_out(result):
     """Returns stderr if set, else stdout.


### PR DESCRIPTION
When I build on windows with CUDA enabled I receive the following error immediatly when starting building:
```
3>CUSTOMBUILD : error : no such package '@local_config_cuda//cuda': Traceback (most recent call last):
3>	File "C:/workspace/fast/build_release/external/tensorflow/src/tensorflow_download/third_party/gpus/cuda_configure.bzl", line 1369
3>		_create_local_cuda_repository(<1 more arguments>)
3>	File "C:/workspace/fast/build_release/external/tensorflow/src/tensorflow_download/third_party/gpus/cuda_configure.bzl", line 1213, in _create_local_cuda_repository
3>		to_list_of_strings(<1 more arguments>)
3>	File "C:/workspace/fast/build_release/external/tensorflow/src/tensorflow_download/third_party/gpus/cuda_configure.bzl", line 1214, in to_list_of_strings
3>		_cuda_include_path(<2 more arguments>)
3>	File "C:/workspace/fast/build_release/external/tensorflow/src/tensorflow_download/third_party/gpus/cuda_configure.bzl", line 363, in _cuda_include_path
3>		inc_entries.append(<1 more arguments>)
3>	File "C:/workspace/fast/build_release/external/tensorflow/src/tensorflow_download/third_party/gpus/cuda_configure.bzl", line 363, in inc_entries.append
3>		realpath(repository_ctx, <1 more arguments>)
3>	File "C:/workspace/fast/build_release/external/tensorflow/src/tensorflow_download/third_party/remote_config/common.bzl", line 268, in realpath
3>		execute(repository_ctx, <1 more arguments>)
3>	File "C:/workspace/fast/build_release/external/tensorflow/src/tensorflow_download/third_party/remote_config/common.bzl", line 208, in execute
3>		fail(<1 more arguments>)
3>Repository command failed
3>/usr/bin/bash: realpath: command not found
```

I found a post on msys2's gitter chat commenting the same error, but fixed it with just adding the -l option to bash when running the command. I testet this with msys from the terminal:
```
PS C:\dev_tools\msys64\usr\bin> .\bash.exe -c realpath
/usr/bin/bash: realpath: command not found
PS C:\dev_tools\msys64\usr\bin> .\bash.exe -cl realpath
realpath: missing operand
Try 'realpath --help' for more information.
```
Thus adding the -l option helps, why it helps I don't know. From the manual (https://www.gnu.org/software/bash/manual/html_node/Invoking-Bash.html) it says:

> -l Make this shell act as if it had been directly invoked by login. When the shell is interactive, this is equivalent to starting a login shell with ‘exec -l bash’. When the shell is not interactive, the login shell startup files will be executed. ‘exec bash -l’ or ‘exec bash --login’ will replace the current shell with a Bash login shell. See Bash Startup Files, for a description of the special behavior of a login shell.


This pull request just adds this -l option to the realpath command in third_party/remote_config/common.bzl

Some system info:
* Windows 10
* Python 3.8 64 bit
* MSVC 16.8.4
* Bazel 3.1.0
* CUDA 10.1
* msys2 64 bit 20201109