### PR TITLE
Add GPU kernel for SparseSegment[Sum,Mean,SqrtN]Grad

### DIFF
--- a/tensorflow/core/kernels/segment_reduction_ops_gpu.cu.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops_gpu.cu.cc
@@ -230,7 +230,8 @@ __device__ T ReduceBlockAlongCols(ReduceOp reduce_op, const T& value,
 // but Tinit is always a scalar type.
 // Note that the first dimension of input_vec is nouter if indices is not
 // provided; otherwise it is indexed indirectly via indices and can have any
-// size (as long as it spans at least the maximum value in indices).
+// size (as long as it spans at least the maximum value in indices). This also
+// applies to the weights vector.
 template <typename Treducevec, typename Tvec, typename Tindex,
           typename Tsegmentids, typename ReduceOp, typename Tinit>
 __global__ void SegmentReduceVectorKernel(
@@ -239,6 +240,7 @@ __global__ void SegmentReduceVectorKernel(
     const Tvec* __restrict__ input_vec,          // [nouter or any, ninner_vec]
     const Tindex* __restrict__ segment_offsets,  // [nsegments + 1]
     const Tindex* __restrict__ indices,          // [nouter] (optional)
+    const Tinit* __restrict__ weights,           // [nouter or any] (optional)
     Tvec* __restrict__ output_vec) {             // [nsegments, ninner_vec]
   const int num_blocks_x = (ninner_vec - 1) / blockDim.x + 1;
   // Grid-stride loop over inner dimension blocks.
@@ -263,6 +265,8 @@ __global__ void SegmentReduceVectorKernel(
         // Load the input row from global mem.
         Treducevec block_result =
             x_ok && y_ok ? input_vec[input_idx] : Tvec(initial_value);
+        // Apply weights if provided.
+        if (weights && y_ok) block_result *= Tvec(weights[y_idx]);
         // Reduce along the columns of the block, returning result in first row.
         block_result = ReduceBlockAlongCols(reduce_op, block_result, x_ok);
         if (y == 0 && x_ok) {
@@ -307,6 +311,7 @@ Status LaunchSegmentReduceVectorKernel(
     const Tvec* input_vec,          // [nouter or any, ninner_vec]
     const Tindex* segment_offsets,  // [nsegments + 1]
     const Tindex* indices,          // [nouter] (optional)
+    const Tinit* weights,           // [nouter or any] (optional)
     Tvec* output_vec) {             // [nsegments, ninner_vec]
   static constexpr const int kMaxGridX = (1u << 31) - 1;
   static constexpr const int kMaxGridY = (1u << 16) - 1;
@@ -335,7 +340,7 @@ Status LaunchSegmentReduceVectorKernel(
                                 Tinit>,
       grid, block, shared_memory_bytes, d.stream(), nouter, ninner_vec,
       nsegments, reduce_op, initial_value, empty_segment_value, is_mean,
-      is_sqrtn, input_vec, segment_offsets, indices, output_vec);
+      is_sqrtn, input_vec, segment_offsets, indices, weights, output_vec);
 }
 
 template <typename Tvec, typename Treducevec, typename Tindex,
@@ -395,6 +400,37 @@ struct CastFunctor {
   }
 };
 
+template <typename Treducevec, typename Tvec, typename Tindex, typename Tinit>
+struct LookupAndScaleAndCastInputsFunctor {
+  LookupAndScaleAndCastInputsFunctor(const Tvec* input_vec,
+                                     const Tindex* indices,
+                                     const Tinit* weights)
+      : input_vec_(input_vec), indices_(indices), weights_(weights) {}
+
+  __device__ Treducevec operator()(Tindex idx) const {
+    if (indices_) idx = indices_[idx];
+    Treducevec result = static_cast<Treducevec>(input_vec_[idx]);
+    if (weights_) result *= Tvec(weights_[idx]);
+    return result;
+  }
+
+ private:
+  const Tvec* __restrict__ input_vec_;
+  const Tindex* __restrict__ indices_;
+  const Tinit* __restrict__ weights_;
+};
+
+template <typename Treducevec, typename Tvec, typename Tindex, typename Tinit>
+auto MakeLookupAndScaleAndCastInputsIterator(const Tvec* input_vec,
+                                             const Tindex* indices,
+                                             const Tinit* weights) {
+  LookupAndScaleAndCastInputsFunctor<Treducevec, Tvec, Tindex, Tinit> functor(
+      input_vec, indices, weights);
+  return gpuprim::TransformInputIterator<
+      Treducevec, decltype(functor), gpuprim::CountingInputIterator<Tindex>>(
+      Tindex(0), functor);
+}
+
 template <typename Treducevec, typename Tvec, typename Tindex,
           typename Tsegmentids, typename ReduceOp, typename Tinit>
 Status SegmentReduceGPUImplNoInnerDim(
@@ -404,6 +440,7 @@ Status SegmentReduceGPUImplNoInnerDim(
     const Tvec* input_vec,          // [nouter or any]
     const Tindex* segment_offsets,  // [nsegments + 1]
     const Tindex* indices,          // [nouter] (optional)
+    const Tinit* weights,           // [nouter or any] (optional)
     Tvec* output_vec) {             // [nsegments]
   // Here we use gpuprim::DeviceSegmentedReduce (which is optimized for this
   // shape) and add the additional required functionality using fancy input
@@ -424,25 +461,11 @@ Status SegmentReduceGPUImplNoInnerDim(
     output_raw_ptr =
         reinterpret_cast<Treducevec*>(output_raw.flat<int8>().data());
   }
-  if (indices) {
-    // Use fancy iterators to do lookup via indices and to cast to Treducevec.
-    PermutationInputIterator<Treducevec, decltype(input_vec), decltype(indices)>
-        perm_iter(input_vec, indices);
-    gpuprim::TransformInputIterator<Treducevec, CastFunctor<Treducevec>,
-                                    decltype(perm_iter)>
-        input_lookup_cast(perm_iter, {});
-    TF_RETURN_IF_ERROR(
-        GpuSegmentedReduce(ctx, nsegments, reduce_op, Treducevec(initial_value),
-                           input_lookup_cast, segment_offsets, output_raw_ptr));
-  } else {
-    // Use a fancy iterator to cast to Treducevec.
-    gpuprim::TransformInputIterator<Treducevec, CastFunctor<Treducevec>,
-                                    decltype(input_vec)>
-        input_cast(input_vec, {});
-    TF_RETURN_IF_ERROR(GpuSegmentedReduce(ctx, nsegments, reduce_op,
-                                          Treducevec(initial_value), input_cast,
-                                          segment_offsets, output_raw_ptr));
-  }
+  auto input_iter = MakeLookupAndScaleAndCastInputsIterator<Treducevec>(
+      input_vec, indices, weights);
+  TF_RETURN_IF_ERROR(GpuSegmentedReduce(ctx, nsegments, reduce_op,
+                                        Treducevec(initial_value), input_iter,
+                                        segment_offsets, output_raw_ptr));
   bool need_epilogue = !std::is_same<Tvec, Treducevec>::value ||
                        initial_value != empty_segment_value || is_mean ||
                        is_sqrtn;
@@ -465,6 +488,7 @@ Status SegmentReduceGPUImpl(
     const Tvec* input_vec,           // [nouter or any, ninner_vec]
     const Tsegmentids* segment_ids,  // [nouter]
     const Tindex* indices,           // [nouter] (optional)
+    const Tinit* weights,            // [nouter or any] (optional)
     Tvec* output_vec) {              // [nsegments, ninner_vec]
   const GPUDevice& device = ctx->eigen_gpu_device();
 
@@ -495,7 +519,8 @@ Status SegmentReduceGPUImpl(
     // inner dimension but can be significantly faster for large reductions.
     return SegmentReduceGPUImplNoInnerDim<Treducevec>(
         ctx, nouter, nsegments, reduce_op, initial_value, empty_segment_value,
-        is_mean, is_sqrtn, input_vec, segment_offsets_ptr, indices, output_vec);
+        is_mean, is_sqrtn, input_vec, segment_offsets_ptr, indices, weights,
+        output_vec);
   }
   // Here we use a custom kernel that is optimized for ninner_vec >= ~64 and
   // gives decent performance for smaller cases. It also handles indices,
@@ -503,7 +528,7 @@ Status SegmentReduceGPUImpl(
   return LaunchSegmentReduceVectorKernel<Treducevec>(
       device, nouter, ninner_vec, nsegments, reduce_op, initial_value,
       empty_segment_value, is_mean, is_sqrtn, input_vec, segment_offsets_ptr,
-      indices, output_vec);
+      indices, weights, output_vec);
 }
 
 template <typename Treduce>
@@ -517,7 +542,7 @@ struct SegmentReduceGPUVectorized {
                       T initial_value, T empty_segment_value, bool is_mean,
                       bool is_sqrtn, const T* input,
                       const Tsegmentids* segment_ids, const Tindex* indices,
-                      T* output) {
+                      const T* weights, T* output) {
       DCHECK_EQ(ninner % vec_size, 0);
       DCHECK_EQ(reinterpret_cast<std::uintptr_t>(input) % vec_size, 0);
       DCHECK_EQ(reinterpret_cast<std::uintptr_t>(output) % vec_size, 0);
@@ -530,7 +555,7 @@ struct SegmentReduceGPUVectorized {
       return SegmentReduceGPUImpl<Treducevec>(
           ctx, nouter, ninner_vec, nsegments, reduce_op, initial_value,
           empty_segment_value, is_mean, is_sqrtn, input_vec, segment_ids,
-          indices, output_vec);
+          indices, weights, output_vec);
     }
   };
 };
@@ -553,13 +578,45 @@ Status SegmentReduceGPU(OpKernelContext* ctx, Tindex nouter, Tindex ninner,
                         const T* input,  // [nouter or any, ninner]
                         const Tsegmentids* segment_ids,  // [nouter]
                         const Tindex* indices,           // [nouter] (optional)
-                        T* output) {                     // [nsegments, ninner]
+                        const T* weights,  // [nouter or any] (optional)
+                        T* output) {       // [nsegments, ninner]
   if (ninner == 0 || nsegments == 0) return Status::OK();
   return DispatchToVectorized<
       T, SegmentReduceGPUVectorized<Treduce>::template Impl>(
       MinAlignmentOf(input, output, ninner), ctx, nouter, ninner, nsegments,
       reduce_op, initial_value, empty_segment_value, is_mean, is_sqrtn, input,
-      segment_ids, indices, output);
+      segment_ids, indices, weights, output);
+}
+
+template <typename SegmentId, typename Index, typename T>
+__global__ void SegmentWeightsKernel(
+    SegmentId nsegments, SparseSegmentReductionOperation operation,
+    const Index* __restrict__ segment_offsets,  // [nsegments + 1]
+    T* __restrict__ weights) {                  // [nsegments]
+  GPU_1D_KERNEL_LOOP(i, nsegments) {
+    Index segment_size = segment_offsets[i + 1] - segment_offsets[i];
+    segment_size = max(segment_size, Index(1));  // Avoid division by zero
+    if (operation == SparseSegmentReductionOperation::kMean) {
+      weights[i] = T(1) / static_cast<T>(segment_size);
+    } else if (operation == SparseSegmentReductionOperation::kSqrtN) {
+      weights[i] = T(1) / sqrt(static_cast<T>(segment_size));
+    }
+  }
+}
+
+template <typename SegmentId, typename Index, typename T>
+Status LaunchSegmentWeightsKernel(
+    const GPUDevice& d, SegmentId nsegments,
+    SparseSegmentReductionOperation operation,
+    const Index* segment_offsets,  // [nsegments + 1]
+    T* weights) {                  // [nsegments]
+  GpuLaunchConfig config = GetGpuLaunchConfig(
+      nsegments, d, &SegmentWeightsKernel<SegmentId, Index, T>,
+      /*dynamic_shared_memory_size=*/0, /*block_size_limit=*/0);
+  return GpuLaunchKernel(SegmentWeightsKernel<SegmentId, Index, T>,
+                         config.block_count, config.thread_per_block, 0,
+                         d.stream(), nsegments, operation, segment_offsets,
+                         weights);
 }
 
 template <typename ReduceOp, typename T>
@@ -693,8 +750,86 @@ Status SparseSegmentReductionFunctor<T, Index, SegmentId>::operator()(
       /*empty_segment_value=*/default_value,
       /*is_mean=*/is_mean, /*is_sqrtn=*/is_sqrtn,
       /*input=*/input.data(), /*segment_ids=*/segment_ids.data(),
-      /*indices=*/indices.data(), /*output=*/output.data());
+      /*indices=*/indices.data(), /*weights=*/static_cast<T*>(nullptr),
+      /*output=*/output.data());
 }
