### PR TITLE
Consider Tensors with data in only single dimension to be Linear Tensor

### DIFF
--- a/tensorflow/lite/delegates/gpu/common/model_builder_helper.cc
+++ b/tensorflow/lite/delegates/gpu/common/model_builder_helper.cc
@@ -304,18 +304,27 @@ absl::Status CheckIfLinearConvertible(const TfLiteIntArray* dimensions) {
   if (dimensions->size <= 0) {
     return absl::InvalidArgumentError("Dimension is empty.");
   }
-  for (int i = 0; i < dimensions->size - 1; ++i) {
+  int num_actual_dimensions = 0;
+  for (int i = 0; i < dimensions->size; ++i) {
     if (dimensions->data[i] != 1) {
-      return absl::InvalidArgumentError(absl::StrCat(
-          GetDimensionString(dimensions), "  cannot be reduced to linear."));
+      num_actual_dimensions++;
     }
+  }
+  if (num_actual_dimensions > 1)
+  {
+    return absl::InvalidArgumentError(absl::StrCat(
+        GetDimensionString(dimensions), "  cannot be reduced to linear."));
   }
   return absl::OkStatus();
 }
 
 absl::Status SetAllDimensions(const TfLiteIntArray* dimensions, Linear* shape) {
   RETURN_IF_ERROR(CheckIfLinearConvertible(dimensions));
-  shape->v = dimensions->data[dimensions->size - 1];
+  int dimensions_size = 0;
+  for (int i = 0; i < dimensions->size; ++i) {
+    dimensions_size *= dimensions->data[i];
+  }
+  shape->v = dimensions_size;
   return absl::OkStatus();
 }
 


### PR DESCRIPTION
Currently only Tensors where the last dimension is not of size 1 are recognized as Linear Tensors. However, in many applications Tensors can have shape like (1,64,1,1). These are currently not recognized as Linear. My commit aims to recognize these as being Linear.

The change affect TF Lite GPU delegate.