### PR TITLE
Change "Simple Audio Recognition" to right link

### DIFF
--- a/tensorflow/lite/micro/examples/micro_speech/train/README.md
+++ b/tensorflow/lite/micro/examples/micro_speech/train/README.md
@@ -24,7 +24,7 @@ go
 ```
 
 The scripts used in training the model have been sourced from the
-[Simple Audio Recognition](https://www.tensorflow.org/tutorials/sequences/audio_recognition)
+[Simple Audio Recognition](https://www.tensorflow.org/tutorials/audio/simple_audio)
 tutorial.
 
 ## Table of contents


### PR DESCRIPTION
1. Change the link of " Simple Audio Recognition" from "https://www.tensorflow.org/tutorials/sequences/audio_recognition" to "https://www.tensorflow.org/tutorials/audio/simple_audio"

resolves #48627