### PR TITLE
micro:BATCH_MATMUL PR3-5

### DIFF
--- a/tensorflow/lite/micro/all_ops_resolver.cc
+++ b/tensorflow/lite/micro/all_ops_resolver.cc
@@ -27,6 +27,7 @@ AllOpsResolver::AllOpsResolver() {
   AddArgMax();
   AddArgMin();
   AddAveragePool2D();
+  AddBatchMatMul();
   AddBatchToSpaceNd();
   AddCeil();
   AddConcatenation();

--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -37,6 +37,20 @@ cc_library(
 )
 
 cc_library(
+    name = "batch_matmul_test_util",
+    hdrs = ["batch_matmul_test_util.h"],
+    deps = [
+        "//tensorflow/lite/c:common",
+        "//tensorflow/lite/kernels/internal:compatibility",
+        "//tensorflow/lite/kernels/internal:types",
+        "//tensorflow/lite/micro:debug_log",
+        "//tensorflow/lite/micro:micro_utils",
+        "//tensorflow/lite/micro:test_helpers",
+        "//tensorflow/lite/micro/testing:micro_test",
+    ],
+)
+
+cc_library(
     name = "circular_buffer_flexbuffers_generated_data",
     srcs = [
         "circular_buffer_flexbuffers_generated_data.cc",
@@ -463,6 +477,7 @@ cc_test(
         "batch_matmul_test.cc",
     ],
     deps = [
+        ":batch_matmul_test_util",
         ":kernel_runner",
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/micro:debug_log",

--- a/tensorflow/lite/micro/kernels/BUILD
+++ b/tensorflow/lite/micro/kernels/BUILD
@@ -265,6 +265,7 @@ cc_library(
         "add.cc",
         "add_n.cc",
         "arg_min_max.cc",
+        "batch_matmul.cc",
         "batch_to_space_nd.cc",
         "cast.cc",
         "ceil.cc",
@@ -450,6 +451,21 @@ cc_test(
     deps = [
         ":kernel_runner",
         "//tensorflow/lite/c:common",
+        "//tensorflow/lite/micro:op_resolvers",
+        "//tensorflow/lite/micro:test_helpers",
+        "//tensorflow/lite/micro/testing:micro_test",
+    ],
+)
+
+cc_test(
+    name = "batch_matmul_test",
+    srcs = [
+        "batch_matmul_test.cc",
+    ],
+    deps = [
+        ":kernel_runner",
+        "//tensorflow/lite/c:common",
+        "//tensorflow/lite/micro:debug_log",
         "//tensorflow/lite/micro:op_resolvers",
         "//tensorflow/lite/micro:test_helpers",
         "//tensorflow/lite/micro/testing:micro_test",

--- a/tensorflow/lite/micro/kernels/batch_matmul.cc
+++ b/tensorflow/lite/micro/kernels/batch_matmul.cc
@@ -1,0 +1,742 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/kernels/internal/reference/batch_matmul.h"
+
+#include <stddef.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/cpu_backend_context.h"
+#include "tensorflow/lite/kernels/internal/compatibility.h"
+#include "tensorflow/lite/kernels/internal/optimized/batch_matmul.h"
+#include "tensorflow/lite/kernels/internal/optimized/optimized_ops.h"
+#include "tensorflow/lite/kernels/internal/reference/reference_ops.h"
+#include "tensorflow/lite/kernels/internal/tensor.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/internal/tensor_utils.h"
+#include "tensorflow/lite/kernels/internal/types.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+
+namespace tflite {
+namespace ops {
+namespace builtin {
+namespace batch_matmul {
+
+static const int kInputLHSTensor = 0;
+static const int kInputRHSTensor = 1;
+static const int kOutputTensor = 0;
+
+static const int kNumTempTensorsForAdjoints = 2;
+static const int kNumTempTensorsForHybrid = 5;
+
+// This file has two implementations of Transpose.
+enum KernelType {
+  kReference,
+  kGenericOptimized,
+};
+
+struct OpData {
+  // The scaling factor from input to output (aka the 'real multiplier') can
+  // be represented as a fixed point multiplier plus a left shift.
+  int32_t output_multiplier;
+  int output_shift;
+  // The range of the fused activation layer. For example for kNone and
+  // uint8_t these would be 0 and 255.
+  int32_t output_activation_min;
+  int32_t output_activation_max;
+  // The index of the temporary tensors where we store transposed LHS/RHS.
+  int scratch_tensor_index;
+  bool rhs_transposed;
+  bool compute_row_sums = false;
+};
+
+struct OpContext {
+  OpContext(TfLiteContext* context, TfLiteNode* node) {
+    params = reinterpret_cast<TfLiteBatchMatMulParams*>(node->builtin_data);
+    lhs = GetInput(context, node, kInputLHSTensor);
+    rhs = GetInput(context, node, kInputRHSTensor);
+    output = GetOutput(context, node, 0);
+  }
+  TfLiteBatchMatMulParams* params;
+  const TfLiteTensor* lhs;
+  const TfLiteTensor* rhs;
+  TfLiteTensor* output;
+};
+
+void* Init(TfLiteContext* context, const char* buffer, size_t length) {
+  auto* op_data = new OpData();
+  // If the RHS is constant, we only transpose once.
+  op_data->rhs_transposed = false;
+  // Creates the temp tensors to store the transposed LHS and/or RHS, and
+  // extra buffers for the quantized case.
+  context->AddTensors(context,
+                      kNumTempTensorsForAdjoints + kNumTempTensorsForHybrid,
+                      &op_data->scratch_tensor_index);
+  return op_data;
+}
+
+void Free(TfLiteContext* context, void* buffer) {
+  delete static_cast<OpData*>(buffer);
+}
+
+TfLiteStatus ResizeOutputTensor(TfLiteContext* context,
+                                const RuntimeShape& extended_lhs_shape,
+                                const RuntimeShape& extended_rhs_shape,
+                                bool adj_x, bool adj_y, int output_rank,
+                                TfLiteTensor* output) {
+  TfLiteIntArray* output_shape = TfLiteIntArrayCreate(output_rank);
+  // Fill in any broadcast dimensions.
+  for (int i = 0; i < output_rank - 2; ++i) {
+    const int lhs_dim = extended_lhs_shape.Dims(i);
+    const int rhs_dim = extended_rhs_shape.Dims(i);
+    int broadcast_dim = lhs_dim;
+    if ((lhs_dim != rhs_dim) && (lhs_dim == 1)) {
+      broadcast_dim = rhs_dim;
+    }
+    output_shape->data[i] = broadcast_dim;
+  }
+  // Fill in the matmul dimensions.
+  int lhs_rows_index = adj_x ? output_rank - 1 : output_rank - 2;
+  int rhs_cols_index = adj_y ? output_rank - 2 : output_rank - 1;
+
+  output_shape->data[output_rank - 2] = extended_lhs_shape.Dims(lhs_rows_index);
+  output_shape->data[output_rank - 1] = extended_rhs_shape.Dims(rhs_cols_index);
+  TfLiteStatus stat = context->ResizeTensor(context, output, output_shape);
+  return stat;
+}
+
+// Initializes temp tensors to store transposed operands.
+TfLiteStatus InitializeTemporaries(TfLiteContext* context, TfLiteNode* node,
+                                   OpContext* op_context) {
+  // Create temporary tensors to hold transposed LHS/RHS.
+  OpData* op_data = reinterpret_cast<OpData*>(node->user_data);
+  const TfLiteTensor* lhs = op_context->lhs;
+  const TfLiteTensor* rhs = op_context->rhs;
+  TfLiteIntArrayFree(node->temporaries);
+  // For "hybrid" quantization, we impose the constraint that the LHS
+  // is float (typically an activation from a prior layer) and the RHS
+  // is quantized int8.
+  bool is_hybrid =
+      (op_context->lhs->type == kTfLiteFloat32 && rhs->type == kTfLiteInt8);
+  if (is_hybrid) {
+    node->temporaries = TfLiteIntArrayCreate(kNumTempTensorsForAdjoints +
+                                             kNumTempTensorsForHybrid);
+  } else {
+    node->temporaries = TfLiteIntArrayCreate(kNumTempTensorsForAdjoints);
+  }
+
+  const int lhs_rank = NumDimensions(lhs);
+  const int rhs_rank = NumDimensions(rhs);
+  const int batch_size = op_context->params->adj_x
+                             ? lhs->dims->data[lhs_rank - 2]
+                             : lhs->dims->data[lhs_rank - 1];
+  const int num_units = op_context->params->adj_x
+                            ? lhs->dims->data[lhs_rank - 1]
+                            : lhs->dims->data[lhs_rank - 2];
+
+  // Temp tensor for Transposed LHS;
+  {
+    node->temporaries->data[0] = op_data->scratch_tensor_index;
+    TfLiteTensor* scratch_buffer;
+    TF_LITE_ENSURE_OK(
+        context, GetTemporarySafe(context, node, /*index=*/0, &scratch_buffer));
+    TfLiteIntArray* scratch_buffer_size = TfLiteIntArrayCreate(lhs_rank);
+    for (int i = 0; i < lhs_rank - 2; ++i) {
+      scratch_buffer_size->data[i] = lhs->dims->data[i];
+    }
+    // Swap last two dimensions.
+    scratch_buffer_size->data[lhs_rank - 2] = lhs->dims->data[lhs_rank - 1];
+    scratch_buffer_size->data[lhs_rank - 1] = lhs->dims->data[lhs_rank - 2];
+
+    scratch_buffer->type = op_context->lhs->type;
+    scratch_buffer->allocation_type = kTfLiteArenaRw;
+    TF_LITE_ENSURE_OK(context, context->ResizeTensor(context, scratch_buffer,
+                                                     scratch_buffer_size));
+  }
+
+  // We need a temp buffer for the RHS if we need to transpose the RHS. We
+  // transpose by default, so that the two inputs (LHS and RHS) are in a proper
+  // layout for our fast matrix multiplication routines. If the transpose flag
+  // is set by the caller, the data is already in the desired layout.
+  {
+    node->temporaries->data[1] = op_data->scratch_tensor_index + 1;
+    TfLiteTensor* scratch_buffer;
+    TF_LITE_ENSURE_OK(
+        context, GetTemporarySafe(context, node, /*index=*/1, &scratch_buffer));
+    const TfLiteTensor* rhs = op_context->rhs;
+    int rhs_rank = NumDimensions(rhs);
+    TfLiteIntArray* scratch_buffer_size = TfLiteIntArrayCreate(rhs_rank);
+    for (int i = 0; i < rhs_rank - 2; ++i) {
+      scratch_buffer_size->data[i] = rhs->dims->data[i];
+    }
+    // Swap last two dimensions.
+    scratch_buffer_size->data[rhs_rank - 2] = rhs->dims->data[rhs_rank - 1];
+    scratch_buffer_size->data[rhs_rank - 1] = rhs->dims->data[rhs_rank - 2];
+
+    if (IsConstantTensor(op_context->rhs)) {
+      scratch_buffer->allocation_type = kTfLiteArenaRwPersistent;
+    } else {
+      scratch_buffer->allocation_type = kTfLiteArenaRw;
+    }
+    scratch_buffer->type = op_context->rhs->type;
+    scratch_buffer->allocation_type = kTfLiteArenaRw;
+    TF_LITE_ENSURE_OK(context, context->ResizeTensor(context, scratch_buffer,
+                                                     scratch_buffer_size));
+  }
+
+  // If we have to perform on-the-fly quantization (with quantized weights and
+  // float inputs) first we need to quantize the inputs. Allocate temporary
+  // buffer to store the intermediate quantized values, the batch scaling
+  // factors, the accumulator buffer (optimized version), the input offsets,
+  // and the sums of the rows for each weights matrix.
+  // RHS = weights, LHS = inputs
+  if (is_hybrid) {
+    // Calculate the total number of LHS batches.
+    int num_batches = 1;
+    for (int i = 0; i < lhs_rank - 2; ++i) {
+      num_batches *= lhs->dims->data[i];
+    }
+    int num_weights_matrices = 1;
+    for (int i = 0; i < rhs_rank - 2; ++i) {
+      num_weights_matrices *= rhs->dims->data[i];
+    }
+    op_data->compute_row_sums = true;
+    node->temporaries->data[2] = op_data->scratch_tensor_index + 2;
+    TfLiteTensor* input_quantized;
+    TF_LITE_ENSURE_OK(context, GetTemporarySafe(context, node, /*index=*/2,
+                                                &input_quantized));
+    input_quantized->type = op_context->rhs->type;
+    input_quantized->allocation_type = kTfLiteArenaRw;
+
+    TfLiteIntArray* input_quantized_size =
+        TfLiteIntArrayCopy(op_context->lhs->dims);
+    TF_LITE_ENSURE_OK(context, context->ResizeTensor(context, input_quantized,
+                                                     input_quantized_size));
+
+    node->temporaries->data[3] = op_data->scratch_tensor_index + 3;
+    TfLiteTensor* scaling_factors;
+    TF_LITE_ENSURE_OK(context, GetTemporarySafe(context, node, /*index=*/3,
+                                                &scaling_factors));
+    scaling_factors->type = kTfLiteFloat32;
+    scaling_factors->allocation_type = kTfLiteArenaRw;
+    // Total size of scaling factors is batch size * number of total batches
+    int scaling_dims[1] = {num_batches * batch_size};
+    if (!TfLiteIntArrayEqualsArray(scaling_factors->dims, 1, scaling_dims)) {
+      TfLiteIntArray* scaling_factors_size = TfLiteIntArrayCreate(1);
+      scaling_factors_size->data[0] = batch_size;
+      TF_LITE_ENSURE_OK(context, context->ResizeTensor(context, scaling_factors,
+                                                       scaling_factors_size));
+    }
+
+    node->temporaries->data[4] = op_data->scratch_tensor_index + 4;
+    TfLiteTensor* accum_scratch;
+    TF_LITE_ENSURE_OK(
+        context, GetTemporarySafe(context, node, /*index=*/4, &accum_scratch));
+    accum_scratch->type = kTfLiteInt32;
+    accum_scratch->allocation_type = kTfLiteArenaRw;
+    int accum_scratch_dims[2] = {num_units, batch_size};
+    if (!TfLiteIntArrayEqualsArray(accum_scratch->dims, 2,
+                                   accum_scratch_dims)) {
+      TfLiteIntArray* accum_size = TfLiteIntArrayCreate(2);
+      accum_size->data[0] = num_units;
+      accum_size->data[1] = batch_size;
+      TF_LITE_ENSURE_OK(
+          context, context->ResizeTensor(context, accum_scratch, accum_size));
+    }
+
+    node->temporaries->data[5] = op_data->scratch_tensor_index + 5;
+    TfLiteTensor* input_offsets;
+    TF_LITE_ENSURE_OK(
+        context, GetTemporarySafe(context, node, /*index=*/5, &input_offsets));
+    input_offsets->type = kTfLiteInt32;
+    input_offsets->allocation_type = kTfLiteArenaRw;
+    if (!TfLiteIntArrayEqualsArray(input_offsets->dims, 1, scaling_dims)) {
+      TfLiteIntArray* input_offsets_size = TfLiteIntArrayCreate(1);
+      input_offsets_size->data[0] = num_batches * batch_size;
+      TF_LITE_ENSURE_OK(context, context->ResizeTensor(context, input_offsets,
+                                                       input_offsets_size));
+    }
+    node->temporaries->data[6] = op_data->scratch_tensor_index + 6;
+    TfLiteTensor* row_sums;
+    TF_LITE_ENSURE_OK(context,
+                      GetTemporarySafe(context, node, /*index=*/6, &row_sums));
+    row_sums->type = kTfLiteInt32;
+    row_sums->allocation_type = kTfLiteArenaRwPersistent;
+    int row_sums_dims[1] = {num_weights_matrices * num_units};
+    if (!TfLiteIntArrayEqualsArray(row_sums->dims, 1, row_sums_dims)) {
+      TfLiteIntArray* row_sums_size = TfLiteIntArrayCreate(1);
+      row_sums_size->data[0] = row_sums_dims[0];
+      TF_LITE_ENSURE_OK(
+          context, context->ResizeTensor(context, row_sums, row_sums_size));
+    }
+  }
+
+  return kTfLiteOk;
+}
+
+TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+  TF_LITE_ENSURE_EQ(context, NumInputs(node), 2);
+  TF_LITE_ENSURE_EQ(context, NumOutputs(node), 1);
+
+  OpContext op_context(context, node);
+  TF_LITE_ENSURE_OK(context, InitializeTemporaries(context, node, &op_context));
+  OpData* op_data = reinterpret_cast<OpData*>(node->user_data);
+
+  bool adj_x = op_context.params->adj_x;
+  bool adj_y = op_context.params->adj_y;
+
+  const TfLiteTensor* lhs_data;
+  TF_LITE_ENSURE_OK(context,
+                    GetInputSafe(context, node, kInputLHSTensor, &lhs_data));
+  const TfLiteTensor* rhs_data;
+  TF_LITE_ENSURE_OK(context,
+                    GetInputSafe(context, node, kInputRHSTensor, &rhs_data));
+  TfLiteTensor* output;
+  TF_LITE_ENSURE_OK(context,
+                    GetOutputSafe(context, node, kOutputTensor, &output));
+
+  // Note that quantized inference requires that all tensors have their
+  // parameters set. This is usually done during quantized training.
+  if (lhs_data->type == kTfLiteInt8 || lhs_data->type == kTfLiteInt16) {
+    double real_multiplier = 0.0;
+    TF_LITE_ENSURE_STATUS(GetQuantizedConvolutionMultipler(
+        context, lhs_data, rhs_data, output, &real_multiplier));
+    int exponent;
+    QuantizeMultiplier(real_multiplier, &op_data->output_multiplier, &exponent);
+    op_data->output_shift = exponent;
+    // BatchMatMul has no fused activation functions. Therefore, set
+    // output activation min and max to min and max of int8_t or int16_t
+    // type.
+    if (lhs_data->type == kTfLiteInt8) {
+      op_data->output_activation_min = std::numeric_limits<int8_t>::min();
+      op_data->output_activation_max = std::numeric_limits<int8_t>::max();
+    } else {
+      op_data->output_activation_min = std::numeric_limits<int16_t>::min();
+      op_data->output_activation_max = std::numeric_limits<int16_t>::max();
+    }
+  }
+
+  if (lhs_data->type == kTfLiteInt16) {
+    TF_LITE_ENSURE_EQ(context, lhs_data->params.zero_point, 0);
+    TF_LITE_ENSURE_EQ(context, rhs_data->params.zero_point, 0);
+    TF_LITE_ENSURE_EQ(context, output->params.zero_point, 0);
+  }
+
+  TF_LITE_ENSURE(context, lhs_data->type == kTfLiteFloat32 ||
+                              lhs_data->type == kTfLiteInt8 ||
+                              lhs_data->type == kTfLiteInt16);
+  TF_LITE_ENSURE(context, rhs_data->type == kTfLiteFloat32 ||
+                              rhs_data->type == kTfLiteInt8 ||
+                              rhs_data->type == kTfLiteInt16);
+  // Either we have a hybrid quantization with a float32 and an int8 input,
+  // otherwise both inputs should be of the same type.
+  TF_LITE_ENSURE(context, (lhs_data->type == kTfLiteFloat32 &&
+                           rhs_data->type == kTfLiteInt8) ||
+                              lhs_data->type == rhs_data->type);
+  // Support dimensions between 2 and 4, inclusive.
+  TF_LITE_ENSURE(context, NumDimensions(lhs_data) >= 2);
+  TF_LITE_ENSURE(context, NumDimensions(lhs_data) <= 4);
+  TF_LITE_ENSURE(context, NumDimensions(rhs_data) >= 2);
+  TF_LITE_ENSURE(context, NumDimensions(rhs_data) <= 4);
+
+  const int lhs_rank = NumDimensions(lhs_data);
+  const int rhs_rank = NumDimensions(rhs_data);
+  const int output_rank = std::max(lhs_rank, rhs_rank);
+  const RuntimeShape extended_lhs_shape =
+      RuntimeShape::ExtendedShape(output_rank, GetTensorShape(lhs_data));
+  const RuntimeShape extended_rhs_shape =
+      RuntimeShape::ExtendedShape(output_rank, GetTensorShape(rhs_data));
+
+  // Ensure any batch dimensions obey broacasting rules.
+  for (int i = 0; i < output_rank - 2; ++i) {
+    const int lhs_dim = extended_lhs_shape.Dims(i);
+    const int rhs_dim = extended_rhs_shape.Dims(i);
+    if (lhs_dim != rhs_dim) {
+      if (lhs_dim != 1) {
+        TF_LITE_ENSURE_EQ(context, rhs_dim, 1);
+      }
+    }
+  }
+  // Ensure other dimensions work for matrix multiplication.
+  int accum_dim_lhs = adj_x ? extended_lhs_shape.Dims(output_rank - 2)
+                            : extended_lhs_shape.Dims(output_rank - 1);
+  int accum_dim_rhs = adj_y ? extended_rhs_shape.Dims(output_rank - 1)
+                            : extended_rhs_shape.Dims(output_rank - 2);
+
+  TF_LITE_ENSURE_EQ(context, accum_dim_lhs, accum_dim_rhs);
+  TfLiteStatus status =
+      ResizeOutputTensor(context, extended_lhs_shape, extended_rhs_shape, adj_x,
+                         adj_y, output_rank, output);
+  return status;
+}
+
+template <typename scalar>
+void TransposeRowsColumnsImpl(const TfLiteTensor* tensor_in,
+                              const scalar* input, TfLiteTensor* tensor_out,
+                              scalar* output) {
+  RuntimeShape transposed_shape(GetTensorShape(tensor_in));
+  RuntimeShape shape(GetTensorShape(tensor_in));
+  TransposeParams params;
+  int rank = NumDimensions(tensor_in);
+  params.perm_count = rank;
+  for (int i = 0; i < rank - 2; ++i) {
+    params.perm[i] = i;
+  }
+  // Transpose the last two dimensions.
+  params.perm[rank - 2] = rank - 1;
+  params.perm[rank - 1] = rank - 2;
+  transposed_shape.SetDim(rank - 1, shape.Dims(rank - 2));
+  transposed_shape.SetDim(rank - 2, shape.Dims(rank - 1));
+  optimized_ops::Transpose(params, shape, input, transposed_shape, output);
+}
+
+TfLiteStatus TransposeRowsColumns(TfLiteContext* context,
+                                  const TfLiteTensor* tensor_in,
+                                  TfLiteTensor* tensor_out) {
+  if (tensor_in->type == kTfLiteFloat32) {
+    TransposeRowsColumnsImpl<float>(tensor_in, GetTensorData<float>(tensor_in),
+                                    tensor_out,
+                                    GetTensorData<float>(tensor_out));
+    return kTfLiteOk;
+  } else if (tensor_in->type == kTfLiteInt8) {
+    TransposeRowsColumnsImpl<int8_t>(
+        tensor_in, GetTensorData<int8_t>(tensor_in), tensor_out,
+        GetTensorData<int8_t>(tensor_out));
+    return kTfLiteOk;
+  } else if (tensor_in->type == kTfLiteInt16) {
+    TransposeRowsColumnsImpl<int16_t>(
+        tensor_in, GetTensorData<int16_t>(tensor_in), tensor_out,
+        GetTensorData<int16_t>(tensor_out));
+    return kTfLiteOk;
+  } else {
+    TF_LITE_KERNEL_LOG(
+        context, "Can only transpose tensors with float, int8 or int16 type.");
+    return kTfLiteError;
+  }
+}
+
+RuntimeShape SwapRowColumnDims(const RuntimeShape& shape) {
+  RuntimeShape swapped_shape(shape);
+  const int32_t dims = shape.DimensionsCount();
+  swapped_shape.SetDim(dims - 2, shape.Dims(dims - 1));
+  swapped_shape.SetDim(dims - 1, shape.Dims(dims - 2));
+  return swapped_shape;
+}
+
+template <KernelType kernel_type>
+TfLiteStatus EvalHybrid(TfLiteContext* context, TfLiteNode* node, OpData* data,
+                        const RuntimeShape& input_shape,
+                        const TfLiteTensor* input,
+                        const RuntimeShape& filter_shape,
+                        const TfLiteTensor* filter,
+                        TfLiteTensor* input_quantized,
+                        TfLiteTensor* scaling_factors,
+                        TfLiteTensor* accum_scratch, TfLiteTensor* row_sums,
+                        TfLiteTensor* input_offsets, TfLiteTensor* output) {
+  const auto* params =
+      reinterpret_cast<TfLiteBatchMatMulParams*>(node->builtin_data);
+  const int32_t num_input_dims = input_shape.DimensionsCount();
+
+  // Input row/cols have been swapped at this point, so dims are
+  // {input_size, num_batches}
+  const int input_size = input_shape.Dims(num_input_dims - 2);
+  const int batch_size = input_shape.Dims(num_input_dims - 1);
+
+  int num_batches_to_quantize = batch_size;
+  for (int i = 0; i < input_shape.DimensionsCount() - 2; ++i) {
+    num_batches_to_quantize *= input_shape.Dims(i);
+  }
+  // Quantize input from float to uint8 + quantization params (scaling factor).
+  float* scaling_factors_ptr = GetTensorData<float>(scaling_factors);
+  int32_t* input_offset_ptr = nullptr;
+  int32_t* row_sums_ptr = nullptr;
+  input_offset_ptr = GetTensorData<int32_t>(input_offsets);
+  row_sums_ptr = GetTensorData<int32_t>(row_sums);
+  if (!params->asymmetric_quantize_inputs) {
+    memset(input_offset_ptr, 0, input_offsets->bytes);
+  }
+  int8_t* quant_data = GetTensorData<int8_t>(input_quantized);
+  const int8_t* filter_data = GetTensorData<int8_t>(filter);
+  const float* input_ptr = GetTensorData<float>(input);
+  // Quantize each batch independently.
+  tensor_utils::BatchQuantizeFloats(input_ptr, num_batches_to_quantize,
+                                    input_size, quant_data, scaling_factors_ptr,
+                                    input_offset_ptr,
+                                    params->asymmetric_quantize_inputs);
+  for (int b = 0; b < num_batches_to_quantize; ++b) {
+    // Incorporate scaling of the filter.
+    scaling_factors_ptr[b] *= filter->params.scale;
+  }
+
+  RuntimeShape output_shape = GetTensorShape(output);
+  int output_size = 1;
+  for (int i = 0; i < output_shape.DimensionsCount(); ++i) {
+    output_size *= output_shape.Dims(i);
+  }
+  std::fill_n(GetTensorData<float>(output), output_size, 0.0f);
+  if (kernel_type == kGenericOptimized) {
+    optimized_ops::BatchMatMul(
+        filter_shape, filter_data, input_shape, quant_data, scaling_factors_ptr,
+        input_offset_ptr, row_sums_ptr, GetTensorShape(output),
+        GetTensorData<int32_t>(accum_scratch), GetTensorData<float>(output),
+        &(data->compute_row_sums), CpuBackendContext::GetFromContext(context));
+  } else {
+    reference_ops::BatchMatMul(
+        filter_shape, filter_data, input_shape, quant_data, scaling_factors_ptr,
+        input_offset_ptr, row_sums_ptr, GetTensorShape(output),
+        GetTensorData<float>(output), &(data->compute_row_sums));
+  }
+
+  return kTfLiteOk;
+}
+
+template <KernelType kernel_type>
+TfLiteStatus EvalInt8(TfLiteContext* context, const OpData* data,
+                      const RuntimeShape& lhs_shape, const TfLiteTensor* lhs,
+                      const RuntimeShape& rhs_shape, const TfLiteTensor* rhs,
+                      const RuntimeShape& output_shape, TfLiteTensor* output) {
+  // Reuse params struct from FullyConnected Op.
+  FullyConnectedParams op_params;
+  int32_t input_offset = -lhs->params.zero_point;
+  int32_t filter_offset = -rhs->params.zero_point;
+  int32_t output_offset = output->params.zero_point;
+  op_params.input_offset = input_offset;
+  op_params.weights_offset = filter_offset;
+  op_params.output_offset = output_offset;
+  op_params.output_multiplier = data->output_multiplier;
+  op_params.output_shift = data->output_shift;
+  op_params.quantized_activation_min = data->output_activation_min;
+  op_params.quantized_activation_max = data->output_activation_max;
+  op_params.lhs_cacheable = IsConstantTensor(lhs);
+  op_params.rhs_cacheable = IsConstantTensor(rhs);
+
+  if (kernel_type == kReference) {
+    reference_ops::BatchMatMul<int8_t, int32_t>(
+        op_params, rhs_shape, GetTensorData<int8_t>(rhs), lhs_shape,
+        GetTensorData<int8_t>(lhs), GetTensorShape(output),
+        GetTensorData<int8_t>(output));
+  } else {
+    optimized_ops::BatchMatMul(op_params, rhs_shape, GetTensorData<int8_t>(rhs),
+                               lhs_shape, GetTensorData<int8_t>(lhs),
+                               GetTensorShape(output),
+                               GetTensorData<int8_t>(output),
+                               CpuBackendContext::GetFromContext(context));
+  }
+  return kTfLiteOk;
+}
+
+template <KernelType kernel_type>
+TfLiteStatus EvalInt16(TfLiteContext* context, const OpData* data,
+                       const RuntimeShape& lhs_shape, const TfLiteTensor* lhs,
+                       const RuntimeShape& rhs_shape, const TfLiteTensor* rhs,
+                       const RuntimeShape& output_shape, TfLiteTensor* output) {
+  // Reuse params struct from FullyConnected Op.
+  FullyConnectedParams op_params;
+  int32_t input_offset = -lhs->params.zero_point;
+  int32_t filter_offset = -rhs->params.zero_point;
+  int32_t output_offset = output->params.zero_point;
+  op_params.input_offset = input_offset;
+  op_params.weights_offset = filter_offset;
+  op_params.output_offset = output_offset;
+  op_params.output_multiplier = data->output_multiplier;
+  op_params.output_shift = data->output_shift;
+  op_params.quantized_activation_min = data->output_activation_min;
+  op_params.quantized_activation_max = data->output_activation_max;
+
+  // optimized_ops not yet implemnted for int16_t, use reference_ops in all
+  // cases.
+  reference_ops::BatchMatMul<int16_t, int64_t>(
+      op_params, rhs_shape, GetTensorData<int16_t>(rhs), lhs_shape,
+      GetTensorData<int16_t>(lhs), GetTensorShape(output),
+      GetTensorData<int16_t>(output));
+  return kTfLiteOk;
+}
+
+template <KernelType kernel_type>
+TfLiteStatus EvalQuantized(TfLiteContext* context, TfLiteNode* node,
+                           OpData* data, const RuntimeShape& lhs_shape,
+                           const TfLiteTensor* lhs,
+                           const RuntimeShape& rhs_shape,
+                           const TfLiteTensor* rhs, TfLiteTensor* output) {
+  if (lhs->type == kTfLiteFloat32 && rhs->type == kTfLiteInt8) {
+    TfLiteTensor* input_quantized;
+    TF_LITE_ENSURE_OK(context, GetTemporarySafe(context, node, /*index=*/2,
+                                                &input_quantized));
+    TfLiteTensor* scaling_factors;
+    TF_LITE_ENSURE_OK(context, GetTemporarySafe(context, node, /*index=*/3,
+                                                &scaling_factors));
+    TfLiteTensor* accum_scratch;
+    TF_LITE_ENSURE_OK(
+        context, GetTemporarySafe(context, node, /*index=*/4, &accum_scratch));
+    TfLiteTensor* input_offsets;
+    TF_LITE_ENSURE_OK(
+        context, GetTemporarySafe(context, node, /*index=*/5, &input_offsets));
+    TfLiteTensor* row_sums;
+    TF_LITE_ENSURE_OK(context,
+                      GetTemporarySafe(context, node, /*index=*/6, &row_sums));
+    return EvalHybrid<kernel_type>(
+        context, node, data, lhs_shape, lhs, rhs_shape, rhs, input_quantized,
+        scaling_factors, accum_scratch, row_sums, input_offsets, output);
+  } else if (lhs->type == kTfLiteInt8 && rhs->type == kTfLiteInt8) {
+    return EvalInt8<kernel_type>(context, data, lhs_shape, lhs, rhs_shape, rhs,
+                                 GetTensorShape(output), output);
+  } else if (lhs->type == kTfLiteInt16 && rhs->type == kTfLiteInt16) {
+    return EvalInt16<kernel_type>(context, data, lhs_shape, lhs, rhs_shape, rhs,
+                                  GetTensorShape(output), output);
+  } else {
+    TF_LITE_KERNEL_LOG(
+        context,
+        "Currently only hybrid, int8 and int16 quantization are supported.\n");
+    return kTfLiteError;
+  }
+  return kTfLiteOk;
+}
+
+TfLiteTensor* GetTempRhs(TfLiteContext* context, TfLiteNode* node,
+                         const TfLiteTensor* rhs) {
+  TfLiteTensor* transposed_rhs = GetTemporary(context, node, 1);
+  if (transposed_rhs == nullptr) {
+    return nullptr;
+  }
+
+  if (rhs->type == kTfLiteInt8 || rhs->type == kTfLiteInt16) {
+    // Get the quantization params from the RHS tensor.
+    transposed_rhs->params.scale = rhs->params.scale;
+    transposed_rhs->params.zero_point = rhs->params.zero_point;
+  }
+  return transposed_rhs;
+}
+
+TfLiteTensor* GetTempLhs(TfLiteContext* context, TfLiteNode* node,
+                         const TfLiteTensor* lhs) {
+  TfLiteTensor* transposed_lhs = GetTemporary(context, node, 0);
+  if (transposed_lhs == nullptr) {
+    return nullptr;
+  }
+
+  if (lhs->type == kTfLiteInt8 || lhs->type == kTfLiteInt16) {
+    // Get the quantization params from the LHS tensor.
+    transposed_lhs->params.scale = lhs->params.scale;
+    transposed_lhs->params.zero_point = lhs->params.zero_point;
+  }
+  return transposed_lhs;
+}
+
+// Perform a batch matrix multiply on
+// LHS <..., A, B>  X  RHS<..., B, C>
+// where the leading dimensions of LHS and RHS obey broadcasting rules
+// (this Op will apply broadcasting rules).
+// We assume that LHS and RHS are both row oriented (adjacent values in memory
+// are in the same row) and will output in the same memory layout. However,
+// our fast GEMM libraries assume RCC layout (LHS row oriented,
+// RHS column oriented, output column oriented). Therefore, we perform
+// RHS <..., C, B> X LHS <..., B, A>
+// where output is a C X A column-oriented, which is equivalent to
+// A X C row-oriented.
+template <KernelType kernel_type>
+TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
+  OpContext op_context(context, node);
+  OpData* op_data = reinterpret_cast<OpData*>(node->user_data);
+  const TfLiteTensor* lhs;
+  TF_LITE_ENSURE_OK(context,
+                    GetInputSafe(context, node, kInputLHSTensor, &lhs));
+  const TfLiteTensor* rhs;
+  TF_LITE_ENSURE_OK(context,
+                    GetInputSafe(context, node, kInputRHSTensor, &rhs));
+  TfLiteTensor* output;
+  TF_LITE_ENSURE_OK(context,
+                    GetOutputSafe(context, node, kOutputTensor, &output));
+  RuntimeShape orig_lhs_shape = GetTensorShape(lhs);
+  RuntimeShape orig_rhs_shape = GetTensorShape(rhs);
+
+  bool adj_y = op_context.params->adj_y;
+  bool adj_x = op_context.params->adj_x;
+
+  const TfLiteTensor* rhs_tensor = adj_y ? rhs : GetTempRhs(context, node, rhs);
+  const TfLiteTensor* lhs_tensor = adj_x ? GetTempLhs(context, node, lhs) : lhs;
+  if (!adj_y) {
+    // TODO(b/154760341) Constant tensors should already be transposed, but
+    // we transpose once if necessary for now.
+    if (!(IsConstantTensor(rhs) && op_data->rhs_transposed)) {
+      TransposeRowsColumns(context, rhs, GetTemporary(context, node, 1));
+      op_data->rhs_transposed = true;
+    }
+  }
+  if (adj_x) {
+    TransposeRowsColumns(context, lhs, GetTemporary(context, node, 0));
+  }
+  RuntimeShape rhs_shape =
+      adj_y ? orig_rhs_shape : SwapRowColumnDims(orig_rhs_shape);
+  RuntimeShape lhs_shape =
+      adj_x ? orig_lhs_shape : SwapRowColumnDims(orig_lhs_shape);
+
+  switch (rhs->type) {
+    case kTfLiteFloat32:
+      // Note we pass RHS args first, LHS args second. See note above.
+      if (kernel_type == kGenericOptimized) {
+        optimized_ops::BatchMatMul(rhs_shape, GetTensorData<float>(rhs_tensor),
+                                   lhs_shape, GetTensorData<float>(lhs_tensor),
+                                   GetTensorShape(output),
+                                   GetTensorData<float>(output),
+                                   CpuBackendContext::GetFromContext(context));
+      } else {
+        reference_ops::BatchMatMul(rhs_shape, GetTensorData<float>(rhs_tensor),
+                                   lhs_shape, GetTensorData<float>(lhs_tensor),
+                                   GetTensorShape(output),
+                                   GetTensorData<float>(output));
+      }
+      break;
+    case kTfLiteInt8:
+    case kTfLiteInt16:
+      EvalQuantized<kernel_type>(context, node, op_data, lhs_shape, lhs_tensor,
+                                 rhs_shape, rhs_tensor, output);
+      break;
+    default:
+      TF_LITE_KERNEL_LOG(context,
+                         "Currently BatchMatMul doesn't support type: %s",
+                         TfLiteTypeGetName(lhs->type));
+      return kTfLiteError;
+  }
+  return kTfLiteOk;
+}
+
+}  // namespace batch_matmul
+
+TfLiteRegistration* Register_BATCH_MATMUL_REF() {
+  static TfLiteRegistration r = {batch_matmul::Init, batch_matmul::Free,
+                                 batch_matmul::Prepare,
+                                 batch_matmul::Eval<batch_matmul::kReference>};
+  return &r;
+}
+
+TfLiteRegistration* Register_BATCH_MATMUL_GENERIC_OPTIMIZED() {
+  static TfLiteRegistration r = {
+      batch_matmul::Init, batch_matmul::Free, batch_matmul::Prepare,
+      batch_matmul::Eval<batch_matmul::kGenericOptimized>};
+  return &r;
+}
+
+TfLiteRegistration* Register_BATCH_MATMUL() {
+  return Register_BATCH_MATMUL_GENERIC_OPTIMIZED();
+}
+
+}  // namespace builtin
+}  // namespace ops
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/batch_matmul.cc
+++ b/tensorflow/lite/micro/kernels/batch_matmul.cc
@@ -257,8 +257,6 @@ TfLiteStatus InitializeTemporaries(TfLiteContext* context, TfLiteNode* node,
       num_weights_matrices *= rhs->dims->data[i];
     }
 
-    op_data->hybrid->compute_row_sums = true;
-
     const size_t input_quantized_size = static_cast<size_t>(
         NumElements(lhs->dims) * TfLiteTypeGetSize(rhs->type));
     TF_LITE_ENSURE_OK(context, context->RequestScratchBufferInArena(
@@ -283,6 +281,7 @@ TfLiteStatus InitializeTemporaries(TfLiteContext* context, TfLiteNode* node,
         context->AllocatePersistentBuffer(context, row_sums_size));
     TF_LITE_ENSURE(context, op_data->hybrid->row_sums_buffer != nullptr);
 
+    op_data->hybrid->compute_row_sums = true;
     op_data->hybrid->filter_scale = rhs->params.scale;
   }
 

--- a/tensorflow/lite/micro/kernels/batch_matmul.cc
+++ b/tensorflow/lite/micro/kernels/batch_matmul.cc
@@ -1,4 +1,4 @@
-/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,93 +15,121 @@ limitations under the License.
 
 #include "tensorflow/lite/kernels/internal/reference/batch_matmul.h"
 
-#include <stddef.h>
-
 #include <algorithm>
 #include <cstdint>
 #include <limits>
 
-#include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
-#include "tensorflow/lite/kernels/cpu_backend_context.h"
-#include "tensorflow/lite/kernels/internal/compatibility.h"
-#include "tensorflow/lite/kernels/internal/optimized/batch_matmul.h"
-#include "tensorflow/lite/kernels/internal/optimized/optimized_ops.h"
-#include "tensorflow/lite/kernels/internal/reference/reference_ops.h"
-#include "tensorflow/lite/kernels/internal/tensor.h"
+#include "tensorflow/lite/kernels/internal/quantization_util.h"
+#include "tensorflow/lite/kernels/internal/reference/process_broadcast_shapes.h"
+#include "tensorflow/lite/kernels/internal/reference/transpose.h"
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
-#include "tensorflow/lite/kernels/internal/tensor_utils.h"
 #include "tensorflow/lite/kernels/internal/types.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/micro/kernels/kernel_util.h"
 
 namespace tflite {
-namespace ops {
-namespace builtin {
-namespace batch_matmul {
+namespace {
 
-static const int kInputLHSTensor = 0;
-static const int kInputRHSTensor = 1;
-static const int kOutputTensor = 0;
+constexpr int kInputLHSTensor = 0;
+constexpr int kInputRHSTensor = 1;
+constexpr int kOutputTensor = 0;
 
-static const int kNumTempTensorsForAdjoints = 2;
-static const int kNumTempTensorsForHybrid = 5;
+constexpr int kInvalidScratchBufferIndex = -1;
 
-// This file has two implementations of Transpose.
-enum KernelType {
-  kReference,
-  kGenericOptimized,
-};
-
-struct OpData {
+struct QuantizationOpData {
   // The scaling factor from input to output (aka the 'real multiplier') can
   // be represented as a fixed point multiplier plus a left shift.
   int32_t output_multiplier;
-  int output_shift;
+  int output_shift;  // exponent
+
   // The range of the fused activation layer. For example for kNone and
-  // uint8_t these would be 0 and 255.
+  // int8_t these would be -128 and 127.
   int32_t output_activation_min;
   int32_t output_activation_max;
-  // The index of the temporary tensors where we store transposed LHS/RHS.
-  int scratch_tensor_index;
-  bool rhs_transposed;
-  bool compute_row_sums = false;
+
+  int32_t lhs_zero_point;
+  int32_t rhs_zero_point;
+  int32_t output_zero_point;
+};
+
+struct HybridOpData {
+  float filter_scale;  // RHS tensor scale
+
+  // scratch buffer indices
+  int input_quantized_index;
+  int scaling_factors_index;
+  int input_offsets_index;
+
+  // row_sums_buffer may be re-used across eval calls
+  int32_t* row_sums_buffer;
+
+  bool compute_row_sums;
+};
+
+struct OpData {
+  union {
+    QuantizationOpData* quantization;
+    HybridOpData* hybrid;
+  };
+
+  // Transpose tensors and state
+  TfLiteEvalTensor* lhs_transposed_tensor;
+  TfLiteEvalTensor* rhs_transposed_tensor;
+  bool rhs_is_transposed;
+  bool lhs_is_constant_tensor;
+  bool rhs_is_constant_tensor;
 };
 
 struct OpContext {
   OpContext(TfLiteContext* context, TfLiteNode* node) {
-    params = reinterpret_cast<TfLiteBatchMatMulParams*>(node->builtin_data);
+    params = static_cast<TfLiteBatchMatMulParams*>(node->builtin_data);
+    opdata = static_cast<OpData*>(node->user_data);
+  }
+
+  TfLiteBatchMatMulParams* params;
+  OpData* opdata;
+};
+
+struct PrepareOpContext : OpContext {
+  PrepareOpContext(TfLiteContext* context, TfLiteNode* node)
+      : OpContext(context, node) {
     lhs = GetInput(context, node, kInputLHSTensor);
     rhs = GetInput(context, node, kInputRHSTensor);
-    output = GetOutput(context, node, 0);
+    output = GetOutput(context, node, kOutputTensor);
   }
-  TfLiteBatchMatMulParams* params;
+
   const TfLiteTensor* lhs;
   const TfLiteTensor* rhs;
   TfLiteTensor* output;
 };
 
-void* Init(TfLiteContext* context, const char* buffer, size_t length) {
-  auto* op_data = new OpData();
-  // If the RHS is constant, we only transpose once.
-  op_data->rhs_transposed = false;
-  // Creates the temp tensors to store the transposed LHS and/or RHS, and
-  // extra buffers for the quantized case.
-  context->AddTensors(context,
-                      kNumTempTensorsForAdjoints + kNumTempTensorsForHybrid,
-                      &op_data->scratch_tensor_index);
-  return op_data;
-}
+struct EvalOpContext : OpContext {
+  EvalOpContext(TfLiteContext* context, TfLiteNode* node)
+      : OpContext(context, node) {
+    lhs = tflite::micro::GetEvalInput(context, node, kInputLHSTensor);
+    rhs = tflite::micro::GetEvalInput(context, node, kInputRHSTensor);
+    output = tflite::micro::GetEvalOutput(context, node, kOutputTensor);
+  }
 
-void Free(TfLiteContext* context, void* buffer) {
-  delete static_cast<OpData*>(buffer);
-}
+  const TfLiteEvalTensor* lhs;
+  const TfLiteEvalTensor* rhs;
+  TfLiteEvalTensor* output;
+};
 
-TfLiteStatus ResizeOutputTensor(TfLiteContext* context,
+TfLiteStatus ResizeOutputTensor(TfLiteContext* context, TfLiteNode* node,
                                 const RuntimeShape& extended_lhs_shape,
                                 const RuntimeShape& extended_rhs_shape,
                                 bool adj_x, bool adj_y, int output_rank,
                                 TfLiteTensor* output) {
-  TfLiteIntArray* output_shape = TfLiteIntArrayCreate(output_rank);
+  auto orig_size = NumElements(output);
+
+  // make sure output tensor dims are not in the FlatBuffer
+  TfLiteEvalTensor* output_eval =
+      tflite::micro::GetEvalOutput(context, node, kOutputTensor);
+  TF_LITE_ENSURE_OK(context, tflite::micro::CreateWritableTensorDimsWithCopy(
+                                 context, output, output_eval));
+
   // Fill in any broadcast dimensions.
   for (int i = 0; i < output_rank - 2; ++i) {
     const int lhs_dim = extended_lhs_shape.Dims(i);
@@ -110,104 +138,115 @@ TfLiteStatus ResizeOutputTensor(TfLiteContext* context,
     if ((lhs_dim != rhs_dim) && (lhs_dim == 1)) {
       broadcast_dim = rhs_dim;
     }
-    output_shape->data[i] = broadcast_dim;
+    output->dims->data[i] = broadcast_dim;
   }
   // Fill in the matmul dimensions.
   int lhs_rows_index = adj_x ? output_rank - 1 : output_rank - 2;
   int rhs_cols_index = adj_y ? output_rank - 2 : output_rank - 1;
 
-  output_shape->data[output_rank - 2] = extended_lhs_shape.Dims(lhs_rows_index);
-  output_shape->data[output_rank - 1] = extended_rhs_shape.Dims(rhs_cols_index);
-  TfLiteStatus stat = context->ResizeTensor(context, output, output_shape);
-  return stat;
+  output->dims->data[output_rank - 2] = extended_lhs_shape.Dims(lhs_rows_index);
+  output->dims->data[output_rank - 1] = extended_rhs_shape.Dims(rhs_cols_index);
+  output->dims->size = output_rank;
+
+  // Check that output tensor has not been resized
+  // since TFLM doesn't support tensor resizing.
+  TF_LITE_ENSURE_EQ(context, orig_size, NumElements(output));
+
+  return kTfLiteOk;
 }
 
-// Initializes temp tensors to store transposed operands.
+TfLiteEvalTensor* AllocInitTransposeTensorFromTfLiteTensor(
+    TfLiteContext* context, const TfLiteTensor& tensor) {
+  TfLiteEvalTensor* eval_tensor = static_cast<TfLiteEvalTensor*>(
+      context->AllocatePersistentBuffer(context, sizeof(TfLiteEvalTensor)));
+
+  eval_tensor->type = tensor.type;
+
+  const int tensor_rank = NumDimensions(&tensor);
+  auto eval_dims_size = TfLiteIntArrayGetSizeInBytes(tensor_rank);
+  eval_tensor->dims = static_cast<TfLiteIntArray*>(
+      context->AllocatePersistentBuffer(context, eval_dims_size));
+  eval_tensor->dims->size = tensor_rank;
+  for (int i = 0; i < tensor_rank - 2; ++i) {
+    eval_tensor->dims->data[i] = tensor.dims->data[i];
+  }
+  // Swap last two dimensions.
+  eval_tensor->dims->data[tensor_rank - 2] = tensor.dims->data[tensor_rank - 1];
+  eval_tensor->dims->data[tensor_rank - 1] = tensor.dims->data[tensor_rank - 2];
+
+  size_t eval_data_size = static_cast<size_t>(NumElements(&tensor));
+  if (tensor.type == kTfLiteFloat32) {
+    eval_data_size *= sizeof(float);
+  }
+  eval_tensor->data.data =
+      context->AllocatePersistentBuffer(context, eval_data_size);
+
+  return eval_tensor;
+}
+
+// Initializes tensors to store transposed operands.
+// Allocate storage for hybrid quantization if needed.
+// Allocate normal quantization data if needed.
 TfLiteStatus InitializeTemporaries(TfLiteContext* context, TfLiteNode* node,
-                                   OpContext* op_context) {
-  // Create temporary tensors to hold transposed LHS/RHS.
-  OpData* op_data = reinterpret_cast<OpData*>(node->user_data);
-  const TfLiteTensor* lhs = op_context->lhs;
-  const TfLiteTensor* rhs = op_context->rhs;
-  TfLiteIntArrayFree(node->temporaries);
+                                   const PrepareOpContext& op_context) {
+  OpData* op_data = op_context.opdata;
+  const TfLiteTensor* lhs = op_context.lhs;
+  const TfLiteTensor* rhs = op_context.rhs;
+
   // For "hybrid" quantization, we impose the constraint that the LHS
   // is float (typically an activation from a prior layer) and the RHS
   // is quantized int8.
-  bool is_hybrid =
-      (op_context->lhs->type == kTfLiteFloat32 && rhs->type == kTfLiteInt8);
+  bool is_hybrid = (lhs->type == kTfLiteFloat32 && rhs->type == kTfLiteInt8);
   if (is_hybrid) {
-    node->temporaries = TfLiteIntArrayCreate(kNumTempTensorsForAdjoints +
-                                             kNumTempTensorsForHybrid);
+    op_data->hybrid = static_cast<decltype(op_data->hybrid)>(
+        context->AllocatePersistentBuffer(context, sizeof(*op_data->hybrid)));
+    TF_LITE_ENSURE(context, op_data->hybrid != nullptr);
+    op_data->hybrid->input_quantized_index = kInvalidScratchBufferIndex;
+    op_data->hybrid->scaling_factors_index = kInvalidScratchBufferIndex;
+    op_data->hybrid->row_sums_buffer = nullptr;
+    op_data->hybrid->input_offsets_index = kInvalidScratchBufferIndex;
+  } else if (lhs->type == kTfLiteInt8) {
+    op_data->quantization = static_cast<decltype(op_data->quantization)>(
+        context->AllocatePersistentBuffer(context,
+                                          sizeof(*op_data->quantization)));
+    TF_LITE_ENSURE(context, op_data->quantization != nullptr);
   } else {
-    node->temporaries = TfLiteIntArrayCreate(kNumTempTensorsForAdjoints);
+    op_data->quantization = nullptr;  // also op_data->hybrid
   }
 
-  const int lhs_rank = NumDimensions(lhs);
-  const int rhs_rank = NumDimensions(rhs);
-  const int batch_size = op_context->params->adj_x
-                             ? lhs->dims->data[lhs_rank - 2]
-                             : lhs->dims->data[lhs_rank - 1];
-  const int num_units = op_context->params->adj_x
-                            ? lhs->dims->data[lhs_rank - 1]
-                            : lhs->dims->data[lhs_rank - 2];
-
-  // Temp tensor for Transposed LHS;
-  {
-    node->temporaries->data[0] = op_data->scratch_tensor_index;
-    TfLiteTensor* scratch_buffer;
-    TF_LITE_ENSURE_OK(
-        context, GetTemporarySafe(context, node, /*index=*/0, &scratch_buffer));
-    TfLiteIntArray* scratch_buffer_size = TfLiteIntArrayCreate(lhs_rank);
-    for (int i = 0; i < lhs_rank - 2; ++i) {
-      scratch_buffer_size->data[i] = lhs->dims->data[i];
-    }
-    // Swap last two dimensions.
-    scratch_buffer_size->data[lhs_rank - 2] = lhs->dims->data[lhs_rank - 1];
-    scratch_buffer_size->data[lhs_rank - 1] = lhs->dims->data[lhs_rank - 2];
-
-    scratch_buffer->type = op_context->lhs->type;
-    scratch_buffer->allocation_type = kTfLiteArenaRw;
-    TF_LITE_ENSURE_OK(context, context->ResizeTensor(context, scratch_buffer,
-                                                     scratch_buffer_size));
+  // tensor for Transposed LHS;
+  if (op_context.params->adj_x) {
+    op_data->lhs_transposed_tensor =
+        AllocInitTransposeTensorFromTfLiteTensor(context, *lhs);
+  } else {
+    op_data->lhs_transposed_tensor = nullptr;
   }
 
-  // We need a temp buffer for the RHS if we need to transpose the RHS. We
+  // We need a buffer for the RHS if we need to transpose the RHS. We
   // transpose by default, so that the two inputs (LHS and RHS) are in a proper
   // layout for our fast matrix multiplication routines. If the transpose flag
   // is set by the caller, the data is already in the desired layout.
-  {
-    node->temporaries->data[1] = op_data->scratch_tensor_index + 1;
-    TfLiteTensor* scratch_buffer;
-    TF_LITE_ENSURE_OK(
-        context, GetTemporarySafe(context, node, /*index=*/1, &scratch_buffer));
-    const TfLiteTensor* rhs = op_context->rhs;
-    int rhs_rank = NumDimensions(rhs);
-    TfLiteIntArray* scratch_buffer_size = TfLiteIntArrayCreate(rhs_rank);
-    for (int i = 0; i < rhs_rank - 2; ++i) {
-      scratch_buffer_size->data[i] = rhs->dims->data[i];
-    }
-    // Swap last two dimensions.
-    scratch_buffer_size->data[rhs_rank - 2] = rhs->dims->data[rhs_rank - 1];
-    scratch_buffer_size->data[rhs_rank - 1] = rhs->dims->data[rhs_rank - 2];
-
-    if (IsConstantTensor(op_context->rhs)) {
-      scratch_buffer->allocation_type = kTfLiteArenaRwPersistent;
-    } else {
-      scratch_buffer->allocation_type = kTfLiteArenaRw;
-    }
-    scratch_buffer->type = op_context->rhs->type;
-    scratch_buffer->allocation_type = kTfLiteArenaRw;
-    TF_LITE_ENSURE_OK(context, context->ResizeTensor(context, scratch_buffer,
-                                                     scratch_buffer_size));
+  if (!op_context.params->adj_y) {
+    op_data->rhs_transposed_tensor =
+        AllocInitTransposeTensorFromTfLiteTensor(context, *rhs);
+  } else {
+    op_data->rhs_transposed_tensor = nullptr;
   }
 
   // If we have to perform on-the-fly quantization (with quantized weights and
   // float inputs) first we need to quantize the inputs. Allocate temporary
   // buffer to store the intermediate quantized values, the batch scaling
-  // factors, the accumulator buffer (optimized version), the input offsets,
-  // and the sums of the rows for each weights matrix.
+  // factors, the input offsets, and persistent storage for the sums of the
+  // rows for each weights matrix.
   // RHS = weights, LHS = inputs
   if (is_hybrid) {
+    const int lhs_rank = NumDimensions(lhs);
+    const int rhs_rank = NumDimensions(rhs);
+    const int batch_size = op_context.params->adj_x
+                               ? lhs->dims->data[lhs_rank - 1]
+                               : lhs->dims->data[lhs_rank - 2];
+    const int num_units = rhs->dims->data[rhs_rank - 1];
+
     // Calculate the total number of LHS batches.
     int num_batches = 1;
     for (int i = 0; i < lhs_rank - 2; ++i) {
@@ -217,147 +256,152 @@ TfLiteStatus InitializeTemporaries(TfLiteContext* context, TfLiteNode* node,
     for (int i = 0; i < rhs_rank - 2; ++i) {
       num_weights_matrices *= rhs->dims->data[i];
     }
-    op_data->compute_row_sums = true;
-    node->temporaries->data[2] = op_data->scratch_tensor_index + 2;
-    TfLiteTensor* input_quantized;
-    TF_LITE_ENSURE_OK(context, GetTemporarySafe(context, node, /*index=*/2,
-                                                &input_quantized));
-    input_quantized->type = op_context->rhs->type;
-    input_quantized->allocation_type = kTfLiteArenaRw;
 
-    TfLiteIntArray* input_quantized_size =
-        TfLiteIntArrayCopy(op_context->lhs->dims);
-    TF_LITE_ENSURE_OK(context, context->ResizeTensor(context, input_quantized,
-                                                     input_quantized_size));
+    op_data->hybrid->compute_row_sums = true;
 
-    node->temporaries->data[3] = op_data->scratch_tensor_index + 3;
-    TfLiteTensor* scaling_factors;
-    TF_LITE_ENSURE_OK(context, GetTemporarySafe(context, node, /*index=*/3,
-                                                &scaling_factors));
-    scaling_factors->type = kTfLiteFloat32;
-    scaling_factors->allocation_type = kTfLiteArenaRw;
-    // Total size of scaling factors is batch size * number of total batches
-    int scaling_dims[1] = {num_batches * batch_size};
-    if (!TfLiteIntArrayEqualsArray(scaling_factors->dims, 1, scaling_dims)) {
-      TfLiteIntArray* scaling_factors_size = TfLiteIntArrayCreate(1);
-      scaling_factors_size->data[0] = batch_size;
-      TF_LITE_ENSURE_OK(context, context->ResizeTensor(context, scaling_factors,
-                                                       scaling_factors_size));
-    }
+    const size_t input_quantized_size = static_cast<size_t>(
+        NumElements(lhs->dims) * TfLiteTypeGetSize(rhs->type));
+    TF_LITE_ENSURE_OK(context, context->RequestScratchBufferInArena(
+                                   context, input_quantized_size,
+                                   &op_data->hybrid->input_quantized_index));
 
-    node->temporaries->data[4] = op_data->scratch_tensor_index + 4;
-    TfLiteTensor* accum_scratch;
-    TF_LITE_ENSURE_OK(
-        context, GetTemporarySafe(context, node, /*index=*/4, &accum_scratch));
-    accum_scratch->type = kTfLiteInt32;
-    accum_scratch->allocation_type = kTfLiteArenaRw;
-    int accum_scratch_dims[2] = {num_units, batch_size};
-    if (!TfLiteIntArrayEqualsArray(accum_scratch->dims, 2,
-                                   accum_scratch_dims)) {
-      TfLiteIntArray* accum_size = TfLiteIntArrayCreate(2);
-      accum_size->data[0] = num_units;
-      accum_size->data[1] = batch_size;
-      TF_LITE_ENSURE_OK(
-          context, context->ResizeTensor(context, accum_scratch, accum_size));
-    }
+    const size_t scaling_factors_size =
+        static_cast<size_t>(batch_size * num_batches * sizeof(float));
+    TF_LITE_ENSURE_OK(context, context->RequestScratchBufferInArena(
+                                   context, scaling_factors_size,
+                                   &op_data->hybrid->scaling_factors_index));
 
-    node->temporaries->data[5] = op_data->scratch_tensor_index + 5;
-    TfLiteTensor* input_offsets;
-    TF_LITE_ENSURE_OK(
-        context, GetTemporarySafe(context, node, /*index=*/5, &input_offsets));
-    input_offsets->type = kTfLiteInt32;
-    input_offsets->allocation_type = kTfLiteArenaRw;
-    if (!TfLiteIntArrayEqualsArray(input_offsets->dims, 1, scaling_dims)) {
-      TfLiteIntArray* input_offsets_size = TfLiteIntArrayCreate(1);
-      input_offsets_size->data[0] = num_batches * batch_size;
-      TF_LITE_ENSURE_OK(context, context->ResizeTensor(context, input_offsets,
-                                                       input_offsets_size));
-    }
-    node->temporaries->data[6] = op_data->scratch_tensor_index + 6;
-    TfLiteTensor* row_sums;
-    TF_LITE_ENSURE_OK(context,
-                      GetTemporarySafe(context, node, /*index=*/6, &row_sums));
-    row_sums->type = kTfLiteInt32;
-    row_sums->allocation_type = kTfLiteArenaRwPersistent;
-    int row_sums_dims[1] = {num_weights_matrices * num_units};
-    if (!TfLiteIntArrayEqualsArray(row_sums->dims, 1, row_sums_dims)) {
-      TfLiteIntArray* row_sums_size = TfLiteIntArrayCreate(1);
-      row_sums_size->data[0] = row_sums_dims[0];
-      TF_LITE_ENSURE_OK(
-          context, context->ResizeTensor(context, row_sums, row_sums_size));
-    }
+    const size_t input_offsets_size =
+        static_cast<size_t>(batch_size * num_batches * sizeof(int32_t));
+    TF_LITE_ENSURE_OK(context, context->RequestScratchBufferInArena(
+                                   context, input_offsets_size,
+                                   &op_data->hybrid->input_offsets_index));
+
+    const size_t row_sums_size =
+        static_cast<size_t>(num_weights_matrices * num_units * sizeof(int32_t));
+    op_data->hybrid->row_sums_buffer = static_cast<int32_t*>(
+        context->AllocatePersistentBuffer(context, row_sums_size));
+    TF_LITE_ENSURE(context, op_data->hybrid->row_sums_buffer != nullptr);
+
+    op_data->hybrid->filter_scale = rhs->params.scale;
   }
 
   return kTfLiteOk;
 }
 
-TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+template <typename scalar>
+void TransposeRowsColumnsImpl(const TfLiteEvalTensor& tensor_in,
+                              const scalar* input, TfLiteEvalTensor* tensor_out,
+                              scalar* output) {
+  RuntimeShape transposed_shape(tflite::micro::GetTensorShape(&tensor_in));
+  RuntimeShape shape(transposed_shape);
+  TransposeParams params;
+  int rank = shape.DimensionsCount();
+  params.perm_count = rank;
+  for (int i = 0; i < rank - 2; ++i) {
+    params.perm[i] = i;
+  }
+  // Transpose the last two dimensions.
+  params.perm[rank - 2] = rank - 1;
+  params.perm[rank - 1] = rank - 2;
+  transposed_shape.SetDim(rank - 1, shape.Dims(rank - 2));
+  transposed_shape.SetDim(rank - 2, shape.Dims(rank - 1));
+  reference_ops::Transpose(params, shape, input, transposed_shape, output);
+}
+
+TfLiteStatus TransposeRowsColumns(TfLiteContext* context,
+                                  const TfLiteEvalTensor& tensor_in,
+                                  TfLiteEvalTensor* tensor_out) {
+  if (tensor_in.type == kTfLiteFloat32) {
+    TransposeRowsColumnsImpl<float>(
+        tensor_in, tflite::micro::GetTensorData<float>(&tensor_in), tensor_out,
+        tflite::micro::GetTensorData<float>(tensor_out));
+    return kTfLiteOk;
+  } else if (tensor_in.type == kTfLiteInt8) {
+    TransposeRowsColumnsImpl<int8_t>(
+        tensor_in, tflite::micro::GetTensorData<int8_t>(&tensor_in), tensor_out,
+        tflite::micro::GetTensorData<int8_t>(tensor_out));
+    return kTfLiteOk;
+  } else {
+    TF_LITE_KERNEL_LOG(context,
+                       "BATCH_MATMUL can only transpose tensors with float, "
+                       "int8 type.");
+    return kTfLiteError;
+  }
+}
+
+RuntimeShape SwapRowColumnDims(const RuntimeShape& shape) {
+  RuntimeShape swapped_shape(shape);
+  const int32_t dims = shape.DimensionsCount();
+  swapped_shape.SetDim(dims - 2, shape.Dims(dims - 1));
+  swapped_shape.SetDim(dims - 1, shape.Dims(dims - 2));
+  return swapped_shape;
+}
+
+TfLiteStatus CalculateOpData(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE_EQ(context, NumInputs(node), 2);
   TF_LITE_ENSURE_EQ(context, NumOutputs(node), 1);
 
-  OpContext op_context(context, node);
-  TF_LITE_ENSURE_OK(context, InitializeTemporaries(context, node, &op_context));
-  OpData* op_data = reinterpret_cast<OpData*>(node->user_data);
-
-  bool adj_x = op_context.params->adj_x;
-  bool adj_y = op_context.params->adj_y;
-
-  const TfLiteTensor* lhs_data;
-  TF_LITE_ENSURE_OK(context,
-                    GetInputSafe(context, node, kInputLHSTensor, &lhs_data));
-  const TfLiteTensor* rhs_data;
-  TF_LITE_ENSURE_OK(context,
-                    GetInputSafe(context, node, kInputRHSTensor, &rhs_data));
-  TfLiteTensor* output;
-  TF_LITE_ENSURE_OK(context,
-                    GetOutputSafe(context, node, kOutputTensor, &output));
-
-  // Note that quantized inference requires that all tensors have their
-  // parameters set. This is usually done during quantized training.
-  if (lhs_data->type == kTfLiteInt8 || lhs_data->type == kTfLiteInt16) {
-    double real_multiplier = 0.0;
-    TF_LITE_ENSURE_STATUS(GetQuantizedConvolutionMultipler(
-        context, lhs_data, rhs_data, output, &real_multiplier));
-    int exponent;
-    QuantizeMultiplier(real_multiplier, &op_data->output_multiplier, &exponent);
-    op_data->output_shift = exponent;
-    // BatchMatMul has no fused activation functions. Therefore, set
-    // output activation min and max to min and max of int8_t or int16_t
-    // type.
-    if (lhs_data->type == kTfLiteInt8) {
-      op_data->output_activation_min = std::numeric_limits<int8_t>::min();
-      op_data->output_activation_max = std::numeric_limits<int8_t>::max();
-    } else {
-      op_data->output_activation_min = std::numeric_limits<int16_t>::min();
-      op_data->output_activation_max = std::numeric_limits<int16_t>::max();
-    }
-  }
-
-  if (lhs_data->type == kTfLiteInt16) {
-    TF_LITE_ENSURE_EQ(context, lhs_data->params.zero_point, 0);
-    TF_LITE_ENSURE_EQ(context, rhs_data->params.zero_point, 0);
-    TF_LITE_ENSURE_EQ(context, output->params.zero_point, 0);
-  }
+  PrepareOpContext op_context(context, node);
+  const TfLiteTensor* lhs_data = op_context.lhs;
+  TF_LITE_ENSURE(context, lhs_data != nullptr);
+  const TfLiteTensor* rhs_data = op_context.rhs;
+  TF_LITE_ENSURE(context, rhs_data != nullptr);
+  TfLiteTensor* output = op_context.output;
+  TF_LITE_ENSURE(context, output != nullptr);
 
   TF_LITE_ENSURE(context, lhs_data->type == kTfLiteFloat32 ||
-                              lhs_data->type == kTfLiteInt8 ||
-                              lhs_data->type == kTfLiteInt16);
+                              lhs_data->type == kTfLiteInt8);
   TF_LITE_ENSURE(context, rhs_data->type == kTfLiteFloat32 ||
-                              rhs_data->type == kTfLiteInt8 ||
-                              rhs_data->type == kTfLiteInt16);
+                              rhs_data->type == kTfLiteInt8);
   // Either we have a hybrid quantization with a float32 and an int8 input,
   // otherwise both inputs should be of the same type.
   TF_LITE_ENSURE(context, (lhs_data->type == kTfLiteFloat32 &&
                            rhs_data->type == kTfLiteInt8) ||
                               lhs_data->type == rhs_data->type);
-  // Support dimensions between 2 and 4, inclusive.
-  TF_LITE_ENSURE(context, NumDimensions(lhs_data) >= 2);
-  TF_LITE_ENSURE(context, NumDimensions(lhs_data) <= 4);
-  TF_LITE_ENSURE(context, NumDimensions(rhs_data) >= 2);
-  TF_LITE_ENSURE(context, NumDimensions(rhs_data) <= 4);
 
   const int lhs_rank = NumDimensions(lhs_data);
   const int rhs_rank = NumDimensions(rhs_data);
+  // Support dimensions between 2 and 4, inclusive.
+  TF_LITE_ENSURE(context, lhs_rank >= 2);
+  TF_LITE_ENSURE(context, lhs_rank <= 4);
+  TF_LITE_ENSURE(context, rhs_rank >= 2);
+  TF_LITE_ENSURE(context, rhs_rank <= 4);
+
+  TF_LITE_ENSURE_OK(context, InitializeTemporaries(context, node, op_context));
+
+  OpData* op_data = op_context.opdata;
+  // If the RHS is constant, we only transpose once.
+  op_data->rhs_is_transposed = false;
+  op_data->lhs_is_constant_tensor = IsConstantTensor(lhs_data);
+  op_data->rhs_is_constant_tensor = IsConstantTensor(rhs_data);
+
+  bool adj_x = op_context.params->adj_x;
+  bool adj_y = op_context.params->adj_y;
+
+  // Note that quantized inference requires that all tensors have their
+  // parameters set. This is usually done during quantized training.
+  if (lhs_data->type == kTfLiteInt8) {
+    TF_LITE_ENSURE(context, op_data->quantization != nullptr);
+    double real_multiplier = 0.0;
+    TF_LITE_ENSURE_STATUS(GetQuantizedConvolutionMultipler(
+        context, lhs_data, rhs_data, output, &real_multiplier));
+    QuantizeMultiplier(real_multiplier,
+                       &op_data->quantization->output_multiplier,
+                       &op_data->quantization->output_shift);
+    // BatchMatMul has no fused activation functions. Therefore, set
+    // output activation min and max to min and max of int8_t type.
+    op_data->quantization->output_activation_min =
+        std::numeric_limits<int8_t>::min();
+    op_data->quantization->output_activation_max =
+        std::numeric_limits<int8_t>::max();
+
+    // set zero_point for Int8 only
+    op_data->quantization->lhs_zero_point = lhs_data->params.zero_point;
+    op_data->quantization->rhs_zero_point = rhs_data->params.zero_point;
+    op_data->quantization->output_zero_point = output->params.zero_point;
+  }
+
   const int output_rank = std::max(lhs_rank, rhs_rank);
   const RuntimeShape extended_lhs_shape =
       RuntimeShape::ExtendedShape(output_rank, GetTensorShape(lhs_data));
@@ -382,76 +426,31 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
 
   TF_LITE_ENSURE_EQ(context, accum_dim_lhs, accum_dim_rhs);
   TfLiteStatus status =
-      ResizeOutputTensor(context, extended_lhs_shape, extended_rhs_shape, adj_x,
-                         adj_y, output_rank, output);
+      ResizeOutputTensor(context, node, extended_lhs_shape, extended_rhs_shape,
+                         adj_x, adj_y, output_rank, output);
   return status;
 }
 
-template <typename scalar>
-void TransposeRowsColumnsImpl(const TfLiteTensor* tensor_in,
-                              const scalar* input, TfLiteTensor* tensor_out,
-                              scalar* output) {
-  RuntimeShape transposed_shape(GetTensorShape(tensor_in));
-  RuntimeShape shape(GetTensorShape(tensor_in));
-  TransposeParams params;
-  int rank = NumDimensions(tensor_in);
-  params.perm_count = rank;
-  for (int i = 0; i < rank - 2; ++i) {
-    params.perm[i] = i;
-  }
-  // Transpose the last two dimensions.
-  params.perm[rank - 2] = rank - 1;
-  params.perm[rank - 1] = rank - 2;
-  transposed_shape.SetDim(rank - 1, shape.Dims(rank - 2));
-  transposed_shape.SetDim(rank - 2, shape.Dims(rank - 1));
-  optimized_ops::Transpose(params, shape, input, transposed_shape, output);
+void* Init(TfLiteContext* context, const char* buffer, size_t length) {
+  // This is a builtin op, so we don't use the contents in 'buffer', if any.
+  // Instead, we allocate a new object to carry information from Prepare() to
+  // Eval().
+  TFLITE_DCHECK(context->AllocatePersistentBuffer != nullptr);
+  return context->AllocatePersistentBuffer(context, sizeof(OpData));
 }
 
-TfLiteStatus TransposeRowsColumns(TfLiteContext* context,
-                                  const TfLiteTensor* tensor_in,
-                                  TfLiteTensor* tensor_out) {
-  if (tensor_in->type == kTfLiteFloat32) {
-    TransposeRowsColumnsImpl<float>(tensor_in, GetTensorData<float>(tensor_in),
-                                    tensor_out,
-                                    GetTensorData<float>(tensor_out));
-    return kTfLiteOk;
-  } else if (tensor_in->type == kTfLiteInt8) {
-    TransposeRowsColumnsImpl<int8_t>(
-        tensor_in, GetTensorData<int8_t>(tensor_in), tensor_out,
-        GetTensorData<int8_t>(tensor_out));
-    return kTfLiteOk;
-  } else if (tensor_in->type == kTfLiteInt16) {
-    TransposeRowsColumnsImpl<int16_t>(
-        tensor_in, GetTensorData<int16_t>(tensor_in), tensor_out,
-        GetTensorData<int16_t>(tensor_out));
-    return kTfLiteOk;
-  } else {
-    TF_LITE_KERNEL_LOG(
-        context, "Can only transpose tensors with float, int8 or int16 type.");
-    return kTfLiteError;
-  }
+TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+  return CalculateOpData(context, node);
 }
 
-RuntimeShape SwapRowColumnDims(const RuntimeShape& shape) {
-  RuntimeShape swapped_shape(shape);
-  const int32_t dims = shape.DimensionsCount();
-  swapped_shape.SetDim(dims - 2, shape.Dims(dims - 1));
-  swapped_shape.SetDim(dims - 1, shape.Dims(dims - 2));
-  return swapped_shape;
-}
-
-template <KernelType kernel_type>
-TfLiteStatus EvalHybrid(TfLiteContext* context, TfLiteNode* node, OpData* data,
-                        const RuntimeShape& input_shape,
-                        const TfLiteTensor* input,
+TfLiteStatus EvalHybrid(TfLiteContext* context, TfLiteNode* node,
+                        const OpData& data, const RuntimeShape& input_shape,
+                        const TfLiteEvalTensor& input,
                         const RuntimeShape& filter_shape,
-                        const TfLiteTensor* filter,
-                        TfLiteTensor* input_quantized,
-                        TfLiteTensor* scaling_factors,
-                        TfLiteTensor* accum_scratch, TfLiteTensor* row_sums,
-                        TfLiteTensor* input_offsets, TfLiteTensor* output) {
+                        const TfLiteEvalTensor& filter,
+                        TfLiteEvalTensor* output) {
   const auto* params =
-      reinterpret_cast<TfLiteBatchMatMulParams*>(node->builtin_data);
+      static_cast<TfLiteBatchMatMulParams*>(node->builtin_data);
   const int32_t num_input_dims = input_shape.DimensionsCount();
 
   // Input row/cols have been swapped at this point, so dims are
@@ -464,17 +463,19 @@ TfLiteStatus EvalHybrid(TfLiteContext* context, TfLiteNode* node, OpData* data,
     num_batches_to_quantize *= input_shape.Dims(i);
   }
   // Quantize input from float to uint8 + quantization params (scaling factor).
-  float* scaling_factors_ptr = GetTensorData<float>(scaling_factors);
-  int32_t* input_offset_ptr = nullptr;
-  int32_t* row_sums_ptr = nullptr;
-  input_offset_ptr = GetTensorData<int32_t>(input_offsets);
-  row_sums_ptr = GetTensorData<int32_t>(row_sums);
+  float* scaling_factors_ptr = static_cast<float*>(
+      context->GetScratchBuffer(context, data.hybrid->scaling_factors_index));
+  int32_t* input_offset_ptr = static_cast<int32_t*>(
+      context->GetScratchBuffer(context, data.hybrid->input_offsets_index));
+  int32_t* row_sums_ptr = data.hybrid->row_sums_buffer;
   if (!params->asymmetric_quantize_inputs) {
-    memset(input_offset_ptr, 0, input_offsets->bytes);
+    std::fill_n(input_offset_ptr, num_batches_to_quantize, 0);
   }
-  int8_t* quant_data = GetTensorData<int8_t>(input_quantized);
-  const int8_t* filter_data = GetTensorData<int8_t>(filter);
-  const float* input_ptr = GetTensorData<float>(input);
+
+  int8_t* quant_data = static_cast<int8_t*>(
+      context->GetScratchBuffer(context, data.hybrid->input_quantized_index));
+  const int8_t* filter_data = tflite::micro::GetTensorData<int8_t>(&filter);
+  const float* input_ptr = tflite::micro::GetTensorData<float>(&input);
   // Quantize each batch independently.
   tensor_utils::BatchQuantizeFloats(input_ptr, num_batches_to_quantize,
                                     input_size, quant_data, scaling_factors_ptr,
@@ -482,161 +483,77 @@ TfLiteStatus EvalHybrid(TfLiteContext* context, TfLiteNode* node, OpData* data,
                                     params->asymmetric_quantize_inputs);
   for (int b = 0; b < num_batches_to_quantize; ++b) {
     // Incorporate scaling of the filter.
-    scaling_factors_ptr[b] *= filter->params.scale;
+    scaling_factors_ptr[b] *= data.hybrid->filter_scale;
   }
 
-  RuntimeShape output_shape = GetTensorShape(output);
-  int output_size = 1;
-  for (int i = 0; i < output_shape.DimensionsCount(); ++i) {
-    output_size *= output_shape.Dims(i);
-  }
-  std::fill_n(GetTensorData<float>(output), output_size, 0.0f);
-  if (kernel_type == kGenericOptimized) {
-    optimized_ops::BatchMatMul(
-        filter_shape, filter_data, input_shape, quant_data, scaling_factors_ptr,
-        input_offset_ptr, row_sums_ptr, GetTensorShape(output),
-        GetTensorData<int32_t>(accum_scratch), GetTensorData<float>(output),
-        &(data->compute_row_sums), CpuBackendContext::GetFromContext(context));
-  } else {
-    reference_ops::BatchMatMul(
-        filter_shape, filter_data, input_shape, quant_data, scaling_factors_ptr,
-        input_offset_ptr, row_sums_ptr, GetTensorShape(output),
-        GetTensorData<float>(output), &(data->compute_row_sums));
-  }
+  RuntimeShape output_shape = tflite::micro::GetTensorShape(output);
+  int output_size = NumElements(output->dims);
+  std::fill_n(tflite::micro::GetTensorData<float>(output), output_size, 0.0f);
+  reference_ops::BatchMatMul(
+      filter_shape, filter_data, input_shape, quant_data, scaling_factors_ptr,
+      input_offset_ptr, row_sums_ptr, tflite::micro::GetTensorShape(output),
+      tflite::micro::GetTensorData<float>(output),
+      &(data.hybrid->compute_row_sums));
 
   return kTfLiteOk;
 }
 
-template <KernelType kernel_type>
-TfLiteStatus EvalInt8(TfLiteContext* context, const OpData* data,
-                      const RuntimeShape& lhs_shape, const TfLiteTensor* lhs,
-                      const RuntimeShape& rhs_shape, const TfLiteTensor* rhs,
-                      const RuntimeShape& output_shape, TfLiteTensor* output) {
+TfLiteStatus EvalInt8(TfLiteContext* context, const OpData& data,
+                      const RuntimeShape& lhs_shape,
+                      const TfLiteEvalTensor& lhs,
+                      const RuntimeShape& rhs_shape,
+                      const TfLiteEvalTensor& rhs,
+                      const RuntimeShape& output_shape,
+                      TfLiteEvalTensor* output) {
+  TF_LITE_ENSURE(context, data.quantization != nullptr);
+
   // Reuse params struct from FullyConnected Op.
   FullyConnectedParams op_params;
-  int32_t input_offset = -lhs->params.zero_point;
-  int32_t filter_offset = -rhs->params.zero_point;
-  int32_t output_offset = output->params.zero_point;
-  op_params.input_offset = input_offset;
-  op_params.weights_offset = filter_offset;
-  op_params.output_offset = output_offset;
-  op_params.output_multiplier = data->output_multiplier;
-  op_params.output_shift = data->output_shift;
-  op_params.quantized_activation_min = data->output_activation_min;
-  op_params.quantized_activation_max = data->output_activation_max;
-  op_params.lhs_cacheable = IsConstantTensor(lhs);
-  op_params.rhs_cacheable = IsConstantTensor(rhs);
+  op_params.input_offset = -data.quantization->lhs_zero_point;
+  op_params.weights_offset =
+      -data.quantization->rhs_zero_point;  // filter offset
+  op_params.output_offset = data.quantization->output_zero_point;
+  op_params.output_multiplier = data.quantization->output_multiplier;
+  op_params.output_shift = data.quantization->output_shift;
+  op_params.quantized_activation_min = data.quantization->output_activation_min;
+  op_params.quantized_activation_max = data.quantization->output_activation_max;
+  op_params.lhs_cacheable = data.lhs_is_constant_tensor;
+  op_params.rhs_cacheable = data.rhs_is_constant_tensor;
 
-  if (kernel_type == kReference) {
-    reference_ops::BatchMatMul<int8_t, int32_t>(
-        op_params, rhs_shape, GetTensorData<int8_t>(rhs), lhs_shape,
-        GetTensorData<int8_t>(lhs), GetTensorShape(output),
-        GetTensorData<int8_t>(output));
-  } else {
-    optimized_ops::BatchMatMul(op_params, rhs_shape, GetTensorData<int8_t>(rhs),
-                               lhs_shape, GetTensorData<int8_t>(lhs),
-                               GetTensorShape(output),
-                               GetTensorData<int8_t>(output),
-                               CpuBackendContext::GetFromContext(context));
-  }
+  // Note we pass RHS args first, LHS args second. See note for Eval.
+  reference_ops::BatchMatMul<int8_t, int32_t>(
+      op_params, rhs_shape, tflite::micro::GetTensorData<int8_t>(&rhs),
+      lhs_shape, tflite::micro::GetTensorData<int8_t>(&lhs), output_shape,
+      tflite::micro::GetTensorData<int8_t>(output));
+
   return kTfLiteOk;
 }
 
-template <KernelType kernel_type>
-TfLiteStatus EvalInt16(TfLiteContext* context, const OpData* data,
-                       const RuntimeShape& lhs_shape, const TfLiteTensor* lhs,
-                       const RuntimeShape& rhs_shape, const TfLiteTensor* rhs,
-                       const RuntimeShape& output_shape, TfLiteTensor* output) {
-  // Reuse params struct from FullyConnected Op.
-  FullyConnectedParams op_params;
-  int32_t input_offset = -lhs->params.zero_point;
-  int32_t filter_offset = -rhs->params.zero_point;
-  int32_t output_offset = output->params.zero_point;
-  op_params.input_offset = input_offset;
-  op_params.weights_offset = filter_offset;
-  op_params.output_offset = output_offset;
-  op_params.output_multiplier = data->output_multiplier;
-  op_params.output_shift = data->output_shift;
-  op_params.quantized_activation_min = data->output_activation_min;
-  op_params.quantized_activation_max = data->output_activation_max;
-
-  // optimized_ops not yet implemnted for int16_t, use reference_ops in all
-  // cases.
-  reference_ops::BatchMatMul<int16_t, int64_t>(
-      op_params, rhs_shape, GetTensorData<int16_t>(rhs), lhs_shape,
-      GetTensorData<int16_t>(lhs), GetTensorShape(output),
-      GetTensorData<int16_t>(output));
-  return kTfLiteOk;
-}
-
-template <KernelType kernel_type>
 TfLiteStatus EvalQuantized(TfLiteContext* context, TfLiteNode* node,
-                           OpData* data, const RuntimeShape& lhs_shape,
-                           const TfLiteTensor* lhs,
+                           const OpData& data, const RuntimeShape& lhs_shape,
+                           const TfLiteEvalTensor& lhs,
                            const RuntimeShape& rhs_shape,
-                           const TfLiteTensor* rhs, TfLiteTensor* output) {
-  if (lhs->type == kTfLiteFloat32 && rhs->type == kTfLiteInt8) {
-    TfLiteTensor* input_quantized;
-    TF_LITE_ENSURE_OK(context, GetTemporarySafe(context, node, /*index=*/2,
-                                                &input_quantized));
-    TfLiteTensor* scaling_factors;
-    TF_LITE_ENSURE_OK(context, GetTemporarySafe(context, node, /*index=*/3,
-                                                &scaling_factors));
-    TfLiteTensor* accum_scratch;
-    TF_LITE_ENSURE_OK(
-        context, GetTemporarySafe(context, node, /*index=*/4, &accum_scratch));
-    TfLiteTensor* input_offsets;
-    TF_LITE_ENSURE_OK(
-        context, GetTemporarySafe(context, node, /*index=*/5, &input_offsets));
-    TfLiteTensor* row_sums;
-    TF_LITE_ENSURE_OK(context,
-                      GetTemporarySafe(context, node, /*index=*/6, &row_sums));
-    return EvalHybrid<kernel_type>(
-        context, node, data, lhs_shape, lhs, rhs_shape, rhs, input_quantized,
-        scaling_factors, accum_scratch, row_sums, input_offsets, output);
-  } else if (lhs->type == kTfLiteInt8 && rhs->type == kTfLiteInt8) {
-    return EvalInt8<kernel_type>(context, data, lhs_shape, lhs, rhs_shape, rhs,
-                                 GetTensorShape(output), output);
-  } else if (lhs->type == kTfLiteInt16 && rhs->type == kTfLiteInt16) {
-    return EvalInt16<kernel_type>(context, data, lhs_shape, lhs, rhs_shape, rhs,
-                                  GetTensorShape(output), output);
+                           const TfLiteEvalTensor& rhs,
+                           TfLiteEvalTensor* output) {
+  if (lhs.type == kTfLiteFloat32 && rhs.type == kTfLiteInt8) {
+    TF_LITE_ENSURE(context, data.hybrid != nullptr);
+    TF_LITE_ENSURE(context, data.hybrid->row_sums_buffer != nullptr);
+    TF_LITE_ENSURE(context, data.hybrid->input_quantized_index !=
+                                kInvalidScratchBufferIndex);
+    TF_LITE_ENSURE(context, data.hybrid->scaling_factors_index !=
+                                kInvalidScratchBufferIndex);
+    TF_LITE_ENSURE(context, data.hybrid->input_offsets_index !=
+                                kInvalidScratchBufferIndex);
+    return EvalHybrid(context, node, data, lhs_shape, lhs, rhs_shape, rhs,
+                      output);
+  } else if (lhs.type == kTfLiteInt8 && rhs.type == kTfLiteInt8) {
+    return EvalInt8(context, data, lhs_shape, lhs, rhs_shape, rhs,
+                    tflite::micro::GetTensorShape(output), output);
   } else {
     TF_LITE_KERNEL_LOG(
-        context,
-        "Currently only hybrid, int8 and int16 quantization are supported.\n");
-    return kTfLiteError;
+        context, "BATCH_MATMUL only supports hybrid, int8 quantization.\n");
   }
-  return kTfLiteOk;
-}
-
-TfLiteTensor* GetTempRhs(TfLiteContext* context, TfLiteNode* node,
-                         const TfLiteTensor* rhs) {
-  TfLiteTensor* transposed_rhs = GetTemporary(context, node, 1);
-  if (transposed_rhs == nullptr) {
-    return nullptr;
-  }
-
-  if (rhs->type == kTfLiteInt8 || rhs->type == kTfLiteInt16) {
-    // Get the quantization params from the RHS tensor.
-    transposed_rhs->params.scale = rhs->params.scale;
-    transposed_rhs->params.zero_point = rhs->params.zero_point;
-  }
-  return transposed_rhs;
-}
-
-TfLiteTensor* GetTempLhs(TfLiteContext* context, TfLiteNode* node,
-                         const TfLiteTensor* lhs) {
-  TfLiteTensor* transposed_lhs = GetTemporary(context, node, 0);
-  if (transposed_lhs == nullptr) {
-    return nullptr;
-  }
-
-  if (lhs->type == kTfLiteInt8 || lhs->type == kTfLiteInt16) {
-    // Get the quantization params from the LHS tensor.
-    transposed_lhs->params.scale = lhs->params.scale;
-    transposed_lhs->params.zero_point = lhs->params.zero_point;
-  }
-  return transposed_lhs;
+  return kTfLiteError;
 }
 
 // Perform a batch matrix multiply on
@@ -650,37 +567,34 @@ TfLiteTensor* GetTempLhs(TfLiteContext* context, TfLiteNode* node,
 // RHS <..., C, B> X LHS <..., B, A>
 // where output is a C X A column-oriented, which is equivalent to
 // A X C row-oriented.
-template <KernelType kernel_type>
 TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
-  OpContext op_context(context, node);
-  OpData* op_data = reinterpret_cast<OpData*>(node->user_data);
-  const TfLiteTensor* lhs;
-  TF_LITE_ENSURE_OK(context,
-                    GetInputSafe(context, node, kInputLHSTensor, &lhs));
-  const TfLiteTensor* rhs;
-  TF_LITE_ENSURE_OK(context,
-                    GetInputSafe(context, node, kInputRHSTensor, &rhs));
-  TfLiteTensor* output;
-  TF_LITE_ENSURE_OK(context,
-                    GetOutputSafe(context, node, kOutputTensor, &output));
-  RuntimeShape orig_lhs_shape = GetTensorShape(lhs);
-  RuntimeShape orig_rhs_shape = GetTensorShape(rhs);
+  EvalOpContext op_context(context, node);
+  OpData* op_data = op_context.opdata;
+  const TfLiteEvalTensor* lhs = op_context.lhs;
+  const TfLiteEvalTensor* rhs = op_context.rhs;
+  TfLiteEvalTensor* output = op_context.output;
+  RuntimeShape orig_lhs_shape = tflite::micro::GetTensorShape(lhs);
+  RuntimeShape orig_rhs_shape = tflite::micro::GetTensorShape(rhs);
 
   bool adj_y = op_context.params->adj_y;
   bool adj_x = op_context.params->adj_x;
 
-  const TfLiteTensor* rhs_tensor = adj_y ? rhs : GetTempRhs(context, node, rhs);
-  const TfLiteTensor* lhs_tensor = adj_x ? GetTempLhs(context, node, lhs) : lhs;
+  TfLiteEvalTensor* rhs_tensor = adj_y ? const_cast<TfLiteEvalTensor*>(rhs)
+                                       : op_data->rhs_transposed_tensor;
+  TfLiteEvalTensor* lhs_tensor = adj_x ? op_data->lhs_transposed_tensor
+                                       : const_cast<TfLiteEvalTensor*>(lhs);
+  TF_LITE_ENSURE(context, rhs_tensor != nullptr);
+  TF_LITE_ENSURE(context, lhs_tensor != nullptr);
   if (!adj_y) {
-    // TODO(b/154760341) Constant tensors should already be transposed, but
+    // OLD-TODO(b/154760341) Constant tensors should already be transposed, but
     // we transpose once if necessary for now.
-    if (!(IsConstantTensor(rhs) && op_data->rhs_transposed)) {
-      TransposeRowsColumns(context, rhs, GetTemporary(context, node, 1));
-      op_data->rhs_transposed = true;
+    if (!(op_data->rhs_is_constant_tensor && op_data->rhs_is_transposed)) {
+      TransposeRowsColumns(context, *rhs, rhs_tensor);
+      op_data->rhs_is_transposed = true;
     }
   }
   if (adj_x) {
-    TransposeRowsColumns(context, lhs, GetTemporary(context, node, 0));
+    TransposeRowsColumns(context, *lhs, lhs_tensor);
   }
   RuntimeShape rhs_shape =
       adj_y ? orig_rhs_shape : SwapRowColumnDims(orig_rhs_shape);
@@ -690,53 +604,35 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   switch (rhs->type) {
     case kTfLiteFloat32:
       // Note we pass RHS args first, LHS args second. See note above.
-      if (kernel_type == kGenericOptimized) {
-        optimized_ops::BatchMatMul(rhs_shape, GetTensorData<float>(rhs_tensor),
-                                   lhs_shape, GetTensorData<float>(lhs_tensor),
-                                   GetTensorShape(output),
-                                   GetTensorData<float>(output),
-                                   CpuBackendContext::GetFromContext(context));
-      } else {
-        reference_ops::BatchMatMul(rhs_shape, GetTensorData<float>(rhs_tensor),
-                                   lhs_shape, GetTensorData<float>(lhs_tensor),
-                                   GetTensorShape(output),
-                                   GetTensorData<float>(output));
-      }
+      reference_ops::BatchMatMul(
+          rhs_shape, tflite::micro::GetTensorData<float>(rhs_tensor), lhs_shape,
+          tflite::micro::GetTensorData<float>(lhs_tensor),
+          tflite::micro::GetTensorShape(output),
+          tflite::micro::GetTensorData<float>(output));
       break;
     case kTfLiteInt8:
-    case kTfLiteInt16:
-      EvalQuantized<kernel_type>(context, node, op_data, lhs_shape, lhs_tensor,
-                                 rhs_shape, rhs_tensor, output);
-      break;
+      return EvalQuantized(context, node, *op_data, lhs_shape, *lhs_tensor,
+                           rhs_shape, *rhs_tensor, output);
     default:
       TF_LITE_KERNEL_LOG(context,
-                         "Currently BatchMatMul doesn't support type: %s",
+                         "Currently BATCH_MATMUL doesn't support type: %s",
                          TfLiteTypeGetName(lhs->type));
       return kTfLiteError;
   }
   return kTfLiteOk;
 }
 
-}  // namespace batch_matmul
+}  // namespace
 
-TfLiteRegistration* Register_BATCH_MATMUL_REF() {
-  static TfLiteRegistration r = {batch_matmul::Init, batch_matmul::Free,
-                                 batch_matmul::Prepare,
-                                 batch_matmul::Eval<batch_matmul::kReference>};
-  return &r;
+TfLiteRegistration Register_BATCH_MATMUL() {
+  return {/*init=*/Init,
+          /*free=*/nullptr,
+          /*prepare=*/Prepare,
+          /*invoke=*/Eval,
+          /*profiling_string=*/nullptr,
+          /*builtin_code=*/0,
+          /*custom_name=*/nullptr,
+          /*version=*/0};
 }
 
-TfLiteRegistration* Register_BATCH_MATMUL_GENERIC_OPTIMIZED() {
-  static TfLiteRegistration r = {
-      batch_matmul::Init, batch_matmul::Free, batch_matmul::Prepare,
-      batch_matmul::Eval<batch_matmul::kGenericOptimized>};
-  return &r;
-}
-
-TfLiteRegistration* Register_BATCH_MATMUL() {
-  return Register_BATCH_MATMUL_GENERIC_OPTIMIZED();
-}
-
-}  // namespace builtin
-}  // namespace ops
 }  // namespace tflite

--- a/tensorflow/lite/micro/kernels/batch_matmul_test.cc
+++ b/tensorflow/lite/micro/kernels/batch_matmul_test.cc
@@ -1,0 +1,739 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include <stddef.h>
+#include <stdint.h>
+
+#include <initializer_list>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include "flatbuffers/flatbuffers.h"  // from @flatbuffers
+#include "tensorflow/lite/kernels/test_util.h"
+#include "tensorflow/lite/schema/schema_generated.h"
+
+namespace tflite {
+
+namespace ops {
+namespace builtin {
+
+TfLiteRegistration* Register_BATCH_MATMUL_REF();
+TfLiteRegistration* Register_BATCH_MATMUL_GENERIC_OPTIMIZED();
+
+}  // namespace builtin
+}  // namespace ops
+
+namespace {
+
+using ::testing::ElementsAre;
+using ::testing::ElementsAreArray;
+
+template <typename T>
+class BatchMatMulOpModel : public SingleOpModel {
+ public:
+  BatchMatMulOpModel(const TensorData& lhs, const TensorData& rhs,
+                     bool adj_x = false, bool adj_y = false) {
+    lhs_id_ = AddInput(lhs);
+    rhs_id_ = AddInput(rhs);
+    output_id_ = AddOutput(lhs.type);
+    SetBuiltinOp(BuiltinOperator_BATCH_MATMUL,
+                 BuiltinOptions_BatchMatMulOptions,
+                 CreateBatchMatMulOptions(builder_, adj_x, adj_y).Union());
+    BuildInterpreter({GetShape(lhs_id_), GetShape(rhs_id_)});
+  }
+
+  int lhs() const { return lhs_id_; }
+  int rhs() const { return rhs_id_; }
+  std::vector<T> GetOutput() { return ExtractVector<T>(output_id_); }
+  std::vector<int32_t> GetOutputShape() { return GetTensorShape(output_id_); }
+
+ protected:
+  int lhs_id_;
+  int rhs_id_;
+  int output_id_;
+};
+
+const auto kKernelMap = new std::map<string, TfLiteRegistration*>({
+    {"Reference", ops::builtin::Register_BATCH_MATMUL_REF()},
+    {"GenericOptimized",
+     ops::builtin::Register_BATCH_MATMUL_GENERIC_OPTIMIZED()},
+});
+
+class BatchMatMulOpTest : public SingleOpTest {
+ protected:
+  const std::map<string, TfLiteRegistration*>& GetKernelMap() override {
+    return *kKernelMap;
+  }
+};
+
+TEST_P(BatchMatMulOpTest, Float32Test_Simple) {
+  BatchMatMulOpModel<float> model({TensorType_FLOAT32, {1, 2, 3}},
+                                  {TensorType_FLOAT32, {1, 3, 4}});
+  model.PopulateTensor<float>(model.lhs(), {1, 2, 3, 4, 5, 6});
+  model.PopulateTensor<float>(model.rhs(),
+                              {7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18});
+  model.Invoke();
+  EXPECT_THAT(model.GetOutput(),
+              ElementsAreArray({74., 80., 86., 92., 173., 188., 203., 218.}));
+  EXPECT_THAT(model.GetOutputShape(), ElementsAreArray({1, 2, 4}));
+}
+
+TEST_P(BatchMatMulOpTest, Float32Test_SimpleRHSAdjoint) {
+  BatchMatMulOpModel<float> model({TensorType_FLOAT32, {1, 2, 3}},
+                                  {TensorType_FLOAT32, {1, 4, 3}}, false, true);
+  model.PopulateTensor<float>(model.lhs(), {1, 2, 3, 4, 5, 6});
+  model.PopulateTensor<float>(model.rhs(),
+                              {7, 11, 15, 8, 12, 16, 9, 13, 17, 10, 14, 18});
+  model.Invoke();
+  EXPECT_THAT(model.GetOutput(),
+              ElementsAreArray({74., 80., 86., 92., 173., 188., 203., 218.}));
+  EXPECT_THAT(model.GetOutputShape(), ElementsAreArray({1, 2, 4}));
+}
+
+TEST_P(BatchMatMulOpTest, Float32Test_SimpleLHSAdjoint) {
+  BatchMatMulOpModel<float> model({TensorType_FLOAT32, {1, 3, 2}},
+                                  {TensorType_FLOAT32, {1, 3, 4}}, true, false);
+  model.PopulateTensor<float>(model.lhs(), {1, 4, 2, 5, 3, 6});
+  model.PopulateTensor<float>(model.rhs(),
+                              {7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18});
+  model.Invoke();
+  EXPECT_THAT(model.GetOutput(),
+              ElementsAreArray({74., 80., 86., 92., 173., 188., 203., 218.}));
+  EXPECT_THAT(model.GetOutputShape(), ElementsAreArray({1, 2, 4}));
+}
+
+TEST_P(BatchMatMulOpTest, Float32Test_BatchSizeTwo) {
+  BatchMatMulOpModel<float> model({TensorType_FLOAT32, {2, 2, 3}},
+                                  {TensorType_FLOAT32, {2, 3, 4}});
+  model.PopulateTensor<float>(model.lhs(),
+                              {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
+  model.PopulateTensor<float>(model.rhs(),
+                              {7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18,
+                               19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30});
+  model.Invoke();
+  EXPECT_THAT(
+      model.GetOutput(),
+      ElementsAreArray({74., 80., 86., 92., 173., 188., 203., 218., 560., 584.,
+                        608., 632., 767., 800., 833., 866.}));
+  EXPECT_THAT(model.GetOutputShape(), ElementsAreArray({2, 2, 4}));
+}
+
+TEST_P(BatchMatMulOpTest, Float32Test_Broadcast) {
+  BatchMatMulOpModel<float> model({TensorType_FLOAT32, {2, 2, 3}},
+                                  {TensorType_FLOAT32, {3, 4}});
+  model.PopulateTensor<float>(model.lhs(),
+                              {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
+  model.PopulateTensor<float>(model.rhs(),
+                              {7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18});
+
+  model.Invoke();
+  EXPECT_THAT(
+      model.GetOutput(),
+      ElementsAreArray({74., 80., 86., 92., 173., 188., 203., 218., 272., 296.,
+                        320., 344., 371., 404., 437., 470.}));
+  EXPECT_THAT(model.GetOutputShape(), ElementsAreArray({2, 2, 4}));
+}
+
+TEST_P(BatchMatMulOpTest, Float32Test_BroadcastLHSAdjoint) {
+  BatchMatMulOpModel<float> model({TensorType_FLOAT32, {2, 3, 2}},
+                                  {TensorType_FLOAT32, {3, 4}}, true, false);
+  model.PopulateTensor<float>(model.lhs(),
+                              {1, 4, 2, 5, 3, 6, 7, 10, 8, 11, 9, 12});
+  model.PopulateTensor<float>(model.rhs(),
+                              {7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18});
+
+  model.Invoke();
+  EXPECT_THAT(
+      model.GetOutput(),
+      ElementsAreArray({74., 80., 86., 92., 173., 188., 203., 218., 272., 296.,
+                        320., 344., 371., 404., 437., 470.}));
+  EXPECT_THAT(model.GetOutputShape(), ElementsAreArray({2, 2, 4}));
+}
+
+TEST_P(BatchMatMulOpTest, Float32Test_Broadcast2) {
+  BatchMatMulOpModel<float> model({TensorType_FLOAT32, {2, 1, 3, 2}},
+                                  {TensorType_FLOAT32, {3, 2, 4}});
+  model.PopulateTensor<float>(model.lhs(),
+                              {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
+  model.PopulateTensor<float>(model.rhs(),
+                              {7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18,
+                               19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30});
+
+  model.Invoke();
+  EXPECT_THAT(
+      model.GetOutput(),
+      ElementsAreArray({29.,  32.,  35.,  38.,  65.,  72.,  79.,  86.,  101.,
+                        112., 123., 134., 53.,  56.,  59.,  62.,  121., 128.,
+                        135., 142., 189., 200., 211., 222., 77.,  80.,  83.,
+                        86.,  177., 184., 191., 198., 277., 288., 299., 310.,
+                        137., 152., 167., 182., 173., 192., 211., 230., 209.,
+                        232., 255., 278., 257., 272., 287., 302., 325., 344.,
+                        363., 382., 393., 416., 439., 462., 377., 392., 407.,
+                        422., 477., 496., 515., 534., 577., 600., 623., 646.}));
+
+  EXPECT_THAT(model.GetOutputShape(), ElementsAreArray({2, 3, 3, 4}));
+}
+
+TEST_P(BatchMatMulOpTest, Float32Test_Broadcast2LHSAdjoint) {
+  BatchMatMulOpModel<float> model({TensorType_FLOAT32, {2, 1, 2, 3}},
+                                  {TensorType_FLOAT32, {3, 2, 4}}, true, false);
+  model.PopulateTensor<float>(model.lhs(),
+                              {1, 3, 5, 2, 4, 6, 7, 9, 11, 8, 10, 12});
+  model.PopulateTensor<float>(model.rhs(),
+                              {7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18,
+                               19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30});
+
+  model.Invoke();
+  EXPECT_THAT(
+      model.GetOutput(),
+      ElementsAreArray({29.,  32.,  35.,  38.,  65.,  72.,  79.,  86.,  101.,
+                        112., 123., 134., 53.,  56.,  59.,  62.,  121., 128.,
+                        135., 142., 189., 200., 211., 222., 77.,  80.,  83.,
+                        86.,  177., 184., 191., 198., 277., 288., 299., 310.,
+                        137., 152., 167., 182., 173., 192., 211., 230., 209.,
+                        232., 255., 278., 257., 272., 287., 302., 325., 344.,
+                        363., 382., 393., 416., 439., 462., 377., 392., 407.,
+                        422., 477., 496., 515., 534., 577., 600., 623., 646.}));
+
+  EXPECT_THAT(model.GetOutputShape(), ElementsAreArray({2, 3, 3, 4}));
+}
+
+TEST_P(BatchMatMulOpTest, Float32Test_Broadcast2RHSAdjoint) {
+  BatchMatMulOpModel<float> model({TensorType_FLOAT32, {2, 1, 3, 2}},
+                                  {TensorType_FLOAT32, {3, 4, 2}}, false, true);
+  model.PopulateTensor<float>(model.lhs(),
+                              {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
+  model.PopulateTensor<float>(model.rhs(),
+                              {7,  11, 8,  12, 9,  13, 10, 14, 15, 19, 16, 20,
+                               17, 21, 18, 22, 23, 27, 24, 28, 25, 29, 26, 30});
+  model.Invoke();
+  EXPECT_THAT(
+      model.GetOutput(),
+      ElementsAreArray({29.,  32.,  35.,  38.,  65.,  72.,  79.,  86.,  101.,
+                        112., 123., 134., 53.,  56.,  59.,  62.,  121., 128.,
+                        135., 142., 189., 200., 211., 222., 77.,  80.,  83.,
+                        86.,  177., 184., 191., 198., 277., 288., 299., 310.,
+                        137., 152., 167., 182., 173., 192., 211., 230., 209.,
+                        232., 255., 278., 257., 272., 287., 302., 325., 344.,
+                        363., 382., 393., 416., 439., 462., 377., 392., 407.,
+                        422., 477., 496., 515., 534., 577., 600., 623., 646.}));
+
+  EXPECT_THAT(model.GetOutputShape(), ElementsAreArray({2, 3, 3, 4}));
+}
+
+TEST_P(BatchMatMulOpTest, Float32Test_Broadcast2BothAdjoint) {
+  BatchMatMulOpModel<float> model({TensorType_FLOAT32, {2, 1, 2, 3}},
+                                  {TensorType_FLOAT32, {3, 4, 2}}, true, true);
+  model.PopulateTensor<float>(model.lhs(),
+                              {1, 3, 5, 2, 4, 6, 7, 9, 11, 8, 10, 12});
+  model.PopulateTensor<float>(model.rhs(),
+                              {7,  11, 8,  12, 9,  13, 10, 14, 15, 19, 16, 20,
+                               17, 21, 18, 22, 23, 27, 24, 28, 25, 29, 26, 30});
+  model.Invoke();
+  EXPECT_THAT(
+      model.GetOutput(),
+      ElementsAreArray({29.,  32.,  35.,  38.,  65.,  72.,  79.,  86.,  101.,
+                        112., 123., 134., 53.,  56.,  59.,  62.,  121., 128.,
+                        135., 142., 189., 200., 211., 222., 77.,  80.,  83.,
+                        86.,  177., 184., 191., 198., 277., 288., 299., 310.,
+                        137., 152., 167., 182., 173., 192., 211., 230., 209.,
+                        232., 255., 278., 257., 272., 287., 302., 325., 344.,
+                        363., 382., 393., 416., 439., 462., 377., 392., 407.,
+                        422., 477., 496., 515., 534., 577., 600., 623., 646.}));
+
+  EXPECT_THAT(model.GetOutputShape(), ElementsAreArray({2, 3, 3, 4}));
+}
+
+TEST_P(BatchMatMulOpTest, Float32Test_BroadcastFromRHS) {
+  BatchMatMulOpModel<float> model({TensorType_FLOAT32, {4, 5}},
+                                  {TensorType_FLOAT32, {3, 1, 5, 2}});
+  model.PopulateTensor<float>(
+      model.lhs(),
+      {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20});
+  model.PopulateTensor<float>(
+      model.rhs(),
+      {7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+       22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36});
+
+  model.Invoke();
+  EXPECT_THAT(
+      model.GetOutput(),
+      ElementsAreArray({185., 200., 460.,  500.,  735.,  800.,  1010., 1100.,
+                        335., 350., 860.,  900.,  1385., 1450., 1910., 2000.,
+                        485., 500., 1260., 1300., 2035., 2100., 2810., 2900.}));
+  EXPECT_THAT(model.GetOutputShape(), ElementsAreArray({3, 1, 4, 2}));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BatchMatMulOpTest, BatchMatMulOpTest,
+    ::testing::ValuesIn(SingleOpTest::GetKernelTags(*kKernelMap)));
+
+// In the hybrid model the weights are quantized int8. But the input
+// and output are expected to be in float precision.
+class HybridBatchMatMulOpModel : public SingleOpModel {
+ public:
+  HybridBatchMatMulOpModel(int units, int batches, const TensorData& lhs,
+                           const TensorData& rhs,
+                           const TensorData& output = {TensorType_FLOAT32},
+                           bool asymmetric_quantize_inputs = true)
+      : units_(units), batches_(batches) {
+    int total_input_size = 1;
+    for (size_t i = 0; i < lhs.shape.size(); ++i) {
+      total_input_size *= lhs.shape[i];
+    }
+    input_size_ = total_input_size / batches_;
+
+    lhs_id_ = AddInput(lhs);
+    rhs_id_ = AddInput(rhs);
+
+    output_id_ = AddOutput(output);
+
+    SetBuiltinOp(
+        BuiltinOperator_BATCH_MATMUL, BuiltinOptions_BatchMatMulOptions,
+        CreateBatchMatMulOptions(builder_, /*adj_x=*/false, /*adj_y=*/false,
+                                 asymmetric_quantize_inputs)
+            .Union());
+    BuildInterpreter({GetShape(lhs_id_), GetShape(rhs_id_)});
+  }
+  void SetWeights(const std::vector<float>& data) {
+    SymmetricQuantizeAndPopulate(rhs_id_, data);
+  }
+
+  void SetSignedWeights(std::initializer_list<float> f) {
+    SignedSymmetricQuantizeAndPopulate(rhs_id_, f);
+  }
+
+  void SetInput(const std::vector<float>& f) { PopulateTensor(lhs_id_, f); }
+  std::vector<float> GetOutput() { return ExtractVector<float>(output_id_); }
+  std::vector<int> GetOutputShape() { return GetTensorShape(output_id_); }
+
+  int input_size() { return input_size_; }
+  int num_units() { return units_; }
+  int num_batches() { return batches_; }
+
+  int lhs() const { return lhs_id_; }
+  int rhs() const { return rhs_id_; }
+
+ protected:
+  int lhs_id_;
+  int rhs_id_;
+  int output_id_;
+  int units_;
+  int batches_;
+  int input_size_;
+};
+
+class HybridAsymmetricBatchMatMulOpTest : public SingleOpTest {
+ protected:
+  const std::map<string, TfLiteRegistration*>& GetKernelMap() override {
+    return *kKernelMap;
+  }
+};
+
+TEST_P(HybridAsymmetricBatchMatMulOpTest, SimpleTestQuantizedInt8) {
+  HybridBatchMatMulOpModel m(
+      /*units=*/3, /*batches=*/2,
+      /*lhs=*/{TensorType_FLOAT32, {2, 10}},
+      /*rhs=*/{TensorType_INT8, {10, 3}, 0, 0, 10.0 / 127.0, 0});
+
+  m.SetSignedWeights({
+      1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5,  5,  5,
+      6, 6, 6, 7, 7, 7, 8, 8, 8, 9, 9, 9, 10, 10, 10,
+  });
+
+  m.SetInput({
+      11, 12, 13, 14, 15, 16, 17, 18,  -19, -20,  // batch 1, 0
+      11, 12, 13, 14, 15, 16, 17, -18, 19,  -20,  // batch 1, 1
+  });
+
+  m.Invoke();
+
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray(ArrayFloatNear(
+                                 {
+                                     196,
+                                     196,
+                                     196,
+                                     246,
+                                     246,
+                                     246,
+                                 },
+                                 /*max_abs_error=*/0.64f)));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 3}));
+}
+
+TEST_P(HybridAsymmetricBatchMatMulOpTest, QuantizedInt8BroadcastWeights) {
+  HybridBatchMatMulOpModel m(
+      /*units=*/3, /*batches=*/2,
+      /*lhs=*/{TensorType_FLOAT32, {2, 2, 10}},
+      /*rhs=*/{TensorType_INT8, {10, 3}, 0, 0, 10.0 / 127.0, 0});
+
+  m.SetSignedWeights({
+      1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5,  5,  5,
+      6, 6, 6, 7, 7, 7, 8, 8, 8, 9, 9, 9, 10, 10, 10,
+  });
+
+  m.SetInput({
+      1,  2,  3,  4,  5,  6,  7,  8,   -9,  -10,  // batch 0, 0
+      1,  2,  3,  4,  5,  6,  7,  -8,  9,   -10,  // batch 0, 1
+      11, 12, 13, 14, 15, 16, 17, 18,  -19, -20,  // batch 1, 0
+      11, 12, 13, 14, 15, 16, 17, -18, 19,  -20,  // batch 1, 1
+  });
+
+  m.Invoke();
+
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray(ArrayFloatNear(
+                                 {
+                                     24, 24, 24,     //
+                                     58, 58, 58,     //
+                                     196, 196, 196,  //
+                                     246, 246, 246,  //
+                                 },
+                                 /*max_abs_error=*/1.3f)));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 2, 3}));
+}
+
+TEST_P(HybridAsymmetricBatchMatMulOpTest, QuantizedInt8BroadcastBigWeights) {
+  HybridBatchMatMulOpModel m(
+      /*units=*/9, /*batches=*/2,
+      /*lhs=*/{TensorType_FLOAT32, {2, 2, 10}},
+      /*rhs=*/{TensorType_INT8, {10, 9}, 0, 0, 10.0 / 127.0, 0});
+
+  m.SetSignedWeights({
+      1, 1, 1, 17, 17, 17, 26, 26, 26, 2,  2,  2,  18, 18, 18, 27, 27, 27,
+      3, 3, 3, 19, 19, 19, 28, 28, 28, 4,  4,  4,  20, 20, 20, 29, 29, 29,
+      5, 5, 5, 21, 21, 21, 30, 30, 30, 6,  6,  6,  22, 22, 22, 31, 31, 31,
+      7, 7, 7, 23, 23, 23, 32, 32, 32, 8,  8,  8,  24, 24, 24, 33, 33, 33,
+      9, 9, 9, 25, 25, 25, 34, 34, 34, 10, 10, 10, 26, 26, 26, 35, 35, 35,
+  });
+
+  m.SetInput({
+      1,  2,  3,  4,  5,  6,  7,  8,   -9,  -10,  // batch 0, 0
+      1,  2,  3,  4,  5,  6,  7,  -8,  9,   -10,  // batch 0, 1
+      11, 12, 13, 14, 15, 16, 17, 18,  -19, -20,  // batch 1, 0
+      11, 12, 13, 14, 15, 16, 17, -18, 19,  -20,  // batch 1, 1
+  });
+
+  m.Invoke();
+
+  EXPECT_THAT(m.GetOutput(),
+              ElementsAreArray(ArrayFloatNear(
+                  {
+                      23,  23,  23,  295,  295,  295,  449,  449,  449,   //
+                      60,  60,  60,  364,  364,  364,  533,  533,  533,   //
+                      195, 195, 195, 1429, 1429, 1429, 2124, 2124, 2124,  //
+                      250, 250, 250, 1512, 1512, 1512, 2213, 2213, 2213   //
+                  },
+                  /*max_abs_error=*/1.3f)));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 2, 9}));
+}
+
+TEST_P(HybridAsymmetricBatchMatMulOpTest, QuantizedInt8BroadcastInputs) {
+  HybridBatchMatMulOpModel m(
+      /*units=*/3, /*batches=*/2,
+      /*lhs=*/{TensorType_FLOAT32, {2, 10}},
+      /*rhs=*/{TensorType_INT8, {2, 10, 3}, 0, 0, 10.0 / 127.0, 0});
+
+  m.SetSignedWeights({
+      1, -3, 1, 2, -2, 2, 3, -1, 3, 4,  0, 4, 5, 1, 5, 6, 2, 6,  7,  3,
+      7, 8,  4, 8, 9,  5, 9, 10, 6, 10, 1, 1, 1, 2, 2, 2, 3, 3,  3,  4,
+      4, 4,  5, 5, 5,  6, 6, 6,  7, 7,  7, 8, 8, 8, 9, 9, 9, 10, 10, 10,
+  });
+
+  m.SetInput({
+      1, 2, 3, 4, 5, 6, 7, 8,  -9, -10,  // batch 0, 0
+      1, 2, 3, 4, 5, 6, 7, -8, 9,  -10,  // batch 0, 1
+  });
+
+  m.Invoke();
+
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray(ArrayFloatNear(
+                                 {
+                                     24, -45, 24,  //
+                                     58, -18, 58,  //
+                                     24, 24, 24,   //
+                                     58, 58, 58,   //
+                                 },
+                                 /*max_abs_error=*/0.64f)));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 2, 3}));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    HybridAsymmetricBatchMatMulOpTest, HybridAsymmetricBatchMatMulOpTest,
+    ::testing::ValuesIn(SingleOpTest::GetKernelTags(*kKernelMap)));
+
+class HybridSymmetricBatchMatMulOpTest : public SingleOpTest {
+ protected:
+  const std::map<string, TfLiteRegistration*>& GetKernelMap() override {
+    return *kKernelMap;
+  }
+};
+
+TEST_P(HybridSymmetricBatchMatMulOpTest, SimpleTestQuantizedInt8) {
+  HybridBatchMatMulOpModel m(
+      /*units=*/3, /*batches=*/2,
+      /*lhs=*/{TensorType_FLOAT32, {2, 10}},
+      /*rhs=*/{TensorType_INT8, {10, 3}, 0, 0, 10.0 / 127.0, 0},
+      /*output=*/{TensorType_FLOAT32}, /*asymmetric_quantize_inputs=*/false);
+
+  m.SetSignedWeights({
+      1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5,  5,  5,
+      6, 6, 6, 7, 7, 7, 8, 8, 8, 9, 9, 9, 10, 10, 10,
+  });
+
+  m.SetInput({
+      11, 12, 13, 14, 15, 16, 17, 18,  -19, -20,  // batch 1, 0
+      11, 12, 13, 14, 15, 16, 17, -18, 19,  -20,  // batch 1, 1
+  });
+
+  m.Invoke();
+
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray(ArrayFloatNear(
+                                 {
+                                     194,
+                                     194,
+                                     194,
+                                     248,
+                                     248,
+                                     248,
+                                 },
+                                 /*max_abs_error=*/0.64f)));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 3}));
+}
+
+TEST_P(HybridSymmetricBatchMatMulOpTest, QuantizedInt8BroadcastWeights) {
+  HybridBatchMatMulOpModel m(
+      /*units=*/3, /*batches=*/2,
+      /*lhs=*/{TensorType_FLOAT32, {2, 2, 10}},
+      /*rhs=*/{TensorType_INT8, {10, 3}, 0, 0, 10.0 / 127.0, 0},
+      /*output=*/{TensorType_FLOAT32}, /*asymmetric_quantize_inputs=*/false);
+
+  m.SetSignedWeights({
+      1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5,  5,  5,
+      6, 6, 6, 7, 7, 7, 8, 8, 8, 9, 9, 9, 10, 10, 10,
+  });
+
+  m.SetInput({
+      1,  2,  3,  4,  5,  6,  7,  8,   -9,  -10,  // batch 0, 0
+      1,  2,  3,  4,  5,  6,  7,  -8,  9,   -10,  // batch 0, 1
+      11, 12, 13, 14, 15, 16, 17, 18,  -19, -20,  // batch 1, 0
+      11, 12, 13, 14, 15, 16, 17, -18, 19,  -20,  // batch 1, 1
+  });
+
+  m.Invoke();
+
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray(ArrayFloatNear(
+                                 {
+                                     24, 24, 24,     //
+                                     56, 56, 56,     //
+                                     194, 194, 194,  //
+                                     248, 248, 248,  //
+                                 },
+                                 /*max_abs_error=*/1.3f)));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 2, 3}));
+}
+
+TEST_P(HybridSymmetricBatchMatMulOpTest, QuantizedInt8BroadcastBigWeights) {
+  HybridBatchMatMulOpModel m(
+      /*units=*/9, /*batches=*/2,
+      /*lhs=*/{TensorType_FLOAT32, {2, 2, 10}},
+      /*rhs=*/{TensorType_INT8, {10, 9}, 0, 0, 10.0 / 127.0, 0},
+      {TensorType_FLOAT32}, false);
+
+  m.SetSignedWeights({
+      1, 1, 1, 17, 17, 17, 26, 26, 26, 2,  2,  2,  18, 18, 18, 27, 27, 27,
+      3, 3, 3, 19, 19, 19, 28, 28, 28, 4,  4,  4,  20, 20, 20, 29, 29, 29,
+      5, 5, 5, 21, 21, 21, 30, 30, 30, 6,  6,  6,  22, 22, 22, 31, 31, 31,
+      7, 7, 7, 23, 23, 23, 32, 32, 32, 8,  8,  8,  24, 24, 24, 33, 33, 33,
+      9, 9, 9, 25, 25, 25, 34, 34, 34, 10, 10, 10, 26, 26, 26, 35, 35, 35,
+  });
+
+  m.SetInput({
+      1,  2,  3,  4,  5,  6,  7,  8,   -9,  -10,  // batch 0, 0
+      1,  2,  3,  4,  5,  6,  7,  -8,  9,   -10,  // batch 0, 1
+      11, 12, 13, 14, 15, 16, 17, 18,  -19, -20,  // batch 1, 0
+      11, 12, 13, 14, 15, 16, 17, -18, 19,  -20,  // batch 1, 1
+  });
+
+  m.Invoke();
+
+  EXPECT_THAT(m.GetOutput(),
+              ElementsAreArray(ArrayFloatNear(
+                  {
+                      23,  23,  23,  296,  296,  296,  451,  451,  451,   //
+                      58,  58,  58,  362,  362,  362,  529,  529,  529,   //
+                      193, 193, 193, 1424, 1424, 1424, 2118, 2118, 2118,  //
+                      253, 253, 253, 1519, 1519, 1519, 2223, 2223, 2223   //
+                  },
+                  /*max_abs_error=*/1.3f)));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 2, 9}));
+}
+
+TEST_P(HybridSymmetricBatchMatMulOpTest, QuantizedInt8BroadcastInputs) {
+  HybridBatchMatMulOpModel m(
+      /*units=*/3, /*batches=*/2,
+      /*lhs=*/{TensorType_FLOAT32, {2, 10}},
+      /*rhs=*/{TensorType_INT8, {2, 10, 3}, 0, 0, 10.0 / 127.0, 0},
+      {TensorType_FLOAT32}, false);
+
+  m.SetSignedWeights({
+      1, -3, 1, 2, -2, 2, 3, -1, 3, 4,  0, 4, 5, 1, 5, 6, 2, 6,  7,  3,
+      7, 8,  4, 8, 9,  5, 9, 10, 6, 10, 1, 1, 1, 2, 2, 2, 3, 3,  3,  4,
+      4, 4,  5, 5, 5,  6, 6, 6,  7, 7,  7, 8, 8, 8, 9, 9, 9, 10, 10, 10,
+  });
+
+  m.SetInput({
+      1, 2, 3, 4, 5, 6, 7, 8,  -9, -10,  // batch 0, 0
+      1, 2, 3, 4, 5, 6, 7, -8, 9,  -10,  // batch 0, 1
+  });
+
+  m.Invoke();
+
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray(ArrayFloatNear(
+                                 {
+                                     24, -45, 24,  //
+                                     56, -19, 56,  //
+                                     24, 24, 24,   //
+                                     56, 56, 56,   //
+                                 },
+                                 /*max_abs_error=*/0.64f)));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 2, 3}));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    HybridSymmetricBatchMatMulOpTest, HybridSymmetricBatchMatMulOpTest,
+    ::testing::ValuesIn(SingleOpTest::GetKernelTags(*kKernelMap)));
+
+class QuantizedBatchMatMulOpModel : public SingleOpModel {
+ public:
+  QuantizedBatchMatMulOpModel(int units, int batches, const TensorData& lhs,
+                              const TensorData& output = {TensorType_INT8},
+                              bool adj_x = false, bool adj_y = false)
+      : units_(units), batches_(batches) {
+    int total_input_size = 1;
+    for (size_t i = 0; i < lhs.shape.size(); ++i) {
+      total_input_size *= lhs.shape[i];
+    }
+    input_size_ = total_input_size / batches_;
+
+    lhs_id_ = AddInput(lhs);
+    rhs_id_ = AddInput({lhs.type,
+                        {input_size_, units_},
+                        0,
+                        0,
+                        GetScale(lhs_id_),
+                        GetZeroPoint(lhs_id_)});
+
+    output_id_ = AddOutput(output);
+
+    SetBuiltinOp(BuiltinOperator_BATCH_MATMUL,
+                 BuiltinOptions_BatchMatMulOptions,
+                 CreateBatchMatMulOptions(builder_, adj_x, adj_y).Union());
+    BuildInterpreter({GetShape(lhs_id_), GetShape(rhs_id_)});
+  }
+
+  template <typename T>
+  void SetWeights(const std::vector<float>& data) {
+    QuantizeAndPopulate<T>(rhs_id_, data);
+  }
+
+  template <typename T>
+  void SetInput(const std::vector<float>& data) {
+    QuantizeAndPopulate<T>(lhs_id_, data);
+  }
+
+  template <typename T>
+  std::vector<T> GetOutput() {
+    return ExtractVector<T>(output_id_);
+  }
+
+  template <typename T>
+  std::vector<float> GetDequantizedOutput() {
+    return Dequantize<T>(ExtractVector<T>(output_id_), GetScale(output_id_),
+                         GetZeroPoint(output_id_));
+  }
+
+ protected:
+  int lhs_id_;
+  int rhs_id_;
+  int output_id_;
+  int units_;
+  int batches_;
+  int input_size_;
+};
+
+class QuantizedBatchMatMulOpTest : public SingleOpTest {
+ protected:
+  const std::map<string, TfLiteRegistration*>& GetKernelMap() override {
+    return *kKernelMap;
+  }
+};
+
+TEST_P(QuantizedBatchMatMulOpTest, SimpleTestQuantizedInt8) {
+  QuantizedBatchMatMulOpModel m(
+      /*units=*/3, /*batches*/ 2,
+      /*lhs=*/{TensorType_INT8, {2, 10}, -63.5, 64},
+      /*output=*/{TensorType_INT8, {}, -127, 128});
+
+  m.SetWeights<int8_t>({
+      1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5,  5,  5,
+      6, 6, 6, 7, 7, 7, 8, 8, 8, 9, 9, 9, 10, 10, 10,
+  });
+
+  m.SetInput<int8_t>({
+      1, 2, 3, 4, 5, 6, 7, 8,  -9, -10,  // b = 0
+      1, 2, 3, 4, 5, 6, 7, -8, 9,  -10,  // b = 1
+  });
+
+  m.Invoke();
+
+  EXPECT_THAT(m.GetDequantizedOutput<int8_t>(),
+              ElementsAreArray(ArrayFloatNear({23, 23, 23, 57, 57, 57})));
+  EXPECT_THAT(m.GetOutput<int8_t>(), ElementsAre(22, 22, 22, 56, 56, 56));
+}
+
+TEST_P(QuantizedBatchMatMulOpTest, SimpleTestQuantizedInt16) {
+  const float inputs_scale = 10.0 / std::numeric_limits<int16_t>::max();
+  const float output_scale = 1.0;
+  const int32_t zero_point = 0;
+
+  QuantizedBatchMatMulOpModel m(
+      /*units=*/3, /*batches*/ 2,
+      /*lhs=*/
+      {TensorType_INT16, {2, 10}, 0, 0, inputs_scale, zero_point},
+      /*output=*/
+      {TensorType_INT16, {}, 0, 0, output_scale, zero_point});
+
+  m.SetWeights<int16_t>({
+      1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5,  5,  5,
+      6, 6, 6, 7, 7, 7, 8, 8, 8, 9, 9, 9, 10, 10, 10,
+  });
+
+  m.SetInput<int16_t>({
+      1, 2, 3, 4, 5, 6, 7, 8,  -9, -10,  // b = 0
+      1, 2, 3, 4, 5, 6, 7, -8, 9,  -10,  // b = 1
+  });
+
+  m.Invoke();
+
+  EXPECT_THAT(m.GetDequantizedOutput<int16_t>(),
+              ElementsAreArray(ArrayFloatNear({23, 23, 23, 57, 57, 57})));
+  EXPECT_THAT(m.GetOutput<int16_t>(), ElementsAre(23, 23, 23, 57, 57, 57));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    QuantizedBatchMatMulOpTest, QuantizedBatchMatMulOpTest,
+    ::testing::ValuesIn(SingleOpTest::GetKernelTags(*kKernelMap)));
+
+}  // namespace
+}  // namespace tflite

