### PR TITLE
Micro transpose op ported and tested for TFLM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ node_modules
 __pycache__
 *.swp
 .vscode/
+venv/
 cmake_build/
 tensorflow/contrib/cmake/_build/
 .idea/**

--- a/tensorflow/lite/core/api/flatbuffer_conversions.cc
+++ b/tensorflow/lite/core/api/flatbuffer_conversions.cc
@@ -475,7 +475,7 @@ TfLiteStatus ParseOpDataTfLite(const Operator* op, BuiltinOperator op_type,
     }
 
     case BuiltinOperator_TRANSPOSE: {
-      return ParseTranspose(op, op_type, error_reporter, allocator, builtin_data);
+      return ParseTranspose(op, error_reporter, allocator, builtin_data);
     }
 
     case BuiltinOperator_TRANSPOSE_CONV: {
@@ -2062,7 +2062,7 @@ TfLiteStatus ParseTanh(const Operator*, ErrorReporter*, BuiltinDataAllocator*,
 // We have this parse function instead of directly returning kTfLiteOk from the
 // switch-case in ParseOpData because this function is used as part of the
 // selective registration for the OpResolver implementation in micro.
-TfLiteStatus ParseTranspose(const Operator* op, BuiltinOperator op_type,
+TfLiteStatus ParseTranspose(const Operator* op,
                             ErrorReporter* error_reporter,
                             BuiltinDataAllocator* allocator,
                             void** builtin_data) {

--- a/tensorflow/lite/core/api/flatbuffer_conversions.cc
+++ b/tensorflow/lite/core/api/flatbuffer_conversions.cc
@@ -474,6 +474,10 @@ TfLiteStatus ParseOpDataTfLite(const Operator* op, BuiltinOperator op_type,
       return ParseTanh(op, error_reporter, allocator, builtin_data);
     }
 
+    case BuiltinOperator_TRANSPOSE: {
+      return ParseTranspose(op, op_type, error_reporter, allocator, builtin_data);
+    }
+
     case BuiltinOperator_TRANSPOSE_CONV: {
       return ParseTransposeConv(op, error_reporter, allocator, builtin_data);
     }
@@ -806,7 +810,6 @@ TfLiteStatus ParseOpDataTfLite(const Operator* op, BuiltinOperator op_type,
     case BuiltinOperator_SLICE:
     case BuiltinOperator_TILE:
     case BuiltinOperator_TOPK_V2:
-    case BuiltinOperator_TRANSPOSE:
     case BuiltinOperator_RANGE:
     case BuiltinOperator_SQUARED_DIFFERENCE:
     case BuiltinOperator_REVERSE_V2:
@@ -2059,8 +2062,10 @@ TfLiteStatus ParseTanh(const Operator*, ErrorReporter*, BuiltinDataAllocator*,
 // We have this parse function instead of directly returning kTfLiteOk from the
 // switch-case in ParseOpData because this function is used as part of the
 // selective registration for the OpResolver implementation in micro.
-TfLiteStatus ParseTranspose(const Operator*, ErrorReporter*,
-                            BuiltinDataAllocator*, void**) {
+TfLiteStatus ParseTranspose(const Operator* op, BuiltinOperator op_type,
+                            ErrorReporter* error_reporter,
+                            BuiltinDataAllocator* allocator,
+                            void** builtin_data) {
   return kTfLiteOk;
 }
 

--- a/tensorflow/lite/core/api/flatbuffer_conversions.h
+++ b/tensorflow/lite/core/api/flatbuffer_conversions.h
@@ -334,9 +334,10 @@ TfLiteStatus ParseSvdf(const Operator* op, ErrorReporter* error_reporter,
 TfLiteStatus ParseTanh(const Operator* op, ErrorReporter* error_reporter,
                        BuiltinDataAllocator* allocator, void** builtin_data);
 
-TfLiteStatus ParseTranspose(const Operator* op, ErrorReporter* error_reporter,
-                            BuiltinDataAllocator* allocator,
-                            void** builtin_data);
+TfLiteStatus ParseTranspose(const Operator* op, BuiltinOperator op_type,
+                            ErrorReporter* error_reporter,
+					        BuiltinDataAllocator* allocator,
+							void** builtin_data);
 
 TfLiteStatus ParseTransposeConv(const Operator* op,
                                 ErrorReporter* error_reporter,

--- a/tensorflow/lite/core/api/flatbuffer_conversions.h
+++ b/tensorflow/lite/core/api/flatbuffer_conversions.h
@@ -334,7 +334,7 @@ TfLiteStatus ParseSvdf(const Operator* op, ErrorReporter* error_reporter,
 TfLiteStatus ParseTanh(const Operator* op, ErrorReporter* error_reporter,
                        BuiltinDataAllocator* allocator, void** builtin_data);
 
-TfLiteStatus ParseTranspose(const Operator* op, BuiltinOperator op_type,
+TfLiteStatus ParseTranspose(const Operator* op,
                             ErrorReporter* error_reporter,
 					        BuiltinDataAllocator* allocator,
 							void** builtin_data);

--- a/tensorflow/lite/micro/all_ops_resolver.cc
+++ b/tensorflow/lite/micro/all_ops_resolver.cc
@@ -86,6 +86,7 @@ AllOpsResolver::AllOpsResolver() {
   AddSub();
   AddSvdf();
   AddTanh();
+  AddTranspose();
   AddTransposeConv();
   AddUnpack();
 }

--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -302,6 +302,7 @@ cc_library(
         "sub.cc",
         "svdf_common.cc",
         "tanh.cc",
+        "transpose.cc",
         "transpose_conv.cc",
         "unpack.cc",
         "zeros_like.cc",
@@ -322,6 +323,7 @@ cc_library(
         "quantize.h",
         "softmax.h",
         "svdf.h",
+        "kernel_utils.h",
     ],
     copts = micro_copts(),
     visibility = [
@@ -1085,6 +1087,19 @@ cc_test(
         ":kernel_runner",
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/micro:test_helpers",
+        "//tensorflow/lite/micro/testing:micro_test",
+    ],
+)
+
+cc_test(
+    name = "transpose_test",
+    srcs = [
+        "transpose_test.cc"
+    ],
+    deps = [
+        "//tensorflow/lite/c:common",
+        "//tensorflow/lite/micro:micro_framework",
+        "//tensorflow/lite/micro:op_resolvers",
         "//tensorflow/lite/micro/testing:micro_test",
     ],
 )

--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -323,7 +323,6 @@ cc_library(
         "quantize.h",
         "softmax.h",
         "svdf.h",
-        "kernel_utils.h",
     ],
     copts = micro_copts(),
     visibility = [

--- a/tensorflow/lite/micro/kernels/micro_ops.h
+++ b/tensorflow/lite/micro/kernels/micro_ops.h
@@ -106,6 +106,7 @@ TfLiteRegistration Register_SUB();
 TfLiteRegistration Register_UNPACK();
 TfLiteRegistration Register_L2_NORMALIZATION();
 TfLiteRegistration Register_TANH();
+TfLiteRegistration* Register_TRANSPOSE();
 
 }  // namespace micro
 }  // namespace ops

--- a/tensorflow/lite/micro/kernels/micro_ops.h
+++ b/tensorflow/lite/micro/kernels/micro_ops.h
@@ -49,6 +49,7 @@ TfLiteRegistration Register_SOFTMAX();
 TfLiteRegistration Register_SPACE_TO_BATCH_ND();
 TfLiteRegistration Register_SQUEEZE();
 TfLiteRegistration Register_SVDF();
+TfLiteRegistration Register_TRANSPOSE();
 TfLiteRegistration Register_TRANSPOSE_CONV();
 TfLiteRegistration Register_ZEROS_LIKE();
 
@@ -106,7 +107,6 @@ TfLiteRegistration Register_SUB();
 TfLiteRegistration Register_UNPACK();
 TfLiteRegistration Register_L2_NORMALIZATION();
 TfLiteRegistration Register_TANH();
-TfLiteRegistration Register_TRANSPOSE();
 
 }  // namespace micro
 }  // namespace ops

--- a/tensorflow/lite/micro/kernels/micro_ops.h
+++ b/tensorflow/lite/micro/kernels/micro_ops.h
@@ -106,7 +106,7 @@ TfLiteRegistration Register_SUB();
 TfLiteRegistration Register_UNPACK();
 TfLiteRegistration Register_L2_NORMALIZATION();
 TfLiteRegistration Register_TANH();
-TfLiteRegistration* Register_TRANSPOSE();
+TfLiteRegistration Register_TRANSPOSE();
 
 }  // namespace micro
 }  // namespace ops

--- a/tensorflow/lite/micro/kernels/transpose.cc
+++ b/tensorflow/lite/micro/kernels/transpose.cc
@@ -23,9 +23,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/reference/transpose.h"
 
 namespace tflite {
-namespace ops {
-namespace micro {
-namespace transpose {
+namespace {
 
 constexpr int kInputTensor = 0;
 constexpr int kPermTensor = 1;
@@ -115,14 +113,12 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
 TfLiteRegistration Register_TRANSPOSE() {
   return {/*init=*/nullptr,
           /*free=*/nullptr,
