### PR TITLE
[ClusterSpec] Allow sparse representation of TF_CONFIG.

### DIFF
--- a/tensorflow/python/distribute/cluster_resolver/tfconfig_cluster_resolver.py
+++ b/tensorflow/python/distribute/cluster_resolver/tfconfig_cluster_resolver.py
@@ -40,7 +40,17 @@ def format_master_url(master, rpc_layer=None):
 
 
 def _load_tf_config():
-  return json.loads(os.environ.get(_TF_CONFIG_ENV, '{}'))
+  tf_config = json.loads(os.environ.get(_TF_CONFIG_ENV, '{}'))
+  if 'cluster' in tf_config:
+    cluster = tf_config['cluster']
+    to_overwrite = {}
+    for job_name, tasks in cluster.items():
+      if isinstance(tasks, dict):
+        # In Json, the type of dictionary key is always `string`. Thus, task index
+        # should be casted to integer for compatibility with `tf.train.ClusterSpec`.
+        cluster[job_name] = {int(i): task for i, task in tasks.items()}
+    cluster.update(to_overwrite)
+  return tf_config
 
 
 def _get_value_in_tfconfig(key, default=None):

--- a/tensorflow/python/distribute/cluster_resolver/tfconfig_cluster_resolver.py
+++ b/tensorflow/python/distribute/cluster_resolver/tfconfig_cluster_resolver.py
@@ -40,17 +40,7 @@ def format_master_url(master, rpc_layer=None):
 
 
 def _load_tf_config():
-  tf_config = json.loads(os.environ.get(_TF_CONFIG_ENV, '{}'))
-  if 'cluster' in tf_config:
-    cluster = tf_config['cluster']
-    to_overwrite = {}
-    for job_name, tasks in cluster.items():
-      if isinstance(tasks, dict):
-        # In Json, the type of dictionary key is always `string`. Thus, task index
-        # should be casted to integer for compatibility with `tf.train.ClusterSpec`.
-        cluster[job_name] = {int(i): task for i, task in tasks.items()}
-    cluster.update(to_overwrite)
-  return tf_config
+  return json.loads(os.environ.get(_TF_CONFIG_ENV, '{}'))
 
 
 def _get_value_in_tfconfig(key, default=None):

--- a/tensorflow/python/distribute/cluster_resolver/tfconfig_cluster_resolver_test.py
+++ b/tensorflow/python/distribute/cluster_resolver/tfconfig_cluster_resolver_test.py
@@ -70,6 +70,29 @@ class TFConfigClusterResolverTest(test.TestCase):
     actual_cluster_spec = cluster_resolver.cluster_spec()
     self._verifyClusterSpecEquality(actual_cluster_spec, expected_proto)
 
