### PR TITLE
Fix xtensa_download.sh to appropriately return error string to Makefile.

### DIFF
--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa_download.sh
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa_download.sh
@@ -66,14 +66,14 @@ else
 
   unzip -qo /tmp/${TMP_ZIP_ARCHIVE_NAME} -d ${DOWNLOADS_DIR} >&2
 
-  pushd ${DOWNLOADS_DIR}/xa_nnlib_hifi4/
-  git init .
+  pushd ${DOWNLOADS_DIR}/xa_nnlib_hifi4/ >&2
+  git init . >&2
   git config user.email "tflm@google.com"
   git config user.name "TensorflowLite Micro"
   git add *
   git commit -a -m "Commit for a temporary repository." > /dev/null
   git apply ../../ext_libs/xtensa_patch.patch
-  popd
+  popd >&2
 
 fi
 


### PR DESCRIPTION
Since we call the script via the Makefile, we need to ensure that the only logs on stdout (when the script is successful) SUCCESS. Every other log should either be directed to /dev/null or to stderr.

Manually confirmed that the following two commands now succeed:
```
rm -rf tensorflow/lite/micro/tools/make/downloads/xa_nnlib_hifi4
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=fusion_f1 XTENSA_CORE=F1_190305_swupgrade run_keyword_benchmark -j8
```

Prior to this change, we would get the following error:
```
tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc:5: *** Something went wrong with the xtensa download: ~/github/tensorflow/tensorflow/lite/micro/tools/make/downloads/xa_nnlib_hifi4 ~/github/tensorflow Initialized empty Git repository in /home/advaitjain/github/tensorflow/tensorflow/lite/micro/tools/make/downloads/xa_nnlib_hifi4/.git/ ~/github/tensorflow SUCCESS.  Stop.
```

Also confirmed that:
```
tensorflow/lite/micro/tools/make/downloads/xa_nnlib_hifi4
```
is a git repo with uncommitted changes (i.e. the patch was properly applied).

The depthwise_conv kernel test is failing, likely because of https://github.com/tensorflow/tensorflow/pull/47950

```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=fusion_f1 XTENSA_CORE=F1_190305_swupgrade test_kernel_depthwise_conv_test -j8
```

gives:
```
Testing Int8Input32x1Filter32x1ShouldMatchGolden
tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc:338 required_scratch > 0 was not true.
kTfLiteOk == tflite::testing::ValidateDepthwiseConvGoldens( golden_quantized, output_elements, &conv_params, kQuantizationTolerance, kTensorsSize, tensors) failed at tensorflow/lite/micro/kernels/depthwise_conv_:936 (0 vs 1)
2/3 tests passed
~~~SOME TESTS FAILED~~~
```

Progress towards http://b/183497550