### PR TITLE
[ROCm] Added to AMP allow list to include BatchMatMul

### DIFF
--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
@@ -129,8 +129,12 @@ class AutoMixedPrecisionListsCuda : public AutoMixedPrecisionLists {
         "LSTMBlockCellGrad",
         "MatMul",
     };
+#if TENSORFLOW_USE_ROCM
+    if (true) {
+#else 
     if (cuda_version_ >= 9010) {
       // Fp16 BatchMatMul is slow before CUDA 9.1.
+#endif
       list.insert("BatchMatMul");
       list.insert("BatchMatMulV2");
     }
@@ -142,6 +146,9 @@ class AutoMixedPrecisionListsCuda : public AutoMixedPrecisionLists {
       list.insert("Conv3DBackpropInput");
       list.insert("Conv3DBackpropInputV2");
     }
+#if TENSORFLOW_USE_ROCM
+      list.insert("_ROCmFusedConvolutionBiasActivation");
+#endif
     if (cudnn_version_ >= 8000) {
       list.insert("DepthwiseConv2dNative");
       list.insert("DepthwiseConv2dNativeBackpropFilter");

--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
@@ -146,9 +146,6 @@ class AutoMixedPrecisionListsCuda : public AutoMixedPrecisionLists {
       list.insert("Conv3DBackpropInput");
       list.insert("Conv3DBackpropInputV2");
     }
-#if TENSORFLOW_USE_ROCM
-      list.insert("_ROCmFusedConvolutionBiasActivation");
-#endif
     if (cudnn_version_ >= 8000) {
       list.insert("DepthwiseConv2dNative");
       list.insert("DepthwiseConv2dNativeBackpropFilter");


### PR DESCRIPTION
Updated AMP allowlist to include BatchMatMul for ROCm missing from when PR https://github.com/tensorflow/tensorflow/pull/47650 was merged. 

@cheshire 