### PR TITLE
Fix an issue for multi CUPTI sessions

### DIFF
--- a/tensorflow/core/profiler/internal/gpu/cupti_tracer.cc
+++ b/tensorflow/core/profiler/internal/gpu/cupti_tracer.cc
@@ -1597,7 +1597,7 @@ int CuptiTracer::NumGpus() {
   return num_gpus;
 }
 
-void CuptiTracer::Enable(const CuptiTracerOptions &option,
+bool CuptiTracer::Enable(const CuptiTracerOptions &option,
                          CuptiTraceCollector *collector) {
   option_ = option;
   collector_ = collector;
@@ -1612,11 +1612,12 @@ void CuptiTracer::Enable(const CuptiTracerOptions &option,
 
   Status status = EnableApiTracing();
   need_root_access_ |= status.code() == error::PERMISSION_DENIED;
-  if (!status.ok()) return;
+  if (!status.ok()) return false;
 
   if (option_->enable_activity_api) {
     EnableActivityTracing().IgnoreError();
   }
+  return true;
 }
 
 void CuptiTracer::Disable() {

--- a/tensorflow/core/profiler/internal/gpu/cupti_tracer.h
+++ b/tensorflow/core/profiler/internal/gpu/cupti_tracer.h
@@ -87,7 +87,7 @@ class CuptiTracer {
   bool IsAvailable() const;
   bool NeedRootAccess() const { return need_root_access_; }
 
-  void Enable(const CuptiTracerOptions& option, CuptiTraceCollector* collector);
+  bool Enable(const CuptiTracerOptions& option, CuptiTraceCollector* collector);
   void Disable();
 
   Status HandleCallback(CUpti_CallbackDomain domain, CUpti_CallbackId cbid,

--- a/tensorflow/core/profiler/internal/gpu/cupti_tracer.h
+++ b/tensorflow/core/profiler/internal/gpu/cupti_tracer.h
@@ -87,6 +87,7 @@ class CuptiTracer {
   bool IsAvailable() const;
   bool NeedRootAccess() const { return need_root_access_; }
 
+  // Returns a boolean telling whether the CUPTI tracer was enabled.
   bool Enable(const CuptiTracerOptions& option, CuptiTraceCollector* collector);
   void Disable();
 

--- a/tensorflow/core/profiler/internal/gpu/device_tracer.cc
+++ b/tensorflow/core/profiler/internal/gpu/device_tracer.cc
@@ -158,7 +158,11 @@ Status GpuTracer::DoStart() {
                                           start_gputime_ns);
 
   AnnotationStack::Enable(true);
-  cupti_tracer_->Enable(options_, cupti_collector_.get());
+  bool ret = cupti_tracer_->Enable(options_, cupti_collector_.get());
+  if (!ret) {
+    return errors::Unavailable("CUPTI cannot be enabled. Another profile "
+                               "session might be running.");
+  }
   return Status::OK();
 }
 


### PR DESCRIPTION
When using an external profiler tools (like NVIDIA Nsight Systems), some collected components might be missing in the profiling results if the TF profiler is used in the python script. This PR fixes this issue by explicitly checking if the CUPTI tracer is successfully enabled or not. If not, we return an error msg instead of a OK status.

FYI. @nluehr 