### PR TITLE
Initialize allowed_devices when creating a local client in BuildXlaCo…

### DIFF
--- a/tensorflow/compiler/jit/xla_platform_info.cc
+++ b/tensorflow/compiler/jit/xla_platform_info.cc
@@ -60,6 +60,10 @@ Status BuildXlaCompilationCache(DeviceBase* device,
   client_options.set_platform(platform.ValueOrDie());
   client_options.set_intra_op_parallelism_threads(
       device->tensorflow_cpu_worker_threads()->num_threads);
+  // Initialize allowed_devices to the selected incoming device.
+  // Without this, allowed_devices is empty, resulting in the device
+  // initialization in GetStreamExecutors to initialize _all_ visible
+  // devices. Not only is that wasteful, in can result in OOMs.
   auto dev_info = device->tensorflow_gpu_device_info();
   if (dev_info != nullptr) {
     std::set<int> allowed_device = {dev_info->gpu_id};

--- a/tensorflow/compiler/jit/xla_platform_info.cc
+++ b/tensorflow/compiler/jit/xla_platform_info.cc
@@ -60,6 +60,11 @@ Status BuildXlaCompilationCache(DeviceBase* device,
   client_options.set_platform(platform.ValueOrDie());
   client_options.set_intra_op_parallelism_threads(
       device->tensorflow_cpu_worker_threads()->num_threads);
+  auto dev_info = device->tensorflow_gpu_device_info();
+  if (dev_info != nullptr) {
+    std::set<int> allowed_device = {dev_info->gpu_id};
+    client_options.set_allowed_devices(allowed_device);
+  }
   auto client = xla::ClientLibrary::GetOrCreateLocalClient(client_options);
   if (!client.ok()) {
     return client.status();


### PR DESCRIPTION
…mpilationCache.

w/o any allowed devices, the loop in GetStreamExecutors (platfrom_util.cc) sees
all devices, and initializes all of them.
In a multigpu scenario, this causes OOMs, as CUDA contexts are allocated on
all devices. This change results in GetStreamExecutors only initializing the
current device

This PR addresses https://github.com/horovod/horovod/issues/2548
