### PR TITLE
[tf.data] eager mode support for experimental benchmarks part2

### DIFF
--- a/tensorflow/python/data/benchmarks/benchmark_base.py
+++ b/tensorflow/python/data/benchmarks/benchmark_base.py
@@ -52,15 +52,15 @@ class DatasetBenchmarkBase(test.Benchmark):
     """
 
     if context.executing_eagerly():
-      if warmup:
-        iterator = iter(op)
-        next(iterator)
-
-      iterator = iter(op)
-      start = time.time()
       for _ in range(iters):
+        if warmup:
+          iterator = iter(op)
+          next(iterator)
+
+        iterator = iter(op)
+        start = time.time()
         next(iterator)
-      end = time.time()
+        end = time.time()
       return (end - start) / iters
 
     with session.Session() as sess:

--- a/tensorflow/python/data/benchmarks/benchmark_base.py
+++ b/tensorflow/python/data/benchmarks/benchmark_base.py
@@ -31,10 +31,97 @@ from tensorflow.python.platform import test
 class DatasetBenchmarkBase(test.Benchmark):
   """Base class for dataset benchmarks."""
 
+  def _run_eager_benchmark(self, op_or_dataset, iters, warmup):
+    """Benchmark in eager mode.
+
+    Runs the op `iters` times. In each iteration, the benchmark measures
+    the time it takes to go execute the op.
+
+    Args:
+      op_or_dataset: The tf op or tf.data Dataset to benchmark.
+      iters: Number of times to repeat the timing.
+      warmup: If true, warms up the session caches by running an untimed run.
+
+    Returns:
+      A float, representing the median time (with respect to `iters`)
+      it takes for the op to be executed `iters` num of times.
+    """
+
+    deltas = []
+    if not context.executing_eagerly():
+      raise RuntimeError(
+          "Eager mode benchmarking is not supported in graph mode.")
+
+    for _ in range(iters):
+      if warmup:
+        iterator = iter(op_or_dataset)
+        next(iterator)
+
+      iterator = iter(op_or_dataset)
+      start = time.time()
+      next(iterator)
+      end = time.time()
+      deltas.append(end - start)
+    return np.median(deltas)
+
+  def _run_graph_benchmark(self,
+                           op_or_dataset,
+                           iters,
+                           warmup,
+                           session_config,
+                           is_dataset=True):
+    """Benchmarks the op in graph mode.
+
+    Runs the op `iters` times. In each iteration, the benchmark measures
+    the time it takes to go execute the op.
+
+    Args:
+      op_or_dataset: The tf op or tf.data Dataset to benchmark.
+      iters: Number of times to repeat the timing.
+      warmup: If true, warms up the session caches by running an untimed run.
+      session_config: A ConfigProto protocol buffer with configuration options
+        for the session. Applicable only for benchmarking in graph mode.
+      is_dataset: A boolean value representing whether the op is a tf.data
+        Dataset or not.
+
+    Returns:
+      A float, representing the median time (with respect to `iters`)
+      it takes for the op to be executed `iters` num of times.
+    """
+
+    deltas = []
+    if context.executing_eagerly():
+      raise RuntimeError(
+          "Graph mode benchmarking is not supported in eager mode.")
+
+    if is_dataset:
+      iterator = dataset_ops.make_initializable_iterator(dataset)
+      next_element = iterator.get_next()
+      op = nest.flatten(next_element)[0].op
+    else:
+      op = op_or_dataset
+
+    for _ in range(iters):
+      with session.Session(config=session_config) as sess:
+        if warmup:
+          if is_dataset:
+            sess.run(iterator.initializer)
+          # Run once to warm up the session caches.
+          sess.run(op)
+
+        if is_dataset:
+          sess.run(iterator.initializer)
+        start = time.time()
+        sess.run(op)
+        end = time.time()
+      deltas.append(end - start)
+    return np.median(deltas)
+
   def run_op_benchmark(self,
                        op,
                        iters=1,
-                       warmup=True):
+                       warmup=True,
+                       session_config=None):
     """Benchmarks the op.
 
     Runs the op `iters` times. In each iteration, the benchmark measures
@@ -44,6 +131,8 @@ class DatasetBenchmarkBase(test.Benchmark):
       op: The tf op to benchmark.
       iters: Number of times to repeat the timing.
       warmup: If true, warms up the session caches by running an untimed run.
+      session_config: A ConfigProto protocol buffer with configuration options
+        for the session. Applicable only for benchmarking in graph mode.
 
     Returns:
       A float, representing the per-execution wall time of the op in seconds.
