### PR TITLE
Include limits to prevent CI failure for tflite-micro.

### DIFF
--- a/tensorflow/lite/micro/micro_utils.h
+++ b/tensorflow/lite/micro/micro_utils.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <limits>
 
 #include "tensorflow/lite/c/common.h"
 


### PR DESCRIPTION
This change is upstreaming the fix made with https://github.com/tensorflow/tflite-micro/pull/71/commits/5bd86af7fa8519c463eae03c72733aa479f00e5f
