### PR TITLE
[GO] Memory leak when loading in a string source in encodeTensorWithSlices

### DIFF
--- a/tensorflow/go/tensor.go
+++ b/tensorflow/go/tensor.go
@@ -25,6 +25,10 @@ void toNewTString(_GoString_ gstr, TF_TString *tstr) {
     TF_TString_Init(tstr);
     TF_TString_Copy(tstr, _GoStringPtr(gstr), _GoStringLen(gstr));
 }
+
+void freeTString(TF_TString *tstr) {
+    TF_TString_Dealloc(tstr);
+}
 */
 import "C"
 
@@ -491,6 +495,9 @@ func encodeTensorWithSlices(w *bytes.Buffer, v reflect.Value, shape []int64) (in
 		var tstr C.TF_TString
 		C.toNewTString(s, &tstr)
 		ptr := unsafe.Pointer(&tstr)
+		runtime.SetFinalizer(w, func(s *bytes.Buffer) {
+			C.freeTString(&tstr)
+		})
 		return copyPtr(w, ptr, C.sizeof_TF_TString)
 	} else if v.Kind() != reflect.Array {
 		return 0, fmt.Errorf("unsupported type %v", v.Type())


### PR DESCRIPTION
I noticed my GO application memory usage was growing very quickly when I was feeding in tensor with my webcam's data. In a couple of minutes my app grows about a few gigs per minute and my system started to swap memory.Finally the application terminated with OOM.

I could narrow down the origin of the memory leak to:
```go
tensor, err := tf.NewTensor(string(img))
```

The problem is not on the GO side but in the C++ side where a string buffer is created and not released from memory.

In the specific function `encodeTensorWithSlices`. There is a TF_TString being allocated and initialized. But is never deallocated. I created a new macro for it to deallocate when the used buffer is finalized/garbage collected.

I'm not 100% confident that this is the right object to register the finalizer on. If someone could check and explain to me if this is correct.

