### PR TITLE
Saved_model should be able to save any CompositeTensor signature.

### DIFF
--- a/tensorflow/python/saved_model/signature_serialization.py
+++ b/tensorflow/python/saved_model/signature_serialization.py
@@ -23,6 +23,7 @@ from absl import logging
 from tensorflow.python.eager import def_function
 from tensorflow.python.eager import function as defun
 from tensorflow.python.framework import ops
+from tensorflow.python.framework import composite_tensor
 from tensorflow.python.framework import tensor_spec
 from tensorflow.python.ops import resource_variable_ops
 from tensorflow.python.saved_model import function_serialization
@@ -210,7 +211,7 @@ def _normalize_outputs(outputs, function_name, signature_key):
           ("Got a dictionary with a non-string key {!r} in the output of the "
            "function {} used to generate the SavedModel signature {!r}.")
           .format(key, compat.as_str_any(function_name), signature_key))
-    if not isinstance(value, ops.Tensor):
+    if not isinstance(value, (ops.Tensor, composite_tensor.CompositeTensor)):
       raise ValueError(
           ("Got a non-Tensor value {!r} for key {!r} in the output of the "
            "function {} used to generate the SavedModel signature {!r}. "


### PR DESCRIPTION
Fix for #45797.

The allows the saved_model library to save a signature for a function that returns a RaggedTensor (or any CompositeTensor).

My understanding is that function traces use signatures where any CompositeTensor argument is expanded to its dense tensor components via ```nest.flatten(arg, expand_composites=True)```; the saved_model save method has the same behaviour. Relaxing the check in signature_serialization should be correct as long as CompositeTensors support ```nest.flatten```.