### PR TITLE
[BugFix] Fix bug when reduce dimension becomes emptry in reduction_degenerate_dim_remover pass

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/reduction_degenerate_dim_remover.cc
+++ b/tensorflow/compiler/xla/service/gpu/reduction_degenerate_dim_remover.cc
@@ -65,6 +65,12 @@ class ReductionDegenerateDimRemoverVisitor : public DfsHloRewriteVisitor {
       }
     }
 
+    if (updated_reduced_dimensions.empty()) {
+      std::unique_ptr<HloInstruction> reshape = HloInstruction::CreateBitcast(
+          reduce_shape, reduced_op);
+      return ReplaceWithNewInstruction(instr, std::move(reshape));
+    }
+
     HloInstruction *input_reshape = instr->parent()->AddInstruction(
         HloInstruction::CreateBitcast(canonical_input_shape, reduced_op));
 


### PR DESCRIPTION
I have encountered the following bug triggered by reduction_degenerate_dim_remover pass for HLO. Suppose we have the following two instructions.
```
%add.127 = f32[1,512,1024]{2,1,0} .......
%reduce = f32[512,1024]{1,0} reduce(f32[1,512,1024]{2,1,0} %add.127, f32[] %constant_3), dimensions={0},
```

Then the reduction_degenerate_dim_remover pass helps to remove the only reduction dimension for ```%reduce```.
```
%add.127 = f32[1,512,1024]{2,1,0} .......
%bitcast.292 = f32[512,1024]{1,0} bitcast(f32[1,512,1024]{2,1,0} %add.127)
%reduce = f32[512,1024]{1,0} reduce(f32[512,1024]{1,0} %bitcast.292, f32[] %constant_3), dimensions={}, 
```

This leads to produce an illegal reduce instruction which causes core dump in llvm code generation phase.

So, I submit my bug fix for this scenario. The ```%reduce``` instruction is unnecessary and can be replaced by its operations (```%bitcast```) directly. 
