### PR TITLE
[CherryPick:r2.5][tf.data] Apply options for a dataset before it is copied to another device in `tf.data.experimental.copy_to_device()`.

### DIFF
--- a/tensorflow/python/data/experimental/kernel_tests/BUILD
+++ b/tensorflow/python/data/experimental/kernel_tests/BUILD
@@ -116,6 +116,7 @@ cuda_py_test(
         "//tensorflow/python:math_ops",
         "//tensorflow/python/compat",
         "//tensorflow/python/data/experimental/ops:prefetching_ops",
+        "//tensorflow/python/data/experimental/ops:testing",
         "//tensorflow/python/data/kernel_tests:test_base",
         "//tensorflow/python/data/ops:dataset_ops",
         "//tensorflow/python/data/ops:iterator_ops",

--- a/tensorflow/python/data/experimental/kernel_tests/copy_to_device_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/copy_to_device_test.py
@@ -21,6 +21,7 @@ from absl.testing import parameterized
 
 from tensorflow.core.protobuf import config_pb2
 from tensorflow.python.data.experimental.ops import prefetching_ops
+from tensorflow.python.data.experimental.ops import testing
 from tensorflow.python.data.kernel_tests import test_base
 from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.data.ops import iterator_ops
@@ -61,6 +62,24 @@ class CopyToDeviceTest(test_base.DatasetTestBase, parameterized.TestCase):
     with self.test_session(config=worker_config):
       for i in range(10):
         self.assertEqual(i, self.evaluate(next_element))
+      with self.assertRaises(errors.OutOfRangeError):
+        self.evaluate(next_element)
+
+  @combinations.generate(test_base.graph_only_combinations())
+  def testCopyToDeviceHostOptimizations(self):
+    host_dataset = dataset_ops.Dataset.range(10)
+    host_dataset = host_dataset.apply(testing.assert_next(["MapAndBatch"]))
+    host_dataset = host_dataset.map(lambda x: x*x).batch(10)
+    device_dataset = host_dataset.apply(
+        prefetching_ops.copy_to_device("/cpu:1"))
+
+    with ops.device("/cpu:1"):
+      iterator = dataset_ops.make_one_shot_iterator(device_dataset)
+      next_element = iterator.get_next()
+
+    worker_config = config_pb2.ConfigProto(device_count={"CPU": 2})
+    with self.test_session(config=worker_config):
+      self.assertAllEqual([x*x for x in range(10)], self.evaluate(next_element))
       with self.assertRaises(errors.OutOfRangeError):
         self.evaluate(next_element)
 

--- a/tensorflow/python/data/experimental/ops/prefetching_ops.py
+++ b/tensorflow/python/data/experimental/ops/prefetching_ops.py
@@ -94,7 +94,7 @@ class _CopyToDeviceDataset(dataset_ops.UnaryUnchangedStructureDataset):
       target_device: The name of the device to which elements would be copied.
       source_device: Device where input_dataset would be placed.
     """
-    self._input_dataset = input_dataset
+    self._input_dataset = input_dataset._apply_options()  # pylint: disable=protected-access
     self._target_device = target_device
     spec = framework_device.DeviceSpec().from_string(self._target_device)
     self._is_gpu_target = (spec.device_type == "GPU")


### PR DESCRIPTION
PiperOrigin-RevId: 366293759
Change-Id: I2f38afd28f448cbd5a731a4a0261d74b3cc4ad0c