### PR TITLE
TFLM: download a specific version of renode

### DIFF
--- a/tensorflow/lite/micro/tools/make/renode_download.sh
+++ b/tensorflow/lite/micro/tools/make/renode_download.sh
@@ -48,54 +48,10 @@ DOWNLOADED_RENODE_PATH=${DOWNLOADS_DIR}/renode
 if [ -d ${DOWNLOADED_RENODE_PATH} ]; then
   echo >&2 "${DOWNLOADED_RENODE_PATH} already exists, skipping the download."
 else
-  # Colours
-  ORANGE="\033[33m"
-  RED="\033[31m"
-  NC="\033[0m"
-
-  # Target version
-  RENODE_VERSION='1.11.0'
-
-  echo >&2 "Downloading Renode portable in version ${RENODE_VERSION}"
-
-  # Get link to requested version
-  RELEASES_JSON=`curl https://api.github.com/repos/renode/renode/releases 2>/dev/null`
-
-  # Make sure API rate limit is not exceeded and if so retry
-  RATE_LIMIT="API rate limit exceeded"
-  if [[ $RELEASES_JSON == *"${RATE_LIMIT}"* ]]; then
-      retries=10
-      until [ $retries -eq 1 ]; do
-          sleep 1
-          echo >&2 "${RATE_LIMIT} .. retrying"
-          RELEASES_JSON=`curl https://api.github.com/repos/renode/renode/releases 2>/dev/null`
-          if [[ $RELEASES_JSON != *"${RATE_LIMIT}"* ]]; then
-              break
-          fi
-          let retries-=1
-      done
-      if [[ $RELEASES_JSON == *"${RATE_LIMIT}"* ]]; then
-          echo >&2 "${RATE_LIMIT} .. please try later"
-          exit 1
-      fi
-  fi
-
-  LINUX_PORTABLE_URL=`echo "${RELEASES_JSON}" |grep 'browser_download_url'|\
-      grep --extended-regexp --only-matching "https://.*${RENODE_VERSION}.*linux-portable.*tar.gz"`
-  if [ -z "${LINUX_PORTABLE_URL}" ]; then
-    echo -e "${RED}Portable version of release v${RENODE_VERSION} not found. Please make sure you use correct version format ('[0-9]+.[0-9]+.[0-9]+')${NC}"
-    exit 1
-  fi
-
-  # Check if newer version available
-  LATEST_RENODE_VERSION=`echo "${RELEASES_JSON}" |grep 'tag_name' |\
-      head --lines 1 | grep --extended-regexp --only-matching '[0-9]+\.[0-9]+\.[0-9]+'`
-  if [ "${RENODE_VERSION}" != "${LATEST_RENODE_VERSION}" ]; then
-    echo -e "${ORANGE}Latest available version is ${LATEST_RENODE_VERSION}, please consider using it.${NC}" &>2
-  fi
-  echo >&2 "Downloading from url: ${LINUX_PORTABLE_URL}"
-
+  LINUX_PORTABLE_URL="https://github.com/renode/renode/releases/download/v1.11.0/renode-1.11.0.linux-portable.tar.gz"
   TEMP_ARCHIVE="/tmp/renode.tar.gz"
+
+  echo >&2 "Downloading from url: ${LINUX_PORTABLE_URL}"
   wget ${LINUX_PORTABLE_URL} -O ${TEMP_ARCHIVE} >&2
 
   EXPECTED_MD5="8415361f5caa843f1e31b59c50b2858f"


### PR DESCRIPTION
As discussed in #47841, the approach of downloading a json file, parsing out and then getting the url for the renode download can result in some flakiness sure to rate limiting.

Directly using the URL for a specific renode release avoids this issue.

Fix for: https://github.com/tensorflow/tensorflow/issues/47841