### PR TITLE
Update tf.keras.callbacks.CSVLogger to work with cloud storage

### DIFF
--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -2745,14 +2745,13 @@ class CSVLogger(Callback):
   def on_train_begin(self, logs=None):
     if self.append:
       if file_io.file_exists_v2(self.filename):
-        with open(self.filename, 'r' + self.file_flags) as f:
+        with file_io.FileIO(self.filename, 'r' + self.file_flags) as f:
           self.append_header = not bool(len(f.readline()))
       mode = 'a'
     else:
       mode = 'w'
-    self.csv_file = io.open(self.filename,
-                            mode + self.file_flags,
-                            **self._open_args)
+    self.csv_file = file_io.FileIO(self.filename,
+                            mode + self.file_flags)
 
   def on_epoch_end(self, epoch, logs=None):
     logs = logs or {}

--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -19,7 +19,6 @@
 import collections
 import copy
 import csv
-import io
 import json
 import os
 import re


### PR DESCRIPTION
Small bug in CSVLogger. Change the `open` function to `file_io.FileIO` to make it work with files stored on the cloud and not only locally.