### PR TITLE
Map XLA opaque type to a scalar TensorShape in XLAShapeToTensorShape.

### DIFF
--- a/tensorflow/compiler/tf2xla/shape_util.cc
+++ b/tensorflow/compiler/tf2xla/shape_util.cc
@@ -93,6 +93,12 @@ Status XLAShapeToTensorShape(const xla::Shape& shape,
                                    " cannot be converted to a TensorShape");
   }
   *tensor_shape = TensorShape();
+
+  // XLA Opaque types have a scalar TensorShape.
+  if (shape.IsOpaque()) {
+    return Status::OK();
+  }
+
   for (int i = 0; i < shape.rank(); ++i) {
     tensor_shape->AddDim(shape.dimensions(i));
   }


### PR DESCRIPTION
The `variant` type is (by convention) given a scalar shape in op definitions.
The `variant` type maps to the `opaque` type in TF2XLA.
So It appears reasonable to return a scalar `TensorShape` when an opaque typed shape is given to `XLAShapeToTensorShape`.

This allows an XLA backend to return TF variant tensors for opaque backend-specific values.