### PR TITLE
Fix `tf.raw_ops.CTCGreedyDecoder` CHECK failure.

### DIFF
--- a/tensorflow/core/kernels/ctc_decoder_ops.cc
+++ b/tensorflow/core/kernels/ctc_decoder_ops.cc
@@ -232,6 +232,8 @@ class CTCGreedyDecoderOp : public OpKernel {
         int prev_indices = -1;
         for (int t = 0; t < seq_len_t(b); ++t) {
           int max_class_indices;
+          OP_REQUIRES(ctx, input_list_t[t].dimension(1) > 0,
+                      errors::InvalidArgument("Invalid input dimensions."));
           log_prob_t(b, 0) +=
               -RowMax<T>(input_list_t[t], b, &max_class_indices);
           if (max_class_indices != blank_index &&


### PR DESCRIPTION
PiperOrigin-RevId: 369960465
Change-Id: If0b8b3264d5a47a24ac0970ed7b81ce6b4921fae