### PR TITLE
Change head command to use -n instead of --lines

### DIFF
--- a/tensorflow/lite/micro/tools/make/renode_download.sh
+++ b/tensorflow/lite/micro/tools/make/renode_download.sh
@@ -69,7 +69,7 @@ else
 
   # Check if newer version available
   LATEST_RENODE_VERSION=`echo "${RELEASES_JSON}" |grep 'tag_name' |\
-      head --lines 1 | grep --extended-regexp --only-matching '[0-9]+\.[0-9]+\.[0-9]+'`
+      head -n 1 | grep --extended-regexp --only-matching '[0-9]+\.[0-9]+\.[0-9]+'`
   if [ "${RENODE_VERSION}" != "${LATEST_RENODE_VERSION}" ]; then
     echo -e "${ORANGE}Latest available version is ${LATEST_RENODE_VERSION}, please consider using it.${NC}" &>2
   fi


### PR DESCRIPTION
When running the `renode_download.sh`, the following line breaks on OSX:

```
 LATEST_RENODE_VERSION=`echo "${RELEASES_JSON}" |grep 'tag_name' |\
      head --lines 1 | grep --extended-regexp --only-matching '[0-9]+\.[0-9]+\.[0-9]+'`
```

`head` on OSX only accepts as options `-n` or `-c`. Changing this to `-n 1` works in the same way and is compatible with both OSX and Linux.


Line that caused this issue:

```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=bluepill hello_world_bin
```