### PR TITLE
[INTEL MKL] Fix Pooling3D test case for --config=cuda build setting

### DIFF
--- a/tensorflow/python/kernel_tests/pooling_ops_3d_test.py
+++ b/tensorflow/python/kernel_tests/pooling_ops_3d_test.py
@@ -40,7 +40,7 @@ def GetTestConfigs():
     # "NCDHW" format is currently supported exclusively on CUDA GPUs.
     # "NCDHW" format is currently not supported by MKL pooling ops. 
     if not test_util.IsMklEnabled():
-       test_configs += [("NCDHW", True)]
+      test_configs += [("NCDHW", True)]
   return test_configs
 
 

--- a/tensorflow/python/kernel_tests/pooling_ops_3d_test.py
+++ b/tensorflow/python/kernel_tests/pooling_ops_3d_test.py
@@ -37,8 +37,10 @@ def GetTestConfigs():
   """
   test_configs = [("NDHWC", False), ("NDHWC", True)]
   if test.is_gpu_available(cuda_only=True):
-    # "NCHW" format is currently supported exclusively on CUDA GPUs.
-    test_configs += [("NCDHW", True)]
+    # "NCDHW" format is currently supported exclusively on CUDA GPUs.
+    # "NCDHW" format is currently not supported by MKL pooling ops. 
+    if not test_util.IsMklEnabled():
+       test_configs += [("NCDHW", True)]
   return test_configs
 
 


### PR DESCRIPTION
This PR is for the Google requirement that all tests should pass with --config=cuda and when MKL is enabled.
MKL pooling ops do not support NCDHW data format. The change disables the test execution when


1. gpu is available, and


2. MKL (oneDNN) is enabled.


The updated test has no impact on actual gpu execution (cuda_only=True) and MKL is disabled.