### PR TITLE
[tflite] Enable CoreML/GPU delegate on m1

### DIFF
--- a/tensorflow/lite/delegates/coreml/BUILD
+++ b/tensorflow/lite/delegates/coreml/BUILD
@@ -27,7 +27,6 @@ objc_library(
     hdrs = ["coreml_executor.h"],
     sdk_frameworks = [
         "Foundation",
-        "UIKit",
         "CoreML",
     ],
     deps = [

--- a/tensorflow/lite/delegates/coreml/coreml_executor.h
+++ b/tensorflow/lite/delegates/coreml/coreml_executor.h
@@ -13,7 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 #import <CoreML/CoreML.h>
-#import <UIKit/UIKit.h>
 
 #include <string>
 #include <vector>

--- a/tensorflow/lite/tools/delegates/BUILD
+++ b/tensorflow/lite/tools/delegates/BUILD
@@ -58,6 +58,9 @@ cc_library(
         "//tensorflow:ios": [
             "-xobjective-c++",
         ],
+        "//tensorflow:macos_arm64": [
+            "-xobjective-c++",
+        ],
         "//conditions:default": [],
     }),
     deps = [
@@ -70,6 +73,9 @@ cc_library(
         "//conditions:default": [],
     }) + select({
         "//tensorflow:ios": [
+            "//tensorflow/lite/delegates/gpu:metal_delegate",
+        ],
+        "//tensorflow:macos_arm64": [
             "//tensorflow/lite/delegates/gpu:metal_delegate",
         ],
         "//conditions:default": [],

--- a/tensorflow/lite/tools/delegates/BUILD
+++ b/tensorflow/lite/tools/delegates/BUILD
@@ -116,6 +116,9 @@ cc_library(
         "//tensorflow:ios": [
             "-xobjective-c++",
         ],
+        "//tensorflow:macos_arm64": [
+            "-xobjective-c++",
+        ],
         "//conditions:default": [],
     }),
     deps = [
@@ -123,6 +126,9 @@ cc_library(
         "//tensorflow/lite/tools/evaluation:utils",
     ] + select({
         "//tensorflow:ios": [
+            "//tensorflow/lite/delegates/coreml:coreml_delegate",
+        ],
+        "//tensorflow:macos_arm64": [
             "//tensorflow/lite/delegates/coreml:coreml_delegate",
         ],
         "//conditions:default": [],

--- a/tensorflow/lite/tools/delegates/coreml_delegate_provider.cc
+++ b/tensorflow/lite/tools/delegates/coreml_delegate_provider.cc
@@ -18,7 +18,7 @@ limitations under the License.
 #include "tensorflow/lite/tools/evaluation/utils.h"
 #if defined(__APPLE__)
 #include "TargetConditionals.h"
-#if (TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR) || (TARGET_OS_OSX && TARGET_CPU_ARM)
+#if (TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR) || (TARGET_OS_OSX && TARGET_CPU_ARM64)
 // Only enable coreml delegate when using a real iPhone device or Apple Silicon.
 #define REAL_IPHONE_DEVICE
 #include "tensorflow/lite/delegates/coreml/coreml_delegate.h"

--- a/tensorflow/lite/tools/delegates/coreml_delegate_provider.cc
+++ b/tensorflow/lite/tools/delegates/coreml_delegate_provider.cc
@@ -18,7 +18,7 @@ limitations under the License.
 #include "tensorflow/lite/tools/evaluation/utils.h"
 #if defined(__APPLE__)
 #include "TargetConditionals.h"
-#if TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR
+#if (TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR) || TARGET_OS_OSX
 // Only enable metal delegate when using a real iPhone device.
 #define REAL_IPHONE_DEVICE
 #include "tensorflow/lite/delegates/coreml/coreml_delegate.h"

--- a/tensorflow/lite/tools/delegates/coreml_delegate_provider.cc
+++ b/tensorflow/lite/tools/delegates/coreml_delegate_provider.cc
@@ -18,8 +18,8 @@ limitations under the License.
 #include "tensorflow/lite/tools/evaluation/utils.h"
 #if defined(__APPLE__)
 #include "TargetConditionals.h"
-#if (TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR) || TARGET_OS_OSX
-// Only enable metal delegate when using a real iPhone device.
+#if (TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR) || (TARGET_OS_OSX && TARGET_CPU_ARM)
+// Only enable coreml delegate when using a real iPhone device or Apple Silicon.
 #define REAL_IPHONE_DEVICE
 #include "tensorflow/lite/delegates/coreml/coreml_delegate.h"
 #endif

--- a/tensorflow/lite/tools/delegates/gpu_delegate_provider.cc
+++ b/tensorflow/lite/tools/delegates/gpu_delegate_provider.cc
@@ -20,8 +20,8 @@ limitations under the License.
 #include "tensorflow/lite/delegates/gpu/delegate.h"
 #elif defined(__APPLE__)
 #include "TargetConditionals.h"
-#if (TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR) || TARGET_OS_OSX
-// Only enable metal delegate when using a real iPhone device.
+#if (TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR) || (TARGET_OS_OSX && TARGET_CPU_ARM)
+// Only enable metal delegate when using a real iPhone device or Apple Silicon.
 #define REAL_IPHONE_DEVICE
 #include "tensorflow/lite/delegates/gpu/metal_delegate.h"
 #endif

--- a/tensorflow/lite/tools/delegates/gpu_delegate_provider.cc
+++ b/tensorflow/lite/tools/delegates/gpu_delegate_provider.cc
@@ -20,7 +20,7 @@ limitations under the License.
 #include "tensorflow/lite/delegates/gpu/delegate.h"
 #elif defined(__APPLE__)
 #include "TargetConditionals.h"
-#if (TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR) || (TARGET_OS_OSX && TARGET_CPU_ARM)
+#if (TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR) || (TARGET_OS_OSX && TARGET_CPU_ARM64)
 // Only enable metal delegate when using a real iPhone device or Apple Silicon.
 #define REAL_IPHONE_DEVICE
 #include "tensorflow/lite/delegates/gpu/metal_delegate.h"

--- a/tensorflow/lite/tools/delegates/gpu_delegate_provider.cc
+++ b/tensorflow/lite/tools/delegates/gpu_delegate_provider.cc
@@ -20,7 +20,7 @@ limitations under the License.
 #include "tensorflow/lite/delegates/gpu/delegate.h"
 #elif defined(__APPLE__)
 #include "TargetConditionals.h"
-#if TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR
+#if (TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR) || TARGET_OS_OSX
 // Only enable metal delegate when using a real iPhone device.
 #define REAL_IPHONE_DEVICE
 #include "tensorflow/lite/delegates/gpu/metal_delegate.h"


### PR DESCRIPTION
To run TFLite models on M1 devices, we need CoreML delegate to offload computation to Apple's Neural Engine.

```
bazel build //tensorflow/lite/tools/benchmark:benchmark_model \
  --macos_cpus arm64
```
    
```
./bazel-bin/tensorflow/lite/tools/benchmark/benchmark_model \
  --use_coreml=1 \
  --graph=/tmp/mobilenet_edgetpu_224_1.0_float.tflite
```
works as expected
