### PR TITLE
Update metrics.py: Fix SparseCategoricalAccuracy.update_state() doc string

### DIFF
--- a/tensorflow/python/keras/metrics.py
+++ b/tensorflow/python/keras/metrics.py
@@ -870,6 +870,30 @@ class SparseCategoricalAccuracy(MeanMetricWrapper):
   def __init__(self, name='sparse_categorical_accuracy', dtype=None):
     super(SparseCategoricalAccuracy, self).__init__(
         sparse_categorical_accuracy, name, dtype=dtype)
+  
+  def update_state(self, y_true, y_pred, sample_weight=None):
+    """Accumulates metric statistics.
+
+    The shapes of `y_true` and `y_pred` are different.
+
+    Args:
+      y_true: Ground truth label values. shape = `[batch_size, 1]`.
+      y_pred: The predicted probability values. shape = `[batch_size, d0, .. dN]`.
+      sample_weight: Optional `sample_weight` acts as a
+        coefficient for the metric. If a scalar is provided, then the metric is
+        simply scaled by the given value. If `sample_weight` is a tensor of size
+        `[batch_size]`, then the metric for each sample of the batch is rescaled
+        by the corresponding element in the `sample_weight` vector. If the shape
+        of `sample_weight` is `[batch_size, d0, .. dN-1]` (or can be broadcasted
+        to this shape), then each metric element of `y_pred` is scaled by the
+        corresponding value of `sample_weight`. (Note on `dN-1`: all metric
+        functions reduce by 1 dimension, usually the last axis (-1)).
+
+    Returns:
+      Update op.
+    """
+    super(SparseCategoricalAccuracy, self).update_state(
+      y_true=y_true, y_pred=y_pred, sample_weight=sample_weight)
 
 
 @keras_export('keras.metrics.TopKCategoricalAccuracy')

--- a/tensorflow/python/keras/metrics.py
+++ b/tensorflow/python/keras/metrics.py
@@ -877,7 +877,7 @@ class SparseCategoricalAccuracy(MeanMetricWrapper):
     The shapes of `y_true` and `y_pred` are different.
 
     Args:
-      y_true: Ground truth label values. shape = `[batch_size, d1, .. dN-1]` or shape = `[batch_size, d1, .. dN-1, 1]`.
+      y_true: Ground truth label values. shape = `[batch_size, d0, .. dN-1]` or shape = `[batch_size, d0, .. dN-1, 1]`.
       y_pred: The predicted probability values. shape = `[batch_size, d0, .. dN]`.
       sample_weight: Optional `sample_weight` acts as a
         coefficient for the metric. If a scalar is provided, then the metric is

--- a/tensorflow/python/keras/metrics.py
+++ b/tensorflow/python/keras/metrics.py
@@ -71,6 +71,28 @@ from tensorflow.python.util.tf_export import keras_export
 from tensorflow.tools.docs import doc_controls
 
 
+_SPARSE_CATEGORICAL_UPDATE_STATE_DOCSTRING = """Accumulates metric statistics.
+
+For sparse categorical metrics, the shapes of `y_true` and `y_pred` are different.
+
+Args:
+  y_true: Ground truth label values. shape = `[batch_size, d0, .. dN-1]` or shape = `[batch_size, d0, .. dN-1, 1]`.
+  y_pred: The predicted probability values. shape = `[batch_size, d0, .. dN]`.
+  sample_weight: Optional `sample_weight` acts as a
+    coefficient for the metric. If a scalar is provided, then the metric is
+    simply scaled by the given value. If `sample_weight` is a tensor of size
+    `[batch_size]`, then the metric for each sample of the batch is rescaled
+    by the corresponding element in the `sample_weight` vector. If the shape
+    of `sample_weight` is `[batch_size, d0, .. dN-1]` (or can be broadcasted
+    to this shape), then each metric element of `y_pred` is scaled by the
+    corresponding value of `sample_weight`. (Note on `dN-1`: all metric
+    functions reduce by 1 dimension, usually the last axis (-1)).
+
+Returns:
+  Update op.
+"""
+
+
 @keras_export('keras.metrics.Metric')
 class Metric(base_layer.Layer, metaclass=abc.ABCMeta):
   """Encapsulates metric logic and state.
@@ -870,30 +892,8 @@ class SparseCategoricalAccuracy(MeanMetricWrapper):
   def __init__(self, name='sparse_categorical_accuracy', dtype=None):
     super(SparseCategoricalAccuracy, self).__init__(
         sparse_categorical_accuracy, name, dtype=dtype)
-  
-  def update_state(self, y_true, y_pred, sample_weight=None):
-    """Accumulates metric statistics.
 
