### PR TITLE
[tflite] make tflite related stuff build again on non-NNAPI platform

### DIFF
--- a/tensorflow/lite/nnapi/nnapi_implementation_disabled.cc
+++ b/tensorflow/lite/nnapi/nnapi_implementation_disabled.cc
@@ -18,3 +18,10 @@ const NnApi* NnApiImplementation() {
   static const NnApi nnapi = {};
   return &nnapi;
 }
+
+std::unique_ptr<const NnApi> CreateNnApiFromSupportLibrary(
+    const NnApiSLDriverImplFL5* nnapi_support_library_driver) {
+  auto nnapi = std::make_unique<NnApi>();
+  nnapi->nnapi_exists = false;
+  return nnapi;
+}


### PR DESCRIPTION
The NNAPI SL patch 4b949de introduced using of `CreateNnApiFromSupportLibrary(NnApiSLDriverImplFL5 const*)` which caused a problem.

When running `bazel build --config opt tensorflow/lite/tools/benchmark:benchmark_model` on macOS,  I got:
```
Undefined symbols for architecture x86_64:
  "CreateNnApiFromSupportLibrary(NnApiSLDriverImplFL5 const*)", referenced from:
      tflite::StatefulNnApiDelegate::StatefulNnApiDelegate(NnApiSLDriverImplFL5 const*, tflite::StatefulNnApiDelegate::Options) in libnnapi_delegate.a(nnapi_delegate.o)
      tflite::StatefulNnApiDelegate::StatefulNnApiDelegate(NnApiSLDriverImplFL5 const*, tflite::StatefulNnApiDelegate::Options) in libnnapi_delegate.a(nnapi_delegate.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

To fix this, I created a simple dummy function

