### PR TITLE
[INTEL MKL] Adding padding_list in mkl quantized conv2d per channel op

### DIFF
--- a/tensorflow/core/ops/mkl_nn_ops.cc
+++ b/tensorflow/core/ops/mkl_nn_ops.cc
@@ -1229,6 +1229,7 @@ REGISTER_OP("_MklQuantizedConv2DPerChannel")
     .Attr("is_filter_const: bool = false")
     .Attr(GetPaddingAttrString())
     .Attr("dilations: list(int) = [1, 1, 1, 1]")
+    .Attr("padding_list: list(int) = []")
     .SetShapeFn([](InferenceContext* c) {
       TF_RETURN_IF_ERROR(shape_inference::Conv2DShape(c));
       ShapeHandle unused, channel;


### PR DESCRIPTION
Adding padding_list in mkl quantized conv2d per channel op in the attribute. It is needed to do pad fusion with quantized conv2d per channel.