### PR TITLE
Value of num_replicas parameter now propagates.

### DIFF
--- a/tensorflow/python/eager/benchmarks/resnet50/resnet50_test.py
+++ b/tensorflow/python/eager/benchmarks/resnet50/resnet50_test.py
@@ -267,7 +267,7 @@ class ResNet50Benchmarks(tf.test.Benchmark):
   def _report(self, label, start, num_iters, device, batch_size, data_format,
               num_replicas=1):
     resnet50_test_util.report(self, label, start, num_iters, device,
-                              batch_size, data_format, num_replicas=1)
+                              batch_size, data_format, num_replicas)
 
   def _train_batch_sizes(self):
     """Choose batch sizes based on GPU capability."""


### PR DESCRIPTION
The value of `num_replicas` parameter of the `_report` function in `resnet50_test.py` was not passed to the `report` function in `resnet50_test_util.py`, as a relevant parameter (with the same name) was assigned a value in the call. 

