### PR TITLE
Explicitly disable layering check for TFLM bazel packages.

### DIFF
--- a/tensorflow/lite/micro/BUILD
+++ b/tensorflow/lite/micro/BUILD
@@ -10,6 +10,7 @@ load(
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["-layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/tensorflow/lite/micro/benchmarks/BUILD
+++ b/tensorflow/lite/micro/benchmarks/BUILD
@@ -1,6 +1,9 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
-licenses(["notice"])  # Apache 2.0
+package(
+    features = ["-layering_check"],
+    licenses = ["notice"],  # Apache 2.0
+)
 
 package_group(
     name = "micro_top_level",

--- a/tensorflow/lite/micro/examples/hello_world/BUILD
+++ b/tensorflow/lite/micro/examples/hello_world/BUILD
@@ -10,9 +10,11 @@ load(
     "micro_copts",
 )
 
-package(default_visibility = ["//visibility:public"])
-
-licenses(["notice"])  # Apache 2.0
+package(
+    default_visibility = ["//visibility:public"],
+    features = ["-layering_check"],
+    licenses = ["notice"],  # Apache 2.0
+)
 
 cc_library(
     name = "model",

--- a/tensorflow/lite/micro/examples/image_recognition_experimental/BUILD
+++ b/tensorflow/lite/micro/examples/image_recognition_experimental/BUILD
@@ -6,7 +6,10 @@ load(
     "tflite_micro_cc_test",
 )
 
-licenses(["notice"])  # Apache 2.0
+package(
+    features = ["-layering_check"],
+    licenses = ["notice"],  # Apache 2.0
+)
 
 cc_library(
     name = "image_model_data",

--- a/tensorflow/lite/micro/examples/magic_wand/BUILD
+++ b/tensorflow/lite/micro/examples/magic_wand/BUILD
@@ -6,9 +6,11 @@ load(
     "tflite_micro_cc_test",
 )
 
-package(default_visibility = ["//visibility:public"])
-
-licenses(["notice"])  # Apache 2.0
+package(
+    default_visibility = ["//visibility:public"],
+    features = ["-layering_check"],
+    licenses = ["notice"],  # Apache 2.0
+)
 
 cc_library(
     name = "magic_wand_model_data",

--- a/tensorflow/lite/micro/examples/micro_speech/BUILD
+++ b/tensorflow/lite/micro/examples/micro_speech/BUILD
@@ -8,6 +8,7 @@ load(
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["-layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/tensorflow/lite/micro/examples/micro_speech/micro_features/BUILD
+++ b/tensorflow/lite/micro/examples/micro_speech/micro_features/BUILD
@@ -7,6 +7,7 @@ load(
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["-layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/tensorflow/lite/micro/examples/person_detection/BUILD
+++ b/tensorflow/lite/micro/examples/person_detection/BUILD
@@ -6,9 +6,11 @@ load(
     "tflite_micro_cc_test",
 )
 
-package(default_visibility = ["//visibility:public"])
-
-licenses(["notice"])  # Apache 2.0
+package(
+    default_visibility = ["//visibility:public"],
+    features = ["-layering_check"],
+    licenses = ["notice"],  # Apache 2.0
+)
 
 cc_library(
     name = "model_settings",

--- a/tensorflow/lite/micro/examples/person_detection/utils/BUILD
+++ b/tensorflow/lite/micro/examples/person_detection/utils/BUILD
@@ -1,6 +1,9 @@
 # Description:
 #   TensorFlow Lite for Microcontrollers Vision Example Utils.
-licenses(["notice"])  # Apache 2.0
+package(
+    features = ["-layering_check"],
+    licenses = ["notice"],  # Apache 2.0
+)
 
 py_binary(
     name = "raw_to_bitmap",

--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -7,7 +7,10 @@ load(
     "micro_copts",
 )
 
-licenses(["notice"])  # Apache 2.0
+package(
+    licenses = ["notice"],  # Apache 2.0
+    features = ["-layering_check"],
+)
 
 config_setting(
     name = "xtensa_hifimini",
@@ -670,6 +673,7 @@ cc_library(
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/kernels/internal:compatibility",
         "//tensorflow/lite/kernels/internal:types",
+        "//tensorflow/lite/micro:debug_log",
     ],
 )
 

--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -8,8 +8,8 @@ load(
 )
 
 package(
-    licenses = ["notice"],  # Apache 2.0
     features = ["-layering_check"],
+    licenses = ["notice"],  # Apache 2.0
 )
 
 config_setting(

--- a/tensorflow/lite/micro/kernels/test_data_generation/BUILD
+++ b/tensorflow/lite/micro/kernels/test_data_generation/BUILD
@@ -1,6 +1,9 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
-licenses(["notice"])
+package(
+    features = ["-layering_check"],
+    licenses = ["notice"],  # Apache 2.0
+)
 
 cc_binary(
     name = "generate_flexbuffers_data",

--- a/tensorflow/lite/micro/memory_planner/BUILD
+++ b/tensorflow/lite/micro/memory_planner/BUILD
@@ -9,6 +9,7 @@ load(
 
 package(
     default_visibility = ["//visibility:public"],
+    features = ["-layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/tensorflow/lite/micro/testing/BUILD
+++ b/tensorflow/lite/micro/testing/BUILD
@@ -4,7 +4,10 @@ load(
     "tflite_micro_cc_test",
 )
 
-licenses(["notice"])  # Apache 2.0
+package(
+    features = ["-layering_check"],
+    licenses = ["notice"],  # Apache 2.0
+)
 
 package_group(
     name = "micro",


### PR DESCRIPTION
Note that we will need to manually ensure that any new bazel package has the layering_check disabled.

The internal builds have layering_check turned on by default, while the open-source builds have them turned off by default. Ideally, we would explicitly turn them on for the open-source build.

However, turning it on (with `layering_check` instead of `-layering_check`) and building with this command:
```
bazel build tensorflow/lite/micro/kernels:add_test --repo_env=CC=`which clang`
```

results in a number of additional build errors that will need much broader changes to the TFLM BUILD files to fix.

As a result, we are currently turning off the layering_check to at least make the internal and external builds consistent.

Fixes #46347

See http://b/177257332 for more internal-only context.
