### PR TITLE
Prevent BackupAndRestore cleanup from throwing if dir doesn't exist

### DIFF
--- a/tensorflow/python/keras/callbacks_test.py
+++ b/tensorflow/python/keras/callbacks_test.py
@@ -42,6 +42,7 @@ from tensorflow.python.framework import ops
 from tensorflow.python.framework import random_seed
 from tensorflow.python.keras import keras_parameterized
 from tensorflow.python.keras import testing_utils
+from tensorflow.python.keras.callbacks import BackupAndRestore
 from tensorflow.python.keras.engine import sequential
 from tensorflow.python.keras.layers import Activation
 from tensorflow.python.keras.layers import Dense
@@ -280,6 +281,12 @@ class KerasCallbacksTest(keras_parameterized.TestCase):
     with self.captureWritesToStream(sys.stdout) as printed:
       model.fit(dataset, epochs=2, steps_per_epoch=10)
       self.assertRegex(printed.contents(), expected_log)
+
+  def test_trivial_backup_restore(self):
+    model = keras.Sequential([keras.layers.Dense(1)])
+    model.compile('sgd', 'mse')
+    cbk = BackupAndRestore(self.get_temp_dir())
+    model.fit(np.ones((10, 1)), np.ones((10, 1)), epochs=0, callbacks=[cbk])
 
   @keras_parameterized.run_all_keras_modes
   def test_callback_warning(self):

--- a/tensorflow/python/keras/distribute/worker_training_state.py
+++ b/tensorflow/python/keras/distribute/worker_training_state.py
@@ -21,6 +21,7 @@ import os
 
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import errors
 from tensorflow.python.keras import backend as K
 from tensorflow.python.keras.distribute import distributed_file_utils
 from tensorflow.python.keras.utils import mode_keys
@@ -114,7 +115,10 @@ class WorkerTrainingState(object):
     successfully finishes.
     """
     if self.write_checkpoint_manager is self.read_checkpoint_manager:
-      file_io.delete_recursively_v2(self.write_checkpoint_manager.directory)
+      try:
+        file_io.delete_recursively_v2(self.write_checkpoint_manager.directory)
+      except errors.NotFoundError:
+        pass
 
   def maybe_load_initial_epoch_from_ckpt(self, initial_epoch, mode):
     """Maybe load initial epoch from ckpt considering possible worker recovery.


### PR DESCRIPTION
If `model.fit()` is called with `epochs=0` (which is allowed by Keras) [`BackupAndRestore.on_train_end`](https://github.com/tensorflow/tensorflow/blob/9663abe4c9037030b0b497c68cc4b2ba991967dd/tensorflow/python/keras/callbacks.py#L1648-L1656) would throw due to the fact that the checkpoint directory doesn't exist since [`on_epoch_end`](https://github.com/tensorflow/tensorflow/blob/9663abe4c9037030b0b497c68cc4b2ba991967dd/tensorflow/python/keras/callbacks.py#L1658-L1660) never get's called. This PR makes sure that `BackupAndRestore` doesn't throw in cases where no cleanup is necessary.