### PR TITLE
Update xtensa fully_connected kernel to call into xa_nnlib.

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/fully_connected.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/fully_connected.cc
@@ -196,6 +196,40 @@ TfLiteStatus EvalQuantizedInt8(TfLiteContext* context, TfLiteNode* node,
                  tflite::micro::GetTensorData<int32_t>(bias),
                  tflite::micro::GetTensorShape(output),
                  tflite::micro::GetTensorData<int8_t>(output));
+#elif defined(FUSION_F1)
+  FullyConnectedParams op_params = FullyConnectedParamsQuantized(data);
+  // Weights will always be symmetric quantized since we only support int
+  // quantization.
+  TFLITE_DCHECK(op_params.weights_offset == 0);
+
+  const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
+  const int num_batches = output_shape.Dims(0);
+  const int output_depth = output_shape.Dims(1);
+
+  const RuntimeShape& filter_shape = tflite::micro::GetTensorShape(filter);
+  const int filter_dim_count = filter_shape.DimensionsCount();
+  const int accum_depth = filter_shape.Dims(filter_dim_count - 1);
+
+  for (int b = 0; b < num_batches; ++b) {
+    TF_LITE_ENSURE_EQ(
+        context,
+        xa_nn_fully_connected_sym8sxasym8s_asym8s(
+            (tflite::micro::GetTensorData<int8_t>(output) + b * output_depth),
+            tflite::micro::GetTensorData<int8_t>(filter),
+            (tflite::micro::GetTensorData<int8_t>(input) + b * accum_depth),
+            tflite::micro::GetTensorData<int32_t>(bias), accum_depth,
+            output_depth, op_params.input_offset, op_params.output_multiplier,
+            op_params.output_shift, op_params.output_offset),
+        0);
+  }
+
+  int8_t* output_arr = tflite::micro::GetTensorData<int8_t>(output);
+  TF_LITE_ENSURE_EQ(context,
+                    xa_nn_vec_activation_min_max_8_8(
+                        output_arr, output_arr, data.output_activation_min,
+                        data.output_activation_max, num_batches * output_depth),
+                    0);
+  return kTfLiteOk;
 #else
   reference_integer_ops::FullyConnected(
       FullyConnectedParamsQuantized(data), tflite::micro::GetTensorShape(input),

--- a/tensorflow/lite/micro/kernels/xtensa/xtensa.h
+++ b/tensorflow/lite/micro/kernels/xtensa/xtensa.h
@@ -18,6 +18,8 @@ limitations under the License.
 
 #if defined(HIFIMINI)
 #include <xtensa/tie/xt_hifi2.h>
+#elif defined(FUSION_F1)
+#include "include/nnlib/xa_nnlib_api.h"
 #endif
 
 #endif  // TENSORFLOW_LITE_MICRO_KERNELS_XTENSA_XTENSA_H_

--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
@@ -29,6 +29,7 @@ ifeq ($(TARGET_ARCH), $(findstring $(TARGET_ARCH), "fusion_f1 hifi4"))
   THIRD_PARTY_CC_SRCS := $(filter-out $(EXCLUDED_NNLIB_SRCS), $(THIRD_PARTY_CC_SRCS))
 
   INCLUDES += \
+    -I$(NNLIB_PATH)/ \
     -I$(NNLIB_PATH)/algo/kernels/ \
     -I$(NNLIB_PATH)/include/nnlib/ \
     -I$(NNLIB_PATH)/include/ \


### PR DESCRIPTION
This is the relevant code snippet from https://github.com/tensorflow/tensorflow/pull/44581 that is needed to use xa_nnlib with the fully_connected kernel for fusion_f1.

Profiling the keyword benchmark shows a reduction of ~20,000 ticks for invoke (if we use the updated xa_nnlib from https://github.com/tensorflow/tensorflow/pull/44581)

```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=fusion_f1 XTENSA_CORE=F1_190305_swupgrade test_keyword_benchmark -j8
```

gives:
```
InitializeKeywordRunner() took 279792 ticks (279 ms)
KeywordRunNIerations(1) took 151304 ticks (151 ms)
KeywordRunNIerations(10) took 1512547 ticks (1512 ms)
```

Also confirmed that the kernel_fully_connected_test passes:
```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=fusion_f1 XTENSA_CORE=F1_190305_swupgrade test_kernel_fully_connected_test -j8
```

Progress towards http://b/177457688