### PR TITLE
Go: Deallocate large TF_TString on Tensor finalization

### DIFF
--- a/tensorflow/go/tensor.go
+++ b/tensorflow/go/tensor.go
@@ -95,8 +95,17 @@ func NewTensor(value interface{}) (*Tensor, error) {
 		c:     C.TF_AllocateTensor(C.TF_DataType(dataType), shapePtr, C.int(len(shape)), C.size_t(nbytes)),
 		shape: shape,
 	}
-	runtime.SetFinalizer(t, (*Tensor).finalize)
+
 	raw := tensorData(t.c)
+
+	runtime.SetFinalizer(t, func(t *Tensor) {
+		if dataType == String {
+			t.clearTStrings(raw, nflattened)
+		}
+
+		t.finalize()
+	})
+
 	buf := bytes.NewBuffer(raw[:0:len(raw)])
 
 	if isAllArray(val.Type()) {
@@ -204,6 +213,14 @@ func newTensorFromC(c *C.TF_Tensor) *Tensor {
 	t := &Tensor{c: c, shape: shape}
 	runtime.SetFinalizer(t, (*Tensor).finalize)
 	return t
+}
+
+func (t *Tensor) clearTStrings(raw []byte, n int64) {
+	tstrs := (*(*[]C.TF_TString)(unsafe.Pointer(&raw)))[:n]
+
+	for _, tstr := range tstrs {
+		C.TF_TString_Dealloc(&tstr)
+	}
 }
 
 func (t *Tensor) finalize() { C.TF_DeleteTensor(t.c) }


### PR DESCRIPTION
Since version 2.4 Tensorflow [moved](https://github.com/tensorflow/tensorflow/commit/b9b042cfd91908456055564ffa2ce86bfa44bda9) to the [new way](https://github.com/tensorflow/community/pull/91) to store string tensors.

Earlier `std::string` was used an array of strings was encoded as an array of 8-byte offsets followed by string data. With the current design of the `tensorflow::tstring` creating tensor with `NewTensor` function could allocate string in two ways ([description of the tstring types](https://github.com/tensorflow/tensorflow/blob/a2766ce758be7d31e1f4aab93ef2328d4a56b07a/tensorflow/core/platform/ctstring.h#L53)):
- `TF_TSTR_SMALL` -  the contents of strings less than 22-bytes are stored in the TF_TString struct
- `TF_TSTR_LARGE` - Heap allocated string

The second case assumes that, in addition to [TF_DeleteTensor](https://github.com/tensorflow/tensorflow/blob/71c1ae43e2504da27ab60d1848b5fc0deec3fb31/tensorflow/c/tf_tensor.h#L111), the string should be deallocated with [TF_TString_Dealloc](https://github.com/tensorflow/tensorflow/blob/3fcba829d82ea34245db62afd45b9523e8db02d4/tensorflow/core/platform/ctstring.h#L28). This situation [wasn't handled](https://github.com/tensorflow/tensorflow/commit/24f835217fd27f21141ff0254a2b93ea3cfd7b6c#diff-025d2fb7b19fc74ebf16c55f0e3bd73d8c0530bddb63f9a9b1e322303515bf98) in the Go bindings.