### PR TITLE
Issue 47269: Disallow inline optimizer to optimize away function when it has been decorated with 'experimental_implements'

### DIFF
--- a/tensorflow/compiler/mlir/lite/transforms/prepare_composite_functions_tf.cc
+++ b/tensorflow/compiler/mlir/lite/transforms/prepare_composite_functions_tf.cc
@@ -281,6 +281,9 @@ void PrepareCompositeFunctionsPass::ConvertTFImplements(FuncOp func,
     if (failed(image_warping.RewriteFunc())) {
       return signalPassFailure();
     }
+  } else {
+      func.emitError() << "Function was flagged with experimental_implements, but no handler picked it up";
+      return signalPassFailure();
   }
 }
 
@@ -305,6 +308,9 @@ void PrepareCompositeFunctionsPass::ConvertTFImplementsWithAttributes(
     if (failed(max_unpooling.RewriteFunc())) {
       return signalPassFailure();
     }
+  } else {
+      func.emitError() << "Function was flagged with experimental_implements, but no handler picked it up";
+      return signalPassFailure();
   }
 }
 
@@ -323,6 +329,9 @@ void PrepareCompositeFunctionsPass::ConvertTFAPIImplements(FuncOp func,
     func.addEntryBlock();
     OpBuilder builder(func.getBody());
     if (failed(ConvertKerasLSTMLayer(func, &builder)))
+      return signalPassFailure();
+  } else {
+      func.emitError() << "Function was flagged with experimental_implements, but no handler picked it up";
       return signalPassFailure();
   }
 }

--- a/tensorflow/compiler/mlir/lite/transforms/prepare_composite_functions_tf.cc
+++ b/tensorflow/compiler/mlir/lite/transforms/prepare_composite_functions_tf.cc
@@ -282,8 +282,7 @@ void PrepareCompositeFunctionsPass::ConvertTFImplements(FuncOp func,
       return signalPassFailure();
     }
   } else {
-      func.emitError() << "Function was flagged with experimental_implements, but no handler picked it up";
-      return signalPassFailure();
+      func.emitWarning() << "Function was flagged with experimental_implements, but no handler picked it up";
   }
 }
 
@@ -309,8 +308,7 @@ void PrepareCompositeFunctionsPass::ConvertTFImplementsWithAttributes(
       return signalPassFailure();
     }
   } else {
-      func.emitError() << "Function was flagged with experimental_implements, but no handler picked it up";
-      return signalPassFailure();
+      func.emitWarning() << "Function was flagged with experimental_implements, but no handler picked it up";
   }
 }
 
@@ -331,8 +329,7 @@ void PrepareCompositeFunctionsPass::ConvertTFAPIImplements(FuncOp func,
     if (failed(ConvertKerasLSTMLayer(func, &builder)))
       return signalPassFailure();
   } else {
-      func.emitError() << "Function was flagged with experimental_implements, but no handler picked it up";
-      return signalPassFailure();
+      func.emitWarning() << "Function was flagged with experimental_implements, but no handler picked it up";
   }
 }
 

--- a/tensorflow/core/common_runtime/inline_function_utils.cc
+++ b/tensorflow/core/common_runtime/inline_function_utils.cc
@@ -400,6 +400,10 @@ Status ValidateInlining(const Node* node, const FunctionBody* fbody,
     }
   }
 
+  if (fbody->fdef.attr().find("_implements") != fbody->fdef.attr().end())
+    return errors::InvalidArgument(
+        "Function was declared with experimental_implements");
+
   if (!options.ignore_noinline) {
     TF_RETURN_IF_ERROR(ValidateNoInline(fbody));
   }


### PR DESCRIPTION
Reference issue: https://github.com/tensorflow/tensorflow/issues/47269

The cause of the issue (i.e. that the 'experimental_implements' flag did not cause the PrepareCompositeFunctionsPass::ConvertTFImplements function to be called) was that the inline optimizer optimized away the function entirely, and thereby removing said flag.
Unless I misunderstand the intended functionality, when a function has been decorated with that flag, it should remain entirely untouched, since it is intended to be transformed by ConvertTFImplements.

Tfhe fix in the PR checks for the  "_implements"  attribute in the function (which is what 'experimental_implements' gets transformed into) and returns as un-optimizable.