### PR TITLE
Remove redundant arguments of ImageResizerState's API

### DIFF
--- a/tensorflow/core/kernels/conv_ops_fused_image_transform.cc
+++ b/tensorflow/core/kernels/conv_ops_fused_image_transform.cc
@@ -653,7 +653,7 @@ class FusedResizeConv2DUsingGemmOp : public OpKernel {
     ImageResizerState st(false, false);
     if (DoResize) {
       st = ImageResizerState(align_corners_, false);
-      st.ValidateAndCalculateOutputSize(context, input);
+      st.ValidateAndCalculateOutputSize(context);
       if (!context->status().ok()) return;
     } else {
       // Set up the resize parameters to do no scaling at all.

--- a/tensorflow/core/kernels/image/resize_area_op.cc
+++ b/tensorflow/core/kernels/image/resize_area_op.cc
@@ -19,7 +19,6 @@ limitations under the License.
 #include <algorithm>
 #include <memory>
 
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/framework/tensor.h"
@@ -28,6 +27,7 @@ limitations under the License.
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/platform/logging.h"
 #include "tensorflow/core/util/image_resizer_state.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 namespace tensorflow {
 
@@ -144,17 +144,17 @@ class ResizeAreaOp : public OpKernel {
   }
 
   void Compute(OpKernelContext* context) override {
-    const Tensor& input = context->input(0);
     // The op always did the correct thing with regard to pixel centers, so we
     // always pass false here for half_pixel_centers since ImageResizerState
     // enforces that if align_corners_ is true, half_pixel_centers must be
     // false.
     ImageResizerState st(align_corners_, /*unused half_pixel_centers=*/false);
-    st.ValidateAndCreateOutput(context, input);
+    st.ValidateAndCreateOutput(context);
 
     if (!context->status().ok()) return;
 
-    typename TTypes<T, 4>::ConstTensor input_data(input.tensor<T, 4>());
+    typename TTypes<T, 4>::ConstTensor input_data(
+        context->input(0).tensor<T, 4>());
 
     // Precompute values used when iterating over x coordinates within a row.
     // Note that it may be useful to cache x_interps for a given

--- a/tensorflow/core/kernels/image/resize_bicubic_op.cc
+++ b/tensorflow/core/kernels/image/resize_bicubic_op.cc
@@ -21,7 +21,6 @@ limitations under the License.
 #include <algorithm>
 #include <array>
 
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/framework/tensor.h"
@@ -30,6 +29,7 @@ limitations under the License.
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/platform/logging.h"
 #include "tensorflow/core/util/image_resizer_state.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 namespace tensorflow {
 namespace {
@@ -557,13 +557,13 @@ class ResizeBicubicOp : public OpKernel {
   }
 
   void Compute(OpKernelContext* context) override {
-    const Tensor& input = context->input(0);
     ImageResizerState st(align_corners_, half_pixel_centers_);
-    st.ValidateAndCreateOutput(context, input);
+    st.ValidateAndCreateOutput(context);
 
     if (!context->status().ok()) return;
 
-    typename TTypes<T, 4>::ConstTensor input_data(input.tensor<T, 4>());
+    typename TTypes<T, 4>::ConstTensor input_data(
+        context->input(0).tensor<T, 4>());
     TTypes<float, 4>::Tensor output_data = st.output->tensor<float, 4>();
 
     interpolate_with_caching<T>(input_data, st, half_pixel_centers_,
@@ -587,16 +587,15 @@ class ResizeBicubicOpGrad : public OpKernel {
 
   void Compute(OpKernelContext* context) override {
     // Validate input.
-    // First argument is gradient with respect to resized image.
-    const Tensor& input = context->input(0);
-    const Tensor& original_image = context->input(1);
-
     ImageResizerGradientState st(align_corners_, half_pixel_centers_);
-    st.ValidateAndCreateOutput(context, input, original_image);
+    st.ValidateAndCreateOutput(context);
 
     if (!context->status().ok()) return;
 
-    TTypes<float, 4>::ConstTensor input_grad = input.tensor<float, 4>();
+    // First argument is gradient with respect to resized image.
+    TTypes<float, 4>::ConstTensor input_grad =
+        context->input(0).tensor<float, 4>();
+
     typename TTypes<T, 4>::Tensor output_grad(st.output->tensor<T, 4>());
 
     ResizeBicubicGrad<T>(input_grad, st, half_pixel_centers_, output_grad);

--- a/tensorflow/core/kernels/image/resize_nearest_neighbor_op.cc
+++ b/tensorflow/core/kernels/image/resize_nearest_neighbor_op.cc
@@ -20,7 +20,6 @@ limitations under the License.
 
 #include <memory>
 
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/framework/tensor.h"
@@ -29,6 +28,7 @@ limitations under the License.
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/platform/logging.h"
 #include "tensorflow/core/util/image_resizer_state.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 namespace tensorflow {
 
@@ -46,9 +46,8 @@ class ResizeNearestNeighborOp : public OpKernel {
   }
 
   void Compute(OpKernelContext* context) override {
-    const Tensor& input = context->input(0);
     ImageResizerState st(align_corners_, half_pixel_centers_);
-    st.ValidateAndCreateOutput(context, input);
+    st.ValidateAndCreateOutput(context);
 
     if (!context->status().ok()) return;
 
@@ -59,7 +58,8 @@ class ResizeNearestNeighborOp : public OpKernel {
     // Return if the output is empty.
     if (st.output->NumElements() == 0) return;
 
-    typename TTypes<T, 4>::ConstTensor input_data(input.tensor<T, 4>());
+    typename TTypes<T, 4>::ConstTensor input_data(
+        context->input(0).tensor<T, 4>());
     typename TTypes<T, 4>::Tensor output_data(st.output->tensor<T, 4>());
 
     bool status;

--- a/tensorflow/core/kernels/quantized_resize_bilinear_op.cc
+++ b/tensorflow/core/kernels/quantized_resize_bilinear_op.cc
@@ -700,19 +700,19 @@ class QuantizedResizeBilinearOp : public OpKernel {
   }
 
   void Compute(OpKernelContext* context) override {
-    const Tensor& input = context->input(0);
     const float in_min = context->input(2).flat<float>()(0);
     const float in_max = context->input(3).flat<float>()(0);
 
     ImageResizerState st(align_corners_, false);
-    st.ValidateAndCreateOutput(context, input);
+    st.ValidateAndCreateOutput(context);
 
     if (!context->status().ok()) return;
 
     // Return if the output is empty.
     if (st.output->NumElements() == 0) return;
 
-    typename TTypes<T, 4>::ConstTensor image_data(input.tensor<T, 4>());
+    typename TTypes<T, 4>::ConstTensor image_data(
+        context->input(0).tensor<T, 4>());
     typename TTypes<T, 4>::Tensor output_data(st.output->tensor<T, 4>());
 
     ResizeBilinear<T>(image_data, st.height_scale, st.width_scale, in_min,

--- a/tensorflow/core/util/image_resizer_state.h
+++ b/tensorflow/core/util/image_resizer_state.h
@@ -27,13 +27,13 @@ limitations under the License.
 #include <algorithm>
 #include <array>
 
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/bounds_check.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/framework/tensor_shape.h"
 #include "tensorflow/core/framework/types.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 namespace tensorflow {
 
@@ -76,16 +76,38 @@ struct ImageResizerState {
   // height_scale and width_scale, and calculates the output size.
   // If any of these operations fails, it sets an error status in
   // the context, which the caller must check.
-  void ValidateAndCalculateOutputSize(OpKernelContext* context,
-                                      const Tensor& input) {
+  void ValidateAndCalculateOutputSize(OpKernelContext* context) {
     OP_REQUIRES(
         context,
         !half_pixel_centers_ || (half_pixel_centers_ && !align_corners_),
         errors::InvalidArgument("If half_pixel_centers is True, "
                                 "align_corners must be False."));
-    OP_REQUIRES(context, input.dims() == 4,
+
+    const TensorShape& input_shape = context->input(0).shape();
+    OP_REQUIRES(context, input_shape.dims() == 4,
                 errors::InvalidArgument("input must be 4-dimensional",
-                                        input.shape().DebugString()));
+                                        input_shape.DebugString()));
+    batch_size = input_shape.dim_size(0);
+    channels = input_shape.dim_size(3);
+    OP_REQUIRES(
+        context, channels > 0,
+        errors::InvalidArgument("image must have at least one channel"));
+
+    // Verify and assign `in_height` and `in_width`.
+    OP_REQUIRES(
+        context, input_shape.dim_size(1) > 0 && input_shape.dim_size(2) > 0,
+        errors::InvalidArgument("input image must be of non-zero size"));
+    OP_REQUIRES(
+        context,
+        FastBoundsCheck(input_shape.dim_size(1),
+                        std::numeric_limits<int32>::max()) &&
+            FastBoundsCheck(input_shape.dim_size(2),
+                            std::numeric_limits<int32>::max()),
+        errors::InvalidArgument("input sizes must be between 0 and max int32"));
+    in_height = static_cast<int32>(input_shape.dim_size(1));
+    in_width = static_cast<int32>(input_shape.dim_size(2));
+
+    // Verify the output tensor's shape.
     const Tensor& shape_t = context->input(1);
     OP_REQUIRES(context, shape_t.dims() == 1,
                 errors::InvalidArgument("shape_t must be 1-dimensional",
@@ -93,28 +115,14 @@ struct ImageResizerState {
     OP_REQUIRES(context, shape_t.NumElements() == 2,
                 errors::InvalidArgument("shape_t must have two elements",
                                         shape_t.shape().DebugString()));
+
+    // Verify and assign `out_height` and `out_width`.
     auto Svec = shape_t.vec<int32>();
-    batch_size = input.dim_size(0);
     out_height = internal::SubtleMustCopy(Svec(0));
     out_width = internal::SubtleMustCopy(Svec(1));
-    OP_REQUIRES(
-        context,
-        FastBoundsCheck(input.dim_size(1), std::numeric_limits<int32>::max()) &&
-            FastBoundsCheck(input.dim_size(2),
-                            std::numeric_limits<int32>::max()),
-        errors::InvalidArgument("input sizes must be between 0 and max int32"));
-
-    in_height = static_cast<int32>(input.dim_size(1));
-    in_width = static_cast<int32>(input.dim_size(2));
-    channels = input.dim_size(3);
     OP_REQUIRES(context, out_height > 0 && out_width > 0,
                 errors::InvalidArgument("output dimensions must be positive"));
-    OP_REQUIRES(
-        context, channels > 0,
-        errors::InvalidArgument("image must have at least one channel"));
-    OP_REQUIRES(
-        context, input.dim_size(1) > 0 && input.dim_size(2) > 0,
-        errors::InvalidArgument("input image must be of non-zero size"));
+
     height_scale = CalculateResizeScale(in_height, out_height, align_corners_);
     width_scale = CalculateResizeScale(in_width, out_width, align_corners_);
 
@@ -132,14 +140,14 @@ struct ImageResizerState {
   }
 
   // Calculates all the required variables, and allocates the output.
-  void ValidateAndCreateOutput(OpKernelContext* context, const Tensor& input) {
-    ValidateAndCalculateOutputSize(context, input);
+  void ValidateAndCreateOutput(OpKernelContext* context) {
+    ValidateAndCalculateOutputSize(context);
     if (!context->status().ok()) return;
-    OP_REQUIRES_OK(context, context->allocate_output(
-                                0,
-                                TensorShape({input.dim_size(0), out_height,
-                                             out_width, input.dim_size(3)}),
-                                &output));
+    OP_REQUIRES_OK(
+        context,
+        context->allocate_output(
+            0, TensorShape({batch_size, out_height, out_width, channels}),
+            &output));
   }
 
   int64 batch_size;
@@ -163,40 +171,42 @@ struct ImageResizerGradientState {
       : align_corners_(align_corners),
         half_pixel_centers_(half_pixel_centers) {}
 
-  void ValidateAndCreateOutput(OpKernelContext* context, const Tensor& input,
-                               const Tensor& original_image) {
+  void ValidateAndCreateOutput(OpKernelContext* context) {
     OP_REQUIRES(
         context,
         !half_pixel_centers_ || (half_pixel_centers_ && !align_corners_),
         errors::InvalidArgument("If half_pixel_centers is True, "
                                 "align_corners must be False."));
 
+    const Tensor& input = context->input(0);
     OP_REQUIRES(context, input.dims() == 4,
                 errors::InvalidArgument("input_grad must be 4-dimensional",
                                         input.shape().DebugString()));
+
     // Resizers always produce float images, so input gradient must
     // always be a float.
     OP_REQUIRES(context, input.dtype() == DT_FLOAT,
                 errors::InvalidArgument("input_grad must be of type float",
                                         DataTypeString(input.dtype())));
 
-    OP_REQUIRES(context, original_image.dims() == 4,
-                errors::InvalidArgument("original_image must be 4-dimensional",
-                                        original_image.shape().DebugString()));
-
-    // Allocate output and initialize to zeros.
     batch_size = input.dim_size(0);
     channels = input.dim_size(3);
+
     resized_height = input.dim_size(1);
     resized_width = input.dim_size(2);
-    original_height = original_image.dim_size(1);
-    original_width = original_image.dim_size(2);
 
     // The following check is also carried out for the forward op. It is added
     // here to prevent a divide-by-zero exception when either height_scale or
     // width_scale is being calculated.
     OP_REQUIRES(context, resized_height > 0 && resized_width > 0,
                 errors::InvalidArgument("resized dimensions must be positive"));
+
+    const TensorShape& output_shape = context->input(1).shape();
+    OP_REQUIRES(context, output_shape.dims() == 4,
+                errors::InvalidArgument("original_image must be 4-dimensional",
+                                        output_shape.DebugString()));
+    original_height = output_shape.dim_size(1);
+    original_width = output_shape.dim_size(2);
 
     // The following check is also carried out for the forward op. It is added
     // here to prevent either height_scale or width_scale from being set to
@@ -217,7 +227,7 @@ struct ImageResizerGradientState {
         CalculateResizeScale(original_height, resized_height, align_corners_);
     width_scale =
         CalculateResizeScale(original_width, resized_width, align_corners_);
-    output = nullptr;
+
     OP_REQUIRES_OK(context, context->allocate_output(
                                 0,
                                 TensorShape({batch_size, original_height,
@@ -233,7 +243,7 @@ struct ImageResizerGradientState {
   int64 original_width;
   float height_scale;
   float width_scale;
-  Tensor* output;
+  Tensor* output = nullptr;
 
  private:
   bool align_corners_;


### PR DESCRIPTION
Fix #47789 

Currently `ImageResizerState::ValidateAndCreateOutput()` needs a tensor as the second argument. Actually its value can be retrieved through `context->input(0)`. Hence, it is unnecessary to provide the second argument. `ImageResizerGradientState::ValidateAndCreateOutput()` has the similar issue.

This code change removes the redundant arguments of the two functions mentioned above.