### PR TITLE
Modernize TF_CPP_VMODULE handling using absl

### DIFF
--- a/tensorflow/core/platform/default/BUILD
+++ b/tensorflow/core/platform/default/BUILD
@@ -206,6 +206,7 @@ cc_library(
         "//tensorflow/core/platform:types",
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/container:flat_hash_map",
     ],
 )
 


### PR DESCRIPTION
This gets rid of the custom StringData struct since flat_hash_map
supports heterogenous lookups.