### PR TITLE
[tf.data] graduate experimental save and load APIs to tf.data

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -58,6 +58,10 @@
     *   Promoting `tf.data.experimental.group_by_window` API to
         `tf.data.Dataset.group_by_window` and deprecating the experimental
         endpoint.
+    *   Promoting `tf.data.experimental.save` API to `tf.data.Dataset.save`
+        and deprecating the experimental endpoint.
+    *   Promoting `tf.data.experimental.load` API to `tf.data.Dataset.load`
+        and deprecating the experimental endpoint.
     *   Added `stop_on_empty_dataset` parameter to `sample_from_datasets` and
         `choose_from_datasets`. Setting `stop_on_empty_dataset=True` will stop
         sampling if it encounters an empty dataset. This preserves the sampling

--- a/tensorflow/python/data/experimental/kernel_tests/BUILD
+++ b/tensorflow/python/data/experimental/kernel_tests/BUILD
@@ -301,19 +301,6 @@ tf_py_test(
 )
 
 tf_py_test(
-    name = "io_test",
-    size = "small",
-    srcs = ["io_test.py"],
-    deps = [
-        "//tensorflow/python:client_testlib",
-        "//tensorflow/python:util",
-        "//tensorflow/python/data/experimental/ops:io",
-        "//tensorflow/python/data/kernel_tests:test_base",
-        "//tensorflow/python/data/ops:dataset_ops",
-    ],
-)
-
-tf_py_test(
     name = "lookup_ops_test",
     size = "small",
     srcs = ["lookup_ops_test.py"],

--- a/tensorflow/python/data/experimental/ops/BUILD
+++ b/tensorflow/python/data/experimental/ops/BUILD
@@ -174,7 +174,7 @@ py_library(
     ],
     srcs_version = "PY3",
     deps = [
-        "//tensorflow/python:experimental_dataset_ops_gen",
+        "//tensorflow/python:util",
         "//tensorflow/python/data/ops:dataset_ops",
     ],
 )

--- a/tensorflow/python/data/experimental/ops/io.py
+++ b/tensorflow/python/data/experimental/ops/io.py
@@ -136,7 +136,7 @@ def load(path, element_spec=None, compression=None, reader_func=None):
       structure of `tf.TypeSpec` can not be located with the saved dataset.
   """
 
-  return dataset_ops.DatasetV2.load(
+  return dataset_ops.Dataset.load(
       path=path,
       element_spec=element_spec,
       compression=compression,

--- a/tensorflow/python/data/kernel_tests/BUILD
+++ b/tensorflow/python/data/kernel_tests/BUILD
@@ -410,6 +410,18 @@ tf_py_test(
 )
 
 tf_py_test(
+    name = "io_test",
+    size = "small",
+    srcs = ["io_test.py"],
+    deps = [
+        "//tensorflow/python:client_testlib",
+        "//tensorflow/python:util",
+        "//tensorflow/python/data/kernel_tests:test_base",
+        "//tensorflow/python/data/ops:dataset_ops",
+    ],
+)
+
+tf_py_test(
     name = "iterator_cluster_test",
     size = "small",
     srcs = ["iterator_cluster_test.py"],

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -5404,7 +5404,7 @@ class _GroupByWindowDataset(UnaryDataset):
     return "Dataset.group_by_window()"
 
 
-class _LoadDataset(dataset_ops.DatasetSource):
+class _LoadDataset(DatasetSource):
   """A dataset that loads previously saved dataset."""
 
   def __init__(self, path, element_spec=None, compression=None,

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -2578,10 +2578,10 @@ name=None))
     tf.Tensor(0, shape=(), dtype=int64)
     tf.Tensor(1, shape=(), dtype=int64)
 
-    The saved dataset is saved in multiple file "shards". By default, the dataset
-    output is divided to shards in a round-robin fashion but custom sharding can
-    be specified via the `shard_func` function. For example, you can save the
-    dataset to using a single shard as follows:
+    The saved dataset is saved in multiple file "shards". By default, the
+    dataset output is divided to shards in a round-robin fashion but custom
+    sharding can be specified via the `shard_func` function. For example, you
+    can save the dataset to using a single shard as follows:
 
     ```python
     dataset = make_dataset()
@@ -2591,18 +2591,19 @@ name=None))
     ```
 
     NOTE: The directory layout and file format used for saving the dataset is
-    considered an implementation detail and may change. For this reason, datasets
-    saved through `tf.data.Dataset.save` should only be consumed through
-    `tf.data.Dataset.load`, which is guaranteed to be backwards compatible.
+    considered an implementation detail and may change. For this reason,
+    datasets saved through `tf.data.Dataset.save` should only be consumed
+    through `tf.data.Dataset.load`, which is guaranteed to be backwards
+    compatible.
 
     Args:
       path: Required. A directory to use for saving the dataset.
       compression: Optional. The algorithm to use to compress data when writing
         it. Supported options are `GZIP` and `NONE`. Defaults to `NONE`.
-      shard_func: Optional. A function to control the mapping of dataset elements
-        to file shards. The function is expected to map elements of the input
-        dataset to int64 shard IDs. If present, the function will be traced and
-        executed as graph computation.
+      shard_func: Optional. A function to control the mapping of dataset
+        elements to file shards. The function is expected to map elements of
+        the input dataset to int64 shard IDs. If present, the function will be
+        traced and executed as graph computation.
     """
 
     if shard_func is None:
