### PR TITLE
Use static variable for checking TF_CUDNN_USE_FRONTEND

### DIFF
--- a/tensorflow/core/util/use_cudnn.cc
+++ b/tensorflow/core/util/use_cudnn.cc
@@ -37,19 +37,17 @@ namespace tensorflow {
   }
 
 bool CudnnUseFrontend() {
-#if GOOGLE_CUDA && CUDNN_VERSION >= 8100
   static bool result = [] {
     bool value = false;
+#if GOOGLE_CUDA && CUDNN_VERSION >= 8100
     Status status = ReadBoolFromEnvVar("TF_CUDNN_USE_FRONTEND", false, &value);
     if (!status.ok()) {
       LOG(ERROR) << status;
     }
+#endif  // GOOGLE_CUDA && CUDNN_VERSION >= 8100
     return value;
   }();
   return result;
-#else
-  return false;
-#endif  // GOOGLE_CUDA && CUDNN_VERSION >= 8100
 }
 
 ADD_BOOL_CUDNN_FLAG(CudnnUseAutotune, TF_CUDNN_USE_AUTOTUNE, true);

--- a/tensorflow/core/util/use_cudnn.cc
+++ b/tensorflow/core/util/use_cudnn.cc
@@ -38,12 +38,15 @@ namespace tensorflow {
 
 bool CudnnUseFrontend() {
 #if GOOGLE_CUDA && CUDNN_VERSION >= 8100
-  bool value = false;
-  Status status = ReadBoolFromEnvVar("TF_CUDNN_USE_FRONTEND", false, &value);
-  if (!status.ok()) {
-    LOG(ERROR) << status;
-  }
-  return value;
+  static bool result = [] {
+    bool value = false;
+    Status status = ReadBoolFromEnvVar("TF_CUDNN_USE_FRONTEND", false, &value);
+    if (!status.ok()) {
+      LOG(ERROR) << status;
+    }
+    return value;
+  }();
+  return result;
 #else
   return false;
 #endif  // GOOGLE_CUDA && CUDNN_VERSION >= 8100


### PR DESCRIPTION
This PR avoid checking TF_CUDNN_USE_FRONTEND every time we call the CudnnUseFrontend().

cc. @nluehr 