### PR TITLE
Add elastic training for workers in PSv2

### DIFF
--- a/tensorflow/python/distribute/coordinator/cluster_coordinator.py
+++ b/tensorflow/python/distribute/coordinator/cluster_coordinator.py
@@ -629,7 +629,9 @@ class WorkerPreemptionHandler(object):
           # Consider adding backoff retry logic if we see the error logged
           # too frequently.
           logging.error("Cluster update failed with error: %s. Retrying...", e)
-
+          # Add sleep to prevent consistent cluster recovering in fault tolerance.
+          import time
+          time.sleep(5)
 
 class Worker(object):
   """A worker in a cluster.
@@ -652,13 +654,29 @@ class Worker(object):
     self._should_worker_thread_run = True
 
     # Worker threads need to start after `Worker`'s initialization.
-    threading.Thread(target=self._process_queue,
+    self._process_thread = threading.Thread(target=self._process_queue,
                      name="WorkerClosureProcessingLoop-%d" % self.worker_index,
-                     daemon=True).start()
+                     daemon=True)
+    self._process_thread.start()
 
   def stop(self):
     """Ensure the worker thread is closed."""
     self._should_worker_thread_run = False
+    self._set_resources_aborted()
+
+  def restart(self):
+    """Restart the stopped worker."""
+    if self._should_worker_thread_run:
+      return
+    # join the thread here the prevent deadlock in _closure_queue.get()
+    if self._process_thread is not None:
+      self._process_thread.join()
+    self._should_worker_thread_run = True
+    # Worker threads need to start after `Worker`'s initialization.
+    self._process_thread = threading.Thread(target=self._process_queue,
+                     name="WorkerClosureProcessingLoop-%d" % self.worker_index,
+                     daemon=True)
+    self._process_thread.start()
 
   def _set_resources_aborted(self):
     # TODO(yuefengz): maybe we can query whether a tensor is valid or not
@@ -718,6 +736,7 @@ class Worker(object):
     while self._should_worker_thread_run:
       closure = self._cluster.closure_queue.get()
       if not self._should_worker_thread_run or closure is None:
+        self._cluster._closure_queue.put_back(closure)
         return
       self._process_closure(closure)
       # To properly stop the worker and preemption threads, it is important that

--- a/tensorflow/python/distribute/coordinator/cluster_coordinator.py
+++ b/tensorflow/python/distribute/coordinator/cluster_coordinator.py
@@ -977,7 +977,7 @@ class ClusterCoordinator(object):
       self._strategy = strategy
       self.strategy.extended._used_with_coordinator = True
       self._cluster = Cluster(strategy)
-      self._cluster_spec = self._strategy._cluster_coordinator.cluster_spec()
+      self._cluster_spec = self._strategy._cluster_resolver.cluster_spec()
       self._stopped_workers = {}
       self._has_initialized = True
 
@@ -1280,7 +1280,8 @@ class ClusterCoordinator(object):
         if task_address == address:
           if job_name == "worker":
             logging.warning(
-                "Worker address %r already active in current cluster." % address)
+                "Worker address %r already active in current cluster." %
+                address)
             return
           else:
             raise ValueError(

--- a/tensorflow/python/distribute/coordinator/elastic_test.py
+++ b/tensorflow/python/distribute/coordinator/elastic_test.py
@@ -1,0 +1,227 @@
+# Lint as: python3
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Elastic test for parameter server training in TF2."""
+import threading
+import unittest
+import time
+import sys
+import gc
+
+from tensorflow.python.distribute.coordinator import cluster_coordinator
+from tensorflow.python.eager import context
+from tensorflow.python.distribute import test_util
+from tensorflow.python.distribute.cluster_resolver.cluster_resolver import SimpleClusterResolver
+from tensorflow.python.compat import v2_compat
+from tensorflow.python.distribute import multi_process_runner, multi_worker_test_base, parameter_server_strategy_v2
+from tensorflow.python.distribute.coordinator.fault_tolerance_test import Model
+from tensorflow.python.training import server_lib
+
+
+_RPC_ERROR_FROM_WORKER = "GRPC error information from remote target /job:worker"
+_RPC_ERROR_FROM_PS = "GRPC error information from remote target /job:ps"
+_WORKER_PREEMPTION_THREAD_NAME = "WorkerPreemptionHandler"
+_WORKER_THREAD_PREFIX = "WorkerClosureProcessingLoop"
+
+
+class BaseElasticTest(object):  # pylint: disable=missing-docstring
+
+  def setUp(self, num_workers, num_ps, thread_coordinator=None):
+    super(BaseElasticTest, self).setUp()
+
+    self._cluster = multi_worker_test_base.create_multi_process_cluster(
+        num_workers=num_workers, num_ps=num_ps, rpc_layer="grpc")
+    self._cluster_def = self._cluster.cluster_resolver.cluster_spec().as_dict()
+    self._cluster_def["chief"] = [
+      "localhost:%d" % multi_worker_test_base.pick_unused_port()
+    ]
+    self.cluster_resolver = SimpleClusterResolver(
+      server_lib.ClusterSpec(self._cluster_def), rpc_layer="grpc")
+
+    # The strategy's constructor would connect to the cluster.
+    self.strategy = parameter_server_strategy_v2.ParameterServerStrategyV2(
+      self.cluster_resolver)
+    self.cluster_coord = cluster_coordinator.ClusterCoordinator(self.strategy)
+
+    self.thread_coord = thread_coordinator.Coordinator(
+      clean_stop_exception_types=[])
+    self.num_workers = num_workers
+    self.num_ps = num_ps
+    self.max_idx_worker = num_workers - 1
+    self.max_idx_ps = num_ps - 1
+
+  def tearDown(self):
+    super(BaseElasticTest, self).tearDown()
+    self._cluster.stop()
+    self._cluster = None
+
+  def _restart(self, downtime_secs, task_type, killed_idx, restart_idx):
+    """Kills `job` (index: 0) and restarts it after `downtime_secs` with
+       a new name if specified.
+
+    Args:
+      downtime_secs: secs before restarting the job.
+      task_type: a string specifying the type of job to restart.
+      killed_idx: a string specifying the index of the old job.
+      restart_idx: a string specifying the index of the new job.
+    """
+    self._remove_participant(downtime_secs, task_type=task_type,
+                             killed_idx=killed_idx)
+    self._add_participant(task_type=task_type, restart_idx=restart_idx)
+
+  def _restart_in_thread(self,
+                         downtime_secs, task_type, killed_idx, restart_idx):
+    def _restart_fn():
+      with self.thread_coord.stop_on_exception():
+        self._restart(downtime_secs, task_type, killed_idx, restart_idx)
+
+    restart_thread = threading.Thread(target=_restart_fn)
+    restart_thread.start()
+    return restart_thread
+
+  def _remove_participant(self, downtime_secs, task_type, killed_idx):
+    self._cluster.kill_task(task_type=task_type, task_id=killed_idx)
+    time.sleep(downtime_secs)
+    self.cluster_resolver._cluster_spec.remove_task(task_type, killed_idx)
+
+  def _add_participant(self, task_type, restart_idx):
+    self.assertFalse(
+      context.check_alive(f"/job:{task_type}/replica:0/task:{restart_idx}"))
+    self._cluster.start_task(task_type=task_type, task_id=restart_idx)
+    while not context.check_alive(
+            f"/job:{task_type}/replica:0/task:{restart_idx}"):
+      time.sleep(1)
+    self.cluster_resolver._cluster_spec.add_task(task_type, restart_idx)
+    if task_type.lower() == "worker":
+      self.max_idx_worker = max(self.max_idx_worker, restart_idx)
+    elif task_type.lower() == "ps" or task_type.lower() == "parameterserver":
+      self.max_idx_ps = max(self.max_idx_ps, restart_idx)
+
+  def _ensure_threads_closed(self):
+    """Ensures worker and preemption threads are closed."""
+    # Worker and preemption threads should exist before releasing
+    # ClusterCoordinator.
+    running_threads = test_util.get_running_threads()
+    self.assertTrue(
+      test_util.has_thread(_WORKER_THREAD_PREFIX, running_threads))
+    self.assertIn(_WORKER_PREEMPTION_THREAD_NAME, running_threads)
+
+    # Print object graph if ClusterCoordinator may leak.
+    if sys.getrefcount(self.cluster_coord) > 2:
+      try:
+        test_util.show_backref(self.cluster_coord)
+      except:  # pylint: disable=bare-except
+        pass
+
+    # Wait for threads to close.
+    self.cluster_coord = None
+    self.strategy = None
+    gc.collect()
+    time.sleep(1)
+
+    # Verify thread names.
+    running_threads = test_util.get_running_threads()
+    self.assertNotIn(_WORKER_PREEMPTION_THREAD_NAME, running_threads)
+    self.assertFalse(
+      test_util.has_thread(_WORKER_THREAD_PREFIX, running_threads),
+      "Worker thread is not stopped properly.")
+
+  def _create_model_and_run_indefinitely(self):
+    model = Model(self.cluster_coord)
+    model.do_infinite_step.assign(True)
+    model.schedule_training_functions(10)
+    # Model does infinite training step, so at this moment, we expect to have
+    # `self.num_workers` infinite closures inflight, and `10-self.num_workers`
+    # closures in the queue.
+    while (self.cluster_coord._cluster.closure_queue._inflight_closure_count <
+           self.num_workers):
+      time.sleep(0.1)
+    return model
+  
+  def testClusterCoordinatorDestroyed(self):
+    self._ensure_threads_closed()
+
+  def testWorkerAdditionBetweenFunctions(self):
+    model = Model(self.cluster_coord)
+    model.schedule_training_functions(2)
+    model.join_training_functions()
+    self.assertEqual(model.iterations.numpy(), 2)
+
+    self._add_participant("worker", self.max_idx_worker + 1)
+    # TODO(zw0610): update coordinator with the new worker
+
+    model.schedule_training_functions(2)
+    model.join_training_functions()
+    self.assertEqual(model.iterations.numpy(), 4)
+
+  def testWorkerAdditionMidstFunction(self):
+    model = Model(self.cluster_coord)
+    model.do_infinite_step.assign(True)
+
+    model.schedule_training_functions(4)
+    # Model does infinite training step, so at this moment, we expect to have
+    # `self.num_workers` infinite closures inflight, and `4-self.num_workers`
+    # closures in the queue.
+    while (self.cluster_coord._cluster.closure_queue._inflight_closure_count <
+           self.num_workers):
+      time.sleep(0.1)
+    self.assertFalse(self.cluster_coord.done())
+    self._add_participant("worker", self.max_idx_worker + 1)
+    # TODO(zw0610): update coordinator with the new worker
+    model.join_training_functions()
+    self.assertGreaterEqual(model.iterations.numpy(), 4)
+
+  def testWorkerRestoreWithSameName(self):
+    model = Model(self.cluster_coord)
+    model.schedule_training_functions(2)
+    model.join_training_functions()
+    self.assertEqual(model.iterations.numpy(), 2)
+
+    self._restart(
+      downtime_secs=2, task_type="worker", killed_idx=0, restart_idx=0)
+
+    model.schedule_training_functions(2)
+    model.join_training_functions()
+    self.assertEqual(model.iterations.numpy(), 4)
+
+  def testWorkerRestoreWithAnotherName(self):
+    model = Model(self.cluster_coord)
+    model.schedule_training_functions(2)
+    model.join_training_functions()
+    self.assertEqual(model.iterations.numpy(), 2)
+
+    self._restart(downtime_secs=2,
+                  task_type="worker",
+                  killed_idx=0,
+                  restart_idx=self.max_idx_worker + 1)
+
+    model.schedule_training_functions(2)
+    model.join_training_functions()
+    self.assertEqual(model.iterations.numpy(), 4)
+
+
+class MultiWorkerElasticTest(BaseElasticTest, unittest.TestCase):
+  """Multi worker elastic tests.
+
+  This covers the ordinary cases where multiple workers and PS are used.
+  """
+
+  def setUp(self):
+    super(MultiWorkerElasticTest, self).setUp(2, 2)
+
+
+if __name__ == '__main__':
+  v2_compat.enable_v2_behavior()
+  multi_process_runner.test_main()

