### PR TITLE
Fix error message for using numpy-related methods

### DIFF
--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -396,7 +396,7 @@ class Tensor(internal.NativeObject, core_tf_types.Tensor):
       raise AttributeError("""
         '{}' object has no attribute '{}'.
         If you are looking for numpy-related methods, please run the following:
-        import tensorflow.python.ops.numpy_ops.np_config
+        from tensorflow.python.ops.numpy_ops import np_config
         np_config.enable_numpy_behavior()""".format(type(self).__name__, name))
     self.__getattribute__(name)
 


### PR DESCRIPTION
When attempting to use numpy-related methods, you encounter the following error:

```python
x = tf.constant([[1, 2, 3], [4, 5, 6]])
x.T
```

```
AttributeError: 
        'EagerTensor' object has no attribute 'T'.
        If you are looking for numpy-related methods, please run the following:
        import tensorflow.python.ops.numpy_ops.np_config
        np_config.enable_numpy_behavior()
```

Attempting the fix in that error message results in:

```
NameError: name 'np_config' is not defined
```

This updates the error message to be consistent with usage here: https://github.com/tensorflow/tensorflow/blob/5dcfc51118817f27fad5246812d83e5dccdc5f72/tensorflow/python/ops/numpy_ops/integration_test/np_config_test.py#L22

which works as expected