### PR TITLE
Allow specifying dtype to keras dataset generator

### DIFF
--- a/tensorflow/python/keras/preprocessing/image_dataset.py
+++ b/tensorflow/python/keras/preprocessing/image_dataset.py
@@ -20,6 +20,7 @@ import numpy as np
 from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.keras.layers.preprocessing import image_preprocessing
 from tensorflow.python.keras.preprocessing import dataset_utils
+from tensorflow.python.framework import dtypes
 from tensorflow.python.keras.preprocessing import image as keras_image_ops
 from tensorflow.python.ops import image_ops
 from tensorflow.python.ops import io_ops
@@ -43,7 +44,8 @@ def image_dataset_from_directory(directory,
                                  subset=None,
                                  interpolation='bilinear',
                                  follow_links=False,
-                                 smart_resize=False):
+                                 smart_resize=False,
+                                 dtype=dtypes.uint8):
   """Generates a `tf.data.Dataset` from image files in a directory.
 
   If your directory structure is:
@@ -117,6 +119,8 @@ def image_dataset_from_directory(directory,
       ratio of the original image by using a mixture of resizing and cropping.
       If False (default), the resizing function is `tf.image.resize`, which
       does not preserve aspect ratio.
+    dtype: The data type that should be used to load the image.
+        Defaults to uint8
 
   Returns:
     A `tf.data.Dataset` object.
@@ -207,7 +211,9 @@ def image_dataset_from_directory(directory,
       label_mode=label_mode,
       num_classes=len(class_names),
       interpolation=interpolation,
-      smart_resize=smart_resize)
+      smart_resize=smart_resize,
+      dtype=dtype)
+
   if shuffle:
     # Shuffle locally at each iteration
     dataset = dataset.shuffle(buffer_size=batch_size * 8, seed=seed)
@@ -226,7 +232,8 @@ def paths_and_labels_to_dataset(image_paths,
                                 label_mode,
                                 num_classes,
                                 interpolation,
-                                smart_resize=False):
+                                smart_resize=False,
+                                dtype=dtypes.uint8):
   """Constructs a dataset of images and labels."""
   # TODO(fchollet): consider making num_parallel_calls settable
   path_ds = dataset_ops.Dataset.from_tensor_slices(image_paths)
@@ -240,11 +247,11 @@ def paths_and_labels_to_dataset(image_paths,
 
 
 def load_image(path, image_size, num_channels, interpolation,
-               smart_resize=False):
+               smart_resize=False, dtype=dtypes.uint8):
   """Load an image from a path and resize it."""
   img = io_ops.read_file(path)
   img = image_ops.decode_image(
-      img, channels=num_channels, expand_animations=False)
+      img, channels=num_channels, expand_animations=False, dtype=dtype)
   if smart_resize:
     img = keras_image_ops.smart_resize(img, image_size,
                                        interpolation=interpolation)

--- a/tensorflow/python/keras/preprocessing/image_dataset_test.py
+++ b/tensorflow/python/keras/preprocessing/image_dataset_test.py
@@ -38,18 +38,18 @@ class ImageDatasetFromDirectoryTest(keras_parameterized.TestCase):
   def _get_images(self,
                   count=16,
                   color_mode='rgb',
-                  min=0,
-                  max=256,
+                  image_min=0,
+                  image_max=256,
                   dtype=None):
     width = height = 24
     imgs = []
     for _ in range(count):
       if color_mode == 'grayscale':
-        img = np.random.randint(min, max, size=(height, width, 1))
+        img = np.random.randint(image_min, image_max, size=(height, width, 1))
       elif color_mode == 'rgba':
-        img = np.random.randint(min, max, size=(height, width, 4))
+        img = np.random.randint(image_min, image_max, size=(height, width, 4))
       else:
-        img = np.random.randint(min, max, size=(height, width, 3))
+        img = np.random.randint(image_min, image_max, size=(height, width, 3))
       img = image_preproc.array_to_img(img)
       imgs.append(img)
     return imgs
@@ -86,7 +86,11 @@ class ImageDatasetFromDirectoryTest(keras_parameterized.TestCase):
 
     # Save images to the paths
     i = 0
-    for img in self._get_images(color_mode=color_mode, count=count, min=min_img_val, max=max_img_val, dtype=dtype):
+    for img in self._get_images(color_mode=color_mode,
+                                count=count,
+                                min=min_img_val,
+                                max=max_img_val,
+                                dtype=dtype):
       path = paths[i % len(paths)]
       if color_mode == 'rgb':
         ext = 'jpg'
@@ -244,9 +248,18 @@ class ImageDatasetFromDirectoryTest(keras_parameterized.TestCase):
     if PIL is None:
       return  # Skip test if PIL is not available.
 
-    directory = self._prepare_directory(num_classes=1, color_mode='rgba', min_img_val=256, max_img_val=60000, dtype=dtypes.uint16)
+    directory = self._prepare_directory(
+        num_classes=1,
+        color_mode='rgba',
+        min_img_val=256,
+        max_img_val=60000,
+        dtype=dtypes.uint16)
     dataset = image_dataset.image_dataset_from_directory(
-        directory, batch_size=8, image_size=(18, 18), color_mode='rgba', dtype=dtypes.uint16)
+        directory,
+        batch_size=8,
+        image_size=(18, 18),
+        color_mode='rgba',
+        dtype=dtypes.uint16)
     batch = next(iter(dataset))
     self.assertLen(batch, 2)
     self.assertEqual(batch[0].dtype.name, 'uint16')


### PR DESCRIPTION
This change would allow image_dataset_from_directory to load images with
arbitary dtypes, like 16 bit IR imagery.