### PR TITLE
First step towards prototyping v2 of TFLM integration with external IDEs.

### DIFF
--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -885,7 +885,6 @@ cc_test(
         "space_to_batch_nd_test.cc",
     ],
     deps = [
-        ":conv_test_common",
         ":kernel_runner",
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/micro:micro_utils",

--- a/tensorflow/lite/micro/tools/ci_build/test_all.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_all.sh
@@ -61,6 +61,12 @@ if [[ ${1} == "GITHUB_PRESUBMIT" ]]; then
   # coverage, it is unlikely that an internal change would break only the corstone build.
   echo "Running cortex_m_corstone_300 tests at `date`"
   tensorflow/lite/micro/tools/ci_build/test_cortex_m_corstone_300.sh
+
+  # Only running project generation v2 prototype as part of the github CI while
+  # it is under development. See
+  # https://github.com/tensorflow/tensorflow/issues/47413 for more context.
+  echo "Running project_generation test at `date`"
+  tensorflow/lite/micro/tools/ci_build/test_project_generation.sh
 fi
 
 echo "Running x86 tests at `date`"

--- a/tensorflow/lite/micro/tools/ci_build/test_project_generation.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_project_generation.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# This script can be used to initiate a bazel build with a reduced set of
+# downloads, but still sufficient to test all the TFLM targets.
+#
+# This is primarily intended for use from a Docker image as part of the TFLM
+# github continuous integration system. There are still a number of downloads
+# (e.g. java) that are not necessary and it may be possible to further reduce
+# the set of external libraries and downloads.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR=${SCRIPT_DIR}/../../../../..
+cd "${ROOT_DIR}"
+
+source tensorflow/lite/micro/tools/ci_build/helper_functions.sh
+
+TEST_OUTPUT_DIR="/tmp/tflm_project_gen"
+rm -rf ${TEST_OUTPUT_DIR}
+
+TEST_OUTPUT_DIR_CMSIS="/tmp/tflm_project_gen_cmsis"
+rm -rf ${TEST_OUTPUT_DIR_CMSIS}
+
+readable_run python3 tensorflow/lite/micro/tools/project_generation/create_tflm_tree.py ${TEST_OUTPUT_DIR}
+readable_run cp tensorflow/lite/micro/tools/project_generation/Makefile ${TEST_OUTPUT_DIR}
+
+pushd ${TEST_OUTPUT_DIR} > /dev/null
+readable_run make -j8 libtflm
+popd > /dev/null
+
+readable_run python3 tensorflow/lite/micro/tools/project_generation/create_tflm_tree.py \
+  --makefile_options="TARGET=cortex_m_generic OPTIMIZED_KERNEL_DIR=cmsis_nn TARGET_ARCH=cortex-m4" \
+  ${TEST_OUTPUT_DIR_CMSIS}

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -318,7 +318,6 @@ tensorflow/lite/micro/kernels/comparisons.cc \
 tensorflow/lite/micro/kernels/concatenation.cc \
 tensorflow/lite/micro/kernels/conv.cc \
 tensorflow/lite/micro/kernels/conv_common.cc \
-tensorflow/lite/micro/kernels/conv_test_common.cc \
 tensorflow/lite/micro/kernels/depthwise_conv.cc \
 tensorflow/lite/micro/kernels/depthwise_conv_common.cc \
 tensorflow/lite/micro/kernels/dequantize.cc \
@@ -461,22 +460,37 @@ tensorflow/lite/portable_type_to_tflitetype.h \
 tensorflow/lite/schema/schema_generated.h \
 tensorflow/lite/schema/schema_utils.h
 
+# For project generation v1, the headers that are common to all targets need to
+# have a third_party prefix. Other third_party headers (e.g. CMSIS) do not have
+# this requirement and are added to THIRD_PARTY_CC_HDRS with full path from the
+# tensorflow root. This inconsistency may also be the reason why (for
+# example) these different third party libraries are fund in different paths in
+# the Arduino output tree.
+#
+# The convention with the (under development) project generation v2 is for all
+# third party paths to be relative to the root of the git repository. We are
+# keeping backwards compatibility between v1 and v2 by having a
+# THIRD_PARTY_CC_HDRS_BASE variable and adding in a third_party prefix to
+# THIRD_PARTY_CC_HDRS later on in the Makefile logic.
+# TODO(#47413): remove this additional logic once we are ready to switch over to
+# project generation v2.
+THIRD_PARTY_CC_HDRS :=
+
 # TODO(b/165940489): Figure out how to avoid including fixed point
 # platform-specific headers.
-THIRD_PARTY_CC_HDRS := \
-third_party/gemmlowp/fixedpoint/fixedpoint.h \
-third_party/gemmlowp/fixedpoint/fixedpoint_neon.h \
-third_party/gemmlowp/fixedpoint/fixedpoint_sse.h \
-third_party/gemmlowp/internal/detect_platform.h \
-third_party/gemmlowp/LICENSE \
-third_party/flatbuffers/include/flatbuffers/base.h \
-third_party/flatbuffers/include/flatbuffers/stl_emulation.h \
-third_party/flatbuffers/include/flatbuffers/flatbuffers.h \
-third_party/flatbuffers/include/flatbuffers/flexbuffers.h \
-third_party/flatbuffers/include/flatbuffers/util.h \
-third_party/flatbuffers/LICENSE.txt \
-third_party/ruy/ruy/profiler/instrumentation.h
-
+THIRD_PARTY_CC_HDRS_BASE := \
+gemmlowp/fixedpoint/fixedpoint.h \
+gemmlowp/fixedpoint/fixedpoint_neon.h \
+gemmlowp/fixedpoint/fixedpoint_sse.h \
+gemmlowp/internal/detect_platform.h \
+gemmlowp/LICENSE \
+flatbuffers/include/flatbuffers/base.h \
+flatbuffers/include/flatbuffers/stl_emulation.h \
+flatbuffers/include/flatbuffers/flatbuffers.h \
+flatbuffers/include/flatbuffers/flexbuffers.h \
+flatbuffers/include/flatbuffers/util.h \
+flatbuffers/LICENSE.txt \
+ruy/ruy/profiler/instrumentation.h
 
 MAKE_PROJECT_FILES := \
   Makefile \
@@ -579,6 +593,15 @@ ifneq ($(CO_PROCESSOR),)
   # Specialize for the coprocessor kernels.
   MICROLITE_CC_KERNEL_SRCS := $(call substitute_specialized_implementations,$(MICROLITE_CC_KERNEL_SRCS),$(CO_PROCESSOR))
 endif
+
+# TODO(#47413): Remove this logic once we are switched over to the newer version
+# of project generation (v2). Project generation v1 needs the "base" third party
+# headers to have a prefix of third_party/. In order to support v2 prototyping
+# without a lot of changes with the v1 system, we are manually adding in this
+# prefix, and also making a copy in THIRD_PARTY_CC_HDRS_V2 that will be used in
+# the list_third_party_headers target.
+THIRD_PARTY_CC_HDRS_V2 := $(THIRD_PARTY_CC_HDRS)
+THIRD_PARTY_CC_HDRS += $(addprefix third_party/,$(THIRD_PARTY_CC_HDRS_BASE))
 
 # Specialize for debug_log. micro_time etc.
 MICROLITE_CC_SRCS := $(call substitute_specialized_implementations,$(MICROLITE_CC_SRCS),$(TARGET))
@@ -711,6 +734,31 @@ ifneq ($(findstring $(EXPLICITLY_SPECIFIED_TEST),$(MICROLITE_TEST_SRCS)),)
   $(EXPLICITLY_SPECIFIED_TEST_SRCS),$(EXPLICITLY_SPECIFIED_TEST_HDRS)))
 endif
 
