### PR TITLE
add go_package to proto definition files

### DIFF
--- a/tensorflow/core/framework/dataset_options.proto
+++ b/tensorflow/core/framework/dataset_options.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package tensorflow.data;
 
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/dataset_options_go_proto";
+
 // Represents the type of auto-sharding we enable.
 enum AutoShardPolicy {
   // AUTO: Attempts FILE-based sharding, falling back to DATA-based sharding.

--- a/tensorflow/core/framework/model.proto
+++ b/tensorflow/core/framework/model.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package tensorflow.data.model;
 
 option cc_enable_arenas = true;
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/model_go_proto";
 
 // Class of a node in the performance model.
 enum NodeClass {

--- a/tensorflow/core/protobuf/extension_type_variant.proto
+++ b/tensorflow/core/protobuf/extension_type_variant.proto
@@ -4,6 +4,8 @@ package tensorflow;
 
 import "tensorflow/core/protobuf/struct.proto";
 
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf/for_core_protos_go_proto";
+
 // Metadata for ExtensionTypeVariant, used when serializing as Variant.
 //
 // We define a new message here (rather than directly using TypeSpecProto for

--- a/tensorflow/core/protobuf/service_config.proto
+++ b/tensorflow/core/protobuf/service_config.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package tensorflow.data.experimental;
 
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf/for_core_protos_go_proto";
+
 // Configuration for a tf.data service DispatchServer.
 message DispatcherConfig {
   // The port for the dispatcher to bind to. A value of 0 indicates that the

--- a/tensorflow/core/protobuf/snapshot.proto
+++ b/tensorflow/core/protobuf/snapshot.proto
@@ -6,6 +6,8 @@ import "tensorflow/core/framework/tensor.proto";
 import "tensorflow/core/framework/tensor_shape.proto";
 import "tensorflow/core/framework/types.proto";
 
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf/for_core_protos_go_proto";
+
 // Each SnapshotRecord represents one batch of pre-processed input data. A batch
 // consists of a list of tensors that we encode as TensorProtos. This message
 // doesn't store the structure of the batch.


### PR DESCRIPTION
In TF 2.5.0, protoc-gen-go errors on a select set of proto definition files: `unable to determine import path`.  This PR fixes this issue by declaring the go_package in these definitions.  See also #17262. 