### PR TITLE
Added missing reshape folding for MEAN op to TFLite MLIR converter

### DIFF
--- a/tensorflow/compiler/mlir/lite/tests/optimize.mlir
+++ b/tensorflow/compiler/mlir/lite/tests/optimize.mlir
@@ -1536,6 +1536,18 @@ func @FoldReduceProdKeepDim(%arg0: tensor<8x128xf32>) -> tensor<1x1xf32> {
 // CHECK: return %[[RESULT]] : tensor<1x1xf32>
 }
 
+func @FoldReduceMeanKeepDim(%arg0: tensor<8x128xf32>) -> tensor<1x128xf32> {
+  %cst = constant dense<0> : tensor<1xi32>
+  %cst_1 = constant dense<[1, 128]> : tensor<2xi32>
+  %0 = "tfl.reduce_mean"(%arg0, %cst) {keep_dims = false} : (tensor<8x128xf32>, tensor<1xi32>) -> tensor<128xf32>
+  %1 = "tfl.reshape"(%0, %cst_1) : (tensor<128xf32>, tensor<2xi32>) -> tensor<1x128xf32>
+  return %1 : tensor<1x128xf32>
+
+// CHECK-LABEL: FoldReduceMeanKeepDim
+// CHECK: %[[RESULT:.*]] = "tfl.reduce_mean"(%arg0, %cst) {keep_dims = true} : (tensor<8x128xf32>, tensor<1xi32>) -> tensor<1x128xf32>
+// CHECK: return %[[RESULT]] : tensor<1x128xf32>
+}
+
 func @SoftMaxWithNormalization(%arg0: tensor<8x128xf32>) -> tensor<8x128xf32> {
   %cst = constant dense<1> : tensor<1xi32>
   %0 = "tfl.reduce_max"(%arg0, %cst) {keep_dims = true} : (tensor<8x128xf32>, tensor<1xi32>) -> tensor<8x1xf32>

--- a/tensorflow/compiler/mlir/lite/tests/optimize.mlir
+++ b/tensorflow/compiler/mlir/lite/tests/optimize.mlir
@@ -1536,15 +1536,15 @@ func @FoldReduceProdKeepDim(%arg0: tensor<8x128xf32>) -> tensor<1x1xf32> {
 // CHECK: return %[[RESULT]] : tensor<1x1xf32>
 }
 
-func @FoldReduceMeanKeepDim(%arg0: tensor<8x128xf32>) -> tensor<1x128xf32> {
+func @FoldMeanKeepDim(%arg0: tensor<8x128xf32>) -> tensor<1x128xf32> {
   %cst = constant dense<0> : tensor<1xi32>
   %cst_1 = constant dense<[1, 128]> : tensor<2xi32>
-  %0 = "tfl.reduce_mean"(%arg0, %cst) {keep_dims = false} : (tensor<8x128xf32>, tensor<1xi32>) -> tensor<128xf32>
+  %0 = "tfl.mean"(%arg0, %cst) {keep_dims = false} : (tensor<8x128xf32>, tensor<1xi32>) -> tensor<128xf32>
   %1 = "tfl.reshape"(%0, %cst_1) : (tensor<128xf32>, tensor<2xi32>) -> tensor<1x128xf32>
   return %1 : tensor<1x128xf32>
 
-// CHECK-LABEL: FoldReduceMeanKeepDim
-// CHECK: %[[RESULT:.*]] = "tfl.reduce_mean"(%arg0, %cst) {keep_dims = true} : (tensor<8x128xf32>, tensor<1xi32>) -> tensor<1x128xf32>
+// CHECK-LABEL: FoldMeanKeepDim
+// CHECK: %[[RESULT:.*]] = "tfl.mean"(%arg0, %cst) {keep_dims = true} : (tensor<8x128xf32>, tensor<1xi32>) -> tensor<1x128xf32>
 // CHECK: return %[[RESULT]] : tensor<1x128xf32>
 }
 

--- a/tensorflow/compiler/mlir/lite/transforms/optimize_patterns.td
+++ b/tensorflow/compiler/mlir/lite/transforms/optimize_patterns.td
@@ -742,7 +742,7 @@ def ShapeMatchesReduceWithKeepAxes : Constraint<CPred<
 // Fold reshapes re-inserting reduced dimensions into the results of a reduction
 // with `keep_dims=false` by changing it to one using `keep_dims=true`.
 foreach ReduceOp = [TFL_ReduceMaxOp, TFL_ReduceMinOp, TFL_ReduceProdOp,
-                    TFL_SumOp] in {
+                    TFL_SumOp, TFL_MeanOp] in {
   def FoldReshapeTo#ReduceOp : Pat<
     (TFL_ReshapeOp
       (ReduceOp:$reduce $input, (ConstantOp I32ElementsAttr: $axes),

--- a/tensorflow/compiler/mlir/lite/transforms/optimize_patterns.td
+++ b/tensorflow/compiler/mlir/lite/transforms/optimize_patterns.td
@@ -741,8 +741,8 @@ def ShapeMatchesReduceWithKeepAxes : Constraint<CPred<
 
 // Fold reshapes re-inserting reduced dimensions into the results of a reduction
 // with `keep_dims=false` by changing it to one using `keep_dims=true`.
-foreach ReduceOp = [TFL_ReduceMaxOp, TFL_ReduceMinOp, TFL_ReduceProdOp,
-                    TFL_SumOp, TFL_MeanOp] in {
+foreach ReduceOp = [TFL_MeanOp, TFL_ReduceMaxOp, TFL_ReduceMinOp,
+                    TFL_ReduceProdOp, TFL_SumOp] in {
   def FoldReshapeTo#ReduceOp : Pat<
     (TFL_ReshapeOp
       (ReduceOp:$reduce $input, (ConstantOp I32ElementsAttr: $axes),


### PR DESCRIPTION
Added optimizing pattern for folding RESHAPE op in MEAN op when the former is following the latter with `keep_dims=false` for re-inserting reduced dimensions to TFLite MLIR converter. Apparently it is supposed to be there before, but was missing for some reason. Without the proposed fix MLIR converter may produce a very inefficient model when quantization is used, because `keep_dims=true` is an [essential condition](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/kernels/reduce.cc#L316) for using optimized reduce kernel instead of reference one.