### PR TITLE
Simplify tf.keras.activations.softmax codepath

### DIFF
--- a/tensorflow/python/keras/activations.py
+++ b/tensorflow/python/keras/activations.py
@@ -70,6 +70,7 @@ def softmax(x, axis=-1):
         and sum to 1).
   """
   output = nn.softmax(x, axis=axis)
+  # Cache the logits to use for crossentropy loss.
   output._keras_logits = x  # pylint: disable=protected-access
   return output
 

--- a/tensorflow/python/keras/activations.py
+++ b/tensorflow/python/keras/activations.py
@@ -68,22 +68,8 @@ def softmax(x, axis=-1):
   Returns:
       Tensor, output of softmax transformation (all values are non-negative
         and sum to 1).
-
-  Raises:
-      ValueError: In case `dim(x) == 1`.
   """
-  rank = x.shape.rank
-  if rank == 2:
-    output = nn.softmax(x)
-  elif rank > 2:
-    e = math_ops.exp(x - math_ops.reduce_max(x, axis=axis, keepdims=True))
-    s = math_ops.reduce_sum(e, axis=axis, keepdims=True)
-    output = e / s
-  else:
-    raise ValueError('Cannot apply softmax to a tensor that is 1D. '
-                     'Received input: %s' % (x,))
-
-  # Cache the logits to use for crossentropy loss.
+  output = nn.softmax(x, axis=axis)
   output._keras_logits = x  # pylint: disable=protected-access
   return output
 

--- a/tensorflow/python/keras/activations_test.py
+++ b/tensorflow/python/keras/activations_test.py
@@ -31,10 +31,10 @@ from tensorflow.python.ops import nn_ops as nn
 from tensorflow.python.platform import test
 
 
-def _ref_softmax(values, axis=-1):
-  m = np.max(values, axis=axis, keepdims=True)
+def _ref_softmax(values):
+  m = np.max(values, axis=-1, keepdims=True)
   e = np.exp(values - m)
-  return e / np.sum(e, axis=axis, keepdims=True)
+  return e / np.sum(e, axis=-1, keepdims=True)
 
 
 @combinations.generate(combinations.combine(mode=['graph', 'eager']))
@@ -87,7 +87,7 @@ class KerasActivationsTest(test.TestCase, parameterized.TestCase):
     f = backend.function([x], [activations.softmax(x, axis=-1)])
     test_values = np.random.random(shape)
     result = f([test_values])[0]
-    expected = _ref_softmax(test_values, axis=-1)
+    expected = _ref_softmax(test_values)
     self.assertAllClose(result, expected, rtol=1e-05)
 
   def test_selu(self):


### PR DESCRIPTION
Fixes https://github.com/tensorflow/tensorflow/issues/35199 although TFLite has already optimized that pattern into single softmax op. Since `tf.nn.softmax` supports input of any rank, there is no reason to have other implementations. For common 3D input with `axis=-1`, `tf.nn.softmax` is also faster than original implementation.

https://colab.research.google.com/drive/1E1rS69LJ7e-pH4bcyfxEJ_wC6IiRISvS?usp=sharing