### PR TITLE
Fix a bug about opengles(AARCH64 Ubuntu 18.04)

### DIFF
--- a/tensorflow/lite/delegates/gpu/cl/api.cc
+++ b/tensorflow/lite/delegates/gpu/cl/api.cc
@@ -41,6 +41,9 @@ limitations under the License.
 
 #ifdef CL_DELEGATE_ALLOW_GL
 #include <EGL/eglext.h>
+//add by sky on 20210402
+//Why: see ../gl/portable_gl31.h:line 36-47
+#undef Status
 
 #include "tensorflow/lite/delegates/gpu/cl/egl_sync.h"
 #include "tensorflow/lite/delegates/gpu/cl/gl_interop.h"

--- a/tensorflow/lite/delegates/gpu/cl/api.h
+++ b/tensorflow/lite/delegates/gpu/cl/api.h
@@ -22,6 +22,10 @@ limitations under the License.
 
 #include <EGL/egl.h>
 
+//add by sky on 20210402
+//Why: see ../gl/portable_gl31.h:line 36-47
+#undef Status
+
 #include <cstdint>
 #include <memory>
 

--- a/tensorflow/lite/delegates/gpu/cl/egl_sync.h
+++ b/tensorflow/lite/delegates/gpu/cl/egl_sync.h
@@ -19,6 +19,10 @@ limitations under the License.
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 
+//add by sky on 20210402
+//Why: see ../gl/portable_gl31.h:line 36-47
+#undef Status
+
 #include "tensorflow/lite/delegates/gpu/common/status.h"
 
 namespace tflite {

--- a/tensorflow/lite/delegates/gpu/cl/gl_interop.h
+++ b/tensorflow/lite/delegates/gpu/cl/gl_interop.h
@@ -19,6 +19,10 @@ limitations under the License.
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 
+//add by sky on 20210402
+//Why: see ../gl/portable_gl31.h:line 36-47
+#undef Status
+
 #include <vector>
 
 #include "tensorflow/lite/delegates/gpu/cl/cl_command_queue.h"

--- a/tensorflow/lite/delegates/gpu/cl/gpu_api_delegate.h
+++ b/tensorflow/lite/delegates/gpu/cl/gpu_api_delegate.h
@@ -20,6 +20,11 @@ limitations under the License.
 #define EGL_NO_PROTOTYPES
 #include <EGL/egl.h>
 #include <GLES3/gl31.h>
+
+//add by sky on 20210402
+//Why: see ../gl/portable_gl31.h:line 36-47
+#undef Status
+
 #undef GL_NO_PROTOTYPES
 #undef EGL_NO_PROTOTYPES
 

--- a/tensorflow/lite/delegates/gpu/gl/portable_egl.h
+++ b/tensorflow/lite/delegates/gpu/gl/portable_egl.h
@@ -19,4 +19,8 @@ limitations under the License.
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 
+//add by sky on 20210402
+//Why: see portable_gl31.h:line 36-47
+#undef Status
+
 #endif  // TENSORFLOW_LITE_DELEGATES_GPU_GL_PORTABLE_EGL_H_

--- a/tensorflow/lite/delegates/gpu/gl/portable_gl31.h
+++ b/tensorflow/lite/delegates/gpu/gl/portable_gl31.h
@@ -33,4 +33,18 @@ limitations under the License.
 
 #include <GLES3/gl31.h>
 
+/*
+//add by sky on 20210402
+//note:
+"#include <EGL/egl.h>" import a macro 'Status' from there:
+In file EGL/egl.h: #include <EGL/eglplatform.h>
+In file EGL/eglplatform.h: #include <X11/Xlib.h>
+In file X11/Xlib.h(line:83): #define Status int
+
+After we import it, if you define a var like 'absl::Status TestVar', the compiler will precompile it to 'absl::int TestVar'. It is a disaster.
+
+we should undef it to avoid this disaster.
+*/
+#undef Status
+
 #endif  // TENSORFLOW_LITE_DELEGATES_GPU_GL_PORTABLE_GL31_H_

--- a/tensorflow/lite/delegates/gpu/gl_delegate.cc
+++ b/tensorflow/lite/delegates/gpu/gl_delegate.cc
@@ -18,6 +18,10 @@ limitations under the License.
 #include <EGL/egl.h>
 #include <GLES3/gl31.h>
 
+//add by sky on 20210402
+//Why: see gl/portable_gl31.h:line 36-47
+#undef Status
+
 #include <algorithm>
 #include <cstdint>
 #include <cstring>


### PR DESCRIPTION
### Notes:
As "include <EGL/egl.h>" import a macro 'Status' from there:</br>
&nbsp; In file EGL/egl.h: #include <EGL/eglplatform.h></br>
&nbsp; In file EGL/eglplatform.h: #include <X11/Xlib.h></br>
&nbsp; In file X11/Xlib.h(line:83): #define Status int</br>

### Why:
After we import it, if you define a var like 'absl::Status TestVar', the compiler will precompile it to 'absl::int TestVar'. It is a disaster.
we should undef it to avoid this disaster.

### Dependent Issues
https://github.com/tensorflow/tensorflow/issues/46650
https://github.com/google/mediapipe/issues/200

