### PR TITLE
Fix the spawning of subprocess on windows displaying a console window 

### DIFF
--- a/tensorflow/core/platform/windows/subprocess.cc
+++ b/tensorflow/core/platform/windows/subprocess.cc
@@ -271,7 +271,7 @@ bool SubProcess::Start() {
   // Execute the child program.
   bool bSuccess =
       CreateProcessA(nullptr, const_cast<char*>(command_line.c_str()), nullptr,
-                     nullptr, TRUE, 0, nullptr, nullptr, &si,
+                     nullptr, TRUE, CREATE_NO_WINDOW, nullptr, nullptr, &si,
                      reinterpret_cast<PROCESS_INFORMATION*>(win_pi_));
 
   if (bSuccess) {


### PR DESCRIPTION
Make it so that when running on the Windows platform the creation of a subprocess does not spawn a new console window. 
Closes https://github.com/tensorflow/tensorflow/issues/46854