### PR TITLE
[ROCm] Minor updates to the XLA / LLVM for AMDGPU backend

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
+++ b/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
@@ -874,6 +874,14 @@ void AMDGPUBackendInit(const HloModuleConfig& hlo_module_config) {
   LLVMInitializeAMDGPUTargetInfo();
   LLVMInitializeAMDGPUTargetMC();
   LLVMInitializeAMDGPUAsmPrinter();
+
+#if TF_ROCM_VERSION < 40100
+  // Use code-object-v3 for ROCm versions 4.0.1 and lower, since the
+  // HIP runtime for those ROCm versions expects the v3 HSACO objects
+  // Default is now v4 for newer LLVM versions (starting around 210326)
+  FeedLLVMWithFlags({"--amdhsa-code-object-version=3"});
+#endif
+
 #endif
 
   llvm::PassRegistry* registry = llvm::PassRegistry::getPassRegistry();

--- a/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
+++ b/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
@@ -795,6 +795,13 @@ Status AMDGPUTargetModuleLinker(llvm::Module* module, GpuVersion gpu_version,
   TF_RETURN_IF_ERROR(LinkROCDLIfNecessary(module, amdgpu_version->first,
                                           device_bitcode_dir_path));
 
+  // If ftz is enabled, set it as an attribute on every function in the module.
+  if (hlo_module_config.debug_options().xla_gpu_ftz()) {
+    for (llvm::Function& fn : *module) {
+      fn.addFnAttr("denormal-fp-math-f32", "preserve-sign");
+    }
+  }
+
   return Status::OK();
 }
 


### PR DESCRIPTION
## 1  Fix for ROCm CSB breakage - 210329

The following commit breaks the XLA unit-testcases on the ROCm platform

cb3e0b2#diff-3916e937a690715a62df34b7dae19bbdd92d7c79b9d6712ba3605b8d208c8a7fR7

The above commit updates the LLVM pointer, which in turn picks a lot of changes in the AMDGPU backend implementation in LLVM. One of those changes is to use code-object-v4, by default, for the generated HSACOs (AMDGPU binaries). This is okay if you also use the corresponding HIP runtime, which is ROCm 4.1 or higher. But with ROCm 4.0.1 or older, the newer HSACO files do not get loaded properly by the older HIP runtime, resulting in errors like the following error

```
tensorflow/compiler/xla/service/gpu/tests/reduction_layout_normalizer_test.cc:62: Failure
Value of: RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5})
  Actual: false (Internal: Failed to load HSACO: hipError_t(303))
Expected: true
```

This commit fixes the issue by changing the default code object version to v3, when TF is built with ROCm 4.0.1 or older.

## 2  Adding support for enbale_ftz flag (flush denormals to zero) in the LLVM backend for AMDGPUs 

----------------------

thanks to @ekuznetsov139 for helping out on the fixes.

------------------------------

/cc @cheshire @chsigg 
