### PR TITLE
Dynamic shape for block3 to support input_shape (None, None, 3)

### DIFF
--- a/tensorflow/python/keras/applications/resnet.py
+++ b/tensorflow/python/keras/applications/resnet.py
@@ -405,12 +405,12 @@ def block3(x,
       depth_multiplier=c,
       use_bias=False,
       name=name + '_2_conv')(x)
-  x_shape = backend.int_shape(x)[1:-1]
-  x = layers.Reshape(x_shape + (groups, c, c))(x)
+  x_shape = backend.shape(x)[:-1]
+  x = backend.reshape(x, backend.concatenate([x_shape, (groups, c, c)]))
   x = layers.Lambda(
       lambda x: sum(x[:, :, :, :, i] for i in range(c)),
       name=name + '_2_reduce')(x)
-  x = layers.Reshape(x_shape + (filters,))(x)
+  x = backend.reshape(x, backend.concatenate([x_shape, (filters,)]))
   x = layers.BatchNormalization(
       axis=bn_axis, epsilon=1.001e-5, name=name + '_2_bn')(x)
   x = layers.Activation('relu', name=name + '_2_relu')(x)


### PR DESCRIPTION
This PR is a part of #37146, the error I have addressed at [this comment](https://github.com/tensorflow/tensorflow/pull/37146#issuecomment-759351768)

For ResNext models which use block3 function to build up. When the input shape is `(None, None, 3)`, the error will occur.
I changed the function to get dynamic shape and reshape with None dimension.

```python
ResNeXt50(include_top=False, input_shape=(224, 224,3)).summary()
```
![image](https://user-images.githubusercontent.com/36766404/104455554-0af51f00-55da-11eb-8ed1-8c705fd236f9.png)

```python
ResNeXt50(include_top=False, input_shape=(None, None,3)).summary()
```
![image](https://user-images.githubusercontent.com/36766404/104455487-ebf68d00-55d9-11eb-83b2-74c05d54a48b.png)