### PR TITLE
add support for concatenated gzip in ZlibInputStream

### DIFF
--- a/tensorflow/core/lib/io/zlib_inputstream.cc
+++ b/tensorflow/core/lib/io/zlib_inputstream.cc
@@ -255,6 +255,9 @@ Status ZlibInputStream::Inflate() {
     }
     return errors::DataLoss(error_string);
   }
+  if (error == Z_STREAM_END && zlib_options_.window_bits == MAX_WBITS + 16) {
+    inflateReset(z_stream_def_->stream.get());
+  }
   return Status::OK();
 }
 


### PR DESCRIPTION
This PR will fix #45137.

To support concatenated gzip, we need to call `inflateReset()` when `inflate()` returns `Z_STREAM_END`, as the zlib's doc explained:
> Unlike the gunzip utility and gzread() (see below), inflate() will not automatically decode concatenated gzip streams. inflate() will return Z_STREAM_END at the end of the gzip stream. The state would need to be reset to continue decoding a subsequent gzip stream.

from https://github.com/madler/zlib/blob/cacf7f1d4e3d44d871b605da3b647f07d718623f/zlib.h#L868

Thank you for your time on reviewing this pr.