@@ -52,27 +141,19 @@ class DatasetBenchmarkBase(test.Benchmark):
     """
 
     if context.executing_eagerly():
-      for _ in range(iters):
-        if warmup:
-          iterator = iter(op)
-          next(iterator)
+      return self._run_eager_benchmark(
+          op_or_dataset=op,
+          iters=iters,
+          warmup=warmup
+      )
 
-        iterator = iter(op)
-        start = time.time()
-        next(iterator)
-        end = time.time()
-      return (end - start) / iters
-
-    with session.Session() as sess:
-      if warmup:
-        # Run once to warm up the session caches.
-        sess.run(op)
-      start = time.time()
-      for _ in range(iters):
-        sess.run(op)
-      end = time.time()
-
-    return (end - start) / iters
+    return self._run_graph_benchmark(
+        op_or_dataset=op,
+        iters=iters,
+        warmup=warmup,
+        session_config=session_config,
+        is_dataset=False
+    )
 
   def run_benchmark(self,
                     dataset,
@@ -116,38 +197,22 @@ class DatasetBenchmarkBase(test.Benchmark):
     # to execute upstream computation. If it is optimized in the future,
     # we will have to change this code.
     dataset = dataset.skip(num_elements - 1)
-    deltas = []
 
     if context.executing_eagerly():
-      for _ in range(iters):
-        if warmup:
-          iterator = iter(dataset)
-          next(iterator)
+      median_duration = self._run_eager_benchmark(
+          op_or_dataset=dataset,
+          iters=iters,
+          warmup=warmup
+      )
+      return median_duration / float(num_elements)
 
-        iterator = iter(dataset)
-        start = time.time()
-        next(iterator)
-        end = time.time()
-        deltas.append(end - start)
-      return np.median(deltas) / float(num_elements)
-
-    iterator = dataset_ops.make_initializable_iterator(dataset)
-    next_element = iterator.get_next()
-    next_element = nest.flatten(next_element)[0]
-
-    for _ in range(iters):
-      with session.Session(config=session_config) as sess:
-        if warmup:
-          # Run once to warm up the session caches.
-          sess.run(iterator.initializer)
-          sess.run(next_element.op)
-
-        sess.run(iterator.initializer)
-        start = time.time()
-        sess.run(next_element.op)
-        end = time.time()
-      deltas.append(end - start)
-    return np.median(deltas) / float(num_elements)
+    median_duration = self._run_graph_benchmark(
+        op_or_dataset=dataset,
+        iters=iters,
+        warmup=warmup,
+        session_config=session_config
+    )
+    return median_duration / float(num_elements)
 
   def run_and_report_benchmark(self,
                                dataset,

--- a/tensorflow/python/data/benchmarks/benchmark_base.py
+++ b/tensorflow/python/data/benchmarks/benchmark_base.py
@@ -56,7 +56,7 @@ class DatasetBenchmarkBase(test.Benchmark):
         iterator = iter(op)
         next(iterator)
 
-      iterator = iter(dataset)
+      iterator = iter(op)
       start = time.time()
       for _ in range(iters):
         next(iterator)

--- a/tensorflow/python/data/benchmarks/benchmark_base.py
+++ b/tensorflow/python/data/benchmarks/benchmark_base.py
@@ -79,7 +79,8 @@ class DatasetBenchmarkBase(test.Benchmark):
                     num_elements,
                     iters=1,
                     warmup=True,
-                    apply_default_optimizations=False):
+                    apply_default_optimizations=False,
+                    session_config=None):
     """Benchmarks the dataset.
 
     Runs the dataset `iters` times. In each iteration, the benchmark measures
@@ -93,6 +94,8 @@ class DatasetBenchmarkBase(test.Benchmark):
       warmup: If true, warms up the session caches by running an untimed run.
       apply_default_optimizations: Determines whether default optimizations
         should be applied.
+      session_config: A ConfigProto protocol buffer with configuration options
+        for the session. Applicable only for benchmarking in graph mode.
 
     Returns:
       A float, representing the per-element wall time of the dataset in seconds.
@@ -133,7 +136,7 @@ class DatasetBenchmarkBase(test.Benchmark):
     next_element = nest.flatten(next_element)[0]
 
     for _ in range(iters):
-      with session.Session() as sess:
+      with session.Session(config=session_config) as sess:
         if warmup:
           # Run once to warm up the session caches.
           sess.run(iterator.initializer)
@@ -153,7 +156,8 @@ class DatasetBenchmarkBase(test.Benchmark):
                                iters=5,
                                extras=None,
                                warmup=True,
