### PR TITLE
[tf.data] Switch to TF combinations instead of test_util

### DIFF
--- a/tensorflow/python/data/util/BUILD
+++ b/tensorflow/python/data/util/BUILD
@@ -29,6 +29,7 @@ py_test(
         "//tensorflow/python:client_testlib",
         "//tensorflow/python:framework_for_generated_wrappers",
         "//tensorflow/python:math_ops",
+        "//tensorflow/python/data/kernel_tests:test_base",
         "//tensorflow/python/ops/ragged",
         "//third_party/py/numpy",
     ],
@@ -133,6 +134,7 @@ py_test(
     deps = [
         ":options",
         "//tensorflow/python:client_testlib",
+        "//tensorflow/python/data/kernel_tests:test_base",
     ],
 )
 

--- a/tensorflow/python/data/util/BUILD
+++ b/tensorflow/python/data/util/BUILD
@@ -63,6 +63,7 @@ py_test(
         "//tensorflow/python:dtypes",
         "//tensorflow/python:sparse_tensor",
         "//tensorflow/python:tensor_shape",
+        "//tensorflow/python/data/kernel_tests:test_base",
     ],
 )
 
@@ -158,6 +159,7 @@ py_test(
         "//tensorflow/python:client_testlib",
         "//tensorflow/python:framework_for_generated_wrappers",
         "//tensorflow/python:util",
+        "//tensorflow/python/data/kernel_tests:test_base",
     ],
 )
 
@@ -183,6 +185,7 @@ py_test(
         "//tensorflow/python:client_testlib",
         "//tensorflow/python:framework_for_generated_wrappers",
         "//tensorflow/python:util",
+        "//tensorflow/python/data/kernel_tests:test_base",
     ],
 )
 
@@ -204,6 +207,7 @@ py_test(
         ":traverse",
         "//tensorflow/python:client_testlib",
         "//tensorflow/python:framework_for_generated_wrappers",
+        "//tensorflow/python/data/kernel_tests:test_base",
         "//tensorflow/python/data/ops:dataset_ops",
     ],
 )

--- a/tensorflow/python/data/util/convert_test.py
+++ b/tensorflow/python/data/util/convert_test.py
@@ -19,10 +19,11 @@ from __future__ import division
 from __future__ import print_function
 
 from tensorflow.python.data.util import convert
+from tensorflow.python.data.kernel_tests import test_base
+from tensorflow.python.framework import combinations
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import tensor_shape
-from tensorflow.python.framework import test_util
 from tensorflow.python.platform import test
 from tensorflow.python.util import compat
 
@@ -61,7 +62,7 @@ class ConvertTest(test.TestCase):
                             convert.partial_shape_to_tensor(
                                 constant_op.constant([1], dtype=dtypes.int64))))
 
-  @test_util.run_deprecated_v1
+  @combinations.generate(test_base.graph_only_combinations())
   def testPartialShapeToTensorUnknownDimension(self):
     self.assertAllEqual([-1],
                         self.evaluate(

--- a/tensorflow/python/data/util/convert_test.py
+++ b/tensorflow/python/data/util/convert_test.py
@@ -18,6 +18,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from absl.testing import parameterized
+
 from tensorflow.python.data.util import convert
 from tensorflow.python.data.kernel_tests import test_base
 from tensorflow.python.framework import combinations
@@ -28,7 +30,7 @@ from tensorflow.python.platform import test
 from tensorflow.python.util import compat
 
 
-class ConvertTest(test.TestCase):
+class ConvertTest(test_base.DatasetTestBase, parameterized.TestCase):
 
   def testInteger(self):
     resp = convert.optional_param_to_tensor("foo", 3)

--- a/tensorflow/python/data/util/convert_test.py
+++ b/tensorflow/python/data/util/convert_test.py
@@ -20,8 +20,8 @@ from __future__ import print_function
 
 from absl.testing import parameterized
 
-from tensorflow.python.data.util import convert
 from tensorflow.python.data.kernel_tests import test_base
+from tensorflow.python.data.util import convert
 from tensorflow.python.framework import combinations
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
@@ -31,29 +31,29 @@ from tensorflow.python.util import compat
 
 
 class ConvertTest(test_base.DatasetTestBase, parameterized.TestCase):
-  
+
   @combinations.generate(test_base.default_test_combinations())
   def testInteger(self):
     resp = convert.optional_param_to_tensor("foo", 3)
     self.assertEqual(3, self.evaluate(resp))
-  
+
   @combinations.generate(test_base.default_test_combinations())
   def testIntegerDefault(self):
     resp = convert.optional_param_to_tensor("foo", None)
     self.assertEqual(0, self.evaluate(resp))
-  
+
   @combinations.generate(test_base.default_test_combinations())
   def testStringDefault(self):
     resp = convert.optional_param_to_tensor("bar", None, "default",
                                             dtypes.string)
     self.assertEqual(compat.as_bytes("default"), self.evaluate(resp))
-  
+
   @combinations.generate(test_base.default_test_combinations())
   def testString(self):
     resp = convert.optional_param_to_tensor("bar", "value", "default",
                                             dtypes.string)
     self.assertEqual(compat.as_bytes("value"), self.evaluate(resp))
-  
+
   @combinations.generate(test_base.default_test_combinations())
   def testPartialShapeToTensorKnownDimension(self):
     self.assertAllEqual([1],
@@ -97,7 +97,7 @@ class ConvertTest(test_base.DatasetTestBase, parameterized.TestCase):
         TypeError, r"The given shape .* must be a 1-D tensor of tf.int64 "
         r"values, but the element type was float32."):
       convert.partial_shape_to_tensor(constant_op.constant([1., 1.]))
-  
+
   @combinations.generate(test_base.default_test_combinations())
   def testPartialShapeToTensorMultipleDimensions(self):
     self.assertAllEqual([3, 6],
@@ -145,7 +145,7 @@ class ConvertTest(test_base.DatasetTestBase, parameterized.TestCase):
                             convert.partial_shape_to_tensor(
                                 constant_op.constant([-1, -1],
                                                      dtype=dtypes.int64))))
-  
+
   @combinations.generate(test_base.default_test_combinations())
   def testPartialShapeToTensorScalar(self):
     self.assertAllEqual([],

--- a/tensorflow/python/data/util/convert_test.py
+++ b/tensorflow/python/data/util/convert_test.py
@@ -31,25 +31,30 @@ from tensorflow.python.util import compat
 
 
 class ConvertTest(test_base.DatasetTestBase, parameterized.TestCase):
-
+  
+  @combinations.generate(test_base.default_test_combinations())
   def testInteger(self):
     resp = convert.optional_param_to_tensor("foo", 3)
     self.assertEqual(3, self.evaluate(resp))
-
+  
+  @combinations.generate(test_base.default_test_combinations())
   def testIntegerDefault(self):
     resp = convert.optional_param_to_tensor("foo", None)
     self.assertEqual(0, self.evaluate(resp))
-
+  
+  @combinations.generate(test_base.default_test_combinations())
   def testStringDefault(self):
     resp = convert.optional_param_to_tensor("bar", None, "default",
                                             dtypes.string)
     self.assertEqual(compat.as_bytes("default"), self.evaluate(resp))
-
+  
+  @combinations.generate(test_base.default_test_combinations())
   def testString(self):
     resp = convert.optional_param_to_tensor("bar", "value", "default",
                                             dtypes.string)
     self.assertEqual(compat.as_bytes("value"), self.evaluate(resp))
-
+  
+  @combinations.generate(test_base.default_test_combinations())
   def testPartialShapeToTensorKnownDimension(self):
     self.assertAllEqual([1],
                         self.evaluate(
@@ -92,7 +97,8 @@ class ConvertTest(test_base.DatasetTestBase, parameterized.TestCase):
         TypeError, r"The given shape .* must be a 1-D tensor of tf.int64 "
         r"values, but the element type was float32."):
       convert.partial_shape_to_tensor(constant_op.constant([1., 1.]))
-
+  
+  @combinations.generate(test_base.default_test_combinations())
   def testPartialShapeToTensorMultipleDimensions(self):
     self.assertAllEqual([3, 6],
                         self.evaluate(
@@ -139,7 +145,8 @@ class ConvertTest(test_base.DatasetTestBase, parameterized.TestCase):
                             convert.partial_shape_to_tensor(
                                 constant_op.constant([-1, -1],
                                                      dtype=dtypes.int64))))
-
+  
+  @combinations.generate(test_base.default_test_combinations())
   def testPartialShapeToTensorScalar(self):
     self.assertAllEqual([],
                         self.evaluate(

--- a/tensorflow/python/data/util/nest_test.py
+++ b/tensorflow/python/data/util/nest_test.py
@@ -22,8 +22,8 @@ import collections
 import numpy as np
 from absl.testing import parameterized
 
-from tensorflow.python.data.util import nest
 from tensorflow.python.data.kernel_tests import test_base
+from tensorflow.python.data.util import nest
 from tensorflow.python.framework import combinations
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import sparse_tensor

--- a/tensorflow/python/data/util/nest_test.py
+++ b/tensorflow/python/data/util/nest_test.py
@@ -19,10 +19,12 @@ from __future__ import division
 from __future__ import print_function
 
 import collections
-
 import numpy as np
+from absl.testing import parameterized
 
 from tensorflow.python.data.util import nest
+from tensorflow.python.data.kernel_tests import test_base
+from tensorflow.python.framework import combinations
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import sparse_tensor
 from tensorflow.python.ops import array_ops
@@ -31,8 +33,9 @@ from tensorflow.python.ops.ragged import ragged_factory_ops
 from tensorflow.python.platform import test
 
 
-class NestTest(test.TestCase):
-
+class NestTest(test_base.DatasetTestBase, parameterized.TestCase):
+  
+  @combinations.generate(test_base.default_test_combinations())
   def testFlattenAndPack(self):
     structure = ((3, 4), 5, (6, 7, (9, 10), 8))
     flat = ["a", "b", "c", "d", "e", "f", "g", "h"]
@@ -66,7 +69,8 @@ class NestTest(test.TestCase):
 
     with self.assertRaises(ValueError):
       nest.pack_sequence_as([5, 6, [7, 8]], ["a", "b", "c"])
-
+  
+  @combinations.generate(test_base.default_test_combinations())
   def testFlattenDictOrder(self):
     """`flatten` orders dicts by key, including OrderedDicts."""
     ordered = collections.OrderedDict([("d", 3), ("b", 1), ("a", 0), ("c", 2)])
@@ -75,7 +79,8 @@ class NestTest(test.TestCase):
     plain_flat = nest.flatten(plain)
     self.assertEqual([0, 1, 2, 3], ordered_flat)
     self.assertEqual([0, 1, 2, 3], plain_flat)
-
+  
+  @combinations.generate(test_base.default_test_combinations())
   def testPackDictOrder(self):
     """Packing orders dicts by key, including OrderedDicts."""
     ordered = collections.OrderedDict([("d", 0), ("b", 0), ("a", 0), ("c", 0)])
@@ -87,7 +92,8 @@ class NestTest(test.TestCase):
         collections.OrderedDict([("d", 3), ("b", 1), ("a", 0), ("c", 2)]),
         ordered_reconstruction)
     self.assertEqual({"d": 3, "b": 1, "a": 0, "c": 2}, plain_reconstruction)
-
+  
+  @combinations.generate(test_base.default_test_combinations())
   def testFlattenAndPackWithDicts(self):
     # A nice messy mix of tuples, lists, dicts, and `OrderedDict`s.
     named_tuple = collections.namedtuple("A", ("b", "c"))
@@ -133,7 +139,8 @@ class NestTest(test.TestCase):
     unflattened_ordered_dict = unflattened[2]["c"][1]
     self.assertIsInstance(unflattened_ordered_dict, collections.OrderedDict)
     self.assertEqual(list(unflattened_ordered_dict.keys()), ["b", "a"])
-
+  
+  @combinations.generate(test_base.default_test_combinations())
   def testFlattenSparseValue(self):
     st = sparse_tensor.SparseTensorValue([[0]], [0], [1])
     single_value = st
@@ -144,7 +151,8 @@ class NestTest(test.TestCase):
     self.assertEqual([[st, st, st]], nest.flatten(list_of_values))
     self.assertEqual([st, st, st], nest.flatten(nest_of_values))
     self.assertEqual([st, st, st], nest.flatten(dict_of_values))
-
+  
+  @combinations.generate(test_base.default_test_combinations())
   def testFlattenRaggedValue(self):
     rt = ragged_factory_ops.constant_value([[[0]], [[1]]])
     single_value = rt
@@ -155,7 +163,8 @@ class NestTest(test.TestCase):
     self.assertEqual([[rt, rt, rt]], nest.flatten(list_of_values))
     self.assertEqual([rt, rt, rt], nest.flatten(nest_of_values))
     self.assertEqual([rt, rt, rt], nest.flatten(dict_of_values))
-
+  
+  @combinations.generate(test_base.default_test_combinations())
   def testIsSequence(self):
     self.assertFalse(nest.is_sequence("1234"))
     self.assertFalse(nest.is_sequence([1, 3, [4, 5]]))
@@ -171,7 +180,8 @@ class NestTest(test.TestCase):
         nest.is_sequence(sparse_tensor.SparseTensorValue([[0]], [0], [1])))
     self.assertFalse(
         nest.is_sequence(ragged_factory_ops.constant_value([[[0]], [[1]]])))
-
+  
+  @combinations.generate(test_base.default_test_combinations())
   def testAssertSameStructure(self):
     structure1 = (((1, 2), 3), 4, (5, 6))
     structure2 = ((("foo1", "foo2"), "foo3"), "foo4", ("foo5", "foo6"))
@@ -242,7 +252,8 @@ class NestTest(test.TestCase):
         check_types=False)
     nest.assert_same_structure(
         structure1_list, structure2_list, check_types=False)
-
+  
+  @combinations.generate(test_base.default_test_combinations())
   def testMapStructure(self):
     structure1 = (((1, 2), 3), 4, (5, 6))
     structure2 = (((7, 8), 9), 10, (11, 12))
@@ -282,7 +293,8 @@ class NestTest(test.TestCase):
 
     with self.assertRaisesRegex(ValueError, "Only valid keyword argument"):
       nest.map_structure(lambda x: None, structure1, check_types=False, foo="a")
-
+  
+  @combinations.generate(test_base.default_test_combinations())
   def testAssertShallowStructure(self):
     inp_ab = ("a", "b")
     inp_abc = ("a", "b", "c")
@@ -314,7 +326,8 @@ class NestTest(test.TestCase):
     inp_ab = collections.OrderedDict([("a", 1), ("b", (2, 3))])
     inp_ba = collections.OrderedDict([("b", (2, 3)), ("a", 1)])
     nest.assert_shallow_structure(inp_ab, inp_ba)
-
+  
+  @combinations.generate(test_base.default_test_combinations())
   def testFlattenUpTo(self):
     input_tree = (((2, 2), (3, 3)), ((4, 9), (5, 5)))
     shallow_tree = ((True, True), (False, True))
@@ -422,7 +435,8 @@ class NestTest(test.TestCase):
     flattened_shallow_tree = nest.flatten_up_to(shallow_tree, shallow_tree)
     self.assertEqual(flattened_input_tree, [(2, 2), (3, 3), (4, 9), (5, 5)])
     self.assertEqual(flattened_shallow_tree, [True, True, False, True])
-
+  
+  @combinations.generate(test_base.default_test_combinations())
   def testMapStructureUpTo(self):
     ab_tuple = collections.namedtuple("ab_tuple", "a, b")
     op_tuple = collections.namedtuple("op_tuple", "add, mul")

--- a/tensorflow/python/data/util/options_test.py
+++ b/tensorflow/python/data/util/options_test.py
@@ -20,8 +20,8 @@ from __future__ import print_function
 
 from absl.testing import parameterized
 
-from tensorflow.python.data.util import options
 from tensorflow.python.data.kernel_tests import test_base
+from tensorflow.python.data.util import options
 from tensorflow.python.framework import combinations
 from tensorflow.python.platform import test
 

--- a/tensorflow/python/data/util/options_test.py
+++ b/tensorflow/python/data/util/options_test.py
@@ -18,7 +18,11 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from absl.testing import parameterized
+
 from tensorflow.python.data.util import options
+from tensorflow.python.data.kernel_tests import test_base
+from tensorflow.python.framework import combinations
 from tensorflow.python.platform import test
 
 
@@ -37,12 +41,14 @@ class _NestedTestOptions(options.OptionsBase):
       name="opts", ty=_TestOptions, docstring="nested options")
 
 
-class OptionsTest(test.TestCase):
-
+class OptionsTest(test_base.DatasetTestBase, parameterized.TestCase):
+  
+  @combinations.generate(test_base.default_test_combinations())
   def testDocumentation(self):
     self.assertEqual(_TestOptions.x.__doc__, "the answer to everything")
     self.assertEqual(_TestOptions.y.__doc__, "a tasty pie")
-
+  
+  @combinations.generate(test_base.default_test_combinations())
   def testCreateOption(self):
     opts = _TestOptions()
     self.assertEqual(opts.x, 42)
@@ -57,7 +63,8 @@ class OptionsTest(test.TestCase):
     self.assertEqual(opts.y, 0.0)
     with self.assertRaises(TypeError):
       opts.y = 42
-
+  
+  @combinations.generate(test_base.default_test_combinations())
   def testMergeOptions(self):
     options1, options2 = _TestOptions(), _TestOptions()
     with self.assertRaises(ValueError):
@@ -70,7 +77,8 @@ class OptionsTest(test.TestCase):
     merged_options = options.merge_options(options1, options2)
     self.assertEqual(merged_options.x, 0)
     self.assertEqual(merged_options.y, 0.0)
-
+  
+  @combinations.generate(test_base.default_test_combinations())
   def testMergeNestedOptions(self):
     options1, options2 = _NestedTestOptions(), _NestedTestOptions()
     merged_options = options.merge_options(options1, options2)
@@ -86,14 +94,16 @@ class OptionsTest(test.TestCase):
     merged_options = options.merge_options(options1, options2)
     self.assertEqual(merged_options.opts.x, 0)
     self.assertEqual(merged_options.opts.y, 0.0)
-
+  
+  @combinations.generate(test_base.default_test_combinations())
   def testMergeOptionsInvalid(self):
     with self.assertRaises(TypeError):
       options.merge_options(0)
     options1, options2 = _TestOptions(), _NestedTestOptions()
     with self.assertRaises(TypeError):
       options.merge_options(options1, options2)
-
+  
+  @combinations.generate(test_base.default_test_combinations())
   def testNoSpuriousAttrs(self):
     test_options = _TestOptions()
     with self.assertRaises(AttributeError):

--- a/tensorflow/python/data/util/random_seed_test.py
+++ b/tensorflow/python/data/util/random_seed_test.py
@@ -122,8 +122,7 @@ class RandomSeedTest(test_base.DatasetTestBase, parameterized.TestCase):
       )
   )
   def testRandomSeed(self, input_fn, output_fn):
-
-    tinput, toutput = input_fn(), output_fn() # pylint: disable=protected-access
+    tinput, toutput = input_fn(), output_fn()
     random_seed.set_random_seed(tinput[0])
     g_seed, op_seed = data_random_seed.get_seed(tinput[1])
     g_seed = self.evaluate(g_seed)
@@ -132,6 +131,20 @@ class RandomSeedTest(test_base.DatasetTestBase, parameterized.TestCase):
         tinput, (g_seed, op_seed), toutput)
     self.assertEqual((g_seed, op_seed), toutput, msg=msg)
     random_seed.set_random_seed(None)
+
+  @combinations.generate(test_base.graph_only_combinations())
+  def testIncrementalRandomSeed(self):
+    random_seed.set_random_seed(1)
+    for i in range(10):
+      tinput = (1, None)
+      toutput = (1, i)
+      random_seed.set_random_seed(tinput[0])
+      g_seed, op_seed = data_random_seed.get_seed(tinput[1])
+      g_seed = self.evaluate(g_seed)
+      op_seed = self.evaluate(op_seed)
+      msg = 'test_case = {0}, got {1}, want {2}'.format(
+          1, (g_seed, op_seed), toutput)
+      self.assertEqual((g_seed, op_seed), toutput, msg=msg)
 
 
 if __name__ == '__main__':

