### PR TITLE
[TFLite] Support GPU buffer binding with C API

### DIFF
--- a/tensorflow/lite/c/c_api_experimental.cc
+++ b/tensorflow/lite/c/c_api_experimental.cc
@@ -80,4 +80,24 @@ void TfLiteInterpreterOptionsSetEnableDelegateFallback(
   options->enable_delegate_fallback = enable;
 }
 
+void TfLiteSetAllowBufferHandleOutput(const TfLiteInterpreter* interpreter,
+                                      bool allow_buffer_handle_output) {
+  interpreter->impl->SetAllowBufferHandleOutput(allow_buffer_handle_output);
+}
+
+TfLiteStatus TfLiteInterpreterModifyGraphWithDelegate(
+    const TfLiteInterpreter* interpreter, TfLiteDelegate* delegate) {
+  return interpreter->impl->ModifyGraphWithDelegate(delegate);
+}
+
+int32_t TfLiteInterpreterGetInputTensorIndex(
+    const TfLiteInterpreter* interpreter, int32_t input_index) {
+  return interpreter->impl->inputs()[input_index];
+}
+
+int32_t TfLiteInterpreterGetOutputTensorIndex(
+    const TfLiteInterpreter* interpreter, int32_t output_index) {
+  return interpreter->impl->outputs()[output_index];
+}
+
 }  // extern "C"

