### PR TITLE
[ROCm] Workaround for Eigen::half bug related bug on ROCm platform

### DIFF
--- a/tensorflow/python/kernel_tests/pad_op_test.py
+++ b/tensorflow/python/kernel_tests/pad_op_test.py
@@ -111,7 +111,8 @@ class PadOpTest(test.TestCase):
 
     with self.cached_session():
       jacob_t, jacob_n = gradient_checker_v2.compute_gradient(pad, [x])
-      self.assertAllClose(jacob_t, jacob_n, rtol=1e-5, atol=1e-5)
+      tol = 1e-3 if x.dtype == np.float16 else 4e-5
+      self.assertAllClose(jacob_t, jacob_n, rtol=tol, atol=tol)
 
   def _testAll(self, np_inputs, paddings, constant_values):
     for mode in ("CONSTANT", "REFLECT", "SYMMETRIC", "reflect", "symmetric",
@@ -257,10 +258,12 @@ class PadOpTest(test.TestCase):
           [[0, 0], [0, 0], [0, 0], [0, 0]], -123)
 
   def testFloatTypes(self):
-    for t in [np.float32, np.float64]:
+    for t in [np.float16, np.float32, np.float64]:
       self._testAll(np.random.rand(2, 5).astype(t), [[1, 0], [2, 0]], 0.0)
       self._testAll(np.random.rand(2, 3, 4).astype(t),
-                    [[0, 0], [0, 0], [0, 0]], -1234.0)
+                    [[0, 0], [0, 0], [0, 0]], -12.34)
+      self._testAll(np.random.rand(12, 13, 14).astype(t),
+                    [[0, 0], [3, 3], [3, 3]], 1.41)
       self._testAll(np.random.rand(0, 3, 4).astype(t),
                     [[0, 0], [2, 1], [2, 3]], 0.0)
 


### PR DESCRIPTION
copy-pasting the PR description from @ekuznetsov139 description for the same in ROCm fork

--------------

There appears to be an ABI mismatch between gcc7 and clang that, in case of functor::Pad<Eigen::half, 3>, results in the pad value being passed incorrectly (we see the correct value of 0 in pad_op.cc, which is compiled with gcc, and a random incorrect value in pad_op.h, which is compiled with clang).

This PR switches functor::Pad to taking all arguments by reference, which works around the problem.

It also adds float16 to tested data types for pad_op_test (the problem was not noticed for a long time because pad_op_test was not testing float16).

---------------

/cc @rmlarsen @cantonios ... this is the TF side workaround for the same issue/bug for which we filed this Eigen PR - https://gitlab.com/libeigen/eigen/-/merge_requests/422

----------------

/cc @cheshire @chsigg 