### PR TITLE
Update of oneDNN version for mkl_aarch64 build target

### DIFF
--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -192,11 +192,11 @@ def _tf_repositories():
     tf_http_archive(
         name = "mkl_dnn_acl_compatible",
         build_file = "//third_party/mkl_dnn:mkldnn_acl.BUILD",
-        sha256 = "5f7fd92e2d0bf83580656695d4404e2cd1390ecad36496fd8ba10b5adc905f70",
-        strip_prefix = "oneDNN-2.1",
+        sha256 = "4d655c0751ee6439584ef5e3d465953fe0c2f4ee2700bc02699bdc1d1572af0d",
+        strip_prefix = "oneDNN-2.2",
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/oneapi-src/oneDNN/archive/v2.1.tar.gz",
-            "https://github.com/oneapi-src/oneDNN/archive/v2.1.tar.gz",
+            "https://storage.googleapis.com/mirror.tensorflow.org/https://github.com/oneapi-src/oneDNN/archive/v2.2.tar.gz",
+            "https://github.com/oneapi-src/oneDNN/archive/v2.2.tar.gz",
         ],
     )
 

--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -195,7 +195,7 @@ def _tf_repositories():
         sha256 = "4d655c0751ee6439584ef5e3d465953fe0c2f4ee2700bc02699bdc1d1572af0d",
         strip_prefix = "oneDNN-2.2",
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/https://github.com/oneapi-src/oneDNN/archive/v2.2.tar.gz",
+            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/oneapi-src/oneDNN/archive/v2.2.tar.gz",
             "https://github.com/oneapi-src/oneDNN/archive/v2.2.tar.gz",
         ],
     )

--- a/third_party/mkl_dnn/mkldnn_acl.BUILD
+++ b/third_party/mkl_dnn/mkldnn_acl.BUILD
@@ -27,9 +27,9 @@ template_rule(
     out = "include/oneapi/dnnl/dnnl_version.h",
     substitutions = {
         "@DNNL_VERSION_MAJOR@": "2",
-        "@DNNL_VERSION_MINOR@": "1",
+        "@DNNL_VERSION_MINOR@": "2",
         "@DNNL_VERSION_PATCH@": "0",
-        "@DNNL_VERSION_HASH@": "fbdfeea2642fec05387ed37d565cf904042f507e",
+        "@DNNL_VERSION_HASH@": "269680b228218158fc172e9d5277446f73ac1917",
     },
 )
 
@@ -38,16 +38,25 @@ cc_library(
     srcs = glob(
         [
             "src/common/*.cpp",
-            "src/common/*.hpp",
             "src/cpu/**/*.cpp",
-            "src/cpu/**/*.hpp",
+            "src/cpu/*.cpp",
         ],
-        exclude = ["src/cpu/x64/**/*"],
-    ) + [
-        ":dnnl_config_h",
-        ":dnnl_version_h",
-    ],
-    hdrs = glob(["include/*"]),
+        exclude = [
+            "src/cpu/x64/**",
+        ],
+    ),
+    textual_hdrs = glob(
+        [
+            "include/**/*",
+            "include/*",
+            "src/common/*.hpp",
+            "src/cpu/**/*.hpp",
+            "src/cpu/*.hpp",
+            "src/cpu/aarch64/xbyak_aarch64/**/*.h",
+        ]) + [
+            ":dnnl_config_h",
+            ":dnnl_version_h",
+        ],
     copts = [
         "-fexceptions",
         "-UUSE_MKL",
@@ -60,6 +69,8 @@ cc_library(
         "src/common",
         "src/cpu",
         "src/cpu/gemm",
+        "src/cpu/aarch64/xbyak_aarch64/src",
+        "src/cpu/aarch64/xbyak_aarch64/xbyak_aarch64",
     ],
     linkopts = ["-lgomp"],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
This change noticeably, x1.7 for ResNet50 inference, improves the performance of CNNs on AArch64 (`--config=mkl_aarch64`).