### PR TITLE
Allow environment variables to execution of flatc command

### DIFF
--- a/third_party/flatbuffers/build_defs.bzl
+++ b/third_party/flatbuffers/build_defs.bzl
@@ -320,6 +320,7 @@ def _gen_flatbuffer_srcs_impl(ctx):
                 src.path,
             ],
             progress_message = "Generating flatbuffer files for {}:".format(src),
+            use_default_shell_env = True,
         )
     return [
         DefaultInfo(files = depset(outputs)),


### PR DESCRIPTION
Allow setting of LD_LIBRARY_PATH to reach execution environment of flatc so it can load correct version of libstdc++ and so avoid build failure when built with non-system gcc
Fixes #46549 