### PR TITLE
removing inconsistencies in micro_speech_test.cc

### DIFF
--- a/tensorflow/lite/micro/examples/micro_speech/micro_speech_test.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/micro_speech_test.cc
@@ -100,8 +100,8 @@ TF_LITE_MICRO_TEST(TestInvoke) {
   const int kNoIndex = 3;
 
   // Make sure that the expected "Yes" score is higher than the other classes.
-  uint8_t silence_score = output->data.uint8[kSilenceIndex] + 128;
-  uint8_t unknown_score = output->data.uint8[kUnknownIndex] + 128;
+  uint8_t silence_score = output->data.int8[kSilenceIndex] + 128;
+  uint8_t unknown_score = output->data.int8[kUnknownIndex] + 128;
   uint8_t yes_score = output->data.int8[kYesIndex] + 128;
   uint8_t no_score = output->data.int8[kNoIndex] + 128;
   TF_LITE_MICRO_EXPECT_GT(yes_score, silence_score);


### PR DESCRIPTION
PR to fix issue mentioned in #48841. 

I ran 

```
make -f tensorflow/lite/micro/tools/make/Makefile test_micro_speech_test -j8
```

all tests passed on macOS