### PR TITLE
Fix LayerNormalization on CPU

### DIFF
--- a/tensorflow/python/keras/layers/normalization.py
+++ b/tensorflow/python/keras/layers/normalization.py
@@ -1206,6 +1206,8 @@ class LayerNormalization(Layer):
   def call(self, inputs):
     # Compute the axes along which to reduce the mean / variance
     input_shape = inputs.shape
+    if 0 in input_shape:
+      return inputs
     ndims = len(input_shape)
 
     # Broadcasting only necessary for norm when the axis is not just


### PR DESCRIPTION
Fix #46366 . `LayerNormalization` layer crashes on empty inputs on CPU. This pull request would help `LayerNormalization` return the input as the output if the input value is `[]` .  This is a similar condition to `LayerNormalization on GPU` and `BatchNormalization` which returns back the empty input without throwing in an error.