### PR TITLE
Enable method delegation test in eager distributed `AutoCastVariable`

### DIFF
--- a/tensorflow/python/keras/mixed_precision/autocast_variable_test.py
+++ b/tensorflow/python/keras/mixed_precision/autocast_variable_test.py
@@ -164,10 +164,10 @@ class AutoCastVariableTest(test.TestCase, parameterized.TestCase):
     # underlying variable.
     with self.test_session(), distribution.scope():
       for read_dtype in (dtypes.float32, dtypes.float16):
-        if ds_context.has_strategy():
+        if ds_context.has_strategy() and not context.executing_eagerly():
           # MirroredVariable.assign will (incorrectly) return a Mirrored value
-          # instead of a MirroredVariable. So we cannot properly wrap it in an
-          # AutoCastVariable.
+          # instead of a MirroredVariable in graph mode.
+          # So we cannot properly wrap it in an AutoCastVariable.
           evaluate = self.evaluate
         else:
 


### PR DESCRIPTION
This PR enables the method delegation tests of `AutoCastVariable` when run in eager mode within a distribution strategy as the issue appears to be fixed on master.

/cc @reedwm 