### PR TITLE
[INTEL MKL] Fix failing v1 CI test

### DIFF
--- a/tensorflow/python/debug/cli/analyzer_cli_test.py
+++ b/tensorflow/python/debug/cli/analyzer_cli_test.py
@@ -49,11 +49,23 @@ from tensorflow.python.util import tf_inspect
 
 
 # Helper function to accommodate MKL-enabled TensorFlow:
-# MatMul op is supported by MKL and its name is prefixed with "_Mkl" during the
-# MKL graph rewrite pass.
+# MatMul op is supported by MKL for some data types and its name is prefixed
+# with "_Mkl" during the MKL graph rewrite pass.
 def _matmul_op_name():
-  return "_MklMatMul" if test_util.IsMklEnabled() else "MatMul"
+  if (test_util.IsMklEnabled() and
+      _get_graph_matmul_dtype() in _mkl_matmul_supported_types()):
+    return "_MklMatMul"
+  else:
+    return "MatMul"
 
+# Helper function to get MklMatMul supported types
+def _mkl_matmul_supported_types():
+  return {"float32", "bfloat16"}
+
+# Helper function to get dtype used in the graph of SetUpClass()
+def _get_graph_matmul_dtype():
+  # default dtype of matmul op created is float64
+  return "float64"
 
 def _cli_config_from_temp_file():
   return cli_config.CLIConfig(


### PR DESCRIPTION
Added check for dtype as MklMatMul supports bfloat16 and float32. whereas the default type is float64. Now with this fix, the correct op names can be compared.