### PR TITLE
Port RESIZE_BILINEAR kernel and tests from lite to micro

### DIFF
--- a/tensorflow/lite/micro/all_ops_resolver.cc
+++ b/tensorflow/lite/micro/all_ops_resolver.cc
@@ -72,6 +72,7 @@ AllOpsResolver::AllOpsResolver() {
   AddRelu();
   AddRelu6();
   AddReshape();
+  AddResizeBilinear();
   AddResizeNearestNeighbor();
   AddRound();
   AddRsqrt();

--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -293,6 +293,7 @@ cc_library(
         "quantize_common.cc",
         "reduce.cc",
         "reshape.cc",
+        "resize_bilinear.cc",
         "resize_nearest_neighbor.cc",
         "round.cc",
         "shape.cc",
@@ -969,6 +970,20 @@ cc_test(
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/kernels/internal:tensor",
         "//tensorflow/lite/micro:micro_utils",
+        "//tensorflow/lite/micro:test_helpers",
+        "//tensorflow/lite/micro/testing:micro_test",
+    ],
+)
+
+cc_test(
+    name = "resize_bilinear_test",
+    srcs = [
+        "resize_bilinear_test.cc",
+    ],
+    deps = [
+        ":kernel_runner",
+        "//tensorflow/lite/c:common",
+        "//tensorflow/lite/micro:op_resolvers",
         "//tensorflow/lite/micro:test_helpers",
         "//tensorflow/lite/micro/testing:micro_test",
     ],

--- a/tensorflow/lite/micro/kernels/micro_ops.h
+++ b/tensorflow/lite/micro/kernels/micro_ops.h
@@ -48,6 +48,7 @@ TfLiteRegistration Register_L2_POOL_2D();
 TfLiteRegistration Register_LEAKY_RELU();
 TfLiteRegistration Register_LOG_SOFTMAX();
 TfLiteRegistration Register_QUANTIZE();
+TfLiteRegistration Register_RESIZE_BILINEAR();
 TfLiteRegistration Register_SHAPE();
 TfLiteRegistration Register_SOFTMAX();
 TfLiteRegistration Register_SPACE_TO_BATCH_ND();

--- a/tensorflow/lite/micro/kernels/resize_bilinear.cc
+++ b/tensorflow/lite/micro/kernels/resize_bilinear.cc
@@ -70,23 +70,27 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       tflite::micro::GetEvalOutput(context, node, kOutputTensor);
 
   if (output->type == kTfLiteFloat32) {
-#define TF_LITE_RESIZE_BILINEAR(opname, datatype)                        \
-  tflite::ResizeBilinearParams op_params;                                \
-  op_params.align_corners = params->align_corners;                       \
-  op_params.half_pixel_centers = params->half_pixel_centers;             \
-  reference_ops::opname(op_params, tflite::micro::GetTensorShape(input), \
-                        tflite::micro::GetTensorData<datatype>(input),   \
-                        tflite::micro::GetTensorShape(size),             \
-                        tflite::micro::GetTensorData<int32_t>(size),     \
-                        tflite::micro::GetTensorShape(output),           \
-                        tflite::micro::GetTensorData<datatype>(output))
-
-    TF_LITE_RESIZE_BILINEAR(ResizeBilinear, float);
+    tflite::ResizeBilinearParams op_params;
+    op_params.align_corners = params->align_corners;
+    op_params.half_pixel_centers = params->half_pixel_centers;
+    reference_ops::ResizeBilinear(op_params,
+                                  tflite::micro::GetTensorShape(input),
+                                  tflite::micro::GetTensorData<float>(input),
+                                  tflite::micro::GetTensorShape(size),
+                                  tflite::micro::GetTensorData<int32_t>(size),
+                                  tflite::micro::GetTensorShape(output),
+                                  tflite::micro::GetTensorData<float>(output));
   } else if (output->type == kTfLiteInt8) {
-    TF_LITE_RESIZE_BILINEAR(ResizeBilinearInteger, int8_t);
-  } else if (output->type == kTfLiteInt16) {
-    TF_LITE_RESIZE_BILINEAR(ResizeBilinearInteger, int16_t);
-#undef TF_LITE_RESIZE_BILINEAR
+    tflite::ResizeBilinearParams op_params;
+    op_params.align_corners = params->align_corners;
+    op_params.half_pixel_centers = params->half_pixel_centers;
+    reference_ops::ResizeBilinearInteger(
+        op_params, tflite::micro::GetTensorShape(input),
+        tflite::micro::GetTensorData<int8_t>(input),
+        tflite::micro::GetTensorShape(size),
+        tflite::micro::GetTensorData<int32_t>(size),
+        tflite::micro::GetTensorShape(output),
+        tflite::micro::GetTensorData<int8_t>(output));
   } else {
     TF_LITE_KERNEL_LOG(context, "Output type is %d, requires float or int8.",
                        output->type);

--- a/tensorflow/lite/micro/kernels/resize_bilinear.cc
+++ b/tensorflow/lite/micro/kernels/resize_bilinear.cc
@@ -1,0 +1,112 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/lite/kernels/internal/reference/resize_bilinear.h"
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/kernels/op_macros.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_utils.h"
+
+namespace tflite {
+namespace {
+
+constexpr int kInputTensor = 0;
+constexpr int kSizeTensor = 1;
+constexpr int kOutputTensor = 0;
+
+TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+  TF_LITE_ENSURE_EQ(context, NumInputs(node), 2);
+  TF_LITE_ENSURE_EQ(context, NumOutputs(node), 1);
+
+  const TfLiteTensor* input = GetInput(context, node, kInputTensor);
+  const TfLiteTensor* size = GetInput(context, node, kSizeTensor);
+  TfLiteTensor* output = GetOutput(context, node, kOutputTensor);
+
+  TF_LITE_ENSURE_EQ(context, NumDimensions(input), 4);
+  TF_LITE_ENSURE_EQ(context, NumDimensions(size), 1);
+
+  TF_LITE_ENSURE_EQ(context, size->type, kTfLiteInt32);
+  output->type = input->type;
+
+  TF_LITE_ENSURE_MSG(context, IsConstantTensor(size),
+                     "Non constant size tensor not supported");
+
+  // Ensure params are valid.
+  auto* params =
+      reinterpret_cast<TfLiteResizeBilinearParams*>(node->builtin_data);
+  if (params->half_pixel_centers && params->align_corners) {
+    TF_LITE_KERNEL_LOG(
+        context, "If half_pixel_centers is True, align_corners must be False.");
+    return kTfLiteError;
+  }
+
+  return kTfLiteOk;
+}
+
+TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
+  auto* params =
+      reinterpret_cast<TfLiteResizeBilinearParams*>(node->builtin_data);
+
+  const TfLiteEvalTensor* input =
+      tflite::micro::GetEvalInput(context, node, kInputTensor);
+  const TfLiteEvalTensor* size =
+      tflite::micro::GetEvalInput(context, node, kSizeTensor);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kOutputTensor);
+
+  if (output->type == kTfLiteFloat32) {
+#define TF_LITE_RESIZE_BILINEAR(opname, datatype)                        \
+  tflite::ResizeBilinearParams op_params;                                \
+  op_params.align_corners = params->align_corners;                       \
+  op_params.half_pixel_centers = params->half_pixel_centers;             \
+  reference_ops::opname(op_params, tflite::micro::GetTensorShape(input), \
+                        tflite::micro::GetTensorData<datatype>(input),   \
+                        tflite::micro::GetTensorShape(size),             \
+                        tflite::micro::GetTensorData<int32_t>(size),     \
+                        tflite::micro::GetTensorShape(output),           \
+                        tflite::micro::GetTensorData<datatype>(output))
+
+    TF_LITE_RESIZE_BILINEAR(ResizeBilinear, float);
+  } else if (output->type == kTfLiteInt8) {
+    TF_LITE_RESIZE_BILINEAR(ResizeBilinearInteger, int8_t);
+  } else if (output->type == kTfLiteInt16) {
+    TF_LITE_RESIZE_BILINEAR(ResizeBilinearInteger, int16_t);
+#undef TF_LITE_RESIZE_BILINEAR
+  } else {
+    TF_LITE_KERNEL_LOG(context, "Output type is %d, requires float or int8.",
+                       output->type);
+    return kTfLiteError;
+  }
+
+  return kTfLiteOk;
+}
+
+}  // namespace
+
+TfLiteRegistration Register_RESIZE_BILINEAR() {
+  return {/*init=*/nullptr,
+          /*free=*/nullptr,
+          /*prepare=*/Prepare,
+          /*invoke=*/Eval,
+          /*profiling_string=*/nullptr,
+          /*builtin_code=*/0,
+          /*custom_name=*/nullptr,
+          /*version=*/0};
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/resize_bilinear_test.cc
+++ b/tensorflow/lite/micro/kernels/resize_bilinear_test.cc
@@ -1,0 +1,322 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/micro/all_ops_resolver.h"
+#include "tensorflow/lite/micro/kernels/kernel_runner.h"
+#include "tensorflow/lite/micro/test_helpers.h"
+#include "tensorflow/lite/micro/testing/micro_test.h"
+
+namespace tflite {
+namespace testing {
+namespace {
+
+TfLiteTensor TestCreateTensor(const float* data, TfLiteIntArray* dims) {
+  return CreateTensor(data, dims);
+}
+
+TfLiteTensor TestCreateTensor(const int8_t* data, TfLiteIntArray* dims) {
+  return CreateQuantizedTensor(data, dims, -128, 127);
+}
+
+template <typename T>
+TfLiteStatus ValidateGoldens(TfLiteTensor* tensors, int tensors_size,
+                             const T* expected_output_data, T* output_data,
+                             int output_length,
+                             TfLiteResizeBilinearParams* params,
+                             float tolerance = 1e-5) {
+  int inputs_array_data[] = {2, 0, 1};
+  TfLiteIntArray* inputs_array = IntArrayFromInts(inputs_array_data);
+  int outputs_array_data[] = {1, 2};
+  TfLiteIntArray* outputs_array = IntArrayFromInts(outputs_array_data);
+
+  const TfLiteRegistration registration = Register_RESIZE_BILINEAR();
+  micro::KernelRunner runner(registration, tensors, tensors_size, inputs_array,
+                             outputs_array, params);
+
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, runner.InitAndPrepare());
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, runner.Invoke());
+
+  for (int i = 0; i < output_length; ++i) {
+    TF_LITE_MICRO_EXPECT_NEAR(expected_output_data[i], output_data[i],
+                              tolerance);
+  }
+
+  return kTfLiteOk;
+}
+
+template <typename T>
+void TestResizeBilinear(const int* input_dims_data, const T* input_data,
+                        const int32_t* expected_size_data,
+                        const T* expected_output_data,
+                        const int* output_dims_data, T* output_data,
+                        TfLiteResizeBilinearParams* params,
+                        float tolerance = 1e-5) {
+  int expected_size_dims_data[] = {1, 2};
+  TfLiteIntArray* input_dims = IntArrayFromInts(input_dims_data);
+  TfLiteIntArray* expected_size_dims =
+      IntArrayFromInts(expected_size_dims_data);
+  TfLiteIntArray* output_dims = IntArrayFromInts(output_dims_data);
+
+  const int output_dims_count = ElementCount(*output_dims);
+
+  // Hack to pass ConstantTensor check in prepare
+  TfLiteTensor t = CreateTensor(expected_size_data, expected_size_dims);
+  t.allocation_type = kTfLiteMmapRo;
+
+  constexpr int tensors_size = 3;
+  TfLiteTensor tensors[tensors_size]{
+      TestCreateTensor(input_data, input_dims),
+      t,
+      TestCreateTensor(output_data, output_dims),
+  };
+
+  TF_LITE_MICRO_EXPECT_EQ(
+      kTfLiteOk,
+      ValidateGoldens(tensors, tensors_size, expected_output_data, output_data,
+                      output_dims_count, params, tolerance));
+}
+
+}  // namespace
+}  // namespace testing
+}  // namespace tflite
+
+TF_LITE_MICRO_TESTS_BEGIN
+
+TF_LITE_MICRO_TEST(HorizontalResize) {
+  const int input_dims[] = {4, 1, 1, 2, 1};
+  const float input_data[] = {3, 6};
+  const int32_t expected_size_data[] = {1, 3};
+  const float expected_output_data[] = {3, 5, 6};
+  const int output_dims[] = {4, 1, 1, 3, 1};
+  float output_data[3];
+
+  TfLiteResizeBilinearParams params = {
+      false, /*align_corners*/
+      false  /*half pixel centers*/
+  };
+
+  tflite::testing::TestResizeBilinear(input_dims, input_data,
+                                      expected_size_data, expected_output_data,
+                                      output_dims, output_data, &params);
+}
+TF_LITE_MICRO_TEST(HorizontalResizeInt8) {
+  const int input_dims[] = {4, 1, 1, 2, 1};
+  const int8_t input_data[] = {3, 6};
+  const int32_t expected_size_data[] = {1, 3};
+  const int8_t expected_output_data[] = {3, 5, 6};
+  const int output_dims[] = {4, 1, 1, 3, 1};
+  int8_t output_data[3];
+
+  TfLiteResizeBilinearParams params = {
+      false, /*align_corners*/
+      false  /*half pixel centers*/
+  };
+
+  tflite::testing::TestResizeBilinear<int8_t>(
+      input_dims, input_data, expected_size_data, expected_output_data,
+      output_dims, output_data, &params);
+}
+TF_LITE_MICRO_TEST(VerticalResize) {
+  const int input_dims[] = {4, 1, 2, 1, 1};
+  const float input_data[] = {3, 9};
+  const int32_t expected_size_data[] = {3, 1};
+  const float expected_output_data[] = {3, 7, 9};
+  const int output_dims[] = {4, 1, 3, 1, 1};
+  float output_data[3];
+
+  TfLiteResizeBilinearParams params = {
+      false, /*align_corners*/
+      false  /*half pixel centers*/
+  };
+
+  tflite::testing::TestResizeBilinear(input_dims, input_data,
+                                      expected_size_data, expected_output_data,
+                                      output_dims, output_data, &params);
+}
+TF_LITE_MICRO_TEST(VerticalResizeInt8) {
+  const int input_dims[] = {4, 1, 2, 1, 1};
+  const int8_t input_data[] = {3, 9};
+  const int32_t expected_size_data[] = {3, 1};
+  const int8_t expected_output_data[] = {3, 7, 9};
+  const int output_dims[] = {4, 1, 3, 1, 1};
+  int8_t output_data[3];
+
+  TfLiteResizeBilinearParams params = {
+      false, /*align_corners*/
+      false  /*half pixel centers*/
+  };
+
+  tflite::testing::TestResizeBilinear<int8_t>(
+      input_dims, input_data, expected_size_data, expected_output_data,
+      output_dims, output_data, &params);
+}
+TF_LITE_MICRO_TEST(TwoDimensionalResize) {
+  const int input_dims[] = {4, 1, 2, 2, 1};
+  const float input_data[] = {
+      3, 6,   //
+      9, 12,  //
+  };
+  const int32_t expected_size_data[] = {3, 3};
+  const float expected_output_data[] = {
+      3, 5,  6,   //
+      7, 9,  10,  //
+      9, 11, 12   //
+  };
+
+  const int output_dims[] = {4, 1, 3, 3, 1};
+  float output_data[9];
+
+  TfLiteResizeBilinearParams params = {
+      false, /*align_corners*/
+      false  /*half pixel centers*/
+  };
+
+  tflite::testing::TestResizeBilinear(input_dims, input_data,
+                                      expected_size_data, expected_output_data,
+                                      output_dims, output_data, &params);
+}
+TF_LITE_MICRO_TEST(TwoDimensionalResizeInt8) {
+  const int input_dims[] = {4, 1, 2, 2, 1};
+  const int8_t input_data[] = {
+      3, 6,   //
+      9, 12,  //
+  };
+  const int32_t expected_size_data[] = {3, 3};
+  const int8_t expected_output_data[] = {
+      3, 5,  6,   //
+      7, 9,  10,  //
+      9, 11, 12,  //
+  };
+  const int output_dims[] = {4, 1, 3, 3, 1};
+  int8_t output_data[9];
+
+  TfLiteResizeBilinearParams params = {
+      false, /*align_corners*/
+      false  /*half pixel centers*/
+  };
+
+  tflite::testing::TestResizeBilinear<int8_t>(
+      input_dims, input_data, expected_size_data, expected_output_data,
+      output_dims, output_data, &params);
+}
+TF_LITE_MICRO_TEST(TwoDimensionalResizeWithTwoBatches) {
+  const int input_dims[] = {4, 2, 2, 2, 1};
+  const float input_data[] = {
+      3,  6,   //
+      9,  12,  //
+      4,  10,  //
+      10, 16   //
+  };
+  const int32_t expected_size_data[] = {3, 3};
+  const float expected_output_data[] = {
+      3,  5,  6,   //
+      7,  9,  10,  //
+      9,  11, 12,  //
+      4,  8,  10,  //
+      8,  12, 14,  //
+      10, 14, 16,  //
+  };
+  const int output_dims[] = {4, 2, 3, 3, 1};
+  float output_data[18];
+
+  TfLiteResizeBilinearParams params = {
+      false, /*align_corners*/
+      false  /*half pixel centers*/
+  };
+
+  tflite::testing::TestResizeBilinear(input_dims, input_data,
+                                      expected_size_data, expected_output_data,
+                                      output_dims, output_data, &params);
+}
+TF_LITE_MICRO_TEST(TwoDimensionalResizeWithTwoBatchesInt8) {
+  const int input_dims[] = {4, 2, 2, 2, 1};
+  const int8_t input_data[] = {
+      3,  6,   //
+      9,  12,  //
+      4,  10,  //
+      12, 16   //
+  };
+  const int32_t expected_size_data[] = {3, 3};
+  const int8_t expected_output_data[] = {
+      3,  5,  6,   //
+      7,  9,  10,  //
+      9,  11, 12,  //
+      4,  8,  10,  //
+      9,  12, 13,  //
+      12, 14, 16,  //
+  };
+  const int output_dims[] = {4, 2, 3, 3, 1};
+  int8_t output_data[18];
+
+  TfLiteResizeBilinearParams params = {
+      false, /*align_corners*/
+      false  /*half pixel centers*/
+  };
+
+  tflite::testing::TestResizeBilinear<int8_t>(
+      input_dims, input_data, expected_size_data, expected_output_data,
+      output_dims, output_data, &params, /*tolerance=*/1);
+}
+TF_LITE_MICRO_TEST(ThreeDimensionalResize) {
+  const int input_dims[] = {4, 1, 2, 2, 2};
+  const float input_data[] = {
+      3, 4,  6,  10,  //
+      9, 10, 12, 16,  //
+  };
+  const int32_t expected_size_data[] = {3, 3};
+  const float expected_output_data[] = {
+      3, 4,  5,  8,  6,  10,  //
+      7, 8,  9,  12, 10, 14,  //
+      9, 10, 11, 14, 12, 16,  //
+  };
+  const int output_dims[] = {4, 1, 3, 3, 2};
+  float output_data[18];
+
+  TfLiteResizeBilinearParams params = {
+      false, /*align_corners*/
+      false  /*half pixel centers*/
+  };
+
+  tflite::testing::TestResizeBilinear(input_dims, input_data,
+                                      expected_size_data, expected_output_data,
+                                      output_dims, output_data, &params);
+}
+TF_LITE_MICRO_TEST(ThreeDimensionalResizeInt8) {
+  const int input_dims[] = {4, 1, 2, 2, 2};
+  const int8_t input_data[] = {
+      3,  4,  6,  10,  //
+      10, 12, 14, 16,  //
+  };
+  const int32_t expected_size_data[] = {3, 3};
+  const int8_t expected_output_data[] = {
+      3,  4,  5,  8,  6,  10,  //
+      7,  9,  10, 12, 11, 13,  //
+      10, 12, 12, 14, 14, 16,  //
+  };
+  const int output_dims[] = {4, 1, 3, 3, 2};
+  int8_t output_data[18];
+
+  TfLiteResizeBilinearParams params = {
+      false, /*align_corners*/
+      false  /*half pixel centers*/
+  };
+
+  tflite::testing::TestResizeBilinear<int8_t>(
+      input_dims, input_data, expected_size_data, expected_output_data,
+      output_dims, output_data, &params, /*tolerance=*/1);
+}
+
+TF_LITE_MICRO_TESTS_END

