### PR TITLE
[TFTRT] Add Dynamic Shape Testing and fix Explicit Batch Mode for ConvertUnpack

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -2957,7 +2957,7 @@ Status Converter::SqueezeTensor(nvinfer1::ITensor* input,
                     input_dims->end());
   // Reshape tensor.
   nvinfer1::Dims new_dims;
-  VLOG(2) << "input_dims" << input_dims;
+  VLOG(2) << "input_dims: " << input_dims;
   TF_RETURN_IF_ERROR(ContainerToTrtDims(*input_dims, &new_dims));
   TF_RETURN_IF_ERROR(PrepareTensorForShape(
       params->converter, TRT_TensorOrWeights(input), new_dims,
@@ -5081,6 +5081,13 @@ Status ConvertSplitHelper(OpConverterParams* params,
   int trt_axis;
   TF_RETURN_IF_ERROR(ConvertAxis(tf_axis, dims.nbDims, node_def.name(),
                                  params->use_implicit_batch, &trt_axis));
+
+  if (dims.d[trt_axis] < 0) {
+    return errors::InvalidArgument(
+        "Dimension ", tf_axis, " must have statically defined dimensions, at ",
+        node_def.name());
+  }
+
   // Dimension must equal num_splits for Unstack (when squeeze_after is true)
   if (squeeze_after && dims.d[trt_axis] != num_splits) {
     return errors::InvalidArgument(
@@ -5091,7 +5098,7 @@ Status ConvertSplitHelper(OpConverterParams* params,
   if (dims.d[trt_axis] % num_splits != 0) {
     return errors::InvalidArgument(
         "Dimension ", tf_axis, " of size ", dims.d[trt_axis],
-        " is not evenly divisble by ", num_splits, ", at ", node_def.name());
+        " is not evenly divisible by ", num_splits, ", at ", node_def.name());
   }
 
   // Create parameters for StridedSliceHelper.
@@ -5099,33 +5106,59 @@ Status ConvertSplitHelper(OpConverterParams* params,
   // will change.
   std::vector<int> begin(dims.nbDims, 0);
   // Determine size of split. Slice will get the full length of all dims, except
-  // the one being split.
+  // the one being split. Undefined dims (-1) will translate to a size of -1
+  // which will tell StridedSlice to take full length of that dim.
   std::vector<int> size(dims.d, dims.d + dims.nbDims);
   const int split_size_on_axis = dims.d[trt_axis] / num_splits;
   size[trt_axis] = split_size_on_axis;
   // Stride will always be 1
   std::vector<int> stride(dims.nbDims, 1);
   // Add dummy batch dimension
-  begin.insert(begin.begin(), 0);
-  size.insert(size.begin(), 1);
-  stride.insert(stride.begin(), 1);
+  if (params->use_implicit_batch) {
+    begin.insert(begin.begin(), 0);
+    size.insert(size.begin(), 1);
+    stride.insert(stride.begin(), 1);
+  }
   // Create final shape for Unpack/Unstack, where split axis is squeezed.
   nvinfer1::Dims final_shape_for_unpack;
   nvinfer1::Dims* final_shape_for_unpack_ptr = nullptr;
-  if (squeeze_after) {
+
+  // We can't use final_shape_for_unpack_ptr when input dimensions are not
+  // fully defined.
+  const bool is_dynamic_shape = ! HasStaticShape(dims);
+  if (squeeze_after && ! is_dynamic_shape) {
     std::vector<int> size_after_squeeze(size);
-    size_after_squeeze.erase(size_after_squeeze.begin() + trt_axis + 1);
-    TF_RETURN_IF_ERROR(ContainerToTrtDims(
-        size_after_squeeze, &final_shape_for_unpack, /*ignore_frst_dim=*/true));
+    const int tf_axis = trt_axis + (params->use_implicit_batch ? 1 : 0);
+    size_after_squeeze.erase(size_after_squeeze.begin() + tf_axis);
+    TF_RETURN_IF_ERROR(ContainerToTrtDims(size_after_squeeze,
+                                          &final_shape_for_unpack,
+                                          /*ignore_first_dim=*/
+                                          params->use_implicit_batch));
     final_shape_for_unpack_ptr = &final_shape_for_unpack;
   }
 
   // Slice the input. ConvertStridedSliceHelper will push the outputs onto
   // params->outputs.
   for (int i = 0; i < num_splits; ++i) {
-    begin[trt_axis + 1] = i * split_size_on_axis;
+    const int tf_axis = trt_axis + (params->use_implicit_batch ? 1 : 0);
+    begin[tf_axis] = i * split_size_on_axis;
     TF_RETURN_IF_ERROR(ConvertStridedSliceHelper(
-        params, input, begin, size, stride, final_shape_for_unpack_ptr, i));
+        params, input, begin, size, stride, final_shape_for_unpack_ptr,
+        /*op_instance=*/i));
+  }
+  if (params->validation_only) return Status::OK();
+
+  // Squeeze for dynamic shapes
+  if (squeeze_after && is_dynamic_shape) {
+    for (int i = 0; i < params->outputs->size(); i++) {
+      nvinfer1::ITensor* output_tensor = nullptr;
+      std::vector<int> input_dims(dims.d, dims.d + dims.nbDims);
+      input_dims[trt_axis] = 0;
+      TF_RETURN_IF_ERROR(params->converter->SqueezeTensor(
+          params->outputs->at(i).tensor(), &input_dims, params,
+          &output_tensor));
+      (*params->outputs)[i] = TRT_TensorOrWeights(output_tensor);
+    }
   }
   return Status::OK();
 }

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -1689,6 +1689,7 @@ class OpConverterTest : public ::testing::Test {
       const std::vector<std::vector<int>>& exp_out_dims) {
     RunValidationAndConversion(node_def, status.code(),
                                status.error_message().c_str(), true);
+
     if (status.ok()) {
       // TODO(tfeher): Enable this check in explicit_batch_mode.
       // In dynamic shape mode the output dims cannot be tested here. In that
@@ -1922,7 +1923,7 @@ class ParameterizedOpConverterTestBase
         TF_EXPECT_OK(
             TensorShapeUtils::MakeShape(expected_output_dims[i], &shape));
         EXPECT_TRUE(output_data[i].tensor.shape() == shape)
-            << "Expected shape: " << shape.DebugString() << ", actual shape"
+            << "Expected shape: " << shape.DebugString() << ", actual shape: "
             << output_data[i].tensor.shape().DebugString();
         EXPECT_THAT(GetDataAsFloat(output_data[i]), matcher[i]);
       }
@@ -6346,156 +6347,184 @@ auto get_unpack_nodedef = [](DataType dtype, int num, int axis) -> NodeDef {
   return unstack.operation.node()->def();
 };
 
-template <DataType dtype>
-void TestConvertUnpack(OpConverterTest* test) {
-  typedef typename EnumToDataType<dtype>::Type CType;
+struct UnpackTestParams {
+  std::vector<int> input_shape;
+  std::vector<float> input_value;
+  int axis;
+  int num;
+  std::vector<int> expected_output_dims;
+  std::vector<std::vector<float>> expected_outputs;
+  Status run_status;
+};
 
-  struct TestParams {
-    std::vector<int> input_shape;
-    std::vector<CType> value;
-    int axis;
-    int num;
-    std::vector<int> expected_output_dims;
-    std::vector<std::vector<CType>> expected_outputs;
-  };
+void TestConvertUnpack(ParameterizedOpConverterTestBase* test,
+                       UnpackTestParams& p) {
 
-  const std::vector<CType> common_input = InitTestVector<CType>(6);
-  std::vector<TestParams> ok_params = {
-      {/*input_shape=*/{1, 2, 3}, /*value=*/common_input, /*axis=*/1,
-       /*num=*/1, /*expected_output_dims=*/{2, 3},
-       /*expected_outputs=*/{InitTestVector<CType>(6)}},
-      {/*input_shape=*/{1, 2, 3},
-       /*value=*/common_input,
-       /*axis=*/3,
-       /*num=*/3,
-       /*expected_output_dims=*/{1, 2},
-       /*expected_outputs=*/
-       {{CType(0), CType(3)}, {CType(1), CType(4)}, {CType(2), CType(5)}}},
-      {/*input_shape=*/{6, 1},
-       /*value=*/common_input,
-       /*axis=*/-2,
-       /*num=*/6,
-       /*expected_output_dims=*/{1},
-       /*expected_outputs=*/
-       {{CType(0)},
-        {CType(1)},
-        {CType(2)},
-        {CType(3)},
-        {CType(4)},
-        {CType(5)}}},
-      {/*input_shape=*/{6},
-       /*value=*/common_input,
-       /*axis=*/1,
-       /*num=*/6,
-       /*expected_output_dims=*/{},
-       /*expected_outputs=*/
-       {{CType(0)},
-        {CType(1)},
-        {CType(2)},
-        {CType(3)},
-        {CType(4)},
-        {CType(5)}}},
-  };
+  test->Reset();
+  NodeDef node_def = get_unpack_nodedef(test->get_tf_type(), p.num, p.axis);
+  // Create inputs.
+  test->AddTestTensor("value", p.input_shape, test->get_tf_type(),
+                      p.input_value);
 
-  for (int i = 0; i < ok_params.size(); ++i) {
-    test->Reset();
-    NodeDef node_def =
-        get_unpack_nodedef(dtype, ok_params[i].num, ok_params[i].axis);
-    // Create inputs.
-    nvinfer1::DataType trt_type;
-    TF_ASSERT_OK(TfTypeToTrtType(dtype, &trt_type));
-    test->AddTestTensor("value", ok_params[i].input_shape, 1, trt_type);
-    // Convert.
-    test->RunValidationAndConversion(node_def);
+  std::vector<Matcher<std::vector<float>>> matcher_vec;
+  std::vector<DataType> datatype_vec;
+  std::vector<std::vector<int>> expected_output_dims;
 
-    // Get output tensors and verify output dims.
-    EXPECT_EQ(ok_params[i].expected_outputs.size(), ok_params[i].num);
-    std::vector<TRT_TensorOrWeights> outputs(ok_params[i].num);
-    DataVec output_data;
-    for (int j = 0; j < outputs.size(); ++j) {
-      const string name = j == 0 ? "my_unpack" : StrCat("my_unpack:", j);
-      TF_EXPECT_OK(test->GetTensorOrWeights(name, &outputs[j]));
-      EXPECT_TRUE(outputs[j].is_tensor());
-      ExpectTrtDimsEqualsArray(ok_params[i].expected_output_dims,
-                               outputs[j].tensor()->getDimensions());
-      // Create buffer to store output.
-      output_data.push_back(
-          {name, test->ConstructTensor<CType>(
-                     ok_params[i].expected_outputs[j].size())});
-    }
-
-    // Verify output values are correct.
-    const DataVec input_data{
-        {"value", test->AsTensor<CType>(ok_params[i].value)}};
-    TF_EXPECT_OK(test->BuildAndRun(input_data, &output_data));
-    for (int j = 0; j < outputs.size(); ++j) {
-      EXPECT_THAT(GetSpanForData<CType>(output_data[j]),
-                  ElementsAreArray(ok_params[i].expected_outputs[j]));
-    }
+  for (int j = 0; j < p.expected_outputs.size(); ++j) {
+    matcher_vec.push_back(ElementsAreArray(p.expected_outputs[j]));
+    datatype_vec.push_back(test->get_tf_type());
+    expected_output_dims.push_back(p.expected_output_dims);
   }
+
+  test->TestOpConverterMultiOut(/*name=*/"my_unpack",
+                                /*node_def=*/node_def,
+                                /*expected_output_dims=*/expected_output_dims,
+                                /*expected_conversion_status=*/p.run_status,
+                                /*expected_runtime_status=*/p.run_status,
+                                /*matcher=*/matcher_vec,
+                                /*out_tf_type=*/datatype_vec);
 }
 
-TEST_F(OpConverterTest, ConvertUnpack) {
-  {
-    // Value is weights, should fail.
-    Reset();
-    NodeDef node_def = get_unpack_nodedef(DT_FLOAT, /*num=*/3, /*axis=*/3);
-    AddTestWeights<float>("value", {1, 2, 3}, {1, 2, 3, 4, 5, 6});
-    RunValidationAndConversion(
-        node_def, error::UNIMPLEMENTED,
-        "The input \"value\" for Unpack must be a tensor, at my_unpack");
-  }
-  {
-    // Axis is out of bounds, should fail.
-    Reset();
-    NodeDef node_def = get_unpack_nodedef(DT_FLOAT, /*num=*/1, /*axis=*/4);
-    AddTestTensor("value", {1, 2, 3});
-    RunValidationAndConversion(node_def, error::INVALID_ARGUMENT,
-                               "Axis value of 4 is out of bounds, must be in "
-                               "range [-4, 4), at my_unpack");
-  }
-  {
-    // Axis is out of bounds (negative), should fail.
-    Reset();
-    NodeDef node_def = get_unpack_nodedef(DT_FLOAT, /*num=*/1, /*axis=*/-5);
-    AddTestTensor("value", {1, 2, 3});
-    RunValidationAndConversion(node_def, error::INVALID_ARGUMENT,
-                               "Axis value of -5 is out of bounds, must be in "
-                               "range [-4, 4), at my_unpack");
-  }
-  {
-    // Axis is batch dimension, should fail.
-    Reset();
-    NodeDef node_def = get_unpack_nodedef(DT_FLOAT, /*num=*/1, /*axis=*/0);
-    AddTestTensor("value", {1, 2, 3});
-    RunValidationAndConversion(node_def, error::UNIMPLEMENTED,
-                               "TensorRT does not allow manipulation of the "
-                               "batch dimension, at my_unpack");
-  }
-  {
-    // Dim size does not match num, should fail.
-    Reset();
-    NodeDef node_def = get_unpack_nodedef(DT_FLOAT, /*num=*/5, /*axis=*/2);
-    AddTestTensor("value", {1, 6});
-    RunValidationAndConversion(
-        node_def, error::INVALID_ARGUMENT,
-        "Dimension 2 has size 6 which is not equal to num of 5, at my_unpack");
-  }
-  {
-    // Output would be TF scalar, should fail.
-    Reset();
-    NodeDef node_def = get_unpack_nodedef(DT_FLOAT, /*num=*/1, /*axis=*/0);
-    AddTestTensor("value", {});
-    RunValidationAndConversion(
-        node_def, error::UNIMPLEMENTED,
-        "Input \"value\" for Unpack must be rank 2 or greater, at my_unpack");
+// TODO: Reactivate when INT32 Segfault fixed
+#if IS_TRT_VERSION_GE(5, 1, 3, 1)
+TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertUnpack) {
+#else
+TEST_P(OpConverter_FP32_FP16_Test, ConvertUnpack) {
+#endif
+  // We need to skip error testing for Dynamic Shape mode, as it is impossible
+  // to convert Unpack in Dynamic Shape Mode.
+  if (trt_mode_ != TrtTestMode::kDynamicShape){
+    {
+      // Value is weights, should fail.
+      Reset();
+      NodeDef node_def = get_unpack_nodedef(tf_type_, /*num=*/3, /*axis=*/3);
+      AddTestWeights<float>("value", {1, 1, 2, 3}, {1, 2, 3, 4, 5, 6});
+      RunValidationAndConversion(
+          node_def,
+          error::UNIMPLEMENTED,
+          "The input \"value\" for Unpack must be a tensor, at my_unpack");
+    }
+    {
+      // Axis is out of bounds, should fail.
+      Reset();
+      NodeDef node_def = get_unpack_nodedef(tf_type_, /*num=*/1, /*axis=*/4);
+      AddTestTensor("value", {1, 1, 2, 3});
+      RunValidationAndConversion(node_def, error::INVALID_ARGUMENT,
+                                 "Axis value of 4 is out of bounds, must be in "
+                                 "range [-4, 4), at my_unpack");
+    }
+    {
+      // Axis is out of bounds (negative), should fail.
+      Reset();
+      NodeDef node_def = get_unpack_nodedef(tf_type_, /*num=*/1, /*axis=*/-5);
+      AddTestTensor("value", {1, 1, 2, 3});
+      RunValidationAndConversion(node_def, error::INVALID_ARGUMENT,
+                                 "Axis value of -5 is out of bounds, must be "
+                                 "in range [-4, 4), at my_unpack");
+    }
+    {
+      if (trt_mode_ != TrtTestMode::kExplicitBatch){
+        // Axis is batch dimension, should fail.
+        Reset();
+        NodeDef node_def = get_unpack_nodedef(tf_type_, /*num=*/1, /*axis=*/0);
+        AddTestTensor("value", {1, 2, 3});
+        RunValidationAndConversion(node_def,
+                                   error::UNIMPLEMENTED,
+                                   "TensorRT does not allow manipulation of "
+                                   "the batch dimension, at my_unpack");
+      }
+    }
+    {
+      // Dim size does not match num, should fail.
+      Reset();
+      NodeDef node_def = get_unpack_nodedef(tf_type_, /*num=*/5, /*axis=*/2);
+      AddTestTensor("value", {1, 1, 6});
+      RunValidationAndConversion(
+          node_def, error::INVALID_ARGUMENT,
+          "Dimension 2 has size 6 which is not equal to num of 5, at "
+          "my_unpack");
+    }
+    {
+      // Output would be TF scalar, should fail.
+      Reset();
+      NodeDef node_def = get_unpack_nodedef(tf_type_, /*num=*/1, /*axis=*/0);
+      AddTestTensor("value", {}, tf_type_, {}, {},
+                    trt_mode_ == TrtTestMode::kImplicitBatch ?
+                    errors::Internal("Scalars cannot be represented in "
+                                     "implicit batch mode") : Status::OK());
+
+      if (trt_mode_ == TrtTestMode::kImplicitBatch) {
+        RunValidationAndConversion(
+          node_def, error::INTERNAL,
+          "Failed to convert input value to a TRT_TensorOrWeights: Scalar "
+          "input tensor is not supported since the first dimension is treated "
+          "as batch dimension by TRT"
+        );
+      } else {
+        RunValidationAndConversion(
+          node_def, error::UNIMPLEMENTED,
+          "Input \"value\" for Unpack must be rank 2 or greater, at my_unpack"
+        );
+      }
+    }
   }
 
-  TestConvertUnpack<DT_FLOAT>(this);
-  TestConvertUnpack<DT_HALF>(this);
-#if IS_TRT_VERSION_GE(5, 1, 3, 1)
-  TestConvertUnpack<DT_INT32>(this);
-#endif
+  const std::vector<float> common_input = InitTestVector<float>(6);
+
+  Status run_status = trt_mode_ == TrtTestMode::kDynamicShape
+    ? errors::Unimplemented("Strided slice op not implemented for dynamic "
+                            "shape input") : Status::OK();
+
+  std::vector<UnpackTestParams> params = {
+      {
+        /*input_shape=*/{1, 1, 2, 1, 3, 1},
+        /*input_value=*/common_input,
+        /*axis=*/4,
+        /*num=*/3,
+        /*expected_output_dims=*/{1, 1, 2, 1, 1},
+        /*expected_outputs=*/{{0, 3}, {1, 4}, {2, 5}},
+        /*run_status=*/run_status
+      },
+      {
+        /*input_shape=*/{1, 1, 2, 1, 3},
+        /*input_value=*/common_input,
+        /*axis=*/4,
+        /*num=*/3,
+        /*expected_output_dims=*/{1, 1, 2, 1},
+        /*expected_outputs=*/{{0, 3}, {1, 4}, {2, 5}},
+        /*run_status=*/run_status
+      },
+      {
+        /*input_shape=*/{1, 1, 2, 3},
+        /*input_value=*/common_input,
+        /*axis=*/1,
+        /*num=*/1,
+        /*expected_output_dims=*/{1, 2, 3},
+        /*expected_outputs=*/{InitTestVector<float>(6)},
+        /*run_status=*/run_status
+      },
+      {
+        /*input_shape=*/{1, 6, 1},
+        /*input_value=*/common_input,
+        /*axis=*/-2,
+        /*num=*/6,
+        /*expected_output_dims=*/{1, 1},
+        /*expected_outputs=*/{{0}, {1}, {2}, {3}, {4}, {5}},
+        /*run_status=*/run_status
+      },
+      {
+        /*input_shape=*/{1, 6},
+        /*input_value=*/common_input,
+        /*axis=*/1,
+        /*num=*/6,
+        /*expected_output_dims=*/{1},
+        /*expected_outputs=*/{{0}, {1}, {2}, {3}, {4}, {5}},
+        /*run_status=*/run_status
+      },
+  };
+  for (auto p : params) {
+    TestConvertUnpack(this, p);
+  }
 }
 
 // Get the NodeDef for Pack.


### PR DESCRIPTION
Fixed ConvertSplitHelper to make ConvertUnpack work for explicit batch mode.
Add dynamic shape testing for ConvertUnpack.

@bixia1 @tfeher for review

Feature Tracker: #45481