### PR TITLE
Add support of tf.qint16 and tf.quint16 for tf.stack

### DIFF
--- a/tensorflow/core/kernels/cwise_op_equal_to_1.cc
+++ b/tensorflow/core/kernels/cwise_op_equal_to_1.cc
@@ -18,8 +18,8 @@ limitations under the License.
 namespace tensorflow {
 REGISTER7(BinaryOp, CPU, "Equal", functor::equal_to, float, Eigen::half, double,
           uint8, int8, int16, bfloat16);
-REGISTER7(BinaryOp, CPU, "Equal", functor::equal_to, uint16, uint32, uint64,
-          qint8, qint16, quint8, quint16);
+REGISTER8(BinaryOp, CPU, "Equal", functor::equal_to, uint16, uint32, uint64,
+          qint8, qint16, quint8, quint16, qint32);
 REGISTER_KERNEL_BUILDER(
     Name("ApproximateEqual").Device(DEVICE_CPU).TypeConstraint<float>("T"),
     ApproximateEqualOp<CPUDevice, float>);

--- a/tensorflow/core/kernels/cwise_op_not_equal_to_1.cc
+++ b/tensorflow/core/kernels/cwise_op_not_equal_to_1.cc
@@ -18,8 +18,8 @@ limitations under the License.
 namespace tensorflow {
 REGISTER7(BinaryOp, CPU, "NotEqual", functor::not_equal_to, float, Eigen::half,
           double, uint8, int8, int16, bfloat16);
-REGISTER7(BinaryOp, CPU, "NotEqual", functor::not_equal_to, uint16, uint32,
-          uint64, qint8, qint16, quint8, quint16);
+REGISTER8(BinaryOp, CPU, "NotEqual", functor::not_equal_to, uint16, uint32,
+          uint64, qint8, qint16, quint8, quint16, qint32);
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED) || \
     !defined(MLIR_GENERATED_EXPERIMENTAL_GPU_KERNELS_ENABLED)

--- a/tensorflow/core/kernels/pack_op.cc
+++ b/tensorflow/core/kernels/pack_op.cc
@@ -127,6 +127,8 @@ class PackOp : public OpKernel {
 
 TF_CALL_ALL_TYPES(REGISTER_PACK);
 TF_CALL_QUANTIZED_TYPES(REGISTER_PACK);
+TF_CALL_qint16(REGISTER_PACK);
+TF_CALL_quint16(REGISTER_PACK);
 
 #if defined(IS_MOBILE_PLATFORM) && !defined(SUPPORT_SELECTIVE_REGISTRATION)
 // Primarily used for SavedModel support on mobile.

--- a/tensorflow/python/kernel_tests/array_ops/stack_op_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/stack_op_test.py
@@ -27,6 +27,7 @@ from tensorflow.python.framework import ops
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import gradient_checker
+from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import variables
 from tensorflow.python.platform import test
 
@@ -273,6 +274,21 @@ class StackOpTest(test.TestCase):
             xs = list(map(constant_op.constant, data))
             c = array_ops.stack(xs)
             self.assertAllEqual(self.evaluate(c), data)
+
+  def testQTypes(self):
+    np.random.seed(7)
+    with self.session(use_gpu=True):
+      shape = [2]
+      for dtype in [
+          dtypes.quint8,
+          dtypes.quint16,
+          dtypes.qint8,
+          dtypes.qint16]:
+        with self.subTest(shape=shape, dtype=dtype):
+          data = self.randn(shape, dtype.as_numpy_dtype)
+          xs = list(map(constant_op.constant, data))
+          c = math_ops.equal(array_ops.stack(xs), data)
+          self.assertAllEqual(self.evaluate(c), [True, True])
 
 
 class AutomaticStackingTest(test.TestCase):

--- a/tensorflow/python/kernel_tests/array_ops/stack_op_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/stack_op_test.py
@@ -283,7 +283,8 @@ class StackOpTest(test.TestCase):
           dtypes.quint8,
           dtypes.quint16,
           dtypes.qint8,
-          dtypes.qint16]:
+          dtypes.qint16,
+          dtypes.qint32]:
         with self.subTest(shape=shape, dtype=dtype):
           data = self.randn(shape, dtype.as_numpy_dtype)
           xs = list(map(constant_op.constant, data))

--- a/tensorflow/python/kernel_tests/cwise_ops_binary_test.py
+++ b/tensorflow/python/kernel_tests/cwise_ops_binary_test.py
@@ -998,6 +998,7 @@ class ComparisonOpTest(test.TestCase):
         dtypes_lib.qint16,
         dtypes_lib.quint8,
         dtypes_lib.quint16,
+        dtypes_lib.qint32,
     ]
     x = np.asarray([0, 1, 2, 3, 4])
     y = np.asarray([0, 1, 2, 3, 4])


### PR DESCRIPTION
This PR is part of the effort for #26069 where `tf.stack` support most of the qtypes (`tf.qint8/tf.quint8/tf.qint32`)
but not `tf.qint16` and `tf.quint16`. The reason was that `TF_CALL_QUANTIZED_TYPES` does not include `qint16` and `quint16`.

This PR also update to add `qint32` for tf.equal and tf.not_equal to be consistent with other ops.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>