-                               apply_default_optimizations=False):
+                               apply_default_optimizations=False,
+                               session_config=None):
     """Benchmarks the dataset and reports the stats.
 
     Runs the dataset `iters` times. In each iteration, the benchmark measures
@@ -170,6 +174,8 @@ class DatasetBenchmarkBase(test.Benchmark):
       warmup: If true, warms up the session caches by running an untimed run.
       apply_default_optimizations: Determines whether default optimizations
         should be applied.
+      session_config: A ConfigProto protocol buffer with configuration options
+        for the session. Applicable only for benchmarking in graph mode.
 
     Returns:
       A float, representing the per-element wall time of the dataset in seconds.
@@ -181,7 +187,8 @@ class DatasetBenchmarkBase(test.Benchmark):
         num_elements=num_elements,
         iters=iters,
         warmup=warmup,
-        apply_default_optimizations=apply_default_optimizations)
+        apply_default_optimizations=apply_default_optimizations,
+        session_config=session_config)
     if context.executing_eagerly():
       name = "{}.eager".format(name)
     else:

--- a/tensorflow/python/data/experimental/benchmarks/autotune_benchmark.py
+++ b/tensorflow/python/data/experimental/benchmarks/autotune_benchmark.py
@@ -63,9 +63,9 @@ class AutotuneBenchmark(benchmark_base.DatasetBenchmarkBase):
     dataset = dataset.map(
         math_ops.matmul, num_parallel_calls=dataset_ops.AUTOTUNE)
     return self._run_benchmark(
-        dataset,
-        autotune,
-        autotune_buffers,
+        dataset=dataset,
+        autotune=autotune,
+        autotune_buffers=autotune_buffers,
         benchmark_iters=10000,
         benchmark_label="map")
 
@@ -86,9 +86,9 @@ class AutotuneBenchmark(benchmark_base.DatasetBenchmarkBase):
         math_ops.matmul, num_parallel_calls=dataset_ops.AUTOTUNE)
     dataset = dataset.batch(batch_size=batch_size)
     return self._run_benchmark(
-        dataset,
-        autotune,
-        autotune_buffers,
+        dataset=dataset,
+        autotune=autotune,
+        autotune_buffers=autotune_buffers,
         benchmark_iters=1000,
         benchmark_label="map_and_batch")
 
@@ -110,9 +110,9 @@ class AutotuneBenchmark(benchmark_base.DatasetBenchmarkBase):
         cycle_length=10,
         num_parallel_calls=dataset_ops.AUTOTUNE)
     return self._run_benchmark(
-        dataset,
-        autotune,
-        autotune_buffers,
+        dataset=dataset,
+        autotune=autotune,
+        autotune_buffers=autotune_buffers,
         benchmark_iters=10000,
         benchmark_label="interleave")
 
@@ -158,9 +158,9 @@ class AutotuneBenchmark(benchmark_base.DatasetBenchmarkBase):
     dataset = dataset_ops.Dataset.zip((dataset, dataset_c))
     dataset = dataset.map(f2, num_parallel_calls=dataset_ops.AUTOTUNE)
     return self._run_benchmark(
-        dataset,
-        autotune,
-        autotune_buffers,
+        dataset=dataset,
+        autotune=autotune,
+        autotune_buffers=autotune_buffers,
         benchmark_iters=10000,
         benchmark_label="map_and_interleave")
 
@@ -206,9 +206,9 @@ class AutotuneBenchmark(benchmark_base.DatasetBenchmarkBase):
     dataset_c = dataset_c.batch(batch_size=batch_size)
     dataset = dataset_ops.Dataset.zip((dataset, dataset_c))
     return self._run_benchmark(
-        dataset,
-        autotune,
-        autotune_buffers,
+        dataset=dataset,
+        autotune=autotune,
+        autotune_buffers=autotune_buffers,
         benchmark_iters=1000,
         benchmark_label="map_batch_and_interleave")
 

--- a/tensorflow/python/data/experimental/benchmarks/choose_fastest_benchmark.py
+++ b/tensorflow/python/data/experimental/benchmarks/choose_fastest_benchmark.py
@@ -17,18 +17,12 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import time
-
-import numpy as np
-
-from tensorflow.python.client import session
 from tensorflow.python.data.experimental.ops import optimization
+from tensorflow.python.data.benchmarks import benchmark_base
 from tensorflow.python.data.ops import dataset_ops
-from tensorflow.python.platform import test
 
 
-# TODO(b/119837791): Add eager benchmarks too.
-class ChooseFastestBenchmark(test.Benchmark):
+class ChooseFastestBenchmark(benchmark_base.DatasetBenchmarkBase):
   """Benchmarks for static optimizations."""
 
   def benchmark_choose_fastest(self):
@@ -42,9 +36,9 @@ class ChooseFastestBenchmark(test.Benchmark):
 
     merge_dataset = optimization._ChooseFastestDataset(  # pylint: disable=protected-access
         [batch_map_dataset, map_batch_dataset])
-    self._benchmark(map_batch_dataset, "map_batch_dataset")
-    self._benchmark(batch_map_dataset, "batch_map_dataset")
-    self._benchmark(merge_dataset, "merge_dataset")
+    self._benchmark(dataset=map_batch_dataset, name="map_batch_dataset")
+    self._benchmark(dataset=batch_map_dataset, name="batch_map_dataset")
+    self._benchmark(dataset=merge_dataset, name="merge_dataset")
 
   def benchmark_choose_fastest_first_n_iterations(self):
 
@@ -58,48 +52,30 @@ class ChooseFastestBenchmark(test.Benchmark):
     merge_dataset = optimization._ChooseFastestDataset(  # pylint: disable=protected-access
         [batch_map_dataset, map_batch_dataset])
 
-    self._benchmark_first_n(map_batch_dataset, "map_batch_dataset")
-    self._benchmark_first_n(batch_map_dataset, "batch_map_dataset")
-    self._benchmark_first_n(merge_dataset, "merge_dataset")
+    self._benchmark_first_n(dataset=map_batch_dataset, name="map_batch_dataset")
+    self._benchmark_first_n(dataset=batch_map_dataset, name="batch_map_dataset")
+    self._benchmark_first_n(dataset=merge_dataset, name="merge_dataset")
 
   def _benchmark_first_n(self, dataset, name):
     n = 10  # The default num_experiments for ChooseFastestDataset
-    iterator = dataset_ops.make_one_shot_iterator(dataset)
-    next_element = iterator.get_next()
-
-    deltas = []
-    for _ in range(100):
-      with session.Session() as sess:
-        start = time.time()
-        for _ in range(n):
-          sess.run(next_element.op)
-        end = time.time()
-        deltas.append(end - start)
-    median_wall_time = np.median(deltas) / n
-    self.report_benchmark(
-        iters=n, wall_time=median_wall_time, name=name + "_first_%d" % n)
+    self.run_and_report_benchmark(
+        dataset=dataset,
+        num_elements=n,
+        iters=100,
+        warmup=True,
+        name=name + "_first_%d" % n
+    )
 
   def _benchmark(self, dataset, name):
-    iterator = dataset_ops.make_one_shot_iterator(dataset)
-    next_element = iterator.get_next()
 
-    with session.Session() as sess:
-      # Run 10 steps to warm up the session caches before taking the first
-      # measurement. Additionally, 10 is the default num_experiments for
-      # ChooseFastestDataset.
-      for _ in range(10):
-        sess.run(next_element.op)
-      deltas = []
-      for _ in range(50):
-        start = time.time()
-        for _ in range(50):
-          sess.run(next_element.op)
-        end = time.time()
-        deltas.append(end - start)
-
-      median_wall_time = np.median(deltas) / 100
-      self.report_benchmark(iters=100, wall_time=median_wall_time, name=name)
+    self.run_and_report_benchmark(
+        dataset=dataset,
+        num_elements=100,
+        iters=100,
+        warmup=True,
+        name=name
+    )
 
 
 if __name__ == "__main__":
-  test.main()
+  benchmark_base.test.main()

--- a/tensorflow/python/data/experimental/benchmarks/map_and_batch_benchmark.py
+++ b/tensorflow/python/data/experimental/benchmarks/map_and_batch_benchmark.py
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Benchmarks for `tf.data.experimental.map_and_batch()`."""
+"""Benchmarks for `tf.data.experimental.map_and_batch()`.
+
+NOTE: Eager support is not added to these benchmarks as the `map_and_batch`
+  functionality is being deprecated.
+"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -70,7 +74,8 @@ class MapAndBatchBenchmark(test.Benchmark):
           # Use a C++ callable to minimize the Python overhead in the benchmark.
           callable_opts = config_pb2.CallableOptions()
           callable_opts.target.append(next_element.op.name)
-          op_callable = sess._make_callable_from_options(callable_opts)  # pylint: disable=protected-access
+          op_callable = sess._make_callable_from_options(  # pylint: disable=protected-access
+              callable_opts)
 
           # Run five steps to warm up the session caches before taking the
           # first measurement.

--- a/tensorflow/python/data/experimental/benchmarks/map_and_batch_benchmark.py
+++ b/tensorflow/python/data/experimental/benchmarks/map_and_batch_benchmark.py
@@ -55,7 +55,7 @@ class MapAndBatchBenchmark(benchmark_base.DatasetBenchmarkBase):
 
         self.run_and_report_benchmark(
             dataset=dataset,
-            num_elements=100,
+            num_elements=batch_size,
             iters=100,
             warmup=True,
             name="num_elements_%d_batch_size_%d" % (np.prod(shape), batch_size)

--- a/tensorflow/python/data/experimental/benchmarks/map_and_batch_benchmark.py
+++ b/tensorflow/python/data/experimental/benchmarks/map_and_batch_benchmark.py
@@ -12,36 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Benchmarks for `tf.data.experimental.map_and_batch()`.
-
-NOTE: Eager support is not added to these benchmarks as the `map_and_batch`
-  functionality is being deprecated.
-"""
+"""Benchmarks for `tf.data.experimental.map_and_batch()`."""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
 import hashlib
 import itertools
