### PR TITLE
Fused map and batch autotune

### DIFF
--- a/tensorflow/core/kernels/data/experimental/map_and_batch_dataset_op.cc
+++ b/tensorflow/core/kernels/data/experimental/map_and_batch_dataset_op.cc
@@ -538,7 +538,7 @@ class MapAndBatchDatasetOp::Dataset : public DatasetBase {
         tf_shared_lock l(*mu_);  // mu_ == num_parallel_calls_->mu
         new_calls.reserve(num_parallel_calls_->value);
       }
-      auto busy = [this]() EXCLUSIVE_LOCKS_REQUIRED(*mu_) -> bool {
+      auto busy = [this]() TF_EXCLUSIVE_LOCKS_REQUIRED(*mu_) -> bool {
         int64 num_parallel_calls = num_parallel_calls_->value;
         return num_calls_ >= num_parallel_calls ||
                (static_cast<int64>(batch_results_.size()) >

--- a/tensorflow/core/kernels/data/experimental/map_and_batch_dataset_op.cc
+++ b/tensorflow/core/kernels/data/experimental/map_and_batch_dataset_op.cc
@@ -538,11 +538,13 @@ class MapAndBatchDatasetOp::Dataset : public DatasetBase {
         tf_shared_lock l(*mu_);  // mu_ == num_parallel_calls_->mu
         new_calls.reserve(num_parallel_calls_->value);
       }
-      auto busy = [this]() TF_EXCLUSIVE_LOCKS_REQUIRED(*mu_) -> bool {
+      auto busy = [this]() EXCLUSIVE_LOCKS_REQUIRED(*mu_) -> bool {
         int64 num_parallel_calls = num_parallel_calls_->value;
         return num_calls_ >= num_parallel_calls ||
-               (batch_results_.size() > max_batch_results_ ||
-                (batch_results_.size() == max_batch_results_ &&
+               (static_cast<int64>(batch_results_.size()) >
+                    max_batch_results_ ||
+                (static_cast<int64>(batch_results_.size()) ==
+                     max_batch_results_ &&
                  call_counter_ % dataset()->batch_size_ == 0));
       };
       while (true) {


### PR DESCRIPTION
When auto-tuning is active and the batch size is 1, fused map and batch schedules ctx->runner_threadpool_size() parallel applications of the map. For instance, on a DGX-1, 80 parallel calls of the map are invoked (vs. 2 for a batch size of 2), which can result in Out Of Memory Segfaults.

The cause of this behavior can be traced to the comparison in auto busy() of the unsigned int return value of batch_results_.size() to the signed integer max_batch_results_, which is -1 under these conditions. The proposed resolution casts the return value to a signed integer.