### PR TITLE
Use the right input_dims[] in lite/micro/kernels/exp_test.cc

### DIFF
--- a/tensorflow/lite/micro/kernels/exp_test.cc
+++ b/tensorflow/lite/micro/kernels/exp_test.cc
@@ -66,11 +66,9 @@ TF_LITE_MICRO_TEST(SingleDim) {
   const int input_dims[] = {2, 1, 7};
   const float input_values[] = {0.0f,    1.0f,  -1.0f, 100.0f,
                                 -100.0f, 0.01f, -0.01f};
-
-  // (1.17549e-038 ~ 3.40282e+038), so the golden is set to float32's upper
-  // limit.
-  const float golden[] = {1.0f,         2.71828f, 0.36788f, std::numeric_limits<float>::infinity(),
-                          1.17549e-38f, 1.01005f, 0.99005f};
+  const float golden[] = {
+      1.0f,         2.71828f, 0.36788f, std::numeric_limits<float>::infinity(),
+      1.17549e-38f, 1.01005f, 0.99005f};
   tflite::testing::TestExp(input_dims, input_values, golden, output_data);
 }
 

--- a/tensorflow/lite/micro/kernels/exp_test.cc
+++ b/tensorflow/lite/micro/kernels/exp_test.cc
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+#include <limits>
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
@@ -49,7 +50,6 @@ void TestExp(const int* input_dims_data, const float* input_data,
 
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, runner.InitAndPrepare());
   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, runner.Invoke());
-
   for (int i = 0; i < output_dims_count; ++i) {
     TF_LITE_MICRO_EXPECT_NEAR(expected_output_data[i], output_data[i], 1e-5f);
   }
@@ -63,13 +63,13 @@ TF_LITE_MICRO_TESTS_BEGIN
 
 TF_LITE_MICRO_TEST(SingleDim) {
   float output_data[7];
-  const int input_dims[] = {1, 1, 7};
+  const int input_dims[] = {2, 1, 7};
   const float input_values[] = {0.0f,    1.0f,  -1.0f, 100.0f,
                                 -100.0f, 0.01f, -0.01f};
 
   // (1.17549e-038 ~ 3.40282e+038), so the golden is set to float32's upper
   // limit.
-  const float golden[] = {1.0f,         2.71823f, 0.36788f, 3.40282e+038f,
+  const float golden[] = {1.0f,         2.71828f, 0.36788f, std::numeric_limits<float>::infinity(),
                           1.17549e-38f, 1.01005f, 0.99005f};
   tflite::testing::TestExp(input_dims, input_values, golden, output_data);
 }


### PR DESCRIPTION
Issue #45415. Bug fix for micro op EXP's test code.