### PR TITLE
[TF] Fix convert_variables_to_constants_v2 for DT_RESOURCE.

### DIFF
--- a/tensorflow/python/framework/convert_to_constants.py
+++ b/tensorflow/python/framework/convert_to_constants.py
@@ -823,6 +823,8 @@ class _FunctionConverterData(_ConverterData):
       if idx in map_index_to_variable:
         data = map_index_to_variable[idx].numpy()
       else:
+        if val_tensor.dtype == dtypes.resource:
+          continue
         data = np.array(val_tensor.numpy())
       self._tensor_data[tensor_name] = _TensorData(
           numpy=data,


### PR DESCRIPTION
In GraphDef, a node with dtype DT_RESOURCE may not always represent a Var resource. Previously, when converting variables to constants, we always converted the val_tensor from a DT_RESOURCE to a numpy array and it crashes the TF runtime when
the resource is not a Var resource. 

This PR avoids converting a val_tensor with dtype==resource to numpy array.

These github issues: https://github.com/tensorflow/tensorrt/issues/233 & https://github.com/tensorflow/tensorflow/issues/46254 explain why this bug is a problem for the savedModel utility convert_variables_to_constants_v2, it basically prevents TF-TRT from converting any NLP related models. 

This simple PR addresses this important bug. Please let me know how I can help to get this merged

Google Colab link to reproduce the issue from this bug: https://colab.research.google.com/drive/1_S37VihkTZ1B0HgjW8D7DMZcI8nwz2Bk

CC1: @tfeher @MattConley @WhiteFangBuck @nluehr 
CC2: @pkanwar23 @sanjoy @bixia1