+
+template <typename T, typename Index, typename SegmentId>
+struct SparseSegmentGradFunctor<GPUDevice, T, Index, SegmentId> {
+  void operator()(OpKernelContext* context,
+                  SparseSegmentReductionOperation operation,
+                  typename TTypes<T>::ConstMatrix input_flat,
+                  typename TTypes<Index>::ConstVec indices_vec,
+                  typename TTypes<SegmentId>::ConstVec segment_vec,
+                  typename TTypes<T>::Matrix output_flat) {
+    const GPUDevice& device = context->eigen_gpu_device();
+
+    const SegmentId nsegments = input_flat.dimension(0);
+    const Index ninner = input_flat.dimension(1);
+    const Index nouter = indices_vec.dimension(0);
+    const Index noutput = output_flat.dimension(0);
+
+    // Allocate and compute segment weights (for Mean/SqrtN operations only).
+    Tensor weights;
+    T* weights_ptr = nullptr;
+    if (operation != SparseSegmentReductionOperation::kSum) {
+      OP_REQUIRES_OK(
+          context, context->allocate_temp(DataTypeToEnum<T>::value,
+                                          TensorShape({nsegments}), &weights));
+      weights_ptr = weights.flat<T>().data();
+      // Allocate and compute segment_offsets.
+      Tensor segment_offsets;
+      OP_REQUIRES_OK(context,
+                     context->allocate_temp(DataTypeToEnum<Index>::value,
+                                            TensorShape({nsegments + 1}),
+                                            &segment_offsets));
+      Index* segment_offsets_ptr = segment_offsets.flat<Index>().data();
+      OP_REQUIRES_OK(context, LaunchSegmentOffsetsKernel(
+                                  device, nouter, nsegments, segment_vec.data(),
+                                  segment_offsets_ptr));
+      // Compute the weights based on the segment sizes using segment_offsets.
+      OP_REQUIRES_OK(context, LaunchSegmentWeightsKernel(
+                                  device, nsegments, operation,
+                                  segment_offsets_ptr, weights_ptr));
+    }
+
+    // Sort indices and permute segments.
+    Tensor sorted_indices;
+    OP_REQUIRES_OK(context, context->allocate_temp(DataTypeToEnum<Index>::value,
+                                                   TensorShape({nouter}),
+                                                   &sorted_indices));
+    Index* sorted_indices_ptr = sorted_indices.flat<Index>().data();
+    Tensor sorted_segment;
+    OP_REQUIRES_OK(context, context->allocate_temp(
+                                DataTypeToEnum<SegmentId>::value,
+                                TensorShape({nouter}), &sorted_segment));
+    SegmentId* sorted_segment_ptr = sorted_segment.flat<SegmentId>().data();
+    OP_REQUIRES_OK(context, GpuRadixSort(context, nouter,
+                                         /*keys_in=*/indices_vec.data(),
+                                         /*keys_out=*/sorted_indices_ptr,
+                                         /*indices_in=*/segment_vec.data(),
+                                         /*indices_out=*/sorted_segment_ptr,
+                                         /*num_bits=*/Log2Ceiling64(noutput)));
+
+    // Compute the gradient using a weighted SegmentReduceGPU with the segment
+    // IDs and indices swapped.
+    using ReduceOp = gpuprim::Sum;
+    using Treduce = typename ReduceType<ReduceOp, T>::type;
+    OP_REQUIRES_OK(
+        context,
+        SegmentReduceGPU<Treduce>(
+            context, /*nouter=*/static_cast<SegmentId>(nouter),
+            /*ninner=*/static_cast<SegmentId>(ninner),
+            /*nsegments=*/noutput,
+            /*reduce_op=*/ReduceOp(),
+            /*initial_value=*/T(0),
+            /*empty_segment_value=*/T(0),
+            /*is_mean=*/false, /*is_sqrtn=*/false,
+            /*input=*/input_flat.data(), /*segment_ids=*/sorted_indices_ptr,
+            /*indices=*/sorted_segment_ptr, /*weights=*/weights_ptr,
+            /*output=*/output_flat.data()));
+  }
+};
 
 #define DEFINE_SORTED_GPU_SPECS_INDEX(T, Index)                           \
   template struct SegmentReductionFunctor<T, Index, functor::Zero<T>,     \
