### PR TITLE
Note tf.cast truncates floating-point when casting to integral types

### DIFF
--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -918,7 +918,8 @@ def cast(x, dtype, name=None):
   types, only the real part of `x` is returned. In case of casting from real
   types to complex types (`complex64`, `complex128`), the imaginary part of the
   returned value is set to `0`. The handling of complex types here matches the
-  behavior of numpy.
+  behavior of numpy. In case of casting from floating-point types to integral
+  types, the number is truncated towards zero.
 
   Note casting nan and inf values to integral types has undefined behavior.
 


### PR DESCRIPTION
I had assumed that it would round to the nearest integer; I was wrong.

I assume that this behavior is deliberate and should be defined, rather than left undefined or implementation-defined.