### PR TITLE
Replace --extra-index-url to --index-url to prevent typosquatting

### DIFF
--- a/tensorflow/lite/g3doc/guide/python.md
+++ b/tensorflow/lite/g3doc/guide/python.md
@@ -46,7 +46,7 @@ echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" | sud
 For all other systems, you can install with pip:
 
 <pre class="devsite-terminal devsite-click-to-copy">
-pip3 install --extra-index-url https://google-coral.github.io/py-repo/ tflite_runtime
+pip3 install --index-url https://google-coral.github.io/py-repo/ tflite_runtime
 </pre>
 
 If you'd like to manually install a Python wheel, you can select one from


### PR DESCRIPTION
The tflite_runtime package is not in PyPI and its name is available. With --extra-index-url, if the version is higher, pip will infer to PyPI. This may result in typosquatting.

This is a minor fix.