### PR TITLE
Add tf.io.encode_raw

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_EncodeRaw.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_EncodeRaw.pbtxt
@@ -1,0 +1,18 @@
+op {
+  graph_op_name: "EncodeRaw"
+  in_arg {
+    name: "tensor"
+    description: <<END
+A Tensor with at least one dimension. The first dimension will be
+treated as batch dimension and each sample in the batch will
+be encoded into a string of bytes.
+END
+  }
+  out_arg {
+    name: "output"
+    description: <<END
+A string Tensor whose shape is equal to the first dimension of tensor.
+END
+  }
+  summary: "Encode tensor into a batch of byte strings."
+}

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -4286,6 +4286,7 @@ cc_library(
         ":decode_csv_op",
         ":decode_padded_raw_op",
         ":decode_raw_op",
+        ":encode_raw_op",
         ":example_parsing_ops",
         ":parse_tensor_op",
         ":string_to_number_op",
@@ -4324,6 +4325,12 @@ tf_kernel_library(
     deps = [
         "//tensorflow/core:lib_internal",
     ] + PARSING_DEPS,
+)
+
+tf_kernel_library(
+    name = "encode_raw_op",
+    prefix = "encode_raw_op",
+    deps = PARSING_DEPS,
 )
 
 tf_kernel_library(

--- a/tensorflow/core/kernels/encode_raw_op.cc
+++ b/tensorflow/core/kernels/encode_raw_op.cc
@@ -1,0 +1,72 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// See docs in ../ops/parse_ops.cc.
+
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/framework/types.h"
+
+namespace tensorflow {
+
+template <typename T>
+class EncodeRawOp : public OpKernel {
+ public:
+  explicit EncodeRawOp(OpKernelConstruction* context) : OpKernel(context) {}
+
+  void Compute(OpKernelContext* context) override {
+    const auto& input = context->input(0);
+    int64 num_elements = input.NumElements();
+    int64 batch_size = input.shape().dim_size(0);
+    Tensor* output_tensor = nullptr;
+    OP_REQUIRES_OK(context, context->allocate_output("output", TensorShape({batch_size}),
+                                                     &output_tensor));
+    if (num_elements == 0) {
+      return;
+    }
+    int64 num_elements_per_sample = num_elements / batch_size;
+    const T* input_data = input.flat<T>().data();
+
+    auto output = output_tensor->vec<tstring>();
+    for (int64 i = 0; i < batch_size; i++) {
+      output(i).resize_uninitialized(num_elements_per_sample * sizeof(T));
+      memcpy(output(i).data(), input_data, num_elements_per_sample * sizeof(T));
+      input_data += num_elements_per_sample;
+    }
+  }
+};
+
+#define REGISTER(type)                                                       \
+  REGISTER_KERNEL_BUILDER(                                                   \
+      Name("EncodeRaw").Device(DEVICE_CPU).TypeConstraint<type>("dtype"),    \
+      EncodeRawOp<type>)
+
+REGISTER(Eigen::half);
+REGISTER(float);
+REGISTER(double);
+REGISTER(int32);
+REGISTER(uint16);
+REGISTER(uint8);
+REGISTER(int16);
+REGISTER(int8);
+REGISTER(int64);
+REGISTER(bool);
+REGISTER(complex64);
+REGISTER(complex128);
+
+#undef REGISTER
+
+}  // namespace tensorflow

--- a/tensorflow/core/ops/parsing_ops.cc
+++ b/tensorflow/core/ops/parsing_ops.cc
@@ -111,6 +111,18 @@ REGISTER_OP("DecodeRaw")
       return Status::OK();
     });
 
+REGISTER_OP("EncodeRaw")
+    .Input("tensor: dtype")
+    .Output("output: string")
+    .Attr("dtype: type")
+    .SetShapeFn([](InferenceContext* c) {
+      ShapeHandle in, out;
+      TF_RETURN_IF_ERROR(c->WithRankAtLeast(c->input(0), 1, &in));
+      TF_RETURN_IF_ERROR(c->Subshape(in, 0, 1, &out));
+      c->set_output(0, out);
+      return Status::OK();
+    });
+
 REGISTER_OP("DecodePaddedRaw")
     .Input("input_bytes: string")
     .Input("fixed_length: int32")