@@ -2654,11 +2655,11 @@ name=None))
     tf.Tensor(0, shape=(), dtype=int64)
     tf.Tensor(1, shape=(), dtype=int64)
 
-
     Note that to load a previously saved dataset, you need to specify
-    `element_spec` -- a type signature of the elements of the saved dataset, which
-    can be obtained via `tf.data.Dataset.element_spec`. This requirement exists so
-    that shape inference of the loaded dataset does not need to perform I/O.
+    `element_spec` -- a type signature of the elements of the saved dataset,
+    which can be obtained via `tf.data.Dataset.element_spec`. This requirement
+    exists so that shape inference of the loaded dataset does not need to
+    perform I/O.
 
     If the default option of sharding the saved dataset was used, the element
     order of the saved dataset will be preserved when loading it.
@@ -2680,14 +2681,15 @@ name=None))
 
     Args:
       path: Required. A path pointing to a previously saved dataset.
-      element_spec: Optional. A nested structure of `tf.TypeSpec` objects matching
-        the structure of an element of the saved dataset and specifying the type
-        of individual element components. If not provided, the nested structure of
-        `tf.TypeSpec` saved with the saved dataset is used.
+      element_spec: Optional. A nested structure of `tf.TypeSpec` objects
+        matching the structure of an element of the saved dataset and specifying
+        the type of individual element components. If not provided, the nested
+        structure of `tf.TypeSpec` saved with the saved dataset is used.
       compression: Optional. The algorithm to use to decompress the data when
         reading it. Supported options are `GZIP` and `NONE`. Defaults to `NONE`.
       reader_func: Optional. A function to control how to read data from shards.
-        If present, the function will be traced and executed as graph computation.
+        If present, the function will be traced and executed as graph
+        computation.
 
     Returns:
       A `tf.data.Dataset` instance.

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -2614,11 +2614,11 @@ name=None))
     wrapped_func = StructuredFunctionWrapper(
         shard_func,
         "save()",
-        input_structure=dataset.element_spec,
+        input_structure=self.element_spec,
         add_to_graph=False)
 
     coder = nested_structure_coder.StructureCoder()
-    encoded = coder.encode_structure(dataset.element_spec)
+    encoded = coder.encode_structure(self.element_spec)
     gfile.MakeDirs(path)
     with gfile.GFile(os.path.join(path, DATASET_SPEC_FILENAME), "wb") as f:
       f.write(encoded.SerializeToString())
@@ -2628,9 +2628,9 @@ name=None))
     shard_func.add_to_graph(ops.get_default_graph())
 
     # pylint: disable=protected-access
