### PR TITLE
[r2.5 cherry-pick] Fix Keras Callbacks logs / numpy_logs sync

### DIFF
--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -234,6 +234,8 @@ class CallbackList:
 
     # Performance optimization: determines if batch hooks need to be called.
     # pylint: disable=protected-access
+    self._supports_tf_logs = all(
+        getattr(cb, '_supports_tf_logs', False) for cb in self.callbacks)
     self._should_call_train_batch_hooks = any(
         cb._implements_train_batch_hooks() for cb in self.callbacks)
     self._should_call_test_batch_hooks = any(
@@ -271,6 +273,14 @@ class CallbackList:
     if self._history is None and add_history:
       self._history = History()
       self.callbacks.append(self._history)
+
+  def _process_logs(self, logs):
+    """Turns tensors into numpy arrays or Python scalars if necessary."""
+    if logs is None:
+      return {}
+    if not self._supports_tf_logs:
+      return tf_utils.sync_to_numpy_or_python_type(logs)
+    return logs
 
   def append(self, callback):
     self.callbacks.append(callback)
@@ -347,19 +357,13 @@ class CallbackList:
 
   def _call_batch_hook_helper(self, hook_name, batch, logs):
     """Helper function for `on_*_batch_*` methods."""
-    logs = logs or {}
-    numpy_logs = None
     if self._check_timing:
       start_time = time.time()
 
+    logs = self._process_logs(logs)
     for callback in self.callbacks:
       hook = getattr(callback, hook_name)
-      if getattr(callback, '_supports_tf_logs', False):
-        hook(batch, logs)
-      else:
-        if numpy_logs is None:  # Only convert once.
-          numpy_logs = tf_utils.sync_to_numpy_or_python_type(logs)
-        hook(batch, numpy_logs)
+      hook(batch, logs)
 
     if self._check_timing:
       if hook_name not in self._hook_times:
@@ -402,15 +406,9 @@ class CallbackList:
         logs: Dict. Currently no data is passed to this argument for this method
           but that may change in the future.
     """
-    logs = logs or {}
-    numpy_logs = None
+    logs = self._process_logs(logs)
     for callback in self.callbacks:
-      if getattr(callback, '_supports_tf_logs', False):
-        callback.on_epoch_begin(epoch, logs)
-      else:
-        if numpy_logs is None:  # Only convert once.
-          numpy_logs = tf_utils.sync_to_numpy_or_python_type(logs)
-        callback.on_epoch_begin(epoch, numpy_logs)
+      callback.on_epoch_begin(epoch, logs)
 
   def on_epoch_end(self, epoch, logs=None):
     """Calls the `on_epoch_end` methods of its callbacks.
@@ -423,15 +421,9 @@ class CallbackList:
           validation epoch if validation is performed. Validation result keys
           are prefixed with `val_`.
     """
-    logs = logs or {}
-    numpy_logs = None
+    logs = self._process_logs(logs)
     for callback in self.callbacks:
-      if getattr(callback, '_supports_tf_logs', False):
-        callback.on_epoch_end(epoch, logs)
-      else:
-        if numpy_logs is None:  # Only convert once.
-          numpy_logs = tf_utils.sync_to_numpy_or_python_type(logs)
-        callback.on_epoch_end(epoch, numpy_logs)
+      callback.on_epoch_end(epoch, logs)
 
   def on_train_batch_begin(self, batch, logs=None):
     """Calls the `on_train_batch_begin` methods of its callbacks.
@@ -506,15 +498,9 @@ class CallbackList:
         logs: Dict. Currently no data is passed to this argument for this method
           but that may change in the future.
     """
-    logs = logs or {}
-    numpy_logs = None
+    logs = self._process_logs(logs)
     for callback in self.callbacks:
-      if getattr(callback, '_supports_tf_logs', False):
-        callback.on_train_begin(logs)
-      else:
-        if numpy_logs is None:  # Only convert once.
-          numpy_logs = tf_utils.sync_to_numpy_or_python_type(logs)
-        callback.on_train_begin(numpy_logs)
+      callback.on_train_begin(logs)
 
   def on_train_end(self, logs=None):
     """Calls the `on_train_end` methods of its callbacks.
@@ -523,15 +509,9 @@ class CallbackList:
         logs: Dict. Currently no data is passed to this argument for this method
           but that may change in the future.
     """
-    logs = logs or {}
-    numpy_logs = None
+    logs = self._process_logs(logs)
     for callback in self.callbacks:
-      if getattr(callback, '_supports_tf_logs', False):
-        callback.on_train_end(logs)
-      else:
-        if numpy_logs is None:  # Only convert once.
-          numpy_logs = tf_utils.sync_to_numpy_or_python_type(logs)
-        callback.on_train_end(numpy_logs)
+      callback.on_train_end(logs)
 
   def on_test_begin(self, logs=None):
     """Calls the `on_test_begin` methods of its callbacks.
@@ -540,15 +520,9 @@ class CallbackList:
         logs: Dict. Currently no data is passed to this argument for this method
           but that may change in the future.
     """
-    logs = logs or {}
-    numpy_logs = None
+    logs = self._process_logs(logs)
     for callback in self.callbacks:
-      if getattr(callback, '_supports_tf_logs', False):
-        callback.on_test_begin(logs)
-      else:
-        if numpy_logs is None:  # Only convert once.
-          numpy_logs = tf_utils.sync_to_numpy_or_python_type(logs)
-        callback.on_test_begin(numpy_logs)
+      callback.on_test_begin(logs)
 
   def on_test_end(self, logs=None):
     """Calls the `on_test_end` methods of its callbacks.
@@ -557,15 +531,9 @@ class CallbackList:
         logs: Dict. Currently no data is passed to this argument for this method
           but that may change in the future.
     """
-    logs = logs or {}
-    numpy_logs = None
+    logs = self._process_logs(logs)
     for callback in self.callbacks:
-      if getattr(callback, '_supports_tf_logs', False):
-        callback.on_test_end(logs)
-      else:
-        if numpy_logs is None:  # Only convert once.
-          numpy_logs = tf_utils.sync_to_numpy_or_python_type(logs)
-        callback.on_test_end(numpy_logs)
+      callback.on_test_end(logs)
 
   def on_predict_begin(self, logs=None):
     """Calls the 'on_predict_begin` methods of its callbacks.
@@ -574,15 +542,9 @@ class CallbackList:
         logs: Dict. Currently no data is passed to this argument for this method
           but that may change in the future.
     """
-    logs = logs or {}
-    numpy_logs = None
+    logs = self._process_logs(logs)
     for callback in self.callbacks:
-      if getattr(callback, '_supports_tf_logs', False):
-        callback.on_predict_begin(logs)
-      else:
-        if numpy_logs is None:  # Only convert once.
-          numpy_logs = tf_utils.sync_to_numpy_or_python_type(logs)
-        callback.on_predict_begin(numpy_logs)
+      callback.on_predict_begin(logs)
 
   def on_predict_end(self, logs=None):
     """Calls the `on_predict_end` methods of its callbacks.
@@ -591,15 +553,9 @@ class CallbackList:
         logs: Dict. Currently no data is passed to this argument for this method
           but that may change in the future.
     """
-    logs = logs or {}
-    numpy_logs = None
+    logs = self._process_logs(logs)
     for callback in self.callbacks:
-      if getattr(callback, '_supports_tf_logs', False):
-        callback.on_predict_end(logs)
-      else:
-        if numpy_logs is None:  # Only convert once.
-          numpy_logs = tf_utils.sync_to_numpy_or_python_type(logs)
-        callback.on_predict_end(numpy_logs)
+      callback.on_predict_end(logs)
 
   def __iter__(self):
     return iter(self.callbacks)

--- a/tensorflow/python/keras/callbacks_test.py
+++ b/tensorflow/python/keras/callbacks_test.py
@@ -1694,6 +1694,12 @@ class KerasCallbacksTest(keras_parameterized.TestCase):
       def on_predict_batch_end(self, batch, logs=None):
         self.predict_batches += 1
 
+    class MyCallbackWithTFBatchHooks(keras.callbacks.Callback):
+
+      def __init__(self):
+        super(MyCallbackWithTFBatchHooks, self).__init__()
+        self._supports_tf_logs = True
+
     class MyCallbackWithoutBatchHooks(keras.callbacks.Callback):
 
       def __init__(self):
@@ -1711,6 +1717,7 @@ class KerasCallbacksTest(keras_parameterized.TestCase):
     self.assertTrue(cb_list._should_call_train_batch_hooks)
     self.assertTrue(cb_list._should_call_test_batch_hooks)
     self.assertTrue(cb_list._should_call_predict_batch_hooks)
+    self.assertFalse(cb_list._batch_hooks_support_tf_logs)
 
     model.fit(x, y, epochs=2, batch_size=10, callbacks=[my_cb], verbose=0)
     model.evaluate(x, y, batch_size=10, callbacks=[my_cb], verbose=0)
@@ -1719,6 +1726,10 @@ class KerasCallbacksTest(keras_parameterized.TestCase):
     self.assertEqual(my_cb.train_batches, 2)
     self.assertEqual(my_cb.test_batches, 1)
     self.assertEqual(my_cb.predict_batches, 1)
+
+    my_cb = MyCallbackWithTFBatchHooks()
+    cb_list = keras.callbacks.CallbackList([my_cb], verbose=0)
+    self.assertTrue(cb_list._batch_hooks_support_tf_logs)
 
     my_cb = MyCallbackWithoutBatchHooks()
     cb_list = keras.callbacks.CallbackList([my_cb], verbose=0)


### PR DESCRIPTION
This PR cherry-picks #47922 onto the `r2.5` branch which addresses Keras callback issues reported in #41851 and #45895.
Would be great if this fix could make it into the 2.5.