--- a/tensorflow/lite/c/c_api_experimental.h
+++ b/tensorflow/lite/c/c_api_experimental.h
@@ -161,6 +161,8 @@ TFL_CAPI_EXPORT extern void TfLiteSetAllowBufferHandleOutput(
 /// parts of the graph themselves. After this is called, the graph may
 /// contain new nodes that replace 1 more nodes.
 /// 'delegate' must outlive the interpreter.
+/// Use `TfLiteInterpreterOptionsAddDelegate` instead of this unless
+/// absolutely required.
 /// Returns one of the following three status codes:
 /// 1. kTfLiteOk: Success.
 /// 2. kTfLiteDelegateError: Delegation failed due to an error in the

--- a/tensorflow/lite/c/c_api_experimental.h
+++ b/tensorflow/lite/c/c_api_experimental.h
@@ -146,6 +146,43 @@ TFL_CAPI_EXPORT extern void TfLiteInterpreterOptionsSetUseNNAPI(
 TFL_CAPI_EXPORT extern void TfLiteInterpreterOptionsSetEnableDelegateFallback(
     TfLiteInterpreterOptions* options, bool enable);
 
+// Set if buffer handle output is allowed.
+//
+/// When using hardware delegation, Interpreter will make the data of output
+/// tensors available in `tensor->data` by default. If the application can
+/// consume the buffer handle directly (e.g. reading output from OpenGL
+/// texture), it can set this flag to false, so Interpreter won't copy the
+/// data from buffer handle to CPU memory. WARNING: This is an experimental
+/// API and subject to change.
+TFL_CAPI_EXPORT extern void TfLiteSetAllowBufferHandleOutput(
+    const TfLiteInterpreter* interpreter, bool allow_buffer_handle_output);
+
+/// Allow a delegate to look at the graph and modify the graph to handle
+/// parts of the graph themselves. After this is called, the graph may
+/// contain new nodes that replace 1 more nodes.
+/// 'delegate' must outlive the interpreter.
+/// Returns one of the following three status codes:
+/// 1. kTfLiteOk: Success.
+/// 2. kTfLiteDelegateError: Delegation failed due to an error in the
+/// delegate. The Interpreter has been restored to its pre-delegation state.
+/// NOTE: This undoes all delegates previously applied to the Interpreter.
+/// 3. kTfLiteError: Unexpected/runtime failure.
+/// WARNING: This is an experimental API and subject to change.
+TFL_CAPI_EXPORT extern TfLiteStatus TfLiteInterpreterModifyGraphWithDelegate(
+    const TfLiteInterpreter* interpreter, TfLiteDelegate* delegate);
+
+/// Returns the tensor index with the input index.
+///
+/// WARNING: This is an experimental API and subject to change.
+TFL_CAPI_EXPORT extern int32_t TfLiteInterpreterGetInputTensorIndex(
+    const TfLiteInterpreter* interpreter, int32_t input_index);
+
+/// Returns the tensor index with the output index.
+///
+/// WARNING: This is an experimental API and subject to change.
+TFL_CAPI_EXPORT extern int32_t TfLiteInterpreterGetOutputTensorIndex(
+    const TfLiteInterpreter* interpreter, int32_t output_index);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/tensorflow/lite/c/c_api_experimental.h
+++ b/tensorflow/lite/c/c_api_experimental.h
@@ -171,13 +171,13 @@ TFL_CAPI_EXPORT extern void TfLiteSetAllowBufferHandleOutput(
 TFL_CAPI_EXPORT extern TfLiteStatus TfLiteInterpreterModifyGraphWithDelegate(
     const TfLiteInterpreter* interpreter, TfLiteDelegate* delegate);
 
-/// Returns the tensor index with the input index.
+/// Returns the tensor index corresponding to the input tensor
 ///
 /// WARNING: This is an experimental API and subject to change.
 TFL_CAPI_EXPORT extern int32_t TfLiteInterpreterGetInputTensorIndex(
     const TfLiteInterpreter* interpreter, int32_t input_index);
 
-/// Returns the tensor index with the output index.
+/// Returns the tensor index corresponding to the output tensor
 ///
 /// WARNING: This is an experimental API and subject to change.
 TFL_CAPI_EXPORT extern int32_t TfLiteInterpreterGetOutputTensorIndex(

--- a/tensorflow/lite/delegates/gpu/metal_delegate.h
+++ b/tensorflow/lite/delegates/gpu/metal_delegate.h
@@ -75,6 +75,7 @@ TFL_CAPI_EXPORT extern void TFLGpuDelegateDelete(TfLiteDelegate* delegate);
 // Returns non-zero on success, or zero otherwise.
 //
 // *** Must be called *after* `Interpreter::ModifyGraphWithDelegate`. ***
+// WARNING: This is an experimental API and subject to change.
 TFL_CAPI_EXPORT extern bool TFLGpuDelegateBindMetalBufferToTensor(TfLiteDelegate* delegate,
                                                                   int tensor_index,
                                                                   id<MTLBuffer> metal_buffer);

--- a/tensorflow/lite/delegates/gpu/metal_delegate.h
+++ b/tensorflow/lite/delegates/gpu/metal_delegate.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define TENSORFLOW_LITE_DELEGATES_GPU_METAL_DELEGATE_H_
 
 #include "tensorflow/lite/c/common.h"
+#import <Metal/Metal.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -66,6 +67,17 @@ TFL_CAPI_EXPORT extern TfLiteDelegate* TFLGpuDelegateCreate(
 
 // Destroys a delegate created with `TFLGpuDelegateCreate` call.
 TFL_CAPI_EXPORT extern void TFLGpuDelegateDelete(TfLiteDelegate* delegate);
+
+// Binds Metal buffer to an input or an output tensor in the initialized
+// delegate. Bound buffer should have sufficient storage to accommodate all
+// elements of a tensor. For quantized model, the buffer is bound to internal
+// dequantized float32 tensor.
+// Returns non-zero on success, or zero otherwise.
+//
+// *** Must be called *after* `Interpreter::ModifyGraphWithDelegate`. ***
+TFL_CAPI_EXPORT extern bool TFLGpuDelegateBindMetalBufferToTensor(TfLiteDelegate* delegate,
+                                                                  int tensor_index,
+                                                                  id<MTLBuffer> metal_buffer);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/tensorflow/lite/delegates/gpu/metal_delegate_internal.h
+++ b/tensorflow/lite/delegates/gpu/metal_delegate_internal.h
@@ -22,17 +22,6 @@ limitations under the License.
 
 struct TfLiteDelegate;
 
-// Binds Metal buffer to an input or an output tensor in the initialized
-// delegate. Bound buffer should have sufficient storage to accommodate all
-// elements of a tensor. For quantized model, the buffer is bound to internal
-// dequantized float32 tensor.
-// Returns non-zero on success, or zero otherwise.
-//
-// *** Must be called *after* `Interpreter::ModifyGraphWithDelegate`. ***
-bool TFLGpuDelegateBindMetalBufferToTensor(TfLiteDelegate* delegate,
-                                           int tensor_index,
-                                           id<MTLBuffer> metal_buffer);
-
 // Binds user-defined MTLCommandBuffer. The delegate puts all GPU tasks
 // into this buffer instead of the internal command buffer.
 bool TFLGpuDelegateSetCommandBuffer(TfLiteDelegate* delegate,

--- a/tensorflow/lite/ios/BUILD.apple
+++ b/tensorflow/lite/ios/BUILD.apple
@@ -84,6 +84,7 @@ strip_common_include_path_prefix(
     name = "strip_common_include_path_core",
     hdr_labels = [
         "//tensorflow/lite/c:c_api.h",
+        "//tensorflow/lite/c:c_api_experimental.h",
         "//tensorflow/lite/c:common.h",
         "//tensorflow/lite/delegates/xnnpack:xnnpack_delegate.h",
     ],
@@ -103,6 +104,7 @@ tflite_ios_framework(
     name = "TensorFlowLiteC_framework",
     hdrs = [
         ":c_api.h",
+        ":c_api_experimental.h",
         ":common.h",
         ":xnnpack_delegate.h",
         "//tensorflow/lite/c:c_api_types.h",
@@ -121,6 +123,7 @@ ios_static_framework(
     name = "TensorFlowLiteC_static_framework",
     hdrs = [
         ":c_api.h",
+        ":c_api_experimental.h",
         ":common.h",
         ":xnnpack_delegate.h",
         "//tensorflow/lite/c:c_api_types.h",
@@ -193,6 +196,7 @@ cc_library(
     name = "tensorflow_lite_c",
     hdrs = [
         "//tensorflow/lite/c:c_api.h",
+        "//tensorflow/lite/c:c_api_experimental.h",
         "//tensorflow/lite/c:c_api_types.h",
         "//tensorflow/lite/c:common.h",
         "//tensorflow/lite/delegates/xnnpack:xnnpack_delegate.h",
@@ -203,6 +207,7 @@ cc_library(
     ],
     deps = [
         "//tensorflow/lite/c:c_api",
+        "//tensorflow/lite/c:c_api_experimental",
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/delegates/xnnpack:xnnpack_delegate",
     ],

--- a/tensorflow/lite/ios/allowlist_TensorFlowLiteCMetal.txt
+++ b/tensorflow/lite/ios/allowlist_TensorFlowLiteCMetal.txt
@@ -1,2 +1,3 @@
 _TFLGpuDelegateCreate
 _TFLGpuDelegateDelete
+_TFLGpuDelegateBindMetalBufferToTensor


### PR DESCRIPTION
The binding model's Input/Output with MTLBuffer/OpenGL SSBO is considerably effective for performance. But it is only available with C++ API, it will be great if we can use this feature with C API and eventually, Swift and Java.

https://www.tensorflow.org/lite/performance/gpu_advanced#inputoutput_buffers_ios_c_api_only

This PR allows us to call `TFLGpuDelegateBindMetalBufferToTensor (Metal Delegate)` and `TfLiteGpuDelegateBindBufferToTensor (GL Delegate)` from the C API.
