### PR TITLE
Use xa_nnlib for conv for Fusion F1

### DIFF
--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -734,8 +734,8 @@ cc_test(
     ],
     tags = [
         "noasan",
-        "nomsan",
-    ],  # TODO(b/175133159): currently failing with asan and msan
+        "nomsan",  # TODO(b/175133159): currently failing with asan and msan
+    ],
     deps = [
         ":kernel_runner",
         "//tensorflow/lite/c:common",

--- a/tensorflow/lite/micro/kernels/xtensa/conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv.cc
@@ -31,6 +31,12 @@ limitations under the License.
 namespace tflite {
 namespace {
 
+struct OpData {
+  OpDataConv reference_op_data;
+
+  int scratch_tensor_index;
+};
+
 #if defined(HIFIMINI)
 void ConvPerChannel(const ConvParams& params, const int32_t* output_multiplier,
                     const int32_t* output_shift,
@@ -236,7 +242,211 @@ inline void Conv1x32Input32x32Filter(
 
 void* Init(TfLiteContext* context, const char* buffer, size_t length) {
   TFLITE_DCHECK(context->AllocatePersistentBuffer != nullptr);
-  return context->AllocatePersistentBuffer(context, sizeof(OpDataConv));
+  return context->AllocatePersistentBuffer(context, sizeof(OpData));
+}
+
+TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+  TF_LITE_ENSURE_OK(context, ConvPrepare(context, node));
+
+#if defined(FUSION_F1)
+  OpData* data = static_cast<OpData*>(node->user_data);
+  const auto params = static_cast<const TfLiteConvParams*>(node->builtin_data);
+
+  // Calculate scratch memory requirements and request scratch buffer
+  TfLiteTensor* output = GetOutput(context, node, kConvOutputTensor);
+  TF_LITE_ENSURE(context, output != nullptr);
+  const TfLiteTensor* input = GetInput(context, node, kConvInputTensor);
+  TF_LITE_ENSURE(context, input != nullptr);
+  const TfLiteTensor* filter = GetInput(context, node, kConvWeightsTensor);
+  TF_LITE_ENSURE(context, filter != nullptr);
+
+  const RuntimeShape& input_shape = GetTensorShape(input);
+  const RuntimeShape& filter_shape = GetTensorShape(filter);
+  const int input_depth = MatchingDim(input_shape, 3, filter_shape, 3);
+  const int filter_height = filter->dims->data[1];
+  const int filter_width = filter->dims->data[2];
+  const int input_height = input->dims->data[1];
+  const int output_height = output->dims->data[1];
+  const int stride_height = params->stride_height;
+  const int pad_height = data->reference_op_data.padding.height;
+
+  int input_precision;
+  if (input->type == kTfLiteInt8) {
+    input_precision = PREC_ASYM8S;
+  } else if (input->type == kTfLiteUInt8) {
+    input_precision = PREC_ASYM8;
+  } else {
+    input_precision = PREC_F32;
+  }
+
+  int output_channels = output->dims->data[3];
+  int required_scratch = 0;
+  // Dilation is currently not supported on HiFi 4 NN Library
+  if ((params->dilation_width_factor == 1) &&
+      (params->dilation_height_factor == 1)) {
+    required_scratch = xa_nn_conv2d_std_getsize(
+        input_height, input_depth, filter_height, filter_width, stride_height,
+        pad_height, output_height, output_channels, input_precision);
+    TF_LITE_ENSURE(context, required_scratch > 0);
+  }
+  TF_LITE_ENSURE_OK(
+      context, context->RequestScratchBufferInArena(
+                   context, required_scratch, &data->scratch_tensor_index));
+#endif
+  return kTfLiteOk;
+}
+
+TfLiteStatus EvalQuantizedPerChannel(
+    TfLiteContext* context, TfLiteNode* node, const TfLiteConvParams& params,
+    const OpData& data, const TfLiteEvalTensor* input,
+    const TfLiteEvalTensor* filter, const TfLiteEvalTensor* bias,
+    TfLiteEvalTensor* output, TfLiteEvalTensor* im2col) {
+#if defined(HIFIMINI)
+  ConvPerChannel(ConvParamsQuantized(params, op_data.reference_op_data),
+                 op_data.reference_op_data.per_channel_output_multiplier,
+                 op_data.reference_op_data.per_channel_output_shift,
+                 tflite::micro::GetTensorShape(input),
+                 tflite::micro::GetTensorData<int8_t>(input),
+                 tflite::micro::GetTensorShape(filter),
+                 tflite::micro::GetTensorData<int8_t>(filter),
+                 tflite::micro::GetTensorShape(bias),
+                 tflite::micro::GetTensorData<int32_t>(bias),
+                 tflite::micro::GetTensorShape(output),
+                 tflite::micro::GetTensorData<int8_t>(output));
+#elif defined(FUSION_F1)
+  /* Dilation is currently not supported on HiFi 4 NN Library */
+  if ((params.dilation_width_factor == 1) &&
+      (params.dilation_height_factor == 1)) {
+    const int32_t input_offset = -data.reference_op_data.input_zero_point;
+    const int32_t output_offset = data.reference_op_data.output_zero_point;
+    const int8_t *input_data, *filter_data;
+    const int32_t* bias_data;
+    int8_t* output_data;
+    const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
+    const RuntimeShape& filter_shape = tflite::micro::GetTensorShape(filter);
+    const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
+
+    input_data = tflite::micro::GetTensorData<int8_t>(input);
+    filter_data = tflite::micro::GetTensorData<int8_t>(filter);
+    bias_data = tflite::micro::GetTensorData<int32_t>(bias);
+    output_data = tflite::micro::GetTensorData<int8_t>(output);
+
+    const int stride_width = params.stride_width;
+    const int stride_height = params.stride_height;
+    const int pad_width = data.reference_op_data.padding.width;
+    const int pad_height = data.reference_op_data.padding.height;
+    const int32_t output_activation_min =
+        data.reference_op_data.output_activation_min;
+    const int32_t output_activation_max =
+        data.reference_op_data.output_activation_max;
+
+    const int batches = MatchingDim(input_shape, 0, output_shape, 0);
+    const int input_depth = MatchingDim(input_shape, 3, filter_shape, 3);
+    const int output_depth = MatchingDim(filter_shape, 0, output_shape, 3);
+
+    const int input_height = input_shape.Dims(1);
+    const int input_width = input_shape.Dims(2);
+    const int filter_height = filter_shape.Dims(1);
+    const int filter_width = filter_shape.Dims(2);
+    const int output_height = output_shape.Dims(1);
+    const int output_width = output_shape.Dims(2);
+
+    int output_data_format = 0;
+    void* p_scratch;
+    int8_t* p_filter;
+    int out_length = output_height * output_width * output_depth;
+
+    if (filter_height == 1 && filter_width == 1) {
+      for (int batch = 0; batch < batches; ++batch) {
+        int8_t* p_out_temp;
+        p_out_temp = &output_data[batch * out_length];
+
+        TF_LITE_ENSURE_EQ(
+            context,
+
+            xa_nn_conv2d_pointwise_per_chan_sym8sxasym8s(
+                p_out_temp, const_cast<WORD8*>(filter_data),
+                const_cast<WORD8*>(&input_data[batch * input_height *
+                                               input_width * input_depth]),
+                const_cast<WORD32*>(bias_data), input_height, input_width,
+                input_depth, output_depth, input_offset,
+                data.reference_op_data.per_channel_output_multiplier,
+                data.reference_op_data.per_channel_output_shift, output_offset,
+                output_data_format),
+            0);
+
+        TF_LITE_ENSURE_EQ(context,
+                          xa_nn_vec_activation_min_max_8_8(
+                              p_out_temp, p_out_temp, output_activation_min,
+                              output_activation_max, out_length),
+                          0);
+      }
+    } else {
+      p_scratch = static_cast<void*>(
+          context->GetScratchBuffer(context, data.scratch_tensor_index));
+
+      p_filter = const_cast<int8_t*>(filter_data);
+
+      for (int batch = 0; batch < batches; ++batch) {
+        int8_t* p_out_temp;
+        p_out_temp = &output_data[batch * out_length];
+
+        {
+          TF_LITE_ENSURE_EQ(
+              context,
+              xa_nn_conv2d_std_per_chan_sym8sxasym8s(
+                  p_out_temp,
+                  &input_data[batch * input_height * input_width * input_depth],
+                  p_filter,  // filter_data,
+                  bias_data, input_height, input_width, input_depth,
+                  filter_height, filter_width, output_depth, stride_width,
+                  stride_height, pad_width, pad_height, output_height,
+                  output_width, input_offset,
+                  data.reference_op_data.per_channel_output_multiplier,
+                  data.reference_op_data.per_channel_output_shift,
+                  output_offset, output_data_format,
+                  static_cast<void*>(p_scratch)),
+              0);
+        }
+
+        TF_LITE_ENSURE_EQ(context,
+                          xa_nn_vec_activation_min_max_8_8(
+                              p_out_temp, p_out_temp, output_activation_min,
+                              output_activation_max, out_length),
+                          0);
+      }
+    }
+    return kTfLiteOk;
+  }
+
+  reference_integer_ops::ConvPerChannel(
+      ConvParamsQuantized(params, data.reference_op_data),
+      data.reference_op_data.per_channel_output_multiplier,
+      data.reference_op_data.per_channel_output_shift,
+      tflite::micro::GetTensorShape(input),
+      tflite::micro::GetTensorData<int8_t>(input),
+      tflite::micro::GetTensorShape(filter),
+      tflite::micro::GetTensorData<int8_t>(filter),
+      tflite::micro::GetTensorShape(bias),
+      tflite::micro::GetTensorData<int32_t>(bias),
+      tflite::micro::GetTensorShape(output),
+      tflite::micro::GetTensorData<int8_t>(output));
+#else
+  reference_integer_ops::ConvPerChannel(
+      ConvParamsQuantized(params, op_data.reference_op_data),
+      op_data.reference_op_data.per_channel_output_multiplier,
+      op_data.reference_op_data.per_channel_output_shift,
+      tflite::micro::GetTensorShape(input),
+      tflite::micro::GetTensorData<int8_t>(input),
+      tflite::micro::GetTensorShape(filter),
+      tflite::micro::GetTensorData<int8_t>(filter),
+      tflite::micro::GetTensorShape(bias),
+      tflite::micro::GetTensorData<int32_t>(bias),
+      tflite::micro::GetTensorShape(output),
+      tflite::micro::GetTensorData<int8_t>(output));
+#endif
+
+  return kTfLiteOk;
 }
 
 TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
@@ -244,7 +454,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   TFLITE_DCHECK(node->builtin_data != nullptr);
   const auto& params =
       *(reinterpret_cast<TfLiteConvParams*>(node->builtin_data));
-  const auto& op_data = *(reinterpret_cast<OpDataConv*>(node->user_data));
+  const auto& op_data = *(reinterpret_cast<OpData*>(node->user_data));
 
   TfLiteEvalTensor* output =
       tflite::micro::GetEvalOutput(context, node, kConvOutputTensor);
@@ -264,9 +474,12 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       input_dims[3] == 32 && filter_dims[0] == 32 && filter_dims[1] == 1 &&
       filter_dims[2] == 1 && filter_dims[3] == 32) {
     Conv1x32Input32x32Filter(
-        -op_data.input_zero_point, op_data.output_zero_point,
-        op_data.output_activation_min, op_data.output_activation_max,
-        op_data.per_channel_output_multiplier, op_data.per_channel_output_shift,
+        -op_data.reference_op_data.input_zero_point,
+        op_data.reference_op_data.output_zero_point,
+        op_data.reference_op_data.output_activation_min,
+        op_data.reference_op_data.output_activation_max,
+        op_data.reference_op_data.per_channel_output_multiplier,
+        op_data.reference_op_data.per_channel_output_shift,
         tflite::micro::GetTensorShape(input),
         tflite::micro::GetTensorData<int8_t>(input),
         tflite::micro::GetTensorShape(filter),
@@ -281,32 +494,8 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
 
   switch (input->type) {
     case kTfLiteInt8: {
-#if defined(HIFIMINI)
-      ConvPerChannel(ConvParamsQuantized(params, op_data),
-                     op_data.per_channel_output_multiplier,
-                     op_data.per_channel_output_shift,
-                     tflite::micro::GetTensorShape(input),
-                     tflite::micro::GetTensorData<int8_t>(input),
-                     tflite::micro::GetTensorShape(filter),
-                     tflite::micro::GetTensorData<int8_t>(filter),
-                     tflite::micro::GetTensorShape(bias),
-                     tflite::micro::GetTensorData<int32_t>(bias),
-                     tflite::micro::GetTensorShape(output),
-                     tflite::micro::GetTensorData<int8_t>(output));
-#else
-      reference_integer_ops::ConvPerChannel(
-          ConvParamsQuantized(params, op_data),
-          op_data.per_channel_output_multiplier,
-          op_data.per_channel_output_shift,
-          tflite::micro::GetTensorShape(input),
-          tflite::micro::GetTensorData<int8_t>(input),
-          tflite::micro::GetTensorShape(filter),
-          tflite::micro::GetTensorData<int8_t>(filter),
-          tflite::micro::GetTensorShape(bias),
-          tflite::micro::GetTensorData<int32_t>(bias),
-          tflite::micro::GetTensorShape(output),
-          tflite::micro::GetTensorData<int8_t>(output));
-#endif
+      EvalQuantizedPerChannel(context, node, params, op_data, input, filter,
+                              bias, output, nullptr);
       break;
     }
     default:
@@ -321,7 +510,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
 TfLiteRegistration Register_CONV_2D() {
   return {/*init=*/Init,
           /*free=*/nullptr,
-          /*prepare=*/ConvPrepare,
+          /*prepare=*/Prepare,
           /*invoke=*/Eval,
           /*profiling_string=*/nullptr,
           /*builtin_code=*/0,

--- a/tensorflow/lite/micro/kernels/xtensa/xtensa.h
+++ b/tensorflow/lite/micro/kernels/xtensa/xtensa.h
@@ -21,6 +21,9 @@ limitations under the License.
 #elif defined(FUSION_F1)
 #include "include/nnlib/xa_nnlib_api.h"
 #include "include/nnlib/xa_nnlib_standards.h"
+
+#define ALIGNED_SIZE(x, bytes) (((x) + (bytes - 1)) & (~(bytes - 1)))
+#define ALIGN_PTR(x, bytes) ((((unsigned)(x)) + (bytes - 1)) & (~(bytes - 1)))
 #endif
 
 #endif  // TENSORFLOW_LITE_MICRO_KERNELS_XTENSA_XTENSA_H_


### PR DESCRIPTION
The code in this change is the subset of functionality needed for int8 svdf for Hifi4 copied from pnikam-cad/tensorflow@a737c1e/tensorflow/lite/micro/kernels/xtensa_hifi/conv.cc

Note that the current change has not pulled in the floating point, uint8 implementation or the Hifi5 implementation.

Profiled the person_detection_benchmark with the following command:

make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=fusion_f1 XTENSA_CORE=F1_190305_swupgrade run_person_detection_benchmark -j8
gives a latency of 73.761M ticks with this change vs 212.980M ticks without this change.

Per OP latency with this change:
```
KeywordRunNIerations(1) took 38516 ticks (38 ms)
DEPTHWISE_CONV_2D took 11961939 ticks (11961 ms).
DEPTHWISE_CONV_2D took 12296923 ticks (12296 ms).
CONV_2D took 987358 ticks (987 ms).
DEPTHWISE_CONV_2D took 6138259 ticks (6138 ms).
CONV_2D took 554614 ticks (554 ms).
DEPTHWISE_CONV_2D took 12063331 ticks (12063 ms).
CONV_2D took 665206 ticks (665 ms).
DEPTHWISE_CONV_2D took 3018615 ticks (3018 ms).
CONV_2D took 334246 ticks (334 ms).
DEPTHWISE_CONV_2D took 5837463 ticks (5837 ms).
CONV_2D took 444838 ticks (444 ms).
DEPTHWISE_CONV_2D took 1462009 ticks (1462 ms).
CONV_2D took 225286 ticks (225 ms).
DEPTHWISE_CONV_2D took 2734009 ticks (2734 ms).
CONV_2D took 335878 ticks (335 ms).
DEPTHWISE_CONV_2D took 2734009 ticks (2734 ms).
CONV_2D took 335878 ticks (335 ms).
DEPTHWISE_CONV_2D took 2734009 ticks (2734 ms).
CONV_2D took 335878 ticks (335 ms).
DEPTHWISE_CONV_2D took 2734009 ticks (2734 ms).
CONV_2D took 335878 ticks (335 ms).
DEPTHWISE_CONV_2D took 2734009 ticks (2734 ms).
CONV_2D took 335878 ticks (335 ms).
DEPTHWISE_CONV_2D took 685980 ticks (685 ms).
CONV_2D took 173254 ticks (173 ms).
DEPTHWISE_CONV_2D took 1197084 ticks (1197 ms).
CONV_2D took 283846 ticks (283 ms).
AVERAGE_POOL_2D took 75604 ticks (75 ms).
CONV_2D took 3382 ticks (3 ms).
RESHAPE took 290 ticks (0 ms).
SOFTMAX took 1933 ticks (1 ms).
```
Without this change:
```
WithPersonDataIterations(1) took 212980371 ticks (212980 ms)
DEPTHWISE_CONV_2D took 11961939 ticks (11961 ms).
DEPTHWISE_CONV_2D took 12296923 ticks (12296 ms).
CONV_2D took 13604549 ticks (13604 ms).
DEPTHWISE_CONV_2D took 6138259 ticks (6138 ms).
CONV_2D took 9585893 ticks (9585 ms).
DEPTHWISE_CONV_2D took 12063331 ticks (12063 ms).
CONV_2D took 15189221 ticks (15189 ms).
DEPTHWISE_CONV_2D took 3018615 ticks (3018 ms).
CONV_2D took 7590389 ticks (7590 ms).
DEPTHWISE_CONV_2D took 5837463 ticks (5837 ms).
CONV_2D took 13193717 ticks (13193 ms).
DEPTHWISE_CONV_2D took 1462009 ticks (1462 ms).
CONV_2D took 6596093 ticks (6596 ms).
DEPTHWISE_CONV_2D took 2734009 ticks (2734 ms).
CONV_2D took 12199421 ticks (12199 ms).
DEPTHWISE_CONV_2D took 2734009 ticks (2734 ms).
CONV_2D took 12199421 ticks (12199 ms).
DEPTHWISE_CONV_2D took 2734009 ticks (2734 ms).
CONV_2D took 12199421 ticks (12199 ms).
DEPTHWISE_CONV_2D took 2734009 ticks (2734 ms).
CONV_2D took 12199421 ticks (12199 ms).
DEPTHWISE_CONV_2D took 2734009 ticks (2734 ms).
CONV_2D took 12199421 ticks (12199 ms).
DEPTHWISE_CONV_2D took 685980 ticks (685 ms).
CONV_2D took 6099809 ticks (6099 ms).
DEPTHWISE_CONV_2D took 1197084 ticks (1197 ms).
CONV_2D took 11703137 ticks (11703 ms).
AVERAGE_POOL_2D took 75604 ticks (75 ms).
CONV_2D took 10983 ticks (10 ms).
RESHAPE took 290 ticks (0 ms).
SOFTMAX took 1933 ticks (1 ms).
```
Confirmed that the kernel_conv_test passes with:

```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=fusion_f1 XTENSA_CORE=F1_190305_swupgrade test_kernel_conv_test -j8
```
Progress towards http://b/177457688