### PR TITLE
Multiple Eager Rewriters

### DIFF
--- a/tensorflow/compiler/mlir/tfr/integration/node_expansion_pass.cc
+++ b/tensorflow/compiler/mlir/tfr/integration/node_expansion_pass.cc
@@ -92,7 +92,8 @@ Status CompositeOpExpansion::Run(EagerOperation* orig_op,
   return Status::OK();
 }
 
-REGISTER_REWRITE(EagerOpRewriteRegistry::POST_PLACEMENT, CompositeOpExpansion);
+REGISTER_REWRITE(EagerOpRewriteRegistry::POST_PLACEMENT, 20000,
+                 CompositeOpExpansion);
 
 }  // namespace tfr
 }  // namespace tensorflow

--- a/tensorflow/core/common_runtime/eager/eager_op_rewrite_registry.cc
+++ b/tensorflow/core/common_runtime/eager/eager_op_rewrite_registry.cc
@@ -45,13 +45,11 @@ Status EagerOpRewriteRegistry::RunRewrite(
     Phase phase, EagerOperation* orig_op,
     std::unique_ptr<EagerOperation>* out_op) {
   EagerOperation* pre_op = orig_op;
-  std::unique_ptr<EagerOperation>* post_op = out_op;
   for (auto it_rewrites = rewrites_[phase].cbegin();
        it_rewrites != rewrites_[phase].cend(); ++it_rewrites) {
-    TF_RETURN_IF_ERROR(it_rewrites->first->Run(pre_op, post_op));
-    if (*post_op != nullptr) {
-      pre_op = post_op->release();
-      out_op->reset(pre_op);
+    TF_RETURN_IF_ERROR(it_rewrites->first->Run(pre_op, out_op));
+    if (*out_op != nullptr) {
+      pre_op = out_op->get();
     }
   }
 

--- a/tensorflow/core/common_runtime/eager/eager_op_rewrite_registry.h
+++ b/tensorflow/core/common_runtime/eager/eager_op_rewrite_registry.h
@@ -70,10 +70,10 @@ class EagerOpRewriteRegistry {
 
  private:
   static constexpr int32 kNumPhases = 2;
-  // Holds all the registered Eager op rewrites.
-  std::array<std::list<std::unique_ptr<EagerOpRewrite>>, kNumPhases> rewrites_;
-  // Holds the ordinals of the registered op rewrites.
-  std::array<std::list<int32>, kNumPhases> ordinals_;
+  // Holds all the registered Eager op rewrites and their ordinal numbers.
+  std::array<std::list<std::pair<std::unique_ptr<EagerOpRewrite>, int32>>,
+             kNumPhases>
+      rewrites_;
 };
 
 namespace eager_rewrite_registration {

--- a/tensorflow/core/common_runtime/eager/eager_op_rewrite_registry.h
+++ b/tensorflow/core/common_runtime/eager/eager_op_rewrite_registry.h
@@ -57,7 +57,6 @@ class EagerOpRewriteRegistry {
   };
 
   // Add a rewrite pass to the registry.
-  // Only one rewrite pass is allowed per phase.
   void Register(Phase phase, int32 ordinal,
                 std::unique_ptr<EagerOpRewrite> pass);
 

--- a/tensorflow/core/common_runtime/eager/eager_op_rewrite_registry.h
+++ b/tensorflow/core/common_runtime/eager/eager_op_rewrite_registry.h
@@ -15,9 +15,6 @@ limitations under the License.
 #ifndef TENSORFLOW_CORE_COMMON_RUNTIME_EAGER_EAGER_OP_REWRITE_REGISTRY_H_
 #define TENSORFLOW_CORE_COMMON_RUNTIME_EAGER_EAGER_OP_REWRITE_REGISTRY_H_
 
-#include <map>
-#include <vector>
-
 #include "tensorflow/core/common_runtime/eager/eager_operation.h"
 
 namespace tensorflow {
@@ -61,7 +58,8 @@ class EagerOpRewriteRegistry {
 
   // Add a rewrite pass to the registry.
   // Only one rewrite pass is allowed per phase.
-  void Register(Phase phase, std::unique_ptr<EagerOpRewrite> pass);
+  void Register(Phase phase, int32 ordinal,
+                std::unique_ptr<EagerOpRewrite> pass);
 
   // Run the rewrite pass registered for a given phase.
   Status RunRewrite(Phase phase, EagerOperation* orig_op,
@@ -73,7 +71,9 @@ class EagerOpRewriteRegistry {
  private:
   static constexpr int32 kNumPhases = 2;
   // Holds all the registered Eager op rewrites.
-  std::array<std::unique_ptr<EagerOpRewrite>, kNumPhases> rewrites_;
+  std::array<std::list<std::unique_ptr<EagerOpRewrite>>, kNumPhases> rewrites_;
+  // Holds the ordinals of the registered op rewrites.
+  std::array<std::list<int32>, kNumPhases> ordinals_;
 };
 
 namespace eager_rewrite_registration {
@@ -81,23 +81,24 @@ namespace eager_rewrite_registration {
 // This class is used to register a new Eager Op rewrite.
 class EagerRewriteRegistration {
  public:
-  EagerRewriteRegistration(EagerOpRewriteRegistry::Phase phase,
+  EagerRewriteRegistration(EagerOpRewriteRegistry::Phase phase, int32 ordinal,
                            std::unique_ptr<EagerOpRewrite> pass) {
-    EagerOpRewriteRegistry::Global()->Register(phase, std::move(pass));
+    EagerOpRewriteRegistry::Global()->Register(phase, ordinal, std::move(pass));
   }
 };
 
 }  // namespace eager_rewrite_registration
 
-#define REGISTER_REWRITE(phase, rewrite) \
-  REGISTER_REWRITE_UNIQ_HELPER(__COUNTER__, __FILE__, __LINE__, phase, rewrite)
+#define REGISTER_REWRITE(phase, ordinal, rewrite)                      \
+  REGISTER_REWRITE_UNIQ_HELPER(__COUNTER__, __FILE__, __LINE__, phase, \
+                               ordinal, rewrite)
 
-#define REGISTER_REWRITE_UNIQ_HELPER(ctr, file, line, phase, rewrite) \
-  REGISTER_REWRITE_UNIQ(ctr, file, line, phase, rewrite)
+#define REGISTER_REWRITE_UNIQ_HELPER(ctr, file, line, phase, ordinal, rewrite) \
+  REGISTER_REWRITE_UNIQ(ctr, file, line, phase, ordinal, rewrite)
 
-#define REGISTER_REWRITE_UNIQ(ctr, file, line, phase, rewrite)                \
+#define REGISTER_REWRITE_UNIQ(ctr, file, line, phase, ordinal, rewrite)       \
   static ::tensorflow::eager_rewrite_registration::EagerRewriteRegistration   \
-      register_rewrite_##ctr(phase,                                           \
+      register_rewrite_##ctr(phase, ordinal,                                  \
                              ::std::unique_ptr<::tensorflow::EagerOpRewrite>( \
                                  new rewrite(#rewrite, file, #line)))
 

--- a/tensorflow/core/common_runtime/eager/eager_op_rewrite_registry_test.cc
+++ b/tensorflow/core/common_runtime/eager/eager_op_rewrite_registry_test.cc
@@ -39,7 +39,11 @@ class TestEagerOpRewrite : public EagerOpRewrite {
 
 int TestEagerOpRewrite::count_ = 0;
 
-REGISTER_REWRITE(EagerOpRewriteRegistry::PRE_EXECUTION, TestEagerOpRewrite);
+// Register two rewriter passes during the PRE_EXECUTION phase
+REGISTER_REWRITE(EagerOpRewriteRegistry::PRE_EXECUTION, 10000,
+                 TestEagerOpRewrite);
+REGISTER_REWRITE(EagerOpRewriteRegistry::PRE_EXECUTION, 10001,
+                 TestEagerOpRewrite);
 
 TEST(EagerOpRewriteRegistryTest, RegisterRewritePass) {
   EXPECT_EQ(0, TestEagerOpRewrite::count_);
@@ -54,7 +58,7 @@ TEST(EagerOpRewriteRegistryTest, RegisterRewritePass) {
   EXPECT_EQ(Status::OK(),
             EagerOpRewriteRegistry::Global()->RunRewrite(
                 EagerOpRewriteRegistry::PRE_EXECUTION, &orig_op, &out_op));
-  EXPECT_EQ(1, TestEagerOpRewrite::count_);
+  EXPECT_EQ(2, TestEagerOpRewrite::count_);
   EXPECT_EQ("NoOp", out_op->Name());
   ctx->Unref();
 }

--- a/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite.cc
+++ b/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite.cc
@@ -81,7 +81,8 @@ class MklEagerOpRewrite : public EagerOpRewrite {
   std::unordered_map<std::string, bool> registered_kernels_map_;
 };
 
-REGISTER_REWRITE(EagerOpRewriteRegistry::PRE_EXECUTION, MklEagerOpRewrite);
+REGISTER_REWRITE(EagerOpRewriteRegistry::PRE_EXECUTION, 20000,
+                 MklEagerOpRewrite);
 
 // Constructor
 MklEagerOpRewrite::MklEagerOpRewrite(string name, string file, string line)


### PR DESCRIPTION
Enables the configuration of multiple rewriters for each of the rewriter phases in eager mode. The order of execution of the rewriters of each phase is determined by an integer ordinal number prescribed in the registration of the rewriters.