### PR TITLE
Automatically treat dataclasses as pytrees

### DIFF
--- a/tensorflow/compiler/xla/python/pytree.h
+++ b/tensorflow/compiler/xla/python/pytree.h
@@ -148,6 +148,7 @@ class PyTreeDef {
     kNone,        // None.
     kTuple,       // A tuple
     kNamedTuple,  // A collections.namedtuple
+    kDataClass,   // A @dataclass
     kList,        // A list
     kDict,        // A dict
     kCustom,      // A custom type.
@@ -159,9 +160,10 @@ class PyTreeDef {
     // Arity for non-kLeaf types.
     int arity = 0;
 
-    // Kind-specific auxiliary data. For a kNamedTuple, contains the tuple type
-    // object. For a kDict, contains a sorted list of keys. For a kCustom type,
-    // contains the auxiliary data returned by the `to_iterable` function.
+    // Kind-specific auxiliary data. For kNamedTuple or kDataClass, contains the
+    // relevant type object. For a kDict, contains a sorted list of keys.
+    // For a kCustom type, contains the auxiliary data returned by the
+    // `to_iterable` function.
     pybind11::object node_data;
 
     const CustomNodeRegistry::Registration* custom = nullptr;


### PR DESCRIPTION
This change enables dataclasses to be used in pytrees. The relevant tests are in jax: https://github.com/google/jax/pull/5618.

Fixes google/jax#2371