### PR TITLE
Do not rely on ADL when invoking std::sort

### DIFF
--- a/tensorflow/core/grappler/optimizers/scoped_allocator_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/scoped_allocator_optimizer.cc
@@ -1197,9 +1197,9 @@ Status ScopedAllocatorOptimizer::OrderNodeSet(
   // the same instance_key.
   if (nodes->size() <= 1) return Status::OK();
   if (IsCollectiveNode(*nodes->at(0))) {
-    sort(nodes->begin(), nodes->end(), InstanceKeyLess());
+    std::sort(nodes->begin(), nodes->end(), InstanceKeyLess());
   } else {
-    sort(nodes->begin(), nodes->end(), NameLess());
+    std::sort(nodes->begin(), nodes->end(), NameLess());
   }
   return Status::OK();
 }

--- a/tensorflow/lite/toco/tensorflow_graph_matching/resolve_svdf.cc
+++ b/tensorflow/lite/toco/tensorflow_graph_matching/resolve_svdf.cc
@@ -66,7 +66,7 @@ void FilterPartitionedConstNodes(
       }
     }
   }
-  sort(const_node_parts->begin(), const_node_parts->end(),
+  std::sort(const_node_parts->begin(), const_node_parts->end(),
        [](const NodeDef* a, const NodeDef* b) {
          return (a->name().compare(b->name()) < 0 &&
                  (a->name().size() < b->name().size()));


### PR DESCRIPTION
This PR is similar with protobuf/#7639.

An attempt to use ADL with std::vector breaks when std::vector::iterator is a raw pointer typedef.

There is no need to use ADL here.