### PR TITLE
Fix build failure undefined reference to hwloc_linuxio_component on aarch64

### DIFF
--- a/third_party/hwloc/BUILD.bazel
+++ b/third_party/hwloc/BUILD.bazel
@@ -262,6 +262,10 @@ cc_library(
             "hwloc/topology-x86.c",
             "include/private/cpuid-x86.h",
         ],
+        "@org_tensorflow//tensorflow:linux_aarch64": [
+            "hwloc/topology-linux.c",
+            "include/hwloc/linux.h",
+        ],
         "@org_tensorflow//tensorflow:linux_ppc64le": [
             "hwloc/topology-linux.c",
             "include/hwloc/linux.h",


### PR DESCRIPTION
This is the same fix as previously in the file but for aarch64 instead of ppc64le, for the same reason.