### PR TITLE
[TFLM] For CEVA-DSP Makefiles: Added ceva_dsp_lib to linker, added ceva_common.h to headers list

### DIFF
--- a/tensorflow/lite/micro/tools/make/targets/ceva_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/ceva_makefile.inc
@@ -81,6 +81,7 @@ CCFLAGS += $(PLATFORM_ARGS)
 MICROLITE_CC_HDRS += \
   tensorflow/lite/micro/kernels/ceva/ceva_tflm_lib.h \
   tensorflow/lite/micro/kernels/ceva/types.h \
+  tensorflow/lite/micro/kernels/ceva/ceva_common.h 
   
 
 MICROLITE_CC_SRCS += \

--- a/tensorflow/lite/micro/tools/make/templates/ceva/ceva_app_makefile_v18.0.5.tpl
+++ b/tensorflow/lite/micro/tools/make/templates/ceva/ceva_app_makefile_v18.0.5.tpl
@@ -21,7 +21,7 @@ TOOLS_LIBS := \
 	-defsym \
 	__internal_code_size=256k \
 	-L${TARGET_TOOLCHAIN_ROOT}cevatools/lib/clang/9.0.1/cevabx1-unknown-unknown-elf/rtlv1.0.0-fp1-dpfp1/lib/ \
-	-lc++ -lc++abi -lc -lcompiler-rt -lCEVA_TFLM_lib
+	-lc++ -lc++abi -lc -lcompiler-rt -lCEVA_TFLM_lib -lceva_dsp_lib
     
 
 OUT_NAME = %{EXECUTABLE}%


### PR DESCRIPTION
CEVA-DSP Makefiles: Added ceva_dsp_lib to linker, added ceva_common.h to headers list
For pulling in the header file added in this PR: https://github.com/tensorflow/tensorflow/pull/47783
