### PR TITLE
Add reminder on MacOS Catalina

### DIFF
--- a/tensorflow/lite/micro/examples/micro_speech/README.md
+++ b/tensorflow/lite/micro/examples/micro_speech/README.md
@@ -406,7 +406,7 @@ Before we begin, you'll need the following:
 
 - STM32F7 discovery kit board
 - Mini-USB cable
-- ARM Mbed CLI ([installation instructions](https://os.mbed.com/docs/mbed-os/v5.12/tools/installation-and-setup.html))
+- ARM Mbed CLI ([installation instructions](https://os.mbed.com/docs/mbed-os/v5.12/tools/installation-and-setup.html). Check it out for MacOS Catalina - [mbed-cli is broken on MacOS Catalina #930](https://github.com/ARMmbed/mbed-cli/issues/930#issuecomment-660550734))
 - Python 2.7 and pip
 
 Since Mbed requires a special folder structure for projects, we'll first run a


### PR DESCRIPTION
Same as   #47153 which is applicable to another location of different applications (micro_speech) using same board (STM32 DISCO_F746NG).

ARM mbed MacOS installer (mbed-cli-v0.0.10.dmg from https://github.com/ARMmbed/mbed-cli-osx-installer/releases/tag/v0.0.10) creates error during installation.

It is caused by MacOS Catalina moving path of terminal app from /Applications/Utilities/Terminal.app to /System/Applications/Utilities/Terminal.app. ) ARM mbed installer scripts still use /Applications/Utilities/Terminal.app.

So add a reminder, and a link to a solution from ARM mbed github.