### PR TITLE
ifdef out newly added depthwise_conv test for hifimini.

### DIFF
--- a/tensorflow/lite/micro/kernels/depthwise_conv_test.cc
+++ b/tensorflow/lite/micro/kernels/depthwise_conv_test.cc
@@ -807,6 +807,9 @@ TF_LITE_MICRO_TEST(Int8Input32x4Filter32x4ShouldMatchGolden) {
       kTensorsSize, tensors);
 }
 
+#if !defined(HIFIMINI)
+// TODO(b/184087246): Remove this ifdef once the hifimini implementation is
+// updated to be more general.
 TF_LITE_MICRO_TEST(Int8Input32x1Filter32x1ShouldMatchGolden) {
   const int input_elements = 32 * 1;
   const int filter_elements = 32 * 1;
@@ -935,4 +938,6 @@ TF_LITE_MICRO_TEST(Int8Input32x1Filter32x1ShouldMatchGolden) {
                               golden_quantized, output_elements, &conv_params,
                               kQuantizationTolerance, kTensorsSize, tensors));
 }
+#endif  // !defined(HIFIMINI)
+
 TF_LITE_MICRO_TESTS_END


### PR DESCRIPTION
See http://b/184087246 for additional context.

Manually confirmed that hifimimini tests pass with:
```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=hifimini XTENSA_CORE=mini1m1m_RG test -j8
```