### PR TITLE
Updated dso_loader.cc, removed redundant log

### DIFF
--- a/tensorflow/stream_executor/platform/default/dso_loader.cc
+++ b/tensorflow/stream_executor/platform/default/dso_loader.cc
@@ -50,7 +50,7 @@ port::StatusOr<void*> GetDsoHandle(const string& name, const string& version) {
   port::Status status =
       port::Env::Default()->LoadDynamicLibrary(filename.c_str(), &dso_handle);
   if (status.ok()) {
-    VLOG(1) << "Successfully opened dynamic library " << filename;
+    
     return dso_handle;
   }
 


### PR DESCRIPTION
Removed `VLOG(1) << "Successfully opened dynamic library " << filename;` because it was annoying. No reason to log loading libcudart successfully. 

Fix for issue referenced in Issue #45214 