### PR TITLE
[MLIR][DISC] porting dynamic shape related OPs to mhlo and lmhlo dialect

### DIFF
--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/hlo_ops.td
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/hlo_ops.td
@@ -2162,4 +2162,99 @@ def HLO_ReducePrecisionOp :
   let results = (outs HLO_FpTensor:$output);
 }
 
+def HLO_H2DOp: HLO_Op<"h2d", [NoSideEffect, SameOperandsAndResultType]> {
+  let arguments = (ins HLO_Tensor);
+  let results = (outs HLO_Tensor);
+  let hasCustomHLOConverter = 1;
+}
+
+def HLO_D2HOp: HLO_Op<"d2h", [NoSideEffect, SameOperandsAndResultType]> {
+  let arguments = (ins HLO_Tensor);
+  let results = (outs HLO_Tensor);
+  let hasCustomHLOConverter = 1;
+}
+
+def HLO_RealDynamicSliceOp: HLO_Op<
+      "dynamic_slice",
+      [NoSideEffect, AllElementTypesMatch<["operand", "result"]>,
+       AllTypesMatch<["start_indices", "limit_indices", "strides"]>]> {
+  let arguments = (ins
+    HLO_Tensor:$operand,
+    HLO_Tensor:$start_indices,
+    HLO_Tensor:$limit_indices,
+    HLO_Tensor:$strides
+  );
+  let results = (outs HLO_Tensor:$result);
+  let extraClassDeclaration = [{
+    // Infers output type for given operand and attributes. Result type is
+    // unranked if any of the attributes is illegal.
+    static Type InferOutputTypes(Builder *builder, Value operand,
+                                 Value *start_indices,
+                                 Value *limit_indices,
+                                 Value *strides);
+  }];
+  let hasCustomHLOConverter = 1;
+  let hasCanonicalizer = 0;
+  let hasFolder = 0;
+}
+
+def HLO_DynamicPadOp: HLO_Op<"dynamic_pad",
+      [NoSideEffect, AllElementTypesMatch<["operand", "padding_value", "result"]>,
+      AllTypesMatch<["edge_padding_low", "edge_padding_high", "interior_padding"]>]> {
+  let arguments = (ins
+    HLO_Tensor:$operand,
+    HLO_Tensor:$padding_value,
+    HLO_Tensor:$edge_padding_low,
+    HLO_Tensor:$edge_padding_high,
+    HLO_Tensor:$interior_padding
+  );
+  let results = (outs HLO_Tensor:$result);
+  let description = [{
+    Dynamically Pads the `operand` according to TBD, with amount of padding added at
+    low-end/high-end/interior is passed through input tensors.
+  }];
+  let hasCanonicalizer = 1;
+  let hasCustomHLOConverter = 1;
+}
+
+def HLO_DynamicGatherOp: HLO_Op<"dynamic_gather", [NoSideEffect]> {
+  let arguments = (ins
+    HLO_Tensor:$operand,
+    HLO_IntTensor:$start_indices,
+    HLO_IntTensor:$slice_sizes,
+    GatherDimensionNumbers:$dimension_numbers,
+    DefaultValuedAttr<BoolAttr, "false">:$indices_are_sorted
+  );
+  let results = (outs HLO_Tensor);
+  
+  let hasCustomHLOConverter = 1;
+}
+
+def HLO_DynamicConvOp : HLO_Op<"dynamic_conv", [NoSideEffect]>, BASE_HLO_ConvOp {
+  let arguments = !con(
+    (ins
+       HLO_Tensor:$lhs,
+       HLO_Tensor:$rhs,
+       HLO_Tensor:$d_padding),
+    ConvolutionAttributes.attributes);
+  let results = (outs HLO_Tensor);
+  let hasCustomHLOConverter = 1;
+}
+
+// For test
+def HLO_DebugPrintOp : HLO_Op<"debug_print", [NoSideEffect]> {
+  let summary = "call_external_func operation";
+  let description = [{
+    call external function
+  }];
+
+  // The operation takes an input tensor to print.
+  let arguments = (ins
+      AnyTypeOf<[HLO_Tensor]>:$operand
+  );
+
+  let hasCustomHLOConverter = 1;
+
+}
+
 #endif // HLO_OPS

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/hlo_ops.td
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/hlo_ops.td
@@ -2162,28 +2162,8 @@ def HLO_ReducePrecisionOp :
   let results = (outs HLO_FpTensor:$output);
 }
 
-def HLO_H2DOp: HLO_Op<"h2d", [NoSideEffect, SameOperandsAndResultType]> {
-  let summary = "H2D operator";
-  let description = [{
-    Copy `operand` from host to device.
-  }];
-  let arguments = (ins HLO_Tensor);
-  let results = (outs HLO_Tensor);
-  let hasCustomHLOConverter = 1;
-}
-
-def HLO_D2HOp: HLO_Op<"d2h", [NoSideEffect, SameOperandsAndResultType]> {
-  let summary = "D2H operator";
-  let description = [{
-    Copy `operand` from device to host.
-  }];
-  let arguments = (ins HLO_Tensor);
-  let results = (outs HLO_Tensor);
-  let hasCustomHLOConverter = 1;
-}
-
 def HLO_RealDynamicSliceOp: HLO_Op<
