### PR TITLE
[INTEL MKL] Remove unnecessary oneDNN dependency.

### DIFF
--- a/tensorflow/core/common_runtime/BUILD
+++ b/tensorflow/core/common_runtime/BUILD
@@ -39,7 +39,6 @@ load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda")
 load(
     "//third_party/mkl:build_defs.bzl",
     "if_mkl",
-    "mkl_deps",
 )
 
 default_package_visibility = [
@@ -1030,7 +1029,7 @@ cc_library(
         ":bfc_allocator",
         ":pool_allocator",
         "//tensorflow/core:lib",
-    ] + mkl_deps(),
+    ],
 )
 
 cc_library(
@@ -1051,7 +1050,7 @@ cc_library(
         "//tensorflow/core:lib",
         "//tensorflow/core:lib_internal",
         "//tensorflow/core:protos_all_cc",
-    ] + mkl_deps(),
+    ],
     alwayslink = 1,
 )
 
@@ -1071,7 +1070,7 @@ cc_library(
         "//tensorflow/core:graph",
         "//tensorflow/core:lib",
         "//tensorflow/core:lib_internal",
-    ] + mkl_deps(),
+    ],
     alwayslink = 1,
 )
 
@@ -1668,7 +1667,7 @@ tf_cuda_library(
         "//tensorflow/core/grappler/clusters:virtual_cluster",
         "//tensorflow/core/grappler/optimizers:meta_optimizer",
         "//third_party/eigen3",
-    ] + mkl_deps() + tf_additional_core_deps() + if_static([
+    ] + tf_additional_core_deps() + if_static([
         ":core_cpu_impl",
         "//tensorflow/core:function_ops_op_lib",
         "//tensorflow/core:functional_grad",

--- a/tensorflow/core/common_runtime/BUILD
+++ b/tensorflow/core/common_runtime/BUILD
@@ -1043,13 +1043,13 @@ cc_library(
     deps = [
         ":function",
         ":optimization_registry",
-        "@com_google_absl//absl/base",
         "//tensorflow/core:framework",
         "//tensorflow/core:framework_internal",
         "//tensorflow/core:graph",
         "//tensorflow/core:lib",
         "//tensorflow/core:lib_internal",
         "//tensorflow/core:protos_all_cc",
+        "@com_google_absl//absl/base",
     ],
     alwayslink = 1,
 )


### PR DESCRIPTION
Removes the redundant inclusion of oneDNN in libtensorflow_framework.so.2.