### PR TITLE
Add -mlongcalls to the Xtensa compiler flags.

### DIFF
--- a/tensorflow/lite/micro/tools/make/targets/xtensa_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/xtensa_makefile.inc
@@ -39,7 +39,8 @@ PLATFORM_FLAGS = \
   -mcoproc \
   -DMAX_RFFT_PWR=9 \
   -DMIN_RFFT_PWR=MAX_RFFT_PWR \
-  $(TARGET_ARCH_DEFINES)
+  $(TARGET_ARCH_DEFINES) \
+  -mlongcalls
 
 ifeq ($(BUILD_TYPE), release)
   PLATFORM_FLAGS += -Wno-unused-private-field


### PR DESCRIPTION
This is the fix suggested by @kpraving and fixes #48516

Manually confirmed by restoring the resize_bilinear kernel and checking that the Xtensa build command from #48516 passes.

While the additional `-mlongcalls` is only currently needed for the Vision P6, we have applied it uniformly to all Xtensa builds since the latency impact is minimal.

The latency change for the keyword benchmark is as follows:

Fusion F1:
```
 make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=fusion_f1 XTENSA_CORE=F1_190305_swupgrade run_keyword_benchmark -j8
```

before:
```
InitializeKeywordRunner took 177927 ticks (177 ms).

KeywordRunNIerations(1) took 34251 ticks (34 ms)
```

after:
```
InitializeKeywordRunner took 178575 ticks (178 ms).

KeywordRunNIerations(1) took 34333 ticks (34 ms)
```

Hifimini:
```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=hifimini XTENSA_CORE=mini1m1m_RG run_keyword_benchmark -j8
```

before:
```
InitializeKeywordRunner took 1403928 ticks (1403 ms).

KeywordRunNIerations(1) took 90231 ticks (90 ms)
```

after:
```
InitializeKeywordRunner took 1405400 ticks (1405 ms).

KeywordRunNIerations(1) took 90252 ticks (90 ms)
```
