### PR TITLE
Lazy load optional modules to speedup pip package import

### DIFF
--- a/tensorflow/python/distribute/cluster_resolver/kubernetes_cluster_resolver.py
+++ b/tensorflow/python/distribute/cluster_resolver/kubernetes_cluster_resolver.py
@@ -23,13 +23,6 @@ from tensorflow.python.distribute.cluster_resolver.cluster_resolver import forma
 from tensorflow.python.training import server_lib
 from tensorflow.python.util.tf_export import tf_export
 
-_KUBERNETES_API_CLIENT_INSTALLED = True
-try:
-  from kubernetes import client as k8sclient  # pylint: disable=g-import-not-at-top
-  from kubernetes import config as k8sconfig  # pylint: disable=g-import-not-at-top
-except ImportError:
-  _KUBERNETES_API_CLIENT_INSTALLED = False
-
 
 @tf_export('distribute.cluster_resolver.KubernetesClusterResolver')
 class KubernetesClusterResolver(ClusterResolver):
@@ -98,17 +91,19 @@ class KubernetesClusterResolver(ClusterResolver):
         `override_client` is passed in.
       RuntimeError: If autoresolve_task is not a boolean or a callable.
     """
-    if _KUBERNETES_API_CLIENT_INSTALLED:
+    try:
+      from kubernetes import config as k8sconfig  # pylint: disable=g-import-not-at-top
+
       k8sconfig.load_kube_config()
+    except ImportError:
+      if not override_client:
+          raise ImportError('The Kubernetes Python client must be installed before'
+          'using the Kubernetes Cluster Resolver. To install the'
+          'Kubernetes Python client, run `pip install '
+          'kubernetes` on your command line.')
 
     if not job_to_label_mapping:
       job_to_label_mapping = {'worker': ['job-name=tensorflow']}
-
-    if not override_client and not _KUBERNETES_API_CLIENT_INSTALLED:
-      raise ImportError('The Kubernetes Python client must be installed before'
-                        'using the Kubernetes Cluster Resolver. To install the'
-                        'Kubernetes Python client, run `pip install '
-                        'kubernetes` on your command line.')
 
     self._job_to_label_mapping = job_to_label_mapping
     self._tf_server_port = tf_server_port
@@ -159,6 +154,9 @@ class KubernetesClusterResolver(ClusterResolver):
       RuntimeError: If any of the pods returned by the master is not in the
         `Running` phase.
     """
+    from kubernetes import client as k8sclient  # pylint: disable=g-import-not-at-top
+    from kubernetes import config as k8sconfig  # pylint: disable=g-import-not-at-top
+
     if not self._override_client:
       k8sconfig.load_kube_config()
 

--- a/tensorflow/python/distribute/cluster_resolver/kubernetes_cluster_resolver.py
+++ b/tensorflow/python/distribute/cluster_resolver/kubernetes_cluster_resolver.py
@@ -97,10 +97,10 @@ class KubernetesClusterResolver(ClusterResolver):
       k8sconfig.load_kube_config()
     except ImportError:
       if not override_client:
-          raise ImportError('The Kubernetes Python client must be installed before'
-          'using the Kubernetes Cluster Resolver. To install the'
-          'Kubernetes Python client, run `pip install '
-          'kubernetes` on your command line.')
+        raise ImportError('The Kubernetes Python client must be installed '
+                          'before using the Kubernetes Cluster Resolver. '
+                          'To install the Kubernetes Python client, run '
+                          '`pip install kubernetes` on your command line.')
 
     if not job_to_label_mapping:
       job_to_label_mapping = {'worker': ['job-name=tensorflow']}
