### PR TITLE
Change from model.predict_proba to  using model.predict

### DIFF
--- a/tensorflow/python/keras/wrappers/scikit_learn.py
+++ b/tensorflow/python/keras/wrappers/scikit_learn.py
@@ -261,7 +261,7 @@ class KerasClassifier(BaseWrapper):
             (instead of `(n_sample, 1)` as in Keras).
     """
     kwargs = self.filter_sk_params(Sequential.predict_proba, kwargs)
-    probs = self.model.predict_proba(x, **kwargs)
+    probs = self.model.predict(x, **kwargs)
 
     # check if binary classification
     if probs.shape[1] == 1:


### PR DESCRIPTION
model.predict_proba is deprecated in the Keras code base, and should be replaced by model.predict
This replaces the usage of the deprecated call in the scikit_learn wrapper