### PR TITLE
Updated the equation for FTLP as per the paper

### DIFF
--- a/tensorflow/python/keras/optimizer_v2/ftrl.py
+++ b/tensorflow/python/keras/optimizer_v2/ftrl.py
@@ -47,10 +47,10 @@ class Ftrl(optimizer_v2.OptimizerV2):
   $$n_{t,i} = n_{t-1,i} + g_{t,i}^{2}$$
   $$\sigma_{t,i} = (\sqrt{n_{t,i}} - \sqrt{n_{t-1,i}}) / \alpha$$
   $$z_{t,i} = z_{t-1,i} + g_{t,i} - \sigma_{t,i} * w_{t,i}$$
-  $$w_{t,i} =\begin{cases}
-0 & | z_{i}| \leqslant \lambda _{1} ,\\
-\ -\left(\frac{\beta +\sqrt{n_{t,i}}}{\alpha } +\lambda _{2}\right)^{-1}( z_{i} -sgn(z_{i} )*\lambda _{1}) & otherwise.
-\end{cases}$$
+  $$w_{t,i} =\begin{cases} 0 & | z_{i}| \leqslant \lambda _{1} ,\\
+              \ -\left(\frac{\beta +\sqrt{n_{t,i}}}{\alpha } 
+              +\lambda _{2}\right)^{-1}( z_{i} -sgn(z_{i} )
+              *\lambda _{1}) & otherwise.\end{cases}$$
 
   Check the documentation for the l2_shrinkage_regularization_strength
   parameter for more details when shrinkage is enabled, in which case gradient

--- a/tensorflow/python/keras/optimizer_v2/ftrl.py
+++ b/tensorflow/python/keras/optimizer_v2/ftrl.py
@@ -47,9 +47,10 @@ class Ftrl(optimizer_v2.OptimizerV2):
   $$n_{t,i} = n_{t-1,i} + g_{t,i}^{2}$$
   $$\sigma_{t,i} = (\sqrt{n_{t,i}} - \sqrt{n_{t-1,i}}) / \alpha$$
   $$z_{t,i} = z_{t-1,i} + g_{t,i} - \sigma_{t,i} * w_{t,i}$$
-  $$w_{t,i} = - ((\beta+\sqrt{n_{t,i}}) / \alpha + 2 * \lambda_{2})^{-1} *
-              (z_{i} - sgn(z_{i}) * \lambda_{1}) if \abs{z_{i}} > \lambda_{i}
-                                                 else 0$$
+  $$w_{t,i} =\begin{cases}
+0 & | z_{i}| \leqslant \lambda _{1} ,\\
+\ -\left(\frac{\beta +\sqrt{n_{t,i}}}{\alpha } +\lambda _{2}\right)^{-1}( z_{i} -sgn(z_{i} )*\lambda _{1}) & otherwise.
+\end{cases}$$
 
   Check the documentation for the l2_shrinkage_regularization_strength
   parameter for more details when shrinkage is enabled, in which case gradient


### PR DESCRIPTION
Used this https://static.googleusercontent.com/media/research.google.com/en//pubs/archive/41159.pdf to update the description.
![image](https://user-images.githubusercontent.com/16112670/108043678-6433f080-7067-11eb-9e00-9d7d56ae6e22.png)

Currenly, in the exisiting website:
![image](https://user-images.githubusercontent.com/16112670/108043964-b6751180-7067-11eb-94d7-e7f7ef60a85c.png)

The \abs function is errornious, Lambda_2 is doubled but as per the paper it is not multiplied by 2.
