### PR TITLE
build_pip_package_with_bazel: add support of Bazel startup option

### DIFF
--- a/tensorflow/lite/tools/pip_package/build_pip_package_with_bazel.sh
+++ b/tensorflow/lite/tools/pip_package/build_pip_package_with_bazel.sh
@@ -88,7 +88,7 @@ case "${TENSORFLOW_TARGET}" in
     ;;
 esac
 
-bazel build -c opt -s --config=monolithic --config=noaws --config=nogcp --config=nohdfs --config=nonccl \
+bazel ${BAZEL_STARTUP_OPTIONS} build -c opt -s --config=monolithic --config=noaws --config=nogcp --config=nohdfs --config=nonccl \
   ${BAZEL_FLAGS} ${CUSTOM_BAZEL_FLAGS} //tensorflow/lite/python/interpreter_wrapper:_pywrap_tensorflow_interpreter_wrapper
 cp "${TENSORFLOW_DIR}/bazel-bin/tensorflow/lite/python/interpreter_wrapper/_pywrap_tensorflow_interpreter_wrapper${LIBRARY_EXTENSION}" \
    "${BUILD_DIR}/tflite_runtime"


### PR DESCRIPTION
Bazel startup options must appear before the name of the Bazel command.

This commit adds a BAZEL_ARGS variable to be able to specify startup option.

Signed-off-by: Julien STEPHAN <jstephan@baylibre.com>