### PR TITLE
TFL: Update detection_postprocess kernel

### DIFF
--- a/tensorflow/lite/kernels/detection_postprocess.cc
+++ b/tensorflow/lite/kernels/detection_postprocess.cc
@@ -369,6 +369,9 @@ void DecreasingPartialArgSort(const float* values, int num_values,
 
 void DecreasingArgSort(const float* values, int num_values, int* indices) {
   std::iota(indices, indices + num_values, 0);
+
+  // We want here a stable sort, in order to get completely defined output.
+  // In this way TFL and TFLM can be bit-exact.
   std::stable_sort(
       indices, indices + num_values,
       [&values](const int i, const int j) { return values[i] > values[j]; });

--- a/tensorflow/lite/kernels/detection_postprocess.cc
+++ b/tensorflow/lite/kernels/detection_postprocess.cc
@@ -367,6 +367,13 @@ void DecreasingPartialArgSort(const float* values, int num_values,
       [&values](const int i, const int j) { return values[i] > values[j]; });
 }
 
+void DecreasingArgSort(const float* values, int num_values, int* indices) {
+  std::iota(indices, indices + num_values, 0);
+  std::stable_sort(
+      indices, indices + num_values,
+      [&values](const int i, const int j) { return values[i] > values[j]; });
+}
+
 void SelectDetectionsAboveScoreThreshold(const std::vector<float>& values,
                                          const float threshold,
                                          std::vector<float>* keep_values,
@@ -451,8 +458,8 @@ TfLiteStatus NonMaxSuppressionSingleClassHelper(
   int num_scores_kept = keep_scores.size();
   std::vector<int> sorted_indices;
   sorted_indices.resize(num_scores_kept);
-  DecreasingPartialArgSort(keep_scores.data(), num_scores_kept, num_scores_kept,
-                           sorted_indices.data());
+  DecreasingArgSort(keep_scores.data(), num_scores_kept, sorted_indices.data());
+
   const int num_boxes_kept = num_scores_kept;
   const int output_size = std::min(num_boxes_kept, max_detections);
   selected->clear();


### PR DESCRIPTION
This change uses std::stable_sort instead of std::partial_sort for the case where std::partial_sort use the full range.

This is the case preventing bit-exactness between TFL and TFLM. Problem with std::partial_sort is that the order of equal elements is not guaranteed to be preserved. Potentially std::partial_sort should be totally replaced but leaving that for now.

Next step would be to add a custom stable sort to TFLM, as std::stable_sort uses heap.

This progress towards: https://github.com/tensorflow/tensorflow/issues/47158
