### PR TITLE
Thrown out ValueError when alpha=None is passed for tf.keras.layers.LeakyReLU

### DIFF
--- a/tensorflow/python/keras/layers/advanced_activations.py
+++ b/tensorflow/python/keras/layers/advanced_activations.py
@@ -209,6 +209,9 @@ class ELU(Layer):
 
   def __init__(self, alpha=1.0, **kwargs):
     super(ELU, self).__init__(**kwargs)
+    if alpha is None:
+      raise ValueError('alpha of ELU layer '
+                       'cannot be None. Required a float')
     self.supports_masking = True
     self.alpha = K.cast_to_floatx(alpha)
 

--- a/tensorflow/python/keras/layers/advanced_activations.py
+++ b/tensorflow/python/keras/layers/advanced_activations.py
@@ -71,6 +71,9 @@ class LeakyReLU(Layer):
 
   def __init__(self, alpha=0.3, **kwargs):
     super(LeakyReLU, self).__init__(**kwargs)
+    if alpha is None:
+      raise ValueError('alpha of leaky Relu layer '
+                       'cannot be None. Required a float')
     self.supports_masking = True
     self.alpha = K.cast_to_floatx(alpha)
 

--- a/tensorflow/python/keras/layers/advanced_activations_test.py
+++ b/tensorflow/python/keras/layers/advanced_activations_test.py
@@ -109,9 +109,19 @@ class AdvancedActivationsTest(keras_parameterized.TestCase):
     model.fit(np.ones((10, 10)), np.ones((10, 1)), batch_size=2)
 
   def test_leaky_relu_with_invalid_alpha(self):
+    # Test case for GitHub issue 46993.
     with self.assertRaisesRegex(
         ValueError, 'alpha of leaky Relu layer cannot be None'):
       testing_utils.layer_test(keras.layers.LeakyReLU,
+                               kwargs={'alpha': None},
+                               input_shape=(2, 3, 4),
+                               supports_masking=True)
+
+  def test_leaky_elu_with_invalid_alpha(self):
+    # Test case for GitHub issue 46993.
+    with self.assertRaisesRegex(
+        ValueError, 'alpha of ELU layer cannot be None'):
+      testing_utils.layer_test(keras.layers.ELU,
                                kwargs={'alpha': None},
                                input_shape=(2, 3, 4),
                                supports_masking=True)

--- a/tensorflow/python/keras/layers/advanced_activations_test.py
+++ b/tensorflow/python/keras/layers/advanced_activations_test.py
@@ -108,6 +108,14 @@ class AdvancedActivationsTest(keras_parameterized.TestCase):
         run_eagerly=testing_utils.should_run_eagerly())
     model.fit(np.ones((10, 10)), np.ones((10, 1)), batch_size=2)
 
+  def test_leaky_relu_with_invalid_alpha(self):
+    with self.assertRaisesRegex(
+        ValueError, 'alpha of leaky Relu layer cannot be None'):
+      testing_utils.layer_test(keras.layers.LeakyReLU,
+                               kwargs={'alpha': None},
+                               input_shape=(2, 3, 4),
+                               supports_masking=True)
+
 
 if __name__ == '__main__':
   test.main()


### PR DESCRIPTION
This PR tries to address the issue raised in #46993 where
incorrect nan value is returned when alpha=None is passed for
tf.keras.layers.LeakyReLU. The nan could be misleading to users.

This PR address the issue and throw out ValueError instead.

This PR fixes #46993.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
