### PR TITLE
Iterative horizontal fusion.

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
@@ -352,7 +352,7 @@ Status GpuCompiler::OptimizeHloModule(
     fusion.AddPass<HloDCE>();
     TF_RETURN_IF_ERROR(fusion.Run(hlo_module).status());
 
-    HloPassPipeline horizontal_fusion("horizontal_fusion");
+    HloPassFix<HloPassPipeline> horizontal_fusion("horizontal_fusion");
     horizontal_fusion.AddPass<GpuHorizontalLoopFusion>();
     horizontal_fusion.AddPass<GpuHorizontalInputFusion>();
     horizontal_fusion.AddPass<HloCSE>(/*is_layout_sensitive=*/true,

--- a/tensorflow/compiler/xla/service/gpu/gpu_fusible.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_fusible.cc
@@ -549,17 +549,18 @@ size_t GetInstrCountOfFusible(const HloInstruction& instr) {
   }
 }
 
-absl::InlinedVector<HloInstruction*, 2> GetOutputsOfFusible(
+absl::InlinedVector<const HloInstruction*, 2> GetOutputsOfFusible(
     const HloInstruction& instr) {
   if (instr.opcode() != HloOpcode::kFusion) {
-    return {const_cast<HloInstruction*>(&instr)};
+    return {&instr};
   }
 
   HloInstruction* root = instr.fused_expression_root();
   if (root->opcode() != HloOpcode::kTuple) {
     return {root};
   } else {
-    return root->operands();
+    auto v = root->operands();
+    return absl::InlinedVector<const HloInstruction*, 2>(v.begin(), v.end());
   }
 }
 

--- a/tensorflow/compiler/xla/service/gpu/gpu_fusible.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_fusible.cc
@@ -541,5 +541,35 @@ bool IsConsumerTheOnlyNonRootUser(const HloInstruction& instr,
   });
 }
 
+size_t GetInstrCountOfFusible(const HloInstruction& instr) {
+  if (instr.opcode() != HloOpcode::kFusion) {
+    return 1;
+  } else {
+    return instr.fused_instruction_count();
+  }
+}
+
+absl::InlinedVector<HloInstruction*, 2> GetOutputsOfFusible(
+    const HloInstruction& instr) {
+  if (instr.opcode() != HloOpcode::kFusion) {
+    return {const_cast<HloInstruction*>(&instr)};
+  }
+
+  HloInstruction* root = instr.fused_expression_root();
+  if (root->opcode() != HloOpcode::kTuple) {
+    return {root};
+  } else {
+    return root->operands();
+  }
+}
+
+size_t GetOutputSizeOfFusible(const HloInstruction& instr) {
+  if (!instr.IsMultiOutputFusion()) {
+    return 1;
+  }
+  const HloInstruction* root = instr.fused_expression_root();
+  return ShapeUtil::TupleElementCount(root->shape());
+}
+
 }  // namespace gpu
 }  // namespace xla

