### PR TITLE
Include C env API into part of the libtensorflow_framework.so

### DIFF
--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -736,6 +736,7 @@ tf_cc_shared_object(
     deps = [
         "//tensorflow/c/experimental/filesystem:filesystem_interface",
         "//tensorflow/c/experimental/stream_executor:stream_executor",
+        "//tensorflow/c:env",
         "//tensorflow/c:kernels",
         "//tensorflow/c:logging",
         "//tensorflow/c:ops_hdrs",

--- a/tensorflow/c/BUILD
+++ b/tensorflow/c/BUILD
@@ -505,11 +505,13 @@ tf_cuda_library(
             "//tensorflow/core:framework",
         ],
     }) + [
-        ":c_api",
+        ":c_api_macros",
+        ":tf_status",
         ":tf_status_helper",
-        ":c_api_internal",
         ":tf_file_statistics",
-        "//tensorflow/core:lib",
+        "//tensorflow/core/platform:env",
+        "//tensorflow/core/platform:path",
+        "//tensorflow/core/platform:types",
     ],
 )
 

--- a/tensorflow/c/env.cc
+++ b/tensorflow/c/env.cc
@@ -15,7 +15,8 @@ limitations under the License.
 
 #include "tensorflow/c/env.h"
 
-#include "tensorflow/c/c_api_internal.h"
+#include "tensorflow/c/c_api_macros.h"
+#include "tensorflow/c/tf_status.h"
 #include "tensorflow/c/tf_status_helper.h"
 #include "tensorflow/core/platform/env.h"
 #include "tensorflow/core/platform/path.h"

--- a/tensorflow/c/env.h
+++ b/tensorflow/c/env.h
@@ -20,8 +20,9 @@ limitations under the License.
 #include <stddef.h>
 #include <stdint.h>
 
-#include "tensorflow/c/c_api.h"
+#include "tensorflow/c/c_api_macros.h"
 #include "tensorflow/c/tf_file_statistics.h"
+#include "tensorflow/c/tf_status.h"
 
 // --------------------------------------------------------------------------
 // C API for tensorflow::Env.


### PR DESCRIPTION
`env` only uses some transitive dependencies of `c_api` ( It doesn't even call any function in `c_api.h` ) and `//tensorflow/core:lib`. So I replace these `deps` by its actual `deps`.

It is required by `gcs_filesystem` plugin.

Part of https://github.com/tensorflow/io/issues/1183

/cc: @yongtang, @mihaimaruseac 