### PR TITLE
Disable AWS and HDFS support by default

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -142,6 +142,10 @@ build --config=short_logs
 
 build --config=v2
 
+# Disable AWS/HDFS support by default
+build --define=no_aws_support=true
+build --define=no_hdfs_support=true
+
 # Default options should come above this line.
 
 # Allow builds using libc++ as a linker library

--- a/configure.py
+++ b/configure.py
@@ -1467,9 +1467,7 @@ def main():
   config_info_line('v2', 'Build TensorFlow 2.x instead of 1.x.')
 
   print('Preconfigured Bazel build configs to DISABLE default on features:')
-  config_info_line('noaws', 'Disable AWS S3 filesystem support.')
   config_info_line('nogcp', 'Disable GCP support.')
-  config_info_line('nohdfs', 'Disable HDFS support.')
   config_info_line('nonccl', 'Disable NVIDIA NCCL support.')
 
 

--- a/tensorflow/core/platform/default/build_config.bzl
+++ b/tensorflow/core/platform/default/build_config.bzl
@@ -670,7 +670,6 @@ def tf_additional_core_deps():
         clean_dep("//tensorflow:android"): [],
         clean_dep("//tensorflow:ios"): [],
         clean_dep("//tensorflow:linux_s390x"): [],
-        clean_dep("//tensorflow:windows"): [],
         clean_dep("//tensorflow:no_hdfs_support"): [],
         clean_dep("//tensorflow:with_tpu_support"): [],
         "//conditions:default": [

--- a/tensorflow/tools/lib_package/BUILD
+++ b/tensorflow/tools/lib_package/BUILD
@@ -139,7 +139,6 @@ genrule(
     srcs = [
         "//third_party/eigen3:LICENSE",
         "//third_party/fft2d:LICENSE",
-        "//third_party/hadoop:LICENSE.txt",
         "//third_party/icu/data:LICENSE",
         "@boringssl//:LICENSE",
         "@com_google_protobuf//:LICENSE",
@@ -168,13 +167,7 @@ genrule(
         "//tensorflow:ios": [],
         "//tensorflow:linux_s390x": [],
         "//tensorflow:windows": [],
-        "//tensorflow:no_aws_support": [],
-        "//conditions:default": [
-            "@aws//:LICENSE",
-            "@aws-checksums//:LICENSE",
-            "@aws-c-event-stream//:LICENSE",
-            "@aws-c-common//:LICENSE",
-        ],
+        "//conditions:default": [],
     }) + select({
         "//tensorflow:android": [],
         "//tensorflow:ios": [],
@@ -216,7 +209,6 @@ genrule(
     srcs = [
         "//third_party/eigen3:LICENSE",
         "//third_party/fft2d:LICENSE",
-        "//third_party/hadoop:LICENSE.txt",
         "//third_party/icu/data:LICENSE",
         "@boringssl//:LICENSE",
         "@com_google_protobuf//:LICENSE",
@@ -247,13 +239,7 @@ genrule(
         "//tensorflow:ios": [],
         "//tensorflow:linux_s390x": [],
         "//tensorflow:windows": [],
-        "//tensorflow:no_aws_support": [],
-        "//conditions:default": [
-            "@aws//:LICENSE",
-            "@aws-checksums//:LICENSE",
-            "@aws-c-event-stream//:LICENSE",
-            "@aws-c-common//:LICENSE",
-        ],
+        "//conditions:default": [],
     }) + select({
         "//tensorflow:android": [],
         "//tensorflow:ios": [],

--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -182,7 +182,6 @@ filegroup(
         "//:LICENSE",
         "//third_party/eigen3:LICENSE",
         "//third_party/fft2d:LICENSE",
-        "//third_party/hadoop:LICENSE.txt",
         "//third_party/icu/data:LICENSE",
         "@ruy//:LICENSE",
         "@arm_neon_2_x86_sse//:LICENSE",
@@ -232,13 +231,7 @@ filegroup(
         "//tensorflow:ios": [],
         "//tensorflow:linux_s390x": [],
         "//tensorflow:windows": [],
-        "//tensorflow:no_aws_support": [],
-        "//conditions:default": [
-            "@aws//:LICENSE",
-            "@aws-c-common//:LICENSE",
-            "@aws-c-event-stream//:LICENSE",
-            "@aws-checksums//:LICENSE",
-        ],
+        "//conditions:default": [],
     }) + select({
         "//tensorflow:android": [],
         "//tensorflow:ios": [],


### PR DESCRIPTION
This PR disables AWS and HDFS support by default, as was discussed in:
https://docs.google.com/document/d/1CB51yJxns5WA4Ylv89D-a5qReiGTC0GYum6DU-9nKGo/edit#heading=h.8ifswzr0wtbp

/cc @mihaimaruseac @vnvo2409 @kvignesh1420 

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>