### PR TITLE
[ROCm] HipSparse csru2csr for ROCm 4.2+

### DIFF
--- a/tensorflow/core/util/rocm_sparse.cc
+++ b/tensorflow/core/util/rocm_sparse.cc
@@ -188,6 +188,8 @@ Status GpuSparse::Initialize() {
 
 // Macros to construct hipsparse method names.
 #define SPARSE_FN(method, sparse_prefix) wrap::hipsparse##sparse_prefix##method
+#define BUFSIZE_FN(method, sparse_prefix) \
+  wrap::hipsparse##sparse_prefix##method##_bufferSizeExt
 
 Status GpuSparse::Coo2csr(const int* cooRowInd, int nnz, int m,
                           int* csrRowPtr) const {
@@ -329,6 +331,55 @@ static inline Status CsrgemmImpl(
   }
 
 TF_CALL_HIP_LAPACK_TYPES(CSRGEMM_INSTANCE);
+
+#if TF_ROCM_VERSION >= 40200
+
+template <typename Scalar, typename BufferSizeFnT, typename SparseFnT>
+static inline Status Csru2csrImpl(SparseFnT op, BufferSizeFnT buffer_size_op,
+                                  OpKernelContext* context,
+                                  hipsparseHandle_t hipsparse_handle, int m,
+                                  int n, int nnz,
+                                  const hipsparseMatDescr_t descrA,
+                                  Scalar* csrVal, const int* csrRowPtr,
+                                  int* csrColInd) {
+  GpuSparseCsrSortingConversionInfo info;
+  TF_RETURN_IF_ERROR(info.Initialize());
+
+  size_t pBufferSizeInBytes = 0;
+
+  TF_RETURN_IF_GPUSPARSE_ERROR(
+      buffer_size_op(hipsparse_handle, m, n, nnz, AsHipComplex(csrVal),
+                     csrRowPtr, csrColInd, info.info(), &pBufferSizeInBytes));
+
+  Tensor pBuffer_t;
+  TF_RETURN_IF_ERROR(context->allocate_temp(
+      DT_INT8, TensorShape({static_cast<int64>(pBufferSizeInBytes)}),
+      &pBuffer_t));
+  auto pBuffer = pBuffer_t.flat<int8>();
+  DCHECK(pBuffer.data() != nullptr);
+
+  TF_RETURN_IF_GPUSPARSE_ERROR(op(hipsparse_handle, m, n, nnz, descrA,
+                                  AsHipComplex(csrVal), csrRowPtr, csrColInd,
+                                  info.info(), pBuffer.data()));
+
+  return Status::OK();
+}
+
+#define CSRU2CSR_INSTANCE(Scalar, sparse_prefix)                              \
+  template <>                                                                 \
+  Status GpuSparse::Csru2csr<Scalar>(                                         \
+      int m, int n, int nnz, const hipsparseMatDescr_t descrA, Scalar* csrVal, \
+      const int* csrRowPtr, int* csrColInd) {                                 \
+    DCHECK(initialized_);                                                     \
+    return Csru2csrImpl(SPARSE_FN(csru2csr, sparse_prefix),                   \
+                        BUFSIZE_FN(csru2csr, sparse_prefix), context_,        \
+                        *gpusparse_handle_, m, n, nnz, descrA, csrVal,        \
+                        csrRowPtr, csrColInd);                                \
+  }
+
+TF_CALL_LAPACK_TYPES(CSRU2CSR_INSTANCE);
+
+#endif
 
 template <typename Scalar, typename SparseFnT>
 static inline Status Csr2cscImpl(SparseFnT op, OpKernelContext* context,

--- a/tensorflow/stream_executor/rocm/hipsparse_wrapper.h
+++ b/tensorflow/stream_executor/rocm/hipsparse_wrapper.h
@@ -104,6 +104,22 @@ namespace wrap {
   __macro(hipsparseZcsrmm2)             \
   __macro(hipsparseZcsrmv)
 
+#if TF_ROCM_VERSION >= 40200
+#define FOREACH_HIPSPARSE_ROCM_42_API(__macro)  \
+  __macro(hipsparseCcsru2csr_bufferSizeExt)     \
+  __macro(hipsparseCcsru2csr)                   \
+  __macro(hipsparseDcsru2csr_bufferSizeExt)     \
+  __macro(hipsparseDcsru2csr)                   \
+  __macro(hipsparseScsru2csr_bufferSizeExt)     \
+  __macro(hipsparseScsru2csr)                   \
+  __macro(hipsparseZcsru2csr_bufferSizeExt)     \
+  __macro(hipsparseZcsru2csr)
+
+FOREACH_HIPSPARSE_ROCM42_API(HIPSPARSE_API_WRAPPER)
+
+#undef FOREACH_HIPSPARSE_ROCM42_API
+#endif
+
 // clang-format on
 
 FOREACH_HIPSPARSE_API(HIPSPARSE_API_WRAPPER)


### PR DESCRIPTION
Adding csru2csr functionality to HipSparse wrappers, inline with cuSparse implementations.
In conjunction with https://github.com/tensorflow/tensorflow/pull/49305. 
@cheshire  @chsigg for review. 