-    dataset = dataset._apply_options()
+    self = self._apply_options()
     ged_ops.save_dataset(
-        dataset._variant_tensor,
+        self._variant_tensor,
         path=path,
         shard_func_other_args=shard_func.captured_inputs,
         compression=compression,

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -19,6 +19,8 @@ from __future__ import print_function
 
 import abc
 import functools
+import multiprocessing
+import os
 import sys
 import threading
 import warnings
@@ -69,6 +71,7 @@ from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import script_ops
 from tensorflow.python.ops import string_ops
 from tensorflow.python.ops.ragged import ragged_tensor
+from tensorflow.python.platform import gfile
 from tensorflow.python.training.tracking import base as tracking_base
 from tensorflow.python.training.tracking import tracking
 from tensorflow.python.util import deprecation
@@ -78,6 +81,10 @@ from tensorflow.python.util import nest as tf_nest
 from tensorflow.python.util.compat import collections_abc
 from tensorflow.python.util.tf_export import tf_export
 
+# TODO(b/176933539): Use the regular import.
+nested_structure_coder = lazy_loader.LazyLoader(
+    "nested_structure_coder", globals(),
+    "tensorflow.python.saved_model.nested_structure_coder")
 # Loaded lazily due to a circular dependency (roughly
 # tf.function->wrap_function->dataset->autograph->tf.function).
 # TODO(b/133251390): Use a regular import.
@@ -106,6 +113,8 @@ UNKNOWN = -2
 tf_export("data.INFINITE_CARDINALITY").export_constant(__name__, "INFINITE")
 tf_export("data.UNKNOWN_CARDINALITY").export_constant(__name__, "UNKNOWN")
 
+# Constant for dataset spec while saving and loading datasets
+DATASET_SPEC_FILENAME = "dataset_spec.pb"
 
 @tf_export("data.Dataset", v1=[])
 @six.add_metaclass(abc.ABCMeta)
@@ -2553,6 +2562,146 @@ name=None))
 
     return _GroupByWindowDataset(self, key_func, reduce_func, window_size_func)
 
