### PR TITLE
Enable clang+bazel as part of the TFLM github CI.

### DIFF
--- a/tensorflow/lite/micro/CONTRIBUTING.md
+++ b/tensorflow/lite/micro/CONTRIBUTING.md
@@ -339,12 +339,22 @@ that can be expanded and improved as necessary.
         host machine.
         ```
         docker run -v `pwd`:/tensorflow -it tf_ci.micro bash
+        # cd tensorflow
+        ```
+
+      * If you would prefer to not mount your local folder on the docker image,
+        you can also simply download the branch:
+        ```
+        docker run -it tf_ci.micro bash
+        # wget https://github.com/<github-username>/tensorflow/archive/<git-branch>.zip
+        # unzip <git-branch>.zip
+        # cd tensorflow-<git-branch>
         ```
 
       * Within the docker container, you can now run the TFLM test script, or
         any other command that you would like to test. For example, the following
         commands will run all of the TFLM checks:
         ```
-        # cd tensorflow
         # tensorflow/lite/micro/tools/ci_build/test_all.sh GITHUB_PRESUBMIT
         ```
+

--- a/tensorflow/lite/micro/tools/ci_build/test_all.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_all.sh
@@ -24,6 +24,8 @@ ROOT_DIR=${SCRIPT_DIR}/../../../../..
 cd "${ROOT_DIR}"
 pwd
 
+echo "Starting to run micro tests at `date`"
+
 make -f tensorflow/lite/micro/tools/make/Makefile clean_downloads DISABLE_DOWNLOADS=true
 make -f tensorflow/lite/micro/tools/make/Makefile TAGS=cmsis-nn clean DISABLE_DOWNLOADS=true
 if [ -d tensorflow/lite/micro/tools/make/downloads ]; then
@@ -39,10 +41,24 @@ tensorflow/lite/micro/tools/ci_build/test_code_style.sh PRESUBMIT
 # pipeline and reduces duplication associated with setting up the docker
 # environment.
 
-echo "Starting to run micro tests at `date`"
+if [[ ${1} == "GITHUB_PRESUBMIT" ]]; then
+  # We enable bazel as part of the github CI only. This is because the same
+  # checks are already part of the internal CI and there isn't a good reason to
+  # duplicate them.
+  #
+  # Another reason is that the bazel checks involve some patching of TF
+  # workspace and BUILD files and this is an experiment to see what the
+  # trade-off should be between the maintenance overhead, increased CI time from
+  # the unnecessary TF downloads.
+  #
+  # See https://github.com/tensorflow/tensorflow/issues/46465 and
+  # http://b/177672856 for more context.
+  echo "Running bazel tests at `date`"
+  tensorflow/lite/micro/tools/ci_build/test_bazel.sh
+fi
 
 echo "Running x86 tests at `date`"
-tensorflow/lite/micro/tools/ci_build/test_x86.sh PRESUBMIT
+tensorflow/lite/micro/tools/ci_build/test_x86.sh
 
 echo "Running bluepill tests at `date`"
 tensorflow/lite/micro/tools/ci_build/test_bluepill.sh
@@ -63,5 +79,6 @@ tensorflow/lite/micro/tools/ci_build/test_arduino.sh
 
 echo "Running cortex_m_generic tests at `date`"
 tensorflow/lite/micro/tools/ci_build/test_cortex_m_generic.sh
+
 
 echo "Finished all micro tests at `date`"

