### PR TITLE
Support OpenCL 1.1 properly by forcing buffer usage in kernels that don't check .SupportsImageBuffer()

### DIFF
--- a/tensorflow/lite/delegates/gpu/common/tasks/depthwise_conv.cc
+++ b/tensorflow/lite/delegates/gpu/common/tasks/depthwise_conv.cc
@@ -236,7 +236,7 @@ std::string GenerateDepthwiseConvolutionCode(
 GPUOperation CreateDepthwiseConvolution2D(
     const GpuInfo& gpu_info, const OperationDef& definition,
     const DepthwiseConvolution2DAttributes& attr) {
-  bool weights_are_buffer = gpu_info.IsMali();
+  bool weights_are_buffer = !gpu_info.SupportsImageBuffer() || gpu_info.IsMali();
   GPUOperation op(definition);
   op.args_.AddInt("kernel_size_x", attr.weights.shape.w);
   op.args_.AddInt("stride_x", attr.strides.w);

--- a/tensorflow/lite/delegates/gpu/common/tasks/depthwise_conv_3x3.cc
+++ b/tensorflow/lite/delegates/gpu/common/tasks/depthwise_conv_3x3.cc
@@ -312,7 +312,7 @@ bool IsDepthwiseConv3x3Supported(const DepthwiseConvolution2DAttributes& attr) {
 DepthwiseConv3x3 CreateDepthwiseConv3x3(
     const GpuInfo& gpu_info, const OperationDef& definition,
     const DepthwiseConvolution2DAttributes& attr) {
-  bool weights_are_buffer = gpu_info.IsPowerVR() || gpu_info.IsMali();
+  bool weights_are_buffer = !gpu_info.SupportsImageBuffer() || gpu_info.IsPowerVR() || gpu_info.IsMali();
   bool local_mem_uploads = weights_are_buffer && gpu_info.IsPowerVR();
   DepthwiseConv3x3 result(definition, weights_are_buffer, local_mem_uploads,
                           gpu_info);

--- a/tensorflow/lite/delegates/gpu/common/tasks/fully_connected.cc
+++ b/tensorflow/lite/delegates/gpu/common/tasks/fully_connected.cc
@@ -155,7 +155,7 @@ FullyConnected CreateFullyConnected(const GpuInfo& gpu_info,
   result.UploadWeights(attr.weights, UseBufferForWeights(gpu_info));
 
   TensorLinearDescriptor desc;
-  desc.storage_type = LinearStorageType::TEXTURE_2D;
+  desc.storage_type = gpu_info.SupportsImageBuffer() ? LinearStorageType::TEXTURE_2D : LinearStorageType::BUFFER;
   desc.element_type = definition.GetDataType();
   desc.UploadLinearData(attr.bias);
   result.args_.AddObject(


### PR DESCRIPTION
On an OpenCL device (AMD G-series SOC with Mesa drivers) with 1.1 support we can meaningfully run the opencl gpu delegate. However given the lack of Image support some kernels need to force buffer usage instead which isn't always done.