### PR TITLE
Update common_win.bat

### DIFF
--- a/tensorflow/tools/ci_build/release/common_win.bat
+++ b/tensorflow/tools/ci_build/release/common_win.bat
@@ -46,8 +46,8 @@ SET PATH=%PATH%;C:\%PYTHON_DIRECTORY%
 %PY_EXE% -m pip install "gast == 0.3.3"
 @REM Finally, install tensorboard and estimator
 @REM Note that here we want the latest version that matches (b/156523241)
-%PY_EXE% -m pip install --upgrade --force-reinstall "tb-nightly ~= 2.4.0.a"
-%PY_EXE% -m pip install --upgrade --force-reinstall "tensorflow_estimator ~= 2.3.0"
+%PY_EXE% -m pip install --upgrade "tb-nightly ~= 2.4.0.a"
+%PY_EXE% -m pip install --upgrade "tensorflow_estimator ~= 2.3.0"
 @REM Test dependencies
 %PY_EXE% -m pip install "grpcio ~= 1.32.0"
 %PY_EXE% -m pip install "portpicker ~= 1.3.1"


### PR DESCRIPTION
Force reinstalling causes numpy 1.20 to be installed on the host which then breaks a ton of tests that were compiled with numpy 1.19.