### PR TITLE
Cleanup expired forward compatibility horizons

### DIFF
--- a/tensorflow/python/data/experimental/ops/error_ops.py
+++ b/tensorflow/python/data/experimental/ops/error_ops.py
@@ -20,7 +20,6 @@ from __future__ import print_function
 from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.ops import gen_experimental_dataset_ops
 from tensorflow.python.util.tf_export import tf_export
-from tensorflow.python.compat import compat
 
 
 @tf_export("data.experimental.ignore_errors")
@@ -63,15 +62,9 @@ class _IgnoreErrorsDataset(dataset_ops.UnaryUnchangedStructureDataset):
   def __init__(self, input_dataset, log_warning):
     """See `Dataset.ignore_errors()` for details."""
     self._input_dataset = input_dataset
-    if compat.forward_compatible(2020, 8, 26) or log_warning:
-      variant_tensor = (
-          gen_experimental_dataset_ops.ignore_errors_dataset(
-              self._input_dataset._variant_tensor,  # pylint: disable=protected-access
-              log_warning=log_warning,
-              **self._flat_structure))
-    else:
-      variant_tensor = (
-          gen_experimental_dataset_ops.ignore_errors_dataset(
-              self._input_dataset._variant_tensor,  # pylint: disable=protected-access
-              **self._flat_structure))
+    variant_tensor = (
+        gen_experimental_dataset_ops.ignore_errors_dataset(
+            self._input_dataset._variant_tensor,  # pylint: disable=protected-access
+            log_warning=log_warning,
+            **self._flat_structure))
     super(_IgnoreErrorsDataset, self).__init__(input_dataset, variant_tensor)

--- a/tensorflow/python/data/experimental/ops/readers.py
+++ b/tensorflow/python/data/experimental/ops/readers.py
@@ -25,7 +25,6 @@ import gzip
 import numpy as np
 
 from tensorflow.python import tf2
-from tensorflow.python.compat import compat
 from tensorflow.python.data.experimental.ops import error_ops
 from tensorflow.python.data.experimental.ops import parsing_ops
 from tensorflow.python.data.ops import dataset_ops
@@ -780,31 +779,18 @@ class CsvDatasetV2(dataset_ops.DatasetSource):
     )
     self._element_spec = tuple(
         tensor_spec.TensorSpec([], d.dtype) for d in self._record_defaults)
-    if compat.forward_compatible(2020, 7, 3) or exclude_cols is not None:
-      variant_tensor = gen_experimental_dataset_ops.csv_dataset_v2(
-          filenames=self._filenames,
-          record_defaults=self._record_defaults,
-          buffer_size=self._buffer_size,
-          header=self._header,
-          output_shapes=self._flat_shapes,
-          field_delim=self._field_delim,
-          use_quote_delim=self._use_quote_delim,
-          na_value=self._na_value,
-          select_cols=self._select_cols,
-          exclude_cols=self._exclude_cols,
-          compression_type=self._compression_type)
-    else:
-      variant_tensor = gen_experimental_dataset_ops.csv_dataset(
-          filenames=self._filenames,
-          record_defaults=self._record_defaults,
-          buffer_size=self._buffer_size,
-          header=self._header,
-          output_shapes=self._flat_shapes,
-          field_delim=self._field_delim,
-          use_quote_delim=self._use_quote_delim,
-          na_value=self._na_value,
-          select_cols=self._select_cols,
-          compression_type=self._compression_type)
+    variant_tensor = gen_experimental_dataset_ops.csv_dataset_v2(
+        filenames=self._filenames,
+        record_defaults=self._record_defaults,
+        buffer_size=self._buffer_size,
+        header=self._header,
+        output_shapes=self._flat_shapes,
+        field_delim=self._field_delim,
+        use_quote_delim=self._use_quote_delim,
+        na_value=self._na_value,
+        select_cols=self._select_cols,
+        exclude_cols=self._exclude_cols,
+        compression_type=self._compression_type)
     super(CsvDatasetV2, self).__init__(variant_tensor)
 
   @property

