### PR TITLE
Fix the TFLM github bazel CI.

### DIFF
--- a/tensorflow/lite/micro/tools/ci_build/tflm_bazel/tensorflow.bzl
+++ b/tensorflow/lite/micro/tools/ci_build/tflm_bazel/tensorflow.bzl
@@ -16,6 +16,9 @@ tf_cc_test = cc_test
 def py_test(deps = [], data = [], kernels = [], exec_properties = None, **kwargs):
     pass
 
+def pybind_extension(**kwargs):
+  pass
+
 def if_not_windows(a):
     return select({
         clean_dep("//tensorflow:windows"): [],


### PR DESCRIPTION
We use only a subset of the Skylark functions to keep the TFLM bazel build quick enough to be run as part of CI. As a result, the bazel CI can be broken when additional Skylark functions are used in the BUILD files that are shared between Lite and Micro.

In the case of the current breakage, https://github.com/tensorflow/tensorflow/commit/05addf893ca52dc3ddfa0a28e7b50d46c96b09fe added `pybind_extension` to `lite/kernels/BUILD` and the current PR creates an empty stub implementation of `pybind_extension`.