### PR TITLE
TFLu: Update downloaded GCC version to 10

### DIFF
--- a/tensorflow/lite/micro/tools/make/arm_gcc_download.sh
+++ b/tensorflow/lite/micro/tools/make/arm_gcc_download.sh
@@ -49,42 +49,25 @@ if [ -d ${DOWNLOADED_GCC_PATH} ]; then
   echo >&2 "${DOWNLOADED_GCC_PATH} already exists, skipping the download."
 else
 
-  if [[ ${OSTYPE} == "linux" ]]; then
+  UNAME_S=`uname -s`
+  if [ ${UNAME_S} == Linux ]; then
     GCC_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2"
     EXPECTED_MD5="8312c4c91799885f222f663fc81f9a31"
-  elif [[ ${HOST_OS} == "darwin" ]]; then
+  elif [ ${UNAME_S} == Darwin ]; then
     GCC_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-mac.tar.bz2"
     EXPECTED_MD5="bc8ae26d7c429f30d583a605a4bcf9bc"
   else
-    GCC_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-win32.zip"
-    EXPECTED_MD5="a66be9828cf3c57d7d21178e07cd8904"
+    echo "OS type ${UNAME_S} not supported."
+    exit 1
   fi
 
-  FILE_EXTENSION="${GCC_URL##*.}"
   TEMPFILE=$(mktemp -d)/temp_file
-
   wget ${GCC_URL} -O ${TEMPFILE} >&2
   check_md5 ${TEMPFILE} ${EXPECTED_MD5}
 
