### PR TITLE
Fix tablegen definitions of ops base structs

### DIFF
--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/hlo_ops_base_structs.td
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/hlo_ops_base_structs.td
@@ -26,7 +26,7 @@ def DotDimensionNumbers : StructAttr<"DotDimensionNumbers", HLO_Dialect, [
                 StructFieldAttr<"lhs_contracting_dimensions", I64ElementsAttr>,
                 StructFieldAttr<"rhs_contracting_dimensions", I64ElementsAttr>
   ]> {
-  let summary = "Structure of dimension information for dot product";
+  let description = "Structure of dimension information for dot product";
 }
 
 def ScatterDimensionNumbers : StructAttr<
@@ -35,7 +35,7 @@ def ScatterDimensionNumbers : StructAttr<
       StructFieldAttr<"inserted_window_dims", I64ElementsAttr>,
       StructFieldAttr<"scatter_dims_to_operand_dims", I64ElementsAttr>,
       StructFieldAttr<"index_vector_dim", I64Attr>]> {
-  let summary = "Structure of dimension information for scatter";
+  let description = "Structure of dimension information for scatter";
 }
 
 def ConvDimensionNumbers : StructAttr<"ConvDimensionNumbers", HLO_Dialect, [
@@ -49,7 +49,7 @@ def ConvDimensionNumbers : StructAttr<"ConvDimensionNumbers", HLO_Dialect, [
   StructFieldAttr<"output_feature_dimension", I64Attr>,
   StructFieldAttr<"output_spatial_dimensions", I64ElementsAttr>] > {
 
-  let summary = "Structure of dimension information for conv op";
+  let description = "Structure of dimension information for conv op";
 }
 
 def GatherDimensionNumbers : StructAttr<"GatherDimensionNumbers", HLO_Dialect,
@@ -57,7 +57,7 @@ def GatherDimensionNumbers : StructAttr<"GatherDimensionNumbers", HLO_Dialect,
       StructFieldAttr<"collapsed_slice_dims", I64ElementsAttr>,
       StructFieldAttr<"start_index_map", I64ElementsAttr>,
       StructFieldAttr<"index_vector_dim", I64Attr>]> {
-  let summary = "Structure of dimension information for gather";
+  let description = "Structure of dimension information for gather";
 }
 
 
@@ -67,7 +67,7 @@ def GatherDimensionNumbers : StructAttr<"GatherDimensionNumbers", HLO_Dialect,
 def ChannelHandle : StructAttr<"ChannelHandle", HLO_Dialect, [
                 StructFieldAttr<"handle", I64Attr>,
                 StructFieldAttr<"type", I64Attr>]> {
-  let summary = "two 64-bit integers 'handle' and 'type'";
+  let description = "two 64-bit integers 'handle' and 'type'";
 }
 
 #endif // HLO_OPS_BASE_STRUCTS

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/lhlo_gpu_ops_structs.td
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/lhlo_gpu_ops_structs.td
@@ -32,7 +32,7 @@ def ConvolutionBackendConfigAttr : StructAttr<"ConvolutionBackendConfig",
    StructFieldAttr<"operand_0_layout", I64ArrayAttr>,
    StructFieldAttr<"operand_1_layout", I64ArrayAttr>,
    StructFieldAttr<"result_layout", I64ArrayAttr>]> {
-   let summary = "GPU Convolution backend configuration";
+   let description = "GPU Convolution backend configuration";
 }
 
 #endif // LHLO_GPU_OPS_STRUCTS


### PR DESCRIPTION
Prior to this the build failed with erros like:
```
[build] [..] lhlo_gpu_ops_structs.td:35:18: error: Value 'summary' unknown!
[build]    let summary = "GPU Convolution backend configuration";
```