### PR TITLE
Update array_ops.py

### DIFF
--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -2123,11 +2123,12 @@ def split(value, num_or_size_splits, axis=0, num=None, name="split"):
   Raises:
     ValueError: If `num` is unspecified and cannot be inferred.
   """
-  size_splits = ops.convert_to_tensor(num_or_size_splits)
   if isinstance(num_or_size_splits,
                 (numbers.Integral, tensor_shape.Dimension)):
     return gen_array_ops.split(
         axis=axis, num_split=num_or_size_splits, value=value, name=name)
+
+  size_splits = ops.convert_to_tensor(num_or_size_splits)
 
   if size_splits._rank() == 0:
     raise ValueError(


### PR DESCRIPTION
The current implementation of the `Split / SplitV` op's wrapper function (in Python)
convert `num_or_size_splits` to the `size_splits` tensor at the first line.
However, if we pass `num_or_size_splits` as a `Integral` or `Dimension` type, this function calls `Split` op directly
(does not use `size_splits` tensor).

This does not matter in eager mode but creates a redundant tensor (`Const` tensor or `Pack` etc...) in graph mode.
(Actually, the grappler might remove this redundant tensor since it is not used anywhere, but for the neat graph in tensorboard)
Then I just reordered Python statement after the first `if` statement