### PR TITLE
Fix faulty link to numpy docs.

### DIFF
--- a/tensorflow/python/ops/numpy_ops/__init__.py
+++ b/tensorflow/python/ops/numpy_ops/__init__.py
@@ -185,12 +185,12 @@ from tensorflow.python.ops.numpy_ops.np_utils import result_type
 
 
 # pylint: disable=redefined-builtin,undefined-variable
-@np_utils.np_doc("max", link=np_utils.AliasOf("maximum"))
+@np_utils.np_doc("max", link=np_utils.AliasOf("amax"))
 def max(a, axis=None, keepdims=None):
   return amax(a, axis=axis, keepdims=keepdims)
 
 
-@np_utils.np_doc("min", link=np_utils.AliasOf("minimum"))
+@np_utils.np_doc("min", link=np_utils.AliasOf("amin"))
 def min(a, axis=None, keepdims=None):
   return amin(a, axis=axis, keepdims=keepdims)
 


### PR DESCRIPTION
The links to the numpy documentation for `tensorflow.experimental.numpy.min()` and `tnp.max()` point to the documentation of `np.minimum()` and `np.maximum()` but this is wrong. `tnp.max()` roughly corresponds to `np.amax()` and `tnp.maximum()` to `np.maximum()`.