### PR TITLE
Add ragged tensor support to mean_absolute_error.

### DIFF
--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -1293,6 +1293,13 @@ def mean_absolute_error(y_true, y_pred):
   return K.mean(math_ops.abs(y_pred - y_true), axis=-1)
 
 
+@dispatch.dispatch_for_types(mean_absolute_error, ragged_tensor.RaggedTensor)
+def _ragged_tensor_mae(y_true, y_pred):
+  """ RaggedTensor adapter for mean_absolute_error
+  """
+  return _ragged_tensor_apply_loss(mean_absolute_error, y_true, y_pred)
+
+
 @keras_export('keras.metrics.mean_absolute_percentage_error',
               'keras.metrics.mape', 'keras.metrics.MAPE',
               'keras.losses.mean_absolute_percentage_error',

--- a/tensorflow/python/keras/losses_test.py
+++ b/tensorflow/python/keras/losses_test.py
@@ -499,6 +499,17 @@ class MeanAbsoluteErrorTest(test.TestCase):
     loss = mae_obj(y_true, y_pred, sample_weight=2.3)
     self.assertAlmostEqual(self.evaluate(loss), 25.29999, 3)
 
+  def test_ragged_tensor(self):
+    mae_obj = losses.MeanAbsoluteError()
+    y_true = ragged_factory_ops.constant([[1, 9, 2], [-5, -2]],
+                                         dtype=dtypes.float32)
+    y_pred = ragged_factory_ops.constant([[4, 8, 12], [8, 1]],
+                                         dtype=dtypes.float32)
+    # loss = [14/3, 16/2]
+    sample_weight = constant_op.constant([1.2, 1.0], shape=(2, 1))
+    loss = mae_obj(y_true, y_pred, sample_weight=sample_weight)
+    self.assertAlmostEqual(self.evaluate(loss), 6.8, 5)
+
 
 @combinations.generate(combinations.combine(mode=['graph', 'eager']))
 class MeanAbsolutePercentageErrorTest(test.TestCase):


### PR DESCRIPTION
Use the same approach as PR #46283 for mean_absolute_error.

Maintainers: I'm assuming that you would prefer the smallest possible PRs in order to extend the support across all/most predefined metric functions; even though that increases is overhead from your side in dealing with reviews / CI-handholding. Please advise if that is not the case.