### PR TITLE
Revert "[Cherrypick:2.5]Switch absl to `lts_2021_03_24` LTS branch"

### DIFF
--- a/third_party/absl/com_google_absl_fix_mac_and_nvcc_build.patch
+++ b/third_party/absl/com_google_absl_fix_mac_and_nvcc_build.patch
@@ -207,7 +207,7 @@ index 02bfd03..d25d96d 100644
  
    template <int I>
    ElemT<I>& get() & {
--    return StorageT<I>::get();
+-    return internal_compressed_tuple::Storage<ElemT<I>, I>::get();
 +    return internal_compressed_tuple::Storage<CompressedTuple, I>::get();
    }
  

--- a/third_party/absl/workspace.bzl
+++ b/third_party/absl/workspace.bzl
@@ -6,8 +6,8 @@ def repo():
     """Imports absl."""
 
     # Attention: tools parse and update these lines.
-    ABSL_COMMIT = "997aaf3a28308eba1b9156aa35ab7bca9688e9f6"
-    ABSL_SHA256 = "35f22ef5cb286f09954b7cc4c85b5a3f6221c9d4df6b8c4a1e9d399555b366ee"
+    ABSL_COMMIT = "6f9d96a1f41439ac172ee2ef7ccd8edf0e5d068c"
+    ABSL_SHA256 = "62c27e7a633e965a2f40ff16b487c3b778eae440bab64cad83b34ef1cbe3aa93"
 
     tf_http_archive(
         name = "com_google_absl",


### PR DESCRIPTION
Reverts tensorflow/tensorflow#48618

Breaks TF Text on 2.5 release.