### PR TITLE
Patched C API implementation to correctly use interpreter num threads

### DIFF
--- a/tensorflow/lite/c/c_api.cc
+++ b/tensorflow/lite/c/c_api.cc
@@ -275,8 +275,16 @@ TfLiteInterpreter* InterpreterCreateWithOpResolver(
                                      error_reporter);
 
   std::unique_ptr<tflite::Interpreter> interpreter;
-  if (builder(&interpreter) != kTfLiteOk) {
-    return nullptr;
+  if (optional_options && optional_options->num_threads !=
+      TfLiteInterpreterOptions::kDefaultNumThreads) {
+    if (builder(&interpreter, optional_options->num_threads) !=
+        kTfLiteOk) {
+      return nullptr;
+    }
+  } else {
+    if (builder(&interpreter) != kTfLiteOk) {
+      return nullptr;
+    }
   }
 
   if (optional_options) {


### PR DESCRIPTION
Patched C API implementation to correctly use interpreter number of threads setting while invoking `InterpreterBuilder` since it is not enough to only call `SetNumThreads` method for setting to be applied for delegates as well. See https://github.com/tensorflow/tensorflow/issues/42277 for detailed description.