### PR TITLE
Prefer generator expressions over list comprehensions

### DIFF
--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -834,10 +834,10 @@ class DatasetV2(collections_abc.Iterable, tracking_base.Trackable,
       output_signature = nest.map_structure_up_to(output_types,
                                                   tensor_spec.TensorSpec,
                                                   output_shapes, output_types)
-    if all([
+    if all(
         isinstance(x, tensor_spec.TensorSpec)
         for x in nest.flatten(output_signature)
-    ]):
+    ):
       output_types = nest.pack_sequence_as(
           output_signature, [x.dtype for x in nest.flatten(output_signature)])
       output_shapes = nest.pack_sequence_as(

--- a/tensorflow/python/distribute/multi_worker_util.py
+++ b/tensorflow/python/distribute/multi_worker_util.py
@@ -82,7 +82,7 @@ def _validate_cluster_spec(cluster_spec,
 
   cluster_spec = normalize_cluster_spec(cluster_spec)
 
-  if any([job not in allowed_task_types for job in cluster_spec.jobs]):
+  if any(job not in allowed_task_types for job in cluster_spec.jobs):
     raise ValueError("Disallowed task type found in cluster spec. Allowed "
                      "types are {} and the cluster spec is {}.".format(
                          allowed_task_types, cluster_spec))

--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -247,8 +247,8 @@ class CallbackList(object):
 
     # Performance check: Check batch hooks for slowness compared to batch time.
     # Only run check for custom callbacks (i.e. not present in this file).
-    self._check_timing = any([cbk.__class__.__name__ not in globals()
-                              for cbk in self.callbacks])
+    self._check_timing = any(cbk.__class__.__name__ not in globals()
+                             for cbk in self.callbacks)
     self._num_batches_for_timing_check = 5
     self._hook_times = {}
     self._batch_start_time = None

--- a/tensorflow/python/keras/layers/preprocessing/preprocessing_stage.py
+++ b/tensorflow/python/keras/layers/preprocessing/preprocessing_stage.py
@@ -173,9 +173,9 @@ class FunctionalPreprocessingStage(functional.Functional,
     """
     if not isinstance(data, dataset_ops.Dataset):
       data = self._flatten_to_reference_inputs(data)
-      if any([
+      if any(
           not isinstance(datum, (np.ndarray, ops.EagerTensor)) for datum in data
-      ]):
+      ):
         raise ValueError(
             '`adapt()` requires a batched Dataset, a list of EagerTensors '
             'or Numpy arrays as input, got {}'.format(type(data)))

--- a/tensorflow/python/ops/parallel_for/control_flow_ops.py
+++ b/tensorflow/python/ops/parallel_for/control_flow_ops.py
@@ -537,7 +537,7 @@ def vectorized_map(fn, elems, fallback_to_while_loop=True):
       return None
     return x.shape.as_list()[0]
   static_first_dims = [_get_shape(elem) for elem in flat_elems]
-  if any([s is None for s in static_first_dims]):
+  if any(s is None for s in static_first_dims):
     batch_size = math_ops.reduce_max(
         [array_ops.shape(elem)[0] for elem in flat_elems])
   else:


### PR DESCRIPTION
This PR replaces list comprehensions that are only used as input to `any()` or `all()` with generator expressions. This removes the need to instantiate unnecessary lists if the expression is only consumed as an iterator and in the case of any allows the loop to potentially exit early which can improve performance for long iterations.

Most of the changes are not in a hot code path so this won't noticeably improve performance but since the change don't hurt readability I think they are still useful to include.