### PR TITLE
Operator validation result reporting for NNAPI

### DIFF
--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -58,10 +58,12 @@ set(CMAKE_PREFIX_PATH
   "${TFLITE_SOURCE_DIR}/tools/cmake/modules"
   ${CMAKE_PREFIX_PATH}
 )
-
+include(CMakeDependentOption)
 option(TFLITE_ENABLE_RUY "Enable experimental RUY integration" OFF)
 option(TFLITE_ENABLE_RESOURCE "Enable experimental support for resources" ON)
 option(TFLITE_ENABLE_NNAPI "Enable NNAPI (Android only)." ON)
+cmake_dependent_option(TFLITE_ENABLE_NNAPI_VERBOSE_VALIDATION "Enable NNAPI verbose validation." OFF
+                       "TFLITE_ENABLE_NNAPI" ON)
 option(TFLITE_ENABLE_MMAP "Enable MMAP (unsupported on Windows)" ON)
 option(TFLITE_ENABLE_GPU "Enable GPU" OFF)
 # This must be enabled when converting from TF models with SELECT_TF_OPS
@@ -298,6 +300,9 @@ if(_TFLITE_ENABLE_NNAPI)
   populate_tflite_source_vars(
     "nnapi" TFLITE_NNAPI_SRCS FILTER "(_disabled)\\.(cc|h)$"
   )
+  if(${TFLITE_ENABLE_NNAPI_VERBOSE_VALIDATION})
+    list(APPEND TFLITE_TARGET_PUBLIC_OPTIONS "-DNNAPI_VERBOSE_VALIDATION")
+  endif()
 else()
   set(TFLITE_DELEGATES_NNAPI_SRCS
     "${TFLITE_SOURCE_DIR}/delegates/nnapi/nnapi_delegate_disabled.cc"

--- a/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
+++ b/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
@@ -57,6 +57,9 @@ limitations under the License.
 #include "tensorflow/lite/nnapi/nnapi_implementation.h"
 #include "tensorflow/lite/nnapi/nnapi_util.h"
 #include "tensorflow/lite/util.h"
+#ifdef NNAPI_VERBOSE_VALIDATION
+#include "tensorflow/lite/schema/schema_generated.h"
+#endif
 #include <farmhash.h>
 
 namespace tflite {
@@ -5133,6 +5136,7 @@ TfLiteStatus StatefulNnApiDelegate::DoPrepare(TfLiteContext* context,
   // Check for every node if it is supported
   const bool is_accelerator_specified = ShouldUseTargetDevices(
       delegate_options, nnapi, /*exclude_nnapi_reference=*/true);
+  std::vector<delegate::nnapi::NNAPIValidationFailure> map_failures;
   for (int node_index : TfLiteIntArrayView(plan)) {
     TfLiteNode* node;
     TfLiteRegistration* registration;
@@ -5140,9 +5144,20 @@ TfLiteStatus StatefulNnApiDelegate::DoPrepare(TfLiteContext* context,
         context, node_index, &node, &registration));
     if (NNAPIDelegateKernel::Validate(context, registration->builtin_code,
                                       registration->version, target_sdk_version,
-                                      node, is_accelerator_specified)) {
+                                      node, is_accelerator_specified,
+                                      &map_failures)) {
       supported_nodes.push_back(node_index);
     }
+#ifdef NNAPI_VERBOSE_VALIDATION
+    for (auto& failure : map_failures) {
+      TFLITE_LOG_PROD(
+          TFLITE_LOG_WARNING, "Operator %s (v%d) refused by NNAPI delegate: %s",
+          tflite::EnumNameBuiltinOperator(
+              static_cast<BuiltinOperator>(registration->builtin_code)),
+          registration->version, failure.message.c_str());
+    }
+    map_failures.clear();
+#endif
   }
 
   // If there are no delegated nodes, short-circuit node replacement.


### PR DESCRIPTION
NNAPI delegate reports the validation failures for operations in the
computation graph. However this information is not visible to the user.

The patch causes NNAPI delegate to print messages for any refused operator appearing in the computational graph, if compiler with NNAPI_VERBOSE_VALIDATION. Also the patch adds the option to activate the NNAPI_VERBOSE_VALIDATION into CMake. 