### PR TITLE
[CherryPick:r2.5]Allow ProfilerFactory to return a nullptr ProfilerInterface

### DIFF
--- a/tensorflow/core/profiler/lib/profiler_factory.cc
+++ b/tensorflow/core/profiler/lib/profiler_factory.cc
@@ -47,6 +47,8 @@ void CreateProfilers(
   mutex_lock lock(mu);
   for (auto factory : *GetFactories()) {
     if (auto profiler = factory(options)) {
+      // A factory might return nullptr based on options.
+      if (profiler == nullptr) continue;
       result->push_back(std::move(profiler));
     }
   }

--- a/tensorflow/core/profiler/lib/profiler_factory.h
+++ b/tensorflow/core/profiler/lib/profiler_factory.h
@@ -24,11 +24,16 @@ limitations under the License.
 namespace tensorflow {
 namespace profiler {
 
+// A ProfilerFactory returns an instance of ProfilerInterface if ProfileOptions
+// require it. Otherwise, it might return nullptr.
 using ProfilerFactory =
     std::unique_ptr<ProfilerInterface> (*)(const ProfileOptions&);
 
+// Registers a profiler factory. Should be invoked at most once per factory.
 void RegisterProfilerFactory(ProfilerFactory factory);
 
+// Invokes all registered profiler factories with the given options, and
+// returns the instantiated (non-null) profiler interfaces in result.
 void CreateProfilers(const ProfileOptions& options,
                      std::vector<std::unique_ptr<ProfilerInterface>>* result);
 

--- a/tensorflow/core/profiler/lib/profiler_session.cc
+++ b/tensorflow/core/profiler/lib/profiler_session.cc
@@ -144,6 +144,7 @@ ProfilerSession::ProfilerSession(ProfileOptions options)
   status_ = Status::OK();
 
   for (auto& profiler : profilers_) {
+    DCHECK(profiler != nullptr);
     auto start_status = profiler->Start();
     if (!start_status.ok()) {
       LOG(WARNING) << "Encountered error while starting profiler: "


### PR DESCRIPTION
PiperOrigin-RevId: 368888650
Change-Id: I6d76435f8dfb376c5c8108d778efbf11d2e2b939