### PR TITLE
Add missing "metrics_*.py" modules to tflite_runtime bazel build script

### DIFF
--- a/tensorflow/lite/tools/pip_package/build_pip_package_with_bazel.sh
+++ b/tensorflow/lite/tools/pip_package/build_pip_package_with_bazel.sh
@@ -48,6 +48,8 @@ cp -r "${TENSORFLOW_LITE_DIR}/tools/pip_package/debian" \
       "${TENSORFLOW_LITE_DIR}/python/interpreter_wrapper" \
       "${BUILD_DIR}"
 cp "${TENSORFLOW_LITE_DIR}/python/interpreter.py" \
+   "${TENSORFLOW_LITE_DIR}/python/metrics_interface.py" \
+   "${TENSORFLOW_LITE_DIR}/python/metrics_portable.py" \
    "${BUILD_DIR}/tflite_runtime"
 echo "__version__ = '${PACKAGE_VERSION}'" >> "${BUILD_DIR}/tflite_runtime/__init__.py"
 echo "__git_version__ = '$(git -C "${TENSORFLOW_DIR}" describe)'" >> "${BUILD_DIR}/tflite_runtime/__init__.py"
@@ -158,4 +160,3 @@ case "${TENSORFLOW_TARGET}" in
 esac
 
 cat "${BUILD_DIR}/debian/changelog"
-


### PR DESCRIPTION
Fix for #49198 

## Steps to reproduce 
* https://github.com/avroshk/build-tflite-runtime 

## Test fix 
* https://github.com/avroshk/build-tflite-runtime/tree/fix 