### PR TITLE
Construct scalar constants directly instead of calling zeros([]) or ones([])

### DIFF
--- a/tensorflow/python/keras/optimizer_v2/adagrad.py
+++ b/tensorflow/python/keras/optimizer_v2/adagrad.py
@@ -90,7 +90,7 @@ class Adagrad(optimizer_v2.OptimizerV2):
             epsilon=ops.convert_to_tensor_v2_with_dispatch(
                 self.epsilon, var_dtype),
             neg_lr_t=-apply_state[(var_device, var_dtype)]['lr_t'],
-            zero=array_ops.zeros((), dtype=dtypes.int64)))
+            zero=array_ops.constant(0, dtype=dtypes.int64)))
 
   def set_weights(self, weights):
     params = self.weights

--- a/tensorflow/python/keras/optimizer_v2/adamax.py
+++ b/tensorflow/python/keras/optimizer_v2/adamax.py
@@ -128,7 +128,7 @@ class Adamax(optimizer_v2.OptimizerV2):
             beta_1_power=beta_1_power,
             one_minus_beta_1_t=1 - beta_1_t,
             beta_2_t=beta_2_t,
-            zero=array_ops.zeros((), dtype=dtypes.int64)))
+            zero=array_ops.constant(0, dtype=dtypes.int64)))
 
   def _resource_apply_dense(self, grad, var, apply_state=None):
     var_device, var_dtype = var.device, var.dtype.base_dtype

--- a/tensorflow/python/ops/array_grad.py
+++ b/tensorflow/python/ops/array_grad.py
@@ -592,7 +592,7 @@ def _GetBatchIndices(params_shape, indices, batch_dims):
   for dim in range(batch_dims, 0, -1):
     dim_value = casted_params_shape[dim - 1]
     accum_dim_value *= casted_params_shape[dim]
-    start = array_ops.zeros((), dtype=indices_dtype)
+    start = array_ops.constant(0, dtype=indices_dtype)
     step = array_ops.ones((), dtype=indices_dtype)
     dim_indices = math_ops.range(start, dim_value, step)
     dim_indices *= accum_dim_value

--- a/tensorflow/python/ops/array_grad.py
+++ b/tensorflow/python/ops/array_grad.py
@@ -588,12 +588,12 @@ def _GetBatchIndices(params_shape, indices, batch_dims):
   indices_ndims = indices.shape.ndims
   indices_dtype = indices.dtype.base_dtype
   casted_params_shape = math_ops.cast(params_shape, indices_dtype)
-  accum_dim_value = array_ops.ones((), dtype=indices_dtype)
+  accum_dim_value = array_ops.constant(1, dtype=indices_dtype)
   for dim in range(batch_dims, 0, -1):
     dim_value = casted_params_shape[dim - 1]
     accum_dim_value *= casted_params_shape[dim]
     start = array_ops.constant(0, dtype=indices_dtype)
-    step = array_ops.ones((), dtype=indices_dtype)
+    step = array_ops.constant(1, dtype=indices_dtype)
     dim_indices = math_ops.range(start, dim_value, step)
     dim_indices *= accum_dim_value
     dim_shape = array_ops.stack(

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -5165,7 +5165,7 @@ def _batch_gather(params, indices, batch_dims, axis=None):
   for dim in range(batch_dims, 0, -1):
     dim_value = casted_params_shape[dim - 1]
     accum_dim_value *= casted_params_shape[dim]
-    start = zeros((), dtype=indices_dtype)
+    start = constant(0, dtype=indices_dtype)
     step = ones((), dtype=indices_dtype)
     dim_indices = gen_math_ops._range(start, dim_value, step)
     dim_indices *= accum_dim_value

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -5159,14 +5159,14 @@ def _batch_gather(params, indices, batch_dims, axis=None):
   params_shape = shape(params)
   batch_indices = indices
   indices_dtype = indices.dtype.base_dtype
-  accum_dim_value = ones((), dtype=indices_dtype)
+  accum_dim_value = constant(1, dtype=indices_dtype)
   # Use correct type for offset index computation
   casted_params_shape = gen_math_ops.cast(params_shape, indices_dtype)
   for dim in range(batch_dims, 0, -1):
     dim_value = casted_params_shape[dim - 1]
     accum_dim_value *= casted_params_shape[dim]
     start = constant(0, dtype=indices_dtype)
-    step = ones((), dtype=indices_dtype)
+    step = constant(1, dtype=indices_dtype)
     dim_indices = gen_math_ops._range(start, dim_value, step)
     dim_indices *= accum_dim_value
     dim_shape = stack(

--- a/tensorflow/python/ops/math_grad.py
+++ b/tensorflow/python/ops/math_grad.py
@@ -1659,7 +1659,7 @@ def _SelectGradV2(op, grad):
   c = op.inputs[0]
   x = op.inputs[1]
   y = op.inputs[2]
-  zeros = array_ops.zeros([], dtype=grad.dtype.base_dtype)
+  zeros = array_ops.constant(0, dtype=grad.dtype.base_dtype)
   gx = array_ops.where_v2(c, grad, zeros)
   x_shape = array_ops.shape(x)
   output_shape = array_ops.shape(op.outputs[0])

--- a/tensorflow/python/ops/nn_grad.py
+++ b/tensorflow/python/ops/nn_grad.py
@@ -1125,7 +1125,7 @@ def _TopKGrad(op, grad, _):
           array_ops.scatter_nd(
               array_ops.expand_dims(ind, -1), array_ops.reshape(grad, [-1]),
               [math_ops.reduce_prod(in_shape)]), in_shape),
-      array_ops.zeros([], dtype=dtypes.int32)
+      array_ops.constant(0, dtype=dtypes.int32)
   ]
 
 


### PR DESCRIPTION
This PR changes the code to construct scalar constants directly instead of calling `zeros([])` or `ones([])`.
For scalars in eager mode calling `tf.constant` directly is about 9x faster than calls to `zeros([])` or `ones([])`. In practice this will only matter in edge cases, but since it doesn't reduce readability I think it is good to do in any case.