### PR TITLE
[mlir-hlo] Added pass to transform view to alloc operations of the memref dialect.

### DIFF
--- a/tensorflow/compiler/mlir/hlo/BUILD
+++ b/tensorflow/compiler/mlir/hlo/BUILD
@@ -1036,6 +1036,7 @@ cc_library(
     name = "all_passes",
     hdrs = [
         "include/mlir-hlo/Dialect/mhlo/transforms/register_passes.h",
+        "include/mlir-hlo/Transforms/register_passes.h",
     ],
     visibility = [
         ":friends",
@@ -1043,6 +1044,7 @@ cc_library(
     deps = [
         ":LmhloPassIncGen",
         ":MhloPassIncGen",
+        ":mlir_buffer_transforms_pass_inc_gen",
         ":chlo_legalize_to_hlo",
         ":hlo_legalize_to_lhlo",
         ":legalize_control_flow",
@@ -1055,6 +1057,7 @@ cc_library(
         ":lhlo_legalize_to_affine",
         ":lhlo_legalize_to_gpu",
         ":lhlo_legalize_to_parallel_loops",
+        ":memref_view_to_alloc",
         ":mhlo_control_flow_to_scf",
         ":mhlo_fusion",
         ":mhlo_to_mhlo_lowering_patterns",
@@ -1063,6 +1066,55 @@ cc_library(
         ":test_passes",
         ":transform_unranked_hlo",
         "@llvm-project//mlir:Pass",
+    ],
+)
+
+gentbl(
+    name = "mlir_buffer_transforms_pass_inc_gen",
+    compatible_with = get_compatible_with_cloud(),
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            "-gen-pass-decls -name BufferTransforms",
+            "include/mlir-hlo/Transforms/passes.h.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "include/mlir-hlo/Transforms/passes.td",
+    deps = [
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ],
+)
+
+cc_library(
+    name = "buffer_transforms_pass_details",
+    hdrs = [
+        "include/mlir-hlo/Transforms/PassDetail.h",
+    ],
+    visibility = [
+        "//visibility:private",  # This target is a private detail of pass implementations
+    ],
+    deps = [
+        ":mlir_buffer_transforms_pass_inc_gen",
+        "@llvm-project//mlir:Pass",
+    ],
+)
+
+cc_library(
+    name = "memref_view_to_alloc",
+    srcs = ["lib/Transforms/memref_view_to_alloc.cc"],
+    hdrs = [
+        "include/mlir-hlo/Transforms/passes.h",
+        "include/mlir-hlo/Transforms/PassDetail.h"
+    ],
+    includes = ["include"],
+    deps = [
+        ":mlir_buffer_transforms_pass_inc_gen",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:MemRefDialect",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Transforms",
     ],
 )
 

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/CMakeLists.txt
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/CMakeLists.txt
@@ -14,3 +14,4 @@
 # limitations under the License.
 #
 add_subdirectory(Dialect)
+add_subdirectory(Transforms)

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/CMakeLists.txt
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-add_subdirectory(Dialect)
-add_subdirectory(Transforms)
-add_subdirectory(utils)
+
+set(LLVM_TARGET_DEFINITIONS passes.td)
+mlir_tablegen(passes.h.inc -gen-pass-decls -name BufferTransforms)
+add_public_tablegen_target(MLIRBufferTransformsPassIncGen)

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/PassDetail.h
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/PassDetail.h
@@ -1,0 +1,32 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_COMPILER_MLIR_HLO_INCLUDE_MLIR_HLO_TRANSFORMS_PASSDETAIL_H_
+#define TENSORFLOW_COMPILER_MLIR_HLO_INCLUDE_MLIR_HLO_TRANSFORMS_PASSDETAIL_H_
+
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+
+namespace memref {
+class MemRefDialect;
+} // end namespace memref
+
+#define GEN_PASS_CLASSES
+#include "mlir-hlo/Transforms/passes.h.inc"
+
+}  // end namespace mlir
+
+#endif  // TENSORFLOW_COMPILER_MLIR_HLO_INCLUDE_MLIR_HLO_TRANSFORMS_PASSDETAIL_H_

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.h
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.h
@@ -1,0 +1,35 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_COMPILER_MLIR_HLO_LIB_TRANSFORMS_PASSES_H_
+#define TENSORFLOW_COMPILER_MLIR_HLO_LIB_TRANSFORMS_PASSES_H_
+
+#include <memory>
+
+namespace mlir {
+
+class FuncOp;
+template <typename T>
+class OperationPass;
+
+//===----------------------------------------------------------------------===//
+// Passes
+//===----------------------------------------------------------------------===//
+
+std::unique_ptr<OperationPass<FuncOp>> createMemRefViewToAllocatePass();
+
+} // namespace mlir
+
+#endif  // TENSORFLOW_COMPILER_MLIR_HLO_LIB_TRANSFORMS_PASSES_H_

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.td
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.td
@@ -1,0 +1,29 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_COMPILER_MLIR_HLO_TRANSFORMS_PASSES
+#define TENSORFLOW_COMPILER_MLIR_HLO_TRANSFORMS_PASSES
+
+include "mlir/Pass/PassBase.td"
+
+def MemRefViewToAllocate : Pass<"memref-view-to-alloc","FuncOp">{
+  let summary = "Substitute a memref view with an allocate operation.";
+  let description = [{
+  This pass transforms memref view operations to allocate operations.
+  }];
+  let constructor = "mlir::createMemRefViewToAllocatePass()";
+}
+
+#endif // TENSORFLOW_COMPILER_MLIR_HLO_TRANSFORMS_PASSES

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/register_passes.h
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/register_passes.h
@@ -1,0 +1,31 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef MLIR_HLO_TRANSFORMS_REGISTER_PASSES_H_
+#define MLIR_HLO_TRANSFORMS_REGISTER_PASSES_H_
+
+#include "mlir-hlo/Transforms/passes.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+
+#define GEN_PASS_REGISTRATION
+#include "mlir-hlo/Transforms/passes.h.inc"
+
+inline void registerAllTransformPasses() { registerBufferTransformsPasses(); }
+
+} // end namespace mlir
+
+#endif  // MLIR_HLO_TRANSFORMS_REGISTER_PASSES_H_

--- a/tensorflow/compiler/mlir/hlo/lib/Transforms/CMakeLists.txt
+++ b/tensorflow/compiler/mlir/hlo/lib/Transforms/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-add_subdirectory(Dialect)
-add_subdirectory(Transforms)
-add_subdirectory(utils)
+
+add_mlir_library(MLIRBufferTransforms
+  memref_view_to_alloc.cc
+
+  DEPENDS
+  MLIRBufferTransformsPassIncGen
+
+  LINK_COMPONENTS
+  Core
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRMemRef
+  MLIRPass
+  MLIRTransforms
+)

--- a/tensorflow/compiler/mlir/hlo/lib/Transforms/memref_view_to_alloc.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Transforms/memref_view_to_alloc.cc
@@ -1,0 +1,73 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "mlir-hlo/Transforms/passes.h"
+#include "mlir-hlo/Transforms/PassDetail.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+using namespace mlir;
+
+namespace {
+class MemRefViewToAllocOp : public OpConversionPattern<memref::ViewOp> {
+public:
+  using OpConversionPattern<memref::ViewOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(memref::ViewOp op, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const final {
+    memref::ViewOpAdaptor adaptor(operands, op->getAttrDictionary());
+    rewriter.replaceOpWithNewOp<memref::AllocOp>(
+        op, getTypeConverter()->convertType(op.getType()).cast<MemRefType>(),
+        adaptor.sizes());
+    return success();
+  }
+};
+
+/// A helper type converter class that registers a type to type conversion.
+class MemRefViewTypeConverter : public TypeConverter {
+public:
+  MemRefViewTypeConverter() {
+    addConversion([](Type type) { return type; });
+  }
+};
+} // end anonymous namespace
+
+namespace {
+/// Pass to convert memref views to allocates.
+struct MemRefViewToAllocatePass
+    : public MemRefViewToAllocateBase<MemRefViewToAllocatePass> {
+  void runOnOperation() override {
+    // Parse memref.views to allocates
+    MLIRContext &context = getContext();
+    ConversionTarget target(context);
+    MemRefViewTypeConverter typeConverter;
+
+    target.addLegalDialect<memref::MemRefDialect>();
+    target.addIllegalOp<memref::ViewOp>();
+
+    RewritePatternSet patterns(&context);
+    patterns.add<MemRefViewToAllocOp>(typeConverter, patterns.getContext());
+    if (failed(applyPartialConversion(getOperation(), target,
+                                      std::move(patterns))))
+      signalPassFailure();
+  }
+};
+} // end anonymous namespace
+
+/// Create a pass to transform memref views to allocates.
+std::unique_ptr<OperationPass<FuncOp>> mlir::createMemRefViewToAllocatePass() {
+  return std::make_unique<MemRefViewToAllocatePass>();
+}

--- a/tensorflow/compiler/mlir/hlo/tests/memref_view_alloc.mlir
+++ b/tensorflow/compiler/mlir/hlo/tests/memref_view_alloc.mlir
@@ -1,0 +1,28 @@
+// RUN: mlir-hlo-opt --memref-view-to-alloc --split-input-file %s | FileCheck %s
+
+// Expected behavior: This code transforms the memref view to an alloc.
+// CHECK-LABEL: func @viewToAlloc
+ func @viewToAlloc(%arg0: memref<4xi8>){
+    %c0 = constant 0 : index
+    %0 = memref.view %arg0[%c0][] : memref<4xi8> to memref<i32>
+    return
+}
+
+// CHECK-SAME: %[[ARG0:.*]]: {{.*}}
+// CHECK-NEXT: %[[C0:.*]] = constant 0 : index
+// CHECK-NEXT: %[[V0:.*]] = memref.alloc() : memref<i32>
+
+// -----
+
+// Expected behavior: This code transforms the
+// memref view with a dynamic shape to an alloc.
+// CHECK-LABEL: func @dynamicTypeViewToAlloc
+ func @dynamicTypeViewToAlloc(%arg0: memref<?xi8>){
+    %c0 = constant 0 : index
+    %0 = memref.view %arg0[%c0][] : memref<?xi8> to memref<i32>
+    return
+}
+
+// CHECK-SAME: %[[ARG0:.*]]: {{.*}}
+// CHECK-NEXT: %[[C0:.*]] = constant 0 : index
+// CHECK-NEXT: %[[V0:.*]] = memref.alloc() : memref<i32>

--- a/tensorflow/compiler/mlir/hlo/tools/mlir-hlo-opt/CMakeLists.txt
+++ b/tensorflow/compiler/mlir/hlo/tools/mlir-hlo-opt/CMakeLists.txt
@@ -22,11 +22,13 @@ set(LIBS
 
         MhloRegisterDialects
         AllMhloPasses
+        MLIRBufferTransforms
         )
 add_llvm_executable(mlir-hlo-opt mlir-hlo-opt.cpp
   DEPENDS
         MLIRLmhloPassIncGen
         MLIRMhloPassIncGen
+        MLIRBufferTransformsPassIncGen
 )
 llvm_update_compile_flags(mlir-hlo-opt)
 target_link_libraries(mlir-hlo-opt PRIVATE ${LIBS})

--- a/tensorflow/compiler/mlir/hlo/tools/mlir-hlo-opt/mlir-hlo-opt.cpp
+++ b/tensorflow/compiler/mlir/hlo/tools/mlir-hlo-opt/mlir-hlo-opt.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 #include "mlir-hlo/Dialect/mhlo/IR/lhlo_gpu_ops.h"
 #include "mlir-hlo/Dialect/mhlo/IR/lhlo_ops.h"
 #include "mlir-hlo/Dialect/mhlo/transforms/register_passes.h"
+#include "mlir-hlo/Transforms/register_passes.h"
 #include "mlir/InitAllDialects.h"
 #include "mlir/InitAllPasses.h"
 #include "mlir/Support/MlirOptMain.h"
@@ -26,6 +27,7 @@ int main(int argc, char **argv) {
   mlir::registerAllPasses();
   mlir::mhlo::registerAllMhloPasses();
   mlir::lmhlo::registerAllLmhloPasses();
+  mlir::registerAllTransformPasses();
 
   mlir::DialectRegistry registry;
   mlir::registerAllDialects(registry);

--- a/tensorflow/compiler/mlir/tf_mlir_opt_main.cc
+++ b/tensorflow/compiler/mlir/tf_mlir_opt_main.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include "mlir/Support/MlirOptMain.h"  // from @llvm-project
 #include "tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/register.h"
 #include "tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/transforms/register_passes.h"
+#include "tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/register_passes.h"
 #include "tensorflow/compiler/mlir/init_mlir.h"
 #include "tensorflow/compiler/mlir/lite/ir/tfl_ops.h"
 #include "tensorflow/compiler/mlir/tensorflow/dialect_registration.h"
@@ -33,6 +34,7 @@ int main(int argc, char **argv) {
   mlir::registerTensorFlowPasses();
   mlir::mhlo::registerAllMhloPasses();
   mlir::lmhlo::registerAllLmhloPasses();
+  mlir::registerAllTransformPasses();
 
   mlir::DialectRegistry registry;
   mlir::registerAllDialects(registry);

--- a/tensorflow/compiler/mlir/tools/kernel_gen/tools/kernel-gen-opt/kernel-gen-opt.cc
+++ b/tensorflow/compiler/mlir/tools/kernel_gen/tools/kernel-gen-opt/kernel-gen-opt.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include "mlir/Support/MlirOptMain.h"  // from @llvm-project
 #include "tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/register.h"
 #include "tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/transforms/register_passes.h"
+#include "tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/register_passes.h"
 #include "tensorflow/compiler/mlir/tensorflow/dialect_registration.h"
 #include "tensorflow/compiler/mlir/tools/kernel_gen/ir/tf_framework_ops.h"
 #include "tensorflow/compiler/mlir/tools/kernel_gen/transforms/passes.h"
@@ -27,6 +28,7 @@ int main(int argc, char **argv) {
   mlir::mhlo::registerAllMhloPasses();
   mlir::lmhlo::registerAllLmhloPasses();
   mlir::kernel_gen::registerKernelGenPasses();
+  mlir::registerAllTransformPasses();
 
   mlir::DialectRegistry registry;
   mlir::registerAllDialects(registry);


### PR DESCRIPTION
We have added a new folder `Transform` to the mlir-hlo directory to add and compile new passes. This change also includes a number of new files, namely `passes.h`, `passed.td`, `register_passes.h` and `PassDetail.h`. These contain the information necessary to register new transformation-based passes in the MLIR namespace.

We have also added a new `memrefViewToAlloc` pass implemented in `memref_view_to_alloc.cc`. This pass intentionally converts `memref::View` ops to `memref::Alloc` ops. This is particularly useful for transforming the view-based intermediate output of the HLO backend into separate allocate operations.