### PR TITLE
Remove unnecessary set_model overwrite in BackupAndRestore calllback

### DIFF
--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -1628,9 +1628,6 @@ class BackupAndRestore(Callback):
     # restore checkpoint at on_train_begin().
     self._chief_worker_only = False
 
-  def set_model(self, model):
-    self.model = model
-
   def on_train_begin(self, logs=None):
     # TrainingState is used to manage the training state needed for
     # failure-recovery of a worker in training.


### PR DESCRIPTION
`keras.callbacks.BackupAndRestore` subclasses `keras.callbacks.Callback` which already implements `set_model()` so there is no need to reimplement it here.
https://github.com/tensorflow/tensorflow/blob/bbeb7264026e216eba9f0479017d429e2e9d06f6/tensorflow/python/keras/callbacks.py#L636-L637

This PR removes the overwrite, as it doesn't change the behaviour of the code.