### PR TITLE
Fix/stm32f746 examples

### DIFF
--- a/tensorflow/lite/micro/examples/hello_world/README.md
+++ b/tensorflow/lite/micro/examples/hello_world/README.md
@@ -462,13 +462,13 @@ command to generate a subfolder containing the required source files in this
 structure:
 
 ```
-make -f tensorflow/lite/micro/tools/make/Makefile TARGET=mbed TAGS="CMSIS disco_f746ng" generate_hello_world_mbed_project
+make -f tensorflow/lite/micro/tools/make/Makefile TARGET=disco_f746ng OPTIMIZED_KERNEL_DIR=cmsis_nn generate_hello_world_mbed_project
 ```
 
 This will result in the creation of a new folder:
 
 ```
-tensorflow/lite/micro/tools/make/gen/mbed_cortex-m4/prj/hello_world/mbed
+tensorflow/lite/micro/tools/make/gen/disco_f746ng_cortex-m4_default/prj/hello_world/mbed
 ```
 
 This folder contains all of the example's dependencies structured in the correct

--- a/tensorflow/lite/micro/examples/hello_world/README.md
+++ b/tensorflow/lite/micro/examples/hello_world/README.md
@@ -454,8 +454,8 @@ Before we begin, you'll need the following:
 
 - STM32F7 discovery kit board
 - Mini-USB cable
