### PR TITLE
[Graph C API] Util API

### DIFF
--- a/tensorflow/c/experimental/grappler/BUILD
+++ b/tensorflow/c/experimental/grappler/BUILD
@@ -54,13 +54,9 @@ tf_cc_test(
     srcs = ["grappler_test.cc"],
     deps = [
         ":grappler",
-        "//tensorflow/c:c_api_internal",
-        "//tensorflow/core:framework",
         "//tensorflow/core:test",
         "//tensorflow/core:test_main",
-        "//tensorflow/core/grappler:grappler_item",
         "//tensorflow/core/grappler/clusters:single_machine",
-        "//tensorflow/core/grappler/costs:graph_properties",
         "//tensorflow/core/grappler/inputs:trivial_test_graph_input_yielder",
         "//tensorflow/core/protobuf:error_codes_proto_impl_cc",
     ],

--- a/tensorflow/c/experimental/grappler/grappler.cc
+++ b/tensorflow/c/experimental/grappler/grappler.cc
@@ -193,3 +193,204 @@ tensorflow::Status InitGraphPlugin(TFInitGraphPluginFn init_fn) {
 
 }  // namespace grappler
 }  // namespace tensorflow
+
+const TF_GrapplerItem* TF_GetGrapplerItem(TF_Buffer* graph_buf,
+                                          TF_Status* status) {
+  TF_SetStatus(status, TF_OK, "");
+  const auto it = GrapplerItemMap()->find(graph_buf);
+  if (it != GrapplerItemMap()->end()) {
+    return it->second;
+  } else {
+    status->status = tensorflow::errors::NotFound("GrapplerItem is not found");
+    return nullptr;
+  }
+}
+
+void TF_GetNodesToPreserveListSize(const TF_GrapplerItem* item, int* num_values,
+                                   size_t* storage_size, TF_Status* status) {
+  TF_SetStatus(status, TF_OK, "");
+  std::unordered_set<std::string> nodes =
+      reinterpret_cast<const tensorflow::grappler::GrapplerItem*>(item)
+          ->NodesToPreserve();
+  *num_values = nodes.size();
+  *storage_size = 0;
+  for (const std::string& str : nodes) {
+    *storage_size += str.size();
+  }
+}
+
+void TF_GetNodesToPreserveList(const TF_GrapplerItem* item, char** values,
+                               size_t* lengths, int num_values, void* storage,
+                               size_t storage_size, TF_Status* status) {
+  TF_SetStatus(status, TF_OK, "");
+  std::unordered_set<std::string> nodes =
+      reinterpret_cast<const tensorflow::grappler::GrapplerItem*>(item)
+          ->NodesToPreserve();
+  char* p = static_cast<char*>(storage);
+
+  int index = 0;
+  for (const std::string& s : nodes) {
+    if (index >= num_values) break;
+    values[index] = p;
+    lengths[index] = s.size();
+    if ((p + s.size()) > (static_cast<char*>(storage) + storage_size)) {
+      status->status = tensorflow::errors::InvalidArgument(
+          "Not enough storage to hold the requested list of nodes");
+      return;
+    }
+    memcpy(values[index], s.data(), s.size());
+    p += s.size();
+    index++;
+  }
+}
+
+void TF_GetFetchNodesListSize(const TF_GrapplerItem* item, int* num_values,
+                              size_t* storage_size, TF_Status* status) {
+  TF_SetStatus(status, TF_OK, "");
+  std::vector<std::string> nodes =
+      reinterpret_cast<const tensorflow::grappler::GrapplerItem*>(item)->fetch;
+  *num_values = nodes.size();
+  *storage_size = 0;
+  for (const std::string& str : nodes) {
+    *storage_size += str.size();
+  }
+}
+
+void TF_GetFetchNodesList(const TF_GrapplerItem* item, char** values,
+                          size_t* lengths, int num_values, void* storage,
+                          size_t storage_size, TF_Status* status) {
+  TF_SetStatus(status, TF_OK, "");
+  std::vector<std::string> nodes =
+      reinterpret_cast<const tensorflow::grappler::GrapplerItem*>(item)->fetch;
+
+  const int len = std::min(num_values, static_cast<int>(nodes.size()));
+  char* p = static_cast<char*>(storage);
+  for (int index = 0; index < len; ++index) {
+    const std::string& s = nodes[index];
+    values[index] = p;
+    lengths[index] = s.size();
+    if ((p + s.size()) > (static_cast<char*>(storage) + storage_size)) {
+      status->status = tensorflow::errors::InvalidArgument(
+          "Not enough storage to hold the requested list of nodes");
+      return;
+    }
+    memcpy(values[index], s.data(), s.size());
+    p += s.size();
+  }
+}
+
+TF_GraphProperties* TF_NewGraphProperties(const TF_GrapplerItem* item) {
+  return reinterpret_cast<TF_GraphProperties*>(
+      new tensorflow::grappler::GraphProperties(
+          *reinterpret_cast<const tensorflow::grappler::GrapplerItem*>(item)));
+}
+
+void TF_DeleteGraphProperties(TF_GraphProperties* g_prop) {
+  if (g_prop == nullptr) return;
+  delete reinterpret_cast<tensorflow::grappler::GraphProperties*>(g_prop);
+}
+
+void TF_InferStatically(TF_GraphProperties* g_prop, TF_Bool assume_valid_feeds,
+                        TF_Bool aggressive_shape_inference,
+                        TF_Bool include_input_tensor_values,
+                        TF_Bool include_output_tensor_values,
+                        TF_Status* status) {
+  TF_SetStatus(status, TF_OK, "");
+  tensorflow::Status s =
+      reinterpret_cast<tensorflow::grappler::GraphProperties*>(g_prop)
+          ->InferStatically(assume_valid_feeds, aggressive_shape_inference,
+                            include_input_tensor_values,
+                            include_output_tensor_values);
+  if (!s.ok()) {
+    ::tensorflow::Set_TF_Status_from_Status(status, s);
+  }
+}
+
+void TF_GetInputPropertiesListSize(TF_GraphProperties* g_prop, const char* name,
+                                   int* num_values, TF_Status* status) {
+  TF_SetStatus(status, TF_OK, "");
+  *num_values = reinterpret_cast<tensorflow::grappler::GraphProperties*>(g_prop)
+                    ->GetInputProperties(name)
+                    .size();
+}
+
+void TF_GetOutputPropertiesListSize(TF_GraphProperties* g_prop,
+                                    const char* name, int* num_values,
+                                    TF_Status* status) {
+  TF_SetStatus(status, TF_OK, "");
+  *num_values = reinterpret_cast<tensorflow::grappler::GraphProperties*>(g_prop)
+                    ->GetOutputProperties(name)
+                    .size();
+}
+
+void TF_GetInputPropertiesList(TF_GraphProperties* g_prop, const char* name,
+                               TF_Buffer** prop, int num_values,
+                               TF_Status* status) {
+  TF_SetStatus(status, TF_OK, "");
+  std::vector<tensorflow::OpInfo::TensorProperties> in_prop =
+      reinterpret_cast<tensorflow::grappler::GraphProperties*>(g_prop)
+          ->GetInputProperties(name);
+  const int len = std::min(num_values, static_cast<int>(in_prop.size()));
+  for (int i = 0; i < len; ++i) {
+    tensorflow::Status s = tensorflow::MessageToBuffer(in_prop[i], prop[i]);
+    if (!s.ok()) {
+      ::tensorflow::Set_TF_Status_from_Status(status, s);
+      return;
+    }
+  }
+}
+
+void TF_GetOutputPropertiesList(TF_GraphProperties* g_prop, const char* name,
+                                TF_Buffer** prop, int num_values,
+                                TF_Status* status) {
+  TF_SetStatus(status, TF_OK, "");
+  std::vector<tensorflow::OpInfo::TensorProperties> out_prop =
+      reinterpret_cast<tensorflow::grappler::GraphProperties*>(g_prop)
+          ->GetOutputProperties(name);
+  const int len = std::min(num_values, static_cast<int>(out_prop.size()));
+  for (int i = 0; i < len; ++i) {
+    tensorflow::Status s = tensorflow::MessageToBuffer(out_prop[i], prop[i]);
+    if (!s.ok()) {
+      ::tensorflow::Set_TF_Status_from_Status(status, s);
+      return;
+    }
+  }
+}
+
+TF_FunctionLibraryDefinition* TF_NewFunctionLibraryDefinition(
+    TF_Buffer* graph_buf, TF_Status* status) {
+  TF_SetStatus(status, TF_OK, "");
+  tensorflow::GraphDef graph_def;
+  tensorflow::Status s = tensorflow::BufferToMessage(graph_buf, &graph_def);
+  if (!s.ok()) {
+    ::tensorflow::Set_TF_Status_from_Status(status, s);
+    return nullptr;
+  }
+  return reinterpret_cast<TF_FunctionLibraryDefinition*>(
+      new tensorflow::FunctionLibraryDefinition(
+          tensorflow::OpRegistry::Global(), graph_def.library()));
+}
+
+void TF_DeleteFunctionLibraryDefinition(TF_FunctionLibraryDefinition* f_lib) {
+  if (f_lib == nullptr) return;
+  delete reinterpret_cast<tensorflow::FunctionLibraryDefinition*>(f_lib);
+}
+
+void TF_LookUpOpDef(TF_FunctionLibraryDefinition* f_lib, const char* name,
+                    TF_Buffer* buf, TF_Status* status) {
+  TF_SetStatus(status, TF_OK, "");
+  const tensorflow::OpDef* op_def_ptr = nullptr;
+  tensorflow::Status s =
+      reinterpret_cast<tensorflow::FunctionLibraryDefinition*>(f_lib)
+          ->LookUpOpDef(name, &op_def_ptr);
+  if (!s.ok()) {
+    ::tensorflow::Set_TF_Status_from_Status(status, s);
+    return;
+  }
+
+  s = tensorflow::MessageToBuffer(*op_def_ptr, buf);
+  if (!s.ok()) {
+    ::tensorflow::Set_TF_Status_from_Status(status, s);
+    return;
+  }
+}

