### PR TITLE
Sort variables by name in custom gradient for determinism

### DIFF
--- a/tensorflow/python/ops/custom_gradient.py
+++ b/tensorflow/python/ops/custom_gradient.py
@@ -373,8 +373,10 @@ def _graph_mode_decorator(f, args, kwargs):
       v.ref() for v in _get_dependent_variables(
           input_ops=filtered_input_tensors, output_ops=flat_result)
   ])
-  variables = list(
-      [v.deref() for v in variables_in_subgraph.union(variables_in_tape)])
+  variables = sorted(
+      [v.deref() for v in variables_in_subgraph.union(variables_in_tape)],
+      key=lambda v: v.name
+  )
 
   grad_argspec = tf_inspect.getfullargspec(grad_fn)
   variables_in_signature = ("variables" in grad_argspec.args or


### PR DESCRIPTION
This PR is the fix for issue https://github.com/tensorflow/tensorflow/issues/47267.

`tf.custom_gradient()` keeps track of variables that are not part of the inputs and returns gradients for them. When there are multiple such variables, the created graph (in non-eager mode) is non-deterministic. The reason is that watched variable references are stored in a frozenset and since these references are essentially ids that have different ordering from one python invocation to another, the generated graph is different across different runs.

This change deterministically orders the watched variables by their name to avoid that issue.