### PR TITLE
Improved lookup function

### DIFF
--- a/tensorflow/compiler/mlir/tfr/python/tfr_gen.py
+++ b/tensorflow/compiler/mlir/tfr/python/tfr_gen.py
@@ -234,7 +234,7 @@ class OpDefCache(object):
     self._op_defs = {}
 
   def lookup(self, f_name, func_def=None, optional=False):
-    if f_name in self._op_defs.keys():
+    if f_name in self._op_defs:
       return self._op_defs[f_name]
 
     if isinstance(func_def, types.FunctionType):


### PR DESCRIPTION
In python 3.x checking f_name in self._op_defs is faster than performing on a view object (i.e. self._op_defs.keys()), while in 2.x it's faster than creating a list which avoids linear time lookups.