### PR TITLE
2.5.0-rc1 cherry-pick request: Update tensorboard dependency to 2.5.x

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -100,7 +100,7 @@ REQUIRED_PACKAGES = [
     # These need to be in sync with the existing TF version
     # They are updated during the release process
     # When updating these, please also update the nightly versions below
-    'tensorboard ~= 2.4',
+    'tensorboard ~= 2.5',
     'tensorflow-estimator >= 2.5.0rc0 , < 2.6.0',
     # TODO(scottzhu): OSS keras hasn't been formally released yet.
     # Use keras-nightly at the moment.


### PR DESCRIPTION
TensorBoard release: https://pypi.org/project/tensorboard/2.5.0/

PiperOrigin-RevId: 369275616
Change-Id: I4355e3861c493aa8693ca1e0ea1d96695ed87a53