### PR TITLE
Replacing cuda_py_tests with cuda_py_test where applicable

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -24,9 +24,6 @@ load("//tensorflow:tensorflow.bzl", "pywrap_tensorflow_macro")
 load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 
 # buildifier: disable=same-origin-load
-load("//tensorflow:tensorflow.bzl", "cuda_py_tests")
-
-# buildifier: disable=same-origin-load
 load("//tensorflow:tensorflow.bzl", "tf_external_workspace_visible")
 
 # buildifier: disable=same-origin-load
@@ -3298,7 +3295,7 @@ tf_python_pybind_extension(
     ],
 )
 
-cuda_py_tests(
+cuda_py_test(
     name = "device_lib_test",
     size = "small",
     srcs = [

--- a/tensorflow/python/kernel_tests/signal/BUILD
+++ b/tensorflow/python/kernel_tests/signal/BUILD
@@ -1,4 +1,4 @@
-load("//tensorflow:tensorflow.bzl", "cuda_py_tests")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 load("//tensorflow:tensorflow.bzl", "py_test")  # @unused
 
 package(
@@ -19,7 +19,7 @@ py_library(
     ],
 )
 
-cuda_py_tests(
+cuda_py_test(
     name = "dct_ops_test",
     srcs = ["dct_ops_test.py"],
     python_version = "PY3",
@@ -33,7 +33,7 @@ cuda_py_tests(
     ],
 )
 
-cuda_py_tests(
+cuda_py_test(
     name = "fft_ops_test",
     size = "medium",
     srcs = ["fft_ops_test.py"],
@@ -53,7 +53,7 @@ cuda_py_tests(
     ],
 )
 
-cuda_py_tests(
+cuda_py_test(
     name = "mel_ops_test",
     srcs = ["mel_ops_test.py"],
     python_version = "PY3",
@@ -65,7 +65,7 @@ cuda_py_tests(
     ],
 )
 
-cuda_py_tests(
+cuda_py_test(
     name = "mfcc_ops_test",
     srcs = ["mfcc_ops_test.py"],
     python_version = "PY3",
@@ -80,7 +80,7 @@ cuda_py_tests(
     ],
 )
 
-cuda_py_tests(
+cuda_py_test(
     name = "reconstruction_ops_test",
     srcs = ["reconstruction_ops_test.py"],
     python_version = "PY3",
@@ -99,7 +99,7 @@ cuda_py_tests(
     ],
 )
 
-cuda_py_tests(
+cuda_py_test(
     name = "shape_ops_test",
     srcs = ["shape_ops_test.py"],
     python_version = "PY3",
@@ -117,7 +117,7 @@ cuda_py_tests(
     ],
 )
 
-cuda_py_tests(
+cuda_py_test(
     name = "spectral_ops_test",
     size = "large",
     srcs = ["spectral_ops_test.py"],
@@ -142,7 +142,7 @@ cuda_py_tests(
     ],
 )
 
-cuda_py_tests(
+cuda_py_test(
     name = "window_ops_test",
     srcs = ["window_ops_test.py"],
     python_version = "PY3",


### PR DESCRIPTION
This commit replaces the use of `cuda_py_tests` (plural) with `cuda_py_test`, in cases where the unit-test has only one source file (and hence the singular version will suffice).

Amongst other things, test targets defined via the plural version do not seem to get the `_gpu` suffix :(

Ideally `cuda_py_tests` should just iterate over the `srcs` list, and call `cuda_py_test` for each source file. But that change probably has much wider implications, and hence not attempting it here.

-----------------------------

/cc @chsigg @cheshire 