### PR TITLE
[TF-TRT] Throwing error if compiling with NVIDIA TensorRT < 7

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/trt_optimization_pass.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/trt_optimization_pass.h
@@ -25,6 +25,11 @@ limitations under the License.
 
 #if GOOGLE_CUDA && GOOGLE_TENSORRT
 
+#if !IS_TRT_VERSION_GE(7, 0, 0, 0)
+    #error From version 2.6, we only support NVIDIA TensorRT version 7 or newer.
+    #error Please update your environment and relaunch the compilation.
+#endif
+
 namespace tensorflow {
 namespace tensorrt {
 namespace convert {


### PR DESCRIPTION
This PR blocks TF compilation with TRT_VERSION < 7, effectively removing support for TRT 5 and 6.