### PR TITLE
Fix all conv layers when filters is 0

### DIFF
--- a/tensorflow/python/keras/layers/convolutional.py
+++ b/tensorflow/python/keras/layers/convolutional.py
@@ -170,7 +170,7 @@ class Conv(Layer):
               self.groups, self.filters))
       
     if self.filters == 0:
-      raise ValueError("The value of `filters` argument should not be zero")
+      raise ValueError("The value of the `filters` argument should not be zero")
 
     if not all(self.kernel_size):
       raise ValueError('The argument `kernel_size` cannot contain 0(s). '

--- a/tensorflow/python/keras/layers/convolutional.py
+++ b/tensorflow/python/keras/layers/convolutional.py
@@ -191,6 +191,8 @@ class Conv(Layer):
           'of groups. Received groups={}, but the input has {} channels '
           '(full input shape is {}).'.format(self.groups, input_channel,
                                              input_shape))
+    if self.filters == 0:
+      raise ValueError("filters should not be zero")
     kernel_shape = self.kernel_size + (input_channel // self.groups,
                                        self.filters)
 
@@ -969,6 +971,8 @@ class Conv1DTranspose(Conv1D):
     if input_shape.dims[channel_axis].value is None:
       raise ValueError('The channel dimension of the inputs '
                        'should be defined. Found `None`.')
+    if self.filters == 0:
+      raise ValueError("filters should not be zero")
     input_dim = int(input_shape[channel_axis])
     self.input_spec = InputSpec(ndim=3, axes={channel_axis: input_dim})
     kernel_shape = self.kernel_size + (self.filters, input_dim)
@@ -1240,6 +1244,8 @@ class Conv2DTranspose(Conv2D):
     if input_shape.dims[channel_axis].value is None:
       raise ValueError('The channel dimension of the inputs '
                        'should be defined. Found `None`.')
+    if self.filters == 0:
+      raise ValueError("filters should not be zero")
     input_dim = int(input_shape[channel_axis])
     self.input_spec = InputSpec(ndim=4, axes={channel_axis: input_dim})
     kernel_shape = self.kernel_size + (self.filters, input_dim)
@@ -1550,6 +1556,8 @@ class Conv3DTranspose(Conv3D):
     if input_shape.dims[channel_axis].value is None:
       raise ValueError('The channel dimension of the inputs '
                        'should be defined, found None: ' + str(input_shape))
+    if self.filters == 0:
+      raise ValueError("filters should not be zero")
     input_dim = int(input_shape[channel_axis])
     kernel_shape = self.kernel_size + (self.filters, input_dim)
     self.input_spec = InputSpec(ndim=5, axes={channel_axis: input_dim})
@@ -1814,6 +1822,8 @@ class SeparableConv(Conv):
     if input_shape.dims[channel_axis].value is None:
       raise ValueError('The channel dimension of the inputs '
                        'should be defined. Found `None`.')
+    if self.filters == 0:
+      raise ValueError("filters should not be zero")
     input_dim = int(input_shape[channel_axis])
     self.input_spec = InputSpec(ndim=self.rank + 2,
                                 axes={channel_axis: input_dim})

--- a/tensorflow/python/keras/layers/convolutional.py
+++ b/tensorflow/python/keras/layers/convolutional.py
@@ -170,7 +170,8 @@ class Conv(Layer):
               self.groups, self.filters))
       
     if self.filters == 0:
-      raise ValueError("The value of the `filters` argument should not be zero")
+      raise ValueError('The value of the `filters` argument should not '
+                       'be zero')
 
     if not all(self.kernel_size):
       raise ValueError('The argument `kernel_size` cannot contain 0(s). '

--- a/tensorflow/python/keras/layers/convolutional.py
+++ b/tensorflow/python/keras/layers/convolutional.py
@@ -168,6 +168,9 @@ class Conv(Layer):
           'The number of filters must be evenly divisible by the number of '
           'groups. Received: groups={}, filters={}'.format(
               self.groups, self.filters))
+      
+    if self.filters == 0:
+      raise ValueError("The value of filters should not be zero")
 
     if not all(self.kernel_size):
       raise ValueError('The argument `kernel_size` cannot contain 0(s). '
@@ -191,8 +194,6 @@ class Conv(Layer):
           'of groups. Received groups={}, but the input has {} channels '
           '(full input shape is {}).'.format(self.groups, input_channel,
                                              input_shape))
