### PR TITLE
[ROCm] Fix for a bug in the ROCMFftPlan::UpdateScratchAllocator routine.

### DIFF
--- a/tensorflow/stream_executor/rocm/rocm_fft.cc
+++ b/tensorflow/stream_executor/rocm/rocm_fft.cc
@@ -329,6 +329,7 @@ port::Status ROCMFftPlan::Initialize(GpuExecutor *parent, Stream *stream,
 
 port::Status ROCMFftPlan::UpdateScratchAllocator(
     Stream *stream, ScratchAllocator *scratch_allocator) {
+  scratch_allocator_ = scratch_allocator;
   if (scratch_size_bytes_ != 0) {
     auto allocated = scratch_allocator->AllocateBytes(scratch_size_bytes_);
     if (!allocated.ok() || (scratch_ = allocated.ValueOrDie()) == nullptr) {


### PR DESCRIPTION
This was the cause of some unit-test failures in JAX...see the following github issue for more details

https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/240

many thanks to @ekuznetsov139 for coming up with this fix.

--------------------------------

/cc @cheshire @chsigg @hawkinsp 