### PR TITLE
Add float16 support for SparseSegmentSumGrad

### DIFF
--- a/tensorflow/core/kernels/segment_reduction_ops_impl_5.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl_5.cc
@@ -93,9 +93,7 @@ TF_CALL_FLOAT_TYPES(REGISTER_CPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE);
           .TypeConstraint<index_type>("Tidx")                           \
           .TypeConstraint<segment_ids_type>("Tsegmentids"),             \
       SparseSegmentSumGradOp<type, index_type, segment_ids_type>);
-REGISTER_CPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE(float);
-REGISTER_CPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE(double);
-REGISTER_CPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE(bfloat16);
+TF_CALL_FLOAT_TYPES(REGISTER_CPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE);
 #undef REGISTER_CPU_SPARSE_KERNELS
 
 #define REGISTER_CPU_SPARSE_KERNELS(type, index_type, segment_ids_type) \

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -1366,7 +1366,7 @@ REGISTER_OP("SparseSegmentSumGrad")
     .Input("segment_ids: Tsegmentids")
     .Input("output_dim0: int32")
     .Output("output: T")
-    .Attr("T: {bfloat16, float, double}")
+    .Attr("T: {bfloat16, half, float, double}")
     .Attr("Tidx: {int32, int64} = DT_INT32")
     .Attr("Tsegmentids: {int32, int64} = DT_INT32")
     .SetShapeFn(SparseSegmentReductionGradShapeFn);


### PR DESCRIPTION
This is a follow-up to https://github.com/tensorflow/tensorflow/pull/49604 that adds fp16 support to the recently-added `SparseSegmentSumGrad` op.

cc @nluehr 