### PR TITLE
Fix std error when building the magic-wand demo for zephyr_vexriscv

### DIFF
--- a/tensorflow/lite/kernels/internal/cppmath.h
+++ b/tensorflow/lite/kernels/internal/cppmath.h
@@ -34,6 +34,7 @@ namespace tflite {
   }
 
 DECLARE_STD_GLOBAL_SWITCH1(TfLiteRound, round);
+DECLARE_STD_GLOBAL_SWITCH1(TfLiteExpm1, expm1);
 
 }  // namespace tflite
 

--- a/tensorflow/lite/kernels/internal/reference/elu.h
+++ b/tensorflow/lite/kernels/internal/reference/elu.h
@@ -15,8 +15,7 @@ limitations under the License.
 #ifndef TENSORFLOW_LITE_KERNELS_INTERNAL_REFERENCE_ELU_H_
 #define TENSORFLOW_LITE_KERNELS_INTERNAL_REFERENCE_ELU_H_
 
-#include <cmath>
-
+#include "tensorflow/lite/kernels/internal/cppmath.h"
 #include "tensorflow/lite/kernels/internal/types.h"
 
 namespace tflite {
@@ -28,7 +27,7 @@ inline void Elu(const RuntimeShape& input_shape, const float* input_data,
   const int flat_size = MatchingFlatSize(input_shape, output_shape);
   for (int i = 0; i < flat_size; ++i) {
     const float val = input_data[i];
-    output_data[i] = val < 0.0f ? std::expm1(val) : val;
+    output_data[i] = val < 0.0f ? TfLiteExpm1(val) : val;
   }
 }
 

--- a/tensorflow/lite/micro/kernels/elu.cc
+++ b/tensorflow/lite/micro/kernels/elu.cc
@@ -16,10 +16,10 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/reference/elu.h"
 
 #include <algorithm>
-#include <cmath>
 #include <limits>
 
 #include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/cppmath.h"
 #include "tensorflow/lite/kernels/internal/quantization_util.h"
 #include "tensorflow/lite/kernels/internal/reference/process_broadcast_shapes.h"
 #include "tensorflow/lite/kernels/internal/types.h"
@@ -54,7 +54,7 @@ void PopulateLookupTable(const TfLiteTensor* input, const TfLiteTensor* output,
     const float dequantized =
         input->params.scale * (val - input->params.zero_point);
     const float transformed = transform(dequantized);
-    const float rescaled = std::round(transformed * inverse_scale);
+    const float rescaled = TfLiteRound(transformed * inverse_scale);
     const int32_t quantized =
         static_cast<int32_t>(rescaled + output->params.zero_point);
     data->table[static_cast<uint8_t>(static_cast<T>(val))] =


### PR DESCRIPTION
When compiling the magic-wand demo for the zephyr_vexriscv target (with command: `make -f tensorflow/lite/micro/tools/make/Makefile TARGET=zephyr_vexriscv magic_wand_bin`) there are the following errors:

```
tensorflow/lite/kernels/internal/reference/elu.h:31:40: error: 'expm1' is not a member of 'std'; did you mean 'exp'?
tensorflow/lite/micro/kernels/elu.cc:57:33: error: 'round' is not a member of 'std'; did you mean 'round'?
```
This happens on a current master branch.

It looks like declaring std global switch for `expm1` function and changing `std::round` to `TfLiteRound` in `elu.cc` solves the problem.

Related to https://github.com/tensorflow/tensorflow/issues/47622#issuecomment-794696077