### PR TITLE
Fix AllocateTensors fails for  tflite squeezenet

### DIFF
--- a/tensorflow/lite/kernels/reshape.cc
+++ b/tensorflow/lite/kernels/reshape.cc
@@ -107,8 +107,19 @@ inline TfLiteIntArray* GetOutputShapeFromParam(TfLiteContext* context,
 // Check if the shape tensor is valid. Shapes should be int32 vectors.
 inline bool ShapeIsVector(TfLiteContext* context, TfLiteNode* node) {
   const TfLiteTensor* shape = GetInput(context, node, kShapeTensor);
-  return (shape != nullptr && shape->dims->size == 1 &&
-          shape->type == kTfLiteInt32);
+  bool is_vector;
+  int num_not_one = 0;
+  if (shape != nullptr && shape->type == kTfLiteInt32) {
+    for (int i = 0; i < shape->dims->size; ++i) {
+      if (shape->dims->data[i] != 1) {
+        num_not_one++;
+      }
+    }
+    is_vector = num_not_one > 1 ? false : true;
+  } else {
+    is_vector = false;
+  }
+  return is_vector;
 }
 
 TfLiteIntArray* GetOutputShape(TfLiteContext* context, TfLiteNode* node) {


### PR DESCRIPTION
**[Purpose]**

Fix AllocateTensors fails for  tflite squeezenet

**[How to reproduce]**
1. download squeezenet (squeezenet.tflit)
2. build write test of serialization : bazel build -c opt //tensorflow/lite/tools/serialization:writer_test
3. bazel-bin/tensorflow/lite/tools/serialization/writer_test [model folder]/squeezenet.tflite

**[Result]**
```
ERROR: tensorflow/lite/kernels/reshape.cc:69 num_input_elements != num_output_elements (1001 != 1)
ERROR: Node number 38 (RESHAPE) failed to prepare.

AllocateTensors failed on the round-tripped model.
```
**[Root cause]**
https://drive.google.com/file/d/1aJGy2lvEkfAMApQV4NrY67KKc4OYFpe1/view?usp=sharing

```
// Check if the shape tensor is valid. Shapes should be int32 vectors.
inline bool ShapeIsVector(TfLiteContext* context, TfLiteNode* node) {
  const TfLiteTensor* shape = GetInput(context, node, kShapeTensor);
  return (shape != nullptr && shape->dims->size == 1 &&
          shape->type == kTfLiteInt32);
}
```
Notice that the reshape module has Shape Tensor's shape = 2 x 1.
Compared to mobilenet, where the Shape Tensor's shape = 2.  
The check within **ShapeIsVector** only considers the case where dim of shape needs to be 1.
Obviously, squeezenet fails to satisfy the condition: 
```
shape->dims->size == 1

```
Hence it uses GetOutputShapeFromParam to get output shape.
```
TfLiteIntArray* GetOutputShape(TfLiteContext* context, TfLiteNode* node) {
  if (NumInputs(node) == 2 && ShapeIsVector(context, node)) {
    return GetOutputShapeFromTensor(context, node);
  } else {
    return GetOutputShapeFromParam(context, node);
  }
``` 
However we don't have **TfLiteReshapeParams** so issue happens.

**[Proposal of fix]**
According to the semantic of function **ShapeIsVector**, allow additional ones(tailed).
Only think of the Shape Tensor **is NOT a vector** when **there are more than one "non-one" dimensions**.

**[Result]**
squeezenet.tflite is O.K (bug fix)
mobilenet.tflit is O.K (have no impact to the model which originally pass) 

