### PR TITLE
Wire up set_filesystem_configuration with modular file system

### DIFF
--- a/tensorflow/c/experimental/filesystem/filesystem_interface.h
+++ b/tensorflow/c/experimental/filesystem/filesystem_interface.h
@@ -95,8 +95,8 @@ typedef union TF_Filesystem_Option_Value_Union {
 } TF_Filesystem_Option_Value_Union;
 
 typedef struct TF_Filesystem_Option_Value {
-  int type_tag;
-  int num_values;
+  int type_tag;       // type of values in the values union
+  int num_values; // number of values
   TF_Filesystem_Option_Value_Union* values;  // owned
 } TF_Filesystem_Option_Value;
 

--- a/tensorflow/c/experimental/filesystem/filesystem_interface.h
+++ b/tensorflow/c/experimental/filesystem/filesystem_interface.h
@@ -95,7 +95,7 @@ typedef union TF_Filesystem_Option_Value_Union {
 } TF_Filesystem_Option_Value_Union;
 
 typedef struct TF_Filesystem_Option_Value {
-  int type_tag;       // type of values in the values union
+  int type_tag;   // type of values in the values union
   int num_values; // number of values
   TF_Filesystem_Option_Value_Union* values;  // owned
 } TF_Filesystem_Option_Value;

--- a/tensorflow/c/experimental/filesystem/filesystem_interface.h
+++ b/tensorflow/c/experimental/filesystem/filesystem_interface.h
@@ -83,8 +83,9 @@ typedef struct TF_TransactionToken {
   TF_Filesystem* owner;
 } TF_TransactionToken;
 
