### PR TITLE
Libcudnn Major Version Variable attached

### DIFF
--- a/tensorflow/tools/dockerfiles/partials/ubuntu/devel-nvidia.partial.Dockerfile
+++ b/tensorflow/tools/dockerfiles/partials/ubuntu/devel-nvidia.partial.Dockerfile
@@ -26,8 +26,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libcurand-dev-${CUDA/./-} \
         libcusolver-dev-${CUDA/./-} \
         libcusparse-dev-${CUDA/./-} \
-        libcudnn8=${CUDNN}+cuda${CUDA} \
-        libcudnn8-dev=${CUDNN}+cuda${CUDA} \
+        libcudnn${CUDNN_MAJOR_VERSION}=${CUDNN}+cuda${CUDA} \
+        libcudnn${CUDNN_MAJOR_VERSION}-dev=${CUDNN}+cuda${CUDA} \
         libcurl3-dev \
         libfreetype6-dev \
         libhdf5-serial-dev \

--- a/tensorflow/tools/dockerfiles/partials/ubuntu/nvidia.partial.Dockerfile
+++ b/tensorflow/tools/dockerfiles/partials/ubuntu/nvidia.partial.Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libcusolver-${CUDA/./-} \
         libcusparse-${CUDA/./-} \
         curl \
-        libcudnn8=${CUDNN}+cuda${CUDA} \
+        libcudnn${CUDNN_MAJOR_VERSION}=${CUDNN}+cuda${CUDA} \
         libfreetype6-dev \
         libhdf5-serial-dev \
         libzmq3-dev \


### PR DESCRIPTION
The libcudnn Major Version was not used in for getting the Packages with apt-get