### PR TITLE
[XLA] Bitcast lift

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -1134,6 +1134,7 @@ tf_cc_test(
     deps = [
         ":fusion_bitcast_lift",
         "//tensorflow/compiler/xla/service:hlo_parser",
+        "//tensorflow/compiler/xla/tests:filecheck",
         "//tensorflow/compiler/xla/tests:hlo_test_base",
         "//tensorflow/compiler/xla/tests:xla_internal_test_main",
     ],

--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -1115,6 +1115,31 @@ tf_cc_test(
 )
 
 cc_library(
+    name = "fusion_bitcast_lift",
+    srcs = ["fusion_bitcast_lift.cc"],
+    hdrs = ["fusion_bitcast_lift.h"],
+    deps = [
+        ":gpu_fusible",
+        "//tensorflow/compiler/xla:shape_util",
+        "//tensorflow/compiler/xla/service:hlo",
+        "//tensorflow/compiler/xla/service:hlo_pass",
+        "//tensorflow/core:lib",
+    ],
+)
+
+tf_cc_test(
+    name = "fusion_bitcast_lift_test",
+    srcs = ["fusion_bitcast_lift_test.cc"],
+    tags = ["no_pip"],
+    deps = [
+        ":fusion_bitcast_lift",
+        "//tensorflow/compiler/xla/service:hlo_parser",
+        "//tensorflow/compiler/xla/tests:hlo_test_base",
+        "//tensorflow/compiler/xla/tests:xla_internal_test_main",
+    ],
+)
+
+cc_library(
     name = "fusion_merger",
     srcs = ["fusion_merger.cc"],
     hdrs = ["fusion_merger.h"],
@@ -1342,6 +1367,7 @@ cc_library(
     deps = [
         ":alias_passthrough_params",
         ":cudnn_batchnorm_rewriter",
+        ":fusion_bitcast_lift",
         ":fusion_merger",
         ":gemm_rewriter",
         ":gpu_constants",

--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -1119,11 +1119,13 @@ cc_library(
     srcs = ["fusion_bitcast_lift.cc"],
     hdrs = ["fusion_bitcast_lift.h"],
     deps = [
-        ":gpu_fusible",
+        "//tensorflow/core/platform:errors",
         "//tensorflow/compiler/xla:shape_util",
         "//tensorflow/compiler/xla/service:hlo",
+        "//tensorflow/compiler/xla/service:hlo_casting_utils",
+        "//tensorflow/compiler/xla/service:hlo_dce",
         "//tensorflow/compiler/xla/service:hlo_pass",
-        "//tensorflow/core:lib",
+        "@com_google_absl//absl/types:span",
     ],
 )
 

--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -1119,13 +1119,13 @@ cc_library(
     srcs = ["fusion_bitcast_lift.cc"],
     hdrs = ["fusion_bitcast_lift.h"],
     deps = [
-        "//tensorflow/core/platform:errors",
         "//tensorflow/compiler/xla:shape_util",
         "//tensorflow/compiler/xla/service:hlo",
         "//tensorflow/compiler/xla/service:hlo_casting_utils",
         "//tensorflow/compiler/xla/service:hlo_dce",
         "//tensorflow/compiler/xla/service:hlo_pass",
         "//tensorflow/compiler/xla/service:hlo_verifier",
+        "//tensorflow/core/platform:errors",
         "@com_google_absl//absl/types:span",
     ],
 )

--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -1125,6 +1125,7 @@ cc_library(
         "//tensorflow/compiler/xla/service:hlo_casting_utils",
         "//tensorflow/compiler/xla/service:hlo_dce",
         "//tensorflow/compiler/xla/service:hlo_pass",
+        "//tensorflow/compiler/xla/service:hlo_verifier",
         "@com_google_absl//absl/types:span",
     ],
 )

--- a/tensorflow/compiler/xla/service/gpu/fusion_bitcast_lift.cc
+++ b/tensorflow/compiler/xla/service/gpu/fusion_bitcast_lift.cc
@@ -1,0 +1,197 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/compiler/xla/service/gpu/fusion_bitcast_lift.h"
+#include "tensorflow/compiler/xla/service/hlo_casting_utils.h"
+#include "tensorflow/compiler/xla/service/hlo_instructions.h"
+#include "tensorflow/compiler/xla/shape_util.h"
+
+namespace xla {
+namespace gpu {
+
+// Returns true if all instructions are supported operations.
+bool AreInstructionSupported(HloComputation* comp) {
+  for (HloInstruction* instr: comp->instructions()) {
+    bool supported =
+      (HloInstruction::IsOpElementwise(instr->opcode()) ||
+       instr->opcode() == HloOpcode::kConstant ||
+       instr->opcode() == HloOpcode::kReduce ||
+       instr->opcode() == HloOpcode::kTuple ||
+       instr->opcode() == HloOpcode::kParameter ||
+       (instr->opcode() == HloOpcode::kBitcast &&
+        instr->shape().rank() < instr->operand(0)->shape().rank()) ||
+       (instr->opcode() == HloOpcode::kBroadcast &&
+        (instr->dimensions().size() == 0 ||   // scalar broadcasting
+         (instr->dimensions().size() == 1 &&  // row broadcasting
+          instr->dimensions()[0] == (instr->shape().rank() - 1)))));
+    if (!supported) {
+      VLOG(2) << "NOT SUPPORTED " << instr->ToString();
+      return false;
+    }
+  }
+  return true;
+}
+
+StatusOr<bool> FusionBitcastLift::Run(HloModule* module) {
+  XLA_VLOG_LINES(2, "FusionBitcastLift::Run(), before:\n" + module->ToString());
+  bool changed = false;
+  for (auto* comp : module->MakeNonfusionComputations()) {
+    // Copy the instruction list as we modify the HloComputation.
+    std::vector<HloInstruction*> comp_instruction(comp->instructions().begin(),
+                                                  comp->instructions().end());
+    for (auto it = comp_instruction.begin(); it != comp_instruction.end();
+         it++) {
+      // 1) Is this a fusion that we want to modify.
+      HloInstruction* instr = *it;
+      if (HloFusionInstruction* fusion = DynCast<HloFusionInstruction>(instr)) {
+        // 1.1) We only support kInput fusion and some operations.
+        if (fusion->fusion_kind() != HloInstruction::FusionKind::kInput ||
+	    !AreInstructionSupported(
+                fusion->fused_instructions_computation())) {
+          continue;
+        }
+        // 1.2) Check if there is a bitcast that we lift. Currently
+        //      we do not lift(merge) bitcast above(with) broadcast.
+        if (!std::any_of(fusion->fused_instructions().begin(),
+                         fusion->fused_instructions().end(),
+                         [](HloInstruction* inner) {
+              return inner->opcode() == HloOpcode::kBitcast &&
+                  inner->operand(0)->opcode() != HloOpcode::kBroadcast;
+                         })) {
+          continue;
+        }
+        // 1.3) Check that all the bitcast have the same shape pattern.
+        //      Multiple bitcast pattern isn't supported/tested.
+	std::vector<HloInstruction*> bitcasts;
+	for (HloInstruction* fused_instr : fusion->fused_instructions()) {
+	  if (fused_instr->opcode() == HloOpcode::kBitcast &&
+	      fused_instr->shape().rank() <
+	      fused_instr->operand(0)->shape().rank()) {
+	    if (bitcasts.size() > 0 && (
+                    !ShapeUtil::Equal(fused_instr->shape(),
+				      bitcasts[0]->shape()) ||
+                    !ShapeUtil::Equal(bitcasts[0]->operand(0)->shape(),
+				      fused_instr->operand(0)->shape()))) {
+	      continue;
+	    }
+	    bitcasts.push_back(fused_instr);
+	  }
+	}
+
+	// 2) Now that we have found a fusion that we want to modify,
+	//    create the new fusion. We do so by:
+	//    a) Cloning the old fusion.
+	//    b) Recursively walk the graph from the root and lift
+	//       the bitcast one instruction at a time.
+	std::unique_ptr<HloInstruction> cloned_fusion =
+	  fusion->Clone("bitcast");
+	std::vector<HloInstruction*> stack(
+					   {cloned_fusion->fused_expression_root()});
+	bool clone_changed = false;
+	while (stack.size() > 0) {
+	  HloInstruction* i = stack.back();
+	  stack.pop_back();
+	  if (i->opcode() == HloOpcode::kTuple) {
+	    stack.insert(stack.end(), i->operands().begin(),
+			 i->operands().end());
+	    continue;
+	  } else if (i->opcode() == HloOpcode::kParameter &&
+		     absl::c_all_of(i->users(), [](HloInstruction* u) {
+                         return u->opcode() == HloOpcode::kBitcast;
+                       })) {
+	    // Replace the parameter inside the fusion.
+	    Shape new_shape = i->users()[0]->shape();
+	    int64 parameter_number = i->parameter_number();
+	    string name = i->name();
+	    auto n = HloInstruction::CreateParameter(parameter_number,
+						     new_shape, name);
+	    HloInstruction* new_parameter =
+	      i->parent()->ReplaceParameter(parameter_number,
+					    std::move(n));
+	    // Remove the old inner bitcast.
+	    auto old_users = new_parameter->users();
+	    for (HloInstruction* param_user : old_users) {
+	      DCHECK(param_user->opcode() == HloOpcode::kBitcast)
+		<< "Expected a bitcast";
+	      param_user->parent()->ReplaceInstructionWithDifferentShape(
+									 param_user, new_parameter);
+	    }
+	    // Replace the corresponding fusion operands with a new bitcast.
+	    HloInstruction* old_outer_parameter =
+	      cloned_fusion->mutable_operand(parameter_number);
+	    HloInstruction* new_op =
+	      old_outer_parameter->parent()->AddInstruction(
+                    HloInstruction::CreateBitcast(new_shape,
+						  old_outer_parameter));
+	    cloned_fusion->ReplaceOperandWithDifferentShape(
+                parameter_number, new_op);
+	    clone_changed = true;
+	    changed = true;
+	  } else if (i->opcode() == HloOpcode::kBroadcast) {
+	    // For now, do nothing. Later we can merge the broadcast
+	    // and the bitcast, but this doesn't bring benefit in my
+	    // current case.
+	    stack.push_back(i->mutable_operand(0));
+	  } else if (i->users().size() > 0 &&
+		     absl::c_all_of(i->users(), [](HloInstruction* u) {
+                         return u->opcode() == HloOpcode::kBitcast;
+                       })) {
+	    // All users are bitcast, so lift the bitcast.
+	    Shape new_shape = i->users()[0]->shape();
+	    std::vector<HloInstruction*> new_operands;
+	    for (HloInstruction* opnd : i->operands()) {
+	      Shape dtyped_new_shape = ShapeUtil::ChangeElementType(
+                  new_shape, opnd->shape().element_type());
+	      HloInstruction* new_opnd = opnd->parent()->AddInstruction(
+                  HloInstruction::CreateBitcast(dtyped_new_shape, opnd));
+	      new_operands.push_back(new_opnd);
+	      // Handle the operand right before the inserted bitcast now.
+	      if (std::find(stack.begin(), stack.end(), opnd) ==
+		  stack.end()) {
+		stack.push_back(opnd);
+	      }
+	    }
+	    Shape dtyped_new_shape = ShapeUtil::ChangeElementType(
+                new_shape, i->shape().element_type());
+	    HloInstruction* cloned_i = i->parent()->AddInstruction(
+                i->CloneWithNewOperands(dtyped_new_shape, new_operands));
+	    // Replace the old bitcasts with the new instruction to
+	    // remove it.
+	    for (HloInstruction* user: i->users()) {
+	      i->parent()->ReplaceInstructionWithDifferentShape(
+                  user, cloned_i);
+	    }
+	    clone_changed = true;
+	    changed = true;
+	  } else {
+	    stack.insert(stack.end(), i->operands().begin(),
+			 i->operands().end());
+	  }
+	}  // while
+	DCHECK(clone_changed) << "We should have changed the fusion!";
+	if (clone_changed) {
+	  // 3) Replace the old fusion with the new fusion.
+	  fusion->parent()->ReplaceWithNewInstruction(
+              fusion, std::move(cloned_fusion));
+	}
+      } // if fusion
+    }
+  }
+  XLA_VLOG_LINES(2, "FusionBitcastLift::Run(), after:\n" + module->ToString());
+  return changed;
+}
+
+}  // namespace gpu
+}  // namespace xla

--- a/tensorflow/compiler/xla/service/gpu/fusion_bitcast_lift.cc
+++ b/tensorflow/compiler/xla/service/gpu/fusion_bitcast_lift.cc
@@ -193,7 +193,9 @@ StatusOr<bool> FusionBitcastLift::Run(HloModule* module) {
                 i->CloneWithNewOperands(dtyped_new_shape, new_operands));
             // Replace the old bitcasts with the new instruction to
             // remove it.
-            for (HloInstruction* user: i->users()) {
+            // Copy the vector as it will be modified while we iterate on it.
+            const std::vector<HloInstruction*> users = i->users();
+            for (HloInstruction* user: users) {
               TF_RETURN_IF_ERROR(i->parent()->ReplaceInstructionWithDifferentShape(
                   user, cloned_i));
             }

--- a/tensorflow/compiler/xla/service/gpu/fusion_bitcast_lift.cc
+++ b/tensorflow/compiler/xla/service/gpu/fusion_bitcast_lift.cc
@@ -127,7 +127,6 @@ StatusOr<bool> FusionBitcastLift::Run(HloModule* module) {
                          i->operands().end());
             set.insert(i->operands().begin(),
                        i->operands().end());
-            continue;
           } else if (i->opcode() == HloOpcode::kParameter &&
                      absl::c_all_of(i->users(), [](HloInstruction* u) {
                          return u->opcode() == HloOpcode::kBitcast;

--- a/tensorflow/compiler/xla/service/gpu/fusion_bitcast_lift.h
+++ b/tensorflow/compiler/xla/service/gpu/fusion_bitcast_lift.h
@@ -1,0 +1,42 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_COMPILER_XLA_SERVICE_GPU_FUSION_BITCAST_LIFT_H_
+#define TENSORFLOW_COMPILER_XLA_SERVICE_GPU_FUSION_BITCAST_LIFT_H_
+
+#include "tensorflow/compiler/xla/service/hlo_module.h"
+#include "tensorflow/compiler/xla/service/hlo_pass_interface.h"
+
+namespace xla {
+namespace gpu {
+
+// Lift "rank-reducing bitcast" inside fusions to outside the fusion.
+//
+// Bitcast instruction are no-op, so we can duplicate them for free.
+// "rank-reducing bitcast" is defined to be a bitcast whose output have
+// a lower rank than the input.  Inside a fusion, we lift the
+// "rank-reducing bitcast" out of the fusion as this allow using simpler,
+// so faster, indexing.
+class FusionBitcastLift : public HloModulePass {
+ public:
+  absl::string_view name() const override { return "fusion_bitcast_lift"; }
+
+  StatusOr<bool> Run(HloModule* module) override;
+};
+
+}  // namespace gpu
+}  // namespace xla
+
+#endif  // TENSORFLOW_COMPILER_XLA_SERVICE_GPU_FUSION_BITCAST_LIFT_H_

--- a/tensorflow/compiler/xla/service/gpu/fusion_bitcast_lift_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/fusion_bitcast_lift_test.cc
@@ -366,12 +366,194 @@ ENTRY %main {
                     R"(
 ; CHECK-LABEL: %fused_computation
 ; CHECK:         f16[392,672]{1,0} parameter(0)
-; CHECK-COUNT-1: bitcast
+; CHECK-COUNT-1: bitcast(
+; CHECK-NOT:     bitcast(
 ; CHECK-LABEL: ENTRY %main
 ; CHECK-NEXT:    f16[392,672]{1,0} parameter(0)
 ; CHECK-NEXT:    f32[1]{0} parameter(1)
 ; CHECK-NEXT:    bitcast(
 ; CHECK-NEXT:    ROOT %fusion.bitcast
+      )");
+  EXPECT_TRUE(filecheck_result.status().ok());
+  EXPECT_TRUE(filecheck_result.ValueOrDie());
+}
+
+TEST_F(FusionBitcastLiftTest, Swish1Test) {
+  const char* hlo_text = R"(
+HloModule mod
+
+%scalar_add_computation (scalar_lhs.1: f32[], scalar_rhs.1: f32[]) -> f32[] {
+  %scalar_lhs.1 = f32[] parameter(0)
+  %scalar_rhs.1 = f32[] parameter(1)
+  ROOT %add.5 = f32[] add(f32[] %scalar_lhs.1, f32[] %scalar_rhs.1)
+}
+
+%fused_computation (param_0.90: f32[672], param_1.127: f16[2,14,14,672], param_2.77: f16[2,14,14,672], param_3.57: f16[2,14,14,672], param_4.57: f32[672], param_5.63: f32[672], param_6.44: f32[672]) -> (f32[672], f32[672]) {
+  %param_2.77 = f16[2,14,14,672]{3,2,1,0} parameter(2)
+  %param_3.57 = f16[2,14,14,672]{3,2,1,0} parameter(3)
+  %constant_153 = f16[] constant(1)
+  %broadcast.174 = f16[2,14,14,672]{3,2,1,0} broadcast(f16[] %constant_153), dimensions={}
+  %param_1.127 = f16[2,14,14,672]{3,2,1,0} parameter(1)
+  %convert.46 = f32[2,14,14,672]{3,2,1,0} convert(f16[2,14,14,672]{3,2,1,0} %param_1.127)
+  %param_0.90 = f32[672]{0} parameter(0)
+  %constant_77_clone_1 = f32[] constant(9.96492327e-06)
+  %broadcast.173 = f32[672]{0} broadcast(f32[] %constant_77_clone_1), dimensions={}
+  %multiply.155 = f32[672]{0} multiply(f32[672]{0} %param_0.90, f32[672]{0} %broadcast.173)
+  %broadcast.172 = f32[2,14,14,672]{3,2,1,0} broadcast(f32[672]{0} %multiply.155), dimensions={3}
+  %subtract.55 = f32[2,14,14,672]{3,2,1,0} subtract(f32[2,14,14,672]{3,2,1,0} %convert.46, f32[2,14,14,672]{3,2,1,0} %broadcast.172)
+  %param_6.44 = f32[672]{0} parameter(6)
+  %multiply.154 = f32[672]{0} multiply(f32[672]{0} %param_6.44, f32[672]{0} %broadcast.173)
+  %multiply.153 = f32[672]{0} multiply(f32[672]{0} %multiply.155, f32[672]{0} %multiply.155)
+  %subtract.54 = f32[672]{0} subtract(f32[672]{0} %multiply.154, f32[672]{0} %multiply.153)
+  %constant_151 = f32[] constant(0.001)
+  %broadcast.171 = f32[672]{0} broadcast(f32[] %constant_151), dimensions={}
+  %add.50 = f32[672]{0} add(f32[672]{0} %subtract.54, f32[672]{0} %broadcast.171)
+  %rsqrt.23 = f32[672]{0} rsqrt(f32[672]{0} %add.50)
+  %broadcast.170 = f32[2,14,14,672]{3,2,1,0} broadcast(f32[672]{0} %rsqrt.23), dimensions={3}
+  %multiply.152 = f32[2,14,14,672]{3,2,1,0} multiply(f32[2,14,14,672]{3,2,1,0} %subtract.55, f32[2,14,14,672]{3,2,1,0} %broadcast.170)
+  %param_5.63 = f32[672]{0} parameter(5)
+  %broadcast.169 = f32[2,14,14,672]{3,2,1,0} broadcast(f32[672]{0} %param_5.63), dimensions={3}
+  %multiply.151 = f32[2,14,14,672]{3,2,1,0} multiply(f32[2,14,14,672]{3,2,1,0} %multiply.152, f32[2,14,14,672]{3,2,1,0} %broadcast.169)
+  %param_4.57 = f32[672]{0} parameter(4)
+  %broadcast.168 = f32[2,14,14,672]{3,2,1,0} broadcast(f32[672]{0} %param_4.57), dimensions={3}
+  %add.48 = f32[2,14,14,672]{3,2,1,0} add(f32[2,14,14,672]{3,2,1,0} %multiply.151, f32[2,14,14,672]{3,2,1,0} %broadcast.168)
+  %convert.45 = f16[2,14,14,672]{3,2,1,0} convert(f32[2,14,14,672]{3,2,1,0} %add.48)
+  %subtract.53 = f16[2,14,14,672]{3,2,1,0} subtract(f16[2,14,14,672]{3,2,1,0} %broadcast.174, f16[2,14,14,672]{3,2,1,0} %param_3.57)
+  %multiply.150 = f16[2,14,14,672]{3,2,1,0} multiply(f16[2,14,14,672]{3,2,1,0} %convert.45, f16[2,14,14,672]{3,2,1,0} %subtract.53)
+  %add.47 = f16[2,14,14,672]{3,2,1,0} add(f16[2,14,14,672]{3,2,1,0} %broadcast.174, f16[2,14,14,672]{3,2,1,0} %multiply.150)
+  %multiply.149 = f16[2,14,14,672]{3,2,1,0} multiply(f16[2,14,14,672]{3,2,1,0} %param_3.57, f16[2,14,14,672]{3,2,1,0} %add.47)
+  %multiply.148 = f16[2,14,14,672]{3,2,1,0} multiply(f16[2,14,14,672]{3,2,1,0} %param_2.77, f16[2,14,14,672]{3,2,1,0} %multiply.149)
+  %convert.10 = f32[2,14,14,672]{3,2,1,0} convert(f16[2,14,14,672]{3,2,1,0} %multiply.148)
+  %bitcast.21 = f32[392,672]{1,0} bitcast(f32[2,14,14,672]{3,2,1,0} %convert.10)
+  %constant_57 = f32[] constant(0)
+  %reduce.9 = f32[672]{0} reduce(f32[392,672]{1,0} %bitcast.21, f32[] %constant_57), dimensions={0}, to_apply=%scalar_add_computation
+  %multiply.30.clone.1 = f32[2,14,14,672]{3,2,1,0} multiply(f32[2,14,14,672]{3,2,1,0} %convert.10, f32[2,14,14,672]{3,2,1,0} %subtract.55)
+  %bitcast.20.clone.1 = f32[392,672]{1,0} bitcast(f32[2,14,14,672]{3,2,1,0} %multiply.30.clone.1)
+  %reduce.8.clone.1 = f32[672]{0} reduce(f32[392,672]{1,0} %bitcast.20.clone.1, f32[] %constant_57), dimensions={0}, to_apply=%scalar_add_computation
+  ROOT %tuple.9 = (f32[672]{0}, f32[672]{0}) tuple(f32[672]{0} %reduce.9, f32[672]{0} %reduce.8.clone.1)
+}
+
+ENTRY %main {
+  %param_0 = f32[672]{0} parameter(0)
+  %param_1 = f16[2,14,14,672]{3,2,1,0} parameter(1)
+  %param_2 = f16[2,14,14,672]{3,2,1,0} parameter(2)
+  %param_3 = f16[2,14,14,672]{3,2,1,0} parameter(3)
+  %param_4 = f32[672]{0} parameter(4)
+  %param_5 = f32[672]{0} parameter(5)
+  %param_6 = f32[672]{0} parameter(6)
+
+  ROOT %fusion = (f32[672]{0}, f32[672]{0}) fusion(%param_0, %param_1, %param_2, %param_3, %param_4, %param_5, %param_6), kind=kInput, calls=%fused_computation
+}
+)";
+  auto module = ParseAndReturnVerifiedModule(hlo_text).ValueOrDie();
+  EXPECT_TRUE(FusionBitcastLift().Run(module.get()).ValueOrDie());
+  // Remove the old fusion not used anymore.
+  EXPECT_TRUE(HloDCE().Run(module.get()).ValueOrDie());
+
+  EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
+
+  StatusOr<bool> filecheck_result =
+      RunFileCheck(module->ToString(),
+                    R"(
+; CHECK-LABEL: %fused_computation
+; CHECK-COUNT-6: bitcast(
+; CHECK-NOT:     bitcast(
+; CHECK-LABEL: ENTRY %main
+; CHECK-COUNT-3: bitcast(
+; CHECK-NOT:     bitcast(
+; CHECK:         ROOT %fusion.bitcast
+      )");
+  EXPECT_TRUE(filecheck_result.status().ok());
+  EXPECT_TRUE(filecheck_result.ValueOrDie());
+}
+
+TEST_F(FusionBitcastLiftTest, Swish2Test) {
+  const char* hlo_text = R"(
+HloModule mod
+
+%scalar_add_computation (scalar_lhs.1: f32[], scalar_rhs.1: f32[]) -> f32[] {
+  %scalar_lhs.1 = f32[] parameter(0)
+  %scalar_rhs.1 = f32[] parameter(1)
+  ROOT %add.5 = f32[] add(f32[] %scalar_lhs.1, f32[] %scalar_rhs.1)
+}
+
+
+%fused_computation (param_0.95: f32[672], param_1.128: f16[2,14,14,672], param_2.81: f16[2,14,14,672], param_3.66: f32[672], param_4.61: f32[672], param_5.62: f32[672]) -> (f32[672], f32[672]) {
+  %param_2.81 = f16[2,14,14,672]{3,2,1,0} parameter(2)
+  %constant_211 = f16[] constant(1)
+  %broadcast.288 = f16[2,14,14,672]{3,2,1,0} broadcast(f16[] %constant_211), dimensions={}
+  %param_1.128 = f16[2,14,14,672]{3,2,1,0} parameter(1)
+  %convert.74 = f32[2,14,14,672]{3,2,1,0} convert(f16[2,14,14,672]{3,2,1,0} %param_1.128)
+  %param_0.95 = f32[672]{0} parameter(0)
+  %constant_77 = f32[] constant(9.96492327e-06)
+  %broadcast.287 = f32[672]{0} broadcast(f32[] %constant_77), dimensions={}
+  %multiply.253 = f32[672]{0} multiply(f32[672]{0} %param_0.95, f32[672]{0} %broadcast.287)
+  %broadcast.286 = f32[2,14,14,672]{3,2,1,0} broadcast(f32[672]{0} %multiply.253), dimensions={3}
+  %subtract.92 = f32[2,14,14,672]{3,2,1,0} subtract(f32[2,14,14,672]{3,2,1,0} %convert.74, f32[2,14,14,672]{3,2,1,0} %broadcast.286)
+  %param_5.62 = f32[672]{0} parameter(5)
+  %multiply.252 = f32[672]{0} multiply(f32[672]{0} %param_5.62, f32[672]{0} %broadcast.287)
+  %multiply.250 = f32[672]{0} multiply(f32[672]{0} %multiply.253, f32[672]{0} %multiply.253)
+  %subtract.91 = f32[672]{0} subtract(f32[672]{0} %multiply.252, f32[672]{0} %multiply.250)
+  %constant_208 = f32[] constant(0.001)
+  %broadcast.284 = f32[672]{0} broadcast(f32[] %constant_208), dimensions={}
+  %add.93 = f32[672]{0} add(f32[672]{0} %subtract.91, f32[672]{0} %broadcast.284)
+  %rsqrt.37 = f32[672]{0} rsqrt(f32[672]{0} %add.93)
+  %broadcast.283 = f32[2,14,14,672]{3,2,1,0} broadcast(f32[672]{0} %rsqrt.37), dimensions={3}
+  %multiply.249 = f32[2,14,14,672]{3,2,1,0} multiply(f32[2,14,14,672]{3,2,1,0} %subtract.92, f32[2,14,14,672]{3,2,1,0} %broadcast.283)
+  %param_4.61 = f32[672]{0} parameter(4)
+  %broadcast.282 = f32[2,14,14,672]{3,2,1,0} broadcast(f32[672]{0} %param_4.61), dimensions={3}
+  %multiply.248 = f32[2,14,14,672]{3,2,1,0} multiply(f32[2,14,14,672]{3,2,1,0} %multiply.249, f32[2,14,14,672]{3,2,1,0} %broadcast.282)
+  %param_3.66 = f32[672]{0} parameter(3)
+  %broadcast.281 = f32[2,14,14,672]{3,2,1,0} broadcast(f32[672]{0} %param_3.66), dimensions={3}
+  %add.92 = f32[2,14,14,672]{3,2,1,0} add(f32[2,14,14,672]{3,2,1,0} %multiply.248, f32[2,14,14,672]{3,2,1,0} %broadcast.281)
+  %convert.73 = f16[2,14,14,672]{3,2,1,0} convert(f32[2,14,14,672]{3,2,1,0} %add.92)
+  %negate.14 = f16[2,14,14,672]{3,2,1,0} negate(f16[2,14,14,672]{3,2,1,0} %convert.73)
+  %exponential.12 = f16[2,14,14,672]{3,2,1,0} exponential(f16[2,14,14,672]{3,2,1,0} %negate.14)
+  %add.91 = f16[2,14,14,672]{3,2,1,0} add(f16[2,14,14,672]{3,2,1,0} %broadcast.288, f16[2,14,14,672]{3,2,1,0} %exponential.12)
+  %divide.22 = f16[2,14,14,672]{3,2,1,0} divide(f16[2,14,14,672]{3,2,1,0} %broadcast.288, f16[2,14,14,672]{3,2,1,0} %add.91)
+  %subtract.88 = f16[2,14,14,672]{3,2,1,0} subtract(f16[2,14,14,672]{3,2,1,0} %broadcast.288, f16[2,14,14,672]{3,2,1,0} %divide.22)
+  %multiply.241 = f16[2,14,14,672]{3,2,1,0} multiply(f16[2,14,14,672]{3,2,1,0} %convert.73, f16[2,14,14,672]{3,2,1,0} %subtract.88)
+  %add.87 = f16[2,14,14,672]{3,2,1,0} add(f16[2,14,14,672]{3,2,1,0} %broadcast.288, f16[2,14,14,672]{3,2,1,0} %multiply.241)
+  %multiply.240 = f16[2,14,14,672]{3,2,1,0} multiply(f16[2,14,14,672]{3,2,1,0} %divide.22, f16[2,14,14,672]{3,2,1,0} %add.87)
+  %multiply.239 = f16[2,14,14,672]{3,2,1,0} multiply(f16[2,14,14,672]{3,2,1,0} %param_2.81, f16[2,14,14,672]{3,2,1,0} %multiply.240)
+  %convert.9 = f32[2,14,14,672]{3,2,1,0} convert(f16[2,14,14,672]{3,2,1,0} %multiply.239)
+  %multiply.30 = f32[2,14,14,672]{3,2,1,0} multiply(f32[2,14,14,672]{3,2,1,0} %convert.9, f32[2,14,14,672]{3,2,1,0} %subtract.92)
+  %bitcast.20 = f32[392,672]{1,0} bitcast(f32[2,14,14,672]{3,2,1,0} %multiply.30)
+  %constant_58 = f32[] constant(0)
+  %reduce.8 = f32[672]{0} reduce(f32[392,672]{1,0} %bitcast.20, f32[] %constant_58), dimensions={0}, to_apply=%scalar_add_computation
+  %bitcast.21.clone.1 = f32[392,672]{1,0} bitcast(f32[2,14,14,672]{3,2,1,0} %convert.9)
+  %reduce.9.clone.1 = f32[672]{0} reduce(f32[392,672]{1,0} %bitcast.21.clone.1, f32[] %constant_58), dimensions={0}, to_apply=%scalar_add_computation
+  ROOT %tuple.9 = (f32[672]{0}, f32[672]{0}) tuple(f32[672]{0} %reduce.8, f32[672]{0} %reduce.9.clone.1)
+}
+
+ENTRY %main {
+  %param_0 = f32[672]{0} parameter(0)
+  %param_1 = f16[2,14,14,672]{3,2,1,0} parameter(1)
+  %param_2 = f16[2,14,14,672]{3,2,1,0} parameter(2)
+  %param_3 = f32[672]{0} parameter(3)
+  %param_4 = f32[672]{0} parameter(4)
+  %param_5 = f32[672]{0} parameter(5)
+
+  ROOT %fusion = (f32[672]{0}, f32[672]{0}) fusion(%param_0, %param_1, %param_2, %param_3, %param_4, %param_5), kind=kInput, calls=%fused_computation
+}
+)";
+  auto module = ParseAndReturnVerifiedModule(hlo_text).ValueOrDie();
+  EXPECT_TRUE(FusionBitcastLift().Run(module.get()).ValueOrDie());
+  // Remove the old fusion not used anymore.
+  EXPECT_TRUE(HloDCE().Run(module.get()).ValueOrDie());
+
+  EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
+
+  StatusOr<bool> filecheck_result =
+      RunFileCheck(module->ToString(),
+                    R"(
+; CHECK-LABEL: %fused_computation
+; CHECK-COUNT-8: bitcast(
+; CHECK-NOT:     bitcast(
+; CHECK-LABEL: ENTRY %main
+; CHECK-COUNT-2: bitcast(
+; CHECK-NOT:     bitcast(
+; CHECK:         ROOT %fusion.bitcast
       )");
   EXPECT_TRUE(filecheck_result.status().ok());
   EXPECT_TRUE(filecheck_result.ValueOrDie());

--- a/tensorflow/compiler/xla/service/gpu/fusion_bitcast_lift_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/fusion_bitcast_lift_test.cc
@@ -1,0 +1,215 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/compiler/xla/service/gpu/fusion_bitcast_lift.h"
+
+#include <vector>
+
+#include "absl/types/span.h"
+#include "tensorflow/compiler/xla/service/hlo_parser.h"
+#include "tensorflow/compiler/xla/tests/hlo_test_base.h"
+
+namespace xla {
+namespace gpu {
+namespace {
+
+class FusionBitcastLiftTest : public HloTestBase {};
+
+// Tests that we lift bitcast outside the fusion.
+//
+// This test MultiOutputFusion, multiple consecutive lift, bitcast
+// with multiple users and bitcast that are used many time by the same
+// user. This is a real kernel from Efficient Net, but with smaller
+// shape to speed up tests.
+//
+// Input graph:
+// Fusion 4d input, 2 1d output
+//
+// After optimization, the graph is:
+// Bitcast 4d -> 2d
+//   |
+// Fusion 2d input, 2x1d outputs.
+TEST_F(FusionBitcastLiftTest, NoBroadcastTest) {
+  const char* hlo_text = R"(
+HloModule mod
+
+%scalar_add_computation (scalar_lhs.1: f32[], scalar_rhs.1: f32[]) -> f32[] {
+  %scalar_lhs.1 = f32[] parameter(0)
+  %scalar_rhs.1 = f32[] parameter(1)
+  ROOT %add.5 = f32[] add(f32[] %scalar_lhs.1, f32[] %scalar_rhs.1)
+}
+
+%fused_computation.21_4d (param_0.59: f16[2,14,14,672]) -> (f32[672], f32[672]) {
+  %param_0.59 = f16[2,14,14,672] parameter(0)
+  %convert.21 = f32[2,14,14,672] convert(%param_0.59)
+  %bitcast.25 = f32[392,672] bitcast(%convert.21)
+  %constant_84 = f32[] constant(0)
+  %reduce.12 = f32[672]{0} reduce(%bitcast.25, %constant_84), dimensions={0}, to_apply=%scalar_add_computation
+  %multiply.43.clone.1 = f32[2,14,14,672] multiply(%convert.21, %convert.21)
+  %bitcast.24.clone.1 = f32[392,672] bitcast(%multiply.43.clone.1)
+  %reduce.11.clone.1 = f32[672]{0} reduce(%bitcast.24.clone.1, %constant_84), dimensions={0}, to_apply=%scalar_add_computation
+  ROOT %tuple.13 = (f32[672]{0}, f32[672]{0}) tuple(%reduce.12, %reduce.11.clone.1)
+}
+
+ENTRY main {
+  %param_0.59 = f16[2,14,14,672] parameter(0)
+  ROOT %fusion.21_4d = (f32[672]{0}, f32[672]{0}) fusion(%param_0.59), kind=kInput, calls=%fused_computation.21_4d
+}
+)";
+  auto module = ParseAndReturnVerifiedModule(hlo_text).ValueOrDie();
+  EXPECT_TRUE(FusionBitcastLift().Run(module.get()).ValueOrDie());
+
+  auto* root = module->entry_computation()->root_instruction();
+  EXPECT_EQ(HloOpcode::kFusion, root->opcode());
+
+  // The fusion should have 1 input and it should be a bitcast with 2d output.
+  EXPECT_EQ(1, root->operands().size());
+  EXPECT_EQ(HloOpcode::kBitcast, root->operand(0)->opcode());
+  EXPECT_EQ(2, root->operand(0)->shape().rank());
+
+  // No bitcast should be left inside the fusion.
+  for (HloInstruction* instr : root->fused_instructions()) {
+    EXPECT_NE(HloOpcode::kBitcast, instr->opcode());
+  }
+
+  EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
+}
+
+// Tests that we lift bitcast outside the fusion when scalar broadcasting are
+// present.
+//
+// Input graph:
+// Fusion 1x4d and 1x0d inputs, 2 1d output
+//
+// After optimization, the graph is:
+// Bitcast 4d -> 2d
+//   |
+// Fusion 1x2d and 1x0d inputs, 2 1d output
+//   Inside the fusion, there is a bitcast left after the broadcast.
+TEST_F(FusionBitcastLiftTest, ScalarBroadcastTest) {
+  const char* hlo_text = R"(
+HloModule mod
+
+%scalar_add_computation (scalar_lhs.1: f32[], scalar_rhs.1: f32[]) -> f32[] {
+  %scalar_lhs.1 = f32[] parameter(0)
+  %scalar_rhs.1 = f32[] parameter(1)
+  ROOT %add.5 = f32[] add(f32[] %scalar_lhs.1, f32[] %scalar_rhs.1)
+}
+
+%fused_computation.21_4d (param_0.59: f16[2,14,14,672], param_1: f32[]) -> (f32[672], f32[672]) {
+  %param_0.59 = f16[2,14,14,672] parameter(0)
+  %convert.21 = f32[2,14,14,672] convert(%param_0.59)
+  %bitcast.25 = f32[392,672] bitcast(%convert.21)
+  %constant_84 = f32[] constant(0)
+  %reduce.12 = f32[672]{0} reduce(%bitcast.25, %constant_84), dimensions={0}, to_apply=%scalar_add_computation
+  %param_1 = f32[] parameter(1)
+  %broadcast = f32[2,14,14,672] broadcast(%param_1), dimensions={}
+  %multiply.43.clone.1 = f32[2,14,14,672] multiply(%convert.21, %broadcast)
+  %bitcast.24.clone.1 = f32[392,672] bitcast(%multiply.43.clone.1)
+  %reduce.11.clone.1 = f32[672]{0} reduce(%bitcast.24.clone.1, %constant_84), dimensions={0}, to_apply=%scalar_add_computation
+  ROOT %tuple.13 = (f32[672]{0}, f32[672]{0}) tuple(%reduce.12, %reduce.11.clone.1)
+}
+
+ENTRY main {
+  %param_0.59 = f16[2,14,14,672] parameter(0)
+  %param_1 = f32[] parameter(1)
+  ROOT %fusion.21_4d = (f32[672]{0}, f32[672]{0}) fusion(%param_0.59, %param_1), kind=kInput, calls=%fused_computation.21_4d
+}
+)";
+  auto module = ParseAndReturnVerifiedModule(hlo_text).ValueOrDie();
+  EXPECT_TRUE(FusionBitcastLift().Run(module.get()).ValueOrDie());
+
+  auto* root = module->entry_computation()->root_instruction();
+  EXPECT_EQ(HloOpcode::kFusion, root->opcode());
+
+  // The fusion should have 2 inputs and the first one should be a
+  // bitcast with 2d output.
+  EXPECT_EQ(2, root->operands().size());
+  EXPECT_EQ(HloOpcode::kBitcast, root->operand(0)->opcode());
+  EXPECT_EQ(2, root->operand(0)->shape().rank());
+
+  // Inside the fusion, there is 1 bitcast left after the broadcast.
+  EXPECT_EQ(HloOpcode::kBroadcast, root->fused_instructions_computation()
+                                       ->parameter_instruction(1)
+                                       ->users()[0]
+                                       ->opcode());
+  EXPECT_EQ(HloOpcode::kBitcast, root->fused_instructions_computation()
+                                     ->parameter_instruction(1)
+                                     ->users()[0]
+                                     ->users()[0]
+                                     ->opcode());
+
+  EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
+}
+
+TEST_F(FusionBitcastLiftTest, RowBroadcastTest) {
+  const char* hlo_text = R"(
+HloModule mod
+
+%scalar_add_computation (scalar_lhs.1: f32[], scalar_rhs.1: f32[]) -> f32[] {
+  %scalar_lhs.1 = f32[] parameter(0)
+  %scalar_rhs.1 = f32[] parameter(1)
+  ROOT %add.5 = f32[] add(f32[] %scalar_lhs.1, f32[] %scalar_rhs.1)
+}
+
+%fused_computation.21_4d (param_0.59: f16[2,14,14,672], param_1: f32[672]) -> (f32[672], f32[672]) {
+  %param_0.59 = f16[2,14,14,672] parameter(0)
+  %convert.21 = f32[2,14,14,672] convert(%param_0.59)
+  %bitcast.25 = f32[392,672] bitcast(%convert.21)
+  %constant_84 = f32[] constant(0)
+  %reduce.12 = f32[672]{0} reduce(%bitcast.25, %constant_84), dimensions={0}, to_apply=%scalar_add_computation
+  %param_1 = f32[672] parameter(1)
+  %broadcast = f32[2,14,14,672] broadcast(%param_1), dimensions={3}
+  %multiply.43.clone.1 = f32[2,14,14,672] multiply(%convert.21, %broadcast)
+  %bitcast.24.clone.1 = f32[392,672] bitcast(%multiply.43.clone.1)
+  %reduce.11.clone.1 = f32[672]{0} reduce(%bitcast.24.clone.1, %constant_84), dimensions={0}, to_apply=%scalar_add_computation
+  ROOT %tuple.13 = (f32[672]{0}, f32[672]{0}) tuple(%reduce.12, %reduce.11.clone.1)
+}
+
+ENTRY main {
+  %param_0.59 = f16[2,14,14,672] parameter(0)
+  %param_1 = f32[672] parameter(1)
+  ROOT %fusion.21_4d = (f32[672]{0}, f32[672]{0}) fusion(%param_0.59, %param_1), kind=kInput, calls=%fused_computation.21_4d
+}
+)";
+  auto module = ParseAndReturnVerifiedModule(hlo_text).ValueOrDie();
+  EXPECT_TRUE(FusionBitcastLift().Run(module.get()).ValueOrDie());
+
+  auto* root = module->entry_computation()->root_instruction();
+  EXPECT_EQ(HloOpcode::kFusion, root->opcode());
+
+  // The fusion should have 2 inputs and the first one should be a
+  // bitcast with 2d output.
+  EXPECT_EQ(2, root->operands().size());
+  EXPECT_EQ(HloOpcode::kBitcast, root->operand(0)->opcode());
+  EXPECT_EQ(2, root->operand(0)->shape().rank());
+
+  // Inside the fusion, there is 1 bitcast left after the broadcast.
+  EXPECT_EQ(HloOpcode::kBroadcast, root->fused_instructions_computation()
+                                       ->parameter_instruction(1)
+                                       ->users()[0]
+                                       ->opcode());
+  EXPECT_EQ(HloOpcode::kBitcast, root->fused_instructions_computation()
+                                     ->parameter_instruction(1)
+                                     ->users()[0]
+                                     ->users()[0]
+                                     ->opcode());
+
+  EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
+}
+
+}  // namespace
+}  // namespace gpu
+}  // namespace xla

--- a/tensorflow/compiler/xla/service/gpu/fusion_bitcast_lift_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/fusion_bitcast_lift_test.cc
@@ -220,6 +220,68 @@ ENTRY %main {
   EXPECT_TRUE(filecheck_result.ValueOrDie());
 }
 
+TEST_F(FusionBitcastLiftTest, ScalarAndRowBroadcastTest) {
+  const char* hlo_text = R"(
+HloModule mod
+
+%scalar_add_computation (scalar_lhs.1: f32[], scalar_rhs.1: f32[]) -> f32[] {
+  %scalar_lhs.1 = f32[] parameter(0)
+  %scalar_rhs.1 = f32[] parameter(1)
+  ROOT %add.5 = f32[] add(f32[] %scalar_lhs.1, f32[] %scalar_rhs.1)
+}
+
+%fused_computation.4d (param_0: f16[2,14,14,672], param_1: f32[672], param_2: f32[]) -> (f32[672], f32[672]) {
+  %param_0 = f16[2,14,14,672] parameter(0)
+  %convert = f32[2,14,14,672] convert(%param_0)
+  %bitcast.1 = f32[392,672] bitcast(%convert)
+  %constant_0 = f32[] constant(0)
+  %reduce.1 = f32[672]{0} reduce(%bitcast.1, %constant_0), dimensions={0}, to_apply=%scalar_add_computation
+  %param_1 = f32[672] parameter(1)
+  %broadcast = f32[2,14,14,672] broadcast(%param_1), dimensions={3}
+  %multiply.1 = f32[2,14,14,672] multiply(%convert, %broadcast)
+  %param_2 = f32[] parameter(2)
+  %broadcast.1 = f32[2,14,14,672] broadcast(%param_2), dimensions={}
+  %multiply.2 = f32[2,14,14,672] multiply(%broadcast.1, %multiply.1)
+  %bitcast.2 = f32[392,672] bitcast(%multiply.2)
+  %reduce.2 = f32[672]{0} reduce(%bitcast.2, %constant_0), dimensions={0}, to_apply=%scalar_add_computation
+  ROOT %tuple = (f32[672]{0}, f32[672]{0}) tuple(%reduce.1, %reduce.2)
+}
+
+ENTRY %main {
+  %param_0 = f16[2,14,14,672] parameter(0)
+  %param_1 = f32[672] parameter(1)
+  %param_2 = f32[] parameter(2)
+  ROOT %fusion.4d = (f32[672]{0}, f32[672]{0}) fusion(%param_0, %param_1, %param_2), kind=kInput, calls=%fused_computation.4d
+}
+)";
+
+  auto module = ParseAndReturnVerifiedModule(hlo_text).ValueOrDie();
+  EXPECT_TRUE(FusionBitcastLift().Run(module.get()).ValueOrDie());
+  // Remove the old fusion not used anymore.
+  EXPECT_TRUE(HloDCE().Run(module.get()).ValueOrDie());
+
+  EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
+
+  StatusOr<bool> filecheck_result =
+      RunFileCheck(module->ToString(),
+                    R"(
+; CHECK-LABEL: %fused_computation
+; CHECK-NOT:     bitcast
+; CHECK:         f32[2,14,14,672]{3,2,1,0} broadcast(
+; CHECK-NEXT:    f32[392,672]{1,0} bitcast(
+; CHECK-NOT:     bitcast
+; CHECK:         f32[2,14,14,672]{3,2,1,0} broadcast(
+; CHECK-NEXT:    f32[392,672]{1,0} bitcast(
+; CHECK-NOT:     bitcast(
+; CHECK-LABEL: ENTRY %main
+; CHECK-NOT:     bitcast(
+; CHECK:    bitcast(f16[2,14,14,672]{3,2,1,0} %param_0
+; CHECK-NOT:     bitcast(
+      )");
+  EXPECT_TRUE(filecheck_result.status().ok());
+  EXPECT_TRUE(filecheck_result.ValueOrDie());
+}
+
 }  // namespace
 }  // namespace gpu
 }  // namespace xla

--- a/tensorflow/compiler/xla/service/gpu/fusion_bitcast_lift_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/fusion_bitcast_lift_test.cc
@@ -53,21 +53,21 @@ HloModule mod
   ROOT %add.5 = f32[] add(f32[] %scalar_lhs.1, f32[] %scalar_rhs.1)
 }
 
-%fused_computation.21_4d (param_0.59: f16[2,14,14,672]) -> (f32[672], f32[672]) {
-  %param_0.59 = f16[2,14,14,672] parameter(0)
-  %convert.21 = f32[2,14,14,672] convert(%param_0.59)
-  %bitcast.25 = f32[392,672] bitcast(%convert.21)
-  %constant_84 = f32[] constant(0)
-  %reduce.12 = f32[672]{0} reduce(%bitcast.25, %constant_84), dimensions={0}, to_apply=%scalar_add_computation
-  %multiply.43.clone.1 = f32[2,14,14,672] multiply(%convert.21, %convert.21)
-  %bitcast.24.clone.1 = f32[392,672] bitcast(%multiply.43.clone.1)
-  %reduce.11.clone.1 = f32[672]{0} reduce(%bitcast.24.clone.1, %constant_84), dimensions={0}, to_apply=%scalar_add_computation
-  ROOT %tuple.13 = (f32[672]{0}, f32[672]{0}) tuple(%reduce.12, %reduce.11.clone.1)
+%fused_computation.4d (param_0: f16[2,14,14,672]) -> (f32[672], f32[672]) {
+  %param_0 = f16[2,14,14,672] parameter(0)
+  %convert = f32[2,14,14,672] convert(%param_0)
+  %bitcast.1 = f32[392,672] bitcast(%convert)
+  %constant_0 = f32[] constant(0)
+  %reduce.1 = f32[672]{0} reduce(%bitcast.1, %constant_0), dimensions={0}, to_apply=%scalar_add_computation
+  %multiply = f32[2,14,14,672] multiply(%convert, %convert)
+  %bitcast.2 = f32[392,672] bitcast(%multiply)
+  %reduce.2 = f32[672]{0} reduce(%bitcast.2, %constant_0), dimensions={0}, to_apply=%scalar_add_computation
+  ROOT %tuple = (f32[672]{0}, f32[672]{0}) tuple(%reduce.1, %reduce.2)
 }
 
-ENTRY main {
-  %param_0.59 = f16[2,14,14,672] parameter(0)
-  ROOT %fusion.21_4d = (f32[672]{0}, f32[672]{0}) fusion(%param_0.59), kind=kInput, calls=%fused_computation.21_4d
+ENTRY %main {
+  %param_0 = f16[2,14,14,672] parameter(0)
+  ROOT %fusion.4d = (f32[672]{0}, f32[672]{0}) fusion(%param_0), kind=kInput, calls=%fused_computation.4d
 }
 )";
   auto module = ParseAndReturnVerifiedModule(hlo_text).ValueOrDie();
@@ -85,9 +85,9 @@ ENTRY main {
 ; CHECK-NOT:     parameter
 ; CHECK-NOT:     bitcast
 ; CHECK-LABEL: ENTRY %main
-; CHECK-NEXT:    %param_0.0 = f16[2,14,14,672]{3,2,1,0} parameter(0)
+; CHECK-NEXT:    f16[2,14,14,672]{3,2,1,0} parameter(0)
 ; CHECK-NEXT:    bitcast(
-; CHECK-NEXT:    ROOT %fusion.21_4d.bitcast
+; CHECK-NEXT:    ROOT %fusion.4d.bitcast
       )");
   EXPECT_TRUE(filecheck_result.status().ok());
   EXPECT_TRUE(filecheck_result.ValueOrDie());
@@ -114,24 +114,24 @@ HloModule mod
   ROOT %add.5 = f32[] add(f32[] %scalar_lhs.1, f32[] %scalar_rhs.1)
 }
 
-%fused_computation.21_4d (param_0.59: f16[2,14,14,672], param_1: f32[]) -> (f32[672], f32[672]) {
-  %param_0.59 = f16[2,14,14,672] parameter(0)
-  %convert.21 = f32[2,14,14,672] convert(%param_0.59)
-  %bitcast.25 = f32[392,672] bitcast(%convert.21)
-  %constant_84 = f32[] constant(0)
-  %reduce.12 = f32[672]{0} reduce(%bitcast.25, %constant_84), dimensions={0}, to_apply=%scalar_add_computation
+%fused_computation.4d (param_0: f16[2,14,14,672], param_1: f32[]) -> (f32[672], f32[672]) {
+  %param_0 = f16[2,14,14,672] parameter(0)
+  %convert = f32[2,14,14,672] convert(%param_0)
+  %bitcast.1 = f32[392,672] bitcast(%convert)
+  %constant_0 = f32[] constant(0)
+  %reduce.1 = f32[672]{0} reduce(%bitcast.1, %constant_0), dimensions={0}, to_apply=%scalar_add_computation
   %param_1 = f32[] parameter(1)
   %broadcast = f32[2,14,14,672] broadcast(%param_1), dimensions={}
-  %multiply.43.clone.1 = f32[2,14,14,672] multiply(%convert.21, %broadcast)
-  %bitcast.24.clone.1 = f32[392,672] bitcast(%multiply.43.clone.1)
-  %reduce.11.clone.1 = f32[672]{0} reduce(%bitcast.24.clone.1, %constant_84), dimensions={0}, to_apply=%scalar_add_computation
-  ROOT %tuple.13 = (f32[672]{0}, f32[672]{0}) tuple(%reduce.12, %reduce.11.clone.1)
+  %multiply = f32[2,14,14,672] multiply(%convert, %broadcast)
+  %bitcast.2 = f32[392,672] bitcast(%multiply)
+  %reduce.2 = f32[672]{0} reduce(%bitcast.2, %constant_0), dimensions={0}, to_apply=%scalar_add_computation
+  ROOT %tuple = (f32[672]{0}, f32[672]{0}) tuple(%reduce.1, %reduce.2)
 }
 
-ENTRY main {
-  %param_0.59 = f16[2,14,14,672] parameter(0)
+ENTRY %main {
+  %param_0 = f16[2,14,14,672] parameter(0)
   %param_1 = f32[] parameter(1)
-  ROOT %fusion.21_4d = (f32[672]{0}, f32[672]{0}) fusion(%param_0.59, %param_1), kind=kInput, calls=%fused_computation.21_4d
+  ROOT %fusion.4d = (f32[672]{0}, f32[672]{0}) fusion(%param_0, %param_1), kind=kInput, calls=%fused_computation.4d
 }
 )";
   auto module = ParseAndReturnVerifiedModule(hlo_text).ValueOrDie();
@@ -153,10 +153,10 @@ ENTRY main {
 ; CHECK-NEXT:    bitcast(f32[2,14,14,672]{3,2,1,0} %broadcast.1)
 ; CHECK-NOT:     bitcast(
 ; CHECK-LABEL: ENTRY %main
-; CHECK-NEXT:    %param_0.0 = f16[2,14,14,672]{3,2,1,0} parameter(0)
+; CHECK-NEXT:    f16[2,14,14,672]{3,2,1,0} parameter(0)
 ; CHECK-NEXT:    bitcast(
 ; CHECK-NEXT:    %param_1.1 = f32[] parameter(1)
-; CHECK-NEXT:    ROOT %fusion.21_4d.bitcast
+; CHECK-NEXT:    ROOT %fusion.4d.bitcast
       )");
   EXPECT_TRUE(filecheck_result.status().ok());
   EXPECT_TRUE(filecheck_result.ValueOrDie());
@@ -172,24 +172,24 @@ HloModule mod
   ROOT %add.5 = f32[] add(f32[] %scalar_lhs.1, f32[] %scalar_rhs.1)
 }
 
-%fused_computation.21_4d (param_0.59: f16[2,14,14,672], param_1: f32[672]) -> (f32[672], f32[672]) {
-  %param_0.59 = f16[2,14,14,672] parameter(0)
-  %convert.21 = f32[2,14,14,672] convert(%param_0.59)
-  %bitcast.25 = f32[392,672] bitcast(%convert.21)
-  %constant_84 = f32[] constant(0)
-  %reduce.12 = f32[672]{0} reduce(%bitcast.25, %constant_84), dimensions={0}, to_apply=%scalar_add_computation
+%fused_computation.4d (param_0: f16[2,14,14,672], param_1: f32[672]) -> (f32[672], f32[672]) {
+  %param_0 = f16[2,14,14,672] parameter(0)
+  %convert = f32[2,14,14,672] convert(%param_0)
+  %bitcast.1 = f32[392,672] bitcast(%convert)
+  %constant_0 = f32[] constant(0)
+  %reduce.1 = f32[672]{0} reduce(%bitcast.1, %constant_0), dimensions={0}, to_apply=%scalar_add_computation
   %param_1 = f32[672] parameter(1)
   %broadcast = f32[2,14,14,672] broadcast(%param_1), dimensions={3}
-  %multiply.43.clone.1 = f32[2,14,14,672] multiply(%convert.21, %broadcast)
-  %bitcast.24.clone.1 = f32[392,672] bitcast(%multiply.43.clone.1)
-  %reduce.11.clone.1 = f32[672]{0} reduce(%bitcast.24.clone.1, %constant_84), dimensions={0}, to_apply=%scalar_add_computation
-  ROOT %tuple.13 = (f32[672]{0}, f32[672]{0}) tuple(%reduce.12, %reduce.11.clone.1)
+  %multiply = f32[2,14,14,672] multiply(%convert, %broadcast)
+  %bitcast.2 = f32[392,672] bitcast(%multiply)
+  %reduce.2 = f32[672]{0} reduce(%bitcast.2, %constant_0), dimensions={0}, to_apply=%scalar_add_computation
+  ROOT %tuple = (f32[672]{0}, f32[672]{0}) tuple(%reduce.1, %reduce.2)
 }
 
-ENTRY main {
-  %param_0.59 = f16[2,14,14,672] parameter(0)
+ENTRY %main {
+  %param_0 = f16[2,14,14,672] parameter(0)
   %param_1 = f32[672] parameter(1)
-  ROOT %fusion.21_4d = (f32[672]{0}, f32[672]{0}) fusion(%param_0.59, %param_1), kind=kInput, calls=%fused_computation.21_4d
+  ROOT %fusion.4d = (f32[672]{0}, f32[672]{0}) fusion(%param_0, %param_1), kind=kInput, calls=%fused_computation.4d
 }
 )";
   auto module = ParseAndReturnVerifiedModule(hlo_text).ValueOrDie();
@@ -211,10 +211,10 @@ ENTRY main {
 ; CHECK:         bitcast(f32[2,14,14,672]{3,2,1,0} %broadcast.1)
 ; CHECK-NOT:     bitcast(
 ; CHECK-LABEL: ENTRY %main
-; CHECK-NEXT:    %param_0.0 = f16[2,14,14,672]{3,2,1,0} parameter(0)
+; CHECK-NEXT:    f16[2,14,14,672]{3,2,1,0} parameter(0)
 ; CHECK-NEXT:    bitcast(
 ; CHECK-NEXT:    %param_1.1 = f32[672]{0} parameter(1)
-; CHECK-NEXT:    ROOT %fusion.21_4d.bitcast
+; CHECK-NEXT:    ROOT %fusion.4d.bitcast
       )");
   EXPECT_TRUE(filecheck_result.status().ok());
   EXPECT_TRUE(filecheck_result.ValueOrDie());

--- a/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
@@ -62,6 +62,7 @@ limitations under the License.
 #include "tensorflow/compiler/xla/service/gather_expander.h"
 #include "tensorflow/compiler/xla/service/gpu/alias_passthrough_params.h"
 #include "tensorflow/compiler/xla/service/gpu/cudnn_batchnorm_rewriter.h"
+#include "tensorflow/compiler/xla/service/gpu/fusion_bitcast_lift.h"
 #include "tensorflow/compiler/xla/service/gpu/fusion_merger.h"
 #include "tensorflow/compiler/xla/service/gpu/gemm_rewriter.h"
 #include "tensorflow/compiler/xla/service/gpu/gpu_constants.h"
@@ -357,6 +358,9 @@ Status GpuCompiler::OptimizeHloModule(
     HloPassFix<HloPassPipeline> horizontal_fusion("horizontal_fusion");
     horizontal_fusion.AddPass<GpuHorizontalLoopFusion>();
     horizontal_fusion.AddPass<GpuHorizontalInputFusion>();
+    // FusionBitcastLift must be after InstructionFusion, as it undo
+    // part of it.
+    horizontal_fusion.AddPass<FusionBitcastLift>();
     horizontal_fusion.AddPass<HloCSE>(/*is_layout_sensitive=*/true,
                                       /*only_fusion_computations=*/true);
     horizontal_fusion.AddPass<HloDCE>();

--- a/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
@@ -358,7 +358,7 @@ Status GpuCompiler::OptimizeHloModule(
     HloPassFix<HloPassPipeline> horizontal_fusion("horizontal_fusion");
     horizontal_fusion.AddPass<GpuHorizontalLoopFusion>();
     horizontal_fusion.AddPass<GpuHorizontalInputFusion>();
-    // FusionBitcastLift must be after InstructionFusion, as it undo
+    // FusionBitcastLift must be after InstructionFusion, as it undoes
     // part of it.
     horizontal_fusion.AddPass<FusionBitcastLift>();
     horizontal_fusion.AddPass<HloCSE>(/*is_layout_sensitive=*/true,

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -5117,6 +5117,7 @@ ReductionCodegenInfo IrEmitterUnnested::ComputeReductionCodegenInfo(
       return kStridedIndexingX;
     }
   }();
+  VLOG(3) << "Each threads will produce " << num_partial_results << " output(s)";
 
   int vector_size = 1;
   if (indexing_order == kStridedLinearIndexingX) {

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -4979,6 +4979,10 @@ bool IsUnrollingColumnReductionBeneficial(
     return false;
   }
 
+  if (input_shape.dimensions()[input_shape.rank()-1] < 64) {
+    return false;
+  }
+
   if (IsReductionFromOrToContiguousDimensions(unnested_hlo, layout_analysis)) {
     return true;
   }

--- a/tensorflow/compiler/xla/service/hlo_computation.cc
+++ b/tensorflow/compiler/xla/service/hlo_computation.cc
@@ -971,7 +971,8 @@ Status HloComputation::ReplaceInstructionWithDifferentShape(
     new_instruction->set_sharding(old_instruction->sharding_ptr());
   }
 
-  TF_RETURN_IF_ERROR(old_instruction->ReplaceAllUsesWith(new_instruction));
+  TF_RETURN_IF_ERROR(old_instruction->ReplaceAllUsesWithDifferentShape(
+      new_instruction));
   return RemoveInstructionAndUnusedOperands(old_instruction);
 }
 

--- a/tensorflow/compiler/xla/service/hlo_computation.cc
+++ b/tensorflow/compiler/xla/service/hlo_computation.cc
@@ -210,9 +210,9 @@ HloInstruction* HloComputation::ReplaceParameter(
   instruction->set_parent(this);
   HloInstruction* new_instruction = AddInstructionInternal(std::move(instruction));
   HloInstruction* old_instruction = param_instructions_[param_no];
-  CHECK(old_instruction->ReplaceAllUsesWithDifferentShape(new_instruction).ok()) << "Check failed";
+  CHECK(old_instruction->ReplaceAllUsesWithDifferentShape(new_instruction).ok());
   param_instructions_[param_no] = new_instruction;
-  CHECK(RemoveInstruction(old_instruction).ok()) << "Check failed";
+  CHECK(RemoveInstruction(old_instruction).ok());
   return new_instruction;
 }
 

--- a/tensorflow/compiler/xla/service/hlo_computation.cc
+++ b/tensorflow/compiler/xla/service/hlo_computation.cc
@@ -198,6 +198,24 @@ Status HloComputation::RemoveParameter(int64 param_no) {
   return Status::OK();
 }
 
+HloInstruction* HloComputation::ReplaceParameter(
+    int64 param_no,
+    std::unique_ptr<HloInstruction> instruction) {
+  CHECK_GE(param_no, 0);
+  CHECK_LT(param_no, param_instructions_.size());
+  CHECK(instruction->opcode() == HloOpcode::kParameter);
+  CHECK(IsFusionComputation());
+  CHECK_EQ(fusion_instruction_->operand_count(), param_instructions_.size());
+
+  instruction->set_parent(this);
+  HloInstruction* new_instruction = AddInstructionInternal(std::move(instruction));
+  HloInstruction* old_instruction = param_instructions_[param_no];
+  CHECK(old_instruction->ReplaceAllUsesWithDifferentShape(new_instruction).ok()) << "Check failed";
+  param_instructions_[param_no] = new_instruction;
+  CHECK(RemoveInstruction(old_instruction).ok()) << "Check failed";
+  return new_instruction;
+}
+
 Status HloComputation::RemoveUnusedParametersFromFusedComputation() {
   return RemoveUnusedParametersImpl(/*allow_non_fusion=*/false);
 }
@@ -919,7 +937,11 @@ Status HloComputation::ReplaceInstruction(HloInstruction* old_instruction,
       ShapeUtil::Compatible(old_instruction->shape(), new_instruction->shape()))
       << ShapeUtil::HumanString(old_instruction->shape()) << " vs "
       << ShapeUtil::HumanString(new_instruction->shape());
+  return ReplaceInstructionWithDifferentShape(old_instruction, new_instruction);
+}
 
+Status HloComputation::ReplaceInstructionWithDifferentShape(
+    HloInstruction* old_instruction, HloInstruction* new_instruction) {
   VLOG(10) << "transformed " << old_instruction->ToString() << " to "
            << new_instruction->ToString();
   // Try to add metadata for HLO instructions that are created to replace

--- a/tensorflow/compiler/xla/service/hlo_computation.h
+++ b/tensorflow/compiler/xla/service/hlo_computation.h
@@ -131,7 +131,7 @@ class HloComputation {
   HloInstruction* AddInstruction(std::unique_ptr<HloInstruction> instruction,
                                  const std::string& new_name = "");
 
-  // Replace the old paramter at index param_no with
+  // Replace the old parameter at index param_no with
   // `instruction`. Updates uses and root instruction. Removes old
   // instruction from computation. No check is done on the shape.
   HloInstruction* ReplaceParameter(

--- a/tensorflow/compiler/xla/service/hlo_computation.h
+++ b/tensorflow/compiler/xla/service/hlo_computation.h
@@ -131,6 +131,13 @@ class HloComputation {
   HloInstruction* AddInstruction(std::unique_ptr<HloInstruction> instruction,
                                  const std::string& new_name = "");
 
+  // Replace the old paramter at index param_no with
+  // `instruction`. Updates uses and root instruction. Removes old
+  // instruction from computation. No check is done on the shape.
+  HloInstruction* ReplaceParameter(
+      int64 param_no,
+      std::unique_ptr<HloInstruction> instruction);
+
   // Remove the param_no'th parameter from the computation.
   // Note this is only applicatable to the computation for the fusion
   // instruction.
@@ -161,7 +168,7 @@ class HloComputation {
       std::unique_ptr<HloInstruction> instruction);
 
   // Replaces an old parameter with a new parameter. Adds the new parameter
-  // instruction to the entry computation.
+  // instruction to the entry computation.  Updates users instruction.
   Status ReplaceEntryComputationParameter(
       int64 param_no, HloInstruction* old_instruction,
       std::unique_ptr<HloInstruction> instruction);
@@ -356,6 +363,10 @@ class HloComputation {
   // receive the sharding information of |old_instruction|.
   Status ReplaceInstruction(HloInstruction* old_instruction,
                             HloInstruction* new_instruction);
+
+  // As ReplaceInstruction, but the new instruction can have a different shape.
+  Status ReplaceInstructionWithDifferentShape(
+      HloInstruction* old_instruction, HloInstruction* new_instruction);
 
   // Set/get the module containing this computation.
   void set_parent(HloModule* module) { parent_ = module; }

--- a/tensorflow/compiler/xla/service/platform_util.cc
+++ b/tensorflow/compiler/xla/service/platform_util.cc
@@ -112,7 +112,7 @@ PlatformUtil::GetSupportedPlatforms() {
       [](string* out, const se::Platform* p) { out->append(p->Name()); });
   return InvalidArgument(
       "must specify platform because more than one platform (except for the "
-      "interpreter platform) found: %s",
+      "interpreter platform) found: %s.",
       platforms_string);
 }
 


### PR DESCRIPTION
This PR includes 2 changes:
1) when a rank-reducing bitcast is present inside a kInput fusion, we lift it to outside the fusion. This lower the indexing computation generated by XLA. LLVM isn't always able to optimize it.
2) Mark kExp as not expensive. This cause its computation to be duplicated in the gradient of EfficientNet. This remove IO as the forward fusion now have one less output and the gradient have less inputs. This also allows a bigger mini-batch size. This is a one liner + test.



Number 1) speed up some kernels in EfficientNet. But number 2) on A100 cause one kernel to slow down as the simpler fusion is not as much optimized. Further optimization is possible. But to keep the changes changes, I combine them as the combination of both optimization doesn't cause any regression. Doing them in 2 separate PR cause one intermediate steps that will be faster for one kernel. **On V100, we do not have this problem.**

Here is one not-optimized HLO dump of a simplified EfficientNet script that show the problem this optimize. Before this PR, it generates a fusion called: fusion.7. After this PR, that kernel is renamed fusion.6_bitcast.

[module_0000.before_optimizations.txt](https://github.com/tensorflow/tensorflow/files/6617698/module_0000.before_optimizations.txt)

timed previous commit: 643e7db56ec5d9b0d7deecaf6a089374d140a286
timed current commit: dcc241f057047129e234a5cb3155b0d21e4aee59

V100: old time: 660us, new time: 557us
A100: old time: 622us, new tiem: 556us


@cheshire