### PR TITLE
Port micro op GATHER_ND and its test code from lite

### DIFF
--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -278,6 +278,7 @@ cc_library(
         "floor.cc",
         "floor_div.cc",
         "floor_mod.cc",
+        "gather_nd.cc",
         "l2norm.cc",
         "l2_pool_2d.cc",
         "leaky_relu.cc",
@@ -728,6 +729,21 @@ cc_test(
     name = "fully_connected_test",
     srcs = [
         "fully_connected_test.cc",
+    ],
+    deps = [
+        ":kernel_runner",
+        "//tensorflow/lite/c:common",
+        "//tensorflow/lite/micro:micro_utils",
+        "//tensorflow/lite/micro:op_resolvers",
+        "//tensorflow/lite/micro:test_helpers",
+        "//tensorflow/lite/micro/testing:micro_test",
+    ],
+)
+
+cc_test(
+    name = "gather_nd_test",
+    srcs = [
+        "gather_nd_test.cc",
     ],
     deps = [
         ":kernel_runner",

--- a/tensorflow/lite/micro/kernels/gather_nd.cc
+++ b/tensorflow/lite/micro/kernels/gather_nd.cc
@@ -1,0 +1,201 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/micro_utils.h"
+
+namespace tflite {
+namespace {
+
+constexpr int kParams = 0;
+constexpr int kIndices = 1;
+constexpr int kOutputTensor = 0;
+constexpr int MAX_INDICES_ND = 5;
+
+TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+  TF_LITE_ENSURE_EQ(context, NumInputs(node), 2);
+  TF_LITE_ENSURE_EQ(context, NumOutputs(node), 1);
+
+  const TfLiteTensor* params;
+  TF_LITE_ENSURE_OK(context, GetInputSafe(context, node, kParams, &params));
+  const TfLiteTensor* indices;
+  TF_LITE_ENSURE_OK(context, GetInputSafe(context, node, kIndices, &indices));
+  TfLiteTensor* output;
+  TF_LITE_ENSURE_OK(context,
+                    GetOutputSafe(context, node, kOutputTensor, &output));
+
+  switch (params->type) {
+    case kTfLiteFloat32:
+    case kTfLiteInt8:
+      break;
+    default:
+      TF_LITE_KERNEL_LOG(context,
+                         "Params of type '%s' are not supported by gather_nd.",
+                         TfLiteTypeGetName(params->type));
+      return kTfLiteError;
+      break;
+  }
+  switch (indices->type) {
+    case kTfLiteInt32:
+      break;
+    default:
+      TF_LITE_KERNEL_LOG(context,
+                         "Indices of type '%s' are not supported by gather_nd.",
+                         TfLiteTypeGetName(indices->type));
+      return kTfLiteError;
+  }
+
+  const int params_rank = NumDimensions(params);
+  const int indices_rank = NumDimensions(indices);
+  const int indices_nd = SizeOfDimension(indices, indices_rank - 1);
+  if (params_rank < 1) {
+    TF_LITE_KERNEL_LOG(context, "Params must be at least a vector.");
+    return kTfLiteError;
+  }
+  if (indices_rank < 1) {
+    TF_LITE_KERNEL_LOG(context, "Indices must be at least a vector.");
+    return kTfLiteError;
+  }
+  if (indices_nd > params_rank) {
+    TF_LITE_KERNEL_LOG(
+        context, "Index innermost dimension length must be <= params rank.");
+    return kTfLiteError;
+  }
+  if (indices_nd > MAX_INDICES_ND) {
+    TF_LITE_KERNEL_LOG(context,
+                       "Index innermost dimension length must not exceed %d.",
+                       MAX_INDICES_ND);
+    return kTfLiteError;
+  }
+
+  // Assign to output the input type.
+  output->type = params->type;
+
+  // TFLM gather_nd does not create the output tensor, but it needs to ensure
+  // that the output shape is correct. The result shape is
+  // indices.shape[:-1] + params.shape[indices.shape[-1]:]
+  TfLiteIntArray* output_shape = output->dims;
+  int output_index = 0;
+  for (int i = 0; i < indices_rank - 1; ++i) {
+    output_shape->data[output_index++] = indices->dims->data[i];
+  }
+  for (int i = indices_nd; i < params_rank; ++i) {
+    output_shape->data[output_index++] = params->dims->data[i];
+  }
+  output_shape->size = output_index;
+  return kTfLiteOk;
+}
+
+template <typename ParamsT, typename IndicesT>
+TfLiteStatus GatherNd(const TfLiteEvalTensor* params,
+                      const TfLiteEvalTensor* indices,
+                      TfLiteEvalTensor* output) {
+  const int indices_dims = indices->dims->size;
+  const int indices_nd = indices->dims->data[indices_dims - 1];
+  const int params_dims = params->dims->size;
+  const IndicesT* index_data = tflite::micro::GetTensorData<IndicesT>(indices);
+  const ParamsT* param_data = tflite::micro::GetTensorData<ParamsT>(params);
+  ParamsT* output_data = tflite::micro::GetTensorData<ParamsT>(output);
+
+  int n_slices = 1;
+  for (int i = 0; i < indices_dims - 1; ++i) {
+    n_slices *= indices->dims->data[i];
+  }
+
+  // If indices[-1] == params.rank, fetch single elements.
+  // If indices[-1] < params.rank, fetch slices.
+  int slice_size = 1;
+  for (int i = indices_nd; i < params_dims; ++i) {
+    slice_size *= params->dims->data[i];
+  }
+
+  int remain_flat_size = ElementCount(*params->dims);
+
+  // Number of elements per dimension
+  int dims_to_count[MAX_INDICES_ND];
+  for (int i = 0; i < indices_nd; ++i) {
+    dims_to_count[i] = remain_flat_size / params->dims->data[i];
+    remain_flat_size = dims_to_count[i];
+  }
+
+  for (int i = 0; i < n_slices; ++i) {
+    int from_pos = 0;
+    for (int j = 0; j < indices_nd; ++j) {
+      int offset = i * indices_nd + j;
+      IndicesT index = index_data[offset];
+      from_pos += index * dims_to_count[j];
+    }
+    std::memcpy(output_data + i * slice_size, param_data + from_pos,
+                sizeof(ParamsT) * slice_size);
+  }
+  return kTfLiteOk;
+}
+
+template <typename IndicesT>
+TfLiteStatus EvalGatherNd(TfLiteContext* context,
+                          const TfLiteEvalTensor* params,
+                          const TfLiteEvalTensor* indices,
+                          TfLiteEvalTensor* output) {
+  switch (params->type) {
+    case kTfLiteFloat32:
+      return GatherNd<float, IndicesT>(params, indices, output);
+      break;
+    case kTfLiteInt8:
+      return GatherNd<int8_t, IndicesT>(params, indices, output);
+      break;
+    default:
+      TF_LITE_KERNEL_LOG(context,
+                         "Params type '%s' are not supported by gather_nd.",
+                         TfLiteTypeGetName(params->type));
+      return kTfLiteError;
+  }
+}
+
+TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
+  const TfLiteEvalTensor* params =
+      tflite::micro::GetEvalInput(context, node, kParams);
+  const TfLiteEvalTensor* indices =
+      tflite::micro::GetEvalInput(context, node, kIndices);
+  TfLiteEvalTensor* output =
+      tflite::micro::GetEvalOutput(context, node, kOutputTensor);
+
+  switch (indices->type) {
+    case kTfLiteInt32:
+      return EvalGatherNd<int32_t>(context, params, indices, output);
+      break;
+    default:
+      TF_LITE_KERNEL_LOG(context,
+                         "Indices of type '%s' are not supported by gather_nd.",
+                         TfLiteTypeGetName(indices->type));
+      return kTfLiteError;
+  }
+}
+}  // namespace
+
+TfLiteRegistration Register_GATHER_ND() {
+  return {/*init=*/nullptr,
+          /*free=*/nullptr,
+          /*prepare=*/Prepare,
+          /*invoke=*/Eval,
+          /*profiling_string=*/nullptr,
+          /*builtin_code=*/0,
+          /*custom_name=*/nullptr,
+          /*version=*/0};
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/gather_nd_test.cc
+++ b/tensorflow/lite/micro/kernels/gather_nd_test.cc
@@ -1,0 +1,301 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/micro/all_ops_resolver.h"
+#include "tensorflow/lite/micro/kernels/kernel_runner.h"
+#include "tensorflow/lite/micro/test_helpers.h"
+#include "tensorflow/lite/micro/testing/micro_test.h"
+
+namespace tflite {
+namespace testing {
+namespace {
+
+template <typename ParamType, typename IndexType>
+void TestGatherNd(const int* param_dims, const ParamType* param_data,
+                  const int* index_dims, const IndexType* index_data,
+                  int* output_dims, ParamType* output_data,
+                  const ParamType* expected_output_data) {
+  TfLiteIntArray* pdims = IntArrayFromInts(param_dims);
+  TfLiteIntArray* idims = IntArrayFromInts(index_dims);
+  TfLiteIntArray* odims = IntArrayFromInts(output_dims);
+
+  constexpr int inputs_size = 2;
+  constexpr int outputs_size = 1;
+  constexpr int tensors_size = inputs_size + outputs_size;
+  TfLiteTensor tensors[tensors_size] = {
+      CreateTensor(param_data, pdims),
+      CreateTensor(index_data, idims),
+      CreateTensor(output_data, odims),
+  };
+  int inputs_array_data[] = {2, 0, 1};
+  TfLiteIntArray* inputs_array = IntArrayFromInts(inputs_array_data);
+  int outputs_array_data[] = {1, 2};
+  TfLiteIntArray* outputs_array = IntArrayFromInts(outputs_array_data);
+
+  const TfLiteRegistration registration = Register_GATHER_ND();
+  micro::KernelRunner runner(registration, tensors, tensors_size, inputs_array,
+                             outputs_array, /*builtin_data=*/nullptr);
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, runner.InitAndPrepare());
+  TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, runner.Invoke());
+
+  // The output tensor's data and shape have been updated by the kernel.
+  TfLiteTensor* actual_output_tensor = &tensors[2];
+  TfLiteIntArray* actual_output_dims = actual_output_tensor->dims;
+  const int output_size = ElementCount(*actual_output_dims);
+  for (int i = 0; i < output_size; ++i) {
+    TF_LITE_MICRO_EXPECT_EQ(expected_output_data[i], output_data[i]);
+  }
+}
+
+}  // namespace
+}  // namespace testing
+}  // namespace tflite
+
+TF_LITE_MICRO_TESTS_BEGIN
+
+TF_LITE_MICRO_TEST(GatherNd_ElementIndexingIntoMatrix) {
+  // For input_dims[], index_dims[], or output_dims[], element 0 is the
+  // number of dimensions in that array, not the actual dimension data.
+  const int input_dims[] = {2, 2, 2};
+  const int index_dims[] = {2, 2, 2};
+  const int32_t index_data[] = {0, 0, 1, 1};
+  const float input_data[] = {1.1, 1.2, 2.1, 2.2};
+  const float golden_data[] = {1.1, 2.2};
+  float output_data[2];
+  int output_dims[] = {1, 0};
+  tflite::testing::TestGatherNd<float, int32_t>(
+      input_dims, input_data, index_dims, index_data, output_dims, output_data,
+      golden_data);
+}
+
+TF_LITE_MICRO_TEST(GatherNd_SliceIndexingIntoMatrix) {
+  // For input_dims[], index_dims[], or output_dims[], element 0 is the
+  // number of dimensions in that array, not the actual dimension data.
+  const int input_dims[] = {2, 2, 2};
+  const int index_dims[] = {2, 2, 1};
+  const int32_t index_data[] = {1, 0};
+  const float input_data[] = {1.1, 1.2, 2.1, 2.2};
+  const float golden_data[] = {2.1, 2.2, 1.1, 1.2};
+  float output_data[4];
+  int output_dims[] = {2, 0, 0};
+  tflite::testing::TestGatherNd<float, int32_t>(
+      input_dims, input_data, index_dims, index_data, output_dims, output_data,
+      golden_data);
+}
+
+TF_LITE_MICRO_TEST(GatherNd_BatchedIndexingIntoMatrix1) {
+  // For input_dims[], index_dims[], or output_dims[], element 0 is the
+  // number of dimensions in that array, not the actual dimension data.
+  const int input_dims[] = {2, 2, 2};
+  const int index_dims[] = {3, 2, 1, 1};
+  const int32_t index_data[] = {1, 0};
+  const float input_data[] = {1.1, 1.2, 2.1, 2.2};
+  const float golden_data[] = {2.1, 2.2, 1.1, 1.2};
+  float output_data[4];
+  int output_dims[] = {3, 0, 0, 0};
+  tflite::testing::TestGatherNd<float, int32_t>(
+      input_dims, input_data, index_dims, index_data, output_dims, output_data,
+      golden_data);
+}
+
+TF_LITE_MICRO_TEST(GatherNd_BatchedIndexingIntoMatrix2) {
+  // For input_dims[], index_dims[], or output_dims[], element 0 is the
+  // number of dimensions in that array, not the actual dimension data.
+  const int input_dims[] = {2, 2, 2};
+  const int index_dims[] = {3, 2, 1, 2};
+  const int32_t index_data[] = {0, 0, 1, 1};
+  const float input_data[] = {1.1, 1.2, 2.1, 2.2};
+  const float golden_data[] = {1.1, 2.2};
+  float output_data[2];
+  int output_dims[] = {3, 0, 0, 0};
+  tflite::testing::TestGatherNd<float, int32_t>(
+      input_dims, input_data, index_dims, index_data, output_dims, output_data,
+      golden_data);
+}
+
+TF_LITE_MICRO_TEST(GatherNd_DuplicateIndexingIntoMatrix) {
+  // For input_dims[], index_dims[], or output_dims[], element 0 is the
+  // number of dimensions in that array, not the actual dimension data.
+  const int input_dims[] = {2, 2, 2};
+  const int index_dims[] = {2, 2, 2};
+  const int32_t index_data[] = {0, 0, 0, 0};
+  const float input_data[] = {1.1, 1.2, 2.1, 2.2};
+  const float golden_data[] = {1.1, 1.1};
+  float output_data[2];
+  int output_dims[] = {1, 0};
+  tflite::testing::TestGatherNd<float, int32_t>(
+      input_dims, input_data, index_dims, index_data, output_dims, output_data,
+      golden_data);
+}
+
+TF_LITE_MICRO_TEST(GatherNd_ElementIndexingIntoRank3Tensor) {
+  // For input_dims[], index_dims[], or output_dims[], element 0 is the
+  // number of dimensions in that array, not the actual dimension data.
+  const int input_dims[] = {3, 3, 2, 3};
+  const int index_dims[] = {3, 1, 2, 3};
+  const int32_t index_data[] = {0, 0, 1, 1, 1, 0};
+  const float input_data[] = {1.1, -1.2, 1.3,  -2.1, 2.2,  2.3,  //
+                              3.1, 3.2,  -3.3, -4.1, -4.2, 4.3,  //
+                              5.1, -5.2, 5.3,  6.1,  -6.2, 6.3};
+  const float golden_data[] = {-1.2, -4.1};
+  float output_data[2];
+  int output_dims[] = {1, 0};
+  tflite::testing::TestGatherNd<float, int32_t>(
+      input_dims, input_data, index_dims, index_data, output_dims, output_data,
+      golden_data);
+}
+
+TF_LITE_MICRO_TEST(GatherNd_SliceIndexingIntoRank3Tensor) {
+  // For input_dims[], index_dims[], or output_dims[], element 0 is the
+  // number of dimensions in that array, not the actual dimension data.
+  const int input_dims[] = {3, 3, 2, 3};
+  const int index_dims[] = {2, 2, 1};
+  const int32_t index_data[] = {0, 2};
+  const float input_data[] = {1.1, -1.2, 1.3,  -2.1, 2.2,  2.3,  //
+                              3.1, 3.2,  -3.3, -4.1, -4.2, 4.3,  //
+                              5.1, -5.2, 5.3,  6.1,  -6.2, 6.3};
+  const float golden_data[] = {1.1, -1.2, 1.3, -2.1, 2.2,  2.3,
+                               5.1, -5.2, 5.3, 6.1,  -6.2, 6.3};
+  float output_data[12];
+  int output_dims[] = {3, 0, 0, 0};
+  tflite::testing::TestGatherNd<float, int32_t>(
+      input_dims, input_data, index_dims, index_data, output_dims, output_data,
+      golden_data);
+}
+
+TF_LITE_MICRO_TEST(GatherNd_BatchedIndexingIntoRank3Tensor1) {
+  // For input_dims[], index_dims[], or output_dims[], element 0 is the
+  // number of dimensions in that array, not the actual dimension data.
+  const int input_dims[] = {3, 3, 2, 3};
+  const int index_dims[] = {3, 2, 1, 3};
+  const int32_t index_data[] = {0, 0, 1, 1, 1, 0};
+  const float input_data[] = {1.1, -1.2, 1.3,  -2.1, 2.2,  2.3,  //
+                              3.1, 3.2,  -3.3, -4.1, -4.2, 4.3,  //
+                              5.1, -5.2, 5.3,  6.1,  -6.2, 6.3};
+  const float golden_data[] = {-1.2, -4.1};
+  float output_data[2];
+  int output_dims[] = {2, 0, 0};
+  tflite::testing::TestGatherNd<float, int32_t>(
+      input_dims, input_data, index_dims, index_data, output_dims, output_data,
+      golden_data);
+}
+
+TF_LITE_MICRO_TEST(GatherNd_BatchedIndexingIntoRank3Tensor2) {
+  // For input_dims[], index_dims[], or output_dims[], element 0 is the
+  // number of dimensions in that array, not the actual dimension data.
+  const int input_dims[] = {3, 3, 2, 3};
+  const int index_dims[] = {3, 3, 1, 1};
+  const int32_t index_data[] = {1, 2, 0};
+  const float input_data[] = {1.1, -1.2, 1.3,  -2.1, 2.2,  2.3,  //
+                              3.1, 3.2,  -3.3, -4.1, -4.2, 4.3,  //
+                              5.1, -5.2, 5.3,  6.1,  -6.2, 6.3};
+  const float golden_data[] = {3.1, 3.2,  -3.3, -4.1, -4.2, 4.3,
+                               5.1, -5.2, 5.3,  6.1,  -6.2, 6.3,
+                               1.1, -1.2, 1.3,  -2.1, 2.2,  2.3};
+  float output_data[18];
+  int output_dims[] = {4, 0, 0, 0, 0};
+  tflite::testing::TestGatherNd<float, int32_t>(
+      input_dims, input_data, index_dims, index_data, output_dims, output_data,
+      golden_data);
+}
+
+TF_LITE_MICRO_TEST(GatherNd_BatchedIndexingIntoRank3Tensor3) {
+  // For input_dims[], index_dims[], or output_dims[], element 0 is the
+  // number of dimensions in that array, not the actual dimension data.
+  const int input_dims[] = {3, 3, 2, 3};
+  const int index_dims[] = {3, 2, 2, 2};
+  const int32_t index_data[] = {0, 1, 1, 0, 0, 0, 2, 1};
+  const float input_data[] = {1.1, -1.2, 1.3,  -2.1, 2.2,  2.3,  //
+                              3.1, 3.2,  -3.3, -4.1, -4.2, 4.3,  //
+                              5.1, -5.2, 5.3,  6.1,  -6.2, 6.3};
+  const float golden_data[] = {-2.1, 2.2,  2.3, 3.1, 3.2,  -3.3,
+                               1.1,  -1.2, 1.3, 6.1, -6.2, 6.3};
+  float output_data[12];
+  int output_dims[] = {3, 0, 0, 0};
+  tflite::testing::TestGatherNd<float, int32_t>(
+      input_dims, input_data, index_dims, index_data, output_dims, output_data,
+      golden_data);
+}
+
+TF_LITE_MICRO_TEST(GatherNd_BatchedIndexingIntoRank3Tensor4) {
+  // For input_dims[], index_dims[], or output_dims[], element 0 is the
+  // number of dimensions in that array, not the actual dimension data.
+  const int input_dims[] = {3, 3, 2, 3};
+  const int index_dims[] = {3, 2, 2, 3};
+  const int32_t index_data[] = {0, 0, 1, 1, 0, 1, 1, 1, 2, 2, 1, 2};
+  const float input_data[] = {1.1, -1.2, 1.3,  -2.1, 2.2,  2.3,  //
+                              3.1, 3.2,  -3.3, -4.1, -4.2, 4.3,  //
+                              5.1, -5.2, 5.3,  6.1,  -6.2, 6.3};
+  const float golden_data[] = {-1.2, 3.2, 4.3, 6.3};
+  float output_data[4];
+  int output_dims[] = {2, 0, 0};
+  tflite::testing::TestGatherNd<float, int32_t>(
+      input_dims, input_data, index_dims, index_data, output_dims, output_data,
+      golden_data);
+}
+
+TF_LITE_MICRO_TEST(GatherNd_DuplicateIndexingIntoRank3Tensor) {
+  // For input_dims[], index_dims[], or output_dims[], element 0 is the
+  // number of dimensions in that array, not the actual dimension data.
+  const int input_dims[] = {3, 3, 2, 3};
+  const int index_dims[] = {2, 2, 2};
+  const int32_t index_data[] = {0, 1, 0, 1};
+  const float input_data[] = {1.1, -1.2, 1.3,  -2.1, 2.2,  2.3,  //
+                              3.1, 3.2,  -3.3, -4.1, -4.2, 4.3,  //
+                              5.1, -5.2, 5.3,  6.1,  -6.2, 6.3};
+  const float golden_data[] = {-2.1, 2.2, 2.3, -2.1, 2.2, 2.3};
+  float output_data[6];
+  int output_dims[] = {2, 0, 0};
+  tflite::testing::TestGatherNd<float, int32_t>(
+      input_dims, input_data, index_dims, index_data, output_dims, output_data,
+      golden_data);
+}
+
+TF_LITE_MICRO_TEST(GatherNd_Float32Int32) {
+  // For input_dims[], index_dims[], or output_dims[], element 0 is the
+  // number of dimensions in that array, not the actual dimension data.
+  const int input_dims[] = {3, 3, 2, 3};
+  const int index_dims[] = {2, 2, 2};
+  const int32_t index_data[] = {0, 1, 1, 0};
+  const float input_data[] = {1.1, -1.2, 1.3,  -2.1, 2.2,  2.3,  //
+                              3.1, 3.2,  -3.3, -4.1, -4.2, 4.3,  //
+                              5.1, -5.2, 5.3,  6.1,  -6.2, 6.3};
+  const float golden_data[] = {-2.1, 2.2, 2.3, 3.1, 3.2, -3.3};
+  float output_data[6];
+  int output_dims[] = {2, 0, 0};
+  tflite::testing::TestGatherNd<float, int32_t>(
+      input_dims, input_data, index_dims, index_data, output_dims, output_data,
+      golden_data);
+}
+
+TF_LITE_MICRO_TEST(GatherNd_Int8Int32) {
+  // For input_dims[], index_dims[], or output_dims[], element 0 is the
+  // number of dimensions in that array, not the actual dimension data.
+  const int input_dims[] = {3, 3, 2, 3};
+  const int index_dims[] = {2, 2, 2};
+  const int32_t index_data[] = {0, 1, 1, 0};
+  const int8_t input_data[] = {1, -1, 1,  -2, 2,  2,  //
+                               3, 3,  -3, -4, -4, 4,  //
+                               5, -5, 5,  6,  -6, 6};
+  const int8_t golden_data[] = {-2, 2, 2, 3, 3, -3};
+  int8_t output_data[6];
+  int output_dims[] = {2, 0, 0};
+  tflite::testing::TestGatherNd<int8_t, int32_t>(
+      input_dims, input_data, index_dims, index_data, output_dims, output_data,
+      golden_data);
+}
+
+TF_LITE_MICRO_TESTS_END

--- a/tensorflow/lite/micro/kernels/micro_ops.h
+++ b/tensorflow/lite/micro/kernels/micro_ops.h
@@ -45,6 +45,7 @@ TfLiteRegistration Register_EXPAND_DIMS();
 TfLiteRegistration Register_FILL();
 TfLiteRegistration Register_FLOOR_DIV();
 TfLiteRegistration Register_FLOOR_MOD();
+TfLiteRegistration Register_GATHER_ND();
 TfLiteRegistration Register_L2_POOL_2D();
 TfLiteRegistration Register_LEAKY_RELU();
 TfLiteRegistration Register_LOG_SOFTMAX();

--- a/tensorflow/lite/micro/micro_mutable_op_resolver.h
+++ b/tensorflow/lite/micro/micro_mutable_op_resolver.h
@@ -254,6 +254,11 @@ class MicroMutableOpResolver : public MicroOpResolver {
                       ParseFullyConnected);
   }
 
