### PR TITLE
Hide subprocess windows for windows os

### DIFF
--- a/tensorflow/core/platform/windows/subprocess.cc
+++ b/tensorflow/core/platform/windows/subprocess.cc
@@ -248,9 +248,13 @@ bool SubProcess::Start() {
   STARTUPINFOA si;
   ZeroMemory(&si, sizeof(STARTUPINFO));
   si.cb = sizeof(STARTUPINFO);
-  si.dwFlags |= STARTF_USESTDHANDLES;
+
+  // Prevent console window popping in case we are in GUI mode
+  si.dwFlags |= STARTF_USESHOWWINDOW;
+  si.wShowWindow = SW_HIDE;
 
   // Handle the pipes for the child process.
+  si.dwFlags |= STARTF_USESTDHANDLES;
   if (child_pipe_[CHAN_STDIN]) {
     si.hStdInput = child_pipe_[CHAN_STDIN];
   }


### PR DESCRIPTION
Unlike Linux-based operating systems, Windows will create a new console for a child process if the parent is a GUI application.

This causes console window flashes when `ptxas` is called if the process that loaded `tensorflow.dll` is running in GUI mode.

This PR makes children's windows hidden by default. 

As tensorflow does not start any GUI programs, it should not cause any bad effect.

Console mode is not affected.