@@ -154,13 +154,15 @@ class KubernetesClusterResolver(ClusterResolver):
       RuntimeError: If any of the pods returned by the master is not in the
         `Running` phase.
     """
-    from kubernetes import client as k8sclient  # pylint: disable=g-import-not-at-top
-    from kubernetes import config as k8sconfig  # pylint: disable=g-import-not-at-top
+    if self._override_client:
+      client = self._override_client
+    else:
+      from kubernetes import config as k8sconfig  # pylint: disable=g-import-not-at-top
+      from kubernetes import client as k8sclient  # pylint: disable=g-import-not-at-top
 
-    if not self._override_client:
       k8sconfig.load_kube_config()
+      client = k8sclient.CoreV1Api()
 
-    client = self._override_client or k8sclient.CoreV1Api()
     cluster_map = {}
 
     for tf_job in self._job_to_label_mapping:

--- a/tensorflow/python/keras/engine/data_adapter.py
+++ b/tensorflow/python/keras/engine/data_adapter.py
@@ -58,15 +58,6 @@ from tensorflow.python.util.tf_export import keras_export
 keras_data_adapter_gauge = monitoring.BoolGauge(
     "/tensorflow/api/keras/data_adapters", "keras data adapter usage", "method")
 
-try:
-  from scipy import sparse as scipy_sparse  # pylint: disable=g-import-not-at-top
-except ImportError:
-  scipy_sparse = None
-try:
-  import pandas as pd  # pylint: disable=g-import-not-at-top
-except ImportError:
-  pd = None
-
 
 @six.add_metaclass(abc.ABCMeta)
 class DataAdapter(object):
@@ -239,9 +230,7 @@ class TensorLikeDataAdapter(DataAdapter):
     if y is not None:
       flat_inputs += nest.flatten(y)
 
-    tensor_types = (ops.Tensor, np.ndarray)
-    if pd:
-      tensor_types = (ops.Tensor, np.ndarray, pd.Series, pd.DataFrame)
+    tensor_types = _get_tensor_types()
 
     def _is_tensor(v):
       if isinstance(v, tensor_types):
@@ -567,9 +556,7 @@ class CompositeTensorDataAdapter(DataAdapter):
           not _is_distributed_dataset(v)):
         return True
       # Support Scipy sparse tensors if scipy is installed
-      if scipy_sparse is not None and scipy_sparse.issparse(v):
-        return True
-      return False
+      return _is_scipy_sparse(v)
 
     def _is_tensor_or_composite(v):
       if isinstance(v, (ops.Tensor, np.ndarray)):
@@ -1045,7 +1032,7 @@ def _process_tensorlike(inputs):
       if issubclass(x.dtype.type, np.floating):
         dtype = backend.floatx()
       return ops.convert_to_tensor_v2_with_dispatch(x, dtype=dtype)
-    elif scipy_sparse and scipy_sparse.issparse(x):
+    elif _is_scipy_sparse(x):
       return _scipy_sparse_to_sparse_tensor(x)
     return x
 
@@ -1463,9 +1450,7 @@ def train_validation_split(arrays, validation_split):
   """
 
   def _can_split(t):
-    tensor_types = (ops.Tensor, np.ndarray)
-    if pd:
-      tensor_types = (ops.Tensor, np.ndarray, pd.Series, pd.DataFrame)
+    tensor_types = _get_tensor_types()
     return isinstance(t, tensor_types) or t is None
 
   flat_arrays = nest.flatten(arrays)
@@ -1644,6 +1629,24 @@ def _check_data_cardinality(data):
           label, ", ".join(str(i.shape[0]) for i in nest.flatten(single_data)))
     msg += "Make sure all arrays contain the same number of samples."
     raise ValueError(msg)
+
+
+def _get_tensor_types():
+  try:
+    import pandas as pd  # pylint: disable=g-import-not-at-top
+
+    return (ops.Tensor, np.ndarray, pd.Series, pd.DataFrame)
+  except ImportError:
+    return (ops.Tensor, np.ndarray)
+
+
+def _is_scipy_sparse(x):
+  try:
+    from scipy.sparse import issparse  # pylint: disable=g-import-not-at-top
+
+    return issparse(x)
+  except ImportError:
+    return False
 
 
 def _scipy_sparse_to_sparse_tensor(t):


### PR DESCRIPTION
This PR lazy loads optional external Python modules to speedup initial import times of the TF pip package.

These changes speedup initial import by roughly **24%**:

modules | percentage of TF import
---|---
kubernetes | 14.5 %
pandas | 6.9 %
scipy | 2.6 %

This partially addresses #37729, but import times are still quite slow. A large chunk is spent importing the `tf.compat` which I don't think is used a lot by the average user, so it would be great if this could be lazy loaded as well in the future.

/cc @mihaimaruseac