### PR TITLE
Fixed person_detection_example for esp32

### DIFF
--- a/tensorflow/lite/micro/examples/person_detection/Makefile.inc
+++ b/tensorflow/lite/micro/examples/person_detection/Makefile.inc
@@ -77,5 +77,10 @@ $(eval $(call microlite_test,detection_responder_test_int8,\
 $(DETECTION_RESPONDER_TEST_SRCS),$(DETECTION_RESPONDER_TEST_HDRS)))
 
 # Builds a standalone object recognition binary.
+ifneq ($(TARGET), esp)
 $(eval $(call microlite_test,person_detection_int8,\
 $(person_detection_SRCS),$(person_detection_HDRS)))
+else
+$(eval $(call microlite_test,person_detection,\
+$(person_detection_SRCS),$(person_detection_HDRS)))
+endif

--- a/tensorflow/lite/micro/examples/person_detection/esp/Makefile.inc
+++ b/tensorflow/lite/micro/examples/person_detection/esp/Makefile.inc
@@ -33,12 +33,12 @@ person_detection_ESP_PROJECT_FILES := \
   main/Kconfig.projbuild
 
 # Remap downloaded model files as if they were in tensorflow/lite/micro/examples/..
-MODEL_DOWNLOADS_DIR := tensorflow/lite/micro/tools/make/downloads/person_model_grayscale
-MODEL_EXAMPLES_DIR := tensorflow/lite/micro/examples/person_detection/person_model_grayscale
+MODEL_DOWNLOADS_DIR := tensorflow/lite/micro/tools/make/downloads/person_model_int8
+MODEL_EXAMPLES_DIR := tensorflow/lite/micro/examples/person_detection/person_model_int8
 person_detection_SRCS := $(patsubst $(MODEL_DOWNLOADS_DIR)/%,$(MODEL_EXAMPLES_DIR)/%,$(person_detection_SRCS))
 
 # Custom rule to transform downloaded model files
-$(PRJDIR)person_detection/esp-idf/main/person_model_grayscale/%: $(MODEL_DOWNLOADS_DIR)/%
+$(PRJDIR)person_detection/esp-idf/main/person_model_int8/%: $(MODEL_DOWNLOADS_DIR)/%
 	@mkdir -p $(dir $@)
 	@python tensorflow/lite/micro/tools/make/transform_source.py \
         --platform=esp \

--- a/tensorflow/lite/micro/tools/make/helper_functions.inc
+++ b/tensorflow/lite/micro/tools/make/helper_functions.inc
@@ -178,7 +178,7 @@ $(PRJDIR)$(3)/$(1)/Makefile: tensorflow/lite/micro/tools/make/templates/ceva/cev
 	sed -E 's#\%\{LD_FLAGS\}\%#$(6)#g' | \
 	sed -E 's#\%\{CXX_FLAGS\}\%#$(7)#g' | \
 	sed -E 's#\%\{CC_FLAGS\}\%#$(8)#g' > $$@
-	
+
 $(PRJDIR)$(3)/$(1)/%: tensorflow/lite/micro/tools/make/templates/ceva/%.tpl
 	@cp $$< $$@
 


### PR DESCRIPTION
1. Use int8 model
2. Avoid build issues with target rule: Changed the rule from person_detection_int8 to person_detection for esp
3. Treat uint8 camera buffer as int8
