### PR TITLE
Add pre-load CPU feature guard check

### DIFF
--- a/tensorflow/core/platform/cpu_feature_guard.cc
+++ b/tensorflow/core/platform/cpu_feature_guard.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "tensorflow/core/platform/cpu_feature_guard.h"
 
+#include <iostream>
 #include <mutex>
 #include <string>
 
@@ -30,15 +31,17 @@ namespace {
 // If the CPU feature isn't present, log a fatal error.
 void CheckFeatureOrDie(CPUFeature feature, const string& feature_name) {
   if (!TestCPUFeature(feature)) {
-#ifdef __ANDROID__
-    // Some Android emulators seem to indicate they don't support SSE, so to
-    // avoid crashes when testing, switch this to a warning.
-    LOG(WARNING)
-#else
-    LOG(FATAL)
+    // Avoiding use of the logging framework here as that might trigger a SIGILL
+    // by itself.
+    std::cerr << "The TensorFlow library was compiled to use " << feature_name
+              << " instructions, but these aren't available on your machine."
+              << std::endl;
+
+#ifndef __ANDROID__
+    // Some Android emulators seem to indicate they don't support SSE, so avoid
+    // crashes when testing.
+    std::abort();
 #endif
-        << "The TensorFlow library was compiled to use " << feature_name
-        << " instructions, but these aren't available on your machine.";
   }
 }
 

--- a/tensorflow/python/platform/BUILD
+++ b/tensorflow/python/platform/BUILD
@@ -33,6 +33,14 @@ py_library(
     srcs_version = "PY3",
 )
 
+cc_binary(
+    name = "_cpu_feature_guard.so",
+    deps = [
+        "//tensorflow/core/platform:cpu_feature_guard",
+    ],
+    linkshared = True,
+)
+
 py_library(
     name = "platform",
     srcs = glob(
@@ -58,6 +66,10 @@ py_library(
         "@rules_python//python/runfiles",
         "@six_archive//:six",
     ],
+    data = select({
+        "//tensorflow:windows": [],
+        "//conditions:default": [":_cpu_feature_guard.so"],
+    }),
 )
 
 py_library(

--- a/tensorflow/python/platform/BUILD
+++ b/tensorflow/python/platform/BUILD
@@ -35,10 +35,10 @@ py_library(
 
 cc_binary(
     name = "_cpu_feature_guard.so",
+    linkshared = True,
     deps = [
         "//tensorflow/core/platform:cpu_feature_guard",
     ],
-    linkshared = True,
 )
 
 py_library(
@@ -54,6 +54,10 @@ py_library(
             "device_context.py",  # In platform_device_context.
         ],
     ) + ["build_info.py"],
+    data = select({
+        "//tensorflow:windows": [],
+        "//conditions:default": [":_cpu_feature_guard.so"],
+    }),
     srcs_version = "PY3",
     deps = [
         ":build_info",
@@ -66,10 +70,6 @@ py_library(
         "@rules_python//python/runfiles",
         "@six_archive//:six",
     ],
-    data = select({
-        "//tensorflow:windows": [],
-        "//conditions:default": [":_cpu_feature_guard.so"],
-    }),
 )
 
 py_library(

--- a/tensorflow/python/platform/self_check.py
+++ b/tensorflow/python/platform/self_check.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import ctypes
 import os
 
 MSVCP_DLL_NAMES = "msvcp_dll_names"
@@ -42,7 +43,6 @@ def preload_check():
     # Attempt to load any DLLs that the Python extension depends on before
     # we load the Python extension, so that we can raise an actionable error
     # message if they are not found.
-    import ctypes  # pylint: disable=g-import-not-at-top
     if MSVCP_DLL_NAMES in build_info.build_info:
       missing = []
       for dll_name in build_info.build_info[MSVCP_DLL_NAMES].split(","):
@@ -60,5 +60,10 @@ def preload_check():
             "https://support.microsoft.com/help/2977003/the-latest-supported-visual-c-downloads"
             % " or ".join(missing))
   else:
-    # TODO(mrry): Consider adding checks for the Linux and Mac OS X builds.
-    pass
+    # Load a library that performs CPU feature guard checking as a part of its
+    # static initialization. Doing this here as a preload check makes it more
+    # likely that we detect any CPU feature incompatibilities before we trigger
+    # them (which would typically result in SIGILL).
+    cpu_feature_guard_library = os.path.join(
+        os.path.dirname(__file__), "_cpu_feature_guard.so")
+    ctypes.CDLL(cpu_feature_guard_library)


### PR DESCRIPTION
Compile a small shared library that performs an x86 CPU feature guard
check that compares the features enabled during compile-time with the
features available at run-time (using the `CPUID` instruction). This
comparison is done during static initialization and the process is
aborted with an error message if we have compiled with a feature that is
not supported by the current CPU.

Such a check is already performed during static initialization of the
library `libtensorflow_framework.so.2`, but since this library performs
many actions during initialization, there is a high risk of triggering
an illegal instruction before we reach the check, depending on the
(undefined) static initialization order.

Because of this we compile a separate shared library that we load as a
self-check before loading `_pywrap_tensorflow_internal.so`.

We also change to use `<iostream>` for printing in case of a failed
check, as use of the logging framework might itself trigger an
illegal instruction (it did in my testing).

Tested by attempting to use a wheel built with AVX-512 on an AMD CPU:

Before:

```
$ python -c 'import tensorflow'
Illegal instruction
```

After:

```
$ python -c 'import tensorflow'
The TensorFlow library was compiled to use AVX512F instructions, but these aren't available on your machine.
Aborted
```