### PR TITLE
Add CAST and ZEROS_LIKE tests in lite/micro/kernels/BUILD

### DIFF
--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -223,8 +223,34 @@ test_suite(
 )
 
 tflite_micro_cc_test(
+    name = "cast_test",
+    srcs = ["cast_test.cc"],
+    deps = [
+        ":kernel_runner",
+        "//tensorflow/lite/c:common",
+        "//tensorflow/lite/micro:debug_log",
+        "//tensorflow/lite/micro:op_resolvers",
+        "//tensorflow/lite/micro:test_helpers",
+        "//tensorflow/lite/micro/testing:micro_test",
+    ],
+)
+
+tflite_micro_cc_test(
     name = "elementwise_test",
     srcs = ["elementwise_test.cc"],
+    deps = [
+        ":kernel_runner",
+        "//tensorflow/lite/c:common",
+        "//tensorflow/lite/micro:debug_log",
+        "//tensorflow/lite/micro:op_resolvers",
+        "//tensorflow/lite/micro:test_helpers",
+        "//tensorflow/lite/micro/testing:micro_test",
+    ],
+)
+
+tflite_micro_cc_test(
+    name = "zeros_like_test",
+    srcs = ["zeros_like_test.cc"],
     deps = [
         ":kernel_runner",
         "//tensorflow/lite/c:common",


### PR DESCRIPTION
This is a fix for micro ops CAST and ZEROS_LIKE (issues #45608 and #46049).