-    if self.filters == 0:
-      raise ValueError("filters should not be zero")
     kernel_shape = self.kernel_size + (input_channel // self.groups,
                                        self.filters)
 
@@ -971,8 +972,6 @@ class Conv1DTranspose(Conv1D):
     if input_shape.dims[channel_axis].value is None:
       raise ValueError('The channel dimension of the inputs '
                        'should be defined. Found `None`.')
-    if self.filters == 0:
-      raise ValueError("filters should not be zero")
     input_dim = int(input_shape[channel_axis])
     self.input_spec = InputSpec(ndim=3, axes={channel_axis: input_dim})
     kernel_shape = self.kernel_size + (self.filters, input_dim)
@@ -1244,8 +1243,6 @@ class Conv2DTranspose(Conv2D):
     if input_shape.dims[channel_axis].value is None:
       raise ValueError('The channel dimension of the inputs '
                        'should be defined. Found `None`.')
-    if self.filters == 0:
-      raise ValueError("filters should not be zero")
     input_dim = int(input_shape[channel_axis])
     self.input_spec = InputSpec(ndim=4, axes={channel_axis: input_dim})
     kernel_shape = self.kernel_size + (self.filters, input_dim)
@@ -1556,8 +1553,6 @@ class Conv3DTranspose(Conv3D):
     if input_shape.dims[channel_axis].value is None:
       raise ValueError('The channel dimension of the inputs '
                        'should be defined, found None: ' + str(input_shape))
-    if self.filters == 0:
-      raise ValueError("filters should not be zero")
     input_dim = int(input_shape[channel_axis])
     kernel_shape = self.kernel_size + (self.filters, input_dim)
     self.input_spec = InputSpec(ndim=5, axes={channel_axis: input_dim})
@@ -1822,8 +1817,6 @@ class SeparableConv(Conv):
     if input_shape.dims[channel_axis].value is None:
       raise ValueError('The channel dimension of the inputs '
                        'should be defined. Found `None`.')
-    if self.filters == 0:
-      raise ValueError("filters should not be zero")
     input_dim = int(input_shape[channel_axis])
     self.input_spec = InputSpec(ndim=self.rank + 2,
                                 axes={channel_axis: input_dim})

--- a/tensorflow/python/keras/layers/convolutional.py
+++ b/tensorflow/python/keras/layers/convolutional.py
@@ -170,7 +170,7 @@ class Conv(Layer):
               self.groups, self.filters))
       
     if self.filters == 0:
