### PR TITLE
[tf.data] support all test combinations for `PrefetchWithSlackTest`

### DIFF
--- a/tensorflow/python/data/experimental/kernel_tests/BUILD
+++ b/tensorflow/python/data/experimental/kernel_tests/BUILD
@@ -629,7 +629,6 @@ tf_py_test(
     size = "small",
     srcs = ["prefetch_with_slack_test.py"],
     deps = [
-        "//tensorflow/core:protos_all_py",
         "//tensorflow/python:client_testlib",
         "//tensorflow/python:errors",
         "//tensorflow/python:framework_test_lib",

--- a/tensorflow/python/data/experimental/kernel_tests/prefetch_with_slack_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/prefetch_with_slack_test.py
@@ -20,13 +20,11 @@ from __future__ import print_function
 
 from absl.testing import parameterized
 
-from tensorflow.core.protobuf import config_pb2
 from tensorflow.python.data.kernel_tests import test_base
 from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.data.ops import multi_device_iterator_ops
 from tensorflow.python.framework import combinations
 from tensorflow.python.framework import errors
-from tensorflow.python.framework import ops
 from tensorflow.python.platform import test
 
 


### PR DESCRIPTION
This PR addresses point 5 of https://github.com/tensorflow/tensorflow/pull/46761#issuecomment-770059963 by refactoring `PrefetchWithSlackTest` and enabling the test case for all the test combinations.

TEST LOG
```console
INFO: Build completed successfully, 4070 total actions
//tensorflow/python/data/experimental/kernel_tests:prefetch_with_slack_test PASSED in 2.5s
```

cc: @jsimsa 
