### PR TITLE
added double braces to initialization

### DIFF
--- a/tensorflow/lite/micro/examples/network_tester/expected_output_data.h
+++ b/tensorflow/lite/micro/examples/network_tester/expected_output_data.h
@@ -16,6 +16,6 @@ limitations under the License.
 #ifndef TENSORFLOW_LITE_MICRO_EXAMPLES_NETWORK_TESTER_EXPECTED_OUTPUT_DATA_H_
 #define TENSORFLOW_LITE_MICRO_EXAMPLES_NETWORK_TESTER_EXPECTED_OUTPUT_DATA_H_
 
-static unsigned char expected_output_data[1][4] = {6, 8, 14, 16};
+static unsigned char expected_output_data[1][4] = {{6, 8, 14, 16}};
 
 #endif  // TENSORFLOW_LITE_MICRO_EXAMPLES_NETWORK_TESTER_EXPECTED_OUTPUT_DATA_H_


### PR DESCRIPTION
Not raised an issue, however this fixes and error with the `expected_output_data.h`.

Issue came about when running:

```
make -f tensorflow/lite/micro/tools/make/Makefile test
```

Error message was:

```
warning: suggest braces around initialization of subobject [-Wmissing-braces]
```

This failed on:

```
Apple clang version 12.0.0 (clang-1200.0.32.27)
Target: x86_64-apple-darwin19.6.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```

Fix:

added set of braces around the initialisation.