### PR TITLE
[INTEL MKL] [2.5 cherry pick]  Log warning message for int8 in case of native format

### DIFF
--- a/tensorflow/core/common_runtime/mkl_layout_pass.cc
+++ b/tensorflow/core/common_runtime/mkl_layout_pass.cc
@@ -30,6 +30,7 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
+#include "absl/base/call_once.h"
 #include "tensorflow/core/common_runtime/function.h"
 #include "tensorflow/core/common_runtime/optimization_registry.h"
 #include "tensorflow/core/framework/node_def_util.h"
@@ -3688,6 +3689,24 @@ MklLayoutRewritePass::CheckForQuantizedNodeRewrite(const Node* n) const {
   if (type_attrs_present) {
     for (auto ri = rinfo_.cbegin(); ri != rinfo_.cend(); ++ri) {
       if (n->type_string().compare(ri->name) == 0 && ri->rewrite_rule(n)) {
+	// Currently OneDNN optimization does not support int8 with native
+	// format.
+        if (NativeFormatEnabled()) {
+          static absl::once_flag once;
+	  absl::call_once(once, [] {
+#if defined(ENABLE_MKL)
+            VLOG(0) << "MklLayoutRewritePass::RewriteInfo: Do not support INT8"
+                    << "data type for native format. Please set environment "
+                    << "variable TF_ENABLE_MKL_NATIVE_FORMAT to false.";
+#else
+            VLOG(0) << "MklLayoutRewritePass::RewriteInfo: Do not support INT8 "
+	            << "data type for native format. Please switch to Intel "
+	            << "Optimized Tensorflow and set environment variable "
+                    << "TF_ENABLE_MKL_NATIVE_FORMAT to false.";
+#endif  // defined(ENABLE_MKL)
+          });
+          return nullptr;
+        }
         return &*ri;
       }
     }

--- a/tensorflow/core/common_runtime/mkl_layout_pass.cc
+++ b/tensorflow/core/common_runtime/mkl_layout_pass.cc
@@ -3689,19 +3689,19 @@ MklLayoutRewritePass::CheckForQuantizedNodeRewrite(const Node* n) const {
   if (type_attrs_present) {
     for (auto ri = rinfo_.cbegin(); ri != rinfo_.cend(); ++ri) {
       if (n->type_string().compare(ri->name) == 0 && ri->rewrite_rule(n)) {
-	// Currently OneDNN optimization does not support int8 with native
-	// format.
+        // Currently OneDNN optimization does not support int8 with native
+        // format.
         if (NativeFormatEnabled()) {
           static absl::once_flag once;
-	  absl::call_once(once, [] {
+          absl::call_once(once, [] {
 #if defined(ENABLE_MKL)
-            VLOG(0) << "MklLayoutRewritePass::RewriteInfo: Do not support INT8"
-                    << "data type for native format. Please set environment "
-                    << "variable TF_ENABLE_MKL_NATIVE_FORMAT to false.";
+            VLOG(0) << "MklLayoutRewritePass::RewriteInfo does not support INT8"
+                    << "data type for native format. Please set the environment"
+                    << " variable TF_ENABLE_MKL_NATIVE_FORMAT to false. ";
 #else
-            VLOG(0) << "MklLayoutRewritePass::RewriteInfo: Do not support INT8 "
-	            << "data type for native format. Please switch to Intel "
-	            << "Optimized Tensorflow and set environment variable "
+            VLOG(0) << "MklLayoutRewritePass::RewriteInfo does not support INT8"
+                    << " data type for native format. Please switch to Intel "
+                    << "Optimized Tensorflow and set environment variable "
                     << "TF_ENABLE_MKL_NATIVE_FORMAT to false.";
 #endif  // defined(ENABLE_MKL)
           });

--- a/tensorflow/core/common_runtime/mkl_layout_pass.cc
+++ b/tensorflow/core/common_runtime/mkl_layout_pass.cc
@@ -3701,7 +3701,7 @@ MklLayoutRewritePass::CheckForQuantizedNodeRewrite(const Node* n) const {
 #else
             VLOG(0) << "MklLayoutRewritePass::RewriteInfo does not support INT8"
                     << " data type for native format. Please switch to Intel "
-                    << "Optimized Tensorflow and set environment variable "
+                    << "Optimized Tensorflow and set the environment variable "
                     << "TF_ENABLE_MKL_NATIVE_FORMAT to false.";
 #endif  // defined(ENABLE_MKL)
           });


### PR DESCRIPTION

This PR logs a warning message to the Tensorflow customers in the following cases when OneDNN optimization does not 
support INT8 inference/training:

   (1) stock Tensorflow, with OneDNN optimizations enabled (in this case, INT8 is not supported at all.
 
   (2) Intel Optimized Tensorflow (aka, build with --config=mkl): in this case, the warning message reminds the user
        to set a proper environment variable before running INT8 inference/training. 

Please help to cherry pick this small PR into RC2 branch. 