@@ -769,6 +904,14 @@ TF_CALL_COMPLEX_TYPES(DEFINE_SUM_GPU_SPECS);
   template struct SparseSegmentReductionFunctor<T, int64, int64>;
 TF_CALL_GPU_NUMBER_TYPES(DEFINE_SPARSE_SEGMENT_REDUCTION_FUNCTOR);
 #undef DEFINE_SPARSE_SEGMENT_REDUCTION_FUNCTOR
+
+#define DEFINE_SPARSE_SEGMENT_GRAD_FUNCTOR(T)                           \
+  template struct SparseSegmentGradFunctor<GPUDevice, T, int32, int32>; \
+  template struct SparseSegmentGradFunctor<GPUDevice, T, int32, int64>; \
+  template struct SparseSegmentGradFunctor<GPUDevice, T, int64, int32>; \
+  template struct SparseSegmentGradFunctor<GPUDevice, T, int64, int64>;
+TF_CALL_GPU_NUMBER_TYPES(DEFINE_SPARSE_SEGMENT_GRAD_FUNCTOR);
+#undef DEFINE_SPARSE_SEGMENT_GRAD_FUNCTOR
 
 #endif  // !defined(PLATFORM_WINDOWS)
 

--- a/tensorflow/core/kernels/segment_reduction_ops_impl_5.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl_5.cc
@@ -202,4 +202,49 @@ TF_CALL_FLOAT_TYPES(REGISTER_CPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE);
 #undef REGISTER_CPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE
 #undef REGISTER_CPU_SPARSE_KERNELS_FOR_EACH_SEGMENT_ID_TYPE
 
