### PR TITLE
[MLIR][DISC] Add memref_disc dialect as a temporary solution to optim…

### DIFF
--- a/tensorflow/compiler/mlir/hlo/BUILD
+++ b/tensorflow/compiler/mlir/hlo/BUILD
@@ -610,6 +610,7 @@ cc_library(
         ":hlo",
         ":lhlo",
         ":lhlo_gpu",
+        ":memref_disc_dialect",
         "@llvm-project//mlir:IR",
     ],
 )
@@ -697,6 +698,71 @@ cc_library(
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:StandardOps",
         "@llvm-project//mlir:TransformUtils",
+    ],
+    alwayslink = 1,
+)
+
+td_library(
+    name = "memref_disc_ops_td_files",
+    srcs = [
+        "include/mlir-hlo/Dialect/disc/IR/memref_disc_base.td",
+        "include/mlir-hlo/Dialect/disc/IR/memref_disc_ops.td",
+    ],
+    includes = ["include"],
+)
+
+gentbl_cc_library(
+    name = "memref_disc_base_inc_gen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            [
+                "-gen-dialect-decls",
+                "-dialect=memref_disc",
+            ],
+            "include/mlir-hlo/Dialect/disc/IR/memref_disc_ops_dialect.h.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "include/mlir-hlo/Dialect/disc/IR/memref_disc_base.td",
+    deps = [":memref_disc_ops_td_files"],
+)
+
+gentbl_cc_library(
+    name = "memref_disc_ops_inc_gen",
+    strip_include_prefix = "include",
+    tbl_outs = [
+        (
+            ["-gen-op-decls"],
+            "include/mlir-hlo/Dialect/disc/IR/memref_disc_ops.h.inc",
+        ),
+        (
+            ["-gen-op-defs"],
+            "include/mlir-hlo/Dialect/disc/IR/memref_disc_ops.cc.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "include/mlir-hlo/Dialect/disc/IR/memref_disc_ops.td",
+    deps = [":memref_disc_ops_td_files"],
+)
+
+cc_library(
+    name = "memref_disc_dialect",
+    srcs = glob(
+        [
+            "lib/Dialect/disc/IR/*.cc",
+        ],
+    ),
+    hdrs = [
+        "include/mlir-hlo/Dialect/disc/IR/memref_disc.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":memref_disc_base_inc_gen",
+        ":memref_disc_ops_inc_gen",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:MemRefDialect",
+        "@llvm-project//llvm:Support",
     ],
     alwayslink = 1,
 )

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/disc/IR/memref_disc.h
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/disc/IR/memref_disc.h
@@ -1,0 +1,49 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_COMPILER_MLIR_HLO_INCLUDE_MLIR_HLO_DIALECT_MEMREF_DISC_IR_MEMREF_DISC_H_
+#define TENSORFLOW_COMPILER_MLIR_HLO_INCLUDE_MLIR_HLO_DIALECT_MEMREF_DISC_IR_MEMREF_DISC_H_
+
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/Region.h"
+
+class Location;
+class OpBuilder;
+
+//===----------------------------------------------------------------------===//
+// MemRefDisc Dialect
+//===----------------------------------------------------------------------===//
+// MemRefDisc Dialect is an expansion for MemRefDialect for DISC. This is
+// a temporary workaround for optimizing the index calculations during codegen.
+// Refer to
+// https://llvm.discourse.group/t/add-an-expanded-load-store-op-in-memref-dialect/3503/26
+// for more informations.
+//
+// TODO: Re-visit this with solutions like the explicit linearize/delinearize
+// op definition.
+
+#include "mlir-hlo/Dialect/disc/IR/memref_disc_ops_dialect.h.inc"
+
+//===----------------------------------------------------------------------===//
+// MemRefDisc Dialect Operations
+//===----------------------------------------------------------------------===//
+
+#define GET_OP_CLASSES
+#include "mlir-hlo/Dialect/disc/IR/memref_disc_ops.h.inc"
+
+#endif  // TENSORFLOW_COMPILER_MLIR_HLO_INCLUDE_MLIR_HLO_DIALECT_MEMREF_DISC_IR_MEMREF_DISC_H_

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/disc/IR/memref_disc_base.td
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/disc/IR/memref_disc_base.td
@@ -1,0 +1,29 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef MEMREF_DISC_BASE
+#define MEMREF_DISC_BASE
+
+include "mlir/IR/OpBase.td"
+
+def MemRefDisc_Dialect : Dialect {
+  let name = "memref_disc";
+  let cppNamespace = "::mlir::memref_disc";
+  let description = [{
+    Supplement of the `memref` dialect for DISC.
+  }];
+}
+
+#endif // MEMREF_DISC_BASE

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/disc/IR/memref_disc_ops.td
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/disc/IR/memref_disc_ops.td
@@ -1,0 +1,133 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef MEMREF_DISC_OPS
+#define MEMREF_DISC_OPS
+
+include "mlir-hlo/Dialect/disc/IR/memref_disc_base.td"
+include "mlir/IR/OpBase.td"
+
+class MemRefDisc_Op<string mnemonic, list<OpTrait> traits = []>
+    : Op<MemRefDisc_Dialect, mnemonic, traits> {
+  let printer = [{ return ::print(p, *this); }];
+  let verifier = [{ return ::verify(*this); }];
+  let parser = [{ return ::parse$cppClass(parser, result); }];
+}
+
+//===----------------------------------------------------------------------===//
+// LoadLinIdxOp 
+//===----------------------------------------------------------------------===//
+def LoadLinIdxOp : MemRefDisc_Op<"load_lin_idx",
+     [AttrSizedOperandSegments,
+      TypesMatchWith<"result type matches element type of 'memref'",
+                     "memref", "result",
+                     "$_self.cast<MemRefType>().getElementType()">]> {
+
+  let summary = "load_lin_idx operation";
+  let description = [{
+    An variant of the "load" op with optional linear index or multidim
+    index. Either linear or multidim index can be empty but at least one
+    of them must be provided, unless for load from scalar tensor.
+
+    examples:
+      %3 = load %0[][%1, %1] : memref<4x4xi32>
+      %3 = load %0[%2][%1, %1] : memref<4x4xi32>
+      %3 = load %0[%2][] : memref<4x4xi32>
+  }];
+
+  let arguments = (ins AnyMemRef:$memref,
+                       Variadic<Index>:$linear_index,
+                       Variadic<Index>:$indices);
+  let results = (outs AnyType:$result);
+
+  let builders = [
+    OpBuilder<(ins "Value":$memref,
+      "ValueRange":$linear_index,
+      "ValueRange":$indices), [{
+       auto memrefType = memref.getType().cast<MemRefType>();
+       $_state.addOperands(memref);
+       $_state.addOperands(linear_index);
+       $_state.addOperands(indices);
+       $_state.types.push_back(memrefType.getElementType());
+    }]>];
+
+  let extraClassDeclaration = [{
+    Value getMemRef() { return getOperand(0); }
+    void setMemRef(Value value) { setOperand(0, value); }
+    MemRefType getMemRefType() {
+      return getMemRef().getType().cast<MemRefType>();
+    }
+
+    bool hasLinearIndex() { return llvm::size(linear_index()) > 0; }
+    int64_t getNumIndices() { return llvm::size(indices()); }
+    Value getLinearIndex() { return linear_index()[0]; }
+    operand_range getIndices() { return indices(); }
+  }];
+
+  let assemblyFormat = "$memref `[` $linear_index `]``[` $indices `]` attr-dict `:` type($memref)";
+}
+
+//===----------------------------------------------------------------------===//
+// StoreLinIdxOp 
+//===----------------------------------------------------------------------===//
+def StoreLinIdxOp : MemRefDisc_Op<"store_lin_idx",
+     [AttrSizedOperandSegments,
+      TypesMatchWith<"type of 'value' matches element type of 'memref'",
+                     "memref", "value",
+                     "$_self.cast<MemRefType>().getElementType()">]> {
+  let summary = "store operation with potential linear index";
+  let description = [{
+    An variant of the "store" op with optional linear index or multidim
+    index. Either linear or multidim index can be empty but at least one
+    of them must be provided, unless for store to scalar tensor.
+
+    examples:
+      store %v, %A[][%i, %j] : memref<4x128xf32>
+      store %v, %A[%m][%i, %j] : memref<4x128xf32>
+      store %v, %A[%m][] : memref<4x128xf32>
+  }];
+
+  let arguments = (ins AnyType:$value,
+                       AnyMemRef:$memref,
+                       Variadic<Index>:$linear_index,
+                       Variadic<Index>:$indices);
+
+  let builders = [
+    OpBuilder<(ins "Value":$valueToStore, "Value":$memref), [{
+      $_state.addOperands(valueToStore);
+      $_state.addOperands(memref);
+  }]>];
+
+  let extraClassDeclaration = [{
+    Value getValueToStore() { return getOperand(0); }
+    Value getMemRef() { return getOperand(1); }
+    void setMemRef(Value value) { setOperand(1, value); }
+    MemRefType getMemRefType() {
+      return getMemRef().getType().cast<MemRefType>();
+    }
+
+    bool hasLinearIndex() { return llvm::size(linear_index()) > 0; }
+    int64_t getNumIndices() { return llvm::size(indices()); }
+    Value getLinearIndex() { return linear_index()[0]; }
+    operand_range getIndices() { return indices(); }
+  }];
+
+  let verifier = [{ return success(); }];
+  let assemblyFormat = [{
+    $value `,` $memref `[` $linear_index `]``[` $indices `]` attr-dict `:` type($memref)
+  }];
+}
+
+#endif // MEMREF_DISC_OPS

--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/disc/IR/memref_disc_dialect.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/disc/IR/memref_disc_dialect.cc
@@ -1,0 +1,26 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "mlir-hlo/Dialect/disc/IR/memref_disc.h",
+
+using namespace mlir;
+using namespace mlir::memref_disc;
+
+void mlir::memref_disc::MemRefDiscDialect::initialize() {
+  addOperations<
+#define GET_OP_LIST
+#include "mlir-hlo/Dialect/disc/IR/memref_disc_ops.cc.inc"
+      >();
+}

--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/disc/IR/memref_disc_ops.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/disc/IR/memref_disc_ops.cc
@@ -1,0 +1,53 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "mlir-hlo/Dialect/disc/IR/memref_disc.h",
+
+using namespace mlir;
+using namespace mlir::memref_disc;
+
+//===----------------------------------------------------------------------===//
+// LoadLinIdxOp
+//===----------------------------------------------------------------------===//
+
+static LogicalResult verify(LoadLinIdxOp op) {
+  if ((op.getNumIndices() != op.getMemRefType().getRank()) &&
+      (!op.hasLinearIndex())) {
+    return op.emitOpError(
+        "either multidim or linear index must be provided for load");
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// StoreLinIdxOp
+//===----------------------------------------------------------------------===//
+
+static LogicalResult verify(StoreLinIdxOp op) {
+  if ((op.getNumOperands() != op.getMemRefType().getRank()) &&
+      (!op.hasLinearIndex())) {
+    return op.emitOpError("either multidim/linear index must be provided");
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// TableGen'd op method definitions
+//===----------------------------------------------------------------------===//
+
+#define GET_OP_CLASSES
+#include "mlir-hlo/Dialect/disc/IR/memref_disc_ops.cc.inc"

--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/IR/init.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/IR/init.cc
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include "mlir-hlo/Dialect/disc/IR/memref_disc.h"
 #include "mlir-hlo/Dialect/mhlo/IR/chlo_ops.h"
 #include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
 #include "mlir-hlo/Dialect/mhlo/IR/lhlo_gpu_ops.h"
@@ -24,6 +25,7 @@ void mlir::mhlo::registerAllMhloDialects(mlir::DialectRegistry &registry) {
   registry.insert<mlir::chlo::HloClientDialect,
                   mlir::mhlo::MhloDialect,
                   mlir::lmhlo::LmhloDialect,
-                  mlir::lmhlo_gpu::LmhloGpuDialect>();
+                  mlir::lmhlo_gpu::LmhloGpuDialect,
+                  mlir::memref_disc::MemRefDiscDialect>();
   // clang-format on
 }


### PR DESCRIPTION
MemRefDisc Dialect is an expansion for MemRefDialect for DISC. This is a temporary workaround for optimizing the index calculations during codegen. Refer to https://llvm.discourse.group/t/add-an-expanded-load-store-op-in-memref-dialect/3503/26 for background informations.