### PR TITLE
Remove extraneous expand_nonconcat_dims from doc string of tf.sparse.concat

### DIFF
--- a/tensorflow/python/ops/sparse_ops.py
+++ b/tensorflow/python/ops/sparse_ops.py
@@ -429,7 +429,8 @@ def sparse_concat_v2(axis, sp_inputs, expand_nonconcat_dims=False, name=None):  
 
 
 sparse_concat_v2.__doc__ = sparse_concat.__doc__.replace(
-    "    concat_dim: The old (deprecated) name for axis.\n", "")
+    "    concat_dim: The old (deprecated) name for axis.\n", "").replace(
+        "    expand_nonconcat_dims: alias for expand_nonconcat_dim\n", "")
 
 
 @tf_export(v1=["sparse.add", "sparse_add"])


### PR DESCRIPTION
This PR tries to address the issue raised in #45778 where the doc string
of  tf.sparse.concat has an extraneous expand_nonconcat_dims arg.
The expand_nonconcat_dims was the leftover of tf.v1.sparse.concat.

This PR fixes #45778.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>