### PR TITLE
Enable broadcast send from non-collective group leader

### DIFF
--- a/tensorflow/core/distributed_runtime/collective_param_resolver_distributed.cc
+++ b/tensorflow/core/distributed_runtime/collective_param_resolver_distributed.cc
@@ -192,6 +192,7 @@ void CollectiveParamResolverDistributed::CompleteInstanceAsync(
   cp->instance.instance_key = request->instance_key();
   cp->instance.data_type = request->data_type();
   cp->instance.shape = TensorShape(request->shape());
+  cp->is_source = request->is_source();
   for (int32 offset : request->subdiv_offset()) {
     cp->instance.impl_details.subdiv_offsets.push_back(offset);
   }


### PR DESCRIPTION
This PR enables broadcast send(collective) from the non-collective group leader. The current master code ignores the `is_source` value in `CompleteGroupRequest` to raise the internal error if a non-collective group leader tries to send a tensor using BcastSend. The error message is as follows:`Instance 7 found no source for broadcast.  This could mean that there were group_size=2 BcastRecvs but no BcastSend.`. 