### PR TITLE
Lower tf.IsFinite.

### DIFF
--- a/tensorflow/compiler/mlir/tensorflow/tests/lower_tf.mlir
+++ b/tensorflow/compiler/mlir/tensorflow/tests/lower_tf.mlir
@@ -96,6 +96,18 @@ func @is_inf(%arg0: tensor<3x4xf32>) -> tensor<3x4xi1> {
   return %0 : tensor<3x4xi1>
 }
 
+// CHECK-LABEL: @is_finite
+func @is_finite(%arg0: tensor<3x4xf32>) -> tensor<3x4xi1> {
+  // CHECK: %[[INF:.*]] = "tf.Const"() {value = dense<0x7F800000> : tensor<f32>} : () -> tensor<f32>
+  // CHECK: %[[EQUAL:.*]] = "tf.Equal"(%arg0, %arg0) {incompatible_shape_error = true} : (tensor<3x4xf32>, tensor<3x4xf32>) -> tensor<3x4xi1>
+  // CHECK: %[[ABS:.*]] = "tf.Abs"(%arg0) : (tensor<3x4xf32>) -> tensor<3x4xf32>
+  // CHECK: %[[NOT_EQUAL:.*]] = "tf.NotEqual"(%2, %0) {incompatible_shape_error = true} : (tensor<3x4xf32>, tensor<f32>) -> tensor<3x4xi1>
+  // CHECK: %[[RESULT:.*]] = "tf.LogicalAnd"(%1, %3) : (tensor<3x4xi1>, tensor<3x4xi1>) -> tensor<3x4xi1>
+  %0 = "tf.IsFinite"(%arg0) : (tensor<3x4xf32>) -> tensor<3x4xi1>
+  // CHECK: return %[[RESULT]]
+  return %0 : tensor<3x4xi1>
+}
+
 // CHECK-LABEL: @is_nan
 func @is_nan(%arg0: tensor<3x4xf32>) -> tensor<3x4xi1> {
   // CHECK: %[[RESULT:.*]] = "tf.NotEqual"(%arg0, %arg0) {incompatible_shape_error = true} : (tensor<3x4xf32>, tensor<3x4xf32>) -> tensor<3x4xi1>

--- a/tensorflow/compiler/mlir/tensorflow/transforms/lower_tf.td
+++ b/tensorflow/compiler/mlir/tensorflow/transforms/lower_tf.td
@@ -196,6 +196,22 @@ def LowerIsNanOp : Pat<(TF_IsNanOp $x),
                         /*incompatible_shape_error*/ConstBoolAttrTrue)>;
 
 //===----------------------------------------------------------------------===//
+// Finite op patterns.
+//===----------------------------------------------------------------------===//
+
+// IsFinite(x) = !IsNan(x) && !IsInf(x) = (x == x) && (abs(x) != inf)
+def LowerIsFiniteOp : Pat<(TF_IsFiniteOp $x),
+                          (TF_LogicalAndOp
+                            (TF_EqualOp
+                              $x,
+                              $x,
+                              /*incompatible_shape_error*/ConstBoolAttrTrue),
+                            (TF_NotEqualOp
+                              (TF_AbsOp $x),
+                              (TF_ConstOp (GetScalarInfOfType $x)),
+                              /*incompatible_shape_error*/ConstBoolAttrTrue))>;
+
+//===----------------------------------------------------------------------===//
 // L2Loss op patterns.
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
Fixes #47361. It allows to use `tf.is_finite` in TFLite without flex. `tf.is_finite` appears in `tf.keras.layers.Softmax` with multi-axes reduction.

/cc @abattery for visibility.