### PR TITLE
Include and build xa_nnlib with TARGET_ARCH=fusion_f1.

### DIFF
--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
@@ -1,16 +1,33 @@
-ifeq ($(TARGET_ARCH), hifi4)
+ifeq ($(TARGET_ARCH), $(findstring $(TARGET_ARCH), "fusion_f1 hifi4"))
 
   DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/ext_libs/xtensa_download.sh ${MAKEFILE_DIR}/downloads hifi4)
   ifneq ($(DOWNLOAD_RESULT), SUCCESS)
     $(error Something went wrong with the xtensa download: $(DOWNLOAD_RESULT))
   endif
 
+  # TODO(b/161489252): -Wno-shadow is only needed for xannlib. But since we do
+  # not have separate cflags (or the concept of modular build targets) with the
+  # Makefile, -Wno-shadow will be used for everything.
+
+  PLATFORM_FLAGS = \
+    -DNNLIB_V2 \
+    -DXTENSA_NNLIB_MAX_SCRATCH_SIZE=70*1024 \
+    -Wno-shadow
+
+  CCFLAGS += $(PLATFORM_FLAGS)
+  CXXFLAGS += $(PLATFORM_FLAGS)
+
   NNLIB_PATH := $(MAKEFILE_DIR)/downloads/xa_nnlib_hifi4
 
   THIRD_PARTY_CC_SRCS += \
     $(shell find $(NNLIB_PATH) -name "*.c")
 
-  $(info THIRD_PARTY_CC_SRCS: $(THIRD_PARTY_CC_SRCS))
+  EXCLUDED_NNLIB_SRCS = \
+    $(NNLIB_PATH)/algo/layers/cnn/src/xa_nn_cnn_api.c \
+    $(NNLIB_PATH)/algo/layers/gru/src/xa_nn_gru_api.c \
+    $(NNLIB_PATH)/algo/layers/lstm/src/xa_nn_lstm_api.c
+
+  THIRD_PARTY_CC_SRCS := $(filter-out $(EXCLUDED_NNLIB_SRCS), $(THIRD_PARTY_CC_SRCS))
 
   INCLUDES += \
     -I$(NNLIB_PATH)/algo/kernels/ \


### PR DESCRIPTION
 * Needed to add some defines, disable warning and exclude some sources from xa_nnlib to build everything.
 * The kernels are still unchanged (i.e. have a reference fallback).

Manually verified that the following command downloads xa_nnlib:
```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=fusion_f1 XTENSA_CORE=F1_190305_swupgrade test_keyword_benchmark -j8
```

And the latency is unchanged:
```
InitializeKeywordRunner() took 280862 ticks (280 ms)
KeywordRunNIerations(1) took 170431 ticks (170 ms)
KeywordRunNIerations(10) took 1703817 ticks (1703 ms)
```

And the size with the release build:
```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=fusion_f1 XTENSA_CORE=F1_190305_swupgrade keyword_benchmark -j8 BUILD_TYPE=release
xt-size tensorflow/lite/micro/tools/make/gen/xtensa_fusion_f1/bin/keyword_benchmark
```

is also unchanged:
```
   text	   data	    bss	    dec	    hex	filename
  51168	  40132	  24872	 116172	  1c5cc	tensorflow/lite/micro/tools/make/gen/xtensa_fusion_f1/bin/keyword_benchmark
```
