### PR TITLE
Mark header-implemented functions as inline

### DIFF
--- a/tensorflow/python/lib/core/pybind11_lib.h
+++ b/tensorflow/python/lib/core/pybind11_lib.h
@@ -55,12 +55,12 @@ inline py::object PyoOrThrow(PyObject* ptr) {
   return Pyo(ptr);
 }
 
-[[noreturn]] void ThrowTypeError(const char* error_message) {
+[[noreturn]] inline void ThrowTypeError(const char* error_message) {
   PyErr_SetString(PyExc_TypeError, error_message);
   throw pybind11::error_already_set();
 }
 
-[[noreturn]] void ThrowValueError(const char* error_message) {
+[[noreturn]] inline void ThrowValueError(const char* error_message) {
   PyErr_SetString(PyExc_ValueError, error_message);
   throw pybind11::error_already_set();
 }


### PR DESCRIPTION
This makes their signature to match functions from above.
It also solves duplicate symbol errors in certain conditions.