### PR TITLE
Additional bug fix for CreateWritableTensorDimsWithCopy

### DIFF
--- a/tensorflow/lite/micro/kernels/kernel_util.cc
+++ b/tensorflow/lite/micro/kernels/kernel_util.cc
@@ -58,6 +58,7 @@ TfLiteStatus CreateWritableTensorDimsWithCopy(TfLiteContext* context,
                                               TfLiteEvalTensor* eval_tensor) {
   TF_LITE_ENSURE(context, tensor != nullptr);
   TF_LITE_ENSURE(context, eval_tensor != nullptr);
+  TF_LITE_ENSURE(context, context->AllocatePersistentBuffer != nullptr);
   int ranks = tensor->dims->size;
   size_t alloc_size = TfLiteIntArrayGetSizeInBytes(ranks);
   TfLiteIntArray* new_dims = static_cast<TfLiteIntArray*>(


### PR DESCRIPTION
Also check that the AllocatePersistentBuffer method is available.

Additional fix for issue micro: port op L2_POOL_2D from lite #47814