### PR TITLE
Fix 'Illegal ambiguous match' on Windows with `--config=nogcp/noaws`.

### DIFF
--- a/tensorflow/core/platform/default/build_config.bzl
+++ b/tensorflow/core/platform/default/build_config.bzl
@@ -662,9 +662,6 @@ def tf_additional_core_deps():
         clean_dep("//tensorflow:android"): [],
         clean_dep("//tensorflow:ios"): [],
         clean_dep("//tensorflow:linux_s390x"): [],
-        clean_dep("//tensorflow:windows"): [
-            "//tensorflow/core/platform/cloud:gcs_file_system",
-        ],
         clean_dep("//tensorflow:no_gcp_support"): [],
         "//conditions:default": [
             "//tensorflow/core/platform/cloud:gcs_file_system",
@@ -683,9 +680,6 @@ def tf_additional_core_deps():
         clean_dep("//tensorflow:android"): [],
         clean_dep("//tensorflow:ios"): [],
         clean_dep("//tensorflow:linux_s390x"): [],
-        clean_dep("//tensorflow:windows"): [
-            clean_dep("//tensorflow/core/platform/s3:s3_file_system"),
-        ],
         clean_dep("//tensorflow:no_aws_support"): [],
         "//conditions:default": [
             clean_dep("//tensorflow/core/platform/s3:s3_file_system"),


### PR DESCRIPTION
At the moment, compiling the target `//tensorflow/core:core_cpu_internal` on Windows in combination with either `--config=nogcp` or `--config=noaws` (or of course both) gives the following Bazel error:

```
Illegal ambiguous match on configurable attribute "deps" in 
//tensorflow/core/common_runtime:core_cpu_internal:
//tensorflow:windows
//tensorflow:no_gcp_support
Multiple matches are not allowed unless one is unambiguously more specialized.
ERROR: Analysis of target '//tensorflow/core:core_cpu_internal' failed; build aborted
```

This is because the select statement here matches both `//tensorflow:windows` and `//tensorflow:no_gcp_support`: https://github.com/tensorflow/tensorflow/blob/a07640071d446365e0ee6584cc8e0e953cb7afaf/tensorflow/core/platform/default/build_config.bzl#L661-L672
(or similarly [here](https://github.com/tensorflow/tensorflow/blob/a07640071d446365e0ee6584cc8e0e953cb7afaf/tensorflow/core/platform/default/build_config.bzl#L682-L693) in the `noaws` case)

Since the `"//conditions:default"` arm is to include the GCS dependency, there's no need to explicitly match against `//tensorflow:windows` in order to include it, so this PR fixes the problem by removing the Windows-specific arm. This doesn't affect the default behaviour (*not* having `--config=nogcp`) but resolves the ambiguous match otherwise.