### PR TITLE
[TF:TRT] ConvertSplit for dynamic shapes.

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h
@@ -586,7 +586,8 @@ class Converter {
   // The input_dims argument stores the TRT dimensions of the input tensor,
   // where the dimensions to be squeezed are replaced by 0.
   Status SqueezeTensor(ITensorProxyPtr input, std::vector<int>* input_dims,
-                       OpConverterParams* params, ITensorProxyPtr* output);
+                       OpConverterParams* params, ITensorProxyPtr* output,
+                       absl::optional<int> op_instance = absl::nullopt);
 
   // Creates an IConstantLayer using 'weights' whose dimensions are specified by
   // 'dims', and returns the output ITensor.

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -30,6 +30,7 @@ limitations under the License.
 #include "absl/strings/match.h"
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
 #include "third_party/gpus/cuda/include/cuda.h"
@@ -6353,98 +6354,63 @@ auto get_split_nodedef = [](DataType dtype, int num_split) -> NodeDef {
   return split.operation.node()->def();
 };
 
-template <DataType dtype>
-void TestConvertSplit(OpConverterTest* test) {
-  typedef typename EnumToDataType<dtype>::Type CType;
+struct SplitTestParams {
+  std::vector<int> input_shape;
+  std::vector<float> input_value;
+  int axis;
+  int num_split;
+  std::vector<int> expected_output_dims;
+  std::vector<std::vector<float>> expected_outputs;
+  error::Code error_code;
+};
 
-  struct TestParams {
-    std::vector<int> input_shape;
-    std::vector<CType> value;
-    int axis;
-    int num_split;
-    std::vector<int> expected_output_dims;
-    std::vector<std::vector<CType>> expected_outputs;
-  };
+void TestConvertSplit(ParameterizedOpConverterTestBase* test, SplitTestParams& p) {
+  // All inputs are tensors.
+  test->Reset();
+  NodeDef node_def = get_split_nodedef(test->get_tf_type(), p.num_split);
 
-  const std::vector<CType> common_input = InitTestVector<CType>(6);
-  std::vector<TestParams> ok_params = {
-      // Identity (num_split = 1)
-      {/*input_shape=*/{1, 2, 3}, /*value=*/common_input, /*axis=*/1,
-       /*num_split=*/1, /*expected_output_dims=*/{1, 2, 3},
-       /*expected_outputs=*/{InitTestVector<CType>(6)}},
-      {/*input_shape=*/{1, 2, 3},
-       /*value=*/common_input,
-       /*axis=*/3,
-       /*num_split=*/3,
-       /*expected_output_dims=*/{1, 2, 1},
-       /*expected_outputs=*/
-       {{CType(0), CType(3)}, {CType(1), CType(4)}, {CType(2), CType(5)}}},
-      {/*input_shape=*/{1, 6},
-       /*value=*/common_input,
-       /*axis=*/2,
-       /*num_split=*/6,
-       /*expected_output_dims=*/{1, 1},
-       /*expected_outputs=*/
-       {{CType(0)},
-        {CType(1)},
-        {CType(2)},
-        {CType(3)},
-        {CType(4)},
-        {CType(5)}}},
-      {/*input_shape=*/{1, 6},
-       /*value=*/common_input,
-       /*axis=*/-1,
-       /*num_split=*/2,
-       /*expected_output_dims=*/{1, 3},
-       /*expected_outputs=*/
-       {InitTestVector<CType>(3), InitTestVector<CType>(3, CType(3))}},
-  };
+  // Create inputs.
+  test->AddTestWeights("axis", {1}, {p.axis}, DT_INT32);
+  test->AddTestTensor("value", p.input_shape, test->get_tf_type(),
+                      p.input_value);
 
-  for (int i = 0; i < ok_params.size(); ++i) {
-    test->Reset();
-    NodeDef node_def = get_split_nodedef(dtype, ok_params[i].num_split);
-    // Create inputs.
-    test->AddTestWeights<int32>("axis", {1}, {ok_params[i].axis});
-    nvinfer1::DataType trt_type;
-    TF_ASSERT_OK(TfTypeToTrtType(dtype, &trt_type));
-    test->AddTestTensor("value", ok_params[i].input_shape, 1, trt_type);
-    // Convert.
-    test->RunValidationAndConversion(node_def);
+  std::vector<Matcher<std::vector<float>>> matcher_vec;
+  std::vector<DataType> datatype_vec;
+  std::vector<std::vector<int>> expected_output_dims;
 
-    // Get output tensors and verify output dims.
-    EXPECT_EQ(ok_params[i].expected_outputs.size(), ok_params[i].num_split);
-    std::vector<TRT_TensorOrWeights> outputs(ok_params[i].num_split);
-    DataVec output_data;
-    for (int j = 0; j < outputs.size(); ++j) {
-      const string name = j == 0 ? StrCat("my_split") : StrCat("my_split:", j);
-      TF_EXPECT_OK(test->GetTensorOrWeights(name, &outputs[j]));
-      EXPECT_TRUE(outputs[j].is_tensor());
-      ExpectTrtDimsEqualsArray(ok_params[i].expected_output_dims,
-                               outputs[j].tensor()->getDimensions());
-      // Create buffer to store output.
-      output_data.push_back(
-          {name, test->ConstructTensor<CType>(
-                     ok_params[i].expected_outputs[j].size())});
-    }
-
-    // Verify output values are correct.
-    const DataVec input_data{
-        {"value", test->AsTensor<CType>(ok_params[i].value)}};
-    TF_EXPECT_OK(test->BuildAndRun(input_data, &output_data));
-    for (int j = 0; j < outputs.size(); ++j) {
-      EXPECT_THAT(GetSpanForData<CType>(output_data[j]),
-                  ElementsAreArray(ok_params[i].expected_outputs[j]));
-    }
+  for (int j = 0; j < p.expected_outputs.size(); ++j) {
+    matcher_vec.push_back(ElementsAreArray(p.expected_outputs[j]));
+    datatype_vec.push_back(test->get_tf_type());
+    expected_output_dims.push_back(p.expected_output_dims);
   }
+
+  Status run_status;
+  if (p.error_code == error::OK) {
+    run_status = Status::OK();
+  }
+  else {
+    auto expected_error_msg = absl::StrFormat(
+      "Dimension %d must have statically defined dimensions, at my_split",
+      p.axis);
+    run_status = Status(p.error_code, expected_error_msg);
+  }
+
+  test->TestOpConverterMultiOut(/*name=*/"my_split",
+                                /*node_def=*/node_def,
+                                /*expected_output_dims=*/expected_output_dims,
+                                /*expected_conversion_status=*/run_status,
+                                /*expected_runtime_status=*/run_status,
+                                /*matcher=*/matcher_vec,
+                                /*out_tf_type=*/datatype_vec);
 }
 
-TEST_F(OpConverterTest, ConvertSplit) {
+TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertSplit) {
   {
     // Axis is a tensor, should fail.
     Reset();
-    NodeDef node_def = get_split_nodedef(DT_FLOAT, 1);
+    NodeDef node_def = get_split_nodedef(tf_type_, 1);
     AddTestTensor("axis", {1});
-    AddTestTensor("value", {1, 2, 3});
+    AddTestTensor("value", {1, 1, 2, 3});
     RunValidationAndConversion(
         node_def, error::UNIMPLEMENTED,
         "The input \"axis\" for Split must be a constant, at my_split");
@@ -6452,9 +6418,9 @@ TEST_F(OpConverterTest, ConvertSplit) {
   {
     // Axis is out of bounds, should fail.
     Reset();
-    NodeDef node_def = get_split_nodedef(DT_FLOAT, 1);
+    NodeDef node_def = get_split_nodedef(tf_type_, 1);
     AddTestWeights<int32>("axis", {1}, {4});
-    AddTestTensor("value", {1, 2, 3});
+    AddTestTensor("value", {1, 1, 2, 3});
     RunValidationAndConversion(node_def, error::INVALID_ARGUMENT,
                                "Axis value of 4 is out of bounds, must be in "
                                "range [-4, 4), at my_split");
@@ -6462,9 +6428,9 @@ TEST_F(OpConverterTest, ConvertSplit) {
   {
     // Axis is out of bounds (negative), should fail.
     Reset();
-    NodeDef node_def = get_split_nodedef(DT_FLOAT, 1);
+    NodeDef node_def = get_split_nodedef(tf_type_, 1);
     AddTestWeights<int32>("axis", {1}, {-5});
-    AddTestTensor("value", {1, 2, 3});
+    AddTestTensor("value", {1, 1, 2, 3});
     RunValidationAndConversion(node_def, error::INVALID_ARGUMENT,
                                "Axis value of -5 is out of bounds, must be in "
                                "range [-4, 4), at my_split");
@@ -6472,17 +6438,27 @@ TEST_F(OpConverterTest, ConvertSplit) {
   {
     // Axis is batch dimension, should fail.
     Reset();
-    NodeDef node_def = get_split_nodedef(DT_FLOAT, 1);
+    NodeDef node_def = get_split_nodedef(tf_type_, 1);
     AddTestWeights<int32>("axis", {1}, {0});
-    AddTestTensor("value", {1, 2, 3});
-    RunValidationAndConversion(node_def, error::UNIMPLEMENTED,
-                               "TensorRT does not allow manipulation of the "
-                               "batch dimension, at my_split");
+    AddTestTensor("value", {1, 1, 2, 3});
+    if (trt_mode_ == TrtTestMode::kImplicitBatch) {
+      RunValidationAndConversion(node_def, error::UNIMPLEMENTED,
+                                 "TensorRT does not allow manipulation of the "
+                                 "batch dimension, at my_split");
+    }
+    else if (trt_mode_ == TrtTestMode::kDynamicShape) {
+      RunValidationAndConversion(node_def, error::INVALID_ARGUMENT,
+                                 "Dimension 0 must have statically defined "
+                                 "dimensions, at my_split");
+    } else {
+      RunValidationAndConversion(node_def);
+    }
+
   }
   {
     // Value is a weight, should fail.
     Reset();
-    NodeDef node_def = get_split_nodedef(DT_FLOAT, 1);
+    NodeDef node_def = get_split_nodedef(tf_type_, 1);
     AddTestWeights<int32>("axis", {1}, {1});
     AddTestWeights<float>("value", {1, 2, 3}, {1, 2, 3, 4, 5, 6});
     RunValidationAndConversion(
@@ -6490,29 +6466,88 @@ TEST_F(OpConverterTest, ConvertSplit) {
         "The input \"value\" for Split must be a tensor, at my_split");
   }
   {
-    // Dim is not evenly divisibly by num_split, should fail.
+    // Dim is not evenly divisible by num_split, should fail.
     Reset();
-    NodeDef node_def = get_split_nodedef(DT_FLOAT, 2);
+    NodeDef node_def = get_split_nodedef(tf_type_, 2);
     AddTestWeights<int32>("axis", {1}, {3});
-    AddTestTensor("value", {1, 2, 3});
-    RunValidationAndConversion(
-        node_def, error::INVALID_ARGUMENT,
-        "Dimension 3 of size 3 is not evenly divisible by 2, at my_split");
+    AddTestTensor("value", {1, 1, 2, 3});
+    if (trt_mode_ == TrtTestMode::kDynamicShape) {
+      RunValidationAndConversion(
+          node_def, error::INVALID_ARGUMENT,
+          "Dimension 3 must have statically defined dimensions, at my_split");
+    } else {
+      RunValidationAndConversion(
+          node_def, error::INVALID_ARGUMENT,
+          "Dimension 3 of size 3 is not evenly divisible by 2, at my_split");
+    }
   }
   {
     // num_split > dim size, should fail.
     Reset();
-    NodeDef node_def = get_split_nodedef(DT_FLOAT, 4);
+    NodeDef node_def = get_split_nodedef(tf_type_, 4);
     AddTestWeights<int32>("axis", {1}, {3});
-    AddTestTensor("value", {1, 2, 3});
-    RunValidationAndConversion(
-        node_def, error::INVALID_ARGUMENT,
-        "Dimension 3 of size 3 is not evenly divisible by 4, at my_split");
+    AddTestTensor("value", {1, 1, 2, 3});
+    if (trt_mode_ == TrtTestMode::kDynamicShape) {
+      RunValidationAndConversion(
+          node_def, error::INVALID_ARGUMENT,
+          "Dimension 3 must have statically defined dimensions, at my_split");
+    } else {
+      RunValidationAndConversion(
+          node_def, error::INVALID_ARGUMENT,
+          "Dimension 3 of size 3 is not evenly divisible by 4, at my_split");
+    }
   }
 
-  TestConvertSplit<DT_FLOAT>(this);
-  TestConvertSplit<DT_HALF>(this);
-  TestConvertSplit<DT_INT32>(this);
+  const std::vector<float> common_input = InitTestVector<float>(6);
+
+  std::vector<SplitTestParams> ok_params = {
+    // Identity (num_split = 1)
+    {
+      /*input_shape=*/{1, 1, 2, 3},
+      /*input_value=*/common_input,
+      /*axis=*/1,
+      /*num_split=*/1,
+      /*expected_output_dims=*/{1, 1, 2, 3},
+      /*expected_outputs=*/{common_input},
+      /*error_code=*/trt_mode_ == TrtTestMode::kDynamicShape ?
+        error::INVALID_ARGUMENT : error::OK
+    },
+    {
+      /*input_shape=*/{1, 1, 2, 3},
+      /*input_value=*/common_input,
+      /*axis=*/3,
+      /*num_split=*/3,
+      /*expected_output_dims=*/{1, 1, 2, 1},
+      /*expected_outputs=*/{{0, 3}, {1, 4}, {2, 5}},
+      /*error_code=*/trt_mode_ == TrtTestMode::kDynamicShape ?
+        error::INVALID_ARGUMENT : error::OK
+    },
+    {
+      /*input_shape=*/{1, 1, 6},
+      /*input_value=*/common_input,
+      /*axis=*/2,
+      /*num_split=*/6,
+      /*expected_output_dims=*/{1, 1, 1},
+      /*expected_outputs=*/{{0}, {1}, {2}, {3}, {4}, {5}},
+      /*error_code=*/trt_mode_ == TrtTestMode::kDynamicShape ?
+        error::INVALID_ARGUMENT : error::OK
+    },
+    {
+      /*input_shape=*/{1, 1, 6},
+      /*input_value=*/common_input,
+      /*axis=*/-1,
+      /*num_split=*/2,
+      /*expected_output_dims=*/{1, 1, 3},
+      /*expected_outputs=*/
+      {InitTestVector<float>(3), InitTestVector<float>(3, 3)},
+      /*error_code=*/trt_mode_ == TrtTestMode::kDynamicShape ?
+        error::INVALID_ARGUMENT : error::OK
+    },
+  };
+
+  for (auto p : ok_params) {
+    TestConvertSplit(this, p);
+  }
 }
 
 // Get the NodeDef for Unpack (Unstack in TF API).


### PR DESCRIPTION
@tfeher @bixia1 for review
Fix SqueezeTensor to ensure that the TRT layers generated by ConvertSplit have unique names.

Add tests for ConvertSplit dynamic shapes.  