### PR TITLE
[TFLite]: Add CXXSTANDARD to Makefile

### DIFF
--- a/tensorflow/lite/tools/make/Makefile
+++ b/tensorflow/lite/tools/make/Makefile
@@ -63,7 +63,8 @@ LIBS := \
 # generate things like the protobuf compiler that require that), so all of
 # these settings are for the target compiler.
 CFLAGS := -O3 -DNDEBUG -DCPU_SETSIZE=__CPU_SETSIZE -fPIC $(EXTRA_CFLAGS)
-CXXFLAGS := $(CFLAGS) --std=c++11 $(EXTRA_CXXFLAGS)
+CXXSTANDARD := -std=c++11
+CXXFLAGS := $(CFLAGS) $(CXXSTANDARD) $(EXTRA_CXXFLAGS)
 LDOPTS := -L/usr/local/lib
 ARFLAGS := -r
 TARGET_TOOLCHAIN_PREFIX :=


### PR DESCRIPTION
This PR adds a new variable in the Tensorflow Lite Makefile: `CXXSTANDARD`.
This variable defaults to the current `c++11` standard used by Tensorflow
Lite, but also allows users to use a different standard if they desire.
