### PR TITLE
Update bazel command to `bazel run` instead of `bazel test`.

### DIFF
--- a/tensorflow/lite/micro/CONTRIBUTING.md
+++ b/tensorflow/lite/micro/CONTRIBUTING.md
@@ -236,9 +236,9 @@ Below are some tips that might be useful and improve the development experience.
     want to test:
 
     ```
-    CC=clang bazel test ---config=asan tensorflow/lite/micro:micro_interpreter_test
-    CC=clang bazel test ---config=msan tensorflow/lite/micro:micro_interpreter_test
-    CC=clang bazel test ---config=ubsan tensorflow/lite/micro:micro_interpreter_test
+    CC=clang bazel run --config=asan tensorflow/lite/micro:micro_interpreter_test
+    CC=clang bazel run --config=msan tensorflow/lite/micro:micro_interpreter_test
+    CC=clang bazel run --config=ubsan tensorflow/lite/micro:micro_interpreter_test
     ```
 
 ## During the PR review


### PR DESCRIPTION
`bazel test` puts the error logs into a file instead of on the terminal, whereas `bazel run` will show all the logs on the terminal, which is nicer when debugging locally.
