### PR TITLE
micro: copy op DEPTH_TO_SPACE kernel from lite

### DIFF
--- a/tensorflow/lite/micro/kernels/depth_to_space.cc
+++ b/tensorflow/lite/micro/kernels/depth_to_space.cc
@@ -1,0 +1,170 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include <stdint.h>
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/optimized/optimized_ops.h"
+#include "tensorflow/lite/kernels/internal/reference/reference_ops.h"
+#include "tensorflow/lite/kernels/internal/tensor.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/internal/types.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+
+namespace tflite {
+namespace ops {
+namespace builtin {
+namespace depth_to_space {
+
+// This file has two implementation of DepthToSpace. Note that DepthToSpace only
+// works on 4D tensors.
+enum KernelType {
+  kReference,
+  kGenericOptimized,
+};
+
+constexpr int kInputTensor = 0;
+constexpr int kOutputTensor = 0;
+
+TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+  auto* params =
+      reinterpret_cast<TfLiteDepthToSpaceParams*>(node->builtin_data);
+
+  TF_LITE_ENSURE_EQ(context, NumInputs(node), 1);
+  TF_LITE_ENSURE_EQ(context, NumOutputs(node), 1);
+
+  const TfLiteTensor* input;
+  TF_LITE_ENSURE_OK(context, GetInputSafe(context, node, kInputTensor, &input));
+  TfLiteTensor* output;
+  TF_LITE_ENSURE_OK(context,
+                    GetOutputSafe(context, node, kOutputTensor, &output));
+
+  TF_LITE_ENSURE_EQ(context, NumDimensions(input), 4);
+
+  auto data_type = output->type;
+  TF_LITE_ENSURE(context,
+                 data_type == kTfLiteFloat32 || data_type == kTfLiteUInt8 ||
+                     data_type == kTfLiteInt8 || data_type == kTfLiteInt32 ||
+                     data_type == kTfLiteInt64);
+  TF_LITE_ENSURE_TYPES_EQ(context, input->type, output->type);
+
+  const int block_size = params->block_size;
+  const int input_height = input->dims->data[1];
+  const int input_width = input->dims->data[2];
+  const int input_channels = input->dims->data[3];
+  int output_height = input_height * block_size;
+  int output_width = input_width * block_size;
+  int output_channels = input_channels / block_size / block_size;
+
+  TF_LITE_ENSURE_EQ(context, input_height, output_height / block_size);
+  TF_LITE_ENSURE_EQ(context, input_width, output_width / block_size);
+  TF_LITE_ENSURE_EQ(context, input_channels,
+                    output_channels * block_size * block_size);
+
+  TfLiteIntArray* output_size = TfLiteIntArrayCreate(4);
+  output_size->data[0] = input->dims->data[0];
+  output_size->data[1] = output_height;
+  output_size->data[2] = output_width;
+  output_size->data[3] = output_channels;
+
+  return context->ResizeTensor(context, output, output_size);
+}
+
+template <KernelType kernel_type>
+TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
+  auto* params =
+      reinterpret_cast<TfLiteDepthToSpaceParams*>(node->builtin_data);
+
+  const TfLiteTensor* input;
+  TF_LITE_ENSURE_OK(context, GetInputSafe(context, node, kInputTensor, &input));
+  TfLiteTensor* output;
+  TF_LITE_ENSURE_OK(context,
+                    GetOutputSafe(context, node, kOutputTensor, &output));
+
+#define TF_LITE_DEPTH_TO_SPACE(type, scalar)                               \
+  tflite::DepthToSpaceParams op_params;                                    \
+  op_params.block_size = params->block_size;                               \
+  type::DepthToSpace(op_params, GetTensorShape(input),                     \
+                     GetTensorData<scalar>(input), GetTensorShape(output), \
+                     GetTensorData<scalar>(output))
+  switch (input->type) {  // Already know in/out types are same.
+    case kTfLiteFloat32:
+      if (kernel_type == kReference) {
+        TF_LITE_DEPTH_TO_SPACE(reference_ops, float);
+      } else {
+        TF_LITE_DEPTH_TO_SPACE(optimized_ops, float);
+      }
+      break;
+    case kTfLiteUInt8:
+      if (kernel_type == kReference) {
+        TF_LITE_DEPTH_TO_SPACE(reference_ops, uint8_t);
+      } else {
+        TF_LITE_DEPTH_TO_SPACE(optimized_ops, uint8_t);
+      }
+      break;
+    case kTfLiteInt8:
+      if (kernel_type == kReference) {
+        TF_LITE_DEPTH_TO_SPACE(reference_ops, int8_t);
+      } else {
+        TF_LITE_DEPTH_TO_SPACE(optimized_ops, int8_t);
+      }
+      break;
+    case kTfLiteInt32:
+      if (kernel_type == kReference) {
+        TF_LITE_DEPTH_TO_SPACE(reference_ops, int32_t);
+      } else {
+        TF_LITE_DEPTH_TO_SPACE(optimized_ops, int32_t);
+      }
+      break;
+    case kTfLiteInt64:
+      if (kernel_type == kReference) {
+        TF_LITE_DEPTH_TO_SPACE(reference_ops, int64_t);
+      } else {
+        TF_LITE_DEPTH_TO_SPACE(optimized_ops, int64_t);
+      }
+      break;
+    default:
+      context->ReportError(context, "Type '%s' not currently supported.",
+                           TfLiteTypeGetName(input->type));
+      return kTfLiteError;
+  }
+#undef TF_LITE_DEPTH_TO_SPACE
+
+  return kTfLiteOk;
+}
+
+}  // namespace depth_to_space
+
+TfLiteRegistration* Register_DEPTH_TO_SPACE_REF() {
+  static TfLiteRegistration r = {
+      nullptr, nullptr, depth_to_space::Prepare,
+      depth_to_space::Eval<depth_to_space::kReference>};
+  return &r;
+}
+
+TfLiteRegistration* Register_DEPTH_TO_SPACE_GENERIC_OPT() {
+  static TfLiteRegistration r = {
+      nullptr, nullptr, depth_to_space::Prepare,
+      depth_to_space::Eval<depth_to_space::kGenericOptimized>};
+  return &r;
+}
+
+TfLiteRegistration* Register_DEPTH_TO_SPACE() {
+  return Register_DEPTH_TO_SPACE_GENERIC_OPT();
+}
+
+}  // namespace builtin
+}  // namespace ops
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/depth_to_space.cc
+++ b/tensorflow/lite/micro/kernels/depth_to_space.cc
@@ -136,8 +136,8 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       }
       break;
     default:
