### PR TITLE
Fix xtensa build.

### DIFF
--- a/tensorflow/lite/micro/kernels/xtensa/softmax_int8_int16.cc
+++ b/tensorflow/lite/micro/kernels/xtensa/softmax_int8_int16.cc
@@ -225,9 +225,9 @@ TfLiteStatus EvalHifi(const XtensaSoftmaxOpData* op_data,
   }
   return kTfLiteOk;
 }
-}  // namespace
-
 #endif  // defined(FUSION_F1) || defined(HIFI5)
+
+}  // namespace
 
 void* XtensaInitSoftmax(TfLiteContext* context, const char* buffer,
                         size_t length) {


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/49117 was only tested for Fusion F1 and broke the Hifimini and Vision P6 builds.

Verified that with this change, the following commands pass:
```
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=hifimini XTENSA_CORE=mini1m1m_RG run_keyword_benchmark -j8
make -f tensorflow/lite/micro/tools/make/Makefile TARGET=xtensa OPTIMIZED_KERNEL_DIR=xtensa TARGET_ARCH=vision_p6 XTENSA_CORE=P6_200528 build -j8
```
