### PR TITLE
TFLM: Reduce memory usage for some types

### DIFF
--- a/tensorflow/lite/kernels/kernel_util.cc
+++ b/tensorflow/lite/kernels/kernel_util.cc
@@ -234,23 +234,25 @@ TfLiteStatus PopulateConvolutionQuantizationParams(
         filter->dims->data[affine_quantization->quantized_dimension]);
   }
 
-  // Populate multiplier and shift using affine quantization.
-  const float input_scale = input->params.scale;
-  const float output_scale = output->params.scale;
-  const float* filter_scales = affine_quantization->scale->data;
-  for (int i = 0; i < num_channels; ++i) {
-    // If per-tensor quantization parameter is specified, broadcast it along the
-    // quantization dimension (channels_out).
-    const float scale = is_per_channel ? filter_scales[i] : filter_scales[0];
-    const double filter_scale = static_cast<double>(scale);
-    const double effective_output_scale = static_cast<double>(input_scale) *
-                                          filter_scale /
-                                          static_cast<double>(output_scale);
-    int32_t significand;
-    int channel_shift;
-    QuantizeMultiplier(effective_output_scale, &significand, &channel_shift);
-    per_channel_multiplier[i] = significand;
-    per_channel_shift[i] = channel_shift;
+  if (per_channel_multiplier != nullptr && per_channel_shift != nullptr) {
+    // Populate multiplier and shift using affine quantization.
+    const float input_scale = input->params.scale;
+    const float output_scale = output->params.scale;
+    const float* filter_scales = affine_quantization->scale->data;
+    for (int i = 0; i < num_channels; ++i) {
+      // If per-tensor quantization parameter is specified, broadcast it along
+      // the quantization dimension (channels_out).
+      const float scale = is_per_channel ? filter_scales[i] : filter_scales[0];
+      const double filter_scale = static_cast<double>(scale);
+      const double effective_output_scale = static_cast<double>(input_scale) *
+                                            filter_scale /
+                                            static_cast<double>(output_scale);
+      int32_t significand;
+      int channel_shift;
+      QuantizeMultiplier(effective_output_scale, &significand, &channel_shift);
+      per_channel_multiplier[i] = significand;
+      per_channel_shift[i] = channel_shift;
+    }
   }
 
   // Populate scalar quantization parameters.

--- a/tensorflow/lite/micro/kernels/cmsis_nn/depthwise_conv.cc
+++ b/tensorflow/lite/micro/kernels/cmsis_nn/depthwise_conv.cc
@@ -85,15 +85,21 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
                       affine_quantization->zero_point->size);
   }
 
-  // Allocate memory for per-channel quantization parameters
-  const int num_channels = filter->dims->data[kDepthwiseConvQuantizedDimension];
+  if (input->type == kTfLiteInt8) {
+    // Allocate memory for per-channel quantization parameters
+    const int num_channels =
+        filter->dims->data[kDepthwiseConvQuantizedDimension];
 
-  data->reference_op_data.per_channel_output_multiplier =
-      reinterpret_cast<int32_t*>(context->AllocatePersistentBuffer(
-          context, num_channels * sizeof(int32_t)));
-  data->reference_op_data.per_channel_output_shift =
-      reinterpret_cast<int32_t*>(context->AllocatePersistentBuffer(
-          context, num_channels * sizeof(int32_t)));
+    data->reference_op_data.per_channel_output_multiplier =
+        reinterpret_cast<int32_t*>(context->AllocatePersistentBuffer(
+            context, num_channels * sizeof(int32_t)));
+    data->reference_op_data.per_channel_output_shift =
+        reinterpret_cast<int32_t*>(context->AllocatePersistentBuffer(
+            context, num_channels * sizeof(int32_t)));
+  } else {
+    data->reference_op_data.per_channel_output_multiplier = nullptr;
+    data->reference_op_data.per_channel_output_shift = nullptr;
+  }
 
   TF_LITE_ENSURE_STATUS(CalculateOpDataDepthwiseConv(
       context, node, params, input_width, input_height, filter_width,


### PR DESCRIPTION
Reducing memory usage for non-int<8> types in conv and depthwise_conv
kernels.

This is a fix for: https://github.com/tensorflow/tensorflow/issues/42883