### PR TITLE
Adjust adjust unique hash table size to decrease memory bound .

### DIFF
--- a/tensorflow/core/kernels/unique_op.cc
+++ b/tensorflow/core/kernels/unique_op.cc
@@ -76,7 +76,13 @@ struct UniqueOpHashMap<bfloat16, TIndex> {
 template <typename T, typename TIndex>
 class UniqueOp : public OpKernel {
  public:
-  explicit UniqueOp(OpKernelConstruction* context) : OpKernel(context) {}
+  static constexpr size_t INIT_SIZE = 1 << 12;
+
+ public:
+  explicit UniqueOp(OpKernelConstruction* c) : OpKernel(c) {
+    uniq_table_size_ = INIT_SIZE;
+    OP_REQUIRES_OK(c, c->GetAttr("auto_adjust_uniq_table_size", &auto_adjust_));
+  }
 
   void Compute(OpKernelContext* context) override {
     const Tensor& input = context->input(0);
@@ -151,7 +157,7 @@ class UniqueOp : public OpKernel {
       const int64 N = static_cast<int64>(Tin.size());
 
       typename UniqueOpHashMap<T, TIndex>::map_type uniq;
-      uniq.reserve(2 * N);
+      uniq.reserve(auto_adjust_ ? uniq_table_size_ : (N << 1));
       for (Eigen::Index i = 0, j = 0; i < N; ++i) {
         auto it = uniq.emplace(Tin(i), j);
         idx_vec(i) = it.first->second;
@@ -161,6 +167,9 @@ class UniqueOp : public OpKernel {
       }
 
       uniq_size = static_cast<int64>(uniq.size());
+      if (auto_adjust_) {
+        AutoAdjustUniqTableSize(uniq_size);
+      }
       TensorShape output_shape(input.shape());
       output_shape.set_dim(axis, uniq_size);
       Tensor* output = nullptr;
@@ -200,8 +209,7 @@ class UniqueOp : public OpKernel {
       absl::flat_hash_map<int64, int64, decltype(hash_fn),
                           decltype(equal_to_fn)>
           uniq(0, hash_fn, equal_to_fn);
-
-      uniq.reserve(2 * Tin.dimension(1));
+      uniq.reserve(auto_adjust_ ? uniq_table_size_ : (Tin.dimension(1) << 1));
 
       for (int64 i = 0, j = 0; i < Tin.dimension(1); ++i) {
         auto it = uniq.emplace(i, j);
@@ -212,6 +220,9 @@ class UniqueOp : public OpKernel {
       }
 
       uniq_size = static_cast<int64>(uniq.size());
+      if (auto_adjust_) {
+        AutoAdjustUniqTableSize(uniq_size);
+      }
       new_sizes[1] = uniq_size;
       TensorShape output_shape(input.shape());
       output_shape.set_dim(axis, uniq_size);
@@ -237,6 +248,19 @@ class UniqueOp : public OpKernel {
       }
     }
   }
+
+ private:
+  void AutoAdjustUniqTableSize(const size_t uniq_size) {
+    if ((uniq_size << 1) > uniq_table_size_) {
+      uniq_table_size_ = uniq_size * 2.1;
+    } else if (uniq_size > (uniq_table_size_ << 2)) {
+      uniq_table_size_ = (uniq_size >> 2);
+    }
+  }
+
+ private:
+  size_t uniq_table_size_ = 0;
+  bool auto_adjust_ = false;
 };
 
 #define REGISTER_UNIQUE(type)                                    \

--- a/tensorflow/core/ops/array_ops.cc
+++ b/tensorflow/core/ops/array_ops.cc
@@ -1523,6 +1523,7 @@ REGISTER_OP("UniqueWithCounts")
     .Output("count: out_idx")
     .Attr("T: type")
     .Attr("out_idx: {int32, int64} = DT_INT32")
+    .Attr("auto_adjust_uniq_table_size: bool = false")
     .SetShapeFn([](InferenceContext* c) {
       auto uniq = c->Vector(InferenceContext::kUnknownDim);
       c->set_output(0, uniq);
@@ -1540,6 +1541,7 @@ REGISTER_OP("UniqueWithCountsV2")
     .Attr("T: type")
     .Attr("Taxis: {int32,int64} = DT_INT64")
     .Attr("out_idx: {int32, int64} = DT_INT32")
+    .Attr("auto_adjust_uniq_table_size: bool = false")
     .SetShapeFn([](InferenceContext* c) {
       c->set_output(0, c->UnknownShapeOfRank(c->Rank(c->input(0))));
       TF_RETURN_IF_ERROR(UniqueIdxShapeFn(c));

--- a/tensorflow/core/ops/array_ops.cc
+++ b/tensorflow/core/ops/array_ops.cc
@@ -1491,6 +1491,7 @@ REGISTER_OP("Unique")
     .Output("idx: out_idx")
     .Attr("T: type")
     .Attr("out_idx: {int32, int64} = DT_INT32")
+    .Attr("auto_adjust_uniq_table_size: bool = false")
     .SetShapeFn([](InferenceContext* c) {
       c->set_output(0, c->Vector(InferenceContext::kUnknownDim));
       c->set_output(1, c->input(0));
@@ -1507,6 +1508,7 @@ REGISTER_OP("UniqueV2")
     .Attr("T: type")
     .Attr("Taxis: {int32,int64} = DT_INT64")
     .Attr("out_idx: {int32, int64} = DT_INT32")
+    .Attr("auto_adjust_uniq_table_size: bool = false")
     .SetShapeFn([](InferenceContext* c) {
       c->set_output(0, c->UnknownShapeOfRank(c->Rank(c->input(0))));
       TF_RETURN_IF_ERROR(UniqueIdxShapeFn(c));

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -1968,7 +1968,10 @@ def sparse_mask(a, mask_indices, name=None):
 
 @tf_export("unique")
 @dispatch.add_dispatch_support
-def unique(x, out_idx=dtypes.int32, name=None):
+def unique(x,
+           out_idx=dtypes.int32,
+           auto_adjust_uniq_table_size=False,
+           name=None):
   """Finds unique elements in a 1-D tensor.
 
   See also `tf.unique_with_counts`.
@@ -1996,6 +1999,8 @@ def unique(x, out_idx=dtypes.int32, name=None):
     x: A Tensor. 1-D.
     out_idx: An optional tf.DType from: tf.int32, tf.int64. Defaults to
       tf.int32.
+    auto_adjust_uniq_table_size: When the repetition rate is high, some
+      performance can be improved by adjusting this parameter.
     name: A name for the operation (optional).
 
   Returns:
@@ -2008,7 +2013,7 @@ def unique(x, out_idx=dtypes.int32, name=None):
   # period (3 weeks) pass.
   # TODO(yongtang): The documentation should also
   # be updated when switch  to v2.
-  return gen_array_ops.unique(x, out_idx, name)
+  return gen_array_ops.unique(x, out_idx, auto_adjust_uniq_table_size, name)
 
 
 unique.__doc__ = gen_array_ops.unique.__doc__

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -1999,8 +1999,10 @@ def unique(x,
     x: A Tensor. 1-D.
     out_idx: An optional tf.DType from: tf.int32, tf.int64. Defaults to
       tf.int32.
-    auto_adjust_uniq_table_size: When the repetition rate is high, some
-      performance can be improved by adjusting this parameter.
+    auto_adjust_uniq_table_size: A `bool`. If `True`, Heuristic adjustment
+      of memory usage in unique op to decrease DRAM bound and improve
+      performance, else fixed memory usage(2*input_size) in unique op.
+      Defaults to `False`.
     name: A name for the operation (optional).
 
   Returns:


### PR DESCRIPTION
I found a small performance optimization point about unique_op.
>My test data: Input: size:20\*1000k, uniqued size:5\*1000k.

> test A(Origin):
>> Origin: The initial size of the hash table in unique_op is 2*input_size
>> Origin: spend: 2.517s

> I find heavy DRAM Bound by vtune .
> so I decrease hash size from default value(2*input_size) to custom value(1*input).

> test B(My test):
>> My test: The initial size of the hash table in unique_op is 1*input_size(change source code"tensorflow/core/kernels/unique_op.cc").
>> My test: spend: 1.709s**(↑32.1%)**

So I think we should adjust default hash table size from default value to dynamic size.

