### PR TITLE
[ROCm] Updates to account for the removal of $ROCM_PATH/include/hiprand,rocrand dirs

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -69,6 +69,16 @@ RUN apt-get update --allow-insecure-repositories && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# explicitly remove the following subdirs from under $ROCM_PATH/include
+# These dirs will be removed from the ROCm install in a (near) future ROCm release, and 
+# ROCm TF has been updated (via a separate commit in the same PR as this commit) to account
+# for this future change.
+# This explicit removal is required because without it the creation of the "local_config_rocm" repo
+# runs into errors relating to two different copy rules (rocm-include + hiprand-include|rocrand-include)
+# trying to copy a header file to the same location.
+RUN rm -rf ${ROCM_PATH}/include/rocrand ${ROCM_PATH}/include/hiprand
+
+
 # Set up paths
 ENV HCC_HOME=$ROCM_PATH/hcc
 ENV HIP_PATH=$ROCM_PATH/hip

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -69,16 +69,6 @@ RUN apt-get update --allow-insecure-repositories && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# explicitly remove the following subdirs from under $ROCM_PATH/include
-# These dirs will be removed from the ROCm install in a (near) future ROCm release, and 
-# ROCm TF has been updated (via a separate commit in the same PR as this commit) to account
-# for this future change.
-# This explicit removal is required because without it the creation of the "local_config_rocm" repo
-# runs into errors relating to two different copy rules (rocm-include + hiprand-include|rocrand-include)
-# trying to copy a header file to the same location.
-RUN rm -rf ${ROCM_PATH}/include/rocrand ${ROCM_PATH}/include/hiprand
-
-
 # Set up paths
 ENV HCC_HOME=$ROCM_PATH/hcc
 ENV HIP_PATH=$ROCM_PATH/hip

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -572,6 +572,18 @@ def _create_local_rocm_repository(repository_ctx):
         ),
         make_copy_dir_rule(
             repository_ctx,
+            name = "hiprand-include",
+            src_dir = rocm_toolkit_path + "/hiprand/include",
+            out_dir = "rocm/include/hiprand",
+        ),
+        make_copy_dir_rule(
+            repository_ctx,
+            name = "rocrand-include",
+            src_dir = rocm_toolkit_path + "/rocrand/include",
+            out_dir = "rocm/include/rocrand",
+        ),
+        make_copy_dir_rule(
+            repository_ctx,
             name = "hipsparse-include",
             src_dir = rocm_toolkit_path + "/hipsparse/include",
             out_dir = "rocm/include/hipsparse",
@@ -642,7 +654,9 @@ def _create_local_rocm_repository(repository_ctx):
                                 '":rocblas-include",\n' +
                                 '":miopen-include",\n' +
                                 '":rccl-include",\n' +
-                                '":hipsparse-include",' +
+                                '":hiprand-include",\n' +
+                                '":rocrand-include",\n' +
+                                '":hipsparse-include",\n' +
                                 '":rocsolver-include"'),
         },
     )

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -572,18 +572,6 @@ def _create_local_rocm_repository(repository_ctx):
         ),
         make_copy_dir_rule(
             repository_ctx,
-            name = "hiprand-include",
-            src_dir = rocm_toolkit_path + "/hiprand/include",
-            out_dir = "rocm/include/hiprand",
-        ),
-        make_copy_dir_rule(
-            repository_ctx,
-            name = "rocrand-include",
-            src_dir = rocm_toolkit_path + "/rocrand/include",
-            out_dir = "rocm/include/rocrand",
-        ),
-        make_copy_dir_rule(
-            repository_ctx,
             name = "hipsparse-include",
             src_dir = rocm_toolkit_path + "/hipsparse/include",
             out_dir = "rocm/include/hipsparse",
@@ -595,6 +583,38 @@ def _create_local_rocm_repository(repository_ctx):
             out_dir = "rocm/include/rocsolver",
         ),
     ]
+
+    # explicitly copy (into the local_config_rocm repo) the $ROCM_PATH/hiprand/include and
+    # $ROCM_PATH/rocrand/include dirs, only once the softlink to them in $ROCM_PATH/include
+    # dir has been removed. This removal will happen in a near-future ROCm release.
+    hiprand_include = ""
+    hiprand_include_softlink = rocm_config.rocm_toolkit_path + "/include/hiprand"
+    softlink_exists = files_exist(repository_ctx, [hiprand_include_softlink], bash_bin)
+    if not softlink_exists[0]:
+        hiprand_include = '":hiprand-include",\n'
+        copy_rules.append(
+            make_copy_dir_rule(
+                repository_ctx,
+                name = "hiprand-include",
+                src_dir = rocm_toolkit_path + "/hiprand/include",
+                out_dir = "rocm/include/hiprand",
+            )
+        )
+
+    rocrand_include = ""
+    rocrand_include_softlink = rocm_config.rocm_toolkit_path + "/include/rocrand"
+    softlink_exists = files_exist(repository_ctx, [rocrand_include_softlink], bash_bin)
+    if not softlink_exists[0]:
+        rocrand_include = '":rocrand-include",\n'
+        copy_rules.append(
+            make_copy_dir_rule(
+                repository_ctx,
+                name = "rocrand-include",
+                src_dir = rocm_toolkit_path + "/rocrand/include",
+                out_dir = "rocm/include/rocrand",
+            )
+        )
+
 
     rocm_libs = _find_libs(repository_ctx, rocm_config, bash_bin)
     rocm_lib_srcs = []
@@ -622,6 +642,7 @@ def _create_local_rocm_repository(repository_ctx):
             "rocm/bin/" + "clang-offload-bundler",
         ],
     ))
+
 
     # Set up BUILD file for rocm/
     repository_ctx.template(
@@ -654,8 +675,8 @@ def _create_local_rocm_repository(repository_ctx):
                                 '":rocblas-include",\n' +
                                 '":miopen-include",\n' +
                                 '":rccl-include",\n' +
-                                '":hiprand-include",\n' +
-                                '":rocrand-include",\n' +
+                                hiprand_include +
+                                rocrand_include +
                                 '":hipsparse-include",\n' +
                                 '":rocsolver-include"'),
         },


### PR DESCRIPTION
The following dirs (which are soft-links really) will removed in a (near) future ROCm release. This commit updates `rocm_configure.bzl` to account for that change by explicitly copying over the header files (for `local_config_rocm` repo) from the following directories instead
* $ROCM_PATH/hiprand/include
* $ROCM_PATH/rocrand/include

Unfortunately making the above change also breaks the build, if the directories that will be going away, are still present. This is because we end up with two `make_copy_dir_rule`s in `rocm_configure.bzl` that try to write to the same destination dirs

```
ERROR: Traceback (most recent call last):
	File "/root/.cache/bazel/_bazel_root/efb88f6336d9c4a18216fb94287b8d97/external/local_config_rocm/rocm/BUILD", line 1588, column 8, in <toplevel>
		genrule(
Error in genrule: generated file 'rocm/include/hiprand/hiprand.h' in rule 'hiprand-include' conflicts with existing generated file from rule 'rocm-include', defined at /root/.cache/bazel/_bazel_root/efb88f6336d9c4a18216fb94287b8d97/external/local_config_rocm/rocm/BUILD:175:8
```

In order to get around this error, this commit is also updating the `Dockerfile.rocm` to explicitly delete those two dirs from the `$ROCM_PATH/include` dir, immediately after installing ROCm


------------------------------------


@cheshire @chsigg