### PR TITLE
Deprecate legacy hdfs file system

### DIFF
--- a/tensorflow/core/platform/hadoop/hadoop_file_system.cc
+++ b/tensorflow/core/platform/hadoop/hadoop_file_system.cc
@@ -584,8 +584,8 @@ Status HadoopFileSystem::Stat(const string& fname, TransactionToken* token,
   return Status::OK();
 }
 
-REGISTER_FILE_SYSTEM("hdfs", HadoopFileSystem);
-REGISTER_FILE_SYSTEM("viewfs", HadoopFileSystem);
-REGISTER_FILE_SYSTEM("har", HadoopFileSystem);
+REGISTER_LEGACY_FILE_SYSTEM("hdfs", HadoopFileSystem);
+REGISTER_LEGACY_FILE_SYSTEM("viewfs", HadoopFileSystem);
+REGISTER_LEGACY_FILE_SYSTEM("har", HadoopFileSystem);
 
 }  // namespace tensorflow


### PR DESCRIPTION
This PR is part of the effort to switch to modular file system support
by deprecates hdfs file system and direct user to use modular file system
from tensorflow-io instead.

A `TF_ENABLE_LEGACY_FILESYSTEM=1` will allow the usage of legacy hdfs file
system the same way as before (a warning will be displayed).

/cc @mihaimaruseac  @vnvo2409 @tensorflow/sig-io-maintainers @burgerkingeater 

**Update**: See related changes in https://github.com/tensorflow/io/pull/1309 where hdfs is enabled in tensorflow/io.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>