### PR TITLE
[CHerryPick:r2.5] Keras Training API: Make sure to update the stateful metrics in the Progbar once the MetricsContainer is built so the metrics are not averaged over an epoch.

### DIFF
--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -974,7 +974,7 @@ class ProgbarLogger(Callback):
     else:
       raise ValueError('Unknown `count_mode`: ' + str(count_mode))
     # Defaults to all Model's metrics except for loss.
-    self.stateful_metrics = set(stateful_metrics) if stateful_metrics else None
+    self.stateful_metrics = set(stateful_metrics) if stateful_metrics else set()
 
     self.seen = 0
     self.progbar = None
@@ -1051,11 +1051,17 @@ class ProgbarLogger(Callback):
     self.progbar = None
 
   def _maybe_init_progbar(self):
-    if self.stateful_metrics is None:
-      if self.model:
-        self.stateful_metrics = set(m.name for m in self.model.metrics)
-      else:
-        self.stateful_metrics = set()
+    """Instantiate a `Progbar` if not yet, and update the stateful metrics."""
+    # TODO(rchao): Legacy TF1 code path may use list for
+    # `self.stateful_metrics`. Remove "cast to set" when TF1 support is dropped.
+    self.stateful_metrics = set(self.stateful_metrics)
+
+    if self.model:
+      # Update the existing stateful metrics as `self.model.metrics` may contain
+      # updated metrics after `MetricsContainer` is built in the first train
+      # step.
+      self.stateful_metrics = self.stateful_metrics.union(
+          set(m.name for m in self.model.metrics))
 
     if self.progbar is None:
       self.progbar = Progbar(
@@ -1063,6 +1069,8 @@ class ProgbarLogger(Callback):
           verbose=self.verbose,
           stateful_metrics=self.stateful_metrics,
           unit_name='step' if self.use_steps else 'sample')
+
+    self.progbar._update_stateful_metrics(self.stateful_metrics)  # pylint: disable=protected-access
 
   def _implements_train_batch_hooks(self):
     return self._call_batch_hooks

--- a/tensorflow/python/keras/callbacks_test.py
+++ b/tensorflow/python/keras/callbacks_test.py
@@ -34,6 +34,7 @@ from tensorflow.python import keras
 from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.data.ops import readers
 from tensorflow.python.eager import context
+from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import random_seed
 from tensorflow.python.keras import keras_parameterized
@@ -263,7 +264,8 @@ class CallbackCountsTest(keras_parameterized.TestCase):
 
 class KerasCallbacksTest(keras_parameterized.TestCase):
 
-  def _get_model(self, input_shape=None):
+  def _get_model(self, input_shape=None, additional_metrics=None):
+    additional_metrics = additional_metrics or []
     layers = [
         keras.layers.Dense(3, activation='relu'),
         keras.layers.Dense(2, activation='softmax')
@@ -272,7 +274,8 @@ class KerasCallbacksTest(keras_parameterized.TestCase):
     model.compile(
         loss='mse',
         optimizer='rmsprop',
-        metrics=[keras.metrics.CategoricalAccuracy(name='my_acc')],
+        metrics=[keras.metrics.CategoricalAccuracy(name='my_acc')] +
+        additional_metrics,
         run_eagerly=testing_utils.should_run_eagerly())
     return model
 
@@ -289,6 +292,45 @@ class KerasCallbacksTest(keras_parameterized.TestCase):
     with self.captureWritesToStream(sys.stdout) as printed:
       model.fit(dataset, epochs=2, steps_per_epoch=10)
       self.assertRegex(printed.contents(), expected_log)
+
+  @keras_parameterized.run_with_all_model_types
+  @keras_parameterized.run_all_keras_modes
+  def test_progbar_logging_with_stateful_metrics(self):
+
+    class AddAllOnes(keras.metrics.Metric):
+      """A simple metric that adds all the one's in `y_true`."""
+
+      def __init__(self, name='add_all_ones', **kwargs):
+        super(AddAllOnes, self).__init__(name=name, **kwargs)
+        self.total = self.add_weight(name='total', initializer='zeros')
+
+      def update_state(self, y_true, y_pred, sample_weight=None):
+        self.total.assign_add(
+            math_ops.cast(math_ops.reduce_sum(y_true), dtype=dtypes.float32))
+
+      def result(self):
+        return self.total
+
+    x_train = np.array([[0, 1, 0, 1, 0, 1, 0, 1]] * 8).astype(float)
+    y_train = np.array([[1, 0], [0, 0], [1, 1], [1, 0], [0, 1], [1, 0], [1, 0],
+                        [0, 0]])
+    # There are 7 ones in total in `y_train` after two batches.
+    expected_log = r'(.*- loss:.*- my_acc:.*- add_all_ones: 7.0000)+'
+
+    with self.captureWritesToStream(sys.stdout) as printed:
+      model = self._get_model(
+          input_shape=(8,), additional_metrics=[AddAllOnes()])
+      model.fit(x_train, y_train, verbose=1, batch_size=4, shuffle=False)
+      self.assertRegex(printed.contents(), expected_log)
+
+    # When not executing eagerly, `model.evaluate` does not have the metrics
+    # results printed.
+    if context.executing_eagerly():
+      with self.captureWritesToStream(sys.stdout) as printed:
+        model = self._get_model(
+            input_shape=(8,), additional_metrics=[AddAllOnes()])
+        model.evaluate(x_train, y_train, verbose=1, batch_size=4)
+        self.assertRegex(printed.contents(), expected_log)
 
   @keras_parameterized.run_all_keras_modes
   def test_trivial_backup_restore(self):

--- a/tensorflow/python/keras/utils/generic_utils.py
+++ b/tensorflow/python/keras/utils/generic_utils.py
@@ -1019,6 +1019,9 @@ class Progbar(object):
     else:
       return 0
 
+  def _update_stateful_metrics(self, stateful_metrics):
+    self.stateful_metrics = self.stateful_metrics.union(stateful_metrics)
+
 
 def make_batches(size, batch_size):
   """Returns a list of batch indices (tuples of indices).


### PR DESCRIPTION
Fixes https://github.com/tensorflow/tensorflow/issues/47099

Unit test element courtesy of the reporter of https://github.com/tensorflow/tensorflow/issues/47099.

PiperOrigin-RevId: 369572207
Change-Id: I308fcccac5164ab92a70e74d27ecd0f0cbba275a