### PR TITLE
Update the TFLM CI docs based on the new way to build a docker image.

### DIFF
--- a/tensorflow/lite/micro/CONTRIBUTING.md
+++ b/tensorflow/lite/micro/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+<!-- mdformat off(b/169948621#comment2) -->
+
 <!--
 Semi-automated TOC generation with instructions from
 https://github.com/ekalinin/github-markdown-toc#auto-insert-and-update-toc
@@ -307,31 +309,42 @@ that can be expanded and improved as necessary.
     yapf log_parser.py -i --style='{based_on_style: pep8, indent_width: 2}'
     ```
 
-    # Continuous Integration System
+# Continuous Integration System
 
-    *   As a contributor, please make sure that the TfLite Micro build is green.
-        You can click on the details link to see what the errors are:
+*   As a contributor, please make sure that the TfLite Micro build is green.
+    You can click on the details link to see what the errors are:
 
-    [![TfLite Micro Build](docs/images/tflm_continuous_integration_1.png)](https://storage.googleapis.com/tensorflow-kokoro-build-badges/tflite-micro.html)
+[![TfLite Micro Build](docs/images/tflm_continuous_integration_1.png)](https://storage.googleapis.com/tensorflow-kokoro-build-badges/tflite-micro.html)
 
-    *   Most of the tests that are run as part of the CI are with the
-        [micro/tools/ci_build/test_all.sh](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/micro/tools/ci_build/test_all.sh)
-        script.
-
-        *   There are a few additional tests that use bazel that are not
-            captured by the `test_all.sh` script.
-
-    *   If an error is not reproducible on your development machine, you can
-        recreate the docker container that is used on the CI servers with the
-        following commands (run from the root of the tensorflow github repo):
-
+*   Tests that are run as part of the CI are with the
+    [micro/tools/ci_build/test_all.sh](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/micro/tools/ci_build/test_all.sh)
+    script when run with the `GITHUB_PRESUBMIT` command line parameter:
     ```
-    mkdir /tmp/tflm-docker
-    docker build -f tensorflow/tools/ci_build/Dockerfile.micro -t tflm /tmp/tflm-docker
-    docker run -v `pwd`:/tensorflow -it tflm bash
+    tensorflow/lite/micro/tools/ci_build/test_all.sh GITHUB_PRESUBMIT
     ```
 
-    The `docker run` command is mounting the tensorflow repository on your
-    machine to the docker containter. As a result, any changes made within the
-    docker container will also be reflected in the directory in the host
-    machine.
+*   If an error is not reproducible on your development machine, you can
+    recreate the docker container that is used on the CI servers.
+
+      * First, create a build a TFLM docker image with:
+        ```
+        tensorflow/tools/ci_build/ci_build.sh micro bash
+        ```
+        The second parameter to the ci_build.sh script is not important. It can
+        be any command.
+
+      * Next, mount the tensorflow repo on your machine to the docker container.
+        Please be careful (or make a separate clone of tensorflow) since any
+        changes docker container will also be reflected in the directory in the
+        host machine.
+        ```
+        docker run -v `pwd`:/tensorflow -it tf_ci.micro bash
+        ```
+
+      * Within the docker container, you can now run the TFLM test script, or
+        any other command that you would like to test. For example, the following
+        commands will run all of the TFLM checks:
+        ```
+        # cd tensorflow
+        # tensorflow/lite/micro/tools/ci_build/test_all.sh GITHUB_PRESUBMIT
+        ```


### PR DESCRIPTION
The instructions need to be updated after the change from https://github.com/tensorflow/tensorflow/commit/4491d6ee3a13956f3e455f9506459c82de9ed268