### PR TITLE
Simplify Huber Loss implementation

### DIFF
--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -1538,7 +1538,7 @@ def huber(y_true, y_pred, delta=1.0):
 
   ```
   loss = 0.5 * x^2                  if |x| <= d
-  loss = 0.5 * d^2 + d * (|x| - d)  if |x| > d
+  loss = d * |x| - 0.5 * d^2        if |x| > d
   ```
   where d is `delta`. See: https://en.wikipedia.org/wiki/Huber_loss
 
@@ -1559,8 +1559,8 @@ def huber(y_true, y_pred, delta=1.0):
   half = ops.convert_to_tensor_v2_with_dispatch(0.5, dtype=abs_error.dtype)
   return K.mean(
       array_ops.where_v2(
-          abs_error <= delta, half * math_ops.pow(error, 2),
-          half * math_ops.pow(delta, 2) + delta * (abs_error - delta)),
+          abs_error <= delta, half * math_ops.square(error),
+          delta * abs_error - half * math_ops.square(delta)),
       axis=-1)
 
 


### PR DESCRIPTION
This PR simplifies the Huber Loss implementation and also updates the docstring to use a more readable formulation matching the one on Wikipedia.

This PR does not change the mathematics, but removes the need for one operation in the code path that cannot be constant folded away which should improve performance.