### PR TITLE
[ROCm] Reduction for complex types, dynamic warp setting

### DIFF
--- a/tensorflow/core/kernels/reduction_gpu_kernels.cu.h
+++ b/tensorflow/core/kernels/reduction_gpu_kernels.cu.h
@@ -43,6 +43,23 @@ struct SqrtOfReal {
   }
 };
 
+#if TENSORFLOW_USE_ROCM
+template <>
+struct SqrtOfReal<hipFloatComplex> {
+  __host__ __device__ hipFloatComplex operator()(const hipFloatComplex& a) const {
+    return hipFloatComplex(sqrt(float(a.x)), 0.0f);
+  }
+};
+
+template <>
+struct SqrtOfReal<hipDoubleComplex> {
+  __host__ __device__ hipDoubleComplex operator()(const hipDoubleComplex& a) const {
+    return hipDoubleComplex(sqrt(double(a.x)), 0.0);
+  }
+};
+#endif
+
+
 template <typename T>
 struct Sum {
   __host__ __device__ T operator()(const T& a, const T& b) const {
@@ -64,13 +81,52 @@ struct Square {
   }
 };
 
+#if TENSORFLOW_USE_ROCM
+template <>
+struct Square<hipFloatComplex> {
+  __host__ __device__ hipFloatComplex operator()(const hipFloatComplex& a) const {
+    return hipFloatComplex(a.x*a.x+a.y*a.y, 0.0f);
+  }
+};
+
+template <>
+struct Square<hipDoubleComplex> {
+  __host__ __device__ hipDoubleComplex operator()(const hipDoubleComplex& a) const {
+    return hipDoubleComplex(a.x*a.x+a.y*a.y, 0.0);
+  }
+};
+#endif
+
+template <typename T> struct inner_float {
+  typedef float IT;
+};
+
+template <> struct inner_float<double> {
+  typedef double IT;
+};
+
+template <> struct inner_float<std::complex<double> > {
+  typedef double IT;
+};
+
+#if TENSORFLOW_USE_ROCM
+template <> struct inner_float<hipDoubleComplex> {
+  typedef double IT;
+};
+#endif
+
+//divisor_type was previously same as T, but it's wasteful since the constructor
+//argument is always integer (and it introduces troubles with complex division)
 template <typename T, typename OUT_T = T>
 struct DividesBy {
-  T divisor;
+  // Do the division in float unless the type is double or double complex
+  typedef typename inner_float<T>::IT divisor_type;
+  divisor_type divisor;
 
-  __host__ __device__ explicit DividesBy(T divisor) : divisor(divisor) {}
+  __host__ __device__ explicit DividesBy(uint64 divisor) 
+    : divisor(divisor_type(1.0)/divisor) {}
 
-  __host__ __device__ OUT_T operator()(const T& x) const { return x / divisor; }
+  __host__ __device__ OUT_T operator()(const T& x) const { return x*divisor; }
 };
 
 struct MaxPropagateNaN {
@@ -88,49 +144,46 @@ struct MinPropagateNaN {
 };
 
 #if GOOGLE_CUDA
-// TODO(rocm) : enable this once ROCm platform has support for complex datatypes
-//
 // needed to work around a compiler bug in nvcc - it doesn't seem to like
 // the overloaded ops for std::complex
+// (TODO: check if this is still needed)
 template <>
 struct DividesBy<std::complex<float>> {
-  cuFloatComplex divisor;
+  float divisor;
 
-  __host__ __device__ explicit DividesBy(std::complex<float> divisor)
-      : divisor(make_cuComplex(divisor.real(), divisor.imag())) {}
+  __host__ __device__ explicit DividesBy(uint64 divisor)
+      : divisor(1.0f/divisor) {}
 
   // implements
   __host__ __device__ std::complex<float> operator()(
       const std::complex<float>& x) const {
-    auto result = cuCdivf(make_cuComplex(x.real(), x.imag()), divisor);
-    return std::complex<float>(result.x, result.y);
+    return std::complex<float>(x.real()*divisor, x.imag()*divisor);
   }
 };
 
 template <>
 struct DividesBy<std::complex<double>> {
-  cuDoubleComplex divisor;
+  double divisor;
 
-  __host__ __device__ explicit DividesBy(std::complex<double> divisor)
-      : divisor(make_cuDoubleComplex(divisor.real(), divisor.imag())) {}
+  __host__ __device__ explicit DividesBy(uint64 divisor)
+      : divisor(1./divisor) {}
 
   // implements
   __host__ __device__ std::complex<double> operator()(
       const std::complex<double>& x) const {
-    auto result = cuCdiv(make_cuDoubleComplex(x.real(), x.imag()), divisor);
-    return std::complex<double>(result.x, result.y);
+    return std::complex<double>(x.real()*divisor, x.imag()*divisor);
   }
 };
-#endif  // GOOGLE_CUDA
+#endif
 
 template <>
 struct DividesBy<float, Eigen::half> {
   float divisor;
 
-  __host__ __device__ explicit DividesBy(float divisor) : divisor(divisor) {}
+  __host__ __device__ explicit DividesBy(uint64 divisor) : divisor(1.0f/divisor) {}
 
   __host__ __device__ Eigen::half operator()(const float& x) const {
-    return Eigen::half(x / divisor);
+    return Eigen::half(x * divisor);
   }
 };
 
@@ -197,17 +250,17 @@ __global__ __launch_bounds__(1024) void BlockReduceKernel(
 }
 
 // maps a warp to each row
-template <typename T, typename OUT_T, typename Op>
+template <typename T, typename OUT_T, typename Op, int WARPSIZE>
 __global__ __launch_bounds__(1024) void RowReduceKernel(
     T in, OUT_T out, int num_rows, int num_cols, Op op,
     typename std::iterator_traits<T>::value_type initVal) {
   typedef typename std::iterator_traits<T>::value_type value_type;
   // Defensive index computation to avoid integer overflow.
-  assert(blockDim.x % TF_RED_WARPSIZE == 0);
-  int warps_per_block = blockDim.x / TF_RED_WARPSIZE;
-  int warp_index = threadIdx.x / TF_RED_WARPSIZE;
+  assert(blockDim.x % WARPSIZE == 0);
+  int warps_per_block = blockDim.x / WARPSIZE;
+  int warp_index = threadIdx.x / WARPSIZE;
   const int row = blockIdx.x * warps_per_block + warp_index;
-  const int lane = threadIdx.x % TF_RED_WARPSIZE;
+  const int lane = threadIdx.x % WARPSIZE;
 
   if (num_cols == 1) {
     int gid = threadIdx.x + blockIdx.x * blockDim.x;
@@ -220,8 +273,8 @@ __global__ __launch_bounds__(1024) void RowReduceKernel(
 
   if (row < num_rows && col < num_cols) {
     sum = in[row * num_cols + col];
-    col += TF_RED_WARPSIZE;
-    for (; col < num_cols; col += TF_RED_WARPSIZE) {
+    col += WARPSIZE;
+    for (; col < num_cols; col += WARPSIZE) {
       sum = op(sum, in[row * num_cols + col]);
     }
   }
@@ -231,7 +284,7 @@ __global__ __launch_bounds__(1024) void RowReduceKernel(
   __shared__ typename WarpReduce::TempStorage temp_storage;
 
   sum =
-      WarpReduce(temp_storage).Reduce(sum, op, min(num_cols, TF_RED_WARPSIZE));
+      WarpReduce(temp_storage).Reduce(sum, op, min(num_cols, WARPSIZE));
 
   if (row < num_rows && lane == 0) out[row] = sum;
 }
@@ -265,14 +318,20 @@ struct storage_type<std::complex<T2>> {
 
 // Works only if there are <= 16 columns
 // each warps sums over multiple rows at once
-template <typename T, typename OUT_T, typename Op>
+template <typename T, typename OUT_T, typename Op, int _WARPSIZE>
 __global__ __launch_bounds__(1024) void ColumnReduceMax16ColumnsKernel(
     T in, OUT_T out, int num_rows, int num_cols, Op op,
     typename std::iterator_traits<T>::value_type initVal) {
+  // must resort to this trick because, at least on ROCm, the compiler
+  // tries to instantiate the template with _WARPSIZE=64 for all types,
+  // resulting in an "insufficient shared memory" error,
+  // even if runtime logic prevents the version with complex128,64 from
+  // ever being called,
   typedef typename std::iterator_traits<T>::value_type value_type;
-  int rows_per_warp = TF_RED_WARPSIZE / num_cols;
+  constexpr int WARPSIZE = sizeof(value_type)>=16 ? 32 : _WARPSIZE;
+  int rows_per_warp = WARPSIZE / num_cols;
 
-  const int lane = threadIdx.x % TF_RED_WARPSIZE;
+  const int lane = threadIdx.x % WARPSIZE;
   const int lane_row = lane / num_cols;
 
   const int start_row_warp =
@@ -292,12 +351,12 @@ __global__ __launch_bounds__(1024) void ColumnReduceMax16ColumnsKernel(
     //   (TF_RED_WARPSIZE+1)];
 #if GOOGLE_CUDA
   __shared__ __align__(alignof(value_type)) char
-      partial_sums_raw[TF_RED_WARPSIZE * (TF_RED_WARPSIZE + 1) *
+      partial_sums_raw[WARPSIZE * (WARPSIZE + 1) *
                        sizeof(value_type)];
   value_type* partial_sums = reinterpret_cast<value_type*>(partial_sums_raw);
 #elif TENSORFLOW_USE_ROCM
   __shared__ storage_type<value_type>
-      partial_sums[TF_RED_WARPSIZE * (TF_RED_WARPSIZE + 1)];
+      partial_sums[WARPSIZE * (WARPSIZE + 1)];
 #endif
 
   row += rows_per_warp * gridDim.y * blockDim.y;
@@ -309,23 +368,24 @@ __global__ __launch_bounds__(1024) void ColumnReduceMax16ColumnsKernel(
 
   const int rows_in_this_warp = min(rows_per_warp, num_rows - start_row_warp);
   // not the most efficient way to do this sum
+  uint64_t warp_mask = (WARPSIZE==32) ? 0xffffffff : 0xffffffffffffffffll;
   for (int i = 1; i < rows_in_this_warp; ++i) {
-    value_type tmp = gpuprim::ShuffleIndex<TF_RED_WARPSIZE, value_type>(
-        sum, static_cast<int>(threadIdx.x + i * num_cols), 0xffffffff);
+    value_type tmp = gpuprim::ShuffleIndex<WARPSIZE, value_type>(
+        sum, static_cast<int>(threadIdx.x + i * num_cols), warp_mask);
     if (lane < num_cols) sum = op(sum, tmp);
   }
 
   if (lane < num_cols)
-    partial_sums[lane * (TF_RED_WARPSIZE + 1) + threadIdx.y] = sum;
+    partial_sums[lane * (WARPSIZE + 1) + threadIdx.y] = sum;
 
   __syncthreads();
 
   if (threadIdx.y == 0 && threadIdx.x < num_cols) {
-    value_type s = partial_sums[threadIdx.x * (TF_RED_WARPSIZE + 1)];
+    value_type s = partial_sums[threadIdx.x * (WARPSIZE + 1)];
 
     if (blockDim.y > 1) {
       for (int row = 1; row < blockDim.y; ++row) {
-        value_type t = partial_sums[threadIdx.x * (TF_RED_WARPSIZE + 1) + row];
+        value_type t = partial_sums[threadIdx.x * (WARPSIZE + 1) + row];
         s = op(s, t);
       }
     }
@@ -334,14 +394,15 @@ __global__ __launch_bounds__(1024) void ColumnReduceMax16ColumnsKernel(
   }
 }
 
-// Maps each block to a column range TF_RED_WARPSIZE wide
-template <typename T, typename OUT_T, typename Op>
+// Maps each block to a column range WARPSIZE wide
+template <typename T, typename OUT_T, typename Op, int _WARPSIZE>
 __global__ __launch_bounds__(1024) void ColumnReduceKernel(
     T in, OUT_T out, int num_rows, int num_cols, Op op,
     typename std::iterator_traits<T>::value_type initVal) {
   typedef typename std::iterator_traits<T>::value_type value_type;
+  constexpr int WARPSIZE = sizeof(value_type)>=16 ? 32 : _WARPSIZE;
   int row = blockIdx.y * blockDim.y + threadIdx.y;
-  int col = blockIdx.x * TF_RED_WARPSIZE + threadIdx.x;
+  int col = blockIdx.x * WARPSIZE + threadIdx.x;
 
   value_type sum = initVal;
   if (row < num_rows && col < num_cols) sum = in[row * num_cols + col];
@@ -349,16 +410,16 @@ __global__ __launch_bounds__(1024) void ColumnReduceKernel(
     // 1D array necessary due to bug in CUDA 9 compiler.
     // TODO(nluehr) revert to 2D array when compiler is ready.
     // This is to mimic the following, but without constructors:
-    //     __shared__ storage_type<value_type> partial_sums[TF_RED_WARPSIZE *
-    //     (TF_RED_WARPSIZE + 1)];
+    //     __shared__ storage_type<value_type> partial_sums[WARPSIZE *
+    //     (WARPSIZE + 1)];
 #if GOOGLE_CUDA
   __shared__ __align__(alignof(value_type)) char
-      partial_sums_raw[TF_RED_WARPSIZE * (TF_RED_WARPSIZE + 1) *
+      partial_sums_raw[WARPSIZE * (WARPSIZE + 1) *
                        sizeof(value_type)];
   value_type* partial_sums = reinterpret_cast<value_type*>(partial_sums_raw);
 #elif TENSORFLOW_USE_ROCM
   __shared__ storage_type<value_type>
-      partial_sums[TF_RED_WARPSIZE * (TF_RED_WARPSIZE + 1)];
+      partial_sums[WARPSIZE * (WARPSIZE + 1)];
 #endif
 
   row += gridDim.y * blockDim.y;
@@ -369,12 +430,12 @@ __global__ __launch_bounds__(1024) void ColumnReduceKernel(
     }
   }
 
-  partial_sums[threadIdx.x * (TF_RED_WARPSIZE + 1) + threadIdx.y] = sum;
+  partial_sums[threadIdx.x * (WARPSIZE + 1) + threadIdx.y] = sum;
 
   __syncthreads();
 
   if (threadIdx.y == 0 && col < num_cols) {
-    value_type s = partial_sums[threadIdx.x * (TF_RED_WARPSIZE + 1)];
+    value_type s = partial_sums[threadIdx.x * (WARPSIZE + 1)];
 
     // only include input values in the reduction
     // elem   block_rows
@@ -390,7 +451,7 @@ __global__ __launch_bounds__(1024) void ColumnReduceKernel(
         min(static_cast<int>(blockDim.y), num_rows - blockIdx.y * blockDim.y);
 
     for (int row = 1; row < numRowsThisBlock; ++row) {
-      value_type t = partial_sums[threadIdx.x * (TF_RED_WARPSIZE + 1) + row];
+      value_type t = partial_sums[threadIdx.x * (WARPSIZE + 1) + row];
       s = op(s, t);
     }
 
@@ -645,10 +706,29 @@ struct GatherOp {
   int group_size_;
 };
 
+#if TENSORFLOW_USE_ROCM
+inline bool isGfx10(OpKernelContext* ctx) {
+  hipDeviceProp_t props;
+  int dev = 0;
+  hipError_t result = hipGetDevice(&dev);
+  result = hipGetDeviceProperties(&props, dev);
+  if (result == hipSuccess) {
+    std::string gcnArchName = props.gcnArchName;
+    return (gcnArchName.substr(0,5)=="gfx10");
+  }
+  return false;
+}
+#endif
+
 template <typename T, typename Op, typename OUT_T, typename IN_T>
 void LaunchScalarReduction(OpKernelContext* ctx, OUT_T out, IN_T in,
                            int in_size, Op op, T init,
                            const gpuStream_t& cu_stream) {
+#if TENSORFLOW_USE_ROCM
+  int WARPSIZE = isGfx10(ctx) ? 32 : 64;
+#else
+  constexpr int WARPSIZE = TF_RED_WARPSIZE;
+#endif
   // handle situations where low latency is important better than CUB
   if (in_size <= 4096) {
     const int num_blocks = 1;
@@ -660,7 +740,7 @@ void LaunchScalarReduction(OpKernelContext* ctx, OUT_T out, IN_T in,
   } else if (in_size <= 1 << 18) {
     const int num_threads = 256;
     const int num_blocks =
-        std::min(TF_RED_WARPSIZE, Eigen::divup(in_size, num_threads));
+        std::min(WARPSIZE, Eigen::divup(in_size, num_threads));
     // it seems like tailoring this to the GPU
     // would be more effective, but all attempts
     // at making this a multiple of the number of
@@ -685,12 +765,11 @@ void LaunchScalarReduction(OpKernelContext* ctx, OUT_T out, IN_T in,
     // requires it to be used with a full warp.  Can reduce TF_RED_WARPSIZE ->
     // num_blocks when this is fixed.
     TF_CHECK_OK(GpuLaunchKernel(CleanupSegments<T*, OUT_T, Op>, 1,
-                                TF_RED_WARPSIZE, 0, cu_stream,
+                                WARPSIZE==32 ? 32 : 64, 0, cu_stream,
                                 (T*)temp_storage.flat<int8_t>().data(), out, 1,
                                 1, num_blocks, op, init));
     return;
   }
-
   size_t temp_storage_bytes = 0;
   auto reduce = [&](void* temp_storage_ptr) {
     auto success =
@@ -717,17 +796,23 @@ template <typename T, typename Op, typename OUT_T, typename IN_T>
 void LaunchRowReduction(OpKernelContext* ctx, OUT_T out, IN_T in, int num_rows,
                         int num_cols, Op op, T init,
                         const gpuStream_t& cu_stream) {
+#if TENSORFLOW_USE_ROCM
+  int WARPSIZE = isGfx10(ctx) ? 32 : 64;
+#else
+  constexpr int WARPSIZE = TF_RED_WARPSIZE;
+#endif
   if (num_cols < 1024) {
     const int threads_per_block = 128;
-    const int warps_per_block = threads_per_block / TF_RED_WARPSIZE;
+    const int warps_per_block = threads_per_block / WARPSIZE;
     int num_blocks = (num_rows + warps_per_block - 1) / warps_per_block;
-
-    TF_CHECK_OK(GpuLaunchKernel(RowReduceKernel<IN_T, OUT_T, Op>, num_blocks,
+    auto fun = WARPSIZE==32 
+         ? RowReduceKernel<IN_T, OUT_T, Op, 32>
+         : RowReduceKernel<IN_T, OUT_T, Op, 64>;
+    TF_CHECK_OK(GpuLaunchKernel(fun, num_blocks,
                                 threads_per_block, 0, cu_stream, in, out,
                                 num_rows, num_cols, op, init));
     return;
   }
-
   // setup segment offsets with counting and transform iterator
   RowOffset row_offset_op(num_cols);
   gpuprim::CountingInputIterator<int> counting_iter(0);
@@ -761,26 +846,34 @@ template <typename T, typename Op, typename OUT_T, typename IN_T>
 void LaunchColumnReduction_LTE16Cols(OpKernelContext* ctx, OUT_T out, IN_T in,
                                      int extent_x, int extent_y, Op op, T init,
                                      const gpuStream_t& cu_stream) {
-  int rows_per_warp = TF_RED_WARPSIZE / extent_y;
+#if TENSORFLOW_USE_ROCM
+  int WARPSIZE = (std::is_same<T, hipDoubleComplex>::value || isGfx10(ctx))
+      ? 32 : 64;
+#else
+  constexpr int WARPSIZE = TF_RED_WARPSIZE;
+#endif
+  int rows_per_warp = WARPSIZE / extent_y;
   dim3 block_dim(
-      TF_RED_WARPSIZE,
-      std::min(Eigen::divup(extent_x, rows_per_warp), (1024 / TF_RED_WARPSIZE)),
+      WARPSIZE,
+      std::min(Eigen::divup(extent_x, rows_per_warp), (1024 / WARPSIZE)),
       1);
   dim3 grid_dim(1,
                 Eigen::divup(static_cast<unsigned int>(extent_x),
                              rows_per_warp * block_dim.y),
                 1);
 
-  grid_dim.y = std::min((int)grid_dim.y, TF_RED_WARPSIZE);
+  grid_dim.y = std::min((int)grid_dim.y, WARPSIZE);
 
-  if (grid_dim.y > 2 && grid_dim.y < TF_RED_WARPSIZE) {
+  if (grid_dim.y > 2 && grid_dim.y < WARPSIZE) {
     int log2 = Log2Floor(grid_dim.y);
     grid_dim.y = 1 << log2;
   }
 
   if (grid_dim.y == 1) {
-    TF_CHECK_OK(GpuLaunchKernel(ColumnReduceMax16ColumnsKernel<IN_T, OUT_T, Op>,
-                                grid_dim, block_dim, 0, cu_stream, in, out,
+    auto fun = WARPSIZE==32
+              ? ColumnReduceMax16ColumnsKernel<IN_T, OUT_T, Op, 32>
+              : ColumnReduceMax16ColumnsKernel<IN_T, OUT_T, Op, 64>;
+    TF_CHECK_OK(GpuLaunchKernel(fun, grid_dim, block_dim, 0, cu_stream, in, out,
                                 extent_x, extent_y, op, init));
   } else {
     Tensor temp_storage;
@@ -789,13 +882,15 @@ void LaunchColumnReduction_LTE16Cols(OpKernelContext* ctx, OUT_T out, IN_T in,
                                       TensorShape({static_cast<int64>(
                                           sizeof(T) * extent_y * grid_dim.y)}),
                                       &temp_storage));
-    TF_CHECK_OK(GpuLaunchKernel(ColumnReduceMax16ColumnsKernel<IN_T, T*, Op>,
-                                grid_dim, block_dim, 0, cu_stream, in,
+    auto fun = WARPSIZE==32
+            ? ColumnReduceMax16ColumnsKernel<IN_T, T*, Op, 32>
+            : ColumnReduceMax16ColumnsKernel<IN_T, T*, Op, 64>;
+    TF_CHECK_OK(GpuLaunchKernel(fun, grid_dim, block_dim, 0, cu_stream, in,
                                 (T*)temp_storage.flat<int8_t>().data(),
                                 extent_x, extent_y, op, init));
 
     dim3 new_grid_dim(
-        (grid_dim.y * extent_y + (TF_RED_WARPSIZE - 1)) / TF_RED_WARPSIZE, 1,
+        (grid_dim.y * extent_y + (WARPSIZE - 1)) / WARPSIZE, 1,
         1);
     dim3 num_threads(128, 1, 1);
     TF_CHECK_OK(GpuLaunchKernel(CleanupSegments<T*, OUT_T, Op>, new_grid_dim,
@@ -809,21 +904,33 @@ template <typename T, typename Op, typename OUT_T, typename IN_T>
 void LaunchColumnReduction_LTE4096Cols(OpKernelContext* ctx, OUT_T out, IN_T in,
                                        int extent_x, int extent_y, Op op,
                                        T init, const gpuStream_t& cu_stream) {
-  dim3 block_dim(TF_RED_WARPSIZE, std::min(extent_x, (1024 / TF_RED_WARPSIZE)),
+#if TENSORFLOW_USE_ROCM  
+  // On ROCm, TF_RED_WARPSIZE is 64 and the default value would require
+  // 66 kB of shared memory with double complex - more than actually
+  // available in the GPU.
+  int WARPSIZE = (std::is_same<T, hipDoubleComplex>::value || isGfx10(ctx))
+      ? 32 : 64;
+#else
+  constexpr int WARPSIZE = TF_RED_WARPSIZE;
+#endif
+  dim3 block_dim(WARPSIZE, std::min(extent_x, (1024 / WARPSIZE)),
                  1);
-  dim3 grid_dim((extent_y + (TF_RED_WARPSIZE - 1)) / TF_RED_WARPSIZE, 1, 1);
+  dim3 grid_dim((extent_y + (WARPSIZE - 1)) / WARPSIZE, 1, 1);
 
   if (grid_dim.x < 16)
-    grid_dim.y = std::min((extent_x + (TF_RED_WARPSIZE - 1)) / TF_RED_WARPSIZE,
-                          TF_RED_WARPSIZE);
+    grid_dim.y = std::min((extent_x + (WARPSIZE - 1)) / WARPSIZE,
+                          WARPSIZE);
 
-  if (grid_dim.y > 2 && grid_dim.y < TF_RED_WARPSIZE) {
+  if (grid_dim.y > 2 && grid_dim.y < WARPSIZE) {
     int log2 = Log2Floor(grid_dim.y);
     grid_dim.y = 1 << log2;
   }
 
   if (grid_dim.y == 1) {
-    TF_CHECK_OK(GpuLaunchKernel(ColumnReduceKernel<IN_T, OUT_T, Op>, grid_dim,
+    auto fun = WARPSIZE==32
+               ? ColumnReduceKernel<IN_T, OUT_T, Op, 32>
+               : ColumnReduceKernel<IN_T, OUT_T, Op, 64>;
+    TF_CHECK_OK(GpuLaunchKernel(fun, grid_dim,
                                 block_dim, 0, cu_stream, in, out, extent_x,
                                 extent_y, op, init));
   } else {
@@ -834,12 +941,15 @@ void LaunchColumnReduction_LTE4096Cols(OpKernelContext* ctx, OUT_T out, IN_T in,
                                           sizeof(T) * extent_y * grid_dim.y)}),
                                       &temp_storage));
 
+    auto fun = WARPSIZE==32
+               ? ColumnReduceKernel<IN_T, T*, Op, 32>
+               : ColumnReduceKernel<IN_T, T*, Op, 64>;
     TF_CHECK_OK(GpuLaunchKernel(
-        ColumnReduceKernel<IN_T, T*, Op>, grid_dim, block_dim, 0, cu_stream, in,
+        fun, grid_dim, block_dim, 0, cu_stream, in,
         (T*)temp_storage.flat<int8_t>().data(), extent_x, extent_y, op, init));
 
     dim3 new_grid_dim(
-        (grid_dim.y * extent_y + (TF_RED_WARPSIZE - 1)) / TF_RED_WARPSIZE, 1,
+        (grid_dim.y * extent_y + (WARPSIZE - 1)) / WARPSIZE, 1,
         1);
     TF_CHECK_OK(GpuLaunchKernel(CleanupSegments<T*, OUT_T, Op>, new_grid_dim,
                                 block_dim, 0, cu_stream,
@@ -975,9 +1085,7 @@ void Launch3DXZReduction(OpKernelContext* ctx, OUT_T out, IN_T in, int extent_x,
                 errors::Internal("CUB segmented reduce error",
                                  GpuGetErrorString(success)));
   };
-
   reduce(nullptr);  // Get required amount of temp storage.
-
   Tensor temp_storage;
   OP_REQUIRES_OK(
       ctx, ctx->allocate_temp(
@@ -1066,6 +1174,23 @@ struct IdentityValue {
   }
 };
 
+#if TENSORFLOW_USE_ROCM
+// the generic template produces identity value 1+i (header bug?)
+template <>
+struct IdentityValue<hipFloatComplex, Prod<hipFloatComplex> > {
+  hipFloatComplex operator()() {
+    return hipFloatComplex(1.0, 0.0);
+  }
+};
+
+template <>
+struct IdentityValue<hipDoubleComplex, Prod<hipDoubleComplex> > {
+  hipDoubleComplex operator()() {
+    return hipDoubleComplex(1.0, 0.0);
+  }
+};
+#endif
+
 }  // namespace reduction_op_helper
 
 template <typename T, typename Op, typename OUT_T, typename IN_T,
@@ -1107,66 +1232,61 @@ void ReduceImpl(OpKernelContext* ctx, OUT_T out, IN_T in, int in_rank,
   }
 }
 
-template <typename Reducer>
-struct ReduceFunctor<GPUDevice, Reducer> {
-  template <typename OUT_T, typename IN_T, typename ReductionAxes>
-  static void Reduce(OpKernelContext* ctx, OUT_T out, IN_T in,
-                     const ReductionAxes& reduction_axes,
-                     const Reducer& reducer);
-};
-
 template <typename T>
 struct ReduceFunctor<GPUDevice, Eigen::internal::SumReducer<T>> {
+  using TM = typename MapComplexToHipComplex<T>::TM;
   template <typename OUT_T, typename IN_T, typename ReductionAxes>
   static void Reduce(OpKernelContext* ctx, OUT_T out, IN_T in,
                      const ReductionAxes& reduction_axes,
                      const Eigen::internal::SumReducer<T>& reducer) {
-    ReduceImpl<T, Sum<T>, T*, T*, ReductionAxes>(
-        ctx, (T*)out.data(), (T*)in.data(), in.rank(), in.dimension(0),
+    ReduceImpl<TM, Sum<TM>, TM*, TM*, ReductionAxes>(
+        ctx, (TM*)out.data(), (TM*)in.data(), in.rank(), in.dimension(0),
         in.rank() >= 2 ? in.dimension(1) : 1,
         in.rank() >= 3 ? in.dimension(2) : 1, out.rank(), reduction_axes,
-        Sum<T>());
+        Sum<TM>());
   }
 
   template <typename OUT_T>
   static void FillIdentity(const GPUDevice& d, OUT_T out,
                            const Eigen::internal::SumReducer<T>& reducer) {
-    FillIdentityEigenImpl(d, To32Bit(out), reducer);
+    FillIdentityEigenImplWithCast<T>(d, To32Bit(out), Eigen::internal::SumReducer<TM>());
   }
 };
 
 // TODO(rmlarsen): Specialize for float16.
 template <typename T>
 struct ReduceFunctor<GPUDevice, functor::EuclideanNormReducer<T>> {
+  using TM = typename MapComplexToHipComplex<T>::TM;
   template <typename OUT_T, typename IN_T, typename ReductionAxes>
   static void Reduce(OpKernelContext* ctx, OUT_T out, IN_T in,
                      const ReductionAxes& reduction_axes,
                      const functor::EuclideanNormReducer<T>& reducer) {
-    typedef gpuprim::TransformInputIterator<T, Square<T>, T*> inputIterType;
-    inputIterType input_itr((T*)in.data(), Square<T>());
-    typedef TransformOutputIterator<T, T, SqrtOfReal<T>> outputIterType;
-    outputIterType output_itr((T*)out.data(), SqrtOfReal<T>());
-    ReduceImpl<T, Sum<T>, outputIterType, inputIterType, ReductionAxes>(
+    typedef gpuprim::TransformInputIterator<TM, Square<TM>, TM*> inputIterType;
+    inputIterType input_itr((TM*)in.data(), Square<TM>());
+    typedef TransformOutputIterator<TM, TM, SqrtOfReal<TM>> outputIterType;
+    outputIterType output_itr((TM*)out.data(), SqrtOfReal<TM>());
+    ReduceImpl<TM, Sum<TM>, outputIterType, inputIterType, ReductionAxes>(
         ctx, output_itr, input_itr, in.rank(), in.dimension(0),
         in.rank() >= 2 ? in.dimension(1) : 1,
         in.rank() >= 3 ? in.dimension(2) : 1, out.rank(), reduction_axes,
-        Sum<T>());
+        Sum<TM>());
   }
 
   template <typename OUT_T>
   static void FillIdentity(const GPUDevice& d, OUT_T out,
                            const functor::EuclideanNormReducer<T>& reducer) {
-    FillIdentityEigenImpl(d, To32Bit(out), reducer);
+    FillIdentityEigenImplWithCast<T>(d, To32Bit(out), functor::EuclideanNormReducer<TM>());
   }
 };
 
 template <typename T>
 struct ReduceFunctor<GPUDevice, functor::MeanReducer<T>> {
+  using TM = typename MapComplexToHipComplex<T>::TM;
   template <typename OUT_T, typename IN_T, typename ReductionAxes>
   static void Reduce(OpKernelContext* ctx, OUT_T out, IN_T in,
                      const ReductionAxes& reduction_axes,
                      const functor::MeanReducer<T>& reducer) {
-    int divisor = 1;
+    uint64 divisor = 1;
     if (out.rank() == 0)
       divisor = in.size();
     else if (out.rank() == 1 && in.rank() == 2 && reduction_axes[0] == 0)
@@ -1179,20 +1299,20 @@ struct ReduceFunctor<GPUDevice, functor::MeanReducer<T>> {
     else if (out.rank() == 2 && in.rank() == 3 && reduction_axes[0] == 1)
       divisor = in.dimension(1);
 
-    DividesBy<T> div_op(static_cast<T>(divisor));
-    TransformOutputIterator<T, T, DividesBy<T>> itr((T*)out.data(), div_op);
-    ReduceImpl<T, Sum<T>, TransformOutputIterator<T, T, DividesBy<T>>, T*,
-               ReductionAxes>(ctx, itr, (T*)in.data(), in.rank(),
+    DividesBy<TM> div_op(divisor);
+    TransformOutputIterator<TM, TM, DividesBy<TM>> itr((TM*)out.data(), div_op);
+    ReduceImpl<TM, Sum<TM>, TransformOutputIterator<TM, TM, DividesBy<TM>>, TM*,
+               ReductionAxes>(ctx, itr, (TM*)in.data(), in.rank(),
                               in.dimension(0),
                               in.rank() >= 2 ? in.dimension(1) : 1,
                               in.rank() >= 3 ? in.dimension(2) : 1, out.rank(),
-                              reduction_axes, Sum<T>());
+                              reduction_axes, Sum<TM>());
   }
 
   template <typename OUT_T>
   static void FillIdentity(const GPUDevice& d, OUT_T out,
                            const functor::MeanReducer<T>& reducer) {
-    FillIdentityEigenImpl(d, To32Bit(out), reducer);
+    FillIdentityEigenImplWithCast<T>(d, To32Bit(out), functor::MeanReducer<TM>());
   }
 };
 
@@ -1202,7 +1322,7 @@ struct ReduceFunctor<GPUDevice, functor::MeanReducer<Eigen::half>> {
   static void Reduce(OpKernelContext* ctx, OUT_T out, IN_T in,
                      const ReductionAxes& reduction_axes,
                      const functor::MeanReducer<Eigen::half>& reducer) {
-    float divisor = 1.f;
+    uint64 divisor = 1;
     if (out.rank() == 0)
       divisor = in.size();
     else if (out.rank() == 1 && in.rank() == 2 && reduction_axes[0] == 0)
@@ -1242,13 +1362,14 @@ struct ReduceFunctor<GPUDevice, functor::MeanReducer<Eigen::half>> {
 template <typename T>
 struct ReduceFunctor<GPUDevice,
                      Eigen::internal::MaxReducer<T, Eigen::PropagateNaN>> {
+  using TM = typename MapComplexToHipComplex<T>::TM;
   template <typename OUT_T, typename IN_T, typename ReductionAxes>
   static void Reduce(
       OpKernelContext* ctx, OUT_T out, IN_T in,
       const ReductionAxes& reduction_axes,
       const Eigen::internal::MaxReducer<T, Eigen::PropagateNaN>& reducer) {
-    ReduceImpl<T, MaxPropagateNaN, T*, T*, ReductionAxes>(
-        ctx, (T*)out.data(), (T*)in.data(), in.rank(), in.dimension(0),
+    ReduceImpl<TM, MaxPropagateNaN, TM*, TM*, ReductionAxes>(
+        ctx, (TM*)out.data(), (TM*)in.data(), in.rank(), in.dimension(0),
         in.rank() >= 2 ? in.dimension(1) : 1,
         in.rank() >= 3 ? in.dimension(2) : 1, out.rank(), reduction_axes,
         MaxPropagateNaN());
@@ -1258,20 +1379,23 @@ struct ReduceFunctor<GPUDevice,
   static void FillIdentity(
       const GPUDevice& d, OUT_T out,
       const Eigen::internal::MaxReducer<T, Eigen::PropagateNaN>& reducer) {
-    FillIdentityEigenImpl(d, To32Bit(out), reducer);
+    FillIdentityEigenImplWithCast<T>(
+        d, To32Bit(out),
+        Eigen::internal::MaxReducer<TM, Eigen::PropagateNaN>());
   }
 };
 
 template <typename T>
 struct ReduceFunctor<GPUDevice,
                      Eigen::internal::MinReducer<T, Eigen::PropagateNaN>> {
+  using TM = typename MapComplexToHipComplex<T>::TM;
   template <typename OUT_T, typename IN_T, typename ReductionAxes>
   static void Reduce(
       OpKernelContext* ctx, OUT_T out, IN_T in,
       const ReductionAxes& reduction_axes,
       const Eigen::internal::MinReducer<T, Eigen::PropagateNaN>& reducer) {
-    ReduceImpl<T, MinPropagateNaN, T*, T*, ReductionAxes>(
-        ctx, (T*)out.data(), (T*)in.data(), in.rank(), in.dimension(0),
+    ReduceImpl<TM, MinPropagateNaN, TM*, TM*, ReductionAxes>(
+        ctx, (TM*)out.data(), (TM*)in.data(), in.rank(), in.dimension(0),
         in.rank() >= 2 ? in.dimension(1) : 1,
         in.rank() >= 3 ? in.dimension(2) : 1, out.rank(), reduction_axes,
         MinPropagateNaN());
@@ -1281,27 +1405,30 @@ struct ReduceFunctor<GPUDevice,
   static void FillIdentity(
       const GPUDevice& d, OUT_T out,
       const Eigen::internal::MinReducer<T, Eigen::PropagateNaN>& reducer) {
-    FillIdentityEigenImpl(d, To32Bit(out), reducer);
+    FillIdentityEigenImplWithCast<T>(
+        d, To32Bit(out),
+        Eigen::internal::MinReducer<TM, Eigen::PropagateNaN>());
   }
 };
 
 template <typename T>
 struct ReduceFunctor<GPUDevice, Eigen::internal::ProdReducer<T>> {
+  using TM = typename MapComplexToHipComplex<T>::TM;  
   template <typename OUT_T, typename IN_T, typename ReductionAxes>
   static void Reduce(OpKernelContext* ctx, OUT_T out, IN_T in,
                      const ReductionAxes& reduction_axes,
                      const Eigen::internal::ProdReducer<T>& reducer) {
-    ReduceImpl<T, Prod<T>, T*, T*, ReductionAxes>(
-        ctx, (T*)out.data(), (T*)in.data(), in.rank(), in.dimension(0),
+    ReduceImpl<TM, Prod<TM>, TM*, TM*, ReductionAxes>(
+        ctx, (TM*)out.data(), (TM*)in.data(), in.rank(), in.dimension(0),
         in.rank() >= 2 ? in.dimension(1) : 1,
         in.rank() >= 3 ? in.dimension(2) : 1, out.rank(), reduction_axes,
-        Prod<T>());
+        Prod<TM>());
   }
 
   template <typename OUT_T>
   static void FillIdentity(const GPUDevice& d, OUT_T out,
                            const Eigen::internal::ProdReducer<T>& reducer) {
-    FillIdentityEigenImpl(d, To32Bit(out), reducer);
+    FillIdentityEigenImplWithCast<T>(d, To32Bit(out), Eigen::internal::ProdReducer<TM>());
   }
 };
 

--- a/tensorflow/core/kernels/reduction_ops.h
+++ b/tensorflow/core/kernels/reduction_ops.h
@@ -22,6 +22,10 @@ limitations under the License.
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/tensor_types.h"
 
+#if TENSORFLOW_USE_ROCM
+#include "rocm/include/hip/hip_complex.h"
+#endif
+
 namespace tensorflow {
 namespace functor {
 
@@ -177,11 +181,41 @@ struct Identity {
 FIX_MEAN_IDENTITY(Eigen::half)
 FIX_MEAN_IDENTITY(float)
 FIX_MEAN_IDENTITY(double)
+#if TENSORFLOW_USE_ROCM
+template <>
+struct Identity<functor::MeanReducer<hipFloatComplex> > {
+  static hipFloatComplex identity(const functor::MeanReducer<hipFloatComplex>&) { 
+    return hipFloatComplex(Eigen::NumTraits<float>::quiet_NaN(), Eigen::NumTraits<float>::quiet_NaN());
+  }
+};
+template <>
+struct Identity<functor::MeanReducer<hipDoubleComplex> > {
+  static hipDoubleComplex identity(const functor::MeanReducer<hipDoubleComplex>&) { 
+    return hipDoubleComplex(Eigen::NumTraits<double>::quiet_NaN(), Eigen::NumTraits<double>::quiet_NaN());
+  }
+};
+#else
+FIX_MEAN_IDENTITY(complex64)
+FIX_MEAN_IDENTITY(complex128)
+#endif
 #undef FIX_MEAN_IDENTITY
 
 template <typename Device, typename OUT_T, typename Reducer>
 void FillIdentityEigenImpl(const Device& d, OUT_T out, const Reducer& reducer) {
   out.device(d) = out.constant(Identity<Reducer>::identity(reducer));
+}
+
+//on ROCm with complex input, reducer produces hipFloatComplex/hipDoubleComplex
+//and this function bitcasts them to std::complex.
+//In all other cases, it is identical to FillIdentityEigenImpl.
+template <typename T, typename Device, typename OUT_T, typename Reducer>
+void FillIdentityEigenImplWithCast(const Device& d, OUT_T out, const Reducer& reducer) {
+  auto id = Identity<Reducer>::identity(reducer);
+  T cast_id;
+  static_assert(sizeof(id)==sizeof(cast_id), 
+      "Error: FillIdentityEigenImplWithCast with incompatible types?");
+  memcpy(&cast_id, &id, sizeof(cast_id)); // to avoid strict-aliasing warnings
+  out.device(d) = out.constant(cast_id);
 }
 
 template <typename Device, typename Reducer>

--- a/tensorflow/core/kernels/reduction_ops_gpu_complex128.cu.cc
+++ b/tensorflow/core/kernels/reduction_ops_gpu_complex128.cu.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #define EIGEN_USE_GPU
 
@@ -34,15 +34,15 @@ typedef TTypes<float>::Tensor::Index Index;
 // NUM_AXES: the number of axes to reduce
 // IN_DIMS: the number of dimensions of the input tensor
 #define DEFINE(T, REDUCER, IN_DIMS, NUM_AXES)                          \
-  template void ReduceFunctor<GPUDevice, REDUCER>::Reduce(             \
+  template void ReduceFunctor<GPUDevice, REDUCER<T> >::Reduce(         \
       OpKernelContext* ctx, TTypes<T, IN_DIMS - NUM_AXES>::Tensor out, \
       TTypes<T, IN_DIMS>::ConstTensor in,                              \
       const Eigen::array<Index, NUM_AXES>& reduction_axes,             \
-      const REDUCER& reducer);
+      const REDUCER<T>& reducer);
 
-#define DEFINE_IDENTITY(T, REDUCER)                              \
-  template void ReduceFunctor<GPUDevice, REDUCER>::FillIdentity( \
-      const GPUDevice& d, TTypes<T>::Vec out, const REDUCER& reducer);
+#define DEFINE_IDENTITY(T, REDUCER)                                  \
+  template void ReduceFunctor<GPUDevice, REDUCER<T> >::FillIdentity( \
+      const GPUDevice& d, TTypes<T>::Vec out, const REDUCER<T>& reducer);
 
 #define DEFINE_FOR_TYPE_AND_R(T, R) \
   DEFINE(T, R, 1, 1);               \
@@ -51,14 +51,14 @@ typedef TTypes<float>::Tensor::Index Index;
   DEFINE(T, R, 3, 2);               \
   DEFINE_IDENTITY(T, R)
 
-DEFINE_FOR_TYPE_AND_R(complex128, Eigen::internal::SumReducer<complex128>);
-DEFINE_FOR_TYPE_AND_R(complex128, functor::MeanReducer<complex128>);
-DEFINE_FOR_TYPE_AND_R(complex128, functor::EuclideanNormReducer<complex128>);
-DEFINE_FOR_TYPE_AND_R(complex128, Eigen::internal::ProdReducer<complex128>);
+DEFINE_FOR_TYPE_AND_R(complex128, Eigen::internal::SumReducer);
+DEFINE_FOR_TYPE_AND_R(complex128, functor::MeanReducer);
+DEFINE_FOR_TYPE_AND_R(complex128, functor::EuclideanNormReducer);
+DEFINE_FOR_TYPE_AND_R(complex128, Eigen::internal::ProdReducer);
 #undef DEFINE_FOR_TYPE_AND_R
 #undef DEFINE
 
 }  // end namespace functor
 }  // end namespace tensorflow
 
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/core/kernels/reduction_ops_gpu_complex64.cu.cc
+++ b/tensorflow/core/kernels/reduction_ops_gpu_complex64.cu.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #define EIGEN_USE_GPU
 
@@ -34,15 +34,15 @@ typedef TTypes<float>::Tensor::Index Index;
 // NUM_AXES: the number of axes to reduce
 // IN_DIMS: the number of dimensions of the input tensor
 #define DEFINE(T, REDUCER, IN_DIMS, NUM_AXES)                          \
-  template void ReduceFunctor<GPUDevice, REDUCER>::Reduce(             \
+  template void ReduceFunctor<GPUDevice, REDUCER<T> >::Reduce(         \
       OpKernelContext* ctx, TTypes<T, IN_DIMS - NUM_AXES>::Tensor out, \
       TTypes<T, IN_DIMS>::ConstTensor in,                              \
       const Eigen::array<Index, NUM_AXES>& reduction_axes,             \
-      const REDUCER& reducer);
+      const REDUCER<T>& reducer);
 
-#define DEFINE_IDENTITY(T, REDUCER)                              \
-  template void ReduceFunctor<GPUDevice, REDUCER>::FillIdentity( \
-      const GPUDevice& d, TTypes<T>::Vec out, const REDUCER& reducer);
+#define DEFINE_IDENTITY(T, REDUCER)                                  \
+  template void ReduceFunctor<GPUDevice, REDUCER<T> >::FillIdentity( \
+      const GPUDevice& d, TTypes<T>::Vec out, const REDUCER<T>& reducer);
 
 #define DEFINE_FOR_TYPE_AND_R(T, R) \
   DEFINE(T, R, 1, 1);               \
@@ -51,14 +51,14 @@ typedef TTypes<float>::Tensor::Index Index;
   DEFINE(T, R, 3, 2);               \
   DEFINE_IDENTITY(T, R)
 
-DEFINE_FOR_TYPE_AND_R(complex64, Eigen::internal::SumReducer<complex64>);
-DEFINE_FOR_TYPE_AND_R(complex64, functor::MeanReducer<complex64>);
-DEFINE_FOR_TYPE_AND_R(complex64, functor::EuclideanNormReducer<complex64>);
-DEFINE_FOR_TYPE_AND_R(complex64, Eigen::internal::ProdReducer<complex64>);
+DEFINE_FOR_TYPE_AND_R(complex64, Eigen::internal::SumReducer);
+DEFINE_FOR_TYPE_AND_R(complex64, functor::MeanReducer);
+DEFINE_FOR_TYPE_AND_R(complex64, functor::EuclideanNormReducer);
+DEFINE_FOR_TYPE_AND_R(complex64, Eigen::internal::ProdReducer);
 #undef DEFINE_FOR_TYPE_AND_R
 #undef DEFINE
 
 }  // end namespace functor
 }  // end namespace tensorflow
 
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/core/kernels/reduction_ops_gpu_double.cu.cc
+++ b/tensorflow/core/kernels/reduction_ops_gpu_double.cu.cc
@@ -73,3 +73,4 @@ DEFINE_FOR_ALL_REDUCERS(double);
 }  // end namespace tensorflow
 
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+

--- a/tensorflow/core/util/gpu_kernel_helper.h
+++ b/tensorflow/core/util/gpu_kernel_helper.h
@@ -30,7 +30,8 @@ limitations under the License.
 #if GOOGLE_CUDA
 #define TF_RED_WARPSIZE 32
 #elif TENSORFLOW_USE_ROCM
-#define TF_RED_WARPSIZE 64
+// We don't define TF_RED_WARPSIZE here, because it can be either 32 or 64
+// and the value is not known at compile time.
 #endif
 
 // Deprecated, use 'for(int i : GpuGridRangeX(n))' instead.


### PR DESCRIPTION
This PR supplies two related sets of ROCm-related changes:
* Reduction for complex data types
* Dynamic warp size setting (on ROCm, warp size is either 32 vs 64 depending on the GPU and the value is not known at compile time)