### PR TITLE
[ROCm] Switching to rocblas_gemm_ex for MFMA-enabled architectures

### DIFF
--- a/tensorflow/stream_executor/gpu/gpu_driver.h
+++ b/tensorflow/stream_executor/gpu/gpu_driver.h
@@ -474,6 +474,11 @@ class GpuDriver {
   static port::Status GetGpuGCNArchName(GpuDeviceHandle device,
                                         std::string* gcnArchName);
 
+#if TENSORFLOW_USE_ROCM
+  // tests the current device for MFMA insn support (ROCm only)
+  static port::Status GetMFMASupport(bool& support);
+#endif
+
   // Returns the number of multiprocessors on the device (note that the device
   // may be multi-GPU-per-board).
   static port::StatusOr<int> GetMultiprocessorCount(GpuDeviceHandle device);

--- a/tensorflow/stream_executor/gpu/gpu_driver.h
+++ b/tensorflow/stream_executor/gpu/gpu_driver.h
@@ -476,7 +476,7 @@ class GpuDriver {
 
 #if TENSORFLOW_USE_ROCM
   // tests the current device for MFMA insn support (ROCm only)
-  static port::Status GetMFMASupport(bool& support);
+  static port::StatusOr<bool> GetMFMASupport();
 #endif
 
   // Returns the number of multiprocessors on the device (note that the device

--- a/tensorflow/stream_executor/rocm/rocm_blas.cc
+++ b/tensorflow/stream_executor/rocm/rocm_blas.cc
@@ -267,6 +267,7 @@ namespace wrap {
   __macro(rocblas_ztrmm)		    \
   __macro(rocblas_sgeam)                    \
   __macro(rocblas_dgeam)                    \
+  __macro(rocblas_gemm_ex)                  \
   /*__macro(rocblas_cgeam)                  \
     __macro(rocblas_zgeam)                  \
     __macro(rocblas_sdgmm)                  \
@@ -1617,9 +1618,13 @@ bool ROCMBlas::DoBlasGemm(Stream *stream, blas::Transpose transa,
                       "precondition violation";
     }
   }
-  const Eigen::half alpha_half(alpha);
-  const Eigen::half beta_half(beta);
-  return DoBlasInternal(
+  bool hasXDLOPS = false;
+  auto status = GpuDriver::GetMFMASupport(hasXDLOPS);
+  if(!hasXDLOPS) {
+    VLOG(1) << "Using rocblas_hgemm";
+    const Eigen::half alpha_half(alpha);
+    const Eigen::half beta_half(beta);
+    return DoBlasInternal(
       wrap::rocblas_hgemm, stream, /* pointer_mode_host = */ true,
       ROCMBlasTranspose(transa), ROCMBlasTranspose(transb), m, n, k,
       reinterpret_cast<const rocblas_half *>(&alpha_half),
@@ -1627,6 +1632,21 @@ bool ROCMBlas::DoBlasGemm(Stream *stream, blas::Transpose transa,
       reinterpret_cast<const rocblas_half *>(GpuMemory(b)), ldb,
       reinterpret_cast<const rocblas_half *>(&beta_half),
       reinterpret_cast<rocblas_half *>(GpuMemoryMutable(c)), ldc);
+  } else {
+    VLOG(1) << "Using rocblas_gemm_ex";
+    return DoBlasInternal(
+      wrap::rocblas_gemm_ex, stream, /* pointer_mode_host = */ true,
+      ROCMBlasTranspose(transa), ROCMBlasTranspose(transb), 
+      (rocblas_int)m, (rocblas_int)n, (rocblas_int)k,
+      reinterpret_cast<const void*>(&alpha),
+      reinterpret_cast<const void*>(GpuMemory(a)), rocblas_datatype_f16_r, lda,
+      reinterpret_cast<const void*>(GpuMemory(b)), rocblas_datatype_f16_r, ldb,
+      reinterpret_cast<const void*>(&beta),
+      reinterpret_cast<const void*>(GpuMemoryMutable(c)), 
+      rocblas_datatype_f16_r, ldc,
+      reinterpret_cast<void*>(GpuMemoryMutable(c)), rocblas_datatype_f16_r, ldc,
+          rocblas_datatype_f32_r, rocblas_gemm_algo_standard, 0, 0);
+  }
 }
 
 bool ROCMBlas::DoBlasGemm(Stream *stream, blas::Transpose transa,

--- a/tensorflow/stream_executor/rocm/rocm_blas.cc
+++ b/tensorflow/stream_executor/rocm/rocm_blas.cc
@@ -1618,9 +1618,8 @@ bool ROCMBlas::DoBlasGemm(Stream *stream, blas::Transpose transa,
                       "precondition violation";
     }
   }
-  bool hasXDLOPS = false;
-  port::Status status = GpuDriver::GetMFMASupport(hasXDLOPS);
-  if (status.ok() && hasXDLOPS) {
+  port::StatusOr<bool> maybe_hasXDLOPS = GpuDriver::GetMFMASupport();
+  if (maybe_hasXDLOPS.ok() && maybe_hasXDLOPS.ValueOrDie()) {
     VLOG(1) << "Using rocblas_gemm_ex";
     return DoBlasInternal(
       wrap::rocblas_gemm_ex, stream, /* pointer_mode_host = */ true,

--- a/tensorflow/stream_executor/rocm/rocm_driver.cc
+++ b/tensorflow/stream_executor/rocm/rocm_driver.cc
@@ -1095,8 +1095,7 @@ GpuDriver::ContextGetSharedMemConfig(GpuContext* context) {
                       device)};
 }
 
-/* static */ port::Status GpuDriver::GetMFMASupport(bool& supported) {
-  supported = false;
+/* static */ port::StatusOr<bool> GpuDriver::GetMFMASupport() {
   hipDeviceProp_t props;
   int dev = 0;
   hipError_t result = hipGetDevice(&dev);
@@ -1111,8 +1110,7 @@ GpuDriver::ContextGetSharedMemConfig(GpuContext* context) {
     if(pos!=string::npos)
        gcnArchName = gcnArchName.substr(pos+3);
     VLOG(1)<<"GCN arch name (stripped) " << gcnArchName;
-    supported = (gcnArchName=="908" || gcnArchName=="909");
-    return port::Status::OK();
+    return ((gcnArchName == "908") || (gcnArchName == "909"));
   }
   return port::Status{
       port::error::INTERNAL,


### PR DESCRIPTION
Filing the PR to upstream the same submitted by @ekuznetsov139 in the rocmfork.

This PR adds two pieces of functionality.
1. `GetMFMASupport` routine (which is ROCM specific) to determine whether the underlying AMDGPU has support for mfma instructions
2. Call the rocblas GEMM API that leverages the mfma instructions (when available and applicable)

-----------------------------

/cc @chsigg @cheshire 