### PR TITLE
[cherry-pick r2.5] Fix the backward RNN layer with ragged inputs.

### DIFF
--- a/tensorflow/python/keras/backend.py
+++ b/tensorflow/python/keras/backend.py
@@ -6510,12 +6510,20 @@ def convert_inputs_if_ragged(inputs):
   return inputs, nested_row_lengths
 
 
-def maybe_convert_to_ragged(is_ragged_input, output, nested_row_lengths):
+def maybe_convert_to_ragged(is_ragged_input, output, nested_row_lengths,
+                            go_backwards=False):
   """Converts any ragged input back to its initial structure."""
   if not is_ragged_input:
     return output
 
-  return ragged_tensor.RaggedTensor.from_tensor(output, nested_row_lengths)
+  if go_backwards:
+    # Reverse based on the timestep dim, so that nested_row_lengths will mask
+    # from the correct direction. Return the reverse ragged tensor.
+    output = reverse(output, [1])
+    ragged = ragged_tensor.RaggedTensor.from_tensor(output, nested_row_lengths)
+    return reverse(ragged, [1])
+  else:
+    return ragged_tensor.RaggedTensor.from_tensor(output, nested_row_lengths)
 
 
 class ContextValueCache(weakref.WeakKeyDictionary):

--- a/tensorflow/python/keras/layers/recurrent.py
+++ b/tensorflow/python/keras/layers/recurrent.py
@@ -820,7 +820,7 @@ class RNN(Layer):
 
     if self.return_sequences:
       output = backend.maybe_convert_to_ragged(
-          is_ragged_input, outputs, row_lengths)
+          is_ragged_input, outputs, row_lengths, go_backwards=self.go_backwards)
     else:
       output = last_output
 

--- a/tensorflow/python/keras/layers/recurrent_test.py
+++ b/tensorflow/python/keras/layers/recurrent_test.py
@@ -1681,6 +1681,40 @@ class RNNTest(keras_parameterized.TestCase):
         output_dense, lengths=row_lengths)
     self.assertAllClose(output_ragged, output_dense)
 
+    # Check if return sequences and go_backwards outputs are correct
+    np.random.seed(100)
+    returning_rnn_layer = layer(4, go_backwards=True, return_sequences=True)
+
+    x_ragged = keras.Input(shape=(None, 5), ragged=True)
+    y_ragged = returning_rnn_layer(x_ragged)
+    model = keras.models.Model(x_ragged, y_ragged)
+    output_ragged = model.predict(ragged_data, steps=1)
+    self.assertAllClose(output_ragged.ragged_rank, ragged_data.ragged_rank)
+    self.assertAllClose(output_ragged.row_splits, ragged_data.row_splits)
+
+    x_dense = keras.Input(shape=(3, 5))
+    masking = keras.layers.Masking()(x_dense)
+    y_dense = returning_rnn_layer(masking)
+    model_2 = keras.models.Model(x_dense, y_dense)
+    dense_data = ragged_data.to_tensor()
+    output_dense = model_2.predict(dense_data, steps=1)
+
+    # Note that the raw output for dense and ragged input when go_backward=True
+    # will be different. Consider following input
+    # [[a, b, 0], [c, 0, 0], [d, e, f]] where 0s are masked value.
+    # The dense output will be [[0, b, a], [0, 0, c], [f, e, d]] since it will
+    # process the whole sequence from the end.
+    # While ragged output will be [[b, a], [c], [f, e, d]] since it just ignore
+    # the 0s. And if we densify the ragged output, it will by default inserting
+    # 0s to the end (rather than from the beginning), which make the output to
+    # be [[b, a, 0], [c, 0, 0], [f, e, d]]. With this, we need to verify that
+    # reverse(ragged_output.to_tensor()) == reverse(dense_output)
+    output_dense = keras.backend.reverse(output_dense, [1])
+    output_dense = ragged_tensor.RaggedTensor.from_tensor(
+        output_dense, lengths=row_lengths)
+
+    self.assertAllClose(keras.backend.reverse(output_ragged, [1]), output_dense)
+
   def test_stateless_rnn_cell(self):
 
     class StatelessCell(keras.layers.Layer):

--- a/tensorflow/python/keras/layers/recurrent_v2.py
+++ b/tensorflow/python/keras/layers/recurrent_v2.py
@@ -463,7 +463,7 @@ class GRU(recurrent.DropoutRNNCellMixin, recurrent.GRU):
 
     if self.return_sequences:
       output = backend.maybe_convert_to_ragged(
-          is_ragged_input, outputs, row_lengths)
+          is_ragged_input, outputs, row_lengths, go_backwards=self.go_backwards)
     else:
       output = last_output
 
@@ -1276,7 +1276,7 @@ class LSTM(recurrent.DropoutRNNCellMixin, recurrent.LSTM):
 
     if self.return_sequences:
       output = backend.maybe_convert_to_ragged(
-          is_ragged_input, outputs, row_lengths)
+          is_ragged_input, outputs, row_lengths, go_backwards=self.go_backwards)
     else:
       output = last_output
 


### PR DESCRIPTION
When RaggedTensors are used in Bidirectional (or backward) RNN/LSTM/GRU layers, the current implementation silently returns incorrect values, which is a grave issue without any obvious indication. Therefore, I propose to cherry-pick it for TF 2.5 before it is released.