### PR TITLE
TFLite: tools: make: remove test_delegate_providers.cc from the build resources for libtensorflow-lite.a

### DIFF
--- a/tensorflow/lite/tools/make/Makefile
+++ b/tensorflow/lite/tools/make/Makefile
@@ -172,6 +172,7 @@ CORE_CC_EXCLUDE_SRCS := \
 $(wildcard tensorflow/lite/*test.cc) \
 $(wildcard tensorflow/lite/*/*test.c) \
 $(wildcard tensorflow/lite/*/*test.cc) \
+$(wildcard tensorflow/lite/*/*test*.cc) \
 $(wildcard tensorflow/lite/*/*/benchmark.cc) \
 $(wildcard tensorflow/lite/*/*/example*.cc) \
 $(wildcard tensorflow/lite/*/*/test*.cc) \
@@ -187,8 +188,6 @@ $(wildcard tensorflow/lite/*/*/*/*/*/example*.cc) \
 $(wildcard tensorflow/lite/*/*/*/*/*/test*.cc) \
 $(wildcard tensorflow/lite/*/*/*/*/*/*test.cc) \
 $(wildcard tensorflow/lite/*/*/*/*/*/*tool.cc) \
-$(wildcard tensorflow/lite/kernels/*test_main.cc) \
-$(wildcard tensorflow/lite/kernels/*test_util*.cc) \
 $(wildcard tensorflow/lite/tools/make/downloads/cpuinfo/src/*/mock*.c) \
 tensorflow/lite/create_op_resolver_with_selected_ops.cc \
 tensorflow/lite/tflite_with_xnnpack.cc \


### PR DESCRIPTION
lite/kernel/test_delegate_providers.cc should not be include in
libtensorflow-lite.a but it was not par of CORE_CC_EXCLUDE_SRCS because the
file syntax was not recognized as an excluded file.
This patch propose to exclude all the file containing in *test*.cc.

Signed-off-by: Vincent ABRIOU <vincent.abriou@st.com>