+EXPLICITLY_SPECIFIED_TEST:= tensorflow/lite/micro/kernels/conv_test.cc
+ifneq ($(findstring $(EXPLICITLY_SPECIFIED_TEST),$(MICROLITE_TEST_SRCS)),)
+  MICROLITE_TEST_SRCS := $(filter-out $(EXPLICITLY_SPECIFIED_TEST), $(MICROLITE_TEST_SRCS))
+  EXPLICITLY_SPECIFIED_TEST_SRCS := \
+  $(EXPLICITLY_SPECIFIED_TEST) \
+  tensorflow/lite/micro/kernels/conv_test_common.cc
+  EXPLICITLY_SPECIFIED_TEST_HDRS := \
+  tensorflow/lite/micro/kernels/conv_test.h
+  $(eval $(call microlite_test,kernel_conv_test,\
+  $(EXPLICITLY_SPECIFIED_TEST_SRCS),$(EXPLICITLY_SPECIFIED_TEST_HDRS)))
+endif
+
+EXPLICITLY_SPECIFIED_TEST:= tensorflow/lite/micro/kernels/transpose_conv_test.cc
+ifneq ($(findstring $(EXPLICITLY_SPECIFIED_TEST),$(MICROLITE_TEST_SRCS)),)
+  MICROLITE_TEST_SRCS := $(filter-out $(EXPLICITLY_SPECIFIED_TEST), $(MICROLITE_TEST_SRCS))
+  EXPLICITLY_SPECIFIED_TEST_SRCS := \
+  $(EXPLICITLY_SPECIFIED_TEST) \
+  tensorflow/lite/micro/kernels/conv_test_common.cc
+  EXPLICITLY_SPECIFIED_TEST_HDRS := \
+  tensorflow/lite/micro/kernels/conv_test.h
+  $(eval $(call microlite_test,kernel_transpose_conv_test,\
+  $(EXPLICITLY_SPECIFIED_TEST_SRCS),$(EXPLICITLY_SPECIFIED_TEST_HDRS)))
+endif
+
+
 # For all the tests that do not have any additional dependencies, we can
 # add a make target in a common way.
 $(foreach TEST_TARGET,$(filter-out tensorflow/lite/micro/kernels/%,$(MICROLITE_TEST_SRCS)),\
@@ -732,6 +780,18 @@ ARDUINO_PROJECT_TARGETS := $(foreach TARGET,$(ALL_PROJECT_TARGETS),$(if $(findst
 
 generate_arduino_zip: $(ARDUINO_PROJECT_TARGETS) $(ARDUINO_LIBRARY_ZIPS)
 	python tensorflow/lite/micro/tools/make/merge_arduino_zips.py $(PRJDIR)/tensorflow_lite.zip $(ARDUINO_LIBRARY_ZIPS)
+
+list_library_sources:
+	@echo $(MICROLITE_CC_SRCS)
+
+list_library_headers:
+	@echo $(MICROLITE_CC_HDRS)
+
+list_third_party_sources:
+	@echo $(THIRD_PARTY_CC_SRCS)
+
+list_third_party_headers:
+	@echo $(addprefix $(MAKEFILE_DIR)/downloads/,$(THIRD_PARTY_CC_HDRS_BASE)) $(THIRD_PARTY_CC_HDRS_V2)
 
 # Gets rid of all generated files.
 clean:

--- a/tensorflow/lite/micro/tools/project_generation/Makefile
+++ b/tensorflow/lite/micro/tools/project_generation/Makefile
@@ -1,0 +1,60 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# Simple Makefile that serves as a smokes-check for project generation on x86.
+#
+# Execute the following command after copying this Makefile to the root of the
+# TFLM tree created with the project generation script:
+# make -j8 libtflm
+
+CXX := clang++
+CXXFLAGS := \
+	-std=c++11
+
+CC := clang
+
+INCLUDES := \
+  -I. \
+  -I./third_party/gemmlowp \
+  -I./third_party/flatbuffers/include \
+  -I./third_party/ruy
+
+AR := ar
+ARFLAGS := -r
+
+GENDIR := gen
+OBJDIR := $(GENDIR)/obj
+LIB := $(GENDIR)/libtflm.a
+
+TFLM_CC_SRCS := $(shell find tensorflow -name "*.cc" -o -name "*.c")
+OBJS := $(addprefix $(OBJDIR)/, $(patsubst %.c,%.o,$(patsubst %.cc,%.o,$(TFLM_CC_SRCS))))
+
+$(OBJDIR)/%.o: %.cc
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+
+$(OBJDIR)/%.o: %.c
+	@mkdir -p $(dir $@)
+	$(CC) $(INCLUDES) -c $< -o $@
+
+$(LIB): $(OBJS)
+	@mkdir -p $(dir $@)
+	$(AR) $(ARFLAGS) $(LIB) $(OBJS)
+
+clean:
+	rm -rf $(GENDIR)
+
+libtflm: $(LIB)
+

--- a/tensorflow/lite/micro/tools/project_generation/create_tflm_tree.py
+++ b/tensorflow/lite/micro/tools/project_generation/create_tflm_tree.py
@@ -1,0 +1,114 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Starting point for writing scripts to integrate TFLM with external IDEs.
+
+This script can be used to output a tree containing only the sources and headers
+needed to use TFLM for a specific configuration (e.g. target and
+optimized_kernel_implementation). This should serve as a starting
+point to integrate TFLM with external IDEs.
+
+The goal is for this script to be an interface that is maintained by the TFLM
+team and any additional scripting needed for integration with a particular IDE
+should be written external to the TFLM repository and built to work on top of
+the output tree generated with this script.
+
+We will add more documentation for a desired end-to-end integration workflow as
+we get further along in our prototyping. See this github issue for more details:
+  https://github.com/tensorflow/tensorflow/issues/47413
+"""
+
+import argparse
+import os
+import shutil
+import subprocess
+
+
+def _get_dirs(file_list):
+  dirs = set()
+  for filepath in file_list:
+    dirs.add(os.path.dirname(filepath))
+  return dirs
+
+
+def _get_file_list(key, makefile_options):
+  params_list = [
+      "make", "-f", "tensorflow/lite/micro/tools/make/Makefile", key
+  ] + makefile_options.split()
+  process = subprocess.Popen(params_list,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
+  stdout, stderr = process.communicate()
+
+  if process.returncode != 0:
+    raise RuntimeError("%s failed with \n\n %s" %
+                       (" ".join(params_list), stderr.decode()))
+
+  return [bytepath.decode() for bytepath in stdout.split()]
+
+
+def _add_third_party_code(prefix_dir, makefile_options):
+  files = []
+  files.extend(_get_file_list("list_third_party_sources", makefile_options))
+  files.extend(_get_file_list("list_third_party_headers", makefile_options))
+
+  # The list_third_party_* rules give path relative to the root of the git repo.
+  # However, in the output tree, we would like for the third_party code to be a tree
+  # under prefix_dir/third_party, with the path to the tflm_download directory
+  # removed. The path manipulation logic that follows removes the downloads
+  # directory prefix, and adds the third_party prefix to create a list of
+  # destination directories for each of the third party files.
+  tflm_download_path = "tensorflow/lite/micro/tools/make/downloads"
+  dest_dir_list = [
+      os.path.join(prefix_dir, "third_party",
+                   os.path.relpath(os.path.dirname(f), tflm_download_path))
+      for f in files
+  ]
+
+  for dest_dir, filepath in zip(dest_dir_list, files):
+    os.makedirs(dest_dir, exist_ok=True)
+    shutil.copy(filepath, dest_dir)
+
+
+def _add_tflm_code(prefix_dir, makefile_options):
+  files = []
+  files.extend(_get_file_list("list_library_sources", makefile_options))
+  files.extend(_get_file_list("list_library_headers", makefile_options))
+
+  for dirname in _get_dirs(files):
+    os.makedirs(os.path.join(prefix_dir, dirname), exist_ok=True)
+
+  for filepath in files:
+    shutil.copy(filepath, os.path.join(prefix_dir, os.path.dirname(filepath)))
+
+
+def _create_tflm_tree(prefix_dir, makefile_options):
+  _add_tflm_code(prefix_dir, makefile_options)
+  _add_third_party_code(prefix_dir, makefile_options)
+
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser(
+      description="Starting script for TFLM project generation")
+  parser.add_argument("output_dir",
+                      help="Output directory for generated TFLM tree")
+  parser.add_argument("--makefile_options",
+                      default="",
+                      help="Additional TFLM Makefile options. For example: "
+                      "--makefile_options=\"TARGET=<target> "
+                      "OPTIMIZED_KERNEL_DIR=<optimized_kernel_dir> "
+                      "TARGET_ARCH=corex-m4\"")
+  args = parser.parse_args()
+
+  _create_tflm_tree(args.output_dir, args.makefile_options)


### PR DESCRIPTION
With this change we can create an output directory containing all the sources and headers (including third_party) needed to build the TFLM static library.

See tools/ci_build/test_project_generation.sh for some sample commands.

A next step will be to add the sources for the examples as well.

Progress towards: #47413
