### PR TITLE
[CherryPick:r2.5]Use the standard lib ast.unparse instead of astunparse, available in Python 3.9+.

### DIFF
--- a/tensorflow/python/autograph/pyct/parser.py
+++ b/tensorflow/python/autograph/pyct/parser.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import ast
 import inspect
 import linecache
 import re
@@ -35,6 +36,11 @@ import six
 from tensorflow.python.autograph.pyct import errors
 from tensorflow.python.autograph.pyct import inspect_utils
 from tensorflow.python.util import tf_inspect
+
+
+if sys.version_info >= (3, 9):
+  # ast has an unparse function in 3.9+
+  astunparse = ast
 
 
 PY2_PREAMBLE = textwrap.dedent("""


### PR DESCRIPTION
PiperOrigin-RevId: 367434930
Change-Id: Ieab1c5b76e54f00986ea4e6467714b1ee71199d4