### PR TITLE
remove duplicated lines in documentation

### DIFF
--- a/tensorflow/python/keras/layers/preprocessing/image_preprocessing.py
+++ b/tensorflow/python/keras/layers/preprocessing/image_preprocessing.py
@@ -767,14 +767,6 @@ class RandomRotation(PreprocessingLayer):
   At inference time, the layer does nothing. If you need to apply random
   rotations at inference time, set `training` to True when calling the layer.
 
-  Input shape:
-    4D tensor with shape:
-    `(samples, height, width, channels)`, data_format='channels_last'.
-
-  Output shape:
-    4D tensor with shape:
-    `(samples, height, width, channels)`, data_format='channels_last'.
-
   Attributes:
     factor: a float represented as fraction of 2pi, or a tuple of size
       2 representing lower and upper bound for rotating clockwise and

--- a/tensorflow/python/keras/layers/preprocessing/image_preprocessing.py
+++ b/tensorflow/python/keras/layers/preprocessing/image_preprocessing.py
@@ -767,6 +767,14 @@ class RandomRotation(PreprocessingLayer):
   At inference time, the layer does nothing. If you need to apply random
   rotations at inference time, set `training` to True when calling the layer.
 
+  Input shape:
+    4D tensor with shape:
+    `(samples, height, width, channels)`, data_format='channels_last'.
+
+  Output shape:
+    4D tensor with shape:
+    `(samples, height, width, channels)`, data_format='channels_last'.
+
   Attributes:
     factor: a float represented as fraction of 2pi, or a tuple of size
       2 representing lower and upper bound for rotating clockwise and

--- a/tensorflow/python/keras/layers/preprocessing/image_preprocessing.py
+++ b/tensorflow/python/keras/layers/preprocessing/image_preprocessing.py
@@ -802,13 +802,6 @@ class RandomRotation(PreprocessingLayer):
     fill_value: a float represents the value to be filled outside the
       boundaries when `fill_mode` is "constant".
 
-  Input shape:
-    4D tensor with shape: `(samples, height, width, channels)`,
-      data_format='channels_last'.
-  Output shape:
-    4D tensor with shape: `(samples, height, width, channels)`,
-      data_format='channels_last'.
-
   Raise:
     ValueError: if either bound is not between [0, 1], or upper bound is
       less than lower bound.


### PR DESCRIPTION
Remove duplicated lines in documentation. See: https://www.tensorflow.org/api_docs/python/tf/keras/layers/experimental/preprocessing/RandomRotation

![Captura de tela de 2021-01-21 09-44-28](https://user-images.githubusercontent.com/12160840/105353478-0c23de80-5bce-11eb-9589-890722f33d31.png)
