### PR TITLE
[Intel MKL] update public CI with gcc7

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.cpu-py36
+++ b/tensorflow/tools/ci_build/Dockerfile.cpu-py36
@@ -2,14 +2,6 @@ FROM ubuntu:16.04
 
 LABEL maintainer="Rama Ketineni <rama.ketineni@intel.com>"
 
-ENV http_proxy="http://proxy-us.intel.com:911"
-ENV https_proxy="http://proxy-us.intel.com:912"
-ENV HTTP_PROXY="http://proxy-us.intel.com:911"
-ENV HTTPS_PROXY="http://proxy-us.intel.com:912"
-ENV ftp_proxy="http://proxy-chain.intel.com:911"
-ENV socks_proxy="http://proxy-us.intel.com:1080"
-ENV no_proxy="intel.com,.intel.com,localhost,127.0.0.1"
-
 # Copy and run the install scripts.
 COPY install/*.sh /install/
 RUN /install/install_bootstrap_deb_packages.sh
@@ -32,7 +24,7 @@ RUN python3 -V
 RUN /install/install_bazel.sh
 RUN /install/install_proto3.sh
 RUN /install/install_buildifier.sh
-# RUN /install/install_auditwheel.sh
+RUN /install/install_auditwheel.sh
 RUN /install/install_golang.sh
 # Set up the master bazelrc configuration file.
 COPY install/.bazelrc /etc/bazel.bazelrc

--- a/tensorflow/tools/ci_build/Dockerfile.cpu-py36
+++ b/tensorflow/tools/ci_build/Dockerfile.cpu-py36
@@ -18,13 +18,8 @@ RUN add-apt-repository -y ppa:openjdk-r/ppa && \
 RUN /install/install_deb_packages.sh
 
 # Install gcc 7
-RUN apt-get install -y software-properties-common
-RUN add-apt-repository ppa:ubuntu-toolchain-r/test
-RUN apt update
-RUN apt install g++-7 -y
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 \
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 700 \
                          --slave /usr/bin/g++ g++ /usr/bin/g++-7
-RUN update-alternatives --config gcc
 
 # The following line installs the Python 3.6 cross-compilation toolchain.
 RUN /install/install_pi_python3x_toolchain.sh "3.6"

--- a/tensorflow/tools/ci_build/Dockerfile.cpu-py36
+++ b/tensorflow/tools/ci_build/Dockerfile.cpu-py36
@@ -18,6 +18,7 @@ RUN add-apt-repository -y ppa:openjdk-r/ppa && \
 RUN /install/install_deb_packages.sh
 
 # Install gcc 7
+RUN apt install g++-7 -y
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 700 \
                          --slave /usr/bin/g++ g++ /usr/bin/g++-7
 

--- a/tensorflow/tools/ci_build/Dockerfile.cpu-py36
+++ b/tensorflow/tools/ci_build/Dockerfile.cpu-py36
@@ -2,6 +2,13 @@ FROM ubuntu:16.04
 
 LABEL maintainer="Rama Ketineni <rama.ketineni@intel.com>"
 
+ENV http_proxy="http://proxy-us.intel.com:911"
+ENV https_proxy="http://proxy-us.intel.com:912"
+ENV HTTP_PROXY="http://proxy-us.intel.com:911"
+ENV HTTPS_PROXY="http://proxy-us.intel.com:912"
+ENV ftp_proxy="http://proxy-chain.intel.com:911"
+ENV socks_proxy="http://proxy-us.intel.com:1080"
+ENV no_proxy="intel.com,.intel.com,localhost,127.0.0.1"
 
 # Copy and run the install scripts.
 COPY install/*.sh /install/
@@ -9,6 +16,15 @@ RUN /install/install_bootstrap_deb_packages.sh
 RUN add-apt-repository -y ppa:openjdk-r/ppa && \
    add-apt-repository -y ppa:george-edison55/cmake-3.x
 RUN /install/install_deb_packages.sh
+
+# Install gcc 7
+RUN apt-get install -y software-properties-common
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test
+RUN apt update
+RUN apt install g++-7 -y
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 \
+                         --slave /usr/bin/g++ g++ /usr/bin/g++-7
+RUN update-alternatives --config gcc
 
 # The following line installs the Python 3.6 cross-compilation toolchain.
 RUN /install/install_pi_python3x_toolchain.sh "3.6"

--- a/tensorflow/tools/ci_build/Dockerfile.cpu-py36
+++ b/tensorflow/tools/ci_build/Dockerfile.cpu-py36
@@ -18,7 +18,9 @@ RUN add-apt-repository -y ppa:openjdk-r/ppa && \
 RUN /install/install_deb_packages.sh
 
 # Install gcc 7
-RUN apt install g++-7 -y
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test
+RUN apt update
+RUN apt -y install gcc-7 g++-7
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 700 \
                          --slave /usr/bin/g++ g++ /usr/bin/g++-7
 

--- a/tensorflow/tools/ci_build/Dockerfile.cpu-py36
+++ b/tensorflow/tools/ci_build/Dockerfile.cpu-py36
@@ -34,7 +34,7 @@ RUN python3 -V
 RUN /install/install_bazel.sh
 RUN /install/install_proto3.sh
 RUN /install/install_buildifier.sh
-RUN /install/install_auditwheel.sh
+# RUN /install/install_auditwheel.sh
 RUN /install/install_golang.sh
 # Set up the master bazelrc configuration file.
 COPY install/.bazelrc /etc/bazel.bazelrc


### PR DESCRIPTION
currently public CI https://tensorflow-ci.intel.com/ running with gcc5, upgrade to use gcc7