### PR TITLE
Update convolutional.py

### DIFF
--- a/tensorflow/python/keras/layers/convolutional.py
+++ b/tensorflow/python/keras/layers/convolutional.py
@@ -2106,7 +2106,8 @@ class SeparableConv2D(SeparableConv):
     strides: An integer or tuple/list of 2 integers,
       specifying the strides of the convolution along the height and width.
       Can be a single integer to specify the same value for
-      all spatial dimensions.
+      all spatial dimensions. Current implementation only supports equal 
+      length strides in the row and column dimensions.
       Specifying any stride value != 1 is incompatible with specifying
       any `dilation_rate` value != 1.
     padding: one of `"valid"` or `"same"` (case-insensitive).


### PR DESCRIPTION
Updating `stride` argument in `SeparableConv2D` class as it currently supports  equal 
      length strides in the row and column dimensions.

Fixes the issue https://github.com/tensorflow/tensorflow/issues/45259