### PR TITLE
Fixed NotImplementedError: Cannot convert a symbolic Tensor to a numpy array

### DIFF
--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -2895,7 +2895,7 @@ def _constant_if_small(value, shape, dtype, name):
   try:
     if np.prod(shape) < 1000:
       return constant(value, shape=shape, dtype=dtype, name=name)
-  except TypeError:
+  except (NotImplementedError, TypeError):
     # Happens when shape is a Tensor, list with Tensor elements, etc.
     pass
   return None


### PR DESCRIPTION
Fixed #9706

Implemented as mentioned in https://github.com/tensorflow/models/issues/9706#issuecomment-791113516 and https://github.com/tensorflow/models/issues/9706#issuecomment-792106149 .

This problem happens with tensorflow 2.4.1 and numpy 1.20.1 .
Minimal code to reproduce the problem:
```python
from tensorflow.keras.models import Sequential
from tensorflow.keras import layers
model = Sequential()
model.add(layers.LSTM(256, return_sequences=True))
model.build((10,20,30))
model.summary()
```
