### PR TITLE
[MLIR] TF Graphdef to MLIR python binding: input/output options

### DIFF
--- a/tensorflow/compiler/mlir/python/mlir.cc
+++ b/tensorflow/compiler/mlir/python/mlir.cc
@@ -16,11 +16,18 @@ limitations under the License.
 #include "tensorflow/compiler/mlir/python/mlir.h"
 
 #include <string>
+#include <type_traits>
 
+#include "absl/algorithm/container.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/container/inlined_vector.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/str_split.h"
 #include "llvm/Support/raw_ostream.h"
-#include "mlir/IR/BuiltinOps.h"  // from @llvm-project
-#include "mlir/InitAllPasses.h"  // from @llvm-project
-#include "mlir/Parser.h"  // from @llvm-project
+#include "mlir/IR/BuiltinOps.h"     // from @llvm-project
+#include "mlir/InitAllPasses.h"     // from @llvm-project
+#include "mlir/Parser.h"            // from @llvm-project
 #include "mlir/Pass/PassManager.h"  // from @llvm-project
 #include "mlir/Pass/PassRegistry.h"  // from @llvm-project
 #include "tensorflow/c/eager/c_api.h"
@@ -31,15 +38,22 @@ limitations under the License.
 #include "tensorflow/compiler/mlir/tensorflow/transforms/passes.h"
 #include "tensorflow/compiler/mlir/tensorflow/transforms/tf_saved_model_passes.h"
 #include "tensorflow/compiler/mlir/tensorflow/translate/import_model.h"
+#include "tensorflow/compiler/mlir/tensorflow/translate/mlir_roundtrip_flags.h"
 #include "tensorflow/compiler/mlir/tensorflow/translate/tf_mlir_translate.h"
 #include "tensorflow/compiler/mlir/tensorflow/utils/error_util.h"
 #include "tensorflow/compiler/mlir/tensorflow/utils/import_utils.h"
+#include "tensorflow/compiler/xla/status_macros.h"
 #include "tensorflow/core/common_runtime/eager/context.h"
 #include "tensorflow/core/common_runtime/function_body.h"
 #include "tensorflow/core/common_runtime/function_def_utils.h"
 #include "tensorflow/core/framework/function.h"
 #include "tensorflow/core/framework/function.pb.h"
 #include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/tensor_shape.pb.h"
