### PR TITLE
[StreamExecutor C API] Lazy getting device count to provide more feasibility

### DIFF
--- a/tensorflow/c/experimental/stream_executor/stream_executor.cc
+++ b/tensorflow/c/experimental/stream_executor/stream_executor.cc
@@ -735,9 +735,15 @@ port::StatusOr<std::unique_ptr<StreamExecutor>> CPlatform::GetUncachedExecutor(
   TF_RETURN_IF_ERROR(StatusFromTF_Status(c_status.get()));
   TF_RETURN_IF_ERROR(ValidateSPDevice(device));
 
+  // Get Device Count
+  int visible_device_count = 0;
+  platform_fns_.get_device_count(&platform_, &visible_device_count,
+                                 c_status.get());
+  TF_RETURN_IF_ERROR(StatusFromTF_Status(c_status.get()));
+
   auto executor = absl::make_unique<CStreamExecutor>(
       std::move(device), &device_fns_, &stream_executor_, &platform_,
-      &platform_fns_, &timer_fns_, name_, platform_.visible_device_count);
+      &platform_fns_, &timer_fns_, name_, visible_device_count);
   auto result = absl::make_unique<StreamExecutor>(this, std::move(executor),
                                                   config.ordinal);
   return result;

--- a/tensorflow/c/experimental/stream_executor/stream_executor.h
+++ b/tensorflow/c/experimental/stream_executor/stream_executor.h
@@ -76,7 +76,7 @@ limitations under the License.
 //     // Values such as `name` and `type` must outlive SE_InitPlugin call.
 //     params->platform->name = DEVICE_NAME;
 //     params->platform->type = DEVICE_TYPE;
-//     params->platform->visible_device_count = 2;
+//     params->platform_fns->get_device_count = get_device_count;
 //     params->platform_fns->create_device = create_device;
 //     params->platform_fns->destroy_device = destroy_device;
 //     ...
@@ -428,9 +428,6 @@ typedef struct SP_Platform {
   // capital letters and underscores.
   const char* type;
 
-  // Number of visible devices
-  size_t visible_device_count;
-
   // Whether this platform supports unified memory.
   // Unified memory is a single memory address space accessible from any device.
   TF_Bool supports_unified_memory;
@@ -444,6 +441,9 @@ typedef struct SP_PlatformFns {
 
   void* ext;  // reserved for future use
 
+  // Callbacks for getting device count
+  void (*get_device_count)(const SP_Platform* platform, int* device_count,
+                           TF_Status* status);
   // Callbacks for creating/destroying SP_Device.
   void (*create_device)(const SP_Platform* platform,
                         SE_CreateDeviceParams* params, TF_Status* status);

--- a/tensorflow/c/experimental/stream_executor/stream_executor_internal.h
+++ b/tensorflow/c/experimental/stream_executor/stream_executor_internal.h
@@ -58,7 +58,15 @@ class CPlatform : public Platform {
   Id id() const override { return const_cast<int*>(&plugin_id_value_); }
   const std::string& Name() const override { return name_; }
   int VisibleDeviceCount() const override {
-    return platform_.visible_device_count;
+    int visible_device_count = 0;
+    std::unique_ptr<TF_Status, TFStatusDeleter> c_status(TF_NewStatus());
+    platform_fns_.get_device_count(&platform_, &visible_device_count,
+                                   c_status.get());
+    if (TF_GetCode(c_status.get()) != TF_OK) {
+      LOG(ERROR) << TF_Message(c_status.get());
+      return 0;
+    }
+    return visible_device_count;
   }
   port::StatusOr<std::unique_ptr<DeviceDescription>> DescriptionForDevice(
       int ordinal) const override;

--- a/tensorflow/c/experimental/stream_executor/stream_executor_test.cc
+++ b/tensorflow/c/experimental/stream_executor/stream_executor_test.cc
@@ -171,7 +171,11 @@ void create_stream_executor(const SP_Platform* platform,
 }
 void destroy_stream_executor(const SP_Platform* platform,
                              SP_StreamExecutor* se) {}
-
+void get_device_count(const SP_Platform* platform, int* device_count,
+                      TF_Status* status) {
+  TF_SetStatus(status, TF_OK, "");
+  *device_count = kDeviceCount;
+}
 void create_device(const SP_Platform* platform, SE_CreateDeviceParams* params,
                    TF_Status* status) {
   TF_SetStatus(status, TF_OK, "");
@@ -192,7 +196,7 @@ void PopulateDefaultPlatform(SP_Platform* platform,
   *platform = {SP_PLATFORM_STRUCT_SIZE};
   platform->name = kDeviceName;
   platform->type = kDeviceType;
-  platform->visible_device_count = kDeviceCount;
+  platform_fns->get_device_count = get_device_count;
   platform_fns->create_device = create_device;
   platform_fns->destroy_device = destroy_device;
   platform_fns->create_device_fns = create_device_fns;


### PR DESCRIPTION
This PR allows plugins provide the device count at runtime instead of loading stage, which provides more feasibility, for example, plugin can register a virtual device during the loading time(import tensorflow), and can select another backend through some plugin specific API, so the device count is possible to be changed.