### PR TITLE
micro: prepare to port operator ELU kernel from lite with test

### DIFF
--- a/tensorflow/lite/micro/kernels/elu.cc
+++ b/tensorflow/lite/micro/kernels/elu.cc
@@ -1,4 +1,4 @@
-/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -12,59 +12,31 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-#include <stddef.h>
+
+#include "tensorflow/lite/kernels/internal/reference/elu.h"
 
 #include <algorithm>
 #include <cmath>
-#include <cstdint>
 #include <functional>
 #include <limits>
 
-#include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/kernels/cpu_backend_context.h"
-#include "tensorflow/lite/kernels/internal/common.h"
-#include "tensorflow/lite/kernels/internal/compatibility.h"
-#include "tensorflow/lite/kernels/internal/cppmath.h"
-#include "tensorflow/lite/kernels/internal/optimized/optimized_ops.h"
 #include "tensorflow/lite/kernels/internal/quantization_util.h"
-#include "tensorflow/lite/kernels/internal/reference/binary_function.h"
-#include "tensorflow/lite/kernels/internal/reference/integer_ops/log_softmax.h"
-#include "tensorflow/lite/kernels/internal/reference/integer_ops/logistic.h"
-#include "tensorflow/lite/kernels/internal/reference/integer_ops/tanh.h"
-#include "tensorflow/lite/kernels/internal/reference/logistic.h"
-#include "tensorflow/lite/kernels/internal/reference/prelu.h"
-#include "tensorflow/lite/kernels/internal/reference/reference_ops.h"
-#include "tensorflow/lite/kernels/internal/reference/softmax.h"
-#include "tensorflow/lite/kernels/internal/reference/tanh.h"
-#include "tensorflow/lite/kernels/internal/tensor.h"
-#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/internal/reference/process_broadcast_shapes.h"
 #include "tensorflow/lite/kernels/internal/types.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
-
-#if __aarch64__ && __clang__
-#include <arm_neon.h>
-#endif
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
 
 namespace tflite {
 namespace ops {
-namespace builtin {
+namespace micro {
 namespace activations {
+namespace {
 
 // OLD-TODO(b/142762739): We should figure out a multi-threading plan for most
 // of the activation ops below.
 
-enum KernelType {
-  kReference,
-  kGenericOptimized,
-  kFixedPointOptimized,
-};
-
 struct OpData {
-  int32_t input_multiplier = 0;
-  int input_left_shift = 0;
-  int32_t input_range_radius = 0;
-  int diff_min = 0;
   uint8_t table[256] = {0};
 };
 
@@ -97,42 +69,19 @@ void EvalUsingLookupTable(struct OpData* data, const TfLiteTensor* input,
   uint8_t* output_data = GetTensorData<uint8_t>(output);
   const uint8_t* input_data = GetTensorData<uint8_t>(input);
   int i = 0;
-#if __aarch64__ && __clang__
-  // This code uses ARM64-only instructions.
-  // OLD-TODO(b/143709993): Port to ARMv7
 
-  // Load the tables into registers. (4*4 128-bit registers)
-  uint8x16x4_t table[4];
-  table[0] = vld1q_u8_x4(data->table + 16 * 4 * 0);
-  table[1] = vld1q_u8_x4(data->table + 16 * 4 * 1);
-  table[2] = vld1q_u8_x4(data->table + 16 * 4 * 2);
-  table[3] = vld1q_u8_x4(data->table + 16 * 4 * 3);
-
-  // Vectorized loop; process uint8x16_t (16 elements) at a time.
-  constexpr int vectorized_16_loop_step = 16;
-  const int vectorized_16_loop_end =
-      size / vectorized_16_loop_step * vectorized_16_loop_step;
-  for (; i < vectorized_16_loop_end; i += vectorized_16_loop_step) {
-    uint8x16_t input = vld1q_u8(input_data + i);
-    uint8x16_t output = optimized_ops::aarch64_lookup_vector(table, input);
-    vst1q_u8(output_data + i, output);
-  }
-  // Postamble and non-ARM64 code: simple for loop.
-#endif
   for (; i < size; ++i) {
     output_data[i] = data->table[input_data[i]];
   }
 }
 
+}  // namespace
+
 void* Init(TfLiteContext* context, const char* buffer, size_t length) {
   // This is a builtin op, so we don't use the contents in 'buffer', if any.
   // Instead, we allocate a new object to carry information from Prepare() to
   // Eval().
-  return new OpData;
-}
-
-void Free(TfLiteContext* context, void* buffer) {
-  delete reinterpret_cast<OpData*>(buffer);
+  return nullptr;
 }
 
 TfLiteStatus GenericPrepare(TfLiteContext* context, TfLiteNode* node) {
@@ -144,8 +93,7 @@ TfLiteStatus GenericPrepare(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE_OK(context, GetOutputSafe(context, node, 0, &output));
   TF_LITE_ENSURE_TYPES_EQ(context, input->type, output->type);
 
-  return context->ResizeTensor(context, output,
-                               TfLiteIntArrayCopy(input->dims));
+  return kTfLiteError;
 }
 
 TfLiteStatus EluPrepare(TfLiteContext* context, TfLiteNode* node) {
@@ -174,12 +122,12 @@ TfLiteStatus EluEval(TfLiteContext* context, TfLiteNode* node) {
       optimized_ops::Elu(GetTensorShape(input), GetTensorData<float>(input),
                          GetTensorShape(output), GetTensorData<float>(output));
       return kTfLiteOk;
-    } break;
+    }
     case kTfLiteInt8: {
       OpData* data = reinterpret_cast<OpData*>(node->user_data);
       EvalUsingLookupTable(data, input, output);
       return kTfLiteOk;
-    } break;
+    }
     default:
       TF_LITE_KERNEL_LOG(
           context, "Only float32 and int8 is supported currently, got %s.",
@@ -190,12 +138,8 @@ TfLiteStatus EluEval(TfLiteContext* context, TfLiteNode* node) {
 
 }  // namespace activations
 
-TfLiteRegistration* Register_ELU() {
-  static TfLiteRegistration r = {activations::Init, activations::Free,
-                                 activations::EluPrepare, activations::EluEval};
-  return &r;
-}
+TfLiteRegistration* Register_ELU() { return nullptr; }
 
-}  // namespace builtin
+}  // namespace micro
 }  // namespace ops
 }  // namespace tflite


### PR DESCRIPTION
Implement skeleton (non-working) code for operator and test.
Header files changed.
Namespaces changed.
Some original code deleted.
Some original code modified.

PR step 4 of the work to port operator ELU as tracked in Issue #46323