### PR TITLE
[WIP] Initial support for sparse labels on confusion-matrix metrics

### DIFF
--- a/tensorflow/python/keras/utils/metrics_utils.py
+++ b/tensorflow/python/keras/utils/metrics_utils.py
@@ -363,13 +363,16 @@ def update_confusion_matrix_variables(variables_to_update,
       y_pred, y_true, sample_weight = (
           losses_utils.squeeze_or_expand_dimensions(
               y_pred, y_true, sample_weight=sample_weight))
-  y_pred.shape.assert_is_compatible_with(y_true.shape)
 
   if top_k is not None:
     y_pred = _filter_top_k(y_pred, top_k)
   if class_id is not None:
-    y_true = y_true[..., class_id]
+    if y_true.shape.ndims == 1:
+      y_true = math_ops.equal(y_true, class_id)
+    else:
+      y_true = y_true[..., class_id]
     y_pred = y_pred[..., class_id]
+  y_pred.shape.assert_is_compatible_with(y_true.shape)
 
   pred_shape = array_ops.shape(y_pred)
   num_predictions = pred_shape[0]


### PR DESCRIPTION
This PR addresses https://github.com/tensorflow/tensorflow/issues/37104 by supporting sparse labels in confusion-matrix metrics (`Precision`, `Recall`, `SensitivityAtSpecificity`, `SpecificityAtSensitivity`, etc).

Currently, the implementation simply infers whether the `y_true` argument to `update_confusion_matrix_variables` is sparse (and only when passing `class_id`). However, I think I'd personally prefer something more explicit since this enables users to call metrics like

```
m = tf.keras.metrics.Precision(class_id=3)
m.update([3, 0, 0], [[0, 0, 0, 1], [1, 0, 0, 0], [0, 0, 1, 0]])
```

where `y_true` (first arg) and `y_pred` (second arg) have different dimensions (but the same length) which is something other metrics don't allow, to my knowledge.

Two ideas:
1. Pass an arg to the metric constructor to indicate that `y_true` is sparse like `tf.keras.metrics.Precision(class_id=3, sparse_labels=True)`
2. Create Sparse variants of metrics like `SparsePrecision`, `SparseRecall`, etc. This is the current pattern used for accuracy (`SparseCategoricalAccuracy`, `SparseCategoricalCrossentropy`, etc.)

I think I slightly prefer 1. as it is a little more lightweight compared to proliferating classes/test cases. However perhaps others don't think we need either of these options and can just simply infer whether the `y_true` argument is sparse as in the current iplementation.