### PR TITLE
micro: Show memory plan if preprocessor define set

### DIFF
--- a/tensorflow/lite/micro/micro_allocator.cc
+++ b/tensorflow/lite/micro/micro_allocator.cc
@@ -1080,6 +1080,9 @@ TfLiteStatus MicroAllocator::CommitStaticMemoryPlan(
   TF_LITE_ENSURE_STATUS(CommitPlan(error_reporter_, &planner,
                                    memory_allocator_->GetHeadBuffer(),
                                    allocation_info, allocation_info_count));
+#ifdef TF_LITE_SHOW_MEMORY_USE
+  planner.PrintMemoryPlan(error_reporter_);
+#endif
   head_usage = planner.GetMaximumMemorySize();
 
   // The head is used to store memory plans for one model at a time during the


### PR DESCRIPTION
Changes MicroAllocator to call GreedyMemoryPlanner::PrintMemoryPlan when
the TF_LITE_SHOW_MEMORY_USE preprocessor symbol is defined. The
motivation is to make it possible for developers to show the memory plan
without needing to modify TfLM source code.

TF_LITE_SHOW_MEMORY_USE is a new preprocessor symbol. It is not used
elsewhere.