### PR TITLE
Add docs about forcing zero output for mask with Bidirectional

### DIFF
--- a/tensorflow/python/keras/layers/wrappers.py
+++ b/tensorflow/python/keras/layers/wrappers.py
@@ -393,6 +393,9 @@ class Bidirectional(Wrapper):
       Note that the recommended way to create new RNN layers is to write a
       custom RNN cell and use it with `keras.layers.RNN`, instead of
       subclassing `keras.layers.Layer` directly.
+      - When the `returns_sequences` is true, the output of the masked timestep
+      will be zero regardless of the layer's original `zero_output_for_mask`
+      value.
     merge_mode: Mode by which outputs of the forward and backward RNNs will be
       combined. One of {'sum', 'mul', 'concat', 'ave', None}. If None, the
       outputs will not be combined, they will be returned as a list. Default


### PR DESCRIPTION
#49738 
Add description that the output of mask timestep is zero when `returns_sequences` of layer is true with Bidirectional.