### PR TITLE
[TFLM] Remove uint8 support from Quantize

### DIFF
--- a/tensorflow/lite/micro/kernels/quantize.cc
+++ b/tensorflow/lite/micro/kernels/quantize.cc
@@ -31,60 +31,12 @@ void* Init(TfLiteContext* context, const char* buffer, size_t length) {
                                            sizeof(OpDataQuantizeReference));
 }
 
-TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
-  TFLITE_DCHECK(node->user_data != nullptr);
-  auto* data = static_cast<OpDataQuantizeReference*>(node->user_data);
-
-  TF_LITE_ENSURE_EQ(context, NumInputs(node), 1);
-  TF_LITE_ENSURE_EQ(context, NumOutputs(node), 1);
-
-  const TfLiteTensor* input = GetInput(context, node, 0);
-  TF_LITE_ENSURE(context, input != nullptr);
-  TfLiteTensor* output = GetOutput(context, node, 0);
-  TF_LITE_ENSURE(context, output != nullptr);
-
-  // TODO(b/128934713): Add support for fixed-point per-channel quantization.
-  // Currently this only support affine per-layer quantization.
-  TF_LITE_ENSURE_EQ(context, output->quantization.type,
-                    kTfLiteAffineQuantization);
-  const auto* affine_quantization =
-      reinterpret_cast<TfLiteAffineQuantization*>(output->quantization.params);
-  TF_LITE_ENSURE(context, affine_quantization);
-  TF_LITE_ENSURE(context, affine_quantization->scale);
-  TF_LITE_ENSURE(context, affine_quantization->scale->size == 1);
-
-  TF_LITE_ENSURE(context, input->type == kTfLiteFloat32 ||
-                              input->type == kTfLiteInt16 ||
-                              input->type == kTfLiteInt8);
-  TF_LITE_ENSURE(context, output->type == kTfLiteInt8 ||
-                              output->type == kTfLiteInt16 ||
-                              output->type == kTfLiteInt32);
-
-  if ((input->type == kTfLiteInt16 && output->type == kTfLiteInt8) ||
-      (input->type == kTfLiteInt8 && output->type == kTfLiteInt8) ||
-      (input->type == kTfLiteInt8 && output->type == kTfLiteInt32) ||
-      (input->type == kTfLiteInt16 && output->type == kTfLiteInt16) ||
-      (input->type == kTfLiteInt16 && output->type == kTfLiteInt32)) {
-    double effective_scale = static_cast<double>(input->params.scale) /
-                             static_cast<double>(output->params.scale);
-
-    QuantizeMultiplier(effective_scale, &data->requantize_output_multiplier,
-                       &data->requantize_output_shift);
-  }
-
-  data->quantization_params.zero_point = output->params.zero_point;
-  data->quantization_params.scale = static_cast<double>(output->params.scale);
-
-  data->input_zero_point = input->params.zero_point;
-  return kTfLiteOk;
-}
-
 }  // namespace
 
 TfLiteRegistration Register_QUANTIZE() {
   return {/*init=*/Init,
           /*free=*/nullptr,
-          /*prepare=*/Prepare,
+          /*prepare=*/PrepareQuantizeReference,
           /*invoke=*/EvalQuantizeReference,
           /*profiling_string=*/nullptr,
           /*builtin_code=*/0,

--- a/tensorflow/lite/micro/kernels/quantize.cc
+++ b/tensorflow/lite/micro/kernels/quantize.cc
@@ -56,8 +56,7 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE(context, input->type == kTfLiteFloat32 ||
                               input->type == kTfLiteInt16 ||
                               input->type == kTfLiteInt8);
-  TF_LITE_ENSURE(context, output->type == kTfLiteUInt8 ||
-                              output->type == kTfLiteInt8 ||
+  TF_LITE_ENSURE(context, output->type == kTfLiteInt8 ||
                               output->type == kTfLiteInt16 ||
                               output->type == kTfLiteInt32);
 

--- a/tensorflow/lite/micro/kernels/quantize.h
+++ b/tensorflow/lite/micro/kernels/quantize.h
@@ -31,7 +31,7 @@ struct OpDataQuantizeReference {
 };
 
 TfLiteStatus EvalQuantizeReference(TfLiteContext* context, TfLiteNode* node);
-
+TfLiteStatus PrepareQuantizeReference(TfLiteContext* context, TfLiteNode* node);
 }  // namespace tflite
 
 #endif  // TENSORFLOW_LITE_MICRO_KERNELS_QUANTIZE_H_

--- a/tensorflow/lite/micro/kernels/quantize_common.cc
+++ b/tensorflow/lite/micro/kernels/quantize_common.cc
@@ -24,6 +24,54 @@ limitations under the License.
 #include "tensorflow/lite/micro/micro_utils.h"
 
 namespace tflite {
+	
+TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+  TFLITE_DCHECK(node->user_data != nullptr);
+  auto* data = static_cast<OpDataQuantizeReference*>(node->user_data);
+
+  TF_LITE_ENSURE_EQ(context, NumInputs(node), 1);
+  TF_LITE_ENSURE_EQ(context, NumOutputs(node), 1);
+
+  const TfLiteTensor* input = GetInput(context, node, 0);
+  TF_LITE_ENSURE(context, input != nullptr);
+  TfLiteTensor* output = GetOutput(context, node, 0);
+  TF_LITE_ENSURE(context, output != nullptr);
+
+  // TODO(b/128934713): Add support for fixed-point per-channel quantization.
+  // Currently this only support affine per-layer quantization.
+  TF_LITE_ENSURE_EQ(context, output->quantization.type,
+                    kTfLiteAffineQuantization);
+  const auto* affine_quantization =
+      reinterpret_cast<TfLiteAffineQuantization*>(output->quantization.params);
+  TF_LITE_ENSURE(context, affine_quantization);
+  TF_LITE_ENSURE(context, affine_quantization->scale);
+  TF_LITE_ENSURE(context, affine_quantization->scale->size == 1);
+
+  TF_LITE_ENSURE(context, input->type == kTfLiteFloat32 ||
+                              input->type == kTfLiteInt16 ||
+                              input->type == kTfLiteInt8);
+  TF_LITE_ENSURE(context, output->type == kTfLiteInt8 ||
+                              output->type == kTfLiteInt16 ||
+                              output->type == kTfLiteInt32);
+
+  if ((input->type == kTfLiteInt16 && output->type == kTfLiteInt8) ||
+      (input->type == kTfLiteInt8 && output->type == kTfLiteInt8) ||
+      (input->type == kTfLiteInt8 && output->type == kTfLiteInt32) ||
+      (input->type == kTfLiteInt16 && output->type == kTfLiteInt16) ||
+      (input->type == kTfLiteInt16 && output->type == kTfLiteInt32)) {
+    double effective_scale = static_cast<double>(input->params.scale) /
+                             static_cast<double>(output->params.scale);
+
+    QuantizeMultiplier(effective_scale, &data->requantize_output_multiplier,
+                       &data->requantize_output_shift);
+  }
+
+  data->quantization_params.zero_point = output->params.zero_point;
+  data->quantization_params.scale = static_cast<double>(output->params.scale);
+
+  data->input_zero_point = input->params.zero_point;
+  return kTfLiteOk;
+}	
 
 TfLiteStatus EvalQuantizeReference(TfLiteContext* context, TfLiteNode* node) {
   TFLITE_DCHECK(node->user_data != nullptr);

--- a/tensorflow/lite/micro/kernels/quantize_common.cc
+++ b/tensorflow/lite/micro/kernels/quantize_common.cc
@@ -24,8 +24,9 @@ limitations under the License.
 #include "tensorflow/lite/micro/micro_utils.h"
 
 namespace tflite {
-	
-TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+
+TfLiteStatus PrepareQuantizeReference(TfLiteContext* context,
+                                      TfLiteNode* node) {
   TFLITE_DCHECK(node->user_data != nullptr);
   auto* data = static_cast<OpDataQuantizeReference*>(node->user_data);
 
@@ -71,7 +72,7 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
 
   data->input_zero_point = input->params.zero_point;
   return kTfLiteOk;
-}	
+}
 
 TfLiteStatus EvalQuantizeReference(TfLiteContext* context, TfLiteNode* node) {
   TFLITE_DCHECK(node->user_data != nullptr);

--- a/tensorflow/lite/micro/kernels/quantize_common.cc
+++ b/tensorflow/lite/micro/kernels/quantize_common.cc
@@ -41,13 +41,6 @@ TfLiteStatus EvalQuantizeReference(TfLiteContext* context, TfLiteNode* node) {
             tflite::micro::GetTensorShape(output),
             tflite::micro::GetTensorData<int8_t>(output));
         break;
-      case kTfLiteUInt8:
-        reference_ops::AffineQuantize(
-            data->quantization_params, tflite::micro::GetTensorShape(input),
-            tflite::micro::GetTensorData<float>(input),
-            tflite::micro::GetTensorShape(output),
-            tflite::micro::GetTensorData<uint8_t>(output));
-        break;
       case kTfLiteInt16:
         reference_ops::AffineQuantize(
             data->quantization_params, tflite::micro::GetTensorShape(input),

--- a/tensorflow/lite/micro/kernels/quantize_test.cc
+++ b/tensorflow/lite/micro/kernels/quantize_test.cc
@@ -122,58 +122,6 @@ void TestRequantize(const int* input_dims_data, const float* input_data,
 TF_LITE_MICRO_TESTS_BEGIN
 
 #if !defined(XTENSA)
-TF_LITE_MICRO_TEST(QuantizeOpTestUint8) {
-  const int length = 10;
-  const int dims[] = {2, 2, 5};
-  const float values[] = {-63.5, -63,  -62.5, -62,  -61.5,
-                          62,    62.5, 63,    63.5, 64};
-  const float scale = 0.5;
-  const int zero_point = 127;
-  uint8_t output[length];
-  uint8_t values_quantized[length];
-  tflite::testing::TestQuantizeFloat(
-      dims, values, dims, values, values_quantized, scale, zero_point, output);
-}
-
-TF_LITE_MICRO_TEST(QuantizeOpTestUint8NoScale) {
-  const int length = 10;
-  const int dims[] = {2, 2, 5};
-  const float values[] = {-127, -126, -125, -124, -123,
-                          124,  125,  126,  127,  128};
-  const float scale = 1.0;
-  const int zero_point = 127;
-  uint8_t output[length];
-  uint8_t values_quantized[length];
-  tflite::testing::TestQuantizeFloat(
-      dims, values, dims, values, values_quantized, scale, zero_point, output);
-}
-
-TF_LITE_MICRO_TEST(QuantizeOpTestInt8) {
-  const int length = 10;
-  const int dims[] = {2, 2, 5};
-  const float values[] = {-63.5, -63,  -62.5, -62,  -61.5,
-                          62,    62.5, 63,    63.5, 64};
-  const float scale = 0.5;
-  const int zero_point = -1;
-  uint8_t output[length];
-  uint8_t values_quantized[length];
-  tflite::testing::TestQuantizeFloat(
-      dims, values, dims, values, values_quantized, scale, zero_point, output);
-}
-
-TF_LITE_MICRO_TEST(QuantizeOpTestInt8NoScale) {
-  const int length = 10;
-  const int dims[] = {2, 2, 5};
-  const float values[] = {-128, -127, -126, -125, -124,
-                          123,  124,  125,  126,  127};
-  const float scale = 1.0;
-  const int zero_point = 0;
-  uint8_t output[length];
-  uint8_t values_quantized[length];
-  tflite::testing::TestQuantizeFloat(
-      dims, values, dims, values, values_quantized, scale, zero_point, output);
-}
-
 TF_LITE_MICRO_TEST(QuantizeOpTestInt16) {
   const int length = 10;
   const int dims[] = {2, 2, 5};


### PR DESCRIPTION
As discussed https://github.com/tensorflow/tensorflow/issues/47417

Removed uint8 support and moved the prepare function into quantize_common.cc

Progress towards #44912 