### PR TITLE
Create .zenodo.json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,13 @@
+{
+    "description": "TensorFlow is an end-to-end open source platform for machine learning. It has a comprehensive, flexible ecosystem of tools, libraries, and community resources that lets researchers push the state-of-the-art in ML and developers easily build and deploy ML-powered applications.",
+    "license": "Apache-2.0",
+    "title": "TensorFlow",
+    "upload_type": "software",
+    "creators": [
+        {
+            "name": "TensorFlow Developers"
+        }
+    ],
+    "access_right": "open",
+    "notes": "See full list of authors on Github: https://github.com/tensorflow/tensorflow/graphs/contributors"
+}


### PR DESCRIPTION
This is for clean metadata on TensorFlow's Zenodo DOI page. It won't be used until a new full release is made (probably 2.6).