### PR TITLE
[CherryPick:r2.5] Rollback of rollback of [TF/XLA] Make sure that XLAControlFlowContext is injected on all paths of jit_compile=True

### DIFF
--- a/tensorflow/python/eager/def_function.py
+++ b/tensorflow/python/eager/def_function.py
@@ -517,6 +517,24 @@ class FunctionDeleter(object):
       pass
 
 
+class OptionalXlaContext(object):
+  """Wrapper for XLA context optionally applied under a context manager."""
+
+  def __init__(self, is_compiled):
+    wrap = is_compiled and not control_flow_util.GraphOrParentsInXlaContext( \
+              ops.get_default_graph())
+    self.xla_context = control_flow_ops.XLAControlFlowContext() \
+        if wrap else None
+
+  def __enter__(self):
+    if self.xla_context:
+      self.xla_context.Enter()
+
+  def __exit__(self, t, value, traceback):
+    if self.xla_context:
+      self.xla_context.Exit()
+
+
 # TODO(mdan): Consider expose this type for instance type checking.
 @tf_export("__internal__.function.Function", v1=[])
 class Function(object):
@@ -650,15 +668,7 @@ class Function(object):
       with default_graph._variable_creator_scope(scope, priority=50):  # pylint: disable=protected-access
         # __wrapped__ allows AutoGraph to swap in a converted function. We give
         # the function a weak reference to itself to avoid a reference cycle.
-        if compile_with_xla and \
-            not control_flow_util.GraphOrParentsInXlaContext(default_graph):
-          xla_context = control_flow_ops.XLAControlFlowContext()
-          try:
-            xla_context.Enter()
-            out = weak_wrapped_fn().__wrapped__(*args, **kwds)
-          finally:
-            xla_context.Exit()
-        else:
+        with OptionalXlaContext(compile_with_xla):
           out = weak_wrapped_fn().__wrapped__(*args, **kwds)
         return out
 
@@ -752,18 +762,6 @@ class Function(object):
     self._concrete_stateful_fn = (
         self._stateful_fn._get_concrete_function_internal_garbage_collected(  # pylint: disable=protected-access
             *args, **kwds))
-
-    compiled = bool(self._jit_compile and
-                    not control_flow_util.GraphOrParentsInXlaContext(
-                        ops.get_default_graph()))
-    # For nested functions, increment the counter only when a function with
-    # jit_compile=True is called within a function with jit_compile=False. We
-    # count this special case to correctly record that both jit_compile=True and
-    # jit_compile=False is being used for parts of the outer function.
-    if ops.executing_eagerly_outside_functions() and (
-        context.executing_eagerly() or compiled):
-      # Labels must be strings in Python, so we convert 'compiled' to a string
-      _tf_function_counter.get_cell(str(int(compiled))).increase_by(1)
 
     def invalid_creator_scope(*unused_args, **unused_kwds):
       """Disables variable creation."""
@@ -867,10 +865,29 @@ class Function(object):
       with trace.Trace(self._name, tf_function_call="eager"):
         return self._python_function(*args, **kwds)
 
+    # Only count the statistics the fitst time, before initialization took
+    # place.
+    if self._created_variables is None:
+      compiled = bool(self._jit_compile and
+                      not control_flow_util.GraphOrParentsInXlaContext(
+                          ops.get_default_graph()))
+      # For nested functions, increment the counter only when a function with
+      # jit_compile=True is called within a function with jit_compile=False. We
+      # count this special case to correctly record that both jit_compile=True
+      # and jit_compile=False is being used for parts of the outer function.
+      if ops.executing_eagerly_outside_functions() and (
+          context.executing_eagerly() or compiled):
+        # Labels must be strings in Python, so we convert 'compiled' to a string
+        _tf_function_counter.get_cell(str(int(compiled))).increase_by(1)
+
     tracing_count = self.experimental_get_tracing_count()
     with trace.Trace(self._name) as tm:
-      result = self._call(*args, **kwds)
+      # TODO(cheshire): Do not duplicate the XLAControlFlowContext annotation.
       compiler = "xla" if self._jit_compile else "nonXla"
+
+      with OptionalXlaContext(self._jit_compile):
+        result = self._call(*args, **kwds)
+
       new_tracing_count = self.experimental_get_tracing_count()
       without_tracing = (tracing_count == new_tracing_count)
       execution_mode = "notTraced" if without_tracing else "traced"

--- a/tensorflow/python/eager/def_function_xla_jit_test.py
+++ b/tensorflow/python/eager/def_function_xla_jit_test.py
@@ -900,7 +900,7 @@ class DefFunctionTest(xla_test.XLATestCase):
                                     'EXPECTED_MESSAGE_OLD'):
           f()
 
-  def test_counter(self):
+  def testCounter(self):
     cell_nojit = def_function._tf_function_counter.get_cell('0')
     cell_jit = def_function._tf_function_counter.get_cell('1')
     orig_nojit = cell_nojit.value()
@@ -981,6 +981,18 @@ class DefFunctionTest(xla_test.XLATestCase):
           return array_ops.reshape(x * 3, d)
 
       f(random_ops.random_normal([10, 10]), constant_op.constant([100]))
+
+  def testConditionalGradientTapeMathRegression(self):
+    with ops.device('device:{}:0'.format(self.device)):
+      with backprop.GradientTape():
+
+        @def_function.function(jit_compile=True, autograph=False)
+        def f(x):
+          return control_flow_ops.cond(
+              math_ops.reduce_all(x > 1), lambda: 1. / x, lambda: x)
+
+        v = variables.Variable([[2.]])
+        self.assertAllClose(f(v), constant_op.constant([[0.5]]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
PiperOrigin-RevId: 366389161
Change-Id: If4aca391be05315ccc875ac43acdcbc70bc64c67