### PR TITLE
Add \r and \n to DEFAULT_STRIP_REGEX

### DIFF
--- a/tensorflow/python/keras/layers/preprocessing/text_vectorization.py
+++ b/tensorflow/python/keras/layers/preprocessing/text_vectorization.py
@@ -51,7 +51,7 @@ COUNT = index_lookup.COUNT
 # This is an explicit regex of all the tokens that will be stripped if
 # LOWER_AND_STRIP_PUNCTUATION is set. If an application requires other
 # stripping, a Callable should be passed into the 'standardize' arg.
-DEFAULT_STRIP_REGEX = r'[!"#$%&()\*\+,-\./:;<=>?@\[\\\]^_`{|}~\']'
+DEFAULT_STRIP_REGEX = r'[!"\r\n#$%&()\*\+,-\./:;<=>?@\[\\\]^_`{|}~\']'
 
 # The string tokens in the extracted vocabulary
 _VOCAB_NAME = "vocab"


### PR DESCRIPTION
I worked with text vectorization and I thought that \r and \n needed to be cropped off. 