### PR TITLE
TF-TRT CombinedNMS: fix top_k parameter max value

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -6151,6 +6151,20 @@ Status ConvertSquaredDifference(OpConverterParams* params) {
 }
 
 #if IS_TRT_VERSION_GE(7, 1, 3, 0)
+
+bool AllowNmsTopkOverride() {
+  static bool result = [] {
+    bool value;
+    Status status = ReadBoolFromEnvVar("TF_TRT_ALLOW_NMS_TOPK_OVERRIDE",
+                                       /*default_value=*/false, &value);
+    if (!status.ok()) {
+      LOG(ERROR) << status;
+    }
+    return value;
+  }();
+  return result;
+}
+
 Status ConvertCombinedNMS(OpConverterParams* params) {
   TF_RETURN_IF_ERROR(
       CheckInputsWeights(*params, {{"boxes", false},
@@ -6235,8 +6249,6 @@ Status ConvertCombinedNMS(OpConverterParams* params) {
         node_def.name());
   }
 
-  if (params->validation_only) return Status::OK();
-
   // TRT op is_normalized=False treats input corrdinates as pixels and
   // calculates width/height as (max - min + 1).
   //
@@ -6256,10 +6268,30 @@ Status ConvertCombinedNMS(OpConverterParams* params) {
   } else {
     keep_top_k = max_total_size;
   }
+
   // According to the batchedNMS plugin description we need to set top_k so that
   // keep_top_k <= top_k
   // https://github.com/NVIDIA/TensorRT/tree/master/plugin/batchedNMSPlugin
-  const int top_k = std::max(num_boxes, keep_top_k);
+  // Before the NMS step, TRT selects top_k candidate from each class and
+  // discards the rest. The NMS step is performed only among the top_k
+  // candidates. To be strictly compatible with the TF op, we need that top_k is
+  // greater equal to num_boxes.
+  int top_k = std::max(num_boxes, keep_top_k);
+  // TRT has a limitation: top_k <=4096.
+  if (top_k > 4096) {
+    if (AllowNmsTopkOverride()) {
+      top_k = 4096;
+      keep_top_k = std::min(top_k, keep_top_k);
+    } else {
+      return errors::InvalidArgument(
+          "TRT NMS plugin allow top_k<=4096, where top_k = max(num_boxes, "
+          "max_total_size). You can override this by setting "
+          "TF_TRT_ALLOW_NMS_TOPK_OVERRIDE=1 environment variable, but this can "
+          "result in a loss of accuracy.");
+    }
+  }
+
+  if (params->validation_only) return Status::OK();
   float score_thresh = *(static_cast<float*>(score_threshold.GetValues()));
   const int background_id = -1;
   nvinfer1::PluginField fields[9] = {

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -3419,6 +3419,30 @@ TEST_P(OpConverter_FP32_Test, ConvertCombinedNMS) {
           {0, 0, 0, -1},  // exp_classes
           {3},            // exp_num_detections
           conv_status},
+      TestParams{"Test 5: TopK error",
+                 {1, 5000, 1, 4},  // boxes dims
+                 {1, 5000, 1},     // scores dims
+                 {},               // boxes values:
+                 {},               // scores values
+                 4,                // max_output_size_per_class
+                 4,                // max_total_size
+                 0.1,              // IOU threshold
+                 0,                // score threshold
+                 false,            // pad_per_class
+                 false,            // clip_boxes
+                 {},               // expected_valid_detections_dims
+                 {},               // exp_boxes_values
+                 {},               // exp_scores
+                 {},               // exp_classes
+                 {},               // exp_num_detections
+                 conv_status.ok()
+                     ? errors::InvalidArgument(
+                           "TRT NMS plugin allow top_k<=4096, where top_k = "
+                           "max(num_boxes, max_total_size). You can override "
+                           "this by setting TF_TRT_ALLOW_NMS_TOPK_OVERRIDE=1 "
+                           "environment variable, but this can result in a "
+                           "loss of accuracy.")
+                     : conv_status},
   };
 
   for (auto p : params) {

--- a/tensorflow/python/compiler/tensorrt/test/combined_nms_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/combined_nms_test.py
@@ -31,6 +31,10 @@ from tensorflow.python.platform import test
 class CombinedNmsTest(trt_test.TfTrtIntegrationTestBase):
   """Test for CombinedNMS op in TF-TRT."""
 
+  def setUp(self):
+    super().setUp()
+    self.num_boxes = 200
+
   def GraphFn(self, boxes, scores):
     max_output_size_per_class = 3
     max_total_size = 3
@@ -64,12 +68,11 @@ class CombinedNmsTest(trt_test.TfTrtIntegrationTestBase):
     # Parameters
     q = 1
     batch_size = 2
-    num_boxes = 200
     num_classes = 2
     max_total_size = 3
 
-    boxes_shape = [batch_size, num_boxes, q, 4]
-    scores_shape = [batch_size, num_boxes, num_classes]
+    boxes_shape = [batch_size, self.num_boxes, q, 4]
+    scores_shape = [batch_size, self.num_boxes, num_classes]
     nmsed_boxes_shape = [batch_size, max_total_size, 4]
     nmsed_scores_shape = [batch_size, max_total_size]
     nmsed_classes_shape = [batch_size, max_total_size]
@@ -199,6 +202,21 @@ class CombinedNmsTestTopK(CombinedNmsTest):
                                 nmsed_classes_shape, valid_detections_shape
                             ])
 
+
+class CombinedNmsTopKOverride(CombinedNmsTest):
+  def setUp(self):
+    super().setUp()
+    self.num_boxes = 5000
+    os.environ['TF_TRT_ALLOW_NMS_TOPK_OVERRIDE'] = '1'
+
+  def tearDown(self):
+    super().tearDown()
+    os.environ['TF_TRT_ALLOW_NMS_TOPK_OVERRIDE'] = '0'
+
+  def GetMaxBatchSize(self, run_params):
+    """Returns the max_batch_size that the converter should use for tests."""
+    if run_params.dynamic_engine:
+      return None
 
 if __name__ == '__main__':
   test.main()


### PR DESCRIPTION
Fixes #46453

The TRT plugin has a limitation on the max value of the top_k input parameter. This PR modifies the converter to refuse conversion if top_k > 4096. 

In some cases it might be desirable to do the conversion, even if the top_k<=4096 restriction would lead to loss of accuracy. The user can set TF_TRT_ALLOW_NMS_TOPK_OVERRIDE=1 environment variable can be set to opt-in for conversion in this case.
