### PR TITLE
Update the use of setAlpha/setBeta for Cudnn frontend APIs

### DIFF
--- a/tensorflow/stream_executor/cuda/cuda_dnn.cc
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.cc
@@ -3382,22 +3382,19 @@ GetCudnnOperationGraph(dnn::ConvolutionKind kind, dnn::DataType element_type,
   RETURN_MSG_IF_CUDNN_ERROR(conv_desc);
 
   // Alpha is the scaling factor for input.
-  float falpha = 1.0;
-  double dalpha = 1.0;
+  float alpha = 1.0;
   // Beta is the scaling factor for output.
-  float fbeta = 0.0;
-  double dbeta = 0.0;
+  float beta = 0.0;
 
   // CUDNN Operation
-  auto op_builder = cudnn_frontend::OperationBuilder(conv_mode);
-  op_builder.setxDesc(tensor_x).setyDesc(tensor_y).setwDesc(tensor_w).setcDesc(
-      conv_desc);
-  if (cudnn_type == CUDNN_DATA_DOUBLE) {
-    op_builder.setAlpha(dalpha).setBeta(dbeta);
-  } else {
-    op_builder.setAlpha(falpha).setBeta(fbeta);
-  }
-  auto op = op_builder.build();
+  auto op = cudnn_frontend::OperationBuilder(conv_mode)
+                .setxDesc(tensor_x)
+                .setyDesc(tensor_y)
+                .setwDesc(tensor_w)
+                .setcDesc(conv_desc)
+                .setAlpha(alpha)
+                .setBeta(beta)
+                .build();
   RETURN_MSG_IF_CUDNN_ERROR(op);
 
   // CUDNN OperationGraph


### PR DESCRIPTION
The Cudnn frontend APIs overload the setAlpha/setBeta to allow either float or double parameters. The backend stores two copies of the value and will pick the value of correct data type when the build() is called.

This PR follows this behavior and simplifies the usage.

cc. @nluehr 