### PR TITLE
Do not specialize eigen convolution classes for ppc64le arch

### DIFF
--- a/tensorflow/core/kernels/eigen_cuboid_convolution.h
+++ b/tensorflow/core/kernels/eigen_cuboid_convolution.h
@@ -25,10 +25,17 @@ limitations under the License.
 
 #include "tensorflow/core/kernels/eigen_convolution_helpers.h"
 
+#if defined(EIGEN_VECTORIZE_ALTIVEC) || defined(EIGEN_VECTORIZE_VSX)
+#define TF_USE_CUSTOM_EIGEN_PACK 0
+#else
+#define TF_USE_CUSTOM_EIGEN_PACK 1
+#endif
+
 namespace Eigen {
 
 namespace internal {
 
+#if TF_USE_CUSTOM_EIGEN_PACK
 // WARNING: Most of the code here implicitly assumes that the matrix is in
 // ColMajor layout. This is guaranteed by the tensor contraction (see
 // TensorContraction.h).
@@ -1625,6 +1632,7 @@ struct gemm_pack_rhs<
     }
   }
 };
+#endif
 
 #if defined(TENSORFLOW_USE_CUSTOM_CONTRACTION_KERNEL)
 // Pack a block of the right input matrix (in our case it's always a "virtual

--- a/tensorflow/core/kernels/eigen_spatial_convolutions-inl.h
+++ b/tensorflow/core/kernels/eigen_spatial_convolutions-inl.h
@@ -18,11 +18,18 @@ limitations under the License.
 
 #include "tensorflow/core/kernels/eigen_convolution_helpers.h"
 
+#if defined(EIGEN_VECTORIZE_ALTIVEC) || defined(EIGEN_VECTORIZE_VSX)
+#define TF_USE_CUSTOM_EIGEN_PACK 0
+#else
+#define TF_USE_CUSTOM_EIGEN_PACK 1
+#endif
+
 // Note this header is used in both TF and TFLite.
 namespace Eigen {
 
 namespace internal {
 
+#if TF_USE_CUSTOM_EIGEN_PACK
 // WARNING: Most of the code here implicitly assumes that the matrix is in
 // ColMajor layout. This is guaranteed by the tensor contraction (see
 // TensorContraction.h).
@@ -1532,6 +1539,7 @@ struct gemm_pack_rhs<
     }
   }
 };
+#endif
 }  // end namespace internal
 
 /** SpatialConvolution


### PR DESCRIPTION
Eigen merged a new ppc64le improvement that specializes the
Eigen::internal::gemm_pack_rhs structure. TF also specializes the
packing routine. This patch removes this double specialization for
ppc64le, using only the Eigen one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tensorflow/47768)
<!-- Reviewable:end -->
