### PR TITLE
Fix UT failure config_test and context_test

### DIFF
--- a/tensorflow/python/eager/context_test.py
+++ b/tensorflow/python/eager/context_test.py
@@ -136,8 +136,12 @@ class ContextTest(test.TestCase):
 
   @test_util.disable_tfrt('b/169293680: TFE_GetTotalMemoryUsage is unsupported')
   def testGetMemoryInfoCPU(self):
-    info = context.context().get_memory_info('CPU:0')
-    self.assertEqual(info['current'], 0)
+    # MklCPUAllocator (mkl_cpu_allocator.h) does not throw exception.
+    # So skip the test.
+    # TODO(gzmkl) work with Google team to address design issue in allocator.h
+    if not test_util.IsMklEnabled():
+      with self.assertRaisesRegex(ValueError, 'Allocator stats not available'):
+        context.context().get_memory_info('CPU:0')
 
   @test_util.disable_tfrt('b/169293680: TFE_GetTotalMemoryUsage is unsupported')
   def testGetMemoryInfoUnknownDevice(self):

--- a/tensorflow/python/eager/context_test.py
+++ b/tensorflow/python/eager/context_test.py
@@ -136,8 +136,8 @@ class ContextTest(test.TestCase):
 
   @test_util.disable_tfrt('b/169293680: TFE_GetTotalMemoryUsage is unsupported')
   def testGetMemoryInfoCPU(self):
-    with self.assertRaisesRegex(ValueError, 'Allocator stats not available'):
-      context.context().get_memory_info('CPU:0')
+    info = context.context().get_memory_info('CPU:0')
+    self.assertEqual(info['current'], 0)
 
   @test_util.disable_tfrt('b/169293680: TFE_GetTotalMemoryUsage is unsupported')
   def testGetMemoryInfoUnknownDevice(self):

--- a/tensorflow/python/eager/context_test.py
+++ b/tensorflow/python/eager/context_test.py
@@ -136,12 +136,12 @@ class ContextTest(test.TestCase):
 
   @test_util.disable_tfrt('b/169293680: TFE_GetTotalMemoryUsage is unsupported')
   def testGetMemoryInfoCPU(self):
-    # MklCPUAllocator (mkl_cpu_allocator.h) does not throw exception.
-    # So skip the test.
-    # TODO(gzmkl) work with Google team to address design issue in allocator.h
-    if not test_util.IsMklEnabled():
-      with self.assertRaisesRegex(ValueError, 'Allocator stats not available'):
-        context.context().get_memory_info('CPU:0')
+    if test_util.IsMklEnabled():
+      # TODO(gzmkl) work with Google team to address design issue in allocator.h
+      self.skipTest("MklCPUAllocator does not throw exception. So skip test.")
+
+    with self.assertRaisesRegex(ValueError, 'Allocator stats not available'):
+      context.context().get_memory_info('CPU:0')
 
   @test_util.disable_tfrt('b/169293680: TFE_GetTotalMemoryUsage is unsupported')
   def testGetMemoryInfoUnknownDevice(self):

--- a/tensorflow/python/framework/config_test.py
+++ b/tensorflow/python/framework/config_test.py
@@ -610,14 +610,14 @@ class DeviceTest(test.TestCase):
 
   @reset_eager
   def testGetMemoryInfoCPU(self):
-    # MklCPUAllocator (mkl_cpu_allocator.h) does not throw exception.
-    # So skip the test.
-    # TODO(gzmkl) work with Google team to address design issue in allocator.h
-    if not test_util.IsMklEnabled():
-      with self.assertRaisesRegex(ValueError, 'Allocator stats not available'):
-        config.get_memory_info('CPU:0')
-      with self.assertRaisesRegex(ValueError, 'Allocator stats not available'):
-        config.get_memory_usage('CPU:0')
+    if test_util.IsMklEnabled():
+      # TODO(gzmkl) work with Google team to address design issue in allocator.h
+      self.skipTest("MklCPUAllocator does not throw exception. So skip test.")
+
+    with self.assertRaisesRegex(ValueError, 'Allocator stats not available'):
+      config.get_memory_info('CPU:0')
+    with self.assertRaisesRegex(ValueError, 'Allocator stats not available'):
+      config.get_memory_usage('CPU:0')
 
   @reset_eager
   def testGetMemoryInfoUnknownDevice(self):
