### PR TITLE
micro: prepare to port operator FLOOR_DIV kernel from lite with test

### DIFF
--- a/tensorflow/lite/micro/kernels/floor_div_test.cc
+++ b/tensorflow/lite/micro/kernels/floor_div_test.cc
@@ -1,4 +1,4 @@
-/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -12,106 +12,88 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-#include <stdint.h>
 
-#include <vector>
+#include <type_traits>
 
-#include "tensorflow/lite/kernels/test_util.h"
-#include "tensorflow/lite/schema/schema_generated.h"
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/micro/kernels/kernel_runner.h"
+#include "tensorflow/lite/micro/test_helpers.h"
+#include "tensorflow/lite/micro/testing/micro_test.h"
 
 namespace tflite {
+namespace testing {
 namespace {
 
-using ::testing::ElementsAre;
+TF_LITE_MICRO_TESTS_BEGIN
 
-template <typename T>
-class FloorDivModel : public SingleOpModel {
- public:
-  FloorDivModel(const TensorData& input1, const TensorData& input2,
-                const TensorData& output) {
-    input1_ = AddInput(input1);
-    input2_ = AddInput(input2);
-    output_ = AddOutput(output);
-    SetBuiltinOp(BuiltinOperator_FLOOR_DIV, BuiltinOptions_FloorDivOptions,
-                 CreateFloorDivOptions(builder_).Union());
-    BuildInterpreter({GetShape(input1_), GetShape(input2_)});
-  }
-
-  int input1() { return input1_; }
-  int input2() { return input2_; }
-
-  std::vector<T> GetOutput() { return ExtractVector<T>(output_); }
-  std::vector<int> GetOutputShape() { return GetTensorShape(output_); }
-
- private:
-  int input1_;
-  int input2_;
-  int output_;
-};
-
-TEST(FloorDivModel, Simple) {
+TF_LITE_MICRO_TEST(FloorDivModelSimple) {
+#ifdef notdef
   FloorDivModel<int32_t> model({TensorType_INT32, {1, 2, 2, 1}},
                                {TensorType_INT32, {1, 2, 2, 1}},
                                {TensorType_INT32, {}});
   model.PopulateTensor<int32_t>(model.input1(), {10, 9, 11, 3});
   model.PopulateTensor<int32_t>(model.input2(), {2, 2, 3, 4});
-  model.Invoke();
-  EXPECT_THAT(model.GetOutputShape(), ElementsAre(1, 2, 2, 1));
   EXPECT_THAT(model.GetOutput(), ElementsAre(5, 4, 3, 0));
+#endif
 }
 
-TEST(FloorDivModel, NegativeValue) {
+TF_LITE_MICRO_TEST(FloorDivModelNegativeValue) {
+#ifdef notdef
   FloorDivModel<int32_t> model({TensorType_INT32, {1, 2, 2, 1}},
                                {TensorType_INT32, {1, 2, 2, 1}},
                                {TensorType_INT32, {}});
   model.PopulateTensor<int32_t>(model.input1(), {10, -9, -11, 7});
   model.PopulateTensor<int32_t>(model.input2(), {2, 2, -3, -4});
-  model.Invoke();
-  EXPECT_THAT(model.GetOutputShape(), ElementsAre(1, 2, 2, 1));
   EXPECT_THAT(model.GetOutput(), ElementsAre(5, -5, 3, -2));
+#endif
 }
 
-TEST(FloorDivModel, BroadcastFloorDiv) {
+TF_LITE_MICRO_TEST(FloorDivModelBroadcastFloorDiv) {
+#ifdef notdef
   FloorDivModel<int32_t> model({TensorType_INT32, {1, 2, 2, 1}},
                                {TensorType_INT32, {1}}, {TensorType_INT32, {}});
   model.PopulateTensor<int32_t>(model.input1(), {10, -9, -11, 7});
   model.PopulateTensor<int32_t>(model.input2(), {-3});
-  model.Invoke();
-  EXPECT_THAT(model.GetOutputShape(), ElementsAre(1, 2, 2, 1));
   EXPECT_THAT(model.GetOutput(), ElementsAre(-4, 3, 3, -3));
+#endif
 }
 
-TEST(FloorDivModel, SimpleFloat) {
+TF_LITE_MICRO_TEST(FloorDivModelSimpleFloat) {
+#ifdef notdef
   FloorDivModel<float> model({TensorType_FLOAT32, {1, 2, 2, 1}},
                              {TensorType_FLOAT32, {1, 2, 2, 1}},
                              {TensorType_FLOAT32, {}});
   model.PopulateTensor<float>(model.input1(), {10.05, 9.09, 11.9, 3.01});
   model.PopulateTensor<float>(model.input2(), {2.05, 2.03, 3.03, 4.03});
-  model.Invoke();
-  EXPECT_THAT(model.GetOutputShape(), ElementsAre(1, 2, 2, 1));
   EXPECT_THAT(model.GetOutput(), ElementsAre(4.0, 4.0, 3.0, 0.0));
+#endif
 }
 
-TEST(FloorDivModel, NegativeValueFloat) {
+TF_LITE_MICRO_TEST(FloorDivModelNegativeValueFloat) {
+#ifdef notdef
   FloorDivModel<float> model({TensorType_FLOAT32, {1, 2, 2, 1}},
                              {TensorType_FLOAT32, {1, 2, 2, 1}},
                              {TensorType_FLOAT32, {}});
   model.PopulateTensor<float>(model.input1(), {10.03, -9.9, -11.0, 7.0});
   model.PopulateTensor<float>(model.input2(), {2.0, 2.3, -3.0, -4.1});
-  model.Invoke();
-  EXPECT_THAT(model.GetOutputShape(), ElementsAre(1, 2, 2, 1));
   EXPECT_THAT(model.GetOutput(), ElementsAre(5.0, -5.0, 3.0, -2.0));
+#endif
 }
 
-TEST(FloorDivModel, BroadcastFloorDivFloat) {
+TF_LITE_MICRO_TEST(FloorDivModelBroadcastFloorDivFloat) {
+#ifdef notdef
   FloorDivModel<float> model({TensorType_FLOAT32, {1, 2, 2, 1}},
                              {TensorType_FLOAT32, {1}},
                              {TensorType_FLOAT32, {}});
   model.PopulateTensor<float>(model.input1(), {10.03, -9.9, -11.0, 7.0});
   model.PopulateTensor<float>(model.input2(), {-3.3});
-  model.Invoke();
-  EXPECT_THAT(model.GetOutputShape(), ElementsAre(1, 2, 2, 1));
   EXPECT_THAT(model.GetOutput(), ElementsAre(-4.0, 2.0, 3.0, -3.0));
+#endif
 }
+
+TF_LITE_MICRO_TESTS_END
+
 }  // namespace
+}  // namespace testing
 }  // namespace tflite


### PR DESCRIPTION
Implement skeleton (non-working) code for operator and test.
Header files changed.
Namespaces changed.
Some original code deleted.
Some original code modified.

This represents PR step 4 of the work to port operator FLOOR_DIV as tracked in Issue #45657