### PR TITLE
Update broken GitHub policy link in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/00-bug-issue.md
+++ b/.github/ISSUE_TEMPLATE/00-bug-issue.md
@@ -6,7 +6,7 @@ labels: 'type:bug'
 ---
 
 <em>Please make sure that this is a bug. As per our
-[GitHub Policy](https://github.com/tensorflow/tensorflow/blob/master/ISSUES.md),
+[GitHub Policy](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/opensource_only/ISSUES.md),
 we only address code/doc bugs, performance issues, feature requests and
 build/installation issues on GitHub. tag:bug_template</em>
 

--- a/.github/ISSUE_TEMPLATE/10-build-installation-issue.md
+++ b/.github/ISSUE_TEMPLATE/10-build-installation-issue.md
@@ -5,7 +5,7 @@ labels: 'type:build/install'
 
 ---
 
-<em>Please make sure that this is a build/installation issue. As per our [GitHub Policy](https://github.com/tensorflow/tensorflow/blob/master/ISSUES.md), we only address code/doc bugs, performance issues, feature requests and build/installation issues on GitHub. tag:build_template</em>
+<em>Please make sure that this is a build/installation issue. As per our [GitHub Policy](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/opensource_only/ISSUES.md), we only address code/doc bugs, performance issues, feature requests and build/installation issues on GitHub. tag:build_template</em>
 
 **System information**
 - OS Platform and Distribution (e.g., Linux Ubuntu 16.04):

--- a/.github/ISSUE_TEMPLATE/20-documentation-issue.md
+++ b/.github/ISSUE_TEMPLATE/20-documentation-issue.md
@@ -6,8 +6,7 @@ labels: 'type:docs'
 ---
 
 
-Thank you for submitting a TensorFlow documentation issue. Per our GitHub
-policy, we only address code/doc bugs, performance issues, feature requests, and
+Thank you for submitting a TensorFlow documentation issue. As per our [GitHub Policy](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/opensource_only/ISSUES.md), we only address code/doc bugs, performance issues, feature requests, and
 build/installation issues on GitHub.
 
 The TensorFlow docs are open source! To get involved, read the documentation

--- a/.github/ISSUE_TEMPLATE/30-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/30-feature-request.md
@@ -5,7 +5,7 @@ labels: 'type:feature'
 
 ---
 
-<em>Please make sure that this is a feature request. As per our [GitHub Policy](https://github.com/tensorflow/tensorflow/blob/master/ISSUES.md), we only address code/doc bugs, performance issues, feature requests and build/installation issues on GitHub. tag:feature_template</em>
+<em>Please make sure that this is a feature request. As per our [GitHub Policy](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/opensource_only/ISSUES.md), we only address code/doc bugs, performance issues, feature requests and build/installation issues on GitHub. tag:feature_template</em>
 
 
 **System information**

--- a/.github/ISSUE_TEMPLATE/80-performance-issue.md
+++ b/.github/ISSUE_TEMPLATE/80-performance-issue.md
@@ -7,7 +7,7 @@ labels: 'type:performance'
 
 <em>Please make sure that this is an issue related to performance of TensorFlow.
 As per our
-[GitHub Policy](https://github.com/tensorflow/tensorflow/blob/master/ISSUES.md),
+[GitHub Policy](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/opensource_only/ISSUES.md),
 we only address code/doc bugs, performance issues, feature requests and
 build/installation issues on GitHub. tag:performance_template</em>
 


### PR DESCRIPTION
The GitHub policy page has been moved from 

https://github.com/tensorflow/tensorflow/blob/master/ISSUES.md

to 

https://github.com/tensorflow/tensorflow/blob/master/tensorflow/opensource_only/ISSUES.md

Updated the links in the issue templates. Fixes [#46592](https://github.com/tensorflow/tensorflow/issues/46592).