### PR TITLE
[Intel MKL] Upgrading to oneDNN 2.1

### DIFF
--- a/tensorflow/core/graph/mkl_graph_util.h
+++ b/tensorflow/core/graph/mkl_graph_util.h
@@ -89,14 +89,14 @@ bool inline DoesControlEdgeExist(const Node* src, const Node* dst) {
 }
 
 // Check if graph should run in layout-dependent mode or native format mode
-// based on environment variable setting. User can set
-// TF_ENABLE_MKL_NATIVE_FORMAT=1 to enable the native format mode.
+// based on environment variable setting. Native format mode is default. User
+// can set TF_ENABLE_MKL_NATIVE_FORMAT=0 to disable the native format mode.
 bool inline NativeFormatEnabled() {
-  static bool native_fmt_enabled = false;
+  static bool native_fmt_enabled = true;
   static absl::once_flag once;
   absl::call_once(once, [&] {
     TF_CHECK_OK(ReadBoolFromEnvVar("TF_ENABLE_MKL_NATIVE_FORMAT",
-                                   /*default_value*/ false,
+                                   /*default_value*/ true,
                                    &native_fmt_enabled));
   });
   return native_fmt_enabled;

--- a/tensorflow/core/kernels/mkl/mkl_matmul_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_op.cc
@@ -157,8 +157,8 @@ class MklMatMulOp : public OpKernel {
     VLOG(2) << "MKL DNN SGEMM called";
 #ifndef ENABLE_ONEDNN_OPENMP
     MklDnnThreadPool eigen_tp(ctx);
-    dnnl_sgemm_tp(char_transa, char_transb, m, n, k, alpha, a, lda, b, ldb,
-                  beta, c, ldc, &eigen_tp);
+    dnnl::threadpool_interop::sgemm(char_transa, char_transb, m, n, k, alpha, a,
+                                    lda, b, ldb, beta, c, ldc, &eigen_tp);
 #else
     dnnl_sgemm(char_transa, char_transb, m, n, k, alpha, a, lda, b, ldb, beta,
                c, ldc);

--- a/tensorflow/core/util/mkl_threadpool.h
+++ b/tensorflow/core/util/mkl_threadpool.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
+#include "dnnl_threadpool.hpp"
 #include "mkldnn.hpp"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/platform/threadpool.h"
@@ -33,8 +34,7 @@ limitations under the License.
 namespace tensorflow {
 
 #ifndef ENABLE_ONEDNN_OPENMP
-using dnnl::stream_attr;
-using dnnl::threadpool_iface;
+using dnnl::threadpool_interop::threadpool_iface;
 
 // Divide 'n' units of work equally among 'teams' threads. If 'n' is not
 // divisible by 'teams' and has a remainder 'r', the first 'r' teams have one
@@ -60,7 +60,7 @@ inline void balance211(T n, U team, U tid, T* n_start, T* n_end) {
   *n_end = *n_start + min_per_team + (tid < remainder);
 }
 
-struct MklDnnThreadPool : public dnnl::threadpool_iface {
+struct MklDnnThreadPool : public threadpool_iface {
   MklDnnThreadPool() = default;
 
   MklDnnThreadPool(OpKernelContext* ctx)

--- a/tensorflow/core/util/mkl_util.h
+++ b/tensorflow/core/util/mkl_util.h
@@ -225,11 +225,9 @@ inline bool array_cmp(const T* a1, const T* a2, size_t size) {
 inline mkldnn::stream* CreateStream(MklDnnThreadPool* eigen_tp,
                                     const engine& engine) {
 #ifndef ENABLE_ONEDNN_OPENMP
-  stream_attr tp_stream_attr(engine::kind::cpu);
   if (eigen_tp != nullptr) {
-    tp_stream_attr.set_threadpool(eigen_tp);
     stream* tp_stream =
-        new stream(engine, stream::flags::default_flags, tp_stream_attr);
+        new stream(dnnl::threadpool_interop::make_stream(engine, eigen_tp));
     return tp_stream;
   } else {
     stream* tp_stream = new stream(engine);

--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -167,12 +167,13 @@ def _tf_repositories():
 
     tf_http_archive(
         name = "mkl_dnn_v1",
+        patch_file = "//third_party/mkl_dnn:build_fix.patch",
         build_file = "//third_party/mkl_dnn:mkldnn_v1.BUILD",
-        sha256 = "5369f7b2f0b52b40890da50c0632c3a5d1082d98325d0f2bff125d19d0dcaa1d",
-        strip_prefix = "oneDNN-1.6.4",
+        sha256 = "5f7fd92e2d0bf83580656695d4404e2cd1390ecad36496fd8ba10b5adc905f70",
+        strip_prefix = "oneDNN-2.1",
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/oneapi-src/oneDNN/archive/v1.6.4.tar.gz",
-            "https://github.com/oneapi-src/oneDNN/archive/v1.6.4.tar.gz",
+            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/oneapi-src/oneDNN/archive/v2.1.tar.gz",
+            "https://github.com/oneapi-src/oneDNN/archive/v2.1.tar.gz",
         ],
     )
 

--- a/third_party/mkl_dnn/build_fix.patch
+++ b/third_party/mkl_dnn/build_fix.patch
@@ -1,0 +1,66 @@
+diff --git a/src/common/utils.hpp b/src/common/utils.hpp
+index b2d554ea3..155a6da0a 100644
+--- a/src/common/utils.hpp
++++ b/src/common/utils.hpp
+@@ -17,7 +17,17 @@
+ #ifndef COMMON_UTILS_HPP
+ #define COMMON_UTILS_HPP
+ 
++#if (__GNUC__ == 7)
++#pragma GCC push_options
++#pragma GCC optimize("O0")
++#endif
++
+ #include <atomic>
++
++#if (__GNUC__ == 7)
++#pragma GCC pop_options
++#endif
++
+ #include <cassert>
+ #include <cstddef>
+ #include <cstdint>
+diff -u a/src/cpu/x64/jit_avx512_core_amx_convolution.cpp b/src/cpu/x64/jit_avx512_core_amx_convolution.cpp
+--- a/src/cpu/x64/jit_avx512_core_amx_convolution.cpp
++++ b/src/cpu/x64/jit_avx512_core_amx_convolution.cpp
+@@ -38,10 +38,14 @@
+     (pd()->with_groups() ? (d).blk_off((g), __VA_ARGS__) \
+                          : (d).blk_off(__VA_ARGS__))
+
+-#define mem_blk_off(md, ndims, n, c, d, h, w) \
+-    (ndims) == 3 ? (md).blk_off((n), (c), (w)) \
+-                 : (ndims) == 4 ? (md).blk_off((n), (c), (h), (w)) \
+-                                : (md).blk_off((n), (c), (d), (h), (w))
++inline int mem_blk_off(const memory_desc_wrapper& md, int ndims, int n, int c,
++                       int d, int h, int w) {
++  switch (ndims) {
++    case 3: return md.blk_off((n), (c), (w));
++    case 4: return md.blk_off((n), (c), (h), (w));
++    default: return md.blk_off((n), (c), (d), (h), (w));
++  }
++}
+
+ template <data_type_t src_type, data_type_t wei_type, data_type_t dst_type>
+ void jit_avx512_core_amx_convolution_fwd_t<src_type, wei_type,
+diff -u a/src/cpu/x64/jit_avx512_core_amx_1x1_convolution.cpp b/src/cpu/x64/jit_avx512_core_amx_1x1_convolution.cpp
+--- a/src/cpu/x64/jit_avx512_core_amx_1x1_convolution.cpp
++++ b/src/cpu/x64/jit_avx512_core_amx_1x1_convolution.cpp
+@@ -38,10 +38,14 @@
+     (pd()->with_groups() ? (d).blk_off((g), __VA_ARGS__) \
+                          : (d).blk_off(__VA_ARGS__))
+
+-#define md_blk_off(md, ndims, n, c, d, h, w) \
+-    (ndims) == 3 ? (md).blk_off((n), (c), (w)) \
+-                 : (ndims) == 4 ? (md).blk_off((n), (c), (h), (w)) \
+-                                : (md).blk_off((n), (c), (d), (h), (w));
++inline int md_blk_off(const memory_desc_wrapper& md, int ndims, int n, int c,
++                       int d, int h, int w) {
++  switch (ndims) {
++    case 3: return md.blk_off((n), (c), (w));
++    case 4: return md.blk_off((n), (c), (h), (w));
++    default: return md.blk_off((n), (c), (d), (h), (w));
++  }
++}
+
+ template <data_type_t src_type, data_type_t wei_type, data_type_t dst_type>
+ void jit_avx512_core_amx_1x1_convolution_fwd_t<src_type, wei_type,

--- a/third_party/mkl_dnn/mkldnn_v1.BUILD
+++ b/third_party/mkl_dnn/mkldnn_v1.BUILD
@@ -25,24 +25,33 @@ _DNNL_RUNTIME_OMP = {
     "#cmakedefine DNNL_CPU_THREADING_RUNTIME DNNL_RUNTIME_${DNNL_CPU_THREADING_RUNTIME}": "#define DNNL_CPU_THREADING_RUNTIME DNNL_RUNTIME_OMP",
     "#cmakedefine DNNL_CPU_RUNTIME DNNL_RUNTIME_${DNNL_CPU_RUNTIME}": "#define DNNL_CPU_RUNTIME DNNL_RUNTIME_OMP",
     "#cmakedefine DNNL_GPU_RUNTIME DNNL_RUNTIME_${DNNL_GPU_RUNTIME}": "#define DNNL_GPU_RUNTIME DNNL_RUNTIME_NONE",
+    "#cmakedefine DNNL_WITH_SYCL": "#undef DNNL_WITH_SYCL",
+    "#cmakedefine DNNL_WITH_LEVEL_ZERO": "#undef DNNL_WITH_LEVEL_ZERO",
+    "#cmakedefine DNNL_SYCL_CUDA": "#undef DNNL_SYCL_CUDA",
 }
 
 _DNNL_RUNTIME_THREADPOOL = {
     "#cmakedefine DNNL_CPU_THREADING_RUNTIME DNNL_RUNTIME_${DNNL_CPU_THREADING_RUNTIME}": "#define DNNL_CPU_THREADING_RUNTIME DNNL_RUNTIME_THREADPOOL",
     "#cmakedefine DNNL_CPU_RUNTIME DNNL_RUNTIME_${DNNL_CPU_RUNTIME}": "#define DNNL_CPU_RUNTIME DNNL_RUNTIME_THREADPOOL",
     "#cmakedefine DNNL_GPU_RUNTIME DNNL_RUNTIME_${DNNL_GPU_RUNTIME}": "#define DNNL_GPU_RUNTIME DNNL_RUNTIME_NONE",
+    "#cmakedefine DNNL_WITH_SYCL": "#undef DNNL_WITH_SYCL",
+    "#cmakedefine DNNL_WITH_LEVEL_ZERO": "#undef DNNL_WITH_LEVEL_ZERO",
+    "#cmakedefine DNNL_SYCL_CUDA": "#undef DNNL_SYCL_CUDA",
 }
 
 _DNNL_RUNTIME_SEQ = {
     "#cmakedefine DNNL_CPU_THREADING_RUNTIME DNNL_RUNTIME_${DNNL_CPU_THREADING_RUNTIME}": "#define DNNL_CPU_THREADING_RUNTIME DNNL_RUNTIME_SEQ",
     "#cmakedefine DNNL_CPU_RUNTIME DNNL_RUNTIME_${DNNL_CPU_RUNTIME}": "#define DNNL_CPU_RUNTIME DNNL_RUNTIME_SEQ",
     "#cmakedefine DNNL_GPU_RUNTIME DNNL_RUNTIME_${DNNL_GPU_RUNTIME}": "#define DNNL_GPU_RUNTIME DNNL_RUNTIME_NONE",
+    "#cmakedefine DNNL_WITH_SYCL": "#undef DNNL_WITH_SYCL",
+    "#cmakedefine DNNL_WITH_LEVEL_ZERO": "#undef DNNL_WITH_LEVEL_ZERO",
+    "#cmakedefine DNNL_SYCL_CUDA": "#undef DNNL_SYCL_CUDA",
 }
 
 template_rule(
     name = "dnnl_config_h",
-    src = "include/dnnl_config.h.in",
-    out = "include/dnnl_config.h",
+    src = "include/oneapi/dnnl/dnnl_config.h.in",
+    out = "include/oneapi/dnnl/dnnl_config.h",
     substitutions = select({
         "@org_tensorflow//third_party/mkl_dnn:build_with_mkldnn_openmp": _DNNL_RUNTIME_OMP,
         "@org_tensorflow//third_party/mkl:build_with_mkl": _DNNL_RUNTIME_THREADPOOL,
@@ -59,29 +68,32 @@ template_rule(
 # TODO(agramesh1): Automatically get the version numbers from CMakeLists.txt.
 template_rule(
     name = "dnnl_version_h",
-    src = "include/dnnl_version.h.in",
-    out = "include/dnnl_version.h",
+    src = "include/oneapi/dnnl/dnnl_version.h.in",
+    out = "include/oneapi/dnnl/dnnl_version.h",
     substitutions = {
-        "@DNNL_VERSION_MAJOR@": "1",
-        "@DNNL_VERSION_MINOR@": "6",
-        "@DNNL_VERSION_PATCH@": "4",
+        "@DNNL_VERSION_MAJOR@": "2",
+        "@DNNL_VERSION_MINOR@": "1",
+        "@DNNL_VERSION_PATCH@": "0",
         "@DNNL_VERSION_HASH@": "N/A",
     },
 )
 
 cc_library(
     name = "mkl_dnn",
-    srcs = glob([
-        "src/common/*.cpp",
-        "src/common/*.hpp",
-        "src/cpu/*.cpp",
-        "src/cpu/*.hpp",
-        "src/cpu/**/*.cpp",
-        "src/cpu/**/*.hpp",
-        "src/cpu/xbyak/*.h",
-        "src/cpu/x64/jit_utils/jitprofiling/*.c",
-        "src/cpu/x64/jit_utils/jitprofiling/*.h",
-    ]) + [
+    srcs = glob(
+        [
+            "src/common/*.cpp",
+            "src/common/*.hpp",
+            "src/cpu/*.cpp",
+            "src/cpu/*.hpp",
+            "src/cpu/**/*.cpp",
+            "src/cpu/**/*.hpp",
+            "src/cpu/x64/xbyak/*.h",
+            "src/cpu/x64/jit_utils/jitprofiling/*.c",
+            "src/cpu/x64/jit_utils/jitprofiling/*.h",
+        ],
+        exclude = ["src/cpu/aarch64/**"],
+    ) + [
         ":dnnl_config_h",
         ":dnnl_version_h",
     ],
@@ -100,7 +112,7 @@ cc_library(
         "src/common",
         "src/cpu",
         "src/cpu/gemm",
-        "src/cpu/xbyak",
+        "src/cpu/x64/xbyak",
     ],
     visibility = ["//visibility:public"],
     deps = if_mkl_ml(
@@ -116,6 +128,7 @@ cc_library(
         "src/cpu/*.cpp",
         "src/cpu/gemm/**/*.cpp",
         "src/cpu/matmul/**/*.cpp",
+        "src/cpu/reorder/*.cpp",
         "src/cpu/rnn/**/*.cpp",
         "src/cpu/x64/**/*.cpp",
         "src/cpu/x64/jit_utils/jitprofiling/*.c",


### PR DESCRIPTION
This PR upgrades oneDNN version to 2.1. It also includes a patch to fix 2 build errors with certain gcc versions. So [this ](https://github.com/tensorflow/tensorflow/commit/ce7ad9e58aabea67595afa0d601f7277d93ba7e9#diff-501d1399b467b9f36e528126219bea5c3c9d6b2156248f6fe44e5c33eae5f0f5) patch is also included in this PR. 