### PR TITLE
Add GPU implem of sparse segment reduction ops

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -3428,6 +3428,7 @@ tf_kernel_library(
     name = "segment_reduction_ops",
     prefix = "segment_reduction_ops",
     deps = MATH_DEPS + if_cuda_or_rocm([
+        ":gpu_prim_helpers",
         "//tensorflow/core/util:cuda_solvers",
     ]),
 )

--- a/tensorflow/core/kernels/gpu_prim_helpers.h
+++ b/tensorflow/core/kernels/gpu_prim_helpers.h
@@ -136,6 +136,43 @@ Status GpuInclusivePrefixSum(OpKernelContext* context, int size,
   return Status::OK();
 }
 
+template <typename InputIteratorT, typename OutputIteratorT,
+          typename OffsetIteratorT, typename ReduceOp, typename T>
+Status GpuSegmentedReduce(
+    OpKernelContext* context, int num_segments, ReduceOp reduce_op,
+    T initial_value,
+    InputIteratorT input,             // [any]
+    OffsetIteratorT segment_offsets,  // [num_segments + 1]
+    OutputIteratorT output) {         // [num_segments]
+  if (num_segments == 0) return Status::OK();
+  const auto& cu_stream = GetGpuStream(context);
+  size_t temp_storage_bytes;
+  auto err = gpuprim::DeviceSegmentedReduce::Reduce(
+      nullptr, temp_storage_bytes, input, output, num_segments, segment_offsets,
+      segment_offsets + 1, reduce_op, initial_value, cu_stream);
+  if (err != 0) {
+    return errors::Internal(
+        "Failed to launch gpuprim::DeviceSegmentedReduce::Reduce to calculate "
+        "temp_storage_bytes, status: ",
+        cudaGetErrorString(err));
+  }
+  Tensor temp_storage;
+  TF_RETURN_IF_ERROR(context->allocate_temp(
+      DT_INT8, TensorShape({static_cast<int64>(temp_storage_bytes)}),
+      &temp_storage));
+  err = gpuprim::DeviceSegmentedReduce::Reduce(
+      temp_storage.flat<int8>().data(), temp_storage_bytes, input, output,
+      num_segments, segment_offsets, segment_offsets + 1, reduce_op,
+      initial_value, cu_stream);
+  if (err != 0) {
+    return errors::Internal(
+        "Failed to launch gpuprim::DeviceSegmentedReduce::Reduce"
+        ", temp_storage_bytes: ",
+        temp_storage_bytes, ", status: ", cudaGetErrorString(err));
+  }
+  return Status::OK();
+}
+
 }  // namespace tensorflow
 
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/core/kernels/gpu_prim_helpers.h
+++ b/tensorflow/core/kernels/gpu_prim_helpers.h
@@ -140,7 +140,7 @@ template <typename InputIteratorT, typename OutputIteratorT,
           typename OffsetIteratorT, typename ReduceOp, typename T>
 Status GpuSegmentedReduce(
     OpKernelContext* context, int num_segments, ReduceOp reduce_op,
-    T initial_value,
+    const T& initial_value,
     InputIteratorT input,             // [any]
     OffsetIteratorT segment_offsets,  // [num_segments + 1]
     OutputIteratorT output) {         // [num_segments]

--- a/tensorflow/core/kernels/gpu_prim_helpers.h
+++ b/tensorflow/core/kernels/gpu_prim_helpers.h
@@ -136,6 +136,7 @@ Status GpuInclusivePrefixSum(OpKernelContext* context, int size,
   return Status::OK();
 }
 
+// Note that this behaves deterministically for repeat calls on the same device.
 template <typename InputIteratorT, typename OutputIteratorT,
           typename OffsetIteratorT, typename ReduceOp, typename T>
 Status GpuSegmentedReduce(

--- a/tensorflow/core/kernels/gpu_prim_helpers_test.cu.cc
+++ b/tensorflow/core/kernels/gpu_prim_helpers_test.cu.cc
@@ -128,6 +128,56 @@ REGISTER_OP("TestGpuInclusivePrefixSum")
 REGISTER_KERNELS(int32);
 #undef REGISTER_KERNELS
 
+template <typename T, typename Toffset, typename ReduceOp>
+class TestGpuSegmentedReduceKernel : public tensorflow::OpKernel {
+ public:
+  explicit TestGpuSegmentedReduceKernel(
+      tensorflow::OpKernelConstruction* context)
+      : OpKernel(context) {}
+
+  void Compute(tensorflow::OpKernelContext* context) override {
+    const Tensor& input = context->input(0);
+    const T* input_data = input.flat<T>().data();
+    const Tensor& segment_offsets = context->input(1);
+    const Toffset* segment_offsets_data =
+        segment_offsets.flat<Toffset>().data();
+    int num_segments = segment_offsets.NumElements() - 1;
+    const Tensor& initial_value_tensor = context->input(2);
+    T initial_value = initial_value_tensor.scalar<T>()();
+
+    Tensor* output = nullptr;
+    OP_REQUIRES_OK(context, context->allocate_output(
+                                0, TensorShape({num_segments}), &output));
+    T* output_data = output->flat<T>().data();
+
+    OP_REQUIRES_OK(
+        context,
+        GpuSegmentedReduce(context, num_segments, ReduceOp(), initial_value,
+                           input_data, segment_offsets_data, output_data));
+  }
+
+ private:
+  T initial_value_;
+};
+
+REGISTER_OP("TestGpuSegmentedSum")
+    .Input("input: T")
+    .Input("segment_offsets: Toffset")
+    .Input("initial_value: T")
+    .Output("output: T")
+    .Attr("T: type")
+    .Attr("Toffset: type");
+#define REGISTER_KERNELS(T, Toffset)           \
+  REGISTER_KERNEL_BUILDER(                     \
+      Name("TestGpuSegmentedSum")              \
+          .Device(tensorflow::DEVICE_GPU)      \
+          .HostMemory("initial_value")         \
+          .TypeConstraint<T>("T")              \
+          .TypeConstraint<Toffset>("Toffset"), \
+      TestGpuSegmentedReduceKernel<T, Toffset, gpuprim::Sum>)
+REGISTER_KERNELS(int32, int32);
+#undef REGISTER_KERNELS
+
 class GpuPrimHelpersTest : public OpsTestBase {
  protected:
   GpuPrimHelpersTest() {
@@ -149,6 +199,15 @@ class GpuPrimHelpersTest : public OpsTestBase {
 
   void MakeInclusivePrefixSum(DataType type) {
     TF_ASSERT_OK(NodeDefBuilder("test_op", "TestGpuInclusivePrefixSum")
+                     .Input(FakeInput(type))
+                     .Finalize(node_def()));
+    TF_ASSERT_OK(InitOp());
+  }
+
+  void MakeSegmentedSum(DataType type, DataType offset_type) {
+    TF_ASSERT_OK(NodeDefBuilder("test_op", "TestGpuSegmentedSum")
+                     .Input(FakeInput(type))
+                     .Input(FakeInput(offset_type))
                      .Input(FakeInput(type))
                      .Finalize(node_def()));
     TF_ASSERT_OK(InitOp());
@@ -219,6 +278,21 @@ TEST_F(GpuPrimHelpersTest, GpuInclusivePrefixSum) {
 
   Tensor expected_output(allocator(), DT_INT32, TensorShape({8}));
   test::FillValues<int32>(&expected_output, {4, 6, 12, 19, 20, 23, 23, 28});
+  test::ExpectTensorEqual<int32>(expected_output, *GetOutput(0));
+}
+
+TEST_F(GpuPrimHelpersTest, GpuSegmentedReduce_Sum) {
+  MakeSegmentedSum(DT_INT32, DT_INT32);
+  // Input.
+  AddInputFromArray<int32>(TensorShape({10}), {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+  // Segment IDs.
+  AddInputFromArray<int32>(TensorShape({6}), {1, 3, 4, 4, 8, 10});
+  // Initial value.
+  AddInputFromArray<int32>(TensorShape({}), {0});
+  TF_ASSERT_OK(RunOpKernel());
+
+  Tensor expected_output(allocator(), DT_INT32, TensorShape({5}));
+  test::FillValues<int32>(&expected_output, {3, 3, 0, 22, 17});
   test::ExpectTensorEqual<int32>(expected_output, *GetOutput(0));
 }
 

--- a/tensorflow/core/kernels/segment_reduction_ops.h
+++ b/tensorflow/core/kernels/segment_reduction_ops.h
@@ -171,6 +171,15 @@ struct Highest {
   }
 };
 
+template <typename T, typename Index, typename SegmentId>
+struct SparseSegmentReductionFunctor {
+  Status operator()(OpKernelContext* context, bool is_mean, bool is_sqrtn,
+                    T default_value, typename TTypes<T, 2>::ConstTensor input,
+                    typename TTypes<Index>::ConstVec indices,
+                    typename TTypes<SegmentId>::ConstVec segment_ids,
+                    typename TTypes<T, 2>::Tensor output);
+};
+
 }  // namespace functor
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/segment_reduction_ops_gpu.cu.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops_gpu.cu.cc
@@ -380,7 +380,7 @@ Status LaunchSegmentReduceEpilogueKernel(
 template <typename Tto>
 struct CastFunctor {
   template <typename T>
-  __device__ Tto operator()(T val) const {
+  __device__ Tto operator()(const T& val) const {
     return static_cast<Tto>(val);
   }
 };

--- a/tensorflow/core/kernels/segment_reduction_ops_gpu.cu.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops_gpu.cu.cc
@@ -154,22 +154,6 @@ bool DisableSegmentReductionOpDeterminismExceptions() {
   return cached_disable;
 }
 
-// Helper to set all tensor entries to a specific value. This differs from
-// SetToValue because it performs an explicit conversion from the given value
-// to the output type, which avoids compilation issues when Tvec is an aligned
-// vector type.
-template <typename Tvec, typename Tinit>
-__global__ void SetToValueVectorized(const int count, Tvec* __restrict__ ptr,
-                                     Tinit value) {
-  // Check that the grid is one dimensional and index doesn't overflow.
-  assert(blockDim.y == 1);
-  assert(blockDim.z == 1);
-  assert(blockDim.x * gridDim.x / blockDim.x == gridDim.x);
-  for (int i : GpuGridRangeX(count)) {
-    ptr[i] = Tvec(value);
-  }
-}
-
 template <typename Tindex, typename Tsegmentids>
 __global__ void SegmentOffsetsKernel(
     Tindex size, Tsegmentids nsegments,
@@ -418,10 +402,9 @@ Status SegmentReduceGPUImpl(
     GPUDevice d = ctx->template eigen_device<GPUDevice>();
     int64 output_size = static_cast<int64>(nsegments) * ninner_vec;
     GpuLaunchConfig config = GetGpuLaunchConfig(output_size, d);
-    return GpuLaunchKernel(SetToValueVectorized<Tvec, Tinit>,
-                           config.block_count, config.thread_per_block, 0,
-                           d.stream(), output_size, output_vec,
-                           empty_segment_value);
+    return GpuLaunchKernel(SetToValue<Tvec, Tinit>, config.block_count,
+                           config.thread_per_block, 0, d.stream(), output_size,
+                           output_vec, empty_segment_value);
   }
 
   // Allocate and compute segment_offsets.

--- a/tensorflow/core/kernels/segment_reduction_ops_gpu.cu.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops_gpu.cu.cc
@@ -24,9 +24,13 @@ limitations under the License.
 // clang-format on
 
 #include "tensorflow/core/framework/register_types.h"
+#include "tensorflow/core/kernels/gpu_prim.h"
+#include "tensorflow/core/kernels/gpu_prim_helpers.h"
 #include "tensorflow/core/kernels/segment_reduction_ops.h"
+#include "tensorflow/core/lib/core/bits.h"
 #include "tensorflow/core/util/env_var.h"
 #include "tensorflow/core/util/gpu_device_functions.h"
+#include "tensorflow/core/util/permutation_input_iterator.h"
 
 namespace tensorflow {
 
@@ -150,6 +154,406 @@ bool DisableSegmentReductionOpDeterminismExceptions() {
   return cached_disable;
 }
 
+template <typename Tindex, typename Tsegmentids>
+__global__ void SegmentOffsetsKernel(
+    Tindex size, Tsegmentids nsegments,
+    const Tsegmentids* __restrict__ segment_ids,  // [size]
+    Tindex* __restrict__ segment_offsets) {       // [nsegments + 1]
+  GPU_1D_KERNEL_LOOP(i, size + 1) {
+    // IDs are clipped to [-1, nsegments] so that out-of-bounds IDs are ignored.
+    // Note that we can't report invalid IDs from the GPU without incurring
+    // additional overhead.
+    auto clip = [&](Tsegmentids id) {
+      return min(max(Tsegmentids(-1), id), nsegments);
+    };
+    const Tsegmentids cur_id = (i < size) ? clip(segment_ids[i]) : nsegments;
+    const Tsegmentids prev_id =
+        (i == 0) ? Tsegmentids(-1) : clip(segment_ids[i - 1]);
+    // At segment boundaries, write the offset for this ID and any missing IDs
+    // since the previous one.
+    for (Tsegmentids id = prev_id + 1; id <= cur_id; ++id) {
+      segment_offsets[id] = i;
+    }
+  }
+}
+
+// Finds the start offset of each segment in the given sorted segment_ids
+// vector. Missing IDs are given the same offset as the next ID so that they
+// represent empty ranges. Invalid IDs (those that are outside the range
+// [0, nsegments)) are ignored. The value at segment_offsets[0] is set to the
+// start index of the first valid ID (e.g., 0 if all IDs are valid), and the
+// value at segment_offsets[nsegments] is set to the end index of the last valid
+// ID (e.g., nsegments if all IDs are valid).
+template <typename Tindex, typename Tsegmentids>
+Status LaunchSegmentOffsetsKernel(const GPUDevice& d, Tindex size,
+                                  Tsegmentids nsegments,
+                                  const Tsegmentids* segment_ids,  // [size]
+                                  Tindex* segment_offsets) {  // [nsegments + 1]
+  GpuLaunchConfig config = GetGpuLaunchConfig(
+      size + 1, d, &SegmentOffsetsKernel<Tindex, Tsegmentids>,
+      /*dynamic_shared_memory_size=*/0, /*block_size_limit=*/0);
+  return GpuLaunchKernel(SegmentOffsetsKernel<Tindex, Tsegmentids>,
+                         config.block_count, config.thread_per_block, 0,
+                         d.stream(), size, nsegments, segment_ids,
+                         segment_offsets);
+}
+
+template <typename T>
+struct RealTypeIfComplex {
+  using type = T;
+};
+
+template <typename Real>
+struct RealTypeIfComplex<std::complex<Real>> {
+  using type = Real;
+};
+
+// This kernel uses a 2D thread decomposition. The x dimension maps to the inner
+// dimension of the input/output. The y grid dimension maps to segments, and y
+// threads within a block cooperate to reduce over the block's segment.
+// Note that Tinit is needed because Tvec and Treducevec may be vector types,
+// but Tinit is always a scalar type.
+template <typename Treducevec, typename Tvec, typename Tindex,
+          typename Tsegmentids, typename ReduceOp, typename Tinit>
+__global__ void SegmentReduceVectorKernel(
+    Tindex nouter, Tindex ninner_vec, Tsegmentids nsegments, ReduceOp reduce_op,
+    Tinit initial_value, Tinit empty_segment_value, bool is_mean, bool is_sqrtn,
+    const Tvec* __restrict__ input_vec,          // [nouter or any, ninner_vec]
+    const Tindex* __restrict__ segment_offsets,  // [nsegments + 1]
+    const Tindex* __restrict__ indices,          // [nouter] (optional)
+    Tvec* __restrict__ output_vec) {             // [nsegments, ninner_vec]
+  GPU_DYNAMIC_SHARED_MEM_DECL(/*ALIGN = */ 16, char, smem_raw);
+  Treducevec* const smem =
+      reinterpret_cast<Treducevec*>(smem_raw);  // [blockDim.y, blockDim.x]
+  const int num_blocks_x = (ninner_vec - 1) / blockDim.x + 1;
+  // Grid-stride loop over inner dimension blocks.
+  for (Tindex blk_x = blockIdx.x; blk_x < num_blocks_x; blk_x += gridDim.x) {
+    const Tindex x = threadIdx.x + blk_x * blockDim.x;
+    const Tindex y = threadIdx.y;
+    const bool x_ok = x < ninner_vec;
+    // Grid-stride loop over segment blocks, each processing one segment.
+    for (Tsegmentids seg = blockIdx.y; seg < nsegments; seg += gridDim.y) {
+      // Load segment range.
+      const Tindex beg = segment_offsets[seg];
+      const Tindex end = segment_offsets[seg + 1];
+      // Reduce over the segment.
+      Treducevec result = Treducevec(initial_value);
+      // Loop over the segment, reducing blockDim.y elements at a time.
+      for (Tindex yy = beg; yy < end; yy += blockDim.y) {
+        const bool y_ok = yy + y < end;
+        // Perform indirect lookup if required.
+        const Tindex y_idx = indices && y_ok ? indices[yy + y] : yy + y;
+        const int64 input_idx = static_cast<int64>(y_idx) * ninner_vec + x;
+        // Load the input row from global mem.
+        Treducevec block_result =
+            x_ok && y_ok ? input_vec[input_idx] : Tvec(initial_value);
+        // Reduce over the y dimension of the block.
+        for (unsigned k = blockDim.y / 2; k > 0; k /= 2) {
+          if (x_ok && y < 2 * k) {
+            smem[y * blockDim.x + x] = block_result;
+          }
+          __syncthreads();
+          if (x_ok && y < k) {
+            block_result =
+                reduce_op(block_result, smem[(y + k) * blockDim.x + x]);
+          }
+          __syncthreads();
+        }
+        result = reduce_op(result, block_result);
+      }
+      // First row of the block stores the result to global memory.
+      if (y == 0 && x_ok) {
+        if (beg == end) {
+          // Empty segment.
+          result = Treducevec(empty_segment_value);
+        } else {
+          typename RealTypeIfComplex<Tinit>::type total_weight(end - beg);
+          // Normalize the results if necessary.
+          if (is_mean) {
+            result /= Treducevec(total_weight);
+          } else if (is_sqrtn) {
+            result /= Treducevec(sqrt(total_weight));
+          }
+        }
+        // Cast from Treducevec to Tvec.
+        const int64 output_idx = static_cast<int64>(seg) * ninner_vec + x;
+        output_vec[output_idx] = static_cast<Tvec>(result);
+      }
+    }
+  }
+}
+
+// Reduces input matrix within segments over the outer dimension. Empty segments
+// always output empty_segment_value.
+// If is_mean or is_sqrtn is true, the results are normalized using the
+// corresponding function.
+// If indices is not nullptr, input rows are accessed indirectly as
+// input[indices[i]], instead of input[i].
+// Note: Treducevec is to allow reducing in higher precision than Tvec.
+template <typename Treducevec, typename Tvec, typename Tindex,
+          typename Tsegmentids, typename ReduceOp, typename Tinit>
+Status LaunchSegmentReduceVectorKernel(
+    const GPUDevice& d, Tindex nouter, Tindex ninner_vec, Tsegmentids nsegments,
+    ReduceOp reduce_op, Tinit initial_value, Tinit empty_segment_value,
+    bool is_mean, bool is_sqrtn,
+    const Tvec* input_vec,          // [nouter or any, ninner_vec]
+    const Tindex* segment_offsets,  // [nsegments + 1]
+    const Tindex* indices,          // [nouter] (optional)
+    Tvec* output_vec) {             // [nsegments, ninner_vec]
+  static constexpr const int kMaxGridX = (1u << 31) - 1;
+  static constexpr const int kMaxGridY = (1u << 16) - 1;
+  const int max_block_size = 1024;  // Can be tuned for perf (<= 1024)
+  const int min_block_size = 64;    // Can be tuned for perf
+  const Tindex ninner_pow2 = Tindex(1) << Log2Ceiling64(ninner_vec);
+  // This is a heuristic that first allocates threads in the block to the inner
+  // (x) dimension (which is most efficient) and then allocates the rest to the
+  // reduction (y) dimension (which is less efficient but increases
+  // parallelism).
+  int block_x = std::min(ninner_pow2, static_cast<Tindex>(max_block_size));
+  const Tindex avg_reduce_size =
+      Eigen::divup(nouter, static_cast<Tindex>(nsegments));
+  const Tindex avg_reduce_size_pow2 = Tindex(1)
+                                      << Log2Ceiling64(avg_reduce_size);
+  dim3 block(
+      block_x,
+      std::min(static_cast<Tindex>(Eigen::divup(min_block_size, block_x)),
+               avg_reduce_size_pow2));
+  dim3 grid(std::min(Eigen::divup(ninner_vec, static_cast<Tindex>(block.x)),
+                     static_cast<Tindex>(kMaxGridX)),
+            std::min(nsegments, static_cast<Tsegmentids>(kMaxGridY)));
+  unsigned smem = block.x * block.y * sizeof(Treducevec);
+  return GpuLaunchKernel(
+      SegmentReduceVectorKernel<Treducevec, Tvec, Tindex, Tsegmentids, ReduceOp,
+                                Tinit>,
+      grid, block, smem, d.stream(), nouter, ninner_vec, nsegments, reduce_op,
+      initial_value, empty_segment_value, is_mean, is_sqrtn, input_vec,
+      segment_offsets, indices, output_vec);
+}
+
+template <typename Tvec, typename Treducevec, typename Tindex,
+          typename Tsegmentids, typename Tinit>
+__global__ void SegmentReduceEpilogueKernel(
+    Tsegmentids nsegments, Tinit empty_segment_value, bool is_mean,
+    bool is_sqrtn,
+    const Treducevec* __restrict__ output_raw,   // [nsegments]
+    const Tindex* __restrict__ segment_offsets,  // [nsegments + 1]
+    Tvec* __restrict__ output) {                 // [nsegments]
+  GPU_1D_KERNEL_LOOP(seg, nsegments) {
+    Tindex segment_size = segment_offsets[seg + 1] - segment_offsets[seg];
+    Treducevec val = output_raw[seg];
+    if (segment_size == 0) {
+      // Empty segment.
+      val = Treducevec(empty_segment_value);
+    } else if (is_mean) {
+      val /= Treducevec(segment_size);
+    } else if (is_sqrtn) {
+      val /= Treducevec(
+          sqrt(typename RealTypeIfComplex<Tinit>::type(segment_size)));
+    }
+    // Cast from Treducevec to Tvec.
+    output[seg] = static_cast<Tvec>(val);
+  }
+}
+
+// Normalizes output_raw based on segment size and casts from Treducevec to
+// Tvec. If Tvec == Treducevec, this is safe to call with output_raw == output.
+template <typename Tvec, typename Treducevec, typename Tindex,
+          typename Tsegmentids, typename Tinit>
+Status LaunchSegmentReduceEpilogueKernel(
+    const GPUDevice& d, Tsegmentids nsegments, Tinit empty_segment_value,
+    bool is_mean, bool is_sqrtn,
+    const Treducevec* output_raw,   // [nsegments]
+    const Tindex* segment_offsets,  // [nsegments + 1]
+    Tvec* output) {                 // [nsegments]
+  GpuLaunchConfig config = GetGpuLaunchConfig(
+      nsegments, d,
+      &SegmentReduceEpilogueKernel<Tvec, Treducevec, Tindex, Tsegmentids,
+                                   Tinit>,
+      /*dynamic_shared_memory_size=*/0, /*block_size_limit=*/0);
+  return GpuLaunchKernel(
+      SegmentReduceEpilogueKernel<Tvec, Treducevec, Tindex, Tsegmentids, Tinit>,
+      config.block_count, config.thread_per_block, 0, d.stream(), nsegments,
+      empty_segment_value, is_mean, is_sqrtn, output_raw, segment_offsets,
+      output);
+}
+
+template <typename Tto>
+struct CastFunctor {
+  template <typename T>
+  __device__ Tto operator()(T val) const {
+    return static_cast<Tto>(val);
+  }
+};
+
+template <typename Treducevec, typename Tvec, typename Tindex,
+          typename Tsegmentids, typename ReduceOp, typename Tinit>
+Status SegmentReduceGPUImpl(
+    OpKernelContext* ctx, Tindex nouter, Tindex ninner_vec,
+    Tsegmentids nsegments, ReduceOp reduce_op, Tinit initial_value,
+    Tinit empty_segment_value, bool is_mean, bool is_sqrtn,
+    const Tvec* input_vec,           // [nouter or any, ninner_vec]
+    const Tsegmentids* segment_ids,  // [nouter]
+    const Tindex* indices,           // [nouter] (optional)
+    Tvec* output_vec) {              // [nsegments, ninner_vec]
+  const GPUDevice& device = ctx->eigen_gpu_device();
+
+  if (nouter == 0) {
+    // Just set output to empty_segment_value.
+    GPUDevice d = ctx->template eigen_device<GPUDevice>();
+    int64 output_size = static_cast<int64>(nsegments) * ninner_vec;
+    GpuLaunchConfig config = GetGpuLaunchConfig(output_size, d);
+    return GpuLaunchKernel(SetToValue<Tvec>, config.block_count,
+                           config.thread_per_block, 0, d.stream(), output_size,
+                           output_vec, empty_segment_value);
+  }
+
+  // Allocate and compute segment_offsets.
+  Tensor segment_offsets;
+  TF_RETURN_IF_ERROR(ctx->allocate_temp(DataTypeToEnum<Tindex>::value,
+                                        TensorShape({nsegments + 1}),
+                                        &segment_offsets));
+  Tindex* segment_offsets_ptr = segment_offsets.flat<Tindex>().data();
+  TF_RETURN_IF_ERROR(LaunchSegmentOffsetsKernel(
+      device, nouter, nsegments, segment_ids, segment_offsets_ptr));
+
+  if (ninner_vec == 1) {
+    // Here we use gpuprim::DeviceSegmentedReduce (which is optimized for this
+    // shape) and add the additional required functionality using fancy input
+    // iterators and an epilogue kernel.
+
+    // Note: This reinterpret cast is only needed to avoid compilation error
+    // when Tvec != Treducevec; the result is only used if Tvec == Treducevec.
+    Treducevec* output_raw_ptr = reinterpret_cast<Treducevec*>(output_vec);
+    Tensor output_raw;
+    bool need_temp_output = !std::is_same<Tvec, Treducevec>::value;
+    if (need_temp_output) {
+      // Note: We must allocate and reinterpret as bytes because Treducevec may
+      // be a vector type and they are not supported as Tensor dtypes.
+      TF_RETURN_IF_ERROR(ctx->allocate_temp(
+          DT_INT8,
+          TensorShape({static_cast<int64>(nsegments * sizeof(Treducevec))}),
+          &output_raw));
+      output_raw_ptr =
+          reinterpret_cast<Treducevec*>(output_raw.flat<int8>().data());
+    }
+    if (indices) {
+      // Use fancy iterators to do lookup via indices and to cast to Treducevec.
+      PermutationInputIterator<Treducevec, decltype(input_vec),
+                               decltype(indices)>
+          perm_iter(input_vec, indices);
+      gpuprim::TransformInputIterator<Treducevec, CastFunctor<Treducevec>,
+                                      decltype(perm_iter)>
+          input_lookup_cast(perm_iter, {});
+      TF_RETURN_IF_ERROR(GpuSegmentedReduce(
+          ctx, nsegments, reduce_op, Treducevec(initial_value),
+          input_lookup_cast, segment_offsets_ptr, output_raw_ptr));
+    } else {
+      // Use a fancy iterator to cast to Treducevec.
+      gpuprim::TransformInputIterator<Treducevec, CastFunctor<Treducevec>,
+                                      decltype(input_vec)>
+          input_cast(input_vec, {});
+      TF_RETURN_IF_ERROR(GpuSegmentedReduce(
+          ctx, nsegments, reduce_op, Treducevec(initial_value), input_cast,
+          segment_offsets_ptr, output_raw_ptr));
+    }
+    bool need_epilogue = !std::is_same<Tvec, Treducevec>::value ||
+                         initial_value != empty_segment_value || is_mean ||
+                         is_sqrtn;
+    if (need_epilogue) {
+      // Normalize based on the segment size and cast results back to T.
+      TF_RETURN_IF_ERROR(LaunchSegmentReduceEpilogueKernel(
+          device, nsegments, empty_segment_value, is_mean, is_sqrtn,
+          output_raw_ptr, segment_offsets_ptr, output_vec));
+    }
+  } else {
+    // Here we use a custom kernel that is optimized for ninner_vec >= ~64 and
+    // gives decent performance for smaller cases. It also handles indices,
+    // casting to/from Treducevec, and normalizing the output.
+    TF_RETURN_IF_ERROR(LaunchSegmentReduceVectorKernel<Treducevec>(
+        device, nouter, ninner_vec, nsegments, reduce_op, initial_value,
+        empty_segment_value, is_mean, is_sqrtn, input_vec, segment_offsets_ptr,
+        indices, output_vec));
+  }
+  return Status::OK();
+}
+
+template <typename Treduce>
+struct SegmentReduceGPUVectorized {
+  template <int vec_size>
+  struct Impl {
+    template <typename T, typename Tindex, typename Tsegmentids,
+              typename ReduceOp>
+    Status operator()(OpKernelContext* ctx, Tindex nouter, Tindex ninner,
+                      Tsegmentids nsegments, ReduceOp reduce_op,
+                      T initial_value, T empty_segment_value, bool is_mean,
+                      bool is_sqrtn, const T* input,
+                      const Tsegmentids* segment_ids, const Tindex* indices,
+                      T* output) {
+      DCHECK_EQ(ninner % vec_size, 0);  // Crash OK
+      DCHECK_EQ(reinterpret_cast<std::uintptr_t>(input) % vec_size,
+                0);  // Crash OK
+      DCHECK_EQ(reinterpret_cast<std::uintptr_t>(output) % vec_size,
+                0);  // Crash OK
+      Tindex ninner_vec = ninner / vec_size;
+      using Tvec = AlignedVector<T, vec_size>;
+      using Treducevec = AlignedVector<Treduce, vec_size>;
+      const Tvec* input_vec = reinterpret_cast<const Tvec*>(input);
+      Tvec* output_vec = reinterpret_cast<Tvec*>(output);
+
+      return SegmentReduceGPUImpl<Treducevec>(
+          ctx, nouter, ninner_vec, nsegments, reduce_op, initial_value,
+          empty_segment_value, is_mean, is_sqrtn, input_vec, segment_ids,
+          indices, output_vec);
+    }
+  };
+};
+
+// Reduces input matrix within segments over the outer dimension. Empty segments
+// always output empty_segment_value.
+// The segment_ids vector must be sorted.
+// If is_mean or is_sqrtn is true, the results are normalized using the
+// corresponding function.
+// If indices is not nullptr, input rows are accessed indirectly as
+// input[indices[i]], instead of input[i].
+// The implementation is deterministic.
+// Note: Treduce is to allow reducing in higher precision than T.
+template <typename Treduce, typename T, typename Tindex, typename Tsegmentids,
+          typename ReduceOp>
+Status SegmentReduceGPU(OpKernelContext* ctx, Tindex nouter, Tindex ninner,
+                        Tsegmentids nsegments, ReduceOp reduce_op,
+                        T initial_value, T empty_segment_value, bool is_mean,
+                        bool is_sqrtn,
+                        const T* input,  // [nouter or any, ninner]
+                        const Tsegmentids* segment_ids,  // [nouter]
+                        const Tindex* indices,           // [nouter] (optional)
+                        T* output) {                     // [nsegments, ninner]
+  if (ninner == 0 || nsegments == 0) return Status::OK();
+  if (nouter == 0) {
+    // Just fill output with empty_segment_value and return.
+    const GPUDevice& device = ctx->eigen_gpu_device();
+    GpuLaunchConfig config = GetGpuLaunchConfig(nsegments * ninner, device);
+    return GpuLaunchKernel(SetToValue<T>, config.block_count,
+                           config.thread_per_block, 0, device.stream(),
+                           nsegments * ninner, output, empty_segment_value);
+  }
+  return DispatchToVectorized<
+      T, SegmentReduceGPUVectorized<Treduce>::template Impl>(
+      MinAlignmentOf(input, output, ninner), ctx, nouter, ninner, nsegments,
+      reduce_op, initial_value, empty_segment_value, is_mean, is_sqrtn, input,
+      segment_ids, indices, output);
+}
+
+template <typename ReduceOp, typename T>
+struct ReduceType {
+  using type = T;
+};
+
+// Sum fp16 values using an fp32 accumulator to avoid numerical issues.
+template <>
+struct ReduceType<gpuprim::Sum, Eigen::half> {
+  using type = float;
+};
+
 namespace functor {
 
 template <typename T, typename Index, typename InitialValueF,
@@ -251,6 +655,28 @@ struct UnsortedSegmentFunctor<GPUDevice, T, Index, InitialValueF, ReductionF> {
   }
 };
 
+template <typename T, typename Index, typename SegmentId>
+Status SparseSegmentReductionFunctor<T, Index, SegmentId>::operator()(
+    OpKernelContext* context, bool is_mean, bool is_sqrtn, T default_value,
+    typename TTypes<T, 2>::ConstTensor input,
+    typename TTypes<Index>::ConstVec indices,
+    typename TTypes<SegmentId>::ConstVec segment_ids,
+    typename TTypes<T, 2>::Tensor output) {
+  using ReduceOp = gpuprim::Sum;
+  using Treduce = typename ReduceType<ReduceOp, T>::type;
+  Index nouter = segment_ids.size();
+  Index ninner = input.dimension(1);
+  SegmentId nsegments = output.dimension(0);
+  return SegmentReduceGPU<Treduce>(
+      context, /*nouter=*/nouter, /*ninner=*/ninner,
+      /*nsegments=*/nsegments, /*reduce_op=*/ReduceOp(),
+      /*initial_value=*/T(0),
+      /*empty_segment_value=*/default_value,
+      /*is_mean=*/is_mean, /*is_sqrtn=*/is_sqrtn,
+      /*input=*/input.data(), /*segment_ids=*/segment_ids.data(),
+      /*indices=*/indices.data(), /*output=*/output.data());
+}
+
 #define DEFINE_SORTED_GPU_SPECS_INDEX(T, Index)                           \
   template struct SegmentReductionFunctor<T, Index, functor::Zero<T>,     \
                                           functor::NonAtomicSumOpGpu<T>,  \
@@ -308,6 +734,14 @@ TF_CALL_COMPLEX_TYPES(DEFINE_SUM_GPU_SPECS);
 #undef DEFINE_SUM_UNSORTED_GPU_SPECS_INDEX
 #undef DEFINE_REAL_GPU_SPECS
 #undef DEFINE_SUM_GPU_SPECS
+
+#define DEFINE_SPARSE_SEGMENT_REDUCTION_FUNCTOR(T)                \
+  template struct SparseSegmentReductionFunctor<T, int32, int32>; \
+  template struct SparseSegmentReductionFunctor<T, int32, int64>; \
+  template struct SparseSegmentReductionFunctor<T, int64, int32>; \
+  template struct SparseSegmentReductionFunctor<T, int64, int64>;
+TF_CALL_GPU_NUMBER_TYPES(DEFINE_SPARSE_SEGMENT_REDUCTION_FUNCTOR);
+#undef DEFINE_SPARSE_SEGMENT_REDUCTION_FUNCTOR
 
 }  // namespace functor
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/segment_reduction_ops_impl.h
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl.h
@@ -779,6 +779,8 @@ class SparseSegmentReductionOpBase : public OpKernel {
   const T default_value_;
 };
 
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
 // Specialization for GPU. Must be Async because may need to wait for a host to
 // device memcpy before allocating output.
 template <class T, typename Index, typename SegmentId>
@@ -874,6 +876,8 @@ class SparseSegmentReductionOpBase<GPUDevice, T, Index, SegmentId>
   const bool has_num_segments_;
   const T default_value_;
 };
+
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 template <typename Device, class T, typename Index, typename SegmentId>
 class SparseSegmentReductionMeanOp

--- a/tensorflow/core/kernels/segment_reduction_ops_impl_1.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl_1.cc
@@ -76,16 +76,15 @@ void SparseSegmentReductionValidationHelper(OpKernelContext* context,
     done = [] {};
   }
   if (has_num_segments) {
-    const Tensor& num_segments = context->input(3);
+    const Tensor& num_segments_t = context->input(3);
     OP_REQUIRES_ASYNC(
-        context, TensorShapeUtils::IsScalar(num_segments.shape()),
+        context, TensorShapeUtils::IsScalar(num_segments_t.shape()),
         errors::InvalidArgument("num_segments should be a scalar, not shape ",
-                                num_segments.shape().DebugString()),
+                                num_segments_t.shape().DebugString()),
         done);
-    // Note that there is a Tnumsegments parameter on the op, but it is not
-    // plumbed through to here and so always takes its default value of int32.
-    int32 output_rows =
-        internal::SubtleMustCopy(num_segments.scalar<int32>()());
+    int64 output_rows = internal::SubtleMustCopy(
+        num_segments_t.dtype() == DT_INT32 ? num_segments_t.scalar<int32>()()
+                                           : num_segments_t.scalar<int64>()());
     OP_REQUIRES_ASYNC(context, output_rows >= 0,
                       errors::InvalidArgument("segment ids must be >= 0"),
                       done);

--- a/tensorflow/core/kernels/segment_reduction_ops_impl_1.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl_1.cc
@@ -66,6 +66,53 @@ bool UnsortedSegmentReductionDoValidation(OpKernel* op_kernel,
   return context->status().ok();
 }
 
+void SparseSegmentReductionValidationHelper(OpKernelContext* context,
+                                            const Tensor& input,
+                                            const Tensor& indices,
+                                            const Tensor& segment_ids,
+                                            bool has_num_segments,
+                                            AsyncOpKernel::DoneCallback done) {
+  if (!done) {
+    done = [] {};
+  }
+  if (has_num_segments) {
+    const Tensor& num_segments = context->input(3);
+    OP_REQUIRES_ASYNC(
+        context, TensorShapeUtils::IsScalar(num_segments.shape()),
+        errors::InvalidArgument("num_segments should be a scalar, not shape ",
+                                num_segments.shape().DebugString()),
+        done);
+    // Note that there is a Tnumsegments parameter on the op, but it is not
+    // plumbed through to here and so always takes its default value of int32.
+    int32 output_rows =
+        internal::SubtleMustCopy(num_segments.scalar<int32>()());
+    OP_REQUIRES_ASYNC(context, output_rows >= 0,
+                      errors::InvalidArgument("segment ids must be >= 0"),
+                      done);
+  }
+  OP_REQUIRES_ASYNC(context, TensorShapeUtils::IsVector(indices.shape()),
+                    errors::InvalidArgument("indices should be a vector."),
+                    done);
+  OP_REQUIRES_ASYNC(context, TensorShapeUtils::IsVector(segment_ids.shape()),
+                    errors::InvalidArgument("segment_ids should be a vector."),
+                    done);
+  const int64 num_indices = indices.NumElements();
+  OP_REQUIRES_ASYNC(
+      context, num_indices == segment_ids.NumElements(),
+      errors::InvalidArgument("segment_ids and indices should have same size."),
+      done);
+}
+
+bool SparseSegmentReductionDoValidation(OpKernelContext* c, const Tensor& input,
+                                        const Tensor& indices,
+                                        const Tensor& segment_ids,
+                                        bool has_num_segments,
+                                        AsyncOpKernel::DoneCallback done) {
+  SparseSegmentReductionValidationHelper(c, input, indices, segment_ids,
+                                         has_num_segments, done);
+  return c->status().ok();
+}
+
 }  // namespace internal
 
 #define REGISTER_CPU_KERNEL_SEGMENT(name, functor, type, index_type, \

--- a/tensorflow/core/kernels/segment_reduction_ops_impl_5.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl_5.cc
@@ -89,6 +89,76 @@ REGISTER_CPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE(double);
 REGISTER_CPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE(bfloat16);
 #undef REGISTER_CPU_SPARSE_KERNELS
 
+#define REGISTER_GPU_SPARSE_KERNELS_FOR_EACH_SEGMENT_ID_TYPE(type, index_type) \
+  REGISTER_GPU_SPARSE_KERNELS(type, index_type, int32)                         \
+  REGISTER_GPU_SPARSE_KERNELS(type, index_type, int64)
+#define REGISTER_GPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE(type)       \
+  REGISTER_GPU_SPARSE_KERNELS_FOR_EACH_SEGMENT_ID_TYPE(type, int32) \
+  REGISTER_GPU_SPARSE_KERNELS_FOR_EACH_SEGMENT_ID_TYPE(type, int64)
+
+#define REGISTER_GPU_SPARSE_KERNELS(type, index_type, segment_ids_type)       \
+  REGISTER_KERNEL_BUILDER(                                                    \
+      Name("SparseSegmentSum")                                                \
+          .Device(DEVICE_GPU)                                                 \
+          .TypeConstraint<type>("T")                                          \
+          .TypeConstraint<index_type>("Tidx")                                 \
+          .TypeConstraint<segment_ids_type>("Tsegmentids"),                   \
+      SparseSegmentReductionSumOp<GPUDevice, type, index_type,                \
+                                  segment_ids_type>);                         \
+  REGISTER_KERNEL_BUILDER(                                                    \
+      Name("SparseSegmentSumWithNumSegments")                                 \
+          .Device(DEVICE_GPU)                                                 \
+          .HostMemory("num_segments")                                         \
+          .TypeConstraint<type>("T")                                          \
+          .TypeConstraint<index_type>("Tidx")                                 \
+          .TypeConstraint<segment_ids_type>("Tsegmentids"),                   \
+      SparseSegmentReductionSumWithNumSegmentsOp<GPUDevice, type, index_type, \
+                                                 segment_ids_type>);
+TF_CALL_GPU_NUMBER_TYPES(REGISTER_GPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE);
+#undef REGISTER_GPU_SPARSE_KERNELS
+
+#define REGISTER_GPU_SPARSE_KERNELS(type, index_type, segment_ids_type)        \
+  REGISTER_KERNEL_BUILDER(                                                     \
+      Name("SparseSegmentMean")                                                \
+          .Device(DEVICE_GPU)                                                  \
+          .TypeConstraint<type>("T")                                           \
+          .TypeConstraint<index_type>("Tidx")                                  \
+          .TypeConstraint<segment_ids_type>("Tsegmentids"),                    \
+      SparseSegmentReductionMeanOp<GPUDevice, type, index_type,                \
+                                   segment_ids_type>);                         \
+  REGISTER_KERNEL_BUILDER(                                                     \
+      Name("SparseSegmentMeanWithNumSegments")                                 \
+          .Device(DEVICE_GPU)                                                  \
+          .HostMemory("num_segments")                                          \
+          .TypeConstraint<type>("T")                                           \
+          .TypeConstraint<index_type>("Tidx")                                  \
+          .TypeConstraint<segment_ids_type>("Tsegmentids"),                    \
+      SparseSegmentReductionMeanWithNumSegmentsOp<GPUDevice, type, index_type, \
+                                                  segment_ids_type>);
+TF_CALL_GPU_NUMBER_TYPES(REGISTER_GPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE);
+#undef REGISTER_GPU_SPARSE_KERNELS
+
+#define REGISTER_GPU_SPARSE_KERNELS(type, index_type, segment_ids_type) \
+  REGISTER_KERNEL_BUILDER(                                              \
+      Name("SparseSegmentSqrtN")                                        \
+          .Device(DEVICE_GPU)                                           \
+          .TypeConstraint<type>("T")                                    \
+          .TypeConstraint<index_type>("Tidx")                           \
+          .TypeConstraint<segment_ids_type>("Tsegmentids"),             \
+      SparseSegmentReductionSqrtNOp<GPUDevice, type, index_type,        \
+                                    segment_ids_type>);                 \
+  REGISTER_KERNEL_BUILDER(                                              \
+      Name("SparseSegmentSqrtNWithNumSegments")                         \
+          .Device(DEVICE_GPU)                                           \
+          .HostMemory("num_segments")                                   \
+          .TypeConstraint<type>("T")                                    \
+          .TypeConstraint<index_type>("Tidx")                           \
+          .TypeConstraint<segment_ids_type>("Tsegmentids"),             \
+      SparseSegmentReductionSqrtNWithNumSegmentsOp<                     \
+          GPUDevice, type, index_type, segment_ids_type>);
+TF_CALL_GPU_NUMBER_TYPES(REGISTER_GPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE);
+#undef REGISTER_GPU_SPARSE_KERNELS
+
 #define REGISTER_CPU_SPARSE_KERNELS(type, index_type, segment_ids_type) \
   REGISTER_KERNEL_BUILDER(                                              \
       Name("SparseSegmentMeanGrad")                                     \

--- a/tensorflow/core/util/gpu_device_functions.h
+++ b/tensorflow/core/util/gpu_device_functions.h
@@ -563,14 +563,14 @@ __global__ void SetZero(const int count, T* __restrict__ ptr) {
 }
 
 // Helper to set all tensor entries to a specific value.
-template <typename T>
-__global__ void SetToValue(const int count, T* __restrict__ ptr, T value) {
+template <typename T, typename Tvalue = T>
+__global__ void SetToValue(const int count, T* __restrict__ ptr, Tvalue value) {
   // Check that the grid is one dimensional and index doesn't overflow.
   assert(blockDim.y == 1);
   assert(blockDim.z == 1);
   assert(blockDim.x * gridDim.x / blockDim.x == gridDim.x);
   for (int i : GpuGridRangeX(count)) {
-    ptr[i] = value;
+    ptr[i] = static_cast<T>(value);
   }
 }
 

--- a/tensorflow/core/util/gpu_kernel_helper.h
+++ b/tensorflow/core/util/gpu_kernel_helper.h
@@ -228,6 +228,51 @@ class alignas(alignof(T) * N) AlignedVector {
     value_type uniform(uniform_u);
     UNROLL_ON_DEVICE for (int i = 0; i < kSize; ++i) { values_[i] = uniform; }
   }
+  // Implicit conversion.
+  template <typename U, typename std::enable_if<
+                            std::is_convertible<U, T>::value, int>::type = 0>
+  __host__ __device__ AlignedVector(const AlignedVector<U, N>& other) {
+    UNROLL_ON_DEVICE for (int i = 0; i < kSize; ++i) { values_[i] = other[i]; }
+  }
+  // Explicit conversion.
+  template <typename U,
+            typename std::enable_if<!std::is_convertible<U, T>::value &&
+                                        std::is_constructible<T, U>::value,
+                                    int>::type = 0>
+  __host__ __device__ explicit AlignedVector(const AlignedVector<U, N>& other) {
+    UNROLL_ON_DEVICE for (int i = 0; i < kSize; ++i) {
+      values_[i] = T(other[i]);
+    }
+  }
+
+  value_type& operator[](int i) { return values_[i]; }
+  const value_type& operator[](int i) const { return values_[i]; }
+
+#define DEFINE_BINARY_UPDATE_OPERATOR(op)                                      \
+  __host__ __device__ AlignedVector& operator op(const AlignedVector& rhs) {   \
+    UNROLL_ON_DEVICE for (int i = 0; i < kSize; ++i) { values_[i] op rhs[i]; } \
+    return *this;                                                              \
+  }
+  DEFINE_BINARY_UPDATE_OPERATOR(+=)
+  DEFINE_BINARY_UPDATE_OPERATOR(-=)
+  DEFINE_BINARY_UPDATE_OPERATOR(*=)
+  DEFINE_BINARY_UPDATE_OPERATOR(/=)
+#undef DEFINE_BINARY_UPDATE_OPERATOR
+
+#define DEFINE_BINARY_OPERATOR(op)                          \
+  friend __host__ __device__ AlignedVector operator op(     \
+      const AlignedVector& lhs, const AlignedVector& rhs) { \
+    AlignedVector ret;                                      \
+    UNROLL_ON_DEVICE for (int i = 0; i < kSize; ++i) {      \
+      ret[i] = lhs[i] op rhs[i];                            \
+    }                                                       \
+    return ret;                                             \
+  }
+  DEFINE_BINARY_OPERATOR(+)
+  DEFINE_BINARY_OPERATOR(-)
+  DEFINE_BINARY_OPERATOR(*)
+  DEFINE_BINARY_OPERATOR(/)
+#undef DEFINE_BINARY_OPERATOR
 
  private:
   value_type values_[N];

--- a/tensorflow/core/util/gpu_kernel_helper.h
+++ b/tensorflow/core/util/gpu_kernel_helper.h
@@ -245,8 +245,10 @@ class alignas(alignof(T) * N) AlignedVector {
     }
   }
 
-  value_type& operator[](int i) { return values_[i]; }
-  const value_type& operator[](int i) const { return values_[i]; }
+  __host__ __device__ value_type& operator[](int i) { return values_[i]; }
+  __host__ __device__ const value_type& operator[](int i) const {
+    return values_[i];
+  }
 
 #define DEFINE_BINARY_UPDATE_OPERATOR(op)                                      \
   __host__ __device__ AlignedVector& operator op(const AlignedVector& rhs) {   \

--- a/tensorflow/python/kernel_tests/segment_reduction_ops_test.py
+++ b/tensorflow/python/kernel_tests/segment_reduction_ops_test.py
@@ -539,36 +539,38 @@ class SparseSegmentReductionOpTest(SparseSegmentReductionHelper):
                  math_ops.sparse_segment_mean)]
 
     n = 400
-    shape = [n, 2]
-    segment_indices = []
-    for i in range(20):
-      for _ in range(i + 1):
-        segment_indices.append(i)
-    num_indices = len(segment_indices)
-    for dtype in dtypes:
-      for index_dtype in index_dtypes:
-        for segment_ids_dtype in segment_ids_dtypes:
-          with self.cached_session(use_gpu=False):
-            tf_indices, np_indices, tf_x, np_x = self._sparse_input(
-                shape, num_indices, dtype=dtype)
-            for np_op1, np_op2, tf_op in ops_list:
-              if (tf_op == math_ops.sparse_segment_mean
-                  and dtype not in mean_dtypes):
-                continue
-              np_ans = self._sparseSegmentReduce(np_x, np_indices,
-                                                 segment_indices, np_op1,
-                                                 np_op2)
-              s = tf_op(
-                  data=tf_x,
-                  indices=math_ops.cast(tf_indices, index_dtype),
-                  segment_ids=math_ops.cast(segment_indices, segment_ids_dtype))
-              tf_ans = self.evaluate(s)
-              self.assertAllClose(np_ans, tf_ans)
-              # NOTE(mrry): The static shape inference that computes
-              # `tf_ans.shape` can only infer that sizes from dimension 1
-              # onwards, because the size of dimension 0 is data-dependent
-              # and may therefore vary dynamically.
-              self.assertAllEqual(np_ans.shape[1:], tf_ans.shape[1:])
+    # Note that the GPU implem has different paths for different inner sizes.
+    for inner_size in [1, 2, 3, 32]:
+      shape = [n, inner_size]
+      segment_indices = []
+      for i in range(20):
+        for _ in range(i + 1):
+          segment_indices.append(i)
+      num_indices = len(segment_indices)
+      for dtype in dtypes:
+        for index_dtype in index_dtypes:
+          for segment_ids_dtype in segment_ids_dtypes:
+            with self.cached_session():
+              tf_indices, np_indices, tf_x, np_x = self._sparse_input(
+                  shape, num_indices, dtype=dtype)
+              for np_op1, np_op2, tf_op in ops_list:
+                if (tf_op == math_ops.sparse_segment_mean
+                    and dtype not in mean_dtypes):
+                  continue
+                np_ans = self._sparseSegmentReduce(np_x, np_indices,
+                                                   segment_indices, np_op1,
+                                                   np_op2)
+                s = tf_op(
+                    data=tf_x,
+                    indices=math_ops.cast(tf_indices, index_dtype),
+                    segment_ids=math_ops.cast(segment_indices, segment_ids_dtype))
+                tf_ans = self.evaluate(s)
+                self.assertAllClose(np_ans, tf_ans)
+                # NOTE(mrry): The static shape inference that computes
+                # `tf_ans.shape` can only infer that sizes from dimension 1
+                # onwards, because the size of dimension 0 is data-dependent
+                # and may therefore vary dynamically.
+                self.assertAllEqual(np_ans.shape[1:], tf_ans.shape[1:])
 
   def testSegmentIdsHole(self):
     tf_x, np_x = self._input([10, 4], dtype=dtypes_lib.float32)
@@ -576,7 +578,7 @@ class SparseSegmentReductionOpTest(SparseSegmentReductionHelper):
         self._mean_cum_op, self._mean_reduce_op, math_ops.sparse_segment_mean)]
     segment_indices = [0, 2, 2, 2]
     tf_indices = [8, 3, 0, 9]
-    with self.session(use_gpu=False):
+    with self.session():
       for np_op1, np_op2, tf_op in ops_list:
         np_ans = self._sparseSegmentReduce(np_x, tf_indices, segment_indices,
                                            np_op1, np_op2)
@@ -592,7 +594,7 @@ class SparseSegmentReductionOpTest(SparseSegmentReductionHelper):
     segment_indices = [0, 2, 2, 2]
     tf_indices = [8, 3, 0, 9]
     num_segments = 5
-    with self.session(use_gpu=False):
+    with self.session():
       for np_op1, np_op2, tf_op in ops_list:
         np_ans = self._sparseSegmentReduce(
             np_x,
@@ -618,7 +620,7 @@ class SparseSegmentReductionOpTest(SparseSegmentReductionHelper):
     segment_indices = []
     tf_indices = []
     num_segments = 5
-    with self.session(use_gpu=False):
+    with self.session():
       for tf_op in ops_list:
         s = tf_op(
             data=tf_x,
@@ -634,7 +636,7 @@ class SparseSegmentReductionOpTest(SparseSegmentReductionHelper):
         self._mean_cum_op, self._mean_reduce_op, math_ops.sparse_segment_mean)]
     segment_indices = [1, 2, 2, 2]
     tf_indices = [8, 3, 0, 9]
-    with self.session(use_gpu=False):
+    with self.session():
       for np_op1, np_op2, tf_op in ops_list:
         np_ans = self._sparseSegmentReduce(np_x, tf_indices, segment_indices,
                                            np_op1, np_op2)
@@ -648,7 +650,7 @@ class SparseSegmentReductionOpTest(SparseSegmentReductionHelper):
     ops_list = [math_ops.sparse_segment_sum, math_ops.sparse_segment_mean]
     segment_indices = [0, 1, 2, 2]
     tf_indices = [8, 3, 0, 9]
-    with self.session(use_gpu=False):
+    with self.session():
       for tf_op in ops_list:
         s = tf_op(data=tf_x, indices=tf_indices, segment_ids=segment_indices)
         self.evaluate(s)
@@ -753,7 +755,7 @@ class SparseSegmentReductionOpTest(SparseSegmentReductionHelper):
     num_segments = 5
     segment_indices = [0, 1, 3, 3]
     tf_indices = [8, 3, 0, 9]
-    with self.session(use_gpu=False):
+    with self.session():
       for tf_op in ops_list:
         s = tf_op(
             data=tf_x,

--- a/tensorflow/python/kernel_tests/segment_reduction_ops_test.py
+++ b/tensorflow/python/kernel_tests/segment_reduction_ops_test.py
@@ -563,7 +563,8 @@ class SparseSegmentReductionOpTest(SparseSegmentReductionHelper):
                 s = tf_op(
                     data=tf_x,
                     indices=math_ops.cast(tf_indices, index_dtype),
-                    segment_ids=math_ops.cast(segment_indices, segment_ids_dtype))
+                    segment_ids=math_ops.cast(segment_indices,
+                                              segment_ids_dtype))
                 tf_ans = self.evaluate(s)
                 self.assertAllClose(np_ans, tf_ans)
                 # NOTE(mrry): The static shape inference that computes


### PR DESCRIPTION
Adds GPU implementations of the ops: `SparseSegment[Sum|Mean|SqrtN][WithNumSegments]`.

This GPU kernel will also be used to implement the corresponding non-sparse and gradient ops in future PRs.

cc @nluehr @duncanriach 