### PR TITLE
[tf.data] eager mode support for experimental benchmarks part1

### DIFF
--- a/tensorflow/python/data/benchmarks/benchmark_base.py
+++ b/tensorflow/python/data/benchmarks/benchmark_base.py
@@ -112,7 +112,28 @@ class DatasetBenchmarkBase(test.Benchmark):
                                extras=None,
                                warmup=True,
                                apply_default_optimizations=False):
-    # Measure the per-element wall time.
+    """Benchmarks the dataset and reports the stats.
+
+    Runs the dataset `iters` times. In each iteration, the benchmark measures
+    the time it takes to go through `num_elements` elements of the dataset.
+    This is followed by logging/printing the benchmark stats.
+
+    Args:
+      dataset: Dataset to benchmark.
+      num_elements: Number of dataset elements to iterate through each benchmark
+        iteration.
+      name: Name of the benchmark.
+      iters: Number of times to repeat the timing.
+      extras: A dict which maps string keys to additional benchmark info.
+      warmup: If true, warms up the session caches by running an untimed run.
+      apply_default_optimizations: Determines whether default optimizations
+        should be applied.
+
+    Returns:
+      A float, representing the per-element wall time of the dataset in seconds.
+      This is the median time (with respect to `iters`) it takes for the dataset
+      to go through `num_elements` elements, divided by `num_elements.`
+    """
     wall_time = self.run_benchmark(
         dataset=dataset, num_elements=num_elements, iters=iters, warmup=warmup,
         apply_default_optimizations=apply_default_optimizations

--- a/tensorflow/python/data/benchmarks/benchmark_base.py
+++ b/tensorflow/python/data/benchmarks/benchmark_base.py
@@ -113,8 +113,10 @@ class DatasetBenchmarkBase(test.Benchmark):
                                warmup=True,
                                apply_default_optimizations=False):
     # Measure the per-element wall time.
-    wall_time = self.run_benchmark(dataset, num_elements, iters, warmup,
-                                   apply_default_optimizations)
+    wall_time = self.run_benchmark(
+        dataset=dataset, num_elements=num_elements, iters=iters, warmup=warmup,
+        apply_default_optimizations=apply_default_optimizations
+    )
     if context.executing_eagerly():
       name = "{}.eager".format(name)
     else:
@@ -124,5 +126,4 @@ class DatasetBenchmarkBase(test.Benchmark):
     extras["num_elements"] = num_elements
     self.report_benchmark(
         wall_time=wall_time, iters=iters, name=name, extras=extras)
-
     return wall_time

--- a/tensorflow/python/data/benchmarks/benchmark_base.py
+++ b/tensorflow/python/data/benchmarks/benchmark_base.py
@@ -150,7 +150,7 @@ class DatasetBenchmarkBase(test.Benchmark):
     return wall_time
 
   def consume_dataset(self, dataset, num_elements):
-    """Consume the `num_elements` of the dataset.
+    """Consumes num_elements of the dataset.
 
     Args:
       dataset: A tf.data.Dataset to consume data from.
@@ -162,7 +162,7 @@ class DatasetBenchmarkBase(test.Benchmark):
     # pipeline. Note that this relies on the underlying implementation of `skip`
     # to execute upstream computation. If it is optimized in the future,
     # we will have to change this code.
-    dataset = dataset.skip(num_elements)
+    dataset = dataset.skip(num_elements - 1)
     if context.executing_eagerly():
       iterator = iter(dataset)
       try:

--- a/tensorflow/python/data/benchmarks/benchmark_base.py
+++ b/tensorflow/python/data/benchmarks/benchmark_base.py
@@ -149,7 +149,7 @@ class DatasetBenchmarkBase(test.Benchmark):
         wall_time=wall_time, iters=iters, name=name, extras=extras)
     return wall_time
 
