### PR TITLE
[Kernel C API] Fix inplacement issue in C API

### DIFF
--- a/tensorflow/c/kernels.cc
+++ b/tensorflow/c/kernels.cc
@@ -238,8 +238,8 @@ void TF_GetInput(TF_OpKernelContext* ctx, int i, TF_Tensor** tensor,
     return;
   }
   const ::tensorflow::Tensor& cc_tensor(cc_ctx->input(i));
-  TF_Tensor* result =
-      ::tensorflow::TF_TensorFromTensor(cc_tensor, &status->status);
+  TF_Tensor* result = ::tensorflow::TF_TensorFromTensor(
+      cc_tensor, &status->status, /*increment_refcount_by_one*/ false);
   if (TF_GetCode(status) == TF_OK) {
     *tensor = result;
   }
@@ -472,7 +472,8 @@ TF_Tensor* TF_AllocateOutput(TF_OpKernelContext* context, int index,
     ::tensorflow::Set_TF_Status_from_Status(status, s);
     return nullptr;
   }
-  TF_Tensor* tf_tensor = TF_TensorFromTensor(*tensor, &s);
+  TF_Tensor* tf_tensor =
+      TF_TensorFromTensor(*tensor, &s, /*increment_refcount_by_one*/ false);
   if (!s.ok()) {
     ::tensorflow::Set_TF_Status_from_Status(status, s);
     return nullptr;
@@ -502,7 +503,8 @@ TF_Tensor* TF_ForwardInputOrAllocateOutput(
     ::tensorflow::Set_TF_Status_from_Status(status, s);
     return nullptr;
   }
-  TF_Tensor* tf_tensor_output = TF_TensorFromTensor(*output_tensor_pointer, &s);
+  TF_Tensor* tf_tensor_output = TF_TensorFromTensor(
+      *output_tensor_pointer, &s, /*increment_refcount_by_one*/ false);
   if (!s.ok()) {
     ::tensorflow::Set_TF_Status_from_Status(status, s);
     return nullptr;

--- a/tensorflow/python/lib/core/ndarray_tensor.cc
+++ b/tensorflow/python/lib/core/ndarray_tensor.cc
@@ -546,7 +546,8 @@ Status NdarrayToTensor(TFE_Context* ctx, PyObject* ndarray,
 }
 
 Status TF_TensorToTensor(const TF_Tensor* src, Tensor* dst);
-TF_Tensor* TF_TensorFromTensor(const tensorflow::Tensor& src, Status* status);
+TF_Tensor* TF_TensorFromTensor(const tensorflow::Tensor& src, Status* status,
+                               bool used_by_kernel);
 
 Status NdarrayToTensor(PyObject* obj, Tensor* ret) {
   Safe_TF_TensorPtr tf_tensor = make_safe(static_cast<TF_Tensor*>(nullptr));


### PR DESCRIPTION
This commit is intended to fix two inplace issue in kernel C API:
1. RefCountIsOne
   tensor.RefCountIsOne() is the condition to decide whether the op can
   do inplacement(e.g. forward_input), however, TF_Tensor retrieved through
   TF_GetInput(), TF_AllocateOutput() makes the refcount always > 1, in
   TF_TensorFromTensor, it will call tensor.CopyFrom() and increment the refcount

2. TF_TensorBitcastFrom()
   Currently, this API only modifies TF_Tensor's buf pointer, but the src c++ tensor it
   copied from is not modified, that makes the TF_Tensor inconsistent with src c++ tensor,
   see the following example, it allocated an output TF_Tensor and modified its buffer through
   TF_TensorBitcastFrom(), however, src c++ tensor in Op_KernelContext is not modified.
   ```c++
    // Example:
    TF_Tensor* a = TF_AllocateOutput(ctx, 0); // src c++ tensor: x
    TF_Tensor* b = TF_AllocateTemp(ctx);
    TF_TensorBitcastFrom(b, a); // a->buf_ = b_buf;
    // src c++ tensor x's buf is not modified, thus x->buf_ != a->buf_
   ```