### PR TITLE
[ROCm] Fixes for ROCm CSB breakage - 210414

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -1473,6 +1473,7 @@ tf_cc_test(
     ],
     tags = [
         "gpu",
+        "no_rocm",
         "nomsan",  # Pulls in precompiled NVIDIA libraries which cause false
         # positives in msan.
     ],

--- a/tensorflow/compiler/xla/service/gpu/gemm_thunk.cc
+++ b/tensorflow/compiler/xla/service/gpu/gemm_thunk.cc
@@ -123,6 +123,12 @@ static Status DoGemmWithAlgorithm(
   se::DeviceMemory<Element> rhs_data(rhs_matrix.data);
   se::DeviceMemory<Element> output_data(output_matrix.data);
 
+  // Ignore the "algorithm" field on the ROCm platform. This is because
+  // autotuning for GEMM is not yet available on the ROCm platform
+  // The "algorithm" field does not get populated in the "normal" flow
+  // on the ROCm platform, but atleast one unittest directly populates it
+  // and hence the need for this check
+#if !defined(TENSORFLOW_USE_ROCM)
   if (algorithm) {
     // Autotuning is disabled for batch_size != 1.
     CHECK_EQ(1, batch_size);
@@ -137,6 +143,7 @@ static Status DoGemmWithAlgorithm(
         /*leading dim of output=*/output_matrix.num_rows, computation_type,
         *algorithm, output_profile_result);
   }
+#endif  // !defined(TENSORFLOW_USE_ROCM)
 
   if (batch_size != 1) {
     int64 lhs_stride = lhs_matrix.num_rows * lhs_matrix.num_cols;

--- a/tensorflow/compiler/xla/service/gpu/gemm_thunk.cc
+++ b/tensorflow/compiler/xla/service/gpu/gemm_thunk.cc
@@ -123,12 +123,6 @@ static Status DoGemmWithAlgorithm(
   se::DeviceMemory<Element> rhs_data(rhs_matrix.data);
   se::DeviceMemory<Element> output_data(output_matrix.data);
 
-  // Ignore the "algorithm" field on the ROCm platform. This is because
-  // autotuning for GEMM is not yet available on the ROCm platform
-  // The "algorithm" field does not get populated in the "normal" flow
-  // on the ROCm platform, but atleast one unittest directly populates it
-  // and hence the need for this check
-#if !defined(TENSORFLOW_USE_ROCM)
   if (algorithm) {
     // Autotuning is disabled for batch_size != 1.
     CHECK_EQ(1, batch_size);
@@ -143,7 +137,6 @@ static Status DoGemmWithAlgorithm(
         /*leading dim of output=*/output_matrix.num_rows, computation_type,
         *algorithm, output_profile_result);
   }
-#endif  // !defined(TENSORFLOW_USE_ROCM)
 
   if (batch_size != 1) {
     int64 lhs_stride = lhs_matrix.num_rows * lhs_matrix.num_cols;

--- a/tensorflow/compiler/xla/service/gpu/tests/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/tests/BUILD
@@ -633,6 +633,7 @@ glob_lit_tests(
     driver = "@llvm-project//mlir:run_lit.sh",
     tags_override = {
         "reduction_vectorization_sm_all.hlo": ["no_rocm"],
+        "element_wise_row_vectorization.hlo": ["no_rocm"],
     },
     test_file_exts = [
         "hlo",

--- a/tensorflow/compiler/xla/service/gpu/tests/mlir_gemm_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/mlir_gemm_test.cc
@@ -31,7 +31,7 @@ TEST_F(GemmTest, SimpleCase1) {
                    %arg2: memref<2x2xf32> {lmhlo.output_index = dense<[0]> : tensor<1xindex>}) attributes {
                        result_xla_shape = "(f32[4]) "
                    } {
-          "lmhlo_gpu.gemm"(%arg0, %arg1, %arg2) {algorithm = 7 : i64, alpha_imag = 0.000000e+00 : f64, alpha_real = 1.000000e+00 : f64, batch_size = 1 : i64, dot_dimension_numbers = {lhs_batching_dimensions = dense<> : tensor<0xi64>, lhs_contracting_dimensions = dense<1> : tensor<1xi64>, rhs_batching_dimensions = dense<> : tensor<0xi64>, rhs_contracting_dimensions = dense<0> : tensor<1xi64>}} : (memref<2x2xf32>, memref<2x2xf32>, memref<2x2xf32>) -> ()
+          "lmhlo_gpu.gemm"(%arg0, %arg1, %arg2) {alpha_imag = 0.000000e+00 : f64, alpha_real = 1.000000e+00 : f64, batch_size = 1 : i64, dot_dimension_numbers = {lhs_batching_dimensions = dense<> : tensor<0xi64>, lhs_contracting_dimensions = dense<1> : tensor<1xi64>, rhs_batching_dimensions = dense<> : tensor<0xi64>, rhs_contracting_dimensions = dense<0> : tensor<1xi64>}} : (memref<2x2xf32>, memref<2x2xf32>, memref<2x2xf32>) -> ()
           "lmhlo.terminator"() : () -> ()
         }
       })";

--- a/tensorflow/python/keras/distribute/BUILD
+++ b/tensorflow/python/keras/distribute/BUILD
@@ -843,6 +843,7 @@ distribute_py_test(
     shard_count = 7,
     tags = [
         "multi_and_single_gpu",
+        "no_rocm",
     ],
     xla_tags = [
         "no_cuda_asan",  # times out

--- a/tensorflow/python/keras/distribute/BUILD
+++ b/tensorflow/python/keras/distribute/BUILD
@@ -862,6 +862,7 @@ distribute_py_test(
     shard_count = 4,  # TODO(b/184290570): Investigate why only 1 shard times out.
     tags = [
         "multi_and_single_gpu",
+        "no_rocm",
     ],
     deps = [
         ":multi_worker_testing_utils",

--- a/tensorflow/python/kernel_tests/segment_reduction_ops_deterministic_test.py
+++ b/tensorflow/python/kernel_tests/segment_reduction_ops_deterministic_test.py
@@ -109,6 +109,9 @@ class SegmentReductionDeterminismExceptionsTest(test.TestCase):
               result = op(data, segment_ids, num_segments)
               self.evaluate(result)
 
+  @test.disable_with_predicate(
+      pred=test.is_built_with_rocm,
+      skip_message="No ROCm support for complex types in segment reduction ops")
   @test_util.run_cuda_only
   def testUnsortedOpsComplex(self):
     for op in [
@@ -144,10 +147,10 @@ class SegmentReductionDeterminismExceptionsTest(test.TestCase):
 
   @test_util.run_cuda_only
   def testGatherBackprop(self):
-    for data_type in [
-        dtypes.float16, dtypes.float32, dtypes.float64, dtypes.complex64,
-        dtypes.complex128
-    ]:
+    dtypes_to_test = [dtypes.float16, dtypes.float32, dtypes.float64]
+    if not test.is_built_with_rocm():
+      dtypes_to_test += [dtypes.complex64, dtypes.complex128]
+    for data_type in dtypes_to_test:
       for segment_ids_type in [dtypes.int32, dtypes.int64]:
         with self.cached_session(force_gpu=True):
           params, indices, _ = self._input(data_type, segment_ids_type)


### PR DESCRIPTION
copy-pasting individual commit messages here for description

## 1 
Adding "no_rocm" tag to the test `//tensorflow/compiler/xla/service/gpu:nvptx_compiler_test`

This is a CUDA specific test, and should not be enabled on the ROCm platform

## 2
ROCM specific workaround for an MLIR unittest that results in a call to `ThenBlasGemmWithAlgorithm`

ROCm platform does not yet have autotuning support for rocBLAS GEMM API. The `GemmAlgorithmPicker` pass is not called on the ROCm platform ( `amdgpu_compiler.cc` ), so the algorithm field does not get populated, and hence the `ThenBlassGemmWithAlgorithm` routine does not get called.

However the MLIR unit-tests introduced by the following commit ( 15e1036) has the algorithm field pre-populated leading to failure on the ROCm platform

```
...
2021-04-14 23:22:14.718495: I tensorflow/compiler/xla/service/gpu/gemm_thunk.cc:63] Running GEMM thunk
2021-04-14 23:22:14.718504: I tensorflow/compiler/xla/service/gpu/gemm_thunk.cc:179] Executing a GemmThunk
2021-04-14 23:22:14.718541: I tensorflow/stream_executor/stream.cc:3487] [stream=0x5597e86929e0,impl=0x5597e868b170] Called Stream::ThenBlasGemmWithAlgorithm(transa=NoTranspose, transb=NoTranspose, m=2, n=2, k=2, alpha=1, a=0x7fe5d4201000, lda=2, b=0x7fe5d4200000, ldb=2, beta=0, c=0x7fe5d420d000, ldc=2, computation_type=f32, algorithm=7)
2021-04-14 23:22:14.718555: I tensorflow/stream_executor/plugin_registry.cc:246] Selecting default BLAS plugin, rocBLAS
2021-04-14 23:22:14.747078: I tensorflow/stream_executor/platform/default/dso_loader.cc:53] Successfully opened dynamic library librocblas.so
2021-04-14 23:22:14.747200: E tensorflow/stream_executor/rocm/rocm_blas.cc:1883] rocBLAS does not currently support the GEMMwithAlgorithm operation for the "float" datatype
...

```

This commit updates the code in `gemm_thunk.cc` to always skip the path that calls `ThenBlasGemmWithAlgorithm` routine on the ROCm platform.


## 3

Skipping unit-tests (within `segment_reduction_ops_deterministic_test_gpu`) that test complex types.

Complex type support has not yet been enabled for segment_reduction_ops on the ROCm platform.


------------------------------------

/cc @cheshire @chsigg @sanjoy 


