### PR TITLE
make `bazel build //tensorflow/tools/pip_package:build_pip_package` work on Jetson devices

### DIFF
--- a/tensorflow/core/platform/default/build_config.bzl
+++ b/tensorflow/core/platform/default/build_config.bzl
@@ -798,9 +798,10 @@ def tf_google_mobile_srcs_only_runtime():
     return []
 
 def if_llvm_aarch64_available(then, otherwise = []):
-    # TODO(b/...): The TF XLA build fails when adding a dependency on
-    # @llvm/llvm-project/llvm:aarch64_target.
-    return otherwise
+    return select({
+        "//tensorflow:linux_aarch64": then,
+        "//conditions:default": otherwise,
+    })
 
 def if_llvm_system_z_available(then, otherwise = []):
     return select({

--- a/tensorflow/core/platform/default/cord.h
+++ b/tensorflow/core/platform/default/cord.h
@@ -16,7 +16,12 @@ limitations under the License.
 #ifndef TENSORFLOW_CORE_PLATFORM_DEFAULT_CORD_H_
 #define TENSORFLOW_CORE_PLATFORM_DEFAULT_CORD_H_
 
+// It seems CORD doesn't work well with CUDA <= 10.2
+#if !defined(__CUDACC__) || ((defined(__CUDACC__) && CUDA_VERSOIN > 10020))
+
 #include "absl/strings/cord.h"
 #define TF_CORD_SUPPORT 1
+
+#endif  // __CUDACC__
 
 #endif  // TENSORFLOW_CORE_PLATFORM_DEFAULT_CORD_H_


### PR DESCRIPTION
Fixed two problems stopping `bazel build //tensorflow/tools/pip_package:build_pip_package` on Jetson devices
1. CUDA 10.2 doesn't work well with absl CORD
2. mlir needs AArch64 codegen

Fixes #48468