--- a/tensorflow/python/distribute/coordinator/values.py
+++ b/tensorflow/python/distribute/coordinator/values.py
@@ -275,7 +275,8 @@ class PerWorkerValues(composite_tensor.CompositeTensor):
       if isinstance(v, RemoteValue):
         return v
       else:
-        raise AssertionError("`PerWorkerValues` should only take `RemoteValue`s.")
+        raise AssertionError(
+          "`PerWorkerValues` should only take `RemoteValue`s.")
 
     if isinstance(values, list):
       self._values = {i: filter_by_type(values[i]) for i in range(len(values))}

--- a/tensorflow/python/training/server_lib.py
+++ b/tensorflow/python/training/server_lib.py
@@ -495,6 +495,47 @@ class ClusterSpec(object):
                           task_address)
         job_def.tasks[i] = task_address
 
+  def add_task(self, job_name, task_index, task_address):
+    """Add a task to the cluster.
+
+    Args:
+      job_name: The string name of a job, that may not be in the cluster.
+      task_index: A non-negative integer.
+      task_address: The address of added task.
+
+    Raises:
+      ValueError: If there is already a task with index `task_index`
+      in job `job_name`.
+    """
+    if job_name not in self._cluster_spec:
+      self._cluster_spec[job_name] = {}
+    elif task_index in self._cluster_spec[job_name]:
+      raise ValueError("There is Already a task with index %r in job %r" %
+                       (task_index, job_name))
+    self._cluster_spec[job_name][task_index] = task_address
+    self._make_cluster_def()
+
+  def remove_task(self, job_name, task_index):
+    """Remove a task from the cluster.
+
+    Args:
+      job_name: The string name of a job in this cluster.
+      task_index: A non-negative integer.
+
+    Raises:
+      ValueError: If there is no task with index `task_index`
+      in job `job_name`. Or if there is no job `job_name`.
+    """
+    if job_name in self._cluster_spec:
+      if task_index in self._cluster_spec[job_name]:
+        del self._cluster_spec[job_name][task_index]
+        self._make_cluster_def()
+      else:
+        raise ValueError("No task with index %r in job %r" %
+                  (task_index, job_name))
+    else:
+      raise ValueError("No such job in cluster: %r" % job_name)
+
 
 @tf_export("config.experimental.ClusterDeviceFilters")
 class ClusterDeviceFilters(object):


