### PR TITLE
[Cherrypick:2.5]Copy execution plan in graph partitioner. Also adds code to model_builder_test that fails without this fix.

### DIFF
--- a/tensorflow/lite/delegates/utils.h
+++ b/tensorflow/lite/delegates/utils.h
@@ -60,7 +60,10 @@ class GraphPartitionHelper {
         supported_nodes_(
             ConvertVectorToTfLiteIntArray(supported_node_indices)) {}
 
-  virtual ~GraphPartitionHelper() { TfLiteIntArrayFree(supported_nodes_); }
+  virtual ~GraphPartitionHelper() {
+    TfLiteIntArrayFree(supported_nodes_);
+    TfLiteIntArrayFree(original_execution_plan_);
+  }
 
   // Partition the graph into node subsets such that each subset could be
   // replaced with one delegate kernel (i.e. a kTfLiteBuiltinDelegate op).
@@ -108,6 +111,10 @@ class GraphPartitionHelper {
   // managed by the TfLite runtime itself. See
   // TfLiteContext::PreviewDelegatePartitioning for details.
   std::vector<TfLiteDelegateParams*> partitions_;
+
+  // Copy of (pre-delegation) execution plan obtained from TfLiteContext in
+  // PrepareSupportedNodes
+  TfLiteIntArray* original_execution_plan_ = nullptr;
 
  private:
   // Generate a list of supported nodes (i.e. populating 'supported_nodes_') by


### PR DESCRIPTION
PiperOrigin-RevId: 368744429
Change-Id: I59378037b9e42a20581fa4c2393e2a64bbcb54ef