### PR TITLE
[ROCm] Fix for ROCm CSB breakage - 210309

### DIFF
--- a/tensorflow/core/util/gpu_device_functions.h
+++ b/tensorflow/core/util/gpu_device_functions.h
@@ -741,8 +741,7 @@ __device__ inline double GpuAtomicAdd(double* ptr, double value) {
 // components individually. The operation as a whole is not atomic, but we can
 // safely treat the components independently for the purpose of accumulating.
 
-// ROCM TODO support GpuAtomicAdd for std::complex<>
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 __device__ inline std::complex<float> GpuAtomicAdd(std::complex<float>* ptr,
                                                    std::complex<float> value) {
   auto ptr_scalar = reinterpret_cast<float*>(ptr);


### PR DESCRIPTION
The following commit breaks the ROCm build

https://github.com/tensorflow/tensorflow/commit/abe97cb58c3eb139d4628b5d2c268a7e7a282115

```
In file included from tensorflow/core/kernels/sparse_tensor_dense_matmul_op_gpu.cu.cc:23:
In file included from ./tensorflow/core/util/gpu_kernel_helper.h:25:
./tensorflow/core/util/gpu_device_functions.h:721:10: error: no matching function for call to 'atomicAdd'
  return atomicAdd(detail::ToCudaSupportedPtr(ptr), value);
         ^~~~~~~~~
tensorflow/core/kernels/sparse_tensor_dense_matmul_op_gpu.cu.cc:63:7: note: in instantiation of function template specialization 'tensorflow::GpuAtomicAdd<std::complex<float>, std::complex<float>>' requested here
      GpuAtomicAdd(out_location, OutOfBoundsValue<Tsum>::value());
      ^
tensorflow/core/kernels/sparse_tensor_dense_matmul_op_gpu.cu.cc:119:9: note: in instantiation of function template specialization 'tensorflow::SparseTensorDenseMatMulKernel<std::complex<float>, std::complex<float>, int, false, false>' requested here
        SparseTensorDenseMatMulKernel<T, Tsum, Tindices, ADJ_A, ADJ_B>,
        ^
/opt/rocm-4.0.1/hip/include/hip/hcc_detail/hip_atomic.h:39:5: note: candidate function not viable: no known conversion from 'CudaSupportedType<std::complex<float>> *' (aka 'std::complex<float> *') to 'int *' for 1st argument
int atomicAdd(int* address, int val)
    ^
/opt/rocm-4.0.1/hip/include/hip/hcc_detail/hip_atomic.h:45:14: note: candidate function not viable: no known conversion from 'CudaSupportedType<std::complex<float>> *' (aka 'std::complex<float> *') to 'unsigned int *' for 1st argument
unsigned int atomicAdd(unsigned int* address, unsigned int val)
             ^
/opt/rocm-4.0.1/hip/include/hip/hcc_detail/hip_atomic.h:51:20: note: candidate function not viable: no known conversion from 'CudaSupportedType<std::complex<float>> *' (aka 'std::complex<float> *') to 'unsigned long long *' for 1st argument
unsigned long long atomicAdd(
                   ^
/opt/rocm-4.0.1/hip/include/hip/hcc_detail/hip_atomic.h:58:7: note: candidate function not viable: no known conversion from 'CudaSupportedType<std::complex<float>> *' (aka 'std::complex<float> *') to 'float *' for 1st argument
float atomicAdd(float* address, float val)
      ^
/opt/rocm-4.0.1/hip/include/hip/hcc_detail/hip_atomic.h:86:8: note: candidate function not viable: no known conversion from 'CudaSupportedType<std::complex<float>> *' (aka 'std::complex<float> *') to 'double *' for 1st argument
double atomicAdd(double* address, double val)
```

This commit fixes the build error by enabling for ROCm, the `GpuAtomicAdd` specialization for std::complex types, already in place for CUDA

--------------------------------------------------

/cc @cheshire @chsigg 