### PR TITLE
Add use_bfc_allocator parameter to StreamExecutor C API

### DIFF
--- a/tensorflow/c/experimental/stream_executor/stream_executor.cc
+++ b/tensorflow/c/experimental/stream_executor/stream_executor.cc
@@ -812,6 +812,8 @@ port::Status InitStreamExecutorPlugin(SEInitPluginFn init_fn) {
       std::move(cplatform)));
 
   // TODO(annarev): Add pluggable device registration here.
+  // TODO(annarev): Return `use_bfc_allocator` value in some way so that it is
+  // available in `PluggableDeviceProcessState` once the latter is checked in.
   return port::Status::OK();
 }
 }  // namespace stream_executor

--- a/tensorflow/c/experimental/stream_executor/stream_executor.h
+++ b/tensorflow/c/experimental/stream_executor/stream_executor.h
@@ -434,10 +434,13 @@ typedef struct SP_Platform {
   // Whether this platform supports unified memory.
   // Unified memory is a single memory address space accessible from any device.
   TF_Bool supports_unified_memory;
+
+  // Whether to wrap allocator for this device with an allocator that uses BFC
+  // (best-fit with coalescing) strategy.
+  TF_Bool use_bfc_allocator;
 } SP_Platform;
 
-#define SP_PLATFORM_STRUCT_SIZE \
-  TF_OFFSET_OF_END(SP_Platform, supports_unified_memory)
+#define SP_PLATFORM_STRUCT_SIZE TF_OFFSET_OF_END(SP_Platform, use_bfc_allocator)
 
 typedef struct SP_PlatformFns {
   size_t struct_size;


### PR DESCRIPTION
`use_bfc_allocator` parameter will decide whether to wrap pluggable device `SubAllocator` with BFC allocator or not.

I am thinking it can be used as follows:
See lines here:
https://github.com/tensorflow/tensorflow/blob/2c31420a533f839d19af384c3d83038fde3583f8/tensorflow/core/common_runtime/pluggable_device/pluggable_device_process_state.cc#L115

They should be replaced with something like
```cpp
Allocator * device_allocator = nullptr;
if (use_bfc_allocator) {
  PluggableDeviceBFCAllocator* device_bfc_allocator =
        new PluggableDeviceBFCAllocator(
            sub_allocator, total_bytes, options,
            strings::StrCat("PluggableDevice_", tf_device_id.value(), "_bfc"));
  device_allocator = device_bfc_allocator;
} else {
  PluggableDeviceSimpleAllocator* simple_allocator = new PluggableDeviceSimpleAllocator(sub_allocator);
  device_allocator = simple_allocator;
}
```

`PluggableDeviceSimpleAllocator` should just be a minimal wrapper over the `sub_allocator` (currently not implemented as a part of this PR). This seems much simpler to me than what I was thinking of originally (sorry for the delay).

PTAL @penpornk @kulinseth, @jzhoulon


