### PR TITLE
Fix 'Illegal ambiguous match'

### DIFF
--- a/tensorflow/core/platform/default/build_config.bzl
+++ b/tensorflow/core/platform/default/build_config.bzl
@@ -679,7 +679,6 @@ def tf_additional_core_deps():
         clean_dep("//tensorflow:android"): [],
         clean_dep("//tensorflow:ios"): [],
         clean_dep("//tensorflow:linux_s390x"): [],
-        clean_dep("//tensorflow:no_aws_support"): [],
         "//conditions:default": [
             clean_dep("//tensorflow/core/platform/s3:s3_file_system"),
         ],


### PR DESCRIPTION
bazel build for pip package //tensorflow/tools/pip_package:build_pip_package  on s390x gives the following error:

```
Illegal ambiguous match on configurable attribute "deps" in //tensorflow/core/common_runtime:core_cpu_internal:
//tensorflow:linux_s390x
//tensorflow:no_aws_support
Multiple matches are not allowed unless one is unambiguously more specialized.
```

This is because the select statement [here](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/platform/default/build_config.bzl#L678-L686) matches both //tensorflow:linux_s390x and //tensorflow:no_aws_support 


This pr is to to remove `clean_dep("//tensorflow:no_aws_support"): []` as AWS and HDFS support is disabled by default. 