### PR TITLE
[tf.data] graduate ThreadingOptions from experimental to tf.data

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -114,6 +114,8 @@
         `tf.data.Dataset.take_while` and deprecating the experimental endpoint.
     *   Promoting `tf.data.experimental.unique` API to
         `tf.data.Dataset.unique` and deprecating the experimental endpoint.
+    *   Promoting `tf.data.experimental.ThreadingOptions` API to
+        `tf.data.ThreadingOptions` and deprecating the experimental endpoint.
     *   Added `stop_on_empty_dataset` parameter to `sample_from_datasets` and
         `choose_from_datasets`. Setting `stop_on_empty_dataset=True` will stop
         sampling if it encounters an empty dataset. This preserves the sampling

--- a/tensorflow/python/data/experimental/ops/threading_options.py
+++ b/tensorflow/python/data/experimental/ops/threading_options.py
@@ -54,12 +54,6 @@ class ThreadingOptions(options.OptionsBase):
       "The value 0 can be used to indicate that the threadpool size should be "
       "determined at runtime based on the number of available CPU cores.")
 
-  def _has_non_default_values(self):
-    for attr in filter(lambda opt: not opt.startswith("_"), dir(self)):
-      if getattr(self, attr) is not None:
-        return True
-    return False
-
   def _to_proto(self):
     pb = dataset_options_pb2.ThreadingOptions()
     if self.max_intra_op_parallelism is not None:

--- a/tensorflow/python/data/experimental/ops/threading_options.py
+++ b/tensorflow/python/data/experimental/ops/threading_options.py
@@ -24,14 +24,14 @@ from tensorflow.python.data.util import options
 from tensorflow.python.util.tf_export import tf_export
 
 
-@deprecation.deprecated("data.experimental.ThreadingOptions")
+@deprecation.deprecated_endpoints("data.experimental.ThreadingOptions")
 @tf_export("data.experimental.ThreadingOptions", "data.ThreadingOptions")
 class ThreadingOptions(options.OptionsBase):
   """Represents options for dataset threading.
 
   You can set the threading options of a dataset through the
   `experimental_threading` property of `tf.data.Options`; the property is
-  an instance of `tf.data.experimental.ThreadingOptions`.
+  an instance of `tf.data.ThreadingOptions`.
 
   ```python
   options = tf.data.Options()

--- a/tensorflow/python/data/experimental/ops/threading_options.py
+++ b/tensorflow/python/data/experimental/ops/threading_options.py
@@ -19,11 +19,13 @@ from __future__ import print_function
 
 
 from tensorflow.core.framework import dataset_options_pb2
+from tensorflow.python.util import deprecation
 from tensorflow.python.data.util import options
 from tensorflow.python.util.tf_export import tf_export
 
 
-@tf_export("data.experimental.ThreadingOptions")
+@deprecation.deprecated("data.experimental.ThreadingOptions")
+@tf_export("data.experimental.ThreadingOptions", "data.ThreadingOptions")
 class ThreadingOptions(options.OptionsBase):
   """Represents options for dataset threading.
 

