### PR TITLE
Fix kernel_l2_pool_2d_test for the Xtensa target

### DIFF
--- a/tensorflow/lite/micro/kernels/l2_pool_2d_test.cc
+++ b/tensorflow/lite/micro/kernels/l2_pool_2d_test.cc
@@ -105,7 +105,6 @@ TF_LITE_MICRO_TEST(FloatPoolingOpTestL2Pool) {
   constexpr int kOutputCount = std::extent<decltype(kExpect)>::value;
   float output_data[kOutputCount];
   tflite::testing::L2Pool2DTestParams params;
-  params.compare_tolerance = 0;
 
   tflite::testing::TestL2Pool2D(params, kInputDims, kInput, kExpectDims,
                                 kExpect, output_data);
@@ -174,7 +173,6 @@ TF_LITE_MICRO_TEST(FloatPoolingOpTestL2PoolPaddingSame) {
   float output_data[kOutputCount];
   tflite::testing::L2Pool2DTestParams params;
   params.padding = kTfLitePaddingSame;
-  params.compare_tolerance = 0;
 
   tflite::testing::TestL2Pool2D(params, kInputDims, kInput, kExpectDims,
                                 kExpect, output_data);


### PR DESCRIPTION
 * Changed the comparison to use 1e-5. We should not be comparing floats with tolerance = 0.
 * manually confirmed that the following command now passes:
```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=fusion_f1 XTENSA_CORE=F1_190305_swupgrade test_kernel_l2_pool_2d_test -j8
```
