### PR TITLE
[file systems] fix the fall back to legacy implementation

### DIFF
--- a/tensorflow/core/platform/env.h
+++ b/tensorflow/core/platform/env.h
@@ -642,16 +642,16 @@ struct Register {
     if (try_modular_filesystems) {
       const char* env_value = getenv("TF_USE_MODULAR_FILESYSTEM");
       string load_plugin = env_value ? absl::AsciiStrToLower(env_value) : "";
-      if (!(load_plugin == "true" || load_plugin == "1")) {
+      if (load_plugin == "true" || load_plugin == "1") {
         // We don't register the static filesystem and wait for SIG IO one
-        LOG(WARNING) << "Using modular file system for '" << scheme << "."
-                     << " Please switch to tensorflow-io"
-                     << " (https://github.com/tensorflow/io) for file system"
-                     << " support of '" << scheme << "'.";
         return;
       }
       // If the envvar is missing or not "true"/"1", then fall back to legacy
       // implementation to be backwards compatible.
+      LOG(WARNING) << "Using modular file system for '" << scheme << "."
+                   << " Please switch to tensorflow-io"
+                   << " (https://github.com/tensorflow/io) for file system"
+                   << " support of '" << scheme << "'.";
     }
     // TODO(b/32704451): Don't just ignore the ::tensorflow::Status object!
     env->RegisterFileSystem(scheme, []() -> FileSystem* { return new Factory; })


### PR DESCRIPTION
This PR is a follow up of https://github.com/tensorflow/tensorflow/commit/aa35d4755409474f6619c68af1bfca168db24518.

The switch to plugin-based file systems was a bit unintuitive as per the current implementation.
As per the understanding that the env var `TF_USE_MODULAR_FILESYSTEM` is unset by default, the users will be using the legacy implementation of fs (i.e we ensure backward compatibility). However, if the env var is set then it is inferred that they want to use the plugins based modular fs from tfio. This PR addresses this confusion by simplifying the condition block.

cc: @mihaimaruseac @yongtang  @vnvo2409   please let me know if there is some confusion with this approach. A PR https://github.com/tensorflow/io/pull/1348 has been raised in tfio to make the necessary changes.