### PR TITLE
[TFL] Fix BatchMatMul constant RHS.

### DIFF
--- a/tensorflow/lite/kernels/batch_matmul.cc
+++ b/tensorflow/lite/kernels/batch_matmul.cc
@@ -196,7 +196,6 @@ TfLiteStatus InitializeTemporaries(TfLiteContext* context, TfLiteNode* node,
       scratch_buffer->allocation_type = kTfLiteArenaRw;
     }
     scratch_buffer->type = op_context->rhs->type;
-    scratch_buffer->allocation_type = kTfLiteArenaRw;
     TF_LITE_ENSURE_OK(context, context->ResizeTensor(context, scratch_buffer,
                                                      scratch_buffer_size));
   }

--- a/tensorflow/lite/kernels/batch_matmul_test.cc
+++ b/tensorflow/lite/kernels/batch_matmul_test.cc
@@ -295,8 +295,13 @@ class ConstRHSBatchMatMulOpModel : public MultiOpModel {
                  CreateBatchMatMulOptions(builder_, adj_x, adj_y).Union(),
                  matmul_inputs, matmul_outputs);
 
-    // This is just a dummy op to check if the values of transposed RHS are
-    // polluted.
+    // Without following ops (not limited to neg), temporary allocation with
+    // kTfLiteArenaRw tends to re-claim the same memory across each evaluation,
+    // and no other ops will modify values at that memory address because no
+    // other memory allocations take place. Therefore, it's likely that results
+    // are correct even if constant transposed RHS is allocated with
+    // kTfLiteArenaRw. We thus use a dummy op to make sure constant transposed
+    // RHS behaves correctly.
     neg_output_id_ = AddOutput(lhs.type);
     std::vector<int> neg_inputs{matmul_output_id_};
     std::vector<int> neg_outputs{neg_output_id_};


### PR DESCRIPTION
Fixes #46724. For constant RHS and !adj_y, transpose of RHS only occurs once, so the allocation should be persistent across runs. Old commit does this, but the allocation is accidentally overridden to kTfLiteArenaRw for constant RHS.

https://github.com/tensorflow/tensorflow/blob/7c0a3f12dd00b0aeb9d2a91d157b0e9d1a4c1250/tensorflow/lite/kernels/batch_matmul.cc#L193-L199

/cc @abattery for visibility.