### PR TITLE
2.5-rc1 cherry-pick request: Disable GPU SparseToDense

### DIFF
--- a/tensorflow/core/kernels/sparse_to_dense_op.cc
+++ b/tensorflow/core/kernels/sparse_to_dense_op.cc
@@ -273,6 +273,9 @@ class SparseToDenseGPU : public AsyncOpKernel {
   bool validate_indices_;
 };
 
+// TODO(b/184077412): SparseToDense causes an illegal access error.
+
+#if 0
 #define REGISTER_GPU_KERNELS(type, index_type)                         \
   REGISTER_KERNEL_BUILDER(Name("SparseToDense")                        \
                               .Device(DEVICE_GPU)                      \
@@ -292,6 +295,7 @@ REGISTER_GPU_KERNELS_ALL(bool)
 
 #undef REGISTER_GPU_KERNELS_ALL
 #undef REGISTER_GPU_KERNELS
+#endif
 
 #endif  // GOOGLE_CUDA
 

--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -1121,7 +1121,7 @@ tf_py_test(
     ],
 )
 
-cuda_py_test(
+tf_py_test(
     name = "sparse_to_dense_op_py_test",
     size = "small",
     srcs = ["sparse_to_dense_op_py_test.py"],


### PR DESCRIPTION
The GPU version of SparseToDense is introduced in 2.5, but sometimes crashes the process when run, which will crash previously-working models. This cherry-pick disables the GPU version of SparseToDense to fix the issue.

/CC @sanjoy