+// TODO(benbarsdell): See comment above.
+#if !defined(PLATFORM_WINDOWS)
+
+#define REGISTER_GPU_SPARSE_KERNELS(type, index_type, segment_ids_type) \
+  REGISTER_KERNEL_BUILDER(                                              \
+      Name("SparseSegmentSumGrad")                                      \
+          .Device(DEVICE_GPU)                                           \
+          .HostMemory("output_dim0")                                    \
+          .TypeConstraint<type>("T")                                    \
+          .TypeConstraint<index_type>("Tidx")                           \
+          .TypeConstraint<segment_ids_type>("Tsegmentids"),             \
+      SparseSegmentSumGradOp<GPUDevice, type, index_type, segment_ids_type>);
+TF_CALL_GPU_NUMBER_TYPES(REGISTER_GPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE);
+#undef REGISTER_GPU_SPARSE_KERNELS
+
+#define REGISTER_GPU_SPARSE_KERNELS(type, index_type, segment_ids_type) \
+  REGISTER_KERNEL_BUILDER(                                              \
+      Name("SparseSegmentMeanGrad")                                     \
+          .Device(DEVICE_GPU)                                           \
+          .HostMemory("output_dim0")                                    \
+          .TypeConstraint<type>("T")                                    \
+          .TypeConstraint<index_type>("Tidx")                           \
+          .TypeConstraint<segment_ids_type>("Tsegmentids"),             \
+      SparseSegmentMeanGradOp<GPUDevice, type, index_type, segment_ids_type>);
+TF_CALL_GPU_NUMBER_TYPES(REGISTER_GPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE);
+#undef REGISTER_GPU_SPARSE_KERNELS
+
+#define REGISTER_GPU_SPARSE_KERNELS(type, index_type, segment_ids_type) \
+  REGISTER_KERNEL_BUILDER(                                              \
+      Name("SparseSegmentSqrtNGrad")                                    \
+          .Device(DEVICE_GPU)                                           \
+          .HostMemory("output_dim0")                                    \
+          .TypeConstraint<type>("T")                                    \
+          .TypeConstraint<index_type>("Tidx")                           \
+          .TypeConstraint<segment_ids_type>("Tsegmentids"),             \
+      SparseSegmentSqrtNGradOp<GPUDevice, type, index_type,             \
+                               segment_ids_type>);
+TF_CALL_GPU_NUMBER_TYPES(REGISTER_GPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE);
+#undef REGISTER_GPU_SPARSE_KERNELS
+
+#undef REGISTER_GPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE
+#undef REGISTER_GPU_SPARSE_KERNELS_FOR_EACH_SEGMENT_ID_TYPE
+
+#endif  // !defined(PLATFORM_WINDOWS)
+
 }  // namespace tensorflow

