### PR TITLE
Fix the Xtensa Vision P6 build.

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/quantize.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/quantize.cc
@@ -111,6 +111,7 @@ void AffineQuantize(int scale_multiplier, const int32_t zero_point,
 
 #endif  // defined(HIFIMINI)
 
+#if defined(HIFIMINI) || defined(FUSION_F1)
 TfLiteStatus EvalXtensa(TfLiteContext* context, TfLiteNode* node) {
   TFLITE_DCHECK(node->user_data != nullptr);
 #if defined(HIFIMINI)
@@ -167,6 +168,7 @@ TfLiteStatus EvalXtensa(TfLiteContext* context, TfLiteNode* node) {
   }
   return kTfLiteOk;
 }
+#endif  // defined(HIFIMINI) || defined(FUSION_F1)
 
 void* Init(TfLiteContext* context, const char* buffer, size_t length) {
   TFLITE_DCHECK(context->AllocatePersistentBuffer != nullptr);


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/47199 broke the Vision P6 build with the following error message:
```
tensorflow/lite/micro/kernels/xtensa/quantize.cc:144:5: error: static_assert failed "Unsupported xtensa architecture."
    static_assert(false, "Unsupported xtensa architecture.");
```

Manually confirmed that with this change, the following command passes:
```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=vision_p6 XTENSA_CORE=P6_200528 test -j8
```
