### PR TITLE
Fix for issue #47216

### DIFF
--- a/tensorflow/python/keras/engine/base_layer.py
+++ b/tensorflow/python/keras/engine/base_layer.py
@@ -1868,6 +1868,8 @@ class Layer(module.Module, version_utils.LayerVersionSelector):
           'expecting %s weights. Provided weights: %s...' %
           (self.name, len(weights), expected_num_weights, str(weights)[:50]))
 
+    weights = [np.array(item) for item in weights]
+    
     weight_index = 0
     weight_value_tuples = []
     for param in params:


### PR DESCRIPTION
FIX TypeError if set the weights to the current weights via `set_weights, more details in #47216.
This new line improves the versatility of the set_weights() function. Now we can use .get_weights() or .weights of any existing layer to the set_weights() of a new layer to copy the existing weights to the new layer. @chenmoneygithub  I fixed the issue mentioned in #47255 