### PR TITLE
TF-TRT Prefer static shapes

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -1484,8 +1484,7 @@ class OpConverterTest : public ::testing::Test {
     if (engine_.get() != nullptr) {
       return errors::Internal("Engine already exists");
     }
-    TrtShapeOptimizationProfile profiles(
-        ProfileStrategy::kImplicitBatchModeCompatible);
+    TrtShapeOptimizationProfile profiles;
     if (!converter_->use_implicit_batch()) {
       profiles.SetShapeTensorMask(converter_->network());
       TF_RETURN_IF_ERROR(profiles.CollectShapeValues(input_data));
@@ -1496,7 +1495,8 @@ class OpConverterTest : public ::testing::Test {
       std::vector<PartialTensorShape> input_partial_shapes;
       TF_RETURN_IF_ERROR(
           GetNetworkInputShapes(converter_->network(), &input_partial_shapes));
-      profiles.InitProfiles(input_partial_shapes);
+      profiles.InitProfiles(input_partial_shapes,
+                            ProfileStrategy::kImplicitBatchModeCompatible);
     }
     TF_RETURN_IF_ERROR(
         converter_->BuildCudaEngine(&engine_,

--- a/tensorflow/compiler/tf2tensorrt/convert/utils.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/utils.cc
@@ -273,13 +273,16 @@ string ProfileStrategyToName(const ProfileStrategy strategy) {
 }
 
 Status ProfileStrategyFromName(const string& name, ProfileStrategy* strategy) {
-  if (name == "range") {
+  string name_lowercase(name);
+  std::transform(name.begin(), name.end(), name_lowercase.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  if (name_lowercase == "range") {
     *strategy = ProfileStrategy::kRange;
-  } else if (name == "optimal") {
+  } else if (name_lowercase == "optimal") {
     *strategy = ProfileStrategy::kOptimal;
-  } else if (name == "range+optimal") {
+  } else if (name_lowercase == "range+optimal") {
     *strategy = ProfileStrategy::kRangeOptimal;
-  } else if (name == "implicitbatchmodecompatible") {
+  } else if (name_lowercase == "implicitbatchmodecompatible") {
     *strategy = ProfileStrategy::kImplicitBatchModeCompatible;
   } else {
     return errors::InvalidArgument("Invalid profile strategy: ", name);

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op_test.cc
@@ -110,6 +110,7 @@ class TRTEngineOpTestBase : public OpsTestBase {
                      .Attr("workspace_size_bytes", 1 << 20)
                      .Attr("precision_mode", "FP32")
                      .Attr("use_calibration", false)
+                     .Attr("profile_strategy", "optimal")
                      .Attr("_use_implicit_batch", use_implicit_batch)
                      .Attr("_allow_build_at_runtime", allow_build_at_runtime)
                      .Attr("_allow_soft_placement", false)

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_resource_ops_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_resource_ops_test.cc
@@ -195,7 +195,8 @@ class TRTEngineResourceOpsTest
       }
       std::vector<PartialTensorShape> input_partial_shapes;
       TF_CHECK_OK(GetNetworkInputShapes(network.get(), &input_partial_shapes));
-      profile.InitProfiles(input_partial_shapes);
+      profile.InitProfiles(input_partial_shapes,
+                           ProfileStrategy::kImplicitBatchModeCompatible);
       // Configure and build engine
 #if IS_TRT_VERSION_GE(6, 0, 0, 0)
       TF_CHECK_OK(profile.ConfigureBuilder(builder.get(), builder_config.get(),

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.cc
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.cc
@@ -198,7 +198,9 @@ bool AlreadyCollected(const std::vector<std::vector<nvinfer1::Dims>>& values,
 }
 
 void TrtShapeOptimizationProfile::InitProfiles(
-    const std::vector<PartialTensorShape>& input_partial_shapes) {
+    const std::vector<PartialTensorShape>& input_partial_shapes,
+    ProfileStrategy strategy) {
+  strategy_ = strategy;
   if (input_shapes_.size() == 0) {
     VLOG(1) << "Not creating profiles without input_shapes. "
                "You have to enable profile generation mode first (build).";

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles_test.cc
@@ -162,7 +162,7 @@ TEST_F(TrtShapeOptimizationProfileTest, Dynamic) {
   nvinfer1::Dims3 dims(-1, -1, 10);
   DefineNetwork(network_.get(), dims);
 
-  TrtShapeOptimizationProfile profile(ProfileStrategy::kOptimal);
+  TrtShapeOptimizationProfile profile;
   std::vector<std::vector<nvinfer1::Dims3>> input_profiles{
       {nvinfer1::Dims3(2, 2, 10), nvinfer1::Dims3(2, 2, 10)},
       {nvinfer1::Dims3(3, 3, 10), nvinfer1::Dims3(3, 3, 10)},
@@ -176,7 +176,7 @@ TEST_F(TrtShapeOptimizationProfileTest, Dynamic) {
   }
   std::vector<PartialTensorShape> input_partial_shapes;
   TF_CHECK_OK(GetNetworkInputShapes(network_.get(), &input_partial_shapes));
-  profile.InitProfiles(input_partial_shapes);
+  profile.InitProfiles(input_partial_shapes, ProfileStrategy::kOptimal);
 
   // Configure and build engine.
   TF_CHECK_OK(profile.ConfigureBuilder(builder_.get(), builder_config_.get(),


### PR DESCRIPTION
This PR improves TF-TRT conversion when the "Optimal" profile generation strategy is used with only a single input shape. 

In that case the TRT engine would have a single profile with min=opt=max. This means that the engine should only handle the concrete input dimension defined by the single profile. Therefore, we can define the TRT network with static shapes. This increases conversion rate, because some of our converters are not able to convert dynamic shape input.

This PR updates `TRTEngineOp` constructor to retrieve the `profile_strategy` graph attribute, and pass it to `TrtShapeOptimizationProfiles` during the `InitProfiles` call. Additionally an `IsStaticCompatible` method is introduced to `TrtShapeOptimizationProfiles`, and is used in `TRTEngineOp::BuildEngine` to decide whether to build a dynamic or a static engine. 

Tracker #45481
Tagging @bixia1 for review and @DEKHTIARJonathan