### PR TITLE
Note string optimizer name is case-insensitive

### DIFF
--- a/tensorflow/python/keras/engine/training.py
+++ b/tensorflow/python/keras/engine/training.py
@@ -496,8 +496,8 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
     """Configures the model for training.
 
     Args:
-        optimizer: String (name of optimizer) or optimizer instance. See
-          `tf.keras.optimizers`.
+        optimizer: String (name of optimizer, case-insensitive) or optimizer 
+          instance. See `tf.keras.optimizers`.
         loss: String (name of objective function), objective function or
           `tf.keras.losses.Loss` instance. See `tf.keras.losses`. An objective
           function is any callable with the signature `loss = fn(y_true,


### PR DESCRIPTION
A minor documentation addition. For clarity, it can be noted that the optimizer string can be put in any casing in `model.compile`, i.e. case-insensitive. e.g.

```python
model.compile(optimizer='RMSprop')
model.compile(optimizer='rmsprop')
model.compile(optimizer='RMSPROP')
```

→ Are all the same. It makes sense to tell the user they do not have to mind the casing.

This is because whatever the user inputs as an optimizer string is converted to a lowercase string in [optimizers.py#L81](https://github.com/tensorflow/tensorflow/blob/v2.4.1/tensorflow/python/keras/optimizers.py#L81); and then compared to other lower-cased optimizer strings.

Have a great day still ☀️