-      "dynamic_slice",
+      "real_dynamic_slice",
       [NoSideEffect, AllElementTypesMatch<["operand", "result"]>,
        AllTypesMatch<["start_indices", "limit_indices", "strides"]>]> {
   let summary = "Real Dynamic Slice operator";
@@ -2195,9 +2175,9 @@ def HLO_RealDynamicSliceOp: HLO_Op<
   }];
   let arguments = (ins
     HLO_Tensor:$operand,
-    HLO_Tensor:$start_indices,
-    HLO_Tensor:$limit_indices,
-    HLO_Tensor:$strides
+    HLO_DimensionTensor:$start_indices,
+    HLO_DimensionTensor:$limit_indices,
+    HLO_DimensionTensor:$strides
   );
   let results = (outs HLO_Tensor:$result);
   let hasCustomHLOConverter = 1;
@@ -2218,9 +2198,9 @@ def HLO_DynamicPadOp: HLO_Op<"dynamic_pad",
   let arguments = (ins
     HLO_Tensor:$operand,
     HLO_Tensor:$padding_value,
-    HLO_Tensor:$edge_padding_low,
-    HLO_Tensor:$edge_padding_high,
-    HLO_Tensor:$interior_padding
+    HLO_DimensionTensor:$edge_padding_low,
+    HLO_DimensionTensor:$edge_padding_high,
+    HLO_DimensionTensor:$interior_padding
   );
   let results = (outs HLO_Tensor:$result);
   let description = [{
@@ -2264,22 +2244,6 @@ def HLO_DynamicConvOp : HLO_Op<"dynamic_conv", [NoSideEffect]>, BASE_HLO_ConvOp 
     ConvolutionAttributes.attributes);
   let results = (outs HLO_Tensor);
   let hasCustomHLOConverter = 1;
-}
-
-// For test use
-def HLO_DebugPrintOp : HLO_Op<"debug_print", [NoSideEffect]> {
-  let summary = "debug print operation";
-  let description = [{
-    This operation is used to debug tensor.
-  }];
-
-  // The operation takes an input tensor to print.
-  let arguments = (ins
-      AnyTypeOf<[HLO_Tensor]>:$operand
-  );
-
-  let hasCustomHLOConverter = 1;
-
 }
 
 #endif // HLO_OPS

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/hlo_ops.td
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/hlo_ops.td
@@ -2163,12 +2163,20 @@ def HLO_ReducePrecisionOp :
 }
 
 def HLO_H2DOp: HLO_Op<"h2d", [NoSideEffect, SameOperandsAndResultType]> {
+  let summary = "H2D operator";
+  let description = [{
+    Copy `operand` from host to device.
+  }];
   let arguments = (ins HLO_Tensor);
   let results = (outs HLO_Tensor);
   let hasCustomHLOConverter = 1;
 }
 
 def HLO_D2HOp: HLO_Op<"d2h", [NoSideEffect, SameOperandsAndResultType]> {
+  let summary = "D2H operator";
+  let description = [{
+    Copy `operand` from device to host.
+  }];
   let arguments = (ins HLO_Tensor);
   let results = (outs HLO_Tensor);
   let hasCustomHLOConverter = 1;
@@ -2178,6 +2186,13 @@ def HLO_RealDynamicSliceOp: HLO_Op<
       "dynamic_slice",
       [NoSideEffect, AllElementTypesMatch<["operand", "result"]>,
        AllTypesMatch<["start_indices", "limit_indices", "strides"]>]> {
+  let summary = "Real Dynamic Slice operator";
+  let description = [{
+    The dynamic shape version of SliceOp. Extracts a sub-array from the input 
+    array according to start_indices, limit_indices and strides. Expect 
+    start_indices/limit_indices/strides to be statically shaped and matching 
+    the rank of the input.
+  }];
   let arguments = (ins
     HLO_Tensor:$operand,
     HLO_Tensor:$start_indices,
@@ -2185,22 +2200,21 @@ def HLO_RealDynamicSliceOp: HLO_Op<
     HLO_Tensor:$strides
   );
   let results = (outs HLO_Tensor:$result);
-  let extraClassDeclaration = [{
-    // Infers output type for given operand and attributes. Result type is
-    // unranked if any of the attributes is illegal.
-    static Type InferOutputTypes(Builder *builder, Value operand,
-                                 Value *start_indices,
-                                 Value *limit_indices,
-                                 Value *strides);
-  }];
   let hasCustomHLOConverter = 1;
-  let hasCanonicalizer = 0;
-  let hasFolder = 0;
 }
 
 def HLO_DynamicPadOp: HLO_Op<"dynamic_pad",
       [NoSideEffect, AllElementTypesMatch<["operand", "padding_value", "result"]>,
       AllTypesMatch<["edge_padding_low", "edge_padding_high", "interior_padding"]>]> {
+  let summary = "Dynamic Pad operator";
+  let description = [{
+    The dynamic shape version of PadOp. Pads the edges of `operand` with the 
+    `padding_value` and according to the passed configuration. Expect 
+    edge_padding_low/edge_padding_high/interior_padding to be statically shaped 
+    and matching the rank of the input. 
+    See 
+    https://www.tensorflow.org/xla/operation_semantics#pad
+  }];
   let arguments = (ins
     HLO_Tensor:$operand,
     HLO_Tensor:$padding_value,
@@ -2210,7 +2224,7 @@ def HLO_DynamicPadOp: HLO_Op<"dynamic_pad",
   );
   let results = (outs HLO_Tensor:$result);
   let description = [{
-    Dynamically Pads the `operand` according to TBD, with amount of padding added at
+    Dynamically Pads the `operand`, with amount of padding added at
     low-end/high-end/interior is passed through input tensors.
   }];
   let hasCanonicalizer = 1;
@@ -2218,6 +2232,12 @@ def HLO_DynamicPadOp: HLO_Op<"dynamic_pad",
 }
 
 def HLO_DynamicGatherOp: HLO_Op<"dynamic_gather", [NoSideEffect]> {
+  string summary = "Dynamic Gather operator";
+  string description = [{
+    The dynamic shape version of GatherOp. Stitches together several slices of an input 
+    array. slice_sizes is a compile-time variable.
+  }];
+  
   let arguments = (ins
     HLO_Tensor:$operand,
     HLO_IntTensor:$start_indices,
@@ -2231,6 +2251,11 @@ def HLO_DynamicGatherOp: HLO_Op<"dynamic_gather", [NoSideEffect]> {
 }
 
 def HLO_DynamicConvOp : HLO_Op<"dynamic_conv", [NoSideEffect]>, BASE_HLO_ConvOp {
+  let summary = "Dynamic Convolution operator";
+  let description = [{
+    The dynamic shape version of ConvOp. Computes a convolution with dynamic padding.
+  }];
+
   let arguments = !con(
     (ins
        HLO_Tensor:$lhs,
@@ -2241,11 +2266,11 @@ def HLO_DynamicConvOp : HLO_Op<"dynamic_conv", [NoSideEffect]>, BASE_HLO_ConvOp 
   let hasCustomHLOConverter = 1;
 }
 
-// For test
+// For test use
 def HLO_DebugPrintOp : HLO_Op<"debug_print", [NoSideEffect]> {
-  let summary = "call_external_func operation";
+  let summary = "debug print operation";
   let description = [{
-    call external function
+    This operation is used to debug tensor.
   }];
 
   // The operation takes an input tensor to print.

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/lhlo_ops.td
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/lhlo_ops.td
@@ -1386,4 +1386,116 @@ def TerminatorOp :
     [{ build($_builder, $_state, llvm::None, operands, llvm::None); }]>];
 }
 
+
+def LHLO_D2HOp: LHLO_Op<"d2h", []> {
+  let arguments = (ins
+    Arg<LHLO_Buffer, "", [MemRead]>:$operand,
+    Arg<LHLO_Buffer, "", [MemWrite]>:$output
+  );
+}
+
+def LHLO_H2DOp: LHLO_Op<"h2d", []> {
+  let arguments = (ins
+    Arg<LHLO_Buffer, "", [MemRead]>:$operand,
+    Arg<LHLO_Buffer, "", [MemWrite]>:$output
+  );
+}
+
+def LHLO_DebugPrintOp:  LHLO_Op<"debug_print", [NoSideEffect]> {
+  let arguments = (ins
+    Arg<LHLO_Buffer, "", [MemRead]>:$input
+  );
+}
+
+def LHLO_RealDynamicSliceOp: LHLO_Op<
+      "dynamic_slice",
+      [AllTypesMatch<["start_indices", "limit_indices", "strides"]>]> {
+  let arguments = (ins
+    Arg<LHLO_Buffer, "", [MemRead]>:$operand,
+    Arg<LHLO_Buffer, "", [MemRead]>:$start_indices,
+    Arg<LHLO_Buffer, "", [MemRead]>:$limit_indices,
+    Arg<LHLO_Buffer, "", [MemRead]>:$strides,
+    Arg<LHLO_Buffer, "", [MemWrite]>:$output
+  );
+}
+
+def LHLO_DynamicBroadcastInDimOp : LHLO_Op<"dynamic_broadcast_in_dim",
+      []> {
+  let arguments = (ins
+    Arg<LHLO_Buffer, "", [MemRead]>:$operand,
+    Arg<LHLO_Buffer, "", [MemRead]>:$out_dim_size,
+    Arg<LHLO_Buffer, "", [MemWrite]>:$output,
+    BroadcastDimAttr:$broadcast_dimensions
+  );
+}
+
+def LHLO_DotGeneralOp: LHLO_Op<"dot_general", []> {
+  let arguments = (ins
+    Arg<LHLO_Buffer, "", [MemRead]>:$lhs,
+    Arg<LHLO_Buffer, "", [MemRead]>:$rhs,
+    DotDimensionNumbers:$dot_dimension_numbers,
+    HLO_PrecisionConfigAttr:$precision_config,
+    Arg<LHLO_Buffer, "", [MemWrite]>:$output
+  );
+}
+
+def LHLO_DynamicGatherOp: LHLO_Op<"dynamic_gather", []> {
+  let arguments = (ins
+    Arg<LHLO_Buffer, "", [MemRead]>:$operand,
+    Arg<LHLO_Buffer, "", [MemRead]>:$start_indices,
+    Arg<LHLO_Buffer, "", [MemRead]>:$slice_sizes,
+    GatherDimensionNumbers:$dimension_numbers,
+    Arg<LHLO_Buffer, "", [MemWrite]>:$output
+  );
+}
+
+def LHLO_DynamicPadOp: LHLO_Op<"dynamic_pad", []> {
+  let arguments = (ins
+    Arg<LHLO_Buffer, "", [MemRead]>:$operand,
+    Arg<LHLO_Buffer, "", [MemRead]>:$padding_value,
+    Arg<LHLO_Buffer, "", [MemRead]>:$edge_padding_low,
+    Arg<LHLO_Buffer, "", [MemRead]>:$edge_padding_high,
+    Arg<LHLO_Buffer, "", [MemRead]>:$interior_padding,
+    Arg<LHLO_Buffer, "", [MemWrite]>:$output
+  );
+}
+
+def LHLO_BitcastOp: LHLO_Op<"bitcast", []> {
+  let arguments = (ins
+    Arg<LHLO_Buffer, "", [MemRead]>:$operand,
+    Arg<LHLO_Buffer, "", [MemWrite]>:$output
+  );
+}
+
+def LHLO_DynamicBitcastOp: LHLO_Op<"dynamic_bitcast", []> {
+  let arguments = (ins
+    Arg<LHLO_Buffer, "", [MemRead]>:$operand,
+    Arg<LHLO_IntBuffer, "", [MemRead]>:$shape,
+    Arg<LHLO_Buffer, "", [MemWrite]>:$output
+  );
+}
+
+def LHLO_DynamicIotaOp : LHLO_Op<"dynamic_iota", []> {
+  let arguments = (ins Arg<LHLO_IntBuffer, "", [MemRead]>:$shape,
+                   I64Attr:$iota_dimension,
+                   Arg<LHLO_Buffer, "", [MemWrite]>:$output);
+}
+
+def LHLO_DynamicConvOp : LHLO_Op<"dynamic_conv", []> {
+  let arguments = !con(
+    (ins Arg<LHLO_Buffer, "", [MemRead]>:$lhs,
+    Arg<LHLO_Buffer, "", [MemRead]>:$rhs,
+    Arg<LHLO_Buffer, "", [MemRead]>:$d_padding,
+    Arg<LHLO_Buffer, "", [MemWrite]>:$output),
+    ConvolutionAttributes.attributes);
+}
+
+def LHLO_DynamicReshapeOp: LHLO_Op<"dynamic_reshape", []> {
+  let arguments = (ins
+    Arg<LHLO_Buffer, "", [MemRead]>:$operand,
+    Arg<LHLO_IntBuffer, "", [MemRead]>:$shape,
+    Arg<LHLO_Buffer, "", [MemWrite]>:$output
+  );
+}
+
 #endif // LHLO_OPS

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/lhlo_ops.td
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/lhlo_ops.td
@@ -1386,43 +1386,8 @@ def TerminatorOp :
     [{ build($_builder, $_state, llvm::None, operands, llvm::None); }]>];
 }
 
-
-def LHLO_D2HOp: LHLO_Op<"d2h", []> {
-  let summary = "LHLO D2H operator";
-  let description = [{
-    Copy operand to output. operand is in device memory. output is in 
-    host memory
-  }];
-  let arguments = (ins
-    Arg<LHLO_Buffer, "", [MemRead]>:$operand,
-    Arg<LHLO_Buffer, "", [MemWrite]>:$output
-  );
-}
-
-def LHLO_H2DOp: LHLO_Op<"h2d", []> {
-  let summary = "LHLO H2D operator";
-  let description = [{
-    Copy operand to output. operand is in host memory. output is in 
-    device memory
-  }];
-  let arguments = (ins
-    Arg<LHLO_Buffer, "", [MemRead]>:$operand,
-    Arg<LHLO_Buffer, "", [MemWrite]>:$output
-  );
-}
-
-def LHLO_DebugPrintOp:  LHLO_Op<"debug_print", [NoSideEffect]> {
-  let summary = "LHLO debug print operation";
-  let description = [{
-    This LHLO operation is used to debug tensor.
-  }];
-  let arguments = (ins
-    Arg<LHLO_Buffer, "", [MemRead]>:$input
-  );
-}
-
 def LHLO_RealDynamicSliceOp: LHLO_Op<
-      "dynamic_slice",
+      "real_dynamic_slice",
       [AllTypesMatch<["start_indices", "limit_indices", "strides"]>]> {
   let summary = "LHLO Real Dynamic Slice operator";
   let description = [{
@@ -1431,9 +1396,9 @@ def LHLO_RealDynamicSliceOp: LHLO_Op<
   }];
   let arguments = (ins
     Arg<LHLO_Buffer, "", [MemRead]>:$operand,
-    Arg<LHLO_Buffer, "", [MemRead]>:$start_indices,
-    Arg<LHLO_Buffer, "", [MemRead]>:$limit_indices,
-    Arg<LHLO_Buffer, "", [MemRead]>:$strides,
+    Arg<LHLO_DimensionBuffer, "", [MemRead]>:$start_indices,
+    Arg<LHLO_DimensionBuffer, "", [MemRead]>:$limit_indices,
+    Arg<LHLO_DimensionBuffer, "", [MemRead]>:$strides,
     Arg<LHLO_Buffer, "", [MemWrite]>:$output
   );
 }
@@ -1450,7 +1415,7 @@ def LHLO_DynamicBroadcastInDimOp : LHLO_Op<"dynamic_broadcast_in_dim",
   }];
   let arguments = (ins
     Arg<LHLO_Buffer, "", [MemRead]>:$operand,
-    Arg<LHLO_Buffer, "", [MemRead]>:$out_dim_size,
+    Arg<LHLO_DimensionBuffer, "", [MemRead]>:$output_dimensions,
     Arg<LHLO_Buffer, "", [MemWrite]>:$output,
     BroadcastDimAttr:$broadcast_dimensions
   );
