### PR TITLE
TFL: Update detection_postprocess kernel

### DIFF
--- a/tensorflow/lite/kernels/detection_postprocess.cc
+++ b/tensorflow/lite/kernels/detection_postprocess.cc
@@ -367,6 +367,16 @@ void DecreasingPartialArgSort(const float* values, int num_values,
       [&values](const int i, const int j) { return values[i] > values[j]; });
 }
 
+void DecreasingArgSort(const float* values, int num_values, int* indices) {
+  std::iota(indices, indices + num_values, 0);
+
+  // We want here a stable sort, in order to get completely defined output.
+  // In this way TFL and TFLM can be bit-exact.
+  std::stable_sort(
+      indices, indices + num_values,
+      [&values](const int i, const int j) { return values[i] > values[j]; });
+}
+
 void SelectDetectionsAboveScoreThreshold(const std::vector<float>& values,
                                          const float threshold,
                                          std::vector<float>* keep_values,
@@ -451,8 +461,8 @@ TfLiteStatus NonMaxSuppressionSingleClassHelper(
   int num_scores_kept = keep_scores.size();
   std::vector<int> sorted_indices;
   sorted_indices.resize(num_scores_kept);
-  DecreasingPartialArgSort(keep_scores.data(), num_scores_kept, num_scores_kept,
-                           sorted_indices.data());
+  DecreasingArgSort(keep_scores.data(), num_scores_kept, sorted_indices.data());
+
   const int num_boxes_kept = num_scores_kept;
   const int output_size = std::min(num_boxes_kept, max_detections);
   selected->clear();

--- a/tensorflow/lite/kernels/detection_postprocess_test.cc
+++ b/tensorflow/lite/kernels/detection_postprocess_test.cc
@@ -150,7 +150,7 @@ TEST(DetectionPostprocessOpTest, FloatTest) {
       0.5, 0.5,   1.0, 1.0,  // anchor #2
       0.5, 0.5,   1.0, 1.0,  // anchor #3
       0.5, 10.5,  1.0, 1.0,  // anchor #4
-      0.5, 10.5,  1.0, 1.0,  //  anchor #5
+      0.5, 10.5,  1.0, 1.0,  // anchor #5
       0.5, 100.5, 1.0, 1.0   // anchor #6
   });
   // Same boxes in box-corner encoding:
@@ -425,7 +425,7 @@ TEST(DetectionPostprocessOpTest, FloatTestFastNMS) {
       0.5, 0.5,   1.0, 1.0,  // anchor #2
       0.5, 0.5,   1.0, 1.0,  // anchor #3
       0.5, 10.5,  1.0, 1.0,  // anchor #4
-      0.5, 10.5,  1.0, 1.0,  //  anchor #5
+      0.5, 10.5,  1.0, 1.0,  // anchor #5
       0.5, 100.5, 1.0, 1.0   // anchor #6
   });
   // Same boxes in box-corner encoding:
@@ -545,7 +545,7 @@ TEST(DetectionPostprocessOpTest, FloatTestRegularNMS) {
       0.5, 0.5,   1.0, 1.0,  // anchor #2
       0.5, 0.5,   1.0, 1.0,  // anchor #3
       0.5, 10.5,  1.0, 1.0,  // anchor #4
-      0.5, 10.5,  1.0, 1.0,  //  anchor #5
+      0.5, 10.5,  1.0, 1.0,  // anchor #5
       0.5, 100.5, 1.0, 1.0   // anchor #6
   });
   m.Invoke();
@@ -656,7 +656,7 @@ TEST(DetectionPostprocessOpTest, FloatTestwithNoBackgroundClassAndNoKeypoints) {
       0.5, 0.5,   1.0, 1.0,  // anchor #2
       0.5, 0.5,   1.0, 1.0,  // anchor #3
       0.5, 10.5,  1.0, 1.0,  // anchor #4
-      0.5, 10.5,  1.0, 1.0,  //  anchor #5
+      0.5, 10.5,  1.0, 1.0,  // anchor #5
       0.5, 100.5, 1.0, 1.0   // anchor #6
   });
 
@@ -712,7 +712,7 @@ TEST(DetectionPostprocessOpTest, FloatTestwithBackgroundClassAndKeypoints) {
       0.5, 0.5,   1.0, 1.0,  // anchor #2
       0.5, 0.5,   1.0, 1.0,  // anchor #3
       0.5, 10.5,  1.0, 1.0,  // anchor #4
-      0.5, 10.5,  1.0, 1.0,  //  anchor #5
+      0.5, 10.5,  1.0, 1.0,  // anchor #5
       0.5, 100.5, 1.0, 1.0   // anchor #6
   });
 
@@ -826,7 +826,7 @@ TEST(DetectionPostprocessOpTest, FloatTestwithNoBackgroundClassAndKeypoints) {
       0.5, 0.5,   1.0, 1.0,  // anchor #2
       0.5, 0.5,   1.0, 1.0,  // anchor #3
       0.5, 10.5,  1.0, 1.0,  // anchor #4
-      0.5, 10.5,  1.0, 1.0,  //  anchor #5
+      0.5, 10.5,  1.0, 1.0,  // anchor #5
       0.5, 100.5, 1.0, 1.0   // anchor #6
   });
 
