### PR TITLE
Fix the 9KB binary size increase.

### DIFF
--- a/tensorflow/lite/kernels/kernel_util.cc
+++ b/tensorflow/lite/kernels/kernel_util.cc
@@ -383,6 +383,13 @@ bool HaveSameShapes(const TfLiteTensor* input1, const TfLiteTensor* input2) {
   return TfLiteIntArrayEqual(input1->dims, input2->dims);
 }
 
+#ifndef TF_LITE_STATIC_MEMORY
+
+// TODO(b/172067338): Having this function be part of TF_LITE_STATIC_MEMORY
+// build results in a 6KB size increase, even though the function is unsused for
+// that build. What appears to be happening is that while the linker drops the
+// unsused function, the string library that gets pulled in is not dropped,
+// resulting in the increased binary size.
 std::string GetShapeDebugString(const TfLiteIntArray* shape) {
   std::string str;
   for (int d = 0; d < shape->size; ++d) {
@@ -395,9 +402,6 @@ std::string GetShapeDebugString(const TfLiteIntArray* shape) {
   return str;
 }
 
-// TODO(petewarden): Having macros around this is ugly, look at other strategies
-// before replicating this approach elsewhere.
-#ifndef TF_LITE_STATIC_MEMORY
 TfLiteStatus CalculateShapeForBroadcast(TfLiteContext* context,
                                         const TfLiteTensor* input1,
                                         const TfLiteTensor* input2,


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/commit/9ee7896d229278f582a3a381c6d22ec0559d9765 added a function that was unused for the TFLM build yet still contributed to binary size increase.

This change moves that function inside #ifndef TF_LITE_STATIC_MEMORY and so avoids the size increase.

Manually tested with the following commands:
```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=fusion_f1 XTENSA_CORE=F1_190305_swupgrade keyword_benchmark -j8 BUILD_TYPE=release
xt-size tensorflow/lite/micro/tools/make/gen/xtensa_fusion_f1_release/bin/keyword_benchmark
```

Before this change:
```
   text	   data	    bss	    dec
  67192	  44512	  24968	 136672
```

After this change:
```
   text	   data	    bss	    dec
  62184	  40180	  24872	 127236
```

Fixes http://b/178731766
