### PR TITLE
Keras: Remove leftover Python 2 compatibility code

### DIFF
--- a/tensorflow/python/keras/activations.py
+++ b/tensorflow/python/keras/activations.py
@@ -8,7 +8,7 @@
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY backendIND, either express or implied.
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================

--- a/tensorflow/python/keras/saving/save_test.py
+++ b/tensorflow/python/keras/saving/save_test.py
@@ -16,8 +16,8 @@
 
 import collections
 import os
+import pathlib
 import shutil
-import sys
 import tempfile
 import warnings
 
@@ -54,8 +54,6 @@ from tensorflow.python.saved_model import loader_impl
 from tensorflow.python.training import training as training_module
 
 
-if sys.version_info >= (3, 6):
-  import pathlib  # pylint:disable=g-import-not-at-top
 try:
   import h5py  # pylint:disable=g-import-not-at-top
 except ImportError:
@@ -86,8 +84,6 @@ class TestSaveModel(test.TestCase, parameterized.TestCase):
 
   @testing_utils.run_v2_only
   def test_save_format_defaults_pathlib(self):
-    if sys.version_info < (3, 6):
-      self.skipTest('pathlib is only available for python version >= 3.6')
     path = pathlib.Path(self.get_temp_dir()) / 'model_path'
     save.save_model(self.model, path)
     self.assert_saved_model(path)
@@ -104,8 +100,6 @@ class TestSaveModel(test.TestCase, parameterized.TestCase):
 
   @testing_utils.run_v2_only
   def test_save_load_hdf5_pathlib(self):
-    if sys.version_info < (3, 6):
-      self.skipTest('pathlib is only available for python version >= 3.6')
     path = pathlib.Path(self.get_temp_dir()) / 'model'
     save.save_model(self.model, path, save_format='h5')
     save.load_model(path)
@@ -129,24 +123,18 @@ class TestSaveModel(test.TestCase, parameterized.TestCase):
 
   @testing_utils.run_v2_only
   def test_save_load_tf_pathlib(self):
-    if sys.version_info < (3, 6):
-      self.skipTest('pathlib is only available for python version >= 3.6')
     path = pathlib.Path(self.get_temp_dir()) / 'model'
     save.save_model(self.model, path, save_format='tf')
     save.load_model(path)
 
   @testing_utils.run_v2_only
   def test_save_load_weights_tf_pathlib(self):
-    if sys.version_info < (3, 6):
-      self.skipTest('pathlib is only available for python version >= 3.6')
     path = pathlib.Path(self.get_temp_dir()) / 'model'
     self.model.save_weights(path, save_format='tf')
     self.model.load_weights(path)
 
   @testing_utils.run_v2_only
   def test_save_load_weights_hdf5_pathlib(self):
-    if sys.version_info < (3, 6):
-      self.skipTest('pathlib is only available for python version >= 3.6')
     path = pathlib.Path(self.get_temp_dir()) / 'model'
     self.model.save_weights(path, save_format='h5')
     self.model.load_weights(path)

--- a/tensorflow/python/keras/utils/data_utils.py
+++ b/tensorflow/python/keras/utils/data_utils.py
@@ -44,6 +44,7 @@ from tensorflow.python.keras.utils.generic_utils import Progbar
 from tensorflow.python.keras.utils.io_utils import path_to_string
 from tensorflow.python.util.tf_export import keras_export
 
+# Required to support google internal urlretrieve
 if sys.version_info[0] == 2:
 
   def urlretrieve(url, filename, reporthook=None, data=None):

--- a/tensorflow/python/keras/utils/io_utils.py
+++ b/tensorflow/python/keras/utils/io_utils.py
@@ -16,36 +16,13 @@
 """Utilities related to disk I/O."""
 
 import os
-import sys
-
-if sys.version_info >= (3, 6):
-
-  def _path_to_string(path):
-    if isinstance(path, os.PathLike):
-      return os.fspath(path)
-    return path
-elif sys.version_info >= (3, 4):
-
-  def _path_to_string(path):
-    import pathlib
-    if isinstance(path, pathlib.Path):
-      return str(path)
-    return path
-else:
-
-  def _path_to_string(path):
-    return path
 
 
 def path_to_string(path):
   """Convert `PathLike` objects to their string representation.
 
   If given a non-string typed path object, converts it to its string
-  representation. Depending on the python version used, this function
-  can handle the following arguments:
-  python >= 3.6: Everything supporting the fs path protocol
-    https://www.python.org/dev/peps/pep-0519
-  python >= 3.4: Only `pathlib.Path` objects
+  representation.
 
   If the object passed to `path` is not among the above, then it is
   returned unchanged. This allows e.g. passthrough of file objects
@@ -57,7 +34,9 @@ def path_to_string(path):
   Returns:
     A string representation of the path argument, if Python support exists.
   """
-  return _path_to_string(path)
+  if isinstance(path, os.PathLike):
+    return os.fspath(path)
+  return path
 
 
 def ask_to_proceed_with_overwrite(filepath):

--- a/tensorflow/python/keras/utils/io_utils_test.py
+++ b/tensorflow/python/keras/utils/io_utils_test.py
@@ -15,7 +15,7 @@
 """Tests for io_utils."""
 
 import builtins
-import sys
+from pathlib import Path
 
 from tensorflow.python.keras import keras_parameterized
 from tensorflow.python.keras.utils import io_utils
@@ -48,12 +48,9 @@ class TestIOUtils(keras_parameterized.TestCase):
         return 'dummypath'
 
     dummy = object()
-    if sys.version_info >= (3, 4):
-      from pathlib import Path  # pylint:disable=g-import-not-at-top
-      # conversion of PathLike
-      self.assertEqual(io_utils.path_to_string(Path('path')), 'path')
-    if sys.version_info >= (3, 6):
-      self.assertEqual(io_utils.path_to_string(PathLikeDummy()), 'dummypath')
+    # conversion of PathLike
+    self.assertEqual(io_utils.path_to_string(Path('path')), 'path')
+    self.assertEqual(io_utils.path_to_string(PathLikeDummy()), 'dummypath')
 
     # pass-through, works for all versions of python
     self.assertEqual(io_utils.path_to_string('path'), 'path')


### PR DESCRIPTION
This PR removes some leftover Python 2 compatibility code from Keras since the minimal Python version is now 3.6.