### PR TITLE
Extract a function for parsing op SPACE_TO_DEPTH

### DIFF
--- a/tensorflow/lite/core/api/flatbuffer_conversions.cc
+++ b/tensorflow/lite/core/api/flatbuffer_conversions.cc
@@ -378,6 +378,10 @@ TfLiteStatus ParseOpDataTfLite(const Operator* op, BuiltinOperator op_type,
       return ParseSoftmax(op, error_reporter, allocator, builtin_data);
     }
 
+    case BuiltinOperator_SPACE_TO_DEPTH: {
+      return ParseSpaceToDepth(op, error_reporter, allocator, builtin_data);
+    }
+
     case BuiltinOperator_SPLIT: {
       return ParseSplit(op, error_reporter, allocator, builtin_data);
     }
@@ -590,10 +594,6 @@ TfLiteStatus ParseOpDataTfLite(const Operator* op, BuiltinOperator op_type,
       }
       *builtin_data = params.release();
       return kTfLiteOk;
-    }
-
-    case BuiltinOperator_SPACE_TO_DEPTH: {
-      return ParseSpaceToDepth(op, error_reporter, allocator, builtin_data);
     }
 
     case BuiltinOperator_DEPTH_TO_SPACE: {

--- a/tensorflow/lite/core/api/flatbuffer_conversions.h
+++ b/tensorflow/lite/core/api/flatbuffer_conversions.h
@@ -243,6 +243,11 @@ TfLiteStatus ParseSin(const Operator* op, ErrorReporter* error_reporter,
 TfLiteStatus ParseSoftmax(const Operator* op, ErrorReporter* error_reporter,
                           BuiltinDataAllocator* allocator, void** builtin_data);
 
+TfLiteStatus ParseSpaceToDepth(const Operator* op,
+                               ErrorReporter* error_reporter,
+                               BuiltinDataAllocator* allocator,
+                               void** builtin_data);
+
 TfLiteStatus ParseSplit(const Operator* op, ErrorReporter* error_reporter,
                         BuiltinDataAllocator* allocator, void** builtin_data);
 


### PR DESCRIPTION
Extract the parsing of op parameters from the flatbuffer out of a
switch statement case, into a standalone function which can be
called by the micro op resolver.

This PR is part of the work to port operator SPACE_TO_DEPTH
from lite to micro, as tracked in issue #45824.