### PR TITLE
Split UniqueOpGPU compilation into multiple files

### DIFF
--- a/tensorflow/core/kernels/unique_op_gpu.cu.h
+++ b/tensorflow/core/kernels/unique_op_gpu.cu.h
@@ -13,6 +13,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#ifndef TENSORFLOW_CORE_KERNELS_UNIQUE_OP_GPU_CU_H_
+#define TENSORFLOW_CORE_KERNELS_UNIQUE_OP_GPU_CU_H_
+
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #define EIGEN_USE_GPU
@@ -20,7 +23,6 @@ limitations under the License.
 #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/common_runtime/gpu/gpu_event_mgr.h"
 #include "tensorflow/core/framework/op_kernel.h"
-#include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/kernels/gpu_prim.h"
 #include "tensorflow/core/kernels/gpu_prim_helpers.h"
@@ -38,7 +40,7 @@ namespace tensorflow {
 
 typedef Eigen::GpuDevice GPUDevice;
 
-namespace {
+namespace unique_op_gpu {
 
 // Returns true iff index is at the end of a segment (which is equivalent to the
 // beginning of the next segment).
@@ -167,7 +169,7 @@ Status LookupAndScatterUniqueIds(const GPUDevice& d, int64 input_size,
                          sorted_input_unique_ids, inv_sorted_unique_perm, idx);
 }
 
-}  // namespace
+}  // namespace unique_op_gpu
 
 // This only supports Unique[WithCounts], not Unique[WithCounts]V2.
 template <typename T, typename TIndex>
@@ -285,6 +287,8 @@ class UniqueOpGPU : public AsyncOpKernel {
                      /*indices_in=*/static_cast<const TIndex*>(nullptr),
                      /*indices_out=*/sorted_input_inds_ptr),
         done);
+
+    using namespace unique_op_gpu;
 
     // Create a fancy input iterator to indicate segment boundaries.
     gpuprim::TransformInputIterator<TIndex, SegmentIndicatorFunctor<T, TIndex>,
@@ -436,33 +440,8 @@ class UniqueOpGPU : public AsyncOpKernel {
   }
 };
 
-#define REGISTER_UNIQUE_GPU(type)                                \
-  REGISTER_KERNEL_BUILDER(Name("Unique")                         \
-                              .Device(DEVICE_GPU)                \
-                              .TypeConstraint<type>("T")         \
-                              .TypeConstraint<int32>("out_idx"), \
-                          UniqueOpGPU<type, int32>);             \
-  REGISTER_KERNEL_BUILDER(Name("Unique")                         \
-                              .Device(DEVICE_GPU)                \
-                              .TypeConstraint<type>("T")         \
-                              .TypeConstraint<int64>("out_idx"), \
-                          UniqueOpGPU<type, int64>);             \
-  REGISTER_KERNEL_BUILDER(Name("UniqueWithCounts")               \
-                              .Device(DEVICE_GPU)                \
-                              .TypeConstraint<type>("T")         \
-                              .TypeConstraint<int32>("out_idx"), \
-                          UniqueOpGPU<type, int32>);             \
-  REGISTER_KERNEL_BUILDER(Name("UniqueWithCounts")               \
-                              .Device(DEVICE_GPU)                \
-                              .TypeConstraint<type>("T")         \
-                              .TypeConstraint<int64>("out_idx"), \
-                          UniqueOpGPU<type, int64>)
-
-TF_CALL_REAL_NUMBER_TYPES(REGISTER_UNIQUE_GPU);
-REGISTER_UNIQUE_GPU(bool);
-
-#undef REGISTER_UNIQUE_GPU
-
 }  // end namespace tensorflow
 
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
+#endif  // TENSORFLOW_CORE_KERNELS_UNIQUE_OP_GPU_CU_H_

--- a/tensorflow/core/kernels/unique_op_gpu_int32.cu.cc
+++ b/tensorflow/core/kernels/unique_op_gpu_int32.cu.cc
@@ -1,0 +1,43 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
+#include "tensorflow/core/framework/register_types.h"
+#include "tensorflow/core/kernels/unique_op_gpu.cu.h"
+
+namespace tensorflow {
+
+// Register with int32 out_idx.
+#define REGISTER_UNIQUE_GPU(type)                                \
+  REGISTER_KERNEL_BUILDER(Name("Unique")                         \
+                              .Device(DEVICE_GPU)                \
+                              .TypeConstraint<type>("T")         \
+                              .TypeConstraint<int32>("out_idx"), \
+                          UniqueOpGPU<type, int32>);             \
+  REGISTER_KERNEL_BUILDER(Name("UniqueWithCounts")               \
+                              .Device(DEVICE_GPU)                \
+                              .TypeConstraint<type>("T")         \
+                              .TypeConstraint<int32>("out_idx"), \
+                          UniqueOpGPU<type, int32>)
+
+TF_CALL_REAL_NUMBER_TYPES(REGISTER_UNIQUE_GPU);
+REGISTER_UNIQUE_GPU(bool);
+
+#undef REGISTER_UNIQUE_GPU
+
+}  // end namespace tensorflow
+
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/core/kernels/unique_op_gpu_int64.cu.cc
+++ b/tensorflow/core/kernels/unique_op_gpu_int64.cu.cc
@@ -1,0 +1,43 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
+#include "tensorflow/core/framework/register_types.h"
+#include "tensorflow/core/kernels/unique_op_gpu.cu.h"
+
+namespace tensorflow {
+
+// Register with int64 out_idx.
+#define REGISTER_UNIQUE_GPU(type)                                \
+  REGISTER_KERNEL_BUILDER(Name("Unique")                         \
+                              .Device(DEVICE_GPU)                \
+                              .TypeConstraint<type>("T")         \
+                              .TypeConstraint<int64>("out_idx"), \
+                          UniqueOpGPU<type, int64>);             \
+  REGISTER_KERNEL_BUILDER(Name("UniqueWithCounts")               \
+                              .Device(DEVICE_GPU)                \
+                              .TypeConstraint<type>("T")         \
+                              .TypeConstraint<int64>("out_idx"), \
+                          UniqueOpGPU<type, int64>)
+
+TF_CALL_REAL_NUMBER_TYPES(REGISTER_UNIQUE_GPU);
+REGISTER_UNIQUE_GPU(bool);
+
+#undef REGISTER_UNIQUE_GPU
+
+}  // end namespace tensorflow
+
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM


### PR DESCRIPTION
Avoids long single-file compilation time (>4 mins). No functional change.

cc @nluehr @sanjoy 