### PR TITLE
Instructions to add git hook for code-style checks.

### DIFF
--- a/tensorflow/lite/micro/CONTRIBUTING.md
+++ b/tensorflow/lite/micro/CONTRIBUTING.md
@@ -6,23 +6,23 @@ https://github.com/ekalinin/github-markdown-toc#auto-insert-and-update-toc
 -->
 
 <!--ts-->
+   * [Contributing Guidelines](#contributing-guidelines)
+      * [General Pull Request Guidelines](#general-pull-request-guidelines)
+      * [Guidelines for Specific Contribution Categories](#guidelines-for-specific-contribution-categories)
+         * [Bug Fixes](#bug-fixes)
+         * [Reference Kernel Implementations](#reference-kernel-implementations)
+         * [Optimized Kernel Implementations](#optimized-kernel-implementations)
+         * [New Target / Platform / IDE / Examples](#new-target--platform--ide--examples)
+         * [New Features](#new-features)
+   * [Development Workflow Notes](#development-workflow-notes)
+      * [Initial Setup](#initial-setup)
+      * [Before submitting your PR](#before-submitting-your-pr)
+      * [During the PR review](#during-the-pr-review)
+      * [Reviewer notes](#reviewer-notes)
+      * [Python notes](#python-notes)
+   * [Continuous Integration System](#continuous-integration-system)
 
-*   [Contributing Guidelines](#contributing-guidelines)
-    *   [General Pull Request Guidelines](#general-pull-request-guidelines)
-    *   [Guidelines for Specific Contribution Categories](#guidelines-for-specific-contribution-categories)
-        *   [Bug Fixes](#bug-fixes)
-        *   [Reference Kernel Implementations](#reference-kernel-implementations)
-        *   [Optimized Kernel Implementations](#optimized-kernel-implementations)
-        *   [New Target / Platform / IDE / Examples](#new-target--platform--ide--examples)
-        *   [New Features](#new-features)
-*   [Development Workflow Notes](#development-workflow-notes)
-    *   [Before submitting your PR](#before-submitting-your-pr)
-    *   [During the PR review](#during-the-pr-review)
-    *   [Reviewer notes](#reviewer-notes)
-    *   [Python notes](#python-notes)
-*   [Continuous Integration System](#continuous-integration-system)
-
-<!-- Added by: advaitjain, at: Tue 15 Dec 2020 03:06:29 PM PST -->
+<!-- Added by: advaitjain, at: Wed 27 Jan 2021 02:25:07 PM PST -->
 
 <!--te-->
 
@@ -182,6 +182,29 @@ to determine if the requested feature aligns with the TFLM roadmap.
 
 # Development Workflow Notes
 
+## Initial Setup
+
+Below are some tips that might be useful and improve the development experience.
+
+* Add the [Refined GitHub](https://github.com/sindresorhus/refined-github)
+  plugin to make the github experience even better.
+
+* Code search the [TfLite Micro codebase](https://sourcegraph.com/github.com/tensorflow/tensorflow@master/-/tree/tensorflow/lite/micro)
+  on Sourcegraph. And optionally install the [plugin that enables GitHub integration](https://docs.sourcegraph.com/integration/github#github-integration-with-sourcegraph).
+
+* Install [bazel](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/ci_build/install/install_bazel.sh) and [buildifier](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/ci_build/install/install_buildifier.sh).
+
+* Install the latest clang and clang-format. For example,
+  [here](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/ci_build/Dockerfile.micro)
+  is the  what we do for the TFLM continuous integration Docker container.
+
+* Get a copy of [cpplint](https://github.com/google/styleguide/tree/gh-pages/cpplint)
+
+* Add a git hook to check for code style etc. prior to creating a pull request:
+  ```
+  cp tensorflow/lite/micro/tools/dev_setup/pre-push.tflm .git/hooks/pre-push
+  ```
+
 ## Before submitting your PR
 
 1.  Run in-place clang-format on all the files that are modified in your git
@@ -193,11 +216,6 @@ to determine if the requested feature aligns with the TFLM roadmap.
     ```
 
 1.  Make sure your code is lint-free.
-
-    Get a copy of
-    [cpplint](https://github.com/google/styleguide/tree/gh-pages/cpplint)
-
-    Run cpplint.py on all modified files in your git tree:
 
     ```
     cpplint.py `git ls-files -m`

--- a/tensorflow/lite/micro/tools/dev_setup/pre-push.tflm
+++ b/tensorflow/lite/micro/tools/dev_setup/pre-push.tflm
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+tensorflow/lite/micro/tools/ci_build/test_code_style.sh

--- a/tensorflow/lite/micro/tools/make/pigweed.patch
+++ b/tensorflow/lite/micro/tools/make/pigweed.patch
@@ -10,6 +10,20 @@ index 4a370e33..224ad9c6 100644
  from pw_presubmit import call, log_run, plural, PresubmitFailure, tools
  
  _LOG = logging.getLogger(__name__)
+diff --git a/pw_presubmit/py/pw_presubmit/format_code.py b/pw_presubmit/py/pw_presubmit/format_code.py
+index 19d09546..dae2e813 100755
+--- a/pw_presubmit/py/pw_presubmit/format_code.py
++++ b/pw_presubmit/py/pw_presubmit/format_code.py
+@@ -229,8 +229,7 @@ def print_format_check(errors: Dict[Path, str],
+             except ValueError:
+                 return Path(path).resolve()
+ 
+-        message = (f'  pw format --fix {path_relative_to_cwd(path)}'
+-                   for path in errors)
++        message = (f' tensorflow/lite/{__file__} --fix {path}' for path in errors)
+         _LOG.warning('To fix formatting, run:\n\n%s\n', '\n'.join(message))
+ 
+ 
 diff --git a/pw_presubmit/py/pw_presubmit/pigweed_presubmit.py b/pw_presubmit/py/pw_presubmit/pigweed_presubmit.py
 index 794967db..061db7ea 100755
 --- a/pw_presubmit/py/pw_presubmit/pigweed_presubmit.py


### PR DESCRIPTION
Installing such a hook should enable fixing formatting and other style issues faster.

Also, updated the pigweed patch to have the format_code error message give a command that can be copy-pasted into the terminal to fix the formatting errors.