### PR TITLE
[Crash fix] Fix cudaMallocAsync crashes.

### DIFF
--- a/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
@@ -41,10 +41,13 @@ static std::string GetCudaErrorMessage(CUresult result) {
 }
 #endif  // GOOGLE_CUDA
 
+int GpuCudaMallocAsyncAllocator::nb_instanciated_ = 0;
+
 GpuCudaMallocAsyncAllocator::GpuCudaMallocAsyncAllocator(
     PlatformDeviceId platform_device_id, size_t pool_size, bool reserve_memory,
     bool compute_stats)
     : name_(absl::StrCat("gpu_async_", platform_device_id.value())) {
+  ++nb_instanciated_;
 #if TF_CUDA_MALLOC_ASYNC_SUPPORTED
   stream_exec_ = DeviceIdUtil::ExecutorForPlatformDeviceId(GPUMachineManager(),
                                                            platform_device_id)

--- a/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
@@ -41,13 +41,13 @@ static std::string GetCudaErrorMessage(CUresult result) {
 }
 #endif  // GOOGLE_CUDA
 
-int GpuCudaMallocAsyncAllocator::nb_instanciated_ = 0;
+std::atomic<int> GpuCudaMallocAsyncAllocator::number_instantiated_(0);
 
 GpuCudaMallocAsyncAllocator::GpuCudaMallocAsyncAllocator(
     PlatformDeviceId platform_device_id, size_t pool_size, bool reserve_memory,
     bool compute_stats)
     : name_(absl::StrCat("gpu_async_", platform_device_id.value())) {
-  ++nb_instanciated_;
+  ++number_instantiated_;
 #if TF_CUDA_MALLOC_ASYNC_SUPPORTED
   stream_exec_ = DeviceIdUtil::ExecutorForPlatformDeviceId(GPUMachineManager(),
                                                            platform_device_id)

--- a/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.h
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.h
@@ -67,7 +67,7 @@ class GpuCudaMallocAsyncAllocator : public Allocator {
   explicit GpuCudaMallocAsyncAllocator(PlatformDeviceId platform_device_id,
                                        size_t pool_size,
                                        bool reserve_memory = false,
-                                       bool compute_stats = false);
+                                       bool compute_stats = true);
   ~GpuCudaMallocAsyncAllocator() override;
   string Name() override { return name_; }
   void* AllocateRaw(size_t alignment, size_t num_bytes) override;

--- a/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.h
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.h
@@ -85,7 +85,7 @@ class GpuCudaMallocAsyncAllocator : public Allocator {
 
   void SetStream(void* stream) override {
 #if TF_CUDA_MALLOC_ASYNC_SUPPORTED
-    cuda_stream_ = reinterpret_cast<CUstream>(stream);
+    cuda_stream_ = *(reinterpret_cast<CUstream*>(stream));
 #endif
   }
 

--- a/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.h
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.h
@@ -85,7 +85,7 @@ class GpuCudaMallocAsyncAllocator : public Allocator {
 
   void SetStream(void* stream) override {
 #if TF_CUDA_MALLOC_ASYNC_SUPPORTED
-    cuda_stream_ = *(reinterpret_cast<CUstream*>(stream));
+    cuda_stream_ = *(static_cast<CUstream*>(stream));
 #endif
   }
 

--- a/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.h
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.h
@@ -89,8 +89,8 @@ class GpuCudaMallocAsyncAllocator : public Allocator {
 #endif
   }
 
-  static int NbInstantiated() {
-    return nb_instanciated_;
+  static int GetInstantiatedCountTestOnly() {
+    return number_instantiated_;
   }
 
  private:
@@ -110,9 +110,9 @@ class GpuCudaMallocAsyncAllocator : public Allocator {
   CUmemoryPool pool_;
 #endif  // TF_CUDA_MALLOC_ASYNC_SUPPORTED
 
-  // Just a counter for the number of time this class is instanciated.
+  // Just a counter for the number of time this class is instantiated.
   // Only useful for tests.
-  static int nb_instanciated_;
+  static std::atomic<int> number_instantiated_;
 
   string name_;
 

--- a/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.h
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.h
@@ -89,6 +89,10 @@ class GpuCudaMallocAsyncAllocator : public Allocator {
 #endif
   }
 
+  static int NbInstantiated() {
+    return nb_instanciated_;
+  }
+
  private:
 #if TF_CUDA_MALLOC_ASYNC_SUPPORTED
   se::StreamExecutor* stream_exec_;  // Not owned.
@@ -105,6 +109,10 @@ class GpuCudaMallocAsyncAllocator : public Allocator {
   // will return an error.
   CUmemoryPool pool_;
 #endif  // TF_CUDA_MALLOC_ASYNC_SUPPORTED
+
+  // Just a counter for the number of time this class is instanciated.
+  // Only useful for tests.
+  static int nb_instanciated_;
 
   string name_;
 

--- a/tensorflow/core/common_runtime/gpu/gpu_device_test.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device_test.cc
@@ -80,7 +80,7 @@ class GPUDeviceTest : public ::testing::Test {
     gpu_options->set_visible_device_list(visible_device_list);
     gpu_options->set_per_process_gpu_memory_fraction(
         per_process_gpu_memory_fraction);
-    gpu_options->set_use_cuda_malloc_async(use_cuda_malloc_async);
+    gpu_options->mutable_experimental()->set_use_cuda_malloc_async(use_cuda_malloc_async);
     for (int i = 0; i < memory_limit_mb.size(); ++i) {
       auto virtual_devices =
           gpu_options->mutable_experimental()->add_virtual_devices();

--- a/tensorflow/core/common_runtime/gpu/gpu_device_test.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device_test.cc
@@ -129,7 +129,7 @@ TEST_F(GPUDeviceTest, CudaMallocAsync) {
     EXPECT_EQ(devices.size(), 1);
     Device* device = devices[0].get();
     auto* device_info = device->tensorflow_gpu_device_info();
-    CHECK(device_info);
+    EXPECT_NE(device_info, nullptr);
     DeviceContext* device_context = device_info->default_context;
 
     AllocatorAttributes allocator_attributes = AllocatorAttributes();

--- a/tensorflow/core/common_runtime/gpu/gpu_device_test.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device_test.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include "tensorflow/core/common_runtime/gpu/gpu_device.h"
 
 #include "tensorflow/core/common_runtime/device/device_id_utils.h"
+#include "tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.h"
 #include "tensorflow/core/common_runtime/gpu/gpu_init.h"
 #include "tensorflow/core/common_runtime/gpu/gpu_process_state.h"
 #include "tensorflow/core/lib/core/errors.h"
@@ -121,6 +122,7 @@ TEST_F(GPUDeviceTest, CudaMallocAsync) {
                                            /*use_cuda_malloc_async=*/true);
   std::vector<std::unique_ptr<Device>> devices;
   Status status;
+  int nb_instantiated = GpuCudaMallocAsyncAllocator::NbInstantiated();
   { // The new scope is to trigger the destruction of the object.
     status = DeviceFactory::GetFactory("GPU")->CreateDevices(
         opts, kDeviceNamePrefix, &devices);
@@ -138,6 +140,7 @@ TEST_F(GPUDeviceTest, CudaMallocAsync) {
     EXPECT_NE(ptr, nullptr);
     allocator->DeallocateRaw(ptr);
   }
+  EXPECT_EQ(nb_instantiated + 1 , GpuCudaMallocAsyncAllocator::NbInstantiated());
   EXPECT_EQ(status.code(), error::OK);
 }
 

--- a/tensorflow/core/common_runtime/gpu/gpu_device_test.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device_test.cc
@@ -71,7 +71,8 @@ class GPUDeviceTest : public ::testing::Test {
       const string& visible_device_list = "",
       double per_process_gpu_memory_fraction = 0, int gpu_device_count = 1,
       const std::vector<std::vector<float>>& memory_limit_mb = {},
-      const std::vector<std::vector<int32>>& priority = {}) {
+      const std::vector<std::vector<int32>>& priority = {},
+      const bool use_cuda_malloc_async = false) {
     SessionOptions options;
     ConfigProto* config = &options.config;
     (*config->mutable_device_count())["GPU"] = gpu_device_count;
@@ -79,6 +80,7 @@ class GPUDeviceTest : public ::testing::Test {
     gpu_options->set_visible_device_list(visible_device_list);
     gpu_options->set_per_process_gpu_memory_fraction(
         per_process_gpu_memory_fraction);
+    gpu_options->set_use_cuda_malloc_async(use_cuda_malloc_async);
     for (int i = 0; i < memory_limit_mb.size(); ++i) {
       auto virtual_devices =
           gpu_options->mutable_experimental()->add_virtual_devices();
@@ -113,6 +115,31 @@ class GPUDeviceTest : public ::testing::Test {
         gpu_tensor, /*tensor_name=*/"", device, cpu_tensor));
   }
 };
+
+TEST_F(GPUDeviceTest, CudaMallocAsync) {
+  SessionOptions opts = MakeSessionOptions("0", 0, 1, {}, {},
+                                           /*use_cuda_malloc_async=*/true);
+  std::vector<std::unique_ptr<Device>> devices;
+  Status status;
+  { // The new scope is to trigger the destruction of the object.
+    status = DeviceFactory::GetFactory("GPU")->CreateDevices(
+        opts, kDeviceNamePrefix, &devices);
+    EXPECT_EQ(devices.size(), 1);
+    Device* device = devices[0].get();
+    auto* device_info = device->tensorflow_gpu_device_info();
+    CHECK(device_info);
+    DeviceContext* device_context = device_info->default_context;
+
+    AllocatorAttributes allocator_attributes = AllocatorAttributes();
+    allocator_attributes.set_gpu_compatible(true);
+    Allocator* allocator = devices[0]->GetAllocator(allocator_attributes);
+    void* ptr = allocator->AllocateRaw(Allocator::kAllocatorAlignment,
+                                       1024);
+    EXPECT_NE(ptr, nullptr);
+    allocator->DeallocateRaw(ptr);
+  }
+  EXPECT_EQ(status.code(), error::OK);
+}
 
 TEST_F(GPUDeviceTest, FailedToParseVisibleDeviceList) {
   SessionOptions opts = MakeSessionOptions("0,abc");

--- a/tensorflow/core/common_runtime/gpu/gpu_device_test.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device_test.cc
@@ -122,7 +122,7 @@ TEST_F(GPUDeviceTest, CudaMallocAsync) {
                                            /*use_cuda_malloc_async=*/true);
   std::vector<std::unique_ptr<Device>> devices;
   Status status;
-  int nb_instantiated = GpuCudaMallocAsyncAllocator::NbInstantiated();
+  int number_instantiated = GpuCudaMallocAsyncAllocator::GetInstantiatedCountTestOnly();
   { // The new scope is to trigger the destruction of the object.
     status = DeviceFactory::GetFactory("GPU")->CreateDevices(
         opts, kDeviceNamePrefix, &devices);
@@ -140,7 +140,7 @@ TEST_F(GPUDeviceTest, CudaMallocAsync) {
     EXPECT_NE(ptr, nullptr);
     allocator->DeallocateRaw(ptr);
   }
-  EXPECT_EQ(nb_instantiated + 1 , GpuCudaMallocAsyncAllocator::NbInstantiated());
+  EXPECT_EQ(number_instantiated + 1 , GpuCudaMallocAsyncAllocator::GetInstantiatedCountTestOnly());
   EXPECT_EQ(status.code(), error::OK);
 }
 

--- a/tensorflow/core/common_runtime/gpu/gpu_process_state.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_process_state.cc
@@ -206,10 +206,6 @@ Allocator* GPUProcessState::GetGPUAllocator(
       // If true, passes all allocation requests through to cudaMalloc
       // useful for doing memory debugging with tools like cuda-memcheck
       // **WARNING** probably will not work in a multi-gpu scenario
-      delete gpu_bfc_allocator;
-      delete sub_allocator;
-      gpu_bfc_allocator = nullptr;
-      sub_allocator = nullptr;
       gpu_allocator = new GPUcudaMallocAllocator(platform_device_id);
     } else if (UseCudaMallocAsyncAllocator() ||
                options.experimental().use_cuda_malloc_async()) {
@@ -219,10 +215,6 @@ Allocator* GPUProcessState::GetGPUAllocator(
       // TODO: useful for doing memory debugging with tools like
       // compute-sanitizer.
       // TODO: **WARNING** probably will not work in a multi-gpu scenario
-      delete gpu_bfc_allocator;
-      delete sub_allocator;
-      gpu_bfc_allocator = nullptr;
-      sub_allocator = nullptr;
       gpu_allocator =
           new GpuCudaMallocAsyncAllocator(platform_device_id, total_bytes);
     }

--- a/tensorflow/core/common_runtime/gpu/gpu_process_state.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_process_state.cc
@@ -211,7 +211,8 @@ Allocator* GPUProcessState::GetGPUAllocator(
       gpu_bfc_allocator = nullptr;
       sub_allocator = nullptr;
       gpu_allocator = new GPUcudaMallocAllocator(platform_device_id);
-    } else if (UseCudaMallocAsyncAllocator()) {
+    } else if (UseCudaMallocAsyncAllocator() ||
+               options.experimental().use_cuda_malloc_async()) {
       LOG(INFO) << "Using CUDA malloc Async allocator for GPU: "
                 << platform_device_id;
       // If true, passes all allocation requests through to cudaMallocAsync

--- a/tensorflow/core/protobuf/config.proto
+++ b/tensorflow/core/protobuf/config.proto
@@ -208,15 +208,15 @@ message GPUOptions {
     // size exceeds the requested memory by 5% of the total virtual device/gpu
     // memory size.
     double internal_fragmentation_fraction = 10;
+
+    // When true, use CUDA cudaMallocAsync API instead of TF gpu allocator.
+    bool use_cuda_malloc_async = 11;
   }
 
   // Everything inside experimental is subject to change and is not subject
   // to API stability guarantees in
   // https://www.tensorflow.org/guide/version_compat.
   Experimental experimental = 9;
-
-  // When true, use CUDA cudaMallocAsync API instead of TF gpu allocator.
-  bool use_cuda_malloc_async = 10;
 }
 
 // Options passed to the graph optimizer

--- a/tensorflow/core/protobuf/config.proto
+++ b/tensorflow/core/protobuf/config.proto
@@ -214,6 +214,9 @@ message GPUOptions {
   // to API stability guarantees in
   // https://www.tensorflow.org/guide/version_compat.
   Experimental experimental = 9;
+
+  // When true, use CUDA cudaMallocAsync API instead of TF gpu allocator.
+  bool use_cuda_malloc_async = 10;
 }
 
 // Options passed to the graph optimizer

--- a/tensorflow/tools/api/golden/v1/tensorflow.-g-p-u-options.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.-g-p-u-options.pbtxt
@@ -114,6 +114,12 @@ tf_proto {
         label: LABEL_OPTIONAL
         type: TYPE_DOUBLE
       }
+      field {
+        name: "use_cuda_malloc_async"
+        number: 11
+        label: LABEL_OPTIONAL
+        type: TYPE_BOOL
+      }
       nested_type {
         name: "VirtualDevices"
         field {


### PR DESCRIPTION
The first commit fixes #48869. The second commit fixes another follow up crashes when using TF_GPU_ALLOCATOR=cuda_malloc_async.

The 2 fixes are:
- The Allocator API have the statistics optional. But the function [BaseGPUDeviceFactory::CreateGPUDevice()](https://github.com/tensorflow/tensorflow/blob/aa08697dcb98135ee39ba00ee08b5c1a28cfde61/tensorflow/core/common_runtime/gpu/gpu_device.cc#L1403) check that they are available.
- Bad handling of the ptr to the compute stream. It is a ptr to the compute stream that is passed, not the compute stream itself.
@sanjoy @chsigg