### PR TITLE
[INTEL MKL]  Setting default value for KMP_BLOCKTIME

### DIFF
--- a/tensorflow/core/common_runtime/BUILD
+++ b/tensorflow/core/common_runtime/BUILD
@@ -39,6 +39,7 @@ load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda")
 load(
     "//third_party/mkl:build_defs.bzl",
     "if_mkl",
+    "if_mkl_ml",
 )
 
 default_package_visibility = [
@@ -1543,7 +1544,9 @@ cc_library(
         "//tensorflow/core:lib",
         "//tensorflow/core:lib_internal",
         "//tensorflow/core:protos_all_cc",
-    ] + if_mkl([":mkl_cpu_allocator"]),
+    ] + if_mkl([":mkl_cpu_allocator"]) + if_mkl_ml([
+        "@org_tensorflow//third_party/mkl:intel_binary_blob",
+    ]),
 )
 
 cc_library(

--- a/tensorflow/core/common_runtime/threadpool_device.cc
+++ b/tensorflow/core/common_runtime/threadpool_device.cc
@@ -12,6 +12,21 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+
+#if defined(ENABLE_ONEDNN_OPENMP) && defined(ENABLE_MKL) && defined(_OPENMP)
+#ifndef DNNL_AARCH64_USE_ACL
+// Using LLVM's OpenMP header
+#include "external/llvm_openmp/include/omp.h"
+/* Added EIGEN_DONT_PARALLELIZE to avoid duplicating omp.h, please refer to
+this link https://eigen.tuxfamily.org/dox/TopicMultiThreading.html for more
+info. It does not have any negetive impact on performance. */
+#define EIGEN_DONT_PARALLELIZE
+#else
+#include "omp.h"
+#endif
+#endif  // defined(ENABLE_ONEDNN_OPENMP) && defined(ENABLE_MKL) &&
+        // defined(_OPENMP)
+
 #include "tensorflow/core/common_runtime/threadpool_device.h"
 
 #include "absl/base/call_once.h"
@@ -32,11 +47,6 @@ limitations under the License.
 #include "tensorflow/core/public/session_options.h"
 #include "tensorflow/core/util/util.h"
 
-#if defined(ENABLE_ONEDNN_OPENMP) && defined(ENABLE_MKL)
-#ifdef _OPENMP
-#include <omp.h>
-#endif
-#endif  // defined(ENABLE_ONEDNN_OPENMP) && defined(ENABLE_MKL)
 #ifdef INTEL_MKL
 #include "tensorflow/core/common_runtime/mkl_cpu_allocator.h"
 #include "tensorflow/core/platform/cpu_info.h"
@@ -57,15 +67,26 @@ ThreadPoolDevice::ThreadPoolDevice(const SessionOptions& options,
   if (!IsMKLEnabled()) return;
 #ifdef _OPENMP
   const char* user_omp_threads = getenv("OMP_NUM_THREADS");
-  static absl::once_flag omp_setting_flag;
+  static absl::once_flag num_threads_setting_flag;
   if (user_omp_threads == nullptr) {
     // OMP_NUM_THREADS controls MKL's intra-op parallelization
     // Default to available physical cores
     const int mkl_intra_op = port::NumSchedulableCPUs();
     const int ht = port::NumHyperthreadsPerCore();
-    absl::call_once(omp_setting_flag, omp_set_num_threads,
+    absl::call_once(num_threads_setting_flag, omp_set_num_threads,
                     (mkl_intra_op + ht - 1) / ht);
   }
+
+#ifndef DNNL_AARCH64_USE_ACL
+  const char* user_kmp_blocktime = getenv("KMP_BLOCKTIME");
+  static absl::once_flag blocktime_setting_flag;
+  if (user_kmp_blocktime == nullptr) {
+    // Sets the time, in milliseconds, that a thread should wait,
+    // after completing the execution of a parallel region, before sleeping.
+    absl::call_once(blocktime_setting_flag, kmp_set_blocktime, 1);
+  }
+#endif
+
 #endif  // _OPENMP
 #endif  // defined(ENABLE_ONEDNN_OPENMP) && defined(INTEL_MKL)
 }
@@ -105,9 +126,9 @@ void ThreadPoolDevice::CopyTensorInSameDevice(
     const Tensor* input_tensor, Tensor* output_tensor,
     const DeviceContext* device_context, StatusCallback done) {
   if (input_tensor->NumElements() != output_tensor->NumElements()) {
-    done(errors::Internal(
-        "CPU->CPU copy shape mismatch: input=", input_tensor->shape(),
-        ", output=", output_tensor->shape()));
+    done(errors::Internal("CPU->CPU copy shape mismatch: input=",
+                          input_tensor->shape(), ", output=",
+                          output_tensor->shape()));
     return;
   }
   tensor::DeepCopy(*input_tensor, output_tensor);

--- a/third_party/llvm_openmp/BUILD
+++ b/third_party/llvm_openmp/BUILD
@@ -10,6 +10,12 @@ load(
     "dict_add",
 )
 
+package(
+    default_visibility = [
+        "//visibility:public",
+    ],
+)
+
 exports_files(["LICENSE.txt"])
 
 genrule(

--- a/third_party/mkl/BUILD
+++ b/third_party/mkl/BUILD
@@ -79,6 +79,7 @@ cc_library(
     srcs = [
         "@llvm_openmp//:libiomp5.so",
     ],
+    hdrs = ["@llvm_openmp//:config_omp"],
     visibility = ["//visibility:public"],
 )
 
@@ -88,6 +89,7 @@ cc_library(
     srcs = [
         "@llvm_openmp//:libiomp5.dylib",
     ],
+    hdrs = ["@llvm_openmp//:config_omp"],
     visibility = ["//visibility:public"],
 )
 
@@ -96,6 +98,7 @@ cc_library(
     srcs = [
         "@llvm_openmp//:libiomp5md.dll",
     ],
+    hdrs = ["@llvm_openmp//:config_omp"],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
To improve overall user experience and performance, this PR sets KMP_BLOCKTIME to 1, if not set already by user.