### PR TITLE
[Intel MKL] Fixing python version of IsMklEnabled() method

### DIFF
--- a/tensorflow/python/framework/test_util.py
+++ b/tensorflow/python/framework/test_util.py
@@ -338,7 +338,8 @@ def GpuSupportsHalfMatMulAndConv():
 
 
 def IsMklEnabled():
-  return _pywrap_util_port.IsMklEnabled()
+  return (_pywrap_util_port.IsMklEnabled() or
+          os.getenv("TF_ENABLE_ONEDNN_OPTS", 'False').lower() in ['true', '1'])
 
 
 def InstallStackTraceHandler():


### PR DESCRIPTION
This PR changes IsMklEnabled() python method which used to consider build flag only to determine if Mkl is enabled. That caused some python tests to fail (like timeline_test) in single binary. Now it also checks the environment variable flag.