### PR TITLE
Add reference fallback for TARGET_ARCH!=hifimini

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/softmax.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/softmax.cc
@@ -13,12 +13,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "tensorflow/lite/kernels/internal/reference/softmax.h"
+#include "tensorflow/lite/micro/kernels/softmax.h"
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/kernels/internal/common.h"
 #include "tensorflow/lite/kernels/internal/quantization_util.h"
+#include "tensorflow/lite/kernels/internal/reference/softmax.h"
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/kernels/op_macros.h"
@@ -27,6 +28,7 @@ limitations under the License.
 namespace tflite {
 namespace {
 
+#if defined(HIFIMINI)
 struct OpData {
   uint16_t* exp_lut;
 };
@@ -49,9 +51,10 @@ constexpr int kMaxExponentValue = (1 << kExpFractionalBits);
 // Passing OpData by value does not have much savings in this op, but following
 // that as a best practice, at least for the xtensa kernels. See b/155656675 for
 // more details.
-TfLiteStatus Softmax(OpData op_data, const RuntimeShape& input_shape,
-                     const int8_t* input_data, const RuntimeShape& output_shape,
-                     int16_t* output_data) {
+TfLiteStatus SoftmaxHifimini(OpData op_data, const RuntimeShape& input_shape,
+                             const int8_t* input_data,
+                             const RuntimeShape& output_shape,
+                             int16_t* output_data) {
   // The last dimension is depth.  Outer size is the total input size
   // divided by depth.
   const int trailing_dim = input_shape.DimensionsCount() - 1;
@@ -102,11 +105,11 @@ TfLiteStatus Softmax(OpData op_data, const RuntimeShape& input_shape,
   return kTfLiteOk;
 }
 
-TfLiteStatus CalculateSoftmaxOpData(TfLiteContext* context,
-                                    const TfLiteTensor* input,
-                                    TfLiteTensor* output,
-                                    const TfLiteSoftmaxParams* params,
-                                    OpData* op_data) {
+TfLiteStatus CalculateSoftmaxOpDataHifimini(TfLiteContext* context,
+                                            const TfLiteTensor* input,
+                                            TfLiteTensor* output,
+                                            const TfLiteSoftmaxParams* params,
+                                            OpData* op_data) {
   if (input->type == kTfLiteUInt8 || input->type == kTfLiteInt8) {
     if (input->type == kTfLiteUInt8) {
       TF_LITE_ENSURE_EQ(context, output->params.zero_point, 0);
@@ -143,13 +146,7 @@ TfLiteStatus CalculateSoftmaxOpData(TfLiteContext* context,
   return kTfLiteOk;
 }
 
-void* SoftmaxInitXtensa(TfLiteContext* context, const char* buffer,
-                        size_t length) {
-  TFLITE_DCHECK(context->AllocatePersistentBuffer != nullptr);
-  return context->AllocatePersistentBuffer(context, sizeof(OpData));
-}
-
-TfLiteStatus SoftmaxPrepareXtensa(TfLiteContext* context, TfLiteNode* node) {
+TfLiteStatus PrepareHifimini(TfLiteContext* context, TfLiteNode* node) {
   auto* params = static_cast<TfLiteSoftmaxParams*>(node->builtin_data);
 
   TF_LITE_ENSURE_EQ(context, NumInputs(node), 1);
@@ -170,16 +167,36 @@ TfLiteStatus SoftmaxPrepareXtensa(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE(context, op_data->exp_lut != nullptr);
 
   TF_LITE_ENSURE_STATUS(
-      CalculateSoftmaxOpData(context, input, output, params, op_data));
+      CalculateSoftmaxOpDataHifimini(context, input, output, params, op_data));
 
   return kTfLiteOk;
 }
+#endif  // defined(HIFIMINI)
 
-TfLiteStatus SoftmaxEval(TfLiteContext* context, TfLiteNode* node) {
-  auto* op_data = static_cast<OpData*>(node->user_data);
+void* Init(TfLiteContext* context, const char* buffer, size_t length) {
+#if defined(HIFIMINI)
+  TFLITE_DCHECK(context->AllocatePersistentBuffer != nullptr);
+  return context->AllocatePersistentBuffer(context, sizeof(OpData));
+#else
+  return SoftmaxInit(context, buffer, length);
+#endif
+}
 
+TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+#if defined(HIFIMINI)
+  return PrepareHifimini(context, node);
+#else
+  return SoftmaxPrepare(context, node);
+#endif
+}
+
+TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   const TfLiteEvalTensor* input = tflite::micro::GetEvalInput(context, node, 0);
   TfLiteEvalTensor* output = tflite::micro::GetEvalOutput(context, node, 0);
+  TFLITE_DCHECK(node->user_data != nullptr);
+
+#if defined(HIFIMINI)
+  auto* op_data = static_cast<OpData*>(node->user_data);
 
   if (input->type == kTfLiteInt8 && output->type == kTfLiteInt16) {
     return Softmax(*op_data, tflite::micro::GetTensorShape(input),
@@ -191,15 +208,50 @@ TfLiteStatus SoftmaxEval(TfLiteContext* context, TfLiteNode* node) {
                        TfLiteTypeGetName(input->type), input->type);
     return kTfLiteError;
   }
+#else   // !defined(HIFIMINI)
+  switch (input->type) {
+    case kTfLiteFloat32: {
+      SoftmaxParams op_data = *static_cast<SoftmaxParams*>(node->user_data);
+      tflite::reference_ops::Softmax(
+          op_data, tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorData<float>(input),
+          tflite::micro::GetTensorShape(output),
+          tflite::micro::GetTensorData<float>(output));
+      return kTfLiteOk;
+    }
+    case kTfLiteInt8: {
+      if (output->type == kTfLiteInt16) {
+        SoftmaxParams op_data = *static_cast<SoftmaxParams*>(node->user_data);
+        tflite::reference_ops::Softmax(
+            op_data, tflite::micro::GetTensorShape(input),
+            tflite::micro::GetTensorData<int8_t>(input),
+            tflite::micro::GetTensorShape(output),
+            tflite::micro::GetTensorData<int16_t>(output));
+      } else {
+        SoftmaxParams op_data = *static_cast<SoftmaxParams*>(node->user_data);
+        tflite::reference_ops::Softmax(
+            op_data, tflite::micro::GetTensorShape(input),
+            tflite::micro::GetTensorData<int8_t>(input),
+            tflite::micro::GetTensorShape(output),
+            tflite::micro::GetTensorData<int8_t>(output));
+      }
+      return kTfLiteOk;
+    }
+    default:
+      TF_LITE_KERNEL_LOG(context, "Type %s (%d) not supported.",
+                         TfLiteTypeGetName(input->type), input->type);
+      return kTfLiteError;
+  }
+#endif  // !defined(HIFIMINI)
 }
 
 }  // namespace
 
 TfLiteRegistration Register_SOFTMAX() {
-  return {/*init=*/SoftmaxInitXtensa,
+  return {/*init=*/Init,
           /*free=*/nullptr,
-          /*prepare=*/SoftmaxPrepareXtensa,
-          /*invoke=*/SoftmaxEval,
+          /*prepare=*/Prepare,
+          /*invoke=*/Eval,
           /*profiling_string=*/nullptr,
           /*builtin_code=*/0,
           /*custom_name=*/nullptr,


### PR DESCRIPTION
A follow-up change will add in calls to the XaNNLib to get an optimized softmax implementation.

Tested that keyword_benchmark has a latency increase of ~1000 ticks for the Fusion F1.

This latency improvement does not matter since the current change is setting the stage for pulling in the optimized implementation.

This command:
```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=fusion_f1 XTENSA_CORE=F1_190305_swupgrade test_keyword_benchmark -j8
```

before this change:
```
InitializeKeywordRunner() took 279548 ticks (279 ms)
KeywordRunNIerations(1) took 151249 ticks (151 ms)
KeywordRunNIerations(10) took 1511997 ticks (1511 ms)
```

after this change:
```
InitializeKeywordRunner() took 201464 ticks (201 ms)
KeywordRunNIerations(1) took 152158 ticks (152 ms)
KeywordRunNIerations(10) took 1521087 ticks (1521 ms)
```

Progress towards http://b/177457688
