### PR TITLE
Newline after printing ConfigError in configuration

### DIFF
--- a/third_party/gpus/find_cuda_config.py
+++ b/third_party/gpus/find_cuda_config.py
@@ -645,7 +645,7 @@ def main():
     for key, value in sorted(find_cuda_config().items()):
       print("%s: %s" % (key, value))
   except ConfigError as e:
-    sys.stderr.write(str(e))
+    sys.stderr.write(str(e) + '\n')
     sys.exit(1)
 
 


### PR DESCRIPTION
Fix error message printed on configuration exception to have a newline suffix
in CUDA configuration, without this the two lines run into each other.

For some reason I didn't investigate further `print(e, file=sys.stderr)` didn't
display output at all in the configuration process (print monkeypatched?),
so I just tacked a newline on. Mostly just didn't want to leave the way it was
after I had seen it happen on the console. :-)

Before:

```
Please specify the comma-separated list of base paths to look for CUDA libraries and headers. [Leave empty to use the default]:

Inconsistent CUDA toolkit path: /usr vs /usr/libAsking for detailed CUDA configuration...
```

After:

```
Please specify the comma-separated list of base paths to look for CUDA libraries and headers. [Leave empty to use the default]:

Inconsistent CUDA toolkit path: /usr vs /usr/lib
Asking for detailed CUDA configuration...
```