### PR TITLE
added Returns and Raises for Reshape class

### DIFF
--- a/tensorflow/python/keras/layers/core.py
+++ b/tensorflow/python/keras/layers/core.py
@@ -492,6 +492,12 @@ class Reshape(Layer):
       target_shape: Target shape. Tuple of integers, does not include the
         samples dimension (batch size).
       **kwargs: Any additional layer keyword arguments.
+    
+    Returns:
+      A layer to Reshape the input.
+    
+    Raises:
+      ValueError: If input_shape and target_shape are of different shape.
     """
     super(Reshape, self).__init__(**kwargs)
     self.target_shape = tuple(target_shape)


### PR DESCRIPTION
Updated `Reshape` class with `Returns` and `Raises` 
[Here](https://colab.research.google.com/gist/jvishnuvardhan/c6d059fd1b0a26c83d809d2bef500f52/untitled989.ipynb) is a gist to show the `Value_error`.