### PR TITLE
Skip hdfs if -config=nohdfs is passed to bazel

### DIFF
--- a/tensorflow/core/platform/default/build_config.bzl
+++ b/tensorflow/core/platform/default/build_config.bzl
@@ -670,8 +670,7 @@ def tf_additional_core_deps():
         clean_dep("//tensorflow:android"): [],
         clean_dep("//tensorflow:ios"): [],
         clean_dep("//tensorflow:linux_s390x"): [],
-        clean_dep("//tensorflow:windows"): [],
-        clean_dep("//tensorflow:with_tpu_support"): [],
+        clean_dep("//tensorflow:no_hdfs_support"): [],
         "//conditions:default": [
             clean_dep("//tensorflow/core/platform/hadoop:hadoop_file_system"),
         ],

--- a/tensorflow/core/platform/default/build_config.bzl
+++ b/tensorflow/core/platform/default/build_config.bzl
@@ -667,17 +667,11 @@ def tf_additional_core_deps():
             "//tensorflow/core/platform/cloud:gcs_file_system",
         ],
     }) + select({
-        clean_dep("//tensorflow:android"): [],
-        clean_dep("//tensorflow:ios"): [],
-        clean_dep("//tensorflow:linux_s390x"): [],
         clean_dep("//tensorflow:no_hdfs_support"): [],
         "//conditions:default": [
             clean_dep("//tensorflow/core/platform/hadoop:hadoop_file_system"),
         ],
     }) + select({
-        clean_dep("//tensorflow:android"): [],
-        clean_dep("//tensorflow:ios"): [],
-        clean_dep("//tensorflow:linux_s390x"): [],
         clean_dep("//tensorflow:no_aws_support"): [],
         "//conditions:default": [
             clean_dep("//tensorflow/core/platform/s3:s3_file_system"),

--- a/tensorflow/tools/lib_package/BUILD
+++ b/tensorflow/tools/lib_package/BUILD
@@ -139,7 +139,6 @@ genrule(
     srcs = [
         "//third_party/eigen3:LICENSE",
         "//third_party/fft2d:LICENSE",
-        "//third_party/hadoop:LICENSE.txt",
         "//third_party/icu/data:LICENSE",
         "@boringssl//:LICENSE",
         "@com_google_protobuf//:LICENSE",
@@ -210,7 +209,6 @@ genrule(
     srcs = [
         "//third_party/eigen3:LICENSE",
         "//third_party/fft2d:LICENSE",
-        "//third_party/hadoop:LICENSE.txt",
         "//third_party/icu/data:LICENSE",
         "@boringssl//:LICENSE",
         "@com_google_protobuf//:LICENSE",

--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -182,7 +182,6 @@ filegroup(
         "//:LICENSE",
         "//third_party/eigen3:LICENSE",
         "//third_party/fft2d:LICENSE",
-        "//third_party/hadoop:LICENSE.txt",
         "//third_party/icu/data:LICENSE",
         "@ruy//:LICENSE",
         "@arm_neon_2_x86_sse//:LICENSE",


### PR DESCRIPTION
While trying to build tensorflow locally, noticed that hdfs is linked
even with -config=nohdfs. The issue comes form an incorrect options
within build_config.bzl.

This PR fixes the issue.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>