### PR TITLE
Make libtensorflow_jni target compatible with Tensorflow Text

### DIFF
--- a/tensorflow/java/config/version_script.lds
+++ b/tensorflow/java/config/version_script.lds
@@ -4,6 +4,7 @@ VERS_1.0 {
     Java_*;
     JNI_OnLoad;
     JNI_OnUnload;
+    *tensorflow*;
 
   # Hide everything else.
   local:


### PR DESCRIPTION
Export tensorflow symbols to solve global static variable lookup issue.

Fix #47431 