### PR TITLE
[TFTRT - Dynamic Shape Phase 3] Add Dynamic Shape Testing for ConvertResize & Various TF2TRT Node Convert Unittest Improvements

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/utils.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/utils.cc
@@ -24,7 +24,7 @@ limitations under the License.
 namespace tensorflow {
 namespace tensorrt {
 
-Status TrtPrecisionModeToName(TrtPrecisionMode mode, string* name) {
+Status TrtPrecisionModeToName(const TrtPrecisionMode mode, string* name) {
   switch (mode) {
     case TrtPrecisionMode::FP32:
       *name = "FP32";
@@ -36,6 +36,7 @@ Status TrtPrecisionModeToName(TrtPrecisionMode mode, string* name) {
       *name = "INT8";
       break;
     default:
+      *name = "UNKNOWN";
       return errors::OutOfRange("Unknown precision mode");
   }
   return Status::OK();
@@ -87,6 +88,21 @@ string DebugString(const nvinfer1::Dims& dims) {
   return out;
 }
 
+string DebugString(const DataType tf_type) {
+  switch (tf_type) {
+    case DT_FLOAT:
+      return "DT_FLOAT";
+    case DT_HALF:
+      return "DT_HALF";
+    case DT_INT32:
+      return "DT_INT32";
+    case DT_INT8:
+      return "DT_INT8";
+    default:
+      return "Unknow TF DataType";
+  }
+}
+
 string DebugString(const nvinfer1::DataType trt_dtype) {
   switch (trt_dtype) {
     case nvinfer1::DataType::kFLOAT:
@@ -100,6 +116,12 @@ string DebugString(const nvinfer1::DataType trt_dtype) {
     default:
       return "Invalid TRT data type";
   }
+}
+
+string DebugString(const TrtPrecisionMode mode){
+  string mode_str;
+  TF_CHECK_OK(TrtPrecisionModeToName(mode, &mode_str));
+  return StrCat("TrtPrecisionMode::", mode_str);
 }
 
 string DebugString(const nvinfer1::Permutation& permutation, int len) {

--- a/tensorflow/compiler/tf2tensorrt/convert/utils.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/utils.h
@@ -51,7 +51,7 @@ using TrtUniquePtrType = std::unique_ptr<T, TrtDestroyer<T>>;
 
 enum class TrtPrecisionMode { FP32, FP16, INT8 };
 
-Status TrtPrecisionModeToName(TrtPrecisionMode mode, string* name);
+Status TrtPrecisionModeToName(const TrtPrecisionMode mode, string* name);
 
 Status TrtPrecisionModeFromName(const string& name, TrtPrecisionMode* mode);
 
@@ -76,6 +76,8 @@ struct VectorTensorShapeHasher {
 string DebugString(const nvinfer1::DimensionType type);
 string DebugString(const nvinfer1::Dims& dims);
 string DebugString(const nvinfer1::DataType trt_dtype);
+string DebugString(const TrtPrecisionMode mode);
+string DebugString(const DataType tf_type);
 string DebugString(const nvinfer1::Permutation& permutation, int len);
 string DebugString(const nvinfer1::ITensor& tensor);
 string DebugString(const std::vector<nvinfer1::Dims>& dimvec);


### PR DESCRIPTION
@bixia1 @tfeher for review
<!--
- add Dynamic Shape Testing for ConvertResize.
- add `DebugString(const TrtPrecisionMode)` in file `tensorflow/compiler/tf2tensorrt/convert/utils.[h/cc]`
- add `DebugString(const DataType)` in file `tensorflow/compiler/tf2tensorrt/convert/utils.[h/cc]`
- add `DebugString(const TrtTestMode)` in file `tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc`
- add LOG(INFO) data for each GTest executed from the base class `ParameterizedOpConverterTestBase`
  - `tf_type_`
  - `trt_mode_`
  - `converter_precision_`
- add C++ public getters in class `ParameterizedOpConverterTestBase` for the attributes:
  - `tf_type_`
  - `trt_mode_`
  - `converter_precision_`
  -->
ConvertResize now requires a static shape for the tensor representing the resized size to workaround the fact that we can't support shape tensors as inputs yet.
Add dynamic shape test cases for ConvertResize.


Feature Tracker: #45481