-          /*prepare=*/transpose::Prepare,
-          /*invoke=*/transpose::Eval,
+          /*prepare=*/Prepare,
+          /*invoke=*/Eval,
           /*profiling_string=*/nullptr,
           /*builtin_code=*/0,
           /*custom_name=*/nullptr,
           /*version=*/2};
 }
 
-} // namespace micro
-} // namespace ops
 } // namespace tflite

--- a/tensorflow/lite/micro/kernels/transpose.cc
+++ b/tensorflow/lite/micro/kernels/transpose.cc
@@ -120,7 +120,7 @@ TfLiteRegistration Register_TRANSPOSE() {
           /*profiling_string=*/nullptr,
           /*builtin_code=*/0,
           /*custom_name=*/nullptr,
-          /*version=*/0};
+          /*version=*/2};
 }
 
 } // namespace micro

--- a/tensorflow/lite/micro/kernels/transpose.cc
+++ b/tensorflow/lite/micro/kernels/transpose.cc
@@ -12,140 +12,91 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-#include <stdint.h>
 
+#include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/kernels/internal/compatibility.h"
-#include "tensorflow/lite/kernels/internal/optimized/optimized_ops.h"
-#include "tensorflow/lite/kernels/internal/reference/reference_ops.h"
-#include "tensorflow/lite/kernels/internal/tensor.h"
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
-#include "tensorflow/lite/kernels/internal/types.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/kernels/op_macros.h"
+#include "tensorflow/lite/micro/memory_helpers.h"
+#include "tensorflow/lite/micro/micro_utils.h"
+#include "tensorflow/lite/kernels/internal/reference/transpose.h"
 
 namespace tflite {
 namespace ops {
-namespace builtin {
+namespace micro {
 namespace transpose {
 
-// This file has two implementations of Transpose.
-enum KernelType {
-  kReference,
-  kGenericOptimized,
-};
+constexpr int kInputTensor = 0;
+constexpr int kPermTensor = 1;
+constexpr int kOutputTensor = 0;
 
 struct TransposeContext {
-  TransposeContext(TfLiteContext* context, TfLiteNode* node) {
-    input = GetInput(context, node, 0);
-    perm = GetInput(context, node, 1);
-    output = GetOutput(context, node, 0);
-  }
-  const TfLiteTensor* input;
-  const TfLiteTensor* perm;
-  TfLiteTensor* output;
+    TransposeContext(TfLiteContext* context, TfLiteNode* node) {
+        input = GetInput(context, node, kInputTensor);
+        perm = GetInput(context, node, kPermTensor);
+        output = GetOutput(context, node, kOutputTensor);
+    }
+    const TfLiteTensor* input;
+    const TfLiteTensor* perm;
+    TfLiteTensor* output;
 };
 
-TfLiteStatus ResizeOutputTensor(TfLiteContext* context,
-                                TransposeContext* op_context) {
-  int dims = NumDimensions(op_context->input);
-  const int* perm_data = GetTensorData<int32_t>(op_context->perm);
-
-  // Ensure validity of the permutations tensor as a 1D tensor.
-  TF_LITE_ENSURE_EQ(context, NumDimensions(op_context->perm), 1);
-  TF_LITE_ENSURE_EQ(context, op_context->perm->dims->data[0], dims);
-  for (int idx = 0; idx < dims; ++idx) {
-    TF_LITE_ENSURE_MSG(context, (perm_data[idx] >= 0 && perm_data[idx] < dims),
-                       "Transpose op permutations array is out of bounds.");
-  }
-
-  // Determine size of output tensor.
-  TfLiteIntArray* input_size = op_context->input->dims;
-  TfLiteIntArray* output_size = TfLiteIntArrayCopy(input_size);
-  for (int idx = 0; idx < dims; ++idx) {
-    output_size->data[idx] = input_size->data[perm_data[idx]];
-  }
-
-  return context->ResizeTensor(context, op_context->output, output_size);
-}
-
 TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
-  TF_LITE_ENSURE_EQ(context, NumInputs(node), 2);
-  TF_LITE_ENSURE_EQ(context, NumOutputs(node), 1);
+    TF_LITE_ENSURE_EQ(context, NumInputs(node), 2);
+    TF_LITE_ENSURE_EQ(context, NumOutputs(node), 1);
 
-  TransposeContext op_context(context, node);
+    TransposeContext op_context(context, node);
 
-  // Ensure validity of input tensor.
-  TF_LITE_ENSURE_MSG(context, NumDimensions(op_context.input) <= 5,
-                     "Transpose op only supports 1D-5D input arrays.");
-  TF_LITE_ENSURE_TYPES_EQ(context, op_context.input->type,
-                          op_context.output->type);
+    // Ensure validity of input tensor.
+    TF_LITE_ENSURE_MSG(context, NumDimensions(op_context.input) <= 5,
+                        "Transpose op only supports 1D-5D input arrays.");
+    TF_LITE_ENSURE_TYPES_EQ(context, op_context.input->type,
+                            op_context.output->type);
 
-  if (!IsConstantTensor(op_context.perm)) {
-    SetTensorToDynamic(op_context.output);
     return kTfLiteOk;
-  }
-  return ResizeOutputTensor(context, &op_context);
 }
 
-template <KernelType kernel_type>
 TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   TransposeContext op_context(context, node);
 
-  // Resize the output tensor if the output tensor is dynamic.
-  if (IsDynamicTensor(op_context.output)) {
-    TF_LITE_ENSURE_OK(context, ResizeOutputTensor(context, &op_context));
-  }
+  // Retrieve the perm permutation array
+  const int32_t* perm_data = GetTensorData<int32_t>(op_context.perm);
 
-  const int* perm_data = GetTensorData<int32_t>(op_context.perm);
+  // Determine the number of dimensions in the perm array
   const int size = op_context.perm->dims->data[0];
+
+  // Prepare an params object to store the perm data whilst implementing
+  // the conversion 
   TransposeParams params;
   params.perm_count = size;
   for (int i = 0; i < size; ++i) {
     params.perm[i] = perm_data[i];
   }
 
-#define TF_LITE_TRANSPOSE(type, scalar)                     \
-  type::Transpose(params, GetTensorShape(op_context.input), \
+  // Helper operation to acquire and convert data types
+#define TF_LITE_TRANSPOSE(scalar)                     \
+  reference_ops::Transpose(params, GetTensorShape(op_context.input), \
                   GetTensorData<scalar>(op_context.input),  \
                   GetTensorShape(op_context.output),        \
                   GetTensorData<scalar>(op_context.output))
 
-  // Transpose kernel only does rearranging values not numeric evaluations on
-  // each cell. It's safe to implement per size of scalar type and this trick
-  // keeps the total code size in a reasonable range.
+  // Transpose really operates at the byte level,
+  // and therefore we only really need to get the 
+  // size of the scalar datatype in bytes.
+  // Using this we can simplify the calls
+  // to only use a small number of data types
   switch (op_context.input->type) {
     case kTfLiteFloat32:
     case kTfLiteInt32:
-      if (kernel_type == kGenericOptimized) {
-        TF_LITE_TRANSPOSE(optimized_ops, int32_t);
-      } else {
-        TF_LITE_TRANSPOSE(reference_ops, int32_t);
-      }
+      TF_LITE_TRANSPOSE(int32_t);
       break;
-    case kTfLiteUInt8:
     case kTfLiteInt8:
-      if (kernel_type == kGenericOptimized) {
-        TF_LITE_TRANSPOSE(optimized_ops, int8_t);
-      } else {
-        TF_LITE_TRANSPOSE(reference_ops, int8_t);
-      }
+    case kTfLiteUInt8:
+      TF_LITE_TRANSPOSE(int8_t);
       break;
     case kTfLiteInt16:
-      TF_LITE_TRANSPOSE(reference_ops, int16_t);
-      break;
-    case kTfLiteInt64:
-      TF_LITE_TRANSPOSE(reference_ops, int64_t);
-      break;
-    case kTfLiteBool:
-      if (sizeof(bool) == 1) {
-        if (kernel_type == kGenericOptimized) {
-          TF_LITE_TRANSPOSE(optimized_ops, int8_t);
-        } else {
-          TF_LITE_TRANSPOSE(reference_ops, int8_t);
-        }
-      } else {
-        TF_LITE_TRANSPOSE(reference_ops, bool);
-      }
+      TF_LITE_TRANSPOSE(int16_t);
       break;
     default:
       TF_LITE_KERNEL_LOG(context,
@@ -153,29 +104,25 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
                          TfLiteTypeGetName(op_context.input->type));
       return kTfLiteError;
   }
+
 #undef TF_LITE_TRANSPOSE
 
   return kTfLiteOk;
 }
 
-}  // namespace transpose
+} // namespace transpose
 
-TfLiteRegistration* Register_TRANSPOSE_REF() {
-  static TfLiteRegistration r = {nullptr, nullptr, transpose::Prepare,
-                                 transpose::Eval<transpose::kReference>};
-  return &r;
+TfLiteRegistration Register_TRANSPOSE() {
+  return {/*init=*/nullptr,
+          /*free=*/nullptr,
+          /*prepare=*/transpose::Prepare,
+          /*invoke=*/transpose::Eval,
+          /*profiling_string=*/nullptr,
+          /*builtin_code=*/0,
+          /*custom_name=*/nullptr,
+          /*version=*/0};
 }
 
-TfLiteRegistration* Register_TRANSPOSE_GENERIC_OPTIMIZED() {
-  static TfLiteRegistration r = {nullptr, nullptr, transpose::Prepare,
-                                 transpose::Eval<transpose::kGenericOptimized>};
-  return &r;
-}
-
-TfLiteRegistration* Register_TRANSPOSE() {
-  return Register_TRANSPOSE_GENERIC_OPTIMIZED();
-}
-
-}  // namespace builtin
-}  // namespace ops
-}  // namespace tflite
+} // namespace micro
+} // namespace ops
+} // namespace tflite

