### PR TITLE
Remove IMAGE_RECOGNITION variables from third_party_downloads

### DIFF
--- a/tensorflow/lite/micro/tools/make/third_party_downloads.inc
+++ b/tensorflow/lite/micro/tools/make/third_party_downloads.inc
@@ -39,9 +39,6 @@ KISSFFT_MD5="438ba1fef5783cc5f5f201395cc477ca"
 RUY_URL="https://github.com/google/ruy/archive/d37128311b445e758136b8602d1bbd2a755e115d.zip"
 RUY_MD5="abf7a91eb90d195f016ebe0be885bb6e"
 
-IMAGE_RECOGNITION_MODEL_URL := "https://storage.googleapis.com/download.tensorflow.org/models/tflite/cifar_image_recognition_model_2020_05_27.zip"
-IMAGE_RECOGNITION_MODEL_MD5 := "1f4607b05ac45b8a6146fb883dbc2d7b"
-
 PERSON_MODEL_URL := "https://storage.googleapis.com/download.tensorflow.org/data/tf_lite_micro_person_data_grayscale_2020_05_27.zip"
 PERSON_MODEL_MD5 := "55b85f76e2995153e660391d4a209ef1"
 


### PR DESCRIPTION
@advaitjain When the image_recognition_experimental example was removed I missed to delete these lines from the third_party_downloads.