--- a/tensorflow/python/kernel_tests/encode_raw_op_test.py
+++ b/tensorflow/python/kernel_tests/encode_raw_op_test.py
@@ -1,0 +1,91 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for DecodeRaw op from parsing_ops."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import parsing_ops
+from tensorflow.python.platform import test
+
+
+class EncodeRawOpTest(test.TestCase):
+
+  def testShapeInference(self):
+    # Shape function requires placeholders and a graph.
+    with ops.Graph().as_default():
+      for dtype in [dtypes.bool, dtypes.int8, dtypes.uint8, dtypes.int16,
+                    dtypes.uint16, dtypes.int32, dtypes.int64, dtypes.float16,
+                    dtypes.float32, dtypes.float64, dtypes.complex64,
+                    dtypes.complex128]:
+        in_bytes = array_ops.placeholder(dtype, shape=[None, None])
+        encode = parsing_ops.encode_raw(in_bytes)
+        self.assertEqual([None], encode.get_shape().as_list())
+
+  def encodeThenDecode(self, val, dtype):
+      self.assertAllEqual(
+          val,
+          parsing_ops.decode_raw(parsing_ops.encode_raw(val), dtype))
+
+  def testUint8(self):
+    self.encodeThenDecode(
+        np.array([[ord("A")], [ord("a")]], dtype="u1"), dtype=dtypes.uint8)
+    self.encodeThenDecode(
+        np.array(
+            [[ord("w"), ord("e"), ord("r")], [ord("X"), ord("Y"), ord("Z")]],
+            dtype="u1"),
+        dtype=dtypes.uint8)
+
+  def testInt16(self):
+    self.encodeThenDecode(
+        np.array([[ord("A") + ord("a") * 256, ord("B") + ord("C") * 256]],
+                 dtype="i2"),
+        dtype=dtypes.int16)
+
+  def testFloat16(self):
+    self.encodeThenDecode(
+        np.matrix([[1, -2, -3, 4]], dtype="f2"),
+        dtype=dtypes.float16)
+
+  def testBool(self):
+    self.encodeThenDecode(
+        np.matrix([[True, False, False, True]], dtype="b1"),
+        dtype=dtypes.bool)
+
+  def testToComplex64(self):
+    self.encodeThenDecode(
+        np.matrix([[1 + 1j, 2 - 2j, -3 + 3j, -4 - 4j]], dtype="c8"),
+        dtype=dtypes.complex64)
+
+  def testToComplex128(self):
+    self.encodeThenDecode(
+        np.matrix([[1 + 1j, 2 - 2j, -3 + 3j, -4 - 4j]], dtype="c16"),
+        dtype=dtypes.complex128)
+
+  def testToUInt16(self):
+    # Use FF/EE/DD/CC so that decoded value is higher than 32768 for uint16
+    self.assertAllEqual(
+        [[0xFF + 0xEE * 256, 0xDD + 0xCC * 256]],
+        parsing_ops.decode_raw([b"\xFF\xEE\xDD\xCC"], dtypes.uint16))
+
+
+if __name__ == "__main__":
+  test.main()

--- a/tensorflow/python/ops/parsing_ops.py
+++ b/tensorflow/python/ops/parsing_ops.py
@@ -884,6 +884,24 @@ def decode_raw(input_bytes,
         input_bytes, out_type, little_endian=little_endian, name=name)
 
 
