### PR TITLE
[INTEL MKL] Use static variables for checking env variable and platform

### DIFF
--- a/tensorflow/core/util/mkl_util.h
+++ b/tensorflow/core/util/mkl_util.h
@@ -1821,15 +1821,21 @@ class MklPrimitiveFactory {
   /// For those legacy device(w/o AVX512 and AVX2),
   /// MKL-DNN GEMM will be used.
   static inline bool IsLegacyPlatform() {
-    return (!port::TestCPUFeature(port::CPUFeature::AVX512F) &&
-            !port::TestCPUFeature(port::CPUFeature::AVX2));
+    static bool is_legacy_platform = [] {
+      return (!port::TestCPUFeature(port::CPUFeature::AVX512F) &&
+              !port::TestCPUFeature(port::CPUFeature::AVX2));
+    }();
+    return is_legacy_platform;
   }
 
   /// Function to check whether primitive memory optimization is enabled
   static inline bool IsPrimitiveMemOptEnabled() {
-    bool is_primitive_mem_opt_enabled = true;
-    TF_CHECK_OK(ReadBoolFromEnvVar("TF_MKL_OPTIMIZE_PRIMITIVE_MEMUSE", true,
-                                   &is_primitive_mem_opt_enabled));
+    static bool is_primitive_mem_opt_enabled = [] {
+      bool value = true;
+      TF_CHECK_OK(
+          ReadBoolFromEnvVar("TF_MKL_OPTIMIZE_PRIMITIVE_MEMUSE", true, &value));
+      return value;
+    }();
     return is_primitive_mem_opt_enabled;
   }
 

--- a/tensorflow/core/util/mkl_util.h
+++ b/tensorflow/core/util/mkl_util.h
@@ -1821,16 +1821,15 @@ class MklPrimitiveFactory {
   /// For those legacy device(w/o AVX512 and AVX2),
   /// MKL-DNN GEMM will be used.
   static inline bool IsLegacyPlatform() {
-    static bool is_legacy_platform = [] {
-      return (!port::TestCPUFeature(port::CPUFeature::AVX512F) &&
-              !port::TestCPUFeature(port::CPUFeature::AVX2));
-    }();
+    static const bool is_legacy_platform =
+        (!port::TestCPUFeature(port::CPUFeature::AVX512F) &&
+         !port::TestCPUFeature(port::CPUFeature::AVX2));
     return is_legacy_platform;
   }
 
   /// Function to check whether primitive memory optimization is enabled
   static inline bool IsPrimitiveMemOptEnabled() {
-    static bool is_primitive_mem_opt_enabled = [] {
+    static const bool is_primitive_mem_opt_enabled = [] {
       bool value = true;
       TF_CHECK_OK(
           ReadBoolFromEnvVar("TF_MKL_OPTIMIZE_PRIMITIVE_MEMUSE", true, &value));


### PR DESCRIPTION
Refactor mkl_util.h by using static variable for checking

(1) environment variable (TF_MKL_OPTIMIZE_PRIMITIVE_MEMUSE)

(2) platform (HW has AVX512 or AVX2, or not)

The benefit is performance improvement (check once use multiple times). 

Reference PR: https://github.com/tensorflow/tensorflow/pull/48951