### PR TITLE
Edit CosineSimilarity documentation on metrics.py

### DIFF
--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -1922,16 +1922,16 @@ def poisson(y_true, y_pred):
     ])
 @dispatch.add_dispatch_support
 def cosine_similarity(y_true, y_pred, axis=-1):
-  """Computes the negative cosine similarity between labels and predictions.
+  """Computes the cosine similarity between labels and predictions.
 
-  Note that it is a number between -1 and 1. As -1 is multiplied,
-  values closer to -1 indicate greater similarity and 0 indicates
-  orthogonality, when it is a negative number between -1 and 0.
-  The values closer to 1 indicate greater dissimilarity. This makes
-  it usable as a loss function in a setting where you try to maximize
-  the proximity between predictions and targets. If either `y_true`
-  or `y_pred` is a zero vector, cosine similarity will be 0 regardless
-  of the proximity between predictions and targets.
+  Note that it is a number between -1 and 1. When it is a negative number
+  between -1 and 0, 0 indicates orthogonality and values closer to -1
+  indicate greater similarity. The values closer to 1 indicate greater
+  dissimilarity. This makes it usable as a loss function in a setting
+  where you try to maximize the proximity between predictions and
+  targets. If either `y_true` or `y_pred` is a zero vector, cosine
+  similarity will be 0 regardless of the proximity between predictions
+  and targets.
 
   `loss = -sum(l2_norm(y_true) * l2_norm(y_pred))`
 
@@ -1949,7 +1949,7 @@ def cosine_similarity(y_true, y_pred, axis=-1):
     axis: Axis along which to determine similarity.
 
   Returns:
-    Negative Cosine similarity tensor.
+    Cosine similarity tensor.
   """
   y_true = nn.l2_normalize(y_true, axis=axis)
   y_pred = nn.l2_normalize(y_pred, axis=axis)
@@ -1958,16 +1958,15 @@ def cosine_similarity(y_true, y_pred, axis=-1):
 
 @keras_export('keras.losses.CosineSimilarity')
 class CosineSimilarity(LossFunctionWrapper):
-  """Computes the negative cosine similarity between labels and predictions.
+  """Computes the cosine similarity between labels and predictions.
 
-  Note that it is a number between -1 and 1. As -1 is multiplied,
-  values closer to -1 indicate greater similarity and 0 indicates
-  orthogonality, when it is a negative number between -1 and 0.
-  The values closer to 1 indicate greater dissimilarity. This makes
-  it usable as a loss function in a setting where you try to maximize
-  the proximity between predictions and targets. If either `y_true`
-  or `y_pred` is a zero vector, cosine similarity will be 0 regardless
-  of the proximity between predictions and targets.
+  Note that it is a number between -1 and 1. When it is a negative number
+  between -1 and 0, 0 indicates orthogonality and values closer to -1
+  indicate greater similarity. The values closer to 1 indicate greater
+  dissimilarity. This makes it usable as a loss function in a setting
+  where you try to maximize the proximity between predictions and targets.
+  If either `y_true` or `y_pred` is a zero vector, cosine similarity will be 0
+  regardless of the proximity between predictions and targets.
 
   `loss = -sum(l2_norm(y_true) * l2_norm(y_pred))`
 

--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -1922,16 +1922,16 @@ def poisson(y_true, y_pred):
     ])
 @dispatch.add_dispatch_support
 def cosine_similarity(y_true, y_pred, axis=-1):
-  """Computes the cosine similarity between labels and predictions.
+  """Computes the negative cosine similarity between labels and predictions.
 
-  Note that it is a number between -1 and 1. When it is a negative number
-  between -1 and 0, 0 indicates orthogonality and values closer to -1
-  indicate greater similarity. The values closer to 1 indicate greater
-  dissimilarity. This makes it usable as a loss function in a setting
-  where you try to maximize the proximity between predictions and
-  targets. If either `y_true` or `y_pred` is a zero vector, cosine
-  similarity will be 0 regardless of the proximity between predictions
-  and targets.
+  Note that it is a number between -1 and 1. As -1 is multiplied,
+  values closer to -1 indicate greater similarity and 0 indicates
+  orthogonality, when it is a negative number between -1 and 0.
+  The values closer to 1 indicate greater dissimilarity. This makes
+  it usable as a loss function in a setting where you try to maximize
+  the proximity between predictions and targets. If either `y_true`
+  or `y_pred` is a zero vector, cosine similarity will be 0 regardless
+  of the proximity between predictions and targets.
 
   `loss = -sum(l2_norm(y_true) * l2_norm(y_pred))`
 
@@ -1949,7 +1949,7 @@ def cosine_similarity(y_true, y_pred, axis=-1):
     axis: Axis along which to determine similarity.
 
   Returns:
-    Cosine similarity tensor.
+    Negative Cosine similarity tensor.
   """
   y_true = nn.l2_normalize(y_true, axis=axis)
   y_pred = nn.l2_normalize(y_pred, axis=axis)
