### PR TITLE
Add axis argument in losses.categorical_crossentropy and losses.binary_crossentropy

### DIFF
--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -1593,7 +1593,8 @@ def log_cosh(y_true, y_pred):
 def categorical_crossentropy(y_true,
                              y_pred,
                              from_logits=False,
-                             label_smoothing=0):
+                             label_smoothing=0,
+                             axis=-1):
   """Computes the categorical crossentropy loss.
 
   Standalone usage:
@@ -1628,7 +1629,7 @@ def categorical_crossentropy(y_true,
 
   y_true = smart_cond.smart_cond(label_smoothing, _smooth_labels,
                                  lambda: y_true)
-  return K.categorical_crossentropy(y_true, y_pred, from_logits=from_logits)
+  return K.categorical_crossentropy(y_true, y_pred, from_logits=from_logits, axis=axis)
 
 
 @dispatch.dispatch_for_types(categorical_crossentropy,
@@ -1691,7 +1692,7 @@ def sparse_categorical_crossentropy(y_true, y_pred, from_logits=False, axis=-1):
 @keras_export('keras.metrics.binary_crossentropy',
               'keras.losses.binary_crossentropy')
 @dispatch.add_dispatch_support
-def binary_crossentropy(y_true, y_pred, from_logits=False, label_smoothing=0):
+def binary_crossentropy(y_true, y_pred, from_logits=False, label_smoothing=0, axis=-1):
   """Computes the binary crossentropy loss.
 
   Standalone usage:
@@ -1726,7 +1727,7 @@ def binary_crossentropy(y_true, y_pred, from_logits=False, label_smoothing=0):
   y_true = smart_cond.smart_cond(label_smoothing, _smooth_labels,
                                  lambda: y_true)
   return K.mean(
-      K.binary_crossentropy(y_true, y_pred, from_logits=from_logits), axis=-1)
+      K.binary_crossentropy(y_true, y_pred, from_logits=from_logits), axis=axis)
 
 
 @keras_export('keras.metrics.kl_divergence',

--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -1614,6 +1614,8 @@ def categorical_crossentropy(y_true,
     label_smoothing: Float in [0, 1]. If > `0` then smooth the labels. For
       example, if `0.1`, use `0.1 / num_classes` for non-target labels
       and `0.9 + 0.1 / num_classes` for target labels.
+    axis: (Optional) Defaults to -1. The dimension along which the entropy is
+      computed.
 
   Returns:
     Categorical crossentropy loss value.
@@ -1712,6 +1714,8 @@ def binary_crossentropy(y_true, y_pred, from_logits=False, label_smoothing=0, ax
     label_smoothing: Float in [0, 1]. If > `0` then smooth the labels by 
       squeezing them towards 0.5 That is, using `1. - 0.5 * label_smoothing`
       for the target class and `0.5 * label_smoothing` for the non-target class.
+    axis: (Optional) Defaults to -1. The dimension along which the mean is
+      computed.
 
   Returns:
     Binary crossentropy loss value. shape = `[batch_size, d0, .. dN-1]`.


### PR DESCRIPTION
Fix tensorflow/tensorflow/issues/39230.
This pull request will add the axis argument in tensorflow.keras.losses.categorical_crossentropy() and in tensorflow.keras.losses.binary_crossentropy() as in tensorflow.keras.losses.sparse_categorical_crossentropy().