--- a/tensorflow/python/debug/lib/debug_v2_ops_test.py
+++ b/tensorflow/python/debug/lib/debug_v2_ops_test.py
@@ -23,7 +23,6 @@ import os
 import numpy as np
 
 from tensorflow.core.protobuf import debug_event_pb2
-from tensorflow.python.compat import compat
 from tensorflow.python.debug.lib import debug_events_reader
 from tensorflow.python.debug.lib import debug_events_writer
 from tensorflow.python.debug.lib import dumping_callback_test_lib
@@ -238,8 +237,6 @@ class DebugIdentityV2OpUninitializedWriterTest(
 
   @test_util.run_in_graph_and_eager_modes
   def testInvokingDebugIdentityV2OpBeforeCreatingDebugEventsWriterWorks(self):
-    if not compat.forward_compatible(2020, 6, 24):
-      self.skipTest("Functionality currently not supported.")
     circular_buffer_size = 3
 
     @def_function.function

--- a/tensorflow/python/debug/lib/dumping_callback.py
+++ b/tensorflow/python/debug/lib/dumping_callback.py
@@ -30,7 +30,6 @@ from six.moves import xrange  # pylint: disable=redefined-builtin
 from tensorflow.core.framework import tensor_pb2
 from tensorflow.core.protobuf import debug_event_pb2
 from tensorflow.core.protobuf import graph_debug_info_pb2
-from tensorflow.python.compat import compat as tf_compat
 from tensorflow.python.debug.lib import debug_events_writer
 from tensorflow.python.debug.lib import op_callbacks_common
 from tensorflow.python.debug.lib import source_utils
@@ -377,12 +376,9 @@ class _DumpingCallback(object):
           "tensor_debug_mode": self._tensor_debug_mode,
           "debug_urls": debug_urls,
           "name": debug_identity_name,
+          "circular_buffer_size": self._circular_buffer_size,
+          "tfdbg_run_id": self._tfdbg_run_id,
       }
-      if tf_compat.forward_compatible(2020, 6, 24):
-        debug_identity_op_kwargs[
-            "circular_buffer_size"] = self._circular_buffer_size
-      if tf_compat.forward_compatible(2020, 7, 1):
-        debug_identity_op_kwargs["tfdbg_run_id"] = self._tfdbg_run_id
       if tensor_debug_mode == debug_event_pb2.TensorDebugMode.NO_TENSOR:
         if (not self._should_dump_tensor(op_type, tensor.dtype) or
             not tensor.dtype.is_numpy_compatible):

--- a/tensorflow/python/distribute/input_lib_test.py
+++ b/tensorflow/python/distribute/input_lib_test.py
@@ -24,7 +24,6 @@ from absl.testing import parameterized
 import numpy as np
 
 from tensorflow.python import tf2
-from tensorflow.python.compat import compat
 from tensorflow.python.data.experimental.ops import data_service_ops
 from tensorflow.python.data.experimental.ops.distribute_options import AutoShardPolicy
 from tensorflow.python.data.experimental.service import server_lib
