### PR TITLE
Suppress TF-32 warning print when disabled by TF's own API

### DIFF
--- a/tensorflow/stream_executor/cuda/cuda_blas.cc
+++ b/tensorflow/stream_executor/cuda/cuda_blas.cc
@@ -1758,8 +1758,11 @@ port::Status CUDABlas::DoBlasGemm(Stream *stream, blas::Transpose transa,
         cc_major >= 8) {
       // TODO(reedwm): Remove or make this VLOG(1) once TensorFloat-32 is more
       // well tested.
-      LOG_FIRST_N(INFO, 1) << "TensorFloat-32 will be used for the matrix "
-                              "multiplication. This will only be logged once.";
+      if (tensorflow::tensor_float_32_execution_enabled()) {
+        LOG_FIRST_N(INFO, 1) << "TensorFloat-32 will be used for the matrix "
+                                "multiplication. This will only be logged "
+                                "once.";
+      }
     }
   }
 #endif


### PR DESCRIPTION
Suppress TF's warning message about the use of TensorFloat-32 when TensorFloat-32 is disabled by its own API,  `tf.config.experimental.enable_tensor_float_32_execution(false)`.  Note that, environment variable `NVIDIA_TF32_OVERRIDE=0` will indeed disable TF32 evaluation, but it couldn't be peeked by TF at this moment. So no effect is expected from `NVIDIA_TF32_OVERRIDE=0`.