--- a/tensorflow/lite/micro/kernels/batch_matmul_test.cc
+++ b/tensorflow/lite/micro/kernels/batch_matmul_test.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/kernels/internal/tensor_utils_common.h"
+#include "tensorflow/lite/micro/kernels/batch_matmul_test_util.h"
 #include "tensorflow/lite/micro/kernels/kernel_runner.h"
 #include "tensorflow/lite/micro/test_helpers.h"
 #include "tensorflow/lite/micro/testing/micro_test.h"
@@ -28,313 +29,14 @@ namespace tflite {
 namespace testing {
 namespace {
 
-constexpr int kMaxDims = RuntimeShape::kMaxSmallSize;
-constexpr int kInputTensor1 = 0;
-constexpr int kInputTensor2 = 1;
-constexpr int kOutputTensor = 2;
-constexpr float kTolerance = 1e-5;
-
-enum TestInputIndex {
-  kInputIndex0,
-  kInputIndex1,
-};
-constexpr size_t kMaxInputs = TestInputIndex::kInputIndex1 + 1;
-
-struct TestTensorData {
-  TestTensorData(const TfLiteType datum_type,
-                 const std::initializer_list<int>& datum_list = {},
-                 float datum_min = 0.0f, float datum_max = 0.0f,
-                 float datum_scale = 0.0f, int32_t datum_zero_point = 0)
-      : type(datum_type),
-        shape(datum_list),
-        min(datum_min),
-        max(datum_max),
-        scale(datum_scale),
-        zero_point(datum_zero_point) {}
-  const TfLiteType type;
-  const std::initializer_list<int>& shape;
-  const float min;
-  const float max;
-  const float scale;
-  const int32_t zero_point;
-};
-
-template <typename T, size_t D>
-struct ElementArray {
-  ElementArray() : scale(0.0f), zero_point(0) {}
-
-  template <typename TA>
-  explicit ElementArray(const TA (&a)[D]) : ElementArray() {
-    for (size_t i = 0; i < D; i++) {
-      data[i] = static_cast<T>(a[i]);
-    }
-  }
-
-  T data[D];
-  TestInputIndex index;
-
-  // quantization parameters
-  float scale;
-  int32_t zero_point;
-};
-
-template <typename T, size_t D>
-struct ElementArrayNear : ElementArray<T, D> {
-  template <typename TA>
-  explicit ElementArrayNear(const TA (&a)[D],
-                            const float tolerance_param = kTolerance)
-      : ElementArray<T, D>(a), tolerance(tolerance_param) {}
-
-  const float tolerance;
-};
-
-template <size_t D>
-inline ElementArrayNear<float, D> ElementsAreArray(const double (&a)[D]) {
-  return ElementArrayNear<float, D>(a);
-}
-
-template <size_t D>
-inline ElementArray<int, D> ElementsAreArray(const int (&a)[D]) {
-  return ElementArray<int, D>(a);
-}
-
-template <typename T, size_t D>
-inline const ElementArrayNear<T, D>& ElementsAreArray(
-    const ElementArrayNear<T, D>& a) {
-  return a;
-}
-
-template <typename T, size_t D>
-inline ElementArrayNear<float, D> ArrayFloatNear(
-    const T (&a)[D], const float tolerance = kTolerance) {
-  return ElementArrayNear<float, D>(a, tolerance);
-}
-
-template <size_t D>
-void ExpectThat(const TfLiteIntArray& actual,
-                const ElementArray<int, D>& expected) {
-  TF_LITE_MICRO_EXPECT_EQ(actual.size, static_cast<int>(D));
-  for (int i = 0; i < actual.size; i++) {
-    TF_LITE_MICRO_EXPECT_EQ(actual.data[i], expected.data[i]);
-  }
-}
-
-template <typename T, size_t D>
-void ExpectThat(const ElementArray<T, D>& actual,
-                const ElementArrayNear<T, D>& expected) {
-  for (size_t i = 0; i < D; i++) {
-    TF_LITE_MICRO_EXPECT_NEAR(actual.data[i], expected.data[i],
-                              expected.tolerance);
-  }
-}
-
-template <typename T1, typename T2, size_t D>
-void ExpectThat(const ElementArray<T1, D>& actual,
-                const ElementArray<T2, D>& expected) {
-  for (size_t i = 0; i < D; i++) {
-    TF_LITE_MICRO_EXPECT_EQ(actual.data[i], static_cast<T1>(expected.data[i]));
-  }
-}
-
-template <typename T1, typename T2, size_t D>
-void ExpectThat(const ElementArray<T1, D>& actual,
-                const ElementArrayNear<T2, D>& expected) {
-  for (size_t i = 0; i < D; i++) {
-    TF_LITE_MICRO_EXPECT_NEAR(static_cast<T2>(actual.data[i]), expected.data[i],
-                              expected.tolerance);
-  }
-}
-
-inline void IntArrayCopy(const TfLiteIntArray& from, TfLiteIntArray* to) {
-  if (from.size > 0) {
-    for (int i = 0; i < from.size; i++) {
-      to->data[i] = from.data[i];
-    }
-    to->size = from.size;
-  }
-}
-
-inline void IntArrayCopy(const std::initializer_list<int>& from,
-                         TfLiteIntArray* to) {
-  if (from.size() > 0) {
-    for (size_t i = 0; i < from.size(); i++) {
-      to->data[i] = from.begin()[i];
-    }
-    to->size = from.size();
-  }
-}
-
-template <typename TIN1, typename TIN2, typename TOUT, size_t IN1, size_t IN2,
-          size_t OUT>
-class TestOpModel {
- public:
-  TestOpModel() {
-    TfLiteIntArray* dims = IntArrayFromInts(dims_output_);
-    dims->size = 1;
-    dims->data[0] = OUT;
-
-    dims = IntArrayFromInts(dims_inputs_[kInputIndex0]);
-    dims->size = 1;
-    dims->data[0] = IN1;
-    data_input0_.index = kInputIndex0;
-
-    dims = IntArrayFromInts(dims_inputs_[kInputIndex1]);
-    dims->size = 1;
-    dims->data[0] = IN2;
-    data_input1_.index = kInputIndex1;
-  }
-
-  void AddInput(const TestTensorData& datum, const TestInputIndex index) {
-    TF_LITE_MICRO_EXPECT_LE(datum.shape.size(), kMaxDims);
-    TfLiteIntArray& dims = GetInputShape(index);
-    IntArrayCopy(datum.shape, &dims);
-    TF_LITE_MICRO_EXPECT_EQ(ElementCount(dims),
-                            static_cast<int>(GetInputSize(index)));
-  }
-
-  template <typename T, size_t D>
-  void AddInput(const TestTensorData& datum, ElementArray<T, D>* const input) {
-    TF_LITE_MICRO_EXPECT_LE(datum.shape.size(), kMaxDims);
-    TestInputIndex index = input->index;
-    TfLiteIntArray& dims = GetInputShape(index);
-    IntArrayCopy(datum.shape, &dims);
-    TF_LITE_MICRO_EXPECT_EQ(ElementCount(dims), static_cast<int>(D));
-
-    const bool quantizable =
-        (datum.type == kTfLiteInt8) &&
-        (datum.min != 0.0f || datum.max != 0.0f || datum.scale != 0.0f);
-    if (quantizable) {
-      if (datum.scale != 0.0f) {
-        input->scale = datum.scale;
-        input->zero_point = datum.zero_point;
-      } else {
-        input->scale = ScaleFromMinMax<int8_t>(datum.min, datum.max);
-        input->zero_point = ZeroPointFromMinMax<int8_t>(datum.min, datum.max);
-      }
-    }
-  }
-
-  void AddOutput(const TestTensorData& datum) {
-    TF_LITE_MICRO_EXPECT_LE(datum.shape.size(), kMaxDims);
-    TfLiteIntArray& dims = GetOutputShape();
-    IntArrayCopy(datum.shape, &dims);
-    TF_LITE_MICRO_EXPECT_EQ(ElementCount(dims), static_cast<int>(OUT));
-
-    const bool quantizable =
-        (datum.type == kTfLiteInt8) &&
-        (datum.min != 0.0f || datum.max != 0.0f || datum.scale != 0.0f);
-    if (quantizable) {
-      if (datum.scale != 0.0f) {
-        data_output_.scale = datum.scale;
-        data_output_.zero_point = datum.zero_point;
-      } else {
-        data_output_.scale = ScaleFromMinMax<int8_t>(datum.min, datum.max);
-        data_output_.zero_point =
-            ZeroPointFromMinMax<int8_t>(datum.min, datum.max);
-      }
-    }
-  }
-
-  ElementArray<TOUT, OUT>& GetOutput() { return data_output_; }
-  TfLiteIntArray& GetOutputShape() { return *IntArrayFromInts(dims_output_); }
-  ElementArray<TIN1, IN1>& GetInput0() { return data_input0_; }
-  ElementArray<TIN2, IN2>& GetInput1() { return data_input1_; }
-  TfLiteIntArray& GetInputShape(const TestInputIndex index) {
-    return *IntArrayFromInts(dims_inputs_[index]);
-  }
-  size_t GetInputSize(const TestInputIndex index) {
-    if (index == kInputIndex0) {
-      return IN1;
-    } else {  // (index == kInputIndex1)
-      return IN2;
-    }
-  }
-
-  template <typename T, size_t D>
-  void PopulateTensor(ElementArray<T, D>* const input,
-                      const std::initializer_list<float>& list) {
-    TF_LITE_MICRO_EXPECT_EQ(list.size(), D);
-
-    auto iter = list.begin();
-    for (size_t i = 0; i < list.size(); i++) {
-      input->data[i] = static_cast<T>(iter[i]);
-    }
-  }
-
-  template <typename T, size_t D>
-  void QuantizeAndPopulate(ElementArray<T, D>* const input,
-                           const std::initializer_list<float>& list) {
-    TF_LITE_MICRO_EXPECT_EQ(list.size(), D);
-
-    Quantize(list.begin(), input->data, D, input->scale, input->zero_point);
-  }
-
-  template <typename T, size_t D>
-  void SignedSymmetricQuantizeAndPopulate(
-      ElementArray<T, D>* const input,
-      const std::initializer_list<float>& list) {
-    TF_LITE_MICRO_EXPECT_EQ(list.size(), D);
-
-    float min, max, scaling_factor;
-    tensor_utils::SymmetricQuantizeFloats(list.begin(), static_cast<int>(D),
-                                          input->data, &min, &max,
-                                          &scaling_factor);
-    input->scale = scaling_factor;
-    input->zero_point = 0;
-  }
-
-  template <typename T>
-  ElementArray<float, OUT> GetDequantizedOutput() {
-    ElementArray<float, OUT> result;
-    auto& output = this->GetOutput();
-    Dequantize<T>(output.data, OUT, output.scale, output.zero_point,
-                  result.data);
-
-    return result;
-  }
-
-  template <typename T>
-  ElementArray<T, OUT>& GetOutput() {
-    return data_output_;
-  }
-
- protected:
-  void DoInvoke(const TfLiteBatchMatMulParams& params, TfLiteTensor* tensors,
-                const int tensors_count) {
-    constexpr int kInputArrayData[] = {kMaxInputs, kInputTensor1,
-                                       kInputTensor2};
-    TfLiteIntArray* inputs_array = IntArrayFromInts(kInputArrayData);
-    constexpr int kOutputArrayData[] = {1, kOutputTensor};
-    TfLiteIntArray* outputs_array = IntArrayFromInts(kOutputArrayData);
-
-    const TfLiteRegistration registration = tflite::Register_BATCH_MATMUL();
-    micro::KernelRunner runner(
-        registration, tensors, tensors_count, inputs_array, outputs_array,
-        static_cast<void*>(const_cast<TfLiteBatchMatMulParams*>(&params)));
-
-    TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, runner.InitAndPrepare());
-    TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, runner.Invoke());
-
-    // The output tensor dims will have moved to a location in the
-    // memory arena.  Copy the tensor dims back into <dims_output_>
-    TfLiteIntArray* dims = IntArrayFromInts(dims_output_);
-    IntArrayCopy(*tensors[kOutputTensor].dims, dims);
-  }
-
- private:
-  int dims_inputs_[kMaxInputs][kMaxDims + 1];  // TfLiteIntArray[kMaxInputs]
-  int dims_output_[kMaxDims + 1];              // TfLiteIntArray
-  ElementArray<TIN1, IN1> data_input0_;
-  ElementArray<TIN2, IN2> data_input1_;
-  ElementArray<TOUT, OUT> data_output_;
-};
-
 template <typename T, size_t IN1, size_t IN2, size_t OUT>
 class BatchMatMulOpModel : public TestOpModel<T, T, T, IN1, IN2, OUT> {
  public:
   BatchMatMulOpModel(const TestTensorData& lhs, const TestTensorData& rhs,
                      bool adj_x = false, bool adj_y = false)
-      : TestOpModel<T, T, T, IN1, IN2, OUT>(), adj_x_(adj_x), adj_y_(adj_y) {
+      : TestOpModel<T, T, T, IN1, IN2, OUT>(tflite::Register_BATCH_MATMUL()),
+        adj_x_(adj_x),
+        adj_y_(adj_y) {
     this->AddInput(lhs, kInputIndex0);
     this->AddInput(rhs, kInputIndex1);
   }
@@ -354,7 +56,7 @@ class BatchMatMulOpModel : public TestOpModel<T, T, T, IN1, IN2, OUT> {
     params.adj_x = adj_x_;
     params.adj_y = adj_y_;
     params.asymmetric_quantize_inputs = false;
-    this->DoInvoke(params, tensors, tensors_count);
+    this->DoInvoke(&params, tensors, tensors_count);
   }
 
  private:
@@ -368,7 +70,9 @@ class QuantizedBatchMatMulOpModel : public TestOpModel<T, T, T, IN1, IN2, OUT> {
   QuantizedBatchMatMulOpModel(int units, int batches, const TestTensorData& lhs,
                               const TestTensorData& output = {kTfLiteInt8},
                               bool adj_x = false, bool adj_y = false)
-      : TestOpModel<T, T, T, IN1, IN2, OUT>(), adj_x_(adj_x), adj_y_(adj_y) {
+      : TestOpModel<T, T, T, IN1, IN2, OUT>(tflite::Register_BATCH_MATMUL()),
+        adj_x_(adj_x),
+        adj_y_(adj_y) {
     int input_size = ElementCount(this->GetInputShape(kInputIndex0)) / batches;
 
     this->AddInput(lhs, &this->GetInput0());
@@ -411,7 +115,7 @@ class QuantizedBatchMatMulOpModel : public TestOpModel<T, T, T, IN1, IN2, OUT> {
     params.adj_x = adj_x_;
     params.adj_y = adj_y_;
     params.asymmetric_quantize_inputs = false;
-    this->DoInvoke(params, tensors, tensors_count);
+    this->DoInvoke(&params, tensors, tensors_count);
   }
 
  private:
@@ -426,7 +130,7 @@ class HybridBatchMatMulOpModel : public TestOpModel<T1, T2, T1, IN1, IN2, OUT> {
                            const TestTensorData& rhs,
                            const TestTensorData& output = {kTfLiteFloat32},
                            bool asymmetric_quantize_inputs = true)
-      : TestOpModel<T1, T2, T1, IN1, IN2, OUT>(),
+      : TestOpModel<T1, T2, T1, IN1, IN2, OUT>(tflite::Register_BATCH_MATMUL()),
         asymmetric_quantize_inputs_(asymmetric_quantize_inputs) {
     this->AddInput(lhs, &this->GetInput0());
     this->AddInput(rhs, &this->GetInput1());
@@ -456,7 +160,7 @@ class HybridBatchMatMulOpModel : public TestOpModel<T1, T2, T1, IN1, IN2, OUT> {
     params.adj_x = false;
     params.adj_y = false;
     params.asymmetric_quantize_inputs = asymmetric_quantize_inputs_;
-    this->DoInvoke(params, tensors, tensors_count);
+    this->DoInvoke(&params, tensors, tensors_count);
   }
 
  private:
@@ -467,16 +171,11 @@ class HybridBatchMatMulOpModel : public TestOpModel<T1, T2, T1, IN1, IN2, OUT> {
 }  // namespace testing
 }  // namespace tflite
 
-using tflite::testing::ArrayFloatNear;
 using tflite::testing::BatchMatMulOpModel;
-using tflite::testing::ElementsAreArray;
-using tflite::testing::ExpectThat;
 using tflite::testing::HybridBatchMatMulOpModel;
 using tflite::testing::QuantizedBatchMatMulOpModel;
 
 TF_LITE_MICRO_TESTS_BEGIN
-
-#define EXPECT_THAT(a, b) ExpectThat(a, b)
 
 TF_LITE_MICRO_TEST(BatchMatMulOpTestFloat32Test_Simple) {
   BatchMatMulOpModel<float, 6, 12, 8> model({kTfLiteFloat32, {1, 2, 3}},

--- a/tensorflow/lite/micro/kernels/batch_matmul_test_util.h
+++ b/tensorflow/lite/micro/kernels/batch_matmul_test_util.h
@@ -1,0 +1,345 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_LITE_MICRO_KERNELS_BATCH_MATMUL_TEST_UTIL_H_
+#define TENSORFLOW_LITE_MICRO_KERNELS_BATCH_MATMUL_TEST_UTIL_H_
+
+#include <cstdint>
+#include <initializer_list>
+#include <type_traits>
+
+#include "tensorflow/lite/c/builtin_op_data.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/tensor_utils_common.h"
+#include "tensorflow/lite/micro/kernels/kernel_runner.h"
+#include "tensorflow/lite/micro/test_helpers.h"
+#include "tensorflow/lite/micro/testing/micro_test.h"
+
+namespace tflite {
+namespace testing {
+
+constexpr int kMaxDims = RuntimeShape::kMaxSmallSize;
+constexpr int kInputTensor1 = 0;
+constexpr int kInputTensor2 = 1;
+constexpr int kOutputTensor = 2;
+constexpr float kTolerance = 1e-5;
+
+enum TestInputIndex {
+  kInputIndex0,
+  kInputIndex1,
+};
+constexpr size_t kMaxInputs = TestInputIndex::kInputIndex1 + 1;
+
+struct TestTensorData {
+  TestTensorData(const TfLiteType datum_type,
+                 const std::initializer_list<int>& datum_list = {},
+                 float datum_min = 0.0f, float datum_max = 0.0f,
+                 float datum_scale = 0.0f, int32_t datum_zero_point = 0)
+      : type(datum_type),
+        shape(datum_list),
+        minimum(datum_min),
+        maximum(datum_max),
+        scale(datum_scale),
+        zero_point(datum_zero_point) {}
+  const TfLiteType type;
+  const std::initializer_list<int>& shape;
+  const float minimum;
+  const float maximum;
+  const float scale;
+  const int32_t zero_point;
+};
+
+template <typename T, size_t D>
+struct ElementArray {
+  ElementArray() : scale(0.0f), zero_point(0) {}
+
+  template <typename TA>
+  explicit ElementArray(const TA (&a)[D]) : ElementArray() {
+    for (size_t i = 0; i < D; i++) {
+      data[i] = static_cast<T>(a[i]);
+    }
+  }
+
+  T data[D];
+  TestInputIndex index;
+
+  // quantization parameters
+  float scale;
+  int32_t zero_point;
+};
+
+template <typename T, size_t D>
+struct ElementArrayNear : ElementArray<T, D> {
+  template <typename TA>
+  explicit ElementArrayNear(const TA (&a)[D],
+                            const float tolerance_param = kTolerance)
+      : ElementArray<T, D>(a), tolerance(tolerance_param) {}
+
+  const float tolerance;
+};
+
+template <size_t D>
+inline ElementArrayNear<float, D> ElementsAreArray(const double (&a)[D]) {
+  return ElementArrayNear<float, D>(a);
+}
+
+template <size_t D>
+inline ElementArray<int, D> ElementsAreArray(const int (&a)[D]) {
+  return ElementArray<int, D>(a);
+}
+
+template <typename T, size_t D>
+inline const ElementArrayNear<T, D>& ElementsAreArray(
+    const ElementArrayNear<T, D>& a) {
+  return a;
+}
+
+template <typename T, size_t D>
+inline ElementArrayNear<float, D> ArrayFloatNear(
+    const T (&a)[D], const float tolerance = kTolerance) {
+  return ElementArrayNear<float, D>(a, tolerance);
+}
+
+template <size_t D>
+void ExpectThat(const TfLiteIntArray& actual,
+                const ElementArray<int, D>& expected) {
+  TF_LITE_MICRO_EXPECT_EQ(actual.size, static_cast<int>(D));
+  for (int i = 0; i < actual.size; i++) {
+    TF_LITE_MICRO_EXPECT_EQ(actual.data[i], expected.data[i]);
+  }
+}
+
+template <typename T, size_t D>
+void ExpectThat(const ElementArray<T, D>& actual,
+                const ElementArrayNear<T, D>& expected) {
+  for (size_t i = 0; i < D; i++) {
+    TF_LITE_MICRO_EXPECT_NEAR(actual.data[i], expected.data[i],
+                              expected.tolerance);
+  }
+}
+
+template <typename T1, typename T2, size_t D>
+void ExpectThat(const ElementArray<T1, D>& actual,
+                const ElementArray<T2, D>& expected) {
+  for (size_t i = 0; i < D; i++) {
+    TF_LITE_MICRO_EXPECT_EQ(actual.data[i], static_cast<T1>(expected.data[i]));
+  }
+}
+
+template <typename T1, typename T2, size_t D>
+void ExpectThat(const ElementArray<T1, D>& actual,
+                const ElementArrayNear<T2, D>& expected) {
+  for (size_t i = 0; i < D; i++) {
+    TF_LITE_MICRO_EXPECT_NEAR(static_cast<T2>(actual.data[i]), expected.data[i],
+                              expected.tolerance);
+  }
+}
+
+inline void IntArrayCopy(const TfLiteIntArray& from, TfLiteIntArray* to) {
+  if (from.size > 0) {
+    for (int i = 0; i < from.size; i++) {
+      to->data[i] = from.data[i];
+    }
+    to->size = from.size;
+  }
+}
+
+inline void IntArrayCopy(const std::initializer_list<int>& from,
+                         TfLiteIntArray* to) {
+  if (from.size() > 0) {
+    for (size_t i = 0; i < from.size(); i++) {
+      to->data[i] = from.begin()[i];
+    }
+    to->size = from.size();
+  }
+}
+
+template <typename TIN1, typename TIN2, typename TOUT, size_t IN1, size_t IN2,
+          size_t OUT>
+class TestOpModel {
+ public:
+  explicit TestOpModel(const TfLiteRegistration& registration)
+      : registration_(registration) {
+    TfLiteIntArray* dims = IntArrayFromInts(dims_output_);
+    dims->size = 1;
+    dims->data[0] = OUT;
+
+    dims = IntArrayFromInts(dims_inputs_[kInputIndex0]);
+    dims->size = 1;
+    dims->data[0] = IN1;
+    data_input0_.index = kInputIndex0;
+
+    dims = IntArrayFromInts(dims_inputs_[kInputIndex1]);
+    dims->size = 1;
+    dims->data[0] = IN2;
+    data_input1_.index = kInputIndex1;
+  }
+
+  void AddInput(const TestTensorData& datum, const TestInputIndex index) {
+    TF_LITE_MICRO_EXPECT_LE(datum.shape.size(), kMaxDims);
+    TfLiteIntArray& dims = GetInputShape(index);
+    IntArrayCopy(datum.shape, &dims);
+    TF_LITE_MICRO_EXPECT_EQ(ElementCount(dims),
+                            static_cast<int>(GetInputSize(index)));
+  }
+
+  template <typename T, size_t D>
+  void AddInput(const TestTensorData& datum, ElementArray<T, D>* const input) {
+    TF_LITE_MICRO_EXPECT_LE(datum.shape.size(), kMaxDims);
+    TestInputIndex index = input->index;
+    TfLiteIntArray& dims = GetInputShape(index);
+    IntArrayCopy(datum.shape, &dims);
+    TF_LITE_MICRO_EXPECT_EQ(ElementCount(dims), static_cast<int>(D));
+
+    const bool quantizable =
+        (datum.type == kTfLiteInt8) &&
+        (datum.minimum != 0.0f || datum.maximum != 0.0f || datum.scale != 0.0f);
+    if (quantizable) {
+      if (datum.scale != 0.0f) {
+        input->scale = datum.scale;
+        input->zero_point = datum.zero_point;
+      } else {
+        input->scale = ScaleFromMinMax<int8_t>(datum.minimum, datum.maximum);
+        input->zero_point =
+            ZeroPointFromMinMax<int8_t>(datum.minimum, datum.maximum);
+      }
+    }
+  }
+
+  void AddOutput(const TestTensorData& datum) {
+    TF_LITE_MICRO_EXPECT_LE(datum.shape.size(), kMaxDims);
+    TfLiteIntArray& dims = GetOutputShape();
+    IntArrayCopy(datum.shape, &dims);
+    TF_LITE_MICRO_EXPECT_EQ(ElementCount(dims), static_cast<int>(OUT));
+
+    const bool quantizable =
+        (datum.type == kTfLiteInt8) &&
+        (datum.minimum != 0.0f || datum.maximum != 0.0f || datum.scale != 0.0f);
+    if (quantizable) {
+      if (datum.scale != 0.0f) {
+        data_output_.scale = datum.scale;
+        data_output_.zero_point = datum.zero_point;
+      } else {
+        data_output_.scale =
+            ScaleFromMinMax<int8_t>(datum.minimum, datum.maximum);
+        data_output_.zero_point =
+            ZeroPointFromMinMax<int8_t>(datum.minimum, datum.maximum);
+      }
+    }
+  }
+
+  ElementArray<TOUT, OUT>& GetOutput() { return data_output_; }
+  TfLiteIntArray& GetOutputShape() { return *IntArrayFromInts(dims_output_); }
+  ElementArray<TIN1, IN1>& GetInput0() { return data_input0_; }
+  ElementArray<TIN2, IN2>& GetInput1() { return data_input1_; }
+  TfLiteIntArray& GetInputShape(const TestInputIndex index) {
+    return *IntArrayFromInts(dims_inputs_[index]);
+  }
+  size_t GetInputSize(const TestInputIndex index) {
+    if (index == kInputIndex0) {
+      return IN1;
+    } else {  // (index == kInputIndex1)
+      return IN2;
+    }
+  }
+
+  template <typename T, size_t D>
+  void PopulateTensor(ElementArray<T, D>* const input,
+                      const std::initializer_list<float>& list) {
+    TF_LITE_MICRO_EXPECT_EQ(list.size(), D);
+
+    auto iter = list.begin();
+    for (size_t i = 0; i < list.size(); i++) {
+      input->data[i] = static_cast<T>(iter[i]);
+    }
+  }
+
+  template <typename T, size_t D>
+  void QuantizeAndPopulate(ElementArray<T, D>* const input,
+                           const std::initializer_list<float>& list) {
+    TF_LITE_MICRO_EXPECT_EQ(list.size(), D);
+
+    Quantize(list.begin(), input->data, D, input->scale, input->zero_point);
+  }
+
+  template <typename T, size_t D>
+  void SignedSymmetricQuantizeAndPopulate(
+      ElementArray<T, D>* const input,
+      const std::initializer_list<float>& list) {
+    TF_LITE_MICRO_EXPECT_EQ(list.size(), D);
+
+    float min, max, scaling_factor;
+    tensor_utils::SymmetricQuantizeFloats(list.begin(), static_cast<int>(D),
+                                          input->data, &min, &max,
+                                          &scaling_factor);
+    input->scale = scaling_factor;
+    input->zero_point = 0;
+  }
+
+  template <typename T>
+  ElementArray<float, OUT> GetDequantizedOutput() {
+    ElementArray<float, OUT> result;
+    auto& output = this->GetOutput();
+    Dequantize<T>(output.data, OUT, output.scale, output.zero_point,
+                  result.data);
+
+    return result;
+  }
+
+  template <typename T>
+  ElementArray<T, OUT>& GetOutput() {
+    return data_output_;
+  }
+
+ protected:
+  void DoInvoke(const void* params, TfLiteTensor* tensors,
+                const int tensors_count) {
+    int kInputArrayData[] = {kMaxInputs, kInputTensor1, kInputTensor2};
+    TfLiteIntArray* inputs_array = IntArrayFromInts(kInputArrayData);
+    int kOutputArrayData[] = {1, kOutputTensor};
+    TfLiteIntArray* outputs_array = IntArrayFromInts(kOutputArrayData);
+
+    micro::KernelRunner runner(registration_, tensors, tensors_count,
+                               inputs_array, outputs_array,
+                               const_cast<void*>(params));
+
+    TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, runner.InitAndPrepare());
+    TF_LITE_MICRO_EXPECT_EQ(kTfLiteOk, runner.Invoke());
+
+    // The output tensor dims will have moved to a location in the
+    // memory arena.  Copy the tensor dims back into <dims_output_>
+    TfLiteIntArray* dims = IntArrayFromInts(dims_output_);
+    IntArrayCopy(*tensors[kOutputTensor].dims, dims);
+  }
+
+ private:
+  int dims_inputs_[kMaxInputs][kMaxDims + 1];  // TfLiteIntArray[kMaxInputs]
+  int dims_output_[kMaxDims + 1];              // TfLiteIntArray
+  ElementArray<TIN1, IN1> data_input0_;
+  ElementArray<TIN2, IN2> data_input1_;
+  ElementArray<TOUT, OUT> data_output_;
+  const TfLiteRegistration registration_;
+};
+
+}  // namespace testing
+}  // namespace tflite
+
+using tflite::testing::ArrayFloatNear;
+using tflite::testing::ElementsAreArray;
+using tflite::testing::ExpectThat;
+
+#define EXPECT_THAT(a, b) ExpectThat(a, b)
+
+#endif  // TENSORFLOW_LITE_MICRO_KERNELS_BATCH_MATMUL_TEST_UTIL_H_

--- a/tensorflow/lite/micro/kernels/kernel_util.cc
+++ b/tensorflow/lite/micro/kernels/kernel_util.cc
@@ -59,7 +59,8 @@ TfLiteStatus CreateWritableTensorDimsWithCopy(TfLiteContext* context,
   TF_LITE_ENSURE(context, tensor != nullptr);
   TF_LITE_ENSURE(context, eval_tensor != nullptr);
   int ranks = tensor->dims->size;
-  size_t alloc_size = TfLiteIntArrayGetSizeInBytes(ranks);
+  // always allocate max ranks to allow for reshaping
+  size_t alloc_size = TfLiteIntArrayGetSizeInBytes(RuntimeShape::kMaxSmallSize);
   TfLiteIntArray* new_dims = static_cast<TfLiteIntArray*>(
       context->AllocatePersistentBuffer(context, alloc_size));
   TfLiteIntArray* old_dims = tensor->dims;

--- a/tensorflow/lite/micro/kernels/micro_ops.h
+++ b/tensorflow/lite/micro/kernels/micro_ops.h
@@ -32,6 +32,7 @@ namespace tflite {
 // have their Register function declarations in the tflite namespace.
 
 TfLiteRegistration Register_ADD_N();
+TfLiteRegistration Register_BATCH_MATMUL();
 TfLiteRegistration Register_BATCH_TO_SPACE_ND();
 TfLiteRegistration Register_CAST();
 TfLiteRegistration Register_CONV_2D();

--- a/tensorflow/lite/micro/micro_mutable_op_resolver.h
+++ b/tensorflow/lite/micro/micro_mutable_op_resolver.h
@@ -144,6 +144,11 @@ class MicroMutableOpResolver : public MicroOpResolver {
                       ParsePool);
   }
 
+  TfLiteStatus AddBatchMatMul() {
+    return AddBuiltin(BuiltinOperator_BATCH_MATMUL,
+                      tflite::Register_BATCH_MATMUL(), ParseBatchMatMul);
+  }
+
   TfLiteStatus AddBatchToSpaceNd() {
     return AddBuiltin(BuiltinOperator_BATCH_TO_SPACE_ND,
                       Register_BATCH_TO_SPACE_ND(), ParseBatchToSpaceNd);

--- a/tensorflow/lite/micro/tensor_utils_common.cc
+++ b/tensorflow/lite/micro/tensor_utils_common.cc
@@ -1,0 +1,143 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/kernels/internal/tensor_utils_common.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/kernels/internal/cppmath.h"
+
+namespace tflite {
+
+//
+// The following is copied from TfLite portable_tensor_utils.cc
+//
+// The declarations are located in header file:
+//   tensorflow/lite/kernels/internal/tensor_utils_common.h
+//
+namespace tensor_utils {
+
+// Quantizes a buffer of floating point values using a symmetric quantization
+// (i.e. linear quantization without an offset) to 8-bit signed integers.
+// It also outputs the range (min, max) of the floating point buffer, and the
+// scaling factor used to quantize the values.
+void SymmetricQuantizeFloats(const float* values, const int size,
+                             int8_t* quantized_values, float* min_value,
+                             float* max_value, float* scaling_factor) {
+  auto minmax = std::minmax_element(values, values + size);
+  *min_value = *minmax.first;
+  *max_value = *minmax.second;
+
+  SymmetricQuantizeFloats(values, size, quantized_values, *min_value,
+                          *max_value, scaling_factor);
+}
+
+// Quantizes a buffer of floating point values using a symmetric quantization
+// (i.e. linear quantization without an offset) to 8-bit signed integers.
+// It uses the range (min, max) provided to the function to calculate the
+// appropriate scaling factor to quantize the values.
+void SymmetricQuantizeFloats(const float* values, const int size,
+                             int8_t* quantized_values, float min_value,
+                             float max_value, float* scaling_factor) {
+  const int32_t kScale = 127;
+  const float range = std::max(std::abs(min_value), std::abs(max_value));
+  if (range == 0) {
+    std::fill_n(quantized_values, size, 0);
+    *scaling_factor = 1;
+    return;
+  }
+  *scaling_factor = range / kScale;
+  const float scaling_factor_inv = kScale / range;
+  for (int i = 0; i < size; ++i) {
+    const int32_t quantized_value =
+        static_cast<int32_t>(TfLiteRound(values[i] * scaling_factor_inv));
+    // Clamp: just in case some odd numeric offset.
+    quantized_values[i] = static_cast<int8_t>(
+        std::min(kScale, std::max(-kScale, quantized_value)));
+  }
+}
+
+void AsymmetricQuantizeFloats(const float* values, const int size,
+                              int8_t* quantized_values, float* scaling_factor,
+                              int32_t* offset) {
+  const int32_t kMinScale = -128;
+  const int32_t kMaxScale = 127;
+  const double qmin_double = kMinScale;
+  const double qmax_double = kMaxScale;
+  const auto minmax = std::minmax_element(values, values + size);
+  const double rmin = std::fmin(0, *minmax.first);
+  const double rmax = std::fmax(0, *minmax.second);
+  if (rmin == rmax) {
+    std::fill_n(quantized_values, size, 0);
+    *scaling_factor = 1;
+    *offset = 0;
+    return;
+  } else {
+    double scale = (rmax - rmin) / (qmax_double - qmin_double);
+    const double zero_point_from_min = qmin_double - rmin / scale;
+    const double zero_point_from_max = qmax_double - rmax / scale;
+    const double zero_point_from_min_error =
+        std::abs(qmin_double) + std::abs(rmin / scale);
+    const double zero_point_from_max_error =
+        std::abs(qmax_double) + std::abs(rmax / scale);
+    const double zero_point_double =
+        zero_point_from_min_error < zero_point_from_max_error
+            ? zero_point_from_min
+            : zero_point_from_max;
+    int8_t nudged_zero_point = 0;
+    if (zero_point_double <= qmin_double) {
+      nudged_zero_point = kMinScale;
+    } else if (zero_point_double >= qmax_double) {
+      nudged_zero_point = kMaxScale;
+    } else {
+      nudged_zero_point = static_cast<int8_t>(round(zero_point_double));
+    }
+    *scaling_factor = scale;
+    *offset = nudged_zero_point;
+  }
+  const float scaling_factor_inv = 1.0f / *scaling_factor;
+  for (int i = 0; i < size; ++i) {
+    const int32_t quantized_value = static_cast<int32_t>(
+        TfLiteRound(*offset + values[i] * scaling_factor_inv));
+    quantized_values[i] =
+        std::min(kMaxScale, std::max(kMinScale, quantized_value));
+  }
+}
+
+// Reduce-sum on a vector:
+// input_vector: pointer to input vector.
+// output_vector: pointer to vector.
+// output_size: output vector size.
+// reduction_size: number of consecutive elements from input vector which are
+// added to get one element of output.
+void ReductionSumVector(const int8_t* input_vector, int32_t* output_vector,
+                        int output_size, int reduction_size) {
+  for (int o = 0; o < output_size; o++) {
+    int32_t result = 0;
+    for (int r = 0; r < reduction_size; r++) {
+      result += input_vector[r];
+    }
+    output_vector[o] = result;
+    input_vector += reduction_size;
+  }
+}
+
+}  // namespace tensor_utils
+
+}  // namespace tflite

--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -261,6 +261,7 @@ tensorflow/lite/micro/kernels/activations_test.cc \
 tensorflow/lite/micro/kernels/add_test.cc \
 tensorflow/lite/micro/kernels/add_n_test.cc \
 tensorflow/lite/micro/kernels/arg_min_max_test.cc \
+tensorflow/lite/micro/kernels/batch_matmul_test.cc \
 tensorflow/lite/micro/kernels/batch_to_space_nd_test.cc \
 tensorflow/lite/micro/kernels/cast_test.cc \
 tensorflow/lite/micro/kernels/ceil_test.cc \
@@ -327,6 +328,7 @@ tensorflow/lite/micro/kernels/activations.cc \
 tensorflow/lite/micro/kernels/add.cc \
 tensorflow/lite/micro/kernels/add_n.cc \
 tensorflow/lite/micro/kernels/arg_min_max.cc \
+tensorflow/lite/micro/kernels/batch_matmul.cc \
 tensorflow/lite/micro/kernels/batch_to_space_nd.cc \
 tensorflow/lite/micro/kernels/cast.cc \
 tensorflow/lite/micro/kernels/ceil.cc \
@@ -435,6 +437,7 @@ tensorflow/lite/kernels/internal/quantization_util.h \
 tensorflow/lite/kernels/internal/reference/add.h \
 tensorflow/lite/kernels/internal/reference/add_n.h \
 tensorflow/lite/kernels/internal/reference/arg_min_max.h \
+tensorflow/lite/kernels/internal/reference/batch_matmul.h \
 tensorflow/lite/kernels/internal/reference/batch_to_space_nd.h \
 tensorflow/lite/kernels/internal/reference/binary_function.h \
 tensorflow/lite/kernels/internal/reference/ceil.h \
@@ -495,6 +498,7 @@ tensorflow/lite/kernels/internal/min.h \
 tensorflow/lite/kernels/internal/portable_tensor.h \
 tensorflow/lite/kernels/internal/strided_slice_logic.h \
 tensorflow/lite/kernels/internal/tensor_ctypes.h \
+tensorflow/lite/kernels/internal/tensor_utils_common.h \
 tensorflow/lite/kernels/internal/types.h \
 tensorflow/lite/kernels/kernel_util.h \
 tensorflow/lite/kernels/op_macros.h \


### PR DESCRIPTION
micro: port operator BATCH_MATMUL kernel from lite with test

Complete implementation of TFLM operator BATCH_MATMUL and associated TFLM test code.

PR step 5 of the work to port operator BATCH_MATMUL as tracked in Issue #46504