### PR TITLE
[MLIR][DISC] Add initial version of LhloLegalizeRootsToParallelLoops and InputInlineFusion

### DIFF
--- a/tensorflow/compiler/mlir/hlo/BUILD
+++ b/tensorflow/compiler/mlir/hlo/BUILD
@@ -437,6 +437,41 @@ cc_library(
     alwayslink = 1,
 )
 
+gentbl_cc_library(
+    name = "lhlo_structured_interface_gen",
+    compatible_with = get_compatible_with_cloud(),
+    tbl_outs = [
+        (
+            ["-gen-op-interface-decls"],
+            "include/mlir-hlo/Dialect/mhlo/IR/lhlo_structured_interface.h.inc",
+        ),
+        (
+            ["-gen-op-interface-defs"],
+            "include/mlir-hlo/Dialect/mhlo/IR/lhlo_structured_interface.cpp.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "include/mlir-hlo/Dialect/mhlo/IR/lhlo_structured_interface.td",
+    deps = [":hlo_ops_td_files"],
+)
+
+cc_library(
+    name = "lhlo_structured_interface",
+    srcs = [
+        "lib/Dialect/mhlo/IR/lhlo_structured_interface.cc",
+    ],
+    hdrs = [
+        "include/mlir-hlo/Dialect/mhlo/IR/lhlo_structured_interface.h",
+        "include/mlir-hlo/Dialect/mhlo/IR/lhlo_structured_interface.h.inc",
+    ],
+    includes = ["include"],
+    deps = [
+        ":lhlo_structured_interface_gen",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
 cc_library(
     name = "hlo_ops_base_structs",
     srcs = [
@@ -546,6 +581,7 @@ cc_library(
         ":hlo_ops_common",
         ":lhlo_ops_inc_gen",
         ":lhlo_ops_structs_inc_gen",
+        ":lhlo_structured_interface",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:ControlFlowInterfaces",
@@ -839,6 +875,118 @@ cc_library(
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LinalgOps",
+        "@llvm-project//mlir:MemRefDialect",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:SCFDialect",
+        "@llvm-project//mlir:StandardOps",
+        "@llvm-project//mlir:Transforms",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "codegen_utils",
+    srcs = ["lib/utils/codegen_utils.cc"],
+    hdrs = ["include/mlir-hlo/utils/codegen_utils.h"],
+    includes = ["include"],
+    deps = [
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LLVMDialect",
+        "@llvm-project//mlir:MemRefDialect",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:StandardOps",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
+cc_library(
+    name = "placement_utils",
+    hdrs = ["include/mlir-hlo/utils/placement_utils.h"],
+    includes = ["include"],
+    deps = [
+        "@llvm-project//mlir:Support",
+    ],
+)
+
+cc_library(
+    name = "lhlo_elemental_utils",
+    srcs = ["lib/Dialect/mhlo/transforms/lhlo_elemental_utils.cc"],
+    hdrs = ["include/mlir-hlo/Dialect/mhlo/transforms/lhlo_elemental_utils.h"],
+    deps = [
+        ":codegen_utils",
+        ":hlo",
+        ":lhlo",
+        ":map_lmhlo_to_scalar_op",
+        "@com_google_absl//absl/memory",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:GPUDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:MemRefDialect",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:SCFDialect",
+        "@llvm-project//mlir:StandardOps",
+        "@llvm-project//mlir:Transforms",
+    ],
+)
+
+cc_library(
+    name = "fusion_utils",
+    srcs = ["lib/Dialect/mhlo/transforms/fusion_utils.cc"],
+    hdrs = ["include/mlir-hlo/Dialect/mhlo/transforms/fusion_utils.h"],
+    deps = [
+        ":lhlo",
+        "@llvm-project//llvm:Core",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Shape",
+        "@llvm-project//mlir:StandardOps",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
+cc_library(
+    name = "disc_supported_list",
+    includes = ["disc_supported_list.h.inc"],
+)
+
+cc_library(
+    name = "lhlo_legalize_roots_to_loops",
+    srcs = ["lib/Dialect/mhlo/transforms/lhlo_legalize_roots_to_loops.cc"],
+    deps = [
+        ":LmhloPassIncGen",
+        ":codegen_utils",
+        ":disc_supported_list",
+        ":fusion_utils",
+        ":hlo",
+        ":lhlo",
+        ":lhlo_elemental_utils",
+        ":map_lmhlo_to_scalar_op",
+        ":placement_utils",
+        "@com_google_absl//absl/memory",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:MemRefDialect",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:SCFDialect",
+        "@llvm-project//mlir:StandardOps",
+        "@llvm-project//mlir:Transforms",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "input_inline_fusion",
+    srcs = ["lib/Dialect/mhlo/transforms/input_inline_fusion_pass.cc"],
+    deps = [
+        ":LmhloPassIncGen",
+        ":disc_supported_list",
+        ":hlo",
+        ":lhlo",
+        ":lhlo_elemental_utils",
+        ":map_lmhlo_to_scalar_op",
+        "@com_google_absl//absl/memory",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
         "@llvm-project//mlir:MemRefDialect",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:SCFDialect",
@@ -1288,22 +1436,6 @@ cc_library(
 )
 
 cc_library(
-    name = "fusion_utils",
-    srcs = ["lib/Dialect/mhlo/transforms/fusion_utils.cc"],
-    hdrs = ["include/mlir-hlo/Dialect/mhlo/transforms/fusion_utils.h"],
-    deps = [
-        ":lhlo",
-        "@llvm-project//llvm:Core",
-        "@llvm-project//llvm:Support",
-        "@llvm-project//mlir:IR",
-        "@llvm-project//mlir:Shape",
-        "@llvm-project//mlir:StandardOps",
-        "@llvm-project//mlir:Support",
-    ],
-    alwayslink = 1,
-)
-
-cc_library(
     name = "lhlo_fusion",
     srcs = ["lib/Dialect/mhlo/transforms/lhlo_fusion.cc"],
     deps = [
@@ -1436,6 +1568,7 @@ cc_library(
         ":chlo_legalize_to_hlo",
         ":hlo_legalize_to_lhlo",
         ":hlo_legalize_to_memref",
+        ":input_inline_fusion",
         ":legalize_control_flow",
         ":legalize_einsum_to_dot_general",
         ":legalize_gather_to_torch_index_select",
@@ -1447,6 +1580,7 @@ cc_library(
         ":lhlo_fuse_linalg",
         ":lhlo_fusion",
         ":lhlo_fusion_inliner",
+        ":lhlo_legalize_roots_to_loops",
         ":lhlo_legalize_to_affine",
         ":lhlo_legalize_to_gpu",
         ":lhlo_legalize_to_parallel_loops",

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/CMakeLists.txt
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/CMakeLists.txt
@@ -55,6 +55,7 @@ add_mlir_hlo_dialect_separate_files(lhlo_ops NO)
 add_mlir_hlo_dialect_separate_files(lhlo_gpu_ops YES)
 
 add_mlir_interface(infer_fusibility_op_interface)
+add_mlir_interface(lhlo_structured_interface)
 
 function(add_disc_ral_dialect dialect)
   set(LLVM_TARGET_DEFINITIONS ${dialect}.td)

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/lhlo_ops.h
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/lhlo_ops.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include "llvm/ADT/StringRef.h"
 #include "mlir-hlo/Dialect/mhlo/IR/hlo_ops_base_structs.h"
 #include "mlir-hlo/Dialect/mhlo/IR/lhlo_ops_structs.h"
+#include "mlir-hlo/Dialect/mhlo/IR/lhlo_structured_interface.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/Attributes.h"

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/lhlo_ops.td
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/lhlo_ops.td
@@ -43,6 +43,7 @@ include "mlir/Interfaces/ViewLikeInterface.td"
 include "mlir-hlo/Dialect/mhlo/IR/lhlo_dialect.td"
 include "mlir-hlo/Dialect/mhlo/IR/lhlo_ops_base.td"
 include "mlir-hlo/Dialect/mhlo/IR/lhlo_ops_structs.td"
+include "mlir-hlo/Dialect/mhlo/IR/lhlo_structured_interface.td"
 
 //===----------------------------------------------------------------------===//
 // LMHLO nullary op definitions.
@@ -50,7 +51,8 @@ include "mlir-hlo/Dialect/mhlo/IR/lhlo_ops_structs.td"
 
 class LHLO_Op<string mnemonic, list<OpTrait> traits> :
   Op<LHLO_Dialect, mnemonic,
-    !listconcat([MemoryEffects<[MemRead, MemWrite]>], traits)>;
+    !listconcat([MemoryEffects<[MemRead, MemWrite]>,
+    LmhloStructuredInterface], traits)>;
 
 def LHLO_ConstOp : LHLO_Op<"constant", []> {
   let summary = "Constant operator";
@@ -81,7 +83,7 @@ def LHLO_IotaOp : LHLO_Op<"iota", []> {
 
 class LHLO_UnaryElementwiseOp<string mnemonic,
                               Type BufferType = LHLO_Buffer,
-                              list<OpTrait> traits = [SameTypeOperands]>
+                              list<OpTrait> traits = [SameTypeOperands, Elementwise]>
     : LHLO_Op<mnemonic, traits> {
   let arguments = (ins Arg<BufferType, "", [MemRead]>:$input,
                        Arg<BufferType, "", [MemWrite]>:$output);
@@ -342,7 +344,7 @@ def LHLO_TanhOp: LHLO_UnaryElementwiseOp<"tanh", LHLO_FpOrComplexBuffer> {
 // See https://www.tensorflow.org/xla/operation_semantics#element-wise_binary_arithmetic_operations
 
 class LHLO_BinaryElementwiseOp<string mnemonic, Type BufferType = LHLO_Buffer,
-                               list<OpTrait> traits = [SameTypeOperands]> :
+                               list<OpTrait> traits = [SameTypeOperands, Elementwise]> :
         LHLO_Op<mnemonic, traits> {
   let arguments = (ins
       Arg<BufferType, "", [MemRead]>:$lhs,
@@ -954,7 +956,7 @@ def LHLO_ScatterOp: LHLO_Op<"scatter", []> {
   let regions = (region SizedRegion<1>:$update_computation);
 }
 
-def LHLO_SelectOp: LHLO_Op<"select", []> {
+def LHLO_SelectOp: LHLO_Op<"select", [Elementwise]> {
   let summary = "Select operator";
   let description = [{
     Constructs an output tensor from the elements of `on_true` and `on_false`

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/lhlo_structured_interface.h
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/lhlo_structured_interface.h
@@ -1,0 +1,24 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_COMPILER_MLIR_HLO_INCLUDE_MLIR_HLO_DIALECT_MHLO_IR_LHLO_STRUCTURED_INTERFACE_H_
+#define TENSORFLOW_COMPILER_MLIR_HLO_INCLUDE_MLIR_HLO_DIALECT_MHLO_IR_LHLO_STRUCTURED_INTERFACE_H_
+
+#include "mlir/IR/OpDefinition.h"
+
+/// Include the generated interface declarations.
+#include "mlir-hlo/Dialect/mhlo/IR/lhlo_structured_interface.h.inc"
+
+#endif  // TENSORFLOW_COMPILER_MLIR_HLO_INCLUDE_MLIR_HLO_DIALECT_MHLO_IR_LHLO_STRUCTURED_INTERFACE_H_

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/lhlo_structured_interface.td
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/lhlo_structured_interface.td
@@ -1,0 +1,47 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// This file contains LmhloStructuredInterface, which provides access to 'LmhloOp'
+// interface.
+
+#ifndef MLIR_LMHLO_STRUCTURED_INTERFACE
+#define MLIR_LMHLO_STRUCTURED_INTERFACE
+
+include "mlir/IR/OpBase.td"
+
+def LmhloStructuredInterface : OpInterface<"LmhloOp"> {
+  let cppNamespace = "::mlir::lmhlo";
+
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/[{Return the operand that is the output buffer
+      }],
+      /*retTy=*/"Value",
+      /*methodName=*/"getResultBuffer",
+      /*args=*/(ins),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        /// By default, the result buffer is the last operand 
+        unsigned num_operands = this->getOperation()->getNumOperands();
+        if (num_operands > 1) {
+          return this->getOperation()->getOperand(num_operands - 1);
+        }
+        return nullptr;
+      }]
+    >,
+  ];
+}
+
+#endif // MLIR_LMHLO_STRUCTURED_INTERFACE

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/transforms/PassDetail.h
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/transforms/PassDetail.h
@@ -19,6 +19,13 @@ limitations under the License.
 #include "mlir/Pass/Pass.h"
 
 namespace mlir {
+namespace scf {
+class SCFDialect;
+}
+namespace memref {
+class MemRefDialect;
+}
+
 namespace mhlo {
 
 #define GEN_PASS_CLASSES

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/transforms/fusion_utils.h
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/transforms/fusion_utils.h
@@ -153,6 +153,10 @@ class FusionPattern {
   FusionValueList& getResults() { return results_; }
 
   // Returns values that are outputs of any lmhlo op in the fused pattern and
+  // have consumers outside the fusion pattern.
+  SmallVector<Operation*, 4>& getRootOps() { return root_ops_; }
+
+  // Returns values that are outputs of any lmhlo op in the fused pattern and
   // are only consumed by the lmhlo ops inside the fused pattern.
   FusionValueList& getInternalResults() { return internal_results_; }
 
@@ -180,6 +184,7 @@ class FusionPattern {
   FusionValueList operands_;
   FusionValueList results_;
   FusionValueList internal_results_;
+  SmallVector<Operation*, 4> root_ops_;
 };
 
 // Represents a list of disjoint fusion patterns for a block.
@@ -226,6 +231,14 @@ class ShapeConstraintAnalysis {
   bool HasSameNumElements(Value lhs, Value rhs) {
     return same_num_elements_impl_.isEquivalent(ValueWrapper(lhs),
                                                 ValueWrapper(rhs));
+  }
+
+  Value GetLeaderValueWithSameShape(Value val) const {
+    if (same_shape_impl_.findLeader(ValueWrapper(val)) ==
+        same_shape_impl_.member_end()) {
+      return nullptr;
+    }
+    return same_shape_impl_.getLeaderValue(ValueWrapper(val)).getValue();
   }
 
  private:

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/transforms/lhlo_elemental_utils.h
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/transforms/lhlo_elemental_utils.h
@@ -1,0 +1,74 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "mlir/IR/Builders.h"
+
+namespace mlir {
+
+class Value;
+class Location;
+class Operation;
+class ValueRange;
+class Region;
+class FuncOp;
+enum class AtomicRMWKind : uint64_t;
+
+namespace scf {
+class ForOp;
+class ParallelOp;
+}  // namespace scf
+
+namespace memref {
+class LoadOp;
+}
+
+namespace lmhlo {
+
+// Check if a loaded value can be used, and create a load if not
+Value createLoadOrUseCachedValue(Location loc, OpBuilder* b, Value memref,
+                                 ValueRange indices,
+                                 OpBuilder::InsertPoint insert_point);
+
+// Remove the unused lmhlo ops inside block
+void cleanUnusedLhloOps(Block* block);
+
+// The building block to lower an lmhlo op inside the loops
+template <typename LHLO_OpTy>
+Value elementalLower(OpBuilder* b, Location loc, Operation* op,
+                     ValueRange output_index, bool check_cache = false);
+
+// Create a ForOp and set the insertion point to the body
+scf::ForOp createLoopAndSetInsPt(OpBuilder& b, Location loc, Value& var,
+                                 Value lb, Value ub, Value step,
+                                 ArrayRef<Value> init_values = {});
+
+// Create a ParallelOp and set the insertion point to the body
+scf::ParallelOp createParallelAndSetInsPt(OpBuilder& b, Location loc,
+                                          SmallVectorImpl<Value>& vars,
+                                          ArrayRef<Value> lbs,
+                                          ArrayRef<Value> ubs,
+                                          ArrayRef<Value> steps,
+                                          ArrayRef<Value> init_values);
+
+// Create store with a linear index to a multidim memref
+void createOffsetStore(OpBuilder& b, Location loc, Value res, Value memref,
+                       Value offset);
+
+// Create load with a linear index to a multidim memref
+memref::LoadOp createOffsetLoad(OpBuilder& b, Location loc, Value memref,
+                                Value offset);
+
+}  // namespace lmhlo
+}  // namespace mlir

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/transforms/lmhlo_passes.td
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/transforms/lmhlo_passes.td
@@ -70,3 +70,22 @@ def LhloFusionInlinerPass : FunctionPass<"lhlo-fusion-inliner"> {
     "after its body has been lowered";
   let constructor = "createLhloFusionInlinerPass()";
 }
+
+def LhloLegalizeRootsToParallelLoopsPass : FunctionPass<"lhlo-legalize-roots-to-parallel-loops"> {
+  let summary = "Legalize the roots of lmhlo.fusion to parallel loops.";
+  let constructor = "createLhloLegalizeRootsToParallelLoopsPass()";
+  let dependentDialects = [
+    "scf::SCFDialect",
+    "memref::MemRefDialect"
+  ];
+}
+
+def InputInlineFusionPass : FunctionPass<"input-inline-fusion"> {
+  let summary = "Fuse the rest of the lmhlo nodes into the parallel loops after the roots "
+    "has been expanded into loops in LhloLegalizeRootsToParallelLoops";
+  let constructor = "createInputInlineFusionPass()";
+  let dependentDialects = [
+    "scf::SCFDialect",
+    "memref::MemRefDialect"
+  ];
+}

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/transforms/passes.h
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/transforms/passes.h
@@ -29,6 +29,9 @@ class Operation;
 template <typename T>
 class OperationPass;
 class Pass;
+namespace lmhlo {
+class FusionOp;
+}
 
 namespace mhlo {
 
@@ -127,6 +130,13 @@ std::unique_ptr<OperationPass<FuncOp>> createLhloFusionPass(
 
 // inline lmhlo.Fusion
 std::unique_ptr<OperationPass<FuncOp>> createLhloFusionInlinerPass();
+
+// Lowers the roots of lmhlo.fusion to parallel loops
+std::unique_ptr<OperationPass<FuncOp>>
+createLhloLegalizeRootsToParallelLoopsPass();
+
+// Input inline fusion pass for fusion codegen
+std::unique_ptr<OperationPass<lmhlo::FusionOp>> createInputInlineFusionPass();
 
 }  // namespace lmhlo
 

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/utils/codegen_utils.h
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/utils/codegen_utils.h
@@ -1,0 +1,63 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/MLIRContext.h"  // TF:llvm-project
+
+#ifndef TENSORFLOW_COMPILER_MLIR_HLO_INCLUDE_MLIR_HLO_UTILS_CODEGEN_UTILS_H_
+#define TENSORFLOW_COMPILER_MLIR_HLO_INCLUDE_MLIR_HLO_UTILS_CODEGEN_UTILS_H_
+
+namespace mlir {
+class Value;
+class ValueRange;
+class OpBuilder;
+class Location;
+class Operation;
+namespace codegen_utils {
+
+Value calcNumElements(OpBuilder& b, Location loc, Operation* op);
+Value calcNumElements(OpBuilder& b, Location loc, Value memref);
+
+Value calcNumElementsForFirstOperand(OpBuilder& b, Location loc, Operation* op);
+
+llvm::SmallVector<Value, 4> calcMultiDimIndex(OpBuilder& b, Location loc,
+                                              Value linear_index,
+                                              Operation* op);
+
+llvm::SmallVector<Value, 4> calcMultiDimIndex(OpBuilder& b, Location loc,
+                                              Value linear_index, Value memref);
+
+llvm::SmallVector<Value, 4> calcMultiDimIndex(OpBuilder& b, Location loc,
+                                              Value linear_index,
+                                              llvm::ArrayRef<Value> shape);
+
+llvm::SmallVector<Value, 4> calcMultiDimIndexForFirstOperand(OpBuilder& b,
+                                                             Location loc,
+                                                             Value linear_index,
+                                                             Operation* op);
+
+Value calcLinearIndex(OpBuilder& b, Location loc,
+                      llvm::ArrayRef<Value> multi_index, Operation* op);
+
+Value calcLinearIndex(OpBuilder& b, Location loc,
+                      llvm::ArrayRef<Value> multi_index,
+                      llvm::ArrayRef<Value> shape);
+
+}  // namespace codegen_utils
+}  // namespace mlir
+
+#endif  // TENSORFLOW_COMPILER_MLIR_HLO_INCLUDE_MLIR_HLO_UTILS_CODEGEN_UTILS_H_

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/utils/disc_supported_list.h.inc
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/utils/disc_supported_list.h.inc
@@ -1,0 +1,27 @@
+#ifdef GET_SUPPORTED_OP_LIST
+#undef GET_SUPPORTED_OP_LIST
+
+// clang-format off
+
+// Unary Elementwise Ops
+lmhlo::AbsOp, lmhlo::CeilOp, lmhlo::FloorOp, lmhlo::ConvertOp, lmhlo::CosOp,
+lmhlo::ExpOp, lmhlo::LogOp, lmhlo::NegOp, lmhlo::RsqrtOp, lmhlo::SqrtOp,
+lmhlo::SignOp, lmhlo::TanhOp,
+
+// Binary Elementwise Ops
+lmhlo::AddOp, lmhlo::DivOp, lmhlo::MaxOp, lmhlo::MinOp, lmhlo::MulOp,
+lmhlo::RemOp, lmhlo::SubOp, lmhlo::AndOp, lmhlo::OrOp, lmhlo::CompareOp,
+lmhlo::PowOp,
+
+// Ternary Elementwise Ops
+lmhlo::SelectOp,
+
+// Other Ops
+lmhlo::ConstOp,
+lmhlo::RealDynamicSliceOp,
+lmhlo::DynamicBroadcastInDimOp,
+lmhlo::BroadcastInDimOp
+
+// clang-format on
+
+#endif

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/utils/placement_utils.h
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/utils/placement_utils.h
@@ -1,0 +1,30 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "llvm/ADT/StringRef.h"
+
+#ifndef TENSORFLOW_COMPILER_MLIR_HLO_INCLUDE_MLIR_HLO_UTILS_PLACEMENT_UTIL_H_
+#define TENSORFLOW_COMPILER_MLIR_HLO_INCLUDE_MLIR_HLO_UTILS_PLACEMENT_UTIL_H_
+
+namespace mlir {
+namespace placement_utils {
+
+constexpr llvm::StringRef c_cpu = "cpu";
+constexpr llvm::StringRef c_gpu = "gpu";
+
+}  // namespace placement_utils
+}  // namespace mlir
+
+#endif  // TENSORFLOW_COMPILER_MLIR_HLO_INCLUDE_MLIR_HLO_UTILS_PLACEMENT_UTIL_H_

--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/IR/CMakeLists.txt
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/IR/CMakeLists.txt
@@ -40,6 +40,14 @@ add_mlir_library(MhloInferFusibilityOpInterface
   MLIRinfer_fusibility_op_interfaceIncGen
 )
 
+add_mlir_library(LmhloStructuredInterface
+  lhlo_structured_interface.cc
+
+  DEPENDS
+  MLIRlhlo_structured_interfaceIncGen
+)
+
+
 add_mlir_library(HloOpsCommon
   hlo_ops_common.cc
 )
@@ -71,10 +79,12 @@ add_mlir_dialect_library(LmhloDialect
   DEPENDS
   MLIRlhlo_opsIncGen
 )
+
 target_link_libraries(LmhloDialect
   PUBLIC
   MLIRIR
   HloOpsCommon
+  LmhloStructuredInterface
 )
 
 add_mlir_dialect_library(LmhloGPUDialect

--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/IR/lhlo_structured_interface.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/IR/lhlo_structured_interface.cc
@@ -1,0 +1,24 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "mlir-hlo/Dialect/mhlo/IR/lhlo_structured_interface.h"
+
+namespace mlir {
+namespace lmhlo {
+
+#include "mlir-hlo/Dialect/mhlo/IR/lhlo_structured_interface.cpp.inc"
+
+}  // namespace lmhlo
+}  // namespace mlir

--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/CMakeLists.txt
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/CMakeLists.txt
@@ -170,10 +170,13 @@ add_mlir_library(MhloLhloToLinalg
 
 add_mlir_library(LmhloPasses
   fusion_utils.cc
+  input_inline_fusion_pass.cc
   legalize_tensor_load_op.cc
+  lhlo_elemental_utils.cc
   lhlo_fuse_linalg.cc
   lhlo_fusion.cc
   lhlo_fusion_inliner.cc
+  lhlo_legalize_roots_to_loops.cc
   lhlo_legalize_to_affine.cc
   lhlo_legalize_to_gpu.cc
   lhlo_legalize_to_parallel_loops.cc

--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/fusion_utils.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/fusion_utils.cc
@@ -29,6 +29,7 @@ namespace lmhlo {
 
 // Returns true if the op is an elementwise unary lmhlo op.
 // TODO(disc): use fusibility interface
+// TODO(disc): Unify with disc_supported_list.h and Elementwise Trait
 bool isElementWiseUnary(Operation* op) {
   // clang-format off
   return isa<
@@ -135,7 +136,7 @@ bool isFusible(Operation* op) {
 // For some ops (e.g. lmhlo ops), some operands are the output memrefs
 // Thus these operands are supposed to be updated.
 int getNumResultOperands(Operation* op) {
-  if (op->getDialect()->getNamespace() != "lmhlo") {
+  if (!isa<LmhloOp>(op)) {
     return 0;
   }
 
@@ -224,7 +225,7 @@ FusionPattern::FusionPattern(lmhlo::FusionOp op) {
         fusion_type_ = FusionType::kLoop;
         dominant_op_ = op;
       }
-    } else {
+    } else if (!isa<lmhlo::TerminatorOp>(op)) {
       // Not a supported fusionOp, early stop.
       fusion_type_ = FusionType::kNone;
       dominant_op_ = nullptr;
@@ -327,6 +328,7 @@ void FusionPattern::calculateOperandsAndResults() {
 
       if (has_external_user) {
         results_.push_back(v);
+        root_ops_.push_back(op);
       } else {
         internal_results_.push_back(v);
       }

--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/input_inline_fusion_pass.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/input_inline_fusion_pass.cc
@@ -1,0 +1,388 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// This file implements inline loop fusion.
+//
+#include <limits>
+
+#include "mlir-hlo/Dialect/mhlo/IR/lhlo_ops.h"
+#include "mlir-hlo/Dialect/mhlo/transforms/lhlo_elemental_utils.h"
+#include "mlir-hlo/Dialect/mhlo/transforms/map_lmhlo_to_scalar_op.h"
+#include "mlir/Analysis/LoopAnalysis.h"
+#include "mlir/Analysis/Utils.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/LoopFusionUtils.h"
+#include "mlir/Transforms/LoopUtils.h"
+#include "mlir/Transforms/Passes.h"
+#include "mlir/Transforms/Utils.h"
+
+using mlir::memref::LoadOp;
+
+namespace mlir {
+namespace lmhlo {
+
+#define GEN_PASS_CLASSES
+#include "mlir-hlo/Dialect/mhlo/transforms/lmhlo_passes.h.inc"
+
+namespace {
+
+// TODO(disc): Maybe it worth explicitly adding the I/O buffers onto the
+// outlining of lmhlo::FusionOp and then mark IsolatedFromAbove for
+// lmhlo::FusionOp. By this way the fusion codegen passes can be OperationPass
+// on lmhlo::FusionOp for better compilation overhead.
+class InputInlineFusion : public InputInlineFusionPassBase<InputInlineFusion> {
+  void runOnFunction() override;
+};
+
+}  // end anonymous namespace
+
+std::unique_ptr<FunctionPass> createInputInlineFusionPass() {
+  return std::make_unique<InputInlineFusion>();
+}
+
+namespace {
+
+constexpr unsigned c_MAX_ITERATION = 4096;
+
+// This pass works after LhloLegalizeRootsToParallelLoops pass for the
+// XLA-style fusion codegen. Refer to:
+// http://pai-blade.cn-hangzhou.oss.aliyun-inc.com/disc/fusion_codegen.png.
+//
+// It iteratively looks for the Lhlo op which is the direct producer of the
+// nested loops, and then inline fuse it if the fusion will not form a loop.
+//
+// The inline fusion action can be generalized as:
+// step 1: replace the producer Lhlo op into associate std op inside the nested
+// loops. step 2: remove the original Load ops inside the loops and insert new
+// Load ops.
+//
+// If there are multiple LoadOps with the same indices, they will be replaced
+// with the same op. This obtains the similar result as GeneratedValueCache.
+//
+// IRs after LhloLegalizeRootsToParallelLoops:
+//    "lmhlo.fusion"() ( {
+//       lmhlo.aaa(%0, %1, %2)
+//       lmhlo.bbb(%2, %3, %4)
+//       scf.parallel (...) {
+//          memref.load %4[...]
+//          ...
+//          memref.store ...
+//       }
+//    })
+//
+// IRs after one round of InputInlineFusionPattern:
+//    "lmhlo.fusion"() ( {
+//       lmhlo.aaa(%0, %1, %2)
+//       scf.parallel (...) {
+//          memref.load %2[...]
+//          ...
+//          memref.store ...
+//       }
+//    })
+//
+// Final IRs after this pass:
+//    "lmhlo.fusion"() ( {
+//       scf.parallel (...) {
+//          memref.load ...
+//          ...
+//          memref.store ...
+//       }
+//    })
+class InputInlineFusionPattern : public RewritePattern {
+ public:
+  explicit InputInlineFusionPattern(MLIRContext* context)
+      : RewritePattern(FusionOp::getOperationName(), 1, context) {}
+
+  LogicalResult matchAndRewrite(Operation* op,
+                                PatternRewriter& rewriter) const override {
+    // skip if not the most outter ParallelOp
+    auto fusion = cast<FusionOp>(op);
+    auto& parent_block = fusion.region().front();
+    SmallVector<scf::ParallelOp, 4> parallel_ops;
+    fusion.walk([&](scf::ParallelOp parallel_op) {
+      parallel_ops.push_back(parallel_op);
+    });
+    assert(parallel_ops.size() == 1 &&
+           "only one scf::ParallelOp is expected after "
+           "LhloLegalizeRootsToParallelLoops");
+    Operation* parallel_op = parallel_ops.front();
+    SmallVector<LoadOp, 4> load_ops;
+    parallel_op->walk([&](LoadOp load_op) { load_ops.push_back(load_op); });
+    for (auto load_op : load_ops) {
+      auto lhlo_op = getFusibleOperation(load_op);
+      if (lhlo_op != nullptr) {
+        // 1, in case of:
+        //      A = ...
+        //      B = op(A)
+        //      C = op(A, B)
+        //    C should fuse B first before fusing A.
+        //    This is the same logic as in instruction_fusion pass of XLA
+        //
+        // 2, When multiple loads consumes the same result of lhlo_op and
+        //    the load indices are also identical, the ir should be
+        //    emitted only once. Other LoadOps should used cached Value.
+
+        // 'load_ops' that can consume the same cached value
+        std::vector<Operation*> same_load_ops;
+        bool can_remove_producer;
+        if (!checkIfFusible(parallel_op, lhlo_op, load_op, can_remove_producer,
+                            same_load_ops)) {
+          continue;
+        }
+        // 'load_op' is always the one that locates in the most
+        // external code block among all the 'same_load_ops', because the walker
+        // is in the post order sequence.
+        if (!failed(inlineFuseLhloOp(rewriter, parallel_op, lhlo_op, load_op,
+                                     same_load_ops))) {
+          if (can_remove_producer) {
+            rewriter.eraseOp(lhlo_op);
+          }
+          for (auto* to_be_removed : same_load_ops) {
+            rewriter.eraseOp(to_be_removed);
+          }
+
+          // Clean all the ops that do not have LoadOps inside the nested
+          // ParallelOps and is not the ancestor of any ops that have LoadOps
+          // inside the nested ParallelOps.
+          cleanUnusedLhloOps(&parent_block);
+
+          return success();
+        } else {
+          assert(false && "inlineFuseLhloOp failed!");
+        }
+      }
+    }
+    return failure();
+  }
+
+ private:
+  Operation* getFusibleOperation(LoadOp load_op) const;
+  LogicalResult inlineFuseLhloOp(PatternRewriter& b, Operation* user,
+                                 Operation* producer, LoadOp load_op,
+                                 std::vector<Operation*> load_ops) const;
+  bool checkIfFusible(Operation* user, Operation* producer, LoadOp load_op,
+                      bool& can_remove_producer,
+                      std::vector<Operation*>& load_ops) const;
+};
+
+Operation* InputInlineFusionPattern::getFusibleOperation(LoadOp load_op) const {
+  Operation* lhlo_op = nullptr;
+  for (auto* user : load_op.getMemRef().getUsers()) {
+    if (isa<LmhloOp>(user) && (cast<LmhloOp>(user).getResultBuffer() ==
+                               load_op.getOperation()->getOperand(0))) {
+      if (lhlo_op == nullptr) {
+        lhlo_op = user;
+      } else {
+        assert(false &&
+               "More than one lhlo_op write to one Memref within one fusion");
+      }
+    }
+  }
+  return lhlo_op;
+}
+
+// Check if there are no other consumers of the producer
+// except the ParallelOp.
+bool InputInlineFusionPattern::checkIfFusible(
+    Operation* user, Operation* producer, LoadOp load_op,
+    bool& can_remove_producer, std::vector<Operation*>& load_ops) const {
+  assert(isa<scf::ParallelOp>(user) &&
+         "User is expected to be scf::ParallelOp");
+  load_ops.clear();
+  assert(isa<LmhloOp>(producer) && "Unexpected producer in checkIfFusible");
+  auto producer_result_memref = cast<LmhloOp>(producer).getResultBuffer();
+  can_remove_producer = true;
+  auto lhlo_dialect = user->getContext()->getLoadedDialect("lmhlo");
+  for (auto* memref_user : producer_result_memref.getUsers()) {
+    if ((memref_user->getDialect() == lhlo_dialect) &&
+        (memref_user != producer)) {
+      return false;
+    } else if (isa<LoadOp>(memref_user)) {
+      LoadOp other = cast<LoadOp>(memref_user);
+      if (other.getMemRef() == load_op.getMemRef() &&
+          other.getIndices() == load_op.getIndices()) {
+        // llvm::to_vector<4>(other.getIndices()) ==
+        // llvm::to_vector<4>(load_op.getIndices())) {
+        load_ops.emplace_back(memref_user);
+      } else {
+        can_remove_producer = false;
+      }
+      // TODO(disc):: check the memref_user is inside the loops
+    }
+  }
+  return true;
+}
+
+template <typename LHLO_OpTy>
+bool elemwiseFuseHelper(PatternRewriter& rewriter, Operation* user,
+                        Operation* producer, LoadOp load_op,
+                        std::vector<Operation*>& load_ops) {
+  if (!isa<LHLO_OpTy>(producer) ||
+      !LHLO_OpTy::template hasTrait<OpTrait::Elementwise>()) {
+    return false;
+  }
+  auto loc = user->getLoc();
+  SmallVector<Value, 4> operand_values;
+  unsigned num_operands = producer->getNumOperands();
+  for (unsigned i = 0; i < num_operands - 1; ++i) {
+    auto producer_operand = producer->getOperand(i);
+    rewriter.setInsertionPoint(load_op);
+    operand_values.push_back(
+        rewriter.create<LoadOp>(loc, producer_operand, load_op.getIndices()));
+  }
+  auto inlined_result =
+      HloOpToStdScalarOp::map<LHLO_OpTy>(llvm::cast<LHLO_OpTy>(producer),
+                                         cast<LmhloOp>(producer)
+                                             .getResultBuffer()
+                                             .getType()
+                                             .cast<MemRefType>()
+                                             .getElementType(),
+                                         operand_values, &rewriter);
+
+  for (auto* to_be_replaced : load_ops) {
+    llvm::cast<LoadOp>(to_be_replaced).replaceAllUsesWith(inlined_result);
+  }
+  return true;
+}
+
+template <typename LHLO_OpTy>
+bool miscFuseHelper(PatternRewriter& rewriter, Operation* user,
+                    Operation* producer, LoadOp load_op,
+                    std::vector<Operation*>& load_ops) {
+  if (!isa<LHLO_OpTy>(producer)) {
+    return false;
+  }
+  auto loc = user->getLoc();
+  rewriter.setInsertionPoint(load_op);
+  auto inlined_result =
+      elementalLower<LHLO_OpTy>(&rewriter, loc, producer, load_op.getIndices());
+  for (auto* to_be_replaced : load_ops) {
+    llvm::cast<LoadOp>(to_be_replaced).replaceAllUsesWith(inlined_result);
+  }
+  return true;
+}
+
+template <>
+bool miscFuseHelper<ConstOp>(PatternRewriter& rewriter, Operation* user,
+                             Operation* producer, LoadOp load_op,
+                             std::vector<Operation*>& load_ops) {
+  if (!isa<ConstOp>(producer)) {
+    return false;
+  }
+  auto memref_type =
+      cast<LmhloOp>(producer).getResultBuffer().getType().cast<MemRefType>();
+  auto rank = memref_type.getRank();
+  assert(rank == 0 && "only scalar ConstOp can be fused");
+  auto loc = user->getLoc();
+  rewriter.setInsertionPoint(load_op);
+  Value inlined_result =
+      rewriter.create<ConstantOp>(loc, memref_type.getElementType(),
+                                  cast<ConstOp>(producer).value().getValue({}));
+  for (auto* to_be_replaced : load_ops) {
+    llvm::cast<LoadOp>(to_be_replaced).replaceAllUsesWith(inlined_result);
+  }
+  return true;
+}
+
+template <typename First>
+bool elemwiseFuseHelperOr(PatternRewriter& rewriter, Operation* user,
+                          Operation* producer, LoadOp load_op,
+                          std::vector<Operation*>& load_ops) {
+  return elemwiseFuseHelper<First>(rewriter, user, producer, load_op, load_ops);
+}
+
+template <typename First, typename Second, typename... Rest>
+bool elemwiseFuseHelperOr(PatternRewriter& rewriter, Operation* user,
+                          Operation* producer, LoadOp load_op,
+                          std::vector<Operation*>& load_ops) {
+  return elemwiseFuseHelperOr<First>(rewriter, user, producer, load_op,
+                                     load_ops) ||
+         elemwiseFuseHelperOr<Second, Rest...>(rewriter, user, producer,
+                                               load_op, load_ops);
+}
+
+// load_op is among the load_ops, whose locates in the most
+// external code block
+LogicalResult InputInlineFusionPattern::inlineFuseLhloOp(
+    PatternRewriter& b, Operation* user, Operation* producer, LoadOp load_op,
+    std::vector<Operation*> load_ops) const {
+  if (elemwiseFuseHelperOr<
+#define GET_SUPPORTED_OP_LIST
+#include "mlir-hlo/utils/disc_supported_list.h.inc"
+          >(b, user, producer, load_op, load_ops) ||
+      // clang-format off
+      // TODO(disc): Upstream is on the way for more Ops
+      miscFuseHelper<RealDynamicSliceOp>(b, user, producer, load_op, load_ops) ||
+      miscFuseHelper<DynamicBroadcastInDimOp>(b, user, producer, load_op, load_ops) ||
+      miscFuseHelper<BroadcastInDimOp>(b, user, producer, load_op, load_ops) ||
+      miscFuseHelper<ConstOp>(b, user, producer, load_op, load_ops)) {
+    // clang-format on
+    return success();
+  } else {
+    assert(false && "unsupported lhlo_op");
+  }
+
+  return success();
+}
+
+void InputInlineFusion::runOnFunction() {
+  auto func = getFunction();
+  auto* context = &this->getContext();
+  OwningRewritePatternList patterns(context);
+  patterns.insert<InputInlineFusionPattern>(context);
+
+  // Just apply the patterns greedily.
+  // There should always be one scf.ParallelOp in the fusion.
+  auto config = GreedyRewriteConfig();
+  config.maxIterations = c_MAX_ITERATION;
+  if (failed(applyPatternsAndFoldGreedily(func, std::move(patterns), config))) {
+    signalPassFailure();
+  }
+
+  // there should be no lmhlo ops after inline fusion,
+  // except for the ConstOp of ColReduction, which for now cannot be
+  // properly optimized by general DCE pass
+  std::vector<Operation*> to_be_removed;
+  func.walk([&](FusionOp fusion) {
+    fusion.region().walk([&](LmhloOp op) {
+      if (isa<TerminatorOp>(op)) {
+        return;
+      }
+      if (isa<ConstOp>(op)) {
+        // TODO(disc): Check the ConstOp is from ReduceOp
+        to_be_removed.push_back(op);
+        return;
+      }
+      assert(false && "unexpected remaining lhlo_op");
+      signalPassFailure();
+    });
+  });
+  for (auto op : to_be_removed) {
+    op->erase();
+  }
+}
+
+}  // namespace
+
+}  // namespace lmhlo
+}  // namespace mlir

--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/lhlo_elemental_utils.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/lhlo_elemental_utils.cc
@@ -1,0 +1,299 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// This file provides basic utilities for the elemental lowering of
+// each node
+
+#include "mlir-hlo/Dialect/mhlo/transforms/lhlo_elemental_utils.h"
+
+#include "llvm/Support/Debug.h"
+#include "mlir-hlo/Dialect/mhlo/IR/lhlo_ops.h"
+#include "mlir-hlo/Dialect/mhlo/transforms/map_lmhlo_to_scalar_op.h"
+#include "mlir-hlo/utils/codegen_utils.h"
+#include "mlir/Dialect/GPU/GPUDialect.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/SCF.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+
+using mlir::memref::DimOp;
+using mlir::memref::LoadOp;
+using mlir::memref::StoreOp;
+
+namespace mlir {
+namespace lmhlo {
+
+Value createLoadOrUseCachedValue(Location loc, OpBuilder* b, Value memref,
+                                 ValueRange indices,
+                                 OpBuilder::InsertPoint insert_point) {
+  // Check if there are any cached value that can be reused,
+  // within the current Block. Alternatively we can do this for
+  // all the Blocks that dominant this Block, but that will be
+  // complicated anyway.
+  std::vector<StoreOp> store_ops;
+  insert_point.getBlock()->walk(
+      insert_point.getBlock()->begin(), insert_point.getPoint(),
+      [&](StoreOp store_op) {
+        if (store_op.getOperation()->getBlock() != insert_point.getBlock()) {
+          return;
+        }
+        if ((store_op.getMemRef() == memref) &&
+            (store_op.getIndices() == indices)) {
+          store_ops.emplace_back(store_op);
+        }
+      });
+  if (store_ops.size() > 0) {
+    return store_ops[0].getOperand(0);
+  }
+  auto rank = memref.getType().dyn_cast<MemRefType>().getRank();
+  return rank > 0 ? b->create<LoadOp>(loc, memref, indices)
+                  : b->create<LoadOp>(loc, memref);
+}
+
+DenseSet<Operation*> NoLoaderUser(SmallVectorImpl<Operation*>& ops) {
+  SmallVector<Operation*, 4> worklist;
+  DenseSet<Operation*> has_loader_ops;
+  for (auto op : ops) {
+    assert(isa<LmhloOp>(op));
+    Value memref = cast<LmhloOp>(op).getResultBuffer();
+    if (memref == nullptr) {
+      continue;
+    }
+    for (auto* user : memref.getUsers()) {
+      if (isa<memref::LoadOp>(user)) {
+        worklist.push_back(op);
+        has_loader_ops.insert(op);
+      }
+    }
+  }
+
+  while (!worklist.empty()) {
+    Operation* op = worklist.pop_back_val();
+    int num_operands = op->getNumOperands();
+    for (int i = 0; i < num_operands - 1; ++i) {
+      auto memref = op->getOperand(i);
+      for (auto* user : memref.getUsers()) {
+        if ((!isa<LmhloOp>(user)) || has_loader_ops.count(user)) {
+          continue;
+        }
+        if (cast<LmhloOp>(user).getResultBuffer() == memref) {
+          worklist.push_back(user);
+          has_loader_ops.insert(user);
+        }
+      }
+    }
+  }
+
+  DenseSet<Operation*> no_loader_ops;
+  for (auto op : ops) {
+    if (!has_loader_ops.count(op)) {
+      no_loader_ops.insert(op);
+    }
+  }
+  return no_loader_ops;
+}
+
+void cleanUnusedLhloOps(Block* parent) {
+  SmallVector<Operation*, 4> lhlo_ops;
+  for (Operation& op : parent->getOperations()) {
+    if (op.getDialect() == op.getContext()->getLoadedDialect("lmhlo") &&
+        (!isa<lmhlo::TerminatorOp>(op))) {
+      lhlo_ops.push_back(&op);
+    }
+  }
+  const DenseSet<Operation*>& no_loader_user = NoLoaderUser(lhlo_ops);
+  for (auto* lhlo_op : no_loader_user) {
+    lhlo_op->erase();
+  }
+};
+
+template <typename LHLO_OpTy>
+Value elementalLower(OpBuilder* b, Location loc, Operation* op,
+                     ValueRange output_index, bool check_cache) {
+  assert(false && "not implemented!");
+  return op->getResult(0);
+}
+
+template <>
+Value elementalLower<lmhlo::RealDynamicSliceOp>(OpBuilder* b, Location loc,
+                                                Operation* op,
+                                                ValueRange output_index,
+                                                bool check_cache) {
+  auto start_indices_memref = op->getOperand(1);
+  auto strides_memref = op->getOperand(3);
+  int rank = output_index.size();
+  SmallVector<Value, 4> input_index;
+  for (int dim = 0; dim < rank; ++dim) {
+    SmallVector<Value, 4> dim_index;
+    dim_index.push_back(b->create<ConstantOp>(
+        loc, b->getIndexType(), b->getIntegerAttr(b->getIndexType(), dim)));
+    auto start_index_load =
+        b->create<LoadOp>(loc, start_indices_memref, ValueRange{dim_index});
+    auto start_index =
+        b->create<IndexCastOp>(loc, b->getIndexType(), start_index_load);
+    auto stride_load =
+        b->create<LoadOp>(loc, strides_memref, ValueRange{dim_index});
+    auto stride = b->create<IndexCastOp>(loc, b->getIndexType(), stride_load);
+    // input_dim = out_dim * stride + start_index
+    auto input_dim = b->create<AddIOp>(
+        loc, b->create<MulIOp>(loc, output_index[dim], stride), start_index);
+    input_index.push_back(input_dim);
+  }
+
+  auto operand_memref = *(op->getOperands().begin());
+
+  if (!check_cache) {
+    return b->create<LoadOp>(loc, operand_memref, input_index);
+  }
+  return createLoadOrUseCachedValue(loc, b, operand_memref, input_index,
+                                    b->saveInsertionPoint());
+}
+
+namespace {
+
+template <typename T>
+Value elementalLowerImplForBroadcastInDimOps(OpBuilder* b, Location loc,
+                                             Operation* op,
+                                             ValueRange output_index,
+                                             bool check_cache) {
+  auto broadcast_in_dim = dyn_cast<T>(op);
+  assert(broadcast_in_dim && "unexpected opcode");
+  auto broadcast_dimensions =
+      broadcast_in_dim.broadcast_dimensions().template getValues<int64_t>();
+  auto out_rank = output_index.size();
+  auto operand_memref = op->getOperand(0);
+  SmallVector<Value, 4> input_index;
+  for (int64_t dim = 0; dim < out_rank; ++dim) {
+    auto it = std::find(broadcast_dimensions.begin(),
+                        broadcast_dimensions.end(), dim);
+
+    bool is_broadcast_dim = (it != broadcast_dimensions.end());
+    if (is_broadcast_dim) {
+      auto input_dim = std::distance(broadcast_dimensions.begin(), it);
+      auto static_dim_size =
+          operand_memref.getType().cast<MemRefType>().getShape()[input_dim];
+      if (static_dim_size == 1) {
+        // we know this dim is to be broadcasted at compile time
+        auto zero = b->create<ConstantOp>(
+            loc, b->getIndexType(), b->getIntegerAttr(b->getIndexType(), 0));
+        input_index.push_back(zero);
+      } else if (static_dim_size == ShapedType::kDynamicSize) {
+        // we are not sure if this dim is to be broadcasted at compile time
+        auto dim_size = b->create<DimOp>(loc, operand_memref, input_dim);
+        auto one = b->create<ConstantOp>(
+            loc, b->getIndexType(), b->getIntegerAttr(b->getIndexType(), 1));
+        auto zero = b->create<ConstantOp>(
+            loc, b->getIndexType(), b->getIntegerAttr(b->getIndexType(), 0));
+        auto dim_size_is_1 =
+            b->create<CmpIOp>(loc, CmpIPredicate::eq, dim_size, one);
+        input_index.push_back(b->create<mlir::SelectOp>(
+            loc, dim_size_is_1, zero, output_index[dim]));
+      } else {
+        // we know this dim is not to be broadcasted at compile time
+        input_index.push_back(output_index[dim]);
+      }
+    }
+  }
+
+  if (!check_cache) {
+    auto rank = operand_memref.getType().dyn_cast<MemRefType>().getRank();
+    return (rank > 0) ? b->create<LoadOp>(loc, operand_memref, input_index)
+                      : b->create<LoadOp>(loc, operand_memref, ValueRange());
+  }
+  return createLoadOrUseCachedValue(loc, b, operand_memref, input_index,
+                                    b->saveInsertionPoint());
+}
+
+}  // namespace
+
+template <>
+Value elementalLower<lmhlo::DynamicBroadcastInDimOp>(OpBuilder* b, Location loc,
+                                                     Operation* op,
+                                                     ValueRange output_index,
+                                                     bool check_cache) {
+  return elementalLowerImplForBroadcastInDimOps<lmhlo::DynamicBroadcastInDimOp>(
+      b, loc, op, output_index, check_cache);
+}
+
+template <>
+Value elementalLower<lmhlo::BroadcastInDimOp>(OpBuilder* b, Location loc,
+                                              Operation* op,
+                                              ValueRange output_index,
+                                              bool check_cache) {
+  return elementalLowerImplForBroadcastInDimOps<lmhlo::BroadcastInDimOp>(
+      b, loc, op, output_index, check_cache);
+}
+
+scf::ForOp createLoopAndSetInsPt(OpBuilder& b, Location loc, Value& var,
+                                 Value lb, Value ub, Value step,
+                                 ArrayRef<Value> init_values) {
+  auto for_op = b.create<scf::ForOp>(loc, lb, ub, step, init_values);
+  b.setInsertionPointToStart(for_op.getBody());
+  var = for_op.getInductionVar();
+  return for_op;
+}
+
+scf::ParallelOp createParallelAndSetInsPt(OpBuilder& b, Location loc,
+                                          SmallVectorImpl<Value>& vars,
+                                          ArrayRef<Value> lbs,
+                                          ArrayRef<Value> ubs,
+                                          ArrayRef<Value> steps,
+                                          ArrayRef<Value> init_values) {
+  auto par_op = b.create<scf::ParallelOp>(loc, lbs, ubs, steps, init_values,
+                                          /*bodyBuilderFn=*/nullptr);
+  b.setInsertionPointToStart(par_op.getBody());
+  vars.append(par_op.getInductionVars().begin(),
+              par_op.getInductionVars().end());
+  return par_op;
+}
+
+// reinterpret_cast the input memref into 1D
+memref::ReinterpretCastOp createMemRef1DReinterpretCast(OpBuilder& b,
+                                                        Location loc,
+                                                        Value memref) {
+  auto memref_ty = memref.getType().cast<MemRefType>();
+  assert(memref_ty.getAffineMaps().empty());
+  Value size = codegen_utils::calcNumElements(b, loc, memref);
+  Value stride = b.create<mlir::ConstantOp>(
+      loc, b.getIndexType(), b.getIntegerAttr(b.getIndexType(), 1));
+  Value zero = b.create<mlir::ConstantOp>(
+      loc, b.getIndexType(), b.getIntegerAttr(b.getIndexType(), 0));
+  auto memref_1d_type =
+      MemRefType::get({MemRefType::kDynamicSize}, memref_ty.getElementType(),
+                      memref_ty.getAffineMaps(), memref_ty.getMemorySpace());
+  return b.create<memref::ReinterpretCastOp>(
+      loc, memref_1d_type, memref, zero, ValueRange{size}, ValueRange{stride});
+}
+
+void createOffsetStore(OpBuilder& b, Location loc, Value res, Value memref,
+                       Value offset) {
+  auto memref_1d = createMemRef1DReinterpretCast(b, loc, memref);
+  b.create<memref::StoreOp>(loc, res, memref_1d, ValueRange{offset});
+  return;
+}
+
+memref::LoadOp createOffsetLoad(OpBuilder& b, Location loc, Value memref,
+                                Value offset) {
+  auto memref_1d = createMemRef1DReinterpretCast(b, loc, memref);
+  return b.create<memref::LoadOp>(loc, memref_1d, ValueRange{offset});
+}
+
+}  // namespace lmhlo
+}  // namespace mlir

--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/lhlo_legalize_roots_to_loops.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/lhlo_legalize_roots_to_loops.cc
@@ -1,0 +1,324 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// This file implements logic for lowering LHLO dialect to Affine dialect.
+#include "llvm/Support/Debug.h"
+#include "mlir-hlo/Dialect/mhlo/IR/lhlo_ops.h"
+#include "mlir-hlo/Dialect/mhlo/transforms/fusion_utils.h"
+#include "mlir-hlo/Dialect/mhlo/transforms/lhlo_elemental_utils.h"
+#include "mlir-hlo/Dialect/mhlo/transforms/map_lmhlo_to_scalar_op.h"
+#include "mlir-hlo/utils/codegen_utils.h"
+#include "mlir-hlo/utils/placement_utils.h"
+#include "mlir/Dialect/GPU/GPUDialect.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/SCF.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BlockAndValueMapping.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+
+using mlir::codegen_utils::calcMultiDimIndex;
+using mlir::memref::DimOp;
+using mlir::memref::LoadOp;
+using mlir::memref::StoreOp;
+
+namespace mlir {
+namespace lmhlo {
+
+#define GEN_PASS_CLASSES
+#include "mlir-hlo/Dialect/mhlo/transforms/lmhlo_passes.h.inc"
+
+namespace {
+
+template <typename LHLO_OpTy>
+bool elemwiseLowerHelper(
+    OpBuilder& b, Location loc, Operation* op, Value output_linear_index,
+    const ShapeConstraintAnalysis* shape_constraint_analysis) {
+  if (!isa<LHLO_OpTy>(op) || !op->hasTrait<mlir::OpTrait::Elementwise>()) {
+    return false;
+  }
+  Value result_memref = cast<LmhloOp>(op).getResultBuffer();
+  Value memref = result_memref;
+  if (shape_constraint_analysis) {
+    Value leader_memref =
+        shape_constraint_analysis->GetLeaderValueWithSameShape(result_memref);
+    if (leader_memref != nullptr) {
+      memref = leader_memref;
+    }
+  }
+  // TODO(disc): Replace with memref.Delinearize
+  auto multidim_index = calcMultiDimIndex(b, loc, output_linear_index, memref);
+  SmallVector<Value, 4> operand_values;
+  int num_operands = op->getNumOperands();
+  for (Value operand_memref : op->getOperands().drop_back()) {
+    auto operand_data = createLoadOrUseCachedValue(
+        loc, &b, operand_memref, multidim_index, b.saveInsertionPoint());
+    operand_values.push_back(operand_data);
+  }
+  auto res = HloOpToStdScalarOp::map<LHLO_OpTy>(
+      llvm::cast<LHLO_OpTy>(op),
+      result_memref.getType().cast<MemRefType>().getElementType(),
+      operand_values, &b);
+  createOffsetStore(b, loc, res, result_memref, output_linear_index);
+  return true;
+}
+
+template <typename LHLO_OpTy>
+bool miscLowerHelper(OpBuilder& b, Location loc, Operation* op,
+                     Value output_linear_index,
+                     const ShapeConstraintAnalysis* shape_constraint_analysis) {
+  if (!isa<LHLO_OpTy>(op)) {
+    return false;
+  }
+  Value result_memref = cast<LmhloOp>(op).getResultBuffer();
+  Value memref = result_memref;
+  if (shape_constraint_analysis) {
+    Value leader_memref =
+        shape_constraint_analysis->GetLeaderValueWithSameShape(result_memref);
+    if (leader_memref != nullptr) {
+      memref = leader_memref;
+    }
+  }
+  auto output_multidim_index =
+      calcMultiDimIndex(b, loc, output_linear_index, memref);
+  auto operand_data =
+      elementalLower<LHLO_OpTy>(&b, loc, op, output_multidim_index,
+                                /*check_cache*/ true);
+  createOffsetStore(b, loc, operand_data, result_memref, output_linear_index);
+  return true;
+}
+
+template <typename First>
+bool elemwiseLowerHelperOr(
+    OpBuilder& b, Location loc, Operation* op, Value output_linear_index,
+    const ShapeConstraintAnalysis* shape_constraint_analysis) {
+  return elemwiseLowerHelper<First>(b, loc, op, output_linear_index,
+                                    shape_constraint_analysis);
+}
+
+template <typename First, typename Second, typename... Rest>
+bool elemwiseLowerHelperOr(
+    OpBuilder& b, Location loc, Operation* op, Value output_linear_index,
+    const ShapeConstraintAnalysis* shape_constraint_analysis) {
+  return elemwiseLowerHelperOr<First>(b, loc, op, output_linear_index,
+                                      shape_constraint_analysis) ||
+         elemwiseLowerHelperOr<Second, Rest...>(b, loc, op, output_linear_index,
+                                                shape_constraint_analysis);
+}
+
+LogicalResult lowerHelper(
+    OpBuilder& b, Location loc, Operation* op, Value output_linear_index,
+    const ShapeConstraintAnalysis* shape_constraint_analysis) {
+  if (elemwiseLowerHelperOr<
+#define GET_SUPPORTED_OP_LIST
+#include "mlir-hlo/utils/disc_supported_list.h.inc"
+          >(b, loc, op, output_linear_index, shape_constraint_analysis) ||
+      // TODO(disc): Upstream is on the way for more Ops
+      miscLowerHelper<RealDynamicSliceOp>(b, loc, op, output_linear_index,
+                                          shape_constraint_analysis) ||
+      miscLowerHelper<DynamicBroadcastInDimOp>(b, loc, op, output_linear_index,
+                                               shape_constraint_analysis) ||
+      miscLowerHelper<BroadcastInDimOp>(b, loc, op, output_linear_index,
+                                        shape_constraint_analysis)) {
+    return success();
+  } else {
+    assert(false && "unsupported lhlo_op");
+    llvm::dbgs() << "unsupported lhlo_op: " << op->getName();
+    return failure();
+  }
+}
+
+// we don't do inbound check for kLoop Schedule
+// LoopSplit pass will do this.
+//
+/* %num_elements = ElementsIn(root_shape)
+ * loop.for %idx = 0 to %num_elements step 1 {
+ *   %multidim_indices_0..n = getMultidimIndices(%idx);
+ *   %operand_0 = load %operand0[]
+ *   %operand_1 = load %operand1[]
+ *   emit calculation..
+ * }
+ */
+LogicalResult lowerWithScheduleLoop(
+    OpBuilder& b, ArrayRef<Operation*> root_ops, Operation* dominant_op,
+    Block* parent = nullptr, bool non_fusion = false, bool parallel_loop = true,
+    const ShapeConstraintAnalysis* shape_constraint_analysis = nullptr) {
+  const auto loc = dominant_op->getLoc();
+  b.setInsertionPoint(root_ops.back());
+  auto zero = b.create<ConstantOp>(loc, b.getIndexType(),
+                                   b.getIntegerAttr(b.getIndexType(), 0));
+  auto one = b.create<ConstantOp>(loc, b.getIndexType(),
+                                  b.getIntegerAttr(b.getIndexType(), 1));
+  auto num_elements = codegen_utils::calcNumElements(b, loc, dominant_op);
+  Value var;
+  if (parallel_loop) {
+    SmallVector<Value, 2> vars;
+    (void)createParallelAndSetInsPt(b, loc, vars, ArrayRef<Value>{zero},
+                                    ArrayRef<Value>{num_elements},
+                                    ArrayRef<Value>{one}, ArrayRef<Value>{});
+    var = vars[0];
+  } else {
+    (void)createLoopAndSetInsPt(b, loc, var, zero, num_elements, one,
+                                ArrayRef<Value>{});
+  }
+  for (Operation* root_op : root_ops) {
+    if (failed(lowerHelper(b, loc, root_op, var, shape_constraint_analysis))) {
+      return failure();
+    }
+  }
+  // remove the root_op if it has no other users except the memref
+  if (non_fusion) {
+    for (Operation* root_op : root_ops) {
+      root_op->erase();
+    }
+  } else {
+    assert(parent != nullptr && "Parent must be provided for fusion lowering");
+    cleanUnusedLhloOps(parent);
+  }
+  return success();
+}
+
+bool isOnGpu(Operation* op) {
+  if (isa<FusionOp>(op)) {
+    // TODO(disc): Revisit this when fusion on cpu is suppported
+    return true;
+  }
+  assert(isa<LmhloOp>(op) && "Unexpected usage of isOnGpu");
+  auto result_memref = cast<LmhloOp>(op).getResultBuffer();
+  auto memory_space =
+      result_memref.getType().cast<MemRefType>().getMemorySpace();
+  return memory_space && memory_space.isa<StringAttr>() &&
+         memory_space.cast<StringAttr>().getValue() == placement_utils::c_gpu;
+}
+
+}  // namespace
+
+// Expand the root ops in a fused func into a parrallel loop or a set of
+// nested loops. This pass must be executed after the fusion pass, and works
+// together with the InputInlineFusion pass after it for fusion codegen.
+//
+// TODO(disc): Currently this pass supports lmhlo.FusionOp to have lmhlo ops
+// inside, not mhlo. It's mainly because we now do fusion on lmhlo, not mhlo.
+// The fusion pass can be moved to mhlo after shape dialect is brought in to
+// represent shape calculation on tensor layer, and we would be able to do shape
+// calculation lowering for mhlo.FusionOp. Reconsider the fusion representation
+// after these are done, a lmhlo.FusionOp with mhlo inside would be more
+// friendly to the legacy FusedIrEmitter.
+class LhloLegalizeRootsToParallelLoops
+    : public LhloLegalizeRootsToParallelLoopsPassBase<
+          LhloLegalizeRootsToParallelLoops> {
+  void runOnFunction() override {
+    auto func = getFunction();
+    OpBuilder b(func);
+    SmallVector<Operation*, 4> gpu_non_fusion_worklist;
+    SmallVector<Operation*, 4> cpu_non_fusion_worklist;
+    SmallVector<Operation*, 4> gpu_fusion_worklist;
+    for (mlir::Operation& op : func.body().getOps()) {
+      if (isa<FusionOp>(&op)) {
+        // TODO(disc): Revisit this when fusion on cpu is supported
+        gpu_fusion_worklist.push_back(&op);
+      } else if (isa<LmhloOp>(&op)) {
+        if (isOnGpu(&op)) {
+          gpu_non_fusion_worklist.push_back(&op);
+        } else {
+          cpu_non_fusion_worklist.push_back(&op);
+        }
+      }
+    }
+
+    for (Operation* op : cpu_non_fusion_worklist) {
+      // Only for calculating shapes when the backend is gpu. A simple schedule
+      // should be sufficient for performance.
+      // TODO(disc): Revisit this when the backend is cpu and the calculation is
+      // for data
+      auto r =
+          lowerWithScheduleLoop(b, {op}, op, nullptr,
+                                /*non_fusion*/ true, /*parallel_loop*/ false);
+      assert(succeeded(r) && "kLoop single instruction on cpu codegen failed");
+    }
+
+    for (Operation* op : gpu_non_fusion_worklist) {
+      // TODO(disc): single nodes with non kLoop schedule like ReduceOp
+      // is not implemented yet. Currently ReduceOp is lowered with loop
+      // schedule, which means for poor performance.
+      auto r =
+          lowerWithScheduleLoop(b, {op}, op, nullptr,
+                                /*non_fusion*/ true, /*parallel_loop*/ true);
+      assert(succeeded(r) && "kLoop single instruction on gpu codegen failed");
+    }
+
+    for (Operation* fusion : gpu_fusion_worklist) {
+      auto fusion_op = cast<FusionOp>(fusion);
+      FusionPattern fusion_pattern(fusion_op);
+      auto root_ops = fusion_pattern.getRootOps();
+      auto fused_block = &(fusion_op.region().front());
+      SmallVector<Operation*, 4> op_list;
+      fused_block->walk(
+          [&](LmhloOp op) { op_list.push_back(op.getOperation()); });
+      ShapeConstraintAnalysis shape_constraint_analysis(op_list);
+
+      // No need to do codegen, return directly.
+      if (root_ops.empty()) {
+        return;
+      }
+      // Make a loop to write the buffer into init value for each
+      // ColReduction root. This will be further lowered to a init_kernel
+      // TODO(disc): Code upstream is on the way
+      // maybeEmitInitLoops(b, root_ops);
+
+      // 1, If any reduce op among the 'root_ops', follow the schedule of it;
+      //    or else, follow the schedule of kLoop.
+      // 2, If there are a mixer of column reductions and row reductions,
+      //    follow the schedule of the row reduction, and implement all the
+      //    column reduction with the 'pure atomic' way, which has no
+      //    requirement on the schedule.
+      // TODO(disc): the support of row reduction and 'pure atomic' reduction
+      auto fusion_type = fusion_pattern.getFusionType();
+      auto dominant_op = fusion_pattern.getDominantOp();
+      switch (fusion_type) {
+        case FusionType::kRowReduction: {
+          assert(false && "Upstream is on the way for kRowReduction Schedule");
+          break;
+        }
+        case FusionType::kColReduction: {
+          assert(false && "Upstream is on the way for kColReduction Schedule");
+          break;
+        }
+        case FusionType::kLoop: {
+          auto r = lowerWithScheduleLoop(b, root_ops, dominant_op, fused_block,
+                                         /*non_fusion*/ false,
+                                         /*parallel_loop*/ true,
+                                         &shape_constraint_analysis);
+          assert(succeeded(r) && "lowerWithScheduleLoop failed");
+          break;
+        }
+        default:
+          assert(false && "unknown fusion_type");
+      }
+    }
+  }
+};
+
+std::unique_ptr<OperationPass<FuncOp>>
+createLhloLegalizeRootsToParallelLoopsPass() {
+  return std::make_unique<LhloLegalizeRootsToParallelLoops>();
+}
+
+}  // namespace lmhlo
+}  // namespace mlir

--- a/tensorflow/compiler/mlir/hlo/lib/utils/CMakeLists.txt
+++ b/tensorflow/compiler/mlir/hlo/lib/utils/CMakeLists.txt
@@ -16,6 +16,7 @@
 
 add_mlir_library(MLIRMhloUtils
   broadcast_utils.cc
+  codegen_utils.cc
   convert_op_folder.cc
   cycle_detector.cc
   hlo_utils.cc

--- a/tensorflow/compiler/mlir/hlo/lib/utils/codegen_utils.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/utils/codegen_utils.cc
@@ -1,0 +1,167 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "mlir-hlo/utils/codegen_utils.h"
+
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Location.h"
+#include "mlir/Pass/Pass.h"
+
+using llvm::SmallVector;
+
+namespace mlir {
+namespace codegen_utils {
+
+Value calcNumElements(OpBuilder& b, Location loc, Value memref) {
+  auto rank = memref.getType().cast<MemRefType>().getRank();
+  Value num_elements;
+  num_elements = b.create<mlir::ConstantOp>(
+      loc, b.getIndexType(), b.getIntegerAttr(b.getIndexType(), 1));
+  for (int r = 0; r < rank; ++r) {
+    auto dim_size = b.create<memref::DimOp>(loc, memref, r);
+    num_elements = b.create<MulIOp>(loc, num_elements, dim_size);
+  }
+  return num_elements;
+}
+
+Value calcNumElements(OpBuilder& b, Location loc, Operation* op) {
+  // only const rank is supported for now
+  assert(op->getDialect()->getNamespace() == "lmhlo");
+  auto num_operands = op->getNumOperands();
+  auto result_memref = op->getOperand(num_operands - 1);
+  return calcNumElements(b, loc, result_memref);
+}
+
+Value calcNumElementsForFirstOperand(OpBuilder& b, Location loc,
+                                     Operation* op) {
+  assert(op->getDialect()->getNamespace() == "lmhlo");
+  auto operand_memref = op->getOperand(0);
+  return calcNumElements(b, loc, operand_memref);
+}
+
+SmallVector<Value, 4> calcMultiDimIndex(OpBuilder& b, Location loc,
+                                        Value linear_index,
+                                        ArrayRef<Value> shape) {
+  auto rank = shape.size();
+  SmallVector<Value, 4> result;
+  if (rank == 0) {
+    return result;
+  } else if (rank == 1) {
+    result.push_back(linear_index);
+    return result;
+  }
+
+  // dim_acc_mul_vec = [d, c*d, b*c*d]
+  std::vector<Value> dim_acc_mul_vec;
+  Value tmp_acc_mul = shape[rank - 1];
+  dim_acc_mul_vec.emplace_back(tmp_acc_mul);
+  for (int i = rank - 2; i > 0; --i) {
+    tmp_acc_mul = b.create<MulIOp>(loc, tmp_acc_mul, shape[i]);
+    dim_acc_mul_vec.emplace_back(tmp_acc_mul);
+  }
+  Value block_index = linear_index;
+  for (int i = 0; i < rank; ++i) {
+    Value index;
+    if (i == rank - 1) {
+      index = block_index;
+    } else {
+      index =
+          b.create<UnsignedDivIOp>(loc, block_index, dim_acc_mul_vec.back());
+      block_index =
+          b.create<UnsignedRemIOp>(loc, block_index, dim_acc_mul_vec.back());
+      dim_acc_mul_vec.pop_back();
+    }
+    result.push_back(index);
+  }
+  return result;
+}
+
+SmallVector<Value, 4> calcMultiDimIndex(OpBuilder& b, Location loc,
+                                        Value linear_index, Value memref) {
+  auto rank = memref.getType().cast<MemRefType>().getRank();
+  SmallVector<Value, 4> result;
+  if (rank == 0) {
+    return result;
+  } else if (rank == 1) {
+    result.push_back(linear_index);
+    return result;
+  }
+  // shape = [a, b, c, d]
+  SmallVector<Value, 4> shape_vec;
+  for (int i = 0; i < rank; ++i) {
+    shape_vec.push_back(b.create<memref::DimOp>(loc, memref, i));
+  }
+
+  return calcMultiDimIndex(b, loc, linear_index, shape_vec);
+}
+
+SmallVector<Value, 4> calcMultiDimIndex(OpBuilder& b, Location loc,
+                                        Value linear_index, Operation* op) {
+  assert(op->getDialect()->getNamespace() == "lmhlo");
+  auto num_operands = op->getNumOperands();
+  auto result_memref = op->getOperand(num_operands - 1);
+  return calcMultiDimIndex(b, loc, linear_index, result_memref);
+}
+
+SmallVector<Value, 4> calcMultiDimIndexForFirstOperand(OpBuilder& b,
+                                                       Location loc,
+                                                       Value linear_index,
+                                                       Operation* op) {
+  assert(op->getDialect()->getNamespace() == "lmhlo");
+  auto operand_memref = op->getOperand(0);
+  return calcMultiDimIndex(b, loc, linear_index, operand_memref);
+}
+
+Value calcLinearIndex(OpBuilder& b, Location loc,
+                      llvm::ArrayRef<Value> multi_index, Operation* op) {
+  auto num_operands = op->getNumOperands();
+  auto result_memref = op->getOperand(num_operands - 1);
+  auto rank = result_memref.getType().cast<MemRefType>().getRank();
+
+  if (rank == 0) {
+    return b.create<ConstantIndexOp>(loc, 0);
+  } else if (rank == 1) {
+    return multi_index[0];
+  }
+
+  SmallVector<Value, 4> shape_vec;
+  for (int i = 0; i < rank; ++i) {
+    shape_vec.push_back(b.create<memref::DimOp>(loc, result_memref, i));
+  }
+
+  return calcLinearIndex(b, loc, multi_index, shape_vec);
+}
+
+Value calcLinearIndex(OpBuilder& b, Location loc,
+                      llvm::ArrayRef<Value> multi_index,
+                      llvm::ArrayRef<Value> shape) {
+  assert(multi_index.size() == shape.size());
+  if (shape.empty()) {
+    return b.create<ConstantIndexOp>(loc, 0);
+  }
+
+  Value linear = multi_index[0];
+  for (size_t i = 1; i < shape.size(); ++i) {
+    // linear = (linear * shape[i]) + multi_index[i]
+    linear = b.create<AddIOp>(loc, b.create<MulIOp>(loc, linear, shape[i]),
+                              multi_index[i]);
+  }
+  return linear;
+}
+
+}  // namespace codegen_utils
+}  // namespace mlir

--- a/tensorflow/compiler/mlir/hlo/tests/lhlo-input-inline-fusion.mlir
+++ b/tensorflow/compiler/mlir/hlo/tests/lhlo-input-inline-fusion.mlir
@@ -1,0 +1,91 @@
+// RUN: mlir-hlo-opt %s -input-inline-fusion -split-input-file | FileCheck %s
+
+// CHECK-LABEL: @inline_fusion_fusion_order
+// CHECK-SAME: (%[[INPUT1:.*]]: memref<?xf32>, %[[INPUT2:.*]]: memref<3xi32>, %[[INPUT3:.*]]: memref<?x?x?xf32>, %[[INPUT4:.*]]: memref<?x?x?xf32>, %[[TMP_BUF1:.*]]: memref<?x?x?xf32>, %[[TMP_BUF2:.*]]: memref<?x?x?xf32>, %[[OUT:.*]]: memref<?x?x?xf32>) -> memref<?x?x?xf32>
+func @inline_fusion_fusion_order(%arg0: memref<?xf32>, %arg1: memref<3xi32>, %arg2: memref<?x?x?xf32>, %arg3: memref<?x?x?xf32>, %arg4: memref<?x?x?xf32>, %arg5: memref<?x?x?xf32>, %arg6: memref<?x?x?xf32>) -> memref<?x?x?xf32> {
+  %c2 = constant 2 : index
+  %c1 = constant 1 : index
+  %c0 = constant 0 : index
+  // CHECK: "lmhlo.fusion"() ( {
+  "lmhlo.fusion"() ( {
+    // CHECK-NOT: lmhlo.dynamic_broadcast_in_dim
+    // CHECK-NOT: lmhlo.add
+    "lmhlo.dynamic_broadcast_in_dim"(%arg0, %arg1, %arg4) {broadcast_dimensions = dense<2> : tensor<1xi64>} : (memref<?xf32>, memref<3xi32>, memref<?x?x?xf32>) -> ()
+    "lmhlo.add"(%arg2, %arg4, %arg5) : (memref<?x?x?xf32>, memref<?x?x?xf32>, memref<?x?x?xf32>) -> ()
+    %0 = memref.dim %arg6, %c0 : memref<?x?x?xf32>
+    %1 = memref.dim %arg6, %c1 : memref<?x?x?xf32>
+    %2 = muli %0, %1 : index
+    %3 = memref.dim %arg6, %c2 : memref<?x?x?xf32>
+    %4 = muli %2, %3 : index
+    // CHECK: scf.parallel
+    scf.parallel (%arg7) = (%c0) to (%4) step (%c1) {
+      %5 = memref.dim %arg3, %c1 : memref<?x?x?xf32>
+      %6 = memref.dim %arg3, %c2 : memref<?x?x?xf32>
+      %7 = muli %6, %5 : index
+      %8 = divi_unsigned %arg7, %7 : index
+      %9 = remi_unsigned %arg7, %7 : index
+      %10 = divi_unsigned %9, %6 : index
+      %11 = remi_unsigned %9, %6 : index
+      %12 = memref.load %arg3[%8, %10, %11] : memref<?x?x?xf32>
+      %13 = memref.load %arg5[%8, %10, %11] : memref<?x?x?xf32>
+      %14 = mulf %12, %13 : f32
+      %15 = memref.reinterpret_cast %arg6 to offset: [%c0], sizes: [%4], strides: [%c1] : memref<?x?x?xf32> to memref<?xf32>
+      memref.store %14, %15[%arg7] : memref<?xf32>
+      scf.yield
+    }
+    // CHECK: "lmhlo.terminator"() : () -> ()
+    "lmhlo.terminator"() : () -> ()
+  }) : () -> ()
+  // CHECK: return %[[OUT]] : memref<?x?x?xf32>
+  return %arg6 : memref<?x?x?xf32>
+}
+
+// CHECK-LABEL: @multioutput_loop_fusion_with_dependency
+// CHECK-SAME: (%[[INPUT1:.*]]: memref<?xf32>, %[[INPUT2:.*]]: memref<3xi32>, %[[INPUT3:.*]]: memref<?x?x?xf32>, %[[TMP_BUF:.*]]: memref<?x?x?xf32>, %[[OUT1:.*]]: memref<?x?x?xf32>, %[[OUT2:.*]]: memref<?x?x?xf32>) -> (memref<?x?x?xf32>, memref<?x?x?xf32>)
+func @multioutput_loop_fusion_with_dependency(%arg0: memref<?xf32>, %arg1: memref<3xi32>, %arg2: memref<?x?x?xf32>, %arg3: memref<?x?x?xf32>, %arg4: memref<?x?x?xf32>, %arg5: memref<?x?x?xf32>) -> (memref<?x?x?xf32>, memref<?x?x?xf32>) {
+  %c2 = constant 2 : index
+  %c1 = constant 1 : index
+  %c0 = constant 0 : index
+  // CHECK: "lmhlo.fusion"() ( {
+  "lmhlo.fusion"() ( {
+    // CHECK-NOT: lmhlo.dynamic_broadcast_in_dim
+    // CHECK-NOT: lmhlo.add
+    "lmhlo.dynamic_broadcast_in_dim"(%arg0, %arg1, %arg3) {broadcast_dimensions = dense<2> : tensor<1xi64>} : (memref<?xf32>, memref<3xi32>, memref<?x?x?xf32>) -> ()
+    "lmhlo.add"(%arg2, %arg3, %arg4) : (memref<?x?x?xf32>, memref<?x?x?xf32>, memref<?x?x?xf32>) -> ()
+    %0 = memref.dim %arg5, %c0 : memref<?x?x?xf32>
+    %1 = memref.dim %arg5, %c1 : memref<?x?x?xf32>
+    %2 = muli %0, %1 : index
+    %3 = memref.dim %arg5, %c2 : memref<?x?x?xf32>
+    %4 = muli %2, %3 : index
+    // CHECK: scf.parallel
+    scf.parallel (%arg6) = (%c0) to (%4) step (%c1) {
+      %5 = memref.dim %arg2, %c1 : memref<?x?x?xf32>
+      %6 = memref.dim %arg2, %c2 : memref<?x?x?xf32>
+      %7 = muli %6, %5 : index
+      %8 = divi_unsigned %arg6, %7 : index
+      %9 = remi_unsigned %arg6, %7 : index
+      %10 = divi_unsigned %9, %6 : index
+      %11 = remi_unsigned %9, %6 : index
+      %12 = memref.load %arg2[%8, %10, %11] : memref<?x?x?xf32>
+      %13 = memref.load %arg3[%8, %10, %11] : memref<?x?x?xf32>
+      %14 = addf %12, %13 : f32
+      %15 = memref.dim %arg4, %c0 : memref<?x?x?xf32>
+      %16 = memref.dim %arg4, %c1 : memref<?x?x?xf32>
+      %17 = muli %15, %16 : index
+      %18 = memref.dim %arg4, %c2 : memref<?x?x?xf32>
+      %19 = muli %17, %18 : index
+      %20 = memref.reinterpret_cast %arg4 to offset: [%c0], sizes: [%19], strides: [%c1] : memref<?x?x?xf32> to memref<?xf32>
+      memref.store %14, %20[%arg6] : memref<?xf32>
+      %21 = memref.load %arg2[%8, %10, %11] : memref<?x?x?xf32>
+      %22 = memref.load %arg4[%8, %10, %11] : memref<?x?x?xf32>
+      %23 = mulf %21, %22 : f32
+      %24 = memref.reinterpret_cast %arg5 to offset: [%c0], sizes: [%4], strides: [%c1] : memref<?x?x?xf32> to memref<?xf32>
+      memref.store %23, %24[%arg6] : memref<?xf32>
+      scf.yield
+    }
+    // CHECK: "lmhlo.terminator"() : () -> ()
+    "lmhlo.terminator"() : () -> ()
+  }) : () -> ()
+  // CHECK: return %[[OUT1]], %[[OUT2]] : memref<?x?x?xf32>, memref<?x?x?xf32>
+  return %arg4, %arg5 : memref<?x?x?xf32>, memref<?x?x?xf32>
+}

--- a/tensorflow/compiler/mlir/hlo/tests/lhlo-legalize-roots-to-loops.mlir
+++ b/tensorflow/compiler/mlir/hlo/tests/lhlo-legalize-roots-to-loops.mlir
@@ -1,0 +1,86 @@
+// RUN: mlir-hlo-opt %s -lhlo-legalize-roots-to-parallel-loops -split-input-file | FileCheck %s
+
+// CHECK-LABEL: @non_fusion_elemwise_gpu
+// CHECK-SAME: (%[[INPUT1:.*]]: memref<?x?x?xf32, "gpu">, %[[INPUT2:.*]]: memref<?x?x?xf32, "gpu">, %[[OUT:.*]]: memref<?x?x?xf32, "gpu">) -> memref<?x?x?xf32, "gpu">
+func @non_fusion_elemwise_gpu(%input1: memref<?x?x?xf32, "gpu">, %input2: memref<?x?x?xf32, "gpu">, %out: memref<?x?x?xf32, "gpu">) -> (memref<?x?x?xf32, "gpu">) {
+  // CHECK-NOT: lmhlo
+  // CHECK: scf.parallel
+  "lmhlo.add"(%input1, %input2, %out) : (memref<?x?x?xf32, "gpu">, memref<?x?x?xf32, "gpu">, memref<?x?x?xf32, "gpu">) -> ()
+  // CHECK: return %[[OUT]] : memref<?x?x?xf32, "gpu">
+  return %out : memref<?x?x?xf32, "gpu">
+}
+
+// CHECK-LABEL: @non_fusion_elemwise_cpu
+// CHECK-SAME: (%[[INPUT1:.*]]: memref<?x?x?xf32>, %[[INPUT2:.*]]: memref<?x?x?xf32>, %[[OUT:.*]]: memref<?x?x?xf32>) -> memref<?x?x?xf32>
+func @non_fusion_elemwise_cpu(%input1: memref<?x?x?xf32>, %input2: memref<?x?x?xf32>, %out: memref<?x?x?xf32>) -> (memref<?x?x?xf32>) {
+  // CHECK-NOT lmhlo
+  // CHECK: scf.for
+  "lmhlo.add"(%input1, %input2, %out) : (memref<?x?x?xf32>, memref<?x?x?xf32>, memref<?x?x?xf32>) -> ()
+  // CHECK: return %[[OUT]] : memref<?x?x?xf32>
+  return %out : memref<?x?x?xf32>
+}
+
+// CHECK-LABEL: @non_fusion_dynamic_broadcast_in_dim_gpu
+// CHECK-SAME: (%[[INPUT1:.*]]: memref<?xf32, "gpu">, %[[INPUT2:.*]]: memref<3xi32>, %[[OUT:.*]]: memref<?x?x?xf32, "gpu">) -> memref<?x?x?xf32, "gpu">
+func @non_fusion_dynamic_broadcast_in_dim_gpu(%input1: memref<?xf32, "gpu">, %input2: memref<3xi32>, %out: memref<?x?x?xf32, "gpu">) -> (memref<?x?x?xf32, "gpu">) {
+  // CHECK-NOT lmhlo
+  // CHECK: scf.parallel
+  "lmhlo.dynamic_broadcast_in_dim"(%input1, %input2, %out) {broadcast_dimensions = dense<2> : tensor<1xi64>} : (memref<?xf32, "gpu">, memref<3xi32>, memref<?x?x?xf32, "gpu">) -> ()
+  // CHECK: return %[[OUT]] : memref<?x?x?xf32, "gpu">
+  return %out : memref<?x?x?xf32, "gpu">
+}
+
+// CHECK-LABEL: @basic_loop_fusion_misc_root
+// CHECK-SAME: (%[[INPUT1:.*]]: memref<?xf32>, %[[INPUT2:.*]]: memref<?xf32>, %[[INPUT3:.*]]: memref<3xi32>, %[[TMP_BUF:.*]]: memref<?xf32>, %[[OUT:.*]]: memref<?x?x?xf32>) -> memref<?x?x?xf32>
+func @basic_loop_fusion_misc_root(%input1: memref<?xf32>, %input2: memref<?xf32>, %input3: memref<3xi32>, %tmp: memref<?xf32>, %out: memref<?x?x?xf32>) -> (memref<?x?x?xf32>) {
+  // CHECK: "lmhlo.fusion"() ( {
+  "lmhlo.fusion"() ( {
+    // CHECK: lmhlo.add
+    // CHECK-NOT lmhlo.dynamic_broadcast_in_dim
+    // CHECK: scf.parallel
+    "lmhlo.add"(%input1, %input2, %tmp) : (memref<?xf32>, memref<?xf32>, memref<?xf32>) -> ()
+    "lmhlo.dynamic_broadcast_in_dim"(%tmp, %input3, %out) {broadcast_dimensions = dense<2> : tensor<1xi64>} : (memref<?xf32>, memref<3xi32>, memref<?x?x?xf32>) -> ()
+    // CHECK: "lmhlo.terminator"() : () -> ()
+    "lmhlo.terminator"() : () -> ()
+  } ) : () -> ()
+  // CHECK: return %[[OUT]] : memref<?x?x?xf32>
+  return %out : memref<?x?x?xf32>
+}
+
+// CHECK-LABEL: @multioutput_loop_fusion_with_dependency
+// CHECK-SAME: (%[[INPUT1:.*]]: memref<?xf32>, %[[INPUT2:.*]]: memref<3xi32>, %[[INPUT3:.*]]: memref<?x?x?xf32>, %[[TMP_BUF:.*]]: memref<?x?x?xf32>, %[[OUT1:.*]]: memref<?x?x?xf32>, %[[OUT2:.*]]: memref<?x?x?xf32>) -> (memref<?x?x?xf32>, memref<?x?x?xf32>)
+func @multioutput_loop_fusion_with_dependency(%input1: memref<?xf32>, %input2: memref<3xi32>, %input3: memref<?x?x?xf32>, %tmp: memref<?x?x?xf32>, %out_1: memref<?x?x?xf32>, %out_2: memref<?x?x?xf32>) -> (memref<?x?x?xf32>, memref<?x?x?xf32>) {
+  // CHECK: "lmhlo.fusion"() ( {
+  "lmhlo.fusion"() ( {
+    // CHECK: lmhlo.dynamic_broadcast_in_dim
+    // CHECK: lmhlo.add
+    // CHECK-NOT: lmhlo.multiply
+    // CHECK: scf.parallel
+    "lmhlo.dynamic_broadcast_in_dim"(%input1, %input2, %tmp) {broadcast_dimensions = dense<2> : tensor<1xi64>} : (memref<?xf32>, memref<3xi32>, memref<?x?x?xf32>) -> ()
+    "lmhlo.add"(%input3, %tmp, %out_1) : (memref<?x?x?xf32>, memref<?x?x?xf32>, memref<?x?x?xf32>) -> ()
+    "lmhlo.multiply"(%input3, %out_1, %out_2) : (memref<?x?x?xf32>, memref<?x?x?xf32>, memref<?x?x?xf32>) -> ()
+    // CHECK: "lmhlo.terminator"() : () -> ()
+    "lmhlo.terminator"() : () -> ()
+  }) : () -> ()
+  // CHECK: return %[[OUT1]], %[[OUT2]] : memref<?x?x?xf32>, memref<?x?x?xf32>
+  return %out_1, %out_2 : memref<?x?x?xf32>, memref<?x?x?xf32>
+}
+
+// CHECK-LABEL: @multioutput_loop_fusion_without_dependency
+// CHECK-SAME: (%[[INPUT1:.*]]: memref<?xf32>, %[[INPUT2:.*]]: memref<3xi32>, %[[INPUT3:.*]]: memref<?x?x?xf32>, %[[TMP_BUF:.*]]: memref<?x?x?xf32>, %[[OUT1:.*]]: memref<?x?x?xf32>, %[[OUT2:.*]]: memref<?x?x?xf32>) -> (memref<?x?x?xf32>, memref<?x?x?xf32>)
+func @multioutput_loop_fusion_without_dependency(%input1: memref<?xf32>, %input2: memref<3xi32>, %input3: memref<?x?x?xf32>, %tmp: memref<?x?x?xf32>, %out_1: memref<?x?x?xf32>, %out_2: memref<?x?x?xf32>) -> (memref<?x?x?xf32>, memref<?x?x?xf32>) {
+  // CHECK: "lmhlo.fusion"() ( {
+  "lmhlo.fusion"() ( {
+    // CHECK: lmhlo.dynamic_broadcast_in_dim
+    // CHECK-NOT: lmhlo.add
+    // CHECK-NOT: lmhlo.multiply
+    // CHECK: scf.parallel
+    "lmhlo.dynamic_broadcast_in_dim"(%input1, %input2, %tmp) {broadcast_dimensions = dense<2> : tensor<1xi64>} : (memref<?xf32>, memref<3xi32>, memref<?x?x?xf32>) -> ()
+    "lmhlo.add"(%input3, %tmp, %out_1) : (memref<?x?x?xf32>, memref<?x?x?xf32>, memref<?x?x?xf32>) -> ()
+    "lmhlo.multiply"(%input3, %tmp, %out_2) : (memref<?x?x?xf32>, memref<?x?x?xf32>, memref<?x?x?xf32>) -> ()
+    // CHECK: "lmhlo.terminator"() : () -> ()
+    "lmhlo.terminator"() : () -> ()
+  }) : () -> ()
+  // CHECK: return %[[OUT1]], %[[OUT2]] : memref<?x?x?xf32>, memref<?x?x?xf32>
+  return %out_1, %out_2 : memref<?x?x?xf32>, memref<?x?x?xf32>
+}


### PR DESCRIPTION
This PR is currently WIP for a discussion in advance. More UTs will be added.

The basic codegen flow will be:
step 1, LhloLegalizeRootsToParallelLoops
step 2, InputInlineFusion
step 3, canonicalize & CSE to optimize the redundant index calculations, we will need a MemRefLoadCSE here since the general cse will not process memref.load (this is only an optimization and will sent PRs as second priority)
step 4, Inline the lmhlo.Fusion
step 5, ParallelToGPULaunch/ParallelToOpenMP

Codegen schedules other than the basic loop schedule are seperated into incoming PRs. And lmhlo Ops support other than RealDynamicSlice, DynamicBroadcastInDim & BroadcastInDim in lhlo_elemental_util are also seperated into subsequent PRs.
Other known TODOs includes:
(1) There is potential redundant Linearize/Delinearize calculations in the initial version. memref.LinearizeIndex/Delinearize op will be brought in future PRs to optimize the index calculation. As discussed in https://llvm.discourse.group/t/add-an-expanded-load-store-op-in-memref-dialect/3503/17.

fusion_utils depends on https://github.com/tensorflow/tensorflow/pull/50020 and will be removed after it's done.