### PR TITLE
Added Lite option to EfficientNets.

### DIFF
--- a/tensorflow/python/keras/applications/efficientnet_weight_update_util.py
+++ b/tensorflow/python/keras/applications/efficientnet_weight_update_util.py
@@ -357,6 +357,11 @@ if __name__ == '__main__':
       action='store_true',
       help='do not include top layers',
       default=False)
+  p.add_argument(
+      '--lite',
+      action='store_true',
+      help='Whether to use lite variant of the model.',
+      default=False)
   p.add_argument('--ckpt', required=True, type=str, help='checkpoint path')
   p.add_argument(
       '--output', '-o', required=True, type=str, help='output (h5) file path')
@@ -364,5 +369,7 @@ if __name__ == '__main__':
 
   include_top = not args.notop
 
-  model = arg_to_model[args.model](include_top=include_top)
+  model = arg_to_model[args.model](
+      include_top=include_top, lite=args.lite, weights=None
+  )
   write_ckpt_to_h5(args.output, args.ckpt, keras_model=model)


### PR DESCRIPTION
### Description
This PR modifies the existing code for EfficientNet inside `tf.keras.applications` so that it allows to use the Lite [1] variants of the model. The Lite variants were introduced in the original EfficientNet repository and had the following differences:
* Removed squeeze-and-excite (SE).
* Replaced swish with RELU6.
* Fixed the stem and head while scaling models up.

I am also referencing my helper repository [2], that uses existing Tensorflow code, for direct conversion of `.ckpt` files to Keras `.h5` variants.

### Motivation
The existing Lite variants of EfficientNets are only available in original repository and Tensorflow Hub [3]. These are written in Tensorflow 1.x and hence do not allow for flexible use with Keras.

The option to add Lite variants has been requested few times in Tensorflow Ecosystem:
https://github.com/tensorflow/tensorflow/issues/45091 
https://github.com/tensorflow/hub/issues/751 

This PR addresses the first issue and partially solves the second one.

### Usage / Changes
In the original version one could call EfficientNet models as such:
```python
import tensorflow as tf

model = tf.keras.applications.efficientnet.EfficientNetB0()
```

With this PR it would be possible to do:
```python
import tensorflow as tf

model_lite = tf.keras.applications.efficientnet.EfficientNetB0(lite=True)
```
This behaviour is not introducing any breaking changes to existing codebase and is very similar to `minimalistic` option in MobilenetV3Small and Large.

### Todos:
This PR is sadly a not finished work and to make it fully compatible with existing codebase I would need help from someone on the Tensorflow team. Most notably there are two things to be discussed:

1. Add converted weights to Remote Storage + add lite variants weights hashes so they can be automatically loaded. I can provide the converted weights (top and notop variants) or they can be obtained by my helper repository [2].
2. Prevent the user from creating lite variants of the models B5 and higher. These are not supported in the original repository, yet still the user can pass the `lite=True` flag via kwargs. This will throw rather cryptic error that the number of layers does not match in architecture vs weight file. Perhaps a different error message would be better?

### References
[1] https://github.com/tensorflow/tpu/tree/master/models/official/efficientnet/lite 
[2] https://github.com/sebastian-sz/efficientnet-lite-keras
[3] https://tfhub.dev/s?q=efficientnet%20lite