### PR TITLE
Add command line option to select `-stdlib=libc++` with Xtensa.

### DIFF
--- a/tensorflow/lite/micro/tools/make/targets/xtensa_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/xtensa_makefile.inc
@@ -9,6 +9,7 @@
 #      For example: hifimini
 
 TARGET_ARCH :=
+XTENSA_USE_LIBC :=
 
 ifndef XTENSA_BASE
   $(error XTENSA_BASE is undefined)
@@ -36,7 +37,6 @@ PLATFORM_FLAGS = \
   -DTF_LITE_USE_CTIME \
   --xtensa-core=$(XTENSA_CORE) \
   -mcoproc \
-  -stdlib=libc++ \
   -DMAX_RFFT_PWR=9 \
   -DMIN_RFFT_PWR=MAX_RFFT_PWR \
   $(TARGET_ARCH_DEFINES)
@@ -49,6 +49,21 @@ export PATH := $(XTENSA_BASE)/tools/$(XTENSA_TOOLS_VERSION)/XtensaTools/bin:$(PA
 TARGET_TOOLCHAIN_PREFIX := xt-
 CXX_TOOL := clang++
 CC_TOOL := clang
+
+# Unused exception related symbols make their way into a binary that links
+# against TFLM as described in https://github.com/tensorflow/tensorflow/issues/47575.
+# We have two options to avoid this. The first involves using -stdlib=libc++ and
+# the second involves stubbing out and modifying some of the files in the Xtensa
+# toolchain to prevent inclusion of the exception handling code
+# (http://b/182209217#comment3). This Makefile supports building TFLM in a way
+# that is compatible with either of the two approaches.
+ifeq ($(XTENSA_USE_LIBC), true)
+  PLATFORM_FLAGS += -stdlib=libc++
+else
+  # TODO(b/150240249): Do not filter-out -fno-rtti once that works for the
+  # Xtensa toolchain.
+  CXXFLAGS := $(filter-out -fno-rtti, $(CXXFLAGS))
+endif
 
 CXXFLAGS += $(PLATFORM_FLAGS)
 CCFLAGS += $(PLATFORM_FLAGS)


### PR DESCRIPTION
Confirmed that the following two commands build and we see different sizes with and without `XTENSA_USE_LIBC=true`.

```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=fusion_f1 XTENSA_CORE=F1_190305_swupgrade keyword_benchmark -j8 BUILD_TYPE=release XTENSA_USE_LIBC=true
xt-size tensorflow/lite/micro/tools/make/gen/xtensa_fusion_f1_release/bin/keyword_benchmark
```
gives:
```
   text	   data	    bss	    dec	    hex	filename
  84496	    384	  22704	 107584	  1a440	tensorflow/lite/micro/tools/make/gen/xtensa_fusion_f1_release/bin/keyword_benchmark
```

And
```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=fusion_f1 XTENSA_CORE=F1_190305_swupgrade keyword_benchmark -j8 BUILD_TYPE=release
xt-size tensorflow/lite/micro/tools/make/gen/xtensa_fusion_f1_release/bin/keyword_benchmark
```

gives:
```
   text	   data	    bss	    dec	    hex	filename
  66696	  40212	  24856	 131764	  202b4 tensorflow/lite/micro/tools/make/gen/xtensa_fusion_f1_release/bin/keyword_benchmark
```

Progress towards #47575 and http://b/182209217
