### PR TITLE
Remove unneeded `file_io.file_exists` checks

### DIFF
--- a/tensorflow/core/platform/cloud/gcs_file_system.cc
+++ b/tensorflow/core/platform/cloud/gcs_file_system.cc
@@ -74,7 +74,7 @@ constexpr uint64 HTTP_CODE_PRECONDITION_FAILED = 412;
 ABSL_DEPRECATED("Use GCS_READ_CACHE_BLOCK_SIZE_MB instead.")
 constexpr char kReadaheadBufferSize[] = "GCS_READAHEAD_BUFFER_SIZE_BYTES";
 // The environment variable that overrides the maximum age of entries in the
-// Stat cache. A value of 0 (the default) means nothing is cached.
+// Stat cache. A value of 0 means nothing is cached.
 constexpr char kStatCacheMaxAge[] = "GCS_STAT_CACHE_MAX_AGE";
 constexpr uint64 kStatCacheDefaultMaxAge = 5;
 // The environment variable that overrides the maximum number of entries in the

--- a/tensorflow/python/framework/graph_io.py
+++ b/tensorflow/python/framework/graph_io.py
@@ -63,7 +63,7 @@ def write_graph(graph_or_graph_def, logdir, name, as_text=True):
     graph_def = graph_or_graph_def
 
   # gcs does not have the concept of directory at the moment.
-  if not file_io.file_exists(logdir) and not logdir.startswith('gs:'):
+  if not logdir.startswith('gs:'):
     file_io.recursive_create_dir(logdir)
   path = os.path.join(logdir, name)
   if as_text:

--- a/tensorflow/python/keras/saving/saved_model_experimental.py
+++ b/tensorflow/python/keras/saving/saved_model_experimental.py
@@ -436,8 +436,7 @@ def load_from_saved_model(saved_model_path, custom_objects=None):
 def _get_or_create_variables_dir(export_dir):
   """Return variables sub-directory, or create one if it doesn't exist."""
   variables_dir = _get_variables_dir(export_dir)
-  if not file_io.file_exists(variables_dir):
-    file_io.recursive_create_dir(variables_dir)
+  file_io.recursive_create_dir(variables_dir)
   return variables_dir
 
 
@@ -459,8 +458,7 @@ def _get_or_create_assets_dir(export_dir):
   """Return assets sub-directory, or create one if it doesn't exist."""
   assets_destination_dir = _get_assets_dir(export_dir)
 
-  if not file_io.file_exists(assets_destination_dir):
-    file_io.recursive_create_dir(assets_destination_dir)
+  file_io.recursive_create_dir(assets_destination_dir)
 
   return assets_destination_dir
 
@@ -470,4 +468,3 @@ def _get_assets_dir(export_dir):
   return os.path.join(
       compat.as_text(export_dir),
       compat.as_text(constants.ASSETS_DIRECTORY))
-

--- a/tensorflow/python/profiler/profile_context.py
+++ b/tensorflow/python/profiler/profile_context.py
@@ -295,16 +295,14 @@ class ProfileContext(object):
       return
     if self._debug:
       sys.stderr.write('debug: dumping file at step: %d\n' % step)
-    if not gfile.Exists(self._profiler_dir):
-      gfile.MakeDirs(self._profiler_dir)
+    gfile.MakeDirs(self._profiler_dir)
 
     filename = os.path.join(compat.as_bytes(self._profiler_dir),
                             compat.as_bytes('profile_%d' % step))
     self.profiler._write_profile(filename)  # pylint: disable=protected-access
 
   def _dump_file(self, pb, basename):
-    if not gfile.Exists(self._profiler_dir):
-      gfile.MakeDirs(self._profiler_dir)
+    gfile.MakeDirs(self._profiler_dir)
     with gfile.Open(os.path.join(self._profiler_dir, basename), 'w') as f:
       f.write('%s' % pb)
 

--- a/tensorflow/python/saved_model/utils_impl.py
+++ b/tensorflow/python/saved_model/utils_impl.py
@@ -216,8 +216,7 @@ def get_element_from_tensor_info(tensor_info, graph=None, import_scope=None):
 def get_or_create_variables_dir(export_dir):
   """Return variables sub-directory, or create one if it doesn't exist."""
   variables_dir = get_variables_dir(export_dir)
-  if not file_io.file_exists(variables_dir):
-    file_io.recursive_create_dir(variables_dir)
+  file_io.recursive_create_dir(variables_dir)
   return variables_dir
 
 
@@ -239,8 +238,7 @@ def get_or_create_assets_dir(export_dir):
   """Return assets sub-directory, or create one if it doesn't exist."""
   assets_destination_dir = get_assets_dir(export_dir)
 
-  if not file_io.file_exists(assets_destination_dir):
-    file_io.recursive_create_dir(assets_destination_dir)
+  file_io.recursive_create_dir(assets_destination_dir)
 
   return assets_destination_dir
 
@@ -256,8 +254,7 @@ def get_or_create_debug_dir(export_dir):
   """Returns path to the debug sub-directory, creating if it does not exist."""
   debug_dir = get_debug_dir(export_dir)
 
-  if not file_io.file_exists(debug_dir):
-    file_io.recursive_create_dir(debug_dir)
+  file_io.recursive_create_dir(debug_dir)
 
   return debug_dir
 

--- a/tensorflow/python/summary/writer/event_file_writer.py
+++ b/tensorflow/python/summary/writer/event_file_writer.py
@@ -67,8 +67,7 @@ class EventFileWriter(object):
         `filename_suffix`.
     """
     self._logdir = str(logdir)
-    if not gfile.IsDirectory(self._logdir):
-      gfile.MakeDirs(self._logdir)
+    gfile.MakeDirs(self._logdir)
     self._max_queue = max_queue
     self._flush_secs = flush_secs
     self._flush_complete = threading.Event()

--- a/tensorflow/python/summary/writer/event_file_writer_v2.py
+++ b/tensorflow/python/summary/writer/event_file_writer_v2.py
@@ -74,8 +74,7 @@ class EventFileWriterV2(object):
     self._session = session
     self._logdir = logdir
     self._closed = False
-    if not gfile.IsDirectory(self._logdir):
-      gfile.MakeDirs(self._logdir)
+    gfile.MakeDirs(self._logdir)
 
     with self._session.graph.as_default():
       with ops.name_scope('filewriter'):


### PR DESCRIPTION
`file_io.recursive_create_dir` correctly handles existing directories so this PR removes unnecessary `file_io.file_exists`. This can be beneficial when working with object storage where listing files or checking for the existence of a directory might be expensive.