### PR TITLE
[tf.data] graduate OptimizationOptions from experimental to tf.data

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -212,8 +212,6 @@ This release contains contributions from many people at Google, as well as:
         `tf.data.Dataset.shapshot` and deprecating the experimental endpoint.
     *   Promoting `tf.data.experimental.take_while` API to
         `tf.data.Dataset.take_while` and deprecating the experimental endpoint.
-    *   Promoting `tf.data.experimental.ThreadingOptions` API to
-        `tf.data.ThreadingOptions` and deprecating the experimental endpoint.
     *   Promoting `tf.data.experimental.unique` API to
         `tf.data.Dataset.unique` and deprecating the experimental endpoint.
     *   Added `stop_on_empty_dataset` parameter to `sample_from_datasets` and
@@ -233,7 +231,12 @@ This release contains contributions from many people at Google, as well as:
         *   `tf.data.experimental.MapVectorizationOptions.*`
         *   `tf.data.experimental.OptimizationOptions.filter_with_random_uniform_fusion`
         *   `tf.data.experimental.OptimizationOptions.hoist_random_uniform`
-        *   `tf.data.experimental.OptimizationOptions.map_vectorization`                 *   `tf.data.experimental.OptimizationOptions.reorder_data_discarding_ops`
+        *   `tf.data.experimental.OptimizationOptions.map_vectorization`                 
+        *   `tf.data.experimental.OptimizationOptions.reorder_data_discarding_ops`
+    *   Promoting `tf.data.experimental.OptimizationOptions` API to
+        `tf.data.OptimizationOptions` and deprecating the experimental endpoint.
+    *   Promoting `tf.data.experimental.ThreadingOptions` API to
+        `tf.data.ThreadingOptions` and deprecating the experimental endpoint.
 *   `tf.keras`:
     *   Fix usage of `__getitem__` slicing in Keras Functional APIs when the
         inputs are `RaggedTensor` objects.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -212,6 +212,8 @@ This release contains contributions from many people at Google, as well as:
         `tf.data.Dataset.shapshot` and deprecating the experimental endpoint.
     *   Promoting `tf.data.experimental.take_while` API to
         `tf.data.Dataset.take_while` and deprecating the experimental endpoint.
+    *   Promoting `tf.data.experimental.ThreadingOptions` API to
+        `tf.data.ThreadingOptions` and deprecating the experimental endpoint.
     *   Promoting `tf.data.experimental.unique` API to
         `tf.data.Dataset.unique` and deprecating the experimental endpoint.
     *   Added `stop_on_empty_dataset` parameter to `sample_from_datasets` and
@@ -235,8 +237,6 @@ This release contains contributions from many people at Google, as well as:
         *   `tf.data.experimental.OptimizationOptions.reorder_data_discarding_ops`
     *   Promoting `tf.data.experimental.OptimizationOptions` API to
         `tf.data.OptimizationOptions` and deprecating the experimental endpoint.
-    *   Promoting `tf.data.experimental.ThreadingOptions` API to
-        `tf.data.ThreadingOptions` and deprecating the experimental endpoint.
 *   `tf.keras`:
     *   Fix usage of `__getitem__` slicing in Keras Functional APIs when the
         inputs are `RaggedTensor` objects.

--- a/tensorflow/core/framework/dataset_options.proto
+++ b/tensorflow/core/framework/dataset_options.proto
@@ -127,6 +127,30 @@ enum ExternalStatePolicy {
   POLICY_FAIL = 2;
 }
 