@@ -1958,15 +1958,16 @@ def cosine_similarity(y_true, y_pred, axis=-1):
 
 @keras_export('keras.losses.CosineSimilarity')
 class CosineSimilarity(LossFunctionWrapper):
-  """Computes the cosine similarity between labels and predictions.
+  """Computes the negative cosine similarity between labels and predictions.
 
-  Note that it is a number between -1 and 1. When it is a negative number
-  between -1 and 0, 0 indicates orthogonality and values closer to -1
-  indicate greater similarity. The values closer to 1 indicate greater
-  dissimilarity. This makes it usable as a loss function in a setting
-  where you try to maximize the proximity between predictions and targets.
-  If either `y_true` or `y_pred` is a zero vector, cosine similarity will be 0
-  regardless of the proximity between predictions and targets.
+  Note that it is a number between -1 and 1. As -1 is multiplied,
+  values closer to -1 indicate greater similarity and 0 indicates
+  orthogonality, when it is a negative number between -1 and 0.
+  The values closer to 1 indicate greater dissimilarity. This makes
+  it usable as a loss function in a setting where you try to maximize
+  the proximity between predictions and targets. If either `y_true`
+  or `y_pred` is a zero vector, cosine similarity will be 0 regardless
+  of the proximity between predictions and targets.
 
   `loss = -sum(l2_norm(y_true) * l2_norm(y_pred))`
 

--- a/tensorflow/python/keras/metrics.py
+++ b/tensorflow/python/keras/metrics.py
@@ -2428,8 +2428,8 @@ class CosineSimilarity(MeanMetricWrapper):
 
   Standalone usage:
 
-  >>> # l2_norm(y_true) = [[0., 1.], [1./1.414], 1./1.414]]]
-  >>> # l2_norm(y_pred) = [[1., 0.], [1./1.414], 1./1.414]]]
+  >>> # l2_norm(y_true) = [[0., 1.], [1./1.414, 1./1.414]]
+  >>> # l2_norm(y_pred) = [[1., 0.], [1./1.414, 1./1.414]]
   >>> # l2_norm(y_true) . l2_norm(y_pred) = [[0., 0.], [0.5, 0.5]]
   >>> # result = mean(sum(l2_norm(y_true) . l2_norm(y_pred), axis=1))
   >>> #        = ((0. + 0.) +  (0.5 + 0.5)) / 2


### PR DESCRIPTION
Match dimensions of input and output of `l2_norm()`.
Applied same work done on #48633 to `metrics.py`.
It would have been better if I'm informed to avoid opening similar pr.

By the way, I would like to suggest to edit comments on `cosine_similarity()` and `CosineSimilarity()` on `losses.py`.
It confuses readers because the output of "cosine similarity" is mutiplied with -1.
It should be mentioned or the comments might be misunderstood.

Phrases to be modified are:
At line 1925
`Computes the cosine similarity between labels and predictions.`   <= negative cosine similarity
At line 1951 ~ 1952
```
Returns:
    Cosine similarity tensor.                                <= negative cosine similarity
```
At line 1961
`Computes the cosine similarity between labels and predictions.`   <= negative cosine similarity
