### PR TITLE
[XLA/GPU] Add CustomCallSchedule to give schedule hints to custom-calls.

### DIFF
--- a/tensorflow/compiler/mlir/xla/ir/mlir_hlo_builder.cc
+++ b/tensorflow/compiler/mlir/xla/ir/mlir_hlo_builder.cc
@@ -135,7 +135,7 @@ StatusOr<XlaOp> MlirHloBuilder::CustomCallInternal(
     bool has_side_effect,
     absl::Span<const std::pair<ShapeIndex, std::pair<int64, ShapeIndex>>>
         output_operand_aliasing,
-    const Literal* literal) {
+    const Literal* literal, CustomCallSchedule schedule) {
   if (operand_shapes_with_layout.has_value())
     return Unimplemented(
         "CustomCall doesn't support operands shapes with layout");
@@ -145,6 +145,8 @@ StatusOr<XlaOp> MlirHloBuilder::CustomCallInternal(
       << "MLIR CustomCallOp does not support output_operand_aliasing yet";
   TF_RET_CHECK(literal == nullptr)
       << "MLIR CustomCallOp does not support literal yet";
+  TF_RET_CHECK(schedule == CustomCallSchedule::NONE)
+      << "MLIR CustomCallOp does not support custom-call-schedule yet";
   auto op = builder_.create<mlir::mhlo::CustomCallOp>(
       loc_, ty, GetValues(operands), builder_.getStringAttr(call_target_name),
       /*has_side_effect=*/builder_.getBoolAttr(has_side_effect),

--- a/tensorflow/compiler/mlir/xla/ir/mlir_hlo_builder.h
+++ b/tensorflow/compiler/mlir/xla/ir/mlir_hlo_builder.h
@@ -138,7 +138,7 @@ class MlirHloBuilder : public XlaBuilder {
       bool has_side_effect,
       absl::Span<const std::pair<ShapeIndex, std::pair<int64, ShapeIndex>>>
           output_operand_aliasing,
-      const Literal* literal) override;
+      const Literal* literal, CustomCallSchedule schedule) override;
 
   StatusOr<XlaOp> ReduceInternal(
       const Shape& shape, absl::Span<const XlaOp> all_operands,

--- a/tensorflow/compiler/xla/client/xla_builder.cc
+++ b/tensorflow/compiler/xla/client/xla_builder.cc
@@ -1893,7 +1893,7 @@ XlaOp XlaBuilder::CustomCall(
     bool has_side_effect,
     absl::Span<const std::pair<ShapeIndex, std::pair<int64, ShapeIndex>>>
         output_operand_aliasing,
-    const Literal* literal) {
+    const Literal* literal, CustomCallSchedule schedule) {
   return ReportErrorOrReturn([&]() -> StatusOr<XlaOp> {
     if (absl::StartsWith(call_target_name, "$")) {
       return InvalidArgument(
@@ -1926,7 +1926,7 @@ XlaOp XlaBuilder::CustomCall(
     }
     return CustomCallInternal(call_target_name, operands, shape, opaque,
                               operand_shapes_with_layout, has_side_effect,
-                              output_operand_aliasing, literal);
+                              output_operand_aliasing, literal, schedule);
   });
 }
 
@@ -1937,7 +1937,7 @@ StatusOr<XlaOp> XlaBuilder::CustomCallInternal(
     bool has_side_effect,
     absl::Span<const std::pair<ShapeIndex, std::pair<int64, ShapeIndex>>>
         output_operand_aliasing,
-    const Literal* literal) {
+    const Literal* literal, CustomCallSchedule schedule) {
   HloInstructionProto instr;
   *instr.mutable_shape() = shape.ToProto();
   instr.set_custom_call_target(call_target_name);
@@ -1962,6 +1962,7 @@ StatusOr<XlaOp> XlaBuilder::CustomCallInternal(
       aliasing->add_output_shape_index(index);
     }
   }
+  instr.set_custom_call_schedule(schedule);
   return AddInstruction(std::move(instr), HloOpcode::kCustomCall, operands);
 }
 
@@ -1972,7 +1973,7 @@ XlaOp XlaBuilder::CustomCall(
     bool has_side_effect,
     absl::Span<const std::pair<ShapeIndex, std::pair<int64, ShapeIndex>>>
         output_operand_aliasing,
-    const Literal* literal) {
+    const Literal* literal, CustomCallSchedule schedule) {
   return ReportErrorOrReturn([&]() -> StatusOr<XlaOp> {
     HloInstructionProto instr;
     if (absl::StartsWith(call_target_name, "$")) {
@@ -2023,6 +2024,7 @@ XlaOp XlaBuilder::CustomCall(
         aliasing->add_output_shape_index(index);
       }
     }
+    instr.set_custom_call_schedule(schedule);
     return AddInstruction(std::move(instr), HloOpcode::kCustomCall, operands);
   });
 }
@@ -4192,10 +4194,11 @@ XlaOp CustomCall(
     bool has_side_effect,
     absl::Span<const std::pair<ShapeIndex, std::pair<int64, ShapeIndex>>>
         output_operand_aliasing,
-    const Literal* literal) {
+    const Literal* literal, CustomCallSchedule schedule) {
   return builder->CustomCall(call_target_name, operands, shape, opaque,
                              /*operand_shapes_with_layout=*/absl::nullopt,
-                             has_side_effect, output_operand_aliasing, literal);
+                             has_side_effect, output_operand_aliasing, literal,
+                             schedule);
 }
 
 XlaOp CustomCallWithComputation(
@@ -4204,11 +4207,11 @@ XlaOp CustomCallWithComputation(
     const Shape& shape, const string& opaque, bool has_side_effect,
     absl::Span<const std::pair<ShapeIndex, std::pair<int64, ShapeIndex>>>
         output_operand_aliasing,
-    const Literal* literal) {
-  return builder->CustomCall(call_target_name, operands, computation, shape,
-                             opaque,
-                             /*operand_shapes_with_layout=*/absl::nullopt,
-                             has_side_effect, output_operand_aliasing, literal);
+    const Literal* literal, CustomCallSchedule schedule) {
+  return builder->CustomCall(
+      call_target_name, operands, computation, shape, opaque,
+      /*operand_shapes_with_layout=*/absl::nullopt, has_side_effect,
+      output_operand_aliasing, literal, schedule);
 }
 
 XlaOp CustomCallWithLayout(
@@ -4218,10 +4221,10 @@ XlaOp CustomCallWithLayout(
     bool has_side_effect,
     absl::Span<const std::pair<ShapeIndex, std::pair<int64, ShapeIndex>>>
         output_operand_aliasing,
-    const Literal* literal) {
+    const Literal* literal, CustomCallSchedule schedule) {
   return builder->CustomCall(call_target_name, operands, shape, opaque,
                              operand_shapes_with_layout, has_side_effect,
-                             output_operand_aliasing, literal);
+                             output_operand_aliasing, literal, schedule);
 }
 
 XlaOp Complex(const XlaOp lhs, const XlaOp rhs,

--- a/tensorflow/compiler/xla/client/xla_builder.h
+++ b/tensorflow/compiler/xla/client/xla_builder.h
@@ -637,7 +637,7 @@ class XlaBuilder {
       bool has_side_effect,
       absl::Span<const std::pair<ShapeIndex, std::pair<int64, ShapeIndex>>>
           output_operand_aliasing,
-      const Literal* literal);
+      const Literal* literal, CustomCallSchedule schedule);
 
   // Internal version of CustomCall without computation that doesn't do op
   // specific error handling and expects arguments to be legal. CustomCall
@@ -649,7 +649,7 @@ class XlaBuilder {
       bool has_side_effect,
       absl::Span<const std::pair<ShapeIndex, std::pair<int64, ShapeIndex>>>
           output_operand_aliasing,
-      const Literal* literal);
+      const Literal* literal, CustomCallSchedule schedule);
 
   XlaOp CustomCall(
       const string& call_target_name, absl::Span<const XlaOp> operands,
@@ -659,7 +659,7 @@ class XlaBuilder {
       bool has_side_effect,
       absl::Span<const std::pair<ShapeIndex, std::pair<int64, ShapeIndex>>>
           output_operand_aliasing,
-      const Literal* literal);
+      const Literal* literal, CustomCallSchedule schedule);
 
   XlaOp Reduce(XlaOp operand, XlaOp init_value,
                const XlaComputation& computation,
@@ -1208,14 +1208,14 @@ class XlaBuilder {
       const string& opaque, bool has_side_effect,
       absl::Span<const std::pair<ShapeIndex, std::pair<int64, ShapeIndex>>>
           output_operand_aliasing,
-      const Literal* literal);
+      const Literal* literal, CustomCallSchedule schedule);
   friend XlaOp CustomCallWithComputation(
       XlaBuilder* builder, const string& call_target_name,
       absl::Span<const XlaOp> operands, const XlaComputation& computation,
       const Shape& shape, const string& opaque, bool has_side_effect,
       absl::Span<const std::pair<ShapeIndex, std::pair<int64, ShapeIndex>>>
           output_operand_aliasing,
-      const Literal* literal);
+      const Literal* literal, CustomCallSchedule schedule);
   friend XlaOp CustomCallWithLayout(
       XlaBuilder* builder, const string& call_target_name,
       absl::Span<const XlaOp> operands, const Shape& shape_with_layout,
@@ -1223,7 +1223,7 @@ class XlaBuilder {
       bool has_side_effect,
       absl::Span<const std::pair<ShapeIndex, std::pair<int64, ShapeIndex>>>
           output_operand_aliasing,
-      const Literal* literal);
+      const Literal* literal, CustomCallSchedule schedule);
   friend XlaOp Complex(XlaOp real, XlaOp imag,
                        absl::Span<const int64> broadcast_dimensions);
   friend XlaOp Conj(XlaOp operand);
@@ -2041,7 +2041,8 @@ XlaOp CustomCall(
     const string& opaque = "", bool has_side_effect = false,
     absl::Span<const std::pair<ShapeIndex, std::pair<int64, ShapeIndex>>>
         output_operand_aliasing = {},
-    const Literal* literal = nullptr);
+    const Literal* literal = nullptr,
+    CustomCallSchedule schedule = CustomCallSchedule::NONE);
 
 // Overload which constructs a custom call that applies an Xla computation.
 XlaOp CustomCallWithComputation(
@@ -2064,7 +2065,8 @@ XlaOp CustomCallWithLayout(
     const string& opaque = "", bool has_side_effect = false,
     absl::Span<const std::pair<ShapeIndex, std::pair<int64, ShapeIndex>>>
         output_operand_aliasing = {},
-    const Literal* literal = nullptr);
+    const Literal* literal = nullptr,
+    CustomCallSchedule schedule = CustomCallSchedule::NONE);
 
 // The following methods enqueue element-wise binary arithmetic operations
 // onto the computation. The shapes of the operands have to match unless one

