### PR TITLE
Update STM32 Bare Lib for zero initialization of the bss section

### DIFF
--- a/tensorflow/lite/micro/micro_error_reporter.cc
+++ b/tensorflow/lite/micro/micro_error_reporter.cc
@@ -54,17 +54,9 @@ void MicroPrintf(const char* format, ...) {
 
 namespace tflite {
 ErrorReporter* GetMicroErrorReporter() {
-#if !defined(RENODE)
   if (error_reporter_ == nullptr) {
     error_reporter_ = new (micro_error_reporter_buffer) MicroErrorReporter();
   }
-#else
-  // TODO(#46937): Until we resolve the global variable issue with Renode, we
-  // will be creating a new ErrorReporter object each time. While this is
-  // inefficient, it still allows us to make progress.
-  error_reporter_ = new (micro_error_reporter_buffer) MicroErrorReporter();
-#endif
-
   return error_reporter_;
 }
 

--- a/tensorflow/lite/micro/tools/make/ext_libs/stm32_bare_lib_download.sh
+++ b/tensorflow/lite/micro/tools/make/ext_libs/stm32_bare_lib_download.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# Called with following arguments:
+# 1 - Path to the downloads folder which is typically
+#     tensorflow/lite/micro/tools/make/downloads
+#
+# This script is called from the Makefile and uses the following convention to
+# enable determination of sucess/failure:
+#
+#   - If the script is successful, the only output on stdout should be SUCCESS.
+#     The makefile checks for this particular string.
+#
+#   - Any string on stdout that is not SUCCESS will be shown in the makefile as
+#     the cause for the script to have failed.
+#
+#   - Any other informational prints should be on stderr.
+
+set -e
+
+DOWNLOADS_DIR=${1}
+if [ ! -d ${DOWNLOADS_DIR} ]; then
+  echo "The top-level downloads directory: ${DOWNLOADS_DIR} does not exist."
+  exit 1
+fi
+
+DOWNLOADED_STM32_BARE_LIB_PATH=${DOWNLOADS_DIR}/stm32_bare_lib
+
+if [ -d ${DOWNLOADED_STM32_BARE_LIB_PATH} ]; then
+  echo >&2 "${DOWNLOADED_STM32_BARE_LIB_PATH} already exists, skipping the download."
+else
+  git clone https://github.com/google/stm32_bare_lib.git ${DOWNLOADED_STM32_BARE_LIB_PATH} >&2
+  pushd ${DOWNLOADED_STM32_BARE_LIB_PATH} > /dev/null
+  git checkout aaabdeb0d6098322a0874b29f6ed547a39b3929f >&2
+  popd > /dev/null
+fi
+
+echo "SUCCESS"

--- a/tensorflow/lite/micro/tools/make/targets/bluepill_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/bluepill_makefile.inc
@@ -7,8 +7,6 @@ ifneq ($(DOWNLOAD_RESULT), SUCCESS)
   $(error Something went wrong with the GCC download: $(DOWNLOAD_RESULT))
 endif
 
-$(eval $(call add_third_party_download,$(STM32_BARE_LIB_URL),$(STM32_BARE_LIB_MD5),stm32_bare_lib,))
-
 DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/renode_download.sh ${MAKEFILE_DIR}/downloads)
 ifneq ($(DOWNLOAD_RESULT), SUCCESS)
   $(error Something went wrong with the renode download: $(DOWNLOAD_RESULT))
@@ -17,6 +15,11 @@ endif
 DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/ext_libs/cmsis_download.sh ${MAKEFILE_DIR}/downloads)
 ifneq ($(DOWNLOAD_RESULT), SUCCESS)
   $(error Something went wrong with the CMSIS download: $(DOWNLOAD_RESULT))
+endif
+
+DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/ext_libs/stm32_bare_lib_download.sh ${MAKEFILE_DIR}/downloads)
+ifneq ($(DOWNLOAD_RESULT), SUCCESS)
+  $(error Something went wrong with the STM32 Bare Lib download: $(DOWNLOAD_RESULT))
 endif
 
 PLATFORM_FLAGS = \

--- a/tensorflow/lite/micro/tools/make/targets/stm32f4_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/stm32f4_makefile.inc
@@ -10,8 +10,6 @@ ifneq ($(DOWNLOAD_RESULT), SUCCESS)
   $(error Something went wrong with the GCC download: $(DOWNLOAD_RESULT))
 endif
 
-$(eval $(call add_third_party_download,$(STM32_BARE_LIB_URL),$(STM32_BARE_LIB_MD5),stm32_bare_lib,))
-
 DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/renode_download.sh ${MAKEFILE_DIR}/downloads)
 ifneq ($(DOWNLOAD_RESULT), SUCCESS)
   $(error Something went wrong with the renode download: $(DOWNLOAD_RESULT))
@@ -20,6 +18,11 @@ endif
 DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/ext_libs/cmsis_download.sh ${MAKEFILE_DIR}/downloads)
 ifneq ($(DOWNLOAD_RESULT), SUCCESS)
   $(error Something went wrong with the CMSIS download: $(DOWNLOAD_RESULT))
+endif
+
+DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/ext_libs/stm32_bare_lib_download.sh ${MAKEFILE_DIR}/downloads)
+ifneq ($(DOWNLOAD_RESULT), SUCCESS)
+  $(error Something went wrong with the STM32 Bare Lib download: $(DOWNLOAD_RESULT))
 endif
 
 # TODO(b/161478030): change -Wno-vla to -Wvla and remove -Wno-shadow once

--- a/tensorflow/lite/micro/tools/make/third_party_downloads.inc
+++ b/tensorflow/lite/micro/tools/make/third_party_downloads.inc
@@ -22,9 +22,6 @@ SF_BSPS_URL := "http://mirror.tensorflow.org/github.com/sparkfun/SparkFun_Apollo
 SF_BSPS_MD5 := "34199f7e754735661d1c8a70a40ca7a3"
 SF_BSPS_DEST := boards_sfe
 
-STM32_BARE_LIB_URL := "http://mirror.tensorflow.org/github.com/google/stm32_bare_lib/archive/c07d611fb0af58450c5a3e0ab4d52b47f99bc82d.zip"
-STM32_BARE_LIB_MD5 := "282bff40d4d0b92278fd123a3b6e3123"
-
 ifeq ($(HOST_OS),osx)
   RISCV_TOOLCHAIN_URL := "http://mirror.tensorflow.org/static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.1.0-2019.01.0-x86_64-apple-darwin.tar.gz"
   RISCV_TOOLCHAIN_MD5 := "2ac2fa00618b9ab7fa0c7d0ec173de94"


### PR DESCRIPTION
With google/stm32_bare_lib@aaabdeb STM32 Bare Lib zero-initializes the bss section.

This change is also pulling out the download into a standalone bash script.

See #46937 for more discussion on this.

Fixes #46937