### PR TITLE
Remove the sources containing the models from the TFLM static lib.

### DIFF
--- a/tensorflow/lite/micro/benchmarks/Makefile.inc
+++ b/tensorflow/lite/micro/benchmarks/Makefile.inc
@@ -3,7 +3,8 @@ tensorflow/lite/micro/benchmarks/keyword_benchmark.cc \
 tensorflow/lite/micro/benchmarks/keyword_scrambled_model_data.cc
 
 KEYWORD_BENCHMARK_HDRS := \
-tensorflow/lite/micro/benchmarks/keyword_scrambled_model_data.h
+tensorflow/lite/micro/benchmarks/keyword_scrambled_model_data.h \
+tensorflow/lite/micro/benchmarks/micro_benchmark.h
 
 PERSON_DETECTION_BENCHMARK_SRCS := \
 tensorflow/lite/micro/benchmarks/person_detection_benchmark.cc \
@@ -20,4 +21,3 @@ $(KEYWORD_BENCHMARK_SRCS),$(KEYWORD_BENCHMARK_HDRS)))
 
 $(eval $(call microlite_test,person_detection_benchmark,\
 $(PERSON_DETECTION_BENCHMARK_SRCS),$(PERSON_DETECTION_BENCHMARK_HDRS)))
-

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -366,9 +366,7 @@ $(wildcard tensorflow/lite/micro/testing/*.h)
 
 MICROLITE_CC_BASE_SRCS := \
 $(wildcard tensorflow/lite/micro/*.cc) \
-$(wildcard tensorflow/lite/micro/benchmarks/*model_data.cc) \
 $(wildcard tensorflow/lite/micro/memory_planner/*.cc) \
-$(wildcard tensorflow/lite/micro/testing/*model.cc) \
 tensorflow/lite/c/common.c \
 tensorflow/lite/core/api/error_reporter.cc \
 tensorflow/lite/core/api/flatbuffer_conversions.cc \
@@ -665,9 +663,55 @@ $(BINDIR)%.bin: $(BINDIR)%
 	@mkdir -p $(dir $@)
 	$(OBJCOPY) $< $@ -O binary
 
-# Generate standalone makefile projects for all of the test targets.
+
+# Some tests have additional dependencies (beyond libtensorflow-microlite.a) and
+# those need to be explicitly specified with their own individual call to the
+# microlite_test helper function. For these tests, we also need to make sure to
+# not add targets for them if they have been excluded as part of the target
+# specific Makefile.
+EXPLICITLY_SPECIFIED_TEST:= tensorflow/lite/micro/memory_arena_threshold_test.cc
+ifneq ($(findstring $(EXPLICITLY_SPECIFIED_TEST),$(MICROLITE_TEST_SRCS)),)
+  MICROLITE_TEST_SRCS := $(filter-out $(EXPLICITLY_SPECIFIED_TEST), $(MICROLITE_TEST_SRCS))
+  EXPLICITLY_SPECIFIED_TEST_SRCS := \
+  $(EXPLICITLY_SPECIFIED_TEST) \
+  tensorflow/lite/micro/benchmarks/keyword_scrambled_model_data.cc \
+  tensorflow/lite/micro/testing/test_conv_model.cc
+  EXPLICITLY_SPECIFIED_TEST_HDRS := \
+  tensorflow/lite/micro/benchmarks/keyword_scrambled_model_data.h \
+  tensorflow/lite/micro/testing/test_conv_model.h
+  $(eval $(call microlite_test,memory_arena_threshold_test,\
+  $(EXPLICITLY_SPECIFIED_TEST_SRCS),$(EXPLICITLY_SPECIFIED_TEST_HDRS)))
+endif
+
+EXPLICITLY_SPECIFIED_TEST:= tensorflow/lite/micro/micro_allocator_test.cc
+ifneq ($(findstring $(EXPLICITLY_SPECIFIED_TEST),$(MICROLITE_TEST_SRCS)),)
+  MICROLITE_TEST_SRCS := $(filter-out $(EXPLICITLY_SPECIFIED_TEST), $(MICROLITE_TEST_SRCS))
+  EXPLICITLY_SPECIFIED_TEST_SRCS := \
+  $(EXPLICITLY_SPECIFIED_TEST) \
+  tensorflow/lite/micro/testing/test_conv_model.cc
+  EXPLICITLY_SPECIFIED_TEST_HDRS := \
+  tensorflow/lite/micro/testing/test_conv_model.h
+  $(eval $(call microlite_test,micro_allocator_test,\
+  $(EXPLICITLY_SPECIFIED_TEST_SRCS),$(EXPLICITLY_SPECIFIED_TEST_HDRS)))
+endif
+
+EXPLICITLY_SPECIFIED_TEST:= tensorflow/lite/micro/recording_micro_allocator_test.cc
+ifneq ($(findstring $(EXPLICITLY_SPECIFIED_TEST),$(MICROLITE_TEST_SRCS)),)
+  MICROLITE_TEST_SRCS := $(filter-out $(EXPLICITLY_SPECIFIED_TEST), $(MICROLITE_TEST_SRCS))
+  EXPLICITLY_SPECIFIED_TEST_SRCS := \
+  $(EXPLICITLY_SPECIFIED_TEST) \
+  tensorflow/lite/micro/testing/test_conv_model.cc
+  EXPLICITLY_SPECIFIED_TEST_HDRS := \
+  tensorflow/lite/micro/testing/test_conv_model.h
+  $(eval $(call microlite_test,recording_micro_allocator_test,\
+  $(EXPLICITLY_SPECIFIED_TEST_SRCS),$(EXPLICITLY_SPECIFIED_TEST_HDRS)))
+endif
+
+# For all the tests that do not have any additional dependencies, we can
+# add a make target in a common way.
 $(foreach TEST_TARGET,$(filter-out tensorflow/lite/micro/kernels/%,$(MICROLITE_TEST_SRCS)),\
 $(eval $(call microlite_test,$(notdir $(basename $(TEST_TARGET))),$(TEST_TARGET))))
+
 $(foreach TEST_TARGET,$(filter tensorflow/lite/micro/kernels/%,$(MICROLITE_TEST_SRCS)),\
 $(eval $(call microlite_test,kernel_$(notdir $(basename $(TEST_TARGET))),$(TEST_TARGET))))
 


### PR DESCRIPTION
These sources are only needed for specific tests and are now explicitly specified as part of creating a test target.

From this change onwards, we will explicitly create test targets for tests that depend on sources outside of libtensorflow-microlite.a. This avoids putting unnecessary files into MICROLITE_CC_SRCS.

Manually verified that the following command does not error out:
```
make -f tensorflow/lite/micro/tools/make/Makefile generate_keyword_benchmark_make_project && cd tensorflow/lite/micro/tools/make/gen/linux_x86_64_default/prj/keyword_benchmark/make/ && make -j8
```

Fixes #46860
