### PR TITLE
[tf.data service] Test split provider failures with distributed and zipped datasets

### DIFF
--- a/tensorflow/python/data/experimental/kernel_tests/data_service_ops_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/data_service_ops_test.py
@@ -662,7 +662,8 @@ class DataServiceOpsTest(data_service_test_base.TestBase,
     ds = self.make_distributed_dataset(
         ds, cluster_2, processing_mode="distributed_epoch")
 
-    error_regex = "Cannot create a split provider for dataset of type DataServiceDataset"  # pylint: disable=line-too-long
+    error_regex = "Cannot create a split provider for dataset " + \
+        "of type DataServiceDataset"
     with self.assertRaisesRegex(errors.UnimplementedError, error_regex):
       self.getDatasetOutput(ds)
 
@@ -720,7 +721,8 @@ class DataServiceOpsTest(data_service_test_base.TestBase,
     ds3 = self.make_distributed_dataset(
         ds3, cluster_3, processing_mode="distributed_epoch")
 
-    error_regex = "Cannot create a split provider for dataset of type ZipDataset"  # pylint: disable=line-too-long
+    error_regex = "Cannot create a split provider for dataset " + \
+        "of type ZipDataset"
     with self.assertRaisesRegex(errors.UnimplementedError, error_regex):
       self.getDatasetOutput(ds3)
 

--- a/tensorflow/python/data/experimental/kernel_tests/data_service_ops_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/data_service_ops_test.py
@@ -649,7 +649,7 @@ class DataServiceOpsTest(data_service_test_base.TestBase,
     self.assertNotEqual(id_1.numpy(), id_2.numpy())
 
   @combinations.generate(test_base.eager_only_combinations())
-  def testDistributeParallelToDistributed(self):
+  def testDistributedEpochOnDistributedDataset(self):
     cluster_1 = self.create_cluster(num_workers=1)
     cluster_2 = self.create_cluster(num_workers=1)
     num_sizes = 10

--- a/tensorflow/python/data/experimental/kernel_tests/data_service_ops_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/data_service_ops_test.py
@@ -650,7 +650,6 @@ class DataServiceOpsTest(data_service_test_base.TestBase,
 
   @combinations.generate(test_base.eager_only_combinations())
   def testDistributeParallelToDistributed(self):
-
     cluster_1 = self.create_cluster(num_workers=1)
     cluster_2 = self.create_cluster(num_workers=1)
     num_sizes = 10
@@ -669,7 +668,6 @@ class DataServiceOpsTest(data_service_test_base.TestBase,
 
   @combinations.generate(test_base.eager_only_combinations())
   def testDistributeDistributedToParallel(self):
-
     cluster_1 = self.create_cluster(num_workers=1)
     cluster_2 = self.create_cluster(num_workers=1)
     num_sizes = 10
@@ -686,7 +684,6 @@ class DataServiceOpsTest(data_service_test_base.TestBase,
         ds, [i + 1 for i in numbers], assert_items_equal=True)
 
   def testParallelZippedDistributedDatasets(self):
-
     cluster_1 = self.create_cluster(num_workers=1)
     cluster_2 = self.create_cluster(num_workers=1)
     cluster_3 = self.create_cluster(num_workers=1)
@@ -707,7 +704,6 @@ class DataServiceOpsTest(data_service_test_base.TestBase,
         ds3, list(zip(numbers, numbers)), assert_items_equal=True)
 
   def testDistributedZippedDistributedDatasets(self):
-
     cluster_1 = self.create_cluster(num_workers=1)
     cluster_2 = self.create_cluster(num_workers=1)
     cluster_3 = self.create_cluster(num_workers=1)

--- a/tensorflow/python/data/experimental/kernel_tests/data_service_ops_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/data_service_ops_test.py
@@ -667,7 +667,7 @@ class DataServiceOpsTest(data_service_test_base.TestBase,
     with self.assertRaisesRegex(errors.UnimplementedError, error_regex):
       self.getDatasetOutput(ds)
 
-  def testDistributedZippedDistributedDatasets(self):
+  def testDistributedEpochOnZippedDistributedDatasets(self):
     cluster_1 = self.create_cluster(num_workers=1)
     cluster_2 = self.create_cluster(num_workers=1)
     cluster_3 = self.create_cluster(num_workers=1)

--- a/tensorflow/python/data/experimental/kernel_tests/data_service_ops_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/data_service_ops_test.py
@@ -685,9 +685,10 @@ class DataServiceOpsTest(data_service_test_base.TestBase,
     self.assertDatasetProduces(
         ds, [i + 1 for i in numbers], assert_items_equal=True)
 
-  @combinations.generate(test_base.eager_only_combinations(),
+  @combinations.generate(
+      combinations.times(test_base.eager_only_combinations(),
                          combinations.combine(processing_mode=[
-                             "parallel_epochs", "distributed_epoch"]))
+                             "parallel_epochs", "distributed_epoch"])))
   def testDistributeZippedDistributedDatasets(self, processing_mode):
 
     cluster_1 = self.create_cluster(num_workers=1)

--- a/tensorflow/python/data/experimental/kernel_tests/data_service_ops_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/data_service_ops_test.py
@@ -667,43 +667,6 @@ class DataServiceOpsTest(data_service_test_base.TestBase,
     with self.assertRaisesRegex(errors.UnimplementedError, error_regex):
       self.getDatasetOutput(ds)
 
-  @combinations.generate(test_base.eager_only_combinations())
-  def testDistributeDistributedToParallel(self):
-    cluster_1 = self.create_cluster(num_workers=1)
-    cluster_2 = self.create_cluster(num_workers=1)
-    num_sizes = 10
-    size_repeats = 5
-    numbers = [1 * i for i in range(num_sizes)] * size_repeats
-    ds = dataset_ops.Dataset.from_tensor_slices(numbers)
-    ds = self.make_distributed_dataset(
-        ds, cluster_1, processing_mode="distributed_epoch")
-    ds = ds.map(lambda x: x + 1)
-    ds = self.make_distributed_dataset(
-        ds, cluster_2, processing_mode="parallel_epochs")
-
-    self.assertDatasetProduces(
-        ds, [i + 1 for i in numbers], assert_items_equal=True)
-
-  def testParallelZippedDistributedDatasets(self):
-    cluster_1 = self.create_cluster(num_workers=1)
-    cluster_2 = self.create_cluster(num_workers=1)
-    cluster_3 = self.create_cluster(num_workers=1)
-    num_sizes = 10
-    size_repeats = 5
-    numbers = [1 * i for i in range(num_sizes)] * size_repeats
-    ds1 = dataset_ops.Dataset.from_tensor_slices(numbers)
-    ds1 = self.make_distributed_dataset(ds1, cluster_1)
-
-    ds2 = dataset_ops.Dataset.from_tensor_slices(numbers)
-    ds2 = self.make_distributed_dataset(ds2, cluster_2)
-
-    ds3 = dataset_ops.Dataset.zip((ds1, ds2))
-    ds3 = self.make_distributed_dataset(
-        ds3, cluster_3, processing_mode="parallel_epochs")
-
-    self.assertDatasetProduces(
-        ds3, list(zip(numbers, numbers)), assert_items_equal=True)
-
   def testDistributedZippedDistributedDatasets(self):
     cluster_1 = self.create_cluster(num_workers=1)
     cluster_2 = self.create_cluster(num_workers=1)

--- a/tensorflow/python/data/experimental/kernel_tests/data_service_ops_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/data_service_ops_test.py
@@ -686,6 +686,28 @@ class DataServiceOpsTest(data_service_test_base.TestBase,
         ds, [i + 1 for i in numbers], assert_items_equal=True)
 
   @combinations.generate(test_base.eager_only_combinations())
+  def testParallelZippedDistributedDatasets(self):
+
+    cluster_1 = self.create_cluster(num_workers=1)
+    cluster_2 = self.create_cluster(num_workers=1)
+    cluster_3 = self.create_cluster(num_workers=1)
+    num_sizes = 10
+    size_repeats = 5
+    numbers = [1 * i for i in range(num_sizes)] * size_repeats
+    ds1 = dataset_ops.Dataset.from_tensor_slices(numbers)
+    ds1 = self.make_distributed_dataset(ds1, cluster_1)
+
+    ds2 = dataset_ops.Dataset.from_tensor_slices(numbers)
+    ds2 = self.make_distributed_dataset(ds2, cluster_2)
+
+    ds3 = tf.data.Dataset.zip((ds1, ds2))
+    ds3 = self.make_distributed_dataset(
+        ds3, cluster_3, processing_mode="parallel_epochs")
+
+    self.assertDatasetProduces(
+        ds3, list(zip(numbers, numbers)), assert_items_equal=True)
+
+  @combinations.generate(test_base.eager_only_combinations())
   def testTwoLevelDistribute(self):
     cluster_1_size = 3
     cluster_1 = self.create_cluster(num_workers=cluster_1_size)

--- a/tensorflow/python/data/experimental/kernel_tests/data_service_ops_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/data_service_ops_test.py
@@ -657,9 +657,11 @@ class DataServiceOpsTest(data_service_test_base.TestBase,
     size_repeats = 5
     numbers = [1 * i for i in range(num_sizes)] * size_repeats
     ds = dataset_ops.Dataset.from_tensor_slices(numbers)
-    ds = self.make_distributed_dataset(ds, cluster_1, processing_mode="parallel_epochs")
+    ds = self.make_distributed_dataset(
+        ds, cluster_1, processing_mode="parallel_epochs")
     ds = ds.map(lambda x: x + 1)
-    ds = self.make_distributed_dataset(ds, cluster_2, processing_mode="distributed_epoch")
+    ds = self.make_distributed_dataset(
+        ds, cluster_2, processing_mode="distributed_epoch")
 
     with self.assertRaisesRegex(errors.UnimplementedError,
                                 "Cannot create a split provider for dataset of type DataServiceDataset"):
@@ -674,9 +676,11 @@ class DataServiceOpsTest(data_service_test_base.TestBase,
     size_repeats = 5
     numbers = [1 * i for i in range(num_sizes)] * size_repeats
     ds = dataset_ops.Dataset.from_tensor_slices(numbers)
-    ds = self.make_distributed_dataset(ds, cluster_1, processing_mode="distributed_epoch")
+    ds = self.make_distributed_dataset(
+        ds, cluster_1, processing_mode="distributed_epoch")
     ds = ds.map(lambda x: x + 1)
-    ds = self.make_distributed_dataset(ds, cluster_2, processing_mode="parallel_epochs")
+    ds = self.make_distributed_dataset(
+        ds, cluster_2, processing_mode="parallel_epochs")
 
     self.assertDatasetProduces(ds, [i + 1 for i in numbers], assert_items_equal=True)
 

--- a/tensorflow/python/data/experimental/kernel_tests/data_service_ops_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/data_service_ops_test.py
@@ -713,24 +713,6 @@ class DataServiceOpsTest(data_service_test_base.TestBase,
         self.assertAllEqual(next(it).numpy(), element)
     self.assertEmpty(list(it))
 
-  # @combinations.generate(test_base.eager_only_combinations())
-  # def testCyclicDistribute(self):
-
-  #   cluster_1 = self.create_cluster(num_workers=1)
-  #   cluster_2 = self.create_cluster(num_workers=1)
-  #   num_sizes = 10
-  #   size_repeats = 5
-  #   numbers = [1 * i for i in range(num_sizes)] * size_repeats
-  #   ds = dataset_ops.Dataset.from_tensors(numbers)
-  #   ds = self.make_distributed_dataset(ds, cluster_1, processing_mode="parallel_epochs")
-  #   ds = ds.map(lambda x: x + 1)
-  #   ds = self.make_distributed_dataset(ds, cluster_2, processing_mode="parallel_epochs")
-  #   ds = ds.map(lambda x: x - 1)
-  #   ds = self.make_distributed_dataset(
-  #       ds, cluster_1, processing_mode="parallel_epochs", job_name="temp_jobname")
-
-  #   self.assertDatasetProduces(ds, numbers, assert_items_equal=True)
-
   @combinations.generate(
       combinations.times(test_base.eager_only_combinations()))
   def testDistributeLargeGraph(self):

--- a/tensorflow/python/data/experimental/kernel_tests/data_service_ops_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/data_service_ops_test.py
@@ -663,8 +663,8 @@ class DataServiceOpsTest(data_service_test_base.TestBase,
     ds = self.make_distributed_dataset(
         ds, cluster_2, processing_mode="distributed_epoch")
 
-    with self.assertRaisesRegex(errors.UnimplementedError,
-                                "Cannot create a split provider for dataset of type DataServiceDataset"):
+    error_regex = "Cannot create a split provider for dataset of type DataServiceDataset"  # pylint: disable=line-too-long
+    with self.assertRaisesRegex(errors.UnimplementedError, error_regex):
       self.getDatasetOutput(ds)
 
   @combinations.generate(test_base.eager_only_combinations())
@@ -682,7 +682,8 @@ class DataServiceOpsTest(data_service_test_base.TestBase,
     ds = self.make_distributed_dataset(
         ds, cluster_2, processing_mode="parallel_epochs")
 
-    self.assertDatasetProduces(ds, [i + 1 for i in numbers], assert_items_equal=True)
+    self.assertDatasetProduces(
+        ds, [i + 1 for i in numbers], assert_items_equal=True)
 
   @combinations.generate(test_base.eager_only_combinations())
   def testTwoLevelDistribute(self):

--- a/tensorflow/python/data/experimental/kernel_tests/data_service_ops_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/data_service_ops_test.py
@@ -700,7 +700,7 @@ class DataServiceOpsTest(data_service_test_base.TestBase,
     ds2 = dataset_ops.Dataset.from_tensor_slices(numbers)
     ds2 = self.make_distributed_dataset(ds2, cluster_2)
 
-    ds3 = tf.data.Dataset.zip((ds1, ds2))
+    ds3 = dataset_ops.Dataset.zip((ds1, ds2))
     ds3 = self.make_distributed_dataset(
         ds3, cluster_3, processing_mode="parallel_epochs")
 


### PR DESCRIPTION
This PR extends the test cases for `data_service_ops` by adding the following tests:
- Test the failing case of creating a split provider for a `ZipDataset`
- Test the failing case of creating a split provider for a `DataServiceDataset`.

cc: @aaudiber