--- a/tensorflow/python/data/util/random_seed_test.py
+++ b/tensorflow/python/data/util/random_seed_test.py
@@ -115,7 +115,7 @@ def _test_random_seed_combinations():
 
 class RandomSeedTest(test_base.DatasetTestBase, parameterized.TestCase):
 
-  def _evaluate(self, tinput, toutput):
+  def _checkEqual(self, tinput, toutput):
     random_seed.set_random_seed(tinput[0])
     g_seed, op_seed = data_random_seed.get_seed(tinput[1])
     g_seed = self.evaluate(g_seed)
@@ -132,7 +132,7 @@ class RandomSeedTest(test_base.DatasetTestBase, parameterized.TestCase):
   )
   def testRandomSeed(self, input_fn, output_fn):
     tinput, toutput = input_fn(), output_fn()
-    self._evaluate(tinput=tinput, toutput=toutput)
+    self._checkEqual(tinput=tinput, toutput=toutput)
     random_seed.set_random_seed(None)
 
   @combinations.generate(test_base.graph_only_combinations())
@@ -141,7 +141,7 @@ class RandomSeedTest(test_base.DatasetTestBase, parameterized.TestCase):
     for i in range(10):
       tinput = (1, None)
       toutput = (1, i)
-      self._evaluate(tinput=tinput, toutput=toutput)
+      self._checkEqual(tinput=tinput, toutput=toutput)
 
 
 if __name__ == '__main__':

--- a/tensorflow/python/data/util/random_seed_test.py
+++ b/tensorflow/python/data/util/random_seed_test.py
@@ -30,6 +30,10 @@ from tensorflow.python.framework import random_seed
 from tensorflow.python.platform import test
 
 
+# NOTE(vikoth18): Arguments of parameterized tests are lifted into lambdas to make
+# sure they are not executed before the (eager- or graph-mode) test environment
+# has been set up.
+#
 class RandomSeedTest(test_base.DatasetTestBase, parameterized.TestCase):
 
   @combinations.generate(

--- a/tensorflow/python/data/util/random_seed_test.py
+++ b/tensorflow/python/data/util/random_seed_test.py
@@ -18,6 +18,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from absl.testing import parameterized
+
 from tensorflow.python.data.util import random_seed as data_random_seed
 from tensorflow.python.eager import context
 from tensorflow.python.data.kernel_tests import test_base
@@ -28,7 +30,7 @@ from tensorflow.python.framework import random_seed
 from tensorflow.python.platform import test
 
 
-class RandomSeedTest(test.TestCase):
+class RandomSeedTest(test_base.DatasetTestBase, parameterized.TestCase):
 
   @combinations.generate(test_base.default_test_combinations())
   def testRandomSeed(self):

--- a/tensorflow/python/data/util/random_seed_test.py
+++ b/tensorflow/python/data/util/random_seed_test.py
@@ -115,6 +115,15 @@ def _test_random_seed_combinations():
 
 class RandomSeedTest(test_base.DatasetTestBase, parameterized.TestCase):
 
+  def _evaluate(self, tinput, toutput):
+    random_seed.set_random_seed(tinput[0])
+    g_seed, op_seed = data_random_seed.get_seed(tinput[1])
+    g_seed = self.evaluate(g_seed)
+    op_seed = self.evaluate(op_seed)
+    msg = 'test_case = {0}, got {1}, want {2}'.format(
+        tinput, (g_seed, op_seed), toutput)
+    self.assertEqual((g_seed, op_seed), toutput, msg=msg)
+
   @combinations.generate(
       combinations.times(
           test_base.default_test_combinations(),
@@ -123,13 +132,7 @@ class RandomSeedTest(test_base.DatasetTestBase, parameterized.TestCase):
   )
   def testRandomSeed(self, input_fn, output_fn):
     tinput, toutput = input_fn(), output_fn()
-    random_seed.set_random_seed(tinput[0])
-    g_seed, op_seed = data_random_seed.get_seed(tinput[1])
-    g_seed = self.evaluate(g_seed)
-    op_seed = self.evaluate(op_seed)
-    msg = 'test_case = {0}, got {1}, want {2}'.format(
-        tinput, (g_seed, op_seed), toutput)
-    self.assertEqual((g_seed, op_seed), toutput, msg=msg)
+    self._evaluate(tinput=tinput, toutput=toutput)
     random_seed.set_random_seed(None)
 
   @combinations.generate(test_base.graph_only_combinations())
@@ -138,13 +141,7 @@ class RandomSeedTest(test_base.DatasetTestBase, parameterized.TestCase):
     for i in range(10):
       tinput = (1, None)
       toutput = (1, i)
-      random_seed.set_random_seed(tinput[0])
-      g_seed, op_seed = data_random_seed.get_seed(tinput[1])
-      g_seed = self.evaluate(g_seed)
-      op_seed = self.evaluate(op_seed)
-      msg = 'test_case = {0}, got {1}, want {2}'.format(
-          1, (g_seed, op_seed), toutput)
-      self.assertEqual((g_seed, op_seed), toutput, msg=msg)
+      self._evaluate(tinput=tinput, toutput=toutput)
 
 
 if __name__ == '__main__':

--- a/tensorflow/python/data/util/random_seed_test.py
+++ b/tensorflow/python/data/util/random_seed_test.py
@@ -123,7 +123,7 @@ class RandomSeedTest(test_base.DatasetTestBase, parameterized.TestCase):
   )
   def testRandomSeed(self, input_fn, output_fn):
 
-    tinput, toutput = input_fn._obj(), output_fn._obj() # pylint: disable=protected-access
+    tinput, toutput = input_fn(), output_fn() # pylint: disable=protected-access
     random_seed.set_random_seed(tinput[0])
     g_seed, op_seed = data_random_seed.get_seed(tinput[1])
     g_seed = self.evaluate(g_seed)

--- a/tensorflow/python/data/util/random_seed_test.py
+++ b/tensorflow/python/data/util/random_seed_test.py
@@ -38,10 +38,10 @@ from tensorflow.python.platform import test
 def _test_random_seed_combinations():
 
   cases = [
-    # Each test case is a tuple with input to get_seed:
-    # (input_graph_seed, input_op_seed)
-    # and output from get_seed:
-    # (output_graph_seed, output_op_seed)
+      # Each test case is a tuple with input to get_seed:
+      # (input_graph_seed, input_op_seed)
+      # and output from get_seed:
+      # (output_graph_seed, output_op_seed)
       (
           "CASE_0",
           lambda: (None, None),

--- a/tensorflow/python/data/util/random_seed_test.py
+++ b/tensorflow/python/data/util/random_seed_test.py
@@ -24,7 +24,6 @@ from absl.testing import parameterized
 
 from tensorflow.python.data.kernel_tests import test_base
 from tensorflow.python.data.util import random_seed as data_random_seed
-from tensorflow.python.eager import context
 from tensorflow.python.framework import combinations
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
@@ -125,24 +124,15 @@ class RandomSeedTest(test_base.DatasetTestBase, parameterized.TestCase):
   def testRandomSeed(self, input_fn, output_fn):
 
     tinput, toutput = input_fn._obj(), output_fn._obj() # pylint: disable=protected-access
-    def check(tinput, toutput):
-      random_seed.set_random_seed(tinput[0])
-      g_seed, op_seed = data_random_seed.get_seed(tinput[1])
-      g_seed = self.evaluate(g_seed)
-      op_seed = self.evaluate(op_seed)
-      msg = 'test_case = {0}, got {1}, want {2}'.format(
-          tinput, (g_seed, op_seed), toutput)
-      self.assertEqual((g_seed, op_seed), toutput, msg=msg)
-      random_seed.set_random_seed(None)
+    random_seed.set_random_seed(tinput[0])
+    g_seed, op_seed = data_random_seed.get_seed(tinput[1])
+    g_seed = self.evaluate(g_seed)
+    op_seed = self.evaluate(op_seed)
+    msg = 'test_case = {0}, got {1}, want {2}'.format(
+        tinput, (g_seed, op_seed), toutput)
+    self.assertEqual((g_seed, op_seed), toutput, msg=msg)
+    random_seed.set_random_seed(None)
 
-    check(tinput=tinput, toutput=toutput)
-
-    if not context.executing_eagerly():
-      random_seed.set_random_seed(1)
-      for i in range(10):
-        tinput = (1, None)
-        toutput = (1, i)
-        check(tinput=tinput, toutput=toutput)
 
 if __name__ == '__main__':
   test.main()

--- a/tensorflow/python/data/util/random_seed_test.py
+++ b/tensorflow/python/data/util/random_seed_test.py
@@ -43,61 +43,61 @@ def _test_random_seed_combinations():
       # and output from get_seed:
       # (output_graph_seed, output_op_seed)
       (
-          "CASE_0",
+          "TestCase_0",
           lambda: (None, None),
           lambda: (0, 0),
       ),
       (
-          "CASE_1",
+          "TestCase_1",
           lambda: (None, 1),
           lambda: (random_seed.DEFAULT_GRAPH_SEED, 1)
       ),
       (
-          "CASE_2",
+          "TestCase_2",
           lambda: (1, 1),
           lambda: (1, 1)
       ),
       (
           # Avoid nondeterministic (0, 0) output
-          "CASE_3",
+          "TestCase_3",
           lambda: (0, 0),
           lambda: (0, 2**31 - 1)
       ),
       (
           # Don't wrap to (0, 0) either
-          "CASE_4",
+          "TestCase_4",
           lambda: (2**31 - 1, 0),
           lambda: (0, 2**31 - 1)
       ),
       (
           # Wrapping for the other argument
-          "CASE_5",
+          "TestCase_5",
           lambda: (0, 2**31 - 1),
           lambda: (0, 2**31 - 1)
       ),
       (
           # Once more, with tensor-valued arguments
-          "CASE_6",
+          "TestCase_6",
           lambda: (None, constant_op.constant(1, dtype=dtypes.int64, name='one')),
           lambda: (random_seed.DEFAULT_GRAPH_SEED, 1)
       ),
       (
-          "CASE_7",
+          "TestCase_7",
           lambda: (1, constant_op.constant(1, dtype=dtypes.int64, name='one')),
           lambda: (1, 1)
       ),
       (
-          "CASE_8",
+          "TestCase_8",
           lambda: (0, constant_op.constant(0, dtype=dtypes.int64, name='zero')),
           lambda: (0, 2**31 - 1)  # Avoid nondeterministic (0, 0) output
       ),
       (
-          "CASE_9",
+          "TestCase_9",
           lambda: (2**31 - 1, constant_op.constant(0, dtype=dtypes.int64, name='zero')),
           lambda: (0, 2**31 - 1)  # Don't wrap to (0, 0) either
       ),
       (
-          "CASE_10",
+          "TestCase_10",
           lambda: (0, constant_op.constant(2**31 - 1, dtype=dtypes.int64, name='intmax')),
           lambda: (0, 2**31 - 1)  # Wrapping for the other argument
       )

--- a/tensorflow/python/data/util/random_seed_test.py
+++ b/tensorflow/python/data/util/random_seed_test.py
@@ -20,9 +20,9 @@ from __future__ import print_function
 
 from absl.testing import parameterized
 
+from tensorflow.python.data.kernel_tests import test_base
 from tensorflow.python.data.util import random_seed as data_random_seed
 from tensorflow.python.eager import context
-from tensorflow.python.data.kernel_tests import test_base
 from tensorflow.python.framework import combinations
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes

--- a/tensorflow/python/data/util/random_seed_test.py
+++ b/tensorflow/python/data/util/random_seed_test.py
@@ -20,16 +20,17 @@ from __future__ import print_function
 
 from tensorflow.python.data.util import random_seed as data_random_seed
 from tensorflow.python.eager import context
+from tensorflow.python.data.kernel_tests import test_base
+from tensorflow.python.framework import combinations
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import random_seed
-from tensorflow.python.framework import test_util
 from tensorflow.python.platform import test
 
 
 class RandomSeedTest(test.TestCase):
 
-  @test_util.run_in_graph_and_eager_modes
+  @combinations.generate(test_base.default_test_combinations())
   def testRandomSeed(self):
     zero_t = constant_op.constant(0, dtype=dtypes.int64, name='zero')
     one_t = constant_op.constant(1, dtype=dtypes.int64, name='one')

--- a/tensorflow/python/data/util/sparse_test.py
+++ b/tensorflow/python/data/util/sparse_test.py
@@ -20,9 +20,9 @@ from __future__ import print_function
 
 from absl.testing import parameterized
 
+from tensorflow.python.data.kernel_tests import test_base
 from tensorflow.python.data.util import nest
 from tensorflow.python.data.util import sparse
-from tensorflow.python.data.kernel_tests import test_base
 from tensorflow.python.framework import combinations
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes

--- a/tensorflow/python/data/util/sparse_test.py
+++ b/tensorflow/python/data/util/sparse_test.py
@@ -20,12 +20,13 @@ from __future__ import print_function
 
 from tensorflow.python.data.util import nest
 from tensorflow.python.data.util import sparse
+from tensorflow.python.data.kernel_tests import test_base
+from tensorflow.python.framework import combinations
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import sparse_tensor
 from tensorflow.python.framework import tensor_shape
-from tensorflow.python.framework import test_util
 from tensorflow.python.platform import test
 
 
@@ -300,7 +301,7 @@ class SparseTest(test.TestCase):
       self.assertAllEqual(a.eval().values, self.evaluate(b).values)
       self.assertAllEqual(a.eval().dense_shape, self.evaluate(b).dense_shape)
 
-  @test_util.run_deprecated_v1
+  @combinations.generate(test_base.graph_only_combinations())
   def testSerializeDeserialize(self):
     test_cases = (
         (),
@@ -330,7 +331,7 @@ class SparseTest(test.TestCase):
       for a, e in zip(nest.flatten(actual), nest.flatten(expected)):
         self.assertSparseValuesEqual(a, e)
 
-  @test_util.run_deprecated_v1
+  @combinations.generate(test_base.graph_only_combinations())
   def testSerializeManyDeserialize(self):
     test_cases = (
         (),

--- a/tensorflow/python/data/util/sparse_test.py
+++ b/tensorflow/python/data/util/sparse_test.py
@@ -38,44 +38,40 @@ class SparseTest(test_base.DatasetTestBase, parameterized.TestCase):
       combinations.times(
           test_base.default_test_combinations(),
           combinations.combine(test_case=[
-              {
+              combinations.NamedObject("Case_0", {
                   "classes": (),
                   "expected": False
-              },
-              {
+              }),
+              combinations.NamedObject("Case_1", {
                   "classes": (ops.Tensor),
                   "expected": False
-              },
-              {
+              }),
+              combinations.NamedObject("Case_2", {
                   "classes": (((ops.Tensor))),
                   "expected": False
-              },
-              {
+              }),
+              combinations.NamedObject("Case_3", {
                   "classes": (ops.Tensor, ops.Tensor),
                   "expected": False
-              },
-              {
+              }),
+              combinations.NamedObject("Case_4", {
                   "classes": (ops.Tensor, sparse_tensor.SparseTensor),
                   "expected": True
-              },
-              {
+              }),
+              combinations.NamedObject("Case_5", {
                   "classes": (sparse_tensor.SparseTensor,
                               sparse_tensor.SparseTensor),
                   "expected": True
-              },
-              {
-                  "classes": (sparse_tensor.SparseTensor, ops.Tensor),
-                  "expected": True
-              },
-              {
+              }),
+              combinations.NamedObject("Case_6", {
                   "classes": (((sparse_tensor.SparseTensor))),
                   "expected": True
-              },
+              }),
           ])
       )
   )
   def testAnySparse(self, test_case):
-
+    test_case = test_case._obj  # pylint: disable=protected-access
     self.assertEqual(sparse.any_sparse(
         test_case["classes"]), test_case["expected"])
 
@@ -92,81 +88,81 @@ class SparseTest(test_base.DatasetTestBase, parameterized.TestCase):
       combinations.times(
           test_base.default_test_combinations(),
           combinations.combine(test_case=[
-              {
+              combinations.NamedObject("Case_0", {
                   "types": (),
                   "classes": (),
                   "expected": ()
-              },
-              {
+              }),
+              combinations.NamedObject("Case_1", {
                   "types": tensor_shape.TensorShape([]),
                   "classes": ops.Tensor,
                   "expected": tensor_shape.TensorShape([])
-              },
-              {
+              }),
+              combinations.NamedObject("Case_2", {
                   "types": tensor_shape.TensorShape([]),
                   "classes": sparse_tensor.SparseTensor,
                   "expected": tensor_shape.unknown_shape()
-              },
-              {
+              }),
+              combinations.NamedObject("Case_3", {
                   "types": (tensor_shape.TensorShape([])),
                   "classes": (ops.Tensor),
                   "expected": (tensor_shape.TensorShape([]))
-              },
-              {
+              }),
+              combinations.NamedObject("Case_4", {
                   "types": (tensor_shape.TensorShape([])),
                   "classes": (sparse_tensor.SparseTensor),
                   "expected": (tensor_shape.unknown_shape())
-              },
-              {
+              }),
+              combinations.NamedObject("Case_5", {
                   "types": (tensor_shape.TensorShape([]), ()),
                   "classes": (ops.Tensor, ()),
                   "expected": (tensor_shape.TensorShape([]), ())
-              },
-              {
+              }),
+              combinations.NamedObject("Case_6", {
                   "types": ((), tensor_shape.TensorShape([])),
                   "classes": ((), ops.Tensor),
                   "expected": ((), tensor_shape.TensorShape([]))
-              },
-              {
+              }),
+              combinations.NamedObject("Case_7", {
                   "types": (tensor_shape.TensorShape([]), ()),
                   "classes": (sparse_tensor.SparseTensor, ()),
                   "expected": (tensor_shape.unknown_shape(), ())
-              },
-              {
+              }),
+              combinations.NamedObject("Case_8", {
                   "types": ((), tensor_shape.TensorShape([])),
                   "classes": ((), sparse_tensor.SparseTensor),
                   "expected": ((), tensor_shape.unknown_shape())
-              },
-              {
+              }),
+              combinations.NamedObject("Case_9", {
                   "types": (tensor_shape.TensorShape([]), (),
                             tensor_shape.TensorShape([])),
                   "classes": (ops.Tensor, (), ops.Tensor),
                   "expected": (tensor_shape.TensorShape([]), (),
                                tensor_shape.TensorShape([]))
-              },
-              {
+              }),
+              combinations.NamedObject("Case_10", {
                   "types": (tensor_shape.TensorShape([]), (),
                             tensor_shape.TensorShape([])),
                   "classes": (sparse_tensor.SparseTensor, (),
                               sparse_tensor.SparseTensor),
                   "expected": (tensor_shape.unknown_shape(), (),
                                tensor_shape.unknown_shape())
-              },
-              {
+              }),
+              combinations.NamedObject("Case_11", {
                   "types": ((), tensor_shape.TensorShape([]), ()),
                   "classes": ((), ops.Tensor, ()),
                   "expected": ((), tensor_shape.TensorShape([]), ())
-              },
-              {
+              }),
+              combinations.NamedObject("Case_12", {
                   "types": ((), tensor_shape.TensorShape([]), ()),
                   "classes": ((), sparse_tensor.SparseTensor, ()),
                   "expected": ((), tensor_shape.unknown_shape(), ())
-              },
+              }),
           ])
       )
   )
   def testAsDenseShapes(self, test_case):
-
+    test_case = test_case._obj  # pylint: disable=protected-access
     self.assertShapesEqual(
         sparse.as_dense_shapes(test_case["types"], test_case["classes"]),
         test_case["expected"])
@@ -175,76 +171,77 @@ class SparseTest(test_base.DatasetTestBase, parameterized.TestCase):
       combinations.times(
           test_base.default_test_combinations(),
           combinations.combine(test_case=[
-              {
+              combinations.NamedObject("Case_0", {
                   "types": (),
                   "classes": (),
                   "expected": ()
-              },
-              {
+              }),
+              combinations.NamedObject("Case_1", {
                   "types": dtypes.int32,
                   "classes": ops.Tensor,
                   "expected": dtypes.int32
-              },
-              {
+              }),
+              combinations.NamedObject("Case_2", {
                   "types": dtypes.int32,
                   "classes": sparse_tensor.SparseTensor,
                   "expected": dtypes.variant
-              },
-              {
+              }),
+              combinations.NamedObject("Case_3", {
                   "types": (dtypes.int32),
                   "classes": (ops.Tensor),
                   "expected": (dtypes.int32)
-              },
-              {
+              }),
+              combinations.NamedObject("Case_4", {
                   "types": (dtypes.int32),
                   "classes": (sparse_tensor.SparseTensor),
                   "expected": (dtypes.variant)
-              },
-              {
+              }),
+              combinations.NamedObject("Case_5", {
                   "types": (dtypes.int32, ()),
                   "classes": (ops.Tensor, ()),
                   "expected": (dtypes.int32, ())
-              },
-              {
+              }),
+              combinations.NamedObject("Case_6", {
                   "types": ((), dtypes.int32),
                   "classes": ((), ops.Tensor),
                   "expected": ((), dtypes.int32)
-              },
-              {
+              }),
+              combinations.NamedObject("Case_7", {
                   "types": (dtypes.int32, ()),
                   "classes": (sparse_tensor.SparseTensor, ()),
                   "expected": (dtypes.variant, ())
-              },
-              {
+              }),
+              combinations.NamedObject("Case_8", {
                   "types": ((), dtypes.int32),
                   "classes": ((), sparse_tensor.SparseTensor),
                   "expected": ((), dtypes.variant)
-              },
-              {
+              }),
+              combinations.NamedObject("Case_9", {
                   "types": (dtypes.int32, (), dtypes.int32),
                   "classes": (ops.Tensor, (), ops.Tensor),
                   "expected": (dtypes.int32, (), dtypes.int32)
-              },
-              {
+              }),
+              combinations.NamedObject("Case_10", {
                   "types": (dtypes.int32, (), dtypes.int32),
                   "classes": (sparse_tensor.SparseTensor, (),
                               sparse_tensor.SparseTensor),
                   "expected": (dtypes.variant, (), dtypes.variant)
-              },
-              {
+              }),
+              combinations.NamedObject("Case_11", {
                   "types": ((), dtypes.int32, ()),
                   "classes": ((), ops.Tensor, ()),
                   "expected": ((), dtypes.int32, ())
-              },
-              {
+              }),
+              combinations.NamedObject("Case_12", {
                   "types": ((), dtypes.int32, ()),
                   "classes": ((), sparse_tensor.SparseTensor, ()),
                   "expected": ((), dtypes.variant, ())
-              },
+              }),
           ])
       )
   )
   def testAsDenseTypes(self, test_case):
+    test_case = test_case._obj  # pylint: disable=protected-access
     self.assertEqual(
         sparse.as_dense_types(test_case["types"], test_case["classes"]),
         test_case["expected"])
@@ -253,67 +250,68 @@ class SparseTest(test_base.DatasetTestBase, parameterized.TestCase):
       combinations.times(
           test_base.default_test_combinations(),
           combinations.combine(test_case=[
-              {
+              combinations.NamedObject("Case_0", {
                   "classes": (),
                   "expected": ()
-              },
-              {
+              }),
+              combinations.NamedObject("Case_1", {
                   "classes": sparse_tensor.SparseTensor(
                       indices=[[0]], values=[1], dense_shape=[1]
                   ),
                   "expected": sparse_tensor.SparseTensor
-              },
-              {
+              }),
+              combinations.NamedObject("Case_2", {
                   "classes": constant_op.constant([1]),
                   "expected": ops.Tensor
-              },
-              {
+              }),
+              combinations.NamedObject("Case_3", {
                   "classes": (sparse_tensor.SparseTensor(
                       indices=[[0]], values=[1], dense_shape=[1])),
                   "expected": (sparse_tensor.SparseTensor)
-              },
-              {
+              }),
+              combinations.NamedObject("Case_4", {
                   "classes": (constant_op.constant([1])),
                   "expected": (ops.Tensor)
-              },
-              {
+              }),
+              combinations.NamedObject("Case_5", {
                   "classes": (sparse_tensor.SparseTensor(
                       indices=[[0]], values=[1], dense_shape=[1]), ()),
                   "expected": (sparse_tensor.SparseTensor, ())
-              },
-              {
+              }),
+              combinations.NamedObject("Case_6", {
                   "classes": ((), sparse_tensor.SparseTensor(
                       indices=[[0]], values=[1], dense_shape=[1])),
                   "expected": ((), sparse_tensor.SparseTensor)
-              },
-              {
+              }),
+              combinations.NamedObject("Case_7", {
                   "classes": (constant_op.constant([1]), ()),
                   "expected": (ops.Tensor, ())
-              },
-              {
+              }),
+              combinations.NamedObject("Case_8", {
                   "classes": ((), constant_op.constant([1])),
                   "expected": ((), ops.Tensor)
-              },
-              {
+              }),
+              combinations.NamedObject("Case_9", {
                   "classes": (
                       sparse_tensor.SparseTensor(
                           indices=[[0]], values=[1], dense_shape=[1]),
                       (), constant_op.constant([1])),
                   "expected": (sparse_tensor.SparseTensor, (), ops.Tensor)
-              },
-              {
+              }),
+              combinations.NamedObject("Case_10", {
                   "classes": ((), sparse_tensor.SparseTensor(
                       indices=[[0]], values=[1], dense_shape=[1]), ()),
                   "expected": ((), sparse_tensor.SparseTensor, ())
-              },
-              {
+              }),
+              combinations.NamedObject("Case_11", {
                   "classes": ((), constant_op.constant([1]), ()),
                   "expected": ((), ops.Tensor, ())
-              },
+              }),
           ])
       )
   )
   def testGetClasses(self, test_case):
+    test_case = test_case._obj  # pylint: disable=protected-access
     self.assertEqual(
         sparse.get_classes(test_case["classes"]), test_case["expected"])
 
@@ -333,23 +331,32 @@ class SparseTest(test_base.DatasetTestBase, parameterized.TestCase):
       combinations.times(
           test_base.graph_only_combinations(),
           combinations.combine(test_case=[
-              (),
-              sparse_tensor.SparseTensor(
-                  indices=[[0, 0]], values=[1], dense_shape=[1, 1]),
-              sparse_tensor.SparseTensor(
-                  indices=[[3, 4]], values=[-1], dense_shape=[4, 5]),
-              sparse_tensor.SparseTensor(
-                  indices=[[0, 0], [3, 4]], values=[1, -1], dense_shape=[4, 5]),
-              (sparse_tensor.SparseTensor(
-                  indices=[[0, 0]], values=[1], dense_shape=[1, 1])),
-              (sparse_tensor.SparseTensor(
-                  indices=[[0, 0]], values=[1], dense_shape=[1, 1]), ()),
-              ((), sparse_tensor.SparseTensor(
-                  indices=[[0, 0]], values=[1], dense_shape=[1, 1])),
+              combinations.NamedObject(
+                  "Case_0", ()),
+              combinations.NamedObject(
+                  "Case_1", sparse_tensor.SparseTensor(
+                      indices=[[0, 0]], values=[1], dense_shape=[1, 1])),
+              combinations.NamedObject(
+                  "Case_2", sparse_tensor.SparseTensor(
+                      indices=[[3, 4]], values=[-1], dense_shape=[4, 5])),
+              combinations.NamedObject(
+                  "Case_3", sparse_tensor.SparseTensor(
+                      indices=[[0, 0], [3, 4]], values=[1, -1],
+                      dense_shape=[4, 5])),
+              combinations.NamedObject(
+                  "Case_4", (sparse_tensor.SparseTensor(
+                      indices=[[0, 0]], values=[1], dense_shape=[1, 1]))),
+              combinations.NamedObject(
+                  "Case_5", (sparse_tensor.SparseTensor(
+                      indices=[[0, 0]], values=[1], dense_shape=[1, 1]), ())),
+              combinations.NamedObject(
+                  "Case_6", ((), sparse_tensor.SparseTensor(
+                      indices=[[0, 0]], values=[1], dense_shape=[1, 1]))),
           ])
       )
   )
   def testSerializeDeserialize(self, test_case):
