### PR TITLE
Fix the TFLM github CI bazel build.

### DIFF
--- a/tensorflow/lite/micro/tools/ci_build/test_bazel.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_bazel.sh
@@ -32,6 +32,7 @@ source tensorflow/lite/micro/tools/ci_build/helper_functions.sh
 
 # Replace Tensorflow's versions of files with pared down versions that download
 # a smaller set of external dependencies to speed up the CI.
+readable_run rm -f .bazelrc
 readable_run rm -f tensorflow/BUILD
 readable_run rm -f tensorflow/tensorflow.bzl
 readable_run rm -f tensorflow/workspace.bzl
@@ -40,6 +41,7 @@ readable_run rm -f tensorflow/workspace1.bzl
 readable_run rm -f tensorflow/workspace2.bzl
 readable_run rm -f WORKSPACE
 
+readable_run cp tensorflow/lite/micro/tools/ci_build/tflm_bazel/dot_bazelrc .bazelrc
 readable_run cp tensorflow/lite/micro/tools/ci_build/tflm_bazel/BUILD tensorflow/
 readable_run cp tensorflow/lite/micro/tools/ci_build/tflm_bazel/tensorflow.bzl tensorflow/
 readable_run cp tensorflow/lite/micro/tools/ci_build/tflm_bazel/workspace.bzl tensorflow/

--- a/tensorflow/lite/micro/tools/ci_build/tflm_bazel/dot_bazelrc
+++ b/tensorflow/lite/micro/tools/ci_build/tflm_bazel/dot_bazelrc
@@ -1,0 +1,52 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# TFLM Bazel configuration file.
+#
+# Other build options:
+#     asan:             Build with the clang address sanitizer
+#     msan:             Build with the clang memory sanitizer
+#     ubsan:            Build with the clang undefined behavior sanitizer
+#
+
+# Address sanitizer
+# CC=clang bazel build --config asan
+build:asan --strip=never
+build:asan --copt -fsanitize=address
+build:asan --copt -DADDRESS_SANITIZER
+build:asan --copt -g
+build:asan --copt -O3
+build:asan --copt -fno-omit-frame-pointer
+build:asan --linkopt -fsanitize=address
+
+# Memory sanitizer
+# CC=clang bazel build --config msan
+build:msan --strip=never
+build:msan --copt -fsanitize=memory
+build:msan --copt -DADDRESS_SANITIZER
+build:msan --copt -g
+build:msan --copt -O3
+build:msan --copt -fno-omit-frame-pointer
+build:msan --linkopt -fsanitize=memory
+
+# Undefined Behavior Sanitizer
+# CC=clang bazel build --config ubsan
+build:ubsan --strip=never
+build:ubsan --copt -fsanitize=undefined
+build:ubsan --copt -g
+build:ubsan --copt -O3
+build:ubsan --copt -fno-omit-frame-pointer
+build:ubsan --linkopt -fsanitize=undefined
+build:ubsan --linkopt -lubsan


### PR DESCRIPTION
We are now using a pared-down version of .bazelrc as well.

The reason for the most recent TFLM CI bazel build breakage wasi:
 * https://github.com/tensorflow/tensorflow/commit/6236b83d80e4907cec016fd3702d7bbf64beabf5 resulted in parsing of the .bazelrc also resulting in the BUILD and build_defs.bzl files in  //tensorflow/code/kernels/mlir_generated to be read.
 * Which in turn meant that CUDA related third party downloads had to be available.
 * And CUDA downloads are not needed for TFLM and had previously been removed from the github TFLM bazel build to speed things up.

With this change, tensorflow/lite/micro/tools/ci_build/test_bazel.sh does not error out.