-import time
 
 import numpy as np
 
 from tensorflow.core.protobuf import config_pb2
-from tensorflow.python.client import session
 from tensorflow.python.data.experimental.ops import batching
+from tensorflow.python.data.benchmarks import benchmark_base
 from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.framework import constant_op
-from tensorflow.python.framework import dtypes
-from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import random_ops
-from tensorflow.python.platform import test
 
 _NUMPY_RANDOM_SEED = 42
 
 
-class MapAndBatchBenchmark(test.Benchmark):
+class MapAndBatchBenchmark(benchmark_base.DatasetBenchmarkBase):
   """Benchmarks for `tf.data.experimental.map_and_batch()`."""
 
   def benchmark_map_and_batch(self):
@@ -49,55 +41,25 @@ class MapAndBatchBenchmark(test.Benchmark):
     shapes = [(), (10,), (10, 10), (10, 10, 10), (224, 224, 3)]
     batch_size_values = [1, 32, 64, 128, 1024]
 
-    shape_placeholder = array_ops.placeholder(dtypes.int64, shape=[None])
-    batch_size_placeholder = array_ops.placeholder(dtypes.int64, shape=[])
-
-    dataset = dataset_ops.Dataset.range(1000000000)
-
-    dense_value = random_ops.random_normal(shape=shape_placeholder)
-
-    dataset = dataset.apply(batching.map_and_batch(
-        lambda _: dense_value, batch_size_placeholder))
-    options = dataset_ops.Options()
-    options.experimental_optimization.apply_default_optimizations = False
-    dataset = dataset.with_options(options)
-    iterator = dataset_ops.make_initializable_iterator(dataset)
-    next_element = iterator.get_next()
-
     for shape in shapes:
       for batch_size in batch_size_values:
 
