### PR TITLE
micro: Update person detection readme

### DIFF
--- a/tensorflow/lite/micro/examples/person_detection/README.md
+++ b/tensorflow/lite/micro/examples/person_detection/README.md
@@ -598,7 +598,7 @@ This will take a few minutes, and downloads frameworks the code uses like
 finished, run:
 
 ```
-make -f tensorflow/lite/micro/tools/make/Makefile test_person_detection_test
+make -f tensorflow/lite/micro/tools/make/Makefile test_person_detection_test_int8
 ```
 
 You should see a series of files get compiled, followed by some logging output


### PR DESCRIPTION
The README points to a Makefile target that no longer exists
(test_person_detection_test).

This commit changes the README file to instruct the developer to use the
test_person_detection_test_int8 target instead.