### PR TITLE
Make OSS errors match the internal errors.

### DIFF
--- a/tensorflow/lite/micro/tools/make/Makefile
+++ b/tensorflow/lite/micro/tools/make/Makefile
@@ -116,7 +116,6 @@ endif
 OPTIMIZATION_LEVEL := -O3
 
 CC_WARNINGS := \
-  -Werror \
   -Wsign-compare \
   -Wdouble-promotion \
   -Wshadow \
@@ -131,6 +130,7 @@ CC_WARNINGS := \
   -Wno-unused-parameter
 
 COMMON_FLAGS := \
+  -Werror \
   -fno-unwind-tables \
   -ffunction-sections \
   -fdata-sections \
@@ -155,6 +155,7 @@ CXXFLAGS := \
   $(COMMON_FLAGS)
 
 CCFLAGS := \
+  -Wimplicit-function-declaration \
   -std=c11 \
   $(COMMON_FLAGS)
 


### PR DESCRIPTION
With this change, the internal errors from https://github.com/tensorflow/tensorflow/pull/47935 are also reproducible from the open-source build.

Bug: http://b/161002902
