### PR TITLE
Add thread name in the error message when thread creation fails.

### DIFF
--- a/tensorflow/core/platform/default/env.cc
+++ b/tensorflow/core/platform/default/env.cc
@@ -70,7 +70,7 @@ class PThread : public Thread {
     }
     int ret = pthread_create(&thread_, &attributes, &ThreadFn, params);
     // There is no mechanism for the thread creation API to fail, so we CHECK.
-    CHECK_EQ(ret, 0) << "Thread creation via pthread_create() failed.";
+    CHECK_EQ(ret, 0) << "Thread " + name + " creation via pthread_create() failed.";
     pthread_attr_destroy(&attributes);
   }
 

--- a/tensorflow/core/platform/default/env.cc
+++ b/tensorflow/core/platform/default/env.cc
@@ -70,7 +70,7 @@ class PThread : public Thread {
     }
     int ret = pthread_create(&thread_, &attributes, &ThreadFn, params);
     // There is no mechanism for the thread creation API to fail, so we CHECK.
-    CHECK_EQ(ret, 0) << "Thread " + name + " creation via pthread_create() failed.";
+    CHECK_EQ(ret, 0) << "Thread " << name << " creation via pthread_create() failed.";
     pthread_attr_destroy(&attributes);
   }
 


### PR DESCRIPTION
This PR adds thread name in the error message when thread creation fails. It helps with debugging when thread creation fails.