-      context->ReportError(context, "Type '%s' not currently supported.",
-                           TfLiteTypeGetName(input->type));
+      TF_LITE_KERNEL_LOG(context, "Type '%s' not currently supported.",
+                         TfLiteTypeGetName(input->type));
       return kTfLiteError;
   }
 #undef TF_LITE_DEPTH_TO_SPACE

--- a/tensorflow/lite/micro/kernels/depth_to_space_test.cc
+++ b/tensorflow/lite/micro/kernels/depth_to_space_test.cc
@@ -1,0 +1,110 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include <stdint.h>
+
+#include <initializer_list>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "flatbuffers/flatbuffers.h"  // from @flatbuffers
+#include "tensorflow/lite/kernels/test_util.h"
+#include "tensorflow/lite/schema/schema_generated.h"
+
+namespace tflite {
+namespace {
+
+using ::testing::ElementsAre;
+using ::testing::ElementsAreArray;
+
+class DepthToSpaceOpModel : public SingleOpModel {
+ public:
+  DepthToSpaceOpModel(const TensorData& tensor_data, int block_size) {
+    input_ = AddInput(tensor_data);
+    output_ = AddOutput(tensor_data);
+    SetBuiltinOp(BuiltinOperator_DEPTH_TO_SPACE,
+                 BuiltinOptions_DepthToSpaceOptions,
+                 CreateDepthToSpaceOptions(builder_, block_size).Union());
+    BuildInterpreter({GetShape(input_)});
+  }
+
+  template <typename T>
+  void SetInput(std::initializer_list<T> data) {
+    PopulateTensor<T>(input_, data);
+  }
+  template <typename T>
+  std::vector<T> GetOutput() {
+    return ExtractVector<T>(output_);
+  }
+  std::vector<int> GetOutputShape() { return GetTensorShape(output_); }
+
+ private:
+  int input_;
+  int output_;
+};
+
+#ifdef GTEST_HAS_DEATH_TEST
+TEST(DepthToSpaceOpModel, BadBlockSize) {
+  EXPECT_DEATH(DepthToSpaceOpModel({TensorType_FLOAT32, {1, 1, 1, 4}}, 4),
+               "Cannot allocate tensors");
+}
+#endif
+
+TEST(DepthToSpaceOpModel, Float32) {
+  DepthToSpaceOpModel m({TensorType_FLOAT32, {1, 1, 1, 4}}, 2);
+  m.SetInput<float>({1.4, 2.3, 3.2, 4.1});
+  m.Invoke();
+  EXPECT_THAT(m.GetOutput<float>(), ElementsAreArray({1.4, 2.3, 3.2, 4.1}));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAre(1, 2, 2, 1));
+}
+
+TEST(DepthToSpaceOpModel, Uint8) {
+  DepthToSpaceOpModel m({TensorType_UINT8, {1, 1, 2, 4}}, 2);
+  m.SetInput<uint8_t>({1, 2, 3, 4, 5, 6, 7, 8});
+  m.Invoke();
+  EXPECT_THAT(m.GetOutput<uint8_t>(),
+              ElementsAreArray({1, 2, 5, 6, 3, 4, 7, 8}));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAre(1, 2, 4, 1));
+}
+
+TEST(DepthToSpaceOpModel, int8) {
+  DepthToSpaceOpModel m({TensorType_INT8, {1, 2, 1, 4}}, 2);
+  m.SetInput<int8_t>({1, 2, 3, 4, 5, 6, 7, 8});
+  m.Invoke();
+  EXPECT_THAT(m.GetOutput<int8_t>(),
+              ElementsAreArray({1, 2, 3, 4, 5, 6, 7, 8}));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAre(1, 4, 2, 1));
+}
+
+TEST(DepthToSpaceOpModel, Int32) {
+  DepthToSpaceOpModel m({TensorType_INT32, {1, 2, 2, 4}}, 2);
+  m.SetInput<int32_t>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16});
+  m.Invoke();
+  EXPECT_THAT(m.GetOutput<int32_t>(),
+              ElementsAreArray(
+                  {1, 2, 5, 6, 3, 4, 7, 8, 9, 10, 13, 14, 11, 12, 15, 16}));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAre(1, 4, 4, 1));
+}
+
+TEST(DepthToSpaceOpModel, Int64) {
+  DepthToSpaceOpModel m({TensorType_INT64, {1, 1, 1, 1}}, 1);
+  m.SetInput<int64_t>({4});
+  m.Invoke();
+  EXPECT_THAT(m.GetOutput<int64_t>(), ElementsAreArray({4}));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAre(1, 1, 1, 1));
+}
+
+}  // namespace
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/depth_to_space_test.cc
+++ b/tensorflow/lite/micro/kernels/depth_to_space_test.cc
@@ -12,13 +12,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <initializer_list>
 #include <vector>
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
 #include "flatbuffers/flatbuffers.h"  // from @flatbuffers
 #include "tensorflow/lite/kernels/test_util.h"
 #include "tensorflow/lite/schema/schema_generated.h"

--- a/tensorflow/lite/micro/kernels/depth_to_space_test.cc
+++ b/tensorflow/lite/micro/kernels/depth_to_space_test.cc
@@ -12,8 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <initializer_list>


### PR DESCRIPTION
Copy the kernel and test for operator DEPTH_TO_SPACE from
tensorflow/lite/kernels at 49524d6 without making modifications.
Adapt to micro and add to the build later.

This PR is part of the work to port operator DEPTH_TO_SPACE
from lite to micro, as tracked in issue #46025.