### PR TITLE
Limit number of parallel builds to nproc.

### DIFF
--- a/tensorflow/lite/micro/tools/ci_build/test_cortex_m_corstone_300.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_cortex_m_corstone_300.sh
@@ -33,5 +33,5 @@ readable_run make -f tensorflow/lite/micro/tools/make/Makefile OPTIMIZED_KERNEL_
 
 # Avoid running tests in parallel.
 readable_run make -f tensorflow/lite/micro/tools/make/Makefile clean
-readable_run make -j -f tensorflow/lite/micro/tools/make/Makefile OPTIMIZED_KERNEL_DIR=${OPTIMIZED_KERNEL_DIR} TARGET=${TARGET} TARGET_ARCH=${TARGET_ARCH} build
+readable_run make -j$(nproc) -f tensorflow/lite/micro/tools/make/Makefile OPTIMIZED_KERNEL_DIR=${OPTIMIZED_KERNEL_DIR} TARGET=${TARGET} TARGET_ARCH=${TARGET_ARCH} build
 readable_run make -f tensorflow/lite/micro/tools/make/Makefile OPTIMIZED_KERNEL_DIR=${OPTIMIZED_KERNEL_DIR} TARGET=${TARGET} TARGET_ARCH=${TARGET_ARCH} test


### PR DESCRIPTION
Without such a limit, running the test_cortex_m_corstone_300 script via github actions results in the ubild failing.

See https://github.com/tensorflow/tflite-micro/pull/29 for additional context.
