### PR TITLE
constant learning rate logging added to TensorBoard callback

### DIFF
--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -2440,6 +2440,8 @@ class TensorBoard(Callback, version_utils.TensorBoardVersionSelector):
     lr_schedule = getattr(self.model.optimizer, 'lr', None)
     if isinstance(lr_schedule, learning_rate_schedule.LearningRateSchedule):
       logs['learning_rate'] = lr_schedule(self.model.optimizer.iterations)
+    elif lr_schedule is not None:
+      logs['learning_rate'] = lr_schedule
     return logs
 
   def _compute_steps_per_second(self):


### PR DESCRIPTION
Allowing TensorBoard callback to log leraning rate (lr) even if there is no scheduler used. Tensorboard will log every lr even when it is a constant. This is especially important when using ReduceLROnPlateau callback as the lr is treated as constatnt in every iteration and changed by assigning a new constant. 