### PR TITLE
Fixes a bug in example code

### DIFF
--- a/tensorflow/lite/g3doc/performance/post_training_quantization.md
+++ b/tensorflow/lite/g3doc/performance/post_training_quantization.md
@@ -68,7 +68,7 @@ samples) of the training or validation data. Refer to the
 <pre>
 def representative_dataset():
   for data in tf.data.Dataset.from_tensor_slices((images)).batch(1).take(100):
-    yield [data.astype(tf.float32)]
+    yield [tf.dtypes.cast(data, tf.float32)]
 </pre>
 
 For testing purposes, you can use a dummy dataset as follows:


### PR DESCRIPTION
The sample implementation of representative_dataset() in the full integer quantization section shows a datatype of tf.float32 instead of np.float32.