### PR TITLE
Avoid empty fallback list for cudnn v8.2

### DIFF
--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -159,11 +159,11 @@ def _tf_repositories():
         name = "cudnn_frontend_archive",
         build_file = "//third_party:cudnn_frontend.BUILD",
         patch_file = "//third_party:cudnn_frontend_header_fix.patch",
-        sha256 = "498f908ced41bbf524af6b89dc4229d5cc89311bfaaed1e3794981e858629196",
-        strip_prefix = "cudnn-frontend-360d6e7164dfb7c802493fd1c0464f0d815b852a",
+        sha256 = "c22e4e402c50e87e1973df5411b996be08db402ab3c73c6fe8e6de3400a974ee",
+        strip_prefix = "cudnn-frontend-b4e1ad9613b89199982c9baf6ee91f6f98f5606d",
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/NVIDIA/cudnn-frontend/archive/360d6e7164dfb7c802493fd1c0464f0d815b852a.zip",
-            "https://github.com/NVIDIA/cudnn-frontend/archive/360d6e7164dfb7c802493fd1c0464f0d815b852a.zip",
+            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/NVIDIA/cudnn-frontend/archive/b4e1ad9613b89199982c9baf6ee91f6f98f5606d.zip",
+            "https://github.com/NVIDIA/cudnn-frontend/archive/b4e1ad9613b89199982c9baf6ee91f6f98f5606d.zip",
         ],
     )
 

--- a/third_party/cudnn_frontend_header_fix.patch
+++ b/third_party/cudnn_frontend_header_fix.patch
@@ -1,4 +1,4 @@
-From e8dd227635918d0dd35f45f91c01c5076e8137d0 Mon Sep 17 00:00:00 2001
+From 7a8b9986a4b60f0156c79378fec6f3e2cb7e3b12 Mon Sep 17 00:00:00 2001
 From: Kaixi Hou <kaixih@nvidia.com>
 Date: Tue, 4 May 2021 15:21:11 -0700
 Subject: [PATCH] Update headers path
@@ -12,11 +12,12 @@ Subject: [PATCH] Update headers path
  include/cudnn_frontend_ExecutionPlan.h      | 4 ++--
  include/cudnn_frontend_Filters.h            | 2 +-
  include/cudnn_frontend_Heuristics.h         | 4 ++--
+ include/cudnn_frontend_MatMulDesc.h         | 4 ++--
  include/cudnn_frontend_Operation.h          | 4 ++--
  include/cudnn_frontend_OperationGraph.h     | 4 ++--
  include/cudnn_frontend_PointWiseDesc.h      | 4 ++--
  include/cudnn_frontend_VariantPack.h        | 4 ++--
- 12 files changed, 21 insertions(+), 23 deletions(-)
+ 13 files changed, 23 insertions(+), 25 deletions(-)
 
 diff --git a/include/cudnn_backend_base.h b/include/cudnn_backend_base.h
 index b07b336..3fb06a7 100644
@@ -141,6 +142,21 @@ index 446f932..b15f472 100644
  
  #include "cudnn_frontend_OperationGraph.h"
  #include "cudnn_frontend_utils.h"
+diff --git a/include/cudnn_frontend_MatMulDesc.h b/include/cudnn_frontend_MatMulDesc.h
+index e416002..da2deb1 100644
+--- a/include/cudnn_frontend_MatMulDesc.h
++++ b/include/cudnn_frontend_MatMulDesc.h
+@@ -29,8 +29,8 @@
+ #include <sstream>
+ #include <utility>
+ 
+-#include <cudnn.h>
+-#include <cudnn_backend.h>
++#include "third_party/gpus/cudnn/cudnn.h"
++#include "third_party/gpus/cudnn/cudnn_backend.h"
+ 
+ #include "cudnn_frontend_utils.h"
+ 
 diff --git a/include/cudnn_frontend_Operation.h b/include/cudnn_frontend_Operation.h
 index e672c73..78a189a 100644
 --- a/include/cudnn_frontend_Operation.h

