### PR TITLE
[INTEL_MKL] Add `is_weight_const` Attr for QMatMulDequantize Op

### DIFF
--- a/tensorflow/core/common_runtime/mkl_layout_pass.cc
+++ b/tensorflow/core/common_runtime/mkl_layout_pass.cc
@@ -2782,23 +2782,17 @@ void MklLayoutRewritePass::CopyAttrsQuantizedConv2D(const Node* orig_node,
 
 void MklLayoutRewritePass::CopyAttrsQuantizedMatMulWithBiasAndDequantize(
     const Node* orig_node, NodeBuilder* nb, bool change_format) {
-  DataType T1, T2, Toutput;
+  CopyAttrsAll(orig_node, nb, change_format);
+  
+  // Check and set filter attribute.
+  Node* filter_node = nullptr;
+  TF_CHECK_OK(orig_node->input_node(1, &filter_node));
+  nb->Attr("is_weight_const", filter_node->IsConstant());
 
-  // Get all attributes from old node.
+  // added "T" for facilitating MklToTf conversion.
+  DataType T1;
   TF_CHECK_OK(GetNodeAttr(orig_node->def(), "T1", &T1));
-  TF_CHECK_OK(GetNodeAttr(orig_node->def(), "T2", &T2));
-  TF_CHECK_OK(GetNodeAttr(orig_node->def(), "Toutput", &Toutput));
-
-  // Add attributes to new node.
-  nb->Attr("T1", T1);
-  nb->Attr("T2", T2);
-  nb->Attr("Toutput", Toutput);
-  nb->Attr("T", T1);  // added "T" for facilitating MklToTf conversion.
-
-  // Requantization attr Tbias
-  DataType Tbias;
-  Status bias_status = GetNodeAttr(orig_node->def(), "Tbias", &Tbias);
-  if (bias_status.ToString() == "OK") nb->Attr("Tbias", Tbias);
+  nb->Attr("T", T1);  
 }
 
 void MklLayoutRewritePass::CopyAttrsQuantizedMatMulWithBias(

--- a/tensorflow/core/common_runtime/mkl_layout_pass.cc
+++ b/tensorflow/core/common_runtime/mkl_layout_pass.cc
@@ -2789,7 +2789,7 @@ void MklLayoutRewritePass::CopyAttrsQuantizedMatMulWithBiasAndDequantize(
   TF_CHECK_OK(orig_node->input_node(1, &filter_node));
   nb->Attr("is_weight_const", filter_node->IsConstant());
 
-  // added "T" for facilitating MklToTf conversion.
+  // Add "T" for facilitating MklToTf conversion.
   DataType T1;
   TF_CHECK_OK(GetNodeAttr(orig_node->def(), "T1", &T1));
   nb->Attr("T", T1);  

--- a/tensorflow/core/ops/mkl_nn_ops.cc
+++ b/tensorflow/core/ops/mkl_nn_ops.cc
@@ -1457,6 +1457,7 @@ REGISTER_OP("_MklQuantizedMatMulWithBiasAndDequantize")
     .Attr("transpose_a: bool = false")
     .Attr("transpose_b: bool = false")
     .Attr("input_quant_mode: {'MIN_FIRST', 'SCALED'} = 'MIN_FIRST'")
+    .Attr("is_weight_const: bool = true")
     .SetShapeFn([](InferenceContext* c) {
       TF_RETURN_IF_ERROR(shape_inference::MatMulShape(c));
       ShapeHandle unused;


### PR DESCRIPTION
To add the missing `is_weight_const` attr in MklQuantizedMatMulAndDequantize registration.
