### PR TITLE
Bug fix for TfLiteTensor dims

### DIFF
--- a/tensorflow/lite/micro/micro_allocator.cc
+++ b/tensorflow/lite/micro/micro_allocator.cc
@@ -822,6 +822,10 @@ TfLiteTensor* MicroAllocator::AllocateTempTfLiteTensor(
     // point the corresponding buffer to the new TfLiteTensor data value.
     tensor->data.data =
         subgraph_allocations[subgraph_index].tensors[tensor_index].data.data;
+    // TfLiteEvalTensor structs must also be the source of truth for the
+    // TfLiteTensor dims.
+    tensor->dims =
+        subgraph_allocations[subgraph_index].tensors[tensor_index].dims;
   }
   return tensor;
 }


### PR DESCRIPTION
When using the MicroInterpreter, the TfLiteEvalTensor must be the source of truth for tensor dims.
It is possible during the Prepare phase for an operator to change the location of the tensor dims to somewhere other than the Flatbuffer.  When using the MicroInterpreter, the Flatbuffer is currently used as the source of truth for TfLiteTensor dims.  This fix makes the TfLiteEvalTensor dims the source of truth when initializing a TfLiteTensor.

Additional fix for issue micro: port op L2_POOL_2D from lite #47814