### PR TITLE
[tf.data] graduate unique API from experimental to tf.data.Dataset

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -106,6 +106,8 @@
         and deprecating the experimental endpoint.
     *   Promoting `tf.data.experimental.take_while` API to
         `tf.data.Dataset.take_while` and deprecating the experimental endpoint.
+    *   Promoting `tf.data.experimental.unique` API to
+        `tf.data.Dataset.unique` and deprecating the experimental endpoint.    
     *   Added `stop_on_empty_dataset` parameter to `sample_from_datasets` and
         `choose_from_datasets`. Setting `stop_on_empty_dataset=True` will stop
         sampling if it encounters an empty dataset. This preserves the sampling

--- a/tensorflow/python/data/experimental/kernel_tests/BUILD
+++ b/tensorflow/python/data/experimental/kernel_tests/BUILD
@@ -647,22 +647,6 @@ tf_py_test(
 )
 
 tf_py_test(
-    name = "unique_test",
-    size = "small",
-    srcs = ["unique_test.py"],
-    deps = [
-        "//tensorflow/python:client_testlib",
-        "//tensorflow/python:dtypes",
-        "//tensorflow/python:errors",
-        "//tensorflow/python:util",
-        "//tensorflow/python/data/experimental/ops:unique",
-        "//tensorflow/python/data/kernel_tests:checkpoint_test_base",
-        "//tensorflow/python/data/kernel_tests:test_base",
-        "//tensorflow/python/data/ops:dataset_ops",
-    ],
-)
-
-tf_py_test(
     name = "variant_test",
     size = "small",
     srcs = ["variant_test.py"],

--- a/tensorflow/python/data/experimental/ops/BUILD
+++ b/tensorflow/python/data/experimental/ops/BUILD
@@ -410,11 +410,7 @@ py_library(
     ],
     srcs_version = "PY3",
     deps = [
-        "//tensorflow/python:dtypes",
-        "//tensorflow/python:experimental_dataset_ops_gen",
-        "//tensorflow/python/data/ops:dataset_ops",
-        "//tensorflow/python/data/util:nest",
-        "//tensorflow/python/data/util:sparse",
+       "//tensorflow/python:util",
     ],
 )
 

--- a/tensorflow/python/data/experimental/ops/BUILD
+++ b/tensorflow/python/data/experimental/ops/BUILD
@@ -410,7 +410,7 @@ py_library(
     ],
     srcs_version = "PY3",
     deps = [
-       "//tensorflow/python:util",
+        "//tensorflow/python:util",
     ],
 )
 

--- a/tensorflow/python/data/experimental/ops/unique.py
+++ b/tensorflow/python/data/experimental/ops/unique.py
@@ -17,12 +17,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from tensorflow.python.data.ops import dataset_ops
-from tensorflow.python.framework import dtypes
-from tensorflow.python.ops import gen_experimental_dataset_ops
+from tensorflow.python.util import deprecation
 from tensorflow.python.util.tf_export import tf_export
 
-
+@deprecation.deprecated(None, "Use `tf.data.Dataset.unique(...)")
 @tf_export("data.experimental.unique")
 def unique():
   """Creates a `Dataset` from another `Dataset`, discarding duplicates.
@@ -43,23 +41,6 @@ def unique():
   """
 
   def _apply_fn(dataset):
-    return _UniqueDataset(dataset)
+    return dataset.unique()
 
   return _apply_fn
-
-
-class _UniqueDataset(dataset_ops.UnaryUnchangedStructureDataset):
-  """A `Dataset` contains the unique elements from its input."""
-
-  def __init__(self, input_dataset):
-    """See `unique()` for details."""
-    self._input_dataset = input_dataset
-    if dataset_ops.get_legacy_output_types(input_dataset) not in (
-        dtypes.int32, dtypes.int64, dtypes.string):
-      raise TypeError(
-          "`tf.data.experimental.unique()` only supports inputs with a single "
-          "`tf.int32`, `tf.int64`, or `tf.string` component.")
-    variant_tensor = gen_experimental_dataset_ops.unique_dataset(
-        self._input_dataset._variant_tensor,  # pylint: disable=protected-access
-        **self._flat_structure)
-    super(_UniqueDataset, self).__init__(input_dataset, variant_tensor)

