### PR TITLE
Make the output for model summary wrap

### DIFF
--- a/tensorflow/python/keras/utils/layer_utils.py
+++ b/tensorflow/python/keras/utils/layer_utils.py
@@ -249,19 +249,11 @@ def print_summary(model, line_length=None, positions=None, print_fn=None):
 
     name = layer.name
     cls_name = layer.__class__.__name__
-    if not connections:
-      first_connection = ''
-    else:
-      first_connection = connections[0]
     fields = [
         name + ' (' + cls_name + ')', output_shape,
-        layer.count_params(), first_connection
+        layer.count_params(), connections
     ]
     print_row(fields, positions)
-    if len(connections) > 1:
-      for i in range(1, len(connections)):
-        fields = ['', '', '', connections[i]]
-        print_row(fields, positions)
 
   layers = model.layers
   for i in range(len(layers)):

--- a/tensorflow/python/keras/utils/layer_utils.py
+++ b/tensorflow/python/keras/utils/layer_utils.py
@@ -190,11 +190,11 @@ def print_summary(model, line_length=None, positions=None, print_fn=None):
         end_pos = positions[col]
         # Leave room for a space to delineate columns
         # we don't need one if we are printing the last column
-        space = 1 if col - 1 == len(positions) else 0
+        space = 1 if col != len(positions) - 1 else 0
         delta = end_pos - start_pos - space
         fit_into_line = left_to_print[col][:delta]
         line += fit_into_line
-        line += ' '
+        line += ' ' if space else ''
         left_to_print[col] = left_to_print[col][delta:]
 
         # Pad out to the next position

--- a/tensorflow/python/keras/utils/layer_utils.py
+++ b/tensorflow/python/keras/utils/layer_utils.py
@@ -182,21 +182,23 @@ def print_summary(model, line_length=None, positions=None, print_fn=None):
     left_to_print = [str(x) for x in fields]
     while any(left_to_print):
       line = ''
-      for i in range(len(left_to_print)):
-        if i > 0:
-          start_pos = positions[i-1]
+      for col in range(len(left_to_print)):
+        if col > 0:
+          start_pos = positions[col-1]
         else:
           start_pos = 0
-        end_pos = positions[i]
-        # Leave room for a space
-        delta = end_pos - start_pos - 1
-        fit_into_line = left_to_print[i][:delta]
+        end_pos = positions[col]
+        # Leave room for a space to delineate columns
+        # we don't need one if we are printing the last column
+        space = 1 if col - 1 == len(positions) else 0
+        delta = end_pos - start_pos - space
+        fit_into_line = left_to_print[col][:delta]
         line += fit_into_line
         line += ' '
-        left_to_print[i] = left_to_print[i][delta:]
+        left_to_print[col] = left_to_print[col][delta:]
 
         # Pad out to the next position
-        line += ' ' * (positions[i] - len(line))
+        line += ' ' * (positions[col] - len(line))
       print_fn(line)
 
   print_fn('Model: "{}"'.format(model.name))

--- a/tensorflow/python/keras/utils/layer_utils.py
+++ b/tensorflow/python/keras/utils/layer_utils.py
@@ -179,14 +179,25 @@ def print_summary(model, line_length=None, positions=None, print_fn=None):
       relevant_nodes += v
 
   def print_row(fields, positions):
-    line = ''
-    for i in range(len(fields)):
-      if i > 0:
-        line = line[:-1] + ' '
-      line += str(fields[i])
-      line = line[:positions[i]]
-      line += ' ' * (positions[i] - len(line))
-    print_fn(line)
+    left_to_print = [str(x) for x in fields]
+    while any(left_to_print):
+      line = ''
+      for i in range(len(left_to_print)):
+        if i > 0:
+          start_pos = positions[i-1]
+        else:
+          start_pos = 0
+        end_pos = positions[i]
+        # Leave room for a space
+        delta = end_pos - start_pos - 1
+        fit_into_line = left_to_print[i][:delta]
+        line += fit_into_line
+        line += ' '
+        left_to_print[i] = left_to_print[i][delta:]
+
+        # Pad out to the next position
+        line += ' ' * (positions[i] - len(line))
+      print_fn(line)
 
   print_fn('Model: "{}"'.format(model.name))
   print_fn('_' * line_length)


### PR DESCRIPTION
This is just a small alteration to the printing logic of the model summary to allow the cells to wrap, this is useful for model with long outputs/inputs (such as BERT, which is what motivated me to do this). Useful for rigorous storage of model summaries.

[x] Read contributing guidelines.
[x] Read Code of Conduct.
[x] Ensure you have signed the Contributor License Agreement (CLA).
[x] Check if my changes are consistent with the guidelines. (I think they are)
[x] Changes are consistent with the Coding Style. (File's pylint score unchanged from 8.56)
[ ] Run Unit Tests.

I am really struggling to be able to run these tests, been trying for a good 4/5 hours, I am on Ubuntu 20.04, I have:
1. Tried running `tensorflow/tools/ci_build/ci_build.sh CPU bazel test //tensorflow/...` from repo root, this consistently errors due to `tensorflow/tools/ci_build/install/install_pip_packages.sh` not seeing the correct python version (which weirdly is trying to use python3.6 even though the git blame for the changes to line 26 suggest the purpose was to migrate to python 3.7)
2. Tried changing the docker file to some other one, I have tried the `tensorflow/tools/ci_build/Dockerfile.pi-python38` (which i now realise is for raspberry pi's - derp!) and `tensorflow/tools/ci_build/Dockerfile.local-toolchain-ubuntu18.04-manylinux2010`. Neither worked.
3. Ultimately, I have pulled `tensorflow/tensorflow   latest-devel   a4c4b6decc02` and exec'd into the container and tried to run `bazel test //tensorflow/python/keras` but that has errored due to:
```
ERROR: /tensorflow_src/tensorflow/core/kernels/BUILD:2736:18: C++ compilation of rule '//tensorflow/core/kernels:resource_variable_ops' failed (Exit 4): gcc failed: error executing command /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer -g0 -O2 '-D_FORTIFY_SOURCE=1' -DNDEBUG -ffunction-sections ... (remaining 240 argument(s) skipped)
gcc: internal compiler error: Killed (program cc1plus)
```

I am really keen to try and get these tests running to verify my changes haven't affected anything (although searching the repo for tests using `model.summary()` suggests everything should still pass.
