### PR TITLE
Speedup DepthToSpace

### DIFF
--- a/tensorflow/core/kernels/depthtospace_op.cc
+++ b/tensorflow/core/kernels/depthtospace_op.cc
@@ -187,10 +187,10 @@ struct DepthToSpaceGenerator {
   }
 
   typename TTypes<T, 4>::ConstTensor input_;
-  const Eigen::Index block_size_;
-  const Eigen::Index output_height_;
-  const Eigen::Index output_width_;
-  const Eigen::Index output_depth_;
+  const Eigen::Index block_size;
+  const Eigen::Index output_height;
+  const Eigen::Index output_width;
+  const Eigen::Index output_depth;
   std::vector<std::pair<Eigen::Index, Eigen::Index>> ys_, xs_;
 };
 }  // namespace generator


### PR DESCRIPTION
This PR speedups DepthToSpace with Eigen Tensor Generator. Below is my benchmark

On ***Intel(R) Core(TM) i5-9600K CPU @ 3.70GHz***

| input_shape (`N_H_W_C`) | block_size | Old (M items/s) | New (M items/s) |
| ---------------------------- | ----------- | ---- | ----- |
| 1_64_64_64                    |  2             |  1123 | 1523 |
| 16_64_64_64                 | 2              | 1299 | 2137 |
| 32_64_64_64                   |  2             |  1123 | 1912|
| 1_128_128_64                  | 2              | 1306| 2644 |
| 16_128_128_64                     |  2             |   627| 1796 |
| 32_64_64_64                  | 2              | 618| 1827 |
| 1_64_64_64                     |  4             |  694| 1283|
| 16_64_64_64                  | 4             | 767 | 1953 |
| 32_64_64_64                     |  4             |  483 | 1515 |
| 1_128_128_64                  | 4              | 806| 1892 |
| 16_128_128_64                     |  4             |   478| 1525 |
| 32_64_64_64                  | 4              | 469| 1514 |