### PR TITLE
Simple reproduction of issue decribed in #46937

### DIFF
--- a/tensorflow/lite/micro/test_renode.cc
+++ b/tensorflow/lite/micro/test_renode.cc
@@ -1,0 +1,23 @@
+
+#include "tensorflow/lite/micro/micro_error_reporter.h"
+
+int a = 45;
+bool init_to_false = false;
+bool init_to_true = true;
+int* init_to_nullptr = nullptr;
+
+int main(int argc, char** argv) {
+  MicroPrintf("a: %d", a);
+  MicroPrintf("init_to_false: %d", init_to_false);
+  if (init_to_false == false) {
+    MicroPrintf("Was initialized to false");
+  } else {
+    MicroPrintf("Was not initialized to false");
+  }
+
+  init_to_false = true;
+  MicroPrintf("init_to_false: %d", init_to_false);
+  MicroPrintf("init_to_true: %d", init_to_true);
+  MicroPrintf("init_to_nullptr: %d", init_to_nullptr);
+}
+

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -742,3 +742,6 @@ $(DEPDIR)/%.d: ;
 .PRECIOUS: $(BINDIR)%_test
 
 -include $(patsubst %,$(DEPDIR)/%.d,$(basename $(ALL_SRCS)))
+
+$(eval $(call microlite_test,test_renode, tensorflow/lite/micro/test_renode.cc,))
+


### PR DESCRIPTION
Simple reproduction of issue decribed in #46937

Expected output (i.e. what I get on x86):
```
make -f tensorflow/lite/micro/tools/make/Makefile run_test_renode -j8
```
gives:
```
a: 45
init_to_false: 0
Was initialized to false
init_to_false: 1
init_to_true: 1
init_to_nullptr: 0
```

What I get with Renode + bluepill:
```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=bluepill test_renode -j8
tensorflow/lite/micro/tools/make/downloads/renode/renode
```
and in the renode terminal:
```
Clear; include @tensorflow/lite/micro/testing/bluepill_nontest.resc; sysbus LoadELF @tensorflow/lite/micro/tools/make/gen/bluepill_cortex-m3_default/bin/test_renode; start
```

gives:
```
a: 45
init_to_false: 239
Was not initialized to false
init_to_false: 1
init_to_true: 1
init_to_nullptr: -559038737
```

Need to debug further, but creating a PR in case @PiotrZierhoffer has any ideas.