--- a/tensorflow/c/experimental/grappler/grappler.h
+++ b/tensorflow/c/experimental/grappler/grappler.h
@@ -166,6 +166,116 @@ void TF_InitGraph(TP_OptimizerRegistrationParams* params, TF_Status* status);
 // and potentially a set of nodes to feed.
 typedef struct TF_GrapplerItem TF_GrapplerItem;
 
+// Get TF_GrapplerItem from TF_Buffer.
+const TF_GrapplerItem* TF_GetGrapplerItem(TF_Buffer* buffer, TF_Status* status);
+
+// Get a set of node names that must be preserved. They can not be transformed
+// or removed during the graph transformation. This includes feed and fetch
+// nodes, keep_ops, init_ops. Fills in `num_values` and `storage_size`, they
+// will be used in `TF_GetNodesToPreserveList`.
+void TF_GetNodesToPreserveListSize(const TF_GrapplerItem* item, int* num_values,
+                                   size_t* storage_size, TF_Status* status);
+
+// Get a set of node names that must be preserved. They can not be transformed
+// or removed during the graph transformation. This includes feed and fetch
+// nodes, keep_ops, init_ops. Fills in `values` and `lengths`, each of which
+// must point to an array of length at least `num_values`.
+//
+// The elements of values will point to addresses in `storage` which must be at
+// least `storage_size` bytes in length.  `num_values` and `storage` can be
+// obtained from TF_GetNodesToPreserveSize
+//
+// Fails if storage_size is too small to hold the requested number of strings.
+void TF_GetNodesToPreserveList(const TF_GrapplerItem* item, char** values,
+                               size_t* lengths, int num_values, void* storage,
+                               size_t storage_size, TF_Status* status);
+
+// Get a set of node names for fetch nodes. Fills in `values` and `lengths`,
+// they will be used in `TF_GetFetchNodesList`
+void TF_GetFetchNodesListSize(const TF_GrapplerItem* item, int* num_values,
+                              size_t* storage_size, TF_Status* status);
+
+// Get a set of node names for fetch nodes. Fills in `values` and `lengths`,
+// each of which must point to an array of length at least `num_values`.
+//
+// The elements of values will point to addresses in `storage` which must be at
+// least `storage_size` bytes in length.  `num_values` and `storage` can be
+// obtained from TF_GetFetchNodesSize
+//
+// Fails if storage_size is too small to hold the requested number of strings.
+void TF_GetFetchNodesList(const TF_GrapplerItem* item, char** values,
+                          size_t* lengths, int num_values, void* storage,
+                          size_t storage_size, TF_Status* status);
+
+// Infer OpInfo::TensorProperties for graph nodes inputs/outputs.
+//
+// Typical use case, is to infer tensor properties from a graph, before doing
+// optimization pass. Nodes modified during optimization pass have to be
+// invalidated, to prevent further incorrect optimizations based on wrong shape
+// and data type properties.
+typedef struct TF_GraphProperties TF_GraphProperties;
+
+// Create GraphProperties. The item must outlive the properties.
+TF_GraphProperties* TF_NewGraphProperties(const TF_GrapplerItem* item);
+
+// Delete GraphProperties.
+void TF_DeleteGraphProperties(TF_GraphProperties* p);
+
+// Infer tensor shapes through abstract interpretation.
+// If assume_valid_feeds is true, it can help infer shapes in the fanout of fed
+// nodes. This may cause incorrectness in graph analyses, but is useful for
+// simulation or scheduling.
+// If aggressive_shape_inference is true, nodes are executed on the host to
+// identify output values when possible and does other aggressive strategies.
+// This may cause incorrectness in graph analyses, but is useful for simulation
+// or scheduling.
+// If include_input_tensor_values is true, the values of constant
+// tensors will included in the input properties.
+// If include_output_tensor_values is true, the values of constant tensors will
+// be included in the output properties.
+void TF_InferStatically(TF_GraphProperties* g_prop, TF_Bool assume_valid_feeds,
+                        TF_Bool aggressive_shape_inference,
+                        TF_Bool include_input_tensor_values,
+                        TF_Bool include_output_tensor_values, TF_Status* s);
+
+// Get the size of input OpInfo::TensorProperties given node name.
+void TF_GetInputPropertiesListSize(TF_GraphProperties* g_prop, const char* name,
+                                   int* num_values, TF_Status* status);
+
+// Get the size of output OpInfo::TensorProperties given node name.
+void TF_GetOutputPropertiesListSize(TF_GraphProperties* g_prop,
+                                    const char* name, int* num_values,
+                                    TF_Status* status);
+
+// Get a list of input OpInfo::TensorProperties given node name.
+// OpInfo::TensorProperties is represented as TF_Buffer*.
+void TF_GetInputPropertiesList(TF_GraphProperties* g_prop, const char* name,
+                               TF_Buffer** prop, int num_values,
+                               TF_Status* status);
+
+// Get a list of output OpInfo::TensorProperties given node name.
+// OpInfo::TensorProperties is represented as TF_Buffer*.
+void TF_GetOutputPropertiesList(TF_GraphProperties* g_prop, const char* name,
+                                TF_Buffer** prop, int num_values,
+                                TF_Status* status);
+
+// Helper to maintain a map between function names in a given
+// FunctionDefLibrary and function definitions.
+// Typical use case, is to look up an OpDef by type name.
+typedef struct TF_FunctionLibraryDefinition TF_FunctionLibraryDefinition;
+
+// Create NewFunctionLibraryDefinition.
+TF_FunctionLibraryDefinition* TF_NewFunctionLibraryDefinition(
+    TF_Buffer* graph_buf, TF_Status* status);
+
+// Delete NewFunctionLibraryDefinition.
+void TF_DeleteFunctionLibraryDefinition(TF_FunctionLibraryDefinition* f_lib);
+
+// Shorthand for calling LookUp to get the OpDef from FunctionLibraryDefinition
+// given op name. The returned OpDef is represented by TF_Buffer.
+void TF_LookUpOpDef(TF_FunctionLibraryDefinition* f_lib, const char* name,
+                    TF_Buffer* buf, TF_Status* s);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/tensorflow/c/experimental/grappler/grappler_test.cc
+++ b/tensorflow/c/experimental/grappler/grappler_test.cc
@@ -111,6 +111,197 @@ TEST(Grappler, OptimizeFuncNotSet) {
             "'optimize_func' field in TP_Optimizer must be set.");
 }
 