### PR DESCRIPTION
We are glad to have PSv2 last year. The single-client distributed training model is much simpler to use and more intuitive to reason able. We especially love the fault tolerance capability of the new strategy, as most industrial scenarios of the asynchronous training with parameter server usually involve dozens of workers and it's crucial to make sure the job keeps running.

In this PR, we will push the fault tolerance capability a step further -- we are adding elastic training for workers in PSv2, which means we could change the number of the workers during training. This would allow us to adjust the worker size by need and make better usage of the computational resources.

For this purpose, this PR mainly add 2 methods to the `CoordinatorCluster`:

- `remove_worker(self, address)`: Remove a `Worker` from `coordinator._cluster` by its address.
- `add_worker(self, address)`: Add a new `Worker` to `coordinator._cluster` by its address.

Notice that we are leaving the start and stop of the worker servers to the plaform, for instance, KubeFlow.

Before discussing about the underlying mechanism, we'd like to split all `Worker`s in the `coordinator._cluster` to 2 states: running and stopped.

- A running `Worker` is one that keeps on grabbing `Closure`s from `_closure_queue` to process. In other words, a `Worker` is running if its processing thread is running. A typical running `Worker` is one that is just initialized.

- A stopped `Worker` is one that stops getting `Closure`s and whose processing thread has stopped (or `join`ed).

