### PR TITLE
Remove unnecessary model parsing from keras.model.load_model

### DIFF
--- a/tensorflow/python/keras/saving/save.py
+++ b/tensorflow/python/keras/saving/save.py
@@ -28,7 +28,6 @@ from tensorflow.python.keras.saving.saved_model import load_context
 from tensorflow.python.keras.saving.saved_model import save as saved_model_save
 from tensorflow.python.keras.utils import generic_utils
 from tensorflow.python.keras.utils.io_utils import path_to_string
-from tensorflow.python.saved_model import loader_impl
 from tensorflow.python.util import keras_deps
 from tensorflow.python.util.tf_export import keras_export
 
@@ -205,7 +204,6 @@ def load_model(filepath, custom_objects=None, compile=True, options=None):  # py
 
         filepath = path_to_string(filepath)
         if isinstance(filepath, six.string_types):
-          loader_impl.parse_saved_model(filepath)
           return saved_model_load.load(filepath, compile, options)
 
   raise IOError(


### PR DESCRIPTION
This PR removes duplicated SavedModel parsing from `keras.model.load_model`. The result of parsing was never used and it is also not needed for error handling either since the same function will be called at the start of `saved_model_load.load`:
https://github.com/tensorflow/tensorflow/blob/7e1c942100039dc0a9adda5d0d45c7e1d2e3b76c/tensorflow/python/keras/saving/saved_model/load.py#L124

This removes the need to read the file content and parse the saved model twice which can improve performance when loading models from a remote file system like GCS.