### PR TITLE
[TFL] Remove unnecessary Reshape before FullyConnected.

### DIFF
--- a/tensorflow/compiler/mlir/lite/tests/end2end/unroll_batch_matmul.pbtxt
+++ b/tensorflow/compiler/mlir/lite/tests/end2end/unroll_batch_matmul.pbtxt
@@ -79,18 +79,15 @@ versions {
 
 # CHECK:       func @main(%[[VAL_0:.*]]: tensor<2x5x3xf32>, %[[VAL_1:.*]]: tensor<3x7xf32>) -> tensor<2x5x7xf32> attributes {tf.entry_function = {control_outputs = "", inputs = "Placeholder,Placeholder_1", outputs = "MatMul"}} {
 # CHECK-DAG:       %[[VAL_2:.*]] = constant dense<[1, 0]> : tensor<2xi32>
-# CHECK-DAG:       %[[VAL_3:.*]] = constant dense<[5, 3]> : tensor<2xi32>
-# CHECK-DAG:       %[[VAL_5:.*]] = constant unit
-# CHECK-DAG:       %[[VAL_6:.*]] = constant dense<[1, 0, 0]> : tensor<3xi32>
-# CHECK-DAG:       %[[VAL_7:.*]] = constant dense<[1, 5, 3]> : tensor<3xi32>
-# CHECK-DAG:       %[[VAL_8:.*]] = constant dense<0> : tensor<3xi32>
-# CHECK:           %[[VAL_10:.*]] = "tfl.slice"(%[[VAL_0]], %[[VAL_8]], %[[VAL_7]]) : (tensor<2x5x3xf32>, tensor<3xi32>, tensor<3xi32>) -> tensor<1x5x3xf32>
-# CHECK:           %[[VAL_11:.*]] = "tfl.reshape"(%[[VAL_10]], %[[VAL_3]]) : (tensor<1x5x3xf32>, tensor<2xi32>) -> tensor<5x3xf32>
-# CHECK:           %[[VAL_12:.*]] = "tfl.slice"(%[[VAL_0]], %[[VAL_6]], %[[VAL_7]]) : (tensor<2x5x3xf32>, tensor<3xi32>, tensor<3xi32>) -> tensor<1x5x3xf32>
-# CHECK:           %[[VAL_13:.*]] = "tfl.reshape"(%[[VAL_12]], %[[VAL_3]]) : (tensor<1x5x3xf32>, tensor<2xi32>) -> tensor<5x3xf32>
-# CHECK:           %[[VAL_17:.*]] = "tfl.transpose"(%[[VAL_1]], %[[VAL_2]]) : (tensor<3x7xf32>, tensor<2xi32>) -> tensor<7x3xf32>
-# CHECK:           %[[VAL_18:.*]] = "tfl.fully_connected"(%[[VAL_11]], %[[VAL_17]], %[[VAL_5]]) {fused_activation_function = "NONE", keep_num_dims = false, weights_format = "DEFAULT"} : (tensor<5x3xf32>, tensor<7x3xf32>, none) -> tensor<5x7xf32>
-# CHECK:           %[[VAL_19:.*]] = "tfl.fully_connected"(%[[VAL_13]], %[[VAL_17]], %[[VAL_5]]) {fused_activation_function = "NONE", keep_num_dims = false, weights_format = "DEFAULT"} : (tensor<5x3xf32>, tensor<7x3xf32>, none) -> tensor<5x7xf32>
-# CHECK:           %[[VAL_20:.*]] = "tfl.pack"(%[[VAL_18]], %[[VAL_19]]) {axis = 0 : i32, values_count = 2 : i32} : (tensor<5x7xf32>, tensor<5x7xf32>) -> tensor<2x5x7xf32>
-# CHECK:           return %[[VAL_20]] : tensor<2x5x7xf32>
+# CHECK-DAG:       %[[VAL_3:.*]] = constant unit
+# CHECK-DAG:       %[[VAL_4:.*]] = constant dense<[1, 0, 0]> : tensor<3xi32>
+# CHECK-DAG:       %[[VAL_5:.*]] = constant dense<[1, 5, 3]> : tensor<3xi32>
+# CHECK-DAG:       %[[VAL_6:.*]] = constant dense<0> : tensor<3xi32>
+# CHECK:           %[[VAL_7:.*]] = "tfl.slice"(%[[VAL_0]], %[[VAL_6]], %[[VAL_5]]) : (tensor<2x5x3xf32>, tensor<3xi32>, tensor<3xi32>) -> tensor<1x5x3xf32>
+# CHECK:           %[[VAL_8:.*]] = "tfl.slice"(%[[VAL_0]], %[[VAL_4]], %[[VAL_5]]) : (tensor<2x5x3xf32>, tensor<3xi32>, tensor<3xi32>) -> tensor<1x5x3xf32>
+# CHECK:           %[[VAL_9:.*]] = "tfl.transpose"(%[[VAL_1]], %[[VAL_2]]) : (tensor<3x7xf32>, tensor<2xi32>) -> tensor<7x3xf32>
+# CHECK:           %[[VAL_10:.*]] = "tfl.fully_connected"(%[[VAL_7]], %[[VAL_9]], %[[VAL_3]]) {fused_activation_function = "NONE", keep_num_dims = false, weights_format = "DEFAULT"} : (tensor<1x5x3xf32>, tensor<7x3xf32>, none) -> tensor<5x7xf32>
+# CHECK:           %[[VAL_11:.*]] = "tfl.fully_connected"(%[[VAL_8]], %[[VAL_9]], %[[VAL_3]]) {fused_activation_function = "NONE", keep_num_dims = false, weights_format = "DEFAULT"} : (tensor<1x5x3xf32>, tensor<7x3xf32>, none) -> tensor<5x7xf32>
+# CHECK:           %[[VAL_12:.*]] = "tfl.pack"(%[[VAL_10]], %[[VAL_11]]) {axis = 0 : i32, values_count = 2 : i32} : (tensor<5x7xf32>, tensor<5x7xf32>) -> tensor<2x5x7xf32>
+# CHECK:           return %[[VAL_12]] : tensor<2x5x7xf32>
 # CHECK:         }

--- a/tensorflow/compiler/mlir/lite/transforms/optimize.cc
+++ b/tensorflow/compiler/mlir/lite/transforms/optimize.cc
@@ -1011,13 +1011,13 @@ struct ConvertTrivialTransposeOpToReshapeOp
 //
 //   %shape = constant dense<[1, 128, 64]> : tensor<3xi32>
 //   %reshape = tfl.reshape(%input, %shape) // %input: tensor<128x64xf32>
-//   %1 = tfl.fully_connected(%reshape, %filter, %bias)
-//          {keep_num_dims = false, weights_format = "DEFAULT"}
+//   %fc = tfl.fully_connected(%reshape, %filter, %bias)
+//           {keep_num_dims = false, weights_format = "DEFAULT"}
 //
 // can be canonicalized to
 //
-//   %1 = tfl.fully_connected(%input, %filter, %bias)
-//          {keep_num_dims = false, weights_format = "DEFAULT"}
+//   %fc = tfl.fully_connected(%input, %filter, %bias)
+//           {keep_num_dims = false, weights_format = "DEFAULT"}
 struct RemoveReshapeBeforeFullyConnected
     : public OpRewritePattern<TFL::FullyConnectedOp> {
   using OpRewritePattern<TFL::FullyConnectedOp>::OpRewritePattern;

--- a/tensorflow/compiler/mlir/lite/transforms/optimize.cc
+++ b/tensorflow/compiler/mlir/lite/transforms/optimize.cc
@@ -1005,6 +1005,56 @@ struct ConvertTrivialTransposeOpToReshapeOp
   }
 };
 
