### PR TITLE
Fix crash when tf.sequence_mask takes a non-integer lengths

### DIFF
--- a/tensorflow/python/kernel_tests/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops_test.py
@@ -1427,6 +1427,13 @@ class SequenceMaskTest(test_util.TensorFlowTestCase):
     check_output_dtype("float64")
     check_output_dtype(np.float64)
 
+  def testInvalidLengthsDTypeD(self):
+    with self.cached_session():
+      with self.assertRaisesRegex(
+          ValueError, "lengths must be integer for sequence_mask"):
+        array_ops.sequence_mask(
+            lengths=np.array([3.05524638e+307], dtype=np.float64))
+
 
 class ConcatSliceResourceTest(test_util.TensorFlowTestCase):
 

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -4382,10 +4382,12 @@ def sequence_mask(lengths, maxlen=None, dtype=dtypes.bool, name=None):
   Returns:
     A mask tensor of shape `lengths.shape + (maxlen,)`, cast to specified dtype.
   Raises:
-    ValueError: if `maxlen` is not a scalar.
+    ValueError: if `maxlen` is not a scalar or lengths is not an integer tensor.
   """
   with ops.name_scope(name, "SequenceMask", [lengths, maxlen]):
     lengths = ops.convert_to_tensor(lengths)
+    if not lengths.dtype.is_integer:
+      raise ValueError("lengths must be integer for sequence_mask")
 
     if maxlen is None:
       maxlen = gen_math_ops._max(lengths, _all_dimensions(lengths))


### PR DESCRIPTION
This PR tries to address the issue raised in #46698 where
tf.sequence_mask will crash abruptly if lengths is not passed
with an integer tensor.

This PR applies a dtype check and throw out ValueError to avoid
program crash.

This PR fixes #46698.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>