### PR TITLE
Fix build failure with CUDA 11.3

### DIFF
--- a/third_party/nccl/build_defs.bzl.tpl
+++ b/third_party/nccl/build_defs.bzl.tpl
@@ -204,7 +204,7 @@ def _prune_relocatable_code_impl(ctx):
             arguments = arguments,
             mnemonic = "nvprune",
         )
-        output.append(outputs)
+        outputs.append(output)
 
     return DefaultInfo(files = depset(outputs))
 


### PR DESCRIPTION
Fix a typo introduced in e07069218c39cbfc4bbad79fc50c83d64b0546af to strip NCCL's relocatable device code.

/cc @chsigg 