### PR TITLE
Skip the default delegate if we already have set up one delegate.

### DIFF
--- a/tensorflow/lite/interpreter.cc
+++ b/tensorflow/lite/interpreter.cc
@@ -400,6 +400,13 @@ TfLiteStatus Interpreter::ModifyGraphWithDelegate(TfLiteDelegate* delegate) {
   if (status == kTfLiteDelegateError) {
     TF_LITE_ENSURE_STATUS(RemoveAllDelegates());
   }
+
+  // We already have a delegate. The default delegate in
+  // "lazy_delegate_providers_" could be skipped.
+  if (status == kTfLiteOk) {
+    lazy_delegate_providers_.clear();
+  }
+
   return status;
 }
 


### PR DESCRIPTION
This pr try to fix the issue at:
https://github.com/tensorflow/tensorflow/issues/42757

When we use the xnnpack delegate, we will see the following error message:
```
/tensorflow/tensorflow/lite/build$ ./examples/label_image/label_image -m ~/mobilenet_v1_1.0_224.f32.tflite -l ~/labels.txt -i /tensorflow/tensorflow/lite/examples/label_image/testdata/grace_hopper.bmp -p 1 -x 1
INFO: Loaded model /home/jerrys/mobilenet_v1_1.0_224.f32.tflite
INFO: resolved reporter
INFO: Created TensorFlow Lite XNNPACK delegate for CPU.
INFO: Use XNNPACK acceleration.
INFO: Applied XNNPACK delegate.
ERROR: ModifyGraphWithDelegate is disallowed when graph is immutable.
ERROR: Ignoring failed application of the default TensorFlow Lite delegate indexed at 0.
```

The messages comes from the following ModifyGraphWithDelegate() and AllocateTensors() calls.
https://github.com/tensorflow/tensorflow/blob/fb7d34de0a7a892d070104aa4e385159817e7ef5/tensorflow/lite/tools/benchmark/benchmark_tflite_model.cc#L635
https://github.com/tensorflow/tensorflow/blob/fb7d34de0a7a892d070104aa4e385159817e7ef5/tensorflow/lite/tools/benchmark/benchmark_tflite_model.cc#L725


When we setup xnnpack delegate in ModifyGraphWithDelegate(), the graph will become immutable. Then, we call AllocateTensors() and apply the default delegate in "lazy_delegate_providers_" again. That will show the error message that we are trying to update the immutable graph using the delegate in "lazy_delegate_providers_".
So, I just clear the "lazy_delegate_providers_" if we already set up a delegate.