### PR TITLE
[TFLite/nnapi delegate] add rank restriction for reshape op

### DIFF
--- a/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
+++ b/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
@@ -1900,6 +1900,14 @@ bool NNAPIDelegateKernel::Validate(
     case kTfLiteBuiltinReshape: {
       ExpectOpVersion(version, 1, &val_ctx);
       ExpectIsFloatOrQuant8Operator(context, node, &val_ctx);
+      const auto& input = context->tensors[node->inputs->data[0]];
+      Expect(input.dims->size <= 4,
+             NNAPIValidationFailureType::kUnsupportedOperandRank,
+             "Input rank should be <= 4", &val_ctx);
+      const auto& output = context->tensors[node->outputs->data[0]];
+      Expect(output.dims->size <= 4,
+             NNAPIValidationFailureType::kUnsupportedOperandRank,
+             "Output rank should be <= 4", &val_ctx);
       if (node->inputs->size >= 2) {
         Expect(context->tensors[node->inputs->data[1]].allocation_type ==
                    kTfLiteMmapRo,


### PR DESCRIPTION
Android NN API only supported tensor rank of reshape op: up to 4.
https://github.com/tensorflow/tensorflow/issues/47546