### PR TITLE
Propagate optional argv to benchmarks_main

### DIFF
--- a/tensorflow/python/platform/googletest.py
+++ b/tensorflow/python/platform/googletest.py
@@ -63,7 +63,7 @@ def main(argv=None):  # pylint: disable=function-redefined
     if args is None:
       args = sys.argv
     return app.run(main=g_main, argv=args)
-  benchmark.benchmarks_main(true_main=main_wrapper)
+  benchmark.benchmarks_main(true_main=main_wrapper, argv=argv)
 
 
 def GetTempDir():


### PR DESCRIPTION
Allows the following:

```python
import tensorflow as tf

class BasicBenchmark(tf.test.Benchmark):
  def benchmark_foo(self):
    print("Ran foo")
 
if __name__ == '__main__':
  tf.test.main([__file__, '--benchmarks=.*'])