### PR TITLE
[BugFix] Fix bug when reduce dimension becomes empty in reduction_degenerate_dim_remover pass

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/reduction_degenerate_dim_remover.cc
+++ b/tensorflow/compiler/xla/service/gpu/reduction_degenerate_dim_remover.cc
@@ -65,6 +65,12 @@ class ReductionDegenerateDimRemoverVisitor : public DfsHloRewriteVisitor {
       }
     }
 
+    if (updated_reduced_dimensions.empty()) {
+      std::unique_ptr<HloInstruction> reshape = HloInstruction::CreateBitcast(
+          reduce_shape, reduced_op);
+      return ReplaceWithNewInstruction(instr, std::move(reshape));
+    }
+
     HloInstruction *input_reshape = instr->parent()->AddInstruction(
         HloInstruction::CreateBitcast(canonical_input_shape, reduced_op));
 

--- a/tensorflow/compiler/xla/service/gpu/tests/reduction_degenerate_dim_remover_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/reduction_degenerate_dim_remover_test.cc
@@ -69,6 +69,36 @@ ENTRY main {
       )");
 }
 
+TEST_F(ReductionDegenerateDimRemoverTest, DegenerateWithEmptyDimension) {
+  const char* hlo_text = R"(
+HloModule ReduceWithDegenerateDimensions
+
+add {
+  accum = f32[] parameter(0)
+  op = f32[] parameter(1)
+  ROOT out = f32[] add(accum, op)
+}
+
+ENTRY main {
+  input = f32[1,3,1,4,1,5,1] parameter(0)
+  zero = f32[] constant(0)
+
+  ROOT out = f32[3,4,5,1] reduce(input, zero), dimensions={0,2,4}, to_apply=add
+}
+
+)";
+
+  EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
+  // Copy insertion
+  MatchOptimizedHloWithShapes(hlo_text,
+                              R"(
+// CHECK: ENTRY %main (input: f32[1,3,1,4,1,5,1]) -> f32[3,4,5,1] {
+// CHECK:   %input = f32[1,3,1,4,1,5,1]{6,5,4,3,2,1,0} parameter(0)
+// CHECK:   %bitcast{{.+}} = f32[3,4,5,1]{3,2,1,0} bitcast(f32[1,3,1,4,1,5,1]{6,5,4,3,2,1,0} %input)
+// CHECK:   ROOT %copy{{.+}} = f32[3,4,5,1]{3,2,1,0} copy(f32[3,4,5,1]{3,2,1,0} %bitcast{{.+}})
+      )");
+}
+
 }  // namespace
 }  // namespace gpu
 }  // namespace xla

--- a/tensorflow/compiler/xla/service/gpu/tests/reduction_degenerate_dim_remover_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/reduction_degenerate_dim_remover_test.cc
@@ -89,7 +89,9 @@ ENTRY main {
 )";
 
   EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
-  // Copy insertion
+  // Copy instruction is added after bitcast because of copy-insertion pass,
+  // so we check the entire hlo module to verify there is no reduce instruction
+  // in this case.
   MatchOptimizedHloWithShapes(hlo_text,
                               R"(
 // CHECK: ENTRY %main (input: f32[1,3,1,4,1,5,1]) -> f32[3,4,5,1] {


### PR DESCRIPTION
I have encountered the following bug triggered by reduction_degenerate_dim_remover pass for HLO. Suppose we have the following two instructions.
```
%add.127 = f32[1,512,1024]{2,1,0} .......
%reduce = f32[512,1024]{1,0} reduce(f32[1,512,1024]{2,1,0} %add.127, f32[] %constant_3), dimensions={0},
```

Then the reduction_degenerate_dim_remover pass helps to remove the only reduction dimension for ```%reduce```.
```
%add.127 = f32[1,512,1024]{2,1,0} .......
%bitcast.292 = f32[512,1024]{1,0} bitcast(f32[1,512,1024]{2,1,0} %add.127)
%reduce = f32[512,1024]{1,0} reduce(f32[512,1024]{1,0} %bitcast.292, f32[] %constant_3), dimensions={}, 
```

This leads to produce an illegal reduce instruction which causes core dump in llvm code generation phase.

So, I submit my bug fix for this scenario. The ```%reduce``` instruction is unnecessary and can be replaced by its operations (```%bitcast```) directly. 

Please start a review for this PR, thanks!
 @cheshire 