### PR TITLE
Use xa_nnlib for depthwise_conv for Fusion F1

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv.cc
@@ -292,7 +292,7 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   return kTfLiteOk;
 }
 
-#if defined(Fusion_F1)
+#if defined(FUSION_F1)
 TfLiteStatus EvalHifi4(TfLiteContext* context, TfLiteNode* node,
                        const TfLiteConvParams& params, const OpData& data,
                        const TfLiteEvalTensor* input,
@@ -409,7 +409,7 @@ TfLiteStatus EvalHifi4(TfLiteContext* context, TfLiteNode* node,
       tflite::micro::GetTensorData<int8_t>(output));
   return kTfLiteOk;
 }
-#endif  // defined(Fusion_F1)
+#endif  // defined(FUSION_F1)
 
 TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   TFLITE_DCHECK(node->user_data != nullptr);

--- a/tensorflow/lite/micro/kernels/xtensa/conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv.cc
@@ -292,6 +292,7 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   return kTfLiteOk;
 }
 
+#if defined(Fusion_F1)
 TfLiteStatus EvalHifi4(TfLiteContext* context, TfLiteNode* node,
                        const TfLiteConvParams& params, const OpData& data,
                        const TfLiteEvalTensor* input,
@@ -408,6 +409,7 @@ TfLiteStatus EvalHifi4(TfLiteContext* context, TfLiteNode* node,
       tflite::micro::GetTensorData<int8_t>(output));
   return kTfLiteOk;
 }
+#endif  // defined(Fusion_F1)
 
 TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   TFLITE_DCHECK(node->user_data != nullptr);

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
@@ -344,6 +344,7 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   return kTfLiteOk;
 }
 