-      raise ValueError("The value of filters should not be zero")
+      raise ValueError("The value of `filters` argument should not be zero")
 
     if not all(self.kernel_size):
       raise ValueError('The argument `kernel_size` cannot contain 0(s). '

--- a/tensorflow/python/keras/layers/convolutional_test.py
+++ b/tensorflow/python/keras/layers/convolutional_test.py
@@ -168,7 +168,8 @@ class Conv1DTest(keras_parameterized.TestCase):
 
   def test_conv1d_zero_filters(self):
     kwargs = {'filters': 0, 'kernel_size': 2}
-    with self.assertRaisesRegex(ValueError, "The value of the `filters` argument should not be zero"):
+    with self.assertRaisesRegex(ValueError, 'The value of the `filters` '
+                                'argument should not be zero'):
       keras.layers.Conv1D(**kwargs)  
 
 
@@ -305,7 +306,8 @@ class Conv2DTest(keras_parameterized.TestCase):
 
   def test_conv2d_zero_filters(self):
     kwargs = {'filters': 0, 'kernel_size': 2}
-    with self.assertRaisesRegex(ValueError, "The value of the `filters` argument should not be zero"):
+    with self.assertRaisesRegex(ValueError, 'The value of the `filters` '
+                                'argument should not be zero'):
       keras.layers.Conv2D(**kwargs)
 
 
@@ -445,7 +447,8 @@ class Conv3DTest(keras_parameterized.TestCase):
 
   def test_conv3d_zero_filters(self):
     kwargs = {'filters': 0, 'kernel_size': 2}
-    with self.assertRaisesRegex(ValueError, "The value of the `filters` argument should not be zero"):
+    with self.assertRaisesRegex(ValueError, 'The value of the `filters` '
+                                'argument should not be zero'):
       keras.layers.Conv3D(**kwargs)
 
 
@@ -535,7 +538,8 @@ class Conv1DTransposeTest(keras_parameterized.TestCase):
 
   def test_conv1d_transpose_zero_filters(self):
     kwargs = {'filters': 0, 'kernel_size': 2}
-    with self.assertRaisesRegex(ValueError, "The value of the `filters` argument should not be zero"):
+    with self.assertRaisesRegex(ValueError, 'The value of the `filters` '
+                                'argument should not be zero'):
       keras.layers.Conv1DTranspose(**kwargs)
 
 
@@ -573,7 +577,8 @@ class Conv3DTransposeTest(keras_parameterized.TestCase):
 
   def test_conv3d_transpose_zero_filters(self):
     kwargs = {'filters': 0, 'kernel_size': 2}
-    with self.assertRaisesRegex(ValueError, "The value of the `filters` argument should not be zero"):
+    with self.assertRaisesRegex(ValueError, 'The value of the `filters` '
+                                'argument should not be zero'):
       keras.layers.Conv3DTranspose(**kwargs)
  
 

--- a/tensorflow/python/keras/layers/convolutional_test.py
+++ b/tensorflow/python/keras/layers/convolutional_test.py
@@ -168,7 +168,7 @@ class Conv1DTest(keras_parameterized.TestCase):
 
   def test_conv1d_zero_filters(self):
     kwargs = {'filters': 0, 'kernel_size': 2}
-    with self.assertRaisesRegex(ValueError):
+    with self.assertRaisesRegex(ValueError, "The value of the `filters` argument should not be zero"):
       keras.layers.Conv1D(**kwargs)  
 
 
@@ -305,7 +305,7 @@ class Conv2DTest(keras_parameterized.TestCase):
 
   def test_conv2d_zero_filters(self):
     kwargs = {'filters': 0, 'kernel_size': 2}
-    with self.assertRaisesRegex(ValueError):
+    with self.assertRaisesRegex(ValueError, "The value of the `filters` argument should not be zero"):
       keras.layers.Conv2D(**kwargs)
 
 
@@ -445,7 +445,7 @@ class Conv3DTest(keras_parameterized.TestCase):
 
   def test_conv3d_zero_filters(self):
     kwargs = {'filters': 0, 'kernel_size': 2}
-    with self.assertRaisesRegex(ValueError):
+    with self.assertRaisesRegex(ValueError, "The value of the `filters` argument should not be zero"):
       keras.layers.Conv3D(**kwargs)
 
 
@@ -535,7 +535,7 @@ class Conv1DTransposeTest(keras_parameterized.TestCase):
 
   def test_conv1d_transpose_zero_filters(self):
     kwargs = {'filters': 0, 'kernel_size': 2}
-    with self.assertRaisesRegex(ValueError):
+    with self.assertRaisesRegex(ValueError, "The value of the `filters` argument should not be zero"):
       keras.layers.Conv1DTranspose(**kwargs)
 
 
@@ -573,7 +573,7 @@ class Conv3DTransposeTest(keras_parameterized.TestCase):
 
   def test_conv3d_transpose_zero_filters(self):
     kwargs = {'filters': 0, 'kernel_size': 2}
-    with self.assertRaisesRegex(ValueError):
+    with self.assertRaisesRegex(ValueError, "The value of the `filters` argument should not be zero"):
       keras.layers.Conv3DTranspose(**kwargs)
  
 

--- a/tensorflow/python/keras/layers/convolutional_test.py
+++ b/tensorflow/python/keras/layers/convolutional_test.py
@@ -168,7 +168,7 @@ class Conv1DTest(keras_parameterized.TestCase):
 
   def test_conv1d_zero_filters(self):
     kwargs = {'filters': 0, 'kernel_size': 2}
-    with self.assertRaises(ValueError):
+    with self.assertRaisesRegex(ValueError):
       keras.layers.Conv1D(**kwargs)  
 
 
@@ -305,7 +305,7 @@ class Conv2DTest(keras_parameterized.TestCase):
 
   def test_conv2d_zero_filters(self):
     kwargs = {'filters': 0, 'kernel_size': 2}
-    with self.assertRaises(ValueError):
+    with self.assertRaisesRegex(ValueError):
       keras.layers.Conv2D(**kwargs)
 
 
@@ -445,7 +445,7 @@ class Conv3DTest(keras_parameterized.TestCase):
 
   def test_conv3d_zero_filters(self):
     kwargs = {'filters': 0, 'kernel_size': 2}
-    with self.assertRaises(ValueError):
+    with self.assertRaisesRegex(ValueError):
       keras.layers.Conv3D(**kwargs)
 
 
@@ -535,7 +535,7 @@ class Conv1DTransposeTest(keras_parameterized.TestCase):
 
   def test_conv1d_transpose_zero_filters(self):
     kwargs = {'filters': 0, 'kernel_size': 2}
-    with self.assertRaises(ValueError):
+    with self.assertRaisesRegex(ValueError):
       keras.layers.Conv1DTranspose(**kwargs)
 
 
@@ -573,7 +573,7 @@ class Conv3DTransposeTest(keras_parameterized.TestCase):
 
   def test_conv3d_transpose_zero_filters(self):
     kwargs = {'filters': 0, 'kernel_size': 2}
-    with self.assertRaises(ValueError):
+    with self.assertRaisesRegex(ValueError):
       keras.layers.Conv3DTranspose(**kwargs)
  
 

--- a/tensorflow/python/keras/layers/convolutional_test.py
+++ b/tensorflow/python/keras/layers/convolutional_test.py
@@ -166,6 +166,11 @@ class Conv1DTest(keras_parameterized.TestCase):
       fn(inpt2)
       self.assertEqual(outp1_shape, layer(inpt1).shape)
 
+  def test_conv1d_zero_filters(self):
+    kwargs = {'filters': 0, 'kernel_size': 2}
+    with self.assertRaises(ValueError):
+      keras.layers.Conv1D(**kwargs)  
+
 
 @keras_parameterized.run_all_keras_modes
 class Conv2DTest(keras_parameterized.TestCase):
@@ -295,6 +300,11 @@ class Conv2DTest(keras_parameterized.TestCase):
 
   def test_conv2d_zero_kernel_size(self):
     kwargs = {'filters': 2, 'kernel_size': 0}
+    with self.assertRaises(ValueError):
+      keras.layers.Conv2D(**kwargs)
+
+  def test_conv2d_zero_filters(self):
+    kwargs = {'filters': 0, 'kernel_size': 2}
     with self.assertRaises(ValueError):
       keras.layers.Conv2D(**kwargs)
 
@@ -433,6 +443,11 @@ class Conv3DTest(keras_parameterized.TestCase):
             input_shape=(None, 3, None, None, None),
             input_data=input_data)
 
