### PR TITLE
[TFL] Support I32 for OptimizeSlice pattern

### DIFF
--- a/tensorflow/compiler/mlir/lite/tests/optimize.mlir
+++ b/tensorflow/compiler/mlir/lite/tests/optimize.mlir
@@ -1679,8 +1679,17 @@ func @ReorderReshapex2Add(%arg0: tensor<1x2x3x4xf32>, %arg1: tensor<1x2x3x4xf32>
   // CHECK: return %[[VAL_1]]
 }
 
-// CHECK-LABEL: ConvertSliceToIdentity
-func @ConvertSliceToIdentity(%arg0: tensor<2x3x4x5xf32>) -> tensor<2x3x4x5xf32> {
+// CHECK-LABEL: ConvertSliceToIdentityI32
+func @ConvertSliceToIdentityI32(%arg0: tensor<2x3x4x5xf32>) -> tensor<2x3x4x5xf32> {
+  %begin = constant dense<0> : tensor<4xi32>
+  %shape = constant dense<[2,3,4,5]> : tensor<4xi32>
+  %0 = "tfl.slice"(%arg0, %begin, %shape) : (tensor<2x3x4x5xf32>, tensor<4xi32>, tensor<4xi32>) -> tensor<2x3x4x5xf32>
+  return %0 : tensor<2x3x4x5xf32>
+  // CHECK: return %arg0
+}
+
+// CHECK-LABEL: ConvertSliceToIdentityI64
+func @ConvertSliceToIdentityI64(%arg0: tensor<2x3x4x5xf32>) -> tensor<2x3x4x5xf32> {
   %begin = constant dense<0> : tensor<4xi64>
   %shape = constant dense<[2,3,4,5]> : tensor<4xi64>
   %0 = "tfl.slice"(%arg0, %begin, %shape) : (tensor<2x3x4x5xf32>, tensor<4xi64>, tensor<4xi64>) -> tensor<2x3x4x5xf32>

--- a/tensorflow/compiler/mlir/lite/tests/optimize.mlir
+++ b/tensorflow/compiler/mlir/lite/tests/optimize.mlir
@@ -1697,6 +1697,24 @@ func @ConvertSliceToIdentityI64(%arg0: tensor<2x3x4x5xf32>) -> tensor<2x3x4x5xf3
   // CHECK: return %arg0
 }
 
+// CHECK-LABEL: ConvertSliceToIdentityStaticDimWithShapeWithNeg1
+func @ConvertSliceToIdentityStaticDimWithShapeWithNeg1(%arg0: tensor<2x3x4x5xf32>) -> tensor<2x3x4x5xf32> {
+  %begin = constant dense<0> : tensor<4xi32>
+  %shape = constant dense<[-1, 3, -1, 5]> : tensor<4xi32>
+  %0 = "tfl.slice"(%arg0, %begin, %shape) : (tensor<2x3x4x5xf32>, tensor<4xi32>, tensor<4xi32>) -> tensor<2x3x4x5xf32>
+  return %0 : tensor<2x3x4x5xf32>
+  // CHECK: return %arg0
+}
+
+// CHECK-LABEL: ConvertSliceToIdentityDynamicDimAndShapeWithNeg1
+func @ConvertSliceToIdentityDynamicDimAndShapeWithNeg1(%arg0: tensor<?x3x?x5xf32>) -> tensor<?x3x?x5xf32> {
+  %begin = constant dense<0> : tensor<4xi32>
+  %shape = constant dense<[-1, 3, -1, 5]> : tensor<4xi32>
+  %0 = "tfl.slice"(%arg0, %begin, %shape) : (tensor<?x3x?x5xf32>, tensor<4xi32>, tensor<4xi32>) -> tensor<?x3x?x5xf32>
+  return %0 : tensor<?x3x?x5xf32>
+  // CHECK: return %arg0
+}
+
 // CHECK-LABEL: DontConvertSliceToIdentity
 func @DontConvertSliceToIdentity(%arg0: tensor<2x3x4x5xf32>) -> (tensor<2x3x4x4xf32>, tensor<1x2x3x4xf32>) {
   %begin0 = constant dense<0> : tensor<4xi64>
@@ -1713,6 +1731,28 @@ func @DontConvertSliceToIdentity(%arg0: tensor<2x3x4x5xf32>) -> (tensor<2x3x4x4x
   // CHECK: %[[SLICE_0:.*]] = "tfl.slice"(%arg0, %[[BEGIN_0]], %[[SHAPE_0]]) : (tensor<2x3x4x5xf32>, tensor<4xi64>, tensor<4xi64>) -> tensor<2x3x4x4xf32>
   // CHECK: %[[SLICE_1:.*]] = "tfl.slice"(%arg0, %[[BEGIN_1]], %[[SHAPE_1]]) : (tensor<2x3x4x5xf32>, tensor<4xi64>, tensor<4xi64>) -> tensor<1x2x3x4xf32>
   // CHECK: return %[[SLICE_0]], %[[SLICE_1]] : tensor<2x3x4x4xf32>, tensor<1x2x3x4xf32>
+}
+
+// CHECK-LABEL: DontConvertSliceToIdentityNonConstShape
+func @DontConvertSliceToIdentityNonConstShape(%arg0: tensor<?xf32>, %arg1: tensor<1xi32>) -> tensor<?xf32> {
+  %begin = constant dense<0> : tensor<1xi32>
+  %0 = "tfl.slice"(%arg0, %begin, %arg1) : (tensor<?xf32>, tensor<1xi32>, tensor<1xi32>) -> tensor<?xf32>
+  return %0 : tensor<?xf32>
+  // CHECK: %[[BEGIN:.*]] = constant dense<0> : tensor<1xi32>
+  // CHECK: %[[SLICE:.*]] = "tfl.slice"(%arg0, %[[BEGIN]], %arg1) : (tensor<?xf32>, tensor<1xi32>, tensor<1xi32>) -> tensor<?xf32>
+  // CHECK: return %[[SLICE]] : tensor<?xf32>
+}
+
+// CHECK-LABEL: DontConvertSliceToIdentityDynamicDimButEqualShape
+func @DontConvertSliceToIdentityDynamicDimButEqualShape(%arg0: tensor<?xf32>) -> tensor<?xf32> {
+  %begin = constant dense<0> : tensor<1xi32>
+  %shape = constant dense<2> : tensor<1xi32>
+  %0 = "tfl.slice"(%arg0, %begin, %shape) : (tensor<?xf32>, tensor<1xi32>, tensor<1xi32>) -> tensor<?xf32>
+  return %0 : tensor<?xf32>
+  // CHECK: %[[BEGIN:.*]] = constant dense<0> : tensor<1xi32>
+  // CHECK: %[[SHAPE:.*]] = constant dense<2> : tensor<1xi32>
+  // CHECK: %[[SLICE:.*]] = "tfl.slice"(%arg0, %[[BEGIN]], %[[SHAPE]]) : (tensor<?xf32>, tensor<1xi32>, tensor<1xi32>) -> tensor<?xf32>
+  // CHECK: return %[[SLICE]] : tensor<?xf32>
 }
 
 // CHECK-LABEL: @FuseAddWithFullyConnectedWithBias

--- a/tensorflow/compiler/mlir/lite/transforms/optimize.cc
+++ b/tensorflow/compiler/mlir/lite/transforms/optimize.cc
@@ -245,7 +245,7 @@ bool CanOptimizeIdentitySliceOp(Value input, Attribute begin, Attribute size) {
 
   // Checks if `begin` is all 0s, and `size[i]` is equal to either -1 or
   // `input.shape[i]`.
-  for (int64_t i = 0; i < rank; ++i) {
+  for (uint64_t i = 0; i < rank; ++i) {
     if (begin_attr.getValue<APInt>({i}).getSExtValue() != 0) return false;
     int64_t si = size_attr.getValue<APInt>({i}).getSExtValue();
     if (si != -1 && si != input_ty.getDimSize(i)) return false;

--- a/tensorflow/compiler/mlir/lite/transforms/optimize.cc
+++ b/tensorflow/compiler/mlir/lite/transforms/optimize.cc
@@ -210,6 +210,50 @@ bool CanOptimizeIdentityGatherNdOrScatterNdOp(Value params,
   return true;
 }
 
+// Returns true if we can eliminate the SliceOp. When the values of `begin` are
+// all 0s and `size[i]` is equal to either -1 or `input.shape[i]`
+// for each dim i, the output tensor is identical to `input`.
+bool CanOptimizeIdentitySliceOp(Value input, Attribute begin, Attribute size) {
+  // Checks if `begin` and `shape` are i32 or i64.
+  auto begin_attr = begin.dyn_cast<DenseIntElementsAttr>();
+  auto size_attr = size.dyn_cast<DenseIntElementsAttr>();
+  if (!begin_attr || !size_attr) {
+    return false;
+  }
+
+  auto begin_elem_ty = begin_attr.getType().getElementType();
+  if (!begin_elem_ty.isInteger(32) && !begin_elem_ty.isInteger(64)) {
+    return false;
+  }
+  auto size_elem_ty = size_attr.getType().getElementType();
+  if (!size_elem_ty.isInteger(32) && !size_elem_ty.isInteger(64)) {
+    return false;
+  }
+
+  // Checks if `input` is ranked and its rank is equal to number of elements in
+  // `begin` and `size`.
+  auto input_ty = input.getType().cast<ShapedType>();
+  if (!input_ty.hasRank()) {
+    return false;
+  }
+
+  int64_t rank = input_ty.getRank();
+  if (rank != begin_attr.getNumElements() ||
+      rank != size_attr.getNumElements()) {
+    return false;
+  }
+
+  // Checks if `begin` is all 0s, and `size[i]` is equal to either -1 or
+  // `input.shape[i]`.
+  for (int64_t i = 0; i < rank; ++i) {
+    if (begin_attr.getValue<APInt>({i}).getSExtValue() != 0) return false;
+    int64_t si = size_attr.getValue<APInt>({i}).getSExtValue();
+    if (si != -1 && si != input_ty.getDimSize(i)) return false;
+  }
+
+  return true;
+}
+
 // Expand Attribute 'a' to 4D with all 1s except 1 dimension.
 // Which dimension depends on 'is_depthwise' is true or false.
 ElementsAttr ExpandTo4DForConvImpl(Attribute a, bool is_depthwise) {

--- a/tensorflow/compiler/mlir/lite/transforms/optimize.cc
+++ b/tensorflow/compiler/mlir/lite/transforms/optimize.cc
@@ -214,7 +214,7 @@ bool CanOptimizeIdentityGatherNdOrScatterNdOp(Value params,
 // all 0s and `size[i]` is equal to either -1 or `input.shape[i]`
 // for each dim i, the output tensor is identical to `input`.
 bool CanOptimizeIdentitySliceOp(Value input, Attribute begin, Attribute size) {
-  // Checks if `begin` and `shape` are i32 or i64.
+  // Checks if `begin` and `size` are i32 or i64.
   auto begin_attr = begin.dyn_cast<DenseIntElementsAttr>();
   auto size_attr = size.dyn_cast<DenseIntElementsAttr>();
   if (!begin_attr || !size_attr) {

--- a/tensorflow/compiler/mlir/lite/transforms/optimize_patterns.td
+++ b/tensorflow/compiler/mlir/lite/transforms/optimize_patterns.td
@@ -760,10 +760,8 @@ foreach ArgMinMaxOp = [TFL_ArgMinOp, TFL_ArgMaxOp] in {
      (AxesIsLastDimension $axes, $logits)]>;
 }
 
-class AllElementsAreI32OrI64<string val> : Constraint<CPred<
+class AllElementsAreInt<string val> : Constraint<CPred<
   "($0.isa<DenseIntElementsAttr>() && "
-  "($0.cast<DenseIntElementsAttr>().getType().cast<ShapedType>().getElementType().isInteger(32) || "
-  "$0.cast<DenseIntElementsAttr>().getType().cast<ShapedType>().getElementType().isInteger(64)) && "
   "llvm::all_of($0.cast<DenseIntElementsAttr>().getIntValues(), "
                "[](APInt v){ return v.getSExtValue() == static_cast<int64_t>(" #val# ");}))">>;
 
@@ -771,6 +769,6 @@ class AllElementsAreI32OrI64<string val> : Constraint<CPred<
 def OptimizeSliceOp : Pat<
   (TFL_SliceOp:$output $input, (ConstantOp $begin), $shape),
   (replaceWithValue $input),
-  [(AllElementsAreI32OrI64<"0"> $begin),
+  [(AllElementsAreInt<"0"> $begin),
    (IsTailOfShape $input, $output),
    (IsTailOfShape $output, $input)]>;

--- a/tensorflow/compiler/mlir/lite/transforms/optimize_patterns.td
+++ b/tensorflow/compiler/mlir/lite/transforms/optimize_patterns.td
@@ -760,17 +760,15 @@ foreach ArgMinMaxOp = [TFL_ArgMinOp, TFL_ArgMaxOp] in {
      (AxesIsLastDimension $axes, $logits)]>;
 }
 
-class AllElementsAreI64<string val> : Constraint<CPred<
-  "($0.isa<DenseElementsAttr>() && "
-   "$0.cast<DenseElementsAttr>().getType().cast<ShapedType>().getElementType().isInteger(64) && "
-   "std::all_of($0.cast<DenseElementsAttr>().getValues<int64_t>().begin(), "
-               "$0.cast<DenseElementsAttr>().getValues<int64_t>().end(), "
-               "[](int64_t v){ return v == " #val# ";}))">>;
+class AllElementsAreInt<string val> : Constraint<CPred<
+  "($0.isa<DenseIntElementsAttr>() && "
+  "llvm::all_of($0.cast<DenseIntElementsAttr>().getIntValues(), "
+               "[](APInt v){ return v.getSExtValue() == static_cast<int64_t>(" #val# ");}))">>;
 
 // Remove Slice ops slicing the whole input tensor, effectively no-op
 def OptimizeSliceOp : Pat<
   (TFL_SliceOp:$output $input, (ConstantOp $begin), $shape),
   (replaceWithValue $input),
-  [(AllElementsAreI64<"0"> $begin),
+  [(AllElementsAreInt<"0"> $begin),
    (IsTailOfShape $input, $output),
    (IsTailOfShape $output, $input)]>;

--- a/tensorflow/compiler/mlir/lite/transforms/optimize_patterns.td
+++ b/tensorflow/compiler/mlir/lite/transforms/optimize_patterns.td
@@ -760,8 +760,10 @@ foreach ArgMinMaxOp = [TFL_ArgMinOp, TFL_ArgMaxOp] in {
      (AxesIsLastDimension $axes, $logits)]>;
 }
 
-class AllElementsAreInt<string val> : Constraint<CPred<
+class AllElementsAreI32OrI64<string val> : Constraint<CPred<
   "($0.isa<DenseIntElementsAttr>() && "
+  "($0.cast<DenseIntElementsAttr>().getType().cast<ShapedType>().getElementType().isInteger(32) || "
+  "$0.cast<DenseIntElementsAttr>().getType().cast<ShapedType>().getElementType().isInteger(64)) && "
   "llvm::all_of($0.cast<DenseIntElementsAttr>().getIntValues(), "
                "[](APInt v){ return v.getSExtValue() == static_cast<int64_t>(" #val# ");}))">>;
 
@@ -769,6 +771,6 @@ class AllElementsAreInt<string val> : Constraint<CPred<
 def OptimizeSliceOp : Pat<
   (TFL_SliceOp:$output $input, (ConstantOp $begin), $shape),
   (replaceWithValue $input),
-  [(AllElementsAreInt<"0"> $begin),
+  [(AllElementsAreI32OrI64<"0"> $begin),
    (IsTailOfShape $input, $output),
    (IsTailOfShape $output, $input)]>;

--- a/tensorflow/compiler/mlir/lite/transforms/optimize_patterns.td
+++ b/tensorflow/compiler/mlir/lite/transforms/optimize_patterns.td
@@ -767,10 +767,21 @@ class AllElementsAreI32OrI64<string val> : Constraint<CPred<
   "llvm::all_of($0.cast<DenseIntElementsAttr>().getIntValues(), "
                "[](APInt v){ return v.getSExtValue() == static_cast<int64_t>(" #val# ");}))">>;
 
-// Remove Slice ops slicing the whole input tensor, effectively no-op
+// There are two cases that the shape represents the whole input
+//   1. shape[i] = -1: no matter whether i-dim is static.
+//   2. shape[i] = input.shape[i].
+def IsSliceWholeInput : Constraint<CPred<
+  "$0.getType().cast<ShapedType>().hasRank() && "
+  "$1.isa<DenseIntElementsAttr>() && "
+  "$0.getType().cast<ShapedType>().getRank() == $1.cast<DenseIntElementsAttr>().getNumElements() && "
+  "llvm::all_of(llvm::zip($0.getType().cast<ShapedType>().getShape(), "
+                         "$1.cast<DenseIntElementsAttr>().getIntValues()), "
+               "[](auto v){ return std::get<1>(v).getSExtValue() == -1 || "
+                                  "std::get<0>(v) == std::get<1>(v).getSExtValue(); })">>;
+
+// Remove Slice ops slicing the whole input tensor, effectively no-op.
 def OptimizeSliceOp : Pat<
-  (TFL_SliceOp:$output $input, (ConstantOp $begin), $shape),
+  (TFL_SliceOp:$output $input, (ConstantOp $begin), (ConstantOp $shape)),
   (replaceWithValue $input),
   [(AllElementsAreI32OrI64<"0"> $begin),
-   (IsTailOfShape $input, $output),
-   (IsTailOfShape $output, $input)]>;
+   (IsSliceWholeInput $input, $shape)]>;

--- a/tensorflow/compiler/mlir/lite/transforms/optimize_patterns.td
+++ b/tensorflow/compiler/mlir/lite/transforms/optimize_patterns.td
@@ -760,28 +760,11 @@ foreach ArgMinMaxOp = [TFL_ArgMinOp, TFL_ArgMaxOp] in {
      (AxesIsLastDimension $axes, $logits)]>;
 }
 
-class AllElementsAreI32OrI64<string val> : Constraint<CPred<
-  "($0.isa<DenseIntElementsAttr>() && "
-  "($0.cast<DenseIntElementsAttr>().getType().cast<ShapedType>().getElementType().isInteger(32) || "
-  "$0.cast<DenseIntElementsAttr>().getType().cast<ShapedType>().getElementType().isInteger(64)) && "
-  "llvm::all_of($0.cast<DenseIntElementsAttr>().getIntValues(), "
-               "[](APInt v){ return v.getSExtValue() == static_cast<int64_t>(" #val# ");}))">>;
-
-// There are two cases that the shape represents the whole input
-//   1. shape[i] = -1: no matter whether i-dim is static.
-//   2. shape[i] = input.shape[i].
-def IsSliceWholeInput : Constraint<CPred<
-  "$0.getType().cast<ShapedType>().hasRank() && "
-  "$1.isa<DenseIntElementsAttr>() && "
-  "$0.getType().cast<ShapedType>().getRank() == $1.cast<DenseIntElementsAttr>().getNumElements() && "
-  "llvm::all_of(llvm::zip($0.getType().cast<ShapedType>().getShape(), "
-                         "$1.cast<DenseIntElementsAttr>().getIntValues()), "
-               "[](auto v){ return std::get<1>(v).getSExtValue() == -1 || "
-                                  "std::get<0>(v) == std::get<1>(v).getSExtValue(); })">>;
+def CanOptimizeIdentitySliceOp : Constraint<CPred<
+  "TFL::CanOptimizeIdentitySliceOp($0, $1, $2)">>;
 
 // Remove Slice ops slicing the whole input tensor, effectively no-op.
 def OptimizeSliceOp : Pat<
-  (TFL_SliceOp:$output $input, (ConstantOp $begin), (ConstantOp $shape)),
+  (TFL_SliceOp:$output $input, (ConstantOp $begin), (ConstantOp $size)),
   (replaceWithValue $input),
-  [(AllElementsAreI32OrI64<"0"> $begin),
-   (IsSliceWholeInput $input, $shape)]>;
+  [(CanOptimizeIdentitySliceOp $input, $begin, $size)]>;


### PR DESCRIPTION
Somehow, some int32 `begin` will be generated. This PR extends the original pattern to support i32 `begin` because we have type constraint of `TFL_I32OrI64Tensor` on `begin` in ODS. Pattern is found in `tf.keras.layers.MultiHeadAttention`, for example.

```python
import tensorflow as tf

layer = tf.keras.layers.MultiHeadAttention(num_heads=2, key_dim=2)
target = tf.keras.Input(shape=[8, 16], batch_size=1)
source = tf.keras.Input(shape=[4, 16], batch_size=1)
output_tensor = layer(target, source, return_attention_scores=False)
model = tf.keras.Model([target, source], output_tensor)
```

Also fix:
- when input has dynamic shape.
- when shape has -1.

It turns out that we have to check if `shape` is the shape of `input`. Otherwise, given `input: tensor<?xf32>` and `output: tensor<?xf32>`, the original pattern is not going to work.