### PR TITLE
Switching to Cadence HiFi 4 NN Library v2.3.0

### DIFF
--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa_download.sh
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa_download.sh
@@ -41,9 +41,9 @@ if [ ! -d ${DOWNLOADS_DIR} ]; then
 fi
 
 if [[ ${2} == "hifi4" ]]; then
-  LIBRARY_URL="http://mirror.tensorflow.org/github.com/foss-xtensa/nnlib-hifi4/raw/master/archive/xa_nnlib_06_27.zip"
+  LIBRARY_URL="http://github.com/foss-xtensa/nnlib-hifi4/raw/master/archive/xa_nnlib_hifi4_12_22.zip"
   LIBRARY_DIRNAME="xa_nnlib_hifi4"
-  LIBRARY_MD5="45fdc1209a8da62ab568aa6040f7eabf"
+  LIBRARY_MD5="bb4aa8bd589ee1b4b9fd71349a1e7317"
 else
   echo "Attempting to download an unsupported xtensa variant: ${2}"
   exit 1


### PR DESCRIPTION
Using the latest version of HiFi 4 NN Library.

This version has optimized implementation of FC and softmax for int8 datatype.

Tested the change using following commands:

```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=hifi4 XTENSA_TOOLS_VERSION=RI-2020.5-linux XTENSA_CORE=AE_HiFi4_LE5_FP_XC clean_downloads

make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=hifi4 XTENSA_TOOLS_VERSION=RI-2020.5-linux XTENSA_CORE=AE_HiFi4_LE5_FP_XC test_kernel_softmax_test
```