### PR TITLE
[ROCm] Fix for ROCm CSB breakages - 210319

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/infeed_manager.cc
+++ b/tensorflow/compiler/xla/service/gpu/infeed_manager.cc
@@ -17,10 +17,10 @@ limitations under the License.
 
 #include "absl/memory/memory.h"
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #include "tensorflow/compiler/xla/service/gpu/xla_executor_state.h"
 #include "tensorflow/stream_executor/gpu/gpu_executor.h"
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 namespace xla {
 namespace gpu {
@@ -31,15 +31,15 @@ InfeedManager::InfeedManager(se::StreamExecutor *executor)
 }
 
 InfeedManager *GetOrCreateInfeedManager(se::StreamExecutor *executor) {
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
   stream_executor::gpu::GpuExecutor *gpu_executor =
       stream_executor::gpu::ExtractGpuExecutor(executor);
   auto *xla_state =
       gpu_executor->getOrCreateXLAState<GpuExecutorXLAState>(executor);
   return xla_state->getOrCreateInfeedManager(executor);
-#else   // GOOGLE_CUDA
+#else   // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
   return nullptr;
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 }
 
 }  // namespace gpu

--- a/tensorflow/python/kernel_tests/segment_reduction_ops_deterministic_test.py
+++ b/tensorflow/python/kernel_tests/segment_reduction_ops_deterministic_test.py
@@ -124,10 +124,10 @@ class SegmentReductionDeterminismExceptionsTest(test.TestCase):
   @test_util.run_in_graph_and_eager_modes
   def testConvertToTensor(self):
     with self.session(force_gpu=True):
-      for data_type in [
-          dtypes.float16, dtypes.float32, dtypes.float64, dtypes.complex64,
-          dtypes.complex128
-      ]:
+      dtypes_to_test = [dtypes.float16, dtypes.float32, dtypes.float64]
+      if not test.is_built_with_rocm():
+        dtypes_to_test += [dtypes.complex64, dtypes.complex128]
+      for data_type in dtypes_to_test:
         for segment_ids_type in [dtypes.int32, dtypes.int64]:
           values, indices, _ = self._input(data_type, segment_ids_type)
           sparse_value = indexed_slices.IndexedSlices(


### PR DESCRIPTION
## 1

The following commit breaks the following unit-tests on ROCm

https://github.com/tensorflow/tensorflow/commit/92e03156976ee8d045e872b3194c8f21576dfc03

```
//tensorflow/compiler/xla/service/gpu/tests:gpu_infeed_test              FAILED in 3 out of 3 in 1.8s
//tensorflow/compiler/xla/tests:local_client_execute_test_gpu            FAILED in 3 out of 3 in 13.7s
//tensorflow/compiler/xla/tests:outfeed_in_nested_computation_test_gpu   FAILED in 3 out of 3 in 2.0s
//tensorflow/compiler/xla/tests:while_test_gpu                           FAILED in 3 out of 3 in 9.9s
```

The cause is that part of the changes were not enabled for ROCm, and this commit fixes that.

## 2

The following commit breaks the following unit-test on ROCm

https://github.com/tensorflow/tensorflow/pull/47772

```
//tensorflow/python/kernel_tests:segment_reduction_ops_deterministic_test_gpu FAILED in 3 out of 3 in 5.3s
```

ROCm platform does not yet support complex datatype for the segment reduction ops, which is what leads to the failure.

This commit modifies the testcase to skip testing the complex datatype on ROCm


---------------------------------------------


/cc @cheshire @chsigg 