### PR TITLE
Make the C API dims constant for the Allocate functions

### DIFF
--- a/tensorflow/c/kernels.cc
+++ b/tensorflow/c/kernels.cc
@@ -460,14 +460,14 @@ int64_t TF_StepId(TF_OpKernelContext* ctx) {
 }
 
 TF_Tensor* TF_AllocateOutput(TF_OpKernelContext* context, int index,
-                             TF_DataType dtype, int64_t* dims, int num_dims,
-                             size_t len, TF_Status* status) {
+                             TF_DataType dtype, const int64_t* dims,
+                             int num_dims, size_t len, TF_Status* status) {
   TF_SetStatus(status, TF_OK, "");
   auto* cc_ctx = reinterpret_cast<::tensorflow::OpKernelContext*>(context);
   static_assert(sizeof(int64_t) == sizeof(tensorflow::int64),
                 "64-bit int types should match in size");
-  tensorflow::gtl::ArraySlice<tensorflow::int64> dimarray(
-      reinterpret_cast<tensorflow::int64*>(dims), num_dims);
+  tensorflow::gtl::ArraySlice<const tensorflow::int64> dimarray(
+      reinterpret_cast<const tensorflow::int64*>(dims), num_dims);
   tensorflow::Tensor* tensor;
   tensorflow::Status s = cc_ctx->allocate_output(
       index, tensorflow::TensorShape(dimarray), &tensor);
@@ -485,8 +485,9 @@ TF_Tensor* TF_AllocateOutput(TF_OpKernelContext* context, int index,
 
 TF_Tensor* TF_ForwardInputOrAllocateOutput(
     TF_OpKernelContext* context, int* candidate_input_indices,
-    int num_candidate_input_indices, int output_index, int64_t* output_dims,
-    int output_num_dims, int* forwarded_input, TF_Status* status) {
+    int num_candidate_input_indices, int output_index,
+    const int64_t* output_dims, int output_num_dims, int* forwarded_input,
+    TF_Status* status) {
   TF_SetStatus(status, TF_OK, "");
   auto* cc_ctx = reinterpret_cast<::tensorflow::OpKernelContext*>(context);
 
@@ -494,8 +495,8 @@ TF_Tensor* TF_ForwardInputOrAllocateOutput(
                 "64-bit int types should match in size");
   tensorflow::gtl::ArraySlice<int> input_indices_array(
       candidate_input_indices, num_candidate_input_indices);
-  tensorflow::gtl::ArraySlice<tensorflow::int64> output_dimarray(
-      reinterpret_cast<tensorflow::int64*>(output_dims), output_num_dims);
+  tensorflow::gtl::ArraySlice<const tensorflow::int64> output_dimarray(
+      reinterpret_cast<const tensorflow::int64*>(output_dims), output_num_dims);
   tensorflow::Tensor* output_tensor_pointer;
   tensorflow::Status s = cc_ctx->forward_input_or_allocate_output(
       input_indices_array, output_index,
@@ -514,15 +515,15 @@ TF_Tensor* TF_ForwardInputOrAllocateOutput(
 }
 
 TF_Tensor* TF_AllocateTemp(TF_OpKernelContext* context, TF_DataType dtype,
-                           int64_t* dims, int num_dims,
+                           const int64_t* dims, int num_dims,
                            TF_AllocatorAttributes* attributes,
                            TF_Status* status) {
   auto* cc_ctx = reinterpret_cast<::tensorflow::OpKernelContext*>(context);
   TF_SetStatus(status, TF_OK, "");
   static_assert(sizeof(int64_t) == sizeof(tensorflow::int64),
                 "64-bit int types should match in size");
-  tensorflow::gtl::ArraySlice<tensorflow::int64> dimarray(
-      reinterpret_cast<tensorflow::int64*>(dims), num_dims);
+  tensorflow::gtl::ArraySlice<const tensorflow::int64> dimarray(
+      reinterpret_cast<const tensorflow::int64*>(dims), num_dims);
   if (attributes && !attributes->struct_size) {
     TF_SetStatus(
         status, TF_INVALID_ARGUMENT,

--- a/tensorflow/c/kernels.h
+++ b/tensorflow/c/kernels.h
@@ -348,8 +348,9 @@ TF_CAPI_EXPORT TF_Tensor* TF_AllocateOutput(TF_OpKernelContext* context,
 // -1.
 TF_CAPI_EXPORT TF_Tensor* TF_ForwardInputOrAllocateOutput(
     TF_OpKernelContext* context, int* candidate_input_indices,
-    int num_candidate_input_indices, int output_index, int64_t* output_dims,
-    int output_num_dims, int* forwarded_input, TF_Status* status);
+    int num_candidate_input_indices, int output_index,
+    const int64_t* output_dims, int output_num_dims, int* forwarded_input,
+    TF_Status* status);
 
 // Allocates a temporary Tensor of the specified type and shape. The
 // Tensor must not be used after kernel construction is
@@ -357,8 +358,8 @@ TF_CAPI_EXPORT TF_Tensor* TF_ForwardInputOrAllocateOutput(
 //
 // num_dims must equal the size of array dims
 TF_CAPI_EXPORT extern TF_Tensor* TF_AllocateTemp(
-    TF_OpKernelContext* context, TF_DataType dtype, int64_t* dims, int num_dims,
-    TF_AllocatorAttributes* alloc_attrs, TF_Status* status);
+    TF_OpKernelContext* context, TF_DataType dtype, const int64_t* dims,
+    int num_dims, TF_AllocatorAttributes* alloc_attrs, TF_Status* status);
 
 #ifdef __cplusplus
 } /* end extern "C" */

--- a/tensorflow/c/kernels.h
+++ b/tensorflow/c/kernels.h
@@ -337,7 +337,7 @@ TF_CAPI_EXPORT extern TF_StringView TF_OpKernelConstruction_GetName(
 // compute function.
 TF_CAPI_EXPORT TF_Tensor* TF_AllocateOutput(TF_OpKernelContext* context,
                                             int index, TF_DataType dtype,
-                                            int64_t* dims, int num_dims,
+                                            const int64_t* dims, int num_dims,
                                             size_t len, TF_Status* status);
 
 // Tries to forward one of the inputs given in input_indices to


### PR DESCRIPTION
The Allocate functions don't modify the dimensions at all, so there's no reason they can't be constant. This makes it easier to call the API deep in a codebase when using arrays that we're not allowed to modify.