@@ -861,9 +860,6 @@ class DistributedIteratorTest(DistributedIteratorTestBase,
   def testShuffleAcrossIterations(self, distribution, reshuffle):
     if not tf2.enabled():
       self.skipTest("Only V2 is supported.")
-
-    if not reshuffle and not compat.forward_compatible(2020, 5, 22):
-      self.skipTest("Functionality currently not supported.")
 
     dataset = dataset_ops.Dataset.range(12).shuffle(
         12, reshuffle_each_iteration=reshuffle).batch(4)

--- a/tensorflow/python/keras/layers/preprocessing/image_preprocessing.py
+++ b/tensorflow/python/keras/layers/preprocessing/image_preprocessing.py
@@ -18,7 +18,6 @@
 import numpy as np
 
 from tensorflow.python.eager import context
-from tensorflow.python.compat import compat
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import tensor_shape
@@ -674,18 +673,10 @@ def transform(images,
     fill_value = ops.convert_to_tensor_v2_with_dispatch(
         fill_value, dtypes.float32, name='fill_value')
 
-    if compat.forward_compatible(2020, 8, 5):
-      return gen_image_ops.ImageProjectiveTransformV3(
-          images=images,
-          output_shape=output_shape,
-          fill_value=fill_value,
-          transforms=transforms,
-          fill_mode=fill_mode.upper(),
-          interpolation=interpolation.upper())
-
-    return gen_image_ops.ImageProjectiveTransformV2(
+    return gen_image_ops.ImageProjectiveTransformV3(
         images=images,
         output_shape=output_shape,
+        fill_value=fill_value,
         transforms=transforms,
         fill_mode=fill_mode.upper(),
         interpolation=interpolation.upper())

--- a/tensorflow/python/ops/embedding_ops.py
+++ b/tensorflow/python/ops/embedding_ops.py
@@ -19,7 +19,6 @@ from __future__ import print_function
 
 from six.moves import xrange  # pylint: disable=redefined-builtin
 
-from tensorflow.python.compat import compat
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
@@ -557,12 +556,8 @@ def embedding_lookup_sparse(params,
       else:
         assert False, "Unrecognized combiner"
     else:
-      if compat.forward_compatible(2020, 5, 14):
-        if segment_ids.dtype not in (dtypes.int32, dtypes.int64):
-          segment_ids = math_ops.cast(segment_ids, dtypes.int32)
-      else:
-        if segment_ids.dtype != dtypes.int32:
-          segment_ids = math_ops.cast(segment_ids, dtypes.int32)
+      if segment_ids.dtype not in (dtypes.int32, dtypes.int64):
+        segment_ids = math_ops.cast(segment_ids, dtypes.int32)
       assert idx is not None
       if combiner == "sum":
         embeddings = math_ops.sparse_segment_sum(

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -21,7 +21,6 @@ from __future__ import print_function
 import functools
 import numpy as np
 
-from tensorflow.python.compat import compat
 from tensorflow.python.eager import def_function
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
@@ -3192,96 +3191,21 @@ def decode_image(contents,
     ValueError: On incorrect number of channels.
   """
   with ops.name_scope(name, 'decode_image'):
-    if compat.forward_compatible(2020, 8, 14):
-      channels = 0 if channels is None else channels
-      if dtype not in [dtypes.float32, dtypes.uint8, dtypes.uint16]:
-        dest_dtype = dtype
-        dtype = dtypes.uint16
-        return convert_image_dtype(gen_image_ops.decode_image(
-            contents=contents,
-            channels=channels,
-            expand_animations=expand_animations,
-            dtype=dtype), dest_dtype)
-      else:
-        return gen_image_ops.decode_image(
-            contents=contents,
-            channels=channels,
-            expand_animations=expand_animations,
-            dtype=dtype)
-
-    if channels not in (None, 0, 1, 3, 4):
-      raise ValueError('channels must be in (None, 0, 1, 3, 4)')
-    substr = string_ops.substr(contents, 0, 3)
-
-    def _bmp():
-      """Decodes a BMP image."""
-      signature = string_ops.substr(contents, 0, 2)
-      # Create assert op to check that bytes are BMP decodable
-      is_bmp = math_ops.equal(signature, 'BM', name='is_bmp')
-      decode_msg = 'Unable to decode bytes as JPEG, PNG, GIF, or BMP'
-      assert_decode = control_flow_ops.Assert(is_bmp, [decode_msg])
-      bmp_channels = 0 if channels is None else channels
-      good_channels = math_ops.not_equal(bmp_channels, 1, name='check_channels')
-      channels_msg = ('Channels must be in (None, 0, 3, 4) when decoding BMP '
-                      'images')
-      assert_channels = control_flow_ops.Assert(good_channels, [channels_msg])
-      with ops.control_dependencies([assert_decode, assert_channels]):
-        return convert_image_dtype(
-            gen_image_ops.decode_bmp(contents, channels=bmp_channels), dtype)
-
-    def _gif():
-      """Decodes a GIF image."""
-      # Create assert to make sure that channels is not set to 1
-      # Already checked above that channels is in (None, 0, 1, 3)
-      gif_channels = 0 if channels is None else channels
-      good_channels = math_ops.logical_and(
-          math_ops.not_equal(gif_channels, 1, name='check_gif_channels'),
-          math_ops.not_equal(gif_channels, 4, name='check_gif_channels'))
-      channels_msg = 'Channels must be in (None, 0, 3) when decoding GIF images'
-      assert_channels = control_flow_ops.Assert(good_channels, [channels_msg])
-      with ops.control_dependencies([assert_channels]):
-        result = convert_image_dtype(gen_image_ops.decode_gif(contents), dtype)
-        if not expand_animations:
-          # For now we decode animated GIFs fully and toss out all but the
-          # first frame when expand_animations is False
-          result = array_ops.gather(result, 0)
-        return result
-
-    def check_gif():
-      # Create assert op to check that bytes are GIF decodable
-      is_gif = math_ops.equal(substr, b'\x47\x49\x46', name='is_gif')
-      return control_flow_ops.cond(is_gif, _gif, _bmp, name='cond_gif')
-
-    def _png():
-      """Decodes a PNG image."""
-      return convert_image_dtype(
-          gen_image_ops.decode_png(
-              contents,
-              channels,
-              dtype=dtypes.uint8 if dtype == dtypes.uint8 else dtypes.uint16),
-          dtype)
-
-    def check_png():
-      """Checks if an image is PNG."""
-      return control_flow_ops.cond(
-          _is_png(contents), _png, check_gif, name='cond_png')
-
-    def _jpeg():
-      """Decodes a jpeg image."""
-      jpeg_channels = 0 if channels is None else channels
-      good_channels = math_ops.not_equal(
-          jpeg_channels, 4, name='check_jpeg_channels')
-      channels_msg = ('Channels must be in (None, 0, 1, 3) when decoding JPEG '
-                      'images')
-      assert_channels = control_flow_ops.Assert(good_channels, [channels_msg])
-      with ops.control_dependencies([assert_channels]):
-        return convert_image_dtype(
-            gen_image_ops.decode_jpeg(contents, channels), dtype)
-
-    # Decode normal JPEG images (start with \xff\xd8\xff\xe0)
-    # as well as JPEG images with EXIF data (start with \xff\xd8\xff\xe1).
-    return control_flow_ops.cond(
-        is_jpeg(contents), _jpeg, check_png, name='cond_jpeg')
+    channels = 0 if channels is None else channels
+    if dtype not in [dtypes.float32, dtypes.uint8, dtypes.uint16]:
+      dest_dtype = dtype
+      dtype = dtypes.uint16
+      return convert_image_dtype(gen_image_ops.decode_image(
+          contents=contents,
+          channels=channels,
+          expand_animations=expand_animations,
+          dtype=dtype), dest_dtype)
+    else:
+      return gen_image_ops.decode_image(
+          contents=contents,
+          channels=channels,
+          expand_animations=expand_animations,
+          dtype=dtype)
 
 
 @tf_export('image.total_variation')
@@ -3975,8 +3899,8 @@ def rgb_to_yuv(images):
   Outputs a tensor of the same shape as the `images` tensor, containing the YUV
   value of the pixels.
   The output is only well defined if the value in images are in [0, 1].
-  There are two ways of representing an image: [0, 255] pixel values range or 
-  [0, 1] (as float) pixel values range. Users need to convert the input image 
+  There are two ways of representing an image: [0, 255] pixel values range or
+  [0, 1] (as float) pixel values range. Users need to convert the input image
   into a float [0, 1] range.
 
   Args:
@@ -5350,40 +5274,31 @@ def non_max_suppression_padded(boxes,
    Raises:
     ValueError: When set pad_to_max_output_size to False for batched input.
   """
-  # if no new arguments are used and no later than 2020/6/23, use the old
-  # version to give us time to fix TFLite conversion after the TF 2.3 release.
-  if (not sorted_input) and \
-      (not canonicalized_coordinates) and \
-      tile_size == 512 and not compat.forward_compatible(2020, 6, 23):
-    return non_max_suppression_padded_v1(
+  with ops.name_scope(name, 'non_max_suppression_padded'):
+    if not pad_to_max_output_size:
+      # pad_to_max_output_size may be set to False only when the shape of
+      # boxes is [num_boxes, 4], i.e., a single image. We make best effort to
+      # detect violations at compile time. If `boxes` does not have a static
+      # rank, the check allows computation to proceed.
+      if boxes.get_shape().rank is not None and boxes.get_shape().rank > 2:
+        raise ValueError(
+            "'pad_to_max_output_size' (value {}) must be True for "
+            'batched input'.format(pad_to_max_output_size))
+    if name is None:
+      name = ''
+    idx, num_valid = non_max_suppression_padded_v2(
         boxes, scores, max_output_size, iou_threshold, score_threshold,
-        pad_to_max_output_size, name)
-  else:
-    with ops.name_scope(name, 'non_max_suppression_padded'):
-      if not pad_to_max_output_size:
-        # pad_to_max_output_size may be set to False only when the shape of
-        # boxes is [num_boxes, 4], i.e., a single image. We make best effort to
-        # detect violations at compile time. If `boxes` does not have a static
-        # rank, the check allows computation to proceed.
-        if boxes.get_shape().rank is not None and boxes.get_shape().rank > 2:
-          raise ValueError(
-              "'pad_to_max_output_size' (value {}) must be True for "
-              'batched input'.format(pad_to_max_output_size))
-      if name is None:
-        name = ''
-      idx, num_valid = non_max_suppression_padded_v2(
-          boxes, scores, max_output_size, iou_threshold, score_threshold,
-          sorted_input, canonicalized_coordinates, tile_size)
-      # def_function.function seems to lose shape information, so set it here.
-      if not pad_to_max_output_size:
-        idx = idx[0, :num_valid]
-      else:
-        batch_dims = array_ops.concat([
-            array_ops.shape(boxes)[:-2],
-            array_ops.expand_dims(max_output_size, 0)
-        ], 0)
-        idx = array_ops.reshape(idx, batch_dims)
-      return idx, num_valid
+        sorted_input, canonicalized_coordinates, tile_size)
+    # def_function.function seems to lose shape information, so set it here.
+    if not pad_to_max_output_size:
+      idx = idx[0, :num_valid]
+    else:
+      batch_dims = array_ops.concat([
+          array_ops.shape(boxes)[:-2],
+          array_ops.expand_dims(max_output_size, 0)
+      ], 0)
+      idx = array_ops.reshape(idx, batch_dims)
+    return idx, num_valid
 
 
 # TODO(b/158709815): Improve performance regression due to
@@ -5809,17 +5724,17 @@ def generate_bounding_box_proposals(scores,
      `[num_images, height, width, num_achors]` containing scores of
       the boxes for given anchors, can be unsorted.
     bbox_deltas: A 4-D float `Tensor` of shape
-     `[num_images, height, width, 4 x num_anchors]` encoding boxes 
-      with respect to each anchor. Coordinates are given 
+     `[num_images, height, width, 4 x num_anchors]` encoding boxes
+      with respect to each anchor. Coordinates are given
       in the form `[dy, dx, dh, dw]`.
-    image_info: A 2-D float `Tensor` of shape `[num_images, 5]` 
+    image_info: A 2-D float `Tensor` of shape `[num_images, 5]`
       containing image information Height, Width, Scale.
-    anchors: A 2-D float `Tensor` of shape `[num_anchors, 4]` 
+    anchors: A 2-D float `Tensor` of shape `[num_anchors, 4]`
       describing the anchor boxes.
       Boxes are formatted in the form `[y1, x1, y2, x2]`.
     nms_threshold: A scalar float `Tensor` for non-maximal-suppression
       threshold. Defaults to 0.7.
-    pre_nms_topn: A scalar int `Tensor` for the number of 
+    pre_nms_topn: A scalar int `Tensor` for the number of
       top scoring boxes to be used as input. Defaults to 6000.
     min_size: A scalar float `Tensor`. Any box that has a smaller size
       than min_size will be discarded. Defaults to 16.

--- a/tensorflow/python/ops/lookup_ops.py
+++ b/tensorflow/python/ops/lookup_ops.py
@@ -24,7 +24,6 @@ import uuid
 
 import six
 
-from tensorflow.python.compat import compat
 from tensorflow.python.eager import context
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
@@ -690,16 +689,10 @@ class TextFileInitializer(TableInitializerBase):
     with ops.name_scope(self._name, "text_file_init", (table.resource_handle,)):
       filename = ops.convert_to_tensor(
           self._filename, dtypes.string, name="asset_filepath")
-      if self._offset != 0 or compat.forward_compatible(2021, 3, 18):
-        init_op = gen_lookup_ops.initialize_table_from_text_file_v2(
-            table.resource_handle, filename, self._key_index, self._value_index,
-            -1 if self._vocab_size is None else self._vocab_size,
-            self._delimiter, self._offset)
-      else:
-        init_op = gen_lookup_ops.initialize_table_from_text_file_v2(
-            table.resource_handle, filename, self._key_index, self._value_index,
-            -1 if self._vocab_size is None else self._vocab_size,
-            self._delimiter)
+      init_op = gen_lookup_ops.initialize_table_from_text_file_v2(
+          table.resource_handle, filename, self._key_index, self._value_index,
+          -1 if self._vocab_size is None else self._vocab_size,
+          self._delimiter, self._offset)
     ops.add_to_collection(ops.GraphKeys.TABLE_INITIALIZERS, init_op)
     # If the filename tensor is anything other than a string constant (e.g.,
     # if it is a placeholder) then it does not make sense to track it as an

--- a/tensorflow/python/ops/sparse_ops.py
+++ b/tensorflow/python/ops/sparse_ops.py
@@ -27,7 +27,6 @@ import numbers
 
 import numpy as np
 
-from tensorflow.python.compat import compat as tf_compat
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
@@ -642,12 +641,10 @@ def sparse_cross(inputs, name=None, separator=None):
   Returns:
     A `SparseTensor` of type `string`.
   """
-  if separator is None and not tf_compat.forward_compatible(2020, 6, 14):
-    return _sparse_cross_internal(inputs=inputs, hashed_output=False, name=name)
   if separator is None:
     separator = "_X_"
   separator = ops.convert_to_tensor(separator, dtypes.string)
-  indices, values, shapes, dense_inputs = _sparse_cross_internval_v2(inputs)
+  indices, values, shapes, dense_inputs = _sparse_cross_internal_v2(inputs)
   indices_out, values_out, shape_out = gen_sparse_ops.sparse_cross_v2(
       indices=indices,
       values=values,
@@ -713,7 +710,7 @@ _sparse_cross_hashed = sparse_cross_hashed
 _DEFAULT_HASH_KEY = 0xDECAFCAFFE
 
 
-def _sparse_cross_internval_v2(inputs):
+def _sparse_cross_internal_v2(inputs):
   """See gen_sparse_ops.sparse_cross_v2."""
   if not isinstance(inputs, (tuple, list)):
     raise TypeError("Inputs must be a list")


### PR DESCRIPTION
The forward compatibility horizons are expired since last year, so these checks can be safely removed.