--- a/third_party/cudnn_frontend_header_fix.patch
+++ b/third_party/cudnn_frontend_header_fix.patch
@@ -1,3 +1,23 @@
+From e8dd227635918d0dd35f45f91c01c5076e8137d0 Mon Sep 17 00:00:00 2001
+From: Kaixi Hou <kaixih@nvidia.com>
+Date: Tue, 4 May 2021 15:21:11 -0700
+Subject: [PATCH] Update headers path
+
+---
+ include/cudnn_backend_base.h                | 2 +-
+ include/cudnn_frontend_ConvDesc.h           | 4 ++--
+ include/cudnn_frontend_Engine.h             | 4 ++--
+ include/cudnn_frontend_EngineConfig.h       | 4 ++--
+ include/cudnn_frontend_EngineFallbackList.h | 4 +---
+ include/cudnn_frontend_ExecutionPlan.h      | 4 ++--
+ include/cudnn_frontend_Filters.h            | 2 +-
+ include/cudnn_frontend_Heuristics.h         | 4 ++--
+ include/cudnn_frontend_Operation.h          | 4 ++--
+ include/cudnn_frontend_OperationGraph.h     | 4 ++--
+ include/cudnn_frontend_PointWiseDesc.h      | 4 ++--
+ include/cudnn_frontend_VariantPack.h        | 4 ++--
+ 12 files changed, 21 insertions(+), 23 deletions(-)
+
 diff --git a/include/cudnn_backend_base.h b/include/cudnn_backend_base.h
 index b07b336..3fb06a7 100644
 --- a/include/cudnn_backend_base.h
@@ -27,7 +47,7 @@ index d8706d4..6cabf6e 100644
  #include "cudnn_frontend_utils.h"
  
 diff --git a/include/cudnn_frontend_Engine.h b/include/cudnn_frontend_Engine.h
-index 7b3c612..05ee6a6 100644
+index 644a759..0e2f76b 100644
 --- a/include/cudnn_frontend_Engine.h
 +++ b/include/cudnn_frontend_Engine.h
 @@ -30,8 +30,8 @@
@@ -42,7 +62,7 @@ index 7b3c612..05ee6a6 100644
  #include "cudnn_frontend_OperationGraph.h"
  #include "cudnn_frontend_utils.h"
 diff --git a/include/cudnn_frontend_EngineConfig.h b/include/cudnn_frontend_EngineConfig.h
-index 37b4e99..1afd3cc 100644
+index 3e37848..1980207 100644
 --- a/include/cudnn_frontend_EngineConfig.h
 +++ b/include/cudnn_frontend_EngineConfig.h
 @@ -29,8 +29,8 @@
@@ -57,7 +77,7 @@ index 37b4e99..1afd3cc 100644
  #include "cudnn_frontend_Engine.h"
  #include "cudnn_frontend_utils.h"
 diff --git a/include/cudnn_frontend_EngineFallbackList.h b/include/cudnn_frontend_EngineFallbackList.h
-index 4fadb44..cb2be8a 100644
+index 6c3164d..86b150e 100644
 --- a/include/cudnn_frontend_EngineFallbackList.h
 +++ b/include/cudnn_frontend_EngineFallbackList.h
 @@ -22,7 +22,7 @@