@@ -671,11 +671,12 @@ class DeviceTest(test.TestCase):
 
   @reset_eager
   def testResetMemoryStatsCPU(self):
-    # MklCPUAllocator (mkl_cpu_allocator.h) does not throw exception.
-    # So skip the test.
-    if not test_util.IsMklEnabled():
-      with self.assertRaisesRegex(ValueError, 'Cannot reset memory stats'):
-        config.reset_memory_stats('CPU:0')
+    if test_util.IsMklEnabled():
+      # TODO(gzmkl) work with Google team to address design issue in allocator.h
+      self.skipTest("MklCPUAllocator does not throw exception. So skip test.")
+
+    with self.assertRaisesRegex(ValueError, 'Cannot reset memory stats'):
+      config.reset_memory_stats('CPU:0')
 
   @reset_eager
   def testResetMemoryStatsUnknownDevice(self):

--- a/tensorflow/python/framework/config_test.py
+++ b/tensorflow/python/framework/config_test.py
@@ -610,10 +610,10 @@ class DeviceTest(test.TestCase):
 
   @reset_eager
   def testGetMemoryInfoCPU(self):
-    with self.assertRaisesRegex(ValueError, 'Allocator stats not available'):
-      config.get_memory_info('CPU:0')
-    with self.assertRaisesRegex(ValueError, 'Allocator stats not available'):
-      config.get_memory_usage('CPU:0')
+    info = config.get_memory_info('CPU:0')
+    self.assertEqual(info['current'], 0)
+    usage = config.get_memory_usage('CPU:0')
+    self.assertEqual(usage, info['current'])
 
   @reset_eager
   def testGetMemoryInfoUnknownDevice(self):

--- a/tensorflow/python/framework/config_test.py
+++ b/tensorflow/python/framework/config_test.py
@@ -610,10 +610,14 @@ class DeviceTest(test.TestCase):
 
   @reset_eager
   def testGetMemoryInfoCPU(self):
-    info = config.get_memory_info('CPU:0')
-    self.assertEqual(info['current'], 0)
-    usage = config.get_memory_usage('CPU:0')
-    self.assertEqual(usage, info['current'])
+    # MklCPUAllocator (mkl_cpu_allocator.h) does not throw exception.
+    # So skip the test.
+    # TODO(gzmkl) work with Google team to address design issue in allocator.h
+    if not test_util.IsMklEnabled():
+      with self.assertRaisesRegex(ValueError, 'Allocator stats not available'):
+        config.get_memory_info('CPU:0')
+      with self.assertRaisesRegex(ValueError, 'Allocator stats not available'):
+        config.get_memory_usage('CPU:0')
 
   @reset_eager
   def testGetMemoryInfoUnknownDevice(self):
@@ -667,8 +671,11 @@ class DeviceTest(test.TestCase):
 
   @reset_eager
   def testResetMemoryStatsCPU(self):
-    with self.assertRaisesRegex(ValueError, 'Cannot reset memory stats'):
-      config.reset_memory_stats('CPU:0')
+    # MklCPUAllocator (mkl_cpu_allocator.h) does not throw exception.
+    # So skip the test.
+    if not test_util.IsMklEnabled():
+      with self.assertRaisesRegex(ValueError, 'Cannot reset memory stats'):
+        config.reset_memory_stats('CPU:0')
 
   @reset_eager
   def testResetMemoryStatsUnknownDevice(self):


### PR DESCRIPTION
Disable two unit tests in config_test.py and context_test.py
because  get_memory_usage() and get_memory_usage() do not throw exception for CPU device in case of MKL is enabled. 

More details: 

1. For default cpu allocator (framework/cpu_allocator_impl.cc), the global Boolean variable  cpu_allocator_collect_stats is set to true by direct_session by invoking EnableCPUAllocatorStats(). 

2. However, for MKL cpu allocator (common_runtime/mkl_cpu_allocator.h/.cc), its static Boolean variable mkl_small_allocator_collect_stats cannot be set to true, as the MKL cpu allocator cannot re-define the method EnableCPUAllocatorStats(). 

TODO: work with Google team to address the limitation in framework/allocator.h, or find a workaround. 

