### PR TITLE
Support all datatypes for Xtensa softmax implementation.

### DIFF
--- a/tensorflow/lite/micro/benchmarks/keyword_benchmark.cc
+++ b/tensorflow/lite/micro/benchmarks/keyword_benchmark.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/benchmarks/keyword_scrambled_model_data.h"
 #include "tensorflow/lite/micro/benchmarks/micro_benchmark.h"
 #include "tensorflow/lite/micro/kernels/fully_connected.h"
+#include "tensorflow/lite/micro/kernels/softmax.h"
 #include "tensorflow/lite/micro/micro_error_reporter.h"
 #include "tensorflow/lite/micro/micro_mutable_op_resolver.h"
 #include "tensorflow/lite/micro/micro_profiler.h"
@@ -60,7 +61,7 @@ KeywordBenchmarkRunner* CreateBenchmarkRunner(MicroProfiler* profiler) {
   KeywordOpResolver* op_resolver = new (op_resolver_buffer) KeywordOpResolver();
   op_resolver->AddFullyConnected(tflite::Register_FULLY_CONNECTED_INT8());
   op_resolver->AddQuantize();
-  op_resolver->AddSoftmax();
+  op_resolver->AddSoftmax(tflite::Register_SOFTMAX_INT8_INT16());
   op_resolver->AddSvdf();
 
   return new (benchmark_runner_buffer)

--- a/tensorflow/lite/micro/examples/micro_speech/micro_speech_test.cc
+++ b/tensorflow/lite/micro/examples/micro_speech/micro_speech_test.cc
@@ -52,7 +52,11 @@ TF_LITE_MICRO_TEST(TestInvoke) {
   micro_op_resolver.AddSoftmax();
 
   // Create an area of memory to use for input, output, and intermediate arrays.
-  const int tensor_arena_size = 10 * 1024;
+#if defined(XTENSA)
+  constexpr int tensor_arena_size = 15 * 1024;
+#else
+  constexpr int tensor_arena_size = 10 * 1024;
+#endif
   uint8_t tensor_arena[tensor_arena_size];
 
   // Build an interpreter to run the model with.

--- a/tensorflow/lite/micro/kernels/micro_ops.h
+++ b/tensorflow/lite/micro/kernels/micro_ops.h
@@ -53,7 +53,6 @@ TfLiteRegistration Register_LOG_SOFTMAX();
 TfLiteRegistration Register_QUANTIZE();
 TfLiteRegistration Register_RESIZE_BILINEAR();
 TfLiteRegistration Register_SHAPE();
-TfLiteRegistration Register_SOFTMAX();
 TfLiteRegistration Register_SPACE_TO_BATCH_ND();
 TfLiteRegistration Register_SQUEEZE();
 TfLiteRegistration Register_SVDF();

--- a/tensorflow/lite/micro/kernels/softmax_test.cc
+++ b/tensorflow/lite/micro/kernels/softmax_test.cc
@@ -24,7 +24,6 @@ namespace tflite {
 namespace testing {
 namespace {
 
-#if !defined(XTENSA)
 // The Softmax kernel assumes an output in the range [0, 1.0], leading to these
 // quantization parameters.
 const float output_scale_int8 = 1.0f / 256.0f;
@@ -42,7 +41,6 @@ const float input_data_1d[] = {1.0, 2.0, 3.0, 4.0, 5.0};
 const float golden_1d[] = {0.011656231, 0.031684921, 0.086128544, 0.234121657,
                            0.636408647};
 
-#endif
 // 2-dimensional test data.
 const int flat_size_2d = 10;
 int shape_2d[] = {2, 2, 5};
@@ -52,7 +50,6 @@ const float golden_2d[] = {0.011656231, 0.031684921, 0.086128544, 0.234121657,
                            0.636408647, 0.636408647, 0.234121657, 0.086128544,
                            0.031684921, 0.011656231};
 
-#if !defined(XTENSA)
 // 3-dimensional test data.
 const int flat_size_3d = 60;
 int shape_3d[] = {3, 3, 4, 5};
@@ -247,7 +244,6 @@ const float golden_4d[] = {
     // h = 3
     0.268866557, 0.000033181, 0.730855076, 0.000000011, 0.000245175};
 
-#endif
 template <typename T>
 void ValidateSoftmaxGoldens(TfLiteTensor* tensors, const int tensor_count,
                             T* output_data, const T* expected_output,
@@ -271,7 +267,6 @@ void ValidateSoftmaxGoldens(TfLiteTensor* tensors, const int tensor_count,
   }
 }
 
-#if !defined(XTENSA)
 void TestSoftmaxFloat(int* input_dims_data, const float* input_data,
                       int* output_dims_data, const float* expected_output_data,
                       float* output_data) {
@@ -290,7 +285,6 @@ void TestSoftmaxFloat(int* input_dims_data, const float* input_data,
   ValidateSoftmaxGoldens(tensors, tensors_size, output_data,
                          expected_output_data, output_dims_count, 1e-5);
 }
-#endif
 
 template <typename inputT, typename outputT>
 void TestSoftmaxQuantized(int* input_dims_data, const float* input_data,
@@ -326,7 +320,6 @@ void TestSoftmaxQuantized(int* input_dims_data, const float* input_data,
 
 TF_LITE_MICRO_TESTS_BEGIN
 
-#if !defined(XTENSA)
 TF_LITE_MICRO_TEST(Softmax1DFloatShouldMatchGolden) {
   float output_data[tflite::testing::flat_size_1d];
   tflite::testing::TestSoftmaxFloat(
@@ -476,7 +469,6 @@ TF_LITE_MICRO_TEST(Softmax4DQuantizedInt16ShouldMatchGolden) {
       tflite::testing::output_zero_point_int16, output_data,
       tflite::testing::tolerance_int16);
 }
-#endif
 
 TF_LITE_MICRO_TEST(Softmax2DQuantizedInt8InputInt16OutputShouldMatchGolden) {
   const float input_scale = 0.1f;

--- a/tensorflow/lite/micro/kernels/xtensa/softmax.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/softmax.cc
@@ -25,273 +25,65 @@ limitations under the License.
 #include "tensorflow/lite/kernels/op_macros.h"
 #include "tensorflow/lite/micro/kernels/kernel_util.h"
 #include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa_softmax.h"
 
 namespace tflite {
 namespace {
 
-#if defined(HIFIMINI)
-struct OpData {
-  uint16_t* exp_lut;
-};
-#elif defined(FUSION_F1) || defined(HIFI5)
-struct OpData {
-  SoftmaxParams params;
-  int scratch_tensor_index;
-};
-#endif
-
-#if defined(HIFIMINI)
-// Number of unique int8_t and int16_t values.  Used in exponent lookup table
-// computation.
-constexpr int kInt8Range =
-    std::numeric_limits<int8_t>::max() - std::numeric_limits<int8_t>::min() + 1;
-constexpr int kInt16Range = std::numeric_limits<int16_t>::max() -
-                            std::numeric_limits<int16_t>::min() + 1;
-// Each 16-bit precalculated exponent is expressed as a Q0.16 fixedpoint
-// value. We special-case e^0 since 1.0 requires 1 integer bit to
-// express.
-constexpr int kExpFractionalBits = 16;
-// e^0 expressed as Q1.15 exceeds the int16_t range, so it must be handled
-// specially.
-constexpr int kMaxExponentValue = (1 << kExpFractionalBits);
-
-// Quantized softmax with int8_t input and int16_t output.
-// Passing OpData by value does not have much savings in this op, but following
-// that as a best practice, at least for the xtensa kernels. See b/155656675 for
-// more details.
-TfLiteStatus SoftmaxHifimini(OpData op_data, const RuntimeShape& input_shape,
-                             const int8_t* input_data,
-                             const RuntimeShape& output_shape,
-                             int16_t* output_data) {
-  // The last dimension is depth.  Outer size is the total input size
-  // divided by depth.
-  const int trailing_dim = input_shape.DimensionsCount() - 1;
-  const int outer_size =
-      MatchingFlatSizeSkipDim(input_shape, trailing_dim, output_shape);
-  const int depth =
-      MatchingDim(input_shape, trailing_dim, output_shape, trailing_dim);
-
-  for (int i = 0; i < outer_size; ++i) {
-    int8_t max_in_row = std::numeric_limits<int8_t>::min();
-    for (int c = 0; c < depth; ++c) {
-      max_in_row = std::max(max_in_row, input_data[i * depth + c]);
-    }
-
-    uint32_t sum_of_exps = 0;
-    for (int c = 0; c < depth; ++c) {
-      TFLITE_DCHECK(max_in_row >= input_data[i * depth + c]);
-      uint8_t input_diff = max_in_row - input_data[i * depth + c];
-
-      sum_of_exps +=
-          input_diff == 0 ? kMaxExponentValue : op_data.exp_lut[input_diff];
-    }
-
-    // Ensure we cannot overflow the full_range_output value.  We need to
-    // guarantee that kInt16Range * max(input_data) / sum_of_exps < kInt16Range.
-    TFLITE_DCHECK(sum_of_exps >= kMaxExponentValue);
-
-    for (int c = 0; c < depth; ++c) {
-      uint8_t input_diff = max_in_row - input_data[i * depth + c];
-      // Special case for diff == 0
-      uint32_t unscaled_output =
-          input_diff == 0 ? kMaxExponentValue : op_data.exp_lut[input_diff];
-      int64_t scaled_output = static_cast<int64_t>(unscaled_output) *
-                              static_cast<int64_t>(kInt16Range);
-      int32_t full_range_output =
-          scaled_output / sum_of_exps + std::numeric_limits<int16_t>::min();
-      // Round up if remainder exceeds half of the divider value.
-      uint32_t remainder = scaled_output % sum_of_exps;
-      if (remainder * 2 >= sum_of_exps) {
-        full_range_output++;
-      }
-      output_data[i * depth + c] = static_cast<int16_t>(std::max(
-          std::min(full_range_output,
-                   static_cast<int32_t>(std::numeric_limits<int16_t>::max())),
-          static_cast<int32_t>(std::numeric_limits<int16_t>::min())));
-    }
-  }
-  return kTfLiteOk;
-}
-
-TfLiteStatus CalculateSoftmaxOpDataHifimini(TfLiteContext* context,
-                                            const TfLiteTensor* input,
-                                            TfLiteTensor* output,
-                                            const TfLiteSoftmaxParams* params,
-                                            OpData* op_data) {
-  if (input->type == kTfLiteUInt8 || input->type == kTfLiteInt8) {
-    if (input->type == kTfLiteUInt8) {
-      TF_LITE_ENSURE_EQ(context, output->params.zero_point, 0);
-    } else {
-      if (output->type == kTfLiteInt16) {
-        TF_LITE_ENSURE_EQ(context, output->params.zero_point,
-                          std::numeric_limits<int16_t>::min());
-        // NOTE: Current int16_t softmax output does not require symmetric
-        // scaling
-        // - so no need to verify scale here.
-      } else {
-        TF_LITE_ENSURE_EQ(context, output->params.zero_point,
-                          std::numeric_limits<int8_t>::min());
-        TF_LITE_ENSURE(context, output->params.scale == 1.f / 256);
-      }
-    }
-
-    // Precompute e^(-x * input_scale * beta) for every possible int8_t input.
-    // This computation is used for every iteration of Softmax.  We must compute
-    // using pre-scaled inputs to avoid introducing additional error, while
-    // restricting our input range to the int8_t range. This is valid since beta
-    // and input scale are constant for a given op in the graph. Skip index 0
-    // since that is a special case which requires 1 integer bit instead of 0.
-    for (int i = 1; i <= kInt8Range; i++) {
-      float scaled_input = i * input->params.scale;
-      float exp_value =
-          std::exp((-scaled_input) * static_cast<float>(params->beta));
-
-      float exponent_scaled =
-          std::round(exp_value * static_cast<float>(1 << kExpFractionalBits));
-      op_data->exp_lut[i] = static_cast<uint16_t>(exponent_scaled);
-    }
-  }
-  return kTfLiteOk;
-}
-
-TfLiteStatus PrepareHifimini(TfLiteContext* context, TfLiteNode* node) {
-  auto* params = static_cast<TfLiteSoftmaxParams*>(node->builtin_data);
-
-  TF_LITE_ENSURE_EQ(context, NumInputs(node), 1);
-  TF_LITE_ENSURE_EQ(context, NumOutputs(node), 1);
-  const TfLiteTensor* input = GetInput(context, node, 0);
-  TfLiteTensor* output = GetOutput(context, node, 0);
-  TF_LITE_ENSURE(context, NumDimensions(input) >= 1);
-
-  TFLITE_DCHECK(node->user_data != nullptr);
-  OpData* op_data = static_cast<OpData*>(node->user_data);
-
-  // Allocate an array to precompute exponents over all int8_t inputs, applying
-  // the scale and beta before calculating exp. It is mandatory to apply beta
-  // and scale here, since each softmax op may have different beta and scale
-  // values. Beta and scale will remain constant for a given softmax op.
-  op_data->exp_lut = static_cast<uint16_t*>(context->AllocatePersistentBuffer(
-      context, (kInt8Range + 1) * sizeof(uint16_t)));
-  TF_LITE_ENSURE(context, op_data->exp_lut != nullptr);
-
-  TF_LITE_ENSURE_STATUS(
-      CalculateSoftmaxOpDataHifimini(context, input, output, params, op_data));
-
-  return kTfLiteOk;
-}
-#endif  // defined(HIFIMINI)
-
-#if defined(FUSION_F1) || defined(HIFI5)
-TfLiteStatus PrepareHifi(TfLiteContext* context, TfLiteNode* node) {
-  TF_LITE_ENSURE_OK(context, SoftmaxPrepare(context, node));
-
-  // Calculate scratch memory requirements and request scratch buffer
-  const TfLiteTensor* input = GetInput(context, node, 0);
-  const TfLiteTensor* output = GetOutput(context, node, 0);
-
-  const RuntimeShape& input_shape = GetTensorShape(input);
-  const RuntimeShape& output_shape = GetTensorShape(output);
-  const int trailing_dim = input_shape.DimensionsCount() - 1;
-  const int depth =
-      MatchingDim(input_shape, trailing_dim, output_shape, trailing_dim);
-
-  if (input->type == kTfLiteInt8) {
-    int required_scratch =
-        get_softmax_scratch_size(PREC_ASYM8S, PREC_ASYM8S, depth);
-    TF_LITE_ENSURE(context, required_scratch > 0);
-
-    auto* data = static_cast<OpData*>(node->user_data);
-    TF_LITE_ENSURE_OK(
-        context, context->RequestScratchBufferInArena(
-                     context, required_scratch, &(data->scratch_tensor_index)));
-  }
-
-  return kTfLiteOk;
-}
-
-TfLiteStatus EvalHifi(const OpData* op_data, const TfLiteEvalTensor* input,
-                      TfLiteEvalTensor* output, TfLiteContext* context) {
-  const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
-  const int8_t* input_data = tflite::micro::GetTensorData<int8_t>(input);
-  const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
-  int16_t* output_data = tflite::micro::GetTensorData<int16_t>(output);
-  const int trailing_dim = input_shape.DimensionsCount() - 1;
-  const int outer_size =
-      MatchingFlatSizeSkipDim(input_shape, trailing_dim, output_shape);
-  const int depth =
-      MatchingDim(input_shape, trailing_dim, output_shape, trailing_dim);
-
-  void* p_scratch = static_cast<void*>(
-      context->GetScratchBuffer(context, op_data->scratch_tensor_index));
-
-  for (int i = 0; i < outer_size; ++i) {
-    int err = xa_nn_vec_softmax_asym8s_16(
-        &output_data[i * depth], &input_data[i * depth],
-        op_data->params.diff_min, op_data->params.input_left_shift,
-        op_data->params.input_multiplier, depth, p_scratch);
-    TF_LITE_ENSURE(context, err == 0);
-  }
-  return kTfLiteOk;
-}
-
-#endif  // defined(FUSION_F1) || defined(HIFI5)
-
-void* Init(TfLiteContext* context, const char* buffer, size_t length) {
-#if defined(HIFIMINI) || defined(FUSION_F1) || defined(HIFI5)
-  TFLITE_DCHECK(context->AllocatePersistentBuffer != nullptr);
-  return context->AllocatePersistentBuffer(context, sizeof(OpData));
-#else
-  return SoftmaxInit(context, buffer, length);
-#endif
-}
-
-TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
-#if defined(HIFIMINI)
-  return PrepareHifimini(context, node);
-#elif defined(FUSION_F1) || defined(HIFI5)
-  return PrepareHifi(context, node);
-#else
-  return SoftmaxPrepare(context, node);
-#endif
-}
-
 TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   const TfLiteEvalTensor* input = tflite::micro::GetEvalInput(context, node, 0);
   TfLiteEvalTensor* output = tflite::micro::GetEvalOutput(context, node, 0);
-  TFLITE_DCHECK(node->user_data != nullptr);
 
   if (input->type == kTfLiteInt8 && output->type == kTfLiteInt16) {
-#if defined(HIFIMINI)
-    return SoftmaxHifimini(*static_cast<OpData*>(node->user_data),
-                           tflite::micro::GetTensorShape(input),
-                           tflite::micro::GetTensorData<int8_t>(input),
-                           tflite::micro::GetTensorShape(output),
-                           tflite::micro::GetTensorData<int16_t>(output));
-#elif defined(FUSION_F1) || defined(HIFI5)
-    return EvalHifi(static_cast<OpData*>(node->user_data), input, output,
-                    context);
+    return XtensaEvalSoftmaxInt8Int16(context, node);
+  }
+
+  TFLITE_DCHECK(node->user_data != nullptr);
+#if defined(FUSION_F1) || defined(HIFI5)
+  XtensaSoftmaxOpData op_data =
+      *static_cast<XtensaSoftmaxOpData*>(node->user_data);
+  SoftmaxParams params = op_data.params;
 #else
-    SoftmaxParams op_data = *static_cast<SoftmaxParams*>(node->user_data);
+  SoftmaxParams params = *static_cast<SoftmaxParams*>(node->user_data);
+#endif
+
+  if (input->type == kTfLiteInt8 && output->type == kTfLiteInt8) {
     tflite::reference_ops::Softmax(
-        op_data, tflite::micro::GetTensorShape(input),
+        params, tflite::micro::GetTensorShape(input),
         tflite::micro::GetTensorData<int8_t>(input),
+        tflite::micro::GetTensorShape(output),
+        tflite::micro::GetTensorData<int8_t>(output));
+    return kTfLiteOk;
+  }
+
+  if (input->type == kTfLiteInt16 && output->type == kTfLiteInt16) {
+    tflite::reference_ops::SoftmaxInt16(
+        params, tflite::micro::GetTensorShape(input),
+        tflite::micro::GetTensorData<int16_t>(input),
         tflite::micro::GetTensorShape(output),
         tflite::micro::GetTensorData<int16_t>(output));
     return kTfLiteOk;
-#endif
-  } else {
-    TF_LITE_KERNEL_LOG(context, "Type %s (%d) not supported.",
-                       TfLiteTypeGetName(input->type), input->type);
-    return kTfLiteError;
   }
+
+  if (input->type == kTfLiteFloat32) {
+    tflite::reference_ops::Softmax(params, tflite::micro::GetTensorShape(input),
+                                   tflite::micro::GetTensorData<float>(input),
+                                   tflite::micro::GetTensorShape(output),
+                                   tflite::micro::GetTensorData<float>(output));
+    return kTfLiteOk;
+  }
+
+  TF_LITE_KERNEL_LOG(context, "Type %s (%d) not supported.",
+                     TfLiteTypeGetName(input->type), input->type);
+  return kTfLiteError;
 }
 
 }  // namespace
 
 TfLiteRegistration Register_SOFTMAX() {
-  return {/*init=*/Init,
+  return {/*init=*/XtensaInitSoftmax,
           /*free=*/nullptr,
-          /*prepare=*/Prepare,
+          /*prepare=*/XtensaPrepareSoftmax,
           /*invoke=*/Eval,
           /*profiling_string=*/nullptr,
           /*builtin_code=*/0,

--- a/tensorflow/lite/micro/kernels/xtensa/softmax_int8_int16.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/softmax_int8_int16.cc
@@ -1,0 +1,296 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/common.h"
+#include "tensorflow/lite/kernels/internal/quantization_util.h"
+#include "tensorflow/lite/kernels/internal/reference/softmax.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/kernels/op_macros.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/softmax.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa.h"
+#include "tensorflow/lite/micro/kernels/xtensa/xtensa_softmax.h"
+
+namespace tflite {
+namespace {
+
+#if defined(HIFIMINI)
+// Number of unique int8_t and int16_t values.  Used in exponent lookup table
+// computation.
+constexpr int kInt8Range =
+    std::numeric_limits<int8_t>::max() - std::numeric_limits<int8_t>::min() + 1;
+constexpr int kInt16Range = std::numeric_limits<int16_t>::max() -
+                            std::numeric_limits<int16_t>::min() + 1;
+// Each 16-bit precalculated exponent is expressed as a Q0.16 fixedpoint
+// value. We special-case e^0 since 1.0 requires 1 integer bit to
+// express.
+constexpr int kExpFractionalBits = 16;
+// e^0 expressed as Q1.15 exceeds the int16_t range, so it must be handled
+// specially.
+constexpr int kMaxExponentValue = (1 << kExpFractionalBits);
+
+// Quantized softmax with int8_t input and int16_t output.
+// Passing XtensaSoftmaxOpData by value does not have much savings in this op,
+// but following that as a best practice, at least for the xtensa kernels. See
+// b/155656675 for more details.
+TfLiteStatus SoftmaxHifimini(XtensaSoftmaxOpData op_data,
+                             const RuntimeShape& input_shape,
+                             const int8_t* input_data,
+                             const RuntimeShape& output_shape,
+                             int16_t* output_data) {
+  // The last dimension is depth.  Outer size is the total input size
+  // divided by depth.
+  const int trailing_dim = input_shape.DimensionsCount() - 1;
+  const int outer_size =
+      MatchingFlatSizeSkipDim(input_shape, trailing_dim, output_shape);
+  const int depth =
+      MatchingDim(input_shape, trailing_dim, output_shape, trailing_dim);
+
+  for (int i = 0; i < outer_size; ++i) {
+    int8_t max_in_row = std::numeric_limits<int8_t>::min();
+    for (int c = 0; c < depth; ++c) {
+      max_in_row = std::max(max_in_row, input_data[i * depth + c]);
+    }
+
+    uint32_t sum_of_exps = 0;
+    for (int c = 0; c < depth; ++c) {
+      TFLITE_DCHECK(max_in_row >= input_data[i * depth + c]);
+      uint8_t input_diff = max_in_row - input_data[i * depth + c];
+
+      sum_of_exps +=
+          input_diff == 0 ? kMaxExponentValue : op_data.exp_lut[input_diff];
+    }
+
+    // Ensure we cannot overflow the full_range_output value.  We need to
+    // guarantee that kInt16Range * max(input_data) / sum_of_exps < kInt16Range.
+    TFLITE_DCHECK(sum_of_exps >= kMaxExponentValue);
+
+    for (int c = 0; c < depth; ++c) {
+      uint8_t input_diff = max_in_row - input_data[i * depth + c];
+      // Special case for diff == 0
+      uint32_t unscaled_output =
+          input_diff == 0 ? kMaxExponentValue : op_data.exp_lut[input_diff];
+      int64_t scaled_output = static_cast<int64_t>(unscaled_output) *
+                              static_cast<int64_t>(kInt16Range);
+      int32_t full_range_output =
+          scaled_output / sum_of_exps + std::numeric_limits<int16_t>::min();
+      // Round up if remainder exceeds half of the divider value.
+      uint32_t remainder = scaled_output % sum_of_exps;
+      if (remainder * 2 >= sum_of_exps) {
+        full_range_output++;
+      }
+      output_data[i * depth + c] = static_cast<int16_t>(std::max(
+          std::min(full_range_output,
+                   static_cast<int32_t>(std::numeric_limits<int16_t>::max())),
+          static_cast<int32_t>(std::numeric_limits<int16_t>::min())));
+    }
+  }
+  return kTfLiteOk;
+}
+
+TfLiteStatus CalculateSoftmaxOpDataHifimini(TfLiteContext* context,
+                                            const TfLiteTensor* input,
+                                            TfLiteTensor* output,
+                                            const TfLiteSoftmaxParams* params,
+                                            XtensaSoftmaxOpData* op_data) {
+  if (input->type == kTfLiteUInt8 || input->type == kTfLiteInt8) {
+    if (input->type == kTfLiteUInt8) {
+      TF_LITE_ENSURE_EQ(context, output->params.zero_point, 0);
+    } else {
+      if (output->type == kTfLiteInt16) {
+        TF_LITE_ENSURE_EQ(context, output->params.zero_point,
+                          std::numeric_limits<int16_t>::min());
+        // NOTE: Current int16_t softmax output does not require symmetric
+        // scaling
+        // - so no need to verify scale here.
+      } else {
+        TF_LITE_ENSURE_EQ(context, output->params.zero_point,
+                          std::numeric_limits<int8_t>::min());
+        TF_LITE_ENSURE(context, output->params.scale == 1.f / 256);
+      }
+    }
+
+    // Precompute e^(-x * input_scale * beta) for every possible int8_t input.
+    // This computation is used for every iteration of Softmax.  We must compute
+    // using pre-scaled inputs to avoid introducing additional error, while
+    // restricting our input range to the int8_t range. This is valid since beta
+    // and input scale are constant for a given op in the graph. Skip index 0
+    // since that is a special case which requires 1 integer bit instead of 0.
+    for (int i = 1; i <= kInt8Range; i++) {
+      float scaled_input = i * input->params.scale;
+      float exp_value =
+          std::exp((-scaled_input) * static_cast<float>(params->beta));
+
+      float exponent_scaled =
+          std::round(exp_value * static_cast<float>(1 << kExpFractionalBits));
+      op_data->exp_lut[i] = static_cast<uint16_t>(exponent_scaled);
+    }
+  }
+  return kTfLiteOk;
+}
+
+TfLiteStatus PrepareHifimini(TfLiteContext* context, TfLiteNode* node) {
+  auto* params = static_cast<TfLiteSoftmaxParams*>(node->builtin_data);
+
+  TF_LITE_ENSURE_EQ(context, NumInputs(node), 1);
+  TF_LITE_ENSURE_EQ(context, NumOutputs(node), 1);
+  const TfLiteTensor* input = GetInput(context, node, 0);
+  TfLiteTensor* output = GetOutput(context, node, 0);
+  TF_LITE_ENSURE(context, NumDimensions(input) >= 1);
+
+  TFLITE_DCHECK(node->user_data != nullptr);
+  XtensaSoftmaxOpData* op_data =
+      static_cast<XtensaSoftmaxOpData*>(node->user_data);
+
+  // Allocate an array to precompute exponents over all int8_t inputs, applying
+  // the scale and beta before calculating exp. It is mandatory to apply beta
+  // and scale here, since each softmax op may have different beta and scale
+  // values. Beta and scale will remain constant for a given softmax op.
+  op_data->exp_lut = static_cast<uint16_t*>(context->AllocatePersistentBuffer(
+      context, (kInt8Range + 1) * sizeof(uint16_t)));
+  TF_LITE_ENSURE(context, op_data->exp_lut != nullptr);
+
+  TF_LITE_ENSURE_STATUS(
+      CalculateSoftmaxOpDataHifimini(context, input, output, params, op_data));
+
+  return kTfLiteOk;
+}
+#endif  // defined(HIFIMINI)
+
+#if defined(FUSION_F1) || defined(HIFI5)
+TfLiteStatus PrepareHifi(TfLiteContext* context, TfLiteNode* node) {
+  TF_LITE_ENSURE_OK(context, SoftmaxPrepare(context, node));
+
+  // Calculate scratch memory requirements and request scratch buffer
+  const TfLiteTensor* input = GetInput(context, node, 0);
+  const TfLiteTensor* output = GetOutput(context, node, 0);
+
+  const RuntimeShape& input_shape = GetTensorShape(input);
+  const RuntimeShape& output_shape = GetTensorShape(output);
+  const int trailing_dim = input_shape.DimensionsCount() - 1;
+  const int depth =
+      MatchingDim(input_shape, trailing_dim, output_shape, trailing_dim);
+
+  if (input->type == kTfLiteInt8) {
+    int required_scratch =
+        get_softmax_scratch_size(PREC_ASYM8S, PREC_ASYM8S, depth);
+    TF_LITE_ENSURE(context, required_scratch > 0);
+
+    auto* data = static_cast<XtensaSoftmaxOpData*>(node->user_data);
+    TF_LITE_ENSURE_OK(
+        context, context->RequestScratchBufferInArena(
+                     context, required_scratch, &(data->scratch_tensor_index)));
+  }
+
+  return kTfLiteOk;
+}
+
+TfLiteStatus EvalHifi(const XtensaSoftmaxOpData* op_data,
+                      const TfLiteEvalTensor* input, TfLiteEvalTensor* output,
+                      TfLiteContext* context) {
+  const RuntimeShape& input_shape = tflite::micro::GetTensorShape(input);
+  const int8_t* input_data = tflite::micro::GetTensorData<int8_t>(input);
+  const RuntimeShape& output_shape = tflite::micro::GetTensorShape(output);
+  int16_t* output_data = tflite::micro::GetTensorData<int16_t>(output);
+  const int trailing_dim = input_shape.DimensionsCount() - 1;
+  const int outer_size =
+      MatchingFlatSizeSkipDim(input_shape, trailing_dim, output_shape);
+  const int depth =
+      MatchingDim(input_shape, trailing_dim, output_shape, trailing_dim);
+
+  void* p_scratch = static_cast<void*>(
+      context->GetScratchBuffer(context, op_data->scratch_tensor_index));
+
+  for (int i = 0; i < outer_size; ++i) {
+    int err = xa_nn_vec_softmax_asym8s_16(
+        &output_data[i * depth], &input_data[i * depth],
+        op_data->params.diff_min, op_data->params.input_left_shift,
+        op_data->params.input_multiplier, depth, p_scratch);
+    TF_LITE_ENSURE(context, err == 0);
+  }
+  return kTfLiteOk;
+}
+}  // namespace
+
+#endif  // defined(FUSION_F1) || defined(HIFI5)
+
+void* XtensaInitSoftmax(TfLiteContext* context, const char* buffer,
+                        size_t length) {
+#if defined(HIFIMINI) || defined(FUSION_F1) || defined(HIFI5)
+  TFLITE_DCHECK(context->AllocatePersistentBuffer != nullptr);
+  return context->AllocatePersistentBuffer(context,
+                                           sizeof(XtensaSoftmaxOpData));
+#else
+  return SoftmaxInit(context, buffer, length);
+#endif
+}
+
+TfLiteStatus XtensaPrepareSoftmax(TfLiteContext* context, TfLiteNode* node) {
+#if defined(HIFIMINI)
+  return PrepareHifimini(context, node);
+#elif defined(FUSION_F1) || defined(HIFI5)
+  return PrepareHifi(context, node);
+#else
+  return SoftmaxPrepare(context, node);
+#endif
+}
+
+TfLiteStatus XtensaEvalSoftmaxInt8Int16(TfLiteContext* context,
+                                        TfLiteNode* node) {
+  const TfLiteEvalTensor* input = tflite::micro::GetEvalInput(context, node, 0);
+  TfLiteEvalTensor* output = tflite::micro::GetEvalOutput(context, node, 0);
+  TFLITE_DCHECK(node->user_data != nullptr);
+
+  if (input->type == kTfLiteInt8 && output->type == kTfLiteInt16) {
+#if defined(HIFIMINI)
+    return SoftmaxHifimini(*static_cast<XtensaSoftmaxOpData*>(node->user_data),
+                           tflite::micro::GetTensorShape(input),
+                           tflite::micro::GetTensorData<int8_t>(input),
+                           tflite::micro::GetTensorShape(output),
+                           tflite::micro::GetTensorData<int16_t>(output));
+#elif defined(FUSION_F1) || defined(HIFI5)
+    return EvalHifi(static_cast<XtensaSoftmaxOpData*>(node->user_data), input,
+                    output, context);
+#else
+    SoftmaxParams op_data = *static_cast<SoftmaxParams*>(node->user_data);
+    tflite::reference_ops::Softmax(
+        op_data, tflite::micro::GetTensorShape(input),
+        tflite::micro::GetTensorData<int8_t>(input),
+        tflite::micro::GetTensorShape(output),
+        tflite::micro::GetTensorData<int16_t>(output));
+    return kTfLiteOk;
+#endif
+  } else {
+    TF_LITE_KERNEL_LOG(context, "Type %s (%d) not supported.",
+                       TfLiteTypeGetName(input->type), input->type);
+    return kTfLiteError;
+  }
+}
+
+TfLiteRegistration Register_SOFTMAX_INT8_INT16() {
+  return {/*init=*/XtensaInitSoftmax,
+          /*free=*/nullptr,
+          /*prepare=*/XtensaPrepareSoftmax,
+          /*invoke=*/XtensaEvalSoftmaxInt8Int16,
+          /*profiling_string=*/nullptr,
+          /*builtin_code=*/0,
+          /*custom_name=*/nullptr,
+          /*version=*/0};
+}
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/xtensa/xtensa_softmax.h
+++ b/tensorflow/lite/micro/kernels/xtensa/xtensa_softmax.h
@@ -12,34 +12,35 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-#ifndef TENSORFLOW_LITE_MICRO_KERNELS_SOFTMAX_H_
-#define TENSORFLOW_LITE_MICRO_KERNELS_SOFTMAX_H_
+#ifndef TENSORFLOW_LITE_MICRO_KERNELS_XTENSA_XTENSA_SOFTMAX_H_
+#define TENSORFLOW_LITE_MICRO_KERNELS_XTENSA_XTENSA_SOFTMAX_H_
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/kernels/internal/types.h"
+#include "tensorflow/lite/micro/kernels/softmax.h"
 
 namespace tflite {
 
-void* SoftmaxInit(TfLiteContext* context, const char* buffer, size_t length);
-
-TfLiteStatus SoftmaxPrepare(TfLiteContext* context, TfLiteNode* node);
-
-// This is the most generic TfLiteRegistration. The actual supported types may
-// still be target dependent. The only requirement is that every implementation
-// (reference or optimized) must define this function.
-TfLiteRegistration Register_SOFTMAX();
-
-#if defined(XTENSA)
-// Returns a TfLiteRegistration struct for kernel variant that only supports
-// int8 input and int16 output.
-TfLiteRegistration Register_SOFTMAX_INT8_INT16();
-#else
-inline TfLiteRegistration Register_SOFTMAX_INT8_INT16() {
-  return Register_SOFTMAX();
-}
+#if defined(HIFIMINI)
+struct XtensaSoftmaxOpData {
+  uint16_t* exp_lut;
+};
+#elif defined(FUSION_F1) || defined(HIFI5)
+struct XtensaSoftmaxOpData {
+  SoftmaxParams params;
+  int scratch_tensor_index;
+};
 #endif
+
+void* XtensaInitSoftmax(TfLiteContext* context, const char* buffer,
+                        size_t length);
+
+TfLiteStatus XtensaPrepareSoftmax(TfLiteContext* context, TfLiteNode* node);
+
+TfLiteStatus XtensaEvalSoftmaxInt8Int16(TfLiteContext* context,
+                                        TfLiteNode* node);
 
 }  // namespace tflite
 
-#endif  // TENSORFLOW_LITE_MICRO_KERNELS_SOFTMAX_H_
+#endif  // TENSORFLOW_LITE_MICRO_KERNELS_XTENSA_XTENSA_SOFTMAX_H_

--- a/tensorflow/lite/micro/micro_mutable_op_resolver.h
+++ b/tensorflow/lite/micro/micro_mutable_op_resolver.h
@@ -27,6 +27,7 @@ limitations under the License.
 #include "tensorflow/lite/micro/kernels/ethosu.h"
 #include "tensorflow/lite/micro/kernels/fully_connected.h"
 #include "tensorflow/lite/micro/kernels/micro_ops.h"
+#include "tensorflow/lite/micro/kernels/softmax.h"
 #include "tensorflow/lite/micro/micro_op_resolver.h"
 #include "tensorflow/lite/schema/schema_generated.h"
 
@@ -445,9 +446,9 @@ class MicroMutableOpResolver : public MicroOpResolver {
                       ParseSin);
   }
 
-  TfLiteStatus AddSoftmax() {
-    return AddBuiltin(BuiltinOperator_SOFTMAX, Register_SOFTMAX(),
-                      ParseSoftmax);
+  TfLiteStatus AddSoftmax(
+      const TfLiteRegistration& registration = Register_SOFTMAX()) {
+    return AddBuiltin(BuiltinOperator_SOFTMAX, registration, ParseSoftmax);
   }
 
   TfLiteStatus AddSpaceToBatchNd() {

--- a/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
+++ b/tensorflow/lite/micro/tools/make/ext_libs/xtensa.inc
@@ -1,3 +1,8 @@
+# Explicitly add kernel sources specific to the Xtensa optimized
+# implementations.
+MICROLITE_CC_KERNEL_SRCS += \
+  tensorflow/lite/micro/kernels/xtensa/softmax_int8_int16.cc
+
 ifeq ($(TARGET_ARCH), $(findstring $(TARGET_ARCH), "hifi5"))
 
   DOWNLOAD_RESULT := $(shell $(MAKEFILE_DIR)/ext_libs/xtensa_download.sh ${MAKEFILE_DIR}/downloads hifi5)

--- a/tensorflow/lite/micro/tools/make/targets/xtensa_makefile.inc
+++ b/tensorflow/lite/micro/tools/make/targets/xtensa_makefile.inc
@@ -84,8 +84,6 @@ EXCLUDED_EXAMPLE_TESTS := \
   tensorflow/lite/micro/examples/hello_world/Makefile.inc \
   tensorflow/lite/micro/examples/image_recognition_experimental/Makefile.inc \
   tensorflow/lite/micro/examples/magic_wand/Makefile.inc \
-  tensorflow/lite/micro/examples/micro_speech/Makefile.inc \
-  tensorflow/lite/micro/examples/network_tester/Makefile.inc \
-  tensorflow/lite/micro/examples/person_detection/Makefile.inc
+  tensorflow/lite/micro/examples/network_tester/Makefile.inc
 MICRO_LITE_EXAMPLE_TESTS := $(filter-out $(EXCLUDED_EXAMPLE_TESTS), $(MICRO_LITE_EXAMPLE_TESTS))
 


### PR DESCRIPTION
 * This allows the micro_speech and person_detect examples to be usable with the optimized xtensa kernels.
 * enabled all the softmax kernel test cases for Xtensa (since we have a fallback to the reference kernels).
 * The keyword_benchmark specific variant is moved to its own .cc file since that allows the Xtensa linker to properly drop unsused symbols and ensures that the binary size for the keyword_benchmark is unchanged.
    
Manually tested that the following tests pass:
```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa TARGET_ARCH=fusion_f1 OPTIMIZED_KERNEL_DIR=xtensa XTENSA_CORE=F1_190305_swupgrade test_person_detection_test_int8 -j8
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa TARGET_ARCH=fusion_f1 OPTIMIZED_KERNEL_DIR=xtensa XTENSA_CORE=F1_190305_swupgrade test_micro_speech_test -j8
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa TARGET_ARCH=fusion_f1 OPTIMIZED_KERNEL_DIR=xtensa XTENSA_CORE=F1_190305_swupgrade test_kernel_softmax_test -j8
```

Confirmed that the binary size for the keyword_benchmark is unchanged (relative to tip of tree):
```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa TARGET_ARCH=fusion_f1 OPTIMIZED_KERNEL_DIR=xtensa XTENSA_CORE=F1_190305_swupgrade keyword_benchmark -j8 BUILD_TYPE=release
xt-size tensorflow/lite/micro/tools/make/gen/xtensa_fusion_f1_release/bin/keyword_benchmark
```

Gives:
```
   text    data     bss     dec     hex filename
   70368   41140   24856  136364   214ac tensorflow/lite/micro/tools/make/gen/xtensa_fusion_f1_release/bin/keyword_benchmark
```

Related bug: http://b/188581097