### PR TITLE
Remove unnecessary bool conversion in basic test.

### DIFF
--- a/tensorflow/python/kernel_tests/argmax_op_test.py
+++ b/tensorflow/python/kernel_tests/argmax_op_test.py
@@ -61,7 +61,7 @@ class ArgMaxTest(test.TestCase):
       self._testArg(method, x, axis, expected_values, False, expected_err_re)
 
   def _testBasic(self, dtype):
-    x = np.arange(200, dtype=np.float32).astype(np.bool_).astype(dtype)
+    x = np.arange(200, dtype=np.float32).astype(dtype)
     np.random.shuffle(x)
 
     # Check that argmin and argmax match numpy along the primary axis
@@ -75,6 +75,12 @@ class ArgMaxTest(test.TestCase):
     # breaking ties.
     self._testBothArg(math_ops.argmax, x, 0, x.argmax())
     self._testBothArg(math_ops.argmin, x, 0, x.argmin())
+
+    # Check that argmin and argmax match numpy along axis=1 for
+    # breaking ties.
+    x = np.array([[0, 0, 1, 1], [1, 1, 0, 0], [0, 1, 0, 1]], dtype=dtype)
+    self._testBothArg(math_ops.argmax, x, 1, x.argmax(axis=1))
+    self._testBothArg(math_ops.argmin, x, 1, x.argmin(axis=1))
 
   def _testDim(self, dtype):
     shape = (3, 2, 4, 5, 6, 3, 7)

--- a/tensorflow/python/kernel_tests/in_topk_op_test.py
+++ b/tensorflow/python/kernel_tests/in_topk_op_test.py
@@ -75,13 +75,7 @@ class InTopKTest(test.TestCase):
     predictions = [[0.1, 0.3, 0.2, 0.4], [0.1, 0.2, 0.3, 0.4]]
     target = [0, 2]
     k = constant_op.constant(3)
-    np_ans = np.array([False, True])
-    with self.cached_session():
-      precision = nn_ops.in_top_k(predictions, target, k)
-      out = self.evaluate(precision)
-      self.assertAllClose(np_ans, out)
-      self.assertShapeEqual(np_ans, precision)
-
+    self._validateInTopK(predictions, target, k, [False, True])
 
 if __name__ == "__main__":
   test.main()


### PR DESCRIPTION
Add tie breaking test for axis=1.