### PR TITLE
Simplify shape inference in Keras resize_images

### DIFF
--- a/tensorflow/python/keras/backend.py
+++ b/tensorflow/python/keras/backend.py
@@ -3198,8 +3198,11 @@ def resize_images(x, height_factor, width_factor, data_format,
   else:
     raise ValueError('Invalid `data_format` argument: %s' % (data_format,))
 
-  original_shape = int_shape(x)
-  new_shape = array_ops.shape(x)[rows:cols + 1]
+  new_shape = x.shape[rows:cols + 1]
+  if new_shape.is_fully_defined():
+    new_shape = constant_op.constant(new_shape.as_list(), dtype='int32')
+  else:
+    new_shape = array_ops.shape_v2(x)[rows:cols + 1]
   new_shape *= constant_op.constant(
       np.array([height_factor, width_factor], dtype='int32'))
 
@@ -3217,21 +3220,6 @@ def resize_images(x, height_factor, width_factor, data_format,
   if data_format == 'channels_first':
     x = permute_dimensions(x, [0, 3, 1, 2])
 
-  if original_shape[rows] is None:
-    new_height = None
-  else:
-    new_height = original_shape[rows] * height_factor
-
-  if original_shape[cols] is None:
-    new_width = None
-  else:
-    new_width = original_shape[cols] * width_factor
-
-  if data_format == 'channels_first':
-    output_shape = (None, None, new_height, new_width)
-  else:
-    output_shape = (None, new_height, new_width, None)
-  x.set_shape(output_shape)
   return x
 
 

--- a/tensorflow/python/keras/backend_test.py
+++ b/tensorflow/python/keras/backend_test.py
@@ -609,6 +609,12 @@ class BackendShapeOpsTest(test.TestCase):
     y = backend.resize_images(x, height_factor, width_factor, data_format)
     self.assertEqual(y.shape.as_list(), [1, 3, 4, 4])
 
+    # Use with a dynamic axis:
+    if not context.executing_eagerly():
+      x = backend.placeholder(shape=(1, 3, None, None))
+      y = backend.resize_images(x, height_factor, width_factor, data_format)
+      self.assertEqual(y.shape.as_list(), [1, 3, None, None])
+
     # Invalid use:
     with self.assertRaises(ValueError):
       backend.resize_images(


### PR DESCRIPTION
This PR simplifies shape inference of `keras.backend.resize_images`, since the shape of the output tensor is already correctly set in `image_ops.resize_images_v2`:
https://github.com/tensorflow/tensorflow/blob/0921a80d56107e19c5c1cebf9500a683d7d41b10/tensorflow/python/ops/image_ops_impl.py#L1390

This also removes the need for the `tf.shape` op in cases where the spatial shape of the input tensor is fully defined which fixes #25086.