+  def test_conv3d_zero_filters(self):
+    kwargs = {'filters': 0, 'kernel_size': 2}
+    with self.assertRaises(ValueError):
+      keras.layers.Conv3D(**kwargs)
+
 
 @keras_parameterized.run_all_keras_modes(always_skip_v1=True)
 class GroupedConvTest(keras_parameterized.TestCase):
@@ -518,6 +533,11 @@ class Conv1DTransposeTest(keras_parameterized.TestCase):
         test.is_gpu_available(cuda_only=True)):
       self._run_test(kwargs, expected_output_shape)
 
+  def test_conv1d_transpose_zero_filters(self):
+    kwargs = {'filters': 0, 'kernel_size': 2}
+    with self.assertRaises(ValueError):
+      keras.layers.Conv1DTranspose(**kwargs)
+
 
 @keras_parameterized.run_all_keras_modes
 class Conv3DTransposeTest(keras_parameterized.TestCase):
@@ -551,6 +571,11 @@ class Conv3DTransposeTest(keras_parameterized.TestCase):
     if 'data_format' not in kwargs or test.is_gpu_available(cuda_only=True):
       self._run_test(kwargs, expected_output_shape)
 
+  def test_conv3d_transpose_zero_filters(self):
+    kwargs = {'filters': 0, 'kernel_size': 2}
+    with self.assertRaises(ValueError):
+      keras.layers.Conv3DTranspose(**kwargs)
+ 
 
 @keras_parameterized.run_all_keras_modes
 class ConvSequentialTest(keras_parameterized.TestCase):


### PR DESCRIPTION
Fix #48470. This PR raises a `ValueError` for all conv layers upon encountering `filters = 0`. @fchollet 