### PR TITLE
[determinism] Add softmax/cross-entropy op exceptions for GPU determinism

### DIFF
--- a/tensorflow/core/kernels/sparse_xent_op.cc
+++ b/tensorflow/core/kernels/sparse_xent_op.cc
@@ -49,6 +49,8 @@ Status CheckInvalidLabelIndex(const Tensor& labels, int64 max_index) {
   return Status::OK();
 }
 
+namespace {
+
 // TODO(duncanriach): Factor this into a shared utility library
 bool RequireDeterminism() {
   static bool require_determinism = [] {
@@ -71,6 +73,8 @@ bool DisableSparseSoftmaxXentWithLogitsOpDeterminismExceptions() {
   }();
   return cached_disable;
 }
+
+} // namespace
 
 template <typename Device, typename T, typename Index>
 class SparseSoftmaxXentWithLogitsOp : public OpKernel {

--- a/tensorflow/core/kernels/sparse_xent_op.cc
+++ b/tensorflow/core/kernels/sparse_xent_op.cc
@@ -101,8 +101,8 @@ class SparseSoftmaxXentWithLogitsOp : public OpKernel {
     if (std::is_same<Device, GPUDevice>::value) {
       OP_REQUIRES(
           context,
-          (!RequireDeterminism() ||
-            DisableSparseSoftmaxXentWithLogitsOpDeterminismExceptions()),
+          !RequireDeterminism() ||
+          DisableSparseSoftmaxXentWithLogitsOpDeterminismExceptions(),
           errors::Unimplemented(
               "Deterministic GPU implementation of"
               " SparseSoftmaxCrossEntropyWithLogits not available."

--- a/tensorflow/core/kernels/xent_op.cc
+++ b/tensorflow/core/kernels/xent_op.cc
@@ -32,6 +32,8 @@ namespace tensorflow {
 typedef Eigen::ThreadPoolDevice CPUDevice;
 typedef Eigen::GpuDevice GPUDevice;
 
+namespace {
+
 // TODO(duncanriach): Factor this into a shared utility library
 bool RequireDeterminism() {
   static bool require_determinism = [] {
@@ -54,6 +56,8 @@ bool DisableSoftmaxXentWithLogitsOpDeterminismExceptions() {
   }();
   return cached_disable;
 }
+
+} // namespace
 
 template <typename Device, typename T>
 class SoftmaxXentWithLogitsOp : public OpKernel {

--- a/tensorflow/core/kernels/xent_op.cc
+++ b/tensorflow/core/kernels/xent_op.cc
@@ -85,8 +85,8 @@ class SoftmaxXentWithLogitsOp : public OpKernel {
     if (std::is_same<Device, GPUDevice>::value) {
       OP_REQUIRES(
           context,
-          (!RequireDeterminism() ||
-            DisableSoftmaxXentWithLogitsOpDeterminismExceptions()),
+          !RequireDeterminism() ||
+          DisableSoftmaxXentWithLogitsOpDeterminismExceptions(),
           errors::Unimplemented(
               "Deterministic GPU implementation of"
               " SoftmaxCrossEntropyWithLogits not available."

--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -2696,6 +2696,20 @@ cuda_py_test(
 )
 
 cuda_py_test(
+    name = "sparse_xent_op_deterministic_test",
+    size = "small",
+    srcs = ["sparse_xent_op_deterministic_test.py"],
+    xla_enable_strict_auto_jit = False,
+    deps = [
+        "//tensorflow/python:client_testlib",
+        "//tensorflow/python:constant_op",
+        "//tensorflow/python:dtypes",
+        "//tensorflow/python:errors",
+        "//tensorflow/python:nn_ops",
+    ],
+)
+
+cuda_py_test(
     name = "sparse_xent_op_test",
     size = "small",
     srcs = ["sparse_xent_op_test.py"],
@@ -2879,6 +2893,20 @@ cuda_py_test(
         "//tensorflow/python:state_ops_gen",
         "//tensorflow/python:variables",
         "//third_party/py/numpy",
+    ],
+)
+
+cuda_py_test(
+    name = "xent_op_deterministic_test",
+    size = "small",
+    srcs = ["xent_op_deterministic_test.py"],
+    xla_enable_strict_auto_jit = False,
+    deps = [
+        "//tensorflow/python:client_testlib",
+        "//tensorflow/python:constant_op",
+        "//tensorflow/python:dtypes",
+        "//tensorflow/python:errors",
+        "//tensorflow/python:nn_ops",
     ],
 )
 

--- a/tensorflow/python/kernel_tests/segment_reduction_ops_deterministic_test.py
+++ b/tensorflow/python/kernel_tests/segment_reduction_ops_deterministic_test.py
@@ -34,7 +34,11 @@ from tensorflow.python.platform import test
 
 
 class SegmentReductionDeterminismExceptionsTest(test.TestCase):
-  """Test that tf.errors.UnimplementedError is thrown or not thrown, as appropriate, by the GPU code-paths for the segment reduction ops when determinsitic ops are enabled.
+  """Test d9m-unimplemented exceptions from the segment reduction ops.
+
+  Test that tf.errors.UnimplementedError is thrown or not thrown, as
+  appropriate, by the GPU code-paths for segment reduction ops when
+  deterministic ops are enabled.
 
   This test assumes that the base op test runs all the same test cases when
   deterministic ops are not enabled and will therefore detect erroneous

--- a/tensorflow/python/kernel_tests/sparse_xent_op_deterministic_test.py
+++ b/tensorflow/python/kernel_tests/sparse_xent_op_deterministic_test.py
@@ -1,0 +1,68 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for deterministic functionality of SparseSoftmaxCrossEntropyWithLogits op."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+
+from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import errors_impl
+from tensorflow.python.framework import test_util
+from tensorflow.python.ops import nn_ops
+from tensorflow.python.platform import test
+
+
+class SparseSoftmaxCrossEntropyWithLogitsDeterminismExceptionsTest(
+    test.TestCase):
+  """Test d9m-unimplemented exceptions from SparseSoftmaxCrossEntropyWithLogits.
+
+  Test that tf.errors.UnimplementedError is thrown or not thrown, as
+  appropriate, by the GPU code-paths for SparseSoftmaxCrossEntropyWithLogits
+  when deterministic ops are enabled.
+
+  This test assumes that the base op test runs all the same test cases when
+  deterministic ops are not enabled and will therefore detect erroneous
+  exception throwing in those cases.
+  """
+
+  @test_util.run_cuda_only
+  @test_util.run_in_graph_and_eager_modes
+  def testExceptionThrowing(self):
+    with self.session(force_gpu=True):
+      for logits_dtype in [dtypes.float16, dtypes.float32]:
+        for labels_dtype in [dtypes.int32, dtypes.int64]:
+          labels = constant_op.constant([1, 0], dtype=labels_dtype)
+          logits = constant_op.constant(
+              [[0.3, 0.5], [0.2, 0.6]], dtype=logits_dtype)
+          with self.assertRaisesRegex(
+              errors_impl.UnimplementedError,
+              "Deterministic GPU implementation of " +
+              "SparseSoftmaxCrossEntropyWithLogits not available."):
+            result = nn_ops.sparse_softmax_cross_entropy_with_logits(
+                labels=labels, logits=logits)
+            self.evaluate(result)
+
+
+if __name__ == "__main__":
+  # Note that the effect of setting the following environment variable to
+  # 'true' is not tested. Unless we can find a simpler pattern for testing these
+  # environment variables, it would require this file to be made into a base
+  # and then two more test files to be created.
+  os.environ["TF_DETERMINISTIC_OPS"] = "1"
+  test.main()

--- a/tensorflow/python/kernel_tests/xent_op_deterministic_test.py
+++ b/tensorflow/python/kernel_tests/xent_op_deterministic_test.py
@@ -1,0 +1,65 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for deterministic functionality of SoftmaxCrossEntropyWithLogits op."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+
+from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import errors_impl
+from tensorflow.python.framework import test_util
+from tensorflow.python.ops import nn_ops
+from tensorflow.python.platform import test
+
+
+class SoftmaxCrossEntropyWithLogitsDeterminismExceptionsTest(test.TestCase):
+  """Test d9m-unimplemented exceptions from SoftmaxCrossEntropyWithLogits.
+
+  Test that tf.errors.UnimplementedError is thrown or not thrown, as
+  appropriate, by the GPU code-paths for SoftmaxCrossEntropyWithLogits when
+  deterministic ops are enabled.
+
+  This test assumes that the base op test runs all the same test cases when
+  deterministic ops are not enabled and will therefore detect erroneous
+  exception throwing in those cases.
+  """
+
+  @test_util.run_cuda_only
+  @test_util.run_in_graph_and_eager_modes
+  def testExceptionThrowing(self):
+    with self.session(force_gpu=True):
+      for dtype in [dtypes.float16, dtypes.float32, dtypes.float64]:
+        labels = constant_op.constant([[0.2, 0.4], [0.1, 0.2]], dtype=dtype)
+        logits = constant_op.constant([[0.3, 0.5], [0.5, 0.6]], dtype=dtype)
+        with self.assertRaisesRegex(
+            errors_impl.UnimplementedError,
+            "Deterministic GPU implementation of " +
+            "SoftmaxCrossEntropyWithLogits not available."):
+          result = nn_ops.softmax_cross_entropy_with_logits(
+              labels=labels, logits=logits)
+          self.evaluate(result)
+
+
+if __name__ == "__main__":
+  # Note that the effect of setting the following environment variable to
+  # 'true' is not tested. Unless we can find a simpler pattern for testing these
+  # environment variables, it would require this file to be made into a base
+  # and then two more test files to be created.
+  os.environ["TF_DETERMINISTIC_OPS"] = "1"
+  test.main()


### PR DESCRIPTION
## High-Level Summary

This current PR adds and tests the following functionality:

When the environment variable `TF_DETERMINISTIC_OPS` is set to `"true"` or `"1"`, an attempt to run the following ops on a GPU will throw `tf.errors.UnimplementedError` (with an understandable message).

`tf.nn.softmax_cross_entropy_with_logits`
`tf.nn.sparse_softmax_cross_entropy_with_logits`

Please see _RFC: Enhancing determinism in TF_ (being added via tensorflow/community PR [346](https://github.com/tensorflow/community/pull/346)).

## Additional Notes

### Data Types

The exceptions will be thrown for all currently GPU-supported data types for the `logits` input: `tf.float16` and `tf.float32` for both ops, and, additionally, `tf.float64` for `tf.nn.softmax_cross_entropy_with_logits`.

Exception-throwing for all combinations of relevant data types for `logits` and `labels` (`tf.int32` and `tf.int64`) are tested in both eager and graph mode when the op is used in the forward direction.

### Forward vs Backward

It is currently suspected that the introduction of random noise into the gradients passed backwards from this op actually originate in the forward path algorithm, but the backward path algorithm might add additional noise. However, the backprop path for this op is not, and cannot, be used without the forward path algorithm also being used (due to this being a loss function). Therefore, the presence of exception-throwing on the backward path specifically is not necessary and is not implemented or tested by this current PR.

When these ops have a fully deterministic mode of operation, the bit-exact reproducibility of the outputs of both the forward and backward paths of the ops should be verified.

### XLA

The tests will not be run with XLA auto-jit enabled because any XLA implementation of these ops will not throw these exceptions.

When a fully deterministic mode for these ops is implemented, the bit-exact reproducibility of the outputs of both the forward and backward paths of the ops should be verified both with and without XLA auto-jit enabled.