### PR TITLE
Modify Transpose kernel to work in TFLu

### DIFF
--- a/tensorflow/lite/micro/all_ops_resolver.cc
+++ b/tensorflow/lite/micro/all_ops_resolver.cc
@@ -91,6 +91,7 @@ AllOpsResolver::AllOpsResolver() {
   AddSvdf();
   AddTanh();
   AddTransposeConv();
+  AddTranspose();
   AddUnpack();
 }
 

--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -308,6 +308,7 @@ cc_library(
         "svdf_common.cc",
         "tanh.cc",
         "transpose_conv.cc",
+        "transpose.cc",
         "unpack.cc",
         "zeros_like.cc",
     ] + select({
@@ -1158,6 +1159,17 @@ cc_test(
 cc_test(
     name = "tanh_test",
     srcs = ["tanh_test.cc"],
+    deps = [
+        ":kernel_runner",
+        "//tensorflow/lite/c:common",
+        "//tensorflow/lite/micro:test_helpers",
+        "//tensorflow/lite/micro/testing:micro_test",
+    ],
+)
+
+cc_test(
+    name = "transpose_test",
+    srcs = ["transpose_test.cc"],
     deps = [
         ":kernel_runner",
         "//tensorflow/lite/c:common",

--- a/tensorflow/lite/micro/kernels/micro_ops.h
+++ b/tensorflow/lite/micro/kernels/micro_ops.h
@@ -55,6 +55,7 @@ TfLiteRegistration Register_SOFTMAX();
 TfLiteRegistration Register_SPACE_TO_BATCH_ND();
 TfLiteRegistration Register_SQUEEZE();
 TfLiteRegistration Register_SVDF();
+TfLiteRegistration Register_TRANSPOSE();
 TfLiteRegistration Register_TRANSPOSE_CONV();
 TfLiteRegistration Register_ZEROS_LIKE();
 

--- a/tensorflow/lite/micro/kernels/transpose.cc
+++ b/tensorflow/lite/micro/kernels/transpose.cc
@@ -12,27 +12,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-#include <stdint.h>
+#include "tensorflow/lite/kernels/internal/reference/transpose.h"
 
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/kernels/internal/compatibility.h"
-#include "tensorflow/lite/kernels/internal/optimized/optimized_ops.h"
-#include "tensorflow/lite/kernels/internal/reference/reference_ops.h"
-#include "tensorflow/lite/kernels/internal/tensor.h"
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/internal/types.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 
 namespace tflite {
-namespace ops {
-namespace builtin {
-namespace transpose {
-
-// This file has two implementations of Transpose.
-enum KernelType {
-  kReference,
-  kGenericOptimized,
-};
+namespace {
 
 struct TransposeContext {
   TransposeContext(TfLiteContext* context, TfLiteNode* node) {
@@ -44,29 +32,6 @@ struct TransposeContext {
   const TfLiteTensor* perm;
   TfLiteTensor* output;
 };
-
-TfLiteStatus ResizeOutputTensor(TfLiteContext* context,
-                                TransposeContext* op_context) {
-  int dims = NumDimensions(op_context->input);
-  const int* perm_data = GetTensorData<int32_t>(op_context->perm);
-
-  // Ensure validity of the permutations tensor as a 1D tensor.
-  TF_LITE_ENSURE_EQ(context, NumDimensions(op_context->perm), 1);
-  TF_LITE_ENSURE_EQ(context, op_context->perm->dims->data[0], dims);
-  for (int idx = 0; idx < dims; ++idx) {
-    TF_LITE_ENSURE_MSG(context, (perm_data[idx] >= 0 && perm_data[idx] < dims),
-                       "Transpose op permutations array is out of bounds.");
-  }
-
-  // Determine size of output tensor.
-  TfLiteIntArray* input_size = op_context->input->dims;
-  TfLiteIntArray* output_size = TfLiteIntArrayCopy(input_size);
-  for (int idx = 0; idx < dims; ++idx) {
-    output_size->data[idx] = input_size->data[perm_data[idx]];
-  }
-
-  return context->ResizeTensor(context, op_context->output, output_size);
-}
 
 TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE_EQ(context, NumInputs(node), 2);
@@ -80,23 +45,24 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE_TYPES_EQ(context, op_context.input->type,
                           op_context.output->type);
 
-  if (!IsConstantTensor(op_context.perm)) {
-    SetTensorToDynamic(op_context.output);
-    return kTfLiteOk;
+  int dims = NumDimensions(op_context.input);
+  const int32_t* perm_data = GetTensorData<int32_t>(op_context.perm);
+
+  // Ensure validity of the permutations tensor as a 1D tensor.
+  TF_LITE_ENSURE_EQ(context, NumDimensions(op_context.perm), 1);
+  TF_LITE_ENSURE_EQ(context, op_context.perm->dims->data[0], dims);
+  for (int idx = 0; idx < dims; ++idx) {
+    TF_LITE_ENSURE_MSG(context, (perm_data[idx] >= 0 && perm_data[idx] < dims),
+                       "Transpose op permutations array is out of bounds.");
   }
-  return ResizeOutputTensor(context, &op_context);
+
+  return kTfLiteOk;
 }
 
-template <KernelType kernel_type>
 TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   TransposeContext op_context(context, node);
 
-  // Resize the output tensor if the output tensor is dynamic.
-  if (IsDynamicTensor(op_context.output)) {
-    TF_LITE_ENSURE_OK(context, ResizeOutputTensor(context, &op_context));
-  }
-
-  const int* perm_data = GetTensorData<int32_t>(op_context.perm);
+  const int32_t* perm_data = GetTensorData<int32_t>(op_context.perm);
   const int size = op_context.perm->dims->data[0];
   TransposeParams params;
   params.perm_count = size;
@@ -104,47 +70,35 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
     params.perm[i] = perm_data[i];
   }
 
-#define TF_LITE_TRANSPOSE(type, scalar)                     \
-  type::Transpose(params, GetTensorShape(op_context.input), \
-                  GetTensorData<scalar>(op_context.input),  \
-                  GetTensorShape(op_context.output),        \
-                  GetTensorData<scalar>(op_context.output))
+#define TF_LITE_TRANSPOSE(type)                                      \
+  reference_ops::Transpose(params, GetTensorShape(op_context.input), \
+                           GetTensorData<type>(op_context.input),    \
+                           GetTensorShape(op_context.output),        \
+                           GetTensorData<type>(op_context.output))
 
-  // Transpose kernel only does rearranging values not numeric evaluations on
-  // each cell. It's safe to implement per size of scalar type and this trick
-  // keeps the total code size in a reasonable range.
+  // Transpose kernel only does rearranging values not numeric evaluations
+  // on each cell. It's safe to implement per size of scalar type and this
+  // trick keeps the total code size in a reasonable range.
   switch (op_context.input->type) {
     case kTfLiteFloat32:
     case kTfLiteInt32:
-      if (kernel_type == kGenericOptimized) {
-        TF_LITE_TRANSPOSE(optimized_ops, int32_t);
-      } else {
-        TF_LITE_TRANSPOSE(reference_ops, int32_t);
-      }
+      TF_LITE_TRANSPOSE(int32_t);
       break;
     case kTfLiteUInt8:
     case kTfLiteInt8:
-      if (kernel_type == kGenericOptimized) {
-        TF_LITE_TRANSPOSE(optimized_ops, int8_t);
-      } else {
-        TF_LITE_TRANSPOSE(reference_ops, int8_t);
-      }
+      TF_LITE_TRANSPOSE(int8_t);
       break;
     case kTfLiteInt16:
-      TF_LITE_TRANSPOSE(reference_ops, int16_t);
+      TF_LITE_TRANSPOSE(int16_t);
       break;
     case kTfLiteInt64:
-      TF_LITE_TRANSPOSE(reference_ops, int64_t);
+      TF_LITE_TRANSPOSE(int64_t);
       break;
     case kTfLiteBool:
       if (sizeof(bool) == 1) {
-        if (kernel_type == kGenericOptimized) {
-          TF_LITE_TRANSPOSE(optimized_ops, int8_t);
-        } else {
-          TF_LITE_TRANSPOSE(reference_ops, int8_t);
-        }
+        TF_LITE_TRANSPOSE(int8_t);
       } else {
-        TF_LITE_TRANSPOSE(reference_ops, bool);
+        TF_LITE_TRANSPOSE(bool);
       }
       break;
     default:
@@ -158,24 +112,16 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   return kTfLiteOk;
 }
 
-}  // namespace transpose
+}  // namespace
 
-TfLiteRegistration* Register_TRANSPOSE_REF() {
-  static TfLiteRegistration r = {nullptr, nullptr, transpose::Prepare,
-                                 transpose::Eval<transpose::kReference>};
-  return &r;
+TfLiteRegistration Register_TRANSPOSE() {
+  return {/*init=*/nullptr,
+          /*free=*/nullptr,
+          /*prepare=*/Prepare,
+          /*invoke=*/Eval,
+          /*profiling_string=*/nullptr,
+          /*builtin_code=*/0,
+          /*custom_name=*/nullptr,
+          /*version=*/0};
 }
-
-TfLiteRegistration* Register_TRANSPOSE_GENERIC_OPTIMIZED() {
-  static TfLiteRegistration r = {nullptr, nullptr, transpose::Prepare,
-                                 transpose::Eval<transpose::kGenericOptimized>};
-  return &r;
-}
-
-TfLiteRegistration* Register_TRANSPOSE() {
-  return Register_TRANSPOSE_GENERIC_OPTIMIZED();
-}
-
-}  // namespace builtin
-}  // namespace ops
 }  // namespace tflite

--- a/tensorflow/lite/micro/kernels/transpose_test.cc
+++ b/tensorflow/lite/micro/kernels/transpose_test.cc
@@ -1,0 +1,614 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/kernels/internal/reference/transpose.h"
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/portable_tensor.h"
+#include "tensorflow/lite/micro/kernels/kernel_runner.h"
+#include "tensorflow/lite/micro/micro_utils.h"
+#include "tensorflow/lite/micro/test_helpers.h"
+#include "tensorflow/lite/micro/testing/micro_test.h"
+
+namespace tflite {
+namespace testing {
+namespace {
+
+template <typename T>
+void RunTestPermutation(int num_dims, const int32_t* shape,
+                        const int32_t* perms, T* input, T* input_transposed) {
+  // Count elements and allocate output.
+  int count = 1;
+  for (int i = 0; i < num_dims; i++) {
+    count *= shape[i];
+  }
+
+  // Create the dummy data
+  for (int i = 0; i < count; i++) {
+    input[i] = i;
+  }
+
+  // Make input and output shapes.
+  const RuntimeShape input_shape = RuntimeShape(num_dims, shape);
+  RuntimeShape output_shape(num_dims);
+
+  for (int i = 0; i < num_dims; i++) {
+    output_shape.SetDim(i, shape[perms[i]]);
+  }
+
+  TransposeParams params;
+  params.perm_count = num_dims;
+  for (int i = 0; i < num_dims; ++i) {
+    params.perm[i] = perms[i];
+  }
+
+  reference_ops::Transpose<T>(params, input_shape, input, output_shape,
+                              input_transposed);
+}
+
+template <typename T>
+TfLiteStatus InvokeTranspose(TfLiteTensor* tensors, int tensors_size,
+                             T* output_data, int output_length,
+                             TransposeParams* params) {
+  int inputs_array_data[] = {2, 0, 1};
+  TfLiteIntArray* inputs_array = IntArrayFromInts(inputs_array_data);
+  int outputs_array_data[] = {1, 2};
+  TfLiteIntArray* outputs_array = IntArrayFromInts(outputs_array_data);
+
+  const TfLiteRegistration registration = Register_TRANSPOSE();
+  micro::KernelRunner runner(registration, tensors, tensors_size, inputs_array,
+                             outputs_array, reinterpret_cast<void*>(params));
+
+  const char* init_data = reinterpret_cast<const char*>(params);
+  TfLiteStatus status = runner.InitAndPrepare(init_data);
+  if (status != kTfLiteOk) {
+    return status;
+  }
+  return runner.Invoke();
+}
+
+template <typename T>
+TfLiteStatus ValidateTranspose(TfLiteTensor* tensors, int tensors_size,
+                               const T* expected_output_data, T* output_data,
+                               int output_length,
+                               tflite::TransposeParams* params,
+                               float tolerance = 1e-5) {
+  TfLiteStatus status = InvokeTranspose(tensors, tensors_size, output_data,
+                                        output_length, params);
+  if (status != kTfLiteOk) {
+    return status;
+  }
+
+  for (int i = 0; i < output_length; ++i) {
+    TF_LITE_MICRO_EXPECT_EQ(expected_output_data[i], output_data[i]);
+  }
+  return kTfLiteOk;
+}
+
+template <typename T>
+void TestTranspose(const int* input_dims_data, T* input_data,
+                   const int* output_dims_data, const T* expected_output_data,
+                   T* output_data, TransposeParams* params) {
+  TfLiteIntArray* input_dims = IntArrayFromInts(input_dims_data);
+  TfLiteIntArray* output_dims = IntArrayFromInts(output_dims_data);
+  const int input_size = ElementCount(*input_dims);
+  for (int i = 0; i < input_size; i++) {
+    input_data[i] = i;
+  }
+
+  for (int i = 0; i < input_dims->size; i++) {
+    output_dims->data[i] = input_dims->data[params->perm[i]];
+  }
+
+  const int perm_dims_data[] = {1, params->perm_count};
+  TfLiteIntArray* perm_dims = IntArrayFromInts(perm_dims_data);
+  const int output_dims_count = ElementCount(*output_dims);
+  constexpr int inputs_size = 2;
+  constexpr int outputs_size = 1;
+  constexpr int tensors_size = inputs_size + outputs_size;
+  TfLiteTensor tensors[tensors_size] = {
+      CreateTensor(input_data, input_dims),
+      CreateTensor(params->perm, perm_dims),
+      CreateTensor(output_data, output_dims),
+  };
+
+  TF_LITE_MICRO_EXPECT_EQ(
+      kTfLiteOk, ValidateTranspose(tensors, tensors_size, expected_output_data,
+                                   output_data, output_dims_count, params));
+}
+
+}  // namespace
+}  // namespace testing
+}  // namespace tflite
+
+TF_LITE_MICRO_TESTS_BEGIN
+
+TF_LITE_MICRO_TEST(1D) {
+  const int input_dims_data[] = {1, 3};
+  const int output_dims_data[] = {1, 3};
+
+  int8_t input_data[3];
+  int8_t output_data[3];
+  const int8_t expected_output_data[] = {0, 1, 2};
+
+  tflite::TransposeParams params = {1, {0}};
+
+  tflite::testing::TestTranspose(input_dims_data, input_data, output_dims_data,
+                                 expected_output_data, output_data, &params);
+}
+
+TF_LITE_MICRO_TEST(2DPerm1) {
+  const int input_dims_data[] = {2, 3, 2};
+  const int output_dims_data[] = {2, 3, 2};
+
+  int8_t input_data[6];
+  int8_t output_data[6];
+  const int8_t expected_output_data[] = {0, 2, 4, 1, 3, 5};
+
+  tflite::TransposeParams params = {2, {1, 0}};
+
+  tflite::testing::TestTranspose(input_dims_data, input_data, output_dims_data,
+                                 expected_output_data, output_data, &params);
+}
+
+TF_LITE_MICRO_TEST(2D4x4KernelLeftOverRightSide) {
+  const int input_dims_data[] = {2, 4, 6};
+  const int output_dims_data[] = {2, 4, 6};
+
+  int8_t input_data[24];
+  int8_t output_data[24];
+  const int8_t expected_output_data[] = {0, 6,  12, 18, 1, 7,  13, 19,
+                                         2, 8,  14, 20, 3, 9,  15, 21,
+                                         4, 10, 16, 22, 5, 11, 17, 23};
+
+  tflite::TransposeParams params = {2, {1, 0}};
+
+  tflite::testing::TestTranspose(input_dims_data, input_data, output_dims_data,
+                                 expected_output_data, output_data, &params);
+}
+
+TF_LITE_MICRO_TEST(2D4x4KernelLeftOverBottomSide) {
+  const int input_dims_data[] = {2, 6, 4};
+  const int output_dims_data[] = {2, 4, 6};
+
+  int8_t input_data[24];
+  int8_t output_data[24];
+  const int8_t expected_output_data[] = {0,  4,  8,  12, 16, 20, 1,  5,
+                                         9,  13, 17, 21, 2,  6,  10, 14,
+                                         18, 22, 3,  7,  11, 15, 19, 23};
+
+  tflite::TransposeParams params = {2, {1, 0}};
+
+  tflite::testing::TestTranspose(input_dims_data, input_data, output_dims_data,
+                                 expected_output_data, output_data, &params);
+}
+
+TF_LITE_MICRO_TEST(3D) {
+  const int input_dims_data[] = {3, 2, 3, 4};
+  const int output_dims_data[] = {3, 2, 3, 4};
+
+  int8_t input_data[24];
+  int8_t output_data[24];
+  const int8_t expected_output_data[] = {0,  4,  8,  12, 16, 20, 1,  5,
+                                         9,  13, 17, 21, 2,  6,  10, 14,
+                                         18, 22, 3,  7,  11, 15, 19, 23};
+
+  tflite::TransposeParams params = {3, {2, 0, 1}};
+
+  tflite::testing::TestTranspose(input_dims_data, input_data, output_dims_data,
+                                 expected_output_data, output_data, &params);
+}
+
+TF_LITE_MICRO_TEST(1DNotShrinked) {
+  const int input_dims_data[] = {1, 1};
+  const int output_dims_data[] = {1, 1};
+
+  float input_data[1];
+  float output_data[1];
+  const float expected_output_data[] = {0};
+
+  tflite::TransposeParams params = {1, {0}};
+
+  tflite::testing::TestTranspose(input_dims_data, input_data, output_dims_data,
+                                 expected_output_data, output_data, &params);
+}
+
+TF_LITE_MICRO_TEST(2DShrinkedOneTime) {
+  const int input_dims_data[] = {2, 2, 1};
+  const int output_dims_data[] = {2, 2, 1};
+
+  float input_data[2];
+  float output_data[2];
+  const float expected_output_data[] = {0, 1};
+
+  tflite::TransposeParams params = {2, {1, 0}};
+
+  tflite::testing::TestTranspose(input_dims_data, input_data, output_dims_data,
+                                 expected_output_data, output_data, &params);
+}
+
+TF_LITE_MICRO_TEST(2DShrinkedTwoTimes) {
+  const int input_dims_data[] = {2, 1, 1};
+  const int output_dims_data[] = {2, 1, 1};
+
+  float input_data[1];
+  float output_data[1];
+  const float expected_output_data[] = {0};
+
+  tflite::TransposeParams params = {2, {1, 0}};
+
+  tflite::testing::TestTranspose(input_dims_data, input_data, output_dims_data,
+                                 expected_output_data, output_data, &params);
+}
+
+TF_LITE_MICRO_TEST(3DShrinkedOneTime) {
+  const int input_dims_data[] = {3, 2, 1, 3};
+  const int output_dims_data[] = {3, 2, 1, 3};
+
+  float input_data[6];
+  float output_data[6];
+  const float expected_output_data[] = {0, 1, 2, 3, 4, 5};
+
+  tflite::TransposeParams params = {3, {0, 2, 1}};
+
+  tflite::testing::TestTranspose(input_dims_data, input_data, output_dims_data,
+                                 expected_output_data, output_data, &params);
+}
+
+TF_LITE_MICRO_TEST(3DShrinkedTwoTimes) {
+  const int input_dims_data[] = {3, 1, 1, 3};
+  const int output_dims_data[] = {3, 1, 1, 3};
+
+  float input_data[3];
+  float output_data[3];
+  const float expected_output_data[] = {0, 1, 2};
+
+  tflite::TransposeParams params = {3, {1, 2, 0}};
+
+  tflite::testing::TestTranspose(input_dims_data, input_data, output_dims_data,
+                                 expected_output_data, output_data, &params);
+}
+
+TF_LITE_MICRO_TEST(3DShrinkedAll) {
+  const int input_dims_data[] = {3, 1, 1, 1};
+  const int output_dims_data[] = {3, 1, 1, 1};
+
+  float input_data[1];
+  float output_data[1];
+  const float expected_output_data[] = {0};
+
+  tflite::TransposeParams params = {3, {1, 2, 0}};
+
+  tflite::testing::TestTranspose(input_dims_data, input_data, output_dims_data,
+                                 expected_output_data, output_data, &params);
+}
+
+TF_LITE_MICRO_TEST(4DShrinkedOneTimes) {
+  const int input_dims_data[] = {4, 2, 2, 3, 1};
+  const int output_dims_data[] = {4, 2, 2, 3, 1};
+
+  float input_data[12];
+  float output_data[12];
+  const float expected_output_data[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+
+  tflite::TransposeParams params = {4, {3, 0, 1, 2}};
+
+  tflite::testing::TestTranspose(input_dims_data, input_data, output_dims_data,
+                                 expected_output_data, output_data, &params);
+}
+
+TF_LITE_MICRO_TEST(4DShrinkedTwoTimes) {
+  const int input_dims_data[] = {4, 2, 1, 3, 1};
+  const int output_dims_data[] = {4, 2, 1, 3, 1};
+
+  float input_data[6];
+  float output_data[6];
+  const float expected_output_data[] = {0, 1, 2, 3, 4, 5};
+
+  tflite::TransposeParams params = {4, {0, 3, 1, 2}};
+
+  tflite::testing::TestTranspose(input_dims_data, input_data, output_dims_data,
+                                 expected_output_data, output_data, &params);
+}
+
+TF_LITE_MICRO_TEST(4DShrinkedThreeTimes) {
+  const int input_dims_data[] = {4, 2, 1, 1, 1};
+  const int output_dims_data[] = {4, 2, 1, 1, 1};
+
+  float input_data[2];
+  float output_data[2];
+  const float expected_output_data[] = {0, 1};
+
+  tflite::TransposeParams params = {4, {3, 2, 1, 0}};
+
+  tflite::testing::TestTranspose(input_dims_data, input_data, output_dims_data,
+                                 expected_output_data, output_data, &params);
+}
+
+TF_LITE_MICRO_TEST(4DShrinkedFourTimes) {
+  const int input_dims_data[] = {4, 1, 1, 1, 1};
+  const int output_dims_data[] = {4, 1, 1, 1, 1};
+
+  float input_data[1];
+  float output_data[1];
+  const float expected_output_data[] = {0};
+
+  tflite::TransposeParams params = {4, {2, 3, 1, 0}};
+
+  tflite::testing::TestTranspose(input_dims_data, input_data, output_dims_data,
+                                 expected_output_data, output_data, &params);
+}
+
+TF_LITE_MICRO_TEST(3DFlatten) {
+  const int input_dims_data[] = {3, 2, 2, 3};
+  const int output_dims_data[] = {3, 2, 2, 3};
+
+  float input_data[12];
+  float output_data[12];
+  const float expected_output_data[] = {0, 3, 1, 4, 2, 5, 6, 9, 7, 10, 8, 11};
+
+  tflite::TransposeParams params = {3, {0, 2, 1}};
+
+  tflite::testing::TestTranspose(input_dims_data, input_data, output_dims_data,
+                                 expected_output_data, output_data, &params);
+}
+
+TF_LITE_MICRO_TEST(4DFlatten) {
+  const int input_dims_data[] = {4, 2, 2, 2, 2};
+  const int output_dims_data[] = {4, 2, 2, 2, 2};
+
+  float input_data[16];
+  float output_data[16];
+  const float expected_output_data[] = {0, 2,  1, 3,  4,  6,  5,  7,
+                                        8, 10, 9, 11, 12, 14, 13, 15};
+
+  tflite::TransposeParams params = {4, {0, 1, 3, 2}};
+
+  tflite::testing::TestTranspose(input_dims_data, input_data, output_dims_data,
+                                 expected_output_data, output_data, &params);
+}
+
+TF_LITE_MICRO_TEST(4DFlattenTwo) {
+  const int input_dims_data[] = {4, 2, 2, 2, 2};
+  const int output_dims_data[] = {4, 2, 2, 2, 2};
+
+  float input_data[16];
+  float output_data[16];
+  const float expected_output_data[] = {0, 4,  1, 5,  2,  6,  3,  7,
+                                        8, 12, 9, 13, 10, 14, 11, 15};
+
+  tflite::TransposeParams params = {4, {0, 2, 3, 1}};
+
+  tflite::testing::TestTranspose(input_dims_data, input_data, output_dims_data,
+                                 expected_output_data, output_data, &params);
+}
+
+TF_LITE_MICRO_TEST(3DDividedIntoTwo2DsOne) {
+  float input_data[24];
+  float expected_output_data[24];
+  int32_t shape[] = {2, 3, 4};
+  int32_t perms[] = {1, 2, 0};
+  tflite::testing::RunTestPermutation(3, shape, perms, input_data,
+                                      expected_output_data);
+  const int input_dims_data[] = {3, 2, 3, 4};
+  const int output_dims_data[] = {3, 2, 3, 4};
+
+  float output_data[24];
+
+  tflite::TransposeParams params = {3, {1, 2, 0}};
+
+  tflite::testing::TestTranspose(input_dims_data, input_data, output_dims_data,
+                                 expected_output_data, output_data, &params);
+}
+
+TF_LITE_MICRO_TEST(3DDividedIntoTwo2DsTwo) {
+  float input_data[24];
+  float expected_output_data[24];
+  int32_t shape[] = {2, 3, 4};
+  int32_t perms[] = {2, 0, 1};
+  tflite::testing::RunTestPermutation(3, shape, perms, input_data,
+                                      expected_output_data);
+  const int input_dims_data[] = {3, 2, 3, 4};
+  const int output_dims_data[] = {3, 2, 3, 4};
+
+  float output_data[24];
+
+  tflite::TransposeParams params = {3, {2, 0, 1}};
+
+  tflite::testing::TestTranspose(input_dims_data, input_data, output_dims_data,
+                                 expected_output_data, output_data, &params);
+}
+
+TF_LITE_MICRO_TEST(4DDividedIntoTwo2DsOne) {
+  int32_t shape[] = {2, 3, 4, 2};
+  int32_t perms[] = {1, 2, 3, 0};
+  float input_data[48];
+  float expected_output_data[48];
+  tflite::testing::RunTestPermutation(4, shape, perms, input_data,
+                                      expected_output_data);
+  const int input_dims_data[] = {4, 2, 3, 4, 2};
+  const int output_dims_data[] = {4, 2, 3, 4, 2};
+
+  float output_data[48];
+
+  tflite::TransposeParams params = {4, {1, 2, 3, 0}};
+
+  tflite::testing::TestTranspose(input_dims_data, input_data, output_dims_data,
+                                 expected_output_data, output_data, &params);
+}
+TF_LITE_MICRO_TEST(4DDividedIntoTwo2DsTwo) {
+  int32_t shape[] = {2, 3, 4, 2};
+  int32_t perms[] = {2, 3, 0, 1};
+  float input_data[48];
+  float expected_output_data[48];
+  tflite::testing::RunTestPermutation(4, shape, perms, input_data,
+                                      expected_output_data);
+  const int input_dims_data[] = {4, 2, 3, 4, 2};
+  const int output_dims_data[] = {4, 2, 3, 4, 2};
+
+  float output_data[48];
+
+  tflite::TransposeParams params = {4, {2, 3, 0, 1}};
+
+  tflite::testing::TestTranspose(input_dims_data, input_data, output_dims_data,
+                                 expected_output_data, output_data, &params);
+}
+
+TF_LITE_MICRO_TEST(4DDividedIntoTwo2DsThree) {
+  int32_t shape[] = {2, 3, 4, 2};
+  int32_t perms[] = {3, 0, 1, 2};
+  float input_data[48];
+  float expected_output_data[48];
+  tflite::testing::RunTestPermutation(4, shape, perms, input_data,
+                                      expected_output_data);
+  const int input_dims_data[] = {4, 2, 3, 4, 2};
+  const int output_dims_data[] = {4, 2, 3, 4, 2};
+
+  float output_data[48];
+
+  tflite::TransposeParams params = {4, {3, 0, 1, 2}};
+
+  tflite::testing::TestTranspose(input_dims_data, input_data, output_dims_data,
+                                 expected_output_data, output_data, &params);
+}
+
+TF_LITE_MICRO_TEST(5DDividedIntoTwo2DsOne) {
+  int32_t shape[] = {2, 3, 2, 2, 2};
+  int32_t perms[] = {1, 4, 2, 3, 0};
+  float input_data[48];
+  float expected_output_data[48];
+  tflite::testing::RunTestPermutation(5, shape, perms, input_data,
+                                      expected_output_data);
+  const int input_dims_data[] = {5, 2, 3, 2, 2, 2};
+  const int output_dims_data[] = {5, 2, 3, 2, 2, 2};
+
+  float output_data[48];
+
+  tflite::TransposeParams params = {5, {1, 4, 2, 3, 0}};
+
+  tflite::testing::TestTranspose(input_dims_data, input_data, output_dims_data,
+                                 expected_output_data, output_data, &params);
+}
+
+TF_LITE_MICRO_TEST(5DDividedIntoTwo2DsTwo) {
+  int32_t shape[] = {2, 3, 2, 2, 2};
+  int32_t perms[] = {2, 3, 0, 4, 1};
+  float input_data[48];
+  float expected_output_data[48];
+  tflite::testing::RunTestPermutation(5, shape, perms, input_data,
+                                      expected_output_data);
+  const int input_dims_data[] = {5, 2, 3, 2, 2, 2};
+  const int output_dims_data[] = {5, 2, 3, 2, 2, 2};
+
+  float output_data[48];
+
+  tflite::TransposeParams params = {5, {2, 3, 0, 4, 1}};
+
+  tflite::testing::TestTranspose(input_dims_data, input_data, output_dims_data,
+                                 expected_output_data, output_data, &params);
+}
+
+TF_LITE_MICRO_TEST(5DDividedIntoTwo2DsThree) {
+  int32_t shape[] = {2, 3, 2, 2, 2};
+  int32_t perms[] = {3, 0, 4, 1, 2};
+  float input_data[48];
+  float expected_output_data[48];
+  tflite::testing::RunTestPermutation(5, shape, perms, input_data,
+                                      expected_output_data);
+  const int input_dims_data[] = {5, 2, 3, 2, 2, 2};
+  const int output_dims_data[] = {5, 2, 3, 2, 2, 2};
+
+  float output_data[48];
+
+  tflite::TransposeParams params = {5, {3, 0, 4, 1, 2}};
+
+  tflite::testing::TestTranspose(input_dims_data, input_data, output_dims_data,
+                                 expected_output_data, output_data, &params);
+}
+
+TF_LITE_MICRO_TEST(SimpleTestNoReorder) {
+  const int input_dims_data[] = {4, 1, 2, 3, 1};
+  const int output_dims_data[] = {4, 1, 2, 3, 1};
+
+  float input_data[6];
+  float output_data[6];
+  const float expected_output_data[] = {0, 1, 2, 3, 4, 5};
+
+  tflite::TransposeParams params = {4, {0, 1, 2, 3}};
+
+  tflite::testing::TestTranspose(input_dims_data, input_data, output_dims_data,
+                                 expected_output_data, output_data, &params);
+}
+
+TF_LITE_MICRO_TEST(SimpleTestWithReorder) {
+  const int input_dims_data[] = {4, 1, 2, 3, 1};
+  const int output_dims_data[] = {4, 1, 2, 3, 1};
+
+  float input_data[6];
+  float output_data[6];
+  const float expected_output_data[] = {0, 3, 1, 4, 2, 5};
+
+  tflite::TransposeParams params = {4, {2, 1, 3, 0}};
+
+  tflite::testing::TestTranspose(input_dims_data, input_data, output_dims_data,
+                                 expected_output_data, output_data, &params);
+}
+
+TF_LITE_MICRO_TEST(ComplexTestWithReorder) {
+  const int input_dims_data[] = {4, 2, 3, 4, 5};
+  const int output_dims_data[] = {4, 2, 3, 4, 5};
+
+  float input_data[120];
+  float output_data[120];
+  const float expected_output_data[] = {
+      0,  1,  2,  3,  4,  20, 21, 22, 23, 24, 40,  41,  42,  43,  44,
+      60, 61, 62, 63, 64, 80, 81, 82, 83, 84, 100, 101, 102, 103, 104,
+      5,  6,  7,  8,  9,  25, 26, 27, 28, 29, 45,  46,  47,  48,  49,
+      65, 66, 67, 68, 69, 85, 86, 87, 88, 89, 105, 106, 107, 108, 109,
+      10, 11, 12, 13, 14, 30, 31, 32, 33, 34, 50,  51,  52,  53,  54,
+      70, 71, 72, 73, 74, 90, 91, 92, 93, 94, 110, 111, 112, 113, 114,
+      15, 16, 17, 18, 19, 35, 36, 37, 38, 39, 55,  56,  57,  58,  59,
+      75, 76, 77, 78, 79, 95, 96, 97, 98, 99, 115, 116, 117, 118, 119};
+
+  tflite::TransposeParams params = {4, {2, 0, 1, 3}};
+
+  tflite::testing::TestTranspose(input_dims_data, input_data, output_dims_data,
+                                 expected_output_data, output_data, &params);
+}
+
+TF_LITE_MICRO_TEST(Complex5DTestWithReorder) {
+  const int input_dims_data[] = {5, 2, 3, 2, 2, 5};
+  const int output_dims_data[] = {5, 2, 3, 2, 2, 5};
+
+  float input_data[120];
+  float output_data[120];
+  const float expected_output_data[] = {
+      0,  5,  1,  6,  2,  7,   3,   8,   4,   9,   20,  25,  21,  26,  22,
+      27, 23, 28, 24, 29, 40,  45,  41,  46,  42,  47,  43,  48,  44,  49,
+      60, 65, 61, 66, 62, 67,  63,  68,  64,  69,  80,  85,  81,  86,  82,
+      87, 83, 88, 84, 89, 100, 105, 101, 106, 102, 107, 103, 108, 104, 109,
+      10, 15, 11, 16, 12, 17,  13,  18,  14,  19,  30,  35,  31,  36,  32,
+      37, 33, 38, 34, 39, 50,  55,  51,  56,  52,  57,  53,  58,  54,  59,
+      70, 75, 71, 76, 72, 77,  73,  78,  74,  79,  90,  95,  91,  96,  92,
+      97, 93, 98, 94, 99, 110, 115, 111, 116, 112, 117, 113, 118, 114, 119};
+
+  tflite::TransposeParams params = {5, {2, 0, 1, 4, 3}};
+
+  tflite::testing::TestTranspose(input_dims_data, input_data, output_dims_data,
+                                 expected_output_data, output_data, &params);
+}
+
+TF_LITE_MICRO_TESTS_END

--- a/tensorflow/lite/micro/micro_mutable_op_resolver.h
+++ b/tensorflow/lite/micro/micro_mutable_op_resolver.h
@@ -496,6 +496,11 @@ class MicroMutableOpResolver : public MicroOpResolver {
                       tflite::Register_TRANSPOSE_CONV(), ParseTransposeConv);
   }
 
+  TfLiteStatus AddTranspose() {
+    return AddBuiltin(BuiltinOperator_TRANSPOSE, Register_TRANSPOSE(),
+                      ParseTranspose);
+  }
+
   TfLiteStatus AddUnpack() {
     return AddBuiltin(BuiltinOperator_UNPACK,
                       tflite::ops::micro::Register_UNPACK(), ParseUnpack);

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -313,6 +313,7 @@ tensorflow/lite/micro/kernels/strided_slice_test.cc \
 tensorflow/lite/micro/kernels/sub_test.cc \
 tensorflow/lite/micro/kernels/svdf_test.cc \
 tensorflow/lite/micro/kernels/tanh_test.cc \
+tensorflow/lite/micro/kernels/transpose_test.cc \
 tensorflow/lite/micro/kernels/transpose_conv_test.cc \
 tensorflow/lite/micro/kernels/unpack_test.cc \
 tensorflow/lite/micro/kernels/zeros_like_test.cc \
@@ -384,6 +385,7 @@ tensorflow/lite/micro/kernels/sub.cc \
 tensorflow/lite/micro/kernels/svdf.cc \
 tensorflow/lite/micro/kernels/svdf_common.cc \
 tensorflow/lite/micro/kernels/tanh.cc \
+tensorflow/lite/micro/kernels/transpose.cc \
 tensorflow/lite/micro/kernels/transpose_conv.cc \
 tensorflow/lite/micro/kernels/unpack.cc \
 tensorflow/lite/micro/kernels/zeros_like.cc
@@ -478,6 +480,7 @@ tensorflow/lite/kernels/internal/reference/sub.h \
 tensorflow/lite/kernels/internal/reference/logistic.h \
 tensorflow/lite/kernels/internal/reference/strided_slice.h \
 tensorflow/lite/kernels/internal/reference/tanh.h \
+tensorflow/lite/kernels/internal/reference/transpose.h \
 tensorflow/lite/kernels/internal/reference/transpose_conv.h \
 tensorflow/lite/kernels/internal/cppmath.h \
 tensorflow/lite/kernels/internal/max.h \


### PR DESCRIPTION
This PR modifies the transpose kernel to make it run in micro, ports the tests and adds the kernel to the micro build.

This is PR 4/4 in delivering #45695