-    The shapes of `y_true` and `y_pred` are different.
-
-    Args:
-      y_true: Ground truth label values. shape = `[batch_size, d0, .. dN-1]` or shape = `[batch_size, d0, .. dN-1, 1]`.
-      y_pred: The predicted probability values. shape = `[batch_size, d0, .. dN]`.
-      sample_weight: Optional `sample_weight` acts as a
-        coefficient for the metric. If a scalar is provided, then the metric is
-        simply scaled by the given value. If `sample_weight` is a tensor of size
-        `[batch_size]`, then the metric for each sample of the batch is rescaled
-        by the corresponding element in the `sample_weight` vector. If the shape
-        of `sample_weight` is `[batch_size, d0, .. dN-1]` (or can be broadcasted
-        to this shape), then each metric element of `y_pred` is scaled by the
-        corresponding value of `sample_weight`. (Note on `dN-1`: all metric
-        functions reduce by 1 dimension, usually the last axis (-1)).
-
-    Returns:
-      Update op.
-    """
-    return super(SparseCategoricalAccuracy, self).update_state(
-      y_true=y_true, y_pred=y_pred, sample_weight=sample_weight)
+SparseCategoricalAccuracy.update_state.__doc__ = _SPARSE_CATEGORICAL_UPDATE_STATE_DOCSTRING
 
 
 @keras_export('keras.metrics.TopKCategoricalAccuracy')
@@ -971,6 +971,8 @@ class SparseTopKCategoricalAccuracy(MeanMetricWrapper):
   def __init__(self, k=5, name='sparse_top_k_categorical_accuracy', dtype=None):
     super(SparseTopKCategoricalAccuracy, self).__init__(
         sparse_top_k_categorical_accuracy, name, dtype=dtype, k=k)
+
+SparseTopKCategoricalAccuracy.update_state.__doc__ = _SPARSE_CATEGORICAL_UPDATE_STATE_DOCSTRING
 
 
 class _ConfusionMatrixConditionCount(Metric):
@@ -3357,6 +3359,8 @@ class SparseCategoricalCrossentropy(MeanMetricWrapper):
         dtype=dtype,
         from_logits=from_logits,
         axis=axis)
+
+SparseCategoricalCrossentropy.update_state.__doc__ = _SPARSE_CATEGORICAL_UPDATE_STATE_DOCSTRING
 
 
 class SumOverBatchSize(Reduce):

--- a/tensorflow/python/keras/metrics.py
+++ b/tensorflow/python/keras/metrics.py
@@ -877,7 +877,7 @@ class SparseCategoricalAccuracy(MeanMetricWrapper):
     The shapes of `y_true` and `y_pred` are different.
 
     Args:
-      y_true: Ground truth label values. shape = `[batch_size, 1]`.
+      y_true: Ground truth label values. shape = `[batch_size, d1, .. dN-1]` or shape = `[batch_size, d1, .. dN-1, 1]`.
       y_pred: The predicted probability values. shape = `[batch_size, d0, .. dN]`.
       sample_weight: Optional `sample_weight` acts as a
         coefficient for the metric. If a scalar is provided, then the metric is

--- a/tensorflow/python/keras/metrics.py
+++ b/tensorflow/python/keras/metrics.py
@@ -892,7 +892,7 @@ class SparseCategoricalAccuracy(MeanMetricWrapper):
     Returns:
       Update op.
     """
