### PR TITLE
Only use pthread_getname on glibc and FreeBSD

### DIFF
--- a/tensorflow/core/platform/default/env.cc
+++ b/tensorflow/core/platform/default/env.cc
@@ -149,9 +149,7 @@ class PosixEnv : public Env {
         return true;
       }
     }
-#if defined(__ANDROID__) || defined(__EMSCRIPTEN__)
-    return false;
-#else
+#if defined(__GLIBC__) || defined(__FreeBSD__)
     char buf[100];
 #ifdef __FreeBSD__
     int res = 0;
@@ -164,6 +162,8 @@ class PosixEnv : public Env {
     }
     *name = buf;
     return true;
+#else
+    return false;
 #endif
   }
 


### PR DESCRIPTION
glibc and FreeBSD are actually the odd ones out and no other platform
supports pthread_getname or equivelant (from what I can find), so let's check for those instead of checking for platforms that don't support it.

This is required to get Tensorflow compiling on Musl libc.

https://linux.die.net/man/3/pthread_getname_np