### PR TITLE
Implement support for ragged tensors in mean_squared_error loss function.

### DIFF
--- a/tensorflow/python/keras/engine/compile_utils_test.py
+++ b/tensorflow/python/keras/engine/compile_utils_test.py
@@ -362,15 +362,16 @@ class LossesContainerTest(keras_parameterized.TestCase):
     """ Ensure that ragged tensors can be passed as targets and predictions."""
 
     def custom_loss_fn(y_true, y_pred):
-      losses = ragged_functional_ops.map_flat_values(losses_mod.mse, y_true,
-                                                     y_pred)
-      return math_ops.reduce_mean(losses)
+      """ MSE supports RaggedTensors directly.
+      """
+      return losses_mod.mse(y_true, y_pred)
 
-    class CustomLossClass(object):
-
-      def __call__(self, y_true, y_pred):
-        losses = ragged_functional_ops.map_flat_values(losses_mod.mse, y_true,
-                                                       y_pred)
+    class CustomLossClass(losses_mod.Loss):
+      """ User defined loss function must implement RaggedTensor support.
+      """
+      def call(self, y_true, y_pred):
+        losses = ragged_functional_ops.map_flat_values(
+            math_ops.squared_difference, y_true, y_pred)
         return math_ops.reduce_mean(losses)
 
     loss_container = compile_utils.LossesContainer(

--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -27,6 +27,7 @@ from tensorflow.python.distribute import distribution_strategy_context
 from tensorflow.python.eager import context
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import smart_cond
+from tensorflow.python.framework import tensor_spec
 from tensorflow.python.framework import tensor_util
 from tensorflow.python.keras import backend as K
 from tensorflow.python.keras.utils import losses_utils
@@ -37,6 +38,9 @@ from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import nn
 from tensorflow.python.ops.losses import losses_impl
+from tensorflow.python.ops.ragged import ragged_map_ops
+from tensorflow.python.ops.ragged import ragged_tensor
+from tensorflow.python.ops.ragged import ragged_util
 from tensorflow.python.util import dispatch
 from tensorflow.python.util.tf_export import keras_export
 from tensorflow.tools.docs import doc_controls
@@ -250,6 +254,7 @@ class LossFunctionWrapper(Loss):
     """
     if tensor_util.is_tf_type(y_pred) and tensor_util.is_tf_type(y_true):
       y_pred, y_true = losses_utils.squeeze_or_expand_dimensions(y_pred, y_true)
+
     ag_fn = autograph.tf_convert(self.fn, ag_ctx.control_status_ctx())
     return ag_fn(y_true, y_pred, **self._fn_kwargs)
 
@@ -1212,6 +1217,48 @@ def mean_squared_error(y_true, y_pred):
   y_true = math_ops.cast(y_true, y_pred.dtype)
   return K.mean(math_ops.squared_difference(y_pred, y_true), axis=-1)
 
+def _ragged_tensor_apply_loss(loss_fn, y_true, y_pred):
+  """Apply a loss function on a per batch basis.
+
+  Args:
+    loss_fn: The loss function
+    y_true: truth values (RaggedTensor)
+    y_pred: predicted values (RaggedTensor)
+
+  Returns:
+    Loss-function result. A dense tensor if the output has a single dimension
+    (per-batch loss value); a ragged tensor otherwise.
+  """
+  def _wrapper(inputs):
+    return loss_fn(*inputs)
+
+  lshape = y_pred.shape.as_list()[1:-1]
+  if len(lshape) > 0:
+    spec = ragged_tensor.RaggedTensorSpec(shape=lshape, dtype=y_pred.dtype)
+  else:
+    spec = tensor_spec.TensorSpec(shape=[], dtype=y_pred.dtype)
+
+  nested_splits_list = [rt.nested_row_splits for rt in (y_true, y_pred)]
+  assertion_list = ragged_util.assert_splits_match(nested_splits_list)
+  with ops.control_dependencies(assertion_list):
+    return ragged_map_ops.map_fn(
+        _wrapper, elems=(y_true, y_pred), dtype=spec)
+
+@dispatch.dispatch_for_types(mean_squared_error, ragged_tensor.RaggedTensor)
+def _ragged_tensor_mse(y_true, y_pred):
+  """ Implements support for handling RaggedTensors.
+
+  Args:
+    y_true: RaggedTensor truth values. shape = `[batch_size, d0, .. dN]`.
+    y_pred: RaggedTensor predicted values. shape = `[batch_size, d0, .. dN]`.
+
+  Returns:
+    Mean squared error values. shape = `[batch_size, d0, .. dN-1]`.
+    When the number of dimensions of the batch feature vector [d0, .. dN] is
+    greater than one the return value is a RaggedTensor. Otherwise a Dense
+    tensor with dimensions [batch_size] is returned.
+  """
+  return _ragged_tensor_apply_loss(mean_squared_error, y_true, y_pred)
 
 @keras_export('keras.metrics.mean_absolute_error', 'keras.metrics.mae',
               'keras.metrics.MAE', 'keras.losses.mean_absolute_error',

--- a/tensorflow/python/keras/losses_test.py
+++ b/tensorflow/python/keras/losses_test.py
@@ -33,6 +33,7 @@ from tensorflow.python.keras import combinations
 from tensorflow.python.keras import losses
 from tensorflow.python.keras.utils import losses_utils
 from tensorflow.python.ops import math_ops
+from tensorflow.python.ops.ragged import ragged_factory_ops
 from tensorflow.python.platform import test
 
 ALL_LOSSES = [
@@ -343,6 +344,20 @@ class MeanSquaredErrorTest(test.TestCase):
     sample_weight = constant_op.constant([1.2, 3.4], shape=(2, 1))
     loss = mse_obj(y_true, y_pred, sample_weight=sample_weight)
     self.assertAlmostEqual(self.evaluate(loss), 767.8 / 6, 3)
+
+  def test_ragged_tensors(self):
+    mse_obj = losses.MeanSquaredError()
+
+    y_true = ragged_factory_ops.constant([[1., 1., 9.], [2., 5.]])
+    y_pred = ragged_factory_ops.constant([[4., 1., 8.], [12., 3.]])
+    sample_weight = constant_op.constant([1.2, 0.5])
+    loss = mse_obj(y_true, y_pred, sample_weight=sample_weight)
+
+    # mse = [((4 - 1)^2 + (8 - 9)^2) / 3, ((12 - 2)^2 + (3 - 5)^2) / 2]
+    # mse = [3.(3), 52]
+    # weighted_mse = [3.(3) * 1.2, 52 * 0.5] = [4, 26]
+    # reduced_weighted_mse = (4 + 26) / 2 =
+    self.assertAllClose(self.evaluate(loss), 15, 1e-2)
 
   def test_timestep_weighted(self):
     mse_obj = losses.MeanSquaredError()

--- a/tensorflow/python/keras/utils/losses_utils.py
+++ b/tensorflow/python/keras/utils/losses_utils.py
@@ -299,7 +299,8 @@ def compute_weighted_loss(losses,
     # to multiple replicas. Used only for estimator + v1 optimizer flow.
     ops.get_default_graph()._last_loss_reduction = reduction  # pylint: disable=protected-access
 
-    if not isinstance(losses, keras_tensor.KerasTensor):
+    if not isinstance(
+        losses, (keras_tensor.KerasTensor, ragged_tensor.RaggedTensor)):
       losses = ops.convert_to_tensor_v2_with_dispatch(losses)
     input_dtype = losses.dtype
 


### PR DESCRIPTION
First cut at addressing Issue #45403.

This PR adds support for RaggedTensors to "mse" loss. Tensors with shapes of (batch, ragged_dimension) or (batch, ragged_dimension, feature dims) are handled on a per batch basis.


