### PR TITLE
[tf.data] graduate experimental `take_while` API to tf.data.Dataset

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -104,6 +104,8 @@
         `tf.data.Dataset.random` and deprecating the experimental endpoint.
     *   Promoting `tf.data.experimental.scan` API to `tf.data.Dataset.scan`
         and deprecating the experimental endpoint.
+    *   Promoting `tf.data.experimental.take_while` API to
+        `tf.data.Dataset.take_while` and deprecating the experimental endpoint.
     *   Added `stop_on_empty_dataset` parameter to `sample_from_datasets` and
         `choose_from_datasets`. Setting `stop_on_empty_dataset=True` will stop
         sampling if it encounters an empty dataset. This preserves the sampling

--- a/tensorflow/python/data/experimental/kernel_tests/BUILD
+++ b/tensorflow/python/data/experimental/kernel_tests/BUILD
@@ -630,29 +630,6 @@ tf_py_test(
 )
 
 tf_py_test(
-    name = "take_while_test",
-    size = "small",
-    srcs = ["take_while_test.py"],
-    shard_count = 4,
-    deps = [
-        "//tensorflow/python:array_ops",
-        "//tensorflow/python:client_testlib",
-        "//tensorflow/python:constant_op",
-        "//tensorflow/python:dtypes",
-        "//tensorflow/python:errors",
-        "//tensorflow/python:framework_test_lib",
-        "//tensorflow/python:math_ops",
-        "//tensorflow/python/data/experimental/ops:take_while_ops",
-        "//tensorflow/python/data/kernel_tests:checkpoint_test_base",
-        "//tensorflow/python/data/kernel_tests:test_base",
-        "//tensorflow/python/data/ops:dataset_ops",
-        "//tensorflow/python/eager:context",
-        "//third_party/py/numpy",
-        "@absl_py//absl/testing:parameterized",
-    ],
-)
-
-tf_py_test(
     name = "tf_record_writer_test",
     size = "small",
     srcs = ["tf_record_writer_test.py"],

--- a/tensorflow/python/data/experimental/ops/BUILD
+++ b/tensorflow/python/data/experimental/ops/BUILD
@@ -378,11 +378,7 @@ py_library(
     srcs = ["take_while_ops.py"],
     srcs_version = "PY3",
     deps = [
-        "//tensorflow/python:dtypes",
-        "//tensorflow/python:experimental_dataset_ops_gen",
-        "//tensorflow/python:framework_ops",
-        "//tensorflow/python:function",
-        "//tensorflow/python/data/ops:dataset_ops",
+        "//tensorflow/python:util",
     ],
 )
 

--- a/tensorflow/python/data/experimental/ops/take_while_ops.py
+++ b/tensorflow/python/data/experimental/ops/take_while_ops.py
@@ -17,41 +17,11 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from tensorflow.python.data.ops import dataset_ops
-from tensorflow.python.framework import dtypes
-from tensorflow.python.framework import tensor_spec
-from tensorflow.python.ops import gen_experimental_dataset_ops
+from tensorflow.python.util import deprecation
 from tensorflow.python.util.tf_export import tf_export
 
 
-class _TakeWhileDataset(dataset_ops.UnaryUnchangedStructureDataset):
-  """A dataset that stops iteration when `predicate` returns false."""
-
-  def __init__(self, input_dataset, predicate):
-    """See `take_while()` for details."""
-
-    self._input_dataset = input_dataset
-    wrapped_func = dataset_ops.StructuredFunctionWrapper(
-        predicate,
-        "tf.data.experimental.take_while()",
-        dataset=self._input_dataset)
-
-    if not wrapped_func.output_structure.is_compatible_with(
-        tensor_spec.TensorSpec([], dtypes.bool)):
-      raise ValueError("`predicate` must return a scalar boolean tensor.")
-
-    self._predicate = wrapped_func
-    var_tensor = gen_experimental_dataset_ops.take_while_dataset(
-        self._input_dataset._variant_tensor,  # pylint: disable=protected-access
-        other_arguments=self._predicate.function.captured_inputs,
-        predicate=self._predicate.function,
-        **self._flat_structure)
-    super(_TakeWhileDataset, self).__init__(input_dataset, var_tensor)
-
-  def _functions(self):
-    return [self._predicate]
-
-
+@deprecation.deprecated(None, "Use `tf.data.Dataset.take_while(...)")
 @tf_export("data.experimental.take_while")
 def take_while(predicate):
   """A transformation that stops dataset iteration based on a `predicate`.
@@ -67,6 +37,6 @@ def take_while(predicate):
   """
 
   def _apply_fn(dataset):
-    return _TakeWhileDataset(dataset, predicate)
+    return dataset.take_while(predicate=predicate)
 
   return _apply_fn

--- a/tensorflow/python/data/kernel_tests/BUILD
+++ b/tensorflow/python/data/kernel_tests/BUILD
@@ -870,6 +870,28 @@ tf_py_test(
     ],
 )
 
