### PR TITLE
Give Grappler hints about function XLA compilation so it can selectively apply compatible optimizations

### DIFF
--- a/tensorflow/core/grappler/grappler_item.h
+++ b/tensorflow/core/grappler/grappler_item.h
@@ -70,6 +70,11 @@ struct GrapplerItem {
   // ensure that the optimized metagraph can still be loaded.
   std::vector<string> keep_ops;
 
+  // A hint for if this item will later be compiled by XLA.
+  // Grappler optimizers can use this hint to avoid making changes to the
+  // item that might not be compatible with XLA.
+  bool will_be_compiled_by_xla = false;
+
   // Return the set of node evaluated during a regular train/inference step.
   std::vector<const NodeDef*> MainOpsFanin() const;
   // Return the set of node run to populate the queues (if any).

--- a/tensorflow/core/grappler/grappler_item.h
+++ b/tensorflow/core/grappler/grappler_item.h
@@ -26,6 +26,7 @@ limitations under the License.
 #include "tensorflow/core/framework/graph.pb.h"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/framework/variable.pb.h"
+#include "tensorflow/core/grappler/utils.h"
 #include "tensorflow/core/protobuf/queue_runner.pb.h"
 
 namespace tensorflow {
@@ -70,10 +71,9 @@ struct GrapplerItem {
   // ensure that the optimized metagraph can still be loaded.
   std::vector<string> keep_ops;
 
-  // A hint for if this item will later be compiled by XLA.
-  // Grappler optimizers can use this hint to avoid making changes to the
-  // item that might not be compatible with XLA.
-  bool will_be_compiled_by_xla = false;
+  // A set of hints that can be used by Grappler optimizers to conditionally
+  // disable certain optimizations that are not compatible with XLA.
+  GrapplerXlaHints xla_hints;
 
   // Return the set of node evaluated during a regular train/inference step.
   std::vector<const NodeDef*> MainOpsFanin() const;

--- a/tensorflow/core/grappler/optimizers/memory_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/memory_optimizer.cc
@@ -514,6 +514,15 @@ void RecomputationRewritingPass(RewriterConfig::MemOptType optimization_level,
 
 bool SchedulingPass(Cluster* cluster, std::unique_ptr<GraphMemory>* memory_ptr,
                     GrapplerItem* item) {
+  // This pass involves making TemporaryVariables, which are not necessarily
+  // supported by XLA devices. Skip if the item will be compiled by XLA later.
+  // Ideally we would do a check to see if the compiling XLA device implements
+  // the TemporaryVariable XlaOpKernel, but when Grappler is run we don't yet
+  // know what the compiling device will be.
+  if (item->will_be_compiled_by_xla) {
+    return false;
+  }
+
   // Look for AddN nodes (and equivalent) and record input names.
   MutableGraphView view(&item->graph);
 


### PR DESCRIPTION
Some Grappler optimizations can cause problems for XLA. This was first discovered by the MemoryOptimizer pass creating TemporaryVariable ops without knowing if the later compiling XLA device implemented the TemporaryVariable OpKernel [[issue](https://github.com/tensorflow/tensorflow/issues/30580)].

The first fix for this was to disable Grappler for any functions called from an XlaLaunch node [[commit 1](https://github.com/tensorflow/tensorflow/commit/471b73c238709fb796929eb412f1dab763b3f8cc)].
It was found that this isn't sufficient, as some functions can be encapsulated out of the main XlaLaunch cluster function e.g. While ops, so a later fix was added to also disable Grappler for any functions transitively called by an XlaLaunch function [[commit 2](https://github.com/tensorflow/tensorflow/commit/e0bb74087f440394f6df00c5c7ff36e50d23132a)].

However, a more general approach may be to introduce hints which Grappler can use to avoid making certain XLA-incompatible optimizations, allowing them to work together.
This PR introduces a GrapplerXlaHints struct which is populated by a GenerateXlaHints function, which allows individual Grappler optimizers to switch themselves off depending on the GrapplerItem's XLA hints.
Currently the PR disables the constant_folding, arithmetic_optimizer and the SchedulingPass of the MemoryOptimizer based on these hints.

Note that this will cause a change in behaviour where the immediate XlaLaunch functions will now go through Grappler where they otherwise weren't before commit 1 (with appropriate passes selectively disabling themselves).

I have added a test which passes locally that checks the hints are generated properly for an example call tree.
I have also linted all files according to [this guide](https://www.tensorflow.org/community/contribute/code_style).