### PR TITLE
Fix cub BUILD file for local_config_cuda reference

### DIFF
--- a/third_party/cub.BUILD
+++ b/third_party/cub.BUILD
@@ -11,5 +11,5 @@ exports_files(["LICENSE.TXT"])
 cc_library(
     name = "cub",
     hdrs = glob(["cub/**"]),
-    deps = ["@local_cuda//:cuda_headers"],
+    deps = ["@local_config_cuda//cuda:cuda_headers"],
 )


### PR DESCRIPTION
On Linux x86_64, while building TF 2.5.0-rc0 for cuda 10.2, I encountered an error that says "no such package @local_cuda referenced by cub" (don't have an exact error). This PR proposes a fix for this.
But I'm surprised how this is working for everyone as the same code is also present on the master branch. And if it is working fine, then what is wrong with my environment.

Creating new PR against master branch. Closing the earlier one https://github.com/tensorflow/tensorflow/pull/48310 as it was earlier created against r2.5 branch and then after changing base branch, it started showing n number of commits from master too.