### PR TITLE
test ExtractVolumePatches with float types that GPU supports

### DIFF
--- a/tensorflow/python/kernel_tests/extract_volume_patches_op_test.py
+++ b/tensorflow/python/kernel_tests/extract_volume_patches_op_test.py
@@ -45,13 +45,14 @@ class ExtractVolumePatches(test.TestCase):
     ksizes = [1] + ksizes + [1]
     strides = [1] + strides + [1]
 
-    out_tensor = array_ops.extract_volume_patches(
-        constant_op.constant(image),
-        ksizes=ksizes,
-        strides=strides,
-        padding=padding,
-        name="im2col_3d")
-    self.assertAllClose(patches, self.evaluate(out_tensor))
+    for dtype in [np.float16, np.float32, np.float64]:
+        out_tensor = array_ops.extract_volume_patches(
+            constant_op.constant(image.astype(dtype)),
+            ksizes=ksizes,
+            strides=strides,
+            padding=padding,
+            name="im2col_3d")
+        self.assertAllClose(patches.astype(dtype), self.evaluate(out_tensor))
 
   # pylint: disable=bad-whitespace
   def testKsize1x1x1Stride1x1x1(self):

--- a/tensorflow/python/kernel_tests/extract_volume_patches_op_test.py
+++ b/tensorflow/python/kernel_tests/extract_volume_patches_op_test.py
@@ -46,13 +46,13 @@ class ExtractVolumePatches(test.TestCase):
     strides = [1] + strides + [1]
 
     for dtype in [np.float16, np.float32, np.float64]:
-        out_tensor = array_ops.extract_volume_patches(
-            constant_op.constant(image.astype(dtype)),
-            ksizes=ksizes,
-            strides=strides,
-            padding=padding,
-            name="im2col_3d")
-        self.assertAllClose(patches.astype(dtype), self.evaluate(out_tensor))
+      out_tensor = array_ops.extract_volume_patches(
+          constant_op.constant(image.astype(dtype)),
+          ksizes=ksizes,
+          strides=strides,
+          padding=padding,
+          name="im2col_3d")
+      self.assertAllClose(patches.astype(dtype), self.evaluate(out_tensor))
 
   # pylint: disable=bad-whitespace
   def testKsize1x1x1Stride1x1x1(self):


### PR DESCRIPTION
The original test case tests int64 data type only, which GPU does not register at all.
The padding issue on GPU was fixed already on eigen side: https://gitlab.com/libeigen/eigen/-/merge_requests/362, https://gitlab.com/libeigen/eigen/-/merge_requests/367 .
So update the case to test data types that GPU supports here.

We may also need to remove the specialization of ExtractVolumePatches op for CPU on TensorFlow side later(as discussed in eigen's MRs)