### PR TITLE
[Grappler] Add support for QuantizeAndDequantizeV4

### DIFF
--- a/tensorflow/core/grappler/costs/op_level_cost_estimator.cc
+++ b/tensorflow/core/grappler/costs/op_level_cost_estimator.cc
@@ -582,6 +582,8 @@ OpLevelCostEstimator::OpLevelCostEstimator() {
   elementwise_ops_.emplace("Prod", EIGEN_COST(scalar_product_op<float>));
   elementwise_ops_.emplace("QuantizeAndDequantizeV2",
                            quantize_and_dequantize_v2_cost);
+  elementwise_ops_.emplace("QuantizeAndDequantizeV4",
+                           quantize_and_dequantize_v2_cost);
   elementwise_ops_.emplace("QuantizedSigmoid",
                            EIGEN_COST(scalar_logistic_op<float>));
   elementwise_ops_.emplace("QuantizeV2", quantize_v2_cost);

--- a/tensorflow/core/grappler/optimizers/generic_layout_optimizer_transposer.cc
+++ b/tensorflow/core/grappler/optimizers/generic_layout_optimizer_transposer.cc
@@ -2027,6 +2027,7 @@ bool IsDefaultLayoutAgnosticOp(const NodeDef& node) {
                                             "PreventGradient",
                                             "QuantizeAndDequantizeV2",
                                             "QuantizeAndDequantizeV3",
+                                            "QuantizeAndDequantizeV4",
                                             "Real",
                                             "Reciprocal",
                                             "Relu",

--- a/tensorflow/core/grappler/optimizers/layout_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/layout_optimizer.cc
@@ -170,6 +170,7 @@ std::set<string> GetOpsFormatAgnostic() {
                                           "Polygamma",
                                           "QuantizeAndDequantizeV2",
                                           "QuantizeAndDequantizeV3",
+                                          "QuantizeAndDequantizeV4",
                                           "Pow",
                                           "Real",
                                           "RealDiv",


### PR DESCRIPTION
52df91c5634e6c666843849a1c6ff29b3d2676be added `QuantizeAndDequantizeV4` which is used in `tf.quantization.quantize_and_dequantize_v2` and deprecated `QuantizeAndDequantizeV2`.

This PR adds  `QuantizeAndDequantizeV4` support to grappler which can be a simple alias to `QuantizeAndDequantizeV2` since they share the same forward kernel implementation:
https://github.com/tensorflow/tensorflow/blob/e43be76009614be88454d2fdf2fe702acc5bab77/tensorflow/core/kernels/quantize_and_dequantize_op.cc#L419-L422

These changes should be covered by the existing unittests.