### PR TITLE
Improve docstrings for strings.lower() and strings.upper()

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_StringLower.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_StringLower.pbtxt
@@ -1,5 +1,18 @@
 op {
   graph_op_name: "StringLower"
+  in_arg {
+    name: "input"
+    description: <<END
+The input to be lower-cased.
+END
+  }
+  attr {
+    name: "encoding"
+    description: <<END
+Character encoding of `input`. Allowed values are '' and 'utf-8'.
+Value '' is interpreted as ASCII.
+END
+  }
   summary: "Converts all uppercase characters into their respective lowercase replacements."
   description: <<END
 Example:

--- a/tensorflow/core/api_def/base_api/api_def_StringUpper.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_StringUpper.pbtxt
@@ -1,5 +1,18 @@
 op {
   graph_op_name: "StringUpper"
+  in_arg {
+    name: "input"
+    description: <<END
+The input to be upper-cased.
+END
+  }
+  attr {
+    name: "encoding"
+    description: <<END
+Character encoding of `input`. Allowed values are '' and 'utf-8'.
+Value '' is interpreted as ASCII.
+END
+  }
   summary: "Converts all lowercase characters into their respective uppercase replacements."
   description: <<END
 Example:


### PR DESCRIPTION
I am adding a description of `input` and `encoding` parameters for strings.lower() and strings.upper() functions.
The set of allowed values for `encoding` seems to be limited to '' and 'utf-8' only.

This PR is related to this issue: https://github.com/tensorflow/tensorflow/issues/48551
