### PR TITLE
Fix InvalidArgumentError error when mixed precision policy is used in Attention/AdditiveAttention layer

### DIFF
--- a/tensorflow/python/keras/layers/dense_attention.py
+++ b/tensorflow/python/keras/layers/dense_attention.py
@@ -126,7 +126,7 @@ class BaseDenseAttention(Layer):
     if scores_mask is not None:
       padding_mask = math_ops.logical_not(scores_mask)
       # Bias so padding positions do not contribute to attention distribution.
-      scores -= 1.e9 * math_ops.cast(padding_mask, dtype=K.floatx())
+      scores -= 1.e9 * math_ops.cast(padding_mask, dtype=scores.dtype)
     if training is None:
       training = K.learning_phase()
     weights = nn.softmax(scores)

--- a/tensorflow/python/keras/layers/dense_attention.py
+++ b/tensorflow/python/keras/layers/dense_attention.py
@@ -126,7 +126,11 @@ class BaseDenseAttention(Layer):
     if scores_mask is not None:
       padding_mask = math_ops.logical_not(scores_mask)
       # Bias so padding positions do not contribute to attention distribution.
-      scores -= 1.e9 * math_ops.cast(padding_mask, dtype=scores.dtype)
+      # Note 65504. is the max float16 value.
+      if scores.dtype is dtypes.float16:
+        scores -= 65504. * math_ops.cast(padding_mask, dtype=scores.dtype)
+      else:
+        scores -= 1.e9 * math_ops.cast(padding_mask, dtype=scores.dtype)
     if training is None:
       training = K.learning_phase()
     weights = nn.softmax(scores)

--- a/tensorflow/python/keras/layers/dense_attention_test.py
+++ b/tensorflow/python/keras/layers/dense_attention_test.py
@@ -763,15 +763,12 @@ class AdditiveAttentionTest(test.TestCase, parameterized.TestCase):
   def test_mixed_float16_policy(self):
     # Test case for GitHub issue:
     # https://github.com/tensorflow/tensorflow/issues/46064
-    try:
-      policy.set_policy('mixed_float16')
+    with policy.policy_scope('mixed_float16'):
       q = math_ops.cast(random_ops.random_uniform((2, 3, 4), seed=1), 'float16')
       v = math_ops.cast(random_ops.random_uniform((2, 3, 4), seed=2), 'float16')
       k = math_ops.cast(random_ops.random_uniform((2, 3, 4), seed=3), 'float16')
       layer = dense_attention.AdditiveAttention(causal=True)
       _ = layer([q, v, k])
-    finally:
-      policy.set_policy('float32')
 
 
 @combinations.generate(combinations.combine(mode=['graph', 'eager']))

--- a/tensorflow/python/keras/mixed_precision/layer_correctness_test.py
+++ b/tensorflow/python/keras/mixed_precision/layer_correctness_test.py
@@ -139,6 +139,12 @@ class LayerCorrectnessTest(keras_parameterized.TestCase):
        (2, 2, 2)),
       ('Bidirectional',
        lambda: wrappers.Bidirectional(recurrent.SimpleRNN(units=4)), (2, 2, 2)),
+      ('AttentionLayer',
+       lambda: dense_attention.Attention(causal=True),
+       [(2, 2, 3), (2, 3, 3), (2, 3, 3)]),
+      ('AdditiveAttentionLayerCausal',
+       lambda: dense_attention.AdditiveAttention(causal=True),
+       [(2, 3, 4), (2, 3, 4), (2, 3, 4)]),
   )
   def test_layer(self, f32_layer_fn, input_shape, rtol=2e-3, atol=2e-3,
                  input_data=None):


### PR DESCRIPTION
This PR tries to address the issue raised in #46064 where
InvalidArgumentError error is thrown when mixed precision policy is used
in keras Attention/AdditiveAttention layer.

This PR fixes #46064.

This PR also fixes  #43261.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>