### PR TITLE
micro: port operator ADD_N kernel from lite with test

### DIFF
--- a/tensorflow/lite/kernels/internal/reference/add_n.h
+++ b/tensorflow/lite/kernels/internal/reference/add_n.h
@@ -23,13 +23,13 @@ namespace reference_ops {
 // T is expected to be either float or int.
 template <typename T>
 inline void AddN(const RuntimeShape& input_shape, const size_t num_inputs,
-                 T* const* input_data, T* output_data) {
+                 const T* const* input_data, T* output_data) {
   // All inputs and output should have the same shape, this is checked during
   // Prepare stage.
   const size_t size = input_shape.FlatSize();
-  for (int i = 0; i < size; ++i) {
+  for (size_t i = 0; i < size; ++i) {
     T x = 0;
-    for (int j = 0; j < num_inputs; ++j) {
+    for (size_t j = 0; j < num_inputs; ++j) {
       x += input_data[j][i];
     }
     output_data[i] = x;

--- a/tensorflow/lite/micro/all_ops_resolver.cc
+++ b/tensorflow/lite/micro/all_ops_resolver.cc
@@ -23,6 +23,7 @@ AllOpsResolver::AllOpsResolver() {
   // Please keep this list of Builtin Operators in alphabetical order.
   AddAbs();
   AddAdd();
+  AddAddN();
   AddArgMax();
   AddArgMin();
   AddAveragePool2D();

--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -258,6 +258,7 @@ cc_library(
         "activations.cc",
         "hard_swish.cc",
         "add.cc",
+        "add_n.cc",
         "arg_min_max.cc",
         "batch_to_space_nd.cc",
         "cast.cc",
@@ -387,6 +388,21 @@ cc_test(
     deps = [
         ":kernel_runner",
         "//tensorflow/lite/c:common",
+        "//tensorflow/lite/micro:op_resolvers",
+        "//tensorflow/lite/micro:test_helpers",
+        "//tensorflow/lite/micro/testing:micro_test",
+    ],
+)
+
+cc_test(
+    name = "add_n_test",
+    srcs = [
+        "add_n_test.cc",
+    ],
+    deps = [
+        ":kernel_runner",
+        "//tensorflow/lite/c:common",
+        "//tensorflow/lite/micro:debug_log",
         "//tensorflow/lite/micro:op_resolvers",
         "//tensorflow/lite/micro:test_helpers",
         "//tensorflow/lite/micro/testing:micro_test",

--- a/tensorflow/lite/micro/kernels/add_n.cc
+++ b/tensorflow/lite/micro/kernels/add_n.cc
@@ -1,4 +1,4 @@
-/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -12,73 +12,91 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-#include <stdint.h>
+
+#include "tensorflow/lite/kernels/internal/reference/add_n.h"
+
+#include <cstdint>
 
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/kernels/internal/reference/reference_ops.h"
-#include "tensorflow/lite/kernels/internal/tensor.h"
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
 
 namespace tflite {
-namespace ops {
-namespace micro {
-namespace add_n {
 namespace {
 
-constexpr int kInputTensor1 = 0;
+constexpr int kInputTensor0 = 0;
 constexpr int kOutputTensor = 0;
 
-TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+TfLiteStatus CalculateOpData(TfLiteContext* context, TfLiteNode* node) {
   int num_inputs = NumInputs(node);
   TF_LITE_ENSURE(context, num_inputs >= 2);
   TF_LITE_ENSURE_EQ(context, NumOutputs(node), 1);
 
-  const TfLiteTensor* input1;
-  TF_LITE_ENSURE_OK(context,
-                    GetInputSafe(context, node, kInputTensor1, &input1));
+  const TfLiteTensor* input_tensor_first;
+  TF_LITE_ENSURE_OK(
+      context, GetInputSafe(context, node, kInputTensor0, &input_tensor_first));
   TfLiteTensor* output;
   TF_LITE_ENSURE_OK(context,
                     GetOutputSafe(context, node, kOutputTensor, &output));
-  output->type = input1->type;
 
-  // Check that all input tensors have the same shape and type.
-  for (int i = kInputTensor1 + 1; i < num_inputs; ++i) {
+  // Check that all tensors have the same shape and type.
+  TF_LITE_ENSURE_TYPES_EQ(context, output->type, input_tensor_first->type);
+  for (int i = kInputTensor0 + 1; i < num_inputs; ++i) {
     const TfLiteTensor* input;
     TF_LITE_ENSURE_OK(context, GetInputSafe(context, node, i, &input));
-    TF_LITE_ENSURE(context, HaveSameShapes(input1, input));
-    TF_LITE_ENSURE_TYPES_EQ(context, input1->type, input->type);
+    TF_LITE_ENSURE(context, HaveSameShapes(input_tensor_first, input));
+    TF_LITE_ENSURE_TYPES_EQ(context, input_tensor_first->type, input->type);
   }
 
-  return kTfLiteError;
+  // Allocate scratch buffer space for pointer to each tensor's data
+  // and store the scratch buffer index in the node's user_data
+  if (output->type == kTfLiteFloat32) {
+    int scratch_index;
+    size_t scratch_size = sizeof(float*) * num_inputs;
+    TF_LITE_ENSURE_OK(context, context->RequestScratchBufferInArena(
+                                   context, scratch_size, &scratch_index));
+    node->user_data =
+        reinterpret_cast<decltype(node->user_data)>(scratch_index);
+  } else {
+    TF_LITE_KERNEL_LOG(context, "ADD_N only supports FLOAT32, got %s.",
+                       TfLiteTypeGetName(output->type));
+    return kTfLiteError;
+  }
+
+  return kTfLiteOk;
+}
+
+TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+  return CalculateOpData(context, node);
 }
 
 template <typename T>
-void EvalAddN(TfLiteContext* context, TfLiteNode* node) {
-  // OLD-TODO(haoliang): Initialize all_inputs only once during init.
-  VectorOfTensors<T> all_inputs(*context, *node->inputs);
-  // Safe to use unchecked since caller checks that tensor is valid
-  TfLiteTensor* output = GetOutput(context, node, kOutputTensor);
+void EvalAddN(TfLiteContext* context, TfLiteNode* node,
+              TfLiteEvalTensor* output) {
   int num_inputs = NumInputs(node);
-  // Safe to use unchecked since caller checks that tensor is valid
-  const TfLiteTensor* input1 = GetInput(context, node, kInputTensor1);
-  reference_ops::AddN<T>(GetTensorShape(input1), num_inputs, all_inputs.data(),
-                         GetTensorData<T>(output));
+
+  int scratch_index =
+      static_cast<int>(reinterpret_cast<intptr_t>(node->user_data));
+  void* scratch_buffer = context->GetScratchBuffer(context, scratch_index);
+  const T** all_inputs = static_cast<decltype(all_inputs)>(scratch_buffer);
+  for (int i = 0; i < num_inputs; i++) {
+    const TfLiteEvalTensor* next_input =
+        tflite::micro::GetEvalInput(context, node, kInputTensor0 + i);
+    all_inputs[i] = tflite::micro::GetTensorData<T>(next_input);
+  }
+
+  reference_ops::AddN<T>(tflite::micro::GetTensorShape(output), num_inputs,
+                         all_inputs, tflite::micro::GetTensorData<T>(output));
 }
 
 TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
-  const TfLiteTensor* input1;
-  TF_LITE_ENSURE_OK(context,
-                    GetInputSafe(context, node, kInputTensor1, &input1));
-  TfLiteTensor* output;
-  TF_LITE_ENSURE_OK(context,
-                    GetOutputSafe(context, node, kOutputTensor, &output));
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kOutputTensor);
   if (output->type == kTfLiteFloat32) {
-    EvalAddN<float>(context, node);
-  } else if (output->type == kTfLiteInt32) {
-    EvalAddN<int32_t>(context, node);
+    EvalAddN<float>(context, node, output);
   } else {
-    TF_LITE_KERNEL_LOG(context, "AddN only supports FLOAT32|INT32 now, got %s.",
+    TF_LITE_KERNEL_LOG(context, "ADD_N only supports FLOAT32, got %s.",
                        TfLiteTypeGetName(output->type));
     return kTfLiteError;
   }
@@ -86,10 +104,16 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
 }
 
 }  // namespace
-}  // namespace add_n
 
-TfLiteRegistration* Register_ADD_N() { return nullptr; }
+TfLiteRegistration Register_ADD_N() {
+  return {/*init=*/nullptr,
+          /*free=*/nullptr,
+          /*prepare=*/Prepare,
+          /*invoke=*/Eval,
+          /*profiling_string=*/nullptr,
+          /*builtin_code=*/0,
+          /*custom_name=*/nullptr,
+          /*version=*/0};
+}
 
-}  // namespace micro
-}  // namespace ops
 }  // namespace tflite

--- a/tensorflow/lite/micro/kernels/add_n_test.cc
+++ b/tensorflow/lite/micro/kernels/add_n_test.cc
@@ -1,4 +1,4 @@
-/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -23,36 +23,75 @@ limitations under the License.
 
 namespace tflite {
 namespace testing {
-namespace {}  // namespace
+namespace {
+
+constexpr int kMaxInputTensors = 3;
+constexpr int kMaxOutputTensors = 1;
+
+void ExecuteAddN(TfLiteTensor* tensors, int tensors_count) {
+  int input_array_data[kMaxInputTensors + kMaxOutputTensors] = {tensors_count -
+                                                                1};
+  for (int i = 1; i < tensors_count; i++) {
+    input_array_data[i] = i - 1;
+  }
+  TfLiteIntArray* inputs_array = IntArrayFromInts(input_array_data);
+  const int kOutputArrayData[] = {1, tensors_count - 1};
+  TfLiteIntArray* outputs_array = IntArrayFromInts(kOutputArrayData);
+
+  const TfLiteRegistration registration = tflite::Register_ADD_N();
+  micro::KernelRunner runner(registration, tensors, tensors_count, inputs_array,
+                             outputs_array, nullptr);
+
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, runner.InitAndPrepare());
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, runner.Invoke());
+}
+
+template <typename T>
+void TestAddN(const int* input_dims_data, const T* const* input_data,
+              int input_data_count, const int* expected_dims,
+              const T* expected_data, T* output_data) {
+  TF_LITE_MICRO_EXPECT_LE(input_data_count, kMaxInputTensors);
+
+  TfLiteIntArray* input_dims = IntArrayFromInts(input_dims_data);
+  TfLiteIntArray* output_dims = IntArrayFromInts(expected_dims);
+  const int output_count = ElementCount(*output_dims);
+
+  TfLiteTensor tensors[kMaxInputTensors + kMaxOutputTensors] = {};
+  for (int i = 0; i < input_data_count; i++) {
+    tensors[i] = CreateTensor(input_data[i], input_dims);
+  }
+  tensors[input_data_count] = CreateTensor(output_data, output_dims);
+
+  ExecuteAddN(tensors, input_data_count + 1);
+
+  for (int i = 0; i < output_count; i++) {
+    TF_LITE_MICRO_EXPECT_EQ(expected_data[i], output_data[i]);
+  }
+}
+
+}  // namespace
 }  // namespace testing
 }  // namespace tflite
 
 TF_LITE_MICRO_TESTS_BEGIN
 
 TF_LITE_MICRO_TEST(FloatAddNOpAddMultipleTensors) {
-#ifdef notdef
-  FloatAddNOpModel m({{TensorType_FLOAT32, {1, 2, 2, 1}},
-                      {TensorType_FLOAT32, {1, 2, 2, 1}},
-                      {TensorType_FLOAT32, {1, 2, 2, 1}}},
-                     {TensorType_FLOAT32, {}});
-  m.PopulateTensor<float>(m.input(0), {-2.0, 0.2, 0.7, 0.8});
-  m.PopulateTensor<float>(m.input(1), {0.1, 0.2, 0.3, 0.5});
-  m.PopulateTensor<float>(m.input(2), {0.5, 0.1, 0.1, 0.2});
-  EXPECT_THAT(m.GetOutput(), ElementsAreArray({-1.4, 0.5, 1.1, 1.5}));
-#endif  // notdef
-}
+  constexpr int kDims[] = {4, 1, 2, 2, 1};
+  constexpr float kInput1[] = {-2.0, 0.2, 0.7, 0.8};
+  constexpr float kInput2[] = {0.1, 0.2, 0.3, 0.5};
+  constexpr float kInput3[] = {0.5, 0.1, 0.1, 0.2};
+  constexpr float kExpect[] = {-1.4, 0.5, 1.1, 1.5};
+  const float* kInputs[tflite::testing::kMaxInputTensors] = {
+      kInput1,
+      kInput2,
+      kInput3,
+  };
+  constexpr int kInputCount = std::extent<decltype(kInputs)>::value;
+  constexpr int kOutputCount = std::extent<decltype(kExpect)>::value;
+  float output_data[kOutputCount];
 
-TF_LITE_MICRO_TEST(IntegerAddNOpAddMultipleTensors) {
-#ifdef notdef
-  IntegerAddNOpModel m({{TensorType_INT32, {1, 2, 2, 1}},
-                        {TensorType_INT32, {1, 2, 2, 1}},
-                        {TensorType_INT32, {1, 2, 2, 1}}},
-                       {TensorType_INT32, {}});
-  m.PopulateTensor<int32_t>(m.input(0), {-20, 2, 7, 8});
-  m.PopulateTensor<int32_t>(m.input(1), {1, 2, 3, 5});
-  m.PopulateTensor<int32_t>(m.input(2), {10, -5, 1, -2});
-  EXPECT_THAT(m.GetOutput(), ElementsAreArray({-9, -1, 11, 11}));
-#endif  // notdef
+  tflite::testing::TestAddN(kDims, kInputs, kInputCount, kDims, kExpect,
+                            output_data);
 }
 
 TF_LITE_MICRO_TESTS_END

--- a/tensorflow/lite/micro/kernels/micro_ops.h
+++ b/tensorflow/lite/micro/kernels/micro_ops.h
@@ -31,6 +31,7 @@ namespace tflite {
 // (https://abseil.io/tips/130). Any new ops (or cleanup of existing ops should
 // have their Register function declarations in the tflite namespace.
 
+TfLiteRegistration Register_ADD_N();
 TfLiteRegistration Register_BATCH_TO_SPACE_ND();
 TfLiteRegistration Register_CAST();
 TfLiteRegistration Register_CONV_2D();

--- a/tensorflow/lite/micro/micro_mutable_op_resolver.h
+++ b/tensorflow/lite/micro/micro_mutable_op_resolver.h
@@ -122,6 +122,11 @@ class MicroMutableOpResolver : public MicroOpResolver {
                       ParseAdd);
   }
 
+  TfLiteStatus AddAddN() {
+    return AddBuiltin(BuiltinOperator_ADD_N, tflite::Register_ADD_N(),
+                      ParseAddN);
+  }
+
   TfLiteStatus AddArgMax() {
     return AddBuiltin(BuiltinOperator_ARG_MAX,
                       tflite::ops::micro::Register_ARG_MAX(), ParseArgMax);

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -258,6 +258,7 @@ tensorflow/lite/micro/simple_memory_allocator_test.cc \
 tensorflow/lite/micro/testing_helpers_test.cc \
 tensorflow/lite/micro/kernels/activations_test.cc \
 tensorflow/lite/micro/kernels/add_test.cc \
+tensorflow/lite/micro/kernels/add_n_test.cc \
 tensorflow/lite/micro/kernels/arg_min_max_test.cc \
 tensorflow/lite/micro/kernels/batch_to_space_nd_test.cc \
 tensorflow/lite/micro/kernels/cast_test.cc \
@@ -312,6 +313,7 @@ tensorflow/lite/micro/memory_planner/linear_memory_planner_test.cc
 MICROLITE_CC_KERNEL_SRCS := \
 tensorflow/lite/micro/kernels/activations.cc \
 tensorflow/lite/micro/kernels/add.cc \
+tensorflow/lite/micro/kernels/add_n.cc \
 tensorflow/lite/micro/kernels/arg_min_max.cc \
 tensorflow/lite/micro/kernels/batch_to_space_nd.cc \
 tensorflow/lite/micro/kernels/cast.cc \
@@ -406,6 +408,7 @@ tensorflow/lite/kernels/internal/compatibility.h \
 tensorflow/lite/kernels/internal/optimized/neon_check.h \
 tensorflow/lite/kernels/internal/quantization_util.h \
 tensorflow/lite/kernels/internal/reference/add.h \
+tensorflow/lite/kernels/internal/reference/add_n.h \
 tensorflow/lite/kernels/internal/reference/arg_min_max.h \
 tensorflow/lite/kernels/internal/reference/batch_to_space_nd.h \
 tensorflow/lite/kernels/internal/reference/binary_function.h \


### PR DESCRIPTION
Complete implementation of TFLM operator ADD_N and associated TFLM test code.

PR step 5 of the work to port operator ADD_N as tracked in Issue  #46162