### PR TITLE
Add reminder on MacOS Catalina

### DIFF
--- a/tensorflow/lite/micro/examples/hello_world/README.md
+++ b/tensorflow/lite/micro/examples/hello_world/README.md
@@ -454,7 +454,7 @@ Before we begin, you'll need the following:
 
 - STM32F7 discovery kit board
 - Mini-USB cable
-- ARM Mbed CLI ([installation instructions](https://os.mbed.com/docs/mbed-os/v5.12/tools/installation-and-setup.html))
+- ARM Mbed CLI ([installation instructions](https://os.mbed.com/docs/mbed-os/v5.12/tools/installation-and-setup.html). Check it out for MacOS Catalina - [mbed-cli is broken on MacOS Catalina #930](https://github.com/ARMmbed/mbed-cli/issues/930#issuecomment-660550734))
 - Python 2.7 and pip
 
 Since Mbed requires a special folder structure for projects, we'll first run a


### PR DESCRIPTION
ARM mbed MacOS installer (mbed-cli-v0.0.10.dmg from https://github.com/ARMmbed/mbed-cli-osx-installer/releases/tag/v0.0.10) creates error during installation.

It is caused by MacOS Catalina moving path of terminal app from _/Applications/Utilities/Terminal.app_ to _/System/Applications/Utilities/Terminal.app_. ) ARM mbed installer scripts still use _/Applications/Utilities/Terminal.app_.

So add a reminder, and a [link](https://github.com/ARMmbed/mbed-cli/issues/930#issuecomment-660550734) to a solution from ARM mbed github.