### PR TITLE
Allow more of the internal checks to have open-source counterparts.

### DIFF
--- a/tensorflow/lite/micro/kernels/detection_postprocess.cc
+++ b/tensorflow/lite/micro/kernels/detection_postprocess.cc
@@ -81,7 +81,7 @@ struct CenterSizeEncoding {
   float h;
   float w;
 };
-// We make sure that the memory allocations are contiguous with static assert.
+// We make sure that the memory allocations are contiguous with static_assert.
 static_assert(sizeof(BoxCornerEncoding) == sizeof(float) * kNumCoordBox,
               "Size of BoxCornerEncoding is 4 float values");
 static_assert(sizeof(CenterSizeEncoding) == sizeof(float) * kNumCoordBox,

--- a/tensorflow/lite/micro/tools/ci_build/helper_functions.sh
+++ b/tensorflow/lite/micro/tools/ci_build/helper_functions.sh
@@ -33,3 +33,18 @@ function readable_run {
   echo "Command completed successfully at $(date)"
   set -x
 }
+
+# Check if the regex ${1} is to be found in the pathspec ${2}.
+# An optional error messsage can be passed with ${3}
+function check_contents() {
+  GREP_OUTPUT=$(git grep -E -rn ${1} -- ${2})
+
+  if [ "${GREP_OUTPUT}" ]; then
+    echo "=============================================="
+    echo "Found matches for ${1} that are not permitted."
+    echo "${3}"
+    echo "=============================================="
+    echo "${GREP_OUTPUT}"
+    return 1
+  fi
+}

--- a/tensorflow/lite/micro/tools/ci_build/test_code_style.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_code_style.sh
@@ -131,11 +131,11 @@ fi
 # Re-enable exit on error now that we are done with the temporary git repo.
 set -e
 
-if [[ -n ${LICENSE_CHECK_RESULT} || \
-         ${CLANG_FORMAT_RESULT} || \
-         ${GTEST_RESULT} || \
-         ${ERROR_REPORTER_RESULT} || \
-         ${ASSERT_RESULT} \
+if [[ ${LICENSE_CHECK_RESULT}  != 0 || \
+      ${CLANG_FORMAT_RESULT}   != 0 || \
+      ${GTEST_RESULT}          != 0 || \
+      ${ERROR_REPORTER_RESULT} != 0 || \
+      ${ASSERT_RESULT}         != 0    \
    ]]
 then
   exit 1

--- a/tensorflow/lite/micro/tools/ci_build/test_code_style.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_code_style.sh
@@ -26,8 +26,9 @@ source tensorflow/lite/micro/tools/ci_build/helper_functions.sh
 # and clang-format checks.
 make -f tensorflow/lite/micro/tools/make/Makefile third_party_downloads
 
-# Explicitly disable exit on error so that we can properly clean up the
-# temporary git repository even when one of the scripts fail with an error code.
+# Explicitly disable exit on error so that we can report all the style errors in
+# one pass and clean up the temporary git repository even when one of the
+# scripts fail with an error code.
 set +e
 
 # The pigweed scripts only work from a git repository and the Tensorflow CI
@@ -42,7 +43,9 @@ if [[ ${1} == "PRESUBMIT" ]]; then
   git commit -a -m "Commit for a temporary repository." > /dev/null
 fi
 
-# Check for license with the necessary exclusions.
+############################################################
+# License Check
+############################################################
 micro/tools/make/downloads/pigweed/pw_presubmit/py/pw_presubmit/pigweed_presubmit.py \
   kernels/internal/reference/ \
   micro/ \
@@ -65,10 +68,12 @@ micro/tools/make/downloads/pigweed/pw_presubmit/py/pw_presubmit/pigweed_presubmi
 
 LICENSE_CHECK_RESULT=$?
 
-# Check that the TFLM-only code is clang-formatted We are currently ignoring
-# Python files (with yapf as the formatter) because that needs additional setup.
-# We are also ignoring the markdown files to allow for a more gradual rollout of
-# this presubmit check.
+############################################################
+# Formatting Check
+############################################################
+# We are currently ignoring Python files (with yapf as the formatter) because
+# that needs additional setup.  We are also ignoring the markdown files to allow
+# for a more gradual rollout of this presubmit check.
 micro/tools/make/downloads/pigweed/pw_presubmit/py/pw_presubmit/format_code.py \
   kernels/internal/reference/ \
   micro/ \
@@ -80,6 +85,44 @@ micro/tools/make/downloads/pigweed/pw_presubmit/py/pw_presubmit/format_code.py \
 
 CLANG_FORMAT_RESULT=$?
 
+#############################################################################
+# Avoided specific-code snippets for TFLM
+#############################################################################
+
+CHECK_CONTENTS_PATHSPEC=\
+"micro "\
+":(exclude)micro/tools/ci_build/test_code_style.sh"
+
+# See https://github.com/tensorflow/tensorflow/issues/46297 for more context.
+check_contents "gtest|gmock" "${CHECK_CONTENTS_PATHSPEC}" \
+  "These matches can likely be deleted."
+GTEST_RESULT=$?
+
+# See http://b/175657165 for more context.
+ERROR_REPORTER_MESSAGE=\
+"TF_LITE_REPORT_ERROR should be used instead, so that log strings can be "\
+"removed to save space, if needed."
+
+check_contents "error_reporter.*Report\(|context->ReportError\(" \
+  "${CHECK_CONTENTS_PATHSPEC}" "${ERROR_REPORTER_MESSAGE}"
+ERROR_REPORTER_RESULT=$?
+
+# See http://b/175657165 for more context.
+ASSERT_PATHSPEC=\
+"${CHECK_CONTENTS_PATHSPEC}"\
+" :(exclude)micro/examples/micro_speech/esp/ringbuf.c"\
+" :(exclude)*\.ipynb"\
+" :(exclude)*\.py"\
+" :(exclude)*zephyr_riscv/Makefile.inc"
+
+check_contents "\<assert\>" "${ASSERT_PATHSPEC}" \
+  "assert should not be used in TFLM code.."
+ASSERT_RESULT=$?
+
+###########################################################################
+# All checks are complete, clean up.
+###########################################################################
+
 popd
 if [[ ${1} == "PRESUBMIT" ]]; then
   rm -rf tensorflow/lite/.git
@@ -88,7 +131,12 @@ fi
 # Re-enable exit on error now that we are done with the temporary git repo.
 set -e
 
-if [[ ${LICENSE_CHECK_RESULT} != 0 || ${CLANG_FORMAT_RESULT} != 0 ]]
+if [[ -n ${LICENSE_CHECK_RESULT} || \
+         ${CLANG_FORMAT_RESULT} || \
+         ${GTEST_RESULT} || \
+         ${ERROR_REPORTER_RESULT} || \
+         ${ASSERT_RESULT} \
+   ]]
 then
   exit 1
 fi


### PR DESCRIPTION
 * gtest includes will be flagged as errors
 * use of the error reporter without the wrapper macros will be an error (https://github.com/tensorflow/tensorflow/pull/45457#discussion_r547434839)
 * assert can not be used (static_assert is ok).

Manually tested by adding the disallowed strings to the code and confirmed that an error is raised.

Fixes #46297
Fixes http://b/175657165
