### PR TITLE
[Cherrypicke:2.5]Disable pad_op_test for macos. Test times out during 2.5 release

### DIFF
--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -2359,6 +2359,7 @@ cuda_py_test(
     name = "pad_op_test",
     size = "small",
     srcs = ["pad_op_test.py"],
+    tags = ["no_mac"],  # test is times out on mac b/186262388
     xla_tags = [
         "no_cuda_asan",  # times out
     ],


### PR DESCRIPTION
PiperOrigin-RevId: 370178263
Change-Id: I57989213810709d73d9e503b40b0f871e9006a05