### PR TITLE
Add note about automatic input expansion

### DIFF
--- a/tensorflow/python/keras/engine/training.py
+++ b/tensorflow/python/keras/engine/training.py
@@ -162,7 +162,11 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
 
   2 - By subclassing the `Model` class: in that case, you should define your
   layers in `__init__` and you should implement the model's forward pass
-  in `call`.
+  in `call`. Note that because this method of instantiation does not include an
+  explicit `Input` operation defining the input shape, inputs will
+  automatically be expanded to at least 2D in `model.fit()`, model.predict()`,
+  and `model.evaluate() so that the first dimension can be assumed to be the
+  batch dimension.
 
   ```python
   import tensorflow as tf


### PR DESCRIPTION
As discussed in https://github.com/tensorflow/tensorflow/issues/42046 this documents the fact that TensorFlow automatically expands inputs to at least 2D when calling functions on Keras models (this actually happens in `model.train_step`, `model.test_step`, and `model.predict_step`, but I suspect those are used less frequently than `model.fit()`, etc).

This should hopefully reduce confusion between

`outputs = model(inputs)  # allows 1D inputs`

and

`outputs = model.predict(inputs)  # will automatically expand 1D inputs to 2D`