### PR TITLE
Update nn_ops.py

### DIFF
--- a/tensorflow/core/kernels/avgpooling_op.cc
+++ b/tensorflow/core/kernels/avgpooling_op.cc
@@ -77,6 +77,10 @@ class AvgPoolingOp : public UnaryOp<T> {
     OP_REQUIRES(context, ksize_[0] == 1 && stride_[0] == 1,
                 errors::Unimplemented(
                     "Pooling is not yet supported on the batch dimension."));
+      
+    for (int i=0; i < 4; ++i){
+        OP_REQUIRES(context, ksize_[i] != 0, errors::InvalidArgument("ksize cannot be zero"));
+    }
   }
 
   void Compute(OpKernelContext* context) override {

--- a/tensorflow/core/kernels/avgpooling_op.cc
+++ b/tensorflow/core/kernels/avgpooling_op.cc
@@ -78,7 +78,7 @@ class AvgPoolingOp : public UnaryOp<T> {
                 errors::Unimplemented(
                     "Pooling is not yet supported on the batch dimension."));
       
-    for (int i=0; i < 4; ++i){
+    for (int i=0; i < ksize_.size(); ++i){
         OP_REQUIRES(context, ksize_[i] != 0, errors::InvalidArgument("ksize cannot be zero"));
     }
   }

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -72,7 +72,7 @@ def _get_sequence(value, n, channel_index, name):
   if value is None:
     return [1] * (n + 2)
 
-  # `value` should not 0
+  # `value` should not be 0
   if value == 0:
     raise FloatingPointError("{} should not be 0".format(name))
 

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -72,10 +72,6 @@ def _get_sequence(value, n, channel_index, name):
   if value is None:
     return [1] * (n + 2)
 
-  # `value` should not be 0
-  if value == 0:
-    raise FloatingPointError("{} should not be 0".format(name))
-
   # Always convert `value` to a `list`.
   if isinstance(value, list):
     pass

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -72,6 +72,10 @@ def _get_sequence(value, n, channel_index, name):
   if value is None:
     return [1] * (n + 2)
 
+  # `value` should not 0
+  if value == 0:
+    raise FloatingPointError("{} should not be 0".format(name))
+
   # Always convert `value` to a `list`.
   if isinstance(value, list):
     pass


### PR DESCRIPTION
Fix [#46834](https://github.com/tensorflow/tensorflow/issues/46834) and [#46994](https://github.com/tensorflow/tensorflow/issues/46994)
On having kernel size as 0 , the code crashes on execution. This pull request will raise a **FloatingPointError** upon getting a value of 0 for the `ksize` argument in `nn_ops`.