### PR TITLE
Do not check md files as part of check_contents.

### DIFF
--- a/tensorflow/lite/micro/tools/ci_build/test_code_style.sh
+++ b/tensorflow/lite/micro/tools/ci_build/test_code_style.sh
@@ -90,8 +90,9 @@ CLANG_FORMAT_RESULT=$?
 #############################################################################
 
 CHECK_CONTENTS_PATHSPEC=\
-"micro "\
-":(exclude)micro/tools/ci_build/test_code_style.sh"
+"micro"\
+" :(exclude)micro/tools/ci_build/test_code_style.sh"\
+" :(exclude)*\.md"
 
 # See https://github.com/tensorflow/tensorflow/issues/46297 for more context.
 check_contents "gtest|gmock" "${CHECK_CONTENTS_PATHSPEC}" \


### PR DESCRIPTION
Documentation should be exempt from these checks. For example the references to gmock in https://github.com/tensorflow/tensorflow/pull/48805 is intended and useful.