+tf_py_test(
+    name = "take_while_test",
+    size = "small",
+    srcs = ["take_while_test.py"],
+    shard_count = 4,
+    deps = [
+        "//tensorflow/python:array_ops",
+        "//tensorflow/python:client_testlib",
+        "//tensorflow/python:constant_op",
+        "//tensorflow/python:dtypes",
+        "//tensorflow/python:errors",
+        "//tensorflow/python:framework_test_lib",
+        "//tensorflow/python:math_ops",
+        "//tensorflow/python/data/kernel_tests:checkpoint_test_base",
+        "//tensorflow/python/data/kernel_tests:test_base",
+        "//tensorflow/python/data/ops:dataset_ops",
+        "//tensorflow/python/eager:context",
+        "//third_party/py/numpy",
+        "@absl_py//absl/testing:parameterized",
+    ],
+)
+
 py_library(
     name = "test_base",
     srcs = ["test_base.py"],

--- a/tensorflow/python/data/kernel_tests/take_while_test.py
+++ b/tensorflow/python/data/kernel_tests/take_while_test.py
@@ -60,7 +60,7 @@ class TakeWhileTest(test_base.DatasetTestBase, parameterized.TestCase):
           combinations.combine(num_elements=[0], upper_bound=[1])))
   def testTakeWhileDatasetRange(self, num_elements, upper_bound):
     dataset = dataset_ops.Dataset.range(num_elements).take_while(
-        lambda x: x < upper_bound)
+        predicate=lambda x: x < upper_bound)
 
     self.assertDatasetProduces(dataset,
                                np.arange(min(num_elements, upper_bound)))

--- a/tensorflow/python/data/kernel_tests/take_while_test.py
+++ b/tensorflow/python/data/kernel_tests/take_while_test.py
@@ -59,8 +59,8 @@ class TakeWhileTest(test_base.DatasetTestBase, parameterized.TestCase):
           combinations.combine(num_elements=[100], upper_bound=[101]) +
           combinations.combine(num_elements=[0], upper_bound=[1])))
   def testTakeWhileDatasetRange(self, num_elements, upper_bound):