+// Remove Reshape before FullyConnected when `keep_num_dims=false` and Reshape
+// does not alter the last dimension as FullyConnected will collapse all other
+// dimensions into a single dimension. For example,
+//
+//   %shape = constant dense<[1, 128, 64]> : tensor<3xi32>
+//   %reshape = tfl.reshape(%input, %shape) // %input: tensor<128x64xf32>
+//   %1 = tfl.fully_connected(%reshape, %filter, %bias) {keep_num_dims = false,
+//   weights_format = "DEFAULT"}
+//
+// can be canonicalized to
+//
+//   %1 = tfl.fully_connected(%input, %filter, %bias) {keep_num_dims = false,
+//   weights_format = "DEFAULT"}
+struct RemoveReshapeBeforeFullyConnected
+    : public OpRewritePattern<TFL::FullyConnectedOp> {
+  using OpRewritePattern<TFL::FullyConnectedOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(TFL::FullyConnectedOp fully_connected_op,
+                                PatternRewriter &) const override {
+    auto input = fully_connected_op.input();
+    auto input_ty = input.getType().dyn_cast<ShapedType>();
+    auto output_ty = fully_connected_op.output()[0]
+                         .getType()
+                         .template dyn_cast<ShapedType>();
+    if (!input_ty.hasStaticShape() ||
+        fully_connected_op.weights_format() != "DEFAULT" ||
+        fully_connected_op.keep_num_dims() || !output_ty.hasStaticShape() ||
+        output_ty.getRank() != 2) {
+      return failure();
+    }
+
+    auto reshape_op = input.getDefiningOp<TFL::ReshapeOp>();
+    if (!reshape_op) return failure();
+
+    // Check if the last dimension does not change after reshape.
+    auto reshape_input = reshape_op.input();
+    auto reshape_input_ty = reshape_input.getType().dyn_cast<ShapedType>();
+    if (!reshape_input_ty.hasStaticShape() || input_ty.getRank() == 0 ||
+        reshape_input_ty.getRank() == 0 ||
+        input_ty.getDimSize(input_ty.getRank() - 1) !=
+            reshape_input_ty.getDimSize(reshape_input_ty.getRank() - 1)) {
+      return failure();
+    }
+
+    // Connect the input to the one of reshape.
+    fully_connected_op.setOperand(0, reshape_input);
+    return success();
+  }
+};
+
 using FuseBinaryOpToFollowingFullyConnected =
     FuseBinaryOpToFollowingAffineOp<FullyConnectedOp>;
 using FuseBinaryOpToFollowingDepthwiseConv2D =
