### PR TITLE
Add sanitizer builds to the TFLM CI.

### DIFF
--- a/tensorflow/lite/micro/CONTRIBUTING.md
+++ b/tensorflow/lite/micro/CONTRIBUTING.md
@@ -212,15 +212,15 @@ to determine if the requested feature aligns with the TFLM roadmap.
     Please check the READMEs in the optimized kernel directories for specific
     instructions.
 
-1.  Sometimes, bugs are caught by the address sanitizer that can go unnoticed
-    via the Makefile. To run a test with the address sanitizer, use the
-    following command (replace `micro_interpreter_test` with the target that you
+1.  Sometimes, bugs are caught by the sanitizers that can go unnoticed
+    via the Makefile. To run a test with the different sanitizers, use the
+    following commands (replace `micro_interpreter_test` with the target that you
     want to test:
 
     ```
-    CC=clang BAZEL_COMPILER=llvm bazel run --copt=-DADDRESS_SANITIZER \
-    --copt=-fsanitize=address --linkopt=-fsanitize=address \
-    tensorflow/lite/micro:micro_interpreter_test
+    CC=clang bazel test ---config=asan tensorflow/lite/micro:micro_interpreter_test
+    CC=clang bazel test ---config=msan tensorflow/lite/micro:micro_interpreter_test
+    CC=clang bazel test ---config=ubsan tensorflow/lite/micro:micro_interpreter_test
     ```
 
 ## During the PR review

--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -732,7 +732,10 @@ tflite_micro_cc_test(
     srcs = [
         "pad_test.cc",
     ],
-    tags = ["nomsan"],  # b/175133159
+    tags = [
+        "noasan",
+        "nomsan",
+    ],  # TODO(b/175133159): currently failing with asan and msan
     deps = [
         ":kernel_runner",
         "//tensorflow/lite/c:common",

--- a/tensorflow/lite/micro/tools/ci_build/test_bazel.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_bazel.sh
@@ -32,21 +32,25 @@ source tensorflow/lite/micro/tools/ci_build/helper_functions.sh
 
 # Replace Tensorflow's versions of files with pared down versions that download
 # a smaller set of external dependencies to speed up the CI.
-rm -f tensorflow/BUILD
-rm -f tensorflow/tensorflow.bzl
-rm -f tensorflow/workspace.bzl
-rm -f tensorflow/workspace0.bzl
-rm -f tensorflow/workspace1.bzl
-rm -f tensorflow/workspace2.bzl
-rm -f WORKSPACE
+readable_run rm -f tensorflow/BUILD
+readable_run rm -f tensorflow/tensorflow.bzl
+readable_run rm -f tensorflow/workspace.bzl
+readable_run rm -f tensorflow/workspace0.bzl
+readable_run rm -f tensorflow/workspace1.bzl
+readable_run rm -f tensorflow/workspace2.bzl
+readable_run rm -f WORKSPACE
 
-cp tensorflow/lite/micro/tools/ci_build/tflm_bazel/BUILD tensorflow/
-cp tensorflow/lite/micro/tools/ci_build/tflm_bazel/tensorflow.bzl tensorflow/
-cp tensorflow/lite/micro/tools/ci_build/tflm_bazel/workspace.bzl tensorflow/
-cp tensorflow/lite/micro/tools/ci_build/tflm_bazel/WORKSPACE ./
+readable_run cp tensorflow/lite/micro/tools/ci_build/tflm_bazel/BUILD tensorflow/
+readable_run cp tensorflow/lite/micro/tools/ci_build/tflm_bazel/tensorflow.bzl tensorflow/
+readable_run cp tensorflow/lite/micro/tools/ci_build/tflm_bazel/workspace.bzl tensorflow/
+readable_run cp tensorflow/lite/micro/tools/ci_build/tflm_bazel/WORKSPACE ./
 
 # Now that we are set up to download fewer external deps as part of a bazel
 # build, we can go ahead and invoke bazel.
 
-CC=clang bazel test tensorflow/lite/micro/... --test_tag_filters=-no_oss --build_tag_filters=-no_oss
-CC=clang bazel test tensorflow/lite/micro/... --test_tag_filters=-no_oss --build_tag_filters=-no_oss --copt=-DTF_LITE_STATIC_MEMORY
+CC=clang readable_run bazel test tensorflow/lite/micro/... --test_tag_filters=-no_oss --build_tag_filters=-no_oss
+CC=clang readable_run bazel test tensorflow/lite/micro/... --config=msan --test_tag_filters=-no_oss,-nomsan --build_tag_filters=-no_oss,-nomsan
+CC=clang readable_run bazel test tensorflow/lite/micro/... --config=asan --test_tag_filters=-no_oss,-noasan --build_tag_filters=-no_oss,-noasan
+# TODO(b/178621680): enable ubsan once bazel + clang + ubsan errors are fixed.
+#CC=clang readable_run bazel test tensorflow/lite/micro/... --config=ubsan --test_tag_filters=-no_oss,-noubsan --build_tag_filters=-no_oss,-noubsan
+CC=clang readable_run bazel test tensorflow/lite/micro/... --test_tag_filters=-no_oss --build_tag_filters=-no_oss --copt=-DTF_LITE_STATIC_MEMORY


### PR DESCRIPTION
Also, updated the docs with the new way of using the sanitizers with bazel.
    
With https://github.com/tensorflow/tensorflow/commit/38f8ad1795b392f0f6bdf86a5a9c4f227bac7b76 we now have a more concise way of using asan/msan/ubsan with bazel.
    
Fixes http://b/177076500

Still open issue: http://b/178621680