--- a/tensorflow/python/data/kernel_tests/BUILD
+++ b/tensorflow/python/data/kernel_tests/BUILD
@@ -1002,6 +1002,21 @@ tf_py_test(
 )
 
 tf_py_test(
+    name = "unique_test",
+    size = "small",
+    srcs = ["unique_test.py"],
+    deps = [
+        "//tensorflow/python:client_testlib",
+        "//tensorflow/python:dtypes",
+        "//tensorflow/python:errors",
+        "//tensorflow/python:util",
+        "//tensorflow/python/data/kernel_tests:checkpoint_test_base",
+        "//tensorflow/python/data/kernel_tests:test_base",
+        "//tensorflow/python/data/ops:dataset_ops",
+    ],
+)
+
+tf_py_test(
     name = "window_test",
     size = "small",
     srcs = ["window_test.py"],

--- a/tensorflow/python/data/kernel_tests/unique_test.py
+++ b/tensorflow/python/data/kernel_tests/unique_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Tests for `tf.data.experimental.unique()`."""
+"""Tests for `tf.data.Dataset.unique()`."""
 
 from __future__ import absolute_import
 from __future__ import division
@@ -20,7 +20,6 @@ from __future__ import print_function
 
 from absl.testing import parameterized
 
-from tensorflow.python.data.experimental.ops import unique
 from tensorflow.python.data.kernel_tests import checkpoint_test_base
 from tensorflow.python.data.kernel_tests import test_base
 from tensorflow.python.data.ops import dataset_ops
@@ -46,7 +45,7 @@ class UniqueTest(test_base.DatasetTestBase, parameterized.TestCase):
     # below; declare it here so that the generator can capture it once.
     current_test_case = []
     dataset = dataset_ops.Dataset.from_generator(lambda: current_test_case,
-                                                 dtype).apply(unique.unique())
+                                                 dtype).unique()
 
     for test_case, expected in test_cases:
       current_test_case = test_case
@@ -92,7 +91,7 @@ class UniqueTest(test_base.DatasetTestBase, parameterized.TestCase):
     ]:
       with self.assertRaises(TypeError):
         _ = dataset_ops.Dataset.from_generator(lambda: [],
-                                               dtype).apply(unique.unique())
+                                               dtype).unique()
 
 
 class UniqueCheckpointTest(checkpoint_test_base.CheckpointTestBase,
@@ -103,7 +102,7 @@ class UniqueCheckpointTest(checkpoint_test_base.CheckpointTestBase,
 
     def build_dataset(num_elements, unique_elem_range):
       return dataset_ops.Dataset.range(num_elements).map(
-          lambda x: x % unique_elem_range).apply(unique.unique())
+          lambda x: x % unique_elem_range).unique()
 
     self.run_core_tests(lambda: build_dataset(200, 100), 100)
 

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -2734,8 +2734,8 @@ name=None))
     >>> sorted(list(dataset.as_numpy_iterator()))
     [1, 2, 37]
 
-    NOTE: This transformation is only applicable on datasets with either
-      `tf.int32`, `tf.int64` or `tf.string` type elements.
+    NOTE: This transformation only supports datasets which fit into memory
+      and have elements of either `tf.int32`, `tf.int64` or `tf.string` type.
 
     Returns:
       A `Dataset`.

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -2734,8 +2734,8 @@ name=None))
     >>> sorted(list(dataset.as_numpy_iterator()))
     [1, 2, 37]
 
-    NOTE: This transformation only supports datasets which fit into memory
-      and have elements of either `tf.int32`, `tf.int64` or `tf.string` type.
+    Note: This transformation only supports datasets which fit into memory
+    and have elements of either `tf.int32`, `tf.int64` or `tf.string` type.
 
     Returns:
       A `Dataset`.

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -2733,7 +2733,6 @@ name=None))
     >>> dataset = dataset.unique()
     >>> sorted(list(dataset.as_numpy_iterator()))
     [1, 2, 37]
-    ```
 
     NOTE: This transformation is only applicable on datasets with either
       `tf.int32`, `tf.int64` or `tf.string` type elements.

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -2723,6 +2723,27 @@ name=None))
 
     return _TakeWhileDataset(self, predicate)
 
+  def unique(self):
+    """A transformation that discards duplicate elements of a `Dataset`.
+
+    Use this transformation to produce a dataset that contains one instance of
+    each unique element in the input. For example:
+
+    >>> dataset = tf.data.Dataset.from_tensor_slices([1, 37, 2, 37, 2, 1])
+    >>> dataset = dataset.unique()
+    >>> sorted(list(dataset.as_numpy_iterator()))
+    [1, 2, 37]
+    ```
+
+    NOTE: This transformation is only applicable on datasets with either
+      `tf.int32`, `tf.int64` or `tf.string` type elements.
+
+    Returns:
+      A `Dataset`.
+    """
+
+    return _UniqueDataset(self)
+
 
 @tf_export(v1=["data.Dataset"])
 class DatasetV1(DatasetV2):
@@ -5261,6 +5282,21 @@ class _TakeWhileDataset(UnaryUnchangedStructureDataset):
   def _transformation_name(self):
     return "Dataset.take_while()"
 
+class _UniqueDataset(UnaryUnchangedStructureDataset):
+  """A `Dataset` contains the unique elements from its input."""
+
+  def __init__(self, input_dataset):
+    """See `unique()` for details."""
+    self._input_dataset = input_dataset
+    if get_legacy_output_types(input_dataset) not in (
+        dtypes.int32, dtypes.int64, dtypes.string):
+      raise TypeError(
+          "`tf.data.Dataset.unique()` only supports inputs with a single "
+          "`tf.int32`, `tf.int64`, or `tf.string` component.")
+    variant_tensor = ged_ops.unique_dataset(
+        self._input_dataset._variant_tensor,  # pylint: disable=protected-access
+        **self._flat_structure)
+    super(_UniqueDataset, self).__init__(input_dataset, variant_tensor)
 
 def _collect_resource_inputs(op):
   """Collects resource inputs for the given ops (and its variant inputs)."""

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-dataset.pbtxt
@@ -172,6 +172,10 @@ tf_class {
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "unique"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "window"
     argspec: "args=[\'self\', \'size\', \'shift\', \'stride\', \'drop_remainder\'], varargs=None, keywords=None, defaults=[\'None\', \'1\', \'False\'], "
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-fixed-length-record-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-fixed-length-record-dataset.pbtxt
@@ -174,6 +174,10 @@ tf_class {
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "unique"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "window"
     argspec: "args=[\'self\', \'size\', \'shift\', \'stride\', \'drop_remainder\'], varargs=None, keywords=None, defaults=[\'None\', \'1\', \'False\'], "
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-t-f-record-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-t-f-record-dataset.pbtxt
@@ -174,6 +174,10 @@ tf_class {
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "unique"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "window"
     argspec: "args=[\'self\', \'size\', \'shift\', \'stride\', \'drop_remainder\'], varargs=None, keywords=None, defaults=[\'None\', \'1\', \'False\'], "
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-text-line-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-text-line-dataset.pbtxt
@@ -174,6 +174,10 @@ tf_class {
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "unique"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "window"
     argspec: "args=[\'self\', \'size\', \'shift\', \'stride\', \'drop_remainder\'], varargs=None, keywords=None, defaults=[\'None\', \'1\', \'False\'], "
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-csv-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-csv-dataset.pbtxt
@@ -174,6 +174,10 @@ tf_class {
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "unique"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "window"
     argspec: "args=[\'self\', \'size\', \'shift\', \'stride\', \'drop_remainder\'], varargs=None, keywords=None, defaults=[\'None\', \'1\', \'False\'], "
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-random-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-random-dataset.pbtxt
@@ -174,6 +174,10 @@ tf_class {
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "unique"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "window"
     argspec: "args=[\'self\', \'size\', \'shift\', \'stride\', \'drop_remainder\'], varargs=None, keywords=None, defaults=[\'None\', \'1\', \'False\'], "
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-sql-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-sql-dataset.pbtxt
@@ -174,6 +174,10 @@ tf_class {
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "unique"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "window"
     argspec: "args=[\'self\', \'size\', \'shift\', \'stride\', \'drop_remainder\'], varargs=None, keywords=None, defaults=[\'None\', \'1\', \'False\'], "
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-dataset.pbtxt
@@ -139,6 +139,10 @@ tf_class {
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "unique"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "window"
     argspec: "args=[\'self\', \'size\', \'shift\', \'stride\', \'drop_remainder\'], varargs=None, keywords=None, defaults=[\'None\', \'1\', \'False\'], "
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-fixed-length-record-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-fixed-length-record-dataset.pbtxt
@@ -141,6 +141,10 @@ tf_class {
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "unique"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "window"
     argspec: "args=[\'self\', \'size\', \'shift\', \'stride\', \'drop_remainder\'], varargs=None, keywords=None, defaults=[\'None\', \'1\', \'False\'], "
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-t-f-record-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-t-f-record-dataset.pbtxt
@@ -140,6 +140,10 @@ tf_class {
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "unique"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "window"
     argspec: "args=[\'self\', \'size\', \'shift\', \'stride\', \'drop_remainder\'], varargs=None, keywords=None, defaults=[\'None\', \'1\', \'False\'], "
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-text-line-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-text-line-dataset.pbtxt
@@ -141,6 +141,10 @@ tf_class {
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "unique"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "window"
     argspec: "args=[\'self\', \'size\', \'shift\', \'stride\', \'drop_remainder\'], varargs=None, keywords=None, defaults=[\'None\', \'1\', \'False\'], "
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-csv-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-csv-dataset.pbtxt
@@ -141,6 +141,10 @@ tf_class {
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "unique"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "window"
     argspec: "args=[\'self\', \'size\', \'shift\', \'stride\', \'drop_remainder\'], varargs=None, keywords=None, defaults=[\'None\', \'1\', \'False\'], "
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-random-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-random-dataset.pbtxt
@@ -142,6 +142,10 @@ tf_class {
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "unique"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "window"
     argspec: "args=[\'self\', \'size\', \'shift\', \'stride\', \'drop_remainder\'], varargs=None, keywords=None, defaults=[\'None\', \'1\', \'False\'], "
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-sql-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-sql-dataset.pbtxt
@@ -141,6 +141,10 @@ tf_class {
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "unique"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+  }
+  member_method {
     name: "window"
     argspec: "args=[\'self\', \'size\', \'shift\', \'stride\', \'drop_remainder\'], varargs=None, keywords=None, defaults=[\'None\', \'1\', \'False\'], "
   }


### PR DESCRIPTION
This PR graduates the `tf.data.experimental.unique` API into `tf.data.Dataset.unique` by making the following changes:

- [x] Adds the deprecation decorator for the experimental API.
- [x] Add the `unique()` method to `DatasetV2` class.
- [x] Update example in docstring with new API.
- [x] Regenerate golden API's.
- [x] Moved and updated the `unique_test` target from `experimental/kernel_tests` to `kernel_tests`
- [x] Updated the RELEASE.md file

TEST LOG
```
INFO: Elapsed time: 28.062s, Critical Path: 23.53s
INFO: 354 processes: 133 internal, 221 local.
INFO: Build completed successfully, 354 total actions
//tensorflow/python/data/kernel_tests:unique_test                        PASSED in 3.9s

INFO: Build completed successfully, 354 total actions
```

cc: @jsimsa @aaudiber 