--- a/tensorflow/lite/micro/kernels/transpose_test.cc
+++ b/tensorflow/lite/micro/kernels/transpose_test.cc
@@ -19,7 +19,6 @@ limitations under the License.
 #include "tensorflow/lite/micro/micro_utils.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"
-#include "tensorflow/lite/micro/testing/test_utils.h"
 #include "tensorflow/lite/kernels/internal/reference/transpose.h"
 
 namespace tflite {

--- a/tensorflow/lite/micro/kernels/transpose_test.cc
+++ b/tensorflow/lite/micro/kernels/transpose_test.cc
@@ -1,0 +1,537 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include <stdint.h>
+
+#include <initializer_list>
+#include <vector>
+
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/micro/micro_utils.h"
+#include "tensorflow/lite/micro/test_helpers.h"
+#include "tensorflow/lite/micro/testing/micro_test.h"
+#include "tensorflow/lite/micro/testing/test_utils.h"
+#include "tensorflow/lite/kernels/internal/reference/transpose.h"
+
+namespace tflite {
+namespace testing {
+namespace {
+
+// template <typename T = float>
+// void ValidateTransposeGoldens(TfLiteTensor* tensors, int tensors_size, TfLiteIntArray* inputs_array,
+//     TfLiteIntArray* outputs_array, const T* expected_output,
+//     const size_t expected_output_len, const int* expected_dims,
+//     const size_t expected_dims_len, bool expect_failure) {
+
+//   const TfLiteRegistration registration =
+//       tflite::ops::micro::Register_TRANSPOSE();
+
+//   micro::KernelRunner runner(registration, tensors, tensors_size, inputs_array,
+//                              outputs_array,
+//                              /*builtin_data=*/nullptr, micro_test::reporter);
+
+//   if (expect_failure) {
+//     TF_LITE_MICRO_EXPECT_NE(kTfLiteOk, runner.InitAndPrepare());
+//     return;
+//   }
+
+//   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, runner.InitAndPrepare());
+//   TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, runner.Invoke());
+
+//   TfLiteTensor* output_tensor = &tensors[outputs_array->data[0]];
+//   const T* output_data = GetTensorData<T>(output_tensor);
+//   for (size_t i = 0; i < expected_output_len; ++i) {
+//     TF_LITE_MICRO_EXPECT_NEAR(expected_output[i], output_data[i], 1e-5f);
+//   }
+//   TF_LITE_MICRO_EXPECT_EQ(expected_dims_len,
+//                           static_cast<size_t>(output_tensor->dims->size));
+//   for (size_t i = 0; i < expected_dims_len; ++i) {
+//     TF_LITE_MICRO_EXPECT_EQ(expected_dims[i], output_tensor->dims->data[i]);
+//   }
+// }
+
+// template <typename T = float>
+// void TestTransposeWithShape(TfLiteTensor* input_tensor, 
+//                     TfLiteTensor* perm_tensor, 
+//                     TfLiteTensor* output_tensor, 
+//                     const T* expected_output,
+//                     const size_t expected_output_len,
+//                     const int* expected_dims,
+//                     const size_t expected_dims_len, 
+//                     bool expect_failure) {
+
+//   constexpr int inputs_size = 2;
+//   constexpr int outputs_size = 1;
+//   constexpr int tensors_size = inputs_size + outputs_size;
+//   TfLiteTensor tensors[tensors_size];
+//   tensors[0] = *input_tensor;
+//   tensors[1] = *perm_tensor;
+//   tensors[2] = *output_tensor;
+
+//   int inputs_data[] = {2, 0, 1};
+//   TfLiteIntArray* inputs_array = IntArrayFromInts(inputs_data);
+//   int outputs_data[] = {1, 2};
+//   TfLiteIntArray* outputs_array = IntArrayFromInts(outputs_data);
+
+//   ValidateTransposeGoldens(tensors, tensors_size, 
+//                         inputs_array, outputs_array,
+//                         expected_output, expected_output_len, 
+//                         expected_dims, expected_dims_len, 
+//                         expect_failure);
+
+// }
+
+// template <typename T = float, TfLiteType tensor_type = kTfLiteFloat32>
+// void TestTranspose(const int* input_dims_data, const T* input_data,
+//                    const int* perm_dims_data, const int32_t* perm_data,
+//                    int* output_dims_data, T* output_data,
+//                    const T* expected_output, const size_t expected_output_len,
+//                    const int* expected_dims, const size_t expected_dims_len,
+//                    bool expect_failure = false) {
+
+//   TfLiteIntArray* input_dims = IntArrayFromInts(input_dims_data);
+//   TfLiteIntArray* perm_dims = IntArrayFromInts(perm_dims_data);
+//   TfLiteIntArray* output_dims = IntArrayFromInts(output_dims_data);
+
+//   TfLiteTensor input_tensor =
+//       CreateTensor<T, tensor_type>(input_data, input_dims);
+//   TfLiteTensor perm_tensor =
+//       CreateTensor<int32_t, kTfLiteInt32>(perm_data, perm_dims);
+//   TfLiteTensor output_tensor =
+//       CreateTensor<T, tensor_type>(output_data, output_dims);
+
+//   TestTransposeWithShape(&input_tensor, &perm_tensor, &output_tensor,
+//                           expected_output, expected_output_len, expected_dims,
+//                           expected_dims_len, expect_failure);
+// }
+
+template <typename T>
+inline RuntimeShape GetTensorShape(std::vector<T> data) {
+  return RuntimeShape(data.size(), data.data());
+}
+
+template <typename T>
+void RunTestPermutation(const std::vector<int>& shape,
+                        const std::vector<int>& perms,
+                        std::vector<T>* input_transposed) {
+  // Count elements and allocate output.
+  int count = 1;
+  for (auto factor : shape) count *= factor;
+  input_transposed->resize(count);
+
+  // Create the dummy data
+  std::vector<T> input(count);
+  for (unsigned int i = 0; i < input.size(); i++) {
+    input[i] = i;
+  }
+
+  // Make input and output shapes.
+  const RuntimeShape input_shape = GetTensorShape(shape);
+  RuntimeShape output_shape(perms.size());
+  for (unsigned int i = 0; i < perms.size(); i++) {
+    output_shape.SetDim(i, input_shape.Dims(perms[i]));
+  }
+
+  TransposeParams params;
+  params.perm_count = perms.size();
+  for (unsigned int i = 0; i < perms.size(); ++i) {
+    params.perm[i] = perms[i];
+  }
+
+  tflite::reference_ops::Transpose<T>(params, 
+      input_shape, input.data(), 
+      output_shape, input_transposed->data());
+}
+
+}  // namespace
+}  // namespace testing
+}  // namespace tflite
+
+#define TF_LITE_MICRO_ARRAY_COMP_EQ(_a,_b)              \
+    {                                                   \
+      TF_LITE_MICRO_EXPECT_EQ(_a.size(),_b.size());     \
+      for (unsigned int _e = 0; _e < _a.size(); _e++) { \
+        TF_LITE_MICRO_EXPECT_EQ(_a[_e], _b[_e]);        \
+      }                                                 \
+    }
+
+#define TF_LITE_MICRO_ARRAY_COMP_NE(_a,_b)              \
+    {                                                   \
+      bool size_eq = _a.size() == _b.size();            \
+      bool cont_eq = true;                              \
+      if (size_eq) {                                    \
+        for (unsigned int _e = 0; _e < _a.size(); _e++) \
+          cont_eq &= _a[_e] == _b[_e];                  \
+      }                                                 \
+      if (size_eq & cont_eq) {                          \
+        TF_LITE_MICRO_FAIL("Arrays are equal");         \
+      }                                                 \
+    }
+
+template <typename T>
+void TransposeTestTestRefOps1D() {
+  // Basic 1D identity.
+  std::vector<T> out;
+  tflite::testing::RunTestPermutation<T>({3}, {0}, &out);
+  std::vector<T> expected({0, 1, 2});
+
+  TF_LITE_MICRO_ARRAY_COMP_EQ(out, expected);
+}
+
+template <typename T>
+void TransposeTestTestRefOps2D() {
+  std::vector<T> out;
+  // Basic 2D.
+  tflite::testing::RunTestPermutation<T>({3, 2}, {1, 0}, &out);
+  TF_LITE_MICRO_ARRAY_COMP_EQ(out, std::vector<T>({0, 2, 4, 1, 3, 5}));
+  // Identity.
+  tflite::testing::RunTestPermutation<T>({3, 2}, {0, 1}, &out);
+  TF_LITE_MICRO_ARRAY_COMP_EQ(out, std::vector<T>({0, 1, 2, 3, 4, 5}));
+}
+
+template <typename T>
+void TransposeTestTestRefOps3D() {
+  std::vector<T> out;    
+  {
+    std::vector<T> ref({0, 4, 8,  12, 16, 20, 1, 5, 9,  13, 17, 21,
+                          2, 6, 10, 14, 18, 22, 3, 7, 11, 15, 19, 23});
+    tflite::testing::RunTestPermutation<T>(/*shape=*/{2, 3, 4}, /*perms=*/{2, 0, 1}, &out);  
+    TF_LITE_MICRO_ARRAY_COMP_EQ(out, ref);
+  }
+
+  // Test 3 dimensional identity transform
+  {
+    tflite::testing::RunTestPermutation<T>(/*shape=*/{2, 3, 4}, /*perms=*/{0, 1, 2}, &out);
+    std::vector<T> ref(out.size());
+    for (unsigned int k = 0; k < ref.size(); k++) ref[k] = k;
+    TF_LITE_MICRO_ARRAY_COMP_EQ(out, ref);
+  }
+
+  /**
+   * Additional tests that mimic first case, but with different perm.
+   */
+  {
+    std::vector<T> ref({0, 12, 1, 13, 2, 14, 3, 15, 4,  16, 5,  17,
+                            6, 18, 7, 19, 8, 20, 9, 21, 10, 22, 11, 23});
+    tflite::testing::RunTestPermutation<T>(/*shape=*/{2, 3, 4}, /*perms=*/{1, 2, 0}, &out);
+    TF_LITE_MICRO_ARRAY_COMP_EQ(out, ref);
+  }
+
+  {
+    std::vector<T> ref({0,  4,  8,  1,  5,  9,  2,  6,  10, 3,  7,  11,
+                            12, 16, 20, 13, 17, 21, 14, 18, 22, 15, 19, 23});
+    tflite::testing::RunTestPermutation<T>(/*shape=*/{2, 3, 4}, /*perms=*/{0, 2, 1}, &out);
+    TF_LITE_MICRO_ARRAY_COMP_EQ(out, ref);
+  }
+
+  {
+    std::vector<T> ref({0,  1,  2,  3,  12, 13, 14, 15, 4,  5,  6,  7,
+                            16, 17, 18, 19, 8,  9,  10, 11, 20, 21, 22, 23});
+    tflite::testing::RunTestPermutation<T>(/*shape=*/{2, 3, 4}, /*perms=*/{1, 0, 2}, &out);
+    TF_LITE_MICRO_ARRAY_COMP_EQ(out, ref);
+  }
+
+  {
+    std::vector<T> ref({0, 12, 4, 16, 8,  20, 1, 13, 5, 17, 9,  21,
+                            2, 14, 6, 18, 10, 22, 3, 15, 7, 19, 11, 23});
+    tflite::testing::RunTestPermutation<T>(/*shape=*/{2, 3, 4}, /*perms=*/{2, 1, 0}, &out);
+    TF_LITE_MICRO_ARRAY_COMP_EQ(out, ref);
+  }
+}
+
+template <typename T>
+void TransposeTestTestRefOps3D_OneInDimension() {
+  std::vector<T> out;
+  // Shape with 1 as first dim -> transposed.
+  {
+    std::vector<T> ref({0, 3, 1, 4, 2, 5});
+    tflite::testing::RunTestPermutation<T>(/*shape=*/{1, 2, 3}, /*perms=*/{2, 0, 1}, &out);
+    TF_LITE_MICRO_ARRAY_COMP_EQ(out, ref);
+  }
+  // Shape with 1 as first dim -> identity.
+  {
+    std::vector<T> ref({0, 1, 2, 3, 4, 5});
+    tflite::testing::RunTestPermutation<T>(/*shape=*/{1, 2, 3}, /*perms=*/{1, 2, 0}, &out);
+    TF_LITE_MICRO_ARRAY_COMP_EQ(out, ref);
+  }
+  // Shape with 1 as third dim -> transposed.
+  {
+    std::vector<T> ref({0, 3, 1, 4, 2, 5});
+    tflite::testing::RunTestPermutation<T>(/*shape=*/{2, 3, 1}, /*perms=*/{1, 2, 0}, &out);
+    TF_LITE_MICRO_ARRAY_COMP_EQ(out, ref);
+  }
+  // Shape with 1 as third dim -> identity.
+  {
+    std::vector<T> ref({0, 1, 2, 3, 4, 5});
+    tflite::testing::RunTestPermutation<T>(/*shape=*/{2, 3, 1}, /*perms=*/{2, 0, 1}, &out);
+    TF_LITE_MICRO_ARRAY_COMP_EQ(out, ref);
+  }
+}
+
+template <typename T>
+void TransposeTestTestRefOps4D() {
+  std::vector<T> out;
+  // Basic 4d.
+  tflite::testing::RunTestPermutation<T>({2, 3, 4, 5}, {2, 0, 1, 3}, &out);
+  TF_LITE_MICRO_ARRAY_COMP_EQ(
+      out,
+      std::vector<T>(
+          {0,  1,  2,  3,  4,  20, 21, 22, 23, 24, 40,  41,  42,  43,  44,
+           60, 61, 62, 63, 64, 80, 81, 82, 83, 84, 100, 101, 102, 103, 104,
+           5,  6,  7,  8,  9,  25, 26, 27, 28, 29, 45,  46,  47,  48,  49,
+           65, 66, 67, 68, 69, 85, 86, 87, 88, 89, 105, 106, 107, 108, 109,
+           10, 11, 12, 13, 14, 30, 31, 32, 33, 34, 50,  51,  52,  53,  54,
+           70, 71, 72, 73, 74, 90, 91, 92, 93, 94, 110, 111, 112, 113, 114,
+           15, 16, 17, 18, 19, 35, 36, 37, 38, 39, 55,  56,  57,  58,  59,
+           75, 76, 77, 78, 79, 95, 96, 97, 98, 99, 115, 116, 117, 118, 119}));
+  tflite::testing::RunTestPermutation<T>({2, 3, 4, 5}, {0, 1, 2, 3}, &out);
+  // Basic identity.
+  std::vector<T> ref(out.size());
+  for (unsigned int k = 0; k < ref.size(); k++) ref[k] = k;
+  TF_LITE_MICRO_ARRAY_COMP_EQ(out, ref);
+};
+
+TF_LITE_MICRO_TESTS_BEGIN
+
+// TF_LITE_MICRO_TEST(MustFail) {
+//   TF_LITE_MICRO_FAIL("Boom");
+// }
+
+// Safety test to ensure the array tests 
+// are passing successfully
+TF_LITE_MICRO_TEST(ARRAY_COMP_ShouldSucceed) {
+  std::vector<float> a({0, 1, 2, 3, 4, 5});
+  std::vector<float> b({0, 1, 2, 3, 4, 5});
+
+  TF_LITE_MICRO_ARRAY_COMP_EQ(a,b);
+}
+
+// Safety test to ensure the array tests 
+// are failing as expected
+TF_LITE_MICRO_TEST(ARRAY_COMP_ShouldFail) {
+  std::vector<float> a({0, 1, 2, 3, 4, 6});
+  std::vector<float> b({0, 1, 2, 3, 4, 5});
+  std::vector<float> c({0, 1, 2, 3, 4});
+
+  TF_LITE_MICRO_ARRAY_COMP_NE(a, b);
+  TF_LITE_MICRO_ARRAY_COMP_NE(b, c);
+}
+
+TF_LITE_MICRO_TEST(TestRefOps1D) { TransposeTestTestRefOps1D<float>(); }
+
+TF_LITE_MICRO_TEST(TestRefOps2DFloat) { TransposeTestTestRefOps2D<float>(); }
+TF_LITE_MICRO_TEST(TestRefOps2DInt8) { TransposeTestTestRefOps2D<int8_t>(); }
+TF_LITE_MICRO_TEST(TestRefOps2DUInt8) { TransposeTestTestRefOps2D<uint8_t>(); }
+
+TF_LITE_MICRO_TEST(TestRefOps3DFloat) { TransposeTestTestRefOps3D<float>(); }
+TF_LITE_MICRO_TEST(TestRefOps3DInt8) { TransposeTestTestRefOps3D<int8_t>(); }
+TF_LITE_MICRO_TEST(TestRefOps3DUInt8) { TransposeTestTestRefOps3D<uint8_t>(); }
+
+TF_LITE_MICRO_TEST(TestRefOps3D_OneInDimensionFloat) { TransposeTestTestRefOps3D_OneInDimension<float>(); }
+TF_LITE_MICRO_TEST(TestRefOps3D_OneInDimensionInt8) { TransposeTestTestRefOps3D_OneInDimension<int8_t>(); }
+TF_LITE_MICRO_TEST(TestRefOps3D_OneInDimensionUInt8) { TransposeTestTestRefOps3D_OneInDimension<uint8_t>(); }
+
+TF_LITE_MICRO_TEST(TestRefOps4DFloat) { TransposeTestTestRefOps4D<float>(); }
+TF_LITE_MICRO_TEST(TestRefOps4DInt8) { TransposeTestTestRefOps4D<int8_t>(); }
+TF_LITE_MICRO_TEST(TestRefOps4DInt16) { TransposeTestTestRefOps4D<int16_t>(); }
+
+
+// TF_LITE_MICRO_TEST(TransposeCreateTensorPerm) {
+//   const int perm_dims_data[] = { 1 };
+//   const int32_t perm_int32[] = { 1 };
+
+//   TfLiteIntArray* perm_dims = tflite::testing::IntArrayFromInts(perm_dims_data);
+//   TfLiteTensor perm_tensor = tflite::testing::CreateTensor<int32_t, kTfLiteInt32>(perm_dims, perm_int32);
+
+//   TF_LITE_MICRO_EXPECT_EQ(perm_tensor.dims.data[0], 1);
+// }
+
+// TF_LITE_MICRO_TEST(TransposeBasic1DIdentityShouldSucceed) {
+
+//   float output_data_float[32];
+//   int8_t output_data_int8[32];
+//   uint8_t output_data_uint8[32];
+
+//   const int input_dims[] = { 3 };
+//   const float input_float[] = { 0, 1, 2 };
+//   const int8_t input_int8[] = { 0, 1, 2 };
+//   const uint8_t input_uint8[] = { 0, 1, 2 };
+
+//   const int perm_dims[] = { 1 };
+//   const int32_t perm_int32[] = { 1 };
+
+//   int output_dims[] = { 3 };
+
+//   const int golden_output_len = 3;
+//   const float golden_output_float[] = { 0, 1, 2 };;
+//   const int8_t golden_output_int8[] = { 0, 1, 2 };;
+//   const uint8_t golden_output_uint8[] = { 0, 1, 2 };;
+
+//   const int golden_dims_len = 1;
+//   const int golden_dims[] = { 3 };
+
+//   tflite::testing::TestTranspose(input_dims, input_float, perm_dims, perm_int32,
+//                                  output_dims, output_data_float,
+//                                  golden_output_float, golden_output_len,
+//                                  golden_dims, golden_dims_len);
+
+//   tflite::testing::TestTranspose<int8_t, kTfLiteInt8>(
+//             input_dims, input_int8, perm_dims, perm_int32,
+//             output_dims, output_data_int8,
+//             golden_output_int8, golden_output_len,
+//             golden_dims, golden_dims_len);
+
+//   tflite::testing::TestTranspose<uint8_t, kTfLiteUInt8>(
+//             input_dims, input_uint8, perm_dims, perm_int32,
+//             output_dims, output_data_uint8,
+//             golden_output_uint8, golden_output_len,
+//             golden_dims, golden_dims_len);
+
+// }
+
+// TF_LITE_MICRO_TEST(TransposeBasic2DShouldSucceed) {
+
+//   float output_data_float[32];
+//   int8_t output_data_int8[32];
+//   uint8_t output_data_uint8[32];
+
+//   const int input_dims[] = { 3, 2 };
+//   const float input_float[] = { 0, 1, 2, 3, 4, 5 };
+//   const int8_t input_int8[] = { 0, 1, 2, 3, 4, 5 };
+//   const uint8_t input_uint8[] = { 0, 1, 2, 3, 4, 5 };
+
+//   const int perm_dims[] = { 1 };
+//   const int32_t perm_int32[] = { 1, 0 };
+
+//    int output_dims[] = { 2, 3 };
+
+//   const int golden_output_len = 6;
+//   const float golden_output_float[] = { 0, 2, 4, 1, 3, 5 };
+//   const int8_t golden_output_int8[] = { 0, 2, 4, 1, 3, 5 };
+//   const uint8_t golden_output_uint8[] = { 0, 2, 4, 1, 3, 5 };
+
+//   const int golden_dims_len = 1;
+//   const int golden_dims[] = { 2, 3 };
+
+//   tflite::testing::TestTranspose<float, kTfLiteFloat32>(
+//             input_dims, input_float, perm_dims, perm_int32,
+//             output_dims, output_data_float,
+//             golden_output_float, golden_output_len,
+//             golden_dims, golden_dims_len);
+
+//   tflite::testing::TestTranspose<int8_t, kTfLiteInt8>(
+//             input_dims, input_int8, perm_dims, perm_int32,
+//             output_dims, output_data_int8,
+//             golden_output_int8, golden_output_len,
+//             golden_dims, golden_dims_len);
+
+//   tflite::testing::TestTranspose<uint8_t, kTfLiteUInt8>(
+//             input_dims, input_uint8, perm_dims, perm_int32,
+//             output_dims, output_data_uint8,
+//             golden_output_uint8, golden_output_len,
+//             golden_dims, golden_dims_len);
+// }
+
+// TF_LITE_MICRO_TEST(TransposeBasic3D) {
+
+//   float output_data_float[32];
+//   int8_t output_data_int8[32];
+//   uint8_t output_data_uint8[32];
+
+//   const int input_dims[] = { 1, 2, 3 };
+//   const float input_float[] = { 0, 1, 2, 3, 4, 5 };
+//   const int8_t input_int8[] = { 0, 1, 2, 3, 4, 5 };
+//   const uint8_t input_uint8[] = { 0, 1, 2, 3, 4, 5 };
+
+//   const int perm_dims[] = { 3 };
+//   const int32_t perm_int32[] = { 2, 0, 1 };
+
+//    int output_dims[] = { 2, 3 };
+
+//   const int golden_output_len = 6;
+//   const float golden_output_float[] = { 0, 2, 4, 1, 3, 5 };
+//   const int8_t golden_output_int8[] = { 0, 2, 4, 1, 3, 5 };
+//   const uint8_t golden_output_uint8[] = { 0, 2, 4, 1, 3, 5 };
+
+//   const int golden_dims_len = 1;
+//   const int golden_dims[] = { 2, 3 };
+
+//   tflite::testing::TestTranspose<float, kTfLiteFloat32>(
+//             input_dims, input_float, perm_dims, perm_int32,
+//             output_dims, output_data_float,
+//             golden_output_float, golden_output_len,
+//             golden_dims, golden_dims_len);
+
+//   tflite::testing::TestTranspose<int8_t, kTfLiteInt8>(
+//             input_dims, input_int8, perm_dims, perm_int32,
+//             output_dims, output_data_int8,
+//             golden_output_int8, golden_output_len,
+//             golden_dims, golden_dims_len);
+
+//   tflite::testing::TestTranspose<uint8_t, kTfLiteUInt8>(
+//             input_dims, input_uint8, perm_dims, perm_int32,
+//             output_dims, output_data_uint8,
+//             golden_output_uint8, golden_output_len,
+//             golden_dims, golden_dims_len);
+
+// }
+
+
+// TF_LITE_MICRO_TEST(TransposeBasic4DShouldSucceed) {
+
+//   float output_data_float[64];
+//   int8_t output_data_int8[64];
+//   uint8_t output_data_uint8[64];
+
+//   const int input_dims[] = { 2, 1, 5, 4 };
+//   const float input_float[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40 };
+//   const int8_t input_int8[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40 };
+//   const uint8_t input_uint8[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40 };
+
+//   const int perm_dims[] = { 1 };
+//   const int32_t perm_int32[] = { 3, 2, 1, 0 };
+
+//   int output_dims[] = { 4 };
+
+//   const int golden_output_len = 40;
+
+//   const float golden_output_float[] = { 1, 5, 9, 13, 17, 2, 6, 10, 14, 18, 3, 7, 11, 15, 19, 4, 8, 12, 16, 20, 21, 25, 29, 33, 37, 22, 26, 30, 34, 38, 23, 27, 31, 35, 39, 24, 28, 32, 36, 40 };
+//   const int8_t golden_output_int8[] = { 1, 5, 9, 13, 17, 2, 6, 10, 14, 18, 3, 7, 11, 15, 19, 4, 8, 12, 16, 20, 21, 25, 29, 33, 37, 22, 26, 30, 34, 38, 23, 27, 31, 35, 39, 24, 28, 32, 36, 40 };
+//   const uint8_t golden_output_uint8[] = { 1, 5, 9, 13, 17, 2, 6, 10, 14, 18, 3, 7, 11, 15, 19, 4, 8, 12, 16, 20, 21, 25, 29, 33, 37, 22, 26, 30, 34, 38, 23, 27, 31, 35, 39, 24, 28, 32, 36, 40 };
+
+//   const int golden_dims_len = 4;
+//   const int golden_dims[] = { 2, 4, 5, 1 };
+
+//   tflite::testing::TestTranspose(
+//             input_dims, input_float, perm_dims, perm_int32,
+//             output_dims, output_data_float,
+//             golden_output_float, golden_output_len,
+//             golden_dims, golden_dims_len);
+
+//   tflite::testing::TestTranspose<int8_t, kTfLiteInt8>(
+//             input_dims, input_int8, perm_dims, perm_int32,
+//             output_dims, output_data_int8,
+//             golden_output_int8, golden_output_len,
+//             golden_dims, golden_dims_len);
+
+//   tflite::testing::TestTranspose<uint8_t, kTfLiteUInt8>(
+//             input_dims, input_uint8, perm_dims, perm_int32,
+//             output_dims, output_data_uint8,
+//             golden_output_uint8, golden_output_len,
+//             golden_dims, golden_dims_len);
+
+// }
+
+TF_LITE_MICRO_TESTS_END
+
+#undef TF_LITE_MICRO_ARRAY_COMP_EQ
+#undef TF_LITE_MICRO_ARRAY_COMP_NE 

--- a/tensorflow/lite/micro/micro_mutable_op_resolver.h
+++ b/tensorflow/lite/micro/micro_mutable_op_resolver.h
@@ -223,6 +223,11 @@ class MicroMutableOpResolver : public MicroOpResolver {
                       ParseExpandDims);
   }
 
