### PR TITLE
Cadence HiFi 5 NN Library v1.5.0 integration

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv.cc
@@ -34,7 +34,7 @@ namespace {
 struct OpData {
   OpDataConv reference_op_data;
 
-#if defined(FUSION_F1)
+#if ((defined(FUSION_F1)) || (defined(HIFI5)))
   int scratch_tensor_index;
 #endif  // defined(FUSION_F1)
 };
@@ -250,7 +250,7 @@ void* Init(TfLiteContext* context, const char* buffer, size_t length) {
 TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE_OK(context, ConvPrepare(context, node));
 
-#if defined(FUSION_F1)
+#if ((defined(FUSION_F1)) || (defined(HIFI5)))
   OpData* data = static_cast<OpData*>(node->user_data);
   const auto params = static_cast<const TfLiteConvParams*>(node->builtin_data);
 
@@ -292,7 +292,7 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   return kTfLiteOk;
 }
 
-#if defined(FUSION_F1)
+#if ((defined(FUSION_F1)) || (defined(HIFI5)))
 TfLiteStatus EvalHifi4(TfLiteContext* context, TfLiteNode* node,
                        const TfLiteConvParams& params, const OpData& data,
                        const TfLiteEvalTensor* input,
@@ -470,7 +470,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
                    tflite::micro::GetTensorData<int32_t>(bias),
                    tflite::micro::GetTensorShape(output),
                    tflite::micro::GetTensorData<int8_t>(output));
-#elif defined(FUSION_F1)
+#elif ((defined(FUSION_F1)) || (defined(HIFI5)))
       EvalHifi4(context, node, params, op_data, input, filter, bias, output,
                 nullptr);
 #else

--- a/tensorflow/lite/micro/kernels/xtensa/conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/conv.cc
@@ -34,9 +34,9 @@ namespace {
 struct OpData {
   OpDataConv reference_op_data;
 
-#if ((defined(FUSION_F1)) || (defined(HIFI5)))
+#if defined(FUSION_F1) || defined(HIFI5)
   int scratch_tensor_index;
-#endif  // defined(FUSION_F1)
+#endif  // defined(FUSION_F1) || defined(HIFI5)
 };
 
 #if defined(HIFIMINI)
@@ -250,7 +250,7 @@ void* Init(TfLiteContext* context, const char* buffer, size_t length) {
 TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE_OK(context, ConvPrepare(context, node));
 
-#if ((defined(FUSION_F1)) || (defined(HIFI5)))
+#if defined(FUSION_F1) || defined(HIFI5)
   OpData* data = static_cast<OpData*>(node->user_data);
   const auto params = static_cast<const TfLiteConvParams*>(node->builtin_data);
 
@@ -288,17 +288,17 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE_OK(
       context, context->RequestScratchBufferInArena(
                    context, required_scratch, &data->scratch_tensor_index));
-#endif  // defined(FUSION_F1)
+#endif  // defined(FUSION_F1) || defined(HIFI5)
   return kTfLiteOk;
 }
 
-#if ((defined(FUSION_F1)) || (defined(HIFI5)))
-TfLiteStatus EvalHifi4(TfLiteContext* context, TfLiteNode* node,
-                       const TfLiteConvParams& params, const OpData& data,
-                       const TfLiteEvalTensor* input,
-                       const TfLiteEvalTensor* filter,
-                       const TfLiteEvalTensor* bias, TfLiteEvalTensor* output,
-                       TfLiteEvalTensor* im2col) {
+#if defined(FUSION_F1) || defined(HIFI5)
+TfLiteStatus EvalHifi(TfLiteContext* context, TfLiteNode* node,
+                      const TfLiteConvParams& params, const OpData& data,
+                      const TfLiteEvalTensor* input,
+                      const TfLiteEvalTensor* filter,
+                      const TfLiteEvalTensor* bias, TfLiteEvalTensor* output,
+                      TfLiteEvalTensor* im2col) {
   const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
   const RuntimeShape& filter_shape = tflite::micro::GetTensorShape(filter);
   /* Dilation is currently not supported on HiFi 4 NN Library */
@@ -411,7 +411,7 @@ TfLiteStatus EvalHifi4(TfLiteContext* context, TfLiteNode* node,
       tflite::micro::GetTensorData<int8_t>(output));
   return kTfLiteOk;
 }
-#endif  // defined(FUSION_F1)
+#endif  // defined(FUSION_F1) || defined(HIFI5)
 
 TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   TFLITE_DCHECK(node->user_data != nullptr);
@@ -470,9 +470,9 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
                    tflite::micro::GetTensorData<int32_t>(bias),
                    tflite::micro::GetTensorShape(output),
                    tflite::micro::GetTensorData<int8_t>(output));
-#elif ((defined(FUSION_F1)) || (defined(HIFI5)))
-      EvalHifi4(context, node, params, op_data, input, filter, bias, output,
-                nullptr);
+#elif defined(FUSION_F1) || defined(HIFI5)
+      EvalHifi(context, node, params, op_data, input, filter, bias, output,
+               nullptr);
 #else
       reference_integer_ops::ConvPerChannel(
           ConvParamsQuantized(params, op_data.reference_op_data),

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
@@ -35,7 +35,7 @@ namespace {
 struct OpData {
   OpDataConv reference_op_data;
 
-#if defined(FUSION_F1)
+#if ((defined(FUSION_F1)) || (defined (HIFI5)))
   int scratch_tensor_index;
 #endif  // defined(FUSION_F1)
 };
@@ -294,7 +294,7 @@ void* Init(TfLiteContext* context, const char* buffer, size_t length) {
 TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE_OK(context, DepthwiseConvPrepare(context, node));
 
-#if defined(FUSION_F1)
+#if ((defined(FUSION_F1)) || (defined (HIFI5)))
   OpData* data = static_cast<OpData*>(node->user_data);
   const auto& params =
       *(static_cast<const TfLiteDepthwiseConvParams*>(node->builtin_data));
@@ -344,7 +344,7 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   return kTfLiteOk;
 }
 
-#if defined(FUSION_F1)
+#if ((defined(FUSION_F1)) || (defined (HIFI5)))
 TfLiteStatus EvalHifi4(TfLiteContext* context, TfLiteNode* node,
                        const TfLiteDepthwiseConvParams& params,
                        const OpData& data, const TfLiteEvalTensor* input,
@@ -499,7 +499,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
           tflite::micro::GetTensorData<int32_t>(bias),
           tflite::micro::GetTensorShape(output),
           tflite::micro::GetTensorData<int8_t>(output));
-#elif defined(FUSION_F1)
+#elif ((defined(FUSION_F1)) || (defined (HIFI5)))
       EvalHifi4(context, node, params, op_data, input, filter, bias, output);
 #else
       reference_integer_ops::DepthwiseConvPerChannel(

--- a/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/depthwise_conv.cc
@@ -35,9 +35,9 @@ namespace {
 struct OpData {
   OpDataConv reference_op_data;
 
-#if ((defined(FUSION_F1)) || (defined (HIFI5)))
+#if defined(FUSION_F1) || defined(HIFI5)
   int scratch_tensor_index;
-#endif  // defined(FUSION_F1)
+#endif  // defined(FUSION_F1) || defined(HIFI5)
 };
 
 #if defined(HIFIMINI)
@@ -294,7 +294,7 @@ void* Init(TfLiteContext* context, const char* buffer, size_t length) {
 TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE_OK(context, DepthwiseConvPrepare(context, node));
 
-#if ((defined(FUSION_F1)) || (defined (HIFI5)))
+#if defined(FUSION_F1) || defined(HIFI5)
   OpData* data = static_cast<OpData*>(node->user_data);
   const auto& params =
       *(static_cast<const TfLiteDepthwiseConvParams*>(node->builtin_data));
@@ -340,16 +340,16 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE_OK(
       context, context->RequestScratchBufferInArena(
                    context, required_scratch, &data->scratch_tensor_index));
-#endif  // defined(FUISON_F1)
+#endif  // defined(FUISON_F1) || defined(HIFI5)
   return kTfLiteOk;
 }
 
-#if ((defined(FUSION_F1)) || (defined (HIFI5)))
-TfLiteStatus EvalHifi4(TfLiteContext* context, TfLiteNode* node,
-                       const TfLiteDepthwiseConvParams& params,
-                       const OpData& data, const TfLiteEvalTensor* input,
-                       const TfLiteEvalTensor* filter,
-                       const TfLiteEvalTensor* bias, TfLiteEvalTensor* output) {
+#if defined(FUSION_F1) || defined(HIFI5)
+TfLiteStatus EvalHifi(TfLiteContext* context, TfLiteNode* node,
+                      const TfLiteDepthwiseConvParams& params,
+                      const OpData& data, const TfLiteEvalTensor* input,
+                      const TfLiteEvalTensor* filter,
+                      const TfLiteEvalTensor* bias, TfLiteEvalTensor* output) {
   // If dilation is not required use the optimized NN Library kernel.
   // Otherwise call the reference implementation.
   if ((params.dilation_width_factor == 1) &&
@@ -439,7 +439,7 @@ TfLiteStatus EvalHifi4(TfLiteContext* context, TfLiteNode* node,
 
   return kTfLiteOk;
 }
-#endif  // defined(FUSION_F1)
+#endif  // defined(FUSION_F1) || defined(HIFI5)
 
 TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   TFLITE_DCHECK(node->user_data != nullptr);
@@ -499,8 +499,8 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
           tflite::micro::GetTensorData<int32_t>(bias),
           tflite::micro::GetTensorShape(output),
           tflite::micro::GetTensorData<int8_t>(output));
-#elif ((defined(FUSION_F1)) || (defined (HIFI5)))
-      EvalHifi4(context, node, params, op_data, input, filter, bias, output);
+#elif defined(FUSION_F1) || defined(HIFI5)
+      EvalHifi(context, node, params, op_data, input, filter, bias, output);
 #else
       reference_integer_ops::DepthwiseConvPerChannel(
           DepthwiseConvParamsQuantized(params, op_data.reference_op_data),

--- a/tensorflow/lite/micro/kernels/xtensa/softmax.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/softmax.cc
@@ -33,7 +33,7 @@ namespace {
 struct OpData {
   uint16_t* exp_lut;
 };
-#elif defined(FUSION_F1)
+#elif ((defined(FUSION_F1)) || (defined(HIFI5)))
 struct OpData {
   SoftmaxParams params;
   int scratch_tensor_index;
@@ -181,7 +181,7 @@ TfLiteStatus PrepareHifimini(TfLiteContext* context, TfLiteNode* node) {
 }
 #endif  // defined(HIFIMINI)
 
-#if defined(FUSION_F1)
+#if ((defined(FUSION_F1)) || (defined(HIFI5)))
 TfLiteStatus PrepareHifi4(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE_OK(context, SoftmaxPrepare(context, node));
 
@@ -237,7 +237,7 @@ TfLiteStatus EvalHifi4(const OpData* op_data, const TfLiteEvalTensor* input,
 #endif  // defined(FUSION_F1)
 
 void* Init(TfLiteContext* context, const char* buffer, size_t length) {
-#if defined(HIFIMINI) || defined(FUSION_F1)
+#if defined(HIFIMINI) || defined(FUSION_F1) || defined(HIFI5)
   TFLITE_DCHECK(context->AllocatePersistentBuffer != nullptr);
   return context->AllocatePersistentBuffer(context, sizeof(OpData));
 #else
@@ -248,7 +248,7 @@ void* Init(TfLiteContext* context, const char* buffer, size_t length) {
 TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
 #if defined(HIFIMINI)
   return PrepareHifimini(context, node);
-#elif defined(FUSION_F1)
+#elif ((defined(FUSION_F1)) ||(defined(HIFI5)))
   return PrepareHifi4(context, node);
 #else
   return SoftmaxPrepare(context, node);
@@ -267,7 +267,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
                            tflite::micro::GetTensorData<int8_t>(input),
                            tflite::micro::GetTensorShape(output),
                            tflite::micro::GetTensorData<int16_t>(output));
-#elif defined(FUSION_F1)
+#elif ((defined(FUSION_F1)) || (defined(HIFI5)))
     return EvalHifi4(static_cast<OpData*>(node->user_data), input, output,
                      context);
 #else

--- a/tensorflow/lite/micro/kernels/xtensa/softmax.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/softmax.cc
@@ -33,7 +33,7 @@ namespace {
 struct OpData {
   uint16_t* exp_lut;
 };
-#elif ((defined(FUSION_F1)) || (defined(HIFI5)))
+#elif defined(FUSION_F1) || defined(HIFI5)
 struct OpData {
   SoftmaxParams params;
   int scratch_tensor_index;
@@ -181,8 +181,8 @@ TfLiteStatus PrepareHifimini(TfLiteContext* context, TfLiteNode* node) {
 }
 #endif  // defined(HIFIMINI)
 
-#if ((defined(FUSION_F1)) || (defined(HIFI5)))
-TfLiteStatus PrepareHifi4(TfLiteContext* context, TfLiteNode* node) {
+#if defined(FUSION_F1) || defined(HIFI5)
+TfLiteStatus PrepareHifi(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE_OK(context, SoftmaxPrepare(context, node));
 
   // Calculate scratch memory requirements and request scratch buffer
@@ -209,8 +209,8 @@ TfLiteStatus PrepareHifi4(TfLiteContext* context, TfLiteNode* node) {
   return kTfLiteOk;
 }
 
-TfLiteStatus EvalHifi4(const OpData* op_data, const TfLiteEvalTensor* input,
-                       TfLiteEvalTensor* output, TfLiteContext* context) {
+TfLiteStatus EvalHifi(const OpData* op_data, const TfLiteEvalTensor* input,
+                      TfLiteEvalTensor* output, TfLiteContext* context) {
   const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
   const int8_t* input_data = tflite::micro::GetTensorData<int8_t>(input);
   const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
@@ -234,7 +234,7 @@ TfLiteStatus EvalHifi4(const OpData* op_data, const TfLiteEvalTensor* input,
   return kTfLiteOk;
 }
 
-#endif  // defined(FUSION_F1)
+#endif  // defined(FUSION_F1) || defined(HIFI5)
 
 void* Init(TfLiteContext* context, const char* buffer, size_t length) {
 #if defined(HIFIMINI) || defined(FUSION_F1) || defined(HIFI5)
@@ -248,8 +248,8 @@ void* Init(TfLiteContext* context, const char* buffer, size_t length) {
 TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
 #if defined(HIFIMINI)
   return PrepareHifimini(context, node);
-#elif ((defined(FUSION_F1)) ||(defined(HIFI5)))
-  return PrepareHifi4(context, node);
+#elif defined(FUSION_F1) || defined(HIFI5)
+  return PrepareHifi(context, node);
 #else
   return SoftmaxPrepare(context, node);
 #endif
@@ -267,9 +267,9 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
                            tflite::micro::GetTensorData<int8_t>(input),
                            tflite::micro::GetTensorShape(output),
                            tflite::micro::GetTensorData<int16_t>(output));
-#elif ((defined(FUSION_F1)) || (defined(HIFI5)))
-    return EvalHifi4(static_cast<OpData*>(node->user_data), input, output,
-                     context);
+#elif defined(FUSION_F1) || defined(HIFI5)
+    return EvalHifi(static_cast<OpData*>(node->user_data), input, output,
+                    context);
 #else
     SoftmaxParams op_data = *static_cast<SoftmaxParams*>(node->user_data);
     tflite::reference_ops::Softmax(

--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
@@ -26,7 +26,16 @@ ifeq ($(TARGET_ARCH), $(findstring $(TARGET_ARCH), "hifi5"))
     $(NNLIB_PATH)/algo/kernels/matXvec/hifi5/xa_nn_matXvec_8x16.c \
     $(NNLIB_PATH)/algo/kernels/matXvec/hifi5/xa_nn_matXvec_8x8.c \
     $(NNLIB_PATH)/algo/kernels/activations/hifi5/xa_nn_activations_8_8.c \
-    $(NNLIB_PATH)/algo/kernels/fc/hifi4/xa_nn_fully_connected.c
+    $(NNLIB_PATH)/algo/kernels/fc/hifi4/xa_nn_fully_connected.c \
+    $(NNLIB_PATH)/algo/kernels/activations/hifi5/xa_nn_softmax_asym8_asym8.c \
+    $(NNLIB_PATH)/algo/kernels/cnn/hifi5/xa_nn_matXvec_sym8sxasym8s_asym8s_circ.c \
+    $(NNLIB_PATH)/algo/kernels/cnn/hifi5/xa_nn_circ_buf.c \
+    $(NNLIB_PATH)/algo/kernels/cnn/hifi5/xa_nn_conv2d_std_circ_buf.c \
+    $(NNLIB_PATH)/algo/kernels/cnn/hifi5/xa_nn_conv2d_std_sym8sxasym8s.c \
+    $(NNLIB_PATH)/algo/kernels/cnn/hifi5/xa_nn_conv2d_depthwise.c \
+    $(NNLIB_PATH)/algo/kernels/cnn/hifi5/xa_nn_conv2d_depthwise_sym8sxasym8s.c \
+    $(NNLIB_PATH)/algo/kernels/cnn/hifi5/xa_nn_conv2d_pointwise_sym8sxasym8s.c \
+    $(NNLIB_PATH)/algo/kernels/matXvec/hifi5/xa_nn_matmul_sym8sxasym8s.c
 
   INCLUDES += \
     -I$(NNLIB_PATH)/ \

--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa_depthwise_patch_hifi5.patch
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa_depthwise_patch_hifi5.patch
@@ -1,0 +1,45 @@
+diff --git a/algo/kernels/cnn/hifi5/xa_nn_conv2d_depthwise.c b/algo/kernels/cnn/hifi5/xa_nn_conv2d_depthwise.c
+index 48fccdc..3c10040 100644
+--- a/algo/kernels/cnn/hifi5/xa_nn_conv2d_depthwise.c
++++ b/algo/kernels/cnn/hifi5/xa_nn_conv2d_depthwise.c
+@@ -348,8 +348,6 @@ WORD32 xa_nn_conv2d_depthwise_getsize
+   XA_NNLIB_CHK_COND((kernel_height <= 0), -1);
+   XA_NNLIB_CHK_COND((kernel_width <= 0), -1);
+   XA_NNLIB_CHK_COND((channels_multiplier <= 0), -1);
+-  XA_NNLIB_CHK_COND((x_stride <= 0 || x_stride > kernel_width), -1); //TODO: x_stride > kernel_width is supported ?
+-  XA_NNLIB_CHK_COND((y_stride <= 0 || y_stride > kernel_height), -1);
+   XA_NNLIB_CHK_COND((x_padding < 0), -1);
+   XA_NNLIB_CHK_COND((y_padding < 0), -1);
+   XA_NNLIB_CHK_COND((output_height <= 0), -1);
+diff --git a/algo/kernels/cnn/hifi5/xa_nn_conv2d_depthwise_sym8sxasym8s.c b/algo/kernels/cnn/hifi5/xa_nn_conv2d_depthwise_sym8sxasym8s.c
+index 71611f4..0fd19ae 100644
+--- a/algo/kernels/cnn/hifi5/xa_nn_conv2d_depthwise_sym8sxasym8s.c
++++ b/algo/kernels/cnn/hifi5/xa_nn_conv2d_depthwise_sym8sxasym8s.c
+@@ -2122,10 +2122,7 @@ WORD32 xa_nn_conv2d_depthwise_nhwc_per_chan_sym8sxasym8s_k3x3
+   /* Implementation dependent checks */
+   //TOOD: support y_stride 2
+   XA_NNLIB_ARG_CHK_COND((y_stride != 1) && (y_stride != 2), -1);
+-  XA_NNLIB_ARG_CHK_COND((y_stride > kernel_height), -1);
+-  XA_NNLIB_ARG_CHK_COND((x_stride > kernel_width), -1);
+   XA_NNLIB_ARG_CHK_COND((kernel_height > input_height), -1);
+-  XA_NNLIB_ARG_CHK_COND((kernel_width > input_width), -1);
+ 
+ #ifndef DISABLE_DEPTHWISE_CONV2D_K3X3_SPECIAL_CASE
+   WORD32 input_zero_bias_neg = -input_zero_bias;
+@@ -2271,7 +2268,6 @@ WORD32 xa_nn_conv2d_depthwise_per_chan_sym8sxasym8s_generic
+   XA_NNLIB_ARG_CHK_COND((input_channels <= 0), -1);
+   XA_NNLIB_ARG_CHK_COND((kernel_height <= 0 || kernel_width <= 0), -1);
+   XA_NNLIB_ARG_CHK_COND((kernel_height > input_height), -1);
+-  XA_NNLIB_ARG_CHK_COND((kernel_width > input_width), -1);
+   XA_NNLIB_ARG_CHK_COND((channels_multiplier <= 0), -1);
+   XA_NNLIB_ARG_CHK_COND((y_stride <= 0 || x_stride <= 0), -1);
+   XA_NNLIB_ARG_CHK_COND((y_padding < 0 || x_padding < 0), -1);
+@@ -2282,8 +2278,6 @@ WORD32 xa_nn_conv2d_depthwise_per_chan_sym8sxasym8s_generic
+   XA_NNLIB_ARG_CHK_COND((inp_data_format != 0 && inp_data_format != 1), -1);
+   XA_NNLIB_ARG_CHK_COND((out_data_format != 0), -1);
+   /* Implementation dependent checks */
+-  XA_NNLIB_ARG_CHK_COND((y_stride > kernel_height), -1);
+-  XA_NNLIB_ARG_CHK_COND((x_stride > kernel_width), -1);
+ 
+   if(inp_data_format == 0)
+   {

--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa_download.sh
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa_download.sh
@@ -81,6 +81,17 @@ else
     popd >&2
   fi
 
+  if [[ ${2} == "hifi5" ]]; then
+    pushd ${DOWNLOADS_DIR}/xa_nnlib_hifi5/ >&2
+    git init . >&2
+    git config user.email "tflm@google.com"
+    git config user.name "TensorflowLite Micro"
+    git add *
+    git commit -a -m "Commit for a temporary repository." > /dev/null
+    git apply ../../ext_libs/xtensa_depthwise_patch_hifi5.patch
+    popd >&2
+  fi
+
 fi
 
 echo "SUCCESS"


### PR DESCRIPTION
Integrate the HiFi 5 Neural Network Library v1.5.0
Used HiFi 5 NN Library kernels for conv, depthwise_conv and softmax
operators int8 variant.

Signed-off-by: Anirban Mandal <amandal@cadence.com>
Signed-off-by: Biswa Dhal <bdhal@cadence.com>
Signed-off-by: Bhanu Prakash Bandaru Venkata <bhanup@cadence.com>
Signed-off-by: Chaitanya Sanjay Muley <cmuley@cadence.com>
Signed-off-by: Harinarayanan E V <hariev@cadence.com>
Signed-off-by: Harshavardhan Ravindra Joshi <joshih@cadence.com>
Signed-off-by: Prasad Nikam <pnikam@cadence.com>