+  def save(self, path, compression=None, shard_func=None):
+    """Saves the content of the given dataset.
+
+    Example usage:
+
+    >>> import tempfile
+    >>> path = os.path.join(tempfile.gettempdir(), "saved_data")
+    >>> # Save a dataset
+    >>> dataset = tf.data.Dataset.range(2)
+    >>> dataset.save(path)
+    >>> new_dataset = tf.data.Dataset.load(path)
+    >>> for elem in new_dataset:
+    ...   print(elem)
+    tf.Tensor(0, shape=(), dtype=int64)
+    tf.Tensor(1, shape=(), dtype=int64)
+
+    The saved dataset is saved in multiple file "shards". By default, the dataset
+    output is divided to shards in a round-robin fashion but custom sharding can
+    be specified via the `shard_func` function. For example, you can save the
+    dataset to using a single shard as follows:
+
+    ```python
+    dataset = make_dataset()
+    def custom_shard_func(element):
+      return 0
+    dataset.save(path="/path/to/data", shard_func=custom_shard_func)
+    ```
+
+    NOTE: The directory layout and file format used for saving the dataset is
+    considered an implementation detail and may change. For this reason, datasets
+    saved through `tf.data.Dataset.save` should only be consumed through
+    `tf.data.Dataset.load`, which is guaranteed to be backwards compatible.
+
+    Args:
+      path: Required. A directory to use for saving the dataset.
+      compression: Optional. The algorithm to use to compress data when writing
+        it. Supported options are `GZIP` and `NONE`. Defaults to `NONE`.
+      shard_func: Optional. A function to control the mapping of dataset elements
+        to file shards. The function is expected to map elements of the input
+        dataset to int64 shard IDs. If present, the function will be traced and
+        executed as graph computation.
+    """
+
+    if shard_func is None:
+      use_shard_func = False
+      shard_func = lambda *x: None  # a dummy function that will not be used
+    else:
+      use_shard_func = True
+
+    wrapped_func = StructuredFunctionWrapper(
+        shard_func,
+        "save()",
+        input_structure=dataset.element_spec,
+        add_to_graph=False)
+
+    coder = nested_structure_coder.StructureCoder()
+    encoded = coder.encode_structure(dataset.element_spec)
+    gfile.MakeDirs(path)
+    with gfile.GFile(os.path.join(path, DATASET_SPEC_FILENAME), "wb") as f:
+      f.write(encoded.SerializeToString())
+
+    path = ops.convert_to_tensor(path, dtype=dtypes.string, name="path")
+    shard_func = wrapped_func.function
+    shard_func.add_to_graph(ops.get_default_graph())
+
+    # pylint: disable=protected-access
+    dataset = dataset._apply_options()
+    ged_ops.save_dataset(
+        dataset._variant_tensor,
+        path=path,
+        shard_func_other_args=shard_func.captured_inputs,
+        compression=compression,
+        shard_func=shard_func,
+        use_shard_func=use_shard_func)
+
+  @staticmethod
+  def load(path, element_spec=None, compression=None, reader_func=None):
+    """Loads a previously saved dataset.
+
+    Example usage:
+
+    >>> import tempfile
+    >>> path = os.path.join(tempfile.gettempdir(), "saved_data")
+    >>> # Save a dataset
+    >>> dataset = tf.data.Dataset.range(2)
+    >>> dataset.save(path)
+    >>> new_dataset = tf.data.Dataset.load(path)
+    >>> for elem in new_dataset:
+    ...   print(elem)
+    tf.Tensor(0, shape=(), dtype=int64)
+    tf.Tensor(1, shape=(), dtype=int64)
+
+
+    Note that to load a previously saved dataset, you need to specify
+    `element_spec` -- a type signature of the elements of the saved dataset, which
+    can be obtained via `tf.data.Dataset.element_spec`. This requirement exists so
+    that shape inference of the loaded dataset does not need to perform I/O.
+
+    If the default option of sharding the saved dataset was used, the element
+    order of the saved dataset will be preserved when loading it.
+
+    The `reader_func` argument can be used to specify a custom order in which
+    elements should be loaded from the individual shards. The `reader_func` is
+    expected to take a single argument -- a dataset of datasets, each containing
+    elements of one of the shards -- and return a dataset of elements. For
+    example, the order of shards can be shuffled when loading them as follows:
+
+    ```python
+    def custom_reader_func(datasets):
+      datasets = datasets.shuffle(NUM_SHARDS)
+      return datasets.interleave(lambda x: x, num_parallel_calls=AUTOTUNE)
+
+    dataset = tf.data.Dataset.load(
+        path="/path/to/data", ..., reader_func=custom_reader_func)
+    ```
+
+    Args:
+      path: Required. A path pointing to a previously saved dataset.
+      element_spec: Optional. A nested structure of `tf.TypeSpec` objects matching
+        the structure of an element of the saved dataset and specifying the type
+        of individual element components. If not provided, the nested structure of
+        `tf.TypeSpec` saved with the saved dataset is used.
+      compression: Optional. The algorithm to use to decompress the data when
+        reading it. Supported options are `GZIP` and `NONE`. Defaults to `NONE`.
+      reader_func: Optional. A function to control how to read data from shards.
+        If present, the function will be traced and executed as graph computation.
+
+    Returns:
+      A `tf.data.Dataset` instance.
+
+    Raises:
+      FileNotFoundError: If `element_spec` is not specified and the saved nested
+        structure of `tf.TypeSpec` can not be located with the saved dataset.
+    """
+
+    return _LoadDataset(
+        path=path,
+        element_spec=element_spec,
+        compression=compression,
+        reader_func=reader_func)
 
 @tf_export(v1=["data.Dataset"])
 class DatasetV1(DatasetV2):
@@ -5253,6 +5402,52 @@ class _GroupByWindowDataset(UnaryDataset):
 
   def _transformation_name(self):
     return "Dataset.group_by_window()"