-        with session.Session() as sess:
-          sess.run(iterator.initializer, feed_dict={
-              shape_placeholder: shape, batch_size_placeholder: batch_size})
+        dataset = dataset_ops.Dataset.range(1000000000)
+        dense_value = random_ops.random_normal(shape=shape)
 
-          # Use a C++ callable to minimize the Python overhead in the benchmark.
-          callable_opts = config_pb2.CallableOptions()
-          callable_opts.target.append(next_element.op.name)
-          op_callable = sess._make_callable_from_options(  # pylint: disable=protected-access
-              callable_opts)
+        dataset = dataset.apply(batching.map_and_batch(
+            lambda _: dense_value, batch_size))
+        options = dataset_ops.Options()
+        options.experimental_optimization.apply_default_optimizations = False
+        dataset = dataset.with_options(options)
 
-          # Run five steps to warm up the session caches before taking the
-          # first measurement.
-          for _ in range(5):
-            op_callable()
-          deltas = []
-          overall_start = time.time()
-          # Run at least five repetitions and for at least five seconds.
-          while len(deltas) < 5 or time.time() - overall_start < 5.0:
-            start = time.time()
-            for _ in range(100):
-              op_callable()
-            end = time.time()
-            deltas.append(end - start)
-          del op_callable
-
-        median_wall_time = np.median(deltas) / 100.0
-        iters = len(deltas) * 100
-
-        self.report_benchmark(
-            iters=iters, wall_time=median_wall_time,
-            name="num_elements_%d_batch_size_%d" % (np.prod(shape), batch_size))
+        self.run_and_report_benchmark(
+            dataset=dataset,
+            num_elements=100,
+            iters=100,
+            warmup=True,
+            name="num_elements_%d_batch_size_%d" % (np.prod(shape), batch_size)
+        )
 
   def benchmark_map_and_batch_chaining_versus_fusing(self):
     """Compares the performance of chaining and fusing map and batch.
@@ -148,54 +110,34 @@ class MapAndBatchBenchmark(test.Benchmark):
             (element_size * batch_size) // min(num_calls, inter_op))
         # By default the chained map().batch() calls will not be fused.
         chained_dataset = make_dataset(element_size, num_calls, batch_size)
-        chained_iterator = dataset_ops.make_one_shot_iterator(chained_dataset)
-        chained_get_next = chained_iterator.get_next()
-        chained_deltas = []
-        with session.Session(
-            config=config_pb2.ConfigProto(
-                inter_op_parallelism_threads=inter_op,
-                use_per_session_threads=True)) as sess:
-          for _ in range(5):
-            sess.run(chained_get_next.op)
-          for _ in range(num_iters):
-            start = time.time()
-            sess.run(chained_get_next.op)
-            end = time.time()
-            chained_deltas.append(end - start)
+        session_config = config_pb2.ConfigProto(
+            inter_op_parallelism_threads=inter_op,
+            use_per_session_threads=True)
 
-        self.report_benchmark(
+        self.run_and_report_benchmark(
+            dataset=chained_dataset,
             iters=num_iters,
-            wall_time=np.median(chained_deltas),
+            num_elements=batch_size,
+            warmup=True,
+            session_config=session_config,
             name=name("chained", label, num_calls, inter_op, element_size,
-                      batch_size))
+                      batch_size)
+        )
 
         # Apply an option to the default dataset that will fuse map().batch().
         options = dataset_ops.Options()
         options.experimental_optimization.map_and_batch_fusion = True
         fused_dataset = chained_dataset.with_options(options)
-        fused_iterator = dataset_ops.make_one_shot_iterator(fused_dataset)
-        fused_get_next = fused_iterator.get_next()
-        fused_deltas = []
-        with session.Session(
-            config=config_pb2.ConfigProto(
-                inter_op_parallelism_threads=inter_op,
-                use_per_session_threads=True)) as sess:
 
-          for _ in range(5):
-            sess.run(fused_get_next.op)
-          for _ in range(num_iters):
-            start = time.time()
-            sess.run(fused_get_next.op)
-            end = time.time()
-            fused_deltas.append(end - start)
-
-        self.report_benchmark(
+        self.run_and_report_benchmark(
+            dataset=fused_dataset,
             iters=num_iters,
-            wall_time=np.median(fused_deltas),
+            num_elements=batch_size,
+            warmup=True,
+            session_config=session_config,
             name=name("fused", label, num_calls, inter_op, element_size,
-                      batch_size))
-
-      print()
+                      batch_size)
+        )
 
     np.random.seed(_NUMPY_RANDOM_SEED)
     benchmark("Sequential element size evaluation", seq_elem_size_series)
@@ -207,4 +149,4 @@ class MapAndBatchBenchmark(test.Benchmark):
 
 
 if __name__ == "__main__":
-  test.main()
+  benchmark_base.test.main()

--- a/tensorflow/python/data/experimental/benchmarks/map_defun_benchmark.py
+++ b/tensorflow/python/data/experimental/benchmarks/map_defun_benchmark.py
@@ -54,9 +54,9 @@ class MapDefunBenchmark(benchmark_base.DatasetBenchmarkBase):
     def fn(x):
       return array_ops.identity(x)
 
-    base = math_ops.range(100)
+    base = math_ops.range(10000)
     for input_size in [10, 100, 1000, 10000]:
-      num_iters = 100000 // input_size
+      num_iters = 10000 // input_size
       map_defun_op = map_defun.map_defun(defun, [base], [dtypes.int32], [()])
       map_fn_op = map_fn.map_fn(fn, base)
 

--- a/tensorflow/python/data/experimental/benchmarks/map_defun_benchmark.py
+++ b/tensorflow/python/data/experimental/benchmarks/map_defun_benchmark.py
@@ -17,37 +17,32 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import time
 
-from tensorflow.python.client import session
 from tensorflow.python.data.experimental.ops import map_defun
+from tensorflow.python.data.benchmarks import benchmark_base
 from tensorflow.python.eager import function
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import tensor_spec
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import map_fn
 from tensorflow.python.ops import math_ops
-from tensorflow.python.platform import test
 
 
-# TODO(b/119837791): Add eager benchmarks too.
-class MapDefunBenchmark(test.Benchmark):
+class MapDefunBenchmark(benchmark_base.DatasetBenchmarkBase):
   """Benchmarks for MapDefunOp."""
 
   def _run(self, op, name=None, num_iters=3000):
-    with session.Session() as sess:
-      for _ in range(5):
-        sess.run(op)
-      start = time.time()
-      for _ in range(num_iters):
-        sess.run(op)
-      end = time.time()
-      mean_us = (end - start) * 1e6 / num_iters
-      self.report_benchmark(
-          name=name,
-          iters=num_iters,
-          wall_time=mean_us,
-          extras={"examples_per_sec": num_iters / (end - start)})
+
+    wall_time = self.run_op_benchmark(
+        op=op,
+        iters=num_iters,
+        warmup=True
+    )
+    self.report_benchmark(
+        name=name,
+        iters=num_iters,
+        wall_time=wall_time,
+        extras={"examples_per_sec": float(1 / wall_time)})
 
   def benchmark_defun_vs_map_fn(self):
     """Benchmarks to compare the performance of MapDefun vs tf.map_fn."""
@@ -66,10 +61,16 @@ class MapDefunBenchmark(test.Benchmark):
       map_fn_op = map_fn.map_fn(fn, base)
 
       self._run(
-          map_defun_op, "with_defun_size_%d" % input_size, num_iters=num_iters)
+          op=map_defun_op,
+          name="with_defun_size_%d" % input_size,
+          num_iters=num_iters
+      )
       self._run(
-          map_fn_op, "without_defun_size_%d" % input_size, num_iters=num_iters)
+          op=map_fn_op,
+          name="without_defun_size_%d" % input_size,
+          num_iters=num_iters
+      )
 
 
 if __name__ == "__main__":
-  test.main()
+  benchmark_base.test.main()

--- a/tensorflow/python/data/experimental/benchmarks/map_defun_benchmark.py
+++ b/tensorflow/python/data/experimental/benchmarks/map_defun_benchmark.py
@@ -38,11 +38,13 @@ class MapDefunBenchmark(benchmark_base.DatasetBenchmarkBase):
         iters=num_iters,
         warmup=True
     )
+    zero_division_delta = 1e-100
+    wall_time = wall_time + zero_division_delta
     self.report_benchmark(
         name=name,
         iters=num_iters,
         wall_time=wall_time,
-        extras={"examples_per_sec": float(1 / wall_time)})
+        extras={"examples_per_sec": 1 / float(wall_time)})
 
   def benchmark_defun_vs_map_fn(self):
     """Benchmarks to compare the performance of MapDefun vs tf.map_fn."""

--- a/tensorflow/python/data/experimental/benchmarks/parallel_interleave_benchmark.py
+++ b/tensorflow/python/data/experimental/benchmarks/parallel_interleave_benchmark.py
@@ -17,16 +17,12 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import time
-
-import numpy as np
 
 from tensorflow.python.data.experimental.ops import interleave_ops
 from tensorflow.python.data.experimental.ops import stats_aggregator
 from tensorflow.python.data.experimental.ops import testing
+from tensorflow.python.data.benchmarks import benchmark_base
 from tensorflow.python.data.ops import dataset_ops
-from tensorflow.python.framework import ops
-from tensorflow.python.platform import test
 
 NON_PARALLEL = "non_parallel"
 EXPERIMENTAL_PARALLEL = "experimental_parallel"
@@ -65,7 +61,7 @@ def _make_fake_dataset_fn(initial_delay_us, remainder_delay_us):
   return fake_dataset_fn
 
 
-class ParallelInterleaveBenchmark(test.Benchmark):
+class ParallelInterleaveBenchmark(benchmark_base.DatasetBenchmarkBase):
   """Benchmarks for `tf.data.experimental.parallel_interleave()`."""
 
   def apply_interleave(self, interleave_version, dataset, interleave_fn,
@@ -115,13 +111,13 @@ class ParallelInterleaveBenchmark(test.Benchmark):
       opts.experimental_stats.aggregator = aggregator
       ds = ds.with_options(opts)
 
-    ds = ds.skip(num_elements)
-    deltas = []
-    for _ in range(iters):
-      start = time.time()
-      next(iter(ds))
-      deltas.append(time.time() - start)
-    self.report_benchmark(iters=iters, wall_time=np.median(deltas), name=name)
+    self.run_and_report_benchmark(
+        dataset=dataset,
+        num_elements=num_elements,
+        iters=iters,
+        warmup=True,
+        name=name
+    )
 
   def benchmark_remote_file_simulation(self):
     for version in [EXPERIMENTAL_PARALLEL, CORE_PARALLEL]:
@@ -174,5 +170,4 @@ class ParallelInterleaveBenchmark(test.Benchmark):
 
 
 if __name__ == "__main__":
-  ops.enable_eager_execution()
-  test.main()
+  benchmark_base.test.main()

--- a/tensorflow/python/data/experimental/benchmarks/parallel_interleave_benchmark.py
+++ b/tensorflow/python/data/experimental/benchmarks/parallel_interleave_benchmark.py
@@ -103,13 +103,13 @@ class ParallelInterleaveBenchmark(benchmark_base.DatasetBenchmarkBase):
                  num_parallel_calls=None,
                  attach_stats_aggregator=False,
                  name=None):
-    ds = self.make_dataset(interleave_version, initial_delay_us,
-                           remainder_delay_us, cycle_length, num_parallel_calls)
+    dataset = self.make_dataset(interleave_version, initial_delay_us,
+                                remainder_delay_us, cycle_length, num_parallel_calls)
     if attach_stats_aggregator:
       aggregator = stats_aggregator.StatsAggregator()
       opts = dataset_ops.Options()
       opts.experimental_stats.aggregator = aggregator
-      ds = ds.with_options(opts)
+      dataset = dataset.with_options(opts)
 
     self.run_and_report_benchmark(
         dataset=dataset,

--- a/tensorflow/python/data/experimental/benchmarks/parallel_interleave_benchmark.py
+++ b/tensorflow/python/data/experimental/benchmarks/parallel_interleave_benchmark.py
@@ -90,8 +90,13 @@ class ParallelInterleaveBenchmark(benchmark_base.DatasetBenchmarkBase):
                    num_parallel_calls=None):
     dataset = dataset_ops.Dataset.range(1).repeat()
     interleave_fn = _make_fake_dataset_fn(initial_delay, remainder_delay)
-    return self.apply_interleave(interleave_version, dataset, interleave_fn,
-                                 cycle_length, num_parallel_calls)
+    return self.apply_interleave(
+        interleave_version=interleave_version,
+        dataset=dataset,
+        interleave_fn=interleave_fn,
+        cycle_length=cycle_length,
+        num_parallel_calls=num_parallel_calls
+    )
 
   def _benchmark(self,
                  interleave_version,
@@ -103,8 +108,13 @@ class ParallelInterleaveBenchmark(benchmark_base.DatasetBenchmarkBase):
                  num_parallel_calls=None,
                  attach_stats_aggregator=False,
                  name=None):
-    dataset = self.make_dataset(interleave_version, initial_delay_us,
-                                remainder_delay_us, cycle_length, num_parallel_calls)
+    dataset = self.make_dataset(
+        interleave_version=interleave_version,
+        initial_delay=initial_delay_us,
+        remainder_delay=remainder_delay_us,
+        cycle_length=cycle_length,
+        num_parallel_calls=num_parallel_calls
+    )
     if attach_stats_aggregator:
       aggregator = stats_aggregator.StatsAggregator()
       opts = dataset_ops.Options()
@@ -122,7 +132,7 @@ class ParallelInterleaveBenchmark(benchmark_base.DatasetBenchmarkBase):
   def benchmark_remote_file_simulation(self):
     for version in [EXPERIMENTAL_PARALLEL, CORE_PARALLEL]:
       self._benchmark(
-          version,
+          interleave_version=version,
           initial_delay_us=100 * 1000,
           remainder_delay_us=1000,
           num_elements=5000,
@@ -131,14 +141,17 @@ class ParallelInterleaveBenchmark(benchmark_base.DatasetBenchmarkBase):
   def benchmark_fast_input(self):
     for version in [EXPERIMENTAL_PARALLEL, CORE_PARALLEL]:
       self._benchmark(
-          version, num_elements=200000, name="fast_input_" + version)
+          interleave_version=version,
+          num_elements=200000,
+          name="fast_input_" + version
+      )
 
   # Measure the overhead of parallel interleaves compared to non-parallel
   # interleave.
   def benchmark_single_cycle(self):
     for version in [NON_PARALLEL, EXPERIMENTAL_PARALLEL, CORE_PARALLEL]:
       self._benchmark(
-          version,
+          interleave_version=version,
           cycle_length=1,
           num_elements=200000,
           name="single_cycle_" + version)
@@ -147,7 +160,7 @@ class ParallelInterleaveBenchmark(benchmark_base.DatasetBenchmarkBase):
   # cannot be compared here because it sets num_parallel_calls = cycle_length.
   def benchmark_single_parallel_call(self):
     self._benchmark(
-        CORE_PARALLEL,
+        interleave_version=CORE_PARALLEL,
         num_elements=200000,
         num_parallel_calls=1,
         name="single_parallel_call_" + CORE_PARALLEL)
@@ -155,14 +168,14 @@ class ParallelInterleaveBenchmark(benchmark_base.DatasetBenchmarkBase):
   def benchmark_long_cycle(self):
     for version in [EXPERIMENTAL_PARALLEL, CORE_PARALLEL]:
       self._benchmark(
-          version,
+          interleave_version=version,
           cycle_length=1000,
           num_elements=100000,
           name="long_cycle_" + version)
 
   def benchmark_stats(self):
     self._benchmark(
-        CORE_PARALLEL,
+        interleave_version=CORE_PARALLEL,
         cycle_length=50,
         num_elements=1000,
         name="stats",

--- a/tensorflow/python/data/experimental/benchmarks/rejection_resample_benchmark.py
+++ b/tensorflow/python/data/experimental/benchmarks/rejection_resample_benchmark.py
@@ -17,43 +17,14 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import time
 
 import numpy as np
-from six.moves import xrange  # pylint: disable=redefined-builtin
-
-from tensorflow.python.client import session
 from tensorflow.python.data.experimental.ops import resampling
+from tensorflow.python.data.benchmarks import benchmark_base
 from tensorflow.python.data.ops import dataset_ops
-from tensorflow.python.platform import test
 
 
-def _time_resampling(data_np, target_dist, init_dist, num_to_sample):  # pylint: disable=missing-docstring
-  dataset = dataset_ops.Dataset.from_tensor_slices(data_np).repeat()
-
-  # Reshape distribution via rejection sampling.
-  dataset = dataset.apply(
-      resampling.rejection_resample(
-          class_func=lambda x: x,
-          target_dist=target_dist,
-          initial_dist=init_dist,
-          seed=142))
-
-  options = dataset_ops.Options()
-  options.experimental_optimization.apply_default_optimizations = False
-  dataset = dataset.with_options(options)
-  get_next = dataset_ops.make_one_shot_iterator(dataset).get_next()
-
-  with session.Session() as sess:
-    start_time = time.time()
-    for _ in xrange(num_to_sample):
-      sess.run(get_next)
-    end_time = time.time()
-
-  return end_time - start_time
-
-
-class RejectionResampleBenchmark(test.Benchmark):
+class RejectionResampleBenchmark(benchmark_base.DatasetBenchmarkBase):
   """Benchmarks for `tf.data.experimental.rejection_resample()`."""
 
   def benchmark_resample_performance(self):
@@ -63,12 +34,35 @@ class RejectionResampleBenchmark(test.Benchmark):
     # We don't need many samples to test a dirac-delta target distribution
     num_samples = 1000
     data_np = np.random.choice(num_classes, num_samples, p=init_dist)
+    # Prepare the dataset
+    dataset = dataset_ops.Dataset.from_tensor_slices(data_np).repeat()
+    # Reshape distribution via rejection sampling.
+    dataset = dataset.apply(
+        resampling.rejection_resample(
+            class_func=lambda x: x,
+            target_dist=target_dist,
+            initial_dist=init_dist,
+            seed=142
+        )
+    )
+    options = dataset_ops.Options()
+    options.experimental_optimization.apply_default_optimizations = False
+    dataset = dataset.with_options(options)
 
-    resample_time = _time_resampling(
-        data_np, target_dist, init_dist, num_to_sample=1000)
+    wall_time = self.run_benchmark(
+        dataset=dataset,
+        num_elements=num_samples,
+        iters=10,
+        warmup=True
+    )
+    resample_time = wall_time * num_samples
 
-    self.report_benchmark(iters=1000, wall_time=resample_time, name="resample")
+    self.report_benchmark(
+        iters=10,
+        wall_time=resample_time,
+        name="resample_{}".format(num_samples)
+    )
 
 
 if __name__ == "__main__":
-  test.main()
+  benchmark_base.test.main()


### PR DESCRIPTION
This PR is a follow up of https://github.com/tensorflow/tensorflow/pull/46761 and extends the eager mode support to the remaining subset of experimental benchmarks.

Sample result:
```
# DATASET Based benchmarking
entry {
  name: "ParallelInterleaveBenchmark.single_cycle_experimental_parallel.eager"
  iters: 100
  wall_time: 9.162362813949585e-06
  extras {
    key: "num_elements"
    value {
      double_value: 200000.0
    }
  }
}

entry {
  name: "ParallelInterleaveBenchmark.single_cycle_core_parallel.eager"
  iters: 100
  wall_time: 6.957079768180847e-06
  extras {
    key: "num_elements"
    value {
      double_value: 200000.0
    }
  }
}

# OP based benchmarking

entry {
  name: "MapDefunBenchmark.with_defun_size_10000"
  iters: 1
  wall_time: 7.152557373046875e-07
  extras {
    key: "examples_per_sec"
    value {
      double_value: 1398101.3333333333
    }
  }
}

entry {
  name: "MapDefunBenchmark.without_defun_size_10000"
  iters: 1
  wall_time: 8.392333984375e-05
  extras {
    key: "examples_per_sec"
    value {
      double_value: 11915.636363636364
    }
  }
}
```

cc: @jsimsa 
