### PR TITLE
Added the Add* function for the missing Builtin operator Fill

### DIFF
--- a/tensorflow/lite/micro/micro_mutable_op_resolver.h
+++ b/tensorflow/lite/micro/micro_mutable_op_resolver.h
@@ -223,6 +223,11 @@ class MicroMutableOpResolver : public MicroOpResolver {
                       ParseExpandDims);
   }
 
+  TfLiteStatus AddFill() {
+    return AddBuiltin(BuiltinOperator_FILL,
+                      tflite::Register_FILL(), ParseFill);
+  }
+
   TfLiteStatus AddFloor() {
     return AddBuiltin(BuiltinOperator_FLOOR,
                       tflite::ops::micro::Register_FLOOR(), ParseFloor);


### PR DESCRIPTION
Fixes #48145

Added the Add* function for the missing Builtin operator Fill in TFLM. I can now consume Fill op in my Cortex-M micro-controller.