### PR TITLE
Don't run nightly update job in forks.

### DIFF
--- a/.github/workflows/update-nightly.yml
+++ b/.github/workflows/update-nightly.yml
@@ -20,6 +20,7 @@ on:
 name: Set nightly branch to master HEAD
 jobs:
   master-to-nightly:
+    if: github.repository == 'tensorflow/tensorflow' # Don't do this in forks
     runs-on: ubuntu-latest
     steps:
     - uses: zofrex/mirror-branch@v1


### PR DESCRIPTION
There are currently ~84000 forks of TensorFlow on GitHub, and this job currently runs daily in all of them (or at least the ones which were last synced more recently than this job was added).

As I understand it, the point of this job is to run nightly so that the TF team can run a suite of nightly tests, so there's no reason for it to happen anywhere other than the upstream `tensorflow/tensorflow` repo - please correct me if I'm wrong about this!

Looking at the list of [runs for the last few days](https://github.com/tensorflow/tensorflow/actions?query=workflow%3A%22Set+nightly+branch+to+master+HEAD%22), some jobs were under 20 seconds but some were more than 10 minutes. That's an awful lot of unnecessary compute that's being used performing the job on forks.