### PR TITLE
[TF-TRT] CombinedNms Deactivated due to bug

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -7241,9 +7241,10 @@ static void RegisterValidatableOpConverters(
 #if IS_TRT_VERSION_GE(5, 1, 2, 0)
   (*registration)["ClipByValue"] = ConvertClipByValue;
 #endif
-#if IS_TRT_VERSION_GE(7, 1, 3, 0)
-  (*registration)["CombinedNonMaxSuppression"] = ConvertCombinedNMS;
-#endif
+  // TODO: @DEKHTIARJonathan - Uncomment when fixed
+  //#if IS_TRT_VERSION_GE(7, 1, 3, 0)
+  //  (*registration)["CombinedNonMaxSuppression"] = ConvertCombinedNMS;
+  //#endif
   (*registration)["AddN"] = ConvertAddN;
   (*registration)["Cast"] = ConvertCast;
   (*registration)["ConcatV2"] = ConvertConcat;

--- a/tensorflow/python/compiler/tensorrt/test/combined_nms_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/combined_nms_test.py
@@ -94,7 +94,7 @@ class CombinedNmsTest(trt_test.TfTrtIntegrationTestBase):
     }
 
   def ShouldRunTest(self, run_params):
-    should_run, reason = super().ShouldRunTest(run_params)
+    should_run, reason = super(CombinedNmsTest, self).ShouldRunTest(run_params)
     should_run = should_run and \
         not trt_test.IsQuantizationMode(run_params.precision_mode)
     reason += ' and precision != INT8'
@@ -126,7 +126,8 @@ class CombinedNmsExecuteNativeSegmentTest(CombinedNmsTest):
     return super().GetMaxBatchSize(run_params) - 1
 
   def ShouldRunTest(self, run_params):
-    should_run, reason = super().ShouldRunTest(run_params)
+    should_run, reason = super(CombinedNmsExecuteNativeSegmentTest, self) \
+                        .ShouldRunTest(run_params)
     # max_batch_size is only useful for selecting static engines. As such,
     # we shouldn't run the test for dynamic engines.
     return should_run and \
@@ -201,6 +202,10 @@ class CombinedNmsTestTopK(CombinedNmsTest):
                                 nmsed_boxes_shape, nmsed_scores_shape,
                                 nmsed_classes_shape, valid_detections_shape
                             ])
+
+  # TODO: @DEKHTIARJonathan remove when fixed
+  def ShouldRunTest(self, run_params):
+      return False
 
 
 class CombinedNmsTopKOverride(CombinedNmsTest):


### PR DESCRIPTION
@bixia1 @tfeher 

This PR temporarily deactivate the Combined NMS convertor, it seems to have issues in numerous versions of TRT.
For safety, I deactivate it. Let's reactivate it when stable.

FYI this bug was found on: `TRT_VERSION: 7.2.3.4`

