### PR TITLE
[CherryPick:r2.5]Run TensorFlow configure script in gpu_pip_on_cpu.sh

### DIFF
--- a/tensorflow/tools/ci_build/rel/ubuntu/gpu_pip_on_cpu.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/gpu_pip_on_cpu.sh
@@ -27,6 +27,11 @@ export LD_LIBRARY_PATH="/usr/local/cuda:/usr/local/cuda/lib64:/usr/local/cuda/ex
 ########################
 ## Build GPU pip package
 ########################
+export PYTHON_BIN_PATH=$(which python3.6)
+set +e  # piping `yes` can raise non-breaking errors; ignore them.
+yes "" | "$PYTHON_BIN_PATH" configure.py
+set -e
+
 bazel build \
   --config=release_gpu_linux \
   --repo_env=PYTHON_BIN_PATH="$(which python3.6)" \


### PR DESCRIPTION
Our other build scripts run pip_new.sh which runs configure at some point. I'm not sure which critical flags this introduces, but without it, bazel still builds a package for Python 2.7.

PiperOrigin-RevId: 370521377
Change-Id: I36282f2487e4fb092bdd782fde7c8d8e0421a359