+#include "tensorflow/core/framework/types.h"
+#include "tensorflow/core/framework/types.pb.h"
+#include "tensorflow/core/lib/core/errors.h"
+#include "tensorflow/core/platform/types.h"
 
 namespace tensorflow {
 
@@ -71,17 +85,18 @@ std::string RunPassPipelineOnModule(mlir::ModuleOp module,
 
 }  // anonymous namespace
 
-std::string ImportGraphDef(const std::string &proto,
-                           const std::string &pass_pipeline,
-                           bool show_debug_info, TF_Status *status) {
+static std::string ImportGraphDefImpl(const std::string& proto,
+                                      const std::string& pass_pipeline,
+                                      bool show_debug_info,
+                                      GraphDebugInfo& debug_info,
+                                      GraphImportConfig& specs,
+                                      TF_Status* status) {
   GraphDef graphdef;
   auto s = tensorflow::LoadProtoFromBuffer(proto, &graphdef);
   if (!s.ok()) {
     Set_TF_Status_from_Status(status, s);
     return "// error";
   }
-  GraphDebugInfo debug_info;
-  GraphImportConfig specs;
   mlir::MLIRContext context;
   auto module = ConvertGraphdefToMlir(graphdef, debug_info, specs, &context);
   if (!module.ok()) {
@@ -131,6 +146,104 @@ std::string ImportFunction(const std::string &functiondef_proto,
 
   return RunPassPipelineOnModule(module->get(), pass_pipeline, show_debug_info,
                                  status);
+}
+
+std::string ImportGraphDef(const std::string& proto,
+                           const std::string& pass_pipeline,
+                           bool show_debug_info, TF_Status* status) {
+  GraphDebugInfo debug_info;
+  GraphImportConfig specs;
+  return ImportGraphDefImpl(proto, pass_pipeline, show_debug_info, debug_info,
+                            specs, status);
+}
+
+std::string ImportGraphDef(const std::string& proto,
+                           const std::string& pass_pipeline,
+                           bool show_debug_info, absl::string_view input_names,
+                           absl::string_view input_data_types,
+                           absl::string_view input_data_shapes,
+                           absl::string_view output_names, TF_Status* status) {
+  std::vector<string> node_names = absl::StrSplit(input_names, ',');
+  std::vector<string> node_dtypes = absl::StrSplit(input_data_types, ',');
+  std::vector<string> node_shapes_str = absl::StrSplit(input_data_shapes, ':');
+  std::vector<std::vector<int>> node_shapes;
+
+  std::vector<int> dims;
+  for (const string& shape_str : node_shapes_str) {
+    dims.clear();
+    if(shape_str.empty()) continue;
+    for (const auto& dim_str : absl::StrSplit(shape_str, ',')) {
+      int size;
+      if (absl::SimpleAtoi(dim_str, &size)) {
+        dims.push_back(size);
+      } else {
+        auto s = tensorflow::errors::InvalidArgument("Invalid Shape Specified.",
+                                                     dim_str);
+        Set_TF_Status_from_Status(status, s);
+        return "// error";
+      }
+    }
+    node_shapes.push_back(dims);
+  }
+  std::vector<string> output_nodes = absl::StrSplit(output_names, ',');
+
+  GraphDebugInfo debug_info;
+  GraphImportConfig specs;
+
+  // Set the output to the output nodes.
+  specs.outputs = output_nodes;
+
+  // Set the input values to specs.input.
+  std::vector<std::string> used_node_dtypes;
+  if (node_dtypes.empty() ||
+      (node_dtypes.size() == 1 && node_dtypes[0].empty())) {
+
+    // Mark all the node dtypes Invalid, so the importer can handle them by
+    // using the type from the graph.
+    used_node_dtypes.resize(node_names.size(), DataType_Name(DT_INVALID));
+  } else if (node_names.size() == node_dtypes.size()) {
+    for (const auto& dtype : node_dtypes) {
+      if (dtype.empty()) {
+        used_node_dtypes.push_back(DataType_Name(DT_INVALID));
+      } else if (dtype != DataType_Name(DT_INVALID)) {
+        used_node_dtypes.push_back(dtype);
+
+        // Use '' if you want to use the type from graph.
+      } else {
+        auto s = tensorflow::errors::InvalidArgument(
+            "DT_INVALID isn't a valid input data type");
+        Set_TF_Status_from_Status(status, s);
+        return "// error";
+      }
+    }
+
+    // Unmatched input node array and data type sizes.
+  } else {
+    auto s = tensorflow::errors::InvalidArgument(
+        "Length of input node array and data type doesn't match");
+    Set_TF_Status_from_Status(status, s);
+    return "// error";
+  }
+
+  // Unmatched input node array and data shapes sizes.
+  if (node_names.size() != node_shapes.size()) {
+    auto s = tensorflow::errors::InvalidArgument(
+        "Length of input node array and data shape doesn't match");
+    Set_TF_Status_from_Status(status, s);
+    return "// error";
+  }
+  for (unsigned i = 0, e = node_names.size(); i < e; i++) {
+    const string& name = node_names[i];
+    if (name.empty()) continue;
+
+    auto it_inserted_pair = specs.inputs.insert({name, {}});
+    ArrayInfo& info = it_inserted_pair.first->second;
+    for (auto& dim : node_shapes[i]) {
+      info.shape.add_dim()->set_size(dim);
+    }
+  }
+  return ImportGraphDefImpl(proto, pass_pipeline, show_debug_info, debug_info,
+                            specs, status);
 }
 
 std::string ExperimentalConvertSavedModelToMlir(

--- a/tensorflow/compiler/mlir/python/mlir.h
+++ b/tensorflow/compiler/mlir/python/mlir.h
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include <string>
 
+#include "absl/strings/string_view.h"
 #include "tensorflow/c/eager/c_api.h"
 #include "tensorflow/c/tf_status.h"
 
@@ -43,6 +44,15 @@ std::string ImportFunction(const std::string &functiondef_proto,
                            const std::string &pass_pipeline,
                            bool show_debug_info, TFE_Context *context,
                            TF_Status *status);
+
+// This wrapper passes the graph_def taking names of input nodes, the shapes and
+// types of its inputs and the ouput nodes as parameters to MLIR.
+std::string ImportGraphDef(const std::string& proto,
+                           const std::string& pass_pipeline,
+                           bool show_debug_info, absl::string_view(input_names),
+                           absl::string_view(input_data_types),
+                           absl::string_view(input_data_shapes),
+                           absl::string_view(output_names), TF_Status* status);
 
 // Load a SavedModel and return a textual MLIR string corresponding to it.
 //

--- a/tensorflow/python/compiler/mlir/mlir_test.py
+++ b/tensorflow/python/compiler/mlir/mlir_test.py
@@ -17,7 +17,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-
 from tensorflow.python.compiler.mlir import mlir
 from tensorflow.python.eager import def_function
 from tensorflow.python.framework import dtypes
@@ -25,7 +24,9 @@ from tensorflow.python.framework import errors
 from tensorflow.python.framework import tensor_spec
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import logging_ops
+from tensorflow.python.ops import math_ops
 from tensorflow.python.platform import test
+from  tensorflow.python.pywrap_mlir import import_graphdef
 
 
 class MLIRGraphDefImportTest(test.TestCase):
@@ -40,6 +41,60 @@ class MLIRGraphDefImportTest(test.TestCase):
     with self.assertRaisesRegex(errors.InvalidArgumentError,
                                 'Could not parse input proto'):
       mlir.convert_graph_def('some invalid proto')
+
+  def testGraphDefToTf(self):
+    """Tests the basic flow of `tf.mlir.experimental.convert_graph_def`
+        with tf-standard-pipeline converting all the way to the TF dialect."""
+
+    tensor_shape = (10,10)
+    @def_function.function(
+        input_signature=(
+            tensor_spec.TensorSpec(shape=tensor_shape, dtype=dtypes.float32),
+            tensor_spec.TensorSpec(shape=tensor_shape, dtype=dtypes.float32),
+        )
+    )
+    def add_func(lhs, rhs):
+      return math_ops.add(lhs, rhs)
+
+    tf_graph_def = add_func.get_concrete_function().graph.as_graph_def()
+
+    mlir_tf = import_graphdef(tf_graph_def,
+                                'tf-standard-pipeline',
+                                False,
+                                input_names=["lhs","rhs"],
+                                input_data_types=["DT_FLOAT","DT_FLOAT"],
+                                input_data_shapes=["10,10", "10,10"],
+                                output_names=["Add"])
+
+    # Check whether the mlir-function signature has the mentioned
+    # inputs and outputs.
+    self.assertRegex(mlir_tf, r'func @main')
+    self.assertRegex(mlir_tf, r'inputs = "lhs,rhs"')
+    self.assertRegex(mlir_tf, r'outputs = "Add"')
+
+    # Test invalid test cases where no. of input names argument is invalid/wrong.
+    with self.assertRaisesRegex(errors.InvalidArgumentError,
+            "Length of input node array and data type doesn't match"):
+
+      import_graphdef(tf_graph_def,
+                      'tf-standard-pipeline',
+                      False,
+                      input_names=["lhs"],
+                      input_data_types=["DT_FLOAT","DT_FLOAT"],
+                      input_data_shapes=["10,10", "10,10"],
+                      output_names=["Add"])
+
+    # Test invalid test cases where the input shapes argument is wrong.
+    with self.assertRaisesRegex(errors.InvalidArgumentError,
+                                "Dimensions must be equal"):
+
+      import_graphdef(tf_graph_def,
+                      'tf-standard-pipeline',
+                      False,
+                      input_names=["lhs","rhs"],
+                      input_data_types=["DT_FLOAT","DT_FLOAT"],
+                      input_data_shapes=["10,11", "10,10"],
+                      output_names=["Add"])
 
 
 class MLIRConcreteFunctionImportTest(test.TestCase):

--- a/tensorflow/python/mlir_wrapper.cc
+++ b/tensorflow/python/mlir_wrapper.cc
@@ -47,9 +47,24 @@ PYBIND11_MODULE(_pywrap_mlir, m) {
           return output;
         });
 
+  m.def("ImportGraphDef",
+        [](const std::string& graphdef, const std::string& pass_pipeline,
+           bool show_debug_info, const std::string& input_names,
+           const std::string& input_data_types,
+           const std::string& input_data_shapes,
+           const std::string& output_names) {
+          tensorflow::Safe_TF_StatusPtr status =
+              tensorflow::make_safe(TF_NewStatus());
+          std::string output = tensorflow::ImportGraphDef(
+              graphdef, pass_pipeline, show_debug_info, input_names,
+              input_data_types, input_data_shapes, output_names, status.get());
+          tensorflow::MaybeRaiseRegisteredFromTFStatus(status.get());
+          return output;
+        });
+
   m.def("ExperimentalConvertSavedModelToMlir",
-        [](const std::string &saved_model_path,
-           const std::string &exported_names, bool show_debug_info) {
+        [](const std::string& saved_model_path,
+           const std::string& exported_names, bool show_debug_info) {
           tensorflow::Safe_TF_StatusPtr status =
               tensorflow::make_safe(TF_NewStatus());
           std::string output = tensorflow::ExperimentalConvertSavedModelToMlir(

--- a/tensorflow/python/pywrap_mlir.py
+++ b/tensorflow/python/pywrap_mlir.py
@@ -24,10 +24,21 @@ from tensorflow.python.eager import context
 from tensorflow.python._pywrap_mlir import *
 
 
-def import_graphdef(graphdef, pass_pipeline, show_debug_info):
-  return ImportGraphDef(
-      str(graphdef).encode('utf-8'), pass_pipeline.encode('utf-8'),
-      show_debug_info)
+def import_graphdef(graphdef, pass_pipeline, show_debug_info,
+                    input_names=None, input_data_types=None,
+                    input_data_shapes=None, output_names=[]):
+  if input_names is not None:
+    return ImportGraphDef(
+        str(graphdef).encode('utf-8'),
+        pass_pipeline.encode('utf-8'),
+        show_debug_info,
+        ','.join(input_names).encode('utf-8'),
+        ','.join(input_data_types).encode('utf-8'),
+        ':'.join(input_data_shapes).encode('utf-8'),
+        ','.join(output_names).encode('utf-8'))
+  return ImportGraphDef(str(graphdef).encode('utf-8'),
+                        pass_pipeline.encode('utf-8'),
+                        show_debug_info)
 
 
 def import_function(concrete_function, pass_pipeline, show_debug_info):


### PR DESCRIPTION
Update the Python binding from Graphdef to TF-MLIR with input/output
options - add non-trivial test cases.