@@ -69,8 +89,17 @@ index 4fadb44..cb2be8a 100644
  #include <numeric>
  
  namespace cudnn_frontend {
+@@ -56,8 +56,6 @@ auto static get_fallback_engine_list(cudnnBackendDescriptorType_t mode) -> std::
+             } else {
+                 return {};
+             }
+-        } else {
+-            return {};
+         }
+     } else {
+         return {};
 diff --git a/include/cudnn_frontend_ExecutionPlan.h b/include/cudnn_frontend_ExecutionPlan.h
-index 03be7ec..1e8ea83 100644
+index 9e29f1e..167586c 100644
 --- a/include/cudnn_frontend_ExecutionPlan.h
 +++ b/include/cudnn_frontend_ExecutionPlan.h
 @@ -29,8 +29,8 @@
@@ -98,7 +127,7 @@ index c8ca775..5969ec1 100644
  namespace cudnn_frontend {
  
 diff --git a/include/cudnn_frontend_Heuristics.h b/include/cudnn_frontend_Heuristics.h
-index 13a2e32..6a74c5f 100644
+index 446f932..b15f472 100644
 --- a/include/cudnn_frontend_Heuristics.h
 +++ b/include/cudnn_frontend_Heuristics.h
 @@ -24,8 +24,8 @@
@@ -113,7 +142,7 @@ index 13a2e32..6a74c5f 100644
  #include "cudnn_frontend_OperationGraph.h"
  #include "cudnn_frontend_utils.h"
 diff --git a/include/cudnn_frontend_Operation.h b/include/cudnn_frontend_Operation.h
-index f79c69c..840076b 100644
+index e672c73..78a189a 100644
 --- a/include/cudnn_frontend_Operation.h
 +++ b/include/cudnn_frontend_Operation.h
 @@ -29,8 +29,8 @@
@@ -143,7 +172,7 @@ index f1d5dcc..5edd0e7 100644
  #include "cudnn_frontend_Operation.h"
  #include "cudnn_frontend_utils.h"
 diff --git a/include/cudnn_frontend_PointWiseDesc.h b/include/cudnn_frontend_PointWiseDesc.h
-index 4715971..b086d23 100644
+index 64a8dcb..20fb954 100644
 --- a/include/cudnn_frontend_PointWiseDesc.h
 +++ b/include/cudnn_frontend_PointWiseDesc.h
 @@ -29,8 +29,8 @@
@@ -172,3 +201,6 @@ index ab2aab3..94aae89 100644
  
  #include "cudnn_frontend_utils.h"
  
+-- 
+2.17.1
+

--- a/third_party/cudnn_frontend_header_fix.patch
+++ b/third_party/cudnn_frontend_header_fix.patch
@@ -1,4 +1,4 @@
-From 7a8b9986a4b60f0156c79378fec6f3e2cb7e3b12 Mon Sep 17 00:00:00 2001
+From cd9edc2363aa1ad8bef9d3b1927d00065d2d1edb Mon Sep 17 00:00:00 2001
 From: Kaixi Hou <kaixih@nvidia.com>
 Date: Tue, 4 May 2021 15:21:11 -0700
 Subject: [PATCH] Update headers path
@@ -8,7 +8,7 @@ Subject: [PATCH] Update headers path
  include/cudnn_frontend_ConvDesc.h           | 4 ++--
  include/cudnn_frontend_Engine.h             | 4 ++--
  include/cudnn_frontend_EngineConfig.h       | 4 ++--
- include/cudnn_frontend_EngineFallbackList.h | 4 +---
+ include/cudnn_frontend_EngineFallbackList.h | 2 +-
  include/cudnn_frontend_ExecutionPlan.h      | 4 ++--
  include/cudnn_frontend_Filters.h            | 2 +-
  include/cudnn_frontend_Heuristics.h         | 4 ++--
@@ -17,7 +17,7 @@ Subject: [PATCH] Update headers path
  include/cudnn_frontend_OperationGraph.h     | 4 ++--
  include/cudnn_frontend_PointWiseDesc.h      | 4 ++--
  include/cudnn_frontend_VariantPack.h        | 4 ++--
- 13 files changed, 23 insertions(+), 25 deletions(-)
+ 13 files changed, 23 insertions(+), 23 deletions(-)
 
 diff --git a/include/cudnn_backend_base.h b/include/cudnn_backend_base.h
 index b07b336..3fb06a7 100644
@@ -78,7 +78,7 @@ index 3e37848..1980207 100644
  #include "cudnn_frontend_Engine.h"
  #include "cudnn_frontend_utils.h"
 diff --git a/include/cudnn_frontend_EngineFallbackList.h b/include/cudnn_frontend_EngineFallbackList.h
-index 6c3164d..86b150e 100644
+index 6c3164d..5984ace 100644
 --- a/include/cudnn_frontend_EngineFallbackList.h
 +++ b/include/cudnn_frontend_EngineFallbackList.h
 @@ -22,7 +22,7 @@
@@ -90,15 +90,6 @@ index 6c3164d..86b150e 100644
  #include <numeric>
  
  namespace cudnn_frontend {
-@@ -56,8 +56,6 @@ auto static get_fallback_engine_list(cudnnBackendDescriptorType_t mode) -> std::
-             } else {
-                 return {};
-             }
--        } else {
--            return {};
-         }
-     } else {
-         return {};
 diff --git a/include/cudnn_frontend_ExecutionPlan.h b/include/cudnn_frontend_ExecutionPlan.h
 index 9e29f1e..167586c 100644
 --- a/include/cudnn_frontend_ExecutionPlan.h


### PR DESCRIPTION
This PR bumps up the cudnn frontend repo commit to v0.2 to resolve the issue of returning empty fallback list when cudnn == 8.2. In addition, the patch file is reformatted to contain more info.

https://github.com/NVIDIA/cudnn-frontend/releases/tag/v0.2


cc. @nluehr 