--- a/tensorflow/compiler/xla/service/gpu/gpu_fusible.h
+++ b/tensorflow/compiler/xla/service/gpu/gpu_fusible.h
@@ -114,7 +114,7 @@ bool IsConsumerTheOnlyNonRootUser(const HloInstruction& instr,
 size_t GetInstrCountOfFusible(const HloInstruction& instr);
 
 // Returns the outputs of the fusible `instr`.
-absl::InlinedVector<HloInstruction*, 2> GetOutputsOfFusible(
+absl::InlinedVector<const HloInstruction*, 2> GetOutputsOfFusible(
     const HloInstruction& instr);
 
 // Returns the output size of the fusible `instr`.

--- a/tensorflow/compiler/xla/service/gpu/gpu_fusible.h
+++ b/tensorflow/compiler/xla/service/gpu/gpu_fusible.h
@@ -109,6 +109,17 @@ HloInstruction::FusionKind ChooseFusionKind(const HloInstruction& producer,
 bool IsConsumerTheOnlyNonRootUser(const HloInstruction& instr,
                                   const HloInstruction& consumer);
 
+// Returns number of instructions in the fusible `instr`. If `instr` is not a
+// fusion instruction, 1 is returned.
+size_t GetInstrCountOfFusible(const HloInstruction& instr);
+
+// Returns the outputs of the fusible `instr`.
+absl::InlinedVector<HloInstruction*, 2> GetOutputsOfFusible(
+    const HloInstruction& instr);
+
+// Returns the output size of the fusible `instr`.
+size_t GetOutputSizeOfFusible(const HloInstruction& instr);
+
 }  // namespace gpu
 }  // namespace xla
 

--- a/tensorflow/compiler/xla/service/gpu/horizontal_loop_fusion.cc
+++ b/tensorflow/compiler/xla/service/gpu/horizontal_loop_fusion.cc
@@ -30,9 +30,12 @@ namespace gpu {
 
 namespace {
 
-absl::InlinedVector<HloInstruction*, 2> GetOutputsOfFusion(
+absl::InlinedVector<HloInstruction*, 2> GetOutputsOfFusible(
     const HloInstruction& instr) {
-  CHECK(instr.opcode() == HloOpcode::kFusion);
+  if (instr.opcode() != HloOpcode::kFusion) {
+    return {const_cast<HloInstruction*>(&instr)};
+  }
+
   HloInstruction* root = instr.fused_expression_root();
   if (root->opcode() != HloOpcode::kTuple) {
     return {root};
@@ -41,19 +44,16 @@ absl::InlinedVector<HloInstruction*, 2> GetOutputsOfFusion(
   }
 }
 
-// Returns the number of outputs of the fused computation.
-size_t GetOutputSizeOfFusion(const HloInstruction& instr) {
-  CHECK(instr.opcode() == HloOpcode::kFusion);
-  const HloInstruction* root = instr.fused_expression_root();
-  if (root->opcode() != HloOpcode::kTuple) {
+size_t GetOutputSizeOfFusible(const HloInstruction& instr) {
+  if (!instr.IsMultiOutputFusion()) {
     return 1;
-  } else {
-    return ShapeUtil::TupleElementCount(root->shape());
   }
+  const HloInstruction* root = instr.fused_expression_root();
+  return ShapeUtil::TupleElementCount(root->shape());
 }
 
-PrimitiveType GetUniqueOutputTypeOfFusion(const HloInstruction& instr) {
-  auto outputs = GetOutputsOfFusion(instr);
+PrimitiveType GetUniqueOutputTypeOfFusible(const HloInstruction& fusible) {
+  auto outputs = GetOutputsOfFusible(fusible);
   CHECK(!outputs.empty());
   PrimitiveType first_output_type = outputs[0]->shape().element_type();
   for (size_t i = 1; i < outputs.size(); ++i) {
@@ -65,6 +65,25 @@ PrimitiveType GetUniqueOutputTypeOfFusion(const HloInstruction& instr) {
   }
 
   return first_output_type;
+}
+
+size_t GetInstrCountOfFusible(const HloInstruction& instr) {
+  if (instr.opcode() != HloOpcode::kFusion) {
+    return 1;
+  } else {
+    return instr.fused_instruction_count();
+  }
+}
+
+// Creates a kLoop fusion instruction and fuses `fused` into the created
+// fusion instruction.
+HloInstruction* MakeLoopFusionInstruction(HloInstruction* fused) {
+  HloComputation* comp = fused->parent();
+  HloInstruction* fusion_instruction =
+      comp->AddInstruction(HloInstruction::CreateFusion(
+          fused->shape(), HloInstruction::FusionKind::kLoop, fused));
+  TF_CHECK_OK(comp->ReplaceInstruction(fused, fusion_instruction));
+  return fusion_instruction;
 }
 
 class HorizontalLoopFusionImpl {
@@ -98,7 +117,7 @@ class HorizontalLoopFusionImpl {
   class FusionCandidates {
    public:
     explicit FusionCandidates(HloInstruction* consumer)
-        : fusion_instrs_(), pos_(0) {
+        : fusible_instrs_(), pos_(0) {
       Initialize(consumer);
     }
 
@@ -108,7 +127,7 @@ class HorizontalLoopFusionImpl {
    private:
     void Initialize(HloInstruction*);
 
-    std::vector<HloInstruction*> fusion_instrs_;
+    std::vector<HloInstruction*> fusible_instrs_;
     // `pos_` points to the start position of the next span.
     size_t pos_;
   };
@@ -116,8 +135,13 @@ class HorizontalLoopFusionImpl {
   HloComputation* computation_;
 };  // HorizontalLoopFusionImpl
 
-bool IsFusionSupported(const HloInstruction& instr) {
-  // Support only kLoop fusion now.
+bool IsFusibleCandidate(const HloInstruction& instr) {
+  // Require no further check for element-wise instructions.
+  if (instr.IsElementwise() && instr.operand_count() > 0) {
+    return true;
+  }
+
+  // Exclude fusions other than kLoop.
   if (!instr.IsLoopFusion()) {
     return false;
   }
@@ -125,7 +149,7 @@ bool IsFusionSupported(const HloInstruction& instr) {
   // Cannot support fusion who has multiple output types, because the
   // concatenate (inserted for horizontal fusion) requires the same type
   // for all of its operands.
-  auto outputs = GetOutputsOfFusion(instr);
+  auto outputs = GetOutputsOfFusible(instr);
   CHECK(!outputs.empty());
   const HloInstruction* first_output = outputs[0];
   for (size_t i = 1; i < outputs.size(); ++i) {
@@ -149,10 +173,11 @@ bool IsFusionSupported(const HloInstruction& instr) {
 // instructions than `kInstrCountThreshold`, it is launch-latency-bound and
 // profitable by horizontal fusion.
 bool IsProfitableFusionCandidate(const HloInstruction& instr) {
-  CHECK(instr.opcode() == HloOpcode::kFusion);
   constexpr int64 kShapeThreshold = 128 * 2048;
   constexpr int64 kInstrCountThreshold = 30;
-  auto root = instr.fused_expression_root();
+  const HloInstruction* root = (instr.opcode() == HloOpcode::kFusion)
+                                   ? instr.fused_expression_root()
+                                   : &instr;
 
   // Too large shapes are not easily profitable.
   if (root->opcode() == HloOpcode::kTuple) {
@@ -170,7 +195,8 @@ bool IsProfitableFusionCandidate(const HloInstruction& instr) {
   }
 
   // Having too many instructions is not easily profitable.
-  if (instr.fused_instruction_count() > kInstrCountThreshold) {
+  if (instr.opcode() == HloOpcode::kFusion &&
+      instr.fused_instruction_count() > kInstrCountThreshold) {
     return false;
   }
 
@@ -181,14 +207,17 @@ bool IsProfitableFusionCandidate(const HloInstruction& instr) {
 // The horizontal fusion excludes computations with non-row-major layouts,
 // because fusing computations with different layouts can result in uncoalesced
 // memory accesses and cause great performance overhead.
-bool HasOnlyRowMajorLayout(const HloInstruction& fusion_instr) {
-  CHECK(fusion_instr.opcode() == HloOpcode::kFusion);
-  auto instrs = fusion_instr.fused_instructions_computation()->instructions();
-  for (auto instr : instrs) {
-    if (instr->shape().layout().format() != DENSE) {
+bool HasOnlyRowMajorLayout(const HloInstruction& instr) {
+  if (instr.opcode() != HloOpcode::kFusion) {
+    return LayoutUtil::IsMonotonicWithDim0Major(instr.shape().layout());
+  }
+
+  auto fused_instrs = instr.fused_instructions_computation()->instructions();
+  for (auto i : fused_instrs) {
+    if (i->shape().layout().format() != DENSE) {
       continue;
     }
-    if (!LayoutUtil::IsMonotonicWithDim0Major(instr->shape().layout())) {
+    if (!LayoutUtil::IsMonotonicWithDim0Major(i->shape().layout())) {
       return false;
     }
   }
@@ -210,25 +239,24 @@ bool AnyOpndIsParamSharedAmongFusions(
 
 void HorizontalLoopFusionImpl::FusionCandidates::Initialize(
     HloInstruction* consumer) {
-  // First, find out all fusion instructions. We will filter out
+  // First, find out all potential target candidates. We will filter out
   // unsupported/non-profitable cases below.
-  absl::flat_hash_set<HloInstruction*> fusion_instrs;
-  std::vector<HloInstruction*> fusion_instrs_ordered;
+  absl::flat_hash_set<HloInstruction*> fusible_candidates;
+  std::vector<HloInstruction*> ordered_fusible_candidates;
   for (auto opnd : consumer->operands()) {
     auto predecessor = opnd->LatestNonGteAncestor();
-    if (predecessor->opcode() == HloOpcode::kFusion) {
-      if (fusion_instrs.insert(predecessor).second) {
+    // We support kLoop fusion and element-wise HLOs now. We may extend the
+    // support list if needs arise.
+    if (IsFusibleCandidate(*predecessor)) {
+      if (fusible_candidates.insert(predecessor).second) {
         // Add unseen fusion to ordered list.
-        fusion_instrs_ordered.push_back(predecessor);
+        ordered_fusible_candidates.push_back(predecessor);
       }
     }
   }
 
-  for (auto instr : fusion_instrs_ordered) {
-    if (!IsFusionSupported(*instr)) {
-      VLOG(2) << "Reject unsupported fusion instr " << instr->ToString();
-      continue;
-    } else if (!IsConsumerTheOnlyNonRootUser(*instr, *consumer)) {
+  for (auto instr : ordered_fusible_candidates) {
+    if (!IsConsumerTheOnlyNonRootUser(*instr, *consumer)) {
       VLOG(2) << "Reject maybe illegal instr " << instr->ToString()
               << "; including it may create cycles in HLO.";
       continue;
@@ -239,35 +267,37 @@ void HorizontalLoopFusionImpl::FusionCandidates::Initialize(
     } else if (!HasOnlyRowMajorLayout(*instr)) {
       VLOG(2) << "Reject non-row-major fusion instr " << instr->ToString();
       continue;
-    } else if (AnyOpndIsParamSharedAmongFusions(instr, fusion_instrs)) {
+    } else if (AnyOpndIsParamSharedAmongFusions(instr, fusible_candidates)) {
       // Don't fuse fusions whose operands are parameter instructions that are
       // shared among fusions because we cannot i/o alias the produced
       // horizontal fusion due to the concat insertion.
       VLOG(2) << "Reject the fusion instr because it shares parameter with"
-              << " other fusion candidates, instr: ",
-          instr->ToString();
+              << " other fusion candidates, instr: "
+              << instr->ToString();
       continue;
     } else {
       VLOG(2) << "Find a fusion candidate " << instr->ToString();
-      fusion_instrs_.push_back(instr);
+      // Encapsulate it into a fusion computation for unified representation
+      // for later processing.
+      fusible_instrs_.push_back(instr);
     }
   }
 
-  // Sort `fusion_instrs` according to output types, the number of outputs,
+  // Sort `fusible_instrs_` according to output types, the number of outputs,
   // and instruction counts, because we only fuse instructions with the same
   // number/type of outputs and whose computations have the same instruction
   // count.
   std::sort(
-      fusion_instrs_.begin(), fusion_instrs_.end(),
+      fusible_instrs_.begin(), fusible_instrs_.end(),
       [&](const HloInstruction* a, const HloInstruction* b) {
-        if (GetUniqueOutputTypeOfFusion(*a) !=
-            GetUniqueOutputTypeOfFusion(*b)) {
-          return GetUniqueOutputTypeOfFusion(*a) <
-                 GetUniqueOutputTypeOfFusion(*b);
-        } else if (GetOutputSizeOfFusion(*a) != GetOutputSizeOfFusion(*b)) {
-          return GetOutputSizeOfFusion(*a) < GetOutputSizeOfFusion(*b);
+        if (GetUniqueOutputTypeOfFusible(*a) !=
+            GetUniqueOutputTypeOfFusible(*b)) {
+          return GetUniqueOutputTypeOfFusible(*a) <
+                 GetUniqueOutputTypeOfFusible(*b);
+        } else if (GetOutputSizeOfFusible(*a) != GetOutputSizeOfFusible(*b)) {
+          return GetOutputSizeOfFusible(*a) < GetOutputSizeOfFusible(*b);
         } else {
-          return a->fused_instruction_count() < b->fused_instruction_count();
+          return GetInstrCountOfFusible(*a) < GetInstrCountOfFusible(*b);
         }
       });
 }
@@ -275,7 +305,7 @@ void HorizontalLoopFusionImpl::FusionCandidates::Initialize(
 // Gets a next span of fusion instructions to be fused.
 absl::Span<HloInstruction*>
 HorizontalLoopFusionImpl::FusionCandidates::GetNextSpanOfFusions() {
-  if (pos_ >= fusion_instrs_.size()) {
+  if (pos_ >= fusible_instrs_.size()) {
     return absl::Span<HloInstruction*>();
   }
 
@@ -290,8 +320,9 @@ HorizontalLoopFusionImpl::FusionCandidates::GetNextSpanOfFusions() {
       return true;
     }
 
-    accum_io_size += fusion_instrs_.at(right)->fused_parameters().size() +
-                     GetOutputSizeOfFusion(*fusion_instrs_.at(right));
+    accum_io_size += fusible_instrs_.at(right)->operand_count() +
+                     GetOutputSizeOfFusible(*fusible_instrs_.at(right));
+
 
     if (accum_io_size * 8 >= kMaxCudaParamSize) {
       return true;
@@ -302,21 +333,21 @@ HorizontalLoopFusionImpl::FusionCandidates::GetNextSpanOfFusions() {
 
   size_t left = pos_;
   size_t right = pos_ + 1;
-  size_t first_output_size = GetOutputSizeOfFusion(*fusion_instrs_[left]);
+  size_t first_output_size = GetOutputSizeOfFusible(*fusible_instrs_[left]);
   PrimitiveType first_output_type =
-      GetUniqueOutputTypeOfFusion(*fusion_instrs_[left]);
-  for (; right < fusion_instrs_.size(); ++right) {
+      GetUniqueOutputTypeOfFusible(*fusible_instrs_[left]);
+  for (; right < fusible_instrs_.size(); ++right) {
     PrimitiveType cur_output_type =
-        GetUniqueOutputTypeOfFusion(*fusion_instrs_[right]);
+        GetUniqueOutputTypeOfFusible(*fusible_instrs_[right]);
     if (first_output_type != cur_output_type) {
       // Cannot fuse computations who have multiple output types.
       break;
     } else if (first_output_size !=
-               GetOutputSizeOfFusion(*fusion_instrs_[right])) {
+               GetOutputSizeOfFusible(*fusible_instrs_[right])) {
       // Cannot fuse computations who have different numbers of outputs.
       break;
-    } else if (fusion_instrs_[left]->fused_instruction_count() !=
-               fusion_instrs_[right]->fused_instruction_count()) {
+    } else if (GetInstrCountOfFusible(*fusible_instrs_[left]) !=
+               GetInstrCountOfFusible(*fusible_instrs_[right])) {
       // Do not fuse computations of different instruction counts as it may
       // introduce control divergence. This is a very simple heuristic to avoid
       // fusing computations with too much discrepancy and we may improve it
@@ -329,7 +360,7 @@ HorizontalLoopFusionImpl::FusionCandidates::GetNextSpanOfFusions() {
   }
 
   pos_ = right;
-  return absl::MakeSpan(fusion_instrs_).subspan(left, right - left);
+  return absl::MakeSpan(fusible_instrs_).subspan(left, right - left);
 }
 
 Status HorizontalLoopFusionImpl::CreateFusedComputation(
@@ -395,11 +426,11 @@ Status HorizontalLoopFusionImpl::CreateFusedComputation(
   // Since we require each fusion to have the same number of outputs, we can
   // simply use the first fusion as the representative for output size.
   size_t fused_instr_output_size =
-      GetOutputSizeOfFusion(*fused_fusion_instrs[0]);
+      GetOutputSizeOfFusible(*fused_fusion_instrs[0]);
   for (size_t i = 0; i < fused_instr_output_size; ++i) {
     std::vector<HloInstruction*> reshapes(fused_fusion_instrs.size());
     for (size_t j = 0; j < fused_fusion_instrs.size(); ++j) {
-      auto old_output = GetOutputsOfFusion(*fused_fusion_instrs[j])[i];
+      auto old_output = GetOutputsOfFusible(*fused_fusion_instrs[j])[i];
       auto new_output = clone_map[old_output];
       TF_ASSIGN_OR_RETURN(
           reshapes[j],
@@ -421,7 +452,7 @@ Status HorizontalLoopFusionImpl::CreateFusedComputation(
     int64 slice_start = 0;
     // Create a slice per fused computation.
     for (size_t j = 0; j < fused_fusion_instrs.size(); ++j) {
-      auto old_output = GetOutputsOfFusion(*fused_fusion_instrs[j])[i];
+      auto old_output = GetOutputsOfFusible(*fused_fusion_instrs[j])[i];
       auto shape = old_output->shape();
       int64 slice_limit = slice_start + ShapeUtil::ElementsIn(shape);
       TF_ASSIGN_OR_RETURN(
@@ -463,9 +494,9 @@ Status HorizontalLoopFusionImpl::Fuse(
   for (size_t i = 0; i < fused_fusion_instrs.size(); ++i) {
     std::vector<HloInstruction*> bitcasts;
     auto fused_instr = fused_fusion_instrs[i];
-    auto num_outputs = GetOutputSizeOfFusion(*fused_instr);
+    auto num_outputs = GetOutputSizeOfFusible(*fused_instr);
     for (size_t j = 0; j < num_outputs; ++j) {
-      auto output = GetOutputsOfFusion(*fused_instr)[j];
+      auto output = GetOutputsOfFusible(*fused_instr)[j];
       TF_ASSIGN_OR_RETURN(auto gep, MakeGetTupleElementHlo(hori_fusion_instr,
                                                            total_output_id++));
       bitcasts.push_back(computation_->AddInstruction(
@@ -493,16 +524,26 @@ StatusOr<bool> HorizontalLoopFusionImpl::Run() {
     auto consumer = def_to_use_order[i];
     HorizontalLoopFusionImpl::FusionCandidates fusion_candidates(consumer);
     while (true) {
-      auto fusions = fusion_candidates.GetNextSpanOfFusions();
-      if (fusions.empty()) {
+      auto fusibles = fusion_candidates.GetNextSpanOfFusions();
+      if (fusibles.empty()) {
         break;
-      } else if (fusions.size() == 1) {
+      } else if (fusibles.size() == 1) {
         // Skip; there is just one fused_instr.
         continue;
       }
 
       changed = true;
-      TF_RETURN_IF_ERROR(Fuse(fusions));
+      // Convert fusible into fusion_instrs to simplify the implementation of
+      // `Fuse()`.
+      std::vector<HloInstruction*> fusion_instrs;
+      for (auto instr : fusibles) {
+        if (instr->opcode() == HloOpcode::kFusion) {
+          fusion_instrs.push_back(instr);
+        } else {
+          fusion_instrs.push_back(MakeLoopFusionInstruction(instr));
+        }
+      }
+      TF_RETURN_IF_ERROR(Fuse(absl::MakeSpan(fusion_instrs)));
     }
   }
 
@@ -520,9 +561,9 @@ StatusOr<bool> GpuHorizontalLoopFusion::RunOnComputation(
 StatusOr<bool> GpuHorizontalLoopFusion::Run(HloModule* module) {
   bool changed = false;
   VLOG(2) << "Run horizontal fusion.";
-  for (auto* comp : module->MakeNonfusionComputations()) {
-    TF_ASSIGN_OR_RETURN(changed, RunOnComputation(comp));
-  }
+
+  // Run on the entry computation is actually enough.
+  TF_ASSIGN_OR_RETURN(changed, RunOnComputation(module->entry_computation()));
 
   return changed;
 }

--- a/tensorflow/compiler/xla/service/gpu/horizontal_loop_fusion.cc
+++ b/tensorflow/compiler/xla/service/gpu/horizontal_loop_fusion.cc
@@ -349,7 +349,7 @@ Status HorizontalLoopFusionImpl::CreateFusedComputation(
   HloComputation* comp = uniq_computation->get();
 
   // Preparing clone_map, which maps old operand to new operand.
-  absl::flat_hash_map<HloInstruction*, HloInstruction*> clone_map;
+  absl::flat_hash_map<const HloInstruction*, HloInstruction*> clone_map;
   size_t new_param_id = 0;
   for (size_t i = 0; i < fused_fusion_instrs.size(); ++i) {
     auto old_params = fused_fusion_instrs[i]->fused_parameters();
@@ -389,7 +389,7 @@ Status HorizontalLoopFusionImpl::CreateFusedComputation(
   for (size_t i = 0; i < fused_instr_output_size; ++i) {
     std::vector<HloInstruction*> reshapes(fused_fusion_instrs.size());
     for (size_t j = 0; j < fused_fusion_instrs.size(); ++j) {
-      HloInstruction* old_output =
+      const HloInstruction* old_output =
           GetOutputsOfFusible(*fused_fusion_instrs[j])[i];
       HloInstruction* new_output = clone_map[old_output];
       TF_ASSIGN_OR_RETURN(
@@ -413,7 +413,7 @@ Status HorizontalLoopFusionImpl::CreateFusedComputation(
     int64 slice_start = 0;
     // Create a slice per fused computation.
     for (size_t j = 0; j < fused_fusion_instrs.size(); ++j) {
-      HloInstruction* old_output =
+      const HloInstruction* old_output =
           GetOutputsOfFusible(*fused_fusion_instrs[j])[i];
       Shape shape = old_output->shape();
       int64 slice_limit = slice_start + ShapeUtil::ElementsIn(shape);
@@ -459,7 +459,7 @@ Status HorizontalLoopFusionImpl::Fuse(
     HloInstruction* fused_instr = fused_fusion_instrs[i];
     size_t num_outputs = GetOutputSizeOfFusible(*fused_instr);
     for (size_t j = 0; j < num_outputs; ++j) {
-      HloInstruction* output = GetOutputsOfFusible(*fused_instr)[j];
+      const HloInstruction* output = GetOutputsOfFusible(*fused_instr)[j];
       TF_ASSIGN_OR_RETURN(
           HloInstruction * gep,
           MakeGetTupleElementHlo(hori_fusion_instr, total_output_id++));

--- a/tensorflow/compiler/xla/service/hlo_creation_utils.cc
+++ b/tensorflow/compiler/xla/service/hlo_creation_utils.cc
@@ -564,6 +564,15 @@ HloInstruction* BroadcastOnes(HloComputation* computation,
                           /*result_shape_bounds=*/broadcast_dimensions);
 }
 
+StatusOr<HloInstruction*> MakeFusionInstruction(
+    HloInstruction* fused, HloInstruction::FusionKind kind) {
+  HloComputation* comp = fused->parent();
+  HloInstruction* fusion_instruction = comp->AddInstruction(
+      HloInstruction::CreateFusion(fused->shape(), kind, fused));
+  TF_RETURN_IF_ERROR(comp->ReplaceInstruction(fused, fusion_instruction));
+  return fusion_instruction;
+}
+
 // Recursively creates a dummy op given a shape. Leaf nodes are broadcasted zero
 // while internal nodes are tuples.
 HloInstruction* CreateDummyOp(HloComputation::Builder* b, const Shape& shape) {

--- a/tensorflow/compiler/xla/service/hlo_creation_utils.h
+++ b/tensorflow/compiler/xla/service/hlo_creation_utils.h
@@ -219,6 +219,11 @@ HloInstruction* MakeScalarLike(HloInstruction* base, NativeT value) {
       HloInstruction::CreateBroadcast(base->shape(), scalar, {}));
 }
 
+// Creates a fusion instruction and fuses `fused` into the created fusion
+// instruction.
+StatusOr<HloInstruction*> MakeFusionInstruction(
+    HloInstruction* fused, HloInstruction::FusionKind kind);
+
 // -----------------------------------------------------------------------------
 // Some other miscellaneous helpers to generate common HLO patterns.  All of
 // these add all the instructions they generate into the computation containing


### PR DESCRIPTION
1. Extend horizontal fusion to support non-fusion instructions.
2. Enable iterative optimization for horizontal fusion. After each iteration,
   new horizontal fusion opportunities are exposed because the producers to
   the previously generated horizontally fused instructions will become
   fusion candidates. See `IterativeHorizontalFusion` in the unittest as an example.