### PR TITLE
Revert "Change definition of tensorflow::int64 to std::int64_t."

### DIFF
--- a/tensorflow/core/platform/default/integral_types.h
+++ b/tensorflow/core/platform/default/integral_types.h
@@ -16,8 +16,6 @@ limitations under the License.
 #ifndef TENSORFLOW_CORE_PLATFORM_DEFAULT_INTEGRAL_TYPES_H_
 #define TENSORFLOW_CORE_PLATFORM_DEFAULT_INTEGRAL_TYPES_H_
 
-#include <cstdint>
-
 // IWYU pragma: private, include "third_party/tensorflow/core/platform/types.h"
 // IWYU pragma: friend third_party/tensorflow/core/platform/types.h
 
@@ -26,12 +24,12 @@ namespace tensorflow {
 typedef signed char int8;
 typedef short int16;
 typedef int int32;
-typedef std::int64_t int64;
+typedef long long int64;
 
 typedef unsigned char uint8;
 typedef unsigned short uint16;
 typedef unsigned int uint32;
-typedef std::uint64_t uint64;
+typedef unsigned long long uint64;
 
 }  // namespace tensorflow
 


### PR DESCRIPTION
This reverts commit 50c714cde2c67b4c326cbec21d9383620ffbd32d.

It breaks tf serving build.