### PR TITLE
Update mobilenet_v3.py

### DIFF
--- a/tensorflow/python/keras/applications/mobilenet_v3.py
+++ b/tensorflow/python/keras/applications/mobilenet_v3.py
@@ -14,7 +14,8 @@
 # ==============================================================================
 # pylint: disable=invalid-name
 # pylint: disable=missing-function-docstring
-"""MobileNet v3 models for Keras."""
+"""MobileNet v3 models for Keras.
+See code for full docstring."""
 
 from tensorflow.python.keras import backend
 from tensorflow.python.keras import models


### PR DESCRIPTION
The documentation on the web, pulls from the docstring for the module.
This module uses an assignment to BASE_DOCSTRING to hold the documentation, which is therefore hidden from the publishing tools.
I've suggested a comment indicating where the docstring can be found
This is one way to fix the issue. 
The correct fix would be to move the contents of BASE_DOCSTRING to the module level. I have not done that fix, because I don't understand why this method passed code review.