### PR TITLE
Fix a bug where reordering tf.Transpose is not done correctly

### DIFF
--- a/tensorflow/compiler/mlir/tensorflow/transforms/layout_optimization.cc
+++ b/tensorflow/compiler/mlir/tensorflow/transforms/layout_optimization.cc
@@ -387,7 +387,7 @@ void MoveTransposeAfter(Operation* op, SmallVector<Operation*, 8>* work_list,
   // Maybe add Transpose nodes for layout dependent results
   // (or reuse existing transposes).
   OpBuilder builder(op);
-  builder.setInsertionPoint(op);
+  builder.setInsertionPointAfter(op);
 
   for (unsigned idx : layout_dependent_results) {
     OpResult result = op->getResult(idx);


### PR DESCRIPTION
When reordering tf.Transpose (downwards) and the original transpose must be preserved, the insertion point is off-by-one.

As demonstrated in attached test, this scenario is not handled properly:

```
%0 = transpose(%input, %axis_t)
%1 = pad(%0, %axis_p)
return %0, %1
```

Will get `operand #0 does not dominate this use` error from IR verifier, indicating a value is used before its def.

cc: @huangkang-chn
