### PR TITLE
Remove duplicated implementation of keras.backend.ndim

### DIFF
--- a/tensorflow/python/keras/backend.py
+++ b/tensorflow/python/keras/backend.py
@@ -1484,10 +1484,7 @@ def ndim(x):
   2
 
   """
-  dims = x.shape._dims
-  if dims is not None:
-    return len(dims)
-  return None
+  return x.shape.rank
 
 
 @keras_export('keras.backend.dtype')


### PR DESCRIPTION
This PR simplifies `keras.backend.ndim` by reusing the identical implementation from `TensorShape.rank`:
https://github.com/tensorflow/tensorflow/blob/7516f6ee75063d8e4f3cfa9d574de64769185de9/tensorflow/python/framework/tensor_shape.py#L825-L830