+#if defined(Fusion_F1)
 TfLiteStatus EvalHifi4(TfLiteContext* context, TfLiteNode* node,
                        const TfLiteDepthwiseConvParams& params,
                        const OpData& data, const TfLiteEvalTensor* input,
@@ -438,6 +439,7 @@ TfLiteStatus EvalHifi4(TfLiteContext* context, TfLiteNode* node,
 
   return kTfLiteOk;
 }
+#endif  // defined(FUSION_F1)
 
 TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   TFLITE_DCHECK(node->user_data != nullptr);
@@ -485,17 +487,18 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   switch (input->type) {  // Already know in/out types are same.
     case kTfLiteInt8: {
 #if defined(HIFIMINI)
-      EvalHifiMini(DepthwiseConvParamsQuantized(params, data.reference_op_data),
-                   data.reference_op_data.per_channel_output_multiplier,
-                   data.reference_op_data.per_channel_output_shift,
-                   tflite::micro::GetTensorShape(input),
-                   tflite::micro::GetTensorData<int8_t>(input),
-                   tflite::micro::GetTensorShape(filter),
-                   tflite::micro::GetTensorData<int8_t>(filter),
-                   tflite::micro::GetTensorShape(bias),
-                   tflite::micro::GetTensorData<int32_t>(bias),
-                   tflite::micro::GetTensorShape(output),
-                   tflite::micro::GetTensorData<int8_t>(output));
+      EvalHifiMini(
+          DepthwiseConvParamsQuantized(params, op_data.reference_op_data),
+          op_data.reference_op_data.per_channel_output_multiplier,
+          op_data.reference_op_data.per_channel_output_shift,
+          tflite::micro::GetTensorShape(input),
+          tflite::micro::GetTensorData<int8_t>(input),
+          tflite::micro::GetTensorShape(filter),
+          tflite::micro::GetTensorData<int8_t>(filter),
+          tflite::micro::GetTensorShape(bias),
+          tflite::micro::GetTensorData<int32_t>(bias),
+          tflite::micro::GetTensorShape(output),
+          tflite::micro::GetTensorData<int8_t>(output));
 #elif defined(FUSION_F1)
       EvalHifi4(context, node, params, op_data, input, filter, bias, output);
 #else

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
@@ -344,7 +344,7 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   return kTfLiteOk;
 }
 
-#if defined(Fusion_F1)
+#if defined(FUSION_F1)
 TfLiteStatus EvalHifi4(TfLiteContext* context, TfLiteNode* node,
                        const TfLiteDepthwiseConvParams& params,
                        const OpData& data, const TfLiteEvalTensor* input,


### PR DESCRIPTION
The code in this change is the subset of functionality needed for int8 svdf for Hifi4 copied from pnikam-cad/tensorflow@a737c1e/tensorflow/lite/micro/kernels/xtensa_hifi/depthwise_conv.cc

Note that the current change has not pulled in the floating point, uint8 implementation or the Hifi5 implementation.

Profiled the person_detection_benchmark with the following command:

make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=fusion_f1 XTENSA_CORE=F1_190305_swupgrade run_person_detection_benchmark -j8
gives a latency of 9.661M ticks with this change vs 73.761M ticks without this change.

Per OP latency with this change:
```
WithPersonDataIterations(1) took 9661310 ticks (9661 ms)
DEPTHWISE_CONV_2D took 1156157 ticks (1156 ms).
DEPTHWISE_CONV_2D took 628525 ticks (628 ms).
CONV_2D took 987374 ticks (987 ms).
DEPTHWISE_CONV_2D took 395420 ticks (395 ms).
CONV_2D took 554630 ticks (554 ms).
DEPTHWISE_CONV_2D took 545252 ticks (545 ms).
CONV_2D took 665222 ticks (665 ms).
DEPTHWISE_CONV_2D took 172412 ticks (172 ms).
CONV_2D took 334262 ticks (334 ms).
DEPTHWISE_CONV_2D took 283280 ticks (283 ms).
CONV_2D took 444854 ticks (444 ms).
DEPTHWISE_CONV_2D took 88394 ticks (88 ms).
CONV_2D took 225302 ticks (225 ms).
DEPTHWISE_CONV_2D took 158090 ticks (158 ms).
CONV_2D took 335894 ticks (335 ms).
DEPTHWISE_CONV_2D took 158090 ticks (158 ms).
CONV_2D took 335894 ticks (335 ms).
DEPTHWISE_CONV_2D took 158090 ticks (158 ms).
CONV_2D took 335894 ticks (335 ms).
DEPTHWISE_CONV_2D took 158090 ticks (158 ms).
CONV_2D took 335894 ticks (335 ms).
DEPTHWISE_CONV_2D took 158090 ticks (158 ms).
CONV_2D took 335894 ticks (335 ms).
DEPTHWISE_CONV_2D took 59525 ticks (59 ms).
CONV_2D took 173270 ticks (173 ms).
DEPTHWISE_CONV_2D took 112424 ticks (112 ms).
CONV_2D took 283862 ticks (283 ms).
AVERAGE_POOL_2D took 75604 ticks (75 ms).
CONV_2D took 3398 ticks (3 ms).
RESHAPE took 290 ticks (0 ms).
SOFTMAX took 1933 ticks (1 ms).
```

Without this change:
```
KeywordRunNIerations(1) took 38516 ticks (38 ms)
DEPTHWISE_CONV_2D took 11961939 ticks (11961 ms).
DEPTHWISE_CONV_2D took 12296923 ticks (12296 ms).
CONV_2D took 987358 ticks (987 ms).
DEPTHWISE_CONV_2D took 6138259 ticks (6138 ms).
CONV_2D took 554614 ticks (554 ms).
DEPTHWISE_CONV_2D took 12063331 ticks (12063 ms).
CONV_2D took 665206 ticks (665 ms).
DEPTHWISE_CONV_2D took 3018615 ticks (3018 ms).
CONV_2D took 334246 ticks (334 ms).
DEPTHWISE_CONV_2D took 5837463 ticks (5837 ms).
CONV_2D took 444838 ticks (444 ms).
DEPTHWISE_CONV_2D took 1462009 ticks (1462 ms).
CONV_2D took 225286 ticks (225 ms).
DEPTHWISE_CONV_2D took 2734009 ticks (2734 ms).
CONV_2D took 335878 ticks (335 ms).
DEPTHWISE_CONV_2D took 2734009 ticks (2734 ms).
CONV_2D took 335878 ticks (335 ms).
DEPTHWISE_CONV_2D took 2734009 ticks (2734 ms).
CONV_2D took 335878 ticks (335 ms).
DEPTHWISE_CONV_2D took 2734009 ticks (2734 ms).
CONV_2D took 335878 ticks (335 ms).
DEPTHWISE_CONV_2D took 2734009 ticks (2734 ms).
CONV_2D took 335878 ticks (335 ms).
DEPTHWISE_CONV_2D took 685980 ticks (685 ms).
CONV_2D took 173254 ticks (173 ms).
DEPTHWISE_CONV_2D took 1197084 ticks (1197 ms).
CONV_2D took 283846 ticks (283 ms).
AVERAGE_POOL_2D took 75604 ticks (75 ms).
CONV_2D took 3382 ticks (3 ms).
RESHAPE took 290 ticks (0 ms).
SOFTMAX took 1933 ticks (1 ms).
```

Confirmed that the kernel_conv_test passes with:
```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=fusion_f1 XTENSA_CORE=F1_190305_swupgrade test_kernel_depthwise_conv_test -j8
```
Progress towards http://b/177457688