### PR TITLE
Add riscv platform support for tflite with cmake.

### DIFF
--- a/tensorflow/lite/g3doc/guide/build_cmake_riscv.md
+++ b/tensorflow/lite/g3doc/guide/build_cmake_riscv.md
@@ -1,0 +1,118 @@
+# Cross compilation TensorFlow Lite with CMake for RISC-V platform
+
+This page describes how to build the TensorFlow Lite library for RISC-V
+platform.
+
+The following instructions have been tested on Ubuntu 16.04.3 64-bit PC (AMD64).
+
+**Note:** This feature is currently experimental and available since version 2.4
+and may change.
+
+### Prerequisites
+
+You need CMake installed and downloaded TensorFlow source code. Please check
+[Build TensorFlow Lite with CMake](https://www.tensorflow.org/lite/guide/build_cmake)
+page for the details.
+
+## Build for RV64 arch
+
+This instruction shows how to build RV64 binary.
+
+#### Download RISC-V clang toolchain and QEMU
+
+These commands install riscv-clang toolchain and QEMU under
+${TENSORFLOW_SRC_PATH}/tensorflow/lite/tools/cmake/riscv folder.
+
+```sh
+cd ${TENSORFLOW_SRC_PATH}/tensorflow/lite/tools/cmake/riscv
+./riscv_bootstrap.sh
+```
+
+**Note1:** If you change the default download path for bootstrap script, you also need to update the
+toolchain path setting in riscv-clang.cmake.
+
+**Note2:** The RISC-V clang toolchain is built from https://github.com/llvm/llvm-project. Currently, the toolchain is based on GNU toolchain(including libgcc, GNU linker, and C libraries). You need to build the GNU toolchain first.
+```sh
+# Get gnu toolchain source code.
+git clone https://github.com/riscv/riscv-gnu-toolchain.git
+
+# Set the build and install path
+PREFIX=/path/to/the/riscv/clang/install/prefix/you/want
+
+# Build gnu toolchain.
+cd riscv-gnu-toolchain
+git submodule update --init --recursive
+cd riscv-binutils
+git fetch origin
+git checkout -b rvv-1.0.x-zfh origin/rvv-1.0.x-zfh
+cd ..
+./configure --with-cmodel=medany --prefix=$PREFIX
+make -j linux
+```
+```sh
+# Get LLVM source code.
+git clone https://github.com/llvm/llvm-project.git
+
+# Set the build and install path.
+PREFIX=/path/to/the/riscv/clang/install/prefix/you/want
+BUILDPATH=/path/to/your/build/path
+SOURCE=/path/to/your/llvm/source
+
+# Build LLVM/Clang.
+mkdir -p $BUILDPATH
+cd $BUILDPATH
+cmake -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DCMAKE_C_COMPILER=clang \
+      -DCMAKE_CXX_COMPILER=clang++ \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DLLVM_TARGETS_TO_BUILD="RISCV" \
+      -DLLVM_ENABLE_PROJECTS="clang" \
+      -DLLVM_DEFAULT_TARGET_TRIPLE="riscv64-unknown-linux-gnu" \
+      -DLLVM_INSTALL_TOOLCHAIN_ONLY=On \
+      -DDEFAULT_SYSROOT=../sysroot \
+      -G "Ninja" $SOURCE
+ninja -j
+ninja install
+```
+
+**Note3:** The RISC-V QEMU is built from https://github.com/sifive/qemu.git
+```sh
+# Get QEMU source code.
+git clone https://github.com/sifive/qemu.git
+
+# Set the install path.
+PREFIX=/path/to/your/qemu/install/prefix/you/want
+
+# Build QEMU.
+cd qemu
+git checkout origin/v5.2.0-rvv-rvb-zfh -b v5.2.0-rvv-rvb-zfh && git submodule update --init --recursive
+mkdir build && cd build
+../configure --prefix=$PREFIX --target-list="riscv64-linux-user"
+make -j install
+```
+
+#### Run CMake
+
+```sh
+cd ${TENSORFLOW_SRC_PATH}/tensorflow/lite/tools/cmake
+mkdir build
+cd build
+cmake -DCMAKE_TOOLCHAIN_FILE=../riscv/riscv-clang.cmake \
+  ../../..
+```
+
+**Note:** XNNPACK is disabled since there is no riscv support in XNNPACK.
+
+#### Run benchmark tool with qemu
+
+```sh
+# Please run CMake using previous CMake instructions.
+cd ${TENSORFLOW_SRC_PATH}/tensorflow/lite/tools/cmake/build
+# Build benchmark tool.
+make -j benchmark_model
+# Run benchmark tool with qemu.
+${TENSORFLOW_SRC_PATH}/tensorflow/lite/tools/cmake/riscv/Prebuilt/qemu/linux/RISCV/bin/qemu-riscv64 \
+  -cpu rv64,x-v=true,x-k=true,vlen=512,elen=64,vext_spec=v1.0 \
+  -L ${TENSORFLOW_SRC_PATH}/tensorflow/lite/tools/cmake/riscv/Prebuilt/toolchain/clang/linux/RISCV/sysroot \
+  ./tools/benchmark/benchmark_model --help
+```

--- a/tensorflow/lite/tools/cmake/riscv/README.md
+++ b/tensorflow/lite/tools/cmake/riscv/README.md
@@ -1,0 +1,3 @@
+# Cross compilation TensorFlow Lite with CMake for RISC-V platform
+
+Please refer [../../../g3doc/guide/build_cmake_riscv.md](../../../g3doc/guide/build_cmake_riscv.md)

--- a/tensorflow/lite/tools/cmake/riscv/riscv-clang.cmake
+++ b/tensorflow/lite/tools/cmake/riscv/riscv-clang.cmake
@@ -1,0 +1,63 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(CMAKE_SYSTEM_NAME "Linux")
+set(CMAKE_SYSTEM_PROCESSOR "riscv")
+
+# Force object file extension to be .o
+set(UNIX TRUE CACHE STRING "" FORCE)
+
+if(APPLE)
+  set(TOOLCHAIN_PREFIX_PATH ${CMAKE_SOURCE_DIR}/tools/cmake/riscv/Prebuilt/toolchain/clang/darwin/RISCV)
+  set(QEMU_PREFIX_PATH ${CMAKE_SOURCE_DIR}/tools/cmake/riscv/Prebuilt/qemu/darwin/RISCV)
+else()
+  set(TOOLCHAIN_PREFIX_PATH ${CMAKE_SOURCE_DIR}/tools/cmake/riscv/Prebuilt/toolchain/clang/linux/RISCV)
+  set(QEMU_PREFIX_PATH ${CMAKE_SOURCE_DIR}/tools/cmake/riscv/Prebuilt/qemu/linux/RISCV)
+endif()
+
+set(CMAKE_C_COMPILER "${TOOLCHAIN_PREFIX_PATH}/bin/clang")
+set(CMAKE_CXX_COMPILER "${TOOLCHAIN_PREFIX_PATH}/bin/clang++")
+# CMake will just use the host-side tools for the following tools, so we setup them here.
+set(CMAKE_C_COMPILER_AR "${TOOLCHAIN_PREFIX_PATH}/bin/llvm-ar")
+set(CMAKE_CXX_COMPILER_AR "${TOOLCHAIN_PREFIX_PATH}/bin/llvm-ar")
+set(CMAKE_C_COMPILER_RANLIB "${TOOLCHAIN_PREFIX_PATH}/bin/llvm-ranlib")
+set(CMAKE_CXX_COMPILER_RANLIB "${TOOLCHAIN_PREFIX_PATH}/bin/llvm-ranlib")
+set(CMAKE_OBJDUMP "${TOOLCHAIN_PREFIX_PATH}/bin/llvm-objdump")
+set(CMAKE_OBJCOPY "${TOOLCHAIN_PREFIX_PATH}/bin/llvm-objcopy")
+
+add_compile_options(-mcpu=sifive-7-rv64)
+# Use fused multiply-add operation.
+add_compile_options(-ffp-contract=fast)
+# The options for "--gc-sections" link option.
+add_compile_options(-fdata-sections -ffunction-sections)
+
+set(RISCV_COMPILE_DEFINITIONS "" CACHE STRING "The riscv specific compiling defs.")
+add_compile_definitions(RISCV_COMPILE_DEFINITIONS)
+
+set(RISCV_LINKER_FLAGS "" CACHE STRING "The riscv specific link flags.")
+set(RISCV_LINKER_FLAGS "${RISCV_LINKER_FLAGS} -Wl,--gc-sections")
+string(STRIP ${RISCV_LINKER_FLAGS} RISCV_LINKER_FLAGS)
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${RISCV_LINKER_FLAGS}")
+
+set(QEMU_PATH ${QEMU_PREFIX_PATH}/bin/qemu-riscv64)
+set(QEMU_OPTION -cpu rv64,x-v=true,x-k=true,vlen=512,elen=64,vext_spec=v1.0 -L ${TOOLCHAIN_PREFIX_PATH}/sysroot)
+# Use qemu for ctest.
+set(CMAKE_CROSSCOMPILING_EMULATOR ${QEMU_PATH} ${QEMU_OPTION})
+
+# The xnnpack haven't support riscv platform yet.
+OPTION(TFLITE_ENABLE_XNNPACK OFF)
+# There is no riscv asm impls in xnnpack.
+OPTION(XNNPACK_ENABLE_ASSEMBLY OFF)
+# There is no riscv specific timer in googlebenchmark project.
+OPTION(XNNPACK_BUILD_BENCHMARKS OFF)

--- a/tensorflow/lite/tools/cmake/riscv/riscv_bootstrap.sh
+++ b/tensorflow/lite/tools/cmake/riscv/riscv_bootstrap.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# This script will download and setup the riscv-linux required toolchain and qemu tool.
+
+set -e
+set -o pipefail
+
+BOOTSTRAP_SCRIPT_PATH=$(dirname "$0")
+BOOTSTRAP_WORK_DIR=${BOOTSTRAP_SCRIPT_PATH}/.bootstrap
+
+PREBUILT_DIR=${BOOTSTRAP_SCRIPT_PATH}/Prebuilt
+
+read -p "Enter the riscv tools root path(press enter to use default path:${PREBUILT_DIR}): " INPUT_PATH
+if [[ "${INPUT_PATH}" ]]; then
+  PREBUILT_DIR=${INPUT_PATH}
+fi
+echo "The riscv tool prefix path: ${PREBUILT_DIR}"
+
+if [[ "${OSTYPE}" == "linux-gnu" ]]; then
+  RISCV_CLANG_TOOLCHAIN_FILE_ID=13q6sYVlae-hRrgj7SNlvbJFYI3Q8sCI4
+  RISCV_CLANG_TOOLCHAIN_FILE_NAME=rvv-llvm-toolchain.tar.bz2
+  QEMU_FILE_ID=1JkLana7CGeD2wfwn8shHQxcYrv3j1l9s
+  QEMU_FILE_NAME=riscv-qemu-v5.2.0-rvv-rvb-zfh-856da0e-linux-ubuntu.tar.gz
+
+  TOOLCHAIN_PATH_PREFIX=${PREBUILT_DIR}/toolchain/clang/linux/RISCV
+  QEMU_PATH_PREFIX=${PREBUILT_DIR}/qemu/linux/RISCV
+elif [[ "${OSTYPE}" == "darwin"* ]]; then
+  RISCV_CLANG_TOOLCHAIN_FILE_ID=empty
+  RISCV_CLANG_TOOLCHAIN_FILE_NAME=empty
+  QEMU_FILE_ID=empty
+  QEMU_FILE_NAME=empty
+
+  TOOLCHAIN_PATH_PREFIX=${PREBUILT_DIR}/toolchain/clang/darwin/RISCV
+  QEMU_PATH_PREFIX=${PREBUILT_DIR}/qemu/darwin/RISCV
+
+  echo "We haven't had the darwin prebuilt binary yet. Skip this script."
+  exit 1
+else
+  echo "${OSTYPE} is not supported."
+  exit 1
+fi
+
+function cleanup {
+  if [[ -d ${BOOTSTRAP_WORK_DIR} ]]; then
+    rm -rf ${BOOTSTRAP_WORK_DIR}
+  fi
+}
+
+# Call the cleanup function when this tool exits.
+trap cleanup EXIT
+
+wget_google_drive() {
+  local file_id="$1"
+  local file_name="$2"
+  local install_path="$3"
+  local tar_option="$4"
+
+  wget --save-cookies ${BOOTSTRAP_WORK_DIR}/cookies.txt \
+    "https://docs.google.com/uc?export=download&id="$file_id -O- | \
+    sed -En "s/.*confirm=([0-9A-Za-z_]+).*/\1/p" > ${BOOTSTRAP_WORK_DIR}/confirm.txt
+  wget --progress=bar:force:noscroll --load-cookies ${BOOTSTRAP_WORK_DIR}/cookies.txt \
+    "https://docs.google.com/uc?export=download&id=$file_id&confirm=`cat ${BOOTSTRAP_WORK_DIR}/confirm.txt`" -O- | \
+    tar $tar_option - --no-same-owner --strip-components=1 -C $install_path
+}
+
+download_file() {
+  # server name or google drive file_id
+  local file_download_info="$1"
+  local file_name="$2"
+  local install_path="$3"
+  # download method(e.g. wget_google_drive)
+  local download_method="$4"
+
+  echo "Install $2 to $3"
+  if [[ -e $3/file_info.txt ]]; then
+    read -p "The file already exists. Keep it (y/n)? " replaced
+    case ${replaced:0:1} in
+      y|Y )
+        echo "Skip download $2."
+        return
+      ;;
+      * )
+        rm -rf $3
+      ;;
+    esac
+  fi
+
+  local tar_option=""
+  if [[ "${file_name##*.}" == "gz" ]]; then
+    tar_option="zxpf"
+  elif [[ "${file_name##*.}" == "bz2" ]]; then
+    tar_option="jxpf"
+  fi
+  echo "tar option: $tar_option"
+
+  echo "Download $file_name ..."
+  mkdir -p $install_path
+  $download_method $file_download_info $file_name $install_path $tar_option
+
+  echo "$file_download_info $file_name" > $install_path/file_info.txt
+}
+
+mkdir -p ${BOOTSTRAP_WORK_DIR}
+
+read -p "Install RISCV clang toolchain(y/n)? " answer
+case ${answer:0:1} in
+  y|Y )
+    download_file ${RISCV_CLANG_TOOLCHAIN_FILE_ID} \
+                  ${RISCV_CLANG_TOOLCHAIN_FILE_NAME} \
+                  ${TOOLCHAIN_PATH_PREFIX} \
+                  wget_google_drive
+  ;;
+  * )
+    echo "Skip RISCV clang toolchain."
+  ;;
+esac
+
+read -p "Install RISCV qemu(y/n)? " answer
+case ${answer:0:1} in
+  y|Y )
+    download_file $QEMU_FILE_ID \
+                  ${QEMU_FILE_NAME} \
+                  ${QEMU_PATH_PREFIX} \
+                  wget_google_drive
+  ;;
+  * )
+    echo "Skip RISCV qemu."
+  ;;
+esac
+
+echo "Bootstrap finished."


### PR DESCRIPTION
This pr try to add the riscv platform support with cmake.
It includes:
1. prebuilt binary download script for riscv clang compiler and qemu.
2. the riscv cmake toolchain file which contains the toolchain and compiling options related setting for riscv platform
3. the howto document for all build steps.