### PR TITLE
XLA: Allow devices to indicate whether the executable can be run async

### DIFF
--- a/tensorflow/compiler/jit/xla_device.cc
+++ b/tensorflow/compiler/jit/xla_device.cc
@@ -146,13 +146,15 @@ static DeviceAttributes BuildXlaDeviceAttributes(const string& name_prefix,
 XlaDevice::Metadata::Metadata(
     int device_ordinal, se::Platform* platform, const DeviceType& device_type,
     XlaCompiler::ShapeRepresentationFn shape_representation_fn,
-    PaddedShapeFn padded_shape_fn, bool use_multiple_streams)
+    PaddedShapeFn padded_shape_fn, bool use_multiple_streams,
+    bool supports_async_executable_run)
     : device_ordinal_(device_ordinal),
       device_type_(device_type),
       platform_(platform),
       shape_representation_fn_(std::move(shape_representation_fn)),
       padded_shape_fn_(std::move(padded_shape_fn)),
-      use_multiple_streams_(use_multiple_streams) {}
+      use_multiple_streams_(use_multiple_streams),
+      supports_async_executable_run_(supports_async_executable_run) {}
 
 int XlaDevice::Metadata::device_ordinal() const { return device_ordinal_; }
 
@@ -203,7 +205,8 @@ XlaDevice::XlaDevice(const SessionOptions& session_options,
                     options.shape_representation_fn,
                     options.padded_shape_fn ? options.padded_shape_fn
                                             : DefaultPaddedShapeFn,
-                    options.use_multiple_streams),
+                    options.use_multiple_streams,
+                    options.supports_async_executable_run),
       device_ordinal_(options.device_ordinal),
       jit_device_name_(options.compilation_device_name),
       platform_(options.platform),

--- a/tensorflow/compiler/jit/xla_device.h
+++ b/tensorflow/compiler/jit/xla_device.h
@@ -61,7 +61,8 @@ class XlaDevice : public LocalDevice {
     Metadata(int device_ordinal, se::Platform* platform,
              const DeviceType& device_type,
              XlaCompiler::ShapeRepresentationFn shape_representation_fn,
-             PaddedShapeFn padded_shape_fn, bool use_multiple_streams);
+             PaddedShapeFn padded_shape_fn, bool use_multiple_streams,
+             bool supports_async_executable_run);
 
     // The index of the device on this host.
     int device_ordinal() const;
@@ -76,6 +77,10 @@ class XlaDevice : public LocalDevice {
 
     bool UseMultipleStreams() const { return use_multiple_streams_; }
 
+    bool SupportsAsyncExecutableRun() const {
+      return supports_async_executable_run_;
+    }
+
    private:
     const int device_ordinal_;
     const DeviceType device_type_;
@@ -83,6 +88,7 @@ class XlaDevice : public LocalDevice {
     XlaCompiler::ShapeRepresentationFn shape_representation_fn_;
     PaddedShapeFn padded_shape_fn_;
     const bool use_multiple_streams_;
+    const bool supports_async_executable_run_;
 
     TF_DISALLOW_COPY_AND_ASSIGN(Metadata);
   };
@@ -118,6 +124,10 @@ class XlaDevice : public LocalDevice {
     // If 'use_multiple_streams' is true, we create separate streams for
     // compute, host-to-device, and device-to-host communication.
     bool use_multiple_streams = false;
+
+    // If 'supports_async_executable_run' is true, then the executables are
+    // allowed to run asynchronously.
+    bool supports_async_executable_run = true;
 
     // A function that describes how the on-host shapes of
     // a) argument and return value, for entry computations

--- a/tensorflow/compiler/jit/xla_platform_info.h
+++ b/tensorflow/compiler/jit/xla_platform_info.h
@@ -44,6 +44,11 @@ class XlaPlatformInfo {
     return xla_device_metadata_ && xla_device_metadata_->UseMultipleStreams();
   }
 
+  bool SupportsAsyncExecutableRun() const {
+    return xla_device_metadata_ &&
+           xla_device_metadata_->SupportsAsyncExecutableRun();
+  }
+
   // Non-null only when run on an XLA device.
   se::DeviceMemoryAllocator* custom_allocator() const {
     return device_allocator_;


### PR DESCRIPTION
This allow an XLA device/backend to indicate if executables can be executed asynchronously.