### PR TITLE
Update the style checks to also include the reference kernels.

### DIFF
--- a/tensorflow/lite/kernels/internal/reference/conv.h
+++ b/tensorflow/lite/kernels/internal/reference/conv.h
@@ -15,15 +15,12 @@ limitations under the License.
 #ifndef TENSORFLOW_LITE_KERNELS_INTERNAL_REFERENCE_CONV_H_
 #define TENSORFLOW_LITE_KERNELS_INTERNAL_REFERENCE_CONV_H_
 
-#include "tensorflow/lite/kernels/internal/types.h"
 #include "tensorflow/lite/kernels/internal/common.h"
-
-
+#include "tensorflow/lite/kernels/internal/types.h"
 
 namespace tflite {
 
 namespace reference_ops {
-
 
 inline void Conv(const ConvParams& params, const RuntimeShape& input_shape,
                  const float* input_data, const RuntimeShape& filter_shape,
@@ -108,8 +105,8 @@ inline void Conv(const ConvParams& params, const RuntimeShape& input_shape,
                  uint8_t* output_data, const RuntimeShape& im2col_shape,
                  uint8_t* im2col_data, void* cpu_backend_context) {
   (void)cpu_backend_context;  // only used in optimized code.
-  (void)im2col_data;   // only used in optimized code.
-  (void)im2col_shape;  // only used in optimized code.
+  (void)im2col_data;          // only used in optimized code.
+  (void)im2col_shape;         // only used in optimized code.
   const int stride_width = params.stride_width;
   const int stride_height = params.stride_height;
   const int dilation_width_factor = params.dilation_width_factor;

--- a/tensorflow/lite/micro/tools/ci_build/test_code_style.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_code_style.sh
@@ -33,7 +33,7 @@ set +e
 # The pigweed scripts only work from a git repository and the Tensorflow CI
 # infrastructure does not always guarantee that. As an ugly workaround, we
 # create our own git repo when running on the CI servers.
-pushd tensorflow/lite/micro/
+pushd tensorflow/lite/
 if [[ ${1} == "PRESUBMIT" ]]; then
   git init .
   git config user.email "tflm@google.com"
@@ -43,9 +43,12 @@ if [[ ${1} == "PRESUBMIT" ]]; then
 fi
 
 # Check for license with the necessary exclusions.
-tools/make/downloads/pigweed/pw_presubmit/py/pw_presubmit/pigweed_presubmit.py \
-  . \
+micro/tools/make/downloads/pigweed/pw_presubmit/py/pw_presubmit/pigweed_presubmit.py \
+  kernels/internal/reference/ \
+  micro/ \
   -p copyright_notice \
+  -e kernels/internal/reference/integer_ops/ \
+  -e kernels/internal/reference/reference_ops.h \
   -e tools/make/downloads \
   -e tools/make/targets/ecm3531 \
   -e BUILD\
@@ -66,8 +69,11 @@ LICENSE_CHECK_RESULT=$?
 # Python files (with yapf as the formatter) because that needs additional setup.
 # We are also ignoring the markdown files to allow for a more gradual rollout of
 # this presubmit check.
-tools/make/downloads/pigweed/pw_presubmit/py/pw_presubmit/format_code.py \
-  . \
+micro/tools/make/downloads/pigweed/pw_presubmit/py/pw_presubmit/format_code.py \
+  kernels/internal/reference/ \
+  micro/ \
+  -e kernels/internal/reference/integer_ops/ \
+  -e kernels/internal/reference/reference_ops.h \
   -e "\.inc" \
   -e "\.md" \
   -e "\.py"
@@ -76,7 +82,7 @@ CLANG_FORMAT_RESULT=$?
 
 popd
 if [[ ${1} == "PRESUBMIT" ]]; then
-  rm -rf tensorflow/lite/micro/.git
+  rm -rf tensorflow/lite/.git
 fi
 
 # Re-enable exit on error now that we are done with the temporary git repo.


### PR DESCRIPTION
Prior to this change we were only looking at code within the tensorflow/lite/micro directory. However, TFLM does share the reference implementations with Lite and so we are also checking for license and formatting in those files.

This should help detect errors faster, for example, PR https://github.com/tensorflow/tensorflow/pull/45814 missed adding a license to the header but that wasn't detected until the PR was imported internally.

See http://b/169948621 and http://b/175315163 for more details.