+
+
+class _LoadDataset(dataset_ops.DatasetSource):
+  """A dataset that loads previously saved dataset."""
+
+  def __init__(self, path, element_spec=None, compression=None,
+               reader_func=None):
+
+    if reader_func is None:
+      reader_func = lambda datasets: datasets.interleave(  # pylint:disable=g-long-lambda
+          lambda x: x,
+          cycle_length=multiprocessing.cpu_count(),
+          num_parallel_calls=AUTOTUNE)
+
+    self._path = path
+    if element_spec is None:
+      with gfile.GFile(os.path.join(path, DATASET_SPEC_FILENAME), "rb") as f:
+        encoded_spec = f.read()
+      struct_pb = nested_structure_coder.struct_pb2.StructuredValue()
+      struct_pb.ParseFromString(encoded_spec)
+      coder = nested_structure_coder.StructureCoder()
+      spec = coder.decode_proto(struct_pb)
+      self._element_spec = spec
+    else:
+      self._element_spec = element_spec
+    self._compression = compression
+    self._reader_func = StructuredFunctionWrapper(
+        reader_func,
+        "load()",
+        # Dataset of datasets of input elements
+        input_structure=DatasetSpec(DatasetSpec(self._element_spec)))
+
+    variant_tensor = ged_ops.load_dataset(
+        path,
+        reader_func_other_args=self._reader_func.function.captured_inputs,
+        compression=compression,
+        reader_func=self._reader_func.function,
+        **self._flat_structure)
+    super(_LoadDataset, self).__init__(variant_tensor)
+
+  def _functions(self):
+    return [self._reader_func]
+
+  @property
+  def element_spec(self):
+    return self._element_spec
 
 
 def _collect_resource_inputs(op):

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-dataset.pbtxt
@@ -96,6 +96,10 @@ tf_class {
     argspec: "args=[\'file_pattern\', \'shuffle\', \'seed\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
+    name: "load"
+    argspec: "args=[\'path\', \'element_spec\', \'compression\', \'reader_func\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\'], "
+  }
+  member_method {
     name: "make_initializable_iterator"
     argspec: "args=[\'self\', \'shared_name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
@@ -134,6 +138,10 @@ tf_class {
   member_method {
     name: "repeat"
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
+    name: "save"
+    argspec: "args=[\'self\', \'path\', \'compression\', \'shard_func\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
     name: "shard"

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-fixed-length-record-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-fixed-length-record-dataset.pbtxt
@@ -98,6 +98,10 @@ tf_class {
     argspec: "args=[\'file_pattern\', \'shuffle\', \'seed\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
+    name: "load"
+    argspec: "args=[\'path\', \'element_spec\', \'compression\', \'reader_func\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\'], "
+  }
+  member_method {
     name: "make_initializable_iterator"
     argspec: "args=[\'self\', \'shared_name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
@@ -136,6 +140,10 @@ tf_class {
   member_method {
     name: "repeat"
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
+    name: "save"
+    argspec: "args=[\'self\', \'path\', \'compression\', \'shard_func\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
     name: "shard"

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-t-f-record-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-t-f-record-dataset.pbtxt
@@ -98,6 +98,10 @@ tf_class {
     argspec: "args=[\'file_pattern\', \'shuffle\', \'seed\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
+    name: "load"
+    argspec: "args=[\'path\', \'element_spec\', \'compression\', \'reader_func\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\'], "
+  }
+  member_method {
     name: "make_initializable_iterator"
     argspec: "args=[\'self\', \'shared_name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
@@ -136,6 +140,10 @@ tf_class {
   member_method {
     name: "repeat"
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
+    name: "save"
+    argspec: "args=[\'self\', \'path\', \'compression\', \'shard_func\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
     name: "shard"

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-text-line-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-text-line-dataset.pbtxt
@@ -98,6 +98,10 @@ tf_class {
     argspec: "args=[\'file_pattern\', \'shuffle\', \'seed\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
+    name: "load"
+    argspec: "args=[\'path\', \'element_spec\', \'compression\', \'reader_func\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\'], "
+  }
+  member_method {
     name: "make_initializable_iterator"
     argspec: "args=[\'self\', \'shared_name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
@@ -136,6 +140,10 @@ tf_class {
   member_method {
     name: "repeat"
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
+    name: "save"
+    argspec: "args=[\'self\', \'path\', \'compression\', \'shard_func\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
     name: "shard"

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-csv-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-csv-dataset.pbtxt
@@ -98,6 +98,10 @@ tf_class {
     argspec: "args=[\'file_pattern\', \'shuffle\', \'seed\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
+    name: "load"
+    argspec: "args=[\'path\', \'element_spec\', \'compression\', \'reader_func\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\'], "
+  }
+  member_method {
     name: "make_initializable_iterator"
     argspec: "args=[\'self\', \'shared_name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
@@ -136,6 +140,10 @@ tf_class {
   member_method {
     name: "repeat"
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
+    name: "save"
+    argspec: "args=[\'self\', \'path\', \'compression\', \'shard_func\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
     name: "shard"

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-random-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-random-dataset.pbtxt
@@ -98,6 +98,10 @@ tf_class {
     argspec: "args=[\'file_pattern\', \'shuffle\', \'seed\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
+    name: "load"
+    argspec: "args=[\'path\', \'element_spec\', \'compression\', \'reader_func\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\'], "
+  }
+  member_method {
     name: "make_initializable_iterator"
     argspec: "args=[\'self\', \'shared_name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
@@ -136,6 +140,10 @@ tf_class {
   member_method {
     name: "repeat"
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
+    name: "save"
+    argspec: "args=[\'self\', \'path\', \'compression\', \'shard_func\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
     name: "shard"

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-sql-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-sql-dataset.pbtxt
@@ -98,6 +98,10 @@ tf_class {
     argspec: "args=[\'file_pattern\', \'shuffle\', \'seed\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
+    name: "load"
+    argspec: "args=[\'path\', \'element_spec\', \'compression\', \'reader_func\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\'], "
+  }
+  member_method {
     name: "make_initializable_iterator"
     argspec: "args=[\'self\', \'shared_name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
@@ -136,6 +140,10 @@ tf_class {
   member_method {
     name: "repeat"
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
+    name: "save"
+    argspec: "args=[\'self\', \'path\', \'compression\', \'shard_func\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
     name: "shard"

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-dataset.pbtxt
@@ -75,6 +75,10 @@ tf_class {
     argspec: "args=[\'file_pattern\', \'shuffle\', \'seed\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
+    name: "load"
+    argspec: "args=[\'path\', \'element_spec\', \'compression\', \'reader_func\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\'], "
+  }
+  member_method {
     name: "map"
     argspec: "args=[\'self\', \'map_func\', \'num_parallel_calls\', \'deterministic\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
@@ -101,6 +105,10 @@ tf_class {
   member_method {
     name: "repeat"
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
+    name: "save"
+    argspec: "args=[\'self\', \'path\', \'compression\', \'shard_func\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
     name: "shard"

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-fixed-length-record-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-fixed-length-record-dataset.pbtxt
@@ -77,6 +77,10 @@ tf_class {
     argspec: "args=[\'file_pattern\', \'shuffle\', \'seed\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
+    name: "load"
+    argspec: "args=[\'path\', \'element_spec\', \'compression\', \'reader_func\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\'], "
+  }
+  member_method {
     name: "map"
     argspec: "args=[\'self\', \'map_func\', \'num_parallel_calls\', \'deterministic\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
@@ -103,6 +107,10 @@ tf_class {
   member_method {
     name: "repeat"
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
+    name: "save"
+    argspec: "args=[\'self\', \'path\', \'compression\', \'shard_func\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
     name: "shard"

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-t-f-record-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-t-f-record-dataset.pbtxt
@@ -76,6 +76,10 @@ tf_class {
     argspec: "args=[\'file_pattern\', \'shuffle\', \'seed\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
+    name: "load"
+    argspec: "args=[\'path\', \'element_spec\', \'compression\', \'reader_func\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\'], "
+  }
+  member_method {
     name: "map"
     argspec: "args=[\'self\', \'map_func\', \'num_parallel_calls\', \'deterministic\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
@@ -102,6 +106,10 @@ tf_class {
   member_method {
     name: "repeat"
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
+    name: "save"
+    argspec: "args=[\'self\', \'path\', \'compression\', \'shard_func\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
     name: "shard"

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-text-line-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-text-line-dataset.pbtxt
@@ -77,6 +77,10 @@ tf_class {
     argspec: "args=[\'file_pattern\', \'shuffle\', \'seed\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
+    name: "load"
+    argspec: "args=[\'path\', \'element_spec\', \'compression\', \'reader_func\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\'], "
+  }
+  member_method {
     name: "map"
     argspec: "args=[\'self\', \'map_func\', \'num_parallel_calls\', \'deterministic\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
@@ -103,6 +107,10 @@ tf_class {
   member_method {
     name: "repeat"
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
+    name: "save"
+    argspec: "args=[\'self\', \'path\', \'compression\', \'shard_func\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
     name: "shard"

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-csv-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-csv-dataset.pbtxt
@@ -77,6 +77,10 @@ tf_class {
     argspec: "args=[\'file_pattern\', \'shuffle\', \'seed\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
+    name: "load"
+    argspec: "args=[\'path\', \'element_spec\', \'compression\', \'reader_func\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\'], "
+  }
+  member_method {
     name: "map"
     argspec: "args=[\'self\', \'map_func\', \'num_parallel_calls\', \'deterministic\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
@@ -103,6 +107,10 @@ tf_class {
   member_method {
     name: "repeat"
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
+    name: "save"
+    argspec: "args=[\'self\', \'path\', \'compression\', \'shard_func\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
     name: "shard"

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-random-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-random-dataset.pbtxt
@@ -77,6 +77,10 @@ tf_class {
     argspec: "args=[\'file_pattern\', \'shuffle\', \'seed\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
+    name: "load"
+    argspec: "args=[\'path\', \'element_spec\', \'compression\', \'reader_func\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\'], "
+  }
+  member_method {
     name: "map"
     argspec: "args=[\'self\', \'map_func\', \'num_parallel_calls\', \'deterministic\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
@@ -103,6 +107,10 @@ tf_class {
   member_method {
     name: "repeat"
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
+    name: "save"
+    argspec: "args=[\'self\', \'path\', \'compression\', \'shard_func\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
     name: "shard"

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-sql-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-sql-dataset.pbtxt
@@ -77,6 +77,10 @@ tf_class {
     argspec: "args=[\'file_pattern\', \'shuffle\', \'seed\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
+    name: "load"
+    argspec: "args=[\'path\', \'element_spec\', \'compression\', \'reader_func\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\'], "
+  }
+  member_method {
     name: "map"
     argspec: "args=[\'self\', \'map_func\', \'num_parallel_calls\', \'deterministic\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
@@ -103,6 +107,10 @@ tf_class {
   member_method {
     name: "repeat"
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
+    name: "save"
+    argspec: "args=[\'self\', \'path\', \'compression\', \'shard_func\'], varargs=None, keywords=None, defaults=[\'None\', \'None\'], "
   }
   member_method {
     name: "shard"


### PR DESCRIPTION
UPDATED: This PR graduates the `tf.data.experimental.save` and `tf.data.experimental.load` APIs into `tf.data.Dataset` by making the following changes:

- [x] Adds the deprecation decorator for the experimental API and export the new API.
- [x] Adds the necessary `save` and `load` methods to `DatasetV2` class.
- [x] Updates example in documentation with new API.
- [x] Regenerate golden API's.
- [x] Moved and updated the `io_test` target from experimental/kernel_tests to kernel_tests
- [x] Updated the RELEASE.md file

TEST LOG
```
INFO: Build completed successfully, 349 total actions
//tensorflow/python/data/kernel_tests:io_test                            PASSED in 1.9s
```

cc: @jsimsa 