### PR TITLE
genop: backport fix for template error

### DIFF
--- a/tensorflow/go/genop/internal/genop.go
+++ b/tensorflow/go/genop/internal/genop.go
@@ -264,7 +264,7 @@ func {{$.Op.Name}}{{CamelCase .RenameTo}}(value {{GoType .Type}}) {{$.Op.Name}}A
 {{- else }}
 {{- if .DescribeOutputs}}
 //
-{{- if ((len .OutArgs) eq 1) }}
+{{- if eq (len .OutArgs) 1 }}
 // Returns {{range .OutArgs}}{{MakeComment .Description}}{{end}}
 {{- else }}
 // Returns:


### PR DESCRIPTION
Rewrite a conditional in a template to be syntactically valid.

PiperOrigin-RevId: 284055201
Change-Id: Ie0129e7553857076e60e4d5d85e912a7893168d9