--- a/tensorflow/lite/micro/tools/ci_build/test_bazel.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_bazel.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# This script can be used to initiate a bazel build with a reduced set of
+# downloads, but still sufficient to test all the TFLM targets.
+#
+# This is primarily intended for use from a Docker image as part of the TFLM
+# github continuous integration system. There are still a number of downloads
+# (e.g. java) that are not necessary and it may be possible to further reduce
+# the set of external libraries and downloads.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR=${SCRIPT_DIR}/../../../../..
+cd "${ROOT_DIR}"
+
+source tensorflow/lite/micro/tools/ci_build/helper_functions.sh
+
+# Replace Tensorflow's versions of files with pared down versions that download
+# a smaller set of external dependencies to speed up the CI.
+rm -f tensorflow/BUILD
+rm -f tensorflow/tensorflow.bzl
+rm -f tensorflow/workspace.bzl
+rm -f tensorflow/workspace0.bzl
+rm -f tensorflow/workspace1.bzl
+rm -f tensorflow/workspace2.bzl
+rm -f WORKSPACE
+
+cp tensorflow/lite/micro/tools/ci_build/tflm_bazel/BUILD tensorflow/
+cp tensorflow/lite/micro/tools/ci_build/tflm_bazel/tensorflow.bzl tensorflow/
+cp tensorflow/lite/micro/tools/ci_build/tflm_bazel/workspace.bzl tensorflow/
+cp tensorflow/lite/micro/tools/ci_build/tflm_bazel/WORKSPACE ./
+
+# Now that we are set up to download fewer external deps as part of a bazel
+# build, we can go ahead and invoke bazel.
+
+CC=clang bazel test tensorflow/lite/micro/... --test_tag_filters=-no_oss --build_tag_filters=-no_oss
+CC=clang bazel test tensorflow/lite/micro/... --test_tag_filters=-no_oss --build_tag_filters=-no_oss --copt=-DTF_LITE_STATIC_MEMORY

--- a/tensorflow/lite/micro/tools/ci_build/test_x86.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_x86.sh
@@ -52,11 +52,3 @@ readable_run make -s -j8 -f tensorflow/lite/micro/tools/make/Makefile build TAGS
 readable_run make -f tensorflow/lite/micro/tools/make/Makefile clean
 readable_run make -s -j8 -f tensorflow/lite/micro/tools/make/Makefile test
 
-#if [[ ${1} == "PRESUBMIT" ]]; then
-#  # Most of TFLM external contributors only use make and we add the bazel builds
-#  # as part of the CI checks. The errors, if any, will be visible to external
-#  # contributors and can be reproduced by installing bazel on their local
-#  # machines, or using the TFLM Docker container.
-#  CC=clang bazel test tensorflow/lite/micro/... --test_tag_filters=-no_oss --build_tag_filters=-no_oss
-#  CC=clang bazel test tensorflow/lite/micro/... --test_tag_filters=-no_oss --build_tag_filters=-no_oss --copt=-DTF_LITE_STATIC_MEMORY
-#fi

