### PR TITLE
Update sequence.py

### DIFF
--- a/tensorflow/python/keras/preprocessing/sequence.py
+++ b/tensorflow/python/keras/preprocessing/sequence.py
@@ -62,7 +62,7 @@ class TimeseriesGenerator(sequence.TimeseriesGenerator, data_utils.Sequence):
       batch_size: Number of timeseries samples in each batch
           (except maybe the last one).
   # Returns
-      A [Sequence](/utils/#sequence) instance.
+      A [Sequence](https://www.tensorflow.org/api_docs/python/tf/keras/utils/Sequence) instance.
   # Examples
   ```python
   from keras.preprocessing.sequence import TimeseriesGenerator


### PR DESCRIPTION
Documentation for [tf.keras.preprocessing.sequence.TimeseriesGenerator](https://www.tensorflow.org/api_docs/python/tf/keras/preprocessing/sequence/TimeseriesGenerator) has a broken link for tf.keras.utils.Sequence

Updated it to redirect to appropriate page.