### PR TITLE
[INTEL MKL] Supporting 2 inputs for  Mkl dequantize op

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_dequantize_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_dequantize_op.cc
@@ -84,7 +84,7 @@ class MklDequantizeOp : public OpKernel {
       auto src_md = src_mkl_shape.IsMklTensor()
                         ? src_mkl_shape.GetMklLayout()
                         : memory::desc(src_dims, MklDnnType<T>(),
-                                       memory::format_tag::nhwc);
+                                       src_dims.size() == 4 ? MEMORY_FORMAT::nhwc : MEMORY_FORMAT::nc); 
 
       src.SetUsrMem(src_md, &src_tensor);
       src.SetUsrMemDataHandle(&src_tensor, reorder_stream);
@@ -100,7 +100,7 @@ class MklDequantizeOp : public OpKernel {
         dst_md.data.data_type = memory::convert_to_c(MklDnnType<float>());
       } else {
         dst_md = memory::desc(src_dims, MklDnnType<float>(),
-                              memory::format_tag::nhwc);
+                              src_dims.size() == 4 ? MEMORY_FORMAT::nhwc : MEMORY_FORMAT::nc); 
       }
 
       // If input is MKL shape, output is also MKL shape.

--- a/tensorflow/core/kernels/mkl/mkl_dequantize_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_dequantize_op.cc
@@ -84,7 +84,7 @@ class MklDequantizeOp : public OpKernel {
       auto src_md = src_mkl_shape.IsMklTensor()
                         ? src_mkl_shape.GetMklLayout()
                         : memory::desc(src_dims, MklDnnType<T>(),
-                                       src_dims.size() == 4 ? MEMORY_FORMAT::nhwc : MEMORY_FORMAT::nc); 
+                                       src_dims.size() == 4 ? MEMORY_FORMAT::nhwc : MEMORY_FORMAT::nc);
 
       src.SetUsrMem(src_md, &src_tensor);
       src.SetUsrMemDataHandle(&src_tensor, reorder_stream);
@@ -100,7 +100,7 @@ class MklDequantizeOp : public OpKernel {
         dst_md.data.data_type = memory::convert_to_c(MklDnnType<float>());
       } else {
         dst_md = memory::desc(src_dims, MklDnnType<float>(),
-                              src_dims.size() == 4 ? MEMORY_FORMAT::nhwc : MEMORY_FORMAT::nc); 
+                              src_dims.size() == 4 ? MEMORY_FORMAT::nhwc : MEMORY_FORMAT::nc);
       }
 
       // If input is MKL shape, output is also MKL shape.


### PR DESCRIPTION
 Mkl dequantize op used to support only 4 inputs. Here, we also need to support 2 inputs since it needs to be used with matmul op in some models.