### PR TITLE
Remove meaningless log in KernelDefBuilder

### DIFF
--- a/tensorflow/core/framework/kernel_def_builder.cc
+++ b/tensorflow/core/framework/kernel_def_builder.cc
@@ -40,7 +40,6 @@ KernelDefBuilder& KernelDefBuilder::AttrConstraint<int64>(
   constraint->set_name(attr_name);
   auto* allowed_values = constraint->mutable_allowed_values()->mutable_list();
   for (const int64 integer : allowed) {
-    LOG(INFO) << integer;
     allowed_values->add_i(integer);
   }
   return *this;


### PR DESCRIPTION
I see a wall of meaningless logs from KernelDefBuilder:
```
2021-06-08 15:48:21.962466: I tensorflow/core/framework/kernel_def_builder.cc:43] 0
2021-06-08 15:48:21.962475: I tensorflow/core/framework/kernel_def_builder.cc:43] 1
2021-06-08 15:48:21.962492: I tensorflow/core/framework/kernel_def_builder.cc:43] 0
2021-06-08 15:48:21.962501: I tensorflow/core/framework/kernel_def_builder.cc:43] 1
2021-06-08 15:48:21.962522: I tensorflow/core/framework/kernel_def_builder.cc:43] 0
2021-06-08 15:48:21.962530: I tensorflow/core/framework/kernel_def_builder.cc:43] 1
2021-06-08 15:48:21.962543: I tensorflow/core/framework/kernel_def_builder.cc:43] 0
2021-06-08 15:48:21.962552: I tensorflow/core/framework/kernel_def_builder.cc:43] 1
```
and so on...

No point to print such logs.