+message AutotuneOptions {
+  // Whether to automatically tune performance knobs.
+  oneof optional_enabled {
+    bool enabled = 1;
+  }
+  // When autotuning is enabled (through autotune), determines whether to also
+  // autotune buffer sizes for datasets with parallelism.
+  oneof optional_autotune_buffers {
+    bool autotune_buffers = 2;
+  }
+  // When autotuning is enabled (through autotune), determines the CPU budget to
+  // use. Values greater than the number of schedulable CPU cores are allowed
+  // but may result in CPU contention.
+  oneof optional_cpu_budget {
+    int32 cpu_budget = 3;
+  }
+  // When autotuning is enabled (through autotune), determines the RAM budget to
+  // use. Values greater than the available RAM in bytes may result in OOM. If
+  // 0, defaults to half of the available RAM in bytes.
+  oneof optional_ram_budget {
+    int64 ram_budget = 4;
+  }
+}
+
 // Message stored with Dataset objects to control how datasets are processed and
 // optimized.
 message Options {
@@ -155,4 +179,6 @@ message Options {
   oneof optional_external_state_policy {
     ExternalStatePolicy external_state_policy = 6;
   }
+  // The autotune options associated with the dataset
+  AutotuneOptions autotune_options = 7;
 }

--- a/tensorflow/python/data/experimental/__init__.py
+++ b/tensorflow/python/data/experimental/__init__.py
@@ -22,6 +22,7 @@ removing existing functionality.
 
 See [Importing Data](https://tensorflow.org/guide/datasets) for an overview.
 
+@@AutotuneOptions
 @@AutoShardPolicy
 @@CheckpointInputPipelineHook
 @@Counter
@@ -95,6 +96,7 @@ from __future__ import print_function
 
 # pylint: disable=unused-import
 from tensorflow.python.data.experimental import service
+from tensorflow.python.data.experimental.ops.autotune_options import AutotuneOptions
 from tensorflow.python.data.experimental.ops.batching import dense_to_ragged_batch
 from tensorflow.python.data.experimental.ops.batching import dense_to_sparse_batch
 from tensorflow.python.data.experimental.ops.batching import map_and_batch

--- a/tensorflow/python/data/experimental/ops/BUILD
+++ b/tensorflow/python/data/experimental/ops/BUILD
@@ -4,6 +4,16 @@ package(
 )
 
 py_library(
+    name = "autotune_options",
+    srcs = ["autotune_options.py"],
+    srcs_version = "PY3",
+    deps = [
+        "//tensorflow/python:util",
+        "//tensorflow/python/data/util:options",
+    ],
+)
+
+py_library(
     name = "batching",
     srcs = ["batching.py"],
     srcs_version = "PY3",

--- a/tensorflow/python/data/experimental/ops/autotune_options.py
+++ b/tensorflow/python/data/experimental/ops/autotune_options.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tensorflow/python/data/experimental/ops/autotune_options.py
+++ b/tensorflow/python/data/experimental/ops/autotune_options.py
@@ -1,0 +1,98 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""API for controlling performance auto-tuning in `tf.data` pipelines."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.core.framework import dataset_options_pb2
+from tensorflow.python.data.util import options
+from tensorflow.python.util.tf_export import tf_export
+
+
+@tf_export("data.AutotuneOptions")
+class AutotuneOptions(options.OptionsBase):
+  """Represents options for performance auto-tuning in
+  dataset operations.
+
+  You can set the auto-tune options of a dataset through the
+  `autotune` property of `tf.data.Options`; the property is
+  an instance of `tf.data.AutotuneOptions`.
+
+  ```python
+  options = tf.data.Options()
+  options.autotune.enabled = True
+  options.autotune.cpu_budget = 8
+  dataset = dataset.with_options(options)
+  ```
+  """
+  enabled = options.create_option(
+      name="enabled",
+      ty=bool,
+      docstring=
+      "Whether to automatically tune performance knobs. If None, defaults to "
+      "True.")
+
+  experimental_autotune_buffers = options.create_option(
+      name="experimental_autotune_buffers",
+      ty=bool,
+      docstring=
+      "When autotuning is enabled (through `enabled`), determines whether to "
+      "also autotune buffer sizes for datasets with parallelism. If None,"
+      " defaults to False.")
+
+  cpu_budget = options.create_option(
+      name="cpu_budget",
+      ty=int,
+      docstring=
+      "When autotuning is enabled (through `autotune`), determines the CPU "
+      "budget to use. Values greater than the number of schedulable CPU cores "
+      "are allowed but may result in CPU contention. If None, defaults to the "
+      "number of schedulable CPU cores.")
+
+  ram_budget = options.create_option(
+      name="ram_budget",
+      ty=int,
+      docstring=
+      "When autotuning is enabled (through `autotune`), determines the RAM "
+      "budget to use. Values greater than the available RAM in bytes may "
+      "result in OOM. If None, defaults to half of the available RAM in bytes.")
+
+  def _to_proto(self):
+    pb = dataset_options_pb2.AutotuneOptions()
+    if self.enabled is not None:
+      pb.enabled = self.enabled
+    if self.experimental_autotune_buffers is not None:
+      pb.autotune_buffers = self.experimental_autotune_buffers
+    if self.cpu_budget is not None:
+      pb.cpu_budget = self.cpu_budget
+    if self.ram_budget is not None:
+      pb.ram_budget = self.ram_budget
+    return pb
+
+  def _from_proto(self, pb):
+    if pb.WhichOneof("optional_enabled") is not None:
+      self.enabled = pb.enabled
+    if pb.WhichOneof("optional_autotune_buffers") is not None:
+      self.experimental_autotune_buffers = pb.autotune_buffers
+    if pb.WhichOneof("optional_cpu_budget") is not None:
+      self.cpu_budget = pb.cpu_budget
+    if pb.WhichOneof("optional_ram_budget") is not None:
+      self.ram_budget = pb.ram_budget
+
+  def _set_mutable(self, mutable):
+    """Change the mutability value to `mutable` on this options and children."""
+    # pylint: disable=protected-access
+    object.__setattr__(self, "_mutable", mutable)

--- a/tensorflow/python/data/experimental/ops/optimization_options.py
+++ b/tensorflow/python/data/experimental/ops/optimization_options.py
@@ -21,6 +21,7 @@ import enum
 
 from tensorflow.core.framework import dataset_options_pb2
 from tensorflow.python.data.util import options
+from tensorflow.python.util import deprecation
 from tensorflow.python.util.tf_export import tf_export
 
 
@@ -29,19 +30,19 @@ class _AutotuneAlgorithm(enum.Enum):
   HILL_CLIMB = 0
   GRADIENT_DESCENT = 1
 
-
-@tf_export("data.experimental.OptimizationOptions")
+@deprecation.deprecated_endpoints("data.experimental.OptimizationOptions")
+@tf_export("data.experimental.OptimizationOptions", "data.OptimizationOptions")
 class OptimizationOptions(options.OptionsBase):
   """Represents options for dataset optimizations.
 
   You can set the optimization options of a dataset through the
-  `experimental_optimization` property of `tf.data.Options`; the property is
-  an instance of `tf.data.experimental.OptimizationOptions`.
+  `optimization` property of `tf.data.Options`; the property is
+  an instance of `tf.data.OptimizationOptions`.
 
   ```python
   options = tf.data.Options()
-  options.experimental_optimization.noop_elimination = True
-  options.experimental_optimization.apply_default_optimizations = False
+  options.optimization.noop_elimination = True
+  options.optimization.apply_default_optimizations = False
   dataset = dataset.with_options(options)
   ```
   """

--- a/tensorflow/python/data/kernel_tests/BUILD
+++ b/tensorflow/python/data/kernel_tests/BUILD
@@ -645,6 +645,7 @@ tf_py_test(
     deps = [
         ":test_base",
         "//tensorflow/python:client_testlib",
+        "//tensorflow/python/data/experimental/ops:autotune_options",
         "//tensorflow/python/data/experimental/ops:optimization_options",
         "//tensorflow/python/data/experimental/ops:testing",
         "//tensorflow/python/data/experimental/ops:threading_options",

--- a/tensorflow/python/data/kernel_tests/options_test.py
+++ b/tensorflow/python/data/kernel_tests/options_test.py
@@ -24,6 +24,7 @@ import sys
 from absl.testing import parameterized
 
 from tensorflow.core.framework import dataset_options_pb2
+from tensorflow.python.data.experimental.ops import autotune_options
 from tensorflow.python.data.experimental.ops import distribute_options
 from tensorflow.python.data.experimental.ops import optimization_options
 from tensorflow.python.data.experimental.ops import testing
@@ -114,6 +115,7 @@ class OptionsTest(test_base.DatasetTestBase, parameterized.TestCase):
     self.assertEqual(options1.optimization,
                      optimization_options.OptimizationOptions())
     self.assertEqual(options1.threading, threading_options.ThreadingOptions())
+    self.assertEqual(options1.autotune, autotune_options.AutotuneOptions())
 
   @combinations.generate(test_base.default_test_combinations())
   def testMutatingOptionsRaiseValueError(self):
@@ -189,6 +191,8 @@ class OptionsTest(test_base.DatasetTestBase, parameterized.TestCase):
         dataset_options_pb2.OptimizationOptions())
     expected_pb.threading_options.CopyFrom(
         dataset_options_pb2.ThreadingOptions())
+    expected_pb.autotune_options.CopyFrom(
+        dataset_options_pb2.AutotuneOptions())
     self.assertProtoEquals(expected_pb, result)
 
   @combinations.generate(test_base.default_test_combinations())

--- a/tensorflow/python/data/ops/BUILD
+++ b/tensorflow/python/data/ops/BUILD
@@ -25,6 +25,7 @@ py_library(
         "//tensorflow/python:tensor_shape",
         "//tensorflow/python:tensor_util",
         "//tensorflow/python:util",
+        "//tensorflow/python/data/experimental/ops:autotune_options",
         "//tensorflow/python/data/experimental/ops:distribute_options",
         "//tensorflow/python/data/experimental/ops:optimization_options",
         "//tensorflow/python/data/experimental/ops:threading_options",

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -33,6 +33,7 @@ from six.moves import queue as Queue  # pylint: disable=redefined-builtin
 from tensorflow.core.framework import dataset_options_pb2
 from tensorflow.core.framework import graph_pb2
 from tensorflow.python import tf2
+from tensorflow.python.data.experimental.ops import autotune_options
 from tensorflow.python.data.experimental.ops import distribute_options
 from tensorflow.python.data.experimental.ops import optimization_options
 from tensorflow.python.data.experimental.ops import threading_options
@@ -3718,6 +3719,13 @@ class Options(options_lib.OptionsBase):
       "`tf.data.OptimizationOptions` for more details.",
       default_factory=optimization_options.OptimizationOptions)
 
+  autotune = options_lib.create_option(
+      name="autotune",
+      ty=autotune_options.AutotuneOptions,
+      docstring="The autotune options associated with the dataset. See "
+      "`tf.data.AutotuneOptions` for more details.",
+      default_factory=autotune_options.AutotuneOptions)
+
   def __getattr__(self, name):
     if name == "experimental_threading":
       logging.warning("options.experimental_threading is deprecated. "
@@ -3755,6 +3763,7 @@ class Options(options_lib.OptionsBase):
     if self.experimental_slack is not None:
       pb.slack = self.experimental_slack
     pb.threading_options.CopyFrom(self.threading._to_proto())  # pylint: disable=protected-access
+    pb.autotune_options.CopyFrom(self.autotune._to_proto())  # pylint: disable=protected-access
     return pb
 
   def _from_proto(self, pb):
@@ -3769,6 +3778,7 @@ class Options(options_lib.OptionsBase):
     if pb.WhichOneof("optional_slack") is not None:
       self.experimental_slack = pb.slack
     self.threading._from_proto(pb.threading_options)  # pylint: disable=protected-access
+    self.autotune._from_proto(pb.autotune_options)  # pylint: disable=protected-access
 
   def _set_mutable(self, mutable):
     """Change the mutability value to `mutable` on this options and children."""
@@ -3777,6 +3787,7 @@ class Options(options_lib.OptionsBase):
     self.experimental_distribute._set_mutable(mutable)
     self.optimization._set_mutable(mutable)
     self.threading._set_mutable(mutable)
+    self.autotune._set_mutable(mutable)
 
   def merge(self, options):
     """Merges itself with the given `tf.data.Options`.

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -3684,14 +3684,6 @@ class Options(options_lib.OptionsBase):
       "`tf.data.experimental.DistributeOptions` for more details.",
       default_factory=distribute_options.DistributeOptions)
 
-  experimental_optimization = options_lib.create_option(
-      name="experimental_optimization",
-      ty=optimization_options.OptimizationOptions,
-      docstring=
-      "The optimization options associated with the dataset. See "
-      "`tf.data.experimental.OptimizationOptions` for more details.",
-      default_factory=optimization_options.OptimizationOptions)
-
   experimental_slack = options_lib.create_option(
       name="experimental_slack",
       ty=bool,
@@ -3718,11 +3710,23 @@ class Options(options_lib.OptionsBase):
       "`tf.data.ThreadingOptions` for more details.",
       default_factory=threading_options.ThreadingOptions)
 
+  optimization = options_lib.create_option(
+      name="optimization",
+      ty=optimization_options.OptimizationOptions,
+      docstring=
+      "The optimization options associated with the dataset. See "
+      "`tf.data.OptimizationOptions` for more details.",
+      default_factory=optimization_options.OptimizationOptions)
+
   def __getattr__(self, name):
     if name == "experimental_threading":
       logging.warning("options.experimental_threading is deprecated. "
                       "Use options.threading instead.")
       return getattr(self, "threading")
+    elif name == "experimental_optimization":
+      logging.warning("options.experimental_optimization is deprecated. "
+                      "Use options.optimization instead.")
+      return getattr(self, "optimization")
     else:
       raise AttributeError("Attribute %s not found." % name)
 
@@ -3731,6 +3735,10 @@ class Options(options_lib.OptionsBase):
       logging.warning("options.experimental_threading is deprecated. "
                       "Use options.threading instead.")
       super(Options, self).__setattr__("threading", value)
+    elif name == "experimental_optimization":
+      logging.warning("options.experimental_optimization is deprecated. "
+                      "Use options.optimization instead.")
+      super(Options, self).__setattr__("optimization", value)
     else:
       super(Options, self).__setattr__(name, value)
 
@@ -3743,7 +3751,7 @@ class Options(options_lib.OptionsBase):
       pb.external_state_policy = (
           distribute_options.ExternalStatePolicy._to_proto(  # pylint: disable=protected-access
               self.experimental_external_state_policy))
-    pb.optimization_options.CopyFrom(self.experimental_optimization._to_proto())  # pylint: disable=protected-access
+    pb.optimization_options.CopyFrom(self.optimization._to_proto())  # pylint: disable=protected-access
     if self.experimental_slack is not None:
       pb.slack = self.experimental_slack
     pb.threading_options.CopyFrom(self.threading._to_proto())  # pylint: disable=protected-access
@@ -3757,7 +3765,7 @@ class Options(options_lib.OptionsBase):
       self.experimental_external_state_policy = (
           distribute_options.ExternalStatePolicy._from_proto(  # pylint: disable=protected-access
               pb.external_state_policy))
-    self.experimental_optimization._from_proto(pb.optimization_options)  # pylint: disable=protected-access
+    self.optimization._from_proto(pb.optimization_options)  # pylint: disable=protected-access
     if pb.WhichOneof("optional_slack") is not None:
       self.experimental_slack = pb.slack
     self.threading._from_proto(pb.threading_options)  # pylint: disable=protected-access
@@ -3767,7 +3775,7 @@ class Options(options_lib.OptionsBase):
     # pylint: disable=protected-access
     object.__setattr__(self, "_mutable", mutable)
     self.experimental_distribute._set_mutable(mutable)
-    self.experimental_optimization._set_mutable(mutable)
+    self.optimization._set_mutable(mutable)
     self.threading._set_mutable(mutable)
 
   def merge(self, options):

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-autotune-options.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-autotune-options.pbtxt
@@ -1,0 +1,26 @@
+path: "tensorflow.data.AutotuneOptions"
+tf_class {
+  is_instance: "<class \'tensorflow.python.data.experimental.ops.autotune_options.AutotuneOptions\'>"
+  is_instance: "<class \'tensorflow.python.data.util.options.OptionsBase\'>"
+  is_instance: "<type \'object\'>"
+  member {
+    name: "cpu_budget"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "enabled"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "experimental_autotune_buffers"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "ram_budget"
+    mtype: "<type \'property\'>"
+  }
+  member_method {
+    name: "__init__"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+  }
+}

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-optimization-options.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-optimization-options.pbtxt
@@ -1,0 +1,74 @@
+path: "tensorflow.data.OptimizationOptions"
+tf_class {
+  is_instance: "<class \'tensorflow.python.data.experimental.ops.optimization_options.OptimizationOptions\'>"
+  is_instance: "<class \'tensorflow.python.data.util.options.OptionsBase\'>"
+  is_instance: "<type \'object\'>"
+  member {
+    name: "apply_default_optimizations"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "autotune"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "autotune_buffers"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "autotune_cpu_budget"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "autotune_ram_budget"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "filter_fusion"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "filter_with_random_uniform_fusion"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "hoist_random_uniform"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "map_and_batch_fusion"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "map_and_filter_fusion"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "map_fusion"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "map_parallelization"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "noop_elimination"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "parallel_batch"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "reorder_data_discarding_ops"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "shuffle_and_repeat_fusion"
+    mtype: "<type \'property\'>"
+  }
+  member_method {
+    name: "__init__"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+  }
+}

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-options.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-options.pbtxt
@@ -4,6 +4,10 @@ tf_class {
   is_instance: "<class \'tensorflow.python.data.util.options.OptionsBase\'>"
   is_instance: "<type \'object\'>"
   member {
+    name: "autotune"
+    mtype: "<type \'property\'>"
+  }
+  member {
     name: "experimental_deterministic"
     mtype: "<type \'property\'>"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-options.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-options.pbtxt
@@ -16,11 +16,11 @@ tf_class {
     mtype: "<type \'property\'>"
   }
   member {
-    name: "experimental_optimization"
+    name: "experimental_slack"
     mtype: "<type \'property\'>"
   }
   member {
-    name: "experimental_slack"
+    name: "optimization"
     mtype: "<type \'property\'>"
   }
   member {

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.pbtxt
@@ -5,6 +5,10 @@ tf_module {
     mtype: "<type \'int\'>"
   }
   member {
+    name: "AutotuneOptions"
+    mtype: "<type \'type\'>"
+  }
+  member {
     name: "Dataset"
     mtype: "<type \'type\'>"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.pbtxt
@@ -25,6 +25,10 @@ tf_module {
     mtype: "<type \'type\'>"
   }
   member {
+    name: "OptimizationOptions"
+    mtype: "<type \'type\'>"
+  }
+  member {
     name: "Options"
     mtype: "<type \'type\'>"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-autotune-options.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-autotune-options.pbtxt
@@ -1,0 +1,26 @@
+path: "tensorflow.data.AutotuneOptions"
+tf_class {
+  is_instance: "<class \'tensorflow.python.data.experimental.ops.autotune_options.AutotuneOptions\'>"
+  is_instance: "<class \'tensorflow.python.data.util.options.OptionsBase\'>"
+  is_instance: "<type \'object\'>"
+  member {
+    name: "cpu_budget"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "enabled"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "experimental_autotune_buffers"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "ram_budget"
+    mtype: "<type \'property\'>"
+  }
+  member_method {
+    name: "__init__"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+  }
+}

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-optimization-options.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-optimization-options.pbtxt
@@ -1,0 +1,74 @@
+path: "tensorflow.data.OptimizationOptions"
+tf_class {
+  is_instance: "<class \'tensorflow.python.data.experimental.ops.optimization_options.OptimizationOptions\'>"
+  is_instance: "<class \'tensorflow.python.data.util.options.OptionsBase\'>"
+  is_instance: "<type \'object\'>"
+  member {
+    name: "apply_default_optimizations"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "autotune"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "autotune_buffers"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "autotune_cpu_budget"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "autotune_ram_budget"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "filter_fusion"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "filter_with_random_uniform_fusion"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "hoist_random_uniform"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "map_and_batch_fusion"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "map_and_filter_fusion"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "map_fusion"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "map_parallelization"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "noop_elimination"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "parallel_batch"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "reorder_data_discarding_ops"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "shuffle_and_repeat_fusion"
+    mtype: "<type \'property\'>"
+  }
+  member_method {
+    name: "__init__"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+  }
+}

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-options.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-options.pbtxt
@@ -4,6 +4,10 @@ tf_class {
   is_instance: "<class \'tensorflow.python.data.util.options.OptionsBase\'>"
   is_instance: "<type \'object\'>"
   member {
+    name: "autotune"
+    mtype: "<type \'property\'>"
+  }
+  member {
     name: "experimental_deterministic"
     mtype: "<type \'property\'>"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-options.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-options.pbtxt
@@ -16,11 +16,11 @@ tf_class {
     mtype: "<type \'property\'>"
   }
   member {
-    name: "experimental_optimization"
+    name: "experimental_slack"
     mtype: "<type \'property\'>"
   }
   member {
-    name: "experimental_slack"
+    name: "optimization"
     mtype: "<type \'property\'>"
   }
   member {

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.pbtxt
@@ -5,6 +5,10 @@ tf_module {
     mtype: "<type \'int\'>"
   }
   member {
+    name: "AutotuneOptions"
+    mtype: "<type \'type\'>"
+  }
+  member {
     name: "Dataset"
     mtype: "<type \'type\'>"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.pbtxt
@@ -29,6 +29,10 @@ tf_module {
     mtype: "<type \'type\'>"
   }
   member {
+    name: "OptimizationOptions"
+    mtype: "<type \'type\'>"
+  }
+  member {
     name: "Options"
     mtype: "<type \'type\'>"
   }


### PR DESCRIPTION
This PR graduates `tf.data.experimental.OptimizationOptions` to `tf.data.OptimizationOptions`.

- [x] deprecate the old endpoint
- [x] update docstring of the class
- [x] Modify the `__getattr__` and `__setattr__` implementation of `dataset_ops.Options` for backward-compatibility
- [x] regenerate golden APIs.
- [x] add/modify relevant test cases for the new endpoint.
- [x] update RELEASE.md

TEST LOG
```
INFO: Elapsed time: 32.496s, Critical Path: 28.35s
INFO: 354 processes: 133 internal, 221 local.
INFO: Build completed successfully, 354 total actions
//tensorflow/python/data/kernel_tests:options_test                       PASSED in 4.3s

INFO: Build completed successfully, 354 total actions
```

cc: @jsimsa 