### PR TITLE
Remove 'Z' because it's a local time

### DIFF
--- a/tensorflow/python/training/evaluation.py
+++ b/tensorflow/python/training/evaluation.py
@@ -252,7 +252,7 @@ def _evaluate_once(checkpoint_path,
         h._set_evals_completed_tensor(eval_step_value)  # pylint: disable=protected-access
 
   logging.info('Starting evaluation at ' +
-               time.strftime('%Y-%m-%dT%H:%M:%SZ', time.localtime()))
+               time.strftime('%Y-%m-%dT%H:%M:%S', time.localtime()))
   start = time.time()
   # Prepare the session creator.
   session_creator = monitored_session.ChiefSessionCreator(


### PR DESCRIPTION
Unless I'm mistaken, the 'Z' indicates 0-offset UTC time. Since this is using the local time, the Z is incorrect/misleading.