### PR TITLE
Remove a deadlock in cudaMallocAsync

### DIFF
--- a/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
@@ -212,7 +212,6 @@ void* GpuCudaMallocAsyncAllocator::AllocateRaw(size_t alignment,
                                   num_bytes, pool_, cuda_stream_)) {
     size_t free, total;
     cuMemGetInfo(&free, &total);
-    mutex_lock lock(lock_);
     LOG(ERROR) << Name() << " cuMemAllocAsync failed to allocate " << num_bytes
                << ": " << GetCudaErrorMessage(result)
                << "\n Free memory/Total memory: " << free << "/" << total;


### PR DESCRIPTION
The call GetStats() a few lines bellow also ask for the lock. But we already own it. So it deadlock.
@akuegel
This was mentioned here: https://github.com/tensorflow/tensorflow/pull/49173/#issuecomment-861011964