### PR TITLE
Fixed docstring formatting for api_docs

### DIFF
--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -3476,6 +3476,7 @@ def leaky_relu(features, alpha=0.2, name=None):
   Source: [Rectifier Nonlinearities Improve Neural Network Acoustic Models.
   AL Maas, AY Hannun, AY Ng - Proc. ICML, 2013]
   (https://ai.stanford.edu/~amaas/papers/relu_hybrid_icml2013_final.pdf).
+
   Args:
     features: A `Tensor` representing preactivation values. Must be one of
       the following types: `float16`, `float32`, `float64`, `int32`, `int64`.


### PR DESCRIPTION
The api_docs website formatting of [leaky_relu](https://www.tensorflow.org/api_docs/python/tf/nn/leaky_relu) was wrong due to a missing newline