### PR TITLE
Fix bool Where accumulation bug

### DIFF
--- a/tensorflow/core/kernels/where_op.cc
+++ b/tensorflow/core/kernels/where_op.cc
@@ -66,7 +66,7 @@ int64 CountAccumulator(const T* begin, const T* end) {
 
 template <>
 int64 CountAccumulator<bool>(const bool* begin, const bool* end) {
-  return std::accumulate(begin, end, 0LL);
+  return end - begin - std::count_if(begin, end, [](bool value) { return !value; });
 }
 
 }  // namespace

--- a/tensorflow/python/kernel_tests/where_op_test.py
+++ b/tensorflow/python/kernel_tests/where_op_test.py
@@ -267,6 +267,11 @@ class WhereOpTest(test.TestCase):
       tf_val = array_ops.where(c_vec, x * x, -x).eval()
     self.assertAllEqual(tf_val, np_val)
 
+  def testV2BoolFromBuffer(self):
+    x = np.frombuffer(b'\x00\x01\x02\x01', dtype=np.bool)
+    truth = np.where(np.abs(x) > 0)  # Tuples of indices by axis.
+    truth = np.vstack(truth).T  # Convert to [num_true, indices].
+    self._testWhere(x, truth, None, array_ops.where_v2)
 
 class WhereBenchmark(test.Benchmark):
 


### PR DESCRIPTION
Contains fix for 'CountAccumulator<bool>' function.
Current version counted underlying byte values instead of logical state, which could lead to "Race condition between counting...".
For example: if underlying input tensor buffer contained values [0, 1, 2, 1] and was marked as boolean, then 'CountAccumulator<bool>' would return 4 elements (as it counted the third one as two elements, 0+1+2+1=4). Such edge case can be encountered in conjuction with custom ops.
