### PR TITLE
[determinism] Factor core/kernels RequireDeterminism() into library

### DIFF
--- a/tensorflow/core/kernels/segment_reduction_ops.h
+++ b/tensorflow/core/kernels/segment_reduction_ops.h
@@ -32,7 +32,6 @@ namespace tensorflow {
 
 class OpKernelContext;
 
-bool RequireDeterminism();
 bool DisableSegmentReductionOpDeterminismExceptions();
 
 namespace functor {

--- a/tensorflow/core/kernels/segment_reduction_ops_impl.h
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl.h
@@ -38,6 +38,7 @@ limitations under the License.
 #include "tensorflow/core/kernels/segment_reduction_ops.h"
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/platform/logging.h"
+#include "tensorflow/core/util/determinism.h"
 #include "tensorflow/core/util/util.h"
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
@@ -305,7 +306,7 @@ class SegmentReductionGPUOp : public AsyncOpKernel {
       // (required for OP_REQUIRES_ASYNC) is not available inside the functor.
       bool determinism_requirement_met =
           SegmentReductionFunctor::atomic_reduction_is_associative ||
-          !RequireDeterminism() ||
+          !OpDeterminismRequired() ||
           DisableSegmentReductionOpDeterminismExceptions();
       OP_REQUIRES_ASYNC(
           context, determinism_requirement_met,

--- a/tensorflow/core/util/determinism.h
+++ b/tensorflow/core/util/determinism.h
@@ -18,8 +18,6 @@ limitations under the License.
 
 namespace tensorflow {
 
-// TODO(duncanriach): use this to replace existing instances of
-// RequireDeterminism in various core/kernels.
 bool OpDeterminismRequired();
 
 }  // namespace tensorflow

--- a/tensorflow/python/kernel_tests/sparse_xent_op_deterministic_test.py
+++ b/tensorflow/python/kernel_tests/sparse_xent_op_deterministic_test.py
@@ -58,7 +58,7 @@ class SparseSoftmaxCrossEntropyWithLogitsDeterminismExceptionsTest(
           with self.assertRaisesRegex(
               errors_impl.UnimplementedError,
               "Deterministic GPU implementation of " +
-              "SparseSoftmaxCrossEntropyWithLogits not available."):
+              "SparseSoftmaxXentWithLogitsOp not available."):
             result = nn_ops.sparse_softmax_cross_entropy_with_logits_v2(
                 labels=labels, logits=logits)
             self.evaluate(result)

--- a/tensorflow/python/kernel_tests/xent_op_deterministic_test.py
+++ b/tensorflow/python/kernel_tests/xent_op_deterministic_test.py
@@ -36,10 +36,10 @@ from tensorflow.python.platform import test
 
 
 class XentOpDeterminismExceptionsTest(test.TestCase):
-  """Test d9m-unimplemented exceptions from SoftmaxCrossEntropyWithLogits.
+  """Test d9m-unimplemented exceptions from SoftmaxXentWithLogitsOp.
 
   Test that tf.errors.UnimplementedError is thrown, as appropriate, by the GPU
-  code-paths for SoftmaxCrossEntropyWithLogits when deterministic ops are
+  code-paths through SoftmaxXentWithLogitsOp when deterministic ops are
   enabled.
 
   This test assumes that xent_op_test.py runs equivalent test cases when


### PR DESCRIPTION
This PR performs a few housekeeping tasks related to GPU-determinism, the most significant of which is factoring various instances of the `RequireDeterminism` function in `core/kernels` into (the previously-implemented) `core/kernels/util/determinism.cc/.h` (as `OpDeterminismRequired`), a follow-up to [this conversation](https://github.com/tensorflow/tensorflow/pull/47772#discussion_r594847461) with @sanjoy on PR [47772](https://github.com/tensorflow/tensorflow/pull/47772).

cc @reedwm @nluehr