@@ -1041,7 +1091,8 @@ void Optimize::runOnFunction() {
               FuseBinaryOpToFollowingDepthwiseConv2D,
               FuseBinaryOpToFollowingFullyConnected, FuseConv2DAndMulWithQDQs,
               FuseDepthwiseConv2DAndMulWithQDQs,
-              ConvertTrivialTransposeOpToReshapeOp>(ctx);
+              ConvertTrivialTransposeOpToReshapeOp,
+              RemoveReshapeBeforeFullyConnected>(ctx);
   (void)applyPatternsAndFoldGreedily(func, std::move(phase_2_patterns));
 }
 

--- a/tensorflow/compiler/mlir/lite/transforms/optimize.cc
+++ b/tensorflow/compiler/mlir/lite/transforms/optimize.cc
@@ -1011,13 +1011,13 @@ struct ConvertTrivialTransposeOpToReshapeOp
 //
 //   %shape = constant dense<[1, 128, 64]> : tensor<3xi32>
 //   %reshape = tfl.reshape(%input, %shape) // %input: tensor<128x64xf32>
-//   %1 = tfl.fully_connected(%reshape, %filter, %bias) {keep_num_dims = false,
-//   weights_format = "DEFAULT"}
+//   %1 = tfl.fully_connected(%reshape, %filter, %bias)
+//          {keep_num_dims = false, weights_format = "DEFAULT"}
 //
 // can be canonicalized to
 //
-//   %1 = tfl.fully_connected(%input, %filter, %bias) {keep_num_dims = false,
-//   weights_format = "DEFAULT"}
+//   %1 = tfl.fully_connected(%input, %filter, %bias)
+//          {keep_num_dims = false, weights_format = "DEFAULT"}
 struct RemoveReshapeBeforeFullyConnected
     : public OpRewritePattern<TFL::FullyConnectedOp> {
   using OpRewritePattern<TFL::FullyConnectedOp>::OpRewritePattern;


### PR DESCRIPTION
Remove unnecessary Reshape before FullyConnected. TFLite support N-D input of shape [batch_size, ..., channels] for FullyConnected. When keep_num_dims is false, all dimensions except the last one are collapsed into a single dimension. Therefore, it's safe to remove Reshape when it does not alter the last dimension.

The pattern is found in the official [mobilebert](https://www.tensorflow.org/lite/models/bert_qa/overview). Reshape op is not expensive but will block the folding of two consecutive FullyConnected Op (unimplemented yet).

I benchmark with simple model here, which is similar to the one found in provided tflite mobilebert model `bert/encoder/layer_0/bottleneck/attention/FakeLayerNorm/add`.

```python
model = tf.keras.Sequential([
  tf.keras.layers.Dense(128, batch_input_shape=(1, 384, 128), use_bias=True),
])
```

It contains a pattern of Reshape-FullyConnected-Reshape. This PR remove the first Reshape so it becomes FullyConnected-Reshape. The performance on Pixel3a is in the following

-----
Before
```
count=1035 first=987 curr=923 min=913 max=1070 avg=939.102 std=27
```
-----
After
```
count=1049 first=991 curr=910 min=894 max=1069 avg=923.888 std=31
```
-----

For end2end testing, I download the savedmodel from [google-research/mobilebert](https://github.com/google-research/google-research/tree/master/mobilebert) (floating point) and convert to tflite.

-----
Before
```
count=94 first=1612190 curr=1611814 min=1601869 max=1623227 avg=1.61185e+06 std=4439
```
-----
After
```
count=94 first=1601583 curr=1600427 min=1590411 max=1614870 avg=1.60146e+06 std=5378
```
-----

There is no significant performance regression or improvement as FullyConnected ops dominate the running time.

I have to reword that the Reshape that will block the folding of two consecutive FullyConnected disappears if I convert the model  manually with tf-nightly, but the pattern still happens very often in mobilebert as well as using `tf.keras.layers.Dense` with 3D or higher input. Also, I cannot really find the pattern stated in my previous response https://github.com/tensorflow/tensorflow/pull/47258#issuecomment-782819838 if I convert the model manually with tf-nightly.

Moreover, even with the simple two consecutive dense layers with 3D input, for example,

```python
model = tf.keras.Sequential([
  tf.keras.layers.Dense(2, batch_input_shape=(1, 384, 512)),
  tf.keras.layers.Dense(3)
])
```

the Reshape ops between two dense layers are optimized out.