### PR TITLE
[ROCm] AMP selection process for AMD GPUs

### DIFF
--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision.cc
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision.cc
@@ -43,20 +43,6 @@ limitations under the License.
 
 namespace tensorflow {
 namespace grappler {
-
-#if TENSORFLOW_USE_ROCM
-// Returns true if the corresponding gfx arch string for the detected AMD GPU 
-// is in the list for FP16 supported compute. Returns false otherwise. 
-
-bool HasFastFP16Support(const DeviceProperties &props) {
-  absl::flat_hash_set<std::string> FP16SupportedDevices = {{"gfx906"}, {"gfx908"}};
-  std::string gcnArchName = props.environment().at("architecture");
-  std::vector<std::string> gpu_arch = absl::StrSplit(gcnArchName, ":");
-  return !gpu_arch.empty() && FP16SupportedDevices.contains(gpu_arch[0]);
-}
-#endif
-
-
 namespace {
 
 #if GOOGLE_CUDA
@@ -69,6 +55,48 @@ const char kSuffix[] = "AutoMixedPrecision";
 const char kCastToFp16[] = "CastToFp16";
 const char kCastToBf16[] = "CastToBf16";
 const char kCastToFp32[] = "CastToFp32";
+
+// Returns the GPU architecture (compute capability) as a (major, minor) pair.
+std::pair<int, int> GetDeviceGPUArch(
+    const DeviceProperties& device_properties) {
+  if (device_properties.type() != "GPU") return {0, 0};
+  string arch_str = device_properties.environment().at("architecture");
+  std::vector<string> split_arch_str = str_util::Split(arch_str, '.');
+  if (split_arch_str.empty()) {
+    return {0, 0};
+  }
+
+  int major, minor;
+  if (!strings::safe_strto32(split_arch_str[0], &major)) {
+    return {0, 0};
+  }
+
+  if (split_arch_str.size() > 1) {
+    if (strings::safe_strto32(split_arch_str[1], &minor)) {
+      return {major, minor};
+    } else {
+      return {0, 0};
+    }
+  } else {
+    return {major, 0};
+  }
+}
+
+// Returns true if FP16Support is valid
+// For CUDA, We compare the GPUArch with the kMinGPUArch, if GPUArch is >= min, return true
+// For AMD the corresponding gfx arch string for the detected AMD GPU
+// is in the list for FP16 supported compute. Returns false otherwise.
+bool HasFastFP16Support(const DeviceProperties &props) {
+#if GOOGLE_CUDA
+  return GetDeviceGPUArch(props) >= kMinGPUArch;
+#elif TENSORFLOW_USE_ROCM
+  absl::flat_hash_set<std::string> FP16SupportedDevices = {{"gfx906"}, {"gfx908"}};
+  std::string gcnArchName = props.environment().at("architecture");
+  std::vector<std::string> gpu_arch = absl::StrSplit(gcnArchName, ":");
+  return !gpu_arch.empty() && FP16SupportedDevices.contains(gpu_arch[0]);
+#endif
+  return false;
+}
 
 // Instances of this class represent unique type attribute identifiers within a
 // node. It handles regular type attributes, list type attributes (where
@@ -1147,38 +1175,10 @@ bool AutoMixedPrecisionImpl::IsOnDevice(const NodeDef& node,
   return false;
 }
 
-// Returns the GPU architecture (compute capability) as a (major, minor) pair.
-std::pair<int, int> GetDeviceGPUArch(
-    const DeviceProperties& device_properties) {
-  if (device_properties.type() != "GPU") return {0, 0};
-  string arch_str = device_properties.environment().at("architecture");
-  std::vector<string> split_arch_str = str_util::Split(arch_str, '.');
-  if (split_arch_str.empty()) {
-    return {0, 0};
-  }
 
-  int major, minor;
-  if (!strings::safe_strto32(split_arch_str[0], &major)) {
-    return {0, 0};
-  }
-
-  if (split_arch_str.size() > 1) {
-    if (strings::safe_strto32(split_arch_str[1], &minor)) {
-      return {major, minor};
-    } else {
-      return {0, 0};
-    }
-  } else {
-    return {major, 0};
-  }
-}
 
 bool AutoMixedPrecisionImpl::IsOnSuitableGPUArch(const NodeDef& node) const {
-#if TENSORLFOW_USE_ROCM
-  return HasFastFP16Support(virtual_placer_.get_device(node)); 
-#else
-  return GetDeviceGPUArch(virtual_placer_.get_device(node)) >= kMinGPUArch;
-#endif
+  return HasFastFP16Support(virtual_placer_.get_device(node));
 }
 
 bool AutoMixedPrecisionImpl::ShouldProcess(const NodeDef& node) const {
@@ -1982,24 +1982,16 @@ Status AutoMixedPrecisionImpl::ChangeTypeAttrsAndAddCasts(
   return Status::OK();
 }
 
-int GetNumGPUs(const Cluster& cluster,
-               const std::pair<int, int>& min_arch = {0, 0}) {
+int GetNumGPUs(const Cluster& cluster) {
   auto devices = cluster.GetDevices();
   int num_gpus = 0;
   for (const auto& device : devices) {
     const DeviceProperties& device_properties = device.second;
-#if GOOGLE_CUDA
-    std::pair<int, int> arch = GetDeviceGPUArch(device_properties);
-    if (device_properties.type() == "GPU" && arch >= min_arch) {
-      num_gpus++;
-    }
-#elif TENSORFLOW_USE_ROCM
     if (device_properties.type() == "GPU") {
       if (ShouldIgnorePerformance() || HasFastFP16Support(device_properties)) {
         num_gpus++;
       }
     }
-#endif
   }
   return num_gpus;
 }
@@ -2027,8 +2019,7 @@ Status AutoMixedPrecision::Optimize(Cluster* cluster, const GrapplerItem& item,
   // Start by copying input graph to output.
   *output = item.graph;
 
-  int num_gpus = ShouldIgnorePerformance() ? GetNumGPUs(*cluster)
-                                           : GetNumGPUs(*cluster, kMinGPUArch);
+  int num_gpus = GetNumGPUs(*cluster);
   if (num_gpus < 1 && mode_ == AutoMixedPrecisionMode::CUDA) {
     // AutoMixedPrecision is currently only tuned for GPU.
     LOG(WARNING) << "No (suitable) GPUs detected, skipping " << name()

--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision.cc
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision.cc
@@ -52,10 +52,7 @@ bool HasFastFP16Support(const DeviceProperties &props) {
   absl::flat_hash_set<std::string> FP16SupportedDevices = {{"gfx906"}, {"gfx908"}};
   std::string gcnArchName = props.environment().at("architecture");
   std::vector<std::string> gpu_arch = absl::StrSplit(gcnArchName, ":");
-  if(gpu_arch.size()>0) {
-    return FP16SupportedDevices.contains(gpu_arch[0]); 
-  }
-  else return false;
+  return !gpu_arch.empty() && FP16SupportedDevices.contains(gpu_arch[0]);
 }
 #endif
 

--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision.cc
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision.cc
@@ -45,15 +45,17 @@ namespace tensorflow {
 namespace grappler {
 
 #if TENSORFLOW_USE_ROCM
-bool GetFastFP16Support(const DeviceProperties &props) {
-  bool supported = false;
-  std::set<std::string> FP16SupportedDevices = {"gfx906", "gfx908"};
+// Returns true if the corresponding gfx arch string for the detected AMD GPU 
+// is in the list for FP16 supported compute. Returns false otherwise. 
+
+bool HasFastFP16Support(const DeviceProperties &props) {
+  absl::flat_hash_set<std::string> FP16SupportedDevices = {{"gfx906"}, {"gfx908"}};
   std::string gcnArchName = props.environment().at("architecture");
   std::vector<std::string> gpu_arch = absl::StrSplit(gcnArchName, ":");
-  supported = std::find(std::begin(FP16SupportedDevices),
-              std::end(FP16SupportedDevices),
-              gpu_arch[0]) != std::end(FP16SupportedDevices);
-  return supported;
+  if(gpu_arch.size()>0) {
+    return FP16SupportedDevices.contains(gpu_arch[0]); 
+  }
+  else return false;
 }
 #endif
 
@@ -1175,10 +1177,10 @@ std::pair<int, int> GetDeviceGPUArch(
 }
 
 bool AutoMixedPrecisionImpl::IsOnSuitableGPUArch(const NodeDef& node) const {
-#ifndef TENSORFLOW_USE_ROCM
-  return GetDeviceGPUArch(virtual_placer_.get_device(node)) >= kMinGPUArch;
+#if TENSORLFOW_USE_ROCM
+  return HasFastFP16Support(virtual_placer_.get_device(node)); 
 #else
-  return GetFastFP16Support(virtual_placer_.get_device(node)); 
+  return GetDeviceGPUArch(virtual_placer_.get_device(node)) >= kMinGPUArch;
 #endif
 }
 
@@ -1996,7 +1998,7 @@ int GetNumGPUs(const Cluster& cluster,
     }
 #elif TENSORFLOW_USE_ROCM
     if (device_properties.type() == "GPU") {
-      if (ShouldIgnorePerformance() || GetFastFP16Support(device_properties)) {
+      if (ShouldIgnorePerformance() || HasFastFP16Support(device_properties)) {
         num_gpus++;
       }
     }

--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision.cc
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision.cc
@@ -83,14 +83,15 @@ std::pair<int, int> GetDeviceGPUArch(
 }
 
 // Returns true if FP16Support is valid
-// For CUDA, We compare the GPUArch with the kMinGPUArch, if GPUArch is >= min, return true
-// For AMD the corresponding gfx arch string for the detected AMD GPU
-// is in the list for FP16 supported compute. Returns false otherwise.
-bool HasFastFP16Support(const DeviceProperties &props) {
+// For CUDA, We compare the GPUArch with the kMinGPUArch, if GPUArch is >= min,
+// return true. For AMD the corresponding gfx arch string for the detected AMD
+// GPU is in the list for FP16 supported compute. Returns false otherwise.
+bool HasFastFP16Support(const DeviceProperties& props) {
 #if GOOGLE_CUDA
   return GetDeviceGPUArch(props) >= kMinGPUArch;
 #elif TENSORFLOW_USE_ROCM
-  absl::flat_hash_set<std::string> FP16SupportedDevices = {{"gfx906"}, {"gfx908"}};
+  absl::flat_hash_set<std::string> FP16SupportedDevices = {{"gfx906"},
+                                                           {"gfx908"}};
   std::string gcnArchName = props.environment().at("architecture");
   std::vector<std::string> gpu_arch = absl::StrSplit(gcnArchName, ":");
   return !gpu_arch.empty() && FP16SupportedDevices.contains(gpu_arch[0]);
@@ -1175,8 +1176,6 @@ bool AutoMixedPrecisionImpl::IsOnDevice(const NodeDef& node,
   return false;
 }
 
-
-
 bool AutoMixedPrecisionImpl::IsOnSuitableGPUArch(const NodeDef& node) const {
   return HasFastFP16Support(virtual_placer_.get_device(node));
 }
@@ -1987,10 +1986,9 @@ int GetNumGPUs(const Cluster& cluster) {
   int num_gpus = 0;
   for (const auto& device : devices) {
     const DeviceProperties& device_properties = device.second;
-    if (device_properties.type() == "GPU") {
-      if (ShouldIgnorePerformance() || HasFastFP16Support(device_properties)) {
-        num_gpus++;
-      }
+    if (device_properties.type() == "GPU" &&
+        (ShouldIgnorePerformance() || HasFastFP16Support(device_properties))) {
+      num_gpus++;
     }
   }
   return num_gpus;

--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision_test.cc
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision_test.cc
@@ -49,7 +49,7 @@ bool IsSupportedGPU()
 #ifdef GOOGLE_CUDA
     return GetCudaVersion(*virtual_cluster_.get()) >= 9010;
 #else
-    return True;
+    return true;
 #endif
 }
 

--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision_test.cc
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision_test.cc
@@ -43,13 +43,6 @@ namespace tensorflow {
 namespace grappler {
 namespace {
 
-bool IsSupportedGPU() {
-#ifdef GOOGLE_CUDA
-    return GetCudaVersion(*virtual_cluster_.get()) >= 9010;
-#else
-    return true;
-#endif
-}
 
 template <DataType DTYPE>
 Tensor GenerateIdentityMatrix(int64 height, int64 width) {
@@ -1029,6 +1022,14 @@ TEST_F(AutoMixedPrecisionTest, TensorListThroughFunction) {
   for (int i = 0; i < item.fetch.size(); ++i) {
     test::ExpectClose(tensors_expected[i], tensors[i], -1, 5e-4);
   }
+}
+
+bool IsSupportedGPU() {
+#ifdef GOOGLE_CUDA
+    return GetCudaVersion(*virtual_cluster_.get()) >= 9010;
+#else
+    return true;
+#endif
 }
 
 int GetCudaVersion(const Cluster& cluster) {

--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision_test.cc
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision_test.cc
@@ -43,9 +43,7 @@ namespace tensorflow {
 namespace grappler {
 namespace {
 
-
-bool IsSupportedGPU()
-{
+bool IsSupportedGPU() {
 #ifdef GOOGLE_CUDA
     return GetCudaVersion(*virtual_cluster_.get()) >= 9010;
 #else
@@ -124,7 +122,7 @@ class AutoMixedPrecisionTest : public GrapplerTest {
       device_properties.mutable_environment()->insert({"architecture", "7"});
       device_properties.mutable_environment()->insert({"cuda", "9010"});
 #else
-      device_properties.mutable_environment()->insert({"architecture", "gfx906");
+      device_properties.mutable_environment()->insert({"architecture", "gfx906"});
 #endif
       virtual_cluster_.reset(
           new VirtualCluster({{"/GPU:1", device_properties}}));

--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision_test.cc
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision_test.cc
@@ -85,10 +85,10 @@ void VerifyGraphsEquivalent(const GraphDef& original_graph,
   }
 }
 
-// Currently, this test suite only passes when TensorFlow passes with CUDA,
+// Currently, this test suite only passes when TensorFlow passes with CUDA/HIP,
 // because otherwise the optimizer will not turn clearlist nodes to float16.
 // When looking at clearlist nodes, this optimizer checks if the nodes have a
-// float16 GPU OpKernel, but without CUDA there are no GPU OpKernels at all.
+// float16 GPU OpKernel, but without CUDA/HIP there are no GPU OpKernels at all.
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 const std::pair<int, int> kMinGPUArch = {7, 0};
@@ -102,6 +102,8 @@ class AutoMixedPrecisionTest : public GrapplerTest {
 #if GOOGLE_CUDA
     gpu_available_ =
         gpu_available_ && (num_gpus == GetNumAvailableGPUs(kMinGPUArch));
+#elif TENSORFLOW_USE_ROCM //Here we force Tensorflow to use the virtual GFX906
+    gpu_available_ = false;
 #endif
     if (gpu_available_) {
       virtual_cluster_.reset(new SingleMachine(/* timeout_s = */ 10, 1, 1));
@@ -111,6 +113,8 @@ class AutoMixedPrecisionTest : public GrapplerTest {
 #if GOOGLE_CUDA
       device_properties.mutable_environment()->insert({"architecture", "7"});
       device_properties.mutable_environment()->insert({"cuda", "9010"});
+#elif TENSORFLOW_USE_ROCM
+      device_properties.mutable_environment()->insert({"architecture", "gfx906");
 #endif
       virtual_cluster_.reset(
           new VirtualCluster({{"/GPU:1", device_properties}}));
@@ -1054,7 +1058,11 @@ TEST_F(AutoMixedPrecisionTest, BatchMatMul) {
 
   GraphView output_view(&output);
   EXPECT_EQ(output_view.GetNode("input")->attr().at("dtype").type(), DT_FLOAT);
+#if GOOGLE_CUDA
   if (GetCudaVersion(*virtual_cluster_.get()) >= 9010) {
+#else
+  if (true) {
+#endif
     EXPECT_EQ(output.node_size(), item.graph.node_size() + 2);
     EXPECT_EQ(output_view.GetNode("allow1")->attr().at("T").type(), DT_HALF);
   } else {


### PR DESCRIPTION
Chooses to enable based on AMD GPU architecture, with current supported arches being gfx906 and gfx908. 
Utilizes the same Auto Mixed Precision tests as CUDA implementation. 

@cheshire @chsigg for review. 