### PR TITLE
[TFL] Optimize add/sub

### DIFF
--- a/tensorflow/lite/kernels/internal/optimized/optimized_ops.h
+++ b/tensorflow/lite/kernels/internal/optimized/optimized_ops.h
@@ -2163,7 +2163,6 @@ inline void Add(const ArithmeticParams& params,
     reference_ops::BroadcastAdd4DSlow(params, input1_shape, input1_data,
                                       input2_shape, input2_data, output_shape,
                                       output_data);
-    return;
   }
 }
 

--- a/tensorflow/lite/kernels/internal/optimized/optimized_ops.h
+++ b/tensorflow/lite/kernels/internal/optimized/optimized_ops.h
@@ -2724,7 +2724,7 @@ inline void SubWithActivation(
     const T* input1_data, const RuntimeShape& input2_shape,
     const T* input2_data, const RuntimeShape& output_shape, T* output_data) {
   ruy::profiler::ScopeLabel label("SubWithActivation_optimized");
-
+  TFLITE_DCHECK_EQ(input1_shape.FlatSize(), input2_shape.FlatSize());
   auto input1_map = MapAsVector(input1_data, input1_shape);
   auto input2_map = MapAsVector(input2_data, input2_shape);
   auto output_map = MapAsVector(output_data, output_shape);

--- a/tensorflow/lite/kernels/internal/optimized/optimized_ops.h
+++ b/tensorflow/lite/kernels/internal/optimized/optimized_ops.h
@@ -2146,21 +2146,25 @@ inline void Add(const ArithmeticParams& params,
   auto input2_map = MapAsVector(input2_data, input2_shape);
   auto output_map = MapAsVector(output_data, output_shape);
   if (input1_shape == input2_shape) {
-    output_map.array() = input1_map.array() + input2_map.array();
+    output_map.array() = (input1_map.array() + input2_map.array())
+                             .cwiseMax(params.quantized_activation_min)
+                             .cwiseMin(params.quantized_activation_max);
   } else if (input2_shape.FlatSize() == 1) {
     auto scalar = input2_data[0];
-    output_map.array() = input1_map.array() + scalar;
+    output_map.array() = (input1_map.array() + scalar)
+                             .cwiseMax(params.quantized_activation_min)
+                             .cwiseMin(params.quantized_activation_max);
   } else if (input1_shape.FlatSize() == 1) {
     auto scalar = input1_data[0];
-    output_map.array() = scalar + input2_map.array();
+    output_map.array() = (scalar + input2_map.array())
+                             .cwiseMax(params.quantized_activation_min)
+                             .cwiseMin(params.quantized_activation_max);
   } else {
     reference_ops::BroadcastAdd4DSlow(params, input1_shape, input1_data,
                                       input2_shape, input2_data, output_shape,
                                       output_data);
     return;
   }
-  output_map = output_map.cwiseMax(params.quantized_activation_min)
-                   .cwiseMin(params.quantized_activation_max);
 }
 
 template <typename T>


### PR DESCRIPTION
- Assign to `Eigen::Map` will cause forced evaluation. Chain `cwiseMin` and `cwiseMax` to avoid read/write memory twice. One can verify with

```cpp
#include <Eigen/Core>
#include <algorithm>

void foo(int* a, int mn, int mx, int n) {
  Eigen::Map<Eigen::Matrix<int, Eigen::Dynamic, 1>> vector_map(a, n, 1);
  vector_map = vector_map.cwiseMin(mx);
  vector_map = vector_map.cwiseMax(mn);
}

void bar(int* a, int mn, int mx, int n) {
  Eigen::Map<Eigen::Matrix<int, Eigen::Dynamic, 1>> vector_map(a, n, 1);
  vector_map = vector_map.cwiseMin(mx).cwiseMax(mn);
}

void zoo(int* a, int mn, int mx, int n) {
  for (int i = 0; i < n; ++i) {
    a[i] = std::min(std::max(a[i], mn), mx);
  }
}
```

- Optimize non broadcast sub with Eigen
   - `SetActivationMinMax` is the same with `GetActivationParams` in `tensorflow/lite/kernels/internal/types.h`
   - I cannot see any usage of  `SubNonBroadcast` across TensorFlow. It's just an alias of `SubWithActivation`, which is the real function being dispatched.
   - Eigen's vectorization for neon looks pretty good. Do we need to write intrinsics like some of optimized kernels in tflite?

On pixel 3a, benchmark with single op

-----

Sub two (224 * 224 * 32) float32 

Before 
```
Timings (microseconds): count=191 first=2281 curr=2278 min=2250 max=3229 avg=2445.86 std=251
```
After
```
Timings (microseconds): count=208 first=1769 curr=1757 min=1715 max=3050 avg=2083.2 std=397
```

-----


Add two (224 * 224 * 32) int32 (I modify int32 kernel only)

Before
```
Timings (microseconds): count=133 first=4698 curr=4344 min=4201 max=6049 avg=4628.22 std=429
```
Commit 6fc655b
```
Timings (microseconds): count=158 first=3307 curr=3015 min=2917 max=4429 avg=3335.49 std=419
```
Commit 86c1a09 -  fuse add and clip
```
Timings (microseconds): count=221 first=1985 curr=1706 min=1596 max=3085 avg=1901.17 std=404
```