### PR TITLE
Use vectorized load/store in GatherOpKernel

### DIFF
--- a/tensorflow/core/kernels/gather_functor_batched_gpu.cu.h
+++ b/tensorflow/core/kernels/gather_functor_batched_gpu.cu.h
@@ -85,33 +85,37 @@ __global__ void GatherOpKernel(const T* __restrict__ params,
 
 namespace detail {
 
-template <int vec_size, bool is_axis_zero, bool is_batch_dims_zero, typename T,
-          typename Index>
-Status LaunchGatherKernelVectorized(const GPUDevice& d, const T* params,
-                                    const Index* indices, T* out,
-                                    int64 outer_size, int64 gather_dim_size,
-                                    int64 indices_size, int64 slice_size,
-                                    int64 out_size) {
-  CHECK(slice_size % vec_size == 0);  // Crash OK
-  CHECK(out_size % vec_size == 0);    // Crash OK
-  CHECK(reinterpret_cast<std::uintptr_t>(params) % vec_size == 0);  // Crash OK
-  CHECK(reinterpret_cast<std::uintptr_t>(out) % vec_size == 0);     // Crash OK
-  int64 out_size_vec = out_size / vec_size;
-  int64 slice_size_vec = slice_size / vec_size;
-  using Tvec = AlignedVector<T, vec_size>;
-  const Tvec* params_vec = reinterpret_cast<const Tvec*>(params);
-  Tvec* out_vec = reinterpret_cast<Tvec*>(out);
+template <bool is_axis_zero, bool is_batch_dims_zero>
+struct LaunchGatherKernelVectorized {
+  template <int vec_size>
+  struct Impl {
+    template <typename T, typename Index>
+    Status operator()(const GPUDevice& d, const T* params, const Index* indices,
+                      T* out, int64 outer_size, int64 gather_dim_size,
+                      int64 indices_size, int64 slice_size, int64 out_size) {
+      CHECK(slice_size % vec_size == 0);  // Crash OK
+      CHECK(out_size % vec_size == 0);    // Crash OK
+      CHECK(reinterpret_cast<std::uintptr_t>(params) % vec_size ==
+            0);                                                      // Crash OK
+      CHECK(reinterpret_cast<std::uintptr_t>(out) % vec_size == 0);  // Crash OK
+      int64 out_size_vec = out_size / vec_size;
+      int64 slice_size_vec = slice_size / vec_size;
+      using Tvec = AlignedVector<T, vec_size>;
+      const Tvec* params_vec = reinterpret_cast<const Tvec*>(params);
+      Tvec* out_vec = reinterpret_cast<Tvec*>(out);
 
-  GpuLaunchConfig config = GetGpuLaunchConfig(
-      out_size_vec, d,
-      &GatherOpKernel<Tvec, Index, is_axis_zero, is_batch_dims_zero>,
-      /*dynamic_shared_memory_size=*/0, /*block_size_limit=*/0);
-  return GpuLaunchKernel(
-      GatherOpKernel<Tvec, Index, is_axis_zero, is_batch_dims_zero>,
-      config.block_count, config.thread_per_block, 0, d.stream(), params_vec,
-      indices, out_vec, outer_size, gather_dim_size, indices_size,
-      slice_size_vec, out_size_vec);
-}
+      GpuLaunchConfig config = GetGpuLaunchConfig(
+          out_size_vec, d,
+          &GatherOpKernel<Tvec, Index, is_axis_zero, is_batch_dims_zero>,
+          /*dynamic_shared_memory_size=*/0, /*block_size_limit=*/0);
+      return GpuLaunchKernel(
+          GatherOpKernel<Tvec, Index, is_axis_zero, is_batch_dims_zero>,
+          config.block_count, config.thread_per_block, 0, d.stream(),
+          params_vec, indices, out_vec, outer_size, gather_dim_size,
+          indices_size, slice_size_vec, out_size_vec);
+    }
+  };
+};
 
 }  // namespace detail
 
@@ -121,36 +125,11 @@ Status LaunchGatherKernel(const GPUDevice& d, const T* params,
                           const Index* indices, T* out, int64 outer_size,
                           int64 gather_dim_size, int64 indices_size,
                           int64 slice_size, int64 out_size) {
-  const int64 min_align =
-      std::min(std::min(alignment_of(params), alignment_of(out)),
-               alignment_of(slice_size));
-  constexpr const int optimal_vec_size = gpu_optimal_vector_size_for<T>();
-  if (optimal_vec_size >= 16 && min_align >= 16) {
-    return detail::LaunchGatherKernelVectorized<16, is_axis_zero,
-                                                is_batch_dims_zero>(
-        d, params, indices, out, outer_size, gather_dim_size, indices_size,
-        slice_size, out_size);
-  } else if (optimal_vec_size >= 8 && min_align >= 8) {
-    return detail::LaunchGatherKernelVectorized<8, is_axis_zero,
-                                                is_batch_dims_zero>(
-        d, params, indices, out, outer_size, gather_dim_size, indices_size,
-        slice_size, out_size);
-  } else if (optimal_vec_size >= 4 && min_align >= 4) {
-    return detail::LaunchGatherKernelVectorized<4, is_axis_zero,
-                                                is_batch_dims_zero>(
-        d, params, indices, out, outer_size, gather_dim_size, indices_size,
-        slice_size, out_size);
-  } else if (optimal_vec_size >= 2 && min_align >= 2) {
-    return detail::LaunchGatherKernelVectorized<2, is_axis_zero,
-                                                is_batch_dims_zero>(
-        d, params, indices, out, outer_size, gather_dim_size, indices_size,
-        slice_size, out_size);
-  } else {
-    return detail::LaunchGatherKernelVectorized<1, is_axis_zero,
-                                                is_batch_dims_zero>(
-        d, params, indices, out, outer_size, gather_dim_size, indices_size,
-        slice_size, out_size);
-  }
+  return DispatchToVectorized<
+      T, detail::LaunchGatherKernelVectorized<
+             is_axis_zero, is_batch_dims_zero>::template Impl>(
+      MinAlignmentOf(params, out, slice_size), d, params, indices, out,
+      outer_size, gather_dim_size, indices_size, slice_size, out_size);
 }
 
 namespace functor {

--- a/tensorflow/core/kernels/gather_functor_batched_gpu.cu.h
+++ b/tensorflow/core/kernels/gather_functor_batched_gpu.cu.h
@@ -29,11 +29,11 @@ namespace tensorflow {
 
 typedef Eigen::GpuDevice GPUDevice;
 
-template <typename T, typename Index, bool is_axis_zero,
+template <typename ValueOrVec, typename Index, bool is_axis_zero,
           bool is_batch_dims_zero>
-__global__ void GatherOpKernel(const T* __restrict__ params,
+__global__ void GatherOpKernel(const ValueOrVec* __restrict__ params,
                                const Index* __restrict__ indices,
-                               T* __restrict__ out, int64 outer_size,
+                               ValueOrVec* __restrict__ out, int64 outer_size,
                                int64 gather_dim_size, int64 indices_size,
                                int64 slice_size, int64 out_size) {
   // params is a tensor of shape
@@ -71,7 +71,7 @@ __global__ void GatherOpKernel(const T* __restrict__ params,
     if (!FastBoundsCheck(gather_i, gather_dim_size)) {
       // Set indices out of range to zero
       // TODO(fpmc): Log an error for transfer back to host.
-      out[i] = T(0);
+      out[i] = ValueOrVec(0);
     } else {
       // Read params[batch_i, outer_i, gather_i, slice_i] and write it to the
       // i'th position in out.
@@ -93,11 +93,12 @@ struct LaunchGatherKernelVectorized {
     Status operator()(const GPUDevice& d, const T* params, const Index* indices,
                       T* out, int64 outer_size, int64 gather_dim_size,
                       int64 indices_size, int64 slice_size, int64 out_size) {
-      CHECK(slice_size % vec_size == 0);  // Crash OK
-      CHECK(out_size % vec_size == 0);    // Crash OK
-      CHECK(reinterpret_cast<std::uintptr_t>(params) % vec_size ==
-            0);                                                      // Crash OK
-      CHECK(reinterpret_cast<std::uintptr_t>(out) % vec_size == 0);  // Crash OK
+      CHECK_EQ(slice_size % vec_size, 0);  // Crash OK
+      CHECK_EQ(out_size % vec_size, 0);    // Crash OK
+      CHECK_EQ(reinterpret_cast<std::uintptr_t>(params) % vec_size,
+               0);  // Crash OK
+      CHECK_EQ(reinterpret_cast<std::uintptr_t>(out) % vec_size,
+               0);  // Crash OK
       int64 out_size_vec = out_size / vec_size;
       int64 slice_size_vec = slice_size / vec_size;
       using Tvec = AlignedVector<T, vec_size>;

--- a/tensorflow/core/kernels/gather_functor_batched_gpu.cu.h
+++ b/tensorflow/core/kernels/gather_functor_batched_gpu.cu.h
@@ -126,6 +126,11 @@ Status LaunchGatherKernel(const GPUDevice& d, const T* params,
                           const Index* indices, T* out, int64 outer_size,
                           int64 gather_dim_size, int64 indices_size,
                           int64 slice_size, int64 out_size) {
+  // Note that the GPU memory allocator always returns aligned buffers, so the
+  // alignment of data pointers is expected to be deterministic.
+  // There will be performance cliffs when slice_size is not aligned, but there
+  // is no easy way to handle the misalignment because each row will be aligned
+  // differently.
   return DispatchToVectorized<
       T, detail::LaunchGatherKernelVectorized<
              is_axis_zero, is_batch_dims_zero>::template Impl>(

--- a/tensorflow/core/kernels/gather_functor_gpu.cu.h
+++ b/tensorflow/core/kernels/gather_functor_gpu.cu.h
@@ -66,8 +66,68 @@ __global__ void GatherOpKernel(const T* __restrict__ params,
       // out.
       Index params_i =
           (batch_i * gather_dim_size + gather_i) * slice_size + slice_i;
-      out[i] = ldg(params + params_i);
+      out[i] = params[params_i];
     }
+  }
+}
+
+namespace detail {
+
+template <int vec_size, bool is_axis_zero, typename T, typename Index>
+Status LaunchGatherKernelVectorized(const GPUDevice& d, const T* params,
+                                    const Index* indices, T* out,
+                                    int64 gather_dim_size, int64 indices_size,
+                                    int64 slice_size, int64 out_size) {
+  CHECK(slice_size % vec_size == 0);  // Crash OK
+  CHECK(out_size % vec_size == 0);    // Crash OK
+  CHECK(reinterpret_cast<std::uintptr_t>(params) % vec_size == 0);  // Crash OK
+  CHECK(reinterpret_cast<std::uintptr_t>(out) % vec_size == 0);     // Crash OK
+  int64 out_size_vec = out_size / vec_size;
+  int64 slice_size_vec = slice_size / vec_size;
+  using Tvec = AlignedVector<T, vec_size>;
+  const Tvec* params_vec = reinterpret_cast<const Tvec*>(params);
+  Tvec* out_vec = reinterpret_cast<Tvec*>(out);
+
+  GpuLaunchConfig config = GetGpuLaunchConfig(
+      out_size_vec, d, &GatherOpKernel<Tvec, Index, is_axis_zero>,
+      /*dynamic_shared_memory_size=*/0, /*block_size_limit=*/0);
+  return GpuLaunchKernel(
+      GatherOpKernel<Tvec, Index, is_axis_zero>, config.block_count,
+      config.thread_per_block, 0, d.stream(), params_vec, indices, out_vec,
+      gather_dim_size, indices_size, slice_size_vec, out_size_vec);
+}
+
+}  // namespace detail
+
+template <bool is_axis_zero, typename T, typename Index>
+Status LaunchGatherKernel(const GPUDevice& d, const T* params,
+                          const Index* indices, T* out, int64 gather_dim_size,
+                          int64 indices_size, int64 slice_size,
+                          int64 out_size) {
+  const int64 min_align =
+      std::min(std::min(alignment_of(params), alignment_of(out)),
+               alignment_of(slice_size));
+  constexpr const int optimal_vec_size = gpu_optimal_vector_size_for<T>();
+  if (optimal_vec_size >= 16 && min_align >= 16) {
+    return detail::LaunchGatherKernelVectorized<16, is_axis_zero>(
+        d, params, indices, out, gather_dim_size, indices_size, slice_size,
+        out_size);
+  } else if (optimal_vec_size >= 8 && min_align >= 8) {
+    return detail::LaunchGatherKernelVectorized<8, is_axis_zero>(
+        d, params, indices, out, gather_dim_size, indices_size, slice_size,
+        out_size);
+  } else if (optimal_vec_size >= 4 && min_align >= 4) {
+    return detail::LaunchGatherKernelVectorized<4, is_axis_zero>(
+        d, params, indices, out, gather_dim_size, indices_size, slice_size,
+        out_size);
+  } else if (optimal_vec_size >= 2 && min_align >= 2) {
+    return detail::LaunchGatherKernelVectorized<2, is_axis_zero>(
+        d, params, indices, out, gather_dim_size, indices_size, slice_size,
+        out_size);
+  } else {
+    return detail::LaunchGatherKernelVectorized<1, is_axis_zero>(
+        d, params, indices, out, gather_dim_size, indices_size, slice_size,
+        out_size);
   }
 }
 
@@ -93,21 +153,13 @@ struct GatherFunctor<GPUDevice, T, Index> {
     const int64 slice_size = params.dimension(2);
 
     if (is_axis_zero) {
-      GpuLaunchConfig config = GetGpuLaunchConfig(
-          out_size, d, &GatherOpKernel<T, Index, true>,
-          /*dynamic_shared_memory_size=*/0, /*block_size_limit=*/0);
-      TF_CHECK_OK(GpuLaunchKernel(
-          GatherOpKernel<T, Index, true>, config.block_count,
-          config.thread_per_block, 0, d.stream(), params.data(), indices.data(),
-          out.data(), gather_dim_size, indices_size, slice_size, out_size));
+      LaunchGatherKernel<true>(d, params.data(), indices.data(), out.data(),
+                               gather_dim_size, indices_size, slice_size,
+                               out_size);
     } else {
-      GpuLaunchConfig config = GetGpuLaunchConfig(
-          out_size, d, &GatherOpKernel<T, Index, false>,
-          /*dynamic_shared_memory_size=*/0, /*block_size_limit=*/0);
-      TF_CHECK_OK(GpuLaunchKernel(
-          GatherOpKernel<T, Index, false>, config.block_count,
-          config.thread_per_block, 0, d.stream(), params.data(), indices.data(),
-          out.data(), gather_dim_size, indices_size, slice_size, out_size));
+      LaunchGatherKernel<false>(d, params.data(), indices.data(), out.data(),
+                                gather_dim_size, indices_size, slice_size,
+                                out_size);
     }
     // TODO(fpmc): enable indices validation on GPU.
     // Right now checking for indices out of bound in the kernel would

--- a/tensorflow/core/kernels/gather_functor_gpu.cu.h
+++ b/tensorflow/core/kernels/gather_functor_gpu.cu.h
@@ -111,6 +111,11 @@ Status LaunchGatherKernel(const GPUDevice& d, const T* params,
                           const Index* indices, T* out, int64 gather_dim_size,
                           int64 indices_size, int64 slice_size,
                           int64 out_size) {
+  // Note that the GPU memory allocator always returns aligned buffers, so the
+  // alignment of data pointers is expected to be deterministic.
+  // There will be performance cliffs when slice_size is not aligned, but there
+  // is no easy way to handle the misalignment because each row will be aligned
+  // differently.
   return DispatchToVectorized<
       T, detail::LaunchGatherKernelVectorized<is_axis_zero>::template Impl>(
       MinAlignmentOf(params, out, slice_size), d, params, indices, out,

--- a/tensorflow/core/util/gpu_kernel_helper.h
+++ b/tensorflow/core/util/gpu_kernel_helper.h
@@ -232,12 +232,18 @@ class alignas(alignof(T) * N) AlignedVector {
 
 #undef UNROLL_ON_DEVICE
 
-// Returns the maximum power-of-two alignment of a stride or pointer value.
-inline int64 alignment_of(int64 stride) { return stride & -stride; }
+// Returns the maximum power-of-two alignment (in units of elements, not bytes)
+// of a stride or pointer value.
+inline int64 alignment_of(int64 element_stride) {
+  return element_stride & -element_stride;
+}
 template <typename T>
 inline int64 alignment_of(T* ptr) {
   const intptr_t ptr_val = reinterpret_cast<std::uintptr_t>(ptr);
-  return alignment_of(ptr_val);
+  // Pointers should always be aligned to sizeof(T) bytes.
+  CHECK(ptr_val % sizeof(T) == 0);  // CRASH OK
+  // Note that we want the alignment in elements, not bytes.
+  return alignment_of(ptr_val / sizeof(T));
 }
 
 // Returns the optimal number of (aligned) elements of T to load/store in a

--- a/tensorflow/core/util/gpu_kernel_helper.h
+++ b/tensorflow/core/util/gpu_kernel_helper.h
@@ -240,11 +240,12 @@ class alignas(alignof(T) * N) AlignedVector {
 inline int64 alignment_of(int64 element_stride) {
   return element_stride & -element_stride;
 }
+
 template <typename T>
 inline int64 alignment_of(T* ptr) {
   const intptr_t ptr_val = reinterpret_cast<std::uintptr_t>(ptr);
   // Pointers should always be aligned to sizeof(T) bytes.
-  CHECK(ptr_val % sizeof(T) == 0);  // CRASH OK
+  CHECK_EQ(ptr_val % sizeof(T), 0);  // CRASH OK
   // Note that we want the alignment in elements, not bytes.
   return alignment_of(ptr_val / sizeof(T));
 }


### PR DESCRIPTION
- Vectorized load/store achieves higher memory throughput.
- This commit chooses the optimal vector size that is compatible with the data shape and pointer alignment.
- Note that the `ldg` function would require more changes to support the vectorized types, but it is not actually needed: the use of `const __restrict__` means the kernel still generates `LDG` instructions without it.
- Some quick benchmarking showed the following speedups with this commit when gathering vectors of length 256 on an NVIDIA TITAN V GPU:
    float64: 1.02x
    float32: 1.07x
    float16: 1.35x
    bool:    1.67x

cc @nluehr 