### PR TITLE
[tf.data] break down and parameterize FromSparseTensorSlicesTest

### DIFF
--- a/tensorflow/python/data/kernel_tests/from_sparse_tensor_slices_test.py
+++ b/tensorflow/python/data/kernel_tests/from_sparse_tensor_slices_test.py
@@ -34,10 +34,14 @@ from tensorflow.python.platform import test
 class FromSparseTensorSlicesTest(test_base.DatasetTestBase,
                                  parameterized.TestCase):
 
-  # TODO(jsimsa): Break this down to multiple (parameterized) test cases.
   @combinations.generate(
-      combinations.combine(tf_api_version=1, mode=["graph"]))
-  def testFromSparseTensorSlices(self):
+      combinations.times(
+          combinations.combine(tf_api_version=1, mode=["graph"]),
+          combinations.combine(slices=[
+              [[1., 2., 3.], [1.], [1.], [1., 2.], [], [1., 2.], [], [], []],
+              [[1., 2.], [], [1., 2.], [1.], [1., 2.], [], [1., 2.]]
+          ])))
+  def testFromSparseTensorSlices(self, slices):
     """Test a dataset based on slices of a `tf.sparse.SparseTensor`."""
     st = array_ops.sparse_placeholder(dtypes.float64)
     iterator = dataset_ops.make_initializable_iterator(
@@ -46,8 +50,6 @@ class FromSparseTensorSlicesTest(test_base.DatasetTestBase,
     get_next = sparse_tensor.SparseTensor(*iterator.get_next())
 
     with self.cached_session() as sess:
-      slices = [[1., 2., 3.], [1.], [1.], [1., 2.], [], [1., 2.], [], [], []]
-
       # Test with sparse tensor in the appropriate order.
       # pylint: disable=g-complex-comprehension
       indices = np.array(
@@ -68,6 +70,27 @@ class FromSparseTensorSlicesTest(test_base.DatasetTestBase,
       with self.assertRaises(errors.OutOfRangeError):
         sess.run(get_next)
 
+  @combinations.generate(
+      combinations.times(
+          combinations.combine(tf_api_version=1, mode=["graph"]),
+          combinations.combine(slices=[
+              [[1., 2., 3.], [1.], [1.], [1., 2.], [], [1., 2.], [], [], []],
+              [[1., 2.], [], [1., 2.], [1.], [1., 2.], [], [1., 2.]]
+          ])))
+  def testFromSparseTensorSlicesInReverse(self, slices):
+    """Test a dataset based on slices of a `tf.sparse.SparseTensor` in reverse order."""
+    st = array_ops.sparse_placeholder(dtypes.float64)
+    iterator = dataset_ops.make_initializable_iterator(
+        dataset_ops.Dataset.from_sparse_tensor_slices(st))
+    init_op = iterator.initializer
+
+    with self.cached_session() as sess:
+      # pylint: disable=g-complex-comprehension
+      indices = np.array(
+          [[i, j] for i in range(len(slices)) for j in range(len(slices[i]))])
+      values = np.array([val for s in slices for val in s])
+      # pylint: enable=g-complex-comprehension
+      dense_shape = np.array([len(slices), max(len(s) for s in slices) + 1])
       # Test with sparse tensor in the reverse order, which is not
       # currently supported.
       reverse_order_indices = indices[::-1, :]
@@ -77,6 +100,17 @@ class FromSparseTensorSlicesTest(test_base.DatasetTestBase,
       with self.assertRaises(errors.UnimplementedError):
         sess.run(init_op, feed_dict={st: sparse_feed})
 
+  @combinations.generate(
+      combinations.combine(tf_api_version=1, mode=["graph"]))
+  def testEmptySparseTensorSlices(self):
+    """Test a dataset based on slices of an empty `tf.sparse.SparseTensor`."""
+    st = array_ops.sparse_placeholder(dtypes.float64)
+    iterator = dataset_ops.make_initializable_iterator(
+        dataset_ops.Dataset.from_sparse_tensor_slices(st))
+    init_op = iterator.initializer
+    get_next = sparse_tensor.SparseTensor(*iterator.get_next())
+
+    with self.cached_session() as sess:
       # Test with an empty sparse tensor.
       empty_indices = np.empty((0, 4), dtype=np.int64)
       empty_values = np.empty((0,), dtype=np.float64)


### PR DESCRIPTION
This PR refactors the `FromSparseTensorSlicesTest` by splitting the test into multiple parameterized tests.

Addresses point 6 in https://github.com/tensorflow/tensorflow/pull/46761#issuecomment-770059963.
cc: @jsimsa 