### PR TITLE
Add in optimizations for softmax for Fusion F1.

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/xtensa.h
+++ b/tensorflow/lite/micro/kernels/xtensa/xtensa.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include <xtensa/tie/xt_hifi2.h>
 #elif defined(FUSION_F1)
 #include "include/nnlib/xa_nnlib_api.h"
+#include "include/nnlib/xa_nnlib_standards.h"
 #endif
 
 #endif  // TENSORFLOW_LITE_MICRO_KERNELS_XTENSA_XTENSA_H_


### PR DESCRIPTION
Confirmed that the test passes with:
```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=fusion_f1 XTENSA_CORE=F1_190305_swupgrade test_kernel_softmax_test -j8
```

However, the latency improvement is only ~1000 ticks, as tested with:
```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=fusion_f1 XTENSA_CORE=F1_190305_swupgrade run_keyword_benchmark -j8
```

Since Softmax is currently a small fraction of the overall keyword_benchmark latency we will focus on the latency of only this particular OP.

With the optimized implementation:
```
SOFTMAX took 749 ticks (0 ms).
```

Reference implementation:
```
SOFTMAX took 2052 ticks (2 ms).
```

And with the LUT hifimini implementation (for completeness):
```
SOFTMAX took 1142 ticks (1 ms).
```

The gain of ~1500 ticks ticks is worth merging because after all the optimizations (e.g.  #47098), this will mean a ~5% improvement for the keyword benchmark.

And the benefits might be more significant for other models too.