### PR TITLE
Incomplete ImageProjectiveTransformV3 documentation.

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_ImageProjectiveTransformV3.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ImageProjectiveTransformV3.pbtxt
@@ -49,7 +49,7 @@ END
   attr {
     name: "fill_mode"
     description: <<END
-Fill mode, "REFLECT", "WRAP", or "CONSTANT".
+Fill mode, "REFLECT", "WRAP", "CONSTANT", or "NEAREST".
 END
   }
   summary: "Applies the given transform to each of the images."


### PR DESCRIPTION
"NEAREST" option is missing in the documentation: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/kernels/image/image_ops.cc/#L141