### PR TITLE
Make tf.image.resize compatible with XLA compilation

### DIFF
--- a/tensorflow/compiler/tests/randomized_tests.cc
+++ b/tensorflow/compiler/tests/randomized_tests.cc
@@ -2691,13 +2691,23 @@ TEST_F(OpTest, ResizeBilinear) {
     std::vector<int64> in_dims = RandomDims(4, 4);
     std::vector<int64> out_dims = RandomDims(2, 2);
 
+    bool half_pixel_centers = Choose<bool>({false, true});
+    bool align_corners = Choose<bool>({false, true});
+    // half_pixel_centers and align_corners can not both be true.
+    if (half_pixel_centers) {
+      align_corners = false;
+    }
+
+    auto dtype = Choose<DataType>({DT_FLOAT, DT_DOUBLE});
+
     return ExpectTfAndXlaOutputsAreClose(
         OpTestBuilder("ResizeBilinear")
-            .RandomInput(DT_FLOAT, in_dims)
+            .RandomInput(dtype, in_dims)
             .Input(test::AsTensor<int32>(
                 std::vector<int32>(out_dims.begin(), out_dims.end())))
-            .Attr("T", DT_FLOAT)
-            .Attr("align_corners", true));
+            .Attr("T", dtype)
+            .Attr("half_pixel_centers", half_pixel_centers)
+            .Attr("align_corners", align_corners));
   });
 }
 
@@ -2713,6 +2723,30 @@ TEST_F(OpTest, ResizeBilinearGrad) {
                          {in_dims[0], out_dims[0], out_dims[1], in_dims[3]})
             .Attr("T", DT_FLOAT)
             .Attr("align_corners", true));
+  });
+}
+
+TEST_F(OpTest, ResizeNearestNeighbor) {
+  Repeatedly([this]() {
+    std::vector<int64> in_dims = RandomDims(4, 4);
+    std::vector<int64> out_dims = RandomDims(2, 2);
+
+    bool half_pixel_centers = Choose<bool>({false, true});
+    bool align_corners = Choose<bool>({false, true});
+    // half_pixel_centers and align_corners can not both be true.
+    if (half_pixel_centers) {
+      align_corners = false;
+    }
+    auto dtype = Choose<DataType>({DT_FLOAT, DT_DOUBLE});
+
+    return ExpectTfAndXlaOutputsAreClose(
+        OpTestBuilder("ResizeNearestNeighbor")
+            .RandomInput(dtype, in_dims)
+            .Input(test::AsTensor<int32>(
+                std::vector<int32>(out_dims.begin(), out_dims.end())))
+            .Attr("T", dtype)
+            .Attr("half_pixel_centers", half_pixel_centers)
+            .Attr("align_corners", align_corners));
   });
 }
 

--- a/tensorflow/compiler/tf2xla/kernels/image_resize_ops.h
+++ b/tensorflow/compiler/tf2xla/kernels/image_resize_ops.h
@@ -28,7 +28,6 @@ class ResizeNearestNeighborOp : public XlaOpKernel {
  protected:
   bool align_corners_ = true;
   bool half_pixel_centers_ = true;
-  bool is_kernel_bilinear_ = false;
 };
 
 class ResizeBilinearOp : public XlaOpKernel {
@@ -40,7 +39,6 @@ class ResizeBilinearOp : public XlaOpKernel {
  protected:
   bool align_corners_ = true;
   bool half_pixel_centers_ = true;
-  bool is_kernel_bilinear_ = true;
 };
 
 class ResizeBilinearGradOp : public XlaOpKernel {


### PR DESCRIPTION
Forward part of #46447. This PR supports combinations of `half_pixel_centers` and `align_corners`, which makes `tf.image.resize` compatible with XLA compilation.
Speedup at least 10x compared to original implementation (dilated conv) and reduce required space for intermediate output to O(output height * output width).

I do not get a chance to test on local GPU, but I benchmark on colab with similar python operations with jit compilation.

- nearest neighbor: https://colab.research.google.com/drive/1W6pFlFn1fVB3O885opiChMUd9C2Dn1cI?usp=sharing
- bilinear: https://colab.research.google.com/drive/11ysUlrCXcaIV0fLGPUZbYUY2CNkRJOVi?usp=sharing

At least 10x speedup, and less memory requirement (change to larger size and CUDA will be OOM for original implementation).

Hi @hawkinsp, I see you're the author of original implementation from commit history. Could you review this when time allows? Thank you!