### PR TITLE
[Intel MKL] Fixing a failure in run_eager_op_as_function_test

### DIFF
--- a/tensorflow/core/common_runtime/eager/BUILD
+++ b/tensorflow/core/common_runtime/eager/BUILD
@@ -4,6 +4,7 @@ load(
     "//tensorflow:tensorflow.bzl",
     "tf_cc_test",
     "tf_cc_test_mkl",
+    "tf_copts",
     "tf_cuda_library",
     "tf_mkl_kernel_library",
 )
@@ -487,7 +488,8 @@ cc_library(
     hdrs = [
         "execute.h",
         "execute_node.h",
-    ],
+    ] + if_mkl(["//tensorflow/core/graph:mkl_graph_util_header"]),
+    copts = if_mkl(["-DINTEL_MKL"]),
     deps = [
         ":context",
         ":copy_to_device_node",
@@ -610,6 +612,7 @@ cc_library(
         "execute.h",
         "execute_node.h",
     ],
+    copts = tf_copts(),
     deps = [
         ":context",
         ":copy_to_device_node",

--- a/tensorflow/core/common_runtime/eager/BUILD
+++ b/tensorflow/core/common_runtime/eager/BUILD
@@ -4,6 +4,7 @@ load(
     "//tensorflow:tensorflow.bzl",
     "tf_cc_test",
     "tf_cc_test_mkl",
+    "tf_copts",
     "tf_cuda_library",
     "tf_mkl_kernel_library",
 )
@@ -487,9 +488,8 @@ cc_library(
     hdrs = [
         "execute.h",
         "execute_node.h",
-        "//tensorflow/core/graph:mkl_graph_util_header",
-    ],
-    copts = ["-DINTEL_MKL"],
+    ] + if_mkl(["//tensorflow/core/graph:mkl_graph_util_header"]),
+    copts = if_mkl(["-DINTEL_MKL"]),
     deps = [
         ":context",
         ":copy_to_device_node",
@@ -612,7 +612,7 @@ cc_library(
         "execute.h",
         "execute_node.h",
     ],
-    copts = ["-DINTEL_MKL"],
+    copts = tf_copts(),
     deps = [
         ":context",
         ":copy_to_device_node",

--- a/tensorflow/core/common_runtime/eager/BUILD
+++ b/tensorflow/core/common_runtime/eager/BUILD
@@ -4,7 +4,6 @@ load(
     "//tensorflow:tensorflow.bzl",
     "tf_cc_test",
     "tf_cc_test_mkl",
-    "tf_copts",
     "tf_cuda_library",
     "tf_mkl_kernel_library",
 )
@@ -488,8 +487,9 @@ cc_library(
     hdrs = [
         "execute.h",
         "execute_node.h",
-    ] + if_mkl(["//tensorflow/core/graph:mkl_graph_util_header"]),
-    copts = if_mkl(["-DINTEL_MKL"]),
+        "//tensorflow/core/graph:mkl_graph_util_header",
+    ],
+    copts = ["-DINTEL_MKL"],
     deps = [
         ":context",
         ":copy_to_device_node",
@@ -612,7 +612,7 @@ cc_library(
         "execute.h",
         "execute_node.h",
     ],
-    copts = tf_copts(),
+    copts = ["-DINTEL_MKL"],
     deps = [
         ":context",
         ":copy_to_device_node",

--- a/tensorflow/core/common_runtime/eager/execute.cc
+++ b/tensorflow/core/common_runtime/eager/execute.cc
@@ -756,6 +756,7 @@ Status WrapInCallOp(EagerOperation* op, EagerOperation** wrapped_op) {
       (*ndef->mutable_attr())[attr.name()].set_placeholder(attr.name());
     }
 
+#ifdef INTEL_MKL
     if (IsMklEnabled() &&
         absl::StartsWith(op->Name(), mkl_op_registry::kMklOpPrefix)) {
       // All MKL eager ops have `_kernel` private attribute that needs to be set
@@ -764,6 +765,7 @@ Status WrapInCallOp(EagerOperation* op, EagerOperation** wrapped_op) {
       attr_kernel.set_s(mkl_op_registry::kMklNameChangeOpLabel);
       (*ndef->mutable_attr()).insert({"_kernel", attr_kernel});
     }
+#endif  // INTEL_MKL
 
     // Set `ret` map.
     TF_RETURN_IF_ERROR(

--- a/tensorflow/core/common_runtime/eager/execute.cc
+++ b/tensorflow/core/common_runtime/eager/execute.cc
@@ -57,7 +57,9 @@ limitations under the License.
 #include "tensorflow/core/framework/node_def_util.h"
 #include "tensorflow/core/framework/tensor_reference.h"
 #include "tensorflow/core/framework/types.pb.h"
+#ifdef INTEL_MKL
 #include "tensorflow/core/graph/mkl_graph_util.h"
+#endif  // INTEL_MKL
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/profiler/lib/traceme.h"
 #include "tensorflow/core/protobuf/error_codes.pb.h"

--- a/tensorflow/core/common_runtime/eager/execute.cc
+++ b/tensorflow/core/common_runtime/eager/execute.cc
@@ -758,7 +758,7 @@ Status WrapInCallOp(EagerOperation* op, EagerOperation** wrapped_op) {
 
     if (IsMklEnabled() &&
         absl::StartsWith(op->Name(), mkl_op_registry::kMklOpPrefix)) {
-      // All MKL eager ops have _kerenl private attribute that needs to be set
+      // All MKL eager ops have `_kernel` private attribute that needs to be set
       // to a fixed label.
       AttrValue attr_kernel;
       attr_kernel.set_s(mkl_op_registry::kMklNameChangeOpLabel);

--- a/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite.cc
+++ b/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite.cc
@@ -156,9 +156,11 @@ Status MklEagerOpRewrite::SetupNewOp(
     (*new_mkl_op)->MutableAttrs()->Set(attr.first, attr.second);
   }
 
-  (*new_mkl_op)
-      ->MutableAttrs()
-      ->Set("_kernel", mkl_op_registry::kMklNameChangeOpLabel);
+  if (!orig_op->EagerContext().RunEagerOpAsFunction()) {
+    (*new_mkl_op)
+        ->MutableAttrs()
+        ->Set("_kernel", mkl_op_registry::kMklNameChangeOpLabel);
+  }
 
   string device_name = orig_op->DeviceName();
   return (*new_mkl_op)->SetDeviceName(device_name.c_str());


### PR DESCRIPTION
This PR fixes a failure in run_eager_op_as_function_test when MKL eager code is enabled. Failure started to happen after this [commit](https://github.com/tensorflow/tensorflow/commit/72e63b74a241c855c540997fd8f7cd2408c37016)