--- a/tensorflow/lite/micro/tools/ci_build/tflm_bazel/BUILD
+++ b/tensorflow/lite/micro/tools/ci_build/tflm_bazel/BUILD
@@ -1,0 +1,540 @@
+load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_setting")
+
+licenses(["notice"])
+
+# Config setting used when building for products
+# which requires restricted licenses to be avoided.
+config_setting(
+    name = "no_lgpl_deps",
+    define_values = {"__TENSORFLOW_NO_LGPL_DEPS__": "1"},
+    visibility = ["//visibility:public"],
+)
+
+# Config setting that disables the default logger, only logging
+# to registered TFLogSinks
+config_setting(
+    name = "no_default_logger",
+    define_values = {"no_default_logger": "true"},
+    visibility = ["//visibility:public"],
+)
+
+# Config setting for determining if we are building for Android.
+config_setting(
+    name = "android",
+    values = {"crosstool_top": "//external:android/crosstool"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "android_x86",
+    values = {
+        "crosstool_top": "//external:android/crosstool",
+        "cpu": "x86",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "android_x86_64",
+    values = {
+        "crosstool_top": "//external:android/crosstool",
+        "cpu": "x86_64",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "android_armeabi",
+    values = {
+        "crosstool_top": "//external:android/crosstool",
+        "cpu": "armeabi",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "emscripten",
+    values = {"crosstool_top": "//external:android/emscripten"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "raspberry_pi_armeabi",
+    values = {
+        "crosstool_top": "@local_config_arm_compiler//:toolchain",
+        "cpu": "armeabi",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "android_arm",
+    values = {
+        "crosstool_top": "//external:android/crosstool",
+        "cpu": "armeabi-v7a",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "android_arm64",
+    values = {
+        "crosstool_top": "//external:android/crosstool",
+        "cpu": "arm64-v8a",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "android_mips",
+    values = {
+        "crosstool_top": "//external:android/crosstool",
+        "cpu": "mips",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "android_mips64",
+    values = {
+        "crosstool_top": "//external:android/crosstool",
+        "cpu": "mips64",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "windows",
+    values = {"cpu": "x64_windows"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "no_tensorflow_py_deps",
+    define_values = {"no_tensorflow_py_deps": "true"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "macos_x86_64",
+    values = {
+        "apple_platform_type": "macos",
+        "cpu": "darwin",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "macos_arm64",
+    values = {
+        "apple_platform_type": "macos",
+        "cpu": "darwin_arm64",
+    },
+    visibility = ["//visibility:public"],
+)
+
+selects.config_setting_group(
+    name = "macos",
+    match_any = [
+        ":macos_x86_64",
+        ":macos_arm64",
+    ],
+)
+
+config_setting(
+    name = "ios",
+    values = {"apple_platform_type": "ios"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "fuchsia",
+    values = {"cpu": "fuchsia"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "ios_x86_64",
+    values = {
+        "crosstool_top": "//tools/osx/crosstool:crosstool",
+        "cpu": "ios_x86_64",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "chromiumos",
+    values = {"crosstool_top": "//external:android/chromiumos"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "linux_aarch64",
+    values = {"cpu": "aarch64"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "linux_armhf",
+    values = {"cpu": "armhf"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "linux_x86_64",
+    values = {"cpu": "k8"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "linux_ppc64le",
+    values = {"cpu": "ppc"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "linux_s390x",
+    values = {"cpu": "s390x"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "linux_mips64",
+    values = {"cpu": "mips64"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "debug",
+    values = {
+        "compilation_mode": "dbg",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "optimized",
+    values = {
+        "compilation_mode": "opt",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "arm",
+    values = {"cpu": "arm"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "armeabi",
+    values = {"cpu": "armeabi"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "armeabi-v7a",
+    values = {"cpu": "armeabi-v7a"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "arm64-v8a",
+    values = {"cpu": "arm64-v8a"},
+    visibility = ["//visibility:public"],
+)
+
+selects.config_setting_group(
+    name = "arm_any",
+    match_any = [
+        ":arm",
+        ":armeabi",
+        ":armeabi-v7a",
+        ":arm64-v8a",
+        ":linux_aarch64",
+        ":linux_armhf",
+    ],
+)
+
+config_setting(
+    name = "freebsd",
+    values = {"cpu": "freebsd"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "with_default_optimizations",
+    define_values = {"with_default_optimizations": "true"},
+    visibility = ["//visibility:public"],
+)
+
+# Features that are default ON are handled differently below.
+#
+config_setting(
+    name = "no_aws_support",
+    define_values = {"no_aws_support": "true"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "no_gcp_support",
+    define_values = {"no_gcp_support": "true"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "no_hdfs_support",
+    define_values = {"no_hdfs_support": "true"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "no_nccl_support",
+    define_values = {"no_nccl_support": "true"},
+    visibility = ["//visibility:public"],
+)
+
+# Experimental features
+config_setting(
+    name = "stackdriver_support",
+    define_values = {"stackdriver_support": "true"},
+    visibility = ["//visibility:public"],
+)
+
+# Crosses between platforms and file system libraries not supported on those
+# platforms due to limitations in nested select() statements.
+config_setting(
+    name = "with_cuda_support_windows_override",
+    define_values = {"using_cuda_nvcc": "true"},
+    values = {"cpu": "x64_windows"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "with_xla_support",
+    define_values = {"with_xla_support": "true"},
+    visibility = ["//visibility:public"],
+)
+
+# By default, XLA GPU is compiled into tensorflow when building with
+# --config=cuda even when `with_xla_support` is false. The config setting
+# here allows us to override the behavior if needed.
+config_setting(
+    name = "no_xla_deps_in_cuda",
+    define_values = {"no_xla_deps_in_cuda": "true"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "with_numa_support",
+    define_values = {"with_numa_support": "true"},
+    visibility = ["//visibility:public"],
+)
+
+# Crosses between framework_shared_object and a bunch of other configurations
+# due to limitations in nested select() statements.
+config_setting(
+    name = "framework_shared_object",
+    define_values = {"framework_shared_object": "true"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "macos_x86_64_with_framework_shared_object",
+    define_values = {
+        "framework_shared_object": "true",
+    },
+    values = {
+        "apple_platform_type": "macos",
+        "cpu": "darwin",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "macos_arm64_with_framework_shared_object",
+    define_values = {
+        "framework_shared_object": "true",
+    },
+    values = {
+        "apple_platform_type": "macos",
+        "cpu": "darwin_arm64",
+    },
+    visibility = ["//visibility:public"],
+)
+
+selects.config_setting_group(
+    name = "macos_with_framework_shared_object",
+    match_any = [
+        ":macos_x86_64_with_framework_shared_object",
+        ":macos_arm64_with_framework_shared_object",
+    ],
+)
+
+config_setting(
+    name = "using_cuda_clang",
+    define_values = {"using_cuda_clang": "true"},
+)
+
+# Config setting to use in select()s to distinguish open source build from
+# google internal build on configurable attributes.
+config_setting(
+    name = "oss",
+    flag_values = {":oss_setting": "True"},
+    visibility = ["//visibility:public"],
+)
+
+# Fixed setting to indicate open source build.
+bool_setting(
+    name = "oss_setting",
+    build_setting_default = True,
+)
+
+config_setting(
+    name = "using_cuda_clang_with_dynamic_build",
+    define_values = {
+        "using_cuda_clang": "true",
+        "framework_shared_object": "true",
+    },
+)
+
+selects.config_setting_group(
+    name = "build_oss_using_cuda_clang",
+    match_all = [
+        ":using_cuda_clang",
+        ":oss",
+    ],
+)
+
+# Setting to use when loading kernels dynamically
+config_setting(
+    name = "dynamic_loaded_kernels",
+    define_values = {
+        "dynamic_loaded_kernels": "true",
+        "framework_shared_object": "true",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "using_cuda_nvcc",
+    define_values = {"using_cuda_nvcc": "true"},
+)
+
+config_setting(
+    name = "using_cuda_nvcc_with_dynamic_build",
+    define_values = {
+        "using_cuda_nvcc": "true",
+        "framework_shared_object": "true",
+    },
+)
+
+selects.config_setting_group(
+    name = "build_oss_using_cuda_nvcc",
+    match_all = [
+        ":using_cuda_nvcc",
+        ":oss",
+    ],
+)
+
+config_setting(
+    name = "using_rocm_hipcc",
+    define_values = {"using_rocm_hipcc": "true"},
+)
+
+config_setting(
+    name = "override_eigen_strong_inline",
+    define_values = {"override_eigen_strong_inline": "true"},
+    visibility = ["//visibility:public"],
+)
+
+# This flag specifies whether TensorFlow 2.0 API should be built instead
+# of 1.* API. Note that TensorFlow 2.0 API is currently under development.
+config_setting(
+    name = "api_version_2",
+    define_values = {"tf_api_version": "2"},
+    visibility = ["//visibility:public"],
+)
+
+# This flag is defined for select statements that match both
+# on 'windows' and 'api_version_2'. In this case, bazel requires
+# having a flag which is a superset of these two.
+config_setting(
+    name = "windows_and_api_version_2",
+    define_values = {"tf_api_version": "2"},
+    values = {"cpu": "x64_windows"},
+)
+
+# This flag enables experimental MLIR support.
+config_setting(
+    name = "with_mlir_support",
+    define_values = {"with_mlir_support": "true"},
+    visibility = ["//visibility:public"],
+)
+
+# This flag forcibly enables experimental MLIR bridge support.
+config_setting(
+    name = "enable_mlir_bridge",
+    define_values = {"enable_mlir_bridge": "true"},
+    visibility = ["//visibility:public"],
+)
+
+# This flag forcibly disables experimental MLIR bridge support.
+config_setting(
+    name = "disable_mlir_bridge",
+    define_values = {"enable_mlir_bridge": "false"},
+    visibility = ["//visibility:public"],
+)
+
+# This flag enables experimental TPU support
+config_setting(
+    name = "with_tpu_support",
+    define_values = {"with_tpu_support": "true"},
+    visibility = ["//visibility:public"],
+)
+
+# Specifies via a config setting if this is a mobile build or not, makes
+# it easier to combine settings later.
+selects.config_setting_group(
+    name = "mobile",
+    match_any = [
+        ":android",
+        ":chromiumos",
+        ":emscripten",
+        ":ios",
+    ],
+)
+
+config_setting(
+    name = "lite_protos_legacy",
+    define_values = {"TENSORFLOW_PROTOS": "lite"},
+    visibility = ["//visibility:private"],
+)
+
+config_setting(
+    name = "full_protos",
+    define_values = {"TENSORFLOW_PROTOS": "full"},
+    visibility = ["//visibility:public"],
+)
+
+selects.config_setting_group(
+    name = "lite_protos",
+    match_any = [":lite_protos_legacy"],
+)
+
+selects.config_setting_group(
+    name = "mobile_lite_protos",
+    match_all = [
+        ":lite_protos",
+        ":mobile",
+    ],
+)
+
+selects.config_setting_group(
+    name = "mobile_full_protos",
+    match_all = [
+        ":full_protos",
+        ":mobile",
+    ],
+)

--- a/tensorflow/lite/micro/tools/ci_build/tflm_bazel/WORKSPACE
+++ b/tensorflow/lite/micro/tools/ci_build/tflm_bazel/WORKSPACE
@@ -1,0 +1,19 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+workspace(name = "org_tensorflow")
+
+load("@//tensorflow:workspace.bzl", "workspace")
+workspace()

--- a/tensorflow/lite/micro/tools/ci_build/tflm_bazel/tensorflow.bzl
+++ b/tensorflow/lite/micro/tools/ci_build/tflm_bazel/tensorflow.bzl
@@ -1,0 +1,114 @@
+load(
+    "@rules_cc//cc:defs.bzl",
+    "cc_binary",
+    "cc_test",
+)
+
+# version for the shared libraries, can
+# not contain rc or alpha, only numbers.
+# Also update tensorflow/core/public/version.h
+# and tensorflow/tools/pip_package/setup.py
+VERSION = "2.5.0"
+VERSION_MAJOR = VERSION.split(".")[0]
+
+tf_cc_test = cc_test
+
+def py_test(deps = [], data = [], kernels = [], exec_properties = None, **kwargs):
+    pass
+
+def if_not_windows(a):
+    return select({
+        clean_dep("//tensorflow:windows"): [],
+        "//conditions:default": a,
+    })
+
+def transitive_hdrs(name, deps = [], **kwargs):
+    pass
+
+def clean_dep(dep):
+    return str(Label(dep))
+
+def get_compatible_with_portable():
+    return []
+
+def get_compatible_with_cloud():
+    return []
+
+def tf_opts_nortti_if_android():
+    return []
+
+def tf_binary_additional_srcs(fullversion = False):
+    if fullversion:
+        suffix = "." + VERSION
+    else:
+        suffix = "." + VERSION_MAJOR
+
+    return []
+
+def tf_cc_shared_object(
+        name,
+        srcs = [],
+        deps = [],
+        data = [],
+        linkopts = [],
+        framework_so = [],
+        soversion = None,
+        kernels = [],
+        per_os_targets = False,  # Generate targets with SHARED_LIBRARY_NAME_PATTERNS
+        visibility = None,
+        **kwargs):
+    """Configure the shared object (.so) file for TensorFlow."""
+    if soversion != None:
+        suffix = "." + str(soversion).split(".")[0]
+        longsuffix = "." + str(soversion)
+    else:
+        suffix = ""
+        longsuffix = ""
+
+    names = [(
+        name,
+        name + suffix,
+        name + longsuffix,
+    )]
+
+    for name_os, name_os_major, name_os_full in names:
+        if name_os != name_os_major:
+            native.genrule(
+                name = name_os + "_sym",
+                outs = [name_os],
+                srcs = [name_os_major],
+                output_to_bindir = 1,
+                cmd = "ln -sf $$(basename $<) $@",
+            )
+            native.genrule(
+                name = name_os_major + "_sym",
+                outs = [name_os_major],
+                srcs = [name_os_full],
+                output_to_bindir = 1,
+                cmd = "ln -sf $$(basename $<) $@",
+            )
+
+        data_extra = []
+
+        cc_binary(
+            name = name_os_full,
+            srcs = srcs + framework_so,
+            deps = deps,
+            linkshared = 1,
+            data = data + data_extra,
+            linkopts = linkopts,
+            visibility = visibility,
+            **kwargs
+        )
+
+    flat_names = [item for sublist in names for item in sublist]
+    if name not in flat_names:
+        native.filegroup(
+            name = name,
+            srcs = select({
+                "//tensorflow:windows": [":%s.dll" % (name)],
+                "//tensorflow:macos": [":lib%s%s.dylib" % (name, longsuffix)],
+                "//conditions:default": [":lib%s.so%s" % (name, longsuffix)],
+            }),
+            visibility = visibility,
+        )

--- a/tensorflow/lite/micro/tools/ci_build/tflm_bazel/workspace.bzl
+++ b/tensorflow/lite/micro/tools/ci_build/tflm_bazel/workspace.bzl
@@ -1,0 +1,86 @@
+# TensorFlow external dependencies that can be loaded in WORKSPACE files.
+
+load("//tensorflow:version_check.bzl", "check_bazel_version_at_least")
+load("//third_party/clog:workspace.bzl", clog = "repo")
+load("//third_party/cpuinfo:workspace.bzl", cpuinfo = "repo")
+load("//third_party/flatbuffers:workspace.bzl", flatbuffers = "repo")
+load("//third_party/kissfft:workspace.bzl", kissfft = "repo")
+load("//third_party/ruy:workspace.bzl", ruy = "repo")
+load("//third_party:repo.bzl", "tf_http_archive")
+
+def initialize_third_party():
+    """ Load third party repositories.  See above load() statements. """
+    clog()
+    cpuinfo()
+    flatbuffers()
+    kissfft()
+    ruy()
+
+# Sanitize a dependency so that it works correctly from code that includes
+# TensorFlow as a submodule.
+def clean_dep(dep):
+    return str(Label(dep))
+
+def tf_repositories(path_prefix = "", tf_repo_name = ""):
+    """All external dependencies for TF builds."""
+
+    tf_http_archive(
+        name = "arm_neon_2_x86_sse",
+        build_file = clean_dep("//third_party:arm_neon_2_x86_sse.BUILD"),
+        sha256 = "213733991310b904b11b053ac224fee2d4e0179e46b52fe7f8735b8831e04dcc",
+        strip_prefix = "ARM_NEON_2_x86_SSE-1200fe90bb174a6224a525ee60148671a786a71f",
+        urls = [
+            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/intel/ARM_NEON_2_x86_SSE/archive/1200fe90bb174a6224a525ee60148671a786a71f.tar.gz",
+            "https://github.com/intel/ARM_NEON_2_x86_SSE/archive/1200fe90bb174a6224a525ee60148671a786a71f.tar.gz",
+        ],
+    )
+
+    # https://github.com/bazelbuild/bazel-skylib/releases
+    tf_http_archive(
+        name = "bazel_skylib",
+        sha256 = "1dde365491125a3db70731e25658dfdd3bc5dbdfd11b840b3e987ecf043c7ca0",
+        urls = [
+            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/bazelbuild/bazel-skylib/releases/download/0.9.0/bazel_skylib-0.9.0.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/0.9.0/bazel_skylib-0.9.0.tar.gz",
+        ],
+    )
+
+    tf_http_archive(
+        name = "build_bazel_rules_android",
+        sha256 = "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
+        strip_prefix = "rules_android-0.1.1",
+        urls = [
+            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/bazelbuild/rules_android/archive/v0.1.1.zip",
+            "https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip",
+        ],
+    )
+
+    tf_http_archive(
+        name = "eigen_archive",
+        build_file = clean_dep("//third_party:eigen.BUILD"),
+        patch_file = clean_dep("//third_party/eigen3:gpu_packet_math.patch"),
+        sha256 = "768b744d98505db4d73562b7813ee1e102dd185cf79a7ef1d5dbcc6e7e918eaf",  # SHARED_EIGEN_SHA
+        strip_prefix = "eigen-352f1422d3ceea19a04cab297c6339e0870e1c6c",
+        urls = [
+            "https://storage.googleapis.com/mirror.tensorflow.org/gitlab.com/libeigen/eigen/-/archive/352f1422d3ceea19a04cab297c6339e0870e1c6c/eigen-352f1422d3ceea19a04cab297c6339e0870e1c6c.tar.gz",
+            "https://gitlab.com/libeigen/eigen/-/archive/352f1422d3ceea19a04cab297c6339e0870e1c6c/eigen-352f1422d3ceea19a04cab297c6339e0870e1c6c.tar.gz",
+        ],
+    )
+
+    tf_http_archive(
+        name = "gemmlowp",
+        sha256 = "43146e6f56cb5218a8caaab6b5d1601a083f1f31c06ff474a4378a7d35be9cfb",  # SHARED_GEMMLOWP_SHA
+        strip_prefix = "gemmlowp-fda83bdc38b118cc6b56753bd540caa49e570745",
+        urls = [
+            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/google/gemmlowp/archive/fda83bdc38b118cc6b56753bd540caa49e570745.zip",
+            "https://github.com/google/gemmlowp/archive/fda83bdc38b118cc6b56753bd540caa49e570745.zip",
+        ],
+    )
+
+    initialize_third_party()
+
+def workspace():
+    # Check the bazel version before executing any repository rules, in case
+    # those rules rely on the version we require here.
+    check_bazel_version_at_least("1.0.0")
+    tf_repositories()

--- a/tensorflow/lite/micro/tools/make/flatbuffers_download.sh
+++ b/tensorflow/lite/micro/tools/make/flatbuffers_download.sh
@@ -82,6 +82,7 @@ function patch_to_avoid_strtod() {
 #   $1 - path to the downloaded flatbuffers code.
 function delete_build_files() {
   rm -f `find ${1} -name BUILD`
+  rm -f `find ${1} -name BUILD.bazel`
 }
 
 DOWNLOADED_FLATBUFFERS_PATH=${DOWNLOADS_DIR}/flatbuffers


### PR DESCRIPTION
We patch some of the TF workspace and BUILD files to reduce the number of downloads as part of a bazel build.
    
We can revisit this decision if the maintenance overhead from this patching becomes too high.
    
Also, there may be an opportunity to further reduce the downloads, but this change has made a decision to leave the TfLite build files unchanged and incur the cost of the additional downloads that are needed for TfLite but not for TfLite Micro.

Fixes #46465
Fixes http://b/177672856
