### PR TITLE
Heuristic adjust hash table size in unique_op

### DIFF
--- a/tensorflow/core/ops/array_ops.cc
+++ b/tensorflow/core/ops/array_ops.cc
@@ -1491,6 +1491,7 @@ REGISTER_OP("Unique")
     .Output("idx: out_idx")
     .Attr("T: type")
     .Attr("out_idx: {int32, int64} = DT_INT32")
+    .Attr("auto_adjust_uniq_table_size: bool = false")
     .SetShapeFn([](InferenceContext* c) {
       c->set_output(0, c->Vector(InferenceContext::kUnknownDim));
       c->set_output(1, c->input(0));
@@ -1507,6 +1508,7 @@ REGISTER_OP("UniqueV2")
     .Attr("T: type")
     .Attr("Taxis: {int32,int64} = DT_INT64")
     .Attr("out_idx: {int32, int64} = DT_INT32")
+    .Attr("auto_adjust_uniq_table_size: bool = false")
     .SetShapeFn([](InferenceContext* c) {
       c->set_output(0, c->UnknownShapeOfRank(c->Rank(c->input(0))));
       TF_RETURN_IF_ERROR(UniqueIdxShapeFn(c));

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -1968,7 +1968,10 @@ def sparse_mask(a, mask_indices, name=None):
 
 @tf_export("unique")
 @dispatch.add_dispatch_support
-def unique(x, out_idx=dtypes.int32, name=None):
+def unique(x,
+           out_idx=dtypes.int32,
+           auto_adjust_uniq_table_size=False,
+           name=None):
   """Finds unique elements in a 1-D tensor.
 
   See also `tf.unique_with_counts`.
@@ -1996,6 +1999,8 @@ def unique(x, out_idx=dtypes.int32, name=None):
     x: A Tensor. 1-D.
     out_idx: An optional tf.DType from: tf.int32, tf.int64. Defaults to
       tf.int32.
+    auto_adjust_uniq_table_size: When the repetition rate is high, some
+      performance can be improved by adjusting this parameter.
     name: A name for the operation (optional).
 
   Returns:
@@ -2008,7 +2013,7 @@ def unique(x, out_idx=dtypes.int32, name=None):
   # period (3 weeks) pass.
   # TODO(yongtang): The documentation should also
   # be updated when switch  to v2.
-  return gen_array_ops.unique(x, out_idx, name)
+  return gen_array_ops.unique(x, out_idx, auto_adjust_uniq_table_size, name)
 
 
 unique.__doc__ = gen_array_ops.unique.__doc__


### PR DESCRIPTION
I find unique hash table size has a trouble performance in my test.
>My test: Input: size:20\*1000k, uniqued size:5\*1000k.

I find heavy DRAM Bound by vtune .

so I decrease hash size from default value(2*input_size) to custom value(1*input).
> cmp test:

>> Origin: The initial size of the hash table in unique_op is 2*input_size

>> My test: The initial size of the hash table in unique_op is 1*input_size(change source code"tensorflow/core/kernels/unique_op.cc").

> cmp result:
>> Origin: spend: 2.517s
>> My test: spend: 1.709s(↑32.1%)

So I think we should adjust default hash table size from default value to dynamic size.

