### PR TITLE
Lr workaround for wrapped  optimizers

### DIFF
--- a/tensorflow/python/keras/mixed_precision/loss_scale_optimizer.py
+++ b/tensorflow/python/keras/mixed_precision/loss_scale_optimizer.py
@@ -890,9 +890,12 @@ class LossScaleOptimizer(_DelegatingTrackableMixin, optimizer_v2.OptimizerV2):
 
       # Delegate hyperparameter accesses to inner optimizer.
       if name == 'lr':
-        name = 'learning_rate'
+        name = 'learning_rate'        
       if name in self._optimizer._hyper:
         return self._optimizer._get_hyper(name)
+      elif hasattr(self._optimizer,"_optimizer"):
+        if name in self._optimizer._optimizer._hyper:
+          return self._optimizer._optimizer._get_hyper(name)
       raise e
 
   def __dir__(self):

--- a/tensorflow/python/keras/mixed_precision/loss_scale_optimizer.py
+++ b/tensorflow/python/keras/mixed_precision/loss_scale_optimizer.py
@@ -890,7 +890,7 @@ class LossScaleOptimizer(_DelegatingTrackableMixin, optimizer_v2.OptimizerV2):
 
       # Delegate hyperparameter accesses to inner optimizer.
       if name == 'lr':
-        name = 'learning_rate'        
+        name = 'learning_rate'
       if name in self._optimizer._hyper:
         return self._optimizer._get_hyper(name)
       elif hasattr(self._optimizer,"_optimizer"):

--- a/tensorflow/python/keras/mixed_precision/loss_scale_optimizer.py
+++ b/tensorflow/python/keras/mixed_precision/loss_scale_optimizer.py
@@ -893,7 +893,7 @@ class LossScaleOptimizer(_DelegatingTrackableMixin, optimizer_v2.OptimizerV2):
         name = 'learning_rate'
       if name in self._optimizer._hyper:
         return self._optimizer._get_hyper(name)
-      elif hasattr(self._optimizer,"_optimizer"):
+      elif hasattr(self._optimizer, "_optimizer"):
         if name in self._optimizer._optimizer._hyper:
           return self._optimizer._optimizer._get_hyper(name)
       raise e


### PR DESCRIPTION
Investigate side effects in CI tests with a Workaround for mixed precision hyper access with wrapped optimizers.

See:
https://github.com/tensorflow/addons/pull/2404
