### PR TITLE
hello0 alternative error message for failed shape broadcasting

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 """configure script to get build parameters from user."""
 
+hello world
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/tensorflow/python/kernel_tests/cwise_ops_binary_test.py
+++ b/tensorflow/python/kernel_tests/cwise_ops_binary_test.py
@@ -960,7 +960,8 @@ class ComparisonOpTest(test.TestCase):
       for f in funcs:
         with self.assertRaisesRegex(
             (ValueError, errors.InvalidArgumentError),
-            "Incompatible shapes|Dimensions must be equal"):
+            "Incompatible shapes|Dimensions must be equal|"
+            "required broadcastable shapes"):
           f(x.astype(t), y.astype(t))
 
   def testEqualDType(self):


### PR DESCRIPTION
This just ensures that the test also passes with alternative generated kernels.

PiperOrigin-RevId: 355814751
Change-Id: I2a148427ebc059244c9f94ba91e294c460bb5544