### PR TITLE
Remove duplicated entry of Env::Default

### DIFF
--- a/tensorflow/compiler/tf2xla/ops/BUILD
+++ b/tensorflow/compiler/tf2xla/ops/BUILD
@@ -38,7 +38,6 @@ tf_custom_op_library(
     ],
     deps = [
         "//tensorflow/compiler/xla:xla_data_proto_cc",
-        "//tensorflow/core:lib",
         "@com_google_absl//absl/algorithm:container",
     ],
 )


### PR DESCRIPTION
While checking duplicated symbols in .so/dll, noticed that
both `_xla_ops.so` and `_pywrap_tensorflow_internal.so` consists
of Env::Default symbols exported.

This PR removed the duplication in `_xla_ops.so`.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>