### PR TITLE
Clarify behavior of array_to_img(scale=True)

### DIFF
--- a/tensorflow/python/keras/preprocessing/image.py
+++ b/tensorflow/python/keras/preprocessing/image.py
@@ -162,13 +162,13 @@ def array_to_img(x, data_format=None, scale=True, dtype=None):
 
 
   Args:
-      x: Input Numpy array.
+      x: Input data, in any form that can be converted to a Numpy array.
       data_format: Image data format, can be either "channels_first" or
         "channels_last". Defaults to `None`, in which case the global setting
         `tf.keras.backend.image_data_format()` is used (unless you changed it,
         it defaults to "channels_last").
-      scale: Whether to rescale image values to be within `[0, 255]`. Defaults
-        to `True`.
+      scale: Whether to rescale the image such that minimum and maximum values
+        are 0 and 255 respectively. Defaults to `True`.
       dtype: Dtype to use. Default to `None`, in which case the global setting
       `tf.keras.backend.floatx()` is used (unless you changed it, it defaults
       to "float32")


### PR DESCRIPTION
I was confused why my images looked wrong (e.g., `apply_brightness_shift` does nothing?!). I had interpreted `scale=True` to mean "multiply by 255 to go from `[0,1]` format to `[0,255]` format". This is _not_ what it does. I've copied the more precise docs from https://github.com/keras-team/keras-preprocessing/blob/master/keras_preprocessing/image/utils.py#L271-L272

(I've also made the `x` doc more precise - it does not just accept a Numpy array; e.g. it accepts tensors)