### PR TITLE
lite: nnapi: Fix fd leak in NNMemory's destructor

### DIFF
--- a/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
+++ b/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
@@ -676,7 +676,7 @@ NNMemory::~NNMemory() {
   if (nn_memory_handle_) {
     nnapi_->ANeuralNetworksMemory_free(nn_memory_handle_);
   }
-  if (fd_ > 0) close(fd_);
+  if (fd_ >= 0) close(fd_);
 #endif
 }
 


### PR DESCRIPTION
Valid fd values are non-negative, including zero.