### PR TITLE
[Pluggable Device] Fix the MacOS regression for registering Pluggable…

### DIFF
--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -939,6 +939,7 @@ tf_cc_shared_object(
         "//tensorflow/core/common_runtime:core_cpu_impl",
         "//tensorflow/core:framework_internal_impl",
         "//tensorflow/core/common_runtime/gpu:gpu_runtime_impl",
+        "//tensorflow/core/common_runtime/pluggable_device:pluggable_device_runtime_impl",
         "//tensorflow/core/grappler/optimizers:custom_graph_optimizer_registry_impl",
         "//tensorflow/core:lib_internal_impl",
         "//tensorflow/core/profiler:profiler_impl",

--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -939,7 +939,6 @@ tf_cc_shared_object(
         "//tensorflow/core/common_runtime:core_cpu_impl",
         "//tensorflow/core:framework_internal_impl",
         "//tensorflow/core/common_runtime/gpu:gpu_runtime_impl",
-        "//tensorflow/core/common_runtime/pluggable_device:pluggable_device_runtime_impl",
         "//tensorflow/core/grappler/optimizers:custom_graph_optimizer_registry_impl",
         "//tensorflow/core:lib_internal_impl",
         "//tensorflow/core/profiler:profiler_impl",

--- a/tensorflow/core/common_runtime/pluggable_device/BUILD
+++ b/tensorflow/core/common_runtime/pluggable_device/BUILD
@@ -43,7 +43,6 @@ cc_library(
         ":pluggable_device_simple_allocator",
         "//tensorflow/c/experimental/stream_executor",
         "//tensorflow/c/experimental/stream_executor:stream_executor_internal",
-        "//tensorflow/core:core_cpu",
         "//tensorflow/core:core_cpu_lib",
         "//tensorflow/core:framework",
         "//tensorflow/core:framework_internal",
@@ -54,8 +53,6 @@ cc_library(
         "//tensorflow/core/common_runtime/device:device_event_mgr",
         "//tensorflow/core/platform:stream_executor",
         "//tensorflow/core/platform:tensor_float_32_utils",
-        "//tensorflow/stream_executor:event",
-        "//tensorflow/stream_executor:kernel",
     ],
     alwayslink = 1,
 )
@@ -74,25 +71,8 @@ cc_library(
     deps = [
         "//tensorflow/c/experimental/grappler",
         "//tensorflow/c/experimental/stream_executor",
-        "//tensorflow/c/experimental/stream_executor:stream_executor_internal",
-        "//tensorflow/core:core_cpu",
-        "//tensorflow/core:framework",
-        "//tensorflow/core:lib",
-        "//tensorflow/core:lib_internal",
-        "//tensorflow/core:protos_all_cc",
-        "//tensorflow/core/common_runtime:bfc_allocator",
-        "//tensorflow/core/common_runtime:dma_helper",
-        "//tensorflow/core/common_runtime:local_device",
-        "//tensorflow/core/common_runtime:process_state",
-        "//tensorflow/core/common_runtime:shared_counter",
-        "//tensorflow/core/platform:stream_executor",
-        "//tensorflow/stream_executor:event",
-        "//tensorflow/stream_executor:kernel",
-    ] + if_static([
-        # Temporary workaround for duplicated symbols issues.
         ":pluggable_device_runtime_impl",
-        "//tensorflow/core/common_runtime:copy_tensor",
-    ]),
+    ],
 )
 
 cc_library(
@@ -100,25 +80,8 @@ cc_library(
     hdrs = [":pluggable_device_runtime_headers"],
     linkstatic = 1,
     deps = [
-        "//tensorflow/core:core_cpu",
-        "//tensorflow/core:framework",
-        "//tensorflow/core:lib",
-        "//tensorflow/core:lib_internal",
-        "//tensorflow/core:protos_all_cc",
-        "//tensorflow/core/common_runtime:core_cpu",
-        "//tensorflow/core/common_runtime:dma_helper",
-        "//tensorflow/core/common_runtime:shared_counter",
-        "//tensorflow/core/lib/core:status",
-        "//tensorflow/core/platform:stream_executor",
-        "//tensorflow/stream_executor:event",
-        "//tensorflow/stream_executor:kernel",
-    ] + if_static([
-        # Temporary workaround for duplicated symbols issues.
         ":pluggable_device_runtime_impl",
-        "//tensorflow/core/common_runtime:bfc_allocator",
-        "//tensorflow/core/common_runtime:local_device",
-        "//tensorflow/core/common_runtime:process_state",
-    ]),
+    ],
 )
 
 cc_library(

--- a/tensorflow/core/common_runtime/pluggable_device/BUILD
+++ b/tensorflow/core/common_runtime/pluggable_device/BUILD
@@ -43,6 +43,7 @@ cc_library(
         ":pluggable_device_simple_allocator",
         "//tensorflow/c/experimental/stream_executor",
         "//tensorflow/c/experimental/stream_executor:stream_executor_internal",
+        "//tensorflow/core:core_cpu",
         "//tensorflow/core:core_cpu_lib",
         "//tensorflow/core:framework",
         "//tensorflow/core:framework_internal",
@@ -53,6 +54,8 @@ cc_library(
         "//tensorflow/core/common_runtime/device:device_event_mgr",
         "//tensorflow/core/platform:stream_executor",
         "//tensorflow/core/platform:tensor_float_32_utils",
+        "//tensorflow/stream_executor:event",
+        "//tensorflow/stream_executor:kernel",
     ],
     alwayslink = 1,
 )
@@ -71,7 +74,21 @@ cc_library(
     deps = [
         "//tensorflow/c/experimental/grappler",
         "//tensorflow/c/experimental/stream_executor",
+        "//tensorflow/c/experimental/stream_executor:stream_executor_internal",
+        "//tensorflow/core:core_cpu",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:lib_internal",
+        "//tensorflow/core:protos_all_cc",
+        "//tensorflow/core/common_runtime:bfc_allocator",
+        "//tensorflow/core/common_runtime:dma_helper",
+        "//tensorflow/core/common_runtime:local_device",
+        "//tensorflow/core/common_runtime:process_state",
+        "//tensorflow/core/common_runtime:shared_counter",
+        "//tensorflow/core/platform:stream_executor",
+        "//tensorflow/stream_executor:kernel",
         ":pluggable_device_runtime_impl",
+        "//tensorflow/core/common_runtime:copy_tensor",
     ],
 )
 
@@ -80,7 +97,19 @@ cc_library(
     hdrs = [":pluggable_device_runtime_headers"],
     linkstatic = 1,
     deps = [
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:lib_internal",
+        "//tensorflow/core:protos_all_cc",
+        "//tensorflow/core/common_runtime:core_cpu",
+        "//tensorflow/core/common_runtime:dma_helper",
+        "//tensorflow/core/common_runtime:shared_counter",
+        "//tensorflow/core/platform:stream_executor",
+        "//tensorflow/stream_executor:kernel",
         ":pluggable_device_runtime_impl",
+        "//tensorflow/core/common_runtime:bfc_allocator",
+        "//tensorflow/core/common_runtime:local_device",
+        "//tensorflow/core/common_runtime:process_state",
     ],
 )
 

--- a/tensorflow/core/common_runtime/pluggable_device/BUILD
+++ b/tensorflow/core/common_runtime/pluggable_device/BUILD
@@ -86,10 +86,12 @@ cc_library(
         "//tensorflow/core/common_runtime:process_state",
         "//tensorflow/core/common_runtime:shared_counter",
         "//tensorflow/core/platform:stream_executor",
+        "//tensorflow/stream_executor:event",
         "//tensorflow/stream_executor:kernel",
         ":pluggable_device_runtime_impl",
+    ] + if_static([
         "//tensorflow/core/common_runtime:copy_tensor",
-    ],
+    ]),
 )
 
 cc_library(
@@ -97,6 +99,7 @@ cc_library(
     hdrs = [":pluggable_device_runtime_headers"],
     linkstatic = 1,
     deps = [
+        "//tensorflow/core:core_cpu",
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",
         "//tensorflow/core:lib_internal",
@@ -104,13 +107,17 @@ cc_library(
         "//tensorflow/core/common_runtime:core_cpu",
         "//tensorflow/core/common_runtime:dma_helper",
         "//tensorflow/core/common_runtime:shared_counter",
+        "//tensorflow/core/lib/core:status",
         "//tensorflow/core/platform:stream_executor",
+        "//tensorflow/stream_executor:event",
         "//tensorflow/stream_executor:kernel",
+    ] + if_static([
+        # Temporary workaround for duplicated symbols issues.
         ":pluggable_device_runtime_impl",
         "//tensorflow/core/common_runtime:bfc_allocator",
         "//tensorflow/core/common_runtime:local_device",
         "//tensorflow/core/common_runtime:process_state",
-    ],
+    ]),
 )
 
 cc_library(


### PR DESCRIPTION
Earlier[ commit in ](https://github.com/tensorflow/tensorflow/pull/45784/commits/463cad1324fcfbb082ae757484614f77bdc3929d) pluggable [impl ](https://github.com/tensorflow/tensorflow/pull/45784) seems to have caused regression on mac platforms to register pluggable device. When _pywrap_tensorflow .so loads up the plugin it goes through the device initialization fine then it hands over to libtensorflow_framework dylib to query the plugin handle using the Platform name in MultiPlatformManager . And during this part it fails with "Platform " not found. Reverting the commit fixes the problem for Mac. The change was added to fix unit tests on MacOS tests, which seem to be working with this.

@penpornk and @jzhoulon 