### PR TITLE
Use reference_ops::Softmax() for RunSoftmaxFloatReference().

### DIFF
--- a/tensorflow/lite/kernels/internal/softmax_quantized_test.cc
+++ b/tensorflow/lite/kernels/internal/softmax_quantized_test.cc
@@ -50,7 +50,7 @@ void RunSoftmaxFloatReference(const uint8* input_data,
                             reference_dequant_data.data());
   SoftmaxParams sm_params;
   sm_params.beta = beta;
-  optimized_ops::Softmax(sm_params, shape_common, reference_dequant_data.data(),
+  reference_ops::Softmax(sm_params, shape_common, reference_dequant_data.data(),
                          shape_common, reference_output_float_data.data());
   // Work with quantized scaling for Softmax, under which 256 represents 1, but
   // we limit this to 255.


### PR DESCRIPTION
If we use TFLITE_SOFTMAX_USE_UINT16_LUT table look up optimization
for softmax[1], the float look up table will not be initialized.
The optimized_ops::Softmax<float, float>() call will crash.
This commit turns to use reference_ops::Softmax<float, float>()
instead. That reference call should always be available.

[1]
https://github.com/tensorflow/tensorflow/blob/8f8b15c9cdd4f549354cc0e97c81ed9ab6096f67/tensorflow/lite/kernels/activations.cc#L602-L619