-  mkdir "${DOWNLOADED_GCC_PATH}"
-  if [[ ${FILE_EXTENSION} == "bz2" ]]; then
-    tar -C "${DOWNLOADED_GCC_PATH}" --strip-components=1 -xjf ${TEMPFILE}
-  elif [[ ${FILE_EXTENSION} == "zip" ]]; then
-    TEMPDIR=$(mktemp -d)
-    unzip ${TEMPFILE} -d ${TEMPDIR} 2>&1 1>/dev/null
-    # If the zip file contains nested directories, extract the files from the
-    # inner directory.
-    if [ $(find $TEMPDIR/* -maxdepth 0 | wc -l) = 1 ] && [ -d $TEMPDIR/* ]; then
-      # unzip has no strip components, so unzip to a temp dir, and move the
-      # files we want from the tempdir to destination.
-      cp -R ${TEMPDIR}/*/* ${dir}/
-    else
-      cp -R ${TEMPDIR}/* ${dir}/
-    fi
-  else
-    echo "Error unsupported archive type. Failed to extract tool after download."
-    exit 1
-  fi
+  mkdir ${DOWNLOADED_GCC_PATH}
+  tar -C ${DOWNLOADED_GCC_PATH} --strip-components=1 -xjf ${TEMPFILE} >&2
+  echo >&2 "Unpacked to directory: ${DOWNLOADED_GCC_PATH}"
 fi
 
 echo "SUCCESS"

--- a/tensorflow/lite/micro/tools/make/gcc_download.sh
+++ b/tensorflow/lite/micro/tools/make/gcc_download.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# Called with following arguments:
+# 1 - Path to the downloads folder which is typically
+#     tensorflow/lite/micro/tools/make/downloads
+#
+# This script is called from the Makefile and uses the following convention to
+# enable determination of sucess/failure:
+#
+#   - If the script is successful, the only output on stdout should be SUCCESS.
+#     The makefile checks for this particular string.
+#
+#   - Any string on stdout that is not SUCCESS will be shown in the makefile as
+#     the cause for the script to have failed.
+#
+#   - Any other informational prints should be on stderr.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR=${SCRIPT_DIR}/../../../../..
+cd "${ROOT_DIR}"
+
+source tensorflow/lite/micro/tools/make/bash_helpers.sh
+
+DOWNLOADS_DIR=${1}
+if [ ! -d ${DOWNLOADS_DIR} ]; then
+  echo "The top-level downloads directory: ${DOWNLOADS_DIR} does not exist."
+  exit 1
+fi
+
+DOWNLOADED_GCC_PATH=${DOWNLOADS_DIR}/gcc_embedded
+
+if [ -d ${DOWNLOADED_GCC_PATH} ]; then
+  echo >&2 "${DOWNLOADED_GCC_PATH} already exists, skipping the download."
+else
+
+  if [[ ${OSTYPE} == "linux" ]]; then
+    GCC_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2"
+    EXPECTED_MD5="8312c4c91799885f222f663fc81f9a31"
+  elif [[ ${HOST_OS} == "darwin" ]]; then
+    GCC_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-mac.tar.bz2"
+    EXPECTED_MD5="bc8ae26d7c429f30d583a605a4bcf9bc"
+  else
+    GCC_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-win32.zip"
+    EXPECTED_MD5="a66be9828cf3c57d7d21178e07cd8904"
+  fi
+
+  FILE_EXTENSION="${GCC_URL##*.}"
+  TEMPFILE=$(mktemp -d)/temp_file
+
+  wget ${GCC_URL} -O ${TEMPFILE} >&2
+  check_md5 ${TEMPFILE} ${EXPECTED_MD5}
+
+  mkdir "${DOWNLOADED_GCC_PATH}"
+  if [[ ${FILE_EXTENSION} == "bz2" ]]; then
+    tar -C "${DOWNLOADED_GCC_PATH}" --strip-components=1 -xjf ${TEMPFILE}
+  elif [[ ${FILE_EXTENSION} == "zip" ]]; then
+    TEMPDIR=$(mktemp -d)
+    unzip ${TEMPFILE} -d ${TEMPDIR} 2>&1 1>/dev/null
+    # If the zip file contains nested directories, extract the files from the
+    # inner directory.
+    if [ $(find $TEMPDIR/* -maxdepth 0 | wc -l) = 1 ] && [ -d $TEMPDIR/* ]; then
+      # unzip has no strip components, so unzip to a temp dir, and move the
+      # files we want from the tempdir to destination.
+      cp -R ${TEMPDIR}/*/* ${dir}/
+    else
+      cp -R ${TEMPDIR}/* ${dir}/
+    fi
+  else
+    echo "Error unsupported archive type. Failed to extract tool after download."
+    exit 1
+  fi
+fi
+
+echo "SUCCESS"

--- a/tensorflow/lite/micro/tools/make/targets/apollo3evb_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/apollo3evb_makefile.inc
@@ -9,7 +9,11 @@ APOLLO3_SDK := $(MAKEFILE_DIR)/downloads/$(AM_SDK_DEST)
 # with the hard interfaces.
 GCC_ARM := $(MAKEFILE_DIR)/downloads/gcc_embedded/
 
-$(eval $(call add_third_party_download,$(GCC_EMBEDDED_URL),$(GCC_EMBEDDED_MD5),gcc_embedded,))
+DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/arm_gcc_download.sh ${MAKEFILE_DIR}/downloads)
+ifneq ($(DOWNLOAD_RESULT), SUCCESS)
+  $(error Something went wrong with the GCC download: $(DOWNLOAD_RESULT))
+endif
+
 $(eval $(call add_third_party_download,$(AM_SDK_URL),$(AM_SDK_MD5),$(AM_SDK_DEST),patch_am_sdk))
 
 DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/ext_libs/cmsis_download.sh ${MAKEFILE_DIR}/downloads)

--- a/tensorflow/lite/micro/tools/make/targets/apollo3evb_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/apollo3evb_makefile.inc
@@ -88,7 +88,7 @@ endif
 MICROLITE_LIBS := \
   $(BOARD_BSP_PATH)/gcc/bin/libam_bsp.a \
   $(APOLLO3_SDK)/mcu/apollo3/hal/gcc/bin/libam_hal.a \
-  $(GCC_ARM)/lib/gcc/arm-none-eabi/10.2.1/thumb/v7e-m/nofp/crtbegin.o \
+  $(GCC_ARM)/lib/gcc/arm-none-eabi/10.2.1/thumb/v7e-m+fp/hard/crtbegin.o \
   -lm
 INCLUDES += \
   -isystem$(MAKEFILE_DIR)/downloads/cmsis/CMSIS/Core/Include/ \

--- a/tensorflow/lite/micro/tools/make/targets/apollo3evb_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/apollo3evb_makefile.inc
@@ -88,7 +88,7 @@ endif
 MICROLITE_LIBS := \
   $(BOARD_BSP_PATH)/gcc/bin/libam_bsp.a \
   $(APOLLO3_SDK)/mcu/apollo3/hal/gcc/bin/libam_hal.a \
-  $(GCC_ARM)/lib/gcc/arm-none-eabi/7.3.1/thumb/v7e-m/fpv4-sp/hard/crtbegin.o \
+  $(GCC_ARM)/lib/gcc/arm-none-eabi/10.2.1/thumb/v7e-m/nofp/crtbegin.o \
   -lm
 INCLUDES += \
   -isystem$(MAKEFILE_DIR)/downloads/cmsis/CMSIS/Core/Include/ \

--- a/tensorflow/lite/micro/tools/make/targets/bluepill_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/bluepill_makefile.inc
@@ -2,7 +2,11 @@ export PATH := $(MAKEFILE_DIR)/downloads/gcc_embedded/bin/:$(PATH)
 TARGET_ARCH := cortex-m3
 TARGET_TOOLCHAIN_PREFIX := arm-none-eabi-
 
-$(eval $(call add_third_party_download,$(GCC_EMBEDDED_URL),$(GCC_EMBEDDED_MD5),gcc_embedded,))
+DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/arm_gcc_download.sh ${MAKEFILE_DIR}/downloads)
+ifneq ($(DOWNLOAD_RESULT), SUCCESS)
+  $(error Something went wrong with the GCC download: $(DOWNLOAD_RESULT))
+endif
+
 $(eval $(call add_third_party_download,$(STM32_BARE_LIB_URL),$(STM32_BARE_LIB_MD5),stm32_bare_lib,))
 
 DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/renode_download.sh ${MAKEFILE_DIR}/downloads)

--- a/tensorflow/lite/micro/tools/make/targets/cortex_m_generic_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/cortex_m_generic_makefile.inc
@@ -96,7 +96,7 @@ ifeq ($(TOOLCHAIN), armclang)
 
 else ifeq ($(TOOLCHAIN), gcc)
   export PATH := $(MAKEFILE_DIR)/downloads/gcc_embedded/bin/:$(PATH)
-  DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/gcc_download.sh ${MAKEFILE_DIR}/downloads)
+  DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/arm_gcc_download.sh ${MAKEFILE_DIR}/downloads)
   ifneq ($(DOWNLOAD_RESULT), SUCCESS)
     $(error Something went wrong with the GCC download: $(DOWNLOAD_RESULT))
   endif

--- a/tensorflow/lite/micro/tools/make/targets/cortex_m_generic_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/cortex_m_generic_makefile.inc
@@ -25,11 +25,12 @@ else ifeq ($(TARGET_ARCH), cortex-m33+nodsp)
 else ifeq ($(TARGET_ARCH), cortex-m4)
   CORE=M4
   ARM_LDFLAGS := -Wl,--cpu=Cortex-M4.no_fp
+  GCC_TARGET_ARCH := cortex-m4+nofp
 
 else ifeq ($(TARGET_ARCH), cortex-m4+fp)
   CORE=M4
   ARM_LDFLAGS := -Wl,--cpu=Cortex-M4
-  TARGET_SPECIFIC_FLAGS += -D__FPU_PRESENT=1 -mfpu=fpv4-sp-d16
+  TARGET_SPECIFIC_FLAGS += -D__FPU_PRESENT=1
   FLOAT=hard
   GCC_TARGET_ARCH := cortex-m4
 
@@ -51,6 +52,7 @@ else ifeq ($(TARGET_ARCH), cortex-m55+nofp)
 else ifeq ($(TARGET_ARCH), cortex-m7)
   CORE=M7
   ARM_LDFLAGS := -Wl,--cpu=Cortex-M7.no_fp
+  GCC_TARGET_ARCH := cortex-m7+nofp
 
 else ifeq ($(TARGET_ARCH), cortex-m7+fp)
   CORE=M7
@@ -63,10 +65,6 @@ else
 endif
 
 ifneq ($(filter cortex-m55%,$(TARGET_ARCH)),)
-  ifeq ($(TOOLCHAIN), gcc)
-    $(error "Micro architecure support is not available for arm-gcc for TARGET_ARCH=$(TARGET_ARCH)")
-  endif
-
   # soft-abi=soft disables MVE - use softfp instead for M55.
   ifeq ($(FLOAT),soft)
     FLOAT=softfp
@@ -98,11 +96,14 @@ ifeq ($(TOOLCHAIN), armclang)
 
 else ifeq ($(TOOLCHAIN), gcc)
   export PATH := $(MAKEFILE_DIR)/downloads/gcc_embedded/bin/:$(PATH)
-  $(eval $(call add_third_party_download,$(GCC_EMBEDDED_URL),$(GCC_EMBEDDED_MD5),gcc_embedded,))
+  DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/gcc_download.sh ${MAKEFILE_DIR}/downloads)
+  ifneq ($(DOWNLOAD_RESULT), SUCCESS)
+    $(error Something went wrong with the GCC download: $(DOWNLOAD_RESULT))
+  endif
 
   TARGET_TOOLCHAIN_PREFIX := arm-none-eabi-
 
-  FLAGS_GCC = -mcpu=$(GCC_TARGET_ARCH)
+  FLAGS_GCC = -mcpu=$(GCC_TARGET_ARCH) -mfpu=auto
   CXXFLAGS += $(FLAGS_GCC)
   CCFLAGS += $(FLAGS_GCC)
 

--- a/tensorflow/lite/micro/tools/make/targets/mbed_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/mbed_makefile.inc
@@ -3,5 +3,9 @@ ifeq ($(TARGET), mbed)
   TARGET_ARCH := cortex-m4
   $(eval $(call add_third_party_download,$(CMSIS_URL),$(CMSIS_MD5),cmsis,))
   $(eval $(call add_third_party_download,$(CUST_CMSIS_URL),$(CUST_CMSIS_MD5),CMSIS_ext,))
-  $(eval $(call add_third_party_download,$(GCC_EMBEDDED_URL),$(GCC_EMBEDDED_MD5),gcc_embedded,))
+
+  DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/arm_gcc_download.sh ${MAKEFILE_DIR}/downloads)
+  ifneq ($(DOWNLOAD_RESULT), SUCCESS)
+    $(error Something went wrong with the GCC download: $(DOWNLOAD_RESULT))
+  endif
 endif

--- a/tensorflow/lite/micro/tools/make/targets/stm32f4_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/stm32f4_makefile.inc
@@ -5,10 +5,11 @@ TARGET_ARCH := cortex-m4
 TARGET_TOOLCHAIN_PREFIX := arm-none-eabi-
 TARGET_TOOLCHAIN_ROOT := $(TENSORFLOW_ROOT)$(MAKEFILE_DIR)/downloads/gcc_embedded/bin/
 
-DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/gcc_download.sh ${MAKEFILE_DIR}/downloads)
+DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/arm_gcc_download.sh ${MAKEFILE_DIR}/downloads)
 ifneq ($(DOWNLOAD_RESULT), SUCCESS)
   $(error Something went wrong with the GCC download: $(DOWNLOAD_RESULT))
 endif
+
 $(eval $(call add_third_party_download,$(STM32_BARE_LIB_URL),$(STM32_BARE_LIB_MD5),stm32_bare_lib,))
 
 DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/renode_download.sh ${MAKEFILE_DIR}/downloads)

--- a/tensorflow/lite/micro/tools/make/targets/stm32f4_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/stm32f4_makefile.inc
@@ -5,7 +5,10 @@ TARGET_ARCH := cortex-m4
 TARGET_TOOLCHAIN_PREFIX := arm-none-eabi-
 TARGET_TOOLCHAIN_ROOT := $(TENSORFLOW_ROOT)$(MAKEFILE_DIR)/downloads/gcc_embedded/bin/
 
-$(eval $(call add_third_party_download,$(GCC_EMBEDDED_URL),$(GCC_EMBEDDED_MD5),gcc_embedded,))
+DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/gcc_download.sh ${MAKEFILE_DIR}/downloads)
+ifneq ($(DOWNLOAD_RESULT), SUCCESS)
+  $(error Something went wrong with the GCC download: $(DOWNLOAD_RESULT))
+endif
 $(eval $(call add_third_party_download,$(STM32_BARE_LIB_URL),$(STM32_BARE_LIB_MD5),stm32_bare_lib,))
 
 DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/renode_download.sh ${MAKEFILE_DIR}/downloads)

--- a/tensorflow/lite/micro/tools/make/third_party_downloads.inc
+++ b/tensorflow/lite/micro/tools/make/third_party_downloads.inc
@@ -8,17 +8,6 @@
 GEMMLOWP_URL := "https://github.com/google/gemmlowp/archive/719139ce755a0f31cbf1c37f7f98adcc7fc9f425.zip"
 GEMMLOWP_MD5 := "7e8191b24853d75de2af87622ad293ba"
 
-ifeq ($(HOST_OS),osx)
-  GCC_EMBEDDED_URL := "http://mirror.tensorflow.org/developer.arm.com/-/media/Files/downloads/gnu-rm/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-mac.tar.bz2"
-  GCC_EMBEDDED_MD5 := "a66be9828cf3c57d7d21178e07cd8904"
-else ifeq ($(HOST_OS),windows)
-  GCC_EMBEDDED_URL := "http://mirror.tensorflow.org/developer.arm.com/-/media/Files/downloads/gnu-rm/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-win32.zip"
-  GCC_EMBEDDED_MD5 := "bc8ae26d7c429f30d583a605a4bcf9bc"
-else
-  GCC_EMBEDDED_URL := "http://mirror.tensorflow.org/developer.arm.com/-/media/Files/downloads/gnu-rm/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2"
-  GCC_EMBEDDED_MD5 := "299ebd3f1c2c90930d28ab82e5d8d6c0"
-endif
-
 LEON_BCC2_URL := "http://mirror.tensorflow.org/www.gaisler.com/anonftp/bcc2/bin/bcc-2.0.7-gcc-linux64.tar.xz"
 LEON_BCC2_MD5 := "cdf78082be4882da2a92c9baa82fe765"
 


### PR DESCRIPTION
* Add new GCC download script.
* Enable GCC 10 for all targets.
* Update GCC flags for cortex_m_generic target.

This intends to fix: https://github.com/tensorflow/tensorflow/issues/43725 so that M55 can also be compiled with GCC.
Only targets, cortex_m_generic and stm32f4 has been tested.
It has only been tested on Linux.
