### PR TITLE
[INTEL MKL] Fix compiler test failures when oneDNN is enabled.

### DIFF
--- a/tensorflow/core/common_runtime/mkl_layout_pass.cc
+++ b/tensorflow/core/common_runtime/mkl_layout_pass.cc
@@ -1072,17 +1072,22 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
 
     // Substring that should be checked for in device name for CPU device.
     const char* const kCPUDeviceSubStr = "CPU";
+    const char* const kXLACPUDeviceSubStr = "XLA_CPU";
 
-    // If Op has been specifically assigned to a non-CPU device, then No.
+    // If Op has been specifically assigned to a non-CPU or XLA_CPU device, then
+    // No.
     if (!n->assigned_device_name().empty() &&
-        !absl::StrContains(n->assigned_device_name(), kCPUDeviceSubStr)) {
+        (!absl::StrContains(n->assigned_device_name(), kCPUDeviceSubStr) ||
+         absl::StrContains(n->assigned_device_name(), kXLACPUDeviceSubStr))) {
       result = false;
       reason = "Op has been assigned a runtime device that is not CPU.";
     }
 
-    // If user has specifically assigned this op to a non-CPU device, then No.
+    // If user has specifically assigned this op to a non-CPU or XLA_CPU device,
+    // then No.
     if (!n->def().device().empty() &&
-        !absl::StrContains(n->def().device(), kCPUDeviceSubStr)) {
+        (!absl::StrContains(n->def().device(), kCPUDeviceSubStr) ||
+         absl::StrContains(n->def().device(), kXLACPUDeviceSubStr))) {
       result = false;
       reason = "User has assigned a device that is not CPU.";
     }


### PR DESCRIPTION
Fix for a number of compiler xla related failures, where the runtime doesn't find registered kernels for _Mkl* OpKernels for 'XLA_CPU'. The bug is caused by mkl layout pass rewriting an operator which was assigned to XLA_CPU.  The fix is to block the rewrite if device is an XLA_CPU.