```bash
[ RUN      ] OpConvTestInstantiation/OpConverter_FP32_Test.ConvertCombinedNMS/0
2021-05-05 22:34:41.995244: I tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc:1798] %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
2021-05-05 22:34:41.995253: I tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc:1799] tf_type_: DT_FLOAT
2021-05-05 22:34:41.995256: I tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc:1800] trt_mode_: kImplicitBatch
2021-05-05 22:34:41.995260: I tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc:1801] converter_precision_: TrtPrecisionMode::FP32
2021-05-05 22:34:41.995263: I tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc:1802] %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc:1933: Failure
Value of: GetDataAsFloat(output_data[i])
Expected: has 2 elements where
element #0 is equal to 0.7,
element #1 is equal to 0.4
  Actual: { 0.700195, 0.399902 }, whose element #0 doesn't match
Google Test trace:
tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc:3670: Test 1: Original test
tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc:1933: Failure
Value of: GetDataAsFloat(output_data[i])
Expected: has 4 elements where
element #0 is equal to 5,
element #1 is equal to 3,
element #2 is equal to 1,
element #3 is equal to 0
  Actual: { 1.99902, 1.99902, 1, 0 }, whose element #0 doesn't match
Google Test trace:
tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc:3670: Test 2: clip_boxes
tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc:1933: Failure
Value of: GetDataAsFloat(output_data[i])
Expected: has 4 elements where
element #0 is equal to 5,
element #1 is equal to 3,
element #2 is equal to 0,
element #3 is equal to 0
  Actual: { 1.99902, 1.99902, 0, 0 }, whose element #0 doesn't match
Google Test trace:
tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc:3670: Test 3: score threshold
tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc:1933: Failure
Value of: GetDataAsFloat(output_data[i])
Expected: has 4 elements where
element #0 is equal to 5,
element #1 is equal to 3,
element #2 is equal to 1,
element #3 is equal to 0
  Actual: { 1.99902, 1.99902, 1, 0 }, whose element #0 doesn't match
Google Test trace:
tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc:3670: Test 4: max coord first
[  FAILED  ] OpConvTestInstantiation/OpConverter_FP32_Test.ConvertCombinedNMS/0, where GetParam() = (4-byte object <00-00 00-00>, 1, 4-byte object <00-00 00-00>) (49 ms)
[ RUN      ] OpConvTestInstantiation/OpConverter_FP32_Test.ConvertCombinedNMS/1
2021-05-05 22:34:42.044405: I tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc:1798] %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
2021-05-05 22:34:42.044415: I tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc:1799] tf_type_: DT_FLOAT
2021-05-05 22:34:42.044418: I tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc:1800] trt_mode_: kExplicitBatch
2021-05-05 22:34:42.044421: I tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc:1801] converter_precision_: TrtPrecisionMode::FP32
2021-05-05 22:34:42.044424: I tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc:1802] %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc:1933: Failure
Value of: GetDataAsFloat(output_data[i])
Expected: has 2 elements where
element #0 is equal to 0.7,
element #1 is equal to 0.4
  Actual: { 0.700195, 0.399902 }, whose element #0 doesn't match
Google Test trace:
tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc:3670: Test 1: Original test
tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc:1933: Failure
Value of: GetDataAsFloat(output_data[i])
Expected: has 4 elements where
element #0 is equal to 5,
element #1 is equal to 3,
element #2 is equal to 1,
element #3 is equal to 0
  Actual: { 1.99902, 1.99902, 1, 0 }, whose element #0 doesn't match
Google Test trace:
tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc:3670: Test 2: clip_boxes
tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc:1933: Failure
Value of: GetDataAsFloat(output_data[i])
Expected: has 4 elements where
element #0 is equal to 5,
element #1 is equal to 3,
element #2 is equal to 0,
element #3 is equal to 0
  Actual: { 1.99902, 1.99902, 0, 0 }, whose element #0 doesn't match
Google Test trace:
tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc:3670: Test 3: score threshold
tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc:1933: Failure
Value of: GetDataAsFloat(output_data[i])
Expected: has 4 elements where
element #0 is equal to 5,
element #1 is equal to 3,
element #2 is equal to 1,
element #3 is equal to 0
  Actual: { 1.99902, 1.99902, 1, 0 }, whose element #0 doesn't match
Google Test trace:
tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc:3670: Test 4: max coord first
[  FAILED  ] OpConvTestInstantiation/OpConverter_FP32_Test.ConvertCombinedNMS/1, where GetParam() = (4-byte object <01-00 00-00>, 1, 4-byte object <00-00 00-00>) (49 ms)
[ RUN      ] OpConvTestInstantiation/OpConverter_FP32_Test.ConvertCombinedNMS/2
2021-05-05 22:34:42.093225: I tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc:1798] %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
2021-05-05 22:34:42.093234: I tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc:1799] tf_type_: DT_FLOAT
2021-05-05 22:34:42.093237: I tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc:1800] trt_mode_: kDynamicShape
2021-05-05 22:34:42.093241: I tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc:1801] converter_precision_: TrtPrecisionMode::FP32
2021-05-05 22:34:42.093251: I tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc:1802] %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
[       OK ] OpConvTestInstantiation/OpConverter_FP32_Test.ConvertCombinedNMS/2 (7 ms)
[  FAILED  ] 2 tests, listed below:
[  FAILED  ] OpConvTestInstantiation/OpConverter_FP32_Test.ConvertCombinedNMS/0, where GetParam() = (4-byte object <00-00 00-00>, 1, 4-byte object <00-00 00-00>)
[  FAILED  ] OpConvTestInstantiation/OpConverter_FP32_Test.ConvertCombinedNMS/1, where GetParam() = (4-byte object <01-00 00-00>, 1, 4-byte object <00-00 00-00>)
```