@@ -1481,14 +1446,16 @@ def LHLO_DynamicGatherOp: LHLO_Op<"dynamic_gather", []> {
   }];
   let arguments = (ins
     Arg<LHLO_Buffer, "", [MemRead]>:$operand,
-    Arg<LHLO_Buffer, "", [MemRead]>:$start_indices,
-    Arg<LHLO_Buffer, "", [MemRead]>:$slice_sizes,
+    Arg<LHLO_IntBuffer, "", [MemRead]>:$start_indices,
+    Arg<LHLO_IntBuffer, "", [MemRead]>:$slice_sizes,
     GatherDimensionNumbers:$dimension_numbers,
     Arg<LHLO_Buffer, "", [MemWrite]>:$output
   );
 }
 
-def LHLO_DynamicPadOp: LHLO_Op<"dynamic_pad", []> {
+def LHLO_DynamicPadOp: LHLO_Op<
+      "dynamic_pad", 
+      [AllTypesMatch<["edge_padding_low", "edge_padding_high", "interior_padding"]>]> {
   let summary = "LHLO Dynamic Pad operator";
   let description = [{
     The dynamic shape version of PadOp. Pads the edges of `operand` with the `padding_value` and according to
@@ -1499,9 +1466,9 @@ def LHLO_DynamicPadOp: LHLO_Op<"dynamic_pad", []> {
   let arguments = (ins
     Arg<LHLO_Buffer, "", [MemRead]>:$operand,
     Arg<LHLO_Buffer, "", [MemRead]>:$padding_value,
-    Arg<LHLO_Buffer, "", [MemRead]>:$edge_padding_low,
-    Arg<LHLO_Buffer, "", [MemRead]>:$edge_padding_high,
-    Arg<LHLO_Buffer, "", [MemRead]>:$interior_padding,
+    Arg<LHLO_DimensionBuffer, "", [MemRead]>:$edge_padding_low,
+    Arg<LHLO_DimensionBuffer, "", [MemRead]>:$edge_padding_high,
+    Arg<LHLO_DimensionBuffer, "", [MemRead]>:$interior_padding,
     Arg<LHLO_Buffer, "", [MemWrite]>:$output
   );
 }

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/lhlo_ops.td
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/lhlo_ops.td
@@ -1388,6 +1388,11 @@ def TerminatorOp :
 
 
 def LHLO_D2HOp: LHLO_Op<"d2h", []> {
+  let summary = "LHLO D2H operator";
+  let description = [{
+    Copy operand to output. operand is in device memory. output is in 
+    host memory
+  }];
   let arguments = (ins
     Arg<LHLO_Buffer, "", [MemRead]>:$operand,
     Arg<LHLO_Buffer, "", [MemWrite]>:$output
@@ -1395,6 +1400,11 @@ def LHLO_D2HOp: LHLO_Op<"d2h", []> {
 }
 
 def LHLO_H2DOp: LHLO_Op<"h2d", []> {
+  let summary = "LHLO H2D operator";
+  let description = [{
+    Copy operand to output. operand is in host memory. output is in 
+    device memory
+  }];
   let arguments = (ins
     Arg<LHLO_Buffer, "", [MemRead]>:$operand,
     Arg<LHLO_Buffer, "", [MemWrite]>:$output
@@ -1402,6 +1412,10 @@ def LHLO_H2DOp: LHLO_Op<"h2d", []> {
 }
 
 def LHLO_DebugPrintOp:  LHLO_Op<"debug_print", [NoSideEffect]> {
+  let summary = "LHLO debug print operation";
+  let description = [{
+    This LHLO operation is used to debug tensor.
+  }];
   let arguments = (ins
     Arg<LHLO_Buffer, "", [MemRead]>:$input
   );
@@ -1410,6 +1424,11 @@ def LHLO_DebugPrintOp:  LHLO_Op<"debug_print", [NoSideEffect]> {
 def LHLO_RealDynamicSliceOp: LHLO_Op<
       "dynamic_slice",
       [AllTypesMatch<["start_indices", "limit_indices", "strides"]>]> {
+  let summary = "LHLO Real Dynamic Slice operator";
+  let description = [{
+    The dynamic shape version of DynamicSliceOp. Extracts a sub-array from the 
+    input array according to dynamic start_indices, limit_indices and strides.
+  }];
   let arguments = (ins
     Arg<LHLO_Buffer, "", [MemRead]>:$operand,
     Arg<LHLO_Buffer, "", [MemRead]>:$start_indices,
@@ -1421,6 +1440,14 @@ def LHLO_RealDynamicSliceOp: LHLO_Op<
 
 def LHLO_DynamicBroadcastInDimOp : LHLO_Op<"dynamic_broadcast_in_dim",
       []> {
+  let summary = "Broadcast a tensor into the given dynamic shape by adding dimensions.";
+  let description = [{
+    The dynamic shape version of BroadcastInDimOp. This is a generalization of the 
+    BroadcastInDimOp which accepts its output dimensions as an argument. It should 
+    eventually supercede the statically shaped original, but is being phased as a 
+    separate op in order to support compatibility with lowerings and translations that 
+    precede dynamic shapes.
+  }];
   let arguments = (ins
     Arg<LHLO_Buffer, "", [MemRead]>:$operand,
     Arg<LHLO_Buffer, "", [MemRead]>:$out_dim_size,
@@ -1430,6 +1457,13 @@ def LHLO_DynamicBroadcastInDimOp : LHLO_Op<"dynamic_broadcast_in_dim",
 }
 
 def LHLO_DotGeneralOp: LHLO_Op<"dot_general", []> {
+  let summary = "LHLO General Dot operator";
+  let description = [{
+    Performs general dot products between vectors, vector/matrix and
+    matrix/matrix multiplication.
+
+    See https://www.tensorflow.org/xla/operation_semantics#dotgeneral.
+  }];
   let arguments = (ins
     Arg<LHLO_Buffer, "", [MemRead]>:$lhs,
     Arg<LHLO_Buffer, "", [MemRead]>:$rhs,
@@ -1440,6 +1474,11 @@ def LHLO_DotGeneralOp: LHLO_Op<"dot_general", []> {
 }
 
 def LHLO_DynamicGatherOp: LHLO_Op<"dynamic_gather", []> {
+  string summary = "LHLO Dynamic Gather operator";
+  string description = [{
+    The dynamic shape version of GatherOp. Stitches together several slices of an input 
+    array. slice_sizes is not a const.
+  }];
   let arguments = (ins
     Arg<LHLO_Buffer, "", [MemRead]>:$operand,
     Arg<LHLO_Buffer, "", [MemRead]>:$start_indices,
@@ -1450,6 +1489,13 @@ def LHLO_DynamicGatherOp: LHLO_Op<"dynamic_gather", []> {
 }
 
 def LHLO_DynamicPadOp: LHLO_Op<"dynamic_pad", []> {
+  let summary = "LHLO Dynamic Pad operator";
+  let description = [{
+    The dynamic shape version of PadOp. Pads the edges of `operand` with the `padding_value` and according to
+    the passed configuration. Passed configuration are dynamic shape.
+    See
+    https://www.tensorflow.org/xla/operation_semantics#pad
+  }];
   let arguments = (ins
     Arg<LHLO_Buffer, "", [MemRead]>:$operand,
     Arg<LHLO_Buffer, "", [MemRead]>:$padding_value,
@@ -1461,6 +1507,15 @@ def LHLO_DynamicPadOp: LHLO_Op<"dynamic_pad", []> {
 }
 
 def LHLO_BitcastOp: LHLO_Op<"bitcast", []> {
+  let summary = "LHLO Bitcast operator";
+  let description = [{
+    This op changes the shape of the input in the way that the physical
+    arrangement of elements are unchanged.
+
+    However, the op needs layout information to make sense of "physical
+    arrangement of elements". Layout support in MHLO is currently under
+    exploration.
+  }];
   let arguments = (ins
     Arg<LHLO_Buffer, "", [MemRead]>:$operand,
     Arg<LHLO_Buffer, "", [MemWrite]>:$output
@@ -1468,6 +1523,15 @@ def LHLO_BitcastOp: LHLO_Op<"bitcast", []> {
 }
 
 def LHLO_DynamicBitcastOp: LHLO_Op<"dynamic_bitcast", []> {
+  let summary = "LHLO Dynamic Bitcast operator";
+  let description = [{
+    The dynamic shape version of BitcastOp. This op changes the shape of the 
+    input in the way that the physical arrangement of elements are unchanged.
+
+    However, the op needs layout information to make sense of "physical
+    arrangement of elements". Layout support in MHLO is currently under
+    exploration.
+  }];
   let arguments = (ins
     Arg<LHLO_Buffer, "", [MemRead]>:$operand,
     Arg<LHLO_IntBuffer, "", [MemRead]>:$shape,
@@ -1476,6 +1540,13 @@ def LHLO_DynamicBitcastOp: LHLO_Op<"dynamic_bitcast", []> {
 }
 
 def LHLO_DynamicIotaOp : LHLO_Op<"dynamic_iota", []> {
+  let summary = "Create linear increasing values from 0 to length -1.";
+  let description = [{
+    The dynamic shape version of IotaOp. Produces an output of the specified shape, 
+    with an incremental set of values along the specified dimension starting at 0.
+    See
+    https://www.tensorflow.org/xla/operation_semantics#iota
+  }];
   let arguments = (ins Arg<LHLO_IntBuffer, "", [MemRead]>:$shape,
                    I64Attr:$iota_dimension,
                    Arg<LHLO_Buffer, "", [MemWrite]>:$output);
@@ -1491,6 +1562,10 @@ def LHLO_DynamicConvOp : LHLO_Op<"dynamic_conv", []> {
 }
 
 def LHLO_DynamicReshapeOp: LHLO_Op<"dynamic_reshape", []> {
+  let summary = "Reshape a tensor to a given, possibly dynamic, shape.";
+  let description = [{
+    The dynamic shape version of ReshapeOp. Reshapes `operand` to `output`.
+  }];
   let arguments = (ins
     Arg<LHLO_Buffer, "", [MemRead]>:$operand,
     Arg<LHLO_IntBuffer, "", [MemRead]>:$shape,

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/lhlo_ops_base.td
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/lhlo_ops_base.td
@@ -43,4 +43,9 @@ def LHLO_PredOrIntBuffer : MemRefOf<[HLO_Int, HLO_Pred]>;
 
 def LHLO_Buffer : MemRefOf<[AnyFloat, AnyInteger, AnyComplex]>;
 
+def LHLO_DimensionValue : AnyTypeOf<[Index, HLO_Pred, HLO_Int]>;
+
+// Dynamic representation of a shape vector
+def LHLO_DimensionBuffer : MemRefRankOf<[LHLO_DimensionValue], [1]>;
+
 #endif // LHLO_OPS_BASE

--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/IR/hlo_ops.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/IR/hlo_ops.cc
@@ -2254,6 +2254,14 @@ OpFoldResult PadOp::fold(ArrayRef<Attribute> operands) {
 }
 
 //===----------------------------------------------------------------------===//
+// DynamicPadOp
+//===----------------------------------------------------------------------===//
+void DynamicPadOp::getCanonicalizationPatterns(
+    OwningRewritePatternList& results, MLIRContext* context) {
+  results.insert<DPadToPad>(context);
+}
+
+//===----------------------------------------------------------------------===//
 // ReshapeOp
 //===----------------------------------------------------------------------===//
 

--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/IR/hlo_ops.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/IR/hlo_ops.cc
@@ -1554,14 +1554,12 @@ static LogicalResult Verify(DynamicSliceOp op) {
 static LogicalResult Verify(RealDynamicSliceOp op) {
   auto input_type = op.operand().getType().dyn_cast<RankedTensorType>();
   // If operand is unranked, there is very little to verify statically.
-  if (!input_type) {
-    return success();
-  }
+  if (!input_type) return success();
   int input_rank = input_type.getRank();
 
-  auto start_type = op.start_indices().getType().dyn_cast<RankedTensorType>();
-  auto limit_type = op.limit_indices().getType().dyn_cast<RankedTensorType>();
-  auto strides_type = op.strides().getType().dyn_cast<RankedTensorType>();
+  auto start_type = op.start_indices().getType().cast<RankedTensorType>();
+  auto limit_type = op.limit_indices().getType().cast<RankedTensorType>();
+  auto strides_type = op.strides().getType().cast<RankedTensorType>();
 
   if (input_rank != start_type.getNumElements()) {
     return op.emitOpError() << "has mismatched number of operand rank ("
@@ -2302,18 +2300,16 @@ void DynamicPadOp::getCanonicalizationPatterns(
 static LogicalResult Verify(DynamicPadOp op) {
   auto input_type = op.operand().getType().dyn_cast<RankedTensorType>();
   // If operand is unranked, there is very little to verify statically.
-  if (!input_type) {
-    return success();
-  }
+  if (!input_type) return success();
   int input_rank = input_type.getRank();
 
-  auto pad_type = op.padding_value().getType().dyn_cast<RankedTensorType>();
-  if (!pad_type || pad_type.getRank() != 0) {
+  auto pad_type = op.padding_value().getType().cast<RankedTensorType>();
+  if (pad_type.getRank() != 0) {
     return op.emitOpError() << "padding value type should be a rank-0";
   }
 
   auto padding_low_type =
-      op.edge_padding_low().getType().dyn_cast<RankedTensorType>();
+      op.edge_padding_low().getType().cast<RankedTensorType>();
   if (padding_low_type.getNumElements() != input_rank) {
     return op.emitOpError()
            << "edge_padding_low length(" << padding_low_type.getNumElements()
@@ -2321,7 +2317,7 @@ static LogicalResult Verify(DynamicPadOp op) {
   }
 
   auto padding_high_type =
-      op.edge_padding_high().getType().dyn_cast<RankedTensorType>();
+      op.edge_padding_high().getType().cast<RankedTensorType>();
   if (padding_high_type.getNumElements() != input_rank) {
     return op.emitOpError()
            << "edge_padding_high length(" << padding_high_type.getNumElements()
@@ -2329,7 +2325,7 @@ static LogicalResult Verify(DynamicPadOp op) {
   }
 
   auto interior_padding_type =
-      op.interior_padding().getType().dyn_cast<RankedTensorType>();
+      op.interior_padding().getType().cast<RankedTensorType>();
   if (interior_padding_type.getNumElements() != input_rank) {
     return op.emitOpError()
            << "edge_padding_interior length("
@@ -2339,9 +2335,7 @@ static LogicalResult Verify(DynamicPadOp op) {
 
   auto output_type = op.getResult().getType().dyn_cast<RankedTensorType>();
   // If result is unranked, there is very little to verify statically.
-  if (!output_type) {
-    return success();
-  }
+  if (!output_type) return success();
   int output_rank = output_type.getRank();
   if (input_rank != output_rank) {
     return op.emitOpError() << "operand rank(" << input_rank

--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/IR/mhlo_canonicalize.td
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/IR/mhlo_canonicalize.td
@@ -41,3 +41,17 @@ def RemoveRedundantDynamicBroadcast : Pat<
     (HLO_DynamicReshapeOp $operand, $shape),
      $shape, IdentityBroadcastDims:$dims),
   (HLO_DynamicReshapeOp $operand, $shape)>;
+
+
+// Convert DPad to Pad if edge_padding_low, edge_padding_high and
+// interior_paddin are HLO_ConstOp
+def DPadToPad: Pat<
+          (HLO_DynamicPadOp HLO_Tensor:$input,
+            HLO_Tensor:$padding_value,
+            (HLO_ConstOp I64ElementsAttr:$edge_padding_low),
+            (HLO_ConstOp I64ElementsAttr:$edge_padding_high),
+            (HLO_ConstOp I64ElementsAttr:$interior_paddin)),
+          (HLO_PadOp $input, $padding_value,
+            (CastIntElementsAttr $edge_padding_low),
+            (CastIntElementsAttr $edge_padding_high),
+            (CastIntElementsAttr $interior_paddin))>;

--- a/tensorflow/compiler/mlir/xla/mlir_hlo_to_hlo.cc
+++ b/tensorflow/compiler/mlir/xla/mlir_hlo_to_hlo.cc
@@ -1176,6 +1176,34 @@ LogicalResult ExportXlaOp(BitcastOp op, OpLoweringContext ctx) {
   return success();
 }
 
+LogicalResult ExportXlaOp(H2DOp op, OpLoweringContext ctx) {
+  return failure();
+}
+
+LogicalResult ExportXlaOp(D2HOp op, OpLoweringContext ctx) {
+  return failure();
+}
+
+LogicalResult ExportXlaOp(RealDynamicSliceOp op, OpLoweringContext ctx) {
+  return failure();
+}
+
+LogicalResult ExportXlaOp(DynamicPadOp op, OpLoweringContext ctx) {
+  return failure();
+}
+
+LogicalResult ExportXlaOp(DynamicGatherOp op, OpLoweringContext ctx) {
+  return failure();
+}
+
+LogicalResult ExportXlaOp(DynamicConvOp op, OpLoweringContext ctx) {
+  return failure();
+}
+
+LogicalResult ExportXlaOp(DebugPrintOp op, OpLoweringContext ctx) {
+  return failure();
+}
+
 }  // namespace
 }  // namespace mhlo
 }  // namespace mlir

--- a/tensorflow/compiler/mlir/xla/mlir_hlo_to_hlo.cc
+++ b/tensorflow/compiler/mlir/xla/mlir_hlo_to_hlo.cc
@@ -1176,14 +1176,6 @@ LogicalResult ExportXlaOp(BitcastOp op, OpLoweringContext ctx) {
   return success();
 }
 
-LogicalResult ExportXlaOp(H2DOp op, OpLoweringContext ctx) {
-  return failure();
-}
-
-LogicalResult ExportXlaOp(D2HOp op, OpLoweringContext ctx) {
-  return failure();
-}
-
 LogicalResult ExportXlaOp(RealDynamicSliceOp op, OpLoweringContext ctx) {
   return failure();
 }
@@ -1197,10 +1189,6 @@ LogicalResult ExportXlaOp(DynamicGatherOp op, OpLoweringContext ctx) {
 }
 
 LogicalResult ExportXlaOp(DynamicConvOp op, OpLoweringContext ctx) {
-  return failure();
-}
-
-LogicalResult ExportXlaOp(DebugPrintOp op, OpLoweringContext ctx) {
   return failure();
 }
 


### PR DESCRIPTION
We are porting our MLIR-based dynamic shape compiler to tf community (From OP def, Patttern, to Optimization pass, etc). 
This is the first PR, which including some dynamic shape OPs def in mhlo and lmhlo dialect.  
For mhlo dialect, we add:
- HLO_RealDynamicSliceOp
- HLO_DynamicPadOp
- HLO_DynamicGatherOp
- HLO_DynamicConvOp 
 
For lmhlo dialect, we add:
- LHLO_RealDynamicSliceOp
- LHLO_DynamicBroadcastInDimOp
- LHLO_DynamicGatherOp
- LHLO_DynamicPadOp
- LHLO_DynamicBitcastOp
- LHLO_DynamicConvOp
- LHLO_DynamicIotaOp
- LHLO_DynamicReshapeOp
- LHLO_DotGeneralOp
- LHLO_BitcastOp

Rest Ops to add:
* We will send a separate PR containing LHLO_DynamicWhileOp and LHLO_DynamicCaseOp for control flow.
* We will add a separate dedicated dialect like mhlo_ral, which including D2HOp/H2DOp/DebugPrintOp/TopKOp, etc.

Previous discussions：[RFC](https://groups.google.com/a/tensorflow.org/g/mlir/c/_X48poNcbDI/m/jCC8BWIICQAJ), [discussion_1](https://llvm.discourse.group/t/updates-on-mlir-based-dynamic-shape-compiler/2384), [Recording of meeting](https://drive.google.com/file/d/1_uEISlV5MUWdG9faKAdKlCWnPtGjRC-D/view?usp=sharing). 