### PR TITLE
Deprecate s3 file system

### DIFF
--- a/tensorflow/core/platform/s3/s3_file_system.cc
+++ b/tensorflow/core/platform/s3/s3_file_system.cc
@@ -1195,6 +1195,6 @@ Status S3FileSystem::HasAtomicMove(const string& path, bool* has_atomic_move) {
   return Status::OK();
 }
 
-REGISTER_FILE_SYSTEM("s3", RetryingS3FileSystem);
+REGISTER_LEGACY_FILE_SYSTEM("s3", RetryingS3FileSystem);
 
 }  // namespace tensorflow


### PR DESCRIPTION
This PR is part of the effort to switch to modular file system support
by deprecates s3 file system and direct user to use modular file system
from tensorflow-io instead.

A `TF_ENABLE_LEGACY_FILESYSTEM=1` will allow the usage of legacy hdfs file
system the same way as before (a warning will be displayed).

/cc @mihaimaruseac @vnvo2409  @tensorflow/sig-io-maintainers @burgerkingeater 

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>