### PR TITLE
Fix handling of last dimension of RaggedTensor in SparseCategoricalLoss.

### DIFF
--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -1278,7 +1278,10 @@ def _ragged_tensor_apply_loss(loss_fn, y_true, y_pred, y_pred_extra_dim=False):
 
   nested_splits_list = [rt.nested_row_splits for rt in (y_true, y_pred)]
   if y_pred_extra_dim:
-    nested_splits_list[1] = nested_splits_list[1][:-1]
+    # The last dimension of a categorical prediction may be ragged or not.
+    rdims = [len(slist) for slist in nested_splits_list]
+    if rdims[0] == rdims[1] - 1:
+      nested_splits_list[1] = nested_splits_list[1][:-1]
 
   map_fn = functools.partial(_wrapper, ragged_output=len(lshape) > 1)
 

--- a/tensorflow/python/keras/losses_test.py
+++ b/tensorflow/python/keras/losses_test.py
@@ -1170,6 +1170,26 @@ class SparseCategoricalCrossentropyTest(test.TestCase):
     loss = cce_obj(y_true, logits, sample_weight=sample_weight)
     self.assertAlmostEqual(self.evaluate(loss), 0.1934, 3)
 
+  def test_ragged_tensors_rank_1(self):
+    cce_obj = losses.SparseCategoricalCrossentropy()
+    y_true = ragged_factory_ops.constant([[0, 1], [2]])
+    y_pred = ragged_factory_ops.constant(
+        [[[.9, .05, .05], [.5, .89, .6]], [[.05, .01, .94]]],
+        ragged_rank=1, dtype=dtypes.float32)
+    # batch losses [[0.1054, 0.8047], [0.0619]]
+    sample_weight = constant_op.constant([[1.2], [3.4]], shape=(2, 1))
+    loss = cce_obj(y_true, y_pred, sample_weight=sample_weight)
+    # sum([0.1054, 0.8047, 0.0619]) / 3
+    self.assertAlmostEqual(self.evaluate(loss), 0.4341, 3)
+
+    # Test with logits.
+    logits = ragged_factory_ops.constant([[[8., 1., 1.], [0., 9., 1.]],
+                                          [[2., 3., 5.]]], ragged_rank=1)
+    cce_obj = losses.SparseCategoricalCrossentropy(from_logits=True)
+    # batch losses [[0.0018, 0.0004], [0.1698]]
+    loss = cce_obj(y_true, logits, sample_weight=sample_weight)
+    self.assertAlmostEqual(self.evaluate(loss), 0.1934, 3)
+
   def test_ragged_tensors_3d(self):
     # shape [2, 1, None]
     y_true = ragged_factory_ops.constant([[[1, 1]], [[0]]])


### PR DESCRIPTION
The last dimension of a prediction corresponding to the per category scores
may (or not) be ragged, depending on how the tensor was constructed.
Ignore this last dimension, if present, but do not require it to be there.

Fixes #48609