### PR TITLE
Rewrite 1D dilated convolution

### DIFF
--- a/tensorflow/compiler/mlir/lite/transforms/dilated_conv.h
+++ b/tensorflow/compiler/mlir/lite/transforms/dilated_conv.h
@@ -70,7 +70,7 @@ class ConvertTFDilatedConvOp : public OpRewritePattern<Conv2dOpTy> {
 
   // Extract the dilation factor from `block_shape` and pack it in an ArrayAttr.
   llvm::Optional<ArrayAttr> ExtractDilationsAttrFromBlockShape(
-      Value stb_block_shape, Value bts_block_shape,
+      Value stb_block_shape, Value bts_block_shape, int64_t expand_axis,
       PatternRewriter& rewriter) const;
 
  public:
@@ -111,7 +111,7 @@ LogicalResult ConvertTFDilatedConvOp<Conv2dOpTy>::matchAndRewrite(
 
   TF::ExpandDimsOp expand_op;
   TF::SqueezeOp squeeze_op;
-  int64_t expand_axis;
+  int64_t expand_axis = -1;
   // Expand + Squeeze op.
   if (llvm::isa<TF::ExpandDimsOp>(prev_op)) {
     if (!llvm::isa<TF::SqueezeOp>(next_op)) {
@@ -127,13 +127,26 @@ LogicalResult ConvertTFDilatedConvOp<Conv2dOpTy>::matchAndRewrite(
       expand_axis =
           (*const_op.value().cast<DenseElementsAttr>().getIntValues().begin())
               .getSExtValue();
+      // Canonicalize axis. Some TF python functions, such as
+      // `tf.nn.convolution`, use negative axis.
+      if (expand_axis < 0) {
+        // Always expand 3D input to 4D input.
+        expand_axis += 4;
+      }
     } else {
       return failure();
     }
     // Make sure that the `squeeze_dims` is equal to `expand_axis`.
     auto squeeze_dims = squeeze_op.squeeze_dims();
-    if (squeeze_dims.size() != 1 ||
-        squeeze_dims[0].cast<IntegerAttr>().getInt() != expand_axis) {
+    if (squeeze_dims.size() != 1) {
+      return failure();
+    }
+    int64_t squeeze_axis = squeeze_dims[0].cast<IntegerAttr>().getInt();
+    if (squeeze_axis < 0) {
+      // Always squeeze 4D input to 3D input.
+      squeeze_axis += 4;
+    }
+    if (squeeze_axis != expand_axis) {
       return failure();
     }
 
@@ -183,7 +196,7 @@ LogicalResult ConvertTFDilatedConvOp<Conv2dOpTy>::matchAndRewrite(
   }
 
   llvm::Optional<ArrayAttr> dilations_attr = ExtractDilationsAttrFromBlockShape(
-      stb_op.block_shape(), bts_op.block_shape(), rewriter);
+      stb_op.block_shape(), bts_op.block_shape(), expand_axis, rewriter);
   if (!dilations_attr.hasValue()) return failure();
 
   if (expand_op) {
@@ -259,13 +272,21 @@ LogicalResult ConvertTFDilatedConvOp<Conv2dOpTy>::matchAndRewrite(
     auto expand_result_type = RankedTensorType::get(
         expand_shape, getElementTypeOrSelf(stb_op.input()));
     expand_op.getResult().setType(expand_result_type);
-    op.getResult().setType(expand_result_type);
+
+    // Set the last dimension to output channels.
+    SmallVector<int64_t, 4> conv_result_shape(expand_shape);
+    conv_result_shape.back() = result_ty.getShape().back();
+    auto conv_result_type = RankedTensorType::get(
+        conv_result_shape, getElementTypeOrSelf(stb_op.input()));
+    op.getResult().setType(conv_result_type);
 
     squeeze_op.getResult().setType(bts_op.output().getType());
 
     // Connect `biasadd_op` with the output of `squeeze_op`.
-    biasadd_op.setOperand(0, squeeze_op.output());
-    biasadd_op.output().setType(squeeze_op.output().getType());
+    if (biasadd_op) {
+      biasadd_op.setOperand(0, squeeze_op.output());
+      biasadd_op.output().setType(squeeze_op.output().getType());
+    }
   } else {
     if (biasadd_op) biasadd_op.setOperand(0, op.output());
     op.setOperand(0, stb_op.input());
@@ -283,7 +304,7 @@ LogicalResult ConvertTFDilatedConvOp<Conv2dOpTy>::matchAndRewrite(
 template <typename Conv2dOpTy>
 llvm::Optional<ArrayAttr>
 ConvertTFDilatedConvOp<Conv2dOpTy>::ExtractDilationsAttrFromBlockShape(
-    Value stb_block_shape, Value bts_block_shape,
+    Value stb_block_shape, Value bts_block_shape, int64_t expand_axis,
     PatternRewriter& rewriter) const {
   ElementsAttr stb_bs_attr, bts_bs_attr;
   if (!matchPattern(stb_block_shape, m_Constant(&stb_bs_attr)) ||
@@ -297,12 +318,31 @@ ConvertTFDilatedConvOp<Conv2dOpTy>::ExtractDilationsAttrFromBlockShape(
     if (stb_bs_attr.getValue({i}) != bts_bs_attr.getValue({i})) return {};
   }
 
+  int dilation_h_factor = -1, dilation_w_factor = -1;
   // Set dilation factor.
-  if (stb_bs_attr.getNumElements() < 2) return {};
-  int dilation_h_factor =
-      stb_bs_attr.getValue({0}).cast<IntegerAttr>().getInt();
-  int dilation_w_factor =
-      stb_bs_attr.getValue({1}).cast<IntegerAttr>().getInt();
+  if (stb_bs_attr.getNumElements() >= 2) {
+    dilation_h_factor = stb_bs_attr.getValue({0}).cast<IntegerAttr>().getInt();
+    dilation_w_factor = stb_bs_attr.getValue({1}).cast<IntegerAttr>().getInt();
+  } else if (stb_bs_attr.getNumElements() == 1) {
+    // For 1d conv, `tf.nn.convolution` expands NWC to NHWC format after
+    // `SpaceToBatchND`. Therefore, `block_shape` of `stb_op` only has one
+    // dilation factor of W dim, and dilation factor of H dim is set to 1.
+    if (expand_axis == 1) {
+      // NWC -> NHWC
+      dilation_h_factor = 1;
+      dilation_w_factor =
+          stb_bs_attr.getValue({0}).cast<IntegerAttr>().getInt();
+    } else if (expand_axis == 2) {
+      // NHC -> NHWC
+      dilation_h_factor =
+          stb_bs_attr.getValue({0}).cast<IntegerAttr>().getInt();
+      dilation_w_factor = 1;
+    }
+  }
+
+  if (dilation_h_factor == -1 || dilation_w_factor == -1) {
+    return {};
+  }
 
   return rewriter.getI64ArrayAttr({1, dilation_h_factor, dilation_w_factor, 1});
 }


### PR DESCRIPTION
Fixes https://github.com/tensorflow/tensorflow/issues/38638. The pattern is obtained from 

```python
layer = tf.keras.layers.Conv1D(8, 5, 1, dilation_rate=2, padding="SAME", use_bias=False)

@tf.function(input_signature=(tf.TensorSpec(shape=(1, 128, 3)),))
def my_func(x):
  return layer(x)
```

Hi @haozha111, can you take a look at this when time allows? Thank you!