### PR TITLE
 [ROCm] Fix for ROCM CSB breakage - 210322 

### DIFF
--- a/tensorflow/python/keras/distribute/BUILD
+++ b/tensorflow/python/keras/distribute/BUILD
@@ -897,6 +897,7 @@ distribute_py_test(
     tags = [
         "multi_gpu",
         "no_oss",  # TODO(b/183640564): Reenable
+        "no_rocm",
         "notsan",  # TODO(b/184542721)
     ],
     deps = [

--- a/tensorflow/python/keras/optimizer_v2/BUILD
+++ b/tensorflow/python/keras/optimizer_v2/BUILD
@@ -138,6 +138,7 @@ cuda_py_test(
     srcs = ["adamax_test.py"],
     shard_count = 4,
     # TODO(b/168527439): invalid resource variable reference on GPU for TFRT.
+    tags = ["no_rocm"],
     deps = [
         ":optimizer_v2",
         "//tensorflow/python:client_testlib",

--- a/tensorflow/python/training/BUILD
+++ b/tensorflow/python/training/BUILD
@@ -1104,6 +1104,7 @@ cuda_py_test(
     size = "medium",
     srcs = ["adam_test.py"],
     python_version = "PY3",
+    tags = ["no_rocm"],
     deps = [
         ":adam",
         "//tensorflow/python:array_ops",


### PR DESCRIPTION
## 1
The following commit adds GPU support for int32/int64 support for the Unique/UniqueWithCounts ops, but breaks ROCm build in the process

02585ac

```
tensorflow/core/kernels/unique_op_gpu.cu.cc:292:9: error: no matching constructor for initialization of 'gpuprim::TransformInputIterator<int, SegmentIndicatorFunctor<unsigned long, int>, gpuprim::CountingInputIterator<int>>' (aka 'transform_iterator<rocprim::counting_iterator<int, long>, tensorflow::(anonymous namespace)::SegmentIndicatorFunctor<unsigned long, int>, int>')
        segment_indicator_iter(0, {sorted_input_ptr});
        ^                      ~~~~~~~~~~~~~~~~~~~~~
tensorflow/core/kernels/unique_op_gpu.cu.cc:176:12: note: in instantiation of member function 'tensorflow::UniqueOpGPU<unsigned long, int>::ComputeAsync' requested here
  explicit UniqueOpGPU(OpKernelConstruction* context)
           ^
tensorflow/core/kernels/unique_op_gpu.cu.cc:461:27: note: in instantiation of member function 'tensorflow::UniqueOpGPU<unsigned long, int>::UniqueOpGPU' requested here
TF_CALL_REAL_NUMBER_TYPES(REGISTER_UNIQUE_GPU);
```

This PR/commit disables ROCm support for newly added ops to get the CSB passing again. We are looking into resolving the build errors, and will file a separate PR to re-enable ROCm functionality for the same. This PR commit also adds the `no_rocm` tag to a couple of unit tests that start failing as a consequence of lack of ROCm support for these ops.

```
//tensorflow/python/keras/optimizer_v2:adamax_test_gpu                   FAILED in 3 out of 3 in 7.0s
//tensorflow/python/training:adam_test_gpu                               FAILED in 3 out of 3 in 6.3s
```

## 2 

 The following commit adds a new unit-test which is failing on the ROCm platform

50f8897

```
//tensorflow/python/keras/distribute:dataset_creator_model_fit_test_gpu  FAILED in 3 out of 3 in 112.5s
```

This commit adds a `no_rocm` tag to temporarily disable that unit-test on ROCm.

---------------------------------------------------------


/cc @cheshire @chsigg

