### PR TITLE
Update jsoncpp to 1.9.4

### DIFF
--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -694,12 +694,12 @@ def _tf_repositories():
     tf_http_archive(
         name = "jsoncpp_git",
         build_file = "//third_party:jsoncpp.BUILD",
-        sha256 = "77a402fb577b2e0e5d0bdc1cf9c65278915cdb25171e3452c68b6da8a561f8f0",
-        strip_prefix = "jsoncpp-1.9.2",
+        sha256 = "e34a628a8142643b976c7233ef381457efad79468c67cb1ae0b83a33d7493999",
+        strip_prefix = "jsoncpp-1.9.4",
         system_build_file = "//third_party/systemlibs:jsoncpp.BUILD",
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/open-source-parsers/jsoncpp/archive/1.9.2.tar.gz",
-            "https://github.com/open-source-parsers/jsoncpp/archive/1.9.2.tar.gz",
+            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/open-source-parsers/jsoncpp/archive/1.9.4.tar.gz",
+            "https://github.com/open-source-parsers/jsoncpp/archive/1.9.4.tar.gz",
         ],
     )
 

--- a/third_party/jsoncpp.BUILD
+++ b/third_party/jsoncpp.BUILD
@@ -13,7 +13,6 @@ cc_library(
     ],
     hdrs = [
         "include/json/allocator.h",
-        "include/json/autolink.h",
         "include/json/config.h",
         "include/json/forwards.h",
         "include/json/json.h",


### PR DESCRIPTION
The jsoncpp version in tensorflow was 1.9.2 which was almost 2 years
old. This PR updates the jsoncpp to 1.9.4 which consists of OSS-Fuzz
fixes (https://github.com/open-source-parsers/jsoncpp/releases/tag/1.9.4)
that is worth updating.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>