### PR TITLE
fix datatypes in cwise and gather ops

### DIFF
--- a/tensorflow/core/framework/tensor_types.h
+++ b/tensorflow/core/framework/tensor_types.h
@@ -42,6 +42,10 @@ struct TTypes {
                            Eigen::Aligned>
       Tensor32Bit;
 
+  typedef Eigen::TensorMap<Eigen::Tensor<T, NDIMS, Eigen::RowMajor, int64_t>,
+                           Eigen::Aligned>
+      Tensor64Bit;
+
   // Scalar tensor (implemented as a rank-0 tensor) of scalar type T.
   typedef Eigen::TensorMap<
       Eigen::TensorFixedSize<T, Eigen::Sizes<>, Eigen::RowMajor, IndexType>,
@@ -119,6 +123,15 @@ typename TTypes<typename TensorType::Scalar,
 To32Bit(TensorType in) {
   typedef typename TTypes<typename TensorType::Scalar,
                           TensorType::NumIndices>::Tensor32Bit RetType;
+  return RetType(in.data(), To32BitDims(in.dimensions()));
+}
+
+template <typename TensorType>
+typename TTypes<typename TensorType::Scalar,
+                TensorType::NumIndices>::Tensor64Bit
+To64Bit(TensorType in) {
+  typedef typename TTypes<typename TensorType::Scalar,
+                          TensorType::NumIndices>::Tensor64Bit RetType;
   return RetType(in.data(), To32BitDims(in.dimensions()));
 }
 

--- a/tensorflow/core/kernels/cwise_ops_gpu_common.cu.h
+++ b/tensorflow/core/kernels/cwise_ops_gpu_common.cu.h
@@ -41,7 +41,7 @@ template <typename Functor>
 struct UnaryFunctor<GPUDevice, Functor> {
   void operator()(const GPUDevice& d, typename Functor::tout_type out,
                   typename Functor::tin_type in) {
-    To32Bit(out).device(d) = To32Bit(in).unaryExpr(typename Functor::func());
+    To64Bit(out).device(d) = To64Bit(in).unaryExpr(typename Functor::func());
   }
 };
 
@@ -51,8 +51,8 @@ struct BinaryFunctor<GPUDevice, Functor, NDIMS, has_errors> {
   void operator()(const GPUDevice& d, typename Functor::tout_type out,
                   typename Functor::tin_type in0,
                   typename Functor::tin_type in1, bool* error) {
-    To32Bit(out).device(d) =
-        To32Bit(in0).binaryExpr(in1, typename Functor::func());
+    To64Bit(out).device(d) =
+        To64Bit(in0).binaryExpr(in1, typename Functor::func());
   }
 
   void Left(const GPUDevice& d, typename Functor::tout_type out,
@@ -62,7 +62,7 @@ struct BinaryFunctor<GPUDevice, Functor, NDIMS, has_errors> {
     typedef typename Functor::in_type Tin;
     typedef typename Functor::func Binary;
     typedef typename Eigen::internal::scalar_left<Tout, Tin, Binary> Unary;
-    To32Bit(out).device(d) = To32Bit(in).unaryExpr(Unary(scalar.data()));
+    To64Bit(out).device(d) = To64Bit(in).unaryExpr(Unary(scalar.data()));
   }
 
   void Right(const GPUDevice& d, typename Functor::tout_type out,
@@ -72,7 +72,7 @@ struct BinaryFunctor<GPUDevice, Functor, NDIMS, has_errors> {
     typedef typename Functor::in_type Tin;
     typedef typename Functor::func Binary;
     typedef typename Eigen::internal::scalar_right<Tout, Tin, Binary> Unary;
-    To32Bit(out).device(d) = To32Bit(in).unaryExpr(Unary(scalar.data()));
+    To64Bit(out).device(d) = To64Bit(in).unaryExpr(Unary(scalar.data()));
   }
 
   void BCast(const GPUDevice& d,
@@ -89,18 +89,18 @@ struct BinaryFunctor<GPUDevice, Functor, NDIMS, has_errors> {
       const bool bcast0_all_one = AllOne<NDIMS>(bcast0);
       const bool bcast1_all_one = AllOne<NDIMS>(bcast1);
       if (bcast0_all_one && !bcast1_all_one) {
-        To32Bit(out).device(d) =
-            To32Bit(in0).binaryExpr(To32Bit(in1).broadcast(bcast1), func);
+        To64Bit(out).device(d) =
+            To64Bit(in0).binaryExpr(To64Bit(in1).broadcast(bcast1), func);
         return;
       }
       if (!bcast0_all_one && bcast1_all_one) {
-        To32Bit(out).device(d) =
-            To32Bit(in0).broadcast(bcast0).binaryExpr(To32Bit(in1), func);
+        To64Bit(out).device(d) =
+            To64Bit(in0).broadcast(bcast0).binaryExpr(To64Bit(in1), func);
         return;
       }
     }
-    To32Bit(out).device(d) = To32Bit(in0).broadcast(bcast0).binaryExpr(
-        To32Bit(in1).broadcast(bcast1), func);
+    To64Bit(out).device(d) = To64Bit(in0).broadcast(bcast0).binaryExpr(
+        To64Bit(in1).broadcast(bcast1), func);
   }
 };
 

--- a/tensorflow/core/kernels/gather_functor_batched_gpu.cu.h
+++ b/tensorflow/core/kernels/gather_functor_batched_gpu.cu.h
@@ -74,7 +74,7 @@ __global__ void GatherOpKernel(const T* params, const Index* indices, T* out,
     } else {
       // Read params[batch_i, outer_i, gather_i, slice_i] and write it to the
       // i'th position in out.
-      Index params_i = (
+      int64 params_i = (
           (batch_i * outer_size + outer_i) * gather_dim_size + gather_i
       ) * slice_size + slice_i;
       out[i] = ldg(params + params_i);

--- a/tensorflow/core/kernels/gather_functor_gpu.cu.h
+++ b/tensorflow/core/kernels/gather_functor_gpu.cu.h
@@ -64,7 +64,7 @@ __global__ void GatherOpKernel(const T* __restrict__ params,
       // params is a [batch_size, gather_dim_size, slice_size] tensor. Read
       // params[batch_i, gather_i, slice_i] and write it to the i'th position in
       // out.
-      Index params_i =
+      int64 params_i =
           (batch_i * gather_dim_size + gather_i) * slice_size + slice_i;
       out[i] = ldg(params + params_i);
     }


### PR DESCRIPTION
cwise_ops_gpu_common and gather_functor kernels deduce loop variables from input template datatype. they cause overflows  and consequently result in Illegal CUDA memory access issues. Sample code to reproduce is added below. 

`import tensorflow as tf
tf.compat.v1.disable_eager_execution()
​
n = 13417677  # 13417676 works
h = 160
x = tf.compat.v1.get_variable('x', [n, h])
with tf.compat.v1.Session() as sess:
    sess.run(tf.compat.v1.global_variables_initializer())`