@@ -855,6 +855,68 @@ TEST(DetectionPostprocessOpTest, FloatTestwithNoBackgroundClassAndKeypoints) {
   EXPECT_THAT(output_shape4, ElementsAre(1));
   EXPECT_THAT(m.GetOutput4<float>(),
               ElementsAreArray(ArrayFloatNear({3.0}, 1e-4)));
+}
+
+TEST(DetectionPostprocessOpTest,
+     QuantizedTestwithNoBackgroundClassAndKeypointsStableSort) {
+  DetectionPostprocessOpModelwithRegularNMS m(
+      {TensorType_UINT8, {1, 6, 5}, -1.0, 1.0},
+      {TensorType_UINT8, {1, 6, 2}, 0.0, 1.0},
+      {TensorType_UINT8, {6, 4}, 0.0, 100.5}, {TensorType_FLOAT32, {}},
+      {TensorType_FLOAT32, {}}, {TensorType_FLOAT32, {}},
+      {TensorType_FLOAT32, {}}, false);
+  // six boxes in center-size encoding
+  std::vector<std::vector<float>> inputs1 = {{
+      0.0, 0.0,  0.0, 0.0, 1.0,  // box #1
+      0.0, 1.0,  0.0, 0.0, 1.0,  // box #2
+      0.0, -1.0, 0.0, 0.0, 1.0,  // box #3
+      0.0, 0.0,  0.0, 0.0, 1.0,  // box #4
+      0.0, 1.0,  0.0, 0.0, 1.0,  // box #5
+      0.0, 0.0,  0.0, 0.0, 1.0   // box #6
+  }};
+  m.QuantizeAndPopulate<uint8_t>(m.input1(), inputs1[0]);
+  // class scores - two classes with background
+  // inputs2 values taken from ssd mobilenet v1 - a stable sort is required to
+  // retain order of equal elements
+  std::vector<std::vector<float>> inputs2 = {
+    {0.015625, 0.007812, 0.003906, 0.015625, 0.015625, 0.007812, 0.019531,
+     0.019531, 0.007812, 0.003906, 0.003906, 0.003906}};
+  m.QuantizeAndPopulate<uint8_t>(m.input2(), inputs2[0]);
+  // six anchors in center-size encoding
+  std::vector<std::vector<float>> inputs3 = {{
+      0.5, 0.5,   1.0, 1.0,  // anchor #1
+      0.5, 0.5,   1.0, 1.0,  // anchor #2
+      0.5, 0.5,   1.0, 1.0,  // anchor #3
+      0.5, 10.5,  1.0, 1.0,  // anchor #4
+      0.5, 10.5,  1.0, 1.0,  // anchor #5
+      0.5, 100.5, 1.0, 1.0   // anchor #6
+  }};
+  m.QuantizeAndPopulate<uint8_t>(m.input3(), inputs3[0]);
+  m.Invoke();
+  // detection_boxes
+  // in center-size
+  std::vector<int> output_shape1 = m.GetOutputShape1();
+  EXPECT_THAT(output_shape1, ElementsAre(1, 3, 4));
+  EXPECT_THAT(
+      m.GetOutput1<float>(),
+      ElementsAreArray(ArrayFloatNear(
+          {0.0, 10.0, 1.0, 11.0, 0.0, 0.0, 1.0, 1.0, 0.0, 100.0, 1.0, 101.0},
+          3e-1)));
+  // detection_classes
+  std::vector<int> output_shape2 = m.GetOutputShape2();
+  EXPECT_THAT(output_shape2, ElementsAre(1, 3));
+  EXPECT_THAT(m.GetOutput2<float>(),
+              ElementsAreArray(ArrayFloatNear({0, 0, 0}, 1e-1)));
+  // detection_scores
+  std::vector<int> output_shape3 = m.GetOutputShape3();
+  EXPECT_THAT(output_shape3, ElementsAre(1, 3));
+  EXPECT_THAT(m.GetOutput3<float>(), ElementsAreArray(
+      ArrayFloatNear({0.0196078, 0.0156863, 0.00392157 }, 1e-7)));
+  // num_detections
+  std::vector<int> output_shape4 = m.GetOutputShape4();
+  EXPECT_THAT(output_shape4, ElementsAre(1));
+  EXPECT_THAT(m.GetOutput4<float>(),
+              ElementsAreArray(ArrayFloatNear({3.0}, 1e-1)));
 }
 }  // namespace
 }  // namespace custom


### PR DESCRIPTION
Changing std::partial_sort to std::stable_sort in the case where
std::partial_sort use the full range. This is the case preventing
bit-exactness between TFL and TFLM. Problem with std::partial_sort
is that the order of equal elements is not guaranteed to be
preserved. Possibly std::partial_sort should be totally
replaced but leaving that for now.
Also adding a unit test for stable sort.

This progress towards: https://github.com/tensorflow/tensorflow/issues/47158

Note that this was the first fix: https://github.com/tensorflow/tensorflow/pull/47159
However that was merged before adding a unit test, and it was also reverted. So opening this new PR.