-    super(SparseCategoricalAccuracy, self).update_state(
+    return super(SparseCategoricalAccuracy, self).update_state(
       y_true=y_true, y_pred=y_pred, sample_weight=sample_weight)
 
 

--- a/tensorflow/python/keras/metrics.py
+++ b/tensorflow/python/keras/metrics.py
@@ -682,44 +682,6 @@ class MeanMetricWrapper(Mean):
     return super(MeanMetricWrapper, cls).from_config(config)
 
 
-class SparseCategoricalMetricWrapper(MeanMetricWrapper):
-  """Wraps a stateless sparse categorical metric function with the Mean metric.
-
-  Args:
-    fn: The metric function to wrap, with signature `fn(y_true, y_pred,
-      **kwargs)`.
-    name: (Optional) string name of the metric instance.
-    dtype: (Optional) data type of the metric result.
-    **kwargs: The keyword arguments that are passed on to `fn`.
-  """
-  def __init__(self, fn, name=None, dtype=None, **kwargs):
-    super(SparseCategoricalMetricWrapper, self).__init__(fn=fn, name=name, dtype=dtype, **kwargs)
-
-  def update_state(self, y_true, y_pred, sample_weight=None):
-    """Accumulates sparse categorical metric statistics.
-
-    For sparse categorical metrics, the shapes of `y_true` and `y_pred` are different.
-
-    Args:
-      y_true: Ground truth label values. shape = `[batch_size, d0, .. dN-1]` or shape = `[batch_size, d0, .. dN-1, 1]`.
-      y_pred: The predicted probability values. shape = `[batch_size, d0, .. dN]`.
-      sample_weight: Optional `sample_weight` acts as a
-        coefficient for the metric. If a scalar is provided, then the metric is
-        simply scaled by the given value. If `sample_weight` is a tensor of size
-        `[batch_size]`, then the metric for each sample of the batch is rescaled
-        by the corresponding element in the `sample_weight` vector. If the shape
-        of `sample_weight` is `[batch_size, d0, .. dN-1]` (or can be broadcasted
-        to this shape), then each metric element of `y_pred` is scaled by the
-        corresponding value of `sample_weight`. (Note on `dN-1`: all metric
-        functions reduce by 1 dimension, usually the last axis (-1)).
-
-    Returns:
-      Update op.
-    """
-    return super(SparseCategoricalMetricWrapper, self).update_state(
-      y_true=y_true, y_pred=y_pred, sample_weight=sample_weight)
-
-
 @keras_export('keras.metrics.Accuracy')
 class Accuracy(MeanMetricWrapper):
   """Calculates how often predictions equal labels.
@@ -860,7 +822,7 @@ class CategoricalAccuracy(MeanMetricWrapper):
 
 
 @keras_export('keras.metrics.SparseCategoricalAccuracy')
-class SparseCategoricalAccuracy(SparseCategoricalMetricWrapper):
+class SparseCategoricalAccuracy(MeanMetricWrapper):
   """Calculates how often predictions match integer labels.
 
   ```python
@@ -909,6 +871,30 @@ class SparseCategoricalAccuracy(SparseCategoricalMetricWrapper):
     super(SparseCategoricalAccuracy, self).__init__(
         sparse_categorical_accuracy, name, dtype=dtype)
   
+  def update_state(self, y_true, y_pred, sample_weight=None):
+    """Accumulates metric statistics.
+
+    The shapes of `y_true` and `y_pred` are different.
+
+    Args:
+      y_true: Ground truth label values. shape = `[batch_size, d0, .. dN-1]` or shape = `[batch_size, d0, .. dN-1, 1]`.
+      y_pred: The predicted probability values. shape = `[batch_size, d0, .. dN]`.
+      sample_weight: Optional `sample_weight` acts as a
+        coefficient for the metric. If a scalar is provided, then the metric is
+        simply scaled by the given value. If `sample_weight` is a tensor of size
+        `[batch_size]`, then the metric for each sample of the batch is rescaled
+        by the corresponding element in the `sample_weight` vector. If the shape
+        of `sample_weight` is `[batch_size, d0, .. dN-1]` (or can be broadcasted
+        to this shape), then each metric element of `y_pred` is scaled by the
+        corresponding value of `sample_weight`. (Note on `dN-1`: all metric
+        functions reduce by 1 dimension, usually the last axis (-1)).
+
+    Returns:
+      Update op.
+    """
+    return super(SparseCategoricalAccuracy, self).update_state(
+      y_true=y_true, y_pred=y_pred, sample_weight=sample_weight)
+
 
 @keras_export('keras.metrics.TopKCategoricalAccuracy')
 class TopKCategoricalAccuracy(MeanMetricWrapper):
@@ -950,7 +936,7 @@ class TopKCategoricalAccuracy(MeanMetricWrapper):
 
 
 @keras_export('keras.metrics.SparseTopKCategoricalAccuracy')
-class SparseTopKCategoricalAccuracy(SparseCategoricalMetricWrapper):
+class SparseTopKCategoricalAccuracy(MeanMetricWrapper):
   """Computes how often integer targets are in the top `K` predictions.
 
   Args:
@@ -3303,7 +3289,7 @@ class CategoricalCrossentropy(MeanMetricWrapper):
 
 
 @keras_export('keras.metrics.SparseCategoricalCrossentropy')
-class SparseCategoricalCrossentropy(SparseCategoricalMetricWrapper):
+class SparseCategoricalCrossentropy(MeanMetricWrapper):
   """Computes the crossentropy metric between the labels and predictions.
 
   Use this crossentropy metric when there are two or more label classes.

--- a/tensorflow/python/keras/metrics.py
+++ b/tensorflow/python/keras/metrics.py
@@ -682,6 +682,44 @@ class MeanMetricWrapper(Mean):
     return super(MeanMetricWrapper, cls).from_config(config)
 
 
+class SparseCategoricalMetricWrapper(MeanMetricWrapper):
+  """Wraps a stateless sparse categorical metric function with the Mean metric.
+
+  Args:
+    fn: The metric function to wrap, with signature `fn(y_true, y_pred,
+      **kwargs)`.
+    name: (Optional) string name of the metric instance.
+    dtype: (Optional) data type of the metric result.
+    **kwargs: The keyword arguments that are passed on to `fn`.
+  """
+  def __init__(self, fn, name=None, dtype=None, **kwargs):
+    super(SparseCategoricalMetricWrapper, self).__init__(fn=fn, name=name, dtype=dtype, **kwargs)
+
+  def update_state(self, y_true, y_pred, sample_weight=None):
+    """Accumulates sparse categorical metric statistics.
+
+    For sparse categorical metrics, the shapes of `y_true` and `y_pred` are different.
+
+    Args:
+      y_true: Ground truth label values. shape = `[batch_size, d0, .. dN-1]` or shape = `[batch_size, d0, .. dN-1, 1]`.
+      y_pred: The predicted probability values. shape = `[batch_size, d0, .. dN]`.
+      sample_weight: Optional `sample_weight` acts as a
+        coefficient for the metric. If a scalar is provided, then the metric is
+        simply scaled by the given value. If `sample_weight` is a tensor of size
+        `[batch_size]`, then the metric for each sample of the batch is rescaled
+        by the corresponding element in the `sample_weight` vector. If the shape
+        of `sample_weight` is `[batch_size, d0, .. dN-1]` (or can be broadcasted
+        to this shape), then each metric element of `y_pred` is scaled by the
+        corresponding value of `sample_weight`. (Note on `dN-1`: all metric
+        functions reduce by 1 dimension, usually the last axis (-1)).
+
+    Returns:
+      Update op.
+    """
+    return super(SparseCategoricalMetricWrapper, self).update_state(
+      y_true=y_true, y_pred=y_pred, sample_weight=sample_weight)
+
+
 @keras_export('keras.metrics.Accuracy')
 class Accuracy(MeanMetricWrapper):
   """Calculates how often predictions equal labels.
@@ -822,7 +860,7 @@ class CategoricalAccuracy(MeanMetricWrapper):
 
 
 @keras_export('keras.metrics.SparseCategoricalAccuracy')
-class SparseCategoricalAccuracy(MeanMetricWrapper):
+class SparseCategoricalAccuracy(SparseCategoricalMetricWrapper):
   """Calculates how often predictions match integer labels.
 
   ```python
@@ -871,30 +909,6 @@ class SparseCategoricalAccuracy(MeanMetricWrapper):
     super(SparseCategoricalAccuracy, self).__init__(
         sparse_categorical_accuracy, name, dtype=dtype)
   
-  def update_state(self, y_true, y_pred, sample_weight=None):
-    """Accumulates metric statistics.
-
-    The shapes of `y_true` and `y_pred` are different.
-
-    Args:
-      y_true: Ground truth label values. shape = `[batch_size, d0, .. dN-1]` or shape = `[batch_size, d0, .. dN-1, 1]`.
-      y_pred: The predicted probability values. shape = `[batch_size, d0, .. dN]`.
-      sample_weight: Optional `sample_weight` acts as a
-        coefficient for the metric. If a scalar is provided, then the metric is
-        simply scaled by the given value. If `sample_weight` is a tensor of size
-        `[batch_size]`, then the metric for each sample of the batch is rescaled
-        by the corresponding element in the `sample_weight` vector. If the shape
-        of `sample_weight` is `[batch_size, d0, .. dN-1]` (or can be broadcasted
-        to this shape), then each metric element of `y_pred` is scaled by the
-        corresponding value of `sample_weight`. (Note on `dN-1`: all metric
-        functions reduce by 1 dimension, usually the last axis (-1)).
-
-    Returns:
-      Update op.
-    """
-    return super(SparseCategoricalAccuracy, self).update_state(
-      y_true=y_true, y_pred=y_pred, sample_weight=sample_weight)
-
 
 @keras_export('keras.metrics.TopKCategoricalAccuracy')
 class TopKCategoricalAccuracy(MeanMetricWrapper):
@@ -936,7 +950,7 @@ class TopKCategoricalAccuracy(MeanMetricWrapper):
 
 
 @keras_export('keras.metrics.SparseTopKCategoricalAccuracy')
-class SparseTopKCategoricalAccuracy(MeanMetricWrapper):
+class SparseTopKCategoricalAccuracy(SparseCategoricalMetricWrapper):
   """Computes how often integer targets are in the top `K` predictions.
 
   Args:
@@ -3289,7 +3303,7 @@ class CategoricalCrossentropy(MeanMetricWrapper):
 
 
 @keras_export('keras.metrics.SparseCategoricalCrossentropy')
-class SparseCategoricalCrossentropy(MeanMetricWrapper):
+class SparseCategoricalCrossentropy(SparseCategoricalMetricWrapper):
   """Computes the crossentropy metric between the labels and predictions.
 
   Use this crossentropy metric when there are two or more label classes.


### PR DESCRIPTION
Update metrics.py: Fix SparseCategoricalAccuracy.update_state() doc string

Try fixing issue #49252 

For SparseCategoricalAccuracy, `y_true` should be integer labels and `y_pred` should be probabilities.


```
    m = tf.keras.metrics.SparseCategoricalAccuracy()

    m.update_state([[2], [1]], [[0.1, 0.6, 0.3], [0.05, 0.95, 0]])  # Correct usage,  `y_true` as integer labels and `y_pred` as probabilities.
    print(m.result().numpy())
    # >>> 0.5

    m.update_state([[2], [1]], [[1], [1]])  # Wrong usage, both as integer labels.
    print(m.result().numpy())
    # >>> 0.25

    m.update_state([[0, 1, 0], [0, 1, 0]], [[0.1, 0.6, 0.3], [0.05, 0.95, 0]])  # Wrong usage, both as probabilities.
    print(m.result().numpy())
    # >>> Error
```