### PR TITLE
Add GPU support for sparse reorder

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -4665,7 +4665,10 @@ tf_kernel_library(
 tf_kernel_library(
     name = "sparse_reorder_op",
     prefix = "sparse_reorder_op",
-    deps = SPARSE_DEPS,
+    deps = SPARSE_DEPS + if_cuda_or_rocm([
+        ":gpu_prim_hdrs",
+        ":gpu_prim_helpers",
+    ]),
 )
 
 tf_kernel_library(

--- a/tensorflow/core/kernels/sparse_reorder_op.h
+++ b/tensorflow/core/kernels/sparse_reorder_op.h
@@ -1,4 +1,4 @@
-/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tensorflow/core/kernels/sparse_reorder_op.h
+++ b/tensorflow/core/kernels/sparse_reorder_op.h
@@ -1,0 +1,36 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORE_KERNELS_SPARSE_REORDER_OP_H_
+#define TENSORFLOW_CORE_KERNELS_SPARSE_REORDER_OP_H_
+
+#include "tensorflow/core/framework/op_kernel.h"
+
+namespace tensorflow {
+
+namespace functor {
+
+template <typename Device, typename T>
+struct SparseReorderFunctor{
+  void operator()(OpKernelContext* context, const Tensor& input_ind,
+                  const Tensor& input_val, const Tensor& input_shape_in);
+};
+
+} // namespace functor
+
+} // namespace tensorflow
+
+#endif  // TENSORFLOW_CORE_KERNELS_SPARSE_REORDER_OP_H_
+

--- a/tensorflow/core/kernels/sparse_reorder_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/sparse_reorder_op_gpu.cu.cc
@@ -1,0 +1,135 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+#define EIGEN_USE_GPU
+
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
+#include "tensorflow/core/framework/register_types.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/types.h"
+#include "tensorflow/core/kernels/gpu_prim.h"
+#include "tensorflow/core/kernels/gpu_prim_helpers.h"
+#include "tensorflow/core/kernels/sparse_reorder_op.h"
+#include "tensorflow/core/util/gpu_kernel_helper.h"
+#include "tensorflow/core/util/sparse/sparse_tensor.h"
+
+namespace tensorflow {
+
+namespace {
+
+__global__ void IndicesFlattenKernel(
+    const int64* __restrict__ indices, const int64 nnz,
+    const int64* __restrict__ dims, const int64 ndims,
+    int64* __restrict__ flat_indices) {
+  GPU_1D_KERNEL_LOOP(thread_idx, nnz) {
+    eigen_assert(ndims >= 1);
+    int64 output_idx = indices[thread_idx * ndims + ndims - 1];
+    int64 strides = 1;
+    for (int i = ndims - 2; i >= 0; i--) {
+      strides *= dims[i + 1];
+      output_idx += indices[thread_idx * ndims + i] * strides;
+    }
+    flat_indices[thread_idx] = output_idx;
+  }
+}
+
+template <typename T>
+__global__ void PermuteIndicesAndValuesKernel(
+    const int64* __restrict__ indices, const T* __restrict__ values,
+    const int64 nnz, const int64 ndims, const int64* __restrict__ permutes,
+    int64* reordered_indices, T* reordered_values) {
+  GPU_1D_KERNEL_LOOP(thread_idx, nnz) {
+    for (int i = 0; i < ndims; i++) {
+      reordered_indices[thread_idx * ndims + i] =
+          indices[permutes[thread_idx] * ndims + i];
+    }
+    reordered_values[thread_idx] = values[permutes[thread_idx]];
+  }
+}
+
+}  // namespace
+
+using GPUDevice = Eigen::GpuDevice;
+
+namespace functor {
+
+template <typename T>
+struct SparseReorderFunctor<GPUDevice, T> {
+  void operator()(OpKernelContext* c, const Tensor& input_ind,
+                  const Tensor& input_val, const Tensor& input_shape_in) {
+    const Eigen::GpuDevice& d = c->eigen_gpu_device();
+
+    const int64 num_elems = input_ind.dims() > 0 ? input_ind.dim_size(0) : 1;
+    const int64 num_dims = input_ind.dims() > 1 ? input_ind.dim_size(1) : 1;
+
+    auto indices = input_ind.template flat<int64>().data();
+    auto values = input_val.template flat<T>().data();
+    auto dims = input_shape_in.template flat<int64>().data();
+
+    if (num_elems > 0) {
+      Tensor flat_indices_tensor;
+      OP_REQUIRES_OK(c, c->allocate_temp(DT_INT64, TensorShape({num_elems}),
+                                         &flat_indices_tensor));
+      auto flat_indices = flat_indices_tensor.template flat<int64>().data();
+
+      GpuLaunchConfig config = GetGpuLaunchConfig(num_elems, d);
+      OP_REQUIRES_OK(c, GpuLaunchKernel(
+          IndicesFlattenKernel, config.block_count,
+          config.thread_per_block, 0, d.stream(), indices, num_elems,
+          dims, num_dims, flat_indices));
+
+      Tensor permutes_tensor;
+      OP_REQUIRES_OK(c, c->allocate_temp(DT_INT64, {num_elems},
+                                         &permutes_tensor));
+      auto permutes_data = permutes_tensor.template flat<int64>().data();
+
+      OP_REQUIRES_OK(c, GpuRadixSort(c, num_elems, /*keys_in=*/flat_indices,
+                            /*keys_out=*/static_cast<int64*>(nullptr),
+                            /*indices_in=*/static_cast<const int64*>(nullptr),
+                            /*indices_out=*/permutes_data));
+
+      // Free temporary tensor that is no longer needed.
+      flat_indices_tensor = Tensor();
+      flat_indices = nullptr;
+
+      Tensor* reordered_ind_tensor = nullptr;
+      Tensor* reordered_val_tensor = nullptr;
+      OP_REQUIRES_OK(c, c->allocate_output(0, input_ind.shape(),
+                                           &reordered_ind_tensor));
+      OP_REQUIRES_OK(c, c->allocate_output(1, input_val.shape(),
+                                           &reordered_val_tensor));
+      auto reordered_ind_data =
+          reordered_ind_tensor->template flat<int64>().data();
+      auto reordered_val_data =
+          reordered_val_tensor->template flat<T>().data();
+
+      OP_REQUIRES_OK(c, GpuLaunchKernel(
+          PermuteIndicesAndValuesKernel<T>, config.block_count,
+          config.thread_per_block, 0, d.stream(), indices, values, num_elems,
+          num_dims, permutes_data, reordered_ind_data, reordered_val_data));
+    }
+  }
+};
+
+}  // namespace functor
+
+#define DEFINE_GPU_SPEC(T)                                      \
+  template struct functor::SparseReorderFunctor<GPUDevice, T>;
+
+TF_CALL_GPU_NUMBER_TYPES(DEFINE_GPU_SPEC);
+TF_CALL_INTEGRAL_TYPES(DEFINE_GPU_SPEC);
+DEFINE_GPU_SPEC(bool);
+
+}  // namespace tensorflow
+#endif // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/core/kernels/sparse_reorder_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/sparse_reorder_op_gpu.cu.cc
@@ -77,7 +77,7 @@ struct SparseReorderFunctor<GPUDevice, T> {
     auto values = input_val.template flat<T>().data();
     auto dims = input_shape_in.template flat<int64>().data();
 
-    if (num_elems <= 0) return;
+    if (num_elems == 0) return;
 
     Tensor flat_indices_tensor;
     OP_REQUIRES_OK(c, c->allocate_temp(DT_INT64, TensorShape({num_elems}),

--- a/tensorflow/python/kernel_tests/sparse_reorder_op_test.py
+++ b/tensorflow/python/kernel_tests/sparse_reorder_op_test.py
@@ -57,67 +57,72 @@ class SparseReorderTest(test.TestCase):
     self.assertAllEqual((5, 6), sp_output.get_shape())
 
   def testAlreadyInOrder(self):
-    input_val = self._SparseTensorValue_5x6(np.arange(6))
-    sp_output = sparse_ops.sparse_reorder(input_val)
-
-    output_val = self.evaluate(sp_output)
-    self.assertAllEqual(output_val.indices, input_val.indices)
-    self.assertAllEqual(output_val.values, input_val.values)
-    self.assertAllEqual(output_val.dense_shape, input_val.dense_shape)
-
-  @test_util.run_deprecated_v1
-  def testFeedAlreadyInOrder(self):
-    sp_input = self._SparseTensorPlaceholder()
-    input_val = self._SparseTensorValue_5x6(np.arange(6))
-    sp_output = sparse_ops.sparse_reorder(sp_input)
-
-    output_val = sess.run(sp_output, {sp_input: input_val})
-    self.assertAllEqual(output_val.indices, input_val.indices)
-    self.assertAllEqual(output_val.values, input_val.values)
-    self.assertAllEqual(output_val.dense_shape, input_val.dense_shape)
-
-  def testOutOfOrder(self):
-    expected_output_val = self._SparseTensorValue_5x6(np.arange(6))
-    for _ in range(5):  # To test various random permutations
-      input_val = self._SparseTensorValue_5x6(np.random.permutation(6))
+    with self.session() as sess:
+      input_val = self._SparseTensorValue_5x6(np.arange(6))
       sp_output = sparse_ops.sparse_reorder(input_val)
 
       output_val = self.evaluate(sp_output)
-      self.assertAllEqual(output_val.indices, expected_output_val.indices)
-      self.assertAllEqual(output_val.values, expected_output_val.values)
-      self.assertAllEqual(output_val.dense_shape,
-                          expected_output_val.dense_shape)
+      self.assertAllEqual(output_val.indices, input_val.indices)
+      self.assertAllEqual(output_val.values, input_val.values)
+      self.assertAllEqual(output_val.dense_shape, input_val.dense_shape)
+
+  @test_util.run_deprecated_v1
+  def testFeedAlreadyInOrder(self):
+    with self.session() as sess:
+      sp_input = self._SparseTensorPlaceholder()
+      input_val = self._SparseTensorValue_5x6(np.arange(6))
+      sp_output = sparse_ops.sparse_reorder(sp_input)
+
+      output_val = sess.run(sp_output, {sp_input: input_val})
+      self.assertAllEqual(output_val.indices, input_val.indices)
+      self.assertAllEqual(output_val.values, input_val.values)
+      self.assertAllEqual(output_val.dense_shape, input_val.dense_shape)
+
+  def testOutOfOrder(self):
+    expected_output_val = self._SparseTensorValue_5x6(np.arange(6))
+    with self.session() as sess:
+      for _ in range(5):  # To test various random permutations
+        input_val = self._SparseTensorValue_5x6(np.random.permutation(6))
+        sp_output = sparse_ops.sparse_reorder(input_val)
+
+        output_val = self.evaluate(sp_output)
+        self.assertAllEqual(output_val.indices, expected_output_val.indices)
+        self.assertAllEqual(output_val.values, expected_output_val.values)
+        self.assertAllEqual(output_val.dense_shape,
+                            expected_output_val.dense_shape)
 
   @test_util.run_deprecated_v1
   def testFeedOutOfOrder(self):
     expected_output_val = self._SparseTensorValue_5x6(np.arange(6))
-    for _ in range(5):  # To test various random permutations
-      sp_input = self._SparseTensorPlaceholder()
-      input_val = self._SparseTensorValue_5x6(np.random.permutation(6))
-      sp_output = sparse_ops.sparse_reorder(sp_input)
+    with self.session() as sess:
+      for _ in range(5):  # To test various random permutations
+        sp_input = self._SparseTensorPlaceholder()
+        input_val = self._SparseTensorValue_5x6(np.random.permutation(6))
+        sp_output = sparse_ops.sparse_reorder(sp_input)
 
-      output_val = sess.run(sp_output, {sp_input: input_val})
-      self.assertAllEqual(output_val.indices, expected_output_val.indices)
-      self.assertAllEqual(output_val.values, expected_output_val.values)
-      self.assertAllEqual(output_val.dense_shape,
-                          expected_output_val.dense_shape)
+        output_val = sess.run(sp_output, {sp_input: input_val})
+        self.assertAllEqual(output_val.indices, expected_output_val.indices)
+        self.assertAllEqual(output_val.values, expected_output_val.values)
+        self.assertAllEqual(output_val.dense_shape,
+                            expected_output_val.dense_shape)
 
   @test_util.run_deprecated_v1
   def testGradients(self):
-    for _ in range(5):  # To test various random permutations
-      input_val = self._SparseTensorValue_5x6(np.random.permutation(6))
-      sp_input = sparse_tensor.SparseTensor(input_val.indices,
-                                            input_val.values,
-                                            input_val.dense_shape)
-      sp_output = sparse_ops.sparse_reorder(sp_input)
+    with self.session():
+      for _ in range(5):  # To test various random permutations
+        input_val = self._SparseTensorValue_5x6(np.random.permutation(6))
+        sp_input = sparse_tensor.SparseTensor(input_val.indices,
+                                              input_val.values,
+                                              input_val.dense_shape)
+        sp_output = sparse_ops.sparse_reorder(sp_input)
 
-      err = gradient_checker.compute_gradient_error(
-          sp_input.values,
-          input_val.values.shape,
-          sp_output.values,
-          input_val.values.shape,
-          x_init_value=input_val.values)
-      self.assertLess(err, 1e-11)
+        err = gradient_checker.compute_gradient_error(
+            sp_input.values,
+            input_val.values.shape,
+            sp_output.values,
+            input_val.values.shape,
+            x_init_value=input_val.values)
+        self.assertLess(err, 1e-11)
 
   def testShapeOverflow(self):
     # Test case for GitHub issue 45392

--- a/tensorflow/python/kernel_tests/sparse_reorder_op_test.py
+++ b/tensorflow/python/kernel_tests/sparse_reorder_op_test.py
@@ -57,72 +57,67 @@ class SparseReorderTest(test.TestCase):
     self.assertAllEqual((5, 6), sp_output.get_shape())
 
   def testAlreadyInOrder(self):
-    with self.session(use_gpu=True) as sess:
-      input_val = self._SparseTensorValue_5x6(np.arange(6))
-      sp_output = sparse_ops.sparse_reorder(input_val)
+    input_val = self._SparseTensorValue_5x6(np.arange(6))
+    sp_output = sparse_ops.sparse_reorder(input_val)
 
-      output_val = self.evaluate(sp_output)
-      self.assertAllEqual(output_val.indices, input_val.indices)
-      self.assertAllEqual(output_val.values, input_val.values)
-      self.assertAllEqual(output_val.dense_shape, input_val.dense_shape)
+    output_val = self.evaluate(sp_output)
+    self.assertAllEqual(output_val.indices, input_val.indices)
+    self.assertAllEqual(output_val.values, input_val.values)
+    self.assertAllEqual(output_val.dense_shape, input_val.dense_shape)
 
   @test_util.run_deprecated_v1
   def testFeedAlreadyInOrder(self):
-    with self.session(use_gpu=True) as sess:
-      sp_input = self._SparseTensorPlaceholder()
-      input_val = self._SparseTensorValue_5x6(np.arange(6))
-      sp_output = sparse_ops.sparse_reorder(sp_input)
+    sp_input = self._SparseTensorPlaceholder()
+    input_val = self._SparseTensorValue_5x6(np.arange(6))
+    sp_output = sparse_ops.sparse_reorder(sp_input)
 
-      output_val = sess.run(sp_output, {sp_input: input_val})
-      self.assertAllEqual(output_val.indices, input_val.indices)
-      self.assertAllEqual(output_val.values, input_val.values)
-      self.assertAllEqual(output_val.dense_shape, input_val.dense_shape)
+    output_val = sess.run(sp_output, {sp_input: input_val})
+    self.assertAllEqual(output_val.indices, input_val.indices)
+    self.assertAllEqual(output_val.values, input_val.values)
+    self.assertAllEqual(output_val.dense_shape, input_val.dense_shape)
 
   def testOutOfOrder(self):
     expected_output_val = self._SparseTensorValue_5x6(np.arange(6))
-    with self.session(use_gpu=True) as sess:
-      for _ in range(5):  # To test various random permutations
-        input_val = self._SparseTensorValue_5x6(np.random.permutation(6))
-        sp_output = sparse_ops.sparse_reorder(input_val)
+    for _ in range(5):  # To test various random permutations
+      input_val = self._SparseTensorValue_5x6(np.random.permutation(6))
+      sp_output = sparse_ops.sparse_reorder(input_val)
 
-        output_val = self.evaluate(sp_output)
-        self.assertAllEqual(output_val.indices, expected_output_val.indices)
-        self.assertAllEqual(output_val.values, expected_output_val.values)
-        self.assertAllEqual(output_val.dense_shape,
-                            expected_output_val.dense_shape)
+      output_val = self.evaluate(sp_output)
+      self.assertAllEqual(output_val.indices, expected_output_val.indices)
+      self.assertAllEqual(output_val.values, expected_output_val.values)
+      self.assertAllEqual(output_val.dense_shape,
+                          expected_output_val.dense_shape)
 
   @test_util.run_deprecated_v1
   def testFeedOutOfOrder(self):
     expected_output_val = self._SparseTensorValue_5x6(np.arange(6))
-    with self.session(use_gpu=True) as sess:
-      for _ in range(5):  # To test various random permutations
-        sp_input = self._SparseTensorPlaceholder()
-        input_val = self._SparseTensorValue_5x6(np.random.permutation(6))
-        sp_output = sparse_ops.sparse_reorder(sp_input)
+    for _ in range(5):  # To test various random permutations
+      sp_input = self._SparseTensorPlaceholder()
+      input_val = self._SparseTensorValue_5x6(np.random.permutation(6))
+      sp_output = sparse_ops.sparse_reorder(sp_input)
 
-        output_val = sess.run(sp_output, {sp_input: input_val})
-        self.assertAllEqual(output_val.indices, expected_output_val.indices)
-        self.assertAllEqual(output_val.values, expected_output_val.values)
-        self.assertAllEqual(output_val.dense_shape,
-                            expected_output_val.dense_shape)
+      output_val = sess.run(sp_output, {sp_input: input_val})
+      self.assertAllEqual(output_val.indices, expected_output_val.indices)
+      self.assertAllEqual(output_val.values, expected_output_val.values)
+      self.assertAllEqual(output_val.dense_shape,
+                          expected_output_val.dense_shape)
 
   @test_util.run_deprecated_v1
   def testGradients(self):
-    with self.session(use_gpu=True):
-      for _ in range(5):  # To test various random permutations
-        input_val = self._SparseTensorValue_5x6(np.random.permutation(6))
-        sp_input = sparse_tensor.SparseTensor(input_val.indices,
-                                              input_val.values,
-                                              input_val.dense_shape)
-        sp_output = sparse_ops.sparse_reorder(sp_input)
+    for _ in range(5):  # To test various random permutations
+      input_val = self._SparseTensorValue_5x6(np.random.permutation(6))
+      sp_input = sparse_tensor.SparseTensor(input_val.indices,
+                                            input_val.values,
+                                            input_val.dense_shape)
+      sp_output = sparse_ops.sparse_reorder(sp_input)
 
-        err = gradient_checker.compute_gradient_error(
-            sp_input.values,
-            input_val.values.shape,
-            sp_output.values,
-            input_val.values.shape,
-            x_init_value=input_val.values)
-        self.assertLess(err, 1e-11)
+      err = gradient_checker.compute_gradient_error(
+          sp_input.values,
+          input_val.values.shape,
+          sp_output.values,
+          input_val.values.shape,
+          x_init_value=input_val.values)
+      self.assertLess(err, 1e-11)
 
   def testShapeOverflow(self):
     # Test case for GitHub issue 45392

--- a/tensorflow/python/kernel_tests/sparse_reorder_op_test.py
+++ b/tensorflow/python/kernel_tests/sparse_reorder_op_test.py
@@ -57,7 +57,7 @@ class SparseReorderTest(test.TestCase):
     self.assertAllEqual((5, 6), sp_output.get_shape())
 
   def testAlreadyInOrder(self):
-    with self.session(use_gpu=False) as sess:
+    with self.session(use_gpu=True) as sess:
       input_val = self._SparseTensorValue_5x6(np.arange(6))
       sp_output = sparse_ops.sparse_reorder(input_val)
 
@@ -68,7 +68,7 @@ class SparseReorderTest(test.TestCase):
 
   @test_util.run_deprecated_v1
   def testFeedAlreadyInOrder(self):
-    with self.session(use_gpu=False) as sess:
+    with self.session(use_gpu=True) as sess:
       sp_input = self._SparseTensorPlaceholder()
       input_val = self._SparseTensorValue_5x6(np.arange(6))
       sp_output = sparse_ops.sparse_reorder(sp_input)
@@ -80,7 +80,7 @@ class SparseReorderTest(test.TestCase):
 
   def testOutOfOrder(self):
     expected_output_val = self._SparseTensorValue_5x6(np.arange(6))
-    with self.session(use_gpu=False) as sess:
+    with self.session(use_gpu=True) as sess:
       for _ in range(5):  # To test various random permutations
         input_val = self._SparseTensorValue_5x6(np.random.permutation(6))
         sp_output = sparse_ops.sparse_reorder(input_val)
@@ -94,7 +94,7 @@ class SparseReorderTest(test.TestCase):
   @test_util.run_deprecated_v1
   def testFeedOutOfOrder(self):
     expected_output_val = self._SparseTensorValue_5x6(np.arange(6))
-    with self.session(use_gpu=False) as sess:
+    with self.session(use_gpu=True) as sess:
       for _ in range(5):  # To test various random permutations
         sp_input = self._SparseTensorPlaceholder()
         input_val = self._SparseTensorValue_5x6(np.random.permutation(6))
@@ -108,7 +108,7 @@ class SparseReorderTest(test.TestCase):
 
   @test_util.run_deprecated_v1
   def testGradients(self):
-    with self.session(use_gpu=False):
+    with self.session(use_gpu=True):
       for _ in range(5):  # To test various random permutations
         input_val = self._SparseTensorValue_5x6(np.random.permutation(6))
         sp_input = sparse_tensor.SparseTensor(input_val.indices,


### PR DESCRIPTION
This PR adds GPU support to `tf.sparse.reorder`.

cc. @nluehr @benbarsdell 