### PR TITLE
fixed issue template link

### DIFF
--- a/.github/ISSUE_TEMPLATE/00-bug-issue.md
+++ b/.github/ISSUE_TEMPLATE/00-bug-issue.md
@@ -6,7 +6,7 @@ labels: 'type:bug'
 ---
 
 <em>Please make sure that this is a bug. As per our
-[GitHub Policy](https://github.com/tensorflow/tensorflow/blob/master/ISSUES.md),
+[GitHub Policy](https://github.com/tensorflow/tensorflow/blob/master/ISSUE_TEMPLATE.md),
 we only address code/doc bugs, performance issues, feature requests and
 build/installation issues on GitHub. tag:bug_template</em>
 


### PR DESCRIPTION
When creating a new GitHub issue using the "bug" template, the `GitHub Policy` link results in a `404`.
I am assuming it is meant to link to `ISSUE_TEMPLATE.md` instead of `ISSUES.md`.