### PR TITLE
Tensorlist bug fixes

### DIFF
--- a/tensorflow/core/framework/type_index.h
+++ b/tensorflow/core/framework/type_index.h
@@ -23,10 +23,7 @@ limitations under the License.
 #endif  // __GXX_RTTI
 
 #include "tensorflow/core/platform/types.h"
-
-#if defined(MACOS) || defined(TARGET_OS_MAC) || defined(PLATFORM_WINDOWS)
 #include "tensorflow/core/platform/hash.h"
-#endif  // defined(MACOS) || defined(TARGET_OS_MAC) || defined(PLATFORM_WINDOWS)
 
 namespace tensorflow {
 
@@ -62,15 +59,9 @@ class TypeIndex {
 
 #if defined(__GXX_RTTI) || defined(_CPPRTTI)
 
-#if defined(MACOS) || defined(TARGET_OS_MAC) || defined(PLATFORM_WINDOWS)
     // Use a hash based on the type name to avoid issues due to RTLD_LOCAL on
     // MacOS (b/156979412).
     return TypeIndex(Hash64(typeid(T).name()), typeid(T).name());
-#else
-    // Use the real type name if we have RTTI.
-    return TypeIndex(static_cast<uint64>(reinterpret_cast<intptr_t>(hash_bit)),
-                     typeid(T).name());
-#endif  // defined(MACOS) || defined(TARGET_OS_MAC) || defined(PLATFORM_WINDOWS)
 
 #else
 #if TARGET_OS_OSX

--- a/tensorflow/core/framework/variant_op_registry.cc
+++ b/tensorflow/core/framework/variant_op_registry.cc
@@ -52,6 +52,16 @@ std::unordered_set<string>* UnaryVariantOpRegistry::PersistentStringStorage() {
   return string_storage;
 }
 
+// Get a pointer to a global UnaryVariantOpRegistry object
+UnaryVariantOpRegistry* UnaryVariantOpRegistryGlobal() {
+  static UnaryVariantOpRegistry* global_unary_variant_op_registry = NULL;
+
+  if (global_unary_variant_op_registry == NULL) {
+    global_unary_variant_op_registry = new UnaryVariantOpRegistry;
+  }
+  return global_unary_variant_op_registry;
+}
+
 UnaryVariantOpRegistry::VariantDecodeFn* UnaryVariantOpRegistry::GetDecodeFn(
     StringPiece type_name) {
   auto found = decode_fns.find(type_name);

--- a/tensorflow/core/framework/variant_op_registry.h
+++ b/tensorflow/core/framework/variant_op_registry.h
@@ -60,6 +60,9 @@ enum VariantDeviceCopyDirection {
   DEVICE_TO_DEVICE = 3,
 };
 
+class UnaryVariantOpRegistry;
+extern UnaryVariantOpRegistry* UnaryVariantOpRegistryGlobal();
+
 class UnaryVariantOpRegistry {
  public:
   typedef std::function<bool(Variant*)> VariantDecodeFn;
@@ -174,9 +177,7 @@ class UnaryVariantOpRegistry {
 
   // Get a pointer to a global UnaryVariantOpRegistry object
   static UnaryVariantOpRegistry* Global() {
-    static UnaryVariantOpRegistry* global_unary_variant_op_registry =
-        new UnaryVariantOpRegistry;
-    return global_unary_variant_op_registry;
+    return UnaryVariantOpRegistryGlobal();
   }
 
   // Get a pointer to a global persistent string storage object.


### PR DESCRIPTION
Hi

This set of patches fixes 2 bugs in current TF master which is also present in 2.4 and 2.3 versions, this pull request is against master branch, please tell me if you need 2.4 version.

Bug was reported in https://github.com/tensorflow/tensorflow/issues/44428 and https://github.com/tensorflow/tensorflow/issues/44526, in a nutshell TensorList can not be decoded from the proto data, there are two bugs (fixed in two commits): decoder for tensorlist got lost and rtti for tensorlist doesn't match.

Both bugs are related to the fact that for some reasons runtime reloads some TF libraries several times, either it is statically linked first time when model is being loaded and then the second time for the second model or maybe the reason for subsequent load is different, but nevertheless having multiple loads wreck things a lot. I observed this bug for the case when inference runtime loads multiple saved_model models, this never happened for single model runtimes.

Please check commit messages for details on how and when bugs appeared.