--- a/tensorflow/lite/micro/kernels/resize_bilinear_test.cc
+++ b/tensorflow/lite/micro/kernels/resize_bilinear_test.cc
@@ -112,6 +112,7 @@ TF_LITE_MICRO_TEST(HorizontalResize) {
                                       expected_size_data, expected_output_data,
                                       output_dims, output_data, &params);
 }
+
 TF_LITE_MICRO_TEST(HorizontalResizeInt8) {
   const int input_dims[] = {4, 1, 1, 2, 1};
   const int8_t input_data[] = {3, 6};
@@ -129,6 +130,7 @@ TF_LITE_MICRO_TEST(HorizontalResizeInt8) {
       input_dims, input_data, expected_size_data, expected_output_data,
       output_dims, output_data, &params);
 }
+
 TF_LITE_MICRO_TEST(VerticalResize) {
   const int input_dims[] = {4, 1, 2, 1, 1};
   const float input_data[] = {3, 9};
@@ -146,6 +148,7 @@ TF_LITE_MICRO_TEST(VerticalResize) {
                                       expected_size_data, expected_output_data,
                                       output_dims, output_data, &params);
 }
+
 TF_LITE_MICRO_TEST(VerticalResizeInt8) {
   const int input_dims[] = {4, 1, 2, 1, 1};
   const int8_t input_data[] = {3, 9};
@@ -163,6 +166,7 @@ TF_LITE_MICRO_TEST(VerticalResizeInt8) {
       input_dims, input_data, expected_size_data, expected_output_data,
       output_dims, output_data, &params);
 }
