### PR TITLE
Fix API compatibility test under Python 3.9

### DIFF
--- a/tensorflow/tools/api/golden/v1/tensorflow.train.-looper-thread.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.train.-looper-thread.pbtxt
@@ -23,10 +23,6 @@ tf_class {
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
-    name: "isAlive"
-    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
-  }
-  member_method {
     name: "isDaemon"
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/lib/python_object_to_proto_visitor.py
+++ b/tensorflow/tools/api/lib/python_object_to_proto_visitor.py
@@ -46,6 +46,7 @@ _CORNER_CASES = {
         'message': {}
     },
     'train.LooperThread': {
+        'isAlive': {},
         'join': {},
         'native_id': {}
     }


### PR DESCRIPTION
Thread.isAlive removed in Py 3.9: https://bugs.python.org/issue37804

Thanks @mdanatg for the pointer.

See https://github.com/tensorflow/tensorflow/issues/44485#issuecomment-789360728 for the context.