### PR TITLE
Caching of Pointers to Redzone Checker Kernel

### DIFF
--- a/tensorflow/stream_executor/gpu/BUILD
+++ b/tensorflow/stream_executor/gpu/BUILD
@@ -243,6 +243,7 @@ cc_library(
         "//tensorflow/core:lib",
         "//tensorflow/core/platform:regexp",
         "//tensorflow/core/platform:cuda_libdevice_path",
+        "//tensorflow/stream_executor:kernel",
         "//tensorflow/stream_executor/lib",
         "//tensorflow/stream_executor/platform",
         "@com_google_absl//absl/strings",

--- a/tensorflow/stream_executor/gpu/asm_compiler.cc
+++ b/tensorflow/stream_executor/gpu/asm_compiler.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "tensorflow/stream_executor/gpu/asm_compiler.h"
 
-#include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
@@ -25,7 +24,6 @@ limitations under the License.
 #include "tensorflow/core/lib/io/path.h"
 #include "tensorflow/core/platform/cuda_libdevice_path.h"
 #include "tensorflow/core/platform/env.h"
-#include "tensorflow/core/platform/mutex.h"
 #include "tensorflow/core/platform/regexp.h"
 #include "tensorflow/core/platform/subprocess.h"
 #include "tensorflow/stream_executor/gpu/gpu_driver.h"

--- a/tensorflow/stream_executor/gpu/asm_compiler.cc
+++ b/tensorflow/stream_executor/gpu/asm_compiler.cc
@@ -15,6 +15,10 @@ limitations under the License.
 
 #include "tensorflow/stream_executor/gpu/asm_compiler.h"
 
+#include <string>
+#include <utility>
+
+#include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"

--- a/tensorflow/stream_executor/gpu/asm_compiler.h
+++ b/tensorflow/stream_executor/gpu/asm_compiler.h
@@ -18,10 +18,15 @@ limitations under the License.
 
 #include <vector>
 
+#include "absl/container/flat_hash_map.h"
 #include "absl/types/span.h"
+#include "tensorflow/core/platform/mutex.h"
+#include "tensorflow/stream_executor/cuda/cuda_driver.h"
 #include "tensorflow/stream_executor/gpu/gpu_asm_opts.h"
+#include "tensorflow/stream_executor/kernel.h"
 #include "tensorflow/stream_executor/lib/statusor.h"
 #include "tensorflow/stream_executor/platform/port.h"
+#include "tensorflow/stream_executor/stream_executor_pimpl.h"
 
 namespace stream_executor {
 namespace gpu {
@@ -79,6 +84,36 @@ port::StatusOr<std::vector<uint8>> BundleGpuAsm(
 // single image.
 port::StatusOr<std::vector<uint8>> LinkGpuAsm(
     gpu::GpuContext* context, std::vector<CubinOrPTXImage> images);
+
+// Maintains a cache of pointers to loaded kernels
+template <typename... Args>
+port::StatusOr<std::shared_ptr<TypedKernel<Args...>>> LoadKernelOrGetPtr(
+    StreamExecutor* executor, absl::string_view kernel_name,
+    absl::string_view ptx, absl::Span<const uint8> cubin_data) {
+  using KernelPtrCacheKey =
+      std::tuple<CUcontext, absl::string_view, absl::string_view>;
+
+  static tensorflow::mutex kernel_ptr_cache_mutex(
+      tensorflow::LINKER_INITIALIZED);
+  static auto& kernel_ptr_cache GUARDED_BY(kernel_ptr_cache_mutex) =
+      *new absl::flat_hash_map<KernelPtrCacheKey,
+                               std::shared_ptr<TypedKernel<Args...>>>();
+  CUcontext current_context = cuda::CurrentContextOrDie();
+  KernelPtrCacheKey kernel_ptr_cache_key{current_context, kernel_name, ptx};
+  tensorflow::mutex_lock lock(kernel_ptr_cache_mutex);
+
+  auto it = kernel_ptr_cache.find(kernel_ptr_cache_key);
+  if (it == kernel_ptr_cache.end()) {
+    TF_ASSIGN_OR_RETURN(
+        std::shared_ptr<TypedKernel<Args...>> loaded,
+        executor->CreateTypedKernel<Args...>(kernel_name, ptx, cubin_data));
+    it =
+        kernel_ptr_cache.emplace(kernel_ptr_cache_key, std::move(loaded)).first;
+  }
+
+  CHECK(it != kernel_ptr_cache.end());
+  return it->second;
+}
 
 }  // namespace stream_executor
 

--- a/tensorflow/stream_executor/gpu/asm_compiler.h
+++ b/tensorflow/stream_executor/gpu/asm_compiler.h
@@ -21,12 +21,14 @@ limitations under the License.
 #include "absl/container/flat_hash_map.h"
 #include "absl/types/span.h"
 #include "tensorflow/core/platform/mutex.h"
-#include "tensorflow/stream_executor/cuda/cuda_driver.h"
 #include "tensorflow/stream_executor/gpu/gpu_asm_opts.h"
 #include "tensorflow/stream_executor/kernel.h"
 #include "tensorflow/stream_executor/lib/statusor.h"
 #include "tensorflow/stream_executor/platform/port.h"
 #include "tensorflow/stream_executor/stream_executor_pimpl.h"
+#if GOOGLE_CUDA
+#include "tensorflow/stream_executor/cuda/cuda_driver.h"
+#endif  // GOOGLE_CUDA
 
 namespace stream_executor {
 namespace gpu {
@@ -85,6 +87,7 @@ port::StatusOr<std::vector<uint8>> BundleGpuAsm(
 port::StatusOr<std::vector<uint8>> LinkGpuAsm(
     gpu::GpuContext* context, std::vector<CubinOrPTXImage> images);
 
+#if GOOGLE_CUDA
 // Maintains a cache of pointers to loaded kernels
 template <typename... Args>
 port::StatusOr<std::shared_ptr<TypedKernel<Args...>>> LoadKernelOrGetPtr(
@@ -114,6 +117,7 @@ port::StatusOr<std::shared_ptr<TypedKernel<Args...>>> LoadKernelOrGetPtr(
   CHECK(it != kernel_ptr_cache.end());
   return it->second;
 }
+#endif  // GOOGLE_CUDA
 
 }  // namespace stream_executor
 


### PR DESCRIPTION
Introduces a cache for pointers to the Redzone Checker kernel which prevents the repeated loading and unloading of the kernel.