+  TfLiteStatus AddGatherNd() {
+    return AddBuiltin(BuiltinOperator_GATHER_ND, tflite::Register_GATHER_ND(),
+                      ParseGatherNd);
+  }
+
   TfLiteStatus AddGreater() {
     return AddBuiltin(BuiltinOperator_GREATER,
                       tflite::ops::micro::Register_GREATER(), ParseGreater);

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -282,6 +282,7 @@ tensorflow/lite/micro/kernels/floor_test.cc \
 tensorflow/lite/micro/kernels/floor_div_test.cc \
 tensorflow/lite/micro/kernels/floor_mod_test.cc \
 tensorflow/lite/micro/kernels/fully_connected_test.cc \
+tensorflow/lite/micro/kernels/gather_nd_test.cc \
 tensorflow/lite/micro/kernels/hard_swish_test.cc \
 tensorflow/lite/micro/kernels/l2norm_test.cc \
 tensorflow/lite/micro/kernels/l2_pool_2d_test.cc \
@@ -349,6 +350,7 @@ tensorflow/lite/micro/kernels/floor_div.cc \
 tensorflow/lite/micro/kernels/floor_mod.cc \
 tensorflow/lite/micro/kernels/fully_connected.cc \
 tensorflow/lite/micro/kernels/fully_connected_common.cc \
+tensorflow/lite/micro/kernels/gather_nd.cc \
 tensorflow/lite/micro/kernels/hard_swish.cc \
 tensorflow/lite/micro/kernels/kernel_runner.cc \
 tensorflow/lite/micro/kernels/kernel_util.cc \


### PR DESCRIPTION
Issue #46268. This PR aims to finish porting GATHER_ND from TFL to TFLM.
(This PR combines the originally planned PRS 3, 4, and 5)

Notes:
1 For params/output tensors, only the float and int8_t data types are supported;
2 For indices tensors, only the int32_t data type is supported;
3 The reference implementation in lite/kernels/internal/reference/reference_ops.h was not used, due to the vector used in the reference (possible dynamic allocation);
4 As with the TFL kernel Gather_ND, the TFLM kernel does not yet support batch_dims as of April 23, 2021.