### PR TITLE
Update vexriscv + zephyr makefiles.

### DIFF
--- a/tensorflow/lite/micro/tools/make/targets/zephyr_vexriscv_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/zephyr_vexriscv_makefile.inc
@@ -1,6 +1,3 @@
-ifeq ($(TARGET), zephyr_vexriscv)
-  $(eval $(call add_third_party_download,$(ZEPHYR_URL),$(ZEPHYR_MD5),zephyr,setup_zephyr))
-  export ZEPHYR_SDK_INSTALL_DIR?=/opt/zephyr-sdk
-  export ZEPHYR_BASE?=$(realpath $(MAKEFILE_DIR)/downloads/zephyr)
-endif
-
+$(eval $(call add_third_party_download,$(ZEPHYR_URL),$(ZEPHYR_MD5),zephyr,setup_zephyr))
+export ZEPHYR_SDK_INSTALL_DIR?=/opt/zephyr-sdk
+export ZEPHYR_BASE?=$(realpath $(MAKEFILE_DIR)/downloads/zephyr)


### PR DESCRIPTION
Tested that the following commands work:
```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=zephyr_vexriscv OPTIMIZED_KERNEL_DIR=vexriscv third_party_downloads
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=zephyr_vexriscv OPTIMIZED_KERNEL_DIR=vexriscv microlite
```
