### PR TITLE
Use nn.softmax in keras.activations.softmax

### DIFF
--- a/tensorflow/python/keras/activations.py
+++ b/tensorflow/python/keras/activations.py
@@ -73,12 +73,8 @@ def softmax(x, axis=-1):
       ValueError: In case `dim(x) == 1`.
   """
   rank = x.shape.rank
-  if rank == 2:
-    output = nn.softmax(x)
-  elif rank > 2:
-    e = math_ops.exp(x - math_ops.reduce_max(x, axis=axis, keepdims=True))
-    s = math_ops.reduce_sum(e, axis=axis, keepdims=True)
-    output = e / s
+  if rank > 1:
+    output = nn.softmax(x, axis=axis)
   else:
     raise ValueError('Cannot apply softmax to a tensor that is 1D. '
                      'Received input: %s' % (x,))

--- a/tensorflow/python/keras/activations_test.py
+++ b/tensorflow/python/keras/activations_test.py
@@ -92,6 +92,18 @@ class KerasActivationsTest(test.TestCase, parameterized.TestCase):
     with self.assertRaises(ValueError):
       activations.softmax(x)
 
+  def test_softmax_2d_axis0(self):
+    x = backend.placeholder(ndim=2)
+    f = backend.function([x], [activations.softmax(x, axis=0)])
+    test_values = np.random.random((2, 5))
+
+    result = f([test_values])[0]
+    expected = np.zeros((2, 5))
+    for i in range(5):
+      expected[:, i] = _ref_softmax(test_values[:, i])
+
+    self.assertAllClose(result, expected, rtol=1e-05)
+
   def test_temporal_softmax(self):
     x = backend.placeholder(shape=(2, 2, 3))
     f = backend.function([x], [activations.softmax(x)])


### PR DESCRIPTION
There are two issues with [tf.keras.activations.softmax](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/activations.py#L47-L84 ) :

**First**: 
it implements softmax for 3D+ tensors in not optimal way due to old workarounds:
- **Keras**:   Support for 3D+ tensors was added on Nov 29, 2015 [https://github.com/keras-team/keras/commit/8f2d6d2714aa1b60950a2fc355d39297b7f2cdfb](https://github.com/keras-team/keras/commit/8f2d6d2714aa1b60950a2fc355d39297b7f2cdfb)
- **TF**: In that time tensorflow did not support multiple dimensions: issue was reported on Jun 29, 2016 (Softmax for multiple dimensions) [https://github.com/tensorflow/tensorflow/issues/3101](https://github.com/tensorflow/tensorflow/issues/3101)
- **TF**: Support for multiple dimensions was added on Aug 29, 2016 [https://github.com/tensorflow/tensorflow/commit/aeac274ed160618afa242512c38d1fd496466136](https://github.com/tensorflow/tensorflow/commit/aeac274ed160618afa242512c38d1fd496466136)
- **TF**: Improved kernel accepting shapes with higher ranks was added on Aug 6, 2018 [https://github.com/tensorflow/tensorflow/commit/f3aa5d4717deac34b00979fdc4f13c3c9170e819](https://github.com/tensorflow/tensorflow/commit/f3aa5d4717deac34b00979fdc4f13c3c9170e819)

For 3D tensor, the softmax gradient is getting really complicated which seriously hurts performance. example:
![image](https://user-images.githubusercontent.com/37601244/110015738-834ba700-7d24-11eb-9d21-41a6869c3c9c.png)

**Second**:
It returns wrong results for 2D tensors, axis=0. I also prepared unit test for this scenario.