-  def _consume_dataset(self, dataset, num_elements):
+  def consume_dataset(self, dataset, num_elements):
     """Consume the `num_elements` of the dataset.
 
     Args:

--- a/tensorflow/python/data/experimental/benchmarks/csv_dataset_benchmark.py
+++ b/tensorflow/python/data/experimental/benchmarks/csv_dataset_benchmark.py
@@ -21,21 +21,16 @@ from __future__ import print_function
 import os
 import string
 import tempfile
-import time
 
-import numpy as np
-
-from tensorflow.python.client import session
 from tensorflow.python.data.experimental.ops import readers
-from tensorflow.python.data.ops import dataset_ops
+from tensorflow.python.data.benchmarks import benchmark_base
 from tensorflow.python.data.ops import readers as core_readers
 from tensorflow.python.ops import parsing_ops
 from tensorflow.python.platform import gfile
 from tensorflow.python.platform import googletest
-from tensorflow.python.platform import test
 
 
-class CsvDatasetBenchmark(test.Benchmark):
+class CsvDatasetBenchmark(benchmark_base.DatasetBenchmarkBase):
   """Benchmarks for `tf.data.experimental.CsvDataset`."""
 
   FLOAT_VAL = '1.23456E12'
@@ -62,30 +57,14 @@ class CsvDatasetBenchmark(test.Benchmark):
     gfile.DeleteRecursively(self._temp_dir)
 
   def _run_benchmark(self, dataset, num_cols, prefix):
-    dataset = dataset.skip(self._num_per_iter - 1)
-    options = dataset_ops.Options()
-    options.experimental_optimization.apply_default_optimizations = False
-    dataset = dataset.with_options(options)
-    deltas = []
-    for _ in range(10):
-      next_element = dataset_ops.make_one_shot_iterator(dataset).get_next()
-      with session.Session() as sess:
-        start = time.time()
-        # NOTE: This depends on the underlying implementation of skip, to have
-        # the net effect of calling `GetNext` num_per_iter times on the
-        # input dataset. We do it this way (instead of a python for loop, or
-        # batching N inputs in one iter) so that the overhead from session.run
-        # or batch doesn't dominate. If we eventually optimize skip, this has
-        # to change.
-        sess.run(next_element)
-        end = time.time()
-      deltas.append(end - start)
-    # Median wall time per CSV record read and decoded
-    median_wall_time = np.median(deltas) / self._num_per_iter
-    self.report_benchmark(
-        iters=self._num_per_iter,
-        wall_time=median_wall_time,
-        name='%s_with_cols_%d' % (prefix, num_cols))
+
+    self.run_and_report_benchmark(
+        dataset=dataset,
+        num_elements=self._num_per_iter,
+        name='%s_with_cols_%d' % (prefix, num_cols),
+        iters=10,
+        warmup=True
+    )
 
   def benchmark_map_with_floats(self):
     self._set_up(self.FLOAT_VAL)
@@ -93,8 +72,13 @@ class CsvDatasetBenchmark(test.Benchmark):
       num_cols = self._num_cols[i]
       kwargs = {'record_defaults': [[0.0]] * num_cols}
       dataset = core_readers.TextLineDataset(self._filenames[i]).repeat()
-      dataset = dataset.map(lambda l: parsing_ops.decode_csv(l, **kwargs))  # pylint: disable=cell-var-from-loop
-      self._run_benchmark(dataset, num_cols, 'csv_float_map_decode_csv')
+      dataset = dataset.map(lambda l: parsing_ops.decode_csv(
+          l, **kwargs))  # pylint: disable=cell-var-from-loop
+      self._run_benchmark(
+          dataset=dataset,
+          num_cols=num_cols,
+          prefix='csv_float_map_decode_csv'
+      )
     self._tear_down()
 
   def benchmark_map_with_strings(self):
@@ -103,8 +87,13 @@ class CsvDatasetBenchmark(test.Benchmark):
       num_cols = self._num_cols[i]
       kwargs = {'record_defaults': [['']] * num_cols}
       dataset = core_readers.TextLineDataset(self._filenames[i]).repeat()
-      dataset = dataset.map(lambda l: parsing_ops.decode_csv(l, **kwargs))  # pylint: disable=cell-var-from-loop
-      self._run_benchmark(dataset, num_cols, 'csv_strings_map_decode_csv')
+      dataset = dataset.map(lambda l: parsing_ops.decode_csv(
+          l, **kwargs))  # pylint: disable=cell-var-from-loop
+      self._run_benchmark(
+          dataset=dataset,
+          num_cols=num_cols,
+          prefix='csv_strings_map_decode_csv'
+      )
     self._tear_down()
 
   def benchmark_csv_dataset_with_floats(self):
@@ -113,8 +102,13 @@ class CsvDatasetBenchmark(test.Benchmark):
       num_cols = self._num_cols[i]
       kwargs = {'record_defaults': [[0.0]] * num_cols}
       dataset = core_readers.TextLineDataset(self._filenames[i]).repeat()
-      dataset = readers.CsvDataset(self._filenames[i], **kwargs).repeat()  # pylint: disable=cell-var-from-loop
-      self._run_benchmark(dataset, num_cols, 'csv_float_fused_dataset')
+      dataset = readers.CsvDataset(
+          self._filenames[i], **kwargs).repeat()  # pylint: disable=cell-var-from-loop
+      self._run_benchmark(
+          dataset=dataset,
+          num_cols=num_cols,
+          prefix='csv_float_fused_dataset'
+      )
     self._tear_down()
 
   def benchmark_csv_dataset_with_strings(self):
@@ -123,9 +117,15 @@ class CsvDatasetBenchmark(test.Benchmark):
       num_cols = self._num_cols[i]
       kwargs = {'record_defaults': [['']] * num_cols}
       dataset = core_readers.TextLineDataset(self._filenames[i]).repeat()
-      dataset = readers.CsvDataset(self._filenames[i], **kwargs).repeat()  # pylint: disable=cell-var-from-loop
-      self._run_benchmark(dataset, num_cols, 'csv_strings_fused_dataset')
+      dataset = readers.CsvDataset(
+          self._filenames[i], **kwargs).repeat()  # pylint: disable=cell-var-from-loop
+      self._run_benchmark(
+          dataset=dataset,
+          num_cols=num_cols,
+          prefix='csv_strings_fused_dataset'
+      )
     self._tear_down()
 
+
 if __name__ == '__main__':
-  test.main()
+  benchmark_base.test.main()

--- a/tensorflow/python/data/experimental/benchmarks/map_vectorization_benchmark.py
+++ b/tensorflow/python/data/experimental/benchmarks/map_vectorization_benchmark.py
@@ -17,13 +17,12 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import time
 
 import numpy as np
 
 from tensorflow.core.example import example_pb2
 from tensorflow.core.example import feature_pb2
-from tensorflow.python.client import session
+from tensorflow.python.data.benchmarks import benchmark_base
 from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.data.util import nest
 from tensorflow.python.framework import constant_op
@@ -31,7 +30,6 @@ from tensorflow.python.framework import dtypes
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import parsing_ops
-from tensorflow.python.platform import test
 
 
 def _generate_csv_test_case():
@@ -94,26 +92,22 @@ def _generate_parse_single_example_test_case():
 
 # TODO(rachelim): Add a benchmark for more expensive transformations, such as
 # vgg_preprocessing.
-class MapVectorizationBenchmark(test.Benchmark):
+class MapVectorizationBenchmark(benchmark_base.DatasetBenchmarkBase):
   """Benchmarks for the `MapVectorization` optimization."""
 
-  def _run(self, x, num_iters=100, name=None):
-    deltas = []
-    with session.Session() as sess:
-      for _ in range(5):
-        # Warm up session...
-        sess.run(x)
-      for _ in range(num_iters):
-        start = time.time()
-        sess.run(x)
-        end = time.time()
-        deltas.append(end - start)
-    median_time = np.median(deltas)
-    self.report_benchmark(iters=num_iters, wall_time=median_time, name=name)
-    return median_time
+  def _run(self, dataset, num_elements, num_iters=100, name=None):
+
+    wall_time = self.run_benchmark(
+        dataset=dataset,
+        num_elements=num_elements,
+        iters=num_iters,
+        warmup=True
+    )
+    self.report_benchmark(iters=num_iters, wall_time=wall_time, name=name)
+    return wall_time
 
   def _compare(self, input_dataset, map_fn, batch_size, input_size, str_id):
-    num_elems = int(np.sum([np.prod(x) for x in input_size]))
+    num_elements = int(np.sum([np.prod(x) for x in input_size]))
     name_template = "{}_batch_size_{}_input_element_size_{}_{}"
 
     unoptimized_dataset = input_dataset.map(map_fn).batch(batch_size)
@@ -121,21 +115,19 @@ class MapVectorizationBenchmark(test.Benchmark):
     options = dataset_ops.Options()
     options.experimental_optimization.apply_default_optimizations = False
     unoptimized_dataset = unoptimized_dataset.with_options(options)
-    unoptimized_next = dataset_ops.make_one_shot_iterator(
-        unoptimized_dataset).get_next()
 
     options = dataset_ops.Options()
     options.experimental_optimization.map_vectorization.enabled = True
     optimized_dataset = unoptimized_dataset.with_options(options)
-    optimized_next = dataset_ops.make_one_shot_iterator(
-        optimized_dataset).get_next()
 
     unoptimized_time = self._run(
-        unoptimized_next,
-        name=name_template.format(str_id, batch_size, num_elems, "unoptimized"))
+        dataset=unoptimized_dataset,
+        num_elements=num_elements,
+        name=name_template.format(str_id, batch_size, num_elements, "unoptimized"))
     optimized_time = self._run(
-        optimized_next,
-        name=name_template.format(str_id, batch_size, num_elems, "optimized"))
+        dataset=optimized_dataset,
+        num_elements=num_elements,
+        name=name_template.format(str_id, batch_size, num_elements, "optimized"))
 
     print("Batch size: {}\n"
           "Input element size: {}\n"
@@ -198,4 +190,4 @@ class MapVectorizationBenchmark(test.Benchmark):
 
 
 if __name__ == "__main__":
-  test.main()
+  benchmark_base.test.main()

--- a/tensorflow/python/data/experimental/benchmarks/map_vectorization_benchmark.py
+++ b/tensorflow/python/data/experimental/benchmarks/map_vectorization_benchmark.py
@@ -123,11 +123,11 @@ class MapVectorizationBenchmark(benchmark_base.DatasetBenchmarkBase):
     unoptimized_time = self._run(
         dataset=unoptimized_dataset,
         num_elements=num_elements,
-        name=name_template.format(str_id, batch_size, num_elements, "unoptimized"))
+        name=name_template.format(str_id, batch_size, num_elements, "noopt"))
     optimized_time = self._run(
         dataset=optimized_dataset,
         num_elements=num_elements,
-        name=name_template.format(str_id, batch_size, num_elements, "optimized"))
+        name=name_template.format(str_id, batch_size, num_elements, "opt"))
 
     print("Batch size: {}\n"
           "Input element size: {}\n"

--- a/tensorflow/python/data/experimental/benchmarks/map_vectorization_benchmark.py
+++ b/tensorflow/python/data/experimental/benchmarks/map_vectorization_benchmark.py
@@ -95,7 +95,7 @@ def _generate_parse_single_example_test_case():
 class MapVectorizationBenchmark(benchmark_base.DatasetBenchmarkBase):
   """Benchmarks for the `MapVectorization` optimization."""
 
-  def _run(self, dataset, num_elements, num_iters=100, name=None):
+  def _run(self, dataset, num_elements, num_iters=10, name=None):
 
     wall_time = self.run_benchmark(
         dataset=dataset,

--- a/tensorflow/python/data/experimental/benchmarks/optimize_benchmark.py
+++ b/tensorflow/python/data/experimental/benchmarks/optimize_benchmark.py
@@ -17,19 +17,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import time
 
-import numpy as np
-
-from tensorflow.python.client import session
+from tensorflow.python.data.benchmarks import benchmark_base
 from tensorflow.python.data.ops import dataset_ops
-from tensorflow.python.framework import ops
 from tensorflow.python.ops import math_ops
-from tensorflow.python.platform import test
 
 
-# TODO(b/119837791): Add eager benchmarks too.
-class OptimizationBenchmark(test.Benchmark):
+class OptimizationBenchmark(benchmark_base.DatasetBenchmarkBase):
   """Benchmarks for static optimizations."""
 
   def benchmark_map_fusion(self):
@@ -37,123 +31,96 @@ class OptimizationBenchmark(test.Benchmark):
 
     chain_lengths = [0, 1, 2, 5, 10, 20, 50]
     for chain_length in chain_lengths:
-      self._benchmark_map_fusion(chain_length, False)
-      self._benchmark_map_fusion(chain_length, True)
+      self._benchmark_map_fusion(chain_length=chain_length,
+                                 optimize_dataset=False)
+      self._benchmark_map_fusion(chain_length=chain_length,
+                                 optimize_dataset=True)
 
   def _benchmark_map_fusion(self, chain_length, optimize_dataset):
-    with ops.Graph().as_default():
-      dataset = dataset_ops.Dataset.from_tensors(0).repeat(None)
-      for _ in range(chain_length):
-        dataset = dataset.map(lambda x: x)
-      if optimize_dataset:
-        options = dataset_ops.Options()
-        options.experimental_optimization.apply_default_optimizations = False
-        options.experimental_optimization.map_fusion = True
-        dataset = dataset.with_options(options)
 
-      iterator = dataset_ops.make_one_shot_iterator(dataset)
-      next_element = iterator.get_next()
+    dataset = dataset_ops.Dataset.from_tensors(0).repeat(None)
+    for _ in range(chain_length):
+      dataset = dataset.map(lambda x: x)
+    if optimize_dataset:
+      options = dataset_ops.Options()
+      options.experimental_optimization.apply_default_optimizations = False
+      options.experimental_optimization.map_fusion = True
+      dataset = dataset.with_options(options)
 
-      with session.Session() as sess:
-        for _ in range(5):
-          sess.run(next_element.op)
-        deltas = []
-        for _ in range(100):
-          start = time.time()
-          for _ in range(100):
-            sess.run(next_element.op)
-          end = time.time()
-          deltas.append(end - start)
-
-        median_wall_time = np.median(deltas) / 100
-        opt_mark = "opt" if optimize_dataset else "noopt"
-        self.report_benchmark(
-            iters=100,
-            wall_time=median_wall_time,
-            name="map_fusion_{}_chain_length_{}".format(
-                opt_mark, chain_length))
+    opt_mark = "opt" if optimize_dataset else "noopt"
+    self.run_and_report_benchmark(
+        dataset=dataset,
+        num_elements=100,
+        iters=10,
+        warmup=True,
+        name="map_fusion_{}_chain_length_{}".format(
+            opt_mark, chain_length)
+    )
 
   def benchmark_map_and_filter_fusion(self):
     """Evaluates performance map of fusion."""
 
     chain_lengths = [0, 1, 2, 5, 10, 20, 50]
     for chain_length in chain_lengths:
-      self._benchmark_map_and_filter_fusion(chain_length, False)
-      self._benchmark_map_and_filter_fusion(chain_length, True)
+      self._benchmark_map_and_filter_fusion(chain_length=chain_length,
+                                            optimize_dataset=False)
+      self._benchmark_map_and_filter_fusion(chain_length=chain_length,
+                                            optimize_dataset=True)
 
   def _benchmark_map_and_filter_fusion(self, chain_length, optimize_dataset):
-    with ops.Graph().as_default():
-      dataset = dataset_ops.Dataset.from_tensors(0).repeat(None)
-      for _ in range(chain_length):
-        dataset = dataset.map(lambda x: x + 5).filter(
-            lambda x: math_ops.greater_equal(x - 5, 0))
-      if optimize_dataset:
-        options = dataset_ops.Options()
-        options.experimental_optimization.apply_default_optimizations = False
-        options.experimental_optimization.map_and_filter_fusion = True
-        dataset = dataset.with_options(options)
-      iterator = dataset_ops.make_one_shot_iterator(dataset)
-      next_element = iterator.get_next()
 
-      with session.Session() as sess:
-        for _ in range(10):
-          sess.run(next_element.op)
-        deltas = []
-        for _ in range(100):
-          start = time.time()
-          for _ in range(100):
-            sess.run(next_element.op)
-          end = time.time()
-          deltas.append(end - start)
+    dataset = dataset_ops.Dataset.from_tensors(0).repeat(None)
+    for _ in range(chain_length):
+      dataset = dataset.map(lambda x: x + 5).filter(
+          lambda x: math_ops.greater_equal(x - 5, 0))
+    if optimize_dataset:
+      options = dataset_ops.Options()
+      options.experimental_optimization.apply_default_optimizations = False
+      options.experimental_optimization.map_and_filter_fusion = True
+      dataset = dataset.with_options(options)
 
-        median_wall_time = np.median(deltas) / 100
-        opt_mark = "opt" if optimize_dataset else "noopt"
-        self.report_benchmark(
-            iters=100,
-            wall_time=median_wall_time,
-            name="map_and_filter_fusion_{}_chain_length_{}".format(
-                opt_mark, chain_length))
+    opt_mark = "opt" if optimize_dataset else "noopt"
+    self.run_and_report_benchmark(
+        dataset=dataset,
+        num_elements=100,
+        iters=10,
+        warmup=True,
+        name="map_and_filter_fusion_{}_chain_length_{}".format(
+            opt_mark, chain_length)
+    )
 
   # This benchmark compares the performance of pipeline with multiple chained
   # filter with and without filter fusion.
+
   def benchmark_filter_fusion(self):
     chain_lengths = [0, 1, 2, 5, 10, 20, 50]
     for chain_length in chain_lengths:
-      self._benchmark_filter_fusion(chain_length, False)
-      self._benchmark_filter_fusion(chain_length, True)
+      self._benchmark_filter_fusion(chain_length=chain_length,
+                                    optimize_dataset=False)
+      self._benchmark_filter_fusion(chain_length=chain_length,
+                                    optimize_dataset=True)
 
   def _benchmark_filter_fusion(self, chain_length, optimize_dataset):
-    with ops.Graph().as_default():
-      dataset = dataset_ops.Dataset.from_tensors(5).repeat(None)
-      for _ in range(chain_length):
-        dataset = dataset.filter(lambda x: math_ops.greater_equal(x - 5, 0))
-      if optimize_dataset:
-        options = dataset_ops.Options()
-        options.experimental_optimization.apply_default_optimizations = False
-        options.experimental_optimization.filter_fusion = True
-        dataset = dataset.with_options(options)
 
-      iterator = dataset_ops.make_one_shot_iterator(dataset)
-      next_element = iterator.get_next()
+    dataset = dataset_ops.Dataset.from_tensors(5).repeat(None)
+    for _ in range(chain_length):
+      dataset = dataset.filter(lambda x: math_ops.greater_equal(x - 5, 0))
+    if optimize_dataset:
+      options = dataset_ops.Options()
+      options.experimental_optimization.apply_default_optimizations = False
+      options.experimental_optimization.filter_fusion = True
+      dataset = dataset.with_options(options)
 
-      with session.Session() as sess:
-        for _ in range(10):
-          sess.run(next_element.op)
-        deltas = []
-        for _ in range(100):
-          start = time.time()
-          for _ in range(100):
-            sess.run(next_element.op)
-          end = time.time()
-          deltas.append(end - start)
-
-        median_wall_time = np.median(deltas) / 100
-        opt_mark = "opt" if optimize_dataset else "no-opt"
-        self.report_benchmark(
-            iters=1000,
-            wall_time=median_wall_time,
-            name="chain_length_{}_{}".format(opt_mark, chain_length))
+    opt_mark = "opt" if optimize_dataset else "noopt"
+    self.run_and_report_benchmark(
+        dataset=dataset,
+        num_elements=100,
+        iters=10,
+        warmup=True,
+        name="filter_fusion_{}_chain_length_{}".format(
+            opt_mark, chain_length)
+    )
 
 
 if __name__ == "__main__":
-  test.main()
+  benchmark_base.test.main()

--- a/tensorflow/python/data/experimental/benchmarks/snapshot_dataset_benchmark.py
+++ b/tensorflow/python/data/experimental/benchmarks/snapshot_dataset_benchmark.py
@@ -107,7 +107,14 @@ class SnapshotDatasetBenchmark(benchmark_base.DatasetBenchmarkBase):
     )
 
     # Consume only 1 element, thus making sure we don't finalize.
-    self.consume_dataset(dataset=dataset, num_elements=1)
+    self.run_benchmark(
+        dataset=dataset,
+        num_elements=1,
+        iters=1,
+        warmup=False,
+        apply_default_optimizations=True
+    )
+    # Now run the actual benchmarks and report them
     self.run_and_report_benchmark(
         dataset=dataset,
         num_elements=num_elements,
@@ -123,7 +130,14 @@ class SnapshotDatasetBenchmark(benchmark_base.DatasetBenchmarkBase):
     )
 
     # consume all the elements to let snapshot write things to disk
-    self.consume_dataset(dataset=dataset, num_elements=num_elements)
+    self.run_benchmark(
+        dataset=dataset,
+        num_elements=num_elements,
+        iters=1,
+        warmup=False,
+        apply_default_optimizations=True
+    )
+    # Now run the actual benchmarks and report them
     self.run_and_report_benchmark(
         dataset=dataset,
         num_elements=num_elements,
@@ -139,7 +153,15 @@ class SnapshotDatasetBenchmark(benchmark_base.DatasetBenchmarkBase):
         compression=snapshot.COMPRESSION_GZIP
     )
 
-    self.consume_dataset(dataset=dataset, num_elements=num_elements)
+    # consume all the elements to let snapshot write things to disk
+    self.run_benchmark(
+        dataset=dataset,
+        num_elements=num_elements,
+        iters=1,
+        warmup=False,
+        apply_default_optimizations=True
+    )
+    # Now run the actual benchmarks and report them
     self.run_and_report_benchmark(
         dataset=dataset,
         num_elements=num_elements,
@@ -155,7 +177,15 @@ class SnapshotDatasetBenchmark(benchmark_base.DatasetBenchmarkBase):
         compression=snapshot.COMPRESSION_SNAPPY
     )
 
-    self.consume_dataset(dataset=dataset, num_elements=num_elements)
+    # consume all the elements to let snapshot write things to disk
+    self.run_benchmark(
+        dataset=dataset,
+        num_elements=num_elements,
+        iters=1,
+        warmup=False,
+        apply_default_optimizations=True
+    )
+    # Now run the actual benchmarks and report them
     self.run_and_report_benchmark(
         dataset=dataset,
         num_elements=num_elements,

--- a/tensorflow/python/data/experimental/benchmarks/snapshot_dataset_benchmark.py
+++ b/tensorflow/python/data/experimental/benchmarks/snapshot_dataset_benchmark.py
@@ -20,12 +20,9 @@ from __future__ import print_function
 import os
 import shutil
 
-from tensorflow.python.eager import context
-from tensorflow.python.client import session
 from tensorflow.python.data.benchmarks import benchmark_base
 from tensorflow.python.data.experimental.ops import snapshot
 from tensorflow.python.data.ops import dataset_ops
-from tensorflow.python.framework import errors_impl as errors
 from tensorflow.python.ops import gen_array_ops
 from tensorflow.python.platform import test
 

--- a/tensorflow/python/data/experimental/benchmarks/snapshot_dataset_benchmark.py
+++ b/tensorflow/python/data/experimental/benchmarks/snapshot_dataset_benchmark.py
@@ -59,8 +59,10 @@ class SnapshotDatasetBenchmark(benchmark_base.DatasetBenchmarkBase):
     dataset = dataset.skip(num_elements)
     if context.executing_eagerly():
       iterator = iter(dataset)
-      for _ in range(num_elements):
+      try:
         next(iterator)
+      except StopIteration:
+        pass
     else:
       next_element = dataset_ops.make_one_shot_iterator(dataset).get_next()
       with session.Session() as sess:

--- a/tensorflow/python/data/experimental/benchmarks/snapshot_dataset_benchmark.py
+++ b/tensorflow/python/data/experimental/benchmarks/snapshot_dataset_benchmark.py
@@ -107,7 +107,7 @@ class SnapshotDatasetBenchmark(benchmark_base.DatasetBenchmarkBase):
     )
 
     # Consume only 1 element, thus making sure we don't finalize.
-    self._consume_dataset(dataset=dataset, num_elements=1)
+    self.consume_dataset(dataset=dataset, num_elements=1)
     self.run_and_report_benchmark(
         dataset=dataset,
         num_elements=num_elements,
@@ -123,7 +123,7 @@ class SnapshotDatasetBenchmark(benchmark_base.DatasetBenchmarkBase):
     )
 
     # consume all the elements to let snapshot write things to disk
-    self._consume_dataset(dataset=dataset, num_elements=num_elements)
+    self.consume_dataset(dataset=dataset, num_elements=num_elements)
     self.run_and_report_benchmark(
         dataset=dataset,
         num_elements=num_elements,
@@ -139,7 +139,7 @@ class SnapshotDatasetBenchmark(benchmark_base.DatasetBenchmarkBase):
         compression=snapshot.COMPRESSION_GZIP
     )
 
-    self._consume_dataset(dataset=dataset, num_elements=num_elements)
+    self.consume_dataset(dataset=dataset, num_elements=num_elements)
     self.run_and_report_benchmark(
         dataset=dataset,
         num_elements=num_elements,
@@ -155,7 +155,7 @@ class SnapshotDatasetBenchmark(benchmark_base.DatasetBenchmarkBase):
         compression=snapshot.COMPRESSION_SNAPPY
     )
 
-    self._consume_dataset(dataset=dataset, num_elements=num_elements)
+    self.consume_dataset(dataset=dataset, num_elements=num_elements)
     self.run_and_report_benchmark(
         dataset=dataset,
         num_elements=num_elements,

--- a/tensorflow/python/data/experimental/benchmarks/snapshot_dataset_benchmark.py
+++ b/tensorflow/python/data/experimental/benchmarks/snapshot_dataset_benchmark.py
@@ -55,22 +55,6 @@ class SnapshotDatasetBenchmark(benchmark_base.DatasetBenchmarkBase):
 
     return dataset
 
-  def _consumeDataset(self, dataset, num_elements):
-    dataset = dataset.skip(num_elements)
-    if context.executing_eagerly():
-      iterator = iter(dataset)
-      try:
-        next(iterator)
-      except StopIteration:
-        pass
-    else:
-      next_element = dataset_ops.make_one_shot_iterator(dataset).get_next()
-      with session.Session() as sess:
-        try:
-          sess.run(next_element)
-        except errors.OutOfRangeError:
-          pass
-
   def benchmarkWriteSnapshotGzipCompression(self):
     num_elements = 500000
     dataset = self._createSimpleDataset(
@@ -123,7 +107,7 @@ class SnapshotDatasetBenchmark(benchmark_base.DatasetBenchmarkBase):
     )
 
     # Consume only 1 element, thus making sure we don't finalize.
-    self._consumeDataset(dataset=dataset, num_elements=1)
+    self._consume_dataset(dataset=dataset, num_elements=1)
     self.run_and_report_benchmark(
         dataset=dataset,
         num_elements=num_elements,
@@ -139,7 +123,7 @@ class SnapshotDatasetBenchmark(benchmark_base.DatasetBenchmarkBase):
     )
 
     # consume all the elements to let snapshot write things to disk
-    self._consumeDataset(dataset=dataset, num_elements=num_elements)
+    self._consume_dataset(dataset=dataset, num_elements=num_elements)
     self.run_and_report_benchmark(
         dataset=dataset,
         num_elements=num_elements,
@@ -155,7 +139,7 @@ class SnapshotDatasetBenchmark(benchmark_base.DatasetBenchmarkBase):
         compression=snapshot.COMPRESSION_GZIP
     )
 
-    self._consumeDataset(dataset=dataset, num_elements=num_elements)
+    self._consume_dataset(dataset=dataset, num_elements=num_elements)
     self.run_and_report_benchmark(
         dataset=dataset,
         num_elements=num_elements,
@@ -171,7 +155,7 @@ class SnapshotDatasetBenchmark(benchmark_base.DatasetBenchmarkBase):
         compression=snapshot.COMPRESSION_SNAPPY
     )
 
-    self._consumeDataset(dataset=dataset, num_elements=num_elements)
+    self._consume_dataset(dataset=dataset, num_elements=num_elements)
     self.run_and_report_benchmark(
         dataset=dataset,
         num_elements=num_elements,

--- a/tensorflow/python/data/experimental/benchmarks/snapshot_dataset_benchmark.py
+++ b/tensorflow/python/data/experimental/benchmarks/snapshot_dataset_benchmark.py
@@ -20,17 +20,16 @@ from __future__ import print_function
 import os
 import shutil
 
+from tensorflow.python.eager import context
 from tensorflow.python.client import session
 from tensorflow.python.data.benchmarks import benchmark_base
 from tensorflow.python.data.experimental.ops import snapshot
 from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.framework import errors_impl as errors
-from tensorflow.python.framework import test_util
 from tensorflow.python.ops import gen_array_ops
 from tensorflow.python.platform import test
 
 
-@test_util.run_all_in_graph_and_eager_modes
 class SnapshotDatasetBenchmark(benchmark_base.DatasetBenchmarkBase):
   """Benchmarks for `tf.data.experimental.snapshot()`."""
 
@@ -42,7 +41,7 @@ class SnapshotDatasetBenchmark(benchmark_base.DatasetBenchmarkBase):
     os.mkdir(tmp_dir)
     return tmp_dir
 
-  def _createSimpleDataset(self, num_elems, tmp_dir=None,
+  def _createSimpleDataset(self, num_elements, tmp_dir=None,
                            compression=snapshot.COMPRESSION_NONE):
     if not tmp_dir:
       tmp_dir = self._makeSnapshotDirectory()
@@ -50,85 +49,133 @@ class SnapshotDatasetBenchmark(benchmark_base.DatasetBenchmarkBase):
     dataset = dataset_ops.Dataset.from_tensor_slices([1.0])
     dataset = dataset.map(
         lambda x: gen_array_ops.broadcast_to(x, [50, 50, 3]))
-    dataset = dataset.repeat(num_elems)
+    dataset = dataset.repeat(num_elements)
     dataset = dataset.apply(
         snapshot.legacy_snapshot(tmp_dir, compression=compression))
 
     return dataset
 
-  def _consumeDataset(self, dataset, num_elems):
-    dataset = dataset.skip(num_elems)
-    next_element = dataset_ops.make_one_shot_iterator(dataset).get_next()
-    with session.Session() as sess:
-      try:
-        sess.run(next_element)
-      except errors.OutOfRangeError:
-        pass
+  def _consumeDataset(self, dataset, num_elements):
+    dataset = dataset.skip(num_elements)
+    if context.executing_eagerly():
+      iterator = iter(dataset)
+      for _ in range(num_elements):
+        next(iterator)
+    else:
+      next_element = dataset_ops.make_one_shot_iterator(dataset).get_next()
+      with session.Session() as sess:
+        try:
+          sess.run(next_element)
+        except errors.OutOfRangeError:
+          pass
 
   def benchmarkWriteSnapshotGzipCompression(self):
-    num_elems = 500000
+    num_elements = 500000
     dataset = self._createSimpleDataset(
-        num_elems, compression=snapshot.COMPRESSION_GZIP)
-
-    self.run_and_report_benchmark(dataset, num_elems, "write_gzip",
-                                  warmup=False, iters=1)
-
-  def benchmarkWriteSnapshotSnappyCompression(self):
-    num_elems = 500000
-    dataset = self._createSimpleDataset(
-        num_elems, compression=snapshot.COMPRESSION_SNAPPY)
+        num_elements=num_elements, compression=snapshot.COMPRESSION_GZIP
+    )
 
     self.run_and_report_benchmark(
-        dataset, num_elems, "write_snappy", warmup=False, iters=1)
+        dataset=dataset,
+        num_elements=num_elements,
+        name="write_gzip",
+        warmup=False,
+        iters=1
+    )
+
+  def benchmarkWriteSnapshotSnappyCompression(self):
+    num_elements = 500000
+    dataset = self._createSimpleDataset(
+        num_elements=num_elements, compression=snapshot.COMPRESSION_SNAPPY
+    )
+
+    self.run_and_report_benchmark(
+        dataset=dataset,
+        num_elements=num_elements,
+        name="write_snappy",
+        warmup=False,
+        iters=1
+    )
 
   def benchmarkWriteSnapshotSimple(self):
-    num_elems = 500000
-    dataset = self._createSimpleDataset(num_elems)
+    num_elements = 500000
+    dataset = self._createSimpleDataset(num_elements=num_elements)
 
     # We only run one iteration here because running multiple iterations will
     # cause the later iterations to simply read from the already written
     # snapshot rather than write a new one.
-    self.run_and_report_benchmark(dataset, num_elems, "write_simple",
-                                  warmup=False, iters=1)
+    self.run_and_report_benchmark(
+        dataset=dataset,
+        num_elements=num_elements,
+        name="write_simple",
+        warmup=False,
+        iters=1
+    )
 
   def benchmarkPassthroughSnapshotSimple(self):
-    num_elems = 100000
+    num_elements = 100000
     tmp_dir = self._makeSnapshotDirectory()
-    dataset = self._createSimpleDataset(num_elems, tmp_dir)
+    dataset = self._createSimpleDataset(
+        num_elements=num_elements,
+        tmp_dir=tmp_dir
+    )
 
     # Consume only 1 element, thus making sure we don't finalize.
-    self._consumeDataset(dataset, 1)
-
-    self.run_and_report_benchmark(dataset, num_elems, "passthrough_simple")
+    self._consumeDataset(dataset=dataset, num_elements=1)
+    self.run_and_report_benchmark(
+        dataset=dataset,
+        num_elements=num_elements,
+        name="passthrough_simple"
+    )
 
   def benchmarkReadSnapshotSimple(self):
-    num_elems = 100000
+    num_elements = 100000
     tmp_dir = self._makeSnapshotDirectory()
-    dataset = self._createSimpleDataset(num_elems, tmp_dir)
+    dataset = self._createSimpleDataset(
+        num_elements=num_elements,
+        tmp_dir=tmp_dir
+    )
 
     # consume all the elements to let snapshot write things to disk
-    self._consumeDataset(dataset, num_elems)
-
-    self.run_and_report_benchmark(dataset, num_elems, "read_simple")
+    self._consumeDataset(dataset=dataset, num_elements=num_elements)
+    self.run_and_report_benchmark(
+        dataset=dataset,
+        num_elements=num_elements,
+        name="read_simple"
+    )
 
   def benchmarkReadSnapshotGzipCompression(self):
-    num_elems = 100000
+    num_elements = 100000
     tmp_dir = self._makeSnapshotDirectory()
     dataset = self._createSimpleDataset(
-        num_elems, tmp_dir, compression=snapshot.COMPRESSION_GZIP)
+        num_elements=num_elements,
+        tmp_dir=tmp_dir,
+        compression=snapshot.COMPRESSION_GZIP
+    )
 
-    self._consumeDataset(dataset, num_elems)
-    self.run_and_report_benchmark(dataset, num_elems, "read_gzip")
+    self._consumeDataset(dataset=dataset, num_elements=num_elements)
+    self.run_and_report_benchmark(
+        dataset=dataset,
+        num_elements=num_elements,
+        name="read_gzip"
+    )
 
   def benchmarkReadSnapshotSnappyCompression(self):
-    num_elems = 100000
+    num_elements = 100000
     tmp_dir = self._makeSnapshotDirectory()
     dataset = self._createSimpleDataset(
-        num_elems, tmp_dir, compression=snapshot.COMPRESSION_SNAPPY)
+        num_elements=num_elements,
+        tmp_dir=tmp_dir,
+        compression=snapshot.COMPRESSION_SNAPPY
+    )
 
-    self._consumeDataset(dataset, num_elems)
-    self.run_and_report_benchmark(dataset, num_elems, "read_snappy")
+    self._consumeDataset(dataset=dataset, num_elements=num_elements)
+    self.run_and_report_benchmark(
+        dataset=dataset,
+        num_elements=num_elements,
+        name="read_snappy"
+    )
 
 
 if __name__ == "__main__":
-  test.main()
+  benchmark_base.test.main()

--- a/tensorflow/python/data/experimental/benchmarks/unbatch_benchmark.py
+++ b/tensorflow/python/data/experimental/benchmarks/unbatch_benchmark.py
@@ -17,92 +17,48 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import time
-
-import numpy as np
-
-from tensorflow.python.client import session
+from tensorflow.python.data.benchmarks import benchmark_base
 from tensorflow.python.data.ops import dataset_ops
-from tensorflow.python.framework import dtypes
-from tensorflow.python.framework import ops
-from tensorflow.python.ops import array_ops
-from tensorflow.python.platform import test
 
 
-class UnbatchBenchmark(test.Benchmark):
+class UnbatchBenchmark(benchmark_base.DatasetBenchmarkBase):
   """Benchmarks for `tf.data.Dataset.unbatch()`."""
 
   def benchmark_native_unbatch(self):
     batch_sizes = [1, 2, 5, 10, 20, 50]
-    elems_per_trial = 10000
-    with ops.Graph().as_default():
+    num_elements = 10000
+
+    for batch_size in batch_sizes:
       dataset = dataset_ops.Dataset.from_tensors("element").repeat(None)
-      batch_size_placeholder = array_ops.placeholder(dtypes.int64, shape=[])
-      dataset = dataset.batch(batch_size_placeholder)
+      dataset = dataset.batch(batch_size)
       dataset = dataset.unbatch()
-      dataset = dataset.skip(elems_per_trial)
-      options = dataset_ops.Options()
-      options.experimental_optimization.apply_default_optimizations = False
-      dataset = dataset.with_options(options)
-      iterator = dataset_ops.make_initializable_iterator(dataset)
-      next_element = iterator.get_next()
 
-      with session.Session() as sess:
-        for batch_size in batch_sizes:
-          deltas = []
-          for _ in range(5):
-            sess.run(
-                iterator.initializer,
-                feed_dict={batch_size_placeholder: batch_size})
-            start = time.time()
-            sess.run(next_element.op)
-            end = time.time()
-            deltas.append((end - start) / elems_per_trial)
-
-          median_wall_time = np.median(deltas)
-          self.report_benchmark(
-              iters=10000,
-              wall_time=median_wall_time,
-              name="native_batch_size_%d" %
-              batch_size)
+      self.run_and_report_benchmark(
+          dataset=dataset,
+          num_elements=num_elements,
+          iters=5,
+          name="native_batch_size_%d" % batch_size
+      )
 
   # Include a benchmark of the previous `unbatch()` implementation that uses
   # a composition of more primitive ops. Eventually we'd hope to generate code
   # that is as good in both cases.
   def benchmark_old_unbatch_implementation(self):
     batch_sizes = [1, 2, 5, 10, 20, 50]
-    elems_per_trial = 10000
-    with ops.Graph().as_default():
+    num_elements = 10000
+
+    for batch_size in batch_sizes:
       dataset = dataset_ops.Dataset.from_tensors("element").repeat(None)
-      batch_size_placeholder = array_ops.placeholder(dtypes.int64, shape=[])
-      dataset = dataset.batch(batch_size_placeholder)
+      dataset = dataset.batch(batch_size)
       dataset = dataset.flat_map(dataset_ops.Dataset.from_tensor_slices)
-      dataset = dataset.skip(elems_per_trial)
-      options = dataset_ops.Options()
-      options.experimental_optimization.apply_default_optimizations = False
-      dataset = dataset.with_options(options)
-      iterator = dataset_ops.make_initializable_iterator(dataset)
-      next_element = iterator.get_next()
 
-      with session.Session() as sess:
-        for batch_size in batch_sizes:
-          deltas = []
-          for _ in range(5):
-            sess.run(
-                iterator.initializer,
-                feed_dict={batch_size_placeholder: batch_size})
-            start = time.time()
-            sess.run(next_element.op)
-            end = time.time()
-            deltas.append((end - start) / elems_per_trial)
-
-          median_wall_time = np.median(deltas)
-          self.report_benchmark(
-              iters=10000,
-              wall_time=median_wall_time,
-              name="unfused_batch_size_%d" %
-              batch_size)
+      self.run_and_report_benchmark(
+          dataset=dataset,
+          num_elements=num_elements,
+          iters=5,
+          name="unfused_batch_size_%d" % batch_size
+      )
 
 
 if __name__ == "__main__":
-  test.main()
+  benchmark_base.test.main()


### PR DESCRIPTION
This PR is a follow up of https://github.com/tensorflow/tensorflow/pull/46320 and extends the eager mode support to a subset of experimental benchmarks.

Sample result:

```console
entry {
  name: "CsvDatasetBenchmark.csv_strings_map_decode_csv_with_cols_256.eager"
  iters: 10
  wall_time: 0.0020652782201766966
  extras {
    key: "num_elements"
    value {
      double_value: 5000.0
    }
  }
}

#####

entry {
  name: "OptimizationBenchmark.map_fusion_noopt_chain_length_50.eager"
  iters: 10
  wall_time: 2.3424625396728516e-05
  extras {
    key: "num_elements"
    value {
      double_value: 100.0
    }
  }
}

entry {
  name: "OptimizationBenchmark.map_fusion_opt_chain_length_50.eager"
  iters: 10
  wall_time: 5.298852920532227e-06
  extras {
    key: "num_elements"
    value {
      double_value: 100.0
    }
  }
}

```

cc: @jsimsa 