### PR TITLE
Switch gcs to modular file system on tensorflow/io

### DIFF
--- a/tensorflow/core/platform/cloud/gcs_file_system.cc
+++ b/tensorflow/core/platform/cloud/gcs_file_system.cc
@@ -2135,4 +2135,4 @@ Status GcsFileSystem::CreateHttpRequest(std::unique_ptr<HttpRequest>* request) {
 // system is a child of gcs file system with TPU-pod on GCS optimizations.
 // This option is set ON/OFF in the GCP TPU tensorflow config.
 // Initialize gcs_file_system
-REGISTER_FILE_SYSTEM("gs", ::tensorflow::RetryingGcsFileSystem);
+REGISTER_LEGACY_FILE_SYSTEM("gs", ::tensorflow::RetryingGcsFileSystem);


### PR DESCRIPTION
This PR is part of the effort to switch to modular file system support.

This PR switches gcs file system and direct user to use modular file system
from tensorflow-io instead. See PR #46955 for related changes.

A TF_ENABLE_LEGACY_FILESYSTEM=1 will allow the usage of original gcs file
system the same way as before (a warning will be displayed).

/cc @mihaimaruseac @vnvo2409 @tensorflow/sig-io-maintainers @burgerkingeater

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>