### PR TITLE
Switching to Cadence HiFi 4 NN Library v2.4.0

### DIFF
--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa_download.sh
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa_download.sh
@@ -41,9 +41,9 @@ if [ ! -d ${DOWNLOADS_DIR} ]; then
 fi
 
 if [[ ${2} == "hifi4" ]]; then
-  LIBRARY_URL="http://github.com/foss-xtensa/nnlib-hifi4/raw/master/archive/xa_nnlib_hifi4_12_22.zip"
+  LIBRARY_URL="http://github.com/foss-xtensa/nnlib-hifi4/raw/master/archive/xa_nnlib_hifi4_02_11_2021.zip"
   LIBRARY_DIRNAME="xa_nnlib_hifi4"
-  LIBRARY_MD5="bb4aa8bd589ee1b4b9fd71349a1e7317"
+  LIBRARY_MD5="8b934f61ffe0a966644849602810fb1b"
 else
   echo "Attempting to download an unsupported xtensa variant: ${2}"
   exit 1


### PR DESCRIPTION
Using the latest version of HiFi 4 NN Library.
This version has optimized implementation of SVDF and Quantize for int8 datatype.

Tested the change using following commands:
```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=hifi4 XTENSA_TOOLS_VERSION=RI-2020.5-linux XTENSA_CORE=AE_HiFi4_LE5_FP_XC clean_downloads
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=hifi4 XTENSA_TOOLS_VERSION=RI-2020.5-linux XTENSA_CORE=AE_HiFi4_LE5_FP_XC test_kernel_fully_connected_test
```