+TEST(TF_GrapplerItem, NodesToPreserve) {
+  GrapplerItem item;
+  item.fetch = std::vector<string>{"Conv", "BiasAdd"};
+  std::unordered_set<string> nodes_preserved = item.NodesToPreserve();
+  TF_GrapplerItem* c_item = reinterpret_cast<TF_GrapplerItem*>(&item);
+
+  int list_total_size = 0;
+  for (const string& s : nodes_preserved) {
+    list_total_size += s.size();
+  }
+
+  size_t storage_size = 0;
+  int num_values = 0;
+  TF_Status* status = TF_NewStatus();
+  TF_GetNodesToPreserveListSize(c_item, &num_values, &storage_size, status);
+  EXPECT_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
+  EXPECT_EQ(nodes_preserved.size(), num_values);
+  EXPECT_EQ(list_total_size, storage_size);
+
+  std::unique_ptr<char*[]> values(new char*[nodes_preserved.size()]);
+  std::unique_ptr<size_t[]> lens(new size_t[nodes_preserved.size()]);
+  std::unique_ptr<char[]> storage(new char[storage_size]);
+  TF_GetNodesToPreserveList(c_item, values.get(), lens.get(),
+                            nodes_preserved.size(), storage.get(), storage_size,
+                            status);
+  EXPECT_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
+
+  for (size_t i = 0; i < nodes_preserved.size(); ++i) {
+    EXPECT_EQ(nodes_preserved.find(string(static_cast<const char*>(values[i]),
+                                          lens[i])) != nodes_preserved.end(),
+              true);
+  }
+  TF_DeleteStatus(status);
+}
+
+TEST(TF_GrapplerItem, FetchNodes) {
+  GrapplerItem item;
+  item.fetch = std::vector<string>{"Conv", "BiasAdd"};
+  TF_GrapplerItem* c_item = reinterpret_cast<TF_GrapplerItem*>(&item);
+
+  int list_total_size = 0;
+  for (const string& s : item.fetch) {
+    list_total_size += s.size();
+  }
+
+  size_t storage_size = 0;
+  int num_values = 0;
+  TF_Status* status = TF_NewStatus();
+  TF_GetFetchNodesListSize(c_item, &num_values, &storage_size, status);
+  EXPECT_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
+  EXPECT_EQ(item.fetch.size(), num_values);
+  EXPECT_EQ(list_total_size, storage_size);
+
+  std::unique_ptr<char*[]> values(new char*[item.fetch.size()]);
+  std::unique_ptr<size_t[]> lens(new size_t[item.fetch.size()]);
+  std::unique_ptr<char[]> storage(new char[storage_size]);
+  TF_GetFetchNodesList(c_item, values.get(), lens.get(), item.fetch.size(),
+                       storage.get(), storage_size, status);
+  EXPECT_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
+
+  for (size_t i = 0; i < item.fetch.size(); ++i) {
+    EXPECT_EQ(item.fetch[i].size(), lens[i]) << i;
+    EXPECT_EQ(item.fetch[i],
+              string(static_cast<const char*>(values[i]), lens[i]))
+        << i;
+  }
+  TF_DeleteStatus(status);
+}
+
+TEST(TF_GraphProperties, InputProperties) {
+  std::unique_ptr<SingleMachine> cluster(new SingleMachine(5 * 60, 3, 0));
+  TF_ASSERT_OK(cluster->Provision());
+
+  TrivialTestGraphInputYielder fake_input(4, 1, 10, false,
+                                          cluster->GetDeviceNames());
+  GrapplerItem item;
+  CHECK(fake_input.NextItem(&item));
+
+  TF_Status* status = TF_NewStatus();
+  TF_GraphProperties* g_prop =
+      TF_NewGraphProperties(reinterpret_cast<TF_GrapplerItem*>(&item));
+  TF_InferStatically(g_prop, true, false, false, false, status);
+  EXPECT_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
+
+  for (const NodeDef& node : item.graph.node()) {
+    if (node.op() == "AddN") {
+      int num_values = 0;
+      TF_GetInputPropertiesListSize(g_prop, node.name().c_str(), &num_values,
+                                    status);
+      EXPECT_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
+      EXPECT_EQ(num_values, 1);
+
+      std::vector<TF_Buffer*> in_props_buf(num_values, TF_NewBuffer());
+
+      TF_GetInputPropertiesList(g_prop, node.name().c_str(),
+                                in_props_buf.data(), num_values, status);
+      EXPECT_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
+
+      tensorflow::OpInfo::TensorProperties in_prop;
+      Status s = tensorflow::BufferToMessage(in_props_buf[0], &in_prop);
+      TF_ASSERT_OK(s);
+
+      EXPECT_EQ(DT_FLOAT, in_prop.dtype());
+      EXPECT_FALSE(in_prop.shape().unknown_rank());
+      EXPECT_EQ(2, in_prop.shape().dim_size());
+      EXPECT_EQ(10, in_prop.shape().dim(0).size());
+      EXPECT_EQ(1, in_prop.shape().dim(1).size());
+
+      for (int i = 0; i < in_props_buf.size(); i++)
+        TF_DeleteBuffer(in_props_buf[i]);
+    }
+  }
+  TF_DeleteGraphProperties(g_prop);
+  TF_DeleteStatus(status);
+  cluster->Shutdown();
+}
+
+TEST(TF_GraphProperties, OutputProperties) {
+  SingleMachine* cluster = new SingleMachine(5 * 60, 3, 0);
+  TF_ASSERT_OK(cluster->Provision());
+
+  TrivialTestGraphInputYielder fake_input(4, 1, 10, false,
+                                          cluster->GetDeviceNames());
+  GrapplerItem item;
+  CHECK(fake_input.NextItem(&item));
+
+  TF_Status* status = TF_NewStatus();
+  TF_GraphProperties* g_prop =
+      TF_NewGraphProperties(reinterpret_cast<TF_GrapplerItem*>(&item));
+  TF_InferStatically(g_prop, true, false, false, false, status);
+  EXPECT_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
+
+  for (const NodeDef& node : item.graph.node()) {
+    if (node.op() == "AddN") {
+      int num_values = 0;
+      TF_GetOutputPropertiesListSize(g_prop, node.name().c_str(), &num_values,
+                                     status);
+      EXPECT_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
+      EXPECT_EQ(num_values, 1);
+
+      std::vector<TF_Buffer*> out_props_buf(num_values, TF_NewBuffer());
+
+      TF_GetOutputPropertiesList(g_prop, node.name().c_str(),
+                                 out_props_buf.data(), num_values, status);
+      EXPECT_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
+
+      tensorflow::OpInfo::TensorProperties out_prop;
+      Status s = tensorflow::BufferToMessage(out_props_buf[0], &out_prop);
+      TF_ASSERT_OK(s);
+
+      EXPECT_EQ(DT_FLOAT, out_prop.dtype());
+      EXPECT_FALSE(out_prop.shape().unknown_rank());
+      EXPECT_EQ(2, out_prop.shape().dim_size());
+      EXPECT_EQ(10, out_prop.shape().dim(0).size());
+      EXPECT_EQ(1, out_prop.shape().dim(1).size());
+
+      for (int i = 0; i < out_props_buf.size(); i++)
+        TF_DeleteBuffer(out_props_buf[i]);
+    }
+  }
+  TF_DeleteStatus(status);
+  TF_DeleteGraphProperties(g_prop);
+  cluster->Shutdown();
+}
+
+TEST(TF_FunctionLibraryDefinition, LookUpOpDef) {
+  TF_Buffer* g_buf = TF_NewBuffer();
+  TF_Buffer* op_buf = TF_NewBuffer();
+  TF_Status* status = TF_NewStatus();
+  GraphDef g_def;
+  Status s = MessageToBuffer(g_def, g_buf);
+  TF_ASSERT_OK(s);
+  TF_FunctionLibraryDefinition* func =
+      TF_NewFunctionLibraryDefinition(g_buf, status);
+
+  TF_LookUpOpDef(func, "Add", op_buf, status);
+  string actual_string(reinterpret_cast<const char*>(op_buf->data),
+                       op_buf->length);
+  ASSERT_EQ(TF_OK, TF_GetCode(status));
+
+  const OpDef* expected_op_def;
+  TF_ASSERT_OK(OpRegistry::Global()->LookUpOpDef("Add", &expected_op_def));
+  string expected_serialized;
+  expected_op_def->SerializeToString(&expected_serialized);
+  EXPECT_EQ(expected_serialized, actual_string);
+  TF_DeleteBuffer(g_buf);
+  TF_DeleteBuffer(op_buf);
+  TF_DeleteStatus(status);
+  TF_DeleteFunctionLibraryDefinition(func);
+}
+
 }  // namespace
 
 }  // namespace grappler

--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -37,6 +37,7 @@ transitive_hdrs(
         "//tensorflow/cc/saved_model:bundle_v2",
         "//tensorflow/c/experimental/filesystem:filesystem_interface",
         "//tensorflow/c/experimental/stream_executor:stream_executor_hdrs",
+        "//tensorflow/c/experimental/grappler:grappler_hdrs",
         "//tensorflow/c:kernels_hdrs",
         "//tensorflow/c:ops_hdrs",
         # WARNING: None of the C/C++ code under python/ has any API guarantees, and TF team


### PR DESCRIPTION
This PR is to add graph util C API, which includes:
1. `TF_GrapplerItem` to get preserved/fetched nodes.
2. `TF_GraphProperties` to infer tensor shapes.
3. `TF_FunctionLibraryDefinition` to get OpDef.

This PR is following RFC [Modular TensorFlow Graph C API](https://github.com/tensorflow/community/blob/master/rfcs/20201027-modular-tensorflow-graph-c-api.md).