--- a/tensorflow/compiler/xla/service/gpu/gpu_hlo_schedule.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_hlo_schedule.cc
@@ -199,7 +199,7 @@ bool CustomCallWithSchedule(const HloInstruction* instr,
 // relationship of the two calls (typically PerformX is scheduled right after
 // all of its producers have been scheduled and PerformXDone is scheduled right
 // before its first consumer.)
-HloInstructionSequence postprocessor_to_custom_schedule(
+HloInstructionSequence PostprocessorToCustomSchedule(
     const HloInstructionSequence& input) {
   // Schedule `EARLIEST`.
   std::deque<HloInstruction*> earliest_scheduled;
@@ -208,9 +208,8 @@ HloInstructionSequence postprocessor_to_custom_schedule(
     auto is_scheduled = [&](const HloInstruction* instr) -> bool {
       return scheduled.contains(instr);
     };
-    const std::vector<HloInstruction*>& instrs = input.instructions();
-    for (HloInstruction* instr : instrs) {
-      if (scheduled.contains(instr)) {
+    for (HloInstruction* instr : input.instructions()) {
+      if (is_scheduled(instr)) {
         continue;
       }
 
@@ -239,7 +238,7 @@ HloInstructionSequence postprocessor_to_custom_schedule(
     };
     for (auto it = earliest_scheduled.rbegin(); it != earliest_scheduled.rend();
          it++) {
-      if (scheduled.contains(*it)) {
+      if (is_scheduled(*it)) {
         continue;
       }
 
@@ -288,7 +287,7 @@ StatusOr<std::unique_ptr<GpuHloSchedule>> GpuHloSchedule::Build(
               return ShapeUtil::ByteSizeOf(buffer.shape(), pointer_size);
             },
             ComputationSchedulerToModuleScheduler(
-                DefaultMemoryScheduler, postprocessor_to_custom_schedule)));
+                DefaultMemoryScheduler, PostprocessorToCustomSchedule)));
     schedule->thunk_launch_order_ =
         sequences.sequence(entry_computation).instructions();
     schedule->hlo_ordering_ =

--- a/tensorflow/compiler/xla/service/gpu/gpu_hlo_schedule_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_hlo_schedule_test.cc
@@ -368,7 +368,7 @@ TEST_F(GpuHloScheduleTest, AsyncCustomCall) {
           /*custom_call_target=*/"nonblocking-call-start",
           /*opaque=*/""));
   static_cast<HloCustomCallInstruction*>(nonblocking_call)
-      ->set_custom_call_schedule(EARLY_AS_POSSIBLE);
+      ->set_custom_call_schedule(EARLIEST);
   // In addition, add control_depedency: add1->nonblocking_call.
   TF_CHECK_OK(add1->AddControlDependencyTo(nonblocking_call));
   // Blocking call, which only add4 depends on.
@@ -378,7 +378,7 @@ TEST_F(GpuHloScheduleTest, AsyncCustomCall) {
           /*custom_call_target=*/"blocking-call-done",
           /*opaque=*/""));
   static_cast<HloCustomCallInstruction*>(blocking_call)
-      ->set_custom_call_schedule(LATE_AS_POSSIBLE);
+      ->set_custom_call_schedule(LATEST);
   HloInstruction* add3 = builder.AddInstruction(
       HloInstruction::CreateBinary(f32_2x2_, HloOpcode::kAdd, add1, add2));
   HloInstruction* add4 = builder.AddInstruction(HloInstruction::CreateBinary(
@@ -398,13 +398,13 @@ TEST_F(GpuHloScheduleTest, AsyncCustomCall) {
   // Order constrained by control dependency.
   EXPECT_TRUE(order->ExecutesBefore(add1, nonblocking_call));
   // Test that nonblocking_call is scheduled before add2, so that we know
-  // EARLY_AS_POSSIBLE is in effect.
+  // EARLIEST is in effect.
   EXPECT_TRUE(order->ExecutesBefore(nonblocking_call, add2));
   EXPECT_TRUE(order->ExecutesBefore(nonblocking_call, add3));
   EXPECT_TRUE(order->ExecutesBefore(nonblocking_call, add4));
 
   // Test that blocking_call is scheduled after add3, so that we know
-  // LATE_AS_POSSIBLE is in effect.
+  // LATEST is in effect.
   EXPECT_TRUE(order->ExecutesBefore(add3, blocking_call));
   EXPECT_TRUE(order->ExecutesBefore(blocking_call, add4));
 }

--- a/tensorflow/compiler/xla/service/hlo.proto
+++ b/tensorflow/compiler/xla/service/hlo.proto
@@ -34,6 +34,12 @@ import "tensorflow/compiler/xla/xla_data.proto";
 
 option cc_enable_arenas = true;
 
+enum CustomCallSchedule {
+  NONE = 0;
+  LATE_AS_POSSIBLE = 1;
+  EARLY_AS_POSSIBLE = 2;
+}
+
 // Serialization of HloInstruction.
 // Next ID: 76
 message HloInstructionProto {
@@ -236,6 +242,9 @@ message HloInstructionProto {
   // buffers between output and operands for kCustomCall.
   repeated xla.CustomCallOutputOperandAliasing
       custom_call_output_operand_aliasing = 74;
+
+  // Specifies the desired schedule for the custom-call.
+  CustomCallSchedule custom_call_schedule = 76;
 
   // The delta value for kRngGetAndUpdateState.
   int64 delta = 66;

--- a/tensorflow/compiler/xla/service/hlo.proto
+++ b/tensorflow/compiler/xla/service/hlo.proto
@@ -36,8 +36,8 @@ option cc_enable_arenas = true;
 
 enum CustomCallSchedule {
   NONE = 0;
-  LATE_AS_POSSIBLE = 1;
-  EARLY_AS_POSSIBLE = 2;
+  LATEST = 1;
+  EARLIEST = 2;
 }
 
 // Serialization of HloInstruction.

--- a/tensorflow/compiler/xla/service/hlo.proto
+++ b/tensorflow/compiler/xla/service/hlo.proto
@@ -41,7 +41,7 @@ enum CustomCallSchedule {
 }
 
 // Serialization of HloInstruction.
-// Next ID: 76
+// Next ID: 77
 message HloInstructionProto {
   reserved 10;
   reserved "parameter_name";

--- a/tensorflow/compiler/xla/service/hlo.proto
+++ b/tensorflow/compiler/xla/service/hlo.proto
@@ -243,7 +243,8 @@ message HloInstructionProto {
   repeated xla.CustomCallOutputOperandAliasing
       custom_call_output_operand_aliasing = 74;
 
-  // Specifies the desired schedule for the custom-call.
+  // Specifies the desired schedule for the custom-call. The field is only
+  // present for custom-call.
   CustomCallSchedule custom_call_schedule = 76;
 
   // The delta value for kRngGetAndUpdateState.

--- a/tensorflow/compiler/xla/service/hlo_instruction.cc
+++ b/tensorflow/compiler/xla/service/hlo_instruction.cc
@@ -3828,9 +3828,11 @@ StatusOr<PrecisionConfig::Precision> StringToPrecision(const string& name) {
   return found->second;
 }
 
-StatusOr<CustomCallSchedule> StringToCustomCallSchedule(const string& name) {
-  static std::unordered_map<string, CustomCallSchedule>* map = [] {
-    static auto* map = new std::unordered_map<string, CustomCallSchedule>;
+StatusOr<CustomCallSchedule> StringToCustomCallSchedule(
+    absl::string_view name) {
+  static const absl::flat_hash_map<string, CustomCallSchedule>* map = [] {
+    static auto* map =
+        new absl::flat_hash_map<string, CustomCallSchedule>;
     for (int i = 0; i < CustomCallSchedule_ARRAYSIZE; i++) {
       if (CustomCallSchedule_IsValid(i)) {
         auto value = static_cast<CustomCallSchedule>(i);

--- a/tensorflow/compiler/xla/service/hlo_instruction.cc
+++ b/tensorflow/compiler/xla/service/hlo_instruction.cc
@@ -613,6 +613,7 @@ StatusOr<std::unique_ptr<HloInstruction>> HloInstruction::CreateFromProto(
       }
       custom_call_instr->set_output_to_operand_aliasing(
           std::move(output_to_operand_aliasing));
+      custom_call_instr->set_custom_call_schedule(proto.custom_call_schedule());
       break;
     }
     case HloOpcode::kPad:
@@ -3729,6 +3730,10 @@ string PrecisionToString(const PrecisionConfig::Precision& precision) {
   return absl::AsciiStrToLower(PrecisionConfig::Precision_Name(precision));
 }
 
+string CustomCallScheduleToString(const CustomCallSchedule& schedule) {
+  return absl::AsciiStrToLower(CustomCallSchedule_Name(schedule));
+}
+
 string ConvolutionDimensionNumbersToString(
     const ConvolutionDimensionNumbers& dnums) {
   // lhs_dims[i] is the symbol of the logical dimension i for the lhs
@@ -3819,6 +3824,24 @@ StatusOr<PrecisionConfig::Precision> StringToPrecision(const string& name) {
   auto found = map->find(absl::AsciiStrToLower(name));
   if (found == map->end()) {
     return InvalidArgument("Unknown distribution");
+  }
+  return found->second;
+}
+
+StatusOr<CustomCallSchedule> StringToCustomCallSchedule(const string& name) {
+  static std::unordered_map<string, CustomCallSchedule>* map = [] {
+    static auto* map = new std::unordered_map<string, CustomCallSchedule>;
+    for (int i = 0; i < CustomCallSchedule_ARRAYSIZE; i++) {
+      if (CustomCallSchedule_IsValid(i)) {
+        auto value = static_cast<CustomCallSchedule>(i);
+        (*map)[CustomCallScheduleToString(value)] = value;
+      }
+    }
+    return map;
+  }();
+  auto found = map->find(absl::AsciiStrToLower(name));
+  if (found == map->end()) {
+    return InvalidArgument("Unknown schedule");
   }
   return found->second;
 }

--- a/tensorflow/compiler/xla/service/hlo_instruction.h
+++ b/tensorflow/compiler/xla/service/hlo_instruction.h
@@ -2217,7 +2217,7 @@ string ReplicaGroupsToString(const std::vector<ReplicaGroup>& replica_groups);
 StatusOr<RandomAlgorithm> StringToRandomAlgorithm(const string& name);
 StatusOr<RandomDistribution> StringToRandomDistribution(const string& name);
 StatusOr<PrecisionConfig::Precision> StringToPrecision(const string& name);
-StatusOr<CustomCallSchedule> StringToCustomCallSchedule(const string& name);
+StatusOr<CustomCallSchedule> StringToCustomCallSchedule(absl::string_view name);
 
 std::ostream& operator<<(std::ostream& os, HloInstruction::FusionKind kind);
 

--- a/tensorflow/compiler/xla/service/hlo_instruction.h
+++ b/tensorflow/compiler/xla/service/hlo_instruction.h
@@ -2217,6 +2217,7 @@ string ReplicaGroupsToString(const std::vector<ReplicaGroup>& replica_groups);
 StatusOr<RandomAlgorithm> StringToRandomAlgorithm(const string& name);
 StatusOr<RandomDistribution> StringToRandomDistribution(const string& name);
 StatusOr<PrecisionConfig::Precision> StringToPrecision(const string& name);
+StatusOr<CustomCallSchedule> StringToCustomCallSchedule(const string& name);
 
 std::ostream& operator<<(std::ostream& os, HloInstruction::FusionKind kind);
 

--- a/tensorflow/compiler/xla/service/hlo_instructions.cc
+++ b/tensorflow/compiler/xla/service/hlo_instructions.cc
@@ -2420,7 +2420,8 @@ HloCustomCallInstruction::HloCustomCallInstruction(
       batch_group_count_(1),
       layout_constrained_(false),
       padding_type_(PaddingType::PADDING_INVALID),
-      custom_call_has_side_effect_(false) {
+      custom_call_has_side_effect_(false),
+      custom_call_schedule_(CustomCallSchedule::NONE) {
   set_raw_backend_config_string(std::move(opaque));
   for (auto operand : operands) {
     AppendOperand(operand);

--- a/tensorflow/compiler/xla/service/hlo_instructions.h
+++ b/tensorflow/compiler/xla/service/hlo_instructions.h
@@ -1524,6 +1524,12 @@ class HloCustomCallInstruction : public HloInstruction {
           aliasing) {
     output_to_operand_aliasing_ = std::move(aliasing);
   }
+  void set_custom_call_schedule(CustomCallSchedule custom_call_schedule) {
+    custom_call_schedule_ = custom_call_schedule;
+  }
+  CustomCallSchedule custom_call_schedule() const {
+    return custom_call_schedule_;
+  }
 
  private:
   std::vector<string> ExtraAttributesToStringImpl(
@@ -1562,6 +1568,8 @@ class HloCustomCallInstruction : public HloInstruction {
   std::vector<std::pair<ShapeIndex, std::pair<int64, ShapeIndex>>>
       output_to_operand_aliasing_;
   absl::optional<Literal> literal_;
+  // A custom-call schedule hint.
+  CustomCallSchedule custom_call_schedule_;
 };
 
 class HloPadInstruction : public HloInstruction {

--- a/tensorflow/compiler/xla/service/hlo_memory_scheduler.h
+++ b/tensorflow/compiler/xla/service/hlo_memory_scheduler.h
@@ -32,6 +32,12 @@ limitations under the License.
 
 namespace xla {
 
+// Postprocessor of the HloInstructionSequence. This is an opt-in postprocessing
+// function to MemorySchedulerAlgorithm to enforce certain hlo schedule
+// constraints desired for custom-calls.
+typedef std::function<HloInstructionSequence(const HloInstructionSequence&)>
+    MemorySchedulerPostprocessor;
+
 // A memory scheduler computes an execution sequence for the HLO instructions in
 // 'computation' that minimizes peak memory, given a points-to analysis result
 // that describes buffer aliasing, together with a target-specific size function
@@ -44,6 +50,7 @@ typedef std::function<StatusOr<HloInstructionSequence>(
     HloComputation*, const TuplePointsToAnalysis&, const HloAliasAnalysis&,
     const LogicalBuffer::SizeFunction&,
     const absl::flat_hash_map<const HloComputation*, int64>&,
+    const MemorySchedulerPostprocessor&,
     /*peak_memory*/ int64*)>
     MemorySchedulerAlgorithm;
 
@@ -57,7 +64,7 @@ typedef std::function<StatusOr<HloSchedule>(
 // Lift a computation scheduler into a module scheduler by calling the
 // computation scheduler on all computations in a module.
 ModuleSchedulerAlgorithm ComputationSchedulerToModuleScheduler(
-    const MemorySchedulerAlgorithm&);
+    const MemorySchedulerAlgorithm&, const MemorySchedulerPostprocessor& = {});
 
 // List scheduler
 StatusOr<HloInstructionSequence> ListMemoryScheduler(
@@ -67,7 +74,7 @@ StatusOr<HloInstructionSequence> ListMemoryScheduler(
     const LogicalBuffer::SizeFunction& size_function,
     const absl::flat_hash_map<const HloComputation*, int64>&
         memory_by_computation,
-    int64* peak_memory);
+    const MemorySchedulerPostprocessor& postprocessor, int64* peak_memory);
 
 // DFS-order scheduler
 StatusOr<HloInstructionSequence> DFSMemoryScheduler(
@@ -77,7 +84,7 @@ StatusOr<HloInstructionSequence> DFSMemoryScheduler(
     const LogicalBuffer::SizeFunction& size_function,
     const absl::flat_hash_map<const HloComputation*, int64>&
         memory_by_computation,
-    int64* peak_memory);
+    const MemorySchedulerPostprocessor& postprocessor, int64* peak_memory);
 
 // Naive Post Order scheduler
 StatusOr<HloInstructionSequence> PostOrderMemoryScheduler(
@@ -87,7 +94,7 @@ StatusOr<HloInstructionSequence> PostOrderMemoryScheduler(
     const LogicalBuffer::SizeFunction& size_function,
     const absl::flat_hash_map<const HloComputation*, int64>&
         memory_by_computation,
-    int64* peak_memory);
+    const MemorySchedulerPostprocessor& postprocessor, int64* peak_memory);
 
 // The default scheduling algorithm. Runs the list scheduler, the DFS scheduler,
 // and the post-order scheduler and chooses whichever returns a lower min-
@@ -100,7 +107,7 @@ StatusOr<HloInstructionSequence> DefaultMemoryScheduler(
     const LogicalBuffer::SizeFunction& size_function,
     const absl::flat_hash_map<const HloComputation*, int64>&
         memory_by_computation,
-    int64* peak_memory);
+    const MemorySchedulerPostprocessor& postprocessor, int64* peak_memory);
 
 StatusOr<HloSchedule> DefaultModuleScheduler(
     HloModule* module, const TuplePointsToAnalysis& points_to_analysis,
@@ -120,7 +127,8 @@ StatusOr<HloSchedule> ScheduleModule(
 // Currently only used by the GPU backend.
 StatusOr<HloInstructionSequence> ScheduleComputation(
     HloComputation* computation,
-    const LogicalBuffer::SizeFunction& size_function);
+    const LogicalBuffer::SizeFunction& size_function,
+    const MemorySchedulerPostprocessor& postprocessor);
 
 // A pass which schedules the HLO instructions in a module. The HloModule's
 // schedule field is set to the resulting HloSchedule using

--- a/tensorflow/compiler/xla/service/hlo_memory_scheduler.h
+++ b/tensorflow/compiler/xla/service/hlo_memory_scheduler.h
@@ -35,8 +35,8 @@ namespace xla {
 // Postprocessor of the HloInstructionSequence. This is an opt-in postprocessing
 // function to MemorySchedulerAlgorithm to enforce certain hlo schedule
 // constraints desired for custom-calls.
-typedef std::function<HloInstructionSequence(const HloInstructionSequence&)>
-    MemorySchedulerPostprocessor;
+using MemorySchedulerPostprocessor =
+    std::function<HloInstructionSequence(const HloInstructionSequence&)>;
 
 // A memory scheduler computes an execution sequence for the HLO instructions in
 // 'computation' that minimizes peak memory, given a points-to analysis result

--- a/tensorflow/compiler/xla/service/hlo_parser_test.cc
+++ b/tensorflow/compiler/xla/service/hlo_parser_test.cc
@@ -1081,6 +1081,18 @@ ENTRY %CustomCallWithAliasing (p0: (f32[2,2], f32[42,2,3]), p1: f32[123,4]) -> (
 
 )"
 },
+// CustomCall with schedule.
+{
+"CustomCallWithSchedule",
+R"(HloModule custom_call
+
+ENTRY %CustomCall () -> f32[1,2,3] {
+  %constant = f32[1]{0} constant({12345})
+  ROOT %custom-call = f32[1,2,3]{0,2,1} custom-call(f32[1]{0} %constant), custom_call_target="foo\"bar", schedule=LATE_AS_POSSIBLE
+}
+
+)"
+},
 // Parse c64 literal
 {
 "ParseC64Literal",

--- a/tensorflow/compiler/xla/service/hlo_parser_test.cc
+++ b/tensorflow/compiler/xla/service/hlo_parser_test.cc
@@ -1088,7 +1088,8 @@ R"(HloModule custom_call
 
 ENTRY %CustomCall () -> f32[1,2,3] {
   %constant = f32[1]{0} constant({12345})
-  ROOT %custom-call = f32[1,2,3]{0,2,1} custom-call(f32[1]{0} %constant), custom_call_target="foo\"bar", schedule=LATE_AS_POSSIBLE
+  %custom-call.0 = f32[1,2,3]{0,2,1} custom-call(f32[1]{0} %constant), custom_call_target="foo", schedule=EARLY_AS_POSSIBLE
+  ROOT %custom-call.1 = f32[1,2,3]{0,2,1} custom-call(f32[1,2,3]{0,2,1} %custom-call.0), custom_call_target="bar", schedule=LATE_AS_POSSIBLE
 }
 
 )"

--- a/tensorflow/compiler/xla/service/hlo_parser_test.cc
+++ b/tensorflow/compiler/xla/service/hlo_parser_test.cc
@@ -1088,8 +1088,8 @@ R"(HloModule custom_call
 
 ENTRY %CustomCall () -> f32[1,2,3] {
   %constant = f32[1]{0} constant({12345})
-  %custom-call.0 = f32[1,2,3]{0,2,1} custom-call(f32[1]{0} %constant), custom_call_target="foo", schedule=EARLY_AS_POSSIBLE
-  ROOT %custom-call.1 = f32[1,2,3]{0,2,1} custom-call(f32[1,2,3]{0,2,1} %custom-call.0), custom_call_target="bar", schedule=LATE_AS_POSSIBLE
+  %custom-call.0 = f32[1,2,3]{0,2,1} custom-call(f32[1]{0} %constant), custom_call_target="foo", schedule=EARLIEST
+  ROOT %custom-call.1 = f32[1,2,3]{0,2,1} custom-call(f32[1,2,3]{0,2,1} %custom-call.0), custom_call_target="bar", schedule=LATEST
 }
 
 )"


### PR DESCRIPTION
Add schedule hints EARLY_AS_POSSIBLE and LATE_AS_POSSIBLE to custom-calls.
This supports a custom-call case, where a logical operation can be lowered into
two HLOs (e.g., PerformX and PerformXDone). We can utilize this mechanism to
either hide host latencies between the pair of the custom-calls or the two calls
can more accurately identify the def-use relationship (typically PerformX is
scheduled right after all of its producers have been scheduled and PerformXDone
is scheduled right before its first consumer.)

I need this change for implementing XLA Horovod ops. I have a working prototype internally within NVIDIA and it works well with this change for our tracked DL models, i.e., host overhead is well hidden and I do see some overlapping/parallelism between communication and computation.
