### PR TITLE
[tf.data] enhance encapsulation for IteratorResource State

### DIFF
--- a/tensorflow/core/kernels/data/iterator_ops.cc
+++ b/tensorflow/core/kernels/data/iterator_ops.cc
@@ -116,10 +116,10 @@ Status IteratorResource::GetNext(OpKernelContext* ctx,
   IteratorContext::Params params(ctx);
   params.flr = captured_state->GetFLR();
   params.function_handle_cache = captured_state->GetFunctionHandleCache();
-  params.resource_mgr = &captured_state->GetResourceMgr();
+  params.resource_mgr = captured_state->GetResourceMgr();
   params.thread_factory = unbounded_thread_pool_.get_thread_factory();
   params.thread_pool = &unbounded_thread_pool_;
-  params.cancellation_manager = &captured_state->GetCancellationManager();
+  params.cancellation_manager = captured_state->GetCancellationManager();
   std::function<void()> deregister_fn;
   TF_RETURN_IF_ERROR(RegisterCancellationCallback(
       ctx->cancellation_manager(),
@@ -204,10 +204,10 @@ Status IteratorResource::Restore(OpKernelContext* ctx,
   IteratorContext::Params params(ctx);
   params.flr = new_state->GetFLR();
   params.function_handle_cache = new_state->GetFunctionHandleCache();
-  params.resource_mgr = &new_state->GetResourceMgr();
+  params.resource_mgr = new_state->GetResourceMgr();
   params.thread_factory = unbounded_thread_pool_.get_thread_factory();
   params.thread_pool = &unbounded_thread_pool_;
-  params.cancellation_manager = &new_state->GetCancellationManager();
+  params.cancellation_manager = new_state->GetCancellationManager();
   std::function<void()> deregister_fn;
   TF_RETURN_IF_ERROR(RegisterCancellationCallback(
       ctx->cancellation_manager(),
@@ -239,10 +239,10 @@ Status IteratorResource::SetIteratorFromDataset(OpKernelContext* ctx,
   IteratorContext::Params params(ctx);
   params.flr = new_state->GetFLR();
   params.function_handle_cache = new_state->GetFunctionHandleCache();
-  params.resource_mgr = &new_state->GetResourceMgr();
+  params.resource_mgr = new_state->GetResourceMgr();
   params.thread_factory = unbounded_thread_pool_.get_thread_factory();
   params.thread_pool = &unbounded_thread_pool_;
-  params.cancellation_manager = &new_state->GetCancellationManager();
+  params.cancellation_manager = new_state->GetCancellationManager();
   std::function<void()> deregister_fn;
   TF_RETURN_IF_ERROR(RegisterCancellationCallback(
       ctx->cancellation_manager(),

--- a/tensorflow/core/kernels/data/iterator_ops.cc
+++ b/tensorflow/core/kernels/data/iterator_ops.cc
@@ -107,19 +107,19 @@ Status IteratorResource::GetNext(OpKernelContext* ctx,
     tf_shared_lock l(mu_);
     captured_state = iterator_state_;
   }
-  if (!captured_state->iterator) {
+  if (!captured_state->GetIterator()) {
     return errors::FailedPrecondition(
         "GetNext() failed because the iterator has not been initialized. "
         "Ensure that you have run the initializer operation for this iterator "
         "before getting the next element.");
   }
   IteratorContext::Params params(ctx);
-  params.flr = captured_state->flr;
-  params.function_handle_cache = captured_state->function_handle_cache.get();
-  params.resource_mgr = &captured_state->resource_mgr;
+  params.flr = captured_state->GetFLR();
+  params.function_handle_cache = captured_state->GetFunctionHandleCache();
+  params.resource_mgr = &captured_state->GetResourceMgr();
   params.thread_factory = unbounded_thread_pool_.get_thread_factory();
   params.thread_pool = &unbounded_thread_pool_;
-  params.cancellation_manager = &captured_state->cancellation_manager;
+  params.cancellation_manager = &captured_state->GetCancellationManager();
   std::function<void()> deregister_fn;
   TF_RETURN_IF_ERROR(RegisterCancellationCallback(
       ctx->cancellation_manager(),
@@ -141,8 +141,9 @@ Status IteratorResource::GetNext(OpKernelContext* ctx,
     }
     num_get_next_calls_++;
   }
-  auto status = captured_state->iterator->GetNext(
-      IteratorContext(std::move(params)), out_tensors, end_of_sequence);
+  auto iterator_ = captured_state->GetIterator();
+  auto status = iterator_->GetNext(IteratorContext(std::move(params)),
+                                   out_tensors, end_of_sequence);
   if (collect_metrics_) {
     const uint64 end_time_us = ctx->env()->NowMicros();
     metrics::RecordTFDataGetNextDuration(safe_sub(end_time_us, start_time_us));
@@ -167,8 +168,9 @@ Status IteratorResource::Save(SerializationContext* ctx,
     tf_shared_lock l(mu_);
     captured_state = iterator_state_;
   }
-  if (captured_state->iterator) {
-    return captured_state->iterator->Save(ctx, writer);
+  auto iterator_ = captured_state->GetIterator();
+  if (iterator_) {
+    return iterator_->Save(ctx, writer);
   }
   return errors::FailedPrecondition(
       "Save() failed because the iterator has not been initialized. Ensure "
@@ -182,28 +184,30 @@ Status IteratorResource::Restore(OpKernelContext* ctx,
   std::shared_ptr<State> new_state;
   {
     tf_shared_lock l(mu_);
-    if (!iterator_state_->iterator) {
+    if (!iterator_state_->GetIterator()) {
       return errors::FailedPrecondition(
           "Restore() failed because the iterator has not been initialized. "
           "Ensure that you have run the initializer operation for this "
           "iterator before restoring it.");
     }
-    dataset = iterator_state_->iterator->dataset();
+    auto iterator_ = iterator_state_->GetIterator();
+    dataset = iterator_->dataset();
     // Hang onto a reference until we've created the new iterator, which will
     // then hold its own reference to keep the dataset alive.
     dataset->Ref();
-    new_state = std::make_shared<State>(
-        iterator_state_->flib_def, iterator_state_->pflr, iterator_state_->flr,
-        /*iterator=*/nullptr);
+    new_state = std::make_shared<State>(iterator_state_->GetFlibDef(),
+                                        iterator_state_->GetPFLR(),
+                                        iterator_state_->GetFLR(),
+                                        /*iterator=*/nullptr);
   }
   core::ScopedUnref scoped_unref(dataset);
   IteratorContext::Params params(ctx);
-  params.flr = new_state->flr;
-  params.function_handle_cache = new_state->function_handle_cache.get();
-  params.resource_mgr = &new_state->resource_mgr;
+  params.flr = new_state->GetFLR();
+  params.function_handle_cache = new_state->GetFunctionHandleCache();
+  params.resource_mgr = &new_state->GetResourceMgr();
   params.thread_factory = unbounded_thread_pool_.get_thread_factory();
   params.thread_pool = &unbounded_thread_pool_;
-  params.cancellation_manager = &new_state->cancellation_manager;
+  params.cancellation_manager = &new_state->GetCancellationManager();
   std::function<void()> deregister_fn;
   TF_RETURN_IF_ERROR(RegisterCancellationCallback(
       ctx->cancellation_manager(),
@@ -225,19 +229,20 @@ Status IteratorResource::SetIteratorFromDataset(OpKernelContext* ctx,
   std::shared_ptr<State> new_state;
   {
     tf_shared_lock l(mu_);
-    new_state = std::make_shared<State>(
-        iterator_state_->flib_def, iterator_state_->pflr, iterator_state_->flr,
-        /*iterator=*/nullptr);
+    new_state = std::make_shared<State>(iterator_state_->GetFlibDef(),
+                                        iterator_state_->GetPFLR(),
+                                        iterator_state_->GetFLR(),
+                                        /*iterator=*/nullptr);
   }
   // Create new iterator.
   std::unique_ptr<IteratorBase> iterator;
   IteratorContext::Params params(ctx);
-  params.flr = new_state->flr;
-  params.function_handle_cache = new_state->function_handle_cache.get();
-  params.resource_mgr = &new_state->resource_mgr;
+  params.flr = new_state->GetFLR();
+  params.function_handle_cache = new_state->GetFunctionHandleCache();
+  params.resource_mgr = &new_state->GetResourceMgr();
   params.thread_factory = unbounded_thread_pool_.get_thread_factory();
   params.thread_pool = &unbounded_thread_pool_;
-  params.cancellation_manager = &new_state->cancellation_manager;
+  params.cancellation_manager = &new_state->GetCancellationManager();
   std::function<void()> deregister_fn;
   TF_RETURN_IF_ERROR(RegisterCancellationCallback(
       ctx->cancellation_manager(),
@@ -1176,10 +1181,9 @@ REGISTER_KERNEL_BUILDER(
 REGISTER_KERNEL_BUILDER(
     Name("AnonymousIteratorV2").Device(DEVICE_CPU).Priority(2),
     AnonymousIteratorHandleOp);
-REGISTER_KERNEL_BUILDER(Name("AnonymousIteratorV2")
-                            .Device(DEVICE_GPU)
-                            .Priority(1),
-                        AnonymousIteratorHandleOp);
+REGISTER_KERNEL_BUILDER(
+    Name("AnonymousIteratorV2").Device(DEVICE_GPU).Priority(1),
+    AnonymousIteratorHandleOp);
 REGISTER_KERNEL_BUILDER(Name("DatasetToSingleElement").Device(DEVICE_CPU),
                         ToSingleElementOp);
 REGISTER_KERNEL_BUILDER(Name("ReduceDataset").Device(DEVICE_CPU),

--- a/tensorflow/core/kernels/data/iterator_ops.h
+++ b/tensorflow/core/kernels/data/iterator_ops.h
@@ -79,46 +79,46 @@ class IteratorResource : public ResourceBase {
           std::shared_ptr<ProcessFunctionLibraryRuntime> pflr,
           FunctionLibraryRuntime* flr,
           std::unique_ptr<DatasetBaseIterator> iterator)
-        : flib_def(std::move(flib_def)),
-          flr(flr),
-          pflr(std::move(pflr)),
-          function_handle_cache(absl::make_unique<FunctionHandleCache>(flr)),
-          iterator(std::move(iterator)) {}
+        : flib_def_(std::move(flib_def)),
+          flr_(flr),
+          pflr_(std::move(pflr)),
+          function_handle_cache_(absl::make_unique<FunctionHandleCache>(flr)),
+          iterator_(std::move(iterator)) {}
 
-    ~State() { cancellation_manager.StartCancel(); }
+    ~State() { cancellation_manager_.StartCancel(); }
 
     // Downcasts the given `IteratorBase` to a `DatasetBaseIterator`, and uses
     // it to set the `iterator` field.
     void DowncastAndSetIterator(std::unique_ptr<IteratorBase> it) {
-      iterator.reset(static_cast<DatasetBaseIterator*>(it.release()));
+      iterator_.reset(static_cast<DatasetBaseIterator*>(it.release()));
     }
 
-    std::shared_ptr<FunctionLibraryDefinition> flib_def() { return flib_def; }
+    std::shared_ptr<FunctionLibraryDefinition> flib_def() { return flib_def_; }
 
-    FunctionLibraryRuntime* flr() { return flr; }
+    FunctionLibraryRuntime* flr() { return flr_; }
 
-    std::shared_ptr<ProcessFunctionLibraryRuntime> pflr() { return pflr; }
+    std::shared_ptr<ProcessFunctionLibraryRuntime> pflr() { return pflr_; }
 
     FunctionHandleCache* function_handle_cache() {
-      return function_handle_cache.get();
+      return function_handle_cache_.get();
     }
 
-    ResourceMgr* resource_mgr() { return &resource_mgr; }
+    ResourceMgr* resource_mgr() { return &resource_mgr_; }
 
     CancellationManager* cancellation_manager() {
-      return &cancellation_manager;
+      return &cancellation_manager_;
     }
 
-    DatasetBaseIterator* iterator() { return iterator.get(); }
+    DatasetBaseIterator* iterator() { return iterator_.get(); }
 
    private:
-    std::shared_ptr<FunctionLibraryDefinition> flib_def;
-    FunctionLibraryRuntime* flr = nullptr;  // not owned
-    std::shared_ptr<ProcessFunctionLibraryRuntime> pflr;
-    std::unique_ptr<FunctionHandleCache> function_handle_cache;
-    ResourceMgr resource_mgr;
-    CancellationManager cancellation_manager;
-    std::unique_ptr<DatasetBaseIterator> iterator;
+    std::shared_ptr<FunctionLibraryDefinition> flib_def_;
+    FunctionLibraryRuntime* flr_ = nullptr;  // not owned
+    std::shared_ptr<ProcessFunctionLibraryRuntime> pflr_;
+    std::unique_ptr<FunctionHandleCache> function_handle_cache_;
+    ResourceMgr resource_mgr_;
+    CancellationManager cancellation_manager_;
+    std::unique_ptr<DatasetBaseIterator> iterator_;
   };
 
   UnboundedThreadPool unbounded_thread_pool_;

--- a/tensorflow/core/kernels/data/iterator_ops.h
+++ b/tensorflow/core/kernels/data/iterator_ops.h
@@ -73,8 +73,8 @@ class IteratorResource : public ResourceBase {
   }
 
  private:
-  // TODO(aaudibert): convert to a class for better encapsulation.
-  struct State {
+  class State {
+   public:
     State(std::shared_ptr<FunctionLibraryDefinition> flib_def,
           std::shared_ptr<ProcessFunctionLibraryRuntime> pflr,
           FunctionLibraryRuntime* flr,
@@ -93,6 +93,25 @@ class IteratorResource : public ResourceBase {
       iterator.reset(static_cast<DatasetBaseIterator*>(it.release()));
     }
 
+    FunctionLibraryDefinition* GetFlibDef() { return flib_def; }
+
+    FunctionLibraryRuntime* GetFLR() { return flr; }
+
+    ProcessFunctionLibraryRuntime* GetPFLR() { return pflr; }
+
+    FunctionHandleCache GetFunctionHandleCache() {
+      return function_handle_cache.get();
+    }
+
+    ResourceMgr GetResourceMgr() { return resource_mgr; }
+
+    CancellationManager GetCancellationManager() {
+      return cancellation_manager;
+    }
+
+    DatasetBaseIterator* GetIterator() { return iterator; }
+
+   private:
     std::shared_ptr<FunctionLibraryDefinition> flib_def;
     FunctionLibraryRuntime* flr = nullptr;  // not owned.
     std::shared_ptr<ProcessFunctionLibraryRuntime> pflr;

--- a/tensorflow/core/kernels/data/iterator_ops.h
+++ b/tensorflow/core/kernels/data/iterator_ops.h
@@ -93,23 +93,23 @@ class IteratorResource : public ResourceBase {
       iterator.reset(static_cast<DatasetBaseIterator*>(it.release()));
     }
 
-    std::shared_ptr<FunctionLibraryDefinition> GetFlibDef() { return flib_def; }
+    std::shared_ptr<FunctionLibraryDefinition> flib_def() { return flib_def; }
 
-    FunctionLibraryRuntime* GetFLR() { return flr; }
+    FunctionLibraryRuntime* flr() { return flr; }
 
-    std::shared_ptr<ProcessFunctionLibraryRuntime> GetPFLR() { return pflr; }
+    std::shared_ptr<ProcessFunctionLibraryRuntime> pflr() { return pflr; }
 
-    FunctionHandleCache* GetFunctionHandleCache() {
+    FunctionHandleCache* function_handle_cache() {
       return function_handle_cache.get();
     }
 
-    ResourceMgr* GetResourceMgr() { return &resource_mgr; }
+    ResourceMgr* resource_mgr() { return &resource_mgr; }
 
-    CancellationManager* GetCancellationManager() {
+    CancellationManager* cancellation_manager() {
       return &cancellation_manager;
     }
 
-    DatasetBaseIterator* GetIterator() { return iterator.get(); }
+    DatasetBaseIterator* iterator() { return iterator.get(); }
 
    private:
     std::shared_ptr<FunctionLibraryDefinition> flib_def;

--- a/tensorflow/core/kernels/data/iterator_ops.h
+++ b/tensorflow/core/kernels/data/iterator_ops.h
@@ -113,7 +113,7 @@ class IteratorResource : public ResourceBase {
 
    private:
     std::shared_ptr<FunctionLibraryDefinition> flib_def;
-    FunctionLibraryRuntime* flr = nullptr;  // not owned.
+    FunctionLibraryRuntime* flr = nullptr;  // not owned
     std::shared_ptr<ProcessFunctionLibraryRuntime> pflr;
     std::unique_ptr<FunctionHandleCache> function_handle_cache;
     ResourceMgr resource_mgr;

--- a/tensorflow/core/kernels/data/iterator_ops.h
+++ b/tensorflow/core/kernels/data/iterator_ops.h
@@ -93,23 +93,23 @@ class IteratorResource : public ResourceBase {
       iterator.reset(static_cast<DatasetBaseIterator*>(it.release()));
     }
 
-    FunctionLibraryDefinition* GetFlibDef() { return flib_def; }
+    std::shared_ptr<FunctionLibraryDefinition> GetFlibDef() { return flib_def; }
 
     FunctionLibraryRuntime* GetFLR() { return flr; }
 
-    ProcessFunctionLibraryRuntime* GetPFLR() { return pflr; }
+    std::shared_ptr<ProcessFunctionLibraryRuntime> GetPFLR() { return pflr; }
 
-    FunctionHandleCache GetFunctionHandleCache() {
+    FunctionHandleCache* GetFunctionHandleCache() {
       return function_handle_cache.get();
     }
 
-    ResourceMgr GetResourceMgr() { return resource_mgr; }
+    ResourceMgr* GetResourceMgr() { return &resource_mgr; }
 
-    CancellationManager GetCancellationManager() {
-      return cancellation_manager;
+    CancellationManager* GetCancellationManager() {
+      return &cancellation_manager;
     }
 
-    DatasetBaseIterator* GetIterator() { return iterator; }
+    DatasetBaseIterator* GetIterator() { return iterator.get(); }
 
    private:
     std::shared_ptr<FunctionLibraryDefinition> flib_def;


### PR DESCRIPTION
This PR enhances the encapsulation capability of the `State` of `tensorflow:data:IteratorResource` by representing it as a `class` instead of a `struct`. Additionally, the necessary `getter` methods have been added.

cc: @aaudiber this was one of the TODO items which required better encapsulation. Please let me know if this approach is suitable and if any changes are required.
