### PR TITLE
Run bluepill tests with and without -Os

### DIFF
--- a/tensorflow/lite/micro/tools/ci_build/test_bluepill.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_bluepill.sh
@@ -41,6 +41,13 @@ readable_run make -j8 -f tensorflow/lite/micro/tools/make/Makefile TARGET=${TARG
 readable_run make -f tensorflow/lite/micro/tools/make/Makefile clean
 readable_run make -j8 -f tensorflow/lite/micro/tools/make/Makefile TARGET=${TARGET} OPTIMIZATION_LEVEL=-Os test
 
+# We have had examples where tests pass with -Os but fail without it so we run
+# the unit tests with and without -Os. See
+# https://github.com/tensorflow/tensorflow/issues/48516 for one such issue.
+
+readable_run make -f tensorflow/lite/micro/tools/make/Makefile clean
+readable_run make -j8 -f tensorflow/lite/micro/tools/make/Makefile TARGET=${TARGET} test
+
 # We use Renode differently when running the full test suite (make test) vs an
 # individual test. So, we test only of the kernels individually as well to have
 # both of the Renode variations be part of the CI.


### PR DESCRIPTION
For the resize_bilinear port from https://github.com/tensorflow/tensorflow/pull/43426, all the CI checks passed.

However, as noted in https://github.com/tensorflow/tensorflow/issues/48516 it broke the Xtensa build.

Additionally, I found out that #43426 broke the bluepill unit tests as well, but only if we build without -Os.

This change is running the bluepill unit tests with and without -Os to try and catch more errors prior to a PR being merged.

