### PR TITLE
Use -stdlib=libc++ and -fno-rtti with Xtensa.

### DIFF
--- a/tensorflow/lite/micro/tools/make/targets/xtensa_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/xtensa_makefile.inc
@@ -36,6 +36,7 @@ PLATFORM_FLAGS = \
   -DTF_LITE_USE_CTIME \
   --xtensa-core=$(XTENSA_CORE) \
   -mcoproc \
+  -stdlib=libc++ \
   -DMAX_RFFT_PWR=9 \
   -DMIN_RFFT_PWR=MAX_RFFT_PWR \
   $(TARGET_ARCH_DEFINES)
@@ -51,9 +52,6 @@ CC_TOOL := clang
 
 CXXFLAGS += $(PLATFORM_FLAGS)
 CCFLAGS += $(PLATFORM_FLAGS)
-
-# TODO(b/150240249): Do not remove -fno-rtti once that works for the Xtensa toolchain.
-CXXFLAGS := $(filter-out -fno-rtti, $(CXXFLAGS))
 
 TEST_SCRIPT := tensorflow/lite/micro/testing/test_xtensa_binary.sh
 


### PR DESCRIPTION
Manually confirmed with the steps outlined in #47575 that exception related symbols are no longer part of the keyword_benchmark binary when build with the Xtensa toolchain.

Manually tested the size with:
```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=fusion_f1 XTENSA_CORE=F1_190305_swupgrade keyword_benchmark -j8 BUILD_TYPE=release
xt-size tensorflow/lite/micro/tools/make/gen/xtensa_fusion_f1_release/bin/keyword_benchmark
```

Without this change:
```
   text	   data	    bss	    dec	    hex	filename
  70912	  40212	  24856	 135980	  2132c	tensorflow/lite/micro/tools/make/gen/xtensa_fusion_f1_release/bin/keyword_benchmark
```

With this change:
```
   text	   data	    bss	    dec	    hex	filename
  88712	    384	  22704	 111800	  1b4b8	tensorflow/lite/micro/tools/make/gen/xtensa_fusion_f1_release/bin/keyword_benchmark
```

While what goes in the text and data sections has changed, the overall binary size is reduced by ~24KB.

Also confirmed that the cycles for the keyword benchmark are unaffected:
```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=fusion_f1 XTENSA_CORE=F1_190305_swupgrade run_keyword_benchmark -j8
```

gives:
```
InitializeKeywordRunner took 159001 ticks (159 ms).

KeywordRunNIerations(1) took 34253 ticks (34 ms)
QUANTIZE took 800 ticks (0 ms).
SVDF took 4753 ticks (4 ms).
FULLY_CONNECTED took 1353 ticks (1 ms).
SVDF took 4211 ticks (4 ms).
FULLY_CONNECTED took 1353 ticks (1 ms).
SVDF took 3145 ticks (3 ms).
FULLY_CONNECTED took 1353 ticks (1 ms).
SVDF took 4211 ticks (4 ms).
FULLY_CONNECTED took 1353 ticks (1 ms).
SVDF took 2890 ticks (2 ms).
SVDF took 3583 ticks (3 ms).
SVDF took 3054 ticks (3 ms).
FULLY_CONNECTED took 1091 ticks (1 ms).
SOFTMAX took 749 ticks (0 ms).
QUANTIZE took 354 ticks (0 ms).

KeywordRunNIerations(10) took 342530 ticks (342 ms)
```

And all the unit tests pass:
```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=fusion_f1 XTENSA_CORE=F1_190305_swupgrade test -j8
```

Fixes #47575

With this change, we no longer need to remove `-fno-rtti` for Xtensa and http://b/150240249 is also fixed.
