### PR TITLE
Fix for issue #47216

### DIFF
--- a/tensorflow/python/keras/engine/base_layer.py
+++ b/tensorflow/python/keras/engine/base_layer.py
@@ -1868,8 +1868,10 @@ class Layer(module.Module, version_utils.LayerVersionSelector):
           'expecting %s weights. Provided weights: %s...' %
           (self.name, len(weights), expected_num_weights, str(weights)[:50]))
 
-    weights = [np.array(item) for item in weights]
-    
+    for index, item in enumerate(weights):
+      if(str(type(item))=="<class 'tensorflow.python.ops.resource_variable_ops.ResourceVariable'>"):
+          weights[index] = np.array(item)
+
     weight_index = 0
     weight_value_tuples = []
     for param in params:

--- a/tensorflow/python/keras/engine/base_layer.py
+++ b/tensorflow/python/keras/engine/base_layer.py
@@ -1868,6 +1868,8 @@ class Layer(module.Module, version_utils.LayerVersionSelector):
           'expecting %s weights. Provided weights: %s...' %
           (self.name, len(weights), expected_num_weights, str(weights)[:50]))
 
+    weights = [np.array(item) for item in weights]
+    
     weight_index = 0
     weight_value_tuples = []
     for param in params:

--- a/tensorflow/python/keras/engine/base_layer.py
+++ b/tensorflow/python/keras/engine/base_layer.py
@@ -1869,8 +1869,12 @@ class Layer(module.Module, version_utils.LayerVersionSelector):
           (self.name, len(weights), expected_num_weights, str(weights)[:50]))
 
     for index, item in enumerate(weights):
-      if(str(type(item))=="<class 'tensorflow.python.ops.resource_variable_ops.ResourceVariable'>"):
-          weights[index] = np.array(item)
+        if not (isinstance(item, np.ndarray)):
+            raise TypeError(
+              'You called `set_weights(weights)` on layer "%s" '
+              'with a weight list of type %s, but the method was '
+              'expecting a list of Numpy arrays.' %
+              (self.name, type(weights[index])))
 
     weight_index = 0
     weight_value_tuples = []

--- a/tensorflow/python/keras/engine/base_layer.py
+++ b/tensorflow/python/keras/engine/base_layer.py
@@ -1869,12 +1869,14 @@ class Layer(module.Module, version_utils.LayerVersionSelector):
           (self.name, len(weights), expected_num_weights, str(weights)[:50]))
 
     for index, item in enumerate(weights):
-        if not (isinstance(item, np.ndarray)):
+        if isinstance(item, tf_variables.Variable):
+             weights[index] = np.array(item)
+        elif not isinstance(item, np.ndarray):
             raise TypeError(
-              'You called `set_weights(weights)` on layer "%s" '
-              'with a weight list of type %s, but the method was '
+              'You called `set_weights(weights)` on layer '
+              'with a weight list of type %s, but the set_weights() method was '
               'expecting a list of Numpy arrays.' %
-              (self.name, type(weights[index])))
+              (type(weights[index])))
 
     weight_index = 0
     weight_value_tuples = []


### PR DESCRIPTION
FIX TypeError if set the weights to the current weights via `set_weights, 
Incorporated suggestions by @qlzh727 i.e. included type checking to reduce overhead.
Simply, this change will allow users to use .weights to initialize the set_weights() method of a layer without any type error improving the versatility of keras.