+  TfLiteStatus AddFill() {
+    return AddBuiltin(BuiltinOperator_FILL,
+                      tflite::Register_FILL(), ParseFill);
+  }
+
   TfLiteStatus AddFloor() {
     return AddBuiltin(BuiltinOperator_FLOOR,
                       tflite::ops::micro::Register_FLOOR(), ParseFloor);

--- a/tensorflow/lite/micro/micro_mutable_op_resolver.h
+++ b/tensorflow/lite/micro/micro_mutable_op_resolver.h
@@ -471,14 +471,14 @@ class MicroMutableOpResolver : public MicroOpResolver {
                       ParseTanh);
   }
 
+  TfLiteStatus AddTranspose() {
+    return AddBuiltin(BuiltinOperator_TRANSPOSE,
+                      tflite::ops::micro::Register_TRANSPOSE(), ParseTranspose);
+  }
+
   TfLiteStatus AddTransposeConv() {
     return AddBuiltin(BuiltinOperator_TRANSPOSE_CONV,
                       tflite::Register_TRANSPOSE_CONV(), ParseTransposeConv);
-  }
-
-  TfLiteStatus AddTranspose() {    
-    return AddBuiltin(BuiltinOperator_TRANSPOSE,
-                      *tflite::ops::micro::Register_TRANSPOSE(), ParseTranspose);
   }
 
   TfLiteStatus AddUnpack() {

--- a/tensorflow/lite/micro/micro_mutable_op_resolver.h
+++ b/tensorflow/lite/micro/micro_mutable_op_resolver.h
@@ -476,6 +476,11 @@ class MicroMutableOpResolver : public MicroOpResolver {
                       tflite::Register_TRANSPOSE_CONV(), ParseTransposeConv);
   }
 