+  def testSparseClusterSpecRead(self):
+    os.environ['TF_CONFIG'] = """
+    {
+      "cluster": {
+        "ps": ["ps0:2222", "ps1:2222"],
+        "worker": {"1": "worker1:2222"}
+      },
+      "task": {
+        "type": "worker",
+        "index": 1
+      }
+    }
+    """
+
+    cluster_resolver = TFConfigClusterResolver()
+    expected_proto = """
+    job { name: 'ps' tasks { key: 0 value: 'ps0:2222' }
+                     tasks { key: 1 value: 'ps1:2222' } }
+    job { name: 'worker' tasks { key: 1 value: 'worker1:2222' } }
+    """
+    actual_cluster_spec = cluster_resolver.cluster_spec()
+    self._verifyClusterSpecEquality(actual_cluster_spec, expected_proto)
+
   def testAutomaticMasterRead(self):
     os.environ['TF_CONFIG'] = """
     {

--- a/tensorflow/python/training/server_lib.py
+++ b/tensorflow/python/training/server_lib.py
@@ -293,7 +293,7 @@ class ClusterSpec(object):
         if isinstance(tasks, (list, tuple)):
           job_tasks = {i: task for i, task in enumerate(tasks)}
         elif isinstance(tasks, dict):
-          job_tasks = {i: task for i, task in tasks.items()}
+          job_tasks = {int(i): task for i, task in tasks.items()}
         else:
           raise TypeError("The tasks for job %r must be a list or a dictionary "
                           "from integers to strings." % job_name)

--- a/tensorflow/python/training/server_lib_test.py
+++ b/tensorflow/python/training/server_lib_test.py
@@ -516,6 +516,29 @@ class ClusterSpecTest(test.TestCase):
         expected_proto,
         server_lib.ClusterSpec(cluster_spec.as_dict()).as_cluster_def())
 
+  def testProtoDictDefEquivalencesWithStringTaskIndex(self):
+    cluster_spec = server_lib.ClusterSpec({
+        "ps": ["ps0:2222", "ps1:2222"],
+        "worker": {"1": "worker1:2222"}
+    })
+
+    expected_proto = """
+    job { name: 'ps' tasks { key: 0 value: 'ps0:2222' }
+                     tasks { key: 1 value: 'ps1:2222' } }
+    job { name: 'worker' tasks { key: 1 value: 'worker1:2222' } }
+    """
+
+    self.assertProtoEquals(expected_proto, cluster_spec.as_cluster_def())
+    self.assertProtoEquals(
+        expected_proto,
+        server_lib.ClusterSpec(cluster_spec).as_cluster_def())
+    self.assertProtoEquals(
+        expected_proto,
+        server_lib.ClusterSpec(cluster_spec.as_cluster_def()).as_cluster_def())
+    self.assertProtoEquals(
+        expected_proto,
+        server_lib.ClusterSpec(cluster_spec.as_dict()).as_cluster_def())
+
   def testProtoDictDefEquivalencesWithZeroWorker(self):
     cluster_spec = server_lib.ClusterSpec({
         "ps": ["ps0:2222", "ps1:2222"],


### PR DESCRIPTION
For asynchronous parallel training with PS and Worker, `tf.train.ClusterSpec` propagation is usaully enabled for better fault-tolerance and worker-scalability. In this case:
- Each PS server is started without others' addresses like:
```
{
  "cluster": {
    "local": {"0": "localhost:2222"}
  },
  "task": {
    "type": "local",
    "index": 0
  }
}
```
- Each Worker session is started with a sparse `TF_CONFIG` containing all PS IP-port pairs and its own address like:
```json
{
  "cluster": {
    "ps": ["ps0:2222", "ps1:2222"],
    "worker": {"1": "worker1:2222"}
  },
  "task": {
    "type": "worker",
    "index": 1
  }
}
```

However, in Json, the type of dictionary key is always `string`. Thus, task index should be casted to integer for compatibility with `tf.train.ClusterSpec`. Otherwise, an error comes out:
```text
>>> cluster_resolver.cluster_spec()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/data00/home/shishaochen/.venvs/dev-py2/local/lib/python2.7/site-packages/tensorflow_core/python/distribute/cluster_resolver/tfconfig_cluster_resolver.py", line 138, in cluster_spec
    return ClusterSpec(tf_config['cluster'])
  File "/data00/home/shishaochen/.venvs/dev-py2/local/lib/python2.7/site-packages/tensorflow_core/python/training/server_lib.py", line 295, in __init__
    self._make_cluster_def()
  File "/data00/home/shishaochen/.venvs/dev-py2/local/lib/python2.7/site-packages/tensorflow_core/python/training/server_lib.py", line 490, in _make_cluster_def
    job_def.tasks[i] = task_address
TypeError: u'1' has type unicode, but expected one of: int, long
```

To keep compatibilty with both `tf.distribute.cluster_resolver.TFConfigClusterResolver` and `tf.estimator.RunConfig`, we'd better push down type casting to constructor of `tf.train.ClusterSpec`.

The following code snippets tell how they directly consume the parsed `TF_CONFIG` of Json.
- https://github.com/tensorflow/estimator/blob/v2.4.0/tensorflow_estimator/python/estimator/run_config.py#L647
```python
self._cluster_spec = tf.train.ClusterSpec(tf_config.get(_CLUSTER_KEY, {}))
```
- https://github.com/tensorflow/tensorflow/blob/v2.4.1/tensorflow/python/distribute/cluster_resolver/tfconfig_cluster_resolver.py#L162
```python
return ClusterSpec(tf_config['cluster'])
```

Collaborated with @wangcaihua.