### PR TITLE
Legacy C++ gradients for PartitionedCall and StatefulPartitionedCall

### DIFF
--- a/tensorflow/cc/BUILD
+++ b/tensorflow/cc/BUILD
@@ -160,6 +160,7 @@ cc_library(
     deps = [
         ":array_grad",
         ":data_flow_grad",
+        ":functional_grad",
         ":image_grad",
         ":manip_grad",
         ":math_grad",
@@ -518,6 +519,39 @@ tf_cc_test(
         ":cc_ops",
         ":gradient_checker",
         ":manip_grad",
+        ":testutil",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
+        "//tensorflow/core:testlib",
+    ],
+)
+
+cc_library(
+    name = "functional_grad",
+    srcs = ["gradients/functional_grad.cc"],
+    deps = [
+        ":cc_ops",
+        ":cc_ops_internal",
+        ":functional_ops",
+        ":grad_op_registry",
+        ":gradients",
+        "//tensorflow/core:lib_proto_parsing",
+    ],
+    alwayslink = 1,
+)
+
+tf_cc_test(
+    name = "gradients_functional_grad_test",
+    srcs = ["gradients/functional_grad_test.cc"],
+    deps = [
+        ":cc_ops",
+        ":cc_ops_internal",
+        ":functional_grad",
+        ":functional_ops",
+        ":grad_op_registry",
+        ":grad_testutil",
+        ":gradient_checker",
+        ":math_grad",
         ":testutil",
         "//tensorflow/core:test",
         "//tensorflow/core:test_main",

--- a/tensorflow/cc/BUILD
+++ b/tensorflow/cc/BUILD
@@ -553,6 +553,7 @@ tf_cc_test(
         ":gradient_checker",
         ":math_grad",
         ":testutil",
+        "//tensorflow/cc:ops",
         "//tensorflow/core:test",
         "//tensorflow/core:test_main",
         "//tensorflow/core:testlib",

--- a/tensorflow/cc/gradients/functional_grad.cc
+++ b/tensorflow/cc/gradients/functional_grad.cc
@@ -1,0 +1,61 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <vector>
+#include <iostream>
+
+#include "tensorflow/cc/framework/grad_op_registry.h"
+#include "tensorflow/cc/framework/gradients.h"
+#include "tensorflow/cc/ops/functional_ops.h"
+
+
+namespace tensorflow {
+namespace ops {
+namespace {
+
+Status PartitionedCallGrad(const Scope& scope, const Operation& op,
+                    const std::vector<Output>& grad_inputs,
+                    std::vector<Output>* grad_outputs) {
+  NameAttrList f;
+  TF_RETURN_IF_ERROR(GetNodeAttr(op.node()->attrs(), "f",
+                               &f));
+  for (const auto& attr : op.node()->attrs()) {
+    (*f.mutable_attr())[attr.first] = attr.second;
+  }
+
+  std::vector<Output> func_inputs;
+  std::vector<DataType> input_dtypes;
+
+  for(int32 i = 0 ; i < op.num_inputs() ; i++) {
+    func_inputs.push_back(op.input(i));
+    input_dtypes.push_back(op.input_type(i));
+  }
+
+  func_inputs.insert(std::end(func_inputs), std::begin(grad_inputs), std::end(grad_inputs));
+
+  auto grad = SymbolicGradient(scope, func_inputs, input_dtypes, f);
+  for(int32 i = 0 ; i < op.num_inputs() ; i++) {
+    grad_outputs->push_back(grad[i]);
+  }
+
+  return scope.status();
+}
+
+REGISTER_GRADIENT_OP("PartitionedCall", PartitionedCallGrad);
+REGISTER_GRADIENT_OP("StatefulPartitionedCall", PartitionedCallGrad);
+
+}  // anonymous namespace
+}  // namespace ops
+}  // namespace tensorflow

--- a/tensorflow/cc/gradients/functional_grad_test.cc
+++ b/tensorflow/cc/gradients/functional_grad_test.cc
@@ -74,6 +74,10 @@ TEST_F(FunctionGradTest, PartitionedCallGrad) {
   (*f.mutable_attr())["T"].set_type(DT_FLOAT);
   auto results = PartitionedCall(scope_, std::initializer_list<Input>{ x }, {DT_FLOAT}, f);
   RunTest(x, {}, results[0], {});
+
+
+  auto stateful_results = StatefulPartitionedCall(scope_, std::initializer_list<Input>{ x }, {DT_FLOAT}, f);
+  RunTest(x, {}, stateful_results[0], {});
 }
 
 }  // namespace

--- a/tensorflow/cc/gradients/functional_grad_test.cc
+++ b/tensorflow/cc/gradients/functional_grad_test.cc
@@ -1,0 +1,80 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/cc/framework/ops.h"
+#include "tensorflow/cc/ops/array_ops.h"
+#include "tensorflow/cc/ops/functional_ops.h"
+#include "tensorflow/cc/ops/standard_ops.h"
+#include "tensorflow/core/framework/function_testlib.h"
+#include "tensorflow/cc/framework/grad_op_registry.h"
+#include "tensorflow/cc/framework/gradient_checker.h"
+#include "tensorflow/cc/framework/testutil.h"
+#include "tensorflow/cc/gradients/grad_testutil.h"
+#include "tensorflow/core/framework/tensor_testutil.h"
+#include "tensorflow/core/lib/core/status_test_util.h"
+
+namespace tensorflow {
+namespace {
+
+using namespace ops;  // NOLINT(build/namespaces)
+
+class FunctionGradTest : public ::testing::Test {
+ protected:
+  FunctionGradTest() : scope_(Scope::NewRootScope()) {}
+
+  void RunTest(const Output& x, const TensorShape& x_shape, const Output& y,
+               const TensorShape& y_shape) {
+    TF_ASSERT_OK(scope_.status());
+    float max_error;
+    auto result = (ComputeGradientError<float, float, float>(
+        scope_, {x}, {x_shape}, {y}, {y_shape}, &max_error));
+    TF_CHECK_OK(result);
+    TF_ASSERT_OK(result);
+    EXPECT_LT(max_error, 1e-3);
+  }
+
+  void RunTest(const OutputList& xs, const std::vector<TensorShape>& x_shapes,
+               const OutputList& ys, const std::vector<TensorShape>& y_shapes) {
+    TF_ASSERT_OK(scope_.status());
+    float max_error;
+    TF_ASSERT_OK((ComputeGradientError<float, float, float>(
+        scope_, xs, x_shapes, ys, y_shapes, &max_error)));
+    EXPECT_LT(max_error, 1e-3);
+  }
+
+  Scope scope_;
+};
+
+TEST_F(FunctionGradTest, PartitionedCallGrad) {
+
+  FunctionDefLibrary f_lib_proto;
+  *(f_lib_proto.add_function()) = test::function::XTimesTwo();
+
+  // Construct a graph:
+  //   A = Placeholder[dtype=int32]
+  //   B = XTimesTwo[_tpu_replicate="cluster"](A)
+  //   C = XTimesTwo[_xla_compile_id="cluster"](A)
+  TF_ASSERT_OK(scope_.graph()->AddFunctionLibrary(f_lib_proto));
+
+  Output x = Placeholder(scope_, DT_FLOAT);
+  NameAttrList f;
+  f.set_name("XTimesTwo");
+  (*f.mutable_attr())["T"].set_type(DT_FLOAT);
+  auto results = PartitionedCall(scope_, std::initializer_list<Input>{ x }, {DT_FLOAT}, f);
+  RunTest(x, {}, results[0], {});
+}
+
+}  // namespace
+}  // namespace tensorflow

--- a/tensorflow/cc/gradients/functional_grad_test.cc
+++ b/tensorflow/cc/gradients/functional_grad_test.cc
@@ -26,9 +26,8 @@ limitations under the License.
 #include "tensorflow/core/lib/core/status_test_util.h"
 
 namespace tensorflow {
+namespace ops {
 namespace {
-
-using namespace ops;  // NOLINT(build/namespaces)
 
 class FunctionGradTest : public ::testing::Test {
  protected:
@@ -81,4 +80,5 @@ TEST_F(FunctionGradTest, PartitionedCallGrad) {
 }
 
 }  // namespace
+}  // namespace ops
 }  // namespace tensorflow


### PR DESCRIPTION
This adds legacy C++ (`cc/gradients`) gradients for `PartitionedCall` and `StatefulPartitionedCall`, using `SymbolicGradient` as per https://github.com/tensorflow/tensorflow/pull/46115#issuecomment-797685426.