### PR TITLE
micro: prepare to port operator LEAKY_RELU kernel from lite with test

### DIFF
--- a/tensorflow/lite/kernels/internal/reference/leaky_relu.h
+++ b/tensorflow/lite/kernels/internal/reference/leaky_relu.h
@@ -19,7 +19,6 @@ limitations under the License.
 #include <limits>
 
 #include "tensorflow/lite/kernels/internal/common.h"
-#include "tensorflow/lite/kernels/internal/types.h"
 
 namespace tflite {
 namespace reference_ops {


### PR DESCRIPTION
Implement skeleton (non-working) code for operator and test.
Header files changed.
Namespaces changed.
Some original code deleted.
Some original code modified.

PR step 4 of the work to port operator LEAKY_RELU as tracked in Issue #46161