### PR TITLE
Fix build errors on OSX

### DIFF
--- a/tensorflow/lite/examples/minimal/CMakeLists.txt
+++ b/tensorflow/lite/examples/minimal/CMakeLists.txt
@@ -35,6 +35,7 @@ add_subdirectory(
   EXCLUDE_FROM_ALL
 )
 
+set(CMAKE_CXX_STANDARD 11)
 add_executable(minimal
   minimal.cc
 )


### PR DESCRIPTION
Without explicitly specifying C++ 11 as a required minimal version, on OSX Catalina I was getting these errors:

```
➜  hello_tflite pwd
/tmp/hello_tflite
➜  hello_tflite cmake --build . -j
[100%] Building CXX object tensorflow-lite/CMakeFiles/tensorflow-lite.dir/tools/optimize/sparsity/format_converter.cc.o
[100%] Linking CXX static library libtensorflow-lite.a
[100%] Built target tensorflow-lite
Scanning dependencies of target minimal
[100%] Building CXX object CMakeFiles/minimal.dir/minimal.cc.o
In file included from /Users/tleyden/Development/tensorflow_src/tensorflow/lite/examples/minimal/minimal.cc:16:
In file included from /Users/tleyden/Development/tensorflow_src/tensorflow/lite/interpreter.h:34:
/Users/tleyden/Development/tensorflow_src/tensorflow/lite/allocation.h:38:8: warning: scoped enumerations are a
      C++11 extension [-Wc++11-extensions]
  enum class Type {
       ^
/Users/tleyden/Development/tensorflow_src/tensorflow/lite/allocation.h:66:28: warning: 'override' keyword is a C++11
      extension [-Wc++11-extensions]
  const void* base() const override;
                           ^
/Users/tleyden/Development/tensorflow_src/tensorflow/lite/allocation.h:67:24: warning: 'override' keyword is a C++11
      extension [-Wc++11-extensions]
  size_t bytes() const override;
etc..
```

Adding the proposed change fixed the issues.