### PR TITLE
[tf.data] support ~/ alias for home dir in tf.data.Dataset.list_files

### DIFF
--- a/tensorflow/python/data/kernel_tests/list_files_test.py
+++ b/tensorflow/python/data/kernel_tests/list_files_test.py
@@ -252,7 +252,7 @@ class ListFilesTest(test_base.DatasetTestBase, parameterized.TestCase):
     self._touchTempHomeFiles(filenames)
     dir_name = self.tmp_home_dir.split("/")[-1]
     dataset = dataset_ops.Dataset.list_files(
-        [pat for pat in ['~/{}/*.pyc'.format(dir_name), '~/{}/*.py'.format(dir_name)]])
+        ['~/{}/*.pyc'.format(dir_name), '~/{}/*.py'.format(dir_name)])
     self.assertDatasetProduces(
         dataset,
         expected_output=[

--- a/tensorflow/python/data/kernel_tests/list_files_test.py
+++ b/tensorflow/python/data/kernel_tests/list_files_test.py
@@ -260,7 +260,8 @@ class ListFilesTest(test_base.DatasetTestBase, parameterized.TestCase):
         assert_items_equal=True)
 
     os.environ['HOME'] = original_home
-    os.environ['USERPROFILE'] = original_userprofile
+    if original_userprofile:
+      os.environ['USERPROFILE'] = original_userprofile
 
 
 if __name__ == '__main__':

--- a/tensorflow/python/data/kernel_tests/list_files_test.py
+++ b/tensorflow/python/data/kernel_tests/list_files_test.py
@@ -237,8 +237,8 @@ class ListFilesTest(test_base.DatasetTestBase, parameterized.TestCase):
   @combinations.generate(test_base.default_test_combinations())
   def testMultipleHomeDirPatternsAsTensor(self):
 
-    original_home = os.environ['HOME']
-    original_userprofile = os.environ['USERPROFILE']
+    original_home = os.getenv('HOME')
+    original_userprofile = os.getenv('USERPROFILE')
     os.environ['HOME'] = self.tmp_dir
     os.environ['USERPROFILE'] = self.tmp_dir
 

--- a/tensorflow/python/data/kernel_tests/list_files_test.py
+++ b/tensorflow/python/data/kernel_tests/list_files_test.py
@@ -259,7 +259,8 @@ class ListFilesTest(test_base.DatasetTestBase, parameterized.TestCase):
         ],
         assert_items_equal=True)
 
-    os.environ['HOME'] = original_home
+    if original_home:
+      os.environ['HOME'] = original_home
     if original_userprofile:
       os.environ['USERPROFILE'] = original_userprofile
 

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import os
 import abc
 import functools
 import sys
@@ -1209,6 +1210,19 @@ class DatasetV2(collections_abc.Iterable, tracking_base.Trackable,
     with ops.name_scope("list_files"):
       if shuffle is None:
         shuffle = True
+      if isinstance(file_pattern, str):
+        if file_pattern.startswith("~"):
+          file_pattern = file_pattern.replace("~", os.path.expanduser("~"))
+      if isinstance(file_pattern, list):
+        tmp_pattern = []
+        for pattern in iter(file_pattern):
+          if pattern.startswith("~"):
+            pattern = pattern.replace("~", os.path.expanduser("~"))
+            tmp_pattern.append(pattern)
+          else:
+            tmp_pattern.append(pattern)
+        file_pattern = tmp_pattern
+        del tmp_pattern
       file_pattern = ops.convert_to_tensor(
           file_pattern, dtype=dtypes.string, name="file_pattern")
       matching_files = gen_io_ops.matching_files(file_pattern)


### PR DESCRIPTION
This PR addresses the issue: https://github.com/tensorflow/tensorflow/issues/44264 by:
- Adding support to handle `~/` alias for home dir in file paths while using `tf.data.Dataset.list_files` API.
- Adding a test case to validate the functionality.