+    test_case = test_case._obj  # pylint: disable=protected-access
     classes = sparse.get_classes(test_case)
     shapes = nest.map_structure(lambda _: tensor_shape.TensorShape(None),
                                 classes)
@@ -365,23 +372,32 @@ class SparseTest(test_base.DatasetTestBase, parameterized.TestCase):
       combinations.times(
           test_base.graph_only_combinations(),
           combinations.combine(test_case=[
-              (),
-              sparse_tensor.SparseTensor(
-                  indices=[[0, 0]], values=[1], dense_shape=[1, 1]),
-              sparse_tensor.SparseTensor(
-                  indices=[[3, 4]], values=[-1], dense_shape=[4, 5]),
-              sparse_tensor.SparseTensor(
-                  indices=[[0, 0], [3, 4]], values=[1, -1], dense_shape=[4, 5]),
-              (sparse_tensor.SparseTensor(
-                  indices=[[0, 0]], values=[1], dense_shape=[1, 1])),
-              (sparse_tensor.SparseTensor(
-                  indices=[[0, 0]], values=[1], dense_shape=[1, 1]), ()),
-              ((), sparse_tensor.SparseTensor(
-                  indices=[[0, 0]], values=[1], dense_shape=[1, 1])),
+              combinations.NamedObject(
+                  "Case_0", ()),
+              combinations.NamedObject(
+                  "Case_1", sparse_tensor.SparseTensor(
+                      indices=[[0, 0]], values=[1], dense_shape=[1, 1])),
+              combinations.NamedObject(
+                  "Case_2", sparse_tensor.SparseTensor(
+                      indices=[[3, 4]], values=[-1], dense_shape=[4, 5])),
+              combinations.NamedObject(
+                  "Case_3", sparse_tensor.SparseTensor(
+                      indices=[[0, 0], [3, 4]], values=[1, -1],
+                      dense_shape=[4, 5])),
+              combinations.NamedObject(
+                  "Case_4", (sparse_tensor.SparseTensor(
+                      indices=[[0, 0]], values=[1], dense_shape=[1, 1]))),
+              combinations.NamedObject(
+                  "Case_5", (sparse_tensor.SparseTensor(
+                      indices=[[0, 0]], values=[1], dense_shape=[1, 1]), ())),
+              combinations.NamedObject(
+                  "Case_6", ((), sparse_tensor.SparseTensor(
+                      indices=[[0, 0]], values=[1], dense_shape=[1, 1]))),
           ])
       )
   )
   def testSerializeManyDeserialize(self, test_case):
+    test_case = test_case._obj  # pylint: disable=protected-access
     classes = sparse.get_classes(test_case)
     shapes = nest.map_structure(lambda _: tensor_shape.TensorShape(None),
                                 classes)

--- a/tensorflow/python/data/util/sparse_test.py
+++ b/tensorflow/python/data/util/sparse_test.py
@@ -414,7 +414,7 @@ class SparseTest(test_base.DatasetTestBase, parameterized.TestCase):
       )
   )
   def testAnySparse(self, classes_fn, expected):
-    classes = classes_fn._obj() # pylint: disable=protected-access
+    classes = classes_fn()
     expected = expected._obj # pylint: disable=protected-access
     self.assertEqual(sparse.any_sparse(classes), expected)
 
@@ -433,9 +433,9 @@ class SparseTest(test_base.DatasetTestBase, parameterized.TestCase):
       )
   )
   def testAsDenseShapes(self, types_fn, classes_fn, expected_fn):
-    types = types_fn._obj() # pylint: disable=protected-access
-    classes = classes_fn._obj() # pylint: disable=protected-access
-    expected = expected_fn._obj() # pylint: disable=protected-access
+    types = types_fn()
+    classes = classes_fn()
+    expected = expected_fn()
     self.assertShapesEqual(sparse.as_dense_shapes(types, classes), expected)
 
   @combinations.generate(
@@ -445,9 +445,9 @@ class SparseTest(test_base.DatasetTestBase, parameterized.TestCase):
       )
   )
   def testAsDenseTypes(self, types_fn, classes_fn, expected_fn):
-    types = types_fn._obj() # pylint: disable=protected-access
-    classes = classes_fn._obj() # pylint: disable=protected-access
-    expected = expected_fn._obj() # pylint: disable=protected-access
+    types = types_fn()
+    classes = classes_fn()
+    expected = expected_fn()
     self.assertEqual(sparse.as_dense_types(types, classes), expected)
 
   @combinations.generate(
@@ -457,8 +457,8 @@ class SparseTest(test_base.DatasetTestBase, parameterized.TestCase):
       )
   )
   def testGetClasses(self, classes_fn, expected_fn):
-    classes = classes_fn._obj() # pylint: disable=protected-access
-    expected = expected_fn._obj() # pylint: disable=protected-access
+    classes = classes_fn()
+    expected = expected_fn()
     self.assertEqual(sparse.get_classes(classes), expected)
 
   def assertSparseValuesEqual(self, a, b):
@@ -479,7 +479,7 @@ class SparseTest(test_base.DatasetTestBase, parameterized.TestCase):
       )
   )
   def testSerializeDeserialize(self, input_fn):
-    test_case = input_fn._obj() # pylint: disable=protected-access
+    test_case = input_fn()
     classes = sparse.get_classes(test_case)
     shapes = nest.map_structure(lambda _: tensor_shape.TensorShape(None),
                                 classes)
@@ -498,7 +498,7 @@ class SparseTest(test_base.DatasetTestBase, parameterized.TestCase):
       )
   )
   def testSerializeManyDeserialize(self, input_fn):
-    test_case = input_fn._obj() # pylint: disable=protected-access
+    test_case = input_fn()
     classes = sparse.get_classes(test_case)
     shapes = nest.map_structure(lambda _: tensor_shape.TensorShape(None),
                                 classes)

--- a/tensorflow/python/data/util/sparse_test.py
+++ b/tensorflow/python/data/util/sparse_test.py
@@ -42,13 +42,13 @@ from tensorflow.python.platform import test
 def _test_any_sparse_combinations():
 
   cases = [
-      ("CASE_0", lambda: (), False),
-      ("CASE_1", lambda: (ops.Tensor), False),
-      ("CASE_2", lambda: (((ops.Tensor))), False),
-      ("CASE_3", lambda: (ops.Tensor, ops.Tensor), False),
-      ("CASE_4", lambda: (ops.Tensor, sparse_tensor.SparseTensor), True),
-      ("CASE_5", lambda: (sparse_tensor.SparseTensor, sparse_tensor.SparseTensor), True),
-      ("CASE_6", lambda: (((sparse_tensor.SparseTensor))), True)
+      ("TestCase_0", lambda: (), False),
+      ("TestCase_1", lambda: (ops.Tensor), False),
+      ("TestCase_2", lambda: (((ops.Tensor))), False),
+      ("TestCase_3", lambda: (ops.Tensor, ops.Tensor), False),
+      ("TestCase_4", lambda: (ops.Tensor, sparse_tensor.SparseTensor), True),
+      ("TestCase_5", lambda: (sparse_tensor.SparseTensor, sparse_tensor.SparseTensor), True),
+      ("TestCase_6", lambda: (((sparse_tensor.SparseTensor))), True)
   ]
   def reduce_fn(x, y):
     name, classes_fn, expected = y