+@tf_export("io.encode_raw", v1=[])
+@dispatch.add_dispatch_support
+def encode_raw(tensor, name=None):
+  """Convert tensor into raw byte strings.
+
+  Args:
+    tensor:
+      The tensor to encode. The first dimension of the tensor will be
+      regard as batch dimension and it will be converted into a batch of
+      string tensor.
+    name: A name for the operation (optional).
+
+  Returns:
+    Each element of the input Tensor is converted to an array of bytes.
+  """
+  return gen_parsing_ops.encode_raw(tensor, name=name)
+
+
 @tf_export(v1=["decode_raw", "io.decode_raw"])
 @dispatch.add_dispatch_support
 @deprecation.deprecated_args(None,

--- a/tensorflow/python/ops/parsing_ops.py
+++ b/tensorflow/python/ops/parsing_ops.py
@@ -893,7 +893,8 @@ def encode_raw(tensor, name=None):
     tensor:
       The tensor to encode. The first dimension of the tensor will be
       regard as batch dimension and it will be converted into a batch of
-      string tensor.
+      string tensor. Acceptable types are `half`, `float`, `double`,
+      `int32`, `uint16`, `uint8`, `int16`, `int8`, `int64`.
     name: A name for the operation (optional).
 
   Returns:

--- a/tensorflow/tools/api/golden/v1/tensorflow.io.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.io.pbtxt
@@ -121,6 +121,10 @@ tf_module {
     argspec: "args=[\'sizes\', \'values\', \'field_names\', \'message_type\', \'descriptor_source\', \'name\'], varargs=None, keywords=None, defaults=[\'local://\', \'None\'], "
   }
   member_method {
+    name: "encode_raw"
+    argspec: "args=[\'tensor\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
     name: "extract_jpeg_shape"
     argspec: "args=[\'contents\', \'output_type\', \'name\'], varargs=None, keywords=None, defaults=[\"<dtype: \'int32\'>\", \'None\'], "
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.pbtxt
@@ -1221,6 +1221,10 @@ tf_module {
     argspec: "args=[\'input\', \'pad\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'None\'], "
   }
   member_method {
+    name: "encode_raw"
+    argspec: "args=[\'tensor\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
     name: "ensure_shape"
     argspec: "args=[\'x\', \'shape\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.raw_ops.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.raw_ops.pbtxt
@@ -1337,6 +1337,10 @@ tf_module {
     argspec: "args=[\'sizes\', \'values\', \'field_names\', \'message_type\', \'descriptor_source\', \'name\'], varargs=None, keywords=None, defaults=[\'local://\', \'None\'], "
   }
   member_method {
+    name: "EncodeRaw"
+    argspec: "args=[\'tensor\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
     name: "EncodeWav"
     argspec: "args=[\'audio\', \'sample_rate\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.io.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.io.pbtxt
@@ -101,6 +101,10 @@ tf_module {
     argspec: "args=[\'sizes\', \'values\', \'field_names\', \'message_type\', \'descriptor_source\', \'name\'], varargs=None, keywords=None, defaults=[\'local://\', \'None\'], "
   }
   member_method {
+    name: "encode_raw"
+    argspec: "args=[\'tensor\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
     name: "extract_jpeg_shape"
     argspec: "args=[\'contents\', \'output_type\', \'name\'], varargs=None, keywords=None, defaults=[\"<dtype: \'int32\'>\", \'None\'], "
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.pbtxt
@@ -625,6 +625,10 @@ tf_module {
     argspec: "args=[\'equation\'], varargs=inputs, keywords=kwargs, defaults=None"
   }
   member_method {
+    name: "encode_raw"
+    argspec: "args=[\'tensor\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
     name: "ensure_shape"
     argspec: "args=[\'x\', \'shape\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.raw_ops.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.raw_ops.pbtxt
@@ -1337,6 +1337,10 @@ tf_module {
     argspec: "args=[\'sizes\', \'values\', \'field_names\', \'message_type\', \'descriptor_source\', \'name\'], varargs=None, keywords=None, defaults=[\'local://\', \'None\'], "
   }
   member_method {
+    name: "EncodeRaw"
+    argspec: "args=[\'tensor\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
     name: "EncodeWav"
     argspec: "args=[\'audio\', \'sample_rate\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }


### PR DESCRIPTION
This PR implemented `tf.io.encode_raw` as a counterpart for `tf.io.decode_raw` as requested in #46493.

The interface of `encode_raw` is simply:
```python
def encode_raw(tensor, name=None):
```
And the function will return a Tensor with type `tf.string`. Because the `decode_raw` api already supports different host encoding method with `little_endian`, I think it's not necessary to have one for `encode_raw`. And it doesn't seem reasonable to have a `fixed_length` arg for `encode_raw` as well.

To make sure the `encode_raw` is the reverse operation of `decode_raw`, it will regard the first dimension of the input tensor as batch size and encode the input tensor into a batch of string tensor. In this way, we can do the following check:
```python
val == tf.io.decode_raw(tf.io.encode_raw(val), val.dtype)
```
(which is also how I implemented the test in `encode_raw_op_test.py`).

Thank you for your time on reviewing this PR :).
