### PR TITLE
[tf.data service] test zipped datasets with different processing modes

### DIFF
--- a/tensorflow/python/data/experimental/kernel_tests/data_service_ops_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/data_service_ops_test.py
@@ -556,10 +556,7 @@ class DataServiceOpsTest(data_service_test_base.TestBase,
     ds = dataset_ops.Dataset.zip((ds1, ds2))
     with self.assertRaisesRegex(errors.FailedPreconditionError,
                                 "but there is already an existing job"):
-
-      self.assertDatasetProduces(
-          ds, list(zip(range(num_elements), range(num_elements))),
-          assert_items_equal=True)
+      self.getDatasetOutput(ds)
 
   @combinations.generate(test_base.eager_only_combinations())
   def testFromDatasetId(self):

--- a/tensorflow/python/data/experimental/kernel_tests/data_service_ops_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/data_service_ops_test.py
@@ -529,7 +529,7 @@ class DataServiceOpsTest(data_service_test_base.TestBase,
               processing_mode="invalid", service="grpc://localhost:5000"))
 
   @combinations.generate(test_base.eager_only_combinations())
-  def testZipMultipleProcessingModes(self):
+  def testZipDatasetsWithDifferentProcessingModes(self):
     cluster = self.create_cluster(num_workers=2)
     num_elements = 100
     ds1 = dataset_ops.Dataset.range(num_elements)

--- a/tensorflow/python/data/experimental/kernel_tests/data_service_ops_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/data_service_ops_test.py
@@ -529,7 +529,7 @@ class DataServiceOpsTest(data_service_test_base.TestBase,
               processing_mode="invalid", service="grpc://localhost:5000"))
 
   @combinations.generate(test_base.eager_only_combinations())
-  def testZipDatasetsWithDifferentProcessingModes(self):
+  def testZipDifferentProcessingModesDatasets(self):
     cluster = self.create_cluster(num_workers=2)
     num_elements = 100
     ds1 = dataset_ops.Dataset.range(num_elements)
@@ -538,6 +538,21 @@ class DataServiceOpsTest(data_service_test_base.TestBase,
     ds2 = dataset_ops.Dataset.range(num_elements)
     ds2 = self.make_distributed_dataset(
         ds2, cluster, processing_mode="parallel_epochs")
+    ds = dataset_ops.Dataset.zip(ds1, ds2)
+    self.assertDatasetProduces(
+        ds, list(zip(range(num_elements), range(num_elements))),
+        assert_items_equal=True)
+
+  @combinations.generate(test_base.eager_only_combinations())
+  def testZipDifferentProcessingModesDatasetsSharedJobName(self):
+    cluster = self.create_cluster(num_workers=2)
+    num_elements = 100
+    ds1 = dataset_ops.Dataset.range(num_elements)
+    ds1 = self.make_distributed_dataset(
+        ds1, cluster, processing_mode="distributed_epoch", job_name="job_name")
+    ds2 = dataset_ops.Dataset.range(num_elements)
+    ds2 = self.make_distributed_dataset(
+        ds2, cluster, processing_mode="parallel_epochs", job_name="job_name")
     ds = dataset_ops.Dataset.zip(ds1, ds2)
     self.assertDatasetProduces(
         ds, list(zip(range(num_elements), range(num_elements))),


### PR DESCRIPTION
This PR extends the `tf.data service` tests by testing the functionality on zipped datasets which have been distributed using `parallel_epochs` and `distributed_epoch` processing modes.