### PR TITLE
Re-enable Fused BatchNorm + Add + Activation for the backprop

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/cudnn_batchnorm_runner.cc
+++ b/tensorflow/compiler/xla/service/gpu/cudnn_batchnorm_runner.cc
@@ -191,19 +191,24 @@ template <typename ElemType>
 void RunCudnnBatchNormBackwardImpl(CudnnBatchNormBackwardParams* params,
                                    se::Stream* stream) {
   se::DeviceMemory<float> null_device_ptr(nullptr);
+  se::DeviceMemory<ElemType> null_elem_device_ptr(nullptr);
   auto output_grad_data = se::DeviceMemory<ElemType>(params->output_grad_data);
   stream->ThenBatchNormalizationBackward(
       se::DeviceMemory<ElemType>(params->grad_output),     //
       se::DeviceMemory<ElemType>(params->common.operand),  //
       params->common.scale,                                //
+      /*offset=*/null_device_ptr,                          //
       params->mean,                                        //
       params->inv_stddev,                                  //
+      /*y=*/null_elem_device_ptr,                          //
       params->common.operand_desc,                         //
       params->common.scale_offset_desc,                    //
       params->common.epsilon,                              //
+      se::dnn::ActivationMode::kNone,                      //
       &output_grad_data,                                   //
       &params->output_grad_scale,                          //
       &params->output_grad_offset,                         //
+      /*side_input_backprop=*/&null_elem_device_ptr,       //
       /*reserve_space_allocator=*/nullptr,                 //
       /*workspace_allocator=*/nullptr);
 }

--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -1009,6 +1009,8 @@ bool FindFusedBatchNormGradEx(const RemapperContext& ctx, int node_index,
     return true;
   };
 
+  if (ctx.xla_auto_clustering_on) return false;
+
   if (!valid_batch_norm_grad(*node_view)) return false;
 
   if (node_view->NumRegularFanins() < 1) return false;