-// The named union is needed here in as otherwise
-// compilation fails on Windows C++ compiler.
+// The named union is needed here (as opposed to
+// inside the `TF_Filesystem_Option_Value` struct)
+// as MSVC does not recognize `typeof`.
 typedef union TF_Filesystem_Option_Value_Union {
   int64_t inv_val;
   double real_val;

--- a/tensorflow/c/experimental/filesystem/filesystem_interface.h
+++ b/tensorflow/c/experimental/filesystem/filesystem_interface.h
@@ -83,24 +83,28 @@ typedef struct TF_TransactionToken {
   TF_Filesystem* owner;
 } TF_TransactionToken;
 
-typedef union TF_Filesystem_Option_Value {
-  int64_t inv_val;
-  double real_val;
-  struct {
-    char* buf;
-    int buf_length;
-  } buffer_val;
+typedef struct TF_Filesystem_Option_Value {
+  int type_tag; // type of the value (int, real, buffer)
+  union {
+    int64_t inv_val;
+    double real_val;
+    struct {
+      char* buf;
+      int buf_length;
+    } buffer_val;
+  } u;
 } TF_Filesystem_Option_Value;
 
-constexpr int TF_FILESYSTEM_OPTION_TYPE_INT = 0;
-constexpr int TF_FILESYSTEM_OPTION_TYPE_REAL = 1;
-constexpr int TF_FILESYSTEM_OPTION_TYPE_BUFFER = 2;
+typedef enum TF_Filesystem_Option_Type {
+  TF_Filesystem_Option_Type_Int = 0,
+  TF_Filesystem_Option_Type_Real,
+  TF_Filesystem_Option_Type_Buffer,
+} TF_Filesystem_Option_Type;
 
 typedef struct TF_Filesystem_Option {
   char* name;                         // null terminated, owned
   char* description;                  // null terminated, owned
   int per_file;                       // bool actually, but bool is not a C type
-  int type_tag;                       // type of the value (int, real, buffer)
   int num_values;                     // num of values
   TF_Filesystem_Option_Value* value;  // owned
 } TF_Filesystem_Option;
@@ -881,6 +885,24 @@ typedef struct TF_FilesystemOps {
                                               const char* key,
                                               TF_Filesystem_Option** option,
                                               TF_Status* status);
+
+  /// Sets the value of the filesystem option given in `key` to value in
+  /// `option`. Valid values of the `key` are returned by
+  /// `get_file_system_configuration_keys` call. Ownership of the `option` and
+  /// the `key` belogs to the caller. Buffers therein should be allocated and
+  /// freed by the filesystems allocation API.
+  ///
+  /// Plugins:
+  ///   * Must set `status` to `TF_OK` if `option` is set/updated
+  ///   * Must set `status` to `TF_NOT_FOUND` if the key is invalid
+  ///   * Might use any other error value for `status` to signal other errors.
+  ///
+  /// DEFAULT IMPLEMENTATION: return `TF_NOT_FOUND`.
+  void (*set_filesystem_configuration_option)(
+      const TF_Filesystem* filesystem,
+      const char* key,
+      const TF_Filesystem_Option* option,
+      TF_Status* status);
 
   /// Returns a list of valid configuration keys in `keys` array and number of
   /// keys in `num_keys`. Ownership of the buffers in `keys` are transferred to

--- a/tensorflow/c/experimental/filesystem/filesystem_interface.h
+++ b/tensorflow/c/experimental/filesystem/filesystem_interface.h
@@ -87,7 +87,7 @@ typedef struct TF_TransactionToken {
 // inside the `TF_Filesystem_Option_Value` struct)
 // as MSVC does not recognize `typeof`.
 typedef union TF_Filesystem_Option_Value_Union {
-  int64_t inv_val;
+  int64_t int_val;
   double real_val;
   struct {
     char* buf;
@@ -98,7 +98,7 @@ typedef union TF_Filesystem_Option_Value_Union {
 typedef struct TF_Filesystem_Option_Value {
   int type_tag;   // type of values in the values union
   int num_values; // number of values
-  TF_Filesystem_Option_Value_Union* values;  // owned
+  TF_Filesystem_Option_Value_Union* values;  // owned (plugins must make a copy if storing this)
 } TF_Filesystem_Option_Value;
 
 typedef enum TF_Filesystem_Option_Type {

--- a/tensorflow/c/experimental/filesystem/modular_filesystem.cc
+++ b/tensorflow/c/experimental/filesystem/modular_filesystem.cc
@@ -390,8 +390,8 @@ void ModularFileSystem::FlushCaches(TransactionToken* token) {
   if (ops_->flush_caches != nullptr) ops_->flush_caches(filesystem_.get());
 }
 
-Status ModularFileSystem::SetConfiguration(const std::string& name,
-                                           const std::vector<string>& values) {
+Status ModularFileSystem::SetOption(const std::string& name,
+                                    const std::vector<string>& values) {
   if (ops_->set_filesystem_configuration == nullptr) {
     return errors::Unimplemented(
         "Filesystem does not support SetConfiguration()");
@@ -404,16 +404,77 @@ Status ModularFileSystem::SetConfiguration(const std::string& name,
   TF_Filesystem_Option option;
   memset(&option, 0, sizeof(option));
   option.name = const_cast<char*>(name.c_str());
-  option.per_file = 0;
   TF_Filesystem_Option_Value option_value;
   memset(&option_value, 0, sizeof(option_value));
   option_value.type_tag = TF_Filesystem_Option_Type_Buffer;
   option_value.num_values = values.size();
   std::vector<TF_Filesystem_Option_Value_Union> option_values(values.size());
   for (size_t i = 0; i < values.size(); i++) {
-    memset(&option_values[i], 0, sizeof(TF_Filesystem_Option_Value_Union));
+    memset(&option_values[i], 0, sizeof(option_values[i]));
     option_values[i].buffer_val.buf = const_cast<char*>(values[i].c_str());
     option_values[i].buffer_val.buf_length = values[i].size();
+  }
+  option_value.values = &option_values[0];
+  option.value = &option_value;
+  UniquePtrTo_TF_Status plugin_status(TF_NewStatus(), TF_DeleteStatus);
+  ops_->set_filesystem_configuration(
+      filesystem_.get(), &option, 1, plugin_status.get());
+  return StatusFromTF_Status(plugin_status.get());
+}
+
+Status ModularFileSystem::SetOption(const std::string& name,
+                                    const std::vector<int64>& values) {
+  if (ops_->set_filesystem_configuration == nullptr) {
+    return errors::Unimplemented(
+        "Filesystem does not support SetConfiguration()");
+  }
+  if (values.size() == 0) {
+    return errors::InvalidArgument(
+        "SetConfiguration() needs number of values > 0");
+  }
+
+  TF_Filesystem_Option option;
+  memset(&option, 0, sizeof(option));
+  option.name = const_cast<char*>(name.c_str());
+  TF_Filesystem_Option_Value option_value;
+  memset(&option_value, 0, sizeof(option_value));
+  option_value.type_tag = TF_Filesystem_Option_Type_Int;
+  option_value.num_values = values.size();
+  std::vector<TF_Filesystem_Option_Value_Union> option_values(values.size());
+  for (size_t i = 0; i < values.size(); i++) {
+    memset(&option_values[i], 0, sizeof(option_values[i]));
+    option_values[i].int_val = values[i];
+  }
+  option_value.values = &option_values[0];
+  option.value = &option_value;
+  UniquePtrTo_TF_Status plugin_status(TF_NewStatus(), TF_DeleteStatus);
+  ops_->set_filesystem_configuration(
+      filesystem_.get(), &option, 1, plugin_status.get());
+  return StatusFromTF_Status(plugin_status.get());
+}
+
+Status ModularFileSystem::SetOption(const std::string& name,
+                                    const std::vector<double>& values) {
+  if (ops_->set_filesystem_configuration == nullptr) {
+    return errors::Unimplemented(
+        "Filesystem does not support SetConfiguration()");
+  }
+  if (values.size() == 0) {
+    return errors::InvalidArgument(
+        "SetConfiguration() needs number of values > 0");
+  }
+
+  TF_Filesystem_Option option;
+  memset(&option, 0, sizeof(option));
+  option.name = const_cast<char*>(name.c_str());
+  TF_Filesystem_Option_Value option_value;
+  memset(&option_value, 0, sizeof(option_value));
+  option_value.type_tag = TF_Filesystem_Option_Type_Real;
+  option_value.num_values = values.size();
+  std::vector<TF_Filesystem_Option_Value_Union> option_values(values.size());
+  for (size_t i = 0; i < values.size(); i++) {
+    memset(&option_values[i], 0, sizeof(option_values[i]));
+    option_values[i].real_val = values[i];
   }
   option_value.values = &option_values[0];
   option.value = &option_value;

--- a/tensorflow/c/experimental/filesystem/modular_filesystem.cc
+++ b/tensorflow/c/experimental/filesystem/modular_filesystem.cc
@@ -405,13 +405,13 @@ Status ModularFileSystem::SetConfiguration(const std::string& name,
   memset(&option, 0, sizeof(option));
   option.name = const_cast<char*>(name.c_str());
   option.per_file = 0;
-  option.type_tag = TF_FILESYSTEM_OPTION_TYPE_BUFFER;
   option.num_values = values.size();
   std::vector<TF_Filesystem_Option_Value> option_values(values.size());
   for (size_t i = 0; i < values.size(); i++) {
     memset(&option_values[i], 0, sizeof(TF_Filesystem_Option_Value));
-    option_values[i].buffer_val.buf = const_cast<char*>(values[i].c_str());
-    option_values[i].buffer_val.buf_length = values[i].size();
+    option_values[i].type_tag = TF_Filesystem_Option_Type_Buffer;
+    option_values[i].u.buffer_val.buf = const_cast<char*>(values[i].c_str());
+    option_values[i].u.buffer_val.buf_length = values[i].size();
   }
   option.value = &option_values[0];
   UniquePtrTo_TF_Status plugin_status(TF_NewStatus(), TF_DeleteStatus);

--- a/tensorflow/c/experimental/filesystem/modular_filesystem.cc
+++ b/tensorflow/c/experimental/filesystem/modular_filesystem.cc
@@ -405,15 +405,18 @@ Status ModularFileSystem::SetConfiguration(const std::string& name,
   memset(&option, 0, sizeof(option));
   option.name = const_cast<char*>(name.c_str());
   option.per_file = 0;
-  option.num_values = values.size();
-  std::vector<TF_Filesystem_Option_Value> option_values(values.size());
+  TF_Filesystem_Option_Value option_value;
+  memset(&option_value, 0, sizeof(option_value));
+  option_value.type_tag = TF_Filesystem_Option_Type_Buffer;
+  option_value.num_values = values.size();
+  std::vector<TF_Filesystem_Option_Value_Union> option_values(values.size());
   for (size_t i = 0; i < values.size(); i++) {
-    memset(&option_values[i], 0, sizeof(TF_Filesystem_Option_Value));
-    option_values[i].type_tag = TF_Filesystem_Option_Type_Buffer;
-    option_values[i].u.buffer_val.buf = const_cast<char*>(values[i].c_str());
-    option_values[i].u.buffer_val.buf_length = values[i].size();
+    memset(&option_values[i], 0, sizeof(TF_Filesystem_Option_Value_Union));
+    option_values[i].buffer_val.buf = const_cast<char*>(values[i].c_str());
+    option_values[i].buffer_val.buf_length = values[i].size();
   }
-  option.value = &option_values[0];
+  option_value.values = &option_values[0];
+  option.value = &option_value;
   UniquePtrTo_TF_Status plugin_status(TF_NewStatus(), TF_DeleteStatus);
   ops_->set_filesystem_configuration(
       filesystem_.get(), &option, 1, plugin_status.get());

--- a/tensorflow/c/experimental/filesystem/modular_filesystem.h
+++ b/tensorflow/c/experimental/filesystem/modular_filesystem.h
@@ -101,8 +101,12 @@ class ModularFileSystem final : public FileSystem {
                   TransactionToken* token) override;
   std::string TranslateName(const std::string& name) const override;
   void FlushCaches(TransactionToken* token) override;
-  Status SetConfiguration(const std::string& name,
-                          const std::vector<string>& values) override;
+  Status SetOption(const std::string& name,
+                   const std::vector<string>& values) override;
+  Status SetOption(const std::string& name,
+                   const std::vector<int64>& values) override;
+  Status SetOption(const std::string& name,
+                   const std::vector<double>& values) override;
 
  private:
   std::unique_ptr<TF_Filesystem> filesystem_;

--- a/tensorflow/c/experimental/filesystem/modular_filesystem.h
+++ b/tensorflow/c/experimental/filesystem/modular_filesystem.h
@@ -102,7 +102,7 @@ class ModularFileSystem final : public FileSystem {
   std::string TranslateName(const std::string& name) const override;
   void FlushCaches(TransactionToken* token) override;
   Status SetConfiguration(const std::string& name,
-                          const std::string& value) override;
+                          const std::vector<string>& values) override;
 
  private:
   std::unique_ptr<TF_Filesystem> filesystem_;

--- a/tensorflow/c/experimental/filesystem/modular_filesystem.h
+++ b/tensorflow/c/experimental/filesystem/modular_filesystem.h
@@ -101,6 +101,8 @@ class ModularFileSystem final : public FileSystem {
                   TransactionToken* token) override;
   std::string TranslateName(const std::string& name) const override;
   void FlushCaches(TransactionToken* token) override;
+  Status SetConfiguration(const std::string& name,
+                          const std::string& value) override;
 
  private:
   std::unique_ptr<TF_Filesystem> filesystem_;

--- a/tensorflow/core/platform/env.cc
+++ b/tensorflow/core/platform/env.cc
@@ -140,6 +140,16 @@ Status Env::RegisterFileSystem(const std::string& scheme,
   return file_system_registry_->Register(scheme, std::move(filesystem));
 }
 
+Status Env::SetConfiguration(const std::string& scheme,
+                             const std::string& key, const std::string& value) {
+  FileSystem* file_system = file_system_registry_->Lookup(scheme);
+  if (!file_system) {
+    return errors::Unimplemented("File system scheme '", scheme,
+                                 "' not found to set configuration");
+  }
+  return file_system->SetConfiguration(key, value);
+}
+
 Status Env::FlushFileSystemCaches() {
   std::vector<string> schemes;
   TF_RETURN_IF_ERROR(GetRegisteredFileSystemSchemes(&schemes));

--- a/tensorflow/core/platform/env.cc
+++ b/tensorflow/core/platform/env.cc
@@ -140,14 +140,35 @@ Status Env::RegisterFileSystem(const std::string& scheme,
   return file_system_registry_->Register(scheme, std::move(filesystem));
 }
 
-Status Env::SetConfiguration(const std::string& scheme, const std::string& key,
-                             const std::vector<string>& values) {
+Status Env::SetOption(const std::string& scheme, const std::string& key,
+                      const std::vector<string>& values) {
   FileSystem* file_system = file_system_registry_->Lookup(scheme);
   if (!file_system) {
     return errors::Unimplemented("File system scheme '", scheme,
                                  "' not found to set configuration");
   }
-  return file_system->SetConfiguration(key, values);
+  return file_system->SetOption(key, values);
+}
+
+Status Env::SetOption(const std::string& scheme, const std::string& key,
+                      const std::vector<int64>& values) {
+  FileSystem* file_system = file_system_registry_->Lookup(scheme);
+  if (!file_system) {
+    return errors::Unimplemented("File system scheme '", scheme,
+                                 "' not found to set configuration");
+  }
+  return file_system->SetOption(key, values);
+}
+
+
+Status Env::SetOption(const std::string& scheme, const std::string& key,
+                      const std::vector<double>& values) {
+  FileSystem* file_system = file_system_registry_->Lookup(scheme);
+  if (!file_system) {
+    return errors::Unimplemented("File system scheme '", scheme,
+                                 "' not found to set configuration");
+  }
+  return file_system->SetOption(key, values);
 }
 
 Status Env::FlushFileSystemCaches() {

--- a/tensorflow/core/platform/env.cc
+++ b/tensorflow/core/platform/env.cc
@@ -140,14 +140,14 @@ Status Env::RegisterFileSystem(const std::string& scheme,
   return file_system_registry_->Register(scheme, std::move(filesystem));
 }
 
-Status Env::SetConfiguration(const std::string& scheme,
-                             const std::string& key, const std::string& value) {
+Status Env::SetConfiguration(const std::string& scheme, const std::string& key,
+                             const std::vector<string>& values) {
   FileSystem* file_system = file_system_registry_->Lookup(scheme);
   if (!file_system) {
     return errors::Unimplemented("File system scheme '", scheme,
                                  "' not found to set configuration");
   }
-  return file_system->SetConfiguration(key, value);
+  return file_system->SetConfiguration(key, values);
 }
 
 Status Env::FlushFileSystemCaches() {

--- a/tensorflow/core/platform/env.h
+++ b/tensorflow/core/platform/env.h
@@ -93,6 +93,9 @@ class Env {
   virtual Status RegisterFileSystem(const std::string& scheme,
                                     std::unique_ptr<FileSystem> filesystem);
 
+  Status SetConfiguration(const std::string& scheme,
+                          const std::string& key, const std::string& value);
+
   /// \brief Flush filesystem caches for all registered filesystems.
   Status FlushFileSystemCaches();
 

--- a/tensorflow/core/platform/env.h
+++ b/tensorflow/core/platform/env.h
@@ -93,8 +93,8 @@ class Env {
   virtual Status RegisterFileSystem(const std::string& scheme,
                                     std::unique_ptr<FileSystem> filesystem);
 
-  Status SetConfiguration(const std::string& scheme,
-                          const std::string& key, const std::string& value);
+  Status SetConfiguration(const std::string& scheme, const std::string& key,
+                          const std::vector<string>& values);
 
   /// \brief Flush filesystem caches for all registered filesystems.
   Status FlushFileSystemCaches();

--- a/tensorflow/core/platform/env.h
+++ b/tensorflow/core/platform/env.h
@@ -93,8 +93,14 @@ class Env {
   virtual Status RegisterFileSystem(const std::string& scheme,
                                     std::unique_ptr<FileSystem> filesystem);
 
-  Status SetConfiguration(const std::string& scheme, const std::string& key,
-                          const std::vector<string>& values);
+  Status SetOption(const std::string& scheme, const std::string& key,
+                   const std::vector<string>& values);
+
+  Status SetOption(const std::string& scheme, const std::string& key,
+                   const std::vector<int64>& values);
+
+  Status SetOption(const std::string& scheme, const std::string& key,
+                   const std::vector<double>& values);
 
   /// \brief Flush filesystem caches for all registered filesystems.
   Status FlushFileSystemCaches();

--- a/tensorflow/core/platform/file_system.h
+++ b/tensorflow/core/platform/file_system.h
@@ -517,8 +517,8 @@ class FileSystem {
   virtual std::string DecodeTransaction(const TransactionToken* token);
 
   /// \brief Set File System Configuration
-  virtual tensorflow::Status SetConfiguration(const std::string& name,
-                                              const std::string& value) {
+  virtual tensorflow::Status SetConfiguration(
+      const std::string& name, const std::vector<string>& values) {
     return errors::Unimplemented("SetConfiguration");
   }
 

--- a/tensorflow/core/platform/file_system.h
+++ b/tensorflow/core/platform/file_system.h
@@ -516,6 +516,12 @@ class FileSystem {
   /// \brief Decode transaction to human readable string.
   virtual std::string DecodeTransaction(const TransactionToken* token);
 
+  /// \brief Set File System Configuration
+  virtual tensorflow::Status SetConfiguration(const std::string& name,
+                                              const std::string& value) {
+    return errors::Unimplemented("SetConfiguration");
+  }
+
   FileSystem() {}
 
   virtual ~FileSystem() = default;

--- a/tensorflow/core/platform/file_system.h
+++ b/tensorflow/core/platform/file_system.h
@@ -516,10 +516,22 @@ class FileSystem {
   /// \brief Decode transaction to human readable string.
   virtual std::string DecodeTransaction(const TransactionToken* token);
 
-  /// \brief Set File System Configuration
-  virtual tensorflow::Status SetConfiguration(
+  /// \brief Set File System Configuration Option
+  virtual tensorflow::Status SetOption(
       const std::string& name, const std::vector<string>& values) {
-    return errors::Unimplemented("SetConfiguration");
+    return errors::Unimplemented("SetOption");
+  }
+
+  /// \brief Set File System Configuration Option
+  virtual tensorflow::Status SetOption(
+      const std::string& name, const std::vector<int64>& values) {
+    return errors::Unimplemented("SetOption");
+  }
+
+  /// \brief Set File System Configuration Option
+  virtual tensorflow::Status SetOption(
+      const std::string& name, const std::vector<double>& values) {
+    return errors::Unimplemented("SetOption");
   }
 
   FileSystem() {}


### PR DESCRIPTION
This PR tries to wire up set_filesystem_configuration with modular file system so that it is possible to set up the file
system configuration through modular file system plugins.

While set_filesystem_configuration API has been defined in the past, the API was not wired up with modular file system so it was not possible to use it from plugins.

This PR adds the missing implementation.

This PR also made several changes:
- values associated with `type_tag` was not defined in the past. This PR adds the definition.
- TF_Filesystem_Option_Value definition has been modified as previous unnamed union was difficult to assign value.
- set_filesystem_configuration_option was removed as it is almost a duplicate of set_filesystem_configuration, and it does not match the description.

While the API was modified, since set_filesystem_configuration was not wired with modular file system, it is not used anyway. So this will not break user or plugins.

This PR is needed in order to have gcs-config support in modular file system plugins.

cc @mihaimaruseac, FYI @vnvo2409 @kvignesh1420 @terrytangyuan @burgerkingeater 

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>