### PR TITLE
Consider `FakeQuantWithMinMaxArgs` to be a train-time quant op in the TFLite Converter

### DIFF
--- a/tensorflow/lite/python/lite.py
+++ b/tensorflow/lite/python/lite.py
@@ -411,6 +411,7 @@ class QuantizationMode(object):
     """Checks if the graph contains any training-time quantization ops."""
     training_quant_ops = frozenset({
         "FakeQuantWithMinMaxVars", "FakeQuantWithMinMaxVarsPerChannel",
+        "FakeQuantWithMinMaxArgs", "FakeQuantWithMinMaxArgsPerChannel",
         "QuantizeAndDequantizeV2", "QuantizeAndDequantizeV3"
     })
 


### PR DESCRIPTION
`tf.quantization.fake_quant_with_min_max_vars` is commonly used for training-time Int8 fake-quantisation in TF, and when used correctly will cause the TFLite converter to output int8 (rather than float) ops.

`tf.quantization.fake_quant_with_min_max_vars` requires a min/max quantisation scale to be passed in as TF variables. This means that the scales can be updated during training. However, one could conceivably instead use `tf.quantization.fake_quant_with_min_max_args`, which is the same op with the exception that the min/max scales are passed in as constants rather than variables.

At the moment, attempting to convert an model that contains only `tf.quantization.fake_quant_with_min_max_args` ops does not work correctly, because the function `contains_training_quant_op` incorrectly returns false, which means that `is_training_time_int8_allow_float` returns false:

https://github.com/tensorflow/tensorflow/blob/2833b3d9457aa04de808578bbc0fa70ec136c63f/tensorflow/lite/python/lite.py#L249-L251

This PR fixes the problem by updating `contains_training_quant_op` to recognise `FakeQuantWithMinMaxArgs` and `FakeQuantWithMinMaxArgsPerChannel` as training-time quant ops.