### PR TITLE
expose c `env` headers

### DIFF
--- a/tensorflow/c/BUILD
+++ b/tensorflow/c/BUILD
@@ -207,6 +207,7 @@ tf_cuda_library(
             "//tensorflow/core:portable_tensorflow_lib_lite",
         ],
         "//conditions:default": [
+            ":env",
             ":logging",
             ":tf_status",
             ":tf_tensor",


### PR DESCRIPTION
There is one missing line that is needed to expose the `env` header.

I am really sorry for the back and forth.

related to #46302 https://github.com/tensorflow/io/issues/1183

@yongtang @mihaimaruseac 