### PR TITLE
[ROCm] Add NHWC layout support when creating miopenTensorDescriptor for conv filter

### DIFF
--- a/tensorflow/stream_executor/dnn.cc
+++ b/tensorflow/stream_executor/dnn.cc
@@ -226,8 +226,69 @@ std::tuple<int, int, int> GetDimIndices(const DataLayout& layout,
   return std::make_tuple(depth_idx, batch_idx, spatial_idx);
 }
 
+std::tuple<int, int, int> GetDimIndices(const FilterLayout& layout,
+                                        const int data_dims) {
+  int output_idx, input_idx, spatial_idx;
+  switch (layout) {
+    case FilterLayout::kOutputInputYX:
+    case FilterLayout::kOutputInputYX4:
+      input_idx = 1;
+      output_idx = 0;
+      spatial_idx = 2;
+      break;
+
+    case FilterLayout::kOutputYXInput:
+      input_idx = data_dims - 1;
+      output_idx = 0;
+      spatial_idx = 1;
+      break;
+
+    case FilterLayout::kInputYXOutput:
+      input_idx = 0;
+      output_idx = data_dims - 1;
+      spatial_idx = 1;
+      break;
+
+    case FilterLayout::kYXInputOutput:
+      input_idx = data_dims - 2;
+      output_idx = data_dims - 1;
+      spatial_idx = 0;
+      break;
+
+    default:
+      LOG(FATAL) << "Unknown layout " << layout;
+  }
+
+  return std::make_tuple(output_idx, input_idx, spatial_idx);
+}
+
 std::vector<int64> ReorderDims(const std::vector<int64>& input,
                                const DataLayout& from, const DataLayout& to) {
+  if (from == to) return input;
+
+  int d_idx_from, b_idx_from, spatial_idx_from;
+  int d_idx_to, b_idx_to, spatial_idx_to;
+
+  std::tie(d_idx_from, b_idx_from, spatial_idx_from) =
+      GetDimIndices(from, input.size());
+  std::tie(d_idx_to, b_idx_to, spatial_idx_to) =
+      GetDimIndices(to, input.size());
+
+  std::vector<int64> reordered(input.size());
+  reordered[b_idx_to] = input[b_idx_from];
+  reordered[d_idx_to] = input[d_idx_from];
+
+  for (size_t i = 0; i < input.size() - 2;
+       i++, spatial_idx_from++, spatial_idx_to++) {
+    reordered[spatial_idx_to] = input[spatial_idx_from];
+  }
+
+  return reordered;
+}
+
+std::vector<int64> ReorderDims(const std::vector<int64>& input,
+                               const FilterLayout& from,
+                               const FilterLayout& to) {
   if (from == to) return input;
 
   int d_idx_from, b_idx_from, spatial_idx_from;
@@ -473,6 +534,31 @@ int64 FilterDescriptor::ComputeWeightCount() const {
     ret *= input_filter_dims()[i];
   }
   return ret;
+}
+
+std::vector<int64> FilterDescriptor::full_dims(
+    const FilterLayout& layout) const {
+  std::vector<int64> oiyx_dims(ndims() + 2);
+  oiyx_dims[0] = output_feature_map_count();
+  oiyx_dims[1] = input_feature_map_count();
+  std::copy(input_filter_dims().begin(), input_filter_dims().end(),
+            oiyx_dims.begin() + 2);
+  return ReorderDims(oiyx_dims, FilterLayout::kOutputInputYX, layout);
+}
+
+std::vector<int64> FilterDescriptor::full_strides(
+    const FilterLayout& layout) const {
+  if (this->layout() == FilterLayout::kOutputInputYX4) {
+    LOG(FATAL) << "Cannot compute full strides for filter descriptor "
+               << ToString();
+  }
+  std::vector<int64> phys_dims = full_dims(this->layout());
+  std::vector<int64> phys_strides(phys_dims.size());
+  phys_strides[ndims() + 1] = 1;
+  for (int i = ndims(); i >= 0; i--) {
+    phys_strides[i] = phys_strides[i + 1] * phys_dims[i + 1];
+  }
+  return ReorderDims(phys_strides, this->layout(), layout);
 }
 
 TensorDescriptorProto FilterDescriptor::ToProto(DataType data_type) const {

--- a/tensorflow/stream_executor/dnn.cc
+++ b/tensorflow/stream_executor/dnn.cc
@@ -190,94 +190,104 @@ std::string ShortPoolingModeString(PoolingMode mode) {
   return "unknown filter layout";
 }
 
-std::tuple<int, int, int> GetDimIndices(const DataLayout& layout,
-                                        const int data_dims) {
-  int depth_idx, batch_idx, spatial_idx;
+struct ConvDimIndices {
+  union {
+    struct {
+      int depth_idx;
+      int batch_idx;
+      int spatial_idx;
+    } data;
+    struct {
+      int output_idx;
+      int input_idx;
+      int spatial_idx;
+    } filter;
+  };
+};
+
+ConvDimIndices GetDimIndices(const DataLayout& layout, const int data_dims) {
+  ConvDimIndices dim_indices;
   switch (layout) {
     case DataLayout::kYXBatchDepth:
-      depth_idx = data_dims - 1;
-      batch_idx = data_dims - 2;
-      spatial_idx = 0;
+      dim_indices.data.depth_idx = data_dims - 1;
+      dim_indices.data.batch_idx = data_dims - 2;
+      dim_indices.data.spatial_idx = 0;
       break;
 
     case DataLayout::kYXDepthBatch:
-      depth_idx = data_dims - 2;
-      batch_idx = data_dims - 1;
-      spatial_idx = 0;
+      dim_indices.data.depth_idx = data_dims - 2;
+      dim_indices.data.batch_idx = data_dims - 1;
+      dim_indices.data.spatial_idx = 0;
       break;
 
     case DataLayout::kBatchYXDepth:
-      depth_idx = data_dims - 1;
-      batch_idx = 0;
-      spatial_idx = 1;
+      dim_indices.data.depth_idx = data_dims - 1;
+      dim_indices.data.batch_idx = 0;
+      dim_indices.data.spatial_idx = 1;
       break;
 
     case DataLayout::kBatchDepthYX:
     case DataLayout::kBatchDepthYX4:
-      depth_idx = 1;
-      batch_idx = 0;
-      spatial_idx = 2;
+      dim_indices.data.depth_idx = 1;
+      dim_indices.data.batch_idx = 0;
+      dim_indices.data.spatial_idx = 2;
       break;
 
     default:
       LOG(FATAL) << "Unknown layout " << layout;
   }
 
-  return std::make_tuple(depth_idx, batch_idx, spatial_idx);
+  return dim_indices;
 }
 
-std::tuple<int, int, int> GetDimIndices(const FilterLayout& layout,
-                                        const int data_dims) {
-  int output_idx, input_idx, spatial_idx;
+ConvDimIndices GetDimIndices(const FilterLayout& layout, const int data_dims) {
+  ConvDimIndices dim_indices;
   switch (layout) {
     case FilterLayout::kOutputInputYX:
     case FilterLayout::kOutputInputYX4:
-      input_idx = 1;
-      output_idx = 0;
-      spatial_idx = 2;
+      dim_indices.filter.input_idx = 1;
+      dim_indices.filter.output_idx = 0;
+      dim_indices.filter.spatial_idx = 2;
       break;
 
     case FilterLayout::kOutputYXInput:
-      input_idx = data_dims - 1;
-      output_idx = 0;
-      spatial_idx = 1;
+      dim_indices.filter.input_idx = data_dims - 1;
+      dim_indices.filter.output_idx = 0;
+      dim_indices.filter.spatial_idx = 1;
       break;
 
     case FilterLayout::kInputYXOutput:
-      input_idx = 0;
-      output_idx = data_dims - 1;
-      spatial_idx = 1;
+      dim_indices.filter.input_idx = 0;
+      dim_indices.filter.output_idx = data_dims - 1;
+      dim_indices.filter.spatial_idx = 1;
       break;
 
     case FilterLayout::kYXInputOutput:
-      input_idx = data_dims - 2;
-      output_idx = data_dims - 1;
-      spatial_idx = 0;
+      dim_indices.filter.input_idx = data_dims - 2;
+      dim_indices.filter.output_idx = data_dims - 1;
+      dim_indices.filter.spatial_idx = 0;
       break;
 
     default:
       LOG(FATAL) << "Unknown layout " << layout;
   }
 
-  return std::make_tuple(output_idx, input_idx, spatial_idx);
+  return dim_indices;
 }
 
 std::vector<int64> ReorderDims(const std::vector<int64>& input,
                                const DataLayout& from, const DataLayout& to) {
   if (from == to) return input;
 
-  int d_idx_from, b_idx_from, spatial_idx_from;
-  int d_idx_to, b_idx_to, spatial_idx_to;
-
-  std::tie(d_idx_from, b_idx_from, spatial_idx_from) =
-      GetDimIndices(from, input.size());
-  std::tie(d_idx_to, b_idx_to, spatial_idx_to) =
-      GetDimIndices(to, input.size());
+  ConvDimIndices from_indices = GetDimIndices(from, input.size());
+  ConvDimIndices to_indices = GetDimIndices(to, input.size());
 
   std::vector<int64> reordered(input.size());
-  reordered[b_idx_to] = input[b_idx_from];
-  reordered[d_idx_to] = input[d_idx_from];
+  reordered[to_indices.data.batch_idx] = input[from_indices.data.batch_idx];
+  reordered[to_indices.data.depth_idx] = input[from_indices.data.depth_idx];
 
+  int spatial_idx_from = from_indices.data.spatial_idx;
+  int spatial_idx_to = to_indices.data.spatial_idx;
   for (size_t i = 0; i < input.size() - 2;
        i++, spatial_idx_from++, spatial_idx_to++) {
     reordered[spatial_idx_to] = input[spatial_idx_from];
@@ -291,18 +301,16 @@ std::vector<int64> ReorderDims(const std::vector<int64>& input,
                                const FilterLayout& to) {
   if (from == to) return input;
 
-  int d_idx_from, b_idx_from, spatial_idx_from;
-  int d_idx_to, b_idx_to, spatial_idx_to;
-
-  std::tie(d_idx_from, b_idx_from, spatial_idx_from) =
-      GetDimIndices(from, input.size());
-  std::tie(d_idx_to, b_idx_to, spatial_idx_to) =
-      GetDimIndices(to, input.size());
+  ConvDimIndices from_indices = GetDimIndices(from, input.size());
+  ConvDimIndices to_indices = GetDimIndices(to, input.size());
 
   std::vector<int64> reordered(input.size());
-  reordered[b_idx_to] = input[b_idx_from];
-  reordered[d_idx_to] = input[d_idx_from];
+  reordered[to_indices.filter.output_idx] =
+      input[from_indices.filter.output_idx];
+  reordered[to_indices.filter.input_idx] = input[from_indices.filter.input_idx];
 
+  int spatial_idx_from = from_indices.filter.spatial_idx;
+  int spatial_idx_to = to_indices.filter.spatial_idx;
   for (size_t i = 0; i < input.size() - 2;
        i++, spatial_idx_from++, spatial_idx_to++) {
     reordered[spatial_idx_to] = input[spatial_idx_from];

--- a/tensorflow/stream_executor/dnn.h
+++ b/tensorflow/stream_executor/dnn.h
@@ -446,6 +446,14 @@ class FilterDescriptor {
     return AsInt64Slice(tensor_.dimensions()).subspan(2);
   }
 
+  // Full dimensions of the underlying filter,
+  // ordered according to a specific layout.
+  std::vector<int64> full_dims(const FilterLayout& layout) const;
+
+  // Full strides of the underlying filter,
+  // ordered according to a specific layout.
+  std::vector<int64> full_strides(const FilterLayout& layout) const;
+
  private:
   absl::Span<int64> input_filter_dims() {
     return AsInt64Slice(tensor_.mutable_dimensions()).subspan(2);

--- a/tensorflow/stream_executor/rocm/BUILD
+++ b/tensorflow/stream_executor/rocm/BUILD
@@ -266,6 +266,7 @@ cc_library(
         "//tensorflow/stream_executor/lib",
         "//tensorflow/stream_executor/platform",
         "//tensorflow/stream_executor/platform:dso_loader",
+        "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/strings",
         "@local_config_rocm//rocm:rocm_headers",
     ]),

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <functional>
 #include <memory>
 
+#include "absl/algorithm/container.h"
 #include "absl/strings/str_cat.h"
 #include "third_party/eigen3/Eigen/Core"
 #include "rocm/include/miopen/miopen.h"
@@ -761,12 +762,12 @@ class ScopedFilterDescriptor {
             filter_descriptor.full_dims(dnn::FilterLayout::kOutputInputYX);
 
         // MIOpen requires arrays of ints.
-        std::vector<int> strides(nd);
-        std::vector<int> dims(nd);
-        std::transform(strides64.cbegin(), strides64.cend(), strides.begin(),
-                       &CheckedNarrowing<int64, int>);
-        std::transform(dims64.cbegin(), dims64.cend(), dims.begin(),
-                       &CheckedNarrowing<int64, int>);
+        std::vector<int> strides;
+        std::vector<int> dims;
+        absl::c_transform(strides64, std::back_inserter(strides),
+                          &CheckedNarrowing<int64, int>);
+        absl::c_transform(dims64, std::back_inserter(dims),
+                          &CheckedNarrowing<int64, int>);
         status = wrap::miopenSetTensorDescriptor(handle_, elem_type, nd,
                                                  dims.data(), strides.data());
 


### PR DESCRIPTION
This PR has two commits 
1. add code in `rocm_dnn.cc` and `dnn.[h,cc]` to correctly populate the `miopenTensorDescriptor` for the convolution filter for NHWC layout (it currently works only for NCHW layout) ... see commit message for details
2. Remove dead code from `rocm_dnn.cc` w.r.t NHWC layout


--------------------------------------------------


/cc @cheshire @chsigg