### PR TITLE
Tensorflow Lite Micro micro_speech example suppress warning on MacOS build

### DIFF
--- a/tensorflow/lite/micro/examples/micro_speech/osx/audio_provider.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/osx/audio_provider.cc
@@ -61,10 +61,7 @@ void OnAudioBufferFilledCallback(
 // device on MacOS.
 TfLiteStatus InitAudioRecording(tflite::ErrorReporter* error_reporter) {
   // Set up the format of the audio - single channel, 32-bit float at 16KHz.
-  #pragma clang diagnostic push
-  #pragma clang diagnostic ignored "-Wmissing-field-initializers"
-  AudioStreamBasicDescription recordFormat = {0};
-  #pragma clang diagnostic pop 
+  AudioStreamBasicDescription recordFormat = { };
   recordFormat.mSampleRate = kAudioSampleFrequency;
   recordFormat.mFormatID = kAudioFormatLinearPCM;
   recordFormat.mFormatFlags =

--- a/tensorflow/lite/micro/examples/micro_speech/osx/audio_provider.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/osx/audio_provider.cc
@@ -61,7 +61,10 @@ void OnAudioBufferFilledCallback(
 // device on MacOS.
 TfLiteStatus InitAudioRecording(tflite::ErrorReporter* error_reporter) {
   // Set up the format of the audio - single channel, 32-bit float at 16KHz.
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-field-initializers"
   AudioStreamBasicDescription recordFormat = {0};
+  #pragma clang diagnostic pop 
   recordFormat.mSampleRate = kAudioSampleFrequency;
   recordFormat.mFormatID = kAudioFormatLinearPCM;
   recordFormat.mFormatFlags =

--- a/tensorflow/lite/micro/examples/micro_speech/osx/audio_provider.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/osx/audio_provider.cc
@@ -61,7 +61,7 @@ void OnAudioBufferFilledCallback(
 // device on MacOS.
 TfLiteStatus InitAudioRecording(tflite::ErrorReporter* error_reporter) {
   // Set up the format of the audio - single channel, 32-bit float at 16KHz.
-  AudioStreamBasicDescription recordFormat = { };
+  AudioStreamBasicDescription recordFormat = {};
   recordFormat.mSampleRate = kAudioSampleFrequency;
   recordFormat.mFormatID = kAudioFormatLinearPCM;
   recordFormat.mFormatFlags =


### PR DESCRIPTION
When building for MacOS an error occurs when using the built in Apple clang (mentioned in https://github.com/tensorflow/tensorflow/issues/46218). The built in Apple clang version:

```
Configured with: --prefix=/Library/Developer/CommandLineTools/usr --with-gxx-include-dir=/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include/c++/4.2.1
Apple clang version 12.0.0 (clang-1200.0.32.27)
Target: x86_64-apple-darwin19.6.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```

This fix selectively suppresses the warning to work on MacOS. Alternatively, the below works on the same Clang version

```
AudioStreamBasicDescription recordFormat = { };
```