### PR TITLE
Fix crash with tf.transpose when a is complex and conjugate is True

### DIFF
--- a/tensorflow/core/kernels/transpose_functor.h
+++ b/tensorflow/core/kernels/transpose_functor.h
@@ -166,7 +166,6 @@ template <typename Device>
 Status DoTransposeImpl(const Device& d, const Tensor& in,
                        const gtl::ArraySlice<int32> perm, bool conjugate,
                        Tensor* out) {
-  CHECK_GE(in.dims(), 2);
   CHECK_EQ(in.dims(), out->dims());
   CHECK_EQ(in.dims(), perm.size());
   CHECK_EQ(in.dtype(), out->dtype());

--- a/tensorflow/python/kernel_tests/transpose_op_test.py
+++ b/tensorflow/python/kernel_tests/transpose_op_test.py
@@ -531,6 +531,22 @@ class TransposeTest(test.TestCase):
     self._testError(
         np.arange(0., 30).reshape([2, 3, 5]), [0, 1, 1], "2 is missing")
 
+  @test_util.run_v1_only("b/120545219")
+  def testComplexScaler(self):
+    # Test case for GitHub issue 46891.
+    for dtype in [np.complex64, np.complex128]:
+      x = np.asarray(1+1j, dtype=dtype)
+      xt = self.evaluate(array_ops.transpose(x, conjugate=True))
+      self.assertAllEqual(xt, np.transpose(x).conj())
+
+  @test_util.run_v1_only("b/120545219")
+  def testComplex1D(self):
+    # Test case for GitHub issue 46891.
+    for dtype in [np.complex64, np.complex128]:
+      x = np.asarray([1+1j], dtype=dtype)
+      xt = self.evaluate(array_ops.transpose(x, conjugate=True))
+      self.assertAllEqual(xt, np.transpose(x).conj())
+
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/kernel_tests/transpose_op_test.py
+++ b/tensorflow/python/kernel_tests/transpose_op_test.py
@@ -379,6 +379,8 @@ class TransposeTest(test.TestCase):
         np.arange(0, 16).reshape([1, 2, 1, 2, 1, 2, 1, 2]).astype(np.float64))
 
   def testComplex64(self):
+    self._testBoth(np.array(np.complex(1, 2)).astype(np.complex64))
+    self._testBoth(np.complex(1, 2) * np.arange(0, 21).astype(np.complex64))
     self._testBoth(
         np.complex(1, 2) *
         np.arange(0, 21).reshape([3, 7]).astype(np.complex64))
@@ -390,6 +392,8 @@ class TransposeTest(test.TestCase):
         np.arange(0, 1260).reshape([2, 3, 5, 7, 2, 3]).astype(np.complex64))
 
   def testComplex128(self):
+    self._testBoth(np.array(np.complex(1, 2)).astype(np.complex128))
+    self._testBoth(np.complex(1, 2) * np.arange(0, 21).astype(np.complex128))
     self._testBoth(
         np.complex(1, 2) *
         np.arange(0, 21).reshape([3, 7]).astype(np.complex128))
@@ -530,22 +534,6 @@ class TransposeTest(test.TestCase):
       array_ops.transpose(np.arange(0., 30).reshape([2, 3, 5]), [0, 1, 3])
     self._testError(
         np.arange(0., 30).reshape([2, 3, 5]), [0, 1, 1], "2 is missing")
-
-  @test_util.run_v1_only("b/120545219")
-  def testComplexScaler(self):
-    # Test case for GitHub issue 46891.
-    for dtype in [np.complex64, np.complex128]:
-      x = np.asarray(1+1j, dtype=dtype)
-      xt = self.evaluate(array_ops.transpose(x, conjugate=True))
-      self.assertAllEqual(xt, np.transpose(x).conj())
-
-  @test_util.run_v1_only("b/120545219")
-  def testComplex1D(self):
-    # Test case for GitHub issue 46891.
-    for dtype in [np.complex64, np.complex128]:
-      x = np.asarray([1+1j], dtype=dtype)
-      xt = self.evaluate(array_ops.transpose(x, conjugate=True))
-      self.assertAllEqual(xt, np.transpose(x).conj())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR tries to address the issue raised in #46891 where
tf.transpose will crash when a is complex and conjugate is True.
The issue comes from:
https://github.com/tensorflow/tensorflow/blob/57bbc5e0d4b93483b8ae853352173516f1c08018/tensorflow/core/kernels/transpose_functor.h#L169

However, as ndims < 2 has already been handled properly:
https://github.com/tensorflow/tensorflow/blob/57bbc5e0d4b93483b8ae853352173516f1c08018/tensorflow/core/kernels/transpose_functor_cpu.cc#L103-L105
The check could be removed.

This PR fixes #46891.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>