### PR TITLE
[TF-TRT] Argument bugfix

### DIFF
--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -469,7 +469,9 @@ class TrtGraphConverter(object):
     self._calibration_graph = None
     self._calibration_data_collected = False
     self._need_calibration = (
-        precision_mode == TrtPrecisionMode.INT8 and use_calibration)
+        ((precision_mode == TrtPrecisionMode.INT8) or 
+         (precision_mode == TrtPrecisionMode.INT8.lower())) 
+        and use_calibration)
     if self._need_calibration and not is_dynamic_op:
       tf_logging.warn(
           "INT8 precision mode with calibration is supported with "
@@ -995,8 +997,9 @@ class TrtGraphConverterV2(object):
         signature_constants.DEFAULT_SERVING_SIGNATURE_DEF_KEY)
 
     self._need_calibration = (
-        conversion_params.precision_mode == TrtPrecisionMode.INT8 and
-        conversion_params.use_calibration)
+        ((conversion_params.precision_mode == TrtPrecisionMode.INT8) or
+         (conversion_params.precision_mode == TrtPrecisionMode.INT8.lower()))
+        and conversion_params.use_calibration)
 
     self._converted = False
     self._build_called_once = False


### PR DESCRIPTION
TF-TRT supports lowercase arguments.
https://github.com/tensorflow/tensorflow/blob/9460c57fb5fb112e1e6d03a0221799d71b042926/tensorflow/python/compiler/tensorrt/trt_convert.py#L100-L110

From official documentation API instruction,
https://docs.nvidia.com/deeplearning/frameworks/tf-trt-user-guide/index.html#int8-quantization

<br>

```precision_mode```
Default value is TrtPrecisionMode.FP32. This is one of TrtPrecisionMode.supported_precision_modes(), in other words, FP32, FP16 or INT8 (lowercase is also supported).

But INT8 calibration with ```precision_mode='int8'``` didn't work before.