### PR TITLE
Add SkipLine to BufferedInputStream

### DIFF
--- a/tensorflow/core/lib/io/buffered_inputstream.cc
+++ b/tensorflow/core/lib/io/buffered_inputstream.cc
@@ -220,5 +220,28 @@ string BufferedInputStream::ReadLineAsString() {
   return result;
 }
 
+Status BufferedInputStream::SkipLine() {
+  Status s;
+  bool skipped = false;
+  while (true) {
+    if (pos_ == limit_) {
+      // Get more data into buffer
+      s = FillBuffer();
+      if (limit_ == 0) {
+        break;
+      }
+    }
+    char c = buf_[pos_++];
+    skipped = true;
+    if (c == '\n') {
+      return Status::OK();
+    }
+  }
+  if (errors::IsOutOfRange(s) && skipped) {
+    return Status::OK();
+  }
+  return s;
+}
+
 }  // namespace io
 }  // namespace tensorflow

--- a/tensorflow/core/lib/io/buffered_inputstream.h
+++ b/tensorflow/core/lib/io/buffered_inputstream.h
@@ -76,6 +76,13 @@ class BufferedInputStream : public InputStreamInterface {
   // no special treatment.
   string ReadLineAsString();
 
+  // Skip one text line of data.
+  //
+  // If successful, returns OK.  If we are already at the end of the
+  // file, we return an OUT_OF_RANGE error.  Otherwise, we return
+  // some other non-OK status.
+  tensorflow::Status SkipLine();
+
   // Reads the entire contents of the file into *result.
   //
   // Note: the amount of memory used by this function call is unbounded, so only


### PR DESCRIPTION
This PR adds a `SkipLine` method to `BufferedInputStream` which will help implement the `SkipInternal` method of `TextLineDataset`, like #41222 to `TFRecordDataset`

Thank you for yor time on reviewing this PR.