### PR TITLE
[Pluggable Device] Add custom device mem allocator for Pluggable device.

### DIFF
--- a/tensorflow/c/experimental/stream_executor/stream_executor_internal.h
+++ b/tensorflow/c/experimental/stream_executor/stream_executor_internal.h
@@ -73,6 +73,9 @@ class CPlatform : public Platform {
     }
     return visible_device_count;
   }
+  bool UseBfcAllocator() const {
+    return platform_.use_bfc_allocator;
+  }
   port::StatusOr<std::unique_ptr<DeviceDescription>> DescriptionForDevice(
       int ordinal) const override;
   port::StatusOr<StreamExecutor*> ExecutorForDevice(int ordinal) override;

--- a/tensorflow/core/common_runtime/pluggable_device/BUILD
+++ b/tensorflow/core/common_runtime/pluggable_device/BUILD
@@ -15,6 +15,7 @@ filegroup(
     srcs = [
         "pluggable_device.h",
         "pluggable_device_bfc_allocator.h",
+        "pluggable_device_simple_allocator.h",
         "pluggable_device_context.h",
         "pluggable_device_factory.h",
         "pluggable_device_init.h",
@@ -38,7 +39,9 @@ cc_library(
     copts = tf_copts(),
     deps = [
         ":pluggable_device_bfc_allocator",
+        ":pluggable_device_simple_allocator",
         ":pluggable_device_init_impl",
+        "//tensorflow/c/experimental/stream_executor:stream_executor_internal",
         "//tensorflow/core:core_cpu",
         "//tensorflow/core:core_cpu_lib",
         "//tensorflow/core:framework",
@@ -129,6 +132,23 @@ cc_library(
         "//tensorflow/core:lib_internal",
         "//tensorflow/core:protos_all_cc",
         "//tensorflow/core/common_runtime:bfc_allocator",
+        "//tensorflow/core/common_runtime/device:device_id",
+        "//tensorflow/core/common_runtime/device:device_mem_allocator",
+    ],
+)
+
+cc_library(
+    name = "pluggable_device_simple_allocator",
+    srcs = [
+        "pluggable_device_simple_allocator.cc",
+    ],
+    hdrs = ["pluggable_device_simple_allocator.h"],
+    features = ["parse_headers"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tensorflow/core:lib",
+        "//tensorflow/core:lib_internal",
+        "//tensorflow/core:protos_all_cc",
         "//tensorflow/core/common_runtime/device:device_id",
         "//tensorflow/core/common_runtime/device:device_mem_allocator",
     ],

--- a/tensorflow/core/common_runtime/pluggable_device/pluggable_device_process_state.cc
+++ b/tensorflow/core/common_runtime/pluggable_device/pluggable_device_process_state.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include <unordered_map>
 #include <vector>
 
+#include "tensorflow/c/experimental/stream_executor/stream_executor_internal.h"
 #include "tensorflow/core/common_runtime/device/device_host_allocator.h"
 #include "tensorflow/core/common_runtime/device/device_id.h"
 #include "tensorflow/core/common_runtime/device/device_id_manager.h"
@@ -116,7 +117,8 @@ Allocator* PluggableDeviceProcessState::GetPluggableDeviceAllocator(
         pluggable_device_visitors_[bus_id], {});
 
     Allocator* device_allocator = nullptr;
-    if (platform->UseBfcAllocator()) {
+    auto cplatform = dynamic_cast<se::CPlatform*>(platform);
+    if (cplatform->UseBfcAllocator()) {
         device_allocator =
             new PluggableDeviceBFCAllocator(
                 sub_allocator, total_bytes, options,

--- a/tensorflow/core/common_runtime/pluggable_device/pluggable_device_process_state.h
+++ b/tensorflow/core/common_runtime/pluggable_device/pluggable_device_process_state.h
@@ -33,6 +33,7 @@ namespace tensorflow {
 
 class Allocator;
 class PluggableDeviceBFCAllocator;
+class PluggableDeviceSimpleAllocator;
 class PoolAllocator;
 
 // Singleton that manages per-process state when PluggableDevices are present.
@@ -104,7 +105,7 @@ class PluggableDeviceProcessState {
 
   struct AllocatorParts {
     std::unique_ptr<Allocator> allocator;
-    PluggableDeviceBFCAllocator* bfc_allocator;
+    Allocator* device_allocator;
     SubAllocator* sub_allocator;  // owned by allocator
   };
 

--- a/tensorflow/core/common_runtime/pluggable_device/pluggable_device_simple_allocator.cc
+++ b/tensorflow/core/common_runtime/pluggable_device/pluggable_device_simple_allocator.cc
@@ -1,0 +1,48 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/core/common_runtime/pluggable_device/pluggable_device_simple_allocator.h"
+#include "tensorflow/core/lib/strings/strcat.h"
+
+namespace tensorflow {
+
+
+PluggableDeviceSimpleAllocator::PluggableDeviceSimpleAllocator(DeviceMemAllocator* sub_allocator)
+  : sub_allocator_(sub_allocator)
+{
+
+}
+
+void* PluggableDeviceSimpleAllocator::AllocateRaw(size_t alignment, size_t num_bytes)
+{
+  size_t bytes_received;
+  return sub_allocator_->Alloc(alignment, num_bytes, &bytes_received);
+}
+
+void PluggableDeviceSimpleAllocator::DeallocateRaw(void* ptr)
+{
+  return sub_allocator_->Free(ptr, 0);
+}
+absl::optional<AllocatorStats> PluggableDeviceSimpleAllocator::GetStats()
+{
+  AllocatorStats stats_;
+  stats_.num_allocs = 0;
+  stats_.peak_bytes_in_use = 0;
+  stats_.largest_alloc_size = 0;
+  
+  return stats_;
+}
+
+
+} // namespace tensorflow

--- a/tensorflow/core/common_runtime/pluggable_device/pluggable_device_simple_allocator.h
+++ b/tensorflow/core/common_runtime/pluggable_device/pluggable_device_simple_allocator.h
@@ -1,0 +1,48 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_CORE_COMMON_RUNTIME_PLUGGABLE_DEVICE_SIMPLE_ALLOCATOR_H_
+#define TENSORFLOW_CORE_COMMON_RUNTIME_PLUGGABLE_DEVICE_SIMPLE_ALLOCATOR_H_
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "tensorflow/core/common_runtime/device/device_mem_allocator.h"
+#include "tensorflow/core/platform/thread_annotations.h"
+#include "tensorflow/core/platform/types.h"
+#include "tensorflow/core/protobuf/config.pb.h"
+
+namespace tensorflow {
+
+class PluggableDeviceSimpleAllocator : public Allocator {
+ public:
+  PluggableDeviceSimpleAllocator(DeviceMemAllocator* sub_allocator);
+  ~PluggableDeviceSimpleAllocator() override {}
+  
+  void* AllocateRaw(size_t alignment, size_t num_bytes) override;
+  void DeallocateRaw(void* ptr) override;
+
+  bool TracksAllocationSizes() const override { return false; }
+  string Name() override { return "Simple allocator"; }
+  absl::optional<AllocatorStats> GetStats() override;
+private:
+  TF_DISALLOW_COPY_AND_ASSIGN(PluggableDeviceSimpleAllocator);
+  std::unique_ptr<SubAllocator> sub_allocator_;
+};
+
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_CORE_COMMON_RUNTIME_PLUGGABLE_DEVICE_SIMPLE_ALLOCATOR_H_

--- a/tensorflow/stream_executor/platform.h
+++ b/tensorflow/stream_executor/platform.h
@@ -126,9 +126,6 @@ class Platform {
   // Returns true iff the platform has been initialized.
   virtual bool Initialized() const;
 
-  // Returns true iff platform is using BFC device memory allocator.
-  virtual bool UseBfcAllocator() { return true; }
-
   // Initializes the platform with a custom set of options. The platform must be
   // initialized before obtaining StreamExecutor objects.  The interpretation of
   // the platform_options argument is implementation specific.  This method may

--- a/tensorflow/stream_executor/platform.h
+++ b/tensorflow/stream_executor/platform.h
@@ -126,6 +126,9 @@ class Platform {
   // Returns true iff the platform has been initialized.
   virtual bool Initialized() const;
 
+  // Returns true iff platform is using BFC device memory allocator.
+  virtual bool UseBfcAllocator() { return true; }
+
   // Initializes the platform with a custom set of options. The platform must be
   // initialized before obtaining StreamExecutor objects.  The interpretation of
   // the platform_options argument is implementation specific.  This method may


### PR DESCRIPTION
The commit provides a simple alternative to BFCAllocator for Pluggable devices
to do their own device memory management.

@penpornk , @annarev , @jzhoulon 