### PR TITLE
Improve rendering for tf.distribute.cluster_resolver.TPUClusterResolver in tpu_strategy API docs

### DIFF
--- a/tensorflow/python/distribute/tpu_strategy.py
+++ b/tensorflow/python/distribute/tpu_strategy.py
@@ -320,9 +320,10 @@ class TPUStrategyV2(distribute_lib.Strategy):
     """Synchronous training in TPU donuts or Pods.
 
     Args:
-      tpu_cluster_resolver: A `tf.distribute.cluster_resolver.TPUClusterResolver`
-        instance, which provides information about the TPU cluster. If None, it
-        will assume running on a local TPU worker.
+      tpu_cluster_resolver: A 
+        `tf.distribute.cluster_resolver.TPUClusterResolver` instance, which
+        provides information about the TPU cluster. If None, it will assume
+        running on a local TPU worker.
       experimental_device_assignment: Optional
         `tf.tpu.experimental.DeviceAssignment` to specify the placement of
         replicas on the TPU cluster.

--- a/tensorflow/python/distribute/tpu_strategy.py
+++ b/tensorflow/python/distribute/tpu_strategy.py
@@ -320,7 +320,7 @@ class TPUStrategyV2(distribute_lib.Strategy):
     """Synchronous training in TPU donuts or Pods.
 
     Args:
-      tpu_cluster_resolver: A tf.distribute.cluster_resolver.TPUClusterResolver,
+      tpu_cluster_resolver: A `tf.distribute.cluster_resolver.TPUClusterResolver`,
         which provides information about the TPU cluster. If None, it will
         assume running on a local TPU worker.
       experimental_device_assignment: Optional

--- a/tensorflow/python/distribute/tpu_strategy.py
+++ b/tensorflow/python/distribute/tpu_strategy.py
@@ -320,9 +320,9 @@ class TPUStrategyV2(distribute_lib.Strategy):
     """Synchronous training in TPU donuts or Pods.
 
     Args:
-      tpu_cluster_resolver: A `tf.distribute.cluster_resolver.TPUClusterResolver`,
-        which provides information about the TPU cluster. If None, it will
-        assume running on a local TPU worker.
+      tpu_cluster_resolver: A `tf.distribute.cluster_resolver.TPUClusterResolver`
+        instance, which provides information about the TPU cluster. If None, it
+        will assume running on a local TPU worker.
       experimental_device_assignment: Optional
         `tf.tpu.experimental.DeviceAssignment` to specify the placement of
         replicas on the TPU cluster.


### PR DESCRIPTION
This should fix the auto-linking and rendering

<img width="500" alt="image" src="https://user-images.githubusercontent.com/19637339/106074345-9a82ed80-6103-11eb-9074-0c5433eba08d.png">
