### PR TITLE
Update python package description to include python 3.9

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -343,6 +343,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Scientific/Engineering',
         'Topic :: Scientific/Engineering :: Mathematics',


### PR DESCRIPTION
As tf-nightly have python 3.9 available, this PR updates
the python package description to include python 3.9 entry.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>