### PR TITLE
NFC - minor spelling tweaks under lite directory

### DIFF
--- a/tensorflow/lite/delegates/gpu/common/testing/feature_parity/utils.h
+++ b/tensorflow/lite/delegates/gpu/common/testing/feature_parity/utils.h
@@ -191,7 +191,7 @@ void InitializeInputs(int left, int right,
 // Invokes a prebuilt interpreter.
 absl::Status Invoke(std::unique_ptr<Interpreter>* interpreter);
 
-// Usability structure, which is used to pass parameters data to parametrized
+// Usability structure, which is used to pass parameters data to parameterized
 // tests.
 struct TestParams {
   // A gtest name, which will be used for a generated tests.

--- a/tensorflow/lite/experimental/examples/lstm/input_data.py
+++ b/tensorflow/lite/experimental/examples/lstm/input_data.py
@@ -139,7 +139,7 @@ class _DataSet(object):
     Args:
       images: The images
       labels: The labels
-      fake_data: Ignore inages and labels, use fake data.
+      fake_data: Ignore images and labels, use fake data.
       one_hot: Bool, return the labels as one hot vectors (if True) or ints (if
         False).
       dtype: Output image dtype. One of [uint8, float32]. `uint8` output has

--- a/tensorflow/lite/g3doc/guide/ops_version.md
+++ b/tensorflow/lite/g3doc/guide/ops_version.md
@@ -197,7 +197,7 @@ struct {
     } depthwise_conv_2d;
 ```
 
-Then polulate these new parameters in `GetOpSignature` function in
+Then populate these new parameters in `GetOpSignature` function in
 `lite/tools/versioning/op_version.cc`:
 
 ```

--- a/tensorflow/lite/g3doc/performance/delegates.md
+++ b/tensorflow/lite/g3doc/performance/delegates.md
@@ -222,7 +222,7 @@ output-value deviation) in two settings:
 
 To do so, the tool generates random Gaussian data and passes it through two
 TFLite Interpreters - one running single-threaded CPU kernels, and the other
-parametrized by the user's arguments.
+parameterized by the user's arguments.
 
 It measures the latency of both, as well as the absolute difference between the
 output tensors from each Interpreter, on a per-element basis.

--- a/tensorflow/lite/micro/examples/micro_speech/apollo3/compare_1k.py
+++ b/tensorflow/lite/micro/examples/micro_speech/apollo3/compare_1k.py
@@ -104,7 +104,7 @@ plt.plot(cmsis_dft, label='CMSIS fixed')
 plt.legend()
 plt.subplot(313)
 plt.plot(to_float(micro_dft, 22), label='Micro to float')
-# CMSIS result has 6 fractionanl bits (not 7) due to documentation error (see
+# CMSIS result has 6 fractional bits (not 7) due to documentation error (see
 # README.md)
 plt.plot(to_float(cmsis_dft, 6), label='CMSIS to float')
 plt.plot(py_result, label='Python result')

--- a/tensorflow/lite/python/lite_test.py
+++ b/tensorflow/lite/python/lite_test.py
@@ -2498,7 +2498,7 @@ class FromKerasFile(TestModels, parameterized.TestCase):
     self.assertEqual((0., 0.), output_details[1]['quantization'])
 
   def testPartialShapeOverriding(self):
-    """Test a Functional tf.keras model with parital input shape overriding."""
+    """Test a Functional tf.keras model with partial input shape overriding."""
     self._getFunctionalModelMultipleInputs()
 
     # Convert to TFLite model.

--- a/tensorflow/lite/python/schema_util.py
+++ b/tensorflow/lite/python/schema_util.py
@@ -26,7 +26,7 @@ def get_builtin_code_from_operator_code(opcode):
   """Return the builtin code of the given operator code.
 
   The following method is introduced to resolve op builtin code shortage
-  problem. The new builtin opreator will be assigned to the extended builtin
+  problem. The new builtin operator will be assigned to the extended builtin
   code field in the flatbuffer schema. Those methods helps to hide builtin code
   details.
 

--- a/tensorflow/lite/python/tflite_keras_util.py
+++ b/tensorflow/lite/python/tflite_keras_util.py
@@ -17,7 +17,7 @@
 
 The functions defined in this library have been copied over from Keras in order
 to remove the dependency from TensorFlow Lite to Keras. The functions which
-could not be copied over are accessed using the dependecy inversion principle.
+could not be copied over are accessed using the dependency inversion principle.
 (for details, refer to tensorflow/python/util/keras_deps.py).
 """
 

--- a/tensorflow/lite/schema/schema_utils.h
+++ b/tensorflow/lite/schema/schema_utils.h
@@ -21,7 +21,7 @@ limitations under the License.
 namespace tflite {
 
 // The following methods are introduced to resolve op builtin code shortage
-// problem. The new builtin opreator will be assigned to the extended builtin
+// problem. The new builtin operator will be assigned to the extended builtin
 // code field in the flatbuffer schema. Those methods helps to hide builtin code
 // details.
 BuiltinOperator GetBuiltinCode(const OperatorCode *op_code);

--- a/tensorflow/lite/special_rules.bzl
+++ b/tensorflow/lite/special_rules.bzl
@@ -70,7 +70,7 @@ def tflite_hexagon_nn_skel_libraries():
         name = "libhexagon_nn_skel",
         srcs = glob(["*.so"]),
     )
-    you need to modify this macro to specifiy the build target.
+    you need to modify this macro to specify the build target.
     return ["//third_party/hexagon_nn_skel:libhexagon_nn_skel"]
     """
     return []

--- a/tensorflow/lite/testing/model_coverage/model_coverage_lib.py
+++ b/tensorflow/lite/testing/model_coverage/model_coverage_lib.py
@@ -561,7 +561,7 @@ def compare_model_golden(tflite_model,
     input_data: np.ndarray to pass into models during inference.
     golden_name: Name of the file containing the (expected) golden values.
     update_golden: Whether to update the golden values with the model output
-      instead of comparing againts them. This should only be done when a change
+      instead of comparing against them. This should only be done when a change
       in TFLite warrants it.
     tolerance: Decimal place to check accuracy to. (default 5).
   """
@@ -815,7 +815,7 @@ def _test_conversion_quant_float16(converter,
     golden_name: Optional golden values to compare the output of the model
       against.
     update_golden: Whether to update the golden values with the model output
-      instead of comparing againts them.
+      instead of comparing against them.
     **kwargs: Additional arguments to be passed into the converter.
   """
   tflite_model_float = _convert(converter, version=2, **kwargs)
@@ -867,7 +867,7 @@ def test_saved_model_v2_quant_float16(directory,
     golden_name: Optional golden values to compare the output of the model
       against.
     update_golden: Whether to update the golden values with the model output
-      instead of comparing againts them.
+      instead of comparing against them.
     **kwargs: Additional arguments to be passed into the converter.
   """
   converter = _lite.TFLiteConverterV2.from_saved_model(directory)
@@ -897,7 +897,7 @@ def test_frozen_graph_quant_float16(filename,
     golden_name: Optional golden values to compare the output of the model
       against.
     update_golden: Whether to update the golden values with the model output
-      instead of comparing againts them.
+      instead of comparing against them.
     **kwargs: Additional arguments to be passed into the converter.
   """
   converter = _lite.TFLiteConverter.from_frozen_graph(filename, input_arrays,

--- a/tensorflow/lite/testing/op_tests/not_equal.py
+++ b/tensorflow/lite/testing/op_tests/not_equal.py
@@ -35,7 +35,7 @@ def make_not_equal_tests(options):
   }]
 
   def build_graph(parameters):
-    """Build the not euqal op testing graph."""
+    """Build the not equal op testing graph."""
     input_value1 = tf.compat.v1.placeholder(
         dtype=parameters["input_dtype"],
         name="input1",

--- a/tensorflow/lite/toco/python/toco_from_protos.py
+++ b/tensorflow/lite/toco/python/toco_from_protos.py
@@ -85,7 +85,7 @@ def main():
   parser.add_argument(
       "--enable_mlir_converter",
       action="store_true",
-      help=("Boolean indiciating whether to enable MLIR-based conversion "
+      help=("Boolean indicating whether to enable MLIR-based conversion "
             "instead of TOCO conversion. (default False)"))
 
   FLAGS, unparsed = parser.parse_known_args()

--- a/tensorflow/lite/tools/benchmark/android/README.md
+++ b/tensorflow/lite/tools/benchmark/android/README.md
@@ -45,7 +45,7 @@ filegroup(
 ```
 
 you need to modify tflite_hexagon_nn_skel_libraries macro in
-tensorflow/lite/special_rules.bzl to specifiy the build target.
+tensorflow/lite/special_rules.bzl to specify the build target.
 
 ```
 return ["//third_party/hexagon_nn_skel:libhexagon_nn_skel"]


### PR DESCRIPTION
This PR addresses minor spelling tweaks under `tensorflow/lite` directory.