### PR TITLE
micro: in CONTRIBUTING.md, fix path to test script

### DIFF
--- a/tensorflow/lite/micro/CONTRIBUTING.md
+++ b/tensorflow/lite/micro/CONTRIBUTING.md
@@ -204,7 +204,7 @@ to determine if the requested feature aligns with the TFLM roadmap.
 1.  Run all the tests for x86, and any other platform that you are modifying.
 
     ```
-    tensorflow/lite/micro/tools/make/tools/ci_build/test_x86.sh
+    tensorflow/lite/micro/tools/ci_build/test_x86.sh
     ```
 
     Please check the READMEs in the optimized kernel directories for specific


### PR DESCRIPTION
Fix path to test script in CONTRIBUTING.md.

Fixes #46148.