### PR TITLE
Build Failure fix on AVX2 machines replace si64 with epi64

### DIFF
--- a/tensorflow/lite/kernels/internal/optimized/depthwiseconv_uint8.h
+++ b/tensorflow/lite/kernels/internal/optimized/depthwiseconv_uint8.h
@@ -955,9 +955,9 @@ struct QuantizedDepthwiseConvKernel<true, 0, 1> {
       for (; ic <= input_depth - 16; ic += 16) {
 #ifdef __AVX2__
         // Load the filters, add filter_offset.
-        __m128i filter_u8_0 = _mm_loadu_si64(
+        __m128i filter_u8_0 = _mm_loadl_epi64(
             reinterpret_cast<const __m128i*>(local_filter_ptr + 8 * 0));
-        __m128i filter_u8_1 = _mm_loadu_si64(
+        __m128i filter_u8_1 = _mm_loadl_epi64(
             reinterpret_cast<const __m128i*>(local_filter_ptr + 8 * 1));
         local_filter_ptr += 16;
         __m256i filter_0 = _mm256_cvtepu8_epi32(filter_u8_0);
@@ -966,9 +966,9 @@ struct QuantizedDepthwiseConvKernel<true, 0, 1> {
         filter_0 = _mm256_add_epi32(filter_0, filter_offset_vec);
         filter_1 = _mm256_add_epi32(filter_1, filter_offset_vec);
         // Load the inputs, add input_offset.
-        __m128i input_u8_0 = _mm_loadu_si64(
+        __m128i input_u8_0 = _mm_loadl_epi64(
             reinterpret_cast<const __m128i*>(local_input_ptr + 8 * 0));
-        __m128i input_u8_1 = _mm_loadu_si64(
+        __m128i input_u8_1 = _mm_loadl_epi64(
             reinterpret_cast<const __m128i*>(local_input_ptr + 8 * 1));
         local_input_ptr += 16;
         __m256i input_0 = _mm256_cvtepu8_epi32(input_u8_0);


### PR DESCRIPTION
**Problem**:
CI has failed because of a recent commit from Public TF from Google for all AVX2 builds.
**Observation:**
*  Failure happens in AVX2 Haswell Machines

**Analysis**
*  Failure is because of this commit for AVX2 https://github.com/tensorflow/tensorflow/commit/878e2bb97bcef2881650a12c2187cd8a2249a6ad
*  To Reproduce you need to build using the following command that will use AVX2.
*  build command: build --cxxopt=-D_GLIBCXX_USE_CXX11_ABI=0 --copt=-O3 --copt=-march=haswell

**Fix**
*  "replace _mm_loadu_si64 with _mm_loadl_epi64 that generates the same assembly and works for AVX2 (such as Haswell machines)."
*  For reference: Similar Fix from before: https://github.com/abseil/abseil-cpp/issues/394
