### PR TITLE
Failing saved model multi output model unittest

### DIFF
--- a/tensorflow/lite/python/BUILD
+++ b/tensorflow/lite/python/BUILD
@@ -243,6 +243,7 @@ py_library(
     ],
     deps = [
         ":lite",
+        "//tensorflow:tensorflow_py",
         "//tensorflow/python:client_testlib",
         "//tensorflow/python:framework_test_lib",
         "@six_archive//:six",

--- a/tensorflow/lite/python/lite_v2_test.py
+++ b/tensorflow/lite/python/lite_v2_test.py
@@ -1330,41 +1330,13 @@ class FromKerasModelTest(lite_v2_test_util.ModelTest):
   @test_util.run_v2_only
   def testSequentialMultiInputOutputModel(self):
     """Test a tf.Keras model with multiple inputs and outputs."""
-    left_input_data = tf.constant(1., shape=[1, 3])
-    right_input_data = tf.constant(1., shape=[1, 3])
-
-    # Create a simple Keras model.
-    input_a_np = np.random.random((10, 3))
-    input_b_np = np.random.random((10, 3))
-    output_c_np = np.random.random((10, 3))
-    output_d_np = np.random.random((10, 2))
-
-    input_a = tf.keras.layers.Input(shape=(3,), name='input_a')
-    input_b = tf.keras.layers.Input(shape=(3,), name='input_b')
-
-    dense = tf.keras.layers.Dense(8, name='dense_1')
-    interm_a = dense(input_a)
-    interm_b = dense(input_b)
-    merged = tf.keras.layers.concatenate([interm_a, interm_b], name='merge')
-
-    output_c = tf.keras.layers.Dense(
-        3, activation='softmax', name='dense_2')(
-            merged)
-    output_d = tf.keras.layers.Dense(
-        2, activation='softmax', name='dense_3')(
-            merged)
-
-    model = tf.keras.models.Model(
-        inputs=[input_a, input_b], outputs=[output_c, output_d])
-    model.compile(optimizer='sgd', loss='mean_squared_error')
-    model.fit([input_a_np, input_b_np], [output_c_np, output_d_np], epochs=1)
+    model, input_data = self._getSequentialMultiInputOutputModel()
 
     # Convert model and ensure model is not None.
     converter = lite.TFLiteConverterV2.from_keras_model(model)
     tflite_model = converter.convert()
 
     # Check values from converted model.
-    input_data = [left_input_data, right_input_data]
     expected_value = model.predict(input_data)
     actual_value = self._evaluateTFLiteModel(tflite_model, input_data)
     for tf_result, tflite_result in zip(expected_value, actual_value):

--- a/tensorflow/lite/python/lite_v2_test.py
+++ b/tensorflow/lite/python/lite_v2_test.py
@@ -1299,6 +1299,22 @@ class FromSavedModelTest(lite_v2_test_util.ModelTest):
     actual_value = interpreter.get_tensor(output_details[0]['index'])
     self.assertEqual([2., 4., 6.], list(actual_value))
 
+  @test_util.run_v2_only
+  def testSequentialMultiInputOutputModel(self):
+    """Test a saved model with multiple inputs and outputs."""
+    model, input_data = self._getSequentialMultiInputOutputModel()
+
+    save_dir = os.path.join(self.get_temp_dir(), 'saved_model')
+    model.save(save_dir)
+    converter = lite.TFLiteConverterV2.from_saved_model(save_dir)
+    tflite_model = converter.convert()
+
+    # Check values from converted saved model.
+    expected_value = model.predict(input_data)
+    actual_value = self._evaluateTFLiteModel(tflite_model, input_data)
+    for tf_result, tflite_result in zip(expected_value, actual_value):
+      self.assertAllClose(tf_result, tflite_result, atol=1e-05)
+
 
 class FromKerasModelTest(lite_v2_test_util.ModelTest):
 

--- a/tensorflow/lite/python/lite_v2_test_util.py
+++ b/tensorflow/lite/python/lite_v2_test_util.py
@@ -22,7 +22,9 @@ from __future__ import print_function
 import os
 
 from absl.testing import parameterized
+import numpy as np
 from six.moves import zip
+import tensorflow as tf
 
 from tensorflow.lite.python.interpreter import Interpreter
 from tensorflow.python.eager import def_function
@@ -120,6 +122,39 @@ class ModelTest(test_util.TensorFlowTestCase, parameterized.TestCase):
         return x * self.z + y
 
     return BasicModel()
+
+  def _getSequentialMultiInputOutputModel(self):
+    left_input_data = tf.constant(1., shape=[1, 3])
+    right_input_data = tf.constant(1., shape=[1, 3])
+    input_data = [left_input_data, right_input_data]
+
+    # Create a simple Keras model.
+    input_a_np = np.random.random((10, 3))
+    input_b_np = np.random.random((10, 3))
+    output_c_np = np.random.random((10, 3))
+    output_d_np = np.random.random((10, 2))
+
+    input_a = tf.keras.layers.Input(shape=(3,), name='input_a')
+    input_b = tf.keras.layers.Input(shape=(3,), name='input_b')
+
+    dense = tf.keras.layers.Dense(8, name='dense_1')
+    interm_a = dense(input_a)
+    interm_b = dense(input_b)
+    merged = tf.keras.layers.concatenate([interm_a, interm_b], name='merge')
+
+    output_c = tf.keras.layers.Dense(
+        3, activation='softmax', name='dense_2')(
+            merged)
+    output_d = tf.keras.layers.Dense(
+        2, activation='softmax', name='dense_3')(
+            merged)
+
+    model = tf.keras.models.Model(
+        inputs=[input_a, input_b], outputs=[output_c, output_d])
+    model.compile(optimizer='sgd', loss='mean_squared_error')
+    model.fit([input_a_np, input_b_np], [output_c_np, output_d_np], epochs=1)
+
+    return model, input_data
 
   def _assertValidDebugInfo(self, debug_info):
     """Verify the DebugInfo is valid."""


### PR DESCRIPTION
This PR pushes a failing test case (093f927aa9c217bfbecf7350c3c3f651964587af) showing the bug described in #47927.

The failure can be reproduced by running the unittests with `bazelisk test tensorflow/lite/python:lite_v2_test --test_output=all`.