### PR TITLE
_init_profile_batch docstring specifies wrong return

### DIFF
--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -2341,15 +2341,14 @@ class TensorBoard(Callback, version_utils.TensorBoardVersionSelector):
 
   def _init_profile_batch(self, profile_batch):
     """Validate profile_batch value and set the range of batches to profile.
+    Sets values of _start_batch and _stop_batch attributes,
+    specifying the start and stop batch to profile.
+    Setting `profile_batch=0` disables profiling.
 
     Args:
       profile_batch: The range of batches to profile. Should be a non-negative
         integer or a comma separated string of pair of positive integers. A pair
         of positive integers signify a range of batches to profile.
-
-    Returns:
-      A pair of non-negative integers specifying the start and stop batch to
-      profile.
 
     Raises:
       ValueError: If profile_batch is not an integer or a comma seperated pair


### PR DESCRIPTION
Existing documentation describes method as returning
a pair of integers, while it actually sets values of the object attributes.

This can be potentially confusing. Docstring was updated to describe
an actual state of the method.

Added mention of special behavior encountered when profile_batch=0.

Signed-off-by: Jiri Podivin <jpodivin@gmail.com>