We could call `worker.stop()` to turn a running `Worker` to stopped. And to make a stopped `Worker` back to running, we added a `restart` method to `Worker` class. In `restart` method, the `Worker` will recreate a processing thread if it is stopped.

```
                     ----- stop ----->
__init__ ->  running                   stopped
                     <--- restart ---- 
```

Let's come back to the mechanism of elastic training. In fact, we are just using the `connect_to_cluster` function. This great function could recreate the topology of the server in runtime. But because every `connect_to_cluster` will clean all server caches, which introduce overhead, instead of calling `connect_to_cluster` in every `remove_worker` and `add_worker`,

- in `remove_worker`, we will only stop the `Worker` (by running `worker.stop()`) and add the stopped worker to a dict in `coordinator` called `_stopped_workers`, which is a map from the address of the stopped worker to its index;

- in `add_worker`, if the address is in the `_stopped_workers`, restart the worker to running state (by running `worker.restart()`). Otherwise, we need to use `connect_to_cluster` to recreate the cluster. In this way, we will first remove the stopped workers from the cluster spec and clean the `_stopped_workers`. Then, add the new worker to the cluster spec and call `connect_to_cluster`. Finally, create a new `Worker` and append it to `coordinator._cluster`.

We add some auxiliary functions as well, for example, `add_task` and `remove_task` in `ClusterSpec`. And to support sparse worker_index (worker indices like [0, 2, 5]), we changed the `PerWorkerValues` to hold a dict.

As for the dataset part, we choose to create new iterator after `add_task`. This may be oversimplied. But the dataset part seems to be relatively isolated with the coordinator and can be updated in maybe another PR.

A typical use case of the new apis is:

```python
...
per_worker_train_ds = coordinator.create_per_worker_dataset(per_worker_dataset_fn)
per_worker_train_iter = iter(per_worker_train_ds)

for epoch in range(EPOCHS):
    ...
    if epoch == 0:
        coordinator.remove_worker("localhost:2101")

    if epoch == 1:
        coordinator.add_worker("localhost:2102")
        per_worker_train_ds = coordinator.create_per_worker_dataset(per_worker_dataset_fn)
        per_worker_train_iter = iter(per_worker_train_ds)

    for i in range(step):
        coordinator.schedule(step_fn,
                              args=(per_worker_train_iter,))
    coordinator.join()
    ...
```

Any discussion on the design or any details of this PR is welcomed :). It will be great if you can give us some suggestion on the limitation of this design.

As for the test, we have tested this PR in multiple elastic scenarios. And we hope to discuss with you on how to integrate test for the elastic training as well.

Thank you for your time on reviewing this PR!

Gently ping @yuefengz @rchao.

cc @zw0610
