### PR TITLE
Added protobuf systemlib stub needed by gRPC.

### DIFF
--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -570,6 +570,7 @@ def _tf_repositories():
         system_build_file = "//third_party/systemlibs:protobuf.BUILD",
         system_link_files = {
             "//third_party/systemlibs:protobuf.bzl": "protobuf.bzl",
+            "//third_party/systemlibs:protobuf_deps.bzl": "protobuf_deps.bzl",
         },
         urls = [
             "https://storage.googleapis.com/mirror.tensorflow.org/github.com/protocolbuffers/protobuf/archive/v3.9.2.zip",

--- a/third_party/systemlibs/protobuf_deps.bzl
+++ b/third_party/systemlibs/protobuf_deps.bzl
@@ -1,0 +1,2 @@
+def protobuf_deps():
+    pass


### PR DESCRIPTION
An unusual (but possible) systemlib configuration is to use system
libprotobuf but bundled gRPC. This doesn't currently work: gRPC requires
the protobuf_deps rule that isn't defined by systemlib libprotobuf.

This change adds the rule, fixing that particular systemlib
configuration.