### PR TITLE
Update the `compiler_pieces` of the RPi ARM compiler.

### DIFF
--- a/arm_compiler.BUILD
+++ b/arm_compiler.BUILD
@@ -43,9 +43,9 @@ filegroup(
 filegroup(
     name = "compiler_pieces",
     srcs = glob([
-        "arm-linux-gnueabihf/**",
+        "arm-rpi-linux-gnueabihf/**",
         "libexec/**",
-        "lib/gcc/arm-linux-gnueabihf/**",
+        "lib/gcc/arm-rpi-linux-gnueabihf/**",
         "include/**",
     ]),
 )


### PR DESCRIPTION
`arm_compiler.BUILD` is used as the build file for the Raspberry Pi Arm-v7a cross-compiler registered in the workspace here: https://github.com/tensorflow/tensorflow/blob/52e009a5118632b13672ee1d06cdaa81a2e56702/tensorflow/workspace2.bzl#L215-L224

(The same build file is also used for the [aarch64 cross-compiler](https://github.com/tensorflow/tensorflow/blob/52e009a5118632b13672ee1d06cdaa81a2e56702/tensorflow/workspace2.bzl#L226-L238), but there's a separate (correct) [`aarch64_compiler_pieces`](aarch64_compiler_pieces) defined for that case.)

Currently, the filegroup `compiler_pieces` defined in this build file does not match the directory structure of the cross-compiler that's downloaded from https://github.com/rvagg/rpi-newer-crosstools. The commit that's downloaded, after applying the `strip_prefix`, has [this directory structure](https://github.com/rvagg/rpi-newer-crosstools/tree/eb68350c5c8ec1663b7fe52c742ac4271e3217c5/x64-gcc-6.5.0/arm-rpi-linux-gnueabihf). Note the 'real' directories `arm-rpi-linux-gnueabihf` and `lib/gcc/arm-rpi-linux-gnueabihf`, which don't match the current glob patterns. This PR updates the glob patterns to match.