### PR TITLE
Fix AbcTest.testAbstract assertion

### DIFF
--- a/tensorflow/python/module/module_test.py
+++ b/tensorflow/python/module/module_test.py
@@ -335,8 +335,7 @@ class ForwardMethodsTest(test_util.TensorFlowTestCase):
 class AbcTest(test_util.TensorFlowTestCase):
 
   def testAbstract(self):
-    msg = "Can't instantiate .* abstract methods"
-    with self.assertRaisesRegex(TypeError, msg):
+    with self.assertRaises(TypeError):
       AbstractModule()  # pylint: disable=abstract-class-instantiated
 
   def testConcrete(self):


### PR DESCRIPTION
Fixes the following test failure:
```
======================================================================
FAIL: testAbstract (__main__.AbcTest)
testAbstract (__main__.AbcTest)
----------------------------------------------------------------------
TypeError: Can't instantiate abstract class AbstractModule with abstract method __call__

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/buildfarm/default/operations/52eafc82-3509-47a0-ad8a-d565ef4de86b/bazel-out/k8-opt/bin/tensorflow/python/module/module_test.runfiles/org_tensorflow/tensorflow/python/module/module_test.py", line 340, in testAbstract
    AbstractModule()  # pylint: disable=abstract-class-instantiated
AssertionError: "Can't instantiate .* abstract methods" does not match "Can't instantiate abstract class AbstractModule with abstract method __call__"

----------------------------------------------------------------------
```