### PR TITLE
Prefer std::copy_n to naive for loop

### DIFF
--- a/tensorflow/core/kernels/ragged_gather_op.cc
+++ b/tensorflow/core/kernels/ragged_gather_op.cc
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+#include <algorithm>
 #include <limits>
 #include <memory>
 #include <string>
@@ -41,9 +42,7 @@ void WriteValueSlices(
   int out_pos = 0;
   for (const auto& slice : value_slices) {
     for (int i = slice.first; i < slice.second; ++i) {
-      for (int j = 0; j < value_size; ++j) {
-        values(out_pos, j) = params_dense_values(i, j);
-      }
+      std::copy_n(&params_dense_values(i, 0), value_size, &values(out_pos, 0));
       ++out_pos;
     }
   }

--- a/tensorflow/core/kernels/ragged_tensor_from_variant_op.cc
+++ b/tensorflow/core/kernels/ragged_tensor_from_variant_op.cc
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+#include <algorithm>
 #include <utility>
 #include <vector>
 
@@ -183,9 +184,8 @@ Status NestedStackRaggedTensors(
     }
     for (int j = 0; j < ragged_components[i].values().dim_size(0);
          j++, values_index++) {
-      for (int k = 0; k < num_inner_elements; k++) {
-        output_values_flat(values_index, k) = component_values_flat(j, k);
-      }
+      std::copy_n(&component_values_flat(j, 0), num_inner_elements,
+                  &output_values_flat(values_index, 0));
     }
   }
   return Status::OK();

--- a/tensorflow/core/kernels/ragged_tensor_to_variant_op.cc
+++ b/tensorflow/core/kernels/ragged_tensor_to_variant_op.cc
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+#include <algorithm>
 #include <utility>
 #include <vector>
 
@@ -62,10 +63,9 @@ Status UnbatchRaggedZerothDim(
           Tensor(DataTypeToEnum<VALUE_TYPE>::value, values_shape));
       auto ragged_component_values_flat =
           (*ragged_components)[i].mutable_values()->flat<VALUE_TYPE>();
-      for (int j = 0; j < num_values * num_inner_elems; j++) {
-        ragged_component_values_flat(j) =
-            batched_flat(j + start * num_inner_elems);
-      }
+      std::copy_n(&batched_flat(start * num_inner_elems),
+                  num_values * num_inner_elems,
+                  ragged_component_values_flat.data());
     }
     return Status::OK();
   }
@@ -116,9 +116,9 @@ Status UnbatchRaggedZerothDim(
         Tensor(DataTypeToEnum<VALUE_TYPE>::value, values_shape));
     auto ragged_component_values_flat =
         (*ragged_components)[i].mutable_values()->flat<VALUE_TYPE>();
-    for (int j = 0; j < num_values * num_inner_elems; j++, value_index++) {
-      ragged_component_values_flat(j) = batched_flat(value_index);
-    }
+    std::copy_n(&batched_flat(value_index), num_values * num_inner_elems,
+                ragged_component_values_flat.data());
+    value_index += num_values * num_inner_elems;
   }
 
   return Status::OK();


### PR DESCRIPTION
Modern compiler is able to optimize (with -O1 or higher) std::copy_n to memmove for TriviallyCopyable type, which is usually faster, and fall back to naive for-loop for others. There is no reason to use naive for loop when trying to copy contiguous memory.