### PR TITLE
Fix a BUILD file for fusion ops to use Cudnn Frontend 

### DIFF
--- a/tensorflow/stream_executor/BUILD
+++ b/tensorflow/stream_executor/BUILD
@@ -10,6 +10,8 @@ load("//tensorflow:tensorflow.bzl", "tf_cc_test")
 load("//tensorflow/core/platform:build_config.bzl", "tf_proto_library")
 load("//tensorflow/core/platform:build_config_root.bzl", "if_static")
 load("//tensorflow/stream_executor:build_defs.bzl", "stream_executor_friends")
+load("//tensorflow/core/platform/default:cuda_build_defs.bzl",
+     "if_cuda_is_configured")
 
 package(
     default_visibility = [":friends"],
@@ -541,6 +543,7 @@ cc_library(
         "@com_google_absl//absl/types:optional",
         "@com_google_absl//absl/types:span",
     ],
+    copts = if_cuda_is_configured(["-DGOOGLE_CUDA=1"]),
 )
 
 # The stream_executor_headers target does not prescribe an implementation.

--- a/tensorflow/stream_executor/BUILD
+++ b/tensorflow/stream_executor/BUILD
@@ -4,16 +4,12 @@
 # Throughout this file, all targets are built with the standard crosstool and
 # do not link against restricted binary blobs.
 
-load("//tensorflow:tensorflow.bzl", "filegroup")
+load("//tensorflow:tensorflow.bzl", "filegroup", "tf_cuda_library")
 load("//tensorflow/core/platform:rules_cc.bzl", "cc_library")
 load("//tensorflow:tensorflow.bzl", "tf_cc_test")
 load("//tensorflow/core/platform:build_config.bzl", "tf_proto_library")
 load("//tensorflow/core/platform:build_config_root.bzl", "if_static")
 load("//tensorflow/stream_executor:build_defs.bzl", "stream_executor_friends")
-load(
-    "//tensorflow/core/platform/default:cuda_build_defs.bzl",
-    "if_cuda_is_configured",
-)
 
 package(
     default_visibility = [":friends"],
@@ -508,14 +504,13 @@ cc_library(
 )
 
 # It implements :stream_executor_pimpl_header
-cc_library(
+tf_cuda_library(
     name = "stream_executor_pimpl",
     srcs = [
         "stream.cc",
         "stream_executor_pimpl.cc",
     ],
     hdrs = ["stream_executor_pimpl.h"],
-    copts = if_cuda_is_configured(["-DGOOGLE_CUDA=1"]),
     deps = [
         ":blas",
         ":device_memory",

--- a/tensorflow/stream_executor/BUILD
+++ b/tensorflow/stream_executor/BUILD
@@ -10,8 +10,10 @@ load("//tensorflow:tensorflow.bzl", "tf_cc_test")
 load("//tensorflow/core/platform:build_config.bzl", "tf_proto_library")
 load("//tensorflow/core/platform:build_config_root.bzl", "if_static")
 load("//tensorflow/stream_executor:build_defs.bzl", "stream_executor_friends")
-load("//tensorflow/core/platform/default:cuda_build_defs.bzl",
-     "if_cuda_is_configured")
+load(
+    "//tensorflow/core/platform/default:cuda_build_defs.bzl",
+    "if_cuda_is_configured",
+)
 
 package(
     default_visibility = [":friends"],
@@ -513,6 +515,7 @@ cc_library(
         "stream_executor_pimpl.cc",
     ],
     hdrs = ["stream_executor_pimpl.h"],
+    copts = if_cuda_is_configured(["-DGOOGLE_CUDA=1"]),
     deps = [
         ":blas",
         ":device_memory",
@@ -543,7 +546,6 @@ cc_library(
         "@com_google_absl//absl/types:optional",
         "@com_google_absl//absl/types:span",
     ],
-    copts = if_cuda_is_configured(["-DGOOGLE_CUDA=1"]),
 )
 
 # The stream_executor_headers target does not prescribe an implementation.


### PR DESCRIPTION
This fixes an issue when using the Cudnn Frontend for fusion ops. Specifically, the `StreamExecutor::GetFusedConvolveExecutionPlans` requires GOOGLE_CUDA to enable the Cudnn Frontend API for fusion ops. So, we need to set it when CUDA config is detected in the BUILD file.

cc. @nluehr 