### PR TITLE
Exclude some Python targets from OSS presubmit checks.

### DIFF
--- a/tensorflow/lite/micro/examples/person_detection/utils/BUILD
+++ b/tensorflow/lite/micro/examples/person_detection/utils/BUILD
@@ -10,6 +10,9 @@ py_binary(
     srcs = ["raw_to_bitmap.py"],
     python_version = "PY3",
     srcs_version = "PY3ONLY",
+    tags = [
+        "no_oss",  # TODO(b/186670822): enable once tflite-micro supports bazel+Python
+    ],
     deps = ["//third_party/py/numpy"],
 )
 
@@ -17,6 +20,9 @@ py_library(
     name = "raw_to_bitmap_lib",
     srcs = ["raw_to_bitmap.py"],
     srcs_version = "PY3",
+    tags = [
+        "no_oss",  # TODO(b/186670822): enable once tflite-micro supports bazel+Python
+    ],
     deps = [
         "//third_party/py/numpy",
     ],


### PR DESCRIPTION
While these targets work ok in the TF github repo, they need some additional setup for the tflite-micro repo which we are currently punting on.

Fixes http://b/186670822