### PR TITLE
Change profiler dir to non-temporary in Keras TensorBoard callback

### DIFF
--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -2465,7 +2465,7 @@ class TensorBoard(Callback, version_utils.TensorBoardVersionSelector):
 
   def _start_trace(self):
     summary_ops_v2.trace_on(graph=True, profiler=False)
-    self._start_profiler(logdir=self._train_dir)
+    self._start_profiler(logdir=self.log_dir)
     self._is_tracing = True
 
   def _stop_trace(self, batch=None):


### PR DESCRIPTION
This is to fix the issue https://github.com/tensorflow/tensorflow/issues/49852.
Without the fix, the profiler dir will always be deleted for non-chief node under MWMS mode when Keras TensorBoard callback(https://www.tensorflow.org/api_docs/python/tf/keras/callbacks/TensorBoard) is used.
