### PR TITLE
[tf.data] Add SkipInternal for flat_map and interleave

### DIFF
--- a/tensorflow/core/kernels/data/dataset_test_base.h
+++ b/tensorflow/core/kernels/data/dataset_test_base.h
@@ -809,7 +809,7 @@ class DatasetOpsTestBase : public ::testing::Test {
                                 public ::testing::WithParamInterface<       \
                                     SkipTestCase<dataset_params_class>> {}; \
                                                                             \
-  TEST_P(ParameterizedSkipTest, GetNext) {                                  \
+  TEST_P(ParameterizedSkipTest, Skip) {                                     \
     auto test_case = GetParam();                                            \
     TF_ASSERT_OK(Initialize(test_case.dataset_params));                     \
     TF_ASSERT_OK(CheckIteratorSkip(                                         \

--- a/tensorflow/core/kernels/data/flat_map_dataset_op.cc
+++ b/tensorflow/core/kernels/data/flat_map_dataset_op.cc
@@ -162,6 +162,49 @@ class FlatMapDatasetOp::Dataset : public DatasetBase {
       } while (true);
     }
 
+    Status SkipInternal(IteratorContext* ctx, int num_to_skip,
+                        bool* end_of_sequence, int* num_skipped) override {
+      mutex_lock l(mu_);
+      *num_skipped = 0;
+      do {
+        if (!input_impl_) {
+          *end_of_sequence = true;
+          return Status::OK();
+        }
+        if (current_element_iterator_) {
+          // We are currently processing a mapped element, so try to get the
+          // next subelement.
+          bool end_of_element;
+          int last_num_skipped;
+          TF_RETURN_IF_ERROR(current_element_iterator_->Skip(
+              ctx, num_to_skip - *num_skipped, &end_of_element,
+              &last_num_skipped));
+          *num_skipped += last_num_skipped;
+          if (!end_of_element) {
+            // Produce the subelement as output.
+            *end_of_sequence = false;
+            return Status::OK();
+          }
+
+          // We have reached the end of the current element, so maybe move on
+          // to the next element.
+          current_element_iterator_.reset();
+        }
+
+        // Get the next element from the input dataset.
+        captured_func_inputs_.clear();
+        TF_RETURN_IF_ERROR(
+            input_impl_->GetNext(ctx, &captured_func_inputs_, end_of_sequence));
+        if (*end_of_sequence) {
+          input_impl_.reset();
+          return Status::OK();
+        }
+
+        TF_RETURN_IF_ERROR(BuildCurrentElementIteratorLocked(
+            ctx, /*is_get_next=*/false));
+      } while (true);
+    }
+
    protected:
     std::shared_ptr<model::Node> CreateNode(
         IteratorContext* ctx, model::Node::Args args) const override {

--- a/tensorflow/core/kernels/data/flat_map_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/flat_map_dataset_op_test.cc
@@ -130,6 +130,24 @@ std::vector<GetNextTestCase<FlatMapDatasetParams>> GetNextTestCases() {
 ITERATOR_GET_NEXT_TEST_P(FlatMapDatasetOpTest, FlatMapDatasetParams,
                          GetNextTestCases())
 
+std::vector<SkipTestCase<FlatMapDatasetParams>> SkipTestCases() {
+  return {{/*dataset_params=*/FlatMapDatasetParams1(),
+           /*num_to_skip*/ 2, /*expected_num_skipped*/ 2, /*get_next*/ true,
+           /*expected_outputs=*/
+           CreateTensors<int64>(TensorShape({1}), {{2}})},
+          {/*dataset_params=*/FlatMapDatasetParams1(),
+           /*num_to_skip*/ 4, /*expected_num_skipped*/ 4, /*get_next*/ true,
+           /*expected_outputs=*/
+           CreateTensors<int64>(TensorShape({1}), {{4}})},
+          {/*dataset_params=*/FlatMapDatasetParams1(),
+           /*num_to_skip*/ 9, /*expected_num_skipped*/ 9, /*get_next*/ false},
+          {/*dataset_params=*/FlatMapDatasetParams1(),
+           /*num_to_skip*/ 10, /*expected_num_skipped*/ 9, /*get_next*/ false}};
+}
+
+ITERATOR_SKIP_TEST_P(FlatMapDatasetOpTest, FlatMapDatasetParams,
+                     SkipTestCases())
+
 TEST_F(FlatMapDatasetOpTest, DatasetNodeName) {
   auto dataset_params = FlatMapDatasetParams1();
   TF_ASSERT_OK(Initialize(dataset_params));

--- a/tensorflow/core/kernels/data/interleave_dataset_op.cc
+++ b/tensorflow/core/kernels/data/interleave_dataset_op.cc
@@ -173,20 +173,53 @@ class InterleaveDatasetOp::Dataset : public DatasetBase {
           args_list_[cycle_index_].clear();
           --num_open_;
           AdvanceToNextInCycle();
-        } else if (!end_of_input_) {
-          // Get the next element from the input dataset, and create
-          // an iterator from it.
-          TF_RETURN_IF_ERROR(input_impl_->GetNext(
-              ctx, &args_list_[cycle_index_], &end_of_input_));
-          if (!end_of_input_) {
-            TF_RETURN_IF_ERROR(MakeIteratorFromInputElement(
-                ctx, this, args_list_[cycle_index_], cycle_index_,
-                *instantiated_captured_func_, prefix(),
-                &current_elements_[cycle_index_], model_node()));
-            ++num_open_;
+        } else {
+          TF_RETURN_IF_ERROR(MoveToNextElement(ctx));
+        }
+      }
+
+      *end_of_sequence = true;
+      return Status::OK();
+    }
+
+    Status SkipInternal(IteratorContext* ctx, int num_to_skip,
+                        bool* end_of_sequence, int* num_skipped) override {
+      mutex_lock l(mu_);
+      *num_skipped = 0;
+      while (!end_of_input_ || num_open_ > 0) {
+        if (current_elements_[cycle_index_]) {
+          // We are currently processing a mapped element, so try to get the
+          // next subelement.
+          int element_num_to_skip = num_to_skip - *num_skipped;
+          if (element_num_to_skip >
+              dataset()->block_length_ - block_index_) {
+            element_num_to_skip = dataset()->block_length_ - block_index_;
+          }
+          bool end_of_element = false;
+          int element_num_skipped = 0;
+          TF_RETURN_IF_ERROR(current_elements_[cycle_index_]->Skip(
+              ctx, element_num_to_skip, &end_of_element,
+              &element_num_skipped));
+          *num_skipped += element_num_skipped;
+          if (end_of_element) {
+            // We have reached the end of the current element, so move
+            // on to the next element in the cycle.
+            current_elements_[cycle_index_].reset();
+            args_list_[cycle_index_].clear();
+            --num_open_;
+            AdvanceToNextInCycle();
+          } else {
+            block_index_ += element_num_skipped;
+            if (block_index_ == dataset()->block_length_) {
+              AdvanceToNextInCycle();
+            }
+          }
+          if (num_to_skip == *num_skipped) {
+            *end_of_sequence = false;
+            return Status::OK();
           }
         } else {
-          AdvanceToNextInCycle();
+          TF_RETURN_IF_ERROR(MoveToNextElement(ctx));
         }
       }
 
@@ -284,6 +317,26 @@ class InterleaveDatasetOp::Dataset : public DatasetBase {
         } else {
           current_elements_[idx].reset();
         }
+      }
+      return Status::OK();
+    }
+
+    Status MoveToNextElement(IteratorContext* ctx)
+        TF_EXCLUSIVE_LOCKS_REQUIRED(mu_) {
+      if (!end_of_input_) {
+        // Get the next element from the input dataset, and create
+        // an iterator from it.
+        TF_RETURN_IF_ERROR(input_impl_->GetNext(
+            ctx, &args_list_[cycle_index_], &end_of_input_));
+        if (!end_of_input_) {
+          TF_RETURN_IF_ERROR(MakeIteratorFromInputElement(
+              ctx, this, args_list_[cycle_index_], cycle_index_,
+              *instantiated_captured_func_, prefix(),
+              &current_elements_[cycle_index_], model_node()));
+          ++num_open_;
+        }
+      } else {
+        AdvanceToNextInCycle();
       }
       return Status::OK();
     }

--- a/tensorflow/core/kernels/data/interleave_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/interleave_dataset_op_test.cc
@@ -335,6 +335,58 @@ std::vector<GetNextTestCase<InterleaveDatasetParams>> GetNextTestCases() {
 ITERATOR_GET_NEXT_TEST_P(InterleaveDatasetOpTest, InterleaveDatasetParams,
                          GetNextTestCases())
 
+std::vector<SkipTestCase<InterleaveDatasetParams>> SkipTestCases() {
+  return {{/*dataset_params=*/InterleaveDatasetParams1(),
+           /*num_to_skip*/ 0, /*expected_num_skipped*/ 0, /*get_next*/ true,
+           /*expected_outputs=*/
+           CreateTensors<int64>(TensorShape({1}), {{0}})},
+          {/*dataset_params=*/InterleaveDatasetParams1(),
+           /*num_to_skip*/ 5, /*expected_num_skipped*/ 5, /*get_next*/ true,
+           /*expected_outputs=*/
+           CreateTensors<int64>(TensorShape({1}), {{5}})},
+          {/*dataset_params=*/InterleaveDatasetParams1(),
+           /*num_to_skip*/ 10, /*expected_num_skipped*/ 9},
+          {/*dataset_params=*/InterleaveDatasetParams2(),
+           /*num_to_skip*/ 5, /*expected_num_skipped*/ 5, /*get_next*/ true,
+           /*expected_outputs=*/
+           CreateTensors<int64>(TensorShape({1}), {{5}})},
+          {/*dataset_params=*/InterleaveDatasetParams2(),
+           /*num_to_skip*/ 10, /*expected_num_skipped*/ 9},
+          {/*dataset_params=*/InterleaveDatasetParams3(),
+           /*num_to_skip*/ 5, /*expected_num_skipped*/ 5, /*get_next*/ true,
+           /*expected_outputs=*/
+           CreateTensors<int64>(TensorShape({1}), {{7}})},
+          {/*dataset_params=*/InterleaveDatasetParams3(),
+           /*num_to_skip*/ 10, /*expected_num_skipped*/ 9},
+          {/*dataset_params=*/InterleaveDatasetParams4(),
+           /*num_to_skip*/ 5, /*expected_num_skipped*/ 5, /*get_next*/ true,
+           /*expected_outputs=*/
+           CreateTensors<int64>(TensorShape({1}), {{7}})},
+          {/*dataset_params=*/InterleaveDatasetParams4(),
+           /*num_to_skip*/ 10, /*expected_num_skipped*/ 9},
+          {/*dataset_params=*/InterleaveDatasetParams5(),
+           /*num_to_skip*/ 3, /*expected_num_skipped*/ 3, /*get_next*/ true,
+           /*expected_outputs=*/
+           CreateTensors<tstring>(TensorShape({1}), {{"e"}})},
+          {/*dataset_params=*/InterleaveDatasetParams5(),
+           /*num_to_skip*/ 10, /*expected_num_skipped*/ 9},
+          {/*dataset_params=*/InterleaveDatasetParams6(),
+           /*num_to_skip*/ 3, /*expected_num_skipped*/ 3, /*get_next*/ true,
+           /*expected_outputs=*/
+           CreateTensors<tstring>(TensorShape({1}), {{"d"}})},
+          {/*dataset_params=*/InterleaveDatasetParams6(),
+           /*num_to_skip*/ 10, /*expected_num_skipped*/ 9},
+          {/*dataset_params=*/InterleaveDatasetParams7(),
+           /*num_to_skip*/ 3, /*expected_num_skipped*/ 3, /*get_next*/ true,
+           /*expected_outputs=*/
+           CreateTensors<tstring>(TensorShape({1}), {{"d"}})},
+          {/*dataset_params=*/InterleaveDatasetParams7(),
+           /*num_to_skip*/ 10, /*expected_num_skipped*/ 9}};
+}
+
+ITERATOR_SKIP_TEST_P(InterleaveDatasetOpTest, InterleaveDatasetParams,
+                     SkipTestCases())
+
 TEST_F(InterleaveDatasetOpTest, DatasetNodeName) {
   auto dataset_params = InterleaveDatasetParams1();
   TF_ASSERT_OK(Initialize(dataset_params));


### PR DESCRIPTION
This is a PR from JIZHI Team & TaiJi AI platform in Tencent.

This is a follow up of #46358. I added the `SkipInternal` for `flat_map` and `interleave` so that user could utilize the speed up of `TFRecordDataset` with `tf.data.TFRecordDataset`.

Also, I hope we could discuss about how to deal with the `SkipInternal` for `ParallelInterleaveDataset`, as the output of it could be nondeterministic.

Thank you for your time on reviewing this PR :).

gently ping @aaudiber 