### PR TITLE
Expose TF_NewOperationLocked, TF_FinishOperationLocked, and ToOperation

### DIFF
--- a/tensorflow/c/c_api.cc
+++ b/tensorflow/c/c_api.cc
@@ -645,11 +645,11 @@ TF_DEVICELIST_METHOD(uint64_t, TF_DeviceListIncarnation, incarnation(), 0);
 
 // Helper functions -----------------------------------------------------------
 
-namespace {
-
 TF_Operation* ToOperation(Node* node) {
   return static_cast<TF_Operation*>(static_cast<void*>(node));
 }
+
+namespace {
 
 string OutputName(const TF_Output& output) {
   return StrCat(output.oper->node.name(), ":", output.index);
@@ -782,7 +782,7 @@ void TF_GraphGetTensorShape(TF_Graph* graph, TF_Output output, int64_t* dims,
 
 extern "C" {
 
-static TF_OperationDescription* TF_NewOperationLocked(TF_Graph* graph,
+TF_OperationDescription* TF_NewOperationLocked(TF_Graph* graph,
                                                       const char* op_type,
                                                       const char* oper_name)
     TF_EXCLUSIVE_LOCKS_REQUIRED(graph->mu) {
@@ -1041,7 +1041,7 @@ void TF_SetAttrValueProto(TF_OperationDescription* desc, const char* attr_name,
   status->status = Status::OK();
 }
 
-static TF_Operation* TF_FinishOperationLocked(TF_OperationDescription* desc,
+TF_Operation* TF_FinishOperationLocked(TF_OperationDescription* desc,
                                               TF_Status* status)
     TF_EXCLUSIVE_LOCKS_REQUIRED(desc->graph->mu) {
   Node* ret = nullptr;

--- a/tensorflow/c/c_api.cc
+++ b/tensorflow/c/c_api.cc
@@ -645,11 +645,11 @@ TF_DEVICELIST_METHOD(uint64_t, TF_DeviceListIncarnation, incarnation(), 0);
 
 // Helper functions -----------------------------------------------------------
 
+namespace {
+
 TF_Operation* ToOperation(Node* node) {
   return static_cast<TF_Operation*>(static_cast<void*>(node));
 }
-
-namespace {
 
 string OutputName(const TF_Output& output) {
   return StrCat(output.oper->node.name(), ":", output.index);

--- a/tensorflow/c/c_api.cc
+++ b/tensorflow/c/c_api.cc
@@ -783,8 +783,8 @@ void TF_GraphGetTensorShape(TF_Graph* graph, TF_Output output, int64_t* dims,
 extern "C" {
 
 TF_OperationDescription* TF_NewOperationLocked(TF_Graph* graph,
-                                                      const char* op_type,
-                                                      const char* oper_name)
+                                               const char* op_type,
+                                               const char* oper_name)
     TF_EXCLUSIVE_LOCKS_REQUIRED(graph->mu) {
   return new TF_OperationDescription(graph, op_type, oper_name);
 }
@@ -1042,7 +1042,7 @@ void TF_SetAttrValueProto(TF_OperationDescription* desc, const char* attr_name,
 }
 
 TF_Operation* TF_FinishOperationLocked(TF_OperationDescription* desc,
-                                              TF_Status* status)
+                                       TF_Status* status)
     TF_EXCLUSIVE_LOCKS_REQUIRED(desc->graph->mu) {
   Node* ret = nullptr;
 

--- a/tensorflow/c/c_api.h
+++ b/tensorflow/c/c_api.h
@@ -255,6 +255,12 @@ TF_CAPI_EXPORT extern void TF_GraphGetTensorShape(TF_Graph* graph,
                                                   int64_t* dims, int num_dims,
                                                   TF_Status* status);
 
+// TF_NewOperation, but without locking the graph.
+// Should prefer TF_NewOperation when possible.
+TF_CAPI_EXPORT extern TF_OperationDescription* TF_NewOperationLocked(TF_Graph* graph,
+                                                      const char* op_type,
+                                                      const char* oper_name);
+
 // Operation will only be added to *graph when TF_FinishOperation() is
 // called (assuming TF_FinishOperation() does not return an error).
 // *graph must not be deleted until after TF_FinishOperation() is
@@ -405,6 +411,11 @@ TF_CAPI_EXPORT extern void TF_SetAttrValueProto(TF_OperationDescription* desc,
                                                 const void* proto,
                                                 size_t proto_len,
                                                 TF_Status* status);
+
+// TF_FinishOperation, but without locking the graph.
+// TF_FinishOperation should be preferred when possible.
+TF_CAPI_EXPORT extern TF_Operation* TF_FinishOperationLocked(TF_OperationDescription* desc,
+                                              TF_Status* status);
 
 // If this function succeeds:
 //   * *status is set to an OK value,

--- a/tensorflow/c/c_api.h
+++ b/tensorflow/c/c_api.h
@@ -258,8 +258,8 @@ TF_CAPI_EXPORT extern void TF_GraphGetTensorShape(TF_Graph* graph,
 // TF_NewOperation, but without locking the graph.
 // Should prefer TF_NewOperation when possible.
 TF_CAPI_EXPORT extern TF_OperationDescription* TF_NewOperationLocked(TF_Graph* graph,
-                                                      const char* op_type,
-                                                      const char* oper_name);
+                                                                     const char* op_type,
+                                                                     const char* oper_name);
 
 // Operation will only be added to *graph when TF_FinishOperation() is
 // called (assuming TF_FinishOperation() does not return an error).
@@ -415,7 +415,7 @@ TF_CAPI_EXPORT extern void TF_SetAttrValueProto(TF_OperationDescription* desc,
 // TF_FinishOperation, but without locking the graph.
 // TF_FinishOperation should be preferred when possible.
 TF_CAPI_EXPORT extern TF_Operation* TF_FinishOperationLocked(TF_OperationDescription* desc,
-                                              TF_Status* status);
+                                                             TF_Status* status);
 
 // If this function succeeds:
 //   * *status is set to an OK value,

--- a/tensorflow/c/c_api_internal.h
+++ b/tensorflow/c/c_api_internal.h
@@ -185,6 +185,12 @@ struct TF_Server {
 };
 #endif  // !defined(IS_MOBILE_PLATFORM) && !defined(IS_SLIM_BUILD)
 
+// Exposed helper functions
+
+TF_Operation* ToOperation(tensorflow::Node* node);
+
+// End Exposed helper functions
+
 namespace tensorflow {
 
 Status MessageToBuffer(const tensorflow::protobuf::MessageLite& in,

--- a/tensorflow/c/c_api_internal.h
+++ b/tensorflow/c/c_api_internal.h
@@ -185,12 +185,6 @@ struct TF_Server {
 };
 #endif  // !defined(IS_MOBILE_PLATFORM) && !defined(IS_SLIM_BUILD)
 
-// Exposed helper functions
-
-TF_Operation* ToOperation(tensorflow::Node* node);
-
-// End Exposed helper functions
-
 namespace tensorflow {
 
 Status MessageToBuffer(const tensorflow::protobuf::MessageLite& in,


### PR DESCRIPTION
Expose `TF_NewOperationLocked`, `TF_FinishOperationLocked`, and `ToOperation` to the C API.  `ToOperation` is in `c_api_internal.h`.

Fixes #48767
Fixes #48815