--- a/tensorflow/python/kernel_tests/segment_reduction_ops_test.py
+++ b/tensorflow/python/kernel_tests/segment_reduction_ops_test.py
@@ -519,6 +519,22 @@ class SparseSegmentReductionHelper(SegmentReductionHelper):
     return self._segmentReduce(
         segment_indices, x[indices], op1, op2, num_segments=num_segments)
 
+  def _sparseSegmentReduceGrad(self, ygrad, indices, segment_ids, output_dim0,
+                               mode):
+    assert(mode in ('sum', 'mean', 'sqrtn'))
+    if mode != 'sum':
+      weights = np.zeros(ygrad.shape[0], ygrad.dtype)
+      for segment in segment_ids:
+        weights[segment] += 1
+      weights = 1. / weights if mode == 'mean' else 1. / np.sqrt(weights)
+    xgrad = np.zeros([output_dim0, ygrad.shape[1]], ygrad.dtype)
+    for segment, index in zip(segment_ids, indices):
+      if mode == 'sum':
+        xgrad[index] += ygrad[segment]
+      else:
+        xgrad[index] += ygrad[segment] * weights[segment]
+    return xgrad
+
 
 class SparseSegmentReductionOpTest(SparseSegmentReductionHelper):
 
@@ -864,6 +880,26 @@ class SparseSegmentReductionOpTest(SparseSegmentReductionHelper):
             x_init_value=np_x.astype(np.double),
             delta=1)
       self.assertAllClose(jacob_t, jacob_n)
