### PR TITLE
Update ICU to 69.1

### DIFF
--- a/third_party/icu/udata.patch
+++ b/third_party/icu/udata.patch
@@ -1,6 +1,6 @@
-diff -ru a/icu4c/source/common/udata.cpp b/icu4c/source/common/udata.cpp
---- a/icu4c/source/common/udata.cpp	2019-04-17 12:03:04.000000000 +0000
-+++ b/icu4c/source/common/udata.cpp	2020-07-14 23:49:37.836668741 +0000
+diff -ruN a/icu4c/source/common/udata.cpp b/icu4c/source/common/udata.cpp
+--- a/icu4c/source/common/udata.cpp	2021-05-09 19:28:29.342798850 +0000
++++ b/icu4c/source/common/udata.cpp	2021-05-09 19:35:03.859262671 +0000
 @@ -18,11 +18,10 @@
  
  #include "unicode/utypes.h"  /* U_PLATFORM etc. */
@@ -17,7 +17,7 @@ diff -ru a/icu4c/source/common/udata.cpp b/icu4c/source/common/udata.cpp
  #endif
  
  #include "unicode/putil.h"
-@@ -649,10 +648,9 @@
+@@ -651,10 +650,9 @@
   * partial-data-library access functions where each returns a pointer
   * to its data package, if it is linked in.
   */
@@ -31,7 +31,7 @@ diff -ru a/icu4c/source/common/udata.cpp b/icu4c/source/common/udata.cpp
  
  /*----------------------------------------------------------------------*
   *                                                                      *
-@@ -710,10 +708,11 @@
+@@ -713,10 +711,10 @@
          if (uprv_getICUData_collation) {
              setCommonICUDataPointer(uprv_getICUData_collation(), FALSE, pErrorCode);
          }
@@ -40,13 +40,12 @@ diff -ru a/icu4c/source/common/udata.cpp b/icu4c/source/common/udata.cpp
              setCommonICUDataPointer(uprv_getICUData_conversion(), FALSE, pErrorCode);
          }
 -        */
-+
- #if U_PLATFORM_HAS_WINUWP_API == 0 // Windows UWP Platform does not support dll icu data at this time
+ #if !defined(ICU_DATA_DIR_WINDOWS)
+ // When using the Windows system data, we expect only a single data file.
          setCommonICUDataPointer(&U_ICUDATA_ENTRY_POINT, FALSE, pErrorCode);
-         {
-diff -ru a/icu4c/source/common/unicode/uconfig.h b/icu4c/source/common/unicode/uconfig.h
---- a/icu4c/source/common/unicode/uconfig.h	2019-04-17 12:03:04.000000000 +0000
-+++ b/icu4c/source/common/unicode/uconfig.h	2020-07-14 23:49:37.836668741 +0000
+diff -ruN a/icu4c/source/common/unicode/uconfig.h b/icu4c/source/common/unicode/uconfig.h
+--- a/icu4c/source/common/unicode/uconfig.h	2021-05-09 19:28:29.346798604 +0000
++++ b/icu4c/source/common/unicode/uconfig.h	2021-05-09 19:29:48.594193508 +0000
 @@ -55,6 +55,11 @@
  #include "uconfig_local.h"
  #endif

--- a/third_party/icu/workspace.bzl
+++ b/third_party/icu/workspace.bzl
@@ -5,11 +5,11 @@ load("//third_party:repo.bzl", "tf_http_archive")
 def repo():
     tf_http_archive(
         name = "icu",
-        strip_prefix = "icu-release-64-2",
-        sha256 = "dfc62618aa4bd3ca14a3df548cd65fe393155edd213e49c39f3a30ccd618fc27",
+        strip_prefix = "icu-release-69-1",
+        sha256 = "3144e17a612dda145aa0e4acb3caa27a5dae4e26edced64bc351c43d5004af53",
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/unicode-org/icu/archive/release-64-2.zip",
-            "https://github.com/unicode-org/icu/archive/release-64-2.zip",
+            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/unicode-org/icu/archive/refs/tags/release-69-1.zip",
+            "https://github.com/unicode-org/icu/archive/refs/tags/release-69-1.zip",
         ],
         build_file = "//third_party/icu:BUILD.bazel",
         system_build_file = "//third_party/icu:BUILD.system",


### PR DESCRIPTION

This PR updates ICU from 64.2 to to 69.1.

Note this PR will cover CVE-2020-10531 (https://www.cvedetails.com/cve/CVE-2020-10531/) which exists through 66.1.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>