### PR TITLE
[TFLite]: Add missing cc file to Makefile

### DIFF
--- a/tensorflow/lite/tools/make/Makefile
+++ b/tensorflow/lite/tools/make/Makefile
@@ -140,6 +140,7 @@ $(wildcard tensorflow/lite/core/api/*.cc) \
 $(wildcard tensorflow/lite/delegates/interpreter_utils.cc) \
 $(wildcard tensorflow/lite/experimental/resource/*.cc) \
 $(wildcard tensorflow/lite/schema/schema_utils.cc) \
+$(wildcard tensorflow/lite/schema/schema_conversion_utils.cc) \
 $(wildcard tensorflow/lite/tools/make/downloads/ruy/ruy/*.cc)
 ifeq ($(TFLITE_HAVE_CPUINFO),true)
 CORE_CC_ALL_SRCS += \

--- a/tensorflow/lite/tools/make/Makefile
+++ b/tensorflow/lite/tools/make/Makefile
@@ -139,8 +139,8 @@ $(wildcard tensorflow/lite/core/*.cc) \
 $(wildcard tensorflow/lite/core/api/*.cc) \
 $(wildcard tensorflow/lite/delegates/interpreter_utils.cc) \
 $(wildcard tensorflow/lite/experimental/resource/*.cc) \
-$(wildcard tensorflow/lite/schema/schema_utils.cc) \
 $(wildcard tensorflow/lite/schema/schema_conversion_utils.cc) \
+$(wildcard tensorflow/lite/schema/schema_utils.cc) \
 $(wildcard tensorflow/lite/tools/make/downloads/ruy/ruy/*.cc)
 ifeq ($(TFLITE_HAVE_CPUINFO),true)
 CORE_CC_ALL_SRCS += \


### PR DESCRIPTION
This PR adds a missing file whose code is used in libedgetpu/libcoral
to the Tensorflow Lite `Makefile`.