--- a/tensorflow/python/data/experimental/ops/threading_options.py
+++ b/tensorflow/python/data/experimental/ops/threading_options.py
@@ -35,7 +35,7 @@ class ThreadingOptions(options.OptionsBase):
 
   ```python
   options = tf.data.Options()
-  options.experimental_threading.private_threadpool_size = 10
+  options.threading.private_threadpool_size = 10
   dataset = dataset.with_options(options)
   ```
   """
@@ -53,6 +53,16 @@ class ThreadingOptions(options.OptionsBase):
       "If set, the dataset will use a private threadpool of the given size. "
       "The value 0 can be used to indicate that the threadpool size should be "
       "determined at runtime based on the number of available CPU cores.")
+
+  def _get_option_names(self):
+    return ["max_intra_op_parallelism", "private_threadpool_size"]
+
+  def _has_non_default_values(self):
+    attrs = self._get_option_names()
+    for attr in attrs:
+      if object.__getattribute__(self, attr) is not None:
+        return True
+    return False
 
   def _to_proto(self):
     pb = dataset_options_pb2.ThreadingOptions()

--- a/tensorflow/python/data/experimental/ops/threading_options.py
+++ b/tensorflow/python/data/experimental/ops/threading_options.py
@@ -54,6 +54,14 @@ class ThreadingOptions(options.OptionsBase):
       "The value 0 can be used to indicate that the threadpool size should be "
       "determined at runtime based on the number of available CPU cores.")
 
+  def _has_default_values(self):
+    attrs = ["max_intra_op_parallelism", "private_threadpool_size"]
+    for attr in attrs:
+      if object.__getattribute__(self, attr) is not None:
+        return False
+    else:
+      return True    
+
   def _to_proto(self):
     pb = dataset_options_pb2.ThreadingOptions()
     if self.max_intra_op_parallelism is not None:

--- a/tensorflow/python/data/experimental/ops/threading_options.py
+++ b/tensorflow/python/data/experimental/ops/threading_options.py
@@ -54,13 +54,9 @@ class ThreadingOptions(options.OptionsBase):
       "The value 0 can be used to indicate that the threadpool size should be "
       "determined at runtime based on the number of available CPU cores.")
 
-  def _get_option_names(self):
-    return ["max_intra_op_parallelism", "private_threadpool_size"]
-
   def _has_non_default_values(self):
-    attrs = self._get_option_names()
-    for attr in attrs:
-      if object.__getattribute__(self, attr) is not None:
+    for attr in filter(lambda opt: not opt.startswith("_"), dir(self)):
+      if getattr(self, attr) is not None:
         return True
     return False
 

--- a/tensorflow/python/data/experimental/ops/threading_options.py
+++ b/tensorflow/python/data/experimental/ops/threading_options.py
@@ -54,14 +54,6 @@ class ThreadingOptions(options.OptionsBase):
       "The value 0 can be used to indicate that the threadpool size should be "
       "determined at runtime based on the number of available CPU cores.")
 
-  def _has_default_values(self):
-    attrs = ["max_intra_op_parallelism", "private_threadpool_size"]
-    for attr in attrs:
-      if object.__getattribute__(self, attr) is not None:
-        return False
-    else:
-      return True    
-
   def _to_proto(self):
     pb = dataset_options_pb2.ThreadingOptions()
     if self.max_intra_op_parallelism is not None:

--- a/tensorflow/python/data/kernel_tests/options_test.py
+++ b/tensorflow/python/data/kernel_tests/options_test.py
@@ -110,11 +110,11 @@ class OptionsTest(test_base.DatasetTestBase, parameterized.TestCase):
     options2 = dataset_ops.Options()
     self.assertIsNot(options1.experimental_optimization,
                      options2.experimental_optimization)
-    self.assertIsNot(options1.experimental_threading,
-                     options2.experimental_threading)
+    self.assertIsNot(options1.threading,
+                     options2.threading)
     self.assertEqual(options1.experimental_optimization,
                      optimization_options.OptimizationOptions())
-    self.assertEqual(options1.experimental_threading,
+    self.assertEqual(options1.threading,
                      threading_options.ThreadingOptions())
 
   @combinations.generate(test_base.default_test_combinations())
@@ -169,8 +169,8 @@ class OptionsTest(test_base.DatasetTestBase, parameterized.TestCase):
     options.experimental_optimization.reorder_data_discarding_ops = True
     options.experimental_optimization.shuffle_and_repeat_fusion = True
     options.experimental_slack = True
-    options.experimental_threading.max_intra_op_parallelism = 30
-    options.experimental_threading.private_threadpool_size = 40
+    options.threading.max_intra_op_parallelism = 30
+    options.threading.private_threadpool_size = 40
     pb = options._to_proto()
     result = dataset_ops.Options()
     result._from_proto(pb)

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -3613,12 +3613,6 @@ class Options(options_lib.OptionsBase):
     pb.optimization_options.CopyFrom(self.experimental_optimization._to_proto())  # pylint: disable=protected-access
     if self.experimental_slack is not None:
       pb.slack = self.experimental_slack
-    # (kvignesh1420): We try to keep the values of `threading` and
-    # `experimental_threading` the same, to prevent unexpected behaviours.
-    if not self.threading._has_default_values():
-      self.experimental_threading = self.threading
-    else:
-      self.threading = self.experimental_threading
     pb.threading_options.CopyFrom(self.threading._to_proto())  # pylint: disable=protected-access  
     return pb
 

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -3617,8 +3617,10 @@ class Options(options_lib.OptionsBase):
     # else we go with `experimental_threading`.
     if not self.threading._has_default_values():
       pb.threading_options.CopyFrom(self.threading._to_proto())  # pylint: disable=protected-access
+      self.experimental_threading = self.threading
     else:
       pb.threading_options.CopyFrom(self.experimental_threading._to_proto())  # pylint: disable=protected-access
+      self.threading = self.experimental_threading
     return pb
 
   def _from_proto(self, pb):

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -3579,7 +3579,7 @@ class Options(options_lib.OptionsBase):
       ty=threading_options.ThreadingOptions,
       docstring=
       "The threading options associated with the dataset. See "
-      "`tf.data.experimental.ThreadingOptions` for more details.",
+      "`tf.data.ThreadingOptions` for more details.",
       default_factory=threading_options.ThreadingOptions)
 
   experimental_external_state_policy = options_lib.create_option(

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -3617,20 +3617,16 @@ class Options(options_lib.OptionsBase):
     # (kvignesh1420): We try to keep the values of `threading` and
     # `experimental_threading` the same, to prevent unexpected behaviours
     # and ensure backward-compatibility.
-    if self.threading._has_non_default_values():
-      if self.experimental_threading._has_non_default_values():
-        override_options = []
-        for name in self.threading._get_option_names():
-          if (object.__getattribute__(self.threading, name) !=
-              object.__getattribute__(self.experimental_threading, name)):
-            override_options.append(name)
-        if override_options:
-          logging.warning("overriding options '{}' of experimental_threading "
-                "with respective values in threading.".format(
-                  ",".join(override_options)))
-      self.experimental_threading = self.threading
-    else:
-      self.threading = self.experimental_threading
+    override_attrs = []
+    for attr in filter(lambda opt: not opt.startswith("_"), dir(self.threading)):
+      if (getattr(self.threading, attr) !=
+          getattr(self.experimental_threading, attr)):
+        override_attrs.append(attr)
+    if override_attrs:
+      logging.warning("overriding attr(s) '{}' of experimental_threading "
+            "with respective values in threading.".format(
+              ",".join(override_attrs)))
+    self.experimental_threading = self.threading
     pb.threading_options.CopyFrom(self.threading._to_proto())  # pylint: disable=protected-access
     return pb
 

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -3613,14 +3613,13 @@ class Options(options_lib.OptionsBase):
     pb.optimization_options.CopyFrom(self.experimental_optimization._to_proto())  # pylint: disable=protected-access
     if self.experimental_slack is not None:
       pb.slack = self.experimental_slack
-    # If `threading` doesn't have default values, then we save it to proto,
-    # else we go with `experimental_threading`.
+    # (kvignesh1420): We try to keep the values of `threading` and
+    # `experimental_threading` the same, to prevent unexpected behaviours.
     if not self.threading._has_default_values():
-      pb.threading_options.CopyFrom(self.threading._to_proto())  # pylint: disable=protected-access
       self.experimental_threading = self.threading
     else:
-      pb.threading_options.CopyFrom(self.experimental_threading._to_proto())  # pylint: disable=protected-access
       self.threading = self.experimental_threading
+    pb.threading_options.CopyFrom(self.threading._to_proto())  # pylint: disable=protected-access  
     return pb
 
   def _from_proto(self, pb):

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -3617,15 +3617,13 @@ class Options(options_lib.OptionsBase):
     # (kvignesh1420): We try to keep the values of `threading` and
     # `experimental_threading` the same, to prevent unexpected behaviours
     # and ensure backward-compatibility.
-    override_attrs = []
     for attr in filter(lambda opt: not opt.startswith("_"), dir(self.threading)):
-      if (getattr(self.threading, attr) !=
-          getattr(self.experimental_threading, attr)):
-        override_attrs.append(attr)
-    if override_attrs:
-      logging.warning("overriding attr(s) '{}' of experimental_threading "
-            "with respective values in threading.".format(
-              ",".join(override_attrs)))
+      t_val = getattr(self.threading, attr)
+      et_val = getattr(self.experimental_threading, attr)
+      if (t_val != et_val):
+        logging.warning(
+          "overriding `experimental_threading.{} = {}` "
+          "with `threading.{} = {}".format(attr, et_val, attr, t_val))
     self.experimental_threading = self.threading
     pb.threading_options.CopyFrom(self.threading._to_proto())  # pylint: disable=protected-access
     return pb

--- a/tensorflow/python/data/util/options.py
+++ b/tensorflow/python/data/util/options.py
@@ -60,6 +60,9 @@ class OptionsBase(object):
                        "`tf.data.Dataset.with_options(options)` to set or "
                        "update dataset options.")
     if hasattr(self, name):
+      if name=="experimental_threading":
+        logging.warning("options.experimental_threading is deprecated."
+                        "Use options.threading instead.")
       object.__setattr__(self, name, value)
     else:
       raise AttributeError(

--- a/tensorflow/python/data/util/options.py
+++ b/tensorflow/python/data/util/options.py
@@ -61,9 +61,13 @@ class OptionsBase(object):
                        "update dataset options.")
     if hasattr(self, name):
       if name=="experimental_threading":
-        logging.warning("options.experimental_threading is deprecated."
+        logging.warning("options.experimental_threading is deprecated. "
                         "Use options.threading instead.")
         object.__setattr__(self, "threading", value)
+      elif name=="threading":
+        # ensure backward-compatibility until total deprecation of
+        # `experimental_threading`
+        object.__setattr__(self, "experimental_threading", value)
       object.__setattr__(self, name, value)
     else:
       raise AttributeError(

--- a/tensorflow/python/data/util/options.py
+++ b/tensorflow/python/data/util/options.py
@@ -63,6 +63,7 @@ class OptionsBase(object):
       if name=="experimental_threading":
         logging.warning("options.experimental_threading is deprecated."
                         "Use options.threading instead.")
+        object.__setattr__(self, "threading", value)
       object.__setattr__(self, name, value)
     else:
       raise AttributeError(

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-options.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-options.pbtxt
@@ -27,6 +27,10 @@ tf_class {
     name: "experimental_threading"
     mtype: "<type \'property\'>"
   }
+  member {
+    name: "threading"
+    mtype: "<type \'property\'>"
+  }
   member_method {
     name: "__init__"
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-threading-options.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-threading-options.pbtxt
@@ -1,0 +1,18 @@
+path: "tensorflow.data.ThreadingOptions"
+tf_class {
+  is_instance: "<class \'tensorflow.python.data.experimental.ops.threading_options.ThreadingOptions\'>"
+  is_instance: "<class \'tensorflow.python.data.util.options.OptionsBase\'>"
+  is_instance: "<type \'object\'>"
+  member {
+    name: "max_intra_op_parallelism"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "private_threadpool_size"
+    mtype: "<type \'property\'>"
+  }
+  member_method {
+    name: "__init__"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+  }
+}

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.pbtxt
@@ -37,6 +37,10 @@ tf_module {
     mtype: "<type \'type\'>"
   }
   member {
+    name: "ThreadingOptions"
+    mtype: "<type \'type\'>"
+  }
+  member {
     name: "UNKNOWN_CARDINALITY"
     mtype: "<type \'int\'>"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-options.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-options.pbtxt
@@ -27,6 +27,10 @@ tf_class {
     name: "experimental_threading"
     mtype: "<type \'property\'>"
   }
+  member {
+    name: "threading"
+    mtype: "<type \'property\'>"
+  }
   member_method {
     name: "__init__"
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-threading-options.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-threading-options.pbtxt
@@ -1,0 +1,18 @@
+path: "tensorflow.data.ThreadingOptions"
+tf_class {
+  is_instance: "<class \'tensorflow.python.data.experimental.ops.threading_options.ThreadingOptions\'>"
+  is_instance: "<class \'tensorflow.python.data.util.options.OptionsBase\'>"
+  is_instance: "<type \'object\'>"
+  member {
+    name: "max_intra_op_parallelism"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "private_threadpool_size"
+    mtype: "<type \'property\'>"
+  }
+  member_method {
+    name: "__init__"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+  }
+}

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.pbtxt
@@ -41,6 +41,10 @@ tf_module {
     mtype: "<type \'type\'>"
   }
   member {
+    name: "ThreadingOptions"
+    mtype: "<type \'type\'>"
+  }
+  member {
     name: "UNKNOWN_CARDINALITY"
     mtype: "<type \'int\'>"
   }


### PR DESCRIPTION
**[UPDATED]** This PR graduates `tf.data.experimental.ThreadingOptions` to `tf.data.ThreadingOptions`.

- [x] deprecate the old endpoint
- [x] update docstring of the class
- [x] Modify the serialization-deserialization implementation of `options.threading` and `options.experimental_threading` for backward-compatibility
- [x] regenerate golden APIs
- [x] add relevant test cases for the new ser-des implementation.
- [x] update RELEASE.md

TEST LOG
```
INFO: Elapsed time: 43.917s, Critical Path: 34.51s
INFO: 351 processes: 130 internal, 221 processwrapper-sandbox.
INFO: Build completed successfully, 351 total actions
//tensorflow/python/data/kernel_tests:options_test                       PASSED in 3.3s

INFO: Build completed successfully, 351 total actions
```

cc: @jsimsa