### PR TITLE
Update TFLM docker image to be based off Ubuntu 20.04

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.micro
+++ b/tensorflow/tools/ci_build/Dockerfile.micro
@@ -1,18 +1,21 @@
 # Use a prebuilt Python image instead of base Ubuntu to speed up the build process,
 # since it has all the build dependencies we need for Micro and downloads much faster
 # than the install process.
-FROM python:3.9.0-buster
+FROM ubuntu:20.04
 
 LABEL maintainer="Pete Warden <petewarden@google.com>"
 
-RUN echo deb http://apt.llvm.org/buster/ llvm-toolchain-buster main > /etc/apt/sources.list.d/llvm.list
-RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 
 RUN apt-get update
 
-RUN apt-get install -y zip xxd
+RUN apt-get install -y python3 python3-pip build-essential
+RUN apt-get install -y zip xxd wget
+
+RUN echo deb http://apt.llvm.org/focal/ llvm-toolchain-focal main > /etc/apt/sources.list.d/llvm.list
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+RUN apt-get update
 RUN apt-get install -y clang-format
 
-RUN pip install six
+RUN pip3 install six
 # Install Renode test dependencies
-RUN pip install pyyaml requests psutil robotframework==3.1
+RUN pip3 install pyyaml requests psutil robotframework==3.1


### PR DESCRIPTION
With this, we can easily install gcc-9, and Ubuntu is also part of the CI for the broader Tensorflow project.

Fixes #46415
