### PR TITLE
Update mobilenet_v3.py

### DIFF
--- a/tensorflow/python/keras/applications/mobilenet_v3.py
+++ b/tensorflow/python/keras/applications/mobilenet_v3.py
@@ -261,7 +261,6 @@ def MobileNetV3(stack_fn,
     se_ratio = 0.25
 
   x = img_input
-  x = layers.Rescaling(scale=1. / 127.5, offset=-1.)(x)
   x = layers.Conv2D(
       16,
       kernel_size=3,


### PR DESCRIPTION
Hi, I found that normalization operation is included in the definition of mobilenetv3 model and Mobile netv2 doesn't do that.
I don't think include normalization in the model a good idea, it should be outside the model. First of all, it limits the ability to customize. Secondly, I find that the normalization of 255 directly results in the accuracy of the model almost reduced to random after the model is converted to tflite int-8 version. 
So I think it's better to remove it in the model.