### PR TITLE
[INTEL MKL] Disable group conv test.

### DIFF
--- a/tensorflow/python/kernel_tests/conv_ops_test.py
+++ b/tensorflow/python/kernel_tests/conv_ops_test.py
@@ -837,8 +837,13 @@ class Conv2DTest(test.TestCase):
   def testConv2DGroupConvFwd(self):
     if test.is_gpu_available(cuda_only=True):
       data_formats = ["NHWC", "NCHW"]
-    else:
+    # TODO(Intel-tf) Remove this check once group conv is implemented in the
+    # oneDNN based conv2d op kernel.
+    elif (not test_util.IsMklEnabled() and
+          os.getenv("TF_ENABLE_ONEDNN_OPTS","0") == "0"):
       data_formats = ["NHWC"]
+    else:
+      data_formats = []
     for data_format in data_formats:
       for dilation in [1, 2]:
         for stride in [1, 2]:


### PR DESCRIPTION
Disables group conv test when oneDNN is enabled.  Also disables test when oneDNN is enabled via env variables (pending merging of the PR https://github.com/tensorflow/tensorflow/pull/47745). This PR will work even if that PR is not merged.
This regression was caused by recent commit https://github.com/tensorflow/tensorflow/commit/7b8db6083b34520688dbc71f341f7aeaf156bf17 that enabled it for CPUs.
We will submit another PR to add group conv support for oneDNN based conv_ops shortly.