### PR TITLE
[Intel MKL] Parallelize UnsortedSegmentSum on CPU deivce

### DIFF
--- a/tensorflow/core/kernels/segment_reduction_ops_test.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops_test.cc
@@ -200,4 +200,47 @@ BENCHMARK(BM_SparseSegmentMeanGrad_High_BF16)
     ->Arg(1000)
     ->Arg(100000);
 
+static void BM_UnsortedSegmentReduction(::testing::benchmark::State& state,
+                                        const string& reduction, int num_rows,
+                                        int num_cols, int segment_size) {
+  Graph* g = new Graph(OpRegistry::Global());
+
+  // Create inputs
+  TensorShape shape1({num_rows, num_cols});
+  Tensor input(DT_FLOAT, shape1);
+  input.flat<float>().setRandom();
+
+  TensorShape shape2({num_rows});
+  Tensor indices(DT_INT32, shape2);
+  test::FillFn<int>(&indices,
+                    [&segment_size](int i) -> int { return i % segment_size; });
+
+  Tensor num_segments(DT_INT32, TensorShape({}));
+  num_segments.scalar<int>()() = segment_size;
+
+  Node* node;
+  TF_CHECK_OK(NodeBuilder(g->NewName("n"), reduction)
+                  .Input(test::graph::Constant(g, input))
+                  .Input(test::graph::Constant(g, indices))
+                  .Input(test::graph::Constant(g, num_segments))
+                  .Attr("T", DT_FLOAT)
+                  .Finalize(g, &node));
+
+  test::Benchmark("cpu", g, /*old_benchmark_api*/ false).Run(state);
+  state.SetBytesProcessed(static_cast<int64>(state.iterations()) *
+                          (num_rows * num_cols) * sizeof(float));
+}
+
+#define BM_UnsortedReduce(O, R, C, S)                                        \
+  static void BM_##O##_##R##_##C##_##S(::testing::benchmark::State& state) { \
+    BM_UnsortedSegmentReduction(state, #O, R, C, S);                         \
+  }                                                                          \
+  BENCHMARK(BM_##O##_##R##_##C##_##S);
+
+#define BM_UnsortedReduce_Arg(R, C, S) \
+  BM_UnsortedReduce(UnsortedSegmentSum, R, C, S);
+
+BM_UnsortedReduce_Arg(4096, 128, 1);
+BM_UnsortedReduce_Arg(4096, 128, 128);
+
 }  // namespace tensorflow

--- a/tensorflow/python/kernel_tests/segment_reduction_ops_test.py
+++ b/tensorflow/python/kernel_tests/segment_reduction_ops_test.py
@@ -500,6 +500,13 @@ class UnsortedSegmentTest(SegmentReductionHelper):
         self.assertAllClose(np_ans, tf_ans)
         self.assertShapeEqual(np_ans, s)
 
+  @test_util.run_deprecated_v1
+  def testAllNegatives(self):
+    with self.session(use_gpu=False):
+      data = np.ones((2, 1), dtype=np.float32)
+      segment_ids = np.array([-1, -1], dtype=np.int32)
+      unsorted = math_ops.unsorted_segment_sum(data, segment_ids, 2)
+      self.assertAllClose(unsorted.eval(), np.zeros((2, 1), dtype=np.float32))
 
 class SparseSegmentReductionHelper(SegmentReductionHelper):
 


### PR DESCRIPTION
`UnsortedSegmentSum` is a single thread op on CPU, here use the Eigen device to parallelize it. It's updated from an old PR #26427 .

I resubmit this PR because the original one got an internal crash and was reverted. Because I can't get the failure case, I just went through the old code and found a potential rounding issue here: https://github.com/Intel-tensorflow/tensorflow/blob/52a6cfddef9b51b608b4a554b77a10e1522d56ec/tensorflow/core/kernels/segment_reduction_ops.cc#L419-L425

This PR uses a simple and reasonable way to balance workload like what TF usually did:
```c++
    // Each output row may contain different size of reduction from inputs,
    // balance the workload to a task group. Each task is output row index.
    const int64 kMaxTaskBlock =
        std::min(num_reductions, (int64)cpu_device.numThreads());
    const int64 kAverTaskSize = (N + kMaxTaskBlock - 1) / kMaxTaskBlock
```
Other parts are the same as the original one.


Performance improvement:
* Origin
```
BM_UnsortedSegmentSum_4096_128_1_ 300315 2279 6983.2MB/s
BM_UnsortedSegmentSum_4096_128_128_ 306408 2268 6844.3MB/s
```

* Optimized
```
BM_UnsortedSegmentSum_4096_128_1_ 302769 2268 6926.6MB/s
BM_UnsortedSegmentSum_4096_128_128_ 116179 6112 18051.1MB/s
```

This patch tries to parallel UnsortSegmentReduction with num_segments, so the performance has no change if num_segments is 1, otherwise it has ~3X improvement in the benchmark.