### PR TITLE
[tf.data] Implement SkipInternal for TFRecordDataset

### DIFF
--- a/tensorflow/core/kernels/data/dataset_test_base.cc
+++ b/tensorflow/core/kernels/data/dataset_test_base.cc
@@ -607,6 +607,27 @@ Status DatasetOpsTestBase::CheckIteratorGetNext(
   return Status::OK();
 }
 
+Status DatasetOpsTestBase::CheckIteratorSkip(
+    int num_to_skip, int expected_num_skipped,
+    bool get_next, const std::vector<Tensor>& expected_outputs,
+    bool compare_order) {
+  IteratorBase* iterator = iterator_.get();
+  IteratorContext* ctx = iterator_ctx_.get();
+
+  bool end_of_sequence = false;
+  int num_skipped = 0;
+  iterator->Skip(ctx, num_to_skip, &end_of_sequence, &num_skipped);
+  EXPECT_TRUE(num_skipped == expected_num_skipped);
+  if (get_next) {
+    EXPECT_TRUE(!end_of_sequence);
+    std::vector<Tensor> out_tensors;
+    TF_RETURN_IF_ERROR(iterator->GetNext(ctx, &out_tensors, &end_of_sequence));
+    TF_EXPECT_OK(ExpectEqual(out_tensors, expected_outputs,
+                             /*compare_order=*/compare_order));
+  }
+  return Status::OK();
+}
+
 Status DatasetOpsTestBase::CheckSplitProviderFullIteration(
     const DatasetParams& params, const std::vector<Tensor>& expected_outputs) {
   std::unique_ptr<TestDataset> dataset;

--- a/tensorflow/core/kernels/data/dataset_test_base.cc
+++ b/tensorflow/core/kernels/data/dataset_test_base.cc
@@ -616,7 +616,8 @@ Status DatasetOpsTestBase::CheckIteratorSkip(
 
   bool end_of_sequence = false;
   int num_skipped = 0;
-  iterator->Skip(ctx, num_to_skip, &end_of_sequence, &num_skipped);
+  TF_RETURN_IF_ERROR(
+      iterator->Skip(ctx, num_to_skip, &end_of_sequence, &num_skipped));
   EXPECT_TRUE(num_skipped == expected_num_skipped);
   if (get_next) {
     EXPECT_TRUE(!end_of_sequence);

--- a/tensorflow/core/kernels/data/dataset_test_base.h
+++ b/tensorflow/core/kernels/data/dataset_test_base.h
@@ -386,7 +386,7 @@ struct SkipTestCase {
   SkipTestCase(T dataset_params, int num_to_skip,
                int expected_num_skipped, bool get_next = false,
                std::vector<Tensor> expected_outputs = {},
-               bool compare_ordered = true)
+               bool compare_order = true)
       : dataset_params(std::move(dataset_params)),
         num_to_skip(num_to_skip),
         expected_num_skipped(expected_num_skipped),

--- a/tensorflow/core/kernels/data/tf_record_dataset_op.cc
+++ b/tensorflow/core/kernels/data/tf_record_dataset_op.cc
@@ -167,11 +167,11 @@ class TFRecordDatasetOp::Dataset : public DatasetBase {
         // We are currently processing a file, so try to skip reading
         // the next (num_to_skip - *num_skipped) record.
         if (reader_) {
-          int num_skipped_once;
+          int last_num_skipped;
           Status s =
               reader_->SkipRecords(num_to_skip - *num_skipped,
-                                   &num_skipped_once);
-          *num_skipped += num_skipped_once;
+                                   &last_num_skipped);
+          *num_skipped += last_num_skipped;
           if (s.ok()) {
             *end_of_sequence = false;
             return Status::OK();

--- a/tensorflow/core/kernels/data/tf_record_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/tf_record_dataset_op_test.cc
@@ -154,6 +154,45 @@ std::vector<GetNextTestCase<TFRecordDatasetParams>> GetNextTestCases() {
 ITERATOR_GET_NEXT_TEST_P(TFRecordDatasetOpTest, TFRecordDatasetParams,
                          GetNextTestCases())
 
+std::vector<SkipTestCase<TFRecordDatasetParams>> SkipTestCases() {
+  return {
+      {/*dataset_params=*/TFRecordDatasetParams1(),
+       /*num_to_skip*/2, /*expected_num_skipped*/2, /*get_next*/true,
+       /*expected_outputs=*/
+       CreateTensors<tstring>(TensorShape({}), {{"333"}})},
+      {/*dataset_params=*/TFRecordDatasetParams1(),
+       /*num_to_skip*/4, /*expected_num_skipped*/4, /*get_next*/true,
+       /*expected_outputs=*/
+       CreateTensors<tstring>(TensorShape({}), {{"bb"}})},
+      {/*dataset_params=*/TFRecordDatasetParams1(),
+       /*num_to_skip*/7, /*expected_num_skipped*/6},
+
+      {/*dataset_params=*/TFRecordDatasetParams2(),
+       /*num_to_skip*/2, /*expected_num_skipped*/2, /*get_next*/true,
+       /*expected_outputs=*/
+       CreateTensors<tstring>(TensorShape({}), {{"333"}})},
+      {/*dataset_params=*/TFRecordDatasetParams2(),
+       /*num_to_skip*/4, /*expected_num_skipped*/4, /*get_next*/true,
+       /*expected_outputs=*/
+       CreateTensors<tstring>(TensorShape({}), {{"bb"}})},
+      {/*dataset_params=*/TFRecordDatasetParams2(),
+       /*num_to_skip*/7, /*expected_num_skipped*/6},
+
+      {/*dataset_params=*/TFRecordDatasetParams3(),
+       /*num_to_skip*/2, /*expected_num_skipped*/2, /*get_next*/true,
+       /*expected_outputs=*/
+       CreateTensors<tstring>(TensorShape({}), {{"333"}})},
+      {/*dataset_params=*/TFRecordDatasetParams3(),
+       /*num_to_skip*/4, /*expected_num_skipped*/4, /*get_next*/true,
+       /*expected_outputs=*/
+       CreateTensors<tstring>(TensorShape({}), {{"bb"}})},
+      {/*dataset_params=*/TFRecordDatasetParams3(),
+       /*num_to_skip*/7, /*expected_num_skipped*/6}};
+}
+
+ITERATOR_SKIP_TEST_P(TFRecordDatasetOpTest, TFRecordDatasetParams,
+                     SkipTestCases())
+
 TEST_F(TFRecordDatasetOpTest, DatasetNodeName) {
   auto dataset_params = TFRecordDatasetParams1();
   TF_ASSERT_OK(Initialize(dataset_params));


### PR DESCRIPTION
This is a PR from JIZHI Team & TaiJi AI platform in Tencent.

This PR is a follow-up of #40963 and #41222. In those 2 PRs, I added the `Skip` method to `IteratorBase` and `RecordReader` so that we can potentially reduce the IO when user is using `tf.data.Dataset.shard()` method on samples instead of filenames.

This PR adds the `SkipInternal` for `TFRecordDatasetOp`. The implementation is very similar to `GetNextInternal`. And to test the new method, I added the helper functions and macros for `Skip`, which are also very similar to that of `GetNext`.

I'm not sure the proper way to deal with `metrics::GetTFDataBytesReadCounter` in `SkipInternal`, so it is omitted for now. It would be great if you could give me some hints on it.

Sorry for this late follow-up, I would try to add the meaningful `SkipInternal`s in the coming months.

cc @aaudiber @jsimsa 