@@ -67,61 +67,61 @@ def _test_as_dense_shapes_combinations():
 
   cases = [
       (
-          "CASE_0",
+          "TestCase_0",
           lambda: (),
           lambda: (),
           lambda: ()
       ),
       (
-          "CASE_1",
+          "TestCase_1",
           lambda: tensor_shape.TensorShape([]),
           lambda: ops.Tensor,
           lambda: tensor_shape.TensorShape([])
       ),
       (
-          "CASE_2",
+          "TestCase_2",
           lambda: tensor_shape.TensorShape([]),
           lambda: sparse_tensor.SparseTensor,
           lambda: tensor_shape.unknown_shape() # pylint: disable=unnecessary-lambda
       ),
       (
-          "CASE_3",
+          "TestCase_3",
           lambda: (tensor_shape.TensorShape([])),
           lambda: (ops.Tensor),
           lambda: (tensor_shape.TensorShape([]))
       ),
       (
-          "CASE_4",
+          "TestCase_4",
           lambda: (tensor_shape.TensorShape([])),
           lambda: (sparse_tensor.SparseTensor),
           lambda: (tensor_shape.unknown_shape()) # pylint: disable=unnecessary-lambda
       ),
       (
-          "CASE_5",
+          "TestCase_5",
           lambda: (tensor_shape.TensorShape([]), ()),
           lambda: (ops.Tensor, ()),
           lambda: (tensor_shape.TensorShape([]), ())
       ),
       (
-          "CASE_6",
+          "TestCase_6",
           lambda: ((), tensor_shape.TensorShape([])),
           lambda: ((), ops.Tensor),
           lambda: ((), tensor_shape.TensorShape([]))
       ),
       (
-          "CASE_7",
+          "TestCase_7",
           lambda: (tensor_shape.TensorShape([]), ()),
           lambda: (sparse_tensor.SparseTensor, ()),
           lambda: (tensor_shape.unknown_shape(), ())
       ),
       (
-          "CASE_8",
+          "TestCase_8",
           lambda: ((), tensor_shape.TensorShape([])),
           lambda: ((), sparse_tensor.SparseTensor),
           lambda: ((), tensor_shape.unknown_shape())
       ),
       (
-          "CASE_9",
+          "TestCase_9",
           lambda: (tensor_shape.TensorShape([]), (),
                    tensor_shape.TensorShape([])),
           lambda: (ops.Tensor, (), ops.Tensor),
@@ -129,7 +129,7 @@ def _test_as_dense_shapes_combinations():
                    tensor_shape.TensorShape([]))
       ),
       (
-          "CASE_10",
+          "TestCase_10",
           lambda: (tensor_shape.TensorShape([]), (),
                    tensor_shape.TensorShape([])),
           lambda: (sparse_tensor.SparseTensor, (),
@@ -138,13 +138,13 @@ def _test_as_dense_shapes_combinations():
                    tensor_shape.unknown_shape())
       ),
       (
-          "CASE_11",
+          "TestCase_11",
           lambda: ((), tensor_shape.TensorShape([]), ()),
           lambda: ((), ops.Tensor, ()),
           lambda: ((), tensor_shape.TensorShape([]), ())
       ),
       (
-          "CASE_12",
+          "TestCase_12",
           lambda: ((), tensor_shape.TensorShape([]), ()),
           lambda: ((), sparse_tensor.SparseTensor, ()),
           lambda: ((), tensor_shape.unknown_shape(), ())
@@ -170,80 +170,80 @@ def _test_as_dense_shapes_combinations():
 def _test_as_dense_types_combinations():
   cases = [
       (
-          "CASE_0",
+          "TestCase_0",
           lambda: (),
           lambda: (),
           lambda: ()
       ),
       (
-          "CASE_1",
+          "TestCase_1",
           lambda: dtypes.int32,
           lambda: ops.Tensor,
           lambda: dtypes.int32
       ),
       (
-          "CASE_2",
+          "TestCase_2",
           lambda: dtypes.int32,
           lambda: sparse_tensor.SparseTensor,
           lambda: dtypes.variant
       ),
       (
-          "CASE_3",
+          "TestCase_3",
           lambda: (dtypes.int32),
           lambda: (ops.Tensor),
           lambda: (dtypes.int32)
       ),
       (
-          "CASE_4",
+          "TestCase_4",
           lambda: (dtypes.int32),
           lambda: (sparse_tensor.SparseTensor),
           lambda: (dtypes.variant)
       ),
       (
-          "CASE_5",
+          "TestCase_5",
           lambda: (dtypes.int32, ()),
           lambda: (ops.Tensor, ()),
           lambda: (dtypes.int32, ())
       ),
       (
-          "CASE_6",
+          "TestCase_6",
           lambda: ((), dtypes.int32),
           lambda: ((), ops.Tensor),
           lambda: ((), dtypes.int32)
       ),
       (
-          "CASE_7",
+          "TestCase_7",
           lambda: (dtypes.int32, ()),
           lambda: (sparse_tensor.SparseTensor, ()),
           lambda: (dtypes.variant, ())
       ),
       (
-          "CASE_8",
+          "TestCase_8",
           lambda: ((), dtypes.int32),
           lambda: ((), sparse_tensor.SparseTensor),
           lambda: ((), dtypes.variant)
       ),
       (
-          "CASE_9",
+          "TestCase_9",
           lambda: (dtypes.int32, (), dtypes.int32),
           lambda: (ops.Tensor, (), ops.Tensor),
           lambda: (dtypes.int32, (), dtypes.int32)
       ),
       (
-          "CASE_10",
+          "TestCase_10",
           lambda: (dtypes.int32, (), dtypes.int32),
           lambda: (sparse_tensor.SparseTensor, (),
                    sparse_tensor.SparseTensor),
           lambda: (dtypes.variant, (), dtypes.variant)
       ),
       (
-          "CASE_11",
+          "TestCase_11",
           lambda: ((), dtypes.int32, ()),
           lambda: ((), ops.Tensor, ()),
           lambda: ((), dtypes.int32, ())
       ),
       (
-          "CASE_12",
+          "TestCase_12",
           lambda: ((), dtypes.int32, ()),
           lambda: ((), sparse_tensor.SparseTensor, ()),
           lambda: ((), dtypes.variant, ())
@@ -268,69 +268,69 @@ def _test_as_dense_types_combinations():
 def _test_get_classes_combinations():
   cases = [
       (
-          "CASE_0",
+          "TestCase_0",
           lambda: (),
           lambda: ()
       ),
       (
-          "CASE_1",
+          "TestCase_1",
           lambda: sparse_tensor.SparseTensor(
               indices=[[0]], values=[1], dense_shape=[1]),
           lambda: sparse_tensor.SparseTensor
       ),
       (
-          "CASE_2",
+          "TestCase_2",
           lambda: constant_op.constant([1]),
           lambda: ops.Tensor
       ),
       (
-          "CASE_3",
+          "TestCase_3",
           lambda: (sparse_tensor.SparseTensor(
               indices=[[0]], values=[1], dense_shape=[1])),
           lambda: (sparse_tensor.SparseTensor)
       ),
       (
-          "CASE_4",
+          "TestCase_4",
           lambda: (constant_op.constant([1])),
           lambda: (ops.Tensor)
       ),
       (
-          "CASE_5",
+          "TestCase_5",
           lambda: (sparse_tensor.SparseTensor(
               indices=[[0]], values=[1], dense_shape=[1]), ()),
           lambda: (sparse_tensor.SparseTensor, ())
       ),
       (
-          "CASE_6",
+          "TestCase_6",
           lambda: ((), sparse_tensor.SparseTensor(
               indices=[[0]], values=[1], dense_shape=[1])),
           lambda: ((), sparse_tensor.SparseTensor)
       ),
       (
-          "CASE_7",
+          "TestCase_7",
           lambda: (constant_op.constant([1]), ()),
           lambda: (ops.Tensor, ())
       ),
       (
-          "CASE_8",
+          "TestCase_8",
           lambda: ((), constant_op.constant([1])),
           lambda: ((), ops.Tensor)
       ),
       (
-          "CASE_9",
+          "TestCase_9",
           lambda: (sparse_tensor.SparseTensor(
               indices=[[0]], values=[1], dense_shape=[1]),
                    (), constant_op.constant([1])),
           lambda: (sparse_tensor.SparseTensor, (), ops.Tensor)
       ),
       (
-          "CASE_10",
+          "TestCase_10",
           lambda: ((), sparse_tensor.SparseTensor(
               indices=[[0]], values=[1], dense_shape=[1]), ()),
           lambda: ((), sparse_tensor.SparseTensor, ())
       ),
       (
-          "CASE_11",
+          "TestCase_11",
           lambda: ((), constant_op.constant([1]), ()),
           lambda: ((), ops.Tensor, ())
       ),
@@ -351,19 +351,19 @@ def _test_get_classes_combinations():
 
 def _test_serialize_deserialize_combinations():
   cases = [
-      ("CASE_0", lambda: ()),
-      ("CASE_1", lambda: sparse_tensor.SparseTensor(
+      ("TestCase_0", lambda: ()),
+      ("TestCase_1", lambda: sparse_tensor.SparseTensor(
           indices=[[0, 0]], values=[1], dense_shape=[1, 1])),
-      ("CASE_2", lambda: sparse_tensor.SparseTensor(
+      ("TestCase_2", lambda: sparse_tensor.SparseTensor(
           indices=[[3, 4]], values=[-1], dense_shape=[4, 5])),
-      ("CASE_3", lambda: sparse_tensor.SparseTensor(
+      ("TestCase_3", lambda: sparse_tensor.SparseTensor(
           indices=[[0, 0], [3, 4]], values=[1, -1],
           dense_shape=[4, 5])),
-      ("CASE_4", lambda: (sparse_tensor.SparseTensor(
+      ("TestCase_4", lambda: (sparse_tensor.SparseTensor(
           indices=[[0, 0]], values=[1], dense_shape=[1, 1]))),
-      ("CASE_5", lambda: (sparse_tensor.SparseTensor(
+      ("TestCase_5", lambda: (sparse_tensor.SparseTensor(
           indices=[[0, 0]], values=[1], dense_shape=[1, 1]), ())),
-      ("CASE_6", lambda: ((), sparse_tensor.SparseTensor(
+      ("TestCase_6", lambda: ((), sparse_tensor.SparseTensor(
           indices=[[0, 0]], values=[1], dense_shape=[1, 1])))
   ]
   def reduce_fn(x, y):
@@ -379,19 +379,19 @@ def _test_serialize_deserialize_combinations():
 
 def _test_serialize_many_deserialize_combinations():
   cases = [
-      ("CASE_0", lambda: ()),
-      ("CASE_1", lambda: sparse_tensor.SparseTensor(
+      ("TestCase_0", lambda: ()),
+      ("TestCase_1", lambda: sparse_tensor.SparseTensor(
           indices=[[0, 0]], values=[1], dense_shape=[1, 1])),
-      ("CASE_2", lambda: sparse_tensor.SparseTensor(
+      ("TestCase_2", lambda: sparse_tensor.SparseTensor(
           indices=[[3, 4]], values=[-1], dense_shape=[4, 5])),
-      ("CASE_3", lambda: sparse_tensor.SparseTensor(
+      ("TestCase_3", lambda: sparse_tensor.SparseTensor(
           indices=[[0, 0], [3, 4]], values=[1, -1],
           dense_shape=[4, 5])),
-      ("CASE_4", lambda: (sparse_tensor.SparseTensor(
+      ("TestCase_4", lambda: (sparse_tensor.SparseTensor(
           indices=[[0, 0]], values=[1], dense_shape=[1, 1]))),
-      ("CASE_5", lambda: (sparse_tensor.SparseTensor(
+      ("TestCase_5", lambda: (sparse_tensor.SparseTensor(
           indices=[[0, 0]], values=[1], dense_shape=[1, 1]), ())),
-      ("CASE_6", lambda: ((), sparse_tensor.SparseTensor(
+      ("TestCase_6", lambda: ((), sparse_tensor.SparseTensor(
           indices=[[0, 0]], values=[1], dense_shape=[1, 1])))
   ]
   def reduce_fn(x, y):

--- a/tensorflow/python/data/util/sparse_test.py
+++ b/tensorflow/python/data/util/sparse_test.py
@@ -56,9 +56,7 @@ def _test_any_sparse_combinations():
         classes_fn=combinations.NamedObject(
             "classes_fn.{}".format(name), classes_fn
         ),
-        expected=combinations.NamedObject(
-            "expected.{}".format(name), expected
-        )
+        expected=expected
     )
 
   return functools.reduce(reduce_fn, cases, [])
@@ -415,7 +413,6 @@ class SparseTest(test_base.DatasetTestBase, parameterized.TestCase):
   )
   def testAnySparse(self, classes_fn, expected):
     classes = classes_fn()
-    expected = expected._obj # pylint: disable=protected-access
     self.assertEqual(sparse.any_sparse(classes), expected)
 
   def assertShapesEqual(self, a, b):

--- a/tensorflow/python/data/util/sparse_test.py
+++ b/tensorflow/python/data/util/sparse_test.py
@@ -37,45 +37,46 @@ class SparseTest(test_base.DatasetTestBase, parameterized.TestCase):
   @combinations.generate(
       combinations.times(
           test_base.default_test_combinations(),
-          combinations.combine(test_case=[
-              combinations.NamedObject("Case_0", {
+          combinations.combine(test_case_fn=[
+              combinations.NamedObject("Case_0", lambda: {
                   "classes": (),
                   "expected": False
               }),
-              combinations.NamedObject("Case_1", {
+              combinations.NamedObject("Case_1", lambda: {
                   "classes": (ops.Tensor),
                   "expected": False
               }),
-              combinations.NamedObject("Case_2", {
+              combinations.NamedObject("Case_2", lambda: {
                   "classes": (((ops.Tensor))),
                   "expected": False
               }),
-              combinations.NamedObject("Case_3", {
+              combinations.NamedObject("Case_3", lambda: {
                   "classes": (ops.Tensor, ops.Tensor),
                   "expected": False
               }),
-              combinations.NamedObject("Case_4", {
+              combinations.NamedObject("Case_4", lambda: {
                   "classes": (ops.Tensor, sparse_tensor.SparseTensor),
                   "expected": True
               }),
-              combinations.NamedObject("Case_5", {
+              combinations.NamedObject("Case_5", lambda: {
                   "classes": (sparse_tensor.SparseTensor,
                               sparse_tensor.SparseTensor),
                   "expected": True
               }),
-              combinations.NamedObject("Case_6", {
+              combinations.NamedObject("Case_6", lambda: {
                   "classes": (((sparse_tensor.SparseTensor))),
                   "expected": True
               }),
           ])
       )
   )
-  def testAnySparse(self, test_case):
-    test_case = test_case._obj  # pylint: disable=protected-access
-    self.assertEqual(sparse.any_sparse(
-        test_case["classes"]), test_case["expected"])
+  def testAnySparse(self, test_case_fn):
+    test_case_fn = test_case_fn._obj  # pylint: disable=protected-access
+    test_case = test_case_fn()
+    classes = test_case["classes"]
+    expected = test_case["expected"]
+    self.assertEqual(sparse.any_sparse(classes), expected)
 
-  @combinations.generate(test_base.default_test_combinations())
   def assertShapesEqual(self, a, b):
     for a, b in zip(nest.flatten(a), nest.flatten(b)):
       self.assertEqual(a.ndims, b.ndims)
@@ -87,60 +88,60 @@ class SparseTest(test_base.DatasetTestBase, parameterized.TestCase):
   @combinations.generate(
       combinations.times(
           test_base.default_test_combinations(),
-          combinations.combine(test_case=[
-              combinations.NamedObject("Case_0", {
+          combinations.combine(test_case_fn=[
+              combinations.NamedObject("Case_0", lambda: {
                   "types": (),
                   "classes": (),
                   "expected": ()
               }),
-              combinations.NamedObject("Case_1", {
+              combinations.NamedObject("Case_1", lambda: {
                   "types": tensor_shape.TensorShape([]),
                   "classes": ops.Tensor,
                   "expected": tensor_shape.TensorShape([])
               }),
-              combinations.NamedObject("Case_2", {
+              combinations.NamedObject("Case_2", lambda: {
                   "types": tensor_shape.TensorShape([]),
                   "classes": sparse_tensor.SparseTensor,
                   "expected": tensor_shape.unknown_shape()
               }),
-              combinations.NamedObject("Case_3", {
+              combinations.NamedObject("Case_3", lambda: {
                   "types": (tensor_shape.TensorShape([])),
                   "classes": (ops.Tensor),
                   "expected": (tensor_shape.TensorShape([]))
               }),
-              combinations.NamedObject("Case_4", {
+              combinations.NamedObject("Case_4", lambda: {
                   "types": (tensor_shape.TensorShape([])),
                   "classes": (sparse_tensor.SparseTensor),
                   "expected": (tensor_shape.unknown_shape())
               }),
-              combinations.NamedObject("Case_5", {
+              combinations.NamedObject("Case_5", lambda: {
                   "types": (tensor_shape.TensorShape([]), ()),
                   "classes": (ops.Tensor, ()),
                   "expected": (tensor_shape.TensorShape([]), ())
               }),
-              combinations.NamedObject("Case_6", {
+              combinations.NamedObject("Case_6", lambda: {
                   "types": ((), tensor_shape.TensorShape([])),
                   "classes": ((), ops.Tensor),
                   "expected": ((), tensor_shape.TensorShape([]))
               }),
-              combinations.NamedObject("Case_7", {
+              combinations.NamedObject("Case_7", lambda: {
                   "types": (tensor_shape.TensorShape([]), ()),
                   "classes": (sparse_tensor.SparseTensor, ()),
                   "expected": (tensor_shape.unknown_shape(), ())
               }),
-              combinations.NamedObject("Case_8", {
+              combinations.NamedObject("Case_8", lambda: {
                   "types": ((), tensor_shape.TensorShape([])),
                   "classes": ((), sparse_tensor.SparseTensor),
                   "expected": ((), tensor_shape.unknown_shape())
               }),
-              combinations.NamedObject("Case_9", {
+              combinations.NamedObject("Case_9", lambda: {
                   "types": (tensor_shape.TensorShape([]), (),
                             tensor_shape.TensorShape([])),
                   "classes": (ops.Tensor, (), ops.Tensor),
                   "expected": (tensor_shape.TensorShape([]), (),
                                tensor_shape.TensorShape([]))
               }),
-              combinations.NamedObject("Case_10", {
+              combinations.NamedObject("Case_10", lambda: {
                   "types": (tensor_shape.TensorShape([]), (),
                             tensor_shape.TensorShape([])),
                   "classes": (sparse_tensor.SparseTensor, (),
@@ -148,12 +149,12 @@ class SparseTest(test_base.DatasetTestBase, parameterized.TestCase):
                   "expected": (tensor_shape.unknown_shape(), (),
                                tensor_shape.unknown_shape())
               }),
-              combinations.NamedObject("Case_11", {
+              combinations.NamedObject("Case_11", lambda: {
                   "types": ((), tensor_shape.TensorShape([]), ()),
                   "classes": ((), ops.Tensor, ()),
                   "expected": ((), tensor_shape.TensorShape([]), ())
               }),
-              combinations.NamedObject("Case_12", {
+              combinations.NamedObject("Case_12", lambda: {
                   "types": ((), tensor_shape.TensorShape([]), ()),
                   "classes": ((), sparse_tensor.SparseTensor, ()),
                   "expected": ((), tensor_shape.unknown_shape(), ())
@@ -161,78 +162,80 @@ class SparseTest(test_base.DatasetTestBase, parameterized.TestCase):
           ])
       )
   )
-  def testAsDenseShapes(self, test_case):
-    test_case = test_case._obj  # pylint: disable=protected-access
-    self.assertShapesEqual(
-        sparse.as_dense_shapes(test_case["types"], test_case["classes"]),
-        test_case["expected"])
+  def testAsDenseShapes(self, test_case_fn):
+    test_case_fn = test_case_fn._obj  # pylint: disable=protected-access
+    test_case = test_case_fn()
+    types = test_case["types"]
+    classes = test_case["classes"]
+    expected = test_case["expected"]
+    self.assertShapesEqual(sparse.as_dense_shapes(types, classes), expected)
 
   @combinations.generate(
       combinations.times(
           test_base.default_test_combinations(),
-          combinations.combine(test_case=[
-              combinations.NamedObject("Case_0", {
+          combinations.combine(test_case_fn=[
+              combinations.NamedObject("Case_0", lambda: {
                   "types": (),
                   "classes": (),
                   "expected": ()
               }),
-              combinations.NamedObject("Case_1", {
+              combinations.NamedObject("Case_1", lambda: {
                   "types": dtypes.int32,
                   "classes": ops.Tensor,
                   "expected": dtypes.int32
               }),
-              combinations.NamedObject("Case_2", {
+              combinations.NamedObject("Case_2", lambda: {
                   "types": dtypes.int32,
                   "classes": sparse_tensor.SparseTensor,
                   "expected": dtypes.variant
               }),
-              combinations.NamedObject("Case_3", {
+              combinations.NamedObject("Case_3", lambda: {
                   "types": (dtypes.int32),
                   "classes": (ops.Tensor),
                   "expected": (dtypes.int32)
               }),
-              combinations.NamedObject("Case_4", {
+              combinations.NamedObject("Case_4", lambda: {
                   "types": (dtypes.int32),
                   "classes": (sparse_tensor.SparseTensor),
                   "expected": (dtypes.variant)
               }),
-              combinations.NamedObject("Case_5", {
+              combinations.NamedObject("Case_5", lambda: {
                   "types": (dtypes.int32, ()),
                   "classes": (ops.Tensor, ()),
                   "expected": (dtypes.int32, ())
               }),
-              combinations.NamedObject("Case_6", {
+              combinations.NamedObject("Case_6", lambda: {
                   "types": ((), dtypes.int32),
                   "classes": ((), ops.Tensor),
                   "expected": ((), dtypes.int32)
               }),
-              combinations.NamedObject("Case_7", {
+              combinations.NamedObject("Case_7", lambda: {
                   "types": (dtypes.int32, ()),
                   "classes": (sparse_tensor.SparseTensor, ()),
                   "expected": (dtypes.variant, ())
               }),
-              combinations.NamedObject("Case_8", {
+              combinations.NamedObject("Case_8", lambda: {
                   "types": ((), dtypes.int32),
                   "classes": ((), sparse_tensor.SparseTensor),
                   "expected": ((), dtypes.variant)
               }),
-              combinations.NamedObject("Case_9", {
+              combinations.NamedObject("Case_9", lambda: {
                   "types": (dtypes.int32, (), dtypes.int32),
                   "classes": (ops.Tensor, (), ops.Tensor),
                   "expected": (dtypes.int32, (), dtypes.int32)
               }),
-              combinations.NamedObject("Case_10", {
+              combinations.NamedObject("Case_10", lambda: {
                   "types": (dtypes.int32, (), dtypes.int32),
                   "classes": (sparse_tensor.SparseTensor, (),
                               sparse_tensor.SparseTensor),
                   "expected": (dtypes.variant, (), dtypes.variant)
               }),
-              combinations.NamedObject("Case_11", {
+              combinations.NamedObject("Case_11", lambda: {
                   "types": ((), dtypes.int32, ()),
                   "classes": ((), ops.Tensor, ()),
                   "expected": ((), dtypes.int32, ())
               }),
-              combinations.NamedObject("Case_12", {
+              combinations.NamedObject("Case_12", lambda: {
                   "types": ((), dtypes.int32, ()),
                   "classes": ((), sparse_tensor.SparseTensor, ()),
                   "expected": ((), dtypes.variant, ())
@@ -240,82 +243,85 @@ class SparseTest(test_base.DatasetTestBase, parameterized.TestCase):
           ])
       )
   )
-  def testAsDenseTypes(self, test_case):
-    test_case = test_case._obj  # pylint: disable=protected-access
-    self.assertEqual(
-        sparse.as_dense_types(test_case["types"], test_case["classes"]),
-        test_case["expected"])
+  def testAsDenseTypes(self, test_case_fn):
+    test_case_fn = test_case_fn._obj  # pylint: disable=protected-access
+    test_case = test_case_fn()
+    types = test_case["types"]
+    classes = test_case["classes"]
+    expected = test_case["expected"]
+    self.assertEqual(sparse.as_dense_types(types, classes), expected)
 
   @combinations.generate(
       combinations.times(
           test_base.default_test_combinations(),
-          combinations.combine(test_case=[
-              combinations.NamedObject("Case_0", {
+          combinations.combine(test_case_fn=[
+              combinations.NamedObject("Case_0", lambda: {
                   "classes": (),
                   "expected": ()
               }),
-              combinations.NamedObject("Case_1", {
+              combinations.NamedObject("Case_1", lambda: {
                   "classes": sparse_tensor.SparseTensor(
                       indices=[[0]], values=[1], dense_shape=[1]
                   ),
                   "expected": sparse_tensor.SparseTensor
               }),
-              combinations.NamedObject("Case_2", {
+              combinations.NamedObject("Case_2", lambda: {
                   "classes": constant_op.constant([1]),
                   "expected": ops.Tensor
               }),
-              combinations.NamedObject("Case_3", {
+              combinations.NamedObject("Case_3", lambda: {
                   "classes": (sparse_tensor.SparseTensor(
                       indices=[[0]], values=[1], dense_shape=[1])),
                   "expected": (sparse_tensor.SparseTensor)
               }),
-              combinations.NamedObject("Case_4", {
+              combinations.NamedObject("Case_4", lambda: {
                   "classes": (constant_op.constant([1])),
                   "expected": (ops.Tensor)
               }),
-              combinations.NamedObject("Case_5", {
+              combinations.NamedObject("Case_5", lambda: {
                   "classes": (sparse_tensor.SparseTensor(
                       indices=[[0]], values=[1], dense_shape=[1]), ()),
                   "expected": (sparse_tensor.SparseTensor, ())
               }),
-              combinations.NamedObject("Case_6", {
+              combinations.NamedObject("Case_6", lambda: {
                   "classes": ((), sparse_tensor.SparseTensor(
                       indices=[[0]], values=[1], dense_shape=[1])),
                   "expected": ((), sparse_tensor.SparseTensor)
               }),
-              combinations.NamedObject("Case_7", {
+              combinations.NamedObject("Case_7", lambda: {
                   "classes": (constant_op.constant([1]), ()),
                   "expected": (ops.Tensor, ())
               }),
-              combinations.NamedObject("Case_8", {
+              combinations.NamedObject("Case_8", lambda: {
                   "classes": ((), constant_op.constant([1])),
                   "expected": ((), ops.Tensor)
               }),
-              combinations.NamedObject("Case_9", {
+              combinations.NamedObject("Case_9", lambda: {
                   "classes": (
                       sparse_tensor.SparseTensor(
                           indices=[[0]], values=[1], dense_shape=[1]),
                       (), constant_op.constant([1])),
                   "expected": (sparse_tensor.SparseTensor, (), ops.Tensor)
               }),
-              combinations.NamedObject("Case_10", {
+              combinations.NamedObject("Case_10", lambda: {
                   "classes": ((), sparse_tensor.SparseTensor(
                       indices=[[0]], values=[1], dense_shape=[1]), ()),
                   "expected": ((), sparse_tensor.SparseTensor, ())
               }),
-              combinations.NamedObject("Case_11", {
+              combinations.NamedObject("Case_11", lambda: {
                   "classes": ((), constant_op.constant([1]), ()),
                   "expected": ((), ops.Tensor, ())
               }),
           ])
       )
   )
-  def testGetClasses(self, test_case):
-    test_case = test_case._obj  # pylint: disable=protected-access
-    self.assertEqual(
-        sparse.get_classes(test_case["classes"]), test_case["expected"])
+  def testGetClasses(self, test_case_fn):
+    test_case_fn = test_case_fn._obj  # pylint: disable=protected-access
+    test_case = test_case_fn()
+    classes = test_case["classes"]
+    expected = test_case["expected"]
+    self.assertEqual(sparse.get_classes(classes), expected)
 
-  @combinations.generate(test_base.default_test_combinations())
   def assertSparseValuesEqual(self, a, b):
     if not isinstance(a, sparse_tensor.SparseTensor):
       self.assertFalse(isinstance(b, sparse_tensor.SparseTensor))
@@ -330,33 +336,40 @@ class SparseTest(test_base.DatasetTestBase, parameterized.TestCase):
   @combinations.generate(
       combinations.times(
           test_base.graph_only_combinations(),
-          combinations.combine(test_case=[
+          combinations.combine(test_case_fn=[
               combinations.NamedObject(
-                  "Case_0", ()),
+                  "Case_0", lambda: ()
+              ),
               combinations.NamedObject(
-                  "Case_1", sparse_tensor.SparseTensor(
-                      indices=[[0, 0]], values=[1], dense_shape=[1, 1])),
+                  "Case_1", lambda: sparse_tensor.SparseTensor(
+                      indices=[[0, 0]], values=[1], dense_shape=[1, 1])
+              ),
               combinations.NamedObject(
-                  "Case_2", sparse_tensor.SparseTensor(
-                      indices=[[3, 4]], values=[-1], dense_shape=[4, 5])),
+                  "Case_2", lambda: sparse_tensor.SparseTensor(
+                      indices=[[3, 4]], values=[-1], dense_shape=[4, 5])
+              ),
               combinations.NamedObject(
-                  "Case_3", sparse_tensor.SparseTensor(
+                  "Case_3", lambda: sparse_tensor.SparseTensor(
                       indices=[[0, 0], [3, 4]], values=[1, -1],
-                      dense_shape=[4, 5])),
+                      dense_shape=[4, 5])
+              ),
               combinations.NamedObject(
-                  "Case_4", (sparse_tensor.SparseTensor(
-                      indices=[[0, 0]], values=[1], dense_shape=[1, 1]))),
+                  "Case_4", lambda: (sparse_tensor.SparseTensor(
+                      indices=[[0, 0]], values=[1], dense_shape=[1, 1]))
+              ),
               combinations.NamedObject(
-                  "Case_5", (sparse_tensor.SparseTensor(
-                      indices=[[0, 0]], values=[1], dense_shape=[1, 1]), ())),
+                  "Case_5", lambda: (sparse_tensor.SparseTensor(
+                      indices=[[0, 0]], values=[1], dense_shape=[1, 1]), ())
+              ),
               combinations.NamedObject(
-                  "Case_6", ((), sparse_tensor.SparseTensor(
+                  "Case_6", lambda: ((), sparse_tensor.SparseTensor(
                       indices=[[0, 0]], values=[1], dense_shape=[1, 1]))),
           ])
       )
   )
-  def testSerializeDeserialize(self, test_case):
-    test_case = test_case._obj  # pylint: disable=protected-access
+  def testSerializeDeserialize(self, test_case_fn):
+    test_case_fn = test_case_fn._obj  # pylint: disable=protected-access
+    test_case = test_case_fn()
     classes = sparse.get_classes(test_case)
     shapes = nest.map_structure(lambda _: tensor_shape.TensorShape(None),
                                 classes)
@@ -371,33 +384,41 @@ class SparseTest(test_base.DatasetTestBase, parameterized.TestCase):
   @combinations.generate(
       combinations.times(
           test_base.graph_only_combinations(),
-          combinations.combine(test_case=[
+          combinations.combine(test_case_fn=[
               combinations.NamedObject(
-                  "Case_0", ()),
+                  "Case_0", lambda: ()
+              ),
               combinations.NamedObject(
-                  "Case_1", sparse_tensor.SparseTensor(
-                      indices=[[0, 0]], values=[1], dense_shape=[1, 1])),
+                  "Case_1", lambda: sparse_tensor.SparseTensor(
+                      indices=[[0, 0]], values=[1], dense_shape=[1, 1])
+              ),
               combinations.NamedObject(
-                  "Case_2", sparse_tensor.SparseTensor(
-                      indices=[[3, 4]], values=[-1], dense_shape=[4, 5])),
+                  "Case_2", lambda: sparse_tensor.SparseTensor(
+                      indices=[[3, 4]], values=[-1], dense_shape=[4, 5])
+              ),
               combinations.NamedObject(
-                  "Case_3", sparse_tensor.SparseTensor(
+                  "Case_3", lambda: sparse_tensor.SparseTensor(
                       indices=[[0, 0], [3, 4]], values=[1, -1],
-                      dense_shape=[4, 5])),
+                      dense_shape=[4, 5])
+              ),
               combinations.NamedObject(
-                  "Case_4", (sparse_tensor.SparseTensor(
-                      indices=[[0, 0]], values=[1], dense_shape=[1, 1]))),
+                  "Case_4", lambda: (sparse_tensor.SparseTensor(
+                      indices=[[0, 0]], values=[1], dense_shape=[1, 1]))
+              ),
               combinations.NamedObject(
-                  "Case_5", (sparse_tensor.SparseTensor(
-                      indices=[[0, 0]], values=[1], dense_shape=[1, 1]), ())),
+                  "Case_5", lambda: (sparse_tensor.SparseTensor(
+                      indices=[[0, 0]], values=[1], dense_shape=[1, 1]), ())
+              ),
               combinations.NamedObject(
-                  "Case_6", ((), sparse_tensor.SparseTensor(
-                      indices=[[0, 0]], values=[1], dense_shape=[1, 1]))),
+                  "Case_6", lambda: ((), sparse_tensor.SparseTensor(
+                      indices=[[0, 0]], values=[1], dense_shape=[1, 1]))
+              ),
           ])
       )
   )
-  def testSerializeManyDeserialize(self, test_case):
-    test_case = test_case._obj  # pylint: disable=protected-access
+  def testSerializeManyDeserialize(self, test_case_fn):
+    test_case_fn = test_case_fn._obj  # pylint: disable=protected-access
+    test_case = test_case_fn()
     classes = sparse.get_classes(test_case)
     shapes = nest.map_structure(lambda _: tensor_shape.TensorShape(None),
                                 classes)

--- a/tensorflow/python/data/util/sparse_test.py
+++ b/tensorflow/python/data/util/sparse_test.py
@@ -33,7 +33,8 @@ from tensorflow.python.platform import test
 
 
 class SparseTest(test_base.DatasetTestBase, parameterized.TestCase):
-
+  
+  @combinations.generate(test_base.default_test_combinations())
   def testAnySparse(self):
     test_cases = (
         {
@@ -73,7 +74,8 @@ class SparseTest(test_base.DatasetTestBase, parameterized.TestCase):
     for test_case in test_cases:
       self.assertEqual(
           sparse.any_sparse(test_case["classes"]), test_case["expected"])
-
+  
+  @combinations.generate(test_base.default_test_combinations())
   def assertShapesEqual(self, a, b):
     for a, b in zip(nest.flatten(a), nest.flatten(b)):
       self.assertEqual(a.ndims, b.ndims)
@@ -81,7 +83,8 @@ class SparseTest(test_base.DatasetTestBase, parameterized.TestCase):
         continue
       for c, d in zip(a.as_list(), b.as_list()):
         self.assertEqual(c, d)
-
+  
+  @combinations.generate(test_base.default_test_combinations())
   def testAsDenseShapes(self):
     test_cases = (
         {
@@ -159,7 +162,8 @@ class SparseTest(test_base.DatasetTestBase, parameterized.TestCase):
       self.assertShapesEqual(
           sparse.as_dense_shapes(test_case["types"], test_case["classes"]),
           test_case["expected"])
-
+  
+  @combinations.generate(test_base.default_test_combinations())
   def testAsDenseTypes(self):
     test_cases = (
         {
@@ -233,7 +237,8 @@ class SparseTest(test_base.DatasetTestBase, parameterized.TestCase):
       self.assertEqual(
           sparse.as_dense_types(test_case["types"], test_case["classes"]),
           test_case["expected"])
-
+  
+  @combinations.generate(test_base.default_test_combinations())
   def testGetClasses(self):
     s = sparse_tensor.SparseTensor(indices=[[0]], values=[1], dense_shape=[1])
     d = ops.Tensor
@@ -291,7 +296,8 @@ class SparseTest(test_base.DatasetTestBase, parameterized.TestCase):
     for test_case in test_cases:
       self.assertEqual(
           sparse.get_classes(test_case["classes"]), test_case["expected"])
-
+  
+  @combinations.generate(test_base.default_test_combinations())
   def assertSparseValuesEqual(self, a, b):
     if not isinstance(a, sparse_tensor.SparseTensor):
       self.assertFalse(isinstance(b, sparse_tensor.SparseTensor))

--- a/tensorflow/python/data/util/sparse_test.py
+++ b/tensorflow/python/data/util/sparse_test.py
@@ -18,6 +18,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from absl.testing import parameterized
+
 from tensorflow.python.data.util import nest
 from tensorflow.python.data.util import sparse
 from tensorflow.python.data.kernel_tests import test_base
@@ -30,7 +32,7 @@ from tensorflow.python.framework import tensor_shape
 from tensorflow.python.platform import test
 
 
-class SparseTest(test.TestCase):
+class SparseTest(test_base.DatasetTestBase, parameterized.TestCase):
 
   def testAnySparse(self):
     test_cases = (

--- a/tensorflow/python/data/util/sparse_test.py
+++ b/tensorflow/python/data/util/sparse_test.py
@@ -33,48 +33,52 @@ from tensorflow.python.platform import test
 
 
 class SparseTest(test_base.DatasetTestBase, parameterized.TestCase):
-  
-  @combinations.generate(test_base.default_test_combinations())
-  def testAnySparse(self):
-    test_cases = (
-        {
-            "classes": (),
-            "expected": False
-        },
-        {
-            "classes": (ops.Tensor),
-            "expected": False
-        },
-        {
-            "classes": (((ops.Tensor))),
-            "expected": False
-        },
-        {
-            "classes": (ops.Tensor, ops.Tensor),
-            "expected": False
-        },
-        {
-            "classes": (ops.Tensor, sparse_tensor.SparseTensor),
-            "expected": True
-        },
-        {
-            "classes": (sparse_tensor.SparseTensor, sparse_tensor.SparseTensor),
-            "expected":
-                True
-        },
-        {
-            "classes": (sparse_tensor.SparseTensor, ops.Tensor),
-            "expected": True
-        },
-        {
-            "classes": (((sparse_tensor.SparseTensor))),
-            "expected": True
-        },
-    )
-    for test_case in test_cases:
-      self.assertEqual(
-          sparse.any_sparse(test_case["classes"]), test_case["expected"])
-  
+
+  @combinations.generate(
+      combinations.times(
+          test_base.default_test_combinations(),
+          combinations.combine(test_case=[
+              {
+                  "classes": (),
+                  "expected": False
+              },
+              {
+                  "classes": (ops.Tensor),
+                  "expected": False
+              },
+              {
+                  "classes": (((ops.Tensor))),
+                  "expected": False
+              },
+              {
+                  "classes": (ops.Tensor, ops.Tensor),
+                  "expected": False
+              },
+              {
+                  "classes": (ops.Tensor, sparse_tensor.SparseTensor),
+                  "expected": True
+              },
+              {
+                  "classes": (sparse_tensor.SparseTensor,
+                              sparse_tensor.SparseTensor),
+                  "expected": True
+              },
+              {
+                  "classes": (sparse_tensor.SparseTensor, ops.Tensor),
+                  "expected": True
+              },
+              {
+                  "classes": (((sparse_tensor.SparseTensor))),
+                  "expected": True
+              },
+          ])
+      )
+  )
+  def testAnySparse(self, test_case):
+
+    self.assertEqual(sparse.any_sparse(
+        test_case["classes"]), test_case["expected"])
+
   @combinations.generate(test_base.default_test_combinations())
   def assertShapesEqual(self, a, b):
     for a, b in zip(nest.flatten(a), nest.flatten(b)):
@@ -83,220 +87,236 @@ class SparseTest(test_base.DatasetTestBase, parameterized.TestCase):
         continue
       for c, d in zip(a.as_list(), b.as_list()):
         self.assertEqual(c, d)
-  
-  @combinations.generate(test_base.default_test_combinations())
-  def testAsDenseShapes(self):
-    test_cases = (
-        {
-            "types": (),
-            "classes": (),
-            "expected": ()
-        },
-        {
-            "types": tensor_shape.TensorShape([]),
-            "classes": ops.Tensor,
-            "expected": tensor_shape.TensorShape([])
-        },
-        {
-            "types": tensor_shape.TensorShape([]),
-            "classes": sparse_tensor.SparseTensor,
-            "expected": tensor_shape.unknown_shape()
-        },
-        {
-            "types": (tensor_shape.TensorShape([])),
-            "classes": (ops.Tensor),
-            "expected": (tensor_shape.TensorShape([]))
-        },
-        {
-            "types": (tensor_shape.TensorShape([])),
-            "classes": (sparse_tensor.SparseTensor),
-            "expected": (tensor_shape.unknown_shape())
-        },
-        {
-            "types": (tensor_shape.TensorShape([]), ()),
-            "classes": (ops.Tensor, ()),
-            "expected": (tensor_shape.TensorShape([]), ())
-        },
-        {
-            "types": ((), tensor_shape.TensorShape([])),
-            "classes": ((), ops.Tensor),
-            "expected": ((), tensor_shape.TensorShape([]))
-        },
-        {
-            "types": (tensor_shape.TensorShape([]), ()),
-            "classes": (sparse_tensor.SparseTensor, ()),
-            "expected": (tensor_shape.unknown_shape(), ())
-        },
-        {
-            "types": ((), tensor_shape.TensorShape([])),
-            "classes": ((), sparse_tensor.SparseTensor),
-            "expected": ((), tensor_shape.unknown_shape())
-        },
-        {
-            "types": (tensor_shape.TensorShape([]), (),
-                      tensor_shape.TensorShape([])),
-            "classes": (ops.Tensor, (), ops.Tensor),
-            "expected": (tensor_shape.TensorShape([]), (),
-                         tensor_shape.TensorShape([]))
-        },
-        {
-            "types": (tensor_shape.TensorShape([]), (),
-                      tensor_shape.TensorShape([])),
-            "classes":
-                (sparse_tensor.SparseTensor, (), sparse_tensor.SparseTensor),
-            "expected": (tensor_shape.unknown_shape(), (),
-                         tensor_shape.unknown_shape())
-        },
-        {
-            "types": ((), tensor_shape.TensorShape([]), ()),
-            "classes": ((), ops.Tensor, ()),
-            "expected": ((), tensor_shape.TensorShape([]), ())
-        },
-        {
-            "types": ((), tensor_shape.TensorShape([]), ()),
-            "classes": ((), sparse_tensor.SparseTensor, ()),
-            "expected": ((), tensor_shape.unknown_shape(), ())
-        },
-    )
-    for test_case in test_cases:
-      self.assertShapesEqual(
-          sparse.as_dense_shapes(test_case["types"], test_case["classes"]),
-          test_case["expected"])
-  
-  @combinations.generate(test_base.default_test_combinations())
-  def testAsDenseTypes(self):
-    test_cases = (
-        {
-            "types": (),
-            "classes": (),
-            "expected": ()
-        },
-        {
-            "types": dtypes.int32,
-            "classes": ops.Tensor,
-            "expected": dtypes.int32
-        },
-        {
-            "types": dtypes.int32,
-            "classes": sparse_tensor.SparseTensor,
-            "expected": dtypes.variant
-        },
-        {
-            "types": (dtypes.int32),
-            "classes": (ops.Tensor),
-            "expected": (dtypes.int32)
-        },
-        {
-            "types": (dtypes.int32),
-            "classes": (sparse_tensor.SparseTensor),
-            "expected": (dtypes.variant)
-        },
-        {
-            "types": (dtypes.int32, ()),
-            "classes": (ops.Tensor, ()),
-            "expected": (dtypes.int32, ())
-        },
-        {
-            "types": ((), dtypes.int32),
-            "classes": ((), ops.Tensor),
-            "expected": ((), dtypes.int32)
-        },
-        {
-            "types": (dtypes.int32, ()),
-            "classes": (sparse_tensor.SparseTensor, ()),
-            "expected": (dtypes.variant, ())
-        },
-        {
-            "types": ((), dtypes.int32),
-            "classes": ((), sparse_tensor.SparseTensor),
-            "expected": ((), dtypes.variant)
-        },
-        {
-            "types": (dtypes.int32, (), dtypes.int32),
-            "classes": (ops.Tensor, (), ops.Tensor),
-            "expected": (dtypes.int32, (), dtypes.int32)
-        },
-        {
-            "types": (dtypes.int32, (), dtypes.int32),
-            "classes": (sparse_tensor.SparseTensor, (),
-                        sparse_tensor.SparseTensor),
-            "expected": (dtypes.variant, (), dtypes.variant)
-        },
-        {
-            "types": ((), dtypes.int32, ()),
-            "classes": ((), ops.Tensor, ()),
-            "expected": ((), dtypes.int32, ())
-        },
-        {
-            "types": ((), dtypes.int32, ()),
-            "classes": ((), sparse_tensor.SparseTensor, ()),
-            "expected": ((), dtypes.variant, ())
-        },
-    )
-    for test_case in test_cases:
-      self.assertEqual(
-          sparse.as_dense_types(test_case["types"], test_case["classes"]),
-          test_case["expected"])
-  
-  @combinations.generate(test_base.default_test_combinations())
-  def testGetClasses(self):
-    s = sparse_tensor.SparseTensor(indices=[[0]], values=[1], dense_shape=[1])
-    d = ops.Tensor
-    t = sparse_tensor.SparseTensor
-    test_cases = (
-        {
-            "classes": (),
-            "expected": ()
-        },
-        {
-            "classes": s,
-            "expected": t
-        },
-        {
-            "classes": constant_op.constant([1]),
-            "expected": d
-        },
-        {
-            "classes": (s),
-            "expected": (t)
-        },
-        {
-            "classes": (constant_op.constant([1])),
-            "expected": (d)
-        },
-        {
-            "classes": (s, ()),
-            "expected": (t, ())
-        },
-        {
-            "classes": ((), s),
-            "expected": ((), t)
-        },
-        {
-            "classes": (constant_op.constant([1]), ()),
-            "expected": (d, ())
-        },
-        {
-            "classes": ((), constant_op.constant([1])),
-            "expected": ((), d)
-        },
-        {
-            "classes": (s, (), constant_op.constant([1])),
-            "expected": (t, (), d)
-        },
-        {
-            "classes": ((), s, ()),
-            "expected": ((), t, ())
-        },
-        {
-            "classes": ((), constant_op.constant([1]), ()),
-            "expected": ((), d, ())
-        },
-    )
-    for test_case in test_cases:
-      self.assertEqual(
-          sparse.get_classes(test_case["classes"]), test_case["expected"])
-  
+
+  @combinations.generate(
+      combinations.times(
+          test_base.default_test_combinations(),
+          combinations.combine(test_case=[
+              {
+                  "types": (),
+                  "classes": (),
+                  "expected": ()
+              },
+              {
+                  "types": tensor_shape.TensorShape([]),
+                  "classes": ops.Tensor,
+                  "expected": tensor_shape.TensorShape([])
+              },
+              {
+                  "types": tensor_shape.TensorShape([]),
+                  "classes": sparse_tensor.SparseTensor,
+                  "expected": tensor_shape.unknown_shape()
+              },
+              {
+                  "types": (tensor_shape.TensorShape([])),
+                  "classes": (ops.Tensor),
+                  "expected": (tensor_shape.TensorShape([]))
+              },
+              {
+                  "types": (tensor_shape.TensorShape([])),
+                  "classes": (sparse_tensor.SparseTensor),
+                  "expected": (tensor_shape.unknown_shape())
+              },
+              {
+                  "types": (tensor_shape.TensorShape([]), ()),
+                  "classes": (ops.Tensor, ()),
+                  "expected": (tensor_shape.TensorShape([]), ())
+              },
+              {
+                  "types": ((), tensor_shape.TensorShape([])),
+                  "classes": ((), ops.Tensor),
+                  "expected": ((), tensor_shape.TensorShape([]))
+              },
+              {
+                  "types": (tensor_shape.TensorShape([]), ()),
+                  "classes": (sparse_tensor.SparseTensor, ()),
+                  "expected": (tensor_shape.unknown_shape(), ())
+              },
+              {
+                  "types": ((), tensor_shape.TensorShape([])),
+                  "classes": ((), sparse_tensor.SparseTensor),
+                  "expected": ((), tensor_shape.unknown_shape())
+              },
+              {
+                  "types": (tensor_shape.TensorShape([]), (),
+                            tensor_shape.TensorShape([])),
+                  "classes": (ops.Tensor, (), ops.Tensor),
+                  "expected": (tensor_shape.TensorShape([]), (),
+                               tensor_shape.TensorShape([]))
+              },
+              {
+                  "types": (tensor_shape.TensorShape([]), (),
+                            tensor_shape.TensorShape([])),
+                  "classes": (sparse_tensor.SparseTensor, (),
+                              sparse_tensor.SparseTensor),
+                  "expected": (tensor_shape.unknown_shape(), (),
+                               tensor_shape.unknown_shape())
+              },
+              {
+                  "types": ((), tensor_shape.TensorShape([]), ()),
+                  "classes": ((), ops.Tensor, ()),
+                  "expected": ((), tensor_shape.TensorShape([]), ())
+              },
+              {
+                  "types": ((), tensor_shape.TensorShape([]), ()),
+                  "classes": ((), sparse_tensor.SparseTensor, ()),
+                  "expected": ((), tensor_shape.unknown_shape(), ())
+              },
+          ])
+      )
+  )
+  def testAsDenseShapes(self, test_case):
+
+    self.assertShapesEqual(
+        sparse.as_dense_shapes(test_case["types"], test_case["classes"]),
+        test_case["expected"])
+
+  @combinations.generate(
+      combinations.times(
+          test_base.default_test_combinations(),
+          combinations.combine(test_case=[
+              {
+                  "types": (),
+                  "classes": (),
+                  "expected": ()
+              },
+              {
+                  "types": dtypes.int32,
+                  "classes": ops.Tensor,
+                  "expected": dtypes.int32
+              },
+              {
+                  "types": dtypes.int32,
+                  "classes": sparse_tensor.SparseTensor,
+                  "expected": dtypes.variant
+              },
+              {
+                  "types": (dtypes.int32),
+                  "classes": (ops.Tensor),
+                  "expected": (dtypes.int32)
+              },
+              {
+                  "types": (dtypes.int32),
+                  "classes": (sparse_tensor.SparseTensor),
+                  "expected": (dtypes.variant)
+              },
+              {
+                  "types": (dtypes.int32, ()),
+                  "classes": (ops.Tensor, ()),
+                  "expected": (dtypes.int32, ())
+              },
+              {
+                  "types": ((), dtypes.int32),
+                  "classes": ((), ops.Tensor),
+                  "expected": ((), dtypes.int32)
+              },
+              {
+                  "types": (dtypes.int32, ()),
+                  "classes": (sparse_tensor.SparseTensor, ()),
+                  "expected": (dtypes.variant, ())
+              },
+              {
+                  "types": ((), dtypes.int32),
+                  "classes": ((), sparse_tensor.SparseTensor),
+                  "expected": ((), dtypes.variant)
+              },
+              {
+                  "types": (dtypes.int32, (), dtypes.int32),
+                  "classes": (ops.Tensor, (), ops.Tensor),
+                  "expected": (dtypes.int32, (), dtypes.int32)
+              },
+              {
+                  "types": (dtypes.int32, (), dtypes.int32),
+                  "classes": (sparse_tensor.SparseTensor, (),
+                              sparse_tensor.SparseTensor),
+                  "expected": (dtypes.variant, (), dtypes.variant)
+              },
+              {
+                  "types": ((), dtypes.int32, ()),
+                  "classes": ((), ops.Tensor, ()),
+                  "expected": ((), dtypes.int32, ())
+              },
+              {
+                  "types": ((), dtypes.int32, ()),
+                  "classes": ((), sparse_tensor.SparseTensor, ()),
+                  "expected": ((), dtypes.variant, ())
+              },
+          ])
+      )
+  )
+  def testAsDenseTypes(self, test_case):
+    self.assertEqual(
+        sparse.as_dense_types(test_case["types"], test_case["classes"]),
+        test_case["expected"])
+
+  @combinations.generate(
+      combinations.times(
+          test_base.default_test_combinations(),
+          combinations.combine(test_case=[
+              {
+                  "classes": (),
+                  "expected": ()
+              },
+              {
+                  "classes": sparse_tensor.SparseTensor(
+                      indices=[[0]], values=[1], dense_shape=[1]
+                  ),
+                  "expected": sparse_tensor.SparseTensor
+              },
+              {
+                  "classes": constant_op.constant([1]),
+                  "expected": ops.Tensor
+              },
+              {
+                  "classes": (sparse_tensor.SparseTensor(
+                      indices=[[0]], values=[1], dense_shape=[1])),
+                  "expected": (sparse_tensor.SparseTensor)
+              },
+              {
+                  "classes": (constant_op.constant([1])),
+                  "expected": (ops.Tensor)
+              },
+              {
+                  "classes": (sparse_tensor.SparseTensor(
+                      indices=[[0]], values=[1], dense_shape=[1]), ()),
+                  "expected": (sparse_tensor.SparseTensor, ())
+              },
+              {
+                  "classes": ((), sparse_tensor.SparseTensor(
+                      indices=[[0]], values=[1], dense_shape=[1])),
+                  "expected": ((), sparse_tensor.SparseTensor)
+              },
+              {
+                  "classes": (constant_op.constant([1]), ()),
+                  "expected": (ops.Tensor, ())
+              },
+              {
+                  "classes": ((), constant_op.constant([1])),
+                  "expected": ((), ops.Tensor)
+              },
+              {
+                  "classes": (
+                      sparse_tensor.SparseTensor(
+                          indices=[[0]], values=[1], dense_shape=[1]),
+                      (), constant_op.constant([1])),
+                  "expected": (sparse_tensor.SparseTensor, (), ops.Tensor)
+              },
+              {
+                  "classes": ((), sparse_tensor.SparseTensor(
+                      indices=[[0]], values=[1], dense_shape=[1]), ()),
+                  "expected": ((), sparse_tensor.SparseTensor, ())
+              },
+              {
+                  "classes": ((), constant_op.constant([1]), ()),
+                  "expected": ((), ops.Tensor, ())
+              },
+          ])
+      )
+  )
+  def testGetClasses(self, test_case):
+    self.assertEqual(
+        sparse.get_classes(test_case["classes"]), test_case["expected"])
+
   @combinations.generate(test_base.default_test_combinations())
   def assertSparseValuesEqual(self, a, b):
     if not isinstance(a, sparse_tensor.SparseTensor):
@@ -309,65 +329,69 @@ class SparseTest(test_base.DatasetTestBase, parameterized.TestCase):
       self.assertAllEqual(a.eval().values, self.evaluate(b).values)
       self.assertAllEqual(a.eval().dense_shape, self.evaluate(b).dense_shape)
 
-  @combinations.generate(test_base.graph_only_combinations())
-  def testSerializeDeserialize(self):
-    test_cases = (
-        (),
-        sparse_tensor.SparseTensor(
-            indices=[[0, 0]], values=[1], dense_shape=[1, 1]),
-        sparse_tensor.SparseTensor(
-            indices=[[3, 4]], values=[-1], dense_shape=[4, 5]),
-        sparse_tensor.SparseTensor(
-            indices=[[0, 0], [3, 4]], values=[1, -1], dense_shape=[4, 5]),
-        (sparse_tensor.SparseTensor(
-            indices=[[0, 0]], values=[1], dense_shape=[1, 1])),
-        (sparse_tensor.SparseTensor(
-            indices=[[0, 0]], values=[1], dense_shape=[1, 1]), ()),
-        ((),
-         sparse_tensor.SparseTensor(
-             indices=[[0, 0]], values=[1], dense_shape=[1, 1])),
-    )
-    for expected in test_cases:
-      classes = sparse.get_classes(expected)
-      shapes = nest.map_structure(lambda _: tensor_shape.TensorShape(None),
-                                  classes)
-      types = nest.map_structure(lambda _: dtypes.int32, classes)
-      actual = sparse.deserialize_sparse_tensors(
-          sparse.serialize_sparse_tensors(expected), types, shapes,
-          sparse.get_classes(expected))
-      nest.assert_same_structure(expected, actual)
-      for a, e in zip(nest.flatten(actual), nest.flatten(expected)):
-        self.assertSparseValuesEqual(a, e)
+  @combinations.generate(
+      combinations.times(
+          test_base.graph_only_combinations(),
+          combinations.combine(test_case=[
+              (),
+              sparse_tensor.SparseTensor(
+                  indices=[[0, 0]], values=[1], dense_shape=[1, 1]),
+              sparse_tensor.SparseTensor(
+                  indices=[[3, 4]], values=[-1], dense_shape=[4, 5]),
+              sparse_tensor.SparseTensor(
+                  indices=[[0, 0], [3, 4]], values=[1, -1], dense_shape=[4, 5]),
+              (sparse_tensor.SparseTensor(
+                  indices=[[0, 0]], values=[1], dense_shape=[1, 1])),
+              (sparse_tensor.SparseTensor(
+                  indices=[[0, 0]], values=[1], dense_shape=[1, 1]), ()),
+              ((), sparse_tensor.SparseTensor(
+                  indices=[[0, 0]], values=[1], dense_shape=[1, 1])),
+          ])
+      )
+  )
+  def testSerializeDeserialize(self, test_case):
+    classes = sparse.get_classes(test_case)
+    shapes = nest.map_structure(lambda _: tensor_shape.TensorShape(None),
+                                classes)
+    types = nest.map_structure(lambda _: dtypes.int32, classes)
+    actual = sparse.deserialize_sparse_tensors(
+        sparse.serialize_sparse_tensors(test_case), types, shapes,
+        sparse.get_classes(test_case))
+    nest.assert_same_structure(test_case, actual)
+    for a, e in zip(nest.flatten(actual), nest.flatten(test_case)):
+      self.assertSparseValuesEqual(a, e)
 
-  @combinations.generate(test_base.graph_only_combinations())
-  def testSerializeManyDeserialize(self):
-    test_cases = (
-        (),
-        sparse_tensor.SparseTensor(
-            indices=[[0, 0]], values=[1], dense_shape=[1, 1]),
-        sparse_tensor.SparseTensor(
-            indices=[[3, 4]], values=[-1], dense_shape=[4, 5]),
-        sparse_tensor.SparseTensor(
-            indices=[[0, 0], [3, 4]], values=[1, -1], dense_shape=[4, 5]),
-        (sparse_tensor.SparseTensor(
-            indices=[[0, 0]], values=[1], dense_shape=[1, 1])),
-        (sparse_tensor.SparseTensor(
-            indices=[[0, 0]], values=[1], dense_shape=[1, 1]), ()),
-        ((),
-         sparse_tensor.SparseTensor(
-             indices=[[0, 0]], values=[1], dense_shape=[1, 1])),
-    )
-    for expected in test_cases:
-      classes = sparse.get_classes(expected)
-      shapes = nest.map_structure(lambda _: tensor_shape.TensorShape(None),
-                                  classes)
-      types = nest.map_structure(lambda _: dtypes.int32, classes)
-      actual = sparse.deserialize_sparse_tensors(
-          sparse.serialize_many_sparse_tensors(expected), types, shapes,
-          sparse.get_classes(expected))
-      nest.assert_same_structure(expected, actual)
-      for a, e in zip(nest.flatten(actual), nest.flatten(expected)):
-        self.assertSparseValuesEqual(a, e)
+  @combinations.generate(
+      combinations.times(
+          test_base.graph_only_combinations(),
+          combinations.combine(test_case=[
+              (),
+              sparse_tensor.SparseTensor(
+                  indices=[[0, 0]], values=[1], dense_shape=[1, 1]),
+              sparse_tensor.SparseTensor(
+                  indices=[[3, 4]], values=[-1], dense_shape=[4, 5]),
+              sparse_tensor.SparseTensor(
+                  indices=[[0, 0], [3, 4]], values=[1, -1], dense_shape=[4, 5]),
+              (sparse_tensor.SparseTensor(
+                  indices=[[0, 0]], values=[1], dense_shape=[1, 1])),
+              (sparse_tensor.SparseTensor(
+                  indices=[[0, 0]], values=[1], dense_shape=[1, 1]), ()),
+              ((), sparse_tensor.SparseTensor(
+                  indices=[[0, 0]], values=[1], dense_shape=[1, 1])),
+          ])
+      )
+  )
+  def testSerializeManyDeserialize(self, test_case):
+    classes = sparse.get_classes(test_case)
+    shapes = nest.map_structure(lambda _: tensor_shape.TensorShape(None),
+                                classes)
+    types = nest.map_structure(lambda _: dtypes.int32, classes)
+    actual = sparse.deserialize_sparse_tensors(
+        sparse.serialize_many_sparse_tensors(test_case), types, shapes,
+        sparse.get_classes(test_case))
+    nest.assert_same_structure(test_case, actual)
+    for a, e in zip(nest.flatten(actual), nest.flatten(test_case)):
+      self.assertSparseValuesEqual(a, e)
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/data/util/sparse_test.py
+++ b/tensorflow/python/data/util/sparse_test.py
@@ -32,6 +32,10 @@ from tensorflow.python.framework import tensor_shape
 from tensorflow.python.platform import test
 
 
+# NOTE(vikoth18): Arguments of parameterized tests are lifted into lambdas to make
+# sure they are not executed before the (eager- or graph-mode) test environment
+# has been set up.
+#
 class SparseTest(test_base.DatasetTestBase, parameterized.TestCase):
 
   @combinations.generate(

--- a/tensorflow/python/data/util/sparse_test.py
+++ b/tensorflow/python/data/util/sparse_test.py
@@ -82,7 +82,7 @@ def _test_as_dense_shapes_combinations():
           "CASE_2",
           lambda: tensor_shape.TensorShape([]),
           lambda: sparse_tensor.SparseTensor,
-          lambda: tensor_shape.unknown_shape()
+          lambda: tensor_shape.unknown_shape() # pylint: disable=unnecessary-lambda
       ),
       (
           "CASE_3",
@@ -94,7 +94,7 @@ def _test_as_dense_shapes_combinations():
           "CASE_4",
           lambda: (tensor_shape.TensorShape([])),
           lambda: (sparse_tensor.SparseTensor),
-          lambda: (tensor_shape.unknown_shape())
+          lambda: (tensor_shape.unknown_shape()) # pylint: disable=unnecessary-lambda
       ),
       (
           "CASE_5",

--- a/tensorflow/python/data/util/structure_test.py
+++ b/tensorflow/python/data/util/structure_test.py
@@ -536,7 +536,7 @@ def _test_convert_legacy_structure_combinations():
           {
               "a": tensor_spec.TensorSpec([], dtypes.float32),
               "b": (sparse_tensor.SparseTensorSpec(
-                      [2, 2], dtypes.int32),
+                  [2, 2], dtypes.int32),
                     tensor_spec.TensorSpec([], dtypes.string))
           }
       )
@@ -1135,7 +1135,8 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase):
           _test_batch_combinations()
       )
   )
-  def testBatch(self, element_structure, batch_size, expected_batched_structure):
+  def testBatch(self, element_structure, batch_size,
+                expected_batched_structure):
     element_structure = element_structure._obj
     batch_size = batch_size._obj
     expected_batched_structure = expected_batched_structure._obj

--- a/tensorflow/python/data/util/structure_test.py
+++ b/tensorflow/python/data/util/structure_test.py
@@ -72,14 +72,14 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase):
           "b": constant_op.constant([1, 2, 3])
       }, dict, [dtypes.float32, dtypes.int32], [[], [3]]),
       ("Nested_2", lambda: {
-          "a":
-              constant_op.constant(37.0),
+          "a": constant_op.constant(37.0),
           "b": (sparse_tensor.SparseTensor(
-              indices=[[0, 0]], values=[1], dense_shape=[1, 1]),
-                sparse_tensor.SparseTensor(
-                    indices=[[3, 4]], values=[-1], dense_shape=[4, 5]))
-      }, dict, [dtypes.float32, dtypes.variant, dtypes.variant], [[], None, None
-                                                                 ]),
+              indices=[[0, 0]], values=[1],
+              dense_shape=[1, 1]), sparse_tensor.SparseTensor(
+                  indices=[[3, 4]], values=[-1], dense_shape=[4, 5]))
+      }, dict, [dtypes.float32, dtypes.variant, dtypes.variant], [
+          [], None, None]
+      ),
   )
   def testFlatStructure(self, value_fn, expected_structure, expected_types,
                         expected_shapes):
@@ -135,9 +135,11 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase):
                           indices=[[3, 4]], values=[-1], dense_shape=[4, 5]),
                       lambda: [
                           sparse_tensor.SparseTensor(
-                              indices=[[1, 1], [3, 4]], values=[10, -1], dense_shape=[4, 5]),
+                              indices=[[1, 1], [3, 4]], values=[10, -1],
+                              dense_shape=[4, 5]),
                           sparse_tensor.SparseTensorValue(
-                              indices=[[1, 1], [3, 4]], values=[10, -1], dense_shape=[4, 5]),
+                              indices=[[1, 1], [3, 4]], values=[10, -1],
+                              dense_shape=[4, 5]),
                           array_ops.sparse_placeholder(dtype=dtypes.int32),
                           array_ops.sparse_placeholder(
                               dtype=dtypes.int32, shape=[None, None])
@@ -145,11 +147,13 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase):
                       lambda: [
                           constant_op.constant(37, shape=[4, 5]),
                           sparse_tensor.SparseTensor(
-                              indices=[[3, 4]], values=[-1], dense_shape=[5, 6]),
+                              indices=[[3, 4]], values=[-1],
+                              dense_shape=[5, 6]),
                           array_ops.sparse_placeholder(
                               dtype=dtypes.int32, shape=[None, None, None]),
                           sparse_tensor.SparseTensor(
-                              indices=[[3, 4]], values=[-1.0], dense_shape=[4, 5])
+                              indices=[[3, 4]], values=[-1.0],
+                              dense_shape=[4, 5])
                       ]
                   ]),
               combinations.NamedObject(
@@ -187,13 +191,12 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase):
                           constant_op.constant(15),
                           "b":
                           sparse_tensor.SparseTensor(
-                              indices=[[0], [1], [2]], values=[4, 5, 6], dense_shape=[3])
-                      }, (constant_op.constant(15.0), constant_op.constant([4, 5, 6]))
-                      ]
+                              indices=[[0], [1], [2]], values=[4, 5, 6],
+                              dense_shape=[3])
+                      }, (constant_op.constant(15.0),
+                          constant_op.constant([4, 5, 6]))]
                   ]),
-          ])
-      )
-  )
+          ])))
   def testIsCompatibleWithStructure(self, value_fns):
     value_fns = value_fns._obj
     original_value_fn = value_fns[0]

--- a/tensorflow/python/data/util/structure_test.py
+++ b/tensorflow/python/data/util/structure_test.py
@@ -25,10 +25,10 @@ import wrapt
 from absl.testing import parameterized
 
 from tensorflow.python.data.kernel_tests import test_base
-from tensorflow.python.framework import combinations
 from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.data.util import nest
 from tensorflow.python.data.util import structure
+from tensorflow.python.framework import combinations
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops

--- a/tensorflow/python/data/util/structure_test.py
+++ b/tensorflow/python/data/util/structure_test.py
@@ -96,6 +96,7 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase):
       else:
         self.assertEqual(actual.as_list(), expected)
 
+  @combinations.generate(test_base.graph_only_combinations())
   @parameterized.named_parameters(
       ("Tensor", lambda: constant_op.constant(37.0), lambda: [
           constant_op.constant(38.0),
@@ -164,7 +165,6 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase):
                   indices=[[0], [1], [2]], values=[4, 5, 6], dense_shape=[3])
       }, (constant_op.constant(15.0), constant_op.constant([4, 5, 6]))]),
   )
-  @combinations.generate(test_base.graph_only_combinations())
   def testIsCompatibleWithStructure(self, original_value_fn,
                                     compatible_values_fn,
                                     incompatible_values_fn):

--- a/tensorflow/python/data/util/structure_test.py
+++ b/tensorflow/python/data/util/structure_test.py
@@ -96,78 +96,109 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase):
       else:
         self.assertEqual(actual.as_list(), expected)
 
-  @combinations.generate(test_base.graph_only_combinations())
-  @parameterized.named_parameters(
-      ("Tensor", lambda: constant_op.constant(37.0), lambda: [
-          constant_op.constant(38.0),
-          array_ops.placeholder(dtypes.float32),
-          variables.Variable(100.0), 42.0,
-          np.array(42.0, dtype=np.float32)
-      ], lambda: [constant_op.constant([1.0, 2.0]),
-                  constant_op.constant(37)]),
-      ("TensorArray", lambda: tensor_array_ops.TensorArray(
-          dtype=dtypes.float32, element_shape=(3,), size=0), lambda: [
-              tensor_array_ops.TensorArray(
-                  dtype=dtypes.float32, element_shape=(3,), size=0),
-              tensor_array_ops.TensorArray(
-                  dtype=dtypes.float32, element_shape=(3,), size=10)
-          ], lambda: [
-              tensor_array_ops.TensorArray(
-                  dtype=dtypes.int32, element_shape=(3,), size=0),
-              tensor_array_ops.TensorArray(
-                  dtype=dtypes.float32, element_shape=(), size=0)
-          ]),
-      ("SparseTensor", lambda: sparse_tensor.SparseTensor(
-          indices=[[3, 4]], values=[-1], dense_shape=[4, 5]),
-       lambda: [
-           sparse_tensor.SparseTensor(
-               indices=[[1, 1], [3, 4]], values=[10, -1], dense_shape=[4, 5]),
-           sparse_tensor.SparseTensorValue(
-               indices=[[1, 1], [3, 4]], values=[10, -1], dense_shape=[4, 5]),
-           array_ops.sparse_placeholder(dtype=dtypes.int32),
-           array_ops.sparse_placeholder(dtype=dtypes.int32, shape=[None, None])
-       ], lambda: [
-           constant_op.constant(37, shape=[4, 5]),
-           sparse_tensor.SparseTensor(
-               indices=[[3, 4]], values=[-1], dense_shape=[5, 6]),
-           array_ops.sparse_placeholder(
-               dtype=dtypes.int32, shape=[None, None, None]),
-           sparse_tensor.SparseTensor(
-               indices=[[3, 4]], values=[-1.0], dense_shape=[4, 5])
-       ]),
-      ("RaggedTensor", lambda: ragged_factory_ops.constant([[1, 2], [], [3]]),
-       lambda: [
-           ragged_factory_ops.constant([[1, 2], [3, 4], []]),
-           ragged_factory_ops.constant([[1], [2, 3, 4], [5]]),
-       ], lambda: [
-           ragged_factory_ops.constant(1),
-           ragged_factory_ops.constant([1, 2]),
-           ragged_factory_ops.constant([[1], [2]]),
-           ragged_factory_ops.constant([["a", "b"]]),
-       ]),
-      ("Nested", lambda: {
-          "a": constant_op.constant(37.0),
-          "b": constant_op.constant([1, 2, 3])
-      }, lambda: [{
-          "a": constant_op.constant(15.0),
-          "b": constant_op.constant([4, 5, 6])
-      }], lambda: [{
-          "a": constant_op.constant(15.0),
-          "b": constant_op.constant([4, 5, 6, 7])
-      }, {
-          "a": constant_op.constant(15),
-          "b": constant_op.constant([4, 5, 6])
-      }, {
-          "a":
-              constant_op.constant(15),
-          "b":
-              sparse_tensor.SparseTensor(
-                  indices=[[0], [1], [2]], values=[4, 5, 6], dense_shape=[3])
-      }, (constant_op.constant(15.0), constant_op.constant([4, 5, 6]))]),
+  @combinations.generate(
+      combinations.times(
+          test_base.graph_only_combinations(),
+          combinations.combine(value_fns=[
+              combinations.NamedObject(
+                  "Tensor", [
+                      lambda: constant_op.constant(37.0),
+                      lambda: [
+                          constant_op.constant(38.0),
+                          array_ops.placeholder(dtypes.float32),
+                          variables.Variable(100.0), 42.0,
+                          np.array(42.0, dtype=np.float32)
+                      ],
+                      lambda: [constant_op.constant([1.0, 2.0]),
+                               constant_op.constant(37)]
+                  ]),
+              combinations.NamedObject(
+                  "TensorArray", [
+                      lambda: tensor_array_ops.TensorArray(
+                          dtype=dtypes.float32, element_shape=(3,), size=0),
+                      lambda: [
+                          tensor_array_ops.TensorArray(
+                              dtype=dtypes.float32, element_shape=(3,), size=0),
+                          tensor_array_ops.TensorArray(
+                              dtype=dtypes.float32, element_shape=(3,), size=10)
+                      ],
+                      lambda: [
+                          tensor_array_ops.TensorArray(
+                              dtype=dtypes.int32, element_shape=(3,), size=0),
+                          tensor_array_ops.TensorArray(
+                              dtype=dtypes.float32, element_shape=(), size=0)
+                      ]
+                  ]),
+              combinations.NamedObject(
+                  "SparseTensor", [
+                      lambda: sparse_tensor.SparseTensor(
+                          indices=[[3, 4]], values=[-1], dense_shape=[4, 5]),
+                      lambda: [
+                          sparse_tensor.SparseTensor(
+                              indices=[[1, 1], [3, 4]], values=[10, -1], dense_shape=[4, 5]),
+                          sparse_tensor.SparseTensorValue(
+                              indices=[[1, 1], [3, 4]], values=[10, -1], dense_shape=[4, 5]),
+                          array_ops.sparse_placeholder(dtype=dtypes.int32),
+                          array_ops.sparse_placeholder(
+                              dtype=dtypes.int32, shape=[None, None])
+                      ],
+                      lambda: [
+                          constant_op.constant(37, shape=[4, 5]),
+                          sparse_tensor.SparseTensor(
+                              indices=[[3, 4]], values=[-1], dense_shape=[5, 6]),
+                          array_ops.sparse_placeholder(
+                              dtype=dtypes.int32, shape=[None, None, None]),
+                          sparse_tensor.SparseTensor(
+                              indices=[[3, 4]], values=[-1.0], dense_shape=[4, 5])
+                      ]
+                  ]),
+              combinations.NamedObject(
+                  "RaggedTensor", [
+                      lambda: ragged_factory_ops.constant([[1, 2], [], [3]]),
+                      lambda: [
+                          ragged_factory_ops.constant([[1, 2], [3, 4], []]),
+                          ragged_factory_ops.constant([[1], [2, 3, 4], [5]]),
+                      ],
+                      lambda: [
+                          ragged_factory_ops.constant(1),
+                          ragged_factory_ops.constant([1, 2]),
+                          ragged_factory_ops.constant([[1], [2]]),
+                          ragged_factory_ops.constant([["a", "b"]]),
+                      ]
+                  ]),
+              combinations.NamedObject(
+                  "Nested", [
+                      lambda: {
+                          "a": constant_op.constant(37.0),
+                          "b": constant_op.constant([1, 2, 3])
+                      },
+                      lambda: [{
+                          "a": constant_op.constant(15.0),
+                          "b": constant_op.constant([4, 5, 6])
+                      }],
+                      lambda: [{
+                          "a": constant_op.constant(15.0),
+                          "b": constant_op.constant([4, 5, 6, 7])
+                      }, {
+                          "a": constant_op.constant(15),
+                          "b": constant_op.constant([4, 5, 6])
+                      }, {
+                          "a":
+                          constant_op.constant(15),
+                          "b":
+                          sparse_tensor.SparseTensor(
+                              indices=[[0], [1], [2]], values=[4, 5, 6], dense_shape=[3])
+                      }, (constant_op.constant(15.0), constant_op.constant([4, 5, 6]))
+                      ]
+                  ]),
+          ])
+      )
   )
-  def testIsCompatibleWithStructure(self, original_value_fn,
-                                    compatible_values_fn,
-                                    incompatible_values_fn):
+  def testIsCompatibleWithStructure(self, value_fns):
+    value_fns = value_fns._obj
+    original_value_fn = value_fns[0]
+    compatible_values_fn = value_fns[1]
+    incompatible_values_fn = value_fns[2]
     original_value = original_value_fn()
     compatible_values = compatible_values_fn()
     incompatible_values = incompatible_values_fn()

--- a/tensorflow/python/data/util/structure_test.py
+++ b/tensorflow/python/data/util/structure_test.py
@@ -20,11 +20,12 @@ from __future__ import print_function
 
 import collections
 
-from absl.testing import parameterized
 import numpy as np
 import wrapt
+from absl.testing import parameterized
 
 from tensorflow.python.data.kernel_tests import test_base
+from tensorflow.python.framework import combinations
 from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.data.util import nest
 from tensorflow.python.data.util import structure
@@ -77,10 +78,10 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase,
               constant_op.constant(37.0),
           "b": (sparse_tensor.SparseTensor(
               indices=[[0, 0]], values=[1], dense_shape=[1, 1]),
-                sparse_tensor.SparseTensor(
-                    indices=[[3, 4]], values=[-1], dense_shape=[4, 5]))
+                  sparse_tensor.SparseTensor(
+              indices=[[3, 4]], values=[-1], dense_shape=[4, 5]))
       }, dict, [dtypes.float32, dtypes.variant, dtypes.variant], [[], None, None
-                                                                 ]),
+                                                                  ]),
   )
   def testFlatStructure(self, value_fn, expected_structure, expected_types,
                         expected_shapes):
@@ -111,12 +112,12 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase,
                   dtype=dtypes.float32, element_shape=(3,), size=0),
               tensor_array_ops.TensorArray(
                   dtype=dtypes.float32, element_shape=(3,), size=10)
-          ], lambda: [
+      ], lambda: [
               tensor_array_ops.TensorArray(
                   dtype=dtypes.int32, element_shape=(3,), size=0),
               tensor_array_ops.TensorArray(
                   dtype=dtypes.float32, element_shape=(), size=0)
-          ]),
+      ]),
       ("SparseTensor", lambda: sparse_tensor.SparseTensor(
           indices=[[3, 4]], values=[-1], dense_shape=[4, 5]),
        lambda: [
@@ -126,7 +127,7 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase,
                indices=[[1, 1], [3, 4]], values=[10, -1], dense_shape=[4, 5]),
            array_ops.sparse_placeholder(dtype=dtypes.int32),
            array_ops.sparse_placeholder(dtype=dtypes.int32, shape=[None, None])
-       ], lambda: [
+      ], lambda: [
            constant_op.constant(37, shape=[4, 5]),
            sparse_tensor.SparseTensor(
                indices=[[3, 4]], values=[-1], dense_shape=[5, 6]),
@@ -134,17 +135,17 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase,
                dtype=dtypes.int32, shape=[None, None, None]),
            sparse_tensor.SparseTensor(
                indices=[[3, 4]], values=[-1.0], dense_shape=[4, 5])
-       ]),
+      ]),
       ("RaggedTensor", lambda: ragged_factory_ops.constant([[1, 2], [], [3]]),
        lambda: [
            ragged_factory_ops.constant([[1, 2], [3, 4], []]),
            ragged_factory_ops.constant([[1], [2, 3, 4], [5]]),
-       ], lambda: [
+      ], lambda: [
            ragged_factory_ops.constant(1),
            ragged_factory_ops.constant([1, 2]),
            ragged_factory_ops.constant([[1], [2]]),
            ragged_factory_ops.constant([["a", "b"]]),
-       ]),
+      ]),
       ("Nested", lambda: {
           "a": constant_op.constant(37.0),
           "b": constant_op.constant([1, 2, 3])
@@ -165,7 +166,7 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase,
                   indices=[[0], [1], [2]], values=[4, 5, 6], dense_shape=[3])
       }, (constant_op.constant(15.0), constant_op.constant([4, 5, 6]))]),
   )
-  @test_util.run_deprecated_v1
+  @combinations.generate(test_base.graph_only_combinations())
   def testIsCompatibleWithStructure(self, original_value_fn,
                                     compatible_values_fn,
                                     incompatible_values_fn):
@@ -322,8 +323,8 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase,
                   constant_op.constant(37.0),
               "b": (sparse_tensor.SparseTensor(
                   indices=[[0, 0]], values=[1], dense_shape=[1, 1]),
-                    sparse_tensor.SparseTensor(
-                        indices=[[3, 4]], values=[-1], dense_shape=[4, 5]))
+                      sparse_tensor.SparseTensor(
+                  indices=[[3, 4]], values=[-1], dense_shape=[4, 5]))
           },
       ),
   )
@@ -351,7 +352,7 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase,
         self.assertAllEqual(b.dense_shape, a.dense_shape)
       elif isinstance(
           b,
-          (ragged_tensor.RaggedTensor, ragged_tensor_value.RaggedTensorValue)):
+              (ragged_tensor.RaggedTensor, ragged_tensor_value.RaggedTensorValue)):
         self.assertAllEqual(b, a)
       else:
         self.assertAllEqual(b, a)
@@ -418,11 +419,11 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase,
     flat_nest = structure.to_tensor_list(s_nest, value_nest)
 
     with self.assertRaisesRegex(
-        ValueError, r"SparseTensor.* is not convertible to a tensor with "
-        r"dtype.*float32.* and shape \(\)"):
+            ValueError, r"SparseTensor.* is not convertible to a tensor with "
+            r"dtype.*float32.* and shape \(\)"):
       structure.to_tensor_list(s_tensor, value_sparse_tensor)
     with self.assertRaisesRegex(
-        ValueError, "The two structures don't have the same nested structure."):
+            ValueError, "The two structures don't have the same nested structure."):
       structure.to_tensor_list(s_tensor, value_nest)
 
     with self.assertRaisesRegex(TypeError,
@@ -430,15 +431,15 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase,
       structure.to_tensor_list(s_sparse_tensor, value_tensor)
 
     with self.assertRaisesRegex(
-        ValueError, "The two structures don't have the same nested structure."):
+            ValueError, "The two structures don't have the same nested structure."):
       structure.to_tensor_list(s_sparse_tensor, value_nest)
 
     with self.assertRaisesRegex(
-        ValueError, "The two structures don't have the same nested structure."):
+            ValueError, "The two structures don't have the same nested structure."):
       structure.to_tensor_list(s_nest, value_tensor)
 
     with self.assertRaisesRegex(
-        ValueError, "The two structures don't have the same nested structure."):
+            ValueError, "The two structures don't have the same nested structure."):
       structure.to_tensor_list(s_nest, value_sparse_tensor)
 
     with self.assertRaisesRegex(ValueError, r"Incompatible input:"):
@@ -492,19 +493,19 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase,
             constant_op.constant(37.0),
         "b": (sparse_tensor.SparseTensor(
             indices=[[0, 0]], values=[1], dense_shape=[1, 1]),
-              sparse_tensor.SparseTensor(
-                  indices=[[3, 4]], values=[-1], dense_shape=[4, 5]))
+                sparse_tensor.SparseTensor(
+            indices=[[3, 4]], values=[-1], dense_shape=[4, 5]))
     }
     s_2 = structure.type_spec_from_value(value_2)
     flat_s_2 = structure.to_tensor_list(s_2, value_2)
 
     with self.assertRaisesRegex(
-        ValueError, r"SparseTensor.* is not convertible to a tensor with "
-        r"dtype.*int32.* and shape \(3,\)"):
+            ValueError, r"SparseTensor.* is not convertible to a tensor with "
+            r"dtype.*int32.* and shape \(3,\)"):
       structure.to_tensor_list(s_0, value_1)
 
     with self.assertRaisesRegex(
-        ValueError, "The two structures don't have the same nested structure."):
+            ValueError, "The two structures don't have the same nested structure."):
       structure.to_tensor_list(s_0, value_2)
 
     with self.assertRaisesRegex(TypeError,
@@ -512,7 +513,7 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase,
       structure.to_tensor_list(s_1, value_0)
 
     with self.assertRaisesRegex(
-        ValueError, "The two structures don't have the same nested structure."):
+            ValueError, "The two structures don't have the same nested structure."):
       structure.to_tensor_list(s_1, value_2)
 
     # NOTE(mrry): The repr of the dictionaries is not sorted, so the regexp
@@ -520,11 +521,11 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase,
     # adding a deterministic repr for these error messages (among other
     # improvements).
     with self.assertRaisesRegex(
-        ValueError, "The two structures don't have the same nested structure."):
+            ValueError, "The two structures don't have the same nested structure."):
       structure.to_tensor_list(s_2, value_0)
 
     with self.assertRaisesRegex(
-        ValueError, "The two structures don't have the same nested structure."):
+            ValueError, "The two structures don't have the same nested structure."):
       structure.to_tensor_list(s_2, value_1)
 
     with self.assertRaisesRegex(ValueError, r"Incompatible input:"):
@@ -553,17 +554,17 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase,
        sparse_tensor.SparseTensorSpec([2, 2], dtypes.int32)),
       ("TensorArray_0", dtypes.int32,
        tensor_shape.TensorShape([None, True, 2, 2
-                                ]), tensor_array_ops.TensorArray,
+                                 ]), tensor_array_ops.TensorArray,
        tensor_array_ops.TensorArraySpec(
            [2, 2], dtypes.int32, dynamic_size=None, infer_shape=True)),
       ("TensorArray_1", dtypes.int32,
        tensor_shape.TensorShape([True, None, 2, 2
-                                ]), tensor_array_ops.TensorArray,
+                                 ]), tensor_array_ops.TensorArray,
        tensor_array_ops.TensorArraySpec(
            [2, 2], dtypes.int32, dynamic_size=True, infer_shape=None)),
       ("TensorArray_2", dtypes.int32,
        tensor_shape.TensorShape([True, False, 2, 2
-                                ]), tensor_array_ops.TensorArray,
+                                 ]), tensor_array_ops.TensorArray,
        tensor_array_ops.TensorArraySpec(
            [2, 2], dtypes.int32, dynamic_size=True, infer_shape=False)),
       ("RaggedTensor", dtypes.int32, tensor_shape.TensorShape([2, None]),
@@ -727,7 +728,7 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase,
         unbatched_s, [t[0] for t in batched_tensor_list])
 
     for expected, actual in zip(
-        nest.flatten(expected_element_0), nest.flatten(actual_element_0)):
+            nest.flatten(expected_element_0), nest.flatten(actual_element_0)):
       self.assertValuesEqual(expected, actual)
 
   # pylint: enable=g-long-lambda

--- a/tensorflow/python/data/util/structure_test.py
+++ b/tensorflow/python/data/util/structure_test.py
@@ -35,7 +35,6 @@ from tensorflow.python.framework import ops
 from tensorflow.python.framework import sparse_tensor
 from tensorflow.python.framework import tensor_shape
 from tensorflow.python.framework import tensor_spec
-from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import tensor_array_ops
 from tensorflow.python.ops import variables
@@ -51,8 +50,7 @@ from tensorflow.python.util.compat import collections_abc
 # has been set up.
 #
 # TODO(jsimsa): Add tests for OptionalStructure and DatasetStructure.
-class StructureTest(test_base.DatasetTestBase, parameterized.TestCase,
-                    test_util.TensorFlowTestCase):
+class StructureTest(test_base.DatasetTestBase, parameterized.TestCase):
 
   # pylint: disable=g-long-lambda,protected-access
   @parameterized.named_parameters(
@@ -78,10 +76,10 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase,
               constant_op.constant(37.0),
           "b": (sparse_tensor.SparseTensor(
               indices=[[0, 0]], values=[1], dense_shape=[1, 1]),
-                  sparse_tensor.SparseTensor(
-              indices=[[3, 4]], values=[-1], dense_shape=[4, 5]))
+                sparse_tensor.SparseTensor(
+                    indices=[[3, 4]], values=[-1], dense_shape=[4, 5]))
       }, dict, [dtypes.float32, dtypes.variant, dtypes.variant], [[], None, None
-                                                                  ]),
+                                                                 ]),
   )
   def testFlatStructure(self, value_fn, expected_structure, expected_types,
                         expected_shapes):
@@ -112,12 +110,12 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase,
                   dtype=dtypes.float32, element_shape=(3,), size=0),
               tensor_array_ops.TensorArray(
                   dtype=dtypes.float32, element_shape=(3,), size=10)
-      ], lambda: [
+          ], lambda: [
               tensor_array_ops.TensorArray(
                   dtype=dtypes.int32, element_shape=(3,), size=0),
               tensor_array_ops.TensorArray(
                   dtype=dtypes.float32, element_shape=(), size=0)
-      ]),
+          ]),
       ("SparseTensor", lambda: sparse_tensor.SparseTensor(
           indices=[[3, 4]], values=[-1], dense_shape=[4, 5]),
        lambda: [
@@ -127,7 +125,7 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase,
                indices=[[1, 1], [3, 4]], values=[10, -1], dense_shape=[4, 5]),
            array_ops.sparse_placeholder(dtype=dtypes.int32),
            array_ops.sparse_placeholder(dtype=dtypes.int32, shape=[None, None])
-      ], lambda: [
+       ], lambda: [
            constant_op.constant(37, shape=[4, 5]),
            sparse_tensor.SparseTensor(
                indices=[[3, 4]], values=[-1], dense_shape=[5, 6]),
@@ -135,17 +133,17 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase,
                dtype=dtypes.int32, shape=[None, None, None]),
            sparse_tensor.SparseTensor(
                indices=[[3, 4]], values=[-1.0], dense_shape=[4, 5])
-      ]),
+       ]),
       ("RaggedTensor", lambda: ragged_factory_ops.constant([[1, 2], [], [3]]),
        lambda: [
            ragged_factory_ops.constant([[1, 2], [3, 4], []]),
            ragged_factory_ops.constant([[1], [2, 3, 4], [5]]),
-      ], lambda: [
+       ], lambda: [
            ragged_factory_ops.constant(1),
            ragged_factory_ops.constant([1, 2]),
            ragged_factory_ops.constant([[1], [2]]),
            ragged_factory_ops.constant([["a", "b"]]),
-      ]),
+       ]),
       ("Nested", lambda: {
           "a": constant_op.constant(37.0),
           "b": constant_op.constant([1, 2, 3])
@@ -323,8 +321,8 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase,
                   constant_op.constant(37.0),
               "b": (sparse_tensor.SparseTensor(
                   indices=[[0, 0]], values=[1], dense_shape=[1, 1]),
-                      sparse_tensor.SparseTensor(
-                  indices=[[3, 4]], values=[-1], dense_shape=[4, 5]))
+                    sparse_tensor.SparseTensor(
+                        indices=[[3, 4]], values=[-1], dense_shape=[4, 5]))
           },
       ),
   )
@@ -352,7 +350,7 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase,
         self.assertAllEqual(b.dense_shape, a.dense_shape)
       elif isinstance(
           b,
-              (ragged_tensor.RaggedTensor, ragged_tensor_value.RaggedTensorValue)):
+          (ragged_tensor.RaggedTensor, ragged_tensor_value.RaggedTensorValue)):
         self.assertAllEqual(b, a)
       else:
         self.assertAllEqual(b, a)
@@ -419,11 +417,11 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase,
     flat_nest = structure.to_tensor_list(s_nest, value_nest)
 
     with self.assertRaisesRegex(
-            ValueError, r"SparseTensor.* is not convertible to a tensor with "
-            r"dtype.*float32.* and shape \(\)"):
+        ValueError, r"SparseTensor.* is not convertible to a tensor with "
+        r"dtype.*float32.* and shape \(\)"):
       structure.to_tensor_list(s_tensor, value_sparse_tensor)
     with self.assertRaisesRegex(
-            ValueError, "The two structures don't have the same nested structure."):
+        ValueError, "The two structures don't have the same nested structure."):
       structure.to_tensor_list(s_tensor, value_nest)
 
     with self.assertRaisesRegex(TypeError,
@@ -431,15 +429,15 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase,
       structure.to_tensor_list(s_sparse_tensor, value_tensor)
 
     with self.assertRaisesRegex(
-            ValueError, "The two structures don't have the same nested structure."):
+        ValueError, "The two structures don't have the same nested structure."):
       structure.to_tensor_list(s_sparse_tensor, value_nest)
 
     with self.assertRaisesRegex(
-            ValueError, "The two structures don't have the same nested structure."):
+        ValueError, "The two structures don't have the same nested structure."):
       structure.to_tensor_list(s_nest, value_tensor)
 
     with self.assertRaisesRegex(
-            ValueError, "The two structures don't have the same nested structure."):
+        ValueError, "The two structures don't have the same nested structure."):
       structure.to_tensor_list(s_nest, value_sparse_tensor)
 
     with self.assertRaisesRegex(ValueError, r"Incompatible input:"):
@@ -493,19 +491,19 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase,
             constant_op.constant(37.0),
         "b": (sparse_tensor.SparseTensor(
             indices=[[0, 0]], values=[1], dense_shape=[1, 1]),
-                sparse_tensor.SparseTensor(
-            indices=[[3, 4]], values=[-1], dense_shape=[4, 5]))
+              sparse_tensor.SparseTensor(
+                  indices=[[3, 4]], values=[-1], dense_shape=[4, 5]))
     }
     s_2 = structure.type_spec_from_value(value_2)
     flat_s_2 = structure.to_tensor_list(s_2, value_2)
 
     with self.assertRaisesRegex(
-            ValueError, r"SparseTensor.* is not convertible to a tensor with "
-            r"dtype.*int32.* and shape \(3,\)"):
+        ValueError, r"SparseTensor.* is not convertible to a tensor with "
+        r"dtype.*int32.* and shape \(3,\)"):
       structure.to_tensor_list(s_0, value_1)
 
     with self.assertRaisesRegex(
-            ValueError, "The two structures don't have the same nested structure."):
+        ValueError, "The two structures don't have the same nested structure."):
       structure.to_tensor_list(s_0, value_2)
 
     with self.assertRaisesRegex(TypeError,
@@ -513,7 +511,7 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase,
       structure.to_tensor_list(s_1, value_0)
 
     with self.assertRaisesRegex(
-            ValueError, "The two structures don't have the same nested structure."):
+        ValueError, "The two structures don't have the same nested structure."):
       structure.to_tensor_list(s_1, value_2)
 
     # NOTE(mrry): The repr of the dictionaries is not sorted, so the regexp
@@ -521,11 +519,11 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase,
     # adding a deterministic repr for these error messages (among other
     # improvements).
     with self.assertRaisesRegex(
-            ValueError, "The two structures don't have the same nested structure."):
+        ValueError, "The two structures don't have the same nested structure."):
       structure.to_tensor_list(s_2, value_0)
 
     with self.assertRaisesRegex(
-            ValueError, "The two structures don't have the same nested structure."):
+        ValueError, "The two structures don't have the same nested structure."):
       structure.to_tensor_list(s_2, value_1)
 
     with self.assertRaisesRegex(ValueError, r"Incompatible input:"):
@@ -554,17 +552,17 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase,
        sparse_tensor.SparseTensorSpec([2, 2], dtypes.int32)),
       ("TensorArray_0", dtypes.int32,
        tensor_shape.TensorShape([None, True, 2, 2
-                                 ]), tensor_array_ops.TensorArray,
+                                ]), tensor_array_ops.TensorArray,
        tensor_array_ops.TensorArraySpec(
            [2, 2], dtypes.int32, dynamic_size=None, infer_shape=True)),
       ("TensorArray_1", dtypes.int32,
        tensor_shape.TensorShape([True, None, 2, 2
-                                 ]), tensor_array_ops.TensorArray,
+                                ]), tensor_array_ops.TensorArray,
        tensor_array_ops.TensorArraySpec(
            [2, 2], dtypes.int32, dynamic_size=True, infer_shape=None)),
       ("TensorArray_2", dtypes.int32,
        tensor_shape.TensorShape([True, False, 2, 2
-                                 ]), tensor_array_ops.TensorArray,
+                                ]), tensor_array_ops.TensorArray,
        tensor_array_ops.TensorArraySpec(
            [2, 2], dtypes.int32, dynamic_size=True, infer_shape=False)),
       ("RaggedTensor", dtypes.int32, tensor_shape.TensorShape([2, None]),
@@ -728,7 +726,7 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase,
         unbatched_s, [t[0] for t in batched_tensor_list])
 
     for expected, actual in zip(
-            nest.flatten(expected_element_0), nest.flatten(actual_element_0)):
+        nest.flatten(expected_element_0), nest.flatten(actual_element_0)):
       self.assertValuesEqual(expected, actual)
 
   # pylint: enable=g-long-lambda

--- a/tensorflow/python/data/util/structure_test.py
+++ b/tensorflow/python/data/util/structure_test.py
@@ -757,7 +757,6 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase):
   )
   def testFlatStructure(self, value_fn, expected_structure,
                         expected_types, expected_shapes):
-    value_fn = value_fn._obj
     expected_structure = expected_structure._obj
     expected_types = expected_types._obj
     expected_shapes = expected_shapes._obj
@@ -783,9 +782,9 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase):
   def testIsCompatibleWithStructure(self, original_value_fn,
                                     compatible_values_fn,
                                     incompatible_values_fn):
-    original_value = original_value_fn._obj()
-    compatible_values = compatible_values_fn._obj()
-    incompatible_values = incompatible_values_fn._obj()
+    original_value = original_value_fn()
+    compatible_values = compatible_values_fn()
+    incompatible_values = incompatible_values_fn()
 
     s = structure.type_spec_from_value(original_value)
     for compatible_value in compatible_values:
@@ -806,8 +805,6 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase):
   def testStructureFromValueEquality(self, value1_fn, value2_fn,
                                      not_equal_value_fns):
     # pylint: disable=g-generic-assert
-    value1_fn = value1_fn._obj
-    value2_fn = value2_fn._obj
     not_equal_value_fns = not_equal_value_fns._obj
     s1 = structure.type_spec_from_value(value1_fn())
     s2 = structure.type_spec_from_value(value2_fn())
@@ -845,9 +842,6 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase):
       )
   )
   def testHash(self, value1_fn, value2_fn, value3_fn):
-    value1_fn = value1_fn._obj
-    value2_fn = value2_fn._obj
-    value3_fn = value3_fn._obj
     s1 = structure.type_spec_from_value(value1_fn())
     s2 = structure.type_spec_from_value(value2_fn())
     s3 = structure.type_spec_from_value(value3_fn())
@@ -864,7 +858,7 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase):
       )
   )
   def testRoundTripConversion(self, value_fn):
-    value = value_fn._obj()
+    value = value_fn()
     s = structure.type_spec_from_value(value)
 
     def maybe_stack_ta(v):
@@ -1166,8 +1160,6 @@ class StructureTest(test_base.DatasetTestBase, parameterized.TestCase):
       )
   )
   def testToBatchedTensorList(self, value_fn, element_0_fn):
-    value_fn = value_fn._obj
-    element_0_fn = element_0_fn._obj
     batched_value = value_fn()
     s = structure.type_spec_from_value(batched_value)
     batched_tensor_list = structure.to_batched_tensor_list(s, batched_value)

--- a/tensorflow/python/data/util/traverse_test.py
+++ b/tensorflow/python/data/util/traverse_test.py
@@ -20,7 +20,8 @@ from __future__ import print_function
 
 from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.data.util import traverse
-from tensorflow.python.framework import test_util
+from tensorflow.python.data.kernel_tests import test_base
+from tensorflow.python.framework import combinations
 from tensorflow.python.ops import gen_dataset_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.platform import test
@@ -41,13 +42,13 @@ class _TestDataset(dataset_ops.UnaryUnchangedStructureDataset):
 
 class TraverseTest(test.TestCase):
 
-  @test_util.run_deprecated_v1
+  @combinations.generate(test_base.graph_only_combinations())
   def testOnlySource(self):
     ds = dataset_ops.Dataset.range(10)
     variant_tensor_ops = traverse.obtain_all_variant_tensor_ops(ds)
     self.assertAllEqual(["RangeDataset"], [x.name for x in variant_tensor_ops])
 
-  @test_util.run_deprecated_v1
+  @combinations.generate(test_base.graph_only_combinations())
   def testSimplePipeline(self):
     ds = dataset_ops.Dataset.range(10).map(math_ops.square)
     variant_tensor_ops = traverse.obtain_all_variant_tensor_ops(ds)
@@ -55,7 +56,7 @@ class TraverseTest(test.TestCase):
         set(["MapDataset", "RangeDataset"]),
         set(x.name for x in variant_tensor_ops))
 
-  @test_util.run_deprecated_v1
+  @combinations.generate(test_base.graph_only_combinations())
   def testConcat(self):
     ds1 = dataset_ops.Dataset.range(10)
     ds2 = dataset_ops.Dataset.range(10)
@@ -65,7 +66,7 @@ class TraverseTest(test.TestCase):
         set(["ConcatenateDataset", "RangeDataset", "RangeDataset_1"]),
         set(x.name for x in variant_tensor_ops))
 
-  @test_util.run_deprecated_v1
+  @combinations.generate(test_base.graph_only_combinations())
   def testZip(self):
     ds1 = dataset_ops.Dataset.range(10)
     ds2 = dataset_ops.Dataset.range(10)
@@ -75,7 +76,7 @@ class TraverseTest(test.TestCase):
         set(["ZipDataset", "RangeDataset", "RangeDataset_1"]),
         set(x.name for x in variant_tensor_ops))
 
-  @test_util.run_deprecated_v1
+  @combinations.generate(test_base.graph_only_combinations())
   def testMultipleVariantTensors(self):
     ds = dataset_ops.Dataset.range(10)
     ds = _TestDataset(ds)
@@ -84,7 +85,7 @@ class TraverseTest(test.TestCase):
         set(["RangeDataset", "ModelDataset", "PrefetchDataset"]),
         set(x.name for x in variant_tensor_ops))
 
