### PR TITLE
Add extra point in ./tensorflow/examples README file

### DIFF
--- a/tensorflow/examples/README.md
+++ b/tensorflow/examples/README.md
@@ -14,3 +14,4 @@ If that's not what you're looking for here are some links:
 * The C++ API is only easily buildable from within the TensorFlow `bazel` build.
   If you need a stand alone build [see the C API](https://www.tensorflow.org/install/lang_c).
 * This directory is not actively maintained. 
+

--- a/tensorflow/examples/README.md
+++ b/tensorflow/examples/README.md
@@ -7,7 +7,7 @@ If that's not what you're looking for here are some links:
   [the tutorials on tensorflow.org](https://tensorflow.org/tutorials)
 * For community maintained keras examples goto [keras.io/examples](https://keras.io/examples/)
 * For TensorFlow Lite examples see [the tensorflow/examples repository](https://github.com/tensorflow/examples/tree/master/lite)
-* For the Udacity course notebooks, refer [this directory](https://github.com/tensorflow/examples/tree/master/courses)
+* For the Udacity course notebooks, refer to [this directory](https://github.com/tensorflow/examples/tree/master/courses)
 
 ## About these examples
 

--- a/tensorflow/examples/README.md
+++ b/tensorflow/examples/README.md
@@ -7,7 +7,7 @@ If that's not what you're looking for here are some links:
   [the tutorials on tensorflow.org](https://tensorflow.org/tutorials)
 * For community maintained keras examples goto [keras.io/examples](https://keras.io/examples/)
 * For TensorFlow Lite examples see [the tensorflow/examples repository](https://github.com/tensorflow/examples/tree/master/lite)
-* If you're looking for topics like course assignments, templates, refer [the tensorflow/examples repository](https://github.com/tensorflow/examples/tree/master/lite)
+* If you're looking for topics like course assignments, templates, then refer [the tensorflow/examples repository](https://github.com/tensorflow/examples/tree/master/lite)
 
 ## About these examples
 

--- a/tensorflow/examples/README.md
+++ b/tensorflow/examples/README.md
@@ -7,10 +7,10 @@ If that's not what you're looking for here are some links:
   [the tutorials on tensorflow.org](https://tensorflow.org/tutorials)
 * For community maintained keras examples goto [keras.io/examples](https://keras.io/examples/)
 * For TensorFlow Lite examples see [the tensorflow/examples repository](https://github.com/tensorflow/examples/tree/master/lite)
+* If you're looking for topics like courses, templates, refer [the tensorflow/examples repository](https://github.com/tensorflow/examples/tree/master/lite)
 
 ## About these examples
 
 * The C++ API is only easily buildable from within the TensorFlow `bazel` build.
   If you need a stand alone build [see the C API](https://www.tensorflow.org/install/lang_c).
-* This directory is not actively maintained.
-
+* This directory is not actively maintained. 

--- a/tensorflow/examples/README.md
+++ b/tensorflow/examples/README.md
@@ -7,7 +7,7 @@ If that's not what you're looking for here are some links:
   [the tutorials on tensorflow.org](https://tensorflow.org/tutorials)
 * For community maintained keras examples goto [keras.io/examples](https://keras.io/examples/)
 * For TensorFlow Lite examples see [the tensorflow/examples repository](https://github.com/tensorflow/examples/tree/master/lite)
-* If you're looking for topics like course assignments, templates, then refer [the tensorflow/examples repository](https://github.com/tensorflow/examples/tree/master/lite)
+* For the Udacity course notebooks, refer [this directory](https://github.com/tensorflow/examples/tree/master/courses)
 
 ## About these examples
 

--- a/tensorflow/examples/README.md
+++ b/tensorflow/examples/README.md
@@ -7,7 +7,7 @@ If that's not what you're looking for here are some links:
   [the tutorials on tensorflow.org](https://tensorflow.org/tutorials)
 * For community maintained keras examples goto [keras.io/examples](https://keras.io/examples/)
 * For TensorFlow Lite examples see [the tensorflow/examples repository](https://github.com/tensorflow/examples/tree/master/lite)
-* If you're looking for topics like courses, templates, refer [the tensorflow/examples repository](https://github.com/tensorflow/examples/tree/master/lite)
+* If you're looking for topics like course assignments, templates, refer [the tensorflow/examples repository](https://github.com/tensorflow/examples/tree/master/lite)
 
 ## About these examples
 


### PR DESCRIPTION
## Description
This PR fixes #48394 

## Changes made
I added an extra point to refer course assignments and all other things. Just a minor change though! 

## Notes for reviewers
This is actually a small change but review and suggest changes to do if any. Thanks