-    dataset = dataset_ops.Dataset.range(num_elements).apply(
-        take_while_ops.take_while(lambda x: x < upper_bound))
+    dataset = dataset_ops.Dataset.range(num_elements).take_while(
+        lambda x: x < upper_bound)
 
     self.assertDatasetProduces(dataset,
                                np.arange(min(num_elements, upper_bound)))

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -2707,6 +2707,11 @@ name=None))
   def take_while(self, predicate):
     """A transformation that stops dataset iteration based on a `predicate`.
 
+    >>> dataset = tf.data.Dataset.range(10)
+    >>> dataset = dataset.take_while(lambda x: x < 5)
+    >>> list(dataset.as_numpy_iterator())
+    [0, 1, 2, 3, 4]
+
     Args:
       predicate: A function that maps a nested structure of tensors (having
         shapes and types defined by `self.output_shapes` and

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -2704,6 +2704,19 @@ name=None))
 
     return _ScanDataset(self, initial_state=initial_state, scan_func=scan_func)
 
+  def take_while(self, predicate):
+    """A transformation that stops dataset iteration based on a `predicate`.
+
+    Args:
+      predicate: A function that maps a nested structure of tensors (having
+        shapes and types defined by `self.output_shapes` and
+        `self.output_types`) to a scalar `tf.bool` tensor.
+
+    Returns:
+      A `Dataset`.
+    """
+
+    return _TakeWhileDataset(self, predicate)
 
 @tf_export(v1=["data.Dataset"])
 class DatasetV1(DatasetV2):
@@ -5213,6 +5226,35 @@ class RandomDataset(DatasetSource):
   def element_spec(self):
     return tensor_spec.TensorSpec([], dtypes.int64)
 
+class _TakeWhileDataset(UnaryUnchangedStructureDataset):
+  """A dataset that stops iteration when `predicate` returns false."""
+
+  def __init__(self, input_dataset, predicate):
+    """See `take_while()` for details."""
+
+    self._input_dataset = input_dataset
+    wrapped_func = StructuredFunctionWrapper(
+        predicate,
+        self._transformation_name(),
+        dataset=self._input_dataset)
+
+    if not wrapped_func.output_structure.is_compatible_with(
+        tensor_spec.TensorSpec([], dtypes.bool)):
+      raise ValueError("`predicate` must return a scalar boolean tensor.")
+
+    self._predicate = wrapped_func
+    var_tensor = ged_ops.take_while_dataset(
+        self._input_dataset._variant_tensor,  # pylint: disable=protected-access
+        other_arguments=self._predicate.function.captured_inputs,
+        predicate=self._predicate.function,
+        **self._flat_structure)
+    super(_TakeWhileDataset, self).__init__(input_dataset, var_tensor)
+
+  def _functions(self):
+    return [self._predicate]
+
+  def _transformation_name(self):
+    return "Dataset.take_while()"
 
 def _collect_resource_inputs(op):
   """Collects resource inputs for the given ops (and its variant inputs)."""

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-dataset.pbtxt
@@ -164,6 +164,10 @@ tf_class {
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "take_while"
+    argspec: "args=[\'self\', \'predicate\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "unbatch"
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-fixed-length-record-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-fixed-length-record-dataset.pbtxt
@@ -166,6 +166,10 @@ tf_class {
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "take_while"
+    argspec: "args=[\'self\', \'predicate\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "unbatch"
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-t-f-record-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-t-f-record-dataset.pbtxt
@@ -166,6 +166,10 @@ tf_class {
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "take_while"
+    argspec: "args=[\'self\', \'predicate\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "unbatch"
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-text-line-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-text-line-dataset.pbtxt
@@ -166,6 +166,10 @@ tf_class {
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "take_while"
+    argspec: "args=[\'self\', \'predicate\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "unbatch"
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-csv-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-csv-dataset.pbtxt
@@ -166,6 +166,10 @@ tf_class {
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "take_while"
+    argspec: "args=[\'self\', \'predicate\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "unbatch"
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-random-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-random-dataset.pbtxt
@@ -166,6 +166,10 @@ tf_class {
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "take_while"
+    argspec: "args=[\'self\', \'predicate\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "unbatch"
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-sql-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-sql-dataset.pbtxt
@@ -166,6 +166,10 @@ tf_class {
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "take_while"
+    argspec: "args=[\'self\', \'predicate\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "unbatch"
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-dataset.pbtxt
@@ -131,6 +131,10 @@ tf_class {
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "take_while"
+    argspec: "args=[\'self\', \'predicate\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "unbatch"
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-fixed-length-record-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-fixed-length-record-dataset.pbtxt
@@ -133,6 +133,10 @@ tf_class {
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "take_while"
+    argspec: "args=[\'self\', \'predicate\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "unbatch"
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-t-f-record-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-t-f-record-dataset.pbtxt
@@ -132,6 +132,10 @@ tf_class {
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "take_while"
+    argspec: "args=[\'self\', \'predicate\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "unbatch"
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-text-line-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-text-line-dataset.pbtxt
@@ -133,6 +133,10 @@ tf_class {
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "take_while"
+    argspec: "args=[\'self\', \'predicate\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "unbatch"
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-csv-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-csv-dataset.pbtxt
@@ -133,6 +133,10 @@ tf_class {
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "take_while"
+    argspec: "args=[\'self\', \'predicate\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "unbatch"
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-random-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-random-dataset.pbtxt
@@ -134,6 +134,10 @@ tf_class {
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "take_while"
+    argspec: "args=[\'self\', \'predicate\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "unbatch"
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-sql-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-sql-dataset.pbtxt
@@ -133,6 +133,10 @@ tf_class {
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "take_while"
+    argspec: "args=[\'self\', \'predicate\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "unbatch"
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }


### PR DESCRIPTION
This PR graduates the `tf.data.experimental.take_while` API into `tf.data.Dataset.take_while` by making the following changes:

- [x] Adds the deprecation decorator for the experimental API.
- [x] Add the `take_while()` method to `DatasetV2` class.
- [x] Updates example in documentation with new API.
- [x] Regenerate golden API's.
- [x] Moved and updated the `take_while_test` target from experimental/kernel_tests to kernel_tests
- [x] Updated the RELEASE.md file

TEST LOG
```
INFO: Build completed successfully, 355 total actions
//tensorflow/python/data/kernel_tests:take_while_test                    PASSED in 3.9s
  Stats over 4 runs: max = 3.9s, min = 3.7s, avg = 3.8s, dev = 0.1s

```

cc: @jsimsa @aaudiber 