### PR TITLE
Clean up intermediate files from CI execution.

### DIFF
--- a/tensorflow/lite/micro/tools/ci_build/test_all.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_all.sh
@@ -24,6 +24,15 @@ ROOT_DIR=${SCRIPT_DIR}/../../../../..
 cd "${ROOT_DIR}"
 pwd
 
+# Clean up the intermediate files to avoid errors with Kokoro.
+# See http://b/186570469 for additional context.
+function cleanup() {
+  cd "${ROOT_DIR}"
+  echo "Cleaning up to prevent Kokoro errors (see http://b/186570469)"
+  make -f tensorflow/lite/micro/tools/make/Makefile clean clean_downloads DISABLE_DOWNLOADS=true
+}
+trap cleanup EXIT
+
 echo "Starting to run micro tests at `date`"
 
 make -f tensorflow/lite/micro/tools/make/Makefile clean_downloads DISABLE_DOWNLOADS=true


### PR DESCRIPTION
Manually tested that running test_all.sh when there is an error exits on the error with the proper error code, and also calls the cleanup function to delete the downloads and gen directories.

Fixes http://b/186570469
