### PR TITLE
No need for layers.Rescaling(1. / 255.) and layers.Normalization(axis=bn_axis) in efficientnet.py

### DIFF
--- a/tensorflow/python/keras/applications/efficientnet.py
+++ b/tensorflow/python/keras/applications/efficientnet.py
@@ -317,8 +317,6 @@ def EfficientNet(
 
   # Build stem
   x = img_input
-  x = layers.Rescaling(1. / 255.)(x)
-  x = layers.Normalization(axis=bn_axis)(x)
 
   x = layers.ZeroPadding2D(
       padding=imagenet_utils.correct_pad(x, 3),


### PR DESCRIPTION
in tensorflow/tensorflow/python/keras/applications/efficientnet.py
at line 316,317 there is 

x = layers.Rescaling(1. / 255.)(x)
x = layers.Normalization(axis=bn_axis)(x)

We normally put normalized data as input, and other networks(like mobilenet and resnet) other than efficientnet don't have such layers.
I think these two layers should be removed.