-- ARM Mbed CLI ([installation instructions](https://os.mbed.com/docs/mbed-os/v5.12/tools/installation-and-setup.html). Check it out for MacOS Catalina - [mbed-cli is broken on MacOS Catalina #930](https://github.com/ARMmbed/mbed-cli/issues/930#issuecomment-660550734))
-- Python 2.7 and pip
+- ARM Mbed CLI ([installation instructions](https://os.mbed.com/docs/mbed-os/v6.9/quick-start/build-with-mbed-cli.html). Check it out for MacOS Catalina - [mbed-cli is broken on MacOS Catalina #930](https://github.com/ARMmbed/mbed-cli/issues/930#issuecomment-660550734))
+- Python 3 and pip3
 
 Since Mbed requires a special folder structure for projects, we'll first run a
 command to generate a subfolder containing the required source files in this
@@ -474,8 +474,7 @@ tensorflow/lite/micro/tools/make/gen/disco_f746ng_cortex-m4_default/prj/hello_wo
 This folder contains all of the example's dependencies structured in the correct
 way for Mbed to be able to build it.
 
-Change into the directory and run the following commands, making sure you are
-using Python 2.7.15.
+Change into the directory and run the following commands.
 
 First, tell Mbed that the current directory is the root of an Mbed project:
 
@@ -489,15 +488,15 @@ Next, tell Mbed to download the dependencies and prepare to build:
 mbed deploy
 ```
 
-By default, Mbed will build the project using C++98. However, TensorFlow Lite
-requires C++11. Run the following Python snippet to modify the Mbed
+Older versions of Mbed will build the project using C++98. However, TensorFlow Lite
+requires C++11. If needed, run the following Python snippet to modify the Mbed
 configuration files so that it uses C++11:
 
 ```
 python -c 'import fileinput, glob;
 for filename in glob.glob("mbed-os/tools/profiles/*.json"):
   for line in fileinput.input(filename, inplace=True):
-    print line.replace("\"-std=gnu++98\"","\"-std=c++11\", \"-fpermissive\"")'
+    print(line.replace("\"-std=gnu++98\"","\"-std=c++11\", \"-fpermissive\""))'
 
 ```
 

--- a/tensorflow/lite/micro/examples/hello_world/README.md
+++ b/tensorflow/lite/micro/examples/hello_world/README.md
@@ -500,6 +500,14 @@ for filename in glob.glob("mbed-os/tools/profiles/*.json"):
 
 ```
 
+Note: Mbed has a dependency to an old version of arm_math.h and cmsis_gcc.h (adapted from the general [CMSIS-NN MBED example](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/micro/kernels/cmsis_nn#example-2---mbed)). Therefore you need to copy the newer version as follows:
+```bash
+cp tensorflow/lite/micro/tools/make/downloads/cmsis/CMSIS/DSP/Include/\
+arm_math.h mbed-os/cmsis/TARGET_CORTEX_M/arm_math.h
+cp tensorflow/lite/micro/tools/make/downloads/cmsis/CMSIS/Core/Include/\
+cmsis_gcc.h mbed-os/cmsis/TARGET_CORTEX_M/cmsis_gcc.h
+```
+
 Finally, run the following command to compile:
 
 ```

--- a/tensorflow/lite/micro/examples/hello_world/disco_f746ng/Makefile.inc
+++ b/tensorflow/lite/micro/examples/hello_world/disco_f746ng/Makefile.inc
@@ -1,5 +1,5 @@
 # Settings for the Discovery STM32F746NG board.
-ifneq ($(filter disco_f746ng,$(ALL_TAGS)),)
+ifeq ($(TARGET), disco_f746ng)
   hello_world_MBED_PROJECT_FILES += \
     BSP_DISCO_F746NG.lib \
     LCD_DISCO_F746NG.lib

--- a/tensorflow/lite/micro/examples/micro_speech/README.md
+++ b/tensorflow/lite/micro/examples/micro_speech/README.md
@@ -407,8 +407,8 @@ Before we begin, you'll need the following:
 
 - STM32F7 discovery kit board
 - Mini-USB cable
-- ARM Mbed CLI ([installation instructions](https://os.mbed.com/docs/mbed-os/v5.12/tools/installation-and-setup.html). Check it out for MacOS Catalina - [mbed-cli is broken on MacOS Catalina #930](https://github.com/ARMmbed/mbed-cli/issues/930#issuecomment-660550734))
-- Python 2.7 and pip
+- ARM Mbed CLI ([installation instructions](https://os.mbed.com/docs/mbed-os/v6.9/quick-start/build-with-mbed-cli.html). Check it out for MacOS Catalina - [mbed-cli is broken on MacOS Catalina #930](https://github.com/ARMmbed/mbed-cli/issues/930#issuecomment-660550734))
+- Python 3 and pip3
 
 Since Mbed requires a special folder structure for projects, we'll first run a
 command to generate a subfolder containing the required source files in this
@@ -427,8 +427,7 @@ tensorflow/lite/micro/tools/make/gen/disco_f746ng_cortex-m4_default/prj/micro_sp
 This folder contains all of the example's dependencies structured in the correct
 way for Mbed to be able to build it.
 
-Change into the directory and run the following commands, making sure you are
-using Python 2.7.15.
+Change into the directory and run the following commands.
 
 First, tell Mbed that the current directory is the root of an Mbed project:
 
@@ -442,15 +441,15 @@ Next, tell Mbed to download the dependencies and prepare to build:
 mbed deploy
 ```
 
-By default, Mbed will build the project using C++98. However, TensorFlow Lite
-requires C++11. Run the following Python snippet to modify the Mbed
+Older versions of Mbed will build the project using C++98. However, TensorFlow Lite
+requires C++11. If needed, run the following Python snippet to modify the Mbed
 configuration files so that it uses C++11:
 
 ```
 python -c 'import fileinput, glob;
 for filename in glob.glob("mbed-os/tools/profiles/*.json"):
   for line in fileinput.input(filename, inplace=True):
-    print line.replace("\"-std=gnu++98\"","\"-std=c++11\", \"-fpermissive\"")'
+    print(line.replace("\"-std=gnu++98\"","\"-std=c++11\", \"-fpermissive\""))'
 
 ```
 

--- a/tensorflow/lite/micro/examples/micro_speech/README.md
+++ b/tensorflow/lite/micro/examples/micro_speech/README.md
@@ -450,7 +450,14 @@ python -c 'import fileinput, glob;
 for filename in glob.glob("mbed-os/tools/profiles/*.json"):
   for line in fileinput.input(filename, inplace=True):
     print(line.replace("\"-std=gnu++98\"","\"-std=c++11\", \"-fpermissive\""))'
+```
 
+Note: Mbed has a dependency to an old version of arm_math.h and cmsis_gcc.h (adapted from the general [CMSIS-NN MBED example](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/micro/kernels/cmsis_nn#example-2---mbed)). Therefore you need to copy the newer version as follows:
+```bash
+cp tensorflow/lite/micro/tools/make/downloads/cmsis/CMSIS/DSP/Include/\
+arm_math.h mbed-os/cmsis/TARGET_CORTEX_M/arm_math.h
+cp tensorflow/lite/micro/tools/make/downloads/cmsis/CMSIS/Core/Include/\
+cmsis_gcc.h mbed-os/cmsis/TARGET_CORTEX_M/cmsis_gcc.h
 ```
 
 Finally, run the following command to compile:


### PR DESCRIPTION
This PR updates the mbed project generation for the hello_world and micro_speech examples for the disco_f746ng board. Based on a [recent PR](https://github.com/tensorflow/tensorflow/pull/48659) addressing [this issue](https://github.com/tensorflow/tensorflow/issues/46721) regarding "the TAGS command line option is no longer supported in the TFLM Makefile". 