### PR TITLE
to_categorical() doc fixes.

### DIFF
--- a/tensorflow/python/keras/utils/np_utils.py
+++ b/tensorflow/python/keras/utils/np_utils.py
@@ -25,11 +25,11 @@ def to_categorical(y, num_classes=None, dtype='float32'):
   E.g. for use with categorical_crossentropy.
 
   Args:
-      y: class vector to be converted into a matrix
-          (integers from 0 to num_classes).
+      y: array-like with class values to be converted into a matrix
+          (integers from 0 to num_classes-1).
       num_classes: total number of classes. If `None`, this would be inferred
         as the (largest number in `y`) + 1.
-      dtype: The data type expected by the input. Default: `'float32'`.
+      dtype: The data type of the output. Default: `'float32'`.
 
   Returns:
       A binary matrix representation of the input. The classes axis is placed


### PR DESCRIPTION
1. For consistency with the definition of `num_classes`, the input `y` contains values up to `num_classes`-1 (included) only.
2. `y` is more general than a vector: it can by any array-like (`y = numpy.arange(12).reshape((3, 4))` works as expected).
3. Clearer definition of `dtype` (it's the type of the output of this function, not necessarily of some "input").