### PR TITLE
fix offset datatype for philox random kernel

### DIFF
--- a/tensorflow/core/kernels/random_op_gpu.h
+++ b/tensorflow/core/kernels/random_op_gpu.h
@@ -145,7 +145,7 @@ PHILOX_DEVICE_INLINE void FillPhiloxRandomKernel<Distribution, false>::Run(
 
   const int32 thread_id = blockIdx.x * blockDim.x + threadIdx.x;
   const int32 total_thread_count = gridDim.x * blockDim.x;
-  int32 offset = thread_id * kGroupSize;
+  int64 offset = thread_id * kGroupSize;
   if (key != nullptr && counter != nullptr) {
     gen = GetPhiloxRandomFromCounterKeyMem(counter, key);
   }

--- a/tensorflow/core/kernels/scatter_functor_gpu.cu.h
+++ b/tensorflow/core/kernels/scatter_functor_gpu.cu.h
@@ -97,7 +97,7 @@ __global__ void ScatterOpCustomKernel(T* __restrict__ params,
       // Ignore indices that are out of range.
       continue;
     }
-    int params_i = param_first_index * update_block + (i % update_block);
+    int64 params_i = param_first_index * update_block + (i % update_block);
     body(&params[params_i], ldg(updates + updates_i));
   }
 }


### PR DESCRIPTION
The offset parameter in of one of "FillPhiloxRandomKernel" template specialization as well as the "params_i" in ScatterOpCustomKernel, data types have been set to int32. This is troublesome for tensors of size bigger than 2^32. The issue is significant since initialization of many layers by default end up in this particular implementation and as a result, we cannot have a Dense layer larger than 8GB of data. Simplest replication of the issue:
`import tensorflow as tf;
tf.random.uniform(shape=[256, 8493466], maxval=3, dtype=tf.float32, seed=10)`
