### PR TITLE
Fix systemlib rule to support gRPC

### DIFF
--- a/third_party/repo.bzl
+++ b/third_party/repo.bzl
@@ -28,10 +28,11 @@ def _use_system_lib(ctx, name):
     return name in [n.strip() for n in syslibenv.split(",")]
 
 def _get_link_dict(ctx, link_files, build_file):
+    link_dict = {ctx.path(v): ctx.path(Label(k)) for k, v in link_files.items()}
     if build_file:
         # Use BUILD.bazel because it takes precedence over BUILD.
-        link_files = dict(link_files, **{build_file: "BUILD.bazel"})
-    return {ctx.path(v): ctx.path(Label(k)) for k, v in link_files.items()}
+        link_dict[ctx.path("BUILD.bazel")] = ctx.path(Label(build_file))
+    return link_dict
 
 def _tf_http_archive_impl(ctx):
     # Construct all paths early on to prevent rule restart. We want the


### PR DESCRIPTION
Systemlib rules currently can't handle the systemlib build file appearing in the system link dictionary.

This occurs in the gRPC target here:
https://github.com/tensorflow/tensorflow/blob/a4dfb8d1a71385bd6d122e4f27f86dcebb96712d/tensorflow/workspace2.bzl#L639

Gentoo (the primary client of systemlib) only packages TF 2.4.0,
potentially explaining why the new systemlib logic hasn't been exercised
for gRPC.

This change fixes the issue with the systemlib logic.