### PR TITLE
Fix kernel_exp_test with the Xtensa toolchain.

### DIFF
--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -236,6 +236,19 @@ tflite_micro_cc_test(
 )
 
 tflite_micro_cc_test(
+    name = "exp_test",
+    srcs = ["exp_test.cc"],
+    deps = [
+        ":kernel_runner",
+        "//tensorflow/lite/c:common",
+        "//tensorflow/lite/micro:debug_log",
+        "//tensorflow/lite/micro:op_resolvers",
+        "//tensorflow/lite/micro:test_helpers",
+        "//tensorflow/lite/micro/testing:micro_test",
+    ],
+)
+
+tflite_micro_cc_test(
     name = "pooling_test",
     srcs = [
         "pooling_test.cc",

--- a/tensorflow/lite/micro/kernels/exp_test.cc
+++ b/tensorflow/lite/micro/kernels/exp_test.cc
@@ -54,7 +54,6 @@ void TestExp(const int* input_dims_data, const float* input_data,
     TF_LITE_MICRO_EXPECT_NEAR(expected_output_data[i], output_data[i], 1e-5f);
   }
 }
-
 }  // namespace
 }  // namespace testing
 }  // namespace tflite
@@ -62,13 +61,16 @@ void TestExp(const int* input_dims_data, const float* input_data,
 TF_LITE_MICRO_TESTS_BEGIN
 
 TF_LITE_MICRO_TEST(SingleDim) {
-  float output_data[7];
-  const int input_dims[] = {2, 1, 7};
-  const float input_values[] = {0.0f,    1.0f,  -1.0f, 100.0f,
-                                -100.0f, 0.01f, -0.01f};
-  const float golden[] = {
-      1.0f,         2.71828f, 0.36788f, std::numeric_limits<float>::infinity(),
-      1.17549e-38f, 1.01005f, 0.99005f};
+  constexpr int kInputSize = 7;
+  float output_data[kInputSize];
+  const int input_dims[] = {2, 1, kInputSize};
+  const float input_values[kInputSize] = {0.0f,    1.0f,  -1.0f, 100.0f,
+                                          -100.0f, 0.01f, -0.01f};
+  float golden[kInputSize];
+  for (int i = 0; i < kInputSize; ++i) {
+    golden[i] = std::exp(input_values[i]);
+  }
+
   tflite::testing::TestExp(input_dims, input_values, golden, output_data);
 }
 

--- a/tensorflow/lite/micro/testing/micro_test.h
+++ b/tensorflow/lite/micro/testing/micro_test.h
@@ -142,12 +142,14 @@ extern bool did_test_fail;
     }                                                                         \
   } while (false)
 
+// The check vx != vy is needed to properly handle the case where both
+// x and y evaluate to infinity. See #46960 for more details.
 #define TF_LITE_MICRO_EXPECT_NEAR(x, y, epsilon)                              \
   do {                                                                        \
     auto vx = (x);                                                            \
     auto vy = (y);                                                            \
     auto delta = ((vx) > (vy)) ? ((vx) - (vy)) : ((vy) - (vx));               \
-    if (delta > epsilon) {                                                    \
+    if (vx != vy && delta > epsilon) {                                        \
       MicroPrintf(#x " (%f) near " #y " (%f) failed at %s:%d",                \
                   static_cast<double>(vx), static_cast<double>(vy), __FILE__, \
                   __LINE__);                                                  \


### PR DESCRIPTION
Underlying issue is a bug in the EXPECT_NEAR macro, as described in #46960

Also,
  * added an exp_test rule to the BUILD file.
  * changed the golden value computation to make use of std::exp instead of hard-coded values. This is closer to the TfLite test as well.

Manually confirmed that the following command passes:
```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=fusion_f1 XTENSA_CORE=F1_190305_swupgrade test -j8
```

Fixes #46960
