### PR TITLE
Skip unnecessary ops in embedding_lookup_sparse

### DIFF
--- a/tensorflow/python/ops/embedding_ops.py
+++ b/tensorflow/python/ops/embedding_ops.py
@@ -507,10 +507,15 @@ def embedding_lookup_sparse(params,
     segment_ids = sp_ids.indices[:, 0]
 
     ids = sp_ids.values
-    ids, idx = array_ops.unique(ids)
 
-    embeddings = embedding_lookup(
-        params, ids, partition_strategy=partition_strategy, max_norm=max_norm)
+    if len(params) == 1 and max_norm is None:
+      idx = ids
+      embeddings = params[0]
+    else:
+      ids, idx = array_ops.unique(ids)
+      embeddings = embedding_lookup(
+          params, ids, partition_strategy=partition_strategy, max_norm=max_norm)
+
     if not ignore_weights:
       if segment_ids.dtype != dtypes.int32:
         segment_ids = math_ops.cast(segment_ids, dtypes.int32)


### PR DESCRIPTION
- Skips the `unique` + `embedding_lookup` calls when possible and instead passes the embedding parameters directly to the sparse segment reduction op (or the corresponding ops for the weighted case), which is significantly more efficient.
- This same optimization is already done in the Grappler [SimplifyEmbeddingLookupStage](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/grappler/optimizers/arithmetic_optimizer.cc#L4085-L4107) pass, but that does not apply in Eager mode or when weights are used.

cc @nluehr 