### PR TITLE
[Cherry-pick] Support the input/output data type inside the mlir quantizer

### DIFF
--- a/tensorflow/compiler/mlir/lite/BUILD
+++ b/tensorflow/compiler/mlir/lite/BUILD
@@ -550,6 +550,7 @@ cc_library(
         "transforms/default_quant_params.cc",
         "transforms/generated_post_quantize.inc",
         "transforms/generated_quantize.inc",
+        "transforms/modify_io_nodes.cc",
         "transforms/post_quantize.cc",
         "transforms/prepare_quantize.cc",
         "transforms/quantize.cc",

--- a/tensorflow/compiler/mlir/lite/quantization/lite/quantize_model.cc
+++ b/tensorflow/compiler/mlir/lite/quantization/lite/quantize_model.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include "absl/strings/string_view.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
 #include "mlir/IR/BuiltinOps.h"  // from @llvm-project
 #include "mlir/IR/Location.h"  // from @llvm-project
 #include "mlir/IR/MLIRContext.h"  // from @llvm-project
@@ -46,13 +47,6 @@ TfLiteStatus QuantizeModel(
     flatbuffers::FlatBufferBuilder* builder,
     tflite::ErrorReporter* error_reporter, bool verify_numeric,
     bool legacy_float_scale) {
-  // TODO(b/142502494): remove this restriction by improving the `emit_adaptor`
-  // flag
-  if (input_type != output_type) {
-    error_reporter->Report("Required same input type and output type.");
-    return kTfLiteError;
-  }
-
   DialectRegistry registry;
   registry.insert<mlir::TFL::TensorFlowLiteDialect>();
   MLIRContext context(registry);
@@ -76,29 +70,34 @@ TfLiteStatus QuantizeModel(
     return kTfLiteError;
   }
 
-  // Apply quantization passes
+  // Apply quantization passes.
   PassManager pm(module->getContext(), OpPassManager::Nesting::Implicit);
   TFL::QuantizationSpecs quant_specs;
   quant_specs.inference_type = tflite::TflTypeToTfType(inference_type);
   quant_specs.post_training_quantization = true;
   quant_specs.disable_per_channel = disable_per_channel;
-
-  bool emit_adaptor = false;
-  auto input_tf_type = tflite::TflTypeToTfType(input_type);
-  if (input_tf_type == tensorflow::DT_FLOAT) {
-    emit_adaptor = true;
-  } else if (input_tf_type == tensorflow::DT_UINT8 ||
-             input_tf_type == tensorflow::DT_INT8 ||
-             input_tf_type == tensorflow::DT_INT16) {
-    quant_specs.inference_type = input_tf_type;
-  }
-
   quant_specs.verify_numeric = verify_numeric;
   quant_specs.legacy_float_scale = legacy_float_scale;
 
+  llvm::dbgs() << "fully_quantize: " << fully_quantize
+               << ", inference_type: " << quant_specs.inference_type
+               << ", input_inference_type: " << input_type
+               << ", output_inference_type: " << output_type << "\n";
+  mlir::Builder mlir_builder(&context);
+  mlir::Type input_mlir_type =
+      tflite::ConvertElementType(input_type, mlir_builder);
+  mlir::Type output_mlir_type =
+      tflite::ConvertElementType(output_type, mlir_builder);
+
+  if (fully_quantize) {
+    input_mlir_type = tflite::ConvertElementType(inference_type, mlir_builder);
+    output_mlir_type = input_mlir_type;
+  }
+
   pm.addPass(TFL::CreatePrepareQuantizePass(quant_specs));
   pm.addPass(TFL::CreateQuantizePass(verify_numeric, legacy_float_scale));
-  pm.addPass(TFL::CreatePostQuantizePass(emit_adaptor));
+  pm.addPass(TFL::CreatePostQuantizePass(/*emit_quant_adaptor_ops=*/true));
+  pm.addPass(TFL::CreateModifyIONodesPass(input_mlir_type, output_mlir_type));
 
   if (failed(pm.run(module.get()))) {
     const std::string& err = statusHandler.ConsumeStatus().error_message();

--- a/tensorflow/compiler/mlir/lite/quantization/quantization_utils.h
+++ b/tensorflow/compiler/mlir/lite/quantization/quantization_utils.h
@@ -383,6 +383,10 @@ struct QuantizationPattern : public RewritePattern {
   bool log_if_failed;
 };
 
+// Converts quantized tensor type with signed integer type to quantized tensor
+// type with unsigned integer type.
+Type ConvertSignedQuantizedToUnsigned(Type signed_tensor_type, Location loc);
+
 // Converts quantize ops with unsigned quantized types to these with signed
 // quantized types and preserves the scales.
 template <typename Q>

--- a/tensorflow/compiler/mlir/lite/tests/modify_io_nodes.mlir
+++ b/tensorflow/compiler/mlir/lite/tests/modify_io_nodes.mlir
@@ -1,0 +1,46 @@
+// RUN: tf-opt %s -tfl-modify-io-nodes -tfl-test-io-types="float32,float32" | FileCheck %s
+// RUN: tf-opt %s -tfl-modify-io-nodes -tfl-test-io-types="int8,int8" | FileCheck --check-prefix=INT8 %s
+// RUN: tf-opt %s -tfl-modify-io-nodes -tfl-test-io-types="uint8,uint8" | FileCheck --check-prefix=UINT8 %s
+
+func @main(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x401408xf32> {
+  %cst = constant dense<[1, 401408]> : tensor<2xi32>
+  %0 = "tfl.quantize"(%arg0) {qtype = tensor<1x224x224x3x!quant.uniform<i8:f32, 7.812500e-03>>} : (tensor<1x224x224x3xf32>) -> tensor<1x224x224x3x!quant.uniform<i8:f32, 7.812500e-03>>
+  %1 = "tfl.pseudo_qconst"() {qtype = tensor<32x3x3x3x!quant.uniform<i8<-127:127>:f32, 0.021826678373682216:151>>, value = dense<-76> : tensor<32x3x3x3xi8>} : () -> tensor<32x3x3x3x!quant.uniform<i8<-127:127>:f32, 0.021826678373682216>>
+  %2 = "tfl.pseudo_qconst"() {qtype = tensor<32x!quant.uniform<i32:f32, 1.7052092479439231E-4>>, value = dense<0> : tensor<32xi32>} : () -> tensor<32x!quant.uniform<i32:f32, 1.7052092479439231E-4>>
+  %3 = "tfl.conv_2d"(%0, %1, %2) {dilation_h_factor = 1 : i32, dilation_w_factor = 1 : i32, fused_activation_function = "NONE", padding = "SAME", stride_h = 2 : i32, stride_w = 2 : i32} : (tensor<1x224x224x3x!quant.uniform<i8:f32, 7.812500e-03>>, tensor<32x3x3x3x!quant.uniform<i8<-127:127>:f32, 0.021826678373682216>>, tensor<32x!quant.uniform<i32:f32, 1.7052092479439231E-4>>) -> tensor<1x112x112x32x!quant.uniform<i8:f32, 0.023528476789885875>>
+  %4 = "tfl.reshape"(%3, %cst) : (tensor<1x112x112x32x!quant.uniform<i8:f32, 0.023528476789885875>>, tensor<2xi32>) -> tensor<1x401408x!quant.uniform<i8:f32, 0.023528476789885875>>
+  %5 = "tfl.softmax"(%4) {beta = 1.000000e+00 : f32} : (tensor<1x401408x!quant.uniform<i8:f32, 0.023528476789885875>>) -> tensor<1x401408x!quant.uniform<i8:f32, 3.906250e-03>>
+  %6 = "tfl.dequantize"(%5) : (tensor<1x401408x!quant.uniform<i8:f32, 3.906250e-03>>) -> tensor<1x401408xf32>
+  return %6 : tensor<1x401408xf32>
+
+// CHECK-LABEL: func @main(%arg0: tensor<1x224x224x3xf32>) -> tensor<1x401408xf32> {
+// CHECK-NEXT: %[[shape:.*]] = constant dense<[1, 401408]> : tensor<2xi32>
+// CHECK-NEXT: %[[q:.*]] = "tfl.quantize"(%arg0) {qtype = tensor<1x224x224x3x!quant.uniform<i8:f32, 7.812500e-03>>} : (tensor<1x224x224x3xf32>) -> tensor<1x224x224x3x!quant.uniform<i8:f32, 7.812500e-03>>
+// CHECK-NEXT: %[[cst1:.*]] = "tfl.pseudo_qconst"() {qtype = tensor<32x3x3x3x!quant.uniform<i8<-127:127>:f32, 0.021826678373682216:151>>, value = dense<-76> : tensor<32x3x3x3xi8>} : () -> tensor<32x3x3x3x!quant.uniform<i8<-127:127>:f32, 0.021826678373682216>>
+// CHECK-NEXT: %[[cst2:.*]] = "tfl.pseudo_qconst"() {qtype = tensor<32x!quant.uniform<i32:f32, 1.7052092479439231E-4>>, value = dense<0> : tensor<32xi32>} : () -> tensor<32x!quant.uniform<i32:f32, 1.7052092479439231E-4>>
+// CHECK-NEXT: %[[conv:.*]] = "tfl.conv_2d"(%[[q]], %[[cst1]], %[[cst2]]) {dilation_h_factor = 1 : i32, dilation_w_factor = 1 : i32, fused_activation_function = "NONE", padding = "SAME", stride_h = 2 : i32, stride_w = 2 : i32} : (tensor<1x224x224x3x!quant.uniform<i8:f32, 7.812500e-03>>, tensor<32x3x3x3x!quant.uniform<i8<-127:127>:f32, 0.021826678373682216>>, tensor<32x!quant.uniform<i32:f32, 1.7052092479439231E-4>>) -> tensor<1x112x112x32x!quant.uniform<i8:f32, 0.023528476789885875>>
+// CHECK-NEXT: %[[reshape:.*]] = "tfl.reshape"(%[[conv]], %[[shape]]) : (tensor<1x112x112x32x!quant.uniform<i8:f32, 0.023528476789885875>>, tensor<2xi32>) -> tensor<1x401408x!quant.uniform<i8:f32, 0.023528476789885875>>
+// CHECK-NEXT: %[[softmax:.*]] = "tfl.softmax"(%[[reshape]]) {beta = 1.000000e+00 : f32} : (tensor<1x401408x!quant.uniform<i8:f32, 0.023528476789885875>>) -> tensor<1x401408x!quant.uniform<i8:f32, 3.906250e-03>>
+// CHECK-NEXT: %[[dq:.*]] = "tfl.dequantize"(%[[softmax]]) : (tensor<1x401408x!quant.uniform<i8:f32, 3.906250e-03>>) -> tensor<1x401408xf32>
+// CHECK-NEXT: return %[[dq]] : tensor<1x401408xf32>
+
+// INT8-LABEL: @main(%arg0: tensor<1x224x224x3x!quant.uniform<i8:f32, 7.812500e-03>>) -> tensor<1x401408x!quant.uniform<i8:f32, 3.906250e-03>> {
+// INT8-NEXT: %[[shape:.*]] = constant dense<[1, 401408]> : tensor<2xi32>
+// INT8-NEXT: %[[cst1:.*]] = "tfl.pseudo_qconst"() {qtype = tensor<32x3x3x3x!quant.uniform<i8<-127:127>:f32, 0.021826678373682216:151>>, value = dense<-76> : tensor<32x3x3x3xi8>} : () -> tensor<32x3x3x3x!quant.uniform<i8<-127:127>:f32, 0.021826678373682216>>
+// INT8-NEXT: %[[cst2:.*]] = "tfl.pseudo_qconst"() {qtype = tensor<32x!quant.uniform<i32:f32, 1.7052092479439231E-4>>, value = dense<0> : tensor<32xi32>} : () -> tensor<32x!quant.uniform<i32:f32, 1.7052092479439231E-4>>
+// INT8-NEXT: %[[conv:.*]] = "tfl.conv_2d"(%arg0, %[[cst1]], %[[cst2]]) {dilation_h_factor = 1 : i32, dilation_w_factor = 1 : i32, fused_activation_function = "NONE", padding = "SAME", stride_h = 2 : i32, stride_w = 2 : i32} : (tensor<1x224x224x3x!quant.uniform<i8:f32, 7.812500e-03>>, tensor<32x3x3x3x!quant.uniform<i8<-127:127>:f32, 0.021826678373682216>>, tensor<32x!quant.uniform<i32:f32, 1.7052092479439231E-4>>) -> tensor<1x112x112x32x!quant.uniform<i8:f32, 0.023528476789885875>>
+// INT8-NEXT: %[[reshape:.*]] = "tfl.reshape"(%[[conv]], %[[shape]]) : (tensor<1x112x112x32x!quant.uniform<i8:f32, 0.023528476789885875>>, tensor<2xi32>) -> tensor<1x401408x!quant.uniform<i8:f32, 0.023528476789885875>>
+// INT8-NEXT: %[[softmax:.*]] = "tfl.softmax"(%[[reshape]]) {beta = 1.000000e+00 : f32} : (tensor<1x401408x!quant.uniform<i8:f32, 0.023528476789885875>>) -> tensor<1x401408x!quant.uniform<i8:f32, 3.906250e-03>>
+// INT8-NEXT: return %[[softmax]] : tensor<1x401408x!quant.uniform<i8:f32, 3.906250e-03>>
+
+// UINT8-LABEL: func @main(%arg0: tensor<1x224x224x3x!quant.uniform<u8:f32, 7.812500e-03:128>>) -> tensor<1x401408x!quant.uniform<u8:f32, 3.906250e-03:128>> {
+// UINT8-NEXT: %[[shape:.*]] = constant dense<[1, 401408]> : tensor<2xi32>
+// UINT8-NEXT: %[[q:.*]] = "tfl.quantize"(%arg0) {qtype = tensor<1x224x224x3x!quant.uniform<i8:f32, 7.812500e-03>>} : (tensor<1x224x224x3x!quant.uniform<u8:f32, 7.812500e-03:128>>) -> tensor<1x224x224x3x!quant.uniform<i8:f32, 7.812500e-03>>
+// UINT8-NEXT: %[[cst1:.*]] = "tfl.pseudo_qconst"() {qtype = tensor<32x3x3x3x!quant.uniform<i8<-127:127>:f32, 0.021826678373682216:151>>, value = dense<-76> : tensor<32x3x3x3xi8>} : () -> tensor<32x3x3x3x!quant.uniform<i8<-127:127>:f32, 0.021826678373682216>>
+// UINT8-NEXT: %[[cst2:.*]] = "tfl.pseudo_qconst"() {qtype = tensor<32x!quant.uniform<i32:f32, 1.7052092479439231E-4>>, value = dense<0> : tensor<32xi32>} : () -> tensor<32x!quant.uniform<i32:f32, 1.7052092479439231E-4>>
+// UINT8-NEXT: %[[conv:.*]] = "tfl.conv_2d"(%[[q]], %[[cst1]], %[[cst2]]) {dilation_h_factor = 1 : i32, dilation_w_factor = 1 : i32, fused_activation_function = "NONE", padding = "SAME", stride_h = 2 : i32, stride_w = 2 : i32} : (tensor<1x224x224x3x!quant.uniform<i8:f32, 7.812500e-03>>, tensor<32x3x3x3x!quant.uniform<i8<-127:127>:f32, 0.021826678373682216>>, tensor<32x!quant.uniform<i32:f32, 1.7052092479439231E-4>>) -> tensor<1x112x112x32x!quant.uniform<i8:f32, 0.023528476789885875>>
+// UINT8-NEXT: %[[reshape:.*]] = "tfl.reshape"(%[[conv]], %[[shape]]) : (tensor<1x112x112x32x!quant.uniform<i8:f32, 0.023528476789885875>>, tensor<2xi32>) -> tensor<1x401408x!quant.uniform<i8:f32, 0.023528476789885875>>
+// UINT8-NEXT: %[[softmax:.*]] = "tfl.softmax"(%[[reshape]]) {beta = 1.000000e+00 : f32} : (tensor<1x401408x!quant.uniform<i8:f32, 0.023528476789885875>>) -> tensor<1x401408x!quant.uniform<i8:f32, 3.906250e-03>>
+// UINT8-NEXT: %[[dq:.*]] = "tfl.quantize"(%[[softmax]]) {qtype = tensor<1x401408x!quant.uniform<u8:f32, 3.906250e-03:128>>} : (tensor<1x401408x!quant.uniform<i8:f32, 3.906250e-03>>) -> tensor<1x401408x!quant.uniform<u8:f32, 3.906250e-03:128>>
+// UINT8-NEXT: return %[[dq]] : tensor<1x401408x!quant.uniform<u8:f32, 3.906250e-03:128>>
+}

--- a/tensorflow/compiler/mlir/lite/transforms/modify_io_nodes.cc
+++ b/tensorflow/compiler/mlir/lite/transforms/modify_io_nodes.cc
@@ -1,0 +1,232 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/raw_ostream.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"  // from @llvm-project
+#include "mlir/IR/Attributes.h"  // from @llvm-project
+#include "mlir/IR/Block.h"  // from @llvm-project
+#include "mlir/IR/Builders.h"  // from @llvm-project
+#include "mlir/IR/BuiltinTypes.h"  // from @llvm-project
+#include "mlir/IR/MLIRContext.h"  // from @llvm-project
+#include "mlir/Pass/Pass.h"  // from @llvm-project
+#include "mlir/Support/LLVM.h"  // from @llvm-project
+#include "mlir/Support/LogicalResult.h"  // from @llvm-project
+#include "tensorflow/compiler/mlir/lite/ir/tfl_ops.h"
+#include "tensorflow/compiler/mlir/lite/transforms/passes.h"
+
+// NOLINTNEXTLINE
+static llvm::cl::list<std::string> io_node_types(
+    "tfl-test-io-types", llvm::cl::value_desc("list"),
+    llvm::cl::desc("comma separated type strings. Allowed values: "
+                   "'int8', 'uint8', 'float32']"),
+    llvm::cl::CommaSeparated);
+
+namespace mlir {
+namespace TFL {
+namespace {
+
+// This transformation pass modifies the input and output types of the function
+// to what are specified. The task was not just adding cast operations, but,
+// instead, using tfl.quantize and tfl.dequantize ops to scale the tensors.
+struct ModifyIONodesPass : public PassWrapper<ModifyIONodesPass, FunctionPass> {
+ public:
+  explicit ModifyIONodesPass() {}
+  explicit ModifyIONodesPass(mlir::Type input_type, mlir::Type output_type)
+      : input_type(input_type), output_type(output_type) {}
+
+  void runOnFunction() override;
+
+ private:
+  // Assign the io types from the command line flag. This is only required for
+  // tests.
+  LogicalResult SetupInputOutputTypesIfNull(OpBuilder builder);
+
+  // Modifies the element types of entry block arguments to be user specified
+  // and returns  the new argument types.
+  LogicalResult ModifyInputNodes(FuncOp func,
+                                 llvm::SmallVectorImpl<Type>& new_input_types,
+                                 OpBuilder builder);
+
+  // Modifies the element types of entry block returns to be user specified
+  // and returns the new return types.
+  LogicalResult ModifyOutputNodes(FuncOp func,
+                                  llvm::SmallVectorImpl<Type>& new_output_types,
+                                  OpBuilder builder);
+
+  mlir::Type input_type;
+  mlir::Type output_type;
+};
+
+LogicalResult ModifyIONodesPass::SetupInputOutputTypesIfNull(
+    OpBuilder builder) {
+  if (input_type && output_type) return success();
+
+  auto convert_str_to_type = [&builder](absl::string_view str) -> Type {
+    if (str == "int8") {
+      return builder.getIntegerType(8);
+    } else if (str == "uint8") {
+      return builder.getIntegerType(8, /*isSigned=*/false);
+    } else if (str == "float32") {
+      return builder.getF32Type();
+    } else {
+      return {};
+    }
+  };
+  if (io_node_types.size() < 2) return failure();
+  if (!input_type) input_type = convert_str_to_type(io_node_types[0]);
+  if (!output_type) output_type = convert_str_to_type(io_node_types[1]);
+  return success();
+}
+
+LogicalResult ModifyIONodesPass::ModifyInputNodes(
+    FuncOp func, llvm::SmallVectorImpl<Type>& new_input_types,
+    OpBuilder builder) {
+  if (input_type.isa<FloatType>()) {
+    return success();
+  }
+
+  Block& block = func.front();
+  builder.setInsertionPointToStart(&block);
+
+  for (int i = 0; i != block.getNumArguments(); ++i) {
+    Value arg = block.getArgument(0);
+    Type arg_type = arg.getType();
+    Value new_arg = arg;
+    if (arg.hasOneUse() && llvm::isa<QuantizeOp>(*arg.user_begin())) {
+      auto quantize_op = llvm::cast<QuantizeOp>(*arg.user_begin());
+      auto quantize_output = quantize_op.output();
+      auto current_type = quant::QuantizedType::getQuantizedElementType(
+                              quantize_output.getType())
+                              .getStorageType();
+      if (current_type == input_type) {  // int8 == int8
+        arg_type = quantize_output.getType();
+        new_arg = block.addArgument(arg_type);
+        quantize_output.replaceAllUsesWith(new_arg);
+      } else if (input_type.isUnsignedInteger(
+                     current_type.getIntOrFloatBitWidth())) {  // int8 != uint8
+        arg_type = quant::ConvertSignedQuantizedToUnsigned(
+            quantize_output.getType(), quantize_op.getLoc());
+        new_arg = block.addArgument(arg_type);
+        quantize_op.setOperand(new_arg);
+      } else {
+        input_type.print(llvm::errs() << "Requested input type ");
+        quantize_op.emitError(" Couldn't be modified to the requested type.");
+        return failure();
+      }
+      new_input_types[i] = arg_type;
+      arg.dropAllUses();
+      if (quantize_op.use_empty()) {
+        quantize_op.erase();
+      }
+    } else {
+      new_arg = block.addArgument(arg_type);
+    }
+    block.eraseArgument(0);
+  }
+  return success();
+}
+
+LogicalResult ModifyIONodesPass::ModifyOutputNodes(
+    FuncOp func, llvm::SmallVectorImpl<Type>& new_output_types,
+    OpBuilder builder) {
+  Block& block = func.front();
+  auto* terminator = block.getTerminator();
+  builder.setInsertionPoint(terminator);
+
+  if (output_type.isa<FloatType>()) {
+    return success();
+  }
+
+  int num_return_operands = terminator->getNumOperands();
+  new_output_types.reserve(num_return_operands);
+  for (int i = 0; i != num_return_operands; ++i) {
+    auto returned_value = terminator->getOperand(i);
+    Type returned_type = returned_value.getType();
+    Operation* returned_op = returned_value.getDefiningOp();
+    if (returned_op && llvm::isa<DequantizeOp>(returned_op)) {
+      auto dequantize_op = llvm::cast<DequantizeOp>(returned_op);
+      auto dequantize_input = dequantize_op.input();
+      Type current_type = quant::QuantizedType::getQuantizedElementType(
+                              dequantize_input.getType())
+                              .getStorageType();
+      if (current_type == output_type) {  // int8 == int8
+        returned_type = dequantize_input.getType();
+        returned_value = dequantize_input;
+      } else if (output_type.isUnsignedInteger(
+                     current_type.getIntOrFloatBitWidth())) {  // int8 != uint8
+        returned_type = quant::ConvertSignedQuantizedToUnsigned(
+            dequantize_input.getType(), dequantize_op.getLoc());
+        // replace the dequantize op by a quantize op
+        TypeAttr type_attr = TypeAttr::get(returned_type);
+        auto quantize_op = builder.create<QuantizeOp>(
+            dequantize_op.getLoc(), returned_type, dequantize_input, type_attr);
+        returned_value = quantize_op.output();
+      } else {
+        output_type.print(llvm::errs() << "Requested output type ");
+        dequantize_op.emitError(" Couldn't be modified to the requested type.");
+        return failure();
+      }
+      new_output_types[i] = returned_type;
+      terminator->setOperand(i, returned_value);
+      if (dequantize_op.use_empty()) {
+        dequantize_op.erase();
+      }
+    }
+  }
+  return success();
+}
+
+void ModifyIONodesPass::runOnFunction() {
+  auto func = getFunction();
+  OpBuilder builder(func);
+  FunctionType func_type = func.getType();
+  llvm::SmallVector<Type, 4> new_input_types(func_type.getInputs().begin(),
+                                             func_type.getInputs().end());
+  llvm::SmallVector<Type, 4> new_output_types(func_type.getResults().begin(),
+                                              func_type.getResults().end());
+
+  if (failed(SetupInputOutputTypesIfNull(builder))) {
+    return;
+  }
+
+  if (failed(ModifyInputNodes(func, new_input_types, builder))) {
+    return;
+  }
+
+  if (failed(ModifyOutputNodes(func, new_output_types, builder))) {
+    return;
+  }
+
+  auto new_func_type =
+      builder.getFunctionType(new_input_types, new_output_types);
+  func.setType(new_func_type);
+}
+}  // namespace
+
+// Creates an instance of the TensorFlow Lite modify io nodes pass.
+std::unique_ptr<OperationPass<FuncOp>> CreateModifyIONodesPass(
+    Type input_type, Type output_type) {
+  return std::make_unique<ModifyIONodesPass>(input_type, output_type);
+}
+
+static PassRegistration<ModifyIONodesPass> pass(
+    "tfl-modify-io-nodes", "Modify the type of the model io nodes.");
+
+}  // namespace TFL
+}  // namespace mlir

--- a/tensorflow/compiler/mlir/lite/transforms/passes.h
+++ b/tensorflow/compiler/mlir/lite/transforms/passes.h
@@ -25,6 +25,7 @@ class FuncOp;
 class ModuleOp;
 template <typename T>
 class OperationPass;
+class Type;
 
 namespace TFL {
 class QuantizationSpecs;
@@ -75,6 +76,9 @@ std::unique_ptr<OperationPass<FuncOp>> CreateSplitMergedOperandsPass();
 
 // Creates an instance of the TensorFlow Lite dialect OptimizeFunctionalOpsPass.
 std::unique_ptr<OperationPass<ModuleOp>> CreateOptimizeFunctionalOpsPass();
+
+std::unique_ptr<OperationPass<FuncOp>> CreateModifyIONodesPass(
+    mlir::Type input_type, mlir::Type output_type);
 
 // Creates an instance of the TensorFlow Lite dialect pass to add default
 // quantization parameters.

--- a/tensorflow/compiler/mlir/lite/transforms/post_quantize.cc
+++ b/tensorflow/compiler/mlir/lite/transforms/post_quantize.cc
@@ -51,6 +51,7 @@ class PostQuantizePass : public PassWrapper<PostQuantizePass, FunctionPass> {
   bool emit_quant_adaptor_ops_;
 };
 
+// TODO(fengliuai): migrate to use modify_io_nodes pass.
 void RemoveQuantizationAdaptorOps(FuncOp func) {
   mlir::OpBuilder builder(func.getBody());
   auto& bb = func.front();

--- a/tensorflow/lite/python/convert.py
+++ b/tensorflow/lite/python/convert.py
@@ -200,6 +200,8 @@ def mlir_quantize(input_data_str,
                   disable_per_channel=False,
                   fully_quantize=False,
                   inference_type=_types_pb2.QUANTIZED_INT8,
+                  input_data_type=dtypes.float32,
+                  output_data_type=dtypes.float32,
                   enable_numeric_verify=False):
   """Quantize `input_data_str` with calibration results.
 
@@ -211,6 +213,8 @@ def mlir_quantize(input_data_str,
     fully_quantize: Bool indicating whether to fully quantize the model. Besides
       model body, the input/output will be quantized as well.
     inference_type: Data type for the activations. The default value is int8.
+    input_data_type: Data type for the inputs. The default value is float32.
+    output_data_type: Data type for the outputs. The default value is float32.
     enable_numeric_verify: Experimental. Subject to change. Bool indicating
       whether to add NumericVerify ops into the debug mode quantized model.
 
@@ -218,11 +222,11 @@ def mlir_quantize(input_data_str,
     Quantized model in serialized form (e.g. a TFLITE model) with floating-point
     inputs and outputs.
   """
-  return wrap_toco.wrapped_experimental_mlir_quantize(input_data_str,
-                                                      disable_per_channel,
-                                                      fully_quantize,
-                                                      inference_type,
-                                                      enable_numeric_verify)
+  return wrap_toco.wrapped_experimental_mlir_quantize(
+      input_data_str, disable_per_channel, fully_quantize, inference_type,
+      convert_tensor_tf_type_to_tflite_type(input_data_type),
+      convert_tensor_tf_type_to_tflite_type(output_data_type),
+      enable_numeric_verify)
 
 
 def mlir_sparsify(input_data_str):

--- a/tensorflow/lite/python/lite.py
+++ b/tensorflow/lite/python/lite.py
@@ -527,8 +527,7 @@ class TFLiteConverterBase(object):
         activations_type != _dtypes.int16):
       # TODO(b/175659372): remove the activations_type restriction and enable
       # it for all the activation types.
-      return _mlir_quantize(calibrated, disable_per_channel,
-                            input_data_type=inference_input_type,
+      return _mlir_quantize(calibrated, input_data_type=inference_input_type,
                             output_data_type=inference_output_type)
     else:
       return calibrate_quantize.calibrate_and_quantize(

--- a/tensorflow/lite/python/lite.py
+++ b/tensorflow/lite/python/lite.py
@@ -527,7 +527,9 @@ class TFLiteConverterBase(object):
         activations_type != _dtypes.int16):
       # TODO(b/175659372): remove the activations_type restriction and enable
       # it for all the activation types.
-      return _mlir_quantize(calibrated)
+      return _mlir_quantize(calibrated, disable_per_channel,
+                            input_data_type=inference_input_type,
+                            output_data_type=inference_output_type)
     else:
       return calibrate_quantize.calibrate_and_quantize(
           self.representative_dataset.input_gen, inference_input_type,
@@ -784,7 +786,12 @@ class TFLiteConverterBaseV2(TFLiteConverterBase):
         output_tensors=output_tensors,
         **converter_kwargs)
 
-    calibrate_and_quantize, flags = quant_mode.quantizer_flags()
+    if self.experimental_new_quantizer:
+      calibrate_and_quantize, flags = quant_mode.quantizer_flags(
+          self.inference_input_type, self.inference_output_type)
+    else:
+      calibrate_and_quantize, flags = quant_mode.quantizer_flags()
+
     if calibrate_and_quantize:
       result = self._calibrate_quantize_model(result, **flags)
 
@@ -905,7 +912,12 @@ class TFLiteSavedModelConverterV2(TFLiteConverterBaseV2):
     converter_kwargs.update(quant_mode.converter_flags())
 
     result = _convert_saved_model(**converter_kwargs)
-    calibrate_and_quantize, flags = quant_mode.quantizer_flags()
+    if self.experimental_new_quantizer:
+      calibrate_and_quantize, flags = quant_mode.quantizer_flags(
+          self.inference_input_type, self.inference_output_type)
+    else:
+      calibrate_and_quantize, flags = quant_mode.quantizer_flags()
+
     if calibrate_and_quantize:
       result = self._calibrate_quantize_model(result, **flags)
 

--- a/tensorflow/lite/python/wrap_toco.py
+++ b/tensorflow/lite/python/wrap_toco.py
@@ -45,12 +45,16 @@ def wrapped_get_potentially_supported_ops():
 
 def wrapped_experimental_mlir_quantize(input_data_str, disable_per_channel,
                                        fully_quantize, inference_type,
+                                       input_data_type,
+                                       output_data_type,
                                        enable_numeric_verify):
   """Wraps experimental mlir quantize model."""
   return _pywrap_toco_api.ExperimentalMlirQuantizeModel(input_data_str,
                                                         disable_per_channel,
                                                         fully_quantize,
                                                         inference_type,
+                                                        input_data_type,
+                                                        output_data_type,
                                                         enable_numeric_verify)
 
 

--- a/tensorflow/lite/toco/python/toco_python_api.h
+++ b/tensorflow/lite/toco/python/toco_python_api.h
@@ -45,6 +45,7 @@ PyObject* TocoGetPotentiallySupportedOps();
 // model.
 PyObject* MlirQuantizeModel(PyObject* data, bool disable_per_channel,
                             bool fully_quantize, int inference_type,
+                            int input_data_type, int output_data_type,
                             bool enable_numeric_verify = false);
 
 // Sparsifies model to encode sparse tensors with proper format. Throws error if

--- a/tensorflow/python/lite/toco_python_api_wrapper.cc
+++ b/tensorflow/python/lite/toco_python_api_wrapper.cc
@@ -57,13 +57,16 @@ PYBIND11_MODULE(_pywrap_toco_api, m) {
   m.def(
       "ExperimentalMlirQuantizeModel",
       [](py::object input_contents_txt_raw, bool disable_per_channel,
-         bool fully_quantize, int inference_type, bool enable_numeric_verify) {
+         bool fully_quantize, int inference_type, int input_data_type,
+         int output_data_type, bool enable_numeric_verify) {
         return tensorflow::PyoOrThrow(toco::MlirQuantizeModel(
             input_contents_txt_raw.ptr(), disable_per_channel, fully_quantize,
-            inference_type, enable_numeric_verify));
+            inference_type, input_data_type, output_data_type,
+            enable_numeric_verify));
       },
       py::arg("input_contents_txt_raw"), py::arg("disable_per_channel") = false,
       py::arg("fully_quantize") = true, py::arg("inference_type") = 9,
+      py::arg("input_data_type") = 0, py::arg("output_data_type") = 0,
       py::arg("enable_numeric_verify") = false,
       R"pbdoc(
       Returns a quantized model.


### PR DESCRIPTION
This patch added an MLIR pass to modify the input and output types of the
models. This is based on the assumption that the input models have leading
tfl.quantize ops and tailing tfl.dequantize ops. The modification uses the
following rules:

- Requested float input type: no input change
- Requested int8 input type: remove the tfl.quantize op
- Requested uint8 input type: change the input storage type of the tfl.quantize op from int8 to uint8
- Requested float output type: no input change
- Requested int8 output type: remove the tfl.dequantize op
- Requested uint8 output type: replace the tfl.dequantize op by an tfl.quantize op and change the output storage type uint8

PiperOrigin-RevId: 368220771
Change-Id: I513da34045f11402f8e09af6004e8b7df2b923b1