+
 TF_LITE_MICRO_TEST(TwoDimensionalResize) {
   const int input_dims[] = {4, 1, 2, 2, 1};
   const float input_data[] = {
@@ -188,6 +192,7 @@ TF_LITE_MICRO_TEST(TwoDimensionalResize) {
                                       expected_size_data, expected_output_data,
                                       output_dims, output_data, &params);
 }
+
 TF_LITE_MICRO_TEST(TwoDimensionalResizeInt8) {
   const int input_dims[] = {4, 1, 2, 2, 1};
   const int8_t input_data[] = {
@@ -212,6 +217,7 @@ TF_LITE_MICRO_TEST(TwoDimensionalResizeInt8) {
       input_dims, input_data, expected_size_data, expected_output_data,
       output_dims, output_data, &params);
 }
+
 TF_LITE_MICRO_TEST(TwoDimensionalResizeWithTwoBatches) {
   const int input_dims[] = {4, 2, 2, 2, 1};
   const float input_data[] = {
@@ -241,6 +247,7 @@ TF_LITE_MICRO_TEST(TwoDimensionalResizeWithTwoBatches) {
                                       expected_size_data, expected_output_data,
                                       output_dims, output_data, &params);
 }
+
 TF_LITE_MICRO_TEST(TwoDimensionalResizeWithTwoBatchesInt8) {
   const int input_dims[] = {4, 2, 2, 2, 1};
   const int8_t input_data[] = {
@@ -270,6 +277,7 @@ TF_LITE_MICRO_TEST(TwoDimensionalResizeWithTwoBatchesInt8) {
       input_dims, input_data, expected_size_data, expected_output_data,
       output_dims, output_data, &params, /*tolerance=*/1);
 }
+
 TF_LITE_MICRO_TEST(ThreeDimensionalResize) {
   const int input_dims[] = {4, 1, 2, 2, 2};
   const float input_data[] = {
@@ -294,6 +302,7 @@ TF_LITE_MICRO_TEST(ThreeDimensionalResize) {
                                       expected_size_data, expected_output_data,
                                       output_dims, output_data, &params);
 }
+
 TF_LITE_MICRO_TEST(ThreeDimensionalResizeInt8) {
   const int input_dims[] = {4, 1, 2, 2, 2};
   const int8_t input_data[] = {

--- a/tensorflow/lite/micro/micro_mutable_op_resolver.h
+++ b/tensorflow/lite/micro/micro_mutable_op_resolver.h
@@ -401,6 +401,11 @@ class MicroMutableOpResolver : public MicroOpResolver {
                       tflite::ops::micro::Register_RESHAPE(), ParseReshape);
   }
 
+  TfLiteStatus AddResizeBilinear() {
+    return AddBuiltin(BuiltinOperator_RESIZE_BILINEAR,
+                      Register_RESIZE_BILINEAR(), ParseResizeBilinear);
+  }
+
   TfLiteStatus AddResizeNearestNeighbor() {
     return AddBuiltin(BuiltinOperator_RESIZE_NEAREST_NEIGHBOR,
                       tflite::ops::micro::Register_RESIZE_NEAREST_NEIGHBOR(),

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -306,6 +306,7 @@ tensorflow/lite/micro/kernels/quantization_util_test.cc \
 tensorflow/lite/micro/kernels/quantize_test.cc \
 tensorflow/lite/micro/kernels/reduce_test.cc \
 tensorflow/lite/micro/kernels/reshape_test.cc \
+tensorflow/lite/micro/kernels/resize_bilinear_test.cc \
 tensorflow/lite/micro/kernels/resize_nearest_neighbor_test.cc \
 tensorflow/lite/micro/kernels/round_test.cc \
 tensorflow/lite/micro/kernels/shape_test.cc \
@@ -373,6 +374,7 @@ tensorflow/lite/micro/kernels/quantize.cc \
 tensorflow/lite/micro/kernels/quantize_common.cc \
 tensorflow/lite/micro/kernels/reduce.cc \
 tensorflow/lite/micro/kernels/reshape.cc \
+tensorflow/lite/micro/kernels/resize_bilinear.cc \
 tensorflow/lite/micro/kernels/resize_nearest_neighbor.cc \
 tensorflow/lite/micro/kernels/round.cc \
 tensorflow/lite/micro/kernels/shape.cc \
@@ -471,6 +473,7 @@ tensorflow/lite/kernels/internal/reference/process_broadcast_shapes.h \
 tensorflow/lite/kernels/internal/reference/quantize.h \
 tensorflow/lite/kernels/internal/reference/reduce.h \
 tensorflow/lite/kernels/internal/reference/requantize.h \
+tensorflow/lite/kernels/internal/reference/resize_bilinear.h \
 tensorflow/lite/kernels/internal/reference/resize_nearest_neighbor.h \
 tensorflow/lite/kernels/internal/reference/round.h \
 tensorflow/lite/kernels/internal/reference/softmax.h \


### PR DESCRIPTION
This is PR three out of three in delivering #48537. This PR ports the resize_bilinear kernel and the corresponding tests to micro, as well as adds resize bilinear to the micro build. @advaitjain 