### PR TITLE
Add target and pass_string parameters to the renode test script to fix #46186

### DIFF
--- a/tensorflow/lite/micro/testing/test_with_renode.sh
+++ b/tensorflow/lite/micro/testing/test_with_renode.sh
@@ -17,11 +17,13 @@
 #
 # Parameters:
 #  ${1} - path to a binary to test or directory (all *_test will be run).
-#  ${2} - target (bluepill, stm32f4 etc.)
+#  ${2} - String that is checked for pass/fail.
+#  ${3} - target (bluepill, stm32f4 etc.)
 
 set -e
 
-TARGET=${2}
+PASS_STRING=${2}
+TARGET=${3}
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TFLM_ROOT_DIR=${SCRIPT_DIR}/..
@@ -78,7 +80,7 @@ echo -e "*** Settings ***\n" \
         "*** Variables ***\n" \
         "\${RESC}                      undefined_RESC\n" \
         "\${UART_LOG}                  /tmp/uart.log\n" \
-        "\${UART_LINE_ON_SUCCESS}      ~~~ALL TESTS PASSED~~~\n" \
+        "\${UART_LINE_ON_SUCCESS}      ${PASS_STRING}\n" \
         "\${CREATE_SNAPSHOT_ON_FAIL}   False\n" \
         "\n" \
         "*** Test Cases ***\n" \

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -539,6 +539,10 @@ TARGETS_WITHOUT_MAKEFILES := \
 $(HOST_OS) \
 arduino
 
+# This specific string needs to be outputted for a test to be recognized as
+# having passed.
+TEST_PASS_STRING:='~~~ALL TESTS PASSED~~~'
+
 # ${TARGET}_makefile.inc can set this to true to allow it to defined a custom
 # implementation for `make test`. See bluepill_makefile as an example.
 TARGET_SPECIFIC_MAKE_TEST:=0
@@ -646,7 +650,7 @@ $(BINDIR)%_test : $(OBJDIR)%_test.o $(MICROLITE_LIB_PATH)
 
 $(BINDIR)%.test_target: $(BINDIR)%_test
 	@test -f $(TEST_SCRIPT) || (echo 'Unable to find the test script. Is the software emulation available in $(TARGET)?'; exit 1)
-	$(TEST_SCRIPT) $< '~~~ALL TESTS PASSED~~~'
+	$(TEST_SCRIPT) $< $(TEST_PASS_STRING)
 
 # snease: Add %.bin rule here since BINDIR is now defined
 # These are microcontroller-specific rules for converting the ELF output

--- a/tensorflow/lite/micro/tools/make/helper_functions.inc
+++ b/tensorflow/lite/micro/tools/make/helper_functions.inc
@@ -479,7 +479,7 @@ $(1): $$($(1)_BINARY)
 $(1)_bin: $$($(1)_BINARY).bin
 test_$(1): $$($(1)_BINARY)
 	@test -f $$(TEST_SCRIPT) || (echo 'Unable to find the test script. Is the software emulation available in $$(TARGET)?'; exit 1)
-	$$(TEST_SCRIPT) $$($(1)_BINARY) '~~~ALL TESTS PASSED~~~'
+	$$(TEST_SCRIPT) $$($(1)_BINARY) $$(TEST_PASS_STRING) $$(TARGET)
 
 ifneq (,$(findstring _test,$(1)))
   MICROLITE_TEST_TARGETS += test_$(1)

--- a/tensorflow/lite/micro/tools/make/targets/bluepill_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/bluepill_makefile.inc
@@ -68,4 +68,4 @@ TEST_SCRIPT := tensorflow/lite/micro/testing/test_with_renode.sh
 # implementation of `make test` for bluepill
 TARGET_SPECIFIC_MAKE_TEST := 1
 test: build
-	$(TEST_SCRIPT) $(BINDIR) $(TARGET)
+	$(TEST_SCRIPT) $(BINDIR) $(TEST_PASS_STRING) $(TARGET)

--- a/tensorflow/lite/micro/tools/make/targets/stm32f4_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/stm32f4_makefile.inc
@@ -88,5 +88,4 @@ TEST_SCRIPT := tensorflow/lite/micro/testing/test_with_renode.sh
 # implementation of `make test` for bluepill
 TARGET_SPECIFIC_MAKE_TEST := 1
 test: build
-	$(TEST_SCRIPT) $(BINDIR) $(TARGET)
-
+	$(TEST_SCRIPT) $(BINDIR) $(TEST_PASS_STRING) $(TARGET)


### PR DESCRIPTION
This allows the `test_with_renode.sh` script to be called via the makefile with all the parameters needed to run on a given target, while also staying consistent with the other test scripts.

As a result of this change, the makefile is passing in the following parameters to the test scripts:
 param 1 - test binary path
 param 2 - string to determine that test passes
 param 3 - target

Parameter 3 is only used for `test_with_renode.sh`

Manually tested that the following commands now pass:
```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=bluepill test_kernel_add_test
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=stm32f4 TAGS=cmsis-nn test_kernel_fully_connected_test
```

Fixes #46186