### PR TITLE
[ROCm] Adding ROCm support for SparseToDense Op

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -4696,7 +4696,7 @@ tf_kernel_library(
     prefix = "sparse_to_dense_op",
     deps = SPARSE_DEPS + [
         "//third_party/eigen3",
-    ] + if_cuda([
+    ] + if_cuda_or_rocm([
         ":gpu_utils",
         "//tensorflow/core/platform:stream_executor",
     ]),

--- a/tensorflow/core/kernels/sparse_to_dense_op.cc
+++ b/tensorflow/core/kernels/sparse_to_dense_op.cc
@@ -37,11 +37,11 @@ limitations under the License.
 #include "tensorflow/core/util/ptr_util.h"
 #include "tensorflow/core/util/sparse/sparse_tensor.h"
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #include "tensorflow/core/kernels/gpu_utils.h"
 #include "tensorflow/core/kernels/sparse_to_dense_op_gpu.h"
 #include "tensorflow/core/platform/stream_executor.h"
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 namespace tensorflow {
 
@@ -191,7 +191,7 @@ REGISTER_KERNELS_ALL(tstring);
 #undef REGISTER_KERNELS_ALL
 #undef REGISTER_KERNELS
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 template <typename T, typename Index>
 class SparseToDenseGPU : public AsyncOpKernel {
  public:
@@ -277,6 +277,6 @@ REGISTER_GPU_KERNELS_ALL(bool)
 #undef REGISTER_GPU_KERNELS_ALL
 #undef REGISTER_GPU_KERNELS
 
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/sparse_to_dense_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/sparse_to_dense_op_gpu.cu.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #define EIGEN_USE_GPU
 
 #include "tensorflow/core/kernels/sparse_to_dense_op_gpu.h"
@@ -26,7 +26,7 @@ limitations under the License.
 #include "tensorflow/core/framework/types.h"
 #include "tensorflow/core/platform/stream_executor.h"
 #include "tensorflow/core/util/gpu_kernel_helper.h"
-#include "tensorflow/stream_executor/cuda/cuda_activation.h"
+#include "tensorflow/stream_executor/gpu/gpu_activation.h"
 
 namespace tensorflow {
 
@@ -192,7 +192,7 @@ void LaunchSparseToDense<T, Index>::operator()(
       // Ensure that within the callback, the proper GPU settings are
       // configured.
       auto stream = c->op_device_context()->stream();
-      se::cuda::ScopedActivateExecutorContext scoped_activation{
+      se::gpu::ScopedActivateExecutorContext scoped_activation{
           stream->parent()};
 
       OP_REQUIRES_ASYNC(c, valid_status.valid == INT_MAX,
@@ -249,4 +249,4 @@ TF_CALL_INTEGRAL_TYPES(DEFINE_GPU_SPEC)
 DEFINE_GPU_SPEC(bool)
 
 }  // namespace tensorflow
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/core/kernels/sparse_to_dense_op_gpu.h
+++ b/tensorflow/core/kernels/sparse_to_dense_op_gpu.h
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if !GOOGLE_CUDA
+#if !GOOGLE_CUDA && !TENSORFLOW_USE_ROCM
 #error This file must only be included when building with Cuda
 #endif
 


### PR DESCRIPTION
The following PR added CUDA support for SparseToDenseOp.

https://github.com/tensorflow/tensorflow/pull/47234

This PR/commit merely enables the same for the ROCm platform

-------------------------------------------

/cc @cheshire @chsigg 