### PR TITLE
Enable do_pylint only and --incremental

### DIFF
--- a/tensorflow/tools/ci_build/ci_sanity.sh
+++ b/tensorflow/tools/ci_build/ci_sanity.sh
@@ -111,10 +111,10 @@ do_pylint() {
     echo "Invalid syntax for invoking do_pylint"
     echo "Usage: do_pylint [--incremental]"
     return 1
+  else
+    # Get all Python files, regardless of mode.
+    PYTHON_SRC_FILES=$(get_py_files_to_check)
   fi
-
-  # Get all Python files, regardless of mode.
-  PYTHON_SRC_FILES=$(get_py_files_to_check)
 
   # Something happened. TF no longer has Python code if this branch is taken
   if [[ -z ${PYTHON_SRC_FILES} ]]; then
@@ -667,6 +667,8 @@ for arg in "$@"; do
     SANITY_STEPS_DESC=("pep8 test")
   elif [[ "${arg}" == "--incremental" ]]; then
     INCREMENTAL_FLAG="--incremental"
+  elif [[ "${arg}" == "do_pylint" ]]; then
+    SANITY_STEPS=("do_pylint")
   else
     BAZEL_FLAGS="${BAZEL_FLAGS} ${arg}"
   fi

--- a/tensorflow/tools/ci_build/ci_sanity.sh
+++ b/tensorflow/tools/ci_build/ci_sanity.sh
@@ -19,6 +19,7 @@
 # Options:
 #           run sanity checks: python 2&3 pylint checks and bazel nobuild
 #  --pep8   run pep8 test only
+#  --pylint run pylint check only
 #  --incremental  Performs checks incrementally, by using the files changed in
 #                 the latest commit
 
@@ -667,7 +668,7 @@ for arg in "$@"; do
     SANITY_STEPS_DESC=("pep8 test")
   elif [[ "${arg}" == "--incremental" ]]; then
     INCREMENTAL_FLAG="--incremental"
-  elif [[ "${arg}" == "do_pylint" ]]; then
+  elif [[ "${arg}" == "--pylint" ]]; then
     SANITY_STEPS=("do_pylint")
   else
     BAZEL_FLAGS="${BAZEL_FLAGS} ${arg}"

--- a/tensorflow/tools/ci_build/ci_sanity.sh
+++ b/tensorflow/tools/ci_build/ci_sanity.sh
@@ -670,6 +670,7 @@ for arg in "$@"; do
     INCREMENTAL_FLAG="--incremental"
   elif [[ "${arg}" == "--pylint" ]]; then
     SANITY_STEPS=("do_pylint")
+    SANITY_STEPS_DESC=("pylint test")
   else
     BAZEL_FLAGS="${BAZEL_FLAGS} ${arg}"
   fi


### PR DESCRIPTION
This will try to recover `--pylint` only step and `--incremental`

You can check with
`docker run --rm -it -v $PWD:/tensorflow -w /tensorflow tensorflow/tensorflow:devel bash -c "apt-get -y install python3.8 && python3.8 -m pip install pylint==2.7.2 && tensorflow/tools/ci_build/ci_sanity.sh --pylint --incremental"`

Fixes https://github.com/tensorflow/tensorflow/issues/27903