### PR TITLE
Make DataFormatVecPermute's validation and implementation consistent with each other

### DIFF
--- a/tensorflow/core/kernels/data_format_ops.cc
+++ b/tensorflow/core/kernels/data_format_ops.cc
@@ -21,11 +21,11 @@ limitations under the License.
 
 #include <map>
 
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/platform/errors.h"
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 namespace tensorflow {
 

--- a/tensorflow/core/kernels/data_format_ops.cc
+++ b/tensorflow/core/kernels/data_format_ops.cc
@@ -21,11 +21,11 @@ limitations under the License.
 
 #include <map>
 
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/platform/errors.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 namespace tensorflow {
 
@@ -144,17 +144,26 @@ class DataFormatVecPermuteOp : public OpKernel {
                 errors::InvalidArgument(
                     "input must be a vector or 2D tensor, but got shape ",
                     input.shape().DebugString()));
+
+    const int full_dim_count = src_format_.size();
+    const int spatial_dim_count = full_dim_count - 2;
+
     if (input.dims() == 1) {
       OP_REQUIRES(context,
-                  input.NumElements() == 2 || input.NumElements() == 4 ||
-                      input.NumElements() == 5,
-                  errors::InvalidArgument(
-                      "1D input must be of size 2, 4 or 5, but got shape ",
-                      input.shape().DebugString()));
+                  input.NumElements() == spatial_dim_count ||
+                      input.NumElements() == full_dim_count,
+                  errors::InvalidArgument("1D input must be of size ",
+                                          spatial_dim_count, " or ",
+                                          full_dim_count, ", but got shape ",
+                                          input.shape().DebugString()));
     } else if (input.dims() == 2) {
-      OP_REQUIRES(context, input.dim_size(0) == 2 || input.dim_size(0) == 4,
+      OP_REQUIRES(context,
+                  input.dim_size(0) == spatial_dim_count ||
+                      input.dim_size(0) == full_dim_count,
                   errors::InvalidArgument("First dimension of 2D input must be "
-                                          "of size 2 or 4, but got shape ",
+                                          "of size ",
+                                          spatial_dim_count, " or ",
+                                          full_dim_count, ", but got shape ",
                                           input.shape().DebugString()));
       OP_REQUIRES(
           context, input.dim_size(1) == 2,
@@ -167,24 +176,36 @@ class DataFormatVecPermuteOp : public OpKernel {
     OP_REQUIRES_OK(context,
                    context->allocate_output(0, input.shape(), &output));
     // Support 1D and 2D cases.
-    Eigen::DSizes<Eigen::DenseIndex, 8> dst_idx;
+    Eigen::DSizes<Eigen::DenseIndex, 10> dst_idx;
     string src_format_str = src_format_;
     string dst_format_str = dst_format_;
-    if (input.dim_size(0) == 2) {
-      // If the input is a vector of size 2, treat the two elements as spatial
-      // dimensions.
-      auto keep_only_spatial_dimensions = [](string* format_str) -> void {
-        auto new_end = std::remove_if(
-            format_str->begin(), format_str->end(),
-            [](const char dim) { return dim != 'H' && dim != 'W'; });
+    if (input.dim_size(0) == spatial_dim_count) {
+      // If the input is a vector of size spatial_dim_count, treat the elements
+      // as spatial dimensions.
+      auto keep_only_spatial_dimensions =
+          [spatial_dim_count](string* format_str) -> void {
+        auto new_end =
+            std::remove_if(format_str->begin(), format_str->end(),
+                           [spatial_dim_count](const char dim) {
+                             return dim != 'H' && dim != 'W' &&
+                                    (spatial_dim_count == 2 || dim != 'D');
+                           });
         format_str->erase(new_end, format_str->end());
       };
       keep_only_spatial_dimensions(&src_format_str);
       keep_only_spatial_dimensions(&dst_format_str);
-      OP_REQUIRES(context,
-                  src_format_str.size() == 2 && dst_format_str.size() == 2,
-                  errors::InvalidArgument(
-                      "Format specifier must contain H and W for 2D case"));
+      if (spatial_dim_count == 3) {
+        OP_REQUIRES(
+            context, src_format_str.size() == 3 && dst_format_str.size() == 3,
+            errors::InvalidArgument(
+                "Format specifier must contain D, H and W for 2D case"));
+      } else {
+        DCHECK(spatial_dim_count == 2);
+        OP_REQUIRES(context,
+                    src_format_str.size() == 2 && dst_format_str.size() == 2,
+                    errors::InvalidArgument(
+                        "Format specifier must contain H and W for 2D case"));
+      }
     }
     ComputeDstIndex(src_format_str, dst_format_str, input.dims(), &dst_idx);
 
@@ -200,7 +221,7 @@ class DataFormatVecPermuteOp : public OpKernel {
   // 2D: dst = [2, 3, 4, 5, 0, 1, 6, 7]
   static void ComputeDstIndex(const string& src_format_str,
                               const string& dst_format_str, int num_dim,
-                              Eigen::DSizes<Eigen::DenseIndex, 8>* dst) {
+                              Eigen::DSizes<Eigen::DenseIndex, 10>* dst) {
     for (int i = 0; i < src_format_str.size(); ++i) {
       for (int j = 0; j < dst_format_str.size(); ++j) {
         if (dst_format_str[j] != src_format_str[i]) continue;
@@ -266,12 +287,12 @@ TF_CALL_int32(DECLARE_GPU_SPECS);
 TF_CALL_int64(DECLARE_GPU_SPECS);
 #undef DECLARE_GPU_SPEC
 
-#define DECLARE_GPU_SPEC(T)                                \
-  template <>                                              \
-  void DataFormatVecPermute<GPUDevice, T>::operator()(     \
-      const GPUDevice& d, typename TTypes<T>::ConstFlat x, \
-      typename TTypes<T>::Vec y,                           \
-      const Eigen::DSizes<Eigen::DenseIndex, 8>& dst_idx); \
+#define DECLARE_GPU_SPEC(T)                                 \
+  template <>                                               \
+  void DataFormatVecPermute<GPUDevice, T>::operator()(      \
+      const GPUDevice& d, typename TTypes<T>::ConstFlat x,  \
+      typename TTypes<T>::Vec y,                            \
+      const Eigen::DSizes<Eigen::DenseIndex, 10>& dst_idx); \
   extern template struct DataFormatVecPermute<GPUDevice, T>;
 #define DECLARE_GPU_SPECS(T) DECLARE_GPU_SPEC(T);
 TF_CALL_int32(DECLARE_GPU_SPECS);

--- a/tensorflow/core/kernels/data_format_ops.h
+++ b/tensorflow/core/kernels/data_format_ops.h
@@ -77,7 +77,8 @@ struct DataFormatDimMap {
 
 template <typename T>
 struct VecPermute {
-  VecPermute(const Eigen::DSizes<Eigen::DenseIndex, 10>& dst) : dst_(dst) {}
+  explicit VecPermute(const Eigen::DSizes<Eigen::DenseIndex, 10>& dst)
+      : dst(dst) {}
   Eigen::DSizes<Eigen::DenseIndex, 1> dimensions(
       typename TTypes<T>::ConstFlat input) const {
     Eigen::DSizes<Eigen::DenseIndex, 1> result;
@@ -88,12 +89,12 @@ struct VecPermute {
   void eval(typename TTypes<T>::ConstFlat input, Output& output,
             const Device& d) const {
     for (int i = 0; i < input.size(); ++i) {
-      output.template chip<0>(dst_[i]).device(d) = input.template chip<0>(i);
+      output.template chip<0>(dst[i]).device(d) = input.template chip<0>(i);
     }
   }
 
  private:
-  Eigen::DSizes<Eigen::DenseIndex, 10> dst_;
+  Eigen::DSizes<Eigen::DenseIndex, 10> dst;
 };
 
 // Functor used by DataFormatVecPermuteOp to do the computations.

--- a/tensorflow/core/kernels/data_format_ops.h
+++ b/tensorflow/core/kernels/data_format_ops.h
@@ -77,7 +77,7 @@ struct DataFormatDimMap {
 
 template <typename T>
 struct VecPermute {
-  VecPermute(const Eigen::DSizes<Eigen::DenseIndex, 8>& dst) : dst_(dst) {}
+  VecPermute(const Eigen::DSizes<Eigen::DenseIndex, 10>& dst) : dst_(dst) {}
   Eigen::DSizes<Eigen::DenseIndex, 1> dimensions(
       typename TTypes<T>::ConstFlat input) const {
     Eigen::DSizes<Eigen::DenseIndex, 1> result;
@@ -93,7 +93,7 @@ struct VecPermute {
   }
 
  private:
-  Eigen::DSizes<Eigen::DenseIndex, 8> dst_;
+  Eigen::DSizes<Eigen::DenseIndex, 10> dst_;
 };
 
 // Functor used by DataFormatVecPermuteOp to do the computations.
@@ -101,7 +101,7 @@ template <typename Device, typename T>
 struct DataFormatVecPermute {
   void operator()(const Device& d, typename TTypes<T>::ConstFlat x,
                   typename TTypes<T>::Flat y,
-                  const Eigen::DSizes<Eigen::DenseIndex, 8>& dst) {
+                  const Eigen::DSizes<Eigen::DenseIndex, 10>& dst) {
     y.device(d) = x.customOp(VecPermute<T>(dst));
   }
 };

--- a/tensorflow/python/ops/nn_test.py
+++ b/tensorflow/python/ops/nn_test.py
@@ -1478,6 +1478,7 @@ class DataFormatVectorPermuteTest(test_lib.TestCase):
       y_val = self.evaluate(y)
       self.assertAllEqual(y_val, [[7, 4], [8, 2], [9, 3], [4, 5], [5, 1]])
 
+  @test_util.disable_xla("unsupported data format")
   def testNDHWCToDHWNC2D(self):
     x_val = [[7, 4], [9, 3], [4, 5], [5, 1], [8, 2]]
     x = constant_op.constant(x_val)
@@ -1487,6 +1488,7 @@ class DataFormatVectorPermuteTest(test_lib.TestCase):
       y_val = self.evaluate(y)
       self.assertAllEqual(y_val, [[9, 3], [4, 5], [5, 1], [7, 4], [8, 2]])
 
+  @test_util.disable_xla("unsupported data format")
   def testDHWNCToNDHWC2D(self):
     x_val = [[7, 4], [9, 3], [4, 5], [5, 1], [8, 2]]
     x = constant_op.constant(x_val)

--- a/tensorflow/python/ops/nn_test.py
+++ b/tensorflow/python/ops/nn_test.py
@@ -1406,7 +1406,8 @@ class DataFormatVectorPermuteTest(test_lib.TestCase):
   def testNCDHWToNDHWC(self):
     x_val = [7, 4, 9, 3, 5]
     x = constant_op.constant(x_val)
-    y = nn_ops.data_format_vec_permute(x, src_format="NCDHW", dst_format="NDHWC")
+    y = nn_ops.data_format_vec_permute(
+        x, src_format="NCDHW", dst_format="NDHWC")
     with test_util.use_gpu():
       y_val = self.evaluate(y)
       self.assertAllEqual(y_val, [7, 9, 3, 5, 4])

--- a/tensorflow/python/ops/nn_test.py
+++ b/tensorflow/python/ops/nn_test.py
@@ -1331,6 +1331,24 @@ class DataFormatVectorPermuteTest(test_lib.TestCase):
       y_val = self.evaluate(y)
       self.assertAllEqual(y_val, [4, 9])
 
+  def testNDHWCtoNCDHW(self):
+    x_val = [7, 4, 9, 3, 5]
+    x = constant_op.constant(x_val)
+    y = nn_ops.data_format_vec_permute(
+        x, src_format="NDHWC", dst_format="NCDHW")
+    with test_util.use_gpu():
+      y_val = self.evaluate(y)
+      self.assertAllEqual(y_val, [7, 5, 4, 9, 3])
+
+  def testNDHWCtoNCDHW_Size3(self):
+    x_val = [4, 9, 3]
+    x = constant_op.constant(x_val)
+    y = nn_ops.data_format_vec_permute(
+        x, src_format="NDHWC", dst_format="NCDHW")
+    with test_util.use_gpu():
+      y_val = self.evaluate(y)
+      self.assertAllEqual(y_val, [4, 9, 3])
+
   @test_util.disable_xla("unsupported data format")
   def testNHWCToWHCN(self):
     x_val = [7, 4, 9, 3]
@@ -1349,6 +1367,26 @@ class DataFormatVectorPermuteTest(test_lib.TestCase):
       y_val = self.evaluate(y)
       self.assertAllEqual(y_val, [9, 4])
 
+  @test_util.disable_xla("unsupported data format")
+  def testNDHWCToWHDCN(self):
+    x_val = [7, 4, 9, 3, 5]
+    x = constant_op.constant(x_val)
+    y = nn_ops.data_format_vec_permute(
+        x, src_format="NDHWC", dst_format="WHDCN")
+    with test_util.use_gpu():
+      y_val = self.evaluate(y)
+      self.assertAllEqual(y_val, [3, 9, 4, 5, 7])
+
+  @test_util.disable_xla("unsupported data format")
+  def testNDHWCToWHDCN_Size3(self):
+    x_val = [4, 9, 3]
+    x = constant_op.constant(x_val)
+    y = nn_ops.data_format_vec_permute(
+        x, src_format="NDHWC", dst_format="WHDCN")
+    with test_util.use_gpu():
+      y_val = self.evaluate(y)
+      self.assertAllEqual(y_val, [3, 9, 4])
+
   def testNCHWToNHWC(self):
     x_val = [7, 4, 9, 3]
     x = constant_op.constant(x_val)
@@ -1364,6 +1402,23 @@ class DataFormatVectorPermuteTest(test_lib.TestCase):
     with test_util.use_gpu():
       y_val = self.evaluate(y)
       self.assertAllEqual(y_val, [9, 3])
+
+  def testNCDHWToNDHWC(self):
+    x_val = [7, 4, 9, 3, 5]
+    x = constant_op.constant(x_val)
+    y = nn_ops.data_format_vec_permute(x, src_format="NCDHW", dst_format="NDHWC")
+    with test_util.use_gpu():
+      y_val = self.evaluate(y)
+      self.assertAllEqual(y_val, [7, 9, 3, 5, 4])
+
+  def testNCDHWToNDHWC_Size3(self):
+    x_val = [9, 3, 5]
+    x = constant_op.constant(x_val)
+    y = nn_ops.data_format_vec_permute(
+        x, src_format="NCDHW", dst_format="NDHWC")
+    with test_util.use_gpu():
+      y_val = self.evaluate(y)
+      self.assertAllEqual(y_val, [9, 3, 5])
 
   def testNHWCToHWNC(self):
     x_val = [7, 4, 9, 3]
@@ -1412,6 +1467,42 @@ class DataFormatVectorPermuteTest(test_lib.TestCase):
     with test_util.use_gpu():
       y_val = self.evaluate(y)
       self.assertAllEqual(y_val, [[7, 4], [4, 5], [5, 1], [9, 3]])
+
+  def testNDHWCToNCDHW2D(self):
+    x_val = [[7, 4], [9, 3], [4, 5], [5, 1], [8, 2]]
+    x = constant_op.constant(x_val)
+    y = nn_ops.data_format_vec_permute(
+        x, src_format="NDHWC", dst_format="NCDHW")
+    with test_util.use_gpu():
+      y_val = self.evaluate(y)
+      self.assertAllEqual(y_val, [[7, 4], [8, 2], [9, 3], [4, 5], [5, 1]])
+
+  def testNDHWCToDHWNC2D(self):
+    x_val = [[7, 4], [9, 3], [4, 5], [5, 1], [8, 2]]
+    x = constant_op.constant(x_val)
+    y = nn_ops.data_format_vec_permute(
+        x, src_format="NDHWC", dst_format="DHWNC")
+    with test_util.use_gpu():
+      y_val = self.evaluate(y)
+      self.assertAllEqual(y_val, [[9, 3], [4, 5], [5, 1], [7, 4], [8, 2]])
+
+  def testDHWNCToNDHWC2D(self):
+    x_val = [[7, 4], [9, 3], [4, 5], [5, 1], [8, 2]]
+    x = constant_op.constant(x_val)
+    y = nn_ops.data_format_vec_permute(
+        x, src_format="DHWNC", dst_format="NDHWC")
+    with test_util.use_gpu():
+      y_val = self.evaluate(y)
+      self.assertAllEqual(y_val, [[5, 1], [7, 4], [9, 3], [4, 5], [8, 2]])
+
+  def testNCDHWToNDHWC2D(self):
+    x_val = [[7, 4], [9, 3], [4, 5], [5, 1], [8, 2]]
+    x = constant_op.constant(x_val)
+    y = nn_ops.data_format_vec_permute(
+        x, src_format="NCDHW", dst_format="NDHWC")
+    with test_util.use_gpu():
+      y_val = self.evaluate(y)
+      self.assertAllEqual(y_val, [[7, 4], [4, 5], [5, 1], [8, 2], [9, 3]])
 
   @test_util.disable_xla("XLA catches the error and rethrows as different one")
   def testInvalidLength(self):


### PR DESCRIPTION
There's currently a mismatch between what the validation of DataFormatVecPermute and its implementation is doing. While the validation allows src_format and dst_format to be of length 4 or 5, it only allows the input to be of shape [4] or [2, 4]. This leads to a gap in the validation where the following is allowed, but results in undefined behavior or uninitialized garbage data:

`tf.raw_ops.DataFormatVecPermute(x=[1,2,3,4], src_format="NCDHW", dst_format="NDHWC")`