### PR TITLE
updated micro_speech readme.md

### DIFF
--- a/tensorflow/lite/micro/examples/micro_speech/README.md
+++ b/tensorflow/lite/micro/examples/micro_speech/README.md
@@ -267,7 +267,7 @@ The following command will download the required dependencies and then compile a
 binary for the SparkFun Edge:
 
 ```
-make -f tensorflow/lite/micro/tools/make/Makefile TARGET=sparkfun_edge TAGS="cmsis_nn" micro_speech_bin
+make -f tensorflow/lite/micro/tools/make/Makefile TARGET=sparkfun_edge OPTIMIZED_KERNEL_DIR=cmsis_nn micro_speech_bin
 ```
 
 The binary will be created in the following location:


### PR DESCRIPTION
Small fix to the README in the TFLM micro_speech example. The old `TAGS` was still used instead of `OPTIMIZED_KERNEL_DIR`.

Tested the command to generate the binary on macOS.