### PR TITLE
Fix collections.abc import for Python 3.9

### DIFF
--- a/tensorflow/python/keras/feature_column/base_feature_layer.py
+++ b/tensorflow/python/keras/feature_column/base_feature_layer.py
@@ -198,7 +198,7 @@ def _normalize_feature_columns(feature_columns):
   if isinstance(feature_columns, feature_column_v2.FeatureColumn):
     feature_columns = [feature_columns]
 
-  if isinstance(feature_columns, collections.Iterator):
+  if isinstance(feature_columns, collections.abc.Iterator):
     feature_columns = list(feature_columns)
 
   if isinstance(feature_columns, dict):

--- a/tensorflow/python/keras/keras_parameterized.py
+++ b/tensorflow/python/keras/keras_parameterized.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 """Utilities for unit-testing Keras."""
 
-import collections.abc as collections_abc
+import collections
 import functools
 import itertools
 import unittest
@@ -456,7 +456,7 @@ def _test_or_class_decorator(test_or_class, single_method_decorator):
     The decorated result.
   """
   def _decorate_test_or_class(obj):
-    if isinstance(obj, collections_abc.Iterable):
+    if isinstance(obj, collections.abc.Iterable):
       return itertools.chain.from_iterable(
           single_method_decorator(method) for method in obj)
     if isinstance(obj, type):

--- a/tensorflow/python/keras/layers/preprocessing/preprocessing_test_utils.py
+++ b/tensorflow/python/keras/layers/preprocessing/preprocessing_test_utils.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 """Tests for Keras' base preprocessing layer."""
 
-import collections.abc as collections_abc
+import collections
 import numpy as np
 
 from tensorflow.python.platform import test
@@ -33,7 +33,7 @@ class PreprocessingLayerTest(test.TestCase):
       self.assertEqual(len(a), len(b))
       for a_value, b_value in zip(a, b):
         self.assertAllCloseOrEqual(a_value, b_value, msg=msg)
-    elif isinstance(a, collections_abc.Mapping):
+    elif isinstance(a, collections.abc.Mapping):
       self.assertEqual(len(a), len(b))
       for key, a_value in a.items():
         b_value = b[key]

--- a/tensorflow/python/keras/saving/saved_model/json_utils.py
+++ b/tensorflow/python/keras/saving/saved_model/json_utils.py
@@ -21,7 +21,7 @@ separate inputs if the given input_shape is a list, and will create a single
 input if the given shape is a tuple.
 """
 
-import collections.abc as collections_abc
+import collections
 import enum
 import json
 import numpy as np
@@ -118,7 +118,7 @@ def get_json_type(obj):
   if isinstance(obj, dtypes.DType):
     return obj.name
 
-  if isinstance(obj, collections_abc.Mapping):
+  if isinstance(obj, collections.abc.Mapping):
     return dict(obj)
 
   if obj is Ellipsis:

--- a/tensorflow/python/keras/saving/saving_utils.py
+++ b/tensorflow/python/keras/saving/saving_utils.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 """Utils related to keras model saving."""
 
-import collections.abc as collections_abc
+import collections
 import copy
 import os
 
@@ -78,7 +78,7 @@ def model_input_signature(model, keep_original_batch_size=False):
   input_specs = _enforce_names_consistency(input_specs)
   # Return a list with a single element as the model's input signature.
   if isinstance(input_specs,
-                collections_abc.Sequence) and len(input_specs) == 1:
+                collections.abc.Sequence) and len(input_specs) == 1:
     # Note that the isinstance check filters out single-element dictionaries,
     # which should also be wrapped as a single-element list.
     return input_specs

--- a/tensorflow/python/keras/saving/utils_v1/mode_keys.py
+++ b/tensorflow/python/keras/saving/utils_v1/mode_keys.py
@@ -16,7 +16,7 @@
 """Utils for managing different mode strings used by Keras and Estimator models.
 """
 
-import collections.abc as collections_abc
+import collections
 
 
 class KerasModeKeys:
@@ -62,7 +62,7 @@ def is_train(mode):
   return mode in [KerasModeKeys.TRAIN, EstimatorModeKeys.TRAIN]
 
 
-class ModeKeyMap(collections_abc.Mapping):
+class ModeKeyMap(collections.abc.Mapping):
   """Map using ModeKeys as keys.
 
   This class creates an immutable mapping from modes to values. For example,

--- a/tensorflow/python/keras/utils/object_identity.py
+++ b/tensorflow/python/keras/utils/object_identity.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==============================================================================
 
-import collections.abc as collections_abc
+import collections
 import weakref
 
 
@@ -115,7 +115,7 @@ class Reference(_ObjectIdentityWrapper):
     return self._wrapped
 
 
-class ObjectIdentityDictionary(collections_abc.MutableMapping):
+class ObjectIdentityDictionary(collections.abc.MutableMapping):
   """A mutable mapping data structure which compares using "is".
 
   This is necessary because we have trackable objects (_ListWrapper) which
@@ -173,7 +173,7 @@ class ObjectIdentityWeakKeyDictionary(ObjectIdentityDictionary):
         yield unwrapped
 
 
-class ObjectIdentitySet(collections_abc.MutableSet):
+class ObjectIdentitySet(collections.abc.MutableSet):
   """Like the built-in set, but compares objects with "is"."""
 
   __slots__ = ["_storage", "__weakref__"]


### PR DESCRIPTION
This PR fixes Python 3.9 compatibility of `keras/feature_column/base_feature_layer.py` by replacing the deprecated `collections` import.

This also cleans up `collections.abc` imports in the rest of the Keras code base.