### PR TITLE
Remove the AMDGPU due to duplicated dependency

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/BUILD
@@ -30,7 +30,6 @@ cc_library(
         "utils.h",
     ],
     deps = [
-        "@llvm-project//llvm:AMDGPUCodeGen",
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
@@ -60,6 +59,7 @@ cc_library(
         "//tensorflow/core/profiler/lib:traceme",
     ] + if_rocm_is_configured([
         "@local_config_rocm//rocm:rocm_headers",
+        "@llvm-project//llvm:AMDGPUCodeGen",
     ]),
 )
 


### PR DESCRIPTION
The PR #49163 has moved the "llvm:AMDGPUCodeGen" dependency into the "if_rocm_is_configured". However, in the merge commit (commit id: 013bf86), this dependency appears twice for ROCm builds. This makes the build to fail for AMD GPUs.