### PR TITLE
Fix tf_tensor C-API memleak by explicitly dealloc ctstring large.ptr

### DIFF
--- a/tensorflow/c/c_api_test.cc
+++ b/tensorflow/c/c_api_test.cc
@@ -2592,6 +2592,31 @@ TEST(CAPI, MessageBufferConversion) {
   EXPECT_TRUE(differencer.Compare(node_in, node_out));
 }
 
+TEST(CAPI, TestTensorNonScalarBytesAllocateDelete) {
+  const int batch_size = 4;
+  const int num_dims = 2;
+  int64_t* dims = new int64_t[num_dims];
+  int64_t num_elements = 1;
+  dims[0] = batch_size;
+  dims[1] = 1;
+  for (int64_t i = 0; i < num_dims; ++i) {
+    num_elements *= dims[i];
+  }
+  TF_Tensor* t = TF_AllocateTensor(TF_STRING, dims, num_dims, sizeof(TF_TString) * num_elements);
+  delete[] dims;
+
+  TF_TString* data = static_cast<TF_TString*>(TF_TensorData(t));
+  for (int i = 0; i < batch_size; ++i) {
+    TF_TString_Init(&data[i]);
+    // The following input string length is large enough to make sure that
+    // copy to tstring in large mode.
+    std::string source = "This is the " + std::to_string(i + 1) + "th. data element\n";
+    TF_TString_Copy(&data[i], source.c_str(), source.length());
+  }
+
+  TF_DeleteTensor(t);
+}
+
 }  // namespace
 }  // namespace tensorflow
 

--- a/tensorflow/c/tf_tensor.cc
+++ b/tensorflow/c/tf_tensor.cc
@@ -182,7 +182,17 @@ void TF_TensorBitcastFrom(const TF_Tensor* from, TF_DataType type,
 
 namespace tensorflow {
 
-void TensorInterface::Release() { delete this; }
+void TensorInterface::Release() {
+  if (Type() == DT_STRING) {
+    TF_TString* data = static_cast<TF_TString*>(Data());
+    if (data != nullptr) {
+      for (int64_t i = 0; i < NumElements(); ++i) {
+        TF_TString_Dealloc(&data[i]);
+      }
+    }
+  }
+  delete this;
+}
 
 bool TensorInterface::CanMove() const {
   // It is safe to move the Tensor if and only if we own the unique reference to


### PR DESCRIPTION
When we use c api to release a tensor by dtype `string`, there occures heavy memory leak problem, expecially in batch mode. Therefore, we distinguished the problem, where the TensorInterface::Release() function should also deallocate the ctstring large.ptr.