--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -981,6 +981,11 @@ bool FindFusedBatchNormGradEx(const RemapperContext& ctx, int node_index,
     // We fuse FusedBatchNormGrad on GPU.
     if (!NodeIsOnGpu(node_def)) return false;
 
+    // We fuse FusedBatchNormGrad only for the training mode.
+    bool is_training;
+    if (!GetNodeAttr(*node_def, kIsTraining, &is_training).ok() || !is_training)
+      return false;
+
     // Data type must be DT_HALF.
     DataType t_dtype = GetDataTypeFromAttr(*node_def, "T");
     if (t_dtype != DT_HALF) return false;

--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -1045,6 +1045,16 @@ bool FindFusedBatchNormGradEx(const RemapperContext& ctx, int node_index,
   // Check that only 2 nodes consume the output of the ReluGrad node.
   if (fwd_bn_add_act_used &&
       relugrad_node_view->GetRegularFanout(0).size() == 2) {
+
+    // In a graph with the Add node having two BatchNorm nodes as the inputs, we
+    // need to make sure only the one backward BatchNorm that correponds to the
+    // to-be-fused forward BatchNorm should be fused. We use the edge for the
+    // reserve space to get the directly corresponded forward BatchNorm node.
+    const auto& fwd_batch_norm_node = node_view->GetRegularFanin(5);
+    if (fwd_matched.fused_batch_norm != fwd_batch_norm_node.node_index()) {
+      return false;
+    }
+
     const auto& fanouts_at_port_0 = relugrad_node_view->GetRegularFanouts()[0];
     const auto* fanout_0_node_view = ctx.graph_view.GetNode(
         fanouts_at_port_0[0].node_view()->GetName());

--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -65,7 +65,9 @@ constexpr char kFusedConv2D[] = "_FusedConv2D";
 constexpr char kFusedMatMul[] = "_FusedMatMul";
 constexpr char kFusedDepthwiseConv2dNative[] = "_FusedDepthwiseConv2dNative";
 constexpr char kFusedBatchNormEx[] = "_FusedBatchNormEx";
+constexpr char kFusedBatchNormGradEx[] = "_FusedBatchNormGradEx";
 constexpr char kTensorToHashBucket[] = "_TensorToHashBucketFast";
+
 constexpr char kDataFormat[] = "data_format";
 constexpr char kIsTraining[] = "is_training";
 
@@ -110,6 +112,17 @@ struct FusedBatchNormEx {
   int invalidated = kMissingIndex;
 };
 
+// FusedBatchNormGrad with fused side output and/or activation.
+struct FusedBatchNormGradEx {
+  FusedBatchNormGradEx() = default;
+
+  int fused_batch_norm_grad = kMissingIndex;
+  int activation_grad = kMissingIndex;
+  int side_input_grad = kMissingIndex;
+  // Add node of the forward pass to access its "offset" input.
+  int fwd_fused_batch_norm = kMissingIndex;
+};
+
 // TensorToHashBucket that can be replaced with AsString + StringToHashBucket.
 // We also include the fanin node of AsString ("pre_as_string") to determine the
 // device.
@@ -122,6 +135,7 @@ struct TensorToHashBucket {
   int as_string = kMissingIndex;
   int string_to_hash_bucket = kMissingIndex;
 };
+
 // Contraction node followed by a BiasAdd.
 struct ContractionWithBiasAdd {
   ContractionWithBiasAdd() = default;
@@ -952,6 +966,112 @@ bool FindFusedBatchNormEx(const RemapperContext& ctx, int node_index,
   return false;
 }
 
+bool FindFusedBatchNormGradEx(const RemapperContext& ctx, int node_index,
+                              FusedBatchNormGradEx* matched) {
+  // Root of the pattern must be a FusedBatchNormGrad.
+  const auto* node_view = ctx.graph_view.GetNode(node_index);
+
+	// Returns true iff the node is a compatible FusedBatchNormGrad node.
+  const auto valid_batch_norm_grad =
+      [&](const utils::MutableNodeView& fused_batch_norm_grad) -> bool {
+    const auto* node_def = fused_batch_norm_grad.node();
+    if (!IsFusedBatchNormGrad(*node_def) ||
+        HasControlFaninOrFanout(fused_batch_norm_grad)) return false;
+
+    // We fuse FusedBatchNormGrad on GPU.
+    if (!NodeIsOnGpu(node_def)) return false;
+
+    // Data type must be DT_HALF.
+    DataType t_dtype = GetDataTypeFromAttr(*node_def, "T");
+    if (t_dtype != DT_HALF) return false;
+
+    // We rely on cuDNN for computing FusedBatchNormGrad with side
+    // outputs and activation. cuDNN only supports NHWC data layout.
+    string data_format;
+    if (!GetNodeAttr(*node_def, kDataFormat, &data_format).ok()) return false;
+    if (data_format != "NHWC") return false;
+
+    // Channel dimension must be a multiple of 4.
+    const auto& props = ctx.graph_properties.GetInputProperties(
+        node_def->name());
+    const bool valid_channel_dim = !props.empty() &&
+                                   props[0].shape().dim_size() == 4 &&
+                                   props[0].shape().dim(3).size() % 4 == 0;
+    if (!valid_channel_dim) return false;
+
+    // cuDNN must support CUDNN_BATCHNORM_SPATIAL_PERSISTENT mode.
+    if (!BatchnormSpatialPersistentEnabled()) return false;
+
+    // FusedBatchNormV2 and V3 have an extra type parameter.
+    if (node_def->op() != "FusedBatchNorm" &&
+        !HasDataType(node_def, DT_FLOAT, "U")) return false;
+
+    return true;
+  };
+
+  if (!valid_batch_norm_grad(*node_view)) return false;
+
+  if (node_view->NumRegularFanins() < 1) return false;
+
+  const auto& regular_fanin_0 = node_view->GetRegularFanin(0);
+  const auto* relugrad_node_view = regular_fanin_0.node_view();
+  const auto* relugrad_node_def = relugrad_node_view->node();
+  bool is_relugrad = IsReluGrad(*relugrad_node_def);
+
+  if (!is_relugrad || HasControlFaninOrFanout(*relugrad_node_view) ||
+      IsInPreserveSet(ctx, relugrad_node_def)) return false;
+
+  if (relugrad_node_view->NumRegularFanins() < 1) return false;
+  // Find its corresponding forward node. We need the node to determine if the
+  // type is bn+add+act or bn+act. Also, we need to access its "offset" input.
+  const auto& fanin_1 = relugrad_node_view->GetRegularFanin(1);
+  const auto* fwd_node_view = fanin_1.node_view();
+  const auto* fwd_node_def = fwd_node_view->node();
+  FusedBatchNormEx fwd_matched;
+  FindFusedBatchNormEx(ctx, fwd_node_view->node_index(), &fwd_matched);
+  bool fwd_bn_act_used = fwd_matched.activation != kMissingIndex &&
+                         fwd_matched.side_input == kMissingIndex;
+  bool fwd_bn_add_act_used = fwd_matched.activation != kMissingIndex &&
+                             fwd_matched.side_input != kMissingIndex;
+
+  // Check that only 1 node consumes the output of the ReluGrad node.
+  if (fwd_bn_act_used && relugrad_node_view->GetRegularFanout(0).size() == 1) {
+    matched->activation_grad = regular_fanin_0.node_index();
+    matched->fused_batch_norm_grad = node_index;
+    matched->fwd_fused_batch_norm = fwd_matched.fused_batch_norm;
+    return true;
+  }
+
+  // Check that only 2 nodes consume the output of the ReluGrad node.
+  if (fwd_bn_add_act_used &&
+      relugrad_node_view->GetRegularFanout(0).size() == 2) {
+    const auto& fanouts_at_port_0 = relugrad_node_view->GetRegularFanouts()[0];
+    const auto* fanout_0_node_view = ctx.graph_view.GetNode(
+        fanouts_at_port_0[0].node_view()->GetName());
+    const auto* fanout_1_node_view = ctx.graph_view.GetNode(
+        fanouts_at_port_0[1].node_view()->GetName());
+    const auto* fanout_0_node_def = fanout_0_node_view->node();
+    const auto* fanout_1_node_def = fanout_1_node_view->node();
+    const auto* node_def = node_view->node();
+
+    matched->activation_grad = regular_fanin_0.node_index();
+    matched->fused_batch_norm_grad = node_index;
+    matched->fwd_fused_batch_norm = fwd_matched.fused_batch_norm;
+
+    if (fanout_0_node_def == node_def) {
+      matched->side_input_grad = fanout_1_node_view->node_index();
+      return true;
+    }
+
+    if (fanout_1_node_def == node_def) {
+      matched->side_input_grad = fanout_0_node_view->node_index();
+      return true;
+    }
+  }
+  
+  return false;
+}
+
 bool FindTensorToHashBucket(const RemapperContext& ctx, int node_index,
                             TensorToHashBucket* matched) {
   // Root of the pattern must be a StringToHashBucketFast.
@@ -1075,6 +1195,27 @@ void CopyFusedBatchNormAttributes(const NodeDef& fused_batch_norm,
       SetAttrValue(src_attr.at("T"), &(*attr)["U"]);
     else
       SetAttrValue(DT_FLOAT, &(*attr)["U"]);
+  }
+}
+
+void CopyFusedBatchNormGradAttributes(const NodeDef& fused_batch_norm_grad,
+                                      NodeDef* fused_batch_norm_grad_ex) {
+  DCHECK(IsFusedBatchNormGrad(fused_batch_norm_grad))
+      << "Input node must be a FusedBatchNormGrad";
+
+  auto* attr = fused_batch_norm_grad_ex->mutable_attr();
+  auto src_attr = fused_batch_norm_grad.attr();
+
+  (*attr)["T"] = src_attr.at("T");
+  (*attr)["is_training"] = src_attr.at("is_training");
+  (*attr)["data_format"] = src_attr.at("data_format");
+  (*attr)["epsilon"] = src_attr.at("epsilon");
+
+  // FusedBatchNormV2 and V3 have an extra type parameter.
+  if (fused_batch_norm_grad.op() != "FusedBatchNormGrad") {
+    SetAttrValue(src_attr.at("U"), &(*attr)["U"]);
+  } else {
+    SetAttrValue(DT_FLOAT, &(*attr)["U"]);
   }
 }
 
@@ -1487,6 +1628,77 @@ Status AddFusedBatchNormExNode(RemapperContext* ctx,
   return Status::OK();
 }
 
+Status AddFusedBatchNormGradExNode(RemapperContext* ctx,
+                                   const FusedBatchNormGradEx& matched,
+                                   std::vector<bool>* invalidated_nodes,
+                                   std::vector<bool>* nodes_to_delete) {
+  const GraphDef* graph = ctx->graph_view.graph();
+  const NodeDef& fused_batch_norm_grad = graph->node(
+                                             matched.fused_batch_norm_grad);
+  const NodeDef& activation_grad = graph->node(matched.activation_grad);
+  const NodeDef& fwd_fused_batch_norm = graph->node(
+                                            matched.fwd_fused_batch_norm);
+
+  VLOG(2) << "Fuse FusedBatchNormGrad with " << activation_grad.op() << ": "
+          << " fused_batch_norm_grad=" << fused_batch_norm_grad.name()
+          << " side_input=" << (matched.side_input_grad != kMissingIndex
+              ? graph->node(matched.side_input_grad).name() : "<none>")
+          << " activation=" << activation_grad.name()
+          << " corresponding FusedBatchNorm=" << fwd_fused_batch_norm.name();
+
+  NodeDef fused_op;
+  fused_op.set_op(kFusedBatchNormGradEx);
+  fused_op.set_name(fused_batch_norm_grad.name());
+  fused_op.set_device(fused_batch_norm_grad.device());
+
+  fused_op.add_input(activation_grad.input(0));        // 0: y_backprop
+  fused_op.add_input(fused_batch_norm_grad.input(1));  // 1: x
+  fused_op.add_input(fused_batch_norm_grad.input(2));  // 2: scale
+  fused_op.add_input(fused_batch_norm_grad.input(3));  // 3: reserve_space_1
+  fused_op.add_input(fused_batch_norm_grad.input(4));  // 4: reserve_space_2
+  fused_op.add_input(fused_batch_norm_grad.input(5));  // 5: reserve_space_3
+  fused_op.add_input(fwd_fused_batch_norm.input(2));   // 6: offset
+  fused_op.add_input(activation_grad.input(1));        // 7: y
+
+  CopyFusedBatchNormGradAttributes(fused_batch_norm_grad, &fused_op);
+
+  auto* attrs = fused_op.mutable_attr();
+  // Only support Relu mode.
+  SetAttrValue("Relu", &(*attrs)["activation_mode"]);
+
+  if (matched.side_input_grad != kMissingIndex) {
+    SetAttrValue(1, &(*attrs)["num_side_inputs"]);
+  } else {
+    SetAttrValue(0, &(*attrs)["num_side_inputs"]);
+  }
+
+  NodeDef identity_op;
+  identity_op.set_op("Identity");
+  identity_op.set_name(activation_grad.name());
+  identity_op.set_device(fused_batch_norm_grad.device());
+  identity_op.add_input(absl::StrCat(fused_batch_norm_grad.name(), ":5"));
+  (*identity_op.mutable_attr())["T"] = attrs->at("T");
+
+  utils::Mutation* mutation = ctx->graph_view.GetMutationBuilder();
+  Status status;
+  mutation->AddNode(std::move(fused_op), &status);
+  TF_RETURN_IF_ERROR(status);
+  if (matched.side_input_grad != kMissingIndex) {
+    mutation->AddNode(std::move(identity_op), &status);
+    TF_RETURN_IF_ERROR(status);
+  }
+  TF_RETURN_IF_ERROR(mutation->Apply());
+
+  (*invalidated_nodes)[matched.fused_batch_norm_grad] = true;
+  if (matched.side_input_grad != kMissingIndex) {
+    (*invalidated_nodes)[matched.activation_grad] = true;
+  } else {
+    (*nodes_to_delete)[matched.activation_grad] = true;
+  }
+
+  return Status::OK();
+}
+
 Status AddBatchNormNodes(RemapperContext* ctx, const FusedBatchNorm& matched) {
   const GraphDef* graph = ctx->graph_view.graph();
   const NodeDef& fused_node = graph->node(matched.fused_batch_norm);
@@ -1770,6 +1982,7 @@ bool IsContractionWithAdd(const RemapperContext& ctx, int node_index) {
 //   (2) Fusing side input and/or activation into FusedBatchNorm.
 //   (3) Fusing Conv2D biasadd and relu on GPU
 //   (4) INTEL_MKL specific: Conv2D -> Add or Conv2D -> BiasAdd -> Add.
+//   (5) Fusing side output and/or activation into FusedBatchNormGrad.
 bool RequiresInferredShapes(const RemapperContext& ctx, int node_index) {
   // Candidate for a FusedBatchNorm splitting.
   const auto* node_view = ctx.graph_view.GetNode(node_index);
@@ -1840,12 +2053,30 @@ bool RequiresInferredShapes(const RemapperContext& ctx, int node_index) {
     return false;
   };
 
+  // Candidate for a FusedBatchNormGrad fusion.
+  const auto is_batch_norm_grad_fusion_candidate = [&]() -> bool {
+    if (!IsFusedBatchNormGrad(*node_def)) return false;
+
+    if (node_view->NumRegularFanins() < 1) return false;
+    const auto& bn_fanin_0 = node_view->GetRegularFanin(0);
+    const auto* bn_fanin_0_node_view = bn_fanin_0.node_view();
+    const auto* bn_fanin_0_node_def = bn_fanin_0_node_view->node();
+
+    if (IsReluGrad(*bn_fanin_0_node_def)) {
+      // ReluGrad + FusedBatchNormGrad.
+      return true;
+    }
+
+    return false;
+  };
+
   if (IsMKLEnabled())
     return is_batch_norm_candidate() || is_batch_norm_fusion_candidate() ||
            IsContractionWithAdd(ctx, node_index);
 
   return is_relu_biasadd_conv2d_candidate() || is_batch_norm_candidate() ||
-         is_batch_norm_fusion_candidate();
+         is_batch_norm_fusion_candidate() ||
+         is_batch_norm_grad_fusion_candidate();
 }
 
 }  // namespace
@@ -1987,6 +2218,15 @@ Status Remapper::Optimize(Cluster* cluster, const GrapplerItem& item,
         FindFusedBatchNormEx(ctx, i, &fused_batch_norm_ex)) {
       TF_RETURN_IF_ERROR(AddFusedBatchNormExNode(
           &ctx, fused_batch_norm_ex, &invalidated_nodes, &nodes_to_delete));
+      continue;
+    }
+
+    FusedBatchNormGradEx fused_batch_norm_grad_ex;
+    if (allow_non_differentiable_rewrites &&
+        FindFusedBatchNormGradEx(ctx, i, &fused_batch_norm_grad_ex)) {
+      TF_RETURN_IF_ERROR(AddFusedBatchNormGradExNode(
+          &ctx, fused_batch_norm_grad_ex, &invalidated_nodes,
+          &nodes_to_delete));
       continue;
     }
 

--- a/tensorflow/core/grappler/optimizers/remapper_test.cc
+++ b/tensorflow/core/grappler/optimizers/remapper_test.cc
@@ -216,6 +216,135 @@ TEST_F(RemapperTest, FuseBatchNormWithRelu) {
   }
 }
 
+TEST_F(RemapperTest, FuseBatchNormGradWithReluGrad) {
+
+#if !defined(GOOGLE_CUDA) || !(CUDNN_VERSION >= 7402)
+  GTEST_SKIP() << "No CUDA, skip FuseBatchNormGradWithReluGrad on GPU";
+#endif
+  using ::tensorflow::ops::Placeholder;
+  tensorflow::Scope s = tensorflow::Scope::NewRootScope();
+  bool is_training = true;
+
+  const int num_channels = 24;
+
+  TensorShape channel_shape({num_channels});
+  TensorShape empty_shape({0});
+
+  // Forward pass.
+  auto input = Placeholder(s.WithOpName("input"), DT_FLOAT,
+                           ops::Placeholder::Shape({2, 8, 8, num_channels}));
+  auto input_cast = ops::Cast(s.WithOpName("input_cast"), input, DT_HALF);
+  auto scale = Placeholder(s.WithOpName("scale"), DT_FLOAT);
+  auto offset = Placeholder(s.WithOpName("offset"), DT_FLOAT);
+  auto mean = Placeholder(s.WithOpName("mean"), DT_FLOAT);
+  auto var = Placeholder(s.WithOpName("var"), DT_FLOAT);
+
+  float epsilon = 0.1f;
+  auto fbn = ops::FusedBatchNormV3(
+      s.WithOpName("fused_batch_norm"), input_cast, scale, offset, mean, var,
+      ops::FusedBatchNormV3::IsTraining(is_training)
+          .Epsilon(epsilon)
+          .DataFormat("NHWC"));
+  auto relu = ops::Relu(s.WithOpName("relu"), fbn.y);
+
+  // Backward pass.
+  auto output_grad = Placeholder(
+      s.WithOpName("output_grad"), DT_FLOAT,
+      ops::Placeholder::Shape({2, 8, 8, num_channels}));
+  auto output_grad_cast = ops::Cast(s.WithOpName("output_grad_cast"),
+                                    output_grad, DT_HALF);
+  auto relu_grad = ops::internal::ReluGrad(
+      s.WithOpName("relu_grad"), output_grad_cast, relu);
+  auto fbn_grad = ops::FusedBatchNormGradV3(
+      s.WithOpName("fused_batch_norm_grad"), relu_grad, input_cast, scale,
+      fbn.reserve_space_1, fbn.reserve_space_2, fbn.reserve_space_3,
+      ops::FusedBatchNormGradV3::IsTraining(is_training)
+          .Epsilon(epsilon)
+          .DataFormat("NHWC"));
+  auto fetch0 = ops::Identity(s.WithOpName("fetch0"), fbn_grad.x_backprop);
+  auto fetch1 = ops::Identity(s.WithOpName("fetch1"), fbn_grad.scale_backprop);
+  auto fetch2 = ops::Identity(s.WithOpName("fetch2"), fbn_grad.offset_backprop);
+
+  auto input_t = GenerateRandomTensor<DT_FLOAT>({2, 8, 8, num_channels});
+  auto scale_t = GenerateRandomTensor<DT_FLOAT>(channel_shape);
+  auto offset_t = GenerateRandomTensor<DT_FLOAT>(channel_shape);
+  auto mean_t = GenerateRandomTensor<DT_FLOAT>(channel_shape);
+  auto var_t = GenerateRandomTensor<DT_FLOAT>(channel_shape);
+  auto output_grad_t = GenerateRandomTensor<DT_FLOAT>({2, 8, 8, num_channels});
+
+  GrapplerItem item;
+  item.fetch = {"fetch0", "fetch1", "fetch2"};
+  item.feed = {{"input", input_t},
+               {"scale", scale_t},
+               {"offset", offset_t},
+               {"mean", mean_t},
+               {"var", var_t},
+               {"output_grad", output_grad_t}};
+  TF_ASSERT_OK(s.ToGraphDef(&item.graph));
+
+  // Place all nodes on GPU.
+  for (int i = 0; i < item.graph.node_size(); ++i) {
+    item.graph.mutable_node(i)->set_device("/device:GPU:0");
+  }
+
+  Remapper optimizer(RewriterConfig::AGGRESSIVE);  // trust placeholders shape
+  GraphDef output;
+  TF_ASSERT_OK(optimizer.Optimize(nullptr, item, &output));
+
+  int found = 0;
+  for (const NodeDef& node : output.node()) {
+    if (node.name() == "relu") {
+      EXPECT_EQ(node.op(), "Identity");
+      ASSERT_EQ(node.input_size(), 1);
+      EXPECT_EQ(node.input(0), "fused_batch_norm");
+      found++;
+    }
+    if (node.name() == "fused_batch_norm") {
+      EXPECT_EQ(node.op(), "_FusedBatchNormEx");
+      ASSERT_EQ(node.input_size(), 5);
+      EXPECT_EQ(node.input(0), "input_cast");
+      EXPECT_EQ(node.input(1), "scale");
+      EXPECT_EQ(node.input(2), "offset");
+      EXPECT_EQ(node.input(3), "mean");
+      EXPECT_EQ(node.input(4), "var");
+
+      auto attr = node.attr();
+      EXPECT_EQ(attr["num_side_inputs"].i(), 0);
+      EXPECT_EQ(attr["activation_mode"].s(), "Relu");
+      found++;
+    }
+
+    if (node.name() == "fused_batch_norm_grad") {
+      EXPECT_EQ(node.op(), "_FusedBatchNormGradEx");
+      ASSERT_EQ(node.input_size(), 8);
+      EXPECT_EQ(node.input(0), "output_grad_cast");
+      EXPECT_EQ(node.input(1), "input_cast");
+      EXPECT_EQ(node.input(2), "scale");
+      EXPECT_EQ(node.input(3), "fused_batch_norm:3");
+      EXPECT_EQ(node.input(4), "fused_batch_norm:4");
+      EXPECT_EQ(node.input(5), "fused_batch_norm:5");
+      EXPECT_EQ(node.input(6), "offset");
+      EXPECT_EQ(node.input(7), "relu");
+
+      auto attr = node.attr();
+      EXPECT_EQ(attr["num_side_inputs"].i(), 0);
+      EXPECT_EQ(attr["activation_mode"].s(), "Relu");
+      found++;
+    }
+  }
+  EXPECT_EQ(found, 3);
+
+  if (GetNumAvailableGPUs() > 0) {
+    auto tensors_expected = EvaluateNodes(item.graph, item.fetch, item.feed);
+    ASSERT_EQ(tensors_expected.size(), 3);
+    auto tensors = EvaluateNodes(output, item.fetch, item.feed);
+    ASSERT_EQ(tensors.size(), 3);
+    test::ExpectClose(tensors[0], tensors_expected[0], 1e-2, /*rtol=*/1e-2);
+    test::ExpectClose(tensors[1], tensors_expected[1], 1e-2, /*rtol=*/1e-2);
+    test::ExpectClose(tensors[2], tensors_expected[2], 1e-2, /*rtol=*/1e-2);
+  }
+}
+
 TEST_F(RemapperTest, FuseBatchNormWithAddAndRelu) {
   using ::tensorflow::ops::Placeholder;
 
@@ -328,6 +457,151 @@ TEST_F(RemapperTest, FuseBatchNormWithAddAndRelu) {
   }
 }
 
+TEST_F(RemapperTest, FuseBatchNormGradWithAddAndReluGrad) {
+
+#if !defined(GOOGLE_CUDA) || !(CUDNN_VERSION >= 7402)
+  GTEST_SKIP() << "No CUDA, skip FuseBatchNormGradWithReluGrad on GPU";
+#endif
+  using ::tensorflow::ops::Placeholder;
+  tensorflow::Scope s = tensorflow::Scope::NewRootScope();
+  bool is_training = true;
+
+  const int num_channels = 24;
+
+  TensorShape input_shape({2, 8, 8, num_channels});
+  TensorShape channel_shape({num_channels});
+  TensorShape empty_shape({0});
+
+  // Forward pass.
+  auto input = Placeholder(s.WithOpName("input"), DT_FLOAT,
+                           ops::Placeholder::Shape(input_shape));
+  auto input_cast = ops::Cast(s.WithOpName("input_cast"), input, DT_HALF);
+  auto scale = Placeholder(s.WithOpName("scale"), DT_FLOAT);
+  auto offset = Placeholder(s.WithOpName("offset"), DT_FLOAT);
+  auto mean = Placeholder(s.WithOpName("mean"), DT_FLOAT);
+  auto var = Placeholder(s.WithOpName("var"), DT_FLOAT);
+  auto side_input = Placeholder(s.WithOpName("side_input"), DT_FLOAT,
+                                ops::Placeholder::Shape(input_shape));
+  auto side_input_cast =
+      ops::Cast(s.WithOpName("side_input_cast"), side_input, DT_HALF);
+
+  float epsilon = 0.1f;
+  auto fbn = ops::FusedBatchNormV3(
+      s.WithOpName("fused_batch_norm"), input_cast, scale, offset, mean, var,
+      ops::FusedBatchNormV3::IsTraining(is_training)
+          .Epsilon(epsilon)
+          .DataFormat("NHWC"));
+  auto add = ops::Add(s.WithOpName("add"), fbn.y, side_input_cast);
+  auto relu = ops::Relu(s.WithOpName("relu"), add);
+
+  // Backward pass.
+  auto output_grad = Placeholder(
+      s.WithOpName("output_grad"), DT_FLOAT,
+      ops::Placeholder::Shape({2, 8, 8, num_channels}));
+  auto output_grad_cast = ops::Cast(s.WithOpName("output_grad_cast"),
+                                    output_grad, DT_HALF);
+  auto relu_grad = ops::internal::ReluGrad(
+      s.WithOpName("relu_grad"), output_grad_cast, relu);
+  auto side_input_grad = ops::Identity(s.WithOpName("side_input_grad"),
+                                       relu_grad);
+  auto fbn_grad = ops::FusedBatchNormGradV3(
+      s.WithOpName("fused_batch_norm_grad"), relu_grad, input_cast, scale,
+      fbn.reserve_space_1, fbn.reserve_space_2, fbn.reserve_space_3,
+      ops::FusedBatchNormGradV3::IsTraining(is_training)
+          .Epsilon(epsilon)
+          .DataFormat("NHWC"));
+  auto fetch0 = ops::Identity(s.WithOpName("fetch0"), fbn_grad.x_backprop);
+  auto fetch1 = ops::Identity(s.WithOpName("fetch1"), fbn_grad.scale_backprop);
+  auto fetch2 = ops::Identity(s.WithOpName("fetch2"), fbn_grad.offset_backprop);
+  auto fetch3 = ops::Identity(s.WithOpName("fetch3"), side_input_grad);
+
+  auto input_t = GenerateRandomTensor<DT_FLOAT>(input_shape);
+  auto scale_t = GenerateRandomTensor<DT_FLOAT>(channel_shape);
+  auto offset_t = GenerateRandomTensor<DT_FLOAT>(channel_shape);
+  auto mean_t = GenerateRandomTensor<DT_FLOAT>(channel_shape);
+  auto var_t = GenerateRandomTensor<DT_FLOAT>(channel_shape);
+  auto side_input_t = GenerateRandomTensor<DT_FLOAT>({2, 8, 8, num_channels});
+  auto output_grad_t = GenerateRandomTensor<DT_FLOAT>({2, 8, 8, num_channels});
+
+  GrapplerItem item;
+  item.fetch = {"fetch0", "fetch1", "fetch2", "fetch3"};
+  item.feed = {{"input", input_t},   {"scale", scale_t},
+               {"offset", offset_t}, {"mean", mean_t},
+               {"var", var_t},       {"side_input", side_input_t},
+               {"output_grad", output_grad_t}};
+  TF_ASSERT_OK(s.ToGraphDef(&item.graph));
+
+  // Place all nodes on GPU.
+  for (int i = 0; i < item.graph.node_size(); ++i) {
+    item.graph.mutable_node(i)->set_device("/device:GPU:0");
+  }
+
+  Remapper optimizer(RewriterConfig::AGGRESSIVE);  // trust placeholders shape
+  GraphDef output;
+  TF_ASSERT_OK(optimizer.Optimize(nullptr, item, &output));
+
+  int found = 0;
+  for (const NodeDef& node : output.node()) {
+    if (node.name() == "relu") {
+      EXPECT_EQ(node.op(), "Identity");
+      ASSERT_EQ(node.input_size(), 1);
+      EXPECT_EQ(node.input(0), "fused_batch_norm");
+      found++;
+    }
+    if (node.name() == "fused_batch_norm") {
+      EXPECT_EQ(node.op(), "_FusedBatchNormEx");
+      ASSERT_EQ(node.input_size(), 6);
+      EXPECT_EQ(node.input(0), "input_cast");
+      EXPECT_EQ(node.input(1), "scale");
+      EXPECT_EQ(node.input(2), "offset");
+      EXPECT_EQ(node.input(3), "mean");
+      EXPECT_EQ(node.input(4), "var");
+      EXPECT_EQ(node.input(5), "side_input_cast");
+
+      auto attr = node.attr();
+      EXPECT_EQ(attr["num_side_inputs"].i(), 1);
+      EXPECT_EQ(attr["activation_mode"].s(), "Relu");
+      found++;
+    }
+
+    if (node.name() == "relu_grad") {
+      EXPECT_EQ(node.op(), "Identity");
+      ASSERT_EQ(node.input_size(), 1);
+      EXPECT_EQ(node.input(0), "fused_batch_norm_grad:5");
+      found++;
+    }
+
+    if (node.name() == "fused_batch_norm_grad") {
+      EXPECT_EQ(node.op(), "_FusedBatchNormGradEx");
+      ASSERT_EQ(node.input_size(), 8);
+      EXPECT_EQ(node.input(0), "output_grad_cast");
+      EXPECT_EQ(node.input(1), "input_cast");
+      EXPECT_EQ(node.input(2), "scale");
+      EXPECT_EQ(node.input(3), "fused_batch_norm:3");
+      EXPECT_EQ(node.input(4), "fused_batch_norm:4");
+      EXPECT_EQ(node.input(5), "fused_batch_norm:5");
+      EXPECT_EQ(node.input(6), "offset");
+      EXPECT_EQ(node.input(7), "relu");
+
+      auto attr = node.attr();
+      EXPECT_EQ(attr["num_side_inputs"].i(), 1);
+      EXPECT_EQ(attr["activation_mode"].s(), "Relu");
+      found++;
+    }
+  }
+  EXPECT_EQ(found, 4);
+
+  if (GetNumAvailableGPUs() > 0) {
+    auto tensors_expected = EvaluateNodes(item.graph, item.fetch, item.feed);
+    ASSERT_EQ(tensors_expected.size(), 4);
+    auto tensors = EvaluateNodes(output, item.fetch, item.feed);
+    ASSERT_EQ(tensors.size(), 4);
+    test::ExpectClose(tensors[0], tensors_expected[0], 1e-2, /*rtol=*/1e-2);
+    test::ExpectClose(tensors[1], tensors_expected[1], 1e-2, /*rtol=*/1e-2);
+    test::ExpectClose(tensors[2], tensors_expected[2], 1e-2, /*rtol=*/1e-2);
+    test::ExpectClose(tensors[3], tensors_expected[3], 1e-2, /*rtol=*/1e-2);
+  }
+}
 TEST_F(RemapperTest, FuseConv2DWithBias) {
   using ::tensorflow::ops::Placeholder;
 

--- a/tensorflow/core/grappler/optimizers/remapper_test.cc
+++ b/tensorflow/core/grappler/optimizers/remapper_test.cc
@@ -216,11 +216,9 @@ TEST_F(RemapperTest, FuseBatchNormWithRelu) {
   }
 }
 
+#if defined(GOOGLE_CUDA) && CUDNN_VERSION >= 7402
 TEST_F(RemapperTest, FuseBatchNormGradWithReluGrad) {
 
-#if !defined(GOOGLE_CUDA) || !(CUDNN_VERSION >= 7402)
-  GTEST_SKIP() << "No CUDA, skip FuseBatchNormGradWithReluGrad on GPU";
-#endif
   using ::tensorflow::ops::Placeholder;
   tensorflow::Scope s = tensorflow::Scope::NewRootScope();
   bool is_training = true;
@@ -344,6 +342,7 @@ TEST_F(RemapperTest, FuseBatchNormGradWithReluGrad) {
     test::ExpectClose(tensors[2], tensors_expected[2], 1e-2, /*rtol=*/1e-2);
   }
 }
+#endif // defined(GOOGLE_CUDA) && CUDNN_VERSION >= 7402
 
 TEST_F(RemapperTest, FuseBatchNormWithAddAndRelu) {
   using ::tensorflow::ops::Placeholder;
@@ -457,11 +456,9 @@ TEST_F(RemapperTest, FuseBatchNormWithAddAndRelu) {
   }
 }
 
+#if defined(GOOGLE_CUDA) && CUDNN_VERSION >= 7402
 TEST_F(RemapperTest, FuseBatchNormGradWithAddAndReluGrad) {
 
-#if !defined(GOOGLE_CUDA) || !(CUDNN_VERSION >= 7402)
-  GTEST_SKIP() << "No CUDA, skip FuseBatchNormGradWithReluGrad on GPU";
-#endif
   using ::tensorflow::ops::Placeholder;
   tensorflow::Scope s = tensorflow::Scope::NewRootScope();
   bool is_training = true;
@@ -491,29 +488,49 @@ TEST_F(RemapperTest, FuseBatchNormGradWithAddAndReluGrad) {
       ops::FusedBatchNormV3::IsTraining(is_training)
           .Epsilon(epsilon)
           .DataFormat("NHWC"));
-  auto add = ops::Add(s.WithOpName("add"), fbn.y, side_input_cast);
+  auto fbn_side_input = ops::FusedBatchNormV3(
+      s.WithOpName("fused_batch_norm_side_input"),
+      side_input_cast, scale, offset, mean, var,
+      ops::FusedBatchNormV3::IsTraining(is_training)
+          .Epsilon(epsilon)
+          .DataFormat("NHWC"));
+  // Since fbn.y is the first argument of "add" op, "fused_batch_norm" will be
+  // fused (not "fused_batch_norm_side_input"). Correspondingly,
+  // "fused_batch_norm_grad" will be fused (not
+  // "fused_batch_norm_side_input_grad").
+  auto add = ops::Add(s.WithOpName("add"), fbn.y, fbn_side_input.y);
   auto relu = ops::Relu(s.WithOpName("relu"), add);
 
   // Backward pass.
-  auto output_grad = Placeholder(
-      s.WithOpName("output_grad"), DT_FLOAT,
-      ops::Placeholder::Shape({2, 8, 8, num_channels}));
-  auto output_grad_cast = ops::Cast(s.WithOpName("output_grad_cast"),
-                                    output_grad, DT_HALF);
-  auto relu_grad = ops::internal::ReluGrad(
-      s.WithOpName("relu_grad"), output_grad_cast, relu);
-  auto side_input_grad = ops::Identity(s.WithOpName("side_input_grad"),
-                                       relu_grad);
+  auto output_grad =
+      Placeholder(s.WithOpName("output_grad"), DT_FLOAT,
+                  ops::Placeholder::Shape({2, 8, 8, num_channels}));
+  auto output_grad_cast =
+      ops::Cast(s.WithOpName("output_grad_cast"), output_grad, DT_HALF);
+  auto relu_grad = ops::internal::ReluGrad(s.WithOpName("relu_grad"),
+                                           output_grad_cast, relu);
   auto fbn_grad = ops::FusedBatchNormGradV3(
       s.WithOpName("fused_batch_norm_grad"), relu_grad, input_cast, scale,
       fbn.reserve_space_1, fbn.reserve_space_2, fbn.reserve_space_3,
       ops::FusedBatchNormGradV3::IsTraining(is_training)
           .Epsilon(epsilon)
           .DataFormat("NHWC"));
+  auto fbn_side_input_grad = ops::FusedBatchNormGradV3(
+      s.WithOpName("fused_batch_norm_side_input_grad"), relu_grad,
+      side_input_cast, scale, fbn_side_input.reserve_space_1,
+      fbn_side_input.reserve_space_2, fbn_side_input.reserve_space_3,
+      ops::FusedBatchNormGradV3::IsTraining(is_training)
+          .Epsilon(epsilon)
+          .DataFormat("NHWC"));
   auto fetch0 = ops::Identity(s.WithOpName("fetch0"), fbn_grad.x_backprop);
   auto fetch1 = ops::Identity(s.WithOpName("fetch1"), fbn_grad.scale_backprop);
   auto fetch2 = ops::Identity(s.WithOpName("fetch2"), fbn_grad.offset_backprop);
-  auto fetch3 = ops::Identity(s.WithOpName("fetch3"), side_input_grad);
+  auto fetch3 = ops::Identity(s.WithOpName("fetch3"),
+                              fbn_side_input_grad.x_backprop);
+  auto fetch4 = ops::Identity(s.WithOpName("fetch4"),
+                              fbn_side_input_grad.scale_backprop);
+  auto fetch5 = ops::Identity(s.WithOpName("fetch5"),
+                              fbn_side_input_grad.offset_backprop);
 
   auto input_t = GenerateRandomTensor<DT_FLOAT>(input_shape);
   auto scale_t = GenerateRandomTensor<DT_FLOAT>(channel_shape);
@@ -524,10 +541,13 @@ TEST_F(RemapperTest, FuseBatchNormGradWithAddAndReluGrad) {
   auto output_grad_t = GenerateRandomTensor<DT_FLOAT>({2, 8, 8, num_channels});
 
   GrapplerItem item;
-  item.fetch = {"fetch0", "fetch1", "fetch2", "fetch3"};
-  item.feed = {{"input", input_t},   {"scale", scale_t},
-               {"offset", offset_t}, {"mean", mean_t},
-               {"var", var_t},       {"side_input", side_input_t},
+  item.fetch = {"fetch0", "fetch1", "fetch2", "fetch3", "fetch4", "fetch5"};
+  item.feed = {{"input", input_t},
+               {"scale", scale_t},
+               {"offset", offset_t},
+               {"mean", mean_t},
+               {"var", var_t},
+               {"side_input", side_input_t},
                {"output_grad", output_grad_t}};
   TF_ASSERT_OK(s.ToGraphDef(&item.graph));
 
@@ -556,7 +576,7 @@ TEST_F(RemapperTest, FuseBatchNormGradWithAddAndReluGrad) {
       EXPECT_EQ(node.input(2), "offset");
       EXPECT_EQ(node.input(3), "mean");
       EXPECT_EQ(node.input(4), "var");
-      EXPECT_EQ(node.input(5), "side_input_cast");
+      EXPECT_EQ(node.input(5), "fused_batch_norm_side_input");
 
       auto attr = node.attr();
       EXPECT_EQ(attr["num_side_inputs"].i(), 1);
@@ -593,15 +613,19 @@ TEST_F(RemapperTest, FuseBatchNormGradWithAddAndReluGrad) {
 
   if (GetNumAvailableGPUs() > 0) {
     auto tensors_expected = EvaluateNodes(item.graph, item.fetch, item.feed);
-    ASSERT_EQ(tensors_expected.size(), 4);
+    ASSERT_EQ(tensors_expected.size(), 6);
     auto tensors = EvaluateNodes(output, item.fetch, item.feed);
-    ASSERT_EQ(tensors.size(), 4);
+    ASSERT_EQ(tensors.size(), 6);
     test::ExpectClose(tensors[0], tensors_expected[0], 1e-2, /*rtol=*/1e-2);
     test::ExpectClose(tensors[1], tensors_expected[1], 1e-2, /*rtol=*/1e-2);
     test::ExpectClose(tensors[2], tensors_expected[2], 1e-2, /*rtol=*/1e-2);
     test::ExpectClose(tensors[3], tensors_expected[3], 1e-2, /*rtol=*/1e-2);
+    test::ExpectClose(tensors[4], tensors_expected[4], 1e-2, /*rtol=*/1e-2);
+    test::ExpectClose(tensors[5], tensors_expected[5], 1e-2, /*rtol=*/1e-2);
   }
 }
+#endif // defined(GOOGLE_CUDA) && CUDNN_VERSION >= 7402
+
 TEST_F(RemapperTest, FuseConv2DWithBias) {
   using ::tensorflow::ops::Placeholder;
 

--- a/tensorflow/core/kernels/fused_batch_norm_ex_op_test.cc
+++ b/tensorflow/core/kernels/fused_batch_norm_ex_op_test.cc
@@ -204,8 +204,8 @@ class FusedBatchNormExOpTestBase : public OpsTestBase {
         root,
         {"with_activation:0", "fused_batch_norm:1", "fused_batch_norm:2",
          "fused_batch_norm:3", "fused_batch_norm:4", "fused_batch_norm:5",
-         "activation_grad:0", "fused_batch_norm_grad:0",
-         "fused_batch_norm_grad:1", "fused_batch_norm_grad:2"},
+         "fused_batch_norm_grad:0", "fused_batch_norm_grad:1",
+         "fused_batch_norm_grad:2"},
         &out_tensors, /*allow_gpu_device=*/true);
 
     forward->y = out_tensors[0];
@@ -215,10 +215,9 @@ class FusedBatchNormExOpTestBase : public OpsTestBase {
     forward->reserve_space_2 = out_tensors[4];
     forward->reserve_space_3 = out_tensors[5];
 
-    backward->y_backprop = out_tensors[6];
-    backward->x_backprop = out_tensors[7];
-    backward->scale_backprop = out_tensors[8];
-    backward->offset_backprop = out_tensors[9];
+    backward->x_backprop = out_tensors[6];
+    backward->scale_backprop = out_tensors[7];
+    backward->offset_backprop = out_tensors[8];
   }
 
   void RunFusedBatchNormEx(const Tensor& y_backprop_data,
@@ -279,46 +278,71 @@ class FusedBatchNormExOpTestBase : public OpsTestBase {
                      .Attr("is_training", is_training)
                      .Finalize(&fused_batch_norm_ex));
 
+    NodeDef fused_batch_norm_grad;
     NodeDef activation_grad;
-    if (activation_mode == "Relu") {
-      TF_EXPECT_OK(NodeDefBuilder("activation_grad", "ReluGrad")
+    std::vector<Tensor> out_tensors;
+    std::vector<const NodeDef*> add_nodes;
+    if (is_training) {
+      TF_EXPECT_OK(NodeDefBuilder("fused_batch_norm_grad",
+                                  "_FusedBatchNormGradEx")
                        .Input({y_backprop.name(), 0, t_dtype})
+                       .Input({input.name(), 0, t_dtype})
+                       .Input({scale.name(), 0, u_dtype})
+                       .Input({fused_batch_norm_ex.name(), 3, u_dtype})
+                       .Input({fused_batch_norm_ex.name(), 4, u_dtype})
+                       .Input({fused_batch_norm_ex.name(), 5, u_dtype})
+                       .Input({offset.name(), 0, u_dtype})
                        .Input({fused_batch_norm_ex.name(), 0, t_dtype})
                        .Attr("T", t_dtype)
-                       .Finalize(&activation_grad));
+                       .Attr("U", u_dtype)
+                       .Attr("data_format", ToString(data_format))
+                       .Attr("epsilon", epsilon)
+                       .Attr("activation_mode", activation_mode)
+                       .Attr("num_side_inputs", num_side_inputs)
+                       .Attr("is_training", is_training)
+                       .Finalize(&fused_batch_norm_grad));
+      add_nodes = {&fused_batch_norm_ex, &fused_batch_norm_grad};
     } else {
-      TF_EXPECT_OK(NodeDefBuilder("activation_grad", "Identity")
-                       .Input({y_backprop.name(), 0, t_dtype})
+      if (activation_mode == "Relu") {
+        TF_EXPECT_OK(NodeDefBuilder("activation_grad", "ReluGrad")
+                         .Input({y_backprop.name(), 0, t_dtype})
+                         .Input({fused_batch_norm_ex.name(), 0, t_dtype})
+                         .Attr("T", t_dtype)
+                         .Finalize(&activation_grad));
+      } else {
+        TF_EXPECT_OK(NodeDefBuilder("activation_grad", "Identity")
+                         .Input({y_backprop.name(), 0, t_dtype})
+                         .Attr("T", t_dtype)
+                         .Finalize(&activation_grad));
+      }
+      TF_EXPECT_OK(NodeDefBuilder("fused_batch_norm_grad",
+                                  "FusedBatchNormGradV3")
+                       .Input({activation_grad.name(), 0, t_dtype})
+                       .Input({input.name(), 0, t_dtype})
+                       .Input({scale.name(), 0, u_dtype})
+                       .Input({fused_batch_norm_ex.name(), 3, u_dtype})
+                       .Input({fused_batch_norm_ex.name(), 4, u_dtype})
+                       .Input({fused_batch_norm_ex.name(), 5, u_dtype})
                        .Attr("T", t_dtype)
-                       .Finalize(&activation_grad));
+                       .Attr("U", u_dtype)
+                       .Attr("data_format", ToString(data_format))
+                       .Attr("epsilon", epsilon)
+                       .Attr("is_training", is_training)
+                       .Finalize(&fused_batch_norm_grad));
+      add_nodes = {&fused_batch_norm_ex, &activation_grad,
+                   &fused_batch_norm_grad};
     }
 
-    NodeDef fused_batch_norm_grad;
-    TF_EXPECT_OK(NodeDefBuilder("fused_batch_norm_grad", "FusedBatchNormGradV3")
-                     .Input({activation_grad.name(), 0, t_dtype})
-                     .Input({input.name(), 0, t_dtype})
-                     .Input({scale.name(), 0, u_dtype})
-                     .Input({fused_batch_norm_ex.name(), 3, u_dtype})
-                     .Input({fused_batch_norm_ex.name(), 4, u_dtype})
-                     .Input({fused_batch_norm_ex.name(), 5, u_dtype})
-                     .Attr("T", t_dtype)
-                     .Attr("U", u_dtype)
-                     .Attr("data_format", ToString(data_format))
-                     .Attr("epsilon", epsilon)
-                     .Attr("is_training", is_training)
-                     .Finalize(&fused_batch_norm_grad));
-
-    std::vector<Tensor> out_tensors;
     RunAndFetch(
         root,
         {"fused_batch_norm_ex:0", "fused_batch_norm_ex:1",
          "fused_batch_norm_ex:2", "fused_batch_norm_ex:3",
-         "fused_batch_norm_ex:4", "fused_batch_norm_ex:5", "activation_grad:0",
+         "fused_batch_norm_ex:4", "fused_batch_norm_ex:5",
          "fused_batch_norm_grad:0", "fused_batch_norm_grad:1",
          "fused_batch_norm_grad:2"},
         &out_tensors,
         /*allow_gpu_device=*/true,
-        {&fused_batch_norm_ex, &activation_grad, &fused_batch_norm_grad});
+        add_nodes);
 
     forward->y = out_tensors[0];
     forward->batch_mean = out_tensors[1];
@@ -327,10 +351,9 @@ class FusedBatchNormExOpTestBase : public OpsTestBase {
     forward->reserve_space_2 = out_tensors[4];
     forward->reserve_space_3 = out_tensors[5];
 
-    backward->y_backprop = out_tensors[6];
-    backward->x_backprop = out_tensors[7];
-    backward->scale_backprop = out_tensors[8];
-    backward->offset_backprop = out_tensors[9];
+    backward->x_backprop = out_tensors[6];
+    backward->scale_backprop = out_tensors[7];
+    backward->offset_backprop = out_tensors[8];
   }
 
   void VerifyTensorsNear(int batch, int height, int width, int channels,

--- a/tensorflow/core/kernels/fused_batch_norm_op.cc
+++ b/tensorflow/core/kernels/fused_batch_norm_op.cc
@@ -344,10 +344,23 @@ template <typename T, typename U>
 struct FusedBatchNormGrad<CPUDevice, T, U> {
   void operator()(OpKernelContext* context, const Tensor& y_backprop_input,
                   const Tensor& x_input, const Tensor& scale_input,
-                  const Tensor& mean_input, const Tensor& variance_input,
-                  U epsilon, Tensor* x_backprop_output,
-                  Tensor* scale_backprop_output, Tensor* offset_backprop_output,
-                  bool use_reserved_space, TensorFormat tensor_format) {
+                  const Tensor* offset_input, const Tensor& mean_input,
+                  const Tensor& variance_input, const Tensor* y_input,
+                  U epsilon, FusedBatchNormActivationMode activation_mode,
+                  Tensor* x_backprop_output, Tensor* scale_backprop_output,
+                  Tensor* offset_backprop_output,
+                  Tensor* side_input_backprop_output, bool use_reserved_space,
+                  TensorFormat tensor_format) {
+    OP_REQUIRES(context,
+                y_input == nullptr &&
+                activation_mode == FusedBatchNormActivationMode::kIdentity,
+                errors::Internal(
+                    "The CPU implementation of FusedBatchNormGrad does not "
+                    "support activations."));
+    OP_REQUIRES(context, side_input_backprop_output == nullptr,
+                errors::Internal("The CPU implementation of FusedBatchNormGrad "
+                                 "does not support side input."));
+ 
     Tensor transformed_y_backprop_input;
     Tensor transformed_x_input;
     Tensor transformed_x_backprop_output;
@@ -986,9 +999,12 @@ struct FusedBatchNorm<GPUDevice, T, U, is_training> {
 template <typename T, typename U>
 struct FusedBatchNormGrad<GPUDevice, T, U> {
   void operator()(OpKernelContext* context, const Tensor& y_backprop,
-                  const Tensor& x, const Tensor& scale, const Tensor& mean,
-                  const Tensor& inv_variance, U epsilon, Tensor* x_backprop,
-                  Tensor* scale_backprop, Tensor* offset_backprop,
+                  const Tensor& x, const Tensor& scale, const Tensor* offset,
+                  const Tensor& mean, const Tensor& inv_variance,
+                  const Tensor* y, U epsilon,
+                  FusedBatchNormActivationMode activation_mode,
+                  Tensor* x_backprop, Tensor* scale_backprop,
+                  Tensor* offset_backprop, Tensor* side_input_backprop,
                   bool use_reserved_space, TensorFormat tensor_format) {
     auto* stream = context->op_device_context()->stream();
     OP_REQUIRES(context, stream, errors::Internal("No GPU stream available"));
@@ -1022,6 +1038,7 @@ struct FusedBatchNormGrad<GPUDevice, T, U> {
             << " y_backprop shape: " << y_backprop.shape().DebugString()
             << " x shape: " << x.shape().DebugString()
             << " scale shape: " << scale.shape().DebugString()
+            << " activation mode: " << ToString(activation_mode)
             << " tensor format: " << ToString(tensor_format)
             << " compute format: " << ToString(compute_format);
 
@@ -1099,12 +1116,21 @@ struct FusedBatchNormGrad<GPUDevice, T, U> {
         StreamExecutorUtil::AsDeviceMemory<T>(y_backprop_maybe_transformed);
     auto x_ptr = StreamExecutorUtil::AsDeviceMemory<T>(x_maybe_transformed);
     auto scale_ptr = StreamExecutorUtil::AsDeviceMemory<U>(scale);
+    auto offset_ptr = offset != nullptr
+                          ? StreamExecutorUtil::AsDeviceMemory<U>(*offset)
+                          : se::DeviceMemory<U>();
     auto mean_ptr = StreamExecutorUtil::AsDeviceMemory<U>(mean);
     auto inv_variance_ptr = StreamExecutorUtil::AsDeviceMemory<U>(inv_variance);
+    auto y_ptr = y != nullptr ? StreamExecutorUtil::AsDeviceMemory<T>(*y)
+                              : se::DeviceMemory<T>();
     auto scale_backprop_ptr =
         StreamExecutorUtil::AsDeviceMemory<U>(*scale_backprop);
     auto offset_backprop_ptr =
         StreamExecutorUtil::AsDeviceMemory<U>(*offset_backprop);
+    auto side_input_backprop_ptr =
+        side_input_backprop != nullptr
+            ? StreamExecutorUtil::AsDeviceMemory<T>(*side_input_backprop)
+            : se::DeviceMemory<T>();
 
     std::unique_ptr<functor::CudnnBatchNormAllocatorInTemp<uint8>>
         workspace_allocator;
@@ -1129,10 +1155,13 @@ struct FusedBatchNormGrad<GPUDevice, T, U> {
     bool cudnn_launch_status =
         stream
             ->ThenBatchNormalizationBackward(
-                y_backprop_ptr, x_ptr, scale_ptr, mean_ptr, inv_variance_ptr,
-                x_desc, scale_offset_desc, static_cast<double>(epsilon),
-                &x_backprop_ptr, &scale_backprop_ptr, &offset_backprop_ptr,
-                reserve_space_data_ptr, workspace_allocator.get())
+                y_backprop_ptr, x_ptr, scale_ptr, offset_ptr, mean_ptr,
+                inv_variance_ptr, y_ptr, x_desc, scale_offset_desc,
+                static_cast<double>(epsilon),
+                AsDnnActivationMode(activation_mode), &x_backprop_ptr,
+                &scale_backprop_ptr, &offset_backprop_ptr,
+                &side_input_backprop_ptr, reserve_space_data_ptr,
+                workspace_allocator.get())
             .ok();
 
     if (!cudnn_launch_status) {
@@ -1410,8 +1439,11 @@ class FusedBatchNormOpEx : public FusedBatchNormOpBase<Device, T, U> {
 
 template <typename Device, typename T, typename U>
 class FusedBatchNormGradOpBase : public OpKernel {
+  using FbnActivationMode = functor::FusedBatchNormActivationMode;
+
  protected:
-  explicit FusedBatchNormGradOpBase(OpKernelConstruction* context)
+  explicit FusedBatchNormGradOpBase(OpKernelConstruction* context,
+                                    bool is_batch_norm_grad_ex = false)
       : OpKernel(context) {
     float epsilon;
     OP_REQUIRES_OK(context, context->GetAttr("epsilon", &epsilon));
@@ -1421,6 +1453,42 @@ class FusedBatchNormGradOpBase : public OpKernel {
     OP_REQUIRES(context, FormatFromString(tensor_format, &tensor_format_),
                 errors::InvalidArgument("Invalid data format"));
     OP_REQUIRES_OK(context, context->GetAttr("is_training", &is_training_));
+    if (!is_batch_norm_grad_ex) {
+      has_side_input_ = false;
+      activation_mode_ = FbnActivationMode::kIdentity;
+    } else {
+      OP_REQUIRES_OK(context, ParseActivationMode(context, &activation_mode_));
+
+      int num_side_inputs;
+      OP_REQUIRES_OK(context,
+                     context->GetAttr("num_side_inputs", &num_side_inputs));
+      OP_REQUIRES(context, num_side_inputs >= 0 && num_side_inputs <= 1,
+                  errors::InvalidArgument(
+                      "FusedBatchNormGrad accepts at most one side input."));
+      has_side_input_ = (num_side_inputs == 1);
+      if (has_side_input_ && is_training_) {
+        OP_REQUIRES(
+            context, activation_mode_ != FbnActivationMode::kIdentity,
+            errors::InvalidArgument("Identity activation is not supported with "
+                                    "non-empty side input"));
+      }
+    }
+
+    if (activation_mode_ != FbnActivationMode::kIdentity && is_training_) {
+      // NOTE(kaixih@nvidia): Following requirements are coming from
+      // implementation details of cudnnBatchNormalizationBackwardEx used in
+      // training mode.
+      OP_REQUIRES(context, DataTypeToEnum<T>::value == DT_HALF,
+                  errors::InvalidArgument("FusedBatchNormGrad with activation "
+                                          "supports only DT_HALF data type."));
+      OP_REQUIRES(context, tensor_format_ == FORMAT_NHWC,
+                  errors::InvalidArgument("FusedBatchNormGrad with activation "
+                                          "supports only NHWC tensor format."));
+      OP_REQUIRES(context, functor::BatchnormSpatialPersistentEnabled(),
+                  errors::InvalidArgument(
+                      "FusedBatchNormGrad with activation must run with cuDNN "
+                      "spatial persistence mode enabled."));
+    }
   }
 
   virtual void ComputeWithReservedSpace(OpKernelContext* context,
@@ -1436,6 +1504,9 @@ class FusedBatchNormGradOpBase : public OpKernel {
     // The Eigen implementation saves variance in the forward pass, while cuDNN
     // saves inverted variance.
     const Tensor& saved_maybe_inv_var_or_pop_var = context->input(4);
+    bool use_activation = activation_mode_ != FbnActivationMode::kIdentity;
+    const Tensor* offset = use_activation ? &context->input(6) : nullptr;
+    const Tensor* y = use_activation ? &context->input(7) : nullptr;
 
     OP_REQUIRES(context, y_backprop.dims() == 4 || y_backprop.dims() == 5,
                 errors::InvalidArgument("input must be 4 or 5-dimensional",
@@ -1454,6 +1525,14 @@ class FusedBatchNormGradOpBase : public OpKernel {
                 errors::InvalidArgument(
                     "saved variance must be 1-dimensional",
                     saved_maybe_inv_var_or_pop_var.shape().DebugString()));
+    if (use_activation) {
+      OP_REQUIRES(context, x.dim_size(3) % 4 == 0,
+          errors::InvalidArgument("FusedBatchNormGrad with activation requires "
+                                  "channel dimension to be a multiple of 4."));
+      OP_REQUIRES(context, offset->dims() == 1,
+                  errors::InvalidArgument("offset must be 1-dimensional",
+                                          offset->shape().DebugString()));
+    }
     bool use_reshape = (x.dims() == 5);
     auto x_shape = x.shape();
     TensorShape dest_shape;
@@ -1493,6 +1572,13 @@ class FusedBatchNormGradOpBase : public OpKernel {
     OP_REQUIRES_OK(
         context, context->allocate_output(4, TensorShape({0}), &placeholder_2));
 
+    Tensor* side_input_backprop = nullptr;
+    if (has_side_input_) {
+      OP_REQUIRES_OK(context,
+                     context->allocate_output(5, alloc_shape,
+                                              &side_input_backprop));
+    }
+
     // If input is empty, set gradients w.r.t scale/offset to zero.
     if (x.shape().num_elements() == 0) {
       functor::SetZeroFunctor<Device, U> f;
@@ -1503,10 +1589,16 @@ class FusedBatchNormGradOpBase : public OpKernel {
 
     if (is_training_) {
       functor::FusedBatchNormGrad<Device, T, U>()(
-          context, y_backprop, x, scale, saved_mean_or_pop_mean,
-          saved_maybe_inv_var_or_pop_var, epsilon_, x_backprop, scale_backprop,
-          offset_backprop, use_reserved_space, tensor_format_);
+          context, y_backprop, x, scale, offset, saved_mean_or_pop_mean,
+          saved_maybe_inv_var_or_pop_var, y, epsilon_, activation_mode_,
+          x_backprop, scale_backprop, offset_backprop, side_input_backprop,
+          use_reserved_space, tensor_format_);
     } else {
+      OP_REQUIRES(context, activation_mode_ == FbnActivationMode::kIdentity &&
+                           !has_side_input_,
+                  errors::InvalidArgument(
+                      "FusedBatchNormGrad with activation is only supported "
+                      "when is_training=True."));
       // Necessary layout conversion is currently done in python.
       OP_REQUIRES(context, tensor_format_ == FORMAT_NHWC,
                   errors::InvalidArgument(
@@ -1528,6 +1620,8 @@ class FusedBatchNormGradOpBase : public OpKernel {
   U epsilon_;
   TensorFormat tensor_format_;
   bool is_training_;
+  bool has_side_input_;
+  FbnActivationMode activation_mode_;
 };
 
 template <typename Device, typename T, typename U>
@@ -1553,6 +1647,22 @@ class FusedBatchNormGradOpV3 : public FusedBatchNormGradOpBase<Device, T, U> {
                                                                      true);
   }
 };
+
+template <typename Device, typename T, typename U>
+class FusedBatchNormGradOpEx : public FusedBatchNormGradOpBase<Device, T, U> {
+  static constexpr bool kWithSideInputAndActivation = true;
+
+ public:
+  explicit FusedBatchNormGradOpEx(OpKernelConstruction* context)
+      : FusedBatchNormGradOpBase<Device, T, U>(context,
+                                               kWithSideInputAndActivation) {}
+
+  void Compute(OpKernelContext* context) override {
+    FusedBatchNormGradOpBase<Device, T, U>::ComputeWithReservedSpace(context,
+                                                                     true);
+  }
+};
+
 
 REGISTER_KERNEL_BUILDER(
     Name("FusedBatchNorm").Device(DEVICE_CPU).TypeConstraint<float>("T"),
@@ -1662,6 +1772,12 @@ REGISTER_KERNEL_BUILDER(Name("FusedBatchNormGradV3")
                             .TypeConstraint<float>("U"),
                         FusedBatchNormGradOpV3<GPUDevice, float, float>);
 
+REGISTER_KERNEL_BUILDER(Name("_FusedBatchNormGradEx")
+                            .Device(DEVICE_GPU)
+                            .TypeConstraint<float>("T")
+                            .TypeConstraint<float>("U"),
+                        FusedBatchNormGradOpEx<GPUDevice, float, float>);
+
 REGISTER_KERNEL_BUILDER(Name("FusedBatchNormV3")
                             .Device(DEVICE_GPU)
                             .TypeConstraint<Eigen::half>("T")
@@ -1679,6 +1795,12 @@ REGISTER_KERNEL_BUILDER(Name("FusedBatchNormGradV3")
                             .TypeConstraint<Eigen::half>("T")
                             .TypeConstraint<float>("U"),
                         FusedBatchNormGradOpV3<GPUDevice, Eigen::half, float>);
+
+REGISTER_KERNEL_BUILDER(Name("_FusedBatchNormGradEx")
+                            .Device(DEVICE_GPU)
+                            .TypeConstraint<Eigen::half>("T")
+                            .TypeConstraint<float>("U"),
+                        FusedBatchNormGradOpEx<GPUDevice, Eigen::half, float>);
 
 #endif
 

--- a/tensorflow/core/ops/nn_ops.cc
+++ b/tensorflow/core/ops/nn_ops.cc
@@ -301,6 +301,36 @@ REGISTER_OP("FusedBatchNormGradV3")
     .Attr(GetConvnetDataFormat2D3DAttrString())
     .Attr("is_training: bool = true")
     .SetShapeFn(shape_inference::FusedBatchNormGradShape);
+
+REGISTER_OP("_FusedBatchNormGradEx")
+    .Input("y_backprop: T")
+    .Input("x: T")
+    .Input("scale: float")
+    .Input("reserve_space_1: U")
+    .Input("reserve_space_2: U")
+    .Input("reserve_space_3: U")
+    .Input("offset: float")
+    .Input("y: T")
+    .Output("x_backprop: T")
+    .Output("scale_backprop: U")
+    .Output("offset_backprop: U")
+    .Output("reserve_space_4: U")
+    .Output("reserve_space_5: U")
+    .Output("side_input_backprop: num_side_inputs * T")
+    .Attr("T: {half, float}")
+    .Attr("U: {float}")
+    .Attr("epsilon: float = 0.0001")
+    .Attr("num_side_inputs: int >= 0 = 0")
+    .Attr("activation_mode: string = \"Identity\"")
+    .Attr(GetConvnetDataFormat2D3DAttrString())
+    .Attr("is_training: bool = true")
+    .SetShapeFn(shape_inference::FusedBatchNormGradShape)
+    .Doc(R"doc(
+Internal FusedBatchNormGrad operation: reserved for internal use.
+
+Do not invoke this operator directly in Python. A fusion optimization is
+expected to create these operators.
+)doc");
 // --------------------------------------------------------------------------
 
 REGISTER_OP("BiasAdd")

--- a/tensorflow/stream_executor/cuda/cuda_dnn.cc
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.cc
@@ -1806,6 +1806,7 @@ port::StatusOr<DeviceMemory<uint8>> CreateBatchNormForwardWorkspace(
 port::StatusOr<DeviceMemory<uint8>> CreateBatchNormBackwardWorkspace(
     Stream* stream, const CudnnHandle& cudnn, const cudnnBatchNormMode_t& mode,
     const cudnnBatchNormOps_t& bn_ops,
+    const cudnnActivationDescriptor_t& activation_desc,
     const CudnnTensorDescriptor& x_descriptor,
     const CudnnTensorDescriptor& scale_offset_descriptor,
     ScratchAllocator* workspace_allocator) {
@@ -1816,10 +1817,11 @@ port::StatusOr<DeviceMemory<uint8>> CreateBatchNormBackwardWorkspace(
       /*xDesc=*/x_descriptor.handle(),
       /*yDesc=*/x_descriptor.handle(),
       /*dyDesc=*/x_descriptor.handle(),
-      /*dzDesc=*/nullptr,
+      /*dzDesc=*/x_descriptor.handle(),
       /*dxDesc=*/x_descriptor.handle(),
       /*dBnScaleBiasDesc=*/scale_offset_descriptor.handle(),
-      /*activationDesc=*/nullptr, /*sizeInBytes=*/&workspace_size_in_bytes));
+      /*activationDesc=*/activation_desc,
+      /*sizeInBytes=*/&workspace_size_in_bytes));
   // Allocate the workspace.
   if (workspace_size_in_bytes == 0) {
     return DeviceMemory<uint8>();
@@ -4872,17 +4874,20 @@ port::Status CudnnSupport::DoBatchNormalizationForwardImpl(
 bool CudnnSupport::DoBatchNormalizationBackward(
     Stream* stream, const DeviceMemory<float>& y_backprop,
     const DeviceMemory<float>& x, const DeviceMemory<float>& scale,
-    const DeviceMemory<float>& mean, const DeviceMemory<float>& inv_var,
+    const DeviceMemory<float>& offset, const DeviceMemory<float>& mean,
+    const DeviceMemory<float>& inv_var, const DeviceMemory<float>& y,
     const dnn::BatchDescriptor& x_desc,
     const dnn::BatchDescriptor& scale_offset_desc, const double epsilon,
-    DeviceMemory<float>* x_backprop, DeviceMemory<float>* scale_backprop,
-    DeviceMemory<float>* offset_backprop,
+    dnn::ActivationMode activation_mode, DeviceMemory<float>* x_backprop,
+    DeviceMemory<float>* scale_backprop, DeviceMemory<float>* offset_backprop,
+    DeviceMemory<float>* side_input_backprop,
     DeviceMemory<uint8>* reserve_space_data,
     ScratchAllocator* workspace_allocator) {
   return IsStatusOk(DoBatchNormalizationBackwardImpl(
                         stream, CUDNN_DATA_FLOAT, CUDNN_DATA_FLOAT, y_backprop,
-                        x, scale, mean, inv_var, x_desc, scale_offset_desc,
-                        epsilon, x_backprop, scale_backprop, offset_backprop,
+                        x, scale, offset, mean, inv_var, y, x_desc,
+                        scale_offset_desc, epsilon, activation_mode, x_backprop,
+                        scale_backprop, offset_backprop, side_input_backprop,
                         reserve_space_data, workspace_allocator),
                     /*report_error=*/true);
 }
@@ -4890,17 +4895,20 @@ bool CudnnSupport::DoBatchNormalizationBackward(
 bool CudnnSupport::DoBatchNormalizationBackward(
     Stream* stream, const DeviceMemory<Eigen::half>& y_backprop,
     const DeviceMemory<Eigen::half>& x, const DeviceMemory<float>& scale,
-    const DeviceMemory<float>& mean, const DeviceMemory<float>& inv_var,
+    const DeviceMemory<float>& offset, const DeviceMemory<float>& mean,
+    const DeviceMemory<float>& inv_var, const DeviceMemory<Eigen::half>& y,
     const dnn::BatchDescriptor& x_desc,
     const dnn::BatchDescriptor& scale_offset_desc, const double epsilon,
-    DeviceMemory<Eigen::half>* x_backprop, DeviceMemory<float>* scale_backprop,
-    DeviceMemory<float>* offset_backprop,
+    dnn::ActivationMode activation_mode, DeviceMemory<Eigen::half>* x_backprop,
+    DeviceMemory<float>* scale_backprop, DeviceMemory<float>* offset_backprop,
+    DeviceMemory<Eigen::half>* side_input_backprop,
     DeviceMemory<uint8>* reserve_space_data,
     ScratchAllocator* workspace_allocator) {
   return IsStatusOk(DoBatchNormalizationBackwardImpl(
                         stream, CUDNN_DATA_HALF, CUDNN_DATA_FLOAT, y_backprop,
-                        x, scale, mean, inv_var, x_desc, scale_offset_desc,
-                        epsilon, x_backprop, scale_backprop, offset_backprop,
+                        x, scale, offset, mean, inv_var, y, x_desc,
+                        scale_offset_desc, epsilon, activation_mode, x_backprop,
+                        scale_backprop, offset_backprop, side_input_backprop,
                         reserve_space_data, workspace_allocator),
                     /*report_error=*/true);
 }
@@ -4909,11 +4917,14 @@ template <class T, class U>
 port::Status CudnnSupport::DoBatchNormalizationBackwardImpl(
     Stream* stream, int cudnn_input_type, int cudnn_scale_type,
     const DeviceMemory<T>& y_backprop, const DeviceMemory<T>& x,
-    const DeviceMemory<U>& scale, const DeviceMemory<U>& mean,
-    const DeviceMemory<U>& inv_var, const dnn::BatchDescriptor& x_desc,
+    const DeviceMemory<U>& scale, const DeviceMemory<U>& offset,
+    const DeviceMemory<U>& mean, const DeviceMemory<U>& inv_var,
+    const DeviceMemory<T>& y, const dnn::BatchDescriptor& x_desc,
     const dnn::BatchDescriptor& scale_offset_desc, const double epsilon,
-    DeviceMemory<T>* x_backprop, DeviceMemory<U>* scale_backprop,
-    DeviceMemory<U>* offset_backprop, DeviceMemory<uint8>* reserve_space_data,
+    dnn::ActivationMode activation_mode, DeviceMemory<T>* x_backprop,
+    DeviceMemory<U>* scale_backprop, DeviceMemory<U>* offset_backprop,
+    DeviceMemory<T>* side_input_backprop,
+    DeviceMemory<uint8>* reserve_space_data,
     ScratchAllocator* workspace_allocator) {
   CudnnTensorDescriptor x_descriptor(
       x_desc, static_cast<cudnnDataType_t>(cudnn_input_type));
@@ -4932,10 +4943,26 @@ port::Status CudnnSupport::DoBatchNormalizationBackwardImpl(
 #if CUDNN_VERSION >= 7402
   if (reserve_space_data != nullptr && workspace_allocator != nullptr) {
     called = true;
-    const cudnnBatchNormOps_t bn_ops = CUDNN_BATCHNORM_OPS_BN;
+    const auto get_bn_ops = [&]() -> cudnnBatchNormOps_t {
+      if (side_input_backprop->is_null()) {
+        return activation_mode == dnn::ActivationMode::kNone
+                   ? CUDNN_BATCHNORM_OPS_BN
+                   : CUDNN_BATCHNORM_OPS_BN_ACTIVATION;
+      } else {
+        return CUDNN_BATCHNORM_OPS_BN_ADD_ACTIVATION;
+      }
+    };
+    const cudnnBatchNormOps_t bn_ops = get_bn_ops();
+
+    // We use Nan propagation to be consistent with
+    // CudnnSupport::DoActivate(...).
+    CudnnActivationDescriptor activation_desc(
+        activation_mode, CUDNN_PROPAGATE_NAN, x_desc.value_max());
+
     SE_ASSIGN_OR_RETURN(DeviceMemory<uint8> workspace,
                         CreateBatchNormBackwardWorkspace(
-                            stream, cudnn, mode, bn_ops, x_descriptor,
+                            stream, cudnn, mode, bn_ops,
+                            activation_desc.handle(), x_descriptor,
                             scale_offset_descriptor, workspace_allocator))
     RETURN_IF_CUDNN_ERROR(cudnnBatchNormalizationBackwardEx(
         /*handle=*/cudnn.handle(),
@@ -4947,30 +4974,44 @@ port::Status CudnnSupport::DoBatchNormalizationBackwardImpl(
         /*betaParamDiff=*/&zero,
         /*xDesc=*/x_descriptor.handle(),
         /*xData=*/x.opaque(),
-        /*yDesc=*/nullptr,
-        /*yData=*/nullptr,
+        /*yDesc=*/x_descriptor.handle(),
+        /*yData=*/y.opaque(),
         /*dyDesc=*/x_descriptor.handle(),
         /*dyData=*/y_backprop.opaque(),
-        /*dzDesc=*/nullptr,
-        /*dzData=*/nullptr,
+        /*dzDesc=*/x_descriptor.handle(),
+        /*dzData=*/side_input_backprop->opaque(),
         /*dxDesc=*/x_descriptor.handle(),
         /*dxData=*/x_backprop->opaque(),
         /*dBnScaleBiasDesc=*/scale_offset_descriptor.handle(),
         /*bnScaleData=*/scale.opaque(),
-        /*bnBiasData=*/nullptr,
+        /*bnBiasData=*/offset.opaque(),
         /*dBnScaleData=*/scale_backprop->opaque(),
         /*dBnBiasData=*/offset_backprop->opaque(),
         /*epsilon=*/epsilon,
         /*savedMean=*/mean.opaque(),
         /*savedInvVariance=*/inv_var.opaque(),
-        /*activationDesc=*/nullptr,
+        /*activationDesc=*/activation_desc.handle(),
         /*workspace=*/workspace.opaque(),
         /*workSpaceSizeInBytes=*/workspace.size(),
         /*reserveSpace=*/reserve_space_data->opaque(),
         /*reserveSpaceSizeInBytes=*/reserve_space_data->size()));
   }
 #endif
+  auto check_no_side_input_or_activation = [&]() -> port::Status {
+    if (activation_mode != dnn::ActivationMode::kNone ||
+        !side_input_backprop->is_null()) {
+      return port::Status(
+          port::error::INTERNAL,
+          absl::StrCat(
+              "Side input and activation are not supported by cuDNN version: ",
+              CUDNN_VERSION));
+    } else {
+      return port::Status::OK();
+    }
+  };
+
   if (!called) {
+    SE_RETURN_IF_ERROR(check_no_side_input_or_activation());
     RETURN_IF_CUDNN_ERROR(cudnnBatchNormalizationBackward(
         cudnn.handle(), mode, &one, &zero, &one, &zero, x_descriptor.handle(),
         x.opaque(), x_descriptor.handle(), y_backprop.opaque(),

--- a/tensorflow/stream_executor/cuda/cuda_dnn.h
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.h
@@ -272,22 +272,27 @@ class CudnnSupport : public dnn::DnnSupport {
   bool DoBatchNormalizationBackward(
       Stream* stream, const DeviceMemory<float>& y_backprop,
       const DeviceMemory<float>& x, const DeviceMemory<float>& scale,
-      const DeviceMemory<float>& mean, const DeviceMemory<float>& inv_var,
+      const DeviceMemory<float>& offset, const DeviceMemory<float>& mean,
+      const DeviceMemory<float>& inv_var, const DeviceMemory<float>& y,
       const dnn::BatchDescriptor& x_desc,
       const dnn::BatchDescriptor& scale_offset_desc, const double epsilon,
-      DeviceMemory<float>* x_backprop, DeviceMemory<float>* scale_backprop,
-      DeviceMemory<float>* offset_backprop,
+      dnn::ActivationMode activation_mode, DeviceMemory<float>* x_backprop,
+      DeviceMemory<float>* scale_backprop, DeviceMemory<float>* offset_backprop,
+      DeviceMemory<float>* side_input_backprop,
       DeviceMemory<uint8>* reserve_space_data,
       ScratchAllocator* workspace_allocator) override;
 
   bool DoBatchNormalizationBackward(
       Stream* stream, const DeviceMemory<Eigen::half>& y_backprop,
       const DeviceMemory<Eigen::half>& x, const DeviceMemory<float>& scale,
-      const DeviceMemory<float>& mean, const DeviceMemory<float>& inv_var,
+      const DeviceMemory<float>& offset, const DeviceMemory<float>& mean,
+      const DeviceMemory<float>& inv_var, const DeviceMemory<Eigen::half>& y,
       const dnn::BatchDescriptor& x_desc,
       const dnn::BatchDescriptor& scale_offset_desc, const double epsilon,
+      dnn::ActivationMode activation_mode,
       DeviceMemory<Eigen::half>* x_backprop,
       DeviceMemory<float>* scale_backprop, DeviceMemory<float>* offset_backprop,
+      DeviceMemory<Eigen::half>* side_input_backprop,
       DeviceMemory<uint8>* reserve_space_data,
       ScratchAllocator* workspace_allocator) override;
 
@@ -602,11 +607,14 @@ class CudnnSupport : public dnn::DnnSupport {
   port::Status DoBatchNormalizationBackwardImpl(
       Stream* stream, int cudnn_input_type, int cudnn_scale_type,
       const DeviceMemory<T>& y_backprop, const DeviceMemory<T>& x,
-      const DeviceMemory<U>& scale, const DeviceMemory<U>& mean,
-      const DeviceMemory<U>& inv_var, const dnn::BatchDescriptor& x_desc,
+      const DeviceMemory<U>& scale, const DeviceMemory<U>& offset,
+      const DeviceMemory<U>& mean, const DeviceMemory<U>& inv_var,
+      const DeviceMemory<T>& y, const dnn::BatchDescriptor& x_desc,
       const dnn::BatchDescriptor& scale_offset_desc, const double epsilon,
-      DeviceMemory<T>* x_backprop, DeviceMemory<U>* scale_backprop,
-      DeviceMemory<U>* offset_backprop, DeviceMemory<uint8>* reserve_space_data,
+      dnn::ActivationMode activation_mode, DeviceMemory<T>* x_backprop,
+      DeviceMemory<U>* scale_backprop, DeviceMemory<U>* offset_backprop,
+      DeviceMemory<T>* side_input_backprop,
+      DeviceMemory<uint8>* reserve_space_data,
       ScratchAllocator* workspace_allocator);
 
   template <typename ScaleType>

--- a/tensorflow/stream_executor/dnn.h
+++ b/tensorflow/stream_executor/dnn.h
@@ -1113,11 +1113,13 @@ class DnnSupport {
   virtual bool DoBatchNormalizationBackward(
       Stream* stream, const DeviceMemory<float>& y_backprop,
       const DeviceMemory<float>& x, const DeviceMemory<float>& scale,
-      const DeviceMemory<float>& mean, const DeviceMemory<float>& inv_var,
+      const DeviceMemory<float>& offset, const DeviceMemory<float>& mean,
+      const DeviceMemory<float>& inv_var, const DeviceMemory<float>& y,
       const dnn::BatchDescriptor& x_desc,
       const dnn::BatchDescriptor& scale_offset_desc, const double epsilon,
-      DeviceMemory<float>* x_backprop, DeviceMemory<float>* scale_backprop,
-      DeviceMemory<float>* offset_backprop,
+      dnn::ActivationMode activation_mode, DeviceMemory<float>* x_backprop,
+      DeviceMemory<float>* scale_backprop, DeviceMemory<float>* offset_backprop,
+      DeviceMemory<float>* side_input_backprop,
       DeviceMemory<uint8>* reserve_space_data,
       ScratchAllocator* workspace_allocator) {
     return false;
@@ -1129,11 +1131,14 @@ class DnnSupport {
   virtual bool DoBatchNormalizationBackward(
       Stream* stream, const DeviceMemory<Eigen::half>& y_backprop,
       const DeviceMemory<Eigen::half>& x, const DeviceMemory<float>& scale,
-      const DeviceMemory<float>& mean, const DeviceMemory<float>& inv_var,
+      const DeviceMemory<float>& offset, const DeviceMemory<float>& mean,
+      const DeviceMemory<float>& inv_var, const DeviceMemory<Eigen::half>& y,
       const dnn::BatchDescriptor& x_desc,
       const dnn::BatchDescriptor& scale_offset_desc, const double epsilon,
+      dnn::ActivationMode activation_mode,
       DeviceMemory<Eigen::half>* x_backprop,
       DeviceMemory<float>* scale_backprop, DeviceMemory<float>* offset_backprop,
+      DeviceMemory<Eigen::half>* side_input_backprop,
       DeviceMemory<uint8>* reserve_space_data,
       ScratchAllocator* workspace_allocator) {
     return false;

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -3605,11 +3605,13 @@ bool MIOpenSupport::DoBatchNormalizationForwardImpl(
 bool MIOpenSupport::DoBatchNormalizationBackward(
     Stream* stream, const DeviceMemory<Eigen::half>& y_backprop,
     const DeviceMemory<Eigen::half>& x, const DeviceMemory<float>& scale,
-    const DeviceMemory<float>& mean, const DeviceMemory<float>& inv_var,
+    const DeviceMemory<float>& offset, const DeviceMemory<float>& mean,
+    const DeviceMemory<float>& inv_var, const DeviceMemory<Eigen::half>& y,
     const dnn::BatchDescriptor& x_desc,
     const dnn::BatchDescriptor& scale_offset_desc, const double epsilon,
-    DeviceMemory<Eigen::half>* x_backprop, DeviceMemory<float>* scale_backprop,
-    DeviceMemory<float>* offset_backprop,
+    dnn::ActivationMode activation_mode, DeviceMemory<Eigen::half>* x_backprop,
+    DeviceMemory<float>* scale_backprop, DeviceMemory<float>* offset_backprop,
+    DeviceMemory<Eigen::half>* side_input_backprop,
     DeviceMemory<uint8>* reserve_space_data,
     ScratchAllocator* workspace_allocator) {
   return DoBatchNormalizationBackwardImpl<Eigen::half, float>(
@@ -3621,11 +3623,13 @@ bool MIOpenSupport::DoBatchNormalizationBackward(
 bool MIOpenSupport::DoBatchNormalizationBackward(
     Stream* stream, const DeviceMemory<float>& y_backprop,
     const DeviceMemory<float>& x, const DeviceMemory<float>& scale,
-    const DeviceMemory<float>& mean, const DeviceMemory<float>& variance,
+    const DeviceMemory<float>& offset, const DeviceMemory<float>& mean,
+    const DeviceMemory<float>& variance, const DeviceMemory<float>& y,
     const dnn::BatchDescriptor& x_desc,
     const dnn::BatchDescriptor& scale_offset_desc, const double epsilon,
-    DeviceMemory<float>* x_backprop, DeviceMemory<float>* scale_backprop,
-    DeviceMemory<float>* offset_backprop,
+    dnn::ActivationMode activation_mode, DeviceMemory<float>* x_backprop,
+    DeviceMemory<float>* scale_backprop, DeviceMemory<float>* offset_backprop,
+    DeviceMemory<float>* side_input_backprop,
     DeviceMemory<uint8>* reserve_space_data,
     ScratchAllocator* workspace_allocator) {
   return DoBatchNormalizationBackwardImpl<float, float>(

--- a/tensorflow/stream_executor/rocm/rocm_dnn.h
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.h
@@ -291,22 +291,27 @@ class MIOpenSupport : public dnn::DnnSupport {
   bool DoBatchNormalizationBackward(
       Stream* stream, const DeviceMemory<float>& y_backprop,
       const DeviceMemory<float>& x, const DeviceMemory<float>& scale,
-      const DeviceMemory<float>& mean, const DeviceMemory<float>& variance,
+      const DeviceMemory<float>& offset, const DeviceMemory<float>& mean,
+      const DeviceMemory<float>& variance, const DeviceMemory<float>& y,
       const dnn::BatchDescriptor& x_desc,
       const dnn::BatchDescriptor& scale_offset_desc, const double epsilon,
-      DeviceMemory<float>* x_backprop, DeviceMemory<float>* scale_backprop,
-      DeviceMemory<float>* offset_backprop,
+      dnn::ActivationMode activation_mode, DeviceMemory<float>* x_backprop,
+      DeviceMemory<float>* scale_backprop, DeviceMemory<float>* offset_backprop,
+      DeviceMemory<float>* side_input_backprop,
       DeviceMemory<uint8>* reserve_space_data,
       ScratchAllocator* workspace_allocator) override;
 
   bool DoBatchNormalizationBackward(
       Stream* stream, const DeviceMemory<Eigen::half>& y_backprop,
       const DeviceMemory<Eigen::half>& x, const DeviceMemory<float>& scale,
-      const DeviceMemory<float>& mean, const DeviceMemory<float>& inv_var,
+      const DeviceMemory<float>& offset, const DeviceMemory<float>& mean,
+      const DeviceMemory<float>& inv_var, const DeviceMemory<Eigen::half>& y,
       const dnn::BatchDescriptor& x_desc,
       const dnn::BatchDescriptor& scale_offset_desc, const double epsilon,
+      dnn::ActivationMode activation_mode,
       DeviceMemory<Eigen::half>* x_backprop,
       DeviceMemory<float>* scale_backprop, DeviceMemory<float>* offset_backprop,
+      DeviceMemory<Eigen::half>* side_input_backprop,
       DeviceMemory<uint8>* reserve_space_data,
       ScratchAllocator* workspace_allocator) override;
 

--- a/tensorflow/stream_executor/stream.cc
+++ b/tensorflow/stream_executor/stream.cc
@@ -368,11 +368,13 @@ Stream &Stream::ThenBatchNormalizationForward(
 
 Stream &Stream::ThenBatchNormalizationBackward(
     const DeviceMemory<float> &y_backprop, const DeviceMemory<float> &x,
-    const DeviceMemory<float> &scale, const DeviceMemory<float> &mean,
-    const DeviceMemory<float> &inv_var, const dnn::BatchDescriptor &x_desc,
+    const DeviceMemory<float> &scale, const DeviceMemory<float> &offset,
+    const DeviceMemory<float> &mean, const DeviceMemory<float> &inv_var,
+    const DeviceMemory<float> &y, const dnn::BatchDescriptor &x_desc,
     const dnn::BatchDescriptor &scale_offset_desc, const double epsilon,
-    DeviceMemory<float> *x_backprop, DeviceMemory<float> *scale_backprop,
-    DeviceMemory<float> *offset_backprop,
+    dnn::ActivationMode activation_mode, DeviceMemory<float> *x_backprop,
+    DeviceMemory<float> *scale_backprop, DeviceMemory<float> *offset_backprop,
+    DeviceMemory<float> *side_input_backprop,
     DeviceMemory<uint8> *reserve_space_data,
     ScratchAllocator *workspace_allocator) {
   VLOG_CALL(PARAM(y_backprop), PARAM(x), PARAM(scale), PARAM(x_desc),
@@ -380,9 +382,10 @@ Stream &Stream::ThenBatchNormalizationBackward(
             PARAM(scale_backprop), PARAM(offset_backprop));
   if (dnn::DnnSupport *dnn = parent_->AsDnn()) {
     CheckError(dnn->DoBatchNormalizationBackward(
-        this, y_backprop, x, scale, mean, inv_var, x_desc, scale_offset_desc,
-        epsilon, x_backprop, scale_backprop, offset_backprop,
-        reserve_space_data, workspace_allocator));
+        this, y_backprop, x, scale, offset, mean, inv_var, y, x_desc,
+        scale_offset_desc, epsilon, activation_mode, x_backprop, scale_backprop,
+        offset_backprop, side_input_backprop, reserve_space_data,
+        workspace_allocator));
   } else {
     SetErrorAndLogNoDnnSupport();
   }
@@ -420,11 +423,13 @@ Stream &Stream::ThenBatchNormalizationForward(
 Stream &Stream::ThenBatchNormalizationBackward(
     const DeviceMemory<Eigen::half> &y_backprop,
     const DeviceMemory<Eigen::half> &x, const DeviceMemory<float> &scale,
-    const DeviceMemory<float> &mean, const DeviceMemory<float> &inv_var,
+    const DeviceMemory<float> &offset, const DeviceMemory<float> &mean,
+    const DeviceMemory<float> &inv_var, const DeviceMemory<Eigen::half> &y,
     const dnn::BatchDescriptor &x_desc,
     const dnn::BatchDescriptor &scale_offset_desc, const double epsilon,
-    DeviceMemory<Eigen::half> *x_backprop, DeviceMemory<float> *scale_backprop,
-    DeviceMemory<float> *offset_backprop,
+    dnn::ActivationMode activation_mode, DeviceMemory<Eigen::half> *x_backprop,
+    DeviceMemory<float> *scale_backprop, DeviceMemory<float> *offset_backprop,
+    DeviceMemory<Eigen::half> *side_input_backprop,
     DeviceMemory<uint8> *reserve_space_data,
     ScratchAllocator *workspace_allocator) {
   VLOG_CALL(PARAM(y_backprop), PARAM(x), PARAM(scale), PARAM(x_desc),
@@ -432,9 +437,10 @@ Stream &Stream::ThenBatchNormalizationBackward(
             PARAM(scale_backprop), PARAM(offset_backprop));
   if (dnn::DnnSupport *dnn = parent_->AsDnn()) {
     CheckError(dnn->DoBatchNormalizationBackward(
-        this, y_backprop, x, scale, mean, inv_var, x_desc, scale_offset_desc,
-        epsilon, x_backprop, scale_backprop, offset_backprop,
-        reserve_space_data, workspace_allocator));
+        this, y_backprop, x, scale, offset, mean, inv_var, y, x_desc,
+        scale_offset_desc, epsilon, activation_mode, x_backprop, scale_backprop,
+        offset_backprop, side_input_backprop, reserve_space_data,
+        workspace_allocator));
 
   } else {
     SetErrorAndLogNoDnnSupport();

--- a/tensorflow/stream_executor/stream.h
+++ b/tensorflow/stream_executor/stream.h
@@ -265,11 +265,13 @@ class Stream {
 
   Stream &ThenBatchNormalizationBackward(
       const DeviceMemory<float> &y_backprop, const DeviceMemory<float> &x,
-      const DeviceMemory<float> &scale, const DeviceMemory<float> &mean,
-      const DeviceMemory<float> &inv_var, const dnn::BatchDescriptor &x_desc,
+      const DeviceMemory<float> &scale, const DeviceMemory<float> &offset,
+      const DeviceMemory<float> &mean, const DeviceMemory<float> &inv_var,
+      const DeviceMemory<float> &y, const dnn::BatchDescriptor &x_desc,
       const dnn::BatchDescriptor &scale_offset_desc, const double epsilon,
-      DeviceMemory<float> *x_backprop, DeviceMemory<float> *scale_backprop,
-      DeviceMemory<float> *offset_backprop,
+      dnn::ActivationMode activation_mode, DeviceMemory<float> *x_backprop,
+      DeviceMemory<float> *scale_backprop, DeviceMemory<float> *offset_backprop,
+      DeviceMemory<float> *side_input_backprop,
       DeviceMemory<uint8> *reserve_space_data,
       ScratchAllocator *workspace_allocator);
 
@@ -291,11 +293,14 @@ class Stream {
   Stream &ThenBatchNormalizationBackward(
       const DeviceMemory<Eigen::half> &y_backprop,
       const DeviceMemory<Eigen::half> &x, const DeviceMemory<float> &scale,
-      const DeviceMemory<float> &mean, const DeviceMemory<float> &inv_var,
+      const DeviceMemory<float> &offset, const DeviceMemory<float> &mean,
+      const DeviceMemory<float> &inv_var, const DeviceMemory<Eigen::half> &y,
       const dnn::BatchDescriptor &x_desc,
       const dnn::BatchDescriptor &scale_offset_desc, const double epsilon,
+      dnn::ActivationMode activation_mode,
       DeviceMemory<Eigen::half> *x_backprop,
       DeviceMemory<float> *scale_backprop, DeviceMemory<float> *offset_backprop,
+      DeviceMemory<Eigen::half> *side_input_backprop,
       DeviceMemory<uint8> *reserve_space_data,
       ScratchAllocator *workspace_allocator);
 


### PR DESCRIPTION
This PR re-enables the fused (BatchNorm + Add + Activation) for the backprop. This is essentially a combination of the two previous PRs + one line change to disable the remapping when XLA is on:
1. Original PR: https://github.com/tensorflow/tensorflow/pull/48063 
2. Fix an issue of dual BN inputs: https://github.com/tensorflow/tensorflow/pull/48893
3. Disable the remapping when XLA is on.

cc. @nluehr 