### PR TITLE
Upgrade Cudnn Frontend repo to v0.3 and use fallback list for ConvBiasAct ops

### DIFF
--- a/tensorflow/stream_executor/cuda/cuda_dnn.cc
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.cc
@@ -3712,40 +3712,30 @@ GetFirstWorkingExecutionPlan(
                         .build();
   RETURN_MSG_IF_CUDNN_ERROR(heuristics);
 
-  bool use_fallback = kind != dnn::ConvolutionKind::INVALID;
-  std::unique_ptr<cudnn_frontend::EngineFallbackList> fallback_ptr;
-  if (use_fallback) {
-    cudnnBackendDescriptorType_t conv_mode = GetCudnnConvolutionType(kind);
-    auto fallback = cudnn_frontend::EngineFallbackListBuilder()
-                        .setOperationGraph(*op_graph)
-                        .setOperation(conv_mode)
-                        .build();
-    RETURN_MSG_IF_CUDNN_ERROR(fallback);
-    fallback_ptr = std::unique_ptr<cudnn_frontend::EngineFallbackList>(
-        new cudnn_frontend::EngineFallbackList(std::move(fallback)));
-  }
+  cudnnBackendDescriptorType_t conv_mode = GetCudnnConvolutionType(kind);
+  auto fallback = cudnn_frontend::EngineFallbackListBuilder()
+                      .setOperationGraph(*op_graph)
+                      .setOperation(conv_mode)
+                      .build();
+  RETURN_MSG_IF_CUDNN_ERROR(fallback);
 
   auto engine_count = heuristics.getEngineConfigCount();
   auto& engine_config = heuristics.getEngineConfig(engine_count);
+  auto& fallback_list = fallback.getFallbackList();
 
   cudnn_frontend::EngineConfigList filtered_configs;
   if (RequireCudnnDeterminism()) {
     cudnn_frontend::filter(engine_config, filtered_configs,
                            IsNonDeterministicOrIsDownConverting);
-    if (use_fallback) {
-      auto& fallback_list = fallback_ptr->getFallbackList();
-      cudnn_frontend::filter(fallback_list, filtered_configs,
-                             IsNonDeterministicOrIsDownConverting);
-    }
+    cudnn_frontend::filter(fallback_list, filtered_configs,
+                           IsNonDeterministicOrIsDownConverting);
   } else {
     cudnn_frontend::filter(engine_config, filtered_configs,
                            IsDownConvertingInputs);
-    if (use_fallback) {
-      auto& fallback_list = fallback_ptr->getFallbackList();
-      cudnn_frontend::filter(fallback_list, filtered_configs,
-                             IsDownConvertingInputs);
-    }
+    cudnn_frontend::filter(fallback_list, filtered_configs,
+                           IsDownConvertingInputs);
   }
+
   for (int i = 0; i < filtered_configs.size(); i++) {
     auto plan = cudnn_frontend::ExecutionPlanBuilder()
                     .setHandle(cudnn.handle())
@@ -4230,7 +4220,7 @@ port::Status CudnnSupport::DoFusedConvolveWithExecutionPlanImpl(
 
     SE_ASSIGN_OR_RETURN(
         current_plan,
-        GetFirstWorkingExecutionPlan(op_graph, dnn::ConvolutionKind::INVALID,
+        GetFirstWorkingExecutionPlan(op_graph, dnn::ConvolutionKind::FORWARD,
                                      cudnn, scratch_allocator));
   }
 
@@ -4417,16 +4407,29 @@ port::Status CudnnSupport::GetFusedConvolveExecutionPlans(
                   .build();
   RETURN_MSG_IF_CUDNN_ERROR(heur);
 
-  auto& heur_configs = heur.getEngineConfig(heur.getEngineConfigCount());
+  auto fallback =
+      cudnn_frontend::EngineFallbackListBuilder()
+          .setOperationGraph(*op_graph)
+          .setOperation(GetCudnnConvolutionType(dnn::ConvolutionKind::FORWARD))
+          .build();
+  RETURN_MSG_IF_CUDNN_ERROR(fallback);
 
-  VLOG(4) << "\nHeuristics engine configs size: " << heur_configs.size();
+  auto& heur_configs = heur.getEngineConfig(heur.getEngineConfigCount());
+  auto &fallback_configs = fallback.getFallbackList();
+
+  VLOG(4) << "\nHeuristics engine configs size: " << heur_configs.size()
+          << "\nFallback engine configs size: " << fallback_configs.size();
 
   cudnn_frontend::EngineConfigList filtered_configs;
   if (RequireCudnnDeterminism()) {
     cudnn_frontend::filter(heur_configs, filtered_configs,
                            IsNonDeterministicOrIsDownConverting);
+    cudnn_frontend::filter(fallback_configs, filtered_configs,
+                           IsNonDeterministicOrIsDownConverting);
   } else {
     cudnn_frontend::filter(heur_configs, filtered_configs,
+                           IsDownConvertingInputs);
+    cudnn_frontend::filter(fallback_configs, filtered_configs,
                            IsDownConvertingInputs);
   }
 

--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -159,11 +159,11 @@ def _tf_repositories():
         name = "cudnn_frontend_archive",
         build_file = "//third_party:cudnn_frontend.BUILD",
         patch_file = "//third_party:cudnn_frontend_header_fix.patch",
-        sha256 = "498f908ced41bbf524af6b89dc4229d5cc89311bfaaed1e3794981e858629196",
-        strip_prefix = "cudnn-frontend-360d6e7164dfb7c802493fd1c0464f0d815b852a",
+        sha256 = "60b085e1412144e0b24f8b01809857d3a4491c9b2b1c58f0766f673b791d05ca",
+        strip_prefix = "cudnn-frontend-51e60d891b689d618e7a623509a779c422a420f7",
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/NVIDIA/cudnn-frontend/archive/360d6e7164dfb7c802493fd1c0464f0d815b852a.zip",
-            "https://github.com/NVIDIA/cudnn-frontend/archive/360d6e7164dfb7c802493fd1c0464f0d815b852a.zip",
+            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/NVIDIA/cudnn-frontend/archive/51e60d891b689d618e7a623509a779c422a420f7.zip",
+            "https://github.com/NVIDIA/cudnn-frontend/archive/51e60d891b689d618e7a623509a779c422a420f7.zip",
         ],
     )
 

--- a/third_party/cudnn_frontend_header_fix.patch
+++ b/third_party/cudnn_frontend_header_fix.patch
@@ -1,3 +1,25 @@
+From 7bbdd3663cfb6a74541e95fe4b9dd5fe16659963 Mon Sep 17 00:00:00 2001
+From: Kaixi Hou <kaixih@nvidia.com>
+Date: Tue, 4 May 2021 15:21:11 -0700
+Subject: [PATCH] Update headers path
+
+---
+ include/cudnn_backend_base.h                | 2 +-
+ include/cudnn_frontend_ConvDesc.h           | 4 ++--
+ include/cudnn_frontend_Engine.h             | 4 ++--
+ include/cudnn_frontend_EngineConfig.h       | 4 ++--
+ include/cudnn_frontend_EngineFallbackList.h | 2 +-
+ include/cudnn_frontend_ExecutionPlan.h      | 4 ++--
+ include/cudnn_frontend_Filters.h            | 2 +-
+ include/cudnn_frontend_Heuristics.h         | 4 ++--
+ include/cudnn_frontend_MatMulDesc.h         | 4 ++--
+ include/cudnn_frontend_Operation.h          | 4 ++--
+ include/cudnn_frontend_OperationGraph.h     | 4 ++--
+ include/cudnn_frontend_PointWiseDesc.h      | 4 ++--
+ include/cudnn_frontend_ReductionDesc.h      | 4 ++--
+ include/cudnn_frontend_VariantPack.h        | 4 ++--
+ 14 files changed, 25 insertions(+), 25 deletions(-)
+
 diff --git a/include/cudnn_backend_base.h b/include/cudnn_backend_base.h
 index b07b336..3fb06a7 100644
 --- a/include/cudnn_backend_base.h
@@ -27,7 +49,7 @@ index d8706d4..6cabf6e 100644
  #include "cudnn_frontend_utils.h"
  
 diff --git a/include/cudnn_frontend_Engine.h b/include/cudnn_frontend_Engine.h
-index 7b3c612..05ee6a6 100644
+index 644a759..0e2f76b 100644
 --- a/include/cudnn_frontend_Engine.h
 +++ b/include/cudnn_frontend_Engine.h
 @@ -30,8 +30,8 @@
@@ -42,7 +64,7 @@ index 7b3c612..05ee6a6 100644
  #include "cudnn_frontend_OperationGraph.h"
  #include "cudnn_frontend_utils.h"
 diff --git a/include/cudnn_frontend_EngineConfig.h b/include/cudnn_frontend_EngineConfig.h
-index 37b4e99..1afd3cc 100644
+index 3e37848..1980207 100644
 --- a/include/cudnn_frontend_EngineConfig.h
 +++ b/include/cudnn_frontend_EngineConfig.h
 @@ -29,8 +29,8 @@
@@ -57,7 +79,7 @@ index 37b4e99..1afd3cc 100644
  #include "cudnn_frontend_Engine.h"
  #include "cudnn_frontend_utils.h"
 diff --git a/include/cudnn_frontend_EngineFallbackList.h b/include/cudnn_frontend_EngineFallbackList.h
-index 4fadb44..cb2be8a 100644
+index e7d918b..7298ef3 100644
 --- a/include/cudnn_frontend_EngineFallbackList.h
 +++ b/include/cudnn_frontend_EngineFallbackList.h
 @@ -22,7 +22,7 @@
@@ -70,7 +92,7 @@ index 4fadb44..cb2be8a 100644
  
  namespace cudnn_frontend {
 diff --git a/include/cudnn_frontend_ExecutionPlan.h b/include/cudnn_frontend_ExecutionPlan.h
-index 03be7ec..1e8ea83 100644
+index 8ceb03a..048713c 100644
 --- a/include/cudnn_frontend_ExecutionPlan.h
 +++ b/include/cudnn_frontend_ExecutionPlan.h
 @@ -29,8 +29,8 @@
@@ -85,7 +107,7 @@ index 03be7ec..1e8ea83 100644
  #include "cudnn_frontend_Engine.h"
  #include "cudnn_frontend_utils.h"
 diff --git a/include/cudnn_frontend_Filters.h b/include/cudnn_frontend_Filters.h
-index c8ca775..5969ec1 100644
+index b244766..3e9273b 100644
 --- a/include/cudnn_frontend_Filters.h
 +++ b/include/cudnn_frontend_Filters.h
 @@ -22,7 +22,7 @@
@@ -98,7 +120,7 @@ index c8ca775..5969ec1 100644
  namespace cudnn_frontend {
  
 diff --git a/include/cudnn_frontend_Heuristics.h b/include/cudnn_frontend_Heuristics.h
-index 13a2e32..6a74c5f 100644
+index 446f932..b15f472 100644
 --- a/include/cudnn_frontend_Heuristics.h
 +++ b/include/cudnn_frontend_Heuristics.h
 @@ -24,8 +24,8 @@
@@ -112,8 +134,23 @@ index 13a2e32..6a74c5f 100644
  
  #include "cudnn_frontend_OperationGraph.h"
  #include "cudnn_frontend_utils.h"
+diff --git a/include/cudnn_frontend_MatMulDesc.h b/include/cudnn_frontend_MatMulDesc.h
+index e416002..da2deb1 100644
+--- a/include/cudnn_frontend_MatMulDesc.h
++++ b/include/cudnn_frontend_MatMulDesc.h
+@@ -29,8 +29,8 @@
+ #include <sstream>
+ #include <utility>
+ 
+-#include <cudnn.h>
+-#include <cudnn_backend.h>
++#include "third_party/gpus/cudnn/cudnn.h"
++#include "third_party/gpus/cudnn/cudnn_backend.h"
+ 
+ #include "cudnn_frontend_utils.h"
+ 
 diff --git a/include/cudnn_frontend_Operation.h b/include/cudnn_frontend_Operation.h
-index f79c69c..840076b 100644
+index dd3633d..a533a30 100644
 --- a/include/cudnn_frontend_Operation.h
 +++ b/include/cudnn_frontend_Operation.h
 @@ -29,8 +29,8 @@
@@ -128,7 +165,7 @@ index f79c69c..840076b 100644
  #include "cudnn_frontend_ConvDesc.h"
  #include "cudnn_frontend_PointWiseDesc.h"
 diff --git a/include/cudnn_frontend_OperationGraph.h b/include/cudnn_frontend_OperationGraph.h
-index f1d5dcc..5edd0e7 100644
+index 75d58fb..3d7c3d1 100644
 --- a/include/cudnn_frontend_OperationGraph.h
 +++ b/include/cudnn_frontend_OperationGraph.h
 @@ -29,8 +29,8 @@
@@ -143,9 +180,24 @@ index f1d5dcc..5edd0e7 100644
  #include "cudnn_frontend_Operation.h"
  #include "cudnn_frontend_utils.h"
 diff --git a/include/cudnn_frontend_PointWiseDesc.h b/include/cudnn_frontend_PointWiseDesc.h
-index 4715971..b086d23 100644
+index 050a15f..7c07589 100644
 --- a/include/cudnn_frontend_PointWiseDesc.h
 +++ b/include/cudnn_frontend_PointWiseDesc.h
+@@ -29,8 +29,8 @@
+ #include <sstream>
+ #include <utility>
+ 
+-#include <cudnn.h>
+-#include <cudnn_backend.h>
++#include "third_party/gpus/cudnn/cudnn.h"
++#include "third_party/gpus/cudnn/cudnn_backend.h"
+ 
+ #include "cudnn_frontend_utils.h"
+ 
+diff --git a/include/cudnn_frontend_ReductionDesc.h b/include/cudnn_frontend_ReductionDesc.h
+index d4de814..8aa447d 100644
+--- a/include/cudnn_frontend_ReductionDesc.h
++++ b/include/cudnn_frontend_ReductionDesc.h
 @@ -29,8 +29,8 @@
  #include <sstream>
  #include <utility>
@@ -172,3 +224,6 @@ index ab2aab3..94aae89 100644
  
  #include "cudnn_frontend_utils.h"
  
+-- 
+2.17.1
+


### PR DESCRIPTION
- This PR upgrades the Cudnn Frontend repo to v0.3: https://github.com/NVIDIA/cudnn-frontend/releases/tag/v0.3
- The ConvBiasAct ops are updated to support a fallback list to avoid the situation when there is no working engines found in the heuristics list.
- The patch is also updated to be clearer by adding the commit info.
- This PR should be able to replace this pending PR: https://github.com/tensorflow/tensorflow/pull/48906

cc. @nluehr 
