### PR TITLE
fixed the output description of bucketized column to one-hot encoded value

### DIFF
--- a/tensorflow/python/feature_column/feature_column_v2.py
+++ b/tensorflow/python/feature_column/feature_column_v2.py
@@ -1416,9 +1416,9 @@ def bucketized_column(source_column, boundaries):
   then the output will be
 
   ```python
-  output = [[0, 3]
-            [3, 2]
-            [1, 3]]
+  output = [[[1, 0, 0, 0], [0, 0, 0, 1]]
+            [[0, 0, 0, 1], [0, 0, 1, 0]]
+            [[0, 1, 0, 0], [0, 0, 0, 1]]]
   ```
 
   Example:


### PR DESCRIPTION
Bucketized Column returns one-hot encoded value.
Should align to this page.
https://www.tensorflow.org/tutorials/structured_data/feature_columns#bucketized_columns