### PR TITLE
Updated LSTM Cell inputs description to 3D tensor

### DIFF
--- a/tensorflow/python/keras/layers/recurrent_v2.py
+++ b/tensorflow/python/keras/layers/recurrent_v2.py
@@ -903,7 +903,7 @@ class LSTMCell(recurrent.LSTMCell):
       the linear transformation of the recurrent state. Default: 0.
 
   Call arguments:
-    inputs: A 2D tensor, with shape of `[batch, feature]`.
+    inputs: A 3D tensor with shape `[batch, timesteps, feature]`.
     states: List of 2 tensors that corresponding to the cell's units. Both of
       them have shape `[batch, units]`, the first tensor is the memory state
       from previous time step, the second tensor is the carry state from


### PR DESCRIPTION
Actually the LSTM Cell takes a 3D tensor as input as we can see on line number 801 but the description at line number 860 mentions that the input should be a 2D tensor which is incorrect. The LSTM cell gives error with 2D tensor input. Hence modified the description as 3D tensor.  