### PR TITLE
Remove deprecated operations in the datasets

### DIFF
--- a/tensorflow/python/keras/datasets/imdb.py
+++ b/tensorflow/python/keras/datasets/imdb.py
@@ -152,8 +152,10 @@ def load_data(path='imdb.npz',
     xs = [[w for w in x if skip_top <= w < num_words] for x in xs]
 
   idx = len(x_train)
-  x_train, y_train = np.array(xs[:idx], dtype="object"), np.array(labels[:idx], dtype="object")
-  x_test, y_test = np.array(xs[idx:], dtype="object"), np.array(labels[idx:], dtype="object")
+  x_train = np.array(xs[:idx], dtype="object")
+  y_train = np.array(labels[:idx], dtype="object")
+  x_test = np.array(xs[idx:], dtype="object")
+  y_test = np.array(labels[idx:], dtype="object")
 
   return (x_train, y_train), (x_test, y_test)
 

--- a/tensorflow/python/keras/datasets/imdb.py
+++ b/tensorflow/python/keras/datasets/imdb.py
@@ -152,8 +152,8 @@ def load_data(path='imdb.npz',
     xs = [[w for w in x if skip_top <= w < num_words] for x in xs]
 
   idx = len(x_train)
-  x_train, y_train = np.array(xs[:idx]), np.array(labels[:idx])
-  x_test, y_test = np.array(xs[idx:]), np.array(labels[idx:])
+  x_train, y_train = np.array(xs[:idx], dtype="object"), np.array(labels[:idx], dtype="object")
+  x_test, y_test = np.array(xs[idx:], dtype="object"), np.array(labels[idx:], dtype="object")
 
   return (x_train, y_train), (x_test, y_test)
 

--- a/tensorflow/python/keras/datasets/reuters.py
+++ b/tensorflow/python/keras/datasets/reuters.py
@@ -140,8 +140,8 @@ def load_data(path='reuters.npz',
     xs = [[w for w in x if skip_top <= w < num_words] for x in xs]
 
   idx = int(len(xs) * (1 - test_split))
-  x_train, y_train = np.array(xs[:idx]), np.array(labels[:idx])
-  x_test, y_test = np.array(xs[idx:]), np.array(labels[idx:])
+  x_train, y_train = np.array(xs[:idx], dtype="object"), np.array(labels[:idx], dtype="object")
+  x_test, y_test = np.array(xs[idx:], dtype="object"), np.array(labels[idx:], dtype="object")
 
   return (x_train, y_train), (x_test, y_test)
 

--- a/tensorflow/python/keras/datasets/reuters.py
+++ b/tensorflow/python/keras/datasets/reuters.py
@@ -140,9 +140,10 @@ def load_data(path='reuters.npz',
     xs = [[w for w in x if skip_top <= w < num_words] for x in xs]
 
   idx = int(len(xs) * (1 - test_split))
-  x_train, y_train = np.array(xs[:idx], dtype="object"), np.array(labels[:idx], dtype="object")
-  x_test, y_test = np.array(xs[idx:], dtype="object"), np.array(labels[idx:], dtype="object")
-
+  x_train = np.array(xs[:idx], dtype="object")
+  y_train = np.array(labels[:idx], dtype="object")
+  x_test = np.array(xs[idx:], dtype="object")
+  y_test = np.array(labels[idx:], dtype="object")
   return (x_train, y_train), (x_test, y_test)
 
 


### PR DESCRIPTION
In reuters.py and imdb.py, there are ndarray creations with ragged
array, but it's deprecated now. So I added parameter "dtype" to them.