+  TfLiteStatus AddTranspose() {    
+    return AddBuiltin(BuiltinOperator_TRANSPOSE,
+                      *tflite::ops::micro::Register_TRANSPOSE(), ParseTranspose);
+  }
+
   TfLiteStatus AddUnpack() {
     return AddBuiltin(BuiltinOperator_UNPACK,
                       tflite::ops::micro::Register_UNPACK(), ParseUnpack);

--- a/tensorflow/lite/micro/micro_mutable_op_resolver.h
+++ b/tensorflow/lite/micro/micro_mutable_op_resolver.h
@@ -473,7 +473,7 @@ class MicroMutableOpResolver : public MicroOpResolver {
 
   TfLiteStatus AddTranspose() {
     return AddBuiltin(BuiltinOperator_TRANSPOSE,
-                      tflite::ops::micro::Register_TRANSPOSE(), ParseTranspose);
+    		          Register_TRANSPOSE(), ParseTranspose);
   }
 
   TfLiteStatus AddTransposeConv() {

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -315,6 +315,7 @@ tensorflow/lite/micro/kernels/strided_slice_test.cc \
 tensorflow/lite/micro/kernels/sub_test.cc \
 tensorflow/lite/micro/kernels/svdf_test.cc \
 tensorflow/lite/micro/kernels/tanh_test.cc \
+tensorflow/lite/micro/kernels/transpose_test.cc \
 tensorflow/lite/micro/kernels/transpose_conv_test.cc \
 tensorflow/lite/micro/kernels/unpack_test.cc \
 tensorflow/lite/micro/kernels/zeros_like_test.cc \
@@ -381,6 +382,7 @@ tensorflow/lite/micro/kernels/sub.cc \
 tensorflow/lite/micro/kernels/svdf.cc \
 tensorflow/lite/micro/kernels/svdf_common.cc \
 tensorflow/lite/micro/kernels/tanh.cc \
+tensorflow/lite/micro/kernels/transpose.cc \
 tensorflow/lite/micro/kernels/transpose_conv.cc \
 tensorflow/lite/micro/kernels/unpack.cc \
 tensorflow/lite/micro/kernels/zeros_like.cc

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -470,6 +470,7 @@ tensorflow/lite/kernels/internal/reference/sub.h \
 tensorflow/lite/kernels/internal/reference/logistic.h \
 tensorflow/lite/kernels/internal/reference/strided_slice.h \
 tensorflow/lite/kernels/internal/reference/tanh.h \
+tensorflow/lite/kernels/internal/reference/transpose.h \
 tensorflow/lite/kernels/internal/reference/transpose_conv.h \
 tensorflow/lite/kernels/internal/cppmath.h \
 tensorflow/lite/kernels/internal/max.h \


### PR DESCRIPTION
Fixes #45695 
Fixes #43472

Addition of TRANSPOSE operation and its relevant test file to TF Lite for Microcontrollers. This operation has been successfully tested in the following ways:

1. Running `transpose_test` with Bazel
2. Building TFLM for a target nRF52840 DK (Cortex-M) and verifying that the target error `Didn't find op for builtin opcode 'TRANSPOSE' version '2'` disappeared

**More details abut point 1.**
The command used is:
```
bazel test //tensorflow/lite/micro/kernels:transpose_test --verbose_failures
```

It returns:
```
.....
Removed for brevity
.....
INFO: Analyzed target //tensorflow/lite/micro/kernels:transpose_test (0 packages loaded, 0 targets configured).
INFO: Found 1 test target...
Target //tensorflow/lite/micro/kernels:transpose_test up-to-date:
  bazel-bin/tensorflow/lite/micro/kernels/transpose_test
INFO: Elapsed time: 0.156s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
//tensorflow/lite/micro/kernels:transpose_test                  (cached) PASSED in 0.0s

Executed 0 out of 1 test: 1 test passes.
INFO: Build completed successfully, 1 total action
```

**More details abut point 2.**
I always build locally my version of TFLM with the command:
```
make -f tensorflow/lite/micro/tools/make/Makefile \
    TARGET=cortex_m_generic \
    TARGET_ARCH=cortex-m4+fp \
    TARGET_TOOLCHAIN_ROOT=/opt/gcc-arm-none-eabi-9-2020-q2-update/bin/ \
    OPTIMIZED_KERNEL_DIR=cmsis_nn microlite
```

Before applying the fixes of this PR, the error on the target nRF52840 DK was:
```
[ERR] ./model/debug_log.cc:12: Didn't find op for builtin opcode 'TRANSPOSE' version '2'. An older version of this builtin might be supported. Are you using an old TFLite binary with a newer model?
[ERR] ./model/debug_log.cc:12: 
[ERR] ./model/debug_log.cc:12: Failed to get registration from op code TRANSPOSE
[ERR] ./model/debug_log.cc:12: 
[ERR] ./model/debug_log.cc:12: Failed starting model allocation.
[ERR] ./model/debug_log.cc:12: 
[ERR] ./model/debug_log.cc:12: AllocateTensors() failed
```

Now, after applying the fixes of this PR, the error disappears and the code can process further at runtime.