### PR TITLE
[tflite] make build of tflite cmd line tools work again

### DIFF
--- a/third_party/absl/com_google_absl_fix_mac_and_nvcc_build.patch
+++ b/third_party/absl/com_google_absl_fix_mac_and_nvcc_build.patch
@@ -232,3 +232,23 @@ index 02bfd03..d25d96d 100644
    }
  };
  
+diff --git a/absl/time/internal/cctz/BUILD.bazel b/absl/time/internal/cctz/BUILD.bazel
+index 45a9529..57c954e 100644
+--- a/absl/time/internal/cctz/BUILD.bazel
++++ b/absl/time/internal/cctz/BUILD.bazel
+@@ -74,15 +74,6 @@ cc_library(
+         "include/cctz/time_zone.h",
+         "include/cctz/zone_info_source.h",
+     ],
+-    linkopts = select({
+-        ":osx": [
+-            "-framework Foundation",
+-        ],
+-        ":ios": [
+-            "-framework Foundation",
+-        ],
+-        "//conditions:default": [],
+-    }),
+     visibility = ["//visibility:public"],
+     deps = [
+         ":civil_time",


### PR DESCRIPTION
This is to revert 5ba9567, which removed a workaround in absl to
make cross-building android stuff on macOS work. Without this,
when building `benchmark_model` with
```
bazel build --config android_arm64 \
  //tensorflow/lite/tools/benchmark:benchmark_model
```
I saw

```
/bin/external/com_google_absl/absl/base/liblog_severity.a bazel-out/arm64-v8a-opt/bin/external/com_google_absl/absl/numeric/libint128.a bazel-out/arm64-v8a-opt/bin/external/ruy/ruy/profiler/libprofiler.a bazel-out/arm64-v8a-opt/bin/external/ruy/ruy/profiler/libinstrumentation.a external/androidndk/ndk/sources/cxx-stl/llvm-libc++/libs/arm64-v8a/libc++_static.a external/androidndk/ndk/sources/cxx-stl/llvm-libc++/libs/arm64-v8a/libc++abi.a -latomic -Wl,--no-export-dynamic -Wl,--gc-sections -Wl,--as-needed -s -pie -lm '-Wl,--rpath=/data/local/tmp/' -lm -ldl -ldl -ldl -ldl -lEGL -lGLESv2 -ldl -lm -pthread -framework Foundation -pthread -pthread -pthread -pthread -lm -llog -lm -lm -lm -lm -lm -lm -lm -lm -lm -lm -lm -lm -lm -llog -pthread -pthread -pthread -static-libgcc -gcc-toolchain external/androidndk/ndk/toolchains/aarch64-linux-android-4.9/prebuilt/darwin-x86_64 -target aarch64-none-linux-android -no-canonical-prefixes -Lexternal/androidndk/ndk/sources/cxx-stl/llvm-libc++/libs/arm64-v8a '--sysroot=external/androidndk/ndk/platforms/android-28/arch-arm64')
ERROR: /Users/freedom/work/tf-py3/tensorflow/lite/tools/benchmark/BUILD:30:10: Linking of rule '//tensorflow/lite/tools/benchmark:benchmark_model' failed (Exit 1): clang failed: error executing command external/androidndk/ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang -o bazel-out/arm64-v8a-opt/bin/tensorflow/lite/tools/benchmark/benchmark_model ... (remaining 397 argument(s) skipped)
external/androidndk/ndk/toolchains/aarch64-linux-android-4.9/prebuilt/darwin-x86_64/lib/gcc/aarch64-linux-android/4.9.x/../../../../aarch64-linux-android/bin/ld: -f may not be used without -shared
clang: error: linker command failed with exit code 1 (use -v to see invocation)
Target //tensorflow/lite/tools/benchmark:benchmark_model failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 0.293s, Critical Path: 0.04s
INFO: 2 processes: 2 internal.
```