+
+  def testGradientExplicit(self):
+    # Note that the GPU implem has different paths for different inner sizes.
+    for inner_size in (1, 2, 3, 32):
+      with self.session():
+        tf_ygrad, np_ygrad = self._input(
+            [3, inner_size], dtype=dtypes_lib.float32)
+        segment_ids = [0, 1, 2, 2, 2]
+        indices = [8, 3, 0, 9, 3]
+        output_dim0 = 10
+        ops_list = [
+            (math_ops.sparse_segment_sum_grad, 'sum'),
+            (math_ops.sparse_segment_mean_grad, 'mean'),
+            (math_ops.sparse_segment_sqrt_n_grad, 'sqrtn'),
+        ]
+        for tf_op, mode in ops_list:
+          np_xgrad = self._sparseSegmentReduceGrad(
+              np_ygrad, indices, segment_ids, output_dim0, mode)
+          tf_xgrad = tf_op(tf_ygrad, indices, segment_ids, output_dim0)
+          self.assertAllClose(tf_xgrad, np_xgrad)
 
   def testGradientValid(self):
     # Baseline for the testGradient*Invalid* methods below.


### PR DESCRIPTION
Adds a GPU kernel and an additional test for these grad ops.
It uses the existing `SegmentReduceVectorKernel` CUDA kernel with a slight modification.

cc @nluehr 