-  @test_util.run_deprecated_v1
+  @combinations.generate(test_base.graph_only_combinations())
   def testFlatMap(self):
     ds1 = dataset_ops.Dataset.range(10).repeat(10)
 

--- a/tensorflow/python/data/util/traverse_test.py
+++ b/tensorflow/python/data/util/traverse_test.py
@@ -18,6 +18,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from absl.testing import parameterized
+
 from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.data.util import traverse
 from tensorflow.python.data.kernel_tests import test_base
@@ -40,7 +42,7 @@ class _TestDataset(dataset_ops.UnaryUnchangedStructureDataset):
     super(_TestDataset, self).__init__(input_dataset, variant_tensor)
 
 
-class TraverseTest(test.TestCase):
+class TraverseTest(test_base.DatasetTestBase, parameterized.TestCase):
 
   @combinations.generate(test_base.graph_only_combinations())
   def testOnlySource(self):

--- a/tensorflow/python/data/util/traverse_test.py
+++ b/tensorflow/python/data/util/traverse_test.py
@@ -20,9 +20,9 @@ from __future__ import print_function
 
 from absl.testing import parameterized
 
+from tensorflow.python.data.kernel_tests import test_base
 from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.data.util import traverse
-from tensorflow.python.data.kernel_tests import test_base
 from tensorflow.python.framework import combinations
 from tensorflow.python.ops import gen_dataset_ops
 from tensorflow.python.ops import math_ops


### PR DESCRIPTION
This PR switches the tests present in `tensorflow/python/data/util/` to use TF combinations instead of the `test_util` decorator to express the combination of graph/eager modes with TF1/TF2 environments for execution.

Addresses point 1 in https://github.com/tensorflow/tensorflow/pull/46761#issuecomment-770059963
cc: @jsimsa

TEST RUNS (UPDATED):
```
INFO: Build completed successfully, 304 total actions
//tensorflow/python/data/util:random_seed_test                           PASSED in 2.2s

INFO: Build completed successfully, 2 total actions
//tensorflow/python/data/util:sparse_test                                PASSED in 1.5s

INFO: Build completed successfully, 2 total actions
//tensorflow/python/data/util:convert_test                               PASSED in 1.4s

INFO: Build completed successfully, 2 total actions
//tensorflow/python/data/util:traverse_test                              PASSED in 1.4s

INFO: Build completed successfully, 2 total actions
//tensorflow/python/data/util:nest_test                                  PASSED in 1.4s

INFO: Build completed successfully, 2 total actions
//tensorflow/python/data/util:options_test                               PASSED in 1.3s

INFO: Build completed successfully, 2 total actions
//tensorflow/python/data/util:structure_test                             PASSED in 1.7s

```