### PR TITLE
fix static path for find_cuda_config.py script, so tensorflow with cuda can be installed outside master directory.

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1236,14 +1236,16 @@ def validate_cuda_config(environ_cp):
     if environ_cp.get('TF_NCCL_VERSION', None):
       cuda_libraries.append('nccl')
 
-  find_cuda_path = 'third_party/gpus/find_cuda_config.py'
+  find_cuda_path = Path('third_party/gpus/find_cuda_config.py')
   if not Path(find_cuda_path).is_file():
-      find_cuda_path = Path().glob('**/third_party/gpus/find_cuda_config.py')
+    find_cuda_path = Path('.').glob('**/' + str(find_cuda_path))
+    try:
       find_cuda_path = find_cuda_path.__next__()
-      assert find_cuda_path, "Can't find 'find_cuda_config.py' script"
+    except StopIteration:
+      raise FileNotFoundError("Can't find 'find_cuda_config.py' script inside working directory")
 
   proc = subprocess.Popen(
-      [environ_cp['PYTHON_BIN_PATH'], find_cuda_path] +
+      [environ_cp['PYTHON_BIN_PATH'], str(find_cuda_path)] +
       cuda_libraries,
       stdout=subprocess.PIPE,
       env=maybe_encode_env(environ_cp))

--- a/configure.py
+++ b/configure.py
@@ -17,6 +17,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from pathlib import Path
 
 import argparse
 import errno
@@ -1235,8 +1236,14 @@ def validate_cuda_config(environ_cp):
     if environ_cp.get('TF_NCCL_VERSION', None):
       cuda_libraries.append('nccl')
 
+  find_cuda_path = 'third_party/gpus/find_cuda_config.py'
+  if not Path(find_cuda_path).is_file():
+      find_cuda_path = Path().glob('**/third_party/gpus/find_cuda_config.py')
+      find_cuda_path = find_cuda_path.__next__()
+      assert find_cuda_path, "Can't find 'find_cuda_config.py' script"
+
   proc = subprocess.Popen(
-      [environ_cp['PYTHON_BIN_PATH'], 'third_party/gpus/find_cuda_config.py'] +
+      [environ_cp['PYTHON_BIN_PATH'], find_cuda_path] +
       cuda_libraries,
       stdout=subprocess.PIPE,
       env=maybe_encode_env(environ_cp))


### PR DESCRIPTION
Master Tensorflow repo is getting used in another tensorflow related projects ( for example [s4tf](https://github.com/tensorflow/swift-apis/blob/main/Documentation/Development.md) )

As building in other project are done from upper directory static path for find_cuda_config.py was breaking installation this pull request fix that.