### PR TITLE
[CherryPick:r2.5] Use merge_call for optimizer distributed_apply if strategy doesn't support merge_call free path.

### DIFF
--- a/tensorflow/python/distribute/mirrored_strategy.py
+++ b/tensorflow/python/distribute/mirrored_strategy.py
@@ -46,7 +46,6 @@ from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import control_flow_util
-from tensorflow.python.ops import variables as variables_lib
 from tensorflow.python.platform import tf_logging as logging
 from tensorflow.python.util import nest
 from tensorflow.python.util.tf_export import tf_export
@@ -773,10 +772,6 @@ class MirroredExtended(distribute_lib.StrategyExtendedV1):
   def _update(self, var, fn, args, kwargs, group):
     # TODO(josh11b): In eager mode, use one thread per device.
     assert isinstance(var, values.DistributedVariable)
-    if (var.synchronization != variables_lib.VariableSynchronization.ON_READ and
-        var.aggregation != variables_lib.VariableAggregation.NONE):
-      distribute_utils.assert_mirrored(args)
-      distribute_utils.assert_mirrored(kwargs)
     updates = []
     for i, v in enumerate(var.values):
       name = "update_%d" % i
@@ -838,8 +833,8 @@ class MirroredExtended(distribute_lib.StrategyExtendedV1):
       name = "update_%d" % i
       with ops.device(d), distribute_lib.UpdateContext(i), ops.name_scope(name):
         updates.append(
-            fn(*distribute_utils.select_replica_mirrored(i, args),
-               **distribute_utils.select_replica_mirrored(i, kwargs)))
+            fn(*distribute_utils.select_replica(i, args),
+               **distribute_utils.select_replica(i, kwargs)))
     return distribute_utils.update_regroup(self, updates, group)
 
   def read_var(self, replica_local_var):

--- a/tensorflow/python/keras/optimizer_v2/optimizer_v2.py
+++ b/tensorflow/python/keras/optimizer_v2/optimizer_v2.py
@@ -663,8 +663,16 @@ class OptimizerV2(trackable.Trackable):
         grads_and_vars = self._aggregate_gradients(grads_and_vars)
       grads_and_vars = self._transform_gradients(grads_and_vars)
 
-      return self._distributed_apply(strategy, grads_and_vars, name,
-                                     apply_state)
+      if optimizer_utils.strategy_supports_no_merge_call():
+        return self._distributed_apply(strategy, grads_and_vars, name,
+                                       apply_state)
+      else:
+        return distribute_ctx.get_replica_context().merge_call(
+            functools.partial(self._distributed_apply, apply_state=apply_state),
+            args=(grads_and_vars,),
+            kwargs={
+                "name": name,
+            })
 
   def _distributed_apply(self, distribution, grads_and_vars, name, apply_state):
     """`apply_gradients` using a `DistributionStrategy`."""
@@ -703,8 +711,16 @@ class OptimizerV2(trackable.Trackable):
           with name_scope_only_in_function_or_graph(
               "update" if eagerly_outside_functions else "update_" +
               var.op.name):
-            update_ops.append(distribute_ctx.get_replica_context()._update(  # pylint: disable=protected-access
-                var, apply_grad_to_update_var, args=(grad,), group=False))
+            update_op = distribution.extended.update(
+                var, apply_grad_to_update_var, args=(grad,), group=False)
+            if distribute_ctx.in_cross_replica_context():
+              # In cross-replica context, extended.update returns a list of
+              # update ops from all replicas (group=False).
+              update_ops.extend(update_op)
+            else:
+              # In replica context, extended.update return the single update op
+              # of current replica.
+              update_ops.append(update_op)
 
       any_symbolic = any(isinstance(i, ops.Operation) or
                          tf_utils.is_symbolic_tensor(i) for i in update_ops)


### PR DESCRIPTION
In principle even if the strategy doesn't support merge_call free path, distributed_apply can still be called w/o merge_call. However it would be slower than calling it with merge_call in pure eager mode, mainly because MS uses multiple python threads to run replica function, and those python threads are running sequentially.

PiperOrigin-RevId: 367305737
Change-Id: Ie2316fd62131c60eff605cf9f51e044c09ec9abc